### PR TITLE
fix(release): calibrate G12 random-coverage gate

### DIFF
--- a/scripts/release_check_m3_random.py
+++ b/scripts/release_check_m3_random.py
@@ -81,10 +81,15 @@ MIN_FREE_DISK_GB = 30
 # HF connection on a 7-GB shard.
 SERVE_READY_TIMEOUT_S = 600  # 10 minutes
 
-# Per-harness-round timeout. The harness runner's own per-profile cap
-# is 300s (HARNESS_PROFILE_TIMEOUT_S); we add headroom for the
-# bench-CLI startup cost.
-ROUND_TIMEOUT_S = 360
+# Per-harness-round timeout. A scoped ``bench --tier harness`` round
+# runs ONE harness profile end-to-end; the hermes profile alone is
+# ~740-800s on a dense 9B once its deep agentic tests actually run
+# (post #1326/#1330). The old 360s was sized against a stale 300s
+# per-profile cap and killed every hermes round. Track the real profile
+# length with headroom, and keep it below the inherited per-profile cap
+# (HARNESS_PROFILE_TIMEOUT_S, 1200s in the gauntlet) so in the gauntlet
+# the outer subprocess timeout — not the inner cap — bounds a hung round.
+ROUND_TIMEOUT_S = 1080
 
 
 # Match a parameter-count token bounded by name separators (``-``,
@@ -100,6 +105,12 @@ ROUND_TIMEOUT_S = 360
 # than guessed at — guessing landed us with ``glm4.5-air-4bit`` parsing
 # as a 4 B model and slipping past the disk-budget filter.
 _SIZE_TOKEN_RE = re.compile(r"(?:^|[-_.])(\d+(?:\.\d+)?)[bB](?=[-_.]|$)")
+
+# Match an MoE ACTIVE-parameter token: ``A1B`` in ``LFM2.5-8B-A1B``,
+# ``A10B`` in ``Qwen3.5-122B-A10B``. Bounded by name separators. Used to
+# apply the capability floor to a MoE's active (not total) params — an
+# 8B-total/1B-active model is far too weak for agentic harness tasks.
+_ACTIVE_TOKEN_RE = re.compile(r"(?:^|[-_.])[aA](\d+(?:\.\d+)?)[bB](?=[-_.]|$)")
 
 
 def _eligible_aliases(aliases_path: Path) -> list[tuple[str, str]]:
@@ -123,6 +134,13 @@ def _eligible_aliases(aliases_path: Path) -> list[tuple[str, str]]:
             # Known-bad: model-side ``thought\n…`` loop on agent prompts.
             # See issue #686 + HF discussion google/gemma-4-12B-it#41.
             continue
+        if isinstance(entry, dict) and entry.get("is_hybrid"):
+            # Hybrid models can't spec/suffix-decode and run agentic
+            # harness rounds several times slower → they blow the
+            # per-round timeout (esp. hermes) and add false-fail spam,
+            # not coverage signal (same class as the gemma-4 exclude).
+            # G0a/G0b already cover hybrids on non-agentic prompts.
+            continue
         # Use .get() — a future schema change that omits ``hf_path``
         # should silently skip the entry, not crash the gauntlet.
         hf_path = entry.get("hf_path") if isinstance(entry, dict) else None
@@ -137,6 +155,13 @@ def _eligible_aliases(aliases_path: Path) -> list[tuple[str, str]]:
             continue
         size_b = float(match.group(1))
         if not (4.0 <= size_b <= 12.0):
+            continue
+        # Effective-capacity floor for MoEs: e.g. ``LFM2.5-8B-A1B`` is 8B
+        # total but ~1B ACTIVE/token — too weak to solve agentic harness
+        # tasks (emits malformed tool calls → false-fail spam), the same
+        # rationale as the 4B total-size floor but applied to active params.
+        active_m = _ACTIVE_TOKEN_RE.search(repo_name)
+        if active_m and float(active_m.group(1)) < 4.0:
             continue
         out.append((size_b, name, hf_path))
     out.sort()
