### PR TITLE
fix(mcp): handle mcp 1.x→2.0 camelCase→snake_case model attr rename (Connectors 0 tools)

### DIFF
--- a/tests/test_chat_mcp.py
+++ b/tests/test_chat_mcp.py
@@ -24,15 +24,19 @@ from vllm_mlx.mcp.types import MCPServerConfig, MCPTransport
 
 
 class _FakeResult:
-    def __init__(self, name: str, arguments: dict):
+    def __init__(self, name: str, arguments: dict, *, snake_case: bool = False):
         self.name = name
         self.arguments = arguments
-        self.isError = bool(arguments.get("is_error"))
+        is_error = bool(arguments.get("is_error"))
+        if snake_case:
+            self.is_error = is_error
+        else:
+            self.isError = is_error
 
     def model_dump(self, **_kwargs):
         return {
             "content": [{"type": "text", "text": f"{self.name}:{self.arguments}"}],
-            "isError": self.isError,
+            "isError": bool(getattr(self, "is_error", getattr(self, "isError", False))),
         }
 
 
@@ -51,6 +55,7 @@ class _FakeSessionGroup:
     max_active_calls = 0
     active_calls_by_server: dict[str, int] = {}
     max_active_calls_by_server: dict[str, int] = {}
+    snake_case_fields = False
 
     def __init__(self, component_name_hook):
         self._name_hook = component_name_hook
@@ -89,10 +94,11 @@ class _FakeSessionGroup:
             if tool_name == "lookup"
             else {"type": "object"}
         )
+        schema_field = "input_schema" if self.snake_case_fields else "inputSchema"
         self.tools[full_name] = SimpleNamespace(
             name=tool_name,
             description=f"{label} tool",
-            inputSchema=schema,
+            **{schema_field: schema},
         )
 
     async def call_tool(self, name, arguments):
@@ -121,7 +127,11 @@ class _FakeSessionGroup:
                     self.call_cancelled.set()
             if arguments.get("raise"):
                 raise RuntimeError("tool exploded")
-            return _FakeResult(name, arguments)
+            return _FakeResult(
+                name,
+                arguments,
+                snake_case=self.snake_case_fields,
+            )
         finally:
             type(self).active_calls -= 1
             type(self).active_calls_by_server[server_name] -= 1
@@ -141,6 +151,7 @@ def _fake_sdk_group(monkeypatch):
     _FakeSessionGroup.max_active_calls = 0
     _FakeSessionGroup.active_calls_by_server = {}
     _FakeSessionGroup.max_active_calls_by_server = {}
