### PR TITLE
chore: bump version to 0.11.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.11.3"
+version = "0.11.4"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
Release **0.11.4**. Bumps `pyproject.toml` `version` 0.11.3 → 0.11.4 (single-line change).

## Why
0.11.3 shipped the audio/video expansion, but cutting it surfaced release-process friction (the Tier-1 agent-gate harness and the M3 gauntlet's GPU-contention failure mode). Those fixes are now merged, so this is the routine version bump that publishes the accumulated audio/video features plus the release-tooling hardening to PyPI. A dedicated `chore: bump version to X.Y.Z` PR is the only sanctioned way to change the version line (guardrail G4) and is what auto-release watches to tag `v0.11.4`.

## Shipped changes since v0.11.3 (all audio/video lanes, dogfooded at merge)
- feat: video motion controls on `/v1/videos` (#1340)
- feat: expose video capability limits (#1343)
- feat: configure audio output sample rate and channels (#1346)
- feat: lock VoiceDesign voices with deterministic seeds (#1347)
- fix: omit silent audio from LTX videos (#1349)
- docs: audio guide model families (#1345), README refresh (#1351), LTX-no-audio note (#1353)

## Release tooling (not shipped in the wheel)
- perf(release): concurrent Tier-1 agent gate + prefix-cache off (#1348)
- perf(release): parallelize light correctness gates + harden M3 gauntlet pre-flight (#1354)

## Validation
The v0.11.3..main shipped diff is entirely audio/video routes (`tts.py`, `output_format.py`, `audio.py`, `video.py`, `video_lane.py`, `wan.py`, `api/models.py`), each validated by its own PR dogfooding at merge time. On merge this triggers auto-release: the GitHub-hosted `release-preflight` clean-room build+smoke (G1) plus the fails-closed self-hosted `tier1-agent-gate` (text agentic, qwen3.6-35b-8bit) guard the core before the tag is cut.
