### PR TITLE
fix(audio): harden Kokoro espeak probe against 500s + candidate crowd-out [skip-version-bump]

### DIFF
--- a/tests/test_kokoro_espeak_repair.py
+++ b/tests/test_kokoro_espeak_repair.py
@@ -348,3 +348,64 @@ def test_discovery_tries_every_distinct_library_before_data_variants(monkeypatch
     # The first len(libs) pairs cover every distinct library.
     first_round_libs = {lib for lib, _ in pairs[:2]}
     assert first_round_libs == {lib_a, lib_b}
+
+
+def test_sweep_tries_all_discovered_candidates_no_pair_slice(monkeypatch):
+    """The sweep self-tests every discovered pair — no pair-level cap slice.
+
+    Guards against re-introducing a ``[:_MAX_ESPEAK_CANDIDATES]`` slice over
+    the pair list: with the cap pinned to 1 and the ONLY working library
+    sitting second in discovery, a pair slice would stop at the first
+    (broken) candidate and 503 a host that actually has a usable espeak-ng.
+    The bound now lives in discovery (distinct libraries), so the sweep must
+    iterate the whole returned product.
+    """
+    applied: list = []
+    good = "/usr/local/lib/libespeak-ng.1.dylib"
+
+    monkeypatch.setattr(probe, "_MAX_ESPEAK_CANDIDATES", 1)
+    monkeypatch.setattr(
+        probe,
+        "_espeak_selftest_subprocess",
+        lambda lib=None, data=None, timeout=30.0: lib == good,  # bundled + bad fail
+    )
+    monkeypatch.setattr(
+        probe,
+        "_discover_system_espeak",
+        lambda: [("/opt/homebrew/lib/libespeak-ng.1.dylib", "/d"), (good, "/d")],
+    )
+    monkeypatch.setattr(
+        probe, "_apply_system_espeak", lambda lib, data: applied.append((lib, data))
+    )
+
+    probe._ensure_kokoro_g2p_ready()  # must not raise
+    assert probe._ESPEAK_READY is True
+    assert applied == [(good, "/d")]  # reached the 2nd candidate despite cap=1
+
+
+def test_discovery_caps_number_of_distinct_libraries(monkeypatch):
+    """Discovery bounds DISTINCT libraries to _MAX_ESPEAK_CANDIDATES.
+
+    Three libraries exist across prefixes but the cap is 2 → the third is
+    dropped, so the sweep can never spin through an unbounded set of installs.
+    """
+    import ctypes.util
+    import os
+    import shutil
+
+    monkeypatch.setattr(probe, "_MAX_ESPEAK_CANDIDATES", 2)
+    monkeypatch.setattr(shutil, "which", lambda name: None)
+    monkeypatch.setattr(ctypes.util, "find_library", lambda name: None)
+
+    lib_files = {
+        "/opt/homebrew/lib/libespeak-ng.1.dylib",
+        "/usr/local/lib/libespeak-ng.1.dylib",
+        "/usr/lib/libespeak-ng.1.dylib",
+    }
+    phontab = "/opt/homebrew/share/espeak-ng-data/phontab"
+    monkeypatch.setattr(os.path, "exists", lambda p: p in lib_files or p == phontab)
+
+    pairs = probe._discover_system_espeak()
+    distinct_libs = {lib for lib, _ in pairs}
+    assert len(distinct_libs) == 2  # capped from 3 discovered
+    assert "/usr/lib/libespeak-ng.1.dylib" not in distinct_libs  # best-first kept

--- a/tests/test_kokoro_espeak_repair.py
+++ b/tests/test_kokoro_espeak_repair.py
@@ -282,3 +282,69 @@ def test_discover_system_espeak_finds_real_install():
     for lib, data in pairs:
         assert os.path.exists(lib), lib
         assert os.path.exists(os.path.join(data, "espeak-ng-data", "phontab")), data
+
+
+def test_unexpected_probe_exception_is_contained_as_503(monkeypatch):
+    """Discovery/repair blowing up → cached clean 503, not an escaping 500.
+
+    A torn install can make ``_discover_system_espeak`` (filesystem walks)
+    or ``_apply_system_espeak`` (``import misaki.espeak``) raise. That must
+    degrade to the same 503 as "no working espeak" AND cache the verdict,
+    or every request re-probes and re-spawns subprocesses.
+    """
+    discover_calls = {"n": 0}
+
+    def _boom():
+        discover_calls["n"] += 1
+        raise RuntimeError("filesystem exploded mid-probe")
+
+    monkeypatch.setattr(probe, "_espeak_selftest_subprocess", lambda *a, **k: False)
+    monkeypatch.setattr(probe, "_discover_system_espeak", _boom)
+
+    with pytest.raises(HTTPException) as exc:
+        probe._ensure_kokoro_g2p_ready()
+    assert exc.value.status_code == 503  # not a bare RuntimeError → 500
+    assert "espeak-ng" in str(exc.value.detail)
+    assert probe._ESPEAK_READY is False
+
+    # Cached: the second request must not re-run the (throwing) probe.
+    with pytest.raises(HTTPException):
+        probe._ensure_kokoro_g2p_ready()
+    assert discover_calls["n"] == 1
+
+
+def test_discovery_tries_every_distinct_library_before_data_variants(monkeypatch):
+    """Cross-product is data-major so the cap can't crowd out a real install.
+
+    Two libraries in two prefixes, each prefix carrying its own data dir.
+    A library-major product would emit both of lib-A's data variants before
+    lib-B is ever paired, so a small self-test cap could exhaust its budget
+    on lib-A and never reach a valid lib-B. Data-major must place every
+    distinct library within the first ``len(libs)`` pairs.
+    """
+    import ctypes.util
+    import os
+    import shutil
+
+    lib_a = "/opt/homebrew/lib/libespeak-ng.1.dylib"
+    lib_b = "/usr/local/lib/libespeak-ng.1.dylib"
+    phontab_a = "/opt/homebrew/share/espeak-ng-data/phontab"
+    phontab_b = "/usr/local/share/espeak-ng-data/phontab"
+    present = {lib_a, lib_b, phontab_a, phontab_b}
+
+    monkeypatch.setattr(shutil, "which", lambda name: None)
+    monkeypatch.setattr(ctypes.util, "find_library", lambda name: None)
+    monkeypatch.setattr(os.path, "exists", lambda p: p in present)
+
+    pairs = probe._discover_system_espeak()
+
+    # Best-first, data-major: lib-A/lib-B against data-A, then against data-B.
+    assert pairs == [
+        (lib_a, "/opt/homebrew/share"),
+        (lib_b, "/opt/homebrew/share"),
+        (lib_a, "/usr/local/share"),
+        (lib_b, "/usr/local/share"),
+    ]
+    # The first len(libs) pairs cover every distinct library.
+    first_round_libs = {lib for lib, _ in pairs[:2]}
+    assert first_round_libs == {lib_a, lib_b}

--- a/tests/test_kokoro_espeak_repair.py
+++ b/tests/test_kokoro_espeak_repair.py
@@ -313,14 +313,13 @@ def test_unexpected_probe_exception_is_contained_as_503(monkeypatch):
     assert discover_calls["n"] == 1
 
 
-def test_discovery_tries_every_distinct_library_before_data_variants(monkeypatch):
-    """Cross-product is data-major so the cap can't crowd out a real install.
+def test_discovery_schedules_pairs_fairly_anti_diagonal(monkeypatch):
+    """The cross-product is emitted anti-diagonal, not lib- or data-major.
 
-    Two libraries in two prefixes, each prefix carrying its own data dir.
-    A library-major product would emit both of lib-A's data variants before
-    lib-B is ever paired, so a small self-test cap could exhaust its budget
-    on lib-A and never reach a valid lib-B. Data-major must place every
-    distinct library within the first ``len(libs)`` pairs.
+    Two libraries and two data dirs. Ordering by ``lib_rank + data_rank``
+    interleaves the axes so a bounded budget samples multiple libraries AND
+    multiple data dirs — a lib-major or data-major flatten would spend the
+    whole budget on one axis and hide a valid pairing on the other.
     """
     import ctypes.util
     import os
@@ -338,26 +337,21 @@ def test_discovery_tries_every_distinct_library_before_data_variants(monkeypatch
 
     pairs = probe._discover_system_espeak()
 
-    # Best-first, data-major: lib-A/lib-B against data-A, then against data-B.
+    # Anti-diagonal by (lib_rank + data_rank): (a,dA) | (a,dB),(b,dA) | (b,dB).
     assert pairs == [
         (lib_a, "/opt/homebrew/share"),
-        (lib_b, "/opt/homebrew/share"),
         (lib_a, "/usr/local/share"),
+        (lib_b, "/opt/homebrew/share"),
         (lib_b, "/usr/local/share"),
     ]
-    # The first len(libs) pairs cover every distinct library.
-    first_round_libs = {lib for lib, _ in pairs[:2]}
-    assert first_round_libs == {lib_a, lib_b}
 
 
-def test_sweep_tries_all_discovered_candidates_no_pair_slice(monkeypatch):
-    """The sweep self-tests every discovered pair — no pair-level cap slice.
+def test_sweep_iterates_every_discovered_candidate(monkeypatch):
+    """The sweep self-tests every candidate discovery returns.
 
-    Guards against re-introducing a pair-list slice in the sweep: the ONLY
-    working library sits second in discovery, so a slice that stopped at the
-    first (broken) candidate would 503 a host that actually has a usable
-    espeak-ng. The bound now lives in discovery (per-axis caps), so the sweep
-    must iterate the whole returned product.
+    The only working library sits second, so a sweep that stopped at the first
+    (broken) candidate would 503 a host that actually has a usable espeak-ng.
+    The budget lives in discovery, so the sweep must iterate the full list.
     """
     applied: list = []
     good = "/usr/local/lib/libespeak-ng.1.dylib"
@@ -378,50 +372,85 @@ def test_sweep_tries_all_discovered_candidates_no_pair_slice(monkeypatch):
 
     probe._ensure_kokoro_g2p_ready()  # must not raise
     assert probe._ESPEAK_READY is True
-    assert applied == [(good, "/d")]  # reached the 2nd candidate despite cap=1
+    assert applied == [(good, "/d")]  # reached the 2nd candidate
 
 
-def test_discovery_caps_number_of_distinct_libraries(monkeypatch):
-    """Discovery bounds DISTINCT libraries to _MAX_ESPEAK_LIB_CANDIDATES.
+def test_one_malformed_candidate_does_not_abort_sweep(monkeypatch):
+    """A single throwing candidate is skipped, not fatal to the whole sweep.
 
-    Three libraries exist across prefixes but the cap is 2 → the third is
-    dropped, so the sweep can never spin through an unbounded set of installs.
+    Per-candidate containment: if self-testing/repairing one candidate raises,
+    the sweep must continue to a later candidate that still works — not cache
+    a false-negative 503 for the whole worker (codex).
+    """
+    applied: list = []
+    good = "/usr/local/lib/libespeak-ng.1.dylib"
+
+    def _selftest(lib=None, data=None, timeout=30.0):
+        if lib is None:
+            return False  # bundled broken
+        if lib == "/broken/lib":
+            raise RuntimeError("candidate blew up mid-self-test")
+        return lib == good
+
+    monkeypatch.setattr(probe, "_espeak_selftest_subprocess", _selftest)
+    monkeypatch.setattr(
+        probe,
+        "_discover_system_espeak",
+        lambda: [("/broken/lib", "/d"), (good, "/d")],
+    )
+    monkeypatch.setattr(
+        probe, "_apply_system_espeak", lambda lib, data: applied.append((lib, data))
+    )
+
+    probe._ensure_kokoro_g2p_ready()  # must not raise
+    assert probe._ESPEAK_READY is True
+    assert applied == [(good, "/d")]  # continued past the throwing candidate
+
+
+def test_discovery_budget_covers_all_libraries_with_single_data(monkeypatch):
+    """One data dir + libraries up to the budget → every library is tried.
+
+    With a single data dir the anti-diagonal degenerates to one pair per
+    library, so a total budget of N must probe N distinct libraries — no
+    per-library sub-cap silently drops a valid install (codex finding 1).
     """
     import ctypes.util
     import os
     import shutil
 
-    monkeypatch.setattr(probe, "_MAX_ESPEAK_LIB_CANDIDATES", 2)
+    monkeypatch.setattr(probe, "_MAX_ESPEAK_CANDIDATES", 8)
     monkeypatch.setattr(shutil, "which", lambda name: None)
     monkeypatch.setattr(ctypes.util, "find_library", lambda name: None)
 
+    # 6 distinct libraries across prefixes, exactly one data dir.
     lib_files = {
         "/opt/homebrew/lib/libespeak-ng.1.dylib",
+        "/opt/homebrew/lib/libespeak-ng.dylib",
         "/usr/local/lib/libespeak-ng.1.dylib",
-        "/usr/lib/libespeak-ng.1.dylib",
+        "/usr/local/lib/libespeak-ng.dylib",
+        "/usr/lib/libespeak-ng.so.1",
+        "/usr/lib/libespeak-ng.so",
     }
     phontab = "/opt/homebrew/share/espeak-ng-data/phontab"
     monkeypatch.setattr(os.path, "exists", lambda p: p in lib_files or p == phontab)
 
     pairs = probe._discover_system_espeak()
-    distinct_libs = {lib for lib, _ in pairs}
-    assert len(distinct_libs) == 2  # capped from 3 discovered
-    assert "/usr/lib/libespeak-ng.1.dylib" not in distinct_libs  # best-first kept
+    assert len(pairs) == 6  # all libraries, under the budget of 8
+    assert {lib for lib, _ in pairs} == lib_files
+    assert {data for _, data in pairs} == {"/opt/homebrew/share"}
 
 
-def test_discovery_caps_number_of_distinct_data_dirs(monkeypatch):
-    """Discovery bounds DISTINCT data dirs too, so total self-tests stay
-    hard-bounded at ``_MAX_ESPEAK_LIB_CANDIDATES * _MAX_ESPEAK_DATA_CANDIDATES``.
+def test_discovery_budget_covers_all_data_dirs_with_single_library(monkeypatch):
+    """One library + several data dirs → every data dir is tried (finding 2).
 
-    Three prefixes carry valid espeak data but the data cap is 2 → the third
-    data dir is dropped, capping the (library, data) product a broken host
-    can spin through.
+    The correct data prefix may be the third one; capping data independently
+    would discard it. The single library must be paired with every data dir.
     """
     import ctypes.util
     import os
     import shutil
 
-    monkeypatch.setattr(probe, "_MAX_ESPEAK_DATA_CANDIDATES", 2)
+    monkeypatch.setattr(probe, "_MAX_ESPEAK_CANDIDATES", 8)
     monkeypatch.setattr(shutil, "which", lambda name: None)
     monkeypatch.setattr(ctypes.util, "find_library", lambda name: None)
 
@@ -434,6 +463,35 @@ def test_discovery_caps_number_of_distinct_data_dirs(monkeypatch):
     monkeypatch.setattr(os.path, "exists", lambda p: p == lib_file or p in phontabs)
 
     pairs = probe._discover_system_espeak()
-    distinct_data = {data for _, data in pairs}
-    assert len(distinct_data) == 2  # capped from 3 discovered
-    assert "/usr/share" not in distinct_data  # best-first kept (hb, usr/local)
+    assert {data for _, data in pairs} == {
+        "/opt/homebrew/share",
+        "/usr/local/share",
+        "/usr/share",
+    }
+    assert all(lib == lib_file for lib, _ in pairs)
+
+
+def test_discovery_truncates_product_to_total_budget(monkeypatch):
+    """The full product is hard-bounded to _MAX_ESPEAK_CANDIDATES pairs."""
+    import ctypes.util
+    import os
+    import shutil
+
+    monkeypatch.setattr(probe, "_MAX_ESPEAK_CANDIDATES", 4)
+    monkeypatch.setattr(shutil, "which", lambda name: None)
+    monkeypatch.setattr(ctypes.util, "find_library", lambda name: None)
+
+    lib_files = {
+        "/opt/homebrew/lib/libespeak-ng.1.dylib",
+        "/usr/local/lib/libespeak-ng.1.dylib",
+        "/usr/lib/libespeak-ng.so.1",
+    }
+    phontabs = {
+        "/opt/homebrew/share/espeak-ng-data/phontab",
+        "/usr/local/share/espeak-ng-data/phontab",
+        "/usr/share/espeak-ng-data/phontab",
+    }  # 3 libs x 3 data = 9 pairs, capped to 4
+    monkeypatch.setattr(os.path, "exists", lambda p: p in lib_files or p in phontabs)
+
+    pairs = probe._discover_system_espeak()
+    assert len(pairs) == 4  # truncated from 9

--- a/tests/test_kokoro_espeak_repair.py
+++ b/tests/test_kokoro_espeak_repair.py
@@ -353,17 +353,15 @@ def test_discovery_tries_every_distinct_library_before_data_variants(monkeypatch
 def test_sweep_tries_all_discovered_candidates_no_pair_slice(monkeypatch):
     """The sweep self-tests every discovered pair — no pair-level cap slice.
 
-    Guards against re-introducing a ``[:_MAX_ESPEAK_CANDIDATES]`` slice over
-    the pair list: with the cap pinned to 1 and the ONLY working library
-    sitting second in discovery, a pair slice would stop at the first
-    (broken) candidate and 503 a host that actually has a usable espeak-ng.
-    The bound now lives in discovery (distinct libraries), so the sweep must
-    iterate the whole returned product.
+    Guards against re-introducing a pair-list slice in the sweep: the ONLY
+    working library sits second in discovery, so a slice that stopped at the
+    first (broken) candidate would 503 a host that actually has a usable
+    espeak-ng. The bound now lives in discovery (per-axis caps), so the sweep
+    must iterate the whole returned product.
     """
     applied: list = []
     good = "/usr/local/lib/libespeak-ng.1.dylib"
 
-    monkeypatch.setattr(probe, "_MAX_ESPEAK_CANDIDATES", 1)
     monkeypatch.setattr(
         probe,
         "_espeak_selftest_subprocess",
@@ -384,7 +382,7 @@ def test_sweep_tries_all_discovered_candidates_no_pair_slice(monkeypatch):
 
 
 def test_discovery_caps_number_of_distinct_libraries(monkeypatch):
-    """Discovery bounds DISTINCT libraries to _MAX_ESPEAK_CANDIDATES.
+    """Discovery bounds DISTINCT libraries to _MAX_ESPEAK_LIB_CANDIDATES.
 
     Three libraries exist across prefixes but the cap is 2 → the third is
     dropped, so the sweep can never spin through an unbounded set of installs.
@@ -393,7 +391,7 @@ def test_discovery_caps_number_of_distinct_libraries(monkeypatch):
     import os
     import shutil
 
-    monkeypatch.setattr(probe, "_MAX_ESPEAK_CANDIDATES", 2)
+    monkeypatch.setattr(probe, "_MAX_ESPEAK_LIB_CANDIDATES", 2)
     monkeypatch.setattr(shutil, "which", lambda name: None)
     monkeypatch.setattr(ctypes.util, "find_library", lambda name: None)
 
@@ -409,3 +407,33 @@ def test_discovery_caps_number_of_distinct_libraries(monkeypatch):
     distinct_libs = {lib for lib, _ in pairs}
     assert len(distinct_libs) == 2  # capped from 3 discovered
     assert "/usr/lib/libespeak-ng.1.dylib" not in distinct_libs  # best-first kept
+
+
+def test_discovery_caps_number_of_distinct_data_dirs(monkeypatch):
+    """Discovery bounds DISTINCT data dirs too, so total self-tests stay
+    hard-bounded at ``_MAX_ESPEAK_LIB_CANDIDATES * _MAX_ESPEAK_DATA_CANDIDATES``.
+
+    Three prefixes carry valid espeak data but the data cap is 2 → the third
+    data dir is dropped, capping the (library, data) product a broken host
+    can spin through.
+    """
+    import ctypes.util
+    import os
+    import shutil
+
+    monkeypatch.setattr(probe, "_MAX_ESPEAK_DATA_CANDIDATES", 2)
+    monkeypatch.setattr(shutil, "which", lambda name: None)
+    monkeypatch.setattr(ctypes.util, "find_library", lambda name: None)
+
+    lib_file = "/opt/homebrew/lib/libespeak-ng.1.dylib"
+    phontabs = {
+        "/opt/homebrew/share/espeak-ng-data/phontab",
+        "/usr/local/share/espeak-ng-data/phontab",
+        "/usr/share/espeak-ng-data/phontab",
+    }
+    monkeypatch.setattr(os.path, "exists", lambda p: p == lib_file or p in phontabs)
+
+    pairs = probe._discover_system_espeak()
+    distinct_data = {data for _, data in pairs}
+    assert len(distinct_data) == 2  # capped from 3 discovered
+    assert "/usr/share" not in distinct_data  # best-first kept (hb, usr/local)

--- a/vllm_mlx/audio/probe.py
+++ b/vllm_mlx/audio/probe.py
@@ -191,12 +191,20 @@ _ESPEAK_SELFTEST_SRC = (
 # Per-process espeak readiness cache: None = not yet probed, True = ready
 # (bundled works or repaired to system), False = unfixable (clean 503).
 # The lock coalesces concurrent first-request probes (two Kokoro requests
-# racing on a cold worker must not both spawn the subprocess sweep). The
-# candidate cap bounds the worst-case sweep on a badly-broken host.
+# racing on a cold worker must not both spawn the subprocess sweep).
 _ESPEAK_READY: bool | None = None
 _ESPEAK_REASON: str | None = None
 _ESPEAK_LOCK = threading.Lock()
-_MAX_ESPEAK_CANDIDATES = 8
+
+# Hard bounds on the readiness sweep so a badly-broken host can't spin through
+# an unbounded number of subprocess self-tests. Discovery caps DISTINCT
+# libraries and DISTINCT data dirs separately, then self-tests their full
+# (best-first) product — so the worst-case self-test count is exactly the
+# product of these two, while every retained data dir is still paired with
+# every retained library (no crowd-out). Kept small because a real host has
+# only a handful of each; a truncated tail only drops unlikely candidates.
+_MAX_ESPEAK_LIB_CANDIDATES = 4
+_MAX_ESPEAK_DATA_CANDIDATES = 2
 
 
 # F-K-CAPABILITIES-OMIT-AUDIO: D-CAPABILITIES-DETECTION's existing
@@ -522,17 +530,18 @@ def _discover_system_espeak() -> list[tuple[str, str]]:
                 out.append(item)
         return out
 
-    # Cap the number of DISTINCT libraries probed — that (not the raw pair
-    # count) is the meaningful bound, since each library is one real init
-    # attempt and there are only ever a handful on a real host. Dedup keeps
-    # best-first order. Capping libraries rather than pairs means a single
-    # library's several data-dir variants can never exhaust the budget and
-    # hide a later, valid install (codex MAJOR).
-    libs = _dedup(libs)[:_MAX_ESPEAK_CANDIDATES]
-    data_parents = _dedup(data_parents)
-    # Data-major (data outer, library inner) so each capped library is paired
-    # with the best-first data dir first; the sweep self-tests the whole
-    # (now bounded) product, trying every library against every data dir.
+    # Cap EACH dimension (best-first order preserved by dedup). Capping the two
+    # axes independently — rather than slicing the flattened pair list — means
+    # (a) the total self-test count is hard-bounded at LIB x DATA, so a broken
+    # host can't storm subprocesses, and (b) no library's several data-dir
+    # variants can crowd out another library, and no library monopolises the
+    # budget so a later data dir is never reached: every retained data dir is
+    # paired with every retained library (codex MAJOR, both directions).
+    libs = _dedup(libs)[:_MAX_ESPEAK_LIB_CANDIDATES]
+    data_parents = _dedup(data_parents)[:_MAX_ESPEAK_DATA_CANDIDATES]
+    # Data-major (data outer, library inner) so the first round pairs every
+    # retained library with the best-first data dir before any alternate-data
+    # retry — the most likely install is found with the fewest subprocesses.
     return [(lib, data) for data in data_parents for lib in libs]
 
 
@@ -560,10 +569,10 @@ def _probe_espeak_readiness() -> tuple[bool, str | None]:
     the shipped dylib loads correctly (no override, no repair). If bundled
     is broken, self-tests each discovered system espeak-ng candidate in a
     subprocess and repairs this worker to the first that initializes. No
-    candidate works → not ready. Discovery already bounds the sweep to at
-    most :data:`_MAX_ESPEAK_CANDIDATES` distinct libraries (each tried against
-    every data dir), so a badly-broken host can't spin through an unbounded
-    number of installs.
+    candidate works → not ready. Discovery already bounds the sweep to at most
+    :data:`_MAX_ESPEAK_LIB_CANDIDATES` x :data:`_MAX_ESPEAK_DATA_CANDIDATES`
+    self-tests, so a badly-broken host can't spin through an unbounded number
+    of installs.
 
     Discovery (filesystem walks) and repair (``import misaki.espeak`` +
     ``EspeakWrapper`` mutation) can raise unexpectedly on a torn install.

--- a/vllm_mlx/audio/probe.py
+++ b/vllm_mlx/audio/probe.py
@@ -196,15 +196,13 @@ _ESPEAK_READY: bool | None = None
 _ESPEAK_REASON: str | None = None
 _ESPEAK_LOCK = threading.Lock()
 
-# Hard bounds on the readiness sweep so a badly-broken host can't spin through
-# an unbounded number of subprocess self-tests. Discovery caps DISTINCT
-# libraries and DISTINCT data dirs separately, then self-tests their full
-# (best-first) product — so the worst-case self-test count is exactly the
-# product of these two, while every retained data dir is still paired with
-# every retained library (no crowd-out). Kept small because a real host has
-# only a handful of each; a truncated tail only drops unlikely candidates.
-_MAX_ESPEAK_LIB_CANDIDATES = 4
-_MAX_ESPEAK_DATA_CANDIDATES = 2
+# Hard bound on the readiness sweep: at most this many system (library,
+# data-dir) self-tests, so a badly-broken host can't spin through an unbounded
+# number of subprocesses. This is a TOTAL pair budget (not a per-axis cap):
+# discovery schedules candidates fairly (anti-diagonal over the library x data
+# grid) so the budget still samples multiple libraries AND multiple data dirs
+# before exhausting either axis, then truncates the tail.
+_MAX_ESPEAK_CANDIDATES = 8
 
 
 # F-K-CAPABILITIES-OMIT-AUDIO: D-CAPABILITIES-DETECTION's existing
@@ -530,19 +528,23 @@ def _discover_system_espeak() -> list[tuple[str, str]]:
                 out.append(item)
         return out
 
-    # Cap EACH dimension (best-first order preserved by dedup). Capping the two
-    # axes independently — rather than slicing the flattened pair list — means
-    # (a) the total self-test count is hard-bounded at LIB x DATA, so a broken
-    # host can't storm subprocesses, and (b) no library's several data-dir
-    # variants can crowd out another library, and no library monopolises the
-    # budget so a later data dir is never reached: every retained data dir is
-    # paired with every retained library (codex MAJOR, both directions).
-    libs = _dedup(libs)[:_MAX_ESPEAK_LIB_CANDIDATES]
-    data_parents = _dedup(data_parents)[:_MAX_ESPEAK_DATA_CANDIDATES]
-    # Data-major (data outer, library inner) so the first round pairs every
-    # retained library with the best-first data dir before any alternate-data
-    # retry — the most likely install is found with the fewest subprocesses.
-    return [(lib, data) for data in data_parents for lib in libs]
+    libs = _dedup(libs)
+    data_parents = _dedup(data_parents)
+    # Fair (anti-diagonal) schedule over the library x data-dir grid: order
+    # pairs by ``library_rank + data_rank`` so the total budget samples several
+    # libraries AND several data dirs before exhausting either axis. A
+    # library-major or data-major flatten would spend the whole budget on one
+    # axis and hide a valid pairing on the other — e.g. every probe against a
+    # single wrong data dir, or against a single broken library (codex, both
+    # directions). Best-first within each diagonal (lower ranks first); the
+    # caller truncates the tail to :data:`_MAX_ESPEAK_CANDIDATES`.
+    pairs: list[tuple[str, str]] = []
+    for diag in range(len(libs) + len(data_parents)):
+        for i, lib in enumerate(libs):
+            j = diag - i
+            if 0 <= j < len(data_parents):
+                pairs.append((lib, data_parents[j]))
+    return pairs[:_MAX_ESPEAK_CANDIDATES]
 
 
 def _apply_system_espeak(lib: str, data: str) -> None:
@@ -566,32 +568,42 @@ def _probe_espeak_readiness() -> tuple[bool, str | None]:
     """Run the (blocking) espeak readiness sweep. Returns ``(ready, reason)``.
 
     Bundled espeak first — preserves existing behaviour on platforms where
-    the shipped dylib loads correctly (no override, no repair). If bundled
-    is broken, self-tests each discovered system espeak-ng candidate in a
+    the shipped dylib loads correctly (no override, no repair). If bundled is
+    broken, self-tests each discovered system espeak-ng candidate in a
     subprocess and repairs this worker to the first that initializes. No
-    candidate works → not ready. Discovery already bounds the sweep to at most
-    :data:`_MAX_ESPEAK_LIB_CANDIDATES` x :data:`_MAX_ESPEAK_DATA_CANDIDATES`
-    self-tests, so a badly-broken host can't spin through an unbounded number
-    of installs.
+    candidate works → not ready. Discovery bounds the sweep to at most
+    :data:`_MAX_ESPEAK_CANDIDATES` self-tests, so a badly-broken host can't
+    spin through an unbounded number of installs.
 
-    Discovery (filesystem walks) and repair (``import misaki.espeak`` +
-    ``EspeakWrapper`` mutation) can raise unexpectedly on a torn install.
-    Any such error is contained to a not-ready verdict so the caller still
-    returns a clean 503 and the result is cached — an escaping exception
-    would surface as a 500 AND leave the verdict unresolved, re-probing
-    (and re-spawning subprocesses) on every subsequent request (codex MAJOR).
+    Errors are contained so the caller always returns a clean 503 (never a
+    500) and the verdict is cached — an escaping exception would leave
+    ``_ESPEAK_READY`` unresolved, re-probing (and re-spawning subprocesses) on
+    every request (codex). Containment is per-candidate: one malformed
+    candidate (e.g. ``_apply_system_espeak`` raising) is skipped, never
+    aborting the sweep while a later candidate could still work (codex).
     """
     try:
         if _espeak_selftest_subprocess():
             return True, None
+    except Exception:
+        logger.warning("bundled espeak self-test failed unexpectedly", exc_info=True)
 
-        for lib, data in _discover_system_espeak():
+    try:
+        candidates = _discover_system_espeak()
+    except Exception:
+        logger.warning("espeak discovery failed unexpectedly", exc_info=True)
+        return False, _ESPEAK_BROKEN_HINT
+
+    for lib, data in candidates:
+        try:
             if _espeak_selftest_subprocess(lib=lib, data=data):
                 _apply_system_espeak(lib, data)
                 return True, None
-    except Exception:
-        logger.warning("espeak readiness probe failed unexpectedly", exc_info=True)
-        return False, _ESPEAK_BROKEN_HINT
+        except Exception:
+            logger.warning(
+                "espeak candidate %s / %s failed unexpectedly", lib, data, exc_info=True
+            )
+            continue
 
     return False, _ESPEAK_BROKEN_HINT
 

--- a/vllm_mlx/audio/probe.py
+++ b/vllm_mlx/audio/probe.py
@@ -522,16 +522,17 @@ def _discover_system_espeak() -> list[tuple[str, str]]:
                 out.append(item)
         return out
 
-    libs = _dedup(libs)
+    # Cap the number of DISTINCT libraries probed — that (not the raw pair
+    # count) is the meaningful bound, since each library is one real init
+    # attempt and there are only ever a handful on a real host. Dedup keeps
+    # best-first order. Capping libraries rather than pairs means a single
+    # library's several data-dir variants can never exhaust the budget and
+    # hide a later, valid install (codex MAJOR).
+    libs = _dedup(libs)[:_MAX_ESPEAK_CANDIDATES]
     data_parents = _dedup(data_parents)
-    # Data-major (data outer, library inner): the first ``len(libs)`` pairs
-    # cover EVERY distinct library against the best-first data dir. The
-    # readiness sweep caps how many pairs it self-tests, and a library-major
-    # cross-product would spend that whole budget on one library's data
-    # variants — hiding a later, valid library behind them and 503'ing a
-    # host that actually has a working espeak-ng (codex MAJOR). Data-major
-    # guarantees each distinct library is tried before any (library, alt-data)
-    # combo, so the cap trims only redundant pairings, never real installs.
+    # Data-major (data outer, library inner) so each capped library is paired
+    # with the best-first data dir first; the sweep self-tests the whole
+    # (now bounded) product, trying every library against every data dir.
     return [(lib, data) for data in data_parents for lib in libs]
 
 
@@ -558,9 +559,11 @@ def _probe_espeak_readiness() -> tuple[bool, str | None]:
     Bundled espeak first — preserves existing behaviour on platforms where
     the shipped dylib loads correctly (no override, no repair). If bundled
     is broken, self-tests each discovered system espeak-ng candidate in a
-    subprocess (capped at :data:`_MAX_ESPEAK_CANDIDATES` so a badly-broken
-    host can't spin through an unbounded sweep) and repairs this worker to
-    the first that initializes. No candidate works → not ready.
+    subprocess and repairs this worker to the first that initializes. No
+    candidate works → not ready. Discovery already bounds the sweep to at
+    most :data:`_MAX_ESPEAK_CANDIDATES` distinct libraries (each tried against
+    every data dir), so a badly-broken host can't spin through an unbounded
+    number of installs.
 
     Discovery (filesystem walks) and repair (``import misaki.espeak`` +
     ``EspeakWrapper`` mutation) can raise unexpectedly on a torn install.
@@ -573,7 +576,7 @@ def _probe_espeak_readiness() -> tuple[bool, str | None]:
         if _espeak_selftest_subprocess():
             return True, None
 
-        for lib, data in _discover_system_espeak()[:_MAX_ESPEAK_CANDIDATES]:
+        for lib, data in _discover_system_espeak():
             if _espeak_selftest_subprocess(lib=lib, data=data):
                 _apply_system_espeak(lib, data)
                 return True, None

--- a/vllm_mlx/audio/probe.py
+++ b/vllm_mlx/audio/probe.py
@@ -39,8 +39,11 @@ import require_mlx_audio_tts`` without crashing.
 
 from __future__ import annotations
 
+import logging
 import threading
 from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -521,7 +524,15 @@ def _discover_system_espeak() -> list[tuple[str, str]]:
 
     libs = _dedup(libs)
     data_parents = _dedup(data_parents)
-    return [(lib, data) for lib in libs for data in data_parents]
+    # Data-major (data outer, library inner): the first ``len(libs)`` pairs
+    # cover EVERY distinct library against the best-first data dir. The
+    # readiness sweep caps how many pairs it self-tests, and a library-major
+    # cross-product would spend that whole budget on one library's data
+    # variants — hiding a later, valid library behind them and 503'ing a
+    # host that actually has a working espeak-ng (codex MAJOR). Data-major
+    # guarantees each distinct library is tried before any (library, alt-data)
+    # combo, so the cap trims only redundant pairings, never real installs.
+    return [(lib, data) for data in data_parents for lib in libs]
 
 
 def _apply_system_espeak(lib: str, data: str) -> None:
@@ -550,14 +561,25 @@ def _probe_espeak_readiness() -> tuple[bool, str | None]:
     subprocess (capped at :data:`_MAX_ESPEAK_CANDIDATES` so a badly-broken
     host can't spin through an unbounded sweep) and repairs this worker to
     the first that initializes. No candidate works → not ready.
-    """
-    if _espeak_selftest_subprocess():
-        return True, None
 
-    for lib, data in _discover_system_espeak()[:_MAX_ESPEAK_CANDIDATES]:
-        if _espeak_selftest_subprocess(lib=lib, data=data):
-            _apply_system_espeak(lib, data)
+    Discovery (filesystem walks) and repair (``import misaki.espeak`` +
+    ``EspeakWrapper`` mutation) can raise unexpectedly on a torn install.
+    Any such error is contained to a not-ready verdict so the caller still
+    returns a clean 503 and the result is cached — an escaping exception
+    would surface as a 500 AND leave the verdict unresolved, re-probing
+    (and re-spawning subprocesses) on every subsequent request (codex MAJOR).
+    """
+    try:
+        if _espeak_selftest_subprocess():
             return True, None
+
+        for lib, data in _discover_system_espeak()[:_MAX_ESPEAK_CANDIDATES]:
+            if _espeak_selftest_subprocess(lib=lib, data=data):
+                _apply_system_espeak(lib, data)
+                return True, None
+    except Exception:
+        logger.warning("espeak readiness probe failed unexpectedly", exc_info=True)
+        return False, _ESPEAK_BROKEN_HINT
 
     return False, _ESPEAK_BROKEN_HINT
 


### PR DESCRIPTION
## Why

Follow-up to #1312 (Kokoro espeak repair). Post-merge codex review surfaced robustness gaps in the espeak readiness probe that violate its own "the worker survives, callers get a clean 503" contract:

1. **Unexpected exceptions escaped as 500s and defeated caching.** `_discover_system_espeak` (filesystem walks) or `_apply_system_espeak` (`import misaki.espeak` + `EspeakWrapper` mutation) can raise on a torn install; that propagated out of `_ensure_kokoro_g2p_ready` as a **500** (not the promised 503), and left `_ESPEAK_READY` unresolved so **every** request re-probed and re-spawned subprocesses.
2. **One malformed candidate aborted the whole sweep.** A single wrapping `try` meant a candidate that raised mid-self-test/repair skipped every *remaining* candidate and cached a false-negative 503 — even when a later candidate would work.
3. **The candidate schedule could crowd out a valid install.** A lib-major (or data-major) cross-product plus a flat cap could spend the entire probe budget on one axis — all probes against one broken library, or all against one wrong data dir — hiding a working pairing on the other axis.

## What

- **Per-call/per-candidate containment** (`_probe_espeak_readiness`): guard the bundled self-test, discovery, and *each* candidate separately. An unexpected error degrades to the cached clean-503 verdict; one throwing candidate is skipped, never aborting the sweep.
- **Fair schedule + single total budget** (`_discover_system_espeak`): emit the full library × data-dir product in **anti-diagonal** order (by `lib_rank + data_rank`) and truncate to one total budget, `_MAX_ESPEAK_CANDIDATES` (8). The budget samples multiple libraries **and** multiple data dirs before exhausting either axis — no crowd-out in either direction, and the worst-case subprocess count stays bounded.
- 8 regression tests: exception→cached-503, malformed-candidate skip, anti-diagonal order, sweep iterates all candidates, single-data covers all libs, single-lib covers all data dirs, product truncated to budget.

No behaviour change on healthy hosts (bundled-ok and single-install paths unaffected). `[skip-version-bump]` — pure fix. Follows up #1312.
