### PR TITLE
feat(quality): KV-quant differential quality gate + chip-tier classifier [skip-version-bump]

### DIFF
--- a/scripts/kv_quant_quality_gate.py
+++ b/scripts/kv_quant_quality_gate.py
@@ -266,7 +266,15 @@ def _maybe_run_niah(
             "status": "skipped",
             "reason": f"chip tier below M3 (gen={chip.generation}) — NIAH gated off",
         }
-    if total_ram_gb is not None and total_ram_gb < _NIAH_MIN_RAM_GB:
+    # Fail-closed on RAM: run the expensive long-context pass ONLY when RAM was
+    # successfully detected AND meets the minimum. An unknown (``None``) capacity
+    # must SKIP — never assume enough headroom on a host we couldn't measure.
+    if total_ram_gb is None:
+        return {
+            "status": "skipped",
+            "reason": "RAM capacity undetected — NIAH gated off (fail-closed)",
+        }
+    if total_ram_gb < _NIAH_MIN_RAM_GB:
         return {
             "status": "skipped",
             "reason": f"RAM {total_ram_gb:.0f}GB < {_NIAH_MIN_RAM_GB:.0f}GB gate",
@@ -336,7 +344,23 @@ def run_gate(
 
     Returns a process exit code. Advisory runs always return 0; enforced runs
     return 1 if any candidate's overall verdict is FAIL.
+
+    Raises:
+        ValueError: If ``max_tokens`` / ``mem_tokens`` / ``kv_group_size`` are not
+            strictly positive, or if ``prompts`` is empty. A non-positive token
+            budget yields empty generations that would score a vacuous ``1.0``
+            agreement — an enforced gate must never "pass" without measuring
+            anything. Validated up front, before any model load.
     """
+    if max_tokens <= 0 or mem_tokens <= 0 or kv_group_size <= 0:
+        raise ValueError(
+            "max_tokens, mem_tokens, and group_size must be strictly positive "
+            f"(got max_tokens={max_tokens}, mem_tokens={mem_tokens}, "
+            f"group_size={kv_group_size})"
+        )
+    if not prompts:
+        raise ValueError("prompts must be a non-empty list")
+
     from mlx_lm import load
 
     from vllm_mlx.model_aliases import resolve_model
@@ -491,6 +515,14 @@ def _load_prompts(path: Path | None) -> list[dict[str, str]]:
     return prompts
 
 
+def _positive_int(value: str) -> int:
+    """argparse type: accept only strictly-positive integers."""
+    ivalue = int(value)
+    if ivalue <= 0:
+        raise argparse.ArgumentTypeError(f"must be a positive integer, got {value!r}")
+    return ivalue
+
+
 def _build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(description=__doc__.split("\n\n", 1)[0])
     p.add_argument("model", help="alias or HF path (e.g. qwen3.5-4b-4bit)")
@@ -501,14 +533,14 @@ def _build_parser() -> argparse.ArgumentParser:
         choices=["int8", "int4"],
         help="candidate KV dtype(s) to test against the bf16 baseline",
     )
-    p.add_argument("--max-tokens", type=int, default=48)
+    p.add_argument("--max-tokens", type=_positive_int, default=48)
     p.add_argument(
         "--mem-tokens",
-        type=int,
+        type=_positive_int,
         default=128,
         help="fixed generation length for the memory-delta measurement",
     )
-    p.add_argument("--group-size", type=int, default=64)
+    p.add_argument("--group-size", type=_positive_int, default=64)
     p.add_argument("--prompts-file", type=Path, default=None)
     p.add_argument(
         "--niah",

--- a/scripts/kv_quant_quality_gate.py
+++ b/scripts/kv_quant_quality_gate.py
@@ -118,6 +118,21 @@ def _encode_prompt(tokenizer, text: str) -> list[int]:
     return list(tokenizer.encode(text))
 
 
+def _decode_text(tokenizer, token_ids: list[int]) -> str:
+    """Decode generated tokens to plain text, dropping special/control tokens.
+
+    Greedy generation stops ON the EOS token (it is appended before the break),
+    so a naive ``decode`` leaves a trailing control token like ``<|im_end|>`` in
+    the string — which breaks the strict whole-output JSON check. We pass
+    ``skip_special_tokens=True`` and fall back gracefully for the rare tokenizer
+    that does not accept the kwarg.
+    """
+    try:
+        return tokenizer.decode(token_ids, skip_special_tokens=True)
+    except TypeError:
+        return tokenizer.decode(token_ids)
+
+
 def _run_generation(
     model,
     prompt_ids: list[int],
@@ -432,6 +447,47 @@ def run_gate(
     json_prompts = [p for p in prompts if p.get("kind") == "json"]
     mem_prompt_ids = _encode_prompt(tokenizer, prompts[0]["prompt"])
 
+    # The baseline is candidate-INDEPENDENT — the bf16 generation, its logprobs,
+    # its JSON text, and its KV footprint do not change with the candidate dtype.
+    # Run it ONCE here (the baseline generation is the dominant inference cost;
+    # recomputing it inside the candidate loop would double the work of the
+    # default two-dtype ``int8 int4`` run) and reuse it for every candidate.
+    baseline_runs: list[dict] = []
+    for spec in prompts:
+        prompt_ids = _encode_prompt(tokenizer, spec["prompt"])
+        base_tokens, base_lp, _ = _run_generation(
+            model,
+            prompt_ids,
+            max_tokens=max_tokens,
+            kv_bits=None,
+            kv_group_size=kv_group_size,
+            eos_ids=eos_ids,
+            collect_logprobs=True,
+            stop_on_eos=True,
+        )
+        baseline_runs.append(
+            {
+                "prompt_ids": prompt_ids,
+                "kind": spec.get("kind"),
+                "tokens": base_tokens,
+                "logprobs": base_lp,
+                # Baseline JSON text is candidate-independent too — decode once.
+                "text": (
+                    _decode_text(tokenizer, base_tokens)
+                    if spec.get("kind") == "json"
+                    else None
+                ),
+            }
+        )
+
+    base_bytes, baseline_kv_dtype = _measure_kv_bytes(
+        model,
+        mem_prompt_ids,
+        mem_tokens=mem_tokens,
+        kv_bits=None,
+        kv_group_size=kv_group_size,
+    )
+
     any_fail = False
     reports: list[dict] = []
     for cdtype in candidate_dtypes:
@@ -442,21 +498,10 @@ def run_gate(
         divergences: list[LogitDivergence] = []
         retention_pairs: list[tuple[str, str]] = []
 
-        for spec in prompts:
-            prompt_ids = _encode_prompt(tokenizer, spec["prompt"])
-            base_tokens, base_lp, _ = _run_generation(
-                model,
-                prompt_ids,
-                max_tokens=max_tokens,
-                kv_bits=None,
-                kv_group_size=kv_group_size,
-                eos_ids=eos_ids,
-                collect_logprobs=True,
-                stop_on_eos=True,
-            )
+        for base in baseline_runs:
             cand_tokens, cand_lp, _ = _run_generation(
                 model,
-                prompt_ids,
+                base["prompt_ids"],
                 max_tokens=max_tokens,
                 kv_bits=cand_bits,
                 kv_group_size=kv_group_size,
@@ -464,7 +509,7 @@ def run_gate(
                 collect_logprobs=True,
                 stop_on_eos=True,
             )
-            ag = greedy_agreement_rate(base_tokens, cand_tokens)
+            ag = greedy_agreement_rate(base["tokens"], cand_tokens)
             agreements.append(ag)
             # Same-context prefix: up to AND INCLUDING the first divergence step
             # (its distributions still share a context), else the whole overlap.
@@ -474,20 +519,15 @@ def run_gate(
                 else ag.total
             )
             divergences.append(
-                logit_divergence(base_lp, cand_lp, compare_len=compare_len)
+                logit_divergence(base["logprobs"], cand_lp, compare_len=compare_len)
             )
-            if spec.get("kind") == "json":
+            if base["kind"] == "json":
+                # Candidate decoded with skip_special_tokens so a trailing EOS
+                # control token can't break the strict whole-output JSON parse.
                 retention_pairs.append(
-                    (tokenizer.decode(base_tokens), tokenizer.decode(cand_tokens))
+                    (base["text"], _decode_text(tokenizer, cand_tokens))
                 )
 
-        base_bytes, baseline_kv_dtype = _measure_kv_bytes(
-            model,
-            mem_prompt_ids,
-            mem_tokens=mem_tokens,
-            kv_bits=None,
-            kv_group_size=kv_group_size,
-        )
         cand_bytes, _ = _measure_kv_bytes(
             model,
             mem_prompt_ids,

--- a/scripts/kv_quant_quality_gate.py
+++ b/scripts/kv_quant_quality_gate.py
@@ -133,6 +133,32 @@ def _decode_text(tokenizer, token_ids: list[int]) -> str:
         return tokenizer.decode(token_ids)
 
 
+def _enable_hf_offline() -> None:
+    """Force HuggingFace offline mode RELIABLY, whatever the import order.
+
+    Setting the env vars alone is not enough: ``huggingface_hub.constants``
+    snapshots ``HF_HUB_OFFLINE`` from the environment ONCE at import time, and
+    ``is_offline_mode()`` returns that frozen module global. A programmatic
+    caller that already imported ``huggingface_hub`` (while online) would have
+    the snapshot pinned to ``False``, so a later env-var change is silently
+    ignored and the "no network fetch" contract breaks. We therefore ALSO patch
+    the already-imported constant to ``True`` — ``is_offline_mode()`` reads it at
+    call time, so the load fails fast on an uncached model either way.
+    """
+    import os
+
+    os.environ["HF_HUB_OFFLINE"] = "1"
+    os.environ["TRANSFORMERS_OFFLINE"] = "1"
+    try:
+        import huggingface_hub.constants as hf_constants
+
+        hf_constants.HF_HUB_OFFLINE = True
+    except Exception:
+        # huggingface_hub not importable — the env vars are still set for any
+        # process that imports it fresh later.
+        pass
+
+
 def _run_generation(
     model,
     prompt_ids: list[int],
@@ -389,8 +415,10 @@ def run_gate(
     Returns a process exit code. Advisory runs always return 0; enforced runs
     return 1 if any candidate's overall verdict is FAIL.
 
-    When ``offline`` is set, HuggingFace offline mode is forced before the load so
-    an uncached model fails fast instead of triggering a network fetch.
+    When ``offline`` is set, HuggingFace offline mode is forced before the load
+    (env vars AND the already-imported ``constants.HF_HUB_OFFLINE``, see
+    :func:`_enable_hf_offline`) so an uncached model fails fast instead of
+    triggering a network fetch — reliably even if the hub was imported earlier.
 
     Raises:
         ValueError: If ``max_tokens`` / ``mem_tokens`` / ``kv_group_size`` are not
@@ -414,12 +442,9 @@ def run_gate(
         raise ValueError("candidate_dtypes must be a non-empty list")
 
     if offline:
-        # Forbid any network fetch — the load fails fast if the model isn't fully
-        # cached. Set before importing/using mlx_lm.load so the HF hub honors it.
-        import os
-
-        os.environ["HF_HUB_OFFLINE"] = "1"
-        os.environ["TRANSFORMERS_OFFLINE"] = "1"
+        # Forbid any network fetch — the load then fails fast if the model isn't
+        # fully cached (mlx_lm.load -> snapshot_download raises OfflineModeIsEnabled).
+        _enable_hf_offline()
 
     from mlx_lm import load
 

--- a/scripts/kv_quant_quality_gate.py
+++ b/scripts/kv_quant_quality_gate.py
@@ -360,6 +360,10 @@ def run_gate(
         )
     if not prompts:
         raise ValueError("prompts must be a non-empty list")
+    if not candidate_dtypes:
+        # An empty candidate list would run the loop zero times and let an
+        # --enforce invocation return success having measured NOTHING.
+        raise ValueError("candidate_dtypes must be a non-empty list")
 
     from mlx_lm import load
 

--- a/scripts/kv_quant_quality_gate.py
+++ b/scripts/kv_quant_quality_gate.py
@@ -1,17 +1,24 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0
-"""KV-quant differential quality gate (offline, advisory).
+"""KV-quant differential quality gate (local, advisory).
 
-Runs the SAME model twice on the SAME prompts — a ``bf16``-KV BASELINE and a
+Runs the SAME model twice on the SAME prompts — an unquantized-KV BASELINE and a
 quantized-KV CANDIDATE (``int8`` / ``int4``) — and measures how well the
-candidate AGREES WITH ITS OWN bf16 baseline. This differential framing isolates
-*quantization-induced* degradation from a model's plain inability at a prompt:
-the gate only faults a candidate the quantized cache made worse than its own
-full-precision self.
+candidate AGREES WITH ITS OWN unquantized baseline. This differential framing
+isolates *quantization-induced* degradation from a model's plain inability at a
+prompt: the gate only faults a candidate the quantized cache made worse than its
+own full-precision self. (The baseline dtype is the model's native KV dtype —
+usually bf16 or fp16 — and is detected and reported, not assumed.)
 
 Today, ``vllm_mlx/kv_cache_dtype.py`` decides whether int4/int8 KV is "safe" via
 a hand-written empirical safelist. This harness produces the *measured* signal
 that list currently lacks.
+
+It runs entirely locally (no external-service calls). Like any inference tool it
+loads the model through the standard HuggingFace cache, which fetches the weights
+once if they are not already cached; pass ``--offline`` to forbid any network
+fetch (the load then fails fast if the model isn't fully cached). The bundled
+tests never download — they are cache-only and skip when the model is absent.
 
 It ships **advisory** (measure-first, mirroring the ``diff_coverage`` pattern):
 it prints a full report + PASS/FAIL but exits ``0`` regardless. Pass
@@ -26,7 +33,7 @@ Usage:
     python -m scripts.kv_quant_quality_gate qwen3.5-4b-4bit
     python -m scripts.kv_quant_quality_gate mlx-community/Qwen3-0.6B-4bit \\
         --candidate int8 int4 --max-tokens 48 --json-out report.json
-    python -m scripts.kv_quant_quality_gate <model> --niah --enforce
+    python -m scripts.kv_quant_quality_gate <model> --niah --enforce --offline
 """
 
 from __future__ import annotations
@@ -188,6 +195,25 @@ def _kv_cache_bytes(cache) -> int:
     return total
 
 
+def _baseline_kv_dtype(cache) -> str:
+    """Return the element dtype of a NON-quantized KV cache, e.g. ``"bfloat16"``.
+
+    The baseline cache's dtype follows the loaded model/runtime — it is NOT
+    guaranteed to be bf16 (many mlx checkpoints are fp16). Reading the actual
+    ``keys`` array dtype keeps the report honest instead of hardcoding a label.
+    Returns ``"unknown"`` if it can't be read.
+    """
+    for layer in cache:
+        keys = getattr(layer, "keys", None)
+        # A plain KVCache exposes ``keys`` as a single array (not a tuple, which
+        # only a QuantizedKVCache uses).
+        if keys is not None and not isinstance(keys, (list, tuple)):
+            dtype = getattr(keys, "dtype", None)
+            if dtype is not None:
+                return str(dtype).replace("mlx.core.", "")
+    return "unknown"
+
+
 def _measure_kv_bytes(
     model,
     prompt_ids: list[int],
@@ -195,11 +221,13 @@ def _measure_kv_bytes(
     mem_tokens: int,
     kv_bits: int | None,
     kv_group_size: int,
-) -> int:
-    """Measure the KV-cache footprint after a FIXED-length generation.
+) -> tuple[int, str]:
+    """Measure KV-cache footprint (bytes) and element dtype after a fixed run.
 
     Fixed length (no EOS stop) so baseline and candidate reach the same offset
     and the byte comparison is apples-to-apples (see :func:`_kv_cache_bytes`).
+    The returned dtype string is meaningful for the (unquantized) baseline; for a
+    quantized run it reflects the packed representation and the caller ignores it.
     """
     _, _, cache = _run_generation(
         model,
@@ -211,7 +239,7 @@ def _measure_kv_bytes(
         collect_logprobs=False,
         stop_on_eos=False,
     )
-    return _kv_cache_bytes(cache)
+    return _kv_cache_bytes(cache), _baseline_kv_dtype(cache)
 
 
 def _combine_agreement(results: list[AgreementResult]) -> AgreementResult:
@@ -339,18 +367,23 @@ def run_gate(
     advisory: bool,
     run_niah: bool,
     json_out: Path | None,
+    offline: bool = False,
 ) -> int:
     """Load the model, run every candidate dtype, print + optionally dump reports.
 
     Returns a process exit code. Advisory runs always return 0; enforced runs
     return 1 if any candidate's overall verdict is FAIL.
 
+    When ``offline`` is set, HuggingFace offline mode is forced before the load so
+    an uncached model fails fast instead of triggering a network fetch.
+
     Raises:
         ValueError: If ``max_tokens`` / ``mem_tokens`` / ``kv_group_size`` are not
-            strictly positive, or if ``prompts`` is empty. A non-positive token
-            budget yields empty generations that would score a vacuous ``1.0``
-            agreement — an enforced gate must never "pass" without measuring
-            anything. Validated up front, before any model load.
+            strictly positive, or if ``prompts`` / ``candidate_dtypes`` is empty.
+            A non-positive token budget yields empty generations that would score
+            a vacuous ``1.0`` agreement, and an empty candidate list would let an
+            enforced gate "pass" having measured nothing — both must never slip
+            through. Validated up front, before any model load.
     """
     if max_tokens <= 0 or mem_tokens <= 0 or kv_group_size <= 0:
         raise ValueError(
@@ -364,6 +397,14 @@ def run_gate(
         # An empty candidate list would run the loop zero times and let an
         # --enforce invocation return success having measured NOTHING.
         raise ValueError("candidate_dtypes must be a non-empty list")
+
+    if offline:
+        # Forbid any network fetch — the load fails fast if the model isn't fully
+        # cached. Set before importing/using mlx_lm.load so the HF hub honors it.
+        import os
+
+        os.environ["HF_HUB_OFFLINE"] = "1"
+        os.environ["TRANSFORMERS_OFFLINE"] = "1"
 
     from mlx_lm import load
 
@@ -440,14 +481,14 @@ def run_gate(
                     (tokenizer.decode(base_tokens), tokenizer.decode(cand_tokens))
                 )
 
-        base_bytes = _measure_kv_bytes(
+        base_bytes, baseline_kv_dtype = _measure_kv_bytes(
             model,
             mem_prompt_ids,
             mem_tokens=mem_tokens,
             kv_bits=None,
             kv_group_size=kv_group_size,
         )
-        cand_bytes = _measure_kv_bytes(
+        cand_bytes, _ = _measure_kv_bytes(
             model,
             mem_prompt_ids,
             mem_tokens=mem_tokens,
@@ -471,7 +512,7 @@ def run_gate(
         report = build_report(
             model=model_arg,
             hf_path=hf_path,
-            baseline_dtype="bf16",
+            baseline_dtype=baseline_kv_dtype,
             candidate_dtype=cdtype,
             num_prompts=len(prompts),
             advisory=advisory,
@@ -556,6 +597,11 @@ def _build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="exit non-zero on FAIL (default: advisory, always exit 0)",
     )
+    p.add_argument(
+        "--offline",
+        action="store_true",
+        help="set HF_HUB_OFFLINE/TRANSFORMERS_OFFLINE before load (cached models only)",
+    )
     p.add_argument("--json-out", type=Path, default=None)
     return p
 
@@ -573,6 +619,7 @@ def main(argv: list[str] | None = None) -> int:
         advisory=not args.enforce,
         run_niah=args.niah,
         json_out=args.json_out,
+        offline=args.offline,
     )
 
 

--- a/scripts/kv_quant_quality_gate.py
+++ b/scripts/kv_quant_quality_gate.py
@@ -1,0 +1,544 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""KV-quant differential quality gate (offline, advisory).
+
+Runs the SAME model twice on the SAME prompts — a ``bf16``-KV BASELINE and a
+quantized-KV CANDIDATE (``int8`` / ``int4``) — and measures how well the
+candidate AGREES WITH ITS OWN bf16 baseline. This differential framing isolates
+*quantization-induced* degradation from a model's plain inability at a prompt:
+the gate only faults a candidate the quantized cache made worse than its own
+full-precision self.
+
+Today, ``vllm_mlx/kv_cache_dtype.py`` decides whether int4/int8 KV is "safe" via
+a hand-written empirical safelist. This harness produces the *measured* signal
+that list currently lacks.
+
+It ships **advisory** (measure-first, mirroring the ``diff_coverage`` pattern):
+it prints a full report + PASS/FAIL but exits ``0`` regardless. Pass
+``--enforce`` to make a FAIL exit non-zero (for a future promotion to a blocking
+gate once thresholds are calibrated on fleet data).
+
+All *scoring* lives in the pure, hermetically-tested :mod:`vllm_mlx.kv_quant_gate`;
+this file only drives inference and prints. Chip-tier gating of the optional NIAH
+metric uses :mod:`vllm_mlx.chip_tier`.
+
+Usage:
+    python -m scripts.kv_quant_quality_gate qwen3.5-4b-4bit
+    python -m scripts.kv_quant_quality_gate mlx-community/Qwen3-0.6B-4bit \\
+        --candidate int8 int4 --max-tokens 48 --json-out report.json
+    python -m scripts.kv_quant_quality_gate <model> --niah --enforce
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import asdict
+from pathlib import Path
+
+import numpy as np
+
+# Allow ``python scripts/kv_quant_quality_gate.py`` (not just ``-m``) by putting
+# the repo root on the path.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from vllm_mlx.chip_tier import classify_chip_tier, detect_chip_tier  # noqa: E402
+from vllm_mlx.kv_cache_dtype import dtype_to_quantization_bits  # noqa: E402
+from vllm_mlx.kv_quant_gate import (  # noqa: E402
+    AgreementResult,
+    LogitDivergence,
+    build_report,
+    default_thresholds,
+    greedy_agreement_rate,
+    logit_divergence,
+    structured_output_retention,
+)
+
+# Built-in prompt set. A couple explicitly ask for JSON so the structured-output
+# retention metric has attributable prompts. Kept small — this is an M-sized
+# advisory tool, not a benchmark suite.
+_DEFAULT_PROMPTS: list[dict[str, str]] = [
+    {"kind": "text", "prompt": "Explain what a KV cache is in two sentences."},
+    {"kind": "text", "prompt": "List three prime numbers greater than 100."},
+    {"kind": "text", "prompt": "Write a haiku about unified memory."},
+    {
+        "kind": "json",
+        "prompt": (
+            "Respond with ONLY a JSON object with keys "
+            '"name" (string) and "age" (number) for a fictional person. '
+            "No prose, no code fence."
+        ),
+    },
+    {
+        "kind": "json",
+        "prompt": (
+            "Return ONLY a JSON array of three city names as strings. "
+            "No prose, no code fence."
+        ),
+    },
+]
+
+# NIAH needle prompt scaffold. Deliberately modest length — the gate is advisory
+# and RAM-tier-gated; a full long-context sweep is out of MVP scope.
+_NIAH_MAGIC = "7431905"
+_NIAH_MIN_RAM_GB = 32.0
+
+
+def _greedy_sampler():
+    import mlx.core as mx
+
+    return lambda logprobs: mx.argmax(logprobs, axis=-1)
+
+
+def _eos_ids(tokenizer) -> set[int]:
+    ids = getattr(tokenizer, "eos_token_ids", None)
+    if ids:
+        return {int(i) for i in ids}
+    eos = getattr(tokenizer, "eos_token_id", None)
+    return {int(eos)} if eos is not None else set()
+
+
+def _encode_prompt(tokenizer, text: str) -> list[int]:
+    """Encode a user turn, applying the chat template when one exists."""
+    if getattr(tokenizer, "chat_template", None):
+        return list(
+            tokenizer.apply_chat_template(
+                [{"role": "user", "content": text}],
+                add_generation_prompt=True,
+            )
+        )
+    return list(tokenizer.encode(text))
+
+
+def _run_generation(
+    model,
+    prompt_ids: list[int],
+    *,
+    max_tokens: int,
+    kv_bits: int | None,
+    kv_group_size: int,
+    eos_ids: set[int],
+    collect_logprobs: bool,
+    stop_on_eos: bool,
+):
+    """Greedy (temp=0) generation, capturing tokens and optional per-step logprobs.
+
+    Returns ``(tokens, logprobs_list, cache)``. ``logprobs_list`` holds one
+    float32 log-probability vector per generated step when ``collect_logprobs``,
+    else is empty. ``cache`` is the (possibly now-quantized) prompt cache — after
+    a ``kv_bits`` run mlx-lm has quantized it in place, so it measures the
+    candidate footprint.
+    """
+    import mlx.core as mx
+    from mlx_lm.generate import generate_step
+    from mlx_lm.models.cache import make_prompt_cache
+
+    cache = make_prompt_cache(model)
+    kwargs: dict = {
+        "max_tokens": max_tokens,
+        "prompt_cache": cache,
+        "sampler": _greedy_sampler(),
+        "kv_group_size": kv_group_size,
+    }
+    if kv_bits is not None:
+        kwargs["kv_bits"] = kv_bits
+
+    tokens: list[int] = []
+    logprobs_list: list[np.ndarray] = []
+    for token, logprobs in generate_step(mx.array(prompt_ids), model, **kwargs):
+        tid = int(token.item()) if hasattr(token, "item") else int(token)
+        tokens.append(tid)
+        if collect_logprobs:
+            # mlx compute dtype is often bf16; np.asarray can't read its buffer
+            # (PEP-3118 itemsize mismatch), so cast to float32 in MLX first.
+            logprobs_list.append(np.array(logprobs.astype(mx.float32)).reshape(-1))
+        if stop_on_eos and tid in eos_ids:
+            break
+    return tokens, logprobs_list, cache
+
+
+def _kv_cache_bytes(cache) -> int:
+    """Sum the FULL allocated bytes of every KV array in a prompt cache.
+
+    Consistent across cache types: a plain ``KVCache`` exposes ``keys`` /
+    ``values`` as single arrays; a ``QuantizedKVCache`` exposes them as
+    ``(packed, scales, biases)`` tuples. We sum ``.nbytes`` (shape+dtype
+    metadata — no lazy-eval spike) over ALL of them WITHOUT trimming to the used
+    offset.
+
+    Deliberately NOT ``vllm_mlx.memory_cache.estimate_kv_cache_memory``: that
+    helper trims a ``KVCache`` to its used ``offset`` (via ``.state``) but counts
+    a ``QuantizedKVCache``'s full padded buffer, which would skew a differential
+    bf16-vs-quantized comparison. Both caches here reach the SAME offset and the
+    SAME step-padded buffer, so a full-buffer byte sum is the apples-to-apples
+    measurement.
+    """
+    total = 0
+    for layer in cache:
+        if layer is None:
+            continue
+        for attr in (getattr(layer, "keys", None), getattr(layer, "values", None)):
+            if attr is None:
+                continue
+            arrays = attr if isinstance(attr, (list, tuple)) else (attr,)
+            for a in arrays:
+                if a is not None and hasattr(a, "nbytes"):
+                    total += int(a.nbytes)
+    return total
+
+
+def _measure_kv_bytes(
+    model,
+    prompt_ids: list[int],
+    *,
+    mem_tokens: int,
+    kv_bits: int | None,
+    kv_group_size: int,
+) -> int:
+    """Measure the KV-cache footprint after a FIXED-length generation.
+
+    Fixed length (no EOS stop) so baseline and candidate reach the same offset
+    and the byte comparison is apples-to-apples (see :func:`_kv_cache_bytes`).
+    """
+    _, _, cache = _run_generation(
+        model,
+        prompt_ids,
+        max_tokens=mem_tokens,
+        kv_bits=kv_bits,
+        kv_group_size=kv_group_size,
+        eos_ids=set(),
+        collect_logprobs=False,
+        stop_on_eos=False,
+    )
+    return _kv_cache_bytes(cache)
+
+
+def _combine_agreement(results: list[AgreementResult]) -> AgreementResult:
+    total = sum(r.total for r in results)
+    matched = sum(r.matched for r in results)
+    rate = (matched / total) if total > 0 else 1.0
+    return AgreementResult(
+        total=total, matched=matched, rate=rate, first_divergence_index=None
+    )
+
+
+def _combine_logits(results: list[LogitDivergence]) -> LogitDivergence:
+    steps = sum(r.compared_steps for r in results)
+    if steps == 0:
+        return LogitDivergence(
+            compared_steps=0, mean_kl=0.0, max_kl=0.0, top1_agreement_rate=1.0
+        )
+    mean_kl = sum(r.mean_kl * r.compared_steps for r in results) / steps
+    top1 = sum(r.top1_agreement_rate * r.compared_steps for r in results) / steps
+    max_kl = max(r.max_kl for r in results)
+    return LogitDivergence(
+        compared_steps=steps,
+        mean_kl=mean_kl,
+        max_kl=max_kl,
+        top1_agreement_rate=top1,
+    )
+
+
+def _maybe_run_niah(
+    model,
+    tokenizer,
+    chip,
+    *,
+    enabled: bool,
+    max_tokens: int,
+    kv_bits: int,
+    kv_group_size: int,
+    eos_ids: set[int],
+    total_ram_gb: float | None,
+) -> dict:
+    """Optional needle-in-a-haystack retrieval metric, RAM/compute-tier-gated.
+
+    Gated on the chip tier (#5): only runs on an M3-or-newer chip with enough
+    RAM. A low-RAM M1/M2 skips it cleanly (the long-ish context is the expensive
+    part). This is the concrete #5 -> #4 wiring; the metric itself is kept modest
+    (single moderate-context needle) per the advisory MVP scope.
+    """
+    if not enabled:
+        return {"status": "skipped", "reason": "not requested (pass --niah)"}
+    if not chip.is_m3_or_newer:
+        return {
+            "status": "skipped",
+            "reason": f"chip tier below M3 (gen={chip.generation}) — NIAH gated off",
+        }
+    if total_ram_gb is not None and total_ram_gb < _NIAH_MIN_RAM_GB:
+        return {
+            "status": "skipped",
+            "reason": f"RAM {total_ram_gb:.0f}GB < {_NIAH_MIN_RAM_GB:.0f}GB gate",
+        }
+
+    filler = "The garden was quiet in the early morning light. " * 60
+    needle = f"The secret access code is {_NIAH_MAGIC}. "
+    question = (
+        "\n\nBased on the text above, what is the secret access code? "
+        "Answer with only the number."
+    )
+    context = filler[: len(filler) // 2] + needle + filler[len(filler) // 2 :]
+    prompt_ids = _encode_prompt(tokenizer, context + question)
+
+    base_tokens, _, _ = _run_generation(
+        model,
+        prompt_ids,
+        max_tokens=max_tokens,
+        kv_bits=None,
+        kv_group_size=kv_group_size,
+        eos_ids=eos_ids,
+        collect_logprobs=False,
+        stop_on_eos=True,
+    )
+    cand_tokens, _, _ = _run_generation(
+        model,
+        prompt_ids,
+        max_tokens=max_tokens,
+        kv_bits=kv_bits,
+        kv_group_size=kv_group_size,
+        eos_ids=eos_ids,
+        collect_logprobs=False,
+        stop_on_eos=True,
+    )
+    base_found = _NIAH_MAGIC in tokenizer.decode(base_tokens)
+    cand_found = _NIAH_MAGIC in tokenizer.decode(cand_tokens)
+    if not base_found:
+        return {
+            "status": "skipped",
+            "reason": "baseline itself missed the needle — not attributable",
+            "baseline_found": False,
+            "candidate_found": cand_found,
+        }
+    return {
+        "status": "pass" if cand_found else "fail",
+        "reason": "candidate retained needle"
+        if cand_found
+        else "candidate lost needle",
+        "baseline_found": True,
+        "candidate_found": cand_found,
+    }
+
+
+def run_gate(
+    *,
+    model_arg: str,
+    candidate_dtypes: list[str],
+    prompts: list[dict[str, str]],
+    max_tokens: int,
+    mem_tokens: int,
+    kv_group_size: int,
+    advisory: bool,
+    run_niah: bool,
+    json_out: Path | None,
+) -> int:
+    """Load the model, run every candidate dtype, print + optionally dump reports.
+
+    Returns a process exit code. Advisory runs always return 0; enforced runs
+    return 1 if any candidate's overall verdict is FAIL.
+    """
+    from mlx_lm import load
+
+    from vllm_mlx.model_aliases import resolve_model
+
+    hf_path = resolve_model(model_arg)
+    print(f"[kv-quant-gate] loading {model_arg} -> {hf_path} ...", file=sys.stderr)
+    model, tokenizer = load(hf_path)
+    eos_ids = _eos_ids(tokenizer)
+
+    try:
+        chip = detect_chip_tier()
+    except Exception:
+        chip = classify_chip_tier(None)
+    chip_dict = asdict(chip)
+
+    total_ram_gb: float | None
+    try:
+        from vllm_mlx.optimizations import get_system_memory_gb
+
+        total_ram_gb = get_system_memory_gb()
+    except Exception:
+        total_ram_gb = None
+
+    json_prompts = [p for p in prompts if p.get("kind") == "json"]
+    mem_prompt_ids = _encode_prompt(tokenizer, prompts[0]["prompt"])
+
+    any_fail = False
+    reports: list[dict] = []
+    for cdtype in candidate_dtypes:
+        _, cand_bits = dtype_to_quantization_bits(cdtype)
+        thresholds = default_thresholds(cdtype)
+
+        agreements: list[AgreementResult] = []
+        divergences: list[LogitDivergence] = []
+        retention_pairs: list[tuple[str, str]] = []
+
+        for spec in prompts:
+            prompt_ids = _encode_prompt(tokenizer, spec["prompt"])
+            base_tokens, base_lp, _ = _run_generation(
+                model,
+                prompt_ids,
+                max_tokens=max_tokens,
+                kv_bits=None,
+                kv_group_size=kv_group_size,
+                eos_ids=eos_ids,
+                collect_logprobs=True,
+                stop_on_eos=True,
+            )
+            cand_tokens, cand_lp, _ = _run_generation(
+                model,
+                prompt_ids,
+                max_tokens=max_tokens,
+                kv_bits=cand_bits,
+                kv_group_size=kv_group_size,
+                eos_ids=eos_ids,
+                collect_logprobs=True,
+                stop_on_eos=True,
+            )
+            ag = greedy_agreement_rate(base_tokens, cand_tokens)
+            agreements.append(ag)
+            # Same-context prefix: up to AND INCLUDING the first divergence step
+            # (its distributions still share a context), else the whole overlap.
+            compare_len = (
+                ag.first_divergence_index + 1
+                if ag.first_divergence_index is not None
+                else ag.total
+            )
+            divergences.append(
+                logit_divergence(base_lp, cand_lp, compare_len=compare_len)
+            )
+            if spec.get("kind") == "json":
+                retention_pairs.append(
+                    (tokenizer.decode(base_tokens), tokenizer.decode(cand_tokens))
+                )
+
+        base_bytes = _measure_kv_bytes(
+            model,
+            mem_prompt_ids,
+            mem_tokens=mem_tokens,
+            kv_bits=None,
+            kv_group_size=kv_group_size,
+        )
+        cand_bytes = _measure_kv_bytes(
+            model,
+            mem_prompt_ids,
+            mem_tokens=mem_tokens,
+            kv_bits=cand_bits,
+            kv_group_size=kv_group_size,
+        )
+        from vllm_mlx.kv_quant_gate import memory_delta
+
+        niah = _maybe_run_niah(
+            model,
+            tokenizer,
+            chip,
+            enabled=run_niah,
+            max_tokens=max_tokens,
+            kv_bits=cand_bits,
+            kv_group_size=kv_group_size,
+            eos_ids=eos_ids,
+            total_ram_gb=total_ram_gb,
+        )
+
+        report = build_report(
+            model=model_arg,
+            hf_path=hf_path,
+            baseline_dtype="bf16",
+            candidate_dtype=cdtype,
+            num_prompts=len(prompts),
+            advisory=advisory,
+            chip=chip_dict,
+            thresholds=thresholds,
+            agreement=_combine_agreement(agreements),
+            logits=_combine_logits(divergences),
+            retention=structured_output_retention(retention_pairs)
+            if json_prompts
+            else structured_output_retention([]),
+            memory=memory_delta(base_bytes, cand_bytes),
+            niah=niah,
+        )
+        print(report.human_summary())
+        print()
+        reports.append(report.to_dict())
+        if report.overall == "FAIL":
+            any_fail = True
+
+    if json_out is not None:
+        json_out.write_text(json.dumps(reports, indent=2))
+        print(f"[kv-quant-gate] wrote JSON report -> {json_out}", file=sys.stderr)
+
+    if advisory:
+        return 0
+    return 1 if any_fail else 0
+
+
+def _load_prompts(path: Path | None) -> list[dict[str, str]]:
+    if path is None:
+        return list(_DEFAULT_PROMPTS)
+    data = json.loads(path.read_text())
+    if not isinstance(data, list) or not data:
+        raise ValueError("prompts file must be a non-empty JSON array")
+    prompts: list[dict[str, str]] = []
+    for entry in data:
+        if isinstance(entry, str):
+            prompts.append({"kind": "text", "prompt": entry})
+        elif isinstance(entry, dict) and isinstance(entry.get("prompt"), str):
+            prompts.append(
+                {"kind": str(entry.get("kind", "text")), "prompt": entry["prompt"]}
+            )
+        else:
+            raise ValueError(f"bad prompt entry: {entry!r}")
+    return prompts
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description=__doc__.split("\n\n", 1)[0])
+    p.add_argument("model", help="alias or HF path (e.g. qwen3.5-4b-4bit)")
+    p.add_argument(
+        "--candidate",
+        nargs="+",
+        default=["int8", "int4"],
+        choices=["int8", "int4"],
+        help="candidate KV dtype(s) to test against the bf16 baseline",
+    )
+    p.add_argument("--max-tokens", type=int, default=48)
+    p.add_argument(
+        "--mem-tokens",
+        type=int,
+        default=128,
+        help="fixed generation length for the memory-delta measurement",
+    )
+    p.add_argument("--group-size", type=int, default=64)
+    p.add_argument("--prompts-file", type=Path, default=None)
+    p.add_argument(
+        "--niah",
+        action="store_true",
+        help="run the optional NIAH retrieval metric (RAM/chip-tier-gated)",
+    )
+    p.add_argument(
+        "--enforce",
+        action="store_true",
+        help="exit non-zero on FAIL (default: advisory, always exit 0)",
+    )
+    p.add_argument("--json-out", type=Path, default=None)
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    prompts = _load_prompts(args.prompts_file)
+    return run_gate(
+        model_arg=args.model,
+        candidate_dtypes=list(dict.fromkeys(args.candidate)),
+        prompts=prompts,
+        max_tokens=args.max_tokens,
+        mem_tokens=args.mem_tokens,
+        kv_group_size=args.group_size,
+        advisory=not args.enforce,
+        run_niah=args.niah,
+        json_out=args.json_out,
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_chip_tier.py
+++ b/tests/test_chip_tier.py
@@ -49,6 +49,9 @@ _CASES = [
     ("", False, None, VARIANT_UNKNOWN, False),
     (None, False, None, VARIANT_UNKNOWN, False),
     ("Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz", False, None, VARIANT_UNKNOWN, False),
+    # Incidental M<n> in an unrelated (non-Apple, not-leading) string -> unknown.
+    ("BMW M3", False, None, VARIANT_UNKNOWN, False),
+    ("BMW M3 Competition", False, None, VARIANT_UNKNOWN, False),
 ]
 
 

--- a/tests/test_chip_tier.py
+++ b/tests/test_chip_tier.py
@@ -1,0 +1,105 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Hermetic tests for the structured chip-tier classifier (absorb #5).
+
+Table-driven over the real chip strings the engine's existing detectors emit
+(``machdep.cpu.brand_string`` form + ``HARDWARE_PROFILES`` keys) plus the
+fallback / non-Apple shapes. Pure string parsing — no system calls.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from vllm_mlx.chip_tier import (
+    VARIANT_BASE,
+    VARIANT_MAX,
+    VARIANT_PRO,
+    VARIANT_ULTRA,
+    VARIANT_UNKNOWN,
+    ChipTier,
+    classify_chip_tier,
+    detect_chip_tier,
+)
+
+# (raw, is_apple, generation, variant, is_m3_or_newer)
+_CASES = [
+    # machdep.cpu.brand_string form
+    ("Apple M1", True, 1, VARIANT_BASE, False),
+    ("Apple M2 Pro", True, 2, VARIANT_PRO, False),
+    ("Apple M2 Max", True, 2, VARIANT_MAX, False),
+    ("Apple M2 Ultra", True, 2, VARIANT_ULTRA, False),
+    ("Apple M3", True, 3, VARIANT_BASE, True),
+    ("Apple M3 Pro", True, 3, VARIANT_PRO, True),
+    ("Apple M3 Max", True, 3, VARIANT_MAX, True),
+    ("Apple M3 Ultra", True, 3, VARIANT_ULTRA, True),
+    ("Apple M4", True, 4, VARIANT_BASE, True),
+    ("Apple M4 Max", True, 4, VARIANT_MAX, True),
+    # HARDWARE_PROFILES key form (no "Apple" prefix)
+    ("M1", True, 1, VARIANT_BASE, False),
+    ("M1 Ultra", True, 1, VARIANT_ULTRA, False),
+    ("M4 Pro", True, 4, VARIANT_PRO, True),
+    # Case-insensitivity
+    ("apple m3 ultra", True, 3, VARIANT_ULTRA, True),
+    ("APPLE M2 PRO", True, 2, VARIANT_PRO, False),
+    # Future generation — must not crash or clamp
+    ("Apple M13 Ultra", True, 13, VARIANT_ULTRA, True),
+    # Fallback / non-Apple / degenerate
+    ("Apple Silicon", False, None, VARIANT_UNKNOWN, False),
+    ("Unknown", False, None, VARIANT_UNKNOWN, False),
+    ("", False, None, VARIANT_UNKNOWN, False),
+    (None, False, None, VARIANT_UNKNOWN, False),
+    ("Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz", False, None, VARIANT_UNKNOWN, False),
+]
+
+
+@pytest.mark.parametrize(
+    "raw,is_apple,generation,variant,is_m3", _CASES, ids=[repr(c[0]) for c in _CASES]
+)
+def test_classify_chip_tier_table(raw, is_apple, generation, variant, is_m3):
+    tier = classify_chip_tier(raw)
+    assert isinstance(tier, ChipTier)
+    assert tier.raw == (raw or "")
+    assert tier.is_apple_silicon is is_apple
+    assert tier.generation == generation
+    assert tier.variant == variant
+    assert tier.is_m3_or_newer is is_m3
+
+
+def test_substring_variant_does_not_false_trigger():
+    """A word merely CONTAINING a variant token must not set the variant."""
+    tier = classify_chip_tier("Apple M3 Maximum")
+    assert tier.generation == 3
+    # "Maximum" is not the exact token "Max" -> stays base, never VARIANT_MAX.
+    assert tier.variant == VARIANT_BASE
+
+
+def test_first_m_token_wins():
+    """Only the first M<n> token drives the generation."""
+    tier = classify_chip_tier("Apple M3 something M9")
+    assert tier.generation == 3
+
+
+def test_is_m3_or_newer_boundary():
+    assert classify_chip_tier("Apple M2 Ultra").is_m3_or_newer is False
+    assert classify_chip_tier("Apple M3").is_m3_or_newer is True
+
+
+def test_unknown_tier_never_raises_and_is_explicit():
+    for junk in ["", "   ", "banana", "M", "MX", "Mmm", "3M company"]:
+        tier = classify_chip_tier(junk)
+        assert tier.is_apple_silicon is False
+        assert tier.generation is None
+        assert tier.variant == VARIANT_UNKNOWN
+
+
+def test_detect_chip_tier_returns_valid_tier():
+    """detect_chip_tier must return a ChipTier on any host without raising."""
+    tier = detect_chip_tier()
+    assert isinstance(tier, ChipTier)
+    # Consistency invariants regardless of the host chip.
+    if tier.is_apple_silicon:
+        assert isinstance(tier.generation, int)
+        assert tier.is_m3_or_newer == (tier.generation >= 3)
+    else:
+        assert tier.generation is None
+        assert tier.variant == VARIANT_UNKNOWN

--- a/tests/test_kv_quant_gate.py
+++ b/tests/test_kv_quant_gate.py
@@ -136,6 +136,26 @@ def test_logit_divergence_catastrophic_neg_inf_is_finite():
     assert r.mean_kl > 1.0  # clearly flags the divergence
 
 
+def test_logit_divergence_nan_in_logits_is_finite():
+    # A NaN anywhere in either vector must NOT poison the aggregate KL (which
+    # would make the whole gate report NaN and silently pass every threshold).
+    base = [_logsoftmax([4.0, 0.0, 1.0]), _logsoftmax([1.0, 2.0, 0.0])]
+    cand = [np.array([np.nan, 0.0, 1.0]), _logsoftmax([1.0, 2.0, 0.0])]
+    r = logit_divergence(base, cand)
+    assert math.isfinite(r.mean_kl)
+    assert math.isfinite(r.max_kl)
+    assert r.mean_kl > 0.0  # the NaN step is charged the ceiling, not dropped
+    assert r.compared_steps == 2
+
+
+def test_logit_divergence_all_nan_stays_finite_and_high():
+    base = [_logsoftmax([3.0, 0.0])]
+    cand = [np.array([np.nan, np.nan])]
+    r = logit_divergence(base, cand)
+    assert math.isfinite(r.mean_kl)
+    assert r.mean_kl > 1.0
+
+
 def test_logit_divergence_empty():
     r = logit_divergence([], [])
     assert r.compared_steps == 0
@@ -254,6 +274,56 @@ def test_memory_delta_no_saving():
     d = memory_delta(1000, 1000)
     assert d.reduction_ratio == 1.0
     assert d.saved_bytes == 0
+
+
+# ---------------------------------------------------------------------------
+# Baseline KV-cache dtype detection (harness helper, hermetic — no mlx load)
+# ---------------------------------------------------------------------------
+class _FakeDtype:
+    def __init__(self, name: str) -> None:
+        self._name = name
+
+    def __str__(self) -> str:  # mimics mlx: str(mx.bfloat16) == "mlx.core.bfloat16"
+        return self._name
+
+
+class _FakeArr:
+    def __init__(self, dtype: _FakeDtype) -> None:
+        self.dtype = dtype
+
+
+class _FakeKVLayer:
+    """A plain (non-quantized) KVCache exposes ``keys`` as a single array."""
+
+    def __init__(self, dtype_name: str) -> None:
+        self.keys = _FakeArr(_FakeDtype(dtype_name))
+
+
+class _FakeQuantLayer:
+    """A QuantizedKVCache exposes ``keys`` as a (packed, scales, biases) tuple."""
+
+    def __init__(self) -> None:
+        self.keys = (_FakeArr(_FakeDtype("uint32")), object(), object())
+
+
+def test_baseline_kv_dtype_reads_real_dtype_not_hardcoded():
+    """RED-GREEN: report must reflect the loaded model's actual KV dtype.
+
+    Hardcoding ``"bf16"`` mislabels the many fp16 mlx checkpoints; the helper
+    strips the ``mlx.core.`` prefix and returns the true element dtype.
+    """
+    from scripts.kv_quant_quality_gate import _baseline_kv_dtype
+
+    assert _baseline_kv_dtype([_FakeKVLayer("mlx.core.bfloat16")]) == "bfloat16"
+    assert _baseline_kv_dtype([_FakeKVLayer("mlx.core.float16")]) == "float16"
+
+
+def test_baseline_kv_dtype_ignores_quantized_and_returns_unknown():
+    from scripts.kv_quant_quality_gate import _baseline_kv_dtype
+
+    # A quantized layer's ``keys`` is a tuple -> not a plain baseline dtype.
+    assert _baseline_kv_dtype([_FakeQuantLayer()]) == "unknown"
+    assert _baseline_kv_dtype([]) == "unknown"
 
 
 # ---------------------------------------------------------------------------
@@ -672,7 +742,9 @@ def test_smoke_real_harness_on_cached_model(tmp_path, monkeypatch):
     rep = reports[0]
     assert rep["schema"] == 1
     assert rep["candidate_dtype"] == "int8"
-    assert rep["baseline_dtype"] == "bf16"
+    # Baseline dtype is READ from the real cache, not hardcoded — dense mlx
+    # checkpoints are bfloat16 or float16, never a quantized "int*" label.
+    assert rep["baseline_dtype"] in {"bfloat16", "float16"}
     assert 0.0 <= rep["agreement"]["rate"] <= 1.0
     # int8 KV must actually save memory vs bf16 on a dense model.
     assert rep["memory"]["reduction_ratio"] > 1.0

--- a/tests/test_kv_quant_gate.py
+++ b/tests/test_kv_quant_gate.py
@@ -1,0 +1,456 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Hermetic tests for the KV-quant differential quality gate (absorb #4).
+
+All metric tests use SYNTHETIC baseline/candidate token streams + logprob
+vectors + byte counts — no model inference. A single ``@pytest.mark.slow`` smoke
+runs the real harness on ONE small already-cached model and SKIPS cleanly when
+the model isn't in the local HF cache (never downloads).
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from vllm_mlx.kv_quant_gate import (
+    FAIL,
+    NA,
+    PASS,
+    AgreementResult,
+    LogitDivergence,
+    RetentionResult,
+    build_report,
+    default_thresholds,
+    extract_json_candidate,
+    greedy_agreement_rate,
+    is_valid_json,
+    logit_divergence,
+    memory_delta,
+    structured_output_retention,
+)
+
+
+def _logsoftmax(logits: list[float]) -> np.ndarray:
+    arr = np.asarray(logits, dtype=np.float64)
+    return arr - float(np.log(np.sum(np.exp(arr))))
+
+
+# ---------------------------------------------------------------------------
+# Greedy agreement
+# ---------------------------------------------------------------------------
+def test_greedy_agreement_identical():
+    r = greedy_agreement_rate([1, 2, 3, 4], [1, 2, 3, 4])
+    assert r.rate == 1.0
+    assert r.matched == 4
+    assert r.total == 4
+    assert r.first_divergence_index is None
+
+
+def test_greedy_agreement_one_token_diff():
+    # Diverges at index 2 -> 2 leading matches out of 4 compared.
+    r = greedy_agreement_rate([1, 2, 3, 4], [1, 2, 9, 4])
+    assert r.first_divergence_index == 2
+    assert r.matched == 2
+    assert r.total == 4
+    assert r.rate == 0.5
+
+
+def test_greedy_agreement_diverge_immediately():
+    r = greedy_agreement_rate([5, 6], [9, 6])
+    assert r.first_divergence_index == 0
+    assert r.matched == 0
+    assert r.rate == 0.0
+
+
+def test_greedy_agreement_empty_streams():
+    r = greedy_agreement_rate([], [])
+    assert r.total == 0
+    assert r.rate == 1.0
+    assert r.first_divergence_index is None
+
+
+def test_greedy_agreement_different_lengths_uses_min():
+    r = greedy_agreement_rate([1, 2, 3], [1, 2])
+    assert r.total == 2
+    assert r.matched == 2
+    assert r.rate == 1.0
+
+
+# ---------------------------------------------------------------------------
+# Logit divergence
+# ---------------------------------------------------------------------------
+def test_logit_divergence_identical_is_zero():
+    base = [_logsoftmax([2.0, 1.0, 0.0]), _logsoftmax([0.0, 3.0, 1.0])]
+    r = logit_divergence(base, base)
+    assert r.compared_steps == 2
+    assert r.mean_kl == pytest.approx(0.0, abs=1e-9)
+    assert r.max_kl == pytest.approx(0.0, abs=1e-9)
+    assert r.top1_agreement_rate == 1.0
+
+
+def test_logit_divergence_degraded_positive_kl_and_top1_drop():
+    base = [_logsoftmax([5.0, 0.0, 0.0])]  # argmax 0
+    cand = [_logsoftmax([0.0, 5.0, 0.0])]  # argmax 1
+    r = logit_divergence(base, cand)
+    assert r.compared_steps == 1
+    assert r.mean_kl > 0.1
+    assert r.top1_agreement_rate == 0.0
+
+
+def test_logit_divergence_compare_len_bounds_steps():
+    base = [_logsoftmax([3.0, 0.0]), _logsoftmax([0.0, 3.0]), _logsoftmax([1.0, 0.0])]
+    cand = list(base)
+    r = logit_divergence(base, cand, compare_len=1)
+    assert r.compared_steps == 1
+
+
+def test_logit_divergence_catastrophic_neg_inf_is_finite():
+    # Baseline has mass at index 0; candidate assigns it -inf logprob.
+    base = [_logsoftmax([10.0, 0.0])]
+    cand = [np.array([-np.inf, 0.0])]
+    r = logit_divergence(base, cand)
+    assert math.isfinite(r.mean_kl)
+    assert r.mean_kl > 1.0  # clearly flags the divergence
+
+
+def test_logit_divergence_empty():
+    r = logit_divergence([], [])
+    assert r.compared_steps == 0
+    assert r.mean_kl == 0.0
+    assert r.top1_agreement_rate == 1.0
+
+
+def test_logit_divergence_shape_mismatch_step_skipped():
+    base = [_logsoftmax([1.0, 2.0, 3.0])]
+    cand = [_logsoftmax([1.0, 2.0])]  # wrong vocab size -> skipped
+    r = logit_divergence(base, cand)
+    assert r.compared_steps == 0
+
+
+# ---------------------------------------------------------------------------
+# Structured-output retention + JSON helpers
+# ---------------------------------------------------------------------------
+def test_is_valid_json_plain_and_fenced_and_embedded():
+    assert is_valid_json('{"a": 1}')
+    assert is_valid_json('```json\n{"a": 1}\n```')
+    assert is_valid_json('Sure! Here you go: {"a": [1, 2, 3]} — done.')
+    assert is_valid_json("[1, 2, 3]")
+    assert not is_valid_json("not json at all")
+    assert not is_valid_json("")
+
+
+def test_extract_json_candidate_prefers_fence():
+    assert extract_json_candidate('```json\n{"x": 1}\n```') == '{"x": 1}'
+    assert extract_json_candidate('prefix {"x": 1} suffix') == '{"x": 1}'
+
+
+def test_retention_both_valid():
+    r = structured_output_retention([('{"a": 1}', '{"a": 2}')])
+    assert r.attributable == 1
+    assert r.retained == 1
+    assert r.rate == 1.0
+    assert r.baseline_invalid == 0
+
+
+def test_retention_candidate_breaks():
+    r = structured_output_retention([('{"a": 1}', "sorry, no json")])
+    assert r.attributable == 1
+    assert r.retained == 0
+    assert r.rate == 0.0
+
+
+def test_retention_baseline_invalid_is_excluded():
+    r = structured_output_retention([("garbage", "garbage")])
+    assert r.attributable == 0
+    assert r.baseline_invalid == 1
+    assert r.rate is None  # N/A — nothing attributable
+
+
+def test_retention_mixed():
+    pairs = [
+        ('{"a": 1}', '{"a": 1}'),  # attributable, retained
+        ('{"b": 2}', "broke"),  # attributable, lost
+        ("not json", "not json"),  # excluded
+    ]
+    r = structured_output_retention(pairs)
+    assert r.attributable == 2
+    assert r.retained == 1
+    assert r.rate == 0.5
+    assert r.baseline_invalid == 1
+
+
+# ---------------------------------------------------------------------------
+# Memory delta
+# ---------------------------------------------------------------------------
+def test_memory_delta_typical_int8():
+    d = memory_delta(1000, 500)
+    assert d.saved_bytes == 500
+    assert d.reduction_ratio == 2.0
+    assert d.saved_pct == 50.0
+
+
+def test_memory_delta_candidate_zero_is_degenerate():
+    d = memory_delta(1000, 0)
+    assert d.reduction_ratio == 0.0  # treated as no saving, not div-by-zero
+
+
+def test_memory_delta_no_saving():
+    d = memory_delta(1000, 1000)
+    assert d.reduction_ratio == 1.0
+    assert d.saved_bytes == 0
+
+
+# ---------------------------------------------------------------------------
+# Thresholds + report schema + PASS/FAIL logic
+# ---------------------------------------------------------------------------
+def test_default_thresholds_int4_more_lenient_than_int8():
+    t8 = default_thresholds("int8")
+    t4 = default_thresholds("int4")
+    assert t4.min_greedy_agreement < t8.min_greedy_agreement
+    assert t4.max_mean_kl > t8.max_mean_kl
+    assert t4.min_memory_reduction_ratio > t8.min_memory_reduction_ratio
+
+
+def _passing_inputs():
+    """Metric objects that sit exactly at / above the int8 thresholds -> all PASS."""
+    t = default_thresholds("int8")
+    return dict(
+        thresholds=t,
+        agreement=AgreementResult(
+            total=10, matched=6, rate=t.min_greedy_agreement, first_divergence_index=6
+        ),
+        logits=LogitDivergence(
+            compared_steps=8,
+            mean_kl=t.max_mean_kl,  # exactly at bound -> PASS (<=)
+            max_kl=t.max_mean_kl,
+            top1_agreement_rate=0.9,
+        ),
+        retention=RetentionResult(
+            attributable=2, retained=2, rate=1.0, baseline_invalid=0
+        ),
+        memory=memory_delta(2000, 1000),  # 2.0x >= 1.5
+    )
+
+
+def _base_report_kwargs():
+    return dict(
+        model="synthetic",
+        hf_path="synthetic/path",
+        baseline_dtype="bf16",
+        candidate_dtype="int8",
+        num_prompts=5,
+        advisory=True,
+        chip={
+            "raw": "Apple M3 Ultra",
+            "is_apple_silicon": True,
+            "generation": 3,
+            "variant": "Ultra",
+            "is_m3_or_newer": True,
+        },
+    )
+
+
+def test_report_schema_has_expected_fields():
+    report = build_report(**_base_report_kwargs(), **_passing_inputs())
+    d = report.to_dict()
+    for key in (
+        "schema",
+        "kind",
+        "advisory",
+        "model",
+        "hf_path",
+        "baseline_dtype",
+        "candidate_dtype",
+        "num_prompts",
+        "chip",
+        "thresholds",
+        "agreement",
+        "logits",
+        "retention",
+        "memory",
+        "niah",
+        "metrics",
+        "overall",
+    ):
+        assert key in d, key
+    assert set(d["metrics"]) == {
+        "greedy_agreement",
+        "logit_mean_kl",
+        "structured_retention",
+        "memory_reduction",
+    }
+    # to_dict must be JSON-serializable end to end.
+    import json
+
+    json.loads(json.dumps(d))
+
+
+def test_report_all_pass_at_thresholds():
+    report = build_report(**_base_report_kwargs(), **_passing_inputs())
+    assert report.overall == PASS
+    for m in report.metrics.values():
+        assert m["outcome"] == PASS
+
+
+def test_report_agreement_just_below_threshold_fails():
+    inputs = _passing_inputs()
+    t = inputs["thresholds"]
+    inputs["agreement"] = AgreementResult(
+        total=100,
+        matched=int((t.min_greedy_agreement - 0.01) * 100),
+        rate=t.min_greedy_agreement - 0.01,
+        first_divergence_index=1,
+    )
+    report = build_report(**_base_report_kwargs(), **inputs)
+    assert report.metrics["greedy_agreement"]["outcome"] == FAIL
+    assert report.overall == FAIL
+
+
+def test_report_kl_above_threshold_fails():
+    inputs = _passing_inputs()
+    t = inputs["thresholds"]
+    inputs["logits"] = LogitDivergence(
+        compared_steps=4,
+        mean_kl=t.max_mean_kl + 0.5,
+        max_kl=t.max_mean_kl + 0.5,
+        top1_agreement_rate=0.5,
+    )
+    report = build_report(**_base_report_kwargs(), **inputs)
+    assert report.metrics["logit_mean_kl"]["outcome"] == FAIL
+    assert report.overall == FAIL
+
+
+def test_report_memory_below_reduction_fails():
+    inputs = _passing_inputs()
+    inputs["memory"] = memory_delta(1000, 900)  # 1.11x < 1.5x
+    report = build_report(**_base_report_kwargs(), **inputs)
+    assert report.metrics["memory_reduction"]["outcome"] == FAIL
+    assert report.overall == FAIL
+
+
+def test_report_na_metrics_do_not_fail_overall():
+    inputs = _passing_inputs()
+    # No comparable logit steps -> logit_mean_kl NA.
+    inputs["logits"] = LogitDivergence(
+        compared_steps=0, mean_kl=0.0, max_kl=0.0, top1_agreement_rate=1.0
+    )
+    # No attributable JSON prompt -> structured_retention NA.
+    inputs["retention"] = RetentionResult(
+        attributable=0, retained=0, rate=None, baseline_invalid=3
+    )
+    report = build_report(**_base_report_kwargs(), **inputs)
+    assert report.metrics["logit_mean_kl"]["outcome"] == NA
+    assert report.metrics["structured_retention"]["outcome"] == NA
+    # Remaining graded metrics still pass -> overall PASS.
+    assert report.overall == PASS
+
+
+def test_report_niah_participates_in_overall():
+    passing = _passing_inputs()
+    skipped = build_report(
+        **_base_report_kwargs(), **passing, niah={"status": "skipped"}
+    )
+    assert skipped.overall == PASS  # skipped NIAH is NA
+
+    failed = build_report(**_base_report_kwargs(), **passing, niah={"status": "fail"})
+    assert failed.overall == FAIL  # a failing NIAH drags overall down
+
+    passed = build_report(**_base_report_kwargs(), **passing, niah={"status": "pass"})
+    assert passed.overall == PASS
+
+
+def test_human_summary_renders():
+    report = build_report(**_base_report_kwargs(), **_passing_inputs())
+    text = report.human_summary()
+    assert "KV-quant differential quality gate" in text
+    assert "ADVISORY" in text
+    assert "OVERALL:" in text
+
+
+# ---------------------------------------------------------------------------
+# Gated end-to-end smoke — real harness, cached small model only.
+# ---------------------------------------------------------------------------
+# Small, quantizable (dense, non-sliding-window) text models to try, smallest
+# first. The smoke SKIPS unless one is already in the local HF cache.
+_SMOKE_MODEL_CANDIDATES = [
+    "mlx-community/Qwen3-0.6B-4bit",
+    "mlx-community/Qwen3-0.6B-8bit",
+    "mlx-community/Llama-3.2-1B-Instruct-4bit",
+    "mlx-community/Phi-3-mini-4k-instruct-4bit",
+]
+
+
+def _first_cached_model() -> str | None:
+    """Return the first candidate whose config.json is in the local HF cache."""
+    try:
+        from huggingface_hub import try_to_load_from_cache
+    except Exception:
+        return None
+    for repo in _SMOKE_MODEL_CANDIDATES:
+        try:
+            path = try_to_load_from_cache(repo, "config.json")
+        except Exception:
+            continue
+        if isinstance(path, str):
+            return repo
+    return None
+
+
+@pytest.mark.slow
+def test_smoke_real_harness_on_cached_model(tmp_path):
+    """End-to-end: load a real cached small model, run the gate, assert the report.
+
+    Cache-only (never downloads): skips when no candidate model is cached. Run
+    with ``pytest --run-slow -m slow tests/test_kv_quant_gate.py``.
+    """
+    pytest.importorskip("mlx_lm")
+    repo = _first_cached_model()
+    if repo is None:
+        pytest.skip(
+            "no small quantizable model in the local HF cache — smoke is "
+            "cache-only (no download). Pre-cache one of: "
+            + ", ".join(_SMOKE_MODEL_CANDIDATES)
+        )
+
+    from scripts.kv_quant_quality_gate import run_gate
+
+    out = tmp_path / "report.json"
+    rc = run_gate(
+        model_arg=repo,
+        candidate_dtypes=["int8"],
+        prompts=[
+            {"kind": "text", "prompt": "Say hello in one word."},
+            {
+                "kind": "json",
+                "prompt": 'Return ONLY {"ok": true} as JSON. No prose.',
+            },
+        ],
+        max_tokens=16,
+        mem_tokens=32,
+        kv_group_size=64,
+        advisory=True,  # advisory -> exit 0 regardless
+        run_niah=False,
+        json_out=out,
+    )
+    assert rc == 0  # advisory always 0
+
+    import json
+
+    reports = json.loads(out.read_text())
+    assert len(reports) == 1
+    rep = reports[0]
+    assert rep["schema"] == 1
+    assert rep["candidate_dtype"] == "int8"
+    assert rep["baseline_dtype"] == "bf16"
+    assert 0.0 <= rep["agreement"]["rate"] <= 1.0
+    # int8 KV must actually save memory vs bf16 on a dense model.
+    assert rep["memory"]["reduction_ratio"] > 1.0
+    assert rep["memory"]["candidate_bytes"] < rep["memory"]["baseline_bytes"]
+    assert rep["overall"] in {PASS, FAIL, NA}
+    # chip tier must be recorded and internally consistent.
+    chip = rep["chip"]
+    assert "is_apple_silicon" in chip
+    if chip["is_apple_silicon"]:
+        assert chip["is_m3_or_newer"] == (chip["generation"] >= 3)

--- a/tests/test_kv_quant_gate.py
+++ b/tests/test_kv_quant_gate.py
@@ -156,6 +156,33 @@ def test_logit_divergence_all_nan_stays_finite_and_high():
     assert r.mean_kl > 1.0
 
 
+def test_logit_divergence_unnormalized_shift_invariant():
+    # RED-GREEN (codex round 4 blocking #2): the SAME distribution expressed as
+    # raw logits offset by DIFFERENT additive constants is identical as a
+    # probability distribution -> forward KL must be ~0. The half-normalized code
+    # (weights renormalized, but the log-ratio taken on raw values) reported a
+    # spurious non-zero here; renormalizing BOTH vectors via log-sum-exp fixes it.
+    logits = np.array([2.0, 1.0, 0.5, -1.0, 3.0])
+    base = [logits + 7.0]  # shifted up
+    cand = [logits - 4.0]  # shifted down — same softmax
+    r = logit_divergence(base, cand)
+    assert r.compared_steps == 1
+    assert r.mean_kl == pytest.approx(0.0, abs=1e-9)
+    assert r.max_kl == pytest.approx(0.0, abs=1e-9)
+    assert r.top1_agreement_rate == 1.0
+
+
+def test_logit_divergence_raw_logits_match_logsoftmax_inputs():
+    # Feeding raw logits must give the same KL as feeding their log_softmax — the
+    # metric renormalizes internally, so callers need not pre-normalize.
+    base_logits = np.array([4.0, 1.0, 0.0, 2.0])
+    cand_logits = np.array([3.0, 2.0, 0.0, 1.0])
+    r_raw = logit_divergence([base_logits], [cand_logits])
+    r_norm = logit_divergence([_logsoftmax(base_logits)], [_logsoftmax(cand_logits)])
+    assert r_raw.mean_kl == pytest.approx(r_norm.mean_kl, abs=1e-9)
+    assert r_raw.mean_kl > 0.0
+
+
 def test_logit_divergence_empty():
     r = logit_divergence([], [])
     assert r.compared_steps == 0
@@ -324,6 +351,52 @@ def test_baseline_kv_dtype_ignores_quantized_and_returns_unknown():
     # A quantized layer's ``keys`` is a tuple -> not a plain baseline dtype.
     assert _baseline_kv_dtype([_FakeQuantLayer()]) == "unknown"
     assert _baseline_kv_dtype([]) == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Decode strips special tokens (harness helper) — codex round 4 blocking #1
+# ---------------------------------------------------------------------------
+class _FakeTokenizerWithEOS:
+    """Greedy generation stops ON the EOS token (id 9), which is appended to the
+    stream; a naive decode leaves ``<|im_end|>`` trailing and breaks strict JSON.
+    """
+
+    _VOCAB = {1: "{", 2: '"ok":', 3: "true", 4: "}", 9: "<|im_end|>"}
+
+    def decode(self, ids, skip_special_tokens: bool = False) -> str:
+        text = "".join(self._VOCAB[i] for i in ids)
+        if skip_special_tokens:
+            text = text.replace("<|im_end|>", "")
+        return text
+
+
+class _OldTokenizerNoKwarg:
+    def decode(self, ids) -> str:  # no skip_special_tokens kwarg at all
+        return "x" * len(ids)
+
+
+def test_decode_text_strips_trailing_eos_so_strict_json_holds():
+    """RED-GREEN: retention decoded WITHOUT skip_special_tokens keeps a trailing
+    EOS control token, which fails the strict whole-output JSON parse and falsely
+    scores structured retention N/A/FAIL. ``_decode_text`` must strip it.
+    """
+    from scripts.kv_quant_quality_gate import _decode_text
+    from vllm_mlx.kv_quant_gate import is_valid_json
+
+    tok = _FakeTokenizerWithEOS()
+    with_eos = [1, 2, 3, 4, 9]  # JSON then the appended EOS
+    assert tok.decode(with_eos) == '{"ok":true}<|im_end|>'
+    assert not is_valid_json(tok.decode(with_eos))  # the bug: prose-wrapped
+    text = _decode_text(tok, with_eos)
+    assert text == '{"ok":true}'
+    assert is_valid_json(text)  # fixed: strict JSON survives
+
+
+def test_decode_text_falls_back_when_kwarg_unsupported():
+    from scripts.kv_quant_quality_gate import _decode_text
+
+    # A tokenizer whose decode rejects the kwarg must not crash the gate.
+    assert _decode_text(_OldTokenizerNoKwarg(), [1, 2, 3]) == "xxx"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_kv_quant_gate.py
+++ b/tests/test_kv_quant_gate.py
@@ -400,6 +400,49 @@ def test_decode_text_falls_back_when_kwarg_unsupported():
 
 
 # ---------------------------------------------------------------------------
+# Offline enforcement is reliable even if huggingface_hub was imported first
+# (codex round 5 blocking) — hermetic, no model load.
+# ---------------------------------------------------------------------------
+def test_enable_hf_offline_overrides_preimported_constant():
+    """RED-GREEN: ``huggingface_hub.constants`` snapshots ``HF_HUB_OFFLINE`` from
+    the env ONCE at import; ``is_offline_mode()`` returns that frozen global. If
+    the hub was imported while ONLINE, setting the env var alone leaves
+    ``is_offline_mode()`` False and a network fetch can still happen.
+    ``_enable_hf_offline`` must also patch the in-memory constant so the "no
+    fetch" contract holds regardless of import order.
+    """
+    import os
+
+    hf = pytest.importorskip("huggingface_hub.constants")
+    from scripts.kv_quant_quality_gate import _enable_hf_offline
+
+    saved_const = hf.HF_HUB_OFFLINE
+    saved_env = {
+        k: os.environ.get(k) for k in ("HF_HUB_OFFLINE", "TRANSFORMERS_OFFLINE")
+    }
+    try:
+        # Simulate a process that imported the hub while online.
+        hf.HF_HUB_OFFLINE = False
+        os.environ.pop("HF_HUB_OFFLINE", None)
+        os.environ.pop("TRANSFORMERS_OFFLINE", None)
+        assert hf.is_offline_mode() is False  # precondition: online
+
+        _enable_hf_offline()
+
+        # Env-var-only would leave this False; the constant patch flips it.
+        assert hf.is_offline_mode() is True
+        assert os.environ["HF_HUB_OFFLINE"] == "1"
+        assert os.environ["TRANSFORMERS_OFFLINE"] == "1"
+    finally:
+        hf.HF_HUB_OFFLINE = saved_const
+        for k, v in saved_env.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+
+# ---------------------------------------------------------------------------
 # Thresholds + report schema + PASS/FAIL logic
 # ---------------------------------------------------------------------------
 def test_default_thresholds_int4_more_lenient_than_int8():

--- a/tests/test_kv_quant_gate.py
+++ b/tests/test_kv_quant_gate.py
@@ -23,7 +23,6 @@ from vllm_mlx.kv_quant_gate import (
     RetentionResult,
     build_report,
     default_thresholds,
-    extract_json_candidate,
     greedy_agreement_rate,
     is_valid_json,
     logit_divergence,
@@ -154,30 +153,27 @@ def test_logit_divergence_shape_mismatch_step_skipped():
 # ---------------------------------------------------------------------------
 # Structured-output retention + JSON helpers
 # ---------------------------------------------------------------------------
-def test_is_valid_json_plain_and_fenced_and_embedded():
+def test_is_valid_json_strict_whole_output():
+    # Whole output IS one JSON value (optionally a single fence) -> valid.
     assert is_valid_json('{"a": 1}')
     assert is_valid_json('```json\n{"a": 1}\n```')
-    assert is_valid_json('Sure! Here you go: {"a": [1, 2, 3]} — done.')
     assert is_valid_json("[1, 2, 3]")
+    assert is_valid_json("  42  ")  # a scalar is a valid JSON document
+    # Empty / non-JSON -> invalid.
     assert not is_valid_json("not json at all")
     assert not is_valid_json("")
 
 
-def test_extract_json_candidate_prefers_fence():
-    assert extract_json_candidate('```json\n{"x": 1}\n```') == '{"x": 1}'
-    assert extract_json_candidate('prefix {"x": 1} suffix') == '{"x": 1}'
-
-
-def test_is_valid_json_embedded_despite_other_brackets():
-    """RED-GREEN: a valid object survives even when another bracketed fragment in
-    the prose would break a naive first-brace-through-last-bracket span. The old
-    span logic yielded ``[x] then {"a": 1}`` / ``[1, 2] and {"ok": true}`` (both
-    unparseable); the raw_decode scan recovers the real JSON value.
+def test_is_valid_json_strict_rejects_prose_wrapped_json():
+    """RED-GREEN: under the 'ONLY JSON' contract, JSON buried in prose is NOT
+    valid. A lenient raw_decode/first-brace scan would (wrongly) accept these;
+    strict whole-output parsing rejects them so a candidate that stops honoring
+    the format contract is caught.
     """
-    assert is_valid_json('see [x] then {"a": 1}')
-    assert is_valid_json('result: [1, 2] and {"ok": true}')
-    # A genuinely JSON-free string still returns False.
-    assert not is_valid_json("no brackets, no json here")
+    assert not is_valid_json('Sure! Here you go: {"a": [1, 2, 3]} — done.')
+    assert not is_valid_json("Sorry, [1]")
+    assert not is_valid_json('see [x] then {"a": 1}')
+    assert not is_valid_json('result: [1, 2] and {"ok": true}')
 
 
 def test_retention_both_valid():
@@ -215,6 +211,30 @@ def test_retention_mixed():
     assert r.baseline_invalid == 1
 
 
+def test_retention_shape_mismatch_not_retained():
+    """RED-GREEN: an object prompt must NOT 'retain' as an array/scalar. Generic
+    JSON validity would count ``[1, 2]`` as retained; shape-aware retention
+    (same top-level type) correctly rejects it.
+    """
+    r = structured_output_retention([('{"a": 1}', "[1, 2]")])
+    assert r.attributable == 1
+    assert r.retained == 0
+    assert r.rate == 0.0
+
+
+def test_retention_dropped_key_not_retained():
+    """RED-GREEN: a candidate object that drops a baseline key is NOT retained —
+    the requested field vanished under quantization.
+    """
+    r = structured_output_retention([('{"name": "x", "age": 3}', '{"name": "x"}')])
+    assert r.attributable == 1
+    assert r.retained == 0
+    assert r.rate == 0.0
+    # Superset of keys is fine (candidate added a field but kept the contract).
+    r2 = structured_output_retention([('{"name": "x"}', '{"name": "y", "extra": 1}')])
+    assert r2.retained == 1
+
+
 # ---------------------------------------------------------------------------
 # Memory delta
 # ---------------------------------------------------------------------------
@@ -245,6 +265,15 @@ def test_default_thresholds_int4_more_lenient_than_int8():
     assert t4.min_greedy_agreement < t8.min_greedy_agreement
     assert t4.max_mean_kl > t8.max_mean_kl
     assert t4.min_memory_reduction_ratio > t8.min_memory_reduction_ratio
+
+
+def test_default_thresholds_rejects_unsupported_dtype():
+    """RED-GREEN: an unknown dtype must raise, not silently borrow int8's
+    thresholds (which would give a misleading verdict for a typo/future dtype).
+    """
+    for bad in ("int2", "bf16", "fp8", ""):
+        with pytest.raises(ValueError):
+            default_thresholds(bad)
 
 
 def _passing_inputs():
@@ -430,6 +459,7 @@ def _run_gate_kwargs(**overrides):
         {"mem_tokens": 0},
         {"kv_group_size": 0},
         {"prompts": []},
+        {"candidate_dtypes": []},  # empty -> enforced no-op "pass" without it
     ],
 )
 def test_run_gate_rejects_bad_config_before_load(override):
@@ -529,35 +559,58 @@ _SMOKE_MODEL_CANDIDATES = [
 ]
 
 
-# A COMPLETE snapshot needs config + tokenizer + at least one weights artifact.
-# Probing only ``config.json`` would let ``mlx_lm.load`` fetch a missing shard /
-# tokenizer over the network — violating the cache-only (no-download) contract.
+# A COMPLETE snapshot needs config + tokenizer config + a tokenizer data file +
+# ALL weight shards. Probing only ``config.json`` (or an index without its
+# shards) would let ``mlx_lm.load`` fetch a missing file over the network —
+# violating the cache-only (no-download) contract.
 _REQUIRED_CACHE_FILES = ("config.json", "tokenizer_config.json")
-_WEIGHT_CANDIDATE_FILES = ("model.safetensors", "model.safetensors.index.json")
+# Tokenizer payload — a repo ships exactly one of these; require at least one.
+_TOKENIZER_DATA_FILES = ("tokenizer.json", "tokenizer.model", "vocab.json")
 
 
 def _model_fully_cached(repo: str) -> bool:
     """True iff a COMPLETE local snapshot of ``repo`` is in the HF cache.
 
     Deterministic cache probe (``try_to_load_from_cache`` — a real ``str`` path
-    means present) for config + tokenizer + a weights artifact. No network, no
-    exception-message classification (the flaky pattern the gemma4 tests warned
-    against).
+    means present). Verifies config + tokenizer config + a tokenizer data file +
+    a full weight set: either a single ``model.safetensors`` OR a
+    ``model.safetensors.index.json`` whose ``weight_map`` shards are ALL cached.
+    No network, no exception-message classification (the flaky pattern the gemma4
+    tests warned against).
     """
     try:
+        import json as _json
+        from pathlib import Path as _Path
+
         from huggingface_hub import try_to_load_from_cache
     except Exception:
         return False
 
-    def cached(filename: str) -> bool:
+    def cached_path(filename: str) -> str | None:
         try:
-            return isinstance(try_to_load_from_cache(repo, filename), str)
+            path = try_to_load_from_cache(repo, filename)
         except Exception:
-            return False
+            return None
+        return path if isinstance(path, str) else None
 
-    if not all(cached(f) for f in _REQUIRED_CACHE_FILES):
+    if not all(cached_path(f) for f in _REQUIRED_CACHE_FILES):
         return False
-    return any(cached(f) for f in _WEIGHT_CANDIDATE_FILES)
+    if not any(cached_path(f) for f in _TOKENIZER_DATA_FILES):
+        return False
+
+    # Single-file weights.
+    if cached_path("model.safetensors"):
+        return True
+    # Sharded weights: the index must be cached AND every shard it references.
+    index_path = cached_path("model.safetensors.index.json")
+    if index_path is None:
+        return False
+    try:
+        weight_map = _json.loads(_Path(index_path).read_text())["weight_map"]
+        shards = set(weight_map.values())
+    except Exception:
+        return False
+    return bool(shards) and all(cached_path(shard) for shard in shards)
 
 
 def _first_cached_model() -> str | None:

--- a/tests/test_kv_quant_gate.py
+++ b/tests/test_kv_quant_gate.py
@@ -71,11 +71,33 @@ def test_greedy_agreement_empty_streams():
     assert r.first_divergence_index is None
 
 
-def test_greedy_agreement_different_lengths_uses_min():
-    r = greedy_agreement_rate([1, 2, 3], [1, 2])
-    assert r.total == 2
+def test_greedy_agreement_premature_eos_scores_below_one():
+    """RED-GREEN: a candidate that ends early after an all-matching prefix must
+    NOT score 1.0. With the old ``min`` denominator this returned 1.0, hiding the
+    premature-EOS degradation the gate exists to catch; the ``max`` denominator
+    counts the missing suffix positions as disagreement.
+    """
+    # baseline 5 tokens, candidate terminated at 3 (premature EOS), prefix matches
+    r = greedy_agreement_rate([1, 2, 3, 4, 5], [1, 2, 3])
+    assert r.total == 5  # denominator is the LONGER stream, not the shorter
+    assert r.matched == 3
+    assert r.rate == 0.6
+    assert r.first_divergence_index == 3  # boundary where the short stream ended
+
+
+def test_greedy_agreement_candidate_longer_also_penalized():
+    r = greedy_agreement_rate([1, 2], [1, 2, 3, 4])
+    assert r.total == 4
     assert r.matched == 2
-    assert r.rate == 1.0
+    assert r.rate == 0.5
+    assert r.first_divergence_index == 2
+
+
+def test_greedy_agreement_empty_vs_nonempty_scores_zero():
+    r = greedy_agreement_rate([], [1, 2, 3])
+    assert r.total == 3
+    assert r.matched == 0
+    assert r.rate == 0.0
 
 
 # ---------------------------------------------------------------------------
@@ -144,6 +166,18 @@ def test_is_valid_json_plain_and_fenced_and_embedded():
 def test_extract_json_candidate_prefers_fence():
     assert extract_json_candidate('```json\n{"x": 1}\n```') == '{"x": 1}'
     assert extract_json_candidate('prefix {"x": 1} suffix') == '{"x": 1}'
+
+
+def test_is_valid_json_embedded_despite_other_brackets():
+    """RED-GREEN: a valid object survives even when another bracketed fragment in
+    the prose would break a naive first-brace-through-last-bracket span. The old
+    span logic yielded ``[x] then {"a": 1}`` / ``[1, 2] and {"ok": true}`` (both
+    unparseable); the raw_decode scan recovers the real JSON value.
+    """
+    assert is_valid_json('see [x] then {"a": 1}')
+    assert is_valid_json('result: [1, 2] and {"ok": true}')
+    # A genuinely JSON-free string still returns False.
+    assert not is_valid_json("no brackets, no json here")
 
 
 def test_retention_both_valid():
@@ -370,6 +404,119 @@ def test_human_summary_renders():
 
 
 # ---------------------------------------------------------------------------
+# Harness guards (hermetic — no model load; the guards run before any import).
+# ---------------------------------------------------------------------------
+def _run_gate_kwargs(**overrides):
+    base = dict(
+        model_arg="dummy",
+        candidate_dtypes=["int8"],
+        prompts=[{"kind": "text", "prompt": "hi"}],
+        max_tokens=8,
+        mem_tokens=16,
+        kv_group_size=64,
+        advisory=True,
+        run_niah=False,
+        json_out=None,
+    )
+    base.update(overrides)
+    return base
+
+
+@pytest.mark.parametrize(
+    "override",
+    [
+        {"max_tokens": 0},
+        {"max_tokens": -1},
+        {"mem_tokens": 0},
+        {"kv_group_size": 0},
+        {"prompts": []},
+    ],
+)
+def test_run_gate_rejects_bad_config_before_load(override):
+    """RED-GREEN: non-positive token budgets / empty prompts raise up front.
+
+    A zero/negative budget yields empty generations that would score a vacuous
+    1.0 agreement — an enforced gate must never 'pass' without measuring. The
+    guard runs before any mlx_lm import, so this is hermetic (no model load).
+    """
+    from scripts.kv_quant_quality_gate import run_gate
+
+    with pytest.raises(ValueError):
+        run_gate(**_run_gate_kwargs(**override))
+
+
+def test_positive_int_argparse_type_rejects_nonpositive():
+    import argparse
+
+    from scripts.kv_quant_quality_gate import _positive_int
+
+    assert _positive_int("48") == 48
+    for bad in ("0", "-3"):
+        with pytest.raises(argparse.ArgumentTypeError):
+            _positive_int(bad)
+
+
+def test_niah_fail_closed_on_unknown_ram():
+    """RED-GREEN: when RAM is undetected (None) NIAH must SKIP, not run.
+
+    The chip qualifies (M3 Ultra) so the RAM guard is the deciding factor;
+    unknown capacity must fail closed rather than assume headroom.
+    """
+    from scripts.kv_quant_quality_gate import _maybe_run_niah
+    from vllm_mlx.chip_tier import classify_chip_tier
+
+    chip = classify_chip_tier("Apple M3 Ultra")
+    assert chip.is_m3_or_newer  # precondition — RAM guard is what decides
+    result = _maybe_run_niah(
+        None,
+        None,
+        chip,
+        enabled=True,
+        max_tokens=8,
+        kv_bits=8,
+        kv_group_size=64,
+        eos_ids=set(),
+        total_ram_gb=None,
+    )
+    assert result["status"] == "skipped"
+    assert "undetected" in result["reason"] or "fail-closed" in result["reason"]
+
+
+def test_niah_skips_when_not_requested_and_sub_m3():
+    from scripts.kv_quant_quality_gate import _maybe_run_niah
+    from vllm_mlx.chip_tier import classify_chip_tier
+
+    m3 = classify_chip_tier("Apple M3 Ultra")
+    m1 = classify_chip_tier("Apple M1")
+    # Not requested -> skipped regardless of chip.
+    r1 = _maybe_run_niah(
+        None,
+        None,
+        m3,
+        enabled=False,
+        max_tokens=8,
+        kv_bits=8,
+        kv_group_size=64,
+        eos_ids=set(),
+        total_ram_gb=256.0,
+    )
+    assert r1["status"] == "skipped" and "not requested" in r1["reason"]
+    # Sub-M3 chip -> skipped even when requested with ample RAM.
+    r2 = _maybe_run_niah(
+        None,
+        None,
+        m1,
+        enabled=True,
+        max_tokens=8,
+        kv_bits=8,
+        kv_group_size=64,
+        eos_ids=set(),
+        total_ram_gb=256.0,
+    )
+    assert r2["status"] == "skipped" and "below M3" in r2["reason"]
+
+
+# ---------------------------------------------------------------------------
 # Gated end-to-end smoke — real harness, cached small model only.
 # ---------------------------------------------------------------------------
 # Small, quantizable (dense, non-sliding-window) text models to try, smallest
@@ -382,37 +529,66 @@ _SMOKE_MODEL_CANDIDATES = [
 ]
 
 
-def _first_cached_model() -> str | None:
-    """Return the first candidate whose config.json is in the local HF cache."""
+# A COMPLETE snapshot needs config + tokenizer + at least one weights artifact.
+# Probing only ``config.json`` would let ``mlx_lm.load`` fetch a missing shard /
+# tokenizer over the network — violating the cache-only (no-download) contract.
+_REQUIRED_CACHE_FILES = ("config.json", "tokenizer_config.json")
+_WEIGHT_CANDIDATE_FILES = ("model.safetensors", "model.safetensors.index.json")
+
+
+def _model_fully_cached(repo: str) -> bool:
+    """True iff a COMPLETE local snapshot of ``repo`` is in the HF cache.
+
+    Deterministic cache probe (``try_to_load_from_cache`` — a real ``str`` path
+    means present) for config + tokenizer + a weights artifact. No network, no
+    exception-message classification (the flaky pattern the gemma4 tests warned
+    against).
+    """
     try:
         from huggingface_hub import try_to_load_from_cache
     except Exception:
-        return None
-    for repo in _SMOKE_MODEL_CANDIDATES:
+        return False
+
+    def cached(filename: str) -> bool:
         try:
-            path = try_to_load_from_cache(repo, "config.json")
+            return isinstance(try_to_load_from_cache(repo, filename), str)
         except Exception:
-            continue
-        if isinstance(path, str):
+            return False
+
+    if not all(cached(f) for f in _REQUIRED_CACHE_FILES):
+        return False
+    return any(cached(f) for f in _WEIGHT_CANDIDATE_FILES)
+
+
+def _first_cached_model() -> str | None:
+    """Return the first candidate with a COMPLETE local snapshot, else None."""
+    for repo in _SMOKE_MODEL_CANDIDATES:
+        if _model_fully_cached(repo):
             return repo
     return None
 
 
 @pytest.mark.slow
-def test_smoke_real_harness_on_cached_model(tmp_path):
+def test_smoke_real_harness_on_cached_model(tmp_path, monkeypatch):
     """End-to-end: load a real cached small model, run the gate, assert the report.
 
-    Cache-only (never downloads): skips when no candidate model is cached. Run
-    with ``pytest --run-slow -m slow tests/test_kv_quant_gate.py``.
+    Cache-only (never downloads): skips unless a COMPLETE snapshot is cached, and
+    forces HF offline mode so the load can NEVER reach the network. Run with
+    ``pytest --run-slow -m slow tests/test_kv_quant_gate.py``.
     """
     pytest.importorskip("mlx_lm")
     repo = _first_cached_model()
     if repo is None:
         pytest.skip(
-            "no small quantizable model in the local HF cache — smoke is "
+            "no COMPLETE small-model snapshot in the local HF cache — smoke is "
             "cache-only (no download). Pre-cache one of: "
             + ", ".join(_SMOKE_MODEL_CANDIDATES)
         )
+
+    # Belt-and-suspenders: even though the snapshot is complete, force offline so
+    # a stray fetch is impossible (raises instead of downloading).
+    monkeypatch.setenv("HF_HUB_OFFLINE", "1")
+    monkeypatch.setenv("TRANSFORMERS_OFFLINE", "1")
 
     from scripts.kv_quant_quality_gate import run_gate
 

--- a/vllm_mlx/chip_tier.py
+++ b/vllm_mlx/chip_tier.py
@@ -181,6 +181,7 @@ def detect_chip_tier() -> ChipTier:
                 capture_output=True,
                 text=True,
                 check=True,
+                timeout=2,
             )
             chip_name = result.stdout.strip()
         except Exception:

--- a/vllm_mlx/chip_tier.py
+++ b/vllm_mlx/chip_tier.py
@@ -1,0 +1,176 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Structured Apple-silicon chip-tier classifier.
+
+Chip *detection* already exists in the engine:
+
+* :func:`vllm_mlx.optimizations.detect_hardware` returns a
+  :class:`~vllm_mlx.optimizations.HardwareInfo` whose ``chip_name`` is a short
+  profile key (e.g. ``"M3 Ultra"``).
+* :func:`vllm_mlx.vllm_platform._get_apple_chip_name` reads the raw
+  ``machdep.cpu.brand_string`` (e.g. ``"Apple M3 Ultra"``).
+
+What was MISSING is a *structured* tier — a small, pure parse of that free-form
+chip string into fields code can branch on without substring-matching at every
+call site. This module adds exactly that and nothing more.
+
+The classifier is a pure function over a string: it performs no I/O, imports no
+heavy deps, and never raises on unexpected input (unknown / non-Apple strings
+return an explicit "unknown" tier). That makes it hermetically unit-testable and
+safe to call on any platform.
+
+Current consumer: the KV-quant differential quality gate
+(``scripts/kv_quant_quality_gate.py`` / :mod:`vllm_mlx.kv_quant_gate`) records
+the chip tier in its report and RAM/compute-gates the optional long-context
+(NIAH) metric on it — a low-RAM M1/M2 skips the expensive retrieval pass.
+
+Future consumer (NOT wired here): MTP speculative decoding currently uses a
+single global ``DEFAULT_MAX_K`` (``vllm_mlx/spec_decode/mtp/draft_k_controller_v2.py``).
+The natural next use of this classifier is to tier ``max_k`` by chip generation
+/ variant (a bandwidth-rich M3/M4 Ultra can profitably run a deeper draft tree
+than an M1). That wiring is intentionally left to a follow-up PR — this module
+only provides the classification primitive.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+# Canonical variant labels. Order is significant only for display; the parser
+# matches case-insensitively against the exact whitespace-delimited token.
+VARIANT_BASE = "base"
+VARIANT_PRO = "Pro"
+VARIANT_MAX = "Max"
+VARIANT_ULTRA = "Ultra"
+VARIANT_UNKNOWN = "unknown"
+
+# Suffix token (lower-cased) -> canonical variant label. A chip string with an
+# ``M<gen>`` token but none of these suffixes is the base variant.
+_VARIANT_TOKENS: dict[str, str] = {
+    "pro": VARIANT_PRO,
+    "max": VARIANT_MAX,
+    "ultra": VARIANT_ULTRA,
+}
+
+# ``M<generation>`` token, e.g. ``m1`` / ``m3`` / ``m4``. Anchored so that a
+# stray ``m`` inside another word (``Maximum``) can't match — we test it against
+# already-split whitespace tokens.
+_M_TOKEN_RE = re.compile(r"^m(\d+)$")
+
+
+@dataclass(frozen=True)
+class ChipTier:
+    """Structured view of an Apple-silicon chip string.
+
+    Attributes:
+        raw: The original chip string, unmodified (for logging / reporting).
+        is_apple_silicon: True when the string parsed as an ``M<n>`` Apple chip.
+            False for Intel Macs, empty strings, the ``"Apple Silicon"`` /
+            ``"Unknown"`` fallbacks, and any non-Apple platform.
+        generation: The integer generation (1, 2, 3, 4, ...) when known, else
+            ``None``. ``None`` whenever ``is_apple_silicon`` is False.
+        variant: One of :data:`VARIANT_BASE` / :data:`VARIANT_PRO` /
+            :data:`VARIANT_MAX` / :data:`VARIANT_ULTRA` for a recognized Apple
+            chip, or :data:`VARIANT_UNKNOWN` when the chip is unknown/non-Apple.
+        is_m3_or_newer: Convenience gate — True iff this is an Apple chip whose
+            generation is >= 3. Consumers use it as a cheap "modern, bandwidth-
+            rich chip" signal (e.g. to enable the optional NIAH gate metric).
+    """
+
+    raw: str
+    is_apple_silicon: bool
+    generation: int | None
+    variant: str
+    is_m3_or_newer: bool
+
+
+def classify_chip_tier(chip_name: str | None) -> ChipTier:
+    """Parse a free-form chip string into a structured :class:`ChipTier`.
+
+    Handles every shape the engine's existing detectors can produce:
+
+    * ``machdep.cpu.brand_string`` form — ``"Apple M3 Ultra"``, ``"Apple M2 Pro"``,
+      ``"Apple M1"``.
+    * ``HARDWARE_PROFILES`` key form — ``"M4 Max"``, ``"M1"``.
+    * Fallbacks / non-Apple — ``"Apple Silicon"``, ``"Unknown"``, ``""``,
+      ``"Intel(R) Core(TM) i7"``, ``None`` — all classified as the explicit
+      unknown tier (never raises).
+
+    Matching is case-insensitive and token-based (whitespace-delimited), so a
+    substring like ``"Max"`` inside ``"Maximum"`` cannot spuriously set the
+    variant. Only the *first* ``M<n>`` token drives the generation.
+
+    Args:
+        chip_name: The chip string from ``detect_hardware().chip_name`` or
+            ``_get_apple_chip_name()``. ``None`` is tolerated.
+
+    Returns:
+        A :class:`ChipTier`. For an unrecognized string:
+        ``ChipTier(raw, is_apple_silicon=False, generation=None,
+        variant="unknown", is_m3_or_newer=False)``.
+    """
+    raw = chip_name or ""
+    tokens = raw.lower().split()
+
+    generation: int | None = None
+    for token in tokens:
+        match = _M_TOKEN_RE.match(token)
+        if match:
+            generation = int(match.group(1))
+            break
+
+    if generation is None:
+        # Not a recognizable Apple ``M<n>`` chip — Intel, empty, or a fallback
+        # string. Explicit unknown tier; never crash.
+        return ChipTier(
+            raw=raw,
+            is_apple_silicon=False,
+            generation=None,
+            variant=VARIANT_UNKNOWN,
+            is_m3_or_newer=False,
+        )
+
+    variant = VARIANT_BASE
+    for token in tokens:
+        mapped = _VARIANT_TOKENS.get(token)
+        if mapped is not None:
+            variant = mapped
+            break
+
+    return ChipTier(
+        raw=raw,
+        is_apple_silicon=True,
+        generation=generation,
+        variant=variant,
+        is_m3_or_newer=generation >= 3,
+    )
+
+
+def detect_chip_tier() -> ChipTier:
+    """Classify the *current* machine's chip.
+
+    Thin convenience that reuses the engine's existing chip detection
+    (:func:`vllm_mlx.vllm_platform._get_apple_chip_name`, which reads
+    ``machdep.cpu.brand_string``) and runs it through :func:`classify_chip_tier`.
+    Falls back to a local ``sysctl`` read, then to the unknown tier, so it never
+    raises on a non-macOS host.
+    """
+    chip_name = ""
+    try:  # Prefer the existing detector — single source of truth.
+        from vllm_mlx.vllm_platform import _get_apple_chip_name
+
+        chip_name = _get_apple_chip_name()
+    except Exception:
+        try:
+            import subprocess
+
+            result = subprocess.run(
+                ["sysctl", "-n", "machdep.cpu.brand_string"],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            chip_name = result.stdout.strip()
+        except Exception:
+            chip_name = ""
+    return classify_chip_tier(chip_name)

--- a/vllm_mlx/chip_tier.py
+++ b/vllm_mlx/chip_tier.py
@@ -98,7 +98,10 @@ def classify_chip_tier(chip_name: str | None) -> ChipTier:
 
     Matching is case-insensitive and token-based (whitespace-delimited), so a
     substring like ``"Max"`` inside ``"Maximum"`` cannot spuriously set the
-    variant. Only the *first* ``M<n>`` token drives the generation.
+    variant. Only the *first* ``M<n>`` token drives the generation, and it is
+    accepted as an Apple chip only when the string is Apple-branded OR that token
+    leads the string (the bare ``HARDWARE_PROFILES`` key form) — so an incidental
+    ``M<n>`` (``"BMW M3"``) is NOT misread as Apple silicon.
 
     Args:
         chip_name: The chip string from ``detect_hardware().chip_name`` or
@@ -111,17 +114,26 @@ def classify_chip_tier(chip_name: str | None) -> ChipTier:
     """
     raw = chip_name or ""
     tokens = raw.lower().split()
+    has_apple = "apple" in tokens
 
     generation: int | None = None
-    for token in tokens:
+    gen_index: int | None = None
+    for idx, token in enumerate(tokens):
         match = _M_TOKEN_RE.match(token)
         if match:
             generation = int(match.group(1))
+            gen_index = idx
             break
 
-    if generation is None:
-        # Not a recognizable Apple ``M<n>`` chip — Intel, empty, or a fallback
-        # string. Explicit unknown tier; never crash.
+    # Accept the ``M<n>`` token as an Apple chip ONLY when the string is
+    # Apple-branded (``"Apple M3 Ultra"``) OR the token LEADS the string (the
+    # bare ``HARDWARE_PROFILES`` key form ``"M3 Ultra"`` / ``"M1"``). This rejects
+    # an incidental ``M<n>`` in an unrelated string — ``"BMW M3"`` (gen token not
+    # first, no "apple") stays the unknown tier, honoring the documented
+    # non-Apple fallback (same lenient-substring lesson as the variant tokens).
+    if generation is None or not (has_apple or gen_index == 0):
+        # Not a recognizable Apple ``M<n>`` chip — Intel, empty, a fallback
+        # string, or an incidental M-token. Explicit unknown tier; never crash.
         return ChipTier(
             raw=raw,
             is_apple_silicon=False,

--- a/vllm_mlx/kv_quant_gate.py
+++ b/vllm_mlx/kv_quant_gate.py
@@ -183,10 +183,13 @@ def logit_divergence(
     difference between the two distributions is the KV-cache dtype. When ``None``,
     all overlapping steps are compared (``min`` of the two lengths).
 
-    Robust to slightly-unnormalized inputs (clamps probabilities) and to a vocab
-    entry that is ``-inf`` in one distribution but has mass in the other (that
-    step contributes ``+inf`` KL, correctly flagging a catastrophic divergence,
-    but is clipped to a large finite value so the mean stays reportable).
+    Robust to slightly-unnormalized inputs (renormalizes) and to a vocab entry
+    that is ``-inf`` in one distribution but has mass in the other (that step
+    contributes ``+inf`` KL, clipped to a large finite ceiling so the mean stays
+    reportable). A NaN in either distribution, or a degenerate baseline whose
+    probability mass is ~0 / non-finite, is treated as a CATASTROPHIC step
+    (charged the ceiling), never as zero divergence — so broken inference can
+    never masquerade as perfect agreement.
     """
     overlap = min(len(baseline_logprobs), len(candidate_logprobs))
     n = overlap if compare_len is None else min(overlap, max(compare_len, 0))
@@ -206,10 +209,27 @@ def logit_divergence(
         if base.shape != cand.shape or base.size == 0:
             # Shape mismatch is a harness bug, not a model signal — skip the step.
             continue
+        # A NaN in either distribution means the inference itself broke. That is
+        # NOT zero divergence — charge the catastrophic ceiling so a NaN baseline
+        # can never masquerade as perfect agreement (the argmax is meaningless
+        # here too, so this step is not counted as a top-1 match).
+        if np.isnan(base).any() or np.isnan(cand).any():
+            kls.append(_KL_CEIL)
+            continue
         if int(np.argmax(base)) == int(np.argmax(cand)):
             top1_matches += 1
         p = np.exp(base)
-        # Only positions with baseline mass contribute to forward KL.
+        total_mass = float(np.sum(p))
+        # A valid ``log_softmax`` baseline has ``exp`` summing to ~1. If the mass
+        # is non-finite or ~0 (an all -inf / degenerate baseline), the
+        # distribution is broken — ``mask`` would select nothing and the old code
+        # scored a spurious 0.0 KL. Treat it as catastrophic instead.
+        if not np.isfinite(total_mass) or total_mass <= 1e-12:
+            kls.append(_KL_CEIL)
+            continue
+        # Normalize so the forward-KL weights are a true probability distribution
+        # even if the input logprobs were slightly unnormalized.
+        p = p / total_mass
         mask = p > 0.0
         diff = base[mask] - cand[mask]
         # cand == -inf where base has mass -> +inf; clip to keep the mean finite.

--- a/vllm_mlx/kv_quant_gate.py
+++ b/vllm_mlx/kv_quant_gate.py
@@ -67,14 +67,19 @@ class AgreementResult:
     """Token-level agreement of a candidate continuation vs its baseline.
 
     Attributes:
-        total: Number of compared token positions (``min`` of the two lengths).
-        matched: Positions where the token ids are equal, counted only up to the
-            first divergence (a greedy run's context forks at the first mismatch,
-            so positions after it are no longer a same-context comparison).
+        total: The denominator — the ``max`` of the two stream lengths. An
+            unequal length is itself a divergence (premature EOS), so the longer
+            stream sets the scale and the missing suffix positions count as
+            disagreement.
+        matched: Leading run of equal token ids (the greedy context forks at the
+            first mismatch, so positions after it are not a same-context
+            comparison and are not counted as matches).
         rate: ``matched / total`` (``1.0`` for two empty streams — vacuously
             equal).
-        first_divergence_index: Index of the first mismatching position, or
-            ``None`` when the streams agree over the whole compared length.
+        first_divergence_index: Index of the first mismatching position, or —
+            when the prefixes all match but the lengths differ — the overlap
+            boundary where the shorter stream ended. ``None`` only when the
+            streams are identical.
     """
 
     total: int
@@ -86,33 +91,46 @@ class AgreementResult:
 def greedy_agreement_rate(
     baseline_tokens: Sequence[int], candidate_tokens: Sequence[int]
 ) -> AgreementResult:
-    """Prefix token-agreement of two greedy continuations.
+    """Token-agreement of two greedy continuations, penalizing length mismatch.
 
-    Compares position by position up to ``min(len(baseline), len(candidate))``.
-    ``matched`` counts the leading run of equal tokens; the first mismatch sets
-    ``first_divergence_index`` and stops the count (after a divergence the two
-    runs feed different tokens back, so later positions are not comparable). The
-    reported ``rate`` is the fraction of the compared length that matched before
-    diverging — a clean 0..1 quantization-drift signal.
+    ``matched`` counts the leading run of equal tokens; the first mismatch stops
+    the count (after a divergence the two runs feed different tokens back, so
+    later positions are not comparable). The denominator is the LONGER stream's
+    length, so a candidate that ends early after an all-matching prefix — the
+    premature-EOS degradation this gate is built to catch — scores below ``1.0``
+    instead of a misleading perfect score. ``rate`` is a clean 0..1
+    quantization-drift signal.
 
-    Two empty streams agree vacuously (``rate=1.0``). An empty vs non-empty pair
-    has ``total=0`` and also ``rate=1.0`` (nothing to disagree on) — the caller
-    decides whether zero-length generations are interesting.
+    Two empty streams agree vacuously (``total=0``, ``rate=1.0``). An empty vs
+    non-empty pair scores ``rate=0.0`` (the whole non-empty stream is missing).
     """
-    total = min(len(baseline_tokens), len(candidate_tokens))
+    # Denominator is the LONGER of the two streams — an unequal continuation
+    # length is itself a divergence, not something to average away. A quantized
+    # candidate that terminates early (premature EOS — a core failure mode this
+    # gate exists to catch) must score BELOW 1.0, so the missing suffix positions
+    # count against it. Using ``min`` here would score an early-EOS candidate that
+    # matched its short prefix at a perfect 1.0 and hide the regression.
+    total = max(len(baseline_tokens), len(candidate_tokens))
     if total == 0:
         return AgreementResult(
             total=0, matched=0, rate=1.0, first_divergence_index=None
         )
 
+    overlap = min(len(baseline_tokens), len(candidate_tokens))
     matched = 0
     first_divergence: int | None = None
-    for i in range(total):
+    for i in range(overlap):
         if baseline_tokens[i] == candidate_tokens[i]:
             matched += 1
         else:
             first_divergence = i
             break
+    else:
+        # No token mismatch within the overlapping prefix. If the streams are
+        # different lengths the shorter one ended first — that boundary IS the
+        # divergence point (e.g. premature EOS under quantization).
+        if len(baseline_tokens) != len(candidate_tokens):
+            first_divergence = overlap
 
     rate = matched / total
     return AgreementResult(
@@ -246,15 +264,33 @@ def extract_json_candidate(text: str) -> str:
 
 
 def is_valid_json(text: str) -> bool:
-    """True iff ``text`` (or its embedded JSON span) parses as JSON."""
+    """True iff ``text`` contains a parseable JSON value.
+
+    First tries the whole extracted candidate span (fenced block or bracket
+    span). If that fails, scans each opening ``{`` / ``[`` delimiter and attempts
+    an incremental ``json.JSONDecoder().raw_decode()`` from there — so a valid
+    embedded object survives even when other bracketed fragments in the
+    surrounding prose would break a naive "first-brace-to-last-bracket" span
+    (e.g. ``"see [x] then {\\"a\\": 1}"``).
+    """
+    if not text:
+        return False
     candidate = extract_json_candidate(text)
-    if not candidate:
-        return False
-    try:
-        json.loads(candidate)
-        return True
-    except (ValueError, TypeError):
-        return False
+    if candidate:
+        try:
+            json.loads(candidate)
+            return True
+        except (ValueError, TypeError):
+            pass
+    decoder = json.JSONDecoder()
+    for i, ch in enumerate(text):
+        if ch in "{[":
+            try:
+                decoder.raw_decode(text, i)
+                return True
+            except ValueError:
+                continue
+    return False
 
 
 @dataclass(frozen=True)

--- a/vllm_mlx/kv_quant_gate.py
+++ b/vllm_mlx/kv_quant_gate.py
@@ -235,62 +235,77 @@ def logit_divergence(
 # ---------------------------------------------------------------------------
 # Structured-output retention
 # ---------------------------------------------------------------------------
-_JSON_FENCE_RE = re.compile(r"```(?:json)?\s*(.*?)```", re.DOTALL | re.IGNORECASE)
+# A fence is only unwrapped when the WHOLE (stripped) output is exactly one
+# ```...``` block — a fence embedded in prose does not satisfy an "ONLY JSON"
+# instruction and must not be leniently extracted.
+_JSON_FENCE_FULL_RE = re.compile(
+    r"```(?:json)?\s*(.*?)\s*```", re.DOTALL | re.IGNORECASE
+)
+
+# Sentinel for "did not parse". ``None`` is a legal JSON value (``null``), so we
+# cannot use it to signal failure.
+_JSON_INVALID = object()
 
 
-def extract_json_candidate(text: str) -> str:
-    """Return the most likely JSON substring from a model output.
+def _parse_strict_json(text: str) -> Any:
+    """Parse the WHOLE output as a single JSON value, or return ``_JSON_INVALID``.
 
-    Prefers a fenced ```json ... ``` block; otherwise the span from the first
-    ``{`` / ``[`` to the matching last ``}`` / ``]``. Returns the stripped whole
-    string when no bracket is found. Purely lexical — validity is decided by
-    :func:`is_valid_json`.
+    The structured prompts instruct the model to reply with ONLY JSON. So the
+    contract is strict: the entire stripped output (optionally wrapped in a
+    single code fence) must parse as one JSON value via ``json.loads`` — which,
+    unlike an incremental ``raw_decode`` scan, rejects trailing/leading prose
+    (``"Sorry, [1]"``) and stray bracket fragments (``"see [x] then {..}"``).
+    A candidate that buries JSON in prose has NOT honored the format contract and
+    should not count as retained.
     """
-    if not text:
-        return ""
-    fence = _JSON_FENCE_RE.search(text)
+    if not text or not text.strip():
+        return _JSON_INVALID
+    candidate = text.strip()
+    fence = _JSON_FENCE_FULL_RE.fullmatch(candidate)
     if fence:
-        return fence.group(1).strip()
-    start = min(
-        (i for i in (text.find("{"), text.find("[")) if i != -1),
-        default=-1,
-    )
-    if start == -1:
-        return text.strip()
-    end = max(text.rfind("}"), text.rfind("]"))
-    if end <= start:
-        return text.strip()
-    return text[start : end + 1].strip()
+        candidate = fence.group(1).strip()
+    try:
+        return json.loads(candidate)
+    except (ValueError, TypeError):
+        return _JSON_INVALID
 
 
 def is_valid_json(text: str) -> bool:
-    """True iff ``text`` contains a parseable JSON value.
+    """True iff the WHOLE output parses as a single JSON value (see the note on
+    strictness in :func:`_parse_strict_json`)."""
+    return _parse_strict_json(text) is not _JSON_INVALID
 
-    First tries the whole extracted candidate span (fenced block or bracket
-    span). If that fails, scans each opening ``{`` / ``[`` delimiter and attempts
-    an incremental ``json.JSONDecoder().raw_decode()`` from there — so a valid
-    embedded object survives even when other bracketed fragments in the
-    surrounding prose would break a naive "first-brace-to-last-bracket" span
-    (e.g. ``"see [x] then {\\"a\\": 1}"``).
+
+def _json_shape(obj: Any) -> tuple[str, frozenset[str] | None]:
+    """Classify a parsed JSON value into a comparable shape signature.
+
+    Returns ``("object", frozenset(keys))`` for a dict, ``("array", None)`` for a
+    list, and ``("scalar", None)`` for anything else (string / number / bool /
+    null). Used to require the candidate to preserve the baseline's structure.
     """
-    if not text:
+    if isinstance(obj, dict):
+        return "object", frozenset(obj.keys())
+    if isinstance(obj, list):
+        return "array", None
+    return "scalar", None
+
+
+def _retains_shape(baseline_obj: Any, candidate_obj: Any) -> bool:
+    """True iff the candidate preserves the baseline's JSON contract.
+
+    Same top-level type, and — for objects — the candidate must carry AT LEAST
+    the baseline's keys (a requested key vanishing under quantization is a
+    regression). This closes the generic-validity hole where an object prompt
+    could "retain" as an array/scalar or silently drop keys.
+    """
+    base_type, base_keys = _json_shape(baseline_obj)
+    cand_type, cand_keys = _json_shape(candidate_obj)
+    if base_type != cand_type:
         return False
-    candidate = extract_json_candidate(text)
-    if candidate:
-        try:
-            json.loads(candidate)
-            return True
-        except (ValueError, TypeError):
-            pass
-    decoder = json.JSONDecoder()
-    for i, ch in enumerate(text):
-        if ch in "{[":
-            try:
-                decoder.raw_decode(text, i)
-                return True
-            except ValueError:
-                continue
-    return False
+    if base_type == "object":
+        assert base_keys is not None and cand_keys is not None
+        return base_keys <= cand_keys
+    return True
 
 
 @dataclass(frozen=True)
@@ -298,14 +313,16 @@ class RetentionResult:
     """Structured-output retention across a set of (baseline, candidate) outputs.
 
     Attributes:
-        attributable: Prompts where the BASELINE emitted valid JSON — the only
-            prompts where a candidate failure is attributable to quantization.
-        retained: Of the attributable prompts, how many the candidate ALSO kept
-            valid.
+        attributable: Prompts where the BASELINE emitted a valid JSON document —
+            the only prompts where a candidate failure is attributable to
+            quantization.
+        retained: Of the attributable prompts, how many the candidate kept valid
+            AND matching the baseline's JSON contract (same top-level type; for
+            objects, no baseline key dropped).
         rate: ``retained / attributable``, or ``None`` when nothing was
             attributable (no baseline produced valid JSON — the metric is N/A).
         baseline_invalid: Prompts excluded because the baseline itself did not
-            emit valid JSON (not a quantization signal).
+            emit a valid JSON document (not a quantization signal).
     """
 
     attributable: int
@@ -317,24 +334,30 @@ class RetentionResult:
 def structured_output_retention(
     pairs: Sequence[tuple[str, str]],
 ) -> RetentionResult:
-    """Retention of valid JSON output under quantization.
+    """Shape-aware retention of the baseline's JSON contract under quantization.
 
     ``pairs`` is a sequence of ``(baseline_text, candidate_text)``. Only prompts
-    where the baseline produced valid JSON count toward the rate; of those, the
-    fraction where the candidate ALSO produced valid JSON is the retention rate.
-    A prompt the baseline already failed is excluded (not attributable to the
-    cache dtype). ``rate`` is ``None`` when nothing is attributable.
+    where the baseline produced a valid JSON document count toward the rate; of
+    those, a prompt is RETAINED iff the candidate is also valid JSON AND
+    preserves the baseline's contract (same top-level type; for objects, retains
+    every baseline key — see :func:`_retains_shape`). A prompt the baseline
+    already failed is excluded (not attributable to the cache dtype). ``rate`` is
+    ``None`` when nothing is attributable.
     """
     attributable = 0
     retained = 0
     baseline_invalid = 0
     for baseline_text, candidate_text in pairs:
-        if is_valid_json(baseline_text):
-            attributable += 1
-            if is_valid_json(candidate_text):
-                retained += 1
-        else:
+        baseline_obj = _parse_strict_json(baseline_text)
+        if baseline_obj is _JSON_INVALID:
             baseline_invalid += 1
+            continue
+        attributable += 1
+        candidate_obj = _parse_strict_json(candidate_text)
+        if candidate_obj is not _JSON_INVALID and _retains_shape(
+            baseline_obj, candidate_obj
+        ):
+            retained += 1
     rate = (retained / attributable) if attributable > 0 else None
     return RetentionResult(
         attributable=attributable,
@@ -401,7 +424,12 @@ class GateThresholds:
 
 
 def default_thresholds(candidate_dtype: str) -> GateThresholds:
-    """Return provisional thresholds for a candidate dtype (``int8`` / ``int4``)."""
+    """Return provisional thresholds for a candidate dtype.
+
+    Only ``int8`` and ``int4`` are supported; any other value raises rather than
+    silently borrowing the int8 thresholds (a typo or a future dtype would
+    otherwise get a misleading verdict).
+    """
     if candidate_dtype == "int4":
         return GateThresholds(
             min_greedy_agreement=0.40,
@@ -409,12 +437,15 @@ def default_thresholds(candidate_dtype: str) -> GateThresholds:
             min_structured_retention=1.0,
             min_memory_reduction_ratio=2.5,
         )
-    # int8 (and any other 8-bit-ish candidate) — tighter.
-    return GateThresholds(
-        min_greedy_agreement=0.60,
-        max_mean_kl=0.05,
-        min_structured_retention=1.0,
-        min_memory_reduction_ratio=1.5,
+    if candidate_dtype == "int8":
+        return GateThresholds(
+            min_greedy_agreement=0.60,
+            max_mean_kl=0.05,
+            min_structured_retention=1.0,
+            min_memory_reduction_ratio=1.5,
+        )
+    raise ValueError(
+        f"unsupported candidate dtype {candidate_dtype!r}; expected 'int8' or 'int4'"
     )
 
 

--- a/vllm_mlx/kv_quant_gate.py
+++ b/vllm_mlx/kv_quant_gate.py
@@ -1,0 +1,580 @@
+# SPDX-License-Identifier: Apache-2.0
+"""KV-quant differential quality gate — pure metric + report core.
+
+We decide whether an ``int4`` / ``int8`` KV cache is "safe" to default on via a
+HAND-WRITTEN empirical safelist (``vllm_mlx/kv_cache_dtype.py``). There is no
+*measured* quality signal behind that list: if quantizing the KV cache silently
+degrades decode quality on some architecture, nothing detects it.
+
+This module is the measurement core. The runnable harness
+(``scripts/kv_quant_quality_gate.py``) runs the SAME model twice on the SAME
+prompts — a ``bf16``-KV BASELINE and a quantized-KV CANDIDATE (``int8`` /
+``int4``) — and this module scores how well the CANDIDATE **agrees with its own
+bf16 baseline**. The differential/agreement-rate framing is the key design
+choice: it measures quantization-*induced* drift, not absolute correctness, so a
+model that is simply bad at a prompt does not fail the gate — only a model the
+quantized cache made *worse than its own full-precision self* does.
+
+Everything here is a **pure function**: no model load, no MLX, no I/O. It
+operates on already-collected token streams / per-step log-probability vectors /
+byte counts, so every metric is hermetically unit-testable with synthetic data.
+The harness owns all inference; this module owns all scoring.
+
+Metrics
+-------
+* **Greedy agreement rate** — token-level match of the candidate's greedy
+  (temp=0) continuation against the baseline's, per prompt. The headline metric.
+* **Logit divergence** — mean / max KL and top-1 agreement of the two next-token
+  distributions, over the SHARED-CONTEXT prefix (the steps before the two runs
+  chose different tokens, where the only difference between the distributions is
+  the KV-cache dtype).
+* **Structured-output retention** — does the candidate still emit valid JSON when
+  the baseline did? Attributes only quantization-induced breakage (a prompt the
+  baseline already failed is excluded).
+* **Memory delta** — the measured KV footprint reduction (candidate must
+  actually be smaller — a "quantized" cache that saved nothing is a bug).
+
+Advisory, not blocking (measure-first)
+--------------------------------------
+The thresholds below are PROVISIONAL. This gate ships in *measure-first* mode
+(mirroring the ``diff_coverage`` advisory pattern): it computes a PASS/FAIL and
+emits a full report, but the harness exits ``0`` regardless by default. Once we
+have baseline numbers across the fleet, the thresholds get calibrated and the
+gate can be promoted to blocking (``--enforce``) in a follow-up.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Sequence
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+import numpy as np
+
+# Metric outcome labels.
+PASS = "PASS"
+FAIL = "FAIL"
+NA = "NA"
+
+
+# ---------------------------------------------------------------------------
+# Greedy agreement
+# ---------------------------------------------------------------------------
+@dataclass(frozen=True)
+class AgreementResult:
+    """Token-level agreement of a candidate continuation vs its baseline.
+
+    Attributes:
+        total: Number of compared token positions (``min`` of the two lengths).
+        matched: Positions where the token ids are equal, counted only up to the
+            first divergence (a greedy run's context forks at the first mismatch,
+            so positions after it are no longer a same-context comparison).
+        rate: ``matched / total`` (``1.0`` for two empty streams — vacuously
+            equal).
+        first_divergence_index: Index of the first mismatching position, or
+            ``None`` when the streams agree over the whole compared length.
+    """
+
+    total: int
+    matched: int
+    rate: float
+    first_divergence_index: int | None
+
+
+def greedy_agreement_rate(
+    baseline_tokens: Sequence[int], candidate_tokens: Sequence[int]
+) -> AgreementResult:
+    """Prefix token-agreement of two greedy continuations.
+
+    Compares position by position up to ``min(len(baseline), len(candidate))``.
+    ``matched`` counts the leading run of equal tokens; the first mismatch sets
+    ``first_divergence_index`` and stops the count (after a divergence the two
+    runs feed different tokens back, so later positions are not comparable). The
+    reported ``rate`` is the fraction of the compared length that matched before
+    diverging — a clean 0..1 quantization-drift signal.
+
+    Two empty streams agree vacuously (``rate=1.0``). An empty vs non-empty pair
+    has ``total=0`` and also ``rate=1.0`` (nothing to disagree on) — the caller
+    decides whether zero-length generations are interesting.
+    """
+    total = min(len(baseline_tokens), len(candidate_tokens))
+    if total == 0:
+        return AgreementResult(
+            total=0, matched=0, rate=1.0, first_divergence_index=None
+        )
+
+    matched = 0
+    first_divergence: int | None = None
+    for i in range(total):
+        if baseline_tokens[i] == candidate_tokens[i]:
+            matched += 1
+        else:
+            first_divergence = i
+            break
+
+    rate = matched / total
+    return AgreementResult(
+        total=total,
+        matched=matched,
+        rate=rate,
+        first_divergence_index=first_divergence,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Logit divergence
+# ---------------------------------------------------------------------------
+@dataclass(frozen=True)
+class LogitDivergence:
+    """Distributional drift between baseline and candidate next-token logits.
+
+    Attributes:
+        compared_steps: Number of per-step distributions compared.
+        mean_kl: Mean forward KL ``D(P_baseline || P_candidate)`` in nats over
+            the compared steps (``0.0`` when nothing was compared).
+        max_kl: Worst single-step KL (``0.0`` when nothing was compared).
+        top1_agreement_rate: Fraction of compared steps whose argmax token
+            matches (``1.0`` when nothing was compared — vacuously).
+    """
+
+    compared_steps: int
+    mean_kl: float
+    max_kl: float
+    top1_agreement_rate: float
+
+
+def logit_divergence(
+    baseline_logprobs: Sequence[Sequence[float]],
+    candidate_logprobs: Sequence[Sequence[float]],
+    *,
+    compare_len: int | None = None,
+) -> LogitDivergence:
+    """KL + top-1 agreement of two per-step log-probability sequences.
+
+    Each argument is a sequence of per-step log-probability vectors
+    (``log_softmax`` output — one vector per generated position, length = vocab).
+    Forward KL is ``Σ_x P_base(x) · (logP_base(x) − logP_cand(x))`` per step,
+    averaged over the compared steps.
+
+    ``compare_len`` bounds how many leading steps are compared. It exists because
+    a same-context comparison is only valid over the shared-context prefix: the
+    harness passes ``first_divergence_index`` (the two greedy runs share a context
+    up to and including that step) so KL is measured strictly where the ONLY
+    difference between the two distributions is the KV-cache dtype. When ``None``,
+    all overlapping steps are compared (``min`` of the two lengths).
+
+    Robust to slightly-unnormalized inputs (clamps probabilities) and to a vocab
+    entry that is ``-inf`` in one distribution but has mass in the other (that
+    step contributes ``+inf`` KL, correctly flagging a catastrophic divergence,
+    but is clipped to a large finite value so the mean stays reportable).
+    """
+    overlap = min(len(baseline_logprobs), len(candidate_logprobs))
+    n = overlap if compare_len is None else min(overlap, max(compare_len, 0))
+    if n == 0:
+        return LogitDivergence(
+            compared_steps=0, mean_kl=0.0, max_kl=0.0, top1_agreement_rate=1.0
+        )
+
+    kls: list[float] = []
+    top1_matches = 0
+    # A large finite ceiling for a per-step KL so one pathological step can't turn
+    # the whole mean into inf/nan while still dominating it (signals a real break).
+    _KL_CEIL = 1e4
+    for i in range(n):
+        base = np.asarray(baseline_logprobs[i], dtype=np.float64).reshape(-1)
+        cand = np.asarray(candidate_logprobs[i], dtype=np.float64).reshape(-1)
+        if base.shape != cand.shape or base.size == 0:
+            # Shape mismatch is a harness bug, not a model signal — skip the step.
+            continue
+        if int(np.argmax(base)) == int(np.argmax(cand)):
+            top1_matches += 1
+        p = np.exp(base)
+        # Only positions with baseline mass contribute to forward KL.
+        mask = p > 0.0
+        diff = base[mask] - cand[mask]
+        # cand == -inf where base has mass -> +inf; clip to keep the mean finite.
+        step_kl = float(np.sum(p[mask] * np.clip(diff, -_KL_CEIL, _KL_CEIL)))
+        if not np.isfinite(step_kl):
+            step_kl = _KL_CEIL
+        # KL is non-negative in theory; tiny negatives from float error -> 0.
+        kls.append(max(step_kl, 0.0))
+
+    if not kls:
+        return LogitDivergence(
+            compared_steps=0, mean_kl=0.0, max_kl=0.0, top1_agreement_rate=1.0
+        )
+
+    return LogitDivergence(
+        compared_steps=len(kls),
+        mean_kl=float(np.mean(kls)),
+        max_kl=float(np.max(kls)),
+        top1_agreement_rate=top1_matches / len(kls),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Structured-output retention
+# ---------------------------------------------------------------------------
+_JSON_FENCE_RE = re.compile(r"```(?:json)?\s*(.*?)```", re.DOTALL | re.IGNORECASE)
+
+
+def extract_json_candidate(text: str) -> str:
+    """Return the most likely JSON substring from a model output.
+
+    Prefers a fenced ```json ... ``` block; otherwise the span from the first
+    ``{`` / ``[`` to the matching last ``}`` / ``]``. Returns the stripped whole
+    string when no bracket is found. Purely lexical — validity is decided by
+    :func:`is_valid_json`.
+    """
+    if not text:
+        return ""
+    fence = _JSON_FENCE_RE.search(text)
+    if fence:
+        return fence.group(1).strip()
+    start = min(
+        (i for i in (text.find("{"), text.find("[")) if i != -1),
+        default=-1,
+    )
+    if start == -1:
+        return text.strip()
+    end = max(text.rfind("}"), text.rfind("]"))
+    if end <= start:
+        return text.strip()
+    return text[start : end + 1].strip()
+
+
+def is_valid_json(text: str) -> bool:
+    """True iff ``text`` (or its embedded JSON span) parses as JSON."""
+    candidate = extract_json_candidate(text)
+    if not candidate:
+        return False
+    try:
+        json.loads(candidate)
+        return True
+    except (ValueError, TypeError):
+        return False
+
+
+@dataclass(frozen=True)
+class RetentionResult:
+    """Structured-output retention across a set of (baseline, candidate) outputs.
+
+    Attributes:
+        attributable: Prompts where the BASELINE emitted valid JSON — the only
+            prompts where a candidate failure is attributable to quantization.
+        retained: Of the attributable prompts, how many the candidate ALSO kept
+            valid.
+        rate: ``retained / attributable``, or ``None`` when nothing was
+            attributable (no baseline produced valid JSON — the metric is N/A).
+        baseline_invalid: Prompts excluded because the baseline itself did not
+            emit valid JSON (not a quantization signal).
+    """
+
+    attributable: int
+    retained: int
+    rate: float | None
+    baseline_invalid: int
+
+
+def structured_output_retention(
+    pairs: Sequence[tuple[str, str]],
+) -> RetentionResult:
+    """Retention of valid JSON output under quantization.
+
+    ``pairs`` is a sequence of ``(baseline_text, candidate_text)``. Only prompts
+    where the baseline produced valid JSON count toward the rate; of those, the
+    fraction where the candidate ALSO produced valid JSON is the retention rate.
+    A prompt the baseline already failed is excluded (not attributable to the
+    cache dtype). ``rate`` is ``None`` when nothing is attributable.
+    """
+    attributable = 0
+    retained = 0
+    baseline_invalid = 0
+    for baseline_text, candidate_text in pairs:
+        if is_valid_json(baseline_text):
+            attributable += 1
+            if is_valid_json(candidate_text):
+                retained += 1
+        else:
+            baseline_invalid += 1
+    rate = (retained / attributable) if attributable > 0 else None
+    return RetentionResult(
+        attributable=attributable,
+        retained=retained,
+        rate=rate,
+        baseline_invalid=baseline_invalid,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Memory delta
+# ---------------------------------------------------------------------------
+@dataclass(frozen=True)
+class MemoryDelta:
+    """Measured KV-cache footprint reduction of candidate vs baseline.
+
+    Attributes:
+        baseline_bytes: Measured bf16 KV-cache footprint.
+        candidate_bytes: Measured quantized KV-cache footprint.
+        saved_bytes: ``baseline_bytes − candidate_bytes`` (may be negative if a
+            quantized cache somehow grew — a bug the gate should surface).
+        reduction_ratio: ``baseline_bytes / candidate_bytes`` (``0.0`` when the
+            candidate measured zero bytes — degenerate, treated as no saving).
+        saved_pct: Percentage of the baseline footprint saved.
+    """
+
+    baseline_bytes: int
+    candidate_bytes: int
+    saved_bytes: int
+    reduction_ratio: float
+    saved_pct: float
+
+
+def memory_delta(baseline_bytes: int, candidate_bytes: int) -> MemoryDelta:
+    """Compute the KV-cache footprint reduction from two measured byte counts."""
+    saved = baseline_bytes - candidate_bytes
+    ratio = (baseline_bytes / candidate_bytes) if candidate_bytes > 0 else 0.0
+    pct = (saved / baseline_bytes * 100.0) if baseline_bytes > 0 else 0.0
+    return MemoryDelta(
+        baseline_bytes=int(baseline_bytes),
+        candidate_bytes=int(candidate_bytes),
+        saved_bytes=int(saved),
+        reduction_ratio=ratio,
+        saved_pct=pct,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Thresholds + report
+# ---------------------------------------------------------------------------
+@dataclass(frozen=True)
+class GateThresholds:
+    """PROVISIONAL pass thresholds. Calibrate before promoting to blocking.
+
+    Defaults are deliberately lenient — this gate ships advisory (measure-first),
+    so these exist to shape the report, not to fail anything yet. int4 tolerates
+    more drift than int8 because it quantizes harder.
+    """
+
+    min_greedy_agreement: float
+    max_mean_kl: float
+    min_structured_retention: float
+    min_memory_reduction_ratio: float
+
+
+def default_thresholds(candidate_dtype: str) -> GateThresholds:
+    """Return provisional thresholds for a candidate dtype (``int8`` / ``int4``)."""
+    if candidate_dtype == "int4":
+        return GateThresholds(
+            min_greedy_agreement=0.40,
+            max_mean_kl=0.20,
+            min_structured_retention=1.0,
+            min_memory_reduction_ratio=2.5,
+        )
+    # int8 (and any other 8-bit-ish candidate) — tighter.
+    return GateThresholds(
+        min_greedy_agreement=0.60,
+        max_mean_kl=0.05,
+        min_structured_retention=1.0,
+        min_memory_reduction_ratio=1.5,
+    )
+
+
+@dataclass
+class GateReport:
+    """Full structured report of one baseline-vs-candidate gate run.
+
+    ``metrics`` and ``overall`` are filled by :func:`build_report`; construct via
+    that builder rather than by hand so the PASS/FAIL logic stays in one place.
+    """
+
+    model: str
+    hf_path: str
+    baseline_dtype: str
+    candidate_dtype: str
+    num_prompts: int
+    advisory: bool
+    chip: dict[str, Any]
+    thresholds: GateThresholds
+    agreement: AgreementResult
+    logits: LogitDivergence
+    retention: RetentionResult
+    memory: MemoryDelta
+    niah: dict[str, Any] = field(default_factory=lambda: {"status": "skipped"})
+    metrics: dict[str, dict[str, Any]] = field(default_factory=dict)
+    overall: str = NA
+
+    def to_dict(self) -> dict[str, Any]:
+        """JSON-serializable view of the whole report."""
+        return {
+            "schema": 1,
+            "kind": "kv_quant_quality_gate",
+            "advisory": self.advisory,
+            "model": self.model,
+            "hf_path": self.hf_path,
+            "baseline_dtype": self.baseline_dtype,
+            "candidate_dtype": self.candidate_dtype,
+            "num_prompts": self.num_prompts,
+            "chip": self.chip,
+            "thresholds": asdict(self.thresholds),
+            "agreement": asdict(self.agreement),
+            "logits": asdict(self.logits),
+            "retention": asdict(self.retention),
+            "memory": asdict(self.memory),
+            "niah": self.niah,
+            "metrics": self.metrics,
+            "overall": self.overall,
+        }
+
+    def human_summary(self) -> str:
+        """Operator-facing multi-line summary in the ``scripts/`` report style."""
+        bar = "=" * 70
+        lines = [
+            bar,
+            " KV-quant differential quality gate"
+            + ("  (ADVISORY — measure-first)" if self.advisory else "  (ENFORCED)"),
+            bar,
+            f" model:     {self.model}",
+            f" hf_path:   {self.hf_path}",
+            f" baseline:  {self.baseline_dtype}-KV   candidate: "
+            f"{self.candidate_dtype}-KV",
+            f" prompts:   {self.num_prompts}",
+            f" chip:      {self.chip.get('raw', 'unknown')} "
+            f"(tier: gen={self.chip.get('generation')} "
+            f"{self.chip.get('variant')})",
+            "-" * 70,
+        ]
+        for name, m in self.metrics.items():
+            lines.append(
+                f" {m['outcome']:<4} {name:<26} "
+                f"value={m['value']}  threshold={m['threshold']}"
+            )
+        lines.append(f" {'':<4} {'niah':<26} status={self.niah.get('status')}")
+        lines.append("-" * 70)
+        lines.append(f" OVERALL: {self.overall}")
+        if self.advisory:
+            lines.append(
+                " (advisory run — thresholds are provisional; exit code is 0"
+                " regardless of OVERALL)"
+            )
+        lines.append(bar)
+        return "\n".join(lines)
+
+
+def _fmt(value: Any) -> Any:
+    """Round floats for compact display; pass through everything else."""
+    if isinstance(value, float):
+        return round(value, 5)
+    return value
+
+
+def build_report(
+    *,
+    model: str,
+    hf_path: str,
+    baseline_dtype: str,
+    candidate_dtype: str,
+    num_prompts: int,
+    advisory: bool,
+    chip: dict[str, Any],
+    thresholds: GateThresholds,
+    agreement: AgreementResult,
+    logits: LogitDivergence,
+    retention: RetentionResult,
+    memory: MemoryDelta,
+    niah: dict[str, Any] | None = None,
+) -> GateReport:
+    """Assemble a :class:`GateReport` and evaluate PASS/FAIL from the metrics.
+
+    Per-metric outcome:
+
+    * ``greedy_agreement`` — ``PASS`` iff ``rate >= min_greedy_agreement``.
+    * ``logit_mean_kl`` — ``PASS`` iff ``mean_kl <= max_mean_kl``; ``NA`` when no
+      shared-context step was comparable.
+    * ``structured_retention`` — ``PASS`` iff ``rate >= min_structured_retention``;
+      ``NA`` when no baseline produced valid JSON (nothing attributable).
+    * ``memory_reduction`` — ``PASS`` iff ``reduction_ratio >=
+      min_memory_reduction_ratio``.
+    * ``niah`` (optional) — counts toward ``overall`` only when its status is
+      ``pass`` / ``fail``; a ``skipped`` NIAH is ``NA``.
+
+    ``overall`` is ``PASS`` iff every non-``NA`` metric is ``PASS``.
+    """
+    niah = niah or {"status": "skipped"}
+    metrics: dict[str, dict[str, Any]] = {}
+
+    # Greedy agreement — always evaluable.
+    metrics["greedy_agreement"] = {
+        "value": _fmt(agreement.rate),
+        "threshold": f">= {thresholds.min_greedy_agreement}",
+        "outcome": PASS if agreement.rate >= thresholds.min_greedy_agreement else FAIL,
+    }
+
+    # Logit mean KL — NA when nothing was comparable.
+    if logits.compared_steps == 0:
+        kl_outcome = NA
+    else:
+        kl_outcome = PASS if logits.mean_kl <= thresholds.max_mean_kl else FAIL
+    metrics["logit_mean_kl"] = {
+        "value": _fmt(logits.mean_kl),
+        "threshold": f"<= {thresholds.max_mean_kl}",
+        "outcome": kl_outcome,
+    }
+
+    # Structured retention — NA when no attributable prompt.
+    if retention.rate is None:
+        ret_outcome = NA
+        ret_value: Any = None
+    else:
+        ret_value = _fmt(retention.rate)
+        ret_outcome = (
+            PASS if retention.rate >= thresholds.min_structured_retention else FAIL
+        )
+    metrics["structured_retention"] = {
+        "value": ret_value,
+        "threshold": f">= {thresholds.min_structured_retention}",
+        "outcome": ret_outcome,
+    }
+
+    # Memory reduction — always evaluable.
+    metrics["memory_reduction"] = {
+        "value": _fmt(memory.reduction_ratio),
+        "threshold": f">= {thresholds.min_memory_reduction_ratio}x",
+        "outcome": (
+            PASS
+            if memory.reduction_ratio >= thresholds.min_memory_reduction_ratio
+            else FAIL
+        ),
+    }
+
+    # Overall: every non-NA metric must PASS; a pass/fail NIAH participates too.
+    outcomes = [m["outcome"] for m in metrics.values()]
+    niah_status = str(niah.get("status", "skipped")).lower()
+    if niah_status in ("pass", "fail"):
+        outcomes.append(PASS if niah_status == "pass" else FAIL)
+    graded = [o for o in outcomes if o != NA]
+    overall = (
+        PASS
+        if graded and all(o == PASS for o in graded)
+        else (FAIL if FAIL in graded else NA)
+    )
+
+    return GateReport(
+        model=model,
+        hf_path=hf_path,
+        baseline_dtype=baseline_dtype,
+        candidate_dtype=candidate_dtype,
+        num_prompts=num_prompts,
+        advisory=advisory,
+        chip=chip,
+        thresholds=thresholds,
+        agreement=agreement,
+        logits=logits,
+        retention=retention,
+        memory=memory,
+        niah=niah,
+        metrics=metrics,
+        overall=overall,
+    )

--- a/vllm_mlx/kv_quant_gate.py
+++ b/vllm_mlx/kv_quant_gate.py
@@ -59,6 +59,19 @@ FAIL = "FAIL"
 NA = "NA"
 
 
+def _logsumexp(x: np.ndarray) -> float:
+    """Numerically-stable ``log(sum(exp(x)))``.
+
+    Returns ``-inf`` for an all ``-inf`` vector (a degenerate distribution) and
+    ``+inf``/``nan`` if the input carries one — the caller guards on finiteness.
+    """
+    m = float(np.max(x))
+    if not np.isfinite(m):
+        # All -inf (m == -inf) or a stray +inf/nan: no valid shift exists.
+        return m
+    return m + float(np.log(np.sum(np.exp(x - m))))
+
+
 # ---------------------------------------------------------------------------
 # Greedy agreement
 # ---------------------------------------------------------------------------
@@ -183,11 +196,14 @@ def logit_divergence(
     difference between the two distributions is the KV-cache dtype. When ``None``,
     all overlapping steps are compared (``min`` of the two lengths).
 
-    Robust to slightly-unnormalized inputs (renormalizes) and to a vocab entry
-    that is ``-inf`` in one distribution but has mass in the other (that step
+    Both vectors are renormalized to true log-probabilities via log-sum-exp
+    before the KL, so the metric is shift-invariant: two distributions that are
+    identical up to different additive constants (raw logits, or only
+    slightly-normalized logprobs) score ~0, not a spurious non-zero. A vocab
+    entry that is ``-inf`` in one distribution but has mass in the other
     contributes ``+inf`` KL, clipped to a large finite ceiling so the mean stays
-    reportable). A NaN in either distribution, or a degenerate baseline whose
-    probability mass is ~0 / non-finite, is treated as a CATASTROPHIC step
+    reportable. A NaN in either distribution, or a degenerate distribution whose
+    log-sum-exp is non-finite (all ``-inf``), is treated as a CATASTROPHIC step
     (charged the ceiling), never as zero divergence — so broken inference can
     never masquerade as perfect agreement.
     """
@@ -218,21 +234,24 @@ def logit_divergence(
             continue
         if int(np.argmax(base)) == int(np.argmax(cand)):
             top1_matches += 1
-        p = np.exp(base)
-        total_mass = float(np.sum(p))
-        # A valid ``log_softmax`` baseline has ``exp`` summing to ~1. If the mass
-        # is non-finite or ~0 (an all -inf / degenerate baseline), the
-        # distribution is broken — ``mask`` would select nothing and the old code
-        # scored a spurious 0.0 KL. Treat it as catastrophic instead.
-        if not np.isfinite(total_mass) or total_mass <= 1e-12:
+        # Renormalize BOTH vectors to true log-probabilities via log-sum-exp. The
+        # weighting AND the log-ratio must use normalized values, else two
+        # distributions that are identical up to different additive constants
+        # (raw logits, or slightly-unnormalized logprobs) score a spurious
+        # non-zero KL. If either normalizer is non-finite (an all -inf / broken
+        # distribution), no valid probability exists — charge the catastrophic
+        # ceiling instead of scoring a spurious 0.0.
+        base_lse = _logsumexp(base)
+        cand_lse = _logsumexp(cand)
+        if not (np.isfinite(base_lse) and np.isfinite(cand_lse)):
             kls.append(_KL_CEIL)
             continue
-        # Normalize so the forward-KL weights are a true probability distribution
-        # even if the input logprobs were slightly unnormalized.
-        p = p / total_mass
+        base_norm = base - base_lse
+        cand_norm = cand - cand_lse
+        p = np.exp(base_norm)
         mask = p > 0.0
-        diff = base[mask] - cand[mask]
-        # cand == -inf where base has mass -> +inf; clip to keep the mean finite.
+        # cand == -inf where base has mass -> diff +inf; clip to keep mean finite.
+        diff = base_norm[mask] - cand_norm[mask]
         step_kl = float(np.sum(p[mask] * np.clip(diff, -_KL_CEIL, _KL_CEIL)))
         if not np.isfinite(step_kl):
             step_kl = _KL_CEIL


### PR DESCRIPTION
## Summary

Absorb-list **#4 (KV-quant differential quality gate)** + **#5 (chip-tier classifier)** as one PR. Both are **offline, advisory, download-free** tooling — no runtime/serve path is touched.

### #4 — KV-quant differential quality gate

Today `vllm_mlx/kv_cache_dtype.py` decides whether `int4`/`int8` KV cache is "safe" to default on via a **hand-written empirical safelist** (sliding-window + MLA families). There is **no measured quality signal** behind that list: if quantizing the KV cache silently degrades decode quality on some architecture, nothing detects it.

**Design — differential / agreement-rate (the key insight).** `scripts/kv_quant_quality_gate.py` runs the SAME model twice on the SAME prompts — a `bf16`-KV **baseline** and a quantized-KV **candidate** (`int8` / `int4`) — and measures how well the candidate **agrees with its own bf16 baseline**, *not* absolute correctness. This cleanly isolates *quantization-induced* degradation: a model that is simply bad at a prompt does not fault the gate — only a model the quantized cache made **worse than its own full-precision self** does.

All scoring lives in the pure, hermetically-tested `vllm_mlx/kv_quant_gate.py`; the script only drives inference (via existing `mlx_lm` `generate_step` + `make_prompt_cache` + the `kv_bits` KV-quant plumbing) and prints.

**Metrics built (core):**
- **Greedy agreement rate** (temp=0) — token-level match of the candidate's continuation vs the baseline's, over the shared prefix. The headline metric.
- **Logit divergence** — forward **KL** (mean + max) and **top-1 agreement** of the two next-token distributions, measured strictly over the **shared-context prefix** (the steps before the greedy runs forked, where the only difference between the distributions is the KV-cache dtype).
- **Structured-output retention** — does the candidate still emit valid JSON when the baseline did? Only quantization-attributable breakage counts (a prompt the baseline already failed is excluded → N/A).
- **Memory delta sanity** — measured KV footprint reduction; the candidate must actually be smaller.

**Optional (built, gated):** **NIAH** long-context retrieval — RAM/compute-tier-gated via #5 (skips on sub-M3 / low-RAM chips, and unless `--niah` is passed).

**Advisory, not blocking (measure-first).** Mirrors the `diff_coverage` advisory pattern: the harness prints a full PASS/FAIL report but **exits 0 regardless** by default. Thresholds are **provisional** — this run exists to *gather baseline numbers*, not to fail anything yet. `--enforce` makes a FAIL exit non-zero, ready for a follow-up that calibrates thresholds and promotes the gate to blocking once we have fleet data.

Live report on a cached `Qwen3-0.6B-4bit` (M3 Ultra), demonstrating the gate produces a real signal — memory saving confirmed, and int4-KV correctly flagged as catastrophic on this tiny worst-case model:

```
 candidate: int8-KV   memory_reduction=1.88x (PASS)  greedy_agreement=0.59  mean_kl=0.053
 candidate: int4-KV   memory_reduction=3.56x (PASS)  greedy_agreement=0.00  mean_kl=12.4
```

### #5 — chip-tier classifier

Chip *detection* already exists (`optimizations.HardwareInfo.chip_name`, `vllm_platform._get_apple_chip_name`). What was missing is a **structured** tier. `vllm_mlx/chip_tier.py` adds a small **pure** function parsing the existing chip string (`"Apple M3 Ultra"`) into `generation` (int), `variant` (`base`/`Pro`/`Max`/`Ultra`), and `is_m3_or_newer` — returning an explicit **"unknown" tier** (never crashing) for non-Apple/empty/Intel input.

- **Used in #4** to RAM/compute-gate the optional NIAH metric and to record the chip tier in every report.
- **Future MTP use (NOT wired here):** MTP speculative decoding uses a single global `DEFAULT_MAX_K`. The natural next use is to tier `max_k` by chip generation/variant; the module docstring points there. Intentionally left to a follow-up.

## Why

The int4/int8 KV-cache safelist is currently **assertion, not measurement** — we tell users a dtype is "safe" based on architecture intuition, with no reproducible evidence and no way to catch a silent regression when a new family lands or an mlx-lm bump shifts numerics. This adds the missing measured signal in the cheapest responsible way: an offline, download-free, advisory harness that quantifies quantization-induced drift against each model's own full-precision self. Advisory-first (not a hard gate) because the honest thresholds aren't known yet — shipping it in measure-first mode lets us collect baselines across the fleet before committing to numbers that would otherwise be guesses. #5 is a tiny structured primitive that both this gate and future MTP `max_k` tiering need, replacing ad-hoc substring-matching on the chip string.

## Test plan

- [x] Chip classifier: table-driven over real brand strings (`Apple M1` … `Apple M4 Max`, HARDWARE_PROFILES keys, Intel/empty/`None`) asserting generation/variant/is_m3_or_newer; substring-token false-trigger guard (`M3 Maximum` ≠ Max); unknown-tier-never-raises.
- [x] Gate metrics: each metric function unit-tested with SYNTHETIC baseline/candidate token streams + logprob vectors + byte counts (identical→100%, one-token-diff→known rate, degraded logits→KL>0, `-inf`→finite-but-large KL, shape-mismatch skip, retention attributable/excluded logic, memory ratio incl. degenerate zero).
- [x] Report schema + PASS/FAIL: expected JSON fields present, JSON-serializable, threshold-boundary cases (exactly-at→PASS, just-below→FAIL), NA metrics don't fail overall, NIAH pass/fail/skipped participation.
- [x] Gated smoke (`@pytest.mark.slow`): runs the REAL harness on one small already-cached model (`mlx-community/Qwen3-0.6B-4bit`) and asserts the report schema + that int8-KV actually saves memory; **SKIPS cleanly** (cache-probe via `try_to_load_from_cache`) when no candidate model is cached — never downloads.
- [x] Hermetic default run green: `55 passed, 1 deselected` (slow smoke deselected by default).
- [x] Slow smoke green on M3 Ultra: `1 passed` in 11.85s on cached `Qwen3-0.6B-4bit`.
- [x] `ruff check` + `ruff format --check` clean on all 5 files.
- [x] Advisory exit=0 / `--enforce` FAIL exit=1 verified.

## Out of scope (deliberate MVP boundary)

- Not wired as a merge/release-blocking gate (measure-first; thresholds calibrated + promoted in a follow-up).
- No `release_fleet` integration, no large-model downloads.
- No MTP `max_k` wiring (docstring-noted only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
