### PR TITLE
fix(mllm): accept mlx-vlm native KV caches

### DIFF
--- a/tests/test_mllm_hybrid_probe.py
+++ b/tests/test_mllm_hybrid_probe.py
@@ -11,11 +11,14 @@ The user-facing contract:
 
 from __future__ import annotations
 
+import builtins
 from unittest.mock import MagicMock
 
+import pytest
 from mlx_lm.models.cache import KVCache, RotatingKVCache
 
 from vllm_mlx.engine.batched import _probe_mllm_cache_type
+from vllm_mlx.mllm_cache_compat import first_incompatible_mllm_cache_type
 
 
 class _FakeArraysCache:
@@ -56,12 +59,51 @@ def test_probe_returns_none_for_rotating_kvcache():
     assert _probe_mllm_cache_type(model) is None
 
 
+@pytest.mark.parametrize("cache_name", ["KVCache", "RotatingKVCache"])
+def test_probe_accepts_mlx_vlm_native_cache_classes(monkeypatch, cache_name):
+    """mlx-vlm 0.6.4+ owns cache classes distinct from mlx-lm's classes.
+
+    The MLLM model returns those native caches from ``make_cache()``.  They
+    have the batching API Rapid-MLX needs, so rejecting them solely because
+    an ``isinstance`` check names mlx-lm's parallel class crashes every
+    affected VLM during startup (rapid-desktop #603).
+    """
+    from mlx_vlm.models import cache as vlm_cache
+
+    native_cache_class = type(cache_name, (), {})
+    monkeypatch.setattr(vlm_cache, cache_name, native_cache_class)
+
+    model = _model_with_cache(native_cache_class())
+    assert _probe_mllm_cache_type(model) is None
+
+
 def test_probe_returns_class_name_for_arrayscache():
     """Hybrid models (Qwen3.5/3.6/Nemotron) produce ArraysCache; probe
     must return the offending type name so the caller can quote it in
     the startup error."""
     model = _model_with_cache(_FakeArraysCache())
     assert _probe_mllm_cache_type(model) == "ArraysCache"
+
+
+def test_compatibility_check_inspects_every_cache_layer():
+    """A mixed backbone may put a supported KV layer before ArraysCache."""
+    assert (
+        first_incompatible_mllm_cache_type([KVCache(), _FakeArraysCache()])
+        == "ArraysCache"
+    )
+
+
+def test_compatibility_check_without_optional_mlx_vlm(monkeypatch):
+    """Text-only installs have mlx-lm but intentionally omit mlx-vlm."""
+    original_import = builtins.__import__
+
+    def import_without_mlx_vlm(name, *args, **kwargs):
+        if name == "mlx_vlm.models.cache":
+            raise ImportError("mlx-vlm is not installed")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", import_without_mlx_vlm)
+    assert first_incompatible_mllm_cache_type([KVCache()]) is None
 
 
 def test_probe_returns_none_when_make_prompt_cache_raises():

--- a/tests/test_mllm_hybrid_probe.py
+++ b/tests/test_mllm_hybrid_probe.py
@@ -96,14 +96,18 @@ def test_compatibility_check_inspects_every_cache_layer():
 def test_compatibility_check_without_optional_mlx_vlm(monkeypatch):
     """Text-only installs have mlx-lm but intentionally omit mlx-vlm."""
     original_import = builtins.__import__
+    blocked = False
 
-    def import_without_mlx_vlm(name, *args, **kwargs):
-        if name == "mlx_vlm.models.cache":
+    def import_without_mlx_vlm(name, globals=None, locals=None, fromlist=(), level=0):
+        nonlocal blocked
+        if name == "mlx_vlm.models" and "cache" in fromlist:
+            blocked = True
             raise ImportError("mlx-vlm is not installed")
-        return original_import(name, *args, **kwargs)
+        return original_import(name, globals, locals, fromlist, level)
 
     monkeypatch.setattr(builtins, "__import__", import_without_mlx_vlm)
     assert first_incompatible_mllm_cache_type([KVCache()]) is None
