### PR TITLE
fix(release): agent-smoke hermes/codex --base-url + cold-compile timeout headroom

### DIFF
--- a/tests/integrations/agent_smoke.sh
+++ b/tests/integrations/agent_smoke.sh
@@ -26,6 +26,13 @@ RMLX="$VENV/bin/rapid-mlx"
 ALIAS="${1:-qwen3.6-35b-8bit}"
 PORT="${RAPID_MLX_PORT:-8000}"
 B="http://localhost:$PORT"
+# Per-agent wall-clock budgets. The default gate model is a slow 35B hybrid with
+# reasoning: cold (agentic tool/long-context kernels still compiling) it runs
+# ~8 tok/s, warm ~23 tok/s. A multi-turn fix with a large agent system prompt can
+# approach the old 260/300s knee cold, so give generous headroom (the kernel
+# warmup after serve-ready also helps). A genuine hang still fails on the budget.
+AGENT_TO="${AGENT_SMOKE_TIMEOUT:-480}"
+HERMES_TO="${HERMES_SMOKE_TIMEOUT:-600}"
 WORK="$HOME/agent-smoke-work"
 LOG="$HOME/agent-smoke-serve.log"
 SERVE_PID=""
@@ -108,6 +115,16 @@ for i in $(seq 1 120); do
   [ "$i" = 120 ] && { tail -20 "$LOG"; fail "serve not ready in 600s"; }
 done
 
