### PR TITLE
ci: Tier-1 agent gate on self-hosted Apple Silicon (Phase 1, manual)

### DIFF
--- a/.github/workflows/agent-gate.yml
+++ b/.github/workflows/agent-gate.yml
@@ -36,7 +36,11 @@ concurrency:
 jobs:
   tier1-smoke:
     runs-on: [self-hosted, macOS, rapidmlx-studio]
-    timeout-minutes: 40
+    # Headroom above the script's own worst case (~42 min if every agent hits
+    # every per-command timeout) so the smoke exits on its own, prints its
+    # summary, and runs cleanup — instead of GitHub cancelling mid-run. A
+    # passing run finishes in ~5-8 min; the tail only matters on regressions.
+    timeout-minutes: 55
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
       - name: Tier-1 agent re-verification

--- a/.github/workflows/agent-gate.yml
+++ b/.github/workflows/agent-gate.yml
@@ -1,0 +1,50 @@
+name: Tier-1 agent gate
+
+# Re-verifies the four Tier-1 (flagship) agents — Claude Code, Codex, Hermes,
+# Aider — end-to-end against a real local model on Apple Silicon. This is the
+# one release check GitHub-hosted runners structurally cannot do (no Metal, no
+# weights, no agent binaries), so it runs on a self-hosted Apple-Silicon runner
+# (the Studio). Mirrors how Apple's own MLX gates its Metal tests on
+# `[self-hosted, macos]`.
+#
+# Phase 1: manual (`workflow_dispatch`) only, so we can prove the runner + smoke
+# work before wiring it into the release path. Phase 2 will add this as a
+# `needs:` gate in auto-release.yml so a version bump cannot tag/publish unless
+# it passes.
+#
+# SECURITY: this targets a self-hosted runner, so it must NEVER be triggered by
+# `pull_request` (fork code must not touch self-hosted hardware). Keep the
+# triggers to `workflow_dispatch` and, later, `push`/release on the trusted
+# main branch only.
+
+on:
+  workflow_dispatch:
+    inputs:
+      model:
+        description: "Model alias to verify against (>=8-bit; never 4-bit)"
+        default: "qwen3.6-35b-8bit"
+
+permissions:
+  contents: read
+
+concurrency:
+  # One agent-gate run at a time — it boots a large model and drives real
+  # agents; overlapping runs would contend for the Studio's RAM and port 8000.
+  group: tier1-agent-gate
+  cancel-in-progress: false
+
+jobs:
+  tier1-smoke:
+    runs-on: [self-hosted, macOS, rapidmlx-studio]
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - name: Tier-1 agent re-verification
+        env:
+          # The isolated audit venv on the Studio (python@3.12, pinned rapid-mlx).
+          # Phase 2 will (re)create this at the release version before the gate.
+          RAPID_MLX_VENV: /Users/raullenstudio/rapid-mlx-audit-venv
+          # Untrusted-ish input passed via env, never interpolated into the
+          # script line (matches the repo's auto-release.yml convention).
+          MODEL: ${{ inputs.model }}
+        run: bash tests/integrations/agent_smoke.sh "$MODEL"

--- a/tests/integrations/agent_smoke.sh
+++ b/tests/integrations/agent_smoke.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 # Layer-B Tier-1 agent re-verification smoke.
 #
-# Run ON the Studio (real Apple Silicon + models + agent binaries). GitHub CI
-# cannot do this — it has no Metal, no weights, and release-preflight skips
-# every gate that needs a live `rapid-mlx serve`.
+# Run ON the Studio (real Apple Silicon + models + agent binaries), directly or
+# from the self-hosted `agent-gate.yml` job. GitHub-hosted runners cannot do
+# this — no Metal, no weights, and release-preflight skips every gate that needs
+# a live `rapid-mlx serve`.
 #
 # Boots `rapid-mlx serve`, then drives the FOUR Tier-1 (flagship) agents —
 # Claude Code, Codex, Hermes, Aider — through a real multi-step bug-fix task
@@ -14,11 +15,12 @@
 #            which confounds "weak model" with "broken integration")
 #
 # Exit code: 0 iff all four Tier-1 agents PASS. Non-zero blocks the release.
