### PR TITLE
docs(video): LTX does not return audio — #1349 strips it

### DIFF
--- a/docs/guides/video-generation.md
+++ b/docs/guides/video-generation.md
@@ -86,10 +86,14 @@ checkpoints additionally accept `RAPID_MLX_WAN_LORA_HIGH` and
 
 ## LTX-2.3
 
-MLX-native LTX-2.3 with an audio-video checkpoint — it emits synchronized audio
-alongside the frames, which the other two backends do not. The Q4 checkpoint is
-a 22.8 GB download and wants at least 24 GB of unified memory; 32 GB or more is
-comfortable.
+MLX-native LTX-2.3. The Q4 checkpoint is a 22.8 GB download and wants at least
+24 GB of unified memory; 32 GB or more is comfortable.
+
+The checkpoint is an audio-video one and the pipeline runs
+`generate_video_with_audio`, but the track it produces is silent. Rapid-MLX
+remuxes it away, so **the MP4 you get back is video-only** — a silent audio
+track is worse than none, since it makes downstream tools believe the clip has
+sound. Expect no audio from any of the three backends.
 
 ```bash
 pip install 'rapid-mlx[video]'


### PR DESCRIPTION
## Why

[#1351](https://github.com/raullenchai/Rapid-MLX/pull/1351) (mine) added an LTX-2.3 section saying the checkpoint

> "emits synchronized audio alongside the frames, which the other two backends do not"

That was true of the *pipeline* and false of what the *API returns*. [#1349](https://github.com/raullenchai/Rapid-MLX/pull/1349) added an **unconditional** `_remove_audio_track()` at the end of the LTX generation path:

```python
generate_video_with_audio(**generation_kwargs)
...
self._crop_generated_output(..., family="LTX-2.3")
self._remove_audio_track(output_path)     # ← no condition
```

It remuxes with `-map 0:v:0 -c:v copy -an`, and `tests/test_ltx23_video.py` pins exactly that. Every LTX job comes back as a **video-only MP4**.

The two PRs merged **28 seconds apart** (#1349 at 20:35:36, #1351 at 20:36:04). Git saw no conflict — different files. The conflict was semantic, and it shipped.

## What changed

States what a caller actually gets and why: the track LTX produces is silent, and a silent track is worse than none, because downstream tools then believe the clip has sound. Also says plainly that **none** of the three backends return audio, so nobody goes hunting for it on Wan or CogVideoX-Fun either.

Grepped the rest of the repo — no other "synchronized audio" / "audio-video" claim survives.