### PR TITLE
feat(audio): word-level timestamps on /v1/audio/transcriptions [skip-version-bump]

### DIFF
--- a/tests/test_audio_upload_size_limit.py
+++ b/tests/test_audio_upload_size_limit.py
@@ -215,9 +215,20 @@ def test_streaming_cap_rejects_chunked_upload_before_engine_load(monkeypatch):
                 model_form="whisper-small",
                 language_form=None,
                 response_format_form=None,
+                # STT-word-timestamps: the route gained
+                # ``timestamp_granularities[]`` form/query sources. This
+                # test calls the handler directly (bypassing FastAPI's
+                # dependency resolution), so — like the model/language/
+                # response_format params above — the new sources must be
+                # passed explicitly as ``None`` rather than left at their
+                # ``Form``/``Query`` sentinel defaults.
+                timestamp_granularities_bracket_form=None,
+                timestamp_granularities_plain_form=None,
                 model_query=None,
                 language_query=None,
                 response_format_query=None,
+                timestamp_granularities_bracket_query=None,
+                timestamp_granularities_plain_query=None,
             )
         )
 

--- a/tests/test_forced_alignment.py
+++ b/tests/test_forced_alignment.py
@@ -372,6 +372,47 @@ class TestAlignmentRoute:
         assert first["end"] == 0.5
         assert first["text"] == "你"
 
+    def test_segment_granularity_keeps_forced_alignment_path(self, _stub_route_engine):
+        """Rebased word-timestamp plumbing must not reroute aligner requests."""
+        client, restore = _mount_audio_app()
+        try:
+            r = _post(
+                client,
+                {
+                    "model": "qwen3-aligner",
+                    "text": "你好世界",
+                    "response_format": "verbose_json",
+                    "timestamp_granularities[]": "segment",
+                },
+            )
+        finally:
+            restore()
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["text"] == "你好世界"
+        assert len(body["segments"]) == 4
+        assert "words" not in body
+        assert _ALIGN_CALLS[-1]["text"] == "你好世界"
+
+    def test_word_granularity_rejects_forced_aligner(self, _stub_route_engine):
+        client, restore = _mount_audio_app()
+        try:
+            r = _post(
+                client,
+                {
+                    "model": "qwen3-aligner",
+                    "text": "你好世界",
+                    "response_format": "verbose_json",
+                    "timestamp_granularities[]": "word",
+                },
+            )
+        finally:
+            restore()
+        assert r.status_code == 400, r.text
+        error = r.json()["detail"]["error"]
+        assert error["code"] == "invalid_model_for_word_timestamps"
+        assert error["param"] == "timestamp_granularities"
+
     def test_srt_renders_character_cues(self, _stub_route_engine):
         client, restore = _mount_audio_app()
         try:

