### PR TITLE
feat(audio): add IndexTTS zero-shot voice cloning

### DIFF
--- a/docs/guides/audio.md
+++ b/docs/guides/audio.md
@@ -3,7 +3,7 @@
 rapid-mlx supports audio processing using [mlx-audio](https://github.com/Blaizzy/mlx-audio), providing:
 
 - **STT (Speech-to-Text)**: Whisper, Parakeet
-- **TTS (Text-to-Speech)**: Kokoro, Chatterbox, VibeVoice, VoxCPM, Dia
+- **TTS (Text-to-Speech)**: Kokoro, Chatterbox, IndexTTS, VibeVoice, VoxCPM, Dia
 - **Audio Processing**: SAM-Audio (voice separation)
 
 ## Supported Aliases (R10-C1)
@@ -20,6 +20,7 @@ rapid-mlx supports audio processing using [mlx-audio](https://github.com/Blaizzy
 | `vibevoice` / `vibevoice-realtime` | TTS | `mlx-community/VibeVoice-Realtime-0.5B-4bit` |
 | `voxcpm` | TTS | `mlx-community/VoxCPM1.5` |
 | `dia` | TTS | `mlx-community/Dia-1.6B-4bit` |
+| `indextts` / `indextts-1.5` | TTS voice cloning | `mlx-community/IndexTTS-1.5` |
 | `whisper` / `whisper-1` / `whisper-large-v3` | STT | `mlx-community/whisper-large-v3-mlx` |
 | `whisper-large-v3-turbo` | STT | `mlx-community/whisper-large-v3-turbo` |
 | `whisper-medium` / `-small` / `-base` / `-tiny` | STT | `mlx-community/whisper-{size}-mlx` |
@@ -51,6 +52,22 @@ rapid-mlx serve whisper-large-v3
 curl -s http://localhost:8000/v1/audio/transcriptions \
   -F "model=whisper-large-v3" \
   -F "file=@speech.mp3"
+```
+
+### IndexTTS zero-shot voice cloning
+
+IndexTTS has no predefined speakers. Send a base64-encoded reference clip
+through the rapid-mlx `ref_audio` extension; unlike F5-TTS and Qwen3-TTS Base,
+IndexTTS does not require a transcript of that clip.
+
+```bash
+rapid-mlx serve indextts
+
+REF_AUDIO=$(base64 < reference.wav | tr -d '\n')
+curl -s http://localhost:8000/v1/audio/speech \
+  -H "Content-Type: application/json" \
+  -d "{\"model\":\"indextts\",\"input\":\"Hello in the cloned voice.\",\"ref_audio\":\"$REF_AUDIO\"}" \
+  --output cloned.wav
 ```
 
 If `mlx-audio` is missing, the boot guard exits with rc=2 and the install hint:

--- a/tests/test_indextts_cloning.py
+++ b/tests/test_indextts_cloning.py
@@ -1,0 +1,260 @@
+# SPDX-License-Identifier: Apache-2.0
+"""IndexTTS zero-shot cloning: registry, engine, loader, and HTTP contract."""
+
+from __future__ import annotations
+
+import base64
+import importlib.machinery
+import json
+import sys
+import types
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+INDEXTTS_REPO = "mlx-community/IndexTTS-1.5"
+_REF_AUDIO = base64.b64encode(b"RIFF----WAVEfake-reference").decode()
+_UNSET = object()
+
+
+def test_registry_exposes_indextts_aliases():
+    from vllm_mlx.audio.registry import resolve_audio_alias
+
+    for alias in ("indextts", "indextts-1.5", INDEXTTS_REPO):
+        entry = resolve_audio_alias(alias)
+        assert entry is not None
+        assert entry.hf_id == INDEXTTS_REPO
+        assert entry.family == "indextts"
+        assert entry.default_voice == "clone"
+
+
+def test_engine_detects_both_indextts_spellings():
+    from vllm_mlx.audio.tts import TTSEngine
+
+    assert TTSEngine("mlx-community/IndexTTS-1.5")._model_family == "indextts"
+    assert TTSEngine("org/index-tts-custom")._model_family == "indextts"
+
+
+def test_engine_forwards_only_text_and_reference(monkeypatch):
+    from vllm_mlx.audio.tts import TTSEngine
+
+    calls: list[dict] = []
+    decoded_reference = object()
+
+    class _Result:
+        audio = np.zeros(240, dtype=np.float32)
+        sample_rate = 24000
+
+    class _Model:
+        def generate(self, **kwargs):
+            calls.append(kwargs)
+            yield _Result()
+
+    engine = TTSEngine(INDEXTTS_REPO)
+    engine.model = _Model()
+    engine._loaded = True
+    import mlx_audio.tts.generate as generate_mod
+
+    monkeypatch.setattr(
+        generate_mod,
+        "load_audio",
+        lambda path, sample_rate: decoded_reference,
+    )
+
+    output = engine.generate(
+        "Clone this voice",
+        voice="must-not-leak",
+        speed=1.7,
+        lang_code="z",
+        ref_audio="/tmp/reference.wav",
+        ref_text="not needed by IndexTTS",
+    )
+
+    assert calls == [{"text": "Clone this voice", "ref_audio": decoded_reference}]
+    assert output.sample_rate == 24000
+
+
+def test_engine_requires_reference_audio():
+    from vllm_mlx.audio.tts import TTSEngine
+
+    engine = TTSEngine(INDEXTTS_REPO)
+    engine.model = object()
+    engine._loaded = True
+    with pytest.raises(ValueError, match="requires ref_audio"):
+        engine.generate("No reference")
+
+
+def test_loader_injects_tokenizer_without_mutating_config(monkeypatch, tmp_path):
+    """Community checkpoints omit tokenizer_name; patch only in memory."""
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps({"model_type": "indextts"}))
+    (tmp_path / "tokenizer.model").write_bytes(b"tokenizer")
+
+    seen: dict = {}
+
+    class _Model:
+        def __init__(self, config):
+            seen["config"] = config
+
+        def load_weights(self, weights, strict):
+            seen["weights"] = weights
+            seen["strict"] = strict
+
+        def parameters(self):
+            return ["params"]
+
+        def eval(self):
+            seen["eval"] = True
+
+    import huggingface_hub
+    import mlx.core as mx
+    import mlx_audio.tts.models.indextts.indextts as indextts_mod
+
+    def _unexpected_download(*args, **kwargs):
+        raise AssertionError("local IndexTTS checkpoints must not hit Hugging Face")
+
+    monkeypatch.setattr(huggingface_hub, "snapshot_download", _unexpected_download)
+    monkeypatch.setattr(indextts_mod, "Model", _Model)
+    (tmp_path / "model.safetensors").write_bytes(b"weights")
+    monkeypatch.setattr(mx, "load", lambda path: {"w": "value"})
+    monkeypatch.setattr(mx, "eval", lambda params: seen.setdefault("mx_eval", params))
+
+    from vllm_mlx.audio.tts import _load_indextts_model
+
+    model = _load_indextts_model(str(tmp_path))
+
+    assert isinstance(model, _Model)
+    assert Path(seen["config"]["tokenizer_name"]) == tmp_path
+    assert seen["weights"] == [("w", "value")]
+    assert seen["strict"] is True
+    assert seen["eval"] is True
+    # The shared HF cache file remains byte-for-byte untouched.
+    assert json.loads(config_path.read_text()) == {"model_type": "indextts"}
+
+
+def _install_fake_mlx_audio(monkeypatch):
+    fake = types.ModuleType("mlx_audio")
+    fake.__path__ = []
+    fake.__spec__ = importlib.machinery.ModuleSpec(
+        "mlx_audio", loader=None, is_package=True
+    )
+    fake_tts = types.ModuleType("mlx_audio.tts")
+    fake_tts.__path__ = []
+    fake_tts.__spec__ = importlib.machinery.ModuleSpec(
+        "mlx_audio.tts", loader=None, is_package=True
+    )
+    monkeypatch.setitem(sys.modules, "mlx_audio", fake)
+    monkeypatch.setitem(sys.modules, "mlx_audio.tts", fake_tts)
+
+
+class _RecordingEngine:
+    instances: list[_RecordingEngine] = []
+    _real_to_bytes = None
+
+    def __init__(self, model_name: str):
+        self.model_name = model_name
+        self.calls: list[dict] = []
+        type(self).instances.append(self)
+
+    def load(self):
+        pass
+
+    def generate(
+        self,
+        text,
+        voice=_UNSET,
+        speed=1.0,
+        ref_audio=_UNSET,
+        ref_text=_UNSET,
+        **kwargs,
+    ):
+        from vllm_mlx.audio.tts import AudioOutput
+
+        call = {"text": text, "speed": speed}
+        if voice is not _UNSET:
+            call["voice"] = voice
+        if ref_audio is not _UNSET:
+            call["ref_audio"] = ref_audio
+            call["ref_exists_during_generate"] = Path(ref_audio).is_file()
+        if ref_text is not _UNSET:
+            call["ref_text"] = ref_text
+        self.calls.append(call)
+        return AudioOutput(
+            audio=np.zeros(240, dtype=np.float32),
+            sample_rate=24000,
+            duration=0.01,
+        )
+
+    def to_bytes(self, audio, format="wav"):
+        return type(self)._real_to_bytes(self, audio, format=format)
+
+
+def _mount(monkeypatch):
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from vllm_mlx.audio import probe as probe_mod
+    from vllm_mlx.audio import tts as tts_mod
+    from vllm_mlx.config import get_config
+    from vllm_mlx.middleware.exception_handlers import install_exception_handlers
+    from vllm_mlx.routes import audio as audio_route
+
+    _RecordingEngine.instances = []
+    _RecordingEngine._real_to_bytes = tts_mod.TTSEngine.to_bytes
+    _install_fake_mlx_audio(monkeypatch)
+    monkeypatch.setattr(probe_mod, "require_mlx_audio_tts", lambda: None)
+    monkeypatch.setattr(tts_mod, "TTSEngine", _RecordingEngine)
+    monkeypatch.setattr(tts_mod, "_list_snapshot_voices", lambda _name: [])
+    monkeypatch.setattr(audio_route, "_tts_engine", None)
+
+    app = FastAPI()
+    app.include_router(audio_route.router)
+    install_exception_handlers(app)
+    monkeypatch.setattr(get_config(), "api_key", None)
+    return TestClient(app)
+
+
+def test_route_accepts_reference_without_transcript(monkeypatch):
+    client = _mount(monkeypatch)
+    response = client.post(
+        "/v1/audio/speech",
+        json={
+            "model": "indextts",
+            "input": "Clone this voice",
+            "ref_audio": _REF_AUDIO,
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    (engine,) = _RecordingEngine.instances
+    assert engine.model_name == INDEXTTS_REPO
+    (call,) = engine.calls
+    assert call["ref_exists_during_generate"] is True
+    assert "voice" not in call
+    assert "ref_text" not in call
+
+
+def test_route_rejects_indextts_without_reference(monkeypatch):
+    client = _mount(monkeypatch)
+    response = client.post(
+        "/v1/audio/speech",
+        json={"model": "indextts", "input": "No reference"},
+    )
+
+    assert response.status_code == 400, response.text
+    assert response.json()["error"]["code"] == "missing_reference_audio"
+    assert _RecordingEngine.instances == []
+
+
+def test_model_rejects_reference_text_without_audio():
+    from pydantic import ValidationError
+
+    from vllm_mlx.api.models import AudioSpeechRequest
+
+    with pytest.raises(ValidationError, match="ref_text requires ref_audio"):
+        AudioSpeechRequest(
+            model="indextts",
+            input="Bad pair",
+            ref_text="orphan transcript",
+        )

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -2747,6 +2747,14 @@ class AudioSpeechRequest(BaseModel):
 
     @model_validator(mode="after")
     def _validate_f5_reference_pair(self):
+        model_lower = self.model.lower()
+        is_indextts = "indextts" in model_lower or "index-tts" in model_lower
+        if is_indextts:
+            if self.ref_text is not None and self.ref_audio is None:
+                raise ValueError("ref_text requires ref_audio")
+            if self.ref_text is not None and not self.ref_text.strip():
+                raise ValueError("ref_text must not be blank")
+            return self
         if (self.ref_audio is None) != (self.ref_text is None):
             raise ValueError("ref_audio and ref_text must be provided together")
         if self.ref_text is not None and not self.ref_text.strip():

--- a/vllm_mlx/audio/aliases.json
+++ b/vllm_mlx/audio/aliases.json
@@ -111,6 +111,20 @@
     "default_voice": "clone",
     "notes": "F5-TTS (pure-MLX, no torch): EN+ZH multilingual, zero-shot voice CLONING via ref_audio (24kHz clip) + ref_text. Fills the Chinese expressive/cloneable gap (Qwen3-TTS is flat, Chatterbox English-only). With no ref it uses a packaged default voice; supply a Chinese ref for a natural Chinese narrator."
   },
+  "indextts": {
+    "type": "tts",
+    "hf_id": "mlx-community/IndexTTS-1.5",
+    "family": "indextts",
+    "default_voice": "clone",
+    "notes": "IndexTTS 1.5 zero-shot voice cloning. Requires ref_audio; the reference transcript is not required. No predefined speakers."
+  },
+  "indextts-1.5": {
+    "type": "tts",
+    "hf_id": "mlx-community/IndexTTS-1.5",
+    "family": "indextts",
+    "default_voice": "clone",
+    "notes": "Long-form alias for indextts — same IndexTTS 1.5 MLX checkpoint."
+  },
   "qwen3-tts-clone": {
     "type": "tts",
     "hf_id": "mlx-community/Qwen3-TTS-12Hz-1.7B-Base-bf16",

--- a/vllm_mlx/audio/tts.py
+++ b/vllm_mlx/audio/tts.py
@@ -5,11 +5,13 @@ Text-to-Speech (TTS) engine using mlx-audio.
 Supports:
 - Kokoro (fast, lightweight)
 - Chatterbox (multilingual, expressive)
+- IndexTTS (zero-shot voice cloning)
 - VibeVoice (realtime, low latency)
 - VoxCPM (Chinese/English, high quality)
 """
 
 import io
+import json
 import logging
 from collections.abc import Iterator
 from dataclasses import dataclass
@@ -99,6 +101,66 @@ QWEN3_TTS_VOICEDESIGN_DEFAULT_INSTRUCT = (
 # the registry ``default_voice`` for the VoiceDesign aliases so the
 # voice-omitted / cold-start path validates without a real speaker name.
 QWEN3_TTS_VOICEDESIGN_VOICES = ["describe"]
+INDEXTTS_VOICES = ["clone"]
+
+
+def is_indextts_model(model_name: str) -> bool:
+    """True for IndexTTS checkpoints and aliases."""
+    name_lower = model_name.lower()
+    return "indextts" in name_lower or "index-tts" in name_lower
+
+
+def _load_indextts_model(model_name: str):
+    """Load IndexTTS without mutating its incomplete cached config.
+
+    The community checkpoints include ``tokenizer.model`` but omit the
+    ``tokenizer_name`` field required by mlx-audio's ``ModelArgs``. Patch an
+    in-memory copy and otherwise follow mlx-audio's normal load sequence.
+    """
+    import mlx.core as mx
+    from huggingface_hub import snapshot_download
+    from mlx_audio.tts.models.indextts.indextts import Model
+
+    local_path = Path(model_name).expanduser()
+    if local_path.is_dir():
+        model_path = local_path.resolve()
+    else:
+        model_path = Path(
+            snapshot_download(
+                model_name,
+                allow_patterns=[
+                    "config.json",
+                    "tokenizer.model",
+                    "*.safetensors",
+                    "*.safetensors.index.json",
+                ],
+            )
+        )
+    with open(model_path / "config.json") as config_file:
+        config = json.load(config_file)
+
+    tokenizer_path = model_path / "tokenizer.model"
+    if not tokenizer_path.is_file():
+        raise FileNotFoundError(
+            f"IndexTTS tokenizer not found at {tokenizer_path}; "
+            "the checkpoint must include tokenizer.model"
+        )
+    # mlx-audio treats tokenizer_name as a repo id first and a directory
+    # second, appending ``tokenizer.model`` itself on the local fallback.
+    config["tokenizer_name"] = str(model_path)
+
+    model = Model(config)
+    weights = {}
+    for weight_path in sorted(model_path.glob("*.safetensors")):
+        weights.update(mx.load(str(weight_path)))
+    if not weights:
+        raise FileNotFoundError(f"No IndexTTS safetensors found in {model_path}")
+    if hasattr(model, "sanitize"):
+        weights = model.sanitize(weights)
+    model.load_weights(list(weights.items()), strict=True)
+    mx.eval(model.parameters())
+    model.eval()
+    return model
 
 
 def is_qwen3_tts_model(model_name: str) -> bool:
@@ -405,6 +467,8 @@ class TTSEngine:
             # CustomVoice split is a per-request generate-arg distinction, not
             # a separate loader — see ``_is_qwen3_voicedesign``.
             return "qwen3_tts"
+        elif is_indextts_model(model_name):
+            return "indextts"
         elif "f5-tts" in name_lower or "f5_tts" in name_lower:
             return "f5"
         else:
@@ -425,6 +489,12 @@ class TTSEngine:
             self.model = F5TTS.from_pretrained(self.model_name)
             self._loaded = True
             logger.info(f"TTS model loaded (f5): {self.model_name}")
+            return
+
+        if self._model_family == "indextts":
+            self.model = _load_indextts_model(self.model_name)
+            self._loaded = True
+            logger.info(f"TTS model loaded (indextts): {self.model_name}")
             return
 
         try:
@@ -480,7 +550,8 @@ class TTSEngine:
                 ref timbre on top of its default voice); and by Qwen3-TTS
                 **Base** (optional — the Base variant ignores ``voice`` when
                 ``ref_audio`` is set, while CustomVoice ignores ``ref_audio``
-                and keeps its named speaker). Use a clean 5-10s clip at the
+                and keeps its named speaker); and by IndexTTS (required — it
+                has no predefined speakers). Use a clean 5-10s clip at the
                 model's native sample rate. Ignored by families without a
                 cloning surface.
             ref_text: Optional transcript of ``ref_audio`` (its exact spoken
@@ -513,7 +584,23 @@ class TTSEngine:
             # forwarding Kokoro's single-letter ``lang_code="a"`` to it
             # would mis-hint the language. Every other family keeps the
             # pre-existing call shape unchanged.
-            if self._model_family == "chatterbox":
+            if self._model_family == "indextts":
+                if not ref_audio:
+                    raise ValueError(
+                        "IndexTTS requires ref_audio (a reference speech clip "
+                        "to clone); it has no predefined speakers."
+                    )
+                # Older supported mlx-audio releases require an mx.array;
+                # newer releases also accept a path. Decode explicitly so the
+                # route behaves identically across the supported range.
+                from mlx_audio.tts.generate import load_audio
+
+                ref_waveform = load_audio(
+                    ref_audio,
+                    sample_rate=getattr(self.model, "sample_rate", 24000),
+                )
+                gen_kwargs: dict = {"text": text, "ref_audio": ref_waveform}
+            elif self._model_family == "chatterbox":
                 # Chatterbox's ``generate`` steers expressiveness through
                 # ``exaggeration`` and zero-shot cloning through
                 # ``ref_audio``. It DOES also accept ``voice``/``speed``/
@@ -917,6 +1004,8 @@ class TTSEngine:
             if self._is_qwen3_voicedesign():
                 return list(QWEN3_TTS_VOICEDESIGN_VOICES)
             return list(QWEN3_TTS_VOICES)
+        elif self._model_family == "indextts":
+            return list(INDEXTTS_VOICES)
         else:
             return ["default"]
 

--- a/vllm_mlx/routes/audio.py
+++ b/vllm_mlx/routes/audio.py
@@ -1857,6 +1857,7 @@ def _allowed_voices_for(model_name: str) -> list[str]:
         QWEN3_TTS_VOICEDESIGN_VOICES,
         QWEN3_TTS_VOICES,
         _list_snapshot_voices,
+        is_indextts_model,
         is_qwen3_tts_model,
         is_qwen3_voicedesign_model,
     )
@@ -1894,6 +1895,8 @@ def _allowed_voices_for(model_name: str) -> list[str]:
         # registry ``default_voice`` (``Serena``) is a member of this
         # list so the cold-start / voice-omitted path validates.
         return list(QWEN3_TTS_VOICES)
+    if is_indextts_model(model_name):
+        return ["clone"]
     if "f5-tts" in name_lower or "f5_tts" in name_lower:
         # F5 conditions on a reference waveform rather than a named
         # safetensors voice. ``clone`` is the registry's UI/API sentinel;
@@ -1926,12 +1929,13 @@ def _allowed_voices_for(model_name: str) -> list[str]:
 def _is_clone_capable_model(model_name: str) -> bool:
     """Whether ``model_name`` can clone a voice from an inline reference.
 
-    Three TTS families condition synthesis on a ``ref_audio`` reference
+    Four TTS families condition synthesis on a ``ref_audio`` reference
     clip sent on ``/v1/audio/speech``:
 
     * **F5-TTS** — always conditions on a reference waveform.
     * **Chatterbox** — optionally clones the reference timbre on top of
       its default voice (its engine branch forwards ``ref_audio``).
+    * **IndexTTS** — requires a reference clip and has no named speakers.
     * **Qwen3-TTS Base** — the ``...-Base-...`` repo clones a voice
       zero-shot from the reference. Its CustomVoice sibling does NOT
       clone: it keeps a predefined named speaker and ignores
@@ -1959,6 +1963,8 @@ def _is_clone_capable_model(model_name: str) -> bool:
     if "f5-tts" in name_lower or "f5_tts" in name_lower:
         return True
     if "chatterbox" in name_lower:
+        return True
+    if "indextts" in name_lower or "index-tts" in name_lower:
         return True
     repo = model_name.rsplit("/", 1)[-1].lower()
     tokens = set(re.split(r"[-_]", repo))
@@ -2024,7 +2030,11 @@ async def create_speech(request: AudioSpeechRequest = Body(...)):
     exaggeration = request.exaggeration
 
     try:
-        from ..audio.tts import TTSEngine, UnsupportedAudioFormatError
+        from ..audio.tts import (
+            TTSEngine,
+            UnsupportedAudioFormatError,
+            is_indextts_model,
+        )
 
         # R7-H3 follow-up: alias resolution lives in a shared helper
         # (see ``_resolve_tts_model``) so the bare alias / ``"default"``
@@ -2051,12 +2061,29 @@ async def create_speech(request: AudioSpeechRequest = Body(...)):
                     "error": {
                         "message": (
                             "ref_audio/ref_text voice cloning requires a "
-                            "clone-capable model (F5-TTS, Chatterbox, or "
-                            "Qwen3-TTS Base)."
+                            "clone-capable model (F5-TTS, Chatterbox, "
+                            "IndexTTS, or Qwen3-TTS Base)."
                         ),
                         "type": "invalid_request_error",
                         "code": "unsupported_voice_cloning",
                         "param": "model",
+                    }
+                },
+            )
+
+        if is_indextts_model(model_name) and ref_audio is None:
+            raise HTTPException(
+                status_code=400,
+                detail={
+                    "error": {
+                        "message": (
+                            f"model {model_name!r} is an IndexTTS "
+                            "voice-cloning-only repo. Supply ref_audio with a "
+                            "clean reference speech clip; ref_text is optional."
+                        ),
+                        "type": "invalid_request_error",
+                        "code": "missing_reference_audio",
+                        "param": "ref_audio",
                     }
                 },
             )
@@ -2247,7 +2274,8 @@ async def create_speech(request: AudioSpeechRequest = Body(...)):
                 with open(ref_path, "wb") as ref_file:
                     ref_file.write(ref_bytes)
                 gen_kwargs["ref_audio"] = ref_path.path
-                gen_kwargs["ref_text"] = ref_text
+                if ref_text is not None:
+                    gen_kwargs["ref_text"] = ref_text
                 audio = _tts_engine.generate(input_text, **gen_kwargs)
         else:
             audio = _tts_engine.generate(input_text, **gen_kwargs)


### PR DESCRIPTION
## Summary

Adds first-class IndexTTS 1.5 zero-shot voice cloning support to the OpenAI-compatible audio API.

- registers `indextts` and `indextts-1.5` aliases for `mlx-community/IndexTTS-1.5`
- accepts inline base64 `ref_audio` without requiring a reference transcript
- adds an IndexTTS-specific loader that supplies the checkpoint's omitted `tokenizer_name` in memory without mutating the Hugging Face cache
- supports both Hugging Face repo IDs and local checkpoint directories
- decodes reference audio explicitly for compatibility across supported `mlx-audio` versions
- documents the serve/curl workflow and adds route, loader, registry, and engine regression coverage

## Validation

- `python3 -m ruff format --check ...` — passed
- `python3 -m ruff check ...` — passed
- focused audio regression suite — 58 passed, 1 skipped
- broader audio regression run during implementation — 455 passed, 2 skipped
- real `mlx-community/IndexTTS-1.5` strict model load — passed
- real zero-shot generation using `examples/assistant_bank_en.wav` — generated 59,392 finite samples at 24 kHz (2.47 s)
- `codex review --base origin/main` — no correctness regressions identified

Note: plain `uv run` currently fails dependency resolution on main because the project advertises Python 3.10 while `mlx-video-with-audio==0.1.36` requires Python 3.11+. Validation used the existing Python 3.12 environment directly.