### PR TITLE
feat: expose video capability limits

### DIFF
--- a/tests/test_video_capabilities.py
+++ b/tests/test_video_capabilities.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from vllm_mlx.routes import video
+
+
+@pytest.mark.asyncio
+async def test_ltx_capabilities_expose_combined_workload_budget(monkeypatch) -> None:
+    engine = SimpleNamespace(
+        model_name="notapalindrome/ltx23-mlx-av-q4",
+        video_family="ltx-2.3",
+        native_fps=24,
+    )
+    monkeypatch.setattr(video, "_video_engine", lambda: engine)
+
+    body = await video.video_capabilities()
+
+    assert body["object"] == "video.capabilities"
+    assert body["model"] == engine.model_name
+    assert body["modality"] == "video-gen"
+    assert body["modes"] == ["text-to-video", "image-to-video"]
+    assert body["limits"]["seconds"]["maximum"] == 20
+    assert body["limits"]["fps"] == {
+        "minimum": 1,
+        "maximum": 60,
+        "default": 24,
+        "fixed": False,
+    }
+    assert body["limits"]["frames"]["step"] == 8
+    assert body["limits"]["workload"]["maximum"] == 768 * 512 * 97
+    assert body["controls"]["conditioning_strength"]["maximum"] == 1.0
+
+
+@pytest.mark.asyncio
+async def test_cogvideox_capabilities_report_fixed_mvp_shape(monkeypatch) -> None:
+    engine = SimpleNamespace(
+        model_name="dgrauet/CogVideoX-Fun-V1.5-5b-InP-mlx-q4",
+        video_family="cogvideox-fun",
+    )
+    monkeypatch.setattr(video, "_video_engine", lambda: engine)
+
+    body = await video.video_capabilities()
+
+    assert body["modes"] == ["text-to-video"]
+    assert body["limits"]["size"] == {"type": "fixed", "values": ["672x384"]}
+    assert body["limits"]["seconds"]["maximum"] == 1
+    assert body["limits"]["fps"]["default"] == 5
+    assert body["limits"]["workload"]["dimension_rounding"] == "none"
+    assert body["controls"]["conditioning_strength"] is None
+
+
+@pytest.mark.asyncio
+async def test_wan_capabilities_use_checkpoint_limits(monkeypatch) -> None:
+    engine = SimpleNamespace(
+        model_name="Anes1032/Wan2.2-TI2V-5B-mlx-q8",
+        video_family="wan",
+        native_fps=24,
+        _wan_engine=SimpleNamespace(model_type="i2v", max_area=901_120),
+    )
+    monkeypatch.setattr(video, "_video_engine", lambda: engine)
+
+    body = await video.video_capabilities()
+
+    assert body["modes"] == ["image-to-video"]
+    assert body["limits"]["size"]["maximum_area"] == 901_120
+    assert body["limits"]["fps"] == {
+        "minimum": 24,
+        "maximum": 24,
+        "default": 24,
+        "fixed": True,
+    }
+    assert body["limits"]["frames"]["step"] == 4
+
+
+def test_capabilities_route_precedes_dynamic_video_id_route() -> None:
+    routes = [route.path for route in video.router.routes]
+    assert routes.index("/v1/videos/capabilities") < routes.index(
+        "/v1/videos/{video_id}"
+    )

--- a/tests/test_video_capabilities.py
+++ b/tests/test_video_capabilities.py
@@ -66,6 +66,7 @@ async def test_wan_capabilities_use_checkpoint_limits(monkeypatch) -> None:
 
     assert body["modes"] == ["image-to-video"]
     assert body["limits"]["size"]["maximum_area"] == 901_120
+    assert body["limits"]["size"]["also_supported"] == []
     assert body["limits"]["fps"] == {
         "minimum": 24,
         "maximum": 24,
@@ -73,6 +74,26 @@ async def test_wan_capabilities_use_checkpoint_limits(monkeypatch) -> None:
         "fixed": True,
     }
     assert body["limits"]["frames"]["step"] == 4
+
+
+@pytest.mark.asyncio
+async def test_wan_only_lists_openai_sizes_accepted_after_alignment(
+    monkeypatch,
+) -> None:
+    engine = SimpleNamespace(
+        model_name="custom/wan",
+        video_family="wan",
+        native_fps=16,
+        _wan_engine=SimpleNamespace(model_type="t2v", max_area=1280 * 768),
+    )
+    monkeypatch.setattr(video, "_video_engine", lambda: engine)
+
+    body = await video.video_capabilities()
+
+    assert body["limits"]["size"]["also_supported"] == [
+        "1280x720",
+        "720x1280",
+    ]
 
 
 def test_capabilities_route_precedes_dynamic_video_id_route() -> None:

--- a/vllm_mlx/routes/video.py
+++ b/vllm_mlx/routes/video.py
@@ -376,12 +376,19 @@ def _video_capabilities(engine) -> dict:
             "i2v": ["image-to-video"],
             "ti2v": ["text-to-video", "image-to-video"],
         }.get(model_type, ["text-to-video", "image-to-video"])
