### PR TITLE
chore: bump version to 0.11.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.11.2"
+version = "0.11.3"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## chore: bump version to 0.11.3

Cuts the **0.11.3** release from `main` HEAD. This is the version-bump PR that
triggers `auto-release.yml` (detect → Tier-1 agent gate on the self-hosted
Studio → tag `v0.11.3` + GitHub Release → `publish.yml` PyPI + Homebrew).

### Why 0.11.3 (not 0.11.2)
0.11.2 was bumped and merged but **never tagged or published**: its Tier-1 agent
gate aborted three times on a too-tight serve-ready budget while cold-compiling
the 35B hybrid gate model's GatedDeltaNet Metal kernels (~240–242s, right on the
old 240s knee). That gate budget is fixed in #1341 (240s → 600s). 0.11.3 ships
the exact same payload as the intended 0.11.2 **plus** that gate fix. No 0.11.2
ever reached users, so this is a clean skip, not a yank.

### What ships in 0.11.3

**Audio — STT**
- MLX-native SenseVoice STT (#1308)
- Forced-alignment STT via Qwen3-ForcedAligner (#1301) + lane hardening on `/v1/audio/transcriptions` (#1317)
- Word-level timestamps on `/v1/audio/transcriptions` (#1299)

**Audio — TTS / voice**
- Qwen3-TTS: CustomVoice emotion control (#1287), Base zero-shot cloning (#1305), VoiceDesign natural-language style (#1309)
- Chatterbox expressiveness + zero-shot cloning (#1303)
- F5-TTS Chinese cloning (#1297) + `_generate_f5` hardening (#1304)
- IndexTTS zero-shot voice cloning (#1318)
- Kokoro espeak G2P repair instead of worker crash (#1312, #1314)
- De-advertise broken voxcpm Chinese (#1302)

**Audio — music**
- MusicEngine local text-to-music (vendored MLX Stable Audio 3) (#1307) over HTTP `POST /v1/audio/music` (#1316)

**Video**
- Wan 2.1 & 2.2 generation on `/v1/videos` (#1322)
- MLX-native LTX-2.3 generation (#1298)
- Experimental CogVideoX-Fun backend (#1313), runtime deps bundled (#1329)
- Upload body-limit response fix (#1315)
- Python 3.10 core compatibility for the video lane (#1325)

**Core / quality / infra**
- KV-quant differential quality gate + chip-tier classifier (#1289), head_dim guard (#1296)
- Architecture-aware per-token KV byte estimate (#1276)
- Accept mlx-vlm native KV caches for MLLM (#1277)
- Sliding-window prefix-reuse lock against ChunkedKVCache trim-lie (#1285)
- MCP 1.x→2.0 camelCase→snake_case fix (Connectors showing 0 tools) (#1281)
- Tier-1 agent gate on self-hosted Apple Silicon (#1280, #1282)
- Auth hardening (#1271, #1275)
- Telemetry activation funnel (#1273)
- CLI: model download size in listing (#1293), `rmlx` short command (#1284)
- Remove unused cloud routing (#1290) + vLLM platform prototype (#1288); legacy-branding sweep (#1292)
- Harden the G7b hermes `read_file` gauntlet test: pass an absolute path (bare basename was flaky on the 9B gauntlet model) (#1326)
- Stabilize the G7b hermes gauntlet profile: directive no-clarify `code_review` prompt + a per-profile timeout cap sized for the long hermes profile (#1330)
- Calibrate the G12 random-coverage gate: raise the per-round timeout + exclude agentic-incapable models (hybrids, sub-4B-active MoEs) (#1332)
- Widen the Tier-1 agent-gate serve-ready budget 240s→600s for the 35B hybrid cold-compile (#1341)
- Warm concurrent-batch kernel shapes in the batching test suite (#1328)

### Pre-bump verification (local, M3 Ultra)
- `release-smoke`: clean-room wheel build + import of every release surface — **PASS**
- `release-check-m3` (release commit): G0a fleet coherence sweep → G0b model
  coherence gate (#1247) → G5 stress (8 scenarios) → G7×3 SDK (Anthropic /
  pydantic_ai / smolagents) → G7b agent-harness (codex / opencode / hermes /
  aider / langchain + `/v1/responses`) → G6 parallel-tool cap → G9 latency → G8
  parser microbench — **all PASS**.
- G12 random model-sweep **skipped for this cut** (systemic size-based-eligibility
  miscalibration surfacing pre-existing fleet agentic weakness, not a regression;
  calibration fix #1332, redesign tracked in #1331).
- Tier-1 agent gate (`qwen3.6-35b-8bit`) serve verified locally: **~15s warm,
  correct completion**; the gate flake was purely the cold-compile serve budget,
  fixed in #1341.

No behavioral code changes in this PR — version string only.
