### PR TITLE
feat: expose video motion controls on /v1/videos

### DIFF
--- a/docs/guides/video-generation.md
+++ b/docs/guides/video-generation.md
@@ -14,7 +14,8 @@ text and audio features continue to support Python 3.10.
 - `fps` selects the output frame rate for LTX and CogVideoX-Fun. Wan uses the
   checkpoint's native frame rate and rejects a different value.
 - `frames` overrides the frame count derived from `seconds`. LTX requires
-  `8n+1`; Wan and CogVideoX-Fun require `4n+1`.
+  `8n+1` with a minimum of 9; Wan and CogVideoX-Fun require `4n+1` with a
+  minimum of 5.
 - `guidance_scale` (1–30) and `negative_prompt` are passed to the served
   backend's classifier-free guidance implementation.
 - `conditioning_strength` (0–1) controls how closely LTX image-to-video follows

--- a/docs/guides/video-generation.md
+++ b/docs/guides/video-generation.md
@@ -7,6 +7,35 @@ Video generation requires Python 3.11 or newer because the upstream
 `mlx-video-with-audio` runtime does not support Python 3.10. Rapid-MLX's core
 text and audio features continue to support Python 3.10.
 
+## Motion and conditioning controls
+
+`POST /v1/videos` accepts optional controls in addition to `seconds`:
+
+- `fps` selects the output frame rate for LTX and CogVideoX-Fun. Wan uses the
+  checkpoint's native frame rate and rejects a different value.
+- `frames` overrides the frame count derived from `seconds`. LTX requires
+  `8n+1`; Wan and CogVideoX-Fun require `4n+1`.
+- `guidance_scale` (1–30) and `negative_prompt` are passed to the served
+  backend's classifier-free guidance implementation.
+- `conditioning_strength` (0–1) controls how closely LTX image-to-video follows
+  `input_reference`; it is rejected without a reference image and is not
+  currently supported by Wan or CogVideoX-Fun.
+
+For example, request a shorter, lower-frame-rate LTX image-to-video result with
+weaker reference conditioning:
+
+```bash
+curl http://127.0.0.1:8000/v1/videos \
+  -F model=ltx-2.3-mlx-q4 \
+  -F 'prompt=the camera sweeps around the subject' \
+  -F input_reference=@start.png \
+  -F fps=12 \
+  -F frames=17 \
+  -F guidance_scale=4.5 \
+  -F conditioning_strength=0.35 \
+  -F 'negative_prompt=static camera, frozen subject'
+```
+
 ## Wan 2.1 / 2.2
 
 Wan uses the `mlx-video-with-audio` runtime included in the video extra. Four

