### PR TITLE
ci: L1 small-model GPU smoke on free macos-14 — coherence + tool-call (Qwen+Llama)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,13 +201,15 @@ jobs:
     # the expensive Studio gate: garbage-from-first-token (#1234 doubled-norm
     # class, via the #1247 GOLDEN gate) and tool-call parser regressions.
     #
-    # Matrix over two SMALL models from DIFFERENT families so the tool-call
-    # FORMAT check exercises two distinct parser paths — Qwen -> hermes and
-    # Llama -> the `<function=name>` LlamaToolParser — catching family-specific
-    # chat-template / parser breakage that a single-family smoke would miss. Each
-    # model runs on its own runner (parallel), so ~7GB RAM holds one ~2GB model
-    # comfortably. A 3-4B model is fine for a coherence/parser gate — it is not a
-    # chat-quality eval, which stays on the 35B L2 tier.
+    # Matrix over four SMALL models from DIFFERENT families so the tool-call
+    # FORMAT check exercises four distinct parser paths — Qwen -> hermes,
+    # Llama -> the `<function=name>` LlamaToolParser, Gemma -> Gemma4ToolParser,
+    # and Mistral -> the `[TOOL_CALLS]` MistralToolParser — catching
+    # family-specific chat-template / parser breakage that a single-family smoke
+    # would miss. Each model runs on its own runner (parallel), so ~7GB RAM holds
+    # one small (<=2.6GB) model comfortably. A 2-4B model is fine for a
+    # coherence/parser gate — it is not a chat-quality eval, which stays on the
+    # 35B L2 tier.
     #
     # Kept a standalone check (NOT folded into the required ``tests`` aggregate)
     # so it can prove itself green on real PRs before a maintainer marks it a
@@ -215,13 +217,15 @@ jobs:
     runs-on: macos-14
     timeout-minutes: 20
     strategy:
-      # Don't cancel the Llama leg if the Qwen leg fails (or vice versa) — we
-      # want to see which family regressed, not just the first failure.
+      # Don't cancel the other legs when one family fails — we want to see
+      # which families regressed, not just the first failure.
       fail-fast: false
       matrix:
         model:
           - qwen3.5-4b-4bit  # hermes tool-call parser
           - llama3-3b-4bit  # llama `<function=name>` tool-call parser
+          - gemma-4-e2b-4bit  # gemma4 tool-call parser (nano, smallest gemma)
+          - ministral-3b-4bit  # mistral `[TOOL_CALLS]` tool-call parser
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
@@ -233,7 +237,13 @@ jobs:
       - name: Install project
         run: |
           python -m pip install --upgrade pip
-          pip install -e .
+          # ".[vision]" (not plain ".") because some small models here are
+          # detected as multimodal and refuse to load text-only without the
+          # vision extra (e.g. Ministral-3-2512, the Gemma nano models). The
+          # test-apple-silicon job installs the same extra on this runner, so
+          # it is proven to build on macos-14. A coherence/tool-call smoke only
+          # exercises the text path, but the loader still requires the deps.
+          pip install -e ".[vision]"
           # coherence_gate.py + l1_toolcall_check.py drive the server over HTTP;
           # httpx is not a runtime dependency of rapid-mlx itself.
           pip install httpx

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,6 +192,58 @@ jobs:
             -m "not slow" \
             -k "not Integration"
 
