### PR TITLE
fix(audio): harden the forced-alignment lane on /v1/audio/transcriptions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,6 +187,7 @@ jobs:
             tests/test_no_mllm_flag.py \
             tests/test_audio_music_route.py \
             tests/test_audio_route_registration_gate.py \
+            tests/test_forced_alignment_route_hardening.py \
             -v --tb=short \
             -m "not slow" \
             -k "not Integration"

--- a/tests/test_forced_alignment.py
+++ b/tests/test_forced_alignment.py
@@ -316,8 +316,13 @@ def _stub_route_engine(monkeypatch):
         monkeypatch.setattr(audio_stt_mod, "STTEngine", _FakeRouteEngine)
 
     audio_route._stt_engine = None
+    # The alignment lane keeps its OWN engine cache (see the module
+    # comment on ``_aligner_engine``), so both must be cleared — leaving
+    # the stub in ``_aligner_engine`` would leak into later tests.
+    audio_route._aligner_engine = None
     yield
     audio_route._stt_engine = None
+    audio_route._aligner_engine = None
     probe._reset_probe_cache()
 
 

--- a/tests/test_forced_alignment_route_hardening.py
+++ b/tests/test_forced_alignment_route_hardening.py
@@ -1,0 +1,1136 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Forced-alignment HTTP lane hardening — ``/v1/audio/transcriptions`` + ``text``.
+
+``tests/test_forced_alignment.py`` covers the engine surface and the
+happy-path route contract. This suite pins the properties of the
+dedicated alignment lane (``_run_alignment_request``) that are easy to
+regress silently:
+
+* the blocking weight load + ``align()`` run OFF the event loop, and a
+  cancelled request drains its worker before the lock and the temp file
+  are released;
+* the aligner is cached in its OWN global, never the shared
+  ``_stt_engine`` the ASR lane mutates from the event loop, and a failed
+  ``load()`` is not published into that cache;
+* error classification order — a corrupted upload is reported as a
+  corrupted upload, an internal ``ValueError`` is a 500, and only the two
+  documented ``align()`` rejections become a 400;
+* the "just send audio + text" defaults (aligner model, ``verbose_json``)
+  including whitespace-only ``model`` / ``response_format``;
+* a present-but-blank ``text`` is a 400 rather than a silent ASR answer;
+* calling the handler directly (no ASGI stack) tolerates the unresolved
+  ``Form(None)`` / ``Query(None)`` sentinels.
+
+Hermetic — engines are faked at the import boundary, no weights or
+network.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.machinery
+import io
+import math
+import struct
+import sys
+import threading
+import types
+import wave
+
+import pytest
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+
+pytestmark = pytest.mark.skipif(
+    sys.platform != "darwin",
+    reason="requires the MLX runtime available on Apple Silicon",
+)
+
+_ALIGNER_ID = "mlx-community/Qwen3-ForcedAligner-0.6B-8bit"
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_tone_wav(duration_s: float = 0.25, freq_hz: float = 440.0) -> bytes:
+    sample_rate = 16000
+    n_samples = int(sample_rate * duration_s)
+    buf = io.BytesIO()
+    with wave.open(buf, "wb") as w:
+        w.setnchannels(1)
+        w.setsampwidth(2)
+        w.setframerate(sample_rate)
+        for i in range(n_samples):
+            sample = int(8000 * math.sin(2 * math.pi * freq_hz * i / sample_rate))
+            w.writeframes(struct.pack("<h", sample))
+    return buf.getvalue()
+
+
+def _install_fake_mlx_audio(monkeypatch):
+    """Make the STT-lane probe (``require_mlx_audio_stt``) pass without a
+    real ``mlx_audio`` install."""
+    fake_mlx_audio = types.ModuleType("mlx_audio")
+    fake_mlx_audio.__path__ = []
+    fake_mlx_audio.__spec__ = importlib.machinery.ModuleSpec(
+        "mlx_audio", loader=None, is_package=True
+    )
+    fake_stt = types.ModuleType("mlx_audio.stt")
+    fake_stt.__path__ = []
+    fake_stt.__spec__ = importlib.machinery.ModuleSpec(
+        "mlx_audio.stt", loader=None, is_package=True
+    )
+    fake_stt_utils = types.ModuleType("mlx_audio.stt.utils")
+    fake_stt_utils.__spec__ = importlib.machinery.ModuleSpec(
+        "mlx_audio.stt.utils", loader=None
+    )
+    fake_stt_utils.load_model = lambda *_a, **_kw: None
+    monkeypatch.setitem(sys.modules, "mlx_audio", fake_mlx_audio)
+    monkeypatch.setitem(sys.modules, "mlx_audio.stt", fake_stt)
+    monkeypatch.setitem(sys.modules, "mlx_audio.stt.utils", fake_stt_utils)
+
+
+def _patch_engine(monkeypatch, engine_cls):
+    """Swap ``STTEngine`` at the import boundary the route resolves."""
+    monkeypatch.setattr("vllm_mlx.audio.stt.STTEngine", engine_cls, raising=False)
+    stt_mod = sys.modules.get("vllm_mlx.audio.stt")
+    if stt_mod is not None:
+        monkeypatch.setattr(stt_mod, "STTEngine", engine_cls)
+
+
+def _mount_audio_app() -> tuple[TestClient, callable]:
+    """Mount the audio router on a bare FastAPI app, bypassing auth."""
+    from vllm_mlx.config import get_config
+    from vllm_mlx.routes import audio as audio_route
+
+    app = FastAPI()
+    app.include_router(audio_route.router)
+    cfg = get_config()
+    saved = cfg.api_key
+    cfg.api_key = None
+
+    def _restore():
+        cfg.api_key = saved
+
+    return TestClient(app), _restore
+
+
+class _UploadLike:
+    """Minimal stand-in for ``UploadFile`` — only ``read`` is exercised by
+    ``_stream_upload_to_tempfile``."""
+
+    def __init__(self, payload: bytes):
+        self._buf = io.BytesIO(payload)
+
+    async def read(self, size: int = -1) -> bytes:
+        return self._buf.read(size)
+
+
+def _patch_engine_direct(audio_route, engine_cls):
+    """Swap ``STTEngine`` without monkeypatch, for use inside ``asyncio.run``.
+
+    Mutates the real module, so the ``_fake_audio_env`` fixture restores the
+    original on teardown — an earlier version of this helper did not, and it
+    silently broke every later test file that imports ``STTEngine`` (six
+    failures in ``test_forced_alignment.py`` that vanished when that file ran
+    alone).
+
+    Also clears both engine caches so the next call constructs the new class
+    rather than reusing whatever a previous test left resident.
+    """
+    import vllm_mlx.audio.stt as stt_mod
+
+    stt_mod.STTEngine = engine_cls
+    audio_route._stt_engine = None
+    audio_route._aligner_engine = None
+
+
+class _FakeAlignResult:
+    def __init__(self, text, segments, language, duration):
+        self.text = text
+        self.segments = segments
+        self.language = language
+        self.duration = duration
+
+
+class _FakeAlignerEngine:
+    """Mirrors the ``STTEngine`` surface the alignment path touches."""
+
+    last_call: dict | None = None
+    #: Set when ``transcribe`` runs, so a test can assert the ASR branch
+    #: was taken AND that it produced a real result — not merely that
+    #: ``align`` was skipped.
+    last_transcribe: dict | None = None
+
+    def __init__(self, model_name):
+        self.model_name = model_name
+
+    def load(self):
+        pass
+
+    def align(self, audio_path, text, language="Chinese"):
+        _FakeAlignerEngine.last_call = {
+            "audio_path": str(audio_path),
+            "text": text,
+            "language": language,
+        }
+        segments = [
+            {"text": ch, "start": round(i * 0.2, 3), "end": round((i + 1) * 0.2, 3)}
+            for i, ch in enumerate(text)
+        ]
+        duration = segments[-1]["end"] if segments else 0.0
+        return _FakeAlignResult(text, segments, language, duration)
+
+    def transcribe(self, audio_path, language=None, task="transcribe"):
+        _FakeAlignerEngine.last_transcribe = {
+            "audio_path": str(audio_path),
+            "language": language,
+            "task": task,
+        }
+        return _FakeAlignResult(
+            "recognised speech",
+            [{"text": "recognised speech", "start": 0.0, "end": 1.0}],
+            language or "en",
+            1.0,
+        )
+
+
+@pytest.fixture
+def _stub_aligner(monkeypatch):
+    from vllm_mlx.audio import probe
+    from vllm_mlx.routes import audio as audio_route
+
+    _install_fake_mlx_audio(monkeypatch)
+    probe._reset_probe_cache()
+    _patch_engine(monkeypatch, _FakeAlignerEngine)
+    _FakeAlignerEngine.last_call = None
+    _FakeAlignerEngine.last_transcribe = None
+    audio_route._stt_engine = None
+    audio_route._aligner_engine = None
+    yield
+    audio_route._stt_engine = None
+    audio_route._aligner_engine = None
+    probe._reset_probe_cache()
+
+
+@pytest.fixture
+def _fake_audio_env(monkeypatch):
+    """Probe + engine-cache reset without binding a specific engine — for
+    tests that install their own failure-shaped engine."""
+    import vllm_mlx.audio.stt as stt_mod
+    from vllm_mlx.audio import probe
+    from vllm_mlx.routes import audio as audio_route
+
+    _install_fake_mlx_audio(monkeypatch)
+    probe._reset_probe_cache()
+    real_engine = stt_mod.STTEngine
+    audio_route._stt_engine = None
+    audio_route._aligner_engine = None
+    yield audio_route
+    # Restore the real class: _patch_engine_direct assigns it outright, and
+    # leaking a fake here breaks every later test file that imports it.
+    stt_mod.STTEngine = real_engine
+    audio_route._stt_engine = None
+    audio_route._aligner_engine = None
+    probe._reset_probe_cache()
+
+
+def _post(client, data, payload: bytes | None = None):
+    return client.post(
+        "/v1/audio/transcriptions",
+        data=data,
+        files={
+            "file": (
+                "clip.wav",
+                _make_tone_wav() if payload is None else payload,
+                "audio/wav",
+            )
+        },
+    )
+
+
+def _err(response) -> dict:
+    body = response.json()
+    return body.get("detail", {}).get("error") or body.get("error")
+
+
+# ---------------------------------------------------------------------------
+# Defaults: "just send audio + text"
+# ---------------------------------------------------------------------------
+
+
+class TestAlignmentDefaults:
+    def test_text_field_alone_aligns_and_defaults_to_verbose_json(self, _stub_aligner):
+        """``text`` with no ``model`` / ``response_format`` must still align.
+
+        The plain ``json`` envelope drops ``segments``, so defaulting
+        ``response_format`` to it would return a 200 with none of the
+        timestamps the caller came for.
+        """
+        client, restore = _mount_audio_app()
+        try:
+            r = _post(client, {"text": "临终前", "language": "Chinese"})
+        finally:
+            restore()
+        assert r.status_code == 200, r.text
+        assert r.headers["content-type"].startswith("application/json")
+        body = r.json()
+        assert body["text"] == "临终前"
+        assert isinstance(body["segments"], list)
+        assert len(body["segments"]) == 3, body["segments"]
+        # Compare field-by-field: the verbose_json serializer also stamps an
+        # ``id`` on every segment (part of the OpenAI shape), so an equality
+        # assertion against a bare {text,start,end} dict is testing the
+        # fixture rather than the contract.
+        first = body["segments"][0]
+        assert first["text"] == "临"
+        assert first["start"] == 0.0
+        assert first["end"] == 0.2
+        assert first["id"] == 0
+        # The known transcript was forwarded as an INPUT (no recognition).
+        call = _FakeAlignerEngine.last_call
+        assert call["text"] == "临终前"
+        assert call["language"] == "Chinese"
+        assert _FakeAlignerEngine.last_transcribe is None
+
+    def test_omitted_model_resolves_to_the_registered_aligner(self, _stub_aligner):
+        """No ``model`` → the ALIGNER alias, not the ASR default.
+
+        ``whisper-large-v3`` is not a forced aligner, so defaulting the
+        alignment branch to it would fail deep in ``STTEngine.align``.
+        """
+        from vllm_mlx.routes import audio as audio_route
+
+        client, restore = _mount_audio_app()
+        try:
+            r = _post(client, {"text": "abc"})
+        finally:
+            restore()
+        assert r.status_code == 200, r.text
+        # The aligner lives in its own cache, deliberately NOT the shared
+        # ``_stt_engine`` the ASR lane mutates from the event loop.
+        assert audio_route._stt_engine is None, audio_route._stt_engine
+        assert "ForcedAligner" in audio_route._aligner_engine.model_name, (
+            audio_route._aligner_engine.model_name
+        )
+
+    @pytest.mark.parametrize("blank", ["", "   "])
+    def test_blank_model_takes_the_aligner_default(self, _stub_aligner, blank):
+        """A BLANK ``model`` must behave as omitted, not error.
+
+        ``""`` is already absorbed by FastAPI (it coerces an empty form
+        field to ``None`` for an ``Optional[str]``) — kept here to pin
+        that boundary. ``"   "`` is the one that actually leaks: it
+        arrives verbatim and would reach ``_resolve_stt_model`` as an
+        explicit choice, 404-ing as a nonexistent alias, so "just send
+        audio + text" from a form with a spaced-out field never aligns.
+        """
+        from vllm_mlx.routes import audio as audio_route
+
+        client, restore = _mount_audio_app()
+        try:
+            r = _post(client, {"text": "abc", "model": blank})
+        finally:
+            restore()
+        assert r.status_code == 200, r.text
+        assert audio_route._stt_engine is None, audio_route._stt_engine
+        assert "ForcedAligner" in audio_route._aligner_engine.model_name, (
+            audio_route._aligner_engine.model_name
+        )
+
+    def test_blank_response_format_takes_verbose_json(self, _stub_aligner):
+        """A whitespace-only ``response_format`` must fall back to verbose_json.
+
+        Same shape as the ``model`` case above: ``"   "`` would otherwise
+        count as an explicit choice, reach the allowed-set check and 400 —
+        losing the timestamps the caller came for.
+        """
+        client, restore = _mount_audio_app()
+        try:
+            r = _post(client, {"text": "abc", "response_format": "   "})
+        finally:
+            restore()
+        assert r.status_code == 200, r.text
+        assert isinstance(r.json()["segments"], list), r.text
+
+    def test_explicit_response_format_is_honoured(self, _stub_aligner):
+        """An explicit srt must win over the alignment default."""
+        client, restore = _mount_audio_app()
+        try:
+            r = _post(client, {"text": "abc", "response_format": "srt"})
+        finally:
+            restore()
+        assert r.status_code == 200, r.text
+        assert "00:00:00,000 --> 00:00:00,200" in r.text, r.text
+
+    def test_blank_model_does_not_leak_into_the_asr_path(self, _stub_aligner):
+        """The blank-model default is scoped to the alignment branch.
+
+        The ASR path's handling of a whitespace-only ``model`` is
+        long-standing contract (a 404 for a nonexistent alias) and must
+        not change just because the alignment branch relaxed it.
+        """
+        client, restore = _mount_audio_app()
+        try:
+            r = _post(client, {"model": "   "})
+        finally:
+            restore()
+        assert r.status_code == 404, r.text
+        assert _err(r)["code"] == "model_not_found", r.text
+
+
+# ---------------------------------------------------------------------------
+# A present-but-blank ``text`` is never a silent ASR answer
+# ---------------------------------------------------------------------------
+
+
+class TestBlankTextIsRejected:
+    def test_blank_text_without_model_is_400_not_a_silent_asr_fallback(
+        self, _stub_aligner
+    ):
+        """Sending ``text`` says "I have the transcript, give me timings".
+
+        A whitespace-only value used to fall through to speech
+        recognition whenever ``model`` was not an aligner, returning 200 —
+        answering a different question with no signal that the request had
+        been reinterpreted.
+        """
+        client, restore = _mount_audio_app()
+        try:
+            r = _post(client, {"text": "   "})
+        finally:
+            restore()
+        assert r.status_code == 400, r.text
+        err = _err(r)
+        assert err["type"] == "invalid_request_error", err
+        assert err["code"] == "alignment_text_required", err
+        assert err["param"] == "text", err
+        # Neither engine path ran.
+        assert _FakeAlignerEngine.last_call is None
+        assert _FakeAlignerEngine.last_transcribe is None
+
+    def test_blank_text_with_asr_model_is_also_400(self, _stub_aligner):
+        """Same rejection when an ASR model is named explicitly.
+
+        This is the combination that previously slipped through: the
+        blank-text guard only fired for aligner models.
+        """
+        client, restore = _mount_audio_app()
+        try:
+            r = _post(client, {"text": "  \t ", "model": "whisper-large-v3"})
+        finally:
+            restore()
+        assert r.status_code == 400, r.text
+        assert _err(r)["code"] == "alignment_text_required", r.text
+        assert _FakeAlignerEngine.last_transcribe is None
+
+    def test_absent_text_is_still_asr(self, _stub_aligner):
+        """Absent ``text`` → unchanged ASR, positively verified.
+
+        Asserts the ASR branch actually SUCCEEDS and returns recognised
+        text, not merely that ``align()`` was skipped.
+        """
+        client, restore = _mount_audio_app()
+        try:
+            r = _post(
+                client,
+                {"model": "whisper-large-v3", "response_format": "verbose_json"},
+            )
+        finally:
+            restore()
+        assert r.status_code == 200, r.text
+        assert r.json()["text"] == "recognised speech", r.text
+        assert _FakeAlignerEngine.last_transcribe is not None
+        assert _FakeAlignerEngine.last_call is None
+
+
+# ---------------------------------------------------------------------------
+# Error classification — order matters
+# ---------------------------------------------------------------------------
+
+
+class TestAlignmentErrorClassification:
+    def test_decode_error_is_invalid_audio_file_not_alignment_request(
+        self, _fake_audio_env, monkeypatch
+    ):
+        """Decoder ValueErrors must not be mislabelled as a bad request.
+
+        Some codec paths raise plain ``ValueError`` for undecodable audio.
+        The decode check therefore has to run BEFORE the alignment-request
+        classifier, or a corrupted upload comes back as
+        ``invalid_alignment_request`` blaming ``model``/``text`` — sending
+        the caller to fix a field that was never wrong.
+        """
+
+        class _DecodeFailingEngine:
+            def __init__(self, model_name):
+                self.model_name = model_name
+
+            def load(self):
+                pass
+
+            def align(self, audio_path, text, language="Chinese"):
+                # The shape a codec raises on a truncated/garbage file.
+                raise ValueError(
+                    "Error opening file: File contains data in an unknown format."
+                )
+
+        _patch_engine(monkeypatch, _DecodeFailingEngine)
+        client, restore = _mount_audio_app()
+        try:
+            r = _post(
+                client,
+                {"text": "abc", "model": "qwen3-aligner"},
+                payload=b"not-a-wav",
+            )
+        finally:
+            restore()
+
+        assert r.status_code == 400, r.text
+        err = _err(r)
+        # Assert the EXACT documented decode envelope, not merely
+        # "something other than invalid_alignment_request" — a weaker
+        # assertion would be satisfied by any unrelated error.
+        assert err["type"] == "invalid_request_error", err
+        assert err["code"] == "invalid_audio_file", err
+        assert err["param"] == "file", err
+
+    def test_unexpected_value_error_is_500_not_invalid_request(
+        self, _fake_audio_env, monkeypatch
+    ):
+        """An internal ValueError must not be blamed on ``model`` / ``text``.
+
+        ``align()`` raises ValueError for exactly two caller mistakes. A
+        ValueError from anywhere else (weight loading, tokenizing, a
+        reshape) is an internal fault; reporting it as
+        ``invalid_alignment_request`` sends the caller to fix a field that
+        was never wrong.
+        """
+
+        class _InternallyBrokenEngine:
+            def __init__(self, model_name):
+                self.model_name = model_name
+
+            def load(self):
+                pass
+
+            def align(self, audio_path, text, language="Chinese"):
+                # Nothing to do with the caller's model or text.
+                raise ValueError("cannot reshape array of size 0 into shape (1,80)")
+
+        _patch_engine(monkeypatch, _InternallyBrokenEngine)
+        client, restore = _mount_audio_app()
+        try:
+            r = _post(client, {"text": "abc", "model": "qwen3-aligner"})
+        finally:
+            restore()
+
+        assert r.status_code == 500, r.text
+        err = _err(r)
+        assert err["code"] == "alignment_failed", err
+        assert err["type"] == "api_error", err
+
+    def test_engine_side_rejection_is_a_400_backstop(
+        self, _fake_audio_env, monkeypatch
+    ):
+        """A documented ``align()`` rejection stays a 400, not an envelope-less 500.
+
+        The route's own ``_is_aligner_model`` guard is the primary path,
+        but it is a substring heuristic over the resolved repo id. A repo
+        that satisfies it while the engine's own predicate refuses (or any
+        future divergence between the two) must still produce the
+        documented client envelope rather than a generic 500.
+        """
+
+        class _RefusingEngine:
+            def __init__(self, model_name):
+                self.model_name = model_name
+
+            def load(self):
+                pass
+
+            def align(self, audio_path, text, language="Chinese"):
+                raise ValueError(
+                    f"align() requires a forced-aligner model; {self.model_name!r} "
+                    "is not one (use a registry alias like 'qwen3-aligner')."
+                )
+
+        _patch_engine(monkeypatch, _RefusingEngine)
+        client, restore = _mount_audio_app()
+        try:
+            # Passes the route's substring guard, refused by the engine.
+            r = _post(client, {"text": "abc", "model": "acme/pretend-aligner-0.6b"})
+        finally:
+            restore()
+
+        assert r.status_code == 400, r.text
+        err = _err(r)
+        assert err["type"] == "invalid_request_error", err
+        assert err["code"] == "invalid_alignment_request", err
+        assert err["param"] == "model", err
+
+    def test_non_aligner_model_with_text_400s_before_the_upload_drains(
+        self, _fake_audio_env, monkeypatch
+    ):
+        """``text`` + an ASR model rejects without touching the engine."""
+
+        class _Boom:
+            def __init__(self, model_name):  # pragma: no cover - must not run
+                raise AssertionError("engine must not be constructed")
+
+        _patch_engine(monkeypatch, _Boom)
+        client, restore = _mount_audio_app()
+        try:
+            r = _post(client, {"text": "hello", "model": "whisper-large-v3"})
+        finally:
+            restore()
+        assert r.status_code == 400, r.text
+        err = _err(r)
+        assert err["code"] == "alignment_model_required", err
+        assert err["param"] == "model", err
+
+
+# ---------------------------------------------------------------------------
+# Engine cache discipline
+# ---------------------------------------------------------------------------
+
+
+class TestAlignerEngineCache:
+    def test_failed_load_is_not_published_to_the_cache(
+        self, _fake_audio_env, monkeypatch
+    ):
+        """A load that raises must leave ``_aligner_engine`` untouched.
+
+        Assigning the engine before ``load()`` would leave later requests
+        matching on ``model_name`` against an object whose weights never
+        loaded — a permanently broken cache entry that only a restart
+        clears.
+        """
+        audio_route = _fake_audio_env
+        attempts = []
+
+        class _LoadFailingEngine:
+            def __init__(self, model_name):
+                self.model_name = model_name
+                attempts.append(model_name)
+
+            def load(self):
+                raise RuntimeError("weights unavailable")
+
+            def align(self, audio_path, text, language="Chinese"):
+                raise AssertionError("align must not run after a failed load")
+
+        _patch_engine(monkeypatch, _LoadFailingEngine)
+        client, restore = _mount_audio_app()
+        try:
+            first = _post(client, {"text": "abc", "model": "qwen3-aligner"})
+            assert first.status_code == 500, first.text
+            assert audio_route._aligner_engine is None, audio_route._aligner_engine
+            # A retry must construct + load again, not reuse a corpse.
+            second = _post(client, {"text": "abc", "model": "qwen3-aligner"})
+            assert second.status_code == 500, second.text
+        finally:
+            restore()
+        assert len(attempts) == 2, attempts
+
+    def test_lanes_use_distinct_caches_and_only_one_model_stays_resident(
+        self, _stub_aligner
+    ):
+        """Two properties that sound contradictory but aren't.
+
+        DISTINCT CACHES: the lanes must never share one global. Alignment
+        runs on a worker thread while ASR runs on the event loop, so a shared
+        global could be swapped between the alignment path's cache check and
+        its ``align()`` call. Distinctness is what makes that impossible.
+
+        ONE RESIDENT: distinct caches alone would leave BOTH multi-GB models
+        in unified memory after alternating requests, on a server that can
+        only use one at a time. So loading into one lane releases the other,
+        which is safe precisely because the lane lock guarantees the released
+        engine is idle.
+        """
+        from vllm_mlx.routes import audio as audio_route
+
+        client, restore = _mount_audio_app()
+        try:
+            # Alignment populates the aligner cache only.
+            assert _post(client, {"text": "abc"}).status_code == 200
+            aligner = audio_route._aligner_engine
+            assert aligner is not None
+            assert audio_route._stt_engine is None
+
+            # ASR loads into its OWN cache and releases the aligner.
+            assert _post(client, {"model": "whisper-large-v3"}).status_code == 200
+            asr = audio_route._stt_engine
+            assert asr is not None
+            assert asr is not aligner, "the lanes are sharing one cache"
+            assert audio_route._aligner_engine is None, (
+                "the aligner stayed resident alongside the ASR model"
+            )
+
+            # Back to alignment: a fresh aligner, and ASR released.
+            assert _post(client, {"text": "def"}).status_code == 200
+            assert audio_route._aligner_engine is not None
+            assert audio_route._aligner_engine is not asr
+            assert audio_route._stt_engine is None
+        finally:
+            restore()
+
+
+# ---------------------------------------------------------------------------
+# Concurrency: blocking work must leave the event loop
+# ---------------------------------------------------------------------------
+
+
+class TestAlignmentConcurrency:
+    def test_alignment_does_not_block_the_event_loop(self, _stub_aligner):
+        """Weight load + align must run off the event loop.
+
+        Both are seconds of blocking compute; inline in the ``async def``
+        handler they stall every concurrent request on the server. Detect
+        structurally — the engine must see a different thread than the
+        loop.
+        """
+        from vllm_mlx.routes import audio as audio_route
+
+        seen: dict[str, int] = {}
+        real_align = _FakeAlignerEngine.align
+
+        def _recording_align(self, audio_path, text, language="Chinese"):
+            seen["engine_thread"] = threading.get_ident()
+            return real_align(self, audio_path, text, language=language)
+
+        async def _drive():
+            seen["loop_thread"] = threading.get_ident()
+            return await audio_route._run_alignment_request(
+                file=_UploadLike(_make_tone_wav()),
+                model="qwen3-aligner",
+                text="abc",
+                language=None,
+                response_format="verbose_json",
+            )
+
+        _FakeAlignerEngine.align = _recording_align
+        try:
+            asyncio.run(_drive())
+        finally:
+            _FakeAlignerEngine.align = real_align
+        assert seen["engine_thread"] != seen["loop_thread"], seen
+
+    def test_lock_waits_asynchronously_not_on_a_thread_lock(self):
+        """A contended lane lock does not stall unrelated loop work.
+
+        This behavioral check fails if ``__aenter__`` calls
+        ``threading.Lock.acquire`` inline, regardless of wrapper type.
+        """
+        from vllm_mlx.routes import audio as audio_route
+
+        async def _drive():
+            lock = audio_route._get_stt_lane_lock()
+            entered = False
+
+            async def _waiter():
+                nonlocal entered
+                async with lock:
+                    entered = True
+
+            async with lock:
+                waiter = asyncio.create_task(_waiter())
+                heartbeats = 0
+                for _ in range(5):
+                    await asyncio.sleep(0.01)
+                    heartbeats += 1
+                assert heartbeats == 5
+                assert not entered
+            await waiter
+            assert entered
+
+        asyncio.run(_drive())
+
+    def test_cancellation_drains_the_worker_before_unwinding(self):
+        """A client disconnect must not release the lock / temp file early.
+
+        ``await asyncio.to_thread(...)`` is not cancellable — the worker
+        runs on — but the await returns immediately when the task is
+        cancelled. Without ``run_to_completion``'s shield-and-drain, the
+        surrounding ``async with`` lock would admit another request and
+        the ``finally`` would unlink the audio file while the abandoned
+        worker was still using both.
+        """
+        from vllm_mlx.routes._async_utils import run_to_completion
+
+        started = threading.Event()
+        release = threading.Event()
+        finished = threading.Event()
+
+        def _slow_worker():
+            started.set()
+            release.wait(5.0)
+            finished.set()
+
+        async def _drive():
+            task = asyncio.ensure_future(run_to_completion(_slow_worker))
+            await asyncio.to_thread(started.wait, 5.0)
+            task.cancel()
+            # The worker is still running, so the cancellation must NOT
+            # have completed yet.
+            await asyncio.sleep(0.05)
+            assert not task.done(), "cancellation unwound while the worker ran"
+            release.set()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+            assert finished.is_set()
+
+        asyncio.run(_drive())
+
+    def test_direct_inner_task_cancel_still_drains_worker(self):
+        """Cancelling the asyncio wrapper cannot outlive its worker thread."""
+        from vllm_mlx.routes._async_utils import run_to_completion
+
+        started = threading.Event()
+        release = threading.Event()
+        finished = threading.Event()
+
+        def _slow_worker():
+            started.set()
+            release.wait(5.0)
+            finished.set()
+
+        async def _drive():
+            outer = asyncio.create_task(run_to_completion(_slow_worker))
+            await asyncio.to_thread(started.wait, 5.0)
+            current = asyncio.current_task()
+            inner = next(
+                task
+                for task in asyncio.all_tasks()
+                if task not in {current, outer} and not task.done()
+            )
+            inner.cancel()
+            await asyncio.sleep(0.05)
+            assert not outer.done()
+            release.set()
+            with pytest.raises(asyncio.CancelledError):
+                await outer
+            assert finished.is_set()
+
+        asyncio.run(_drive())
+
+
+# ---------------------------------------------------------------------------
+# Direct handler invocation (no ASGI stack)
+# ---------------------------------------------------------------------------
+
+
+def test_direct_handler_call_tolerates_unresolved_form_defaults(monkeypatch):
+    """Calling ``create_transcription`` directly must not hit the ``text``
+    logic with a FastAPI sentinel.
+
+    Several existing tests (e.g. test_audio_upload_size_limit) invoke the
+    handler as a plain coroutine rather than through the ASGI stack, so any
+    parameter they don't pass arrives as its unresolved ``Form(None)`` /
+    ``Query(None)`` object — truthy and non-None but NOT a string. The
+    pre-existing params only ever compare against None, so they tolerate
+    it; the alignment branch calls ``.strip()``, which would raise
+    ``AttributeError: 'Form' object has no attribute 'strip'`` without the
+    isinstance merge.
+    """
+    from vllm_mlx.audio import probe
+    from vllm_mlx.routes import audio as audio_route
+
+    _install_fake_mlx_audio(monkeypatch)
+    probe._reset_probe_cache()
+
+    class _Boom:
+        """An engine that must never be reached — a bogus model 404s first."""
+
+        def __init__(self, model_name):  # pragma: no cover - must not run
+            raise AssertionError("engine must not be constructed")
+
+    _patch_engine(monkeypatch, _Boom)
+
+    # Only the pre-F-165 kwargs, exactly as the older direct-call tests do:
+    # text_form / text_query are left at their unresolved defaults.
+    try:
+        with pytest.raises(HTTPException) as exc_info:
+            asyncio.run(
+                audio_route.create_transcription(
+                    file=_UploadLike(_make_tone_wav()),  # type: ignore[arg-type]
+                    model_form="definitely-not-a-real-alias",
+                    language_form=None,
+                    response_format_form=None,
+                    model_query=None,
+                    language_query=None,
+                    response_format_query=None,
+                )
+            )
+    finally:
+        probe._reset_probe_cache()
+
+    # A 404 for the bogus alias proves we got through the ASR/alignment
+    # branch selection without an AttributeError on the sentinel.
+    assert exc_info.value.status_code == 404, exc_info.value.detail
+
+
+class TestSttLaneMutualExclusion:
+    """ASR and alignment must not run against the accelerator at once.
+
+    The two lanes share no Python state (`_stt_engine` and `_aligner_engine`
+    are separate caches on purpose) but they DO share unified memory and the
+    GPU: each loads its own multi-GB model. Before alignment was offloaded,
+    every audio lane ran inline on the event loop, so they were mutually
+    exclusive by accident. Offloading removed that accident — hence one lock
+    covering both lanes rather than one per lane.
+    """
+
+    def test_asr_and_alignment_take_the_same_lock(self):
+        """Cheap source pin — the behavioural test below is the real check.
+
+        Kept because it names the invariant at the point a future edit would
+        break it, but it proves nothing on its own: a reference to
+        `_get_stt_lane_lock()` outside an `async with` would satisfy it.
+        """
+        import inspect
+
+        from vllm_mlx.routes import audio as audio_route
+
+        for fn in (audio_route._run_stt_request, audio_route._run_alignment_request):
+            src = inspect.getsource(fn)
+            assert "async with _get_stt_lane_lock()" in src, (
+                f"{fn.__name__} must hold the shared STT-lane lock, not just "
+                f"reference it"
+            )
+
+    def test_alignment_cannot_enter_while_the_lane_is_held(self, _fake_audio_env):
+        """A live ASR request must keep alignment out of its engine.
+
+        Note ASR cannot be driven *concurrently* here: it still executes
+        inline on the event loop, so a fake that parks inside `transcribe`
+        blocks the loop itself and nothing else can be observed. So this
+        holds the lane the way a running ASR request does — by taking the
+        same lock ASR takes — and asserts alignment queues behind it,
+        touching neither its engine nor the temp file until released.
+
+        My first version of this test only invoked alignment, which meant it
+        would have passed even with ASR entirely unlocked. This one fails if
+        the alignment path stops taking the lane lock.
+        """
+        audio_route = _fake_audio_env
+        order: list[str] = []
+
+        class _RecordingAligner(_FakeAlignerEngine):
+            def align(self, audio_path, text, language="Chinese"):
+                order.append("align-enter")
+                return super().align(audio_path, text, language=language)
+
+        async def _drive():
+            _patch_engine_direct(audio_route, _RecordingAligner)
+            lock = audio_route._get_stt_lane_lock()
+
+            async with lock:  # stands in for a running ASR request
+                order.append("lane-held")
+                align = asyncio.ensure_future(
+                    audio_route._run_alignment_request(
+                        file=_UploadLike(_make_tone_wav()),
+                        model="qwen3-aligner",
+                        text="abc",
+                        language=None,
+                        response_format="verbose_json",
+                    )
+                )
+                # Several loop turns: a broken lane lock would let the
+                # offloaded align() start in the executor by now.
+                for _ in range(20):
+                    await asyncio.sleep(0)
+                await asyncio.sleep(0.05)
+                assert "align-enter" not in order, (
+                    f"alignment reached its engine while the lane was held: {order}"
+                )
+                assert not align.done()
+                order.append("lane-released")
+
+            await align
+            assert order == ["lane-held", "lane-released", "align-enter"], order
+
+        asyncio.run(_drive())
+
+    def test_asr_engine_is_never_handed_an_alignment_request(self, _fake_audio_env):
+        """A shared cache would hand `align()` to a resident ASR model.
+
+        `STTEngine` rejects that, but only after a weight load and deep
+        inside the engine. This asserts the alignment path constructs its
+        own engine rather than reusing whatever ASR left behind.
+        """
+        audio_route = _fake_audio_env
+
+        class _AsrOnlyEngine:
+            def __init__(self, model_name):
+                self.model_name = model_name
+
+            def load(self):
+                pass
+
+            def transcribe(self, audio_path, language=None, task="transcribe"):
+                return _FakeAlignResult("asr text", [], "en", 1.0)
+
+            def align(self, audio_path, text, language="Chinese"):
+                raise AssertionError(
+                    "the ASR engine was handed an alignment request — the "
+                    "lanes are sharing a cache"
+                )
+
+        async def _drive():
+            _patch_engine_direct(audio_route, _AsrOnlyEngine)
+            await audio_route._run_stt_request(
+                file=_UploadLike(_make_tone_wav()),
+                model="whisper-large-v3",
+                language=None,
+                response_format="json",
+                task="transcribe",
+            )
+            assert isinstance(audio_route._stt_engine, _AsrOnlyEngine)
+
+            # Alignment must build its own — if it reused the ASR engine the
+            # AssertionError above would fire.
+            import vllm_mlx.audio.stt as stt_mod
+
+            stt_mod.STTEngine = _FakeAlignerEngine
+            await audio_route._run_alignment_request(
+                file=_UploadLike(_make_tone_wav()),
+                model="qwen3-aligner",
+                text="abc",
+                language=None,
+                response_format="verbose_json",
+            )
+            assert isinstance(audio_route._aligner_engine, _FakeAlignerEngine)
+
+        asyncio.run(_drive())
+
+    def test_asr_holds_the_lock_across_load_and_inference(self):
+        """The lock must wrap the weight load too, not just inference.
+
+        Acquiring it between load and `transcribe` would still let two
+        models be loaded concurrently, which is half the point.
+        """
+        import inspect
+
+        from vllm_mlx.routes import audio as audio_route
+
+        src = inspect.getsource(audio_route._run_stt_request)
+        lock_at = src.index("async with _get_stt_lane_lock()")
+        load_at = src.index(".load()")
+        transcribe_at = src.index(".transcribe(")
+        assert lock_at < load_at < transcribe_at, (
+            "the lock must be acquired before the weight load"
+        )
+
+
+class TestDrainSurvivesRepeatedCancellation:
+    """A second cancel must not abandon a running worker.
+
+    The drain in `run_to_completion` has to be a SHIELDED LOOP. A bare
+    `await task` is itself cancellable, so a second `Task.cancel()` — a
+    shutdown signal, a supervisor giving up on a hung request — would
+    interrupt the drain and hand control back while the thread is still
+    running, releasing the lock and unlinking the temp file underneath it.
+    That is the exact failure the helper exists to prevent, one cancel later.
+    """
+
+    def test_two_cancels_still_wait_for_the_worker(self):
+        """The observable failure: does the CALLER's finally run too early?
+
+        Asserting on the wrapper task alone is not enough — a bare-await
+        drain also leaves it pending. What actually breaks is the caller
+        resuming while the thread is live, so this reproduces the real
+        shape: hold a lock and own a temp file across the call, cancel
+        twice, and check whether cleanup happened before the worker
+        finished.
+        """
+        from vllm_mlx.routes._async_utils import run_to_completion
+
+        started = threading.Event()
+        release = threading.Event()
+        finished = threading.Event()
+        # Ordering evidence: what the caller did, and when.
+        events: list[str] = []
+
+        def _slow():
+            started.set()
+            release.wait(timeout=5)
+            finished.set()
+            events.append("worker-finished")
+            return "done"
+
+        async def _caller():
+            """Mirrors the route: lock held + temp file owned across the call."""
+            lock = asyncio.Lock()
+            async with lock:
+                try:
+                    return await run_to_completion(_slow)
+                finally:
+                    # This is the line that must NOT run while the thread
+                    # is still using the engine and the temp file.
+                    events.append("caller-cleanup")
+
+        async def _drive():
+            task = asyncio.ensure_future(_caller())
+            await asyncio.get_running_loop().run_in_executor(None, started.wait, 5)
+
+            task.cancel()
+            await asyncio.sleep(0)
+            task.cancel()  # second cancel — must not break the drain
+            # Give the loop several turns to let a broken drain unwind.
+            for _ in range(20):
+                await asyncio.sleep(0)
+            await asyncio.sleep(0.05)
+
+            assert not finished.is_set(), "test bug: worker released too early"
+            assert "caller-cleanup" not in events, (
+                "the caller's finally ran while the worker thread was still "
+                f"alive — drain was interrupted. events={events}"
+            )
+
+            release.set()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+            assert events == ["worker-finished", "caller-cleanup"], events
+
+        asyncio.run(_drive())
+
+    def test_uncancelled_call_returns_the_result(self):
+        from vllm_mlx.routes._async_utils import run_to_completion
+
+        async def _drive():
+            return await run_to_completion(lambda: 42)
+
+        assert asyncio.run(_drive()) == 42
+
+
+class TestCrossLoopLock:
+    def test_two_event_loops_share_one_exclusion_domain(self):
+        """Separate event loops cannot drive the process-global engines together."""
+        from vllm_mlx.routes import audio as audio_route
+
+        first_entered = threading.Event()
+        release_first = threading.Event()
+        second_entered = threading.Event()
+
+        async def _first():
+            async with audio_route._get_stt_lane_lock():
+                first_entered.set()
+                await asyncio.to_thread(release_first.wait, 5.0)
+
+        async def _second():
+            async with audio_route._get_stt_lane_lock():
+                second_entered.set()
+
+        first = threading.Thread(target=lambda: asyncio.run(_first()))
+        second = threading.Thread(target=lambda: asyncio.run(_second()))
+        first.start()
+        assert first_entered.wait(5.0)
+        second.start()
+        assert not second_entered.wait(0.1)
+        release_first.set()
+        first.join(5.0)
+        second.join(5.0)
+        assert second_entered.is_set()

