### PR TITLE
fix(release): stabilize the G7b hermes gauntlet profile

### DIFF
--- a/scripts/release_check_m3.sh
+++ b/scripts/release_check_m3.sh
@@ -25,6 +25,21 @@ set -euo pipefail
 MODEL="${MODEL:-qwen3.5-9b-4bit}"
 PY="${PY:-python3.12}"
 PORT="${PORT:-8000}"
+
+# G7b's consolidated `bench --tier harness` runs 5 harness profiles
+# (codex/opencode/hermes/aider/langchain) under ONE shared per-profile cap
+# (tier_runner's HARNESS_PROFILE_TIMEOUT_S, library default 300s). That default
+# is sized for a single fast harness — codex/opencode/aider/langchain each
+# finish <135s on the 9B gauntlet model — but the hermes profile runs 20+
+# serial agentic tests (~740s). 300s kills hermes mid-profile and false-fails
+# the release gate. Raise the cap for the whole gauntlet: exporting here means
+# every bench subprocess this script spawns later inherits it (the G7b harness
+# at the `--tier harness` call AND the G12 random sweep) — intended, and can
+# only make those gates more lenient, never stricter. The tier_runner library
+# default (300s) is left untouched for any non-gauntlet / standalone caller.
+# See knowledge/release-check-m3-tuning-backlog. Env-overridable.
+export HARNESS_PROFILE_TIMEOUT_S="${HARNESS_PROFILE_TIMEOUT_S:-1200}"
+
 LOG=/tmp/release-check-m3.log
 PIDFILE=/tmp/release-check-m3.pid
 

--- a/tests/integrations/test_hermes.py
+++ b/tests/integrations/test_hermes.py
@@ -529,7 +529,9 @@ def test_hermes_multi_step():
     """Hermes does a multi-step task (search → read → analyze)."""
     out, err = hermes_query(
         "Find the file aliases.json, read it, and tell me how many entries it has",
-        timeout_sec=180,
+        # Slow-but-completes on the 9B gauntlet model (~142s standalone, but
+        # variance pushes it past the old 180s cap under gauntlet contention).
+        timeout_sec=360,
     )
     fail_or_skip(err)
     # Should mention a number (we have ~22 aliases)
@@ -596,8 +598,15 @@ def test_hermes_code_with_tests():
 def test_hermes_code_review():
     """Hermes reads a file and gives a code review suggestion."""
     out, err = hermes_query(
-        "Read vllm_mlx/model_auto_config.py and suggest one specific improvement. Be concise.",
-        timeout_sec=120,
+        # Directive, no-clarify prompt: an open-ended "suggest an improvement"
+        # ask makes the 9B gauntlet model enter hermes' clarify flow, which
+        # blocks 120s per cycle on absent stdin in -Q mode and runs away past
+        # 600s. Giving an explicit path + forbidding clarification keeps the
+        # agent on-task (same class of fix as read_file basename->abspath, #1326).
+        "Read the file vllm_mlx/model_auto_config.py and suggest one specific "
+        "improvement to the code. Do not ask any clarifying questions — just "
+        "give your suggestion directly.",
+        timeout_sec=300,
     )
     fail_or_skip(err)
     # Should mention something about the code (patterns, config, etc.)


### PR DESCRIPTION
## fix(release): stabilize the G7b hermes gauntlet profile

### Why
The consolidated G7b `bench --tier harness` step of `scripts/release_check_m3.sh`
false-fails the release gauntlet on the **hermes** profile in three distinct
ways, all surfaced end-to-end during the 0.11.2 cut (none is a product
regression — all are gauntlet-calibration issues):

1. **`test_hermes_code_review` runs away past 600s.** The open-ended prompt
   ("suggest one specific improvement. Be concise.") makes the 9B gauntlet
   model enter hermes' *clarify* flow. In `-Q` non-interactive mode there is no
   stdin, so each clarify cycle blocks 120s (`clarify timed out after 120s —
   agent will decide`) and the agent re-enters it, never terminating (measured:
   exit 124 at a 600s cap). This is the same class of defect as the `read_file`
   basename flakiness fixed in #1326: an **ambiguous agentic input** produces
   non-deterministic 9B behavior.

2. **`test_hermes_multi_step` variance exceeds its 180s cap.** It completes in
   ~142s standalone, but under full-profile contention it intermittently pushes
   past the old 180s per-test cap → spurious TIMEOUT.

3. **The per-profile cap (300s) is too tight for hermes.** The library default
   `HARNESS_PROFILE_TIMEOUT_S=300` in `tier_runner.py` is sized for a single
   fast harness (codex/opencode/aider/langchain each finish <135s on 9B), but
   the hermes profile runs 20+ serial agentic tests (~740s). 300s kills hermes
   mid-profile before the deep tests even run.

### What
- **`tests/integrations/test_hermes.py`**
  - `test_hermes_code_review`: rewrite the prompt to be directive and forbid
    clarification ("Read the file … suggest one specific improvement … Do not
    ask any clarifying questions — just give your suggestion directly"), and
    raise its per-test cap 120→300s. Assertion is unchanged.
  - `test_hermes_multi_step`: raise its per-test cap 180→360s (variance margin;
    prompt already directive).
- **`scripts/release_check_m3.sh`**: export
  `HARNESS_PROFILE_TIMEOUT_S=${HARNESS_PROFILE_TIMEOUT_S:-1200}` for the
  gauntlet so G7b gives the hermes profile room, without touching the
  `tier_runner` library default (still 300s) or any other caller. Env-overridable.

### Evidence (M3 Ultra, qwen3.5-9b-4bit --no-thinking)
- code_review OLD prompt: exit 124 (HANG) at 600s cap; log shows repeated
  `clarify timed out after 120s`.
- code_review NEW prompt: COMPLETED in 52s, assertion PASS
  (len>50 ✓, mentions model/config ✓, no clarify loop ✓).
- multi_step: COMPLETED in 142s standalone (fits the new 360s cap comfortably).

No production code paths change — this touches only the release gauntlet's test
harness inputs/caps. Deeper root-fixes remain owed as follow-ups (reasoning-aware
coherence #1323, a per-profile cap in `tier_runner` so one global timeout doesn't
have to cover a profile that is 5–6× the others, and a hermes smoke-subset split).
