### PR TITLE
feat: configure audio output sample rate and channels

### DIFF
--- a/docs/guides/audio.md
+++ b/docs/guides/audio.md
@@ -450,6 +450,10 @@ Generate speech from text (OpenAI TTS API compatible).
 - `channels`: Optional output channel count, `1` or `2`. Omit to keep the
   model's native channel count (commonly mono).
 
+MP3 accepts standard MPEG rates from 8–48 kHz; Opus accepts 8, 12, 16, 24,
+or 48 kHz. WAV, PCM, FLAC, and Ogg/Vorbis accept any integer in the documented
+8–96 kHz range. Invalid codec/rate combinations are rejected before synthesis.
+
 **Example:**
 ```bash
 curl http://localhost:8000/v1/audio/speech \

--- a/docs/guides/audio.md
+++ b/docs/guides/audio.md
@@ -443,13 +443,18 @@ Generate speech from text (OpenAI TTS API compatible).
 - `model`: Model name or alias
 - `input`: Text to synthesize
 - `voice`: Voice ID
-- `speed`: Speech speed (0.5 to 2.0)
-- `response_format`: `wav`, `mp3`
+- `speed`: Speech speed (`0.25` to `4.0`)
+- `response_format`: `wav`, `pcm`, `mp3`, `flac`, `ogg`, or `opus`
+- `sample_rate`: Optional output rate (`8000` to `96000` Hz). Omit to keep
+  the TTS model's native rate (commonly 24 kHz).
+- `channels`: Optional output channel count, `1` or `2`. Omit to keep the
+  model's native channel count (commonly mono).
 
 **Example:**
 ```bash
 curl http://localhost:8000/v1/audio/speech \
-  -d '{"model": "kokoro", "input": "Hello world", "voice": "af_heart"}' \
+  -d '{"model": "kokoro", "input": "Hello world", "voice": "af_heart",
+       "sample_rate": 44100, "channels": 2}' \
   -H "Content-Type: application/json" \
   --output speech.wav
 ```
@@ -472,8 +477,12 @@ the same shape as `/v1/audio/speech`.
 | `negative_prompt` | string \| null | `null` | CFG negative branch (e.g. `"vocals, singing"`). Max 4096 chars. |
 | `seed` | integer \| null | `null` | Fixed seed for reproducibility. |
 | `response_format` | string | `"wav"` | Only `wav` is supported (SA3 renders WAV natively). |
+| `sample_rate` | integer \| null | `null` | Output rate, `8000..96000` Hz. Omit to preserve SA3's native 44.1 kHz. |
+| `channels` | `1` \| `2` \| null | `null` | Output channel count. Omit to preserve SA3's native stereo output. |
 
 **Response:** `200 OK`, `Content-Type: audio/wav` — the raw WAV bytes.
+Speech and music responses also include `X-Audio-Sample-Rate` and
+`X-Audio-Channels`, which are especially useful for headerless PCM speech.
 
 Errors: `400` for schema violations (blank or over-4096-char `input`,
 `seconds > 47`, unsupported `response_format`); `500`
@@ -504,7 +513,9 @@ curl http://localhost:8000/v1/audio/music \
         "seconds": 20,
         "steps": 8,
         "negative_prompt": "vocals, singing",
-        "seed": 42
+        "seed": 42,
+        "sample_rate": 24000,
+        "channels": 1
       }' \
   --output bgm.wav
 ```

--- a/tests/test_audio_output_format.py
+++ b/tests/test_audio_output_format.py
@@ -36,6 +36,10 @@ def test_tts_mono_can_be_resampled_and_expanded_to_stereo() -> None:
     assert channels == 2
     assert converted.shape == (44_100, 2)
     np.testing.assert_array_equal(converted[:, 0], converted[:, 1])
+    assert np.max(np.abs(converted)) > 0.9
+    spectrum = np.abs(np.fft.rfft(converted[:, 0]))
+    peak_hz = np.fft.rfftfreq(len(converted), d=1 / sample_rate)[spectrum.argmax()]
+    assert peak_hz == pytest.approx(440, abs=1)
 
 
 def test_music_stereo_can_be_resampled_and_downmixed_to_mono() -> None:
@@ -45,8 +49,8 @@ def test_music_stereo_can_be_resampled_and_downmixed_to_mono() -> None:
 
     payload, sample_rate, channels = _convert_music_wav(
         _wav_bytes(source, 44_100),
-        sample_rate=24_000,
-        channels=1,
+        24_000,
+        1,
     )
 
     with wave.open(io.BytesIO(payload), "rb") as result:
