### PR TITLE
fix(test): hermes read_file passes absolute path (basename was flaky on 9B gauntlet model)

### DIFF
--- a/tests/integrations/test_hermes.py
+++ b/tests/integrations/test_hermes.py
@@ -498,7 +498,7 @@ def test_hermes_read_file():
         with open(path, "w") as f:
             f.write(f"{marker}\n")
         out, err = hermes_query(
-            f"Use the read_file tool to read {os.path.basename(path)}, "
+            f"Use the read_file tool to read {path}, "
             "then reply with its exact contents."
         )
         fail_or_skip(err)


### PR DESCRIPTION
## Why

`test_hermes_read_file` is flaky on the 9B release-gauntlet model and non-deterministically blocks the release-check-m3 **G7b** gate (`bench --tier harness` -> `hermes` profile -> `tests/integrations/test_hermes.py`), unrelated to any engine change.

**Root cause.** The test passed hermes only the file's *basename* (`os.path.basename(path)`). On `qwen3.5-9b-4bit` the model cannot reliably resolve a bare basename against its working directory, so it non-deterministically either:

- asks a clarifying question and never calls `read_file` (fast-fail; marker absent -> assertion **FAIL**), or
- launches an agentic file search that runs past the 120s per-test timeout (-> **TIMEOUT**).

**Evidence (live probe on `qwen3.5-9b-4bit`, quiet M3 Ultra, context_window 262144):**

- basename form -> 41s, hermes replied *"The file ... does not exist ... where should it be?"*, marker **ABSENT**.
- absolute-path form -> 39s, marker **FOUND**, clean exit 0.

Every other deep agentic test in this file (`test_hermes_write_and_run`, `test_hermes_code_with_tests`, `test_hermes_patch_file`) already passes an **absolute** path (e.g. `/tmp/hermes_*.py`). `read_file` was the lone outlier still using a basename.

**Not a regression.** The basename line predates v0.11.1 (commit `310adecf`); `git log v0.11.1..HEAD -- tests/integrations/test_hermes.py` is empty, and the tool-call parsers were untouched.

**Not a gate weakening.** The test still exercises the full path: hermes -> `read_file` tool -> echo exact contents, with the same marker assertion. It only removes path-resolution ambiguity by handing the model the absolute path that was already constructed a few lines above via `os.path.join(os.getcwd(), ...)`.

## What

One-line change in `test_hermes_read_file`: pass `path` (absolute) instead of `os.path.basename(path)` to `hermes_query`.

## Test Plan

- `ruff check .` and `ruff format --check .` both pass.
- `python3.12 -m pytest tests/integrations/test_hermes.py --collect-only -q` collects all 20 tests with no import errors.
- Live hermes tests require a running server and are exercised by the G7b gauntlet; the absolute-path probe above confirms a clean pass at 39s.
