### PR TITLE
feat: lock VoiceDesign voices with deterministic seeds

### DIFF
--- a/docs/guides/audio.md
+++ b/docs/guides/audio.md
@@ -449,6 +449,9 @@ Generate speech from text (OpenAI TTS API compatible).
   the TTS model's native rate (commonly 24 kHz).
 - `channels`: Optional output channel count, `1` or `2`. Omit to keep the
   model's native channel count (commonly mono).
+- `voice_seed`: Optional unsigned 32-bit seed for
+  `qwen3-tts-voicedesign`. Reuse the same `instructions` and seed to lock a
+  designed voice across calls. The response echoes it in `X-Voice-Seed`.
 
 MP3 accepts standard MPEG rates from 8–48 kHz; Opus accepts 8, 12, 16, 24,
 or 48 kHz. WAV, PCM, FLAC, and Ogg/Vorbis accept any integer in the documented

--- a/tests/test_qwen3_tts_voicedesign.py
+++ b/tests/test_qwen3_tts_voicedesign.py
@@ -324,29 +324,40 @@ class TestVoiceDesignEngine:
         import mlx.core as mx
         import numpy as np
 
+        globals()["categorical_sampling"] = lambda logits, temperature: (
+            mx.random.categorical(logits * (1 / temperature))
+        )
+
         class _RandomVoiceDesignModel:
             def generate(
                 self, *, text, instruct, voice=None, speed=1.0, lang_code=None
             ):
                 del text, instruct, voice, speed, lang_code
+                logits = mx.zeros((32, 16))
                 yield types.SimpleNamespace(
-                    audio=mx.random.uniform(shape=(32,)), sample_rate=24000
+                    audio=globals()["categorical_sampling"](logits, 1.0).astype(
+                        mx.float32
+                    ),
+                    sample_rate=24000,
                 )
 
         engine = _voicedesign_engine()
         engine.model = _RandomVoiceDesignModel()
         before = [np.array(value) for value in mx.random.state]
 
-        first = engine.generate(
-            "第一句。", instruct="a warm narrator", voice_seed=20260731
-        )
-        second = engine.generate(
-            "第二句。", instruct="a warm narrator", voice_seed=20260731
-        )
+        try:
+            first = engine.generate(
+                "第一句。", instruct="a warm narrator", voice_seed=20260731
+            )
+            second = engine.generate(
+                "第二句。", instruct="a warm narrator", voice_seed=20260731
+            )
 
-        np.testing.assert_array_equal(first.audio, second.audio)
-        for expected, actual in zip(before, mx.random.state, strict=True):
-            np.testing.assert_array_equal(expected, np.array(actual))
+            np.testing.assert_array_equal(first.audio, second.audio)
+            for expected, actual in zip(before, mx.random.state, strict=True):
+                np.testing.assert_array_equal(expected, np.array(actual))
+        finally:
+            globals().pop("categorical_sampling", None)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_qwen3_tts_voicedesign.py
+++ b/tests/test_qwen3_tts_voicedesign.py
@@ -320,6 +320,34 @@ class TestVoiceDesignEngine:
         assert call["instruct"] == "a warm, low female narrator, calm and measured"
         assert call["lang_code"] == "auto"
 
+    def test_voice_seed_is_deterministic_and_restores_mlx_rng(self):
+        import mlx.core as mx
+        import numpy as np
+
+        class _RandomVoiceDesignModel:
+            def generate(
+                self, *, text, instruct, voice=None, speed=1.0, lang_code=None
+            ):
+                del text, instruct, voice, speed, lang_code
+                yield types.SimpleNamespace(
+                    audio=mx.random.uniform(shape=(32,)), sample_rate=24000
+                )
+
+        engine = _voicedesign_engine()
+        engine.model = _RandomVoiceDesignModel()
+        before = [np.array(value) for value in mx.random.state]
+
+        first = engine.generate(
+            "第一句。", instruct="a warm narrator", voice_seed=20260731
+        )
+        second = engine.generate(
+            "第二句。", instruct="a warm narrator", voice_seed=20260731
+        )
+
+        np.testing.assert_array_equal(first.audio, second.audio)
+        for expected, actual in zip(before, mx.random.state, strict=True):
+            np.testing.assert_array_equal(expected, np.array(actual))
+
 
 # ---------------------------------------------------------------------------
 # C) Route — voice surface + instructions plumbing
