### PR TITLE
docs: RELEASE.md + emergency force_release escape hatch

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -67,6 +67,13 @@ jobs:
             echo "⚠️  FORCED release requested by @$ACTOR → v$FORCE_VERSION"
             echo "    reason: ${REASON:-<none given>}"
             echo "⚠️  The Tier-1 agent gate will be BYPASSED for this release."
+            # workflow_dispatch lets the operator pick any ref; a production
+            # release must come from protected main, never a feature/stale
+            # branch that happens to carry the same version in pyproject.toml.
+            if [ "$GITHUB_REF" != "refs/heads/main" ]; then
+              echo "❌ Forced release must be dispatched on main (got $GITHUB_REF)" >&2
+              exit 1
+            fi
             VERSION="$FORCE_VERSION"
             # Even a forced release must match pyproject and have a fresh tag.
             PROJECT_VER=$(grep -m1 '^version *=' pyproject.toml | awk -F'"' '{print $2}')

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -11,32 +11,83 @@ name: Auto-release on version bump
 # green against the exact source being released. Mirrors Apple MLX's
 # ``publish needs: test_wheel``.
 #
-# Without this, the pipeline stalls between "version committed to main" and
-# "Release published" — a manual step that gets forgotten and leaves users with
-# stale ``rapid-mlx models`` output for days; and a silently-broken agent
-# integration would ship instead of blocking.
+# EMERGENCY OVERRIDE: if the Studio runner is down and a release can't wait, a
+# maintainer can run this workflow manually (``workflow_dispatch``) with
+# ``force_version`` set — that BYPASSES the gate and releases anyway. It is
+# audited (actor + reason are logged and stamped into the release notes). See
+# RELEASE.md § "Studio down / emergency release".
 
 on:
   push:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      force_version:
+        description: "EMERGENCY only: release this exact version WITHOUT the Tier-1 gate (use when the Studio runner is down). Must equal pyproject.toml. Leave blank otherwise."
+        required: false
+        default: ""
+      reason:
+        description: "Why the gate is being bypassed (recorded in the release notes for audit)."
+        required: false
+        default: ""
 
 permissions:
   contents: read
 
 jobs:
   # 1) Cheap detection on a hosted runner: is this a version bump we should
-  #    release? Exposes should_release + version for the downstream jobs.
+  #    release? Exposes should_release + version + force for downstream jobs.
   detect:
     runs-on: ubuntu-latest
     outputs:
       should_release: ${{ steps.detect.outputs.should_release }}
       version: ${{ steps.detect.outputs.version }}