@@ -58,11 +62,13 @@ def test_music_stereo_can_be_resampled_and_downmixed_to_mono() -> None:
 
 
 def test_omitted_output_format_preserves_native_audio() -> None:
-    source = np.zeros((100, 2), dtype=np.float32)
+    source = np.full((100, 2), 32_000, dtype=np.int16)
 
     converted, sample_rate, channels = convert_audio_output(source, 44_100)
 
-    assert converted.shape == source.shape
+    assert converted is source
+    assert converted.dtype == np.int16
+    np.testing.assert_array_equal(converted, source)
     assert sample_rate == 44_100
     assert channels == 2
 
@@ -70,9 +76,7 @@ def test_omitted_output_format_preserves_native_audio() -> None:
 def test_music_omitted_output_format_preserves_wav_bytes() -> None:
     source = _wav_bytes(np.zeros((100, 2), dtype=np.int16), 44_100)
 
-    converted, sample_rate, channels = _convert_music_wav(
-        source, sample_rate=None, channels=None
-    )
+    converted, sample_rate, channels = _convert_music_wav(source, None, None)
 
     assert converted is source
     assert sample_rate == 44_100
@@ -88,6 +92,14 @@ def test_music_omitted_output_format_preserves_wav_bytes() -> None:
         (AudioMusicRequest, {"input": "music", "sample_rate": 96_001}),
         (AudioMusicRequest, {"input": "music", "sample_rate": "44100"}),
         (AudioMusicRequest, {"input": "music", "channels": 0}),
+        (
+            AudioSpeechRequest,
+            {"input": "hello", "response_format": "mp3", "sample_rate": 96_000},
+        ),
+        (
+            AudioSpeechRequest,
+            {"input": "hello", "response_format": "opus", "sample_rate": 44_100},
+        ),
     ],
 )
 def test_audio_output_format_rejects_invalid_values(request_type, payload) -> None:

--- a/tests/test_audio_output_format.py
+++ b/tests/test_audio_output_format.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import io
+import wave
+
+import numpy as np
+import pytest
+from pydantic import ValidationError
+
+from vllm_mlx.api.models import AudioMusicRequest, AudioSpeechRequest
+from vllm_mlx.audio.output_format import convert_audio_output
+from vllm_mlx.routes.audio import _convert_music_wav
+
+
+def _wav_bytes(audio: np.ndarray, sample_rate: int) -> bytes:
+    payload = io.BytesIO()
+    with wave.open(payload, "wb") as output:
+        output.setnchannels(1 if audio.ndim == 1 else audio.shape[1])
+        output.setsampwidth(2)
+        output.setframerate(sample_rate)
+        output.writeframes(audio.astype("<i2").tobytes())
+    return payload.getvalue()
+
+
+def test_tts_mono_can_be_resampled_and_expanded_to_stereo() -> None:
+    source = np.sin(2 * np.pi * 440 * np.arange(24_000) / 24_000).astype(np.float32)
+
+    converted, sample_rate, channels = convert_audio_output(
+        source,
+        24_000,
+        sample_rate=44_100,
+        channels=2,
+    )
+
+    assert sample_rate == 44_100
+    assert channels == 2
+    assert converted.shape == (44_100, 2)
+    np.testing.assert_array_equal(converted[:, 0], converted[:, 1])
+
+
+def test_music_stereo_can_be_resampled_and_downmixed_to_mono() -> None:
+    left = np.full(44_100, 8_000, dtype=np.int16)
+    right = np.full(44_100, -4_000, dtype=np.int16)
+    source = np.column_stack((left, right))
+
+    payload, sample_rate, channels = _convert_music_wav(
+        _wav_bytes(source, 44_100),
+        sample_rate=24_000,
+        channels=1,
+    )
+
+    with wave.open(io.BytesIO(payload), "rb") as result:
+        assert result.getframerate() == 24_000
+        assert result.getnchannels() == 1
+        assert result.getnframes() == 24_000
+    assert sample_rate == 24_000
+    assert channels == 1
+
+
+def test_omitted_output_format_preserves_native_audio() -> None:
+    source = np.zeros((100, 2), dtype=np.float32)
+
+    converted, sample_rate, channels = convert_audio_output(source, 44_100)
+
+    assert converted.shape == source.shape
+    assert sample_rate == 44_100
+    assert channels == 2
+
+
+def test_music_omitted_output_format_preserves_wav_bytes() -> None:
+    source = _wav_bytes(np.zeros((100, 2), dtype=np.int16), 44_100)
+
+    converted, sample_rate, channels = _convert_music_wav(
+        source, sample_rate=None, channels=None
+    )
+
+    assert converted is source
+    assert sample_rate == 44_100
+    assert channels == 2
+
+
+@pytest.mark.parametrize(
+    ("request_type", "payload"),
+    [
+        (AudioSpeechRequest, {"input": "hello", "sample_rate": 7_999}),
+        (AudioSpeechRequest, {"input": "hello", "sample_rate": True}),
+        (AudioSpeechRequest, {"input": "hello", "channels": 3}),
+        (AudioMusicRequest, {"input": "music", "sample_rate": 96_001}),
+        (AudioMusicRequest, {"input": "music", "sample_rate": "44100"}),
+        (AudioMusicRequest, {"input": "music", "channels": 0}),
+    ],
+)
+def test_audio_output_format_rejects_invalid_values(request_type, payload) -> None:
+    with pytest.raises(ValidationError):
+        request_type(**payload)