-# It is non-destructive: it backs up ~/.codex and ~/.hermes config and restores
-# them on exit (the Studio is a shared, in-use machine).
+# Non-destructive on the shared Studio: it starts only its own server (and kills
+# only that one), and backs up / restores (or removes) ~/.codex and ~/.hermes
+# config it touches.
 set -uo pipefail
 
-export PATH="/opt/homebrew/bin:$HOME/.local/bin:$PATH"
+export PATH="/opt/homebrew/bin:/opt/homebrew/opt/coreutils/libexec/gnubin:$HOME/.local/bin:$PATH"
 VENV="${RAPID_MLX_VENV:-$HOME/rapid-mlx-audit-venv}"
 RMLX="$VENV/bin/rapid-mlx"
 ALIAS="${1:-qwen3.6-35b-8bit}"
@@ -26,14 +28,47 @@ PORT="${RAPID_MLX_PORT:-8000}"
 B="http://localhost:$PORT"
 WORK="$HOME/agent-smoke-work"
 LOG="$HOME/agent-smoke-serve.log"
+SERVE_PID=""
 
 CODEX_CFG="$HOME/.codex/config.toml"
 HERMES_CFG="$HOME/.hermes/config.yaml"
 
+# Portable timeout: coreutils `timeout`, or `gtimeout`, else a bash fallback
+# (background the command, hard-kill after N seconds). macOS ships neither
+# `timeout` nor `gtimeout` by default, so never assume one is on PATH.
+if command -v timeout >/dev/null 2>&1; then
+  TO() { timeout "$@"; }
+elif command -v gtimeout >/dev/null 2>&1; then
+  TO() { gtimeout "$@"; }
+else
+  TO() {
+    local secs="$1"; shift
+    ( "$@" ) & local cmd_pid=$!
+    ( sleep "$secs"; kill -9 "$cmd_pid" 2>/dev/null ) & local killer=$!
+    wait "$cmd_pid" 2>/dev/null; local rc=$?
+    kill "$killer" 2>/dev/null; wait "$killer" 2>/dev/null
+    return $rc
+  }
+fi
+
+# Restore a config we may have overwritten with `--setup`: if we backed up a
+# pre-existing file, put it back; if the file did not exist before, remove the
+# one `--setup` created (and its marker). Idempotent — safe to call twice.
+restore_cfg() {
+  if [ -f "$1.smokebak" ]; then
+    mv -f "$1.smokebak" "$1"
+  elif [ -f "$1.created" ]; then
+    rm -f "$1" "$1.created"
+  fi
+}
+save_cfg() {
+  if [ -f "$1" ]; then cp "$1" "$1.smokebak"; else touch "$1.created"; fi
+}
+
 cleanup() {
-  pkill -9 -f "$VENV/bin/rapid-mlx serve" 2>/dev/null
-  [ -f "$CODEX_CFG.smokebak" ]  && mv -f "$CODEX_CFG.smokebak"  "$CODEX_CFG"  2>/dev/null
-  [ -f "$HERMES_CFG.smokebak" ] && mv -f "$HERMES_CFG.smokebak" "$HERMES_CFG" 2>/dev/null
+  [ -n "$SERVE_PID" ] && kill -9 "$SERVE_PID" 2>/dev/null
+  restore_cfg "$CODEX_CFG"
+  restore_cfg "$HERMES_CFG"
   rm -rf "$WORK" "$LOG"
 }
 trap cleanup EXIT
@@ -47,13 +82,17 @@ for b in claude codex aider hermes; do
   command -v "$b" >/dev/null 2>&1 && printf "  %-9s  %s\n" "$b" "$($b --version 2>&1 | head -1)" \
                                   || printf "  %-9s  MISSING\n" "$b"
 done
-echo "== model: $ALIAS =="
+echo "== model: $ALIAS  port: $PORT =="
 
-# ---- boot serve ----------------------------------------------------------
-pkill -f "$VENV/bin/rapid-mlx serve" 2>/dev/null; sleep 2
+# ---- boot serve (never kill a server we did not start) -------------------
+if curl -s -m 3 "$B/v1/models" >/dev/null 2>&1; then
+  fail "port $PORT already serving — free it (a stray server is not ours to kill)"
+fi
 nohup "$RMLX" serve "$ALIAS" --port "$PORT" > "$LOG" 2>&1 &