+      force: ${{ steps.detect.outputs.force }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
-      - name: Detect version bump
+      - name: Detect version bump (or forced release)
         id: detect
+        env:
+          # Pass untrusted-ish dispatch inputs via env, never ``${{ }}`` into the
+          # run block.
+          EVENT: ${{ github.event_name }}
+          FORCE_VERSION: ${{ github.event.inputs.force_version }}
+          REASON: ${{ github.event.inputs.reason }}
+          ACTOR: ${{ github.actor }}
         run: |
+          # --- Emergency manual override (Studio down) ---------------------
+          if [ "$EVENT" = "workflow_dispatch" ]; then
+            if [ -z "$FORCE_VERSION" ]; then
+              echo "workflow_dispatch with no force_version — nothing to do."
+              echo "should_release=false" >> "$GITHUB_OUTPUT"
+              echo "force=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            echo "⚠️  FORCED release requested by @$ACTOR → v$FORCE_VERSION"
+            echo "    reason: ${REASON:-<none given>}"
+            echo "⚠️  The Tier-1 agent gate will be BYPASSED for this release."
+            VERSION="$FORCE_VERSION"
+            # Even a forced release must match pyproject and have a fresh tag.
+            PROJECT_VER=$(grep -m1 '^version *=' pyproject.toml | awk -F'"' '{print $2}')
+            if [ "$PROJECT_VER" != "$VERSION" ]; then
+              echo "❌ force_version $VERSION != pyproject.toml $PROJECT_VER" >&2
+              exit 1
+            fi
+            if git ls-remote --tags origin "refs/tags/v$VERSION" | grep -q "v$VERSION"; then
+              echo "Tag v$VERSION already exists — nothing to do (idempotent)"
+              echo "should_release=false" >> "$GITHUB_OUTPUT"
+              echo "force=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+            echo "should_release=true" >> "$GITHUB_OUTPUT"
+            echo "force=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # --- Normal push path -------------------------------------------
+          echo "force=false" >> "$GITHUB_OUTPUT"
           SUBJECT=$(git log -1 --pretty=%s)
           echo "subject: $SUBJECT"
 
@@ -73,13 +124,14 @@ jobs:
   #    this is the one release check CI can't do elsewhere. Builds the EXACT
   #    source being released into a fresh venv (it isn't on PyPI yet) and
   #    re-verifies the four Tier-1 agents end-to-end. A failure here blocks the
-  #    release job below.
+  #    release job below. Skipped for an emergency forced release.
   #
   #    SECURITY: this self-hosted job runs only on push to the protected main
-  #    branch (never on pull_request), so fork code cannot reach the runner.
+  #    branch / maintainer workflow_dispatch, never on pull_request, so fork
+  #    code cannot reach the runner.
   tier1-agent-gate:
     needs: detect
-    if: needs.detect.outputs.should_release == 'true'
+    if: needs.detect.outputs.should_release == 'true' && needs.detect.outputs.force != 'true'
     runs-on: [self-hosted, macOS, rapidmlx-studio]
     timeout-minutes: 55
     # Serialize with the manual agent-gate.yml so two runs never contend for the
@@ -113,12 +165,17 @@ jobs:
           RAPID_MLX_VENV="$V" bash tests/integrations/agent_smoke.sh qwen3.6-35b-8bit
           rm -rf "$V"
 
-  # 3) Tag + GitHub Release, only if the gate passed. ``needs`` includes the
-  #    gate, so a gate failure (or skip) blocks this job. publish.yml fires on
+  # 3) Tag + GitHub Release. Runs when the gate passed OR this is a forced
+  #    (gate-bypassed) release. ``!cancelled()`` lets the ``if`` evaluate even
+  #    though the gate job is skipped on a forced release. publish.yml fires on
   #    the resulting ``release: published`` event.
   release:
     needs: [detect, tier1-agent-gate]
-    if: needs.detect.outputs.should_release == 'true'
+    if: >-
+      !cancelled()
+      && needs.detect.result == 'success'
+      && needs.detect.outputs.should_release == 'true'
+      && (needs.detect.outputs.force == 'true' || needs.tier1-agent-gate.result == 'success')
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -134,6 +191,9 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ needs.detect.outputs.version }}
+          FORCE: ${{ needs.detect.outputs.force }}
+          ACTOR: ${{ github.actor }}
+          REASON: ${{ github.event.inputs.reason }}
         run: |
           # Find the last release tag to enumerate merged PRs since then.
           PREV_TAG=$(git tag --list 'v*' --sort=-v:refname | head -1 || true)
@@ -175,6 +235,11 @@ jobs:
             echo 'body<<__EOF__'
             echo "## What's new in v$VERSION"
             echo
