### PR TITLE
feat(video): add MLX-native LTX-2.3 generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ curl http://localhost:8000/v1/videos \
   -F seconds=4 \
   -F size=768x512
 
+# Poll until GET /v1/videos/VIDEO_ID reports "status": "completed", then:
 curl http://localhost:8000/v1/videos/VIDEO_ID/content -o output.mp4
 ```
 

--- a/README.md
+++ b/README.md
@@ -96,9 +96,40 @@ rapid-mlx launch claude-code
 
 With a server running (step 3), this patches Claude Code's local config (`~/.config/claude/settings.json`) to route at `http://localhost:8000` — no manual env vars, no editing JSON by hand. You get a fully local Claude Code: `$0` per token, nothing leaves your Mac. Swap in `cursor`, `cline`, or `continue-dev` for the other IDE clients, or run `rapid-mlx launch list` to see what's detected on this machine.
 
-> **Vision / audio / diffusion models?** Base install is text-only (~460 MB). Vision, audio, embeddings, and DFlash speculative decoding ship as opt-in extras. → [Optional extras](https://rapidmlx.com/docs/extras.html)
+> **Vision / audio / video / diffusion models?** Base install is text-only (~460 MB). Vision, audio, LTX-2.3 video generation, embeddings, and DFlash speculative decoding ship as opt-in extras. → [Optional extras](https://rapidmlx.com/docs/extras.html)
 
 > **Not into the terminal?** [**Rapid-MLX Desktop**](https://rapidmlx.com/desktop) bundles the same engine inside a one-click Mac app.
+
+---
+
+## LTX-2.3 video generation
+
+Run text-to-video or image-to-video locally with synchronized audio through
+the OpenAI-compatible Videos API. The default MLX Q4 checkpoint is a 22.8 GB
+download and needs at least 24 GB unified memory; 32 GB or more is recommended.
+`ffmpeg` is required for the final MP4 mux.
+
+```bash
+pip install 'rapid-mlx[video]'
+brew install ffmpeg
+rapid-mlx serve ltx-2.3-mlx-q4
+```
+
+Create and download a four-second video:
+
+```bash
+curl http://localhost:8000/v1/videos \
+  -F model=ltx-2.3-mlx-q4 \
+  -F 'prompt=A fox running through fresh snow, cinematic tracking shot' \
+  -F seconds=4 \
+  -F size=768x512
+
+curl http://localhost:8000/v1/videos/VIDEO_ID/content -o output.mp4
+```
+
+The create call returns a job immediately. Poll `GET /v1/videos/VIDEO_ID`
+until `status` is `completed`. Add `-F input_reference=@start.png` for
+image-to-video.
 
 ---
 
@@ -107,7 +138,7 @@ With a server running (step 3), this patches Claude Code's local config (`~/.con
 | | |
 |---|---|
 | **Apple-Silicon-native** | Pure MLX kernels — no llama.cpp fallback, no Metal shim. Continuous batching, prompt cache (radix + DeltaNet RNN snapshots), and a quantized live KV cache (int4/int8 on the continuous-batching cache + TurboQuant K8V4 codec) run at native MLX bandwidth on M1 → M4. |
-| **Drop-in OpenAI / Anthropic API** | `/v1/chat/completions`, `/v1/responses` (Codex CLI), `/v1/messages` (Anthropic SDK / Claude Code), `/v1/embeddings`, `/v1/audio/*` — same wire as ChatGPT / Claude, no client adapter. |
+| **Drop-in OpenAI / Anthropic API** | `/v1/chat/completions`, `/v1/responses` (Codex CLI), `/v1/messages` (Anthropic SDK / Claude Code), `/v1/embeddings`, `/v1/audio/*`, `/v1/videos` — same wire as ChatGPT / Claude, no client adapter. |
 | **First-class ecosystem coverage** | 11 agent CLIs and 3 Python frameworks are wire-verified against real weights every release (4 are Tier-1, re-verified on current binaries) — Codex CLI, Claude Code, OpenCode, Qwen Code, OpenHands, Hermes Agent, Aider, Kilo Code, GitHub Copilot, Factory Droid, Moonshot Kimi Code + LangChain, PydanticAI, smolagents. |
 
 → [Full feature breakdown](https://rapidmlx.com/docs/index.html)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -380,6 +380,11 @@ audio = [
     # Additional multilingual dependencies
     "cn2an>=0.5.0",          # Chinese number conversion
 ]
+video = [
+    # MLX-native LTX-2.3 T2V/I2V with synchronized audio. 0.1.36 is the
+    # first verified release with the split-format LTX-2.3 VAE fixes.
+    "mlx-video-with-audio==0.1.36; platform_system == 'Darwin'",
+]
 
 [project.urls]
 Homepage = "https://github.com/raullenchai/Rapid-MLX"

--- a/tests/test_ltx23_video.py
+++ b/tests/test_ltx23_video.py
@@ -204,7 +204,7 @@ async def test_cancelled_job_reaches_terminal_state_and_cleans_files(
         input_reference=None,
     )
     assert await asyncio.to_thread(started.wait, 2)
-    task = next(task for task in video._tasks if not task.done())
+    task = video._tasks[created["id"]]
     task.cancel()
     release.set()
     with pytest.raises(asyncio.CancelledError):
@@ -213,5 +213,39 @@ async def test_cancelled_job_reaches_terminal_state_and_cleans_files(
     current = await video.retrieve_video(created["id"])
     assert current["status"] == "failed"
     assert current["error"]["code"] == "video_generation_cancelled"
+    assert not (video._jobs_root / created["id"]).exists()
+    await video.delete_video(created["id"])
+
+
+@pytest.mark.asyncio
+async def test_failed_generation_removes_partial_artifacts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FailingEngine:
+        model_name = "notapalindrome/ltx23-mlx-av-q4"
+
+        def generate(self, *, output_path: Path, **kwargs) -> None:
+            output_path.write_bytes(b"partial")
+            raise RuntimeError("private /tmp/detail")
+
+    monkeypatch.setattr(video, "_video_engine", lambda: FailingEngine())
+    created = await video.create_video(
+        prompt="fail",
+        model="ltx-2.3-mlx-q4",
+        seconds="1",
+        size="512x512",
+        seed=4,
+        input_reference=None,
+    )
+    for _ in range(200):
+        current = await video.retrieve_video(created["id"])
+        if current["status"] == "failed":
+            break
+        await asyncio.sleep(0.01)
+
+    assert current["status"] == "failed"
+    assert current["error"]["message"] == (
+        "Video generation failed; check the server logs for details."
+    )
     assert not (video._jobs_root / created["id"]).exists()
     await video.delete_video(created["id"])

--- a/tests/test_ltx23_video.py
+++ b/tests/test_ltx23_video.py
@@ -54,6 +54,139 @@ def test_video_runtime_preflight_fails_before_download(
     assert "brew install ffmpeg" in error
 
 
+@pytest.mark.asyncio
+async def test_video_multipart_gate_authenticates_before_reading_body() -> None:
+    from vllm_mlx.config import get_config
+
+    cfg = get_config()
+    saved_key = cfg.api_key
+    cfg.api_key = "secret"
+    receive_calls = 0
+    sent = []
+
+    async def downstream(scope, receive, send) -> None:
+        raise AssertionError("unauthenticated request reached FastAPI")
+
+    async def receive():
+        nonlocal receive_calls
+        receive_calls += 1
+        return {"type": "http.request", "body": b"x", "more_body": False}
+
+    async def send(message) -> None:
+        sent.append(message)
+
+    try:
+        middleware = video.VideoBodyLimitMiddleware(downstream)
+        await middleware(
+            {
+                "type": "http",
+                "method": "POST",
+                "path": "/v1/videos",
+                "headers": [],
+            },
+            receive,
+            send,
+        )
+    finally:
+        cfg.api_key = saved_key
+
+    assert receive_calls == 0
+    assert sent[0]["status"] == 401
+
+
+@pytest.mark.asyncio
+async def test_video_multipart_gate_rejects_content_length_before_read() -> None:
+    from vllm_mlx.config import get_config
+
+    cfg = get_config()
+    saved_key = cfg.api_key
+    cfg.api_key = None
+    receive_calls = 0
+    sent = []
+
+    async def downstream(scope, receive, send) -> None:
+        raise AssertionError("oversized request reached FastAPI")
+
+    async def receive():
+        nonlocal receive_calls
+        receive_calls += 1
+        return {"type": "http.request", "body": b"x", "more_body": False}
+
+    async def send(message) -> None:
+        sent.append(message)
+
+    try:
+        middleware = video.VideoBodyLimitMiddleware(downstream)
+        await middleware(
+            {
+                "type": "http",
+                "method": "POST",
+                "path": "/v1/videos",
+                "headers": [
+                    (
+                        b"content-length",
+                        str(video._VIDEO_REQUEST_BYTES + 1).encode(),
+                    )
+                ],
+            },
+            receive,
+            send,
+        )
+    finally:
+        cfg.api_key = saved_key
+
+    assert receive_calls == 0
+    assert sent[0]["status"] == 413
+
+
+@pytest.mark.asyncio
+async def test_video_multipart_gate_caps_chunked_body(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from vllm_mlx.config import get_config
+
+    cfg = get_config()
+    saved_key = cfg.api_key
+    cfg.api_key = None
+    monkeypatch.setattr(video, "_VIDEO_REQUEST_BYTES", 4)
+    chunks = iter(
+        [
+            {"type": "http.request", "body": b"abc", "more_body": True},
+            {"type": "http.request", "body": b"def", "more_body": False},
+        ]
+    )
+    sent = []
+
+    async def downstream(scope, receive, send) -> None:
+        while True:
+            message = await receive()
+            if not message.get("more_body", False):
+                return
+
+    async def receive():
+        return next(chunks)
+
+    async def send(message) -> None:
+        sent.append(message)
+
+    try:
+        middleware = video.VideoBodyLimitMiddleware(downstream)
+        await middleware(
+            {
+                "type": "http",
+                "method": "POST",
+                "path": "/v1/videos",
+                "headers": [],
+            },
+            receive,
+            send,
+        )
+    finally:
+        cfg.api_key = saved_key
+
+    assert sent[0]["status"] == 413
+
+
 def test_serve_dispatches_video_preflight(monkeypatch: pytest.MonkeyPatch) -> None:
     from vllm_mlx import cli
     from vllm_mlx.runtime import video_lane
@@ -117,6 +250,12 @@ def test_video_engine_calls_mlx_native_pipeline(
     assert captured["model_repo"] == "notapalindrome/ltx23-mlx-av-q4"
     assert captured["num_frames"] == 97
     assert captured["image"] == str(reference)
+
+
+def test_video_engines_share_process_generation_lock() -> None:
+    first = VideoEngine("one/model")
+    second = VideoEngine("two/model")
+    assert first._generation_lock is second._generation_lock
 
 
 def test_video_crop_timeout_is_actionable(

--- a/tests/test_ltx23_video.py
+++ b/tests/test_ltx23_video.py
@@ -1,0 +1,96 @@
+"""LTX-2.3 MLX-native lane and OpenAI video API contract tests."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+from vllm_mlx.model_aliases import resolve_profile
+from vllm_mlx.routes import video
+from vllm_mlx.runtime.video_lane import VideoEngine
+
+
+def test_ltx23_alias_routes_to_video_lane() -> None:
+    profile = resolve_profile("ltx-2.3-mlx-q4")
+    assert profile is not None
+    assert profile.hf_path == "notapalindrome/ltx23-mlx-av-q4"
+    assert profile.modality == "video-gen"
+    assert profile.min_memory_gb == 24
+    assert profile.supports_spec_decode is False
+
+
+def test_video_engine_calls_mlx_native_pipeline(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    captured = {}
+    fake = ModuleType("mlx_video")
+
+    def generate_video_with_audio(**kwargs) -> None:
+        captured.update(kwargs)
+        Path(kwargs["output_path"]).write_bytes(b"mp4")
+
+    fake.generate_video_with_audio = generate_video_with_audio
+    monkeypatch.setitem(sys.modules, "mlx_video", fake)
+    monkeypatch.setattr("shutil.which", lambda _: "/opt/homebrew/bin/ffmpeg")
+
+    output = tmp_path / "result.mp4"
+    engine = VideoEngine("notapalindrome/ltx23-mlx-av-q4")
+    engine.generate(
+        prompt="A fox runs through snow",
+        output_path=output,
+        width=768,
+        height=512,
+        num_frames=97,
+        fps=24,
+        seed=7,
+        image=None,
+    )
+
+    assert output.read_bytes() == b"mp4"
+    assert captured["model_repo"] == "notapalindrome/ltx23-mlx-av-q4"
+    assert captured["num_frames"] == 97
+    assert captured["image"] is None
+
+
+def test_video_parameter_validation() -> None:
+    assert video._parse_size("768x512") == (768, 512)
+    assert video._frame_count(4) == 97
+    with pytest.raises(Exception, match="divisible by 64"):
+        video._parse_size("700x512")
+
+
+@pytest.mark.asyncio
+async def test_video_job_lifecycle(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FakeEngine:
+        model_name = "notapalindrome/ltx23-mlx-av-q4"
+
+        def generate(self, *, output_path: Path, **kwargs) -> None:
+            output_path.write_bytes(b"generated-mp4")
+
+    monkeypatch.setattr(video, "_video_engine", lambda: FakeEngine())
+    created = await video.create_video(
+        prompt="Ocean waves at sunset",
+        model="ltx-2.3-mlx-q4",
+        seconds="2",
+        size="768x512",
+        seed=42,
+        input_reference=None,
+    )
+    video_id = created["id"]
+    for _ in range(100):
+        current = await video.retrieve_video(video_id)
+        if current["status"] != "queued":
+            if current["status"] == "completed":
+                break
+        await asyncio.sleep(0.01)
+
+    assert current["status"] == "completed"
+    assert current["progress"] == 100
+    response = await video.retrieve_video_content(video_id)
+    assert Path(response.path).read_bytes() == b"generated-mp4"
+    deleted = await video.delete_video(video_id)
+    assert deleted["deleted"] is True

--- a/tests/test_ltx23_video.py
+++ b/tests/test_ltx23_video.py
@@ -6,7 +6,7 @@ import asyncio
 import sys
 import threading
 from pathlib import Path
-from types import ModuleType
+from types import ModuleType, SimpleNamespace
 
 import pytest
 from fastapi import HTTPException
@@ -14,7 +14,7 @@ from PIL import Image
 
 from vllm_mlx.model_aliases import resolve_profile
 from vllm_mlx.routes import video
-from vllm_mlx.runtime.video_lane import VideoEngine
+from vllm_mlx.runtime.video_lane import VideoEngine, require_video_runtime_or_exit
 
 
 def test_ltx23_alias_routes_to_video_lane() -> None:
@@ -24,6 +24,45 @@ def test_ltx23_alias_routes_to_video_lane() -> None:
     assert profile.modality == "video-gen"
     assert profile.min_memory_gb == 24
     assert profile.supports_spec_decode is False
+
+
+def test_ltx23_model_discovery_is_video_shaped() -> None:
+    from vllm_mlx.routes.models import _build_model_info
+
+    info = _build_model_info("ltx-2.3-mlx-q4")
+    assert info.modality == "video-gen"
+    assert info.capabilities == ["video.generation"]
+
+
+def test_video_runtime_preflight_fails_before_download(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr("importlib.util.find_spec", lambda _: None)
+    monkeypatch.setattr("shutil.which", lambda _: None)
+
+    with pytest.raises(SystemExit) as exc:
+        require_video_runtime_or_exit()
+
+    assert exc.value.code == 2
+    error = capsys.readouterr().err
+    assert "rapid-mlx[video]" in error
+    assert "brew install ffmpeg" in error
+
+
+def test_serve_dispatches_video_preflight(monkeypatch: pytest.MonkeyPatch) -> None:
+    from vllm_mlx import cli
+    from vllm_mlx.runtime import video_lane
+
+    class PreflightReachedError(RuntimeError):
+        pass
+
+    def stop_at_preflight() -> None:
+        raise PreflightReachedError
+
+    monkeypatch.setattr(video_lane, "require_video_runtime_or_exit", stop_at_preflight)
+    args = SimpleNamespace(model="ltx-2.3-mlx-q4", max_tokens=None, watchdog_ppid=None)
+    with pytest.raises(PreflightReachedError):
+        cli.serve_command(args)
 
 
 def test_video_engine_calls_mlx_native_pipeline(

--- a/tests/test_ltx23_video.py
+++ b/tests/test_ltx23_video.py
@@ -83,6 +83,13 @@ def test_video_parameter_validation() -> None:
     assert exc.value.status_code == 400
 
 
+def test_generation_gate_is_owned_by_event_loop() -> None:
+    async def get_gate() -> asyncio.Lock:
+        return video._generation_gate_for_current_loop()
+
+    assert asyncio.run(get_gate()) is not asyncio.run(get_gate())
+
+
 @pytest.mark.asyncio
 async def test_video_rejects_unsafe_pixel_time_workload(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_ltx23_video.py
+++ b/tests/test_ltx23_video.py
@@ -81,6 +81,26 @@ def test_video_parameter_validation() -> None:
 
 
 @pytest.mark.asyncio
+async def test_video_rejects_unsafe_pixel_time_workload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeEngine:
+        model_name = "notapalindrome/ltx23-mlx-av-q4"
+
+    monkeypatch.setattr(video, "_video_engine", lambda: FakeEngine())
+    with pytest.raises(HTTPException, match="safe LTX-2.3 Q4 workload") as exc:
+        await video.create_video(
+            prompt="too large",
+            model="ltx-2.3-mlx-q4",
+            seconds="20",
+            size="1920x1920",
+            seed=1,
+            input_reference=None,
+        )
+    assert exc.value.status_code == 400
+
+
+@pytest.mark.asyncio
 async def test_failed_reference_upload_is_cleaned(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -193,6 +213,48 @@ async def test_video_jobs_stay_queued_until_worker_is_free(
     assert b"".join([chunk async for chunk in response.body_iterator]) == b"mp4"
     await video.delete_video(first["id"])
     await video.delete_video(second["id"])
+
+
+@pytest.mark.asyncio
+async def test_delete_cancels_a_queued_job(monkeypatch: pytest.MonkeyPatch) -> None:
+    started = threading.Event()
+    release = threading.Event()
+
+    class BlockingEngine:
+        model_name = "notapalindrome/ltx23-mlx-av-q4"
+
+        def generate(self, *, output_path: Path, **kwargs) -> None:
+            started.set()
+            assert release.wait(timeout=5)
+            output_path.write_bytes(b"mp4")
+
+    monkeypatch.setattr(video, "_video_engine", lambda: BlockingEngine())
+    first = await video.create_video(
+        prompt="first",
+        model="ltx-2.3-mlx-q4",
+        seconds="1",
+        size="512x512",
+        seed=1,
+        input_reference=None,
+    )
+    assert await asyncio.to_thread(started.wait, 2)
+    queued = await video.create_video(
+        prompt="queued",
+        model="ltx-2.3-mlx-q4",
+        seconds="1",
+        size="512x512",
+        seed=2,
+        input_reference=None,
+    )
+    assert (await video.retrieve_video(queued["id"]))["status"] == "queued"
+    deleted = await video.delete_video(queued["id"])
+    assert deleted["deleted"] is True
+    release.set()
+    for _ in range(200):
+        if (await video.retrieve_video(first["id"]))["status"] == "completed":
+            break
+        await asyncio.sleep(0.01)
+    await video.delete_video(first["id"])
 
 
 @pytest.mark.asyncio

--- a/tests/test_ltx23_video.py
+++ b/tests/test_ltx23_video.py
@@ -268,11 +268,14 @@ async def test_video_jobs_stay_queued_until_worker_is_free(
 async def test_delete_cancels_a_queued_job(monkeypatch: pytest.MonkeyPatch) -> None:
     started = threading.Event()
     release = threading.Event()
+    calls = 0
 
     class BlockingEngine:
         model_name = "notapalindrome/ltx23-mlx-av-q4"
 
         def generate(self, *, output_path: Path, **kwargs) -> None:
+            nonlocal calls
+            calls += 1
             started.set()
             assert release.wait(timeout=5)
             output_path.write_bytes(b"mp4")
@@ -303,6 +306,7 @@ async def test_delete_cancels_a_queued_job(monkeypatch: pytest.MonkeyPatch) -> N
         if (await video.retrieve_video(first["id"]))["status"] == "completed":
             break
         await asyncio.sleep(0.01)
+    assert calls == 1
     await video.delete_video(first["id"])
 
 
@@ -419,6 +423,7 @@ async def test_shutdown_is_bounded_and_stops_video_admission(
     await video.shutdown_video_jobs(timeout=0.02)
     assert loop.time() - began < 0.5
     assert video._jobs[created["id"]].generation_finished is False
+    assert video._jobs[created["id"]].error["code"] == "video_server_shutdown"
     with pytest.raises(HTTPException, match="shutting down") as exc:
         await video.create_video(
             prompt="too late",

--- a/tests/test_ltx23_video.py
+++ b/tests/test_ltx23_video.py
@@ -116,6 +116,8 @@ def test_video_engine_calls_mlx_native_pipeline(
 
 def test_video_parameter_validation() -> None:
     assert video._parse_size("768x512") == (768, 512)
+    assert video._parse_size("1280x720") == (1280, 720)
+    assert video._parse_size("720x1280") == (720, 1280)
     assert video._frame_count(4) == 97
     with pytest.raises(HTTPException, match="divisible by 64") as exc:
         video._parse_size("700x512")
@@ -147,6 +149,39 @@ async def test_video_rejects_unsafe_pixel_time_workload(
             input_reference=None,
         )
     assert exc.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_openai_720p_size_is_aligned_then_cropped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured = {}
+
+    class FakeEngine:
+        model_name = "notapalindrome/ltx23-mlx-av-q4"
+
+        def generate(self, *, output_path: Path, **kwargs) -> None:
+            captured.update(kwargs)
+            output_path.write_bytes(b"mp4")
+
+    monkeypatch.setattr(video, "_video_engine", lambda: FakeEngine())
+    created = await video.create_video(
+        prompt="landscape",
+        model="ltx-2.3-mlx-q4",
+        seconds="1",
+        size="1280x720",
+        seed=1,
+        input_reference=None,
+    )
+    for _ in range(200):
+        if (await video.retrieve_video(created["id"]))["status"] == "completed":
+            break
+        await asyncio.sleep(0.01)
+    assert captured["width"] == 1280
+    assert captured["height"] == 768
+    assert captured["output_width"] == 1280
+    assert captured["output_height"] == 720
+    await video.delete_video(created["id"])
 
 
 @pytest.mark.asyncio

--- a/tests/test_ltx23_video.py
+++ b/tests/test_ltx23_video.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import subprocess
 import sys
 import threading
 from pathlib import Path
@@ -14,7 +15,11 @@ from PIL import Image
 
 from vllm_mlx.model_aliases import resolve_profile
 from vllm_mlx.routes import video
-from vllm_mlx.runtime.video_lane import VideoEngine, require_video_runtime_or_exit
+from vllm_mlx.runtime.video_lane import (
+    VideoEngine,
+    VideoRuntimeError,
+    require_video_runtime_or_exit,
+)
 
 
 def test_ltx23_alias_routes_to_video_lane() -> None:
@@ -112,6 +117,38 @@ def test_video_engine_calls_mlx_native_pipeline(
     assert captured["model_repo"] == "notapalindrome/ltx23-mlx-av-q4"
     assert captured["num_frames"] == 97
     assert captured["image"] == str(reference)
+
+
+def test_video_crop_timeout_is_actionable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    fake = ModuleType("mlx_video")
+
+    def generate_video_with_audio(**kwargs) -> None:
+        Path(kwargs["output_path"]).write_bytes(b"mp4")
+
+    fake.generate_video_with_audio = generate_video_with_audio
+    monkeypatch.setitem(sys.modules, "mlx_video", fake)
+    monkeypatch.setattr("shutil.which", lambda _: "/opt/homebrew/bin/ffmpeg")
+
+    def timeout(*args, **kwargs):
+        raise subprocess.TimeoutExpired("ffmpeg", 120)
+
+    monkeypatch.setattr("subprocess.run", timeout)
+    engine = VideoEngine("notapalindrome/ltx23-mlx-av-q4")
+    with pytest.raises(VideoRuntimeError, match="could not crop"):
+        engine.generate(
+            prompt="portrait",
+            output_path=tmp_path / "result.mp4",
+            width=768,
+            height=1280,
+            num_frames=9,
+            fps=24,
+            seed=1,
+            image=None,
+            output_width=720,
+            output_height=1280,
+        )
 
 
 def test_video_parameter_validation() -> None:

--- a/tests/test_ltx23_video.py
+++ b/tests/test_ltx23_video.py
@@ -10,6 +10,7 @@ from types import ModuleType
 
 import pytest
 from fastapi import HTTPException
+from PIL import Image
 
 from vllm_mlx.model_aliases import resolve_profile
 from vllm_mlx.routes import video
@@ -54,6 +55,8 @@ def test_video_engine_calls_mlx_native_pipeline(
     monkeypatch.setattr("shutil.which", lambda _: "/opt/homebrew/bin/ffmpeg")
 
     output = tmp_path / "result.mp4"
+    reference = tmp_path / "reference.png"
+    Image.new("RGB", (64, 64), "blue").save(reference)
     engine = VideoEngine("notapalindrome/ltx23-mlx-av-q4")
     engine.generate(
         prompt="A fox runs through snow",
@@ -63,13 +66,13 @@ def test_video_engine_calls_mlx_native_pipeline(
         num_frames=97,
         fps=24,
         seed=7,
-        image=None,
+        image=reference,
     )
 
     assert output.read_bytes() == b"mp4"
     assert captured["model_repo"] == "notapalindrome/ltx23-mlx-av-q4"
     assert captured["num_frames"] == 97
-    assert captured["image"] is None
+    assert captured["image"] == str(reference)
 
 
 def test_video_parameter_validation() -> None:

--- a/tests/test_ltx23_video.py
+++ b/tests/test_ltx23_video.py
@@ -380,3 +380,54 @@ async def test_failed_generation_removes_partial_artifacts(
     )
     assert not (video._jobs_root / created["id"]).exists()
     await video.delete_video(created["id"])
+
+
+@pytest.mark.asyncio
+async def test_shutdown_is_bounded_and_stops_video_admission(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    started = threading.Event()
+    release = threading.Event()
+
+    class BlockingEngine:
+        model_name = "notapalindrome/ltx23-mlx-av-q4"
+
+        def generate(self, *, output_path: Path, **kwargs) -> None:
+            started.set()
+            assert release.wait(timeout=5)
+            output_path.write_bytes(b"late-output")
+
+    monkeypatch.setattr(video, "_video_engine", lambda: BlockingEngine())
+    video.start_video_jobs()
+    created = await video.create_video(
+        prompt="shutdown",
+        model="ltx-2.3-mlx-q4",
+        seconds="1",
+        size="512x512",
+        seed=5,
+        input_reference=None,
+    )
+    assert await asyncio.to_thread(started.wait, 2)
+
+    loop = asyncio.get_running_loop()
+    began = loop.time()
+    await video.shutdown_video_jobs(timeout=0.02)
+    assert loop.time() - began < 0.5
+    with pytest.raises(HTTPException, match="shutting down") as exc:
+        await video.create_video(
+            prompt="too late",
+            model="ltx-2.3-mlx-q4",
+            seconds="1",
+            size="512x512",
+            seed=6,
+            input_reference=None,
+        )
+    assert exc.value.status_code == 503
+
+    release.set()
+    for _ in range(200):
+        if not video._generation_threads:
+            break
+        await asyncio.sleep(0.01)
+    video.start_video_jobs()
+    await video.delete_video(created["id"])

--- a/tests/test_ltx23_video.py
+++ b/tests/test_ltx23_video.py
@@ -333,17 +333,22 @@ async def test_cancelled_job_reaches_terminal_state_and_cleans_files(
     assert await asyncio.to_thread(started.wait, 2)
     task = video._tasks[created["id"]]
     task.cancel()
-    release.set()
     with pytest.raises(asyncio.CancelledError):
         await task
 
     current = await video.retrieve_video(created["id"])
     assert current["status"] == "failed"
     assert current["error"]["code"] == "video_generation_cancelled"
+    assert video._jobs[created["id"]].generation_finished is False
+    release.set()
     for _ in range(200):
-        if not (video._jobs_root / created["id"]).exists():
+        if (
+            video._jobs[created["id"]].generation_finished
+            and not (video._jobs_root / created["id"]).exists()
+        ):
             break
         await asyncio.sleep(0.01)
+    assert video._jobs[created["id"]].generation_finished is True
     assert not (video._jobs_root / created["id"]).exists()
     await video.delete_video(created["id"])
 
@@ -413,6 +418,7 @@ async def test_shutdown_is_bounded_and_stops_video_admission(
     began = loop.time()
     await video.shutdown_video_jobs(timeout=0.02)
     assert loop.time() - began < 0.5
+    assert video._jobs[created["id"]].generation_finished is False
     with pytest.raises(HTTPException, match="shutting down") as exc:
         await video.create_video(
             prompt="too late",
@@ -426,8 +432,12 @@ async def test_shutdown_is_bounded_and_stops_video_admission(
 
     release.set()
     for _ in range(200):
-        if not video._generation_threads:
+        if (
+            not video._generation_threads
+            and video._jobs[created["id"]].generation_finished
+        ):
             break
         await asyncio.sleep(0.01)
+    assert video._jobs[created["id"]].generation_finished is True
     video.start_video_jobs()
     await video.delete_video(created["id"])

--- a/tests/test_ltx23_video.py
+++ b/tests/test_ltx23_video.py
@@ -165,10 +165,53 @@ async def test_video_jobs_stay_queued_until_worker_is_free(
     assert (await video.retrieve_video(first["id"]))["status"] == "in_progress"
     assert (await video.retrieve_video(second["id"]))["status"] == "queued"
     release.set()
+    second_status = None
     for _ in range(200):
-        if (await video.retrieve_video(second["id"]))["status"] == "completed":
+        second_status = (await video.retrieve_video(second["id"]))["status"]
+        if second_status == "completed":
             break
         await asyncio.sleep(0.01)
     assert calls == 2
+    assert second_status == "completed"
+    response = await video.retrieve_video_content(second["id"])
+    assert b"".join([chunk async for chunk in response.body_iterator]) == b"mp4"
     await video.delete_video(first["id"])
     await video.delete_video(second["id"])
+
+
+@pytest.mark.asyncio
+async def test_cancelled_job_reaches_terminal_state_and_cleans_files(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    started = threading.Event()
+    release = threading.Event()
+
+    class BlockingEngine:
+        model_name = "notapalindrome/ltx23-mlx-av-q4"
+
+        def generate(self, *, output_path: Path, **kwargs) -> None:
+            started.set()
+            assert release.wait(timeout=5)
+            output_path.write_bytes(b"late-output")
+
+    monkeypatch.setattr(video, "_video_engine", lambda: BlockingEngine())
+    created = await video.create_video(
+        prompt="cancel me",
+        model="ltx-2.3-mlx-q4",
+        seconds="1",
+        size="512x512",
+        seed=3,
+        input_reference=None,
+    )
+    assert await asyncio.to_thread(started.wait, 2)
+    task = next(task for task in video._tasks if not task.done())
+    task.cancel()
+    release.set()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    current = await video.retrieve_video(created["id"])
+    assert current["status"] == "failed"
+    assert current["error"]["code"] == "video_generation_cancelled"
+    assert not (video._jobs_root / created["id"]).exists()
+    await video.delete_video(created["id"])

--- a/tests/test_ltx23_video.py
+++ b/tests/test_ltx23_video.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from types import ModuleType
 
 import pytest
+from fastapi import HTTPException
 
 from vllm_mlx.model_aliases import resolve_profile
 from vllm_mlx.routes import video
@@ -30,9 +31,23 @@ def test_video_engine_calls_mlx_native_pipeline(
     captured = {}
     fake = ModuleType("mlx_video")
 
-    def generate_video_with_audio(**kwargs) -> None:
-        captured.update(kwargs)
-        Path(kwargs["output_path"]).write_bytes(b"mp4")
+    def generate_video_with_audio(
+        *,
+        model_repo,
+        text_encoder_repo,
+        prompt,
+        height,
+        width,
+        num_frames,
+        seed,
+        fps,
+        output_path,
+        image,
+        verbose,
+        enhance_prompt,
+    ) -> None:
+        captured.update(locals())
+        Path(output_path).write_bytes(b"mp4")
 
     fake.generate_video_with_audio = generate_video_with_audio
     monkeypatch.setitem(sys.modules, "mlx_video", fake)
@@ -60,8 +75,9 @@ def test_video_engine_calls_mlx_native_pipeline(
 def test_video_parameter_validation() -> None:
     assert video._parse_size("768x512") == (768, 512)
     assert video._frame_count(4) == 97
-    with pytest.raises(Exception, match="divisible by 64"):
+    with pytest.raises(HTTPException, match="divisible by 64") as exc:
         video._parse_size("700x512")
+    assert exc.value.status_code == 400
 
 
 @pytest.mark.asyncio
@@ -213,6 +229,10 @@ async def test_cancelled_job_reaches_terminal_state_and_cleans_files(
     current = await video.retrieve_video(created["id"])
     assert current["status"] == "failed"
     assert current["error"]["code"] == "video_generation_cancelled"
+    for _ in range(200):
+        if not (video._jobs_root / created["id"]).exists():
+            break
+        await asyncio.sleep(0.01)
     assert not (video._jobs_root / created["id"]).exists()
     await video.delete_video(created["id"])
 

--- a/tests/test_ltx23_video.py
+++ b/tests/test_ltx23_video.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import sys
+import threading
 from pathlib import Path
 from types import ModuleType
 
@@ -64,6 +65,31 @@ def test_video_parameter_validation() -> None:
 
 
 @pytest.mark.asyncio
+async def test_failed_reference_upload_is_cleaned(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeEngine:
+        model_name = "notapalindrome/ltx23-mlx-av-q4"
+
+    class BrokenUpload:
+        async def read(self, size: int) -> bytes:
+            raise OSError("upload interrupted")
+
+    monkeypatch.setattr(video, "_video_engine", lambda: FakeEngine())
+    before = set(video._jobs_root.iterdir())
+    with pytest.raises(OSError, match="upload interrupted"):
+        await video.create_video(
+            prompt="test",
+            model="ltx-2.3-mlx-q4",
+            seconds="1",
+            size="512x512",
+            seed=1,
+            input_reference=BrokenUpload(),
+        )
+    assert set(video._jobs_root.iterdir()) == before
+
+
+@pytest.mark.asyncio
 async def test_video_job_lifecycle(monkeypatch: pytest.MonkeyPatch) -> None:
     class FakeEngine:
         model_name = "notapalindrome/ltx23-mlx-av-q4"
@@ -91,6 +117,58 @@ async def test_video_job_lifecycle(monkeypatch: pytest.MonkeyPatch) -> None:
     assert current["status"] == "completed"
     assert current["progress"] == 100
     response = await video.retrieve_video_content(video_id)
-    assert Path(response.path).read_bytes() == b"generated-mp4"
+    chunks = [chunk async for chunk in response.body_iterator]
+    assert b"".join(chunks) == b"generated-mp4"
     deleted = await video.delete_video(video_id)
     assert deleted["deleted"] is True
+
+
+@pytest.mark.asyncio
+async def test_video_jobs_stay_queued_until_worker_is_free(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    started = threading.Event()
+    release = threading.Event()
+    calls = 0
+
+    class BlockingEngine:
+        model_name = "notapalindrome/ltx23-mlx-av-q4"
+
+        def generate(self, *, output_path: Path, **kwargs) -> None:
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                started.set()
+                assert release.wait(timeout=5)
+            output_path.write_bytes(b"mp4")
+
+    monkeypatch.setattr(video, "_video_engine", lambda: BlockingEngine())
+    first = await video.create_video(
+        prompt="first",
+        model="ltx-2.3-mlx-q4",
+        seconds="1",
+        size="512x512",
+        seed=1,
+        input_reference=None,
+    )
+    assert await asyncio.to_thread(started.wait, 2)
+    second = await video.create_video(
+        prompt="second",
+        model="ltx-2.3-mlx-q4",
+        seconds="1",
+        size="512x512",
+        seed=2,
+        input_reference=None,
+    )
+    await asyncio.sleep(0.05)
+
+    assert (await video.retrieve_video(first["id"]))["status"] == "in_progress"
+    assert (await video.retrieve_video(second["id"]))["status"] == "queued"
+    release.set()
+    for _ in range(200):
+        if (await video.retrieve_video(second["id"]))["status"] == "completed":
+            break
+        await asyncio.sleep(0.01)
+    assert calls == 2
+    await video.delete_video(first["id"])
+    await video.delete_video(second["id"])

--- a/tests/test_modality_field.py
+++ b/tests/test_modality_field.py
@@ -84,7 +84,7 @@ class TestModalityValidation:
         # update the Literal in model_aliases.py AND the dispatch
         # tables in cli.py / routes/models.py. Failing this assertion
         # is the trigger to do that work.
-        assert frozenset({"text", "text-diffusion"}) == _VALID_MODALITIES
+        assert frozenset({"text", "text-diffusion", "video-gen"}) == _VALID_MODALITIES
 
     def test_reserved_modality_set_pinned(self) -> None:
         # Reserved lanes — declared in the type alias so routing

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -1484,6 +1484,18 @@
     "supports_dflash": false,
     "suffix_decoding_tier": "unknown"
   },
+  "ltx-2.3-mlx-q4": {
+    "hf_path": "notapalindrome/ltx23-mlx-av-q4",
+    "modality": "video-gen",
+    "tool_call_parser": null,
+    "reasoning_parser": null,
+    "is_hybrid": false,
+    "is_moe": false,
+    "supports_spec_decode": false,
+    "supports_dflash": false,
+    "suffix_decoding_tier": "unknown",
+    "min_memory_gb": 24
+  },
   "embeddinggemma-300m-6bit": {
     "hf_path": "mlx-community/embeddinggemma-300m-6bit",
     "tool_call_parser": null,

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -2268,6 +2268,18 @@ def serve_command(args):
     _max_tokens_is_explicit = _arg_max_tokens is not None
     effective_max_tokens = _arg_max_tokens if _arg_max_tokens is not None else 32768
 
+    # Video aliases use a dedicated MLX-native runtime. Check the optional
+    # package and ffmpeg before version prompts or a 22+ GB model download.
+    from .model_aliases import resolve_profile as _resolve_serve_profile
+
+    _serve_profile = _resolve_serve_profile(
+        getattr(args, "_original_alias", None) or getattr(args, "model", "")
+    )
+    if _serve_profile is not None and _serve_profile.modality == "video-gen":
+        from .runtime.video_lane import require_video_runtime_or_exit
+
+        require_video_runtime_or_exit()
+
     # F-H08-INCOMPLETE: the ``[embeddings]`` extra-required guard MUST
     # fire first thing in ``serve_command`` — before
     # ``prompt_upgrade_if_available`` (which may exit 0 on user

--- a/vllm_mlx/middleware/body_size.py
+++ b/vllm_mlx/middleware/body_size.py
@@ -107,7 +107,14 @@ _GUARDED_PREFIXES = ("/v1/", "/internal/", "/anthropic/")
 # domain-appropriate cap. We skip them here so the generic 8 MiB JSON
 # cap doesn't trample a 25 MB Whisper upload that the audio middleware
 # already validates. See ``vllm_mlx/routes/audio.py``.
-_EXCLUDED_PATHS = frozenset({"/v1/audio/transcriptions"})
+_EXCLUDED_PATHS = frozenset(
+    {
+        "/v1/audio/transcriptions",
+        # Multipart video uploads have a dedicated 20 MiB file / 21 MiB
+        # request cap plus pre-parse authentication in routes.video.
+        "/v1/videos",
+    }
+)
 
 
 def _path_is_guarded(path: str | None) -> bool:

--- a/vllm_mlx/model_aliases.py
+++ b/vllm_mlx/model_aliases.py
@@ -29,7 +29,7 @@ from .model_profile import Modality, ModelProfile
 # but loading an alias that declares one MUST fail loud right now —
 # otherwise an aliases.json typo would pass schema validation and crash
 # at request time with an unrouted lane (pr_validate codex r13 NIT).
-_VALID_MODALITIES: frozenset[str] = frozenset({"text", "text-diffusion"})
+_VALID_MODALITIES: frozenset[str] = frozenset({"text", "text-diffusion", "video-gen"})
 _RESERVED_MODALITIES: frozenset[str] = frozenset({"vision", "image-gen"})
 
 # Canonical enum for ``suffix_decoding_tier``. Kept here so the contract

--- a/vllm_mlx/model_profile.py
+++ b/vllm_mlx/model_profile.py
@@ -54,7 +54,7 @@ from typing import Literal
 # Adding a new value requires editing this Literal AND the dispatch table
 # in cli.py / routes/models.py so the surface-level UX (info, ls, chat)
 # doesn't silently expose LLM-only columns on a non-LLM alias.
-Modality = Literal["text", "text-diffusion", "vision", "image-gen"]
+Modality = Literal["text", "text-diffusion", "vision", "image-gen", "video-gen"]
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/vllm_mlx/model_sizes.json
+++ b/vllm_mlx/model_sizes.json
@@ -168,6 +168,7 @@
     "mlx-community/whisper-small-mlx": 481307858,
     "mlx-community/whisper-tiny-mlx": 74418802,
     "nightmedia/Qwen3.5-122B-A10B-Text-mxfp4-mlx": 64915343903,
+    "notapalindrome/ltx23-mlx-av-q4": 22815504514,
     "openbmb/MiniCPM5-1B-MLX": 617961816,
     "pipenetwork/GLM-5.2-REAP50-MLX-4bit": 214380689191,
     "pipenetwork/Holo-3.1-35B-A3B-MLX-4bit": 23490832707,

--- a/vllm_mlx/routes/models.py
+++ b/vllm_mlx/routes/models.py
@@ -406,6 +406,9 @@ def _detect_capabilities(
         # embedding model id — the chat surface is not wired.
         return ["embedding"]
 
+    if profile_modality == "video-gen":
+        return ["video.generation"]
+
     caps: list[str] = ["text"]
     if _is_vlm(model_id, profile_modality, is_text_only):
         caps.append("vision")

--- a/vllm_mlx/routes/video.py
+++ b/vllm_mlx/routes/video.py
@@ -52,6 +52,7 @@ class _VideoJob:
 
 _jobs: dict[str, _VideoJob] = {}
 _tasks: dict[str, asyncio.Task] = {}
+_cleanup_tasks: set[asyncio.Task] = set()
 _generation_gate = asyncio.Lock()
 
 
@@ -121,46 +122,58 @@ async def _run_job(
     seed: int,
     image_path: Path | None,
 ) -> None:
-    worker: asyncio.Task | None = None
-    try:
-        # Wait outside the executor so queued jobs consume no worker threads.
+    started = False
+    output = _jobs_root / job.id / "output.mp4"
+
+    async def generate_under_gate() -> None:
+        nonlocal started
+        # This inner task owns the gate, so cancellation of the request-facing
+        # job never releases it while an uncancellable MLX thread is running.
         async with _generation_gate:
+            started = True
             with _jobs_lock:
                 job.status = "in_progress"
                 job.progress = 1
-            output = _jobs_root / job.id / "output.mp4"
-            worker = asyncio.create_task(
-                asyncio.to_thread(
-                    engine.generate,
-                    prompt=job.prompt,
-                    output_path=output,
-                    width=width,
-                    height=height,
-                    num_frames=_frame_count(seconds),
-                    fps=24,
-                    seed=seed,
-                    image=image_path,
-                )
+            await asyncio.to_thread(
+                engine.generate,
+                prompt=job.prompt,
+                output_path=output,
+                width=width,
+                height=height,
+                num_frames=_frame_count(seconds),
+                fps=24,
+                seed=seed,
+                image=image_path,
             )
-            # Cancellation cannot stop a running MLX graph. Shield the worker;
-            # the cancellation handler waits for it before cleaning files.
-            await asyncio.shield(worker)
-            with _jobs_lock:
-                job.status = "completed"
-                job.progress = 100
-                job.completed_at = int(time.time())
-                job.output_path = str(output)
+
+    runner = asyncio.create_task(generate_under_gate())
+    try:
+        await asyncio.shield(runner)
+        with _jobs_lock:
+            job.status = "completed"
+            job.progress = 100
+            job.completed_at = int(time.time())
+            job.output_path = str(output)
     except asyncio.CancelledError:
-        if worker is not None:
-            with contextlib.suppress(Exception):
-                await worker
         with _jobs_lock:
             job.status = "failed"
             job.error = {
                 "code": "video_generation_cancelled",
                 "message": "Video generation was cancelled.",
             }
-        await asyncio.to_thread(shutil.rmtree, _jobs_root / job.id, True)
+        if not started:
+            runner.cancel()
+
+        async def reap_cancelled_job() -> None:
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await runner
+            await asyncio.to_thread(
+                shutil.rmtree, _jobs_root / job.id, ignore_errors=True
+            )
+
+        cleanup = asyncio.create_task(reap_cancelled_job())
+        _cleanup_tasks.add(cleanup)
+        cleanup.add_done_callback(_cleanup_tasks.discard)
         raise
     except Exception as exc:  # noqa: BLE001
         from ..runtime.video_lane import VideoRuntimeError

--- a/vllm_mlx/routes/video.py
+++ b/vllm_mlx/routes/video.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import asyncio
 import atexit
+import contextlib
 import logging
 import shutil
 import tempfile
@@ -120,6 +121,7 @@ async def _run_job(
     seed: int,
     image_path: Path | None,
 ) -> None:
+    worker: asyncio.Task | None = None
     try:
         # Wait outside the executor so queued jobs consume no worker threads.
         async with _generation_gate:
@@ -127,22 +129,39 @@ async def _run_job(
                 job.status = "in_progress"
                 job.progress = 1
             output = _jobs_root / job.id / "output.mp4"
-            await asyncio.to_thread(
-                engine.generate,
-                prompt=job.prompt,
-                output_path=output,
-                width=width,
-                height=height,
-                num_frames=_frame_count(seconds),
-                fps=24,
-                seed=seed,
-                image=image_path,
+            worker = asyncio.create_task(
+                asyncio.to_thread(
+                    engine.generate,
+                    prompt=job.prompt,
+                    output_path=output,
+                    width=width,
+                    height=height,
+                    num_frames=_frame_count(seconds),
+                    fps=24,
+                    seed=seed,
+                    image=image_path,
+                )
             )
+            # Cancellation cannot stop a running MLX graph. Shield the worker;
+            # the cancellation handler waits for it before cleaning files.
+            await asyncio.shield(worker)
             with _jobs_lock:
                 job.status = "completed"
                 job.progress = 100
                 job.completed_at = int(time.time())
                 job.output_path = str(output)
+    except asyncio.CancelledError:
+        if worker is not None:
+            with contextlib.suppress(Exception):
+                await worker
+        with _jobs_lock:
+            job.status = "failed"
+            job.error = {
+                "code": "video_generation_cancelled",
+                "message": "Video generation was cancelled.",
+            }
+        await asyncio.to_thread(shutil.rmtree, _jobs_root / job.id, True)
+        raise
     except Exception as exc:  # noqa: BLE001
         from ..runtime.video_lane import VideoRuntimeError
 
@@ -187,6 +206,7 @@ async def create_video(
     job_dir.mkdir(mode=0o700)
     image_path = None
     enqueued = False
+    evicted_id: str | None = None
     try:
         if input_reference is not None:
             image_path = job_dir / "reference.img"
@@ -221,12 +241,16 @@ async def create_video(
                     )
                 oldest = min(finished, key=lambda item: item.created_at)
                 _jobs.pop(oldest.id, None)
-                shutil.rmtree(_jobs_root / oldest.id, ignore_errors=True)
+                evicted_id = oldest.id
             _jobs[job.id] = job
             enqueued = True
     finally:
         if not enqueued:
-            shutil.rmtree(job_dir, ignore_errors=True)
+            await asyncio.to_thread(shutil.rmtree, job_dir, ignore_errors=True)
+    if evicted_id is not None:
+        await asyncio.to_thread(
+            shutil.rmtree, _jobs_root / evicted_id, ignore_errors=True
+        )
     task = asyncio.create_task(
         _run_job(
             job,
@@ -305,7 +329,7 @@ async def delete_video(video_id: str):
             _jobs.pop(video_id, None)
     if job is None:
         raise HTTPException(status_code=404, detail="video job not found")
-    shutil.rmtree(_jobs_root / video_id, ignore_errors=True)
+    await asyncio.to_thread(shutil.rmtree, _jobs_root / video_id, ignore_errors=True)
     response = job.public()
     response["deleted"] = True
     return response

--- a/vllm_mlx/routes/video.py
+++ b/vllm_mlx/routes/video.py
@@ -15,7 +15,7 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 
 from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, UploadFile
-from fastapi.responses import FileResponse
+from fastapi.responses import StreamingResponse
 
 from ..middleware.auth import verify_api_key
 
@@ -51,6 +51,7 @@ class _VideoJob:
 
 _jobs: dict[str, _VideoJob] = {}
 _tasks: set[asyncio.Task] = set()
+_generation_gate = asyncio.Lock()
 
 
 def _cleanup_jobs() -> None:
@@ -119,27 +120,29 @@ async def _run_job(
     seed: int,
     image_path: Path | None,
 ) -> None:
-    with _jobs_lock:
-        job.status = "in_progress"
-        job.progress = 1
     try:
-        output = _jobs_root / job.id / "output.mp4"
-        await asyncio.to_thread(
-            engine.generate,
-            prompt=job.prompt,
-            output_path=output,
-            width=width,
-            height=height,
-            num_frames=_frame_count(seconds),
-            fps=24,
-            seed=seed,
-            image=image_path,
-        )
-        with _jobs_lock:
-            job.status = "completed"
-            job.progress = 100
-            job.completed_at = int(time.time())
-            job.output_path = str(output)
+        # Wait outside the executor so queued jobs consume no worker threads.
+        async with _generation_gate:
+            with _jobs_lock:
+                job.status = "in_progress"
+                job.progress = 1
+            output = _jobs_root / job.id / "output.mp4"
+            await asyncio.to_thread(
+                engine.generate,
+                prompt=job.prompt,
+                output_path=output,
+                width=width,
+                height=height,
+                num_frames=_frame_count(seconds),
+                fps=24,
+                seed=seed,
+                image=image_path,
+            )
+            with _jobs_lock:
+                job.status = "completed"
+                job.progress = 100
+                job.completed_at = int(time.time())
+                job.output_path = str(output)
     except Exception as exc:  # noqa: BLE001
         from ..runtime.video_lane import VideoRuntimeError
 
@@ -183,43 +186,47 @@ async def create_video(
     job_dir = _jobs_root / job_id
     job_dir.mkdir(mode=0o700)
     image_path = None
-    if input_reference is not None:
-        image_path = job_dir / "reference.img"
-        total = 0
-        with image_path.open("xb") as target:
-            while chunk := await input_reference.read(1024 * 1024):
-                total += len(chunk)
-                if total > _MAX_REFERENCE_BYTES:
-                    target.close()
-                    image_path.unlink(missing_ok=True)
-                    shutil.rmtree(job_dir, ignore_errors=True)
-                    raise HTTPException(
-                        status_code=413, detail="input_reference exceeds 20 MB"
-                    )
-                target.write(chunk)
+    enqueued = False
+    try:
+        if input_reference is not None:
+            image_path = job_dir / "reference.img"
+            total = 0
+            with image_path.open("xb") as target:
+                while chunk := await input_reference.read(1024 * 1024):
+                    total += len(chunk)
+                    if total > _MAX_REFERENCE_BYTES:
+                        raise HTTPException(
+                            status_code=413, detail="input_reference exceeds 20 MB"
+                        )
+                    target.write(chunk)
 
-    job = _VideoJob(
-        id=job_id,
-        model="ltx-2.3-mlx-q4",
-        prompt=prompt,
-        seconds=str(seconds_int),
-        size=f"{width}x{height}",
-        created_at=int(time.time()),
-    )
-    with _jobs_lock:
-        if len(_jobs) >= _MAX_JOBS:
-            finished = [
-                item
-                for item in _jobs.values()
-                if item.status in {"completed", "failed"}
-            ]
-            if not finished:
-                shutil.rmtree(job_dir, ignore_errors=True)
-                raise HTTPException(status_code=429, detail="video job queue is full")
-            oldest = min(finished, key=lambda item: item.created_at)
-            _jobs.pop(oldest.id, None)
-            shutil.rmtree(_jobs_root / oldest.id, ignore_errors=True)
-        _jobs[job.id] = job
+        job = _VideoJob(
+            id=job_id,
+            model="ltx-2.3-mlx-q4",
+            prompt=prompt,
+            seconds=str(seconds_int),
+            size=f"{width}x{height}",
+            created_at=int(time.time()),
+        )
+        with _jobs_lock:
+            if len(_jobs) >= _MAX_JOBS:
+                finished = [
+                    item
+                    for item in _jobs.values()
+                    if item.status in {"completed", "failed"}
+                ]
+                if not finished:
+                    raise HTTPException(
+                        status_code=429, detail="video job queue is full"
+                    )
+                oldest = min(finished, key=lambda item: item.created_at)
+                _jobs.pop(oldest.id, None)
+                shutil.rmtree(_jobs_root / oldest.id, ignore_errors=True)
+            _jobs[job.id] = job
+            enqueued = True
+    finally:
+        if not enqueued:
+            shutil.rmtree(job_dir, ignore_errors=True)
     task = asyncio.create_task(
         _run_job(
             job,
@@ -254,8 +261,26 @@ async def retrieve_video_content(video_id: str):
     job = _get_job(video_id)
     if job.status != "completed" or job.output_path is None:
         raise HTTPException(status_code=409, detail="video is not completed")
-    return FileResponse(
-        job.output_path, media_type="video/mp4", filename=f"{job.id}.mp4"
+    # Open before releasing control. A concurrent delete/eviction may unlink
+    # the path, but the already-open descriptor remains streamable on macOS.
+    try:
+        source = open(job.output_path, "rb")  # noqa: SIM115
+    except FileNotFoundError as exc:
+        raise HTTPException(
+            status_code=410, detail="video content has expired"
+        ) from exc
+
+    def chunks():
+        try:
+            while data := source.read(1024 * 1024):
+                yield data
+        finally:
+            source.close()
+
+    return StreamingResponse(
+        chunks(),
+        media_type="video/mp4",
+        headers={"Content-Disposition": f'attachment; filename="{job.id}.mp4"'},
     )
 
 

--- a/vllm_mlx/routes/video.py
+++ b/vllm_mlx/routes/video.py
@@ -57,6 +57,8 @@ class _VideoJob:
 _jobs: dict[str, _VideoJob] = {}
 _tasks: dict[str, asyncio.Task] = {}
 _cleanup_tasks: set[asyncio.Task] = set()
+_generation_threads: set[threading.Thread] = set()
+_accepting_jobs = True
 _generation_gates: weakref.WeakKeyDictionary[
     asyncio.AbstractEventLoop, asyncio.Lock
 ] = weakref.WeakKeyDictionary()
@@ -79,6 +81,88 @@ def _cleanup_jobs() -> None:
 
 
 atexit.register(_cleanup_jobs)
+
+
+def start_video_jobs() -> None:
+    """Reset the route lifecycle when an application instance starts."""
+    global _accepting_jobs
+    with _jobs_lock:
+        _accepting_jobs = True
+
+
+async def shutdown_video_jobs(timeout: float = 30.0) -> None:
+    """Stop admission and drain video jobs within a bounded shutdown budget.
+
+    MLX generation cannot be interrupted safely once a Metal graph is running.
+    Queued jobs are cancelled immediately; an active job gets ``timeout``
+    seconds to finish. Generation itself runs on a daemon thread, so exceeding
+    the budget cannot keep the Python process alive indefinitely.
+    """
+    global _accepting_jobs
+    loop = asyncio.get_running_loop()
+    with _jobs_lock:
+        _accepting_jobs = False
+        current_tasks = [
+            task
+            for task in _tasks.values()
+            if not task.done() and task.get_loop() is loop
+        ]
+        for job_id, task in list(_tasks.items()):
+            job = _jobs.get(job_id)
+            if task in current_tasks and job is not None and job.status == "queued":
+                job.status = "failed"
+                job.error = {
+                    "code": "video_server_shutdown",
+                    "message": "Video generation was cancelled during server shutdown.",
+                }
+                task.cancel()
+
+    if current_tasks:
+        _, pending = await asyncio.wait(current_tasks, timeout=max(0.0, timeout))
+        if pending:
+            logger.warning(
+                "Video shutdown budget expired with %d active generation job(s); "
+                "detaching daemon MLX worker(s)",
+                len(pending),
+            )
+            for task in pending:
+                task.cancel()
+            await asyncio.gather(*pending, return_exceptions=True)
+
+
+async def _run_in_generation_thread(function, /, **kwargs) -> None:
+    """Run uncancellable MLX work without owning a non-daemon executor thread."""
+    loop = asyncio.get_running_loop()
+    completed = loop.create_future()
+
+    def finish(result: BaseException | None) -> None:
+        if completed.done():
+            return
+        if result is None:
+            completed.set_result(None)
+        else:
+            completed.set_exception(result)
+
+    def target() -> None:
+        try:
+            function(**kwargs)
+        except BaseException as exc:  # noqa: BLE001
+            result = exc
+        else:
+            result = None
+        finally:
+            with _jobs_lock:
+                _generation_threads.discard(thread)
+        with contextlib.suppress(RuntimeError):
+            loop.call_soon_threadsafe(finish, result)
+
+    thread = threading.Thread(
+        target=target, name="rapid-mlx-video-generation", daemon=True
+    )
+    with _jobs_lock:
+        _generation_threads.add(thread)
+    thread.start()
+    await completed
 
 
 def _video_engine():
@@ -185,7 +269,7 @@ async def _run_job(
                 started = True
                 job.status = "in_progress"
                 job.progress = 1
-            await asyncio.to_thread(
+            await _run_in_generation_thread(
                 engine.generate,
                 prompt=job.prompt,
                 output_path=output,
@@ -254,6 +338,9 @@ async def create_video(
     input_reference: UploadFile | None = File(None),
 ):
     engine = _video_engine()
+    with _jobs_lock:
+        if not _accepting_jobs:
+            raise HTTPException(status_code=503, detail="video server is shutting down")
     prompt = prompt.strip()
     if not prompt:
         raise HTTPException(status_code=400, detail="prompt must not be blank")
@@ -309,6 +396,10 @@ async def create_video(
             created_at=int(time.time()),
         )
         with _jobs_lock:
+            if not _accepting_jobs:
+                raise HTTPException(
+                    status_code=503, detail="video server is shutting down"
+                )
             if len(_jobs) >= _MAX_JOBS:
                 finished = [
                     item

--- a/vllm_mlx/routes/video.py
+++ b/vllm_mlx/routes/video.py
@@ -12,6 +12,7 @@ import tempfile
 import threading
 import time
 import uuid
+import warnings
 from dataclasses import asdict, dataclass
 from pathlib import Path
 
@@ -26,6 +27,7 @@ logger = logging.getLogger(__name__)
 _MAX_REFERENCE_BYTES = 20 * 1024 * 1024
 _MAX_JOBS = 100
 _MAX_PIXEL_FRAMES = 768 * 512 * 97
+_MAX_REFERENCE_PIXELS = 16_777_216
 _jobs_lock = threading.Lock()
 _jobs_root = Path(tempfile.mkdtemp(prefix="rapid-mlx-videos-"))
 
@@ -111,6 +113,32 @@ def _parse_size(value: str) -> tuple[int, int]:
 def _frame_count(seconds: int, fps: int = 24) -> int:
     requested = seconds * fps
     return max(9, round((requested - 1) / 8) * 8 + 1)
+
+
+def _validate_reference_image(path: Path) -> None:
+    try:
+        from PIL import Image
+    except ImportError as exc:
+        raise HTTPException(
+            status_code=503,
+            detail="image-to-video requires `pip install 'rapid-mlx[video]'`",
+        ) from exc
+
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", Image.DecompressionBombWarning)
+            with Image.open(path) as image:
+                width, height = image.size
+                image_format = image.format
+                if width <= 0 or height <= 0 or width * height > _MAX_REFERENCE_PIXELS:
+                    raise ValueError("reference image exceeds 16 megapixels")
+                if image_format not in {"JPEG", "PNG", "WEBP"}:
+                    raise ValueError("reference image must be JPEG, PNG, or WebP")
+                image.verify()
+    except (OSError, ValueError, Image.DecompressionBombError, Warning) as exc:
+        raise HTTPException(
+            status_code=400, detail=f"invalid input_reference: {exc}"
+        ) from exc
 
 
 async def _run_job(
@@ -242,6 +270,7 @@ async def create_video(
                             status_code=413, detail="input_reference exceeds 20 MB"
                         )
                     target.write(chunk)
+            _validate_reference_image(image_path)
 
         job = _VideoJob(
             id=job_id,

--- a/vllm_mlx/routes/video.py
+++ b/vllm_mlx/routes/video.py
@@ -154,13 +154,19 @@ async def _run_job(
     started = False
     output = _jobs_root / job.id / "output.mp4"
 
-    async def generate_under_gate() -> None:
+    async def generate_under_gate() -> bool:
         nonlocal started
         # This inner task owns the gate, so cancellation of the request-facing
         # job never releases it while an uncancellable MLX thread is running.
         async with _generation_gate:
-            started = True
             with _jobs_lock:
+                if (
+                    job.status == "failed"
+                    and job.error is not None
+                    and job.error.get("code") == "video_generation_cancelled"
+                ):
+                    return False
+                started = True
                 job.status = "in_progress"
                 job.progress = 1
             await asyncio.to_thread(
@@ -174,10 +180,13 @@ async def _run_job(
                 seed=seed,
                 image=image_path,
             )
+            return True
 
     runner = asyncio.create_task(generate_under_gate())
     try:
-        await asyncio.shield(runner)
+        generated = await asyncio.shield(runner)
+        if not generated:
+            return
         with _jobs_lock:
             job.status = "completed"
             job.progress = 100
@@ -383,6 +392,12 @@ async def delete_video(video_id: str):
                 status_code=409, detail="video generation is in progress"
             )
         task = _tasks.get(video_id) if job is not None else None
+        if job is not None and job.status == "queued":
+            job.status = "failed"
+            job.error = {
+                "code": "video_generation_cancelled",
+                "message": "Video generation was cancelled.",
+            }
         if job is not None and job.status != "queued":
             _jobs.pop(video_id, None)
     if job is None:

--- a/vllm_mlx/routes/video.py
+++ b/vllm_mlx/routes/video.py
@@ -13,6 +13,7 @@ import threading
 import time
 import uuid
 import warnings
+import weakref
 from dataclasses import asdict, dataclass
 from pathlib import Path
 
@@ -56,7 +57,21 @@ class _VideoJob:
 _jobs: dict[str, _VideoJob] = {}
 _tasks: dict[str, asyncio.Task] = {}
 _cleanup_tasks: set[asyncio.Task] = set()
-_generation_gate = asyncio.Lock()
+_generation_gates: weakref.WeakKeyDictionary[
+    asyncio.AbstractEventLoop, asyncio.Lock
+] = weakref.WeakKeyDictionary()
+_generation_gates_lock = threading.Lock()
+
+
+def _generation_gate_for_current_loop() -> asyncio.Lock:
+    """Return the serial generation gate owned by the active event loop."""
+    loop = asyncio.get_running_loop()
+    with _generation_gates_lock:
+        gate = _generation_gates.get(loop)
+        if gate is None:
+            gate = asyncio.Lock()
+            _generation_gates[loop] = gate
+        return gate
 
 
 def _cleanup_jobs() -> None:
@@ -153,12 +168,13 @@ async def _run_job(
 ) -> None:
     started = False
     output = _jobs_root / job.id / "output.mp4"
+    generation_gate = _generation_gate_for_current_loop()
 
     async def generate_under_gate() -> bool:
         nonlocal started
         # This inner task owns the gate, so cancellation of the request-facing
         # job never releases it while an uncancellable MLX thread is running.
-        async with _generation_gate:
+        async with generation_gate:
             with _jobs_lock:
                 if (
                     job.status == "failed"
@@ -271,15 +287,18 @@ async def create_video(
         if input_reference is not None:
             image_path = job_dir / "reference.img"
             total = 0
-            with image_path.open("xb") as target:
+            target = await asyncio.to_thread(image_path.open, "xb")
+            try:
                 while chunk := await input_reference.read(1024 * 1024):
                     total += len(chunk)
                     if total > _MAX_REFERENCE_BYTES:
                         raise HTTPException(
                             status_code=413, detail="input_reference exceeds 20 MB"
                         )
-                    target.write(chunk)
-            _validate_reference_image(image_path)
+                    await asyncio.to_thread(target.write, chunk)
+            finally:
+                await asyncio.to_thread(target.close)
+            await asyncio.to_thread(_validate_reference_image, image_path)
 
         job = _VideoJob(
             id=job_id,

--- a/vllm_mlx/routes/video.py
+++ b/vllm_mlx/routes/video.py
@@ -51,7 +51,7 @@ class _VideoJob:
 
 
 _jobs: dict[str, _VideoJob] = {}
-_tasks: set[asyncio.Task] = set()
+_tasks: dict[str, asyncio.Task] = {}
 _generation_gate = asyncio.Lock()
 
 
@@ -174,6 +174,7 @@ async def _run_job(
         with _jobs_lock:
             job.status = "failed"
             job.error = {"code": "video_generation_failed", "message": message}
+        await asyncio.to_thread(shutil.rmtree, _jobs_root / job.id, ignore_errors=True)
 
 
 @router.post("/v1/videos", dependencies=[Depends(verify_api_key)])
@@ -247,10 +248,6 @@ async def create_video(
     finally:
         if not enqueued:
             await asyncio.to_thread(shutil.rmtree, job_dir, ignore_errors=True)
-    if evicted_id is not None:
-        await asyncio.to_thread(
-            shutil.rmtree, _jobs_root / evicted_id, ignore_errors=True
-        )
     task = asyncio.create_task(
         _run_job(
             job,
@@ -262,8 +259,17 @@ async def create_video(
             image_path=image_path,
         )
     )
-    _tasks.add(task)
-    task.add_done_callback(_tasks.discard)
+    _tasks[job.id] = task
+
+    def discard_task(done: asyncio.Task) -> None:
+        if _tasks.get(job.id) is done:
+            _tasks.pop(job.id, None)
+
+    task.add_done_callback(discard_task)
+    if evicted_id is not None:
+        await asyncio.to_thread(
+            shutil.rmtree, _jobs_root / evicted_id, ignore_errors=True
+        )
     return job.public()
 
 

--- a/vllm_mlx/routes/video.py
+++ b/vllm_mlx/routes/video.py
@@ -18,14 +18,15 @@ from dataclasses import asdict, dataclass, replace
 from pathlib import Path
 
 from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, UploadFile
-from fastapi.responses import StreamingResponse
+from fastapi.responses import JSONResponse, StreamingResponse
 
-from ..middleware.auth import verify_api_key
+from ..middleware.auth import _verify_api_key_values, verify_api_key
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
 
 _MAX_REFERENCE_BYTES = 20 * 1024 * 1024
+_VIDEO_REQUEST_BYTES = _MAX_REFERENCE_BYTES + 1024 * 1024
 _MAX_JOBS = 100
 _MAX_PIXEL_FRAMES = 768 * 512 * 97
 _MAX_REFERENCE_PIXELS = 16_777_216
@@ -65,6 +66,76 @@ _generation_gates: weakref.WeakKeyDictionary[
     asyncio.AbstractEventLoop, asyncio.Lock
 ] = weakref.WeakKeyDictionary()
 _generation_gates_lock = threading.Lock()
+
+
+class _VideoBodyTooLargeError(Exception):
+    """Internal ASGI sentinel for a streamed multipart body over the cap."""
+
+
+class VideoBodyLimitMiddleware:
+    """Authenticate and cap video multipart bodies before FastAPI parses them."""
+
+    def __init__(self, app) -> None:
+        self.app = app
+
+    async def __call__(self, scope, receive, send):
+        if (
+            scope.get("type") != "http"
+            or scope.get("method") != "POST"
+            or scope.get("path") != "/v1/videos"
+        ):
+            return await self.app(scope, receive, send)
+
+        headers = {name.lower(): value for name, value in scope.get("headers", ())}
+        authorization = headers.get(b"authorization", b"").decode(
+            "latin-1", errors="ignore"
+        )
+        scheme, _, token = authorization.partition(" ")
+        bearer = token if scheme.lower() == "bearer" and token else None
+        try:
+            _verify_api_key_values(bearer)
+        except HTTPException as exc:
+            response = JSONResponse(
+                status_code=exc.status_code, content={"detail": exc.detail}
+            )
+            return await response(scope, receive, send)
+
+        advertised = headers.get(b"content-length")
+        if advertised is not None:
+            try:
+                advertised_bytes = int(advertised.decode("ascii"))
+            except (UnicodeDecodeError, ValueError):
+                advertised_bytes = None
+            if advertised_bytes is not None and advertised_bytes > _VIDEO_REQUEST_BYTES:
+                response = JSONResponse(
+                    status_code=413,
+                    content={"detail": "video request body exceeds 21 MB"},
+                )
+                return await response(scope, receive, send)
+
+        total = 0
+
+        async def bounded_receive():
+            nonlocal total
+            message = await receive()
+            if message.get("type") == "http.request":
+                total += len(message.get("body", b"") or b"")
+                if total > _VIDEO_REQUEST_BYTES:
+                    raise _VideoBodyTooLargeError
+            return message
+
+        try:
+            await self.app(scope, bounded_receive, send)
+        except _VideoBodyTooLargeError:
+            response = JSONResponse(
+                status_code=413,
+                content={"detail": "video request body exceeds 21 MB"},
+            )
+            await response(scope, receive, send)
+
+
+def install_video_body_limit_middleware(app) -> None:
+    app.add_middleware(VideoBodyLimitMiddleware)
 
 
 def _generation_gate_for_current_loop() -> asyncio.Lock:
@@ -226,7 +297,10 @@ def _parse_size(value: str) -> tuple[int, int]:
     ):
         raise HTTPException(
             status_code=400,
-            detail="video width/height must be 256..1920 and divisible by 64",
+            detail=(
+                "video width/height must be 256..1920 and divisible by 64, "
+                "or use 1280x720 / 720x1280"
+            ),
         )
     return width, height
 

--- a/vllm_mlx/routes/video.py
+++ b/vllm_mlx/routes/video.py
@@ -25,6 +25,7 @@ logger = logging.getLogger(__name__)
 
 _MAX_REFERENCE_BYTES = 20 * 1024 * 1024
 _MAX_JOBS = 100
+_MAX_PIXEL_FRAMES = 768 * 512 * 97
 _jobs_lock = threading.Lock()
 _jobs_root = Path(tempfile.mkdtemp(prefix="rapid-mlx-videos-"))
 
@@ -214,6 +215,14 @@ async def create_video(
     if not 1 <= seconds_int <= 20:
         raise HTTPException(status_code=400, detail="seconds must be between 1 and 20")
     width, height = _parse_size(size)
+    if width * height * _frame_count(seconds_int) > _MAX_PIXEL_FRAMES:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "requested video exceeds the safe LTX-2.3 Q4 workload limit "
+                "(768x512 at 4 seconds); reduce size or duration"
+            ),
+        )
 
     job_id = f"video_{uuid.uuid4().hex}"
     job_dir = _jobs_root / job_id
@@ -340,14 +349,21 @@ async def list_videos(limit: int = Query(20, ge=1, le=100)):
 async def delete_video(video_id: str):
     with _jobs_lock:
         job = _jobs.get(video_id)
-        if job is not None and job.status in {"queued", "in_progress"}:
+        if job is not None and job.status == "in_progress":
             raise HTTPException(
                 status_code=409, detail="video generation is in progress"
             )
-        if job is not None:
+        task = _tasks.get(video_id) if job is not None else None
+        if job is not None and job.status != "queued":
             _jobs.pop(video_id, None)
     if job is None:
         raise HTTPException(status_code=404, detail="video job not found")
+    if task is not None:
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+        with _jobs_lock:
+            _jobs.pop(video_id, None)
     await asyncio.to_thread(shutil.rmtree, _jobs_root / video_id, ignore_errors=True)
     response = job.public()
     response["deleted"] = True

--- a/vllm_mlx/routes/video.py
+++ b/vllm_mlx/routes/video.py
@@ -14,7 +14,7 @@ import time
 import uuid
 import warnings
 import weakref
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, replace
 from pathlib import Path
 
 from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, UploadFile
@@ -355,9 +355,10 @@ async def create_video(
 def _get_job(video_id: str) -> _VideoJob:
     with _jobs_lock:
         job = _jobs.get(video_id)
-    if job is None:
+        snapshot = replace(job) if job is not None else None
+    if snapshot is None:
         raise HTTPException(status_code=404, detail="video job not found")
-    return job
+    return snapshot
 
 
 @router.get("/v1/videos/{video_id}", dependencies=[Depends(verify_api_key)])
@@ -396,8 +397,11 @@ async def retrieve_video_content(video_id: str):
 @router.get("/v1/videos", dependencies=[Depends(verify_api_key)])
 async def list_videos(limit: int = Query(20, ge=1, le=100)):
     with _jobs_lock:
-        data = sorted(_jobs.values(), key=lambda item: item.created_at, reverse=True)[
-            :limit
+        data = [
+            replace(job)
+            for job in sorted(
+                _jobs.values(), key=lambda item: item.created_at, reverse=True
+            )[:limit]
         ]
     return {"object": "list", "data": [job.public() for job in data]}
 

--- a/vllm_mlx/routes/video.py
+++ b/vllm_mlx/routes/video.py
@@ -1,0 +1,286 @@
+# SPDX-License-Identifier: Apache-2.0
+"""OpenAI-compatible video jobs backed by MLX-native LTX-2.3."""
+
+from __future__ import annotations
+
+import asyncio
+import atexit
+import logging
+import shutil
+import tempfile
+import threading
+import time
+import uuid
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, UploadFile
+from fastapi.responses import FileResponse
+
+from ..middleware.auth import verify_api_key
+
+router = APIRouter()
+logger = logging.getLogger(__name__)
+
+_MAX_REFERENCE_BYTES = 20 * 1024 * 1024
+_MAX_JOBS = 100
+_jobs_lock = threading.Lock()
+_jobs_root = Path(tempfile.mkdtemp(prefix="rapid-mlx-videos-"))
+
+
+@dataclass
+class _VideoJob:
+    id: str
+    model: str
+    prompt: str
+    seconds: str
+    size: str
+    status: str = "queued"
+    progress: int = 0
+    created_at: int = 0
+    completed_at: int | None = None
+    error: dict[str, str] | None = None
+    output_path: str | None = None
+
+    def public(self) -> dict:
+        value = asdict(self)
+        value.pop("output_path")
+        value["object"] = "video"
+        return value
+
+
+_jobs: dict[str, _VideoJob] = {}
+_tasks: set[asyncio.Task] = set()
+
+
+def _cleanup_jobs() -> None:
+    shutil.rmtree(_jobs_root, ignore_errors=True)
+
+
+atexit.register(_cleanup_jobs)
+
+
+def _video_engine():
+    from ..config import get_config
+
+    engine = get_config().engine
+    if engine is None or not getattr(engine, "is_video_gen", False):
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "error": {
+                    "message": (
+                        "This server is not running a video model. Start it with "
+                        "`rapid-mlx serve ltx-2.3-mlx-q4`."
+                    ),
+                    "type": "invalid_request_error",
+                    "code": "video_model_not_loaded",
+                    "param": "model",
+                }
+            },
+        )
+    return engine
+
+
+def _parse_size(value: str) -> tuple[int, int]:
+    try:
+        width, height = (int(part) for part in value.lower().split("x", 1))
+    except (TypeError, ValueError) as exc:
+        raise HTTPException(
+            status_code=400, detail="size must be WIDTHxHEIGHT"
+        ) from exc
+    if (
+        width < 256
+        or height < 256
+        or width > 1920
+        or height > 1920
+        or width % 64
+        or height % 64
+    ):
+        raise HTTPException(
+            status_code=400,
+            detail="video width/height must be 256..1920 and divisible by 64",
+        )
+    return width, height
+
+
+def _frame_count(seconds: int, fps: int = 24) -> int:
+    requested = seconds * fps
+    return max(9, round((requested - 1) / 8) * 8 + 1)
+
+
+async def _run_job(
+    job: _VideoJob,
+    *,
+    engine,
+    width: int,
+    height: int,
+    seconds: int,
+    seed: int,
+    image_path: Path | None,
+) -> None:
+    with _jobs_lock:
+        job.status = "in_progress"
+        job.progress = 1
+    try:
+        output = _jobs_root / job.id / "output.mp4"
+        await asyncio.to_thread(
+            engine.generate,
+            prompt=job.prompt,
+            output_path=output,
+            width=width,
+            height=height,
+            num_frames=_frame_count(seconds),
+            fps=24,
+            seed=seed,
+            image=image_path,
+        )
+        with _jobs_lock:
+            job.status = "completed"
+            job.progress = 100
+            job.completed_at = int(time.time())
+            job.output_path = str(output)
+    except Exception as exc:  # noqa: BLE001
+        from ..runtime.video_lane import VideoRuntimeError
+
+        logger.exception("LTX-2.3 video job %s failed", job.id)
+        message = (
+            str(exc)
+            if isinstance(exc, VideoRuntimeError)
+            else "Video generation failed; check the server logs for details."
+        )
+        with _jobs_lock:
+            job.status = "failed"
+            job.error = {"code": "video_generation_failed", "message": message}
+
+
+@router.post("/v1/videos", dependencies=[Depends(verify_api_key)])
+async def create_video(
+    prompt: str = Form(..., min_length=1, max_length=4096),
+    model: str = Form("ltx-2.3-mlx-q4"),
+    seconds: str = Form("4"),
+    size: str = Form("768x512"),
+    seed: int = Form(42),
+    input_reference: UploadFile | None = File(None),
+):
+    engine = _video_engine()
+    prompt = prompt.strip()
+    if not prompt:
+        raise HTTPException(status_code=400, detail="prompt must not be blank")
+    if model not in {"ltx-2.3-mlx-q4", engine.model_name}:
+        raise HTTPException(status_code=400, detail="model must be ltx-2.3-mlx-q4")
+    try:
+        seconds_int = int(seconds)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=400, detail="seconds must be an integer"
+        ) from exc
+    if not 1 <= seconds_int <= 20:
+        raise HTTPException(status_code=400, detail="seconds must be between 1 and 20")
+    width, height = _parse_size(size)
+
+    job_id = f"video_{uuid.uuid4().hex}"
+    job_dir = _jobs_root / job_id
+    job_dir.mkdir(mode=0o700)
+    image_path = None
+    if input_reference is not None:
+        image_path = job_dir / "reference.img"
+        total = 0
+        with image_path.open("xb") as target:
+            while chunk := await input_reference.read(1024 * 1024):
+                total += len(chunk)
+                if total > _MAX_REFERENCE_BYTES:
+                    target.close()
+                    image_path.unlink(missing_ok=True)
+                    shutil.rmtree(job_dir, ignore_errors=True)
+                    raise HTTPException(
+                        status_code=413, detail="input_reference exceeds 20 MB"
+                    )
+                target.write(chunk)
+
+    job = _VideoJob(
+        id=job_id,
+        model="ltx-2.3-mlx-q4",
+        prompt=prompt,
+        seconds=str(seconds_int),
+        size=f"{width}x{height}",
+        created_at=int(time.time()),
+    )
+    with _jobs_lock:
+        if len(_jobs) >= _MAX_JOBS:
+            finished = [
+                item
+                for item in _jobs.values()
+                if item.status in {"completed", "failed"}
+            ]
+            if not finished:
+                shutil.rmtree(job_dir, ignore_errors=True)
+                raise HTTPException(status_code=429, detail="video job queue is full")
+            oldest = min(finished, key=lambda item: item.created_at)
+            _jobs.pop(oldest.id, None)
+            shutil.rmtree(_jobs_root / oldest.id, ignore_errors=True)
+        _jobs[job.id] = job
+    task = asyncio.create_task(
+        _run_job(
+            job,
+            engine=engine,
+            width=width,
+            height=height,
+            seconds=seconds_int,
+            seed=seed,
+            image_path=image_path,
+        )
+    )
+    _tasks.add(task)
+    task.add_done_callback(_tasks.discard)
+    return job.public()
+
+
+def _get_job(video_id: str) -> _VideoJob:
+    with _jobs_lock:
+        job = _jobs.get(video_id)
+    if job is None:
+        raise HTTPException(status_code=404, detail="video job not found")
+    return job
+
+
+@router.get("/v1/videos/{video_id}", dependencies=[Depends(verify_api_key)])
+async def retrieve_video(video_id: str):
+    return _get_job(video_id).public()
+
+
+@router.get("/v1/videos/{video_id}/content", dependencies=[Depends(verify_api_key)])
+async def retrieve_video_content(video_id: str):
+    job = _get_job(video_id)
+    if job.status != "completed" or job.output_path is None:
+        raise HTTPException(status_code=409, detail="video is not completed")
+    return FileResponse(
+        job.output_path, media_type="video/mp4", filename=f"{job.id}.mp4"
+    )
+
+
+@router.get("/v1/videos", dependencies=[Depends(verify_api_key)])
+async def list_videos(limit: int = Query(20, ge=1, le=100)):
+    with _jobs_lock:
+        data = sorted(_jobs.values(), key=lambda item: item.created_at, reverse=True)[
+            :limit
+        ]
+    return {"object": "list", "data": [job.public() for job in data]}
+
+
+@router.delete("/v1/videos/{video_id}", dependencies=[Depends(verify_api_key)])
+async def delete_video(video_id: str):
+    with _jobs_lock:
+        job = _jobs.get(video_id)
+        if job is not None and job.status in {"queued", "in_progress"}:
+            raise HTTPException(
+                status_code=409, detail="video generation is in progress"
+            )
+        if job is not None:
+            _jobs.pop(video_id, None)
+    if job is None:
+        raise HTTPException(status_code=404, detail="video job not found")
+    shutil.rmtree(_jobs_root / video_id, ignore_errors=True)
+    response = job.public()
+    response["deleted"] = True
+    return response

--- a/vllm_mlx/routes/video.py
+++ b/vllm_mlx/routes/video.py
@@ -130,6 +130,20 @@ async def shutdown_video_jobs(timeout: float = 30.0) -> None:
                 "detaching daemon MLX worker(s)",
                 len(pending),
             )
+            with _jobs_lock:
+                pending_set = set(pending)
+                for job_id, task in _tasks.items():
+                    if task in pending_set:
+                        job = _jobs.get(job_id)
+                        if job is not None:
+                            job.status = "failed"
+                            job.error = {
+                                "code": "video_server_shutdown",
+                                "message": (
+                                    "Video generation was cancelled during "
+                                    "server shutdown."
+                                ),
+                            }
             for task in pending:
                 task.cancel()
             await asyncio.gather(*pending, return_exceptions=True)
@@ -300,11 +314,12 @@ async def _run_job(
             job.generation_finished = True
     except asyncio.CancelledError:
         with _jobs_lock:
-            job.status = "failed"
-            job.error = {
-                "code": "video_generation_cancelled",
-                "message": "Video generation was cancelled.",
-            }
+            if job.status != "failed":
+                job.status = "failed"
+                job.error = {
+                    "code": "video_generation_cancelled",
+                    "message": "Video generation was cancelled.",
+                }
         if not started:
             runner.cancel()
 

--- a/vllm_mlx/routes/video.py
+++ b/vllm_mlx/routes/video.py
@@ -217,13 +217,12 @@ def _parse_size(value: str) -> tuple[int, int]:
         raise HTTPException(
             status_code=400, detail="size must be WIDTHxHEIGHT"
         ) from exc
-    if (
-        width < 256
-        or height < 256
-        or width > 1920
-        or height > 1920
-        or width % 64
-        or height % 64
+    openai_sizes = {(1280, 720), (720, 1280)}
+    is_model_aligned = width % 64 == 0 and height % 64 == 0
+    if not (
+        256 <= width <= 1920
+        and 256 <= height <= 1920
+        and (is_model_aligned or (width, height) in openai_sizes)
     ):
         raise HTTPException(
             status_code=400,
@@ -276,6 +275,8 @@ async def _run_job(
     started = False
     output = _jobs_root / job.id / "output.mp4"
     generation_gate = _generation_gate_for_current_loop()
+    generation_width = ((width + 63) // 64) * 64
+    generation_height = ((height + 63) // 64) * 64
 
     async def generate_under_gate() -> bool:
         nonlocal started
@@ -292,12 +293,14 @@ async def _run_job(
                 engine.generate,
                 prompt=job.prompt,
                 output_path=output,
-                width=width,
-                height=height,
+                width=generation_width,
+                height=generation_height,
                 num_frames=_frame_count(seconds),
                 fps=24,
                 seed=seed,
                 image=image_path,
+                output_width=width,
+                output_height=height,
             )
             return True
 
@@ -379,7 +382,12 @@ async def create_video(
     if not 1 <= seconds_int <= 20:
         raise HTTPException(status_code=400, detail="seconds must be between 1 and 20")
     width, height = _parse_size(size)
-    if width * height * _frame_count(seconds_int) > _MAX_PIXEL_FRAMES:
+    generation_width = ((width + 63) // 64) * 64
+    generation_height = ((height + 63) // 64) * 64
+    if (
+        generation_width * generation_height * _frame_count(seconds_int)
+        > _MAX_PIXEL_FRAMES
+    ):
         raise HTTPException(
             status_code=400,
             detail=(

--- a/vllm_mlx/routes/video.py
+++ b/vllm_mlx/routes/video.py
@@ -46,10 +46,12 @@ class _VideoJob:
     completed_at: int | None = None
     error: dict[str, str] | None = None
     output_path: str | None = None
+    generation_finished: bool = False
 
     def public(self) -> dict:
         value = asdict(self)
         value.pop("output_path")
+        value.pop("generation_finished")
         value["object"] = "video"
         return value
 
@@ -102,6 +104,7 @@ async def shutdown_video_jobs(timeout: float = 30.0) -> None:
     loop = asyncio.get_running_loop()
     with _jobs_lock:
         _accepting_jobs = False
+        cancelled_job_ids: list[str] = []
         current_tasks = [
             task
             for task in _tasks.values()
@@ -115,6 +118,8 @@ async def shutdown_video_jobs(timeout: float = 30.0) -> None:
                     "code": "video_server_shutdown",
                     "message": "Video generation was cancelled during server shutdown.",
                 }
+                job.generation_finished = True
+                cancelled_job_ids.append(job_id)
                 task.cancel()
 
     if current_tasks:
@@ -128,6 +133,8 @@ async def shutdown_video_jobs(timeout: float = 30.0) -> None:
             for task in pending:
                 task.cancel()
             await asyncio.gather(*pending, return_exceptions=True)
+    for job_id in cancelled_job_ids:
+        await asyncio.to_thread(shutil.rmtree, _jobs_root / job_id, ignore_errors=True)
 
 
 async def _run_in_generation_thread(function, /, **kwargs) -> None:
@@ -146,8 +153,10 @@ async def _run_in_generation_thread(function, /, **kwargs) -> None:
     def target() -> None:
         try:
             function(**kwargs)
-        except BaseException as exc:  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
             result = exc
+        except BaseException:  # pragma: no cover - defensive thread boundary
+            result = RuntimeError("video generation worker terminated unexpectedly")
         else:
             result = None
         finally:
@@ -260,11 +269,7 @@ async def _run_job(
         # job never releases it while an uncancellable MLX thread is running.
         async with generation_gate:
             with _jobs_lock:
-                if (
-                    job.status == "failed"
-                    and job.error is not None
-                    and job.error.get("code") == "video_generation_cancelled"
-                ):
+                if job.status == "failed":
                     return False
                 started = True
                 job.status = "in_progress"
@@ -292,6 +297,7 @@ async def _run_job(
             job.progress = 100
             job.completed_at = int(time.time())
             job.output_path = str(output)
+            job.generation_finished = True
     except asyncio.CancelledError:
         with _jobs_lock:
             job.status = "failed"
@@ -305,6 +311,8 @@ async def _run_job(
         async def reap_cancelled_job() -> None:
             with contextlib.suppress(asyncio.CancelledError, Exception):
                 await runner
+            with _jobs_lock:
+                job.generation_finished = True
             await asyncio.to_thread(
                 shutil.rmtree, _jobs_root / job.id, ignore_errors=True
             )
@@ -325,6 +333,7 @@ async def _run_job(
         with _jobs_lock:
             job.status = "failed"
             job.error = {"code": "video_generation_failed", "message": message}
+            job.generation_finished = True
         await asyncio.to_thread(shutil.rmtree, _jobs_root / job.id, ignore_errors=True)
 
 
@@ -370,6 +379,7 @@ async def create_video(
     image_path = None
     enqueued = False
     evicted_id: str | None = None
+    task: asyncio.Task | None = None
     try:
         if input_reference is not None:
             image_path = job_dir / "reference.img"
@@ -405,6 +415,7 @@ async def create_video(
                     item
                     for item in _jobs.values()
                     if item.status in {"completed", "failed"}
+                    and item.generation_finished
                 ]
                 if not finished:
                     raise HTTPException(
@@ -414,22 +425,23 @@ async def create_video(
                 _jobs.pop(oldest.id, None)
                 evicted_id = oldest.id
             _jobs[job.id] = job
+            task = asyncio.create_task(
+                _run_job(
+                    job,
+                    engine=engine,
+                    width=width,
+                    height=height,
+                    seconds=seconds_int,
+                    seed=seed,
+                    image_path=image_path,
+                )
+            )
+            _tasks[job.id] = task
             enqueued = True
     finally:
         if not enqueued:
             await asyncio.to_thread(shutil.rmtree, job_dir, ignore_errors=True)
-    task = asyncio.create_task(
-        _run_job(
-            job,
-            engine=engine,
-            width=width,
-            height=height,
-            seconds=seconds_int,
-            seed=seed,
-            image_path=image_path,
-        )
-    )
-    _tasks[job.id] = task
+    assert task is not None
 
     def discard_task(done: asyncio.Task) -> None:
         if _tasks.get(job.id) is done:

--- a/vllm_mlx/runtime/video_lane.py
+++ b/vllm_mlx/runtime/video_lane.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import importlib.util
 import shutil
+import subprocess
 import sys
 import threading
 from pathlib import Path
@@ -57,6 +58,8 @@ class VideoEngine:
         fps: int,
         seed: int,
         image: Path | None,
+        output_width: int | None = None,
+        output_height: int | None = None,
     ) -> None:
         if shutil.which("ffmpeg") is None:
             raise VideoRuntimeError(
@@ -92,6 +95,40 @@ class VideoEngine:
             raise VideoRuntimeError(
                 "LTX-2.3 generation completed without an MP4 output."
             )
+        requested_width = output_width or width
+        requested_height = output_height or height
+        if (requested_width, requested_height) != (width, height):
+            cropped = output_path.with_name(f"{output_path.stem}.cropped.mp4")
+            try:
+                subprocess.run(
+                    [
+                        "ffmpeg",
+                        "-y",
+                        "-i",
+                        str(output_path),
+                        "-vf",
+                        (
+                            f"crop={requested_width}:{requested_height}:"
+                            "(iw-ow)/2:(ih-oh)/2"
+                        ),
+                        "-c:v",
+                        "libx264",
+                        "-c:a",
+                        "copy",
+                        str(cropped),
+                    ],
+                    check=True,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                )
+                cropped.replace(output_path)
+            except (OSError, subprocess.CalledProcessError) as exc:
+                raise VideoRuntimeError(
+                    "LTX-2.3 generated video but could not crop it to the "
+                    "requested OpenAI-compatible size."
+                ) from exc
+            finally:
+                cropped.unlink(missing_ok=True)
 
     def generate_warmup(self) -> None:
         """Video weights load lazily; startup must not trigger a 40+ GB pull."""

--- a/vllm_mlx/runtime/video_lane.py
+++ b/vllm_mlx/runtime/video_lane.py
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: Apache-2.0
+"""MLX-native LTX-2.3 video-generation lane."""
+
+from __future__ import annotations
+
+import shutil
+import threading
+from pathlib import Path
+
+
+class VideoRuntimeError(RuntimeError):
+    """Safe, actionable generation error suitable for the public API."""
+
+
+class VideoEngine:
+    """Thin adapter over ``mlx-video-with-audio``'s LTX-2.3 pipeline.
+
+    The upstream function owns model loading and generation. Rapid-MLX owns
+    request validation, job lifecycle, concurrency and the OpenAI-compatible
+    transport surface.
+    """
+
+    is_video_gen = True
+    _loaded = True
+
+    def __init__(self, model_name: str) -> None:
+        self.model_name = model_name
+        self._generation_lock = threading.Lock()
+
+    def generate(
+        self,
+        *,
+        prompt: str,
+        output_path: Path,
+        width: int,
+        height: int,
+        num_frames: int,
+        fps: int,
+        seed: int,
+        image: Path | None,
+    ) -> None:
+        if shutil.which("ffmpeg") is None:
+            raise VideoRuntimeError(
+                "LTX-2.3 video generation requires ffmpeg. "
+                "Install it with `brew install ffmpeg`."
+            )
+        try:
+            from mlx_video import generate_video_with_audio
+        except ImportError as exc:
+            raise VideoRuntimeError(
+                "LTX-2.3 support is not installed. "
+                "Run `pip install 'rapid-mlx[video]'`."
+            ) from exc
+
+        # The 22B pipeline is not re-entrant and a second concurrent graph can
+        # exhaust unified memory. Serialize jobs per served model.
+        with self._generation_lock:
+            generate_video_with_audio(
+                model_repo=self.model_name,
+                text_encoder_repo=None,
+                prompt=prompt,
+                height=height,
+                width=width,
+                num_frames=num_frames,
+                seed=seed,
+                fps=fps,
+                output_path=str(output_path),
+                image=str(image) if image is not None else None,
+                verbose=False,
+                enhance_prompt=False,
+            )
+        if not output_path.is_file() or output_path.stat().st_size == 0:
+            raise VideoRuntimeError(
+                "LTX-2.3 generation completed without an MP4 output."
+            )
+
+    def generate_warmup(self) -> None:
+        """Video weights load lazily; startup must not trigger a 40+ GB pull."""
+
+    async def stop(self) -> None:
+        """No persistent worker is owned by this thin adapter."""

--- a/vllm_mlx/runtime/video_lane.py
+++ b/vllm_mlx/runtime/video_lane.py
@@ -3,13 +3,32 @@
 
 from __future__ import annotations
 
+import importlib.util
 import shutil
+import sys
 import threading
 from pathlib import Path
 
 
 class VideoRuntimeError(RuntimeError):
     """Safe, actionable generation error suitable for the public API."""
+
+
+def require_video_runtime_or_exit() -> None:
+    """Fail before model download when the optional video stack is absent."""
+    missing = []
+    if importlib.util.find_spec("mlx_video") is None:
+        missing.append("the `rapid-mlx[video]` Python extra")
+    if shutil.which("ffmpeg") is None:
+        missing.append("ffmpeg (`brew install ffmpeg`)")
+    if missing:
+        print(
+            "\n  Error: LTX-2.3 video generation requires "
+            + " and ".join(missing)
+            + ".\n",
+            file=sys.stderr,
+        )
+        raise SystemExit(2)
 
 
 class VideoEngine:

--- a/vllm_mlx/runtime/video_lane.py
+++ b/vllm_mlx/runtime/video_lane.py
@@ -15,6 +15,9 @@ class VideoRuntimeError(RuntimeError):
     """Safe, actionable generation error suitable for the public API."""
 
 
+_PROCESS_GENERATION_LOCK = threading.Lock()
+
+
 def require_video_runtime_or_exit() -> None:
     """Fail before model download when the optional video stack is absent."""
     missing = []
@@ -45,7 +48,10 @@ class VideoEngine:
 
     def __init__(self, model_name: str) -> None:
         self.model_name = model_name
-        self._generation_lock = threading.Lock()
+        # Shared across engine instances and app lifespans. A bounded shutdown
+        # may detach an old daemon worker; an in-process restart must not run a
+        # second Metal graph concurrently with that still-draining worker.
+        self._generation_lock = _PROCESS_GENERATION_LOCK
 
     def generate(
         self,

--- a/vllm_mlx/runtime/video_lane.py
+++ b/vllm_mlx/runtime/video_lane.py
@@ -120,9 +120,14 @@ class VideoEngine:
                     check=True,
                     stdout=subprocess.DEVNULL,
                     stderr=subprocess.DEVNULL,
+                    timeout=120,
                 )
                 cropped.replace(output_path)
-            except (OSError, subprocess.CalledProcessError) as exc:
+            except (
+                OSError,
+                subprocess.CalledProcessError,
+                subprocess.TimeoutExpired,
+            ) as exc:
                 raise VideoRuntimeError(
                     "LTX-2.3 generated video but could not crop it to the "
                     "requested OpenAI-compatible size."

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -1726,7 +1726,16 @@ def load_model(
     # already-resolved alias profile so the same call (alias-name or
     # full HF path) lands on the right lane without re-resolving.
     _profile_modality = _profile.modality if _profile is not None else "text"
-    if _profile_modality == "text-diffusion":
+    if _profile_modality == "video-gen":
+        from .runtime.video_lane import VideoEngine
+
+        _video_hf_path = _profile.hf_path if _profile is not None else model_name
+        logger.info(
+            f"Loading model with VideoEngine (modality=video-gen): {_video_hf_path}"
+        )
+        _engine = VideoEngine(model_name=_video_hf_path)
+        logger.info(f"Video model ready for lazy generation: {model_name}")
+    elif _profile_modality == "text-diffusion":
         from .runtime.diffusion_lane import DiffusionEngine
 
         # ``python -m vllm_mlx.server --model <alias>`` bypasses
@@ -2022,6 +2031,7 @@ from .routes.mcp_routes import router as _mcp_router
 from .routes.metrics import router as _metrics_router
 from .routes.models import router as _models_router
 from .routes.responses import router as _responses_router
+from .routes.video import router as _video_router
 
 app.include_router(_probe_router)
 app.include_router(_health_router)
@@ -2034,6 +2044,7 @@ app.include_router(_chat_router)
 app.include_router(_completions_router)
 app.include_router(_anthropic_router)
 app.include_router(_responses_router)
+app.include_router(_video_router)
 app.include_router(_embeddings_router)
 app.include_router(_mcp_router)
 # Task #292: ``_audio_router`` is registered LAZILY (after model load) by

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -751,6 +751,12 @@ from .routes.audio import install_audio_body_limit_middleware  # noqa: E402
 
 install_audio_body_limit_middleware(app)
 
+# SECURITY: video multipart auth/body cap must run before Starlette spools an
+# UploadFile. It also owns the 21 MiB request allowance for the 20 MiB file cap.
+from .routes.video import install_video_body_limit_middleware  # noqa: E402
+
+install_video_body_limit_middleware(app)
+
 # SECURITY: blanket request-body size cap across all /v1/* routes.
 # Defends against the DoS pattern documented in rapid-desktop#273 / #463
 # where a 10–100 MB JSON body silently runs full prefill (~60–90 s on a

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -645,6 +645,9 @@ async def lifespan(app: FastAPI):
     # starts returning 200. Anything that races a request before this point
     # would otherwise hit a not-yet-warmed engine.
     _cfg = get_config()
+    from .routes.video import start_video_jobs
+
+    start_video_jobs()
     _cfg.ready = True
 
     # Print the real "Ready:" banner now — only here is the port truly
@@ -695,6 +698,9 @@ async def lifespan(app: FastAPI):
     # ``is_enabled()``-gated and ``@_safe`` → a no-op when telemetry is off
     # and never masks the failure.
     try:
+        from .routes.video import shutdown_video_jobs
+
+        await shutdown_video_jobs()
         await _shutdown_save_prefix_cache()
 
         # Shutdown: Close MCP connections and stop engine


### PR DESCRIPTION
## What changed

- adds a dedicated `video-gen` runtime lane and the `ltx-2.3-mlx-q4` alias
- integrates the MLX-native `mlx-video-with-audio==0.1.36` pipeline as the optional `[video]` extra
- implements OpenAI-compatible asynchronous video jobs:
  - `POST /v1/videos` for T2V and I2V
  - `GET /v1/videos/{id}` and `GET /v1/videos/{id}/content`
  - list and delete endpoints
- generates synchronized audio and MP4 output locally on Apple Silicon
- documents installation, memory/disk requirements, polling, and I2V usage

## Why

LTX-2.3 is the current open-weight LTX audio-video model, but Rapid-MLX had no
video-generation lane or Videos API. This adds a native MLX path without
affecting text, vision, audio, or text-diffusion servers.

The default checkpoint is `notapalindrome/ltx23-mlx-av-q4` (22.8 GB). It is
the split-format LTX-2.3 Q4 model explicitly supported by the pinned runtime;
the alias warns below 24 GB unified memory.

## User impact

```bash
pip install 'rapid-mlx[video]'
brew install ffmpeg
rapid-mlx serve ltx-2.3-mlx-q4
```

Users can then create T2V jobs with the OpenAI Videos API shape, or attach an
`input_reference` image for I2V. Jobs are serialized to avoid concurrent 22B
graphs exhausting unified memory. Output is retained only for the lifetime of
the server process.

## Validation

- `ruff check` and `ruff format --check`
- 2,582 targeted/contract tests passed
- local wheel build passed; video route, runtime lane, aliases, and size
  manifest are present in the wheel
- independent Codex review completed; its pinned-modality finding was fixed
- dependency resolver and MIT package license inspected

## Notes

- `ffmpeg` is required for MP4 audio muxing
- first generation downloads 22.8 GB of weights
- no real-weight generation is run in CI because the checkpoint is too large;
  the public upstream call contract and complete job lifecycle are covered with
  a deterministic fake engine