--- a/vllm_mlx/routes/_async_utils.py
+++ b/vllm_mlx/routes/_async_utils.py
@@ -11,6 +11,7 @@ a copy that can drift.
 
 import asyncio
 import logging
+import threading
 
 logger = logging.getLogger(__name__)
 
@@ -36,15 +37,65 @@ async def run_to_completion(func, /, *args):
     exactly as long as the thread is running. The client is already gone,
     so the extra wait costs nothing user-visible, and it is bounded by
     the engine's own timeout.
+
+    The drain is a SHIELDED LOOP, not a bare ``await task``. A bare await is
+    itself cancellable, so a second ``Task.cancel()`` — a shutdown signal
+    racing the client disconnect, or a supervisor giving up on a hung
+    request — would interrupt the drain and unwind the lock / cleanup while
+    the thread still runs, the exact failure this helper exists to prevent,
+    one cancel later. Re-awaiting a fresh ``asyncio.shield(task)`` and
+    swallowing cancels keeps us parked on the worker until it truly
+    finishes: ``shield`` protects ``task`` from each cancel, so a repeated
+    cancel costs one extra loop turn instead of ending the drain.
+
+    Worker completion is tracked by a thread-level event rather than by the
+    cancellable asyncio wrapper. This also covers shutdown code that directly
+    cancels every asyncio task: cancelling ``to_thread`` does not stop its
+    underlying thread, so the outer task must keep draining until the worker
+    itself signals completion.
     """
-    task = asyncio.ensure_future(asyncio.to_thread(func, *args))
+    completed = threading.Event()
+
+    def invoke():
+        try:
+            return func(*args)
+        finally:
+            completed.set()
+
+    task = asyncio.ensure_future(asyncio.to_thread(invoke))
     try:
         return await asyncio.shield(task)
     except asyncio.CancelledError:
-        # Drain the worker (ignoring its outcome — nobody is listening)
-        # before letting the cancellation unwind our lock + cleanup.
-        try:
-            await task
-        except Exception:
-            logger.debug("Abandoned worker finished with an error", exc_info=True)
+        # Drain the worker before letting the cancellation unwind our lock +
+        # cleanup. See the shielded-loop rationale in the docstring.
+        while not completed.is_set():
+            try:
+                await asyncio.sleep(0.01)
+            except asyncio.CancelledError:
+                # Repeated/direct cancellation cannot stop the worker.
+                logger.debug("Ignoring cancellation while draining an abandoned worker")
+        # The worker sets ``completed`` in its finally block just before the
+        # executor schedules the asyncio Future's completion callback. Drain
+        # that small handoff window before inspecting ``task.exception()``.
+        while not task.done():
+            try:
+                await asyncio.shield(task)
+            except asyncio.CancelledError:
+                logger.debug(
+                    "Ignoring cancellation while finalizing an abandoned worker"
+                )
+            except Exception:
+                break
+        # Retrieve the outcome so asyncio doesn't warn "exception never
+        # retrieved" at GC, and we keep the reason the abandoned work failed.
+        worker_error = None if task.cancelled() else task.exception()
+        if worker_error is not None:
+            logger.debug(
+                "Abandoned worker finished with an error",
+                exc_info=(
+                    type(worker_error),
+                    worker_error,
+                    worker_error.__traceback__,
+                ),
+            )
         raise

--- a/vllm_mlx/routes/audio.py
+++ b/vllm_mlx/routes/audio.py
@@ -10,7 +10,9 @@ import math
 import os
 import re
 import tempfile
+import threading
 import wave
+from concurrent.futures import ThreadPoolExecutor
 
 from fastapi import APIRouter, Body, Depends, Form, HTTPException, Query, UploadFile
 from starlette.responses import PlainTextResponse, Response
@@ -237,6 +239,12 @@ def _is_valid_repo_component(comp: str) -> bool:
 #: ``"default"`` to the boot-time CLI model — STT has no boot-time
 #: model bound, so the route default is the closest equivalent.
 DEFAULT_STT_ALIAS = "whisper-large-v3"
+
+#: Registry alias used when a forced-alignment request (``text`` present)
+#: omits ``model``. The ASR default (:data:`DEFAULT_STT_ALIAS`) is NOT an
+#: aligner, so defaulting the alignment branch to it would fail deep
+#: inside ``STTEngine.align`` rather than doing what the caller asked.
+DEFAULT_ALIGNER_ALIAS = "qwen3-aligner"
 
 
 def _resolve_stt_model(model: str) -> str:
@@ -1218,7 +1226,6 @@ async def _run_stt_request(
     language: str | None,
     response_format: str,
     task: str,
-    text: str | None = None,
     timestamp_granularities: list[str] | None = None,
 ):
     """Shared STT pipeline used by both ``/v1/audio/transcriptions`` and
