### PR TITLE
feat(audio): add MLX-native SenseVoice STT

### DIFF
--- a/tests/test_audio_boot_check.py
+++ b/tests/test_audio_boot_check.py
@@ -39,11 +39,14 @@ def test_is_audio_model_alias_recognises_common_aliases() -> None:
         "whisper-small",
         "parakeet",
         "parakeet-v3",
+        "sensevoice",
+        "sensevoice-small",
         # HF-style ids — capitalisation must not matter.
         "mlx-community/Kokoro-82M-bf16",
         "mlx-community/Kokoro-82M-4bit",
         "mlx-community/whisper-large-v3-mlx",
         "mlx-community/parakeet-tdt-0.6b-v2",
+        "mlx-community/SenseVoiceSmall",
     ]
     for name in audio_positive:
         assert is_audio_model_alias(name), name

--- a/tests/test_audio_r11_b_bundle.py
+++ b/tests/test_audio_r11_b_bundle.py
@@ -562,6 +562,7 @@ _AUDIO_ALIASES_FOR_CAP_CHECK = [
     ("whisper", "mlx-community/whisper-large-v3-mlx", "audio.transcription"),
     ("whisper-large-v3", "mlx-community/whisper-large-v3-mlx", "audio.transcription"),
     ("parakeet", "mlx-community/parakeet-tdt-0.6b-v2", "audio.transcription"),
+    ("sensevoice", "mlx-community/SenseVoiceSmall", "audio.transcription"),
 ]
 
 

--- a/tests/test_sensevoice_stt.py
+++ b/tests/test_sensevoice_stt.py
@@ -1,0 +1,96 @@
+# SPDX-License-Identifier: Apache-2.0
+"""SenseVoice STT adapter and OpenAI-route contracts."""
+
+from __future__ import annotations
+
+import types
+
+import pytest
+from fastapi import HTTPException
+
+from vllm_mlx.audio.registry import resolve_audio_alias, stt_aliases
+from vllm_mlx.audio.stt import STTEngine
+from vllm_mlx.routes.audio import (
+    _reject_non_whisper_for_translation,
+    _resolve_stt_model,
+)
+
+
+class _SenseVoiceModel:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict]] = []
+
+    def generate(self, audio: str, **kwargs):
+        self.calls.append((audio, kwargs))
+        return types.SimpleNamespace(
+            text=" 你好，世界 ",
+            language="zh",
+            segments=[
+                {
+                    "text": "你好，世界",
+                    "language": "zh",
+                    "emotion": "neutral",
+                    "event": "Speech",
+                }
+            ],
+        )
+
+
+@pytest.mark.parametrize("alias", ["sensevoice", "sensevoice-small"])
+def test_sensevoice_alias_contract(alias: str) -> None:
+    entry = resolve_audio_alias(alias)
+    assert entry is not None
+    assert entry.type == "stt"
+    assert entry.family == "sensevoice"
+    assert entry.hf_id == "mlx-community/SenseVoiceSmall"
+    assert stt_aliases()[alias] == entry.hf_id
+    assert _resolve_stt_model(alias) == entry.hf_id
+
+
+def test_sensevoice_transcribe_uses_native_generate_contract() -> None:
+    model = _SenseVoiceModel()
+    engine = STTEngine("mlx-community/SenseVoiceSmall")
+    engine.model = model
+    engine._loaded = True
+
+    result = engine.transcribe("speech.wav", language="ZH")
+
+    assert model.calls == [("speech.wav", {"verbose": False, "language": "zh"})]
+    assert result.text == "你好，世界"
+    assert result.language == "zh"
+    assert result.duration is None
+    assert result.segments == [
+        {
+            "text": "你好，世界",
+            "language": "zh",
+            "emotion": "neutral",
+            "event": "Speech",
+        }
+    ]
+
+
+def test_sensevoice_unknown_language_degrades_to_auto() -> None:
+    model = _SenseVoiceModel()
+    engine = STTEngine("mlx-community/SenseVoiceSmall")
+    engine.model = model
+    engine._loaded = True
+
+    engine.transcribe("speech.wav", language="es")
+
+    assert model.calls[0][1] == {"verbose": False, "language": "auto"}
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "sensevoice",
+        "sensevoice-small",
+        "mlx-community/SenseVoiceSmall",
+    ],
+)
+def test_translations_reject_sensevoice_before_inference(model: str) -> None:
+    with pytest.raises(HTTPException) as exc_info:
+        _reject_non_whisper_for_translation(model)
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail["error"]["code"] == "invalid_model_for_translation"