@@ -269,6 +294,13 @@ def _run_harness_round(
     """Run one ``bench --tier harness`` invocation scoped to one
     harness. Returns ``(ok, wall_clock_s, error_excerpt)``."""
     env = {**os.environ, "RAPID_MLX_HARNESS_PROFILES_FILTER": harness}
+    # Right-size the inner per-profile cap for standalone runs. Via
+    # release_check_m3.sh the gauntlet exports HARNESS_PROFILE_TIMEOUT_S
+    # (1200s) and this setdefault is a no-op; standalone, default it to
+    # ROUND_TIMEOUT_S - 60 so the ~800s hermes profile isn't killed by the
+    # 300s library default. A genuine hang still surfaces as a failure —
+    # the inner cap trips a hair before the outer subprocess timeout.
+    env.setdefault("HARNESS_PROFILE_TIMEOUT_S", str(ROUND_TIMEOUT_S - 60))
     cmd = [
         sys.executable,
         "-m",


### PR DESCRIPTION
## fix(release): calibrate G12 random-coverage gate

### Why
G12 (`scripts/release_check_m3_random.py`) reached completion for the first
time during the 0.11.2 cut (prior gauntlet runs aborted earlier, at G7b) and
false-failed with 9 failures — **none a product regression**. The 0.11.2 range
(v0.11.1..HEAD, 56 commits) touches **zero** tool-call-parser / hermes / lfm /
hybrid-inference code, so the sampled models exercise byte-identical paths to
v0.11.1. Two independent gate-calibration defects were surfaced:

1. **Stale per-round timeout.** `ROUND_TIMEOUT_S = 360` was sized against a
   stale 300s per-profile cap. A scoped `bench --tier harness` round runs one
   whole harness profile; the **hermes** profile alone is ~740–800s on a dense
   9B once its deep agentic tests actually run (post #1326 / #1330). 360s killed
   every hermes round → the sampled hybrid model (`qwopus-9b-4bit`) timed out
   3/3 on hermes.

2. **Eligibility admits agentic-incapable models.** Today's date-seed drew
   `qwopus-9b-4bit` (hybrid — can't spec-decode, runs agentic rounds several ×
   slower → timeout) and `lfm2.5-8b-a1b-4bit` (8B total but ~1B **active** — too
   weak, emits malformed tool calls like `tool_0`). These add only false-fail
   spam, not coverage signal — exactly the rationale already codified for the
   `gemma-4-*` exclusion (issue #686).

### What
`scripts/release_check_m3_random.py`:
- `ROUND_TIMEOUT_S` 360 → **1080s**, tracking the real hermes-profile length with
  headroom while staying below the inherited per-profile cap
  (`HARNESS_PROFILE_TIMEOUT_S`, 1200s in the gauntlet) so the outer subprocess
  timeout gives a clean "round timed out" instead of the inner cap firing first.
- Extend the eligibility filter (same spirit as the existing gemma-4 / kimi /
  vision / <4B excludes):
  - skip `is_hybrid` models (agentic-incapable-in-time; G0a/G0b already cover
    hybrids on non-agentic prompts);
  - apply the capability floor to a MoE's **active** params via a new
    `_ACTIVE_TOKEN_RE` (`A1B` → 1B active < 4B → skip), mirroring the existing
    4B total-size floor.
- When spawning each round, `env.setdefault("HARNESS_PROFILE_TIMEOUT_S", …)` just
  under `ROUND_TIMEOUT_S`, so a standalone G12 run (outside the gauntlet, which
  doesn't export the 1200s cap) doesn't let the 300s library default kill every
  hermes round.

### Evidence (M3 Ultra, seed 20260730)
- **Timeout defect fixed.** Before, every hermes round was killed at the 360s
  cap; after raising to 1080s a hermes round runs to completion (~770s) instead
  of dying mid-profile.
- **Eligibility fix confirmed.** The hybrid `qwopus-9b-4bit` and 1B-active
  `lfm2.5-8b-a1b-4bit` (7 of the 9 original false-failures) are no longer drawn.
- **This PR does NOT make G12 green — and does not claim to.** With those two
  excluded, the same date-seed re-draws dense `llama-3.1-8b-4bit` and
  `gemma3-4b-qat-4bit`, which then *functionally* fail the hardest agentic
  harnesses (gemma3-4b emits no tool_calls on hermes; llama-3.1-8b fast-fails
  langchain in ~11s). That is model capability — not a timeout and not a 0.11.2
  regression: the release model `qwen3.5-9b` passes all five harness profiles in
  G7b, and the 0.11.2 range touches no parser/inference code. It is the systemic
  "size-based eligibility admits agentic-weak models" problem, which needs a
  curated agentic-capable pool rather than one-off excludes.

This PR lands the two unambiguous calibration fixes (timeout + hybrid/tiny-MoE
exclusion). Release-gauntlet tooling only; no production code paths change. The
deeper redesign — plus the still-in-pool reasoning model `deepseek-r1-8b-4bit` —
is tracked in #1331.
