### PR TITLE
fix(video): emit one 413 for oversized streamed uploads

### DIFF
--- a/tests/test_ltx23_video.py
+++ b/tests/test_ltx23_video.py
@@ -12,6 +12,10 @@ from types import ModuleType, SimpleNamespace
 import pytest
 from fastapi import HTTPException
 from PIL import Image
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+from starlette.routing import Route
 
 from vllm_mlx.model_aliases import resolve_profile
 from vllm_mlx.routes import video
@@ -185,6 +189,65 @@ async def test_video_multipart_gate_caps_chunked_body(
         cfg.api_key = saved_key
 
     assert sent[0]["status"] == 413
+
+
+@pytest.mark.asyncio
+async def test_video_multipart_gate_emits_one_413_through_starlette(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The streaming cap must reject outside Starlette's 500 handler."""
+    from vllm_mlx.config import get_config
+
+    cfg = get_config()
+    saved_key = cfg.api_key
+    cfg.api_key = None
+    monkeypatch.setattr(video, "_VIDEO_REQUEST_BYTES", 4)
+
+    async def endpoint(request: Request) -> JSONResponse:
+        await request.body()
+        return JSONResponse({"ok": True})
+
+    app = video.VideoBodyLimitMiddleware(
+        Starlette(routes=[Route("/v1/videos", endpoint, methods=["POST"])])
+    )
+    chunks = iter(
+        [
+            {"type": "http.request", "body": b"abc", "more_body": True},
+            {"type": "http.request", "body": b"def", "more_body": False},
+        ]
+    )
+    sent = []
+
+    async def receive():
+        return next(chunks)
+
+    async def send(message) -> None:
+        sent.append(message)
+
+    try:
+        await app(
+            {
+                "type": "http",
+                "asgi": {"version": "3.0"},
+                "http_version": "1.1",
+                "method": "POST",
+                "scheme": "http",
+                "path": "/v1/videos",
+                "raw_path": b"/v1/videos",
+                "query_string": b"",
+                "root_path": "",
+                "headers": [],
+                "client": ("test", 1),
+                "server": ("test", 80),
+            },
+            receive,
+            send,
+        )
+    finally:
+        cfg.api_key = saved_key
+
+    starts = [message for message in sent if message["type"] == "http.response.start"]
+    assert [message["status"] for message in starts] == [413]
 
 
 def test_serve_dispatches_video_preflight(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/vllm_mlx/routes/video.py
+++ b/vllm_mlx/routes/video.py
@@ -115,19 +115,61 @@ class VideoBodyLimitMiddleware:
                 return await response(scope, receive, send)
 
         total = 0
+        limit_tripped = False
+        replacement_sent = False
+        downstream_started = False
+        downstream_completed = False
 
         async def bounded_receive():
-            nonlocal total
+            nonlocal total, limit_tripped
             message = await receive()
             if message.get("type") == "http.request":
-                total += len(message.get("body", b"") or b"")
+                chunk = message.get("body", b"") or b""
+                total += len(chunk)
                 if total > _VIDEO_REQUEST_BYTES:
+                    limit_tripped = True
                     raise _VideoBodyTooLargeError
             return message
 
+        async def guarded_send(message):
+            nonlocal replacement_sent, downstream_started, downstream_completed
+            if limit_tripped:
+                # Starlette's ServerErrorMiddleware catches the receive
+                # sentinel and attempts to emit a 500 before re-raising it.
+                # Replace that response at the same ASGI boundary, and swallow
+                # its remaining frames, so the client sees exactly one 413.
+                if not downstream_started and not replacement_sent:
+                    response = JSONResponse(
+                        status_code=413,
+                        content={"detail": "video request body exceeds 21 MB"},
+                    )
+                    await response(scope, receive, send)
+                    replacement_sent = True
+                return
+
+            message_type = message.get("type")
+            if message_type == "http.response.start":
+                downstream_started = True
+            elif message_type == "http.response.body" and not message.get(
+                "more_body", False
+            ):
+                downstream_completed = True
+            await send(message)
+
         try:
-            await self.app(scope, bounded_receive, send)
+            await self.app(scope, bounded_receive, guarded_send)
         except _VideoBodyTooLargeError:
+            if replacement_sent or downstream_completed:
+                return
+            if downstream_started:
+                # The video route parses its multipart body before entering the
+                # handler, so this should be unreachable. If a future handler
+                # starts a response first, it is too late to change the status;
+                # terminate the stream instead of emitting a second response.
+                await send(
+                    {"type": "http.response.body", "body": b"", "more_body": False}
+                )
+                return
             response = JSONResponse(
                 status_code=413,
                 content={"detail": "video request body exceeds 21 MB"},


### PR DESCRIPTION
## What changed

- intercept Starlette's internal error response when the streamed `/v1/videos` body cap trips
- replace the attempted 500 with exactly one 413 response and suppress the remaining downstream frames
- preserve streaming body accounting without buffering multipart uploads in process memory
- add a regression test using a real Starlette middleware stack

## Why

This is necessary because `_VideoBodyTooLargeError` was raised from the wrapped ASGI receive callable and Starlette's `ServerErrorMiddleware` caught it first, emitted a 500, and re-raised it. The outer video middleware then emitted a second 413, producing two response-start frames for one request.

## Impact

Chunked requests, requests without `Content-Length`, or requests with an understated `Content-Length` that crossed the 21 MiB cap could return 500 or fail at the ASGI protocol layer instead of returning the intended 413.

## Validation

- `python3.12 -m pytest -q tests/test_ltx23_video.py` — 22 passed
- `ruff check vllm_mlx/routes/video.py tests/test_ltx23_video.py` — passed
- `git diff --check` — passed
- full suite — 14,668 passed, 185 skipped, 6 xfailed; 14 unrelated baseline/environment failures (localhost integration services absent, batching timing test, and current-main env allowlist mismatch)
- Codex review — two memory-amplification findings addressed; final review found no regressions