+# Warm the model kernels before the timed agents. ``/v1/models`` returning above
+# only means the server bound the port — the FIRST real completion still JIT-
+# compiles the hybrid GatedDeltaNet / attention Metal kernels (cold ~8 tok/s vs
+# warm ~23). Paying that here, untimed, keeps a cold shader cache from pushing
+# the first agent past its per-agent budget. Best-effort — never fatal.
+echo "warming kernels…"
+curl -s -m 180 "$B/v1/chat/completions" -H 'Content-Type: application/json' \
+  -d "{\"model\":\"$ALIAS\",\"messages\":[{\"role\":\"user\",\"content\":\"Reply with the single word OK.\"}],\"max_tokens\":16,\"temperature\":0}" \
+  >/dev/null 2>&1 || true
+
 # ---- the task: a buggy factorial + a failing test the agent must fix -----
 seed_repo() {
   local d="$WORK/$1"; rm -rf "$d"; mkdir -p "$d"; cd "$d" || return 1
@@ -130,32 +147,40 @@ TASK='Run python3 test_calc.py, it fails. Fix the bug in calc.py so all assertio
 R_CLAUDE=FAIL
 for _try in 1 2; do
   seed_repo claude
-  TO 260 env ANTHROPIC_BASE_URL="$B" ANTHROPIC_API_KEY=not-needed \
+  TO "$AGENT_TO" env ANTHROPIC_BASE_URL="$B" ANTHROPIC_API_KEY=not-needed \
     claude -p "$TASK" --model "$ALIAS" --dangerously-skip-permissions >/dev/null 2>&1
   [ "$(verify claude)" = PASS ] && { R_CLAUDE=PASS; break; }
 done
 
 # ---- Codex (agents codex --setup writes ~/.codex/config.toml) ------------
+# Pass --base-url so setup points at OUR serve port (not the default :8000) —
+# otherwise the written base_url is wrong and detection can't reach the model.
 save_cfg "$CODEX_CFG"
-"$RMLX" agents codex --setup >/dev/null 2>&1
+"$RMLX" agents codex --setup --base-url "$B/v1" >/dev/null 2>&1
 patch_port "$CODEX_CFG"
 R_CODEX=FAIL
 for _try in 1 2; do
   seed_repo codex
-  TO 260 codex exec "$TASK" --model "$ALIAS" \
+  TO "$AGENT_TO" codex exec "$TASK" --model "$ALIAS" \
     --dangerously-bypass-approvals-and-sandbox --skip-git-repo-check >/dev/null 2>&1
   [ "$(verify codex)" = PASS ] && { R_CODEX=PASS; break; }
 done
 restore_cfg "$CODEX_CFG"
 
-# ---- Hermes (agents hermes --setup; auto-writes context_length >= 64K) ----
+# ---- Hermes (agents hermes --setup writes ~/.hermes/config.yaml) ----------
+# --base-url is REQUIRED here: Hermes rejects any model whose context_length is
+# below 64K, and setup only writes the model's real context (e.g. 262144) when
+# it can reach the running server to detect it. Without --base-url, setup queries
+# the default :8000 (empty in this run), falls back to the 32768 default, and
+# Hermes refuses to start every time. Give hermes a third attempt — the gate
+# model occasionally hallucinates a "tests already pass" no-op (~1 in 3).
 save_cfg "$HERMES_CFG"
-"$RMLX" agents hermes --setup >/dev/null 2>&1
+"$RMLX" agents hermes --setup --base-url "$B/v1" >/dev/null 2>&1
 patch_port "$HERMES_CFG"
 R_HERMES=FAIL
-for _try in 1 2; do
+for _try in 1 2 3; do
   seed_repo hermes
-  TO 300 hermes chat -q "$TASK" -Q -m "$ALIAS" >/dev/null 2>&1
+  TO "$HERMES_TO" hermes chat -q "$TASK" -Q -m "$ALIAS" >/dev/null 2>&1
   [ "$(verify hermes)" = PASS ] && { R_HERMES=PASS; break; }
 done
 restore_cfg "$HERMES_CFG"
@@ -164,7 +189,7 @@ restore_cfg "$HERMES_CFG"
 R_AIDER=FAIL
 for _try in 1 2; do
   seed_repo aider
-  TO 260 env OPENAI_API_BASE="$B/v1" OPENAI_API_KEY=not-needed \
+  TO "$AGENT_TO" env OPENAI_API_BASE="$B/v1" OPENAI_API_KEY=not-needed \
     aider --model "openai/$ALIAS" --message "$TASK" \
     --yes-always --no-auto-commits --no-show-model-warnings calc.py >/dev/null 2>&1
   [ "$(verify aider)" = PASS ] && { R_AIDER=PASS; break; }


### PR DESCRIPTION
## fix(release): agent-smoke hermes/codex `--base-url` + cold-compile timeout headroom

### Why
The `auto-release.yml` **Tier-1 agent gate** (its release debut was 0.11.3)
reported **4/4 FAIL** and blocked the cut. Root-cause on the Studio (M3 Ultra):
the failure was in the gate's own harness, `tests/integrations/agent_smoke.sh`,
**not** in the release payload. The 0.11.3 payload is good — verified below.

Two harness defects:

1. **Hermes could never start (deterministic).** `agents hermes --setup` was
   run without `--base-url`, so setup probed the default `localhost:8000`
   (nothing serving there in this run) and could not detect the served model's
   context window. Hermes refuses any model whose `context_length` is below
   **64K**; with detection failing, setup wrote the **32768** fallback
   (`vllm_mlx/agents/base.py`), so Hermes rejected the model on every attempt.
   `patch_port()` rewrites the URL after the fact but not the already-wrong
   context — so the URL patch alone never fixed it.

2. **Cold shader compile × tight per-agent budget.** The 35B hybrid gate model
   (`qwen3.6-35b-8bit`, Qwen3.6-35B-A3B / GatedDeltaNet) runs **~8 tok/s cold**
   (agentic + long-context Metal kernels still compiling) vs **~23 tok/s warm**.
   The per-agent budgets were hardcoded at **260s/300s**, tight enough that a
   cold multi-turn fix could time out claude/codex/aider.

### What
`tests/integrations/agent_smoke.sh` (release-gate tooling only — not shipped in
the wheel, no product code path changes):

- Pass `--base-url "$B/v1"` to **both** `agents codex --setup` and
  `agents hermes --setup`, so setup reads the model's real context
  (qwen3.6-35b-8bit advertises **262144**) instead of the 32768 fallback.
- Move the per-agent wall-clock budgets to env-overridable vars with headroom:
  `AGENT_TO=${AGENT_SMOKE_TIMEOUT:-480}` (was 260) and
  `HERMES_TO=${HERMES_SMOKE_TIMEOUT:-600}` (was 300). A genuine hang still fails.
- **Warm the kernels** once, untimed, right after serve-ready — `/v1/models`
  binding only means the port is up; the first real completion still JIT-compiles
  the hybrid kernels. Paying that here keeps a cold cache from pushing the first
  timed agent over budget. Best-effort, never fatal.
- Give **Hermes a 3rd attempt** — the gate model occasionally hallucinates a
  "tests already pass" no-op (~1 in 3).

### Verification
End-to-end on the Studio (M3 Ultra) with the fixed harness against
`qwen3.6-35b-8bit` on rapid-mlx **0.11.3**:

```
== Tier-1 re-verification (qwen3.6-35b-8bit) ==
  claude-code  PASS
  codex-cli    PASS
  hermes       PASS
  aider        PASS
RESULT: PASS — all four Tier-1 agents verified on qwen3.6-35b-8bit.
```

### Context
This is the follow-up promised in the 0.11.3 release notes, where the gate was
bypassed via `gh release create --target ae147252` after manual Studio
verification. With this fix, the **next** release's Tier-1 gate runs green
without a bypass.
