### PR TITLE
fix(models): add IndexTTS-1.5 to model_sizes.json manifest [skip-version-bump]

### DIFF
--- a/vllm_mlx/model_sizes.json
+++ b/vllm_mlx/model_sizes.json
@@ -32,6 +32,7 @@
     "mlx-community/GLM-4.7-Flash-4bit": 16872844852,
     "mlx-community/Hermes-3-Llama-3.1-8B-4bit": 4526678175,
     "mlx-community/Hy3-preview-4bit": 165998644038,
+    "mlx-community/IndexTTS-1.5": 1434613094,
     "mlx-community/Kimi-K2.6-mlx-DQ3_K_M-q8": 470632354731,
     "mlx-community/Kokoro-82M-4bit": 310957743,
     "mlx-community/Kokoro-82M-8bit": 317533045,


### PR DESCRIPTION
## Why

`tests/test_model_sizes.py::test_every_audio_alias_has_a_manifest_entry` is **RED on `main`** — a release blocker:

```
AssertionError: audio aliases missing from model_sizes.json — run
`python3.12 scripts/gen_model_sizes.py`: ['mlx-community/IndexTTS-1.5', 'mlx-community/IndexTTS-1.5']
```

The IndexTTS zero-shot voice-cloning aliases (`#1318`) added `mlx-community/IndexTTS-1.5` to `vllm_mlx/audio/aliases.json` (two aliases — `indextts` + a long-form alias — sharing the one repo) but never regenerated the checked-in size manifest, so the audio-alias coverage test flags the missing key.

## What

Add the single entry `"mlx-community/IndexTTS-1.5": 1434613094` (**1.3 GiB**) at its sorted position. The byte value is what `estimate_repo_size_bytes` resolves for the repo in a fresh interpreter — identical to what `scripts/gen_model_sizes.py` would write; placement keeps the map key-sorted. **One-line diff; no other entries touched** (verified a no-op re-dump of the manifest is byte-identical to the committed file, so this is exactly the generator's output for the one new key).

## Verification

- `pytest tests/test_model_sizes.py` → **14 passed** (was 1 failed).
- Manifest still key-sorted; 188 → 189 entries.

## Notes

- `[skip-version-bump]` — manifest-data fix, no `pyproject` version change.
- Discovered via `pr_validate` `full_unit` while validating the unrelated download-gate PR `#1319`; A/B-classified as **pre-existing on `main`** (`0090a392`), hence this dedicated fix — same pattern as `#1320`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)