### PR TITLE
feat(audio): Qwen3-TTS Base zero-shot voice cloning [skip-version-bump]

### DIFF
--- a/tests/test_qwen3_tts_clone.py
+++ b/tests/test_qwen3_tts_clone.py
@@ -1,0 +1,98 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Qwen3-TTS **Base** zero-shot voice cloning (ref_audio + ref_text).
+
+Hermetic: a fake mlx_audio model is injected at ``TTSEngine.model``. We assert
+the engine forwards ``ref_audio``/``ref_text`` to the ``qwen3_tts`` generate
+call ONLY when supplied — so one family serves both CustomVoice (named speaker)
+and Base (cloning) without cross-contaminating the call surface.
+"""
+
+import types
+
+import numpy as np
+
+from vllm_mlx.audio.registry import resolve_audio_alias
+from vllm_mlx.audio.tts import TTSEngine
+
+BASE_BF16 = "mlx-community/Qwen3-TTS-12Hz-1.7B-Base-bf16"
+_UNSET = object()
+
+
+class _CloneCapturingModel:
+    """Fake Qwen3-TTS Base whose ``generate`` accepts the cloning surface.
+    Explicit signature (no ``**kwargs``) so an unexpected keyword raises here;
+    sentinel defaults record ref_audio/ref_text ONLY when actually passed."""
+
+    def __init__(self):
+        self.calls: list[dict] = []
+
+    def generate(
+        self,
+        *,
+        text,
+        voice=None,
+        speed=1.0,
+        lang_code=None,
+        instruct=_UNSET,
+        ref_audio=_UNSET,
+        ref_text=_UNSET,
+    ):
+        rec = {"text": text, "voice": voice, "lang_code": lang_code}
+        if instruct is not _UNSET:
+            rec["instruct"] = instruct
+        if ref_audio is not _UNSET:
+            rec["ref_audio"] = ref_audio
+        if ref_text is not _UNSET:
+            rec["ref_text"] = ref_text
+        self.calls.append(rec)
+        return iter(
+            [
+                types.SimpleNamespace(
+                    audio=np.zeros(240, dtype=np.float32), sample_rate=24000
+                )
+            ]
+        )
+
+
+def _clone_engine():
+    engine = TTSEngine(BASE_BF16)
+    engine.model = _CloneCapturingModel()
+    engine._loaded = True
+    return engine
+
+
+def test_clone_alias_points_at_base_variant():
+    entry = resolve_audio_alias("qwen3-tts-clone")
+    assert entry is not None
+    assert entry.type == "tts"
+    assert entry.family == "qwen3_tts"
+    assert entry.hf_id == BASE_BF16
+
+
+def test_base_repo_detected_as_qwen3_family():
+    assert _clone_engine()._model_family == "qwen3_tts"
+
+
+def test_ref_audio_and_text_forwarded_when_given():
+    eng = _clone_engine()
+    eng.generate("你好世界", ref_audio="narrator_ref.wav", ref_text="这是参考音频")
+    call = eng.model.calls[0]
+    assert call["ref_audio"] == "narrator_ref.wav"
+    assert call["ref_text"] == "这是参考音频"
+    assert call["lang_code"] == "auto"  # qwen3 auto-detects language
+
+
+def test_no_cloning_kwargs_without_ref():
+    eng = _clone_engine()
+    eng.generate("你好世界", voice="Serena")
+    call = eng.model.calls[0]
+    assert "ref_audio" not in call
+    assert "ref_text" not in call
+
+
+def test_ref_text_omitted_when_only_ref_audio():
+    eng = _clone_engine()
+    eng.generate("你好世界", ref_audio="narrator_ref.wav")
+    call = eng.model.calls[0]
+    assert call["ref_audio"] == "narrator_ref.wav"
+    assert "ref_text" not in call

--- a/tests/test_speech_inline_clone_route.py
+++ b/tests/test_speech_inline_clone_route.py
@@ -270,9 +270,31 @@ class TestF5InlineCloneRoute:
         # CustomVoice repo look clone-capable.
         ("base-org/Qwen3-TTS-0.6B-CustomVoice", False),
         ("mlx-community/Kokoro-82M-bf16", False),
+        # A bare ``f5`` token that is NOT ``f5-tts``/``f5_tts`` must NOT be
+        # deemed clone-capable: TTSEngine._detect_family classifies it as
+        # Kokoro and would drop ref_audio, so the gate must agree and let
+        # the reference be rejected up front rather than silently ignored.
+        ("org/f5-foo", False),
+        ("org/f5", False),
     ],
 )
 def test_is_clone_capable_model_classification(model_name, expected):
     from vllm_mlx.routes.audio import _is_clone_capable_model
 
     assert _is_clone_capable_model(model_name) is expected
+
+
+def test_clone_gate_matches_engine_family_for_f5_token():
+    """Regression pin (codex round 2): the route clone gate and the engine
+    family classifier must never disagree in the DANGEROUS direction —
+    gate says clone-capable but engine drops ref_audio. For an ``f5`` token
+    that is not ``f5-tts``/``f5_tts`` the engine detects the default
+    (Kokoro) family, so the gate must NOT deem it clone-capable."""
+    from vllm_mlx.audio.tts import TTSEngine
+    from vllm_mlx.routes.audio import _is_clone_capable_model
+
+    name = "org/f5-foo"
+    assert _is_clone_capable_model(name) is False
+    # Engine would NOT treat it as F5 (family falls back to kokoro), which
+    # is exactly why the gate must reject the reference.
+    assert TTSEngine(name)._model_family != "f5"

--- a/tests/test_speech_inline_clone_route.py
+++ b/tests/test_speech_inline_clone_route.py
@@ -1,0 +1,278 @@
+# SPDX-License-Identifier: Apache-2.0
+"""End-to-end ``POST /v1/audio/speech`` inline voice-cloning contract.
+
+The Qwen3-TTS **Base** clone path (alias ``qwen3-tts-clone``) has to travel
+the FULL route, not just the engine. Three route hazards are pinned here,
+all hermetic (no weights, no network — the ``TTSEngine`` is stubbed and the
+``mlx_audio`` probe is faked):
+
+1. A clone-capable model (Qwen3-TTS Base / F5-TTS) with an inline
+   ``ref_audio`` reference clip must SKIP the named-speaker allowlist and
+   OMIT ``voice`` from the generate call — the Base repo's registry
+   ``default_voice`` is the ``"clone"`` sentinel, which is NOT a member of
+   the speaker allowlist, so running the allowlist would 400 the very
+   request we mean to serve.
+2. A Base repo WITHOUT a reference still 400s with an actionable message
+   (Base cannot synthesize reference-free), while WITH a reference it is
+   the correct target and must reach the engine.
+3. A reference clip aimed at a non-clone model (Qwen3-TTS CustomVoice)
+   is rejected up front rather than silently ignored.
+
+Uses the same ``mlx_audio``-fake + stubbed-``TTSEngine`` harness as
+``tests/test_qwen3_tts_audio.py``, with a clone-aware recording engine that
+records exactly which kwargs the route forwarded so the "voice omitted"
+contract can be asserted.
+"""
+
+from __future__ import annotations
+
+import base64
+import importlib.machinery
+import sys
+import types
+
+import pytest
+
+CLONE_BASE_BF16 = "mlx-community/Qwen3-TTS-12Hz-1.7B-Base-bf16"
+CUSTOMVOICE_BF16 = "mlx-community/Qwen3-TTS-12Hz-1.7B-CustomVoice-bf16"
+
+# A tiny non-empty payload — the route only base64-decodes and size-bounds
+# it (see ``_decode_tts_ref_audio``); the stubbed engine never opens it.
+_REF_WAV_B64 = base64.b64encode(b"RIFF----WAVEfake-reference-clip").decode()
+_UNSET = object()
+
+
+def _install_fake_mlx_audio(monkeypatch):
+    """Minimal fake so the TTS-lane probe passes without the real extra."""
+    fake = types.ModuleType("mlx_audio")
+    fake.__path__ = []
+    fake.__spec__ = importlib.machinery.ModuleSpec(
+        "mlx_audio", loader=None, is_package=True
+    )
+    fake_tts = types.ModuleType("mlx_audio.tts")
+    fake_tts.__path__ = []
+    fake_tts.__spec__ = importlib.machinery.ModuleSpec(
+        "mlx_audio.tts", loader=None, is_package=True
+    )
+    monkeypatch.setitem(sys.modules, "mlx_audio", fake)
+    monkeypatch.setitem(sys.modules, "mlx_audio.tts", fake_tts)
+
+
+class _CloneRecordingEngine:
+    """TTSEngine stub that records generate() kwargs, using sentinel
+    defaults so the test can distinguish "``voice`` was forwarded" from
+    "``voice`` was omitted" — the crux of the inline-clone contract."""
+
+    instances: list[_CloneRecordingEngine] = []
+    _real_to_bytes = None
+
+    def __init__(self, model_name: str):
+        self.model_name = model_name
+        self.generate_calls: list[dict] = []
+        _CloneRecordingEngine.instances.append(self)
+
+    def load(self):
+        pass
+
+    def generate(
+        self,
+        text,
+        voice=_UNSET,
+        speed=1.0,
+        instruct=None,
+        ref_audio=_UNSET,
+        ref_text=_UNSET,
+    ):
+        import numpy as np
+
+        rec: dict = {"text": text, "speed": speed, "instruct": instruct}
+        if voice is not _UNSET:
+            rec["voice"] = voice
+        if ref_audio is not _UNSET:
+            rec["ref_audio"] = ref_audio
+        if ref_text is not _UNSET:
+            rec["ref_text"] = ref_text
+        self.generate_calls.append(rec)
+
+        from vllm_mlx.audio.tts import AudioOutput
+
+        return AudioOutput(
+            audio=np.zeros(240, dtype=np.float32), sample_rate=24000, duration=0.01
+        )
+
+    def to_bytes(self, audio, format="wav"):
+        return type(self)._real_to_bytes(self, audio, format=format)
+
+
+def _mount(monkeypatch):
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from vllm_mlx.audio import probe as probe_mod
+    from vllm_mlx.audio import tts as tts_mod
+    from vllm_mlx.config import get_config
+    from vllm_mlx.middleware.exception_handlers import install_exception_handlers
+    from vllm_mlx.routes import audio as audio_route
+
+    _CloneRecordingEngine.instances = []
+    _CloneRecordingEngine._real_to_bytes = tts_mod.TTSEngine.to_bytes
+    _install_fake_mlx_audio(monkeypatch)
+    monkeypatch.setattr(probe_mod, "require_mlx_audio_tts", lambda: None)
+    monkeypatch.setattr(probe_mod, "require_kokoro_runtime", lambda: None)
+    monkeypatch.setattr(tts_mod, "TTSEngine", _CloneRecordingEngine)
+    # Cold-start: force snapshot enumeration empty so the route uses the
+    # static per-family voice list (matches a fresh install).
+    monkeypatch.setattr(tts_mod, "_list_snapshot_voices", lambda _n: [])
+    monkeypatch.setattr(audio_route, "_tts_engine", None)
+
+    app = FastAPI()
+    app.include_router(audio_route.router)
+    install_exception_handlers(app)
+    cfg = get_config()
+    monkeypatch.setattr(cfg, "api_key", None)
+    return TestClient(app)
+
+
+class TestInlineCloneRoute:
+    def test_base_clone_omits_voice_and_forwards_reference(self, monkeypatch):
+        """qwen3-tts-clone + inline ref_audio/ref_text, ``voice`` omitted:
+        200, the engine receives the reference clip AND its transcript, and
+        ``voice`` is NOT forwarded (the ``"clone"`` sentinel never reaches
+        the engine, and no ``invalid_voice`` 400 is raised)."""
+        client = _mount(monkeypatch)
+        resp = client.post(
+            "/v1/audio/speech",
+            json={
+                "model": "qwen3-tts-clone",
+                "input": "你好世界。",
+                "ref_audio": _REF_WAV_B64,
+                "ref_text": "这是参考音频。",
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.headers["content-type"] == "audio/wav"
+        (engine,) = _CloneRecordingEngine.instances
+        assert engine.model_name == CLONE_BASE_BF16
+        (call,) = engine.generate_calls
+        # The clone surface reached the engine…
+        assert call.get("ref_audio") is not None
+        assert call["ref_text"] == "这是参考音频。"
+        # …and ``voice`` was OMITTED from the generate call.
+        assert "voice" not in call
+
+    def test_base_clone_ignores_explicit_voice(self, monkeypatch):
+        """Even an explicit named speaker is dropped on a clone request —
+        the reference clip governs the timbre, so the route must neither
+        400 on it nor forward it to the engine."""
+        client = _mount(monkeypatch)
+        resp = client.post(
+            "/v1/audio/speech",
+            json={
+                "model": "qwen3-tts-clone",
+                "input": "你好世界。",
+                "voice": "Serena",
+                "ref_audio": _REF_WAV_B64,
+                "ref_text": "这是参考音频。",
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        (engine,) = _CloneRecordingEngine.instances
+        (call,) = engine.generate_calls
+        assert "voice" not in call
+        assert call.get("ref_audio") is not None
+
+    def test_base_without_reference_400s_actionable(self, monkeypatch):
+        """qwen3-tts-clone with NO reference: 400 ``unsupported_model_variant``
+        (Base cannot synthesize reference-free). The message must point at
+        BOTH remedies — supply ref_audio, or use a CustomVoice repo — and
+        no engine is constructed."""
+        client = _mount(monkeypatch)
+        resp = client.post(
+            "/v1/audio/speech",
+            json={"model": "qwen3-tts-clone", "input": "你好世界。"},
+        )
+        assert resp.status_code == 400, resp.text
+        body = resp.json()
+        assert body["error"]["code"] == "unsupported_model_variant"
+        msg = body["error"]["message"]
+        assert "ref_audio" in msg
+        assert "CustomVoice" in msg
+        assert _CloneRecordingEngine.instances == []
+
+    def test_customvoice_with_reference_rejected(self, monkeypatch):
+        """A reference clip aimed at the reference-free CustomVoice variant
+        is rejected up front (``unsupported_voice_cloning``), not silently
+        ignored — CustomVoice has no cloning surface."""
+        client = _mount(monkeypatch)
+        resp = client.post(
+            "/v1/audio/speech",
+            json={
+                "model": "qwen3-tts",  # CustomVoice alias
+                "input": "你好世界。",
+                "ref_audio": _REF_WAV_B64,
+                "ref_text": "这是参考音频。",
+            },
+        )
+        assert resp.status_code == 400, resp.text
+        body = resp.json()
+        assert body["error"]["code"] == "unsupported_voice_cloning"
+        assert _CloneRecordingEngine.instances == []
+
+    def test_real_customvoice_not_swept_by_base_guard(self, monkeypatch):
+        """Regression pin for the classification: the Base-reject guard is
+        keyed on the repo-name tokens, so a real CustomVoice repo is NOT
+        swept up by the Base guard even though both share the qwen3-tts
+        prefix — it synthesizes normally (reference-free)."""
+        client = _mount(monkeypatch)
+        resp = client.post(
+            "/v1/audio/speech",
+            json={"model": "qwen3-tts", "input": "你好世界。", "voice": "Serena"},
+        )
+        assert resp.status_code == 200, resp.text
+        (engine,) = _CloneRecordingEngine.instances
+        (call,) = engine.generate_calls
+        assert call["voice"] == "Serena"
+
+
+class TestF5InlineCloneRoute:
+    def test_f5_clone_forwards_reference_and_omits_voice(self, monkeypatch):
+        """F5-TTS is clone-capable too: an inline reference reaches the
+        engine and ``voice`` is omitted (F5 has no named-speaker surface),
+        proving the clone gate is not Qwen3-only."""
+        client = _mount(monkeypatch)
+        resp = client.post(
+            "/v1/audio/speech",
+            json={
+                "model": "f5-tts-zh",
+                "input": "你好世界。",
+                "ref_audio": _REF_WAV_B64,
+                "ref_text": "这是参考音频。",
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        (engine,) = _CloneRecordingEngine.instances
+        (call,) = engine.generate_calls
+        assert call.get("ref_audio") is not None
+        assert call["ref_text"] == "这是参考音频。"
+        assert "voice" not in call
+
+
+@pytest.mark.parametrize(
+    "model_name,expected",
+    [
+        ("mlx-community/Qwen3-TTS-12Hz-1.7B-Base-bf16", True),
+        ("mlx-community/Qwen3-TTS-12Hz-1.7B-CustomVoice-bf16", False),
+        ("lucasnewman/f5-tts-mlx", True),
+        # An org segment carrying ``customvoice`` must NOT suppress a real
+        # Base repo (classification is on the repo NAME's tokens).
+        ("customvoice-org/Qwen3-TTS-0.6B-Base", True),
+        # An unrelated ``base`` in the ORG segment must NOT make a
+        # CustomVoice repo look clone-capable.
+        ("base-org/Qwen3-TTS-0.6B-CustomVoice", False),
+        ("mlx-community/Kokoro-82M-bf16", False),
+    ],
+)
+def test_is_clone_capable_model_classification(model_name, expected):
+    from vllm_mlx.routes.audio import _is_clone_capable_model
+
+    assert _is_clone_capable_model(model_name) is expected

--- a/vllm_mlx/audio/aliases.json
+++ b/vllm_mlx/audio/aliases.json
@@ -111,6 +111,13 @@
     "default_voice": "clone",
     "notes": "F5-TTS (pure-MLX, no torch): EN+ZH multilingual, zero-shot voice CLONING via ref_audio (24kHz clip) + ref_text. Fills the Chinese expressive/cloneable gap (Qwen3-TTS is flat, Chatterbox English-only). With no ref it uses a packaged default voice; supply a Chinese ref for a natural Chinese narrator."
   },
+  "qwen3-tts-clone": {
+    "type": "tts",
+    "hf_id": "mlx-community/Qwen3-TTS-12Hz-1.7B-Base-bf16",
+    "family": "qwen3_tts",
+    "default_voice": "clone",
+    "notes": "Alibaba Qwen3-TTS 1.7B **Base** — zero-shot Chinese/multilingual voice CLONING. Requires ref_audio (a clean 5-10s reference clip at the model's native sample rate) plus ref_text (its exact transcript); ignores predefined speakers. Lets a channel reuse ONE consistent branded narrator voice. Distinct from the CustomVoice variant (named speakers + `instruct` emotion, no cloning)."
+  },
   "qwen3-tts-customvoice": {
     "type": "tts",
     "hf_id": "mlx-community/Qwen3-TTS-12Hz-1.7B-CustomVoice-bf16",

--- a/vllm_mlx/audio/tts.py
+++ b/vllm_mlx/audio/tts.py
@@ -319,9 +319,15 @@ class TTSEngine:
                 so passing it is a no-op there rather than an error.
             ref_audio: Optional path to a reference audio clip for zero-shot
                 voice cloning. Used by the F5-TTS ``f5`` family to clone the
-                clip's timbre; ignored by families without a cloning surface.
+                clip's timbre, and by Qwen3-TTS **Base** (optional — clones the
+                ref timbre; the Base variant ignores ``voice`` when ``ref_audio``
+                is set, while CustomVoice ignores ``ref_audio`` and keeps its
+                named speaker). Use a clean 5-10s clip at the model's native
+                sample rate. Ignored by families without a cloning surface.
             ref_text: Optional transcript of ``ref_audio`` (its exact spoken
-                text). Paired with ``ref_audio`` for F5-TTS cloning.
+                text). Paired with ``ref_audio`` for F5-TTS cloning and to
+                anchor Qwen3-TTS Base cloning. Ignored by families that clone
+                reference-free.
 
         Returns:
             AudioOutput with audio data and metadata
@@ -349,6 +355,15 @@ class TTSEngine:
                 gen_kwargs["lang_code"] = "auto"
                 if instruct:
                     gen_kwargs["instruct"] = instruct
+                # Qwen3-TTS Base = zero-shot voice cloning: forward the
+                # reference clip (+ its transcript) when given. Base ignores
+                # ``voice`` while a ref is set; CustomVoice ignores
+                # ``ref_audio`` and keeps its named speaker — so forwarding
+                # only-when-set lets one family serve both variants.
+                if ref_audio:
+                    gen_kwargs["ref_audio"] = ref_audio
+                    if ref_text:
+                        gen_kwargs["ref_text"] = ref_text
             else:
                 gen_kwargs["lang_code"] = lang_code
 

--- a/vllm_mlx/model_sizes.json
+++ b/vllm_mlx/model_sizes.json
@@ -58,6 +58,7 @@
     "mlx-community/Qwen3-8B-8bit": 8719009971,
     "mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit": 17197080734,
     "mlx-community/Qwen3-Coder-Next-4bit": 44855905712,
+    "mlx-community/Qwen3-TTS-12Hz-1.7B-Base-bf16": 4544210194,
     "mlx-community/Qwen3-TTS-12Hz-1.7B-CustomVoice-4bit": 2312056829,
     "mlx-community/Qwen3-TTS-12Hz-1.7B-CustomVoice-6bit": 2696097845,
     "mlx-community/Qwen3-TTS-12Hz-1.7B-CustomVoice-bf16": 4520193026,

--- a/vllm_mlx/routes/audio.py
+++ b/vllm_mlx/routes/audio.py
@@ -1538,18 +1538,30 @@ def _is_clone_capable_model(model_name: str) -> bool:
       clone: it keeps a predefined named speaker and ignores
       ``ref_audio``.
 
-    Classify on the repo NAME (the last path component) split into
-    ``-``/``_`` tokens, never a whole-id substring, so an org segment
-    (``customvoice-org/...``) or an unrelated ``base`` elsewhere in the
-    path can't flip the verdict — mirrors the Base-reject guard's
-    tokenization inside :func:`create_speech`.
+    The verdict MUST stay in lock-step with
+    :meth:`vllm_mlx.audio.tts.TTSEngine._detect_family`: a model this
+    gate deems clone-capable while the engine classifies into a
+    non-cloning family would skip voice validation here yet drop
+    ``ref_audio`` in the engine — a silent 200 with the wrong (default)
+    voice. So the F5 check uses the SAME whole-id substring the engine
+    uses (``f5-tts``/``f5_tts``), NOT a broad ``f5`` token that would
+    catch an unrelated ``org/f5-foo`` the engine treats as Kokoro.
+
+    Qwen3-TTS Base is classified on the repo NAME (last path component)
+    split into ``-``/``_`` tokens — mirroring the Base-reject guard so
+    an org segment (``customvoice-org/...``) or an unrelated ``base``
+    elsewhere in the path can't flip the verdict. A repo name containing
+    ``qwen3-tts`` is necessarily a substring of the full id, so whenever
+    this returns True for Base the engine also detects ``qwen3_tts`` and
+    forwards the reference — the dangerous direction cannot occur.
     """