--- a/tests/test_audio_output_format.py
+++ b/tests/test_audio_output_format.py
@@ -102,6 +102,22 @@ def test_requested_conversion_normalizes_int16_pcm() -> None:
 
 
 @pytest.mark.parametrize(
+    ("source", "channels"),
+    [
+        (np.zeros((1, 1), dtype=np.float32), 1),
+        (np.zeros((1, 2), dtype=np.float32), 2),
+        (np.zeros((2, 1), dtype=np.float32), 1),
+        (np.zeros((2, 2), dtype=np.float32), 2),
+    ],
+)
+def test_short_sample_first_audio_has_unambiguous_channels(source, channels) -> None:
+    converted, _, detected_channels = convert_audio_output(source, 24_000)
+
+    assert converted is source
+    assert detected_channels == channels
+
+
+@pytest.mark.parametrize(
     ("request_type", "payload"),
     [
         (AudioSpeechRequest, {"input": "hello", "sample_rate": 7_999}),

--- a/tests/test_audio_output_format.py
+++ b/tests/test_audio_output_format.py
@@ -57,6 +57,9 @@ def test_music_stereo_can_be_resampled_and_downmixed_to_mono() -> None:
         assert result.getframerate() == 24_000
         assert result.getnchannels() == 1
         assert result.getnframes() == 24_000
+        samples = np.frombuffer(result.readframes(result.getnframes()), dtype="<i2")
+    assert samples.mean() == pytest.approx(2_000, abs=20)
+    assert samples.std() < 20
     assert sample_rate == 24_000
     assert channels == 1
 
@@ -81,6 +84,21 @@ def test_music_omitted_output_format_preserves_wav_bytes() -> None:
     assert converted is source
     assert sample_rate == 44_100
     assert channels == 2
+
+
+def test_requested_conversion_normalizes_int16_pcm() -> None:
+    source = np.array([0, 16_384, -16_384, 32_767, -32_768], dtype=np.int16)
+
+    converted, sample_rate, channels = convert_audio_output(source, 24_000, channels=2)
+
+    assert sample_rate == 24_000
+    assert channels == 2
+    np.testing.assert_allclose(
+        converted[:, 0],
+        [0.0, 0.5, -0.5, 32_767 / 32_768, -1.0],
+        atol=1e-6,
+    )
+    np.testing.assert_array_equal(converted[:, 0], converted[:, 1])
 
 
 @pytest.mark.parametrize(

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -2656,6 +2656,11 @@ class AudioSpeechRequest(BaseModel):
     # matches the documented contract.
     speed: float = Field(default=1.0, ge=0.25, le=4.0)
     response_format: str = "wav"
+    # Rapid-MLX extensions for callers mixing speech with other audio lanes.
+    # Omitted values preserve the model's native output (commonly 24 kHz
+    # mono); explicit values resample/rechannel after synthesis.
+    sample_rate: StrictInt | None = Field(default=None, ge=8_000, le=96_000)
+    channels: Literal[1, 2] | None = None
     # OpenAI ``gpt-4o-mini-tts`` accepts an ``instructions`` field that
     # steers the emotional delivery / speaking style ("Speak in a cheerful
     # and positive tone."). We honour the same field name for spec
@@ -2853,6 +2858,9 @@ class AudioMusicRequest(BaseModel):
     negative_prompt: str | None = Field(default=None, max_length=4096)
     seed: int | None = None
     response_format: str = "wav"
+    # Omitted values preserve SA3's native 44.1 kHz stereo output.
+    sample_rate: StrictInt | None = Field(default=None, ge=8_000, le=96_000)
+    channels: Literal[1, 2] | None = None
 
     @field_validator("input")
     @classmethod

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -2766,6 +2766,32 @@ class AudioSpeechRequest(BaseModel):
             raise ValueError("ref_text must not be blank")
         return self
 
+    @model_validator(mode="after")
+    def _validate_codec_sample_rate(self):
+        if self.sample_rate is None:
+            return self
+        codec_rates = {
+            "mp3": {
+                8_000,
+                11_025,
+                12_000,
+                16_000,
+                22_050,
+                24_000,
+                32_000,
+                44_100,
+                48_000,
+            },
+            "opus": {8_000, 12_000, 16_000, 24_000, 48_000},
+        }
+        allowed = codec_rates.get(self.response_format)
+        if allowed is not None and self.sample_rate not in allowed:
+            values = ", ".join(str(value) for value in sorted(allowed))
+            raise ValueError(
+                f"sample_rate for {self.response_format} must be one of: {values}"
+            )
+        return self
+
     @field_validator("input")
     @classmethod
     def _input_must_be_non_blank(cls, v: str) -> str:

--- a/vllm_mlx/audio/output_format.py
+++ b/vllm_mlx/audio/output_format.py
@@ -38,10 +38,27 @@ def convert_audio_output(
         # dtype, object identity, out-of-range floats, and backend layout.
         return audio, source_rate, source_channels
 
-    # MLX arrays do not expose NumPy's buffer protocol consistently across
-    # releases, but their public ``tolist`` bridge is stable.
-    source = audio.tolist() if hasattr(audio, "tolist") else audio
-    value = np.asarray(source, dtype=np.float32)
+    # NumPy is the hot path for music and most TTS engines; never turn a
+    # multi-million-sample array into an equally large Python object graph.
+    # Some MLX releases lack a working NumPy buffer bridge, so only those
+    # array types fall back to their stable public ``tolist`` method.
+    original = np.asarray(audio) if isinstance(audio, np.ndarray) else None
+    if original is None:
+        try:
+            original = np.asarray(audio)
+        except (TypeError, ValueError):
+            source = audio.tolist() if hasattr(audio, "tolist") else audio
+            original = np.asarray(source)
+    if np.issubdtype(original.dtype, np.signedinteger):
+        scale = float(
+            max(abs(np.iinfo(original.dtype).min), np.iinfo(original.dtype).max)
+        )
+        value = original.astype(np.float32) / scale
+    elif np.issubdtype(original.dtype, np.unsignedinteger):
+        midpoint = float(np.iinfo(original.dtype).max + 1) / 2
+        value = (original.astype(np.float32) - midpoint) / midpoint
+    else:
+        value = original.astype(np.float32, copy=False)
     if value.ndim == 1:
         value = value[:, None]
     elif value.ndim == 2:

--- a/vllm_mlx/audio/output_format.py
+++ b/vllm_mlx/audio/output_format.py
@@ -19,6 +19,25 @@ def convert_audio_output(
     if source_rate <= 0:
         raise ValueError("source sample rate must be positive")
 
+    raw_shape = getattr(audio, "shape", None)
+    if raw_shape is None:
+        raw_shape = np.shape(audio)
+    shape = tuple(int(part) for part in raw_shape)
+    if len(shape) == 1:
+        source_channels = 1
+    elif len(shape) == 2:
+        source_channels = shape[0] if shape[0] in (1, 2) and shape[1] > 2 else shape[1]
+    else:
+        raise ValueError(f"audio must be one- or two-dimensional, got {len(shape)}D")
+    if source_channels not in (1, 2):
+        raise ValueError(
+            f"audio must be mono or stereo, got {source_channels} channels"
+        )
+    if sample_rate is None and channels is None:
+        # A missing output preference is a strict compatibility no-op: keep
+        # dtype, object identity, out-of-range floats, and backend layout.
+        return audio, source_rate, source_channels
+
     # MLX arrays do not expose NumPy's buffer protocol consistently across
     # releases, but their public ``tolist`` bridge is stable.
     source = audio.tolist() if hasattr(audio, "tolist") else audio
@@ -30,7 +49,7 @@ def convert_audio_output(
         # while a few return the channel-first shape used by ML models.
         if value.shape[0] in (1, 2) and value.shape[1] > 2:
             value = value.T
-    else:
+    else:  # pragma: no cover - shape validation above owns this branch
         raise ValueError(f"audio must be one- or two-dimensional, got {value.ndim}D")
     if value.shape[1] not in (1, 2):
         raise ValueError(f"audio must be mono or stereo, got {value.shape[1]} channels")

--- a/vllm_mlx/audio/output_format.py
+++ b/vllm_mlx/audio/output_format.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Shared output sample-rate and channel conversion for audio generators."""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+
+
+def convert_audio_output(
+    audio: np.ndarray,
+    source_rate: int,
+    *,
+    sample_rate: int | None = None,
+    channels: int | None = None,
+) -> tuple[np.ndarray, int, int]:
+    """Return sample-first float32 audio in the requested output format."""
+    if source_rate <= 0:
+        raise ValueError("source sample rate must be positive")
+
+    # MLX arrays do not expose NumPy's buffer protocol consistently across
+    # releases, but their public ``tolist`` bridge is stable.
+    source = audio.tolist() if hasattr(audio, "tolist") else audio
+    value = np.asarray(source, dtype=np.float32)
+    if value.ndim == 1:
+        value = value[:, None]
+    elif value.ndim == 2:
+        # TTS backends are not uniform: most return sample-first arrays,
+        # while a few return the channel-first shape used by ML models.
+        if value.shape[0] in (1, 2) and value.shape[1] > 2:
+            value = value.T
+    else:
+        raise ValueError(f"audio must be one- or two-dimensional, got {value.ndim}D")
+    if value.shape[1] not in (1, 2):
+        raise ValueError(f"audio must be mono or stereo, got {value.shape[1]} channels")
+
+    target_channels = value.shape[1] if channels is None else channels
+    if target_channels not in (1, 2):
+        raise ValueError("channels must be 1 or 2")
+    if target_channels == 1 and value.shape[1] == 2:
+        value = value.mean(axis=1, keepdims=True, dtype=np.float32)
+    elif target_channels == 2 and value.shape[1] == 1:
+        value = np.repeat(value, 2, axis=1)
+
+    target_rate = source_rate if sample_rate is None else sample_rate
+    if target_rate <= 0:
+        raise ValueError("sample_rate must be positive")
+    if target_rate != source_rate:
+        from scipy.signal import resample_poly
+
+        divisor = math.gcd(source_rate, target_rate)
+        value = resample_poly(
+            value,
+            target_rate // divisor,
+            source_rate // divisor,
+            axis=0,
+        ).astype(np.float32, copy=False)
+
+    value = np.clip(value, -1.0, 1.0)
+    if target_channels == 1:
+        value = value[:, 0]
+    return value, target_rate, target_channels

--- a/vllm_mlx/audio/output_format.py
+++ b/vllm_mlx/audio/output_format.py
@@ -26,7 +26,9 @@ def convert_audio_output(
     if len(shape) == 1:
         source_channels = 1
     elif len(shape) == 2:
-        source_channels = shape[0] if shape[0] in (1, 2) and shape[1] > 2 else shape[1]
+        # The public contract is sample-first, matching scipy.wavfile,
+        # soundfile, and TTSEngine.to_bytes: (samples, channels).
+        source_channels = shape[1]
     else:
         raise ValueError(f"audio must be one- or two-dimensional, got {len(shape)}D")
     if source_channels not in (1, 2):
@@ -61,12 +63,7 @@ def convert_audio_output(
         value = original.astype(np.float32, copy=False)
     if value.ndim == 1:
         value = value[:, None]
-    elif value.ndim == 2:
-        # TTS backends are not uniform: most return sample-first arrays,
-        # while a few return the channel-first shape used by ML models.
-        if value.shape[0] in (1, 2) and value.shape[1] > 2:
-            value = value.T
-    else:  # pragma: no cover - shape validation above owns this branch
+    elif value.ndim != 2:  # pragma: no cover - shape validation owns this branch
         raise ValueError(f"audio must be one- or two-dimensional, got {value.ndim}D")
     if value.shape[1] not in (1, 2):
         raise ValueError(f"audio must be mono or stereo, got {value.shape[1]} channels")

--- a/vllm_mlx/routes/audio.py
+++ b/vllm_mlx/routes/audio.py
@@ -2488,8 +2488,7 @@ def _generate_speech_blocking(
     )
     if sample_rate is not None or channels is not None:
         # Converted output is normalized to sample-first layout. A no-op
-        # preserves the backend object and its duration metadata verbatim,
-        # including channel-first arrays where len(audio) is channel count.
+        # preserves the backend object and its duration metadata verbatim.
         audio.audio = converted
         audio.sample_rate = output_rate
         audio.duration = len(converted) / output_rate

--- a/vllm_mlx/routes/audio.py
+++ b/vllm_mlx/routes/audio.py
@@ -2994,7 +2994,6 @@ def _wav_has_audio_frames(payload: bytes) -> bool:
 
 def _convert_music_wav(
     payload: bytes,
-    *,
     sample_rate: int | None,
     channels: int | None,
 ) -> tuple[bytes, int, int]:
@@ -3117,10 +3116,11 @@ async def create_music(request: AudioMusicRequest = Body(...)):
                 f"{len(audio_bytes)} bytes)"
             )
 
-        audio_bytes, output_rate, output_channels = _convert_music_wav(
+        audio_bytes, output_rate, output_channels = await run_to_completion(
+            _convert_music_wav,
             audio_bytes,
-            sample_rate=request.sample_rate,
-            channels=request.channels,
+            request.sample_rate,
+            request.channels,
         )
 
         # SA3 emits WAV; ``response_format`` is validated to ``wav`` by

--- a/vllm_mlx/routes/audio.py
+++ b/vllm_mlx/routes/audio.py
@@ -2452,7 +2452,9 @@ def _generate_speech_blocking(
     gen_kwargs: dict,
     ref_bytes: bytes | None,
     ref_text: str | None,
-) -> bytes:
+    sample_rate: int | None,
+    channels: int | None,
+) -> tuple[bytes, int, int]:
     """Load, synthesize, and encode speech without blocking the event loop."""
     global _tts_engine
 
@@ -2476,7 +2478,22 @@ def _generate_speech_blocking(
             audio = _tts_engine.generate(input_text, **kwargs)
     else:
         audio = _tts_engine.generate(input_text, **kwargs)
-    return _tts_engine.to_bytes(audio, format=response_format)
+    from ..audio.output_format import convert_audio_output
+
+    converted, output_rate, output_channels = convert_audio_output(
+        audio.audio,
+        audio.sample_rate,
+        sample_rate=sample_rate,
+        channels=channels,
+    )
+    audio.audio = converted
+    audio.sample_rate = output_rate
+    audio.duration = len(converted) / output_rate
+    return (
+        _tts_engine.to_bytes(audio, format=response_format),
+        output_rate,
+        output_channels,
+    )
 
 
 @router.post("/v1/audio/speech", dependencies=[Depends(verify_api_key)])
@@ -2531,6 +2548,8 @@ async def create_speech(request: AudioSpeechRequest = Body(...)):
     voice = request.voice
     speed = request.speed
     response_format = request.response_format
+    sample_rate = request.sample_rate
+    channels = request.channels
     instructions = request.instructions
     ref_audio = request.ref_audio
     ref_text = request.ref_text
@@ -2773,7 +2792,7 @@ async def create_speech(request: AudioSpeechRequest = Body(...)):
                 ) from exc
         try:
             async with _get_tts_lane_lock():
-                audio_bytes = await run_to_completion(
+                audio_bytes, output_rate, output_channels = await run_to_completion(
                     _generate_speech_blocking,
                     model_name,
                     input_text,
@@ -2781,6 +2800,8 @@ async def create_speech(request: AudioSpeechRequest = Body(...)):
                     gen_kwargs,
                     ref_bytes,
                     ref_text,
+                    sample_rate,
+                    channels,
                 )
         except UnsupportedAudioFormatError as e:
             # R8-H5 (Bo 0.8.9 dogfood): the encoder couldn't produce the
@@ -2810,7 +2831,14 @@ async def create_speech(request: AudioSpeechRequest = Body(...)):
         content_type = _TTS_CONTENT_TYPES.get(
             response_format.lower(), "application/octet-stream"
         )
-        return Response(content=audio_bytes, media_type=content_type)
+        return Response(
+            content=audio_bytes,
+            media_type=content_type,
+            headers={
+                "X-Audio-Sample-Rate": str(output_rate),
+                "X-Audio-Channels": str(output_channels),
+            },
+        )
 
     except HTTPException:
         # Preserve probe-emitted 503 (and any other explicit status)
@@ -2964,6 +2992,47 @@ def _wav_has_audio_frames(payload: bytes) -> bool:
         return False
 
 
+def _convert_music_wav(
+    payload: bytes,
+    *,
+    sample_rate: int | None,
+    channels: int | None,
+) -> tuple[bytes, int, int]:
+    """Convert SA3's PCM WAV while preserving its native format by default."""
+    with wave.open(io.BytesIO(payload), "rb") as source:
+        source_rate = source.getframerate()
+        source_channels = source.getnchannels()
+    if sample_rate is None and channels is None:
+        # Keep the backend's byte-for-byte output, including any metadata
+        # chunks a future SA3 encoder adds. Conversion is strictly opt-in.
+        return payload, source_rate, source_channels
+
+    import scipy.io.wavfile as wav
+
+    from ..audio.output_format import convert_audio_output
+
+    decoded_rate, encoded = wav.read(io.BytesIO(payload))
+    if encoded.dtype == "int16":
+        audio = encoded.astype("float32") / 32768.0
+    elif encoded.dtype == "float32":
+        audio = encoded
+    else:
+        raise ValueError(f"unsupported music WAV sample type: {encoded.dtype}")
+    converted, output_rate, output_channels = convert_audio_output(
+        audio,
+        int(decoded_rate),
+        sample_rate=sample_rate,
+        channels=channels,
+    )
+    output = io.BytesIO()
+    wav.write(
+        output,
+        output_rate,
+        (converted * 32767.0).round().astype("int16"),
+    )
+    return output.getvalue(), output_rate, output_channels
+
+
 def _resolve_music_model(model: str | None) -> tuple[str, str]:
     """Map a ``/v1/audio/music`` ``model`` alias to a ``(dit, decoder)`` pair.
 
@@ -3048,9 +3117,22 @@ async def create_music(request: AudioMusicRequest = Body(...)):
                 f"{len(audio_bytes)} bytes)"
             )
 
+        audio_bytes, output_rate, output_channels = _convert_music_wav(
+            audio_bytes,
+            sample_rate=request.sample_rate,
+            channels=request.channels,
+        )
+
         # SA3 emits WAV; ``response_format`` is validated to ``wav`` by
         # the request model, so the Content-Type is always ``audio/wav``.
-        return Response(content=audio_bytes, media_type="audio/wav")
+        return Response(
+            content=audio_bytes,
+            media_type="audio/wav",
+            headers={
+                "X-Audio-Sample-Rate": str(output_rate),
+                "X-Audio-Channels": str(output_channels),
+            },
+        )
 
     except HTTPException:
         raise

--- a/vllm_mlx/routes/audio.py
+++ b/vllm_mlx/routes/audio.py
@@ -2486,9 +2486,13 @@ def _generate_speech_blocking(
         sample_rate=sample_rate,
         channels=channels,
     )
-    audio.audio = converted
-    audio.sample_rate = output_rate
-    audio.duration = len(converted) / output_rate
+    if sample_rate is not None or channels is not None:
+        # Converted output is normalized to sample-first layout. A no-op
+        # preserves the backend object and its duration metadata verbatim,
+        # including channel-first arrays where len(audio) is channel count.
+        audio.audio = converted
+        audio.sample_rate = output_rate
+        audio.duration = len(converted) / output_rate
     return (
         _tts_engine.to_bytes(audio, format=response_format),
         output_rate,


### PR DESCRIPTION
Closes #1337

## What changed
- add optional sample_rate (8-96 kHz) and channels (mono/stereo) to speech and music requests
- share a polyphase resampler and mono/stereo converter across TTS and Stable Audio 3
- preserve native output when both options are omitted, including byte-for-byte preservation of native music WAVs
- return X-Audio-Sample-Rate and X-Audio-Channels response headers
- document native defaults and uniform-output examples

## Why
Speech is commonly 24 kHz mono while Stable Audio 3 is 44.1 kHz stereo. Callers mixing both currently need a separate resampling and channel-conversion step.

## Validation
- 466 passed, 6 skipped across the complete audio suite
- 205 focused model, route, codec, and output-format tests
- ruff check and format check
- compileall and git diff --check