### PR TITLE
ci(release): harden tier1-agent-gate against cold-kernel timeout

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -140,7 +140,16 @@ jobs:
     needs: detect
     if: needs.detect.outputs.should_release == 'true' && needs.detect.outputs.force != 'true'
     runs-on: [self-hosted, macOS, rapidmlx-studio]
-    timeout-minutes: 55
+    # 90, not 55: the four Tier-1 agents run SERIALLY against a 35B hybrid, each
+    # with retries and a per-agent budget. Worst case = claude+codex+aider at
+    # 2x480s each (2880s) + hermes at 3x600s (1800s) = 4680s ~= 78 min. On a cold
+    # Studio shader cache the first large-context request of each agent also pays
+    # a one-time Metal-kernel compile. 55 min guillotined the run mid-agent (the
+    # job was "cancelled" before any RESULT could print). The step warms kernels
+    # untimed up front (hard-bounded to ~10 min) so the healthy path finishes in
+    # minutes; 90 min is headroom so a slow-but-passing cold run reaches a verdict
+    # instead of being killed. A genuine hang still fails on the per-agent budgets.
+    timeout-minutes: 90
     # Serialize with the manual agent-gate.yml so two runs never contend for the
     # single runner / the serve port.
     concurrency:

--- a/tests/integrations/agent_smoke.sh
+++ b/tests/integrations/agent_smoke.sh
@@ -141,35 +141,75 @@ done
 # warm ~23). Paying that here, untimed, keeps a cold shader cache from pushing
 # the first agent past its per-agent budget. Best-effort — never fatal.
 #
-# Two-stage, because these kernels are effectively SHAPE-SPECIALIZED: a short
-# prompt only compiles the small-sequence kernel. The real agents (claude first)
-# open with a ~25-38k-token system+tools prompt, which hits a DIFFERENT cold
-# path — the large-context / chunked-prefill GatedDeltaNet kernel. On a cold
-# shader cache that first compile can exceed the server's 300s in-flight abort,
-# so the first agent request gets force-aborted at 0 tokens and the agent flaps —
-# exactly how the 0.11.4 gate hung (short warmup finished in 0.3s, then the first
-# 25k agent request stalled 300s with 0 tokens). Warming a large-context prompt
-# here pays that compile untimed, so the first agent request lands on warm kernels.
-echo "warming kernels (small + large context, untimed)…"
+# Shape-specialized: a short prompt only compiles the small-sequence kernel; the
+# real agents (claude first) open with a ~25-38k-token system+tools prompt that
+# hits a DIFFERENT cold path — the large-context / chunked-prefill GatedDeltaNet
+# kernel. That cold compile is what hung the 0.11.4 gate. On a cold Studio shader
+# cache it ran long enough that the first agent's HTTP client timed out and
+# disconnected; ``disconnect_guard`` then aborts the request at 0 tokens, the
+# agent retried, re-hit the cold path and thrashed through its whole per-agent
+# budget — four agents deep, that overran even the (old 55-min) job cap before any
+# RESULT printed. It is NOT a product regression: a WARM box serves the same 25k
+# request in 3-10s (measured), and the engine is byte-identical to the shipped
+# 0.11.3 on every serving path. It is purely one-time cold-compile latency.
+#
+# So warm the LARGE-context kernels here, untimed, on BOTH routes the agents use
+# (/v1/chat/completions for codex/hermes/aider, /v1/messages for claude), and
+# RETRY until a request returns fast — a fast return proves the cold compile is
+# fully paid and cached before any timed agent starts. Generous per-request
+# timeout so the compile completes untimed; best-effort, never fatal.
+echo "warming kernels (small + large context, both routes, untimed)…"
 curl -s -m 60 "$B/v1/chat/completions" -H 'Content-Type: application/json' \
   -d "{\"model\":\"$ALIAS\",\"messages\":[{\"role\":\"user\",\"content\":\"Reply with the single word OK.\"}],\"max_tokens\":16,\"temperature\":0}" \
   >/dev/null 2>&1 || true
 python3 - "$B" "$ALIAS" <<'PY' 2>&1 || true