+SERVE_PID=$!
 for i in $(seq 1 48); do
   curl -s -m 3 "$B/v1/models" 2>/dev/null | grep -q '"id"' && { echo "serve READY (~$((i*5))s)"; break; }
+  kill -0 "$SERVE_PID" 2>/dev/null || { tail -20 "$LOG"; fail "serve process died during boot"; }
   sleep 5
   [ "$i" = 48 ] && { tail -20 "$LOG"; fail "serve not ready in 240s"; }
 done
@@ -69,8 +108,8 @@ seed_repo() {
 # PASS iff the test now exits 0 (agent fixed the bug and it verifies)
 verify() { cd "$WORK/$1" 2>/dev/null && python3 test_calc.py >/dev/null 2>&1 && echo PASS || echo FAIL; }
 
-# Plain phrasing (no backticks / em-dash — keep the prompt boring so the
-# check measures the integration, not prompt parsing).
+# Plain phrasing (no backticks / em-dash — keep the prompt boring so the check
+# measures the integration, not prompt parsing).
 TASK='Run python3 test_calc.py, it fails. Fix the bug in calc.py so all assertions pass, then re-run to confirm. Only edit calc.py.'
 
 # The agents (codex especially) are non-deterministic, so give each up to 2
@@ -80,40 +119,40 @@ TASK='Run python3 test_calc.py, it fails. Fix the bug in calc.py so all assertio
 R_CLAUDE=FAIL
 for _try in 1 2; do
   seed_repo claude
-  ANTHROPIC_BASE_URL="$B" ANTHROPIC_API_KEY=not-needed \
-    timeout 260 claude -p "$TASK" --model "$ALIAS" --dangerously-skip-permissions >/dev/null 2>&1
+  TO 260 env ANTHROPIC_BASE_URL="$B" ANTHROPIC_API_KEY=not-needed \
+    claude -p "$TASK" --model "$ALIAS" --dangerously-skip-permissions >/dev/null 2>&1
   [ "$(verify claude)" = PASS ] && { R_CLAUDE=PASS; break; }
 done
 
 # ---- Codex (agents codex --setup writes ~/.codex/config.toml) ------------
-[ -f "$CODEX_CFG" ] && cp "$CODEX_CFG" "$CODEX_CFG.smokebak"
+save_cfg "$CODEX_CFG"
 "$RMLX" agents codex --setup >/dev/null 2>&1
 R_CODEX=FAIL
 for _try in 1 2; do
   seed_repo codex
-  timeout 260 codex exec "$TASK" --model "$ALIAS" \
+  TO 260 codex exec "$TASK" --model "$ALIAS" \
     --dangerously-bypass-approvals-and-sandbox --skip-git-repo-check >/dev/null 2>&1
   [ "$(verify codex)" = PASS ] && { R_CODEX=PASS; break; }
 done
-[ -f "$CODEX_CFG.smokebak" ] && mv -f "$CODEX_CFG.smokebak" "$CODEX_CFG"
+restore_cfg "$CODEX_CFG"
 
 # ---- Hermes (agents hermes --setup; auto-writes context_length >= 64K) ----
-[ -f "$HERMES_CFG" ] && cp "$HERMES_CFG" "$HERMES_CFG.smokebak"
+save_cfg "$HERMES_CFG"
 "$RMLX" agents hermes --setup >/dev/null 2>&1
 R_HERMES=FAIL
 for _try in 1 2; do
   seed_repo hermes
-  timeout 300 hermes chat -q "$TASK" -Q -m "$ALIAS" >/dev/null 2>&1
+  TO 300 hermes chat -q "$TASK" -Q -m "$ALIAS" >/dev/null 2>&1
   [ "$(verify hermes)" = PASS ] && { R_HERMES=PASS; break; }
 done
-[ -f "$HERMES_CFG.smokebak" ] && mv -f "$HERMES_CFG.smokebak" "$HERMES_CFG"
+restore_cfg "$HERMES_CFG"
 
 # ---- Aider (env vars, LiteLLM openai/ prefix) ----------------------------
 R_AIDER=FAIL
 for _try in 1 2; do
   seed_repo aider
-  OPENAI_API_BASE="$B/v1" OPENAI_API_KEY=not-needed \
-    timeout 260 aider --model "openai/$ALIAS" --message "$TASK" \
+  TO 260 env OPENAI_API_BASE="$B/v1" OPENAI_API_KEY=not-needed \
+    aider --model "openai/$ALIAS" --message "$TASK" \
     --yes-always --no-auto-commits --no-show-model-warnings calc.py >/dev/null 2>&1
   [ "$(verify aider)" = PASS ] && { R_AIDER=PASS; break; }
 done

--- a/tests/integrations/agent_smoke.sh
+++ b/tests/integrations/agent_smoke.sh
@@ -1,0 +1,132 @@
+#!/bin/bash
+# Layer-B Tier-1 agent re-verification smoke.
+#
+# Run ON the Studio (real Apple Silicon + models + agent binaries). GitHub CI
+# cannot do this — it has no Metal, no weights, and release-preflight skips
+# every gate that needs a live `rapid-mlx serve`.
+#
+# Boots `rapid-mlx serve`, then drives the FOUR Tier-1 (flagship) agents —
+# Claude Code, Codex, Hermes, Aider — through a real multi-step bug-fix task
+# against the local model, and asserts each one actually made the test pass.
+#
+#   Usage:   RAPID_MLX_VENV=~/rapid-mlx-audit-venv ./agent_smoke.sh [model-alias]
+#   Default: model-alias = qwen3.6-35b-8bit   (strong 8-bit — never 4-bit,
+#            which confounds "weak model" with "broken integration")
+#
+# Exit code: 0 iff all four Tier-1 agents PASS. Non-zero blocks the release.
+# It is non-destructive: it backs up ~/.codex and ~/.hermes config and restores
+# them on exit (the Studio is a shared, in-use machine).
+set -uo pipefail
+
+export PATH="/opt/homebrew/bin:$HOME/.local/bin:$PATH"
+VENV="${RAPID_MLX_VENV:-$HOME/rapid-mlx-audit-venv}"
+RMLX="$VENV/bin/rapid-mlx"
+ALIAS="${1:-qwen3.6-35b-8bit}"
+PORT="${RAPID_MLX_PORT:-8000}"
+B="http://localhost:$PORT"
+WORK="$HOME/agent-smoke-work"
+LOG="$HOME/agent-smoke-serve.log"
+
+CODEX_CFG="$HOME/.codex/config.toml"
+HERMES_CFG="$HOME/.hermes/config.yaml"
+
+cleanup() {
+  pkill -9 -f "$VENV/bin/rapid-mlx serve" 2>/dev/null
+  [ -f "$CODEX_CFG.smokebak" ]  && mv -f "$CODEX_CFG.smokebak"  "$CODEX_CFG"  2>/dev/null
+  [ -f "$HERMES_CFG.smokebak" ] && mv -f "$HERMES_CFG.smokebak" "$HERMES_CFG" 2>/dev/null
+  rm -rf "$WORK" "$LOG"
+}
+trap cleanup EXIT
+
+fail() { echo "SMOKE-ABORT: $*" >&2; exit 3; }
+[ -x "$RMLX" ] || fail "no rapid-mlx at $RMLX (set RAPID_MLX_VENV)"
+
+echo "== versions =="
+printf "  rapid-mlx  %s\n" "$($RMLX --version 2>&1 | head -1)"
+for b in claude codex aider hermes; do
+  command -v "$b" >/dev/null 2>&1 && printf "  %-9s  %s\n" "$b" "$($b --version 2>&1 | head -1)" \
+                                  || printf "  %-9s  MISSING\n" "$b"
+done
+echo "== model: $ALIAS =="
+
+# ---- boot serve ----------------------------------------------------------
+pkill -f "$VENV/bin/rapid-mlx serve" 2>/dev/null; sleep 2
+nohup "$RMLX" serve "$ALIAS" --port "$PORT" > "$LOG" 2>&1 &
+for i in $(seq 1 48); do
+  curl -s -m 3 "$B/v1/models" 2>/dev/null | grep -q '"id"' && { echo "serve READY (~$((i*5))s)"; break; }
+  sleep 5
+  [ "$i" = 48 ] && { tail -20 "$LOG"; fail "serve not ready in 240s"; }
+done
+
+# ---- the task: a buggy factorial + a failing test the agent must fix -----
+seed_repo() {
+  local d="$WORK/$1"; rm -rf "$d"; mkdir -p "$d"; cd "$d" || return 1
+  git init -q; git config user.email a@b.c; git config user.name smoke
+  printf 'def factorial(n):\n    result = 1\n    for i in range(1, n):   # off-by-one bug\n        result *= i\n    return result\n' > calc.py
+  printf 'from calc import factorial\nassert factorial(5) == 120, factorial(5)\nassert factorial(6) == 720\nassert factorial(0) == 1\nprint("ALL PASS")\n' > test_calc.py
+  git add -A; git commit -qm seed
+}
+# PASS iff the test now exits 0 (agent fixed the bug and it verifies)
+verify() { cd "$WORK/$1" 2>/dev/null && python3 test_calc.py >/dev/null 2>&1 && echo PASS || echo FAIL; }
+
+# Plain phrasing (no backticks / em-dash — keep the prompt boring so the
+# check measures the integration, not prompt parsing).
+TASK='Run python3 test_calc.py, it fails. Fix the bug in calc.py so all assertions pass, then re-run to confirm. Only edit calc.py.'
+
+# The agents (codex especially) are non-deterministic, so give each up to 2
+# attempts — a single miss must not flap the release gate.
+
+# ---- Claude Code (env var, /v1/messages) ---------------------------------
+R_CLAUDE=FAIL
+for _try in 1 2; do
+  seed_repo claude
+  ANTHROPIC_BASE_URL="$B" ANTHROPIC_API_KEY=not-needed \
+    timeout 260 claude -p "$TASK" --model "$ALIAS" --dangerously-skip-permissions >/dev/null 2>&1
+  [ "$(verify claude)" = PASS ] && { R_CLAUDE=PASS; break; }
+done
+
+# ---- Codex (agents codex --setup writes ~/.codex/config.toml) ------------
+[ -f "$CODEX_CFG" ] && cp "$CODEX_CFG" "$CODEX_CFG.smokebak"
+"$RMLX" agents codex --setup >/dev/null 2>&1
+R_CODEX=FAIL
+for _try in 1 2; do
+  seed_repo codex
+  timeout 260 codex exec "$TASK" --model "$ALIAS" \
+    --dangerously-bypass-approvals-and-sandbox --skip-git-repo-check >/dev/null 2>&1
+  [ "$(verify codex)" = PASS ] && { R_CODEX=PASS; break; }
+done
+[ -f "$CODEX_CFG.smokebak" ] && mv -f "$CODEX_CFG.smokebak" "$CODEX_CFG"
+
+# ---- Hermes (agents hermes --setup; auto-writes context_length >= 64K) ----
+[ -f "$HERMES_CFG" ] && cp "$HERMES_CFG" "$HERMES_CFG.smokebak"
+"$RMLX" agents hermes --setup >/dev/null 2>&1
+R_HERMES=FAIL
+for _try in 1 2; do
+  seed_repo hermes
+  timeout 300 hermes chat -q "$TASK" -Q -m "$ALIAS" >/dev/null 2>&1
+  [ "$(verify hermes)" = PASS ] && { R_HERMES=PASS; break; }
+done
+[ -f "$HERMES_CFG.smokebak" ] && mv -f "$HERMES_CFG.smokebak" "$HERMES_CFG"
+
+# ---- Aider (env vars, LiteLLM openai/ prefix) ----------------------------
+R_AIDER=FAIL
+for _try in 1 2; do
+  seed_repo aider
+  OPENAI_API_BASE="$B/v1" OPENAI_API_KEY=not-needed \
+    timeout 260 aider --model "openai/$ALIAS" --message "$TASK" \
+    --yes-always --no-auto-commits --no-show-model-warnings calc.py >/dev/null 2>&1
+  [ "$(verify aider)" = PASS ] && { R_AIDER=PASS; break; }
+done
+
+# ---- report --------------------------------------------------------------
+echo
+echo "== Tier-1 re-verification ($ALIAS) =="
+printf "  claude-code  %s\n" "$R_CLAUDE"
+printf "  codex-cli    %s\n" "$R_CODEX"
+printf "  hermes       %s\n" "$R_HERMES"
+printf "  aider        %s\n" "$R_AIDER"
+
+for r in "$R_CLAUDE" "$R_CODEX" "$R_HERMES" "$R_AIDER"; do
+  [ "$r" = PASS ] || { echo "RESULT: FAIL — a Tier-1 agent regressed; this blocks the release."; exit 1; }
+done
+echo "RESULT: PASS — all four Tier-1 agents verified on $ALIAS."

--- a/tests/integrations/agent_smoke.sh
+++ b/tests/integrations/agent_smoke.sh
@@ -62,8 +62,11 @@ restore_cfg() {
   fi
 }
 save_cfg() {
+  mkdir -p "$(dirname "$1")"   # marker (and later --setup) needs the dir to exist
   if [ -f "$1" ]; then cp "$1" "$1.smokebak"; else touch "$1.created"; fi
 }
+# `agents <x> --setup` hardcodes localhost:8000; repoint it at our actual port.
+patch_port() { [ -f "$1" ] && perl -pi -e "s#localhost:8000/v1#localhost:$PORT/v1#g" "$1"; }
 
 cleanup() {
   [ -n "$SERVE_PID" ] && kill -9 "$SERVE_PID" 2>/dev/null
@@ -127,6 +130,7 @@ done
 # ---- Codex (agents codex --setup writes ~/.codex/config.toml) ------------
 save_cfg "$CODEX_CFG"
 "$RMLX" agents codex --setup >/dev/null 2>&1
+patch_port "$CODEX_CFG"
 R_CODEX=FAIL
 for _try in 1 2; do
   seed_repo codex
@@ -139,6 +143,7 @@ restore_cfg "$CODEX_CFG"
 # ---- Hermes (agents hermes --setup; auto-writes context_length >= 64K) ----
 save_cfg "$HERMES_CFG"
 "$RMLX" agents hermes --setup >/dev/null 2>&1
+patch_port "$HERMES_CFG"
 R_HERMES=FAIL
 for _try in 1 2; do
   seed_repo hermes


### PR DESCRIPTION
## Why

The tier system promises the 4 Tier-1 agents are "re-verified end-to-end against the current client binary every release", but nothing enforced it — GitHub-hosted runners cannot boot Metal + real models + the agent binaries. Industry best practice (Apple MLX, vLLM, PyTorch) is a self-hosted runner on the special hardware, triggered only on trusted events, gating publish. This lands that, in two phases.

## What (Phase 1 — manual, does not touch the release path)

- `tests/integrations/agent_smoke.sh` — boots `rapid-mlx serve` on the Studio and drives Claude Code / Codex / Hermes / Aider through a real multi-step bug-fix (2 attempts each for non-determinism); non-zero exit if any regresses. Non-destructive.
- `.github/workflows/agent-gate.yml` — `workflow_dispatch`-only, `runs-on: [self-hosted, macOS, rapidmlx-studio]`. Lets us prove the runner + smoke go green before wiring the hard gate.

## Phase 2 (follow-up PR)

Split `auto-release.yml` into detect → tier1-gate (self-hosted) → release, with the tag/publish job `needs: [tier1-gate]` so a version bump can't publish unless the smoke passes. Mirrors MLX's `publish needs: test_wheel`.

## Security

Self-hosted job is dispatch-only; it must never run on `pull_request` (fork code must not touch self-hosted hardware). fork-PR workflow-approval was tightened to "all external contributors". Runner is repo-scoped, labeled `rapidmlx-studio`.

Verified locally: `agent_smoke.sh` passes 4/4 on qwen3.6-35b-8bit on the Studio; SHA-pin check + YAML lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)