### PR TITLE
chore: bump version to 0.11.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.11.1"
+version = "0.11.2"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## chore: bump version to 0.11.2

Cuts the **0.11.2** release from `main` HEAD. This is the version-bump PR that
triggers `auto-release.yml` (detect → Tier-1 agent gate on the self-hosted
Studio → tag `v0.11.2` + GitHub Release → `publish.yml` PyPI + Homebrew).

### Why
Bundles the audio + video generation wave and the KV-quant/scheduler quality
work that has accumulated on `main` since v0.11.1 (33 commits). No core `mlx` /
`mlx-lm` / `mlx-vlm` pin change — only additive audio/video optional-deps, all
already dogfooded.

### What ships in 0.11.2

**Audio — STT**
- MLX-native SenseVoice STT (#1308)
- Forced-alignment STT via Qwen3-ForcedAligner (#1301) + lane hardening on `/v1/audio/transcriptions` (#1317)
- Word-level timestamps on `/v1/audio/transcriptions` (#1299)

**Audio — TTS / voice**
- Qwen3-TTS: CustomVoice emotion control (#1287), Base zero-shot cloning (#1305), VoiceDesign natural-language style (#1309)
- Chatterbox expressiveness + zero-shot cloning (#1303)
- F5-TTS Chinese cloning (#1297) + `_generate_f5` hardening (#1304)
- IndexTTS zero-shot voice cloning (#1318)
- Kokoro espeak G2P repair instead of worker crash (#1312, #1314)
- De-advertise broken voxcpm Chinese (#1302)

**Audio — music**
- MusicEngine local text-to-music (vendored MLX Stable Audio 3) (#1307) over HTTP `POST /v1/audio/music` (#1316)

**Video**
- Wan 2.1 & 2.2 generation on `/v1/videos` (#1322)
- MLX-native LTX-2.3 generation (#1298)
- Experimental CogVideoX-Fun backend (#1313), runtime deps bundled (#1329)
- Upload body-limit response fix (#1315)
- Python 3.10 core compatibility for the video lane (#1325)

**Core / quality / infra**
- KV-quant differential quality gate + chip-tier classifier (#1289), head_dim guard (#1296)
- Architecture-aware per-token KV byte estimate (#1276)
- Accept mlx-vlm native KV caches for MLLM (#1277)
- Sliding-window prefix-reuse lock against ChunkedKVCache trim-lie (#1285)
- MCP 1.x→2.0 camelCase→snake_case fix (Connectors showing 0 tools) (#1281)
- Tier-1 agent gate on self-hosted Apple Silicon (#1280, #1282)
- Auth hardening (#1271, #1275)
- Telemetry activation funnel (#1273)
- CLI: model download size in listing (#1293), `rmlx` short command (#1284)
- Remove unused cloud routing (#1290) + vLLM platform prototype (#1288); legacy-branding sweep (#1292)
- Harden the G7b hermes `read_file` gauntlet test: pass an absolute path (bare basename was flaky on the 9B gauntlet model) (#1326)
- Stabilize the G7b hermes gauntlet profile: directive no-clarify `code_review` prompt (open-ended prompt ran the 9B into hermes' clarify loop) + a per-profile timeout cap sized for the long hermes profile (#1330)
- Warm concurrent-batch kernel shapes in the batching test suite (#1328)

### Pre-bump verification (local, M3 Ultra)
- `release-smoke`: clean-room wheel build + import of every release surface — **PASS**
- `release-check-m3` (release commit): G0a fleet coherence sweep → G0b model
  coherence gate (#1247) → G5 stress (8 scenarios) → G7×3 SDK (Anthropic /
  pydantic_ai / smolagents) → G7b agent-harness (codex / opencode / hermes /
  aider / langchain + `/v1/responses`) → G6 parallel-tool cap → G9 latency → G8
  parser microbench — **all PASS**.
- G12 random model-sweep is **skipped for this cut**. On its first-ever
  completion it surfaced pre-existing *agentic* weakness in non-primary fleet
  models (hybrid `qwopus`, 1B-active `lfm2.5`, then dense `llama-3.1-8b` /
  `gemma3-4b`) — **not a 0.11.2 regression**: the range touches no
  parser/inference code and the release model `qwen3.5-9b` passes all five G7b
  harness profiles. Gate-calibration fix landed in #1332; the systemic
  size-based-eligibility redesign is tracked in #1331.

No behavioral code changes in this PR — version string only.