-import json, sys, urllib.request
+import json, sys, time, urllib.request
 B, alias = sys.argv[1], sys.argv[2]
-# ~25k-token prompt (~11 tok/line * 2600) so the large-context Metal kernels the
-# agents actually hit are compiled here, not inside a timed per-agent budget.
-prompt = "The quick brown fox jumps over the lazy dog. " * 2600
-body = json.dumps({"model": alias,
-                   "messages": [{"role": "user", "content": prompt + "\nReply with the single word OK."}],
-                   "max_tokens": 16, "temperature": 0}).encode()
-req = urllib.request.Request(B + "/v1/chat/completions", data=body,
-                            headers={"Content-Type": "application/json"})
-try:
-    urllib.request.urlopen(req, timeout=290).read()
-    print("large-context kernels warmed")
-except Exception as e:  # best-effort — a cold compile that overruns still lets agents (with retries) proceed
-    print("large-context warmup note (non-fatal):", e)
+# Hard wall-clock budget for ALL warmup (both routes, all attempts). Bounds the
+# step so a degraded box can't let the warmup itself eat into the job cap: the
+# realistic cold path is one ~4-min compile then fast confirms (~7 min total),
+# and this caps the pathological tail at ~10 min. Best-effort — on exhaustion we
+# just fall through to the agents (their own retries absorb any residual cold).
+DEADLINE = time.time() + 600
+# ~30k-token prompt (~11 tok/line * 3000) — covers the agents' 25-38k opening
+# prompts so the large-context / chunked-prefill Metal kernels compile HERE, not
+# inside a timed per-agent budget.
+prompt = "The quick brown fox jumps over the lazy dog. " * 3000 + "\nReply with the single word OK."
+
+def warm(route, headers, body, label):
+    # Attempt 1 pays the cold compile (untimed within the budget); attempt 2
+    # confirms warm. "warm" == returned under 45s → stop early. Bounded by the
+    # shared DEADLINE so total warmup can't overrun. Never fatal.
+    data = json.dumps(body).encode()
+    for attempt in (1, 2):
+        remaining = int(DEADLINE - time.time())
+        if remaining <= 1:
+            print(f"{label}: warmup budget exhausted, deferring to agent retries")
+            return
+        t0 = time.time()
+        try:
+            req = urllib.request.Request(B + route, data=data, headers=headers)
+            urllib.request.urlopen(req, timeout=min(480, remaining)).read()
+            dt = time.time() - t0
+            print(f"{label}: attempt {attempt} completed in {dt:.0f}s")
+            if dt < 45:
+                return
+        except Exception as e:
+            print(f"{label}: attempt {attempt} note (non-fatal): {e}")
+
+# OpenAI route (codex / hermes / aider)
+warm("/v1/chat/completions",
+     {"Content-Type": "application/json"},
+     {"model": alias, "messages": [{"role": "user", "content": prompt}],
+      "max_tokens": 16, "temperature": 0},
+     "large-ctx /v1/chat/completions")
+# Anthropic route (claude — the first agent, the one that hung on 0.11.4). Shares
+# the same prefill kernels, so this is usually already warm and returns fast.
+warm("/v1/messages",
+     {"Content-Type": "application/json", "anthropic-version": "2023-06-01"},
+     {"model": alias, "max_tokens": 16, "temperature": 0,
+      "messages": [{"role": "user", "content": prompt}]},
+     "large-ctx /v1/messages")
 PY
 
 # ---- the task: a buggy factorial + a failing test the agent must fix -----


### PR DESCRIPTION
Harden the `tier1-agent-gate` so it stops timing out on 0.11.4 and can reach a real PASS/FAIL. Harness + workflow only — no product code. `pyproject.toml` is already `0.11.4` on `main`, so this PR's squash subject re-triggers `auto-release` and the fixed gate runs.

## Why (root cause — why the gate kept getting "cancelled")

