### PR TITLE
fix(cli): ship official rmlx short command

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -199,6 +199,7 @@ done
 
 # rapid-mlx aliases
 [ -f "$INSTALL_DIR/bin/vllm-mlx" ]      && ln -sf "$INSTALL_DIR/bin/vllm-mlx"      "$BIN_DIR/rapid-mlx"
+[ -f "$INSTALL_DIR/bin/rmlx" ]          && ln -sf "$INSTALL_DIR/bin/rmlx"          "$BIN_DIR/rmlx"
 [ -f "$INSTALL_DIR/bin/vllm-mlx-chat" ]  && ln -sf "$INSTALL_DIR/bin/vllm-mlx-chat"  "$BIN_DIR/rapid-mlx-chat"
 [ -f "$INSTALL_DIR/bin/vllm-mlx-bench" ] && ln -sf "$INSTALL_DIR/bin/vllm-mlx-bench" "$BIN_DIR/rapid-mlx-bench"
 ln -sf "$INSTALL_DIR/bin/python3" "$BIN_DIR/rapid-mlx-python"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -390,6 +390,8 @@ mlx = "vllm_mlx.plugin:mlx_platform_plugin"
 
 [project.scripts]
 rapid-mlx = "vllm_mlx.cli:main"
+# First-class short command for accessibility and reduced typing (#1279).
+rmlx = "vllm_mlx.cli:main"
 rapid-mlx-chat = "vllm_mlx.gradio_app:main"
 rapid-mlx-bench = "vllm_mlx.benchmark:main"
 # Deprecated pre-rename aliases — kept so existing users' scripts/muscle

--- a/scripts/release_artifact_matrix.py
+++ b/scripts/release_artifact_matrix.py
@@ -70,6 +70,7 @@ MATRIX_TEST_DEPENDENCIES = (
 # valid base wheel.
 CLI_SMOKE_SCRIPTS = (
     "rapid-mlx",
+    "rmlx",
     "rapid-mlx-bench",
     "vllm-mlx",
     "vllm-mlx-bench",

--- a/tests/test_cli_short_alias.py
+++ b/tests/test_cli_short_alias.py
@@ -9,7 +9,15 @@ except ModuleNotFoundError:  # pragma: no cover - Python 3.10
 
 
 def test_rmlx_uses_the_canonical_cli_entrypoint():
-    with (Path(__file__).resolve().parents[1] / "pyproject.toml").open("rb") as handle:
+    repo_root = Path(__file__).resolve().parents[1]
+    with (repo_root / "pyproject.toml").open("rb") as handle:
         scripts = tomllib.load(handle)["project"]["scripts"]
 
     assert scripts["rmlx"] == scripts["rapid-mlx"] == "vllm_mlx.cli:main"
+
+
+def test_curl_installer_exposes_rmlx_on_path():
+    installer = (Path(__file__).resolve().parents[1] / "install.sh").read_text()
+
+    assert '"$INSTALL_DIR/bin/rmlx"' in installer
+    assert '"$BIN_DIR/rmlx"' in installer

--- a/tests/test_cli_short_alias.py
+++ b/tests/test_cli_short_alias.py
@@ -1,0 +1,15 @@
+"""Packaging contract for the first-class short CLI command."""
+
+from pathlib import Path
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python 3.10
+    import tomli as tomllib
+
+
+def test_rmlx_uses_the_canonical_cli_entrypoint():
+    with (Path(__file__).resolve().parents[1] / "pyproject.toml").open("rb") as handle:
+        scripts = tomllib.load(handle)["project"]["scripts"]
+
+    assert scripts["rmlx"] == scripts["rapid-mlx"] == "vllm_mlx.cli:main"

--- a/tests/test_release_artifact_matrix.py
+++ b/tests/test_release_artifact_matrix.py
@@ -104,6 +104,7 @@ def test_workflow_default_covers_manifest_artifact_families(matrix):
 def test_cli_smoke_covers_base_commands_but_not_optional_chat(matrix):
     assert set(matrix.CLI_SMOKE_SCRIPTS) == {
         "rapid-mlx",
+        "rmlx",
         "rapid-mlx-bench",
         "vllm-mlx",
         "vllm-mlx-bench",


### PR DESCRIPTION
## What changed

- ship `rmlx` as an official short console command
- keep it on the exact same CLI entrypoint as `rapid-mlx`
- add a packaging contract test so the two commands cannot drift

## Why

Issue #1279 reports an accessibility-motivated shell alias that injects an
unexpected `-F` argument. Rapid-MLX does not generate that argument, so
silently accepting it would hide a broken shell wrapper. A first-class short
command removes the need for users to maintain an alias at all.

After upgrading, users can remove any existing `rmlx` alias/function and run
`rmlx ls` directly.

## Validation

- `pytest tests/test_cli_short_alias.py -q`
- Ruff check and format check
- built the wheel and installed it in a separate venv
- verified both generated executables are present
- verified `rmlx --version`
- verified the issue's `rmlx ls` command exits successfully

Closes #1279
