### PR TITLE
chore: bump version to 0.11.4

### DIFF
--- a/tests/integrations/agent_smoke.sh
+++ b/tests/integrations/agent_smoke.sh
@@ -150,16 +150,17 @@ TASK='Run python3 test_calc.py, it fails. Fix the bug in calc.py so all assertio
 # The agents (codex especially) are non-deterministic, so give each up to 2
 # attempts (hermes 3) — a single miss must not flap the release gate.
 #
-# Run all four CONCURRENTLY against the one warm batching server. An agent
-# spends most of its wall-clock running local tools (git, python, file edits)
-# with the GPU idle between generations, so overlapping the four fills those
-# gaps and collapses the gate's wall-clock from ~sum(agents) to ~max(agent) on
-# the 55-minute self-hosted job. Safe to overlap: the server batches concurrent
-# requests on the one GPU; each agent works in its own seed_repo dir; and the
-# two agents that need a config file write DIFFERENT paths (codex→~/.codex,
-# hermes→~/.hermes) while claude/aider use only env vars — no shared mutable
-# state. Each agent writes PASS/FAIL to its own result file (background
-# subshells can't export vars); we collect after the barrier.
+# Run the four SERIALLY, one at a time, against the warm server. An earlier
+# revision overlapped all four to collapse wall-clock from ~sum to ~max, on the
+# theory that an agent leaves the GPU idle between generations so the four fill
+# each other's gaps. In practice their turns overlap heavily, and batching 5-6
+# in-flight requests — each a 25-38k-token agent prompt — onto the ONE GPU
+# starves every stream (measured on the Studio: 12 output tokens in 65s at
+# running=6). Multi-turn agents then blow their per-agent budgets and the gate
+# flakes/fails (it flapped the 0.11.4 release twice this way). Serial hands each
+# agent the whole GPU, so it runs at solo speed (claude ~75s, aider ~5s) and
+# finishes far inside its budget: deterministic, ~sum(agents) wall-clock, still
+# minutes under the 55-minute job. Each writes PASS/FAIL to its own result file.
 mkdir -p "$WORK"
 
 # ---- Claude Code (env var, /v1/messages) ---------------------------------
@@ -224,15 +225,16 @@ save_cfg "$HERMES_CFG"
 "$RMLX" agents hermes --setup --base-url "$B/v1" >/dev/null 2>&1
 patch_port "$HERMES_CFG"
 
-echo "running 4 Tier-1 agents concurrently (budget ${AGENT_TO}s, hermes ${HERMES_TO}s)…"
-run_claude & _p_claude=$!
-run_codex &  _p_codex=$!
-run_hermes & _p_hermes=$!
-run_aider &  _p_aider=$!
-# Wait ONLY on the four agent jobs. A bare `wait` would also block on the
-# still-running background serve (SERVE_PID, launched with `&` above) and hang
-# the gate forever — the agents all finish but the script never returns.
-wait "$_p_claude" "$_p_codex" "$_p_hermes" "$_p_aider"
+echo "running 4 Tier-1 agents serially (budget ${AGENT_TO}s, hermes ${HERMES_TO}s)…"
+# Serial, NOT backgrounded: overlapping them oversubscribes the single GPU and
+# flakes the gate (see the rationale above run_claude). Each runs to completion
+# — with its own retries + per-agent timeout — before the next starts, so it
+# gets the whole GPU and finishes at solo speed. Never a bare `wait` here: the
+# serve is still backgrounded (SERVE_PID), so a bare wait would hang the gate.
+run_claude
+run_codex
+run_hermes
+run_aider
 
 # Restore the config files only after every agent has finished using them.
 restore_cfg "$CODEX_CFG"


### PR DESCRIPTION
Release **0.11.4** — completes the tag by making the self-hosted `tier1-agent-gate` reliable.

`pyproject.toml` is already `0.11.4` on `main` (merged in #1355), but that bump's `auto-release` run failed at `tier1-agent-gate` and never cut the tag. This PR ships the harness fix that unblocks it; its squash subject re-triggers `auto-release` with `detect` green (subject matches, `pyproject == 0.11.4`, tag `v0.11.4` absent) so the fixed gate runs and tags `v0.11.4`.

## Why
The 0.11.4 bump flapped the `tier1-agent-gate` **twice** (30-min timeouts, all four agents failing). Root cause is a harness defect introduced by #1348 (PR-1), not a product regression:

- #1348 launched all four Tier-1 agents (`claude`/`codex`/`hermes`/`aider`) **concurrently** against the one warm server, on the theory that each agent leaves the GPU idle between generations so overlapping them collapses wall-clock from `~sum` to `~max`.
- In practice a single Claude Code agent alone puts **3-5 requests in flight** (measured on the Studio box, `running=3..5` during the claude-only phase). Four concurrent agents stack to `running=6+`, each a 25-38k-token reasoning prompt on **one** GPU. Batched decode then starves every stream — throughput collapses to **0.7-3.5 tok/s** (seen: `12 output tokens in 65s at running=6`). Multi-turn agents blow their 480/600s per-agent budgets → all time out → gate fails.
- Solo/serial, each agent gets the whole GPU and finishes far inside budget (claude solo `74s`, aider `5s`; serial claude `273s` ≪ `480s`).

Fix: run the four agents **serially** instead of concurrently. Wall-clock becomes `~sum(agents)` — still minutes under the 55-minute job — but deterministic. No product code changes; the wheel is byte-identical to the audio/video features already validated at each feature PR's merge.

## Validation
Ran the patched `agent_smoke.sh` end-to-end on the Studio box (M3 Ultra, `qwen3.6-35b-8bit`, `rapid-mlx 0.11.4`) with the four agents serial — **all four verified PASS**:

| agent | wall | budget |
|---|---|---|
| claude-code | 273s | 480s |
| codex-cli | 133s | 480s |
| hermes | 54s | 600s |
| aider | 5s | 600s |

`RESULT: PASS — all four Tier-1 agents verified on qwen3.6-35b-8bit.` Total serial block `465s` (~7.75 min), comfortably inside the 55-minute self-hosted job. Each agent stays well under its per-agent budget, versus the two prior 30-minute all-fail flaps under the concurrent harness.

## Follow-up (non-blocking)
File an issue to add a PR-2-style pre-flight contention guard to `agent_smoke.sh` so a busy GPU aborts the gate early with a clear signal instead of a 30-minute false-fail.