@@ -356,11 +384,19 @@ class _RecordingEngine:
     def load(self):
         pass
 
-    def generate(self, text, voice="af_heart", speed=1.0, instruct=None):
+    def generate(
+        self, text, voice="af_heart", speed=1.0, instruct=None, voice_seed=None
+    ):
         import numpy as np
 
         self.generate_calls.append(
-            {"text": text, "voice": voice, "speed": speed, "instruct": instruct}
+            {
+                "text": text,
+                "voice": voice,
+                "speed": speed,
+                "instruct": instruct,
+                "voice_seed": voice_seed,
+            }
         )
         from vllm_mlx.audio.tts import AudioOutput
 
@@ -404,6 +440,15 @@ def _mount(monkeypatch):
 
 
 class TestVoiceDesignRoute:
+    @pytest.mark.parametrize("seed", [-1, 4_294_967_296, True, "7"])
+    def test_voice_seed_schema_rejects_invalid_values(self, seed):
+        from pydantic import ValidationError
+
+        from vllm_mlx.api.models import AudioSpeechRequest
+
+        with pytest.raises(ValidationError):
+            AudioSpeechRequest(input="hello", voice_seed=seed)
+
     def test_voices_route_lists_describe_sentinel(self, monkeypatch):
         """``GET /v1/audio/voices`` for a VoiceDesign model advertises the
         ``describe`` sentinel — NOT the CustomVoice speakers."""
@@ -429,6 +474,42 @@ class TestVoiceDesignRoute:
         assert engine.model_name == VOICEDESIGN_BF16
         (call,) = engine.generate_calls
         assert call["instruct"] == "a hoarse elderly male storyteller, slow and grave"
