### PR TITLE
fix: omit silent audio from LTX videos

### DIFF
--- a/tests/test_ltx23_video.py
+++ b/tests/test_ltx23_video.py
@@ -392,6 +392,32 @@ def test_video_only_remux_failure_is_actionable(
     assert not list(tmp_path.glob(".result.*.video-only.mp4"))
 
 
+def test_video_only_cleanup_failure_does_not_mask_remux_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    output = tmp_path / "result.mp4"
+    output.write_bytes(b"mp4-with-silent-audio")
+    original_unlink = Path.unlink
+    temporary_paths = []
+
+    def fail_remux(*args, **kwargs):
+        raise subprocess.CalledProcessError(1, "ffmpeg")
+
+    def fail_cleanup(path: Path, *args, **kwargs) -> None:
+        temporary_paths.append(path)
+        raise PermissionError("cleanup denied")
+
+    monkeypatch.setattr("subprocess.run", fail_remux)
+    monkeypatch.setattr(Path, "unlink", fail_cleanup)
+
+    with pytest.raises(VideoRuntimeError, match="silent audio track") as exc:
+        VideoEngine._remove_audio_track(output)
+
+    assert isinstance(exc.value.__cause__, subprocess.CalledProcessError)
+    assert len(temporary_paths) == 1
+    original_unlink(temporary_paths[0], missing_ok=True)
+
+
 def test_video_engines_share_process_generation_lock() -> None:
     first = VideoEngine("one/model")
     second = VideoEngine("two/model")

--- a/tests/test_ltx23_video.py
+++ b/tests/test_ltx23_video.py
@@ -306,6 +306,7 @@ def test_video_engine_calls_mlx_native_pipeline(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     captured = {}
+    ffmpeg_calls = []
     fake = ModuleType("mlx_video")
 
     def generate_video_with_audio(
@@ -333,6 +334,12 @@ def test_video_engine_calls_mlx_native_pipeline(
     monkeypatch.setitem(sys.modules, "mlx_video", fake)
     monkeypatch.setattr("shutil.which", lambda _: "/opt/homebrew/bin/ffmpeg")
 
+    def remux_video_only(command, **kwargs) -> None:
+        ffmpeg_calls.append(command)
+        Path(command[-1]).write_bytes(b"video-only-mp4")
+
+    monkeypatch.setattr("subprocess.run", remux_video_only)
+
     output = tmp_path / "result.mp4"
     reference = tmp_path / "reference.png"
     Image.new("RGB", (64, 64), "blue").save(reference)
@@ -351,13 +358,35 @@ def test_video_engine_calls_mlx_native_pipeline(
         conditioning_strength=0.25,
     )
 
-    assert output.read_bytes() == b"mp4"
+    assert output.read_bytes() == b"video-only-mp4"
     assert captured["model_repo"] == "notapalindrome/ltx23-mlx-av-q4"
     assert captured["num_frames"] == 97
     assert captured["image"] == str(reference)
     assert captured["negative_prompt"] == "static"
     assert captured["cfg_scale"] == 4.5
     assert captured["image_strength"] == 0.25
+    assert len(ffmpeg_calls) == 1
+    assert ffmpeg_calls[0][ffmpeg_calls[0].index("-map") + 1] == "0:v:0"
+    assert "-an" in ffmpeg_calls[0]
+    assert ffmpeg_calls[0][ffmpeg_calls[0].index("-c:v") + 1] == "copy"
+
+
+def test_video_only_remux_failure_is_actionable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    output = tmp_path / "result.mp4"
+    output.write_bytes(b"mp4-with-silent-audio")
+
+    def fail(*args, **kwargs):
+        raise subprocess.CalledProcessError(1, "ffmpeg")
+
+    monkeypatch.setattr("subprocess.run", fail)
+
+    with pytest.raises(VideoRuntimeError, match="silent audio track"):
+        VideoEngine._remove_audio_track(output)
+
+    assert output.read_bytes() == b"mp4-with-silent-audio"
+    assert not (tmp_path / "result.video-only.mp4").exists()
 
 
 def test_video_engines_share_process_generation_lock() -> None:

--- a/tests/test_ltx23_video.py
+++ b/tests/test_ltx23_video.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import io
+import stat
 import subprocess
 import sys
 import threading
@@ -328,7 +329,9 @@ def test_video_engine_calls_mlx_native_pipeline(
         image_strength=1.0,
     ) -> None:
         captured.update(locals())
-        Path(output_path).write_bytes(b"mp4")
+        generated = Path(output_path)
+        generated.write_bytes(b"mp4")
+        generated.chmod(0o640)
 
     fake.generate_video_with_audio = generate_video_with_audio
     monkeypatch.setitem(sys.modules, "mlx_video", fake)
@@ -359,6 +362,7 @@ def test_video_engine_calls_mlx_native_pipeline(
     )
 
     assert output.read_bytes() == b"video-only-mp4"
+    assert stat.S_IMODE(output.stat().st_mode) == 0o640
     assert captured["model_repo"] == "notapalindrome/ltx23-mlx-av-q4"
     assert captured["num_frames"] == 97
     assert captured["image"] == str(reference)

--- a/tests/test_ltx23_video.py
+++ b/tests/test_ltx23_video.py
@@ -376,6 +376,8 @@ def test_video_only_remux_failure_is_actionable(
 ) -> None:
     output = tmp_path / "result.mp4"
     output.write_bytes(b"mp4-with-silent-audio")
+    sibling = tmp_path / "result.video-only.mp4"
+    sibling.write_bytes(b"unrelated-artifact")
 
     def fail(*args, **kwargs):
         raise subprocess.CalledProcessError(1, "ffmpeg")
@@ -386,7 +388,8 @@ def test_video_only_remux_failure_is_actionable(
         VideoEngine._remove_audio_track(output)
 
     assert output.read_bytes() == b"mp4-with-silent-audio"
-    assert not (tmp_path / "result.video-only.mp4").exists()
+    assert sibling.read_bytes() == b"unrelated-artifact"
+    assert not list(tmp_path.glob(".result.*.video-only.mp4"))
 
 
 def test_video_engines_share_process_generation_lock() -> None:

--- a/vllm_mlx/runtime/video_lane.py
+++ b/vllm_mlx/runtime/video_lane.py
@@ -7,6 +7,7 @@ import importlib.util
 import shutil
 import subprocess
 import sys
+import tempfile
 import threading
 from pathlib import Path
 
@@ -243,8 +244,17 @@ class VideoEngine:
     @staticmethod
     def _remove_audio_track(output_path: Path) -> None:
         """Remux an audio-less LTX generation as a video-only MP4."""
-        video_only = output_path.with_name(f"{output_path.stem}.video-only.mp4")
+        video_only: Path | None = None
         try:
+            with tempfile.NamedTemporaryFile(
+                dir=output_path.parent,
+                prefix=f".{output_path.stem}.",
+                suffix=".video-only.mp4",
+                delete=False,
+            ) as temporary:
+                video_only = Path(temporary.name)
+            if video_only is None:  # pragma: no cover - assigned by the context manager
+                raise OSError("could not create a video-only temporary file")
             subprocess.run(
                 [
                     "ffmpeg",
@@ -276,7 +286,8 @@ class VideoEngine:
                 "be removed."
             ) from exc
         finally:
-            video_only.unlink(missing_ok=True)
+            if video_only is not None:
+                video_only.unlink(missing_ok=True)
 
     @staticmethod
     def _crop_generated_output(

--- a/vllm_mlx/runtime/video_lane.py
+++ b/vllm_mlx/runtime/video_lane.py
@@ -238,6 +238,45 @@ class VideoEngine:
             output_height=output_height,
             family="LTX-2.3",
         )
+        self._remove_audio_track(output_path)
+
+    @staticmethod
+    def _remove_audio_track(output_path: Path) -> None:
+        """Remux an audio-less LTX generation as a video-only MP4."""
+        video_only = output_path.with_name(f"{output_path.stem}.video-only.mp4")
+        try:
+            subprocess.run(
+                [
+                    "ffmpeg",
+                    "-y",
+                    "-i",
+                    str(output_path),
+                    "-map",
+                    "0:v:0",
+                    "-c:v",
+                    "copy",
+                    "-an",
+                    str(video_only),
+                ],
+                check=True,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                timeout=120,
+            )
+            if not video_only.is_file() or video_only.stat().st_size == 0:
+                raise OSError("ffmpeg completed without a video-only MP4")
+            video_only.replace(output_path)
+        except (
+            OSError,
+            subprocess.CalledProcessError,
+            subprocess.TimeoutExpired,
+        ) as exc:
+            raise VideoRuntimeError(
+                "LTX-2.3 generated video but its silent audio track could not "
+                "be removed."
+            ) from exc
+        finally:
+            video_only.unlink(missing_ok=True)
 
     @staticmethod
     def _crop_generated_output(

--- a/vllm_mlx/runtime/video_lane.py
+++ b/vllm_mlx/runtime/video_lane.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import importlib.util
 import shutil
+import stat
 import subprocess
 import sys
 import tempfile
@@ -275,6 +276,7 @@ class VideoEngine:
             )
             if not video_only.is_file() or video_only.stat().st_size == 0:
                 raise OSError("ffmpeg completed without a video-only MP4")
+            video_only.chmod(stat.S_IMODE(output_path.stat().st_mode))
             video_only.replace(output_path)
         except (
             OSError,

--- a/vllm_mlx/runtime/video_lane.py
+++ b/vllm_mlx/runtime/video_lane.py
@@ -287,7 +287,12 @@ class VideoEngine:
             ) from exc
         finally:
             if video_only is not None:
-                video_only.unlink(missing_ok=True)
+                try:
+                    video_only.unlink(missing_ok=True)
+                except OSError:
+                    # Cleanup must not mask either a successful atomic replace
+                    # or the actionable remux error raised above.
+                    pass
 
     @staticmethod
     def _crop_generated_output(


### PR DESCRIPTION
Closes #1339

## What changed

- remux LTX outputs as video-only MP4s before publishing them
- copy the encoded video stream without re-encoding and explicitly omit audio
- replace the job output atomically only after ffmpeg produces a non-empty result
- preserve the original artifact and return an actionable error if remuxing fails

## Root cause

The LTX adapter returned the MP4 emitted by `generate_video_with_audio` unchanged. That upstream file contains a 48 kHz stereo stream even when the endpoint has no audio to render, and the crop path also retained it with `-c:a copy`.

## Validation

- reproduced a video + 48 kHz stereo MP4 with ffmpeg and verified the remux contains only one video stream with ffprobe
- `uv run pytest -q tests/test_ltx23_video.py` — 27 passed
- `uv run ruff check vllm_mlx/runtime/video_lane.py tests/test_ltx23_video.py`
- `git diff --check`