+            if [ "$FORCE" = "true" ]; then
+              echo "> ⚠️ **Emergency release** — the Tier-1 agent gate was bypassed"
+              echo "> (forced by @$ACTOR). Reason: ${REASON:-<none given>}."
+              echo
+            fi
             if [ -n "$COMMITS" ]; then
               echo "$COMMITS"
             else

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,129 @@
+# Releasing Rapid-MLX
+
+How a release actually happens, what gates it, and what to do when things go
+wrong. If you only read one thing: **you cut a release by merging a
+`chore: bump version to X.Y.Z` commit to `main`** — everything else is
+automated.
+
+## TL;DR — cut a release
+
+1. Bump `version` in `pyproject.toml` to `X.Y.Z`.
+2. Open a PR whose commit subject is exactly `chore: bump version to X.Y.Z`
+   (GitHub's `(#N)` squash suffix is fine), and merge it to `main`.
+3. That's it. The pipeline below tags `vX.Y.Z`, publishes a GitHub Release,
+   PyPI, and Homebrew — **after** the Tier-1 agent gate passes.
+
+Nothing else is manual. There is no separate "publish" button.
+
+## The pipeline
+
+`.github/workflows/auto-release.yml` runs on every push to `main` and is three
+jobs:
+
+```
+push to main
+   │
+   ▼
+┌─ detect (GitHub-hosted, ~2s) ─────────────────────────────────┐
+│  Is the commit subject "chore: bump version to X.Y.Z"?        │
+│  pyproject matches? tag not already present?                  │
+│  → outputs should_release / version. Non-bump pushes stop here.│
+└───────────────────────────────────────────────────────────────┘
+   │ should_release == true
+   ▼
+┌─ tier1-agent-gate (SELF-HOSTED, Apple Silicon "Studio", ~10m) ┐
+│  Build the exact release source into a fresh venv, then run   │
+│  tests/integrations/agent_smoke.sh: boot rapid-mlx serve and  │
+│  drive Claude Code / Codex / Hermes / Aider through a real     │
+│  end-to-end edit. Exit non-zero if any of the 4 regresses.    │
+└───────────────────────────────────────────────────────────────┘
+   │ gate passed
+   ▼
+┌─ release (GitHub-hosted) ─────────────────────────────────────┐
+│  Create tag vX.Y.Z + GitHub Release (changelog + contributors)│
+│  using RELEASE_PAT → fires the `release: published` event.     │
+└───────────────────────────────────────────────────────────────┘
+   │
+   ▼
+publish.yml → PyPI    →    Homebrew core autobump → `brew` users
+```
+
+`release` `needs: [detect, tier1-agent-gate]`, so **a version bump cannot tag
+or publish unless the gate passes.** This mirrors how Apple's own MLX gates its
+PyPI publish on a self-hosted-Metal `test_wheel` job.
+
+## Why a self-hosted runner
+
+The gate re-verifies that our four **Tier-1 (flagship) agents** — Claude Code,
+Codex, Hermes, Aider — actually work end-to-end against a real local model on
+Apple Silicon, on the *current* client binaries. GitHub-hosted runners cannot do
+this: no Metal, no cached weights (a boot model is ~40–70 GB), and the agent
+CLIs aren't installed. So the gate runs on a **self-hosted Apple-Silicon runner
+(the "Studio", an M3 Ultra)**.
+
+> **Two meanings of "Tier-1", don't conflate:** *Tier-1 model families*
+> (Qwen 3.6 / Gemma 4 / DeepSeek / gpt-oss / Hy3) and *Tier-1 agents* (the 4
+> flagship). The gate is about the **agents**. See the agent-tier docs on
+> rapidmlx.com/docs/matrix and `tests/integrations/README.md`.
+
+### The runner
+
+- Registered on the Studio as a launchd service
+  (`actions.runner.raullenchai-Rapid-MLX.studio-m3-ultra`), labels
+  `[self-hosted, macOS, ARM64, rapidmlx-studio]`. It auto-restarts on crash or
+  reboot, and maintains an **outbound** long-poll to GitHub (no inbound ports,
+  no VPN) — GitHub never connects *into* the Studio; the runner pulls jobs.
+- **Security:** the self-hosted job runs only on push to protected `main` /
+  maintainer `workflow_dispatch`, never on `pull_request`, and fork-PR workflow
+  approval is set to *all external contributors* — so fork code can never reach
+  the runner. Never add a `pull_request` trigger to a `rapidmlx-studio` job.
+- Check it's online: `gh api repos/raullenchai/Rapid-MLX/actions/runners`.
+- Manual / on-demand run of the gate (no release):
+  `gh workflow run agent-gate.yml -R raullenchai/Rapid-MLX`.
+
+## When the gate fails (a Tier-1 agent regressed)
+
+The `release` job is skipped; the version stays committed-but-unpublished. In
+the failed `tier1-agent-gate` job log you'll see which agent (`claude-code` /
+`codex-cli` / `hermes` / `aider`) reported `FAIL`.
+
+1. First rule out a *model-strength* artifact — a weak model that fakes success
+   is not an integration bug. The gate uses `qwen3.6-35b-8bit` (≥8-bit on
+   purpose; never 4-bit, which confounds the two).
+2. Localize with a wire replay: proxy the real client once, diff our SSE stream
+   against what it expects, and pin the offending event/field.
+3. Fix the integration (engine PR), then re-run: `gh run rerun <run-id>` or push
+   again. Once green, the release proceeds automatically.
+
+## Studio down / emergency release (break-glass)
+
+If the Studio is **offline** when a version bump lands, the `tier1-agent-gate`
+job has no runner to run on: it **queues** (up to GitHub's 24 h limit, then
+fails), and the release stalls. This is intentional — *no verification, no
+release*.
+
+**Normal recovery:** bring the Studio back (it's a launchd service — usually
+just power/network), then `gh run rerun <auto-release-run-id>`. Nothing is lost,
+only delayed.
+
+**Emergency override** (Studio can't be fixed and the release truly can't wait):
+run auto-release manually with the gate bypassed —
+
+```bash
+gh workflow run auto-release.yml -R raullenchai/Rapid-MLX \
+  -f force_version=X.Y.Z \
+  -f reason="Studio offline, security fix must ship"
+```
+
+This skips the gate and releases `vX.Y.Z` (it still checks pyproject matches and
+the tag is new). The bypass is **audited**: the actor + reason are logged and
+stamped into the GitHub Release notes as an "⚠️ Emergency release" banner. Use
+it sparingly — it ships a version whose agent integrations were *not* verified.
+
+## Related docs
+
+- `tests/integrations/agent_smoke.sh` — the gate script (canonical).
+- `tests/integrations/README.md` — the full agent × model integration matrix.
+- `landing/runbooks/agent-release-verification.md` (rapidmlx.com repo) — the
+  operational runbook + the freshness-stamp bump for the website.
+- `.github/workflows/publish.yml` — PyPI publish on `release: published`.