--- a/tests/test_transcription_word_timestamps.py
+++ b/tests/test_transcription_word_timestamps.py
@@ -1,0 +1,510 @@
+# SPDX-License-Identifier: Apache-2.0
+"""STT-word-timestamps — word-level timestamps on ``/v1/audio/transcriptions``.
+
+OpenAI's Whisper API accepts ``timestamp_granularities[]`` (``word`` /
+``segment``) on the transcription request and, for ``response_format=
+verbose_json``, returns a top-level ``words`` array of
+``{word, start, end}`` when word granularity is requested. Pre-feature the
+route parsed ``model`` / ``language`` / ``response_format`` from the
+multipart form but silently dropped ``timestamp_granularities[]``, so
+word-level captions were impossible.
+
+These tests pin the new contract without downloading weights:
+
+* the request Pydantic model accepts the field;
+* ``_normalise_timestamp_granularities`` validates + de-dups values;
+* ``_iter_words_for_verbose`` / ``_build_verbose_json_body`` emit the
+  OpenAI word shape only when requested and omit it otherwise;
+* ``STTEngine.transcribe`` forwards ``word_timestamps=True`` to a Whisper
+  backend only when ``word`` is requested, and never forwards the flag to
+  a non-Whisper (Parakeet) backend (which would raise);
+* the full route path (TestClient + a stubbed engine) returns a non-empty,
+  monotonic ``words`` array for ``verbose_json`` + ``word``.
+"""
+
+from __future__ import annotations
+
+import importlib.machinery
+import io
+import math
+import struct
+import sys
+import types
+import wave
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_tone_wav(duration_s: float = 0.25, freq_hz: float = 440.0) -> bytes:
+    sample_rate = 16000
+    n_samples = int(sample_rate * duration_s)
+    buf = io.BytesIO()
+    with wave.open(buf, "wb") as w:
+        w.setnchannels(1)
+        w.setsampwidth(2)
+        w.setframerate(sample_rate)
+        for i in range(n_samples):
+            sample = int(8000 * math.sin(2 * math.pi * freq_hz * i / sample_rate))
+            w.writeframes(struct.pack("<h", sample))
+    return buf.getvalue()
+
+
+class _FakeWordResult:
+    """Whisper-shaped result: segments carry a ``words`` list of the
+    mlx-audio ``{word, start, end, probability}`` dict shape."""
+
+    text = "hello world"
+    language = "en"
+    duration = 1.4
+    segments = [
+        {
+            "start": 0.0,
+            "end": 0.7,
+            "text": "hello",
+            "words": [
+                {"word": "hello", "start": 0.0, "end": 0.5, "probability": 0.99},
+            ],
+        },
+        {
+            "start": 0.7,
+            "end": 1.4,
+            "text": "world",
+            "words": [
+                {"word": "world", "start": 0.7, "end": 1.2, "probability": 0.98},
+            ],
+        },
+    ]
+
+
+class _FakeNoWordResult:
+    """Non-Whisper-shaped result: segments have NO ``words`` list."""
+
+    text = "hello world"
+    language = "en"
+    duration = 1.4
+    segments = [
+        {"start": 0.0, "end": 1.4, "text": "hello world"},
+    ]
+
+
+class _FakeEngine:
+    """Mirrors the ``STTEngine`` surface the route depends on.
+
+    Accepts the new ``timestamp_granularities`` kwarg and returns a
+    word-laden result only when ``word`` is requested, so both the
+    words-present and words-absent route branches are exercised
+    deterministically.
+    """
+
+    def __init__(self, model_name: str):
+        self.model_name = model_name
+
+    def load(self):
+        pass
+
+    def transcribe(
+        self, audio_path, language=None, task="transcribe", timestamp_granularities=None
+    ):
+        if timestamp_granularities and "word" in timestamp_granularities:
+            return _FakeWordResult()
+        return _FakeNoWordResult()
+
+
+@pytest.fixture
+def _stub_engine(monkeypatch):
+    """Stub the STTEngine + mlx_audio probe so the route runs without weights."""
+    from vllm_mlx.audio import probe
+    from vllm_mlx.routes import audio as audio_route
+
+    fake_mlx_audio = types.ModuleType("mlx_audio")
+    fake_mlx_audio.__path__ = []
+    fake_mlx_audio.__spec__ = importlib.machinery.ModuleSpec(
+        "mlx_audio", loader=None, is_package=True
+    )
+    fake_stt = types.ModuleType("mlx_audio.stt")
+    fake_stt.__path__ = []
+    fake_stt.__spec__ = importlib.machinery.ModuleSpec(
+        "mlx_audio.stt", loader=None, is_package=True
+    )
+    fake_stt_utils = types.ModuleType("mlx_audio.stt.utils")
+    fake_stt_utils.__spec__ = importlib.machinery.ModuleSpec(
+        "mlx_audio.stt.utils", loader=None
+    )
+    fake_stt_utils.load_model = lambda *_a, **_kw: None
+    monkeypatch.setitem(sys.modules, "mlx_audio", fake_mlx_audio)
+    monkeypatch.setitem(sys.modules, "mlx_audio.stt", fake_stt)
+    monkeypatch.setitem(sys.modules, "mlx_audio.stt.utils", fake_stt_utils)
+
+    probe._reset_probe_cache()
+
+    monkeypatch.setattr("vllm_mlx.audio.stt.STTEngine", _FakeEngine, raising=False)
+    audio_stt_mod = sys.modules.get("vllm_mlx.audio.stt")
+    if audio_stt_mod is not None:
+        monkeypatch.setattr(audio_stt_mod, "STTEngine", _FakeEngine)
+
+    audio_route._stt_engine = None
+    yield
+    audio_route._stt_engine = None
+    probe._reset_probe_cache()
+
+
+def _mount_audio_app() -> tuple[TestClient, callable]:
+    from vllm_mlx.config import get_config
+    from vllm_mlx.routes import audio as audio_route
+
+    app = FastAPI()
+    app.include_router(audio_route.router)
+    cfg = get_config()
+    saved = cfg.api_key
+    cfg.api_key = None
+
+    def _restore():
+        cfg.api_key = saved
+
+    return TestClient(app), _restore
+
+
+def _post(client, data):
+    return client.post(
+        "/v1/audio/transcriptions",
+        data=data,
+        files={"file": ("tone.wav", _make_tone_wav(), "audio/wav")},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Request model
+# ---------------------------------------------------------------------------
+
+
+class TestRequestModel:
+    def test_accepts_timestamp_granularities(self):
+        from vllm_mlx.api.models import AudioTranscriptionRequest
+
+        req = AudioTranscriptionRequest(
+            model="whisper-large-v3",
+            response_format="verbose_json",
+            timestamp_granularities=["word", "segment"],
+        )
+        assert req.timestamp_granularities == ["word", "segment"]
+
+    def test_default_is_none(self):
+        from vllm_mlx.api.models import AudioTranscriptionRequest
+
+        assert AudioTranscriptionRequest().timestamp_granularities is None
+
+
+# ---------------------------------------------------------------------------
+# Granularity normalisation
+# ---------------------------------------------------------------------------
+
+
+class TestNormaliseGranularities:
+    def test_none_and_empty_resolve_to_none(self):
+        from vllm_mlx.routes.audio import _normalise_timestamp_granularities
+
+        assert _normalise_timestamp_granularities(None) is None
+        assert _normalise_timestamp_granularities([]) is None
+
+    def test_lowercases_and_dedups(self):
+        from vllm_mlx.routes.audio import _normalise_timestamp_granularities
+
+        assert _normalise_timestamp_granularities(["Word", "word", "SEGMENT"]) == [
+            "word",
+            "segment",
+        ]
+
+    def test_invalid_value_raises_400(self):
+        from fastapi import HTTPException
+
+        from vllm_mlx.routes.audio import _normalise_timestamp_granularities
+
+        with pytest.raises(HTTPException) as exc:
+            _normalise_timestamp_granularities(["words"])
+        assert exc.value.status_code == 400
+        assert exc.value.detail["error"]["param"] == "timestamp_granularities"
+
+
+# ---------------------------------------------------------------------------
+# verbose_json builder / word flattener
+# ---------------------------------------------------------------------------
+
+
+class TestVerboseJsonBuilder:
+    def test_words_omitted_by_default(self):
+        from vllm_mlx.routes.audio import _build_verbose_json_body
+
+        body = _build_verbose_json_body(_FakeWordResult(), timestamp_granularities=None)
+        # Default (no granularities) is unchanged: segments present, no words.
+        assert "segments" in body
+        assert "words" not in body
+
+    def test_segment_only_has_no_words(self):
+        from vllm_mlx.routes.audio import _build_verbose_json_body
+
+        body = _build_verbose_json_body(
+            _FakeWordResult(), timestamp_granularities=["segment"]
+        )
+        assert "segments" in body
+        assert "words" not in body
+
+    def test_word_only_emits_words_and_drops_segments(self):
+        from vllm_mlx.routes.audio import _build_verbose_json_body
+
+        body = _build_verbose_json_body(
+            _FakeWordResult(), timestamp_granularities=["word"]
+        )
+        assert "segments" not in body
+        assert body["words"] == [
+            {"word": "hello", "start": 0.0, "end": 0.5},
+            {"word": "world", "start": 0.7, "end": 1.2},
+        ]
+        # Exactly the three OpenAI keys — no leaked ``probability``.
+        for w in body["words"]:
+            assert set(w.keys()) == {"word", "start", "end"}
+            assert isinstance(w["start"], float)
+            assert isinstance(w["end"], float)
+
+    def test_both_granularities_emit_both(self):
+        from vllm_mlx.routes.audio import _build_verbose_json_body
+
+        body = _build_verbose_json_body(
+            _FakeWordResult(), timestamp_granularities=["word", "segment"]
+        )
+        assert len(body["segments"]) == 2
+        assert len(body["words"]) == 2
+
+    def test_non_whisper_result_yields_empty_words_not_crash(self):
+        from vllm_mlx.routes.audio import _build_verbose_json_body
+
+        # A backend that produced no per-word data must degrade to an
+        # empty words array, never raise.
+        body = _build_verbose_json_body(
+            _FakeNoWordResult(), timestamp_granularities=["word"]
+        )
+        assert body["words"] == []
+
+
+# ---------------------------------------------------------------------------
+# STTEngine forwarding
+# ---------------------------------------------------------------------------
+
+
+class _RecordingModel:
+    """Fake mlx-audio model whose ``generate`` records the kwargs it saw."""
+
+    def __init__(self):
+        self.seen_kwargs = None
+
+    def generate(self, audio_input, **kwargs):
+        self.seen_kwargs = kwargs
+        return _FakeWordResult()
+
+
+class TestEngineForwarding:
+    def _make_engine(self, model_name):
+        from vllm_mlx.audio.stt import STTEngine
+
+        eng = STTEngine(model_name, enable_vad_pretrim=False)
+        eng._loaded = True
+        eng.model = _RecordingModel()
+        return eng
+
+    def test_whisper_forwards_word_timestamps_when_word_requested(self, tmp_path):
+        eng = self._make_engine("mlx-community/whisper-large-v3-turbo")
+        wav = tmp_path / "a.wav"
+        wav.write_bytes(_make_tone_wav())
+        eng.transcribe(str(wav), timestamp_granularities=["word"])
+        assert eng.model.seen_kwargs.get("word_timestamps") is True
+
+    def test_whisper_omits_flag_without_word_granularity(self, tmp_path):
+        eng = self._make_engine("mlx-community/whisper-large-v3-turbo")
+        wav = tmp_path / "a.wav"
+        wav.write_bytes(_make_tone_wav())
+        eng.transcribe(str(wav), timestamp_granularities=["segment"])
+        assert "word_timestamps" not in eng.model.seen_kwargs
+
+    def test_parakeet_never_gets_word_timestamps(self, tmp_path):
+        # Parakeet's generate() has no word_timestamps kwarg; forwarding it
+        # would raise. The engine must omit it even when word is requested.
+        eng = self._make_engine("mlx-community/parakeet-tdt-0.6b-v2")
+        wav = tmp_path / "a.wav"
+        wav.write_bytes(_make_tone_wav())
+        result = eng.transcribe(str(wav), timestamp_granularities=["word"])
+        assert "word_timestamps" not in eng.model.seen_kwargs
+        assert result.text  # did not crash
+
+
+# ---------------------------------------------------------------------------
+# Full route (TestClient) — hermetic
+# ---------------------------------------------------------------------------
+
+
+class TestRouteWordTimestamps:
+    def test_default_verbose_json_has_no_words(self, _stub_engine):
+        client, restore = _mount_audio_app()
+        try:
+            r = _post(
+                client, {"model": "whisper-large-v3", "response_format": "verbose_json"}
+            )
+        finally:
+            restore()
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert "segments" in body
+        assert "words" not in body
+
+    def test_word_granularity_emits_monotonic_words(self, _stub_engine):
+        client, restore = _mount_audio_app()
+        try:
+            r = client.post(
+                "/v1/audio/transcriptions",
+                data={
+                    "model": "whisper-large-v3",
+                    "response_format": "verbose_json",
+                    "timestamp_granularities[]": "word",
+                },
+                files={"file": ("tone.wav", _make_tone_wav(), "audio/wav")},
+            )
+        finally:
+            restore()
+        assert r.status_code == 200, r.text
+        body = r.json()
+        words = body.get("words")
+        assert isinstance(words, list) and len(words) >= 1, body
+        prev_end = -1.0
+        for w in words:
+            assert set(w.keys()) == {"word", "start", "end"}
+            assert w["start"] <= w["end"]
+            assert w["start"] >= prev_end - 1e-6
+            prev_end = w["end"]
+
+    def test_invalid_granularity_returns_400(self, _stub_engine):
+        client, restore = _mount_audio_app()
+        try:
+            r = client.post(
+                "/v1/audio/transcriptions",
+                data={
+                    "model": "whisper-large-v3",
+                    "response_format": "verbose_json",
+                    "timestamp_granularities[]": "words",
+                },
+                files={"file": ("tone.wav", _make_tone_wav(), "audio/wav")},
+            )
+        finally:
+            restore()
+        assert r.status_code == 400, r.text
+
+    def test_granularity_without_verbose_json_is_400(self, _stub_engine):
+        # OpenAI contract: timestamp_granularities[] requires verbose_json.
+        client, restore = _mount_audio_app()
+        try:
+            r = client.post(
+                "/v1/audio/transcriptions",
+                data={
+                    "model": "whisper-large-v3",
+                    "response_format": "json",
+                    "timestamp_granularities[]": "word",
+                },
+                files={"file": ("tone.wav", _make_tone_wav(), "audio/wav")},
+            )
+        finally:
+            restore()
+        assert r.status_code == 400, r.text
+        assert r.json()["detail"]["error"]["param"] == "timestamp_granularities"
+
+    def test_word_granularity_on_non_whisper_is_400(self, _stub_engine):
+        # Word timings are Whisper-only; a non-Whisper model must 400 rather
+        # than return an empty words[] that falsely claims fulfillment.
+        client, restore = _mount_audio_app()
+        try:
+            r = client.post(
+                "/v1/audio/transcriptions",
+                data={
+                    "model": "parakeet",
+                    "response_format": "verbose_json",
+                    "timestamp_granularities[]": "word",
+                },
+                files={"file": ("tone.wav", _make_tone_wav(), "audio/wav")},
+            )
+        finally:
+            restore()
+        assert r.status_code == 400, r.text
+        assert (
+            r.json()["detail"]["error"]["code"] == "invalid_model_for_word_timestamps"
+        )
+
+    def test_segment_granularity_on_non_whisper_is_ok(self, _stub_engine):
+        # segment-level timestamps work on every engine — no rejection.
+        client, restore = _mount_audio_app()
+        try:
+            r = client.post(
+                "/v1/audio/transcriptions",
+                data={
+                    "model": "parakeet",
+                    "response_format": "verbose_json",
+                    "timestamp_granularities[]": "segment",
+                },
+                files={"file": ("tone.wav", _make_tone_wav(), "audio/wav")},
+            )
+        finally:
+            restore()
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert "segments" in body
+        assert "words" not in body
+
+
+# ---------------------------------------------------------------------------
+# Request-model validation + malformed-word robustness
+# ---------------------------------------------------------------------------
+
+
+class TestRequestModelValidation:
+    def test_rejects_unknown_value(self):
+        from pydantic import ValidationError
+
+        from vllm_mlx.api.models import AudioTranscriptionRequest
+
+        with pytest.raises(ValidationError):
+            AudioTranscriptionRequest(timestamp_granularities=["frame"])
+
+    def test_normalises_and_dedups(self):
+        from vllm_mlx.api.models import AudioTranscriptionRequest
+
+        req = AudioTranscriptionRequest(
+            timestamp_granularities=["Word", "word", "SEGMENT"]
+        )
+        assert req.timestamp_granularities == ["word", "segment"]
+
+
+class TestMalformedWordTimings:
+    def test_non_finite_and_non_numeric_words_dropped(self):
+        from vllm_mlx.routes.audio import _iter_words_for_verbose
+
+        class _Result:
+            segments = [
+                {
+                    "words": [
+                        {"word": "ok", "start": 0.0, "end": 0.5},
+                        {"word": "nan", "start": float("nan"), "end": 1.0},
+                        {"word": "inf", "start": 1.0, "end": float("inf")},
+                        {"word": "bad", "start": "x", "end": 2.0},
+                        {"word": "missing", "start": None, "end": None},
+                    ]
+                }
+            ]
+
+        words = _iter_words_for_verbose(_Result())
+        # Only the clean word survives. NaN / inf / non-numeric / missing
+        # timings are all dropped — never fabricated into a 0.0 timestamp.
+        rendered = [w["word"] for w in words]
+        assert rendered == ["ok"], rendered
+        for w in words:
+            assert math.isfinite(w["start"]) and math.isfinite(w["end"])

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -2510,14 +2510,58 @@ class MCPExecuteResponse(BaseModel):
 # =============================================================================
 
 
+#: OpenAI's documented ``timestamp_granularities[]`` enum values. The
+#: multipart route (``routes/audio.py``) is the runtime gate; this mirror
+#: keeps the public request schema self-validating so generated clients
+#: reject bad values too.
+_TIMESTAMP_GRANULARITY_VALUES: frozenset[str] = frozenset(("word", "segment"))
+
+
 class AudioTranscriptionRequest(BaseModel):
-    """Request for audio transcription (STT)."""
+    """Request for audio transcription (STT).
+
+    ``timestamp_granularities`` maps OpenAI's ``timestamp_granularities[]``
+    field: a subset of ``{"word", "segment"}`` requesting per-word and/or
+    per-segment timestamps in the ``verbose_json`` response. The route
+    validates the wire value (it arrives as a multipart form array, not
+    JSON); the validator below keeps this Pydantic surface honest for any
+    caller that constructs the model directly.
+    """
 
     model: str = "whisper-large-v3"
     language: str | None = None
     response_format: str = "json"
     temperature: float = 0.0
-    timestamp_granularities: list[str] | None = None
+    # ``Literal`` (not bare ``list[str]``) so the generated JSON Schema /
+    # OpenAPI advertises the enum and downstream clients reject bad values;
+    # the ``mode="before"`` validator still normalises case/whitespace and
+    # de-dups before this enum check runs.
+    timestamp_granularities: list[Literal["word", "segment"]] | None = None
+
+    @field_validator("timestamp_granularities", mode="before")
+    @classmethod
+    def _validate_timestamp_granularities(cls, value):
+        """Normalise + validate ``timestamp_granularities`` against the
+        OpenAI enum. ``None``/empty → ``None``; unknown values raise so
+        the schema advertises the same contract the route enforces."""
+        if value is None:
+            return None
+        if not isinstance(value, (list, tuple)):
+            raise ValueError("timestamp_granularities must be a list of strings")
+        normalised: list[str] = []
+        for item in value:
+            if not isinstance(item, str):
+                raise ValueError("timestamp_granularities entries must be strings")
+            g = item.strip().lower()
+            if g not in _TIMESTAMP_GRANULARITY_VALUES:
+                allowed = ", ".join(sorted(_TIMESTAMP_GRANULARITY_VALUES))
+                raise ValueError(
+                    f"timestamp_granularities values must each be one of: "
+                    f"{allowed}; got {item!r}"
+                )
+            if g not in normalised:
+                normalised.append(g)
+        return normalised or None
 
 
 class AudioTranscriptionResponse(BaseModel):

--- a/vllm_mlx/audio/stt.py
+++ b/vllm_mlx/audio/stt.py
@@ -651,6 +651,18 @@ class STTEngine:
         # pre-bundle; the comment is here so the call sites are
         # discoverable from the function definition.
         task: str = "transcribe",
+        # STT-word-timestamps: OpenAI's ``timestamp_granularities[]`` maps
+        # here. When the list contains ``"word"`` and the backend is a
+        # Whisper family model, we ask mlx-audio's whisper ``generate`` for
+        # per-word timings (``word_timestamps=True``) so each returned
+        # segment carries a ``words`` list of ``{word, start, end,
+        # probability}``. Non-Whisper backends (Parakeet, etc.) do not
+        # expose the flag; we omit it for them so they never raise, and the
+        # route simply reports whatever word data (if any) the segments
+        # already carry. ``None``/empty preserves the pre-feature behavior
+        # exactly (no extra decoding cost, no signature change for callers
+        # that never request granularities).
+        timestamp_granularities: list[str] | None = None,
     ) -> TranscriptionResult:
         """
         Transcribe audio file to text.
@@ -661,6 +673,10 @@ class STTEngine:
             task: "transcribe" or "translate" (translate to English).
                 Forwarded to ``model.generate`` for Whisper engines;
                 ignored by Parakeet (which is English-only).
+            timestamp_granularities: OpenAI ``timestamp_granularities[]``
+                values (subset of ``{"word", "segment"}``). ``"word"``
+                requests per-word timings on Whisper engines; ignored by
+                non-Whisper backends.
 
         Returns:
             TranscriptionResult with text and metadata
@@ -726,6 +742,20 @@ class STTEngine:
                     kwargs["language"] = language
                 if task:
                     kwargs["task"] = task
+
+            # STT-word-timestamps: only Whisper's ``generate`` accepts
+            # ``word_timestamps``. Guard on ``self._is_whisper`` so a
+            # ``timestamp_granularities=["word"]`` request against a
+            # Parakeet / non-Whisper backend degrades to segment-level
+            # output instead of raising a TypeError (which the route would
+            # otherwise surface as a 500). Whisper attaches a per-segment
+            # ``words`` list of ``{word, start, end, probability}`` when the
+            # flag is set.
+            want_word_timestamps = (
+                bool(timestamp_granularities) and "word" in timestamp_granularities
+            )
+            if want_word_timestamps and self._is_whisper and not self._is_parakeet:
+                kwargs["word_timestamps"] = True
 
             # Choose the input Whisper actually sees: either the
             # VAD-trimmed waveform (mono 16 kHz) or the original file

--- a/vllm_mlx/routes/audio.py
+++ b/vllm_mlx/routes/audio.py
@@ -4,6 +4,7 @@
 import base64
 import binascii
 import logging
+import math
 import os
 import re
 import tempfile
@@ -401,6 +402,57 @@ def _reject_non_whisper_for_translation(model: str) -> None:
     )
 
 
+def _reject_word_timestamps_for_non_whisper(
+    model: str, timestamp_granularities: list[str] | None
+) -> None:
+    """Reject ``timestamp_granularities[]=word`` on non-Whisper engines.
+
+    Only the Whisper family produces per-word timings: mlx-audio's whisper
+    ``generate`` accepts ``word_timestamps=True`` and attaches a per-word
+    list to each segment. Parakeet / other STT engines don't expose the
+    flag, so honoring a ``word`` request against them would return an empty
+    ``words`` array that FALSELY signals the granularity was fulfilled.
+    Reject up front with a 400 (mirroring the Whisper-only routing the
+    translations lane already uses) so callers get an actionable error
+    instead of a misleading 200. ``segment`` granularity is unaffected —
+    every STT engine reports segments.
+
+    Classification mirrors ``_reject_non_whisper_for_translation``: alias
+    is resolved to its upstream id first; unknown bare aliases fall through
+    so ``_resolve_stt_model`` still emits the 404 ``model_not_found``
+    envelope (keeping the error surface consistent with transcriptions).
+    """
+    if not timestamp_granularities or "word" not in timestamp_granularities:
+        return
+    if not isinstance(model, str) or not model:
+        return
+    resolved = STT_MODEL_ALIASES.get(model, model)
+    if "whisper" in resolved.lower():
+        return
+    # Unknown bare alias → let ``_resolve_stt_model`` 404 it so the
+    # envelope matches the unknown-model path rather than this 400.
+    if "/" not in model and model not in STT_MODEL_ALIASES:
+        return
+    raise HTTPException(
+        status_code=400,
+        detail={
+            "error": {
+                "message": (
+                    f"The model `{model}` cannot produce word-level "
+                    "timestamps. `timestamp_granularities[]=word` requires a "
+                    "Whisper engine (e.g. `whisper-large-v3` or "
+                    "`whisper-large-v3-turbo`). Drop `word` (segment-level "
+                    "timestamps work on every STT engine) or switch to a "
+                    "Whisper model."
+                ),
+                "type": "invalid_request_error",
+                "code": "invalid_model_for_word_timestamps",
+                "param": "timestamp_granularities",
+            }
+        },
+    )
+
+
 class AudioBodyLimitMiddleware:
     """ASGI middleware that bounds the request body of audio-upload
     routes BEFORE Starlette's multipart parser can spool it.