+  l1-smoke:
+    # L1 release-flow gate — a small-model GPU coherence + tool-call format
+    # smoke on the FREE macos-14 hosted runner. That runner HAS a real Metal GPU
+    # (``mx.default_device()`` -> ``Device(gpu, 0)``), so MLX runs on the GPU
+    # there for $0; its ~7GB RAM caps it at small models, not the 35B self-hosted
+    # Studio (L2) tier. Runs on every PR to catch GROSS engine breakage BEFORE
+    # the expensive Studio gate: garbage-from-first-token (#1234 doubled-norm
+    # class, via the #1247 GOLDEN gate) and tool-call parser regressions. A
+    # 4B-4bit model (~2.2GB) fits the runner and clears the GOLDEN set in <1min;
+    # 4B is fine for a coherence/parser gate — it is not a chat-quality eval.
+    #
+    # Kept a standalone check (NOT folded into the required ``tests`` aggregate)
+    # so it can prove itself green on real PRs before a maintainer marks it a
+    # required check in branch protection — prove before enforce.
+    runs-on: macos-14
+    timeout-minutes: 20
+    env:
+      L1_MODEL: qwen3.5-4b-4bit
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+        with:
+          python-version: "3.11"
+
+      - name: Install project
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+          # coherence_gate.py + l1_toolcall_check.py drive the server over HTTP;
+          # httpx is not a runtime dependency of rapid-mlx itself.
+          pip install httpx
+
+      - name: Verify Metal GPU
+        # macos-14 hosted runners expose a paravirtualized Metal GPU and MLX
+        # defaults to it. A CPU-only default here means a broken toolchain, so
+        # assert the GPU device rather than silently smoke-testing on CPU.
+        run: |
+          python -c "import platform; assert platform.machine() == 'arm64', platform.machine()"
+          python -c "import mlx.core as mx; d=str(mx.default_device()); assert 'gpu' in d.lower(), d; print('GPU OK:', d)"
+
+      - name: Prefetch L1 model
+        # Download weights up front so the serve boot inside the smoke is fast
+        # and its 180s boot window is not spent on a cold ~2.2GB download.
+        run: rapid-mlx pull "$L1_MODEL"
+
+      - name: L1 smoke (coherence + tool-call format)
+        env:
+          RAPID_MLX_PORT: "8123"
+        run: bash scripts/l1_smoke.sh "$L1_MODEL"
+
   tests:
     needs: [test-matrix, test-apple-silicon]
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,10 +206,13 @@ jobs:
     # Llama -> the `<function=name>` LlamaToolParser, Gemma -> Gemma4ToolParser,
     # and Mistral -> the `[TOOL_CALLS]` MistralToolParser — catching
     # family-specific chat-template / parser breakage that a single-family smoke
-    # would miss. Each model runs on its own runner (parallel), so ~7GB RAM holds
-    # one small (<=2.6GB) model comfortably. A 2-4B model is fine for a
-    # coherence/parser gate — it is not a chat-quality eval, which stays on the
-    # 35B L2 tier.
+    # would miss. Two of them (Gemma nano, Ministral-3-2512) ship as multimodal
+    # checkpoints, but ``l1_smoke.sh`` serves everything with ``--no-mllm`` (the
+    # text-only mlx-lm lane), so only the language backbone loads — vision deps
+    # are never needed and the ~3GB checkpoints stay small in RAM. Each model
+    # runs on its own runner (parallel), so ~7GB comfortably holds one. A 2-4B
+    # model is fine for a coherence/parser gate — it is not a chat-quality eval,
+    # which stays on the 35B L2 tier.
     #
     # Kept a standalone check (NOT folded into the required ``tests`` aggregate)
     # so it can prove itself green on real PRs before a maintainer marks it a
@@ -237,13 +240,14 @@ jobs:
       - name: Install project
         run: |
           python -m pip install --upgrade pip
-          # ".[vision]" (not plain ".") because some small models here are
-          # detected as multimodal and refuse to load text-only without the
-          # vision extra (e.g. Ministral-3-2512, the Gemma nano models). The
-          # test-apple-silicon job installs the same extra on this runner, so
-          # it is proven to build on macos-14. A coherence/tool-call smoke only
-          # exercises the text path, but the loader still requires the deps.
-          pip install -e ".[vision]"
+          # Lean base install — NO ``[vision]`` extra. Two of the matrix models
+          # (Ministral-3-2512, the Gemma nano) are detected as multimodal, but
+          # ``l1_smoke.sh`` serves every model with ``--no-mllm`` (force the
+          # text-only mlx-lm lane), so the vision/mlx-vlm deps are never needed.
+          # This also DODGES the mlx-vlm 0.6.3 text-generation bug: served via
+          # the vision lane those two models return incoherent output / hang
+          # (measured 2026-07-31); the text lane is coherent (6/6 golden).
+          pip install -e .
           # coherence_gate.py + l1_toolcall_check.py drive the server over HTTP;
           # httpx is not a runtime dependency of rapid-mlx itself.
           pip install httpx

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,18 +201,24 @@ jobs:
     # the expensive Studio gate: garbage-from-first-token (#1234 doubled-norm
     # class, via the #1247 GOLDEN gate) and tool-call parser regressions.
     #
