### PR TITLE
fix(cli): stop weightless-stub notice mis-firing on cached video models [skip-version-bump]

### DIFF
--- a/tests/test_download_gate.py
+++ b/tests/test_download_gate.py
@@ -1221,6 +1221,43 @@ def test_is_weightless_stub_ignores_adapter_only_safetensors(tmp_path, monkeypat
     assert gate.is_weightless_stub("some/lora-adapter") is True
 
 
+def test_is_weightless_stub_true_for_dangling_text_shard_with_aux_weight(
+    tmp_path, monkeypatch
+):
+    """Regression guard (codex round-2 MAJOR): the text-layout signal is the
+    ENTRY NAME, not a resolvable file. A corrupted/interrupted text snapshot
+    whose ``model-*.safetensors`` shard is a DANGLING symlink (target not yet
+    materialized) — plus an auxiliary ``vision_model.safetensors`` — must
+    still be recognized as a text repo, so the aux weight can't mask the
+    incomplete cache. ``os.path.isfile``/``exists`` would miss the dangling
+    entry; the name-based probe catches it."""
+    cache_root = tmp_path / "hf-cache"
+    repo_root = cache_root / "models--mlx-community--dangling-vlm-4bit"
+    sha = "4444444444444444444444444444444444444444"
+    snap = repo_root / "snapshots" / sha
+    snap.mkdir(parents=True)
+    (snap / "config.json").write_text("{}")
+    # A dangling shard symlink (target never downloaded) — os.path.exists is
+    # False for it, but the entry name is present in the directory listing.
+    (snap / "model-00001-of-00002.safetensors").symlink_to(
+        tmp_path / "never-materialized-blob"
+    )
+    (snap / "vision_model.safetensors").write_bytes(b"v" * 4096)
+    _seed_refs_main(repo_root, sha)
+
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+    import huggingface_hub.file_download as _fd
+
+    monkeypatch.setattr(_fd, "HF_HUB_CACHE", str(cache_root), raising=False)
+
+    assert (
+        gate._snapshot_has_alt_layout_weights("mlx-community/dangling-vlm-4bit")
+        is False
+    )
+    assert gate.is_repo_cached("mlx-community/dangling-vlm-4bit") is False
+    assert gate.is_weightless_stub("mlx-community/dangling-vlm-4bit") is True
+
+
 def test_weightless_stub_notice_is_size_free_and_no_extra_hf_call(monkeypatch):
     """The notice names the repo and says config cached / weights missing —
     and is deliberately SIZE-FREE. Computing a byte figure here would fire a

--- a/tests/test_download_gate.py
+++ b/tests/test_download_gate.py
@@ -1064,6 +1064,105 @@ def test_is_weightless_stub_real_tree(tmp_path, monkeypatch):
     assert gate.is_weightless_stub("mlx-community/gemma-4-e4b-it-4bit") is False
 
 
+def test_is_weightless_stub_false_for_video_component_weights(tmp_path, monkeypatch):
+    """Video-gen / diffusers repos ship their weights as component files
+    (``transformer.safetensors`` / ``vae.safetensors`` / ...) that mlx-lm's
+    text ``model*.safetensors`` glob never matches — so ``is_repo_cached``
+    reads a fully-cached video model as weightless. That must NOT surface the
+    "config cached, weights missing — will download ~N GB" notice on every
+    serve of an already-downloaded video model (the CogVideoX-Fun / LTX-2.3
+    false alarm). Exercises the real ``_snapshot_has_alt_layout_weights``."""
+    cache_root = tmp_path / "hf-cache"
+    repo_root = cache_root / "models--dgrauet--CogVideoX-Fun-V1.5-5b-InP-mlx-q4"
+    sha = "027bc0493a9dc41fad584568a9453961e18abb55"
+    snap = repo_root / "snapshots" / sha
+    snap.mkdir(parents=True)
+    (snap / "config.json").write_text("{}")
+    # Real CogVideoX-Fun layout: component weights at the snapshot root,
+    # none of them named ``model*.safetensors``.
+    (snap / "transformer.safetensors").write_bytes(b"t" * 4096)
+    (snap / "vae.safetensors").write_bytes(b"v" * 4096)
+    (snap / "text_encoder.safetensors").write_bytes(b"e" * 4096)
+    _seed_refs_main(repo_root, sha)
+
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+    import huggingface_hub.file_download as _fd
+
+    monkeypatch.setattr(_fd, "HF_HUB_CACHE", str(cache_root), raising=False)
+
+    # is_repo_cached (text glob) still reads False — video weights aren't
+    # ``model*.safetensors`` — but the stub notice must be suppressed.
+    assert gate.is_repo_cached("dgrauet/CogVideoX-Fun-V1.5-5b-InP-mlx-q4") is False
+    assert (
+        gate._snapshot_has_alt_layout_weights(
+            "dgrauet/CogVideoX-Fun-V1.5-5b-InP-mlx-q4"
+        )
+        is True
+    )
+    assert gate.is_weightless_stub("dgrauet/CogVideoX-Fun-V1.5-5b-InP-mlx-q4") is False
+
+
+def test_is_weightless_stub_false_for_nested_diffusers_weights(tmp_path, monkeypatch):
+    """Diffusers repos that nest weights in ``transformer/`` / ``vae/``
+    subdirectories are still recognized as weight-present — the alt-layout
+    walk is recursive, not root-only."""
+    cache_root = tmp_path / "hf-cache"
+    repo_root = cache_root / "models--some--diffusers-repo"
+    sha = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+    snap = repo_root / "snapshots" / sha
+    (snap / "transformer").mkdir(parents=True)
+    (snap / "vae").mkdir(parents=True)
+    (snap / "config.json").write_text("{}")
+    (snap / "transformer" / "diffusion_pytorch_model.safetensors").write_bytes(
+        b"t" * 4096
+    )
+    (snap / "vae" / "diffusion_pytorch_model.safetensors").write_bytes(b"v" * 4096)
+    _seed_refs_main(repo_root, sha)
+
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+    import huggingface_hub.file_download as _fd
+
+    monkeypatch.setattr(_fd, "HF_HUB_CACHE", str(cache_root), raising=False)
+
+    assert gate._snapshot_has_alt_layout_weights("some/diffusers-repo") is True
+    assert gate.is_weightless_stub("some/diffusers-repo") is False
+
+
+def test_is_weightless_stub_true_for_partial_text_download(tmp_path, monkeypatch):
+    """A genuinely-incomplete TEXT download (one shard present, a later shard
+    still missing) must STAY a weightless stub — finding ⑥'s original intent.
+    Its shard is ``model-*.safetensors`` at the root, which the alt-layout
+    walk deliberately skips (that's the text loader's own glob), so the stub
+    notice still fires and warns the user about the pending download."""
+    cache_root = tmp_path / "hf-cache"
+    repo_root = cache_root / "models--mlx-community--gemma-4-27b-it-4bit"
+    sha = "1111111111111111111111111111111111111111"
+    snap = repo_root / "snapshots" / sha
+    snap.mkdir(parents=True)
+    (snap / "config.json").write_text("{}")
+    # Sharded index expects two shards; only shard 1/2 is on disk.
+    (snap / "model.safetensors.index.json").write_text(
+        '{"weight_map": {"a": "model-00001-of-00002.safetensors",'
+        ' "b": "model-00002-of-00002.safetensors"}}'
+    )
+    (snap / "model-00001-of-00002.safetensors").write_bytes(b"s" * 4096)
+    _seed_refs_main(repo_root, sha)
+
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+    import huggingface_hub.file_download as _fd
+
+    monkeypatch.setattr(_fd, "HF_HUB_CACHE", str(cache_root), raising=False)
+
+    # No alt-layout weights (the lone shard is a root model*.safetensors), the
+    # cache is incomplete, so the stub notice must still fire.
+    assert (
+        gate._snapshot_has_alt_layout_weights("mlx-community/gemma-4-27b-it-4bit")
+        is False
+    )
+    assert gate.is_repo_cached("mlx-community/gemma-4-27b-it-4bit") is False
+    assert gate.is_weightless_stub("mlx-community/gemma-4-27b-it-4bit") is True
+
+
 def test_weightless_stub_notice_is_size_free_and_no_extra_hf_call(monkeypatch):
     """The notice names the repo and says config cached / weights missing —
     and is deliberately SIZE-FREE. Computing a byte figure here would fire a

--- a/tests/test_download_gate.py
+++ b/tests/test_download_gate.py
@@ -1163,6 +1163,64 @@ def test_is_weightless_stub_true_for_partial_text_download(tmp_path, monkeypatch
     assert gate.is_weightless_stub("mlx-community/gemma-4-27b-it-4bit") is True
 
 
+def test_is_weightless_stub_true_for_incomplete_text_with_aux_weight(
+    tmp_path, monkeypatch
+):
+    """Regression guard (codex MAJOR): a multimodal TEXT repo can carry an
+    auxiliary ``.safetensors`` (e.g. a vision tower) that isn't
+    ``model*.safetensors``. That aux file must NOT mask an incomplete text
+    shard set — the ``model.safetensors.index.json`` text-layout signal makes
+    is_repo_cached the sole authority, so a missing shard still fires the
+    notice. Without the text-layout guard, the aux weight would wrongly
+    suppress it."""
+    cache_root = tmp_path / "hf-cache"
+    repo_root = cache_root / "models--mlx-community--some-vlm-4bit"
+    sha = "2222222222222222222222222222222222222222"
+    snap = repo_root / "snapshots" / sha
+    snap.mkdir(parents=True)
+    (snap / "config.json").write_text("{}")
+    (snap / "model.safetensors.index.json").write_text(
+        '{"weight_map": {"a": "model-00001-of-00002.safetensors",'
+        ' "b": "model-00002-of-00002.safetensors"}}'
+    )
+    (snap / "model-00001-of-00002.safetensors").write_bytes(b"s" * 4096)
+    # shard 2/2 is MISSING; but an auxiliary weight IS present.
+    (snap / "vision_model.safetensors").write_bytes(b"v" * 4096)
+    _seed_refs_main(repo_root, sha)
+
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+    import huggingface_hub.file_download as _fd
+
+    monkeypatch.setattr(_fd, "HF_HUB_CACHE", str(cache_root), raising=False)
+
+    assert gate._snapshot_has_alt_layout_weights("mlx-community/some-vlm-4bit") is False
+    assert gate.is_repo_cached("mlx-community/some-vlm-4bit") is False
+    assert gate.is_weightless_stub("mlx-community/some-vlm-4bit") is True
+
+
+def test_is_weightless_stub_ignores_adapter_only_safetensors(tmp_path, monkeypatch):
+    """A config + ``adapter_model.safetensors`` cache (no base weights) is not
+    a fully-weighted model — the adapter sidecar must NOT be counted as
+    alt-layout weights, so the stub notice still fires (behaviour unchanged
+    from before this fix)."""
+    cache_root = tmp_path / "hf-cache"
+    repo_root = cache_root / "models--some--lora-adapter"
+    sha = "3333333333333333333333333333333333333333"
+    snap = repo_root / "snapshots" / sha
+    snap.mkdir(parents=True)
+    (snap / "config.json").write_text("{}")
+    (snap / "adapter_model.safetensors").write_bytes(b"a" * 4096)
+    _seed_refs_main(repo_root, sha)
+
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+    import huggingface_hub.file_download as _fd
+
+    monkeypatch.setattr(_fd, "HF_HUB_CACHE", str(cache_root), raising=False)
+
+    assert gate._snapshot_has_alt_layout_weights("some/lora-adapter") is False
+    assert gate.is_weightless_stub("some/lora-adapter") is True
+
+
 def test_weightless_stub_notice_is_size_free_and_no_extra_hf_call(monkeypatch):
     """The notice names the repo and says config cached / weights missing —
     and is deliberately SIZE-FREE. Computing a byte figure here would fire a

--- a/tests/test_download_gate.py
+++ b/tests/test_download_gate.py
@@ -1078,8 +1078,10 @@ def test_is_weightless_stub_false_for_video_component_weights(tmp_path, monkeypa
     snap = repo_root / "snapshots" / sha
     snap.mkdir(parents=True)
     (snap / "config.json").write_text("{}")
-    # Real CogVideoX-Fun layout: component weights at the snapshot root,
-    # none of them named ``model*.safetensors``.
+    # Real CogVideoX-Fun layout: a diffusers pipeline manifest + component
+    # weights at the snapshot root, none named ``model*.safetensors``.
+    (snap / "model_index.json").write_text('{"_class_name": "CogVideoXPipeline"}')
+    (snap / "split_model.json").write_text("{}")
     (snap / "transformer.safetensors").write_bytes(b"t" * 4096)
     (snap / "vae.safetensors").write_bytes(b"v" * 4096)
     (snap / "text_encoder.safetensors").write_bytes(b"e" * 4096)
@@ -1103,9 +1105,10 @@ def test_is_weightless_stub_false_for_video_component_weights(tmp_path, monkeypa
 
 
 def test_is_weightless_stub_false_for_nested_diffusers_weights(tmp_path, monkeypatch):
-    """Diffusers repos that nest weights in ``transformer/`` / ``vae/``
-    subdirectories are still recognized as weight-present — the alt-layout
-    walk is recursive, not root-only."""
+    """Diffusers repos (positively identified by ``model_index.json``) that
+    nest weights in ``transformer/`` / ``vae/`` subdirectories are still
+    recognized as weight-present — the alt-layout walk is recursive, not
+    root-only."""
     cache_root = tmp_path / "hf-cache"
     repo_root = cache_root / "models--some--diffusers-repo"
     sha = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
@@ -1113,6 +1116,7 @@ def test_is_weightless_stub_false_for_nested_diffusers_weights(tmp_path, monkeyp
     (snap / "transformer").mkdir(parents=True)
     (snap / "vae").mkdir(parents=True)
     (snap / "config.json").write_text("{}")
+    (snap / "model_index.json").write_text('{"_class_name": "SomePipeline"}')
     (snap / "transformer" / "diffusion_pytorch_model.safetensors").write_bytes(
         b"t" * 4096
     )
@@ -1126,6 +1130,93 @@ def test_is_weightless_stub_false_for_nested_diffusers_weights(tmp_path, monkeyp
 
     assert gate._snapshot_has_alt_layout_weights("some/diffusers-repo") is True
     assert gate.is_weightless_stub("some/diffusers-repo") is False
+
+
+def test_is_weightless_stub_true_for_interrupted_multimodal_aux_weight_first(
+    tmp_path, monkeypatch
+):
+    """Regression guard (codex BLOCKING): an interrupted MULTIMODAL text
+    download can land an auxiliary weight (``vision_model.safetensors``) BEFORE
+    its index/shards — with NO text-layout signal on disk yet. Inferring
+    "non-text" from the absence of ``model*.safetensors`` would misread this as
+    a fully-weighted non-text model and wrongly suppress the notice. Requiring
+    a POSITIVE non-text manifest (model_index.json / split_model.json), which a
+    text repo never ships, keeps it a stub so the notice fires."""
+    cache_root = tmp_path / "hf-cache"
+    repo_root = cache_root / "models--mlx-community--interrupted-vlm-4bit"
+    sha = "5555555555555555555555555555555555555555"
+    snap = repo_root / "snapshots" / sha
+    snap.mkdir(parents=True)
+    (snap / "config.json").write_text("{}")
+    # Only the vision tower arrived so far — no index, no model*.safetensors,
+    # and (crucially) no non-text pipeline manifest.
+    (snap / "vision_model.safetensors").write_bytes(b"v" * 4096)
+    _seed_refs_main(repo_root, sha)
+
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+    import huggingface_hub.file_download as _fd
+
+    monkeypatch.setattr(_fd, "HF_HUB_CACHE", str(cache_root), raising=False)
+
+    assert (
+        gate._snapshot_has_alt_layout_weights("mlx-community/interrupted-vlm-4bit")
+        is False
+    )
+    assert gate.is_repo_cached("mlx-community/interrupted-vlm-4bit") is False
+    assert gate.is_weightless_stub("mlx-community/interrupted-vlm-4bit") is True
+
+
+def test_is_weightless_stub_true_for_component_weights_without_manifest(
+    tmp_path, monkeypatch
+):
+    """Documented scope limit: a non-text repo shipping component weights but
+    NEITHER positive manifest falls back to the (cosmetic) false alarm rather
+    than a wrong suppression — the conservative failure direction. Pins that we
+    require positive metadata evidence, never inference-from-absence."""
+    cache_root = tmp_path / "hf-cache"
+    repo_root = cache_root / "models--vendor--manifestless-video"
+    sha = "6666666666666666666666666666666666666666"
+    snap = repo_root / "snapshots" / sha
+    snap.mkdir(parents=True)
+    (snap / "config.json").write_text("{}")
+    (snap / "transformer.safetensors").write_bytes(b"t" * 4096)
+    (snap / "vae.safetensors").write_bytes(b"v" * 4096)
+    _seed_refs_main(repo_root, sha)
+
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+    import huggingface_hub.file_download as _fd
+
+    monkeypatch.setattr(_fd, "HF_HUB_CACHE", str(cache_root), raising=False)
+
+    assert gate._snapshot_has_alt_layout_weights("vendor/manifestless-video") is False
+    assert gate.is_weightless_stub("vendor/manifestless-video") is True
+
+
+def test_is_weightless_stub_false_for_split_model_manifest(tmp_path, monkeypatch):
+    """LTX-2.3's positive marker is ``split_model.json`` (no model_index.json).
+    A cached component layout carrying it must be recognized as weight-present
+    so the notice is suppressed."""
+    cache_root = tmp_path / "hf-cache"
+    repo_root = cache_root / "models--notapalindrome--ltx23-mlx-av-q4"
+    sha = "88b4b5b2ed7697c25f281e76e3c692f659027ab1"
+    snap = repo_root / "snapshots" / sha
+    snap.mkdir(parents=True)
+    (snap / "config.json").write_text('{"model_type": "AudioVideo"}')
+    (snap / "split_model.json").write_text("{}")
+    (snap / "transformer.safetensors").write_bytes(b"t" * 4096)
+    (snap / "vae_decoder.safetensors").write_bytes(b"v" * 4096)
+    (snap / "vocoder.safetensors").write_bytes(b"o" * 4096)
+    _seed_refs_main(repo_root, sha)
+
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+    import huggingface_hub.file_download as _fd
+
+    monkeypatch.setattr(_fd, "HF_HUB_CACHE", str(cache_root), raising=False)
+
+    assert (
+        gate._snapshot_has_alt_layout_weights("notapalindrome/ltx23-mlx-av-q4") is True
+    )
+    assert gate.is_weightless_stub("notapalindrome/ltx23-mlx-av-q4") is False
 
 
 def test_is_weightless_stub_true_for_partial_text_download(tmp_path, monkeypatch):
@@ -1153,8 +1244,8 @@ def test_is_weightless_stub_true_for_partial_text_download(tmp_path, monkeypatch
 
     monkeypatch.setattr(_fd, "HF_HUB_CACHE", str(cache_root), raising=False)
 
-    # No alt-layout weights (the lone shard is a root model*.safetensors), the
-    # cache is incomplete, so the stub notice must still fire.
+    # No non-text manifest → not an alt-layout model; the cache is an
+    # incomplete text pull, so the stub notice must still fire.
     assert (
         gate._snapshot_has_alt_layout_weights("mlx-community/gemma-4-27b-it-4bit")
         is False
@@ -1169,10 +1260,9 @@ def test_is_weightless_stub_true_for_incomplete_text_with_aux_weight(
     """Regression guard (codex MAJOR): a multimodal TEXT repo can carry an
     auxiliary ``.safetensors`` (e.g. a vision tower) that isn't
     ``model*.safetensors``. That aux file must NOT mask an incomplete text
-    shard set — the ``model.safetensors.index.json`` text-layout signal makes
-    is_repo_cached the sole authority, so a missing shard still fires the
-    notice. Without the text-layout guard, the aux weight would wrongly
-    suppress it."""
+    shard set. Because the repo ships NO positive non-text manifest,
+    ``_snapshot_has_alt_layout_weights`` returns False and is_repo_cached is
+    the sole authority, so the missing shard still fires the notice."""
     cache_root = tmp_path / "hf-cache"
     repo_root = cache_root / "models--mlx-community--some-vlm-4bit"
     sha = "2222222222222222222222222222222222222222"
@@ -1224,13 +1314,12 @@ def test_is_weightless_stub_ignores_adapter_only_safetensors(tmp_path, monkeypat
 def test_is_weightless_stub_true_for_dangling_text_shard_with_aux_weight(
     tmp_path, monkeypatch
 ):
-    """Regression guard (codex round-2 MAJOR): the text-layout signal is the
-    ENTRY NAME, not a resolvable file. A corrupted/interrupted text snapshot
-    whose ``model-*.safetensors`` shard is a DANGLING symlink (target not yet
-    materialized) — plus an auxiliary ``vision_model.safetensors`` — must
-    still be recognized as a text repo, so the aux weight can't mask the
-    incomplete cache. ``os.path.isfile``/``exists`` would miss the dangling
-    entry; the name-based probe catches it."""
+    """A corrupted/interrupted text snapshot whose ``model-*.safetensors``
+    shard is a DANGLING symlink (target not yet materialized) — plus an
+    auxiliary ``vision_model.safetensors`` — must still be a stub. It ships no
+    positive non-text manifest, so ``_snapshot_has_alt_layout_weights`` returns
+    False and is_repo_cached (which treats the dangling shard as incomplete) is
+    the sole authority. The aux weight cannot mask the incomplete cache."""
     cache_root = tmp_path / "hf-cache"
     repo_root = cache_root / "models--mlx-community--dangling-vlm-4bit"
     sha = "4444444444444444444444444444444444444444"

--- a/tests/test_download_gate.py
+++ b/tests/test_download_gate.py
@@ -1071,17 +1071,20 @@ def test_is_weightless_stub_false_for_video_component_weights(tmp_path, monkeypa
     reads a fully-cached video model as weightless. That must NOT surface the
     "config cached, weights missing — will download ~N GB" notice on every
     serve of an already-downloaded video model (the CogVideoX-Fun / LTX-2.3
-    false alarm). Exercises the real ``_snapshot_has_alt_layout_weights``."""
+    false alarm). Exercises the real ``_snapshot_is_complete_split_model``."""
     cache_root = tmp_path / "hf-cache"
     repo_root = cache_root / "models--dgrauet--CogVideoX-Fun-V1.5-5b-InP-mlx-q4"
     sha = "027bc0493a9dc41fad584568a9453961e18abb55"
     snap = repo_root / "snapshots" / sha
     snap.mkdir(parents=True)
     (snap / "config.json").write_text("{}")
-    # Real CogVideoX-Fun layout: a diffusers pipeline manifest + component
-    # weights at the snapshot root, none named ``model*.safetensors``.
+    # Real CogVideoX-Fun layout: a diffusers pipeline manifest + the mlx-video
+    # ``split_model.json`` component manifest + one ``<component>.safetensors``
+    # per component at the snapshot root, none named ``model*.safetensors``.
     (snap / "model_index.json").write_text('{"_class_name": "CogVideoXPipeline"}')
-    (snap / "split_model.json").write_text("{}")
+    (snap / "split_model.json").write_text(
+        '{"components": ["transformer", "text_encoder", "vae"]}'
+    )
     (snap / "transformer.safetensors").write_bytes(b"t" * 4096)
     (snap / "vae.safetensors").write_bytes(b"v" * 4096)
     (snap / "text_encoder.safetensors").write_bytes(b"e" * 4096)
@@ -1096,7 +1099,7 @@ def test_is_weightless_stub_false_for_video_component_weights(tmp_path, monkeypa
     # ``model*.safetensors`` — but the stub notice must be suppressed.
     assert gate.is_repo_cached("dgrauet/CogVideoX-Fun-V1.5-5b-InP-mlx-q4") is False
     assert (
-        gate._snapshot_has_alt_layout_weights(
+        gate._snapshot_is_complete_split_model(
             "dgrauet/CogVideoX-Fun-V1.5-5b-InP-mlx-q4"
         )
         is True
@@ -1104,23 +1107,26 @@ def test_is_weightless_stub_false_for_video_component_weights(tmp_path, monkeypa
     assert gate.is_weightless_stub("dgrauet/CogVideoX-Fun-V1.5-5b-InP-mlx-q4") is False
 
 
-def test_is_weightless_stub_false_for_nested_diffusers_weights(tmp_path, monkeypatch):
-    """Diffusers repos (positively identified by ``model_index.json``) that
-    nest weights in ``transformer/`` / ``vae/`` subdirectories are still
-    recognized as weight-present — the alt-layout walk is recursive, not
-    root-only."""
+def test_is_weightless_stub_true_for_partial_split_model_components(
+    tmp_path, monkeypatch
+):
+    """Codex round-5 BLOCKING: an INTERRUPTED video pull that has landed its
+    ``split_model.json`` manifest + only SOME of its components (here ``vae``
+    is on disk but ``transformer`` is not) must NOT be read as fully weighted.
+    ``_snapshot_is_complete_split_model`` requires EVERY declared component's
+    ``<component>.safetensors`` to be present + non-empty; a missing one means
+    the download is incomplete, so the stub notice must still fire."""
     cache_root = tmp_path / "hf-cache"
-    repo_root = cache_root / "models--some--diffusers-repo"
-    sha = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+    repo_root = cache_root / "models--dgrauet--CogVideoX-Fun-partial-q4"
+    sha = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
     snap = repo_root / "snapshots" / sha
-    (snap / "transformer").mkdir(parents=True)
-    (snap / "vae").mkdir(parents=True)
+    snap.mkdir(parents=True)
     (snap / "config.json").write_text("{}")
-    (snap / "model_index.json").write_text('{"_class_name": "SomePipeline"}')
-    (snap / "transformer" / "diffusion_pytorch_model.safetensors").write_bytes(
-        b"t" * 4096
+    (snap / "split_model.json").write_text(
+        '{"components": ["transformer", "text_encoder", "vae"]}'
     )
-    (snap / "vae" / "diffusion_pytorch_model.safetensors").write_bytes(b"v" * 4096)
+    # Only ``vae`` arrived; ``transformer`` + ``text_encoder`` still pending.
+    (snap / "vae.safetensors").write_bytes(b"v" * 4096)
     _seed_refs_main(repo_root, sha)
 
     monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
@@ -1128,8 +1134,120 @@ def test_is_weightless_stub_false_for_nested_diffusers_weights(tmp_path, monkeyp
 
     monkeypatch.setattr(_fd, "HF_HUB_CACHE", str(cache_root), raising=False)
 
-    assert gate._snapshot_has_alt_layout_weights("some/diffusers-repo") is True
-    assert gate.is_weightless_stub("some/diffusers-repo") is False
+    assert (
+        gate._snapshot_is_complete_split_model("dgrauet/CogVideoX-Fun-partial-q4")
+        is False
+    )
+    assert gate.is_repo_cached("dgrauet/CogVideoX-Fun-partial-q4") is False
+    assert gate.is_weightless_stub("dgrauet/CogVideoX-Fun-partial-q4") is True
+
+
+def test_is_weightless_stub_true_for_zero_byte_split_model_component(
+    tmp_path, monkeypatch
+):
+    """A component whose ``<component>.safetensors`` is a 0-byte in-flight
+    placeholder (HF writes these before the blob lands) must count as
+    incomplete — same failure family as the text zero-byte-shard case. The
+    manifest is present and lists every component, but one file has no bytes,
+    so the pull isn't done and the notice must still fire."""
+    cache_root = tmp_path / "hf-cache"
+    repo_root = cache_root / "models--dgrauet--CogVideoX-Fun-inflight-q4"
+    sha = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    snap = repo_root / "snapshots" / sha
+    snap.mkdir(parents=True)
+    (snap / "config.json").write_text("{}")
+    (snap / "split_model.json").write_text('{"components": ["transformer", "vae"]}')
+    (snap / "transformer.safetensors").write_bytes(b"t" * 4096)
+    (snap / "vae.safetensors").write_bytes(b"")  # 0-byte placeholder
+    _seed_refs_main(repo_root, sha)
+
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+    import huggingface_hub.file_download as _fd
+
+    monkeypatch.setattr(_fd, "HF_HUB_CACHE", str(cache_root), raising=False)
+
+    assert (
+        gate._snapshot_is_complete_split_model("dgrauet/CogVideoX-Fun-inflight-q4")
+        is False
+    )
+    assert gate.is_weightless_stub("dgrauet/CogVideoX-Fun-inflight-q4") is True
+
+
+def test_snapshot_split_model_rejects_malformed_or_empty_manifest(
+    tmp_path, monkeypatch
+):
+    """Defensive: a ``split_model.json`` that is malformed JSON, not an object,
+    or names no components tells us nothing is complete — the helper must
+    return False (fall through to the text-glob path) rather than raise or
+    wrongly suppress. All three shapes share one fixture tree; the component
+    weights are on disk so only the manifest shape is under test."""
+    import json
+
+    cache_root = tmp_path / "hf-cache"
+    repo_root = cache_root / "models--vendor--bad-manifest"
+    sha = "cccccccccccccccccccccccccccccccccccccccc"
+    snap = repo_root / "snapshots" / sha
+    snap.mkdir(parents=True)
+    (snap / "config.json").write_text("{}")
+    (snap / "transformer.safetensors").write_bytes(b"t" * 4096)
+    (snap / "vae.safetensors").write_bytes(b"v" * 4096)
+    _seed_refs_main(repo_root, sha)
+
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+    import huggingface_hub.file_download as _fd
+
+    monkeypatch.setattr(_fd, "HF_HUB_CACHE", str(cache_root), raising=False)
+
+    manifest = snap / "split_model.json"
+    for shape in (
+        "{ this is not valid json",  # malformed
+        "[]",  # not an object
+        "{}",  # object, no components key
+        '{"components": []}',  # empty list
+        '{"components": "transformer"}',  # not a list
+        '{"components": [""]}',  # empty component name
+        '{"components": [123]}',  # non-string component
+    ):
+        manifest.write_text(shape)
+        assert gate._snapshot_is_complete_split_model("vendor/bad-manifest") is False, (
+            shape
+        )
+
+    # And a well-formed manifest over the same on-disk components DOES pass —
+    # proving the False results above are the manifest's doing, not the tree's.
+    manifest.write_text(json.dumps({"components": ["transformer", "vae"]}))
+    assert gate._snapshot_is_complete_split_model("vendor/bad-manifest") is True
+
+
+def test_snapshot_split_model_rejects_path_traversal_component(tmp_path, monkeypatch):
+    """Security: a component name that is absolute, contains a path separator,
+    or contains ``..`` could point ``<component>.safetensors`` outside the
+    snapshot root. The loader never reads such a path, so the helper must
+    reject it rather than stat a file elsewhere on disk."""
+    cache_root = tmp_path / "hf-cache"
+    repo_root = cache_root / "models--vendor--escape-component"
+    sha = "dddddddddddddddddddddddddddddddddddddddd"
+    snap = repo_root / "snapshots" / sha
+    snap.mkdir(parents=True)
+    (snap / "config.json").write_text("{}")
+    (snap / "transformer.safetensors").write_bytes(b"t" * 4096)
+    # A real file at the escaped location the traversal would resolve to.
+    (cache_root / "vae.safetensors").write_bytes(b"v" * 4096)
+    _seed_refs_main(repo_root, sha)
+
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+    import huggingface_hub.file_download as _fd
+
+    monkeypatch.setattr(_fd, "HF_HUB_CACHE", str(cache_root), raising=False)
+
+    import json
+
+    manifest = snap / "split_model.json"
+    for bad in ("../vae", "/etc/passwd", "sub/dir/vae", ".."):
+        manifest.write_text(json.dumps({"components": ["transformer", bad]}))
+        assert (
+            gate._snapshot_is_complete_split_model("vendor/escape-component") is False
+        ), bad
 
 
 def test_is_weightless_stub_true_for_interrupted_multimodal_aux_weight_first(
@@ -1140,8 +1258,8 @@ def test_is_weightless_stub_true_for_interrupted_multimodal_aux_weight_first(
     its index/shards — with NO text-layout signal on disk yet. Inferring
     "non-text" from the absence of ``model*.safetensors`` would misread this as
     a fully-weighted non-text model and wrongly suppress the notice. Requiring
-    a POSITIVE non-text manifest (model_index.json / split_model.json), which a
-    text repo never ships, keeps it a stub so the notice fires."""
+    a POSITIVE mlx-video ``split_model.json`` manifest, which a text repo never
+    ships, keeps it a stub so the notice fires."""
     cache_root = tmp_path / "hf-cache"
     repo_root = cache_root / "models--mlx-community--interrupted-vlm-4bit"
     sha = "5555555555555555555555555555555555555555"
@@ -1159,7 +1277,7 @@ def test_is_weightless_stub_true_for_interrupted_multimodal_aux_weight_first(
     monkeypatch.setattr(_fd, "HF_HUB_CACHE", str(cache_root), raising=False)
 
     assert (
-        gate._snapshot_has_alt_layout_weights("mlx-community/interrupted-vlm-4bit")
+        gate._snapshot_is_complete_split_model("mlx-community/interrupted-vlm-4bit")
         is False
     )
     assert gate.is_repo_cached("mlx-community/interrupted-vlm-4bit") is False
@@ -1188,7 +1306,7 @@ def test_is_weightless_stub_true_for_component_weights_without_manifest(
 
     monkeypatch.setattr(_fd, "HF_HUB_CACHE", str(cache_root), raising=False)
 
-    assert gate._snapshot_has_alt_layout_weights("vendor/manifestless-video") is False
+    assert gate._snapshot_is_complete_split_model("vendor/manifestless-video") is False
     assert gate.is_weightless_stub("vendor/manifestless-video") is True
 
 
@@ -1202,7 +1320,9 @@ def test_is_weightless_stub_false_for_split_model_manifest(tmp_path, monkeypatch
     snap = repo_root / "snapshots" / sha
     snap.mkdir(parents=True)
     (snap / "config.json").write_text('{"model_type": "AudioVideo"}')
-    (snap / "split_model.json").write_text("{}")
+    (snap / "split_model.json").write_text(
+        '{"components": ["transformer", "vae_decoder", "vocoder"]}'
+    )
     (snap / "transformer.safetensors").write_bytes(b"t" * 4096)
     (snap / "vae_decoder.safetensors").write_bytes(b"v" * 4096)
     (snap / "vocoder.safetensors").write_bytes(b"o" * 4096)
@@ -1214,7 +1334,7 @@ def test_is_weightless_stub_false_for_split_model_manifest(tmp_path, monkeypatch
     monkeypatch.setattr(_fd, "HF_HUB_CACHE", str(cache_root), raising=False)
 
     assert (
-        gate._snapshot_has_alt_layout_weights("notapalindrome/ltx23-mlx-av-q4") is True
+        gate._snapshot_is_complete_split_model("notapalindrome/ltx23-mlx-av-q4") is True
     )
     assert gate.is_weightless_stub("notapalindrome/ltx23-mlx-av-q4") is False
 
@@ -1247,7 +1367,7 @@ def test_is_weightless_stub_true_for_partial_text_download(tmp_path, monkeypatch
     # No non-text manifest → not an alt-layout model; the cache is an
     # incomplete text pull, so the stub notice must still fire.
     assert (
-        gate._snapshot_has_alt_layout_weights("mlx-community/gemma-4-27b-it-4bit")
+        gate._snapshot_is_complete_split_model("mlx-community/gemma-4-27b-it-4bit")
         is False
     )
     assert gate.is_repo_cached("mlx-community/gemma-4-27b-it-4bit") is False
@@ -1261,7 +1381,7 @@ def test_is_weightless_stub_true_for_incomplete_text_with_aux_weight(
     auxiliary ``.safetensors`` (e.g. a vision tower) that isn't
     ``model*.safetensors``. That aux file must NOT mask an incomplete text
     shard set. Because the repo ships NO positive non-text manifest,
-    ``_snapshot_has_alt_layout_weights`` returns False and is_repo_cached is
+    ``_snapshot_is_complete_split_model`` returns False and is_repo_cached is
     the sole authority, so the missing shard still fires the notice."""
     cache_root = tmp_path / "hf-cache"
     repo_root = cache_root / "models--mlx-community--some-vlm-4bit"
@@ -1283,7 +1403,9 @@ def test_is_weightless_stub_true_for_incomplete_text_with_aux_weight(
 
     monkeypatch.setattr(_fd, "HF_HUB_CACHE", str(cache_root), raising=False)
 
-    assert gate._snapshot_has_alt_layout_weights("mlx-community/some-vlm-4bit") is False
+    assert (
+        gate._snapshot_is_complete_split_model("mlx-community/some-vlm-4bit") is False
+    )
     assert gate.is_repo_cached("mlx-community/some-vlm-4bit") is False
     assert gate.is_weightless_stub("mlx-community/some-vlm-4bit") is True
 
@@ -1307,26 +1429,30 @@ def test_is_weightless_stub_ignores_adapter_only_safetensors(tmp_path, monkeypat
 
     monkeypatch.setattr(_fd, "HF_HUB_CACHE", str(cache_root), raising=False)
 
-    assert gate._snapshot_has_alt_layout_weights("some/lora-adapter") is False
+    assert gate._snapshot_is_complete_split_model("some/lora-adapter") is False
     assert gate.is_weightless_stub("some/lora-adapter") is True
 
 
-def test_is_weightless_stub_true_for_manifest_plus_lora_only(tmp_path, monkeypatch):
-    """Regression guard (codex round-4 BLOCKING): a diffusers repo can carry a
-    positive manifest (``model_index.json``) yet have ONLY a LoRA sidecar
-    cached — ``pytorch_lora_weights.safetensors`` — with its base components
-    still missing. A LoRA file isn't a primary weight, so it must NOT suppress
-    the notice. The ``adapter``-prefix filter alone would miss the diffusers
-    LoRA name; the ``lora``-substring exclusion catches it."""
+def test_is_weightless_stub_true_for_model_index_without_split_model(
+    tmp_path, monkeypatch
+):
+    """Documented scope limit: a bare diffusers ``model_index.json`` (pipeline
+    manifest) is NOT accepted on its own — it names components but not their
+    on-disk weight filenames (flat vs ``component/`` subdir vs sharded), so it
+    can't be completeness-checked. Only the mlx-video ``split_model.json``
+    manifest is authoritative. A repo shipping model_index.json + component
+    weights but no split_model.json falls back to the (cosmetic) false alarm —
+    the conservative direction — rather than risking a wrong suppression."""
     cache_root = tmp_path / "hf-cache"
-    repo_root = cache_root / "models--vendor--diffusers-lora-pack"
+    repo_root = cache_root / "models--vendor--index-only-diffusers"
     sha = "7777777777777777777777777777777777777777"
     snap = repo_root / "snapshots" / sha
     snap.mkdir(parents=True)
     (snap / "config.json").write_text("{}")
     (snap / "model_index.json").write_text('{"_class_name": "SomePipeline"}')
-    # Only the LoRA delta is cached — no base transformer/vae components.
-    (snap / "pytorch_lora_weights.safetensors").write_bytes(b"l" * 4096)
+    # Full component weights present — but no split_model.json manifest.
+    (snap / "transformer.safetensors").write_bytes(b"t" * 4096)
+    (snap / "vae.safetensors").write_bytes(b"v" * 4096)
     _seed_refs_main(repo_root, sha)
 
     monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
@@ -1334,8 +1460,10 @@ def test_is_weightless_stub_true_for_manifest_plus_lora_only(tmp_path, monkeypat
 
     monkeypatch.setattr(_fd, "HF_HUB_CACHE", str(cache_root), raising=False)
 
-    assert gate._snapshot_has_alt_layout_weights("vendor/diffusers-lora-pack") is False
-    assert gate.is_weightless_stub("vendor/diffusers-lora-pack") is True
+    assert (
+        gate._snapshot_is_complete_split_model("vendor/index-only-diffusers") is False
+    )
+    assert gate.is_weightless_stub("vendor/index-only-diffusers") is True
 
 
 def test_is_weightless_stub_true_for_dangling_text_shard_with_aux_weight(
@@ -1344,7 +1472,7 @@ def test_is_weightless_stub_true_for_dangling_text_shard_with_aux_weight(
     """A corrupted/interrupted text snapshot whose ``model-*.safetensors``
     shard is a DANGLING symlink (target not yet materialized) — plus an
     auxiliary ``vision_model.safetensors`` — must still be a stub. It ships no
-    positive non-text manifest, so ``_snapshot_has_alt_layout_weights`` returns
+    positive non-text manifest, so ``_snapshot_is_complete_split_model`` returns
     False and is_repo_cached (which treats the dangling shard as incomplete) is
     the sole authority. The aux weight cannot mask the incomplete cache."""
     cache_root = tmp_path / "hf-cache"
@@ -1367,7 +1495,7 @@ def test_is_weightless_stub_true_for_dangling_text_shard_with_aux_weight(
     monkeypatch.setattr(_fd, "HF_HUB_CACHE", str(cache_root), raising=False)
 
     assert (
-        gate._snapshot_has_alt_layout_weights("mlx-community/dangling-vlm-4bit")
+        gate._snapshot_is_complete_split_model("mlx-community/dangling-vlm-4bit")
         is False
     )
     assert gate.is_repo_cached("mlx-community/dangling-vlm-4bit") is False

--- a/tests/test_download_gate.py
+++ b/tests/test_download_gate.py
@@ -1250,6 +1250,43 @@ def test_snapshot_split_model_rejects_path_traversal_component(tmp_path, monkeyp
         ), bad
 
 
+def test_snapshot_split_model_rejects_directory_named_component(tmp_path, monkeypatch):
+    """Codex round-5 MAJOR: ``os.path.getsize`` reports a positive size for a
+    directory, so a component that is a DIRECTORY named
+    ``vae.safetensors/`` (or a symlink to a directory inside the repo root)
+    would pass a size-only check even though the real weight never arrived.
+    The helper must require a regular file (``os.path.isfile``), so this stays
+    incomplete and the notice still fires."""
+    cache_root = tmp_path / "hf-cache"
+    repo_root = cache_root / "models--vendor--dir-component"
+    sha = "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee0"
+    snap = repo_root / "snapshots" / sha
+    snap.mkdir(parents=True)
+    (snap / "config.json").write_text("{}")
+    (snap / "split_model.json").write_text('{"components": ["transformer", "vae"]}')
+    (snap / "transformer.safetensors").write_bytes(b"t" * 4096)
+    # ``vae`` is a DIRECTORY, not a weight file — getsize() > 0 but not a file.
+    (snap / "vae.safetensors").mkdir()
+    (snap / "vae.safetensors" / "placeholder").write_bytes(b"x" * 16)
+    _seed_refs_main(repo_root, sha)
+
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+    import huggingface_hub.file_download as _fd
+
+    monkeypatch.setattr(_fd, "HF_HUB_CACHE", str(cache_root), raising=False)
+
+    assert gate._snapshot_is_complete_split_model("vendor/dir-component") is False
+    assert gate.is_weightless_stub("vendor/dir-component") is True
+
+    # A symlink-to-directory at the component path is the same failure mode.
+    (snap / "vae.safetensors" / "placeholder").unlink()
+    (snap / "vae.safetensors").rmdir()
+    real_dir = snap / "vae_real_dir"
+    real_dir.mkdir()
+    (snap / "vae.safetensors").symlink_to(real_dir)
+    assert gate._snapshot_is_complete_split_model("vendor/dir-component") is False
+
+
 def test_is_weightless_stub_true_for_interrupted_multimodal_aux_weight_first(
     tmp_path, monkeypatch
 ):

--- a/tests/test_download_gate.py
+++ b/tests/test_download_gate.py
@@ -1311,6 +1311,33 @@ def test_is_weightless_stub_ignores_adapter_only_safetensors(tmp_path, monkeypat
     assert gate.is_weightless_stub("some/lora-adapter") is True
 
 
+def test_is_weightless_stub_true_for_manifest_plus_lora_only(tmp_path, monkeypatch):
+    """Regression guard (codex round-4 BLOCKING): a diffusers repo can carry a
+    positive manifest (``model_index.json``) yet have ONLY a LoRA sidecar
+    cached — ``pytorch_lora_weights.safetensors`` — with its base components
+    still missing. A LoRA file isn't a primary weight, so it must NOT suppress
+    the notice. The ``adapter``-prefix filter alone would miss the diffusers
+    LoRA name; the ``lora``-substring exclusion catches it."""
+    cache_root = tmp_path / "hf-cache"
+    repo_root = cache_root / "models--vendor--diffusers-lora-pack"
+    sha = "7777777777777777777777777777777777777777"
+    snap = repo_root / "snapshots" / sha
+    snap.mkdir(parents=True)
+    (snap / "config.json").write_text("{}")
+    (snap / "model_index.json").write_text('{"_class_name": "SomePipeline"}')
+    # Only the LoRA delta is cached — no base transformer/vae components.
+    (snap / "pytorch_lora_weights.safetensors").write_bytes(b"l" * 4096)
+    _seed_refs_main(repo_root, sha)
+
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+    import huggingface_hub.file_download as _fd
+
+    monkeypatch.setattr(_fd, "HF_HUB_CACHE", str(cache_root), raising=False)
+
+    assert gate._snapshot_has_alt_layout_weights("vendor/diffusers-lora-pack") is False
+    assert gate.is_weightless_stub("vendor/diffusers-lora-pack") is True
+
+
 def test_is_weightless_stub_true_for_dangling_text_shard_with_aux_weight(
     tmp_path, monkeypatch
 ):

--- a/vllm_mlx/_download_gate.py
+++ b/vllm_mlx/_download_gate.py
@@ -438,10 +438,22 @@ def is_repo_cached(repo_id: str) -> bool:
     return False
 
 
+# Root-level manifests that POSITIVELY identify a non-text (component-split /
+# diffusers) model layout — the kind whose weights mlx-lm's text
+# ``model*.safetensors`` glob can't see. Requiring one of these before we
+# accept alternate-layout weights (rather than inferring "non-text" from the
+# mere absence of text files) is what keeps an interrupted *text* / multimodal
+# download — where an auxiliary weight lands before the index/shards — from
+# being misread as fully weighted (codex BLOCKING). Text LLMs never ship
+# either file: ``model_index.json`` is the diffusers pipeline manifest and
+# ``split_model.json`` is mlx-video's component-split manifest.
+_NON_TEXT_LAYOUT_MANIFESTS = ("model_index.json", "split_model.json")
+
+
 def _snapshot_has_alt_layout_weights(repo_id: str) -> bool:
-    """True if the resolved snapshot is a NON-text model whose weights are
-    present in a layout mlx-lm's text ``model*.safetensors`` root-glob can't
-    see.
+    """True if the resolved snapshot is a POSITIVELY-identified non-text model
+    whose weights are present in a layout mlx-lm's text ``model*.safetensors``
+    root-glob can't see.
 
     Non-text models don't lay their weights out the way :func:`is_repo_cached`
     (which mirrors mlx-lm's text loader) expects. Video-gen repos ship
@@ -455,28 +467,30 @@ def _snapshot_has_alt_layout_weights(repo_id: str) -> bool:
     :func:`is_weightless_stub` cry wolf ("config cached, weights missing —
     will download ~N GB") on every serve of an already-downloaded video model.
 
-    Text-model guard (codex-caught regression): a TEXT / multimodal repo can
-    ALSO carry auxiliary ``.safetensors`` (a ``vision_model.safetensors``
-    tower, an adapter, a neighbour of a half-downloaded shard). If we counted
-    those, an *incomplete* text cache — one whose ``model-*`` shards are still
-    missing — could get its stub notice wrongly suppressed. So when the
-    snapshot shows a text-layout signal (a ``model.safetensors.index.json`` or
-    ANY root ``model*.safetensors``), this is a text model and its
-    completeness is :func:`is_repo_cached`'s sole call; we bail with ``False``.
-    That also keeps the finding-⑥ intent for a partial text download intact.
+    Positive identification (codex BLOCKING): a TEXT / multimodal repo can ALSO
+    carry auxiliary ``.safetensors`` (a ``vision_model.safetensors`` tower, an
+    adapter, a neighbour of a half-downloaded shard). Inferring "non-text" from
+    the mere *absence* of text files would misread an interrupted multimodal
+    text download — one whose auxiliary weight arrived before the index/shards
+    — as fully weighted and wrongly suppress its notice. So we require a
+    POSITIVE non-text-layout marker (:data:`_NON_TEXT_LAYOUT_MANIFESTS`, probed
+    by bare directory-entry name) before accepting any alternate weight. Text
+    LLMs never carry those manifests, so an incomplete text cache always falls
+    through to :func:`is_repo_cached`.
 
     Adapter / LoRA sidecars (``adapter*.safetensors``) aren't a model's
-    primary weights, so a repo shipping only those is not "weighted" for
-    serve and doesn't count. Cache-hygiene: only a ``.safetensors`` whose
-    realpath stays inside this repo's own cache dir counts (HF snapshots
+    primary weights and don't count. Cache-hygiene: only a ``.safetensors``
+    whose realpath stays inside this repo's own cache dir counts (HF snapshots
     symlink into ``<repo_root>/blobs/``); a symlink escaping to an unrelated
     file must not suppress the notice.
 
     Scope note: this establishes weights are *present*, not that a non-text
     cache is *complete* (component-completeness would need each loader's
-    manifest, which we don't have here). An interrupted video pull may thus
-    skip the notice — acceptable, since it's purely cosmetic and the download
-    path still fetches whatever is missing.
+    manifest). An interrupted video pull that already has its manifest + one
+    component may thus skip the notice — acceptable, since it's purely cosmetic
+    and the download path still fetches whatever is missing. A non-text repo
+    that ships NEITHER manifest simply falls back to the old (cosmetic) false
+    alarm rather than a wrong suppression.
 
     Mirrors :func:`is_repo_cached`'s snapshot resolution (``refs/main`` →
     pinned sha) so both read the same on-disk snapshot. Returns ``False`` on
@@ -496,19 +510,15 @@ def _snapshot_has_alt_layout_weights(repo_id: str) -> bool:
         if not os.path.isdir(snap_dir):
             return False
 
-        # Text-layout signal → this is is_repo_cached's job alone; never let
-        # an auxiliary weight mask an incomplete text shard set. Probe by bare
-        # directory-entry NAME, not os.path.exists/isfile: a dangling shard
-        # symlink (or a symlink-to-dir) is still the loader's signal that this
-        # is a text model — exactly how _snapshot_is_complete treats a
-        # corrupted root glob entry as incomplete rather than absent.
         try:
-            root_entries = os.listdir(snap_dir)
+            root_entries = set(os.listdir(snap_dir))
         except OSError:
             return False
-        if "model.safetensors.index.json" in root_entries:
-            return False
-        if any(_is_model_weight_filename(name) for name in root_entries):
+        # Require POSITIVE evidence of a non-text layout — never infer it from
+        # the absence of text files (that misreads interrupted multimodal text
+        # downloads). Probe by bare name so a dangling manifest symlink still
+        # counts as the marker.
+        if not any(m in root_entries for m in _NON_TEXT_LAYOUT_MANIFESTS):
             return False
 
         repo_root_real = os.path.realpath(repo_root)

--- a/vllm_mlx/_download_gate.py
+++ b/vllm_mlx/_download_gate.py
@@ -438,62 +438,40 @@ def is_repo_cached(repo_id: str) -> bool:
     return False
 
 
-# Root-level manifests that POSITIVELY identify a non-text (component-split /
-# diffusers) model layout — the kind whose weights mlx-lm's text
-# ``model*.safetensors`` glob can't see. Requiring one of these before we
-# accept alternate-layout weights (rather than inferring "non-text" from the
-# mere absence of text files) is what keeps an interrupted *text* / multimodal
-# download — where an auxiliary weight lands before the index/shards — from
-# being misread as fully weighted (codex BLOCKING). Text LLMs never ship
-# either file: ``model_index.json`` is the diffusers pipeline manifest and
-# ``split_model.json`` is mlx-video's component-split manifest.
-_NON_TEXT_LAYOUT_MANIFESTS = ("model_index.json", "split_model.json")
+def _snapshot_is_complete_split_model(repo_id: str) -> bool:
+    """True if the resolved snapshot is a mlx-video component-split model whose
+    EVERY declared component weight is cached — the non-text analogue of
+    :func:`is_repo_cached` (which only knows mlx-lm's text
+    ``model*.safetensors`` layout).
 
-
-def _snapshot_has_alt_layout_weights(repo_id: str) -> bool:
-    """True if the resolved snapshot is a POSITIVELY-identified non-text model
-    whose weights are present in a layout mlx-lm's text ``model*.safetensors``
-    root-glob can't see.
-
-    Non-text models don't lay their weights out the way :func:`is_repo_cached`
-    (which mirrors mlx-lm's text loader) expects. Video-gen repos ship
-    component files at the snapshot root — CogVideoX-Fun has
-    ``transformer.safetensors`` / ``vae.safetensors`` / ``text_encoder.safetensors``,
-    LTX-2.3 has ``transformer.safetensors`` / ``vae_encoder.safetensors`` /
-    ``vocoder.safetensors`` / … — and diffusers repos nest them in
-    ``transformer/`` / ``vae/`` subdirectories. None of those match
-    ``model*.safetensors`` at the root, so ``is_repo_cached`` reads a fully
-    cached video model as *weightless*, which would make
+    Video-gen repos don't lay their weights out the way the text loader
+    expects: they ship one ``<component>.safetensors`` per component at the
+    snapshot root (CogVideoX-Fun → ``transformer`` / ``text_encoder`` / ``vae``;
+    LTX-2.3 → ``transformer`` / ``connector`` / ``vae_decoder`` / ``vocoder`` /
+    …), never a ``model*.safetensors``. ``is_repo_cached`` therefore reads a
+    fully-cached video model as *weightless*, which would make
     :func:`is_weightless_stub` cry wolf ("config cached, weights missing —
     will download ~N GB") on every serve of an already-downloaded video model.
 
-    Positive identification (codex BLOCKING): a TEXT / multimodal repo can ALSO
-    carry auxiliary ``.safetensors`` (a ``vision_model.safetensors`` tower, an
-    adapter, a neighbour of a half-downloaded shard). Inferring "non-text" from
-    the mere *absence* of text files would misread an interrupted multimodal
-    text download — one whose auxiliary weight arrived before the index/shards
-    — as fully weighted and wrongly suppress its notice. So we require a
-    POSITIVE non-text-layout marker (:data:`_NON_TEXT_LAYOUT_MANIFESTS`, probed
-    by bare directory-entry name) before accepting any alternate weight. Text
-    LLMs never carry those manifests, so an incomplete text cache always falls
-    through to :func:`is_repo_cached`.
+    Completeness, not mere presence (codex BLOCKING): we DON'T infer "non-text,
+    weighted" from the presence of any stray ``.safetensors`` — that would
+    misread (a) an interrupted multimodal *text* download whose vision tower
+    landed before its shards, or (b) an interrupted *video* pull that has only
+    one of its components. Instead we anchor on ``split_model.json`` — the
+    mlx-video manifest that positively identifies the layout AND enumerates the
+    exact component list — and require EVERY ``<component>.safetensors`` to be
+    present and non-empty, exactly as :func:`_snapshot_is_complete` walks the
+    text ``weight_map``. A text LLM never ships ``split_model.json``, so an
+    incomplete text cache always falls through to :func:`is_repo_cached`; a
+    partial video cache fails a component check and also falls through.
 
-    Adapter / LoRA sidecars aren't a model's primary weights and don't count —
-    PEFT ``adapter*.safetensors`` and the diffusers LoRA convention
-    (``pytorch_lora_weights.safetensors`` / any ``*lora*`` name), so a
-    LoRA-only pack whose base components are still missing doesn't look
-    weighted. Cache-hygiene: only a ``.safetensors`` whose realpath stays
-    inside this repo's own cache dir counts (HF snapshots symlink into
-    ``<repo_root>/blobs/``); a symlink escaping to an unrelated file must not
-    suppress the notice.
-
-    Scope note: this establishes weights are *present*, not that a non-text
-    cache is *complete* (component-completeness would need each loader's
-    manifest). An interrupted video pull that already has its manifest + one
-    component may thus skip the notice — acceptable, since it's purely cosmetic
-    and the download path still fetches whatever is missing. A non-text repo
-    that ships NEITHER manifest simply falls back to the old (cosmetic) false
-    alarm rather than a wrong suppression.
+    ``model_index.json`` (bare diffusers pipeline manifest) is intentionally
+    NOT accepted on its own: it names components but not their on-disk weight
+    filenames (flat file vs ``component/`` subdir vs sharded — packaging
+    dependent), so it can't be completeness-checked reliably here. Both rapid-
+    mlx video families (CogVideoX-Fun, LTX-2.3) ship ``split_model.json``; a
+    hypothetical manifest-less / index-only repo simply falls back to the
+    (cosmetic) false alarm rather than risking a wrong suppression.
 
     Mirrors :func:`is_repo_cached`'s snapshot resolution (``refs/main`` →
     pinned sha) so both read the same on-disk snapshot. Returns ``False`` on
@@ -513,47 +491,46 @@ def _snapshot_has_alt_layout_weights(repo_id: str) -> bool:
         if not os.path.isdir(snap_dir):
             return False
 
-        try:
-            root_entries = set(os.listdir(snap_dir))
-        except OSError:
+        manifest_path = os.path.join(snap_dir, "split_model.json")
+        if not os.path.isfile(manifest_path):
             return False
-        # Require POSITIVE evidence of a non-text layout — never infer it from
-        # the absence of text files (that misreads interrupted multimodal text
-        # downloads). Probe by bare name so a dangling manifest symlink still
-        # counts as the marker.
-        if not any(m in root_entries for m in _NON_TEXT_LAYOUT_MANIFESTS):
+        import json
+
+        try:
+            with open(manifest_path) as fh:
+                manifest = json.load(fh)
+        except (OSError, json.JSONDecodeError):
+            return False
+        components = manifest.get("components") if isinstance(manifest, dict) else None
+        # A manifest that names no components tells us nothing is complete.
+        if not isinstance(components, list) or not components:
             return False
 
         repo_root_real = os.path.realpath(repo_root)
-        for dirpath, _dirnames, filenames in os.walk(snap_dir):
-            for fname in filenames:
-                if not fname.endswith(".safetensors"):
-                    continue
-                # Adapter / LoRA sidecars aren't a model's primary weights, so
-                # a repo shipping ONLY those (a LoRA-only diffusers pack with
-                # its base components still missing) must not look weighted.
-                # Covers PEFT ``adapter*.safetensors`` and the diffusers LoRA
-                # convention ``pytorch_lora_weights.safetensors`` / any
-                # ``*_lora_*`` / ``*lora*`` name. Over-excluding fails SAFE
-                # (back to the cosmetic false alarm); under-excluding would
-                # wrongly suppress the notice.
-                _low = fname.lower()
-                if _low.startswith("adapter") or "lora" in _low:
-                    continue
-                fpath = os.path.join(dirpath, fname)
-                # Only count a file whose real target lives inside this repo's
-                # cache dir (snapshots symlink into ``<repo_root>/blobs/``).
-                real = os.path.realpath(fpath)
-                if real != repo_root_real and not real.startswith(
-                    repo_root_real + os.sep
-                ):
-                    continue
-                try:
-                    if os.path.getsize(fpath) > 0:
-                        return True
-                except OSError:
-                    continue
-        return False
+        for component in components:
+            # Component names become ``<component>.safetensors`` at the
+            # snapshot root; reject anything that could escape it.
+            if not isinstance(component, str) or not component:
+                return False
+            if (
+                os.path.isabs(component)
+                or os.sep in component
+                or "/" in component
+                or ".." in component.split("/")
+            ):
+                return False
+            fpath = os.path.join(snap_dir, f"{component}.safetensors")
+            # The file (via its blob symlink) must resolve inside this repo's
+            # own cache dir — a symlink escaping elsewhere doesn't count.
+            real = os.path.realpath(fpath)
+            if real != repo_root_real and not real.startswith(repo_root_real + os.sep):
+                return False
+            try:
+                if os.path.getsize(fpath) <= 0:
+                    return False
+            except OSError:
+                return False
+        return True
     except Exception:
         return False
 
@@ -581,9 +558,9 @@ def is_weightless_stub(repo_id: str) -> bool:
     diffusers repos never satisfy (their weights are component files like
     ``transformer.safetensors`` / ``vae.safetensors``). A fully-cached
     video model would therefore look weightless and mis-fire this notice on
-    every serve. :func:`_snapshot_has_alt_layout_weights` detects that
-    alt layout so the stub notice stays scoped to genuinely-empty text
-    stubs.
+    every serve. :func:`_snapshot_is_complete_split_model` validates the
+    mlx-video ``split_model.json`` component manifest so the stub notice
+    stays scoped to genuinely-incomplete caches.
 
     Returns ``False`` on any internal error — a best-effort diagnostic
     must never break an otherwise-fine serve.
@@ -600,11 +577,12 @@ def is_weightless_stub(repo_id: str) -> bool:
         cached_config = try_to_load_from_cache(repo_id, "config.json")
         if not isinstance(cached_config, str):
             return False
-        # A non-text model (video-gen / diffusers) stores its weights as
-        # component files the text glob can't see — those are present, not
-        # "missing", so it's not a stub. Check this BEFORE the text-glob
-        # probe so a fully-cached video model doesn't mis-fire the notice.
-        if _snapshot_has_alt_layout_weights(repo_id):
+        # A component-split non-text model (video-gen) stores its weights as
+        # per-component files the text glob can't see. If its split_model.json
+        # manifest lists components and EVERY one is cached, the weights are
+        # present — not a stub. Check this BEFORE the text-glob probe so a
+        # fully-cached video model doesn't mis-fire the notice.
+        if _snapshot_is_complete_split_model(repo_id):
             return False
         # Config is on disk; the stub is exactly "config present but the
         # loader's weight glob (model*.safetensors) is not satisfied".

--- a/vllm_mlx/_download_gate.py
+++ b/vllm_mlx/_download_gate.py
@@ -438,6 +438,67 @@ def is_repo_cached(repo_id: str) -> bool:
     return False
 
 
+def _snapshot_has_alt_layout_weights(repo_id: str) -> bool:
+    """True if the resolved snapshot holds non-empty ``.safetensors`` weights
+    that mlx-lm's text ``model*.safetensors`` root-glob does NOT pick up.
+
+    Non-text models don't lay their weights out the way :func:`is_repo_cached`
+    (which mirrors mlx-lm's text loader) expects. Video-gen repos ship
+    component files at the snapshot root — CogVideoX-Fun has
+    ``transformer.safetensors`` / ``vae.safetensors`` / ``text_encoder.safetensors``,
+    LTX-2.3 has ``transformer.safetensors`` / ``vae_encoder.safetensors`` /
+    ``vocoder.safetensors`` / … — and diffusers repos nest them in
+    ``transformer/`` / ``vae/`` subdirectories. None of those match
+    ``model*.safetensors`` at the root, so ``is_repo_cached`` reads a fully
+    cached video model as *weightless*, which would make
+    :func:`is_weightless_stub` cry wolf ("config cached, weights missing —
+    will download ~N GB") on every serve of an already-downloaded video model.
+
+    A partial *text* download (``model-00001-of-00002.safetensors`` present,
+    a later shard still missing) is deliberately NOT matched: its shard names
+    begin with ``model`` at the snapshot root, so they're treated as the text
+    loader's own weights and skipped here — leaving that repo to flow through
+    to the stub notice, which is exactly finding ⑥'s original intent.
+
+    Mirrors :func:`is_repo_cached`'s snapshot resolution (``refs/main`` →
+    pinned sha) so both read the same on-disk snapshot. Returns ``False`` on
+    any internal error so the caller defaults to the existing text-glob path.
+    """
+    try:
+        from huggingface_hub.constants import HF_HUB_CACHE
+
+        repo_root = os.path.join(
+            HF_HUB_CACHE,
+            f"models--{repo_id.replace('/', '--')}",
+        )
+        resolved_sha = _resolved_snapshot_sha(repo_root)
+        if resolved_sha is None:
+            return False
+        snap_dir = os.path.join(repo_root, "snapshots", resolved_sha)
+        if not os.path.isdir(snap_dir):
+            return False
+        snap_real = os.path.realpath(snap_dir)
+        for dirpath, _dirnames, filenames in os.walk(snap_dir):
+            at_root = os.path.realpath(dirpath) == snap_real
+            for fname in filenames:
+                if not fname.endswith(".safetensors"):
+                    continue
+                # A text-loader weight is ``model*.safetensors`` AT the
+                # snapshot root; that's is_repo_cached's job, not ours.
+                # Anything else — a component file, or a nested shard — is
+                # an alt-layout weight the text glob can't see.
+                if at_root and _is_model_weight_filename(fname):
+                    continue
+                try:
+                    if os.path.getsize(os.path.join(dirpath, fname)) > 0:
+                        return True
+                except OSError:
+                    continue
+        return False
+    except Exception:
+        return False
+
+
 def is_weightless_stub(repo_id: str) -> bool:
     """True if ``repo_id``'s config is cached but its weight shards are NOT.
 
@@ -456,6 +517,15 @@ def is_weightless_stub(repo_id: str) -> bool:
     instead of a generic notice. Local paths and never-touched repos
     return ``False``.
 
+    Non-text scope (video-gen false-alarm fix): the underlying weight
+    probe is mlx-lm's text glob ``model*.safetensors``, which video-gen /
+    diffusers repos never satisfy (their weights are component files like
+    ``transformer.safetensors`` / ``vae.safetensors``). A fully-cached
+    video model would therefore look weightless and mis-fire this notice on
+    every serve. :func:`_snapshot_has_alt_layout_weights` detects that
+    alt layout so the stub notice stays scoped to genuinely-empty text
+    stubs.
+
     Returns ``False`` on any internal error — a best-effort diagnostic
     must never break an otherwise-fine serve.
     """
@@ -470,6 +540,12 @@ def is_weightless_stub(repo_id: str) -> bool:
         # a real cached path (str) counts as "config present".
         cached_config = try_to_load_from_cache(repo_id, "config.json")
         if not isinstance(cached_config, str):
+            return False
+        # A non-text model (video-gen / diffusers) stores its weights as
+        # component files the text glob can't see — those are present, not
+        # "missing", so it's not a stub. Check this BEFORE the text-glob
+        # probe so a fully-cached video model doesn't mis-fire the notice.
+        if _snapshot_has_alt_layout_weights(repo_id):
             return False
         # Config is on disk; the stub is exactly "config present but the
         # loader's weight glob (model*.safetensors) is not satisfied".

--- a/vllm_mlx/_download_gate.py
+++ b/vllm_mlx/_download_gate.py
@@ -439,8 +439,9 @@ def is_repo_cached(repo_id: str) -> bool:
 
 
 def _snapshot_has_alt_layout_weights(repo_id: str) -> bool:
-    """True if the resolved snapshot holds non-empty ``.safetensors`` weights
-    that mlx-lm's text ``model*.safetensors`` root-glob does NOT pick up.
+    """True if the resolved snapshot is a NON-text model whose weights are
+    present in a layout mlx-lm's text ``model*.safetensors`` root-glob can't
+    see.
 
     Non-text models don't lay their weights out the way :func:`is_repo_cached`
     (which mirrors mlx-lm's text loader) expects. Video-gen repos ship
@@ -454,11 +455,28 @@ def _snapshot_has_alt_layout_weights(repo_id: str) -> bool:
     :func:`is_weightless_stub` cry wolf ("config cached, weights missing —
     will download ~N GB") on every serve of an already-downloaded video model.
 
-    A partial *text* download (``model-00001-of-00002.safetensors`` present,
-    a later shard still missing) is deliberately NOT matched: its shard names
-    begin with ``model`` at the snapshot root, so they're treated as the text
-    loader's own weights and skipped here — leaving that repo to flow through
-    to the stub notice, which is exactly finding ⑥'s original intent.
+    Text-model guard (codex-caught regression): a TEXT / multimodal repo can
+    ALSO carry auxiliary ``.safetensors`` (a ``vision_model.safetensors``
+    tower, an adapter, a neighbour of a half-downloaded shard). If we counted
+    those, an *incomplete* text cache — one whose ``model-*`` shards are still
+    missing — could get its stub notice wrongly suppressed. So when the
+    snapshot shows a text-layout signal (a ``model.safetensors.index.json`` or
+    ANY root ``model*.safetensors``), this is a text model and its
+    completeness is :func:`is_repo_cached`'s sole call; we bail with ``False``.
+    That also keeps the finding-⑥ intent for a partial text download intact.
+
+    Adapter / LoRA sidecars (``adapter*.safetensors``) aren't a model's
+    primary weights, so a repo shipping only those is not "weighted" for
+    serve and doesn't count. Cache-hygiene: only a ``.safetensors`` whose
+    realpath stays inside this repo's own cache dir counts (HF snapshots
+    symlink into ``<repo_root>/blobs/``); a symlink escaping to an unrelated
+    file must not suppress the notice.
+
+    Scope note: this establishes weights are *present*, not that a non-text
+    cache is *complete* (component-completeness would need each loader's
+    manifest, which we don't have here). An interrupted video pull may thus
+    skip the notice — acceptable, since it's purely cosmetic and the download
+    path still fetches whatever is missing.
 
     Mirrors :func:`is_repo_cached`'s snapshot resolution (``refs/main`` →
     pinned sha) so both read the same on-disk snapshot. Returns ``False`` on
@@ -477,20 +495,40 @@ def _snapshot_has_alt_layout_weights(repo_id: str) -> bool:
         snap_dir = os.path.join(repo_root, "snapshots", resolved_sha)
         if not os.path.isdir(snap_dir):
             return False
-        snap_real = os.path.realpath(snap_dir)
+
+        # Text-layout signal → this is is_repo_cached's job alone; never let
+        # an auxiliary weight mask an incomplete text shard set.
+        if os.path.exists(os.path.join(snap_dir, "model.safetensors.index.json")):
+            return False
+        try:
+            root_entries = os.listdir(snap_dir)
+        except OSError:
+            return False
+        if any(
+            _is_model_weight_filename(name)
+            and os.path.isfile(os.path.join(snap_dir, name))
+            for name in root_entries
+        ):
+            return False
+
+        repo_root_real = os.path.realpath(repo_root)
         for dirpath, _dirnames, filenames in os.walk(snap_dir):
-            at_root = os.path.realpath(dirpath) == snap_real
             for fname in filenames:
                 if not fname.endswith(".safetensors"):
                     continue
-                # A text-loader weight is ``model*.safetensors`` AT the
-                # snapshot root; that's is_repo_cached's job, not ours.
-                # Anything else — a component file, or a nested shard — is
-                # an alt-layout weight the text glob can't see.
-                if at_root and _is_model_weight_filename(fname):
+                # Adapter / LoRA sidecars aren't primary weights.
+                if fname.lower().startswith("adapter"):
+                    continue
+                fpath = os.path.join(dirpath, fname)
+                # Only count a file whose real target lives inside this repo's
+                # cache dir (snapshots symlink into ``<repo_root>/blobs/``).
+                real = os.path.realpath(fpath)
+                if real != repo_root_real and not real.startswith(
+                    repo_root_real + os.sep
+                ):
                     continue
                 try:
-                    if os.path.getsize(os.path.join(dirpath, fname)) > 0:
+                    if os.path.getsize(fpath) > 0:
                         return True
                 except OSError:
                     continue

--- a/vllm_mlx/_download_gate.py
+++ b/vllm_mlx/_download_gate.py
@@ -520,6 +520,14 @@ def _snapshot_is_complete_split_model(repo_id: str) -> bool:
             ):
                 return False
             fpath = os.path.join(snap_dir, f"{component}.safetensors")
+            # Must be a real regular file (following the blob symlink), not a
+            # directory named ``<component>.safetensors`` nor a dangling /
+            # directory symlink — ``os.path.getsize`` alone reports a positive
+            # size for a directory, so an empty ``vae.safetensors/`` dir would
+            # otherwise pass. ``isfile`` follows symlinks and is False for
+            # symlink→dir and dangling symlinks (codex round-5 MAJOR).
+            if not os.path.isfile(fpath):
+                return False
             # The file (via its blob symlink) must resolve inside this repo's
             # own cache dir — a symlink escaping elsewhere doesn't count.
             real = os.path.realpath(fpath)

--- a/vllm_mlx/_download_gate.py
+++ b/vllm_mlx/_download_gate.py
@@ -497,18 +497,18 @@ def _snapshot_has_alt_layout_weights(repo_id: str) -> bool:
             return False
 
         # Text-layout signal → this is is_repo_cached's job alone; never let
-        # an auxiliary weight mask an incomplete text shard set.
-        if os.path.exists(os.path.join(snap_dir, "model.safetensors.index.json")):
-            return False
+        # an auxiliary weight mask an incomplete text shard set. Probe by bare
+        # directory-entry NAME, not os.path.exists/isfile: a dangling shard
+        # symlink (or a symlink-to-dir) is still the loader's signal that this
+        # is a text model — exactly how _snapshot_is_complete treats a
+        # corrupted root glob entry as incomplete rather than absent.
         try:
             root_entries = os.listdir(snap_dir)
         except OSError:
             return False
-        if any(
-            _is_model_weight_filename(name)
-            and os.path.isfile(os.path.join(snap_dir, name))
-            for name in root_entries
-        ):
+        if "model.safetensors.index.json" in root_entries:
+            return False
+        if any(_is_model_weight_filename(name) for name in root_entries):
             return False
 
         repo_root_real = os.path.realpath(repo_root)

--- a/vllm_mlx/_download_gate.py
+++ b/vllm_mlx/_download_gate.py
@@ -478,11 +478,14 @@ def _snapshot_has_alt_layout_weights(repo_id: str) -> bool:
     LLMs never carry those manifests, so an incomplete text cache always falls
     through to :func:`is_repo_cached`.
 
-    Adapter / LoRA sidecars (``adapter*.safetensors``) aren't a model's
-    primary weights and don't count. Cache-hygiene: only a ``.safetensors``
-    whose realpath stays inside this repo's own cache dir counts (HF snapshots
-    symlink into ``<repo_root>/blobs/``); a symlink escaping to an unrelated
-    file must not suppress the notice.
+    Adapter / LoRA sidecars aren't a model's primary weights and don't count —
+    PEFT ``adapter*.safetensors`` and the diffusers LoRA convention
+    (``pytorch_lora_weights.safetensors`` / any ``*lora*`` name), so a
+    LoRA-only pack whose base components are still missing doesn't look
+    weighted. Cache-hygiene: only a ``.safetensors`` whose realpath stays
+    inside this repo's own cache dir counts (HF snapshots symlink into
+    ``<repo_root>/blobs/``); a symlink escaping to an unrelated file must not
+    suppress the notice.
 
     Scope note: this establishes weights are *present*, not that a non-text
     cache is *complete* (component-completeness would need each loader's
@@ -526,8 +529,16 @@ def _snapshot_has_alt_layout_weights(repo_id: str) -> bool:
             for fname in filenames:
                 if not fname.endswith(".safetensors"):
                     continue
-                # Adapter / LoRA sidecars aren't primary weights.
-                if fname.lower().startswith("adapter"):
+                # Adapter / LoRA sidecars aren't a model's primary weights, so
+                # a repo shipping ONLY those (a LoRA-only diffusers pack with
+                # its base components still missing) must not look weighted.
+                # Covers PEFT ``adapter*.safetensors`` and the diffusers LoRA
+                # convention ``pytorch_lora_weights.safetensors`` / any
+                # ``*_lora_*`` / ``*lora*`` name. Over-excluding fails SAFE
+                # (back to the cosmetic false alarm); under-excluding would
+                # wrongly suppress the notice.
+                _low = fname.lower()
+                if _low.startswith("adapter") or "lora" in _low:
                     continue
                 fpath = os.path.join(dirpath, fname)
                 # Only count a file whose real target lives inside this repo's


### PR DESCRIPTION
## Why

`rapid-mlx serve <video-alias>` prints a **false** pre-serve notice —

> Note: <repo> has its config cached but its model weights are missing — serving will start by downloading the missing weights first.

— on **every** start of a fully-cached video model (CogVideoX-Fun `#1313`, LTX-2.3 `#1298`), even though nothing downloads (the immediately-following `Fetching N files: 100%|…| [00:00]` proves it). Purely cosmetic — the model serves and generates fine — but it misleads users into thinking they're re-pulling 13–22 GB on every launch. Found during release-prep dogfood.

**Root cause:** `is_weightless_stub` probes for weights via `is_repo_cached`, which mirrors mlx-lm's **text** loader glob `model*.safetensors`. Video-gen repos never ship that name — their weights are component files (`transformer.safetensors`, `vae.safetensors`, `text_encoder.safetensors`, …) at the snapshot root — so the glob finds zero "model weights" and a fully-cached model looks weightless.

## What

Add `_snapshot_is_complete_split_model(repo_id)` — the non-text analogue of the existing `_snapshot_is_complete` text `weight_map` walk — and consult it in `is_weightless_stub` **before** the text-glob probe (returns "not a stub" only when the video weights are genuinely complete):

- Anchor on the **`split_model.json`** manifest that both rapid-mlx video families ship (CogVideoX-Fun, LTX-2.3). Read its `"components"` list and require **every** `<component>.safetensors` at the snapshot root to be (a) a **regular file** — not a directory named `vae.safetensors/` (which `getsize` reports as non-empty) nor a symlink-to-dir/dangling symlink; (b) resolved **inside** the repo's own cache dir; (c) **non-empty**.
- **Completeness, not mere presence** (the load-bearing invariant): we never infer "non-text, weighted" from the *absence* of `model*.safetensors`. An interrupted multimodal-**text** download whose vision tower landed before its shards, or a partial video pull missing one component, therefore **stays** a stub and the notice still fires.
- `model_index.json` (bare diffusers pipeline manifest) is **not** accepted on its own — it names components but not their on-disk weight filenames, so it can't be completeness-checked. A manifest-less repo falls back to the (cosmetic) false alarm rather than risking a wrong suppression — the conservative direction.
- Purely cosmetic: **no gating or download behaviour changes** — `_ensure_model_downloaded` still fetches whatever is genuinely missing.

## Tests

`tests/test_download_gate.py`: real CogVideoX-Fun + LTX-2.3 `split_model.json` component layouts → not a stub; **partial** component set, **0-byte** component, malformed/empty/non-list manifest, path-traversal component name, directory-named / symlink-to-dir component, `model_index.json`-without-`split_model.json`, partial sharded **text** download, incomplete text + auxiliary weight, **dangling** text shard symlink + aux weight, and adapter-only cache → **still** a stub. `test_download_gate.py` + `test_serve_stub_notice_wiring.py` green (82 passed).

Verified live against the two cached repos on an M3 Ultra: `is_weightless_stub` now `False` (was `True`) for both; notice suppressed.

## Notes

- No tracking issue (dogfood-found cosmetic bug).
- `[skip-version-bump]` — fix PR, no `pyproject` version change.
- Codex-converged to 0 BLOCKING + 0 MAJOR (STDIN + pr_validate gpt-5.6-sol): presence-heuristic → positive-manifest → **completeness**-of-every-component → regular-file guard.
- Rebased onto `#1320` (allowlist espeak env vars) which fixes a pre-existing `full_unit` red on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)