### PR TITLE
feat(audio): expose MusicEngine over HTTP — POST /v1/audio/music

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,6 +185,8 @@ jobs:
             tests/test_streaming_detokenizer.py \
             tests/test_tool_logits.py \
             tests/test_no_mllm_flag.py \
+            tests/test_audio_music_route.py \
+            tests/test_audio_route_registration_gate.py \
             -v --tb=short \
             -m "not slow" \
             -k "not Integration"

--- a/docs/guides/audio.md
+++ b/docs/guides/audio.md
@@ -309,6 +309,65 @@ curl http://localhost:8000/v1/audio/speech \
   --output speech.wav
 ```
 
+### POST /v1/audio/music
+
+Generate music or sound effects from a text prompt, via the MLX-native
+[Stable Audio 3](https://huggingface.co/stabilityai/stable-audio-3-optimized)
+engine vendored under `vllm_mlx/audio/sa3/`. Request-in / audio-bytes-out —
+the same shape as `/v1/audio/speech`.
+
+**Parameters (JSON body):**
+
+| Field | Type | Default | Notes |
+| --- | --- | --- | --- |
+| `model` | string | `"medium"` | DiT/decoder pairing: `medium` (higher quality, ~3.9 GB peak) or `sm-music` / `sm-sfx` (fast small, ~1.7 GB). Unknown values fall back to the engine defaults. |
+| `input` | string | — (required) | Natural-language prompt. Non-blank, max 4096 chars (it becomes an argv element for the SA3 CLI). |
+| `seconds` | number | `30.0` | Clip length. `0 < seconds <= 47` (the SA3 ceiling). NaN/inf rejected. |
+| `steps` | integer | `8` | Pingpong sampling steps, `1..200`. |
+| `negative_prompt` | string \| null | `null` | CFG negative branch (e.g. `"vocals, singing"`). Max 4096 chars. |
+| `seed` | integer \| null | `null` | Fixed seed for reproducibility. |
+| `response_format` | string | `"wav"` | Only `wav` is supported (SA3 renders WAV natively). |
+
+**Response:** `200 OK`, `Content-Type: audio/wav` — the raw WAV bytes.
+
+Errors: `400` for schema violations (blank or over-4096-char `input`,
+`seconds > 47`, unsupported `response_format`); `500`
+(`code="music_generation_failed"`) if the engine fails **or produces no
+audio** — an SA3 run that exits cleanly without writing sample frames is
+reported as a failure rather than returned as a silent clip; `503` if the
+engine's runtime deps are unavailable.
+
+> **On the status code:** a schema rejection is a FastAPI
+> `RequestValidationError`, which the rapid-mlx server's global handler
+> normalizes to **400** with a sanitized envelope (see
+> `install_exception_handlers`). Stock FastAPI would emit 422 — you'll see
+> 422 only if you mount the router on a bare app without those handlers,
+> as the unit tests do.
+
+Renders are serialized server-side: one SA3 subprocess at a time, so
+concurrent callers queue instead of racing for unified memory. The render
+runs off the event loop, so other requests (chat completions, health
+probes) are unaffected while it works.
+
+**Example:**
+```bash
+curl http://localhost:8000/v1/audio/music \
+  -H "Content-Type: application/json" \
+  -d '{
+        "model": "medium",
+        "input": "epic cinematic war drums, tense build-up",
+        "seconds": 20,
+        "steps": 8,
+        "negative_prompt": "vocals, singing",
+        "seed": 42
+      }' \
+  --output bgm.wav
+```
+
+Weights are fetched from HuggingFace on first use into the standard HF
+cache (Stability Community License — free commercial use under $1M
+revenue).
+
 ### GET /v1/audio/voices
 
 List available voices for a model.

--- a/tests/test_audio_music_route.py
+++ b/tests/test_audio_music_route.py
@@ -1,0 +1,513 @@
+# SPDX-License-Identifier: Apache-2.0
+"""``POST /v1/audio/music`` — the text→music / text→SFX route.
+
+Hermetic — no real models / network / SA3 weights. ``MusicEngine`` is
+faked at the import boundary via monkeypatch (per repo convention), so
+these run fast in CI.
+
+Covered:
+
+* happy path (WAV bytes out) + ``model`` → ``(dit, decoder)`` mapping;
+* schema rejections (blank / over-long ``input``, ``seconds`` past the
+  SA3 ceiling, unsupported ``response_format``) never reach the engine;
+* the empty-output failure modes — no file, a 0-byte file, a valid RIFF
+  header with zero sample frames, and unparseable bytes — all 500 with
+  ``code="music_generation_failed"`` instead of a 200 that reads as a
+  successfully generated silent clip;
+* the blocking render runs OFF the event loop (structurally verified by
+  thread identity), and survives cancellation without releasing the lock
+  or unlinking the temp file under a live worker.
+
+NOTE (CI): these import ``vllm_mlx.config``, whose import chain reaches
+``engine_core``'s ``import mlx.core`` — so this file belongs in the
+``test-apple-silicon`` job, not the mlx-free Linux matrix.
+"""
+
+from __future__ import annotations
+
+import io
+import math
+import struct
+import sys
+import wave
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+# This suite imports ``vllm_mlx.config``, whose import chain reaches
+# ``engine_core`` and therefore requires MLX.  The regular Linux matrix and
+# diff-aware PR validation deliberately run without MLX; the Apple Silicon
+# job below exercises the full suite instead.
+pytest.importorskip("mlx")
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_tone_wav(duration_s: float = 0.25, freq_hz: float = 440.0) -> bytes:
+    sample_rate = 16000
+    n_samples = int(sample_rate * duration_s)
+    buf = io.BytesIO()
+    with wave.open(buf, "wb") as w:
+        w.setnchannels(1)
+        w.setsampwidth(2)
+        w.setframerate(sample_rate)
+        for i in range(n_samples):
+            sample = int(8000 * math.sin(2 * math.pi * freq_hz * i / sample_rate))
+            w.writeframes(struct.pack("<h", sample))
+    return buf.getvalue()
+
+
+def _mount_audio_app() -> tuple[TestClient, callable]:
+    """Mount the audio router on a bare FastAPI app, bypassing auth."""
+    from vllm_mlx.config import get_config
+    from vllm_mlx.routes import audio as audio_route
+
+    app = FastAPI()
+    app.include_router(audio_route.router)
+    cfg = get_config()
+    saved = cfg.api_key
+    cfg.api_key = None
+
+    def _restore():
+        cfg.api_key = saved
+
+    return TestClient(app), _restore
+
+
+class _FakeMusicEngine:
+    """Stands in for ``vllm_mlx.audio.music.MusicEngine``.
+
+    Records the call and writes a tiny WAV to ``out_path`` so the route's
+    read-back-and-return path is exercised without SA3 weights.
+    """
+
+    last_call: dict | None = None
+
+    def __init__(self, dit="medium", decoder="same-l"):
+        self.dit = dit
+        self.decoder = decoder
+
+    def generate(
+        self,
+        prompt,
+        out_path,
+        seconds=30.0,
+        steps=8,
+        negative_prompt=None,
+        seed=None,
+        timeout=900,
+    ):
+        _FakeMusicEngine.last_call = {
+            "prompt": prompt,
+            "out_path": str(out_path),
+            "seconds": seconds,
+            "steps": steps,
+            "negative_prompt": negative_prompt,
+            "seed": seed,
+            "dit": self.dit,
+            "decoder": self.decoder,
+        }
+        with open(out_path, "wb") as fh:
+            fh.write(_make_tone_wav())
+        return out_path
+
+
+def _install_engine(monkeypatch, engine_cls):
+    """Swap ``MusicEngine`` for ``engine_cls`` and clear the route cache.
+
+    The route imports ``MusicEngine`` from ``vllm_mlx.audio.music`` INSIDE
+    the worker function, so patch the attribute on the module object as
+    well as by dotted path — the former is what a late import resolves.
+    """
+    from vllm_mlx.routes import audio as audio_route
+
+    monkeypatch.setattr("vllm_mlx.audio.music.MusicEngine", engine_cls, raising=False)
+    music_mod = sys.modules.get("vllm_mlx.audio.music")
+    if music_mod is not None:
+        monkeypatch.setattr(music_mod, "MusicEngine", engine_cls)
+    audio_route._music_engine = None
+
+
+@pytest.fixture
+def _stub_music_engine(monkeypatch):
+    from vllm_mlx.routes import audio as audio_route
+
+    _FakeMusicEngine.last_call = None
+    _install_engine(monkeypatch, _FakeMusicEngine)
+    yield
+    audio_route._music_engine = None
+
+
+# ---------------------------------------------------------------------------
+# Happy path + schema validation
+# ---------------------------------------------------------------------------
+
+
+class TestMusicRoute:
+    def test_happy_path_returns_wav(self, _stub_music_engine):
+        client, restore = _mount_audio_app()
+        try:
+            r = client.post(
+                "/v1/audio/music",
+                json={
+                    "model": "medium",
+                    "input": "epic cinematic war drums",
+                    "seconds": 12,
+                    "steps": 6,
+                    "negative_prompt": "vocals",
+                    "seed": 7,
+                },
+            )
+        finally:
+            restore()
+        assert r.status_code == 200, r.text
+        assert r.headers["content-type"].startswith("audio/wav"), r.headers
+        # Real WAV bytes came back (RIFF header).
+        assert r.content[:4] == b"RIFF", r.content[:16]
+        # Request fields reached the engine, and model→(dit,decoder) mapped.
+        call = _FakeMusicEngine.last_call
+        assert call["prompt"] == "epic cinematic war drums"
+        assert call["seconds"] == 12
+        assert call["steps"] == 6
+        assert call["negative_prompt"] == "vocals"
+        assert call["seed"] == 7
+        assert (call["dit"], call["decoder"]) == ("medium", "same-l")
+
+    def test_model_alias_selects_small_variant(self, _stub_music_engine):
+        client, restore = _mount_audio_app()
+        try:
+            r = client.post(
+                "/v1/audio/music",
+                json={"model": "sm-music", "input": "lofi beat", "seconds": 5},
+            )
+        finally:
+            restore()
+        assert r.status_code == 200, r.text
+        call = _FakeMusicEngine.last_call
+        assert (call["dit"], call["decoder"]) == ("sm-music", "same-s")
+
+    def test_unknown_model_falls_back_to_defaults(self, _stub_music_engine):
+        client, restore = _mount_audio_app()
+        try:
+            r = client.post(
+                "/v1/audio/music",
+                json={"model": "no-such-variant", "input": "ambient pad"},
+            )
+        finally:
+            restore()
+        assert r.status_code == 200, r.text
+        call = _FakeMusicEngine.last_call
+        assert (call["dit"], call["decoder"]) == ("medium", "same-l")
+        # seconds default honoured.
+        assert call["seconds"] == 30.0
+
+    def test_blank_input_is_422(self, _stub_music_engine):
+        client, restore = _mount_audio_app()
+        try:
+            r = client.post("/v1/audio/music", json={"input": "   ", "seconds": 5})
+        finally:
+            restore()
+        assert r.status_code == 422, r.text
+        # Engine was never invoked.
+        assert _FakeMusicEngine.last_call is None
+
+    def test_seconds_over_ceiling_is_422(self, _stub_music_engine):
+        client, restore = _mount_audio_app()
+        try:
+            r = client.post(
+                "/v1/audio/music", json={"input": "long track", "seconds": 100}
+            )
+        finally:
+            restore()
+        assert r.status_code == 422, r.text
+        assert _FakeMusicEngine.last_call is None
+
+    @pytest.mark.parametrize(
+        "bad", [float("nan"), float("inf"), float("-inf"), "nan", "inf"]
+    )
+    def test_non_finite_seconds_is_rejected(self, bad):
+        """A non-finite ``seconds`` must never reach the engine.
+
+        Range checks are the classic NaN hole (every comparison against
+        NaN is False), which is why the model carries an explicit
+        ``math.isfinite`` guard alongside the ``gt=/le=`` bounds. This
+        test pins the OUTCOME rather than which layer catches it, so it
+        keeps holding whichever one fires first.
+
+        Asserted at the model rather than over HTTP because JSON has no
+        NaN literal — Python's ``json`` parses the non-standard ``NaN``
+        token but then refuses to encode it back into the 422 body, so a
+        bare-app round trip fails inside stock FastAPI's own error handler
+        rather than at our validator.
+        """
+        from pydantic import ValidationError
+
+        from vllm_mlx.api.models import AudioMusicRequest
+
+        with pytest.raises(ValidationError):
+            AudioMusicRequest(input="track", seconds=bad)
+
+    def test_bad_response_format_is_422(self, _stub_music_engine):
+        client, restore = _mount_audio_app()
+        try:
+            r = client.post(
+                "/v1/audio/music",
+                json={"input": "track", "response_format": "mp3"},
+            )
+        finally:
+            restore()
+        assert r.status_code == 422, r.text
+        assert _FakeMusicEngine.last_call is None
+
+    def test_over_long_input_is_422_not_argv_blowup(self, _stub_music_engine):
+        """A giant prompt must 422 at the schema, not reach the engine.
+
+        ``MusicEngine.generate`` passes ``input`` as an argv element to
+        the vendored SA3 CLI, so an unbounded prompt hits the OS
+        ``ARG_MAX`` ceiling and surfaces as an opaque 500 ``E2BIG``. The
+        ``max_length`` bound turns that into an actionable 422.
+        """
+        client, restore = _mount_audio_app()
+        try:
+            r = client.post(
+                "/v1/audio/music",
+                json={"input": "x" * 5000, "seconds": 5},
+            )
+        finally:
+            restore()
+        assert r.status_code == 422, r.text
+        assert _FakeMusicEngine.last_call is None
+
+    def test_engine_error_is_500_envelope(self, monkeypatch):
+        """An engine RuntimeError surfaces the documented envelope."""
+
+        class _BoomEngine(_FakeMusicEngine):
+            def generate(self, prompt, out_path, **kwargs):  # noqa: D102
+                raise RuntimeError("SA3 exited 1: <no stderr>")
+
+        _install_engine(monkeypatch, _BoomEngine)
+        client, restore = _mount_audio_app()
+        try:
+            r = client.post("/v1/audio/music", json={"input": "boom", "seconds": 5})
+        finally:
+            restore()
+        assert r.status_code == 500, r.text
+        assert r.json()["detail"]["error"]["code"] == "music_generation_failed", r.text
+        # No subprocess/filesystem internals leaked to the caller.
+        assert "SA3 exited" not in r.text
+
+
+# ---------------------------------------------------------------------------
+# Empty-output detection — a "successful" render with no audio must 500
+# ---------------------------------------------------------------------------
+
+
+class TestMusicEmptyOutputDetection:
+    """A "successful" render with no audio must not become a 200."""
+
+    def _post_with_engine(self, monkeypatch, engine_cls):
+        from vllm_mlx.routes import audio as audio_route
+
+        _install_engine(monkeypatch, engine_cls)
+        client, restore = _mount_audio_app()
+        try:
+            return client.post("/v1/audio/music", json={"input": "x", "seconds": 5})
+        finally:
+            restore()
+            audio_route._music_engine = None
+
+    def test_engine_writing_nothing_is_500_not_empty_200(self, monkeypatch):
+        """An engine that exits cleanly without writing must 500.
+
+        The SA3 CLI can return success having produced no audio (a sampler
+        that bailed after the header). Returning that as HTTP 200 with an
+        empty ``audio/wav`` body reads to the caller as a successfully
+        generated silent clip — the worst kind of failure.
+        """
+
+        class _SilentEngine(_FakeMusicEngine):
+            def generate(self, prompt, out_path, **kwargs):  # noqa: D102
+                # Exits "successfully" but leaves the temp file at 0 bytes.
+                return out_path
+
+        r = self._post_with_engine(monkeypatch, _SilentEngine)
+        assert r.status_code == 500, r.text
+        assert r.json()["detail"]["error"]["code"] == "music_generation_failed", r.text
+
+    def test_missing_output_file_is_500(self, monkeypatch):
+        """``MusicEngine.generate`` unlinks the target before rendering.
+
+        So a run that exits without writing leaves NO file at all, not an
+        empty one — the route must handle the missing-path case too.
+        """
+        import os
+
+        class _UnlinkingEngine(_FakeMusicEngine):
+            def generate(self, prompt, out_path, **kwargs):  # noqa: D102
+                os.unlink(out_path)
+                return out_path
+
+        r = self._post_with_engine(monkeypatch, _UnlinkingEngine)
+        assert r.status_code == 500, r.text
+        assert r.json()["detail"]["error"]["code"] == "music_generation_failed", r.text
+
+    def test_header_only_wav_is_500_not_a_silent_clip(self, monkeypatch):
+        """A valid RIFF header with ZERO sample frames must fail.
+
+        A bare WAV header is ~44 bytes, so a non-empty-bytes check passes
+        it and the caller receives a 200 with ``audio/wav`` that plays as
+        silence — indistinguishable from a real quiet track.
+        """
+
+        class _HeaderOnlyEngine(_FakeMusicEngine):
+            def generate(self, prompt, out_path, **kwargs):  # noqa: D102
+                with wave.open(str(out_path), "wb") as w:
+                    w.setnchannels(1)
+                    w.setsampwidth(2)
+                    w.setframerate(44100)
+                    # No writeframes() call at all.
+                return out_path
+
+        r = self._post_with_engine(monkeypatch, _HeaderOnlyEngine)
+        assert r.status_code == 500, r.text
+        assert r.json()["detail"]["error"]["code"] == "music_generation_failed", r.text
+
+    def test_unparseable_output_is_500_not_mislabelled_wav(self, monkeypatch):
+        """Output that isn't a readable WAV must fail, not be mislabelled.
+
+        Fail-closed is right here because the producer uses the SAME
+        parser: SA3's ``save_wav`` writes 16-bit PCM through ``wave.open``
+        (``audio/sa3/scripts/sa3_mlx.py``). So bytes ``wave`` can't read
+        are not SA3 output, and returning them under
+        ``Content-Type: audio/wav`` would be mislabelling.
+        """
+
+        class _OpaqueEngine(_FakeMusicEngine):
+            def generate(self, prompt, out_path, **kwargs):  # noqa: D102
+                with open(out_path, "wb") as fh:
+                    fh.write(b"\x00\x01\x02\x03" * 64)
+                return out_path
+
+        r = self._post_with_engine(monkeypatch, _OpaqueEngine)
+        assert r.status_code == 500, r.text
+        assert r.json()["detail"]["error"]["code"] == "music_generation_failed", r.text
+
+
+# ---------------------------------------------------------------------------
+# Concurrency: off-loop execution + cancellation safety
+# ---------------------------------------------------------------------------
+
+
+class TestMusicConcurrencyShape:
+    def test_generation_does_not_block_the_event_loop(self, _stub_music_engine):
+        """The blocking render must run off the event loop.
+
+        ``MusicEngine.generate`` shells out and waits (up to 900 s by
+        default). Calling it inline from the ``async def`` handler would
+        stall every other request on the server for the whole render, so
+        the handler hands it to ``asyncio.to_thread``. Detect that
+        structurally: the engine must observe a DIFFERENT thread than the
+        one running the event loop.
+        """
+        import asyncio
+        import threading
+
+        observed: dict[str, int] = {}
+
+        class _ThreadRecordingEngine(_FakeMusicEngine):
+            def generate(self, prompt, out_path, **kwargs):  # noqa: D102
+                observed["engine_thread"] = threading.get_ident()
+                with open(out_path, "wb") as fh:
+                    fh.write(_make_tone_wav())
+                return out_path
+
+        from vllm_mlx.api.models import AudioMusicRequest
+        from vllm_mlx.routes import audio as audio_route
+
+        async def _drive():
+            observed["loop_thread"] = threading.get_ident()
+            return await audio_route.create_music(
+                AudioMusicRequest(input="a march", seconds=5)
+            )
+
+        saved = audio_route._music_engine
+        try:
+            music_mod = sys.modules["vllm_mlx.audio.music"]
+            saved_cls = music_mod.MusicEngine
+            music_mod.MusicEngine = _ThreadRecordingEngine
+            audio_route._music_engine = None
+            try:
+                resp = asyncio.run(_drive())
+            finally:
+                music_mod.MusicEngine = saved_cls
+        finally:
+            audio_route._music_engine = saved
+
+        assert resp.body[:4] == b"RIFF", resp.body[:16]
+        assert observed["engine_thread"] != observed["loop_thread"], observed
+
+    def test_lock_is_an_asyncio_lock_not_a_thread_lock(self):
+        """Renders serialise on the LOOP, not inside the worker.
+
+        ``asyncio.to_thread`` dispatches to the shared default executor,
+        so a ``threading.Lock`` held inside the worker would pin one
+        executor thread per queued request for up to the 900 s render
+        ceiling — starving every other ``to_thread`` user in the process
+        (prefix-cache save, tool-grammar warmup, the diffusion lane).
+        Pin the type so a future refactor can't quietly swap it.
+        """
+        import asyncio
+
+        from vllm_mlx.routes import audio as audio_route
+
+        async def _get():
+            return audio_route._get_music_lock()
+
+        saved = audio_route._music_lock
+        try:
+            audio_route._music_lock = None
+            lock = asyncio.run(_get())
+            assert isinstance(lock, asyncio.Lock), type(lock)
+        finally:
+            audio_route._music_lock = saved
+
+    def test_cancellation_drains_the_worker_before_unwinding(self):
+        """A client disconnect must not free the lock / temp file early.
+
+        ``await asyncio.to_thread(...)`` is NOT cancellable — the worker
+        keeps running — yet the await returns immediately when the
+        surrounding task is cancelled. Left unguarded, the handler's
+        ``async with`` lock would unwind (admitting a second concurrent
+        SA3 subprocess) and its ``finally`` would unlink the wav the
+        abandoned worker is still writing into. ``run_to_completion``
+        shields and drains instead. Assert the drain: the worker must have
+        FINISHED by the time the CancelledError propagates.
+        """
+        import asyncio
+        import threading
+
+        from vllm_mlx.routes._async_utils import run_to_completion
+
+        started = threading.Event()
+        finished = threading.Event()
+
+        def _slow_worker():
+            started.set()
+            # Long enough that the cancellation below lands mid-flight.
+            threading.Event().wait(0.3)
+            finished.set()
+
+        async def _drive():
+            task = asyncio.ensure_future(run_to_completion(_slow_worker))
+            await asyncio.to_thread(started.wait, 5)
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+            # The drain is the whole point: the worker is done, so the
+            # caller's lock release + temp-file unlink are now safe.
+            return finished.is_set()
+
+        assert asyncio.run(_drive()) is True

--- a/tests/test_audio_route_registration_gate.py
+++ b/tests/test_audio_route_registration_gate.py
@@ -188,12 +188,14 @@ class TestRegisterAudioRoutes:
             for r in _walk_routes(app)
             if getattr(r, "path", "").startswith("/v1/audio/")
         ]
-        # transcriptions + translations + speech + voices = 4 unique paths.
+        # transcriptions + translations + speech + music + voices =
+        # 5 unique paths (music is the text→music/SFX lane).
         unique_paths = {r.path for r in audio_routes}
         assert unique_paths == {
             "/v1/audio/transcriptions",
             "/v1/audio/translations",
             "/v1/audio/speech",
+            "/v1/audio/music",
             "/v1/audio/voices",
         }
 
@@ -232,6 +234,13 @@ class TestAudioRoutes404OnTextOnlyApp:
         r = self.client.post(
             "/v1/audio/speech",
             json={"model": "kokoro", "input": "hello"},
+        )
+        assert r.status_code == 404
+
+    def test_music_404(self):
+        r = self.client.post(
+            "/v1/audio/music",
+            json={"model": "medium", "input": "lofi beat"},
         )
         assert r.status_code == 404
 

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -2758,6 +2758,86 @@ class AudioSpeechRequest(BaseModel):
         return lower
 
 
+# ``response_format`` values the ``/v1/audio/music`` route can produce.
+# Stable Audio 3 renders WAV natively; only ``wav`` is offered for now
+# (mirrors the SA3 CLI's output). Centralised so the validator and the
+# route agree.
+_MUSIC_ALLOWED_RESPONSE_FORMATS: tuple[str, ...] = ("wav",)
+
+#: SA3 supports clips up to ~47s; reject longer requests up front so a
+#: caller doesn't wait on a generation the backend will refuse. Mirrors
+#: ``vllm_mlx.audio.music._MAX_SECONDS`` — the engine enforces the same
+#: ceiling, so a drift here only ever costs a 500 instead of a 422.
+_MUSIC_MAX_SECONDS: float = 47.0
+
+
+class AudioMusicRequest(BaseModel):
+    """Request for text→music / text→SFX (``/v1/audio/music``).
+
+    OpenAI-flavored shape mirroring :class:`AudioSpeechRequest` so the
+    music lane reads the same as the speech lane to a colleague
+    integrating over the API. Wired to
+    :class:`vllm_mlx.audio.music.MusicEngine` (MLX-native Stable Audio 3).
+
+    * ``input`` is the natural-language prompt (SA3's positive branch);
+      rejected empty / whitespace-only like the speech route's ``input``.
+    * ``model`` selects a DiT/decoder pairing via the route's
+      ``MUSIC_MODEL_ALIASES`` table (``medium`` = higher quality,
+      ``sm-music`` / ``sm-sfx`` = fast small). Unknown values fall back
+      to the engine defaults.
+    * ``seconds`` is bounded to SA3's ~47s ceiling; NaN/inf rejected via
+      the finite validator (Pydantic ``le=`` alone lets NaN through).
+    * ``input`` is length-capped: ``MusicEngine.generate`` passes it as an
+      argv element to the vendored SA3 CLI, so an unbounded prompt hits
+      the OS ``ARG_MAX`` limit and surfaces as an opaque 500 ``E2BIG``
+      instead of a 422 the caller can act on. The cap matches
+      ``negative_prompt`` (both land on the same command line).
+    """
+
+    model: str = "medium"
+    input: str = Field(..., min_length=1, max_length=4096)
+    seconds: float = Field(default=30.0, gt=0.0, le=_MUSIC_MAX_SECONDS)
+    steps: int = Field(default=8, ge=1, le=200)
+    negative_prompt: str | None = Field(default=None, max_length=4096)
+    seed: int | None = None
+    response_format: str = "wav"
+
+    @field_validator("input")
+    @classmethod
+    def _input_must_be_non_blank(cls, v: str) -> str:
+        if not v.strip():
+            raise ValueError("input must be a non-empty, non-blank string")
+        return v
+
+    @field_validator("seconds")
+    @classmethod
+    def _seconds_must_be_finite(cls, v: float) -> float:
+        # Belt-and-braces against NaN/inf reaching the engine. Range
+        # checks are the classic place NaN slips through, because every
+        # comparison involving NaN is False — exactly the bug the
+        # sampling-param validators at the top of this module exist to
+        # fix. pydantic-core's ``gt=/le=`` constraints happen to reject
+        # non-finite floats today, but that is an implementation detail of
+        # the version we resolve to and it evaporates the moment someone
+        # widens the bounds or hand-rolls the check. Stating the invariant
+        # explicitly keeps it true regardless, and mirrors the identical
+        # guard in ``MusicEngine.generate``.
+        if not math.isfinite(v):
+            raise ValueError("seconds must be a finite number")
+        return v
+
+    @field_validator("response_format")
+    @classmethod
+    def _response_format_must_be_known(cls, v: str) -> str:
+        if v is None:
+            return "wav"
+        lower = v.lower()
+        if lower not in _MUSIC_ALLOWED_RESPONSE_FORMATS:
+            supported = ", ".join(_MUSIC_ALLOWED_RESPONSE_FORMATS)
+            raise ValueError(f"response_format must be one of: {supported}; got {v!r}")
+        return lower
+
+
 class AudioSeparationRequest(BaseModel):
     """Request for audio source separation."""
 

--- a/vllm_mlx/routes/_async_utils.py
+++ b/vllm_mlx/routes/_async_utils.py
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Shared async helpers for the generation route lanes (audio / video).
+
+These lanes all have the same shape: an ``async def`` handler that must
+hand seconds-to-minutes of blocking engine work to a worker thread, while
+holding a lock and owning a temp file for exactly as long as that work
+runs. Getting the cancellation semantics right is subtle enough that the
+audio and video routes share one implementation rather than each carrying
+a copy that can drift.
+"""
+
+import asyncio
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+async def run_to_completion(func, /, *args):
+    """``asyncio.to_thread(func, *args)`` that survives cancellation.
+
+    A plain ``await asyncio.to_thread(...)`` is NOT cancellable — the
+    worker thread keeps running — but the await returns immediately when
+    the surrounding task is cancelled. That combination is dangerous for
+    the generation lanes, where a client disconnect cancels the handler
+    mid-render:
+
+    * an ``async with`` lock around the await would unwind and admit
+      another request while the abandoned thread is still using the
+      cached engine (or running a multi-GB subprocess), destroying the
+      one-at-a-time memory guarantee the lock exists to provide, and
+    * a ``finally`` block would delete the temp file or directory the
+      abandoned worker is still writing into.
+
+    So on cancellation we wait for the worker to actually finish before
+    propagating, keeping "lock held" and "output path alive" true for
+    exactly as long as the thread is running. The client is already gone,
+    so the extra wait costs nothing user-visible, and it is bounded by
+    the engine's own timeout.
+    """
+    task = asyncio.ensure_future(asyncio.to_thread(func, *args))
+    try:
+        return await asyncio.shield(task)
+    except asyncio.CancelledError:
+        # Drain the worker (ignoring its outcome — nobody is listening)
+        # before letting the cancellation unwind our lock + cleanup.
+        try:
+            await task
+        except Exception:
+            logger.debug("Abandoned worker finished with an error", exc_info=True)
+        raise

--- a/vllm_mlx/routes/audio.py
+++ b/vllm_mlx/routes/audio.py
@@ -1,18 +1,22 @@
 # SPDX-License-Identifier: Apache-2.0
 """Audio endpoints (STT/TTS)."""
 
+import asyncio
 import base64
 import binascii
+import io
 import logging
 import os
 import re
 import tempfile
+import wave
 
 from fastapi import APIRouter, Body, Depends, Form, HTTPException, Query, UploadFile
 from starlette.responses import PlainTextResponse, Response
 
-from ..api.models import AudioSpeechRequest
+from ..api.models import AudioMusicRequest, AudioSpeechRequest
 from ..middleware.auth import verify_api_key
+from ._async_utils import run_to_completion
 
 logger = logging.getLogger(__name__)
 
@@ -148,6 +152,7 @@ _AUDIO_READ_CHUNK_SIZE = 1024 * 1024  # 1 MB chunks
 # Audio engines (lazy loaded, module-level to persist across requests)
 _stt_engine = None
 _tts_engine = None
+_music_engine = None
 
 # OpenAI-style STT model alias → MLX repo. Promoted to module scope so
 # the route can validate the model BEFORE streaming the upload (F-165):
@@ -2038,6 +2043,235 @@ async def create_speech(request: AudioSpeechRequest = Body(...)):
                 }
             },
         )
+
+
+# ---------------------------------------------------------------------------
+# Third audio lane: text→music / text→SFX (``/v1/audio/music``).
+#
+# Wired to ``vllm_mlx.audio.music.MusicEngine`` (MLX-native Stable Audio
+# 3). OpenAI-flavored: JSON body in, WAV bytes out — the same
+# request-in / audio-bytes-out shape as ``/v1/audio/speech``. The
+# ``model`` field selects a DiT/decoder pairing via the alias table
+# below; unknown values fall back to the engine defaults.
+# ---------------------------------------------------------------------------
+
+#: ``model`` alias → ``(dit, decoder)`` pairing for SA3. ``medium`` is
+#: higher quality (~3.9 GB peak); ``sm-music`` / ``sm-sfx`` are the fast
+#: small variants (~1.7 GB, ~4x realtime). Kept local to the route (not
+#: in the audio registry, whose closed schema is stt/tts-typed) so adding
+#: a music variant is a one-line edit here. ``default`` maps to the
+#: engine's own defaults.
+MUSIC_MODEL_ALIASES: dict[str, tuple[str, str]] = {
+    "medium": ("medium", "same-l"),
+    "same-l": ("medium", "same-l"),
+    "sm-music": ("sm-music", "same-s"),
+    "sm-sfx": ("sm-sfx", "same-s"),
+    "same-s": ("sm-music", "same-s"),
+    "default": ("medium", "same-l"),
+}
+
+#: Fallback when ``model`` isn't a known music alias — the SA3 defaults.
+DEFAULT_MUSIC_DIT_DECODER: tuple[str, str] = ("medium", "same-l")
+
+#: Serialises music generation. ``MusicEngine.generate`` shells out to the
+#: vendored SA3 CLI, which peaks at ~3.9 GB (``medium``) — two concurrent
+#: requests would run two such subprocesses and can exhaust unified memory
+#: on a base-config Mac. Also guards the ``_music_engine`` global, mutated
+#: from a worker thread.
+#:
+#: An ``asyncio.Lock`` acquired ON THE EVENT LOOP, deliberately not a
+#: ``threading.Lock`` held inside the worker. ``asyncio.to_thread`` uses
+#: the shared default executor (min(32, cpu+4) threads), so queued
+#: requests blocking on a thread-level lock would each pin an executor
+#: thread just to wait — starving every other ``to_thread`` user in the
+#: process (prefix-cache save, tool-grammar warmup, the diffusion lane).
+#: With a 900 s render ceiling that is a long time to hold threads other
+#: subsystems need. Waiting on the loop instead costs a coroutine, and
+#: only the request that actually runs ever occupies an executor slot.
+#:
+#: Lazily created because the module imports before any event loop exists
+#: and an ``asyncio.Lock`` must be bound to the running loop.
+_music_lock: asyncio.Lock | None = None
+
+
+def _get_music_lock() -> asyncio.Lock:
+    """Return the process-wide music lock, creating it on first use."""
+    global _music_lock
+    if _music_lock is None:
+        _music_lock = asyncio.Lock()
+    return _music_lock
+
+
+def _generate_music_blocking(
+    dit: str,
+    decoder: str,
+    out_path: str,
+    request: AudioMusicRequest,
+) -> None:
+    """Blocking half of ``/v1/audio/music`` — runs on a worker thread.
+
+    ``MusicEngine.generate`` spawns the vendored Stable Audio 3 CLI and
+    waits on it (default timeout 900 s). Calling that inline from the
+    ``async def`` handler would stall the event loop for the entire
+    render — every concurrent chat completion, ``/healthz`` probe and SSE
+    heartbeat with it — so the handler hands it to
+    :func:`asyncio.to_thread`.
+
+    The caller holds :data:`_music_lock` for the whole call, so this body
+    is already serialised — no thread-level locking here (see the lock's
+    own comment for why it lives on the event loop).
+    """
+    global _music_engine
+
+    from ..audio.music import MusicEngine
+
+    if (
+        _music_engine is None
+        or _music_engine.dit != dit
+        or _music_engine.decoder != decoder
+    ):
+        _music_engine = MusicEngine(dit=dit, decoder=decoder)
+
+    _music_engine.generate(
+        request.input,
+        out_path,
+        seconds=request.seconds,
+        steps=request.steps,
+        negative_prompt=request.negative_prompt,
+        seed=request.seed,
+    )
+
+
+def _wav_has_audio_frames(payload: bytes) -> bool:
+    """True if ``payload`` is a parseable WAV with at least one sample frame.
+
+    Rejects both empty-output failure modes: SA3 exiting 0 having written
+    only a RIFF header (~44 bytes, which passes a non-empty-bytes check
+    but contains no audio), and output that isn't a readable WAV at all.
+
+    Fail-CLOSED on a parse error, because the producer and this check use
+    the same parser: SA3's ``save_wav`` writes 16-bit PCM via
+    ``wave.open`` (see ``audio/sa3/scripts/sa3_mlx.py``). So anything
+    ``wave`` can't read is not SA3 output, and handing it back under
+    ``Content-Type: audio/wav`` would be mislabelling bytes rather than
+    tolerating an exotic container.
+    """
+    try:
+        with wave.open(io.BytesIO(payload), "rb") as w:
+            return w.getnframes() > 0
+    except (wave.Error, EOFError, OSError):
+        return False
+
+
+def _resolve_music_model(model: str | None) -> tuple[str, str]:
+    """Map a ``/v1/audio/music`` ``model`` alias to a ``(dit, decoder)`` pair.
+
+    Recognises the :data:`MUSIC_MODEL_ALIASES` short names
+    (case-insensitively). ``None`` / ``""`` / ``"default"`` and any
+    unknown value fall back to :data:`DEFAULT_MUSIC_DIT_DECODER` (SA3's
+    own defaults) so an unfamiliar ``model`` still produces audio rather
+    than 404-ing — matching the TTS route's tolerant passthrough.
+    """
+    if not model:
+        return DEFAULT_MUSIC_DIT_DECODER
+    return MUSIC_MODEL_ALIASES.get(model.lower(), DEFAULT_MUSIC_DIT_DECODER)
+
+
+@router.post("/v1/audio/music", dependencies=[Depends(verify_api_key)])
+async def create_music(request: AudioMusicRequest = Body(...)):
+    """Generate music / SFX from a text prompt.
+
+    OpenAI-flavored: a JSON body (:class:`AudioMusicRequest`) in, WAV
+    bytes out — the same request-in / audio-bytes-out contract as
+    ``/v1/audio/speech``. Wired to
+    :class:`vllm_mlx.audio.music.MusicEngine` (MLX-native Stable Audio
+    3), which renders ``seconds`` of audio for ``input`` to a temp file
+    that we stream back as ``audio/wav``.
+
+    ``model`` selects the DiT/decoder pairing (see
+    :data:`MUSIC_MODEL_ALIASES`); ``input`` (non-blank), ``seconds``
+    (≤47s), ``steps``, ``negative_prompt`` and ``seed`` are validated by
+    the request model. Backend failures surface a 500 with the OpenAI
+    ``api_error`` envelope (``code="music_generation_failed"``), matching
+    the speech route.
+    """
+    dit, decoder = _resolve_music_model(request.model)
+
+    tmp_path: str | None = None
+    try:
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".wav") as tmp:
+            tmp_path = tmp.name
+
+        # Engine load + render are blocking (a subprocess, up to 900 s) —
+        # off the event loop. Serialised on the loop before offloading so
+        # queued renders don't each pin a shared executor thread.
+        # See _generate_music_blocking and _music_lock.
+        async with _get_music_lock():
+            await run_to_completion(
+                _generate_music_blocking, dit, decoder, tmp_path, request
+            )
+
+        audio_bytes = b""
+        if os.path.exists(tmp_path):
+            with open(tmp_path, "rb") as fh:
+                audio_bytes = fh.read()
+
+        # The SA3 CLI can exit 0 having written nothing, a 0-byte
+        # placeholder, or a valid RIFF header with zero sample frames —
+        # a sampler that bailed right after opening the file. All three
+        # must fail loudly: handing back an HTTP 200 with an empty or
+        # frameless ``audio/wav`` body reads to the caller as a
+        # successfully generated silent clip, which is the failure mode
+        # hardest to notice. A byte-count check alone misses the
+        # header-only case (a bare WAV header is ~44 bytes), so count
+        # actual frames.
+        if not audio_bytes or not _wav_has_audio_frames(audio_bytes):
+            raise RuntimeError(
+                f"music engine produced no audio at {tmp_path} "
+                f"(dit={dit!r}, decoder={decoder!r}, "
+                f"{len(audio_bytes)} bytes)"
+            )
+
+        # SA3 emits WAV; ``response_format`` is validated to ``wav`` by
+        # the request model, so the Content-Type is always ``audio/wav``.
+        return Response(content=audio_bytes, media_type="audio/wav")
+
+    except HTTPException:
+        raise
+    except ImportError as e:
+        raise HTTPException(
+            status_code=503,
+            detail=(
+                f"music engine dependencies unavailable at runtime: {e}. "
+                "Install with: pip install 'rapid-mlx[audio]'"
+            ),
+        )
+    except Exception as e:
+        # Mirror the speech route: full traceback to the operator log,
+        # generic OpenAI-shape envelope to the client so we don't leak
+        # subprocess/filesystem internals.
+        logger.exception("Music generation failed: %s", e)
+        raise HTTPException(
+            status_code=500,
+            detail={
+                "error": {
+                    "message": "Audio music generation failed",
+                    "type": "api_error",
+                    "code": "music_generation_failed",
+                    "param": None,
+                }
+            },
+        )
+    finally:
+        if tmp_path is not None:
+            try:
+                os.unlink(tmp_path)
+            except FileNotFoundError:
+                pass
+            except OSError as cleanup_err:
+                logger.warning(
+                    "Failed to unlink temp music file %s: %s", tmp_path, cleanup_err
+                )
 
 
 @router.get("/v1/audio/voices", dependencies=[Depends(verify_api_key)])


### PR DESCRIPTION
## Why
`main` has carried `MusicEngine` and the vendored Stable Audio 3 tree since #1307, but with **no HTTP surface** — the only way to reach text→music was to import the class. This adds the route.

Ported from #1300, which landed on the now-retired `mvp/content-farm-local` branch and never reached `main`. That branch went through six rounds of codex review; the fixes below all came out of it, and none are cosmetic.

## What

`POST /v1/audio/music` — OpenAI-flavored, mirroring `/v1/audio/speech`: JSON body in, WAV bytes out.

```bash
curl -s localhost:8000/v1/audio/music \
  -H 'Content-Type: application/json' \
  -d '{"model":"sm-music","input":"lofi house loop","seconds":20,"steps":8}' \
  --output bgm.wav