-    # Matrix over four SMALL models from DIFFERENT families so the tool-call
-    # FORMAT check exercises four distinct parser paths — Qwen -> hermes,
-    # Llama -> the `<function=name>` LlamaToolParser, Gemma -> Gemma4ToolParser,
-    # and Mistral -> the `[TOOL_CALLS]` MistralToolParser — catching
-    # family-specific chat-template / parser breakage that a single-family smoke
-    # would miss. Two of them (Gemma nano, Ministral-3-2512) ship as multimodal
-    # checkpoints, but ``l1_smoke.sh`` serves everything with ``--no-mllm`` (the
-    # text-only mlx-lm lane), so only the language backbone loads — vision deps
-    # are never needed and the ~3GB checkpoints stay small in RAM. Each model
-    # runs on its own runner (parallel), so ~7GB comfortably holds one. A 2-4B
-    # model is fine for a coherence/parser gate — it is not a chat-quality eval,
-    # which stays on the 35B L2 tier.
+    # Matrix over two SMALL models from DIFFERENT families so the tool-call
+    # FORMAT check exercises two distinct parser paths — Qwen -> hermes and
+    # Llama -> the `<function=name>` LlamaToolParser — catching family-specific
+    # chat-template / parser breakage that a single-family smoke would miss.
+    # Each model runs on its own runner (parallel), so ~7GB RAM holds one ~2GB
+    # model comfortably. A 3-4B model is fine for a coherence/parser gate — it
+    # is not a chat-quality eval, which stays on the 35B L2 tier.
+    #
+    # Why only these two families (not Gemma / Mistral too): the *small* models
+    # in those families ship ONLY as multimodal checkpoints (Gemma nano,
+    # Ministral-3-2512). Serving them here is unreliable — via the mlx-vlm lane
+    # the text path is broken (gemma-4-e2b 0/6 golden, Ministral-3 request-hang
+    # under mlx-vlm 0.6.3); via ``--no-mllm`` (text lane) Ministral is flaky
+    # (5/6) and gemma-4-e2b returns 0/6 on this engine/runner even though the
+    # same model is coherent text-only on an older build. A permanently-red leg
+    # is worse than no leg, so those families are DEFERRED pending an engine fix
+    # (tracked as a follow-up issue). ``l1_smoke.sh`` already forces ``--no-mllm``
+    # so re-adding a multimodal small model later needs no install change.
     #
     # Kept a standalone check (NOT folded into the required ``tests`` aggregate)
     # so it can prove itself green on real PRs before a maintainer marks it a
@@ -227,8 +233,6 @@ jobs:
         model:
           - qwen3.5-4b-4bit  # hermes tool-call parser
           - llama3-3b-4bit  # llama `<function=name>` tool-call parser
-          - gemma-4-e2b-4bit  # gemma4 tool-call parser (nano, smallest gemma)
-          - ministral-3b-4bit  # mistral `[TOOL_CALLS]` tool-call parser
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
@@ -240,13 +244,9 @@ jobs:
       - name: Install project
         run: |
           python -m pip install --upgrade pip
-          # Lean base install — NO ``[vision]`` extra. Two of the matrix models
-          # (Ministral-3-2512, the Gemma nano) are detected as multimodal, but
-          # ``l1_smoke.sh`` serves every model with ``--no-mllm`` (force the
-          # text-only mlx-lm lane), so the vision/mlx-vlm deps are never needed.
-          # This also DODGES the mlx-vlm 0.6.3 text-generation bug: served via
-          # the vision lane those two models return incoherent output / hang
-          # (measured 2026-07-31); the text lane is coherent (6/6 golden).
+          # Lean base install — NO ``[vision]`` extra. Both matrix models are
+          # text-only, and ``l1_smoke.sh`` serves with ``--no-mllm`` anyway, so
+          # the vision/mlx-vlm deps are never needed and the install stays fast.
           pip install -e .
           # coherence_gate.py + l1_toolcall_check.py drive the server over HTTP;
           # httpx is not a runtime dependency of rapid-mlx itself.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,17 +199,29 @@ jobs:
     # there for $0; its ~7GB RAM caps it at small models, not the 35B self-hosted
     # Studio (L2) tier. Runs on every PR to catch GROSS engine breakage BEFORE
     # the expensive Studio gate: garbage-from-first-token (#1234 doubled-norm
