### PR TITLE
fix(auth): normalize bearer token whitespace for rate limit stability

### DIFF
--- a/tests/test_config_and_middleware.py
+++ b/tests/test_config_and_middleware.py
@@ -370,6 +370,88 @@ class TestRateLimitClientId:
             f"got {bearer_id!r} != {x_api_id!r}"
         )
 
+    def test_extract_bearer_token_whitespace_normalization(self):
+        """_extract_bearer_token strips leading, trailing, and tab/newline whitespace."""
+        from vllm_mlx.middleware.auth import _extract_bearer_token
+
+        assert _extract_bearer_token("Bearer    my-token") == "my-token"
+        assert _extract_bearer_token("Bearer \t my-token \n") == "my-token"
+        assert _extract_bearer_token("Bearer my-token   ") == "my-token"
+        assert _extract_bearer_token("Bearer   ") is None
+
+    def test_rate_limit_bearer_whitespace_variants_share_bucket(self):
+        """Auth-equivalent Bearer values must resolve to one rate-limit bucket.
+
+        This pins the security *contract* (not just the helper): the bug being
+        fixed is bucket fragmentation — the same secret sent with extra
+        surrounding whitespace used to hash to a different client id, letting a
+        client dodge its own rate limit simply by padding the header. All of
+        these carry the identical token ``test-secret`` and must share a bucket.
+        """
+        from starlette.requests import Request
+
+        from vllm_mlx.middleware.auth import _rate_limit_client_id
+
+        def client_id(auth_value: str) -> str:
+            scope = {
+                "type": "http",
+                "headers": [(b"authorization", auth_value.encode())],
+                "client": ("192.0.2.1", 12345),
+            }
+            return _rate_limit_client_id(Request(scope))
+
+        canonical = client_id("Bearer test-secret")
+        for variant in (
+            "Bearer  test-secret",
+            "Bearer test-secret ",
+            "Bearer \t test-secret \n",
+        ):
+            assert client_id(variant) == canonical, (
+                f"whitespace-padded {variant!r} must share the bucket of "
+                f"'Bearer test-secret', got {client_id(variant)!r} != {canonical!r}"
+            )
+
+    def test_rate_limit_empty_bearer_falls_through_to_subnet(self):
+        """An empty/whitespace-only Bearer token can't mint fresh buckets.
+
+        Without a real credential (auth disabled), a client sending
+        ``Authorization: Bearer`` with varying trailing whitespace must NOT get
+        a distinct bucket per padding — otherwise the padding itself becomes a
+        rate-limit evasion. All such headers collapse to the caller's subnet
+        bucket (#1291).
+        """
+        from starlette.requests import Request
+
+        from vllm_mlx.middleware.auth import _rate_limit_client_id, _subnet_bucket
+
+        def client_id(auth_value: str) -> str:
+            scope = {
+                "type": "http",
+                "headers": [(b"authorization", auth_value.encode())],
+                "client": ("192.0.2.7", 443),
+            }
+            return _rate_limit_client_id(Request(scope))
+
+        subnet = _subnet_bucket("192.0.2.7")
+        for empty in ("Bearer", "Bearer ", "Bearer  ", "Bearer \t \n"):
+            assert client_id(empty) == subnet, (
+                f"empty Bearer {empty!r} must fall through to the subnet bucket, "
+                f"got {client_id(empty)!r} != {subnet!r}"
+            )
+
+    def test_rate_limit_non_bearer_scheme_still_buckets_by_header(self):
+        """Non-Bearer auth (e.g. Basic) keeps a stable per-credential bucket."""
+        from starlette.requests import Request
+
+        from vllm_mlx.middleware.auth import _bucket_id, _rate_limit_client_id
+
+        scope = {
+            "type": "http",
+            "headers": [(b"authorization", b"Basic dXNlcjpwYXNz")],
+            "client": ("192.0.2.7", 443),
+        }
+        assert _rate_limit_client_id(Request(scope)) == _bucket_id("Basic dXNlcjpwYXNz")
+
 
 # ======================================================================
 # configure_cors — Fetch-spec-compliant defaults (#190)

--- a/vllm_mlx/middleware/auth.py
+++ b/vllm_mlx/middleware/auth.py
@@ -153,7 +153,8 @@ def _extract_bearer_token(authorization: str | None) -> str | None:
     scheme, _, token = authorization.partition(" ")
     if scheme.lower() != "bearer" or not token:
         return None
-    return token
+    token = token.strip()
+    return token or None
 
 
 def _bucket_id(raw: str) -> str:
@@ -194,8 +195,17 @@ def _rate_limit_client_id(request: Request) -> str:
     authorization = request.headers.get("Authorization")
     if authorization:
         bearer_key = _extract_bearer_token(authorization)
-        raw = bearer_key or authorization
-        return _bucket_id(raw)
+        if bearer_key is not None:
+            return _bucket_id(bearer_key)
+        # A recognized ``Bearer`` scheme carrying an empty / whitespace-only
+        # token is not a real credential — fall through to subnet/unknown
+        # bucketing so a client can't mint a fresh rate-limit bucket per
+        # request by padding the header with varying whitespace (#1291). A
+        # non-Bearer scheme (e.g. ``Basic``) still buckets by the raw header
+        # so it keeps a stable per-credential identity.
+        scheme = authorization.split(" ", 1)[0].lower()
+        if scheme != "bearer":
+            return _bucket_id(authorization)
 
     if request.client and request.client.host:
         return _subnet_bucket(request.client.host)


### PR DESCRIPTION
## What does this PR do?
- Adds `.strip()` to `_extract_bearer_token` in `vllm_mlx/middleware/auth.py` so surrounding whitespace (spaces, tabs, newlines) is normalized and an all-whitespace token is treated as absent.
- Adds tests in `tests/test_config_and_middleware.py`: the helper's whitespace edge cases **and** a bucket-level contract test asserting auth-equivalent Bearer values resolve to one `_rate_limit_client_id`.

## Why is this needed?
Closes the "Bearer token whitespace normalization" task from #337.
Without this, a client can dodge its own rate limit just by padding the Bearer token with extra spaces/tabs — the unstripped string hashes to a brand-new bucket identity.

## Scope note (maintainer, narrowed for merge)
Rebased onto current `main` and narrowed to the auth fix + tests per review. Dropped two out-of-scope changes from the original revision: the `if TYPE_CHECKING:` gate on `server_config.py` (it broke runtime `typing.get_type_hints(ServerConfig)` with `NameError: BaseEngine`), and three `except ImportError: pytest.skip` guards on the exception-handler tests (they'd turn a broken/partial MLX install into a green skip and hide packaging regressions). Original authorship preserved on the commit.

## Test plan
- `python3.12 -m pytest tests/test_config_and_middleware.py::TestRateLimitClientId -q` — 5 passed.
- `ruff check && ruff format --check` on both touched files — clean.

## Checklist
- [x] Tests pass locally
- [x] Lint passes (`ruff check && ruff format --check`)
- [x] Self-validated via `pr_validate`
- [x] New tests touch a security path — the bucket contract test fails if the `.strip()` is reverted
- [x] Updated README/docs if applicable — N/A (internal auth helper, no user-facing surface)
- [x] No breaking changes to existing API