@@ -648,6 +700,50 @@ def _validate_response_format(response_format: str | None) -> str:
     return response_format
 
 
+#: OpenAI's documented ``timestamp_granularities[]`` values. ``word``
+#: yields per-word timings; ``segment`` yields per-segment cues.
+_STT_TIMESTAMP_GRANULARITIES: frozenset[str] = frozenset(("word", "segment"))
+
+
+def _normalise_timestamp_granularities(
+    values: list[str] | None,
+) -> list[str] | None:
+    """Validate + de-duplicate OpenAI ``timestamp_granularities[]`` values.
+
+    Returns ``None`` when nothing usable was requested (field omitted or
+    empty list) so downstream code can treat "no granularities" as the
+    pre-feature default. Each value is lower-cased and checked against
+    OpenAI's two-value set; an unknown value raises a 400 with the same
+    ``invalid_request_error`` envelope the rest of the route uses, so a
+    typo (``"words"``) fails cheaply BEFORE the upload drains — mirroring
+    ``_validate_response_format``.
+    """
+    if not values:
+        return None
+    normalised: list[str] = []
+    for raw in values:
+        value = (raw or "").strip().lower()
+        if value not in _STT_TIMESTAMP_GRANULARITIES:
+            available = ", ".join(sorted(_STT_TIMESTAMP_GRANULARITIES))
+            raise HTTPException(
+                status_code=400,
+                detail={
+                    "error": {
+                        "message": (
+                            "`timestamp_granularities[]` values must each be "
+                            f"one of: {available}; got {raw!r}."
+                        ),
+                        "type": "invalid_request_error",
+                        "code": "invalid_request",
+                        "param": "timestamp_granularities",
+                    }
+                },
+            )
+        if value not in normalised:
+            normalised.append(value)
+    return normalised or None
+
+
 def _format_srt_timestamp(seconds: float) -> str:
     """Format a float second offset as the SRT timestamp ``HH:MM:SS,mmm``.
 
@@ -742,21 +838,129 @@ def _build_vtt_body(result) -> str:
     return "\n".join(lines)
 
 
-def _build_verbose_json_body(result) -> dict:
+def _finite_or_none(value) -> float | None:
+    """Parse ``value`` as a finite float for a word-timestamp field.
+
+    Returns the finite float when ``value`` parses cleanly, or ``None`` for
+    anything the caller must drop: a missing (``None``) timing, a
+    non-numeric value, or a NaN / infinity. Nothing is defaulted or
+    fabricated — a word without a genuine, finite start AND end is omitted
+    rather than pinned to a plausible-but-wrong ``0.0`` (which would
+    mislead caption consumers) or serialised as non-JSON-safe
+    ``NaN``/``Infinity``.
+    """
+    if value is None:
+        return None
+    try:
+        f = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(f):
+        return None
+    return f
+
+
+def _iter_words_for_verbose(result) -> list[dict]:
+    """Flatten the engine's per-segment ``words`` lists into OpenAI's
+    top-level ``words`` array shape.
+
+    OpenAI's ``verbose_json`` word object has EXACTLY three keys —
+    ``word`` (str), ``start`` (float seconds), ``end`` (float seconds).
+    Whisper (mlx-audio) attaches a ``words`` list of
+    ``{word, start, end, probability}`` to each segment when
+    ``word_timestamps=True``; we drop ``probability`` (not part of the
+    OpenAI contract) and walk both dict- and object-shaped words so a
+    future non-dict backend still renders. Segments without a ``words``
+    list (e.g. a non-Whisper backend that can't emit per-word timings)
+    contribute nothing — the caller then returns an empty ``words: []``
+    array rather than raising, matching the "degrade, don't 500"
+    contract for models that lack word timestamps.
+    """
+    segments = getattr(result, "segments", None) or []
+    words_out: list[dict] = []
+    for seg in segments:
+        if isinstance(seg, dict):
+            seg_words = seg.get("words")
+        else:
+            seg_words = getattr(seg, "words", None)
+        if not isinstance(seg_words, list):
+            continue
+        for w in seg_words:
+            if isinstance(w, dict):
+                word = w.get("word")
+                start = w.get("start")
+                end = w.get("end")
+            else:
+                word = getattr(w, "word", None)
+                start = getattr(w, "start", None)
+                end = getattr(w, "end", None)
+            if word is None:
+                continue
+            # mlx-audio's whisper carries the raw leading-space token
+            # (`" Welcome"`, `" to"`); OpenAI's ``words`` array reports the
+            # bare word with surrounding whitespace stripped. Match OpenAI
+            # so caption/subtitle consumers don't have to re-trim. A token
+            # that is pure whitespace after stripping contributes nothing.
+            word_str = str(word).strip()
+            if not word_str:
+                continue
+            # A word must carry a genuine finite start AND end to be placed
+            # on a timeline. Drop any word with a missing / non-numeric /
+            # NaN / inf timing instead of fabricating one, raising a 500, or
+            # emitting JSON that standard parsers reject (NaN/inf are not
+            # valid JSON). Whisper always supplies both, so the happy path
+            # is unaffected.
+            start_f = _finite_or_none(start)
+            end_f = _finite_or_none(end)
+            if start_f is None or end_f is None:
+                continue
+            words_out.append(
+                {
+                    "word": word_str,
+                    "start": start_f,
+                    "end": end_f,
+                }
+            )
+    return words_out
+
+
+def _build_verbose_json_body(result, timestamp_granularities=None) -> dict:
     """Render the ``verbose_json`` body — text + language + duration + segments.
 
     Mirrors OpenAI's documented field set. ``segments`` is normalised
     to a list of dicts with the canonical key names; the engine's
     raw shape is whatever ``stt`` chose to expose (whisper-mlx ships
     dicts; future backends might ship objects).
+
+    ``timestamp_granularities`` maps OpenAI's ``timestamp_granularities[]``
+    request field to the response shape:
+
+    * ``None`` (field omitted) — the pre-feature default: emit
+      ``segments`` only. Unchanged so existing clients see no drift.
+    * contains ``"segment"`` — emit ``segments``.
+    * contains ``"word"`` — additionally emit a top-level ``words``
+      array of ``{word, start, end}``.
+
+    Both keys can be present when both granularities are requested; a
+    ``["word"]``-only request emits ``words`` without ``segments``,
+    matching OpenAI's Whisper API.
     """
-    cues = _iter_segments_for_subtitles(result)
-    return {
+    include_segments = (
+        timestamp_granularities is None or "segment" in timestamp_granularities
+    )
+    include_words = (
+        timestamp_granularities is not None and "word" in timestamp_granularities
+    )
+
+    body: dict = {
         "task": "transcribe",
         "text": getattr(result, "text", ""),
         "language": getattr(result, "language", None),
         "duration": getattr(result, "duration", None),
-        "segments": [
+    }
+    if include_segments:
+        cues = _iter_segments_for_subtitles(result)
+        body["segments"] = [
             {
                 "id": idx,
                 "start": start,
@@ -764,16 +968,24 @@ def _build_verbose_json_body(result) -> dict:
                 "text": text,
             }
             for idx, (start, end, text) in enumerate(cues)
-        ],
-    }
+        ]
+    if include_words:
+        body["words"] = _iter_words_for_verbose(result)
+    return body
 
 
-def _format_stt_response(result, response_format: str, task: str):
+def _format_stt_response(
+    result, response_format: str, task: str, timestamp_granularities=None
+):
     """Branch on the validated ``response_format`` and produce a body.
 
     Centralised so the transcription and translation routes pick the
     same shape for the same value — a future change to one path
     automatically lands on the other.
+
+    ``timestamp_granularities`` only affects the ``verbose_json`` branch
+    (OpenAI's word/segment timestamp switch); every other format ignores
+    it, exactly as OpenAI's API does.
     """
     if response_format == "text":
         return PlainTextResponse(getattr(result, "text", "") or "")
@@ -782,7 +994,9 @@ def _format_stt_response(result, response_format: str, task: str):
     if response_format == "vtt":
         return PlainTextResponse(_build_vtt_body(result), media_type="text/vtt")
     if response_format == "verbose_json":
-        body = _build_verbose_json_body(result)
+        body = _build_verbose_json_body(
+            result, timestamp_granularities=timestamp_granularities
+        )
         # The verbose envelope carries an explicit ``task`` field —
         # translations should advertise themselves correctly even
         # when ``transcribe`` is the engine default.
@@ -1000,6 +1214,7 @@ async def _run_stt_request(
     response_format: str,
     task: str,
     text: str | None = None,
+    timestamp_granularities: list[str] | None = None,
 ):
     """Shared STT pipeline used by both ``/v1/audio/transcriptions`` and
     ``/v1/audio/translations``.
@@ -1117,13 +1332,24 @@ async def _run_stt_request(
                 tmp_path, text=text, language=language or "Chinese"
             )
         else:
-            result = _stt_engine.transcribe(tmp_path, language=language, task=task)
+            # Forward ``timestamp_granularities`` only when requested.
+            # Keeping the default call shape unchanged preserves compatibility
+            # with older STTEngine-shaped stubs and third-party engines.
+            transcribe_kwargs: dict = {"language": language, "task": task}
+            if timestamp_granularities:
+                transcribe_kwargs["timestamp_granularities"] = timestamp_granularities
+            result = _stt_engine.transcribe(tmp_path, **transcribe_kwargs)
 
         # R6-H2: branch on the validated ``response_format`` so callers
         # that requested ``srt`` / ``vtt`` / ``verbose_json`` actually
         # get those shapes. Pre-fix only ``text`` had a non-JSON path;
         # everything else fell through to the JSON envelope.
-        return _format_stt_response(result, response_format, task=task)
+        return _format_stt_response(
+            result,
+            response_format,
+            task=task,
+            timestamp_granularities=timestamp_granularities,
+        )
 
     except ImportError:
         raise HTTPException(
@@ -1229,10 +1455,28 @@ async def create_transcription(
     # segment shape verbose_json/srt/vtt already render. Accepted on
     # both form and query for parity with the other STT fields.
     text_form: str | None = Form(None, alias="text"),
+    # STT-word-timestamps: OpenAI serialises the array field as
+    # ``timestamp_granularities[]`` (bracketed) in the multipart body.
+    # We also accept the un-bracketed ``timestamp_granularities`` name
+    # (some SDK/curl variants send it that way) and both spellings on the
+    # query string, mirroring the form-over-query precedence the rest of
+    # this route already uses for ``model``/``language``/``response_format``.
+    timestamp_granularities_bracket_form: list[str] | None = Form(
+        None, alias="timestamp_granularities[]"
+    ),
+    timestamp_granularities_plain_form: list[str] | None = Form(
+        None, alias="timestamp_granularities"
+    ),
     model_query: str | None = Query(None, alias="model"),
     language_query: str | None = Query(None, alias="language"),
     response_format_query: str | None = Query(None, alias="response_format"),
     text_query: str | None = Query(None, alias="text"),
+    timestamp_granularities_bracket_query: list[str] | None = Query(
+        None, alias="timestamp_granularities[]"
+    ),
+    timestamp_granularities_plain_query: list[str] | None = Query(
+        None, alias="timestamp_granularities"
+    ),
 ):
     """Transcribe audio to text (OpenAI Whisper API compatible).
 
@@ -1281,6 +1525,45 @@ async def create_transcription(
     # response_format".
     response_format = _validate_response_format(response_format)
 
+    # STT-word-timestamps: resolve the requested granularities from
+    # whichever source carried them (bracketed form wins → plain form →
+    # bracketed query → plain query), then validate the values up front so
+    # a bad value (``"words"``) fails cheaply with a 400 before the upload
+    # drains — same lifecycle as ``response_format`` above.
+    timestamp_granularities = _normalise_timestamp_granularities(
+        timestamp_granularities_bracket_form
+        or timestamp_granularities_plain_form
+        or timestamp_granularities_bracket_query
+        or timestamp_granularities_plain_query
+    )
+
+    # OpenAI contract: ``timestamp_granularities[]`` is only meaningful
+    # with ``response_format=verbose_json`` (the only shape that carries a
+    # ``words``/``segments`` array). Reject the mismatch with a 400 instead
+    # of silently ignoring the field, so a caller that forgot to set
+    # ``verbose_json`` learns why their timestamps never arrived.
+    if timestamp_granularities is not None and response_format != "verbose_json":
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "error": {
+                    "message": (
+                        "`timestamp_granularities[]` requires "
+                        "`response_format=verbose_json`; got "
+                        f"response_format={response_format!r}."
+                    ),
+                    "type": "invalid_request_error",
+                    "code": "invalid_request",
+                    "param": "timestamp_granularities",
+                }
+            },
+        )
+
+    # Word-level timings are a Whisper-only capability — reject the
+    # ``word`` granularity on non-Whisper engines with a 400 rather than
+    # returning an empty ``words`` array that falsely claims fulfillment.
+    _reject_word_timestamps_for_non_whisper(model, timestamp_granularities)
+
     # F-D05: STT-lane audio dep probe — same envelope as the TTS
     # lane shares. Fires BEFORE we spool any upload bytes so a broken
     # ``mlx_audio.stt`` install rejects cheaply (no temp file, no
@@ -1298,6 +1581,7 @@ async def create_transcription(
         response_format=response_format,
         task="transcribe",
         text=text,
+        timestamp_granularities=timestamp_granularities,
     )
 
 


### PR DESCRIPTION
## Why

This is the **STT / captions lane** of the audio-POC absorption (PR2 of the audio series; PR1 is the TTS cloning lane). The content-farm automation tier needs OpenAI-compatible caption/subtitle plumbing: word-level timings let downstream tooling build karaoke-style captions and precise subtitle cuts without a second forced-alignment pass.

Before this change, `POST /v1/audio/transcriptions` parsed `model` / `language` / `response_format` from the multipart form but **silently dropped** OpenAI's `timestamp_granularities[]` field, so word-level timestamps were impossible even though the request model nominally carried the field.

## What changed

- **Route (`vllm_mlx/routes/audio.py`)** — the transcription route now reads `timestamp_granularities[]` from the multipart form (plus the un-bracketed and query spellings, with the same form-over-query precedence the other fields use), validates values against OpenAI's `{word, segment}` enum, and threads them through the STT pipeline. Two new OpenAI-faithful 400s:
  - `timestamp_granularities[]` requires `response_format=verbose_json` (rejected instead of silently ignored).
  - `word` granularity is rejected on **non-Whisper** engines — mirroring the existing Whisper-only routing `_reject_non_whisper_for_translation` already uses — rather than returning an empty `words` array that would falsely claim fulfillment. `segment` granularity is unaffected (all engines report segments).
- **STT engine (`vllm_mlx/audio/stt.py`)** — `transcribe()` gained a `timestamp_granularities` kwarg. When `word` is requested on a Whisper model it forwards `word_timestamps=True` to mlx-audio's whisper `generate`, which attaches a per-segment `words` list of `{word, start, end, probability}`. Non-Whisper backends never receive the flag (they'd raise). The kwarg is forwarded only when granularities are actually requested, so the default call stays byte-for-byte identical (no signature-break for existing engine stubs, no extra decode cost).
- **verbose_json builder** — emits a top-level `words: [{word, start, end}]` array in OpenAI's exact shape (probability dropped; leading-space whisper tokens trimmed to match OpenAI; missing / non-numeric / NaN / inf timings dropped rather than fabricated into a bogus `0.0`) when `word` is requested; keeps `segments` for `segment`; emits both when both are requested. **Default (no granularities) output is unchanged.**
- **Request model (`vllm_mlx/api/models.py`)** — `AudioTranscriptionRequest.timestamp_granularities` is now `list[Literal["word","segment"]] | None` with a normalising/validating `field_validator`, so the generated OpenAPI schema advertises the enum and matches the route contract.

## How validated

- **Unit** — new hermetic suite `tests/test_transcription_word_timestamps.py` (22 tests) covers: request-model accepts/validates the field, granularity normalisation + dedup, verbose_json builder emitting `words[]` only when requested (and omitting it by default), Whisper-only `word_timestamps` forwarding, non-Whisper never receiving the flag, both route 400s, and malformed-timing dropping. Existing STT/audio/contract suites stay green.
- **Real dogfood** — via `fastapi.testclient.TestClient` against the cached `whisper-large-v3-turbo` on a real English speech clip (`examples/assistant_bank_en.wav`), requesting `response_format=verbose_json` + `timestamp_granularities[]=word`. Returned a non-empty, monotonic `words[]` with exactly `{word, start, end}` keys, e.g.:
  ```json
  [
    {"word": "Welcome", "start": 0.0, "end": 0.62},
    {"word": "to", "start": 0.62, "end": 0.88},
    {"word": "First", "start": 0.88, "end": 1.12},
    {"word": "National", "start": 1.12, "end": 1.52},
    {"word": "Bank.", "start": 1.52, "end": 1.9},
    {"word": "How", "start": 2.12, "end": 2.44},
    {"word": "assist", "start": 2.74, "end": 3.04},
    {"word": "today?", "start": 3.2, "end": 3.42}
  ]
  ```
- **Gates** — `python3.12 scripts/dev_test.py unit` (14232 passed; only unrelated flaky perf test `test_batching_improves_throughput` blipped under full-suite load and passes in isolation — it does not touch this lane), `ruff check .`, and `ruff format --check .` all pass. Version guard respected: no `pyproject.toml` change (`[skip-version-bump]`).
- **Codex review** — converged over 3 rounds to **0 BLOCKING + 0 MAJOR + 0 MINOR**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)