-    # class, via the #1247 GOLDEN gate) and tool-call parser regressions. A
-    # 4B-4bit model (~2.2GB) fits the runner and clears the GOLDEN set in <1min;
-    # 4B is fine for a coherence/parser gate — it is not a chat-quality eval.
+    # class, via the #1247 GOLDEN gate) and tool-call parser regressions.
+    #
+    # Matrix over two SMALL models from DIFFERENT families so the tool-call
+    # FORMAT check exercises two distinct parser paths — Qwen -> hermes and
+    # Llama -> the `<function=name>` LlamaToolParser — catching family-specific
+    # chat-template / parser breakage that a single-family smoke would miss. Each
+    # model runs on its own runner (parallel), so ~7GB RAM holds one ~2GB model
+    # comfortably. A 3-4B model is fine for a coherence/parser gate — it is not a
+    # chat-quality eval, which stays on the 35B L2 tier.
     #
     # Kept a standalone check (NOT folded into the required ``tests`` aggregate)
     # so it can prove itself green on real PRs before a maintainer marks it a
     # required check in branch protection — prove before enforce.
     runs-on: macos-14
     timeout-minutes: 20
-    env:
-      L1_MODEL: qwen3.5-4b-4bit
+    strategy:
+      # Don't cancel the Llama leg if the Qwen leg fails (or vice versa) — we
+      # want to see which family regressed, not just the first failure.
+      fail-fast: false
+      matrix:
+        model:
+          - qwen3.5-4b-4bit  # hermes tool-call parser
+          - llama3-3b-4bit  # llama `<function=name>` tool-call parser
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
@@ -234,15 +246,15 @@ jobs:
           python -c "import platform; assert platform.machine() == 'arm64', platform.machine()"
           python -c "import mlx.core as mx; d=str(mx.default_device()); assert 'gpu' in d.lower(), d; print('GPU OK:', d)"
 
-      - name: Prefetch L1 model
-        # Download weights up front so the serve boot inside the smoke is fast
-        # and its 180s boot window is not spent on a cold ~2.2GB download.
-        run: rapid-mlx pull "$L1_MODEL"
+      - name: Prefetch model (${{ matrix.model }})
+        # rapid-mlx pull uses the R2 mirror (fast — ~40MB/s), so weights are on
+        # disk before the serve boot; no actions/cache needed.
+        run: rapid-mlx pull "${{ matrix.model }}"
 
       - name: L1 smoke (coherence + tool-call format)
         env:
           RAPID_MLX_PORT: "8123"
-        run: bash scripts/l1_smoke.sh "$L1_MODEL"
+        run: bash scripts/l1_smoke.sh "${{ matrix.model }}"
 
   tests:
     needs: [test-matrix, test-apple-silicon]

