### PR TITLE
ci: wire deep coherence + perf into the L2 release gate

### DIFF
--- a/.github/workflows/agent-gate.yml
+++ b/.github/workflows/agent-gate.yml
@@ -1,11 +1,17 @@
 name: Tier-1 agent gate
 
 # Re-verifies the four Tier-1 (flagship) agents — Claude Code, Codex, Hermes,
-# Aider — end-to-end against a real local model on Apple Silicon. This is the
-# one release check GitHub-hosted runners structurally cannot do (no Metal, no
-# weights, no agent binaries), so it runs on a self-hosted Apple-Silicon runner
-# (the Studio). Mirrors how Apple's own MLX gates its Metal tests on
-# `[self-hosted, macos]`.
+# Aider — end-to-end against a real local model on Apple Silicon, then reuses the
+# same warm serve to run the deep output-coherence golden (#1247) and a
+# decode-throughput perf check. This is the one release check GitHub-hosted
+# runners structurally cannot do (no Metal, no weights, no agent binaries), so it
+# runs on a self-hosted Apple-Silicon runner (the Studio). Mirrors how Apple's own
+# MLX gates its Metal tests on `[self-hosted, macos]`.
+#
+# The coherence + perf extras are driven by RAPID_MLX_RELEASE_GATE=1 (set below)
+# and land in agent_smoke.sh so they share the one 35B load — catching the
+# "agentic path works but the model outputs garbage / regressed in speed" class
+# that agentic checks alone missed (0.11.4).
 #
 # Phase 1: manual (`workflow_dispatch`) only, so we can prove the runner + smoke
 # work before wiring it into the release path. Phase 2 will add this as a
@@ -23,6 +29,9 @@ on:
       model:
         description: "Model alias to verify against (>=8-bit; never 4-bit)"
         default: "qwen3.6-35b-8bit"
+      perf_min_tps:
+        description: "Optional reviewed decode tok/s floor for the perf gate. Blank = advisory (measure + print the number to review, never fails)."
+        default: ""
 
 permissions:
   contents: read
@@ -51,4 +60,11 @@ jobs:
           # Untrusted-ish input passed via env, never interpolated into the
           # script line (matches the repo's auto-release.yml convention).
           MODEL: ${{ inputs.model }}
+          # Turn on the release-gate extras in agent_smoke.sh: after the four
+          # agents pass, reuse the SAME warm serve to run the deep coherence
+          # golden (#1247) and a decode-throughput perf check — no second load.
+          RAPID_MLX_RELEASE_GATE: "1"
+          # Reviewed perf floor (tok/s). Blank → perf runs advisory (prints the
+          # number to review); set it here to enforce. Never a fabricated baseline.
+          RAPID_MLX_PERF_MIN_TPS: ${{ inputs.perf_min_tps }}
         run: bash tests/integrations/agent_smoke.sh "$MODEL"

--- a/.github/workflows/agent-gate.yml
+++ b/.github/workflows/agent-gate.yml
@@ -49,7 +49,12 @@ jobs:
     # every per-command timeout) so the smoke exits on its own, prints its
     # summary, and runs cleanup — instead of GitHub cancelling mid-run. A
     # passing run finishes in ~5-8 min; the tail only matters on regressions.
-    timeout-minutes: 55
+    # Raised from 55: the release path now adds the coherence golden and a
+    # perf measurement on top of the four agents (all on the same warm
+    # serve). Each check is individually bounded, but they stack, and a
+    # run where every check PASSES near its own limit could otherwise be
+    # cancelled by Actions for exceeding the job budget.
+    timeout-minutes: 75
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
       - name: Tier-1 agent re-verification

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -149,7 +149,11 @@ jobs:
     # untimed up front (hard-bounded to ~10 min) so the healthy path finishes in
     # minutes; 90 min is headroom so a slow-but-passing cold run reaches a verdict
     # instead of being killed. A genuine hang still fails on the per-agent budgets.
-    timeout-minutes: 90
+    # 105, not 90: the coherence golden + perf measurement now run after the
+    # four agents on the same warm serve. They are minutes on a healthy run,
+    # but they stack on top of the ~78 min worst case above, and a run where
+    # every check PASSES near its own budget must not be guillotined.
+    timeout-minutes: 105
     # Serialize with the manual agent-gate.yml so two runs never contend for the
     # single runner / the serve port.
     concurrency:
