### PR TITLE
ci(diag): runner large-ctx latency probe (manual dispatch only)

### DIFF
--- a/.github/workflows/gate-diag.yml
+++ b/.github/workflows/gate-diag.yml
@@ -1,0 +1,129 @@
+# Throwaway diagnostic: measure a large-context request's latency IN the
+# self-hosted runner context, to separate "serve compute is slow" from
+# "python client can't reach the serve". Runs ONLY on manual dispatch; touches
+# no agent config (~/.codex/~/.hermes untouched), runs no agents. Safe to keep
+# or delete. See PR that added it.
+name: gate-diag (runner large-ctx latency)
+
+on:
+  workflow_dispatch: {}
+
+concurrency:
+  # share the gate's runner-serialization group so this never overlaps a real gate
+  group: tier1-agent-gate
+  cancel-in-progress: false
+
+jobs:
+  diag:
+    runs-on: [self-hosted, macOS, rapidmlx-studio]
+    timeout-minutes: 25
+    env:
+      PORT: "8189"          # spare port, never the gate's 8188 or user's 8000
+      ALIAS: "qwen3.6-35b-8bit"
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - name: Measure large-context latency in runner context
+        run: |
+          set -uo pipefail
+          export PATH="/opt/homebrew/bin:/opt/homebrew/opt/coreutils/libexec/gnubin:$HOME/.local/bin:$PATH"
+          B="http://localhost:$PORT"
+          LOG="$RUNNER_TEMP/diag-serve.log"
+
+          echo "== proxy env (should be empty) =="
+          env | grep -iE "proxy" || echo "  (no proxy vars)"
+
+          echo "== power / thermal / idle state (the untested runner-context differ) =="
+          echo "-- pmset -g therm (CPU_Speed_Limit<100 == thermal/power throttle) --"
+          pmset -g therm 2>/dev/null || echo "  (pmset therm unavailable)"
+          echo "-- pmset -g assertions (PreventUserIdleSystemSleep / display asleep?) --"
+          pmset -g assertions 2>/dev/null | grep -iE "PreventUserIdle|PreventDisplay|DisplaySleep|SystemSleep|Prevent" | head -20 || echo "  (none)"
+          echo "-- pmset -g (idle sleep timers) --"
+          pmset -g 2>/dev/null | grep -iE "sleep|displaysleep|hibernatemode|lowpowermode" | head -20 || echo "  (n/a)"
+          echo "-- caffeinate present? --"; command -v caffeinate || echo "  (no caffeinate)"
+          echo "== python / which =="
+          V="$RUNNER_TEMP/diag-venv"
+          rm -rf "$V"
+          /opt/homebrew/opt/python@3.12/bin/python3.12 -m venv "$V"
+          "$V/bin/pip" install -q --upgrade pip
+          "$V/bin/pip" install -q .
+          echo "diag venv → $("$V/bin/rapid-mlx" --version)"
+          "$V/bin/pip" list 2>/dev/null | grep -iE "^mlx |mlx-lm|mlx-metal"
+
+          echo "== [KEY PROBE] MLX device / Metal availability / arch (does MLX see the GPU here?) =="
+          echo "-- arch / rosetta --"
+          echo "  uname -m: $(uname -m)"
+          echo "  proc_translated (1==Rosetta): $(sysctl -n sysctl.proc_translated 2>/dev/null || echo 'n/a')"
+          echo "  python arch: $("$V/bin/python" -c 'import platform;print(platform.machine())')"
+          echo "-- mlx device (if this says cpu / metal unavailable → 100x slowdown ROOT CAUSE) --"
+          "$V/bin/python" - <<'PY' 2>&1 || echo "  MLX device probe raised"
+          import mlx.core as mx, time
+          try:
+              print("  default_device:", mx.default_device())
+          except Exception as e:
+              print("  default_device ERROR:", type(e).__name__, e)
+          for probe in ("metal.is_available", "metal.device_info"):
+              mod, fn = probe.split(".")
+              try:
+                  obj = getattr(getattr(mx, mod), fn)()
+                  print(f"  mx.{probe}():", obj if not isinstance(obj, dict) else {k: obj[k] for k in list(obj)[:4]})
+              except Exception as e:
+                  print(f"  mx.{probe}() ERROR:", type(e).__name__, e)
+          # tiny GPU matmul: on Metal ~ms; on CPU-fallback for a big op it's still ms but confirms device
+          a = mx.random.normal((2048, 2048)); mx.eval(a)
+          t0 = time.time(); b = a @ a; mx.eval(b); dt = time.time() - t0
+          print(f"  2048^3 matmul: {dt*1000:.1f}ms (device={mx.default_device()})")
+          PY
+
+          echo "== boot serve (same flags as the gate) =="
+          nohup "$V/bin/rapid-mlx" serve "$ALIAS" --port "$PORT" --disable-prefix-cache --no-thinking > "$LOG" 2>&1 &
+          SPID=$!
+          for i in $(seq 1 60); do
+            curl -s -m 3 "$B/v1/models" 2>/dev/null | grep -q '"id"' && { echo "serve READY (~$((i*3))s)"; break; }
+            kill -0 "$SPID" 2>/dev/null || { echo "serve died"; tail -30 "$LOG"; exit 1; }
+            sleep 3
+          done
+
+          # Build a ~30k-token prompt (same shape the agents/warmup hit)
+          python3 - > "$RUNNER_TEMP/body.json" <<'PY'
+          import json
+          p = "The quick brown fox jumps over the lazy dog. " * 3000 + "\nReply with the single word OK."
+          print(json.dumps({"model":"qwen3.6-35b-8bit","messages":[{"role":"user","content":p}],"max_tokens":16,"temperature":0}))
+          PY
+
+          echo "== [A] 30k via curl (client=curl) =="
+          t0=$(date +%s)
+          curl -s -m 900 "$B/v1/chat/completions" -H 'Content-Type: application/json' \
+            --data @"$RUNNER_TEMP/body.json" -o "$RUNNER_TEMP/respA.json" -w 'curl_http=%{http_code} curl_time=%{time_total}s\n' || echo "curl failed"
+          echo "  curl wall=$(( $(date +%s) - t0 ))s ; usage=$(python3 -c "import json;d=json.load(open('$RUNNER_TEMP/respA.json'));print(d.get('usage'))" 2>/dev/null || echo '?')"
+
+          echo "== [B] 30k via python urllib (client=urllib, EXACTLY like the gate warmup) =="
+          python3 - "$B" <<'PY'
+          import json, sys, time, urllib.request
+          B = sys.argv[1]
+          body = open(__import__("os").environ["RUNNER_TEMP"]+"/body.json","rb").read()
+          req = urllib.request.Request(B+"/v1/chat/completions", data=body, headers={"Content-Type":"application/json"})
+          t0=time.time()
+          try:
+              r=json.loads(urllib.request.urlopen(req, timeout=900).read())
+              print(f"  urllib wall={time.time()-t0:.1f}s usage={r.get('usage')}")
+          except Exception as e:
+              print(f"  urllib ERROR after {time.time()-t0:.1f}s: {type(e).__name__} {e}")
+          PY
+
+          echo "== [C] 30k via curl UNDER active caffeinate assertion (tests idle-downclock fix) =="
+          caffeinate -dimsu -w $$ &
+          CAFF=$!
+          sleep 4   # let clocks spin up if they were parked
+          echo "  assertions now:"; pmset -g assertions 2>/dev/null | grep -iE "PreventUserIdle|caffeinate" | head -5 || true
+          t0=$(date +%s)
+          curl -s -m 900 "$B/v1/chat/completions" -H 'Content-Type: application/json' \
+            --data @"$RUNNER_TEMP/body.json" -o "$RUNNER_TEMP/respC.json" -w 'curl_http=%{http_code} curl_time=%{time_total}s\n' || echo "curl failed"
+          echo "  [C] curl wall=$(( $(date +%s) - t0 ))s ; usage=$(python3 -c "import json;d=json.load(open('$RUNNER_TEMP/respC.json'));print(d.get('usage'))" 2>/dev/null || echo '?')"
+          kill "$CAFF" 2>/dev/null || true
+
+          echo "== serve-side ground truth (pflash + completion timing) =="
+          grep -aE "pflash|Chat completion|schedule\]|stream_outputs|Metal memory|throttle" "$LOG" | tail -20 || true
+
+          kill -9 "$SPID" 2>/dev/null || true
+          rm -rf "$V"
+          echo "== DIAG DONE =="


