### PR TITLE
fix(release): widen agent-smoke serve-ready budget for 35B hybrid cold start

### DIFF
--- a/tests/integrations/agent_smoke.sh
+++ b/tests/integrations/agent_smoke.sh
@@ -93,11 +93,19 @@ if curl -s -m 3 "$B/v1/models" >/dev/null 2>&1; then
 fi
 nohup "$RMLX" serve "$ALIAS" --port "$PORT" > "$LOG" 2>&1 &
 SERVE_PID=$!
-for i in $(seq 1 48); do
+# Serve-ready budget: 120 * 5s = 600s. The default gate model is a 35B hybrid
+# (Qwen3.6-35B-A3B, GatedDeltaNet/linear-attention). Its FIRST cold serve on the
+# Studio isn't just a weight load — it compiles the hybrid GatedDeltaNet Metal
+# kernels, which alone pushes cold start to ~240s (a warm shader cache serves the
+# same model in ~15s). The old 240s budget sat right on that cold-compile knee and
+# flaked the release gate by ~1-2s. 600s clears the cold compile with margin and
+# still leaves ample room under the 55-min job timeout for the four agent runs. A
+# genuine hang (never binds) still fails — it just gets a realistic deadline.
+for i in $(seq 1 120); do
   curl -s -m 3 "$B/v1/models" 2>/dev/null | grep -q '"id"' && { echo "serve READY (~$((i*5))s)"; break; }
   kill -0 "$SERVE_PID" 2>/dev/null || { tail -20 "$LOG"; fail "serve process died during boot"; }
   sleep 5
-  [ "$i" = 48 ] && { tail -20 "$LOG"; fail "serve not ready in 240s"; }
+  [ "$i" = 120 ] && { tail -20 "$LOG"; fail "serve not ready in 600s"; }
 done
 
 # ---- the task: a buggy factorial + a failing test the agent must fix -----


### PR DESCRIPTION
## fix(release): widen agent-smoke serve-ready budget for 35B hybrid cold start

### Why
The `auto-release.yml` **Tier-1 agent gate** blocked the 0.11.2 cut three times
in a row — not on a product bug, but on its own too-tight serve-ready budget.

The gate serves the default model `qwen3.6-35b-8bit` (**Qwen3.6-35B-A3B**, a
hybrid GatedDeltaNet / linear-attention model) into a fresh venv, then waits
`48 * 5s = 240s` for `/v1/models`. On a cold Studio the first serve isn't just a
37 GB weight load — it **compiles the hybrid GatedDeltaNet Metal kernels**, and
that cold compile lands cold-start at **~240–242s**, i.e. exactly on the knee of
the old budget. Result: `SMOKE-ABORT: serve not ready in 240s`, missing by ~1–2s,
with the serve log showing the engine had in fact started and warmed up.

Measured on the Studio: a **warm** shader cache serves the identical model in
**~15s** (and returns a correct completion), confirming the delta is one-time
Metal compilation, not a hang or a bad model.

### What
`tests/integrations/agent_smoke.sh`: serve-ready budget **240s → 600s**
(`48 → 120` poll iterations), with a comment explaining the hybrid cold-compile
rationale. 600s clears the cold compile with margin and still leaves ample room
under the gate job's 55-minute timeout for the four agent runs. A genuine
never-binds hang still fails — it just gets a realistic deadline.

Release-gate tooling only; no product code paths change. Follow-up (not this PR):
a prefetch/warm preflight so the gate model is warm before the gate, covering a
fully cold-cache Studio (evicted weights) as well.