The 0.11.4 `auto-release` gate was **cancelled** three times in a row (#1356/#1357/#1358), never a clean pass or a real FAIL. Reading the runner log, the mechanism is two independent factors stacking — both in the harness, neither in the product:

1. **Cold Metal-kernel compile, not pre-paid.** The four agents run serially against `qwen3.6-35b-8bit` (a 35B hybrid, GatedDeltaNet/chunked-prefill). Each agent opens with a ~25-38k-token prompt that hits the **large-context** prefill kernel. On a cold Studio shader cache that first compile runs long enough that the agent's HTTP client times out and disconnects; `disconnect_guard` then aborts the request at 0 tokens, the agent retries, re-hits the cold path, and thrashes through its **entire** per-agent budget. The previous warmup (added in #1358) only compiled the *small-sequence* kernel and its own client timed out at 290 s, so it never actually warmed the shape the agents hit.

2. **Worst-case budget exceeded the job cap.** Serial agents with retries cost `2×480 + 2×480 + 3×600 + 2×480 ≈ 78 min` worst case, but the job cap was **55 min**. So when the agents thrashed on cold kernels, the job was guillotined mid-run — GitHub marks that **cancelled**, and no `RESULT:` line ever printed. That's exactly the log: `warming... → large-context warmup timed out (290s) → running 4 agents → [55min] The operation was canceled`.

**This is not a product regression.** The engine is byte-identical to the shipped 0.11.3 on every serving path (`git log v0.11.3..main` is empty for `engine_core.py`/`scheduler.py`/`engine/batched.py`/`service/helpers.py`), and a **warm** box serves the same 25k-token request in **3-10 s** (measured directly on the Studio with the exact gate flags: `pflash` compresses 26020→5204 tokens, completes in 3.1 s / 9.7 s). It is purely one-time cold-compile latency amplified by a too-tight job cap.

## Fix (two levers, both harness/workflow-only)

1. **Bulletproof warmup** (`tests/integrations/agent_smoke.sh`): replace the single fragile 25k warmup with a retrying warmup that (a) fires a ~30k-token prompt covering the agents' 25-38k range, (b) warms **both** routes the agents use — `/v1/chat/completions` (codex/hermes/aider) and `/v1/messages` (claude, the first agent and the one that hung), (c) does 2 attempts per route with a 480 s per-request timeout and **stops early once a request returns under 45 s** — a fast return proves the cold compile is fully paid and cached before any *timed* agent starts, and (d) is **hard-bounded by a shared 600 s wall-clock budget** so the warmup itself can never eat the job cap (realistic cold path is one ~4-min compile then fast confirms). Best-effort (`|| true`, exception-guarded): it can never turn a healthy box into a failure, it only removes the cold-start cliff.

2. **Job timeout 55 → 90 min** (`.github/workflows/auto-release.yml`): headroom so a slow-but-passing cold run reaches a verdict instead of being killed mid-agent. Self-hosted runner, so no minute cost. A genuine hang still fails on the per-agent budgets — this only stops a *passing* run from being guillotined.

## Validation

- `bash -n` clean; embedded warmup Python compiles; `auto-release.yml` parses.
- Warmup block run live against `qwen3.6-35b-8bit` on the Studio (exact gate flags `--disable-prefix-cache --no-thinking`): both routes return fast, warmup completes cleanly. (Cold-compile latency itself can only be reproduced on a freshly-cold shader cache, which is the runner's first gate request — hence the untimed-with-headroom design rather than a fixed sleep.)

## Note for reviewers

`ps`/`ioreg` are misleading for MLX here: a **healthy** inference shows the serve at ~0-7% CPU and `ioreg "Device Utilization %" = 0` (Python blocks in `mx.eval` while the GPU works). "0% GPU + ~0% CPU" during the original stall was the cold compile, not a deadlock. There is **no** engine-side hard timeout: `_disconnect_guard` aborts only on real client disconnect, so giving the job more wall-clock is safe and correct.