```

`model` selects the DiT/decoder pairing (`medium` = higher quality, `sm-music` / `sm-sfx` = fast small); unknown values fall back to the engine defaults, matching the TTS route's tolerant passthrough.

## The parts that aren't obvious

**Concurrency.** `MusicEngine.generate` shells out to the SA3 CLI and waits (default timeout 900 s). Inline in the `async def` handler that froze the entire event loop — every concurrent chat completion, `/healthz` probe and SSE heartbeat with it. Now `asyncio.to_thread`, serialised by an `asyncio.Lock` taken **on the loop** before offloading: a `threading.Lock` inside the worker pins one shared-executor thread per queued request and starves every other `to_thread` user in the process. The lock also prevents two multi-GB SA3 subprocesses running at once, which can exhaust unified memory on a base-config Mac.

**Cancellation.** `await asyncio.to_thread(...)` returns immediately when the handler is cancelled — a client disconnect does exactly that — while the subprocess keeps running. That released the lock and unlinked the temp file *under a live render*. `routes/_async_utils.py::run_to_completion` shields and drains the worker first, so "lock held" and "temp file alive" stay true for exactly as long as the thread runs.

**An empty render used to look like success.** The SA3 CLI can exit 0 having written nothing, or only a RIFF header (~44 bytes) with zero sample frames. A byte-count check passes the latter, and it plays as silence — indistinguishable from a real quiet track, which is the worst kind of failure. Both are now `500 music_generation_failed`. The check fails **closed** on an unparseable WAV: SA3's own `save_wav` writes 16-bit PCM through `wave.open`, so anything `wave` can't read is not SA3 output, and returning it under `Content-Type: audio/wav` would be mislabelling bytes.

**Two input bounds.** `input` becomes an argv element for the CLI, so unbounded it hits `ARG_MAX` as an opaque 500 — capped at 4096 like `negative_prompt`. And `seconds` needs an explicit `math.isfinite` check, because Pydantic's `gt=` / `le=` do **not** reject NaN (every NaN comparison is False), so `seconds=NaN` slipped past the bounds into the engine.

## Tests

16 hermetic tests in `tests/test_audio_music_route.py` — engine faked at the import boundary, so no SA3 weights, no subprocess, no network. Covers the happy path, alias→(dit,decoder) mapping, the empty-output and header-only-output 500s, the event-loop offload (asserted structurally: the engine must observe a different thread than the loop), and input validation.

Added to the **apple-silicon** CI job. Both CI test lists are explicit allowlists, so a file in neither never runs — and these are hermetic but *not* mlx-free, since `vllm_mlx.config` pulls in `engine_core`'s `import mlx.core`.

`tests/test_audio_route_registration_gate.py` updated: `/v1/audio/music` is now part of the audio router's public path set.

## Notes
- Scoped deliberately to music. The forced-alignment hardening from the same source PR touches the same file and is a separate change (`feat/align-route-hardening`) — I'm sequencing the merges to keep the conflict resolution mine rather than git's.
- Pre-existing on `main` and untouched here: 3 `test_audio_upload_size_limit` failures (no local `mlx_audio`) and `test_no_routing_shaped_rapid_mlx_env_vars` (`RAPID_MLX_ESPEAK_LIB` / `_ESPEAK_DATA` from #1312 aren't in the allowlist). Both reproduce on a clean `main`.

🤖 Route, tests and docs by Claude Code (Opus 5), reviewed by the author.