+    name_lower = model_name.lower()
+    if "f5-tts" in name_lower or "f5_tts" in name_lower:
+        return True
     repo = model_name.rsplit("/", 1)[-1].lower()
     tokens = set(re.split(r"[-_]", repo))
-    is_f5 = "f5-tts" in repo or "f5_tts" in repo or "f5" in tokens
     is_qwen3 = "qwen3-tts" in repo or "qwen3_tts" in repo
-    is_qwen3_base = is_qwen3 and "base" in tokens and "customvoice" not in tokens
-    return is_f5 or is_qwen3_base
+    return is_qwen3 and "base" in tokens and "customvoice" not in tokens
 
 
 @router.post("/v1/audio/speech", dependencies=[Depends(verify_api_key)])

--- a/vllm_mlx/routes/audio.py
+++ b/vllm_mlx/routes/audio.py
@@ -1526,6 +1526,32 @@ def _allowed_voices_for(model_name: str) -> list[str]:
     return ["default"]
 
 
+def _is_clone_capable_model(model_name: str) -> bool:
+    """Whether ``model_name`` can clone a voice from an inline reference.
+
+    Two TTS families condition synthesis on a ``ref_audio`` reference
+    clip sent on ``/v1/audio/speech``:
+
+    * **F5-TTS** — always conditions on a reference waveform.
+    * **Qwen3-TTS Base** — the ``...-Base-...`` repo clones a voice
+      zero-shot from the reference. Its CustomVoice sibling does NOT
+      clone: it keeps a predefined named speaker and ignores
+      ``ref_audio``.
+
+    Classify on the repo NAME (the last path component) split into
+    ``-``/``_`` tokens, never a whole-id substring, so an org segment
+    (``customvoice-org/...``) or an unrelated ``base`` elsewhere in the
+    path can't flip the verdict — mirrors the Base-reject guard's
+    tokenization inside :func:`create_speech`.
+    """
+    repo = model_name.rsplit("/", 1)[-1].lower()
+    tokens = set(re.split(r"[-_]", repo))
+    is_f5 = "f5-tts" in repo or "f5_tts" in repo or "f5" in tokens
+    is_qwen3 = "qwen3-tts" in repo or "qwen3_tts" in repo
+    is_qwen3_base = is_qwen3 and "base" in tokens and "customvoice" not in tokens
+    return is_f5 or is_qwen3_base
+
+
 @router.post("/v1/audio/speech", dependencies=[Depends(verify_api_key)])
 async def create_speech(request: AudioSpeechRequest = Body(...)):
     """Generate speech from text (OpenAI TTS API compatible).
@@ -1591,14 +1617,23 @@ async def create_speech(request: AudioSpeechRequest = Body(...)):
         # the future land in :data:`TTS_MODEL_ALIASES` once, not in the
         # handler body.
         model_name = _resolve_tts_model(model)
-        if ref_audio is not None and not (
-            "f5-tts" in model_name.lower() or "f5_tts" in model_name.lower()
-        ):
+
+        # Zero-shot cloning from an inline ``ref_audio`` reference clip is
+        # only wired for the clone-capable families (F5-TTS + Qwen3-TTS
+        # Base). A reference clip aimed at any other model is rejected up
+        # front so the caller gets an actionable 400 rather than the engine
+        # ignoring the clip and silently synthesizing a default voice.
+        clone_capable = _is_clone_capable_model(model_name)
+        inline_clone = ref_audio is not None and clone_capable
+        if ref_audio is not None and not clone_capable:
             raise HTTPException(
                 status_code=400,
                 detail={
                     "error": {
-                        "message": "ref_audio/ref_text voice cloning requires F5-TTS.",
+                        "message": (
+                            "ref_audio/ref_text voice cloning requires a "
+                            "clone-capable model (F5-TTS or Qwen3-TTS Base)."
+                        ),
                         "type": "invalid_request_error",
                         "code": "unsupported_voice_cloning",
                         "param": "model",
@@ -1607,33 +1642,42 @@ async def create_speech(request: AudioSpeechRequest = Body(...)):
             )
 
         # Qwen3-TTS ships two shapes: CustomVoice (predefined speakers,
-        # reference-free — what we alias and support) and Base (voice-
-        # cloning ONLY, requires a reference clip). A caller passing a raw
-        # ``...-Base-...`` repo id would otherwise reach the CustomVoice
-        # speaker-validation + generate path and fail deep in the engine
-        # ("Must provide one of ref_audio or ref_mel") as an opaque 500.
-        # Reject it up front with an actionable 400 pointing at CustomVoice.
-        # Classify on the REPO NAME (last path component), split into
-        # ``-``/``_``-delimited tokens, not a whole-id substring: an org like
-        # ``customvoice-org/...`` or an unrelated ``base`` elsewhere in the
-        # path must not flip the decision, and a ``base`` token must be
-        # caught wherever it sits (start/middle/end, hyphen or underscore
-        # delimited) — ``...-0.6B-Base``, ``..._base_bf16``, etc.
+        # reference-free) and Base (voice-cloning ONLY, requires a reference
+        # clip). A Base repo WITH an inline ``ref_audio`` is the correct
+        # clone target and is served below. A Base repo WITHOUT a reference
+        # cannot synthesize reference-free — it would otherwise reach the
+        # CustomVoice speaker-validation + generate path and fail deep in
+        # the engine ("Must provide one of ref_audio or ref_mel") as an
+        # opaque 500. Reject the reference-free case up front with an
+        # actionable 400 that points at both remedies (supply a reference,
+        # or use a CustomVoice repo). Classify on the REPO NAME (last path
+        # component), split into ``-``/``_``-delimited tokens, not a
+        # whole-id substring: an org like ``customvoice-org/...`` or an
+        # unrelated ``base`` elsewhere in the path must not flip the
+        # decision, and a ``base`` token must be caught wherever it sits
+        # (start/middle/end, hyphen or underscore delimited) —
+        # ``...-0.6B-Base``, ``..._base_bf16``, etc.
         _repo = model_name.rsplit("/", 1)[-1].lower()
         _tokens = set(re.split(r"[-_]", _repo))
         _is_qwen3 = "qwen3-tts" in _repo or "qwen3_tts" in _repo
-        if _is_qwen3 and "base" in _tokens and "customvoice" not in _tokens:
+        if (
+            _is_qwen3
+            and "base" in _tokens
+            and "customvoice" not in _tokens
+            and ref_audio is None
+        ):
             raise HTTPException(
                 status_code=400,
                 detail={
                     "error": {
                         "message": (
                             f"model {model_name!r} is a Qwen3-TTS Base "
-                            "(voice-cloning-only) repo and needs a reference "
-                            "audio clip, which /v1/audio/speech does not "
-                            "provide. Use a CustomVoice repo (e.g. the "
-                            "`qwen3-tts` alias) for reference-free synthesis "
-                            "with a predefined speaker."
+                            "(voice-cloning-only) repo: it cannot synthesize "
+                            "reference-free. Supply ref_audio (a clean 5-10s "
+                            "reference clip) plus ref_text (its transcript) to "
+                            "clone that voice, or use a CustomVoice repo (e.g. "
+                            "the `qwen3-tts` alias) for reference-free "
+                            "synthesis with a predefined speaker."
                         ),
                         "type": "invalid_request_error",
                         "code": "unsupported_model_variant",
@@ -1642,70 +1686,80 @@ async def create_speech(request: AudioSpeechRequest = Body(...)):
                 },
             )
 
-        # R11-B-F3 (Bo 0.8.12 dogfood, PR #863): translate the literal
-        # ``voice="default"`` to the registry's ``default_voice`` BEFORE
-        # the allowlist check below. Pre-fix the obvious naive caller
-        # value (``"default"``) was rejected by the kokoro allowlist
-        # even though the registry already advertises
-        # ``default_voice="af_heart"`` for it.
-        #
-        # R11-B-F1 (Bo 0.8.12 dogfood, this PR): the same resolver also
-        # fires when ``voice`` was OMITTED from the JSON body. The
-        # Pydantic model defaults ``voice`` to ``"af_heart"`` (kokoro's
-        # canonical voice) for OpenAI-SDK parity. That default is
-        # correct for kokoro but wrong for VibeVoice (no
-        # ``af_heart.safetensors``) and Chatterbox/VoxCPM/Dia (expect
-        # ``"default"``). The omitted-voice shape arrives here as
-        # ``voice="af_heart"`` and 400'd against every non-kokoro
-        # family. Treat the omitted-voice case the same way as the
-        # literal ``"default"`` sentinel — both resolve to the registry
-        # default. A client that EXPLICITLY sends ``voice="af_heart"``
-        # against vibevoice keeps that value (the validator then
-        # surfaces the 400 with the real available list).
-        voice_omitted = "voice" not in request.model_fields_set
-        if voice_omitted:
-            voice = "default"
-        voice = _resolve_default_voice_literal(model_name, voice)
+        # Voice selection + the speaker allowlist govern reference-free
+        # (named-speaker) synthesis only. An inline-clone request is driven
+        # by the reference clip, not a named speaker: a clone-capable Base
+        # repo advertises the ``"clone"`` sentinel as its registry
+        # ``default_voice`` (absent from the speaker allowlist), and F5
+        # conditions on the waveform too — so running the allowlist here
+        # would 400 the very request we intend to serve. Skip voice
+        # resolution + validation entirely for a clone and OMIT ``voice``
+        # from the generate call below — the timbre comes from ``ref_audio``.
+        if not inline_clone:
+            # R11-B-F3 (Bo 0.8.12 dogfood, PR #863): translate the literal
+            # ``voice="default"`` to the registry's ``default_voice`` BEFORE
+            # the allowlist check below. Pre-fix the obvious naive caller
+            # value (``"default"``) was rejected by the kokoro allowlist
+            # even though the registry already advertises
+            # ``default_voice="af_heart"`` for it.
+            #
+            # R11-B-F1 (Bo 0.8.12 dogfood, this PR): the same resolver also
+            # fires when ``voice`` was OMITTED from the JSON body. The
+            # Pydantic model defaults ``voice`` to ``"af_heart"`` (kokoro's
+            # canonical voice) for OpenAI-SDK parity. That default is
+            # correct for kokoro but wrong for VibeVoice (no
+            # ``af_heart.safetensors``) and Chatterbox/VoxCPM/Dia (expect
+            # ``"default"``). The omitted-voice shape arrives here as
+            # ``voice="af_heart"`` and 400'd against every non-kokoro
+            # family. Treat the omitted-voice case the same way as the
+            # literal ``"default"`` sentinel — both resolve to the registry
+            # default. A client that EXPLICITLY sends ``voice="af_heart"``
+            # against vibevoice keeps that value (the validator then
+            # surfaces the 400 with the real available list).
+            voice_omitted = "voice" not in request.model_fields_set
+            if voice_omitted:
+                voice = "default"
+            voice = _resolve_default_voice_literal(model_name, voice)
 
-        # R8-M4 (Bo 0.8.9 dogfood): validate ``voice`` against the
-        # model's known voice set BEFORE we load weights. Pre-fix an
-        # unknown name (drop-in OpenAI SDK code sending ``alloy`` /
-        # ``nova`` / typo'd ``af_hart``) fell through to
-        # ``mlx_audio.load_safetensors`` which 500'd on the missing
-        # ``voices/<name>.safetensors`` file. The 500 envelope hid the
-        # actual cause from the operator log AND from the caller. The
-        # check fires post-resolution so a HF passthrough id (``mlx-
-        # community/Kokoro-82M-bf16``) honours the same voice set as
-        # the ``kokoro`` short alias — both go through the same model
-        # family check.
-        valid_voices = _allowed_voices_for(model_name)
-        # Qwen3-TTS matches speaker names case-INsensitively (its engine
-        # lowercases before the ``spk_id`` lookup) and the upstream docs mix
-        # case ("serena" vs "Serena"). Normalize a case-insensitive hit to
-        # the canonical spelling so ``serena`` / ``ono_anna`` aren't
-        # rejected as ``invalid_voice``; the engine then receives the
-        # canonical form. Other families keep exact-match validation.
-        if "qwen3-tts" in model_name.lower() or "qwen3_tts" in model_name.lower():
-            _canonical = {v.lower(): v for v in valid_voices}
-            voice = _canonical.get(voice.lower(), voice)
-        if voice not in valid_voices:
-            preview = ", ".join(valid_voices[:8])
-            if len(valid_voices) > 8:
-                preview = f"{preview}, ..."
-            raise HTTPException(
-                status_code=400,
-                detail={
-                    "error": {
-                        "message": (
-                            f"voice {voice!r} not recognized for model "
-                            f"{model_name!r}. Available: {preview}."
-                        ),
-                        "type": "invalid_request_error",
-                        "code": "invalid_voice",
-                        "param": "voice",
-                    }
-                },
-            )
+            # R8-M4 (Bo 0.8.9 dogfood): validate ``voice`` against the
+            # model's known voice set BEFORE we load weights. Pre-fix an
+            # unknown name (drop-in OpenAI SDK code sending ``alloy`` /
+            # ``nova`` / typo'd ``af_hart``) fell through to
+            # ``mlx_audio.load_safetensors`` which 500'd on the missing
+            # ``voices/<name>.safetensors`` file. The 500 envelope hid the
+            # actual cause from the operator log AND from the caller. The
+            # check fires post-resolution so a HF passthrough id (``mlx-
+            # community/Kokoro-82M-bf16``) honours the same voice set as
+            # the ``kokoro`` short alias — both go through the same model
+            # family check.
+            valid_voices = _allowed_voices_for(model_name)
+            # Qwen3-TTS matches speaker names case-INsensitively (its engine
+            # lowercases before the ``spk_id`` lookup) and the upstream docs
+            # mix case ("serena" vs "Serena"). Normalize a case-insensitive
+            # hit to the canonical spelling so ``serena`` / ``ono_anna``
+            # aren't rejected as ``invalid_voice``; the engine then receives
+            # the canonical form. Other families keep exact-match validation.
+            if "qwen3-tts" in model_name.lower() or "qwen3_tts" in model_name.lower():
+                _canonical = {v.lower(): v for v in valid_voices}
+                voice = _canonical.get(voice.lower(), voice)
+            if voice not in valid_voices:
+                preview = ", ".join(valid_voices[:8])
+                if len(valid_voices) > 8:
+                    preview = f"{preview}, ..."
+                raise HTTPException(
+                    status_code=400,
+                    detail={
+                        "error": {
+                            "message": (
+                                f"voice {voice!r} not recognized for model "
+                                f"{model_name!r}. Available: {preview}."
+                            ),
+                            "type": "invalid_request_error",
+                            "code": "invalid_voice",
+                            "param": "voice",
+                        }
+                    },
+                )
 
         # F-K-KOKORO-MISAKI: Kokoro pulls ``misaki`` lazily inside
         # ``KokoroPipeline``; the TTS-lane probe above can't catch
@@ -1726,7 +1780,14 @@ async def create_speech(request: AudioSpeechRequest = Body(...)):
         # the real engine, but omitting the kwarg entirely keeps the call
         # shape backward-compatible with any generate() that predates the
         # emotion parameter (only Qwen3-TTS consumes it).
-        gen_kwargs = {"voice": voice, "speed": speed}
+        #
+        # OMIT ``voice`` for an inline clone — the reference clip selects
+        # the timbre and the Base model ignores ``voice`` when a reference
+        # is set (F5 has no named-speaker surface at all). Forwarding the
+        # ``"clone"`` sentinel or a stray named speaker would be meaningless
+        # and, for a strict engine, could raise. Reference-free synthesis
+        # keeps the resolved named speaker.
+        gen_kwargs = {"speed": speed} if inline_clone else {"voice": voice, "speed": speed}
         if instructions:
             gen_kwargs["instruct"] = instructions
         if ref_audio is not None:

--- a/vllm_mlx/routes/audio.py
+++ b/vllm_mlx/routes/audio.py
@@ -1799,7 +1799,9 @@ async def create_speech(request: AudioSpeechRequest = Body(...)):
         # ``"clone"`` sentinel or a stray named speaker would be meaningless
         # and, for a strict engine, could raise. Reference-free synthesis
         # keeps the resolved named speaker.
-        gen_kwargs = {"speed": speed} if inline_clone else {"voice": voice, "speed": speed}
+        gen_kwargs = (
+            {"speed": speed} if inline_clone else {"voice": voice, "speed": speed}
+        )
         if instructions:
             gen_kwargs["instruct"] = instructions
         if ref_audio is not None:


### PR DESCRIPTION
## Why (necessity)

A content channel wants ONE consistent, branded Chinese narrator voice reused across every episode. The already-wired Qwen3-TTS **CustomVoice** variant only offers a fixed roster of named speakers (+ emotion) and cannot clone. The Qwen3-TTS **Base** variant does zero-shot Chinese/multilingual voice cloning from a short reference clip — record the narrator once, then generate unlimited episodes in that exact voice. This fills the Chinese expressive/cloneable-TTS gap on MLX (Chatterbox is English-only) and needs no dependency upgrade — the cloning surface is already present in the pinned `mlx-audio` range (`>=0.2.9,<0.4.4`; verified on 0.4.3).

## What

**Engine** (`vllm_mlx/audio/tts.py`, from the original POC): the `qwen3_tts` branch of `generate()` forwards `ref_audio` (+ `ref_text`) to the model **only when set**. Base ignores `voice` while a ref is set; CustomVoice ignores `ref_audio` and keeps its named speaker — so one family branch serves both variants without cross-contaminating the call surface. The params already exist on the signature (from the F5-TTS PR #1297); this reuses them and refreshes their docstrings.

**Route** (`vllm_mlx/routes/audio.py`, added to make the clone reachable end-to-end): on `main`, `create_speech` (a) rejected any `ref_audio` aimed at a non-F5 model and (b) rejected every Qwen3-TTS Base repo unconditionally — both fired before the clone path could run, so a `qwen3-tts-clone` request always 400'd. Now:
- New `_is_clone_capable_model()` — F5-TTS + Qwen3-TTS Base are clone-capable. It stays in lock-step with `TTSEngine._detect_family` (same `f5-tts`/`f5_tts` whole-id substring; Base classified on repo-name tokens) so the gate can never say "clone-capable" while the engine silently drops the reference.
- Allow an inline `ref_audio` for any clone-capable model (was F5-only).
- Reject a Qwen3-TTS Base repo **only when no reference is supplied** (Base cannot synthesize reference-free); a Base repo **with** a reference is the correct clone target and is served. Message refreshed (the route now DOES accept `ref_audio`).
- For an inline clone, **skip the named-speaker allowlist and omit `voice`** from the generate call — the Base repo's `default_voice` is the `"clone"` sentinel, which is not in the speaker allowlist, so the allowlist would otherwise 400 the request.

**Registry / manifest**
- `aliases.json`: new `qwen3-tts-clone` → `mlx-community/Qwen3-TTS-12Hz-1.7B-Base-bf16` (family `qwen3_tts`, `default_voice: "clone"`). Distinct from `qwen3-tts-customvoice` (named speakers + `instruct` emotion, no cloning).
- `model_sizes.json`: manifest entry for the Base-bf16 repo, `4544210194` bytes — the exact output of the repo's own `estimate_repo_size_bytes` (not a placeholder), keeping `test_every_audio_alias_has_a_manifest_entry` green.

## Test Plan

Hermetic (no weights, no network — the `TTSEngine` and `mlx_audio` probe are stubbed):
- `tests/test_qwen3_tts_clone.py` (engine): conditional `ref_audio`/`ref_text` forwarding — forwarded only when set, omitted otherwise, alias points at the Base repo, Base repo detected as the `qwen3_tts` family.
- `tests/test_speech_inline_clone_route.py` (full HTTP path via `POST /v1/audio/speech`): inline clone omits `voice` and forwards the reference; an explicit `voice` is dropped on a clone; reference-free Base 400s `unsupported_model_variant` with an actionable message and constructs no engine; CustomVoice + `ref_audio` 400s `unsupported_voice_cloning`; F5 clone parity; a `_is_clone_capable_model` classifier table incl. the `org/f5-foo` gate↔engine-family regression.

Gates run locally: `dev_test.py lint` (ruff check + format --check) PASS; targeted audio suites PASS; unit gate PASS (pre-existing branding check tied to a gitignored `docs/plans/in-source-roadmap.md` is unrelated); Codex adversarial review converged to CLEAN (0 BLOCKING / 0 MAJOR). No `pyproject.toml`/version change.

## AI-assisted

This change was drafted and refined with AI assistance (Claude) and reviewed by a human before merge.
