### PR TITLE
fix(video): preserve Python 3.10 core compatibility

### DIFF
--- a/docs/guides/video-generation.md
+++ b/docs/guides/video-generation.md
@@ -3,6 +3,10 @@
 Rapid-MLX exposes LTX-2.3, CogVideoX-Fun and Wan through the asynchronous
 OpenAI-compatible Videos API.
 
+Video generation requires Python 3.11 or newer because the upstream
+`mlx-video-with-audio` runtime does not support Python 3.10. Rapid-MLX's core
+text and audio features continue to support Python 3.10.
+
 ## Wan 2.1 / 2.2
 
 Wan uses the `mlx-video-with-audio` runtime included in the video extra. Four

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -382,11 +382,16 @@ audio = [
 ]
 video = [
     # MLX-native LTX-2.3 T2V/I2V with synchronized audio. 0.1.36 is the
-    # first verified release with the split-format LTX-2.3 VAE fixes.
-    "mlx-video-with-audio==0.1.36; platform_system == 'Darwin'",
-    "mlx-arsenal>=0.10.1; platform_system == 'Darwin'",
-    "imageio[ffmpeg]>=2.34.0; platform_system == 'Darwin'",
-    "pillow>=10.0.0; platform_system == 'Darwin'",
+    # first verified release with the split-format LTX-2.3 VAE fixes. The
+    # upstream runtime requires Python >=3.11, while Rapid-MLX core continues
+    # to support Python 3.10. Keep every dependency behind the same marker so
+    # universal lock generation remains satisfiable for the declared core
+    # Python range; the video startup preflight gives 3.10 users an explicit
+    # upgrade diagnostic.
+    "mlx-video-with-audio==0.1.36; platform_system == 'Darwin' and python_version >= '3.11'",
+    "mlx-arsenal>=0.10.1; platform_system == 'Darwin' and python_version >= '3.11'",
+    "imageio[ffmpeg]>=2.34.0; platform_system == 'Darwin' and python_version >= '3.11'",
+    "pillow>=10.0.0; platform_system == 'Darwin' and python_version >= '3.11'",
 ]
 
 [project.urls]

--- a/tests/test_ltx23_video.py
+++ b/tests/test_ltx23_video.py
@@ -19,11 +19,17 @@ from starlette.routing import Route
 
 from vllm_mlx.model_aliases import resolve_profile
 from vllm_mlx.routes import video
+from vllm_mlx.runtime import video_lane
 from vllm_mlx.runtime.video_lane import (
     VideoEngine,
     VideoRuntimeError,
     require_video_runtime_or_exit,
 )
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python 3.10
+    import tomli as tomllib
 
 
 def test_ltx23_alias_routes_to_video_lane() -> None:
@@ -56,6 +62,35 @@ def test_video_runtime_preflight_fails_before_download(
     error = capsys.readouterr().err
     assert "rapid-mlx[video]" in error
     assert "brew install ffmpeg" in error
+
+
+def test_video_runtime_preflight_reports_python_311_floor(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    class Python310(tuple):
+        major = 3
+        minor = 10
+
+    monkeypatch.setattr(video_lane.sys, "version_info", Python310((3, 10, 0)))
+
+    with pytest.raises(SystemExit) as exc:
+        require_video_runtime_or_exit()
+
+    assert exc.value.code == 2
+    error = capsys.readouterr().err
+    assert "requires Python 3.11 or newer" in error
+    assert "current: 3.10" in error
+
+
+def test_video_extra_marks_every_dependency_python_311_or_newer() -> None:
+    pyproject_path = Path(__file__).resolve().parents[1] / "pyproject.toml"
+    with pyproject_path.open("rb") as file:
+        pyproject = tomllib.load(file)
+
+    video_specs = pyproject["project"]["optional-dependencies"]["video"]
+    assert video_specs
+    assert any(spec.startswith("mlx-video-with-audio==0.1.36;") for spec in video_specs)
+    assert all("python_version >= '3.11'" in spec for spec in video_specs)
 
 
 @pytest.mark.asyncio

--- a/vllm_mlx/runtime/video_lane.py
+++ b/vllm_mlx/runtime/video_lane.py
@@ -51,6 +51,16 @@ def _is_wan_name(model_name: str | None) -> bool:
 
 def require_video_runtime_or_exit(model_name: str | None = None) -> None:
     """Fail before model download when the optional video stack is absent."""
+    if sys.version_info < (3, 11):
+        print(
+            "\n  Error: video generation requires Python 3.11 or newer "
+            f"(current: {sys.version_info.major}.{sys.version_info.minor}). "
+            "Rapid-MLX core still supports Python 3.10, but the upstream "
+            "mlx-video runtime does not.\n",
+            file=sys.stderr,
+        )
+        raise SystemExit(2)
+
     missing = []
     if _is_cogvideox_name(model_name):
         cogvideox_modules = {


### PR DESCRIPTION
## Summary

- keep Rapid-MLX core installable on its documented Python 3.10 floor
- constrain the optional video dependency set to Python 3.11+, matching `mlx-video-with-audio`
- fail video startup early on Python 3.10 with an explicit upgrade diagnostic
- document the video-only Python floor and lock it in with regression tests

## Root cause

PR #1298 added `mlx-video-with-audio==0.1.36` under `[project.optional-dependencies].video` with only a Darwin marker. The upstream package requires Python >=3.11, while Rapid-MLX declares `requires-python = ">=3.10"`. Universal dependency resolution therefore became unsatisfiable for the Python 3.10/Darwin split, including `uv lock --check` and `rapid-mlx[video]` resolution.

The core project does not need to drop Python 3.10: only the optional upstream video runtime has the higher floor.

## Validation

- `uv pip compile pyproject.toml --extra video --python-version 3.10` — passes and excludes the incompatible runtime
- `uv pip compile pyproject.toml --extra video --python-version 3.11` — passes and resolves `mlx-video-with-audio==0.1.36`
- `pytest -q tests/test_ltx23_video.py tests/test_wan_video.py tests/test_cogvideox_video.py tests/test_vision_extra_install.py` — 73 passed
- Ruff and `git diff --check` — clean