@@ -165,6 +169,14 @@ jobs:
           # rapid-mlx serve on the shared Studio; the smoke repoints agent
           # configs at it via patch_port.
           RAPID_MLX_PORT: "8188"
+          # Turn on the coherence + perf extras for the REAL release path.
+          # Without this the smoke skips them and this job would re-verify the
+          # four agents while never checking that the flagship model still
+          # answers coherently — the exact gap (#1247) that let 0.11.4 ship as
+          # garbage. Coherence is fail-closed; perf stays advisory because no
+          # floor is set here (RAPID_MLX_PERF_MIN_TPS unset), so it measures and
+          # prints a number to review rather than inventing a baseline.
+          RAPID_MLX_RELEASE_GATE: "1"
         run: |
           set -euo pipefail
           export PATH="/opt/homebrew/bin:$HOME/.local/bin:$PATH"

--- a/evals/perf_gate.py
+++ b/evals/perf_gate.py
@@ -112,6 +112,11 @@ def _measure_decode(
     SGLang both report TTFT and output-token throughput as separate numbers
     for exactly this reason; measure decode the same way, from the first
     streamed token to the last.
+
+    Token COUNT comes from ``usage.completion_tokens`` via
+    ``stream_options.include_usage``, not from counting SSE frames: one delta
+    is not one token (the detokenizer can batch several, and a frame can
+    carry no text at all), so frame-counting silently understates throughput.
     """
     body = {
         "model": "default",
@@ -119,6 +124,8 @@ def _measure_decode(
         "max_tokens": max_tokens,
         "temperature": 0.0,
         "stream": True,
+        # Authoritative token accounting — see the docstring.
+        "stream_options": {"include_usage": True},
         # Match the gauntlet's --no-thinking boot: measure answer-token decode,
         # not thinking-mode expansion.
         "enable_thinking": False,
@@ -126,7 +133,8 @@ def _measure_decode(
     start = time.monotonic()
     first_tok_at: float | None = None
     last_tok_at = start
-    tokens = 0
+    deltas = 0
+    usage_tokens: int | None = None
     finish_reason: str | None = None
 
     with httpx.stream(
@@ -141,20 +149,54 @@ def _measure_decode(
                 continue
             try:
                 chunk = json.loads(payload)
-                choice = chunk["choices"][0]
-            except (ValueError, KeyError, IndexError):
+            except ValueError as exc:
+                # A frame we cannot parse means the stream is not what we think
+                # it is. Swallowing it would let a truncated run be judged as a
+                # complete one.
+                raise MeasurementError(
+                    f"malformed SSE frame: {payload[:120]!r}"
+                ) from exc
+            # Mid-stream error frames are how the server reports a generation
+            # that died partway. Counting the tokens that arrived before it
+            # would score an incomplete run as a healthy one.
+            if isinstance(chunk, dict) and chunk.get("error"):
+                raise MeasurementError(
+                    f"server reported an error mid-stream: {chunk['error']}"
+                )
+            if usage := (chunk.get("usage") if isinstance(chunk, dict) else None):
+                if (ct := usage.get("completion_tokens")) is not None:
+                    usage_tokens = int(ct)
+            choices = chunk.get("choices") or []
+            if not choices:
                 continue
+            choice = choices[0]
             if choice.get("delta", {}).get("content"):
                 now = time.monotonic()
                 if first_tok_at is None:
                     first_tok_at = now
                 last_tok_at = now
-                tokens += 1
+                deltas += 1
             if choice.get("finish_reason"):
                 finish_reason = choice["finish_reason"]
 
-    if first_tok_at is None or tokens == 0:
+    if first_tok_at is None or deltas == 0:
         raise MeasurementError("server streamed no content tokens")
+
+    # A stream that never reported why it stopped did not demonstrably finish;
+    # judging its throughput would score a truncated generation as a healthy one.
+    if finish_reason is None:
+        raise MeasurementError(
+            "stream ended without a terminal finish_reason — generation did not "
+            "demonstrably complete"
+        )
+
+    tokens = usage_tokens if usage_tokens is not None else deltas
+    if usage_tokens is None:
+        print(
+            "  NOTE: server sent no usage.completion_tokens; falling back to "
+            "counting SSE deltas, which can understate throughput.",
+            file=sys.stderr,
+        )
 
     # A gate that accepts any sample size is not a gate: `max_tokens` is only
     # a CEILING, so a model that stops after 8 tokens would report a number

--- a/evals/perf_gate.py
+++ b/evals/perf_gate.py
@@ -131,6 +131,10 @@ def _measure_decode(
         "enable_thinking": False,
     }
     start = time.monotonic()
+    # httpx's timeout is per-READ (inactivity), not a total deadline: a stream
+    # that trickles one frame every timeout-minus-epsilon seconds never trips
+    # it and can outlive the whole CI job budget. Bound the wall clock too.
+    deadline = start + timeout
     first_tok_at: float | None = None
     last_tok_at = start
     deltas = 0
@@ -142,6 +146,11 @@ def _measure_decode(
     ) as resp:
         resp.raise_for_status()
         for line in resp.iter_lines():
+            if time.monotonic() > deadline:
+                raise MeasurementError(
+                    f"stream exceeded the {timeout:.0f}s budget "
+                    f"(decoded {deltas} frames so far)"
+                )
             if not line.startswith("data:"):
                 continue
             payload = line[5:].strip()
@@ -237,7 +246,11 @@ def main() -> int:
         help="generation length for the measured request (default: 512)",
     )
     ap.add_argument(
-        "--timeout", type=float, default=180.0, help="per-request timeout (s)"
+        "--timeout",
+        type=float,
+        default=300.0,
+        help="total budget for the measured request (s). Bounds wall-clock "
+        "time, not just read inactivity (default: 300)",
     )
     args = ap.parse_args()
 

--- a/evals/perf_gate.py
+++ b/evals/perf_gate.py
@@ -45,6 +45,8 @@ Exit codes:
 from __future__ import annotations
 
 import argparse
+import json
+import math
 import os
 import sys
 import time
@@ -61,8 +63,27 @@ _DEFAULT_PROMPT = (
 )
 
 
+# Smallest decode sample this gate will judge. Below this the tokens/sec
+# figure is dominated by scheduling noise rather than steady-state decode.
+_MIN_DECODE_TOKENS = 64
+
+
 class InvalidServerResponseError(RuntimeError):
     """The server replied, but without usable token accounting."""
+
+
+def _env_float(name: str) -> float | None:
+    """Parse a float env var. Unset/blank -> None (advisory). Garbage raises,
+    because an operator who set the variable meant to enforce something."""
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return None
+    try:
+        return float(raw)
+    except ValueError:
+        raise SystemExit(
+            f"ERROR: {name}={raw!r} is not a number; refusing to guess a floor."
+        )
 
 
 def _server_reachable(base_url: str) -> bool:
@@ -73,35 +94,83 @@ def _server_reachable(base_url: str) -> bool:
         return False
 
 
-def _complete(
+class MeasurementError(RuntimeError):
+    """The run completed but produced no usable perf sample."""
+
+
+def _measure_decode(
     base_url: str, prompt: str, *, max_tokens: int, timeout: float
-) -> tuple[int, float]:
-    """One non-streaming completion at temperature 0. Returns
-    ``(completion_tokens, elapsed_seconds)``. Raises on a malformed reply."""
+) -> tuple[int, float, float]:
+    """Stream one completion and separate prefill from decode.
+
+    Returns ``(decoded_tokens, ttft_seconds, decode_seconds)``.
+
+    Dividing total request latency by token count — which this gate used to
+    do — charges prefill and time-to-first-token against decode, so a long
+    prompt makes a healthy model look slow (512 tokens with 10s TTFT + 20s
+    decode reports 17 tok/s for a model actually decoding at 25.6). vLLM and
+    SGLang both report TTFT and output-token throughput as separate numbers
+    for exactly this reason; measure decode the same way, from the first
+    streamed token to the last.
+    """
     body = {
         "model": "default",
         "messages": [{"role": "user", "content": prompt}],
         "max_tokens": max_tokens,
         "temperature": 0.0,
-        "stream": False,
+        "stream": True,
         # Match the gauntlet's --no-thinking boot: measure answer-token decode,
         # not thinking-mode expansion.
         "enable_thinking": False,
     }
     start = time.monotonic()
-    resp = httpx.post(
-        f"{base_url.rstrip('/')}/chat/completions", json=body, timeout=timeout
-    )
-    elapsed = time.monotonic() - start
-    resp.raise_for_status()
-    try:
-        data = resp.json()
-        completion_tokens = int(data["usage"]["completion_tokens"])
-    except (ValueError, KeyError, TypeError) as exc:
-        raise InvalidServerResponseError(
-            "response lacked usage.completion_tokens — cannot measure throughput"
-        ) from exc
-    return completion_tokens, elapsed
+    first_tok_at: float | None = None
+    last_tok_at = start
+    tokens = 0
+    finish_reason: str | None = None
+
+    with httpx.stream(
+        "POST", f"{base_url.rstrip('/')}/chat/completions", json=body, timeout=timeout
+    ) as resp:
+        resp.raise_for_status()
+        for line in resp.iter_lines():
+            if not line.startswith("data:"):
+                continue
+            payload = line[5:].strip()
+            if not payload or payload == "[DONE]":
+                continue
+            try:
+                chunk = json.loads(payload)
+                choice = chunk["choices"][0]
+            except (ValueError, KeyError, IndexError):
+                continue
+            if choice.get("delta", {}).get("content"):
+                now = time.monotonic()
+                if first_tok_at is None:
+                    first_tok_at = now
+                last_tok_at = now
+                tokens += 1
+            if choice.get("finish_reason"):
+                finish_reason = choice["finish_reason"]
+
+    if first_tok_at is None or tokens == 0:
+        raise MeasurementError("server streamed no content tokens")
+
+    # A gate that accepts any sample size is not a gate: `max_tokens` is only
+    # a CEILING, so a model that stops after 8 tokens would report a number
+    # computed over 0.2s of noise and sail past any floor. Require enough
+    # decode to be meaningful.
+    if tokens < _MIN_DECODE_TOKENS:
+        raise MeasurementError(
+            f"only {tokens} tokens decoded (finish_reason={finish_reason!r}); "
+            f"need >= {_MIN_DECODE_TOKENS} for a meaningful throughput sample"
+        )
+
+    ttft = first_tok_at - start
+    decode_seconds = last_tok_at - first_tok_at
+    if decode_seconds <= 0:
+        raise MeasurementError("all tokens arrived in one batch — cannot time decode")
+    return tokens, ttft, decode_seconds
 
 
 def main() -> int:
@@ -115,11 +184,7 @@ def main() -> int:
     ap.add_argument(
         "--min-tps",
         type=float,
-        default=(
-            float(os.environ["RAPID_MLX_PERF_MIN_TPS"])
-            if os.environ.get("RAPID_MLX_PERF_MIN_TPS")
-            else None
-        ),
+        default=_env_float("RAPID_MLX_PERF_MIN_TPS"),
         help="reviewed decode tokens/sec floor; below it the gate fails. "
         "Default: $RAPID_MLX_PERF_MIN_TPS, else advisory-only.",
     )
@@ -134,6 +199,21 @@ def main() -> int:
     )
     args = ap.parse_args()
 
+    # A floor of NaN silently disables enforcement: every `tps < nan` is False,
+    # so a 1 tok/s model would PASS. Same for inf (always fails) and <= 0
+    # (meaningless). A malformed floor means the operator INTENDED to enforce
+    # and the value is broken — refuse rather than quietly run advisory.
+    if args.min_tps is not None and not (
+        math.isfinite(args.min_tps) and args.min_tps > 0
+    ):
+        print(
+            f"ERROR: --min-tps/RAPID_MLX_PERF_MIN_TPS is {args.min_tps!r}; "
+            "expected a finite number > 0. Refusing to run with a floor that "
+            "cannot enforce anything.",
+            file=sys.stderr,
+        )
+        return 2
+
     base_url = args.base_url
     print("=" * 60)
     print("  perf-regression gate (decode throughput)")
@@ -144,38 +224,57 @@ def main() -> int:
     print(f"  floor: {floor_str}   max_tokens: {args.max_tokens}")
     print("=" * 60)
 
-    if not _server_reachable(base_url):
+    # The caller's contract is "non-zero blocks the release", so whether a
+    # measurement FAILURE blocks depends on the mode. With a reviewed floor we
+    # fail closed: unable to verify == not verified. In advisory mode there is
+    # nothing to enforce, so an unreachable server or a flaky request must not
+    # take the release down over a number nobody is checking yet.
+    advisory = args.min_tps is None
+
+    def _unmeasurable(msg: str) -> int:
+        print(f"ERROR: perf measurement failed: {msg}", file=sys.stderr)
+        if advisory:
+            print(
+                "  ADVISORY: no floor set — not blocking the release on a "
+                "measurement this gate is not yet enforcing."
+            )
+            return 0
         print(
-            f"ERROR: no rapid-mlx server reachable at {base_url}. "
-            "Start one with: rapid-mlx serve <model> --port 8000",
+            "  A floor is set, so an unverifiable measurement blocks: "
+            "cannot confirm the model did not regress.",
             file=sys.stderr,
         )
         return 2
+
+    if not _server_reachable(base_url):
+        return _unmeasurable(
+            f"no rapid-mlx server reachable at {base_url} "
+            "(start one with: rapid-mlx serve <model> --port 8000)"
+        )
 
     try:
-        # Warm the long-context decode path so the measured run is not skewed by
-        # a first-touch kernel compile (the agent smoke already exercised the
+        # Warm the decode path so the measured run is not skewed by a
+        # first-touch kernel compile (the agent smoke already exercised the
         # serve, so this is usually a no-op).
-        _complete(base_url, "Say ready.", max_tokens=8, timeout=args.timeout)
-        tokens, elapsed = _complete(
+        _measure_decode(base_url, "Say ready.", max_tokens=8, timeout=args.timeout)
+    except Exception:  # noqa: BLE001 — warm-up result is deliberately ignored
+        pass
+
+    try:
+        tokens, ttft, decode_seconds = _measure_decode(
             base_url, _DEFAULT_PROMPT, max_tokens=args.max_tokens, timeout=args.timeout
         )
-    except (httpx.HTTPError, InvalidServerResponseError) as exc:
-        print(f"ERROR: perf measurement failed: {exc}", file=sys.stderr)
-        return 2
+    except (httpx.HTTPError, InvalidServerResponseError, MeasurementError) as exc:
+        return _unmeasurable(str(exc))
 
-    if tokens <= 0 or elapsed <= 0:
-        print(
-            f"ERROR: unusable measurement (tokens={tokens}, elapsed={elapsed:.3f}s).",
-            file=sys.stderr,
-        )
-        return 2
-
-    tps = tokens / elapsed
-    print(f"  measured: {tokens} tokens in {elapsed:.2f}s -> {tps:.2f} tok/s")
+    tps = tokens / decode_seconds
+    print(
+        f"  measured: {tokens} tokens, TTFT {ttft:.2f}s, "
+        f"decode {decode_seconds:.2f}s -> {tps:.2f} tok/s (decode only)"
+    )
     print("=" * 60)
 
-    if args.min_tps is None:
+    if advisory:
         print(
             "  ADVISORY: no floor set (RAPID_MLX_PERF_MIN_TPS unset) — record this "
             "number, review it, then set the floor to enforce."

--- a/evals/perf_gate.py
+++ b/evals/perf_gate.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Decode-throughput perf-regression gate — measures generation speed against a
+REAL running ``rapid-mlx serve`` and (optionally) fails when it drops below a
+reviewed floor.
+
+This is the perf half of the release gate that the Tier-1 agent smoke
+(``tests/integrations/agent_smoke.sh``) runs on the SAME warm serve it already
+booted for the agentic checks — so there is no second model load. Like
+``evals/coherence_gate.py`` it requires a server to already be listening (it does
+**not** boot one) and reads ``$RAPID_MLX_BASE_URL`` by default.
+
+Why a long, fixed generation
+----------------------------
+A hybrid MoE model's tokens/sec on a SHORT response is dominated by prefill and
+kernel-warmup noise (#284), so a short-prompt measurement is not a reliable
+regression signal. This gate uses a short prompt and a LONG generation
+(``--max-tokens``, default 512) so decode dominates the wall clock; on a fixed
+workload at temperature 0 the end-to-end tokens/sec is a stable proxy for decode
+throughput. A small warmup request precedes the measured one so a cold
+long-context kernel does not skew the number.
+
+Baseline is a reviewed human decision, never automatic
+------------------------------------------------------
+This gate NEVER invents a baseline. With no floor it runs ADVISORY: it prints the
+measured tokens/sec and exits 0, so the first Studio run yields the number to
+review. Enforcement turns on only when a floor is supplied via ``--min-tps`` or
+``$RAPID_MLX_PERF_MIN_TPS`` (set it to the reviewed number, e.g. ~85% of the
+observed warm rate to absorb run-to-run variance).
+
+Usage
+-----
+    # advisory (prints tokens/sec, always exits 0):
+    python evals/perf_gate.py --base-url http://127.0.0.1:8000/v1
+
+    # enforcing (fails if below the reviewed floor):
+    RAPID_MLX_PERF_MIN_TPS=19.5 python evals/perf_gate.py
+
+Exit codes:
+    0 — measured tokens/sec >= floor, OR advisory mode (no floor set)
+    1 — a floor was set and the measured tokens/sec fell below it (regression)
+    2 — no server reachable, or the response lacked usable token accounting
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+
+import httpx
+
+_DEFAULT_BASE_URL = os.environ.get("RAPID_MLX_BASE_URL", "http://127.0.0.1:8000/v1")
+
+# Short prompt, long deterministic generation — decode dominates the wall clock.
+_DEFAULT_PROMPT = (
+    "Write a thorough technical explanation of how a modern CPU memory cache "
+    "works. Cover the L1/L2/L3 hierarchy, cache lines, associativity, write-back "
+    "vs write-through, and eviction policies such as LRU. Be detailed and precise."
+)
+
+
+class InvalidServerResponseError(RuntimeError):
+    """The server replied, but without usable token accounting."""
+
+
+def _server_reachable(base_url: str) -> bool:
+    try:
+        r = httpx.get(f"{base_url.rstrip('/')}/models", timeout=5.0)
+        return r.status_code == 200
+    except Exception:
+        return False
+
+
+def _complete(
+    base_url: str, prompt: str, *, max_tokens: int, timeout: float
+) -> tuple[int, float]:
+    """One non-streaming completion at temperature 0. Returns
+    ``(completion_tokens, elapsed_seconds)``. Raises on a malformed reply."""
+    body = {
+        "model": "default",
+        "messages": [{"role": "user", "content": prompt}],
+        "max_tokens": max_tokens,
+        "temperature": 0.0,
+        "stream": False,
+        # Match the gauntlet's --no-thinking boot: measure answer-token decode,
+        # not thinking-mode expansion.
+        "enable_thinking": False,
+    }
+    start = time.monotonic()
+    resp = httpx.post(
+        f"{base_url.rstrip('/')}/chat/completions", json=body, timeout=timeout
+    )
+    elapsed = time.monotonic() - start
+    resp.raise_for_status()
+    try:
+        data = resp.json()
+        completion_tokens = int(data["usage"]["completion_tokens"])
+    except (ValueError, KeyError, TypeError) as exc:
+        raise InvalidServerResponseError(
+            "response lacked usage.completion_tokens — cannot measure throughput"
+        ) from exc
+    return completion_tokens, elapsed
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--base-url",
+        default=_DEFAULT_BASE_URL,
+        help="OpenAI-compatible base URL (default: $RAPID_MLX_BASE_URL or "
+        "http://127.0.0.1:8000/v1)",
+    )
+    ap.add_argument(
+        "--min-tps",
+        type=float,
+        default=(
+            float(os.environ["RAPID_MLX_PERF_MIN_TPS"])
+            if os.environ.get("RAPID_MLX_PERF_MIN_TPS")
+            else None
+        ),
+        help="reviewed decode tokens/sec floor; below it the gate fails. "
+        "Default: $RAPID_MLX_PERF_MIN_TPS, else advisory-only.",
+    )
+    ap.add_argument(
+        "--max-tokens",
+        type=int,
+        default=512,
+        help="generation length for the measured request (default: 512)",
+    )
+    ap.add_argument(
+        "--timeout", type=float, default=180.0, help="per-request timeout (s)"
+    )
+    args = ap.parse_args()
+
+    base_url = args.base_url
+    print("=" * 60)
+    print("  perf-regression gate (decode throughput)")
+    print(f"  base_url: {base_url}")
+    floor_str = (
+        f"{args.min_tps:.2f} tok/s" if args.min_tps is not None else "(advisory)"
+    )
+    print(f"  floor: {floor_str}   max_tokens: {args.max_tokens}")
+    print("=" * 60)
+
+    if not _server_reachable(base_url):
+        print(
+            f"ERROR: no rapid-mlx server reachable at {base_url}. "
+            "Start one with: rapid-mlx serve <model> --port 8000",
+            file=sys.stderr,
+        )
+        return 2
+
+    try:
+        # Warm the long-context decode path so the measured run is not skewed by
+        # a first-touch kernel compile (the agent smoke already exercised the
+        # serve, so this is usually a no-op).
+        _complete(base_url, "Say ready.", max_tokens=8, timeout=args.timeout)
+        tokens, elapsed = _complete(
+            base_url, _DEFAULT_PROMPT, max_tokens=args.max_tokens, timeout=args.timeout
+        )
+    except (httpx.HTTPError, InvalidServerResponseError) as exc:
+        print(f"ERROR: perf measurement failed: {exc}", file=sys.stderr)
+        return 2
+
+    if tokens <= 0 or elapsed <= 0:
+        print(
+            f"ERROR: unusable measurement (tokens={tokens}, elapsed={elapsed:.3f}s).",
+            file=sys.stderr,
+        )
+        return 2
+
+    tps = tokens / elapsed
+    print(f"  measured: {tokens} tokens in {elapsed:.2f}s -> {tps:.2f} tok/s")
+    print("=" * 60)
+
+    if args.min_tps is None:
+        print(
+            "  ADVISORY: no floor set (RAPID_MLX_PERF_MIN_TPS unset) — record this "
+            "number, review it, then set the floor to enforce."
+        )
+        return 0
+
+    if tps < args.min_tps:
+        print(
+            f"PERF GATE FAILED — {tps:.2f} tok/s is below the reviewed floor of "
+            f"{args.min_tps:.2f} tok/s. The served model regressed; do NOT release.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"  PASS: {tps:.2f} tok/s >= floor {args.min_tps:.2f} tok/s")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/integrations/agent_smoke.sh
+++ b/tests/integrations/agent_smoke.sh
@@ -375,4 +375,38 @@ printf "  aider        %s\n" "$R_AIDER"
 for r in "$R_CLAUDE" "$R_CODEX" "$R_HERMES" "$R_AIDER"; do
   [ "$r" = PASS ] || { echo "RESULT: FAIL — a Tier-1 agent regressed; this blocks the release."; exit 1; }
 done
+
+# ---- release-gate extras (opt-in): coherence + perf on the SAME warm serve ----
+# Runs ONLY when RAPID_MLX_RELEASE_GATE=1 (set by agent-gate.yml on the release
+# path). Unset by default, so this block is skipped and the smoke behaves
+# byte-for-byte as before — the local gauntlet and every other caller are
+# unaffected. It reuses the model that is already loaded and warm from the
+# agentic run above (SERVE_PID still listening), so there is NO second model load.
+#
+# This closes the L2 gap where the release gate proved the agentic path but never
+# checked that the flagship model still gives coherent answers or hasn't regressed
+# in speed — the exact class (#1247/#1234) that shipped as garbage in 0.11.4.
+if [ "${RAPID_MLX_RELEASE_GATE:-0}" = "1" ]; then
+  GATE_PY="$VENV/bin/python"
+  REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+  echo
+  echo "== release-gate: deep coherence (#1247) + perf on warm $ALIAS serve =="
+
+  # Deep coherence golden (#1247) against the warm flagship model. Fail-closed:
+  # a wrong/incoherent golden answer blocks the release.
+  if ! "$GATE_PY" "$REPO_ROOT/evals/coherence_gate.py" --base-url "$B/v1"; then
+    echo "RESULT: FAIL — $ALIAS coherence gate failed; this blocks the release."
+    exit 1
+  fi
+
+  # Decode-throughput perf gate on the warm serve. Advisory (measure + print)
+  # unless a reviewed floor is set via RAPID_MLX_PERF_MIN_TPS — never a fabricated
+  # baseline. perf_gate.py exits non-zero only when a floor is set AND breached.
+  if ! "$GATE_PY" "$REPO_ROOT/evals/perf_gate.py" --base-url "$B/v1"; then
+    echo "RESULT: FAIL — $ALIAS perf regressed below the reviewed floor; blocks the release."
+    exit 1
+  fi
+  echo "== release-gate extras PASSED (coherence + perf) =="
+fi
+
 echo "RESULT: PASS — all four Tier-1 agents verified on $ALIAS."

--- a/tests/integrations/agent_smoke.sh
+++ b/tests/integrations/agent_smoke.sh
@@ -20,6 +20,13 @@
 # config it touches.
 set -uo pipefail
 
+# Resolved HERE, before anything runs: ``seed_repo``/``verify`` cd into the
+# per-agent scratch dirs and that cwd persists (they are functions, not
+# subshells). Resolving a relative ``$BASH_SOURCE`` later — after the cwd has
+# moved — yields an empty REPO_ROOT, and the release gate would then invoke
+# ``/evals/coherence_gate.py`` and fail a run where every check passed.
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
 export PATH="/opt/homebrew/bin:/opt/homebrew/opt/coreutils/libexec/gnubin:$HOME/.local/bin:$PATH"
 VENV="${RAPID_MLX_VENV:-$HOME/rapid-mlx-audit-venv}"
 RMLX="$VENV/bin/rapid-mlx"
@@ -388,7 +395,6 @@ done
 # in speed — the exact class (#1247/#1234) that shipped as garbage in 0.11.4.
 if [ "${RAPID_MLX_RELEASE_GATE:-0}" = "1" ]; then
   GATE_PY="$VENV/bin/python"
-  REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
   echo
   echo "== release-gate: deep coherence (#1247) + perf on warm $ALIAS serve =="
 

--- a/tests/integrations/agent_smoke.sh
+++ b/tests/integrations/agent_smoke.sh
@@ -401,7 +401,11 @@ if [ "${RAPID_MLX_RELEASE_GATE:-0}" = "1" ]; then
 
   # Decode-throughput perf gate on the warm serve. Advisory (measure + print)
   # unless a reviewed floor is set via RAPID_MLX_PERF_MIN_TPS — never a fabricated
-  # baseline. perf_gate.py exits non-zero only when a floor is set AND breached.
+  # baseline. Exit codes: 0 = passed or advisory (INCLUDING a failed measurement
+  # in advisory mode — nothing is being enforced, so a flaky request must not
+  # take the release down); 1 = below the reviewed floor; 2 = a floor IS set but
+  # the run could not be measured, which fails closed because "unable to verify"
+  # is not "verified".
   if ! "$GATE_PY" "$REPO_ROOT/evals/perf_gate.py" --base-url "$B/v1"; then
     echo "RESULT: FAIL — $ALIAS perf regressed below the reviewed floor; blocks the release."
     exit 1


### PR DESCRIPTION
## Why

The Studio (L2) release gate re-verifies the four Tier-1 agents, but it never checked that the flagship model still gives **coherent answers** or hasn't **regressed in speed** — the exact class (#1247 / #1234) that shipped as garbage in 0.11.4. This closes the L2 gap identified in the release-flow blueprint (P1 / "Track A").

## What

Reuses the model `agent_smoke.sh` already boots warm — **no second model load**:

- **`agent_smoke.sh`** — after the four agents pass, an **opt-in** block (`RAPID_MLX_RELEASE_GATE=1`) runs, on the same warm serve:
  - deep coherence golden (`evals/coherence_gate.py`, #1247) — **fail-closed**
  - decode-throughput perf (`evals/perf_gate.py`)
  - Unset by default → the smoke is **byte-for-byte unchanged** for the local gauntlet and every other caller.
- **`evals/perf_gate.py`** (new) — measures decode tok/s on a short-prompt / long-generation workload (decode-dominated; avoids the hybrid short-response TPS noise of #284). **Advisory** by default (prints the number to review); enforces only when a reviewed floor is set via `--min-tps` / `$RAPID_MLX_PERF_MIN_TPS`. **Never invents a baseline.**
- **`agent-gate.yml`** — sets `RAPID_MLX_RELEASE_GATE=1` and threads an optional `perf_min_tps` dispatch input to the floor.

## Rollout

1. Merge → next Studio gate run prints the measured 35B decode tok/s (advisory).
2. Review that number → set `perf_min_tps` (≈85% of it) to turn on enforcement.

## Notes

- Draft: opened as a **post-0.11.5** change so it does not touch the in-flight release gate. Not for merge until 0.11.5 is out + codex review.
- `agent-gate` runs on `workflow_dispatch` / trusted `push` only (self-hosted safety) — never on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)