+        openai_sizes = [(1280, 720), (720, 1280)]
+        supported_openai_sizes = [
+            f"{width}x{height}"
+            for width, height in openai_sizes
+            if max_area is None
+            or ((width + 63) // 64) * 64 * (((height + 63) // 64) * 64) <= max_area
+        ]
         size = {
             "type": "range",
             "width": {"minimum": 256, "maximum": 1920, "multiple_of": 64},
             "height": {"minimum": 256, "maximum": 1920, "multiple_of": 64},
             "maximum_area": max_area,
-            "also_supported": ["1280x720", "720x1280"],
+            "also_supported": supported_openai_sizes,
         }
         seconds = {"minimum": 1, "maximum": 20, "default": 4}
         frames = {"minimum": 5, "maximum": 1201, "step": 4, "offset": 1}

--- a/vllm_mlx/routes/video.py
+++ b/vllm_mlx/routes/video.py
@@ -354,6 +354,87 @@ def _frame_count(seconds: int, fps: int = 24) -> int:
     return max(9, round((requested - 1) / 8) * 8 + 1)
 
 
+def _video_capabilities(engine) -> dict:
+    """Describe the live video model using the route's validation contract."""
+    family = getattr(engine, "video_family", "ltx-2.3")
+    native_fps = 5 if family == "cogvideox-fun" else getattr(engine, "native_fps", 24)
+    model_type = None
+    max_area = None
+    if family == "wan":
+        wan_engine = getattr(engine, "_wan_engine", None)
+        model_type = getattr(wan_engine, "model_type", None)
+        max_area = getattr(wan_engine, "max_area", None)
+
+    if family == "cogvideox-fun":
+        modes = ["text-to-video"]
+        size = {"type": "fixed", "values": ["672x384"]}
+        seconds = {"minimum": 1, "maximum": 1, "default": 1}
+        frames = {"minimum": 5, "maximum": 1201, "step": 4, "offset": 1}
+    elif family == "wan":
+        modes = {
+            "t2v": ["text-to-video"],
+            "i2v": ["image-to-video"],
+            "ti2v": ["text-to-video", "image-to-video"],
+        }.get(model_type, ["text-to-video", "image-to-video"])
+        size = {
+            "type": "range",
+            "width": {"minimum": 256, "maximum": 1920, "multiple_of": 64},
+            "height": {"minimum": 256, "maximum": 1920, "multiple_of": 64},
+            "maximum_area": max_area,
+            "also_supported": ["1280x720", "720x1280"],
+        }
+        seconds = {"minimum": 1, "maximum": 20, "default": 4}
+        frames = {"minimum": 5, "maximum": 1201, "step": 4, "offset": 1}
+    else:
+        modes = ["text-to-video", "image-to-video"]
+        size = {
+            "type": "range",
+            "width": {"minimum": 256, "maximum": 1920, "multiple_of": 64},
+            "height": {"minimum": 256, "maximum": 1920, "multiple_of": 64},
+            "also_supported": ["1280x720", "720x1280"],
+        }
+        seconds = {"minimum": 1, "maximum": 20, "default": 4}
+        frames = {"minimum": 9, "maximum": 1201, "step": 8, "offset": 1}
+
+    return {
+        "object": "video.capabilities",
+        "model": engine.model_name,
+        "modality": "video-gen",
+        "family": family,
+        "modes": modes,
+        "limits": {
+            "size": size,
+            "seconds": seconds,
+            "fps": {
+                "minimum": native_fps if family == "wan" else 1,
+                "maximum": native_fps if family == "wan" else 60,
+                "default": native_fps,
+                "fixed": family == "wan",
+            },
+            "frames": frames,
+            "workload": {
+                "metric": "pixel_frames",
+                "maximum": _MAX_PIXEL_FRAMES,
+                "dimension_rounding": (
+                    "none" if family == "cogvideox-fun" else "ceil_to_64"
+                ),
+            },
+            "input_reference": {
+                "maximum_bytes": _MAX_REFERENCE_BYTES,
+                "maximum_pixels": _MAX_REFERENCE_PIXELS,
+                "formats": ["jpeg", "png", "webp"],
+            },
+        },
+        "controls": {
+            "guidance_scale": {"minimum": 1.0, "maximum": 30.0},
+            "conditioning_strength": (
+                {"minimum": 0.0, "maximum": 1.0} if family == "ltx-2.3" else None
+            ),
+            "negative_prompt": True,
+        },
+    }
+
+
 def _validate_reference_image(path: Path) -> None:
     try:
         from PIL import Image
@@ -735,6 +816,12 @@ async def create_video(
             shutil.rmtree, _jobs_root / evicted_id, ignore_errors=True
         )
     return job.public()
+
+
+@router.get("/v1/videos/capabilities", dependencies=[Depends(verify_api_key)])
+async def video_capabilities():
+    """Return machine-readable limits for the currently served video model."""
+    return _video_capabilities(_video_engine())
 
 
 def _get_job(video_id: str) -> _VideoJob:


### PR DESCRIPTION
Closes #1336

## What changed
- add authenticated GET /v1/videos/capabilities discovery
- expose live model family, t2v/i2v modes, size, duration, fps, frame-shape, reference-image and motion-control limits
- expose the pixel-frames workload budget and dimension-rounding rule so clients can validate combined size and duration safely
- report Wan checkpoint-native fps, model type, and max-area constraints

## Validation
- 70 focused LTX, CogVideoX-Fun, Wan, and capability tests
- 67 server, model capability, and model-route tests
- ruff check and format check
- compileall and git diff --check