### PR TITLE
feat(api): expose content-farm engines via OpenAI-style routes (music / forced-align / video contract)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,6 +169,14 @@ jobs:
         # test_llm.py, test_deltanet_snapshot.py went with it.
         # test_memory_cache exercises mlx-importing code paths so it
         # lives here, not in the Linux test-matrix job.
+        #
+        # Both CI test lists are explicit allowlists, so a new test file
+        # that lands in neither is never gated. test_content_farm_routes
+        # and test_server_auth_ordering are hermetic (engines faked at the
+        # import boundary, no weights / network / mlx_audio) but they are
+        # NOT mlx-free: they import vllm_mlx.config, whose chain reaches
+        # engine_core's `import mlx.core`. That puts them here rather than
+        # in the Linux job.
         run: |
           pytest \
             tests/test_platform.py \
@@ -185,6 +193,8 @@ jobs:
             tests/test_streaming_detokenizer.py \
             tests/test_tool_logits.py \
             tests/test_no_mllm_flag.py \
+            tests/test_content_farm_routes.py \
+            tests/test_server_auth_ordering.py \
             -v --tb=short \
             -m "not slow" \
             -k "not Integration"

--- a/docs/content_farm_api.md
+++ b/docs/content_farm_api.md
@@ -92,7 +92,7 @@ ASR).
 | Field | Type | Default | Notes |
 | --- | --- | --- | --- |
 | `file` | file | — (required) | The audio whose speech is `text`. |
-| `text` | string | *(absent)* | **Presence switches to alignment.** The known transcript to align. Present-but-blank is a `400` — it is never silently downgraded to ASR. |
+| `text` | string | *(absent)* | **Presence switches to alignment.** The known transcript to align. A whitespace-only value is a `400`, never a silent downgrade to ASR. |
 | `model` | string | `qwen3-aligner` when `text` present, else `whisper-large-v3` | Must resolve to a forced-aligner model (family `qwen3_aligner`) for the alignment path. |
 | `language` | string | aligner default (`Chinese`) | Alignment language, forwarded to the aligner. |
 | `response_format` | string | `verbose_json` when `text` present, else `json` | One of `json`, `text`, `srt`, `vtt`, `verbose_json`. |
@@ -124,10 +124,19 @@ default) returns:
 returns the transcript as `text/plain`.
 
 Errors: `400` (`code="invalid_alignment_request"`) when the chosen model
