### PR TITLE
feat(scheduler): architecture-aware per-token KV byte estimate

### DIFF
--- a/tests/test_kv_estimation.py
+++ b/tests/test_kv_estimation.py
@@ -33,6 +33,8 @@ from types import SimpleNamespace
 import pytest
 
 from vllm_mlx.kv_estimation import (
+    _ROTATING_CACHE_KEEP,
+    _ROTATING_CACHE_STEP,
     KVFootprintEstimate,
     estimate_kv_footprint,
     rotating_cache_slots,
@@ -700,3 +702,53 @@ class TestNeverUnderCounts:
         for tokens in (1, 100, 4096, 32768):
             projected = self._project(est, tokens)
             assert projected >= n_full * tokens * full_per_layer + n_recurrent * state
+
+
+class TestRotatingCacheConstantsMatchInstalledMlxLm:
+    """Drift guard: our sliding-slot estimate is grounded in two ``RotatingKVCache``
+    internals from the INSTALLED ``mlx_lm`` — the ``step`` block granularity and
+    the ``keep`` sink count that ``make_prompt_cache`` reserves. If a future
+    ``mlx_lm`` upgrade changes either, ``rotating_cache_slots`` would silently
+    UNDER-reserve KV on the D-METAL-CAP admission path (an OOM risk — the
+    load-bearing failure). These tests import the real module and FAIL LOUDLY on
+    any change so the constant gets re-grounded rather than drifting unnoticed.
+
+    Hermetic: imports an installed pure-Python module and constructs a rotating
+    cache from a fake model (a ``SimpleNamespace`` with ``.layers`` and no
+    ``make_cache``) — no weights, no network, no model load.
+    """
+
+    def test_step_matches_our_constant(self):
+        cache_mod = pytest.importorskip("mlx_lm.models.cache")
+        installed_step = cache_mod.RotatingKVCache.step
+        assert installed_step == _ROTATING_CACHE_STEP, (
+            "mlx_lm RotatingKVCache.step changed from the value kv_estimation "
+            f"assumes ({_ROTATING_CACHE_STEP} -> installed {installed_step}); "
+            "rotating_cache_slots would round to the wrong block size. If step "
+            "GREW this under-reserves KV at admission (OOM risk). Re-ground "
+            "_ROTATING_CACHE_STEP against the new impl."
+        )
+
+    def test_make_prompt_cache_keep_matches_our_bound(self):
+        cache_mod = pytest.importorskip("mlx_lm.models.cache")
+        # Fake model: exposes .layers, no ``make_cache`` -> make_prompt_cache takes
+        # the RotatingKVCache branch when a max_kv_size (window) is supplied.
+        fake_model = SimpleNamespace(layers=[object(), object()])
+        assert not hasattr(fake_model, "make_cache")
+        caches = cache_mod.make_prompt_cache(fake_model, max_kv_size=512)
+        assert caches, "make_prompt_cache returned no layers"
+        assert all(
+            isinstance(c, cache_mod.RotatingKVCache) for c in caches
+        ), "make_prompt_cache(max_kv_size=...) did not build RotatingKVCache layers"
+        installed_keeps = {c.keep for c in caches}
+        assert installed_keeps == {_ROTATING_CACHE_KEEP}, (
+            "mlx_lm make_prompt_cache builds rotating layers with keep="
+            f"{installed_keeps}, but kv_estimation assumes keep="
+            f"{_ROTATING_CACHE_KEEP}. If the installed keep is LARGER than our "
+            "constant, rotating_cache_slots under-reserves KV at admission (OOM "
+            "risk). Re-ground _ROTATING_CACHE_KEEP (it must be >= every keep any "
+            "shipped construction uses)."
+        )
+        # Restate the safety invariant explicitly: our KEEP must remain an upper
+        # bound over the installed construction's keep.
+        assert max(installed_keeps) <= _ROTATING_CACHE_KEEP

--- a/tests/test_kv_estimation.py
+++ b/tests/test_kv_estimation.py
@@ -7,10 +7,13 @@ These pin the contract that the D-METAL-CAP admission gate depends on
 * Dense / unknown configs are BYTE-IDENTICAL to the uniform formula (no
   spurious change to a codex-hardened, over-estimate-safe admission path).
 * Recognized hybrids (sliding-window, KV-sharing, recurrent) get the smaller,
-  accurate per-token growth with the window / recurrent footprint moved into a
-  per-sequence fixed baseline.
+  accurate per-token growth: full-attention layers grow unbounded, sliding
+  layers grow only up to a rotating window (a window-capped per-token term), and
+  recurrent layers reserve a token-independent fixed baseline.
 * The estimate never under-counts the counted layers (a sliding layer with no
-  readable window, or an unknown layer type, is charged as full-growth).
+  readable window, or an unknown layer type, is charged as full-growth) and
+  never over-charges a short request (the sliding term is capped at
+  ``min(tokens, window)``, byte-identical to uniform below the window).
 
 Hermetic: pure config dataclasses (``SimpleNamespace``) and dicts — no model
 load, no network.
@@ -152,10 +155,12 @@ class TestKVSharing:
             sliding_window=128,
         )
         est = _est(cfg, num_layers=n, kv_heads=kv, head_dim=hd)
-        # Nothing zeroed: 3 full layers grow, 7 sliding layers -> window
-        # baseline (all 10 layers counted).
+        # Nothing zeroed: 3 full layers grow unbounded, 7 sliding layers -> the
+        # window-capped sliding term (all 10 layers counted, none borrowed).
         assert est.per_token_growth_bytes == 2 * 3 * kv * hd * 2
-        assert est.fixed_baseline_bytes == 2 * 7 * 128 * kv * hd * 2
+        assert est.fixed_baseline_bytes == 0
+        assert est.sliding_per_token_bytes == 2 * 7 * kv * hd * 2
+        assert est.sliding_window_tokens == 128
 
     def test_zero_shared_is_not_a_hybrid_signal(self):
         # num_kv_shared_layers=0 (dense Gemma-4 12B/26B/31B) → no reduction,
@@ -174,7 +179,7 @@ class TestKVSharing:
 class TestSlidingWindow:
     """GPT-OSS ~50% sliding-window layers are window-bounded, not per-token."""
 
-    def test_half_sliding_halves_growth_and_adds_window_baseline(self):
+    def test_half_sliding_halves_unbounded_growth_and_caps_sliding(self):
         n, kv, hd, window = 24, 8, 64, 128
         layer_types = ["sliding_attention", "full_attention"] * (n // 2)
         cfg = SimpleNamespace(
@@ -187,9 +192,62 @@ class TestSlidingWindow:
         est = _est(cfg, num_layers=n, kv_heads=kv, head_dim=hd)
         n_full = n // 2
         n_sliding = n // 2
+        # Only the full layers grow unbounded per token — halved vs uniform.
         assert est.per_token_growth_bytes == 2 * n_full * kv * hd * 2
         assert est.per_token_growth_bytes == _uniform(n, kv, hd, 2) // 2  # halved
-        assert est.fixed_baseline_bytes == 2 * n_sliding * window * kv * hd * 2
+        # Sliding layers grow per token too, but only up to the window: the term
+        # is a per-token RATE (not a flat window buffer) so short requests are
+        # charged min(tokens, window) worth (codex round 6 BLOCKING).
+        assert est.fixed_baseline_bytes == 0
+        assert est.sliding_per_token_bytes == 2 * n_sliding * kv * hd * 2
+        assert est.sliding_window_tokens == window
+
+    def test_short_request_sliding_matches_uniform_no_regression(self):
+        # A request SHORTER than the window must project exactly the historical
+        # uniform footprint for the sliding layers — never the whole window
+        # (which would over-charge and spuriously reject it). Emulate the
+        # scheduler projection: per_token_growth * tokens + sliding_per_token *
+        # min(tokens, window).
+        n, kv, hd, window = 24, 8, 64, 4096
+        layer_types = ["sliding_attention", "full_attention"] * (n // 2)
+        cfg = SimpleNamespace(
+            num_hidden_layers=n,
+            num_key_value_heads=kv,
+            head_dim=hd,
+            layer_types=layer_types,
+            sliding_window=window,
+        )
+        est = _est(cfg, num_layers=n, kv_heads=kv, head_dim=hd)
+        tokens = 100  # << window
+        projected = (
+            est.fixed_baseline_bytes
+            + est.per_token_growth_bytes * tokens
+            + est.sliding_per_token_bytes * min(tokens, est.sliding_window_tokens)
+        )
+        # Every layer charged exactly ``tokens`` worth == the old uniform figure.
+        assert projected == _uniform(n, kv, hd, 2) * tokens
+
+    def test_long_request_sliding_caps_below_uniform(self):
+        # A request LONGER than the window must project BELOW the uniform figure:
+        # the sliding layers are capped at ``window`` positions while the uniform
+        # estimate would keep multiplying by the full token count.
+        n, kv, hd, window = 24, 8, 64, 128
+        layer_types = ["sliding_attention", "full_attention"] * (n // 2)
+        cfg = SimpleNamespace(
+            num_hidden_layers=n,
+            num_key_value_heads=kv,
+            head_dim=hd,
+            layer_types=layer_types,
+            sliding_window=window,
+        )
+        est = _est(cfg, num_layers=n, kv_heads=kv, head_dim=hd)
+        tokens = 8192  # >> window
+        projected = (
+            est.fixed_baseline_bytes
+            + est.per_token_growth_bytes * tokens
+            + est.sliding_per_token_bytes * min(tokens, est.sliding_window_tokens)
+        )
+        assert projected < _uniform(n, kv, hd, 2) * tokens
 
     def test_sliding_without_window_charged_as_full_growth(self):
         # A sliding layer whose window is unreadable cannot be bounded → it is
@@ -420,7 +478,10 @@ class TestHybridDimsAndNesting:
         # Producers = first 15 layers. Full at indices 4, 9, 14 → 3 full,
         # 12 sliding. Borrowers (last 20) contribute nothing.
         assert est.per_token_growth_bytes == 2 * 3 * global_kv * global_hd * 2
-        assert est.fixed_baseline_bytes == 12 * 2 * window * kv * hd * 2
+        assert est.fixed_baseline_bytes == 0
+        # Sliding layers use local dims; the term is window-capped, not flat.
+        assert est.sliding_per_token_bytes == 12 * 2 * kv * hd * 2
+        assert est.sliding_window_tokens == window
 
     def test_layer_structure_read_from_text_config(self):
         # Multimodal configs nest the language layer structure under
@@ -437,7 +498,9 @@ class TestHybridDimsAndNesting:
         )
         est = _est(cfg, num_layers=n, kv_heads=kv, head_dim=hd)
         assert est.per_token_growth_bytes == 2 * (n // 2) * kv * hd * 2
-        assert est.fixed_baseline_bytes == 2 * (n // 2) * window * kv * hd * 2
+        assert est.fixed_baseline_bytes == 0
+        assert est.sliding_per_token_bytes == 2 * (n // 2) * kv * hd * 2
+        assert est.sliding_window_tokens == window
 
     def test_dict_config_supported(self):
         # The offline hybrid probe reads parsed config.json dicts.
@@ -452,7 +515,9 @@ class TestHybridDimsAndNesting:
         }
         est = _est(cfg, num_layers=n, kv_heads=kv, head_dim=hd)
         assert est.per_token_growth_bytes == 2 * (n // 2) * kv * hd * 2
-        assert est.fixed_baseline_bytes == 2 * (n // 2) * window * kv * hd * 2
+        assert est.fixed_baseline_bytes == 0
+        assert est.sliding_per_token_bytes == 2 * (n // 2) * kv * hd * 2
+        assert est.sliding_window_tokens == window
 
     def test_unknown_layer_type_charged_as_full_growth(self):
         # An unrecognized attention-type string must never under-count → full.
@@ -472,10 +537,13 @@ class TestNeverUnderCounts:
     """The projected footprint is always >= the true counted-layer footprint."""
 
     def test_projection_upper_bounds_true_footprint(self):
-        # GPT-OSS-like hybrid. For any token count, fixed_baseline +
-        # tokens*growth must be >= the true footprint of the counted layers:
+        # GPT-OSS-like hybrid. For any token count, the full scheduler projection
+        #   fixed_baseline + tokens*growth + sliding_per_token*min(tokens, window)
+        # must be >= the true footprint of the counted layers:
         #   full layers: exact tokens*per-layer
         #   sliding layers: min(tokens, window)*per-layer  (<= window*per-layer)
+        # AND it must be TIGHT (equal), never over-charging a short request
+        # (codex round 6 BLOCKING).
         n, kv, hd, window, db = 24, 8, 64, 128, 2
         layer_types = ["sliding_attention", "full_attention"] * (n // 2)
         cfg = SimpleNamespace(
@@ -490,9 +558,15 @@ class TestNeverUnderCounts:
         n_sliding = n // 2
         full_per_layer = 2 * kv * hd * db
         for tokens in (1, 100, window, window + 1, 4096, 32768):
-            projected = est.fixed_baseline_bytes + tokens * est.per_token_growth_bytes
+            projected = (
+                est.fixed_baseline_bytes
+                + tokens * est.per_token_growth_bytes
+                + est.sliding_per_token_bytes * min(tokens, est.sliding_window_tokens)
+            )
             true_full = n_full * tokens * full_per_layer
             true_sliding = n_sliding * min(tokens, window) * full_per_layer
+            # Tight: the estimator charges each layer its exact peak occupancy.
+            assert projected == true_full + true_sliding
             assert projected >= true_full + true_sliding
 
     def test_full_layer_growth_never_below_uniform_base(self):

--- a/tests/test_kv_estimation.py
+++ b/tests/test_kv_estimation.py
@@ -20,6 +20,8 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
+import pytest
+
 from vllm_mlx.kv_estimation import KVFootprintEstimate, estimate_kv_footprint
 
 
@@ -254,6 +256,32 @@ class TestRecurrent:
         n_recurrent = n - n_full
         assert est.per_token_growth_bytes == 2 * n_full * kv * hd * 2
         assert est.fixed_baseline_bytes == n_recurrent * self._gdn_state_bytes()
+
+    @pytest.mark.parametrize(
+        "gdn_type",
+        ["linear_attention", "gated_delta_net", "gated_deltanet"],
+    )
+    def test_gateddeltanet_aliases_all_sized(self, gdn_type):
+        # Every GatedDeltaNet alias the classifier treats as recurrent must ALSO
+        # route to the GatedDeltaNet sizer — otherwise the alias classifies as
+        # zero-growth but its state cannot be sized, reverting to full per-token
+        # growth and losing the reduction this module exists to deliver (codex
+        # round 5 BLOCKING). All three spellings must yield the identical zero
+        # per-token growth + baseline-reserved fixed state.
+        n, kv, hd = 8, 4, 64
+        layer_types = [gdn_type] * (n - 1) + ["full_attention"]
+        cfg = SimpleNamespace(
+            num_hidden_layers=n,
+            num_key_value_heads=kv,
+            head_dim=hd,
+            layer_types=layer_types,
+            **self._GDN_FIELDS,
+        )
+        est = _est(cfg, num_layers=n, kv_heads=kv, head_dim=hd)
+        # Only the single full layer grows per token; the recurrent layers reserve
+        # their fixed state in the baseline (never full per-token growth).
+        assert est.per_token_growth_bytes == 2 * 1 * kv * hd * 2
+        assert est.fixed_baseline_bytes == (n - 1) * self._gdn_state_bytes()
 
     def test_unsizeable_recurrent_falls_back_to_full_growth(self):
         # linear_attention layers WITHOUT any GatedDeltaNet/Mamba sizing fields

--- a/tests/test_kv_estimation.py
+++ b/tests/test_kv_estimation.py
@@ -267,13 +267,13 @@ class TestSlidingWindow:
 
 
 class TestRecurrent:
-    """Qwen3.5/3.6 GatedDeltaNet / Mamba layers have zero PER-TOKEN growth.
+    """Qwen3.5/3.6 GatedDeltaNet layers have zero PER-TOKEN growth.
 
     Their fixed recurrent state does not grow with generated tokens, so it lands
-    in the per-sequence baseline (sized from the family's real config fields)
-    rather than the per-token term. A recurrent layer whose state cannot be
-    sized falls back to full per-token growth so it is never left unreserved
-    (codex round 2 BLOCKING #1).
+    in the per-sequence baseline (sized from GatedDeltaNet's real config fields)
+    rather than the per-token term. Any recurrent family we do NOT size exactly
+    (Mamba/Mamba2, RWKV, generic) falls back to full per-token growth so it is
+    never left unreserved (codex round 2 BLOCKING #1 + round 7 BLOCKING #1).
     """
 
     # GatedDeltaNet state, sized from the same fields as
@@ -358,25 +358,29 @@ class TestRecurrent:
         assert est.per_token_growth_bytes == _uniform(n, kv, hd, 2)
         assert est.fixed_baseline_bytes == 0
 
-    def test_mamba_state_reserved_in_baseline(self):
+    def test_mamba_not_sized_falls_back_to_full_growth(self):
+        # We deliberately do NOT size a Mamba/Mamba2 state: the conv buffer
+        # channel count differs between Mamba1 (d_inner) and Mamba2 (d_inner +
+        # grouped B/C channels), so a single formula would under-reserve Mamba2
+        # (codex round 7 BLOCKING #1). This engine ships no Mamba model, so its
+        # layers conservatively fall back to full per-token growth — over-count
+        # safe, never unreserved — even when Mamba-shaped fields are present.
         n, kv, hd = 8, 4, 64
-        d_state, d_conv, n_heads, d_head = 128, 4, 24, 64
         layer_types = ["mamba"] * (n - 1) + ["full_attention"]
         cfg = SimpleNamespace(
             num_hidden_layers=n,
             num_key_value_heads=kv,
             head_dim=hd,
             layer_types=layer_types,
-            mamba_d_state=d_state,
-            mamba_d_conv=d_conv,
-            mamba_n_heads=n_heads,
-            mamba_d_head=d_head,
+            mamba_d_state=128,
+            mamba_d_conv=4,
+            mamba_n_heads=24,
+            mamba_d_head=64,
         )
         est = _est(cfg, num_layers=n, kv_heads=kv, head_dim=hd)
-        d_inner = n_heads * d_head
-        state = 4 * (d_inner * d_state + d_inner * (d_conv - 1))
-        assert est.per_token_growth_bytes == 2 * 1 * kv * hd * 2
-        assert est.fixed_baseline_bytes == (n - 1) * state
+        # All 8 layers charged full growth — no baseline, no under-count.
+        assert est.per_token_growth_bytes == _uniform(n, kv, hd, 2)
+        assert est.fixed_baseline_bytes == 0
 
     def test_gateddeltanet_missing_conv_kernel_falls_back(self):
         # GatedDeltaNet head fields present but linear_conv_kernel_dim ABSENT →
@@ -400,25 +404,6 @@ class TestRecurrent:
         assert est.per_token_growth_bytes == _uniform(n, kv, hd, 2)
         assert est.fixed_baseline_bytes == 0
 
-    def test_mamba_missing_conv_kernel_falls_back(self):
-        # Mamba SSM fields present but d_conv/conv_kernel_size ABSENT → fall back
-        # to full growth (codex round 3 BLOCKING #2).
-        n, kv, hd = 8, 4, 64
-        layer_types = ["mamba"] * (n - 1) + ["full_attention"]
-        cfg = SimpleNamespace(
-            num_hidden_layers=n,
-            num_key_value_heads=kv,
-            head_dim=hd,
-            layer_types=layer_types,
-            mamba_d_state=128,
-            mamba_n_heads=24,
-            mamba_d_head=64,
-            # mamba_d_conv / conv_kernel_size intentionally absent
-        )
-        est = _est(cfg, num_layers=n, kv_heads=kv, head_dim=hd)
-        assert est.per_token_growth_bytes == _uniform(n, kv, hd, 2)
-        assert est.fixed_baseline_bytes == 0
-
     def test_full_attention_name_containing_linear_is_not_recurrent(self):
         # Exact-match allowlist (codex round 1 BLOCKING #4): an unfamiliar
         # full-attention type that merely CONTAINS "linear"/"gated"/"local" must
@@ -434,11 +419,11 @@ class TestRecurrent:
         assert est.per_token_growth_bytes == _uniform(n, kv, hd, 2)
         assert est.fixed_baseline_bytes == 0
 
-    def test_generic_recurrent_family_not_mis_sized_as_mamba(self):
+    def test_generic_recurrent_family_not_mis_sized(self):
         # An RWKV (or other generic recurrent) layer that incidentally exposes
-        # Mamba-ish generic fields must NOT be sized as Mamba — its exact state
-        # layout is not implemented, so it falls back to full growth (codex
-        # round 4 BLOCKING #2).
+        # Mamba-ish generic fields must NOT be stamped with a bogus fixed state —
+        # only GatedDeltaNet is sized; every other recurrent family falls back to
+        # full growth (codex round 4 BLOCKING #2 + round 7 BLOCKING #1).
         n, kv, hd = 8, 4, 64
         layer_types = ["rwkv"] * (n - 1) + ["full_attention"]
         cfg = SimpleNamespace(
@@ -446,13 +431,13 @@ class TestRecurrent:
             num_key_value_heads=kv,
             head_dim=hd,
             layer_types=layer_types,
-            # generic fields that the Mamba branch would otherwise consume:
+            # generic fields a naive recurrent sizer might otherwise consume:
             state_size=128,
             intermediate_size=1536,
             conv_kernel_size=4,
         )
         est = _est(cfg, num_layers=n, kv_heads=kv, head_dim=hd)
-        # No baseline reserved (not sized as Mamba); all layers charged full.
+        # No baseline reserved (only GatedDeltaNet is sized); all layers full.
         assert est.per_token_growth_bytes == _uniform(n, kv, hd, 2)
         assert est.fixed_baseline_bytes == 0
 
@@ -537,13 +522,16 @@ class TestNeverUnderCounts:
     """The projected footprint is always >= the true counted-layer footprint."""
 
     def test_projection_upper_bounds_true_footprint(self):
-        # GPT-OSS-like hybrid. For any token count, the full scheduler projection
+        # GPT-OSS-like hybrid. This checks the ESTIMATOR's steady-state (decode)
+        # composition of its returned fields:
         #   fixed_baseline + tokens*growth + sliding_per_token*min(tokens, window)
-        # must be >= the true footprint of the counted layers:
+        # against the true footprint of the counted layers:
         #   full layers: exact tokens*per-layer
         #   sliding layers: min(tokens, window)*per-layer  (<= window*per-layer)
-        # AND it must be TIGHT (equal), never over-charging a short request
-        # (codex round 6 BLOCKING).
+        # It must be TIGHT (equal), never over-charging a short request (codex
+        # round 6 BLOCKING). (The scheduler additionally floors the sliding term
+        # at the full prompt for the transient prefill peak — codex round 7 #3 —
+        # which only ever RAISES the charge; covered in the scheduler tests.)
         n, kv, hd, window, db = 24, 8, 64, 128, 2
         layer_types = ["sliding_attention", "full_attention"] * (n // 2)
         cfg = SimpleNamespace(
@@ -586,6 +574,27 @@ class TestNeverUnderCounts:
         # Clamped to the uniform base-layer size, not the tiny global dims.
         assert est.per_token_growth_bytes == _uniform(n, kv, hd, db)
         assert est.fixed_baseline_bytes == 0
+
+    def test_sliding_rate_never_below_uniform_base(self):
+        # Symmetric to the full-layer clamp: a nested/malformed config whose
+        # local (sliding) dims read SMALLER than the base dims the scheduler used
+        # must not shrink the sliding per-token rate below the uniform per-layer
+        # charge (codex round 7 BLOCKING #2). Here the struct exposes a tiny
+        # local head_dim; the base head_dim passed by the caller is larger.
+        n, kv, hd, db = 8, 8, 128, 2
+        layer_types = ["sliding_attention"] * n
+        cfg = SimpleNamespace(
+            num_hidden_layers=n,
+            num_key_value_heads=kv,
+            head_dim=8,  # << base head_dim (128) — malformed / non-authoritative
+            layer_types=layer_types,
+            sliding_window=256,
+        )
+        est = _est(cfg, num_layers=n, kv_heads=kv, head_dim=hd, dtype_bytes=db)
+        # Clamped to the uniform base per-layer rate, not the tiny local dims.
+        assert est.sliding_per_token_bytes == n * 2 * kv * hd * db
+        assert est.per_token_growth_bytes == 0
+        assert est.sliding_window_tokens == 256
 
     def test_projection_covers_recurrent_fixed_state(self):
         # A GatedDeltaNet hybrid: the projection must reserve the recurrent

--- a/tests/test_kv_estimation.py
+++ b/tests/test_kv_estimation.py
@@ -117,9 +117,10 @@ class TestKVSharing:
         assert est.per_token_growth_bytes == 2 * (n - n_shared) * kv * hd * 2
         assert est.fixed_baseline_bytes == 0
 
-    def test_shared_layers_without_layer_types_still_reduce(self):
-        # num_kv_shared_layers alone (no layer_types) is a recognized signal:
-        # reduce by the shared layers, rest treated as full-growth.
+    def test_shared_layers_without_layer_types_falls_back(self):
+        # num_kv_shared_layers alone (no per-layer map) is NOT enough to zero
+        # borrowers — without layer_types we cannot verify the last-N contract,
+        # so we stay on the uniform estimate (codex round 1 BLOCKING #3).
         n, n_shared, kv, hd = 40, 10, 4, 64
         cfg = SimpleNamespace(
             num_hidden_layers=n,
@@ -128,8 +129,31 @@ class TestKVSharing:
             num_kv_shared_layers=n_shared,
         )
         est = _est(cfg, num_layers=n, kv_heads=kv, head_dim=hd)
-        assert est.per_token_growth_bytes == 2 * (n - n_shared) * kv * hd * 2
+        assert est.per_token_growth_bytes == _uniform(n, kv, hd, 2)
         assert est.fixed_baseline_bytes == 0
+
+    def test_shared_layers_with_unverifiable_split_not_zeroed(self):
+        # num_kv_shared_layers present WITH layer_types, but the last-N borrower
+        # types have no same-type producer below the split (a full-attention
+        # borrower with only sliding producers) → the last-N contract is
+        # unverified, so no layer is zeroed (over-count, never under-count).
+        n, n_shared, kv, hd = 10, 3, 4, 64
+        # First 7 (producers) all sliding; last 3 (borrowers) full → a full
+        # borrower has no full producer below the split.
+        layer_types = ["sliding_attention"] * 7 + ["full_attention"] * 3
+        cfg = SimpleNamespace(
+            num_hidden_layers=n,
+            num_key_value_heads=kv,
+            head_dim=hd,
+            layer_types=layer_types,
+            num_kv_shared_layers=n_shared,
+            sliding_window=128,
+        )
+        est = _est(cfg, num_layers=n, kv_heads=kv, head_dim=hd)
+        # Nothing zeroed: 3 full layers grow, 7 sliding layers -> window
+        # baseline (all 10 layers counted).
+        assert est.per_token_growth_bytes == 2 * 3 * kv * hd * 2
+        assert est.fixed_baseline_bytes == 2 * 7 * 128 * kv * hd * 2
 
     def test_zero_shared_is_not_a_hybrid_signal(self):
         # num_kv_shared_layers=0 (dense Gemma-4 12B/26B/31B) → no reduction,
@@ -183,11 +207,17 @@ class TestSlidingWindow:
 
 
 class TestRecurrent:
-    """Qwen3.5/3.6 GatedDeltaNet linear-attention layers have zero growth."""
+    """Qwen3.5/3.6 GatedDeltaNet linear-attention layers have zero growth.
 
-    def test_linear_layers_contribute_zero_growth(self):
-        # 48 layers, 3:1 linear:full → 12 full grow, 36 recurrent contribute
-        # only a fixed state baseline.
+    Recurrent layers keep a FIXED state that our configs do not expose the
+    fields to size, so we model zero per-token growth (the correctness win) and
+    do NOT invent a fixed-state term (codex round 1 BLOCKING #2). Only the
+    full-attention layers show up in the estimate.
+    """
+
+    def test_linear_layers_contribute_zero_growth_and_zero_baseline(self):
+        # 48 layers, 3:1 linear:full → only the 12 full layers grow; the 36
+        # recurrent layers contribute nothing to either term.
         n, kv, hd = 48, 2, 128
         pattern = [
             "linear_attention",
@@ -204,11 +234,8 @@ class TestRecurrent:
         )
         est = _est(cfg, num_layers=n, kv_heads=kv, head_dim=hd)
         n_full = n // 4
-        n_recurrent = n - n_full
         assert est.per_token_growth_bytes == 2 * n_full * kv * hd * 2
-        # Recurrent state is a fixed per-head state matrix (~head_dim^2 per KV
-        # head), never multiplied by token count.
-        assert est.fixed_baseline_bytes == n_recurrent * 2 * kv * hd * hd
+        assert est.fixed_baseline_bytes == 0
 
     def test_mamba_marker_is_recurrent(self):
         n, kv, hd = 8, 4, 64
@@ -221,7 +248,22 @@ class TestRecurrent:
         )
         est = _est(cfg, num_layers=n, kv_heads=kv, head_dim=hd)
         assert est.per_token_growth_bytes == 2 * 1 * kv * hd * 2
-        assert est.fixed_baseline_bytes == (n - 1) * 2 * kv * hd * hd
+        assert est.fixed_baseline_bytes == 0
+
+    def test_full_attention_name_containing_linear_is_not_recurrent(self):
+        # Exact-match allowlist (codex round 1 BLOCKING #4): an unfamiliar
+        # full-attention type that merely CONTAINS "linear"/"gated"/"local" must
+        # NOT be misread as zero-growth — it is charged as full-growth.
+        n, kv, hd = 6, 4, 64
+        cfg = SimpleNamespace(
+            num_hidden_layers=n,
+            num_key_value_heads=kv,
+            head_dim=hd,
+            layer_types=["gated_full_attention", "linear_global_attention"] * (n // 2),
+        )
+        est = _est(cfg, num_layers=n, kv_heads=kv, head_dim=hd)
+        assert est.per_token_growth_bytes == _uniform(n, kv, hd, 2)
+        assert est.fixed_baseline_bytes == 0
 
 
 class TestHybridDimsAndNesting:

--- a/tests/test_kv_estimation.py
+++ b/tests/test_kv_estimation.py
@@ -207,39 +207,60 @@ class TestSlidingWindow:
 
 
 class TestRecurrent:
-    """Qwen3.5/3.6 GatedDeltaNet linear-attention layers have zero growth.
+    """Qwen3.5/3.6 GatedDeltaNet / Mamba layers have zero PER-TOKEN growth.
 
-    Recurrent layers keep a FIXED state that our configs do not expose the
-    fields to size, so we model zero per-token growth (the correctness win) and
-    do NOT invent a fixed-state term (codex round 1 BLOCKING #2). Only the
-    full-attention layers show up in the estimate.
+    Their fixed recurrent state does not grow with generated tokens, so it lands
+    in the per-sequence baseline (sized from the family's real config fields)
+    rather than the per-token term. A recurrent layer whose state cannot be
+    sized falls back to full per-token growth so it is never left unreserved
+    (codex round 2 BLOCKING #1).
     """
 
-    def test_linear_layers_contribute_zero_growth_and_zero_baseline(self):
-        # 48 layers, 3:1 linear:full → only the 12 full layers grow; the 36
-        # recurrent layers contribute nothing to either term.
+    # GatedDeltaNet state, sized from the same fields as
+    # ``mlx_lm.models.qwen3_next.Qwen3NextGatedDeltaNet``, at fp32/element.
+    _GDN_FIELDS = dict(
+        linear_num_value_heads=32,
+        linear_num_key_heads=16,
+        linear_key_head_dim=128,
+        linear_value_head_dim=128,
+        linear_conv_kernel_dim=4,
+    )
+
+    @staticmethod
+    def _gdn_state_bytes():
+        num_v, num_k, hk, hv, conv = 32, 16, 128, 128, 4
+        key_dim = num_k * hk
+        value_dim = num_v * hv
+        recurrent = num_v * hk * hv
+        conv_dim = 2 * key_dim + value_dim
+        conv_state = (conv - 1) * conv_dim
+        return 4 * (recurrent + conv_state)
+
+    def test_gateddeltanet_state_reserved_in_baseline_zero_growth(self):
+        # 48 layers, 3:1 linear:full → only the 12 full layers grow per token;
+        # the 36 GatedDeltaNet layers reserve their fixed state in the baseline.
         n, kv, hd = 48, 2, 128
-        pattern = [
-            "linear_attention",
-            "linear_attention",
-            "linear_attention",
-            "full_attention",
-        ]
+        pattern = ["linear_attention"] * 3 + ["full_attention"]
         layer_types = pattern * (n // 4)
         cfg = SimpleNamespace(
             num_hidden_layers=n,
             num_key_value_heads=kv,
             head_dim=hd,
             layer_types=layer_types,
+            **self._GDN_FIELDS,
         )
         est = _est(cfg, num_layers=n, kv_heads=kv, head_dim=hd)
         n_full = n // 4
+        n_recurrent = n - n_full
         assert est.per_token_growth_bytes == 2 * n_full * kv * hd * 2
-        assert est.fixed_baseline_bytes == 0
+        assert est.fixed_baseline_bytes == n_recurrent * self._gdn_state_bytes()
 
-    def test_mamba_marker_is_recurrent(self):
+    def test_unsizeable_recurrent_falls_back_to_full_growth(self):
+        # linear_attention layers WITHOUT any GatedDeltaNet/Mamba sizing fields
+        # → cannot size the state → charged the uniform per-token estimate
+        # (full growth), never left unreserved.
         n, kv, hd = 8, 4, 64
-        layer_types = ["mamba"] * (n - 1) + ["full_attention"]
+        layer_types = ["linear_attention"] * (n - 1) + ["full_attention"]
         cfg = SimpleNamespace(
             num_hidden_layers=n,
             num_key_value_heads=kv,
@@ -247,8 +268,29 @@ class TestRecurrent:
             layer_types=layer_types,
         )
         est = _est(cfg, num_layers=n, kv_heads=kv, head_dim=hd)
-        assert est.per_token_growth_bytes == 2 * 1 * kv * hd * 2
+        # All 8 layers charged full growth (uniform) — no reduction, no baseline.
+        assert est.per_token_growth_bytes == _uniform(n, kv, hd, 2)
         assert est.fixed_baseline_bytes == 0
+
+    def test_mamba_state_reserved_in_baseline(self):
+        n, kv, hd = 8, 4, 64
+        d_state, d_conv, n_heads, d_head = 128, 4, 24, 64
+        layer_types = ["mamba"] * (n - 1) + ["full_attention"]
+        cfg = SimpleNamespace(
+            num_hidden_layers=n,
+            num_key_value_heads=kv,
+            head_dim=hd,
+            layer_types=layer_types,
+            mamba_d_state=d_state,
+            mamba_d_conv=d_conv,
+            mamba_n_heads=n_heads,
+            mamba_d_head=d_head,
+        )
+        est = _est(cfg, num_layers=n, kv_heads=kv, head_dim=hd)
+        d_inner = n_heads * d_head
+        state = 4 * (d_inner * d_state + d_inner * (d_conv - 1))
+        assert est.per_token_growth_bytes == 2 * 1 * kv * hd * 2
+        assert est.fixed_baseline_bytes == (n - 1) * state
 
     def test_full_attention_name_containing_linear_is_not_recurrent(self):
         # Exact-match allowlist (codex round 1 BLOCKING #4): an unfamiliar
@@ -361,3 +403,37 @@ class TestNeverUnderCounts:
             true_full = n_full * tokens * full_per_layer
             true_sliding = n_sliding * min(tokens, window) * full_per_layer
             assert projected >= true_full + true_sliding
+
+    def test_projection_covers_recurrent_fixed_state(self):
+        # A GatedDeltaNet hybrid: the projection must reserve the recurrent
+        # layers' fixed state (in the baseline) on top of the full layers'
+        # growth — it is never omitted (codex round 2 BLOCKING #1 + #3).
+        n, kv, hd, db = 16, 2, 128, 2
+        gdn = dict(
+            linear_num_value_heads=32,
+            linear_num_key_heads=16,
+            linear_key_head_dim=128,
+            linear_value_head_dim=128,
+            linear_conv_kernel_dim=4,
+        )
+        layer_types = (["linear_attention"] * 3 + ["full_attention"]) * (n // 4)
+        cfg = SimpleNamespace(
+            num_hidden_layers=n,
+            num_key_value_heads=kv,
+            head_dim=hd,
+            layer_types=layer_types,
+            **gdn,
+        )
+        est = _est(cfg, num_layers=n, kv_heads=kv, head_dim=hd, dtype_bytes=db)
+        n_full = n // 4
+        n_recurrent = n - n_full
+        # Per-layer GatedDeltaNet state (fp32/element), independently recomputed.
+        key_dim = 16 * 128
+        value_dim = 32 * 128
+        state = 4 * (32 * 128 * 128 + (4 - 1) * (2 * key_dim + value_dim))
+        assert est.fixed_baseline_bytes == n_recurrent * state
+        full_per_layer = 2 * kv * hd * db
+        for tokens in (1, 100, 4096, 32768):
+            projected = est.fixed_baseline_bytes + tokens * est.per_token_growth_bytes
+            # >= full-attention growth + the reserved recurrent fixed state.
+            assert projected >= n_full * tokens * full_per_layer + n_recurrent * state

--- a/tests/test_kv_estimation.py
+++ b/tests/test_kv_estimation.py
@@ -1,0 +1,321 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the architecture-aware KV footprint estimator.
+
+These pin the contract that the D-METAL-CAP admission gate depends on
+(``scheduler._resolve_kv_bytes_per_token`` → ``estimate_kv_footprint``):
+
+* Dense / unknown configs are BYTE-IDENTICAL to the uniform formula (no
+  spurious change to a codex-hardened, over-estimate-safe admission path).
+* Recognized hybrids (sliding-window, KV-sharing, recurrent) get the smaller,
+  accurate per-token growth with the window / recurrent footprint moved into a
+  per-sequence fixed baseline.
+* The estimate never under-counts the counted layers (a sliding layer with no
+  readable window, or an unknown layer type, is charged as full-growth).
+
+Hermetic: pure config dataclasses (``SimpleNamespace``) and dicts — no model
+load, no network.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from vllm_mlx.kv_estimation import KVFootprintEstimate, estimate_kv_footprint
+
+
+def _uniform(num_layers: int, kv_heads: int, head_dim: int, dtype_bytes: int) -> int:
+    return 2 * num_layers * kv_heads * head_dim * dtype_bytes
+
+
+def _est(cfg, *, num_layers, kv_heads, head_dim, dtype_bytes=2) -> KVFootprintEstimate:
+    return estimate_kv_footprint(
+        cfg,
+        dtype_bytes=dtype_bytes,
+        uniform_per_token_bytes=_uniform(num_layers, kv_heads, head_dim, dtype_bytes),
+        base_num_layers=num_layers,
+        base_kv_heads=kv_heads,
+        base_head_dim=head_dim,
+    )
+
+
+class TestDenseFallback:
+    """Anything not a recognized hybrid stays byte-identical to uniform."""
+
+    def test_dense_config_is_byte_identical(self):
+        # No layer_types, no sliding_window, no num_kv_shared_layers.
+        cfg = SimpleNamespace(num_hidden_layers=32, num_key_value_heads=8, head_dim=128)
+        est = _est(cfg, num_layers=32, kv_heads=8, head_dim=128)
+        assert est.per_token_growth_bytes == _uniform(32, 8, 128, 2)
+        assert est.fixed_baseline_bytes == 0
+
+    def test_sliding_window_without_layer_types_falls_back(self):
+        # Mistral-like: a global ``sliding_window`` field but NO per-layer
+        # ``layer_types``. We must NOT treat every layer as sliding (that would
+        # zero the per-token growth) — ambiguous → uniform.
+        cfg = SimpleNamespace(
+            num_hidden_layers=32,
+            num_key_value_heads=8,
+            head_dim=128,
+            sliding_window=4096,
+        )
+        est = _est(cfg, num_layers=32, kv_heads=8, head_dim=128)
+        assert est.per_token_growth_bytes == _uniform(32, 8, 128, 2)
+        assert est.fixed_baseline_bytes == 0
+
+    def test_wrong_length_layer_types_falls_back(self):
+        cfg = SimpleNamespace(
+            num_hidden_layers=32,
+            num_key_value_heads=8,
+            head_dim=128,
+            layer_types=["full_attention"] * 30,  # len != num_layers
+        )
+        est = _est(cfg, num_layers=32, kv_heads=8, head_dim=128)
+        assert est.per_token_growth_bytes == _uniform(32, 8, 128, 2)
+        assert est.fixed_baseline_bytes == 0
+
+    def test_non_string_layer_types_falls_back(self):
+        cfg = SimpleNamespace(
+            num_hidden_layers=4,
+            num_key_value_heads=8,
+            head_dim=128,
+            layer_types=[0, 1, 2, 3],  # not strings
+        )
+        est = _est(cfg, num_layers=4, kv_heads=8, head_dim=128)
+        assert est.per_token_growth_bytes == _uniform(4, 8, 128, 2)
+        assert est.fixed_baseline_bytes == 0
+
+    def test_zero_base_dims_returns_uniform(self):
+        # Defensive: the scheduler never calls us with 0 uniform, but the
+        # estimator must not crash / invent an estimate on degenerate input.
+        cfg = SimpleNamespace(num_hidden_layers=0)
+        est = estimate_kv_footprint(
+            cfg,
+            dtype_bytes=2,
+            uniform_per_token_bytes=0,
+            base_num_layers=0,
+            base_kv_heads=0,
+            base_head_dim=0,
+        )
+        assert est.per_token_growth_bytes == 0
+        assert est.fixed_baseline_bytes == 0
+
+
+class TestKVSharing:
+    """Gemma-4 / Gemma-3n ``num_kv_shared_layers`` borrower layers = 0 KV."""
+
+    def test_shared_layers_reduce_growth_exactly(self):
+        # 35 layers, all full-attention, last 20 borrow → 15 producers grow.
+        n, n_shared, kv, hd = 35, 20, 1, 128
+        cfg = SimpleNamespace(
+            num_hidden_layers=n,
+            num_key_value_heads=kv,
+            head_dim=hd,
+            layer_types=["full_attention"] * n,
+            num_kv_shared_layers=n_shared,
+        )
+        est = _est(cfg, num_layers=n, kv_heads=kv, head_dim=hd)
+        assert est.per_token_growth_bytes == 2 * (n - n_shared) * kv * hd * 2
+        assert est.fixed_baseline_bytes == 0
+
+    def test_shared_layers_without_layer_types_still_reduce(self):
+        # num_kv_shared_layers alone (no layer_types) is a recognized signal:
+        # reduce by the shared layers, rest treated as full-growth.
+        n, n_shared, kv, hd = 40, 10, 4, 64
+        cfg = SimpleNamespace(
+            num_hidden_layers=n,
+            num_key_value_heads=kv,
+            head_dim=hd,
+            num_kv_shared_layers=n_shared,
+        )
+        est = _est(cfg, num_layers=n, kv_heads=kv, head_dim=hd)
+        assert est.per_token_growth_bytes == 2 * (n - n_shared) * kv * hd * 2
+        assert est.fixed_baseline_bytes == 0
+
+    def test_zero_shared_is_not_a_hybrid_signal(self):
+        # num_kv_shared_layers=0 (dense Gemma-4 12B/26B/31B) → no reduction,
+        # uniform fallback.
+        cfg = SimpleNamespace(
+            num_hidden_layers=32,
+            num_key_value_heads=8,
+            head_dim=128,
+            num_kv_shared_layers=0,
+        )
+        est = _est(cfg, num_layers=32, kv_heads=8, head_dim=128)
+        assert est.per_token_growth_bytes == _uniform(32, 8, 128, 2)
+        assert est.fixed_baseline_bytes == 0
+
+
+class TestSlidingWindow:
+    """GPT-OSS ~50% sliding-window layers are window-bounded, not per-token."""
+
+    def test_half_sliding_halves_growth_and_adds_window_baseline(self):
+        n, kv, hd, window = 24, 8, 64, 128
+        layer_types = ["sliding_attention", "full_attention"] * (n // 2)
+        cfg = SimpleNamespace(
+            num_hidden_layers=n,
+            num_key_value_heads=kv,
+            head_dim=hd,
+            layer_types=layer_types,
+            sliding_window=window,
+        )
+        est = _est(cfg, num_layers=n, kv_heads=kv, head_dim=hd)
+        n_full = n // 2
+        n_sliding = n // 2
+        assert est.per_token_growth_bytes == 2 * n_full * kv * hd * 2
+        assert est.per_token_growth_bytes == _uniform(n, kv, hd, 2) // 2  # halved
+        assert est.fixed_baseline_bytes == 2 * n_sliding * window * kv * hd * 2
+
+    def test_sliding_without_window_charged_as_full_growth(self):
+        # A sliding layer whose window is unreadable cannot be bounded → it is
+        # charged as full-growth so we never under-count.
+        n, kv, hd = 24, 8, 64
+        layer_types = ["sliding_attention", "full_attention"] * (n // 2)
+        cfg = SimpleNamespace(
+            num_hidden_layers=n,
+            num_key_value_heads=kv,
+            head_dim=hd,
+            layer_types=layer_types,
+            # sliding_window intentionally absent
+        )
+        est = _est(cfg, num_layers=n, kv_heads=kv, head_dim=hd)
+        assert est.per_token_growth_bytes == _uniform(n, kv, hd, 2)
+        assert est.fixed_baseline_bytes == 0
+
+
+class TestRecurrent:
+    """Qwen3.5/3.6 GatedDeltaNet linear-attention layers have zero growth."""
+
+    def test_linear_layers_contribute_zero_growth(self):
+        # 48 layers, 3:1 linear:full → 12 full grow, 36 recurrent contribute
+        # only a fixed state baseline.
+        n, kv, hd = 48, 2, 128
+        pattern = [
+            "linear_attention",
+            "linear_attention",
+            "linear_attention",
+            "full_attention",
+        ]
+        layer_types = pattern * (n // 4)
+        cfg = SimpleNamespace(
+            num_hidden_layers=n,
+            num_key_value_heads=kv,
+            head_dim=hd,
+            layer_types=layer_types,
+        )
+        est = _est(cfg, num_layers=n, kv_heads=kv, head_dim=hd)
+        n_full = n // 4
+        n_recurrent = n - n_full
+        assert est.per_token_growth_bytes == 2 * n_full * kv * hd * 2
+        # Recurrent state is a fixed per-head state matrix (~head_dim^2 per KV
+        # head), never multiplied by token count.
+        assert est.fixed_baseline_bytes == n_recurrent * 2 * kv * hd * hd
+
+    def test_mamba_marker_is_recurrent(self):
+        n, kv, hd = 8, 4, 64
+        layer_types = ["mamba"] * (n - 1) + ["full_attention"]
+        cfg = SimpleNamespace(
+            num_hidden_layers=n,
+            num_key_value_heads=kv,
+            head_dim=hd,
+            layer_types=layer_types,
+        )
+        est = _est(cfg, num_layers=n, kv_heads=kv, head_dim=hd)
+        assert est.per_token_growth_bytes == 2 * 1 * kv * hd * 2
+        assert est.fixed_baseline_bytes == (n - 1) * 2 * kv * hd * hd
+
+
+class TestHybridDimsAndNesting:
+    def test_global_head_dim_used_for_full_layers(self):
+        # Realistic Gemma-4 text: 35 layers, 4:1 sliding:full pattern, last 20
+        # borrow, full layers use the wider global_head_dim/global kv heads.
+        n, n_shared, kv, hd = 35, 20, 1, 256
+        global_hd, global_kv, window = 512, 1, 512
+        layer_types = (["sliding_attention"] * 4 + ["full_attention"]) * (n // 5)
+        cfg = SimpleNamespace(
+            num_hidden_layers=n,
+            num_key_value_heads=kv,
+            head_dim=hd,
+            global_head_dim=global_hd,
+            num_global_key_value_heads=global_kv,
+            num_kv_shared_layers=n_shared,
+            sliding_window=window,
+            layer_types=layer_types,
+        )
+        est = _est(cfg, num_layers=n, kv_heads=kv, head_dim=hd)
+        # Producers = first 15 layers. Full at indices 4, 9, 14 → 3 full,
+        # 12 sliding. Borrowers (last 20) contribute nothing.
+        assert est.per_token_growth_bytes == 2 * 3 * global_kv * global_hd * 2
+        assert est.fixed_baseline_bytes == 12 * 2 * window * kv * hd * 2
+
+    def test_layer_structure_read_from_text_config(self):
+        # Multimodal configs nest the language layer structure under
+        # ``text_config``; the estimator must find it there.
+        n, kv, hd, window = 24, 8, 64, 128
+        layer_types = ["sliding_attention", "full_attention"] * (n // 2)
+        cfg = SimpleNamespace(
+            text_config=SimpleNamespace(
+                num_key_value_heads=kv,
+                head_dim=hd,
+                layer_types=layer_types,
+                sliding_window=window,
+            )
+        )
+        est = _est(cfg, num_layers=n, kv_heads=kv, head_dim=hd)
+        assert est.per_token_growth_bytes == 2 * (n // 2) * kv * hd * 2
+        assert est.fixed_baseline_bytes == 2 * (n // 2) * window * kv * hd * 2
+
+    def test_dict_config_supported(self):
+        # The offline hybrid probe reads parsed config.json dicts.
+        n, kv, hd, window = 24, 8, 64, 128
+        layer_types = ["sliding_attention", "full_attention"] * (n // 2)
+        cfg = {
+            "num_hidden_layers": n,
+            "num_key_value_heads": kv,
+            "head_dim": hd,
+            "layer_types": layer_types,
+            "sliding_window": window,
+        }
+        est = _est(cfg, num_layers=n, kv_heads=kv, head_dim=hd)
+        assert est.per_token_growth_bytes == 2 * (n // 2) * kv * hd * 2
+        assert est.fixed_baseline_bytes == 2 * (n // 2) * window * kv * hd * 2
+
+    def test_unknown_layer_type_charged_as_full_growth(self):
+        # An unrecognized attention-type string must never under-count → full.
+        n, kv, hd = 4, 8, 128
+        cfg = SimpleNamespace(
+            num_hidden_layers=n,
+            num_key_value_heads=kv,
+            head_dim=hd,
+            layer_types=["mystery_attention"] * n,
+        )
+        est = _est(cfg, num_layers=n, kv_heads=kv, head_dim=hd)
+        assert est.per_token_growth_bytes == _uniform(n, kv, hd, 2)
+        assert est.fixed_baseline_bytes == 0
+
+
+class TestNeverUnderCounts:
+    """The projected footprint is always >= the true counted-layer footprint."""
+
+    def test_projection_upper_bounds_true_footprint(self):
+        # GPT-OSS-like hybrid. For any token count, fixed_baseline +
+        # tokens*growth must be >= the true footprint of the counted layers:
+        #   full layers: exact tokens*per-layer
+        #   sliding layers: min(tokens, window)*per-layer  (<= window*per-layer)
+        n, kv, hd, window, db = 24, 8, 64, 128, 2
+        layer_types = ["sliding_attention", "full_attention"] * (n // 2)
+        cfg = SimpleNamespace(
+            num_hidden_layers=n,
+            num_key_value_heads=kv,
+            head_dim=hd,
+            layer_types=layer_types,
+            sliding_window=window,
+        )
+        est = _est(cfg, num_layers=n, kv_heads=kv, head_dim=hd, dtype_bytes=db)
+        n_full = n // 2
+        n_sliding = n // 2
+        full_per_layer = 2 * kv * hd * db
+        for tokens in (1, 100, window, window + 1, 4096, 32768):
+            projected = est.fixed_baseline_bytes + tokens * est.per_token_growth_bytes
+            true_full = n_full * tokens * full_per_layer
+            true_sliding = n_sliding * min(tokens, window) * full_per_layer
+            assert projected >= true_full + true_sliding

--- a/tests/test_kv_estimation.py
+++ b/tests/test_kv_estimation.py
@@ -842,3 +842,68 @@ class TestRotatingCacheConstantsMatchInstalledMlxLm:
         # Restate the safety invariant explicitly: our KEEP must remain an upper
         # bound over the installed construction's keep.
         assert max(installed_keeps) <= _ROTATING_CACHE_KEEP
+
+    def test_no_shipped_rotating_cache_construction_exceeds_our_keep(self):
+        # ``make_prompt_cache`` (tested above) is the GENERIC construction path,
+        # but the engine ALSO builds ``RotatingKVCache`` DIRECTLY in vendored
+        # stacks (Gemma-4, DeepSeek-V4). If any shipped direct construction set
+        # ``keep`` ABOVE our ``_ROTATING_CACHE_KEEP`` bound, ``rotating_cache_slots``
+        # would under-reserve KV at admission (OOM risk). Statically scan EVERY
+        # ``RotatingKVCache(...)`` call in the package and assert its literal
+        # ``keep`` kwarg never exceeds our bound — the "validate the max keep
+        # across all constructors" guarantee, hermetic (AST parse, no imports run,
+        # no model load). Re-wrap constructions that pass ``keep=getattr(src,
+        # "keep", 0)`` inherit the source cache's keep, so bounding the source
+        # literals bounds them too; a non-constant ``keep`` is not asserted here.
+        import ast
+        import pathlib
+
+        import vllm_mlx
+
+        pkg_root = pathlib.Path(vllm_mlx.__file__).parent
+        literal_constructions: list[tuple[str, int, int]] = []
+        total_constructions = 0
+        for py in pkg_root.rglob("*.py"):
+            try:
+                tree = ast.parse(py.read_text(encoding="utf-8"), filename=str(py))
+            except (SyntaxError, UnicodeDecodeError):
+                continue
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Call):
+                    continue
+                func = node.func
+                if isinstance(func, ast.Attribute):
+                    name = func.attr
+                elif isinstance(func, ast.Name):
+                    name = func.id
+                else:
+                    continue
+                # EXACT match — ``BatchRotatingKVCache`` is a distinct batch-decode
+                # re-pack with its own signature and is intentionally excluded.
+                if name != "RotatingKVCache":
+                    continue
+                total_constructions += 1
+                for kw in node.keywords:
+                    if kw.arg == "keep" and isinstance(kw.value, ast.Constant):
+                        keep_val = kw.value.value
+                        if isinstance(keep_val, int) and not isinstance(keep_val, bool):
+                            literal_constructions.append(
+                                (py.name, node.lineno, keep_val)
+                            )
+        # The vendored Gemma-4 / DeepSeek-V4 stacks are in-tree, so the scan must
+        # find real constructions — a zero count means the scan silently missed
+        # them (e.g. a rename) and would give false assurance.
+        assert total_constructions > 0, (
+            "no RotatingKVCache(...) constructions found in vllm_mlx — the keep "
+            "drift scan matched nothing and cannot guard the bound"
+        )
+        assert literal_constructions, (
+            "no RotatingKVCache(keep=<literal>) constructions found to validate"
+        )
+        for fname, lineno, keep_val in literal_constructions:
+            assert keep_val <= _ROTATING_CACHE_KEEP, (
+                f"{fname}:{lineno} constructs RotatingKVCache(keep={keep_val}), which "
+                f"EXCEEDS _ROTATING_CACHE_KEEP={_ROTATING_CACHE_KEEP}; "
+                "rotating_cache_slots would under-reserve KV at admission (OOM "
+                "risk). Raise _ROTATING_CACHE_KEEP to bound every shipped keep."
+            )

--- a/tests/test_kv_estimation.py
+++ b/tests/test_kv_estimation.py
@@ -282,6 +282,45 @@ class TestKVSharing:
         assert est.sliding_slot_bytes == 1 * 2 * kv * hd * 2  # idx3 orphan charged
         assert est.sliding_window == window
 
+    def test_recurrent_layer_in_borrower_range_is_charged_not_zeroed(self):
+        # A recurrent (linear_attention) layer that sits in the last-N borrower
+        # positions and whose type matches an earlier recurrent producer must NOT
+        # be zeroed: KV sharing shares ATTENTION K/V, never recurrent state. It is
+        # charged its own fixed recurrent state (codex round 13 BLOCKING #1). The
+        # full borrower (idx2) still maps to a full producer and is zeroed.
+        n, kv, hd = 4, 2, 128
+        gdn = dict(
+            linear_num_value_heads=32,
+            linear_num_key_heads=16,
+            linear_key_head_dim=128,
+            linear_value_head_dim=128,
+            linear_conv_kernel_dim=4,
+        )
+        layer_types = [
+            "linear_attention",  # 0 producer (recurrent)
+            "full_attention",  # 1 producer (full)
+            "full_attention",  # 2 borrower → maps to full producer 1 → zeroed
+            "linear_attention",  # 3 borrower, recurrent → charged, NOT zeroed
+        ]
+        cfg = SimpleNamespace(
+            num_hidden_layers=n,
+            num_key_value_heads=kv,
+            head_dim=hd,
+            layer_types=layer_types,
+            num_kv_shared_layers=2,
+            **gdn,
+        )
+        est = _est(cfg, num_layers=n, kv_heads=kv, head_dim=hd)
+        key_dim = 16 * 128
+        value_dim = 32 * 128
+        state = 4 * (32 * 128 * 128 + (4 - 1) * (2 * key_dim + value_dim))
+        # idx0 producer + idx3 recurrent borrower (NOT zeroed) → both charged.
+        assert est.fixed_baseline_bytes == 2 * state
+        # idx1 full producer grows; idx2 full borrower is zeroed.
+        assert est.per_token_growth_bytes == 2 * kv * hd * 2
+        assert est.sliding_slot_bytes == 0
+        assert est.sliding_window == 0
+
     def test_zero_shared_is_not_a_hybrid_signal(self):
         cfg = SimpleNamespace(
             num_hidden_layers=32,
@@ -352,6 +391,49 @@ class TestSlidingWindow:
         assert est.per_token_growth_bytes == 0
         assert est.sliding_slot_bytes == 2 * n * kv * hd * 2
         assert est.sliding_window == window
+
+    def test_mixed_per_layer_windows_fold_into_full_growth(self):
+        # A per-layer window LIST with DIFFERING sizes cannot be bounded by one
+        # scalar window without under-counting the larger-window layers, so every
+        # sliding layer is charged as full per-token growth instead of the slot
+        # model (over-count-safe; codex round 13 BLOCKING #3). The estimate never
+        # picks the min/first of the differing windows.
+        n, kv, hd = 24, 8, 64
+        layer_types = ["sliding_attention", "full_attention"] * (n // 2)
+        cfg = SimpleNamespace(
+            num_hidden_layers=n,
+            num_key_value_heads=kv,
+            head_dim=hd,
+            layer_types=layer_types,
+            sliding_window=[128, 4096] * (n // 2),  # differing per-layer windows
+        )
+        est = _est(cfg, num_layers=n, kv_heads=kv, head_dim=hd)
+        # No single safe window → every layer grows unbounded (uniform result).
+        assert est.per_token_growth_bytes == _uniform(n, kv, hd, 2)
+        assert est.sliding_slot_bytes == 0
+        assert est.sliding_window == 0
+        assert est.fixed_baseline_bytes == 0
+
+    def test_uniform_per_layer_window_list_keeps_slot_model(self):
+        # A per-layer window LIST whose positive entries are ALL EQUAL is still a
+        # single uniform window → keep the accurate per-request slot model. Null
+        # entries (full layers carry no window) are ignored.
+        n, kv, hd, window = 24, 8, 64, 128
+        layer_types = ["sliding_attention", "full_attention"] * (n // 2)
+        cfg = SimpleNamespace(
+            num_hidden_layers=n,
+            num_key_value_heads=kv,
+            head_dim=hd,
+            layer_types=layer_types,
+            sliding_window=[window, None] * (n // 2),  # sliding=128, full=None
+        )
+        est = _est(cfg, num_layers=n, kv_heads=kv, head_dim=hd)
+        n_full = n // 2
+        n_sliding = n // 2
+        assert est.per_token_growth_bytes == 2 * n_full * kv * hd * 2
+        assert est.sliding_slot_bytes == 2 * n_sliding * kv * hd * 2
+        assert est.sliding_window == window
+        assert est.fixed_baseline_bytes == 0
 
 
 class TestRecurrent:
@@ -737,9 +819,9 @@ class TestRotatingCacheConstantsMatchInstalledMlxLm:
         assert not hasattr(fake_model, "make_cache")
         caches = cache_mod.make_prompt_cache(fake_model, max_kv_size=512)
         assert caches, "make_prompt_cache returned no layers"
-        assert all(
-            isinstance(c, cache_mod.RotatingKVCache) for c in caches
-        ), "make_prompt_cache(max_kv_size=...) did not build RotatingKVCache layers"
+        assert all(isinstance(c, cache_mod.RotatingKVCache) for c in caches), (
+            "make_prompt_cache(max_kv_size=...) did not build RotatingKVCache layers"
+        )
         installed_keeps = {c.keep for c in caches}
         assert installed_keeps == {_ROTATING_CACHE_KEEP}, (
             "mlx_lm make_prompt_cache builds rotating layers with keep="

--- a/tests/test_kv_estimation.py
+++ b/tests/test_kv_estimation.py
@@ -7,13 +7,14 @@ These pin the contract that the D-METAL-CAP admission gate depends on
 * Dense / unknown configs are BYTE-IDENTICAL to the uniform formula (no
   spurious change to a codex-hardened, over-estimate-safe admission path).
 * Recognized hybrids (sliding-window, KV-sharing, recurrent) get the smaller,
-  accurate per-token growth: full-attention layers grow unbounded, sliding
-  layers grow only up to a rotating window (a window-capped per-token term), and
-  recurrent layers reserve a token-independent fixed baseline.
-* The estimate never under-counts the counted layers (a sliding layer with no
-  readable window, or an unknown layer type, is charged as full-growth) and
-  never over-charges a short request (the sliding term is capped at
-  ``min(tokens, window)``, byte-identical to uniform below the window).
+  accurate per-token growth: only full-attention layers grow unbounded per
+  token; sliding-window layers reserve their WHOLE window buffer once per
+  sequence, and recurrent layers reserve a token-independent fixed state — both
+  in the fixed baseline.
+* The estimate is over-count-safe throughout — it never under-counts the counted
+  layers. A sliding layer with no readable window (or an unknown layer type) is
+  charged as full unbounded growth; a sliding layer WITH a window reserves the
+  whole window (an upper bound on a block-rounded rotating cache).
 
 Hermetic: pure config dataclasses (``SimpleNamespace``) and dicts — no model
 load, no network.
@@ -155,12 +156,10 @@ class TestKVSharing:
             sliding_window=128,
         )
         est = _est(cfg, num_layers=n, kv_heads=kv, head_dim=hd)
-        # Nothing zeroed: 3 full layers grow unbounded, 7 sliding layers -> the
-        # window-capped sliding term (all 10 layers counted, none borrowed).
+        # Nothing zeroed: 3 full layers grow unbounded, 7 sliding layers reserve
+        # their whole window buffer (all 10 layers counted, none borrowed).
         assert est.per_token_growth_bytes == 2 * 3 * kv * hd * 2
-        assert est.fixed_baseline_bytes == 0
-        assert est.sliding_per_token_bytes == 2 * 7 * kv * hd * 2
-        assert est.sliding_window_tokens == 128
+        assert est.fixed_baseline_bytes == 2 * 7 * 128 * kv * hd * 2
 
     def test_zero_shared_is_not_a_hybrid_signal(self):
         # num_kv_shared_layers=0 (dense Gemma-4 12B/26B/31B) → no reduction,
@@ -179,7 +178,7 @@ class TestKVSharing:
 class TestSlidingWindow:
     """GPT-OSS ~50% sliding-window layers are window-bounded, not per-token."""
 
-    def test_half_sliding_halves_unbounded_growth_and_caps_sliding(self):
+    def test_half_sliding_halves_growth_and_reserves_whole_window(self):
         n, kv, hd, window = 24, 8, 64, 128
         layer_types = ["sliding_attention", "full_attention"] * (n // 2)
         cfg = SimpleNamespace(
@@ -195,42 +194,14 @@ class TestSlidingWindow:
         # Only the full layers grow unbounded per token — halved vs uniform.
         assert est.per_token_growth_bytes == 2 * n_full * kv * hd * 2
         assert est.per_token_growth_bytes == _uniform(n, kv, hd, 2) // 2  # halved
-        # Sliding layers grow per token too, but only up to the window: the term
-        # is a per-token RATE (not a flat window buffer) so short requests are
-        # charged min(tokens, window) worth (codex round 6 BLOCKING).
-        assert est.fixed_baseline_bytes == 0
-        assert est.sliding_per_token_bytes == 2 * n_sliding * kv * hd * 2
-        assert est.sliding_window_tokens == window
+        # Sliding layers reserve their WHOLE window buffer once per sequence —
+        # the over-count-safe upper bound (codex round 9 BLOCKING).
+        assert est.fixed_baseline_bytes == 2 * n_sliding * window * kv * hd * 2
 
-    def test_short_request_sliding_matches_uniform_no_regression(self):
-        # A request SHORTER than the window must project exactly the historical
-        # uniform footprint for the sliding layers — never the whole window
-        # (which would over-charge and spuriously reject it). Emulate the
-        # scheduler projection: per_token_growth * tokens + sliding_per_token *
-        # min(tokens, window).
-        n, kv, hd, window = 24, 8, 64, 4096
-        layer_types = ["sliding_attention", "full_attention"] * (n // 2)
-        cfg = SimpleNamespace(
-            num_hidden_layers=n,
-            num_key_value_heads=kv,
-            head_dim=hd,
-            layer_types=layer_types,
-            sliding_window=window,
-        )
-        est = _est(cfg, num_layers=n, kv_heads=kv, head_dim=hd)
-        tokens = 100  # << window
-        projected = (
-            est.fixed_baseline_bytes
-            + est.per_token_growth_bytes * tokens
-            + est.sliding_per_token_bytes * min(tokens, est.sliding_window_tokens)
-        )
-        # Every layer charged exactly ``tokens`` worth == the old uniform figure.
-        assert projected == _uniform(n, kv, hd, 2) * tokens
-
-    def test_long_request_sliding_caps_below_uniform(self):
-        # A request LONGER than the window must project BELOW the uniform figure:
-        # the sliding layers are capped at ``window`` positions while the uniform
-        # estimate would keep multiplying by the full token count.
+    def test_projection_below_uniform_for_long_generation(self):
+        # The reduction: for a long generation the arch-aware projection (halved
+        # per-token growth + a bounded window baseline) stays well below the
+        # uniform per-token over-count that keeps multiplying by every token.
         n, kv, hd, window = 24, 8, 64, 128
         layer_types = ["sliding_attention", "full_attention"] * (n // 2)
         cfg = SimpleNamespace(
@@ -242,11 +213,7 @@ class TestSlidingWindow:
         )
         est = _est(cfg, num_layers=n, kv_heads=kv, head_dim=hd)
         tokens = 8192  # >> window
-        projected = (
-            est.fixed_baseline_bytes
-            + est.per_token_growth_bytes * tokens
-            + est.sliding_per_token_bytes * min(tokens, est.sliding_window_tokens)
-        )
+        projected = est.fixed_baseline_bytes + est.per_token_growth_bytes * tokens
         assert projected < _uniform(n, kv, hd, 2) * tokens
 
     def test_sliding_without_window_charged_as_full_growth(self):
@@ -463,10 +430,8 @@ class TestHybridDimsAndNesting:
         # Producers = first 15 layers. Full at indices 4, 9, 14 → 3 full,
         # 12 sliding. Borrowers (last 20) contribute nothing.
         assert est.per_token_growth_bytes == 2 * 3 * global_kv * global_hd * 2
-        assert est.fixed_baseline_bytes == 0
-        # Sliding layers use local dims; the term is window-capped, not flat.
-        assert est.sliding_per_token_bytes == 12 * 2 * kv * hd * 2
-        assert est.sliding_window_tokens == window
+        # Sliding layers use local dims; whole window reserved in the baseline.
+        assert est.fixed_baseline_bytes == 12 * 2 * window * kv * hd * 2
 
     def test_layer_structure_read_from_text_config(self):
         # Multimodal configs nest the language layer structure under
@@ -483,9 +448,7 @@ class TestHybridDimsAndNesting:
         )
         est = _est(cfg, num_layers=n, kv_heads=kv, head_dim=hd)
         assert est.per_token_growth_bytes == 2 * (n // 2) * kv * hd * 2
-        assert est.fixed_baseline_bytes == 0
-        assert est.sliding_per_token_bytes == 2 * (n // 2) * kv * hd * 2
-        assert est.sliding_window_tokens == window
+        assert est.fixed_baseline_bytes == 2 * (n // 2) * window * kv * hd * 2
 
     def test_dict_config_supported(self):
         # The offline hybrid probe reads parsed config.json dicts.
@@ -500,9 +463,7 @@ class TestHybridDimsAndNesting:
         }
         est = _est(cfg, num_layers=n, kv_heads=kv, head_dim=hd)
         assert est.per_token_growth_bytes == 2 * (n // 2) * kv * hd * 2
-        assert est.fixed_baseline_bytes == 0
-        assert est.sliding_per_token_bytes == 2 * (n // 2) * kv * hd * 2
-        assert est.sliding_window_tokens == window
+        assert est.fixed_baseline_bytes == 2 * (n // 2) * window * kv * hd * 2
 
     def test_unknown_layer_type_charged_as_full_growth(self):
         # An unrecognized attention-type string must never under-count → full.
@@ -522,16 +483,13 @@ class TestNeverUnderCounts:
     """The projected footprint is always >= the true counted-layer footprint."""
 
     def test_projection_upper_bounds_true_footprint(self):
-        # GPT-OSS-like hybrid. This checks the ESTIMATOR's steady-state (decode)
-        # composition of its returned fields:
-        #   fixed_baseline + tokens*growth + sliding_per_token*min(tokens, window)
-        # against the true footprint of the counted layers:
+        # GPT-OSS-like hybrid. The scheduler projection
+        #   fixed_baseline + tokens * per_token_growth
+        # must be >= the true footprint of the counted layers for ANY token
+        # count, since that is the D-METAL-CAP never-under-count guarantee:
         #   full layers: exact tokens*per-layer
-        #   sliding layers: min(tokens, window)*per-layer  (<= window*per-layer)
-        # It must be TIGHT (equal), never over-charging a short request (codex
-        # round 6 BLOCKING). (The scheduler additionally floors the sliding term
-        # at the full prompt for the transient prefill peak — codex round 7 #3 —
-        # which only ever RAISES the charge; covered in the scheduler tests.)
+        #   sliding layers: min(tokens, window)*per-layer  (<= window*per-layer,
+        #                   the whole-window buffer reserved in the baseline)
         n, kv, hd, window, db = 24, 8, 64, 128, 2
         layer_types = ["sliding_attention", "full_attention"] * (n // 2)
         cfg = SimpleNamespace(
@@ -546,15 +504,11 @@ class TestNeverUnderCounts:
         n_sliding = n // 2
         full_per_layer = 2 * kv * hd * db
         for tokens in (1, 100, window, window + 1, 4096, 32768):
-            projected = (
-                est.fixed_baseline_bytes
-                + tokens * est.per_token_growth_bytes
-                + est.sliding_per_token_bytes * min(tokens, est.sliding_window_tokens)
-            )
+            projected = est.fixed_baseline_bytes + tokens * est.per_token_growth_bytes
             true_full = n_full * tokens * full_per_layer
             true_sliding = n_sliding * min(tokens, window) * full_per_layer
-            # Tight: the estimator charges each layer its exact peak occupancy.
-            assert projected == true_full + true_sliding
+            # Over-count-safe: the whole-window baseline is >= any decode/prefill
+            # peak of the sliding layers, so the projection never under-counts.
             assert projected >= true_full + true_sliding
 
     def test_full_layer_growth_never_below_uniform_base(self):
@@ -578,23 +532,24 @@ class TestNeverUnderCounts:
     def test_sliding_rate_never_below_uniform_base(self):
         # Symmetric to the full-layer clamp: a nested/malformed config whose
         # local (sliding) dims read SMALLER than the base dims the scheduler used
-        # must not shrink the sliding per-token rate below the uniform per-layer
+        # must not shrink the sliding per-layer rate below the uniform per-layer
         # charge (codex round 7 BLOCKING #2). Here the struct exposes a tiny
-        # local head_dim; the base head_dim passed by the caller is larger.
-        n, kv, hd, db = 8, 8, 128, 2
+        # local head_dim; the base head_dim passed by the caller is larger, so
+        # the whole-window baseline is computed at the clamped (base) rate.
+        n, kv, hd, db, window = 8, 8, 128, 2, 256
         layer_types = ["sliding_attention"] * n
         cfg = SimpleNamespace(
             num_hidden_layers=n,
             num_key_value_heads=kv,
             head_dim=8,  # << base head_dim (128) — malformed / non-authoritative
             layer_types=layer_types,
-            sliding_window=256,
+            sliding_window=window,
         )
         est = _est(cfg, num_layers=n, kv_heads=kv, head_dim=hd, dtype_bytes=db)
-        # Clamped to the uniform base per-layer rate, not the tiny local dims.
-        assert est.sliding_per_token_bytes == n * 2 * kv * hd * db
+        # Whole-window baseline at the clamped base per-layer rate, not the tiny
+        # local dims (which would under-count).
+        assert est.fixed_baseline_bytes == n * window * 2 * kv * hd * db
         assert est.per_token_growth_bytes == 0
-        assert est.sliding_window_tokens == 256
 
     def test_projection_covers_recurrent_fixed_state(self):
         # A GatedDeltaNet hybrid: the projection must reserve the recurrent

--- a/tests/test_kv_estimation.py
+++ b/tests/test_kv_estimation.py
@@ -8,13 +8,15 @@ These pin the contract that the D-METAL-CAP admission gate depends on
   spurious change to a codex-hardened, over-estimate-safe admission path).
 * Recognized hybrids (sliding-window, KV-sharing, recurrent) get the smaller,
   accurate per-token growth: only full-attention layers grow unbounded per
-  token; sliding-window layers reserve their WHOLE window buffer once per
+  token; sliding-window layers reserve their WHOLE rotating-cache buffer once per
   sequence, and recurrent layers reserve a token-independent fixed state — both
   in the fixed baseline.
 * The estimate is over-count-safe throughout — it never under-counts the counted
   layers. A sliding layer with no readable window (or an unknown layer type) is
   charged as full unbounded growth; a sliding layer WITH a window reserves the
-  whole window (an upper bound on a block-rounded rotating cache).
+  step-rounded, sink-inclusive rotating-cache capacity
+  (``ceil((window + keep) / step) * step`` slots), an upper bound on the real
+  ``RotatingKVCache`` allocation.
 
 Hermetic: pure config dataclasses (``SimpleNamespace``) and dicts — no model
 load, no network.
@@ -31,6 +33,20 @@ from vllm_mlx.kv_estimation import KVFootprintEstimate, estimate_kv_footprint
 
 def _uniform(num_layers: int, kv_heads: int, head_dim: int, dtype_bytes: int) -> int:
     return 2 * num_layers * kv_heads * head_dim * dtype_bytes
+
+
+# Rotating-cache capacity granularity — mirrors kv_estimation's
+# ``_ROTATING_CACHE_STEP`` / ``_ROTATING_CACHE_KEEP`` (sourced from mlx_lm's
+# ``RotatingKVCache.step = 256`` and ``make_prompt_cache(... keep=4)``). A
+# sliding-window layer reserves ``ceil((window + keep) / step) * step`` slots —
+# the step-rounded, sink-inclusive capacity — NOT the raw window.
+_STEP = 256
+_KEEP = 4
+
+
+def _slots(window: int) -> int:
+    """Step-rounded, sink-inclusive rotating-cache capacity for ``window``."""
+    return ((window + _KEEP + _STEP - 1) // _STEP) * _STEP
 
 
 def _est(cfg, *, num_layers, kv_heads, head_dim, dtype_bytes=2) -> KVFootprintEstimate:
@@ -157,9 +173,9 @@ class TestKVSharing:
         )
         est = _est(cfg, num_layers=n, kv_heads=kv, head_dim=hd)
         # Nothing zeroed: 3 full layers grow unbounded, 7 sliding layers reserve
-        # their whole window buffer (all 10 layers counted, none borrowed).
+        # their whole rotating-cache buffer (all 10 layers counted, none borrowed).
         assert est.per_token_growth_bytes == 2 * 3 * kv * hd * 2
-        assert est.fixed_baseline_bytes == 2 * 7 * 128 * kv * hd * 2
+        assert est.fixed_baseline_bytes == 2 * 7 * _slots(128) * kv * hd * 2
 
     def test_zero_shared_is_not_a_hybrid_signal(self):
         # num_kv_shared_layers=0 (dense Gemma-4 12B/26B/31B) → no reduction,
@@ -194,9 +210,10 @@ class TestSlidingWindow:
         # Only the full layers grow unbounded per token — halved vs uniform.
         assert est.per_token_growth_bytes == 2 * n_full * kv * hd * 2
         assert est.per_token_growth_bytes == _uniform(n, kv, hd, 2) // 2  # halved
-        # Sliding layers reserve their WHOLE window buffer once per sequence —
-        # the over-count-safe upper bound (codex round 9 BLOCKING).
-        assert est.fixed_baseline_bytes == 2 * n_sliding * window * kv * hd * 2
+        # Sliding layers reserve their WHOLE rotating-cache buffer once per
+        # sequence — the step-rounded, sink-inclusive capacity, an over-count-safe
+        # upper bound on the real RotatingKVCache (codex round 10 BLOCKING).
+        assert est.fixed_baseline_bytes == 2 * n_sliding * _slots(window) * kv * hd * 2
 
     def test_projection_below_uniform_for_long_generation(self):
         # The reduction: for a long generation the arch-aware projection (halved
@@ -231,6 +248,55 @@ class TestSlidingWindow:
         est = _est(cfg, num_layers=n, kv_heads=kv, head_dim=hd)
         assert est.per_token_growth_bytes == _uniform(n, kv, hd, 2)
         assert est.fixed_baseline_bytes == 0
+
+    def test_non_step_aligned_window_rounds_up_to_capacity(self):
+        # The real RotatingKVCache does NOT allocate exactly ``window`` slots: it
+        # grows the buffer in step=256 increments and retains keep=4 sinks above
+        # the window, so a window of 500 charges ceil((500+4)/256)*256 = 512
+        # slots — STRICTLY MORE than the raw 500 (codex round 10 BLOCKING: the
+        # whole-window figure still under-counts the block-rounded, sink-retaining
+        # allocation).
+        n, kv, hd, window = 8, 4, 64, 500
+        layer_types = ["sliding_attention"] * n
+        cfg = SimpleNamespace(
+            num_hidden_layers=n,
+            num_key_value_heads=kv,
+            head_dim=hd,
+            layer_types=layer_types,
+            sliding_window=window,
+        )
+        est = _est(cfg, num_layers=n, kv_heads=kv, head_dim=hd)
+        slots = _slots(window)
+        assert slots == 512
+        # Capacity property: at least window+keep, and a whole multiple of step.
+        assert slots >= window + _KEEP
+        assert slots % _STEP == 0
+        # Charged at the rounded-up capacity, strictly greater than the raw window.
+        assert est.per_token_growth_bytes == 0
+        assert est.fixed_baseline_bytes == 2 * n * slots * kv * hd * 2
+        assert est.fixed_baseline_bytes > 2 * n * window * kv * hd * 2
+
+    def test_step_aligned_multi_block_window_rounds_to_768(self):
+        # A window whose (window + keep) crosses into the THIRD step block rounds
+        # up to 768 slots: ceil((513 + 4) / 256) * 256 = ceil(517/256)*256 =
+        # 3*256 = 768. Confirms the round-up spans multiple step blocks, not just
+        # a single-block nudge.
+        n, kv, hd, window = 8, 4, 64, 513
+        layer_types = ["sliding_attention"] * n
+        cfg = SimpleNamespace(
+            num_hidden_layers=n,
+            num_key_value_heads=kv,
+            head_dim=hd,
+            layer_types=layer_types,
+            sliding_window=window,
+        )
+        est = _est(cfg, num_layers=n, kv_heads=kv, head_dim=hd)
+        slots = _slots(window)
+        assert slots == 768
+        assert slots >= window + _KEEP
+        assert slots % _STEP == 0
+        assert est.fixed_baseline_bytes == 2 * n * slots * kv * hd * 2
+        assert est.fixed_baseline_bytes > 2 * n * window * kv * hd * 2
 
 
 class TestRecurrent:
@@ -430,8 +496,8 @@ class TestHybridDimsAndNesting:
         # Producers = first 15 layers. Full at indices 4, 9, 14 → 3 full,
         # 12 sliding. Borrowers (last 20) contribute nothing.
         assert est.per_token_growth_bytes == 2 * 3 * global_kv * global_hd * 2
-        # Sliding layers use local dims; whole window reserved in the baseline.
-        assert est.fixed_baseline_bytes == 12 * 2 * window * kv * hd * 2
+        # Sliding layers use local dims; whole rotating-cache capacity reserved.
+        assert est.fixed_baseline_bytes == 12 * 2 * _slots(window) * kv * hd * 2
 
     def test_layer_structure_read_from_text_config(self):
         # Multimodal configs nest the language layer structure under
@@ -448,7 +514,7 @@ class TestHybridDimsAndNesting:
         )
         est = _est(cfg, num_layers=n, kv_heads=kv, head_dim=hd)
         assert est.per_token_growth_bytes == 2 * (n // 2) * kv * hd * 2
-        assert est.fixed_baseline_bytes == 2 * (n // 2) * window * kv * hd * 2
+        assert est.fixed_baseline_bytes == 2 * (n // 2) * _slots(window) * kv * hd * 2
 
     def test_dict_config_supported(self):
         # The offline hybrid probe reads parsed config.json dicts.
@@ -463,7 +529,7 @@ class TestHybridDimsAndNesting:
         }
         est = _est(cfg, num_layers=n, kv_heads=kv, head_dim=hd)
         assert est.per_token_growth_bytes == 2 * (n // 2) * kv * hd * 2
-        assert est.fixed_baseline_bytes == 2 * (n // 2) * window * kv * hd * 2
+        assert est.fixed_baseline_bytes == 2 * (n // 2) * _slots(window) * kv * hd * 2
 
     def test_unknown_layer_type_charged_as_full_growth(self):
         # An unrecognized attention-type string must never under-count → full.
@@ -488,8 +554,9 @@ class TestNeverUnderCounts:
         # must be >= the true footprint of the counted layers for ANY token
         # count, since that is the D-METAL-CAP never-under-count guarantee:
         #   full layers: exact tokens*per-layer
-        #   sliding layers: min(tokens, window)*per-layer  (<= window*per-layer,
-        #                   the whole-window buffer reserved in the baseline)
+        #   sliding layers: min(tokens, window)*per-layer  (<= slots*per-layer,
+        #                   the step-rounded rotating-cache capacity reserved in
+        #                   the baseline, where slots >= window)
         n, kv, hd, window, db = 24, 8, 64, 128, 2
         layer_types = ["sliding_attention", "full_attention"] * (n // 2)
         cfg = SimpleNamespace(
@@ -546,9 +613,9 @@ class TestNeverUnderCounts:
             sliding_window=window,
         )
         est = _est(cfg, num_layers=n, kv_heads=kv, head_dim=hd, dtype_bytes=db)
-        # Whole-window baseline at the clamped base per-layer rate, not the tiny
-        # local dims (which would under-count).
-        assert est.fixed_baseline_bytes == n * window * 2 * kv * hd * db
+        # Whole-capacity baseline at the clamped base per-layer rate, not the tiny
+        # local dims (which would under-count). Capacity = step-rounded slots.
+        assert est.fixed_baseline_bytes == n * _slots(window) * 2 * kv * hd * db
         assert est.per_token_growth_bytes == 0
 
     def test_projection_covers_recurrent_fixed_state(self):

--- a/tests/test_kv_estimation.py
+++ b/tests/test_kv_estimation.py
@@ -292,6 +292,47 @@ class TestRecurrent:
         assert est.per_token_growth_bytes == 2 * 1 * kv * hd * 2
         assert est.fixed_baseline_bytes == (n - 1) * state
 
+    def test_gateddeltanet_missing_conv_kernel_falls_back(self):
+        # GatedDeltaNet head fields present but linear_conv_kernel_dim ABSENT →
+        # cannot size the conv buffer → the whole layer falls back to full
+        # growth rather than silently omitting the conv state (codex round 3
+        # BLOCKING #1).
+        n, kv, hd = 8, 4, 64
+        layer_types = ["linear_attention"] * (n - 1) + ["full_attention"]
+        cfg = SimpleNamespace(
+            num_hidden_layers=n,
+            num_key_value_heads=kv,
+            head_dim=hd,
+            layer_types=layer_types,
+            linear_num_value_heads=32,
+            linear_num_key_heads=16,
+            linear_key_head_dim=128,
+            linear_value_head_dim=128,
+            # linear_conv_kernel_dim intentionally absent
+        )
+        est = _est(cfg, num_layers=n, kv_heads=kv, head_dim=hd)
+        assert est.per_token_growth_bytes == _uniform(n, kv, hd, 2)
+        assert est.fixed_baseline_bytes == 0
+
+    def test_mamba_missing_conv_kernel_falls_back(self):
+        # Mamba SSM fields present but d_conv/conv_kernel_size ABSENT → fall back
+        # to full growth (codex round 3 BLOCKING #2).
+        n, kv, hd = 8, 4, 64
+        layer_types = ["mamba"] * (n - 1) + ["full_attention"]
+        cfg = SimpleNamespace(
+            num_hidden_layers=n,
+            num_key_value_heads=kv,
+            head_dim=hd,
+            layer_types=layer_types,
+            mamba_d_state=128,
+            mamba_n_heads=24,
+            mamba_d_head=64,
+            # mamba_d_conv / conv_kernel_size intentionally absent
+        )
+        est = _est(cfg, num_layers=n, kv_heads=kv, head_dim=hd)
+        assert est.per_token_growth_bytes == _uniform(n, kv, hd, 2)
+        assert est.fixed_baseline_bytes == 0
+
     def test_full_attention_name_containing_linear_is_not_recurrent(self):
         # Exact-match allowlist (codex round 1 BLOCKING #4): an unfamiliar
         # full-attention type that merely CONTAINS "linear"/"gated"/"local" must

--- a/tests/test_kv_estimation.py
+++ b/tests/test_kv_estimation.py
@@ -348,6 +348,28 @@ class TestRecurrent:
         assert est.per_token_growth_bytes == _uniform(n, kv, hd, 2)
         assert est.fixed_baseline_bytes == 0
 
+    def test_generic_recurrent_family_not_mis_sized_as_mamba(self):
+        # An RWKV (or other generic recurrent) layer that incidentally exposes
+        # Mamba-ish generic fields must NOT be sized as Mamba — its exact state
+        # layout is not implemented, so it falls back to full growth (codex
+        # round 4 BLOCKING #2).
+        n, kv, hd = 8, 4, 64
+        layer_types = ["rwkv"] * (n - 1) + ["full_attention"]
+        cfg = SimpleNamespace(
+            num_hidden_layers=n,
+            num_key_value_heads=kv,
+            head_dim=hd,
+            layer_types=layer_types,
+            # generic fields that the Mamba branch would otherwise consume:
+            state_size=128,
+            intermediate_size=1536,
+            conv_kernel_size=4,
+        )
+        est = _est(cfg, num_layers=n, kv_heads=kv, head_dim=hd)
+        # No baseline reserved (not sized as Mamba); all layers charged full.
+        assert est.per_token_growth_bytes == _uniform(n, kv, hd, 2)
+        assert est.fixed_baseline_bytes == 0
+
 
 class TestHybridDimsAndNesting:
     def test_global_head_dim_used_for_full_layers(self):
@@ -444,6 +466,24 @@ class TestNeverUnderCounts:
             true_full = n_full * tokens * full_per_layer
             true_sliding = n_sliding * min(tokens, window) * full_per_layer
             assert projected >= true_full + true_sliding
+
+    def test_full_layer_growth_never_below_uniform_base(self):
+        # A pathological config where global_head_dim / num_global_key_value_heads
+        # are SMALLER than the base dims must not shrink full-layer per-token
+        # growth below the uniform base-layer charge (codex round 4 BLOCKING #1).
+        n, kv, hd, db = 8, 8, 128, 2
+        cfg = SimpleNamespace(
+            num_hidden_layers=n,
+            num_key_value_heads=kv,
+            head_dim=hd,
+            layer_types=["full_attention"] * n,
+            global_head_dim=16,  # << base head_dim
+            num_global_key_value_heads=1,  # << base kv heads
+        )
+        est = _est(cfg, num_layers=n, kv_heads=kv, head_dim=hd, dtype_bytes=db)
+        # Clamped to the uniform base-layer size, not the tiny global dims.
+        assert est.per_token_growth_bytes == _uniform(n, kv, hd, db)
+        assert est.fixed_baseline_bytes == 0
 
     def test_projection_covers_recurrent_fixed_state(self):
         # A GatedDeltaNet hybrid: the projection must reserve the recurrent

--- a/tests/test_kv_estimation.py
+++ b/tests/test_kv_estimation.py
@@ -392,12 +392,13 @@ class TestSlidingWindow:
         assert est.sliding_slot_bytes == 2 * n * kv * hd * 2
         assert est.sliding_window == window
 
-    def test_mixed_per_layer_windows_fold_into_full_growth(self):
-        # A per-layer window LIST with DIFFERING sizes cannot be bounded by one
-        # scalar window without under-counting the larger-window layers, so every
-        # sliding layer is charged as full per-token growth instead of the slot
-        # model (over-count-safe; codex round 13 BLOCKING #3). The estimate never
-        # picks the min/first of the differing windows.
+    def test_per_layer_window_list_folds_into_full_growth(self):
+        # The per-request slot model charges every sliding layer with ONE window,
+        # so it is only sound for a single positive SCALAR window. A per-layer
+        # window LIST is never collapsed to one scalar (scalar-only policy) — it
+        # folds every sliding layer into full per-token growth (over-count-safe;
+        # codex round 13 BLOCKING #3). Differing entries here would obviously
+        # under-count if reduced to the min/first.
         n, kv, hd = 24, 8, 64
         layer_types = ["sliding_attention", "full_attention"] * (n // 2)
         cfg = SimpleNamespace(
@@ -408,31 +409,38 @@ class TestSlidingWindow:
             sliding_window=[128, 4096] * (n // 2),  # differing per-layer windows
         )
         est = _est(cfg, num_layers=n, kv_heads=kv, head_dim=hd)
-        # No single safe window → every layer grows unbounded (uniform result).
+        # A list window → every layer grows unbounded (uniform result).
         assert est.per_token_growth_bytes == _uniform(n, kv, hd, 2)
         assert est.sliding_slot_bytes == 0
         assert est.sliding_window == 0
         assert est.fixed_baseline_bytes == 0
 
-    def test_uniform_per_layer_window_list_keeps_slot_model(self):
-        # A per-layer window LIST whose positive entries are ALL EQUAL is still a
-        # single uniform window → keep the accurate per-request slot model. Null
-        # entries (full layers carry no window) are ignored.
-        n, kv, hd, window = 24, 8, 64, 128
-        layer_types = ["sliding_attention", "full_attention"] * (n // 2)
+    def test_partial_window_list_does_not_borrow_for_unknown_sliding_layer(self):
+        # codex counterexample: a MISALIGNED per-layer window list where one
+        # sliding layer has a positive window and ANOTHER sliding layer's entry is
+        # null (unknown). Borrowing the known 128 for the unknown-window sliding
+        # layer would under-reserve if its real window were larger, so ANY list
+        # shape — even one with a single distinct positive value — folds every
+        # sliding layer into full per-token growth. The estimate must NOT expose a
+        # slot term or a window here.
+        n, kv, hd = 4, 8, 64
+        layer_types = [
+            "sliding_attention",  # 0 — window 128
+            "sliding_attention",  # 1 — window UNKNOWN (null)
+            "full_attention",
+            "full_attention",
+        ]
         cfg = SimpleNamespace(
             num_hidden_layers=n,
             num_key_value_heads=kv,
             head_dim=hd,
             layer_types=layer_types,
-            sliding_window=[window, None] * (n // 2),  # sliding=128, full=None
+            sliding_window=[128, None, None, None],  # only one distinct positive
         )
         est = _est(cfg, num_layers=n, kv_heads=kv, head_dim=hd)
-        n_full = n // 2
-        n_sliding = n // 2
-        assert est.per_token_growth_bytes == 2 * n_full * kv * hd * 2
-        assert est.sliding_slot_bytes == 2 * n_sliding * kv * hd * 2
-        assert est.sliding_window == window
+        assert est.per_token_growth_bytes == _uniform(n, kv, hd, 2)  # all full growth
+        assert est.sliding_slot_bytes == 0
+        assert est.sliding_window == 0
         assert est.fixed_baseline_bytes == 0
 
 

--- a/tests/test_kv_estimation.py
+++ b/tests/test_kv_estimation.py
@@ -2,21 +2,25 @@
 """Unit tests for the architecture-aware KV footprint estimator.
 
 These pin the contract that the D-METAL-CAP admission gate depends on
-(``scheduler._resolve_kv_bytes_per_token`` → ``estimate_kv_footprint``):
+(``scheduler._resolve_kv_bytes_per_token`` → ``estimate_kv_footprint`` /
+``rotating_cache_slots``):
 
-* Dense / unknown configs are BYTE-IDENTICAL to the uniform formula (no
-  spurious change to a codex-hardened, over-estimate-safe admission path).
-* Recognized hybrids (sliding-window, KV-sharing, recurrent) get the smaller,
-  accurate per-token growth: only full-attention layers grow unbounded per
-  token; sliding-window layers reserve their WHOLE rotating-cache buffer once per
-  sequence, and recurrent layers reserve a token-independent fixed state — both
-  in the fixed baseline.
+* Dense / unknown configs are BYTE-IDENTICAL to the uniform formula: the
+  estimate is ``(uniform, 0, 0, 0)`` — no baseline, no sliding term.
+* Recognized hybrids get the accurate per-request footprint split across three
+  terms: only full-attention layers grow unbounded per token
+  (``per_token_growth_bytes``); sliding-window layers are a request-dependent
+  slot term (``sliding_slot_bytes`` × ``rotating_cache_slots(window, T)``);
+  recurrent layers reserve a token-independent fixed state
+  (``fixed_baseline_bytes``).
 * The estimate is over-count-safe throughout — it never under-counts the counted
   layers. A sliding layer with no readable window (or an unknown layer type) is
-  charged as full unbounded growth; a sliding layer WITH a window reserves the
-  step-rounded, sink-inclusive rotating-cache capacity
-  (``ceil((window + keep) / step) * step`` slots), an upper bound on the real
-  ``RotatingKVCache`` allocation.
+  folded into full unbounded growth; a sliding layer WITH a window contributes a
+  slot term whose per-request slot count is an upper bound on the real
+  ``RotatingKVCache`` allocation at every token count, capped at the full window.
+* KV-sharing zeroes a borrower ONLY when the exact per-index producer map
+  (mirrored from ``models/gemma4_vendored/language.py``) gives it a same-type
+  producer below the split; an orphan borrower is charged, never zeroed.
 
 Hermetic: pure config dataclasses (``SimpleNamespace``) and dicts — no model
 load, no network.
@@ -28,25 +32,30 @@ from types import SimpleNamespace
 
 import pytest
 
-from vllm_mlx.kv_estimation import KVFootprintEstimate, estimate_kv_footprint
+from vllm_mlx.kv_estimation import (
+    KVFootprintEstimate,
+    estimate_kv_footprint,
+    rotating_cache_slots,
+)
 
-
-def _uniform(num_layers: int, kv_heads: int, head_dim: int, dtype_bytes: int) -> int:
-    return 2 * num_layers * kv_heads * head_dim * dtype_bytes
-
-
-# Rotating-cache capacity granularity — mirrors kv_estimation's
-# ``_ROTATING_CACHE_STEP`` / ``_ROTATING_CACHE_KEEP`` (sourced from mlx_lm's
-# ``RotatingKVCache.step = 256`` and ``make_prompt_cache(... keep=4)``). A
-# sliding-window layer reserves ``ceil((window + keep) / step) * step`` slots —
-# the step-rounded, sink-inclusive capacity — NOT the raw window.
+# Rotating-cache granularity — mirrors kv_estimation's ``_ROTATING_CACHE_STEP`` /
+# ``_ROTATING_CACHE_KEEP`` (sourced from mlx_lm's ``RotatingKVCache.step = 256``;
+# ``KEEP = 4`` is the largest ``keep`` any shipped construction uses, so the slot
+# count is an upper bound for every path).
 _STEP = 256
 _KEEP = 4
 
 
-def _slots(window: int) -> int:
-    """Step-rounded, sink-inclusive rotating-cache capacity for ``window``."""
-    return ((window + _KEEP + _STEP - 1) // _STEP) * _STEP
+def _slots(window: int, tokens: int) -> int:
+    """Reference re-implementation of ``rotating_cache_slots`` for assertions."""
+    if window <= 0 or tokens <= 0:
+        return 0
+    effective = min(tokens, window) + _KEEP
+    return ((effective + _STEP - 1) // _STEP) * _STEP
+
+
+def _uniform(num_layers: int, kv_heads: int, head_dim: int, dtype_bytes: int) -> int:
+    return 2 * num_layers * kv_heads * head_dim * dtype_bytes
 
 
 def _est(cfg, *, num_layers, kv_heads, head_dim, dtype_bytes=2) -> KVFootprintEstimate:
@@ -60,29 +69,85 @@ def _est(cfg, *, num_layers, kv_heads, head_dim, dtype_bytes=2) -> KVFootprintEs
     )
 
 
+class TestRotatingCacheSlots:
+    """The per-request slot count: an over-count-safe, sublinear upper bound."""
+
+    def test_reference_agreement(self):
+        for window, tokens in [(4096, 1), (128, 10_000), (500, 9_999), (256, 300)]:
+            assert rotating_cache_slots(window, tokens) == _slots(window, tokens)
+
+    def test_zero_window_or_tokens_is_zero(self):
+        assert rotating_cache_slots(0, 100) == 0
+        assert rotating_cache_slots(128, 0) == 0
+        assert rotating_cache_slots(0, 0) == 0
+
+    def test_short_request_far_below_full_window(self):
+        # T=1 against a 4096 window rounds up (1 + keep) to ONE step block, not
+        # the whole window — the codex-flagged over-count of short requests.
+        assert rotating_cache_slots(4096, 1) == 256
+        full = rotating_cache_slots(4096, 4096)
+        assert full > 256  # short request charged far less than the full window
+
+    def test_caps_at_full_window_for_long_request(self):
+        window = 128
+        full = rotating_cache_slots(window, window)  # ceil((128+4)/256)*256 = 256
+        assert full == 256
+        for tokens in (window, window + 1, 10_000, 1_000_000):
+            assert rotating_cache_slots(window, tokens) == full  # flat past window
+
+    def test_monotonic_non_decreasing_in_tokens(self):
+        window = 4096
+        prev = -1
+        for tokens in range(1, 6000, 37):
+            slots = rotating_cache_slots(window, tokens)
+            assert slots >= prev
+            prev = slots
+
+    def test_is_upper_bound_of_real_buffer(self):
+        # The real RotatingKVCache buffer after t tokens is
+        # ``min(ceil(t/step)*step, max_size)`` (decode path). Our slot count adds
+        # ``keep`` before rounding, so it is >= that real buffer for every t.
+        window = 1000
+        for tokens in (1, 100, 256, 257, 999, 1000, 1001, 5000):
+            real = min(((tokens + _STEP - 1) // _STEP) * _STEP, window)
+            assert rotating_cache_slots(window, tokens) >= real
+
+    def test_step_aligned_multiples(self):
+        # ceil((min(T,window)+keep)/step)*step is always a multiple of step and
+        # >= min(T,window)+keep.
+        for window, tokens in [(500, 5000), (513, 5000), (128, 50), (256, 256)]:
+            slots = rotating_cache_slots(window, tokens)
+            assert slots % _STEP == 0
+            assert slots >= min(tokens, window) + _KEEP
+
+
 class TestDenseFallback:
     """Anything not a recognized hybrid stays byte-identical to uniform."""
 
-    def test_dense_config_is_byte_identical(self):
-        # No layer_types, no sliding_window, no num_kv_shared_layers.
-        cfg = SimpleNamespace(num_hidden_layers=32, num_key_value_heads=8, head_dim=128)
-        est = _est(cfg, num_layers=32, kv_heads=8, head_dim=128)
-        assert est.per_token_growth_bytes == _uniform(32, 8, 128, 2)
+    def _assert_byte_identical(self, est, num_layers, kv, hd, dtype_bytes=2):
+        assert est.per_token_growth_bytes == _uniform(num_layers, kv, hd, dtype_bytes)
         assert est.fixed_baseline_bytes == 0
+        assert est.sliding_slot_bytes == 0
+        assert est.sliding_window == 0
+
+    def test_dense_config_is_byte_identical(self):
+        cfg = SimpleNamespace(num_hidden_layers=32, num_key_value_heads=8, head_dim=128)
+        self._assert_byte_identical(
+            _est(cfg, num_layers=32, kv_heads=8, head_dim=128), 32, 8, 128
+        )
 
     def test_sliding_window_without_layer_types_falls_back(self):
         # Mistral-like: a global ``sliding_window`` field but NO per-layer
-        # ``layer_types``. We must NOT treat every layer as sliding (that would
-        # zero the per-token growth) — ambiguous → uniform.
+        # ``layer_types``. Ambiguous → uniform, no sliding term.
         cfg = SimpleNamespace(
             num_hidden_layers=32,
             num_key_value_heads=8,
             head_dim=128,
             sliding_window=4096,
         )
-        est = _est(cfg, num_layers=32, kv_heads=8, head_dim=128)
-        assert est.per_token_growth_bytes == _uniform(32, 8, 128, 2)
-        assert est.fixed_baseline_bytes == 0
+        self._assert_byte_identical(
+            _est(cfg, num_layers=32, kv_heads=8, head_dim=128), 32, 8, 128
+        )
 
     def test_wrong_length_layer_types_falls_back(self):
         cfg = SimpleNamespace(
@@ -91,9 +156,9 @@ class TestDenseFallback:
             head_dim=128,
             layer_types=["full_attention"] * 30,  # len != num_layers
         )
-        est = _est(cfg, num_layers=32, kv_heads=8, head_dim=128)
-        assert est.per_token_growth_bytes == _uniform(32, 8, 128, 2)
-        assert est.fixed_baseline_bytes == 0
+        self._assert_byte_identical(
+            _est(cfg, num_layers=32, kv_heads=8, head_dim=128), 32, 8, 128
+        )
 
     def test_non_string_layer_types_falls_back(self):
         cfg = SimpleNamespace(
@@ -102,13 +167,11 @@ class TestDenseFallback:
             head_dim=128,
             layer_types=[0, 1, 2, 3],  # not strings
         )
-        est = _est(cfg, num_layers=4, kv_heads=8, head_dim=128)
-        assert est.per_token_growth_bytes == _uniform(4, 8, 128, 2)
-        assert est.fixed_baseline_bytes == 0
+        self._assert_byte_identical(
+            _est(cfg, num_layers=4, kv_heads=8, head_dim=128), 4, 8, 128
+        )
 
     def test_zero_base_dims_returns_uniform(self):
-        # Defensive: the scheduler never calls us with 0 uniform, but the
-        # estimator must not crash / invent an estimate on degenerate input.
         cfg = SimpleNamespace(num_hidden_layers=0)
         est = estimate_kv_footprint(
             cfg,
@@ -120,10 +183,13 @@ class TestDenseFallback:
         )
         assert est.per_token_growth_bytes == 0
         assert est.fixed_baseline_bytes == 0
+        assert est.sliding_slot_bytes == 0
+        assert est.sliding_window == 0
 
 
 class TestKVSharing:
-    """Gemma-4 / Gemma-3n ``num_kv_shared_layers`` borrower layers = 0 KV."""
+    """Gemma-4 / Gemma-3n ``num_kv_shared_layers`` borrowers = 0 KV, validated
+    against the EXACT per-index producer map (codex round 11 BLOCKING #2)."""
 
     def test_shared_layers_reduce_growth_exactly(self):
         # 35 layers, all full-attention, last 20 borrow → 15 producers grow.
@@ -138,11 +204,11 @@ class TestKVSharing:
         est = _est(cfg, num_layers=n, kv_heads=kv, head_dim=hd)
         assert est.per_token_growth_bytes == 2 * (n - n_shared) * kv * hd * 2
         assert est.fixed_baseline_bytes == 0
+        assert est.sliding_slot_bytes == 0
 
     def test_shared_layers_without_layer_types_falls_back(self):
-        # num_kv_shared_layers alone (no per-layer map) is NOT enough to zero
-        # borrowers — without layer_types we cannot verify the last-N contract,
-        # so we stay on the uniform estimate (codex round 1 BLOCKING #3).
+        # num_kv_shared_layers alone (no per-layer map) can't verify the borrower
+        # map, so we stay on uniform (codex round 1 BLOCKING #3).
         n, n_shared, kv, hd = 40, 10, 4, 64
         cfg = SimpleNamespace(
             num_hidden_layers=n,
@@ -153,33 +219,68 @@ class TestKVSharing:
         est = _est(cfg, num_layers=n, kv_heads=kv, head_dim=hd)
         assert est.per_token_growth_bytes == _uniform(n, kv, hd, 2)
         assert est.fixed_baseline_bytes == 0
+        assert est.sliding_slot_bytes == 0
 
-    def test_shared_layers_with_unverifiable_split_not_zeroed(self):
-        # num_kv_shared_layers present WITH layer_types, but the last-N borrower
-        # types have no same-type producer below the split (a full-attention
-        # borrower with only sliding producers) → the last-N contract is
-        # unverified, so no layer is zeroed (over-count, never under-count).
-        n, n_shared, kv, hd = 10, 3, 4, 64
-        # First 7 (producers) all sliding; last 3 (borrowers) full → a full
-        # borrower has no full producer below the split.
-        layer_types = ["sliding_attention"] * 7 + ["full_attention"] * 3
+    def test_codex_example_all_borrowers_validly_mapped_are_zeroed(self):
+        # Codex round 11's counterexample: producers ``[full, sliding, full]``,
+        # borrowers ``[full, full, sliding]``. Under the SHIPPED type-keyed map
+        # (``models/gemma4_vendored/language.py``: each borrower reuses the LAST
+        # same-type producer below the split) EVERY borrower here has a same-type
+        # producer — full→idx2, full→idx2, sliding→idx1 — so zeroing all three is
+        # CORRECT, not a mis-sourced mapping. Remaining charged: the 3 producers
+        # (2 full grow per token, 1 sliding contributes a slot term).
+        n, kv, hd, window = 6, 1, 64, 128
+        layer_types = [
+            "full_attention",
+            "sliding_attention",
+            "full_attention",  # producers 0..2
+            "full_attention",
+            "full_attention",
+            "sliding_attention",  # borrowers 3..5
+        ]
         cfg = SimpleNamespace(
             num_hidden_layers=n,
             num_key_value_heads=kv,
             head_dim=hd,
             layer_types=layer_types,
-            num_kv_shared_layers=n_shared,
-            sliding_window=128,
+            num_kv_shared_layers=3,
+            sliding_window=window,
         )
         est = _est(cfg, num_layers=n, kv_heads=kv, head_dim=hd)
-        # Nothing zeroed: 3 full layers grow unbounded, 7 sliding layers reserve
-        # their whole rotating-cache buffer (all 10 layers counted, none borrowed).
-        assert est.per_token_growth_bytes == 2 * 3 * kv * hd * 2
-        assert est.fixed_baseline_bytes == 2 * 7 * _slots(128) * kv * hd * 2
+        assert est.per_token_growth_bytes == 2 * 2 * kv * hd * 2  # idx0, idx2 full
+        assert est.sliding_slot_bytes == 1 * 2 * kv * hd * 2  # idx1 sliding producer
+        assert est.sliding_window == window
+        assert est.fixed_baseline_bytes == 0
+
+    def test_orphan_borrower_type_is_charged_not_zeroed(self):
+        # The per-index map DIVERGES from a plain set check here: producers are
+        # all ``full`` (idx0,1), borrowers are ``full`` (idx2) and ``sliding``
+        # (idx3). The full borrower maps to a same-type producer → zeroed; the
+        # sliding borrower has NO sliding producer below the split → it is NOT
+        # zeroed but charged its own (sliding) footprint. A set-subset test would
+        # instead refuse to zero ANYTHING; the exact per-index map correctly
+        # zeroes the mappable borrower and charges only the orphan.
+        n, kv, hd, window = 4, 1, 64, 128
+        layer_types = [
+            "full_attention",
+            "full_attention",  # producers 0..1
+            "full_attention",  # borrower 2 → maps to a full producer → zeroed
+            "sliding_attention",  # borrower 3 → orphan → charged as sliding
+        ]
+        cfg = SimpleNamespace(
+            num_hidden_layers=n,
+            num_key_value_heads=kv,
+            head_dim=hd,
+            layer_types=layer_types,
+            num_kv_shared_layers=2,
+            sliding_window=window,
+        )
+        est = _est(cfg, num_layers=n, kv_heads=kv, head_dim=hd)
+        assert est.per_token_growth_bytes == 2 * 2 * kv * hd * 2  # idx0, idx1 full
+        assert est.sliding_slot_bytes == 1 * 2 * kv * hd * 2  # idx3 orphan charged
+        assert est.sliding_window == window
 
     def test_zero_shared_is_not_a_hybrid_signal(self):
-        # num_kv_shared_layers=0 (dense Gemma-4 12B/26B/31B) → no reduction,
-        # uniform fallback.
         cfg = SimpleNamespace(
             num_hidden_layers=32,
             num_key_value_heads=8,
@@ -189,12 +290,13 @@ class TestKVSharing:
         est = _est(cfg, num_layers=32, kv_heads=8, head_dim=128)
         assert est.per_token_growth_bytes == _uniform(32, 8, 128, 2)
         assert est.fixed_baseline_bytes == 0
+        assert est.sliding_slot_bytes == 0
 
 
 class TestSlidingWindow:
-    """GPT-OSS ~50% sliding-window layers are window-bounded, not per-token."""
+    """GPT-OSS ~50% sliding layers → a request-dependent slot term, not growth."""
 
-    def test_half_sliding_halves_growth_and_reserves_whole_window(self):
+    def test_half_sliding_halves_growth_and_exposes_slot_term(self):
         n, kv, hd, window = 24, 8, 64, 128
         layer_types = ["sliding_attention", "full_attention"] * (n // 2)
         cfg = SimpleNamespace(
@@ -209,33 +311,17 @@ class TestSlidingWindow:
         n_sliding = n // 2
         # Only the full layers grow unbounded per token — halved vs uniform.
         assert est.per_token_growth_bytes == 2 * n_full * kv * hd * 2
-        assert est.per_token_growth_bytes == _uniform(n, kv, hd, 2) // 2  # halved
-        # Sliding layers reserve their WHOLE rotating-cache buffer once per
-        # sequence — the step-rounded, sink-inclusive capacity, an over-count-safe
-        # upper bound on the real RotatingKVCache (codex round 10 BLOCKING).
-        assert est.fixed_baseline_bytes == 2 * n_sliding * _slots(window) * kv * hd * 2
+        assert est.per_token_growth_bytes == _uniform(n, kv, hd, 2) // 2
+        # Sliding layers contribute a per-SLOT term (one slot's bytes across all
+        # sliding layers) plus the shared window — NOT a fixed whole-window
+        # baseline (codex round 11 BLOCKING #1).
+        assert est.sliding_slot_bytes == 2 * n_sliding * kv * hd * 2
+        assert est.sliding_window == window
+        assert est.fixed_baseline_bytes == 0
 
-    def test_projection_below_uniform_for_long_generation(self):
-        # The reduction: for a long generation the arch-aware projection (halved
-        # per-token growth + a bounded window baseline) stays well below the
-        # uniform per-token over-count that keeps multiplying by every token.
-        n, kv, hd, window = 24, 8, 64, 128
-        layer_types = ["sliding_attention", "full_attention"] * (n // 2)
-        cfg = SimpleNamespace(
-            num_hidden_layers=n,
-            num_key_value_heads=kv,
-            head_dim=hd,
-            layer_types=layer_types,
-            sliding_window=window,
-        )
-        est = _est(cfg, num_layers=n, kv_heads=kv, head_dim=hd)
-        tokens = 8192  # >> window
-        projected = est.fixed_baseline_bytes + est.per_token_growth_bytes * tokens
-        assert projected < _uniform(n, kv, hd, 2) * tokens
-
-    def test_sliding_without_window_charged_as_full_growth(self):
-        # A sliding layer whose window is unreadable cannot be bounded → it is
-        # charged as full-growth so we never under-count.
+    def test_sliding_without_window_folds_into_full_growth(self):
+        # A sliding layer whose window is unreadable cannot be bounded → folded
+        # into full per-token growth; no sliding term is advertised.
         n, kv, hd = 24, 8, 64
         layer_types = ["sliding_attention", "full_attention"] * (n // 2)
         cfg = SimpleNamespace(
@@ -247,70 +333,29 @@ class TestSlidingWindow:
         )
         est = _est(cfg, num_layers=n, kv_heads=kv, head_dim=hd)
         assert est.per_token_growth_bytes == _uniform(n, kv, hd, 2)
+        assert est.sliding_slot_bytes == 0
+        assert est.sliding_window == 0
         assert est.fixed_baseline_bytes == 0
 
-    def test_non_step_aligned_window_rounds_up_to_capacity(self):
-        # The real RotatingKVCache does NOT allocate exactly ``window`` slots: it
-        # grows the buffer in step=256 increments and retains keep=4 sinks above
-        # the window, so a window of 500 charges ceil((500+4)/256)*256 = 512
-        # slots — STRICTLY MORE than the raw 500 (codex round 10 BLOCKING: the
-        # whole-window figure still under-counts the block-rounded, sink-retaining
-        # allocation).
-        n, kv, hd, window = 8, 4, 64, 500
-        layer_types = ["sliding_attention"] * n
+    def test_all_sliding_has_zero_per_token_growth(self):
+        n, kv, hd, window = 8, 4, 64, 256
         cfg = SimpleNamespace(
             num_hidden_layers=n,
             num_key_value_heads=kv,
             head_dim=hd,
-            layer_types=layer_types,
+            layer_types=["sliding_attention"] * n,
             sliding_window=window,
         )
         est = _est(cfg, num_layers=n, kv_heads=kv, head_dim=hd)
-        slots = _slots(window)
-        assert slots == 512
-        # Capacity property: at least window+keep, and a whole multiple of step.
-        assert slots >= window + _KEEP
-        assert slots % _STEP == 0
-        # Charged at the rounded-up capacity, strictly greater than the raw window.
         assert est.per_token_growth_bytes == 0
-        assert est.fixed_baseline_bytes == 2 * n * slots * kv * hd * 2
-        assert est.fixed_baseline_bytes > 2 * n * window * kv * hd * 2
-
-    def test_step_aligned_multi_block_window_rounds_to_768(self):
-        # A window whose (window + keep) crosses into the THIRD step block rounds
-        # up to 768 slots: ceil((513 + 4) / 256) * 256 = ceil(517/256)*256 =
-        # 3*256 = 768. Confirms the round-up spans multiple step blocks, not just
-        # a single-block nudge.
-        n, kv, hd, window = 8, 4, 64, 513
-        layer_types = ["sliding_attention"] * n
-        cfg = SimpleNamespace(
-            num_hidden_layers=n,
-            num_key_value_heads=kv,
-            head_dim=hd,
-            layer_types=layer_types,
-            sliding_window=window,
-        )
-        est = _est(cfg, num_layers=n, kv_heads=kv, head_dim=hd)
-        slots = _slots(window)
-        assert slots == 768
-        assert slots >= window + _KEEP
-        assert slots % _STEP == 0
-        assert est.fixed_baseline_bytes == 2 * n * slots * kv * hd * 2
-        assert est.fixed_baseline_bytes > 2 * n * window * kv * hd * 2
+        assert est.sliding_slot_bytes == 2 * n * kv * hd * 2
+        assert est.sliding_window == window
 
 
 class TestRecurrent:
-    """Qwen3.5/3.6 GatedDeltaNet layers have zero PER-TOKEN growth.
+    """Qwen3.5/3.6 GatedDeltaNet layers have zero PER-TOKEN growth; their fixed
+    state lands in the token-independent baseline (never the sliding term)."""
 
-    Their fixed recurrent state does not grow with generated tokens, so it lands
-    in the per-sequence baseline (sized from GatedDeltaNet's real config fields)
-    rather than the per-token term. Any recurrent family we do NOT size exactly
-    (Mamba/Mamba2, RWKV, generic) falls back to full per-token growth so it is
-    never left unreserved (codex round 2 BLOCKING #1 + round 7 BLOCKING #1).
-    """
-
-    # GatedDeltaNet state, sized from the same fields as
-    # ``mlx_lm.models.qwen3_next.Qwen3NextGatedDeltaNet``, at fp32/element.
     _GDN_FIELDS = dict(
         linear_num_value_heads=32,
         linear_num_key_heads=16,
@@ -330,8 +375,6 @@ class TestRecurrent:
         return 4 * (recurrent + conv_state)
 
     def test_gateddeltanet_state_reserved_in_baseline_zero_growth(self):
-        # 48 layers, 3:1 linear:full → only the 12 full layers grow per token;
-        # the 36 GatedDeltaNet layers reserve their fixed state in the baseline.
         n, kv, hd = 48, 2, 128
         pattern = ["linear_attention"] * 3 + ["full_attention"]
         layer_types = pattern * (n // 4)
@@ -347,18 +390,14 @@ class TestRecurrent:
         n_recurrent = n - n_full
         assert est.per_token_growth_bytes == 2 * n_full * kv * hd * 2
         assert est.fixed_baseline_bytes == n_recurrent * self._gdn_state_bytes()
+        assert est.sliding_slot_bytes == 0
+        assert est.sliding_window == 0
 
     @pytest.mark.parametrize(
         "gdn_type",
         ["linear_attention", "gated_delta_net", "gated_deltanet"],
     )
     def test_gateddeltanet_aliases_all_sized(self, gdn_type):
-        # Every GatedDeltaNet alias the classifier treats as recurrent must ALSO
-        # route to the GatedDeltaNet sizer — otherwise the alias classifies as
-        # zero-growth but its state cannot be sized, reverting to full per-token
-        # growth and losing the reduction this module exists to deliver (codex
-        # round 5 BLOCKING). All three spellings must yield the identical zero
-        # per-token growth + baseline-reserved fixed state.
         n, kv, hd = 8, 4, 64
         layer_types = [gdn_type] * (n - 1) + ["full_attention"]
         cfg = SimpleNamespace(
@@ -369,15 +408,11 @@ class TestRecurrent:
             **self._GDN_FIELDS,
         )
         est = _est(cfg, num_layers=n, kv_heads=kv, head_dim=hd)
-        # Only the single full layer grows per token; the recurrent layers reserve
-        # their fixed state in the baseline (never full per-token growth).
         assert est.per_token_growth_bytes == 2 * 1 * kv * hd * 2
         assert est.fixed_baseline_bytes == (n - 1) * self._gdn_state_bytes()
+        assert est.sliding_slot_bytes == 0
 
     def test_unsizeable_recurrent_falls_back_to_full_growth(self):
-        # linear_attention layers WITHOUT any GatedDeltaNet/Mamba sizing fields
-        # → cannot size the state → charged the uniform per-token estimate
-        # (full growth), never left unreserved.
         n, kv, hd = 8, 4, 64
         layer_types = ["linear_attention"] * (n - 1) + ["full_attention"]
         cfg = SimpleNamespace(
@@ -387,17 +422,11 @@ class TestRecurrent:
             layer_types=layer_types,
         )
         est = _est(cfg, num_layers=n, kv_heads=kv, head_dim=hd)
-        # All 8 layers charged full growth (uniform) — no reduction, no baseline.
         assert est.per_token_growth_bytes == _uniform(n, kv, hd, 2)
         assert est.fixed_baseline_bytes == 0
+        assert est.sliding_slot_bytes == 0
 
     def test_mamba_not_sized_falls_back_to_full_growth(self):
-        # We deliberately do NOT size a Mamba/Mamba2 state: the conv buffer
-        # channel count differs between Mamba1 (d_inner) and Mamba2 (d_inner +
-        # grouped B/C channels), so a single formula would under-reserve Mamba2
-        # (codex round 7 BLOCKING #1). This engine ships no Mamba model, so its
-        # layers conservatively fall back to full per-token growth — over-count
-        # safe, never unreserved — even when Mamba-shaped fields are present.
         n, kv, hd = 8, 4, 64
         layer_types = ["mamba"] * (n - 1) + ["full_attention"]
         cfg = SimpleNamespace(
@@ -411,15 +440,11 @@ class TestRecurrent:
             mamba_d_head=64,
         )
         est = _est(cfg, num_layers=n, kv_heads=kv, head_dim=hd)
-        # All 8 layers charged full growth — no baseline, no under-count.
         assert est.per_token_growth_bytes == _uniform(n, kv, hd, 2)
         assert est.fixed_baseline_bytes == 0
+        assert est.sliding_slot_bytes == 0
 
     def test_gateddeltanet_missing_conv_kernel_falls_back(self):
-        # GatedDeltaNet head fields present but linear_conv_kernel_dim ABSENT →
-        # cannot size the conv buffer → the whole layer falls back to full
-        # growth rather than silently omitting the conv state (codex round 3
-        # BLOCKING #1).
         n, kv, hd = 8, 4, 64
         layer_types = ["linear_attention"] * (n - 1) + ["full_attention"]
         cfg = SimpleNamespace(
@@ -438,9 +463,6 @@ class TestRecurrent:
         assert est.fixed_baseline_bytes == 0
 
     def test_full_attention_name_containing_linear_is_not_recurrent(self):
-        # Exact-match allowlist (codex round 1 BLOCKING #4): an unfamiliar
-        # full-attention type that merely CONTAINS "linear"/"gated"/"local" must
-        # NOT be misread as zero-growth — it is charged as full-growth.
         n, kv, hd = 6, 4, 64
         cfg = SimpleNamespace(
             num_hidden_layers=n,
@@ -451,12 +473,9 @@ class TestRecurrent:
         est = _est(cfg, num_layers=n, kv_heads=kv, head_dim=hd)
         assert est.per_token_growth_bytes == _uniform(n, kv, hd, 2)
         assert est.fixed_baseline_bytes == 0
+        assert est.sliding_slot_bytes == 0
 
     def test_generic_recurrent_family_not_mis_sized(self):
-        # An RWKV (or other generic recurrent) layer that incidentally exposes
-        # Mamba-ish generic fields must NOT be stamped with a bogus fixed state —
-        # only GatedDeltaNet is sized; every other recurrent family falls back to
-        # full growth (codex round 4 BLOCKING #2 + round 7 BLOCKING #1).
         n, kv, hd = 8, 4, 64
         layer_types = ["rwkv"] * (n - 1) + ["full_attention"]
         cfg = SimpleNamespace(
@@ -464,21 +483,20 @@ class TestRecurrent:
             num_key_value_heads=kv,
             head_dim=hd,
             layer_types=layer_types,
-            # generic fields a naive recurrent sizer might otherwise consume:
             state_size=128,
             intermediate_size=1536,
             conv_kernel_size=4,
         )
         est = _est(cfg, num_layers=n, kv_heads=kv, head_dim=hd)
-        # No baseline reserved (only GatedDeltaNet is sized); all layers full.
         assert est.per_token_growth_bytes == _uniform(n, kv, hd, 2)
         assert est.fixed_baseline_bytes == 0
+        assert est.sliding_slot_bytes == 0
 
 
 class TestHybridDimsAndNesting:
     def test_global_head_dim_used_for_full_layers(self):
-        # Realistic Gemma-4 text: 35 layers, 4:1 sliding:full pattern, last 20
-        # borrow, full layers use the wider global_head_dim/global kv heads.
+        # Realistic Gemma-4 text: 35 layers, 4:1 sliding:full, last 20 borrow,
+        # full layers use the wider global_head_dim/global kv heads.
         n, n_shared, kv, hd = 35, 20, 1, 256
         global_hd, global_kv, window = 512, 1, 512
         layer_types = (["sliding_attention"] * 4 + ["full_attention"]) * (n // 5)
@@ -496,12 +514,12 @@ class TestHybridDimsAndNesting:
         # Producers = first 15 layers. Full at indices 4, 9, 14 → 3 full,
         # 12 sliding. Borrowers (last 20) contribute nothing.
         assert est.per_token_growth_bytes == 2 * 3 * global_kv * global_hd * 2
-        # Sliding layers use local dims; whole rotating-cache capacity reserved.
-        assert est.fixed_baseline_bytes == 12 * 2 * _slots(window) * kv * hd * 2
+        # Sliding layers use local dims for the per-slot term.
+        assert est.sliding_slot_bytes == 12 * 2 * kv * hd * 2
+        assert est.sliding_window == window
+        assert est.fixed_baseline_bytes == 0
 
     def test_layer_structure_read_from_text_config(self):
-        # Multimodal configs nest the language layer structure under
-        # ``text_config``; the estimator must find it there.
         n, kv, hd, window = 24, 8, 64, 128
         layer_types = ["sliding_attention", "full_attention"] * (n // 2)
         cfg = SimpleNamespace(
@@ -514,7 +532,8 @@ class TestHybridDimsAndNesting:
         )
         est = _est(cfg, num_layers=n, kv_heads=kv, head_dim=hd)
         assert est.per_token_growth_bytes == 2 * (n // 2) * kv * hd * 2
-        assert est.fixed_baseline_bytes == 2 * (n // 2) * _slots(window) * kv * hd * 2
+        assert est.sliding_slot_bytes == 2 * (n // 2) * kv * hd * 2
+        assert est.sliding_window == window
 
     def test_dict_config_supported(self):
         # The offline hybrid probe reads parsed config.json dicts.
@@ -529,10 +548,10 @@ class TestHybridDimsAndNesting:
         }
         est = _est(cfg, num_layers=n, kv_heads=kv, head_dim=hd)
         assert est.per_token_growth_bytes == 2 * (n // 2) * kv * hd * 2
-        assert est.fixed_baseline_bytes == 2 * (n // 2) * _slots(window) * kv * hd * 2
+        assert est.sliding_slot_bytes == 2 * (n // 2) * kv * hd * 2
+        assert est.sliding_window == window
 
     def test_unknown_layer_type_charged_as_full_growth(self):
-        # An unrecognized attention-type string must never under-count → full.
         n, kv, hd = 4, 8, 128
         cfg = SimpleNamespace(
             num_hidden_layers=n,
@@ -542,21 +561,28 @@ class TestHybridDimsAndNesting:
         )
         est = _est(cfg, num_layers=n, kv_heads=kv, head_dim=hd)
         assert est.per_token_growth_bytes == _uniform(n, kv, hd, 2)
+        assert est.sliding_slot_bytes == 0
         assert est.fixed_baseline_bytes == 0
 
 
 class TestNeverUnderCounts:
-    """The projected footprint is always >= the true counted-layer footprint."""
+    """The per-request projection is always >= the true counted-layer footprint,
+    at every token count — and never over-counts a short request past the full
+    window."""
+
+    def _project(self, est, tokens):
+        return (
+            est.fixed_baseline_bytes
+            + est.per_token_growth_bytes * tokens
+            + est.sliding_slot_bytes * rotating_cache_slots(est.sliding_window, tokens)
+        )
 
     def test_projection_upper_bounds_true_footprint(self):
-        # GPT-OSS-like hybrid. The scheduler projection
-        #   fixed_baseline + tokens * per_token_growth
-        # must be >= the true footprint of the counted layers for ANY token
-        # count, since that is the D-METAL-CAP never-under-count guarantee:
-        #   full layers: exact tokens*per-layer
-        #   sliding layers: min(tokens, window)*per-layer  (<= slots*per-layer,
-        #                   the step-rounded rotating-cache capacity reserved in
-        #                   the baseline, where slots >= window)
+        # GPT-OSS-like hybrid. For ANY token count the projection must be >= the
+        # true footprint of the counted layers:
+        #   full layers: exact tokens × per-layer
+        #   sliding layers: min(tokens, window) × per-layer  (real buffer ≤ this,
+        #                   rounded up to step blocks — bounded by our slot count)
         n, kv, hd, window, db = 24, 8, 64, 128, 2
         layer_types = ["sliding_attention", "full_attention"] * (n // 2)
         cfg = SimpleNamespace(
@@ -569,19 +595,52 @@ class TestNeverUnderCounts:
         est = _est(cfg, num_layers=n, kv_heads=kv, head_dim=hd, dtype_bytes=db)
         n_full = n // 2
         n_sliding = n // 2
-        full_per_layer = 2 * kv * hd * db
+        per_layer = 2 * kv * hd * db
         for tokens in (1, 100, window, window + 1, 4096, 32768):
-            projected = est.fixed_baseline_bytes + tokens * est.per_token_growth_bytes
-            true_full = n_full * tokens * full_per_layer
-            true_sliding = n_sliding * min(tokens, window) * full_per_layer
-            # Over-count-safe: the whole-window baseline is >= any decode/prefill
-            # peak of the sliding layers, so the projection never under-counts.
+            projected = self._project(est, tokens)
+            true_full = n_full * tokens * per_layer
+            true_sliding = n_sliding * min(tokens, window) * per_layer
             assert projected >= true_full + true_sliding
 
+    def test_short_request_not_over_charged_full_window(self):
+        # The codex round 11 win: a SHORT request (T=1) against a big window is
+        # NOT charged the whole window. Its sliding term is one step block, far
+        # below what a fixed whole-window baseline would have charged.
+        n, kv, hd, window, db = 8, 4, 64, 4096, 2
+        cfg = SimpleNamespace(
+            num_hidden_layers=n,
+            num_key_value_heads=kv,
+            head_dim=hd,
+            layer_types=["sliding_attention"] * n,
+            sliding_window=window,
+        )
+        est = _est(cfg, num_layers=n, kv_heads=kv, head_dim=hd, dtype_bytes=db)
+        short = self._project(est, 1)
+        full_window = est.sliding_slot_bytes * rotating_cache_slots(window, window)
+        assert short == est.sliding_slot_bytes * 256  # one step block
+        assert short < full_window  # strictly less than the whole-window charge
+
+    def test_monotonic_and_capped_projection(self):
+        n, kv, hd, window, db = 8, 4, 64, 512, 2
+        cfg = SimpleNamespace(
+            num_hidden_layers=n,
+            num_key_value_heads=kv,
+            head_dim=hd,
+            layer_types=["sliding_attention", "full_attention"] * (n // 2),
+            sliding_window=window,
+        )
+        est = _est(cfg, num_layers=n, kv_heads=kv, head_dim=hd, dtype_bytes=db)
+        # The sliding CONTRIBUTION alone is monotonic non-decreasing and caps at
+        # the full-window buffer.
+        cap = est.sliding_slot_bytes * rotating_cache_slots(window, window)
+        prev = -1
+        for tokens in (1, 200, 511, 512, 513, 5000):
+            slide = est.sliding_slot_bytes * rotating_cache_slots(window, tokens)
+            assert slide >= prev
+            assert slide <= cap
+            prev = slide
+
     def test_full_layer_growth_never_below_uniform_base(self):
-        # A pathological config where global_head_dim / num_global_key_value_heads
-        # are SMALLER than the base dims must not shrink full-layer per-token
-        # growth below the uniform base-layer charge (codex round 4 BLOCKING #1).
         n, kv, hd, db = 8, 8, 128, 2
         cfg = SimpleNamespace(
             num_hidden_layers=n,
@@ -592,36 +651,28 @@ class TestNeverUnderCounts:
             num_global_key_value_heads=1,  # << base kv heads
         )
         est = _est(cfg, num_layers=n, kv_heads=kv, head_dim=hd, dtype_bytes=db)
-        # Clamped to the uniform base-layer size, not the tiny global dims.
         assert est.per_token_growth_bytes == _uniform(n, kv, hd, db)
-        assert est.fixed_baseline_bytes == 0
+        assert est.sliding_slot_bytes == 0
 
-    def test_sliding_rate_never_below_uniform_base(self):
-        # Symmetric to the full-layer clamp: a nested/malformed config whose
-        # local (sliding) dims read SMALLER than the base dims the scheduler used
-        # must not shrink the sliding per-layer rate below the uniform per-layer
-        # charge (codex round 7 BLOCKING #2). Here the struct exposes a tiny
-        # local head_dim; the base head_dim passed by the caller is larger, so
-        # the whole-window baseline is computed at the clamped (base) rate.
+    def test_sliding_slot_rate_never_below_uniform_base(self):
+        # A nested/malformed config whose local (sliding) dims read SMALLER than
+        # the base dims must not shrink the per-slot rate below the uniform
+        # per-layer charge (codex round 7 BLOCKING #2).
         n, kv, hd, db, window = 8, 8, 128, 2, 256
-        layer_types = ["sliding_attention"] * n
         cfg = SimpleNamespace(
             num_hidden_layers=n,
             num_key_value_heads=kv,
             head_dim=8,  # << base head_dim (128) — malformed / non-authoritative
-            layer_types=layer_types,
+            layer_types=["sliding_attention"] * n,
             sliding_window=window,
         )
         est = _est(cfg, num_layers=n, kv_heads=kv, head_dim=hd, dtype_bytes=db)
-        # Whole-capacity baseline at the clamped base per-layer rate, not the tiny
-        # local dims (which would under-count). Capacity = step-rounded slots.
-        assert est.fixed_baseline_bytes == n * _slots(window) * 2 * kv * hd * db
+        # Per-slot term at the clamped base per-layer rate, not the tiny local
+        # dims (which would under-count).
+        assert est.sliding_slot_bytes == n * 2 * kv * hd * db
         assert est.per_token_growth_bytes == 0
 
     def test_projection_covers_recurrent_fixed_state(self):
-        # A GatedDeltaNet hybrid: the projection must reserve the recurrent
-        # layers' fixed state (in the baseline) on top of the full layers'
-        # growth — it is never omitted (codex round 2 BLOCKING #1 + #3).
         n, kv, hd, db = 16, 2, 128, 2
         gdn = dict(
             linear_num_value_heads=32,
@@ -641,13 +692,11 @@ class TestNeverUnderCounts:
         est = _est(cfg, num_layers=n, kv_heads=kv, head_dim=hd, dtype_bytes=db)
         n_full = n // 4
         n_recurrent = n - n_full
-        # Per-layer GatedDeltaNet state (fp32/element), independently recomputed.
         key_dim = 16 * 128
         value_dim = 32 * 128
         state = 4 * (32 * 128 * 128 + (4 - 1) * (2 * key_dim + value_dim))
         assert est.fixed_baseline_bytes == n_recurrent * state
         full_per_layer = 2 * kv * hd * db
         for tokens in (1, 100, 4096, 32768):
-            projected = est.fixed_baseline_bytes + tokens * est.per_token_growth_bytes
-            # >= full-attention growth + the reserved recurrent fixed state.
+            projected = self._project(est, tokens)
             assert projected >= n_full * tokens * full_per_layer + n_recurrent * state

--- a/tests/test_kv_estimation.py
+++ b/tests/test_kv_estimation.py
@@ -843,26 +843,69 @@ class TestRotatingCacheConstantsMatchInstalledMlxLm:
         # bound over the installed construction's keep.
         assert max(installed_keeps) <= _ROTATING_CACHE_KEEP
 
+    @staticmethod
+    def _static_keep_upper_bound(node):
+        """Static upper bound of a ``keep=`` expression, or ``None`` if unbounded.
+
+        Recognizes exactly the two provably-safe forms the engine uses:
+
+        * a constant int literal → its own value;
+        * the re-wrap idiom ``getattr(<src>, "keep", <int literal>)`` → the literal
+          default. Such a construction inherits ``<src>``'s keep, and every source
+          ``RotatingKVCache`` in the tree is itself bounded by THIS scan, so the
+          inherited value is bounded too; the fallback is the literal default.
+
+        Any other expression (a config attribute, a variable, a call we don't
+        recognize) is NOT statically bounded → ``None``, and the caller FAILS: a
+        keep that can exceed the bound at runtime would silently under-reserve KV.
+        """
+        import ast
+
+        if (
+            isinstance(node, ast.Constant)
+            and isinstance(node.value, int)
+            and not isinstance(node.value, bool)
+        ):
+            return node.value
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "getattr"
+            and len(node.args) == 3
+            and isinstance(node.args[1], ast.Constant)
+            and node.args[1].value == "keep"
+            and isinstance(node.args[2], ast.Constant)
+            and isinstance(node.args[2].value, int)
+            and not isinstance(node.args[2].value, bool)
+        ):
+            return node.args[2].value
+        return None
+
     def test_no_shipped_rotating_cache_construction_exceeds_our_keep(self):
         # ``make_prompt_cache`` (tested above) is the GENERIC construction path,
         # but the engine ALSO builds ``RotatingKVCache`` DIRECTLY in vendored
-        # stacks (Gemma-4, DeepSeek-V4). If any shipped direct construction set
-        # ``keep`` ABOVE our ``_ROTATING_CACHE_KEEP`` bound, ``rotating_cache_slots``
-        # would under-reserve KV at admission (OOM risk). Statically scan EVERY
-        # ``RotatingKVCache(...)`` call in the package and assert its literal
-        # ``keep`` kwarg never exceeds our bound — the "validate the max keep
-        # across all constructors" guarantee, hermetic (AST parse, no imports run,
-        # no model load). Re-wrap constructions that pass ``keep=getattr(src,
-        # "keep", 0)`` inherit the source cache's keep, so bounding the source
-        # literals bounds them too; a non-constant ``keep`` is not asserted here.
+        # stacks (Gemma-4, DeepSeek-V4). If any shipped construction set ``keep``
+        # ABOVE our ``_ROTATING_CACHE_KEEP`` bound, ``rotating_cache_slots`` would
+        # under-reserve KV at admission (OOM risk). Statically scan EVERY exact
+        # ``RotatingKVCache(...)`` call in the package and, for each, prove its
+        # ``keep`` is bounded — the "validate the max keep across all constructors"
+        # guarantee, hermetic (AST parse, no imports run, no model load).
+        #
+        # This does NOT silently ignore non-literal keeps: a construction whose
+        # ``keep`` cannot be statically bounded (anything but a literal int or the
+        # ``getattr(src, "keep", <int>)`` re-wrap idiom) FAILS the test, forcing a
+        # human to prove the new form safe or extend the recognizer. A missing
+        # ``keep`` kwarg is the ``RotatingKVCache`` default (0), which is safe.
+        # ``BatchRotatingKVCache`` is a distinct batch-decode re-pack (own
+        # signature) and is intentionally excluded by the exact-name match.
         import ast
         import pathlib
 
         import vllm_mlx
 
         pkg_root = pathlib.Path(vllm_mlx.__file__).parent
-        literal_constructions: list[tuple[str, int, int]] = []
         total_constructions = 0
+        keeps_checked = 0
         for py in pkg_root.rglob("*.py"):
             try:
                 tree = ast.parse(py.read_text(encoding="utf-8"), filename=str(py))
@@ -878,32 +921,36 @@ class TestRotatingCacheConstantsMatchInstalledMlxLm:
                     name = func.id
                 else:
                     continue
-                # EXACT match — ``BatchRotatingKVCache`` is a distinct batch-decode
-                # re-pack with its own signature and is intentionally excluded.
                 if name != "RotatingKVCache":
                     continue
                 total_constructions += 1
-                for kw in node.keywords:
-                    if kw.arg == "keep" and isinstance(kw.value, ast.Constant):
-                        keep_val = kw.value.value
-                        if isinstance(keep_val, int) and not isinstance(keep_val, bool):
-                            literal_constructions.append(
-                                (py.name, node.lineno, keep_val)
-                            )
+                keep_kw = next((kw for kw in node.keywords if kw.arg == "keep"), None)
+                if keep_kw is None:
+                    continue  # default keep=0 → safe
+                bound = self._static_keep_upper_bound(keep_kw.value)
+                assert bound is not None, (
+                    f"{py.name}:{node.lineno} constructs RotatingKVCache with a keep= "
+                    "expression this OOM-safety scan cannot statically bound "
+                    f"({ast.dump(keep_kw.value)}). A keep that can exceed "
+                    f"_ROTATING_CACHE_KEEP={_ROTATING_CACHE_KEEP} at runtime would make "
+                    "rotating_cache_slots under-reserve KV at admission. Use a literal "
+                    'keep <= the bound, the getattr(src, "keep", <int>) re-wrap idiom, '
+                    "or extend _static_keep_upper_bound to prove the new form safe."
+                )
+                assert bound <= _ROTATING_CACHE_KEEP, (
+                    f"{py.name}:{node.lineno} constructs RotatingKVCache(keep={bound}), "
+                    f"which EXCEEDS _ROTATING_CACHE_KEEP={_ROTATING_CACHE_KEEP}; "
+                    "rotating_cache_slots would under-reserve KV at admission (OOM "
+                    "risk). Raise _ROTATING_CACHE_KEEP to bound every shipped keep."
+                )
+                keeps_checked += 1
         # The vendored Gemma-4 / DeepSeek-V4 stacks are in-tree, so the scan must
-        # find real constructions — a zero count means the scan silently missed
-        # them (e.g. a rename) and would give false assurance.
+        # find real constructions AND validate at least one keep — a zero count
+        # means the scan silently missed them (e.g. a rename) → false assurance.
         assert total_constructions > 0, (
             "no RotatingKVCache(...) constructions found in vllm_mlx — the keep "
             "drift scan matched nothing and cannot guard the bound"
         )
-        assert literal_constructions, (
-            "no RotatingKVCache(keep=<literal>) constructions found to validate"
+        assert keeps_checked > 0, (
+            "no explicit RotatingKVCache(keep=...) constructions were validated"
         )
-        for fname, lineno, keep_val in literal_constructions:
-            assert keep_val <= _ROTATING_CACHE_KEEP, (
-                f"{fname}:{lineno} constructs RotatingKVCache(keep={keep_val}), which "
-                f"EXCEEDS _ROTATING_CACHE_KEEP={_ROTATING_CACHE_KEEP}; "
-                "rotating_cache_slots would under-reserve KV at admission (OOM "
-                "risk). Raise _ROTATING_CACHE_KEEP to bound every shipped keep."
-            )

--- a/tests/test_metal_cap_enforcement.py
+++ b/tests/test_metal_cap_enforcement.py
@@ -912,6 +912,27 @@ class TestArchitectureAwareKVEstimate:
         assert sched._kv_sliding_per_token_bytes == 2 * (n // 2) * kv * hd * 2
         assert sched._kv_sliding_window_tokens == window
 
+    def test_nested_config_without_layer_types_stays_byte_identical(self):
+        # BYTE-IDENTICAL guard: a multimodal config whose text_config carries NO
+        # valid layer_types (a non-hybrid nested model) must NOT adopt the nested
+        # dims — the outer config has no num_hidden_layers, so admission
+        # accounting stays exactly as before (0, no phantom estimate). Only a
+        # genuine nested hybrid (valid layer_types) flips to the nested dims.
+        cfg = SimpleNamespace(
+            vision_config=SimpleNamespace(num_hidden_layers=27),
+            text_config=SimpleNamespace(
+                num_hidden_layers=32,
+                num_key_value_heads=8,
+                head_dim=128,
+                # no layer_types → not a recognized nested hybrid
+            ),
+            dtype="bfloat16",
+        )
+        sched = self._sched(cfg)
+        assert sched._resolve_kv_bytes_per_token() == 0
+        assert sched._resolve_kv_fixed_baseline_bytes() == 0
+        assert sched._kv_sliding_per_token_bytes == 0
+
     def test_operator_override_wins_and_zeroes_baseline(self):
         # Explicit knob short-circuits the estimator; no baseline is charged.
         cfg = SimpleNamespace(

--- a/tests/test_metal_cap_enforcement.py
+++ b/tests/test_metal_cap_enforcement.py
@@ -806,3 +806,161 @@ class TestMetricsRoute:
         assert "# TYPE rapid_mlx_metal_cap_violations_total counter" in body, (
             "metric type must be 'counter' for monotonic rate() to work"
         )
+
+
+class TestArchitectureAwareKVEstimate:
+    """Wire-through of the architecture-aware KV estimator into the D-METAL-CAP
+    admission path (``_resolve_kv_bytes_per_token`` /
+    ``_estimate_request_kv_bytes``). The uniform-fallback and operator-override
+    contracts must stay byte-identical (covered by the classes above); these
+    add the hybrid-reduction cases.
+
+    Uses ``SimpleNamespace`` for ``model.config`` so unset fields resolve to
+    ``None`` (a ``MagicMock`` auto-creates every attribute, which would falsely
+    look like a hybrid layer structure).
+    """
+
+    def _sched(self, config_obj, *, kv_bytes_override: int = 0):
+        config = SchedulerConfig(
+            max_num_seqs=8,
+            max_concurrent_requests=64,
+            enable_prefix_cache=False,
+            use_memory_aware_cache=False,
+            use_paged_cache=False,
+            gpu_memory_utilization=0.5,
+            metal_cap_kv_bytes_per_token=kv_bytes_override,
+        )
+        model = MagicMock()
+        model.config = config_obj
+        return Scheduler(model=model, tokenizer=MagicMock(), config=config)
+
+    def test_dense_config_stays_uniform_with_zero_baseline(self):
+        # No layer_types / sliding / sharing → byte-identical uniform, no
+        # fixed baseline.
+        cfg = SimpleNamespace(
+            num_hidden_layers=32,
+            num_key_value_heads=8,
+            head_dim=128,
+            dtype="bfloat16",
+        )
+        sched = self._sched(cfg)
+        assert sched._resolve_kv_bytes_per_token() == 2 * 32 * 8 * 128 * 2
+        assert sched._resolve_kv_fixed_baseline_bytes() == 0
+
+    def test_gpt_oss_hybrid_reduces_per_token_and_sets_baseline(self):
+        # ~50% sliding-window layers → per-token growth halved vs uniform, and
+        # the window footprint lands in the per-sequence fixed baseline.
+        n, kv, hd, window = 24, 8, 64, 128
+        layer_types = ["sliding_attention", "full_attention"] * (n // 2)
+        cfg = SimpleNamespace(
+            num_hidden_layers=n,
+            num_key_value_heads=kv,
+            head_dim=hd,
+            layer_types=layer_types,
+            sliding_window=window,
+            dtype="bfloat16",
+        )
+        sched = self._sched(cfg)
+        uniform = 2 * n * kv * hd * 2
+        assert sched._resolve_kv_bytes_per_token() == uniform // 2
+        assert sched._resolve_kv_fixed_baseline_bytes() == 2 * (n // 2) * window * kv * hd * 2
+
+    def test_gemma4_sharing_reduces_per_token(self):
+        n, n_shared, kv, hd = 35, 20, 1, 128
+        cfg = SimpleNamespace(
+            num_hidden_layers=n,
+            num_key_value_heads=kv,
+            head_dim=hd,
+            layer_types=["full_attention"] * n,
+            num_kv_shared_layers=n_shared,
+            dtype="bfloat16",
+        )
+        sched = self._sched(cfg)
+        assert sched._resolve_kv_bytes_per_token() == 2 * (n - n_shared) * kv * hd * 2
+        assert sched._resolve_kv_fixed_baseline_bytes() == 0
+
+    def test_operator_override_wins_and_zeroes_baseline(self):
+        # Explicit knob short-circuits the estimator; no baseline is charged.
+        cfg = SimpleNamespace(
+            num_hidden_layers=24,
+            num_key_value_heads=8,
+            head_dim=64,
+            layer_types=["sliding_attention", "full_attention"] * 12,
+            sliding_window=128,
+        )
+        sched = self._sched(cfg, kv_bytes_override=42)
+        assert sched._resolve_kv_bytes_per_token() == 42
+        assert sched._resolve_kv_fixed_baseline_bytes() == 0
+
+    def test_magicmock_config_yields_zero_and_no_baseline(self):
+        # Bare MagicMock model — int(MagicMock()) path must still yield 0 with
+        # no phantom baseline (back-compat for the stub-model unit tests).
+        config = SchedulerConfig(
+            max_num_seqs=8,
+            max_concurrent_requests=64,
+            enable_prefix_cache=False,
+            use_memory_aware_cache=False,
+            use_paged_cache=False,
+            gpu_memory_utilization=0.5,
+            metal_cap_kv_bytes_per_token=0,
+        )
+        sched = Scheduler(model=MagicMock(), tokenizer=MagicMock(), config=config)
+        assert sched._resolve_kv_bytes_per_token() == 0
+        assert sched._resolve_kv_fixed_baseline_bytes() == 0
+
+    def test_estimate_request_charges_baseline_plus_growth(self):
+        n, kv, hd, window = 24, 8, 64, 128
+        layer_types = ["sliding_attention", "full_attention"] * (n // 2)
+        cfg = SimpleNamespace(
+            num_hidden_layers=n,
+            num_key_value_heads=kv,
+            head_dim=hd,
+            layer_types=layer_types,
+            sliding_window=window,
+            dtype="bfloat16",
+        )
+        sched = self._sched(cfg)
+        req = _make_request(tokens=100)
+        req.sampling_params = SamplingParams(max_tokens=50)
+        growth = sched._resolve_kv_bytes_per_token()
+        baseline = sched._resolve_kv_fixed_baseline_bytes()
+        assert baseline > 0
+        assert sched._estimate_request_kv_bytes(req) == baseline + growth * (100 + 50)
+
+    def test_hybrid_admitted_where_uniform_would_reject(self):
+        # The headline win: a GPT-OSS-style hybrid whose uniform per-token
+        # over-count would trip the projection gate is ADMITTED once the
+        # sliding layers are correctly excluded from per-token growth.
+        n, kv, hd, window = 24, 8, 64, 128
+        layer_types = ["sliding_attention", "full_attention"] * (n // 2)
+        cfg = SimpleNamespace(
+            num_hidden_layers=n,
+            num_key_value_heads=kv,
+            head_dim=hd,
+            layer_types=layer_types,
+            sliding_window=window,
+            dtype="bfloat16",
+        )
+        sched = self._sched(cfg)
+        req = _make_request(tokens=16)
+        req.sampling_params = SamplingParams(max_tokens=8_000)
+        tokens = 16 + 8_000
+        uniform_per_tok = 2 * n * kv * hd * 2
+        arch_projected = sched._estimate_request_kv_bytes(req)
+        uniform_projected = uniform_per_tok * tokens
+        # Arch-aware projection is strictly smaller than the uniform one for a
+        # large token budget (the fixed window baseline is dwarfed by the
+        # halved per-token growth × tokens).
+        assert arch_projected < uniform_projected
+        # Pick a cap that sits between the two projections: uniform rejects,
+        # arch-aware admits.
+        active = 1_000_000_000
+        cap = active + (arch_projected + uniform_projected) // 2
+        with (
+            patch.object(sched, "_resolve_metal_cap_bytes", return_value=cap),
+            patch.object(sched, "_current_metal_active_bytes", return_value=active),
+        ):
+            sched._enforce_metal_cap_at_admission(req)  # must NOT raise
+        assert sched.num_metal_cap_violations == 0
+        # Sanity: the uniform over-count would have exceeded the cap.
+        assert active + uniform_projected > cap

--- a/tests/test_metal_cap_enforcement.py
+++ b/tests/test_metal_cap_enforcement.py
@@ -961,10 +961,11 @@ class TestArchitectureAwareKVEstimate:
         assert sched._kv_sliding_per_token_bytes == 0  # no sliding layers
         assert sched._estimate_request_kv_bytes(req) == baseline + growth * (100 + 50)
 
-    def test_estimate_request_caps_sliding_term_at_window(self):
-        # A GPT-OSS-style hybrid: the sliding term is charged
-        # ``sliding_per_token × min(tokens, window)`` — capped at the window for
-        # a long request, NOT a flat full-window baseline (codex round 6).
+    def test_estimate_request_sliding_prefill_peak_and_window_cap(self):
+        # A GPT-OSS-style hybrid: sliding layers are charged
+        # ``sliding_per_token × max(prompt_tokens, min(tokens, window))`` — the
+        # window-capped decode steady state, floored at the full prompt to cover
+        # the transient prefill peak (codex round 6 + round 7 BLOCKING #3).
         n, kv, hd, window = 24, 8, 64, 128
         layer_types = ["sliding_attention", "full_attention"] * (n // 2)
         cfg = SimpleNamespace(
@@ -979,30 +980,46 @@ class TestArchitectureAwareKVEstimate:
         growth = sched._resolve_kv_bytes_per_token()
         assert sched._resolve_kv_fixed_baseline_bytes() == 0
         sliding = sched._kv_sliding_per_token_bytes
+        uniform_per_tok = 2 * n * kv * hd * 2
 
-        # Short request (below the window): sliding charged its actual tokens →
-        # byte-identical to the historical uniform figure, no over-charge.
+        # (a) Short request (prompt + budget below the window): sliding charged
+        # its actual tokens → byte-identical to the historical uniform figure.
         short = _make_request(tokens=40)
         short.sampling_params = SamplingParams(max_tokens=20)
         short_tokens = 60
-        uniform_per_tok = 2 * n * kv * hd * 2
         assert sched._estimate_request_kv_bytes(short) == uniform_per_tok * short_tokens
         assert (
             sched._estimate_request_kv_bytes(short)
             == growth * short_tokens + sliding * short_tokens
         )
 
-        # Long request (past the window): sliding capped at the window.
-        long_req = _make_request(tokens=1000)
-        long_req.sampling_params = SamplingParams(max_tokens=1000)
-        long_tokens = 2000
+        # (b) Decode-heavy request (tiny prompt, long generation): the sliding
+        # term is CAPPED at the window — the headline reduction.
+        decode = _make_request(tokens=16)
+        decode.sampling_params = SamplingParams(max_tokens=8_000)
+        decode_tokens = 8_016
         assert (
-            sched._estimate_request_kv_bytes(long_req)
-            == growth * long_tokens + sliding * window
+            sched._estimate_request_kv_bytes(decode)
+            == growth * decode_tokens + sliding * window
         )
-        # And strictly below what the uniform over-count would have projected.
         assert (
-            sched._estimate_request_kv_bytes(long_req) < uniform_per_tok * long_tokens
+            sched._estimate_request_kv_bytes(decode) < uniform_per_tok * decode_tokens
+        )
+
+        # (c) Large-prompt request (prompt itself exceeds the window): the
+        # sliding term is NOT capped at the window — it is floored at the full
+        # prompt to cover the transient prefill allocation (never under-count).
+        big_prompt = _make_request(tokens=1_000)
+        big_prompt.sampling_params = SamplingParams(max_tokens=50)
+        assert (
+            sched._estimate_request_kv_bytes(big_prompt)
+            == growth * 1_050 + sliding * 1_000
+        )
+        # Strictly MORE than a naive window-cap would have projected — that gap
+        # is exactly the prefill peak the round-7 fix stops under-counting.
+        assert (
+            sched._estimate_request_kv_bytes(big_prompt)
+            > growth * 1_050 + sliding * window
         )
 
     def test_hybrid_admitted_where_uniform_would_reject(self):
@@ -1043,3 +1060,43 @@ class TestArchitectureAwareKVEstimate:
         assert sched.num_metal_cap_violations == 0
         # Sanity: the uniform over-count would have exceeded the cap.
         assert active + uniform_projected > cap
+
+    def test_large_prompt_prefill_peak_is_rejected(self):
+        # codex round 7 BLOCKING #3: a prompt LARGER than the sliding window can
+        # transiently allocate the whole prompt's KV during prefill before the
+        # rotating cache trims. The admission gate must charge that prefill peak
+        # (prompt floor, not the window cap) so it REJECTS a request that would
+        # OOM during prefill — a naive window-cap would have wrongly admitted it.
+        n, kv, hd, window = 24, 8, 64, 128
+        layer_types = ["sliding_attention", "full_attention"] * (n // 2)
+        cfg = SimpleNamespace(
+            num_hidden_layers=n,
+            num_key_value_heads=kv,
+            head_dim=hd,
+            layer_types=layer_types,
+            sliding_window=window,
+            dtype="bfloat16",
+        )
+        sched = self._sched(cfg)
+        growth = sched._resolve_kv_bytes_per_token()
+        sliding = sched._kv_sliding_per_token_bytes
+        big_prompt = _make_request(tokens=8_000)
+        big_prompt.sampling_params = SamplingParams(max_tokens=50)
+        total = 8_050
+        prefill_aware = sched._estimate_request_kv_bytes(big_prompt)
+        naive_window = growth * total + sliding * window
+        assert prefill_aware == growth * total + sliding * 8_000
+        assert prefill_aware > naive_window  # the peak the fix stops dropping
+        # A cap between the two: the naive window-cap would admit, the
+        # prefill-aware projection must reject.
+        active = 1_000_000_000
+        cap = active + (naive_window + prefill_aware) // 2
+        with (
+            patch.object(sched, "_resolve_metal_cap_bytes", return_value=cap),
+            patch.object(sched, "_current_metal_active_bytes", return_value=active),
+            pytest.raises(BackpressureError, match="D-METAL-CAP"),
+        ):
+            sched._enforce_metal_cap_at_admission(big_prompt)
+        assert sched.num_metal_cap_violations == 1
+        # Sanity: the naive window-cap would have slipped under the cap.
+        assert active + naive_window < cap

--- a/tests/test_metal_cap_enforcement.py
+++ b/tests/test_metal_cap_enforcement.py
@@ -883,6 +883,35 @@ class TestArchitectureAwareKVEstimate:
         assert sched._resolve_kv_bytes_per_token() == 2 * (n - n_shared) * kv * hd * 2
         assert sched._resolve_kv_fixed_baseline_bytes() == 0
 
+    def test_multimodal_nested_text_config_engages_reduction(self):
+        # A multimodal config nests the text-tower dims under ``text_config`` and
+        # the OUTER config carries no ``num_hidden_layers``. The scheduler must
+        # resolve the base dims from the nested config so the hybrid reduction
+        # actually engages end-to-end — not just in the pure estimator (codex
+        # round 8 BLOCKING).
+        n, kv, hd, window = 24, 8, 64, 128
+        layer_types = ["sliding_attention", "full_attention"] * (n // 2)
+        cfg = SimpleNamespace(
+            # outer multimodal config: vision tower + nested text config, NO
+            # top-level num_hidden_layers.
+            vision_config=SimpleNamespace(num_hidden_layers=27),
+            text_config=SimpleNamespace(
+                num_hidden_layers=n,
+                num_key_value_heads=kv,
+                head_dim=hd,
+                layer_types=layer_types,
+                sliding_window=window,
+            ),
+            dtype="bfloat16",
+        )
+        sched = self._sched(cfg)
+        uniform = 2 * n * kv * hd * 2
+        # Reduction engaged: unbounded growth halved, sliding term populated.
+        assert sched._resolve_kv_bytes_per_token() == uniform // 2
+        assert sched._resolve_kv_fixed_baseline_bytes() == 0
+        assert sched._kv_sliding_per_token_bytes == 2 * (n // 2) * kv * hd * 2
+        assert sched._kv_sliding_window_tokens == window
+
     def test_operator_override_wins_and_zeroes_baseline(self):
         # Explicit knob short-circuits the estimator; no baseline is charged.
         cfg = SimpleNamespace(

--- a/tests/test_metal_cap_enforcement.py
+++ b/tests/test_metal_cap_enforcement.py
@@ -863,7 +863,10 @@ class TestArchitectureAwareKVEstimate:
         sched = self._sched(cfg)
         uniform = 2 * n * kv * hd * 2
         assert sched._resolve_kv_bytes_per_token() == uniform // 2
-        assert sched._resolve_kv_fixed_baseline_bytes() == 2 * (n // 2) * window * kv * hd * 2
+        assert (
+            sched._resolve_kv_fixed_baseline_bytes()
+            == 2 * (n // 2) * window * kv * hd * 2
+        )
 
     def test_gemma4_sharing_reduces_per_token(self):
         n, n_shared, kv, hd = 35, 20, 1, 128

--- a/tests/test_metal_cap_enforcement.py
+++ b/tests/test_metal_cap_enforcement.py
@@ -895,6 +895,25 @@ class TestArchitectureAwareKVEstimate:
         assert sched._resolve_kv_bytes_per_token() == 42
         assert sched._resolve_kv_fixed_baseline_bytes() == 0
 
+    def test_estimator_failure_preserves_uniform_estimate(self):
+        # If the architecture-aware estimator raises, the scheduler must keep
+        # the already-computed uniform per-token value (zero baseline), NOT
+        # reset admission accounting to 0 (codex round 3 BLOCKING #3).
+        cfg = SimpleNamespace(
+            num_hidden_layers=32,
+            num_key_value_heads=8,
+            head_dim=128,
+            dtype="bfloat16",
+        )
+        sched = self._sched(cfg)
+        with patch(
+            "vllm_mlx.scheduler.estimate_kv_footprint",
+            side_effect=RuntimeError("boom"),
+        ):
+            per_tok = sched._resolve_kv_bytes_per_token()
+        assert per_tok == 2 * 32 * 8 * 128 * 2  # uniform, not 0
+        assert sched._resolve_kv_fixed_baseline_bytes() == 0
+
     def test_magicmock_config_yields_zero_and_no_baseline(self):
         # Bare MagicMock model — int(MagicMock()) path must still yield 0 with
         # no phantom baseline (back-compat for the stub-model unit tests).

--- a/tests/test_metal_cap_enforcement.py
+++ b/tests/test_metal_cap_enforcement.py
@@ -1072,6 +1072,14 @@ class TestArchitectureAwareKVEstimate:
         # sliding layers are excluded from per-token growth (their whole window
         # is a bounded per-sequence baseline, dwarfed by the halved growth over a
         # long generation).
+        #
+        # This test carries its OWN negative control (uniform scheduler, SAME cap,
+        # SAME request → REJECTED) so it proves the admission gate genuinely
+        # consumes the projected KV bytes — not merely that the hybrid helper
+        # returns a smaller number. Without the negative control the positive
+        # "does not raise" assertion would still pass even if
+        # ``_enforce_metal_cap_at_admission`` stopped applying the projection
+        # entirely (codex round 10 test-strength BLOCKING).
         n, kv, hd, window = 24, 8, 64, 128
         layer_types = ["sliding_attention", "full_attention"] * (n // 2)
         cfg = SimpleNamespace(
@@ -1094,15 +1102,57 @@ class TestArchitectureAwareKVEstimate:
         # the sliding layers contribute a bounded whole-window baseline instead
         # of unbounded per-token growth.
         assert arch_projected < uniform_projected
-        # Pick a cap that sits between the two projections: uniform rejects,
-        # arch-aware admits.
+        # Pick a cap that sits STRICTLY BETWEEN the two projections, so the SAME
+        # cap admits the hybrid and rejects the uniform over-count. Concrete
+        # numbers for this config (dtype=bf16, n=24, kv=8, hd=64, window=128,
+        # 16+8000 tokens): uniform_per_tok = 49_152 B; arch per_tok = 24_576 B
+        # (half) + a 6_291_456 B sliding baseline. So arch_projected ≈ 203.3 MB,
+        # uniform_projected ≈ 394.0 MB, and the cap delta above ``active`` is
+        # their midpoint ≈ 298.6 MB — comfortably above arch, comfortably below
+        # uniform.
         active = 1_000_000_000
         cap = active + (arch_projected + uniform_projected) // 2
+        assert active + arch_projected < cap  # hybrid fits under the cap
+        assert active + uniform_projected > cap  # uniform over-count exceeds it
+
+        # POSITIVE: the architecture-aware hybrid scheduler ADMITS the request at
+        # this cap (does not raise), because its reduced projection fits.
         with (
             patch.object(sched, "_resolve_metal_cap_bytes", return_value=cap),
             patch.object(sched, "_current_metal_active_bytes", return_value=active),
         ):
             sched._enforce_metal_cap_at_admission(req)  # must NOT raise
         assert sched.num_metal_cap_violations == 0
-        # Sanity: the uniform over-count would have exceeded the cap.
-        assert active + uniform_projected > cap
+
+        # NEGATIVE CONTROL: a scheduler on the SAME base dims (same num layers /
+        # kv heads / head_dim) but a DENSE config (no ``layer_types`` / no
+        # ``sliding_window``) forces the UNIFORM estimate — no hybrid reduction,
+        # zero baseline — so its projection for the SAME request is exactly
+        # ``uniform_projected``. At the SAME cap that admitted the hybrid, this
+        # uniform scheduler MUST raise ``BackpressureError``. The pair
+        # (uniform → rejected, hybrid → admitted, same cap, same request) is the
+        # real proof that the reduced estimate is what flips admission and that
+        # the gate is actually applying the projected KV bytes.
+        dense_cfg = SimpleNamespace(
+            num_hidden_layers=n,
+            num_key_value_heads=kv,
+            head_dim=hd,
+            dtype="bfloat16",  # NO layer_types / sliding_window → uniform, base 0
+        )
+        dense_sched = self._sched(dense_cfg)
+        dense_req = _make_request(tokens=16)
+        dense_req.sampling_params = SamplingParams(max_tokens=8_000)
+        # The dense scheduler really is on the uniform estimate with no baseline,
+        # so its projection is precisely the uniform over-count that exceeds cap.
+        assert dense_sched._resolve_kv_bytes_per_token() == uniform_per_tok
+        assert dense_sched._resolve_kv_fixed_baseline_bytes() == 0
+        assert dense_sched._estimate_request_kv_bytes(dense_req) == uniform_projected
+        with (
+            patch.object(dense_sched, "_resolve_metal_cap_bytes", return_value=cap),
+            patch.object(
+                dense_sched, "_current_metal_active_bytes", return_value=active
+            ),
+            pytest.raises(BackpressureError, match="D-METAL-CAP"),
+        ):
+            dense_sched._enforce_metal_cap_at_admission(dense_req)
+        assert dense_sched.num_metal_cap_violations == 1

--- a/tests/test_metal_cap_enforcement.py
+++ b/tests/test_metal_cap_enforcement.py
@@ -847,11 +847,10 @@ class TestArchitectureAwareKVEstimate:
         assert sched._resolve_kv_bytes_per_token() == 2 * 32 * 8 * 128 * 2
         assert sched._resolve_kv_fixed_baseline_bytes() == 0
 
-    def test_gpt_oss_hybrid_reduces_per_token_and_caps_sliding(self):
+    def test_gpt_oss_hybrid_reduces_per_token_and_reserves_window(self):
         # ~50% sliding-window layers → unbounded per-token growth halved vs
-        # uniform, and the sliding layers become a window-capped per-token term
-        # (NOT a flat baseline, which would over-charge short requests — codex
-        # round 6 BLOCKING). No recurrent state → zero fixed baseline.
+        # uniform, and the sliding layers reserve their WHOLE window buffer once
+        # per sequence in the fixed baseline (over-count-safe — codex round 9).
         n, kv, hd, window = 24, 8, 64, 128
         layer_types = ["sliding_attention", "full_attention"] * (n // 2)
         cfg = SimpleNamespace(
@@ -865,9 +864,10 @@ class TestArchitectureAwareKVEstimate:
         sched = self._sched(cfg)
         uniform = 2 * n * kv * hd * 2
         assert sched._resolve_kv_bytes_per_token() == uniform // 2
-        assert sched._resolve_kv_fixed_baseline_bytes() == 0
-        assert sched._kv_sliding_per_token_bytes == 2 * (n // 2) * kv * hd * 2
-        assert sched._kv_sliding_window_tokens == window
+        assert (
+            sched._resolve_kv_fixed_baseline_bytes()
+            == 2 * (n // 2) * window * kv * hd * 2
+        )
 
     def test_gemma4_sharing_reduces_per_token(self):
         n, n_shared, kv, hd = 35, 20, 1, 128
@@ -885,16 +885,20 @@ class TestArchitectureAwareKVEstimate:
 
     def test_multimodal_nested_text_config_engages_reduction(self):
         # A multimodal config nests the text-tower dims under ``text_config`` and
-        # the OUTER config carries no ``num_hidden_layers``. The scheduler must
-        # resolve the base dims from the nested config so the hybrid reduction
-        # actually engages end-to-end — not just in the pure estimator (codex
-        # round 8 BLOCKING).
+        # the OUTER config carries a DECOY ``num_hidden_layers`` (the vision-tower
+        # count) that differs from the nested text layer count. The scheduler must
+        # resolve the base dims from the config whose OWN layer_types is valid —
+        # the nested text config, NOT the decoy outer count — so the hybrid
+        # reduction engages end-to-end and the uniform base is not read off the
+        # wrong tower (codex round 8 + round 9 BLOCKING #1).
         n, kv, hd, window = 24, 8, 64, 128
+        vision_layers = 27  # decoy != n
         layer_types = ["sliding_attention", "full_attention"] * (n // 2)
         cfg = SimpleNamespace(
-            # outer multimodal config: vision tower + nested text config, NO
-            # top-level num_hidden_layers.
-            vision_config=SimpleNamespace(num_hidden_layers=27),
+            # DECOY: the outer config exposes the vision-tower layer count with
+            # NO valid text layer_types of its own.
+            num_hidden_layers=vision_layers,
+            vision_config=SimpleNamespace(num_hidden_layers=vision_layers),
             text_config=SimpleNamespace(
                 num_hidden_layers=n,
                 num_key_value_heads=kv,
@@ -905,12 +909,14 @@ class TestArchitectureAwareKVEstimate:
             dtype="bfloat16",
         )
         sched = self._sched(cfg)
-        uniform = 2 * n * kv * hd * 2
-        # Reduction engaged: unbounded growth halved, sliding term populated.
+        uniform = 2 * n * kv * hd * 2  # text dims (n=24), NOT the decoy 27
+        # Reduction engaged off the nested text dims: growth halved, whole window
+        # reserved in the baseline.
         assert sched._resolve_kv_bytes_per_token() == uniform // 2
-        assert sched._resolve_kv_fixed_baseline_bytes() == 0
-        assert sched._kv_sliding_per_token_bytes == 2 * (n // 2) * kv * hd * 2
-        assert sched._kv_sliding_window_tokens == window
+        assert (
+            sched._resolve_kv_fixed_baseline_bytes()
+            == 2 * (n // 2) * window * kv * hd * 2
+        )
 
     def test_nested_config_without_layer_types_stays_byte_identical(self):
         # BYTE-IDENTICAL guard: a multimodal config whose text_config carries NO
@@ -931,7 +937,6 @@ class TestArchitectureAwareKVEstimate:
         sched = self._sched(cfg)
         assert sched._resolve_kv_bytes_per_token() == 0
         assert sched._resolve_kv_fixed_baseline_bytes() == 0
-        assert sched._kv_sliding_per_token_bytes == 0
 
     def test_operator_override_wins_and_zeroes_baseline(self):
         # Explicit knob short-circuits the estimator; no baseline is charged.
@@ -944,10 +949,8 @@ class TestArchitectureAwareKVEstimate:
         )
         sched = self._sched(cfg, kv_bytes_override=42)
         assert sched._resolve_kv_bytes_per_token() == 42
-        assert sched._resolve_kv_fixed_baseline_bytes() == 0
         # The override short-circuits ALL architecture-aware refinement.
-        assert sched._kv_sliding_per_token_bytes == 0
-        assert sched._kv_sliding_window_tokens == 0
+        assert sched._resolve_kv_fixed_baseline_bytes() == 0
 
     def test_estimator_failure_preserves_uniform_estimate(self):
         # If the architecture-aware estimator raises, the scheduler must keep
@@ -1007,15 +1010,15 @@ class TestArchitectureAwareKVEstimate:
         req.sampling_params = SamplingParams(max_tokens=50)
         growth = sched._resolve_kv_bytes_per_token()
         baseline = sched._resolve_kv_fixed_baseline_bytes()
-        assert baseline > 0
-        assert sched._kv_sliding_per_token_bytes == 0  # no sliding layers
+        assert baseline > 0  # recurrent state reserved
         assert sched._estimate_request_kv_bytes(req) == baseline + growth * (100 + 50)
 
-    def test_estimate_request_sliding_prefill_peak_and_window_cap(self):
-        # A GPT-OSS-style hybrid: sliding layers are charged
-        # ``sliding_per_token × max(prompt_tokens, min(tokens, window))`` — the
-        # window-capped decode steady state, floored at the full prompt to cover
-        # the transient prefill peak (codex round 6 + round 7 BLOCKING #3).
+    def test_estimate_request_charges_whole_window_baseline(self):
+        # A GPT-OSS-style hybrid: the request projection is
+        # ``fixed_baseline + growth * tokens`` where the fixed baseline holds the
+        # WHOLE sliding-window buffer (once per sequence, token-independent) —
+        # the over-count-safe upper bound (codex round 9 BLOCKING). Charged
+        # identically regardless of prompt/decode split for the same token total.
         n, kv, hd, window = 24, 8, 64, 128
         layer_types = ["sliding_attention", "full_attention"] * (n // 2)
         cfg = SimpleNamespace(
@@ -1028,54 +1031,33 @@ class TestArchitectureAwareKVEstimate:
         )
         sched = self._sched(cfg)
         growth = sched._resolve_kv_bytes_per_token()
-        assert sched._resolve_kv_fixed_baseline_bytes() == 0
-        sliding = sched._kv_sliding_per_token_bytes
-        uniform_per_tok = 2 * n * kv * hd * 2
+        baseline = sched._resolve_kv_fixed_baseline_bytes()
+        assert baseline == 2 * (n // 2) * window * kv * hd * 2
+        per_layer = 2 * kv * hd * 2
+        n_full = n // 2
+        n_sliding = n // 2
 
-        # (a) Short request (prompt + budget below the window): sliding charged
-        # its actual tokens → byte-identical to the historical uniform figure.
-        short = _make_request(tokens=40)
-        short.sampling_params = SamplingParams(max_tokens=20)
-        short_tokens = 60
-        assert sched._estimate_request_kv_bytes(short) == uniform_per_tok * short_tokens
-        assert (
-            sched._estimate_request_kv_bytes(short)
-            == growth * short_tokens + sliding * short_tokens
-        )
-
-        # (b) Decode-heavy request (tiny prompt, long generation): the sliding
-        # term is CAPPED at the window — the headline reduction.
-        decode = _make_request(tokens=16)
-        decode.sampling_params = SamplingParams(max_tokens=8_000)
-        decode_tokens = 8_016
-        assert (
-            sched._estimate_request_kv_bytes(decode)
-            == growth * decode_tokens + sliding * window
-        )
-        assert (
-            sched._estimate_request_kv_bytes(decode) < uniform_per_tok * decode_tokens
-        )
-
-        # (c) Large-prompt request (prompt itself exceeds the window): the
-        # sliding term is NOT capped at the window — it is floored at the full
-        # prompt to cover the transient prefill allocation (never under-count).
-        big_prompt = _make_request(tokens=1_000)
-        big_prompt.sampling_params = SamplingParams(max_tokens=50)
-        assert (
-            sched._estimate_request_kv_bytes(big_prompt)
-            == growth * 1_050 + sliding * 1_000
-        )
-        # Strictly MORE than a naive window-cap would have projected — that gap
-        # is exactly the prefill peak the round-7 fix stops under-counting.
-        assert (
-            sched._estimate_request_kv_bytes(big_prompt)
-            > growth * 1_050 + sliding * window
-        )
+        for prompt, budget in ((40, 20), (16, 8_000), (8_000, 50)):
+            req = _make_request(tokens=prompt)
+            req.sampling_params = SamplingParams(max_tokens=budget)
+            tokens = prompt + budget
+            projected = sched._estimate_request_kv_bytes(req)
+            assert projected == baseline + growth * tokens
+            # Never under-counts the true footprint of the counted layers: the
+            # full layers grow exactly per token and the whole-window baseline is
+            # >= the sliding layers' min(tokens, window) peak.
+            true_footprint = (
+                n_full * tokens * per_layer
+                + n_sliding * min(tokens, window) * per_layer
+            )
+            assert projected >= true_footprint
 
     def test_hybrid_admitted_where_uniform_would_reject(self):
         # The headline win: a GPT-OSS-style hybrid whose uniform per-token
         # over-count would trip the projection gate is ADMITTED once the
-        # sliding layers are correctly excluded from per-token growth.
+        # sliding layers are excluded from per-token growth (their whole window
+        # is a bounded per-sequence baseline, dwarfed by the halved growth over a
+        # long generation).
         n, kv, hd, window = 24, 8, 64, 128
         layer_types = ["sliding_attention", "full_attention"] * (n // 2)
         cfg = SimpleNamespace(
@@ -1095,8 +1077,8 @@ class TestArchitectureAwareKVEstimate:
         uniform_projected = uniform_per_tok * tokens
         # Arch-aware projection is strictly smaller than the uniform one for a
         # large token budget: the full layers grow at half the uniform rate and
-        # the sliding layers are capped at the window instead of the full token
-        # count.
+        # the sliding layers contribute a bounded whole-window baseline instead
+        # of unbounded per-token growth.
         assert arch_projected < uniform_projected
         # Pick a cap that sits between the two projections: uniform rejects,
         # arch-aware admits.
@@ -1110,43 +1092,3 @@ class TestArchitectureAwareKVEstimate:
         assert sched.num_metal_cap_violations == 0
         # Sanity: the uniform over-count would have exceeded the cap.
         assert active + uniform_projected > cap
-
-    def test_large_prompt_prefill_peak_is_rejected(self):
-        # codex round 7 BLOCKING #3: a prompt LARGER than the sliding window can
-        # transiently allocate the whole prompt's KV during prefill before the
-        # rotating cache trims. The admission gate must charge that prefill peak
-        # (prompt floor, not the window cap) so it REJECTS a request that would
-        # OOM during prefill — a naive window-cap would have wrongly admitted it.
-        n, kv, hd, window = 24, 8, 64, 128
-        layer_types = ["sliding_attention", "full_attention"] * (n // 2)
-        cfg = SimpleNamespace(
-            num_hidden_layers=n,
-            num_key_value_heads=kv,
-            head_dim=hd,
-            layer_types=layer_types,
-            sliding_window=window,
-            dtype="bfloat16",
-        )
-        sched = self._sched(cfg)
-        growth = sched._resolve_kv_bytes_per_token()
-        sliding = sched._kv_sliding_per_token_bytes
-        big_prompt = _make_request(tokens=8_000)
-        big_prompt.sampling_params = SamplingParams(max_tokens=50)
-        total = 8_050
-        prefill_aware = sched._estimate_request_kv_bytes(big_prompt)
-        naive_window = growth * total + sliding * window
-        assert prefill_aware == growth * total + sliding * 8_000
-        assert prefill_aware > naive_window  # the peak the fix stops dropping
-        # A cap between the two: the naive window-cap would admit, the
-        # prefill-aware projection must reject.
-        active = 1_000_000_000
-        cap = active + (naive_window + prefill_aware) // 2
-        with (
-            patch.object(sched, "_resolve_metal_cap_bytes", return_value=cap),
-            patch.object(sched, "_current_metal_active_bytes", return_value=active),
-            pytest.raises(BackpressureError, match="D-METAL-CAP"),
-        ):
-            sched._enforce_metal_cap_at_admission(big_prompt)
-        assert sched.num_metal_cap_violations == 1
-        # Sanity: the naive window-cap would have slipped under the cap.
-        assert active + naive_window < cap

--- a/tests/test_metal_cap_enforcement.py
+++ b/tests/test_metal_cap_enforcement.py
@@ -34,6 +34,18 @@ import pytest
 from vllm_mlx.request import Request, SamplingParams
 from vllm_mlx.scheduler import BackpressureError, Scheduler, SchedulerConfig
 
+# Rotating-cache capacity granularity — mirrors kv_estimation's
+# ``_ROTATING_CACHE_STEP`` / ``_ROTATING_CACHE_KEEP`` (mlx_lm's
+# ``RotatingKVCache.step = 256`` and ``make_prompt_cache(... keep=4)``). A
+# sliding-window layer reserves ``ceil((window + keep) / step) * step`` slots.
+_STEP = 256
+_KEEP = 4
+
+
+def _slots(window: int) -> int:
+    """Step-rounded, sink-inclusive rotating-cache capacity for ``window``."""
+    return ((window + _KEEP + _STEP - 1) // _STEP) * _STEP
+
 
 def _make_request(rid: str = "req-1", tokens: int = 16) -> Request:
     """Tiny synthetic request — only ``request_id`` and
@@ -849,8 +861,9 @@ class TestArchitectureAwareKVEstimate:
 
     def test_gpt_oss_hybrid_reduces_per_token_and_reserves_window(self):
         # ~50% sliding-window layers → unbounded per-token growth halved vs
-        # uniform, and the sliding layers reserve their WHOLE window buffer once
-        # per sequence in the fixed baseline (over-count-safe — codex round 9).
+        # uniform, and the sliding layers reserve their WHOLE rotating-cache
+        # buffer once per sequence in the fixed baseline — the step-rounded,
+        # sink-inclusive capacity (over-count-safe — codex round 10).
         n, kv, hd, window = 24, 8, 64, 128
         layer_types = ["sliding_attention", "full_attention"] * (n // 2)
         cfg = SimpleNamespace(
@@ -866,7 +879,7 @@ class TestArchitectureAwareKVEstimate:
         assert sched._resolve_kv_bytes_per_token() == uniform // 2
         assert (
             sched._resolve_kv_fixed_baseline_bytes()
-            == 2 * (n // 2) * window * kv * hd * 2
+            == 2 * (n // 2) * _slots(window) * kv * hd * 2
         )
 
     def test_gemma4_sharing_reduces_per_token(self):
@@ -910,12 +923,12 @@ class TestArchitectureAwareKVEstimate:
         )
         sched = self._sched(cfg)
         uniform = 2 * n * kv * hd * 2  # text dims (n=24), NOT the decoy 27
-        # Reduction engaged off the nested text dims: growth halved, whole window
-        # reserved in the baseline.
+        # Reduction engaged off the nested text dims: growth halved, whole
+        # rotating-cache capacity reserved in the baseline.
         assert sched._resolve_kv_bytes_per_token() == uniform // 2
         assert (
             sched._resolve_kv_fixed_baseline_bytes()
-            == 2 * (n // 2) * window * kv * hd * 2
+            == 2 * (n // 2) * _slots(window) * kv * hd * 2
         )
 
     def test_nested_config_without_layer_types_stays_byte_identical(self):
@@ -1016,9 +1029,10 @@ class TestArchitectureAwareKVEstimate:
     def test_estimate_request_charges_whole_window_baseline(self):
         # A GPT-OSS-style hybrid: the request projection is
         # ``fixed_baseline + growth * tokens`` where the fixed baseline holds the
-        # WHOLE sliding-window buffer (once per sequence, token-independent) —
-        # the over-count-safe upper bound (codex round 9 BLOCKING). Charged
-        # identically regardless of prompt/decode split for the same token total.
+        # WHOLE rotating-cache buffer (once per sequence, token-independent) — the
+        # step-rounded, sink-inclusive capacity, an over-count-safe upper bound
+        # (codex round 10 BLOCKING). Charged identically regardless of
+        # prompt/decode split for the same token total.
         n, kv, hd, window = 24, 8, 64, 128
         layer_types = ["sliding_attention", "full_attention"] * (n // 2)
         cfg = SimpleNamespace(
@@ -1032,7 +1046,7 @@ class TestArchitectureAwareKVEstimate:
         sched = self._sched(cfg)
         growth = sched._resolve_kv_bytes_per_token()
         baseline = sched._resolve_kv_fixed_baseline_bytes()
-        assert baseline == 2 * (n // 2) * window * kv * hd * 2
+        assert baseline == 2 * (n // 2) * _slots(window) * kv * hd * 2
         per_layer = 2 * kv * hd * 2
         n_full = n // 2
         n_sliding = n // 2

--- a/tests/test_metal_cap_enforcement.py
+++ b/tests/test_metal_cap_enforcement.py
@@ -36,15 +36,20 @@ from vllm_mlx.scheduler import BackpressureError, Scheduler, SchedulerConfig
 
 # Rotating-cache capacity granularity — mirrors kv_estimation's
 # ``_ROTATING_CACHE_STEP`` / ``_ROTATING_CACHE_KEEP`` (mlx_lm's
-# ``RotatingKVCache.step = 256`` and ``make_prompt_cache(... keep=4)``). A
-# sliding-window layer reserves ``ceil((window + keep) / step) * step`` slots.
+# ``RotatingKVCache.step = 256``; ``KEEP = 4`` is the largest keep any shipped
+# construction uses). A sliding layer's per-request slot count is
+# ``ceil((min(T, window) + keep) / step) * step`` — sublinear in the token
+# budget, capped at the full window.
 _STEP = 256
 _KEEP = 4
 
 
-def _slots(window: int) -> int:
-    """Step-rounded, sink-inclusive rotating-cache capacity for ``window``."""
-    return ((window + _KEEP + _STEP - 1) // _STEP) * _STEP
+def _slots(window: int, tokens: int) -> int:
+    """Reference re-implementation of ``kv_estimation.rotating_cache_slots``."""
+    if window <= 0 or tokens <= 0:
+        return 0
+    effective = min(tokens, window) + _KEEP
+    return ((effective + _STEP - 1) // _STEP) * _STEP
 
 
 def _make_request(rid: str = "req-1", tokens: int = 16) -> Request:
@@ -859,11 +864,11 @@ class TestArchitectureAwareKVEstimate:
         assert sched._resolve_kv_bytes_per_token() == 2 * 32 * 8 * 128 * 2
         assert sched._resolve_kv_fixed_baseline_bytes() == 0
 
-    def test_gpt_oss_hybrid_reduces_per_token_and_reserves_window(self):
+    def test_gpt_oss_hybrid_reduces_per_token_and_exposes_slot_term(self):
         # ~50% sliding-window layers → unbounded per-token growth halved vs
-        # uniform, and the sliding layers reserve their WHOLE rotating-cache
-        # buffer once per sequence in the fixed baseline — the step-rounded,
-        # sink-inclusive capacity (over-count-safe — codex round 10).
+        # uniform, and the sliding layers are exposed as a request-dependent slot
+        # term (per-slot bytes + shared window), NOT a fixed baseline (codex round
+        # 11 BLOCKING #1: a flat whole-window baseline over-counts short requests).
         n, kv, hd, window = 24, 8, 64, 128
         layer_types = ["sliding_attention", "full_attention"] * (n // 2)
         cfg = SimpleNamespace(
@@ -877,10 +882,10 @@ class TestArchitectureAwareKVEstimate:
         sched = self._sched(cfg)
         uniform = 2 * n * kv * hd * 2
         assert sched._resolve_kv_bytes_per_token() == uniform // 2
-        assert (
-            sched._resolve_kv_fixed_baseline_bytes()
-            == 2 * (n // 2) * _slots(window) * kv * hd * 2
-        )
+        # Sliding footprint is request-dependent → not in the fixed baseline.
+        assert sched._resolve_kv_fixed_baseline_bytes() == 0
+        assert sched._kv_sliding_slot_bytes == 2 * (n // 2) * kv * hd * 2
+        assert sched._kv_sliding_window == window
 
     def test_gemma4_sharing_reduces_per_token(self):
         n, n_shared, kv, hd = 35, 20, 1, 128
@@ -923,13 +928,12 @@ class TestArchitectureAwareKVEstimate:
         )
         sched = self._sched(cfg)
         uniform = 2 * n * kv * hd * 2  # text dims (n=24), NOT the decoy 27
-        # Reduction engaged off the nested text dims: growth halved, whole
-        # rotating-cache capacity reserved in the baseline.
+        # Reduction engaged off the nested text dims: growth halved, sliding
+        # exposed as the request-dependent slot term.
         assert sched._resolve_kv_bytes_per_token() == uniform // 2
-        assert (
-            sched._resolve_kv_fixed_baseline_bytes()
-            == 2 * (n // 2) * _slots(window) * kv * hd * 2
-        )
+        assert sched._resolve_kv_fixed_baseline_bytes() == 0
+        assert sched._kv_sliding_slot_bytes == 2 * (n // 2) * kv * hd * 2
+        assert sched._kv_sliding_window == window
 
     def test_nested_config_without_layer_types_stays_byte_identical(self):
         # BYTE-IDENTICAL guard: a multimodal config whose text_config carries NO
@@ -962,8 +966,11 @@ class TestArchitectureAwareKVEstimate:
         )
         sched = self._sched(cfg, kv_bytes_override=42)
         assert sched._resolve_kv_bytes_per_token() == 42
-        # The override short-circuits ALL architecture-aware refinement.
+        # The override short-circuits ALL architecture-aware refinement — no
+        # baseline and no sliding term.
         assert sched._resolve_kv_fixed_baseline_bytes() == 0
+        assert sched._kv_sliding_slot_bytes == 0
+        assert sched._kv_sliding_window == 0
 
     def test_estimator_failure_preserves_uniform_estimate(self):
         # If the architecture-aware estimator raises, the scheduler must keep
@@ -1026,13 +1033,12 @@ class TestArchitectureAwareKVEstimate:
         assert baseline > 0  # recurrent state reserved
         assert sched._estimate_request_kv_bytes(req) == baseline + growth * (100 + 50)
 
-    def test_estimate_request_charges_whole_window_baseline(self):
+    def test_estimate_request_charges_per_request_sliding_term(self):
         # A GPT-OSS-style hybrid: the request projection is
-        # ``fixed_baseline + growth * tokens`` where the fixed baseline holds the
-        # WHOLE rotating-cache buffer (once per sequence, token-independent) — the
-        # step-rounded, sink-inclusive capacity, an over-count-safe upper bound
-        # (codex round 10 BLOCKING). Charged identically regardless of
-        # prompt/decode split for the same token total.
+        # ``growth * T + slot_bytes * rotating_cache_slots(window, T)`` — the
+        # sliding term GROWS with the token budget up to the full window (codex
+        # round 11 BLOCKING #1), not a flat whole-window baseline. It is charged
+        # identically regardless of prompt/decode split for the same token total.
         n, kv, hd, window = 24, 8, 64, 128
         layer_types = ["sliding_attention", "full_attention"] * (n // 2)
         cfg = SimpleNamespace(
@@ -1045,8 +1051,9 @@ class TestArchitectureAwareKVEstimate:
         )
         sched = self._sched(cfg)
         growth = sched._resolve_kv_bytes_per_token()
-        baseline = sched._resolve_kv_fixed_baseline_bytes()
-        assert baseline == 2 * (n // 2) * _slots(window) * kv * hd * 2
+        slot_bytes = sched._kv_sliding_slot_bytes
+        assert slot_bytes == 2 * (n // 2) * kv * hd * 2
+        assert sched._resolve_kv_fixed_baseline_bytes() == 0
         per_layer = 2 * kv * hd * 2
         n_full = n // 2
         n_sliding = n // 2
@@ -1056,15 +1063,103 @@ class TestArchitectureAwareKVEstimate:
             req.sampling_params = SamplingParams(max_tokens=budget)
             tokens = prompt + budget
             projected = sched._estimate_request_kv_bytes(req)
-            assert projected == baseline + growth * tokens
-            # Never under-counts the true footprint of the counted layers: the
-            # full layers grow exactly per token and the whole-window baseline is
-            # >= the sliding layers' min(tokens, window) peak.
+            assert projected == growth * tokens + slot_bytes * _slots(window, tokens)
+            # Never under-counts the true footprint of the counted layers: full
+            # layers grow exactly per token; the sliding slot count is >= the
+            # sliding layers' min(tokens, window) peak.
             true_footprint = (
                 n_full * tokens * per_layer
                 + n_sliding * min(tokens, window) * per_layer
             )
             assert projected >= true_footprint
+
+    def test_short_request_not_over_charged_full_window(self):
+        # The codex round 11 win end-to-end: a SHORT request (T=1) against a big
+        # window is charged only ONE step block for the sliding layers, far below
+        # a whole-window baseline — so the D-METAL-CAP gate stops spuriously
+        # rejecting short requests a flat baseline would have rejected.
+        n, kv, hd, window = 8, 4, 64, 4096
+        cfg = SimpleNamespace(
+            num_hidden_layers=n,
+            num_key_value_heads=kv,
+            head_dim=hd,
+            layer_types=["sliding_attention"] * n,
+            sliding_window=window,
+            dtype="bfloat16",
+        )
+        sched = self._sched(cfg)
+        assert sched._resolve_kv_bytes_per_token() == 0  # all sliding, no growth
+        slot_bytes = sched._kv_sliding_slot_bytes
+        req = _make_request(tokens=1)
+        req.sampling_params = SamplingParams(max_tokens=0)
+        short = sched._estimate_request_kv_bytes(req)
+        assert short == slot_bytes * 256  # one step block, NOT the whole window
+        assert short < slot_bytes * _slots(window, window)  # << full-window charge
+
+    def test_dict_config_behaves_identically_to_attribute_config(self):
+        # Finding 3 (codex round 11 NIT): ``estimate_kv_footprint`` supports dict
+        # configs, so the scheduler wiring (struct selection, base-dim reads, AND
+        # dtype inference) must resolve dict-backed configs IDENTICALLY to
+        # attribute configs — bare ``getattr`` on a dict returns ``None`` for
+        # every field and would collapse the estimate to 0 (or fall to the fp32
+        # dtype default).
+        n, kv, hd, window = 24, 8, 64, 128
+        layer_types = ["sliding_attention", "full_attention"] * (n // 2)
+        fields = dict(
+            num_hidden_layers=n,
+            num_key_value_heads=kv,
+            head_dim=hd,
+            layer_types=layer_types,
+            sliding_window=window,
+            dtype="bfloat16",
+        )
+        attr_sched = self._sched(SimpleNamespace(**fields))
+        dict_sched = self._sched(dict(fields))
+        assert (
+            dict_sched._resolve_kv_bytes_per_token()
+            == attr_sched._resolve_kv_bytes_per_token()
+        )
+        assert dict_sched._kv_sliding_slot_bytes == attr_sched._kv_sliding_slot_bytes
+        assert dict_sched._kv_sliding_window == attr_sched._kv_sliding_window
+        assert (
+            dict_sched._resolve_kv_fixed_baseline_bytes()
+            == attr_sched._resolve_kv_fixed_baseline_bytes()
+        )
+        # Identical per-request projection too (dtype resolved to bf16, not fp32).
+        req = _make_request(tokens=100)
+        req.sampling_params = SamplingParams(max_tokens=200)
+        assert dict_sched._estimate_request_kv_bytes(
+            req
+        ) == attr_sched._estimate_request_kv_bytes(req)
+
+    def test_orphan_borrower_charged_not_zeroed_end_to_end(self):
+        # Finding 2 (codex round 11 BLOCKING #2) through the scheduler: a config
+        # whose LAST-N borrowers include one whose attention type has no producer
+        # below the split — the exact per-index map (mirrored from
+        # ``models/gemma4_vendored/language.py``) zeroes the mappable borrower and
+        # charges the orphan its own footprint. Producers [full, full]; borrowers
+        # [full (maps → zeroed), sliding (orphan → charged as a slot term)].
+        n, kv, hd, window = 4, 8, 64, 128
+        layer_types = [
+            "full_attention",
+            "full_attention",
+            "full_attention",  # borrower idx2 → maps to a full producer → zeroed
+            "sliding_attention",  # borrower idx3 → orphan → charged
+        ]
+        cfg = SimpleNamespace(
+            num_hidden_layers=n,
+            num_key_value_heads=kv,
+            head_dim=hd,
+            layer_types=layer_types,
+            num_kv_shared_layers=2,
+            sliding_window=window,
+            dtype="bfloat16",
+        )
+        sched = self._sched(cfg)
+        # idx0, idx1 full grow per token; idx2 zeroed; idx3 orphan sliding charged.
+        assert sched._resolve_kv_bytes_per_token() == 2 * 2 * kv * hd * 2
+        assert sched._kv_sliding_slot_bytes == 2 * 1 * kv * hd * 2
+        assert sched._kv_sliding_window == window
 
     def test_hybrid_admitted_where_uniform_would_reject(self):
         # The headline win: a GPT-OSS-style hybrid whose uniform per-token
@@ -1099,8 +1194,8 @@ class TestArchitectureAwareKVEstimate:
         uniform_projected = uniform_per_tok * tokens
         # Arch-aware projection is strictly smaller than the uniform one for a
         # large token budget: the full layers grow at half the uniform rate and
-        # the sliding layers contribute a bounded whole-window baseline instead
-        # of unbounded per-token growth.
+        # the sliding layers contribute a bounded per-request slot term (capped at
+        # the full window) instead of unbounded per-token growth.
         assert arch_projected < uniform_projected
         # Pick a cap that sits STRICTLY BETWEEN the two projections, so the SAME
         # cap admits the hybrid and rejects the uniform over-count. Concrete

--- a/tests/test_metal_cap_enforcement.py
+++ b/tests/test_metal_cap_enforcement.py
@@ -847,9 +847,11 @@ class TestArchitectureAwareKVEstimate:
         assert sched._resolve_kv_bytes_per_token() == 2 * 32 * 8 * 128 * 2
         assert sched._resolve_kv_fixed_baseline_bytes() == 0
 
-    def test_gpt_oss_hybrid_reduces_per_token_and_sets_baseline(self):
-        # ~50% sliding-window layers → per-token growth halved vs uniform, and
-        # the window footprint lands in the per-sequence fixed baseline.
+    def test_gpt_oss_hybrid_reduces_per_token_and_caps_sliding(self):
+        # ~50% sliding-window layers → unbounded per-token growth halved vs
+        # uniform, and the sliding layers become a window-capped per-token term
+        # (NOT a flat baseline, which would over-charge short requests — codex
+        # round 6 BLOCKING). No recurrent state → zero fixed baseline.
         n, kv, hd, window = 24, 8, 64, 128
         layer_types = ["sliding_attention", "full_attention"] * (n // 2)
         cfg = SimpleNamespace(
@@ -863,10 +865,9 @@ class TestArchitectureAwareKVEstimate:
         sched = self._sched(cfg)
         uniform = 2 * n * kv * hd * 2
         assert sched._resolve_kv_bytes_per_token() == uniform // 2
-        assert (
-            sched._resolve_kv_fixed_baseline_bytes()
-            == 2 * (n // 2) * window * kv * hd * 2
-        )
+        assert sched._resolve_kv_fixed_baseline_bytes() == 0
+        assert sched._kv_sliding_per_token_bytes == 2 * (n // 2) * kv * hd * 2
+        assert sched._kv_sliding_window_tokens == window
 
     def test_gemma4_sharing_reduces_per_token(self):
         n, n_shared, kv, hd = 35, 20, 1, 128
@@ -894,6 +895,9 @@ class TestArchitectureAwareKVEstimate:
         sched = self._sched(cfg, kv_bytes_override=42)
         assert sched._resolve_kv_bytes_per_token() == 42
         assert sched._resolve_kv_fixed_baseline_bytes() == 0
+        # The override short-circuits ALL architecture-aware refinement.
+        assert sched._kv_sliding_per_token_bytes == 0
+        assert sched._kv_sliding_window_tokens == 0
 
     def test_estimator_failure_preserves_uniform_estimate(self):
         # If the architecture-aware estimator raises, the scheduler must keep
@@ -930,7 +934,37 @@ class TestArchitectureAwareKVEstimate:
         assert sched._resolve_kv_bytes_per_token() == 0
         assert sched._resolve_kv_fixed_baseline_bytes() == 0
 
-    def test_estimate_request_charges_baseline_plus_growth(self):
+    def test_estimate_request_charges_recurrent_baseline_plus_growth(self):
+        # A GatedDeltaNet hybrid: the recurrent state is a real per-sequence
+        # fixed baseline (token-independent), charged once on top of the
+        # full-attention layers' per-token growth.
+        n, kv, hd = 16, 8, 64
+        layer_types = ["linear_attention"] * (n - 4) + ["full_attention"] * 4
+        cfg = SimpleNamespace(
+            num_hidden_layers=n,
+            num_key_value_heads=kv,
+            head_dim=hd,
+            layer_types=layer_types,
+            linear_num_value_heads=32,
+            linear_num_key_heads=16,
+            linear_key_head_dim=128,
+            linear_value_head_dim=128,
+            linear_conv_kernel_dim=4,
+            dtype="bfloat16",
+        )
+        sched = self._sched(cfg)
+        req = _make_request(tokens=100)
+        req.sampling_params = SamplingParams(max_tokens=50)
+        growth = sched._resolve_kv_bytes_per_token()
+        baseline = sched._resolve_kv_fixed_baseline_bytes()
+        assert baseline > 0
+        assert sched._kv_sliding_per_token_bytes == 0  # no sliding layers
+        assert sched._estimate_request_kv_bytes(req) == baseline + growth * (100 + 50)
+
+    def test_estimate_request_caps_sliding_term_at_window(self):
+        # A GPT-OSS-style hybrid: the sliding term is charged
+        # ``sliding_per_token × min(tokens, window)`` — capped at the window for
+        # a long request, NOT a flat full-window baseline (codex round 6).
         n, kv, hd, window = 24, 8, 64, 128
         layer_types = ["sliding_attention", "full_attention"] * (n // 2)
         cfg = SimpleNamespace(
@@ -942,12 +976,34 @@ class TestArchitectureAwareKVEstimate:
             dtype="bfloat16",
         )
         sched = self._sched(cfg)
-        req = _make_request(tokens=100)
-        req.sampling_params = SamplingParams(max_tokens=50)
         growth = sched._resolve_kv_bytes_per_token()
-        baseline = sched._resolve_kv_fixed_baseline_bytes()
-        assert baseline > 0
-        assert sched._estimate_request_kv_bytes(req) == baseline + growth * (100 + 50)
+        assert sched._resolve_kv_fixed_baseline_bytes() == 0
+        sliding = sched._kv_sliding_per_token_bytes
+
+        # Short request (below the window): sliding charged its actual tokens →
+        # byte-identical to the historical uniform figure, no over-charge.
+        short = _make_request(tokens=40)
+        short.sampling_params = SamplingParams(max_tokens=20)
+        short_tokens = 60
+        uniform_per_tok = 2 * n * kv * hd * 2
+        assert sched._estimate_request_kv_bytes(short) == uniform_per_tok * short_tokens
+        assert (
+            sched._estimate_request_kv_bytes(short)
+            == growth * short_tokens + sliding * short_tokens
+        )
+
+        # Long request (past the window): sliding capped at the window.
+        long_req = _make_request(tokens=1000)
+        long_req.sampling_params = SamplingParams(max_tokens=1000)
+        long_tokens = 2000
+        assert (
+            sched._estimate_request_kv_bytes(long_req)
+            == growth * long_tokens + sliding * window
+        )
+        # And strictly below what the uniform over-count would have projected.
+        assert (
+            sched._estimate_request_kv_bytes(long_req) < uniform_per_tok * long_tokens
+        )
 
     def test_hybrid_admitted_where_uniform_would_reject(self):
         # The headline win: a GPT-OSS-style hybrid whose uniform per-token
@@ -971,8 +1027,9 @@ class TestArchitectureAwareKVEstimate:
         arch_projected = sched._estimate_request_kv_bytes(req)
         uniform_projected = uniform_per_tok * tokens
         # Arch-aware projection is strictly smaller than the uniform one for a
-        # large token budget (the fixed window baseline is dwarfed by the
-        # halved per-token growth × tokens).
+        # large token budget: the full layers grow at half the uniform rate and
+        # the sliding layers are capped at the window instead of the full token
+        # count.
         assert arch_projected < uniform_projected
         # Pick a cap that sits between the two projections: uniform rejects,
         # arch-aware admits.

--- a/vllm_mlx/kv_estimation.py
+++ b/vllm_mlx/kv_estimation.py
@@ -99,11 +99,22 @@ from typing import Any
 # strings the engine actually ships (Gemma-4 / GPT-OSS ``sliding_attention`` +
 # ``full_attention``; Qwen3.5/3.6 GatedDeltaNet ``linear_attention``; Mamba
 # stacks) plus their common upstream aliases.
-_RECURRENT_TYPES: frozenset[str] = frozenset(
+# GatedDeltaNet (Qwen3-Next / Qwen3.5 / Qwen3.6) ships its linear-attention
+# layers under the canonical ``linear_attention`` type plus these upstream
+# aliases. ALL of them must route to ``_gateddeltanet_state_bytes`` — a name
+# that classifies as recurrent (zero per-token growth) but whose state we cannot
+# size would fall back to full-growth and lose the reduction this module exists
+# to deliver (codex round 5 BLOCKING). Keeping the sizer's dispatch keyed on the
+# same set the classifier uses prevents that drift.
+_GATEDDELTANET_TYPES: frozenset[str] = frozenset(
     {
         "linear_attention",
         "gated_delta_net",
         "gated_deltanet",
+    }
+)
+_RECURRENT_TYPES: frozenset[str] = _GATEDDELTANET_TYPES | frozenset(
+    {
         "mamba",
         "mamba2",
         "recurrent",
@@ -299,11 +310,17 @@ def _recurrent_state_bytes(struct: Any, layer_type: str) -> int | None:
     BLOCKING #2). Returns ``None`` (→ caller charges full per-token growth) for
     any family we cannot size exactly.
 
+    Every GatedDeltaNet alias the classifier treats as recurrent
+    (``_GATEDDELTANET_TYPES``: ``linear_attention`` + the ``gated_delta_net`` /
+    ``gated_deltanet`` upstream spellings) routes to the same sizer, so a config
+    that names its linear layers with an alias still gets the reduction rather
+    than silently reverting to full per-token growth (codex round 5 BLOCKING).
+
     The returned term is a per-sequence constant (it does not grow with
     generated tokens), so it lands in the fixed baseline, never in per-token
     growth.
     """
-    if layer_type == "linear_attention":
+    if layer_type in _GATEDDELTANET_TYPES:
         return _gateddeltanet_state_bytes(struct)
     if layer_type in ("mamba", "mamba2"):
         return _mamba_state_bytes(struct)

--- a/vllm_mlx/kv_estimation.py
+++ b/vllm_mlx/kv_estimation.py
@@ -36,14 +36,17 @@ This module computes an accurate footprint by classifying each layer:
 
 ``fixed_baseline_bytes``
     Charged once per sequence, independent of the token budget:
-    ``2 * dtype_bytes * Σ_sliding (window * kv_heads_L * head_dim_L)`` — the
-    WHOLE rotating-window buffer of each sliding-window layer (an over-count-safe
-    upper bound: a rotating/paged cache allocates in block increments and may
-    retain sink positions, so the buffer can reach — but never exceed — the full
-    window) — plus the conservative fixed recurrent state of each sizeable
-    recurrent layer. Even at the whole window this is a massive reduction vs
-    unbounded per-token growth, because the window is bounded (e.g. 512-4096)
-    while generation is not.
+    ``2 * dtype_bytes * Σ_sliding (slots * kv_heads_L * head_dim_L)`` — the WHOLE
+    rotating-cache buffer of each sliding-window layer, where ``slots`` is the
+    real ``mlx_lm`` ``RotatingKVCache`` capacity: ``window`` plus its retained
+    sink positions, rounded UP to the buffer's step granularity
+    (``ceil((window + keep) / step) * step`` with ``step=256``, ``keep=4``). That
+    step-rounded, sink-inclusive capacity is an over-count-safe upper bound on the
+    actual buffer (the cache grows in block increments and keeps sinks above the
+    window, so it can exceed the raw window) — plus the conservative fixed
+    recurrent state of each sizeable recurrent layer. Even at whole capacity this
+    is a massive reduction vs unbounded per-token growth, because the window is
+    bounded (e.g. 512-4096) while generation is not.
 
 Borrower (KV-sharing) layers contribute 0 to both terms. Sliding-window and
 recurrent layers contribute 0 to per-token growth; their worst-case allocation
@@ -68,10 +71,13 @@ path — see ``scheduler._resolve_kv_bytes_per_token``):
    with no readable window is charged as full unbounded growth; an unrecognized
    layer-type string is charged as full growth (exact-match allowlists, no
    substring guessing). A sliding-window layer WITH a readable window reserves
-   its WHOLE window buffer once per sequence (``2·dtype·window·kv·head_dim``) —
-   an upper bound on a rotating/paged cache that rounds up to block increments
-   and may keep sink positions, so a request is never charged less than its true
-   sliding allocation regardless of token budget or prefill length. Recurrent
+   its WHOLE rotating-cache buffer once per sequence
+   (``2·dtype·slots·kv·head_dim`` where ``slots = ceil((window + keep) / step) *
+   step`` is the real ``RotatingKVCache`` capacity — the window rounded up to the
+   buffer's step granularity plus its retained sink positions) — an upper bound
+   on a cache that grows in block increments and keeps sinks above the window, so
+   a request is never charged less than its true sliding allocation regardless of
+   token budget or prefill length. Recurrent
    layers genuinely have zero per-token growth; a GatedDeltaNet layer's fixed
    state is sized from its real config fields (linear head dims + conv kernel)
    and charged at fp32/element to stay conservative. Every other recurrent family
@@ -138,6 +144,26 @@ _SLIDING_TYPES: frozenset[str] = frozenset(
     }
 )
 
+# Rotating-window cache allocation granularity, sourced from the shipped
+# ``mlx_lm.models.cache.RotatingKVCache`` implementation:
+#
+#   * ``RotatingKVCache.step = 256`` — the class attribute that sizes buffer
+#     growth: the cache grows its KV buffer in ``step``-token increments
+#     (``_update_in_place``: ``new_size = min(self.step, self.max_size - prev)``).
+#   * ``keep=4`` — ``mlx_lm.models.cache.make_prompt_cache`` constructs every
+#     rotating layer as ``RotatingKVCache(max_size=max_kv_size, keep=4)``, so the
+#     cache retains 4 sink positions in ADDITION to the rotating window.
+#
+# The real per-layer capacity is therefore the ``step``-rounded size of the
+# window PLUS its sink positions, which can exceed the raw ``sliding_window``
+# figure. Grounding the sliding baseline in this capacity (rather than the raw
+# window) keeps the estimate an over-count-safe upper bound on the actual buffer
+# (codex round 10 BLOCKING: the whole-window baseline still under-counts the
+# block-rounded, sink-retaining allocation). These are the shipped defaults; if a
+# future mlx-lm changes them, update here to match the impl.
+_ROTATING_CACHE_STEP = 256
+_ROTATING_CACHE_KEEP = 4
+
 
 @dataclass(frozen=True)
 class KVFootprintEstimate:
@@ -158,12 +184,14 @@ class KVFootprintEstimate:
             only. This is the value the projection multiplies by
             ``(prompt_tokens + max_tokens)``.
         fixed_baseline_bytes: Bytes allocated once per sequence, independent of
-            the token budget — the WHOLE rotating-window buffer of each
-            sliding-window layer (``2·dtype·window·kv_heads·head_dim``, an upper
-            bound on a rotating/paged cache that allocates in block increments
-            and may retain sink positions) plus the conservative fixed recurrent
-            state of each sizeable recurrent layer. Zero for a dense model and
-            for a hybrid with neither.
+            the token budget — the WHOLE rotating-cache buffer of each
+            sliding-window layer (``2·dtype·slots·kv_heads·head_dim`` where
+            ``slots = ceil((window + keep) / step) * step`` is the real
+            ``RotatingKVCache`` capacity: the window rounded up to the buffer's
+            step granularity plus its retained sink positions, an upper bound on a
+            cache that grows in block increments and keeps sinks above the window)
+            plus the conservative fixed recurrent state of each sizeable recurrent
+            layer. Zero for a dense model and for a hybrid with neither.
     """
 
     per_token_growth_bytes: int
@@ -451,15 +479,22 @@ def estimate_kv_footprint(
     sliding_per_layer = max(
         2 * dtype_bytes * local_kv_heads * local_head_dim, uniform_per_layer
     )
-    # WHOLE-window buffer of ONE sliding-window layer, charged once per sequence.
-    # A rotating/paged KV cache allocates in block increments and may retain sink
-    # positions, so the buffer can be as large as (and never larger than) the
-    # full window — charging the whole window is the over-count-SAFE upper bound
-    # that can never trip the D-METAL-CAP OOM cliff, regardless of the token
-    # budget (codex round 9 BLOCKING: min(tokens, window) under-counts the real
-    # block-rounded allocation). Still a massive reduction vs unbounded per-token
-    # growth: the window is bounded (e.g. 512-4096) while generation is not.
-    sliding_window_bytes = window * sliding_per_layer
+    # WHOLE-capacity buffer of ONE sliding-window layer, charged once per
+    # sequence. The real ``RotatingKVCache`` does NOT allocate exactly ``window``
+    # slots: it grows the buffer in ``_ROTATING_CACHE_STEP``-token increments and
+    # retains ``_ROTATING_CACHE_KEEP`` sink positions ABOVE the rotating window,
+    # so its true capacity is ``window + keep`` rounded UP to the next ``step``
+    # multiple — which can exceed the raw window (codex round 10 BLOCKING: the
+    # whole-window figure still under-counts the block-rounded, sink-retaining
+    # allocation). Reserving that step-rounded capacity is the over-count-SAFE
+    # upper bound that can never trip the D-METAL-CAP OOM cliff, regardless of the
+    # token budget. Still a massive reduction vs unbounded per-token growth: the
+    # window is bounded (e.g. 512-4096) while generation is not.
+    sliding_slots = (
+        (window + _ROTATING_CACHE_KEEP + _ROTATING_CACHE_STEP - 1)
+        // _ROTATING_CACHE_STEP
+    ) * _ROTATING_CACHE_STEP
+    sliding_window_bytes = sliding_slots * sliding_per_layer
 
     per_token_growth = 0
     fixed_baseline = 0

--- a/vllm_mlx/kv_estimation.py
+++ b/vllm_mlx/kv_estimation.py
@@ -365,35 +365,25 @@ def _classify_layer(layer_type: str) -> str:
 
 
 def _uniform_sliding_window(struct: Any) -> int:
-    """Return the single rotating-window size shared by ALL sliding layers, or 0.
+    """Return the sliding window when it is a single positive scalar, else ``0``.
 
     The per-request slot model (``sliding_slot_bytes × rotating_cache_slots(window,
-    T)``) charges every sliding layer with ONE window. That is exact only when the
-    sliding layers genuinely share a single window — the shipped shape: GPT-OSS and
-    Gemma-4 expose ``sliding_window`` as one positive scalar. This resolver returns
-    a window ONLY when it can prove uniformity:
+    T)``) charges EVERY sliding layer with ONE window, so it is sound only when the
+    config states a single window that all sliding layers share. Shipped hybrids
+    (GPT-OSS, Gemma-4) expose ``sliding_window`` as exactly that positive scalar.
 
-    * a positive int scalar → the uniform window (shipped case);
-    * a per-layer list/tuple whose positive entries are ALL EQUAL → that one
-      distinct window (still uniform, so still exact);
-    * otherwise (a list with DIFFERING positive windows, or an unreadable shape) →
-      ``0``.
-
-    Returning ``0`` makes the caller fold those sliding layers into full per-token
-    growth (over-count-safe) rather than charging every sliding layer with one
-    scalar window that could UNDER-count a layer whose real window is larger
-    (codex round 13 BLOCKING #3). It never picks the min/first of differing
-    windows — which would be the under-counting mistake.
+    Any NON-scalar shape — a per-layer window ``list`` / ``tuple``, or an
+    unreadable value — returns ``0`` so the caller folds those sliding layers into
+    full per-token growth (over-count-safe) instead. We deliberately do NOT try to
+    collapse a per-layer list to one window: a partial / misaligned list (e.g. a
+    positive window on one sliding index and a ``None`` on another) could borrow the
+    known layer's window for a sliding layer whose real window is UNKNOWN and
+    possibly larger, under-reserving KV (codex round 13 BLOCKING #3 and follow-up).
+    Verifying full ``layer_types``-aligned per-index uniformity would be the only
+    safe way to trust a list — and no shipped model expresses a list window — so
+    the safe, minimal policy is scalar-only, list ⇒ full-growth fallback.
     """
-    raw = _cfg_get(struct, "sliding_window")
-    scalar = _pos_int(raw)
-    if scalar:
-        return scalar
-    if isinstance(raw, (list, tuple)):
-        distinct = {v for v in (_pos_int(entry) for entry in raw) if v > 0}
-        if len(distinct) == 1:
-            return next(iter(distinct))
-    return 0
+    return _pos_int(_cfg_get(struct, "sliding_window"))
 
 
 # mlx-lm materializes the recurrent conv/SSM state buffers with ``mx.zeros``,

--- a/vllm_mlx/kv_estimation.py
+++ b/vllm_mlx/kv_estimation.py
@@ -35,13 +35,14 @@ This module computes an accurate footprint by classifying each layer:
     when the architecture is hybrid.
 
 ``fixed_baseline_bytes``
-    ``2 * dtype_bytes * Σ_sliding (window_L * kv_heads_L * head_dim_L)`` — the
-    rotating-window buffers of the sliding-window layers, allocated once per
-    sequence rather than per token.
+    ``2 * dtype_bytes * Σ_sliding (window_L * kv_heads_L * head_dim_L)`` (the
+    rotating-window buffers of the sliding-window layers) plus the conservative
+    fixed recurrent state of each recurrent layer we can size from its config.
+    Allocated once per sequence rather than per token.
 
 Borrower (KV-sharing) layers contribute 0 to both. Recurrent / linear-attention
-layers contribute 0 to per-token growth (see safety point 2 for why their fixed
-state is deliberately not modeled).
+layers contribute 0 to per-token growth; their fixed state is reserved in the
+baseline instead (see safety point 2).
 
 Safety contract (this feeds a codex-hardened, over-estimate-safe admission
 path — see ``scheduler._resolve_kv_bytes_per_token``):
@@ -62,16 +63,15 @@ path — see ``scheduler._resolve_kv_bytes_per_token``):
    exactly; a sliding layer with no readable window is charged as full-growth;
    an unrecognized layer-type string is charged as full-growth (exact-match
    allowlists, no substring guessing); recurrent and window-bounded layers
-   genuinely have zero per-token growth. The sliding window footprint lands in
-   ``fixed_baseline`` — an exact per-sequence upper bound (the whole window,
-   ignoring token count). The recurrent layers' small FIXED state is
-   architecture-specific (linear key/value head dims, conv kernel) and our
-   configs do not uniformly expose those fields, so — rather than invent a
-   number that could silently under-count — we leave that fixed per-sequence
-   overhead unmodeled, exactly as the gate already leaves model weights and
-   activation buffers unmodeled. This is sound because the gate exists to catch
-   runaway PER-TOKEN growth, not fixed per-sequence overhead: a non-growing
-   term cannot produce the D-METAL-CAP cliff.
+   genuinely have zero per-token growth. Their per-sequence footprint lands in
+   ``fixed_baseline`` instead: the sliding window term is an exact upper bound
+   (the whole window, ignoring token count), and each recurrent layer's fixed
+   state is sized from its family's real config fields (GatedDeltaNet linear
+   head dims + conv kernel; Mamba d_state/d_conv) and charged at fp32/element to
+   stay conservative. A recurrent layer whose state CANNOT be sized falls back
+   to the uniform per-token estimate (full growth) rather than going
+   unreserved. A fixed baseline is charged once per sequence and never scales
+   with generated tokens.
 3. **KV-sharing only zeroes verified borrowers.** ``num_kv_shared_layers``
    declares that the LAST N layers borrow (Gemma-4 / Gemma-3n contract). We zero
    those borrowers only when the per-layer ``layer_types`` map confirms it —
@@ -131,8 +131,9 @@ class KVFootprintEstimate:
             only. This is the value the D-METAL-CAP projection multiplies by
             ``(prompt_tokens + max_tokens)``.
         fixed_baseline_bytes: Bytes allocated once per sequence regardless of
-            token count — the sliding-window rotating buffers. Zero for a dense
-            model and for any hybrid with no sliding-window layers.
+            token count — the sliding-window rotating buffers plus the
+            conservative fixed recurrent state of each sizeable recurrent layer.
+            Zero for a dense model and for a hybrid with neither.
     """
 
     per_token_growth_bytes: int
@@ -218,6 +219,71 @@ def _classify_layer(layer_type: str) -> str:
     if layer_type in _SLIDING_TYPES:
         return "sliding"
     return "full"
+
+
+# mlx-lm materializes the recurrent conv/SSM state buffers with ``mx.zeros``,
+# which defaults to float32 — so we size the recurrent per-sequence state at 4
+# bytes/element regardless of the (possibly smaller) KV dtype. Over-charging a
+# small fixed term is the safe direction and guarantees we never under-reserve
+# it (codex round 2 BLOCKING #1).
+_RECURRENT_STATE_BYTES_PER_ELEM = 4
+
+
+def _recurrent_state_bytes(struct: Any) -> int | None:
+    """Conservative per-sequence FIXED state of one recurrent layer, in bytes.
+
+    Returns ``None`` when the config exposes no recognized recurrent-state
+    fields — the caller then charges that layer the uniform per-token estimate
+    (full-growth) as the safe fallback, rather than leaving its state
+    unreserved (codex round 2 BLOCKING #1).
+
+    Two supported families, sized from their real config fields:
+
+    * **GatedDeltaNet** (Qwen3-Next / Qwen3.5 / Qwen3.6): the recurrent state is
+      a per-value-head ``head_k_dim × head_v_dim`` matrix plus the causal-conv
+      ring buffer over ``conv_dim = 2·key_dim + value_dim`` channels. Shapes
+      match ``mlx_lm.models.qwen3_next.Qwen3NextGatedDeltaNet``.
+    * **Mamba / Mamba2**: the SSM state ``d_inner × d_state`` plus the conv ring
+      buffer ``d_inner × (d_conv − 1)``.
+
+    Every term is a per-sequence constant (it does not grow with generated
+    tokens), so it lands in the fixed baseline, never in per-token growth.
+    """
+    # GatedDeltaNet.
+    num_v = _pos_int(_cfg_get(struct, "linear_num_value_heads"))
+    num_k = _pos_int(_cfg_get(struct, "linear_num_key_heads"))
+    head_k = _pos_int(_cfg_get(struct, "linear_key_head_dim"))
+    head_v = _pos_int(_cfg_get(struct, "linear_value_head_dim"))
+    if num_v and num_k and head_k and head_v:
+        conv_kernel = _pos_int(_cfg_get(struct, "linear_conv_kernel_dim"))
+        key_dim = num_k * head_k
+        value_dim = num_v * head_v
+        recurrent_elems = num_v * head_k * head_v
+        conv_dim = 2 * key_dim + value_dim
+        conv_elems = max(conv_kernel - 1, 0) * conv_dim
+        return _RECURRENT_STATE_BYTES_PER_ELEM * (recurrent_elems + conv_elems)
+
+    # Mamba / Mamba2.
+    d_state = _pos_int(_cfg_get(struct, "mamba_d_state")) or _pos_int(
+        _cfg_get(struct, "state_size")
+    )
+    if d_state:
+        n_heads = _pos_int(_cfg_get(struct, "mamba_n_heads"))
+        d_head = _pos_int(_cfg_get(struct, "mamba_d_head"))
+        d_inner = (n_heads * d_head) if (n_heads and d_head) else 0
+        if d_inner == 0:
+            d_inner = _pos_int(_cfg_get(struct, "mamba_intermediate_size")) or _pos_int(
+                _cfg_get(struct, "intermediate_size")
+            )
+        if d_inner:
+            d_conv = _pos_int(_cfg_get(struct, "mamba_d_conv")) or _pos_int(
+                _cfg_get(struct, "conv_kernel_size")
+            )
+            ssm_elems = d_inner * d_state
+            conv_elems = d_inner * max(d_conv - 1, 0)
+            return _RECURRENT_STATE_BYTES_PER_ELEM * (ssm_elems + conv_elems)
+
+    return None
 
 
 def estimate_kv_footprint(
@@ -314,6 +380,13 @@ def estimate_kv_footprint(
     # the split. If it does not (interleaved / differently-anchored sharing we
     # do not model), we keep every layer as a producer — an over-count, never an
     # under-count (codex round 1 BLOCKING #3).
+    #
+    # For FOOTPRINT purposes the set-of-types check is sufficient (and mirrors
+    # the shipped ``_check_kv_share_config`` orphan check exactly): a borrower
+    # whose attention type has ANY same-type producer below the split allocates
+    # zero KV — it reuses that producer's cache. WHICH producer index it borrows
+    # from does not change the borrower's own footprint (still zero), so a
+    # per-index source mapping would not alter this estimate.
     num_shared = _cfg_get(struct, "num_kv_shared_layers")
     if isinstance(num_shared, int) and not isinstance(num_shared, bool):
         num_shared = num_shared if 0 < num_shared < base_num_layers else 0
@@ -341,14 +414,18 @@ def estimate_kv_footprint(
         layer_class = _classify_layer(layer_types[idx])
         if layer_class == "recurrent":
             # Recurrent / linear-attention layers keep a FIXED state that does
-            # not grow per token — zero growth (the load-bearing correctness
-            # win). Their fixed state is small, bounded, and architecture-
-            # specific; deriving it needs family fields (linear key/value head
-            # dims, conv kernel) our configs do not uniformly expose, so we do
-            # NOT invent a term for it (codex round 1 BLOCKING #2). Like model
-            # weights and activation buffers, that fixed per-sequence overhead
-            # is simply out of scope for this KV-GROWTH projection; the gate has
-            # never reserved for non-growing allocations.
+            # not grow per token. When we can size that state from the family's
+            # real config fields we reserve it in the per-sequence baseline (so
+            # concurrent sequences don't silently allocate past the cap — codex
+            # round 2 BLOCKING #1) while keeping per-token growth at zero — the
+            # load-bearing correctness win for Qwen3.5/3.6/Mamba. When we CANNOT
+            # size it, we fall back to charging the layer the uniform per-token
+            # estimate (full growth), which never under-counts.
+            state = _recurrent_state_bytes(struct)
+            if state is not None:
+                fixed_baseline += state
+            else:
+                per_token_growth += sliding_full_per_token
             continue
         if layer_class == "sliding":
             if window > 0:

--- a/vllm_mlx/kv_estimation.py
+++ b/vllm_mlx/kv_estimation.py
@@ -34,25 +34,20 @@ This module computes an accurate footprint by classifying each layer:
     full-attention (unbounded per-token-growing) layers, honoring per-layer /
     global dims when the architecture is hybrid.
 
-``sliding_per_token_bytes`` / ``sliding_window_tokens``
-    ``2 * dtype_bytes * Σ_sliding (kv_heads_L * head_dim_L)`` — the per-token
-    KV rate of the sliding-window layers — together with the rotating window
-    length. The caller charges ``sliding_per_token * min(tokens, window)``: a
-    rotating cache holds at most ``window`` positions, but a request shorter
-    than the window holds only ``tokens``, so short requests stay byte-identical
-    to the historical uniform figure and only long requests get the window cap
-    (codex round 6 BLOCKING). Flattening the whole window into a fixed baseline
-    would over-charge — and spuriously reject — short requests.
-
 ``fixed_baseline_bytes``
-    The conservative fixed recurrent state of each recurrent layer we can size
-    from its config. Allocated once per sequence, independent of token count
-    (an SSM/conv state is materialized in full at cache init). Sliding windows
-    are NOT flattened here — see above.
+    Charged once per sequence, independent of the token budget:
+    ``2 * dtype_bytes * Σ_sliding (window * kv_heads_L * head_dim_L)`` — the
+    WHOLE rotating-window buffer of each sliding-window layer (an over-count-safe
+    upper bound: a rotating/paged cache allocates in block increments and may
+    retain sink positions, so the buffer can reach — but never exceed — the full
+    window) — plus the conservative fixed recurrent state of each sizeable
+    recurrent layer. Even at the whole window this is a massive reduction vs
+    unbounded per-token growth, because the window is bounded (e.g. 512-4096)
+    while generation is not.
 
-Borrower (KV-sharing) layers contribute 0 to all terms. Recurrent /
-linear-attention layers contribute 0 to per-token growth; their fixed state is
-reserved in the baseline instead (see safety point 2).
+Borrower (KV-sharing) layers contribute 0 to both terms. Sliding-window and
+recurrent layers contribute 0 to per-token growth; their worst-case allocation
+is reserved in the baseline instead (see safety point 2).
 
 Safety contract (this feeds a codex-hardened, over-estimate-safe admission
 path — see ``scheduler._resolve_kv_bytes_per_token``):
@@ -66,18 +61,17 @@ path — see ``scheduler._resolve_kv_bytes_per_token``):
    recognized hybrid gets the smaller accurate number. ``num_kv_shared_layers``
    is NOT sufficient on its own — the per-layer map must confirm the borrower
    split (see point 3).
-2. **Never under-count the counted layers, never over-count short requests.**
-   The load-bearing guarantee for the D-METAL-CAP cliff is that the projected
-   footprint is >= the true footprint of every counted layer. Full-attention
-   layers are charged exactly per token; a sliding layer with no readable window
-   is charged as full unbounded growth; an unrecognized layer-type string is
-   charged as full growth (exact-match allowlists, no substring guessing).
-   Sliding-window layers with a readable window report a per-token ``rate`` and
-   the window; the caller charges ``rate * min(tokens, window)`` for decode (an
-   upper bound on the rotating cache, equal to the historical uniform figure for
-   any request shorter than the window) floored at the full prompt to cover the
-   transient prefill peak — so the reduction never comes at the cost of
-   over-charging a short request nor under-charging a large prefill. Recurrent
+2. **Never under-count the counted layers (over-count-safe throughout).** The
+   load-bearing guarantee for the D-METAL-CAP cliff is that the projected
+   footprint is >= the true footprint of every counted layer, so every estimate
+   errs UP. Full-attention layers are charged exactly per token; a sliding layer
+   with no readable window is charged as full unbounded growth; an unrecognized
+   layer-type string is charged as full growth (exact-match allowlists, no
+   substring guessing). A sliding-window layer WITH a readable window reserves
+   its WHOLE window buffer once per sequence (``2·dtype·window·kv·head_dim``) —
+   an upper bound on a rotating/paged cache that rounds up to block increments
+   and may keep sink positions, so a request is never charged less than its true
+   sliding allocation regardless of token budget or prefill length. Recurrent
    layers genuinely have zero per-token growth; a GatedDeltaNet layer's fixed
    state is sized from its real config fields (linear head dims + conv kernel)
    and charged at fp32/element to stay conservative. Every other recurrent family
@@ -151,40 +145,29 @@ class KVFootprintEstimate:
 
     The D-METAL-CAP projection reconstructs a request's peak KV footprint as::
 
-        fixed_baseline_bytes
-          + per_token_growth_bytes * (prompt_tokens + max_tokens)
-          + sliding_per_token_bytes * min(prompt_tokens + max_tokens,
-                                          sliding_window_tokens)
+        fixed_baseline_bytes + per_token_growth_bytes * (prompt_tokens + max_tokens)
 
-    Splitting the sliding-window term out (rather than flattening the whole
-    window into ``fixed_baseline``) keeps SHORT requests byte-identical to the
-    historical uniform estimate: a rotating-window layer only holds
-    ``min(tokens, window)`` positions, so a request whose token budget is below
-    the window is charged exactly ``tokens`` worth — never the full window
-    (codex round 6 BLOCKING). Long requests still get the reduction: the sliding
-    term is capped at ``window`` while the old uniform figure kept growing.
+    Only the full-attention (unbounded-growth) layers land in
+    ``per_token_growth_bytes``; every window-bounded or fixed-state layer is
+    charged its worst-case allocation ONCE in ``fixed_baseline_bytes`` so the
+    projection can never under-count and trip the D-METAL-CAP OOM cliff.
 
     Attributes:
         per_token_growth_bytes: Bytes of KV cache allocated per additional
             token, summed over the full-attention (unbounded-growth) layers
-            only.
-        fixed_baseline_bytes: Bytes allocated once per sequence regardless of
-            token count — the conservative fixed recurrent state of each
-            sizeable recurrent layer. (Sliding windows are NOT flattened here;
-            see ``sliding_per_token_bytes``.) Zero for a dense model and for a
-            hybrid with no sizeable recurrent layers.
-        sliding_per_token_bytes: Bytes of KV allocated per token by the
-            sliding-window (local-attention) layers, summed over those layers.
-            Capped in the projection at ``sliding_window_tokens`` positions.
-            Zero when there are no readable-window sliding layers.
-        sliding_window_tokens: The rotating window length (tokens) that caps the
-            sliding term. Zero when ``sliding_per_token_bytes`` is zero.
+            only. This is the value the projection multiplies by
+            ``(prompt_tokens + max_tokens)``.
+        fixed_baseline_bytes: Bytes allocated once per sequence, independent of
+            the token budget — the WHOLE rotating-window buffer of each
+            sliding-window layer (``2·dtype·window·kv_heads·head_dim``, an upper
+            bound on a rotating/paged cache that allocates in block increments
+            and may retain sink positions) plus the conservative fixed recurrent
+            state of each sizeable recurrent layer. Zero for a dense model and
+            for a hybrid with neither.
     """
 
     per_token_growth_bytes: int
     fixed_baseline_bytes: int
-    sliding_per_token_bytes: int = 0
-    sliding_window_tokens: int = 0
 
 
 def _cfg_get(cfg: Any, name: str, default: Any = None) -> Any:
@@ -460,22 +443,26 @@ def estimate_kv_footprint(
     full_per_token = max(
         2 * dtype_bytes * global_kv_heads * global_head_dim, uniform_per_layer
     )
-    # Per-token KV rate of ONE sliding-window layer (local dims). The projection
-    # multiplies this by ``min(tokens, window)`` — the true peak occupancy of a
-    # rotating cache — rather than flattening the whole window into the baseline,
-    # so a request shorter than the window is charged only for the tokens it
-    # actually holds (codex round 6 BLOCKING). Clamped to the uniform base-layer
-    # floor for the same reason full layers are (codex round 7 BLOCKING #2): if a
-    # malformed or semantically-different nested config exposes smaller local
-    # dims than the base the scheduler read, the sliding term must not drop below
-    # the uniform per-layer charge and open an under-count.
+    # Per-token KV rate of ONE sliding-window layer (local dims), clamped to the
+    # uniform base-layer floor for the same reason full layers are (codex round 7
+    # BLOCKING #2): a malformed / non-authoritative nested config exposing
+    # smaller local dims than the base must not drop a layer's charge below the
+    # uniform per-layer rate and open an under-count.
     sliding_per_layer = max(
         2 * dtype_bytes * local_kv_heads * local_head_dim, uniform_per_layer
     )
+    # WHOLE-window buffer of ONE sliding-window layer, charged once per sequence.
+    # A rotating/paged KV cache allocates in block increments and may retain sink
+    # positions, so the buffer can be as large as (and never larger than) the
+    # full window — charging the whole window is the over-count-SAFE upper bound
+    # that can never trip the D-METAL-CAP OOM cliff, regardless of the token
+    # budget (codex round 9 BLOCKING: min(tokens, window) under-counts the real
+    # block-rounded allocation). Still a massive reduction vs unbounded per-token
+    # growth: the window is bounded (e.g. 512-4096) while generation is not.
+    sliding_window_bytes = window * sliding_per_layer
 
     per_token_growth = 0
     fixed_baseline = 0
-    sliding_per_token = 0
     for idx in range(base_num_layers):
         if idx >= first_borrower:
             # Borrower (KV-sharing) layer — reuses a producer's cache, allocates
@@ -489,8 +476,8 @@ def estimate_kv_footprint(
             # real config fields we reserve it in the per-sequence baseline (so
             # concurrent sequences don't silently allocate past the cap — codex
             # round 2 BLOCKING #1) while keeping per-token growth at zero — the
-            # load-bearing correctness win for Qwen3.5/3.6/Mamba. When we CANNOT
-            # size it, we fall back to charging the layer the uniform per-token
+            # load-bearing correctness win for Qwen3.5/3.6. When we CANNOT size
+            # it, we fall back to charging the layer the uniform per-token
             # estimate (full growth), which never under-counts.
             state = _recurrent_state_bytes(struct, layer_type)
             if state is not None:
@@ -500,9 +487,8 @@ def estimate_kv_footprint(
             continue
         if layer_class == "sliding":
             if window > 0:
-                # Window-capped per-token growth — accumulated separately so the
-                # projection can cap it at ``window`` positions.
-                sliding_per_token += sliding_per_layer
+                # Window-bounded: the whole rotating buffer, once per sequence.
+                fixed_baseline += sliding_window_bytes
             else:
                 # No readable window → cannot bound it → charge the uniform
                 # per-layer growth (never under-count).
@@ -513,6 +499,4 @@ def estimate_kv_footprint(
     return KVFootprintEstimate(
         per_token_growth_bytes=int(per_token_growth),
         fixed_baseline_bytes=int(fixed_baseline),
-        sliding_per_token_bytes=int(sliding_per_token),
-        sliding_window_tokens=int(window) if sliding_per_token > 0 else 0,
     )

--- a/vllm_mlx/kv_estimation.py
+++ b/vllm_mlx/kv_estimation.py
@@ -32,25 +32,30 @@ This module computes an accurate footprint by classifying each layer:
 ``per_token_growth_bytes``
     ``2 * dtype_bytes * Σ (kv_heads_L * head_dim_L)`` over ONLY the
     full-attention (unbounded per-token-growing) layers, honoring per-layer /
-    global dims when the architecture is hybrid.
+    global dims when the architecture is hybrid. Multiplied by
+    ``T = prompt_tokens + max_tokens`` in the projection.
+
+``sliding_slot_bytes`` + ``sliding_window``
+    The sliding-window layers grow SUBLINEARLY: up to a rotating window, then
+    flat. ``sliding_slot_bytes`` is the per-SLOT bytes summed over the
+    window-bounded sliding layers (``2 * dtype_bytes * Σ_sliding (kv_heads_L *
+    head_dim_L)``); the scheduler multiplies it by the per-request slot count
+    ``rotating_cache_slots(sliding_window, T)`` — an over-count-safe UPPER BOUND
+    of the real ``mlx_lm`` ``RotatingKVCache`` allocation that grows with ``T``
+    up to ``ceil((window + keep) / step) * step`` (``step=256``, ``keep=4``) and
+    then caps. Modelling this per request keeps it >= the true allocation at
+    every ``T`` (never OOM) yet <= the full window (a short request is not
+    over-charged the whole buffer). See :func:`rotating_cache_slots`.
 
 ``fixed_baseline_bytes``
-    Charged once per sequence, independent of the token budget:
-    ``2 * dtype_bytes * Σ_sliding (slots * kv_heads_L * head_dim_L)`` — the WHOLE
-    rotating-cache buffer of each sliding-window layer, where ``slots`` is the
-    real ``mlx_lm`` ``RotatingKVCache`` capacity: ``window`` plus its retained
-    sink positions, rounded UP to the buffer's step granularity
-    (``ceil((window + keep) / step) * step`` with ``step=256``, ``keep=4``). That
-    step-rounded, sink-inclusive capacity is an over-count-safe upper bound on the
-    actual buffer (the cache grows in block increments and keeps sinks above the
-    window, so it can exceed the raw window) — plus the conservative fixed
-    recurrent state of each sizeable recurrent layer. Even at whole capacity this
-    is a massive reduction vs unbounded per-token growth, because the window is
-    bounded (e.g. 512-4096) while generation is not.
+    Charged once per sequence, independent of the token budget: the conservative
+    fixed recurrent state of each sizeable recurrent (GatedDeltaNet) layer. Zero
+    for a dense model and for a hybrid without recurrent layers.
 
-Borrower (KV-sharing) layers contribute 0 to both terms. Sliding-window and
-recurrent layers contribute 0 to per-token growth; their worst-case allocation
-is reserved in the baseline instead (see safety point 2).
+Borrower (KV-sharing) layers contribute 0 to all terms. Sliding-window and
+recurrent layers contribute 0 to per-token growth; a sliding layer's footprint
+is charged per request via the slot term, a recurrent layer's via the fixed
+baseline (see safety point 2).
 
 Safety contract (this feeds a codex-hardened, over-estimate-safe admission
 path — see ``scheduler._resolve_kv_bytes_per_token``):
@@ -59,39 +64,41 @@ path — see ``scheduler._resolve_kv_bytes_per_token``):
    ``layer_types`` list whose length matches ``num_hidden_layers``. When that is
    absent, or anything is ambiguous, the estimator returns the caller's uniform
    figure unchanged (``per_token_growth_bytes == uniform_per_token_bytes`` and
-   ``fixed_baseline_bytes == 0``) so dense models (Llama/Qwen dense) and
-   unknown/stub configs stay BYTE-IDENTICAL to the historical behavior. Only a
-   recognized hybrid gets the smaller accurate number. ``num_kv_shared_layers``
-   is NOT sufficient on its own — the per-layer map must confirm the borrower
-   split (see point 3).
+   ``fixed_baseline_bytes == sliding_slot_bytes == sliding_window == 0``) so dense
+   models (Llama/Qwen dense) and unknown/stub configs stay BYTE-IDENTICAL to the
+   historical behavior. Only a recognized hybrid gets the smaller accurate
+   number. ``num_kv_shared_layers`` is NOT sufficient on its own — the per-layer
+   map must confirm the borrower split (see point 3).
 2. **Never under-count the counted layers (over-count-safe throughout).** The
    load-bearing guarantee for the D-METAL-CAP cliff is that the projected
    footprint is >= the true footprint of every counted layer, so every estimate
    errs UP. Full-attention layers are charged exactly per token; a sliding layer
    with no readable window is charged as full unbounded growth; an unrecognized
    layer-type string is charged as full growth (exact-match allowlists, no
-   substring guessing). A sliding-window layer WITH a readable window reserves
-   its WHOLE rotating-cache buffer once per sequence
-   (``2·dtype·slots·kv·head_dim`` where ``slots = ceil((window + keep) / step) *
-   step`` is the real ``RotatingKVCache`` capacity — the window rounded up to the
-   buffer's step granularity plus its retained sink positions) — an upper bound
-   on a cache that grows in block increments and keeps sinks above the window, so
-   a request is never charged less than its true sliding allocation regardless of
-   token budget or prefill length. Recurrent
-   layers genuinely have zero per-token growth; a GatedDeltaNet layer's fixed
-   state is sized from its real config fields (linear head dims + conv kernel)
-   and charged at fp32/element to stay conservative. Every other recurrent family
-   (Mamba/Mamba2, RWKV, generic) is NOT sized — its exact cache layout is not
-   modelled here — and falls back to full per-token growth rather than a possibly
-   wrong fixed state, so it is never under-reserved. The fixed baseline is
-   charged once per sequence and never scales with generated tokens.
-3. **KV-sharing only zeroes verified borrowers.** ``num_kv_shared_layers``
-   declares that the LAST N layers borrow (Gemma-4 / Gemma-3n contract). We zero
-   those borrowers only when the per-layer ``layer_types`` map confirms it —
-   every borrower attention type has a same-type producer below the split
-   (mirroring ``gemma4_text._check_kv_share_config``). If the map does not
-   confirm the last-N contract, no layer is zeroed (over-count, never
-   under-count).
+   substring guessing). A sliding-window layer WITH a readable window is charged
+   per request as ``slot_bytes × rotating_cache_slots(window, T)``, where
+   ``rotating_cache_slots`` rounds ``min(T, window) + keep`` UP to the buffer's
+   step granularity — a provable upper bound of the real ``RotatingKVCache``
+   buffer at every ``T`` (it grows in ``step`` blocks up to the window and keeps
+   ``keep`` sinks), so a request is never charged less than its true sliding
+   allocation, yet a SHORT request is not charged the whole window (which would
+   over-count and spuriously reject it). Recurrent layers genuinely have zero
+   per-token growth; a GatedDeltaNet layer's fixed state is sized from its real
+   config fields (linear head dims + conv kernel) and charged at fp32/element to
+   stay conservative. Every other recurrent family (Mamba/Mamba2, RWKV, generic)
+   is NOT sized — its exact cache layout is not modelled here — and falls back to
+   full per-token growth rather than a possibly wrong fixed state, so it is never
+   under-reserved. The fixed baseline is charged once per sequence and never
+   scales with generated tokens.
+3. **KV-sharing zeroes only borrowers with a verified same-type producer.**
+   ``num_kv_shared_layers`` declares that the LAST N layers borrow (Gemma-4 /
+   Gemma-3n contract). We reconstruct the EXACT producer→borrower index map the
+   shipped model builds (``models/gemma4_vendored/language.py``: each borrower
+   reuses the LAST same-type producer below the split) and zero a borrower ONLY
+   when that same-type producer exists. A borrower whose type has no producer
+   below the split is charged its own footprint, never zeroed (over-count, never
+   under-count) — the shipped model would fail to build such a config, so no
+   runnable request is under-reserved.
 
 The estimator is a pure function: it reads only plain fields off a config
 object (or its ``text_config``), performs no I/O, loads no weights, and is unit
@@ -148,54 +155,120 @@ _SLIDING_TYPES: frozenset[str] = frozenset(
 # ``mlx_lm.models.cache.RotatingKVCache`` implementation:
 #
 #   * ``RotatingKVCache.step = 256`` — the class attribute that sizes buffer
-#     growth: the cache grows its KV buffer in ``step``-token increments
-#     (``_update_in_place``: ``new_size = min(self.step, self.max_size - prev)``).
-#   * ``keep=4`` — ``mlx_lm.models.cache.make_prompt_cache`` constructs every
-#     rotating layer as ``RotatingKVCache(max_size=max_kv_size, keep=4)``, so the
-#     cache retains 4 sink positions in ADDITION to the rotating window.
+#     growth: the single-token decode path grows the KV buffer in ``step``-token
+#     increments up to ``max_size`` and only then rotates in place
+#     (``_update_in_place``: ``new_size = min(self.step, self.max_size - prev)``),
+#     so the live buffer after ``t`` tokens is ``min(ceil(t/step)*step, max_size)``.
+#   * ``keep`` — the number of retained sink positions. The construction path
+#     varies across the sliding models this engine serves: the vendored Gemma-4
+#     stack (``models/gemma4_vendored/language.py``) and DeepSeek-V4
+#     (``models/deepseek_v4.py``) build ``RotatingKVCache(max_size=sliding_window,
+#     keep=0)``, while ``mlx_lm.models.cache.make_prompt_cache`` (the generic
+#     factory) passes ``keep=4``. We pin ``KEEP = 4`` — the LARGEST keep any
+#     shipped path uses — so the slot estimate is a valid upper bound for every
+#     construction (more retained sinks ⇒ more slots ⇒ a looser, still-safe
+#     bound; a ``keep=0`` model is over-counted by at most a fraction of one step).
 #
-# The real per-layer capacity is therefore the ``step``-rounded size of the
-# window PLUS its sink positions, which can exceed the raw ``sliding_window``
-# figure. Grounding the sliding baseline in this capacity (rather than the raw
-# window) keeps the estimate an over-count-safe upper bound on the actual buffer
-# (codex round 10 BLOCKING: the whole-window baseline still under-counts the
-# block-rounded, sink-retaining allocation). These are the shipped defaults; if a
-# future mlx-lm changes them, update here to match the impl.
+# See :func:`rotating_cache_slots` for how these ground the per-request slot
+# count. Sourced from the shipped defaults; if a future mlx-lm changes them,
+# update here to match the impl.
 _ROTATING_CACHE_STEP = 256
 _ROTATING_CACHE_KEEP = 4
+
+
+def rotating_cache_slots(window: int, tokens: int) -> int:
+    """Upper-bound slot count a ``RotatingKVCache`` allocates for ``tokens``.
+
+    The real per-layer buffer of a sliding-window (rotating) cache is
+    SUBLINEAR in the token count: the decode path grows it in
+    ``_ROTATING_CACHE_STEP``-token blocks up to ``window`` (``max_size``) and
+    then rotates at a fixed size, retaining ``_ROTATING_CACHE_KEEP`` sink
+    positions. So the live buffer after ``t`` tokens is
+    ``min(ceil(t/step)*step, max_size)`` (verified against
+    ``mlx_lm.models.cache.RotatingKVCache._update_in_place``).
+
+    This returns a provable UPPER BOUND of that buffer for any ``tokens``::
+
+        slots(T) = ceil( (min(T, window) + KEEP) / STEP ) * STEP
+                 = min( ceil((T + KEEP)/STEP)*STEP, ceil((window + KEEP)/STEP)*STEP )
+
+    which is:
+
+    * ``>=`` the real buffer at every ``T`` (rounds UP to the step block and
+      adds the retained sinks), so the D-METAL-CAP projection never under-counts
+      the sliding allocation and trips the OOM cliff;
+    * ``<=`` the full-window buffer ``ceil((window + KEEP)/STEP)*STEP`` for every
+      ``T`` (the ``min(T, window)`` clamp), so a SHORT request is charged only
+      what it can actually grow to — not the whole window (codex round 11
+      BLOCKING #1: a fixed whole-window baseline over-counts short requests and
+      can spuriously reject a request the uniform estimator would have admitted);
+    * monotonic non-decreasing in ``T`` and flat once ``T >= window``.
+
+    Returns ``0`` when there is no window or no tokens (no sliding term).
+    """
+    if window <= 0 or tokens <= 0:
+        return 0
+    effective = min(tokens, window) + _ROTATING_CACHE_KEEP
+    blocks = (effective + _ROTATING_CACHE_STEP - 1) // _ROTATING_CACHE_STEP
+    return blocks * _ROTATING_CACHE_STEP
 
 
 @dataclass(frozen=True)
 class KVFootprintEstimate:
     """Architecture-aware KV footprint of a single sequence.
 
-    The D-METAL-CAP projection reconstructs a request's peak KV footprint as::
+    The D-METAL-CAP projection reconstructs a request's peak KV footprint,
+    per request with ``T = prompt_tokens + max_tokens``, as::
 
-        fixed_baseline_bytes + per_token_growth_bytes * (prompt_tokens + max_tokens)
+        fixed_baseline_bytes
+          + per_token_growth_bytes * T
+          + sliding_slot_bytes * rotating_cache_slots(sliding_window, T)
 
-    Only the full-attention (unbounded-growth) layers land in
-    ``per_token_growth_bytes``; every window-bounded or fixed-state layer is
-    charged its worst-case allocation ONCE in ``fixed_baseline_bytes`` so the
-    projection can never under-count and trip the D-METAL-CAP OOM cliff.
+    The three terms model the three footprint SHAPES this engine's hybrids mix:
+
+    * full-attention layers grow UNBOUNDED per token → ``per_token_growth_bytes``
+      (multiplied by ``T``);
+    * sliding-window layers grow SUBLINEARLY — up to a rotating window, then flat
+      → ``sliding_slot_bytes`` (per-slot bytes) times the per-request slot count
+      ``rotating_cache_slots(sliding_window, T)`` (grounded in the real
+      ``RotatingKVCache`` allocation; see :func:`rotating_cache_slots`);
+    * recurrent / linear-attention layers carry a FIXED state → part of
+      ``fixed_baseline_bytes`` (token-independent, charged once).
+
+    Modelling sliding layers per request — rather than as either a flat window
+    baseline (over-counts short requests, spuriously rejecting them) or unbounded
+    per-token growth (over-counts long requests) — makes the projection an
+    over-count-safe UPPER BOUND at every ``T`` while keeping the GPT-OSS/Gemma-4
+    reduction: a short request is charged only what it can grow to, a long one is
+    capped at the full rotating buffer.
 
     Attributes:
-        per_token_growth_bytes: Bytes of KV cache allocated per additional
-            token, summed over the full-attention (unbounded-growth) layers
-            only. This is the value the projection multiplies by
-            ``(prompt_tokens + max_tokens)``.
-        fixed_baseline_bytes: Bytes allocated once per sequence, independent of
-            the token budget — the WHOLE rotating-cache buffer of each
-            sliding-window layer (``2·dtype·slots·kv_heads·head_dim`` where
-            ``slots = ceil((window + keep) / step) * step`` is the real
-            ``RotatingKVCache`` capacity: the window rounded up to the buffer's
-            step granularity plus its retained sink positions, an upper bound on a
-            cache that grows in block increments and keeps sinks above the window)
-            plus the conservative fixed recurrent state of each sizeable recurrent
-            layer. Zero for a dense model and for a hybrid with neither.
+        per_token_growth_bytes: Bytes of KV cache allocated per additional token,
+            summed over the full-attention (unbounded-growth) layers only. The
+            projection multiplies this by ``T``. A sliding layer whose window is
+            unreadable is folded in here (charged as full growth) so it is never
+            silently dropped.
+        fixed_baseline_bytes: Token-independent bytes allocated once per
+            sequence — the conservative fixed recurrent state of each sizeable
+            recurrent (GatedDeltaNet) layer. Zero for a dense model and for a
+            hybrid without recurrent layers. (Sliding-window buffers are NOT here;
+            they are request-dependent — see ``sliding_slot_bytes``.)
+        sliding_slot_bytes: Bytes for ONE rotating-cache slot summed across all
+            window-bounded sliding-window layers —
+            ``Σ_sliding (2 · dtype · kv_heads_L · head_dim_L)`` (each layer clamped
+            to the uniform per-layer floor). The per-request projection multiplies
+            this by ``rotating_cache_slots(sliding_window, T)``. Zero when the
+            config has no window-bounded sliding layer.
+        sliding_window: The rotating window size (``max_size``) shared by the
+            sliding-window layers. ``0`` when there is no sliding term (dense /
+            unknown, or the window was unreadable and those layers were folded
+            into ``per_token_growth_bytes``).
     """
 
     per_token_growth_bytes: int
     fixed_baseline_bytes: int
+    sliding_slot_bytes: int
+    sliding_window: int
 
 
 def _cfg_get(cfg: Any, name: str, default: Any = None) -> Any:
@@ -375,11 +448,15 @@ def estimate_kv_footprint(
 
     Returns:
         A :class:`KVFootprintEstimate`. For a non-hybrid config this is exactly
-        ``(uniform_per_token_bytes, 0)``.
+        ``(uniform_per_token_bytes, 0, 0, 0)`` — the uniform per-token figure with
+        no fixed baseline and no sliding term (byte-identical to the historical
+        ``per_tok × tokens`` projection).
     """
     uniform = KVFootprintEstimate(
         per_token_growth_bytes=uniform_per_token_bytes,
         fixed_baseline_bytes=0,
+        sliding_slot_bytes=0,
+        sliding_window=0,
     )
 
     # Guard the primitives. If the caller could not read a positive uniform
@@ -431,34 +508,45 @@ def estimate_kv_footprint(
     if layer_types is None:
         return uniform
 
-    # Borrower split: Gemma-4 / Gemma-3n reuse the LAST ``num_kv_shared_layers``
-    # decoder layers' K/V from an earlier same-type producer (split at
-    # ``num_hidden_layers - num_kv_shared_layers`` — see
-    # ``models/gemma4_text._check_kv_share_config``). We only zero those
-    # borrowers when the ACTUAL per-layer map confirms the last-N contract:
-    # every borrower attention type must have a producer of the same type below
-    # the split. If it does not (interleaved / differently-anchored sharing we
-    # do not model), we keep every layer as a producer — an over-count, never an
-    # under-count (codex round 1 BLOCKING #3).
+    # Borrower map: Gemma-4 / Gemma-3n reuse the LAST ``num_kv_shared_layers``
+    # decoder layers' K/V from an earlier producer (split at
+    # ``num_hidden_layers - num_kv_shared_layers``). We build the EXACT
+    # producer→borrower index map the shipped model builds, mirroring
+    # ``models/gemma4_vendored/language.py`` (``LanguageModel.__init__``)::
     #
-    # For FOOTPRINT purposes the set-of-types check is sufficient (and mirrors
-    # the shipped ``_check_kv_share_config`` orphan check exactly): a borrower
-    # whose attention type has ANY same-type producer below the split allocates
-    # zero KV — it reuses that producer's cache. WHICH producer index it borrows
-    # from does not change the borrower's own footprint (still zero), so a
-    # per-index source mapping would not alter this estimate.
+    #     M = num_hidden_layers - num_kv_shared_layers          # split
+    #     last_producer_by_type = {layer_types[i]: i for i in range(M)}  # last wins
+    #     previous_kvs[j] = last_producer_by_type[layer_types[j]]  (j in [M, N))
+    #
+    # so a borrower ``j`` reuses the LAST producer BELOW the split whose
+    # attention type matches its own, and allocates zero KV. We zero borrower
+    # ``j`` ONLY when such a same-type producer exists — i.e. its mapped
+    # producer's type equals its own (true by construction of the map). A
+    # borrower whose type has NO producer below the split is NOT zeroed: it is
+    # charged its own footprint (the shipped model would raise a KeyError at
+    # build time for that config, so no runnable request is ever under-reserved —
+    # over-count, never under-count). This exact per-index map supersedes the old
+    # set-subset test, which could zero a borrower without validating the actual
+    # producer it maps to (codex round 11 BLOCKING #2). If ``num_kv_shared_layers``
+    # is absent / out of range, no layer borrows.
     num_shared = _cfg_get(struct, "num_kv_shared_layers")
     if isinstance(num_shared, int) and not isinstance(num_shared, bool):
         num_shared = num_shared if 0 < num_shared < base_num_layers else 0
     else:
         num_shared = 0
+    borrowed_layers: set[int] = set()
     if num_shared > 0:
         split = base_num_layers - num_shared
-        producer_types = set(layer_types[:split])
-        borrower_types = set(layer_types[split:])
-        if not borrower_types <= producer_types:
-            num_shared = 0  # last-N contract unverified → do not zero anything
-    first_borrower = base_num_layers - num_shared
+        last_producer_by_type: dict[str, int] = {}
+        for producer_idx in range(split):
+            last_producer_by_type[layer_types[producer_idx]] = producer_idx
+        for borrower_idx in range(split, base_num_layers):
+            mapped = last_producer_by_type.get(layer_types[borrower_idx])
+            # ``mapped`` is keyed by type, so ``layer_types[mapped]`` is the
+            # borrower's own type whenever the lookup hits — the exact
+            # same-type-producer condition the shipped model relies on.
+            if mapped is not None and layer_types[mapped] == layer_types[borrower_idx]:
+                borrowed_layers.add(borrower_idx)
 
     # The uniform per-layer charge (base dims). It is the never-under-count
     # floor: no per-token-growing layer is ever charged LESS than this.
@@ -471,37 +559,30 @@ def estimate_kv_footprint(
     full_per_token = max(
         2 * dtype_bytes * global_kv_heads * global_head_dim, uniform_per_layer
     )
-    # Per-token KV rate of ONE sliding-window layer (local dims), clamped to the
-    # uniform base-layer floor for the same reason full layers are (codex round 7
-    # BLOCKING #2): a malformed / non-authoritative nested config exposing
-    # smaller local dims than the base must not drop a layer's charge below the
-    # uniform per-layer rate and open an under-count.
+    # Per-slot (per-token-position) KV bytes of ONE sliding-window layer (local
+    # dims), clamped to the uniform base-layer floor for the same reason full
+    # layers are (codex round 7 BLOCKING #2): a malformed / non-authoritative
+    # nested config exposing smaller local dims than the base must not drop a
+    # layer's charge below the uniform per-layer rate and open an under-count.
     sliding_per_layer = max(
         2 * dtype_bytes * local_kv_heads * local_head_dim, uniform_per_layer
     )
-    # WHOLE-capacity buffer of ONE sliding-window layer, charged once per
-    # sequence. The real ``RotatingKVCache`` does NOT allocate exactly ``window``
-    # slots: it grows the buffer in ``_ROTATING_CACHE_STEP``-token increments and
-    # retains ``_ROTATING_CACHE_KEEP`` sink positions ABOVE the rotating window,
-    # so its true capacity is ``window + keep`` rounded UP to the next ``step``
-    # multiple — which can exceed the raw window (codex round 10 BLOCKING: the
-    # whole-window figure still under-counts the block-rounded, sink-retaining
-    # allocation). Reserving that step-rounded capacity is the over-count-SAFE
-    # upper bound that can never trip the D-METAL-CAP OOM cliff, regardless of the
-    # token budget. Still a massive reduction vs unbounded per-token growth: the
-    # window is bounded (e.g. 512-4096) while generation is not.
-    sliding_slots = (
-        (window + _ROTATING_CACHE_KEEP + _ROTATING_CACHE_STEP - 1)
-        // _ROTATING_CACHE_STEP
-    ) * _ROTATING_CACHE_STEP
-    sliding_window_bytes = sliding_slots * sliding_per_layer
 
     per_token_growth = 0
     fixed_baseline = 0
+    # ``sliding_slot_bytes`` accumulates the per-SLOT bytes of every
+    # window-bounded sliding layer. The scheduler multiplies it by the
+    # per-request slot count ``rotating_cache_slots(window, T)`` — a SUBLINEAR
+    # bound that grows with the request's token budget up to the full rotating
+    # buffer (codex round 11 BLOCKING #1: a fixed whole-window baseline
+    # over-counts short requests). Sliding layers therefore contribute nothing to
+    # the token-independent ``fixed_baseline`` (which now holds recurrent state
+    # only) — their footprint is genuinely request-dependent.
+    sliding_slot_bytes = 0
     for idx in range(base_num_layers):
-        if idx >= first_borrower:
-            # Borrower (KV-sharing) layer — reuses a producer's cache, allocates
-            # nothing.
+        if idx in borrowed_layers:
+            # Borrower (KV-sharing) layer — reuses its mapped same-type
+            # producer's cache, allocates nothing.
             continue
         layer_type = layer_types[idx]
         layer_class = _classify_layer(layer_type)
@@ -522,8 +603,10 @@ def estimate_kv_footprint(
             continue
         if layer_class == "sliding":
             if window > 0:
-                # Window-bounded: the whole rotating buffer, once per sequence.
-                fixed_baseline += sliding_window_bytes
+                # Window-bounded: contributes one slot's bytes to the
+                # per-request sliding term (charged as
+                # ``sliding_slot_bytes × rotating_cache_slots(window, T)``).
+                sliding_slot_bytes += sliding_per_layer
             else:
                 # No readable window → cannot bound it → charge the uniform
                 # per-layer growth (never under-count).
@@ -531,7 +614,14 @@ def estimate_kv_footprint(
         else:  # "full"
             per_token_growth += full_per_token
 
+    # Advertise the window only when at least one window-bounded sliding layer
+    # actually contributed a slot term — otherwise there is no sliding term and
+    # the scheduler must not multiply anything by a stray window.
+    effective_sliding_window = window if sliding_slot_bytes > 0 else 0
+
     return KVFootprintEstimate(
         per_token_growth_bytes=int(per_token_growth),
         fixed_baseline_bytes=int(fixed_baseline),
+        sliding_slot_bytes=int(sliding_slot_bytes),
+        sliding_window=int(effective_sliding_window),
     )

--- a/vllm_mlx/kv_estimation.py
+++ b/vllm_mlx/kv_estimation.py
@@ -72,17 +72,19 @@ path — see ``scheduler._resolve_kv_bytes_per_token``):
    layers are charged exactly per token; a sliding layer with no readable window
    is charged as full unbounded growth; an unrecognized layer-type string is
    charged as full growth (exact-match allowlists, no substring guessing).
-   Sliding-window layers with a readable window are charged their exact peak —
-   ``rate * min(tokens, window)`` — which is both an upper bound on the rotating
-   cache AND equal to the historical uniform figure for any request shorter than
-   the window, so the reduction never comes at the cost of over-charging (and
-   spuriously rejecting) a short request. Recurrent layers genuinely have zero
-   per-token growth; each recurrent layer's fixed state is sized from its
-   family's real config fields (GatedDeltaNet linear head dims + conv kernel;
-   Mamba d_state/d_conv) and charged at fp32/element to stay conservative, and a
-   recurrent layer whose state CANNOT be sized falls back to full per-token
-   growth rather than going unreserved. The fixed baseline is charged once per
-   sequence and never scales with generated tokens.
+   Sliding-window layers with a readable window report a per-token ``rate`` and
+   the window; the caller charges ``rate * min(tokens, window)`` for decode (an
+   upper bound on the rotating cache, equal to the historical uniform figure for
+   any request shorter than the window) floored at the full prompt to cover the
+   transient prefill peak — so the reduction never comes at the cost of
+   over-charging a short request nor under-charging a large prefill. Recurrent
+   layers genuinely have zero per-token growth; a GatedDeltaNet layer's fixed
+   state is sized from its real config fields (linear head dims + conv kernel)
+   and charged at fp32/element to stay conservative. Every other recurrent family
+   (Mamba/Mamba2, RWKV, generic) is NOT sized — its exact cache layout is not
+   modelled here — and falls back to full per-token growth rather than a possibly
+   wrong fixed state, so it is never under-reserved. The fixed baseline is
+   charged once per sequence and never scales with generated tokens.
 3. **KV-sharing only zeroes verified borrowers.** ``num_kv_shared_layers``
    declares that the LAST N layers borrow (Gemma-4 / Gemma-3n contract). We zero
    those borrowers only when the per-layer ``layer_types`` map confirms it —
@@ -300,55 +302,28 @@ def _gateddeltanet_state_bytes(struct: Any) -> int | None:
     return _RECURRENT_STATE_BYTES_PER_ELEM * (recurrent_elems + conv_elems)
 
 
-def _mamba_state_bytes(struct: Any) -> int | None:
-    """Mamba / Mamba2 per-sequence state bytes.
-
-    State = the SSM state ``d_inner × d_state`` plus the conv ring buffer
-    ``d_inner × (d_conv − 1)``.
-
-    Sized ONLY from ``mamba_``-prefixed config fields, never from generic
-    ``state_size`` / ``intermediate_size`` / ``conv_kernel_size`` (codex round 4
-    BLOCKING #2). Those generic names are not Mamba-specific: another recurrent
-    family (RWKV, etc.) commonly exposes ``intermediate_size`` / ``state_size``
-    for an entirely different tensor, so reading them here would stamp a bogus
-    Mamba-shaped fixed state onto a non-Mamba layer and zero its per-token
-    growth — an under-count on the D-METAL-CAP path. A layer that does not carry
-    the Mamba-specific fields returns ``None`` so the caller charges it full
-    per-token growth (the safe, never-under-count fallback).
-
-    Same all-or-nothing rule: ``d_state`` AND the inner dimension AND the conv
-    kernel must all be readable from Mamba-specific fields, else return ``None``
-    so the conv buffer is never silently dropped (codex round 3 BLOCKING #2).
-    """
-    d_state = _pos_int(_cfg_get(struct, "mamba_d_state"))
-    n_heads = _pos_int(_cfg_get(struct, "mamba_n_heads"))
-    d_head = _pos_int(_cfg_get(struct, "mamba_d_head"))
-    d_inner = (n_heads * d_head) if (n_heads and d_head) else 0
-    if d_inner == 0:
-        d_inner = _pos_int(_cfg_get(struct, "mamba_intermediate_size"))
-    d_conv = _pos_int(_cfg_get(struct, "mamba_d_conv"))
-    if not (d_state and d_inner and d_conv):
-        return None
-    ssm_elems = d_inner * d_state
-    conv_elems = d_inner * (d_conv - 1)
-    return _RECURRENT_STATE_BYTES_PER_ELEM * (ssm_elems + conv_elems)
-
-
 def _recurrent_state_bytes(struct: Any, layer_type: str) -> int | None:
     """Conservative per-sequence FIXED state of one recurrent layer, in bytes.
 
-    Dispatches by the EXACT recurrent family named in ``layer_type`` and sizes
-    the state only from that family's real config fields — so a family we do not
-    model (generic ``"recurrent"`` / ``"rwkv"``) never gets a bogus Mamba/GDN
-    estimate from incidentally-matching generic fields (codex round 4
-    BLOCKING #2). Returns ``None`` (→ caller charges full per-token growth) for
-    any family we cannot size exactly.
-
-    Every GatedDeltaNet alias the classifier treats as recurrent
+    Sizes the state only for the recurrent family whose EXACT state + conv
+    layout we have validated against the shipped implementation — GatedDeltaNet
+    (Qwen3-Next / Qwen3.5 / Qwen3.6), keyed on its family-specific ``linear_*``
+    fields. Every GatedDeltaNet alias the classifier treats as recurrent
     (``_GATEDDELTANET_TYPES``: ``linear_attention`` + the ``gated_delta_net`` /
     ``gated_deltanet`` upstream spellings) routes to the same sizer, so a config
     that names its linear layers with an alias still gets the reduction rather
     than silently reverting to full per-token growth (codex round 5 BLOCKING).
+
+    Every OTHER recurrent family — Mamba / Mamba2, RWKV, generic ``recurrent`` —
+    returns ``None`` so the caller charges the layer full per-token growth (the
+    safe, never-under-count fallback). We deliberately do NOT attempt to size a
+    Mamba state: the conv buffer channel count differs between Mamba1
+    (``d_inner``) and Mamba2 (``d_inner`` + grouped ``B``/``C`` channels =
+    ``d_inner + 2·n_groups·d_state``), so a single generic formula would
+    UNDER-reserve Mamba2 (codex round 7 BLOCKING) — and this engine ships no
+    Mamba model, so over-counting those layers as full growth costs nothing while
+    keeping the OOM-safety guarantee intact. When a real Mamba family is shipped,
+    add a family-specific sizer here mirroring its exact cache shapes.
 
     The returned term is a per-sequence constant (it does not grow with
     generated tokens), so it lands in the fixed baseline, never in per-token
@@ -356,10 +331,7 @@ def _recurrent_state_bytes(struct: Any, layer_type: str) -> int | None:
     """
     if layer_type in _GATEDDELTANET_TYPES:
         return _gateddeltanet_state_bytes(struct)
-    if layer_type in ("mamba", "mamba2"):
-        return _mamba_state_bytes(struct)
-    # Generic / unimplemented recurrent family (e.g. "recurrent", "rwkv"): we do
-    # not know its exact state layout, so we cannot size it → full-growth.
+    # Mamba/Mamba2/RWKV/other recurrent: state layout not modelled → full growth.
     return None
 
 
@@ -492,8 +464,14 @@ def estimate_kv_footprint(
     # multiplies this by ``min(tokens, window)`` — the true peak occupancy of a
     # rotating cache — rather than flattening the whole window into the baseline,
     # so a request shorter than the window is charged only for the tokens it
-    # actually holds (codex round 6 BLOCKING).
-    sliding_per_layer = 2 * dtype_bytes * local_kv_heads * local_head_dim
+    # actually holds (codex round 6 BLOCKING). Clamped to the uniform base-layer
+    # floor for the same reason full layers are (codex round 7 BLOCKING #2): if a
+    # malformed or semantically-different nested config exposes smaller local
+    # dims than the base the scheduler read, the sliding term must not drop below
+    # the uniform per-layer charge and open an under-count.
+    sliding_per_layer = max(
+        2 * dtype_bytes * local_kv_heads * local_head_dim, uniform_per_layer
+    )
 
     per_token_growth = 0
     fixed_baseline = 0

--- a/vllm_mlx/kv_estimation.py
+++ b/vllm_mlx/kv_estimation.py
@@ -532,11 +532,11 @@ def estimate_kv_footprint(
     global_head_dim = _pos_int(_cfg_get(struct, "global_head_dim")) or local_head_dim
 
     # Sliding window size — the SINGLE window every sliding layer shares. Resolved
-    # via ``_uniform_sliding_window``, which returns 0 unless uniformity is proven
-    # (positive scalar, or a per-layer list whose positive entries are all equal).
-    # When a sliding layer's window is unreadable, or sliding layers use DIFFERING
-    # per-layer windows, ``window`` is 0 and those layers are charged as full
-    # per-token growth below (over-count-safe, never under-count).
+    # via ``_uniform_sliding_window``, which is scalar-only: it returns the window
+    # only when ``sliding_window`` is one positive scalar (the shipped GPT-OSS /
+    # Gemma-4 shape). Any per-layer window list/tuple, or an unreadable value,
+    # yields 0 and those sliding layers are charged as full per-token growth below
+    # (over-count-safe, never under-count).
     window = _uniform_sliding_window(struct)
 
     # ``layer_types`` is guaranteed present + length-checked by

--- a/vllm_mlx/kv_estimation.py
+++ b/vllm_mlx/kv_estimation.py
@@ -249,39 +249,44 @@ def _recurrent_state_bytes(struct: Any) -> int | None:
     Every term is a per-sequence constant (it does not grow with generated
     tokens), so it lands in the fixed baseline, never in per-token growth.
     """
-    # GatedDeltaNet.
+    # GatedDeltaNet. ALL of the state + conv dimensions must be present and
+    # positive — including the conv kernel. If any is missing we cannot size
+    # the full state, so we return None (the caller charges full growth) rather
+    # than silently omitting the conv buffer and under-reserving (codex round 3
+    # BLOCKING #1).
     num_v = _pos_int(_cfg_get(struct, "linear_num_value_heads"))
     num_k = _pos_int(_cfg_get(struct, "linear_num_key_heads"))
     head_k = _pos_int(_cfg_get(struct, "linear_key_head_dim"))
     head_v = _pos_int(_cfg_get(struct, "linear_value_head_dim"))
-    if num_v and num_k and head_k and head_v:
-        conv_kernel = _pos_int(_cfg_get(struct, "linear_conv_kernel_dim"))
+    conv_kernel = _pos_int(_cfg_get(struct, "linear_conv_kernel_dim"))
+    if num_v and num_k and head_k and head_v and conv_kernel:
         key_dim = num_k * head_k
         value_dim = num_v * head_v
         recurrent_elems = num_v * head_k * head_v
         conv_dim = 2 * key_dim + value_dim
-        conv_elems = max(conv_kernel - 1, 0) * conv_dim
+        conv_elems = (conv_kernel - 1) * conv_dim
         return _RECURRENT_STATE_BYTES_PER_ELEM * (recurrent_elems + conv_elems)
 
-    # Mamba / Mamba2.
+    # Mamba / Mamba2 — same all-or-nothing rule: the SSM state, the inner
+    # dimension AND the conv kernel must all be readable, else return None so
+    # the conv buffer is never silently dropped (codex round 3 BLOCKING #2).
     d_state = _pos_int(_cfg_get(struct, "mamba_d_state")) or _pos_int(
         _cfg_get(struct, "state_size")
     )
-    if d_state:
-        n_heads = _pos_int(_cfg_get(struct, "mamba_n_heads"))
-        d_head = _pos_int(_cfg_get(struct, "mamba_d_head"))
-        d_inner = (n_heads * d_head) if (n_heads and d_head) else 0
-        if d_inner == 0:
-            d_inner = _pos_int(_cfg_get(struct, "mamba_intermediate_size")) or _pos_int(
-                _cfg_get(struct, "intermediate_size")
-            )
-        if d_inner:
-            d_conv = _pos_int(_cfg_get(struct, "mamba_d_conv")) or _pos_int(
-                _cfg_get(struct, "conv_kernel_size")
-            )
-            ssm_elems = d_inner * d_state
-            conv_elems = d_inner * max(d_conv - 1, 0)
-            return _RECURRENT_STATE_BYTES_PER_ELEM * (ssm_elems + conv_elems)
+    n_heads = _pos_int(_cfg_get(struct, "mamba_n_heads"))
+    d_head = _pos_int(_cfg_get(struct, "mamba_d_head"))
+    d_inner = (n_heads * d_head) if (n_heads and d_head) else 0
+    if d_inner == 0:
+        d_inner = _pos_int(_cfg_get(struct, "mamba_intermediate_size")) or _pos_int(
+            _cfg_get(struct, "intermediate_size")
+        )
+    d_conv = _pos_int(_cfg_get(struct, "mamba_d_conv")) or _pos_int(
+        _cfg_get(struct, "conv_kernel_size")
+    )
+    if d_state and d_inner and d_conv:
+        ssm_elems = d_inner * d_state
+        conv_elems = d_inner * (d_conv - 1)
+        return _RECURRENT_STATE_BYTES_PER_ELEM * (ssm_elems + conv_elems)
 
     return None
 

--- a/vllm_mlx/kv_estimation.py
+++ b/vllm_mlx/kv_estimation.py
@@ -1,0 +1,317 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Architecture-aware per-token KV-cache footprint estimation.
+
+The D-METAL-CAP admission gate (``scheduler._enforce_metal_cap_at_admission``)
+projects how much KV-cache a new request would allocate and rejects it before
+the allocation pushes Metal active past the operator cap. That projection is
+driven by a *per-token* byte figure. The historical figure was a UNIFORM
+formula::
+
+    per_token = 2 (K+V) * num_hidden_layers * num_key_value_heads
+                  * head_dim * dtype_bytes
+
+which treats EVERY layer as a full-growth attention layer. That is wrong for
+the hybrid architectures this engine ships:
+
+* **Sliding-window layers** (GPT-OSS ~50% sliding; Gemma-4 local layers) hold a
+  fixed rotating window of KV. Their footprint is bounded by the window size —
+  it does NOT grow per generated token.
+* **KV-sharing / borrower layers** (Gemma-4 / Gemma-3n ``num_kv_shared_layers``)
+  compute no K/V of their own; they reuse an earlier producer layer's cache and
+  allocate ZERO KV.
+* **Recurrent / linear-attention layers** (Qwen3.5/3.6 GatedDeltaNet, Mamba)
+  carry a fixed-size recurrent state. Zero per-token growth.
+
+Counting all of those as full-growth over-estimates the per-token figure by up
+to ~2x for Gemma-4 / GPT-OSS / Qwen3.5, which makes the admission gate reject
+requests that would actually fit — a spurious rejection on memory-constrained
+Macs.
+
+This module computes an accurate footprint by classifying each layer:
+
+``per_token_growth_bytes``
+    ``2 * dtype_bytes * Σ (kv_heads_L * head_dim_L)`` over ONLY the
+    full-attention (per-token-growing) layers, honoring per-layer / global dims
+    when the architecture is hybrid.
+
+``fixed_baseline_bytes``
+    ``2 * dtype_bytes * Σ_sliding (window_L * kv_heads_L * head_dim_L)`` plus a
+    conservative fixed term per recurrent layer. Allocated once per sequence,
+    not per token.
+
+Borrower (KV-sharing) layers contribute 0 to both.
+
+Safety contract (this feeds a codex-hardened, over-estimate-safe admission
+path — see ``scheduler._resolve_kv_bytes_per_token``):
+
+1. **Over-estimate-safe fallback.** When the config lacks the layer-structure
+   fields (no per-layer ``layer_types`` and no ``num_kv_shared_layers``), or
+   anything is ambiguous, the estimator returns the caller's uniform figure
+   unchanged (``per_token_growth_bytes == uniform_per_token_bytes`` and
+   ``fixed_baseline_bytes == 0``) so dense models (Llama/Qwen dense) and
+   unknown/stub configs stay BYTE-IDENTICAL to the historical behavior. Only a
+   recognized hybrid — one that exposes a per-layer ``layer_types`` list of the
+   right length or a valid ``num_kv_shared_layers`` — gets the smaller accurate
+   number.
+2. **Never under-count the counted layers.** ``fixed_baseline + tokens *
+   per_token_growth`` is always >= the true architecture-aware footprint of the
+   counted layers: full-attention layers are charged exactly; sliding layers
+   are charged their whole window (an upper bound for any token count); a
+   sliding layer with no readable window is charged as full-growth; an
+   unrecognized layer type is charged as full-growth. So the estimate can only
+   over-count, never under-count — it can never re-introduce the D-METAL-CAP
+   OOM cliff.
+
+The estimator is a pure function: it reads only plain fields off a config
+object (or its ``text_config``), performs no I/O, loads no weights, and is unit
+testable without a live model.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+# Per-layer attention-type classification tokens. Ordered checks in
+# ``_classify_layer`` matter: ``"linear_attention"`` and ``"sliding_attention"``
+# both contain ``"attention"``, so recurrent and sliding are tested BEFORE the
+# generic full-attention tokens.
+_RECURRENT_TOKENS: tuple[str, ...] = (
+    "linear",
+    "mamba",
+    "recurrent",
+    "rwkv",
+    "ssm",
+    "gated",
+    "delta",
+)
+_SLIDING_TOKENS: tuple[str, ...] = ("slid", "swa", "local", "window")
+_FULL_TOKENS: tuple[str, ...] = ("full", "global", "attention", "sdpa")
+
+
+@dataclass(frozen=True)
+class KVFootprintEstimate:
+    """Architecture-aware KV footprint of a single sequence.
+
+    Attributes:
+        per_token_growth_bytes: Bytes of KV cache allocated per additional
+            token, summed over the full-attention (per-token-growing) layers
+            only. This is the value the D-METAL-CAP projection multiplies by
+            ``(prompt_tokens + max_tokens)``.
+        fixed_baseline_bytes: Bytes allocated once per sequence regardless of
+            token count — the sliding-window rotating buffers plus a
+            conservative recurrent-state term. Zero for a dense model.
+    """
+
+    per_token_growth_bytes: int
+    fixed_baseline_bytes: int
+
+
+def _cfg_get(cfg: Any, name: str, default: Any = None) -> Any:
+    """Read ``name`` off a config that may be a dict or an attribute object."""
+    if cfg is None:
+        return default
+    if isinstance(cfg, dict):
+        return cfg.get(name, default)
+    return getattr(cfg, name, default)
+
+
+def _pos_int(value: Any) -> int:
+    """Return ``value`` when it is a strictly-positive, non-bool int, else 0.
+
+    Mirrors the scheduler's ``isinstance(..., int)`` MagicMock guard: a
+    ``MagicMock`` attribute is not an ``int`` (and ``bool`` is excluded because
+    it is an ``int`` subclass that never denotes a real dimension).
+    """
+    if isinstance(value, bool):
+        return 0
+    if isinstance(value, int) and value > 0:
+        return value
+    return 0
+
+
+def _valid_layer_types(value: Any, expected_len: int) -> list[str] | None:
+    """Return ``value`` as a list of type strings iff it is well-formed.
+
+    Well-formed = a list/tuple of exactly ``expected_len`` string entries. Any
+    other shape (missing, MagicMock, wrong length, non-string entries) returns
+    ``None`` so the caller falls back to the uniform formula rather than
+    guessing a per-layer layout it cannot trust.
+    """
+    if not isinstance(value, (list, tuple)):
+        return None
+    if len(value) != expected_len or expected_len <= 0:
+        return None
+    if not all(isinstance(entry, str) for entry in value):
+        return None
+    return [entry.lower() for entry in value]
+
+
+def _pick_structural_config(model_config: Any, base_num_layers: int) -> Any | None:
+    """Select the config object that carries the hybrid layer structure.
+
+    Layer-structure fields live either directly on ``model_config`` (text-lane
+    configs) or nested under ``model_config.text_config`` (multimodal configs).
+    Returns the config whose ``layer_types`` list matches ``base_num_layers``,
+    or — absent that — the one exposing a valid ``num_kv_shared_layers`` in
+    ``(0, base_num_layers)``. Returns ``None`` when neither carries a
+    recognized hybrid signal (the byte-identical dense/unknown fallback).
+    """
+    candidates = [model_config]
+    text_config = _cfg_get(model_config, "text_config")
+    if text_config is not None:
+        candidates.append(text_config)
+
+    for cfg in candidates:
+        if _valid_layer_types(_cfg_get(cfg, "layer_types"), base_num_layers):
+            return cfg
+    for cfg in candidates:
+        shared = _cfg_get(cfg, "num_kv_shared_layers")
+        if isinstance(shared, int) and not isinstance(shared, bool):
+            if 0 < shared < base_num_layers:
+                return cfg
+    return None
+
+
+def _classify_layer(layer_type: str) -> str:
+    """Map a lower-cased ``layer_types`` entry to a footprint class.
+
+    Returns one of ``"recurrent"``, ``"sliding"``, ``"full"``. A recognized
+    full-attention token and an UNrecognized string both resolve to ``"full"``
+    — the conservative (over-counting) default that can never under-count.
+    """
+    if any(tok in layer_type for tok in _RECURRENT_TOKENS):
+        return "recurrent"
+    if any(tok in layer_type for tok in _SLIDING_TOKENS):
+        return "sliding"
+    if any(tok in layer_type for tok in _FULL_TOKENS):
+        return "full"
+    # Unrecognized attention-type string → charge as full growth (never
+    # under-count).
+    return "full"
+
+
+def estimate_kv_footprint(
+    model_config: Any,
+    *,
+    dtype_bytes: int,
+    uniform_per_token_bytes: int,
+    base_num_layers: int,
+    base_kv_heads: int,
+    base_head_dim: int,
+) -> KVFootprintEstimate:
+    """Compute the architecture-aware KV footprint for one sequence.
+
+    Args:
+        model_config: The live model config (attribute object or dict). Only
+            plain fields are read; no I/O, no weight load.
+        dtype_bytes: KV element size in bytes, as already resolved by the
+            caller (``scheduler._infer_kv_dtype_bytes``).
+        uniform_per_token_bytes: The caller's historical uniform per-token
+            figure. Returned unchanged when the config is not a recognized
+            hybrid, guaranteeing byte-identical behavior for dense/unknown
+            models.
+        base_num_layers: ``num_hidden_layers`` as read by the caller. Used to
+            validate the ``layer_types`` length and to bound the borrower split.
+        base_kv_heads: ``num_key_value_heads`` (or attention heads) as read by
+            the caller — the local/sliding-layer KV-head count.
+        base_head_dim: ``head_dim`` as read by the caller — the local/sliding
+            head dimension.
+
+    Returns:
+        A :class:`KVFootprintEstimate`. For a non-hybrid config this is exactly
+        ``(uniform_per_token_bytes, 0)``.
+    """
+    uniform = KVFootprintEstimate(
+        per_token_growth_bytes=uniform_per_token_bytes,
+        fixed_baseline_bytes=0,
+    )
+
+    # Guard the primitives. If the caller could not read a positive uniform
+    # figure (MagicMock model / missing config), stay at the byte-identical
+    # fallback — the scheduler never calls us in that case, but be defensive.
+    if (
+        _pos_int(dtype_bytes) == 0
+        or _pos_int(base_num_layers) == 0
+        or _pos_int(base_kv_heads) == 0
+        or _pos_int(base_head_dim) == 0
+        or uniform_per_token_bytes <= 0
+    ):
+        return uniform
+
+    struct = _pick_structural_config(model_config, base_num_layers)
+    if struct is None:
+        # Not a recognized hybrid — dense (Llama/Qwen dense) or an
+        # unknown/stub config. Byte-identical to the uniform formula.
+        return uniform
+
+    # Local (sliding / default) dims — prefer the structural config, fall back
+    # to the caller's base values so a config that only splits full vs sliding
+    # via ``layer_types`` (no distinct local fields) still works.
+    local_kv_heads = (
+        _pos_int(_cfg_get(struct, "num_key_value_heads"))
+        or _pos_int(_cfg_get(struct, "num_attention_heads"))
+        or base_kv_heads
+    )
+    local_head_dim = _pos_int(_cfg_get(struct, "head_dim")) or base_head_dim
+
+    # Global (full-attention) dims. Gemma-4 full layers use a wider
+    # ``global_head_dim`` / ``num_global_key_value_heads`` than the local
+    # sliding layers; when absent (GPT-OSS and most hybrids) they fall back to
+    # the local dims. Using the (larger-or-equal) global dim for full layers is
+    # both accurate and never-under-count.
+    global_kv_heads = (
+        _pos_int(_cfg_get(struct, "num_global_key_value_heads")) or local_kv_heads
+    )
+    global_head_dim = _pos_int(_cfg_get(struct, "global_head_dim")) or local_head_dim
+
+    # Sliding window size. When a layer is sliding but the window is unreadable
+    # we cannot bound its footprint, so it is charged as full-growth below.
+    window = _pos_int(_cfg_get(struct, "sliding_window"))
+
+    # Borrower split: the last ``num_kv_shared_layers`` layers reuse an earlier
+    # producer's K/V and allocate nothing. ``first_borrower`` is the index at
+    # which borrowing begins.
+    num_shared = _cfg_get(struct, "num_kv_shared_layers")
+    if isinstance(num_shared, int) and not isinstance(num_shared, bool):
+        num_shared = num_shared if 0 <= num_shared < base_num_layers else 0
+    else:
+        num_shared = 0
+    first_borrower = base_num_layers - num_shared
+
+    layer_types = _valid_layer_types(_cfg_get(struct, "layer_types"), base_num_layers)
+
+    full_per_token = 2 * dtype_bytes * global_kv_heads * global_head_dim
+    sliding_full_per_token = 2 * dtype_bytes * local_kv_heads * local_head_dim
+    sliding_window_bytes = 2 * dtype_bytes * window * local_kv_heads * local_head_dim
+    # Recurrent state is a fixed per-head state matrix (~head_dim x head_dim per
+    # KV head for GatedDeltaNet / Mamba). It never grows per token, so it lands
+    # entirely in the fixed baseline. A conservative single-matrix term (no K+V
+    # doubling) derived from the local dims — see module docstring.
+    recurrent_state_bytes = (
+        dtype_bytes * local_kv_heads * local_head_dim * local_head_dim
+    )
+
+    per_token_growth = 0
+    fixed_baseline = 0
+    for idx in range(base_num_layers):
+        if idx >= first_borrower:
+            # Borrower (KV-sharing) layer — allocates nothing.
+            continue
+        layer_class = _classify_layer(layer_types[idx]) if layer_types else "full"
+        if layer_class == "recurrent":
+            fixed_baseline += recurrent_state_bytes
+        elif layer_class == "sliding":
+            if window > 0:
+                fixed_baseline += sliding_window_bytes
+            else:
+                # No readable window → cannot bound it → charge as full growth
+                # (never under-count).
+                per_token_growth += sliding_full_per_token
+        else:  # "full"
+            per_token_growth += full_per_token
+
+    return KVFootprintEstimate(
+        per_token_growth_bytes=int(per_token_growth),
+        fixed_baseline_bytes=int(fixed_baseline),
+    )

--- a/vllm_mlx/kv_estimation.py
+++ b/vllm_mlx/kv_estimation.py
@@ -206,6 +206,18 @@ def rotating_cache_slots(window: int, tokens: int) -> int:
 
     Returns ``0`` when there is no window or no tokens (no sliding term).
     """
+    # Why ONE global (step=256, keep=4) is valid for every sliding layer we
+    # reduce: rapid-mlx constructs ALL sliding-window caches through mlx_lm's
+    # ``RotatingKVCache`` (directly, or via ``make_prompt_cache`` / the vendored
+    # Gemma-4 / DeepSeek-V4 stacks), which share the class-default ``step = 256``
+    # and a ``keep`` of 0–4. That global invariant IS the per-architecture
+    # verification codex asks for — pinned by the hermetic drift test
+    # ``tests/test_kv_estimation.py::TestRotatingCacheConstantsMatchInstalledMlxLm``
+    # against the INSTALLED mlx_lm (fails loudly if step/keep ever change). If a
+    # future family ships a sliding cache that is NOT mlx_lm ``RotatingKVCache``
+    # (different granularity/retention), that combination must be re-verified
+    # before its ``layer_types`` entry is added to ``_SLIDING_TYPES`` — otherwise
+    # this slot count could under-reserve it.
     if window <= 0 or tokens <= 0:
         return 0
     effective = min(tokens, window) + _ROTATING_CACHE_KEEP
@@ -350,6 +362,38 @@ def _classify_layer(layer_type: str) -> str:
     if layer_type in _SLIDING_TYPES:
         return "sliding"
     return "full"
+
+
+def _uniform_sliding_window(struct: Any) -> int:
+    """Return the single rotating-window size shared by ALL sliding layers, or 0.
+
+    The per-request slot model (``sliding_slot_bytes × rotating_cache_slots(window,
+    T)``) charges every sliding layer with ONE window. That is exact only when the
+    sliding layers genuinely share a single window — the shipped shape: GPT-OSS and
+    Gemma-4 expose ``sliding_window`` as one positive scalar. This resolver returns
+    a window ONLY when it can prove uniformity:
+
+    * a positive int scalar → the uniform window (shipped case);
+    * a per-layer list/tuple whose positive entries are ALL EQUAL → that one
+      distinct window (still uniform, so still exact);
+    * otherwise (a list with DIFFERING positive windows, or an unreadable shape) →
+      ``0``.
+
+    Returning ``0`` makes the caller fold those sliding layers into full per-token
+    growth (over-count-safe) rather than charging every sliding layer with one
+    scalar window that could UNDER-count a layer whose real window is larger
+    (codex round 13 BLOCKING #3). It never picks the min/first of differing
+    windows — which would be the under-counting mistake.
+    """
+    raw = _cfg_get(struct, "sliding_window")
+    scalar = _pos_int(raw)
+    if scalar:
+        return scalar
+    if isinstance(raw, (list, tuple)):
+        distinct = {v for v in (_pos_int(entry) for entry in raw) if v > 0}
+        if len(distinct) == 1:
+            return next(iter(distinct))
+    return 0
 
 
 # mlx-lm materializes the recurrent conv/SSM state buffers with ``mx.zeros``,
@@ -497,9 +541,13 @@ def estimate_kv_footprint(
     )
     global_head_dim = _pos_int(_cfg_get(struct, "global_head_dim")) or local_head_dim
 
-    # Sliding window size. When a layer is sliding but the window is unreadable
-    # we cannot bound its footprint, so it is charged as full-growth below.
-    window = _pos_int(_cfg_get(struct, "sliding_window"))
+    # Sliding window size — the SINGLE window every sliding layer shares. Resolved
+    # via ``_uniform_sliding_window``, which returns 0 unless uniformity is proven
+    # (positive scalar, or a per-layer list whose positive entries are all equal).
+    # When a sliding layer's window is unreadable, or sliding layers use DIFFERING
+    # per-layer windows, ``window`` is 0 and those layers are charged as full
+    # per-token growth below (over-count-safe, never under-count).
+    window = _uniform_sliding_window(struct)
 
     # ``layer_types`` is guaranteed present + length-checked by
     # ``_pick_structural_config``; the ``is None`` branch is unreachable but
@@ -541,6 +589,16 @@ def estimate_kv_footprint(
         for producer_idx in range(split):
             last_producer_by_type[layer_types[producer_idx]] = producer_idx
         for borrower_idx in range(split, base_num_layers):
+            # KV sharing reuses an earlier producer's ATTENTION K/V. A recurrent /
+            # linear-attention layer that happens to sit in the last-N borrower
+            # positions has no attention KV to share — it keeps its OWN fixed
+            # recurrent state — so it must NEVER be zeroed here; it falls through
+            # to the recurrent branch below and is charged its state (or
+            # full-growth fallback). Only an attention-class borrower can borrow
+            # and allocate zero (codex round 13 BLOCKING #1: zeroing a recurrent
+            # borrower would drop its state and under-count).
+            if _classify_layer(layer_types[borrower_idx]) == "recurrent":
+                continue
             mapped = last_producer_by_type.get(layer_types[borrower_idx])
             # ``mapped`` is keyed by type, so ``layer_types[mapped]`` is the
             # borrower's own type whenever the lookup hits — the exact

--- a/vllm_mlx/kv_estimation.py
+++ b/vllm_mlx/kv_estimation.py
@@ -229,65 +229,86 @@ def _classify_layer(layer_type: str) -> str:
 _RECURRENT_STATE_BYTES_PER_ELEM = 4
 
 
-def _recurrent_state_bytes(struct: Any) -> int | None:
-    """Conservative per-sequence FIXED state of one recurrent layer, in bytes.
+def _gateddeltanet_state_bytes(struct: Any) -> int | None:
+    """GatedDeltaNet (Qwen3-Next / Qwen3.5 / Qwen3.6) per-sequence state bytes.
 
-    Returns ``None`` when the config exposes no recognized recurrent-state
-    fields — the caller then charges that layer the uniform per-token estimate
-    (full-growth) as the safe fallback, rather than leaving its state
-    unreserved (codex round 2 BLOCKING #1).
-
-    Two supported families, sized from their real config fields:
-
-    * **GatedDeltaNet** (Qwen3-Next / Qwen3.5 / Qwen3.6): the recurrent state is
-      a per-value-head ``head_k_dim × head_v_dim`` matrix plus the causal-conv
-      ring buffer over ``conv_dim = 2·key_dim + value_dim`` channels. Shapes
-      match ``mlx_lm.models.qwen3_next.Qwen3NextGatedDeltaNet``.
-    * **Mamba / Mamba2**: the SSM state ``d_inner × d_state`` plus the conv ring
-      buffer ``d_inner × (d_conv − 1)``.
-
-    Every term is a per-sequence constant (it does not grow with generated
-    tokens), so it lands in the fixed baseline, never in per-token growth.
+    State = a per-value-head ``head_k_dim × head_v_dim`` matrix plus the
+    causal-conv ring buffer over ``conv_dim = 2·key_dim + value_dim`` channels.
+    Shapes match ``mlx_lm.models.qwen3_next.Qwen3NextGatedDeltaNet``. ALL of the
+    state + conv dimensions must be present and positive — including the conv
+    kernel — else return ``None`` so the caller charges full growth rather than
+    silently omitting the conv buffer and under-reserving (codex round 3
+    BLOCKING #1).
     """
-    # GatedDeltaNet. ALL of the state + conv dimensions must be present and
-    # positive — including the conv kernel. If any is missing we cannot size
-    # the full state, so we return None (the caller charges full growth) rather
-    # than silently omitting the conv buffer and under-reserving (codex round 3
-    # BLOCKING #1).
     num_v = _pos_int(_cfg_get(struct, "linear_num_value_heads"))
     num_k = _pos_int(_cfg_get(struct, "linear_num_key_heads"))
     head_k = _pos_int(_cfg_get(struct, "linear_key_head_dim"))
     head_v = _pos_int(_cfg_get(struct, "linear_value_head_dim"))
     conv_kernel = _pos_int(_cfg_get(struct, "linear_conv_kernel_dim"))
-    if num_v and num_k and head_k and head_v and conv_kernel:
-        key_dim = num_k * head_k
-        value_dim = num_v * head_v
-        recurrent_elems = num_v * head_k * head_v
-        conv_dim = 2 * key_dim + value_dim
-        conv_elems = (conv_kernel - 1) * conv_dim
-        return _RECURRENT_STATE_BYTES_PER_ELEM * (recurrent_elems + conv_elems)
+    if not (num_v and num_k and head_k and head_v and conv_kernel):
+        return None
+    key_dim = num_k * head_k
+    value_dim = num_v * head_v
+    recurrent_elems = num_v * head_k * head_v
+    conv_dim = 2 * key_dim + value_dim
+    conv_elems = (conv_kernel - 1) * conv_dim
+    return _RECURRENT_STATE_BYTES_PER_ELEM * (recurrent_elems + conv_elems)
 
-    # Mamba / Mamba2 — same all-or-nothing rule: the SSM state, the inner
-    # dimension AND the conv kernel must all be readable, else return None so
-    # the conv buffer is never silently dropped (codex round 3 BLOCKING #2).
-    d_state = _pos_int(_cfg_get(struct, "mamba_d_state")) or _pos_int(
-        _cfg_get(struct, "state_size")
-    )
+
+def _mamba_state_bytes(struct: Any) -> int | None:
+    """Mamba / Mamba2 per-sequence state bytes.
+
+    State = the SSM state ``d_inner × d_state`` plus the conv ring buffer
+    ``d_inner × (d_conv − 1)``.
+
+    Sized ONLY from ``mamba_``-prefixed config fields, never from generic
+    ``state_size`` / ``intermediate_size`` / ``conv_kernel_size`` (codex round 4
+    BLOCKING #2). Those generic names are not Mamba-specific: another recurrent
+    family (RWKV, etc.) commonly exposes ``intermediate_size`` / ``state_size``
+    for an entirely different tensor, so reading them here would stamp a bogus
+    Mamba-shaped fixed state onto a non-Mamba layer and zero its per-token
+    growth — an under-count on the D-METAL-CAP path. A layer that does not carry
+    the Mamba-specific fields returns ``None`` so the caller charges it full
+    per-token growth (the safe, never-under-count fallback).
+
+    Same all-or-nothing rule: ``d_state`` AND the inner dimension AND the conv
+    kernel must all be readable from Mamba-specific fields, else return ``None``
+    so the conv buffer is never silently dropped (codex round 3 BLOCKING #2).
+    """
+    d_state = _pos_int(_cfg_get(struct, "mamba_d_state"))
     n_heads = _pos_int(_cfg_get(struct, "mamba_n_heads"))
     d_head = _pos_int(_cfg_get(struct, "mamba_d_head"))
     d_inner = (n_heads * d_head) if (n_heads and d_head) else 0
     if d_inner == 0:
-        d_inner = _pos_int(_cfg_get(struct, "mamba_intermediate_size")) or _pos_int(
-            _cfg_get(struct, "intermediate_size")
-        )
-    d_conv = _pos_int(_cfg_get(struct, "mamba_d_conv")) or _pos_int(
-        _cfg_get(struct, "conv_kernel_size")
-    )
-    if d_state and d_inner and d_conv:
-        ssm_elems = d_inner * d_state
-        conv_elems = d_inner * (d_conv - 1)
-        return _RECURRENT_STATE_BYTES_PER_ELEM * (ssm_elems + conv_elems)
+        d_inner = _pos_int(_cfg_get(struct, "mamba_intermediate_size"))
+    d_conv = _pos_int(_cfg_get(struct, "mamba_d_conv"))
+    if not (d_state and d_inner and d_conv):
+        return None
+    ssm_elems = d_inner * d_state
+    conv_elems = d_inner * (d_conv - 1)
+    return _RECURRENT_STATE_BYTES_PER_ELEM * (ssm_elems + conv_elems)
 
+
+def _recurrent_state_bytes(struct: Any, layer_type: str) -> int | None:
+    """Conservative per-sequence FIXED state of one recurrent layer, in bytes.
+
+    Dispatches by the EXACT recurrent family named in ``layer_type`` and sizes
+    the state only from that family's real config fields — so a family we do not
+    model (generic ``"recurrent"`` / ``"rwkv"``) never gets a bogus Mamba/GDN
+    estimate from incidentally-matching generic fields (codex round 4
+    BLOCKING #2). Returns ``None`` (→ caller charges full per-token growth) for
+    any family we cannot size exactly.
+
+    The returned term is a per-sequence constant (it does not grow with
+    generated tokens), so it lands in the fixed baseline, never in per-token
+    growth.
+    """
+    if layer_type == "linear_attention":
+        return _gateddeltanet_state_bytes(struct)
+    if layer_type in ("mamba", "mamba2"):
+        return _mamba_state_bytes(struct)
+    # Generic / unimplemented recurrent family (e.g. "recurrent", "rwkv"): we do
+    # not know its exact state layout, so we cannot size it → full-growth.
     return None
 
 
@@ -405,8 +426,17 @@ def estimate_kv_footprint(
             num_shared = 0  # last-N contract unverified → do not zero anything
     first_borrower = base_num_layers - num_shared
 
-    full_per_token = 2 * dtype_bytes * global_kv_heads * global_head_dim
-    sliding_full_per_token = 2 * dtype_bytes * local_kv_heads * local_head_dim
+    # The uniform per-layer charge (base dims). It is the never-under-count
+    # floor: no per-token-growing layer is ever charged LESS than this.
+    uniform_per_layer = 2 * dtype_bytes * base_kv_heads * base_head_dim
+    # Full-attention layers use the (wider) global dims when present, but never
+    # below the uniform base-layer size — a config whose ``global_head_dim`` /
+    # ``num_global_key_value_heads`` are smaller than (or unrelated to) the base
+    # dims must not shrink a full layer's per-token growth below uniform and
+    # open an under-count (codex round 4 BLOCKING #1).
+    full_per_token = max(
+        2 * dtype_bytes * global_kv_heads * global_head_dim, uniform_per_layer
+    )
     sliding_window_bytes = 2 * dtype_bytes * window * local_kv_heads * local_head_dim
 
     per_token_growth = 0
@@ -416,7 +446,8 @@ def estimate_kv_footprint(
             # Borrower (KV-sharing) layer — reuses a producer's cache, allocates
             # nothing.
             continue
-        layer_class = _classify_layer(layer_types[idx])
+        layer_type = layer_types[idx]
+        layer_class = _classify_layer(layer_type)
         if layer_class == "recurrent":
             # Recurrent / linear-attention layers keep a FIXED state that does
             # not grow per token. When we can size that state from the family's
@@ -426,19 +457,19 @@ def estimate_kv_footprint(
             # load-bearing correctness win for Qwen3.5/3.6/Mamba. When we CANNOT
             # size it, we fall back to charging the layer the uniform per-token
             # estimate (full growth), which never under-counts.
-            state = _recurrent_state_bytes(struct)
+            state = _recurrent_state_bytes(struct, layer_type)
             if state is not None:
                 fixed_baseline += state
             else:
-                per_token_growth += sliding_full_per_token
+                per_token_growth += uniform_per_layer
             continue
         if layer_class == "sliding":
             if window > 0:
                 fixed_baseline += sliding_window_bytes
             else:
-                # No readable window → cannot bound it → charge as full growth
-                # (never under-count).
-                per_token_growth += sliding_full_per_token
+                # No readable window → cannot bound it → charge the uniform
+                # per-layer growth (never under-count).
+                per_token_growth += uniform_per_layer
         else:  # "full"
             per_token_growth += full_per_token
 

--- a/vllm_mlx/kv_estimation.py
+++ b/vllm_mlx/kv_estimation.py
@@ -35,32 +35,50 @@ This module computes an accurate footprint by classifying each layer:
     when the architecture is hybrid.
 
 ``fixed_baseline_bytes``
-    ``2 * dtype_bytes * Σ_sliding (window_L * kv_heads_L * head_dim_L)`` plus a
-    conservative fixed term per recurrent layer. Allocated once per sequence,
-    not per token.
+    ``2 * dtype_bytes * Σ_sliding (window_L * kv_heads_L * head_dim_L)`` — the
+    rotating-window buffers of the sliding-window layers, allocated once per
+    sequence rather than per token.
 
-Borrower (KV-sharing) layers contribute 0 to both.
+Borrower (KV-sharing) layers contribute 0 to both. Recurrent / linear-attention
+layers contribute 0 to per-token growth (see safety point 2 for why their fixed
+state is deliberately not modeled).
 
 Safety contract (this feeds a codex-hardened, over-estimate-safe admission
 path — see ``scheduler._resolve_kv_bytes_per_token``):
 
-1. **Over-estimate-safe fallback.** When the config lacks the layer-structure
-   fields (no per-layer ``layer_types`` and no ``num_kv_shared_layers``), or
-   anything is ambiguous, the estimator returns the caller's uniform figure
-   unchanged (``per_token_growth_bytes == uniform_per_token_bytes`` and
+1. **Over-estimate-safe fallback.** A recognized hybrid must expose a per-layer
+   ``layer_types`` list whose length matches ``num_hidden_layers``. When that is
+   absent, or anything is ambiguous, the estimator returns the caller's uniform
+   figure unchanged (``per_token_growth_bytes == uniform_per_token_bytes`` and
    ``fixed_baseline_bytes == 0``) so dense models (Llama/Qwen dense) and
    unknown/stub configs stay BYTE-IDENTICAL to the historical behavior. Only a
-   recognized hybrid — one that exposes a per-layer ``layer_types`` list of the
-   right length or a valid ``num_kv_shared_layers`` — gets the smaller accurate
-   number.
-2. **Never under-count the counted layers.** ``fixed_baseline + tokens *
-   per_token_growth`` is always >= the true architecture-aware footprint of the
-   counted layers: full-attention layers are charged exactly; sliding layers
-   are charged their whole window (an upper bound for any token count); a
-   sliding layer with no readable window is charged as full-growth; an
-   unrecognized layer type is charged as full-growth. So the estimate can only
-   over-count, never under-count — it can never re-introduce the D-METAL-CAP
-   OOM cliff.
+   recognized hybrid gets the smaller accurate number. ``num_kv_shared_layers``
+   is NOT sufficient on its own — the per-layer map must confirm the borrower
+   split (see point 3).
+2. **Never under-count the per-token GROWTH.** The load-bearing guarantee for
+   the D-METAL-CAP cliff is on the per-token term, since that is what a long
+   generation multiplies without bound: ``per_token_growth`` is >= the true
+   per-token growth of every counted layer. Full-attention layers are charged
+   exactly; a sliding layer with no readable window is charged as full-growth;
+   an unrecognized layer-type string is charged as full-growth (exact-match
+   allowlists, no substring guessing); recurrent and window-bounded layers
+   genuinely have zero per-token growth. The sliding window footprint lands in
+   ``fixed_baseline`` — an exact per-sequence upper bound (the whole window,
+   ignoring token count). The recurrent layers' small FIXED state is
+   architecture-specific (linear key/value head dims, conv kernel) and our
+   configs do not uniformly expose those fields, so — rather than invent a
+   number that could silently under-count — we leave that fixed per-sequence
+   overhead unmodeled, exactly as the gate already leaves model weights and
+   activation buffers unmodeled. This is sound because the gate exists to catch
+   runaway PER-TOKEN growth, not fixed per-sequence overhead: a non-growing
+   term cannot produce the D-METAL-CAP cliff.
+3. **KV-sharing only zeroes verified borrowers.** ``num_kv_shared_layers``
+   declares that the LAST N layers borrow (Gemma-4 / Gemma-3n contract). We zero
+   those borrowers only when the per-layer ``layer_types`` map confirms it —
+   every borrower attention type has a same-type producer below the split
+   (mirroring ``gemma4_text._check_kv_share_config``). If the map does not
+   confirm the last-N contract, no layer is zeroed (over-count, never
+   under-count).
 
 The estimator is a pure function: it reads only plain fields off a config
 object (or its ``text_config``), performs no I/O, loads no weights, and is unit
@@ -72,21 +90,35 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
-# Per-layer attention-type classification tokens. Ordered checks in
-# ``_classify_layer`` matter: ``"linear_attention"`` and ``"sliding_attention"``
-# both contain ``"attention"``, so recurrent and sliding are tested BEFORE the
-# generic full-attention tokens.
-_RECURRENT_TOKENS: tuple[str, ...] = (
-    "linear",
-    "mamba",
-    "recurrent",
-    "rwkv",
-    "ssm",
-    "gated",
-    "delta",
+# Per-layer attention-type classification uses EXACT (case-folded) matches, not
+# substrings: a substring rule would misclassify an unfamiliar full-attention
+# name that merely contains ``"linear"`` / ``"gated"`` / ``"local"`` as
+# zero-growth or window-bounded and silently UNDER-count it (codex round 1
+# BLOCKING #4). Any value not on these allowlists falls through to full-growth —
+# the conservative, never-under-count default. Values are the ``layer_types``
+# strings the engine actually ships (Gemma-4 / GPT-OSS ``sliding_attention`` +
+# ``full_attention``; Qwen3.5/3.6 GatedDeltaNet ``linear_attention``; Mamba
+# stacks) plus their common upstream aliases.
+_RECURRENT_TYPES: frozenset[str] = frozenset(
+    {
+        "linear_attention",
+        "gated_delta_net",
+        "gated_deltanet",
+        "mamba",
+        "mamba2",
+        "recurrent",
+        "rwkv",
+    }
 )
-_SLIDING_TOKENS: tuple[str, ...] = ("slid", "swa", "local", "window")
-_FULL_TOKENS: tuple[str, ...] = ("full", "global", "attention", "sdpa")
+_SLIDING_TYPES: frozenset[str] = frozenset(
+    {
+        "sliding_attention",
+        "sliding_window_attention",
+        "local_attention",
+        "local_sliding_attention",
+        "swa",
+    }
+)
 
 
 @dataclass(frozen=True)
@@ -99,8 +131,8 @@ class KVFootprintEstimate:
             only. This is the value the D-METAL-CAP projection multiplies by
             ``(prompt_tokens + max_tokens)``.
         fixed_baseline_bytes: Bytes allocated once per sequence regardless of
-            token count — the sliding-window rotating buffers plus a
-            conservative recurrent-state term. Zero for a dense model.
+            token count — the sliding-window rotating buffers. Zero for a dense
+            model and for any hybrid with no sliding-window layers.
     """
 
     per_token_growth_bytes: int
@@ -153,9 +185,13 @@ def _pick_structural_config(model_config: Any, base_num_layers: int) -> Any | No
     Layer-structure fields live either directly on ``model_config`` (text-lane
     configs) or nested under ``model_config.text_config`` (multimodal configs).
     Returns the config whose ``layer_types`` list matches ``base_num_layers``,
-    or — absent that — the one exposing a valid ``num_kv_shared_layers`` in
-    ``(0, base_num_layers)``. Returns ``None`` when neither carries a
-    recognized hybrid signal (the byte-identical dense/unknown fallback).
+    or ``None`` when neither carries one (the byte-identical dense/unknown
+    fallback).
+
+    A per-layer ``layer_types`` list is REQUIRED to engage the hybrid path.
+    ``num_kv_shared_layers`` on its own is not enough: without the per-layer map
+    we cannot verify which layers actually borrow (codex round 1 BLOCKING #3),
+    so a config exposing only a share count stays on the uniform estimate.
     """
     candidates = [model_config]
     text_config = _cfg_get(model_config, "text_config")
@@ -165,29 +201,22 @@ def _pick_structural_config(model_config: Any, base_num_layers: int) -> Any | No
     for cfg in candidates:
         if _valid_layer_types(_cfg_get(cfg, "layer_types"), base_num_layers):
             return cfg
-    for cfg in candidates:
-        shared = _cfg_get(cfg, "num_kv_shared_layers")
-        if isinstance(shared, int) and not isinstance(shared, bool):
-            if 0 < shared < base_num_layers:
-                return cfg
     return None
 
 
 def _classify_layer(layer_type: str) -> str:
-    """Map a lower-cased ``layer_types`` entry to a footprint class.
+    """Map a case-folded ``layer_types`` entry to a footprint class.
 
-    Returns one of ``"recurrent"``, ``"sliding"``, ``"full"``. A recognized
-    full-attention token and an UNrecognized string both resolve to ``"full"``
-    — the conservative (over-counting) default that can never under-count.
+    Returns one of ``"recurrent"``, ``"sliding"``, ``"full"``. Matching is
+    EXACT against the zero-growth / window-bounded allowlists; every other
+    value — a known full-attention type or an unrecognized string — resolves to
+    ``"full"``, the conservative (over-counting) default that can never
+    under-count.
     """
-    if any(tok in layer_type for tok in _RECURRENT_TOKENS):
+    if layer_type in _RECURRENT_TYPES:
         return "recurrent"
-    if any(tok in layer_type for tok in _SLIDING_TOKENS):
+    if layer_type in _SLIDING_TYPES:
         return "sliding"
-    if any(tok in layer_type for tok in _FULL_TOKENS):
-        return "full"
-    # Unrecognized attention-type string → charge as full growth (never
-    # under-count).
     return "full"
 
 
@@ -269,39 +298,59 @@ def estimate_kv_footprint(
     # we cannot bound its footprint, so it is charged as full-growth below.
     window = _pos_int(_cfg_get(struct, "sliding_window"))
 
-    # Borrower split: the last ``num_kv_shared_layers`` layers reuse an earlier
-    # producer's K/V and allocate nothing. ``first_borrower`` is the index at
-    # which borrowing begins.
+    # ``layer_types`` is guaranteed present + length-checked by
+    # ``_pick_structural_config``; the ``is None`` branch is unreachable but
+    # kept as a defensive fallback (avoids an assert that ``python -O`` strips).
+    layer_types = _valid_layer_types(_cfg_get(struct, "layer_types"), base_num_layers)
+    if layer_types is None:
+        return uniform
+
+    # Borrower split: Gemma-4 / Gemma-3n reuse the LAST ``num_kv_shared_layers``
+    # decoder layers' K/V from an earlier same-type producer (split at
+    # ``num_hidden_layers - num_kv_shared_layers`` — see
+    # ``models/gemma4_text._check_kv_share_config``). We only zero those
+    # borrowers when the ACTUAL per-layer map confirms the last-N contract:
+    # every borrower attention type must have a producer of the same type below
+    # the split. If it does not (interleaved / differently-anchored sharing we
+    # do not model), we keep every layer as a producer — an over-count, never an
+    # under-count (codex round 1 BLOCKING #3).
     num_shared = _cfg_get(struct, "num_kv_shared_layers")
     if isinstance(num_shared, int) and not isinstance(num_shared, bool):
-        num_shared = num_shared if 0 <= num_shared < base_num_layers else 0
+        num_shared = num_shared if 0 < num_shared < base_num_layers else 0
     else:
         num_shared = 0
+    if num_shared > 0:
+        split = base_num_layers - num_shared
+        producer_types = set(layer_types[:split])
+        borrower_types = set(layer_types[split:])
+        if not borrower_types <= producer_types:
+            num_shared = 0  # last-N contract unverified → do not zero anything
     first_borrower = base_num_layers - num_shared
-
-    layer_types = _valid_layer_types(_cfg_get(struct, "layer_types"), base_num_layers)
 
     full_per_token = 2 * dtype_bytes * global_kv_heads * global_head_dim
     sliding_full_per_token = 2 * dtype_bytes * local_kv_heads * local_head_dim
     sliding_window_bytes = 2 * dtype_bytes * window * local_kv_heads * local_head_dim
-    # Recurrent state is a fixed per-head state matrix (~head_dim x head_dim per
-    # KV head for GatedDeltaNet / Mamba). It never grows per token, so it lands
-    # entirely in the fixed baseline. A conservative single-matrix term (no K+V
-    # doubling) derived from the local dims — see module docstring.
-    recurrent_state_bytes = (
-        dtype_bytes * local_kv_heads * local_head_dim * local_head_dim
-    )
 
     per_token_growth = 0
     fixed_baseline = 0
     for idx in range(base_num_layers):
         if idx >= first_borrower:
-            # Borrower (KV-sharing) layer — allocates nothing.
+            # Borrower (KV-sharing) layer — reuses a producer's cache, allocates
+            # nothing.
             continue
-        layer_class = _classify_layer(layer_types[idx]) if layer_types else "full"
+        layer_class = _classify_layer(layer_types[idx])
         if layer_class == "recurrent":
-            fixed_baseline += recurrent_state_bytes
-        elif layer_class == "sliding":
+            # Recurrent / linear-attention layers keep a FIXED state that does
+            # not grow per token — zero growth (the load-bearing correctness
+            # win). Their fixed state is small, bounded, and architecture-
+            # specific; deriving it needs family fields (linear key/value head
+            # dims, conv kernel) our configs do not uniformly expose, so we do
+            # NOT invent a term for it (codex round 1 BLOCKING #2). Like model
+            # weights and activation buffers, that fixed per-sequence overhead
+            # is simply out of scope for this KV-GROWTH projection; the gate has
+            # never reserved for non-growing allocations.
+            continue
+        if layer_class == "sliding":
             if window > 0:
                 fixed_baseline += sliding_window_bytes
             else:

--- a/vllm_mlx/kv_estimation.py
+++ b/vllm_mlx/kv_estimation.py
@@ -31,18 +31,28 @@ This module computes an accurate footprint by classifying each layer:
 
 ``per_token_growth_bytes``
     ``2 * dtype_bytes * Σ (kv_heads_L * head_dim_L)`` over ONLY the
-    full-attention (per-token-growing) layers, honoring per-layer / global dims
-    when the architecture is hybrid.
+    full-attention (unbounded per-token-growing) layers, honoring per-layer /
+    global dims when the architecture is hybrid.
+
+``sliding_per_token_bytes`` / ``sliding_window_tokens``
+    ``2 * dtype_bytes * Σ_sliding (kv_heads_L * head_dim_L)`` — the per-token
+    KV rate of the sliding-window layers — together with the rotating window
+    length. The caller charges ``sliding_per_token * min(tokens, window)``: a
+    rotating cache holds at most ``window`` positions, but a request shorter
+    than the window holds only ``tokens``, so short requests stay byte-identical
+    to the historical uniform figure and only long requests get the window cap
+    (codex round 6 BLOCKING). Flattening the whole window into a fixed baseline
+    would over-charge — and spuriously reject — short requests.
 
 ``fixed_baseline_bytes``
-    ``2 * dtype_bytes * Σ_sliding (window_L * kv_heads_L * head_dim_L)`` (the
-    rotating-window buffers of the sliding-window layers) plus the conservative
-    fixed recurrent state of each recurrent layer we can size from its config.
-    Allocated once per sequence rather than per token.
+    The conservative fixed recurrent state of each recurrent layer we can size
+    from its config. Allocated once per sequence, independent of token count
+    (an SSM/conv state is materialized in full at cache init). Sliding windows
+    are NOT flattened here — see above.
 
-Borrower (KV-sharing) layers contribute 0 to both. Recurrent / linear-attention
-layers contribute 0 to per-token growth; their fixed state is reserved in the
-baseline instead (see safety point 2).
+Borrower (KV-sharing) layers contribute 0 to all terms. Recurrent /
+linear-attention layers contribute 0 to per-token growth; their fixed state is
+reserved in the baseline instead (see safety point 2).
 
 Safety contract (this feeds a codex-hardened, over-estimate-safe admission
 path — see ``scheduler._resolve_kv_bytes_per_token``):
@@ -56,22 +66,23 @@ path — see ``scheduler._resolve_kv_bytes_per_token``):
    recognized hybrid gets the smaller accurate number. ``num_kv_shared_layers``
    is NOT sufficient on its own — the per-layer map must confirm the borrower
    split (see point 3).
-2. **Never under-count the per-token GROWTH.** The load-bearing guarantee for
-   the D-METAL-CAP cliff is on the per-token term, since that is what a long
-   generation multiplies without bound: ``per_token_growth`` is >= the true
-   per-token growth of every counted layer. Full-attention layers are charged
-   exactly; a sliding layer with no readable window is charged as full-growth;
-   an unrecognized layer-type string is charged as full-growth (exact-match
-   allowlists, no substring guessing); recurrent and window-bounded layers
-   genuinely have zero per-token growth. Their per-sequence footprint lands in
-   ``fixed_baseline`` instead: the sliding window term is an exact upper bound
-   (the whole window, ignoring token count), and each recurrent layer's fixed
-   state is sized from its family's real config fields (GatedDeltaNet linear
-   head dims + conv kernel; Mamba d_state/d_conv) and charged at fp32/element to
-   stay conservative. A recurrent layer whose state CANNOT be sized falls back
-   to the uniform per-token estimate (full growth) rather than going
-   unreserved. A fixed baseline is charged once per sequence and never scales
-   with generated tokens.
+2. **Never under-count the counted layers, never over-count short requests.**
+   The load-bearing guarantee for the D-METAL-CAP cliff is that the projected
+   footprint is >= the true footprint of every counted layer. Full-attention
+   layers are charged exactly per token; a sliding layer with no readable window
+   is charged as full unbounded growth; an unrecognized layer-type string is
+   charged as full growth (exact-match allowlists, no substring guessing).
+   Sliding-window layers with a readable window are charged their exact peak —
+   ``rate * min(tokens, window)`` — which is both an upper bound on the rotating
+   cache AND equal to the historical uniform figure for any request shorter than
+   the window, so the reduction never comes at the cost of over-charging (and
+   spuriously rejecting) a short request. Recurrent layers genuinely have zero
+   per-token growth; each recurrent layer's fixed state is sized from its
+   family's real config fields (GatedDeltaNet linear head dims + conv kernel;
+   Mamba d_state/d_conv) and charged at fp32/element to stay conservative, and a
+   recurrent layer whose state CANNOT be sized falls back to full per-token
+   growth rather than going unreserved. The fixed baseline is charged once per
+   sequence and never scales with generated tokens.
 3. **KV-sharing only zeroes verified borrowers.** ``num_kv_shared_layers``
    declares that the LAST N layers borrow (Gemma-4 / Gemma-3n contract). We zero
    those borrowers only when the per-layer ``layer_types`` map confirms it —
@@ -136,19 +147,42 @@ _SLIDING_TYPES: frozenset[str] = frozenset(
 class KVFootprintEstimate:
     """Architecture-aware KV footprint of a single sequence.
 
+    The D-METAL-CAP projection reconstructs a request's peak KV footprint as::
+
+        fixed_baseline_bytes
+          + per_token_growth_bytes * (prompt_tokens + max_tokens)
+          + sliding_per_token_bytes * min(prompt_tokens + max_tokens,
+                                          sliding_window_tokens)
+
+    Splitting the sliding-window term out (rather than flattening the whole
+    window into ``fixed_baseline``) keeps SHORT requests byte-identical to the
+    historical uniform estimate: a rotating-window layer only holds
+    ``min(tokens, window)`` positions, so a request whose token budget is below
+    the window is charged exactly ``tokens`` worth — never the full window
+    (codex round 6 BLOCKING). Long requests still get the reduction: the sliding
+    term is capped at ``window`` while the old uniform figure kept growing.
+
     Attributes:
         per_token_growth_bytes: Bytes of KV cache allocated per additional
-            token, summed over the full-attention (per-token-growing) layers
-            only. This is the value the D-METAL-CAP projection multiplies by
-            ``(prompt_tokens + max_tokens)``.
+            token, summed over the full-attention (unbounded-growth) layers
+            only.
         fixed_baseline_bytes: Bytes allocated once per sequence regardless of
-            token count — the sliding-window rotating buffers plus the
-            conservative fixed recurrent state of each sizeable recurrent layer.
-            Zero for a dense model and for a hybrid with neither.
+            token count — the conservative fixed recurrent state of each
+            sizeable recurrent layer. (Sliding windows are NOT flattened here;
+            see ``sliding_per_token_bytes``.) Zero for a dense model and for a
+            hybrid with no sizeable recurrent layers.
+        sliding_per_token_bytes: Bytes of KV allocated per token by the
+            sliding-window (local-attention) layers, summed over those layers.
+            Capped in the projection at ``sliding_window_tokens`` positions.
+            Zero when there are no readable-window sliding layers.
+        sliding_window_tokens: The rotating window length (tokens) that caps the
+            sliding term. Zero when ``sliding_per_token_bytes`` is zero.
     """
 
     per_token_growth_bytes: int
     fixed_baseline_bytes: int
+    sliding_per_token_bytes: int = 0
+    sliding_window_tokens: int = 0
 
 
 def _cfg_get(cfg: Any, name: str, default: Any = None) -> Any:
@@ -454,10 +488,16 @@ def estimate_kv_footprint(
     full_per_token = max(
         2 * dtype_bytes * global_kv_heads * global_head_dim, uniform_per_layer
     )
-    sliding_window_bytes = 2 * dtype_bytes * window * local_kv_heads * local_head_dim
+    # Per-token KV rate of ONE sliding-window layer (local dims). The projection
+    # multiplies this by ``min(tokens, window)`` — the true peak occupancy of a
+    # rotating cache — rather than flattening the whole window into the baseline,
+    # so a request shorter than the window is charged only for the tokens it
+    # actually holds (codex round 6 BLOCKING).
+    sliding_per_layer = 2 * dtype_bytes * local_kv_heads * local_head_dim
 
     per_token_growth = 0
     fixed_baseline = 0
+    sliding_per_token = 0
     for idx in range(base_num_layers):
         if idx >= first_borrower:
             # Borrower (KV-sharing) layer — reuses a producer's cache, allocates
@@ -482,7 +522,9 @@ def estimate_kv_footprint(
             continue
         if layer_class == "sliding":
             if window > 0:
-                fixed_baseline += sliding_window_bytes
+                # Window-capped per-token growth — accumulated separately so the
+                # projection can cap it at ``window`` positions.
+                sliding_per_token += sliding_per_layer
             else:
                 # No readable window → cannot bound it → charge the uniform
                 # per-layer growth (never under-count).
@@ -493,4 +535,6 @@ def estimate_kv_footprint(
     return KVFootprintEstimate(
         per_token_growth_bytes=int(per_token_growth),
         fixed_baseline_bytes=int(fixed_baseline),
+        sliding_per_token_bytes=int(sliding_per_token),
+        sliding_window_tokens=int(window) if sliding_per_token > 0 else 0,
     )

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -40,8 +40,10 @@ from ._sampler_fast_path import (  # noqa: E402
 )
 from ._seeded_sampler import make_seeded_sampler  # noqa: E402
 from .kv_estimation import (  # noqa: E402
+    _cfg_get,
     _valid_layer_types,
     estimate_kv_footprint,
+    rotating_cache_slots,
 )
 from .memory_cache import MemoryAwarePrefixCache, MemoryCacheConfig  # noqa: E402
 from .paged_cache import PagedCacheManager
@@ -2225,17 +2227,28 @@ class Scheduler:
         self._kv_bytes_per_token: int = 0
         self._kv_bytes_per_token_resolved: bool = False
         # D-METAL-CAP: cached per-sequence FIXED KV baseline (bytes) for
-        # architecture-aware hybrids — the WHOLE rotating-window buffer of each
-        # sliding-window layer plus the conservative recurrent-state term of a
-        # hybrid's linear-attention layers. Allocated once per sequence, not per
-        # token (a window buffer / SSM state does not grow with the token
+        # architecture-aware hybrids — the conservative recurrent-state term of a
+        # hybrid's linear-attention (GatedDeltaNet) layers. Allocated once per
+        # sequence, not per token (an SSM state does not grow with the token
         # budget), so ``_estimate_request_kv_bytes`` charges it as a flat add-on
-        # rather than multiplying by the token count. Charging the whole window
-        # is the over-count-SAFE upper bound (a rotating/paged cache rounds up to
-        # block increments and may keep sink positions — codex round 9 BLOCKING).
-        # ``0`` for dense models and for the byte-identical uniform fallback (see
+        # rather than multiplying by the token count. ``0`` for dense models and
+        # for the byte-identical uniform fallback (see
         # ``_resolve_kv_bytes_per_token`` and ``kv_estimation``).
         self._kv_fixed_baseline_bytes: int = 0
+        # D-METAL-CAP: cached SLIDING-window term for hybrids with rotating-cache
+        # layers (GPT-OSS, Gemma-4 local). ``_kv_sliding_slot_bytes`` is the
+        # per-SLOT bytes summed across the window-bounded sliding layers and
+        # ``_kv_sliding_window`` is their shared rotating window. Unlike the fixed
+        # baseline, this term is REQUEST-DEPENDENT: a sliding buffer grows with
+        # the token budget up to the window, so ``_estimate_request_kv_bytes``
+        # multiplies ``_kv_sliding_slot_bytes`` by
+        # ``kv_estimation.rotating_cache_slots(window, T)`` per request — the
+        # over-count-safe upper bound of the real ``RotatingKVCache`` allocation
+        # that grows with ``T`` and caps at the full window (codex round 11
+        # BLOCKING #1: a flat whole-window baseline over-counts short requests).
+        # Both ``0`` for dense models and the uniform fallback.
+        self._kv_sliding_slot_bytes: int = 0
+        self._kv_sliding_window: int = 0
 
         # Prompt-boundary cache snapshot callback for the new mlx-lm 0.31+ API.
         # Built lazily once memory_aware_cache exists and reused per step.
@@ -3299,9 +3312,12 @@ class Scheduler:
             # a string (``"bfloat16"``) or a ``torch.dtype`` whose
             # ``str()`` is e.g. ``"torch.bfloat16"``. Note ``"float16"``
             # is a substring of ``"bfloat16"`` — harmless here since both
-            # map to 2.
+            # map to 2. Read through ``_cfg_get`` so a dict-backed config
+            # resolves its dtype identically to an attribute config (codex
+            # round 11 NIT: dict configs must behave the same end-to-end,
+            # else they silently over-estimate at the fp32 fallback).
             for attr in ("dtype", "torch_dtype"):
-                raw = getattr(obj, attr, None)
+                raw = _cfg_get(obj, attr)
                 if raw is None:
                     continue
                 dtype_str = str(raw).lower()
@@ -3315,7 +3331,7 @@ class Scheduler:
             if n > 0:
                 return n
             # Multimodal configs nest the LM dtype under ``text_config``.
-            text_config = getattr(model_config, "text_config", None)
+            text_config = _cfg_get(model_config, "text_config")
             if text_config is not None:
                 n = _bytes_from(text_config)
                 if n > 0:
@@ -3381,10 +3397,15 @@ class Scheduler:
         """
         if self._kv_bytes_per_token_resolved:
             return self._kv_bytes_per_token
-        # Operator override wins.
+        # Operator override wins — it short-circuits ALL architecture-aware
+        # refinement, so the fixed baseline and the sliding term are both zero
+        # (the operator's flat per-token figure is the whole projection).
         configured = int(getattr(self.config, "metal_cap_kv_bytes_per_token", 0) or 0)
         if configured > 0:
             self._kv_bytes_per_token = configured
+            self._kv_fixed_baseline_bytes = 0
+            self._kv_sliding_slot_bytes = 0
+            self._kv_sliding_window = 0
             self._kv_bytes_per_token_resolved = True
             return configured
         # Auto-derive from model.config — same pattern as
@@ -3398,6 +3419,8 @@ class Scheduler:
         # ints filters that path.
         per_tok = 0
         fixed_baseline = 0
+        sliding_slot_bytes = 0
+        sliding_window = 0
         try:
             model_config = getattr(self.model, "config", None)
             if model_config is not None:
@@ -3417,22 +3440,32 @@ class Scheduler:
                 # ``layer_types`` (a dense / unknown model), fall back to the
                 # outer config exactly as before — dense/text admission
                 # accounting is unchanged.
+                #
+                # Read every field through the estimator's dict-aware
+                # ``_cfg_get`` (not bare ``getattr``): ``estimate_kv_footprint``
+                # explicitly supports dict-backed configs (the offline hybrid
+                # probe parses ``config.json`` into a dict), so the scheduler
+                # wiring must resolve dict and attribute configs identically —
+                # bare ``getattr`` on a dict returns ``None`` for every field
+                # and silently collapses the whole estimate to 0 (codex round 11
+                # NIT: dict-backed configs produced a zero estimate through the
+                # scheduler even though the estimator handles them).
                 struct_config = model_config
                 for _candidate in (
                     model_config,
-                    getattr(model_config, "text_config", None),
+                    _cfg_get(model_config, "text_config"),
                 ):
                     if _candidate is None:
                         continue
-                    _cand_layers = getattr(_candidate, "num_hidden_layers", None)
+                    _cand_layers = _cfg_get(_candidate, "num_hidden_layers")
                     if isinstance(_cand_layers, int) and _valid_layer_types(
-                        getattr(_candidate, "layer_types", None), _cand_layers
+                        _cfg_get(_candidate, "layer_types"), _cand_layers
                     ):
                         struct_config = _candidate
                         break
 
                 def _read_int(name: str, fallback: int = 0) -> int:
-                    raw = getattr(struct_config, name, fallback)
+                    raw = _cfg_get(struct_config, name, fallback)
                     return raw if isinstance(raw, int) else 0
 
                 num_layers = _read_int("num_hidden_layers")
@@ -3459,16 +3492,19 @@ class Scheduler:
                     per_tok = 2 * num_layers * num_kv_heads * head_dim * dtype_bytes
                     # Architecture-aware refinement. For dense / unknown
                     # configs the estimator returns this exact uniform
-                    # ``per_tok`` with a 0 baseline (byte-identical); only a
-                    # recognized hybrid (sliding-window / KV-sharing /
-                    # recurrent layers) reduces the per-token growth and moves
-                    # the window + recurrent-state footprint into the
-                    # per-sequence fixed baseline. Wrapped in its OWN
-                    # try/except so a failure inspecting the newer hybrid
-                    # fields degrades to the SAFE uniform ``per_tok`` (zero
-                    # baseline) instead of the outer handler resetting to 0 —
-                    # which would disable admission accounting entirely (codex
-                    # round 3 BLOCKING #3).
+                    # ``per_tok`` with a 0 baseline and no sliding term
+                    # (byte-identical); only a recognized hybrid (sliding-window
+                    # / KV-sharing / recurrent layers) reduces the per-token
+                    # growth, reserves recurrent state in the per-sequence fixed
+                    # baseline, and exposes the sliding layers as a
+                    # request-dependent slot term
+                    # (``sliding_slot_bytes`` × ``rotating_cache_slots(window,
+                    # T)`` — charged in ``_estimate_request_kv_bytes``). Wrapped
+                    # in its OWN try/except so a failure inspecting the newer
+                    # hybrid fields degrades to the SAFE uniform ``per_tok`` (no
+                    # baseline, no sliding term) instead of the outer handler
+                    # resetting to 0 — which would disable admission accounting
+                    # entirely (codex round 3 BLOCKING #3).
                     try:
                         estimate = estimate_kv_footprint(
                             struct_config,
@@ -3480,15 +3516,19 @@ class Scheduler:
                         )
                         per_tok = estimate.per_token_growth_bytes
                         fixed_baseline = estimate.fixed_baseline_bytes
+                        sliding_slot_bytes = estimate.sliding_slot_bytes
+                        sliding_window = estimate.sliding_window
                     except Exception as est_err:
                         logger.debug(
                             "[D-METAL-CAP] architecture-aware KV estimate "
                             "failed (%s); keeping the uniform per-token "
-                            "estimate with no fixed baseline",
+                            "estimate with no fixed baseline / sliding term",
                             est_err,
                         )
                         # ``per_tok`` already holds the uniform value; keep it.
                         fixed_baseline = 0
+                        sliding_slot_bytes = 0
+                        sliding_window = 0
         except Exception as e:
             logger.debug(
                 "[D-METAL-CAP] failed to auto-derive kv_bytes_per_token "
@@ -3499,6 +3539,10 @@ class Scheduler:
             )
             per_tok = 0
             fixed_baseline = 0
+            sliding_slot_bytes = 0
+            sliding_window = 0
+        self._kv_sliding_slot_bytes = sliding_slot_bytes
+        self._kv_sliding_window = sliding_window
         self._kv_bytes_per_token = per_tok
         self._kv_fixed_baseline_bytes = fixed_baseline
         self._kv_bytes_per_token_resolved = True
@@ -3509,15 +3553,14 @@ class Scheduler:
 
         Companion to :meth:`_resolve_kv_bytes_per_token`: the token-independent
         footprint an architecture-aware hybrid allocates ONCE per sequence (not
-        per token) — the WHOLE rotating-window buffer of each sliding-window
-        layer plus the fixed recurrent state of each sizeable recurrent layer.
-        Charging the whole window is the over-count-safe upper bound (a
-        rotating/paged cache rounds up to block increments and may keep sink
-        positions — codex round 9 BLOCKING). ``0`` for dense models, for the
-        uniform fallback, and under the operator override — so the projection
-        stays byte-identical wherever the baseline is not populated. Resolution
-        and caching happen inside ``_resolve_kv_bytes_per_token`` (both values
-        are computed from the same estimate), so we drive it first, then read the
+        per token) — the fixed recurrent state of each sizeable recurrent
+        (GatedDeltaNet) layer. Sliding-window buffers are NOT here: they are
+        request-dependent and charged via the sliding slot term in
+        ``_estimate_request_kv_bytes``. ``0`` for dense models, for the uniform
+        fallback, and under the operator override — so the projection stays
+        byte-identical wherever the baseline is not populated. Resolution and
+        caching happen inside ``_resolve_kv_bytes_per_token`` (all terms are
+        computed from the same estimate), so we drive it first, then read the
         cached baseline.
         """
         self._resolve_kv_bytes_per_token()
@@ -3526,24 +3569,36 @@ class Scheduler:
     def _estimate_request_kv_bytes(self, request: Request) -> int:
         """Project KV-cache memory the new request would consume.
 
-        Returns ``fixed_baseline + (num_prompt_tokens + max_tokens) ×
-        per_token_growth`` (auto-derived from model config or
-        operator-overridden via ``metal_cap_kv_bytes_per_token``). Used by the
-        admission gate to reject prefill requests that would push Metal active
-        PAST the cap before the allocation happens (codex round 3 BLOCKING #1 +
-        round 4 BLOCKING #1+#2 + round 9 BLOCKING #2).
+        With ``T = num_prompt_tokens + max_tokens`` this returns::
 
-        ``per_token_growth`` counts only the unbounded full-attention layers.
-        Sliding-window layers do not grow per token beyond a rotating window, so
-        their WHOLE window buffer, and the fixed state of recurrent layers, live
-        in ``fixed_baseline`` (allocated once per sequence). Charging the whole
-        window is over-count-safe — a rotating/paged cache rounds up to block
-        increments and may retain sink positions, so the real allocation can
-        reach but never exceed the full window regardless of token budget or
-        prefill length. For a dense model ``fixed_baseline`` is 0 and this
-        reduces to the historical ``per_tok × tokens`` — byte-identical. The sum
-        is always >= the true architecture-aware footprint of the counted
-        layers, so the gate can only over-estimate, never under-count.
+            fixed_baseline
+              + per_token_growth * T
+              + sliding_slot_bytes * rotating_cache_slots(sliding_window, T)
+
+        (auto-derived from model config or operator-overridden via
+        ``metal_cap_kv_bytes_per_token``). Used by the admission gate to reject
+        prefill requests that would push Metal active PAST the cap before the
+        allocation happens (codex round 3 BLOCKING #1 + round 4 BLOCKING #1+#2 +
+        round 9/10/11).
+
+        The three terms model the three footprint shapes:
+
+        * ``per_token_growth`` — the unbounded full-attention layers, growing
+          with every token → multiplied by ``T``.
+        * ``sliding_slot_bytes`` — the window-bounded sliding layers. Their
+          buffer grows SUBLINEARLY (up to a rotating window, then flat), so we
+          multiply the per-slot bytes by ``rotating_cache_slots(window, T)`` — an
+          over-count-safe upper bound of the real ``RotatingKVCache`` allocation
+          that rises with ``T`` and caps at the full window. Charging per request
+          (not a flat whole-window baseline) stops a SHORT request from being
+          over-charged the whole buffer and spuriously rejected (codex round 11
+          BLOCKING #1), while a long request still reserves the full window.
+        * ``fixed_baseline`` — the token-independent recurrent state.
+
+        For a dense model the last two terms are 0 and this reduces to the
+        historical ``per_tok × T`` — byte-identical. The sum is always >= the
+        true architecture-aware footprint of the counted layers, so the gate can
+        only over-estimate, never under-count.
 
         Conservative by design: we count both the prompt and the
         full ``max_tokens`` budget (rather than the much smaller
@@ -3553,7 +3608,9 @@ class Scheduler:
         """
         per_tok = self._resolve_kv_bytes_per_token()
         fixed_baseline = self._resolve_kv_fixed_baseline_bytes()
-        if per_tok <= 0 and fixed_baseline <= 0:
+        sliding_slot_bytes = self._kv_sliding_slot_bytes
+        sliding_window = self._kv_sliding_window
+        if per_tok <= 0 and fixed_baseline <= 0 and sliding_slot_bytes <= 0:
             return 0
         # ``num_prompt_tokens`` is populated by either the route layer
         # (when prompt_token_ids was supplied) or zero at this point
@@ -3593,12 +3650,23 @@ class Scheduler:
         max_tokens = int(
             getattr(getattr(request, "sampling_params", None), "max_tokens", 0) or 0
         )
-        # Fixed baseline (whole sliding-window buffers + recurrent state) is a
-        # per-sequence allocation charged once, plus the unbounded per-token
-        # growth of the full-attention layers over the projected token budget.
-        # For a dense model ``fixed_baseline`` is 0, so this is byte-identical to
-        # the historical ``per_tok × tokens``.
-        return fixed_baseline + per_tok * (prompt_tokens + max_tokens)
+        tokens = prompt_tokens + max_tokens
+        # Sliding-window term: per-slot bytes × the request's slot count, an
+        # over-count-safe upper bound of the real RotatingKVCache allocation that
+        # grows with ``tokens`` up to the full window and then caps (0 when there
+        # is no window-bounded sliding layer). Charged per request so a short
+        # request is not over-charged the whole window.
+        sliding_bytes = 0
+        if sliding_slot_bytes > 0 and sliding_window > 0:
+            sliding_bytes = sliding_slot_bytes * rotating_cache_slots(
+                sliding_window, tokens
+            )
+        # Fixed baseline (recurrent state) charged once, plus the unbounded
+        # per-token growth of the full-attention layers over the projected token
+        # budget, plus the request-dependent sliding term. For a dense model the
+        # baseline and sliding term are 0, so this is byte-identical to the
+        # historical ``per_tok × tokens``.
+        return fixed_baseline + per_tok * tokens + sliding_bytes
 
     def _sum_in_flight_kv_bytes(self) -> int:
         """Sum projected KV reservations of WAITING-only requests.
@@ -3627,14 +3695,14 @@ class Scheduler:
         """
         per_tok = self._resolve_kv_bytes_per_token()
         fixed_baseline = self._resolve_kv_fixed_baseline_bytes()
+        sliding_slot_bytes = self._kv_sliding_slot_bytes
         # Cheap short-circuit only: a hybrid with all-sliding layers has zero
-        # per-token growth but a real per-sequence baseline (the whole window
-        # buffers), so both must be 0 (dense MagicMock / no config) to skip. The
-        # per-request charge itself — including the fixed baseline once per
-        # waiting request — is computed by ``_estimate_request_kv_bytes`` in the
-        # loop below, NOT here, so the baseline is never dropped from the
-        # aggregate.
-        if per_tok <= 0 and fixed_baseline <= 0:
+        # per-token growth and zero fixed baseline but a real per-request sliding
+        # term, so ALL THREE must be 0 (dense MagicMock / no config) to skip. The
+        # per-request charge itself — including the sliding term once per waiting
+        # request — is computed by ``_estimate_request_kv_bytes`` in the loop
+        # below, NOT here, so no term is ever dropped from the aggregate.
+        if per_tok <= 0 and fixed_baseline <= 0 and sliding_slot_bytes <= 0:
             return 0
         try:
             waiting = self.waiting
@@ -3642,9 +3710,9 @@ class Scheduler:
             return 0
         total = 0
         for req in waiting:
-            # ``_estimate_request_kv_bytes`` returns fixed_baseline +
-            # per_tok × tokens for each request — the baseline is charged
-            # per waiting sequence (each allocates its own window buffers).
+            # ``_estimate_request_kv_bytes`` returns the full per-request
+            # projection (baseline + per_tok × tokens + sliding term) — each
+            # waiting sequence allocates its own buffers.
             total += self._estimate_request_kv_bytes(req)
         return int(total)
 

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -39,6 +39,7 @@ from ._sampler_fast_path import (  # noqa: E402
     make_fused_top_p_temp_sampler,
 )
 from ._seeded_sampler import make_seeded_sampler  # noqa: E402
+from .kv_estimation import estimate_kv_footprint  # noqa: E402
 from .memory_cache import MemoryAwarePrefixCache, MemoryCacheConfig  # noqa: E402
 from .paged_cache import PagedCacheManager
 from .pflash import PFlashConfig, compress_request_tokens
@@ -2220,6 +2221,14 @@ class Scheduler:
         # tests built against MagicMock models).
         self._kv_bytes_per_token: int = 0
         self._kv_bytes_per_token_resolved: bool = False
+        # D-METAL-CAP: cached per-sequence FIXED KV baseline (bytes) for
+        # architecture-aware hybrids — sliding-window rotating buffers plus a
+        # conservative recurrent-state term. Allocated once per sequence, not
+        # per token, so ``_estimate_request_kv_bytes`` charges it as a flat
+        # add-on rather than multiplying by the token count. ``0`` for dense
+        # models and for the byte-identical uniform fallback (see
+        # ``_resolve_kv_bytes_per_token`` and ``kv_estimation``).
+        self._kv_fixed_baseline_bytes: int = 0
 
         # Prompt-boundary cache snapshot callback for the new mlx-lm 0.31+ API.
         # Built lazily once memory_aware_cache exists and reused per step.
@@ -3327,7 +3336,7 @@ class Scheduler:
         to fix the "currently below cap, one large prefill allocates
         past cap" failure mode by default.
 
-        Auto-derivation formula:
+        Auto-derivation formula (uniform baseline):
             ``2 (K + V) × num_layers × num_kv_heads × head_dim × dtype_bytes``
 
         Defaults match ``model_runner.py``'s cache-block-size helper
@@ -3338,6 +3347,25 @@ class Scheduler:
         better than the D-METAL-CAP cliff). Operators on quantized-
         KV deployments can pin a tighter value via the SchedulerConfig
         field to recover precision.
+
+        Architecture-aware refinement (``kv_estimation``): the uniform
+        formula counts EVERY layer as a full-growth attention layer,
+        which over-estimates the per-token figure by up to ~2× for the
+        hybrid architectures we ship — sliding-window layers (GPT-OSS,
+        Gemma-4 local) are window-bounded, KV-sharing borrower layers
+        (Gemma-4 ``num_kv_shared_layers``) allocate nothing, and
+        recurrent / linear-attention layers (Qwen3.5 GatedDeltaNet)
+        carry a fixed state. Once the uniform figure is computed we
+        route it through :func:`kv_estimation.estimate_kv_footprint`,
+        which returns the accurate per-token GROWTH (only the
+        full-attention layers) plus a per-sequence FIXED baseline
+        (window buffers + recurrent state). The estimator is
+        over-estimate-safe: a dense model or an unknown/stub config
+        that exposes no ``layer_types`` / ``num_kv_shared_layers``
+        yields a BYTE-IDENTICAL uniform result (per-token unchanged,
+        baseline 0), so only recognized hybrids get the smaller,
+        accurate number and the D-METAL-CAP OOM cliff is never
+        re-introduced.
 
         Returns ``0`` only when the model config is missing entirely
         (e.g. unit-test ``MagicMock`` model) so back-compat unit
@@ -3362,6 +3390,7 @@ class Scheduler:
         # unit-test admission into a projection rejection. Requiring
         # ints filters that path.
         per_tok = 0
+        fixed_baseline = 0
         try:
             model_config = getattr(self.model, "config", None)
             if model_config is not None:
@@ -3392,6 +3421,23 @@ class Scheduler:
                 dtype_bytes = self._infer_kv_dtype_bytes(model_config)
                 if num_layers > 0 and num_kv_heads > 0 and head_dim > 0:
                     per_tok = 2 * num_layers * num_kv_heads * head_dim * dtype_bytes
+                    # Architecture-aware refinement. For dense / unknown
+                    # configs the estimator returns this exact uniform
+                    # ``per_tok`` with a 0 baseline (byte-identical); only a
+                    # recognized hybrid (sliding-window / KV-sharing /
+                    # recurrent layers) reduces the per-token growth and moves
+                    # the window + recurrent-state footprint into the
+                    # per-sequence fixed baseline.
+                    estimate = estimate_kv_footprint(
+                        model_config,
+                        dtype_bytes=dtype_bytes,
+                        uniform_per_token_bytes=per_tok,
+                        base_num_layers=num_layers,
+                        base_kv_heads=num_kv_heads,
+                        base_head_dim=head_dim,
+                    )
+                    per_tok = estimate.per_token_growth_bytes
+                    fixed_baseline = estimate.fixed_baseline_bytes
         except Exception as e:
             logger.debug(
                 "[D-METAL-CAP] failed to auto-derive kv_bytes_per_token "
@@ -3401,19 +3447,45 @@ class Scheduler:
                 e,
             )
             per_tok = 0
+            fixed_baseline = 0
         self._kv_bytes_per_token = per_tok
+        self._kv_fixed_baseline_bytes = fixed_baseline
         self._kv_bytes_per_token_resolved = True
         return per_tok
+
+    def _resolve_kv_fixed_baseline_bytes(self) -> int:
+        """Per-sequence FIXED KV baseline (bytes) for hybrid architectures.
+
+        Companion to :meth:`_resolve_kv_bytes_per_token`: the window /
+        recurrent-state footprint an architecture-aware hybrid allocates ONCE
+        per sequence (not per token). ``0`` for dense models, for the uniform
+        fallback, and under the operator override — so the projection stays
+        byte-identical wherever the baseline is not populated. Resolution and
+        caching happen inside ``_resolve_kv_bytes_per_token`` (both values are
+        computed from the same estimate), so we drive it first, then read the
+        cached baseline.
+        """
+        self._resolve_kv_bytes_per_token()
+        return self._kv_fixed_baseline_bytes
 
     def _estimate_request_kv_bytes(self, request: Request) -> int:
         """Project KV-cache memory the new request would consume.
 
-        Returns ``num_prompt_tokens + max_tokens`` × per-token KV
-        bytes (auto-derived from model config or operator-overridden
-        via ``metal_cap_kv_bytes_per_token``). Used by the admission
-        gate to reject prefill requests that would push Metal active
-        PAST the cap before the allocation happens (codex round 3
-        BLOCKING #1 + round 4 BLOCKING #1+#2).
+        Returns ``fixed_baseline + (num_prompt_tokens + max_tokens) ×
+        per_token_growth`` (auto-derived from model config or
+        operator-overridden via ``metal_cap_kv_bytes_per_token``).
+        Used by the admission gate to reject prefill requests that
+        would push Metal active PAST the cap before the allocation
+        happens (codex round 3 BLOCKING #1 + round 4 BLOCKING #1+#2).
+
+        ``per_token_growth`` counts only the full-attention layers; the
+        window buffers of sliding-window layers and the fixed state of
+        recurrent layers live in ``fixed_baseline`` (allocated once per
+        sequence). For a dense model ``fixed_baseline`` is 0 and this
+        reduces to the historical ``per_tok × tokens`` — byte-identical.
+        The sum is always >= the true architecture-aware footprint of the
+        counted layers (sliding layers charge their whole window), so the
+        gate can only over-estimate, never under-count.
 
         Conservative by design: we count both the prompt and the
         full ``max_tokens`` budget (rather than the much smaller
@@ -3422,7 +3494,8 @@ class Scheduler:
         grow past the cap mid-generation.
         """
         per_tok = self._resolve_kv_bytes_per_token()
-        if per_tok <= 0:
+        fixed_baseline = self._resolve_kv_fixed_baseline_bytes()
+        if per_tok <= 0 and fixed_baseline <= 0:
             return 0
         # ``num_prompt_tokens`` is populated by either the route layer
         # (when prompt_token_ids was supplied) or zero at this point
@@ -3462,7 +3535,12 @@ class Scheduler:
         max_tokens = int(
             getattr(getattr(request, "sampling_params", None), "max_tokens", 0) or 0
         )
-        return per_tok * (prompt_tokens + max_tokens)
+        # Fixed baseline (window buffers + recurrent state) is a per-sequence
+        # allocation charged once, plus the per-token growth of the
+        # full-attention layers over the projected token budget. For a dense
+        # model ``fixed_baseline`` is 0, so this is byte-identical to the
+        # historical ``per_tok × tokens``.
+        return fixed_baseline + per_tok * (prompt_tokens + max_tokens)
 
     def _sum_in_flight_kv_bytes(self) -> int:
         """Sum projected KV reservations of WAITING-only requests.
@@ -3490,7 +3568,12 @@ class Scheduler:
         scheduler lock).
         """
         per_tok = self._resolve_kv_bytes_per_token()
-        if per_tok <= 0:
+        fixed_baseline = self._resolve_kv_fixed_baseline_bytes()
+        # A hybrid whose full-attention layers were all shared/recurrent could
+        # have zero per-token growth yet a real per-sequence baseline; charge
+        # it too. Both zero (dense MagicMock / no config) short-circuits to 0,
+        # matching ``_estimate_request_kv_bytes``.
+        if per_tok <= 0 and fixed_baseline <= 0:
             return 0
         try:
             waiting = self.waiting

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -3405,9 +3405,26 @@ class Scheduler:
         try:
             model_config = getattr(self.model, "config", None)
             if model_config is not None:
+                # Multimodal architectures nest the text-tower dims
+                # (num_hidden_layers, num_key_value_heads, head_dim, layer_types)
+                # under ``text_config``. Read the base dims from whichever config
+                # actually carries ``num_hidden_layers`` so ``base_num_layers``
+                # matches the ``layer_types`` map the estimator inspects —
+                # otherwise a nested hybrid structure is silently rejected by
+                # ``estimate_kv_footprint`` and the reduction never engages
+                # (codex round 8 BLOCKING). The estimator independently
+                # re-validates the layer_types length, so an inconsistent outer
+                # count still falls back to the safe uniform estimate.
+                struct_config = model_config
+                if not isinstance(
+                    getattr(model_config, "num_hidden_layers", None), int
+                ):
+                    text_config = getattr(model_config, "text_config", None)
+                    if text_config is not None:
+                        struct_config = text_config
 
                 def _read_int(name: str, fallback: int = 0) -> int:
-                    raw = getattr(model_config, name, fallback)
+                    raw = getattr(struct_config, name, fallback)
                     return raw if isinstance(raw, int) else 0
 
                 num_layers = _read_int("num_hidden_layers")
@@ -3446,7 +3463,7 @@ class Scheduler:
                     # round 3 BLOCKING #3).
                     try:
                         estimate = estimate_kv_footprint(
-                            model_config,
+                            struct_config,
                             dtype_bytes=dtype_bytes,
                             uniform_per_token_bytes=per_tok,
                             base_num_layers=num_layers,

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -2225,22 +2225,17 @@ class Scheduler:
         self._kv_bytes_per_token: int = 0
         self._kv_bytes_per_token_resolved: bool = False
         # D-METAL-CAP: cached per-sequence FIXED KV baseline (bytes) for
-        # architecture-aware hybrids — the conservative recurrent-state term of
-        # a hybrid's linear-attention / Mamba layers. Allocated once per
-        # sequence, not per token (an SSM/conv state is materialized in full at
-        # cache init), so ``_estimate_request_kv_bytes`` charges it as a flat
-        # add-on rather than multiplying by the token count. ``0`` for dense
-        # models and for the byte-identical uniform fallback (see
+        # architecture-aware hybrids — the WHOLE rotating-window buffer of each
+        # sliding-window layer plus the conservative recurrent-state term of a
+        # hybrid's linear-attention layers. Allocated once per sequence, not per
+        # token (a window buffer / SSM state does not grow with the token
+        # budget), so ``_estimate_request_kv_bytes`` charges it as a flat add-on
+        # rather than multiplying by the token count. Charging the whole window
+        # is the over-count-SAFE upper bound (a rotating/paged cache rounds up to
+        # block increments and may keep sink positions — codex round 9 BLOCKING).
+        # ``0`` for dense models and for the byte-identical uniform fallback (see
         # ``_resolve_kv_bytes_per_token`` and ``kv_estimation``).
         self._kv_fixed_baseline_bytes: int = 0
-        # D-METAL-CAP: cached sliding-window KV term for hybrids. Sliding-window
-        # (local-attention) layers grow per token only up to a rotating window,
-        # so their footprint is ``sliding_per_token × min(tokens, window)`` — NOT
-        # a flat window buffer, which would over-charge (and spuriously reject)
-        # requests shorter than the window (codex round 6 BLOCKING). Both ``0``
-        # for dense models and the uniform fallback.
-        self._kv_sliding_per_token_bytes: int = 0
-        self._kv_sliding_window_tokens: int = 0
 
         # Prompt-boundary cache snapshot callback for the new mlx-lm 0.31+ API.
         # Built lazily once memory_aware_cache exists and reused per step.
@@ -3403,42 +3398,38 @@ class Scheduler:
         # ints filters that path.
         per_tok = 0
         fixed_baseline = 0
-        sliding_per_token = 0
-        sliding_window = 0
         try:
             model_config = getattr(self.model, "config", None)
             if model_config is not None:
                 # Multimodal architectures nest the text-tower dims
                 # (num_hidden_layers, num_key_value_heads, head_dim, layer_types)
-                # under ``text_config``. Read the base dims from the config that
-                # actually carries the text-layer structure so ``base_num_layers``
-                # matches the ``layer_types`` map the estimator inspects —
-                # otherwise a nested hybrid is silently rejected by
-                # ``estimate_kv_footprint`` and the reduction never engages
-                # (codex round 8 BLOCKING).
+                # under ``text_config``, and the OUTER config may still carry a
+                # DECOY ``num_hidden_layers`` describing the vision tower. Read
+                # the base dims from the config that actually carries the
+                # text-layer structure — the SAME rule ``_pick_structural_config``
+                # uses: pick the first of (outer, text_config) whose OWN
+                # ``layer_types`` is valid and length-matches its OWN
+                # ``num_hidden_layers`` (codex round 8 + round 9 BLOCKING #1).
+                # Reusing ``_valid_layer_types`` keeps the scheduler's selection
+                # from drifting away from the estimator's.
                 #
-                # BYTE-IDENTICAL guard: only adopt ``text_config`` when the outer
-                # config has no ``num_hidden_layers`` of its own AND the nested
-                # config exposes a VALID ``layer_types`` list (a genuine nested
-                # hybrid — the exact condition ``_pick_structural_config`` uses,
-                # reused here so the two can't drift). A text-lane model (dims on
-                # the outer config) and a multimodal model whose text_config has
-                # no valid layer_types both keep the outer dims unchanged, so
-                # dense/text behavior stays exactly as before.
+                # BYTE-IDENTICAL guard: if NEITHER config exposes a valid
+                # ``layer_types`` (a dense / unknown model), fall back to the
+                # outer config exactly as before — dense/text admission
+                # accounting is unchanged.
                 struct_config = model_config
-                if not isinstance(
-                    getattr(model_config, "num_hidden_layers", None), int
+                for _candidate in (
+                    model_config,
+                    getattr(model_config, "text_config", None),
                 ):
-                    text_config = getattr(model_config, "text_config", None)
-                    tc_layers = getattr(text_config, "num_hidden_layers", None)
-                    if (
-                        text_config is not None
-                        and isinstance(tc_layers, int)
-                        and _valid_layer_types(
-                            getattr(text_config, "layer_types", None), tc_layers
-                        )
+                    if _candidate is None:
+                        continue
+                    _cand_layers = getattr(_candidate, "num_hidden_layers", None)
+                    if isinstance(_cand_layers, int) and _valid_layer_types(
+                        getattr(_candidate, "layer_types", None), _cand_layers
                     ):
-                        struct_config = text_config
+                        struct_config = _candidate
+                        break
 
                 def _read_int(name: str, fallback: int = 0) -> int:
                     raw = getattr(struct_config, name, fallback)
@@ -3489,8 +3480,6 @@ class Scheduler:
                         )
                         per_tok = estimate.per_token_growth_bytes
                         fixed_baseline = estimate.fixed_baseline_bytes
-                        sliding_per_token = estimate.sliding_per_token_bytes
-                        sliding_window = estimate.sliding_window_tokens
                     except Exception as est_err:
                         logger.debug(
                             "[D-METAL-CAP] architecture-aware KV estimate "
@@ -3500,8 +3489,6 @@ class Scheduler:
                         )
                         # ``per_tok`` already holds the uniform value; keep it.
                         fixed_baseline = 0
-                        sliding_per_token = 0
-                        sliding_window = 0
         except Exception as e:
             logger.debug(
                 "[D-METAL-CAP] failed to auto-derive kv_bytes_per_token "
@@ -3512,12 +3499,8 @@ class Scheduler:
             )
             per_tok = 0
             fixed_baseline = 0
-            sliding_per_token = 0
-            sliding_window = 0
         self._kv_bytes_per_token = per_tok
         self._kv_fixed_baseline_bytes = fixed_baseline
-        self._kv_sliding_per_token_bytes = sliding_per_token
-        self._kv_sliding_window_tokens = sliding_window
         self._kv_bytes_per_token_resolved = True
         return per_tok
 
@@ -3525,15 +3508,16 @@ class Scheduler:
         """Per-sequence FIXED KV baseline (bytes) for hybrid architectures.
 
         Companion to :meth:`_resolve_kv_bytes_per_token`: the token-independent
-        recurrent-state footprint an architecture-aware hybrid allocates ONCE
-        per sequence (not per token). Sliding-window layers are NOT charged here
-        — they grow per token up to a rotating window and live in the separate
-        ``_kv_sliding_per_token_bytes`` / ``_kv_sliding_window_tokens`` term
-        (codex round 6 BLOCKING). ``0`` for dense models, for the uniform
-        fallback, and under the operator override — so the projection stays
-        byte-identical wherever the baseline is not populated. Resolution and
-        caching happen inside ``_resolve_kv_bytes_per_token`` (all values are
-        computed from the same estimate), so we drive it first, then read the
+        footprint an architecture-aware hybrid allocates ONCE per sequence (not
+        per token) — the WHOLE rotating-window buffer of each sliding-window
+        layer plus the fixed recurrent state of each sizeable recurrent layer.
+        Charging the whole window is the over-count-safe upper bound (a
+        rotating/paged cache rounds up to block increments and may keep sink
+        positions — codex round 9 BLOCKING). ``0`` for dense models, for the
+        uniform fallback, and under the operator override — so the projection
+        stays byte-identical wherever the baseline is not populated. Resolution
+        and caching happen inside ``_resolve_kv_bytes_per_token`` (both values
+        are computed from the same estimate), so we drive it first, then read the
         cached baseline.
         """
         self._resolve_kv_bytes_per_token()
@@ -3542,27 +3526,21 @@ class Scheduler:
     def _estimate_request_kv_bytes(self, request: Request) -> int:
         """Project KV-cache memory the new request would consume.
 
-        Returns ``fixed_baseline + tokens × per_token_growth +
-        sliding_per_token × max(prompt_tokens, min(tokens, sliding_window))``
-        where ``tokens = num_prompt_tokens + max_tokens`` (auto-derived from
-        model config or operator-overridden via
-        ``metal_cap_kv_bytes_per_token``). Used by the admission gate to
-        reject prefill requests that would push Metal active PAST the cap
-        before the allocation happens (codex round 3 BLOCKING #1 + round 4
-        BLOCKING #1+#2 + round 6 BLOCKING + round 7 BLOCKING #3).
+        Returns ``fixed_baseline + (num_prompt_tokens + max_tokens) ×
+        per_token_growth`` (auto-derived from model config or
+        operator-overridden via ``metal_cap_kv_bytes_per_token``). Used by the
+        admission gate to reject prefill requests that would push Metal active
+        PAST the cap before the allocation happens (codex round 3 BLOCKING #1 +
+        round 4 BLOCKING #1+#2 + round 9 BLOCKING #2).
 
-        ``per_token_growth`` counts only the unbounded full-attention
-        layers. Sliding-window layers rotate their KV at ``window`` positions
-        during decode, but a prefill longer than the window can transiently
-        hold the whole prompt before the cache trims — so they are charged
-        ``sliding_per_token × max(prompt_tokens, min(tokens, window))``: the
-        window-capped steady state, floored at the full prompt to cover the
-        transient prefill peak (the large-prefill OOM this gate targets). For
-        any request shorter than the window this is exactly ``tokens`` worth —
-        equal to the old uniform figure, never over-charging (and spuriously
-        rejecting) a short request. Recurrent layers' token-independent fixed
-        state lives in ``fixed_baseline`` (allocated once per sequence). For a
-        dense model ``fixed_baseline`` and the sliding term are 0 and this
+        ``per_token_growth`` counts only the unbounded full-attention layers.
+        Sliding-window layers do not grow per token beyond a rotating window, so
+        their WHOLE window buffer, and the fixed state of recurrent layers, live
+        in ``fixed_baseline`` (allocated once per sequence). Charging the whole
+        window is over-count-safe — a rotating/paged cache rounds up to block
+        increments and may retain sink positions, so the real allocation can
+        reach but never exceed the full window regardless of token budget or
+        prefill length. For a dense model ``fixed_baseline`` is 0 and this
         reduces to the historical ``per_tok × tokens`` — byte-identical. The sum
         is always >= the true architecture-aware footprint of the counted
         layers, so the gate can only over-estimate, never under-count.
@@ -3575,9 +3553,7 @@ class Scheduler:
         """
         per_tok = self._resolve_kv_bytes_per_token()
         fixed_baseline = self._resolve_kv_fixed_baseline_bytes()
-        sliding_per_tok = self._kv_sliding_per_token_bytes
-        sliding_window = self._kv_sliding_window_tokens
-        if per_tok <= 0 and fixed_baseline <= 0 and sliding_per_tok <= 0:
+        if per_tok <= 0 and fixed_baseline <= 0:
             return 0
         # ``num_prompt_tokens`` is populated by either the route layer
         # (when prompt_token_ids was supplied) or zero at this point
@@ -3617,32 +3593,12 @@ class Scheduler:
         max_tokens = int(
             getattr(getattr(request, "sampling_params", None), "max_tokens", 0) or 0
         )
-        tokens = prompt_tokens + max_tokens
-        # Sliding-window layers rotate their KV at ``window`` positions during
-        # DECODE, but a PREFILL longer than the window can transiently
-        # materialize the whole prompt's KV before the rotating cache trims it —
-        # the exact large-prefill allocation this admission gate exists to catch.
-        # Charging only ``min(tokens, window)`` would ignore that transient peak
-        # and could admit a prompt that OOMs during prefill (codex round 7
-        # BLOCKING #3). So the sliding peak is the LARGER of:
-        #   * the full prompt (conservative prefill peak), and
-        #   * the window-capped steady state ``min(tokens, window)`` (decode).
-        # For a request shorter than the window this is exactly ``tokens`` —
-        # byte-identical to the old uniform figure, no over-charge (codex round 6
-        # BLOCKING). For a small prompt + long generation it stays capped at the
-        # window (the reduction this delivers); only a prompt that itself exceeds
-        # the window pays the uncapped prefill price.
-        if sliding_window > 0:
-            sliding_positions = max(prompt_tokens, min(tokens, sliding_window))
-        else:
-            sliding_positions = 0
-        sliding_bytes = sliding_per_tok * sliding_positions
-        # Fixed baseline (recurrent state) is a per-sequence allocation charged
-        # once, plus the unbounded per-token growth of the full-attention layers
-        # over the projected token budget, plus the window-capped sliding term.
-        # For a dense model ``fixed_baseline`` and ``sliding_bytes`` are 0, so
-        # this is byte-identical to the historical ``per_tok × tokens``.
-        return fixed_baseline + per_tok * tokens + sliding_bytes
+        # Fixed baseline (whole sliding-window buffers + recurrent state) is a
+        # per-sequence allocation charged once, plus the unbounded per-token
+        # growth of the full-attention layers over the projected token budget.
+        # For a dense model ``fixed_baseline`` is 0, so this is byte-identical to
+        # the historical ``per_tok × tokens``.
+        return fixed_baseline + per_tok * (prompt_tokens + max_tokens)
 
     def _sum_in_flight_kv_bytes(self) -> int:
         """Sum projected KV reservations of WAITING-only requests.
@@ -3671,15 +3627,14 @@ class Scheduler:
         """
         per_tok = self._resolve_kv_bytes_per_token()
         fixed_baseline = self._resolve_kv_fixed_baseline_bytes()
-        sliding_per_tok = self._kv_sliding_per_token_bytes
         # Cheap short-circuit only: a hybrid with all-sliding layers has zero
-        # per-token growth and no recurrent baseline but a real per-token sliding
-        # term, so ALL THREE must be 0 (dense MagicMock / no config) to skip. The
-        # per-request charge itself — including the fixed baseline and the
-        # window-capped sliding term for each waiting request — is computed by
-        # ``_estimate_request_kv_bytes`` in the loop below, NOT here, so no term
-        # is ever dropped from the aggregate.
-        if per_tok <= 0 and fixed_baseline <= 0 and sliding_per_tok <= 0:
+        # per-token growth but a real per-sequence baseline (the whole window
+        # buffers), so both must be 0 (dense MagicMock / no config) to skip. The
+        # per-request charge itself — including the fixed baseline once per
+        # waiting request — is computed by ``_estimate_request_kv_bytes`` in the
+        # loop below, NOT here, so the baseline is never dropped from the
+        # aggregate.
+        if per_tok <= 0 and fixed_baseline <= 0:
             return 0
         try:
             waiting = self.waiting

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -39,7 +39,10 @@ from ._sampler_fast_path import (  # noqa: E402
     make_fused_top_p_temp_sampler,
 )
 from ._seeded_sampler import make_seeded_sampler  # noqa: E402
-from .kv_estimation import estimate_kv_footprint  # noqa: E402
+from .kv_estimation import (  # noqa: E402
+    _valid_layer_types,
+    estimate_kv_footprint,
+)
 from .memory_cache import MemoryAwarePrefixCache, MemoryCacheConfig  # noqa: E402
 from .paged_cache import PagedCacheManager
 from .pflash import PFlashConfig, compress_request_tokens
@@ -3407,20 +3410,34 @@ class Scheduler:
             if model_config is not None:
                 # Multimodal architectures nest the text-tower dims
                 # (num_hidden_layers, num_key_value_heads, head_dim, layer_types)
-                # under ``text_config``. Read the base dims from whichever config
-                # actually carries ``num_hidden_layers`` so ``base_num_layers``
+                # under ``text_config``. Read the base dims from the config that
+                # actually carries the text-layer structure so ``base_num_layers``
                 # matches the ``layer_types`` map the estimator inspects —
-                # otherwise a nested hybrid structure is silently rejected by
+                # otherwise a nested hybrid is silently rejected by
                 # ``estimate_kv_footprint`` and the reduction never engages
-                # (codex round 8 BLOCKING). The estimator independently
-                # re-validates the layer_types length, so an inconsistent outer
-                # count still falls back to the safe uniform estimate.
+                # (codex round 8 BLOCKING).
+                #
+                # BYTE-IDENTICAL guard: only adopt ``text_config`` when the outer
+                # config has no ``num_hidden_layers`` of its own AND the nested
+                # config exposes a VALID ``layer_types`` list (a genuine nested
+                # hybrid — the exact condition ``_pick_structural_config`` uses,
+                # reused here so the two can't drift). A text-lane model (dims on
+                # the outer config) and a multimodal model whose text_config has
+                # no valid layer_types both keep the outer dims unchanged, so
+                # dense/text behavior stays exactly as before.
                 struct_config = model_config
                 if not isinstance(
                     getattr(model_config, "num_hidden_layers", None), int
                 ):
                     text_config = getattr(model_config, "text_config", None)
-                    if text_config is not None:
+                    tc_layers = getattr(text_config, "num_hidden_layers", None)
+                    if (
+                        text_config is not None
+                        and isinstance(tc_layers, int)
+                        and _valid_layer_types(
+                            getattr(text_config, "layer_types", None), tc_layers
+                        )
+                    ):
                         struct_config = text_config
 
                 def _read_int(name: str, fallback: int = 0) -> int:

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -2222,13 +2222,22 @@ class Scheduler:
         self._kv_bytes_per_token: int = 0
         self._kv_bytes_per_token_resolved: bool = False
         # D-METAL-CAP: cached per-sequence FIXED KV baseline (bytes) for
-        # architecture-aware hybrids — sliding-window rotating buffers plus a
-        # conservative recurrent-state term. Allocated once per sequence, not
-        # per token, so ``_estimate_request_kv_bytes`` charges it as a flat
+        # architecture-aware hybrids — the conservative recurrent-state term of
+        # a hybrid's linear-attention / Mamba layers. Allocated once per
+        # sequence, not per token (an SSM/conv state is materialized in full at
+        # cache init), so ``_estimate_request_kv_bytes`` charges it as a flat
         # add-on rather than multiplying by the token count. ``0`` for dense
         # models and for the byte-identical uniform fallback (see
         # ``_resolve_kv_bytes_per_token`` and ``kv_estimation``).
         self._kv_fixed_baseline_bytes: int = 0
+        # D-METAL-CAP: cached sliding-window KV term for hybrids. Sliding-window
+        # (local-attention) layers grow per token only up to a rotating window,
+        # so their footprint is ``sliding_per_token × min(tokens, window)`` — NOT
+        # a flat window buffer, which would over-charge (and spuriously reject)
+        # requests shorter than the window (codex round 6 BLOCKING). Both ``0``
+        # for dense models and the uniform fallback.
+        self._kv_sliding_per_token_bytes: int = 0
+        self._kv_sliding_window_tokens: int = 0
 
         # Prompt-boundary cache snapshot callback for the new mlx-lm 0.31+ API.
         # Built lazily once memory_aware_cache exists and reused per step.
@@ -3391,6 +3400,8 @@ class Scheduler:
         # ints filters that path.
         per_tok = 0
         fixed_baseline = 0
+        sliding_per_token = 0
+        sliding_window = 0
         try:
             model_config = getattr(self.model, "config", None)
             if model_config is not None:
@@ -3444,6 +3455,8 @@ class Scheduler:
                         )
                         per_tok = estimate.per_token_growth_bytes
                         fixed_baseline = estimate.fixed_baseline_bytes
+                        sliding_per_token = estimate.sliding_per_token_bytes
+                        sliding_window = estimate.sliding_window_tokens
                     except Exception as est_err:
                         logger.debug(
                             "[D-METAL-CAP] architecture-aware KV estimate "
@@ -3453,6 +3466,8 @@ class Scheduler:
                         )
                         # ``per_tok`` already holds the uniform value; keep it.
                         fixed_baseline = 0
+                        sliding_per_token = 0
+                        sliding_window = 0
         except Exception as e:
             logger.debug(
                 "[D-METAL-CAP] failed to auto-derive kv_bytes_per_token "
@@ -3463,20 +3478,27 @@ class Scheduler:
             )
             per_tok = 0
             fixed_baseline = 0
+            sliding_per_token = 0
+            sliding_window = 0
         self._kv_bytes_per_token = per_tok
         self._kv_fixed_baseline_bytes = fixed_baseline
+        self._kv_sliding_per_token_bytes = sliding_per_token
+        self._kv_sliding_window_tokens = sliding_window
         self._kv_bytes_per_token_resolved = True
         return per_tok
 
     def _resolve_kv_fixed_baseline_bytes(self) -> int:
         """Per-sequence FIXED KV baseline (bytes) for hybrid architectures.
 
-        Companion to :meth:`_resolve_kv_bytes_per_token`: the window /
+        Companion to :meth:`_resolve_kv_bytes_per_token`: the token-independent
         recurrent-state footprint an architecture-aware hybrid allocates ONCE
-        per sequence (not per token). ``0`` for dense models, for the uniform
+        per sequence (not per token). Sliding-window layers are NOT charged here
+        — they grow per token up to a rotating window and live in the separate
+        ``_kv_sliding_per_token_bytes`` / ``_kv_sliding_window_tokens`` term
+        (codex round 6 BLOCKING). ``0`` for dense models, for the uniform
         fallback, and under the operator override — so the projection stays
         byte-identical wherever the baseline is not populated. Resolution and
-        caching happen inside ``_resolve_kv_bytes_per_token`` (both values are
+        caching happen inside ``_resolve_kv_bytes_per_token`` (all values are
         computed from the same estimate), so we drive it first, then read the
         cached baseline.
         """
@@ -3486,21 +3508,27 @@ class Scheduler:
     def _estimate_request_kv_bytes(self, request: Request) -> int:
         """Project KV-cache memory the new request would consume.
 
-        Returns ``fixed_baseline + (num_prompt_tokens + max_tokens) ×
-        per_token_growth`` (auto-derived from model config or
-        operator-overridden via ``metal_cap_kv_bytes_per_token``).
-        Used by the admission gate to reject prefill requests that
-        would push Metal active PAST the cap before the allocation
-        happens (codex round 3 BLOCKING #1 + round 4 BLOCKING #1+#2).
+        Returns ``fixed_baseline + tokens × per_token_growth +
+        sliding_per_token × min(tokens, sliding_window)`` where
+        ``tokens = num_prompt_tokens + max_tokens`` (auto-derived from
+        model config or operator-overridden via
+        ``metal_cap_kv_bytes_per_token``). Used by the admission gate to
+        reject prefill requests that would push Metal active PAST the cap
+        before the allocation happens (codex round 3 BLOCKING #1 + round 4
+        BLOCKING #1+#2 + round 6 BLOCKING).
 
-        ``per_token_growth`` counts only the full-attention layers; the
-        window buffers of sliding-window layers and the fixed state of
-        recurrent layers live in ``fixed_baseline`` (allocated once per
-        sequence). For a dense model ``fixed_baseline`` is 0 and this
-        reduces to the historical ``per_tok × tokens`` — byte-identical.
+        ``per_token_growth`` counts only the unbounded full-attention
+        layers. Sliding-window layers grow per token only up to a rotating
+        window, so they are charged ``sliding_per_token × min(tokens,
+        window)`` — the exact rotating-cache peak, and equal to the old
+        uniform figure for any request shorter than the window (never
+        flattened into a full-window baseline, which would over-charge and
+        spuriously reject short requests). Recurrent layers' token-independent
+        fixed state lives in ``fixed_baseline`` (allocated once per sequence).
+        For a dense model ``fixed_baseline`` and the sliding term are 0 and
+        this reduces to the historical ``per_tok × tokens`` — byte-identical.
         The sum is always >= the true architecture-aware footprint of the
-        counted layers (sliding layers charge their whole window), so the
-        gate can only over-estimate, never under-count.
+        counted layers, so the gate can only over-estimate, never under-count.
 
         Conservative by design: we count both the prompt and the
         full ``max_tokens`` budget (rather than the much smaller
@@ -3510,7 +3538,9 @@ class Scheduler:
         """
         per_tok = self._resolve_kv_bytes_per_token()
         fixed_baseline = self._resolve_kv_fixed_baseline_bytes()
-        if per_tok <= 0 and fixed_baseline <= 0:
+        sliding_per_tok = self._kv_sliding_per_token_bytes
+        sliding_window = self._kv_sliding_window_tokens
+        if per_tok <= 0 and fixed_baseline <= 0 and sliding_per_tok <= 0:
             return 0
         # ``num_prompt_tokens`` is populated by either the route layer
         # (when prompt_token_ids was supplied) or zero at this point
@@ -3550,12 +3580,21 @@ class Scheduler:
         max_tokens = int(
             getattr(getattr(request, "sampling_params", None), "max_tokens", 0) or 0
         )
-        # Fixed baseline (window buffers + recurrent state) is a per-sequence
-        # allocation charged once, plus the per-token growth of the
-        # full-attention layers over the projected token budget. For a dense
-        # model ``fixed_baseline`` is 0, so this is byte-identical to the
-        # historical ``per_tok × tokens``.
-        return fixed_baseline + per_tok * (prompt_tokens + max_tokens)
+        tokens = prompt_tokens + max_tokens
+        # Sliding-window layers grow per token only up to a rotating window, so
+        # their peak occupancy is ``sliding_per_tok × min(tokens, window)`` — the
+        # exact rotating-cache peak, and equal to the old uniform figure for any
+        # request shorter than the window (codex round 6 BLOCKING). Flattening
+        # the full window into the baseline would over-charge short requests and
+        # spuriously reject them.
+        sliding_tokens = min(tokens, sliding_window) if sliding_window > 0 else 0
+        sliding_bytes = sliding_per_tok * sliding_tokens
+        # Fixed baseline (recurrent state) is a per-sequence allocation charged
+        # once, plus the unbounded per-token growth of the full-attention layers
+        # over the projected token budget, plus the window-capped sliding term.
+        # For a dense model ``fixed_baseline`` and ``sliding_bytes`` are 0, so
+        # this is byte-identical to the historical ``per_tok × tokens``.
+        return fixed_baseline + per_tok * tokens + sliding_bytes
 
     def _sum_in_flight_kv_bytes(self) -> int:
         """Sum projected KV reservations of WAITING-only requests.
@@ -3584,13 +3623,15 @@ class Scheduler:
         """
         per_tok = self._resolve_kv_bytes_per_token()
         fixed_baseline = self._resolve_kv_fixed_baseline_bytes()
+        sliding_per_tok = self._kv_sliding_per_token_bytes
         # Cheap short-circuit only: a hybrid with all-sliding layers has zero
-        # per-token growth but a real per-sequence baseline, so both must be 0
-        # (dense MagicMock / no config) to skip. The per-request charge itself —
-        # including the fixed baseline once per waiting request — is computed by
-        # ``_estimate_request_kv_bytes`` in the loop below, NOT here, so the
-        # baseline is never dropped from the aggregate.
-        if per_tok <= 0 and fixed_baseline <= 0:
+        # per-token growth and no recurrent baseline but a real per-token sliding
+        # term, so ALL THREE must be 0 (dense MagicMock / no config) to skip. The
+        # per-request charge itself — including the fixed baseline and the
+        # window-capped sliding term for each waiting request — is computed by
+        # ``_estimate_request_kv_bytes`` in the loop below, NOT here, so no term
+        # is ever dropped from the aggregate.
+        if per_tok <= 0 and fixed_baseline <= 0 and sliding_per_tok <= 0:
             return 0
         try:
             waiting = self.waiting

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -3569,10 +3569,12 @@ class Scheduler:
         """
         per_tok = self._resolve_kv_bytes_per_token()
         fixed_baseline = self._resolve_kv_fixed_baseline_bytes()
-        # A hybrid whose full-attention layers were all shared/recurrent could
-        # have zero per-token growth yet a real per-sequence baseline; charge
-        # it too. Both zero (dense MagicMock / no config) short-circuits to 0,
-        # matching ``_estimate_request_kv_bytes``.
+        # Cheap short-circuit only: a hybrid with all-sliding layers has zero
+        # per-token growth but a real per-sequence baseline, so both must be 0
+        # (dense MagicMock / no config) to skip. The per-request charge itself —
+        # including the fixed baseline once per waiting request — is computed by
+        # ``_estimate_request_kv_bytes`` in the loop below, NOT here, so the
+        # baseline is never dropped from the aggregate.
         if per_tok <= 0 and fixed_baseline <= 0:
             return 0
         try:
@@ -3581,6 +3583,9 @@ class Scheduler:
             return 0
         total = 0
         for req in waiting:
+            # ``_estimate_request_kv_bytes`` returns fixed_baseline +
+            # per_tok × tokens for each request — the baseline is charged
+            # per waiting sequence (each allocates its own window buffers).
             total += self._estimate_request_kv_bytes(req)
         return int(total)
 

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -3509,26 +3509,29 @@ class Scheduler:
         """Project KV-cache memory the new request would consume.
 
         Returns ``fixed_baseline + tokens × per_token_growth +
-        sliding_per_token × min(tokens, sliding_window)`` where
-        ``tokens = num_prompt_tokens + max_tokens`` (auto-derived from
+        sliding_per_token × max(prompt_tokens, min(tokens, sliding_window))``
+        where ``tokens = num_prompt_tokens + max_tokens`` (auto-derived from
         model config or operator-overridden via
         ``metal_cap_kv_bytes_per_token``). Used by the admission gate to
         reject prefill requests that would push Metal active PAST the cap
         before the allocation happens (codex round 3 BLOCKING #1 + round 4
-        BLOCKING #1+#2 + round 6 BLOCKING).
+        BLOCKING #1+#2 + round 6 BLOCKING + round 7 BLOCKING #3).
 
         ``per_token_growth`` counts only the unbounded full-attention
-        layers. Sliding-window layers grow per token only up to a rotating
-        window, so they are charged ``sliding_per_token × min(tokens,
-        window)`` — the exact rotating-cache peak, and equal to the old
-        uniform figure for any request shorter than the window (never
-        flattened into a full-window baseline, which would over-charge and
-        spuriously reject short requests). Recurrent layers' token-independent
-        fixed state lives in ``fixed_baseline`` (allocated once per sequence).
-        For a dense model ``fixed_baseline`` and the sliding term are 0 and
-        this reduces to the historical ``per_tok × tokens`` — byte-identical.
-        The sum is always >= the true architecture-aware footprint of the
-        counted layers, so the gate can only over-estimate, never under-count.
+        layers. Sliding-window layers rotate their KV at ``window`` positions
+        during decode, but a prefill longer than the window can transiently
+        hold the whole prompt before the cache trims — so they are charged
+        ``sliding_per_token × max(prompt_tokens, min(tokens, window))``: the
+        window-capped steady state, floored at the full prompt to cover the
+        transient prefill peak (the large-prefill OOM this gate targets). For
+        any request shorter than the window this is exactly ``tokens`` worth —
+        equal to the old uniform figure, never over-charging (and spuriously
+        rejecting) a short request. Recurrent layers' token-independent fixed
+        state lives in ``fixed_baseline`` (allocated once per sequence). For a
+        dense model ``fixed_baseline`` and the sliding term are 0 and this
+        reduces to the historical ``per_tok × tokens`` — byte-identical. The sum
+        is always >= the true architecture-aware footprint of the counted
+        layers, so the gate can only over-estimate, never under-count.
 
         Conservative by design: we count both the prompt and the
         full ``max_tokens`` budget (rather than the much smaller
@@ -3581,14 +3584,25 @@ class Scheduler:
             getattr(getattr(request, "sampling_params", None), "max_tokens", 0) or 0
         )
         tokens = prompt_tokens + max_tokens
-        # Sliding-window layers grow per token only up to a rotating window, so
-        # their peak occupancy is ``sliding_per_tok × min(tokens, window)`` — the
-        # exact rotating-cache peak, and equal to the old uniform figure for any
-        # request shorter than the window (codex round 6 BLOCKING). Flattening
-        # the full window into the baseline would over-charge short requests and
-        # spuriously reject them.
-        sliding_tokens = min(tokens, sliding_window) if sliding_window > 0 else 0
-        sliding_bytes = sliding_per_tok * sliding_tokens
+        # Sliding-window layers rotate their KV at ``window`` positions during
+        # DECODE, but a PREFILL longer than the window can transiently
+        # materialize the whole prompt's KV before the rotating cache trims it —
+        # the exact large-prefill allocation this admission gate exists to catch.
+        # Charging only ``min(tokens, window)`` would ignore that transient peak
+        # and could admit a prompt that OOMs during prefill (codex round 7
+        # BLOCKING #3). So the sliding peak is the LARGER of:
+        #   * the full prompt (conservative prefill peak), and
+        #   * the window-capped steady state ``min(tokens, window)`` (decode).
+        # For a request shorter than the window this is exactly ``tokens`` —
+        # byte-identical to the old uniform figure, no over-charge (codex round 6
+        # BLOCKING). For a small prompt + long generation it stays capped at the
+        # window (the reduction this delivers); only a prompt that itself exceeds
+        # the window pays the uncapped prefill price.
+        if sliding_window > 0:
+            sliding_positions = max(prompt_tokens, min(tokens, sliding_window))
+        else:
+            sliding_positions = 0
+        sliding_bytes = sliding_per_tok * sliding_positions
         # Fixed baseline (recurrent state) is a per-sequence allocation charged
         # once, plus the unbounded per-token growth of the full-attention layers
         # over the projected token budget, plus the window-capped sliding term.

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -3380,15 +3380,31 @@ class Scheduler:
         recurrent / linear-attention layers (Qwen3.5 GatedDeltaNet)
         carry a fixed state. Once the uniform figure is computed we
         route it through :func:`kv_estimation.estimate_kv_footprint`,
-        which returns the accurate per-token GROWTH (only the
-        full-attention layers) plus a per-sequence FIXED baseline
-        (window buffers + recurrent state). The estimator is
-        over-estimate-safe: a dense model or an unknown/stub config
-        that exposes no ``layer_types`` / ``num_kv_shared_layers``
-        yields a BYTE-IDENTICAL uniform result (per-token unchanged,
-        baseline 0), so only recognized hybrids get the smaller,
-        accurate number and the D-METAL-CAP OOM cliff is never
-        re-introduced.
+        which decomposes the real footprint into THREE terms that the
+        admission projection recombines per request:
+
+          1. per-token GROWTH bytes — the full-attention layers only;
+             the one term that scales linearly and unbounded with
+             ``prompt + max_tokens``.
+          2. a per-request SLIDING term — the sliding-window layers,
+             charged as ``sliding_slot_bytes ×
+             rotating_cache_slots(window, tokens)``. This is
+             request-dependent and SUBLINEAR: it grows in ``step``
+             blocks up to the window, then stays flat, so short
+             requests are not charged the whole window. Cached here as
+             ``_kv_sliding_slot_bytes`` / ``_kv_sliding_window`` and
+             applied in :meth:`_estimate_request_kv_bytes`.
+          3. a per-sequence FIXED baseline — recurrent /
+             linear-attention state ONLY (a constant that does not grow
+             with sequence length). Note: window buffers are NOT in the
+             baseline; they live in term 2.
+
+        The estimator is over-estimate-safe: a dense model or an
+        unknown/stub config that exposes no ``layer_types`` /
+        ``num_kv_shared_layers`` yields a BYTE-IDENTICAL uniform result
+        (per-token unchanged, sliding + baseline both 0), so only
+        recognized hybrids get the smaller, accurate number and the
+        D-METAL-CAP OOM cliff is never re-introduced.
 
         Returns ``0`` only when the model config is missing entirely
         (e.g. unit-test ``MagicMock`` model) so back-compat unit

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -3427,17 +3427,32 @@ class Scheduler:
                     # recognized hybrid (sliding-window / KV-sharing /
                     # recurrent layers) reduces the per-token growth and moves
                     # the window + recurrent-state footprint into the
-                    # per-sequence fixed baseline.
-                    estimate = estimate_kv_footprint(
-                        model_config,
-                        dtype_bytes=dtype_bytes,
-                        uniform_per_token_bytes=per_tok,
-                        base_num_layers=num_layers,
-                        base_kv_heads=num_kv_heads,
-                        base_head_dim=head_dim,
-                    )
-                    per_tok = estimate.per_token_growth_bytes
-                    fixed_baseline = estimate.fixed_baseline_bytes
+                    # per-sequence fixed baseline. Wrapped in its OWN
+                    # try/except so a failure inspecting the newer hybrid
+                    # fields degrades to the SAFE uniform ``per_tok`` (zero
+                    # baseline) instead of the outer handler resetting to 0 —
+                    # which would disable admission accounting entirely (codex
+                    # round 3 BLOCKING #3).
+                    try:
+                        estimate = estimate_kv_footprint(
+                            model_config,
+                            dtype_bytes=dtype_bytes,
+                            uniform_per_token_bytes=per_tok,
+                            base_num_layers=num_layers,
+                            base_kv_heads=num_kv_heads,
+                            base_head_dim=head_dim,
+                        )
+                        per_tok = estimate.per_token_growth_bytes
+                        fixed_baseline = estimate.fixed_baseline_bytes
+                    except Exception as est_err:
+                        logger.debug(
+                            "[D-METAL-CAP] architecture-aware KV estimate "
+                            "failed (%s); keeping the uniform per-token "
+                            "estimate with no fixed baseline",
+                            est_err,
+                        )
+                        # ``per_tok`` already holds the uniform value; keep it.
+                        fixed_baseline = 0
         except Exception as e:
             logger.debug(
                 "[D-METAL-CAP] failed to auto-derive kv_bytes_per_token "


### PR DESCRIPTION
## Why

`scheduler._resolve_kv_bytes_per_token` auto-derives the per-token KV-cache byte figure that feeds the D-METAL-CAP admission gate (`_estimate_request_kv_bytes` -> projection reject). It used a UNIFORM formula:

    per_tok = 2 * num_hidden_layers * num_key_value_heads * head_dim * dtype_bytes

which counts **every** layer as a full-growth attention layer. That is wrong for the hybrid architectures we ship:

- **Sliding-window layers** (GPT-OSS ~50% sliding; Gemma-4 local) have window-bounded KV — they do NOT grow per token.
- **KV-sharing borrower layers** (Gemma-4 / Gemma-3n `num_kv_shared_layers`) allocate ZERO KV (they reuse an earlier layer's).
- **Recurrent / linear-attention layers** (Qwen3.5 GatedDeltaNet, Mamba) carry a fixed state — zero per-token growth.
- **Hybrid dims**: full-attention layers may use a wider `global_head_dim` / `num_global_key_value_heads` than the sliding layers.

Net effect: we OVER-count per-token KV by up to ~2x for Gemma-4 / GPT-OSS / Qwen3.5. Because this figure drives the admission projection, on memory-constrained Macs we **spuriously reject** requests that would actually fit, or under-utilize RAM. This PR makes the estimate architecture-aware so we get **fewer spurious rejections without ever re-introducing the D-METAL-CAP OOM cliff**.

## What

- New pure-function module `vllm_mlx/kv_estimation.py` (`estimate_kv_footprint`) classifies each layer and returns BOTH:
  - `per_token_growth_bytes` = `2 * dtype_bytes * Σ (kv_heads_L * head_dim_L)` over ONLY the full-attention (per-token-growing) layers, honoring global dims when hybrid.
  - `fixed_baseline_bytes` = window term for sliding layers + a conservative fixed recurrent-state term. Allocated once per sequence, not per token.
  - Borrower (KV-sharing) layers contribute 0 to both.
- `_resolve_kv_bytes_per_token` routes the uniform figure through the estimator; new `_resolve_kv_fixed_baseline_bytes` exposes the baseline. `_estimate_request_kv_bytes` now charges `fixed_baseline + tokens * per_token_growth` (`_sum_in_flight_kv_bytes` gate updated to match).
- Reuses existing layer-structure reading conventions (`layer_types`, `sliding_window`, `num_kv_shared_layers`, `global_head_dim`, `num_global_key_value_heads`, recurrent `linear/mamba/...` markers) — matches `api/utils.mllm_backbone_is_hybrid`, `kv_cache_dtype`, and `models/gemma4_vendored/config.py`. No new field names invented.

## Safety (over-estimate-safe, zero regression)

1. **Byte-identical fallback.** Dense models (Llama/Qwen dense) and unknown/stub configs — anything without a per-layer `layer_types` list of the right length or a valid `num_kv_shared_layers` — return the exact current uniform value (`per_token` unchanged, `baseline` 0). Only recognized hybrids get the smaller number. A Mistral-like config with a bare `sliding_window` but no `layer_types` stays uniform (not treated as all-sliding).
2. Operator override (`metal_cap_kv_bytes_per_token`) still wins; the `isinstance(..., int)` MagicMock guard still yields 0 (no phantom baseline); `_infer_kv_dtype_bytes` fp32 fallback preserved.
3. **Never under-counts** the counted layers: sliding layers charge their whole window (upper bound for any token count); a sliding layer with no readable window and any unrecognized layer type are charged as full-growth. So `fixed_baseline + tokens * growth` is always >= the true architecture-aware footprint of the counted layers.

## Tests (hermetic, no network / model download)

- `tests/test_kv_estimation.py` (new, 17): dense byte-identical; Gemma-4 KV-sharing reduces by exactly the shared layers; GPT-OSS ~50% sliding halves growth + window baseline; Qwen3.5 recurrent layers zero growth; missing/partial/wrong-length/non-string `layer_types` -> uniform; global-head-dim honored; `text_config` nesting + dict configs; unknown layer type -> full; a never-under-count property over a range of token counts.
- `tests/test_metal_cap_enforcement.py` (7 added): scheduler wire-through — dense stays uniform w/ 0 baseline; GPT-OSS reduces per-token + sets baseline; Gemma-4 sharing; operator override wins + zero baseline; MagicMock -> 0; `_estimate_request_kv_bytes` charges baseline+growth; a hybrid ADMITTED where the uniform over-count would reject.

Scope: estimator + wiring + tests only. No pyproject version bump. Does not touch `spec_decode/` / `speculative/`, and deliberately leaves the first-run `_check_memory_capacity` (cli.py) wiring as a separate follow-on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)