### PR TITLE
feat(audio): add Qwen3-TTS CustomVoice with emotion control

### DIFF
--- a/tests/test_qwen3_tts_audio.py
+++ b/tests/test_qwen3_tts_audio.py
@@ -287,6 +287,34 @@ class TestQwen3TTSRoute:
         # Both shapes → registry default_voice (Serena), not Kokoro's af_heart.
         assert call["voice"] == "Serena"
 
+    @pytest.mark.parametrize(
+        "speaker",
+        # Every speaker the model's talker_config.spk_id carries — Chinese,
+        # English, and the README-undocumented Japanese (Ono_Anna) and
+        # Korean (Sohee). Each must pass route voice validation, not 400.
+        [
+            "Vivian",
+            "Serena",
+            "Uncle_Fu",
+            "Dylan",
+            "Eric",
+            "Ryan",
+            "Aiden",
+            "Ono_Anna",
+            "Sohee",
+        ],
+    )
+    def test_all_documented_speakers_accepted(self, monkeypatch, speaker):
+        client = _mount(monkeypatch)
+        resp = client.post(
+            "/v1/audio/speech",
+            json={"model": "qwen3-tts", "input": "测试。", "voice": speaker},
+        )
+        assert resp.status_code == 200, resp.text
+        (engine,) = _RecordingEngine.instances
+        (call,) = engine.generate_calls
+        assert call["voice"] == speaker
+
     def test_unknown_voice_rejected_with_speaker_list(self, monkeypatch):
         client = _mount(monkeypatch)
         resp = client.post(

--- a/tests/test_qwen3_tts_audio.py
+++ b/tests/test_qwen3_tts_audio.py
@@ -83,17 +83,28 @@ class TestQwen3TTSRegistry:
 # ---------------------------------------------------------------------------
 
 
+_UNSET = object()
+
+
 class _CapturingModel:
-    """Fake mlx_audio model: records the kwargs ``generate`` was called
-    with and yields one result carrying a tiny audio buffer."""
+    """Fake mlx_audio model mirroring the real Qwen3-TTS ``generate``
+    keyword surface (text/voice/speed/lang_code/instruct). An explicit
+    signature — rather than a catch-all ``**kwargs`` — means the engine
+    passing a keyword the real model doesn't accept raises ``TypeError``
+    here instead of silently passing the test. ``instruct`` uses a sentinel
+    default so a call is recorded as carrying it ONLY when actually passed,
+    letting the tests assert conditional forwarding."""
 
     def __init__(self):
         self.calls: list[dict] = []
 
-    def generate(self, **kwargs):
+    def generate(self, *, text, voice=None, speed=1.0, lang_code=None, instruct=_UNSET):
         import numpy as np
 
-        self.calls.append(kwargs)
+        rec = {"text": text, "voice": voice, "speed": speed, "lang_code": lang_code}
+        if instruct is not _UNSET:
+            rec["instruct"] = instruct
+        self.calls.append(rec)
         result = types.SimpleNamespace(
             audio=np.zeros(240, dtype=np.float32), sample_rate=24000
         )

--- a/tests/test_qwen3_tts_audio.py
+++ b/tests/test_qwen3_tts_audio.py
@@ -228,72 +228,67 @@ def _mount(monkeypatch):
     # Cold-start voice path: force snapshot enumeration to empty so the
     # route uses the static Qwen3 speaker list (matches a fresh install).
     monkeypatch.setattr(tts_mod, "_list_snapshot_voices", lambda _n: [])
-    audio_route._tts_engine = None
+    # Route the module-global engine cache through monkeypatch so teardown
+    # restores the true original singleton — a direct assignment would leak
+    # our stub into later audio tests and make them order-dependent.
+    monkeypatch.setattr(audio_route, "_tts_engine", None)
 
     app = FastAPI()
     app.include_router(audio_route.router)
     install_exception_handlers(app)
     cfg = get_config()
-    saved = cfg.api_key
-    cfg.api_key = None
-    monkeypatch.setattr(cfg, "api_key", None, raising=False)
+    # monkeypatch captures the REAL api_key and restores it on teardown;
+    # setting it directly first would make monkeypatch record ``None`` as
+    # the "original" and leak auth-disabled config into later tests.
+    monkeypatch.setattr(cfg, "api_key", None)
     client = TestClient(app)
-    return client, saved, cfg
+    return client
 
 
 class TestQwen3TTSRoute:
     def test_speech_forwards_instructions_as_instruct(self, monkeypatch):
-        client, saved, cfg = _mount(monkeypatch)
-        try:
-            resp = client.post(
-                "/v1/audio/speech",
-                json={
-                    "model": "qwen3-tts",
-                    "input": "他被诸葛亮压了一辈子。",
-                    "voice": "Serena",
-                    "instructions": "悬疑而低沉，逐渐激昂。",
-                },
-            )
-            assert resp.status_code == 200, resp.text
-            assert resp.headers["content-type"] == "audio/wav"
-            (engine,) = _RecordingEngine.instances
-            assert engine.model_name == CUSTOMVOICE_BF16
-            (call,) = engine.generate_calls
-            assert call["voice"] == "Serena"
-            assert call["instruct"] == "悬疑而低沉，逐渐激昂。"
-        finally:
-            cfg.api_key = saved
+        client = _mount(monkeypatch)
+        resp = client.post(
+            "/v1/audio/speech",
+            json={
+                "model": "qwen3-tts",
+                "input": "他被诸葛亮压了一辈子。",
+                "voice": "Serena",
+                "instructions": "悬疑而低沉，逐渐激昂。",
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.headers["content-type"] == "audio/wav"
+        (engine,) = _RecordingEngine.instances
+        assert engine.model_name == CUSTOMVOICE_BF16
+        (call,) = engine.generate_calls
+        assert call["voice"] == "Serena"
+        assert call["instruct"] == "悬疑而低沉，逐渐激昂。"
 
     def test_omitted_voice_resolves_to_registry_default(self, monkeypatch):
-        client, saved, cfg = _mount(monkeypatch)
-        try:
-            resp = client.post(
-                "/v1/audio/speech",
-                json={"model": "qwen3-tts", "input": "你好世界。"},
-            )
-            assert resp.status_code == 200, resp.text
-            (engine,) = _RecordingEngine.instances
-            (call,) = engine.generate_calls
-            # Voice omitted → registry default_voice, not Kokoro's af_heart.
-            assert call["voice"] == "Serena"
-        finally:
-            cfg.api_key = saved
+        client = _mount(monkeypatch)
+        resp = client.post(
+            "/v1/audio/speech",
+            json={"model": "qwen3-tts", "input": "你好世界。"},
+        )
+        assert resp.status_code == 200, resp.text
+        (engine,) = _RecordingEngine.instances
+        (call,) = engine.generate_calls
+        # Voice omitted → registry default_voice, not Kokoro's af_heart.
+        assert call["voice"] == "Serena"
 
     def test_unknown_voice_rejected_with_speaker_list(self, monkeypatch):
-        client, saved, cfg = _mount(monkeypatch)
-        try:
-            resp = client.post(
-                "/v1/audio/speech",
-                json={
-                    "model": "qwen3-tts",
-                    "input": "hi",
-                    "voice": "af_heart",  # a Kokoro voice, invalid for qwen3
-                },
-            )
-            assert resp.status_code == 400, resp.text
-            body = resp.json()
-            assert body["error"]["code"] == "invalid_voice"
-            # The envelope should advertise a real Qwen3 speaker.
-            assert "Serena" in body["error"]["message"]
-        finally:
-            cfg.api_key = saved
+        client = _mount(monkeypatch)
+        resp = client.post(
+            "/v1/audio/speech",
+            json={
+                "model": "qwen3-tts",
+                "input": "hi",
+                "voice": "af_heart",  # a Kokoro voice, invalid for qwen3
+            },
+        )
+        assert resp.status_code == 400, resp.text
+        body = resp.json()
+        assert body["error"]["code"] == "invalid_voice"
+        # The envelope should advertise a real Qwen3 speaker.
+        assert "Serena" in body["error"]["message"]

--- a/tests/test_qwen3_tts_audio.py
+++ b/tests/test_qwen3_tts_audio.py
@@ -265,16 +265,26 @@ class TestQwen3TTSRoute:
         assert call["voice"] == "Serena"
         assert call["instruct"] == "悬疑而低沉，逐渐激昂。"
 
-    def test_omitted_voice_resolves_to_registry_default(self, monkeypatch):
+    @pytest.mark.parametrize(
+        "body",
+        [
+            # Voice omitted entirely (Pydantic default af_heart never reaches
+            # the engine — the omitted-field resolver maps it to the registry
+            # default).
+            {"model": "qwen3-tts", "input": "你好世界。"},
+            # Explicit OpenAI ``"default"`` sentinel (what SDKs emit when the
+            # caller doesn't pick a voice) — the same resolution path.
+            {"model": "qwen3-tts", "input": "你好世界。", "voice": "default"},
+        ],
+        ids=["omitted", "explicit-default"],
+    )
+    def test_default_voice_resolves_to_registry_default(self, monkeypatch, body):
         client = _mount(monkeypatch)
-        resp = client.post(
-            "/v1/audio/speech",
-            json={"model": "qwen3-tts", "input": "你好世界。"},
-        )
+        resp = client.post("/v1/audio/speech", json=body)
         assert resp.status_code == 200, resp.text
         (engine,) = _RecordingEngine.instances
         (call,) = engine.generate_calls
-        # Voice omitted → registry default_voice, not Kokoro's af_heart.
+        # Both shapes → registry default_voice (Serena), not Kokoro's af_heart.
         assert call["voice"] == "Serena"
 
     def test_unknown_voice_rejected_with_speaker_list(self, monkeypatch):

--- a/tests/test_qwen3_tts_audio.py
+++ b/tests/test_qwen3_tts_audio.py
@@ -1,0 +1,299 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Qwen3-TTS (CustomVoice) audio support.
+
+Adds Alibaba's Qwen3-TTS 1.7B CustomVoice to the TTS lane: multilingual
+predefined speakers (Chinese: Vivian/Serena/Uncle_Fu/Dylan/Eric, English:
+Ryan/Aiden) with emotion/style control via the OpenAI ``instructions``
+field (mapped to the engine's ``instruct`` argument).
+
+These tests are hermetic — no weights, no network. They fake the
+``mlx_audio`` boundary and pin the contract:
+
+* the ``qwen3-tts`` aliases resolve through the central registry to the
+  CustomVoice bf16 repo with ``family="qwen3_tts"``;
+* ``TTSEngine`` detects the family and its voice list is the documented
+  speaker set;
+* ``generate`` forwards ``instruct`` AND uses ``lang_code="auto"`` for
+  Qwen3 (never Kokoro's single-letter ``"a"``), and does NOT leak
+  ``instruct`` into families that have no emotion control;
+* the route validates the speaker set, resolves the omitted / ``default``
+  voice to the registry ``default_voice`` (``Serena``), and threads the
+  ``instructions`` field down to the engine.
+"""
+
+from __future__ import annotations
+
+import importlib.machinery
+import sys
+import types
+
+import pytest
+
+CUSTOMVOICE_BF16 = "mlx-community/Qwen3-TTS-12Hz-1.7B-CustomVoice-bf16"
+
+
+# ---------------------------------------------------------------------------
+# A) Registry resolution
+# ---------------------------------------------------------------------------
+
+
+class TestQwen3TTSRegistry:
+    @pytest.mark.parametrize(
+        "alias,expected_hf_id",
+        [
+            ("qwen3-tts", CUSTOMVOICE_BF16),
+            ("qwen3-tts-customvoice", CUSTOMVOICE_BF16),
+            ("qwen3-tts-6bit", "mlx-community/Qwen3-TTS-12Hz-1.7B-CustomVoice-6bit"),
+            ("qwen3-tts-4bit", "mlx-community/Qwen3-TTS-12Hz-1.7B-CustomVoice-4bit"),
+            # Case-insensitive: docs/SDKs mix case off the upstream repo.
+            ("Qwen3-TTS", CUSTOMVOICE_BF16),
+        ],
+    )
+    def test_alias_resolves(self, alias, expected_hf_id):
+        from vllm_mlx.audio.registry import resolve_audio_alias
+
+        entry = resolve_audio_alias(alias)
+        assert entry is not None, f"{alias!r} did not resolve in the registry"
+        assert entry.type == "tts"
+        assert entry.family == "qwen3_tts"
+        assert entry.hf_id == expected_hf_id
+        assert entry.default_voice == "Serena"
+
+    def test_hf_id_reverse_lookup(self):
+        """The full HF id maps back to the qwen3_tts entry so ``serve
+        <hf-id>`` forks into audio mode like the short alias does."""
+        from vllm_mlx.audio.registry import resolve_audio_alias
+
+        entry = resolve_audio_alias(CUSTOMVOICE_BF16)
+        assert entry is not None and entry.family == "qwen3_tts"
+
+    def test_registered_default_voice_is_a_real_speaker(self):
+        """The registry ``default_voice`` MUST be in the served voice list
+        or the cold-start / voice-omitted path 400s on a value the server
+        itself chose."""
+        from vllm_mlx.audio.registry import resolve_audio_alias
+        from vllm_mlx.audio.tts import QWEN3_TTS_VOICES
+
+        entry = resolve_audio_alias("qwen3-tts")
+        assert entry.default_voice in QWEN3_TTS_VOICES
+
+
+# ---------------------------------------------------------------------------
+# B) Engine — family detection, voice list, emotion-aware generate
+# ---------------------------------------------------------------------------
+
+
+class _CapturingModel:
+    """Fake mlx_audio model: records the kwargs ``generate`` was called
+    with and yields one result carrying a tiny audio buffer."""
+
+    def __init__(self):
+        self.calls: list[dict] = []
+
+    def generate(self, **kwargs):
+        import numpy as np
+
+        self.calls.append(kwargs)
+        result = types.SimpleNamespace(
+            audio=np.zeros(240, dtype=np.float32), sample_rate=24000
+        )
+        return iter([result])
+
+
+def _qwen3_engine():
+    """A loaded ``TTSEngine`` for the Qwen3 CustomVoice repo whose model is
+    the capturing fake (no weights, no network)."""
+    from vllm_mlx.audio.tts import TTSEngine
+
+    engine = TTSEngine(CUSTOMVOICE_BF16)
+    engine.model = _CapturingModel()
+    engine._loaded = True
+    return engine
+
+
+class TestQwen3TTSEngine:
+    def test_family_detected(self):
+        assert _qwen3_engine()._model_family == "qwen3_tts"
+
+    def test_get_voices_is_speaker_set(self):
+        from vllm_mlx.audio.tts import QWEN3_TTS_VOICES
+
+        assert _qwen3_engine().get_voices() == list(QWEN3_TTS_VOICES)
+
+    def test_generate_forwards_instruct_and_auto_lang(self):
+        engine = _qwen3_engine()
+        engine.generate("你好", voice="Serena", instruct="悬疑而低沉")
+        (call,) = engine.model.calls
+        assert call["voice"] == "Serena"
+        assert call["instruct"] == "悬疑而低沉"
+        # Qwen3 auto-detects language; forwarding Kokoro's "a" would
+        # mis-hint it.
+        assert call["lang_code"] == "auto"
+
+    def test_generate_omits_instruct_when_absent(self):
+        engine = _qwen3_engine()
+        engine.generate("你好", voice="Serena")
+        (call,) = engine.model.calls
+        assert "instruct" not in call
+
+    def test_instruct_not_leaked_to_kokoro_family(self):
+        """A Kokoro engine handed ``instruct`` (e.g. a client sending
+        ``instructions`` to a non-emotion model) must NOT forward it — the
+        Kokoro path has no such kwarg and would raise, and its lang_code
+        stays the single-letter form."""
+        from vllm_mlx.audio.tts import TTSEngine
+
+        engine = TTSEngine("mlx-community/Kokoro-82M-bf16")
+        engine.model = _CapturingModel()
+        engine._loaded = True
+        engine.generate("hello", voice="af_heart", instruct="cheerful")
+        (call,) = engine.model.calls
+        assert "instruct" not in call
+        assert call["lang_code"] == "a"
+
+
+# ---------------------------------------------------------------------------
+# C) Route — voice validation + instructions plumbing
+# ---------------------------------------------------------------------------
+
+
+def _install_fake_mlx_audio(monkeypatch):
+    """Minimal fake so the TTS-lane probe passes without the real extra."""
+    fake = types.ModuleType("mlx_audio")
+    fake.__path__ = []
+    fake.__spec__ = importlib.machinery.ModuleSpec(
+        "mlx_audio", loader=None, is_package=True
+    )
+    fake_tts = types.ModuleType("mlx_audio.tts")
+    fake_tts.__path__ = []
+    fake_tts.__spec__ = importlib.machinery.ModuleSpec(
+        "mlx_audio.tts", loader=None, is_package=True
+    )
+    monkeypatch.setitem(sys.modules, "mlx_audio", fake)
+    monkeypatch.setitem(sys.modules, "mlx_audio.tts", fake_tts)
+
+
+class _RecordingEngine:
+    """No-op TTSEngine stub that records the generate() kwargs and returns
+    a real WAV via the actual encoder."""
+
+    instances: list[_RecordingEngine] = []
+
+    def __init__(self, model_name: str):
+        self.model_name = model_name
+        self.generate_calls: list[dict] = []
+        _RecordingEngine.instances.append(self)
+
+    def load(self):
+        pass
+
+    def generate(self, text, voice="af_heart", speed=1.0, instruct=None):
+        import numpy as np
+
+        self.generate_calls.append(
+            {"text": text, "voice": voice, "speed": speed, "instruct": instruct}
+        )
+        from vllm_mlx.audio.tts import AudioOutput
+
+        return AudioOutput(
+            audio=np.zeros(240, dtype=np.float32), sample_rate=24000, duration=0.01
+        )
+
+    # Bound to the REAL ``TTSEngine.to_bytes`` in ``_mount`` BEFORE the
+    # monkeypatch rebinds ``tts_mod.TTSEngine`` to this stub — going
+    # through the patched attribute would recurse forever.
+    _real_to_bytes = None
+
+    def to_bytes(self, audio, format="wav"):
+        return type(self)._real_to_bytes(self, audio, format=format)
+
+
+def _mount(monkeypatch):
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from vllm_mlx.audio import probe as probe_mod
+    from vllm_mlx.audio import tts as tts_mod
+    from vllm_mlx.config import get_config
+    from vllm_mlx.middleware.exception_handlers import install_exception_handlers
+    from vllm_mlx.routes import audio as audio_route
+
+    _RecordingEngine.instances = []
+    # Capture the REAL encoder before TTSEngine is rebound to the stub.
+    _RecordingEngine._real_to_bytes = tts_mod.TTSEngine.to_bytes
+    _install_fake_mlx_audio(monkeypatch)
+    monkeypatch.setattr(probe_mod, "require_mlx_audio_tts", lambda: None)
+    monkeypatch.setattr(probe_mod, "require_kokoro_runtime", lambda: None)
+    monkeypatch.setattr(tts_mod, "TTSEngine", _RecordingEngine)
+    # Cold-start voice path: force snapshot enumeration to empty so the
+    # route uses the static Qwen3 speaker list (matches a fresh install).
+    monkeypatch.setattr(tts_mod, "_list_snapshot_voices", lambda _n: [])
+    audio_route._tts_engine = None
+
+    app = FastAPI()
+    app.include_router(audio_route.router)
+    install_exception_handlers(app)
+    cfg = get_config()
+    saved = cfg.api_key
+    cfg.api_key = None
+    monkeypatch.setattr(cfg, "api_key", None, raising=False)
+    client = TestClient(app)
+    return client, saved, cfg
+
+
+class TestQwen3TTSRoute:
+    def test_speech_forwards_instructions_as_instruct(self, monkeypatch):
+        client, saved, cfg = _mount(monkeypatch)
+        try:
+            resp = client.post(
+                "/v1/audio/speech",
+                json={
+                    "model": "qwen3-tts",
+                    "input": "他被诸葛亮压了一辈子。",
+                    "voice": "Serena",
+                    "instructions": "悬疑而低沉，逐渐激昂。",
+                },
+            )
+            assert resp.status_code == 200, resp.text
+            assert resp.headers["content-type"] == "audio/wav"
+            (engine,) = _RecordingEngine.instances
+            assert engine.model_name == CUSTOMVOICE_BF16
+            (call,) = engine.generate_calls
+            assert call["voice"] == "Serena"
+            assert call["instruct"] == "悬疑而低沉，逐渐激昂。"
+        finally:
+            cfg.api_key = saved
+
+    def test_omitted_voice_resolves_to_registry_default(self, monkeypatch):
+        client, saved, cfg = _mount(monkeypatch)
+        try:
+            resp = client.post(
+                "/v1/audio/speech",
+                json={"model": "qwen3-tts", "input": "你好世界。"},
+            )
+            assert resp.status_code == 200, resp.text
+            (engine,) = _RecordingEngine.instances
+            (call,) = engine.generate_calls
+            # Voice omitted → registry default_voice, not Kokoro's af_heart.
+            assert call["voice"] == "Serena"
+        finally:
+            cfg.api_key = saved
+
+    def test_unknown_voice_rejected_with_speaker_list(self, monkeypatch):
+        client, saved, cfg = _mount(monkeypatch)
+        try:
+            resp = client.post(
+                "/v1/audio/speech",
+                json={
+                    "model": "qwen3-tts",
+                    "input": "hi",
+                    "voice": "af_heart",  # a Kokoro voice, invalid for qwen3
+                },
+            )
+            assert resp.status_code == 400, resp.text
+            body = resp.json()
+            assert body["error"]["code"] == "invalid_voice"
+            # The envelope should advertise a real Qwen3 speaker.
+            assert "Serena" in body["error"]["message"]
+        finally:
+            cfg.api_key = saved

--- a/tests/test_qwen3_tts_audio.py
+++ b/tests/test_qwen3_tts_audio.py
@@ -368,22 +368,39 @@ class TestQwen3TTSRoute:
         assert _RecordingEngine.instances[0].model_name.endswith("CustomVoice-bf16")
         assert _RecordingEngine.instances[1].model_name.endswith("CustomVoice-6bit")
 
-    def test_base_repo_rejected_with_actionable_error(self, monkeypatch):
-        """A raw Qwen3-TTS Base (voice-cloning-only) repo id must be
-        rejected up front, not fail opaquely deep in the engine."""
+    @pytest.mark.parametrize(
+        "model_id",
+        [
+            "mlx-community/Qwen3-TTS-12Hz-0.6B-Base-bf16",  # -Base- (middle)
+            "mlx-community/Qwen3-TTS-0.6B-Base",  # -Base at the very end
+            "someorg/Qwen3_TTS_0.6B_base_bf16",  # underscore delimiters
+        ],
+    )
+    def test_base_repo_rejected_with_actionable_error(self, monkeypatch, model_id):
+        """Any raw Qwen3-TTS Base (voice-cloning-only) repo id must be
+        rejected up front, not fail opaquely deep in the engine — the
+        ``base`` token is caught wherever it sits."""
         client = _mount(monkeypatch)
         resp = client.post(
             "/v1/audio/speech",
-            json={
-                "model": "mlx-community/Qwen3-TTS-12Hz-0.6B-Base-bf16",
-                "input": "hi",
-                "voice": "Serena",
-            },
+            json={"model": model_id, "input": "hi", "voice": "Serena"},
         )
         assert resp.status_code == 400, resp.text
         body = resp.json()
         assert body["error"]["code"] == "unsupported_model_variant"
         assert "CustomVoice" in body["error"]["message"]
+
+    def test_customvoice_org_prefix_not_misclassified_as_base(self, monkeypatch):
+        """An org name containing 'customvoice' must NOT suppress the Base
+        guard, and a CustomVoice repo must NOT be rejected — classification
+        is on the repo name's tokens, not the whole id."""
+        client = _mount(monkeypatch)
+        # Real CustomVoice repo → accepted (200), not Base-rejected.
+        resp = client.post(
+            "/v1/audio/speech",
+            json={"model": "qwen3-tts", "input": "hi", "voice": "Serena"},
+        )
+        assert resp.status_code == 200, resp.text
 
     def test_unknown_voice_rejected_with_speaker_list(self, monkeypatch):
         client = _mount(monkeypatch)

--- a/tests/test_qwen3_tts_audio.py
+++ b/tests/test_qwen3_tts_audio.py
@@ -365,8 +365,14 @@ class TestQwen3TTSRoute:
         assert r1.status_code == 200 and r2.status_code == 200
         # Two distinct engines were constructed, the second for the 6bit id.
         assert len(_RecordingEngine.instances) == 2
-        assert _RecordingEngine.instances[0].model_name.endswith("CustomVoice-bf16")
-        assert _RecordingEngine.instances[1].model_name.endswith("CustomVoice-6bit")
+        eng1, eng2 = _RecordingEngine.instances
+        assert eng1.model_name.endswith("CustomVoice-bf16")
+        assert eng2.model_name.endswith("CustomVoice-6bit")
+        # Crucially: each request synthesized on ITS OWN engine — the second
+        # request did NOT reuse the stale first engine. Each engine got
+        # exactly one generate call, carrying that request's text.
+        assert [c["text"] for c in eng1.generate_calls] == ["一。"]
+        assert [c["text"] for c in eng2.generate_calls] == ["二。"]
 
     @pytest.mark.parametrize(
         "model_id",
@@ -390,12 +396,27 @@ class TestQwen3TTSRoute:
         assert body["error"]["code"] == "unsupported_model_variant"
         assert "CustomVoice" in body["error"]["message"]
 
-    def test_customvoice_org_prefix_not_misclassified_as_base(self, monkeypatch):
-        """An org name containing 'customvoice' must NOT suppress the Base
-        guard, and a CustomVoice repo must NOT be rejected — classification
-        is on the repo name's tokens, not the whole id."""
+    def test_customvoice_org_prefix_does_not_suppress_base_guard(self, monkeypatch):
+        """A ``customvoice`` in the ORG segment must NOT suppress the Base
+        guard: classification is on the repo NAME's tokens, so a raw
+        ``customvoice-org/Qwen3-TTS-0.6B-Base`` id is still rejected. (A
+        whole-id substring check would wrongly accept it.)"""
         client = _mount(monkeypatch)
-        # Real CustomVoice repo → accepted (200), not Base-rejected.
+        resp = client.post(
+            "/v1/audio/speech",
+            json={
+                "model": "customvoice-org/Qwen3-TTS-0.6B-Base",
+                "input": "hi",
+                "voice": "Serena",
+            },
+        )
+        assert resp.status_code == 400, resp.text
+        assert resp.json()["error"]["code"] == "unsupported_model_variant"
+
+    def test_real_customvoice_repo_not_base_rejected(self, monkeypatch):
+        """The converse: an actual CustomVoice repo must NOT trip the Base
+        guard — it synthesizes normally."""
+        client = _mount(monkeypatch)
         resp = client.post(
             "/v1/audio/speech",
             json={"model": "qwen3-tts", "input": "hi", "voice": "Serena"},

--- a/tests/test_qwen3_tts_audio.py
+++ b/tests/test_qwen3_tts_audio.py
@@ -315,6 +315,29 @@ class TestQwen3TTSRoute:
         (call,) = engine.generate_calls
         assert call["voice"] == speaker
 
+    @pytest.mark.parametrize(
+        "sent,canonical",
+        [
+            ("serena", "Serena"),
+            ("SERENA", "Serena"),
+            ("ono_anna", "Ono_Anna"),
+            ("sohee", "Sohee"),
+        ],
+    )
+    def test_speaker_case_insensitive_normalized(self, monkeypatch, sent, canonical):
+        """Qwen3's engine matches speakers case-insensitively and the docs
+        mix case; the route must accept any case and hand the engine the
+        canonical spelling rather than 400."""
+        client = _mount(monkeypatch)
+        resp = client.post(
+            "/v1/audio/speech",
+            json={"model": "qwen3-tts", "input": "测试。", "voice": sent},
+        )
+        assert resp.status_code == 200, resp.text
+        (engine,) = _RecordingEngine.instances
+        (call,) = engine.generate_calls
+        assert call["voice"] == canonical
+
     def test_unknown_voice_rejected_with_speaker_list(self, monkeypatch):
         client = _mount(monkeypatch)
         resp = client.post(

--- a/tests/test_qwen3_tts_audio.py
+++ b/tests/test_qwen3_tts_audio.py
@@ -338,6 +338,42 @@ class TestQwen3TTSRoute:
         (call,) = engine.generate_calls
         assert call["voice"] == canonical
 
+    def test_engine_recreated_on_model_switch(self, monkeypatch):
+        """The process-global _tts_engine is keyed on model_name: a second
+        request for a different model must build a fresh engine, never
+        synthesize on the previously-cached one."""
+        client = _mount(monkeypatch)
+        r1 = client.post(
+            "/v1/audio/speech",
+            json={"model": "qwen3-tts", "input": "一。", "voice": "Serena"},
+        )
+        r2 = client.post(
+            "/v1/audio/speech",
+            json={"model": "qwen3-tts-6bit", "input": "二。", "voice": "Serena"},
+        )
+        assert r1.status_code == 200 and r2.status_code == 200
+        # Two distinct engines were constructed, the second for the 6bit id.
+        assert len(_RecordingEngine.instances) == 2
+        assert _RecordingEngine.instances[0].model_name.endswith("CustomVoice-bf16")
+        assert _RecordingEngine.instances[1].model_name.endswith("CustomVoice-6bit")
+
+    def test_base_repo_rejected_with_actionable_error(self, monkeypatch):
+        """A raw Qwen3-TTS Base (voice-cloning-only) repo id must be
+        rejected up front, not fail opaquely deep in the engine."""
+        client = _mount(monkeypatch)
+        resp = client.post(
+            "/v1/audio/speech",
+            json={
+                "model": "mlx-community/Qwen3-TTS-12Hz-0.6B-Base-bf16",
+                "input": "hi",
+                "voice": "Serena",
+            },
+        )
+        assert resp.status_code == 400, resp.text
+        body = resp.json()
+        assert body["error"]["code"] == "unsupported_model_variant"
+        assert "CustomVoice" in body["error"]["message"]
+
     def test_unknown_voice_rejected_with_speaker_list(self, monkeypatch):
         client = _mount(monkeypatch)
         resp = client.post(

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -2612,6 +2612,14 @@ class AudioSpeechRequest(BaseModel):
     # matches the documented contract.
     speed: float = Field(default=1.0, ge=0.25, le=4.0)
     response_format: str = "wav"
+    # OpenAI ``gpt-4o-mini-tts`` accepts an ``instructions`` field that
+    # steers the emotional delivery / speaking style ("Speak in a cheerful
+    # and positive tone."). We honour the same field name for spec
+    # compatibility and route it to engines that expose an emotion/style
+    # control — currently Qwen3-TTS CustomVoice (its ``instruct`` arg).
+    # Families with no such control ignore it, matching OpenAI's behaviour
+    # for voices that don't support styling. ``None`` = omitted.
+    instructions: str | None = None
 
     @model_validator(mode="before")
     @classmethod

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -2618,8 +2618,11 @@ class AudioSpeechRequest(BaseModel):
     # compatibility and route it to engines that expose an emotion/style
     # control — currently Qwen3-TTS CustomVoice (its ``instruct`` arg).
     # Families with no such control ignore it, matching OpenAI's behaviour
-    # for voices that don't support styling. ``None`` = omitted.
-    instructions: str | None = None
+    # for voices that don't support styling. ``None`` = omitted. Bounded to
+    # OpenAI's documented 4096-char ceiling so an oversized style prompt is
+    # rejected up front with the standard envelope rather than ballooning
+    # the generation.
+    instructions: str | None = Field(default=None, max_length=4096)
 
     @model_validator(mode="before")
     @classmethod

--- a/vllm_mlx/audio/aliases.json
+++ b/vllm_mlx/audio/aliases.json
@@ -97,6 +97,35 @@
     "notes": "Dia 1.6B multi-speaker dialogue TTS (4-bit). Best-effort — covered by the audio probe but mlx_audio support is experimental; report bugs upstream if synth fails."
   },
 
+  "qwen3-tts": {
+    "type": "tts",
+    "hf_id": "mlx-community/Qwen3-TTS-12Hz-1.7B-CustomVoice-bf16",
+    "family": "qwen3_tts",
+    "default_voice": "Serena",
+    "notes": "Alibaba Qwen3-TTS 1.7B CustomVoice (bf16). Multilingual predefined speakers (Chinese: Vivian, Serena, Uncle_Fu, Dylan, Eric; English: Ryan, Aiden) with emotion/style control via the OpenAI `instructions` field. The CustomVoice variant is used (not 0.6B-Base, which is voice-cloning-only and needs a reference clip)."
+  },
+  "qwen3-tts-customvoice": {
+    "type": "tts",
+    "hf_id": "mlx-community/Qwen3-TTS-12Hz-1.7B-CustomVoice-bf16",
+    "family": "qwen3_tts",
+    "default_voice": "Serena",
+    "notes": "Long-form alias for ``qwen3-tts`` — same HF id (1.7B CustomVoice bf16)."
+  },
+  "qwen3-tts-6bit": {
+    "type": "tts",
+    "hf_id": "mlx-community/Qwen3-TTS-12Hz-1.7B-CustomVoice-6bit",
+    "family": "qwen3_tts",
+    "default_voice": "Serena",
+    "notes": "6-bit quant of Qwen3-TTS 1.7B CustomVoice — smaller download, mild quality drop."
+  },
+  "qwen3-tts-4bit": {
+    "type": "tts",
+    "hf_id": "mlx-community/Qwen3-TTS-12Hz-1.7B-CustomVoice-4bit",
+    "family": "qwen3_tts",
+    "default_voice": "Serena",
+    "notes": "4-bit quant of Qwen3-TTS 1.7B CustomVoice — smallest download."
+  },
+
   "whisper": {
     "type": "stt",
     "hf_id": "mlx-community/whisper-large-v3-mlx",

--- a/vllm_mlx/audio/aliases.json
+++ b/vllm_mlx/audio/aliases.json
@@ -102,7 +102,7 @@
     "hf_id": "mlx-community/Qwen3-TTS-12Hz-1.7B-CustomVoice-bf16",
     "family": "qwen3_tts",
     "default_voice": "Serena",
-    "notes": "Alibaba Qwen3-TTS 1.7B CustomVoice (bf16). Multilingual predefined speakers (Chinese: Vivian, Serena, Uncle_Fu, Dylan, Eric; English: Ryan, Aiden) with emotion/style control via the OpenAI `instructions` field. The CustomVoice variant is used (not 0.6B-Base, which is voice-cloning-only and needs a reference clip)."
+    "notes": "Alibaba Qwen3-TTS 1.7B CustomVoice (bf16). Multilingual predefined speakers (Chinese: Vivian, Serena, Uncle_Fu, Dylan, Eric; English: Ryan, Aiden; Japanese: Ono_Anna; Korean: Sohee) matched case-insensitively, with emotion/style control via the OpenAI `instructions` field. The CustomVoice variant is used (not 0.6B-Base, which is voice-cloning-only and needs a reference clip)."
   },
   "qwen3-tts-customvoice": {
     "type": "tts",

--- a/vllm_mlx/audio/tts.py
+++ b/vllm_mlx/audio/tts.py
@@ -39,6 +39,23 @@ KOKORO_VOICES = [
 
 CHATTERBOX_VOICES = ["default"]  # Uses reference audio for voice
 
+# Qwen3-TTS CustomVoice predefined speakers. The CustomVoice repos ship
+# NO ``voices/`` snapshot dir (voices are baked-in named speakers, not
+# per-voice safetensors), so ``_list_snapshot_voices`` returns ``[]`` and
+# the route's ``_allowed_voices_for`` / ``get_voices`` fall back to this
+# static list. Names are the canonical capitalized speaker ids documented
+# in the upstream ``mlx_audio.tts.models.qwen3_tts`` README — Chinese
+# speakers first (the primary short-drama-dubbing use case), then English.
+QWEN3_TTS_VOICES = [
+    "Vivian",
+    "Serena",
+    "Uncle_Fu",
+    "Dylan",  # Beijing dialect
+    "Eric",  # Sichuan dialect
+    "Ryan",
+    "Aiden",
+]
+
 
 def _list_snapshot_voices(model_name: str) -> list[str]:
     """Return the safetensors voice files cached for ``model_name``.
@@ -226,6 +243,8 @@ class TTSEngine:
             return "csm"
         elif "cosyvoice" in name_lower:
             return "cosyvoice"
+        elif "qwen3-tts" in name_lower or "qwen3_tts" in name_lower:
+            return "qwen3_tts"
         else:
             return "kokoro"  # Default
 
@@ -254,6 +273,7 @@ class TTSEngine:
         voice: str = "af_heart",
         speed: float = 1.0,
         lang_code: str = "a",
+        instruct: str | None = None,
     ) -> AudioOutput:
         """
         Generate speech from text.
@@ -263,6 +283,14 @@ class TTSEngine:
             voice: Voice ID (model-specific)
             speed: Speech speed (0.5 to 2.0)
             lang_code: Language code (a=English, e=Spanish, f=French, etc.)
+                Kokoro-style single-letter code. Ignored by families that
+                auto-detect language (Qwen3-TTS).
+            instruct: Optional emotion/style instruction (e.g. "Very happy
+                and excited."). Only Qwen3-TTS CustomVoice honours this —
+                it maps to that engine's ``instruct`` argument and drives
+                the emotional delivery of the predefined speaker. Other
+                families ignore it (they have no emotion-control surface),
+                so passing it is a no-op there rather than an error.
 
         Returns:
             AudioOutput with audio data and metadata
@@ -276,12 +304,21 @@ class TTSEngine:
             audio_chunks = []
             sample_rate = 24000  # Default for most models
 
-            for result in self.model.generate(
-                text=text,
-                voice=voice,
-                speed=speed,
-                lang_code=lang_code,
-            ):
+            # Family-aware generate kwargs. Qwen3-TTS auto-detects the
+            # language (``lang_code="auto"``) and accepts an ``instruct``
+            # emotion/style argument the Kokoro-style path doesn't have;
+            # forwarding Kokoro's single-letter ``lang_code="a"`` to it
+            # would mis-hint the language. Every other family keeps the
+            # pre-existing call shape unchanged.
+            gen_kwargs: dict = {"text": text, "voice": voice, "speed": speed}
+            if self._model_family == "qwen3_tts":
+                gen_kwargs["lang_code"] = "auto"
+                if instruct:
+                    gen_kwargs["instruct"] = instruct
+            else:
+                gen_kwargs["lang_code"] = lang_code
+
+            for result in self.model.generate(**gen_kwargs):
                 audio_data = result.audio
                 if hasattr(result, "sample_rate"):
                     sample_rate = result.sample_rate
@@ -510,6 +547,8 @@ class TTSEngine:
             return KOKORO_VOICES
         elif self._model_family == "chatterbox":
             return CHATTERBOX_VOICES
+        elif self._model_family == "qwen3_tts":
+            return list(QWEN3_TTS_VOICES)
         else:
             return ["default"]
 

--- a/vllm_mlx/audio/tts.py
+++ b/vllm_mlx/audio/tts.py
@@ -43,9 +43,17 @@ CHATTERBOX_VOICES = ["default"]  # Uses reference audio for voice
 # NO ``voices/`` snapshot dir (voices are baked-in named speakers, not
 # per-voice safetensors), so ``_list_snapshot_voices`` returns ``[]`` and
 # the route's ``_allowed_voices_for`` / ``get_voices`` fall back to this
-# static list. Names are the canonical capitalized speaker ids documented
-# in the upstream ``mlx_audio.tts.models.qwen3_tts`` README — Chinese
-# speakers first (the primary short-drama-dubbing use case), then English.
+# static list.
+#
+# The AUTHORITATIVE speaker set is the model config's
+# ``talker_config.spk_id`` keys (see ``mlx_audio.tts.models.qwen3_tts``:
+# ``supported_speakers = list(config.talker_config.spk_id.keys())``), which
+# the engine matches case-INsensitively (``speaker.lower() in spk_id``).
+# The upstream README under-documents it (lists only the Chinese + English
+# speakers); the shipped ``1.7B-CustomVoice`` config actually carries nine,
+# including the Japanese ``ono_anna`` and Korean ``sohee`` — omitting those
+# would make the route 400 two valid voices. We list the canonical
+# capitalized display forms here, grouped Chinese → English → JA → KO.
 QWEN3_TTS_VOICES = [
     "Vivian",
     "Serena",
@@ -54,6 +62,8 @@ QWEN3_TTS_VOICES = [
     "Eric",  # Sichuan dialect
     "Ryan",
     "Aiden",
+    "Ono_Anna",  # Japanese
+    "Sohee",  # Korean
 ]
 
 

--- a/vllm_mlx/routes/audio.py
+++ b/vllm_mlx/routes/audio.py
@@ -1566,13 +1566,16 @@ async def create_speech(request: AudioSpeechRequest = Body(...)):
         # speaker-validation + generate path and fail deep in the engine
         # ("Must provide one of ref_audio or ref_mel") as an opaque 500.
         # Reject it up front with an actionable 400 pointing at CustomVoice.
-        # Classify on the REPO NAME (last path component) with exact hyphen-
-        # delimited tokens, not a whole-id substring: an org like
+        # Classify on the REPO NAME (last path component), split into
+        # ``-``/``_``-delimited tokens, not a whole-id substring: an org like
         # ``customvoice-org/...`` or an unrelated ``base`` elsewhere in the
-        # path must not flip the decision.
+        # path must not flip the decision, and a ``base`` token must be
+        # caught wherever it sits (start/middle/end, hyphen or underscore
+        # delimited) — ``...-0.6B-Base``, ``..._base_bf16``, etc.
         _repo = model_name.rsplit("/", 1)[-1].lower()
+        _tokens = set(re.split(r"[-_]", _repo))
         _is_qwen3 = "qwen3-tts" in _repo or "qwen3_tts" in _repo
-        if _is_qwen3 and "-base-" in _repo and "customvoice" not in _repo:
+        if _is_qwen3 and "base" in _tokens and "customvoice" not in _tokens:
             raise HTTPException(
                 status_code=400,
                 detail={

--- a/vllm_mlx/routes/audio.py
+++ b/vllm_mlx/routes/audio.py
@@ -1559,6 +1559,35 @@ async def create_speech(request: AudioSpeechRequest = Body(...)):
         # handler body.
         model_name = _resolve_tts_model(model)
 
+        # Qwen3-TTS ships two shapes: CustomVoice (predefined speakers,
+        # reference-free — what we alias and support) and Base (voice-
+        # cloning ONLY, requires a reference clip). A caller passing a raw
+        # ``...-Base-...`` repo id would otherwise reach the CustomVoice
+        # speaker-validation + generate path and fail deep in the engine
+        # ("Must provide one of ref_audio or ref_mel") as an opaque 500.
+        # Reject it up front with an actionable 400 pointing at CustomVoice.
+        _name_lower = model_name.lower()
+        _is_qwen3 = "qwen3-tts" in _name_lower or "qwen3_tts" in _name_lower
+        if _is_qwen3 and "base" in _name_lower and "customvoice" not in _name_lower:
+            raise HTTPException(
+                status_code=400,
+                detail={
+                    "error": {
+                        "message": (
+                            f"model {model_name!r} is a Qwen3-TTS Base "
+                            "(voice-cloning-only) repo and needs a reference "
+                            "audio clip, which /v1/audio/speech does not "
+                            "provide. Use a CustomVoice repo (e.g. the "
+                            "`qwen3-tts` alias) for reference-free synthesis "
+                            "with a predefined speaker."
+                        ),
+                        "type": "invalid_request_error",
+                        "code": "unsupported_model_variant",
+                        "param": "model",
+                    }
+                },
+            )
+
         # R11-B-F3 (Bo 0.8.12 dogfood, PR #863): translate the literal
         # ``voice="default"`` to the registry's ``default_voice`` BEFORE
         # the allowlist check below. Pre-fix the obvious naive caller

--- a/vllm_mlx/routes/audio.py
+++ b/vllm_mlx/routes/audio.py
@@ -1447,6 +1447,7 @@ def _allowed_voices_for(model_name: str) -> list[str]:
     from ..audio.tts import (
         CHATTERBOX_VOICES,
         KOKORO_VOICES,
+        QWEN3_TTS_VOICES,
         _list_snapshot_voices,
     )
 
@@ -1464,6 +1465,13 @@ def _allowed_voices_for(model_name: str) -> list[str]:
         return list(KOKORO_VOICES)
     if "chatterbox" in name_lower:
         return list(CHATTERBOX_VOICES)
+    if "qwen3-tts" in name_lower or "qwen3_tts" in name_lower:
+        # Qwen3-TTS CustomVoice ships baked-in named speakers and no
+        # ``voices/`` snapshot dir, so the enumeration above always
+        # returns ``[]`` and we serve the documented speaker set. The
+        # registry ``default_voice`` (``Serena``) is a member of this
+        # list so the cold-start / voice-omitted path validates.
+        return list(QWEN3_TTS_VOICES)
     if "vibevoice" in name_lower:
         # Cold-start fallback for VibeVoice — the canonical English
         # default is ``en-Grace_woman`` (per the upstream repo's
@@ -1539,6 +1547,7 @@ async def create_speech(request: AudioSpeechRequest = Body(...)):
     voice = request.voice
     speed = request.speed
     response_format = request.response_format
+    instructions = request.instructions
 
     try:
         from ..audio.tts import TTSEngine, UnsupportedAudioFormatError
@@ -1620,7 +1629,15 @@ async def create_speech(request: AudioSpeechRequest = Body(...)):
             _tts_engine = TTSEngine(model_name)
             _tts_engine.load()
 
-        audio = _tts_engine.generate(input_text, voice=voice, speed=speed)
+        # Only forward ``instruct`` when the caller actually sent an
+        # ``instructions`` field. Passing ``instruct=None`` is a no-op for
+        # the real engine, but omitting the kwarg entirely keeps the call
+        # shape backward-compatible with any generate() that predates the
+        # emotion parameter (only Qwen3-TTS consumes it).
+        gen_kwargs = {"voice": voice, "speed": speed}
+        if instructions:
+            gen_kwargs["instruct"] = instructions
+        audio = _tts_engine.generate(input_text, **gen_kwargs)
         try:
             audio_bytes = _tts_engine.to_bytes(audio, format=response_format)
         except UnsupportedAudioFormatError as e:

--- a/vllm_mlx/routes/audio.py
+++ b/vllm_mlx/routes/audio.py
@@ -1596,6 +1596,15 @@ async def create_speech(request: AudioSpeechRequest = Body(...)):
         # the ``kokoro`` short alias — both go through the same model
         # family check.
         valid_voices = _allowed_voices_for(model_name)
+        # Qwen3-TTS matches speaker names case-INsensitively (its engine
+        # lowercases before the ``spk_id`` lookup) and the upstream docs mix
+        # case ("serena" vs "Serena"). Normalize a case-insensitive hit to
+        # the canonical spelling so ``serena`` / ``ono_anna`` aren't
+        # rejected as ``invalid_voice``; the engine then receives the
+        # canonical form. Other families keep exact-match validation.
+        if "qwen3-tts" in model_name.lower() or "qwen3_tts" in model_name.lower():
+            _canonical = {v.lower(): v for v in valid_voices}
+            voice = _canonical.get(voice.lower(), voice)
         if voice not in valid_voices:
             preview = ", ".join(valid_voices[:8])
             if len(valid_voices) > 8:

--- a/vllm_mlx/routes/audio.py
+++ b/vllm_mlx/routes/audio.py
@@ -1566,9 +1566,13 @@ async def create_speech(request: AudioSpeechRequest = Body(...)):
         # speaker-validation + generate path and fail deep in the engine
         # ("Must provide one of ref_audio or ref_mel") as an opaque 500.
         # Reject it up front with an actionable 400 pointing at CustomVoice.
-        _name_lower = model_name.lower()
-        _is_qwen3 = "qwen3-tts" in _name_lower or "qwen3_tts" in _name_lower
-        if _is_qwen3 and "base" in _name_lower and "customvoice" not in _name_lower:
+        # Classify on the REPO NAME (last path component) with exact hyphen-
+        # delimited tokens, not a whole-id substring: an org like
+        # ``customvoice-org/...`` or an unrelated ``base`` elsewhere in the
+        # path must not flip the decision.
+        _repo = model_name.rsplit("/", 1)[-1].lower()
+        _is_qwen3 = "qwen3-tts" in _repo or "qwen3_tts" in _repo
+        if _is_qwen3 and "-base-" in _repo and "customvoice" not in _repo:
             raise HTTPException(
                 status_code=400,
                 detail={


### PR DESCRIPTION
## Why
Chinese/emotional TTS is the #1 engine gap for a Mac-local content-production pipeline. The existing TTS families (Kokoro / VibeVoice / Chatterbox / VoxCPM / Dia) have no per-utterance emotion/style control — the core need for short-drama-style dubbing. Alibaba's **Qwen3-TTS CustomVoice** ships that control plus multilingual predefined speakers, and mlx_audio already carries the `qwen3_tts` model class, so it slots straight into the existing audio lane.

## What
- **aliases.json**: `qwen3-tts`, `qwen3-tts-customvoice`, `qwen3-tts-6bit`, `qwen3-tts-4bit` → the `mlx-community/Qwen3-TTS-12Hz-1.7B-CustomVoice-*` repos, `family=qwen3_tts`, `default_voice=Serena`. The `0.6B-Base` repo is voice-cloning-only (needs a reference clip), so **CustomVoice** is used for the reference-free OpenAI contract.
- **TTSEngine**: detect the `qwen3_tts` family; expose the documented speaker set (Chinese: Vivian/Serena/Uncle_Fu/Dylan(Beijing)/Eric(Sichuan); English: Ryan/Aiden); make `generate()` family-aware — Qwen3 auto-detects language (`lang_code="auto"`, not Kokoro's single-letter code) and accepts an optional `instruct=` emotion argument. Other families ignore it.
- **AudioSpeechRequest**: accept OpenAI `gpt-4o-mini-tts`'s `instructions` field and thread it to the engine's `instruct` arg. Only forwarded when set, so the call shape stays backward-compatible with every existing TTS stub/engine.
- **routes/audio.py**: validate the Qwen3 speaker set (CustomVoice ships no `voices/` snapshot dir → static cold-start list) and resolve an omitted / `"default"` voice to the registry `default_voice` (`Serena`).

Usage:
```bash
curl .../v1/audio/speech -d '{"model":"qwen3-tts","input":"他被诸葛亮压了一辈子。","voice":"Serena","instructions":"悬疑而低沉，逐渐激昂。"}'
```

## Tests
- New hermetic suite `tests/test_qwen3_tts_audio.py` (15 tests): registry resolution, family detection, voice list, emotion-aware `generate()` (forwards `instruct` + `lang_code="auto"`; does NOT leak `instruct` into Kokoro), and the route (instructions plumbing, omitted-voice→Serena, unknown-voice 400). Fakes the mlx_audio boundary — no weights, no network.
- Full unit suite green (14256 passed); no regressions. (2 `test_event_loop` failures require a live server on :8000; pre-existing, unrelated.)
- Real weight smoke-load verified separately from a locally-built wheel (see PR comment).

## Notes
🤖 This change was written with the assistance of Claude Code (Opus 4.8).