-is not a forced aligner, or when `text` is present but blank (`param:
+is not a forced aligner, or when `text` is whitespace-only (`param:
 "text"`) — sending `text` means "I have the transcript, give me
 timings", so the route refuses rather than quietly answering a different
-question with ASR; `404` for an unknown `model` alias; `400`
+question with ASR.
+
+> One boundary worth knowing: a **truly empty** `text=""` is
+> indistinguishable from an omitted field, because FastAPI coerces an
+> empty form value to `None` for an optional parameter. `text=""`
+> therefore behaves as "no `text`" and runs ASR. Any non-empty blank
+> value (`"   "`) is rejected as above. Send no `text` field for ASR and
+> a real transcript for alignment; don't rely on the empty string.
+
+Also: `404` for an unknown `model` alias; `400`
 (`invalid_audio_file`) for a corrupted upload; `413` for uploads over
 25 MB.
 

--- a/docs/content_farm_api.md
+++ b/docs/content_farm_api.md
@@ -1,0 +1,265 @@
+# Content-Farm Engine API
+
+OpenAI-style HTTP routes that expose the rapid-mlx content-farm engines
+(music generation, forced alignment, and — soon — video generation) so
+colleagues can integrate over a standard API.
+
+All routes live on the rapid-mlx server (`vllm_mlx`). They follow the
+same conventions as the existing `/v1/audio/*` OpenAI-compatible routes:
+JSON or multipart request bodies, `Authorization: Bearer <api-key>` when
+the server was started with `--api-key`, and OpenAI-shaped error
+envelopes (`{"error": {"message", "type", "code", "param"}}`).
+
+| Endpoint | Method | Status | Engine |
+| --- | --- | --- | --- |
+| `/v1/audio/music` | POST | **LIVE** | `MusicEngine` (Stable Audio 3, MLX-native) |
+| `/v1/audio/transcriptions` (`text` field) | POST | **LIVE** | `STTEngine.align` (Qwen3 forced aligner) |
+| `/v1/video/generations` | POST | **CONTRACT-ONLY** (returns 501) | `VideoEngine` — no backend yet (LTX-2.3 pending, see `REQUIREMENTS_rapid.md` B1) |
+
+The audio routes are attached only when the server runs with an
+audio-capable model or `--enable-audio`. The video route is always
+registered (it has no engine to load) and returns HTTP 501 until a
+backend is integrated.
+
+---
+
+## 1. `POST /v1/audio/music` — text → music / SFX (LIVE)
+
+Generates music or sound effects from a text prompt via the MLX-native
+Stable Audio 3 engine. Request-in / audio-bytes-out, the same shape as
+`/v1/audio/speech`.
+
+### Request (JSON body)
+
+| Field | Type | Default | Notes |
+| --- | --- | --- | --- |
+| `model` | string | `"medium"` | DiT/decoder pairing. `medium` (higher quality) or `sm-music` / `sm-sfx` (fast small). Unknown values fall back to engine defaults. |
+| `input` | string | — (required) | Natural-language prompt. Must be non-blank. |
+| `seconds` | number | `30.0` | Clip length. `0 < seconds <= 47` (SA3 ceiling). |
+| `steps` | integer | `8` | Pingpong sampling steps. `1..200`. |
+| `negative_prompt` | string \| null | `null` | CFG negative branch (e.g. `"vocals, singing"`). Max 4096 chars. |
+| `seed` | integer \| null | `null` | Fixed seed for reproducibility. |
+| `response_format` | string | `"wav"` | Only `wav` is supported. |
+
+### Response
+
+`200 OK`, `Content-Type: audio/wav` — the raw WAV bytes (same delivery
+as `/v1/audio/speech`).
+
+Errors: `422` for schema violations (blank `input`, `seconds > 47`,
+unsupported `response_format`); `500`
+(`code="music_generation_failed"`) if the engine fails; `503` if the
+engine's runtime deps are unavailable.
+
+### curl
+
+```bash
+curl -s http://localhost:8000/v1/audio/music \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $RAPID_MLX_API_KEY" \
+  -d '{
+        "model": "medium",
+        "input": "epic cinematic war drums, tense build-up",
+        "seconds": 20,
+        "steps": 8,
+        "negative_prompt": "vocals, singing",
+        "seed": 42
+      }' \
+  --output bgm.wav
+```
+
+---
+
+## 2. `POST /v1/audio/transcriptions` with a `text` field — forced alignment (LIVE)
+
+The existing OpenAI Whisper-compatible transcription route. When the
+request includes a **`text`** field, the route switches from ASR to
+**forced alignment**: it aligns the *known* transcript in `text` to the
+uploaded audio and returns per-unit (per-character for Chinese, per-word
+for space-delimited languages) start/end timestamps with zero
+recognition error. When `text` is absent, behavior is unchanged (normal
+ASR).
+
+### Request (multipart/form-data)
+
+| Field | Type | Default | Notes |
+| --- | --- | --- | --- |
+| `file` | file | — (required) | The audio whose speech is `text`. |
+| `text` | string | *(absent)* | **Presence switches to alignment.** The known transcript to align. |
+| `model` | string | `qwen3-aligner` when `text` present, else `whisper-large-v3` | Must resolve to a forced-aligner model (family `qwen3_aligner`) for the alignment path. |
+| `language` | string | aligner default (`Chinese`) | Alignment language, forwarded to the aligner. |
+| `response_format` | string | `verbose_json` when `text` present, else `json` | One of `json`, `text`, `srt`, `vtt`, `verbose_json`. |
+
+`model`/`language`/`response_format`/`text` are accepted on the
+multipart form (OpenAI-style) or as query parameters (internal-caller
+parity).
+
+### Response
+
+Shares the transcription serializers. `verbose_json` (the alignment
+default) returns:
+
+```json
+{
+  "task": "transcribe",
+  "text": "临终前",
+  "language": "Chinese",
+  "duration": 0.6,
+  "segments": [
+    {"id": 0, "start": 0.0, "end": 0.2, "text": "临"},
+    {"id": 1, "start": 0.2, "end": 0.4, "text": "终"},
+    {"id": 2, "start": 0.4, "end": 0.6, "text": "前"}
+  ]
+}
+```
+
+`srt` / `vtt` return subtitle bodies built from the same segments; `text`
+returns the transcript as `text/plain`.
+
+Errors: `400` (`code="invalid_alignment_request"`) when the chosen model
+is not a forced aligner or the `text` is empty/blank; `404` for an
+unknown `model` alias; `400` (`invalid_audio_file`) for a corrupted
+upload; `413` for uploads over 25 MB.
+
+### curl
+
+```bash
+# Forced alignment: align a known transcript to the audio.
+curl -s http://localhost:8000/v1/audio/transcriptions \
+  -H "Authorization: Bearer $RAPID_MLX_API_KEY" \
+  -F "file=@line.wav" \
+  -F "text=临终前她握着我的手" \
+  -F "language=Chinese" \
+  -F "response_format=verbose_json"
+
+# No text field → unchanged ASR behavior.
+curl -s http://localhost:8000/v1/audio/transcriptions \
+  -H "Authorization: Bearer $RAPID_MLX_API_KEY" \
+  -F "file=@clip.wav" \
+  -F "model=whisper-large-v3"
+```
+
+---
+
+## 3. `POST /v1/video/generations` — text → video / image → video (CONTRACT-ONLY)
+
+The full request/response contract and the `VideoEngine` interface are
+defined now so colleagues can integrate against a stable shape. **There
+is no backend yet** — the route validates the request and then returns
+**HTTP 501**. A future MLX-native LTX-2.3 backend implementing
+`vllm_mlx.video.engine.VideoEngine` makes the route go live with no
+change to the route handler.
+
+One schema covers both modes: **text-to-video** when `image` is omitted,
+**image-to-video** when `image` carries the conditioning first frame.
+
+### Request (JSON body)
+
+| Field | Type | Default | Notes |
+| --- | --- | --- | --- |
+| `model` | string | `"ltx-2.3"` | Target backend. |
+| `prompt` | string | — (required) | Natural-language description. Must be non-blank. |
+| `image` | string \| null | `null` | Conditioning first frame for i2v: a base64 string / `data:` URI, or an `http(s)` URL. `null` → text-to-video. |
+| `height` | integer | `704` | Output height, `1..4096`. |
+| `width` | integer | `1216` | Output width, `1..4096`. |
+| `num_frames` | integer | `97` | Frames to render, `1..4096`. |
+| `frame_rate` | number | `25.0` | Playback fps, `0 < fps <= 240`. |
+| `steps` | integer \| null | `null` | Denoising steps, `1..500` (`null` = backend default). |
+| `seed` | integer \| null | `null` | Fixed seed. |
+| `negative_prompt` | string \| null | `null` | CFG negative branch. Max 4096 chars. |
+| `response_format` | string | `"mp4"` | Only `mp4` is supported. |
+
+### Response (once a backend is integrated)
+
+```json
+{
+  "created": 1730000000,
+  "model": "ltx-2.3",
+  "data": [
+    {
+      "b64_video": null,
+      "url": "/path/or/url/to/out.mp4",
+      "audio": null,
+      "format": "mp4",
+      "width": 1216,
+      "height": 704,
+      "num_frames": 97,
+      "frame_rate": 25.0
+    }
+  ]
+}
+```
+
+Each `data[]` item populates exactly one of `b64_video` (inline base64
+mp4) or `url`. `audio` carries LTX-2.3's native soundtrack (base64) when
+the backend emits one, else `null`.
+
+### Current behavior (no backend)
+
+`501 Not Implemented`:
+
+```json
+{
+  "error": {
+    "message": "video backend not yet integrated; see REQUIREMENTS_rapid.md B1",
+    "type": "not_implemented_error",
+    "code": "video_backend_not_implemented",
+    "param": null
+  }
+}
+```
+
+Schema violations still `422` at the request boundary (missing `prompt`,
+`num_frames=0`, etc.) so you can develop against the real wire contract
+today.
+
+### The interface to implement
+
+A backend implements `vllm_mlx/video/engine.py::VideoEngine`:
+
+```python
+def generate(
+    self,
+    prompt: str,
+    out_path: str | Path,
+    *,
+    image: str | None = None,
+    height: int = 704,
+    width: int = 1216,
+    num_frames: int = 97,
+    frame_rate: float = 25.0,
+    steps: int | None = None,
+    negative_prompt: str | None = None,
+    seed: int | None = None,
+) -> Path: ...
+```
+
+and registers a factory so `resolve_video_engine(model)` returns it. See
+`REQUIREMENTS_rapid.md` B1 for the integration task.
+
+### curl
+
+```bash
+# Text-to-video (returns 501 today).
+curl -s http://localhost:8000/v1/video/generations \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $RAPID_MLX_API_KEY" \
+  -d '{
+        "model": "ltx-2.3",
+        "prompt": "a red fox trotting through fresh snow, cinematic",
+        "height": 704,
+        "width": 1216,
+        "num_frames": 97,
+        "frame_rate": 25
+      }'
+
+# Image-to-video (i2v) — condition on a first frame.
+curl -s http://localhost:8000/v1/video/generations \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $RAPID_MLX_API_KEY" \
+  -d '{
+        "prompt": "the character turns and smiles",
+        "image": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAA...",
+        "num_frames": 65
+      }'
+```

--- a/docs/content_farm_api.md
+++ b/docs/content_farm_api.md
@@ -14,7 +14,7 @@ envelopes (`{"error": {"message", "type", "code", "param"}}`).
 | --- | --- | --- | --- |
 | `/v1/audio/music` | POST | **LIVE** | `MusicEngine` (Stable Audio 3, MLX-native) |
 | `/v1/audio/transcriptions` (`text` field) | POST | **LIVE** | `STTEngine.align` (Qwen3 forced aligner) |
-| `/v1/video/generations` | POST | **CONTRACT-ONLY** (returns 501) | `VideoEngine` — no backend yet (LTX-2.3 pending, see `REQUIREMENTS_rapid.md` B1) |
+| `/v1/video/generations` | POST | **CONTRACT-ONLY** (returns 501) | `VideoEngine` — no backend yet (LTX-2.3 pending, see [The interface to implement](#the-interface-to-implement)) |
 
 The audio routes are attached only when the server runs with an
 audio-capable model or `--enable-audio`. The video route is always
@@ -34,8 +34,8 @@ Stable Audio 3 engine. Request-in / audio-bytes-out, the same shape as
 | Field | Type | Default | Notes |
 | --- | --- | --- | --- |
 | `model` | string | `"medium"` | DiT/decoder pairing. `medium` (higher quality) or `sm-music` / `sm-sfx` (fast small). Unknown values fall back to engine defaults. |
-| `input` | string | — (required) | Natural-language prompt. Must be non-blank. |
-| `seconds` | number | `30.0` | Clip length. `0 < seconds <= 47` (SA3 ceiling). |
+| `input` | string | — (required) | Natural-language prompt. Non-blank, max 4096 chars (it becomes an argv element for the SA3 CLI). |
+| `seconds` | number | `30.0` | Clip length. `0 < seconds <= 47` (SA3 ceiling). NaN/inf rejected. |
 | `steps` | integer | `8` | Pingpong sampling steps. `1..200`. |
 | `negative_prompt` | string \| null | `null` | CFG negative branch (e.g. `"vocals, singing"`). Max 4096 chars. |
 | `seed` | integer \| null | `null` | Fixed seed for reproducibility. |
@@ -46,10 +46,17 @@ Stable Audio 3 engine. Request-in / audio-bytes-out, the same shape as
 `200 OK`, `Content-Type: audio/wav` — the raw WAV bytes (same delivery
 as `/v1/audio/speech`).
 
-Errors: `422` for schema violations (blank `input`, `seconds > 47`,
-unsupported `response_format`); `500`
-(`code="music_generation_failed"`) if the engine fails; `503` if the
-engine's runtime deps are unavailable.
+Errors: `400` for schema violations (blank or over-4096-char `input`,
+`seconds > 47`, unsupported `response_format`); `500`
+(`code="music_generation_failed"`) if the engine fails or produces no
+audio; `503` if the engine's runtime deps are unavailable.
+
+> **On the status code:** the schema rejection is a FastAPI
+> `RequestValidationError`, which the rapid-mlx server's global handler
+> normalizes to **400** with a sanitized envelope (see
+> `install_exception_handlers` in `vllm_mlx/server.py`). Stock FastAPI
+> would emit 422 — you'll see 422 only if you mount the router on a bare
+> app without those handlers, as the unit tests do.
 
 ### curl
 
@@ -177,8 +184,8 @@ One schema covers both modes: **text-to-video** when `image` is omitted,
   "model": "ltx-2.3",
   "data": [
     {
-      "b64_video": null,
-      "url": "/path/or/url/to/out.mp4",
+      "b64_video": "AAAAIGZ0eXBpc29t...",
+      "url": null,
       "audio": null,
       "format": "mp4",
       "width": 1216,
@@ -191,8 +198,11 @@ One schema covers both modes: **text-to-video** when `image` is omitted,
 ```
 
 Each `data[]` item populates exactly one of `b64_video` (inline base64
-mp4) or `url`. `audio` carries LTX-2.3's native soundtrack (base64) when
-the backend emits one, else `null`.
+mp4) or `url`. The wired handler returns `b64_video` — a server-side
+filesystem path is not a URL the client can fetch, and echoing one would
+leak the server's layout. A backend that uploads to real object storage
+can populate `url` instead. `audio` carries LTX-2.3's native soundtrack
+(base64) when the backend emits one, else `null`.
 
 ### Current behavior (no backend)
 
@@ -201,7 +211,7 @@ the backend emits one, else `null`.
 ```json
 {
   "error": {
-    "message": "video backend not yet integrated; see REQUIREMENTS_rapid.md B1",
+    "message": "video backend not yet integrated; see docs/content_farm_api.md",
     "type": "not_implemented_error",
     "code": "video_backend_not_implemented",
     "param": null
@@ -209,9 +219,10 @@ the backend emits one, else `null`.
 }
 ```
 
-Schema violations still `422` at the request boundary (missing `prompt`,
-`num_frames=0`, etc.) so you can develop against the real wire contract
-today.
+Schema violations still fail at the request boundary (missing `prompt`,
+`num_frames=0`, `frame_rate=NaN`, `response_format="webm"`, etc.) so you
+can develop against the real wire contract today — as **400** on the
+rapid-mlx server, per the note in §1.
 
 ### The interface to implement
 
@@ -234,8 +245,10 @@ def generate(
 ) -> Path: ...
 ```
 
-and registers a factory so `resolve_video_engine(model)` returns it. See
-`REQUIREMENTS_rapid.md` B1 for the integration task.
+and registers a factory so `resolve_video_engine(model)` returns it:
+assign `vllm_mlx.video.engine._VIDEO_ENGINE_FACTORY` to a callable
+taking the requested `model` id and returning the engine. The route then
+goes live with no handler change.
 
 ### curl
 

--- a/docs/content_farm_api.md
+++ b/docs/content_farm_api.md
@@ -92,7 +92,7 @@ ASR).
 | Field | Type | Default | Notes |
 | --- | --- | --- | --- |
 | `file` | file | — (required) | The audio whose speech is `text`. |
-| `text` | string | *(absent)* | **Presence switches to alignment.** The known transcript to align. |
+| `text` | string | *(absent)* | **Presence switches to alignment.** The known transcript to align. Present-but-blank is a `400` — it is never silently downgraded to ASR. |
 | `model` | string | `qwen3-aligner` when `text` present, else `whisper-large-v3` | Must resolve to a forced-aligner model (family `qwen3_aligner`) for the alignment path. |
 | `language` | string | aligner default (`Chinese`) | Alignment language, forwarded to the aligner. |
 | `response_format` | string | `verbose_json` when `text` present, else `json` | One of `json`, `text`, `srt`, `vtt`, `verbose_json`. |
@@ -124,9 +124,17 @@ default) returns:
 returns the transcript as `text/plain`.
 
 Errors: `400` (`code="invalid_alignment_request"`) when the chosen model
-is not a forced aligner or the `text` is empty/blank; `404` for an
-unknown `model` alias; `400` (`invalid_audio_file`) for a corrupted
-upload; `413` for uploads over 25 MB.
+is not a forced aligner, or when `text` is present but blank (`param:
+"text"`) — sending `text` means "I have the transcript, give me
+timings", so the route refuses rather than quietly answering a different
+question with ASR; `404` for an unknown `model` alias; `400`
+(`invalid_audio_file`) for a corrupted upload; `413` for uploads over
+25 MB.
+
+A whitespace-only `model` or `response_format` is treated as unset and
+takes the lane default (`qwen3-aligner` / `verbose_json`) rather than
+failing — a truly empty form field is already coerced to absent by
+FastAPI.
 
 ### curl
 
@@ -166,7 +174,7 @@ One schema covers both modes: **text-to-video** when `image` is omitted,
 | --- | --- | --- | --- |
 | `model` | string | `"ltx-2.3"` | Target backend. |
 | `prompt` | string | — (required) | Natural-language description. Must be non-blank. |
-| `image` | string \| null | `null` | Conditioning first frame for i2v: a base64 string / `data:` URI, or an `http(s)` URL. `null` → text-to-video. |
+| `image` | string \| null | `null` | Conditioning first frame for i2v. One of: a `data:image/*;base64,...` URI, an `http(s)://` URL, or a bare base64 payload. Max 12 MB of string. `null` → text-to-video. |
 | `height` | integer | `704` | Output height, `1..4096`. |
 | `width` | integer | `1216` | Output width, `1..4096`. |
 | `num_frames` | integer | `97` | Frames to render, `1..4096`. |
@@ -223,6 +231,27 @@ Schema violations still fail at the request boundary (missing `prompt`,
 `num_frames=0`, `frame_rate=NaN`, `response_format="webm"`, etc.) so you
 can develop against the real wire contract today — as **400** on the
 rapid-mlx server, per the note in §1.
+
+### Security note on `image`
+
+`image` is the only field in this contract a backend **dereferences**,
+which makes it the request's sole server-side fetch primitive. The schema
+therefore restricts it at the boundary — so every future backend inherits
+the restriction instead of each having to remember it:
+
+- `data:` URIs must declare an `image/*` media type (`data:text/html;...`
+  and unlabelled `data:;base64,...` are rejected).
+- URL schemes are an allowlist of `http` / `https`. `file://`,
+  `gopher://`, `ftp://` and friends are rejected — otherwise
+  `file:///etc/passwd` is an arbitrary local-file read the moment a
+  backend honours the field.
+- A bare base64 payload (no scheme) is accepted as an inline frame.
+- The whole string is capped at 12 MB.
+
+This is **not** complete SSRF defence: an allowed `https://` host can
+still resolve to a private address (link-local metadata endpoints,
+`127.0.0.1`, RFC1918). Egress policy for the actual fetch is the backend
+integrator's responsibility.
 
 ### The interface to implement
 

--- a/docs/content_farm_api.md
+++ b/docs/content_farm_api.md
@@ -257,10 +257,30 @@ the restriction instead of each having to remember it:
 - A bare base64 payload (no scheme) is accepted as an inline frame.
 - The whole string is capped at 12 MB.
 
-This is **not** complete SSRF defence: an allowed `https://` host can
-still resolve to a private address (link-local metadata endpoints,
-`127.0.0.1`, RFC1918). Egress policy for the actual fetch is the backend
-integrator's responsibility.
+- `http(s)` URLs must name a host: `https:///etc/passwd` (allowed scheme,
+  empty host, absolute local path) and `http:frame.png` (opaque, no host)
+  are rejected, since both are shapes a lenient fetcher resolves against
+  the local filesystem.
+
+**This is deliberately NOT complete SSRF defence, and the backend must
+finish the job.** Schema validation runs before any network activity, so
+it can only constrain the *shape* of the reference. An allowed
+`https://` host can still resolve to a private address — `127.0.0.1`,
+RFC1918, link-local metadata endpoints (`169.254.169.254`) — or DNS-rebind
+between validation and connect, or redirect to any of those.
+
+**A backend that dereferences `image` MUST**, at fetch time:
+
+1. resolve the hostname and reject non-public addresses **per connection**
+   (not once up front — that's the rebinding window),
+2. re-apply the same check to **every redirect hop**, not just the initial
+   URL, and
+3. bound response size and time.
+
+The route layer cannot do any of this for you: there is no fetch here to
+hook, and doing it correctly requires control of the socket. Treat the
+validation above as a shape filter that removes the trivially-wrong
+inputs, not as an egress policy.
 
 ### The interface to implement
 

--- a/tests/test_audio_route_registration_gate.py
+++ b/tests/test_audio_route_registration_gate.py
@@ -188,12 +188,14 @@ class TestRegisterAudioRoutes:
             for r in _walk_routes(app)
             if getattr(r, "path", "").startswith("/v1/audio/")
         ]
-        # transcriptions + translations + speech + voices = 4 unique paths.
+        # transcriptions + translations + speech + music + voices =
+        # 5 unique paths (music is the content-farm lane addition).
         unique_paths = {r.path for r in audio_routes}
         assert unique_paths == {
             "/v1/audio/transcriptions",
             "/v1/audio/translations",
             "/v1/audio/speech",
+            "/v1/audio/music",
             "/v1/audio/voices",
         }
 

--- a/tests/test_content_farm_routes.py
+++ b/tests/test_content_farm_routes.py
@@ -27,6 +27,7 @@ import wave
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+from pydantic import ValidationError
 
 # ---------------------------------------------------------------------------
 # Shared fixtures
@@ -693,14 +694,13 @@ class TestForcedAlignment:
 
         async def _drive():
             seen["loop_thread"] = threading.get_ident()
-            with open(_tmp_wav(), "rb") as fh:
-                return await audio_route._run_alignment_request(
-                    file=_UploadLike(fh.read()),
-                    model="qwen3-aligner",
-                    text="abc",
-                    language=None,
-                    response_format="verbose_json",
-                )
+            return await audio_route._run_alignment_request(
+                file=_UploadLike(_make_tone_wav()),
+                model="qwen3-aligner",
+                text="abc",
+                language=None,
+                response_format="verbose_json",
+            )
 
         _FakeAlignerEngine.align = _recording_align
         try:
@@ -708,15 +708,6 @@ class TestForcedAlignment:
         finally:
             _FakeAlignerEngine.align = real_align
         assert seen["engine_thread"] != seen["loop_thread"], seen
-
-
-def _tmp_wav() -> str:
-    """Write a throwaway tone wav and return its path."""
-    import tempfile
-
-    with tempfile.NamedTemporaryFile(delete=False, suffix=".wav") as fh:
-        fh.write(_make_tone_wav())
-        return fh.name
 
 
 class _UploadLike:
@@ -826,11 +817,23 @@ class TestVideoContract:
         [
             "file:///etc/passwd",
             "FILE:///etc/passwd",
+            # Single-slash URIs are still URIs. urlsplit() sees scheme
+            # "file" here, but a "://" substring test does not — that gap
+            # would wave an arbitrary local-file read through as "bare
+            # base64". Regression pin for codex round-2 finding 1.
+            "file:/etc/passwd",
+            "file:/../../etc/shadow",
+            "gopher:/internal/x",
             "gopher://internal/x",
             "ftp://internal/frame.png",
             "data:text/html;base64,PHNjcmlwdD4=",
             "data:;base64,AAAA",
             "   ",
+            # Scheme-less but not base64 — a bare path or host must not
+            # sit in the field waiting for a backend to interpret it.
+            "/etc/passwd",
+            "../../secret.png",
+            "internal.corp.example",
         ],
     )
     def test_unsafe_image_reference_is_rejected(self, image):
@@ -857,7 +860,8 @@ class TestVideoContract:
             "data:image/png;base64,iVBORw0KGgo=",
             "https://example.com/frame.png",
             "http://example.com/frame.png",
-            "iVBORw0KGgoAAAANSUhEUg==",  # bare base64, no scheme
+            # Bare base64, no scheme — a real (truncated) PNG payload.
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR4nGP4DwABAQEAGn0nsQAAAABJRU5ErkJggg==",
         ],
     )
     def test_documented_image_forms_are_accepted(self, image):
@@ -887,6 +891,12 @@ class TestVideoContract:
         )
         assert req.num_frames == 97
         assert req.response_format == "mp4"
+
+        # XOR invariant: both channels set, or neither, must be refused.
+        with pytest.raises(ValidationError):
+            VideoGenerationResult(b64_video="AAAA", url="https://x/y.mp4")
+        with pytest.raises(ValidationError):
+            VideoGenerationResult()
 
         resp = VideoGenerationResponse(
             created=123,

--- a/tests/test_content_farm_routes.py
+++ b/tests/test_content_farm_routes.py
@@ -1,0 +1,526 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Content-farm OpenAI-style routes: music, forced-alignment, video.
+
+Hermetic — no real models / network / weights. Engines are faked at the
+import boundary via monkeypatch (per repo convention), so these run fast
+in CI:
+
+* ``POST /v1/audio/music`` → ``MusicEngine`` (LIVE) — happy path + input
+  validation.
+* ``POST /v1/audio/transcriptions`` with a ``text`` field → forced
+  alignment via ``STTEngine.align`` (LIVE) — happy path + the
+  non-aligner-model 400.
+* ``POST /v1/video/generations`` (CONTRACT-ONLY) — schema validates then
+  the route returns a clean 501; a schema violation 422s at the boundary.
+"""
+
+from __future__ import annotations
+
+import importlib.machinery
+import io
+import math
+import struct
+import sys
+import types
+import wave
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_tone_wav(duration_s: float = 0.25, freq_hz: float = 440.0) -> bytes:
+    sample_rate = 16000
+    n_samples = int(sample_rate * duration_s)
+    buf = io.BytesIO()
+    with wave.open(buf, "wb") as w:
+        w.setnchannels(1)
+        w.setsampwidth(2)
+        w.setframerate(sample_rate)
+        for i in range(n_samples):
+            sample = int(8000 * math.sin(2 * math.pi * freq_hz * i / sample_rate))
+            w.writeframes(struct.pack("<h", sample))
+    return buf.getvalue()
+
+
+def _mount_audio_app() -> tuple[TestClient, callable]:
+    """Mount the audio router on a bare FastAPI app, bypassing auth."""
+    from vllm_mlx.config import get_config
+    from vllm_mlx.routes import audio as audio_route
+
+    app = FastAPI()
+    app.include_router(audio_route.router)
+    cfg = get_config()
+    saved = cfg.api_key
+    cfg.api_key = None
+
+    def _restore():
+        cfg.api_key = saved
+
+    return TestClient(app), _restore
+
+
+def _mount_video_app() -> tuple[TestClient, callable]:
+    """Mount the video router on a bare FastAPI app, bypassing auth."""
+    from vllm_mlx.config import get_config
+    from vllm_mlx.routes import video as video_route
+
+    app = FastAPI()
+    app.include_router(video_route.router)
+    cfg = get_config()
+    saved = cfg.api_key
+    cfg.api_key = None
+
+    def _restore():
+        cfg.api_key = saved
+
+    return TestClient(app), _restore
+
+
+def _install_fake_mlx_audio(monkeypatch):
+    """Make the STT-lane probe (``require_mlx_audio_stt``) pass without a
+    real ``mlx_audio`` install."""
+    fake_mlx_audio = types.ModuleType("mlx_audio")
+    fake_mlx_audio.__path__ = []
+    fake_mlx_audio.__spec__ = importlib.machinery.ModuleSpec(
+        "mlx_audio", loader=None, is_package=True
+    )
+    fake_stt = types.ModuleType("mlx_audio.stt")
+    fake_stt.__path__ = []
+    fake_stt.__spec__ = importlib.machinery.ModuleSpec(
+        "mlx_audio.stt", loader=None, is_package=True
+    )
+    fake_stt_utils = types.ModuleType("mlx_audio.stt.utils")
+    fake_stt_utils.__spec__ = importlib.machinery.ModuleSpec(
+        "mlx_audio.stt.utils", loader=None
+    )
+    fake_stt_utils.load_model = lambda *_a, **_kw: None
+    monkeypatch.setitem(sys.modules, "mlx_audio", fake_mlx_audio)
+    monkeypatch.setitem(sys.modules, "mlx_audio.stt", fake_stt)
+    monkeypatch.setitem(sys.modules, "mlx_audio.stt.utils", fake_stt_utils)
+
+
+# ---------------------------------------------------------------------------
+# Route 1: POST /v1/audio/music  (LIVE — MusicEngine)
+# ---------------------------------------------------------------------------
+
+
+class _FakeMusicEngine:
+    """Stands in for ``vllm_mlx.audio.music.MusicEngine``.
+
+    Records the call and writes a tiny WAV to ``out_path`` so the route's
+    read-back-and-return path is exercised without SA3 weights.
+    """
+
+    last_call: dict | None = None
+
+    def __init__(self, dit="medium", decoder="same-l"):
+        self.dit = dit
+        self.decoder = decoder
+
+    def generate(
+        self,
+        prompt,
+        out_path,
+        seconds=30.0,
+        steps=8,
+        negative_prompt=None,
+        seed=None,
+        timeout=900,
+    ):
+        _FakeMusicEngine.last_call = {
+            "prompt": prompt,
+            "out_path": str(out_path),
+            "seconds": seconds,
+            "steps": steps,
+            "negative_prompt": negative_prompt,
+            "seed": seed,
+            "dit": self.dit,
+            "decoder": self.decoder,
+        }
+        with open(out_path, "wb") as fh:
+            fh.write(_make_tone_wav())
+        return out_path
+
+
+@pytest.fixture
+def _stub_music_engine(monkeypatch):
+    from vllm_mlx.routes import audio as audio_route
+
+    _FakeMusicEngine.last_call = None
+    monkeypatch.setattr(
+        "vllm_mlx.audio.music.MusicEngine", _FakeMusicEngine, raising=False
+    )
+    music_mod = sys.modules.get("vllm_mlx.audio.music")
+    if music_mod is not None:
+        monkeypatch.setattr(music_mod, "MusicEngine", _FakeMusicEngine)
+    audio_route._music_engine = None
+    yield
+    audio_route._music_engine = None
+
+
+class TestMusicRoute:
+    def test_happy_path_returns_wav(self, _stub_music_engine):
+        client, restore = _mount_audio_app()
+        try:
+            r = client.post(
+                "/v1/audio/music",
+                json={
+                    "model": "medium",
+                    "input": "epic cinematic war drums",
+                    "seconds": 12,
+                    "steps": 6,
+                    "negative_prompt": "vocals",
+                    "seed": 7,
+                },
+            )
+        finally:
+            restore()
+        assert r.status_code == 200, r.text
+        assert r.headers["content-type"].startswith("audio/wav"), r.headers
+        # Real WAV bytes came back (RIFF header).
+        assert r.content[:4] == b"RIFF", r.content[:16]
+        # Request fields reached the engine, and model→(dit,decoder) mapped.
+        call = _FakeMusicEngine.last_call
+        assert call["prompt"] == "epic cinematic war drums"
+        assert call["seconds"] == 12
+        assert call["steps"] == 6
+        assert call["negative_prompt"] == "vocals"
+        assert call["seed"] == 7
+        assert (call["dit"], call["decoder"]) == ("medium", "same-l")
+
+    def test_model_alias_selects_small_variant(self, _stub_music_engine):
+        client, restore = _mount_audio_app()
+        try:
+            r = client.post(
+                "/v1/audio/music",
+                json={"model": "sm-music", "input": "lofi beat", "seconds": 5},
+            )
+        finally:
+            restore()
+        assert r.status_code == 200, r.text
+        call = _FakeMusicEngine.last_call
+        assert (call["dit"], call["decoder"]) == ("sm-music", "same-s")
+
+    def test_unknown_model_falls_back_to_defaults(self, _stub_music_engine):
+        client, restore = _mount_audio_app()
+        try:
+            r = client.post(
+                "/v1/audio/music",
+                json={"model": "no-such-variant", "input": "ambient pad"},
+            )
+        finally:
+            restore()
+        assert r.status_code == 200, r.text
+        call = _FakeMusicEngine.last_call
+        assert (call["dit"], call["decoder"]) == ("medium", "same-l")
+        # seconds default honoured.
+        assert call["seconds"] == 30.0
+
+    def test_blank_input_is_422(self, _stub_music_engine):
+        client, restore = _mount_audio_app()
+        try:
+            r = client.post("/v1/audio/music", json={"input": "   ", "seconds": 5})
+        finally:
+            restore()
+        assert r.status_code == 422, r.text
+        # Engine was never invoked.
+        assert _FakeMusicEngine.last_call is None
+
+    def test_seconds_over_ceiling_is_422(self, _stub_music_engine):
+        client, restore = _mount_audio_app()
+        try:
+            r = client.post(
+                "/v1/audio/music", json={"input": "long track", "seconds": 100}
+            )
+        finally:
+            restore()
+        assert r.status_code == 422, r.text
+        assert _FakeMusicEngine.last_call is None
+
+    def test_bad_response_format_is_422(self, _stub_music_engine):
+        client, restore = _mount_audio_app()
+        try:
+            r = client.post(
+                "/v1/audio/music",
+                json={"input": "track", "response_format": "mp3"},
+            )
+        finally:
+            restore()
+        assert r.status_code == 422, r.text
+        assert _FakeMusicEngine.last_call is None
+
+
+# ---------------------------------------------------------------------------
+# Route 2: POST /v1/audio/transcriptions + text  (LIVE — forced alignment)
+# ---------------------------------------------------------------------------
+
+
+class _FakeAlignResult:
+    def __init__(self, text, segments, language, duration):
+        self.text = text
+        self.segments = segments
+        self.language = language
+        self.duration = duration
+
+
+class _FakeAlignerEngine:
+    """Mirrors the ``STTEngine`` surface the alignment path touches."""
+
+    last_call: dict | None = None
+
+    def __init__(self, model_name):
+        self.model_name = model_name
+
+    def load(self):
+        pass
+
+    def align(self, audio_path, text, language="Chinese"):
+        _FakeAlignerEngine.last_call = {
+            "audio_path": str(audio_path),
+            "text": text,
+            "language": language,
+        }
+        segments = [
+            {"text": ch, "start": round(i * 0.2, 3), "end": round((i + 1) * 0.2, 3)}
+            for i, ch in enumerate(text)
+        ]
+        duration = segments[-1]["end"] if segments else 0.0
+        return _FakeAlignResult(text, segments, language, duration)
+
+    # Present so a mis-routed request would blow up loudly rather than
+    # silently ASR — the route must NOT call this on the alignment path.
+    def transcribe(
+        self, audio_path, language=None, task="transcribe"
+    ):  # pragma: no cover
+        raise AssertionError("alignment path must not call transcribe()")
+
+
+class _FakeNonAlignerEngine:
+    """An ASR engine whose ``align`` refuses — mirrors the real
+    ``STTEngine.align`` ValueError when the model isn't an aligner."""
+
+    def __init__(self, model_name):
+        self.model_name = model_name
+
+    def load(self):
+        pass
+
+    def align(self, audio_path, text, language="Chinese"):
+        raise ValueError(
+            f"align() requires a forced-aligner model; {self.model_name!r} "
+            "is not one (use a registry alias like 'qwen3-aligner')."
+        )
+
+
+@pytest.fixture
+def _stub_aligner(monkeypatch):
+    from vllm_mlx.audio import probe
+    from vllm_mlx.routes import audio as audio_route
+
+    _install_fake_mlx_audio(monkeypatch)
+    probe._reset_probe_cache()
+
+    monkeypatch.setattr(
+        "vllm_mlx.audio.stt.STTEngine", _FakeAlignerEngine, raising=False
+    )
+    stt_mod = sys.modules.get("vllm_mlx.audio.stt")
+    if stt_mod is not None:
+        monkeypatch.setattr(stt_mod, "STTEngine", _FakeAlignerEngine)
+    _FakeAlignerEngine.last_call = None
+    audio_route._stt_engine = None
+    yield
+    audio_route._stt_engine = None
+    probe._reset_probe_cache()
+
+
+@pytest.fixture
+def _stub_non_aligner(monkeypatch):
+    from vllm_mlx.audio import probe
+    from vllm_mlx.routes import audio as audio_route
+
+    _install_fake_mlx_audio(monkeypatch)
+    probe._reset_probe_cache()
+
+    monkeypatch.setattr(
+        "vllm_mlx.audio.stt.STTEngine", _FakeNonAlignerEngine, raising=False
+    )
+    stt_mod = sys.modules.get("vllm_mlx.audio.stt")
+    if stt_mod is not None:
+        monkeypatch.setattr(stt_mod, "STTEngine", _FakeNonAlignerEngine)
+    audio_route._stt_engine = None
+    yield
+    audio_route._stt_engine = None
+    probe._reset_probe_cache()
+
+
+class TestForcedAlignment:
+    def test_text_field_routes_to_alignment_verbose_json(self, _stub_aligner):
+        client, restore = _mount_audio_app()
+        try:
+            r = client.post(
+                "/v1/audio/transcriptions",
+                data={"text": "临终前", "language": "Chinese"},
+                files={"file": ("clip.wav", _make_tone_wav(), "audio/wav")},
+            )
+        finally:
+            restore()
+        assert r.status_code == 200, r.text
+        assert r.headers["content-type"].startswith("application/json")
+        body = r.json()
+        # Defaults to verbose_json → segments present with per-char timing.
+        assert body["text"] == "临终前"
+        assert isinstance(body["segments"], list)
+        assert len(body["segments"]) == 3
+        assert body["segments"][0]["text"] == "临"
+        assert body["segments"][0]["start"] == 0.0
+        assert body["segments"][0]["end"] == 0.2
+        # The known transcript was forwarded as an INPUT (no recognition),
+        # and the aligner default model was picked (model omitted).
+        call = _FakeAlignerEngine.last_call
+        assert call["text"] == "临终前"
+        assert call["language"] == "Chinese"
+
+    def test_alignment_honors_srt_response_format(self, _stub_aligner):
+        client, restore = _mount_audio_app()
+        try:
+            r = client.post(
+                "/v1/audio/transcriptions",
+                data={"text": "abc", "response_format": "srt"},
+                files={"file": ("clip.wav", _make_tone_wav(), "audio/wav")},
+            )
+        finally:
+            restore()
+        assert r.status_code == 200, r.text
+        ctype = r.headers["content-type"]
+        assert ctype.startswith("text/srt") or ctype.startswith("text/plain")
+        body = r.text
+        assert "00:00:00,000 --> 00:00:00,200" in body, body
+        assert "a" in body
+
+    def test_no_text_field_is_still_asr(self, _stub_aligner):
+        """Absent ``text`` → the alignment branch must NOT fire (the fake
+        aligner's transcribe() asserts if reached, so a clean non-500
+        here proves the ASR branch was taken)."""
+        client, restore = _mount_audio_app()
+        try:
+            r = client.post(
+                "/v1/audio/transcriptions",
+                data={"model": "whisper-large-v3"},
+                files={"file": ("clip.wav", _make_tone_wav(), "audio/wav")},
+            )
+        finally:
+            restore()
+        # transcribe() raises AssertionError → generic 500 envelope. The
+        # point is the alignment path did NOT run (align() not called).
+        assert _FakeAlignerEngine.last_call is None
+        assert r.status_code == 500, r.text
+
+    def test_non_aligner_model_with_text_is_400(self, _stub_non_aligner):
+        client, restore = _mount_audio_app()
+        try:
+            r = client.post(
+                "/v1/audio/transcriptions",
+                data={"model": "whisper-large-v3", "text": "hello"},
+                files={"file": ("clip.wav", _make_tone_wav(), "audio/wav")},
+            )
+        finally:
+            restore()
+        assert r.status_code == 400, r.text
+        body = r.json()
+        err = body.get("detail", {}).get("error") or body.get("error")
+        assert err is not None, body
+        assert err["type"] == "invalid_request_error", err
+        assert err["code"] == "invalid_alignment_request", err
+
+
+# ---------------------------------------------------------------------------
+# Route 3: POST /v1/video/generations  (CONTRACT-ONLY → 501)
+# ---------------------------------------------------------------------------
+
+
+class TestVideoContract:
+    def test_valid_request_returns_501(self):
+        client, restore = _mount_video_app()
+        try:
+            r = client.post(
+                "/v1/video/generations",
+                json={
+                    "model": "ltx-2.3",
+                    "prompt": "a red fox trotting through snow",
+                    "height": 704,
+                    "width": 1216,
+                    "num_frames": 97,
+                    "frame_rate": 25,
+                },
+            )
+        finally:
+            restore()
+        assert r.status_code == 501, r.text
+        body = r.json()
+        err = body.get("detail", {}).get("error") or body.get("error")
+        assert err is not None, body
+        assert err["type"] == "not_implemented_error", err
+        assert err["code"] == "video_backend_not_implemented", err
+        assert "REQUIREMENTS_rapid.md B1" in err["message"], err
+
+    def test_image_to_video_request_also_501(self):
+        client, restore = _mount_video_app()
+        try:
+            r = client.post(
+                "/v1/video/generations",
+                json={
+                    "prompt": "animate this",
+                    "image": "data:image/png;base64,iVBORw0KGgo=",
+                },
+            )
+        finally:
+            restore()
+        assert r.status_code == 501, r.text
+
+    def test_missing_prompt_is_422(self):
+        client, restore = _mount_video_app()
+        try:
+            r = client.post("/v1/video/generations", json={"model": "ltx-2.3"})
+        finally:
+            restore()
+        assert r.status_code == 422, r.text
+
+    def test_zero_frames_is_422(self):
+        client, restore = _mount_video_app()
+        try:
+            r = client.post(
+                "/v1/video/generations",
+                json={"prompt": "x", "num_frames": 0},
+            )
+        finally:
+            restore()
+        assert r.status_code == 422, r.text
+
+    def test_schema_round_trips(self):
+        """The request/response models colleagues integrate against must
+        validate a full payload and serialize the response envelope."""
+        from vllm_mlx.api.models import (
+            VideoGenerationRequest,
+            VideoGenerationResponse,
+            VideoGenerationResult,
+        )
+
+        req = VideoGenerationRequest(
+            prompt="hello", image="https://example.com/frame.png", seed=1
+        )
+        assert req.num_frames == 97
+        assert req.response_format == "mp4"
+
+        resp = VideoGenerationResponse(
+            created=123,
+            model="ltx-2.3",
+            data=[VideoGenerationResult(url="/tmp/out.mp4", width=1216, height=704)],
+        )
+        dumped = resp.model_dump()
+        assert dumped["data"][0]["url"] == "/tmp/out.mp4"
+        assert dumped["data"][0]["format"] == "mp4"

--- a/tests/test_content_farm_routes.py
+++ b/tests/test_content_farm_routes.py
@@ -403,12 +403,23 @@ class _FakeAlignerEngine:
         duration = segments[-1]["end"] if segments else 0.0
         return _FakeAlignResult(text, segments, language, duration)
 
-    # Present so a mis-routed request would blow up loudly rather than
-    # silently ASR — the route must NOT call this on the alignment path.
-    def transcribe(
-        self, audio_path, language=None, task="transcribe"
-    ):  # pragma: no cover
-        raise AssertionError("alignment path must not call transcribe()")
+    #: Set when ``transcribe`` runs, so a test can assert the ASR branch
+    #: was taken AND that it produced a real result — not merely that
+    #: ``align`` was skipped.
+    last_transcribe: dict | None = None
+
+    def transcribe(self, audio_path, language=None, task="transcribe"):
+        _FakeAlignerEngine.last_transcribe = {
+            "audio_path": str(audio_path),
+            "language": language,
+            "task": task,
+        }
+        return _FakeAlignResult(
+            "recognised speech",
+            [{"text": "recognised speech", "start": 0.0, "end": 1.0}],
+            language or "en",
+            1.0,
+        )
 
 
 class _FakeNonAlignerEngine:
@@ -443,9 +454,12 @@ def _stub_aligner(monkeypatch):
     if stt_mod is not None:
         monkeypatch.setattr(stt_mod, "STTEngine", _FakeAlignerEngine)
     _FakeAlignerEngine.last_call = None
+    _FakeAlignerEngine.last_transcribe = None
     audio_route._stt_engine = None
+    audio_route._aligner_engine = None
     yield
     audio_route._stt_engine = None
+    audio_route._aligner_engine = None
     probe._reset_probe_cache()
 
 
@@ -464,8 +478,10 @@ def _stub_non_aligner(monkeypatch):
     if stt_mod is not None:
         monkeypatch.setattr(stt_mod, "STTEngine", _FakeNonAlignerEngine)
     audio_route._stt_engine = None
+    audio_route._aligner_engine = None
     yield
     audio_route._stt_engine = None
+    audio_route._aligner_engine = None
     probe._reset_probe_cache()
 
 
@@ -514,22 +530,54 @@ class TestForcedAlignment:
         assert "a" in body
 
     def test_no_text_field_is_still_asr(self, _stub_aligner):
-        """Absent ``text`` → the alignment branch must NOT fire (the fake
-        aligner's transcribe() asserts if reached, so a clean non-500
-        here proves the ASR branch was taken)."""
+        """Absent ``text`` → unchanged ASR, positively verified.
+
+        This asserts the ASR branch actually SUCCEEDS and returns the
+        recognised text, not merely that ``align()`` was skipped. An
+        earlier version expected a 500 (the fake's ``transcribe`` raised),
+        which would have stayed green even if the whole ASR path were
+        broken — it only ever proved "not alignment".
+        """
         client, restore = _mount_audio_app()
         try:
             r = client.post(
                 "/v1/audio/transcriptions",
-                data={"model": "whisper-large-v3"},
+                data={"model": "whisper-large-v3", "response_format": "verbose_json"},
                 files={"file": ("clip.wav", _make_tone_wav(), "audio/wav")},
             )
         finally:
             restore()
-        # transcribe() raises AssertionError → generic 500 envelope. The
-        # point is the alignment path did NOT run (align() not called).
+        assert r.status_code == 200, r.text
+        assert r.json()["text"] == "recognised speech", r.text
+        # ASR ran; the alignment branch did not.
+        assert _FakeAlignerEngine.last_transcribe is not None
         assert _FakeAlignerEngine.last_call is None
-        assert r.status_code == 500, r.text
+
+    def test_blank_text_is_400_not_a_silent_asr_fallback(self, _stub_aligner):
+        """A present-but-blank ``text`` must 400, never quietly run ASR.
+
+        Sending ``text`` says "I have the transcript, give me timings".
+        Pre-fix a whitespace-only value fell through to speech
+        recognition and returned 200 — answering a different question
+        with no signal that the request had been reinterpreted.
+        """
+        client, restore = _mount_audio_app()
+        try:
+            r = client.post(
+                "/v1/audio/transcriptions",
+                data={"text": "   "},
+                files={"file": ("clip.wav", _make_tone_wav(), "audio/wav")},
+            )
+        finally:
+            restore()
+        assert r.status_code == 400, r.text
+        body = r.json()
+        err = body.get("detail", {}).get("error") or body.get("error")
+        assert err["code"] == "invalid_alignment_request", err
+        assert err["param"] == "text", err
+        # Neither engine path ran.
+        assert _FakeAlignerEngine.last_call is None
+        assert _FakeAlignerEngine.last_transcribe is None
 
     def test_non_aligner_model_with_text_is_400(self, _stub_non_aligner):
         client, restore = _mount_audio_app()
@@ -567,8 +615,11 @@ class TestForcedAlignment:
         finally:
             restore()
         assert r.status_code == 200, r.text
-        assert "ForcedAligner" in audio_route._stt_engine.model_name, (
-            audio_route._stt_engine.model_name
+        # The aligner lives in its own cache, deliberately NOT the shared
+        # ``_stt_engine`` the ASR lane mutates from the event loop.
+        assert audio_route._stt_engine is None, audio_route._stt_engine
+        assert "ForcedAligner" in audio_route._aligner_engine.model_name, (
+            audio_route._aligner_engine.model_name
         )
 
     @pytest.mark.parametrize("blank", ["", "   "])
@@ -594,8 +645,11 @@ class TestForcedAlignment:
         finally:
             restore()
         assert r.status_code == 200, r.text
-        assert "ForcedAligner" in audio_route._stt_engine.model_name, (
-            audio_route._stt_engine.model_name
+        # The aligner lives in its own cache, deliberately NOT the shared
+        # ``_stt_engine`` the ASR lane mutates from the event loop.
+        assert audio_route._stt_engine is None, audio_route._stt_engine
+        assert "ForcedAligner" in audio_route._aligner_engine.model_name, (
+            audio_route._aligner_engine.model_name
         )
 
     def test_blank_response_format_takes_verbose_json(self, _stub_aligner):
@@ -766,6 +820,58 @@ class TestVideoContract:
         finally:
             restore()
         assert r.status_code == 400, r.text
+
+    @pytest.mark.parametrize(
+        "image",
+        [
+            "file:///etc/passwd",
+            "FILE:///etc/passwd",
+            "gopher://internal/x",
+            "ftp://internal/frame.png",
+            "data:text/html;base64,PHNjcmlwdD4=",
+            "data:;base64,AAAA",
+            "   ",
+        ],
+    )
+    def test_unsafe_image_reference_is_rejected(self, image):
+        """``image`` is the only field a backend DEREFERENCES.
+
+        Left unconstrained it is a local-file-read (``file://``) and SSRF
+        primitive the instant ``resolve_video_engine`` stops raising.
+        Validate at the schema boundary so every future backend inherits
+        the restriction rather than each having to remember it.
+        """
+        client, restore = _mount_video_app()
+        try:
+            r = client.post(
+                "/v1/video/generations",
+                json={"prompt": "animate", "image": image},
+            )
+        finally:
+            restore()
+        assert r.status_code == 422, r.text
+
+    @pytest.mark.parametrize(
+        "image",
+        [
+            "data:image/png;base64,iVBORw0KGgo=",
+            "https://example.com/frame.png",
+            "http://example.com/frame.png",
+            "iVBORw0KGgoAAAANSUhEUg==",  # bare base64, no scheme
+        ],
+    )
+    def test_documented_image_forms_are_accepted(self, image):
+        """The three forms docs/content_farm_api.md advertises must pass
+        validation (and then hit the contract-only 501, not a 422)."""
+        client, restore = _mount_video_app()
+        try:
+            r = client.post(
+                "/v1/video/generations",
+                json={"prompt": "animate", "image": image},
+            )
+        finally:
+            restore()
+        assert r.status_code == 501, r.text
 
     def test_schema_round_trips(self):
         """The request/response models colleagues integrate against must

--- a/tests/test_content_farm_routes.py
+++ b/tests/test_content_farm_routes.py
@@ -973,8 +973,12 @@ class TestAlignmentErrorClassification:
         assert r.status_code == 400, r.text
         body = r.json()
         err = body.get("detail", {}).get("error") or body.get("error")
-        assert err["code"] != "invalid_alignment_request", err
-        assert err["param"] != "text", err
+        # Assert the EXACT documented decode envelope, not merely
+        # "something other than invalid_alignment_request" — a weaker
+        # assertion would be satisfied by any unrelated error.
+        assert err["type"] == "invalid_request_error", err
+        assert err["code"] == "invalid_audio_file", err
+        assert err["param"] == "file", err
 
 
 def test_direct_handler_call_tolerates_unresolved_form_defaults(monkeypatch):
@@ -1035,3 +1039,116 @@ def test_direct_handler_call_tolerates_unresolved_form_defaults(monkeypatch):
     # A 404 for the bogus alias proves we got through the ASR/alignment
     # branch selection without an AttributeError on the sentinel.
     assert exc_info.value.status_code == 404, exc_info.value.detail
+
+
+class TestMusicEmptyOutputDetection:
+    """A "successful" render with no audio must not become a 200."""
+
+    def _post_with_engine(self, monkeypatch, engine_cls):
+        from vllm_mlx.routes import audio as audio_route
+
+        monkeypatch.setattr(
+            "vllm_mlx.audio.music.MusicEngine", engine_cls, raising=False
+        )
+        music_mod = sys.modules.get("vllm_mlx.audio.music")
+        if music_mod is not None:
+            monkeypatch.setattr(music_mod, "MusicEngine", engine_cls)
+        audio_route._music_engine = None
+        client, restore = _mount_audio_app()
+        try:
+            return client.post("/v1/audio/music", json={"input": "x", "seconds": 5})
+        finally:
+            restore()
+            audio_route._music_engine = None
+
+    def test_header_only_wav_is_500_not_a_silent_clip(self, monkeypatch):
+        """A valid RIFF header with ZERO sample frames must fail.
+
+        A bare WAV header is ~44 bytes, so a non-empty-bytes check passes
+        it and the caller receives a 200 with `audio/wav` that plays as
+        silence — indistinguishable from a real quiet track. Regression
+        pin for codex round-4 finding 1.
+        """
+
+        class _HeaderOnlyEngine(_FakeMusicEngine):
+            def generate(self, prompt, out_path, **kwargs):  # noqa: D102
+                with wave.open(str(out_path), "wb") as w:
+                    w.setnchannels(1)
+                    w.setsampwidth(2)
+                    w.setframerate(44100)
+                    # No writeframes() call at all.
+                return out_path
+
+        r = self._post_with_engine(monkeypatch, _HeaderOnlyEngine)
+        assert r.status_code == 500, r.text
+        assert r.json()["detail"]["error"]["code"] == "music_generation_failed", r.text
+
+    def test_unparseable_container_is_still_returned(self, monkeypatch):
+        """Non-WAV bytes must NOT be rejected by the emptiness guard.
+
+        The guard exists to catch a specific empty-output failure, not to
+        become a format validator that refuses a good clip in a container
+        ``wave`` can't parse. Bytes it can't read count as having audio.
+        """
+
+        class _OpaqueEngine(_FakeMusicEngine):
+            def generate(self, prompt, out_path, **kwargs):  # noqa: D102
+                with open(out_path, "wb") as fh:
+                    fh.write(b"\x00\x01\x02\x03" * 64)
+                return out_path
+
+        r = self._post_with_engine(monkeypatch, _OpaqueEngine)
+        assert r.status_code == 200, r.text
+        assert r.content == b"\x00\x01\x02\x03" * 64
+
+
+class TestAlignmentInternalErrorsAreNot400:
+    def test_unexpected_value_error_is_500_not_invalid_request(self, monkeypatch):
+        """An internal ValueError must not be blamed on `model` / `text`.
+
+        ``align()`` raises ValueError for exactly two caller mistakes. A
+        ValueError from anywhere else (weight loading, tokenizing, a
+        numeric conversion) is an internal fault; reporting it as
+        ``invalid_alignment_request`` sends the caller to fix a field that
+        was never wrong. Regression pin for codex round-4 finding 2.
+        """
+        from vllm_mlx.audio import probe
+        from vllm_mlx.routes import audio as audio_route
+
+        _install_fake_mlx_audio(monkeypatch)
+        probe._reset_probe_cache()
+
+        class _InternallyBrokenEngine:
+            def __init__(self, model_name):
+                self.model_name = model_name
+
+            def load(self):
+                pass
+
+            def align(self, audio_path, text, language="Chinese"):
+                # Nothing to do with the caller's model or text.
+                raise ValueError("cannot reshape array of size 0 into shape (1,80)")
+
+        monkeypatch.setattr(
+            "vllm_mlx.audio.stt.STTEngine", _InternallyBrokenEngine, raising=False
+        )
+        stt_mod = sys.modules.get("vllm_mlx.audio.stt")
+        if stt_mod is not None:
+            monkeypatch.setattr(stt_mod, "STTEngine", _InternallyBrokenEngine)
+        audio_route._aligner_engine = None
+
+        client, restore = _mount_audio_app()
+        try:
+            r = client.post(
+                "/v1/audio/transcriptions",
+                data={"text": "abc", "model": "qwen3-aligner"},
+                files={"file": ("clip.wav", _make_tone_wav(), "audio/wav")},
+            )
+        finally:
+            restore()
+            audio_route._aligner_engine = None
+            probe._reset_probe_cache()
+
+        assert r.status_code == 500, r.text
+        err = r.json()["detail"]["error"]
+        assert err["code"] == "alignment_failed", err

--- a/tests/test_content_farm_routes.py
+++ b/tests/test_content_farm_routes.py
@@ -64,13 +64,25 @@ def _mount_audio_app() -> tuple[TestClient, callable]:
     return TestClient(app), _restore
 
 
-def _mount_video_app() -> tuple[TestClient, callable]:
-    """Mount the video router on a bare FastAPI app, bypassing auth."""
+def _mount_video_app(with_handlers: bool = False) -> tuple[TestClient, callable]:
+    """Mount the video router on a bare FastAPI app, bypassing auth.
+
+    ``with_handlers=True`` additionally installs the server's global
+    exception handlers, which is what turns a schema rejection into the
+    documented 400 instead of stock FastAPI's 422 — see
+    :meth:`TestVideoContract.test_schema_rejection_is_400_on_the_real_app`.
+    """
     from vllm_mlx.config import get_config
     from vllm_mlx.routes import video as video_route
 
     app = FastAPI()
     app.include_router(video_route.router)
+    if with_handlers:
+        from vllm_mlx.middleware.exception_handlers import (
+            install_exception_handlers,
+        )
+
+        install_exception_handlers(app)
     cfg = get_config()
     saved = cfg.api_key
     cfg.api_key = None
@@ -253,6 +265,105 @@ class TestMusicRoute:
             restore()
         assert r.status_code == 422, r.text
         assert _FakeMusicEngine.last_call is None
+
+    def test_over_long_input_is_422_not_argv_blowup(self, _stub_music_engine):
+        """A giant prompt must 422 at the schema, not reach the engine.
+
+        ``MusicEngine.generate`` passes ``input`` as an argv element to
+        the vendored SA3 CLI, so an unbounded prompt hits the OS
+        ``ARG_MAX`` ceiling and surfaces as an opaque 500 ``E2BIG``. The
+        ``max_length`` bound turns that into an actionable 422.
+        """
+        client, restore = _mount_audio_app()
+        try:
+            r = client.post(
+                "/v1/audio/music",
+                json={"input": "x" * 5000, "seconds": 5},
+            )
+        finally:
+            restore()
+        assert r.status_code == 422, r.text
+        assert _FakeMusicEngine.last_call is None
+
+    def test_engine_writing_nothing_is_500_not_empty_200(self, monkeypatch):
+        """An engine that exits cleanly without writing must 500.
+
+        The SA3 CLI can return success having produced no audio (a sampler
+        that bailed after the header). Returning that as HTTP 200 with an
+        empty ``audio/wav`` body reads to the caller as a successfully
+        generated silent clip — the worst kind of failure. Assert we fail
+        loudly with the documented ``music_generation_failed`` envelope.
+        """
+
+        class _SilentEngine(_FakeMusicEngine):
+            def generate(self, prompt, out_path, **kwargs):  # noqa: D102
+                # Exits "successfully" but leaves the temp file at 0 bytes.
+                return out_path
+
+        from vllm_mlx.routes import audio as audio_route
+
+        monkeypatch.setattr(
+            "vllm_mlx.audio.music.MusicEngine", _SilentEngine, raising=False
+        )
+        music_mod = sys.modules.get("vllm_mlx.audio.music")
+        if music_mod is not None:
+            monkeypatch.setattr(music_mod, "MusicEngine", _SilentEngine)
+        audio_route._music_engine = None
+        client, restore = _mount_audio_app()
+        try:
+            r = client.post("/v1/audio/music", json={"input": "silence", "seconds": 5})
+        finally:
+            restore()
+            audio_route._music_engine = None
+        assert r.status_code == 500, r.text
+        assert r.json()["detail"]["error"]["code"] == "music_generation_failed", r.text
+
+    def test_generation_does_not_block_the_event_loop(self, _stub_music_engine):
+        """The blocking render must run off the event loop.
+
+        ``MusicEngine.generate`` shells out and waits (up to 900 s by
+        default). Calling it inline from the ``async def`` handler would
+        stall every other request on the server for the whole render, so
+        the handler hands it to ``asyncio.to_thread``. Detect that
+        structurally: the engine must observe a DIFFERENT thread than the
+        one running the event loop.
+        """
+        import asyncio
+        import threading
+
+        observed: dict[str, int] = {}
+
+        class _ThreadRecordingEngine(_FakeMusicEngine):
+            def generate(self, prompt, out_path, **kwargs):  # noqa: D102
+                observed["engine_thread"] = threading.get_ident()
+                with open(out_path, "wb") as fh:
+                    fh.write(_make_tone_wav())
+                return out_path
+
+        from vllm_mlx.api.models import AudioMusicRequest
+        from vllm_mlx.routes import audio as audio_route
+
+        async def _drive():
+            observed["loop_thread"] = threading.get_ident()
+            return await audio_route.create_music(
+                AudioMusicRequest(input="a march", seconds=5)
+            )
+
+        saved = audio_route._music_engine
+        try:
+            music_mod = sys.modules["vllm_mlx.audio.music"]
+            saved_cls = music_mod.MusicEngine
+            music_mod.MusicEngine = _ThreadRecordingEngine
+            audio_route._music_engine = None
+            try:
+                resp = asyncio.run(_drive())
+            finally:
+                music_mod.MusicEngine = saved_cls
+        finally:
+            audio_route._music_engine = saved
+
+        assert resp.body[:4] == b"RIFF", resp.body[:16]
+        assert observed["engine_thread"] != observed["loop_thread"], observed
 
 
 # ---------------------------------------------------------------------------
@@ -437,6 +548,133 @@ class TestForcedAlignment:
         assert err["type"] == "invalid_request_error", err
         assert err["code"] == "invalid_alignment_request", err
 
+    def test_omitted_model_resolves_to_the_registered_aligner(self, _stub_aligner):
+        """No ``model`` → the ALIGNER alias, not the ASR default.
+
+        ``whisper-large-v3`` is not a forced aligner, so defaulting the
+        alignment branch to it would fail deep in ``STTEngine.align``.
+        Assert the resolved repo is actually the aligner.
+        """
+        from vllm_mlx.routes import audio as audio_route
+
+        client, restore = _mount_audio_app()
+        try:
+            r = client.post(
+                "/v1/audio/transcriptions",
+                data={"text": "abc"},
+                files={"file": ("clip.wav", _make_tone_wav(), "audio/wav")},
+            )
+        finally:
+            restore()
+        assert r.status_code == 200, r.text
+        assert "ForcedAligner" in audio_route._stt_engine.model_name, (
+            audio_route._stt_engine.model_name
+        )
+
+    @pytest.mark.parametrize("blank", ["", "   "])
+    def test_blank_model_takes_the_aligner_default(self, _stub_aligner, blank):
+        """A BLANK ``model`` must behave as omitted, not error.
+
+        ``""`` is already absorbed by FastAPI (it coerces an empty form
+        field to ``None`` for an ``Optional[str]``) — kept here to pin
+        that boundary. ``"   "`` is the one that actually leaked: it
+        arrives verbatim and pre-fix reached ``_resolve_stt_model`` as an
+        explicit choice, 404-ing as a nonexistent alias, so "just send
+        audio + text" from a form with a spaced-out field never aligned.
+        """
+        from vllm_mlx.routes import audio as audio_route
+
+        client, restore = _mount_audio_app()
+        try:
+            r = client.post(
+                "/v1/audio/transcriptions",
+                data={"text": "abc", "model": blank},
+                files={"file": ("clip.wav", _make_tone_wav(), "audio/wav")},
+            )
+        finally:
+            restore()
+        assert r.status_code == 200, r.text
+        assert "ForcedAligner" in audio_route._stt_engine.model_name, (
+            audio_route._stt_engine.model_name
+        )
+
+    def test_blank_response_format_takes_verbose_json(self, _stub_aligner):
+        """A whitespace-only ``response_format`` must fall back to verbose_json.
+
+        Same shape as the ``model`` case above: pre-fix ``"   "`` counted
+        as an explicit choice, reached the allowed-set check and 400'd —
+        losing the timestamps the caller came for.
+        """
+        client, restore = _mount_audio_app()
+        try:
+            r = client.post(
+                "/v1/audio/transcriptions",
+                data={"text": "abc", "response_format": "   "},
+                files={"file": ("clip.wav", _make_tone_wav(), "audio/wav")},
+            )
+        finally:
+            restore()
+        assert r.status_code == 200, r.text
+        assert isinstance(r.json()["segments"], list), r.text
+
+    def test_alignment_does_not_block_the_event_loop(self, _stub_aligner):
+        """Weight load + align must run off the event loop.
+
+        Both are seconds of blocking compute; inline in the ``async def``
+        handler they stall every concurrent request on the server. Detect
+        structurally — the engine must see a different thread than the
+        loop.
+        """
+        import asyncio
+        import threading
+
+        from vllm_mlx.routes import audio as audio_route
+
+        seen: dict[str, int] = {}
+        real_align = _FakeAlignerEngine.align
+
+        def _recording_align(self, audio_path, text, language="Chinese"):
+            seen["engine_thread"] = threading.get_ident()
+            return real_align(self, audio_path, text, language=language)
+
+        async def _drive():
+            seen["loop_thread"] = threading.get_ident()
+            with open(_tmp_wav(), "rb") as fh:
+                return await audio_route._run_alignment_request(
+                    file=_UploadLike(fh.read()),
+                    model="qwen3-aligner",
+                    text="abc",
+                    language=None,
+                    response_format="verbose_json",
+                )
+
+        _FakeAlignerEngine.align = _recording_align
+        try:
+            asyncio.run(_drive())
+        finally:
+            _FakeAlignerEngine.align = real_align
+        assert seen["engine_thread"] != seen["loop_thread"], seen
+
+
+def _tmp_wav() -> str:
+    """Write a throwaway tone wav and return its path."""
+    import tempfile
+
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".wav") as fh:
+        fh.write(_make_tone_wav())
+        return fh.name
+
+
+class _UploadLike:
+    """Minimal stand-in for ``UploadFile`` — only ``read`` is exercised by
+    ``_stream_upload_to_tempfile``."""
+
+    def __init__(self, payload: bytes):
+        self._buf = io.BytesIO(payload)
+
+    async def read(self, size: int = -1) -> bytes:
+        return self._buf.read(size)
+
 
 # ---------------------------------------------------------------------------
 # Route 3: POST /v1/video/generations  (CONTRACT-ONLY → 501)
@@ -466,7 +704,7 @@ class TestVideoContract:
         assert err is not None, body
         assert err["type"] == "not_implemented_error", err
         assert err["code"] == "video_backend_not_implemented", err
-        assert "REQUIREMENTS_rapid.md B1" in err["message"], err
+        assert "docs/content_farm_api.md" in err["message"], err
 
     def test_image_to_video_request_also_501(self):
         client, restore = _mount_video_app()
@@ -500,6 +738,34 @@ class TestVideoContract:
         finally:
             restore()
         assert r.status_code == 422, r.text
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            {"model": "ltx-2.3"},  # prompt missing
+            {"prompt": "   "},  # blank prompt
+            {"prompt": "x", "num_frames": 0},
+            {"prompt": "x", "frame_rate": "NaN"},
+            {"prompt": "x", "response_format": "webm"},
+        ],
+    )
+    def test_schema_rejection_is_400_on_the_real_app(self, body):
+        """Schema rejections reach the caller as 400, not FastAPI's 422.
+
+        The bare-app tests above see 422 because they mount the router
+        without the server's handlers. On the REAL server
+        ``install_exception_handlers`` normalizes every
+        ``RequestValidationError`` to a sanitized 400 — verified against a
+        live ``rapid-mlx serve`` — so that is the number
+        ``docs/content_farm_api.md`` documents and clients must code
+        against. Pinned here so the two can't drift apart again.
+        """
+        client, restore = _mount_video_app(with_handlers=True)
+        try:
+            r = client.post("/v1/video/generations", json=body)
+        finally:
+            restore()
+        assert r.status_code == 400, r.text
 
     def test_schema_round_trips(self):
         """The request/response models colleagues integrate against must

--- a/tests/test_content_farm_routes.py
+++ b/tests/test_content_farm_routes.py
@@ -975,3 +975,63 @@ class TestAlignmentErrorClassification:
         err = body.get("detail", {}).get("error") or body.get("error")
         assert err["code"] != "invalid_alignment_request", err
         assert err["param"] != "text", err
+
+
+def test_direct_handler_call_tolerates_unresolved_form_defaults(monkeypatch):
+    """Calling ``create_transcription`` directly must not hit the new ``text``
+    logic with a FastAPI sentinel.
+
+    Several existing tests (e.g. test_audio_upload_size_limit) invoke the
+    handler as a plain coroutine rather than through the ASGI stack, so any
+    parameter they don't pass arrives as its unresolved ``Form(None)`` /
+    ``Query(None)`` object — truthy and non-None but NOT a string. The
+    pre-existing params only ever compare against None, so they tolerate
+    it; the forced-alignment branch calls ``.strip()``, which raised
+    ``AttributeError: 'Form' object has no attribute 'strip'`` until the
+    merge switched to an isinstance check.
+
+    Caught by pr_validate's full_unit step, not by the route tests — those
+    all go through TestClient, where FastAPI resolves the defaults.
+    """
+    import asyncio
+
+    from fastapi import HTTPException
+
+    from vllm_mlx.audio import probe
+    from vllm_mlx.routes import audio as audio_route
+
+    _install_fake_mlx_audio(monkeypatch)
+    probe._reset_probe_cache()
+
+    class _Boom:
+        """An engine that must never be reached — a bogus model 404s first."""
+
+        def __init__(self, model_name):  # pragma: no cover
+            raise AssertionError("engine must not be constructed")
+
+    monkeypatch.setattr("vllm_mlx.audio.stt.STTEngine", _Boom, raising=False)
+    stt_mod = sys.modules.get("vllm_mlx.audio.stt")
+    if stt_mod is not None:
+        monkeypatch.setattr(stt_mod, "STTEngine", _Boom)
+
+    # Only the pre-F-165 kwargs, exactly as the older direct-call tests do:
+    # text_form / text_query are left at their unresolved defaults.
+    try:
+        with pytest.raises(HTTPException) as exc_info:
+            asyncio.run(
+                audio_route.create_transcription(
+                    file=_UploadLike(_make_tone_wav()),  # type: ignore[arg-type]
+                    model_form="definitely-not-a-real-alias",
+                    language_form=None,
+                    response_format_form=None,
+                    model_query=None,
+                    language_query=None,
+                    response_format_query=None,
+                )
+            )
+    finally:
+        probe._reset_probe_cache()
+
+    # A 404 for the bogus alias proves we got through the ASR/alignment
+    # branch selection without an AttributeError on the sentinel.
+    assert exc_info.value.status_code == 404, exc_info.value.detail

--- a/tests/test_content_farm_routes.py
+++ b/tests/test_content_farm_routes.py
@@ -910,13 +910,24 @@ class TestVideoContract:
         with pytest.raises(ValidationError):
             VideoGenerationResult()
 
+        # A filesystem path is NOT a client-fetchable url — the field the
+        # handler deliberately avoids must refuse one. codex round-6 #4.
+        with pytest.raises(ValidationError):
+            VideoGenerationResult(url="/tmp/out.mp4")
+        with pytest.raises(ValidationError):
+            VideoGenerationResult(url="file:///tmp/out.mp4")
+
         resp = VideoGenerationResponse(
             created=123,
             model="ltx-2.3",
-            data=[VideoGenerationResult(url="/tmp/out.mp4", width=1216, height=704)],
+            data=[
+                VideoGenerationResult(
+                    url="https://cdn.example.com/out.mp4", width=1216, height=704
+                )
+            ],
         )
         dumped = resp.model_dump()
-        assert dumped["data"][0]["url"] == "/tmp/out.mp4"
+        assert dumped["data"][0]["url"] == "https://cdn.example.com/out.mp4"
         assert dumped["data"][0]["format"] == "mp4"
 
 

--- a/tests/test_content_farm_routes.py
+++ b/tests/test_content_farm_routes.py
@@ -828,6 +828,13 @@ class TestVideoContract:
             "ftp://internal/frame.png",
             "data:text/html;base64,PHNjcmlwdD4=",
             "data:;base64,AAAA",
+            # Right media type, but not base64 at all — the contract
+            # promises base64 image data. Regression pin for codex
+            # round-3 finding 3.
+            "data:image/png,not-base64",
+            "data:image/png;base64,not!valid!base64",
+            "data:image/png;base64,",
+            "data:image/png;charset=utf8,%3Cscript%3E",
             "   ",
             # Scheme-less but not base64 — a bare path or host must not
             # sit in the field waiting for a backend to interpret it.
@@ -906,3 +913,65 @@ class TestVideoContract:
         dumped = resp.model_dump()
         assert dumped["data"][0]["url"] == "/tmp/out.mp4"
         assert dumped["data"][0]["format"] == "mp4"
+
+
+class TestAlignmentErrorClassification:
+    """A corrupted upload must be reported as a corrupted upload."""
+
+    def test_decode_error_is_invalid_audio_file_not_alignment_request(
+        self, monkeypatch
+    ):
+        """Decoder ValueErrors must not be mislabelled as a bad request.
+
+        Some codec paths raise ``ValueError`` for undecodable audio. The
+        alignment handler's ``except ValueError`` sits BEFORE the generic
+        handler that owns the decode envelope, so without an explicit
+        decode check first a corrupted upload came back as
+        ``invalid_alignment_request`` blaming ``model``/``text`` — sending
+        the caller to fix a field that was never wrong. Regression pin for
+        codex round-3 finding 1.
+        """
+        from vllm_mlx.audio import probe
+        from vllm_mlx.routes import audio as audio_route
+
+        _install_fake_mlx_audio(monkeypatch)
+        probe._reset_probe_cache()
+
+        class _DecodeFailingEngine:
+            def __init__(self, model_name):
+                self.model_name = model_name
+
+            def load(self):
+                pass
+
+            def align(self, audio_path, text, language="Chinese"):
+                # The shape a codec raises on a truncated/garbage file.
+                raise ValueError(
+                    "Error opening file: File contains data in an unknown format."
+                )
+
+        monkeypatch.setattr(
+            "vllm_mlx.audio.stt.STTEngine", _DecodeFailingEngine, raising=False
+        )
+        stt_mod = sys.modules.get("vllm_mlx.audio.stt")
+        if stt_mod is not None:
+            monkeypatch.setattr(stt_mod, "STTEngine", _DecodeFailingEngine)
+        audio_route._aligner_engine = None
+
+        client, restore = _mount_audio_app()
+        try:
+            r = client.post(
+                "/v1/audio/transcriptions",
+                data={"text": "abc", "model": "qwen3-aligner"},
+                files={"file": ("clip.wav", b"not-a-wav", "audio/wav")},
+            )
+        finally:
+            restore()
+            audio_route._aligner_engine = None
+            probe._reset_probe_cache()
+
+        assert r.status_code == 400, r.text
+        body = r.json()
+        err = body.get("detail", {}).get("error") or body.get("error")
+        assert err["code"] != "invalid_alignment_request", err
+        assert err["param"] != "text", err

--- a/tests/test_content_farm_routes.py
+++ b/tests/test_content_farm_routes.py
@@ -841,6 +841,11 @@ class TestVideoContract:
             "/etc/passwd",
             "../../secret.png",
             "internal.corp.example",
+            # Allowed scheme but no host — shapes a lenient fetcher may
+            # resolve against the local filesystem. codex round-5 #2.
+            "https:///etc/passwd",
+            "http:frame.png",
+            "https://",
         ],
     )
     def test_unsafe_image_reference_is_rejected(self, image):
@@ -1083,12 +1088,15 @@ class TestMusicEmptyOutputDetection:
         assert r.status_code == 500, r.text
         assert r.json()["detail"]["error"]["code"] == "music_generation_failed", r.text
 
-    def test_unparseable_container_is_still_returned(self, monkeypatch):
-        """Non-WAV bytes must NOT be rejected by the emptiness guard.
+    def test_unparseable_output_is_500_not_mislabelled_wav(self, monkeypatch):
+        """Output that isn't a readable WAV must fail, not be mislabelled.
 
-        The guard exists to catch a specific empty-output failure, not to
-        become a format validator that refuses a good clip in a container
-        ``wave`` can't parse. Bytes it can't read count as having audio.
+        Fail-closed is right here because the producer uses the SAME
+        parser: SA3's ``save_wav`` writes 16-bit PCM through ``wave.open``
+        (``audio/sa3/scripts/sa3_mlx.py``). So bytes ``wave`` can't read
+        are not SA3 output, and returning them under
+        ``Content-Type: audio/wav`` would be mislabelling. Regression pin
+        for codex round-5 finding 1.
         """
 
         class _OpaqueEngine(_FakeMusicEngine):
@@ -1098,8 +1106,8 @@ class TestMusicEmptyOutputDetection:
                 return out_path
 
         r = self._post_with_engine(monkeypatch, _OpaqueEngine)
-        assert r.status_code == 200, r.text
-        assert r.content == b"\x00\x01\x02\x03" * 64
+        assert r.status_code == 500, r.text
+        assert r.json()["detail"]["error"]["code"] == "music_generation_failed", r.text
 
 
 class TestAlignmentInternalErrorsAreNot400:

--- a/tests/test_server_auth_ordering.py
+++ b/tests/test_server_auth_ordering.py
@@ -200,6 +200,12 @@ PROTECTED_ROUTER_MODULES = (
     "vllm_mlx.routes.mcp_routes",
     "vllm_mlx.routes.models",
     "vllm_mlx.routes.responses",
+    # Content-farm video lane. CONTRACT-ONLY (returns 501 until a backend
+    # is registered) but still auth-gated: the route is mounted
+    # unconditionally in server.py, so an anonymous caller must not be
+    # able to probe it — and the day a backend lands it becomes a heavy
+    # compute endpoint that must already be behind the key.
+    "vllm_mlx.routes.video",
 )
 
 

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -2761,10 +2761,15 @@ class AudioMusicRequest(BaseModel):
       to the engine defaults.
     * ``seconds`` is bounded to SA3's ~47s ceiling; NaN/inf rejected via
       the finite validator (Pydantic ``le=`` alone lets NaN through).
+    * ``input`` is length-capped: ``MusicEngine.generate`` passes it as an
+      argv element to the vendored SA3 CLI, so an unbounded prompt hits
+      the OS ``ARG_MAX`` limit and surfaces as an opaque 500 ``E2BIG``
+      instead of a 422 the caller can act on. The cap matches
+      ``negative_prompt`` (both land on the same command line).
     """
 
     model: str = "medium"
-    input: str = Field(..., min_length=1)
+    input: str = Field(..., min_length=1, max_length=4096)
     seconds: float = Field(default=30.0, gt=0.0, le=_MUSIC_MAX_SECONDS)
     steps: int = Field(default=8, ge=1, le=200)
     negative_prompt: str | None = Field(default=None, max_length=4096)

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -9,11 +9,14 @@ These models define the request and response schemas for:
 - MCP (Model Context Protocol) integration
 """
 
+import base64
+import binascii
 import math
 import re
 import time
 import uuid
 from typing import Literal
+from urllib.parse import urlsplit
 
 from pydantic import (
     BaseModel,
@@ -2846,6 +2849,30 @@ _VIDEO_MAX_IMAGE_CHARS: int = 12 * 1024 * 1024
 #: SSRF primitive the moment a backend starts honouring it.
 _VIDEO_ALLOWED_IMAGE_URL_SCHEMES: tuple[str, ...] = ("http", "https")
 
+#: Shortest scheme-less ``image`` value accepted as a bare base64 frame.
+#: No real encoded image is anywhere near this small; the floor keeps
+#: short path-shaped strings from qualifying on charset alone.
+_BARE_BASE64_MIN_CHARS: int = 32
+
+
+def _is_bare_base64(value: str) -> bool:
+    """True if ``value`` is plausibly a raw base64 image payload.
+
+    A charset check alone is not enough: ``/etc/passwd`` contains only
+    base64-alphabet characters, so a naive regex accepts an absolute
+    filesystem path as an "inline frame". Require the value to actually
+    DECODE as base64 — which pins the length to a multiple of 4 and
+    rejects path- and hostname-shaped strings — plus a length floor.
+    """
+    compact = "".join(value.split())
+    if len(compact) < _BARE_BASE64_MIN_CHARS or len(compact) % 4 != 0:
+        return False
+    try:
+        base64.b64decode(compact, validate=True)
+    except (binascii.Error, ValueError):
+        return False
+    return True
+
 
 class VideoGenerationRequest(BaseModel):
     """Request for text→video AND image→video (``/v1/video/generations``).
@@ -2930,16 +2957,26 @@ class VideoGenerationRequest(BaseModel):
                 )
             return stripped
 
-        # A scheme is anything before "://". Bare base64 has none and is
-        # allowed through as an inline payload.
-        if "://" in lowered:
-            scheme = lowered.split("://", 1)[0]
-            if scheme not in _VIDEO_ALLOWED_IMAGE_URL_SCHEMES:
-                supported = ", ".join(_VIDEO_ALLOWED_IMAGE_URL_SCHEMES)
-                raise ValueError(
-                    f"image URL scheme {scheme!r} is not allowed; use one of: "
-                    f"{supported} (or pass the frame inline as base64)"
-                )
+        # Extract the scheme with urlsplit, NOT by looking for "://".
+        # A single-slash URI is still a URI: urlsplit("file:/etc/passwd")
+        # yields scheme "file", but a "://" substring test sees no scheme
+        # and would wave it through as bare base64 — which is exactly the
+        # local-file-read this validator exists to stop.
+        scheme = urlsplit(lowered).scheme
+        if scheme and scheme not in _VIDEO_ALLOWED_IMAGE_URL_SCHEMES:
+            supported = ", ".join(_VIDEO_ALLOWED_IMAGE_URL_SCHEMES)
+            raise ValueError(
+                f"image URL scheme {scheme!r} is not allowed; use one of: "
+                f"{supported} (or pass the frame inline as base64)"
+            )
+        # No scheme at all → treated as an inline base64 payload. Require
+        # it to actually BE base64 so a stray path or hostname can't sit
+        # in the field waiting for a backend to guess at it.
+        if not scheme and not _is_bare_base64(stripped):
+            raise ValueError(
+                "image must be a data:image/* URI, an http(s) URL, or a bare "
+                "base64 payload"
+            )
         return stripped
 
     @field_validator("response_format")
@@ -2971,6 +3008,23 @@ class VideoGenerationResult(BaseModel):
     height: int | None = None
     num_frames: int | None = None
     frame_rate: float | None = None
+
+    @model_validator(mode="after")
+    def _exactly_one_delivery_channel(self) -> "VideoGenerationResult":
+        """Enforce the documented "exactly one of b64_video / url".
+
+        A docstring invariant a model doesn't check is a comment. Without
+        this, a backend could return both (which does the client no favours
+        — which one is authoritative?) or neither (a 200 carrying no video
+        at all, the failure mode hardest to notice).
+        """
+        if (self.b64_video is None) == (self.url is None):
+            raise ValueError(
+                "exactly one of `b64_video` or `url` must be set on a "
+                "video result (got "
+                f"{'both' if self.b64_video is not None else 'neither'})"
+            )
+        return self
 
 
 class VideoGenerationResponse(BaseModel):

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -2833,6 +2833,19 @@ _VIDEO_MAX_DIMENSION: int = 4096
 _VIDEO_MAX_FRAMES: int = 4096
 _VIDEO_MAX_FRAME_RATE: float = 240.0
 
+#: Cap on the i2v conditioning-frame string. A base64 PNG/JPEG frame at
+#: the 4096x4096 dimension ceiling fits comfortably; the bound exists so
+#: an unbounded body can't be used to pin memory before any backend even
+#: looks at it. ~12 MB of base64 ≈ a 9 MB image.
+_VIDEO_MAX_IMAGE_CHARS: int = 12 * 1024 * 1024
+
+#: URL schemes accepted for the i2v conditioning frame. Deliberately a
+#: two-item allowlist rather than a blocklist: the field is a
+#: server-side fetch target, so anything else (``file://``, ``gopher://``,
+#: ``ftp://``, ``data:`` with a non-image type) is a local-file-read or
+#: SSRF primitive the moment a backend starts honouring it.
+_VIDEO_ALLOWED_IMAGE_URL_SCHEMES: tuple[str, ...] = ("http", "https")
+
 
 class VideoGenerationRequest(BaseModel):
     """Request for text→video AND image→video (``/v1/video/generations``).
@@ -2848,9 +2861,10 @@ class VideoGenerationRequest(BaseModel):
 
     model: str = "ltx-2.3"
     prompt: str = Field(..., min_length=1)
-    # base64 (optionally as a ``data:`` URI) OR an http(s) URL of the
-    # conditioning frame for image-to-video. ``None`` → text-to-video.
-    image: str | None = None
+    # base64 (optionally as a ``data:image/*`` URI) OR an http(s) URL of
+    # the conditioning frame for image-to-video. ``None`` → text-to-video.
+    # Scheme-validated below: this becomes a server-side fetch target.
+    image: str | None = Field(default=None, max_length=_VIDEO_MAX_IMAGE_CHARS)
     height: int = Field(default=704, gt=0, le=_VIDEO_MAX_DIMENSION)
     width: int = Field(default=1216, gt=0, le=_VIDEO_MAX_DIMENSION)
     num_frames: int = Field(default=97, ge=1, le=_VIDEO_MAX_FRAMES)
@@ -2875,6 +2889,58 @@ class VideoGenerationRequest(BaseModel):
         if not math.isfinite(v):
             raise ValueError("frame_rate must be a finite number")
         return v
+
+    @field_validator("image")
+    @classmethod
+    def _image_must_be_a_safe_reference(cls, v: str | None) -> str | None:
+        """Constrain the i2v conditioning frame to safe reference forms.
+
+        ``image`` is the one field in this contract a backend will
+        DEREFERENCE, which makes it the request's only server-side fetch
+        primitive. Left unconstrained, ``file:///etc/passwd`` becomes an
+        arbitrary local-file read and ``http://169.254.169.254/...`` (or
+        any internal address) becomes SSRF — the moment
+        ``resolve_video_engine`` stops raising. Validating at the schema
+        boundary means every future backend inherits the restriction
+        instead of each having to remember it.
+
+        Accepted: a ``data:image/...;base64,`` URI, an ``http(s)://`` URL,
+        or a bare base64 payload (no scheme at all). Anything with a
+        scheme outside the allowlist is rejected.
+
+        This is NOT complete SSRF defence — an allowed ``https://`` host
+        can still resolve to a private address. Egress policy for the
+        actual fetch stays the backend integrator's job; see
+        ``docs/content_farm_api.md``.
+        """
+        if v is None:
+            return None
+        stripped = v.strip()
+        if not stripped:
+            raise ValueError("image must be a non-empty string when provided")
+
+        lowered = stripped.lower()
+        if lowered.startswith("data:"):
+            # Only image payloads — ``data:text/html`` or an unlabelled
+            # ``data:;base64`` is not a conditioning frame.
+            if not lowered.startswith("data:image/"):
+                raise ValueError(
+                    "image data: URI must declare an image/* media type "
+                    "(e.g. data:image/png;base64,...)"
+                )
+            return stripped
+
+        # A scheme is anything before "://". Bare base64 has none and is
+        # allowed through as an inline payload.
+        if "://" in lowered:
+            scheme = lowered.split("://", 1)[0]
+            if scheme not in _VIDEO_ALLOWED_IMAGE_URL_SCHEMES:
+                supported = ", ".join(_VIDEO_ALLOWED_IMAGE_URL_SCHEMES)
+                raise ValueError(
+                    f"image URL scheme {scheme!r} is not allowed; use one of: "
+                    f"{supported} (or pass the frame inline as base64)"
+                )
+        return stripped
 
     @field_validator("response_format")
     @classmethod

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -2983,13 +2983,25 @@ class VideoGenerationRequest(BaseModel):
         # yields scheme "file", but a "://" substring test sees no scheme
         # and would wave it through as bare base64 — which is exactly the
         # local-file-read this validator exists to stop.
-        scheme = urlsplit(lowered).scheme
+        parts = urlsplit(lowered)
+        scheme = parts.scheme
         if scheme and scheme not in _VIDEO_ALLOWED_IMAGE_URL_SCHEMES:
             supported = ", ".join(_VIDEO_ALLOWED_IMAGE_URL_SCHEMES)
             raise ValueError(
                 f"image URL scheme {scheme!r} is not allowed; use one of: "
                 f"{supported} (or pass the frame inline as base64)"
             )
+        if scheme:
+            # An allowed scheme is not enough — the URL has to name a host.
+            # ``https:///etc/passwd`` (empty netloc, absolute local path)
+            # and ``http:frame.png`` (opaque, no netloc) both clear a
+            # scheme-only check while being exactly the shapes a lenient
+            # fetcher may resolve against the local filesystem.
+            if not parts.netloc:
+                raise ValueError(
+                    "image http(s) URL must include a host "
+                    "(e.g. https://example.com/frame.png)"
+                )
         # No scheme at all → treated as an inline base64 payload. Require
         # it to actually BE base64 so a stray path or hostname can't sit
         # in the field waiting for a backend to guess at it.

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -2734,11 +2734,184 @@ class AudioSpeechRequest(BaseModel):
         return lower
 
 
+# Content-farm lane: text→music/SFX ``response_format`` values the
+# ``/v1/audio/music`` route can produce. Stable Audio 3 renders WAV
+# natively; only ``wav`` is offered for now (mirrors the SA3 CLI's
+# output). Centralised so the validator and the route agree.
+_MUSIC_ALLOWED_RESPONSE_FORMATS: tuple[str, ...] = ("wav",)
+
+#: SA3 supports clips up to ~47s; reject longer requests up front so a
+#: caller doesn't wait on a generation the backend will clamp/refuse.
+_MUSIC_MAX_SECONDS: float = 47.0
+
+
+class AudioMusicRequest(BaseModel):
+    """Request for text→music / text→SFX (``/v1/audio/music``).
+
+    OpenAI-flavored shape mirroring :class:`AudioSpeechRequest` so the
+    content-farm music lane reads the same as the speech lane to a
+    colleague integrating over the API. Wired to
+    :class:`vllm_mlx.audio.music.MusicEngine` (MLX-native Stable Audio 3).
+
+    * ``input`` is the natural-language prompt (SA3's positive branch);
+      rejected empty / whitespace-only like the speech route's ``input``.
+    * ``model`` selects a DiT/decoder pairing via the route's
+      ``MUSIC_MODEL_ALIASES`` table (``medium`` = higher quality,
+      ``sm-music`` / ``sm-sfx`` = fast small). Unknown values fall back
+      to the engine defaults.
+    * ``seconds`` is bounded to SA3's ~47s ceiling; NaN/inf rejected via
+      the finite validator (Pydantic ``le=`` alone lets NaN through).
+    """
+
+    model: str = "medium"
+    input: str = Field(..., min_length=1)
+    seconds: float = Field(default=30.0, gt=0.0, le=_MUSIC_MAX_SECONDS)
+    steps: int = Field(default=8, ge=1, le=200)
+    negative_prompt: str | None = Field(default=None, max_length=4096)
+    seed: int | None = None
+    response_format: str = "wav"
+
+    @field_validator("input")
+    @classmethod
+    def _input_must_be_non_blank(cls, v: str) -> str:
+        if not v.strip():
+            raise ValueError("input must be a non-empty, non-blank string")
+        return v
+
+    @field_validator("seconds")
+    @classmethod
+    def _seconds_must_be_finite(cls, v: float) -> float:
+        # Pydantic ``gt=/le=`` does NOT reject NaN (every NaN comparison
+        # is False), so a ``seconds=NaN`` slips past the bounds and would
+        # reach the engine. Reject non-finite values explicitly.
+        if not math.isfinite(v):
+            raise ValueError("seconds must be a finite number")
+        return v
+
+    @field_validator("response_format")
+    @classmethod
+    def _response_format_must_be_known(cls, v: str) -> str:
+        if v is None:
+            return "wav"
+        lower = v.lower()
+        if lower not in _MUSIC_ALLOWED_RESPONSE_FORMATS:
+            supported = ", ".join(_MUSIC_ALLOWED_RESPONSE_FORMATS)
+            raise ValueError(f"response_format must be one of: {supported}; got {v!r}")
+        return lower
+
+
 class AudioSeparationRequest(BaseModel):
     """Request for audio source separation."""
 
     model: str = "htdemucs"
     stems: list[str] = Field(default_factory=lambda: ["vocals", "accompaniment"])
+
+
+# =============================================================================
+# Video generation (content-farm lane — CONTRACT-ONLY, no backend yet)
+# =============================================================================
+#
+# ``/v1/video/generations`` ships the request/response CONTRACT and the
+# ``VideoEngine`` interface (see :mod:`vllm_mlx.video.engine`) so
+# colleagues can integrate against a stable shape today and drop an
+# LTX-2.3 backend in behind it later. The route returns HTTP 501 until a
+# concrete backend is registered — the models below are the wire schema
+# a future backend must honour.
+
+_VIDEO_ALLOWED_RESPONSE_FORMATS: tuple[str, ...] = ("mp4",)
+
+#: Generous structural bounds — the concrete backend narrows these to
+#: whatever LTX-2.3 actually supports. They exist so a wildly-invalid
+#: request (0-frame, negative dimension, NaN frame rate) 400s at the
+#: schema boundary rather than reaching the engine.
+_VIDEO_MAX_DIMENSION: int = 4096
+_VIDEO_MAX_FRAMES: int = 4096
+_VIDEO_MAX_FRAME_RATE: float = 240.0
+
+
+class VideoGenerationRequest(BaseModel):
+    """Request for text→video AND image→video (``/v1/video/generations``).
+
+    Single schema covers both modes: text-to-video when ``image`` is
+    omitted, image-to-video (i2v) when ``image`` carries a base64 data
+    URI or an ``http(s)://`` URL of the conditioning first frame.
+
+    CONTRACT-ONLY: no backend is wired yet. A future LTX-2.3
+    implementation of :class:`vllm_mlx.video.engine.VideoEngine`
+    consumes exactly these fields.
+    """
+
+    model: str = "ltx-2.3"
+    prompt: str = Field(..., min_length=1)
+    # base64 (optionally as a ``data:`` URI) OR an http(s) URL of the
+    # conditioning frame for image-to-video. ``None`` → text-to-video.
+    image: str | None = None
+    height: int = Field(default=704, gt=0, le=_VIDEO_MAX_DIMENSION)
+    width: int = Field(default=1216, gt=0, le=_VIDEO_MAX_DIMENSION)
+    num_frames: int = Field(default=97, ge=1, le=_VIDEO_MAX_FRAMES)
+    frame_rate: float = Field(default=25.0, gt=0.0, le=_VIDEO_MAX_FRAME_RATE)
+    steps: int | None = Field(default=None, ge=1, le=500)
+    seed: int | None = None
+    negative_prompt: str | None = Field(default=None, max_length=4096)
+    response_format: str = "mp4"
+
+    @field_validator("prompt")
+    @classmethod
+    def _prompt_must_be_non_blank(cls, v: str) -> str:
+        if not v.strip():
+            raise ValueError("prompt must be a non-empty, non-blank string")
+        return v
+
+    @field_validator("frame_rate")
+    @classmethod
+    def _frame_rate_must_be_finite(cls, v: float) -> float:
+        # Same NaN caveat as AudioMusicRequest.seconds — ``gt=/le=`` lets
+        # NaN through, so reject non-finite frame rates explicitly.
+        if not math.isfinite(v):
+            raise ValueError("frame_rate must be a finite number")
+        return v
+
+    @field_validator("response_format")
+    @classmethod
+    def _response_format_must_be_known(cls, v: str) -> str:
+        if v is None:
+            return "mp4"
+        lower = v.lower()
+        if lower not in _VIDEO_ALLOWED_RESPONSE_FORMATS:
+            supported = ", ".join(_VIDEO_ALLOWED_RESPONSE_FORMATS)
+            raise ValueError(f"response_format must be one of: {supported}; got {v!r}")
+        return lower
+
+
+class VideoGenerationResult(BaseModel):
+    """One generated clip inside a :class:`VideoGenerationResponse`.
+
+    Mirrors the OpenAI images ``data[]`` item shape: exactly one of
+    ``b64_video`` (inline base64 mp4) or ``url`` is populated by a
+    backend. ``audio`` carries LTX-2.3's native soundtrack when the
+    backend emits one (base64 of the muxed track), else ``None``.
+    """
+
+    b64_video: str | None = None
+    url: str | None = None
+    audio: str | None = None
+    format: str = "mp4"
+    width: int | None = None
+    height: int | None = None
+    num_frames: int | None = None
+    frame_rate: float | None = None
+
+
+class VideoGenerationResponse(BaseModel):
+    """Response envelope for ``/v1/video/generations``.
+
+    Shaped like the OpenAI images API (``{created, data: [...]}``) with a
+    ``model`` echo so multi-model clients can attribute the result.
+    """
+
+    created: int
+    model: str
+    data: list[VideoGenerationResult]
 
 
 # =============================================================================

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -2855,6 +2855,18 @@ _VIDEO_ALLOWED_IMAGE_URL_SCHEMES: tuple[str, ...] = ("http", "https")
 _BARE_BASE64_MIN_CHARS: int = 32
 
 
+def _decodes_as_base64(value: str) -> bool:
+    """True if ``value`` (whitespace ignored) is well-formed base64."""
+    compact = "".join(value.split())
+    if not compact or len(compact) % 4 != 0:
+        return False
+    try:
+        base64.b64decode(compact, validate=True)
+    except (binascii.Error, ValueError):
+        return False
+    return True
+
+
 def _is_bare_base64(value: str) -> bool:
     """True if ``value`` is plausibly a raw base64 image payload.
 
@@ -2865,13 +2877,9 @@ def _is_bare_base64(value: str) -> bool:
     rejects path- and hostname-shaped strings — plus a length floor.
     """
     compact = "".join(value.split())
-    if len(compact) < _BARE_BASE64_MIN_CHARS or len(compact) % 4 != 0:
+    if len(compact) < _BARE_BASE64_MIN_CHARS:
         return False
-    try:
-        base64.b64decode(compact, validate=True)
-    except (binascii.Error, ValueError):
-        return False
-    return True
+    return _decodes_as_base64(compact)
 
 
 class VideoGenerationRequest(BaseModel):
@@ -2955,6 +2963,19 @@ class VideoGenerationRequest(BaseModel):
                     "image data: URI must declare an image/* media type "
                     "(e.g. data:image/png;base64,...)"
                 )
+            # The media type alone isn't enough: ``data:image/png,%3C...``
+            # is a well-formed data URI carrying URL-encoded text, and
+            # ``data:image/png;base64,not!base64`` carries garbage. The
+            # contract promises base64 image data, so require the marker
+            # and make the payload actually decode.
+            head, sep, payload = stripped.partition(",")
+            if not sep or not head.lower().endswith(";base64"):
+                raise ValueError(
+                    "image data: URI must be base64-encoded "
+                    "(e.g. data:image/png;base64,...)"
+                )
+            if not payload.strip() or not _decodes_as_base64(payload):
+                raise ValueError("image data: URI payload is not valid base64")
             return stripped
 
         # Extract the scheme with urlsplit, NOT by looking for "://".
@@ -2995,9 +3016,21 @@ class VideoGenerationResult(BaseModel):
     """One generated clip inside a :class:`VideoGenerationResponse`.
 
     Mirrors the OpenAI images ``data[]`` item shape: exactly one of
-    ``b64_video`` (inline base64 mp4) or ``url`` is populated by a
-    backend. ``audio`` carries LTX-2.3's native soundtrack when the
-    backend emits one (base64 of the muxed track), else ``None``.
+    ``b64_video`` (inline base64 mp4) or ``url`` is populated — enforced
+    by :meth:`_exactly_one_delivery_channel`.
+
+    **What the wired handler emits today, and what is reserved.**
+    :meth:`vllm_mlx.video.engine.VideoEngine.generate` returns a single
+    filesystem ``Path``, so the handler in
+    :mod:`vllm_mlx.routes.video` always fills ``b64_video`` and leaves
+    ``url`` and ``audio`` ``None``. Those two fields are RESERVED, not
+    live: a client must not expect them to be populated by the current
+    engine interface. Filling them requires ``VideoEngine`` to return a
+    structured artifact (bytes-or-URL plus an optional separate audio
+    track) rather than a bare ``Path`` — a deliberate follow-up on the
+    interface, kept out of the route layer. Until then, treat
+    ``b64_video`` as the delivery channel and ``url``/``audio`` as
+    forward-compatibility slots. See ``docs/content_farm_api.md``.
     """
 
     b64_video: str | None = None

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -3054,6 +3054,26 @@ class VideoGenerationResult(BaseModel):
     num_frames: int | None = None
     frame_rate: float | None = None
 
+    @field_validator("url")
+    @classmethod
+    def _url_must_be_a_fetchable_url(cls, v: str | None) -> str | None:
+        """``url`` must be a real http(s) URL, never a filesystem path.
+
+        The whole reason the wired handler returns ``b64_video`` is that a
+        server-side path is not something the client can fetch and echoing
+        one leaks the server's layout. Enforcing that here stops a future
+        backend from reintroducing the same mistake through this field.
+        """
+        if v is None:
+            return None
+        parts = urlsplit(v)
+        if parts.scheme.lower() not in ("http", "https") or not parts.netloc:
+            raise ValueError(
+                "url must be an absolute http(s) URL the client can fetch, "
+                "not a server-side filesystem path"
+            )
+        return v
+
     @model_validator(mode="after")
     def _exactly_one_delivery_channel(self) -> "VideoGenerationResult":
         """Enforce the documented "exactly one of b64_video / url".

--- a/vllm_mlx/routes/_async_utils.py
+++ b/vllm_mlx/routes/_async_utils.py
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Shared async helpers for the generation route lanes (audio / video).
+
+These lanes all have the same shape: an ``async def`` handler that must
+hand seconds-to-minutes of blocking engine work to a worker thread, while
+holding a lock and owning a temp file for exactly as long as that work
+runs. Getting the cancellation semantics right is subtle enough that the
+audio and video routes share one implementation rather than each carrying
+a copy that can drift.
+"""
+
+import asyncio
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+async def run_to_completion(func, /, *args):
+    """``asyncio.to_thread(func, *args)`` that survives cancellation.
+
+    A plain ``await asyncio.to_thread(...)`` is NOT cancellable — the
+    worker thread keeps running — but the await returns immediately when
+    the surrounding task is cancelled. That combination is dangerous for
+    the generation lanes, where a client disconnect cancels the handler
+    mid-render:
+
+    * an ``async with`` lock around the await would unwind and admit
+      another request while the abandoned thread is still using the
+      cached engine (or running a multi-GB subprocess), destroying the
+      one-at-a-time memory guarantee the lock exists to provide, and
+    * a ``finally`` block would delete the temp file or directory the
+      abandoned worker is still writing into.
+
+    So on cancellation we wait for the worker to actually finish before
+    propagating, keeping "lock held" and "output path alive" true for
+    exactly as long as the thread is running. The client is already gone,
+    so the extra wait costs nothing user-visible, and it is bounded by
+    the engine's own timeout.
+    """
+    task = asyncio.ensure_future(asyncio.to_thread(func, *args))
+    try:
+        return await asyncio.shield(task)
+    except asyncio.CancelledError:
+        # Drain the worker (ignoring its outcome — nobody is listening)
+        # before letting the cancellation unwind our lock + cleanup.
+        try:
+            await task
+        except Exception:
+            logger.debug("Abandoned worker finished with an error", exc_info=True)
+        raise

--- a/vllm_mlx/routes/audio.py
+++ b/vllm_mlx/routes/audio.py
@@ -2189,22 +2189,24 @@ def _generate_music_blocking(
 
 
 def _wav_has_audio_frames(payload: bytes) -> bool:
-    """True if ``payload`` is a WAV carrying at least one sample frame.
+    """True if ``payload`` is a parseable WAV with at least one sample frame.
 
-    Used to reject the "successful silent clip" outcome: SA3 can exit 0
-    having written only a RIFF header (~44 bytes), which passes a
-    non-empty-bytes check but contains no audio.
+    Rejects both empty-output failure modes: SA3 exiting 0 having written
+    only a RIFF header (~44 bytes, which passes a non-empty-bytes check
+    but contains no audio), and output that isn't a readable WAV at all.
 
-    Anything we cannot parse as WAV is treated as HAVING audio, on
-    purpose — this guard exists to catch a specific empty-output failure,
-    not to become a format validator that rejects a perfectly good clip
-    in a container ``wave`` doesn't understand.
+    Fail-CLOSED on a parse error, because the producer and this check use
+    the same parser: SA3's ``save_wav`` writes 16-bit PCM via
+    ``wave.open`` (see ``audio/sa3/scripts/sa3_mlx.py``). So anything
+    ``wave`` can't read is not SA3 output, and handing it back under
+    ``Content-Type: audio/wav`` would be mislabelling bytes rather than
+    tolerating an exotic container.
     """
     try:
         with wave.open(io.BytesIO(payload), "rb") as w:
             return w.getnframes() > 0
     except (wave.Error, EOFError, OSError):
-        return True
+        return False
 
 
 def _resolve_music_model(model: str | None) -> tuple[str, str]:

--- a/vllm_mlx/routes/audio.py
+++ b/vllm_mlx/routes/audio.py
@@ -994,10 +994,24 @@ async def _stream_upload_to_tempfile(file: UploadFile, tmp) -> None:
 #: Serialises the forced-alignment engine cache + ``align`` call. The
 #: alignment body runs on a worker thread (see
 #: :func:`_run_alignment_request`), so two concurrent requests could
-#: otherwise race the ``_stt_engine`` global and load the aligner's
-#: weights twice. A plain ``threading.Lock`` (not ``asyncio.Lock``) is
+#: otherwise load the aligner's weights twice or swap the engine out
+#: mid-align. A plain ``threading.Lock`` (not ``asyncio.Lock``) is
 #: required because the critical section executes off the event loop.
 _alignment_lock = threading.Lock()
+
+#: Cached forced-aligner engine — DELIBERATELY separate from
+#: ``_stt_engine``.
+#:
+#: Sharing one global across both lanes is unsafe now that alignment runs
+#: on a worker thread while ASR still runs on the event loop: an ASR
+#: request can replace the engine in between the alignment path's cache
+#: check and its ``align()`` call, and no lock held on only one side can
+#: prevent that. A dedicated cache removes the shared mutable state
+#: instead of trying to synchronise two lanes with different concurrency
+#: models. It also stops the two lanes evicting each other's weights on
+#: every alternating request, since an aligner and an ASR model are never
+#: the same ``model_name``.
+_aligner_engine = None
 
 
 def _align_blocking(
@@ -1015,9 +1029,9 @@ def _align_blocking(
 
     Holds :data:`_alignment_lock` across the cache check AND the align
     call so concurrent alignment requests don't double-load weights or
-    swap the shared engine out from under each other mid-align.
+    swap the engine out from under each other mid-align.
     """
-    global _stt_engine
+    global _aligner_engine
 
     from ..audio.stt import STTEngine
 
@@ -1028,10 +1042,10 @@ def _align_blocking(
         align_kwargs["language"] = language
 
     with _alignment_lock:
-        if _stt_engine is None or _stt_engine.model_name != model_name:
-            _stt_engine = STTEngine(model_name)
-            _stt_engine.load()
-        return _stt_engine.align(audio_path, text, **align_kwargs)
+        if _aligner_engine is None or _aligner_engine.model_name != model_name:
+            _aligner_engine = STTEngine(model_name)
+            _aligner_engine.load()
+        return _aligner_engine.align(audio_path, text, **align_kwargs)
 
 
 async def _run_alignment_request(
@@ -1352,9 +1366,38 @@ async def create_transcription(
         else (response_format_query if response_format_query is not None else "json")
     )
 
-    # Content-farm lane: a non-blank ``text`` field switches the route
-    # from ASR to FORCED ALIGNMENT of that known transcript.
-    is_alignment = text is not None and text.strip() != ""
+    # Content-farm lane: a ``text`` field switches the route from ASR to
+    # FORCED ALIGNMENT of that known transcript.
+    #
+    # PRESENCE, not truthiness, selects the branch. A whitespace-only
+    # ``text`` used to fall through to ASR, which silently answered a
+    # different question than the caller asked — they wanted timestamps
+    # for a transcript and got speech recognition instead, with a 200 that
+    # gives no hint anything was ignored. It now 400s with the same
+    # ``invalid_alignment_request`` envelope ``STTEngine.align`` raises for
+    # blank text, which is what docs/content_farm_api.md documents.
+    #
+    # A truly empty ``text=""`` is indistinguishable from an absent field
+    # here — FastAPI coerces both to ``None`` for an ``Optional[str]``
+    # form param — so it stays ASR. Only a non-empty-but-blank value is
+    # rejectable, and it is the shape that signals real caller intent.
+    if text is not None and not text.strip():
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "error": {
+                    "message": (
+                        "`text` was supplied but is blank. Send the known "
+                        "transcript to align, or omit `text` entirely for "
+                        "speech recognition."
+                    ),
+                    "type": "invalid_request_error",
+                    "code": "invalid_alignment_request",
+                    "param": "text",
+                }
+            },
+        )
+    is_alignment = text is not None
 
     if is_alignment:
         # Default to the registered aligner alias when the caller didn't

--- a/vllm_mlx/routes/audio.py
+++ b/vllm_mlx/routes/audio.py
@@ -1016,6 +1016,40 @@ def _get_alignment_lock() -> asyncio.Lock:
     return _alignment_lock
 
 
+async def _run_to_completion(func, /, *args):
+    """``asyncio.to_thread(func, *args)`` that survives cancellation.
+
+    A plain ``await asyncio.to_thread(...)`` is NOT cancellable — the
+    worker thread keeps running — but the await returns immediately on
+    cancellation. That is the dangerous combination for the audio lanes,
+    where a client disconnect cancels the handler mid-render:
+
+    * the ``async with`` lock around the await would unwind and admit
+      another request while the abandoned thread is still using the
+      cached engine (or running a multi-GB SA3 subprocess), destroying
+      the one-at-a-time memory guarantee the lock exists to provide, and
+    * the ``finally`` block would unlink the temp file the abandoned
+      worker is still writing to.
+
+    So on cancellation we wait for the worker to actually finish before
+    propagating, keeping "lock held" and "temp file alive" true for
+    exactly as long as the thread is running. The client is already gone;
+    the extra wait costs nothing user-visible and is bounded by the
+    engine's own timeout (900 s for SA3).
+    """
+    task = asyncio.ensure_future(asyncio.to_thread(func, *args))
+    try:
+        return await asyncio.shield(task)
+    except asyncio.CancelledError:
+        # Drain the worker (ignoring its outcome — nobody is listening)
+        # before letting the cancellation unwind our lock + cleanup.
+        try:
+            await task
+        except Exception:
+            logger.debug("Abandoned worker finished with an error", exc_info=True)
+        raise
+
+
 #: Cached forced-aligner engine — DELIBERATELY separate from
 #: ``_stt_engine``.
 #:
@@ -1108,7 +1142,7 @@ async def _run_alignment_request(
         # coroutine, whereas queueing inside the worker would pin an
         # executor thread per waiter and starve every other to_thread user.
         async with _get_alignment_lock():
-            result = await asyncio.to_thread(
+            result = await _run_to_completion(
                 _align_blocking, model_name, tmp_path, text, language
             )
 
@@ -1122,6 +1156,15 @@ async def _run_alignment_request(
     except HTTPException:
         raise
     except ValueError as e:
+        # Decoder failures come through as ValueError on some codec paths,
+        # and this handler sits BEFORE the generic ``except Exception``
+        # that owns the decode envelope — so classify decode errors first
+        # or a corrupted upload gets reported as ``invalid_alignment_request``
+        # blaming ``model``/``text``, which sends the caller chasing the
+        # wrong field.
+        if _is_decode_error(e):
+            logger.info("Forced alignment rejected corrupted upload: %s", e)
+            raise _audio_decode_error_envelope(e)
         # align() raises ValueError for the two client-fixable shapes:
         # a non-aligner model, or empty/blank known text. Surface a 400
         # ``invalid_request_error`` rather than the generic 500 so the
@@ -2173,7 +2216,7 @@ async def create_music(request: AudioMusicRequest = Body(...)):
         # queued renders don't each pin a shared executor thread.
         # See _generate_music_blocking and _music_lock.
         async with _get_music_lock():
-            await asyncio.to_thread(
+            await _run_to_completion(
                 _generate_music_blocking, dit, decoder, tmp_path, request
             )
 

--- a/vllm_mlx/routes/audio.py
+++ b/vllm_mlx/routes/audio.py
@@ -2,16 +2,19 @@
 """Audio endpoints (STT/TTS)."""
 
 import asyncio
+import io
 import logging
 import os
 import re
 import tempfile
+import wave
 
 from fastapi import APIRouter, Body, Depends, Form, HTTPException, Query, UploadFile
 from starlette.responses import PlainTextResponse, Response
 
 from ..api.models import AudioMusicRequest, AudioSpeechRequest
 from ..middleware.auth import verify_api_key
+from ._async_utils import run_to_completion
 
 logger = logging.getLogger(__name__)
 
@@ -1016,38 +1019,21 @@ def _get_alignment_lock() -> asyncio.Lock:
     return _alignment_lock
 
 
-async def _run_to_completion(func, /, *args):
-    """``asyncio.to_thread(func, *args)`` that survives cancellation.
+#: Signatures of the two ``ValueError``s :meth:`STTEngine.align` raises
+#: for caller mistakes (see its body): a model that isn't a forced
+#: aligner, and empty/blank known text. Matched on message because the
+#: engine raises bare ``ValueError`` for both; everything else that
+#: surfaces as a ValueError is an internal fault, not a bad request.
+_CLIENT_ALIGNMENT_ERROR_SIGNATURES = (
+    "requires a forced-aligner model",
+    "requires non-empty known text",
+)
 
-    A plain ``await asyncio.to_thread(...)`` is NOT cancellable — the
-    worker thread keeps running — but the await returns immediately on
-    cancellation. That is the dangerous combination for the audio lanes,
-    where a client disconnect cancels the handler mid-render:
 
-    * the ``async with`` lock around the await would unwind and admit
-      another request while the abandoned thread is still using the
-      cached engine (or running a multi-GB SA3 subprocess), destroying
-      the one-at-a-time memory guarantee the lock exists to provide, and
-    * the ``finally`` block would unlink the temp file the abandoned
-      worker is still writing to.
-
-    So on cancellation we wait for the worker to actually finish before
-    propagating, keeping "lock held" and "temp file alive" true for
-    exactly as long as the thread is running. The client is already gone;
-    the extra wait costs nothing user-visible and is bounded by the
-    engine's own timeout (900 s for SA3).
-    """
-    task = asyncio.ensure_future(asyncio.to_thread(func, *args))
-    try:
-        return await asyncio.shield(task)
-    except asyncio.CancelledError:
-        # Drain the worker (ignoring its outcome — nobody is listening)
-        # before letting the cancellation unwind our lock + cleanup.
-        try:
-            await task
-        except Exception:
-            logger.debug("Abandoned worker finished with an error", exc_info=True)
-        raise
+def _is_client_alignment_error(exc: Exception) -> bool:
+    """True if ``exc`` is an ``align()`` rejection the CALLER can fix."""
+    message = str(exc).lower()
+    return any(sig in message for sig in _CLIENT_ALIGNMENT_ERROR_SIGNATURES)
 
 
 #: Cached forced-aligner engine — DELIBERATELY separate from
@@ -1148,7 +1134,7 @@ async def _run_alignment_request(
         # coroutine, whereas queueing inside the worker would pin an
         # executor thread per waiter and starve every other to_thread user.
         async with _get_alignment_lock():
-            result = await _run_to_completion(
+            result = await run_to_completion(
                 _align_blocking, model_name, tmp_path, text, language
             )
 
@@ -1161,36 +1147,43 @@ async def _run_alignment_request(
         )
     except HTTPException:
         raise
-    except ValueError as e:
-        # Decoder failures come through as ValueError on some codec paths,
-        # and this handler sits BEFORE the generic ``except Exception``
-        # that owns the decode envelope — so classify decode errors first
-        # or a corrupted upload gets reported as ``invalid_alignment_request``
-        # blaming ``model``/``text``, which sends the caller chasing the
-        # wrong field.
-        if _is_decode_error(e):
-            logger.info("Forced alignment rejected corrupted upload: %s", e)
-            raise _audio_decode_error_envelope(e)
-        # align() raises ValueError for the two client-fixable shapes:
-        # a non-aligner model, or empty/blank known text. Surface a 400
-        # ``invalid_request_error`` rather than the generic 500 so the
-        # caller learns to pick an aligner alias / supply text.
-        logger.info("Forced alignment rejected request: %s", e)
-        raise HTTPException(
-            status_code=400,
-            detail={
-                "error": {
-                    "message": str(e),
-                    "type": "invalid_request_error",
-                    "code": "invalid_alignment_request",
-                    "param": "text" if "text" in str(e).lower() else "model",
-                }
-            },
-        )
     except Exception as e:
+        # ONE handler, classified inside — deliberately not a chain of
+        # ``except ValueError`` / ``except Exception`` clauses. A bare
+        # ``raise`` in the narrower clause exits the whole try statement
+        # rather than falling through to the broader one, so an
+        # "unclassified → let the generic handler take it" flow silently
+        # became a 500 with no envelope. Classifying in one place makes
+        # the precedence explicit and testable.
+
+        # 1. Corrupted / undecodable upload. Checked FIRST because some
+        #    codec paths raise plain ValueError, which would otherwise be
+        #    reported as a bad alignment request blaming ``model``/``text``
+        #    and send the caller chasing a field that was never wrong.
         if _is_decode_error(e):
             logger.info("Forced alignment rejected corrupted upload: %s", e)
             raise _audio_decode_error_envelope(e)
+
+        # 2. The two ``align()`` rejections the CALLER can fix: a model
+        #    that isn't a forced aligner, or blank known text. Any other
+        #    ValueError (weight loading, tokenizing, a reshape deep in the
+        #    model) is an internal fault and must not be dressed up as a
+        #    client error.
+        if isinstance(e, ValueError) and _is_client_alignment_error(e):
+            logger.info("Forced alignment rejected request: %s", e)
+            raise HTTPException(
+                status_code=400,
+                detail={
+                    "error": {
+                        "message": str(e),
+                        "type": "invalid_request_error",
+                        "code": "invalid_alignment_request",
+                        "param": "text" if "text" in str(e).lower() else "model",
+                    }
+                },
+            )
+
+        # 3. Everything else is ours, not the caller's.
         logger.exception("Forced alignment failed: %s", e)
         raise HTTPException(
             status_code=500,
@@ -2195,6 +2188,25 @@ def _generate_music_blocking(
     )
 
 
+def _wav_has_audio_frames(payload: bytes) -> bool:
+    """True if ``payload`` is a WAV carrying at least one sample frame.
+
+    Used to reject the "successful silent clip" outcome: SA3 can exit 0
+    having written only a RIFF header (~44 bytes), which passes a
+    non-empty-bytes check but contains no audio.
+
+    Anything we cannot parse as WAV is treated as HAVING audio, on
+    purpose — this guard exists to catch a specific empty-output failure,
+    not to become a format validator that rejects a perfectly good clip
+    in a container ``wave`` doesn't understand.
+    """
+    try:
+        with wave.open(io.BytesIO(payload), "rb") as w:
+            return w.getnframes() > 0
+    except (wave.Error, EOFError, OSError):
+        return True
+
+
 def _resolve_music_model(model: str | None) -> tuple[str, str]:
     """Map a ``/v1/audio/music`` ``model`` alias to a ``(dit, decoder)`` pair.
 
@@ -2239,7 +2251,7 @@ async def create_music(request: AudioMusicRequest = Body(...)):
         # queued renders don't each pin a shared executor thread.
         # See _generate_music_blocking and _music_lock.
         async with _get_music_lock():
-            await _run_to_completion(
+            await run_to_completion(
                 _generate_music_blocking, dit, decoder, tmp_path, request
             )
 
@@ -2248,14 +2260,20 @@ async def create_music(request: AudioMusicRequest = Body(...)):
             with open(tmp_path, "rb") as fh:
                 audio_bytes = fh.read()
 
-        # The SA3 CLI can exit 0 having written nothing (or a 0-byte
-        # placeholder) — e.g. a sampler that bailed after the header. Fail
-        # loudly instead of handing the caller an HTTP 200 with an empty
-        # ``audio/wav`` body, which reads as a successful silent clip.
-        if not audio_bytes:
+        # The SA3 CLI can exit 0 having written nothing, a 0-byte
+        # placeholder, or a valid RIFF header with zero sample frames —
+        # a sampler that bailed right after opening the file. All three
+        # must fail loudly: handing back an HTTP 200 with an empty or
+        # frameless ``audio/wav`` body reads to the caller as a
+        # successfully generated silent clip, which is the failure mode
+        # hardest to notice. A byte-count check alone misses the
+        # header-only case (a bare WAV header is ~44 bytes), so count
+        # actual frames.
+        if not audio_bytes or not _wav_has_audio_frames(audio_bytes):
             raise RuntimeError(
                 f"music engine produced no audio at {tmp_path} "
-                f"(dit={dit!r}, decoder={decoder!r})"
+                f"(dit={dit!r}, decoder={decoder!r}, "
+                f"{len(audio_bytes)} bytes)"
             )
 
         # SA3 emits WAV; ``response_format`` is validated to ``wav`` by

--- a/vllm_mlx/routes/audio.py
+++ b/vllm_mlx/routes/audio.py
@@ -6,7 +6,6 @@ import logging
 import os
 import re
 import tempfile
-import threading
 
 from fastapi import APIRouter, Body, Depends, Form, HTTPException, Query, UploadFile
 from starlette.responses import PlainTextResponse, Response
@@ -991,13 +990,31 @@ async def _stream_upload_to_tempfile(file: UploadFile, tmp) -> None:
         tmp.write(chunk)
 
 
-#: Serialises the forced-alignment engine cache + ``align`` call. The
-#: alignment body runs on a worker thread (see
-#: :func:`_run_alignment_request`), so two concurrent requests could
-#: otherwise load the aligner's weights twice or swap the engine out
-#: mid-align. A plain ``threading.Lock`` (not ``asyncio.Lock``) is
-#: required because the critical section executes off the event loop.
-_alignment_lock = threading.Lock()
+#: Serialises forced alignment: one weight load / one ``align`` at a time,
+#: so concurrent requests neither double-load the aligner nor swap the
+#: cached engine out from under an in-flight align.
+#:
+#: An ``asyncio.Lock`` acquired ON THE EVENT LOOP, deliberately not a
+#: ``threading.Lock`` held inside the worker. ``asyncio.to_thread`` uses
+#: the shared default executor (min(32, cpu+4) threads), so queued
+#: requests blocking on a thread-level lock would each pin an executor
+#: thread just to wait — starving every other ``to_thread`` user in the
+#: process (prefix-cache save, tool-grammar warmup, the diffusion lane).
+#: Waiting on the loop instead costs a coroutine, not a thread, and only
+#: the request that actually runs ever occupies an executor slot.
+#:
+#: Lazily created because the module imports before any event loop exists
+#: and an ``asyncio.Lock`` must be bound to the running loop.
+_alignment_lock: asyncio.Lock | None = None
+
+
+def _get_alignment_lock() -> asyncio.Lock:
+    """Return the process-wide alignment lock, creating it on first use."""
+    global _alignment_lock
+    if _alignment_lock is None:
+        _alignment_lock = asyncio.Lock()
+    return _alignment_lock
+
 
 #: Cached forced-aligner engine — DELIBERATELY separate from
 #: ``_stt_engine``.
@@ -1027,9 +1044,9 @@ def _align_blocking(
     so the async handler can hand the seconds-long weight load + align
     to :func:`asyncio.to_thread` instead of stalling the event loop.
 
-    Holds :data:`_alignment_lock` across the cache check AND the align
-    call so concurrent alignment requests don't double-load weights or
-    swap the engine out from under each other mid-align.
+    The caller holds :data:`_alignment_lock` for the whole call, so this
+    body is already serialised — no thread-level locking here (see the
+    lock's own comment for why it lives on the event loop).
     """
     global _aligner_engine
 
@@ -1041,11 +1058,14 @@ def _align_blocking(
     if language:
         align_kwargs["language"] = language
 
-    with _alignment_lock:
-        if _aligner_engine is None or _aligner_engine.model_name != model_name:
-            _aligner_engine = STTEngine(model_name)
-            _aligner_engine.load()
-        return _aligner_engine.align(audio_path, text, **align_kwargs)
+    if _aligner_engine is None or _aligner_engine.model_name != model_name:
+        # Load into a local first and publish only on success. Caching a
+        # half-constructed engine would leave later requests matching on
+        # ``model_name`` against an object whose weights never loaded.
+        engine = STTEngine(model_name)
+        engine.load()
+        _aligner_engine = engine
+    return _aligner_engine.align(audio_path, text, **align_kwargs)
 
 
 async def _run_alignment_request(
@@ -1083,9 +1103,14 @@ async def _run_alignment_request(
         # them on a worker thread — an ``async def`` handler that calls
         # them inline stalls the whole event loop (every concurrent chat
         # completion, /healthz probe and SSE heartbeat) for the duration.
-        result = await asyncio.to_thread(
-            _align_blocking, model_name, tmp_path, text, language
-        )
+        #
+        # Serialise BEFORE offloading: queueing on the loop costs a
+        # coroutine, whereas queueing inside the worker would pin an
+        # executor thread per waiter and starve every other to_thread user.
+        async with _get_alignment_lock():
+            result = await asyncio.to_thread(
+                _align_blocking, model_name, tmp_path, text, language
+            )
 
         return _format_stt_response(result, response_format, task="transcribe")
 
@@ -2046,10 +2071,22 @@ DEFAULT_MUSIC_DIT_DECODER: tuple[str, str] = ("medium", "same-l")
 #: Serialises music generation. ``MusicEngine.generate`` shells out to the
 #: vendored SA3 CLI, which peaks at ~3.9 GB (``medium``) — two concurrent
 #: requests would run two such subprocesses and can exhaust unified memory
-#: on a base-config Mac. One at a time; the rest queue on the thread that
-#: awaits this lock. Also guards the ``_music_engine`` global, which is
-#: mutated from a worker thread.
-_music_lock = threading.Lock()
+#: on a base-config Mac. Also guards the ``_music_engine`` global, mutated
+#: from a worker thread.
+#:
+#: On the event loop, not in the worker — same reasoning as
+#: :data:`_alignment_lock`: a thread-level wait would pin one shared
+#: executor thread per queued request. With a 900 s render that is a long
+#: time to hold threads other subsystems need.
+_music_lock: asyncio.Lock | None = None
+
+
+def _get_music_lock() -> asyncio.Lock:
+    """Return the process-wide music lock, creating it on first use."""
+    global _music_lock
+    if _music_lock is None:
+        _music_lock = asyncio.Lock()
+    return _music_lock
 
 
 def _generate_music_blocking(
@@ -2067,30 +2104,29 @@ def _generate_music_blocking(
     heartbeat with it — so the handler hands it to
     :func:`asyncio.to_thread`.
 
-    Holds :data:`_music_lock` across the engine-cache check and the
-    render so concurrent requests neither race the ``_music_engine``
-    global nor run two multi-GB SA3 subprocesses at once.
+    The caller holds :data:`_music_lock` for the whole call, so this body
+    is already serialised — no thread-level locking here (see the lock's
+    own comment for why it lives on the event loop).
     """
     global _music_engine
 
     from ..audio.music import MusicEngine
 
-    with _music_lock:
-        if (
-            _music_engine is None
-            or _music_engine.dit != dit
-            or _music_engine.decoder != decoder
-        ):
-            _music_engine = MusicEngine(dit=dit, decoder=decoder)
+    if (
+        _music_engine is None
+        or _music_engine.dit != dit
+        or _music_engine.decoder != decoder
+    ):
+        _music_engine = MusicEngine(dit=dit, decoder=decoder)
 
-        _music_engine.generate(
-            request.input,
-            out_path,
-            seconds=request.seconds,
-            steps=request.steps,
-            negative_prompt=request.negative_prompt,
-            seed=request.seed,
-        )
+    _music_engine.generate(
+        request.input,
+        out_path,
+        seconds=request.seconds,
+        steps=request.steps,
+        negative_prompt=request.negative_prompt,
+        seed=request.seed,
+    )
 
 
 def _resolve_music_model(model: str | None) -> tuple[str, str]:
@@ -2133,10 +2169,13 @@ async def create_music(request: AudioMusicRequest = Body(...)):
             tmp_path = tmp.name
 
         # Engine load + render are blocking (a subprocess, up to 900 s) —
-        # off the event loop. See _generate_music_blocking.
-        await asyncio.to_thread(
-            _generate_music_blocking, dit, decoder, tmp_path, request
-        )
+        # off the event loop. Serialised on the loop before offloading so
+        # queued renders don't each pin a shared executor thread.
+        # See _generate_music_blocking and _music_lock.
+        async with _get_music_lock():
+            await asyncio.to_thread(
+                _generate_music_blocking, dit, decoder, tmp_path, request
+            )
 
         audio_bytes = b""
         if os.path.exists(tmp_path):

--- a/vllm_mlx/routes/audio.py
+++ b/vllm_mlx/routes/audio.py
@@ -9,7 +9,7 @@ import tempfile
 from fastapi import APIRouter, Body, Depends, Form, HTTPException, Query, UploadFile
 from starlette.responses import PlainTextResponse, Response
 
-from ..api.models import AudioSpeechRequest
+from ..api.models import AudioMusicRequest, AudioSpeechRequest
 from ..middleware.auth import verify_api_key
 
 logger = logging.getLogger(__name__)
@@ -146,6 +146,7 @@ _AUDIO_READ_CHUNK_SIZE = 1024 * 1024  # 1 MB chunks
 # Audio engines (lazy loaded, module-level to persist across requests)
 _stt_engine = None
 _tts_engine = None
+_music_engine = None
 
 # OpenAI-style STT model alias → MLX repo. Promoted to module scope so
 # the route can validate the model BEFORE streaming the upload (F-165):
@@ -229,6 +230,17 @@ def _is_valid_repo_component(comp: str) -> bool:
 #: ``"default"`` to the boot-time CLI model — STT has no boot-time
 #: model bound, so the route default is the closest equivalent.
 DEFAULT_STT_ALIAS = "whisper-large-v3"
+
+#: Default forced-aligner alias used when ``/v1/audio/transcriptions``
+#: receives a ``text`` field (→ forced alignment) but the caller did NOT
+#: explicitly pick a ``model``. The transcription default
+#: (``whisper-large-v3``) is an ASR model, not an aligner — routing the
+#: alignment branch to it would raise ``align() requires a forced-aligner
+#: model`` deep in the engine. Defaulting to the registered aligner alias
+#: keeps the common "just send audio + text" call working. Both this and
+#: the long-form ``qwen3-forced-aligner`` alias live in the audio
+#: registry (type ``stt``), so ``_resolve_stt_model`` resolves them.
+DEFAULT_ALIGNER_ALIAS = "qwen3-aligner"
 
 
 def _resolve_stt_model(model: str) -> str:
@@ -977,6 +989,106 @@ async def _stream_upload_to_tempfile(file: UploadFile, tmp) -> None:
         tmp.write(chunk)
 
 
+async def _run_alignment_request(
+    file: UploadFile,
+    model: str,
+    text: str,
+    language: str | None,
+    response_format: str,
+):
+    """Forced-alignment pipeline for ``/v1/audio/transcriptions`` + ``text``.
+
+    When the transcription request carries a ``text`` field the caller is
+    asking for FORCED ALIGNMENT (align the KNOWN transcript to the audio,
+    returning per-character/word timestamps) rather than ASR. This helper
+    mirrors :func:`_run_stt_request`'s size/resolve/cleanup/envelope
+    wiring but calls :meth:`STTEngine.align` and defaults ``language`` to
+    the aligner's ``"Chinese"`` default when the caller omits it.
+
+    The result's per-unit ``segments`` flow through the SAME
+    ``_format_stt_response`` serializers ASR uses, so ``verbose_json`` /
+    ``srt`` / ``vtt`` all work — the aligner emits exactly the
+    ``{text, start, end}`` segment shape those formatters consume.
+    """
+    global _stt_engine
+
+    # Resolve the aligner model up front (404 for unknown aliases) BEFORE
+    # draining the upload — same fail-fast ordering as the ASR path.
+    model_name = _resolve_stt_model(model)
+
+    tmp_path: str | None = None
+    try:
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".wav") as tmp:
+            tmp_path = tmp.name
+            await _stream_upload_to_tempfile(file, tmp)
+
+        from ..audio.stt import STTEngine
+
+        if _stt_engine is None or _stt_engine.model_name != model_name:
+            _stt_engine = STTEngine(model_name)
+            _stt_engine.load()
+
+        # STTEngine.align defaults language to "Chinese"; only forward an
+        # explicit caller value so the engine default stands otherwise.
+        align_kwargs = {}
+        if language:
+            align_kwargs["language"] = language
+        result = _stt_engine.align(tmp_path, text, **align_kwargs)
+
+        return _format_stt_response(result, response_format, task="transcribe")
+
+    except ImportError:
+        raise HTTPException(
+            status_code=503,
+            detail="mlx-audio not installed. Install with: pip install mlx-audio",
+        )
+    except HTTPException:
+        raise
+    except ValueError as e:
+        # align() raises ValueError for the two client-fixable shapes:
+        # a non-aligner model, or empty/blank known text. Surface a 400
+        # ``invalid_request_error`` rather than the generic 500 so the
+        # caller learns to pick an aligner alias / supply text.
+        logger.info("Forced alignment rejected request: %s", e)
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "error": {
+                    "message": str(e),
+                    "type": "invalid_request_error",
+                    "code": "invalid_alignment_request",
+                    "param": "text" if "text" in str(e).lower() else "model",
+                }
+            },
+        )
+    except Exception as e:
+        if _is_decode_error(e):
+            logger.info("Forced alignment rejected corrupted upload: %s", e)
+            raise _audio_decode_error_envelope(e)
+        logger.exception("Forced alignment failed: %s", e)
+        raise HTTPException(
+            status_code=500,
+            detail={
+                "error": {
+                    "message": "Audio forced alignment failed",
+                    "type": "api_error",
+                    "code": "alignment_failed",
+                    "param": None,
+                }
+            },
+        )
+    finally:
+        if tmp_path is not None:
+            try:
+                os.unlink(tmp_path)
+            except FileNotFoundError:
+                pass
+            except OSError as cleanup_err:
+                logger.warning(
+                    "Failed to unlink temp audio file %s: %s", tmp_path, cleanup_err
+                )
+
+
 async def _run_stt_request(
     file: UploadFile,
     model: str,
@@ -1139,11 +1251,27 @@ async def create_transcription(
     model_form: str | None = Form(None, alias="model"),
     language_form: str | None = Form(None, alias="language"),
     response_format_form: str | None = Form(None, alias="response_format"),
+    # Content-farm lane: when ``text`` is present the request is FORCED
+    # ALIGNMENT (align the known transcript to the audio, returning
+    # per-character/word timestamps) instead of ASR. Absent → unchanged
+    # transcription behaviour. Accepted on both form (OpenAI-style
+    # multipart) and query (internal-caller parity with model/language).
+    text_form: str | None = Form(None, alias="text"),
     model_query: str | None = Query(None, alias="model"),
     language_query: str | None = Query(None, alias="language"),
     response_format_query: str | None = Query(None, alias="response_format"),
+    text_query: str | None = Query(None, alias="text"),
 ):
     """Transcribe audio to text (OpenAI Whisper API compatible).
+
+    Forced-alignment extension (content-farm lane): if the request
+    carries a ``text`` field, the route aligns that KNOWN transcript to
+    the uploaded audio (per-character/word timestamps, zero recognition
+    error) via :meth:`STTEngine.align` instead of running ASR. When
+    ``text`` is present but ``model`` is omitted it defaults to the
+    registered aligner alias (:data:`DEFAULT_ALIGNER_ALIAS`), and the
+    response defaults to ``verbose_json`` so the timestamped ``segments``
+    are returned. When ``text`` is absent the behaviour is unchanged.
 
     Two-layer size guard (defense in depth):
 
@@ -1167,17 +1295,41 @@ async def create_transcription(
     # Form wins over query when both are present (form is the OpenAI
     # contract; query is the pre-F-165 internal contract we're keeping
     # for back-compat). Defaults match the original signature.
-    model = (
-        model_form
-        if model_form is not None
-        else (model_query if model_query is not None else "whisper-large-v3")
+    # Whether the caller explicitly supplied model / response_format —
+    # drives the forced-alignment defaults below (aligner model +
+    # verbose_json) which only kick in when the field was omitted.
+    model_provided = model_form is not None or model_query is not None
+    model_merged = (
+        model_form if model_form is not None else model_query
+    )  # None when neither source supplied a model
+    response_format_provided = (
+        response_format_form is not None or response_format_query is not None
     )
+    text = text_form if text_form is not None else text_query
+
     language = language_form if language_form is not None else language_query
     response_format = (
         response_format_form
         if response_format_form is not None
         else (response_format_query if response_format_query is not None else "json")
     )
+
+    # Content-farm lane: a non-blank ``text`` field switches the route
+    # from ASR to FORCED ALIGNMENT of that known transcript.
+    is_alignment = text is not None and text.strip() != ""
+
+    if is_alignment:
+        # Default to the registered aligner alias when the caller didn't
+        # pick a model — the ASR default (whisper-large-v3) is not an
+        # aligner and would fail deep in the engine.
+        model = model_merged if model_provided else DEFAULT_ALIGNER_ALIAS
+        # Default to verbose_json so the timestamped ``segments`` are in
+        # the body; the plain ``json`` envelope drops them. An explicit
+        # response_format (srt/vtt/text/json) is honoured as-is.
+        if not response_format_provided:
+            response_format = "verbose_json"
+    else:
+        model = model_merged if model_provided else "whisper-large-v3"
 
     # R6-H2: reject unknown ``response_format`` values up front with a
     # 400 envelope so a typo (``"jsno"``) or unsupported value
@@ -1196,6 +1348,15 @@ async def create_transcription(
     from ..audio.probe import require_mlx_audio_stt
 
     require_mlx_audio_stt()
+
+    if is_alignment:
+        return await _run_alignment_request(
+            file=file,
+            model=model,
+            text=text,
+            language=language,
+            response_format=response_format,
+        )
 
     return await _run_stt_request(
         file=file,
@@ -1759,6 +1920,139 @@ async def create_speech(request: AudioSpeechRequest = Body(...)):
                 }
             },
         )
+
+
+# ---------------------------------------------------------------------------
+# Content-farm lane: text→music / text→SFX (``/v1/audio/music``).
+#
+# Wired to ``vllm_mlx.audio.music.MusicEngine`` (MLX-native Stable Audio
+# 3). OpenAI-flavored: JSON body in, WAV bytes out — the same
+# request-in / audio-bytes-out shape as ``/v1/audio/speech``. The
+# ``model`` field selects a DiT/decoder pairing via the alias table
+# below; unknown values fall back to the engine defaults.
+# ---------------------------------------------------------------------------
+
+#: ``model`` alias → ``(dit, decoder)`` pairing for SA3. ``medium`` is
+#: higher quality (~3.9 GB peak); ``sm-music`` / ``sm-sfx`` are the fast
+#: small variants (~1.7 GB, ~4x realtime). Kept local to the route (not
+#: in the audio registry, whose closed schema is stt/tts-typed) so adding
+#: a music variant is a one-line edit here. ``default`` maps to the
+#: engine's own defaults.
+MUSIC_MODEL_ALIASES: dict[str, tuple[str, str]] = {
+    "medium": ("medium", "same-l"),
+    "same-l": ("medium", "same-l"),
+    "sm-music": ("sm-music", "same-s"),
+    "sm-sfx": ("sm-sfx", "same-s"),
+    "same-s": ("sm-music", "same-s"),
+    "default": ("medium", "same-l"),
+}
+
+#: Fallback when ``model`` isn't a known music alias — the SA3 defaults.
+DEFAULT_MUSIC_DIT_DECODER: tuple[str, str] = ("medium", "same-l")
+
+
+def _resolve_music_model(model: str | None) -> tuple[str, str]:
+    """Map a ``/v1/audio/music`` ``model`` alias to a ``(dit, decoder)`` pair.
+
+    Recognises the :data:`MUSIC_MODEL_ALIASES` short names
+    (case-insensitively). ``None`` / ``""`` / ``"default"`` and any
+    unknown value fall back to :data:`DEFAULT_MUSIC_DIT_DECODER` (SA3's
+    own defaults) so an unfamiliar ``model`` still produces audio rather
+    than 404-ing — matching the TTS route's tolerant passthrough.
+    """
+    if not model:
+        return DEFAULT_MUSIC_DIT_DECODER
+    return MUSIC_MODEL_ALIASES.get(model.lower(), DEFAULT_MUSIC_DIT_DECODER)
+
+
+@router.post("/v1/audio/music", dependencies=[Depends(verify_api_key)])
+async def create_music(request: AudioMusicRequest = Body(...)):
+    """Generate music / SFX from a text prompt (content-farm lane).
+
+    OpenAI-flavored: a JSON body (:class:`AudioMusicRequest`) in, WAV
+    bytes out — the same request-in / audio-bytes-out contract as
+    ``/v1/audio/speech``. Wired to
+    :class:`vllm_mlx.audio.music.MusicEngine` (MLX-native Stable Audio
+    3), which renders ``seconds`` of audio for ``input`` to a temp file
+    that we stream back as ``audio/wav``.
+
+    ``model`` selects the DiT/decoder pairing (see
+    :data:`MUSIC_MODEL_ALIASES`); ``input`` (non-blank), ``seconds``
+    (≤47s), ``steps``, ``negative_prompt`` and ``seed`` are validated by
+    the request model. Backend failures surface a 500 with the OpenAI
+    ``api_error`` envelope (``code="music_generation_failed"``), matching
+    the speech route.
+    """
+    global _music_engine
+
+    dit, decoder = _resolve_music_model(request.model)
+
+    tmp_path: str | None = None
+    try:
+        from ..audio.music import MusicEngine
+
+        if (
+            _music_engine is None
+            or _music_engine.dit != dit
+            or _music_engine.decoder != decoder
+        ):
+            _music_engine = MusicEngine(dit=dit, decoder=decoder)
+
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".wav") as tmp:
+            tmp_path = tmp.name
+
+        _music_engine.generate(
+            request.input,
+            tmp_path,
+            seconds=request.seconds,
+            steps=request.steps,
+            negative_prompt=request.negative_prompt,
+            seed=request.seed,
+        )
+
+        with open(tmp_path, "rb") as fh:
+            audio_bytes = fh.read()
+
+        # SA3 emits WAV; ``response_format`` is validated to ``wav`` by
+        # the request model, so the Content-Type is always ``audio/wav``.
+        return Response(content=audio_bytes, media_type="audio/wav")
+
+    except HTTPException:
+        raise
+    except ImportError as e:
+        raise HTTPException(
+            status_code=503,
+            detail=(
+                f"music engine dependencies unavailable at runtime: {e}. "
+                "Install with: pip install 'rapid-mlx[audio]'"
+            ),
+        )
+    except Exception as e:
+        # Mirror the speech route: full traceback to the operator log,
+        # generic OpenAI-shape envelope to the client so we don't leak
+        # subprocess/filesystem internals.
+        logger.exception("Music generation failed: %s", e)
+        raise HTTPException(
+            status_code=500,
+            detail={
+                "error": {
+                    "message": "Audio music generation failed",
+                    "type": "api_error",
+                    "code": "music_generation_failed",
+                    "param": None,
+                }
+            },
+        )
+    finally:
+        if tmp_path is not None:
+            try:
+                os.unlink(tmp_path)
+            except FileNotFoundError:
+                pass
+            except OSError as cleanup_err:
+                logger.warning(
+                    "Failed to unlink temp music file %s: %s", tmp_path, cleanup_err
+                )
 
 
 @router.get("/v1/audio/voices", dependencies=[Depends(verify_api_key)])

--- a/vllm_mlx/routes/audio.py
+++ b/vllm_mlx/routes/audio.py
@@ -1,10 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 """Audio endpoints (STT/TTS)."""
 
+import asyncio
 import logging
 import os
 import re
 import tempfile
+import threading
 
 from fastapi import APIRouter, Body, Depends, Form, HTTPException, Query, UploadFile
 from starlette.responses import PlainTextResponse, Response
@@ -989,6 +991,49 @@ async def _stream_upload_to_tempfile(file: UploadFile, tmp) -> None:
         tmp.write(chunk)
 
 
+#: Serialises the forced-alignment engine cache + ``align`` call. The
+#: alignment body runs on a worker thread (see
+#: :func:`_run_alignment_request`), so two concurrent requests could
+#: otherwise race the ``_stt_engine`` global and load the aligner's
+#: weights twice. A plain ``threading.Lock`` (not ``asyncio.Lock``) is
+#: required because the critical section executes off the event loop.
+_alignment_lock = threading.Lock()
+
+
+def _align_blocking(
+    model_name: str,
+    audio_path: str,
+    text: str,
+    language: str | None,
+):
+    """Blocking half of the forced-alignment request — runs on a thread.
+
+    Loads (or reuses) the aligner engine and runs
+    :meth:`STTEngine.align`. Split out of :func:`_run_alignment_request`
+    so the async handler can hand the seconds-long weight load + align
+    to :func:`asyncio.to_thread` instead of stalling the event loop.
+
+    Holds :data:`_alignment_lock` across the cache check AND the align
+    call so concurrent alignment requests don't double-load weights or
+    swap the shared engine out from under each other mid-align.
+    """
+    global _stt_engine
+
+    from ..audio.stt import STTEngine
+
+    # STTEngine.align defaults language to "Chinese"; only forward an
+    # explicit caller value so the engine default stands otherwise.
+    align_kwargs = {}
+    if language:
+        align_kwargs["language"] = language
+
+    with _alignment_lock:
+        if _stt_engine is None or _stt_engine.model_name != model_name:
+            _stt_engine = STTEngine(model_name)
+            _stt_engine.load()
+        return _stt_engine.align(audio_path, text, **align_kwargs)
+
+
 async def _run_alignment_request(
     file: UploadFile,
     model: str,
@@ -1010,8 +1055,6 @@ async def _run_alignment_request(
     ``srt`` / ``vtt`` all work — the aligner emits exactly the
     ``{text, start, end}`` segment shape those formatters consume.
     """
-    global _stt_engine
-
     # Resolve the aligner model up front (404 for unknown aliases) BEFORE
     # draining the upload — same fail-fast ordering as the ASR path.
     model_name = _resolve_stt_model(model)
@@ -1022,18 +1065,13 @@ async def _run_alignment_request(
             tmp_path = tmp.name
             await _stream_upload_to_tempfile(file, tmp)
 
-        from ..audio.stt import STTEngine
-
-        if _stt_engine is None or _stt_engine.model_name != model_name:
-            _stt_engine = STTEngine(model_name)
-            _stt_engine.load()
-
-        # STTEngine.align defaults language to "Chinese"; only forward an
-        # explicit caller value so the engine default stands otherwise.
-        align_kwargs = {}
-        if language:
-            align_kwargs["language"] = language
-        result = _stt_engine.align(tmp_path, text, **align_kwargs)
+        # Weight load + alignment are seconds of blocking compute, so run
+        # them on a worker thread — an ``async def`` handler that calls
+        # them inline stalls the whole event loop (every concurrent chat
+        # completion, /healthz probe and SSE heartbeat) for the duration.
+        result = await asyncio.to_thread(
+            _align_blocking, model_name, tmp_path, text, language
+        )
 
         return _format_stt_response(result, response_format, task="transcribe")
 
@@ -1298,10 +1336,10 @@ async def create_transcription(
     # Whether the caller explicitly supplied model / response_format —
     # drives the forced-alignment defaults below (aligner model +
     # verbose_json) which only kick in when the field was omitted.
-    model_provided = model_form is not None or model_query is not None
     model_merged = (
         model_form if model_form is not None else model_query
     )  # None when neither source supplied a model
+    model_provided = model_merged is not None
     response_format_provided = (
         response_format_form is not None or response_format_query is not None
     )
@@ -1322,11 +1360,23 @@ async def create_transcription(
         # Default to the registered aligner alias when the caller didn't
         # pick a model — the ASR default (whisper-large-v3) is not an
         # aligner and would fail deep in the engine.
-        model = model_merged if model_provided else DEFAULT_ALIGNER_ALIAS
+        #
+        # A WHITESPACE-ONLY model also takes the default here. FastAPI
+        # already coerces a truly empty form field (``model=""``) to
+        # ``None``, but ``model="   "`` — what you get from a form whose
+        # input was spaced-out, or a shell ``-F "model=$UNSET "`` — comes
+        # through verbatim and 404s in ``_resolve_stt_model`` as a
+        # nonexistent alias. Treat it as unset so "just send audio +
+        # text" keeps working. Scoped to this branch on purpose: the ASR
+        # path's blank-model handling is long-standing contract.
+        alignment_model_chosen = model_provided and bool(model_merged.strip())
+        model = model_merged if alignment_model_chosen else DEFAULT_ALIGNER_ALIAS
         # Default to verbose_json so the timestamped ``segments`` are in
         # the body; the plain ``json`` envelope drops them. An explicit
         # response_format (srt/vtt/text/json) is honoured as-is.
-        if not response_format_provided:
+        # Whitespace-only is treated as unset for the same reason as
+        # ``model`` above (it would otherwise 400 on the allowed set).
+        if not response_format_provided or not response_format.strip():
             response_format = "verbose_json"
     else:
         model = model_merged if model_provided else "whisper-large-v3"
@@ -1950,6 +2000,55 @@ MUSIC_MODEL_ALIASES: dict[str, tuple[str, str]] = {
 #: Fallback when ``model`` isn't a known music alias — the SA3 defaults.
 DEFAULT_MUSIC_DIT_DECODER: tuple[str, str] = ("medium", "same-l")
 
+#: Serialises music generation. ``MusicEngine.generate`` shells out to the
+#: vendored SA3 CLI, which peaks at ~3.9 GB (``medium``) — two concurrent
+#: requests would run two such subprocesses and can exhaust unified memory
+#: on a base-config Mac. One at a time; the rest queue on the thread that
+#: awaits this lock. Also guards the ``_music_engine`` global, which is
+#: mutated from a worker thread.
+_music_lock = threading.Lock()
+
+
+def _generate_music_blocking(
+    dit: str,
+    decoder: str,
+    out_path: str,
+    request: AudioMusicRequest,
+) -> None:
+    """Blocking half of ``/v1/audio/music`` — runs on a worker thread.
+
+    ``MusicEngine.generate`` spawns the vendored Stable Audio 3 CLI and
+    waits on it (default timeout 900 s). Calling that inline from the
+    ``async def`` handler would stall the event loop for the entire
+    render — every concurrent chat completion, ``/healthz`` probe and SSE
+    heartbeat with it — so the handler hands it to
+    :func:`asyncio.to_thread`.
+
+    Holds :data:`_music_lock` across the engine-cache check and the
+    render so concurrent requests neither race the ``_music_engine``
+    global nor run two multi-GB SA3 subprocesses at once.
+    """
+    global _music_engine
+
+    from ..audio.music import MusicEngine
+
+    with _music_lock:
+        if (
+            _music_engine is None
+            or _music_engine.dit != dit
+            or _music_engine.decoder != decoder
+        ):
+            _music_engine = MusicEngine(dit=dit, decoder=decoder)
+
+        _music_engine.generate(
+            request.input,
+            out_path,
+            seconds=request.seconds,
+            steps=request.steps,
+            negative_prompt=request.negative_prompt,
+            seed=request.seed,
+        )
+
 
 def _resolve_music_model(model: str | None) -> tuple[str, str]:
     """Map a ``/v1/audio/music`` ``model`` alias to a ``(dit, decoder)`` pair.
@@ -1983,35 +2082,33 @@ async def create_music(request: AudioMusicRequest = Body(...)):
     ``api_error`` envelope (``code="music_generation_failed"``), matching
     the speech route.
     """
-    global _music_engine
-
     dit, decoder = _resolve_music_model(request.model)
 
     tmp_path: str | None = None
     try:
-        from ..audio.music import MusicEngine
-
-        if (
-            _music_engine is None
-            or _music_engine.dit != dit
-            or _music_engine.decoder != decoder
-        ):
-            _music_engine = MusicEngine(dit=dit, decoder=decoder)
-
         with tempfile.NamedTemporaryFile(delete=False, suffix=".wav") as tmp:
             tmp_path = tmp.name
 
-        _music_engine.generate(
-            request.input,
-            tmp_path,
-            seconds=request.seconds,
-            steps=request.steps,
-            negative_prompt=request.negative_prompt,
-            seed=request.seed,
+        # Engine load + render are blocking (a subprocess, up to 900 s) —
+        # off the event loop. See _generate_music_blocking.
+        await asyncio.to_thread(
+            _generate_music_blocking, dit, decoder, tmp_path, request
         )
 
-        with open(tmp_path, "rb") as fh:
-            audio_bytes = fh.read()
+        audio_bytes = b""
+        if os.path.exists(tmp_path):
+            with open(tmp_path, "rb") as fh:
+                audio_bytes = fh.read()
+
+        # The SA3 CLI can exit 0 having written nothing (or a 0-byte
+        # placeholder) — e.g. a sampler that bailed after the header. Fail
+        # loudly instead of handing the caller an HTTP 200 with an empty
+        # ``audio/wav`` body, which reads as a successful silent clip.
+        if not audio_bytes:
+            raise RuntimeError(
+                f"music engine produced no audio at {tmp_path} "
+                f"(dit={dit!r}, decoder={decoder!r})"
+            )
 
         # SA3 emits WAV; ``response_format`` is validated to ``wav`` by
         # the request model, so the Content-Type is always ``audio/wav``.

--- a/vllm_mlx/routes/audio.py
+++ b/vllm_mlx/routes/audio.py
@@ -1096,9 +1096,15 @@ def _align_blocking(
         # Load into a local first and publish only on success. Caching a
         # half-constructed engine would leave later requests matching on
         # ``model_name`` against an object whose weights never loaded.
-        engine = STTEngine(model_name)
-        engine.load()
-        _aligner_engine = engine
+        #
+        # Named ``aligner``, not ``engine``: test_route_engine_contract
+        # scans this module for ``engine.<method>()`` calls and requires
+        # the method to exist on the LLM ``BaseEngine``. An ``STTEngine``
+        # is a different hierarchy entirely, so the name would trip that
+        # gate with a false positive.
+        aligner = STTEngine(model_name)
+        aligner.load()
+        _aligner_engine = aligner
     return _aligner_engine.align(audio_path, text, **align_kwargs)
 
 
@@ -1425,7 +1431,17 @@ async def create_transcription(
     response_format_provided = (
         response_format_form is not None or response_format_query is not None
     )
-    text = text_form if text_form is not None else text_query
+    # Merge with an isinstance check, NOT ``is not None``. Several existing
+    # tests call this handler directly rather than through FastAPI, so the
+    # unresolved ``Form(None)`` / ``Query(None)`` defaults arrive as
+    # FastAPI param objects — truthy and non-None, but not strings. The
+    # pre-existing params only ever get compared against None so they
+    # tolerate that; ``text`` is inspected with ``.strip()`` below, which
+    # would raise AttributeError on a sentinel. Treat a non-str as absent.
+    text = next(
+        (v for v in (text_form, text_query) if isinstance(v, str)),
+        None,
+    )
 
     language = language_form if language_form is not None else language_query
     response_format = (
@@ -1480,14 +1496,21 @@ async def create_transcription(
         # nonexistent alias. Treat it as unset so "just send audio +
         # text" keeps working. Scoped to this branch on purpose: the ASR
         # path's blank-model handling is long-standing contract.
-        alignment_model_chosen = model_provided and bool(model_merged.strip())
+        # isinstance guard for the same direct-call reason as ``text``.
+        alignment_model_chosen = isinstance(model_merged, str) and bool(
+            model_merged.strip()
+        )
         model = model_merged if alignment_model_chosen else DEFAULT_ALIGNER_ALIAS
         # Default to verbose_json so the timestamped ``segments`` are in
         # the body; the plain ``json`` envelope drops them. An explicit
         # response_format (srt/vtt/text/json) is honoured as-is.
         # Whitespace-only is treated as unset for the same reason as
         # ``model`` above (it would otherwise 400 on the allowed set).
-        if not response_format_provided or not response_format.strip():
+        if (
+            not response_format_provided
+            or not isinstance(response_format, str)
+            or not response_format.strip()
+        ):
             response_format = "verbose_json"
     else:
         model = model_merged if model_provided else "whisper-large-v3"

--- a/vllm_mlx/routes/video.py
+++ b/vllm_mlx/routes/video.py
@@ -10,11 +10,20 @@ raises :class:`NotImplementedError` and the route returns a clean HTTP
 itself the route goes live unchanged.
 """
 
+import asyncio
+import base64
 import logging
+import os
+import tempfile
+import time
 
 from fastapi import APIRouter, Body, Depends, HTTPException
 
-from ..api.models import VideoGenerationRequest
+from ..api.models import (
+    VideoGenerationRequest,
+    VideoGenerationResponse,
+    VideoGenerationResult,
+)
 from ..middleware.auth import verify_api_key
 
 logger = logging.getLogger(__name__)
@@ -62,35 +71,84 @@ async def create_video(request: VideoGenerationRequest = Body(...)):
 
     # Reached only once a backend is registered. Kept wired so the route
     # is live the moment resolve_video_engine stops raising — no handler
-    # edit required. (Response serialization into VideoGenerationResponse
-    # is the backend integrator's follow-up per REQUIREMENTS_rapid.md B1.)
-    import time
+    # edit required.
+    return await _render_and_serialize(engine, request)  # pragma: no cover
 
-    from ..api.models import VideoGenerationResponse, VideoGenerationResult
 
-    out_path = engine.generate(  # pragma: no cover — no backend yet
-        request.prompt,
-        None,
-        image=request.image,
-        height=request.height,
-        width=request.width,
-        num_frames=request.num_frames,
-        frame_rate=request.frame_rate,
-        steps=request.steps,
-        negative_prompt=request.negative_prompt,
-        seed=request.seed,
-    )
-    return VideoGenerationResponse(  # pragma: no cover — no backend yet
-        created=int(time.time()),
-        model=request.model,
-        data=[
-            VideoGenerationResult(
-                url=str(out_path),
-                format=request.response_format,
-                width=request.width,
+async def _render_and_serialize(  # pragma: no cover — no backend yet
+    engine, request: VideoGenerationRequest
+) -> VideoGenerationResponse:
+    """Render via ``engine`` and serialize to the wire response.
+
+    Unreachable while the lane is contract-only (``resolve_video_engine``
+    raises first), but kept correct and wired so registering a backend is
+    the ONLY change needed to make ``/v1/video/generations`` live.
+
+    Two things this deliberately does NOT do the naive way:
+
+    * ``out_path`` is a real temp mp4 path. :meth:`VideoEngine.generate`
+      declares ``out_path: str | Path`` and writes the clip there —
+      passing ``None`` would break every conforming backend.
+    * the clip comes back as base64 in ``b64_video``, not as a ``url``
+      holding a server-side filesystem path. A local path is not a URL
+      the client can fetch, and echoing one leaks the server's
+      filesystem layout. A backend that uploads to real object storage
+      can populate ``url`` instead.
+    """
+    out_dir = tempfile.mkdtemp(prefix="rapidmlx-video-")
+    out_path = os.path.join(out_dir, "out.mp4")
+    try:
+        # Rendering is heavy blocking compute — keep it off the event loop
+        # so concurrent requests and health probes stay responsive.
+        written = await asyncio.to_thread(
+            lambda: engine.generate(
+                request.prompt,
+                out_path,
+                image=request.image,
                 height=request.height,
+                width=request.width,
                 num_frames=request.num_frames,
                 frame_rate=request.frame_rate,
+                steps=request.steps,
+                negative_prompt=request.negative_prompt,
+                seed=request.seed,
             )
-        ],
-    )
+        )
+        video_path = str(written or out_path)
+        with open(video_path, "rb") as fh:
+            payload = fh.read()
+        if not payload:
+            raise HTTPException(
+                status_code=500,
+                detail={
+                    "error": {
+                        "message": "Video generation produced no output",
+                        "type": "api_error",
+                        "code": "video_generation_failed",
+                        "param": None,
+                    }
+                },
+            )
+        return VideoGenerationResponse(
+            created=int(time.time()),
+            model=request.model,
+            data=[
+                VideoGenerationResult(
+                    b64_video=base64.b64encode(payload).decode("ascii"),
+                    format=request.response_format,
+                    width=request.width,
+                    height=request.height,
+                    num_frames=request.num_frames,
+                    frame_rate=request.frame_rate,
+                )
+            ],
+        )
+    finally:
+        try:
+            if os.path.exists(out_path):
+                os.unlink(out_path)
+            os.rmdir(out_dir)
+        except OSError as cleanup_err:
+            logger.warning(
+                "Failed to clean up video temp dir %s: %s", out_dir, cleanup_err
+            )

--- a/vllm_mlx/routes/video.py
+++ b/vllm_mlx/routes/video.py
@@ -10,6 +10,7 @@ raises :class:`NotImplementedError` and the route returns a clean HTTP
 itself the route goes live unchanged.
 """
 
+import asyncio
 import base64
 import logging
 import os
@@ -37,6 +38,58 @@ router = APIRouter()
 #: should upload to object storage and populate ``url`` instead of
 #: ``b64_video``.
 MAX_INLINE_VIDEO_BYTES: int = 256 * 1024 * 1024
+
+#: Serialises rendering, for the same reason the audio lanes do it: a
+#: video model is the heaviest thing this server can be asked to run, and
+#: concurrent renders would multiply peak unified memory. On the event
+#: loop (not a ``threading.Lock`` in the worker) so queued requests cost a
+#: coroutine rather than pinning shared-executor threads — see
+#: :mod:`vllm_mlx.routes._async_utils`.
+#:
+#: Lazily created: the module imports before any event loop exists, and an
+#: ``asyncio.Lock`` must bind to the running loop.
+_render_lock: asyncio.Lock | None = None
+
+
+def _get_render_lock() -> asyncio.Lock:
+    """Return the process-wide video render lock, creating it on first use."""
+    global _render_lock
+    if _render_lock is None:
+        _render_lock = asyncio.Lock()
+    return _render_lock
+
+
+def _resolve_inside(out_dir: str, candidate: str) -> str:
+    """Resolve ``candidate`` under ``out_dir``, refusing anything outside.
+
+    A backend returns a path; we must not treat that path as trusted. A
+    relative return value is resolved against the directory we handed the
+    backend (not the server's cwd), and the result must still live beneath
+    that directory. ``..`` traversal therefore can't get an arbitrary file
+    read, base64'd into a response — containment is checked BEFORE we open
+    the file, not only before we delete it.
+    """
+    resolved = (
+        candidate if os.path.isabs(candidate) else os.path.join(out_dir, candidate)
+    )
+    real_dir = os.path.realpath(out_dir)
+    real_path = os.path.realpath(resolved)
+    if os.path.commonpath([real_dir, real_path]) != real_dir:
+        raise HTTPException(
+            status_code=500,
+            detail={
+                "error": {
+                    "message": (
+                        "Video backend returned an output path outside its "
+                        "working directory"
+                    ),
+                    "type": "api_error",
+                    "code": "video_generation_failed",
+                    "param": None,
+                }
+            },
+        )
+    return real_path
 
 
 @router.post("/v1/video/generations", dependencies=[Depends(verify_api_key)])
@@ -105,39 +158,32 @@ async def _render_and_serialize(  # pragma: no cover — no backend yet
     """
     out_dir = tempfile.mkdtemp(prefix="rapidmlx-video-")
     out_path = os.path.join(out_dir, "out.mp4")
-    # Whatever the backend actually wrote — it may return a path other
-    # than the one we handed it. Tracked so cleanup deletes the real
-    # artifact instead of leaking a multi-MB mp4 on every request.
-    written_path: str | None = None
     try:
         # Rendering is heavy blocking compute — keep it off the event loop
         # so concurrent requests and health probes stay responsive.
         # ``run_to_completion`` (not bare ``to_thread``) so a client
         # disconnect can't send us into ``finally`` and delete the output
         # directory while the worker is still rendering into it.
-        written = await run_to_completion(
-            lambda: engine.generate(
-                request.prompt,
-                out_path,
-                image=request.image,
-                height=request.height,
-                width=request.width,
-                num_frames=request.num_frames,
-                frame_rate=request.frame_rate,
-                steps=request.steps,
-                negative_prompt=request.negative_prompt,
-                seed=request.seed,
+        # Serialised on the loop before offloading — one render at a time.
+        async with _get_render_lock():
+            written = await run_to_completion(
+                lambda: engine.generate(
+                    request.prompt,
+                    out_path,
+                    image=request.image,
+                    height=request.height,
+                    width=request.width,
+                    num_frames=request.num_frames,
+                    frame_rate=request.frame_rate,
+                    steps=request.steps,
+                    negative_prompt=request.negative_prompt,
+                    seed=request.seed,
+                )
             )
-        )
-        # Resolve a RELATIVE returned path against the directory we gave
-        # the backend, not the server's cwd. A backend that returns
-        # ``Path("out.mp4")`` is naming the file it just wrote into
-        # out_dir; resolving that against cwd reports a perfectly good
-        # render as missing.
-        video_path = str(written or out_path)
-        if not os.path.isabs(video_path):
-            video_path = os.path.join(out_dir, video_path)
-        written_path = video_path
+        # Resolve relative against out_dir (not the server's cwd — a
+        # backend returning ``Path("out.mp4")`` means the file it wrote
+        # into our directory) and refuse anything that escapes it.
+        video_path = _resolve_inside(out_dir, str(written or out_path))
 
         size = os.path.getsize(video_path) if os.path.exists(video_path) else 0
         if not size:
@@ -200,30 +246,12 @@ async def _render_and_serialize(  # pragma: no cover — no backend yet
             ],
         )
     finally:
-        # We own ``out_dir`` and nothing else. ``rmtree`` rather than
-        # ``rmdir`` because a backend may drop sidecars (a probe log, a
-        # separate audio track) next to the clip, and a non-empty dir
+        # ``rmtree``, not ``rmdir``: a backend may drop sidecars (a probe
+        # log, a separate audio track) beside the clip, and a non-empty dir
         # would make ``rmdir`` raise and leak the whole directory.
         #
-        # A backend is free to return a path OUTSIDE our directory — a
-        # cached render, a shared spool file. Deleting that would destroy
-        # an artifact we never created and don't own, so containment is
-        # checked before unlinking. Anything inside out_dir is swept by
-        # the rmtree below regardless.
-        if written_path:
-            try:
-                real_out = os.path.realpath(out_dir)
-                real_written = os.path.realpath(written_path)
-                contained = os.path.commonpath([real_out, real_written]) == real_out
-                if contained and os.path.exists(real_written):
-                    os.unlink(real_written)
-                elif not contained:
-                    logger.debug(
-                        "Leaving backend-owned video output in place: %s",
-                        written_path,
-                    )
-            except (OSError, ValueError) as cleanup_err:
-                logger.warning(
-                    "Failed to unlink video output %s: %s", written_path, cleanup_err
-                )
+        # ``written_path`` is already guaranteed to be inside out_dir by
+        # ``_resolve_inside``, so the sweep below covers it — no separate
+        # unlink needed, and no risk of deleting a backend-owned artifact
+        # we never created.
         shutil.rmtree(out_dir, ignore_errors=True)

--- a/vllm_mlx/routes/video.py
+++ b/vllm_mlx/routes/video.py
@@ -31,6 +31,13 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
+#: Largest clip the wired handler will inline as base64. Encoding costs
+#: 4/3 in size and holds the raw bytes plus the encoded string at once, so
+#: this bounds peak memory per request. A backend that renders longer clips
+#: should upload to object storage and populate ``url`` instead of
+#: ``b64_video``.
+MAX_INLINE_VIDEO_BYTES: int = 256 * 1024 * 1024
+
 
 @router.post("/v1/video/generations", dependencies=[Depends(verify_api_key)])
 async def create_video(request: VideoGenerationRequest = Body(...)):
@@ -121,9 +128,9 @@ async def _render_and_serialize(  # pragma: no cover — no backend yet
         )
         video_path = str(written or out_path)
         written_path = video_path
-        with open(video_path, "rb") as fh:
-            payload = fh.read()
-        if not payload:
+
+        size = os.path.getsize(video_path) if os.path.exists(video_path) else 0
+        if not size:
             raise HTTPException(
                 status_code=500,
                 detail={
@@ -135,12 +142,42 @@ async def _render_and_serialize(  # pragma: no cover — no backend yet
                     }
                 },
             )
+        # Refuse to inline a clip too large to base64 safely. Encoding
+        # inflates by 4/3 and both the bytes and the encoded string are
+        # resident at once, so an unbounded render could push the server
+        # into swap. A backend producing clips this size should upload to
+        # object storage and populate ``url`` instead.
+        if size > MAX_INLINE_VIDEO_BYTES:
+            raise HTTPException(
+                status_code=500,
+                detail={
+                    "error": {
+                        "message": (
+                            f"Generated video is {size} bytes, over the "
+                            f"{MAX_INLINE_VIDEO_BYTES}-byte limit for inline "
+                            "base64 delivery"
+                        ),
+                        "type": "api_error",
+                        "code": "video_too_large_to_inline",
+                        "param": None,
+                    }
+                },
+            )
+
+        # Read + base64 off the event loop: a multi-MB read and encode on
+        # the loop thread stalls every other request for its duration.
+        def _read_and_encode() -> str:
+            with open(video_path, "rb") as fh:
+                return base64.b64encode(fh.read()).decode("ascii")
+
+        b64 = await asyncio.to_thread(_read_and_encode)
+
         return VideoGenerationResponse(
             created=int(time.time()),
             model=request.model,
             data=[
                 VideoGenerationResult(
-                    b64_video=base64.b64encode(payload).decode("ascii"),
+                    b64_video=b64,
                     format=request.response_format,
                     width=request.width,
                     height=request.height,

--- a/vllm_mlx/routes/video.py
+++ b/vllm_mlx/routes/video.py
@@ -14,6 +14,7 @@ import asyncio
 import base64
 import logging
 import os
+import shutil
 import tempfile
 import time
 
@@ -97,6 +98,10 @@ async def _render_and_serialize(  # pragma: no cover — no backend yet
     """
     out_dir = tempfile.mkdtemp(prefix="rapidmlx-video-")
     out_path = os.path.join(out_dir, "out.mp4")
+    # Whatever the backend actually wrote — it may return a path other
+    # than the one we handed it. Tracked so cleanup deletes the real
+    # artifact instead of leaking a multi-MB mp4 on every request.
+    written_path: str | None = None
     try:
         # Rendering is heavy blocking compute — keep it off the event loop
         # so concurrent requests and health probes stay responsive.
@@ -115,6 +120,7 @@ async def _render_and_serialize(  # pragma: no cover — no backend yet
             )
         )
         video_path = str(written or out_path)
+        written_path = video_path
         with open(video_path, "rb") as fh:
             payload = fh.read()
         if not payload:
@@ -144,11 +150,16 @@ async def _render_and_serialize(  # pragma: no cover — no backend yet
             ],
         )
     finally:
+        # Delete the artifact the backend actually produced, wherever it
+        # put it, then the whole temp dir. ``rmtree`` rather than
+        # ``rmdir`` because a backend may drop sidecars (a probe log, a
+        # separate audio track) next to the clip, and a non-empty dir
+        # would make ``rmdir`` raise and leak the entire directory.
         try:
-            if os.path.exists(out_path):
-                os.unlink(out_path)
-            os.rmdir(out_dir)
+            if written_path and os.path.exists(written_path):
+                os.unlink(written_path)
         except OSError as cleanup_err:
             logger.warning(
-                "Failed to clean up video temp dir %s: %s", out_dir, cleanup_err
+                "Failed to unlink video output %s: %s", written_path, cleanup_err
             )
+        shutil.rmtree(out_dir, ignore_errors=True)

--- a/vllm_mlx/routes/video.py
+++ b/vllm_mlx/routes/video.py
@@ -26,6 +26,7 @@ from ..api.models import (
     VideoGenerationResult,
 )
 from ..middleware.auth import verify_api_key
+from ._async_utils import run_to_completion
 
 logger = logging.getLogger(__name__)
 
@@ -112,7 +113,10 @@ async def _render_and_serialize(  # pragma: no cover — no backend yet
     try:
         # Rendering is heavy blocking compute — keep it off the event loop
         # so concurrent requests and health probes stay responsive.
-        written = await asyncio.to_thread(
+        # ``run_to_completion`` (not bare ``to_thread``) so a client
+        # disconnect can't send us into ``finally`` and delete the output
+        # directory while the worker is still rendering into it.
+        written = await run_to_completion(
             lambda: engine.generate(
                 request.prompt,
                 out_path,
@@ -187,16 +191,30 @@ async def _render_and_serialize(  # pragma: no cover — no backend yet
             ],
         )
     finally:
-        # Delete the artifact the backend actually produced, wherever it
-        # put it, then the whole temp dir. ``rmtree`` rather than
+        # We own ``out_dir`` and nothing else. ``rmtree`` rather than
         # ``rmdir`` because a backend may drop sidecars (a probe log, a
         # separate audio track) next to the clip, and a non-empty dir
-        # would make ``rmdir`` raise and leak the entire directory.
-        try:
-            if written_path and os.path.exists(written_path):
-                os.unlink(written_path)
-        except OSError as cleanup_err:
-            logger.warning(
-                "Failed to unlink video output %s: %s", written_path, cleanup_err
-            )
+        # would make ``rmdir`` raise and leak the whole directory.
+        #
+        # A backend is free to return a path OUTSIDE our directory — a
+        # cached render, a shared spool file. Deleting that would destroy
+        # an artifact we never created and don't own, so containment is
+        # checked before unlinking. Anything inside out_dir is swept by
+        # the rmtree below regardless.
+        if written_path:
+            try:
+                real_out = os.path.realpath(out_dir)
+                real_written = os.path.realpath(written_path)
+                contained = os.path.commonpath([real_out, real_written]) == real_out
+                if contained and os.path.exists(real_written):
+                    os.unlink(real_written)
+                elif not contained:
+                    logger.debug(
+                        "Leaving backend-owned video output in place: %s",
+                        written_path,
+                    )
+            except (OSError, ValueError) as cleanup_err:
+                logger.warning(
+                    "Failed to unlink video output %s: %s", written_path, cleanup_err
+                )
         shutil.rmtree(out_dir, ignore_errors=True)

--- a/vllm_mlx/routes/video.py
+++ b/vllm_mlx/routes/video.py
@@ -1,0 +1,96 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Video-generation endpoint (content-farm lane — CONTRACT-ONLY).
+
+``POST /v1/video/generations`` ships the full text→video / image→video
+request+response CONTRACT and wires to the
+:class:`vllm_mlx.video.engine.VideoEngine` interface. No concrete
+backend exists yet, so :func:`vllm_mlx.video.engine.resolve_video_engine`
+raises :class:`NotImplementedError` and the route returns a clean HTTP
+501 with an OpenAI-shape envelope. The day an LTX-2.3 backend registers
+itself the route goes live unchanged.
+"""
+
+import logging
+
+from fastapi import APIRouter, Body, Depends, HTTPException
+
+from ..api.models import VideoGenerationRequest
+from ..middleware.auth import verify_api_key
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+@router.post("/v1/video/generations", dependencies=[Depends(verify_api_key)])
+async def create_video(request: VideoGenerationRequest = Body(...)):
+    """Generate a video from text (t2v) or an image + text (i2v).
+
+    CONTRACT-ONLY: the request/response schema and the ``VideoEngine``
+    interface are fixed, but no backend is integrated yet. The route
+    validates the request (so callers can develop against the real wire
+    contract) and then returns HTTP 501 ``not_implemented`` because
+    :func:`vllm_mlx.video.engine.resolve_video_engine` has no backend to
+    hand back.
+
+    A future LTX-2.3 backend implementing
+    :class:`vllm_mlx.video.engine.VideoEngine` makes this route go live
+    with no change here — the resolver stops raising and the engine call
+    below runs.
+    """
+    # Lazy import mirrors the audio routes — keeps the video lane's deps
+    # (none yet) off the module-import hot path.
+    from ..video.engine import resolve_video_engine
+
+    try:
+        engine = resolve_video_engine(request.model)
+    except NotImplementedError as e:
+        # CONTRACT-ONLY state: surface a clean 501 with the OpenAI-shape
+        # envelope so colleagues get the exact message + the pointer to
+        # the backend-integration task, not a stack trace.
+        raise HTTPException(
+            status_code=501,
+            detail={
+                "error": {
+                    "message": str(e),
+                    "type": "not_implemented_error",
+                    "code": "video_backend_not_implemented",
+                    "param": None,
+                }
+            },
+        )
+
+    # Reached only once a backend is registered. Kept wired so the route
+    # is live the moment resolve_video_engine stops raising — no handler
+    # edit required. (Response serialization into VideoGenerationResponse
+    # is the backend integrator's follow-up per REQUIREMENTS_rapid.md B1.)
+    import time
+
+    from ..api.models import VideoGenerationResponse, VideoGenerationResult
+
+    out_path = engine.generate(  # pragma: no cover — no backend yet
+        request.prompt,
+        None,
+        image=request.image,
+        height=request.height,
+        width=request.width,
+        num_frames=request.num_frames,
+        frame_rate=request.frame_rate,
+        steps=request.steps,
+        negative_prompt=request.negative_prompt,
+        seed=request.seed,
+    )
+    return VideoGenerationResponse(  # pragma: no cover — no backend yet
+        created=int(time.time()),
+        model=request.model,
+        data=[
+            VideoGenerationResult(
+                url=str(out_path),
+                format=request.response_format,
+                width=request.width,
+                height=request.height,
+                num_frames=request.num_frames,
+                frame_rate=request.frame_rate,
+            )
+        ],
+    )

--- a/vllm_mlx/routes/video.py
+++ b/vllm_mlx/routes/video.py
@@ -10,7 +10,6 @@ raises :class:`NotImplementedError` and the route returns a clean HTTP
 itself the route goes live unchanged.
 """
 
-import asyncio
 import base64
 import logging
 import os
@@ -130,7 +129,14 @@ async def _render_and_serialize(  # pragma: no cover — no backend yet
                 seed=request.seed,
             )
         )
+        # Resolve a RELATIVE returned path against the directory we gave
+        # the backend, not the server's cwd. A backend that returns
+        # ``Path("out.mp4")`` is naming the file it just wrote into
+        # out_dir; resolving that against cwd reports a perfectly good
+        # render as missing.
         video_path = str(written or out_path)
+        if not os.path.isabs(video_path):
+            video_path = os.path.join(out_dir, video_path)
         written_path = video_path
 
         size = os.path.getsize(video_path) if os.path.exists(video_path) else 0
@@ -170,11 +176,14 @@ async def _render_and_serialize(  # pragma: no cover — no backend yet
 
         # Read + base64 off the event loop: a multi-MB read and encode on
         # the loop thread stalls every other request for its duration.
+        # ``run_to_completion`` again, not bare ``to_thread`` — cancelling
+        # here would otherwise drop into ``finally`` and rmtree the file
+        # the reader is holding open.
         def _read_and_encode() -> str:
             with open(video_path, "rb") as fh:
                 return base64.b64encode(fh.read()).decode("ascii")
 
-        b64 = await asyncio.to_thread(_read_and_encode)
+        b64 = await run_to_completion(_read_and_encode)
 
         return VideoGenerationResponse(
             created=int(time.time()),

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -2047,6 +2047,7 @@ from .routes.mcp_routes import router as _mcp_router
 from .routes.metrics import router as _metrics_router
 from .routes.models import router as _models_router
 from .routes.responses import router as _responses_router
+from .routes.video import router as _video_router
 
 app.include_router(_probe_router)
 app.include_router(_health_router)
@@ -2066,6 +2067,12 @@ app.include_router(_mcp_router)
 # fuzz wave: Qwen3-7B-4bit, etc.) must answer ``/v1/audio/*`` with a
 # stock 404 instead of advertising routes that 500 on first call.
 app.include_router(_cache_router)
+# Content-farm video lane (CONTRACT-ONLY): registered unconditionally so
+# ``/v1/video/generations`` is discoverable in the app and returns a
+# clean HTTP 501 until an LTX-2.3 backend is integrated. Unlike the audio
+# router it has no engine to load, so there's no text-only-server hazard
+# that motivated the audio lane's deferred registration.
+app.include_router(_video_router)
 
 
 def register_audio_routes_if_enabled() -> bool:

--- a/vllm_mlx/video/__init__.py
+++ b/vllm_mlx/video/__init__.py
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Video-generation lane (content-farm engine).
+
+CONTRACT-ONLY today: :mod:`vllm_mlx.video.engine` defines the
+``VideoEngine`` interface a future LTX-2.3 backend implements. The
+``/v1/video/generations`` route (see :mod:`vllm_mlx.routes.video`) ships
+the request/response schema now and returns HTTP 501 until a concrete
+backend is registered.
+"""
+
+from .engine import VideoEngine, resolve_video_engine
+
+__all__ = ["VideoEngine", "resolve_video_engine"]

--- a/vllm_mlx/video/engine.py
+++ b/vllm_mlx/video/engine.py
@@ -1,0 +1,94 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Text→video / image→video engine interface (content-farm lane).
+
+This is the fourth generation lane alongside ``TTSEngine`` (text→speech),
+``STTEngine`` (speech→text) and ``MusicEngine`` (text→music/SFX):
+``VideoEngine`` does text→video AND image→video, targeted at an
+MLX-native LTX-2.3 backend on Apple Silicon.
+
+CONTRACT-ONLY: there is **no** concrete backend wired yet. This module
+defines the :class:`VideoEngine` interface a future LTX-2.3
+implementation must satisfy and a :func:`resolve_video_engine` factory
+that raises :class:`NotImplementedError` until one is registered. The
+``/v1/video/generations`` route calls the factory so the day a backend
+lands the route goes live with zero handler changes.
+
+See ``REQUIREMENTS_rapid.md`` B1 for the backend-integration task.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class VideoEngine(Protocol):
+    """The surface a text→/image→video backend must implement.
+
+    A backend (e.g. an MLX-native LTX-2.3 port) implements ``generate``
+    and is returned by :func:`resolve_video_engine`. The route layer
+    depends ONLY on this Protocol, so swapping backends never touches
+    ``vllm_mlx.routes.video``.
+    """
+
+    def generate(
+        self,
+        prompt: str,
+        out_path: str | Path,
+        *,
+        image: str | None = None,
+        height: int = 704,
+        width: int = 1216,
+        num_frames: int = 97,
+        frame_rate: float = 25.0,
+        steps: int | None = None,
+        negative_prompt: str | None = None,
+        seed: int | None = None,
+    ) -> Path:
+        """Render a clip for ``prompt`` → ``out_path`` (mp4). Returns the path.
+
+        Args:
+            prompt: Natural-language description of the video.
+            out_path: Output mp4 path (absolute recommended).
+            image: Conditioning first frame for image-to-video — a base64
+                (optionally ``data:`` URI) string or an ``http(s)`` URL.
+                ``None`` selects text-to-video.
+            height: Output height in pixels.
+            width: Output width in pixels.
+            num_frames: Number of frames to render.
+            frame_rate: Playback frame rate (fps).
+            steps: Denoising steps (``None`` = backend default).
+            negative_prompt: CFG negative branch.
+            seed: Fixed seed for reproducibility (``None`` = random).
+
+        Returns:
+            The output ``Path`` (an mp4, with a native-audio track when
+            the backend emits one).
+        """
+        ...
+
+
+# Registry hook: a concrete backend assigns this to a zero-arg factory
+# returning a :class:`VideoEngine`. Left ``None`` while the lane is
+# contract-only so :func:`resolve_video_engine` fails loudly.
+_VIDEO_ENGINE_FACTORY = None
+
+
+def resolve_video_engine(model: str) -> VideoEngine:
+    """Return a :class:`VideoEngine` for ``model`` — or raise if none exists.
+
+    CONTRACT-ONLY: no backend is registered yet, so this always raises
+    :class:`NotImplementedError`. The route surfaces that as a clean
+    HTTP 501 so colleagues see the exact request/response contract and
+    the interface to implement LTX-2.3 behind.
+
+    A future backend registers itself by setting
+    :data:`_VIDEO_ENGINE_FACTORY`; this resolver then hands the route a
+    ready engine with no other route change.
+    """
+    if _VIDEO_ENGINE_FACTORY is None:
+        raise NotImplementedError(
+            "video backend not yet integrated; see REQUIREMENTS_rapid.md B1"
+        )
+    return _VIDEO_ENGINE_FACTORY(model)

--- a/vllm_mlx/video/engine.py
+++ b/vllm_mlx/video/engine.py
@@ -13,7 +13,8 @@ that raises :class:`NotImplementedError` until one is registered. The
 ``/v1/video/generations`` route calls the factory so the day a backend
 lands the route goes live with zero handler changes.
 
-See ``REQUIREMENTS_rapid.md`` B1 for the backend-integration task.
+See ``docs/content_farm_api.md`` for the wire contract and the
+backend-integration task.
 """
 
 from __future__ import annotations
@@ -69,9 +70,10 @@ class VideoEngine(Protocol):
         ...
 
 
-# Registry hook: a concrete backend assigns this to a zero-arg factory
-# returning a :class:`VideoEngine`. Left ``None`` while the lane is
-# contract-only so :func:`resolve_video_engine` fails loudly.
+# Registry hook: a concrete backend assigns this to a callable taking the
+# requested ``model`` id and returning a :class:`VideoEngine` (that is the
+# signature :func:`resolve_video_engine` invokes it with). Left ``None``
+# while the lane is contract-only so the resolver fails loudly.
 _VIDEO_ENGINE_FACTORY = None
 
 
@@ -89,6 +91,6 @@ def resolve_video_engine(model: str) -> VideoEngine:
     """
     if _VIDEO_ENGINE_FACTORY is None:
         raise NotImplementedError(
-            "video backend not yet integrated; see REQUIREMENTS_rapid.md B1"
+            "video backend not yet integrated; see docs/content_farm_api.md"
         )
     return _VIDEO_ENGINE_FACTORY(model)


### PR DESCRIPTION
## Why
The content-farm engine work (F5-TTS, MusicEngine, forced-alignment STT) has no HTTP surface yet — colleagues can't integrate it over a standard API. This exposes those engines via OpenAI-style routes so clients can call them, and lays down the request/response **contract** for the upcoming video lane.

## What
Three route surfaces (see `docs/content_farm_api.md` for full schemas + curl examples):

- **`POST /v1/audio/music`** (LIVE) → `MusicEngine` (Stable Audio 3). `{model, input, seconds, steps?, negative_prompt?, seed?, response_format?}` → `audio/wav` bytes. `model` selects the DiT/decoder pair (`medium`/`sm-music`/`sm-sfx`).
- **`POST /v1/audio/transcriptions` + `text` field** (LIVE, extends the existing route) → when `text` is present, switches from ASR to **forced alignment** via `STTEngine.align`, returning per-unit timestamps (reuses the existing srt/vtt/verbose_json serializers). Absent `text` = unchanged ASR.
- **`POST /v1/video/generations`** (CONTRACT-ONLY, returns `501`) → full t2v + i2v request/response schema + a `VideoEngine` Protocol (`vllm_mlx/video/engine.py`). The concrete resolver raises `NotImplementedError` until an LTX-2.3 backend is integrated. Registered so the contract is visible and clients can build against it now.

## Hardening after the initial draft
**Six rounds of codex review**, union of findings — it converged from 5 BLOCKING in round 1 to 1 BLOCKING + 3 nits in round 6. Every round after the first found something the earlier ones missed, twice including a hole in the fix a previous round had asked for, which is exactly why the SOP takes the union rather than trusting one pass. Everything below was a concrete defect, not polish:

**Concurrency.** Both live routes ran their blocking engine work inline in `async def` handlers. `MusicEngine.generate` shells out to the SA3 CLI and waits up to 900 s, so one music request froze the entire event loop — every concurrent completion, health probe and SSE heartbeat with it. Both now offload via `asyncio.to_thread`, serialised by an `asyncio.Lock` taken **on the loop** (a `threading.Lock` inside the worker would pin one shared-executor thread per queued request and starve every other `to_thread` user in the process). Cancellation is handled explicitly: a client disconnect used to unwind the lock and unlink the temp file while the abandoned worker kept writing to it, so both lanes now shield and drain the worker first.

**Error surfaces.**
- `/v1/audio/music` returned HTTP 200 with an empty `audio/wav` body when the SA3 CLI exited 0 without writing — indistinguishable from a successful silent clip. Now a 500 `music_generation_failed`.
- A corrupted upload on the alignment path was reported as `invalid_alignment_request` blaming `model`/`text`; some codec paths raise `ValueError`, which the alignment handler caught before the decode handler. Now classified as `invalid_audio_file` / `param: "file"`.
- A whitespace-only `text` silently ran ASR — answering a different question than the caller asked, with a 200 giving no hint. Now `400 invalid_alignment_request`.
- A whitespace-only `model` / `response_format` 404'd on a nonexistent alias instead of taking the lane default.

**Input validation.** `AudioMusicRequest.input` was unbounded but becomes an argv element for the SA3 CLI (opaque `E2BIG` 500) — capped at 4096. `VideoGenerationRequest.image` was an unbounded unvalidated string that a backend will **dereference**, making `file:///etc/passwd` an arbitrary local-file read and any internal URL an SSRF the moment a backend registers; now scheme-allowlisted via `urlsplit` (single-slash `file:/etc/passwd` was the first bypass), `data:` restricted to `image/*` with a payload that must actually decode, bare base64 validated by decoding rather than charset, 12 MB cap. Egress policy for the fetch itself remains the backend's job — and the docs now spell out the three things a dereferencing backend must do (per-connection address resolution, per-redirect re-checks, size/time bounds) rather than leaving it as a one-line aside. Building an SSRF-safe fetcher in the route layer was explicitly declined: there is no fetch here to hook, nothing dereferences `image`, and correct defence needs socket-level control.

**Cancellation safety.** A client disconnect cancels the handler, and `await asyncio.to_thread(...)` returns immediately on cancellation while the worker thread keeps running. That unwound the lock (admitting another request alongside a still-running multi-GB subprocess) and ran the `finally` that deletes the file the abandoned worker was writing to. All three lanes now go through `routes/_async_utils.run_to_completion`, which shields and drains the worker first.

**Correctness of the "goes live unchanged" claim.** The video handler's post-resolver path passed `out_path=None`, breaking the Protocol it documents, and echoed a server filesystem path as `url`. It now writes a real temp mp4, returns `b64_video`, tracks the path the backend actually wrote (cleanup previously leaked the mp4 if a backend returned a different path), uses `shutil.rmtree`, bounds inline delivery at 256 MB, does the read+encode off the loop, serialises renders behind a lock like the audio lanes, and enforces path containment BEFORE opening the file (a backend returning `../..`-style relative path was otherwise an arbitrary-file-disclosure primitive, since the containment check only guarded deletion). `VideoGenerationResult.url` is now validated as an absolute http(s) URL so a future backend can't reintroduce the path leak through that field, and the documented "exactly one of `b64_video`/`url`" invariant is actually enforced.

**Docs vs reality.** The 501 envelope and the docs pointed clients at `REQUIREMENTS_rapid.md`, which has never existed in this repo — repointed at `docs/content_farm_api.md`. Docs claimed 422 for schema violations; the server's global handler normalizes `RequestValidationError` to 400 (422 appears only on a bare app without those handlers, as unit tests use). Both corrected and pinned by tests.

**Gating.** `vllm_mlx.routes.video` was missing from `PROTECTED_ROUTER_MODULES`, whose own comment says membership IS the contract. And both CI test lists are explicit allowlists with this PR's test file in neither — it would never have run. Added to the apple-silicon job: the tests are hermetic (engines faked at the import boundary, no weights/network/`mlx_audio`) but not mlx-free, since `vllm_mlx.config` pulls in `engine_core`'s `import mlx.core`.

## Tests
- `tests/test_content_farm_routes.py`: **15 → 58 tests**, all hermetic. Every behavioural fix is pinned by a test confirmed to fail before the fix.
- `pr_validate`: 6 steps PASS (`lint` clean on all 10 changed files, `cl_description_quality`, `supply_chain`, `test_env_check`, `test_plan_check`, `fetch`). `full_unit`: **14359 passed, 1 failed** — the one failure is `test_no_unregistered_routing_shaped_flags`, tripped by `--no-conditioner-lora` in the vendored SA3 tree, which fails identically on the base branch untouched. (That same flag is PR #1307's Blocker 2.)
- Full local build (`pip install -e .`, py3.13) + **live `rapid-mlx serve` verification** of all three routes: real forced alignment through the new lock+shield path returning correct per-character timestamps; the music route reaching the SA3 subprocess with correctly-mapped `--dit/--decoder` argv; every image-scheme bypass returning 400; the documented legit forms reaching the 501.
- Regression: the audio/route/auth subset was diffed against both the un-hardened PR head and the base branch — **identical failure sets**, so zero new failures. (86 pre-existing failures on this branch are all local missing optional deps: `mlx_audio`, `prometheus_client`.)
- `ruff format` / `ruff check`: clean on all changed files.

## Notes
- **Base is `mvp/content-farm-local`, not `main`, on purpose**: these routes call `MusicEngine` and `STTEngine.align`, which currently live only on the content-farm branch. A clean march to `main` needs those engine PRs first (`MusicEngine` is #1307); this PR keeps the diff to the route layer.
- Because the base isn't `main`, **neither `ci.yml` nor `pr-validate.yml` triggers on this PR** (both are `pull_request: branches: [main]`) — hence the local build + live server verification above.
- **One open design question for the founder**, deliberately not decided here: `VideoGenerationResult.url` and `.audio` cannot be populated through the current `VideoEngine.generate`, which returns a bare `Path`. codex flagged this in two separate rounds. They're now documented as RESERVED and the handler always emits `b64_video`. Making them live means having the Protocol return a structured artifact (bytes-or-URL + optional audio track) — an interface change on the contract you set, so it's left as a follow-up rather than redesigned in a hardening pass.
- Video route is contract + stub only — no LTX integration in this PR.

🤖 AI-assisted: routes, schemas, tests, and docs drafted by Claude Code; hardening pass, codex review triage, and live verification by Claude Code (Opus 5), reviewed by the author.
