### PR TITLE
fix: kv-quant gate head_dim guard + chip_tier dangling import [skip-version-bump]

### DIFF
--- a/scripts/kv_quant_quality_gate.py
+++ b/scripts/kv_quant_quality_gate.py
@@ -61,6 +61,10 @@ from vllm_mlx.kv_quant_gate import (  # noqa: E402
     logit_divergence,
     structured_output_retention,
 )
+from vllm_mlx.quantized_batch_cache import (  # noqa: E402
+    probe_kv_head_dims,
+    resolve_kv_quantization,
+)
 
 # Built-in prompt set. A couple explicitly ask for JSON so the structured-output
 # retention metric has attributable prompts. Kept small — this is an M-sized
@@ -116,6 +120,18 @@ def _encode_prompt(tokenizer, text: str) -> list[int]:
             )
         )
     return list(tokenizer.encode(text))
+
+
+def _is_kv_quant_incompat(exc: BaseException) -> bool:
+    """True iff ``exc`` is MLX's "head_dim not divisible by group size" error.
+
+    ``mx.quantize`` raises a ``ValueError`` like "The last dimension of the matrix
+    needs to be divisible by the quantization group size 64 ..." when the head_dim
+    is incompatible. We match on that shape so the gate can degrade to an advisory
+    skip for THIS failure only, never swallowing an unrelated error.
+    """
+    msg = str(exc).lower()
+    return "group size" in msg and "divisible" in msg
 
 
 def _decode_text(tokenizer, token_ids: list[int]) -> str:
