### PR TITLE
fix: support mixed-length DeepSeek V4 batches

### DIFF
--- a/tests/test_deepseek_v4_vendored.py
+++ b/tests/test_deepseek_v4_vendored.py
@@ -112,6 +112,35 @@ def test_deepseek_v4_rope_honors_explicit_yarn_attention_factor():
     assert mx.allclose(half_output, expected_half_output, atol=1e-6).item()
 
 
+def test_deepseek_v4_rope_applies_per_row_integer_offsets():
+    """Continuous batches may contain caches at different positions."""
+    import mlx.core as mx
+
+    from vllm_mlx.models.deepseek_v4 import DeepseekV4RoPE
+
+    rope = DeepseekV4RoPE(dims=4, base=10000.0)
+    x = mx.arange(48, dtype=mx.float32).reshape(2, 2, 3, 4) / 10
+    offsets = mx.array([3, 11], dtype=mx.int32)
+
+    actual = rope(x, offsets)
+    expected = mx.concatenate([rope(x[:1], 3), rope(x[1:], 11)], axis=0)
+    mx.eval(actual, expected)
+
+    assert mx.allclose(actual, expected, atol=1e-6).item()
+
+
+def test_deepseek_v4_rope_rejects_offset_batch_mismatch():
+    import mlx.core as mx
+
+    from vllm_mlx.models.deepseek_v4 import DeepseekV4RoPE
+
+    rope = DeepseekV4RoPE(dims=4, base=10000.0)
+    x = mx.zeros((2, 1, 3, 4))
+
+    with pytest.raises(ValueError, match="one offset per batch row"):
+        rope(x, mx.array([3], dtype=mx.int32))
+
+
 def test_tiny_model_forward_pass():
     """Smoke test the full forward path on a CPU-sized synthetic config.
 
@@ -155,6 +184,53 @@ def test_tiny_model_forward_pass():
     mx.eval(logits, [c.state for c in cache])
 
     assert logits.shape == (1, 8, args.vocab_size)
+
+
+def test_tiny_model_decodes_merged_caches_with_different_offsets():
+    """Regression for mixed-length continuous batching on compressed layers."""
+    import mlx.core as mx
+
+    from vllm_mlx.models import deepseek_v4
+
+    args = deepseek_v4.ModelArgs(
+        model_type="deepseek_v4",
+        vocab_size=128,
+        hidden_size=64,
+        num_hidden_layers=4,
+        num_attention_heads=4,
+        num_key_value_heads=1,
+        q_lora_rank=16,
+        o_lora_rank=8,
+        o_groups=2,
+        head_dim=16,
+        qk_rope_head_dim=4,
+        sliding_window=16,
+        compress_ratios=[0, 0, 4, 0],
+        index_n_heads=4,
+        index_head_dim=8,
+        index_topk=4,
+        moe_intermediate_size=16,
+        n_routed_experts=4,
+        n_shared_experts=1,
+        num_experts_per_tok=2,
+        num_hash_layers=1,
+        hc_mult=2,
+        hc_sinkhorn_iters=2,
+    )
+    model = deepseek_v4.Model(args)
+    short_cache = model.make_cache()
+    long_cache = model.make_cache()
+    model(mx.array([[1, 2, 3, 4]]), cache=short_cache)
+    model(mx.array([[1, 2, 3, 4, 5, 6, 7, 8]]), cache=long_cache)
+    mx.eval([cache.state for cache in short_cache + long_cache])
+
+    merged_cache = [
+        type(short).merge([short, long]) for short, long in zip(short_cache, long_cache)
+    ]
+    logits = model(mx.array([[9], [10]]), cache=merged_cache)
+    mx.eval(logits, [cache.state for cache in merged_cache])
+
+    assert logits.shape == (2, 1, args.vocab_size)
 
 
 if __name__ == "__main__":

--- a/tests/test_deepseek_v4_vendored.py
+++ b/tests/test_deepseek_v4_vendored.py
@@ -114,7 +114,7 @@ def test_deepseek_v4_rope_honors_explicit_yarn_attention_factor():
 
 def test_deepseek_v4_rope_applies_per_row_integer_offsets():
     """Continuous batches may contain caches at different positions."""
-    import mlx.core as mx
+    mx = pytest.importorskip("mlx.core")
 
     from vllm_mlx.models.deepseek_v4 import DeepseekV4RoPE
 
@@ -130,7 +130,7 @@ def test_deepseek_v4_rope_applies_per_row_integer_offsets():
 
 
 def test_deepseek_v4_rope_rejects_offset_batch_mismatch():
-    import mlx.core as mx
+    mx = pytest.importorskip("mlx.core")
 
     from vllm_mlx.models.deepseek_v4 import DeepseekV4RoPE
 
@@ -188,7 +188,7 @@ def test_tiny_model_forward_pass():
 
 def test_tiny_model_decodes_merged_caches_with_different_offsets():
     """Regression for mixed-length continuous batching on compressed layers."""
-    import mlx.core as mx
+    mx = pytest.importorskip("mlx.core")
 
     from vllm_mlx.models import deepseek_v4
 

--- a/vllm_mlx/models/deepseek_v4.py
+++ b/vllm_mlx/models/deepseek_v4.py
@@ -260,6 +260,25 @@ class DeepseekV4RoPE(nn.Module):
     ) -> mx.array:
         head_dim = x.shape[-1]
         freqs = self._get_freqs(head_dim, inverse, freq_scale)
+        if isinstance(offset, mx.array) and offset.ndim > 0:
+            offsets = [int(value) for value in offset.tolist()]
+            if len(offsets) != x.shape[0]:
+                raise ValueError(
+                    "DeepSeek-V4 RoPE needs one offset per batch row; "
+                    f"got {len(offsets)} offsets for batch size {x.shape[0]}"
+                )
+            return mx.concatenate(
+                [
+                    self(
+                        x[index : index + 1],
+                        row_offset,
+                        inverse=inverse,
+                        freq_scale=freq_scale,
+                    )
+                    for index, row_offset in enumerate(offsets)
+                ],
+                axis=0,
+            )
         offset = offset // freq_scale if freq_scale != 1 else offset
         if self.attention_factor != 1.0:
             x = x[...]
@@ -1119,11 +1138,11 @@ class DeepseekV4Cache:
         state["buffer_lengths"] = buffer_lengths
         state["_new_pooled_lengths"] = [usable // ratio for usable in usable_lengths]
 
-        prev_lengths = mx.array(buf_lengths, dtype=mx.float32)
+        prev_lengths = mx.array(buf_lengths, dtype=mx.int32)
         if isinstance(start_pos, mx.array):
-            pool_base = mx.maximum(start_pos, 0).astype(mx.float32)
+            pool_base = mx.maximum(start_pos, 0).astype(mx.int32)
         else:
-            pool_base = mx.full((B,), max(0, start_pos), dtype=mx.float32)
+            pool_base = mx.full((B,), max(0, start_pos), dtype=mx.int32)
         return ready_kv, ready_gate, pool_base - prev_lengths
 
     def update_pool(self, new_pooled: mx.array, state_key: str) -> mx.array:


### PR DESCRIPTION
## Summary

- keep compressed-cache RoPE positions as integers
- apply distinct RoPE offsets per batch row when continuous batching merges requests at different decode positions
- add focused RoPE and end-to-end tiny-model regression coverage

## Root cause

DeepSeek V4 compressed attention returned per-request offsets as float32. In a continuous batch containing different prompt/cache lengths, that vector reached mx.fast.rope, which only accepts a scalar integer offset. The resulting ValueError aborted every request in that batch and surfaced empty length-finished responses.

## Validation

- DeepSeek vendored tests: 8 passed
- focused DeepSeek/batching/routes suite: 139 passed, 2 deselected
- Ruff check and format check clean
- git diff --check clean
- built and force-installed rapid_mlx-0.11.4 wheel
- real 167 GB DeepSeek V4 MXFP4 model: concurrently served 2,734-token and 14-token prompts (running=2); both completed with non-empty output and no RoPE error