--- a/scripts/l1_smoke.sh
+++ b/scripts/l1_smoke.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# L1 release-flow smoke — a SMALL-model GPU coherence + tool-call format check
+# for the FREE GitHub-hosted macos-14 runner. That runner has a real Metal GPU
+# (``mx.default_device()`` -> ``Device(gpu, 0)``), so MLX runs on the GPU there
+# for $0; its ~7GB RAM caps it at small models, not the 35B Studio (L2) tier.
+#
+# Runs on every PR to catch GROSS engine breakage on cheap hardware BEFORE the
+# expensive Studio gate:
+#   * garbage-from-first-token (#1234 doubled-norm class) via the #1247 GOLDEN
+#     coherence gate, and
+#   * tool-call parser regressions via a forced-``tool_choice`` format assertion.
+# Neither can run on the pure-CPU Linux CI (no Metal, no weights).
+#
+# Boots ``rapid-mlx serve <model>``, runs both checks, then tears down ONLY the
+# server it started — never ``pkill rapid-mlx``, because a shared machine (a dev
+# box, a self-hosted runner) may have other rapid-mlx servers running, including
+# a production one on :8000.
+#
+#   Usage:   ./scripts/l1_smoke.sh [model-alias]
+#   Default: qwen3.5-4b-4bit  (~2.2GB 4-bit — fits the runner's ~7GB RAM and
+#            clears the GOLDEN set in <1min. 4B is fine for a parser/coherence
+#            gate; it is NOT a chat-quality eval, which needs the L2 35B tier.)
+#
+# Env:
+#   RAPID_MLX        rapid-mlx executable (default: ``rapid-mlx`` on PATH)
+#   PYTHON           python for the gate scripts (default: ``python3``)
+#   RAPID_MLX_PORT   serve port (default: 8123 — deliberately not :8000)
+#   L1_MODEL         model alias (overridden by the positional arg)
+#
+# Exit code: 0 iff BOTH checks pass; non-zero blocks the PR.
+set -uo pipefail
+
+RMLX="${RAPID_MLX:-rapid-mlx}"
+PY="${PYTHON:-python3}"
+ALIAS="${1:-${L1_MODEL:-qwen3.5-4b-4bit}}"
+PORT="${RAPID_MLX_PORT:-8123}"
+B="http://127.0.0.1:$PORT"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LOG="$(mktemp -t l1-serve.XXXXXX)"
+SERVE_PID=""
+
+fail() { echo "L1-SMOKE FAIL: $*" >&2; exit 1; }
+
+cleanup() {
+  # Kill ONLY the server this script started. Never ``pkill rapid-mlx``: on a
+  # shared machine that would also kill an unrelated (possibly production)
+  # server the script does not own.
+  [ -n "$SERVE_PID" ] && kill -9 "$SERVE_PID" 2>/dev/null
+  rm -f "$LOG"
+}
+trap cleanup EXIT
+
+command -v "$RMLX" >/dev/null 2>&1 || fail "no rapid-mlx on PATH (set RAPID_MLX)"
+echo "== L1 smoke =="
+printf "  rapid-mlx  %s\n" "$("$RMLX" --version 2>&1 | head -1)"
+echo "  model: $ALIAS   port: $PORT"
+
+# ---- refuse to hijack a port we do not own -------------------------------
+if curl -s -m 3 "$B/v1/models" >/dev/null 2>&1; then
+  fail "port $PORT already serving — not ours to kill; free it or set RAPID_MLX_PORT"
+fi
+
+# ---- boot serve ----------------------------------------------------------
+# --no-thinking: the coherence gate measures answer coherence, not think-mode
+# behavior (its no-think-leak case still asserts no raw <think> tag leaks).
+nohup "$RMLX" serve "$ALIAS" --port "$PORT" --no-thinking > "$LOG" 2>&1 &
+SERVE_PID=$!
+for i in $(seq 1 60); do
+  curl -s -m 3 "$B/v1/models" 2>/dev/null | grep -q '"id"' && { echo "serve READY (~$((i * 3))s)"; break; }
+  kill -0 "$SERVE_PID" 2>/dev/null || { tail -30 "$LOG"; fail "serve process died during boot"; }
+  sleep 3
+  [ "$i" = 60 ] && { tail -30 "$LOG"; fail "serve not ready in 180s"; }
+done
+
+# ---- check 1/2: output coherence (#1247 GOLDEN, blocking) ----------------
+echo "== [1/2] coherence gate (#1247) =="
+RAPID_MLX_BASE_URL="$B/v1" "$PY" "$REPO_ROOT/evals/coherence_gate.py" \
+  --base-url "$B/v1" --timeout 90 \
+  || fail "coherence gate failed — served model gave a wrong/incoherent golden answer"
+
+# ---- check 2/2: tool-call format under forced tool_choice (blocking) -----
+echo "== [2/2] tool-call format =="
+"$PY" "$REPO_ROOT/scripts/l1_toolcall_check.py" --base-url "$B/v1" --timeout 90 \
+  || fail "tool-call format check failed — forced tool_choice did not yield a well-formed call"
+
+echo "L1-SMOKE PASS ($ALIAS): coherence + tool-call format OK"

--- a/scripts/l1_smoke.sh
+++ b/scripts/l1_smoke.sh
@@ -65,7 +65,17 @@ fi
 # ---- boot serve ----------------------------------------------------------
 # --no-thinking: the coherence gate measures answer coherence, not think-mode
 # behavior (its no-think-leak case still asserts no raw <think> tag leaks).