@@ -455,6 +471,52 @@ def run_gate(
     model, tokenizer = load(hf_path)
     eos_ids = _eos_ids(tokenizer)
 
+    # KV-quant group-size compatibility (issue #1294). ``mx.quantize`` requires
+    # BOTH the key and value head dims to be exact multiples of the group size; a
+    # model whose head_dim isn't divisible by the requested size (e.g. Phi-3's
+    # head_dim=96 vs the default 64) would otherwise abort the whole gate with a
+    # raw MLX ValueError mid-generation. Resolve a compatible size up front with
+    # the SAME probe + policy the live serve path uses (``probe_kv_head_dims`` +
+    # ``resolve_kv_quantization``), so the gate measures the exact config serving
+    # would run — including MLA models whose K/V head dims differ. Baseline runs
+    # are unquantized, so this only affects the candidate generations.
+    k_head_dim, v_head_dim = probe_kv_head_dims(model)
+    resolved, live_disabled = resolve_kv_quantization(
+        k_head_dim, v_head_dim, kv_group_size
+    )
+    if live_disabled:
+        # Serving would keep this model's KV cache bf16 — either its K/V head dims
+        # divide no supported group size (e.g. head_dim=80) or they couldn't be
+        # probed. Either way there is no live KV-quant configuration to measure,
+        # so skip rather than test a config serving never runs (or crash on an
+        # incompatible mx.quantize). Mirrors resolve_kv_quantization exactly.
+        if k_head_dim is not None and v_head_dim is not None:
+            reason = (
+                f"KV head dims (k={k_head_dim}, v={v_head_dim}) divide no "
+                "supported group size (128/64/32)"
+            )
+        else:
+            reason = "KV head dims could not be probed"
+        print(
+            f"[kv-quant-gate] {reason}; serving keeps this model's KV cache bf16 "
+            "— nothing to measure.",
+            file=sys.stderr,
+        )
+        if json_out is not None:
+            json_out.write_text(json.dumps([], indent=2))
+            print(f"[kv-quant-gate] wrote JSON report -> {json_out}", file=sys.stderr)
+        # Advisory: nothing to measure, exit 0. Enforced: a gate that measured
+        # NOTHING must not read as success (mirrors the empty-candidate guard).
+        return 0 if advisory else 1
+    if resolved != kv_group_size:
+        print(
+            f"[kv-quant-gate] adjusted --group-size {kv_group_size} -> {resolved} "
+            f"to satisfy this model's KV head dims (k={k_head_dim}, v={v_head_dim}; "
+            "mx.quantize constraint).",
+            file=sys.stderr,
+        )
+        kv_group_size = resolved
+
     try:
         chip = detect_chip_tier()
     except Exception:
@@ -523,43 +585,60 @@ def run_gate(
         divergences: list[LogitDivergence] = []
         retention_pairs: list[tuple[str, str]] = []
 
-        for base in baseline_runs:
-            cand_tokens, cand_lp, _ = _run_generation(
+        # Safety net for the residual case the up-front resolve can't cover — a
+        # model whose head_dim we couldn't infer, or one with mixed per-layer head
+        # dims (e.g. a k_pe rope split). If ``mx.quantize`` still rejects the
+        # head_dim, skip THIS candidate with an advisory rather than crash the
+        # whole gate (issue #1294). Only the divisibility error is caught.
+        try:
+            for base in baseline_runs:
+                cand_tokens, cand_lp, _ = _run_generation(
+                    model,
+                    base["prompt_ids"],
+                    max_tokens=max_tokens,
+                    kv_bits=cand_bits,
+                    kv_group_size=kv_group_size,
+                    eos_ids=eos_ids,
+                    collect_logprobs=True,
+                    stop_on_eos=True,
+                )
+                ag = greedy_agreement_rate(base["tokens"], cand_tokens)
+                agreements.append(ag)
+                # Same-context prefix: up to AND INCLUDING the first divergence
+                # step (its distributions still share a context), else the whole
+                # overlap.
+                compare_len = (
+                    ag.first_divergence_index + 1
+                    if ag.first_divergence_index is not None
+                    else ag.total
+                )
+                divergences.append(
+                    logit_divergence(base["logprobs"], cand_lp, compare_len=compare_len)
+                )
+                if base["kind"] == "json":
+                    # Candidate decoded with skip_special_tokens so a trailing EOS
+                    # control token can't break the strict whole-output JSON parse.
+                    retention_pairs.append(
+                        (base["text"], _decode_text(tokenizer, cand_tokens))
+                    )
+
+            cand_bytes, _ = _measure_kv_bytes(
                 model,
-                base["prompt_ids"],
-                max_tokens=max_tokens,
+                mem_prompt_ids,
+                mem_tokens=mem_tokens,
                 kv_bits=cand_bits,
                 kv_group_size=kv_group_size,
-                eos_ids=eos_ids,
-                collect_logprobs=True,
-                stop_on_eos=True,
             )
-            ag = greedy_agreement_rate(base["tokens"], cand_tokens)
-            agreements.append(ag)
-            # Same-context prefix: up to AND INCLUDING the first divergence step
-            # (its distributions still share a context), else the whole overlap.
-            compare_len = (
-                ag.first_divergence_index + 1
-                if ag.first_divergence_index is not None
-                else ag.total
+        except ValueError as exc:
+            if not _is_kv_quant_incompat(exc):
+                raise
+            print(
+                f"[kv-quant-gate] skipping {cdtype} candidate — this model's "
+                f"head_dim is incompatible with KV-quant group size "
+                f"{kv_group_size} ({exc}).",
+                file=sys.stderr,
             )
-            divergences.append(
-                logit_divergence(base["logprobs"], cand_lp, compare_len=compare_len)
-            )
-            if base["kind"] == "json":
-                # Candidate decoded with skip_special_tokens so a trailing EOS
-                # control token can't break the strict whole-output JSON parse.
-                retention_pairs.append(
-                    (base["text"], _decode_text(tokenizer, cand_tokens))
-                )
-
-        cand_bytes, _ = _measure_kv_bytes(
-            model,
-            mem_prompt_ids,
-            mem_tokens=mem_tokens,
-            kv_bits=cand_bits,
-            kv_group_size=kv_group_size,
-        )
+            continue
         from vllm_mlx.kv_quant_gate import memory_delta
 
         niah = _maybe_run_niah(
@@ -603,6 +682,15 @@ def run_gate(
 
     if advisory:
         return 0
+    # Enforced: a run where every candidate was skipped as incompatible measured
+    # NOTHING and must not report success (mirrors the empty-candidate guard).
+    if not reports:
+        print(
+            "[kv-quant-gate] --enforce: no candidate could be measured "
+            "(all incompatible with this model's head_dim).",
+            file=sys.stderr,
+        )
+        return 1
     return 1 if any_fail else 0
 
 

--- a/tests/test_chip_tier.py
+++ b/tests/test_chip_tier.py
@@ -8,6 +8,9 @@ fallback / non-Apple shapes. Pure string parsing — no system calls.
 
 from __future__ import annotations
 
+from pathlib import Path
+from types import SimpleNamespace
+
 import pytest
 
 from vllm_mlx.chip_tier import (
@@ -106,3 +109,36 @@ def test_detect_chip_tier_returns_valid_tier():
     else:
         assert tier.generation is None
         assert tier.variant == VARIANT_UNKNOWN
+
+
+def test_chip_tier_has_no_dangling_vllm_platform_reference():
+    """Regression for #1295: #1288 deleted ``vllm_mlx.vllm_platform`` but
+    ``chip_tier.py`` still imported ``_get_apple_chip_name`` from it. The
+    ``try/except`` masked the resulting ``ImportError`` at runtime (the
+    ``sysctl`` fallback ran), so no test caught the dangling reference. Assert
+    the deleted module is never referenced in the source at all.
+    """
+    import vllm_mlx.chip_tier as chip_tier_mod
+
+    source = Path(chip_tier_mod.__file__).read_text()
+    assert "vllm_platform" not in source, (
+        "chip_tier.py references the deleted vllm_platform module — the #1288 "
+        "removal left a dangling import (issue #1295)."
+    )
+
+
+def test_detect_chip_tier_uses_sysctl_not_deleted_import(monkeypatch):
+    """detect_chip_tier reads the chip via ``sysctl`` directly, without routing
+    through the removed ``vllm_platform`` helper. Fake the subprocess and assert
+    the brand string flows through to the classifier."""
+    import subprocess
+
+    def _fake_run(cmd, *args, **kwargs):
+        assert cmd[:2] == ["sysctl", "-n"]
+        return SimpleNamespace(stdout="Apple M3 Ultra\n")
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+    tier = detect_chip_tier()
+    assert tier.is_apple_silicon
+    assert tier.generation == 3
+    assert tier.variant == VARIANT_ULTRA

--- a/tests/test_quantized_batch_cache.py
+++ b/tests/test_quantized_batch_cache.py
@@ -460,6 +460,10 @@ def test_supported_group_size():
     assert supported_group_size(128, 128) == 128
     assert supported_group_size(80, 64) is None  # 80 not div by 32/64/128
     assert supported_group_size(40, 128) is None
+    # Never exceeds the requested size: head_dim=128 with requested=96 resolves
+    # DOWN to 64, not up to 128 — the KV-quant gate (scripts/kv_quant_quality_
+    # gate.py, #1294) reuses this so it measures the SAME config serving runs.
+    assert supported_group_size(128, 96) == 64
 
 
 def test_probe_head_dim():

--- a/vllm_mlx/chip_tier.py
+++ b/vllm_mlx/chip_tier.py
@@ -6,8 +6,8 @@ Chip *detection* already exists in the engine:
 * :func:`vllm_mlx.optimizations.detect_hardware` returns a
   :class:`~vllm_mlx.optimizations.HardwareInfo` whose ``chip_name`` is a short
   profile key (e.g. ``"M3 Ultra"``).
-* :func:`vllm_mlx.vllm_platform._get_apple_chip_name` reads the raw
-  ``machdep.cpu.brand_string`` (e.g. ``"Apple M3 Ultra"``).
+* :func:`detect_chip_tier` (below) reads the raw ``machdep.cpu.brand_string``
+  via ``sysctl`` (e.g. ``"Apple M3 Ultra"``).
 
 What was MISSING is a *structured* tier — a small, pure parse of that free-form
 chip string into fields code can branch on without substring-matching at every
@@ -104,8 +104,9 @@ def classify_chip_tier(chip_name: str | None) -> ChipTier:
     ``M<n>`` (``"BMW M3"``) is NOT misread as Apple silicon.
 
     Args:
-        chip_name: The chip string from ``detect_hardware().chip_name`` or
-            ``_get_apple_chip_name()``. ``None`` is tolerated.
+        chip_name: The chip string from ``detect_hardware().chip_name`` or the
+            raw ``machdep.cpu.brand_string`` (see :func:`detect_chip_tier`).
+            ``None`` is tolerated.
 
     Returns:
         A :class:`ChipTier`. For an unrecognized string:
@@ -161,29 +162,23 @@ def classify_chip_tier(chip_name: str | None) -> ChipTier:
 def detect_chip_tier() -> ChipTier:
     """Classify the *current* machine's chip.
 
-    Thin convenience that reuses the engine's existing chip detection
-    (:func:`vllm_mlx.vllm_platform._get_apple_chip_name`, which reads
-    ``machdep.cpu.brand_string``) and runs it through :func:`classify_chip_tier`.
-    Falls back to a local ``sysctl`` read, then to the unknown tier, so it never
-    raises on a non-macOS host.
+    Reads the raw ``machdep.cpu.brand_string`` (e.g. ``"Apple M3 Ultra"``) via
+    ``sysctl`` and runs it through :func:`classify_chip_tier`. Any failure — a
+    non-macOS host, a missing ``sysctl``, a timeout — degrades to an empty
+    string and hence the unknown tier, so this never raises.
     """
     chip_name = ""
-    try:  # Prefer the existing detector — single source of truth.
-        from vllm_mlx.vllm_platform import _get_apple_chip_name
+    try:
+        import subprocess
 
-        chip_name = _get_apple_chip_name()
+        result = subprocess.run(
+            ["sysctl", "-n", "machdep.cpu.brand_string"],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=2,
+        )
+        chip_name = result.stdout.strip()
     except Exception:
-        try:
-            import subprocess
-
-            result = subprocess.run(
-                ["sysctl", "-n", "machdep.cpu.brand_string"],
-                capture_output=True,
-                text=True,
-                check=True,
-                timeout=2,
-            )
-            chip_name = result.stdout.strip()
-        except Exception:
-            chip_name = ""
+        chip_name = ""
     return classify_chip_tier(chip_name)


### PR DESCRIPTION
## Why

Two P3 bugs surfaced while dogfooding `main:HEAD` (all 24 PRs since 0.11.1). Both are
side-effects of the two most recent quality/cleanup PRs (#1288 removal, #1289 KV-quant
gate). Neither breaks live serving, but both are real defects that a user (or CI) can hit.

### Fix 1 — kv-quant quality gate crashes on incompatible head_dim (Closes #1294)

`scripts/kv_quant_quality_gate.py` (added in #1289) passed the raw `--group-size`
straight into `mx.quantize`, so any model whose K/V head dim doesn't divide the
requested group size raised a bare `ValueError` mid-run:

```
[quantize] The last dimension ... must be divisible by the quantization group size 64 ... shape (1,32,256,96)
```

Repro: Phi-3 (head_dim=96) with the default `--group-size 64`.

The **live serving path already handles this** — `resolve_kv_quantization()` in
`quantized_batch_cache.py` coerces the group size down to the largest supported
size that divides *both* K and V head dims, and fail-closes to bf16 when none do.
The gate now reuses those exact canonical helpers instead of reinventing the logic:

- Up front: `probe_kv_head_dims(model)` + `resolve_kv_quantization(k, v, requested)`.
  - If serving would disable live-quant for this model (incompatible **or** un-probeable
    head dims), the gate prints why and measures nothing — writing an empty JSON report,
    exit 0 in advisory mode / exit 1 under `--enforce` (nothing to certify).
  - Otherwise it adjusts `--group-size` to the resolved value (mirroring serving) and
    logs the adjustment.
- Per candidate: a `ValueError` matching the mlx group-size constraint is caught and
  the candidate is skipped rather than crashing the whole run.
- `--enforce` now fails (exit 1) if it measured **nothing**, so a silently-empty run
  can't pass the gate.

### Fix 2 — chip_tier.py dangling import of a deleted module (Closes #1295)

#1288 deleted `vllm_mlx/vllm_platform.py`, but `chip_tier.py` (added in #1289) still did
`from vllm_mlx.vllm_platform import _get_apple_chip_name` inside `detect_chip_tier()`.
A `try/except` around it masked the `ImportError` at runtime — the `sysctl` fallback ran,
so `detect_chip_tier()` still worked and no test caught the dangling reference.

`detect_chip_tier()` now reads `machdep.cpu.brand_string` via `sysctl` directly (which is
all the deleted helper did) and routes it through `classify_chip_tier`. Three stale
docstrings referencing the old helper are corrected.

## Tests

- `tests/test_chip_tier.py`: `test_chip_tier_has_no_dangling_vllm_platform_reference`
  (asserts the deleted module is never referenced in the source) and
  `test_detect_chip_tier_uses_sysctl_not_deleted_import` (fakes `subprocess.run` →
  asserts the brand string flows through to the classifier).
- `tests/test_quantized_batch_cache.py`: locks `supported_group_size(128, 96) == 64`
  ("never exceeds the requested size").

## Validation

- `ruff check` clean; targeted unit suite 125 passed.
- Live repro on Phi-3 (head_dim=96): gate now logs
  `adjusted --group-size 64 -> 32 to satisfy this model's KV head dims (k=96, v=96 ...)`
  and returns OVERALL PASS (exit 0) instead of crashing.
- codex review converged to 0 BLOCKING / 0 MAJOR.

Closes #1294
Closes #1295