### PR DESCRIPTION
## Why

Two follow-ups to the Tier-1 release gate (#1280, #1282):
1. **Discoverability** — the release process was spread across workflow comments + a website runbook; colleagues had no single doc. Industry standard (PyTorch, vLLM) is a root `RELEASE.md`.
2. **Resilience** — the hard gate means a version bump stalls if the self-hosted Studio runner is down. We need an audited emergency bypass.

## What

- **`RELEASE.md`** (repo root): how to cut a release, the detect→gate→release pipeline diagram, the self-hosted runner + its security model, gate-failure triage, and the Studio-down / emergency path.
- **`auto-release.yml` `force_release` escape hatch**: a maintainer-only `workflow_dispatch` with `force_version` (+ `reason`) that **bypasses the gate**. The gate job is `if: should_release && force != 'true'` (skipped on force); the release job runs via `!cancelled() && … && (force == 'true' || gate.result == 'success')`. Audited: actor + reason are logged and stamped into the release notes as an ⚠️ Emergency-release banner. Forced releases still require pyproject to match and the tag to be new.

## Testing

SHA-pin + YAML validated. Normal push path unchanged (verified on #1282's merge: detect success, gate/release skipped for non-bump). Logic table for the release `if` (non-bump / bump+gate-pass / bump+gate-fail / force / dispatch-no-version) all resolve correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)