--- a/tests/test_cogvideox_video.py
+++ b/tests/test_cogvideox_video.py
@@ -236,6 +236,18 @@ async def test_cogvideox_frame_budget_uses_actual_generation_size(
     assert captured["num_frames"] == 145
     await video.delete_video(created["id"])
 
+    with pytest.raises(HTTPException, match="safe CogVideoX-Fun workload") as exc:
+        await video.create_video(
+            prompt="too many frames",
+            model="cogvideox-fun-5b-q4",
+            seconds="1",
+            size="672x384",
+            seed=2,
+            frames=149,
+            input_reference=None,
+        )
+    assert exc.value.status_code == 400
+
 
 @pytest.mark.asyncio
 async def test_cogvideox_mvp_rejects_unsupported_shape(monkeypatch) -> None:

--- a/tests/test_cogvideox_video.py
+++ b/tests/test_cogvideox_video.py
@@ -201,6 +201,43 @@ async def test_cogvideox_job_maps_validated_mvp_shape(monkeypatch, tmp_path) -> 
 
 
 @pytest.mark.asyncio
+async def test_cogvideox_frame_budget_uses_actual_generation_size(
+    monkeypatch, tmp_path
+) -> None:
+    captured = {}
+
+    class FakeEngine:
+        model_name = "dgrauet/CogVideoX-Fun-V1.5-5b-InP-mlx-q4"
+        video_family = "cogvideox-fun"
+
+        def generate(self, *, output_path: Path, **kwargs):
+            captured.update(kwargs)
+            output_path.write_bytes(b"mp4")
+
+    monkeypatch.setattr(video, "_video_engine", lambda: FakeEngine())
+    created = await video.create_video(
+        prompt="long camera move",
+        model="cogvideox-fun-5b-q4",
+        seconds="1",
+        size="672x384",
+        seed=2,
+        frames=145,
+        input_reference=None,
+    )
+    for _ in range(100):
+        current = await video.retrieve_video(created["id"])
+        if current["status"] == "completed":
+            break
+        await asyncio.sleep(0.01)
+
+    assert current["status"] == "completed"
+    assert captured["width"] == 672
+    assert captured["height"] == 384
+    assert captured["num_frames"] == 145
+    await video.delete_video(created["id"])
+
+
+@pytest.mark.asyncio
 async def test_cogvideox_mvp_rejects_unsupported_shape(monkeypatch) -> None:
     engine = SimpleNamespace(
         model_name="dgrauet/CogVideoX-Fun-V1.5-5b-InP-mlx-q4",

--- a/tests/test_ltx23_video.py
+++ b/tests/test_ltx23_video.py
@@ -321,9 +321,9 @@ def test_video_engine_calls_mlx_native_pipeline(
         image,
         verbose,
         enhance_prompt,
-        negative_prompt,
-        cfg_scale,
-        image_strength,
+        negative_prompt=None,
+        cfg_scale=3.0,
+        image_strength=1.0,
     ) -> None:
         captured.update(locals())
         Path(output_path).write_bytes(b"mp4")

--- a/tests/test_ltx23_video.py
+++ b/tests/test_ltx23_video.py
@@ -321,6 +321,9 @@ def test_video_engine_calls_mlx_native_pipeline(
         image,
         verbose,
         enhance_prompt,
+        negative_prompt,
+        cfg_scale,
+        image_strength,
     ) -> None:
         captured.update(locals())
         Path(output_path).write_bytes(b"mp4")
@@ -342,12 +345,18 @@ def test_video_engine_calls_mlx_native_pipeline(
         fps=24,
         seed=7,
         image=reference,
+        negative_prompt="static",
+        guidance_scale=4.5,
+        conditioning_strength=0.25,
     )
 
     assert output.read_bytes() == b"mp4"
     assert captured["model_repo"] == "notapalindrome/ltx23-mlx-av-q4"
     assert captured["num_frames"] == 97
     assert captured["image"] == str(reference)
+    assert captured["negative_prompt"] == "static"
+    assert captured["cfg_scale"] == 4.5
+    assert captured["image_strength"] == 0.25
 
 
 def test_video_engines_share_process_generation_lock() -> None:
@@ -456,6 +465,73 @@ async def test_openai_720p_size_is_aligned_then_cropped(
     assert captured["output_width"] == 1280
     assert captured["output_height"] == 720
     await video.delete_video(created["id"])
+
+
+@pytest.mark.asyncio
+async def test_video_route_threads_motion_controls(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured = {}
+
+    class FakeEngine:
+        model_name = "notapalindrome/ltx23-mlx-av-q4"
+
+        def generate(self, *, output_path: Path, **kwargs) -> None:
+            captured.update(kwargs)
+            output_path.write_bytes(b"mp4")
+
+    monkeypatch.setattr(video, "_video_engine", lambda: FakeEngine())
+    created = await video.create_video(
+        prompt="a fast camera move",
+        model="ltx-2.3-mlx-q4",
+        seconds="2",
+        size="512x512",
+        seed=3,
+        fps=12,
+        frames=17,
+        guidance_scale=4.25,
+        negative_prompt="static camera",
+        input_reference=None,
+    )
+    for _ in range(100):
+        current = await video.retrieve_video(created["id"])
+        if current["status"] == "completed":
+            break
+        await asyncio.sleep(0.01)
+
+    assert current["status"] == "completed"
+    assert captured["fps"] == 12
+    assert captured["num_frames"] == 17
+    assert captured["guidance_scale"] == 4.25
+    assert captured["negative_prompt"] == "static camera"
+    assert captured["conditioning_strength"] is None
+    await video.delete_video(created["id"])
+
+
+@pytest.mark.asyncio
+async def test_video_route_validates_motion_controls(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeEngine:
+        model_name = "notapalindrome/ltx23-mlx-av-q4"
+
+    monkeypatch.setattr(video, "_video_engine", lambda: FakeEngine())
+    base = {
+        "prompt": "test",
+        "model": "ltx-2.3-mlx-q4",
+        "seconds": "1",
+        "size": "512x512",
+        "seed": 1,
+        "input_reference": None,
+    }
+    with pytest.raises(HTTPException, match="fps must be between"):
+        await video.create_video(**base, fps=0)
+    with pytest.raises(HTTPException, match="LTX frames must be 8n"):
+        await video.create_video(**base, frames=16)
+    with pytest.raises(HTTPException, match="guidance_scale must be between"):
+        await video.create_video(**base, guidance_scale=0.5)
+    with pytest.raises(HTTPException, match="requires input_reference"):
+        await video.create_video(**base, conditioning_strength=0.5)
 
 
 @pytest.mark.asyncio

--- a/tests/test_ltx23_video.py
+++ b/tests/test_ltx23_video.py
@@ -403,6 +403,7 @@ def test_video_parameter_validation() -> None:
     assert video._parse_size("1280x720") == (1280, 720)
     assert video._parse_size("720x1280") == (720, 1280)
     assert video._frame_count(4) == 97
+    assert video._frame_count(1, 26) == 25
     with pytest.raises(HTTPException, match="divisible by 64") as exc:
         video._parse_size("700x512")
     assert exc.value.status_code == 400
@@ -542,6 +543,8 @@ async def test_video_route_validates_motion_controls(
         await video.create_video(**base, fps=0)
     with pytest.raises(HTTPException, match="LTX frames must be 8n"):
         await video.create_video(**base, frames=16)
+    with pytest.raises(HTTPException, match="at least 9"):
+        await video.create_video(**base, frames=1)
     with pytest.raises(HTTPException, match="guidance_scale must be between"):
         await video.create_video(**base, guidance_scale=0.5)
     with pytest.raises(HTTPException, match="requires input_reference"):

--- a/tests/test_ltx23_video.py
+++ b/tests/test_ltx23_video.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import io
 import subprocess
 import sys
 import threading
@@ -473,6 +474,17 @@ async def test_video_route_threads_motion_controls(
 ) -> None:
     captured = {}
 
+    image_bytes = io.BytesIO()
+    Image.new("RGB", (64, 64), "blue").save(image_bytes, format="PNG")
+
+    class ReferenceUpload:
+        def __init__(self, payload: bytes) -> None:
+            self._payload = payload
+
+        async def read(self, size: int) -> bytes:
+            payload, self._payload = self._payload[:size], self._payload[size:]
+            return payload
+
     class FakeEngine:
         model_name = "notapalindrome/ltx23-mlx-av-q4"
 
@@ -490,8 +502,9 @@ async def test_video_route_threads_motion_controls(
         fps=12,
         frames=17,
         guidance_scale=4.25,
+        conditioning_strength=0.35,
         negative_prompt="static camera",
-        input_reference=None,
+        input_reference=ReferenceUpload(image_bytes.getvalue()),
     )
     for _ in range(100):
         current = await video.retrieve_video(created["id"])
@@ -504,7 +517,8 @@ async def test_video_route_threads_motion_controls(
     assert captured["num_frames"] == 17
     assert captured["guidance_scale"] == 4.25
     assert captured["negative_prompt"] == "static camera"
-    assert captured["conditioning_strength"] is None
+    assert captured["conditioning_strength"] == 0.35
+    assert captured["image"].is_file()
     await video.delete_video(created["id"])
 
 

--- a/tests/test_ltx23_video.py
+++ b/tests/test_ltx23_video.py
@@ -497,7 +497,7 @@ async def test_video_route_threads_motion_controls(
     created = await video.create_video(
         prompt="a fast camera move",
         model="ltx-2.3-mlx-q4",
-        seconds="2",
+        seconds="ignored when frames is explicit",
         size="512x512",
         seed=3,
         fps=12,
@@ -514,6 +514,7 @@ async def test_video_route_threads_motion_controls(
         await asyncio.sleep(0.01)
 
     assert current["status"] == "completed"
+    assert current["seconds"] == "2"
     assert captured["fps"] == 12
     assert captured["num_frames"] == 17
     assert captured["guidance_scale"] == 4.25

--- a/tests/test_wan_video.py
+++ b/tests/test_wan_video.py
@@ -273,6 +273,9 @@ async def test_wan_job_uses_native_fps_and_async_video_contract(
         seconds="1",
         size="832x512",
         seed=9,
+        frames=33,
+        guidance_scale=5.5,
+        negative_prompt="rain",
         input_reference=None,
     )
     for _ in range(100):
@@ -284,9 +287,34 @@ async def test_wan_job_uses_native_fps_and_async_video_contract(
     assert current["status"] == "completed"
     assert current["model"] == "wan2.2-ti2v-5b-q8"
     assert captured["fps"] == 24
-    assert captured["num_frames"] == 25
-    assert captured["validated"]["num_frames"] == 25
+    assert captured["num_frames"] == 33
+    assert captured["guidance_scale"] == 5.5
+    assert captured["negative_prompt"] == "rain"
+    assert captured["validated"]["num_frames"] == 33
     await video.delete_video(created["id"])
+
+
+@pytest.mark.asyncio
+async def test_wan_route_rejects_non_native_fps(monkeypatch) -> None:
+    class FakeWanEngine:
+        model_name = "Anes1032/Wan2.2-TI2V-5B-mlx-q8"
+        video_family = "wan"
+        native_fps = 24
+        _wan_engine = None
+
+    engine = FakeWanEngine()
+    engine._wan_engine = engine
+    monkeypatch.setattr(video, "_video_engine", lambda: engine)
+    with pytest.raises(HTTPException, match="output fps is fixed"):
+        await video.create_video(
+            prompt="test",
+            model="wan2.2-ti2v-5b-q8",
+            seconds="1",
+            size="832x512",
+            seed=1,
+            fps=12,
+            input_reference=None,
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/test_wan_video.py
+++ b/tests/test_wan_video.py
@@ -318,6 +318,29 @@ async def test_wan_route_rejects_non_native_fps(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
+async def test_wan_route_rejects_invalid_explicit_frame_shape(monkeypatch) -> None:
+    class FakeWanEngine:
+        model_name = "Anes1032/Wan2.2-TI2V-5B-mlx-q8"
+        video_family = "wan"
+        native_fps = 24
+        _wan_engine = None
+
+    engine = FakeWanEngine()
+    engine._wan_engine = engine
+    monkeypatch.setattr(video, "_video_engine", lambda: engine)
+    with pytest.raises(HTTPException, match=r"Wan frames must be 4n\+1"):
+        await video.create_video(
+            prompt="test",
+            model="wan2.2-ti2v-5b-q8",
+            seconds="ignored",
+            size="832x512",
+            seed=1,
+            frames=6,
+            input_reference=None,
+        )
+
+
+@pytest.mark.asyncio
 async def test_wan_route_returns_model_validation_as_400(monkeypatch) -> None:
     class FakeWanEngine:
         model_name = "Anes1032/Wan2.2-TI2V-5B-mlx-q8"

--- a/vllm_mlx/routes/video.py
+++ b/vllm_mlx/routes/video.py
@@ -595,7 +595,9 @@ async def create_video(
         raise HTTPException(
             status_code=400, detail="LTX frames must be 8n+1 (for example 9, 17, 25)"
         )
-    if generation_width * generation_height * request_frames > _MAX_PIXEL_FRAMES:
+    workload_width = width if is_cogvideox else generation_width
+    workload_height = height if is_cogvideox else generation_height
+    if workload_width * workload_height * request_frames > _MAX_PIXEL_FRAMES:
         family = (
             "CogVideoX-Fun" if is_cogvideox else ("Wan" if is_wan else "LTX-2.3 Q4")
         )
@@ -636,7 +638,7 @@ async def create_video(
                 await asyncio.to_thread(target.close)
             await asyncio.to_thread(_validate_reference_image, image_path)
 
-        num_frames = 5 if is_cogvideox else request_frames
+        num_frames = request_frames
         if is_wan:
             from ..runtime.video_lane import validate_video_request
 

--- a/vllm_mlx/routes/video.py
+++ b/vllm_mlx/routes/video.py
@@ -515,19 +515,26 @@ async def create_video(
             status_code=400,
             detail=f"model must match the served video model ({engine.model_name})",
         )
-    try:
-        seconds_int = int(seconds)
-    except ValueError as exc:
-        raise HTTPException(
-            status_code=400, detail="seconds must be an integer"
-        ) from exc
-    if is_cogvideox and seconds_int != 1:
-        raise HTTPException(
-            status_code=400,
-            detail="CogVideoX-Fun MVP currently supports seconds=1 only",
-        )
-    if not 1 <= seconds_int <= 20:
-        raise HTTPException(status_code=400, detail="seconds must be between 1 and 20")
+    if frames is None:
+        try:
+            seconds_int = int(seconds)
+        except ValueError as exc:
+            raise HTTPException(
+                status_code=400, detail="seconds must be an integer"
+            ) from exc
+        if is_cogvideox and seconds_int != 1:
+            raise HTTPException(
+                status_code=400,
+                detail="CogVideoX-Fun MVP currently supports seconds=1 only",
+            )
+        if not 1 <= seconds_int <= 20:
+            raise HTTPException(
+                status_code=400, detail="seconds must be between 1 and 20"
+            )
+    else:
+        # An explicit frame count is the temporal source of truth. Derive the
+        # public duration after request FPS validation below.
+        seconds_int = 1
     if is_cogvideox:
         if size != "672x384":
             raise HTTPException(
@@ -548,6 +555,8 @@ async def create_video(
         )
     if frames is not None and not 1 <= frames <= 1201:
         raise HTTPException(status_code=400, detail="frames must be between 1 and 1201")
+    if frames is not None:
+        seconds_int = max(1, (frames + request_fps - 1) // request_fps)
     if guidance_scale is not None and not 1.0 <= guidance_scale <= 30.0:
         raise HTTPException(
             status_code=400,
@@ -592,6 +601,11 @@ async def create_video(
         raise HTTPException(
             status_code=400,
             detail="CogVideoX-Fun frames must be 4n+1 (for example 5, 9, 13)",
+        )
+    if is_wan and (request_frames < 5 or request_frames % 4 != 1):
+        raise HTTPException(
+            status_code=400,
+            detail="Wan frames must be 4n+1 and at least 5 (for example 5, 9, 13)",
         )
     if not (is_cogvideox or is_wan):
         if request_frames < 9 or request_frames % 8 != 1:

--- a/vllm_mlx/routes/video.py
+++ b/vllm_mlx/routes/video.py
@@ -16,6 +16,7 @@ import warnings
 import weakref
 from dataclasses import asdict, dataclass, replace
 from pathlib import Path
+from typing import Annotated
 
 from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, UploadFile
 from fastapi.responses import JSONResponse, StreamingResponse
@@ -385,16 +386,18 @@ async def _run_job(
     engine,
     width: int,
     height: int,
-    seconds: int,
+    num_frames: int,
+    fps: int,
     seed: int,
     image_path: Path | None,
+    negative_prompt: str | None,
+    guidance_scale: float | None,
+    conditioning_strength: float | None,
 ) -> None:
     started = False
     output = _jobs_root / job.id / "output.mp4"
     generation_gate = _generation_gate_for_current_loop()
     is_cogvideox = getattr(engine, "video_family", "") == "cogvideox-fun"
-    is_wan = getattr(engine, "video_family", "") == "wan"
-    native_fps = 5 if is_cogvideox else getattr(engine, "native_fps", 24)
     generation_width = width if is_cogvideox else ((width + 63) // 64) * 64
     generation_height = height if is_cogvideox else ((height + 63) // 64) * 64
 
@@ -415,14 +418,13 @@ async def _run_job(
                 output_path=output,
                 width=generation_width,
                 height=generation_height,
-                num_frames=(
-                    5
-                    if is_cogvideox
-                    else _frame_count(seconds, native_fps if is_wan else 24)
-                ),
-                fps=native_fps,
+                num_frames=num_frames,
+                fps=fps,
                 seed=seed,
                 image=image_path,
+                negative_prompt=negative_prompt,
+                guidance_scale=guidance_scale,
+                conditioning_strength=conditioning_strength,
                 output_width=width,
                 output_height=height,
             )
@@ -486,6 +488,11 @@ async def create_video(
     seconds: str = Form("4"),
     size: str = Form("768x512"),
     seed: int = Form(42),
+    fps: Annotated[int | None, Form()] = None,
+    frames: Annotated[int | None, Form()] = None,
+    guidance_scale: Annotated[float | None, Form()] = None,
+    conditioning_strength: Annotated[float | None, Form()] = None,
+    negative_prompt: Annotated[str | None, Form(max_length=4096)] = None,
     input_reference: UploadFile | None = File(None),
 ):
     engine = _video_engine()
@@ -530,16 +537,68 @@ async def create_video(
         width, height = 672, 384
     else:
         width, height = _parse_size(size)
+    native_fps = 5 if is_cogvideox else getattr(engine, "native_fps", 24)
+    request_fps = native_fps if fps is None else fps
+    if not 1 <= request_fps <= 60:
+        raise HTTPException(status_code=400, detail="fps must be between 1 and 60")
+    if is_wan and request_fps != native_fps:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Wan output fps is fixed by this checkpoint at {native_fps}",
+        )
+    if frames is not None and not 1 <= frames <= 1201:
+        raise HTTPException(status_code=400, detail="frames must be between 1 and 1201")
+    if guidance_scale is not None and not 1.0 <= guidance_scale <= 30.0:
+        raise HTTPException(
+            status_code=400,
+            detail="guidance_scale must be between 1 and 30",
+        )
+    if conditioning_strength is not None:
+        if not 0.0 <= conditioning_strength <= 1.0:
+            raise HTTPException(
+                status_code=400,
+                detail="conditioning_strength must be between 0 and 1",
+            )
+        if is_cogvideox or is_wan:
+            raise HTTPException(
+                status_code=400,
+                detail="conditioning_strength is currently supported by LTX only",
+            )
+        if input_reference is None:
+            raise HTTPException(
+                status_code=400,
+                detail="conditioning_strength requires input_reference",
+            )
+    if negative_prompt is not None:
+        negative_prompt = negative_prompt.strip()
     generation_width = ((width + 63) // 64) * 64
     generation_height = ((height + 63) // 64) * 64
-    request_frames = _frame_count(
-        seconds_int, getattr(engine, "native_fps", 24) if is_wan else 24
+    request_frames = (
+        frames
+        if frames is not None
+        else (
+            5
+            if is_cogvideox
+            else _frame_count(seconds_int, native_fps if is_wan else request_fps)
+        )
     )
-    if (
-        not is_cogvideox
-        and generation_width * generation_height * request_frames > _MAX_PIXEL_FRAMES
-    ):
-        family = "Wan" if is_wan else "LTX-2.3 Q4"
+    if is_cogvideox and request_frames < 5:
+        raise HTTPException(
+            status_code=400, detail="CogVideoX-Fun frames must be at least 5"
+        )
+    if is_cogvideox and request_frames % 4 != 1:
+        raise HTTPException(
+            status_code=400,
+            detail="CogVideoX-Fun frames must be 4n+1 (for example 5, 9, 13)",
+        )
+    if not (is_cogvideox or is_wan) and request_frames % 8 != 1:
+        raise HTTPException(
+            status_code=400, detail="LTX frames must be 8n+1 (for example 9, 17, 25)"
+        )
+    if generation_width * generation_height * request_frames > _MAX_PIXEL_FRAMES:
+        family = (
+            "CogVideoX-Fun" if is_cogvideox else ("Wan" if is_wan else "LTX-2.3 Q4")
+        )
         raise HTTPException(
             status_code=400,
             detail=(
@@ -630,9 +689,13 @@ async def create_video(
                     engine=engine,
                     width=width,
                     height=height,
-                    seconds=seconds_int,
+                    num_frames=num_frames,
+                    fps=request_fps,
                     seed=seed,
                     image_path=image_path,
+                    negative_prompt=negative_prompt,
+                    guidance_scale=guidance_scale,
+                    conditioning_strength=conditioning_strength,
                 )
             )
             _tasks[job.id] = task

--- a/vllm_mlx/routes/video.py
+++ b/vllm_mlx/routes/video.py
@@ -573,15 +573,17 @@ async def create_video(
         negative_prompt = negative_prompt.strip()
     generation_width = ((width + 63) // 64) * 64
     generation_height = ((height + 63) // 64) * 64
-    request_frames = (
-        frames
-        if frames is not None
-        else (
-            5
-            if is_cogvideox
-            else _frame_count(seconds_int, native_fps if is_wan else request_fps)
+    if frames is not None:
+        request_frames = frames
+    elif is_cogvideox:
+        request_frames = 5
+    else:
+        # Normalize seconds × fps to the temporal shape the diffusion
+        # backends require. Only an explicitly supplied frame count should
+        # ever reach the validation below unnormalized.
+        request_frames = _frame_count(
+            seconds_int, native_fps if is_wan else request_fps
         )
-    )
     if is_cogvideox and request_frames < 5:
         raise HTTPException(
             status_code=400, detail="CogVideoX-Fun frames must be at least 5"
@@ -591,10 +593,12 @@ async def create_video(
             status_code=400,
             detail="CogVideoX-Fun frames must be 4n+1 (for example 5, 9, 13)",
         )
-    if not (is_cogvideox or is_wan) and request_frames % 8 != 1:
-        raise HTTPException(
-            status_code=400, detail="LTX frames must be 8n+1 (for example 9, 17, 25)"
-        )
+    if not (is_cogvideox or is_wan):
+        if request_frames < 9 or request_frames % 8 != 1:
+            raise HTTPException(
+                status_code=400,
+                detail="LTX frames must be 8n+1 and at least 9 (for example 9, 17, 25)",
+            )
     workload_width = width if is_cogvideox else generation_width
     workload_height = height if is_cogvideox else generation_height
     if workload_width * workload_height * request_frames > _MAX_PIXEL_FRAMES:

--- a/vllm_mlx/runtime/video_lane.py
+++ b/vllm_mlx/runtime/video_lane.py
@@ -138,6 +138,9 @@ class VideoEngine:
         fps: int,
         seed: int,
         image: Path | None,
+        negative_prompt: str | None = None,
+        guidance_scale: float | None = None,
+        conditioning_strength: float | None = None,
         output_width: int | None = None,
         output_height: int | None = None,
     ) -> None:
@@ -154,6 +157,8 @@ class VideoEngine:
                         num_frames=num_frames,
                         seed=seed,
                         image=image,
+                        negative_prompt=negative_prompt,
+                        guidance_scale=guidance_scale,
                     )
             except WanBackendError as exc:
                 raise VideoRuntimeError(str(exc)) from exc
@@ -180,6 +185,8 @@ class VideoEngine:
                     frames=num_frames,
                     fps=fps,
                     seed=seed,
+                    negative_prompt=negative_prompt or "",
+                    guidance_scale=(6.0 if guidance_scale is None else guidance_scale),
                 )
             return
         if shutil.which("ffmpeg") is None:
@@ -209,6 +216,11 @@ class VideoEngine:
                 fps=fps,
                 output_path=str(output_path),
                 image=str(image) if image is not None else None,
+                negative_prompt=negative_prompt,
+                cfg_scale=3.0 if guidance_scale is None else guidance_scale,
+                image_strength=(
+                    1.0 if conditioning_strength is None else conditioning_strength
+                ),
                 verbose=False,
                 enhance_prompt=False,
             )

--- a/vllm_mlx/runtime/video_lane.py
+++ b/vllm_mlx/runtime/video_lane.py
@@ -205,25 +205,27 @@ class VideoEngine:
         # The 22B pipeline is not re-entrant and a second concurrent graph can
         # exhaust unified memory. Serialize jobs per served model.
         with self._generation_lock:
-            generate_video_with_audio(
-                model_repo=self.model_name,
-                text_encoder_repo=None,
-                prompt=prompt,
-                height=height,
-                width=width,
-                num_frames=num_frames,
-                seed=seed,
-                fps=fps,
-                output_path=str(output_path),
-                image=str(image) if image is not None else None,
-                negative_prompt=negative_prompt,
-                cfg_scale=3.0 if guidance_scale is None else guidance_scale,
-                image_strength=(
-                    1.0 if conditioning_strength is None else conditioning_strength
-                ),
-                verbose=False,
-                enhance_prompt=False,
-            )
+            generation_kwargs = {
+                "model_repo": self.model_name,
+                "text_encoder_repo": None,
+                "prompt": prompt,
+                "height": height,
+                "width": width,
+                "num_frames": num_frames,
+                "seed": seed,
+                "fps": fps,
+                "output_path": str(output_path),
+                "image": str(image) if image is not None else None,
+                "verbose": False,
+                "enhance_prompt": False,
+            }
+            if negative_prompt is not None:
+                generation_kwargs["negative_prompt"] = negative_prompt
+            if guidance_scale is not None:
+                generation_kwargs["cfg_scale"] = guidance_scale
+            if conditioning_strength is not None:
+                generation_kwargs["image_strength"] = conditioning_strength
+            generate_video_with_audio(**generation_kwargs)
         if not output_path.is_file() or output_path.stat().st_size == 0:
             raise VideoRuntimeError(
                 "LTX-2.3 generation completed without an MP4 output."

--- a/vllm_mlx/video/wan.py
+++ b/vllm_mlx/video/wan.py
@@ -250,23 +250,26 @@ class WanVideoEngine:
                 "install the rapid-mlx video extra"
             ) from exc
 
-        generate_video(
-            model_dir=str(self.model_path),
-            prompt=prompt,
-            negative_prompt=negative_prompt,
-            image=str(image) if image is not None else None,
-            width=width,
-            height=height,
-            num_frames=num_frames,
-            steps=self.steps,
-            guide_scale=guidance_scale,
-            seed=seed,
-            output_path=str(output_path),
-            scheduler=self.scheduler,
-            tiling=self.tiling,
-            loras=self.loras,
-            loras_high=self.loras_high,
-            loras_low=self.loras_low,
-        )
+        generation_kwargs = {
+            "model_dir": str(self.model_path),
+            "prompt": prompt,
+            "image": str(image) if image is not None else None,
+            "width": width,
+            "height": height,
+            "num_frames": num_frames,
+            "steps": self.steps,
+            "seed": seed,
+            "output_path": str(output_path),
+            "scheduler": self.scheduler,
+            "tiling": self.tiling,
+            "loras": self.loras,
+            "loras_high": self.loras_high,
+            "loras_low": self.loras_low,
+        }
+        if negative_prompt is not None:
+            generation_kwargs["negative_prompt"] = negative_prompt
+        if guidance_scale is not None:
+            generation_kwargs["guide_scale"] = guidance_scale
+        generate_video(**generation_kwargs)
         if not output_path.is_file() or output_path.stat().st_size == 0:
             raise WanBackendError("Wan generation completed without an MP4 output")

--- a/vllm_mlx/video/wan.py
+++ b/vllm_mlx/video/wan.py
@@ -236,6 +236,8 @@ class WanVideoEngine:
         num_frames: int,
         seed: int,
         image: Path | None,
+        negative_prompt: str | None = None,
+        guidance_scale: float | None = None,
     ) -> None:
         self.validate_request(
             width=width, height=height, num_frames=num_frames, image=image
@@ -251,11 +253,13 @@ class WanVideoEngine:
         generate_video(
             model_dir=str(self.model_path),
             prompt=prompt,
+            negative_prompt=negative_prompt,
             image=str(image) if image is not None else None,
             width=width,
             height=height,
             num_frames=num_frames,
             steps=self.steps,
+            guide_scale=guidance_scale,
             seed=seed,
             output_path=str(output_path),
             scheduler=self.scheduler,


### PR DESCRIPTION
Closes #1334.

## What changed

- adds optional `fps`, `frames`, `guidance_scale`, `negative_prompt`, and `conditioning_strength` multipart fields to `POST /v1/videos`
- threads supported controls through LTX-2.3, Wan, and CogVideoX-Fun without changing defaults
- rejects unsupported or unsafe backend combinations instead of silently ignoring controls
- documents temporal-shape and backend-specific constraints

## Validation

- `pytest -q tests/test_ltx23_video.py tests/test_wan_video.py` (53 passed)
- Ruff check and format check
- OpenAPI multipart schema inspection
- `git diff --check`