+    _FakeSessionGroup.snake_case_fields = False
     monkeypatch.setattr(
         mcp.client.session_group,
         "ClientSessionGroup",
@@ -206,6 +217,34 @@ def test_runtime_uses_sdk_groups_for_multiple_servers(tmp_path):
     runtime.close()  # idempotent
     with pytest.raises(RuntimeError, match="closed"):
         runtime.execute_tool_calls([])
+
+
+def test_runtime_accepts_mcp2_snake_case_tool_models(tmp_path):
+    _FakeSessionGroup.snake_case_fields = True
+    path = _write_config(
+        tmp_path,
+        {"alpha": {"command": "python3", "args": ["alpha", "lookup"]}},
+    )
+    events: list[ChatToolEvent] = []
+    runtime = ChatMCPRuntime(str(path))
+    try:
+        assert runtime.tools[0]["function"]["parameters"]["required"] == ["value"]
+        runtime.execute_tool_calls(
+            [
+                {
+                    "id": "call-a",
+                    "function": {
+                        "name": "alpha__lookup",
+                        "arguments": '{"value":"A","is_error":true}',
+                    },
+                }
+            ],
+            on_event=events.append,
+        )
+    finally:
+        runtime.close()
+
+    assert events[-1].is_error is True
 
 
 def test_runtime_parallelizes_servers_but_serializes_each_server(tmp_path):

--- a/tests/test_mcp_client_mcp2_compat.py
+++ b/tests/test_mcp_client_mcp2_compat.py
@@ -1,0 +1,188 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for the mcp SDK camelCase→snake_case rename (rapid-desktop#604).
+
+mcp 1.x exposed model fields in camelCase (``protocolVersion``, ``inputSchema``,
+``isError``); mcp 2.0 renamed the Python attributes to snake_case. The dev/CI
+env resolves mcp 1.x, but a fresh sidecar build resolved ``mcp>=1.9.3`` to
+mcp 2.0 — so ``vllm_mlx/mcp/client.py`` reading camelCase raised
+``AttributeError`` mid-handshake and every configured MCP server reported
+**0 tools**. The pre-existing MCP tests all fake the SDK, so the skew slipped
+through.
+
+The first three tests are **version-independent**: they simulate mcp-2.0
+snake_case-only SDK objects directly, so they fail against the old camelCase
+code regardless of which mcp version is installed (i.e. they catch the bug on
+CI's mcp 1.x too). The last is a real end-to-end stdio round-trip against the
+actually-installed SDK.
+"""
+
+from __future__ import annotations
+
+import sys
+import textwrap
+from types import SimpleNamespace
+
+import pytest
+
+from vllm_mlx.mcp.client import MCPClient, _sdk_attr
+from vllm_mlx.mcp.types import MCPServerConfig, MCPTransport
+
+# --- helper compat shim -----------------------------------------------------
+
+
+def test_sdk_attr_prefers_snake_then_camel_then_default():
+    snake_only = SimpleNamespace(protocol_version="2025-11-25")  # mcp>=2.0 shape
+    camel_only = SimpleNamespace(protocolVersion="2024-11-05")  # mcp<2.0 shape
+    both = SimpleNamespace(protocol_version="new", protocolVersion="old")
+    neither = SimpleNamespace()
+
+    assert _sdk_attr(snake_only, "protocol_version", "protocolVersion") == "2025-11-25"
+    assert _sdk_attr(camel_only, "protocol_version", "protocolVersion") == "2024-11-05"
+    # snake_case (mcp 2.0) wins when both are present
+    assert _sdk_attr(both, "protocol_version", "protocolVersion") == "new"
+    assert _sdk_attr(neither, "protocol_version", "protocolVersion") is None
+    assert _sdk_attr(neither, "input_schema", "inputSchema", {}) == {}
+    # falsy-but-present values are returned as-is, not swallowed by the default
+    assert (
+        _sdk_attr(SimpleNamespace(is_error=False), "is_error", "isError", True) is False
+    )
+
+
+# --- version-independent regression guards (simulate mcp 2.0 snake_case) ----
+
+
+class _FakeSession:
+    """Minimal stand-in for mcp.ClientSession returning mcp-2.0-shaped objects."""
+
+    def __init__(self, *, init_result=None, tools_result=None):
+        self._init_result = init_result
+        self._tools_result = tools_result
+
+    async def initialize(self):
+        return self._init_result
+
+    async def list_tools(self):
+        return self._tools_result
+
+
+@pytest.mark.asyncio
+async def test_initialize_session_reads_mcp2_snake_case():
+    """Old code did ``result.protocolVersion`` — AttributeError under mcp 2.0."""
+    client = MCPClient(MCPServerConfig(name="t", command="python3"))
+    client._session = _FakeSession(
+        init_result=SimpleNamespace(
+            protocol_version="2025-11-25",  # snake only (mcp>=2.0)
+            server_info=SimpleNamespace(name="dogfood"),
+        )
+    )
+    # Must not raise (old camelCase access raised AttributeError here).
+    await client._initialize_session()
+
+
+@pytest.mark.asyncio
+async def test_discover_tools_reads_mcp2_snake_case_input_schema():
+    """Old code fell back to ``{}`` for a snake_case-only ``input_schema``."""
+    schema = {"type": "object", "properties": {"city": {"type": "string"}}}
+    client = MCPClient(MCPServerConfig(name="t", command="python3"))
+    client._session = _FakeSession(
+        tools_result=SimpleNamespace(
+            tools=[
+                SimpleNamespace(
+                    name="get_weather",
+                    description="weather",
+                    input_schema=schema,  # snake only (mcp>=2.0); no inputSchema
+                )
+            ]
+        )
+    )
+    await client._discover_tools()
+    assert len(client.tools) == 1
+    # The whole point: the schema survives the SDK rename, not dropped to {}.
+    assert client.tools[0].input_schema == schema
+
+
+# --- real end-to-end stdio round-trip against the installed SDK -------------
+
+_STDIO_SERVER = textwrap.dedent(
+    """
+    import sys, json
+    TOOLS = [{"name": "get_secret_word",
+              "description": "Return the secret word.",
+              "inputSchema": {"type": "object", "properties": {}, "required": []}},
+             {"name": "add",
+              "description": "Add a and b.",
+              "inputSchema": {"type": "object",
+                              "properties": {"a": {"type": "integer"}, "b": {"type": "integer"}},
+                              "required": ["a", "b"]}}]
+    def dispatch(name, args):
+        if name == "get_secret_word": return "PLATYPUS-42"
+        if name == "add": return str(int(args.get("a", 0)) + int(args.get("b", 0)))
+        raise ValueError(name)
+    def send(o): sys.stdout.write(json.dumps(o) + "\\n"); sys.stdout.flush()
+    for line in sys.stdin:
+        line = line.strip()
+        if not line: continue
+        m = json.loads(line); method = m.get("method"); mid = m.get("id")
+        if method == "initialize":
+            pv = (m.get("params") or {}).get("protocolVersion", "2025-06-18")
+            send({"jsonrpc": "2.0", "id": mid, "result": {
+                "protocolVersion": pv, "capabilities": {"tools": {"listChanged": False}},
+                "serverInfo": {"name": "dogfood-raw", "version": "1.0.0"}}})
+        elif method in ("notifications/initialized", "initialized"):
+            pass
+        elif method == "tools/list":
+            send({"jsonrpc": "2.0", "id": mid, "result": {"tools": TOOLS}})
+        elif method == "tools/call":
+            p = m.get("params") or {}
+            try:
+                send({"jsonrpc": "2.0", "id": mid, "result": {
+                    "content": [{"type": "text", "text": dispatch(p.get("name"), p.get("arguments") or {})}],
+                    "isError": False}})
+            except Exception as e:
+                send({"jsonrpc": "2.0", "id": mid, "result": {
+                    "content": [{"type": "text", "text": str(e)}], "isError": True}})
+        elif method == "ping":
+            send({"jsonrpc": "2.0", "id": mid, "result": {}})
+        elif mid is not None:
+            send({"jsonrpc": "2.0", "id": mid,
+                  "error": {"code": -32601, "message": "method not found"}})
+    """
+)
+
+
+@pytest.mark.asyncio
+async def test_real_stdio_server_discovers_and_calls_tools(tmp_path):
+    """End-to-end: real subprocess stdio server + real mcp SDK.
+
+    Exercises connect → initialize → tools/list → tools/call through the whole
+    client against whatever mcp version is installed. Bypasses the command
+    allowlist via ``skip_security_validation`` because the test runner's
+    interpreter basename (e.g. ``python3.12``) is not on the allowlist.
+    """
+    pytest.importorskip("mcp")
+    server = tmp_path / "stdio_server.py"
+    server.write_text(_STDIO_SERVER)
+
+    client = MCPClient(
+        MCPServerConfig(
+            name="dogfood",
+            transport=MCPTransport.STDIO,
+            command=sys.executable,
+            args=[str(server)],
+            skip_security_validation=True,
+        )
+    )
+    try:
+        connected = await client.connect()
+        assert connected is True, f"connect failed: {client.get_status()}"
+        names = sorted(t.name for t in client.tools)
+        assert names == ["add", "get_secret_word"]
+        # tool schema survives the discovery path
+        add = next(t for t in client.tools if t.name == "add")
+        assert add.input_schema.get("properties", {}).keys() == {"a", "b"}
+        # and a real call round-trips
+        result = await client.call_tool("add", {"a": 20, "b": 22})
+        assert result.is_error is False
+        assert "42" in str(result.content)
+    finally:
+        await client.disconnect()

--- a/vllm_mlx/chat_mcp.py
+++ b/vllm_mlx/chat_mcp.py
@@ -27,6 +27,7 @@ from typing import Any, Literal
 from anyio.abc import TaskStatus
 from anyio.from_thread import start_blocking_portal
 
+from .mcp.client import _sdk_attr
 from .mcp.config import load_mcp_config
 from .mcp.executor import validate_tool_arguments
 from .mcp.security import ToolSandbox
@@ -336,7 +337,10 @@ class ChatMCPRuntime:
                             server_name=server.name,
                             name=sdk_tool.name,
                             description=sdk_tool.description or "",
-                            input_schema=sdk_tool.inputSchema or {},
+                            input_schema=_sdk_attr(
+                                sdk_tool, "input_schema", "inputSchema", {}
+                            )
+                            or {},
                         )
 
             self.tools = mcp_tools_to_openai(list(self._tools_by_name.values()))
@@ -451,7 +455,7 @@ class ChatMCPRuntime:
                 result.model_dump(mode="json", by_alias=True, exclude_none=True),
                 ensure_ascii=False,
             )
-            is_error = bool(getattr(result, "isError", False))
+            is_error = bool(_sdk_attr(result, "is_error", "isError", False))
             self._sandbox.record_execution(
                 tool.name,
                 tool.server_name,

--- a/vllm_mlx/mcp/client.py
+++ b/vllm_mlx/mcp/client.py
@@ -20,6 +20,25 @@ from .types import (
 logger = logging.getLogger(__name__)
 
 
+def _sdk_attr(obj: Any, snake: str, camel: str, default: Any = None) -> Any:
+    """Read an mcp SDK model attribute across the SDK's camelCase→snake_case rename.
+
+    mcp 1.x exposed model fields in camelCase (``protocolVersion``,
+    ``inputSchema``, ``isError``); mcp 2.0 renamed the Python attributes to
+    snake_case (``protocol_version``, ``input_schema``, ``is_error``) and kept
+    camelCase only as a serialization alias. Reading the wrong name raises
+    ``AttributeError`` — which previously aborted the initialize handshake and
+    left every configured server with 0 tools (rapid-desktop#604), because the
+    dev/CI env pinned mcp 1.x while a fresh sidecar build resolved mcp 2.0.
+    Try snake_case first (mcp>=2.0), then camelCase (mcp<2.0), then ``default``.
+    """
+    sentinel = object()
+    value = getattr(obj, snake, sentinel)
+    if value is sentinel:
+        value = getattr(obj, camel, sentinel)
+    return default if value is sentinel else value
+
+
 class MCPClient:
     """
     Client for connecting to a single MCP server.
@@ -176,10 +195,11 @@ class MCPClient:
 
         # Initialize with capabilities
         result = await self._session.initialize()
+        server_info = _sdk_attr(result, "server_info", "serverInfo")
         logger.debug(
             f"MCP server '{self.name}' initialized: "
-            f"protocol={result.protocolVersion}, "
-            f"server={result.serverInfo.name if result.serverInfo else 'unknown'}"
+            f"protocol={_sdk_attr(result, 'protocol_version', 'protocolVersion')}, "
+            f"server={server_info.name if server_info else 'unknown'}"
         )
 
     async def _discover_tools(self):
@@ -196,9 +216,7 @@ class MCPClient:
                     server_name=self.name,
                     name=tool.name,
                     description=tool.description or "",
-                    input_schema=(
-                        tool.inputSchema if hasattr(tool, "inputSchema") else {}
-                    ),
+                    input_schema=_sdk_attr(tool, "input_schema", "inputSchema", {}),
                 )
                 self._tools.append(mcp_tool)
                 logger.debug(f"Discovered tool: {mcp_tool.full_name}")
@@ -282,7 +300,7 @@ class MCPClient:
             return MCPToolResult(
                 tool_name=tool_name,
                 content=content,
-                is_error=result.isError if hasattr(result, "isError") else False,
+                is_error=bool(_sdk_attr(result, "is_error", "isError", False)),
             )
 
         except asyncio.TimeoutError:


### PR DESCRIPTION
## Why

**Connectors (MCP) return 0 tools** in every fresh sidecar build — the desktop Connectors feature is non-functional. Found dogfooding desktop 0.11.0 (bundled rapid-mlx 0.11.1). Tracked at machinefi/rapid-desktop#604.

## Root cause

`pyproject.toml` pins `mcp>=1.9.3` (unbounded). The dev/CI env resolves **mcp 1.x** (currently 1.26.0), but a fresh install resolves **mcp 2.0.0**, which renamed model Python attributes from camelCase to snake_case (camelCase kept only as a serialization alias):

| mcp 1.x | mcp 2.0 |
|---|---|
| `InitializeResult.protocolVersion` / `.serverInfo` | `.protocol_version` / `.server_info` |
| `Tool.inputSchema` | `.input_schema` |
| `CallToolResult.isError` | `.is_error` |

`MCPClient._initialize_session` reads `result.protocolVersion` → `AttributeError` right after a *successful* `initialize()` handshake → connect aborts → **0 tools**. Two `hasattr`-guarded sites degraded silently: tool input schemas dropped to `{}`, tool-call errors masked as success.

The existing MCP tests fake the SDK, and CI runs mcp 1.x (where camelCase still works), so the skew shipped undetected.

## Fix

- Add a version-agnostic `_sdk_attr(obj, snake, camel, default)` shim (snake first, camel fallback) and route all four accesses through it. Works on both mcp 1.x and 2.0 — no version pin needed, forward-compatible.
- Add `tests/test_mcp_client_mcp2_compat.py`:
  - version-independent regression guards that simulate mcp-2.0 snake_case-only objects (they fail against the old code on *any* mcp version, including CI's 1.x)
  - a real end-to-end stdio round-trip against the installed SDK (the pre-existing suite only mocks it).

## Verification

| | mcp 1.26.0 (CI) | mcp 2.0.0 (prod) |
|---|---|---|
| old code | init raises / schema→`{}` | **connect=False, 0 tools** (repros the shipped bug) |
| new code | ok | **connect=True, 2 tools w/ schemas, add(20,22)→'42'** |

All 112 MCP-suite tests pass; `ruff check` + `ruff format --check` clean.

Closes machinefi/rapid-desktop#604

🤖 Generated with [Claude Code](https://claude.com/claude-code)
