### PR TITLE
fix(audio): harden F5-TTS _generate_f5 (silent-ref RMS floor, stereo downmix, channel bound)

### DIFF
--- a/tests/test_f5_tts_wiring.py
+++ b/tests/test_f5_tts_wiring.py
@@ -80,12 +80,9 @@ def test_f5_generation_uses_safe_in_memory_default_and_speed(
     monkeypatch.setitem(sys.modules, "f5_tts_mlx.generate", generate_module)
 
     monkeypatch.setattr("pkgutil.get_data", lambda *_: b"packaged-wave", raising=True)
-    read = MagicMock(return_value=(np.ones(240, dtype=np.float32), 24_000))
-    monkeypatch.setattr(
-        "soundfile.info",
-        lambda *_: SimpleNamespace(samplerate=24_000, channels=1, frames=240),
+    opened = _install_fake_soundfile(
+        monkeypatch, channels=1, frames=240, data=np.ones(240, dtype=np.float32)
     )
-    monkeypatch.setattr("soundfile.read", read)
 
     model = MagicMock()
     model.sample.return_value = (np.ones(480, dtype=np.float32), None)
@@ -94,7 +91,9 @@ def test_f5_generation_uses_safe_in_memory_default_and_speed(
 
     output = engine._generate_f5("你好", None, None, 1.5)
 
-    assert isinstance(read.call_args.args[0], io.BytesIO)
+    # The packaged default reference is read from an in-memory buffer (no
+    # predictable temp path).
+    assert isinstance(opened["source"], io.BytesIO)
     duration.assert_called_once()
     assert duration.call_args.args[-1] == 1.5
     assert model.sample.call_args.kwargs["speed"] == 1.5
@@ -102,15 +101,16 @@ def test_f5_generation_uses_safe_in_memory_default_and_speed(
     assert output.audio.shape == (240,)
 
 
-def test_f5_rejects_stereo_and_silent_references(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def _install_fake_f5_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Register lightweight fakes for ``mlx`` and ``f5_tts_mlx.generate`` so the
+    F5 code path runs without real weights or the native mlx runtime."""
     fake_mx = ModuleType("mlx.core")
     fake_mx.array = np.asarray
     fake_mx.sqrt = np.sqrt
     fake_mx.mean = np.mean
     fake_mx.square = np.square
     fake_mx.eval = lambda value: None
+    fake_mx.expand_dims = np.expand_dims
     mlx_module = ModuleType("mlx")
     mlx_module.core = fake_mx
     monkeypatch.setitem(sys.modules, "mlx", mlx_module)
@@ -125,20 +125,111 @@ def test_f5_rejects_stereo_and_silent_references(
     monkeypatch.setitem(sys.modules, "f5_tts_mlx", ModuleType("f5_tts_mlx"))
     monkeypatch.setitem(sys.modules, "f5_tts_mlx.generate", generate_module)
 
-    engine = TTSEngine("lucasnewman/f5-tts-mlx")
-    monkeypatch.setattr(
-        "soundfile.info",
-        lambda *_: SimpleNamespace(samplerate=24_000, channels=2, frames=240),
+
+def _install_fake_soundfile(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    samplerate: int = 24_000,
+    channels: int = 1,
+    frames: int = 240,
+    data: np.ndarray | None = None,
+) -> dict:
+    """Fake ``soundfile.SoundFile`` as a single-open context manager so the F5
+    read path runs without a real file. The production code validates metadata
+    and reads samples through one handle (no separate ``info``/``read`` opens);
+    the fake mirrors that. Returns a dict whose ``source`` key records the
+    object that was opened. ``data=None`` means ``read()`` must not be reached
+    (e.g. a metadata guard should reject first)."""
+    opened: dict = {}
+
+    class _FakeSoundFile:
+        def __init__(self, source, *args, **kwargs):
+            opened["source"] = source
+            if hasattr(source, "seek"):
+                source.seek(0)
+            self.samplerate = samplerate
+            self.channels = channels
+            self.frames = frames
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+        def read(self, *args, **kwargs):
+            if data is None:
+                raise AssertionError("SoundFile.read() should not be reached")
+            return np.array(data)
+
+    monkeypatch.setattr("soundfile.SoundFile", _FakeSoundFile)
+    return opened
+
+
+def test_f5_downmixes_stereo_reference_to_mono(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A stereo reference is downmixed to mono and accepted (was rejected)."""
+    _install_fake_f5_env(monkeypatch)
+
+    # soundfile returns shape (frames, channels) for multi-channel audio. Use
+    # distinct per-channel values so the test can tell averaging apart from
+    # merely dropping a channel: L=0.2, R=0.4 -> mono mean 0.3. (0.3 exceeds
+    # TARGET_RMS 0.1, so no RMS renormalization is applied and the conditioning
+    # values stay 0.3.)
+    stereo = np.stack(
+        [np.full(240, 0.2, dtype=np.float32), np.full(240, 0.4, dtype=np.float32)],
+        axis=1,
     )
-    with pytest.raises(ValueError, match="mono"):
+    _install_fake_soundfile(monkeypatch, channels=2, frames=240, data=stereo)
+
+    model = MagicMock()
+    model.sample.return_value = (np.ones(480, dtype=np.float32), None)
+    engine = TTSEngine("lucasnewman/f5-tts-mlx")
+    engine.model = model
+
+    output = engine._generate_f5("hello", "ref.wav", "reference", 1.0)
+
+    # The reference handed to sample() must be batched mono: (1, frames), not
+    # (1, frames, channels) — proving the stereo track was collapsed to mono.
+    cond = np.asarray(model.sample.call_args.args[0])
+    assert cond.shape == (1, 240)
+    # It must be the per-channel *average* (0.3), not a dropped channel (0.2/0.4).
+    assert np.allclose(cond, 0.3)
+    assert output.audio.shape == (240,)
+
+
+def test_f5_rejects_reference_with_too_many_channels(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A header advertising more than stereo is rejected before decoding, so a
+    pathological channel count can't force an oversized allocation."""
+    _install_fake_f5_env(monkeypatch)
+
+    # data=None => read() raises if reached; the channel guard must reject first.
+    _install_fake_soundfile(monkeypatch, channels=64, frames=240, data=None)
+
+    engine = TTSEngine("lucasnewman/f5-tts-mlx")
+    with pytest.raises(ValueError, match="mono or stereo"):
         engine._generate_f5("hello", "ref.wav", "reference", 1.0)
 
-    monkeypatch.setattr(
-        "soundfile.info",
-        lambda *_: SimpleNamespace(samplerate=24_000, channels=1, frames=240),
-    )
-    monkeypatch.setattr(
-        "soundfile.read", lambda *_: (np.zeros(240, dtype=np.float32), 24_000)
-    )
+
+def test_f5_rejects_near_silent_reference_below_rms_floor(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A near-silent reference (tiny positive RMS below the floor) is rejected.
+
+    The prior guard only rejected ``rms <= 0``, so a near-silent clip slipped
+    through and got amplified into full-scale noise. The RMS floor must reject
+    it with a clear error.
+    """
+    _install_fake_f5_env(monkeypatch)
+
+    # RMS == 5e-5, which is > 0 (so the old ``rms <= 0`` guard misses it) but
+    # below the 1e-4 floor.
+    near_silent = np.full(240, 5e-5, dtype=np.float32)
+    _install_fake_soundfile(monkeypatch, channels=1, frames=240, data=near_silent)
+
+    engine = TTSEngine("lucasnewman/f5-tts-mlx")
     with pytest.raises(ValueError, match="non-silent"):
         engine._generate_f5("hello", "ref.wav", "reference", 1.0)

--- a/vllm_mlx/audio/tts.py
+++ b/vllm_mlx/audio/tts.py
@@ -22,6 +22,19 @@ logger = logging.getLogger(__name__)
 # Default models
 DEFAULT_TTS_MODEL = "mlx-community/Kokoro-82M-bf16"
 
+# F5-TTS normalizes the reference clip toward ``TARGET_RMS`` via
+# ``aud * TARGET_RMS / rms``. A silent (rms==0) or near-silent reference would
+# either divide by zero (NaN/inf) or get amplified by a huge factor, turning
+# quantization noise / DC offset into full-scale garbage. Refs whose RMS falls
+# below this floor (~-80 dBFS) are rejected with a clear error instead.
+F5_MIN_REF_RMS = 1e-4
+
+# Multi-channel references are downmixed to mono, but the channel count is left
+# unbounded by the (frames-only) duration guard. Cap it so a pathological
+# many-channel header can't force a disproportionately large decode/allocation
+# before the downmix. Mono and stereo are the only realistic reference formats.
+F5_MAX_REF_CHANNELS = 2
+
 # Available voices per model family
 KOKORO_VOICES = [
     "af_heart",
@@ -412,19 +425,36 @@ class TTSEngine:
         )
 
         def read_reference(source):
-            info = sf.info(source)
-            if info.samplerate != SAMPLE_RATE:
-                raise ValueError(
-                    f"F5 ref_audio must be {SAMPLE_RATE} Hz "
-                    f"(got {info.samplerate}); resample it."
-                )
-            if info.channels != 1:
-                raise ValueError("F5 ref_audio must be mono.")
-            if info.frames <= 0 or info.frames > SAMPLE_RATE * 30:
-                raise ValueError("F5 ref_audio must be between 0 and 30 seconds.")
             if hasattr(source, "seek"):
                 source.seek(0)
-            audio, _ = sf.read(source)
+            # Open the source once and validate metadata + read samples through
+            # the SAME handle. Using ``sf.info(path)`` then ``sf.read(path)``
+            # would open the path twice (TOCTOU): a file swapped between the two
+            # opens could pass the sample-rate/frame/channel guards yet decode
+            # something else. A single handle closes that gap and also bounds the
+            # decode to the header's validated frames*channels.
+            with sf.SoundFile(source) as handle:
+                if handle.samplerate != SAMPLE_RATE:
+                    raise ValueError(
+                        f"F5 ref_audio must be {SAMPLE_RATE} Hz "
+                        f"(got {handle.samplerate}); resample it."
+                    )
+                if handle.frames <= 0 or handle.frames > SAMPLE_RATE * 30:
+                    raise ValueError("F5 ref_audio must be between 0 and 30 seconds.")
+                # Reject pathological channel counts before decoding: the
+                # duration guard bounds frames only, so a many-channel header
+                # would otherwise force a frames*channels allocation.
+                if handle.channels < 1 or handle.channels > F5_MAX_REF_CHANNELS:
+                    raise ValueError(
+                        f"F5 ref_audio must be mono or stereo "
+                        f"(got {handle.channels} channels)."
+                    )
+                audio = handle.read()
+            # soundfile returns shape (frames,) for mono and (frames, channels)
+            # for multi-channel. F5's sample() expects batched mono, so downmix
+            # any extra channels to a single mono track by averaging.
+            if audio.ndim > 1:
+                audio = audio.mean(axis=1)
             return audio
 
         if ref_audio is not None:
@@ -443,8 +473,21 @@ class TTSEngine:
         rms = mx.sqrt(mx.mean(mx.square(aud)))
         mx.eval(rms)
         rms_value = float(rms)
-        if not np.isfinite(rms_value) or rms_value <= 0:
-            raise ValueError("F5 ref_audio must contain finite, non-silent audio.")
+        # A zero/near-silent reference divides by ~0 below (NaN/inf) or is
+        # amplified into full-scale noise. Reject it with a clear error. Report
+        # a non-finite RMS separately so the message doesn't nonsensically claim
+        # NaN/inf is "below the floor".
+        if not np.isfinite(rms_value):
+            raise ValueError(
+                "F5 ref_audio must contain finite, non-silent audio "
+                f"(reference RMS is non-finite: {rms_value})."
+            )
+        if rms_value < F5_MIN_REF_RMS:
+            raise ValueError(
+                "F5 ref_audio must contain finite, non-silent audio "
+                f"(reference RMS {rms_value:.2e} is below the "
+                f"{F5_MIN_REF_RMS:.0e} floor)."
+            )
         if rms_value < TARGET_RMS:
             aud = aud * TARGET_RMS / rms
         # explicit duration estimate — F5's auto heuristic can collapse to ~0s


### PR DESCRIPTION
## Why

PR #1297 (F5-TTS Chinese cloning, merged to `main`) drew a codex review with four hardening findings on `TTSEngine._generate_f5` in `vllm_mlx/audio/tts.py`. Two were false positives against the merged code; two were real. This PR fixes the two real ones (plus hardening surfaced during review) and adds hermetic regression tests. No version bump.

## What

- **Silent / near-silent reference → NaN or full-scale noise (real).** The RMS-normalization step `aud * TARGET_RMS / rms` divides by ~0 (NaN/inf) for a silent ref, or amplifies quantization noise / DC offset to full scale for a near-silent one. The prior guard only rejected `rms <= 0`, so a tiny positive RMS slipped through. Added an `F5_MIN_REF_RMS = 1e-4` (~-80 dBFS) floor; refs below it raise a clear `ValueError`. Non-finite RMS is reported with its own message (not "below the floor").
- **Stereo reference (real).** `soundfile` returns `(frames, channels)` for multi-channel input while F5's `sample()` expects batched mono. Previously any non-mono ref was rejected; now extra channels are downmixed to mono via `audio.mean(axis=1)`. Mono refs are unaffected.
- **Bounded channel count (review hardening).** The frames-only duration guard left the channel count unbounded, so a pathological many-channel header could force a large `frames*channels` decode before downmixing. Added `F5_MAX_REF_CHANNELS = 2` (mono/stereo) enforced from the header before decoding.
- **Single-open reference read (review hardening — TOCTOU).** The reference is now validated and read through one `sf.SoundFile` handle instead of `sf.info(path)` + `sf.read(path)`, so a file swapped between the two opens can't bypass the sample-rate / frame / channel guards. `ref_audio` is a real filesystem path in the route, so this is a genuine double-open gap.

The two false-positive findings are unchanged and confirmed against current `main`: the packaged default reference already loads via `pkgutil.get_data(...)` into an in-memory `io.BytesIO` (no predictable temp path / race), and `speed` is already threaded through `estimated_duration(...)` and `self.model.sample(..., speed=speed)`.

## Tests

`tests/test_f5_tts_wiring.py` (hermetic — fakes `mlx`, `f5_tts_mlx`, and `soundfile.SoundFile` at the boundary; no real weights or network):

- `test_f5_downmixes_stereo_reference_to_mono` — distinct L/R (0.2/0.4) confirm the conditioning waveform is the *average* (0.3), not a dropped channel; output is mono. Fails on pre-fix code (stereo rejected as "must be mono").
- `test_f5_rejects_near_silent_reference_below_rms_floor` — RMS `5e-5` (> 0, below floor) raises `ValueError`. Fails on pre-fix code (slips past the `rms <= 0` guard).
- `test_f5_rejects_reference_with_too_many_channels` — a 64-channel header is rejected before `read()` is reached.
- Existing `..._safe_in_memory_default_and_speed` updated to the single-handle read path; still asserts the in-memory default and `speed` wiring.

`full_unit`: 14400 passed. `codex_review`: 0 blocking. pr_validate verdict: **MERGE-SAFE**.

## AI-assisted

Drafted and hardened with AI assistance (Claude Code) and reviewed by the author.