### PR DESCRIPTION
Throwaway, manual-dispatch-only diagnostic to root-cause why 35B large-context prefill runs ~100x slower ONLY inside the self-hosted Tier-1 gate runner (warmup + all 4 agents time out in the release gate) vs 3-10s in every interactive test on the same machine.

Confirmed in failed release run 30629263053: serve boots fine (READY ~20s) but the large-ctx warmup times out twice (600s budget exhausted, never completes a single 30k-token request), cascading all 4 Tier-1 agents to timeout -> gate FAIL.

Falsified so far (each by evidence): deps, background QoS (taskpolicy -b stays fast), launchd GUI-domain, proxy env, ulimit/nice, idle/display sleep (persistent pmset sleep=0/displaysleep=0).

This workflow measures, **in the real runner execution context**:
- arch / Rosetta translation state
- MLX default_device + metal.is_available + a GPU matmul timing (leading hypothesis: MLX falls back to CPU in-context -> exactly the ~100x)
- a 30k-token request via curl AND python urllib (isolates serve-compute-slow vs client-connectivity-slow)
- the same request under an active caffeinate assertion (idle-downclock test + candidate fix)
- pmset therm/assertions, serve-side pflash + completion timing

Runs no agents; never touches ~/.codex or ~/.hermes. Shares the gate's concurrency group so it can't overlap a real release gate. workflow_dispatch only (won't auto-run, subject won't trigger auto-release). Safe to delete once root cause is fixed.

Closes nothing; diagnostic aid for the 0.11.4 release gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)