+    assert blocked is True
 
 
 def test_probe_returns_none_when_make_prompt_cache_raises():

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -536,7 +536,9 @@ def _probe_mllm_cache_type(language_model: Any) -> str | None:
     we return None and let the runtime path surface the real error instead
     of masking it with a misleading hybrid-incompat message.
     """
-    from mlx_lm.models.cache import KVCache, RotatingKVCache, make_prompt_cache
+    from mlx_lm.models.cache import make_prompt_cache
+
+    from ..mllm_cache_compat import first_incompatible_mllm_cache_type
 
     try:
         test_cache = make_prompt_cache(language_model)
@@ -544,10 +546,7 @@ def _probe_mllm_cache_type(language_model: Any) -> str | None:
         return None
     if not test_cache:
         return None
-    sample = test_cache[0]
-    if isinstance(sample, (KVCache, RotatingKVCache)):
-        return None
-    return type(sample).__name__
+    return first_incompatible_mllm_cache_type(test_cache)
 
 
 _CHANNEL_TO_STRING = {

--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -36,6 +36,7 @@ _mlx_compat.install()
 
 from mlx_lm.sample_utils import make_logits_processors, make_sampler  # noqa: E402
 
+from .mllm_cache_compat import first_incompatible_mllm_cache_type  # noqa: E402
 from .multimodal_processor import MultimodalProcessor  # noqa: E402
 from .vision_embedding_cache import VisionEmbeddingCache  # noqa: E402
 
@@ -1093,10 +1094,10 @@ class MLLMBatchGenerator:
         # KVCache.merge() creates a BatchKVCache with proper left-padding
         # alignment, so all requests share a single batched cache for
         # subsequent generation steps.
-        from mlx_lm.models.cache import KVCache, RotatingKVCache
-
-        sample_cache = per_request_caches[0][0]
-        if not isinstance(sample_cache, (KVCache, RotatingKVCache)):
+        incompatible_cache_type = first_incompatible_mllm_cache_type(
+            per_request_caches[0]
+        )
+        if incompatible_cache_type is not None:
             # Two distinct causes land here:
             #   1. Hybrid/linear-attention backbone (ArraysCache /
             #      MambaCache) — see GitHub #352. Should be caught at
@@ -1107,7 +1108,7 @@ class MLLMBatchGenerator:
             # quantization is NOT the cause.
             raise ValueError(
                 f"MLLM continuous batching requires KVCache or RotatingKVCache "
-                f"but got {type(sample_cache).__name__}. Either the language "
+                f"but got {incompatible_cache_type}. Either the language "
                 f"backbone is hybrid/linear-attention (drop --mllm or pick a "
                 f"non-hybrid VLM), or --kv-cache-quantization was enabled "
                 f"(disable it for multimodal models with continuous batching)."

--- a/vllm_mlx/mllm_cache_compat.py
+++ b/vllm_mlx/mllm_cache_compat.py
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Cache compatibility helpers for MLLM continuous batching."""
+
+from collections.abc import Iterable
+from typing import Any
+
+
+def first_incompatible_mllm_cache_type(caches: Iterable[Any]) -> str | None:
+    """Return the first cache type that MLLM batching cannot merge.
+
+    mlx-vlm 0.6.4 split its cache classes from mlx-lm's parallel classes.
+    Models loaded by mlx-vlm therefore return native ``KVCache`` /
+    ``RotatingKVCache`` instances that fail an mlx-lm-only ``isinstance``
+    check despite exposing the supported batching API. Accept both namespaces
+    while continuing to reject ArraysCache, MambaCache, and quantized caches.
+    """
+    from mlx_lm.models.cache import KVCache, RotatingKVCache
+
+    supported_types: tuple[type, ...] = (KVCache, RotatingKVCache)
+    try:
+        from mlx_vlm.models import cache as vlm_cache
+    except ImportError:
+        # mlx-vlm is optional. Text-only installations still import the engine,
+        # although they never enter the MLLM serving path.
+        pass
+    else:
+        supported_types += (vlm_cache.KVCache, vlm_cache.RotatingKVCache)
+
+    for cache in caches:
+        if not isinstance(cache, supported_types):
+            return type(cache).__name__
+    return None


### PR DESCRIPTION
## What changed

- accept both `mlx-lm` and `mlx-vlm` native `KVCache` / `RotatingKVCache` classes in MLLM continuous batching
- share the same compatibility check between the startup probe and request-time cache merge
- inspect every cache layer while continuing to reject `ArraysCache`, Mamba/recurrent, and quantized cache types
- add regression coverage for split cache namespaces and text-only installs without mlx-vlm

## Why

Default Gemma-4 A4B serving crashed before the server became ready because mlx-vlm-native caches were rejected solely by Python class identity. Accepting both upstream namespaces is the narrowest correct fix: it preserves working vision inference without misclassifying Gemma 4 as hybrid or silently downgrading users to text-only mode.

## Root cause

mlx-vlm 0.6.4 owns cache classes that are distinct from the parallel mlx-lm classes. Gemma 4 loaded through mlx-vlm therefore returned `mlx_vlm.models.cache.RotatingKVCache`, but Rapid-MLX checked it with `isinstance(..., mlx_lm.models.cache.RotatingKVCache)`. Default `serve` then failed startup with the contradictory error that RotatingKVCache was incompatible while RotatingKVCache was required.

This is the engine-side fix for [rapid-desktop #603](https://github.com/machinefi/rapid-desktop/issues/603). It deliberately does not mark Gemma 4 as hybrid and does not silently downgrade a working vision model to text-only.

## User impact

`rapid-mlx serve gemma-4-26b-4bit` now starts normally in auto/default MLLM mode instead of exiting. Gemma 4 retains image support; `--no-mllm` remains available for explicit text-only serving.

## Validation

- reproduced the startup crash with a clean main wheel, mlx-vlm 0.6.4, and the real 15 GB Gemma-4 26B A4B checkpoint
- clean fixed wheel with the same dependency/model:
  - default MLLM startup reached ready
  - text request returned `default mllm text works`
  - real image request identified the Rapid-MLX logo as `Cheetah`
  - two concurrent image requests both completed correctly in the same batch cycle
  - explicit `--no-mllm` text lane returned `gemma text lane works`
- new helper: 100% line coverage
- focused regression: 199 passed
- full unit suite: 14,189 passed, 79 skipped, 17 deselected, 6 xfailed, 1 xpassed
- pr_validate stress matrix: Qwen3.5, Qwen3.6, DiffusionGemma, and GPT-OSS Harmony all passed
- Ruff check/format and `git diff --check` passed