### PR TITLE
fix(gate): warm large-context kernel in agent_smoke.sh before timed agents

### DIFF
--- a/tests/integrations/agent_smoke.sh
+++ b/tests/integrations/agent_smoke.sh
@@ -140,10 +140,37 @@ done
 # compiles the hybrid GatedDeltaNet / attention Metal kernels (cold ~8 tok/s vs
 # warm ~23). Paying that here, untimed, keeps a cold shader cache from pushing
 # the first agent past its per-agent budget. Best-effort — never fatal.
-echo "warming kernels…"
-curl -s -m 180 "$B/v1/chat/completions" -H 'Content-Type: application/json' \
+#
+# Two-stage, because these kernels are effectively SHAPE-SPECIALIZED: a short
+# prompt only compiles the small-sequence kernel. The real agents (claude first)
+# open with a ~25-38k-token system+tools prompt, which hits a DIFFERENT cold
+# path — the large-context / chunked-prefill GatedDeltaNet kernel. On a cold
+# shader cache that first compile can exceed the server's 300s in-flight abort,
+# so the first agent request gets force-aborted at 0 tokens and the agent flaps —
+# exactly how the 0.11.4 gate hung (short warmup finished in 0.3s, then the first
+# 25k agent request stalled 300s with 0 tokens). Warming a large-context prompt
+# here pays that compile untimed, so the first agent request lands on warm kernels.
+echo "warming kernels (small + large context, untimed)…"
+curl -s -m 60 "$B/v1/chat/completions" -H 'Content-Type: application/json' \
   -d "{\"model\":\"$ALIAS\",\"messages\":[{\"role\":\"user\",\"content\":\"Reply with the single word OK.\"}],\"max_tokens\":16,\"temperature\":0}" \
   >/dev/null 2>&1 || true
+python3 - "$B" "$ALIAS" <<'PY' 2>&1 || true
+import json, sys, urllib.request
+B, alias = sys.argv[1], sys.argv[2]
+# ~25k-token prompt (~11 tok/line * 2600) so the large-context Metal kernels the
+# agents actually hit are compiled here, not inside a timed per-agent budget.
+prompt = "The quick brown fox jumps over the lazy dog. " * 2600
+body = json.dumps({"model": alias,
+                   "messages": [{"role": "user", "content": prompt + "\nReply with the single word OK."}],
+                   "max_tokens": 16, "temperature": 0}).encode()
+req = urllib.request.Request(B + "/v1/chat/completions", data=body,
+                            headers={"Content-Type": "application/json"})
+try:
+    urllib.request.urlopen(req, timeout=290).read()
+    print("large-context kernels warmed")
+except Exception as e:  # best-effort — a cold compile that overruns still lets agents (with retries) proceed
+    print("large-context warmup note (non-fatal):", e)
+PY
 
 # ---- the task: a buggy factorial + a failing test the agent must fix -----
 seed_repo() {


### PR DESCRIPTION
Release **0.11.4** — the last `tier1-agent-gate` fix. `pyproject.toml` is already `0.11.4` on `main` (#1355); this PR's squash subject re-triggers `auto-release` (`detect` is green — subject matches, `pyproject == 0.11.4`, tag `v0.11.4` absent) so the fixed gate runs and tags `v0.11.4`.

## Why (root cause — why the gate hung on 0.11.4)
The gate drives four agents against a live `qwen3.6-35b-8bit`. On every 0.11.4 `auto-release` run the **first** agent (Claude Code) opened with its ~25k-token system+tools prompt and the request **stalled at 0 tokens for 300s**, hit the server's in-flight abort, and the agent flapped — never a single generated token.

This is **not** a product regression: `engine_core.py` / `scheduler.py` / `engine/batched.py` / `service/helpers.py` are **byte-identical between `v0.11.3` and `main`** (`git log v0.11.3..main` on those paths is empty), and 0.11.4's changes are audio/video features + this harness. It reproduces **nowhere** synthetically: on the same box, same wheel, same flags, single/4-concurrent/tools/`/v1/messages`/streaming 25k requests all complete in **≤48s**.

The trigger is a **cold, shape-specialized Metal-kernel compile**. `agent_smoke.sh` already warms the model after serve-ready, but with a **10-token** prompt — that only compiles the *small-sequence* GatedDeltaNet/attention kernel. The agents' real ~25k-token prompts hit a **different** cold path (the large-context / chunked-prefill kernel). On a cold shader cache that first large-context compile runs long enough to exceed the server's 300s in-flight abort, so the first agent's opening request dies at 0 tokens. The gate log shows it exactly: the short warmup finished in `0.3s` (small kernel already warm), then the first 25k agent request stalled 300s.

## Fix
Add a **large-context** warmup (~25k-token prompt) right after the existing short warmup, before the timed agents. It pays the large-context compile **untimed**, so the first agent request lands on warm kernels. Best-effort (`|| true`, exception-guarded) — it never turns a passing box into a failure; it only removes the cold-start cliff. No product code changes.

Harness-only diff (`tests/integrations/agent_smoke.sh`): the short `curl` warmup keeps compiling the small kernel; a new `python3` stdlib POST warms the large-context kernel.

## Validation
Ran the patched `agent_smoke.sh` end-to-end on the Studio (M3 Ultra, `qwen3.6-35b-8bit`, `rapid-mlx 0.11.4`), four agents serial: large-context warmup completes cleanly, then all four verify PASS. (See run output.)

## Note for reviewers
`ps`/`ioreg` are misleading here: a **healthy** MLX inference shows the serve at ~0–7% CPU and `ioreg "Device Utilization %" = 0` (Python blocks in `mx.eval` while the GPU works). "0% GPU + ~0% CPU" during the original 300s stall was **not** evidence of a deadlock — the engine was compiling/prefilling; it just overran the abort window on a cold cache.
