### PR TITLE
fix(cache): lock sliding-window prefix reuse against ChunkedKVCache trim-lie [skip-version-bump]

### DIFF
--- a/tests/test_hybrid_prefix_cache_growth.py
+++ b/tests/test_hybrid_prefix_cache_growth.py
@@ -232,15 +232,18 @@ def test_dict_form_all_kvcache_stored(cache):
 
 @pytest.mark.parametrize(
     "kv_class",
-    ["RotatingKVCache", "ChunkedKVCache", "ConcatenateKVCache", "QuantizedKVCache"],
+    ["RotatingKVCache", "QuantizedKVCache"],
 )
 def test_dict_form_trimmable_kv_variants_still_stored(cache, kv_class):
-    """Dict-form sliding-window / other trimmable KV classes must NOT be dropped.
+    """Dict-form sliding-window / other genuinely-trimmable KV classes must NOT
+    be dropped.
 
     Regression for codex #1075 finding: an allowlist of only KVCache would
     wrongly classify RotatingKVCache & friends as non-trimmable and drop the
     entry, regressing prefix reuse for dense / sliding-window models. The
-    denylist keeps them cacheable.
+    denylist keeps them cacheable. (``ChunkedKVCache`` / ``ConcatenateKVCache``
+    are the exception — they LIE about trimmability and are dropped; see
+    ``test_dict_form_trim_unsafe_liar_variants_dropped``.)
     """
     prompt = list(range(1000, 1100))
     dict_cache = [
@@ -252,6 +255,30 @@ def test_dict_form_trimmable_kv_variants_still_stored(cache, kv_class):
         f"{kv_class} is trimmable and must remain cacheable"
     )
     assert tuple(prompt) in cache._entries
+
+
+@pytest.mark.parametrize("kv_class", ["ChunkedKVCache", "ConcatenateKVCache"])
+def test_dict_form_trim_unsafe_liar_variants_dropped(cache, kv_class):
+    """Dict-form trim-unsafe "trimmable liar" classes MUST be dropped.
+
+    ``ChunkedKVCache`` (drops front history via ``maybe_trim_front``) and
+    ``ConcatenateKVCache`` (``trim`` never slices its buffers) both report
+    ``is_trimmable()==True`` yet corrupt on a trim-then-continue, so trimming
+    them back to a prefix produces wrong KV. The store gate must refuse them —
+    see ``_TRIM_UNSAFE_CACHE_CLASSES`` in ``memory_cache``. Neither is reachable
+    by a currently-supported family (llama4 / afm7, not in ``aliases.json``);
+    this is defense-in-depth for the latent gap.
+    """
+    prompt = list(range(1000, 1100))
+    dict_cache = [
+        {"class_name": kv_class, "state": (1, 2), "meta_state": ("0",)},
+        {"class_name": kv_class, "state": (3, 4), "meta_state": ("0",)},
+    ]
+
+    assert cache.store(prompt, dict_cache) is False, (
+        f"{kv_class} lies about trimmability and must be dropped"
+    )
+    assert tuple(prompt) not in cache._entries
 
 
 def test_dict_form_mamba_variant_dropped(cache):

--- a/tests/test_paged_cache.py
+++ b/tests/test_paged_cache.py
@@ -795,6 +795,54 @@ class TestBlockAwarePrefixCache:
         }
         assert cache._extract_block_tensor_slice([non_kv_layer], 0, 4) is None
 
+    def test_seq_axis_allowlist_anchored_to_real_mlx_lm_classes(self):
+        """Anchor ``_SEQ_AXIS_KV_CLASSES`` to GROUND TRUTH — the real mlx-lm
+        class *objects*, not synthetic string literals.
+
+        The block-aware path hosts a stored layer only when its ``class_name``
+        is in this fail-closed allowlist. The sibling tests assert against
+        hardcoded strings ("KVCache", "RotatingKVCache", ...), so they can't
+        notice if the allowlist drifts out of sync with the actual mlx-lm
+        classes. This test protects two concrete regressions by keying off the
+        real ``__name__``s:
+          * allowlist drift — anyone adding ``RotatingKVCache`` /
+            ``ChunkedKVCache`` / ``QuantizedKVCache`` / ``ArraysCache`` to the
+            set (all trim-unsafe or non-seq-indexed) turns this red;
+          * an mlx-lm rename of the one hostable class — if ``KVCache`` is
+            renamed, ``KVCache.__name__`` no longer equals the allowlisted
+            string and this turns red.
+        It does NOT (and cannot) detect a hypothetical *future distinct* cache
+        class that also happens to be named ``KVCache`` — a same-name collision
+        is out of reach of a name-based allowlist; guarding that would need
+        per-family ``make_cache`` construction coverage (weights/network), which
+        is intentionally out of scope here.
+        """
+        from mlx_lm.models.cache import (
+            ArraysCache,
+            ChunkedKVCache,
+            KVCache,
+            QuantizedKVCache,
+            RotatingKVCache,
+        )
+
+        from vllm_mlx.prefix_cache import BlockAwarePrefixCache
+
+        allow = BlockAwarePrefixCache._SEQ_AXIS_KV_CLASSES
+
+        # The one and only block-hostable class, keyed by its REAL __name__.
+        assert KVCache.__name__ in allow
+
+        # Every trim-unsafe / non-seq-indexed real class stays OUT.
+        for cls in (
+            RotatingKVCache,
+            ChunkedKVCache,
+            QuantizedKVCache,
+            ArraysCache,
+        ):
+            assert cls.__name__ not in allow, (
+                f"{cls.__name__} must not be block-hostable"
+            )
+
     def test_reconstruct_refuses_non_kvcache_class_name(self):
         """``reconstruct_cache`` must refuse to host anything other than a
         vanilla ``KVCache`` even if ``block.cache_data`` somehow contains