--- a/tests/test_sensevoice_stt.py
+++ b/tests/test_sensevoice_stt.py
@@ -80,6 +80,28 @@ def test_sensevoice_unknown_language_degrades_to_auto() -> None:
     assert model.calls[0][1] == {"verbose": False, "language": "auto"}
 
 
+def test_sensevoice_direct_translation_fails_instead_of_silently_transcribing() -> None:
+    engine = STTEngine("mlx-community/SenseVoiceSmall")
+    engine.model = _SenseVoiceModel()
+    engine._loaded = True
+
+    with pytest.raises(ValueError, match="Whisper"):
+        engine.transcribe("speech.wav", task="translate")
+
+
+def test_sensevoice_backend_detection_uses_loaded_model_metadata(monkeypatch) -> None:
+    model = _SenseVoiceModel()
+    model.config = types.SimpleNamespace(model_type="sensevoice")
+    monkeypatch.setattr("mlx_audio.stt.utils.load_model", lambda _name: model)
+
+    engine = STTEngine("acme/private-asr")
+    engine.load()
+    engine.transcribe("speech.wav", language="zh")
+
+    assert engine._is_sensevoice is True
+    assert model.calls == [("speech.wav", {"verbose": False, "language": "zh"})]
+
+
 @pytest.mark.parametrize(
     "model",
     [

--- a/tests/test_sensevoice_stt.py
+++ b/tests/test_sensevoice_stt.py
@@ -102,6 +102,17 @@ def test_sensevoice_backend_detection_uses_loaded_model_metadata(monkeypatch) ->
     assert model.calls == [("speech.wav", {"verbose": False, "language": "zh"})]
 
 
+def test_loaded_model_metadata_overrides_false_positive_name(monkeypatch) -> None:
+    model = _SenseVoiceModel()
+    model.config = types.SimpleNamespace(model_type="whisper")
+    monkeypatch.setattr("mlx_audio.stt.utils.load_model", lambda _name: model)
+
+    engine = STTEngine("acme/not-really-sensevoice")
+    engine.load()
+
+    assert engine._is_sensevoice is False
+
+
 @pytest.mark.parametrize(
     "model",
     [

--- a/vllm_mlx/audio/aliases.json
+++ b/vllm_mlx/audio/aliases.json
@@ -246,5 +246,19 @@
     "family": "parakeet",
     "languages": "en",
     "notes": "Parakeet TDT 0.6B v3."
+  },
+  "sensevoice": {
+    "type": "stt",
+    "hf_id": "mlx-community/SenseVoiceSmall",
+    "family": "sensevoice",
+    "languages": "zh,yue,ja,ko,en",
+    "notes": "FunAudioLLM SenseVoice Small (~234M, non-autoregressive CTC). Dedicated fast Asian-language ASR (strong on Chinese/Cantonese/Japanese/Korean). Also emits per-segment emotion + audio-event tags. Bare ``sensevoice`` -> the small model."
+  },
+  "sensevoice-small": {
+    "type": "stt",
+    "hf_id": "mlx-community/SenseVoiceSmall",
+    "family": "sensevoice",
+    "languages": "zh,yue,ja,ko,en",
+    "notes": "Explicit long-form alias for ``sensevoice`` — same HF id."
   }
 }

--- a/vllm_mlx/audio/stt.py
+++ b/vllm_mlx/audio/stt.py
@@ -24,10 +24,10 @@ DEFAULT_PARAKEET_MODEL = "mlx-community/parakeet-tdt-0.6b-v2"
 DEFAULT_SENSEVOICE_MODEL = "mlx-community/SenseVoiceSmall"
 
 # SenseVoice accepts a keyword-only language hint restricted to this set;
-# anything else maps to "auto" (language-id) inside mlx_audio, so callers
-# passing a Whisper-style code (e.g. "es") degrade gracefully to detection.
+# anything else maps to "auto" so callers passing a Whisper-style code
+# (e.g. "es") degrade gracefully to language detection.
 # See mlx_audio/stt/models/sensevoice/README.md.
-_SENSEVOICE_LANGUAGES = ("auto", "zh", "en", "ja", "ko", "yue", "nospeech")
+_SENSEVOICE_LANGUAGES = frozenset({"auto", "zh", "en", "ja", "ko", "yue", "nospeech"})
 
 # ---------------------------------------------------------------------------
 # F-K-WHISPER-961: VAD pre-trim guard (see #961)
@@ -460,7 +460,7 @@ def _shift_segment_time(seg: Any, offset: float) -> None:
 
 class STTEngine:
     """
-    Speech-to-Text engine supporting Whisper and Parakeet models.
+    Speech-to-Text engine supporting Whisper, Parakeet, and SenseVoice models.
 
     Usage:
         engine = STTEngine("mlx-community/whisper-large-v3-mlx")
@@ -702,9 +702,13 @@ class STTEngine:
             if self._is_sensevoice:
                 # SenseVoice: keyword-only ``language`` (default auto-detect),
                 # no translation ``task``. A caller-supplied code outside
-                # ``_SENSEVOICE_LANGUAGES`` still maps to auto upstream, so we
-                # forward it verbatim rather than second-guessing here.
-                kwargs["language"] = language or "auto"
+                # ``_SENSEVOICE_LANGUAGES`` maps to auto-detection. Normalize
+                # here as part of our adapter contract rather than depending
+                # on mlx_audio's current unknown-key fallback.
+                language_hint = (language or "auto").lower()
+                kwargs["language"] = (
+                    language_hint if language_hint in _SENSEVOICE_LANGUAGES else "auto"
+                )
             elif not self._is_parakeet:
                 if language:
                     kwargs["language"] = language

--- a/vllm_mlx/audio/stt.py
+++ b/vllm_mlx/audio/stt.py
@@ -542,8 +542,8 @@ class STTEngine:
             # SenseVoice repos still receive the native generate() contract.
             # The constructor's name check remains a useful pre-load fallback.
             model_type = getattr(getattr(self.model, "config", None), "model_type", "")
-            if isinstance(model_type, str) and model_type.lower() == "sensevoice":
-                self._is_sensevoice = True
+            if isinstance(model_type, str) and model_type:
+                self._is_sensevoice = model_type.lower() == "sensevoice"
             # F-K-WHISPER-500: patch up the missing WhisperProcessor
             # mlx-community Whisper repos don't ship. Runs AFTER
             # mlx_audio's own post_load_hook, so if that succeeded

--- a/vllm_mlx/audio/stt.py
+++ b/vllm_mlx/audio/stt.py
@@ -538,6 +538,12 @@ class STTEngine:
             from mlx_audio.stt.utils import load_model
 
             self.model = load_model(self.model_name)
+            # Prefer the backend metadata after loading so renamed/private
+            # SenseVoice repos still receive the native generate() contract.
+            # The constructor's name check remains a useful pre-load fallback.
+            model_type = getattr(getattr(self.model, "config", None), "model_type", "")
+            if isinstance(model_type, str) and model_type.lower() == "sensevoice":
+                self._is_sensevoice = True
             # F-K-WHISPER-500: patch up the missing WhisperProcessor
             # mlx-community Whisper repos don't ship. Runs AFTER
             # mlx_audio's own post_load_hook, so if that succeeded
@@ -674,6 +680,12 @@ class STTEngine:
             self.load()
 
         audio_path = str(audio_path)
+
+        if self._is_sensevoice and task != "transcribe":
+            raise ValueError(
+                "SenseVoice supports transcription only; use a Whisper model "
+                "for task='translate'."
+            )
 
         # F-K-WHISPER-961: VAD pre-trim guard. Runs only for Whisper
         # engines with the guard enabled — see class docstring + the

--- a/vllm_mlx/audio/stt.py
+++ b/vllm_mlx/audio/stt.py
@@ -5,6 +5,8 @@ Speech-to-Text (STT) engine using mlx-audio.
 Supports:
 - Whisper (multilingual, 99+ languages)
 - Parakeet (English-focused, fast)
+- SenseVoice (FunAudioLLM; Chinese/Cantonese/Japanese/Korean/English, very
+  fast non-autoregressive CTC — a dedicated Asian-language ASR option)
 """
 
 import logging
@@ -19,6 +21,13 @@ logger = logging.getLogger(__name__)
 # Default models
 DEFAULT_WHISPER_MODEL = "mlx-community/whisper-large-v3-mlx"
 DEFAULT_PARAKEET_MODEL = "mlx-community/parakeet-tdt-0.6b-v2"
+DEFAULT_SENSEVOICE_MODEL = "mlx-community/SenseVoiceSmall"
+
+# SenseVoice accepts a keyword-only language hint restricted to this set;
+# anything else maps to "auto" (language-id) inside mlx_audio, so callers
+# passing a Whisper-style code (e.g. "es") degrade gracefully to detection.
+# See mlx_audio/stt/models/sensevoice/README.md.
+_SENSEVOICE_LANGUAGES = ("auto", "zh", "en", "ja", "ko", "yue", "nospeech")
 
 # ---------------------------------------------------------------------------
 # F-K-WHISPER-961: VAD pre-trim guard (see #961)
@@ -476,6 +485,7 @@ class STTEngine:
                 - mlx-community/whisper-small-mlx
                 - mlx-community/parakeet-tdt-0.6b-v2 (English, fastest)
                 - mlx-community/parakeet-tdt-0.6b-v3
+                - mlx-community/SenseVoiceSmall (zh/yue/ja/ko/en, fast CTC)
             enable_vad_pretrim: If ``True`` (default) and the engine
                 is Whisper-shaped, run Silero VAD before Whisper. Pure-
                 silence clips return ``text=""`` (guards #961), and
@@ -504,6 +514,15 @@ class STTEngine:
         # a dedicated ``align()`` method — ``transcribe()`` is not valid on
         # them (there is no text to discover).
         self._is_aligner = "aligner" in model_name.lower()
+        # SenseVoice (FunAudioLLM) is a non-autoregressive CTC ASR model
+        # with a different generate() contract than Whisper: keyword-only
+        # ``language`` (from ``_SENSEVOICE_LANGUAGES``, default "auto"),
+        # no translation ``task``, and it emits rich per-segment metadata
+        # (emotion / audio-event). Detected by name so ``transcribe``
+        # forwards the right kwargs. The mlx-community/SenseVoiceSmall
+        # repo carries model_type=sensevoice, which mlx_audio's
+        # ``load_model`` dispatches through MODEL_REMAPPING["sensevoice"].
+        self._is_sensevoice = "sensevoice" in model_name.lower()
         # F-K-WHISPER-961: VAD pre-trim guard. See top-of-file block
         # for the full rationale. Only applied to Whisper engines —
         # Parakeet/Canary/etc. have their own silence semantics and
@@ -680,10 +699,17 @@ class STTEngine:
         try:
             # Use the model's generate method directly
             kwargs = {"verbose": False}
-            if language and not self._is_parakeet:
-                kwargs["language"] = language
-            if task and not self._is_parakeet:
-                kwargs["task"] = task
+            if self._is_sensevoice:
+                # SenseVoice: keyword-only ``language`` (default auto-detect),
+                # no translation ``task``. A caller-supplied code outside
+                # ``_SENSEVOICE_LANGUAGES`` still maps to auto upstream, so we
+                # forward it verbatim rather than second-guessing here.
+                kwargs["language"] = language or "auto"
+            elif not self._is_parakeet:
+                if language:
+                    kwargs["language"] = language
+                if task:
+                    kwargs["task"] = task
 
             # Choose the input Whisper actually sees: either the
             # VAD-trimmed waveform (mono 16 kHz) or the original file

--- a/vllm_mlx/model_sizes.json
+++ b/vllm_mlx/model_sizes.json
@@ -92,6 +92,7 @@
     "mlx-community/Qwen3.6-35B-A3B-OptiQ-4bit": 24693941582,
     "mlx-community/Qwen3.6-35B-A3B-mxfp4": 19346602441,
     "mlx-community/Qwen3.6-35B-A3B-nvfp4": 20429052421,
+    "mlx-community/SenseVoiceSmall": 936491235,
     "mlx-community/SmolLM3-3B-4bit": 1747372864,
     "mlx-community/Tmax-27B-MLX-4bit": 15153227907,
     "mlx-community/Tmax-27B-MLX-6bit": 21876566243,


### PR DESCRIPTION
## Why

Rapid-MLX has multilingual Whisper and English-focused Parakeet, but no purpose-built fast Chinese / Asian-language ASR option. SenseVoice Small adds a native MLX path for Chinese, Cantonese, Japanese, Korean, and English without adding a new dependency.

## What

- Add `sensevoice` and `sensevoice-small` aliases for `mlx-community/SenseVoiceSmall`.
- Adapt `STTEngine` to SenseVoice's native `generate(audio, language=..., verbose=False)` contract.
- Detect renamed/private SenseVoice repositories from loaded `model.config.model_type`, with repository-name fallback.
- Normalize unsupported language hints to auto-detection.
- Reject unsupported `task="translate"` explicitly; the OpenAI translations endpoint remains Whisper-only.
- Add the verified model-size manifest entry and focused alias, CLI, model-capability, engine, and translation-contract tests.

No version bump and no dependency changes.

## User experience

Existing Whisper and Parakeet behavior is unchanged. Users can select `sensevoice` through the existing OpenAI-compatible `/v1/audio/transcriptions` route or use `STTEngine` directly. SenseVoice returns source-language text plus detected language; its engine-level segments retain emotion and audio-event metadata. As upstream SenseVoice emits no timestamps, duration remains `null`, consistent with the existing backend-neutral response contract.

## Validation

- Built `rapid_mlx-0.11.1-py3-none-any.whl`.
- Installed that wheel with `[audio]` into a clean Python 3.12 venv.
- Loaded real `mlx-community/SenseVoiceSmall` weights from the installed wheel.
- Transcribed a generated 16 kHz mono Mandarin clip successfully:
  - text: `你好欢迎使用 rapid m l x 语音识别`
  - language: `zh`
  - metadata: `emotion=neutral`, `event=Speech`
  - cached load: 2.42 s; inference: 0.75 s
- Focused audio regression suite: 199 passed.
- Full unit suite: 14,457 passed, 67 skipped, 18 deselected, 6 xfailed, 1 xpassed.
- Final adversarial Codex review: no blocking issues.
- `scripts.pr_validate`: **MERGE-SAFE**.

## AI-assisted disclosure

Implemented and reviewed with AI assistance; verified with real weights, a clean-wheel install, regression tests, and the repository merge-readiness pipeline.