+
+    def test_speech_forwards_and_echoes_voice_seed(self, monkeypatch):
+        client = _mount(monkeypatch)
+        resp = client.post(
+            "/v1/audio/speech",
+            json={
+                "model": "qwen3-tts-voicedesign",
+                "input": "第一章。",
+                "instructions": "a warm, low narrator",
+                "voice_seed": 8675309,
+            },
+        )
+
+        assert resp.status_code == 200, resp.text
+        assert resp.headers["x-voice-seed"] == "8675309"
+        (engine,) = _RecordingEngine.instances
+        (call,) = engine.generate_calls
+        assert call["voice_seed"] == 8675309
+
+    def test_voice_seed_is_rejected_for_non_voicedesign_model(self, monkeypatch):
+        client = _mount(monkeypatch)
+        resp = client.post(
+            "/v1/audio/speech",
+            json={
+                "model": "qwen3-tts",
+                "input": "Hello.",
+                "voice": "Serena",
+                "voice_seed": 7,
+            },
+        )
+
+        assert resp.status_code == 400, resp.text
+        error = resp.json()["error"]
+        assert error["code"] == "unsupported_voice_seed"
+        assert error["param"] == "voice_seed"
+        assert _RecordingEngine.instances == []
 
     @pytest.mark.parametrize(
         "body",

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -2672,6 +2672,9 @@ class AudioSpeechRequest(BaseModel):
     # rejected up front with the standard envelope rather than ballooning
     # the generation.
     instructions: str | None = Field(default=None, max_length=4096)
+    # Rapid-MLX VoiceDesign extension. Reusing the same description and seed
+    # deterministically reproduces the designed speaker across calls.
+    voice_seed: StrictInt | None = Field(default=None, ge=0, le=4_294_967_295)
     # Rapid-MLX extension for F5-TTS zero-shot cloning. Audio is base64
     # rather than a server-local path so remote clients cannot make the
     # service read arbitrary files. 14 MB base64 ~= 10 MB decoded audio.

--- a/vllm_mlx/audio/tts.py
+++ b/vllm_mlx/audio/tts.py
@@ -518,6 +518,7 @@ class TTSEngine:
         speed: float = 1.0,
         lang_code: str = "a",
         instruct: str | None = None,
+        voice_seed: int | None = None,
         ref_audio: str | None = None,
         ref_text: str | None = None,
         exaggeration: float | None = None,
@@ -544,6 +545,10 @@ class TTSEngine:
                 arg is never missing. Other families ignore it (they have no
                 emotion-control surface), so passing it is a no-op there
                 rather than an error.
+            voice_seed: Optional deterministic seed for Qwen3-TTS VoiceDesign.
+                Reusing the same ``instruct`` and seed reproduces the same
+                designed voice across calls. Rejected for other families by
+                the API route.
             ref_audio: Optional path to a reference audio clip for zero-shot
                 voice cloning. Used by the F5-TTS ``f5`` family to clone the
                 clip's timbre; by the Chatterbox family (optional — clones the
@@ -649,18 +654,32 @@ class TTSEngine:
                 else:
                     gen_kwargs["lang_code"] = lang_code
 
-            for result in self.model.generate(**gen_kwargs):
-                audio_data = result.audio
-                if hasattr(result, "sample_rate"):
-                    sample_rate = result.sample_rate
+            random_state = None
+            if voice_seed is not None:
+                if not self._is_qwen3_voicedesign():
+                    raise ValueError(
+                        "voice_seed is supported only by Qwen3-TTS VoiceDesign"
+                    )
+                random_state = list(mx.random.state)
+                mx.random.seed(voice_seed)
+            try:
+                for result in self.model.generate(**gen_kwargs):
+                    audio_data = result.audio
+                    if hasattr(result, "sample_rate"):
+                        sample_rate = result.sample_rate
 
-                # Convert mlx array to numpy
-                if isinstance(audio_data, mx.array) or hasattr(audio_data, "tolist"):
-                    audio_np = np.array(audio_data.tolist(), dtype=np.float32)
-                else:
-                    audio_np = np.array(audio_data, dtype=np.float32)
+                    # Convert mlx array to numpy
+                    if isinstance(audio_data, mx.array) or hasattr(
+                        audio_data, "tolist"
+                    ):
+                        audio_np = np.array(audio_data.tolist(), dtype=np.float32)
+                    else:
+                        audio_np = np.array(audio_data, dtype=np.float32)
 
-                audio_chunks.append(audio_np)
+                    audio_chunks.append(audio_np)
+            finally:
+                if random_state is not None:
+                    mx.random.state = random_state
 
             if not audio_chunks:
                 raise RuntimeError("No audio generated")

--- a/vllm_mlx/audio/tts.py
+++ b/vllm_mlx/audio/tts.py
@@ -557,10 +557,10 @@ class TTSEngine:
         speed: float = 1.0,
         lang_code: str = "a",
         instruct: str | None = None,
-        voice_seed: int | None = None,
         ref_audio: str | None = None,
         ref_text: str | None = None,
         exaggeration: float | None = None,
+        voice_seed: int | None = None,
     ) -> AudioOutput:
         """
         Generate speech from text.

--- a/vllm_mlx/audio/tts.py
+++ b/vllm_mlx/audio/tts.py
@@ -10,16 +10,55 @@ Supports:
 - VoxCPM (Chinese/English, high quality)
 """
 
+import importlib
 import io
 import json
 import logging
+import threading
 from collections.abc import Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
 
 import numpy as np
 
 logger = logging.getLogger(__name__)
+
+_QWEN_SAMPLER_PATCH_LOCK = threading.RLock()
+
+
+@contextmanager
+def _qwen_seeded_sampling(model, seed: int | None):
+    """Give one Qwen generation a request-local RNG without global seeding."""
+    if seed is None:
+        yield
+        return
+
+    import mlx.core as mx
+
+    module = importlib.import_module(type(model).__module__)
+    original = module.categorical_sampling
+    owner_thread = threading.get_ident()
+    key = mx.random.key(seed)
+
+    def dispatch(logits, temperature):
+        nonlocal key
+        if threading.get_ident() != owner_thread:
+            return original(logits, temperature)
+        keys = mx.random.split(key, 2)
+        key, sample_key = keys[0], keys[1]
+        return mx.random.categorical(logits * (1 / temperature), key=sample_key)
+
+    # The public route already serializes TTS, while this lock also protects
+    # callers embedding TTSEngine directly. Other inference threads may enter
+    # the dispatcher concurrently; they fall through to the untouched sampler.
+    with _QWEN_SAMPLER_PATCH_LOCK:
+        module.categorical_sampling = dispatch
+        try:
+            yield
+        finally:
+            module.categorical_sampling = original
+
 
 # Default models
 DEFAULT_TTS_MODEL = "mlx-community/Kokoro-82M-bf16"
@@ -654,15 +693,12 @@ class TTSEngine:
                 else:
                     gen_kwargs["lang_code"] = lang_code
 