--- a/tests/test_prefix_cache.py
+++ b/tests/test_prefix_cache.py
@@ -131,6 +131,54 @@ class TestPrefixCacheManager:
         assert cache_manager.stats.hits == 1
         assert cache_manager.stats.tokens_saved == len(short_tokens)
 
+    def test_can_trim_cache_rejects_chunked_trim_liar(self, cache_manager):
+        """``_can_trim_cache`` must reject a front-dropped ChunkedKVCache even
+        though its inherited ``is_trimmable()`` lies True — trimming it via
+        ``_trim_cache`` would slice past discarded front tokens. Plain KVCache
+        stays trimmable; rotated RotatingKVCache is honestly non-trimmable.
+        Without the trim-liar guard the first assertion is False (mutation-kill).
+        """
+        mx = pytest.importorskip("mlx.core")
+        from mlx_lm.models.cache import ChunkedKVCache, KVCache, RotatingKVCache
+
+        ck = ChunkedKVCache(chunk_size=128)
+        k = mx.random.normal((1, 2, 200, 8))
+        ck.update_and_fetch(k, k)
+        ck.maybe_trim_front()
+        mx.eval(ck.keys)
+        assert ck.start_position > 0 and ck.is_trimmable() is True  # the lie
+
+        assert cache_manager._can_trim_cache([KVCache(), ck]) is False
+
+        kv = KVCache()
+        kv.update_and_fetch(k, k)
+        assert cache_manager._can_trim_cache([kv]) is True
+
+        rot = RotatingKVCache(max_size=16, keep=0)
+        rk = mx.random.normal((1, 2, 24, 8))
+        rot.update_and_fetch(rk, rk)
+        assert rot.is_trimmable() is False
+        assert cache_manager._can_trim_cache([rot]) is False
+
+    def test_fetch_longer_prefix_skips_chunked_trim_liar(self, cache_manager):
+        """A stored longer entry containing a front-dropped ChunkedKVCache must
+        NOT be trim-reused on a shorter-query fetch — it falls through to a miss
+        instead of returning a corrupt trimmed cache."""
+        mx = pytest.importorskip("mlx.core")
+        from mlx_lm.models.cache import ChunkedKVCache, KVCache
+
+        ck = ChunkedKVCache(chunk_size=128)
+        k = mx.random.normal((1, 2, 200, 8))
+        ck.update_and_fetch(k, k)
+        ck.maybe_trim_front()
+        mx.eval(ck.keys)
+
+        cache_manager.store_cache([1, 2, 3, 4, 5, 6], [KVCache(), ck])
+        cache, remaining = cache_manager.fetch_cache([1, 2, 3])
+
+        assert cache is None
+        assert remaining == [1, 2, 3]
+
     def test_lru_eviction(self, mock_model):
         """Test LRU eviction when cache is full."""
         manager = PrefixCacheManager(mock_model, max_entries=3)