-nohup "$RMLX" serve "$ALIAS" --port "$PORT" --no-thinking > "$LOG" 2>&1 &
+#
+# --no-mllm: force the text-only mlx-lm lane. This gate only exercises the
+# TEXT coherence + tool-call parser paths, never vision, so the LM backbone is
+# all we need. It is a no-op for text-only models, but for a small model that
+# is *detected* as multimodal (Gemma nano, Ministral-3-2512) it (a) skips the
+# ``[vision]`` / mlx-vlm requirement so a lean ``pip install -e .`` suffices,
+# and (b) avoids the mlx-vlm text-generation path, which returns incoherent
+# output / hangs for these models (measured 2026-07-31: gemma-4-e2b 0/6 golden,
+# Ministral-3 request-hang under mlx-vlm 0.6.3). ``resolve_serving_lane`` maps
+# ``--no-mllm`` -> ``force_text`` -> the text lane, matching engine semantics.
+nohup "$RMLX" serve "$ALIAS" --port "$PORT" --no-thinking --no-mllm > "$LOG" 2>&1 &
 SERVE_PID=$!
 for i in $(seq 1 60); do
   curl -s -m 3 "$B/v1/models" 2>/dev/null | grep -q '"id"' && { echo "serve READY (~$((i * 3))s)"; break; }

--- a/scripts/l1_toolcall_check.py
+++ b/scripts/l1_toolcall_check.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""L1 tool-call FORMAT check — assert a forced ``tool_choice`` yields a
+well-formed tool call.
+
+This guards the tool-call *plumbing*, not the small model's discretion to call
+a tool. ``tool_choice="required"`` with a single tool forces the call via a
+grammar-constrained forced-function prefix (see ``vllm_mlx/routes/chat.py``), so
+the result is deterministic at temperature 0 — the check measures whether the
+server emits a structurally valid ``tool_calls`` entry (function name present,
+arguments parseable as a JSON object), the class of regression where a model
+emits a call but the parser mangles it into free text or breaks the JSON args.
+
+Companion to ``evals/coherence_gate.py``; both are driven by
+``scripts/l1_smoke.sh`` on the free macos-14 L1 runner. Requires a
+``rapid-mlx serve`` already listening — it does not boot one.
+
+Exit codes:
+    0 — a well-formed forced tool call came back
+    1 — no/malformed tool call, or the server was unreachable
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+import httpx
+
+_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "get_weather",
+        "description": "Get the current weather for a city.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "location": {"type": "string", "description": "City name, e.g. Paris"}
+            },
+            "required": ["location"],
+        },
+    },
+}
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--base-url", default="http://127.0.0.1:8123/v1")
+    ap.add_argument("--timeout", type=float, default=90.0)
+    args = ap.parse_args()
+
+    body = {
+        "model": "default",
+        "messages": [
+            {"role": "user", "content": "What is the weather in Paris? Use the tool."}
+        ],
+        "tools": [_TOOL],
+        # Single tool + "required" => forced call, grammar-constrained. Makes the
+        # FORMAT deterministic regardless of a small model's tool-calling mood.
+        "tool_choice": "required",
+        "max_tokens": 128,
+        "temperature": 0.0,
+        "stream": False,
+    }
+
+    try:
+        r = httpx.post(
+            f"{args.base_url.rstrip('/')}/chat/completions",
+            json=body,
+            timeout=args.timeout,
+        )
+        r.raise_for_status()
+        data = r.json()
+    except Exception as exc:
+        print(f"FAIL: request error: {exc}", file=sys.stderr)
+        return 1
+
+    try:
+        msg = data["choices"][0]["message"]
+    except (KeyError, IndexError, TypeError) as exc:
+        print(
+            f"FAIL: malformed response ({exc}): {json.dumps(data)[:300]}",
+            file=sys.stderr,
+        )
+        return 1
+
+    calls = msg.get("tool_calls") or []
+    if not calls:
+        content = (msg.get("content") or "")[:200]
+        print(
+            "FAIL: forced tool_choice produced NO tool_calls "
+            f"(the call likely leaked into text): content={content!r}",
+            file=sys.stderr,
+        )
+        return 1
+
+    fn = (calls[0] or {}).get("function") or {}
+    name = fn.get("name")
+    if name != "get_weather":
+        print(f"FAIL: tool name {name!r} != 'get_weather'", file=sys.stderr)
+        return 1
+
+    raw_args = fn.get("arguments")
+    # OpenAI convention: arguments is a JSON *string*. Accept a pre-parsed dict
+    # too so the check asserts structure, not serialization style.
+    if isinstance(raw_args, dict):
+        parsed = raw_args
+    elif isinstance(raw_args, str):
+        try:
+            parsed = json.loads(raw_args)
+        except json.JSONDecodeError as exc:
+            print(
+                f"FAIL: arguments not valid JSON ({exc}): {raw_args!r}", file=sys.stderr
+            )
+            return 1
+    else:
+        print(
+            f"FAIL: arguments must be a JSON string or object, got "
+            f"{type(raw_args).__name__}",
+            file=sys.stderr,
+        )
+        return 1
+
+    if not isinstance(parsed, dict):
+        print(
+            f"FAIL: arguments JSON is {type(parsed).__name__}, expected an object",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"PASS: well-formed forced tool_call get_weather(arguments={parsed})")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Why