-            random_state = None
             if voice_seed is not None:
                 if not self._is_qwen3_voicedesign():
                     raise ValueError(
                         "voice_seed is supported only by Qwen3-TTS VoiceDesign"
                     )
-                random_state = list(mx.random.state)
-                mx.random.seed(voice_seed)
-            try:
+            with _qwen_seeded_sampling(self.model, voice_seed):
                 for result in self.model.generate(**gen_kwargs):
                     audio_data = result.audio
                     if hasattr(result, "sample_rate"):
@@ -675,11 +711,7 @@ class TTSEngine:
                         audio_np = np.array(audio_data.tolist(), dtype=np.float32)
                     else:
                         audio_np = np.array(audio_data, dtype=np.float32)
-
                     audio_chunks.append(audio_np)
-            finally:
-                if random_state is not None:
-                    mx.random.state = random_state
 
             if not audio_chunks:
                 raise RuntimeError("No audio generated")

--- a/vllm_mlx/routes/audio.py
+++ b/vllm_mlx/routes/audio.py
@@ -2554,6 +2554,7 @@ async def create_speech(request: AudioSpeechRequest = Body(...)):
     sample_rate = request.sample_rate
     channels = request.channels
     instructions = request.instructions
+    voice_seed = request.voice_seed
     ref_audio = request.ref_audio
     ref_text = request.ref_text
     exaggeration = request.exaggeration
@@ -2570,6 +2571,23 @@ async def create_speech(request: AudioSpeechRequest = Body(...)):
         # the future land in :data:`TTS_MODEL_ALIASES` once, not in the
         # handler body.
         model_name = _resolve_tts_model(model)
+        from ..audio.tts import is_qwen3_voicedesign_model
+
+        if voice_seed is not None and not is_qwen3_voicedesign_model(model_name):
+            raise HTTPException(
+                status_code=400,
+                detail={
+                    "error": {
+                        "message": (
+                            "voice_seed is supported only by "
+                            "Qwen3-TTS VoiceDesign models"
+                        ),
+                        "type": "invalid_request_error",
+                        "code": "unsupported_voice_seed",
+                        "param": "voice_seed",
+                    }
+                },
+            )
 
         # Zero-shot cloning from an inline ``ref_audio`` reference clip is
         # only wired for the clone-capable families (F5-TTS, Chatterbox, and
@@ -2769,6 +2787,8 @@ async def create_speech(request: AudioSpeechRequest = Body(...)):
         )
         if instructions:
             gen_kwargs["instruct"] = instructions
+        if voice_seed is not None:
+            gen_kwargs["voice_seed"] = voice_seed
         # Only forward ``exaggeration`` when the caller actually sent it, so
         # the engine's own default holds otherwise. Like ``instruct`` it is
         # a no-op keyword for every non-Chatterbox family (``generate``
@@ -2834,13 +2854,16 @@ async def create_speech(request: AudioSpeechRequest = Body(...)):
         content_type = _TTS_CONTENT_TYPES.get(
             response_format.lower(), "application/octet-stream"
         )
+        headers = {
+            "X-Audio-Sample-Rate": str(output_rate),
+            "X-Audio-Channels": str(output_channels),
+        }
+        if voice_seed is not None:
+            headers["X-Voice-Seed"] = str(voice_seed)
         return Response(
             content=audio_bytes,
             media_type=content_type,
-            headers={
-                "X-Audio-Sample-Rate": str(output_rate),
-                "X-Audio-Channels": str(output_channels),
-            },
+            headers=headers,
         )
 
     except HTTPException:


### PR DESCRIPTION
Closes #1338

## What changed
- add an optional unsigned 32-bit voice_seed to /v1/audio/speech
- seed Qwen3-TTS VoiceDesign sampling for repeatable designed speakers across calls and restarts
- restore the prior MLX RNG state after generation, including failures
- reject voice_seed for non-VoiceDesign models instead of silently ignoring it
- echo the accepted seed in X-Voice-Seed and document reuse semantics

## Why
VoiceDesign descriptions alone can drift between utterances. A caller can now reuse the same instructions and voice_seed for consistent long-form narration or recurring characters without server-side handle storage.

## Validation
- 501 passed, 6 skipped across the complete audio suite
- deterministic RNG, state restoration, route forwarding, response header, family guard, and schema-bound tests
- ruff check and format check
- compileall and git diff --check