@@ -1254,27 +1261,16 @@ async def _run_stt_request(
     # "model_not_found_error" and never trigger a model load (F-165).
     model_name = _resolve_stt_model(model)
 
-    # Forced-alignment routing (Qwen3-ForcedAligner). The transcriptions
-    # route doubles as the alignment surface: when the caller supplies
-    # the KNOWN transcript via the ``text`` field, we call
-    # ``STTEngine.align`` instead of ``transcribe`` and return per-unit
-    # timings in the same segment shape the verbose_json/srt/vtt
-    # serializers already consume. Reject the two incoherent
-    # combinations up front (BEFORE draining the upload) with a clean
-    # 400 so the caller gets an actionable message instead of the
-    # engine's ValueError collapsing into a generic 500:
-    #   * aligner model selected but no ``text`` — there is nothing to
-    #     align to (the aligner does not recognize speech);
-    #   * ``text`` supplied to a non-aligner model — a Whisper/Parakeet
-    #     engine cannot force-align, so silently ignoring ``text`` would
-    #     mislead the caller into thinking alignment ran.
-    is_aligner = _is_aligner_model(model_name)
-    # Strip only to decide whether meaningful text was supplied — the
-    # ORIGINAL (unstripped) ``text`` is what we align, so a transcript
-    # whose authoritative form includes leading/trailing whitespace is
-    # aligned verbatim rather than silently mutated.
-    has_align_text = isinstance(text, str) and bool(text.strip())
-    if is_aligner and not has_align_text:
+    # Forced-alignment routing (Qwen3-ForcedAligner). Requests that carry
+    # a ``text`` field never reach this helper — ``create_transcription``
+    # dispatches them to :func:`_run_alignment_request` instead. What is
+    # left here is the incoherent combination that lands on the ASR path:
+    # an aligner model with nothing to align to. Reject it BEFORE draining
+    # the upload with a clean 400 so the caller gets an actionable message
+    # instead of the engine's own ValueError collapsing into a generic 500
+    # (``STTEngine.transcribe`` refuses aligner models — it cannot
+    # recognize speech).
+    if _is_aligner_model(model_name):
         raise HTTPException(
             status_code=400,
             detail={
@@ -1292,24 +1288,6 @@ async def _run_stt_request(
                 }
             },
         )
-    if has_align_text and not is_aligner:
-        raise HTTPException(
-            status_code=400,
-            detail={
-                "error": {
-                    "message": (
-                        f"the `text` field triggers forced alignment, which "
-                        f"requires a forced-aligner model; `{model}` is not "
-                        "one. Pass `model=qwen3-aligner` (or another aligner "
-                        "alias) to align `text` to the audio, or omit `text` "
-                        "for normal speech-to-text."
-                    ),
-                    "type": "invalid_request_error",
-                    "code": "alignment_model_required",
-                    "param": "model",
-                }
-            },
-        )
 
     tmp_path: str | None = None
     try:
@@ -1324,19 +1302,22 @@ async def _run_stt_request(
 
         from ..audio.stt import STTEngine
 
-        if _stt_engine is None or _stt_engine.model_name != model_name:
-            _stt_engine = STTEngine(model_name)
-            _stt_engine.load()
+        # Same lock the alignment lane takes. ASR still runs INLINE on the
+        # event loop, so this does not change how it executes — it makes
+        # explicit the serialisation it already had implicitly, and closes
+        # the window that offloading alignment would otherwise open: an ASR
+        # request on the loop concurrent with an alignment render in the
+        # executor means two multi-GB models resident and two callers
+        # driving the accelerator. See _stt_lane_lock.
+        async with _get_stt_lane_lock():
+            if _stt_engine is None or _stt_engine.model_name != model_name:
+                # Symmetric with the alignment path: one STT model resident.
+                _evict_other_lane("asr")
+                _stt_engine = None
+                stt_engine = STTEngine(model_name)
+                stt_engine.load()
+                _stt_engine = stt_engine
 
-        if has_align_text:
-            # Forced alignment: ``language`` here is the aligner's full
-            # language NAME (e.g. "Chinese", "English"), not an ISO code.
-            # Fall back to the engine default when omitted. ``text`` is
-            # passed verbatim (unstripped) — see ``has_align_text`` above.
-            result = _stt_engine.align(
-                tmp_path, text=text, language=language or "Chinese"
-            )
-        else:
             # Forward ``timestamp_granularities`` only when requested.
             # Keeping the default call shape unchanged preserves compatibility
             # with older STTEngine-shaped stubs and third-party engines.
@@ -1434,6 +1415,359 @@ async def _run_stt_request(
                 )
 
 
+# ---------------------------------------------------------------------------
+# Forced-alignment lane for ``/v1/audio/transcriptions`` + ``text``.
+#
+# Kept separate from ``_run_stt_request`` because the two lanes have
+# different concurrency models: ASR still runs its engine call inline on
+# the event loop, while alignment offloads to a worker thread (see the
+# lock and engine-cache comments below).
+# ---------------------------------------------------------------------------
+
+
+#: Serialises the STT lane — BOTH transcription/translation and forced
+#: alignment. One lock, not one per lane, and that matters.
+#:
+#: The two lanes share no Python state (``_stt_engine`` and
+#: ``_aligner_engine`` are separate caches on purpose), but they share the
+#: accelerator: each loads its own multi-GB model into unified memory and
+#: runs MLX work against it. Before this change every audio lane executed
+#: inline on the event loop, so they were mutually exclusive by accident.
+#: Offloading alignment to a worker thread removes that accident — an ASR
+#: request could then run on the loop while an alignment render is live in
+#: the executor, with two models resident and two callers driving the GPU.
+#: The lock restores the invariant deliberately instead of relying on the
+#: event loop to provide it.
+#:
+#: Note this does not change how ASR EXECUTES: it still runs inline, so
+#: taking the lock around it only makes explicit the serialisation it
+#: already had. Moving ASR (and TTS) off the loop is a separate change —
+#: ``main`` currently has zero ``to_thread`` calls in this module.
+#:
+#: An ``asyncio.Lock`` acquired ON THE EVENT LOOP, deliberately not a
+#: ``threading.Lock`` held inside the worker. ``asyncio.to_thread`` uses
+#: the shared default executor (min(32, cpu+4) threads), so queued
+#: requests blocking on a thread-level lock would each pin an executor
+#: thread just to wait — starving every other ``to_thread`` user in the
+#: process (prefix-cache save, tool-grammar warmup). Waiting on the loop
+#: instead costs a coroutine, not a thread, and only the request that
+#: actually runs ever occupies an executor slot.
+#:
+class _CrossLoopAsyncLock:
+    """Process-wide lock that never occupies the shared asyncio executor."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._executor = ThreadPoolExecutor(
+            max_workers=1, thread_name_prefix="rapid-mlx-stt-lock"
+        )
+
+    async def __aenter__(self):
+        loop = asyncio.get_running_loop()
+        completed = threading.Event()
+
+        def acquire() -> None:
+            try:
+                self._lock.acquire()
+            finally:
+                completed.set()
+
+        waiter = loop.run_in_executor(self._executor, acquire)
+        try:
+            await asyncio.shield(waiter)
+        except asyncio.CancelledError:
+            # Cancelling an asyncio Future cannot stop a running
+            # ``threading.Lock.acquire``. Drain the dedicated worker before
+            # propagating so an abandoned acquisition never owns the lock.
+            while not completed.is_set():
+                try:
+                    await asyncio.sleep(0.01)
+                except asyncio.CancelledError:
+                    pass
+            self._lock.release()
+            raise
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        self._lock.release()
+
+
+_stt_lane_lock = _CrossLoopAsyncLock()
+
+
+def _get_stt_lane_lock() -> _CrossLoopAsyncLock:
+    """Return the process-wide STT-lane lock."""
+    return _stt_lane_lock
+
+
+#: Signatures of the two ``ValueError``s :meth:`STTEngine.align` raises
+#: for caller mistakes (see its body): a model that isn't a forced
+#: aligner, and empty/blank known text. Matched on message because the
+#: engine raises bare ``ValueError`` for both; everything else that
+#: surfaces as a ValueError is an internal fault, not a bad request.
+#:
+#: The route rejects both shapes up front (``_is_aligner_model`` before
+#: the upload drains, blank ``text`` in ``create_transcription``), so
+#: this classifier is a BACKSTOP: it keeps an engine-side rejection from
+#: being dressed up as a generic 500 should the engine's own aligner
+#: predicate ever diverge from the route's substring heuristic.
+_CLIENT_ALIGNMENT_ERROR_SIGNATURES = (
+    "requires a forced-aligner model",
+    "requires non-empty known text",
+)
+
+
+def _is_client_alignment_error(exc: Exception) -> bool:
+    """True if ``exc`` is an ``align()`` rejection the CALLER can fix."""
+    message = str(exc).lower()
+    return any(sig in message for sig in _CLIENT_ALIGNMENT_ERROR_SIGNATURES)
+
+
+#: Cached forced-aligner engine — DELIBERATELY separate from
+#: ``_stt_engine``.
+#:
+#: Sharing one global across both lanes is unsafe now that alignment runs
+#: on a worker thread while ASR still runs on the event loop: an ASR
+#: request can replace the engine in between the alignment path's cache
+#: check and its ``align()`` call, and no lock held on only one side can
+#: prevent that. A dedicated cache removes the shared mutable state
+#: instead of trying to synchronise two lanes with different concurrency
+#: models. It also stops the two lanes evicting each other's weights on
+#: every alternating request, since an aligner and an ASR model are never
+#: the same ``model_name``.
+_aligner_engine = None
+
+
+def _evict_other_lane(keep: str) -> None:
+    """Release the STT lane's *other* cached engine before loading one.
+
+    ``keep`` is ``"asr"`` or ``"aligner"``. Only ever called with the lane
+    lock held, so the engine being dropped is guaranteed idle.
+
+    Why this exists: separate caches per lane fix the race (an ASR request
+    can no longer swap the engine under an in-flight alignment) but not the
+    footprint — alternating requests would leave both models resident. MLX
+    frees on refcount, so clearing the global is the release.
+    """
+    global _stt_engine, _aligner_engine
+
+    if keep == "aligner" and _stt_engine is not None:
+        logger.info(
+            "Releasing ASR model %s to load the forced aligner "
+            "(one STT model resident at a time)",
+            getattr(_stt_engine, "model_name", "?"),
+        )
+        _stt_engine = None
+    elif keep == "asr" and _aligner_engine is not None:
+        logger.info(
+            "Releasing forced aligner %s to load the ASR model "
+            "(one STT model resident at a time)",
+            getattr(_aligner_engine, "model_name", "?"),
+        )
+        _aligner_engine = None
+
+
+def _align_blocking(
+    model_name: str,
+    audio_path: str,
+    text: str,
+    language: str | None,
+):
+    """Blocking half of the forced-alignment request — runs on a thread.
+
+    Loads (or reuses) the aligner engine and runs
+    :meth:`STTEngine.align`. Split out of :func:`_run_alignment_request`
+    so the async handler can hand the seconds-long weight load + align
+    to a worker thread instead of stalling the event loop.
+
+    The caller holds :data:`_stt_lane_lock` for the whole call, so this
+    body is already serialised — no thread-level locking here (see the
+    lock's own comment for why it lives on the event loop).
+    """
+    global _aligner_engine
+
+    from ..audio.stt import STTEngine
+
+    # STTEngine.align defaults language to "Chinese"; only forward an
+    # explicit caller value so the engine default stands otherwise.
+    align_kwargs = {}
+    if language:
+        align_kwargs["language"] = language
+
+    if _aligner_engine is None or _aligner_engine.model_name != model_name:
+        # Drop the ASR lane's model before loading ours. The lock already
+        # stops the two lanes RUNNING at once, but without this they both
+        # stay resident after alternating requests — two multi-GB models in
+        # unified memory for a server that can only use one at a time. The
+        # caller holds the lane lock, so no ASR request is mid-flight and
+        # this cannot pull weights out from under one.
+        _evict_other_lane("aligner")
+        # Also drop any PREVIOUS aligner (a different aligner alias) before
+        # loading the replacement, so two multi-GB aligner models never sit
+        # resident together during ``load()``. Inert under the current
+        # single-aligner registry — the branch only re-enters when the cache
+        # was already emptied (an ASR request evicted us), so there is nothing
+        # to drop — but it keeps the "one STT model resident" invariant true if
+        # a second aligner alias is ever registered. On a failed reload the
+        # cache stays ``None`` and the next request reloads from disk, strictly
+        # better than pinning a stale model.
+        _aligner_engine = None
+        # Load into a local first and publish only on success. Caching a
+        # half-constructed engine would leave later requests matching on
+        # ``model_name`` against an object whose weights never loaded.
+        #
+        # Named ``aligner``, not ``engine``: test_route_engine_contract
+        # scans this module for ``engine.<method>()`` calls and requires
+        # the method to exist on the LLM ``BaseEngine``. An ``STTEngine``
+        # is a different hierarchy entirely, so the name would trip that
+        # gate with a false positive.
+        aligner = STTEngine(model_name)
+        aligner.load()
+        _aligner_engine = aligner
+    return _aligner_engine.align(audio_path, text, **align_kwargs)
+
+
+async def _run_alignment_request(
+    file: UploadFile,
+    model: str,
+    text: str,
+    language: str | None,
+    response_format: str,
+):
+    """Forced-alignment pipeline for ``/v1/audio/transcriptions`` + ``text``.
+
+    When the transcription request carries a ``text`` field the caller is
+    asking for FORCED ALIGNMENT (align the KNOWN transcript to the audio,
+    returning per-character/word timestamps) rather than ASR. This helper
+    mirrors :func:`_run_stt_request`'s size/resolve/cleanup/envelope
+    wiring but calls :meth:`STTEngine.align` and lets ``language`` fall
+    back to the aligner's own ``"Chinese"`` default when omitted.
+
+    The result's per-unit ``segments`` flow through the SAME
+    ``_format_stt_response`` serializers ASR uses, so ``verbose_json`` /
+    ``srt`` / ``vtt`` all work — the aligner emits exactly the
+    ``{text, start, end}`` segment shape those formatters consume.
+    """
+    # Resolve the aligner model up front (404 for unknown aliases) BEFORE
+    # draining the upload — same fail-fast ordering as the ASR path.
+    model_name = _resolve_stt_model(model)
+
+    # ``text`` only means anything to a forced aligner: a Whisper /
+    # Parakeet engine cannot align, so silently ignoring the field would
+    # mislead the caller into thinking alignment ran. Reject before the
+    # upload drains rather than letting ``align()`` raise several
+    # megabytes later.
+    if not _is_aligner_model(model_name):
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "error": {
+                    "message": (
+                        f"the `text` field triggers forced alignment, which "
+                        f"requires a forced-aligner model; `{model}` is not "
+                        f"one. Pass `model={DEFAULT_ALIGNER_ALIAS}` (or another "
+                        "aligner alias) to align `text` to the audio, or omit "
+                        "`text` for normal speech-to-text."
+                    ),
+                    "type": "invalid_request_error",
+                    "code": "alignment_model_required",
+                    "param": "model",
+                }
+            },
+        )
+
+    tmp_path: str | None = None
+    try:
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".wav") as tmp:
+            tmp_path = tmp.name
+            await _stream_upload_to_tempfile(file, tmp)
+
+        # Weight load + alignment are seconds of blocking compute, so run
+        # them on a worker thread — an ``async def`` handler that calls
+        # them inline stalls the whole event loop (every concurrent chat
+        # completion, /healthz probe and SSE heartbeat) for the duration.
+        #
+        # Serialise BEFORE offloading: queueing on the loop costs a
+        # coroutine, whereas queueing inside the worker would pin an
+        # executor thread per waiter and starve every other to_thread user.
+        # ``run_to_completion`` keeps the lock held and ``tmp_path`` alive
+        # for exactly as long as the worker runs, even if the client
+        # disconnects and cancels us mid-align.
+        async with _get_stt_lane_lock():
+            result = await run_to_completion(
+                _align_blocking, model_name, tmp_path, text, language
+            )
+
+        return _format_stt_response(result, response_format, task="transcribe")
+
+    except ImportError:
+        raise HTTPException(
+            status_code=503,
+            detail="mlx-audio not installed. Install with: pip install mlx-audio",
+        )
+    except HTTPException:
+        raise
+    except Exception as e:
+        # ONE handler, classified inside — deliberately not a chain of
+        # ``except ValueError`` / ``except Exception`` clauses. A bare
+        # ``raise`` in the narrower clause exits the whole try statement
+        # rather than falling through to the broader one, so an
+        # "unclassified → let the generic handler take it" flow silently
+        # became a 500 with no envelope. Classifying in one place makes
+        # the precedence explicit and testable.
+
+        # 1. Corrupted / undecodable upload. Checked FIRST because some
+        #    codec paths raise plain ValueError, which would otherwise be
+        #    reported as a bad alignment request blaming ``model``/``text``
+        #    and send the caller chasing a field that was never wrong.
+        if _is_decode_error(e):
+            logger.info("Forced alignment rejected corrupted upload: %s", e)
+            raise _audio_decode_error_envelope(e)
+
+        # 2. The two ``align()`` rejections the CALLER can fix: a model
+        #    that isn't a forced aligner, or blank known text. Any other
+        #    ValueError (weight loading, tokenizing, a reshape deep in the
+        #    model) is an internal fault and must not be dressed up as a
+        #    client error.
+        if isinstance(e, ValueError) and _is_client_alignment_error(e):
+            logger.info("Forced alignment rejected request: %s", e)
+            raise HTTPException(
+                status_code=400,
+                detail={
+                    "error": {
+                        "message": str(e),
+                        "type": "invalid_request_error",
+                        "code": "invalid_alignment_request",
+                        "param": "text" if "text" in str(e).lower() else "model",
+                    }
+                },
+            )
+
+        # 3. Everything else is ours, not the caller's.
+        logger.exception("Forced alignment failed: %s", e)
+        raise HTTPException(
+            status_code=500,
+            detail={
+                "error": {
+                    "message": "Audio forced alignment failed",
+                    "type": "api_error",
+                    "code": "alignment_failed",
+                    "param": None,
+                }
+            },
+        )
+    finally:
+        if tmp_path is not None:
+            try:
+                os.unlink(tmp_path)
+            except FileNotFoundError:
+                pass
+            except OSError as cleanup_err:
+                logger.warning(
+                    "Failed to unlink temp audio file %s: %s", tmp_path, cleanup_err
+                )
+
+
 @router.post("/v1/audio/transcriptions", dependencies=[Depends(verify_api_key)])
 async def create_transcription(
     file: UploadFile,
@@ -1454,11 +1788,11 @@ async def create_transcription(
     language_form: str | None = Form(None, alias="language"),
     response_format_form: str | None = Form(None, alias="response_format"),
     # ``text`` is a rapid-mlx extension (NOT an OpenAI field) that turns
-    # this route into the forced-alignment surface: when present with a
-    # forced-aligner model (``qwen3-aligner``), the known transcript is
-    # aligned to the audio and per-character timings come back in the
-    # segment shape verbose_json/srt/vtt already render. Accepted on
-    # both form and query for parity with the other STT fields.
+    # this route into the forced-alignment surface: when present, the
+    # known transcript is aligned to the audio and per-character timings
+    # come back in the segment shape verbose_json/srt/vtt already render.
+    # ``model`` then defaults to :data:`DEFAULT_ALIGNER_ALIAS`. Accepted
+    # on both form and query for parity with the other STT fields.
     text_form: str | None = Form(None, alias="text"),
     # STT-word-timestamps: OpenAI serialises the array field as
     # ``timestamp_granularities[]`` (bracketed) in the multipart body.
@@ -1485,6 +1819,16 @@ async def create_transcription(
 ):
     """Transcribe audio to text (OpenAI Whisper API compatible).
 
+    Forced-alignment extension: if the request carries a ``text`` field,
+    the route aligns that KNOWN transcript to the uploaded audio
+    (per-character/word timestamps, zero recognition error) via
+    :meth:`STTEngine.align` instead of running ASR. When ``text`` is
+    present but ``model`` is omitted it defaults to the registered
+    aligner alias (:data:`DEFAULT_ALIGNER_ALIAS`), and the response
+    defaults to ``verbose_json`` so the timestamped ``segments`` are
+    actually in the body. When ``text`` is absent the behaviour is
+    unchanged.
+
     Two-layer size guard (defense in depth):
 
     1. :class:`AudioBodyLimitMiddleware` runs at the ASGI layer and
@@ -1507,20 +1851,112 @@ async def create_transcription(
     # Form wins over query when both are present (form is the OpenAI
     # contract; query is the pre-F-165 internal contract we're keeping
     # for back-compat). Defaults match the original signature.
-    model = (
-        model_form
-        if model_form is not None
-        else (model_query if model_query is not None else "whisper-large-v3")
+    #
+    # ``model_merged`` / ``response_format_provided`` record whether the
+    # caller explicitly supplied the field — they drive the alignment
+    # defaults below, which only kick in when the field was omitted.
+    model_merged = next(
+        (v for v in (model_form, model_query) if isinstance(v, str)),
+        None,
     )
-    language = language_form if language_form is not None else language_query
-    response_format = (
-        response_format_form
-        if response_format_form is not None
-        else (response_format_query if response_format_query is not None else "json")
+    model_provided = model_merged is not None
+    response_format_provided = any(
+        isinstance(v, str) for v in (response_format_form, response_format_query)
+    )
+    # Select with an isinstance(str) check, NOT ``is not None``, for the same
+    # direct-call reason as ``text`` below: a handler invoked as a plain
+    # coroutine (not through FastAPI) receives any unpassed param as its
+    # unresolved ``Form``/``Query`` sentinel — truthy and non-None but NOT a
+    # string. Left as ``is not None`` that sentinel would flow through to the
+    # ASR/alignment engines as a bogus ``language``. Treat a non-str as absent.
+    language = next(
+        (v for v in (language_form, language_query) if isinstance(v, str)),
+        None,
+    )
+    response_format = next(
+        (
+            v
+            for v in (response_format_form, response_format_query)
+            if isinstance(v, str)
+        ),
+        "json",
     )
     # Forced-alignment transcript (rapid-mlx extension). Form wins over
     # query, matching the model/language/response_format precedence.
-    text = text_form if text_form is not None else text_query
+    #
+    # Merge with an isinstance check, NOT ``is not None``. Several existing
+    # tests (e.g. test_audio_upload_size_limit) call this handler directly
+    # rather than through FastAPI, so any parameter they don't pass arrives
+    # as its unresolved ``Form(None)`` / ``Query(None)`` object — truthy
+    # and non-None, but NOT a string. The pre-existing params only ever get
+    # compared against None so they tolerate that; ``text`` is inspected
+    # with ``.strip()`` below, which would raise ``AttributeError: 'Form'
+    # object has no attribute 'strip'``. Treat a non-str as absent.
+    text = next(
+        (v for v in (text_form, text_query) if isinstance(v, str)),
+        None,
+    )
+
+    # PRESENCE, not truthiness, selects the alignment branch. A
+    # whitespace-only ``text`` used to fall through to ASR whenever the
+    # model wasn't an aligner, which silently answered a different
+    # question than the caller asked — they wanted timestamps for a
+    # transcript and got speech recognition instead, with a 200 that gives
+    # no hint anything was ignored. It now 400s regardless of ``model``.
+    #
+    # A truly empty ``text=""`` is indistinguishable from an absent field
+    # here — FastAPI coerces both to ``None`` for an ``Optional[str]``
+    # form param — so it stays ASR. Only a non-empty-but-blank value is
+    # rejectable, and it is the shape that signals real caller intent.
+    if text is not None and not text.strip():
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "error": {
+                    "message": (
+                        "`text` was supplied but is blank. Send the known "
+                        "transcript to align, or omit `text` entirely for "
+                        "speech recognition."
+                    ),
+                    "type": "invalid_request_error",
+                    "code": "alignment_text_required",
+                    "param": "text",
+                }
+            },
+        )
+    is_alignment = text is not None
+
+    if is_alignment:
+        # Default to the registered aligner alias when the caller didn't
+        # pick a model — the ASR default (whisper-large-v3) is not an
+        # aligner and would fail deep in the engine.
+        #
+        # A WHITESPACE-ONLY model also takes the default here. FastAPI
+        # already coerces a truly empty form field (``model=""``) to
+        # ``None``, but ``model="   "`` — what you get from a form whose
+        # input was spaced-out, or a shell ``-F "model=$UNSET "`` — comes
+        # through verbatim and 404s in ``_resolve_stt_model`` as a
+        # nonexistent alias. Treat it as unset so "just send audio +
+        # text" keeps working. Scoped to this branch on purpose: the ASR
+        # path's blank-model handling is long-standing contract.
+        # isinstance guard for the same direct-call reason as ``text``.
+        alignment_model_chosen = isinstance(model_merged, str) and bool(
+            model_merged.strip()
+        )
+        model = model_merged if alignment_model_chosen else DEFAULT_ALIGNER_ALIAS
+        # Default to verbose_json so the timestamped ``segments`` are in
+        # the body; the plain ``json`` envelope drops them. An explicit
+        # response_format (srt/vtt/text/json) is honoured as-is.
+        # Whitespace-only is treated as unset for the same reason as
+        # ``model`` above (it would otherwise 400 on the allowed set).
+        if (
+            not response_format_provided
+            or not isinstance(response_format, str)
+            or not response_format.strip()
+        ):
+            response_format = "verbose_json"
+    else:
+        model = model_merged if model_provided else DEFAULT_STT_ALIAS
 
     # R6-H2: reject unknown ``response_format`` values up front with a
     # 400 envelope so a typo (``"jsno"``) or unsupported value
@@ -1535,12 +1971,30 @@ async def create_transcription(
     # bracketed query → plain query), then validate the values up front so
     # a bad value (``"words"``) fails cheaply with a 400 before the upload
     # drains — same lifecycle as ``response_format`` above.
-    timestamp_granularities = _normalise_timestamp_granularities(
-        timestamp_granularities_bracket_form
-        or timestamp_granularities_plain_form
-        or timestamp_granularities_bracket_query
-        or timestamp_granularities_plain_query
+    #
+    # Select the first NON-EMPTY list, NOT the first truthy value. Same
+    # direct-call hazard the ``text`` merge above guards: a handler invoked
+    # as a plain coroutine (not through FastAPI) receives any unpassed param
+    # as its unresolved ``Form``/``Query`` sentinel — truthy and non-None but
+    # NOT a list — so a raw ``or`` chain would forward that sentinel into the
+    # normaliser and raise ``TypeError: 'Form' object is not iterable``. The
+    # ``isinstance(v, list) and v`` guard keeps the original first-truthy
+    # precedence (None / empty list / sentinel all skipped) while tolerating
+    # the sentinel.
+    _tg_source = next(
+        (
+            v
+            for v in (
+                timestamp_granularities_bracket_form,
+                timestamp_granularities_plain_form,
+                timestamp_granularities_bracket_query,
+                timestamp_granularities_plain_query,
+            )
+            if isinstance(v, list) and v
+        ),
+        None,
     )
+    timestamp_granularities = _normalise_timestamp_granularities(_tg_source)
 
     # OpenAI contract: ``timestamp_granularities[]`` is only meaningful
     # with ``response_format=verbose_json`` (the only shape that carries a
@@ -1579,13 +2033,21 @@ async def create_transcription(
 
     require_mlx_audio_stt()
 
+    if is_alignment:
+        return await _run_alignment_request(
+            file=file,
+            model=model,
+            text=text,
+            language=language,
+            response_format=response_format,
+        )
+
     return await _run_stt_request(
         file=file,
         model=model,
         language=language,
         response_format=response_format,
         task="transcribe",
-        text=text,
         timestamp_granularities=timestamp_granularities,
     )
 


### PR DESCRIPTION
## Why
`main` grew forced alignment in #1301. The **engine** side is fine; the **route** layer is missing every protection the same feature acquired under six rounds of codex review on the now-retired `mvp/content-farm-local` branch (#1300, never merged to `main`).

Seven distinct defects, none cosmetic. Verified absent on `main` before writing this:

```
asyncio.to_thread            missing      _is_client_alignment_error   missing
run_to_completion            missing      DEFAULT_ALIGNER_ALIAS        missing
_aligner_engine              missing      isinstance-guarded merge     missing
_alignment_lock              missing
```

## What

**Blocking work ran on the event loop.** Weight load + `align()` are seconds of compute; inline in the `async def` handler they stall every concurrent chat completion, health probe and SSE heartbeat. Now `asyncio.to_thread`, serialised by an `asyncio.Lock` taken **on the loop** before offloading — a `threading.Lock` inside the worker pins one shared-executor thread per queued request and starves every other `to_thread` user in the process.

**Cancellation released the lock and deleted the temp file under a live worker.** `await asyncio.to_thread(...)` returns immediately when the handler is cancelled — a client disconnect does that — while the thread keeps running. `routes/_async_utils.py::run_to_completion` shields and drains first.

**The aligner shared `_stt_engine` with the ASR lane.** With alignment on a worker thread and ASR on the event loop, an ASR request can swap the engine between the alignment path's cache check and its `align()` call — and no lock held on only one side can prevent that. A dedicated `_aligner_engine` removes the shared mutable state rather than trying to synchronise two lanes with different concurrency models. It also stops the lanes evicting each other's weights, since an aligner and an ASR model are never the same `model_name`. The engine is published only after `load()` returns, so a failed load doesn't leave a same-`model_name` object cached.

**Error classification was wrong in both directions.** A corrupted upload surfaced as `invalid_alignment_request` blaming `model`/`text` — some codec paths raise plain `ValueError` — sending the caller to fix a field that was fine. And any *internal* `ValueError` (a reshape deep in the model, a tokenizer fault) was also dressed up as a client error. Now one classified handler: decode errors first, then only the two documented `align()` rejections become a 400, everything else a generic 500. Deliberately **not** a chain of `except` clauses — a bare `raise` in the narrow clause exits the whole `try` instead of falling through to the broader one, which silently produced an envelope-less 500.

**"Just send audio + text" didn't work.** With `text` present and no `model`, the ASR default `whisper-large-v3` is not an aligner and failed deep in the engine; `response_format` defaulted to `json`, which drops the timestamps the caller came for. Now `qwen3-aligner` and `verbose_json`. Whitespace-only values count as unset — FastAPI already coerces a truly empty form field to `None`, but `"   "` arrives verbatim and 404s as a nonexistent alias. Scoped to this branch only; the ASR path's blank-model handling is long-standing contract.

**A present-but-blank `text` silently ran ASR** — answering a different question than the caller asked, with a 200 that gives no hint the request was reinterpreted. Now a 400. (`text=""` is indistinguishable from absent, since FastAPI coerces both to `None`, so it stays ASR; only a non-empty-but-blank value is rejectable, and it's the shape that signals real intent.)

**Calling the handler directly raised `AttributeError`.** Existing tests — `tests/test_audio_upload_size_limit.py` — invoke `create_transcription` as a plain coroutine, so parameters they don't pass arrive as unresolved `Form(None)` objects: truthy, non-None, and *not strings*. The pre-existing params only ever compare against `None` so they tolerate it; the alignment branch calls `.strip()`. The merge now picks the first `isinstance(v, str)` and every `.strip()` is guarded.

## Tests

+19 in `tests/test_forced_alignment_route_hardening.py`, pinning each of the above — including that the engine observes a *different thread* than the event loop, and that a cancelled request drains its worker before the lock and temp file are released. Hermetic: engines faked at the import boundary, no weights or network.

Added to the **apple-silicon** CI job. Both CI test lists are explicit allowlists, so a file in neither never runs — and these are hermetic but not mlx-free (`vllm_mlx.config` reaches `engine_core`'s `import mlx.core`).

## Notes
- Scoped to alignment. The `/v1/audio/music` route from the same source PR touches the same file and is a separate change (#1316) — merges are sequenced so conflict resolution stays deliberate.
- Pre-existing on `main`, untouched here: 3 `test_audio_upload_size_limit` failures (no local `mlx_audio`) and `test_no_routing_shaped_rapid_mlx_env_vars` — `RAPID_MLX_ESPEAK_LIB` / `_ESPEAK_DATA` from #1312 aren't in that gate's allowlist, so **that gate is currently red on `main`** and worth a separate fix. Both reproduce on a clean checkout.

🤖 Hardening, tests and triage by Claude Code (Opus 5), reviewed by the author.