--- a/tests/test_sliding_window_prefix_reuse.py
+++ b/tests/test_sliding_window_prefix_reuse.py
@@ -25,6 +25,7 @@ import copy
 import mlx.core as mx
 import pytest
 from mlx_lm.models.cache import (
+    ChunkedKVCache,
     KVCache,
     RotatingKVCache,
     can_trim_prompt_cache,
@@ -34,6 +35,8 @@ from vllm_mlx.memory_cache import (
     MemoryAwarePrefixCache,
     MemoryCacheConfig,
     _cache_has_non_trimmable,
+    _layer_forbids_trim,
+    _layer_is_trim_liar,
 )
 
 B, H, D = 1, 2, 8
@@ -251,3 +254,111 @@ def test_scheduler_exact_hit_trim_exception_falls_back_to_cold_prefill(monkeypat
     assert req.cached_tokens == 0
     assert req.remaining_tokens == [1, 2, 3, 4, 5, 6]
     assert tokens == [1, 2, 3, 4, 5, 6]
+
+
+# ---------------------------------------------------------------------------
+# ChunkedKVCache trim-liar correctness lock (defense-in-depth; llama4-only,
+# not in aliases.json — see ``_TRIM_UNSAFE_CACHE_CLASSES`` in memory_cache).
+# ``ChunkedKVCache.is_trimmable()`` (inherited from KVCache) returns True
+# UNCONDITIONALLY, but ``maybe_trim_front()`` drops front history and advances
+# ``start_position``, so a trim-back-to-prefix slices past discarded tokens →
+# wrong KV. These tests pin the gate that must REFUSE such reuse.
+# ---------------------------------------------------------------------------
+
+
+def _front_dropped_chunked(
+    n_tokens: int = 200, chunk_size: int = 128
+) -> ChunkedKVCache:
+    """A REAL front-dropped ``ChunkedKVCache`` (``start_position > 0``).
+
+    Fills the cache past ``chunk_size`` then calls ``maybe_trim_front()``
+    exactly as ``llama4.py`` does, so the front is discarded and
+    ``start_position`` advances — the state that makes a trim-back unsafe.
+    """
+    ck = ChunkedKVCache(chunk_size=chunk_size)
+    k = mx.random.normal((B, H, n_tokens, D))
+    v = mx.random.normal((B, H, n_tokens, D))
+    ck.update_and_fetch(k, v)
+    ck.maybe_trim_front()
+    mx.eval(ck.keys, ck.values)
+    assert ck.start_position > 0  # precondition: front actually dropped
+    assert ck.is_trimmable() is True  # the LIE this fix defends against
+    return ck
+
+
+def test_front_dropped_chunked_kvcache_classified_non_trimmable():
+    """A front-dropped ChunkedKVCache is classified non-trimmable by every gate
+    even though its inherited ``is_trimmable()`` lies True. Without the fix
+    ``_cache_has_non_trimmable`` returns False here (mutation-kill)."""
+    ck = _front_dropped_chunked()
+
+    assert _layer_is_trim_liar(ck) is True
+    assert _layer_forbids_trim(ck) is True
+    # mixed dense + chunked entry, mirroring llama4's per-group layout
+    assert _cache_has_non_trimmable([KVCache(), ck]) is True
+
+
+def test_fetch_supersequence_skips_front_dropped_chunked_entry():
+    """A stored entry containing a front-dropped ChunkedKVCache must NOT be
+    reused via the supersequence-with-excess trim path — it falls through to a
+    miss (full prefill). Without the fix this returns a (corrupt) supersequence
+    hit."""
+    # hybrid_reuse_max_entries > 0 so store RETAINS the non-trimmable entry
+    # (default 0 would drop it at store time); the fetch gate is what we test.
+    cache = MemoryAwarePrefixCache(None, MemoryCacheConfig(hybrid_reuse_max_entries=8))
+    long_tokens = list(range(60))
+    kv = KVCache()
+    fk = mx.random.normal((B, H, len(long_tokens), D))
+    kv.update_and_fetch(fk, fk)
+    mx.eval(kv.keys, kv.values)
+    assert cache.store(long_tokens, [kv, _front_dropped_chunked()]) is True
+
+    result, remaining = cache.fetch(list(range(20)))  # supersequence of stored
+    assert result is None
+    assert remaining == list(range(20))
+    assert cache._last_match_type == "miss"
+
+
+def test_fetch_lcp_skips_front_dropped_chunked_entry():
+    """A stored entry containing a front-dropped ChunkedKVCache must NOT be
+    reused via the LCP (divergent-suffix) trim path — it falls through to a
+    miss. Without the fix this returns a (corrupt) LCP hit."""
+    cache = MemoryAwarePrefixCache(None, MemoryCacheConfig(hybrid_reuse_max_entries=8))
+    stored = list(range(20)) + [900, 901, 902, 903, 904]
+    kv = KVCache()
+    fk = mx.random.normal((B, H, len(stored), D))
+    kv.update_and_fetch(fk, fk)
+    mx.eval(kv.keys, kv.values)
+    assert cache.store(stored, [kv, _front_dropped_chunked()]) is True
+
+    # shares prefix [0..19] then diverges -> only the LCP path could match
+    requested = list(range(20)) + [800, 801]
+    result, remaining = cache.fetch(requested)
+    assert result is None
+    assert remaining == requested
+    assert cache._last_match_type == "miss"
+
+
+def test_fix_preserves_kvcache_reuse_and_rotated_skip():
+    """Regression guard: the trim-liar gate changes ONLY the two liar classes.
+    An all-KVCache supersequence entry is still trim-reused, and a rotated
+    RotatingKVCache entry is still skipped — exactly as before the fix."""
+    # (a) all-KVCache supersequence entry -> trimmable reuse retained
+    kv_cache = MemoryAwarePrefixCache(None, MemoryCacheConfig())
+    kv = KVCache()
+    fk = mx.random.normal((B, H, 40, D))
+    kv.update_and_fetch(fk, fk)
+    mx.eval(kv.keys, kv.values)
+    assert kv_cache.store(list(range(40)), [kv]) is True
+    result, remaining = kv_cache.fetch(list(range(15)))
+    assert result is not None
+    assert remaining == []
+    assert kv_cache._last_match_type == "supersequence"
+
+    # (b) rotated RotatingKVCache -> still classified non-trimmable / skipped
+    rot = RotatingKVCache(max_size=W, keep=0)
+    rk = mx.random.normal((B, H, W + 8, D))
+    rot.update_and_fetch(rk, rk)
+    assert rot.is_trimmable() is False
+    assert _layer_forbids_trim(rot) is True
+    assert _cache_has_non_trimmable([KVCache(), rot]) is True

--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -1152,12 +1152,15 @@ def _needs_kv_trim(layer: Any) -> bool:
 # known recurrent-state cache classes. A denylist (not an allowlist of KV
 # classes) is deliberate: it keeps the dict path consistent with the
 # conservative object-path default — an UNKNOWN or new trimmable KV class
-# (``RotatingKVCache`` / ``ChunkedKVCache`` / ``ConcatenateKVCache`` / a future
-# addition) stays cacheable (status quo) instead of being wrongly dropped and
-# regressing prefix reuse for dense / sliding-window models. Only classes that
-# are affirmatively recurrent-state (``ArraysCache`` and Mamba-style aliases)
-# are dropped. Names are matched leniently (substring) so vendor-suffixed
-# variants (``MambaCache`` etc.) are also caught.
+# (``RotatingKVCache`` or a future addition) stays cacheable (status quo)
+# instead of being wrongly dropped and regressing prefix reuse for dense /
+# sliding-window models. Only classes that are affirmatively recurrent-state
+# (``ArraysCache`` and Mamba-style aliases) are dropped here; the two known
+# trim-unsafe "trimmable liar" classes (``ChunkedKVCache`` /
+# ``ConcatenateKVCache``) are handled separately by the
+# ``_TRIM_UNSAFE_CACHE_CLASSES`` gate below. Names are matched leniently
+# (substring) so vendor-suffixed variants (``MambaCache`` etc.) are also
+# caught.
 _RECURRENT_STATE_CACHE_CLASSES = frozenset({"ArraysCache", "MambaCache"})
 
 
@@ -1168,6 +1171,96 @@ def _class_name_is_recurrent(class_name: str) -> bool:
     # Lenient substring match for vendor/variant names (e.g. "MambaCache2",
     # "GatedDeltaNetArraysCache"). "KVCache" etc. never contain these tokens.
     return any(marker in class_name for marker in _RECURRENT_STATE_CACHE_CLASSES)
+
+
+# ---------------------------------------------------------------------------
+# Trim-unsafe "trimmable liar" layer gate — sliding-window prefix-reuse lock
+# ---------------------------------------------------------------------------
+# A stored cache is safe to reuse on a TRIM-REQUIRING match path
+# (supersequence-with-excess / LCP) only if trimming it back to a shorter
+# prefix and then continuing reconstructs byte-identical KV to a cold prefill
+# of that prefix. The reuse gates read that off ``is_trimmable()``:
+# ``RotatingKVCache.is_trimmable()`` is rotation-aware (returns False once the
+# ring has rotated and the front has been overwritten), so the gate already
+# refuses it correctly (see ``test_sliding_window_prefix_reuse``).
+#
+# Two mlx-lm cache classes LIE — ``is_trimmable()`` returns True
+# unconditionally, yet a trim-then-continue does NOT reconstruct correct KV:
+#   * ``ChunkedKVCache`` (a ``KVCache`` subclass) DROPS front history via
+#     ``maybe_trim_front()`` (keeps only the last ``chunk_size`` slots and
+#     advances ``start_position``). Trimming a front-dropped instance back to
+#     a prefix shorter than ``start_position`` slices past discarded tokens →
+#     wrong KV; ``_trim_cache_offset`` even rebuilds it as a plain ``KVCache``
+#     whose offset no longer aligns with the retained window.
+#   * ``ConcatenateKVCache`` ``trim(n)`` only decrements ``offset`` WITHOUT
+#     slicing ``keys``/``values``; the next ``update_and_fetch`` concatenates
+#     onto the un-trimmed buffer, so the "trimmed" tokens resurface in the
+#     continuation → wrong KV.
+# Neither is reachable by a currently-supported family: ``ChunkedKVCache`` is
+# used only by ``mlx_lm/models/llama4.py`` (not in ``aliases.json``) and
+# ``ConcatenateKVCache`` only as a transient KV-reuse scratch inside
+# ``afm7.py`` (whose ``make_cache`` persists only ``KVCache``; also not in
+# ``aliases.json``). This denylist is therefore DEFENSE-IN-DEPTH for a latent
+# gap, not a live-bug fix, and over-classifying (treat as non-trimmable) is
+# always safe: it only ever SKIPS reuse (falling back to a correct full
+# prefill), it never corrupts. Supported KV classes (``KVCache`` /
+# ``RotatingKVCache`` / ``QuantizedKVCache`` / ``ArraysCache``) are NOT listed,
+# so their behavior is byte-for-byte unchanged. Names are matched leniently
+# (substring) like the recurrent denylist so vendor-suffixed variants are also
+# caught; both tokens are strictly longer than the safe ``KVCache`` name, so a
+# plain ``KVCache`` / ``RotatingKVCache`` can never match.
+_TRIM_UNSAFE_CACHE_CLASSES = frozenset({"ChunkedKVCache", "ConcatenateKVCache"})
+
+
+def _class_name_lies_about_trim(class_name: str) -> bool:
+    """True if ``class_name`` names a trim-unsafe "trimmable liar" cache — one
+    whose ``is_trimmable()`` returns True but which cannot be safely trimmed
+    back to a prefix (see ``_TRIM_UNSAFE_CACHE_CLASSES``)."""
+    if class_name in _TRIM_UNSAFE_CACHE_CLASSES:
+        return True
+    return any(marker in class_name for marker in _TRIM_UNSAFE_CACHE_CLASSES)
+
+
+def _layer_is_trim_liar(layer: Any) -> bool:
+    """True if ``layer`` is a trim-unsafe "trimmable liar" cache class.
+
+    Handles both live mlx-lm cache objects (matched on ``type(layer).__name__``)
+    and the dict-form extracted states used on the block-aware path (matched on
+    ``layer["class_name"]``). Classification is by class NAME only — a
+    ``ChunkedKVCache`` is unsafe to trim-reuse whether or not it has
+    front-dropped yet, so there is never a need to inspect ``start_position``
+    (over-classify = safe, it only ever skips reuse). Shared by the store-side
+    ``_layer_is_non_trimmable`` and the fetch-side ``_layer_forbids_trim`` so
+    every reuse gate agrees on these classes.
+    """
+    if layer is None:
+        return False
+    if isinstance(layer, dict):
+        class_name = layer.get("class_name")
+        if not class_name:
+            return False
+        return _class_name_lies_about_trim(class_name)
+    return _class_name_lies_about_trim(type(layer).__name__)
+
+
+def _layer_forbids_trim(layer: Any) -> bool:
+    """Fetch-side predicate: True if ``layer`` must NOT be trimmed on a
+    trim-requiring reuse path (supersequence-with-excess / LCP).
+
+    Combines the shared trim-liar denylist (``_layer_is_trim_liar``) with the
+    EXACT pre-existing inline classification used at the two fetch sites: a
+    layer exposing an ``is_trimmable`` method is non-trimmable iff it returns
+    False; a layer WITHOUT one is non-trimmable iff it also lacks a ``trim``
+    method. That ``hasattr(layer, "trim")`` fallback is preserved verbatim — it
+    differs from the store-side ``_layer_is_non_trimmable`` False fallback by
+    design (fetch-path test doubles such as ``MockKVCache`` depend on it), so
+    the two are intentionally NOT unified.
+    """
+    if _layer_is_trim_liar(layer):
+        return True
+    if hasattr(layer, "is_trimmable"):
+        return not layer.is_trimmable()
+    return not hasattr(layer, "trim")
 
 
 def _layer_is_non_trimmable(layer: Any) -> bool:
@@ -1191,9 +1284,21 @@ def _layer_is_non_trimmable(layer: Any) -> bool:
       * dict-form extracted states (block-aware path) — matched on
         ``class_name`` against the recurrent-state DENYLIST (unknown/new KV
         classes stay cacheable).
+
+    Independently of the above, a trim-unsafe "trimmable liar" class
+    (``ChunkedKVCache`` / ``ConcatenateKVCache`` — see
+    ``_TRIM_UNSAFE_CACHE_CLASSES``) is ALSO reported non-trimmable in both
+    forms, so a stored entry containing one is dropped at store time (default)
+    and never lands on a reuse path that would later trim it into corruption.
     """
     if layer is None:
         return False
+    # Trim-unsafe liar classes report is_trimmable()==True but corrupt on a
+    # trim-then-continue; classify them non-trimmable here (covers both the
+    # live-object and dict forms) so store never retains them for a trimming
+    # reuse path. Checked first so it wins over the inherited is_trimmable().
+    if _layer_is_trim_liar(layer):
+        return True
     if isinstance(layer, dict):
         class_name = layer.get("class_name")
         if not class_name:
@@ -1632,14 +1737,7 @@ class MemoryAwarePrefixCache:
             n_requested = len(tokens)
             excess = n_cached - n_requested
 
-            has_non_trimmable = any(
-                not (
-                    lc.is_trimmable()
-                    if hasattr(lc, "is_trimmable")
-                    else hasattr(lc, "trim")
-                )
-                for lc in best_super.cache
-            )
+            has_non_trimmable = any(_layer_forbids_trim(lc) for lc in best_super.cache)
 
             if excess > 0 and has_non_trimmable:
                 logger.debug(
@@ -1712,12 +1810,7 @@ class MemoryAwarePrefixCache:
             excess = len(best_lcp_entry.tokens) - best_lcp_length
 
             has_non_trimmable = any(
-                not (
-                    lc.is_trimmable()
-                    if hasattr(lc, "is_trimmable")
-                    else hasattr(lc, "trim")
-                )
-                for lc in best_lcp_entry.cache
+                _layer_forbids_trim(lc) for lc in best_lcp_entry.cache
             )
             logger.debug(
                 f"[cache_fetch] LCP candidate: lcp={best_lcp_length} "

--- a/vllm_mlx/prefix_cache.py
+++ b/vllm_mlx/prefix_cache.py
@@ -29,6 +29,17 @@ from .paged_cache import BlockTable, PagedCacheManager
 logger = logging.getLogger(__name__)
 
 
+# Cache classes whose ``is_trimmable()`` returns True unconditionally but which
+# corrupt on a trim-then-continue (``ChunkedKVCache`` drops front history via
+# ``maybe_trim_front`` + ``start_position``; ``ConcatenateKVCache.trim`` never
+# slices its buffers). The canonical denylist + rationale live in
+# ``memory_cache._TRIM_UNSAFE_CACHE_CLASSES``; this legacy trie cache keeps a
+# self-contained mirror so ``_can_trim_cache`` refuses them too (over-classify
+# = safe, only ever skips reuse). Neither is reachable by a supported family
+# (llama4 / afm7, not in ``aliases.json``) — defense-in-depth for a latent gap.
+_TRIM_UNSAFE_CACHE_CLASSES = frozenset({"ChunkedKVCache", "ConcatenateKVCache"})
+
+
 @dataclass
 class CacheEntry:
     """Entry in the prefix cache."""
@@ -324,13 +335,25 @@ class PrefixCacheManager:
                 del parent[tok]
 
     def _can_trim_cache(self, prompt_cache: list[Any]) -> bool:
-        """Check if all cache layers can be trimmed."""
+        """Check if all cache layers can be trimmed.
+
+        A trim-unsafe "trimmable liar" layer (``ChunkedKVCache`` /
+        ``ConcatenateKVCache``) reports ``is_trimmable()==True`` but would
+        corrupt on ``_trim_cache`` -> ``cache.trim()``, so it is treated as
+        NOT trimmable here (falls through to a full prefill).
+        """
         if not prompt_cache:
             return False
-        return all(
-            c.is_trimmable() if hasattr(c, "is_trimmable") else hasattr(c, "trim")
-            for c in prompt_cache
-        )
+        for c in prompt_cache:
+            name = type(c).__name__
+            if any(marker in name for marker in _TRIM_UNSAFE_CACHE_CLASSES):
+                return False
+            trimmable = (
+                c.is_trimmable() if hasattr(c, "is_trimmable") else hasattr(c, "trim")
+            )
+            if not trimmable:
+                return False
+        return True
 
     def _trim_cache(self, prompt_cache: list[Any], num_tokens: int) -> list[Any]:
         """Trim cache by removing num_tokens from the end."""


### PR DESCRIPTION
## Summary

Closes two latent correctness gaps found auditing sliding-window (RotatingKVCache) prefix-cache reuse, plus a sibling instance of the same gap in the legacy trie cache. **All are defense-in-depth** — no reachable class is in `aliases.json`, so this is **not a live bug fix**, and the change has **ZERO behavior change for currently-supported models** (`KVCache` / `RotatingKVCache` / `QuantizedKVCache` / `ArraysCache`). The already-correct sliding-window gate (`RotatingKVCache.is_trimmable()` is rotation-aware) is untouched and stays green.

### GAP 1 — `ChunkedKVCache` / `ConcatenateKVCache` lie about trimmability (production gate)

`is_trimmable()` returns `True` **unconditionally** for both, yet a trim-then-continue does **not** reconstruct correct KV:

- **`ChunkedKVCache`** (a `KVCache` subclass) DROPS front history via `maybe_trim_front()` — it keeps only the last `chunk_size` slots and advances `start_position`. Trimming a front-dropped instance back to a prefix shorter than `start_position` slices past discarded tokens → wrong KV. Worse, `_trim_cache_offset` rebuilds it as a plain `KVCache` whose offset no longer aligns with the retained window (verified: the red run returns two plain `KVCache` objects for what was a `ChunkedKVCache`).
- **`ConcatenateKVCache`** — `trim(n)` only decrements `offset` and never slices `keys`/`values`; the next `update_and_fetch` concatenates onto the un-trimmed buffer, so the "trimmed" tokens **resurface** in the continuation (verified: `trim(2)` then append yields `[0,1,2,3,4,100,101]` instead of `[0,1,2,100,101]`).

Both were classified trimmable by the two inline fetch gates (supersequence-with-excess, LCP) **and** the store-side `_layer_is_non_trimmable` in `MemoryAwarePrefixCache`, so a front-dropped `ChunkedKVCache` would be allowed through an unsafe trim.

**Reachability:** `ChunkedKVCache` is used only by `mlx_lm/models/llama4.py`; `ConcatenateKVCache` only as a transient KV-reuse scratch inside `afm7.py` (whose `make_cache` persists only `KVCache`). Neither `llama4` nor `afm7` is in `aliases.json` → latent, not active.

**Fix (conservative, over-classify = safe — only ever SKIPS reuse, never corrupts):**
- Enumerated every `mlx_lm.models.cache` class and its trim/rotation/history behavior; `ChunkedKVCache` and `ConcatenateKVCache` are the only two liars. `RotatingKVCache` is honest (rotation-aware) and deliberately **not** listed (listing it would regress sliding-window reuse).
- New module-level `_TRIM_UNSAFE_CACHE_CLASSES = frozenset({"ChunkedKVCache", "ConcatenateKVCache"})` + shared `_layer_is_trim_liar(layer)` (handles live objects via `type(layer).__name__` and dict-form via `layer["class_name"]`, substring-lenient like the existing `_class_name_is_recurrent`).
- Two inline fetch-site `has_non_trimmable` computations routed through a new `_layer_forbids_trim(layer)` that **preserves the exact pre-existing `hasattr(layer,"trim")` fallback** and OR-s in the liar check.
- `_layer_is_non_trimmable` (store side) OR-s in the same liar check.
- **Intentional non-unification:** the fetch-side and store-side fallbacks for a layer lacking *both* `is_trimmable` and `trim` already differed before this PR (fetch → non-trimmable, store → cacheable). Fetch-path test doubles (`MockKVCache`) rely on the fetch fallback; store/concurrency tests rely on the store fallback (`store` drops non-trimmable entries by default). Unifying them would regress those tests, so all three sites share only the **liar** predicate, not the fallback. Documented in code.

### Sibling instance — `PrefixCacheManager._can_trim_cache` (legacy trie cache)

The legacy trie prefix cache (used when the memory-aware cache is disabled; instantiated at `scheduler.py`) had the identical lie: `_can_trim_cache` trusted `is_trimmable()`, then `_trim_cache` calls `cache.trim()`. Guarded with a self-contained mirror of `_TRIM_UNSAFE_CACHE_CLASSES` so it refuses the two liars too (falls through to a full prefill). Kept self-contained (no cross-module import) — it already owns a sibling `_SEQ_AXIS_KV_CLASSES`-style constant.

### GAP 2 — anchor `BlockAwarePrefixCache._SEQ_AXIS_KV_CLASSES` to ground truth (test-only)

The fail-closed allowlist protecting the experimental (default-OFF) block cache was only exercised by synthetic hardcoded class-name strings. Added a regression test that imports the REAL `mlx_lm` classes and asserts `KVCache.__name__` is allowlisted while `RotatingKVCache` / `ChunkedKVCache` / `QuantizedKVCache` / `ArraysCache` `__name__`s are not — so allowlist drift or an mlx-lm rename of the one hostable class becomes a red test. The docstring is explicit that a *same-name collision* by a future distinct class is out of reach of a name-based allowlist (guarding that needs weights/network — out of scope).

## Why

The in-memory prefix cache is the hot path for multi-turn / shared-system-prompt reuse. Its correctness rests on one invariant: *a stored cache can be trimmed back to a shorter prefix and continued to reproduce a cold prefill byte-for-byte.* That invariant is read off `is_trimmable()`. Two `mlx_lm` cache classes violate it while returning `True`, so the gate's trust in `is_trimmable()` is misplaced for them. Even though neither is reachable today (llama4/afm7 unsupported), the gate is exactly the kind of silent-corruption surface that must fail *closed*: over-classifying a liar as non-trimmable only ever costs a cache miss (a correct full prefill), whereas the status quo would serve wrong KV the moment such a family is added. The anchor test converts an implicit "the allowlist happens to be right" assumption into an explicit ground-truth-pinned guard.

## Test plan

- [x] New: front-dropped real `ChunkedKVCache` (`start_position > 0`, `is_trimmable()` lies `True`) is classified non-trimmable by `_layer_is_trim_liar` / `_layer_forbids_trim` / `_cache_has_non_trimmable`.
- [x] New: `MemoryAwarePrefixCache` fetch gate skips a stored front-dropped `ChunkedKVCache` entry via **supersequence-with-excess** → miss/full-prefill.
- [x] New: same via the **LCP** (divergent-suffix) path → miss/full-prefill.
- [x] New: regression guard — an all-`KVCache` supersequence entry is still trim-reused, a rotated `RotatingKVCache` is still skipped (no change).
- [x] New: dict-form `ChunkedKVCache` / `ConcatenateKVCache` entries dropped at store; `RotatingKVCache` / `QuantizedKVCache` stay cacheable (updated `test_dict_form_*`).
- [x] New: legacy `PrefixCacheManager._can_trim_cache` rejects a front-dropped `ChunkedKVCache` (KVCache stays trimmable, rotated `RotatingKVCache` honestly non-trimmable); `fetch_cache` on a longer stored liar entry falls through to a miss.
- [x] New: GAP 2 anchor — `_SEQ_AXIS_KV_CLASSES` pinned to real `mlx_lm` `__name__`s.
- [x] Red-green proof: with `_layer_is_trim_liar` (memory_cache) and `_TRIM_UNSAFE_CACHE_CLASSES` (prefix_cache) neutralized, the `ChunkedKVCache` tests fail (supersequence/LCP/longer-prefix return corrupt hits); pass with the fix. Regression guard + anchor stay green.
- [x] Existing sliding-window suite (7 tests) stays green.
- [x] Full related suites green under python3.12 / mlx-lm 0.31.3: `test_memory_cache`, `test_paged_cache`, `test_sliding_window_prefix_reuse`, `test_prefix_cache`, `test_prefix_cache_eviction`, `test_prefix_cache_pressure_eviction`, `test_prefix_cache_radix_e2e`, `test_hybrid_prefix_cache_auto_default`, `test_hybrid_prefix_cache_growth`, `test_turboquant`, `test_mllm_cache` — 310 passed.
- [x] `ruff check` + `ruff format` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