The automated release gate jumps straight from pure-CPU Linux CI (lint/type/mock-MLX units) to the expensive self-hosted **Studio** run (35B agentic + coherence). There is **no cheap GPU tier in between** — so a gross engine regression (garbage from the first token, a mangled tool-call) is only caught by the slow, single-GPU Studio gate at release time, not on the PR that introduced it.

This adds the missing **L1 tier**: a small-model GPU smoke on the **free** GitHub-hosted `macos-14` runner, on **every PR**.

Enabler (empirically verified): `macos-14` hosted runners **have a real Metal GPU** — `mx.default_device()` → `Device(gpu, 0)` — so MLX runs on the GPU there for **\$0**. ~7GB RAM caps it at small models, exactly right for a coherence/parser gate.

## What it catches — across two model families

Runs a **matrix over two small models from different families** so the tool-call FORMAT check exercises two distinct parser paths:

| Model | Family | Tool-call parser |
|---|---|---|
| `qwen3.5-4b-4bit` | Qwen | `hermes` |
| `llama3-3b-4bit` | Llama-3.2 | `<function=name>` `LlamaToolParser` |

Each leg asserts:
1. **Coherence** (#1247 GOLDEN, blocking) — 6 deterministic prompts (`Tokyo`, `391`, `blue`, `7`, `banana`, `Paris`/no-think-leak) via `evals/coherence_gate.py`. Catches garbage-from-first-token (#1234 doubled-norm class).
2. **Tool-call format** — `scripts/l1_toolcall_check.py` forces a single-tool `tool_choice="required"` (grammar-constrained → deterministic) and asserts a structurally valid `tool_calls` entry (function name + JSON-object args). Two families ⇒ two parser paths ⇒ catches **family-specific** chat-template / parser breakage a Qwen-only smoke would miss.

`fail-fast: false` so a regression in either family is visible independently. Each model runs on its own runner, so ~7GB RAM holds one ~2GB model comfortably.

## No weight cache — the R2 mirror already makes it fast

An `actions/cache` for the weights was prototyped and **dropped after measuring** on the runner:

| Path | Fetch ~2GB weights |
|---|---|
| `rapid-mlx pull` (R2 mirror) | ~74s @ ~42 MB/s |
| GitHub cache restore | ~63s + ~40s save on cold/evicted runs |

Net steady-state saving ~11s, at the cost of cold-run overhead and a layer of cache-key logic — not worth it. The R2 mirror already solved "download is slow", so a plain `pull` is simpler and just as quick. (Same "simple beats a marginal cache" call as the L2 tier.)

## Files

- `.github/workflows/ci.yml` — standalone `l1-smoke` matrix job (macos-14, 20-min timeout): install → assert GPU → `rapid-mlx pull` → run smoke.
- `scripts/l1_smoke.sh` — boot serve, run both checks, tear down **only its own** server (never `pkill rapid-mlx`).
- `scripts/l1_toolcall_check.py` — the forced-`tool_choice` format assertion.

## Local proof

Ran `scripts/l1_smoke.sh` against both models on M3: serve boots in ~10s, **coherence 6/6** + a **well-formed forced tool_call** on each. First CI run (Qwen leg) also passed on the real macos-14 runner in **2m18s** including a cold ~2.2GB download.

## Rollout — prove before enforce

Standalone check, deliberately **not** folded into the required `tests` aggregate. Once green on real PRs, a maintainer can flip it required in branch protection. No `pyproject` version touched (does not trigger auto-release).

Part of the tiered release-gate design; extends the #1247 coherence gate to a per-PR free-GPU tier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)