### PR TITLE
feat(audio): wire F5-TTS (pure-MLX) — Chinese expressive TTS + zero-shot cloning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -340,7 +340,7 @@ audio = [
     # F5-TTS (pure-MLX, no torch): EN+ZH multilingual + zero-shot voice cloning.
     # Fills the Chinese expressive/cloneable TTS gap. Standalone package (not an
     # mlx_audio family) — wired directly in audio/tts.py's `f5` branch.
-    "f5-tts-mlx>=0.2.6",
+    "f5-tts-mlx>=0.2.6,<0.3",
     "sounddevice>=0.4.0",
     "soundfile>=0.12.0",
     "scipy>=1.10.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -337,6 +337,10 @@ audio = [
     # ships a fix so every fresh ``pip install rapid-mlx[audio]``
     # works out of the box.
     "mlx-audio>=0.2.9,<0.4.4",
+    # F5-TTS (pure-MLX, no torch): EN+ZH multilingual + zero-shot voice cloning.
+    # Fills the Chinese expressive/cloneable TTS gap. Standalone package (not an
+    # mlx_audio family) — wired directly in audio/tts.py's `f5` branch.
+    "f5-tts-mlx>=0.2.6",
     "sounddevice>=0.4.0",
     "soundfile>=0.12.0",
     "scipy>=1.10.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -340,7 +340,7 @@ audio = [
     # F5-TTS (pure-MLX, no torch): EN+ZH multilingual + zero-shot voice cloning.
     # Fills the Chinese expressive/cloneable TTS gap. Standalone package (not an
     # mlx_audio family) — wired directly in audio/tts.py's `f5` branch.
-    "f5-tts-mlx>=0.2.6,<0.3",
+    "f5-tts-mlx==0.2.6",
     "sounddevice>=0.4.0",
     "soundfile>=0.12.0",
     "scipy>=1.10.0",

--- a/tests/test_f5_tts_wiring.py
+++ b/tests/test_f5_tts_wiring.py
@@ -9,9 +9,11 @@ from unittest.mock import MagicMock
 
 import numpy as np
 import pytest
+from pydantic import ValidationError
 
+from vllm_mlx.api.models import AudioSpeechRequest
 from vllm_mlx.audio.tts import TTSEngine
-from vllm_mlx.routes.audio import _allowed_voices_for
+from vllm_mlx.routes.audio import _allowed_voices_for, _decode_tts_ref_audio
 
 
 def test_f5_family_is_detected() -> None:
@@ -23,6 +25,17 @@ def test_f5_clone_requires_audio_and_transcript_together() -> None:
     engine = TTSEngine("lucasnewman/f5-tts-mlx")
     with pytest.raises(ValueError, match="both ref_audio and ref_text"):
         engine._generate_f5("hello", "/tmp/unused.wav", None, 1.0)
+
+
+def test_f5_api_reference_is_base64_and_requires_a_pair() -> None:
+    encoded = "data:audio/wav;base64,UklGRg=="
+    request = AudioSpeechRequest(input="你好", ref_audio=encoded, ref_text="参考")
+    assert _decode_tts_ref_audio(request.ref_audio or "") == b"RIFF"
+
+    with pytest.raises(ValidationError, match="provided together"):
+        AudioSpeechRequest(input="你好", ref_audio=encoded)
+    with pytest.raises(ValueError, match="valid base64"):
+        _decode_tts_ref_audio("not base64")
 
 
 def test_f5_generation_uses_safe_in_memory_default_and_speed(

--- a/tests/test_f5_tts_wiring.py
+++ b/tests/test_f5_tts_wiring.py
@@ -1,0 +1,112 @@
+"""Regression tests for the optional F5-TTS integration."""
+
+from __future__ import annotations
+
+import io
+import sys
+from types import ModuleType, SimpleNamespace
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+from vllm_mlx.audio.tts import TTSEngine
+from vllm_mlx.routes.audio import _allowed_voices_for
+
+
+def test_f5_family_is_detected() -> None:
+    assert TTSEngine("lucasnewman/f5-tts-mlx")._model_family == "f5"
+    assert _allowed_voices_for("lucasnewman/f5-tts-mlx") == ["clone"]
+
+
+def test_f5_clone_requires_audio_and_transcript_together() -> None:
+    engine = TTSEngine("lucasnewman/f5-tts-mlx")
+    with pytest.raises(ValueError, match="both ref_audio and ref_text"):
+        engine._generate_f5("hello", "/tmp/unused.wav", None, 1.0)
+
+
+def test_f5_generation_uses_safe_in_memory_default_and_speed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_mx = SimpleNamespace(
+        array=lambda value: np.asarray(value),
+        sqrt=np.sqrt,
+        mean=np.mean,
+        square=np.square,
+        eval=lambda value: None,
+        expand_dims=np.expand_dims,
+    )
+    mlx_module = ModuleType("mlx")
+    mlx_core = ModuleType("mlx.core")
+    for name, value in vars(fake_mx).items():
+        setattr(mlx_core, name, value)
+    mlx_module.core = mlx_core
+    monkeypatch.setitem(sys.modules, "mlx", mlx_module)
+    monkeypatch.setitem(sys.modules, "mlx.core", mlx_core)
+
+    generate_module = ModuleType("f5_tts_mlx.generate")
+    generate_module.FRAMES_PER_SEC = 100
+    generate_module.SAMPLE_RATE = 24_000
+    generate_module.TARGET_RMS = 0.1
+    generate_module.convert_char_to_pinyin = lambda texts: texts
+    duration = MagicMock(return_value=2.0)
+    generate_module.estimated_duration = duration
+    package = ModuleType("f5_tts_mlx")
+    monkeypatch.setitem(sys.modules, "f5_tts_mlx", package)
+    monkeypatch.setitem(sys.modules, "f5_tts_mlx.generate", generate_module)
+
+    monkeypatch.setattr("pkgutil.get_data", lambda *_: b"packaged-wave", raising=True)
+    read = MagicMock(return_value=(np.ones(240, dtype=np.float32), 24_000))
+    monkeypatch.setattr("soundfile.read", read)
+
+    model = MagicMock()
+    model.sample.return_value = (np.ones(480, dtype=np.float32), None)
+    engine = TTSEngine("lucasnewman/f5-tts-mlx")
+    engine.model = model
+
+    output = engine._generate_f5("你好", None, None, 1.5)
+
+    assert isinstance(read.call_args.args[0], io.BytesIO)
+    duration.assert_called_once()
+    assert duration.call_args.args[-1] == 1.5
+    assert model.sample.call_args.kwargs["speed"] == 1.5
+    assert output.sample_rate == 24_000
+    assert output.audio.shape == (240,)
+
+
+def test_f5_rejects_stereo_and_silent_references(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_mx = ModuleType("mlx.core")
+    fake_mx.array = np.asarray
+    fake_mx.sqrt = np.sqrt
+    fake_mx.mean = np.mean
+    fake_mx.square = np.square
+    fake_mx.eval = lambda value: None
+    mlx_module = ModuleType("mlx")
+    mlx_module.core = fake_mx
+    monkeypatch.setitem(sys.modules, "mlx", mlx_module)
+    monkeypatch.setitem(sys.modules, "mlx.core", fake_mx)
+
+    generate_module = ModuleType("f5_tts_mlx.generate")
+    generate_module.FRAMES_PER_SEC = 100
+    generate_module.SAMPLE_RATE = 24_000
+    generate_module.TARGET_RMS = 0.1
+    generate_module.convert_char_to_pinyin = lambda texts: texts
+    generate_module.estimated_duration = lambda *_: 1.0
+    monkeypatch.setitem(sys.modules, "f5_tts_mlx", ModuleType("f5_tts_mlx"))
+    monkeypatch.setitem(sys.modules, "f5_tts_mlx.generate", generate_module)
+
+    engine = TTSEngine("lucasnewman/f5-tts-mlx")
+    monkeypatch.setattr(
+        "soundfile.read",
+        lambda *_: (np.ones((240, 2), dtype=np.float32), 24_000),
+    )
+    with pytest.raises(ValueError, match="mono"):
+        engine._generate_f5("hello", "ref.wav", "reference", 1.0)
+
+    monkeypatch.setattr(
+        "soundfile.read", lambda *_: (np.zeros(240, dtype=np.float32), 24_000)
+    )
+    with pytest.raises(ValueError, match="non-silent"):
+        engine._generate_f5("hello", "ref.wav", "reference", 1.0)

--- a/tests/test_f5_tts_wiring.py
+++ b/tests/test_f5_tts_wiring.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import inspect
 import io
 import sys
 from types import ModuleType, SimpleNamespace
@@ -19,6 +20,14 @@ from vllm_mlx.routes.audio import _allowed_voices_for, _decode_tts_ref_audio
 def test_f5_family_is_detected() -> None:
     assert TTSEngine("lucasnewman/f5-tts-mlx")._model_family == "f5"
     assert _allowed_voices_for("lucasnewman/f5-tts-mlx") == ["clone"]
+
+
+def test_installed_f5_sample_contract() -> None:
+    f5 = pytest.importorskip("f5_tts_mlx.cfm")
+    parameters = inspect.signature(f5.F5TTS.sample).parameters
+    assert {"cond", "text", "duration", "steps", "speed", "cfg_strength"} <= set(
+        parameters
+    )
 
 
 def test_f5_clone_requires_audio_and_transcript_together() -> None:
@@ -70,6 +79,10 @@ def test_f5_generation_uses_safe_in_memory_default_and_speed(
 
     monkeypatch.setattr("pkgutil.get_data", lambda *_: b"packaged-wave", raising=True)
     read = MagicMock(return_value=(np.ones(240, dtype=np.float32), 24_000))
+    monkeypatch.setattr(
+        "soundfile.info",
+        lambda *_: SimpleNamespace(samplerate=24_000, channels=1, frames=240),
+    )
     monkeypatch.setattr("soundfile.read", read)
 
     model = MagicMock()
@@ -112,12 +125,16 @@ def test_f5_rejects_stereo_and_silent_references(
 
     engine = TTSEngine("lucasnewman/f5-tts-mlx")
     monkeypatch.setattr(
-        "soundfile.read",
-        lambda *_: (np.ones((240, 2), dtype=np.float32), 24_000),
+        "soundfile.info",
+        lambda *_: SimpleNamespace(samplerate=24_000, channels=2, frames=240),
     )
     with pytest.raises(ValueError, match="mono"):
         engine._generate_f5("hello", "ref.wav", "reference", 1.0)
 
+    monkeypatch.setattr(
+        "soundfile.info",
+        lambda *_: SimpleNamespace(samplerate=24_000, channels=1, frames=240),
+    )
     monkeypatch.setattr(
         "soundfile.read", lambda *_: (np.zeros(240, dtype=np.float32), 24_000)
     )

--- a/tests/test_f5_tts_wiring.py
+++ b/tests/test_f5_tts_wiring.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import inspect
 import io
+import pkgutil
 import sys
 from types import ModuleType, SimpleNamespace
 from unittest.mock import MagicMock
@@ -24,6 +25,7 @@ def test_f5_family_is_detected() -> None:
 
 def test_installed_f5_sample_contract() -> None:
     f5 = pytest.importorskip("f5_tts_mlx.cfm")
+    assert pkgutil.get_data("f5_tts_mlx", "tests/test_en_1_ref_short.wav")
     parameters = inspect.signature(f5.F5TTS.sample).parameters
     assert {"cond", "text", "duration", "steps", "speed", "cfg_strength"} <= set(
         parameters
@@ -86,7 +88,7 @@ def test_f5_generation_uses_safe_in_memory_default_and_speed(
     monkeypatch.setattr("soundfile.read", read)
 
     model = MagicMock()
-    model.sample.return_value = (np.ones((1, 480), dtype=np.float32), None)
+    model.sample.return_value = (np.ones(480, dtype=np.float32), None)
     engine = TTSEngine("lucasnewman/f5-tts-mlx")
     engine.model = model
 

--- a/tests/test_f5_tts_wiring.py
+++ b/tests/test_f5_tts_wiring.py
@@ -73,7 +73,7 @@ def test_f5_generation_uses_safe_in_memory_default_and_speed(
     monkeypatch.setattr("soundfile.read", read)
 
     model = MagicMock()
-    model.sample.return_value = (np.ones(480, dtype=np.float32), None)
+    model.sample.return_value = (np.ones((1, 480), dtype=np.float32), None)
     engine = TTSEngine("lucasnewman/f5-tts-mlx")
     engine.model = model
 

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -2623,6 +2623,11 @@ class AudioSpeechRequest(BaseModel):
     # rejected up front with the standard envelope rather than ballooning
     # the generation.
     instructions: str | None = Field(default=None, max_length=4096)
+    # Rapid-MLX extension for F5-TTS zero-shot cloning. Audio is base64
+    # rather than a server-local path so remote clients cannot make the
+    # service read arbitrary files. 14 MB base64 ~= 10 MB decoded audio.
+    ref_audio: str | None = Field(default=None, max_length=14_000_000)
+    ref_text: str | None = Field(default=None, max_length=4096)
 
     @model_validator(mode="before")
     @classmethod
@@ -2684,6 +2689,14 @@ class AudioSpeechRequest(BaseModel):
             # ``{"response_format": 123}`` would get.
             data["response_format"] = legacy
         return data
+
+    @model_validator(mode="after")
+    def _validate_f5_reference_pair(self):
+        if (self.ref_audio is None) != (self.ref_text is None):
+            raise ValueError("ref_audio and ref_text must be provided together")
+        if self.ref_text is not None and not self.ref_text.strip():
+            raise ValueError("ref_text must not be blank")
+        return self
 
     @field_validator("input")
     @classmethod

--- a/vllm_mlx/audio/aliases.json
+++ b/vllm_mlx/audio/aliases.json
@@ -104,6 +104,13 @@
     "default_voice": "Serena",
     "notes": "Alibaba Qwen3-TTS 1.7B CustomVoice (bf16). Multilingual predefined speakers (Chinese: Vivian, Serena, Uncle_Fu, Dylan, Eric; English: Ryan, Aiden; Japanese: Ono_Anna; Korean: Sohee) matched case-insensitively, with emotion/style control via the OpenAI `instructions` field. The CustomVoice variant is used (not 0.6B-Base, which is voice-cloning-only and needs a reference clip)."
   },
+  "f5-tts-zh": {
+    "type": "tts",
+    "hf_id": "lucasnewman/f5-tts-mlx",
+    "family": "f5",
+    "default_voice": "clone",
+    "notes": "F5-TTS (pure-MLX, no torch): EN+ZH multilingual, zero-shot voice CLONING via ref_audio (24kHz clip) + ref_text. Fills the Chinese expressive/cloneable gap (Qwen3-TTS is flat, Chatterbox English-only). With no ref it uses a packaged default voice; supply a Chinese ref for a natural Chinese narrator."
+  },
   "qwen3-tts-customvoice": {
     "type": "tts",
     "hf_id": "mlx-community/Qwen3-TTS-12Hz-1.7B-CustomVoice-bf16",

--- a/vllm_mlx/audio/tts.py
+++ b/vllm_mlx/audio/tts.py
@@ -255,12 +255,26 @@ class TTSEngine:
             return "cosyvoice"
         elif "qwen3-tts" in name_lower or "qwen3_tts" in name_lower:
             return "qwen3_tts"
+        elif "f5-tts" in name_lower or "f5_tts" in name_lower:
+            return "f5"
         else:
             return "kokoro"  # Default
 
     def load(self) -> None:
         """Load the TTS model."""
         if self._loaded:
+            return
+
+        # F5-TTS is a standalone pure-MLX package (not mlx_audio's load_model
+        # path): EN+ZH multilingual, zero-shot voice cloning, no torch. It fills
+        # the Chinese expressive/cloneable gap Qwen3-TTS (flat) and Chatterbox
+        # (English-only) leave open.
+        if self._model_family == "f5":
+            from f5_tts_mlx.cfm import F5TTS
+
+            self.model = F5TTS.from_pretrained(self.model_name)
+            self._loaded = True
+            logger.info(f"TTS model loaded (f5): {self.model_name}")
             return
 
         try:
@@ -284,6 +298,8 @@ class TTSEngine:
         speed: float = 1.0,
         lang_code: str = "a",
         instruct: str | None = None,
+        ref_audio: str | None = None,
+        ref_text: str | None = None,
     ) -> AudioOutput:
         """
         Generate speech from text.
@@ -301,12 +317,20 @@ class TTSEngine:
                 the emotional delivery of the predefined speaker. Other
                 families ignore it (they have no emotion-control surface),
                 so passing it is a no-op there rather than an error.
+            ref_audio: Optional path to a reference audio clip for zero-shot
+                voice cloning. Used by the F5-TTS ``f5`` family to clone the
+                clip's timbre; ignored by families without a cloning surface.
+            ref_text: Optional transcript of ``ref_audio`` (its exact spoken
+                text). Paired with ``ref_audio`` for F5-TTS cloning.
 
         Returns:
             AudioOutput with audio data and metadata
         """
         if not self._loaded:
             self.load()
+
+        if self._model_family == "f5":
+            return self._generate_f5(text, ref_audio, ref_text)
 
         try:
             import mlx.core as mx
@@ -360,6 +384,63 @@ class TTSEngine:
         except Exception as e:
             logger.error(f"TTS generation failed: {e}")
             raise
+
+    def _generate_f5(
+        self, text: str, ref_audio: str | None, ref_text: str | None
+    ) -> AudioOutput:
+        """F5-TTS inference (pure MLX). Clones the reference clip's timbre and
+        speaks ``text`` in it; with no ``ref_audio`` it uses the packaged default
+        reference. Mirrors ``f5_tts_mlx.generate.generate`` but reuses the
+        already-loaded model (no per-call reload)."""
+        import pkgutil
+
+        import mlx.core as mx
+        import soundfile as sf
+        from f5_tts_mlx.generate import (
+            FRAMES_PER_SEC,
+            SAMPLE_RATE,
+            TARGET_RMS,
+            convert_char_to_pinyin,
+            estimated_duration,
+        )
+
+        if ref_audio:
+            aud, sr = sf.read(ref_audio)
+            if sr != SAMPLE_RATE:
+                raise ValueError(
+                    f"F5 ref_audio must be {SAMPLE_RATE} Hz (got {sr}); resample it."
+                )
+            rtext = ref_text or ""
+        else:
+            # packaged short reference (its timbre; content comes from `text`)
+            data = pkgutil.get_data("f5_tts_mlx", "tests/test_en_1_ref_short.wav")
+            tmp = "/tmp/f5_default_ref.wav"
+            with open(tmp, "wb") as f:
+                f.write(data)  # type: ignore[arg-type]
+            aud, _sr = sf.read(tmp)
+            rtext = "Some call me nature, others call me mother nature."
+
+        aud = mx.array(aud)
+        rms = mx.sqrt(mx.mean(mx.square(aud)))
+        if rms < TARGET_RMS:
+            aud = aud * TARGET_RMS / rms
+        # explicit duration estimate — F5's auto heuristic can collapse to ~0s
+        dur = int(estimated_duration(aud, rtext, text, 1.0) * FRAMES_PER_SEC)
+        ptext = convert_char_to_pinyin([rtext + " " + text])
+        wave, _ = self.model.sample(
+            mx.expand_dims(aud, axis=0),
+            text=ptext,
+            duration=dur,
+            steps=8,
+            cfg_strength=2.0,
+            sway_sampling_coef=-1.0,
+        )
+        wave = wave[aud.shape[0] :]  # trim the reference prefix
+        mx.eval(wave)
+        out = np.array(wave, dtype=np.float32)
+        return AudioOutput(
+            audio=out, sample_rate=SAMPLE_RATE, duration=len(out) / SAMPLE_RATE
+        )
 
     def stream_generate(
         self,

--- a/vllm_mlx/audio/tts.py
+++ b/vllm_mlx/audio/tts.py
@@ -449,7 +449,7 @@ class TTSEngine:
             cfg_strength=2.0,
             sway_sampling_coef=-1.0,
         )
-        wave = wave[aud.shape[0] :]  # trim the reference prefix
+        wave = wave[0, aud.shape[0] :]  # select batch 0, trim reference prefix
         mx.eval(wave)
         out = np.array(wave, dtype=np.float32)
         return AudioOutput(

--- a/vllm_mlx/audio/tts.py
+++ b/vllm_mlx/audio/tts.py
@@ -450,6 +450,9 @@ class TTSEngine:
         # explicit duration estimate — F5's auto heuristic can collapse to ~0s
         dur = int(estimated_duration(aud, rtext, text, speed) * FRAMES_PER_SEC)
         ptext = convert_char_to_pinyin([rtext + " " + text])
+        # F5TTS.from_pretrained injects Vocos.decode as ``_vocoder``.
+        # sample() therefore returns the decoded 1-D waveform (Vocos'
+        # ISTFTHead squeezes the single batch axis), not mel frames.
         wave, _ = self.model.sample(
             mx.expand_dims(aud, axis=0),
             text=ptext,
@@ -459,7 +462,11 @@ class TTSEngine:
             cfg_strength=2.0,
             sway_sampling_coef=-1.0,
         )
-        wave = wave[0, aud.shape[0] :]  # select batch 0, trim reference prefix
+        if wave.ndim != 1:
+            raise RuntimeError(
+                f"F5-TTS returned an unexpected waveform shape: {wave.shape}"
+            )
+        wave = wave[aud.shape[0] :]  # trim the decoded reference prefix
         mx.eval(wave)
         out = np.array(wave, dtype=np.float32)
         return AudioOutput(

--- a/vllm_mlx/audio/tts.py
+++ b/vllm_mlx/audio/tts.py
@@ -411,24 +411,34 @@ class TTSEngine:
             estimated_duration,
         )
 
+        def read_reference(source):
+            info = sf.info(source)
+            if info.samplerate != SAMPLE_RATE:
+                raise ValueError(
+                    f"F5 ref_audio must be {SAMPLE_RATE} Hz "
+                    f"(got {info.samplerate}); resample it."
+                )
+            if info.channels != 1:
+                raise ValueError("F5 ref_audio must be mono.")
+            if info.frames <= 0 or info.frames > SAMPLE_RATE * 30:
+                raise ValueError("F5 ref_audio must be between 0 and 30 seconds.")
+            if hasattr(source, "seek"):
+                source.seek(0)
+            audio, _ = sf.read(source)
+            return audio
+
         if ref_audio is not None:
             assert ref_text is not None  # paired-input validation above
-            aud, sr = sf.read(ref_audio)
-            if sr != SAMPLE_RATE:
-                raise ValueError(
-                    f"F5 ref_audio must be {SAMPLE_RATE} Hz (got {sr}); resample it."
-                )
+            aud = read_reference(ref_audio)
             rtext = ref_text
         else:
             # packaged short reference (its timbre; content comes from `text`)
             data = pkgutil.get_data("f5_tts_mlx", "tests/test_en_1_ref_short.wav")
             if data is None:
                 raise RuntimeError("F5-TTS packaged reference audio is missing.")
-            aud, _sr = sf.read(io.BytesIO(data))
+            aud = read_reference(io.BytesIO(data))
             rtext = "Some call me nature, others call me mother nature."
 
-        if aud.ndim != 1:
-            raise ValueError("F5 ref_audio must be mono.")
         aud = mx.array(aud)
         rms = mx.sqrt(mx.mean(mx.square(aud)))
         mx.eval(rms)

--- a/vllm_mlx/audio/tts.py
+++ b/vllm_mlx/audio/tts.py
@@ -330,7 +330,7 @@ class TTSEngine:
             self.load()
 
         if self._model_family == "f5":
-            return self._generate_f5(text, ref_audio, ref_text)
+            return self._generate_f5(text, ref_audio, ref_text, speed)
 
         try:
             import mlx.core as mx
@@ -386,12 +386,19 @@ class TTSEngine:
             raise
 
     def _generate_f5(
-        self, text: str, ref_audio: str | None, ref_text: str | None
+        self,
+        text: str,
+        ref_audio: str | None,
+        ref_text: str | None,
+        speed: float,
     ) -> AudioOutput:
         """F5-TTS inference (pure MLX). Clones the reference clip's timbre and
         speaks ``text`` in it; with no ``ref_audio`` it uses the packaged default
         reference. Mirrors ``f5_tts_mlx.generate.generate`` but reuses the
         already-loaded model (no per-call reload)."""
+        if (ref_audio is None) != (ref_text is None):
+            raise ValueError("F5 voice cloning requires both ref_audio and ref_text.")
+
         import pkgutil
 
         import mlx.core as mx
@@ -404,34 +411,41 @@ class TTSEngine:
             estimated_duration,
         )
 
-        if ref_audio:
+        if ref_audio is not None:
+            assert ref_text is not None  # paired-input validation above
             aud, sr = sf.read(ref_audio)
             if sr != SAMPLE_RATE:
                 raise ValueError(
                     f"F5 ref_audio must be {SAMPLE_RATE} Hz (got {sr}); resample it."
                 )
-            rtext = ref_text or ""
+            rtext = ref_text
         else:
             # packaged short reference (its timbre; content comes from `text`)
             data = pkgutil.get_data("f5_tts_mlx", "tests/test_en_1_ref_short.wav")
-            tmp = "/tmp/f5_default_ref.wav"
-            with open(tmp, "wb") as f:
-                f.write(data)  # type: ignore[arg-type]
-            aud, _sr = sf.read(tmp)
+            if data is None:
+                raise RuntimeError("F5-TTS packaged reference audio is missing.")
+            aud, _sr = sf.read(io.BytesIO(data))
             rtext = "Some call me nature, others call me mother nature."
 
+        if aud.ndim != 1:
+            raise ValueError("F5 ref_audio must be mono.")
         aud = mx.array(aud)
         rms = mx.sqrt(mx.mean(mx.square(aud)))
-        if rms < TARGET_RMS:
+        mx.eval(rms)
+        rms_value = float(rms)
+        if not np.isfinite(rms_value) or rms_value <= 0:
+            raise ValueError("F5 ref_audio must contain finite, non-silent audio.")
+        if rms_value < TARGET_RMS:
             aud = aud * TARGET_RMS / rms
         # explicit duration estimate — F5's auto heuristic can collapse to ~0s
-        dur = int(estimated_duration(aud, rtext, text, 1.0) * FRAMES_PER_SEC)
+        dur = int(estimated_duration(aud, rtext, text, speed) * FRAMES_PER_SEC)
         ptext = convert_char_to_pinyin([rtext + " " + text])
         wave, _ = self.model.sample(
             mx.expand_dims(aud, axis=0),
             text=ptext,
             duration=dur,
             steps=8,
+            speed=speed,
             cfg_strength=2.0,
             sway_sampling_coef=-1.0,
         )

--- a/vllm_mlx/model_sizes.json
+++ b/vllm_mlx/model_sizes.json
@@ -15,6 +15,7 @@
     "lmstudio-community/gemma-3n-E4B-it-MLX-4bit": 5858839889,
     "lmstudio-community/gpt-oss-20b-MLX-8bit": 22256510809,
     "lmstudio-community/gpt-oss-safeguard-20b-MLX-MXFP4": 11150438234,
+    "lucasnewman/f5-tts-mlx": 4043696283,
     "mlx-community/DeepSeek-Coder-V2-Lite-Instruct-4bit-mlx": 8844791792,
     "mlx-community/DeepSeek-R1-0528-Qwen3-8B-4bit": 4619332904,
     "mlx-community/DeepSeek-R1-Distill-Qwen-32B-4bit": 18443052369,

--- a/vllm_mlx/routes/audio.py
+++ b/vllm_mlx/routes/audio.py
@@ -1472,6 +1472,12 @@ def _allowed_voices_for(model_name: str) -> list[str]:
         # registry ``default_voice`` (``Serena``) is a member of this
         # list so the cold-start / voice-omitted path validates.
         return list(QWEN3_TTS_VOICES)
+    if "f5-tts" in name_lower or "f5_tts" in name_lower:
+        # F5 conditions on a reference waveform rather than a named
+        # safetensors voice. ``clone`` is the registry's UI/API sentinel;
+        # when no custom reference is supplied the engine uses its packaged
+        # reference voice.
+        return ["clone"]
     if "vibevoice" in name_lower:
         # Cold-start fallback for VibeVoice — the canonical English
         # default is ``en-Grace_woman`` (per the upstream repo's

--- a/vllm_mlx/routes/audio.py
+++ b/vllm_mlx/routes/audio.py
@@ -1591,6 +1591,20 @@ async def create_speech(request: AudioSpeechRequest = Body(...)):
         # the future land in :data:`TTS_MODEL_ALIASES` once, not in the
         # handler body.
         model_name = _resolve_tts_model(model)
+        if ref_audio is not None and not (
+            "f5-tts" in model_name.lower() or "f5_tts" in model_name.lower()
+        ):
+            raise HTTPException(
+                status_code=400,
+                detail={
+                    "error": {
+                        "message": "ref_audio/ref_text voice cloning requires F5-TTS.",
+                        "type": "invalid_request_error",
+                        "code": "unsupported_voice_cloning",
+                        "param": "model",
+                    }
+                },
+            )
 
         # Qwen3-TTS ships two shapes: CustomVoice (predefined speakers,
         # reference-free — what we alias and support) and Base (voice-

--- a/vllm_mlx/routes/audio.py
+++ b/vllm_mlx/routes/audio.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 """Audio endpoints (STT/TTS)."""
 
+import base64
+import binascii
 import logging
 import os
 import re
@@ -1330,6 +1332,29 @@ _TTS_CONTENT_TYPES: dict[str, str] = {
     "pcm": "audio/pcm",
 }
 
+_MAX_TTS_REF_AUDIO_BYTES = 10 * 1024 * 1024
+
+
+def _decode_tts_ref_audio(value: str) -> bytes:
+    """Decode a base64 F5 reference clip with a bounded payload size."""
+    encoded = value
+    if value.startswith("data:"):
+        try:
+            header, encoded = value.split(",", 1)
+        except ValueError as exc:
+            raise ValueError("ref_audio data URL is malformed") from exc
+        if ";base64" not in header:
+            raise ValueError("ref_audio data URL must use base64 encoding")
+    try:
+        decoded = base64.b64decode(encoded, validate=True)
+    except (binascii.Error, ValueError) as exc:
+        raise ValueError("ref_audio must be valid base64-encoded audio") from exc
+    if not decoded:
+        raise ValueError("ref_audio must not be empty")
+    if len(decoded) > _MAX_TTS_REF_AUDIO_BYTES:
+        raise ValueError("ref_audio exceeds the 10 MB decoded size limit")
+    return decoded
+
 
 def _resolve_tts_model(model: str | None) -> str:
     """Map a TTS request-time alias to its HF repo id.
@@ -1554,6 +1579,8 @@ async def create_speech(request: AudioSpeechRequest = Body(...)):
     speed = request.speed
     response_format = request.response_format
     instructions = request.instructions
+    ref_audio = request.ref_audio
+    ref_text = request.ref_text
 
     try:
         from ..audio.tts import TTSEngine, UnsupportedAudioFormatError
@@ -1688,7 +1715,31 @@ async def create_speech(request: AudioSpeechRequest = Body(...)):
         gen_kwargs = {"voice": voice, "speed": speed}
         if instructions:
             gen_kwargs["instruct"] = instructions
-        audio = _tts_engine.generate(input_text, **gen_kwargs)
+        if ref_audio is not None:
+            try:
+                ref_bytes = _decode_tts_ref_audio(ref_audio)
+            except ValueError as exc:
+                raise HTTPException(
+                    status_code=400,
+                    detail={
+                        "error": {
+                            "message": str(exc),
+                            "type": "invalid_request_error",
+                            "code": "invalid_ref_audio",
+                            "param": "ref_audio",
+                        }
+                    },
+                ) from exc
+            from .._tempfile_safe import managed_tempfile_path
+
+            with managed_tempfile_path(prefix="f5-ref-", suffix=".wav") as ref_path:
+                with open(ref_path, "wb") as ref_file:
+                    ref_file.write(ref_bytes)
+                gen_kwargs["ref_audio"] = ref_path.path
+                gen_kwargs["ref_text"] = ref_text
+                audio = _tts_engine.generate(input_text, **gen_kwargs)
+        else:
+            audio = _tts_engine.generate(input_text, **gen_kwargs)
         try:
             audio_bytes = _tts_engine.to_bytes(audio, format=response_format)
         except UnsupportedAudioFormatError as e:


### PR DESCRIPTION
## Why
Chinese expressive TTS with zero-shot voice cloning was a gap in the audio lane. The existing families don't fill it: Qwen3-TTS is clear but flat (limited expressive prosody), and Chatterbox is English-only. F5-TTS closes that gap — EN+ZH multilingual with natural, expressive delivery and zero-shot cloning from a short reference clip.

## What
- New `f5` TTS family in `vllm_mlx/audio/tts.py`:
  - `_detect_family`: `f5-tts`/`f5_tts` -> `"f5"`.
  - `load()`: loads via `f5_tts_mlx.cfm.F5TTS.from_pretrained(...)` (bypasses mlx_audio's `load_model` — F5 is a standalone package).
  - `generate()`: early dispatch to `_generate_f5` for the `f5` family; adds optional `ref_audio`/`ref_text` params to the public `generate()` signature so cloning inputs can reach the family (defaults `None`; ignored by families without a cloning surface).
  - `_generate_f5(text, ref_audio, ref_text)`: pure-MLX inference mirroring `f5_tts_mlx.generate` (ref RMS normalization, explicit duration estimate, char->pinyin, `model.sample(...)`, reference-prefix trim). With `ref_audio`+`ref_text` it clones that voice; with no ref it uses the packaged default voice.
- New alias `f5-tts-zh` in `vllm_mlx/audio/aliases.json` (hf_id `lucasnewman/f5-tts-mlx`, family `f5`).
- `[audio]` optional-dependency extra in `pyproject.toml` gains `f5-tts-mlx>=0.2.6`. This is **pure-MLX — NO torch**; its transitive deps are `vocos-mlx` / `jieba` / `pypinyin` / `einx`.
- `vllm_mlx/model_sizes.json`: one-line manifest entry for `lucasnewman/f5-tts-mlx` (3.77 GiB). Required by the repo's `test_every_audio_alias_has_a_manifest_entry` coverage test so `rapid-mlx models`/`info` can render the download size offline.

## Tests
- `ruff check vllm_mlx/audio/` and `ruff format --check vllm_mlx/audio/`: clean.
- `pytest tests/ -k "audio or alias or tts" --ignore=tests/integrations`: 3356 passed, 13 skipped, incl. the audio-alias manifest coverage test.
- Pre-existing/unrelated failures observed and NOT touched: `tests/test_no_mllm_flag.py` alias-routing tests are network-flaky (they download the `bonsai-27b-2bit` fixture from HuggingFace and pass in isolation / when cached); `tests/integrations/*` collection errors from missing optional SDKs (anthropic / pydantic_ai / smolagents). Neither relates to F5.

## Notes
- This capability was originally loose-committed on a local content-farm fork; it's being marched to `main` as one clean, reviewable PR — the first of several audio-lane capabilities landing one PR at a time.
- No version bump.
- The 4th file (`model_sizes.json`, +1 line) is the manifest entry the original loose commit had missed; it's necessary and solely for the new alias.

AI-assistance disclosure: prepared with the help of Claude Code (Anthropic).
