### PR TITLE
test: allowlist RAPID_MLX_ESPEAK_LIB/DATA env vars [skip-version-bump]

### DIFF
--- a/tests/test_no_out_of_band_routing.py
+++ b/tests/test_no_out_of_band_routing.py
@@ -412,6 +412,15 @@ ALLOWED_RAPID_MLX_ENV_VARS: frozenset[str] = frozenset(
         # structurally masked. Read only by
         # ``routes/chat.py::_tool_grammar_eligible``.
         "RAPID_MLX_CONSTRAIN_TOOLS",
+        # #1312/#1314 Kokoro espeak self-test path overrides. When set, they
+        # redirect the phonemizer's espeak-ng shared library / data directory
+        # at a system install (used to repair a broken bundled dylib); absent,
+        # the self-test exercises whatever ``misaki`` wired up at import. Read
+        # ONLY by ``audio/probe.py``'s child-process espeak self-test — pure
+        # filesystem path knobs for a TTS dependency; never select a model,
+        # parser, or routing tier.
+        "RAPID_MLX_ESPEAK_LIB",
+        "RAPID_MLX_ESPEAK_DATA",
     }
 )
 


### PR DESCRIPTION
## Why

`tests/test_no_out_of_band_routing.py::test_no_routing_shaped_rapid_mlx_env_vars` is **RED on `main`** — a release blocker. The Kokoro espeak self-test repair (#1312/#1314) added `RAPID_MLX_ESPEAK_LIB` / `RAPID_MLX_ESPEAK_DATA` path-override knobs to `audio/probe.py` but never added them to `ALLOWED_RAPID_MLX_ENV_VARS`, so the out-of-band-routing guard flags them:

```
audio/probe.py:409 references env var `RAPID_MLX_ESPEAK_LIB` — not in
ALLOWED_RAPID_MLX_ENV_VARS. If this is a non-routing knob, add it to the
allowlist with a comment.
```

## What

Allowlist both vars with a comment, per the test's own guidance. They are **pure filesystem path knobs**: when set, they redirect the phonemizer's espeak-ng shared library / data directory at a system install (to repair a broken bundled dylib); absent, the self-test exercises whatever `misaki` wired up at import. Read **only** by `audio/probe.py`'s child-process espeak self-test — they never select a model, parser, or routing tier. (`grep` confirms `audio/probe.py` is the sole referencing module.)

Test-only change; the runtime behaviour added by #1312/#1314 is unchanged.

## Verification

`pytest tests/test_no_out_of_band_routing.py` → **14 passed** (was 1 failed). ruff check + format clean.

## Notes

- `[skip-version-bump]` — test-only fix, no `pyproject` version change.
- Discovered via `pr_validate` `full_unit` while validating an unrelated download-gate PR; A/B-classified as pre-existing on `main` (`e0f37a61`), hence this dedicated fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)