### PR TITLE
fix: stabilize DeepSeek V4 Flash 0731 serving

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -451,7 +451,7 @@ extend-exclude = [
 # Vendored upstream files — keep formatting identical to the source PR
 # so future syncs produce a clean diff.
 exclude = [
-    "vllm_mlx/models/deepseek_v4.py",
+    "vllm_mlx/models/deepseek_v4*.py",
     "vllm_mlx/models/gemma4_vendored/*.py",
     "vllm_mlx/models/hy_v3.py",
     # Vendored Stability AI MLX Stable Audio 3 (models + scripts). Keep
@@ -492,7 +492,7 @@ ignore = [
 # Vendored from ml-explore/mlx-lm PR #1192 (Blaizzy). Keep as-is so
 # upstream syncs remain a clean diff. Drop this once mlx-lm 0.32+
 # ships native deepseek_v4 support and we delete the vendored copy.
-"vllm_mlx/models/deepseek_v4.py" = ["UP", "B", "SIM", "N", "F", "I", "E"]
+"vllm_mlx/models/deepseek_v4*.py" = ["UP", "B", "SIM", "N", "F", "I", "E"]
 # Vendored from Blaizzy/mlx-vlm 0.6.3 for the Gemma 4 text-only
 # fresh-install regression fix (#1017, closes 0.10.0 dead-end). Keep
 # lint quiet on the copy so upstream diffs stay clean. Sync policy

--- a/tests/test_deepseek_v4_0731.py
+++ b/tests/test_deepseek_v4_0731.py
@@ -28,6 +28,10 @@ def test_alias_points_at_0731_mxfp4_with_ultra_memory_floor():
     assert profile.is_moe is True
     assert profile.min_memory_gb == 192
     assert profile.supports_spec_decode is False
+    assert dict(profile.recommended_sampling or ()) == {
+        "temperature": 1.0,
+        "top_p": 1.0,
+    }
 
 
 def test_official_prompt_shape_bypasses_missing_jinja_template():

--- a/tests/test_deepseek_v4_vendored.py
+++ b/tests/test_deepseek_v4_vendored.py
@@ -187,6 +187,40 @@ def test_hyper_connection_uses_ops_for_non_four_way_multiplicity(monkeypatch):
     assert called["ops"]
 
 
+def test_batch_pooling_cache_empty_batch_is_a_noop():
+    mx = pytest.importorskip("mlx.core")
+
+    from vllm_mlx.models.deepseek_v4_cache import BatchPoolingCache
+
+    cache = BatchPoolingCache(ratio=4, left_padding=[])
+    kv = mx.zeros((0, 2, 3), dtype=mx.float16)
+    gate = mx.zeros((0, 2, 2), dtype=mx.float32)
+    out_kv, out_gate, base = cache.accumulate_windows(kv, gate, 0)
+    mx.eval(out_kv, out_gate, base)
+
+    assert out_kv.shape == kv.shape
+    assert out_gate.shape == gate.shape
+    assert base.shape == (0,)
+
+
+def test_batch_pooling_cache_merge_preserves_projection_dtypes():
+    mx = pytest.importorskip("mlx.core")
+
+    from vllm_mlx.models.deepseek_v4_cache import (
+        BatchPoolingCache,
+        PoolingCache,
+    )
+
+    cache = PoolingCache(ratio=4)
+    cache.buf_kv = mx.ones((1, 4, 3), dtype=mx.float16)
+    cache.buf_gate = mx.ones((1, 4, 2), dtype=mx.float32)
+    cache.remainder = 2
+    merged = BatchPoolingCache.merge([cache])
+
+    assert merged.buf_kv.dtype == mx.float16
+    assert merged.buf_gate.dtype == mx.float32
+
+
 def test_tiny_model_forward_pass():
     """Smoke test the full forward path on a CPU-sized synthetic config.
 

--- a/tests/test_deepseek_v4_vendored.py
+++ b/tests/test_deepseek_v4_vendored.py
@@ -131,6 +131,62 @@ def test_batch_pooling_cache_rejects_nonzero_left_padding():
         cache.prepare(left_padding=[0, 1])
 
 
+def test_extend_mask_preserves_pooled_mask_without_local_mask():
+    mx = pytest.importorskip("mlx.core")
+
+    from vllm_mlx.models.deepseek_v4 import _extend_mask
+
+    pooled = mx.array([[[True, False]]])
+    actual = _extend_mask(None, pooled, N=5)
+    mx.eval(actual)
+
+    assert actual.shape == (1, 1, 1, 5)
+    assert actual.tolist() == [[[[True, True, True, True, False]]]]
+
+
+def test_extend_mask_converts_boolean_pool_mask_to_additive_semantics():
+    mx = pytest.importorskip("mlx.core")
+
+    from vllm_mlx.models.deepseek_v4 import _extend_mask
+
+    local = mx.zeros((1, 1, 1, 3), dtype=mx.float32)
+    pooled = mx.array([[[True, False]]])
+    actual = _extend_mask(local, pooled, N=5)
+    mx.eval(actual)
+
+    assert actual.shape == (1, 1, 1, 5)
+    assert actual[0, 0, 0, 3].item() == 0
+    assert actual[0, 0, 0, 4].item() < -1e30
+
+
+def test_hyper_connection_uses_ops_for_non_four_way_multiplicity(monkeypatch):
+    mx = pytest.importorskip("mlx.core")
+
+    from vllm_mlx.models import deepseek_v4_hyper_connection as hc
+
+    class Config:
+        hc_mult = 2
+        hc_sinkhorn_iters = 1
+        hc_eps = 1e-6
+        rms_norm_eps = 1e-6
+        hidden_size = 4
+
+    layer = hc.HyperConnection(Config())
+    called = {"ops": False}
+    original = hc._hc_ops
+
+    def tracked_ops(*args, **kwargs):
+        called["ops"] = True
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(hc, "_hc_ops", tracked_ops)
+    monkeypatch.setattr(hc.mx, "default_device", lambda: hc.mx.gpu)
+    monkeypatch.setattr(hc.mx.metal, "is_available", lambda: True)
+    layer(mx.zeros((1, 1, 2, 4)))
+
+    assert called["ops"]
+
+
 def test_tiny_model_forward_pass():
     """Smoke test the full forward path on a CPU-sized synthetic config.
 

--- a/tests/test_deepseek_v4_vendored.py
+++ b/tests/test_deepseek_v4_vendored.py
@@ -77,6 +77,60 @@ def test_deepseek_v4_rope_applies_per_row_integer_offsets():
     assert mx.allclose(actual, expected, atol=1e-6).item()
 
 
+def test_deepseek_v4_rope_attention_factor_scales_only_rotary_channels():
+    mx = pytest.importorskip("mlx.core")
+
+    from vllm_mlx.models.deepseek_v4 import DeepseekV4RoPE
+
+    scaling = {
+        "rope_type": "yarn",
+        "factor": 4.0,
+        "original_max_position_embeddings": 4096,
+        "attention_factor": 0.5,
+    }
+    baseline = DeepseekV4RoPE(
+        dims=4,
+        base=10000.0,
+        scaling_config={**scaling, "attention_factor": 1.0},
+    )
+    scaled = DeepseekV4RoPE(dims=4, base=10000.0, scaling_config=scaling)
+    x = mx.arange(16, dtype=mx.float32).reshape(1, 1, 2, 8) / 10
+    expected_input = mx.concatenate([x[..., :4], 0.5 * x[..., 4:]], axis=-1)
+
+    actual = scaled(x, offset=7)
+    expected = baseline(expected_input, offset=7)
+    mx.eval(actual, expected)
+
+    assert mx.allclose(actual, expected, atol=1e-6).item()
+
+
+def test_batch_pooling_cache_restores_neutral_lengths_and_accepts_zero_padding():
+    mx = pytest.importorskip("mlx.core")
+
+    from vllm_mlx.models.deepseek_v4_cache import BatchPoolingCache
+
+    cache = BatchPoolingCache(ratio=4, left_padding=[0, 0])
+    cache.prepare(lengths=[3, 3], left_padding=[0, 0])
+    kv = mx.zeros((2, 3, 4))
+    gate = mx.zeros((2, 3, 2))
+    cache.accumulate_windows(kv, gate, 0)
+
+    restored = BatchPoolingCache.from_state(cache.state, cache.meta_state)
+    assert restored._lengths == [2**31, 2**31]
+    restored.prepare(lengths=[1, 1], left_padding=[0, 0])
+    restored.accumulate_windows(mx.zeros((2, 1, 4)), mx.zeros((2, 1, 2)), 3)
+
+
+def test_batch_pooling_cache_rejects_nonzero_left_padding():
+    pytest.importorskip("mlx.core")
+
+    from vllm_mlx.models.deepseek_v4_cache import BatchPoolingCache
+
+    cache = BatchPoolingCache(ratio=4, left_padding=[0, 0])
+    with pytest.raises(RuntimeError, match="does not support left padding"):
+        cache.prepare(left_padding=[0, 1])
+
+
 def test_tiny_model_forward_pass():
     """Smoke test the full forward path on a CPU-sized synthetic config.
 

--- a/tests/test_deepseek_v4_vendored.py
+++ b/tests/test_deepseek_v4_vendored.py
@@ -60,58 +60,6 @@ def test_register_vendored_archs_is_idempotent():
     assert first is second
 
 
-def test_deepseek_v4_rope_honors_explicit_yarn_attention_factor():
-    """HF's explicit YaRN attention factor scales only rotary channels."""
-    mx = pytest.importorskip("mlx.core")
-
-    from vllm_mlx.models.deepseek_v4 import DeepseekV4RoPE
-
-    scaling = {
-        "rope_type": "yarn",
-        "factor": 4.0,
-        "original_max_position_embeddings": 128,
-    }
-    x = mx.arange(24, dtype=mx.float32).reshape(1, 3, 8) / 10
-    baseline = DeepseekV4RoPE(dims=4, base=10000.0, scaling_config=scaling)
-    explicit_one = DeepseekV4RoPE(
-        dims=4,
-        base=10000.0,
-        scaling_config={**scaling, "attention_factor": 1.0},
-    )
-    explicit_null = DeepseekV4RoPE(
-        dims=4,
-        base=10000.0,
-        scaling_config={**scaling, "attention_factor": None},
-    )
-    explicit_half = DeepseekV4RoPE(
-        dims=4,
-        base=10000.0,
-        scaling_config={**scaling, "attention_factor": 0.5},
-    )
-
-    original_input = mx.array(x)
-    expected_input = mx.concatenate([x[..., :4], 0.5 * x[..., 4:]], axis=-1)
-    baseline_output = baseline(x)
-    one_output = explicit_one(x)
-    null_output = explicit_null(x)
-    half_output = explicit_half(x)
-    expected_half_output = baseline(expected_input)
-    mx.eval(
-        original_input,
-        x,
-        baseline_output,
-        one_output,
-        null_output,
-        half_output,
-        expected_half_output,
-    )
-
-    assert mx.array_equal(x, original_input).item()
-    assert mx.allclose(baseline_output, one_output, atol=1e-6).item()
-    assert mx.allclose(baseline_output, null_output, atol=1e-6).item()
-    assert mx.allclose(half_output, expected_half_output, atol=1e-6).item()
-
-
 def test_deepseek_v4_rope_applies_per_row_integer_offsets():
     """Continuous batches may contain caches at different positions."""
     mx = pytest.importorskip("mlx.core")
@@ -127,18 +75,6 @@ def test_deepseek_v4_rope_applies_per_row_integer_offsets():
     mx.eval(actual, expected)
 
     assert mx.allclose(actual, expected, atol=1e-6).item()
-
-
-def test_deepseek_v4_rope_rejects_offset_batch_mismatch():
-    mx = pytest.importorskip("mlx.core")
-
-    from vllm_mlx.models.deepseek_v4 import DeepseekV4RoPE
-
-    rope = DeepseekV4RoPE(dims=4, base=10000.0)
-    x = mx.zeros((2, 1, 3, 4))
-
-    with pytest.raises(ValueError, match="one offset per batch row"):
-        rope(x, mx.array([3], dtype=mx.int32))
 
 
 def test_tiny_model_forward_pass():
@@ -184,6 +120,52 @@ def test_tiny_model_forward_pass():
     mx.eval(logits, [c.state for c in cache])
 
     assert logits.shape == (1, 8, args.vocab_size)
+
+
+def test_csa_cached_decode_matches_single_prefill():
+    """CSA overlap state must survive an incremental forward boundary."""
+    mx = pytest.importorskip("mlx.core")
+
+    from vllm_mlx.models import deepseek_v4
+
+    args = deepseek_v4.ModelArgs(
+        model_type="deepseek_v4",
+        vocab_size=128,
+        hidden_size=64,
+        num_hidden_layers=4,
+        num_attention_heads=4,
+        num_key_value_heads=1,
+        q_lora_rank=16,
+        o_lora_rank=8,
+        o_groups=2,
+        head_dim=16,
+        qk_rope_head_dim=4,
+        sliding_window=64,
+        compress_ratios=[0, 4, 128, 0],
+        index_n_heads=4,
+        index_head_dim=8,
+        index_topk=4,
+        moe_intermediate_size=16,
+        n_routed_experts=4,
+        n_shared_experts=1,
+        num_experts_per_tok=2,
+        num_hash_layers=1,
+        hc_mult=2,
+        hc_sinkhorn_iters=2,
+    )
+    model = deepseek_v4.Model(args)
+    tokens = mx.array([[i % args.vocab_size for i in range(20)]], dtype=mx.int32)
+
+    full_cache = model.make_cache()
+    full = model(tokens, cache=full_cache)
+
+    split_cache = model.make_cache()
+    prefix = model(tokens[:, :9], cache=split_cache)
+    mx.eval(prefix, [cache.state for cache in split_cache])
+    suffix = model(tokens[:, 9:], cache=split_cache)
+    mx.eval(full, suffix, [cache.state for cache in split_cache])
+
+    assert mx.allclose(full[:, 9:], suffix, rtol=1e-4, atol=1e-4).item()
 
 
 def test_tiny_model_decodes_merged_caches_with_different_offsets():

--- a/tests/test_disk_kv_checkpoint.py
+++ b/tests/test_disk_kv_checkpoint.py
@@ -169,6 +169,32 @@ def test_roundtrip_bf16_kv_cache_byte_identical(root: str):
     assert mx.array_equal(v_in, v_out).item()
 
 
+def test_unregistered_vendored_cache_is_skipped_without_writer_error(
+    root: str, monkeypatch
+):
+    """Custom model caches cannot round-trip through mlx-lm's class registry."""
+
+    class VendoredPoolingCache:
+        state = (mx.array([1]), None)
+        meta_state = ()
+
+    def unexpected_writer(*_args, **_kwargs):
+        raise AssertionError("unsupported cache reached save_prompt_cache")
+
+    import mlx_lm.models.cache as mlx_cache
+
+    monkeypatch.setattr(mlx_cache, "save_prompt_cache", unexpected_writer)
+    path = _dkc.write_checkpoint(
+        [VendoredPoolingCache()],
+        root=root,
+        req_hash="vendored-cache",
+        token_offset=256,
+    )
+
+    assert path is None
+    assert not Path(root).exists()
+
+
 def test_roundtrip_int4_quantized_kv_cache(root: str):
     """Write a QuantizedKVCache to disk, reload, assert state matches.
 

--- a/tests/test_model_auto_config.py
+++ b/tests/test_model_auto_config.py
@@ -197,6 +197,14 @@ class TestDetectModelConfig:
         assert config.is_hybrid is False
         assert config.supports_spec_decode is True
 
+    def test_deepseek_v4_flash_0731_direct_path(self):
+        """A local 0731 snapshot must retain the alias' dedicated wire format."""
+        cfg = detect_model_config("/Volumes/models/DeepSeek-V4-Flash-0731-MXFP4-MLX")
+        assert cfg.tool_call_parser == "deepseek_v4_0731"
+        assert cfg.reasoning_parser == "deepseek_r1"
+        assert cfg.is_hybrid is False
+        assert cfg.supports_spec_decode is False
+
     # DeepSeek-Coder-V2 / V2-Lite — despite the ``V2`` version tag these
     # checkpoints ship the DeepSeek-V3 chat template and emit the V3
     # fenced-JSON tool-call body, so they must route to the dedicated
@@ -368,6 +376,7 @@ class TestDetectModelConfig:
         # Granite 4 does NOT emit <think>...</think> reasoning. Setting
         # a reasoning parser would route all output into reasoning_content.
         assert cfg.reasoning_parser is None
+
         assert cfg.is_hybrid is True
         assert cfg.supports_spec_decode is False
 

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -413,7 +413,11 @@
     "is_hybrid": false,
     "is_moe": true,
     "supports_spec_decode": false,
-    "min_memory_gb": 192
+    "min_memory_gb": 192,
+    "recommended_sampling": {
+      "temperature": 1.0,
+      "top_p": 1.0
+    }
   },
   "qwen3-0.6b-4bit": {
     "hf_path": "mlx-community/Qwen3-0.6B-4bit",

--- a/vllm_mlx/model_auto_config.py
+++ b/vllm_mlx/model_auto_config.py
@@ -78,6 +78,19 @@ _MODEL_PATTERNS: list[tuple[re.Pattern, ModelConfig]] = [
     # (the lfm2*/lfm2.5* entries carry ``tool_call_parser="lfm"``), per
     # the "do NOT add new regex entries here" migration rule above. New
     # LFM variants should be added to aliases.json, not this table.
+    # DeepSeek V4 Flash 0731 ships a dedicated DSML tool wire format and
+    # pre-fills ``<think>`` in its Python chat encoder.  Keep this before the
+    # generic V4 rule so direct HF paths and local snapshot directories get
+    # the same parsers/capability gates as the named alias.
+    (
+        re.compile(r"deepseek.*v4.*flash.*0731", re.IGNORECASE),
+        ModelConfig(
+            tool_call_parser="deepseek_v4_0731",
+            reasoning_parser="deepseek_r1",
+            is_hybrid=False,
+            supports_spec_decode=False,
+        ),
+    ),
     # DeepSeek V4 / V4-Flash — sparse MoE with sliding-window attention
     # (RotatingKVCache). Pure-attention so spec decode is safe; tool
     # parser inherits the standard DeepSeek format. Upstream chat

--- a/vllm_mlx/models/deepseek_v4.py
+++ b/vllm_mlx/models/deepseek_v4.py
@@ -200,11 +200,15 @@ class DeepseekV4RoPE(nn.Module):
         super().__init__()
         self.dims = dims
         self.freq_scale = freq_scale
+        self.attention_factor = 1.0
 
         inv_freq = 1.0 / (base ** (mx.arange(0, dims, 2, dtype=mx.float32) / dims))
         rope_type = None
         if scaling_config is not None:
             rope_type = scaling_config.get("type") or scaling_config.get("rope_type")
+            attention_factor = scaling_config.get("attention_factor")
+            if attention_factor is not None:
+                self.attention_factor = float(attention_factor)
 
         if rope_type in ("yarn", "deepseek_yarn"):
             factor = scaling_config["factor"]
@@ -261,6 +265,15 @@ class DeepseekV4RoPE(nn.Module):
         head_dim = x.shape[-1]
         freqs = self._get_freqs(head_dim, inverse)
         offset = offset // self.freq_scale if self.freq_scale != 1 else offset
+        if self.attention_factor != 1.0:
+            # NOPE channels precede the rotary channels in DeepSeek-V4.
+            x = mx.concatenate(
+                [
+                    x[..., : -self.dims],
+                    self.attention_factor * x[..., -self.dims :],
+                ],
+                axis=-1,
+            )
         return mx.fast.rope(
             x,
             head_dim,
@@ -515,7 +528,6 @@ class DeepseekV4MoE(nn.Module):
 
 
 class Compressor(nn.Module):
-
     def __init__(self, config: ModelArgs, compress_ratio: int, head_dim: int):
         super().__init__()
         self.compress_ratio = compress_ratio
@@ -631,7 +643,9 @@ class Indexer(nn.Module):
         pmask = (
             pool_cache.make_mask(L, offset)
             if pool_cache is not None
-            else _pooled_mask(L, pooled.shape[1], self.compressor.compress_ratio, offset)
+            else _pooled_mask(
+                L, pooled.shape[1], self.compressor.compress_ratio, offset
+            )
         )
         if pmask is not None:
             scores = mx.where(

--- a/vllm_mlx/models/deepseek_v4.py
+++ b/vllm_mlx/models/deepseek_v4.py
@@ -1,19 +1,20 @@
 # Copyright © 2026 Apple Inc.
+# Vendored from spicyneuron/mlx-lm@df50b7a3 (_ds4 branch), including the
+# DeepSeek V4 correctness series through 72c51e3. Keep this file and the
+# deepseek_v4_{cache,hyper_connection,switch}.py companions in sync.
 
 import math
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional, Tuple
+from functools import partial
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import mlx.core as mx
 import mlx.nn as nn
 from mlx.nn.layers.distributed import shard_inplace, shard_linear, sum_gradients
 from mlx.utils import tree_flatten
 
-# MUST install the MLX hardware-compat shim BEFORE any `from mlx_lm.*` import.
-# `mlx_lm/__init__.py` re-exports from `mlx_lm.generate`, which captures
-# `mx.new_thread_local_stream(mx.default_device())` at module-import time; on
-# M5 single-stream GPUs that stream is unusable (#404). The shim is
-# idempotent and a no-op on hardware where the original API works.
+# MUST run before any mlx_lm import: mlx_lm's package initializer captures a
+# thread-local MLX stream, which is unusable on M5 single-stream GPUs (#404).
 from .. import _mlx_compat as _mlx_compat
 
 _mlx_compat.install()
@@ -22,11 +23,14 @@ from mlx_lm.models.base import (
     BaseModelArgs,
     create_attention_mask,
     scaled_dot_product_attention,
-)  # noqa: E402
-from mlx_lm.models.cache import BatchRotatingKVCache, RotatingKVCache  # noqa: E402
-from mlx_lm.models.mla import MultiLinear  # noqa: E402
-from mlx_lm.models.pipeline import PipelineMixin  # noqa: E402
-from mlx_lm.models.switch_layers import SwitchGLU  # noqa: E402
+)
+from mlx_lm.models.cache import CacheList, RotatingKVCache
+from mlx_lm.models.mla import MultiLinear
+from mlx_lm.models.pipeline import PipelineMixin
+
+from .deepseek_v4_cache import DeepseekV4PoolingCache, PoolingCache
+from .deepseek_v4_hyper_connection import HyperConnection, HyperHead, hc_expand
+from .deepseek_v4_switch import FusedSwitchGLU
 
 
 @dataclass
@@ -138,7 +142,9 @@ def _expert_select(
     logits = logits.astype(mx.float32)
     scores = _score_func(logits, scoring_func)
     biased = scores + e_score_correction_bias
-    inds = mx.argpartition(-biased, kth=top_k - 1, axis=-1)[..., :top_k]
+    inds = mx.argpartition(-biased, kth=top_k - 1, axis=-1)[..., :top_k].astype(
+        mx.int32
+    )
     weights = mx.take_along_axis(scores, inds, axis=-1)
     if scoring_func != "softmax" and norm_topk_prob:
         weights = weights / (weights.sum(axis=-1, keepdims=True) + 1e-20)
@@ -189,21 +195,16 @@ class DeepseekV4RoPE(nn.Module):
         base: float,
         scaling_config: Optional[Dict] = None,
         max_position_embeddings: int = 1048576,
+        freq_scale: int = 1,
     ):
         super().__init__()
         self.dims = dims
-        # HF YaRN configs may explicitly override the attention-amplitude
-        # scale. Keep Rapid's existing no-override behavior (1.0) when the
-        # field is absent or null.
-        self.attention_factor = 1.0
+        self.freq_scale = freq_scale
 
         inv_freq = 1.0 / (base ** (mx.arange(0, dims, 2, dtype=mx.float32) / dims))
         rope_type = None
         if scaling_config is not None:
             rope_type = scaling_config.get("type") or scaling_config.get("rope_type")
-            attention_factor = scaling_config.get("attention_factor")
-            if attention_factor is not None:
-                self.attention_factor = attention_factor
 
         if rope_type in ("yarn", "deepseek_yarn"):
             factor = scaling_config["factor"]
@@ -237,12 +238,12 @@ class DeepseekV4RoPE(nn.Module):
         self._freqs = 1.0 / inv_freq
         self._freqs_cache = {}
 
-    def _get_freqs(self, head_dim: int, inverse: bool, freq_scale: int):
-        key = (head_dim, inverse, freq_scale)
+    def _get_freqs(self, head_dim: int, inverse: bool):
+        key = (head_dim, inverse)
         if key not in self._freqs_cache:
             f = self._freqs
-            if freq_scale != 1:
-                f = f / freq_scale
+            if self.freq_scale != 1:
+                f = f / self.freq_scale
             if inverse:
                 f = -f
             nope_pairs = (head_dim - self.dims) // 2
@@ -256,37 +257,10 @@ class DeepseekV4RoPE(nn.Module):
         x: mx.array,
         offset: Any = 0,
         inverse: bool = False,
-        freq_scale: int = 1,
     ) -> mx.array:
         head_dim = x.shape[-1]
-        freqs = self._get_freqs(head_dim, inverse, freq_scale)
-        if isinstance(offset, mx.array) and offset.ndim > 0:
-            offsets = [int(value) for value in offset.tolist()]
-            if len(offsets) != x.shape[0]:
-                raise ValueError(
-                    "DeepSeek-V4 RoPE needs one offset per batch row; "
-                    f"got {len(offsets)} offsets for batch size {x.shape[0]}"
-                )
-            return mx.concatenate(
-                [
-                    self(
-                        x[index : index + 1],
-                        row_offset,
-                        inverse=inverse,
-                        freq_scale=freq_scale,
-                    )
-                    for index, row_offset in enumerate(offsets)
-                ],
-                axis=0,
-            )
-        offset = offset // freq_scale if freq_scale != 1 else offset
-        if self.attention_factor != 1.0:
-            x = x[...]
-            # DeepSeek-V4 lays out the non-rotary (NOPE) channels first and
-            # the rotary channels last. ``_get_freqs`` mirrors that layout by
-            # prepending infinite frequencies for the NOPE pairs, so apply the
-            # YaRN amplitude override to the trailing rotary slice.
-            x[..., -self.dims :] = self.attention_factor * x[..., -self.dims :]
+        freqs = self._get_freqs(head_dim, inverse)
+        offset = offset // self.freq_scale if self.freq_scale != 1 else offset
         return mx.fast.rope(
             x,
             head_dim,
@@ -304,6 +278,97 @@ def _apply_score_mask(scores: mx.array, mask: Optional[mx.array]) -> mx.array:
     if mask.dtype == mx.bool_:
         return mx.where(mask, scores, mx.finfo(scores.dtype).min)
     return scores + mask.astype(scores.dtype)
+
+
+def _extend_mask(mask: Optional[mx.array], pool_mask: Optional[mx.array], N: int):
+    if mask is None:
+        return None
+
+    if mask.ndim == 2:
+        mask = mask[None, None]
+    B, H, L, S = mask.shape
+
+    if pool_mask is None:
+        pool_mask = mx.ones((B, H, L, N - S), dtype=mx.bool_)
+    elif pool_mask.ndim == 2:
+        pool_mask = mx.broadcast_to(pool_mask, (B, H, L, N - S))
+    elif pool_mask.ndim == 3:
+        pool_mask = mx.broadcast_to(pool_mask[:, None], (B, H, L, N - S))
+
+    full_mask = mx.concatenate([mask, pool_mask], axis=-1)
+
+    return full_mask
+
+
+def _align_local_mask(mask: Optional[mx.array], local_len: int):
+    if mask is None:
+        return None
+
+    current_len = mask.shape[-1]
+    if current_len == local_len:
+        return mask
+    if current_len > local_len:
+        return mask[..., -local_len:]
+
+    pad_shape = (*mask.shape[:-1], local_len - current_len)
+    if mask.dtype == mx.bool_:
+        pad = mx.ones(pad_shape, dtype=mask.dtype)
+    else:
+        pad = mx.zeros(pad_shape, dtype=mask.dtype)
+    return mx.concatenate([pad, mask], axis=-1)
+
+
+def _pooled_mask(
+    L: int,
+    pooled_len: int,
+    compress_ratio: int,
+    offset: Union[int, mx.array] = 0,
+):
+    pool_idx = mx.arange(pooled_len)
+    query_idx = mx.arange(1, L + 1)
+
+    if isinstance(offset, mx.array) and offset.ndim > 0:
+        query_idx = offset[:, None] + query_idx[None]
+        return pool_idx[None, None] < query_idx[..., None] // compress_ratio
+
+    query_idx = offset + query_idx
+    return pool_idx[None] < query_idx[:, None] // compress_ratio
+
+
+@partial(mx.compile, shapeless=True)
+def _simple_compress_kv(kv, gate, ape, head_dim):
+    weights = mx.softmax(gate.astype(mx.float32) + ape, axis=-2)
+    weights = weights.astype(kv.dtype)
+    return (kv * weights).sum(axis=-2)
+
+
+@mx.compile
+def _overlap_compress_kv(kv, gate, ape, head_dim, prior_kv, prior_gate):
+    D = kv.shape[-1]
+
+    # Overlap gates are stored before positional bias; add APE to both paths.
+    gate = gate + ape.astype(gate.dtype)
+    prior_gate = prior_gate + ape[:, : D // 2].astype(prior_gate.dtype)
+
+    kv_a, kv_b = mx.split(kv, 2, axis=-1)
+    kv_a = mx.concatenate([prior_kv[:, None], kv_a[:, :-1]], axis=1)
+    kv = mx.concatenate([kv_a, kv_b], axis=2)
+
+    gate_a, gate_b = mx.split(gate, 2, axis=-1)
+    gate_a = mx.concatenate([prior_gate[:, None], gate_a[:, :-1]], axis=1)
+    gate = mx.concatenate([gate_a, gate_b], axis=2)
+
+    weights = mx.softmax(gate, axis=-2, precise=True)
+    return (kv * weights).sum(axis=-2)
+
+
+@partial(mx.compile, shapeless=True)
+def _split_softmax(log_normalizer, logits_a, logits_b, sinks=None):
+    if sinks is not None:
+        log_normalizer = mx.logaddexp(log_normalizer, sinks)
+    weights_a = mx.exp(logits_a - log_normalizer)
+    weights_b = mx.exp(logits_b - log_normalizer)
+    return weights_a, weights_b
 
 
 def _sparse_pooled_attention(
@@ -327,485 +392,28 @@ def _sparse_pooled_attention(
     q_scaled = q * scale
     local_scores = q_scaled @ local_kv.swapaxes(-1, -2)
     local_scores = _apply_score_mask(local_scores, local_mask)
+    normalizer = mx.logsumexp(local_scores, -1, keepdims=True)
 
-    # Pooled scores via matmul instead of broadcast multiply + sum.
-    # The element-wise path creates a (B, H, L, topk, D) intermediate which
-    # at 4k context with H=64, topk=512, D=512 is ~137 GB.
-    # Matmul (B*L, H, D) @ (B*L, D, topk) → (B*L, H, topk) uses ~0.25 GB.
-    pooled_sq = pooled.squeeze(1)  # (B, L, topk, D)
-    q_bl = q_scaled.transpose(0, 2, 1, 3)  # (B, L, H, D)
-    pooled_scores = q_bl @ pooled_sq.swapaxes(-1, -2)  # (B, L, H, topk)
-    pooled_scores = pooled_scores.transpose(0, 2, 1, 3)  # (B, H, L, topk)
+    pooled_sq = pooled.squeeze(1)
+    q_bl = q_scaled.transpose(0, 2, 1, 3)
+    pooled_scores = q_bl @ pooled_sq.swapaxes(-1, -2)
+    pooled_scores = pooled_scores.transpose(0, 2, 1, 3)
     pooled_scores = _apply_score_mask(pooled_scores, pooled_mask)
+    normalizer = mx.logaddexp(
+        normalizer, mx.logsumexp(pooled_scores, -1, keepdims=True)
+    )
 
-    scores = mx.concatenate([local_scores, pooled_scores], axis=-1)
-    sink_offset = 0
-    if sinks is not None:
-        sink_offset = 1
-        sink_scores = mx.broadcast_to(sinks.reshape(1, H, 1, 1), (B, H, L, 1))
-        scores = mx.concatenate([sink_scores.astype(scores.dtype), scores], axis=-1)
-
-    weights = mx.softmax(scores, axis=-1, precise=True)
-    local_len = local_kv.shape[2]
-    local_weights = weights[..., sink_offset : sink_offset + local_len]
-    pooled_weights = weights[..., sink_offset + local_len :]
+    local_weights, pooled_weights = _split_softmax(
+        normalizer,
+        local_scores,
+        pooled_scores,
+        sinks[None, :, None, None] if sinks is not None else None,
+    )
 
     out = local_weights @ local_kv
-    # Same matmul trick for weighted sum: (B*L, H, topk) @ (B*L, topk, D)
-    pw_bl = pooled_weights.transpose(0, 2, 1, 3)  # (B, L, H, topk)
-    out = out + (pw_bl @ pooled_sq).transpose(0, 2, 1, 3)  # (B, H, L, D)
+    pw_bl = pooled_weights.transpose(0, 2, 1, 3)
+    out = out + (pw_bl @ pooled_sq).transpose(0, 2, 1, 3)
     return out.astype(q.dtype)
-
-
-@mx.compile
-def _hc_split_sinkhorn_ops(
-    mixes: mx.array,
-    scale: mx.array,
-    base: mx.array,
-    hc_mult: int,
-    sinkhorn_iters: int,
-    eps: float,
-) -> Tuple[mx.array, mx.array, mx.array]:
-    mixes = mixes.astype(mx.float32)
-    scale = scale.astype(mx.float32)
-    base = base.astype(mx.float32)
-    pre_scale, post_scale, comb_scale = scale[0], scale[1], scale[2]
-
-    pre = mx.sigmoid(mixes[..., :hc_mult] * pre_scale + base[:hc_mult]) + eps
-    post = 2 * mx.sigmoid(
-        mixes[..., hc_mult : 2 * hc_mult] * post_scale + base[hc_mult : 2 * hc_mult]
-    )
-    comb = mixes[..., 2 * hc_mult :].reshape(
-        *mixes.shape[:-1], hc_mult, hc_mult
-    ) * comb_scale + base[2 * hc_mult :].reshape(hc_mult, hc_mult)
-    comb = mx.softmax(comb, axis=-1, precise=True) + eps
-    comb = comb / (comb.sum(axis=-2, keepdims=True) + eps)
-    for _ in range(max(sinkhorn_iters - 1, 0)):
-        comb = comb / (comb.sum(axis=-1, keepdims=True) + eps)
-        comb = comb / (comb.sum(axis=-2, keepdims=True) + eps)
-    return pre, post, comb
-
-
-def _make_hc_split_sinkhorn_kernel():
-    if mx.default_device() != mx.gpu or not mx.metal.is_available():
-        return None
-
-    source = """
-        uint idx = thread_position_in_grid.x;
-        constexpr int MIX  = (2 + HC) * HC;
-        constexpr int BASE = 2 * HC;
-
-        const device float* mix = (const device float*)mixes + idx * MIX;
-        device float* pre_out   = (device float*)pre  + idx * HC;
-        device float* post_out  = (device float*)post + idx * HC;
-        device float* comb_out  = (device float*)comb + idx * HC * HC;
-
-        const float pre_scale  = scale[0];
-        const float post_scale = scale[1];
-        const float comb_scale = scale[2];
-        const float epsv       = eps[0];
-
-        // Pre-sigmoid
-        {
-            float4 z = *(const device float4*)mix * pre_scale
-                     + *(const device float4*)base;
-            *(device float4*)pre_out = 1.0f / (1.0f + metal::fast::exp(-z)) + epsv;
-        }
-
-        // Post-sigmoid
-        {
-            float4 z = *(const device float4*)(mix + HC) * post_scale
-                     + *(const device float4*)(base + HC);
-            *(device float4*)post_out = 2.0f * 1.0f / (1.0f + metal::fast::exp(-z));
-        }
-
-        // Comb: four float4 loads — all independent, GPU issues in parallel
-        float4 v0 = *(const device float4*)(mix  + BASE     ) * comb_scale + *(const device float4*)(base + BASE     );
-        float4 v1 = *(const device float4*)(mix  + BASE +  4) * comb_scale + *(const device float4*)(base + BASE +  4);
-        float4 v2 = *(const device float4*)(mix  + BASE +  8) * comb_scale + *(const device float4*)(base + BASE +  8);
-        float4 v3 = *(const device float4*)(mix  + BASE + 12) * comb_scale + *(const device float4*)(base + BASE + 12);
-
-        // Per-row stable softmax: compute all maxes before any exp
-        float m0 = metal::max(metal::max(v0.x, v0.y), metal::max(v0.z, v0.w));
-        float m1 = metal::max(metal::max(v1.x, v1.y), metal::max(v1.z, v1.w));
-        float m2 = metal::max(metal::max(v2.x, v2.y), metal::max(v2.z, v2.w));
-        float m3 = metal::max(metal::max(v3.x, v3.y), metal::max(v3.z, v3.w));
-
-        float4 e0 = metal::fast::exp(v0 - m0);
-        float4 e1 = metal::fast::exp(v1 - m1);
-        float4 e2 = metal::fast::exp(v2 - m2);
-        float4 e3 = metal::fast::exp(v3 - m3);
-
-        // Explicit adds instead of dot(e, 1) — avoids unnecessary fmul
-        float4 r0 = e0 * 1.0f / (e0.x + e0.y + e0.z + e0.w) + epsv;
-        float4 r1 = e1 * 1.0f / (e1.x + e1.y + e1.z + e1.w) + epsv;
-        float4 r2 = e2 * 1.0f / (e2.x + e2.y + e2.z + e2.w) + epsv;
-        float4 r3 = e3 * 1.0f / (e3.x + e3.y + e3.z + e3.w) + epsv;
-
-        // Initial column normalization
-        float4 col = 1.0f / (r0 + r1 + r2 + r3 + epsv);
-        r0 *= col; r1 *= col; r2 *= col; r3 *= col;
-
-        // Sinkhorn iterations
-        for (int iter = 1; iter < ITERS; ++iter) {
-            r0 *= 1.0f / (r0.x + r0.y + r0.z + r0.w + epsv);
-            r1 *= 1.0f / (r1.x + r1.y + r1.z + r1.w + epsv);
-            r2 *= 1.0f / (r2.x + r2.y + r2.z + r2.w + epsv);
-            r3 *= 1.0f / (r3.x + r3.y + r3.z + r3.w + epsv);
-            col = 1.0f / (r0 + r1 + r2 + r3 + epsv);
-            r0 *= col; r1 *= col; r2 *= col; r3 *= col;
-        }
-
-        // Write comb output (four aligned 128-bit stores)
-        *(device float4*)(comb_out)      = r0;
-        *(device float4*)(comb_out +  4) = r1;
-        *(device float4*)(comb_out +  8) = r2;
-        *(device float4*)(comb_out + 12) = r3;
-    """
-
-    return mx.fast.metal_kernel(
-        name="deepseek_v4_hc_split_sinkhorn",
-        input_names=["mixes", "scale", "base", "eps"],
-        output_names=["pre", "post", "comb"],
-        source=source,
-    )
-
-
-_hc_split_sinkhorn_kernel = _make_hc_split_sinkhorn_kernel()
-
-
-def hc_split_sinkhorn(
-    mixes: mx.array,
-    scale: mx.array,
-    base: mx.array,
-    hc_mult: int,
-    sinkhorn_iters: int,
-    eps: float,
-) -> Tuple[mx.array, mx.array, mx.array]:
-    if _hc_split_sinkhorn_kernel is None or hc_mult != 4:
-        return _hc_split_sinkhorn_ops(mixes, scale, base, hc_mult, sinkhorn_iters, eps)
-
-    if not isinstance(eps, mx.array):
-        eps = mx.array([eps], dtype=mx.float32)
-    n_rows = mixes.size // ((2 + hc_mult) * hc_mult)
-    return _hc_split_sinkhorn_kernel(
-        inputs=[mixes, scale, base, eps],
-        template=[("HC", hc_mult), ("ITERS", sinkhorn_iters)],
-        grid=(n_rows, 1, 1),
-        threadgroup=(256, 1, 1),
-        output_shapes=[
-            (*mixes.shape[:-1], hc_mult),
-            (*mixes.shape[:-1], hc_mult),
-            (*mixes.shape[:-1], hc_mult, hc_mult),
-        ],
-        output_dtypes=[mx.float32, mx.float32, mx.float32],
-    )
-
-
-@mx.compile
-def _hc_collapse_op(pre: mx.array, x: mx.array) -> mx.array:
-    return (pre[..., None] * x.astype(mx.float32)).sum(axis=2).astype(x.dtype)
-
-
-def _make_hc_sinkhorn_collapse_kernel():
-    """Fused sinkhorn + collapse: eliminates one dispatch per HC cycle.
-
-    1. BRANCHLESS SINKHORN: all 32 lanes in simd group 0 execute identical
-       instructions. Lanes >= HC use multiplicative mask (active=0) instead
-       of divergent branches — eliminates SIMD serialization.
-    2. PARALLEL SINKHORN: lanes 0-3 each own one comb row. Column norm
-       via simd_sum() — free SIMD shuffle.
-    3. NATIVE bfloat4 LOADS: single 64-bit load yields 4 bfloat16 values;
-       cast to float4 is a free hardware conversion.
-    4. FMA CHAINS: collapse uses fused multiply-add for 3 of 4 terms.
-    """
-    if mx.default_device() != mx.gpu or not mx.metal.is_available():
-        return None
-
-    source = """
-        uint tid  = thread_position_in_threadgroup.x;
-        uint row  = threadgroup_position_in_grid.x;
-        uint lane = tid % 32;
-        uint sg   = tid / 32;
-
-        constexpr int MIX      = (2 + HC) * HC;
-        constexpr int BASE_OFF = 2 * HC;
-
-        const device float* mix      = (const device float*)mixes + row * MIX;
-        device float*       post_out = (device float*)post + row * HC;
-        device float*       comb_out = (device float*)comb + row * HC * HC;
-
-        threadgroup float pre_shared[HC];
-
-        // ================================================================
-        // PHASE 1: Branchless sinkhorn on simd group 0
-        //   All 32 lanes execute identical instructions. Lanes >= HC
-        //   compute on clamped indices but multiply by active=0, so they
-        //   contribute zero to simd_sum. No divergent branches in the loop.
-        // ================================================================
-        if (sg == 0) {
-            const float pre_scale  = scale[0];
-            const float post_scale = scale[1];
-            const float comb_scale = scale[2];
-            const float epsv       = eps[0];
-
-            const float active = (lane < (uint)HC) ? 1.0f : 0.0f;
-            const uint  llane  = metal::min(lane, (uint)(HC - 1));
-
-            // Pre/post sigmoids: all lanes compute, only active lanes write
-            float pre_z  = mix[llane]      * pre_scale  + base[llane];
-            float post_z = mix[HC + llane] * post_scale + base[HC + llane];
-            float pre_v  = 1.0f / (1.0f + metal::fast::exp(-pre_z)) + epsv;
-            float post_v = 2.0f / (1.0f + metal::fast::exp(-post_z));
-
-            if (lane < (uint)HC) {
-                pre_shared[lane] = pre_v;
-                post_out[lane]   = post_v;
-            }
-
-            // Comb softmax: load + mask. Inactive lanes load row 0 (safe)
-            // but multiply by active=0 so they hold zeros.
-            float4 v = (*(const device float4*)(mix  + BASE_OFF + llane * HC)
-                            * comb_scale
-                      + *(const device float4*)(base + BASE_OFF + llane * HC))
-                     * active;
-
-            float row_max = metal::max(metal::max(v.x, v.y),
-                                       metal::max(v.z, v.w));
-            float4 e = metal::fast::exp(v - row_max) * active;
-            float4 r = e * (1.0f / (e.x + e.y + e.z + e.w + epsv))
-                     + epsv * active;
-
-            // Initial column normalization
-            float4 col_inv = 1.0f / (float4(
-                simd_sum(r.x), simd_sum(r.y),
-                simd_sum(r.z), simd_sum(r.w)
-            ) + epsv);
-            r *= col_inv;
-
-            // Sinkhorn iterations: zero branches in the loop body
-            for (int iter = 1; iter < ITERS; ++iter) {
-                // Row norm + re-clamp inactive lanes
-                r *= (1.0f / (r.x + r.y + r.z + r.w + epsv)) * active;
-
-                // Col norm via simd_sum
-                col_inv = 1.0f / (float4(
-                    simd_sum(r.x), simd_sum(r.y),
-                    simd_sum(r.z), simd_sum(r.w)
-                ) + epsv);
-                r *= col_inv;
-            }
-
-            if (lane < (uint)HC) {
-                *(device float4*)(comb_out + lane * HC) = r;
-            }
-        }
-
-        threadgroup_barrier(mem_flags::mem_threadgroup);
-
-        // ================================================================
-        // PHASE 2: Collapse — all 256 threads, native bfloat4 vectorized
-        // ================================================================
-        const float p0 = pre_shared[0];
-        const float p1 = pre_shared[1];
-        const float p2 = pre_shared[2];
-        const float p3 = pre_shared[3];
-
-        const device bfloat16_t* x_row  = (const device bfloat16_t*)x_in
-                                         + row * (HC * D);
-        device bfloat16_t*       out_row = (device bfloat16_t*)collapsed
-                                         + row * D;
-
-        // Native bfloat4 pointers: single 64-bit load per vector
-        using bf4 = vec<bfloat16_t, 4>;
-        const device bf4* x_row0 = (const device bf4*)(x_row + 0*D);
-        const device bf4* x_row1 = (const device bf4*)(x_row + 1*D);
-        const device bf4* x_row2 = (const device bf4*)(x_row + 2*D);
-        const device bf4* x_row3 = (const device bf4*)(x_row + 3*D);
-        device bf4*       out4   = (device bf4*)out_row;
-
-        constexpr uint D4 = (uint)D / 4;
-
-        for (uint d4 = tid; d4 < D4; d4 += 256) {
-            float4 x0 = float4(x_row0[d4]);
-            float4 x1 = float4(x_row1[d4]);
-            float4 x2 = float4(x_row2[d4]);
-            float4 x3 = float4(x_row3[d4]);
-
-            float4 result = fma(float4(p0), x0,
-                            fma(float4(p1), x1,
-                            fma(float4(p2), x2, float4(p3) * x3)));
-
-            out4[d4] = bf4(result);
-        }
-
-        // Scalar tail for D not divisible by 4
-        #if (D % 4) != 0
-        for (uint d = D4 * 4 + tid; d < (uint)D; d += 256) {
-            float val = p0*(float)x_row[0*D+d] + p1*(float)x_row[1*D+d]
-                      + p2*(float)x_row[2*D+d] + p3*(float)x_row[3*D+d];
-            out_row[d] = (bfloat16_t)val;
-        }
-        #endif
-    """
-
-    return mx.fast.metal_kernel(
-        name="deepseek_v4_hc_sinkhorn_collapse",
-        input_names=["mixes", "scale", "base", "eps", "x_in"],
-        output_names=["post", "comb", "collapsed"],
-        source=source,
-    )
-
-
-_hc_sinkhorn_collapse_kernel = _make_hc_sinkhorn_collapse_kernel()
-
-
-@mx.compile
-def _hc_expand_op(
-    post: mx.array,
-    block_out: mx.array,
-    comb: mx.array,
-    residual: mx.array,
-) -> mx.array:
-    y = post[..., None] * block_out[:, :, None, :].astype(mx.float32)
-    y = y + mx.matmul(comb.swapaxes(-1, -2), residual.astype(mx.float32))
-    return y.astype(block_out.dtype)
-
-
-@mx.compile
-def _rms_rsqrt(flat: mx.array, eps: float) -> mx.array:
-    return mx.rsqrt((flat * flat).mean(axis=-1, keepdims=True) + eps)
-
-
-@mx.compile
-def _hc_mixes(flat: mx.array, fn_T: mx.array, norm_eps: float) -> mx.array:
-    """Fused RMS-rsqrt + matmul + scale into single compiled graph."""
-    rsqrt = mx.rsqrt((flat * flat).mean(axis=-1, keepdims=True) + norm_eps)
-    return (flat @ fn_T) * rsqrt
-
-
-class HyperConnection(nn.Module):
-    def __init__(self, config: ModelArgs):
-        super().__init__()
-        self.hc_mult = config.hc_mult
-        self.sinkhorn_iters = config.hc_sinkhorn_iters
-        self.hc_eps = config.hc_eps
-        self._hc_eps = (mx.array([config.hc_eps], dtype=mx.float32),)
-        self.norm_eps = config.rms_norm_eps
-        mix = (2 + self.hc_mult) * self.hc_mult
-        self.fn = mx.zeros((mix, self.hc_mult * config.hidden_size), dtype=mx.float32)
-        self.base = mx.zeros((mix,), dtype=mx.float32)
-        self.scale = mx.ones((3,), dtype=mx.float32)
-        self._fn_T = None
-
-    def compute_weights(self, x: mx.array):
-        B, L, H, D = x.shape
-        flat = x.reshape(B, L, H * D).astype(mx.float32)
-        if self._fn_T is None:
-            self._fn_T = self.fn.T
-        if self.training:
-            rsqrt = _rms_rsqrt(flat, self.norm_eps)
-            mixes = (flat @ self._fn_T) * rsqrt
-        else:
-            mixes = _hc_mixes(flat, self._fn_T, self.norm_eps)
-        split_sinkhorn = _hc_split_sinkhorn_ops if self.training else hc_split_sinkhorn
-        return split_sinkhorn(
-            mixes,
-            self.scale,
-            self.base,
-            self.hc_mult,
-            self.sinkhorn_iters,
-            self.hc_eps if self.training else self._hc_eps[0],
-        )
-
-    def collapse(self, x: mx.array):
-        if (
-            not self.training
-            and _hc_sinkhorn_collapse_kernel is not None
-            and self.hc_mult == 4
-            and x.dtype == mx.bfloat16
-        ):
-            return self._fused_collapse(x)
-        pre, post, comb = self.compute_weights(x)
-        return _hc_collapse_op(pre, x), post, comb
-
-    def _fused_collapse(self, x: mx.array):
-        """Fused sinkhorn + collapse in a single Metal kernel dispatch."""
-        B, L, H, D = x.shape
-        flat = x.reshape(B, L, H * D).astype(mx.float32)
-        if self._fn_T is None:
-            self._fn_T = self.fn.T
-        mixes = _hc_mixes(flat, self._fn_T, self.norm_eps)
-
-        eps = self._hc_eps[0]
-        n_rows = B * L
-        x_flat = mx.contiguous(x.reshape(n_rows, H, D))
-
-        post, comb, collapsed = _hc_sinkhorn_collapse_kernel(
-            inputs=[mixes, self.scale, self.base, eps, x_flat],
-            template=[("HC", self.hc_mult), ("ITERS", self.sinkhorn_iters), ("D", D)],
-            grid=(n_rows * 256, 1, 1),
-            threadgroup=(256, 1, 1),
-            output_shapes=[
-                (*mixes.shape[:-1], self.hc_mult),
-                (*mixes.shape[:-1], self.hc_mult, self.hc_mult),
-                (B, L, D),
-            ],
-            output_dtypes=[mx.float32, mx.float32, x.dtype],
-        )
-        return collapsed, post, comb
-
-    def expand(
-        self,
-        block_out: mx.array,
-        residual: mx.array,
-        post: mx.array,
-        comb: mx.array,
-    ):
-        return _hc_expand_op(post, block_out, comb, residual)
-
-
-@mx.compile
-def _hyper_head_op(
-    x: mx.array,
-    fn: mx.array,
-    scale: mx.array,
-    base: mx.array,
-    norm_eps: float,
-    hc_eps: float,
-) -> mx.array:
-    """Fused HyperHead: RMS-rsqrt + matmul + sigmoid + weighted sum."""
-    B, L, H, D = x.shape
-    flat = x.reshape(B, L, H * D).astype(mx.float32)
-    rsqrt = mx.rsqrt((flat * flat).mean(axis=-1, keepdims=True) + norm_eps)
-    mixes = (flat @ fn.T) * rsqrt
-    pre = mx.sigmoid(mixes * scale[0] + base) + hc_eps
-    return (pre[..., None] * x.astype(mx.float32)).sum(axis=2).astype(x.dtype)
-
-
-class HyperHead(nn.Module):
-    def __init__(self, config: ModelArgs):
-        super().__init__()
-        self.hc_mult = config.hc_mult
-        self.norm_eps = config.rms_norm_eps
-        self.hc_eps = config.hc_eps
-        self.fn = mx.zeros(
-            (self.hc_mult, self.hc_mult * config.hidden_size), dtype=mx.float32
-        )
-        self.base = mx.zeros((self.hc_mult,), dtype=mx.float32)
-        self.scale = mx.ones((1,), dtype=mx.float32)
-
-    def __call__(self, x: mx.array):
-        if not self.training:
-            return _hyper_head_op(
-                x, self.fn, self.scale, self.base, self.norm_eps, self.hc_eps
-            )
-        B, L, H, D = x.shape
-        flat = x.reshape(B, L, H * D).astype(mx.float32)
-        rsqrt = _rms_rsqrt(flat, self.norm_eps)
-        mixes = (flat @ self.fn.T) * rsqrt
-        pre = mx.sigmoid(mixes * self.scale[0] + self.base) + self.hc_eps
-        return (pre[..., None] * x.astype(mx.float32)).sum(axis=2).astype(x.dtype)
 
 
 class MoEGate(nn.Module):
@@ -879,7 +487,7 @@ class DeepseekV4MoE(nn.Module):
         super().__init__()
         self.config = config
         self.gate = MoEGate(config, layer_idx)
-        self.switch_mlp = SwitchGLU(
+        self.switch_mlp = FusedSwitchGLU(
             config.hidden_size,
             config.moe_intermediate_size,
             config.n_routed_experts,
@@ -888,6 +496,7 @@ class DeepseekV4MoE(nn.Module):
         self.shared_experts = DeepseekV4MLP(
             config,
             intermediate_size=config.moe_intermediate_size * config.n_shared_experts,
+            swiglu_limit=config.swiglu_limit,
         )
         self.sharding_group = None
 
@@ -905,600 +514,8 @@ class DeepseekV4MoE(nn.Module):
         return y
 
 
-class DeepseekV4Cache:
-    _state_keys = ("buffer_kv", "buffer_gate", "pooled")
-    _length_keys = ("buffer_lengths", "pooled_lengths")
-
-    def __init__(self, sliding_window: int):
-        self.local = RotatingKVCache(max_size=sliding_window, keep=0)
-        self.compressor_state = self._new_branch_state()
-        self.indexer_state = self._new_branch_state()
-        self._pending_lengths = None
-
-    @property
-    def offset(self):
-        return self.local.offset
-
-    @property
-    def keys(self):
-        return self.local.keys
-
-    @keys.setter
-    def keys(self, value):
-        self.local.keys = value
-
-    @property
-    def state(self):
-        local_state = None if self.local.empty() else self.local.state
-        return (
-            local_state,
-            self._branch_state_tuple(self.compressor_state),
-            self._branch_state_tuple(self.indexer_state),
-        )
-
-    @state.setter
-    def state(self, value):
-        local_state, compressor_state, indexer_state = value
-        if local_state is None:
-            self.local.keys = None
-            self.local.values = None
-        else:
-            self.local.state = local_state
-        self.compressor_state = self._state_from_tuple(compressor_state)
-        self.indexer_state = self._state_from_tuple(indexer_state)
-
-    @property
-    def meta_state(self):
-        return self.local.meta_state
-
-    @meta_state.setter
-    def meta_state(self, value):
-        self.local.meta_state = value
-
-    def update_and_fetch(self, keys, values):
-        return self.local.update_and_fetch(keys, values)
-
-    def make_mask(self, *args, **kwargs):
-        return self.local.make_mask(*args, **kwargs)
-
-    def is_trimmable(self):
-        if not self.local.is_trimmable():
-            return False
-        for state in (self.compressor_state, self.indexer_state):
-            pooled = state["pooled"]
-            if pooled is not None and pooled.shape[1] > 0:
-                return False
-        return True
-
-    def trim(self, n):
-        trimmed = self.local.trim(n)
-        batch_size = self._cache_batch_size(self.local)
-        for state in (self.compressor_state, self.indexer_state):
-            for key in ("buffer_kv", "buffer_gate"):
-                value = state[key]
-                if value is not None:
-                    state[key] = value[:, : max(value.shape[1] - trimmed, 0)]
-            lengths = state["buffer_lengths"]
-            if lengths is not None:
-                state["buffer_lengths"] = [
-                    max(length - trimmed, 0)
-                    for length in self._lengths_list(lengths, batch_size, 0)
-                ]
-        return trimmed
-
-    def size(self):
-        return self.local.size()
-
-    def empty(self):
-        return self.local.empty()
-
-    @property
-    def nbytes(self):
-        total = self.local.nbytes
-        for state in (self.compressor_state, self.indexer_state):
-            for value in state.values():
-                if value is not None and hasattr(value, "nbytes"):
-                    total += value.nbytes
-        return total
-
-    def _branch_state(self, state_key: str):
-        return (
-            self.indexer_state
-            if state_key == "indexer_state"
-            else self.compressor_state
-        )
-
-    @classmethod
-    def _new_branch_state(cls):
-        return {key: None for key in cls._state_keys + cls._length_keys}
-
-    @classmethod
-    def _branch_state_tuple(cls, state):
-        return tuple(state[k] for k in cls._state_keys + cls._length_keys)
-
-    @classmethod
-    def _state_from_tuple(cls, values):
-        keys = cls._state_keys + cls._length_keys
-        state = cls._new_branch_state()
-        state.update(zip(keys, values))
-        return state
-
-    @staticmethod
-    def _lengths_list(lengths, batch_size: int, default: Optional[int] = None):
-        if lengths is None:
-            if default is None:
-                return None
-            return [default] * batch_size
-        if isinstance(lengths, mx.array):
-            lengths = lengths.tolist()
-        return [int(length) for length in lengths]
-
-    @staticmethod
-    def _filter_lengths(lengths, batch_indices):
-        if lengths is None:
-            return None
-        if isinstance(lengths, mx.array):
-            lengths = lengths.tolist()
-        if isinstance(batch_indices, mx.array):
-            batch_indices = batch_indices.tolist()
-        if len(lengths) == 1 and any(idx != 0 for idx in batch_indices):
-            lengths = lengths * (max(batch_indices) + 1)
-        return [int(lengths[idx]) for idx in batch_indices]
-
-    def accumulate_windows(
-        self,
-        kv: mx.array,
-        gate: mx.array,
-        state_key: str,
-        ratio: int,
-        start_pos: int,
-    ):
-        state = self._branch_state(state_key)
-        buf_kv, buf_gate = state["buffer_kv"], state["buffer_gate"]
-        B, L = kv.shape[:2]
-        buf_lengths = self._lengths_list(state["buffer_lengths"], B)
-        chunk_lengths = self._pending_lengths
-        if buf_lengths is None and chunk_lengths is None:
-            if buf_kv is not None and buf_kv.shape[1]:
-                kv = mx.concatenate([buf_kv, kv], axis=1)
-                gate = mx.concatenate([buf_gate, gate], axis=1)
-            usable = (kv.shape[1] // ratio) * ratio
-            state["buffer_kv"] = kv[:, usable:]
-            state["buffer_gate"] = gate[:, usable:]
-            state["buffer_lengths"] = None
-            state["_new_pooled_lengths"] = None
-            if isinstance(start_pos, mx.array):
-                pool_base = mx.maximum(start_pos, 0)
-            else:
-                pool_base = max(0, start_pos)
-            pool_base = pool_base - (buf_kv.shape[1] if buf_kv is not None else 0)
-            return kv[:, :usable], gate[:, :usable], pool_base
-
-        buf_lengths = self._lengths_list(
-            state["buffer_lengths"],
-            B,
-            0 if buf_kv is None else buf_kv.shape[1],
-        )
-        chunk_lengths = self._lengths_list(chunk_lengths, B, L)
-        total_lengths = [
-            buf_length + min(chunk_length, L)
-            for buf_length, chunk_length in zip(buf_lengths, chunk_lengths)
-        ]
-        usable_lengths = [(length // ratio) * ratio for length in total_lengths]
-        buffer_lengths = [
-            length - usable for length, usable in zip(total_lengths, usable_lengths)
-        ]
-        max_total = max(total_lengths, default=0)
-        max_usable = max(usable_lengths, default=0)
-        max_buffer = max(buffer_lengths, default=0)
-
-        combined_kv = mx.zeros((B, max_total, kv.shape[-1]), dtype=kv.dtype)
-        combined_gate = mx.zeros((B, max_total, gate.shape[-1]), dtype=gate.dtype)
-        for i, (buf_length, chunk_length, total_length) in enumerate(
-            zip(buf_lengths, chunk_lengths, total_lengths)
-        ):
-            parts_kv = []
-            parts_gate = []
-            if buf_length:
-                parts_kv.append(buf_kv[i : i + 1, :buf_length])
-                parts_gate.append(buf_gate[i : i + 1, :buf_length])
-            if chunk_length:
-                parts_kv.append(kv[i : i + 1, : min(chunk_length, L)])
-                parts_gate.append(gate[i : i + 1, : min(chunk_length, L)])
-            if parts_kv:
-                row_kv = (
-                    parts_kv[0]
-                    if len(parts_kv) == 1
-                    else mx.concatenate(parts_kv, axis=1)
-                )
-                row_gate = (
-                    parts_gate[0]
-                    if len(parts_gate) == 1
-                    else mx.concatenate(parts_gate, axis=1)
-                )
-                combined_kv[i : i + 1, :total_length] = row_kv
-                combined_gate[i : i + 1, :total_length] = row_gate
-
-        ready_kv = combined_kv[:, :max_usable]
-        ready_gate = combined_gate[:, :max_usable]
-        state["buffer_kv"] = mx.zeros((B, max_buffer, kv.shape[-1]), dtype=kv.dtype)
-        state["buffer_gate"] = mx.zeros(
-            (B, max_buffer, gate.shape[-1]), dtype=gate.dtype
-        )
-        for i, (usable, buffer_length) in enumerate(
-            zip(usable_lengths, buffer_lengths)
-        ):
-            if buffer_length:
-                state["buffer_kv"][i : i + 1, :buffer_length] = combined_kv[
-                    i : i + 1, usable : usable + buffer_length
-                ]
-                state["buffer_gate"][i : i + 1, :buffer_length] = combined_gate[
-                    i : i + 1, usable : usable + buffer_length
-                ]
-        state["buffer_lengths"] = buffer_lengths
-        state["_new_pooled_lengths"] = [usable // ratio for usable in usable_lengths]
-
-        prev_lengths = mx.array(buf_lengths, dtype=mx.int32)
-        if isinstance(start_pos, mx.array):
-            pool_base = mx.maximum(start_pos, 0).astype(mx.int32)
-        else:
-            pool_base = mx.full((B,), max(0, start_pos), dtype=mx.int32)
-        return ready_kv, ready_gate, pool_base - prev_lengths
-
-    def update_pool(self, new_pooled: mx.array, state_key: str) -> mx.array:
-        state = self._branch_state(state_key)
-        new_lengths = state.pop("_new_pooled_lengths", None)
-        pool = state["pooled"]
-        if new_lengths is not None:
-            B = new_pooled.shape[0]
-            pool_lengths = self._lengths_list(
-                state["pooled_lengths"],
-                B,
-                0 if pool is None else pool.shape[1],
-            )
-            total_lengths = [
-                pool_length + new_length
-                for pool_length, new_length in zip(pool_lengths, new_lengths)
-            ]
-            max_total = max(total_lengths, default=0)
-            merged = mx.zeros(
-                (B, max_total, new_pooled.shape[-1]), dtype=new_pooled.dtype
-            )
-            for i, (pool_length, new_length) in enumerate(
-                zip(pool_lengths, new_lengths)
-            ):
-                if pool is not None and pool_length:
-                    merged[i : i + 1, :pool_length] = pool[i : i + 1, :pool_length]
-                if new_length:
-                    merged[i : i + 1, pool_length : pool_length + new_length] = (
-                        new_pooled[i : i + 1, :new_length]
-                    )
-            state["pooled"] = merged
-            state["pooled_lengths"] = total_lengths
-            return merged
-
-        if new_pooled.shape[1] > 0:
-            pool = (
-                new_pooled
-                if pool is None
-                else mx.concatenate([pool, new_pooled], axis=1)
-            )
-            state["pooled"] = pool
-            state["pooled_lengths"] = None
-        if pool is None:
-            pool = mx.zeros(
-                (new_pooled.shape[0], 0, new_pooled.shape[-1]), new_pooled.dtype
-            )
-        return pool
-
-    def pooled_lengths(self, state_key: str):
-        return self._branch_state(state_key)["pooled_lengths"]
-
-    def prepare(self, *args, **kwargs):
-        lengths = kwargs.get("lengths")
-        right_padding = kwargs.get("right_padding")
-        self._pending_lengths = (
-            list(lengths)
-            if right_padding is not None and max(right_padding) > 0
-            else None
-        )
-        if hasattr(self.local, "prepare"):
-            self.local.prepare(*args, **kwargs)
-            return
-
-        left_padding = kwargs.get("left_padding")
-        if left_padding is not None or (
-            right_padding is not None and max(right_padding) > 0
-        ):
-            batch_size = (
-                len(left_padding)
-                if left_padding is not None
-                else len(kwargs.get("lengths"))
-            )
-            self.local = BatchRotatingKVCache(self.local.max_size, [0] * batch_size)
-            self.local.prepare(*args, **kwargs)
-
-    def finalize(self):
-        if hasattr(self.local, "finalize"):
-            self.local.finalize()
-        self._pending_lengths = None
-
-    def filter(self, batch_indices):
-        if hasattr(self.local, "filter"):
-            self.local.filter(batch_indices)
-        elif self.local.keys is not None:
-            self.local.keys = self.local.keys[batch_indices]
-            self.local.values = self.local.values[batch_indices]
-        for state in (self.compressor_state, self.indexer_state):
-            for key in self._state_keys:
-                value = state[key]
-                if value is not None:
-                    state[key] = value[batch_indices]
-            for key in self._length_keys:
-                state[key] = self._filter_lengths(state[key], batch_indices)
-
-    def extend(self, other):
-        self_batch = self._cache_batch_size(self.local)
-        other_batch = self._cache_batch_size(other.local)
-        if hasattr(self.local, "extend"):
-            other_local = other.local
-            if not hasattr(other_local, "filter"):
-                other_local = self._batch_rotating_from_local(other_local)
-            self.local.extend(other_local)
-        elif (
-            not hasattr(other.local, "filter")
-            and self.local.offset == other.local.offset
-            and self.local._idx == other.local._idx
-        ):
-            if self.local.keys is not None or other.local.keys is not None:
-                self.local.keys = self._concat_optional_local(
-                    self.local.keys, other.local.keys
-                )
-                self.local.values = self._concat_optional_local(
-                    self.local.values, other.local.values
-                )
-        else:
-            self.local = self._batch_rotating_from_local(self.local)
-            other_local = (
-                other.local
-                if hasattr(other.local, "filter")
-                else self._batch_rotating_from_local(other.local)
-            )
-            self.local.extend(other_local)
-        for self_state, other_state in (
-            (self.compressor_state, other.compressor_state),
-            (self.indexer_state, other.indexer_state),
-        ):
-            self_tensors = {key: self_state[key] for key in self._state_keys}
-            other_tensors = {key: other_state[key] for key in self._state_keys}
-            for key in self._state_keys:
-                self_state[key] = self._concat_batch_state(
-                    self_state[key], other_state[key], self_batch, other_batch
-                )
-            for key in self._length_keys:
-                self_state[key] = self._concat_lengths(
-                    self_state[key],
-                    other_state[key],
-                    self_tensors["pooled" if key.startswith("pooled") else "buffer_kv"],
-                    other_tensors[
-                        "pooled" if key.startswith("pooled") else "buffer_kv"
-                    ],
-                    self_batch,
-                    other_batch,
-                )
-
-    def extract(self, idx):
-        cache = DeepseekV4Cache(self.local.max_size)
-        cache.local = (
-            self.local.extract(idx)
-            if hasattr(self.local, "extract")
-            else self._extract_local(self.local, idx)
-        )
-        for cache_state, self_state in (
-            (cache.compressor_state, self.compressor_state),
-            (cache.indexer_state, self.indexer_state),
-        ):
-            for key in self._state_keys:
-                value = self_state[key]
-                cache_state[key] = (
-                    None if value is None else mx.contiguous(value[idx : idx + 1])
-                )
-            for key in self._length_keys:
-                lengths = self_state[key]
-                if lengths is None:
-                    cache_state[key] = None
-                elif isinstance(lengths, mx.array):
-                    cache_state[key] = [int(lengths.tolist()[idx])]
-                else:
-                    cache_state[key] = [int(lengths[idx])]
-        return cache
-
-    @classmethod
-    def merge(cls, caches):
-        if not all(c.local.max_size == caches[0].local.max_size for c in caches):
-            raise ValueError(
-                "DeepseekV4Cache can only merge caches with the same sliding window"
-            )
-
-        cache = cls(caches[0].local.max_size)
-        cache.local = cls._merge_local([c.local for c in caches])
-        for cache_state, state_name in (
-            (cache.compressor_state, "compressor_state"),
-            (cache.indexer_state, "indexer_state"),
-        ):
-            for key in cls._state_keys:
-                cache_state[key] = cls._merge_batch_state(
-                    [getattr(c, state_name)[key] for c in caches]
-                )
-            for key in cls._length_keys:
-                tensor_key = "pooled" if key.startswith("pooled") else "buffer_kv"
-                cache_state[key] = cls._merge_lengths(
-                    [getattr(c, state_name)[key] for c in caches],
-                    [getattr(c, state_name)[tensor_key] for c in caches],
-                )
-        return cache
-
-    @staticmethod
-    def _cache_batch_size(cache):
-        offset = getattr(cache, "offset", 0)
-        if isinstance(offset, mx.array) and offset.ndim:
-            return offset.shape[0]
-        if cache.keys is not None:
-            return cache.keys.shape[0]
-        return 1
-
-    @staticmethod
-    def _extract_local(local, idx):
-        cache = RotatingKVCache(local.max_size, keep=getattr(local, "keep", 0))
-        if local.keys is not None:
-            keys = local._temporal_order(local.keys)
-            values = local._temporal_order(local.values)
-            cache.keys = mx.contiguous(keys[idx : idx + 1])
-            cache.values = mx.contiguous(values[idx : idx + 1])
-            cache._idx = cache.keys.shape[2]
-        cache.offset = local.offset
-        return cache
-
-    @classmethod
-    def _batch_rotating_from_local(cls, local):
-        batch_size = cls._cache_batch_size(local)
-        return BatchRotatingKVCache.merge(
-            [cls._extract_local(local, idx) for idx in range(batch_size)]
-        )
-
-    @staticmethod
-    def _concat_optional_local(a: Optional[mx.array], b: Optional[mx.array]):
-        if a is None:
-            return b
-        if b is None:
-            return a
-        return mx.concatenate([a, b], axis=0)
-
-    @classmethod
-    def _merge_local(cls, locals):
-        offsets = [local.offset for local in locals]
-        sizes = [local.size() for local in locals]
-        use_fast_local = (
-            all(not isinstance(offset, mx.array) for offset in offsets)
-            and all(offset == offsets[0] for offset in offsets)
-            and all(size == sizes[0] for size in sizes)
-        )
-        if not use_fast_local:
-            if hasattr(locals[0], "merge"):
-                return locals[0].merge(locals)
-            return BatchRotatingKVCache.merge(locals)
-
-        cache = RotatingKVCache(locals[0].max_size, keep=getattr(locals[0], "keep", 0))
-        cache.offset = offsets[0]
-        if sizes[0] == 0:
-            return cache
-
-        cache.keys = mx.concatenate(
-            [local._temporal_order(local.keys) for local in locals], axis=0
-        )
-        cache.values = mx.concatenate(
-            [local._temporal_order(local.values) for local in locals], axis=0
-        )
-        cache._idx = cache.keys.shape[2]
-        return cache
-
-    @staticmethod
-    def _concat_batch_state(
-        a: Optional[mx.array],
-        b: Optional[mx.array],
-        a_batch: int,
-        b_batch: int,
-    ):
-        if a is None and b is None:
-            return None
-        if a is None:
-            shape = (a_batch, *b.shape[1:])
-            a = mx.zeros(shape, dtype=b.dtype)
-        if b is None:
-            shape = (b_batch, *a.shape[1:])
-            b = mx.zeros(shape, dtype=a.dtype)
-        if a.shape[2:] != b.shape[2:]:
-            raise ValueError(
-                "Cannot extend DeepseekV4Cache entries with different state shapes"
-            )
-        if a.shape[1] != b.shape[1]:
-            seq_len = max(a.shape[1], b.shape[1])
-            if a.shape[1] != seq_len:
-                padded = mx.zeros((a.shape[0], seq_len, *a.shape[2:]), dtype=a.dtype)
-                padded[:, : a.shape[1]] = a
-                a = padded
-            if b.shape[1] != seq_len:
-                padded = mx.zeros((b.shape[0], seq_len, *b.shape[2:]), dtype=b.dtype)
-                padded[:, : b.shape[1]] = b
-                b = padded
-        return mx.concatenate([a, b], axis=0)
-
-    @staticmethod
-    def _full_lengths(lengths, value: Optional[mx.array], batch_size: int):
-        if lengths is not None:
-            if isinstance(lengths, mx.array):
-                lengths = lengths.tolist()
-            return [int(length) for length in lengths]
-        length = 0 if value is None else value.shape[1]
-        return [length] * batch_size
-
-    @classmethod
-    def _concat_lengths(
-        cls,
-        a_lengths,
-        b_lengths,
-        a_value: Optional[mx.array],
-        b_value: Optional[mx.array],
-        a_batch: int,
-        b_batch: int,
-    ):
-        a_lengths = cls._full_lengths(a_lengths, a_value, a_batch)
-        b_lengths = cls._full_lengths(b_lengths, b_value, b_batch)
-        lengths = a_lengths + b_lengths
-        max_length = max(lengths, default=0)
-        return None if all(length == max_length for length in lengths) else lengths
-
-    @classmethod
-    def _merge_lengths(cls, lengths, values):
-        batch_lengths = [
-            cls._full_lengths(length, value, 1)[0]
-            for length, value in zip(lengths, values)
-        ]
-        max_length = max(batch_lengths, default=0)
-        return (
-            None
-            if all(length == max_length for length in batch_lengths)
-            else batch_lengths
-        )
-
-    @staticmethod
-    def _merge_batch_state(values: List[Optional[mx.array]]):
-        present = [v for v in values if v is not None]
-        if not present:
-            return None
-        if not all(v.shape[2:] == present[0].shape[2:] for v in present):
-            raise ValueError(
-                "Cannot batch DeepseekV4Cache entries with different state shapes"
-            )
-        seq_len = max(v.shape[1] for v in present)
-        shape = present[0].shape
-        dtype = present[0].dtype
-        merged = []
-        for value in values:
-            if value is None:
-                merged.append(mx.zeros((1, seq_len, *shape[2:]), dtype=dtype))
-            else:
-                if value.shape[1] != seq_len:
-                    padded = mx.zeros(
-                        (value.shape[0], seq_len, *value.shape[2:]), dtype=value.dtype
-                    )
-                    padded[:, : value.shape[1]] = value
-                    value = padded
-                merged.append(value)
-        return mx.concatenate(merged, axis=0)
-
-
 class Compressor(nn.Module):
+
     def __init__(self, config: ModelArgs, compress_ratio: int, head_dim: int):
         super().__init__()
         self.compress_ratio = compress_ratio
@@ -1510,60 +527,68 @@ class Compressor(nn.Module):
         self.wgate = nn.Linear(config.hidden_size, self.out_dim, bias=False)
         self.ape = mx.zeros((compress_ratio, self.out_dim), dtype=mx.float32)
         self.norm = nn.RMSNorm(head_dim, eps=config.rms_norm_eps)
-
-    def _overlap_transform(self, x: mx.array, fill_value: float):
-        B, W, R, _ = x.shape
-        second_half = x[:, :, :, self.head_dim :]  # (B, W, R, head_dim)
-        fill_row = mx.full((B, 1, R, self.head_dim), fill_value, dtype=x.dtype)
-        prev_first = mx.concatenate(
-            [fill_row, x[:, :-1, :, : self.head_dim]], axis=1
-        )  # (B, W, R, head_dim)
-        return mx.concatenate([prev_first, second_half], axis=2)  # (B, W, 2R, head_dim)
+        self.rope = DeepseekV4RoPE(
+            config.qk_rope_head_dim,
+            config.compress_rope_theta,
+            config.rope_scaling,
+            config.max_position_embeddings,
+            freq_scale=compress_ratio,
+        )
 
     def __call__(
         self,
         x: mx.array,
-        rope: DeepseekV4RoPE,
-        cache: Optional[DeepseekV4Cache],
-        start_pos: int,
-        state_key: str = "compressor_state",
+        pool_cache: Optional[PoolingCache],
+        offset: Union[int, mx.array],
     ) -> mx.array:
         B, _, _ = x.shape
         kv = self.wkv(x)
         gate = self.wgate(x)
-        if cache is None:
+        if pool_cache is None:
             usable = (kv.shape[1] // self.compress_ratio) * self.compress_ratio
             ready_kv, ready_gate = kv[:, :usable], gate[:, :usable]
-            pool_base = start_pos
+            pool_base = offset
         else:
-            ready_kv, ready_gate, pool_base = cache.accumulate_windows(
-                kv, gate, state_key, self.compress_ratio, start_pos
+            ready_kv, ready_gate, pool_base = pool_cache.accumulate_windows(
+                kv, gate, offset
             )
 
-        if ready_kv.shape[1] == 0:
+        if ready_kv.size == 0:
             new_pooled = mx.zeros((B, 0, self.head_dim), dtype=x.dtype)
         else:
-            W = ready_kv.shape[1] // self.compress_ratio
-            kv = ready_kv.reshape(B, W, self.compress_ratio, self.out_dim)
-            gate = ready_gate.reshape(
-                B, W, self.compress_ratio, self.out_dim
-            ) + self.ape.astype(ready_gate.dtype)
+            kv = mx.unflatten(ready_kv, 1, (-1, self.compress_ratio))
+            gate = mx.unflatten(ready_gate, 1, (-1, self.compress_ratio))
             if self.overlap:
-                kv = self._overlap_transform(kv, 0.0)
-                gate = self._overlap_transform(gate, -float("inf"))
-            weights = mx.softmax(gate.astype(mx.float32), axis=2, precise=True).astype(
-                kv.dtype
-            )
-            new_pooled = (kv * weights).sum(axis=2)
-            new_pooled = self.norm(new_pooled.astype(x.dtype))
-            new_pooled = rope(
+                if pool_cache is None:
+                    prior_kv = mx.zeros(
+                        (B, self.compress_ratio, self.head_dim), dtype=kv.dtype
+                    )
+                    prior_gate = mx.full(
+                        (B, self.compress_ratio, self.head_dim),
+                        -mx.inf,
+                        dtype=gate.dtype,
+                    )
+                else:
+                    prior_kv, prior_gate = pool_cache.update_overlap_state(kv, gate)
+                new_pooled = _overlap_compress_kv(
+                    kv,
+                    gate,
+                    self.ape,
+                    self.head_dim,
+                    prior_kv,
+                    prior_gate,
+                )
+            else:
+                new_pooled = _simple_compress_kv(kv, gate, self.ape, self.head_dim)
+            new_pooled = self.norm(new_pooled)
+            new_pooled = self.rope(
                 new_pooled[:, None],
                 offset=pool_base,
-                freq_scale=self.compress_ratio,
             ).squeeze(1)
 
-        if cache is not None:
-            return cache.update_pool(new_pooled, state_key)
+        if pool_cache is not None:
+            new_pooled = pool_cache.update_and_fetch(new_pooled)
+
         return new_pooled
 
 
@@ -1584,17 +609,15 @@ class Indexer(nn.Module):
         self,
         x: mx.array,
         q_residual: mx.array,
-        rope: DeepseekV4RoPE,
         position_rope: DeepseekV4RoPE,
-        cache: Optional[DeepseekV4Cache],
-        start_pos: int,
+        pool_cache: Optional[PoolingCache],
+        offset: Union[int, mx.array],
     ):
         B, L, _ = x.shape
-        pooled = self.compressor(x, rope, cache, start_pos, state_key="indexer_state")
+        pooled = self.compressor(x, pool_cache, offset)
         if pooled.shape[1] == 0:
             return None
 
-        offset = start_pos
         q = self.wq_b(q_residual).reshape(B, L, self.n_heads, self.head_dim)
         q = q.transpose(0, 2, 1, 3)
         q = position_rope(q, offset)
@@ -1605,11 +628,17 @@ class Indexer(nn.Module):
         scores = mx.maximum(scores, 0) * self.scale
         weights = self.weights_proj(x).astype(mx.float32) * (self.n_heads**-0.5)
         scores = (scores * weights.swapaxes(-1, -2)[..., None]).sum(axis=1)
-        lengths = cache.pooled_lengths("indexer_state") if cache is not None else None
-        if lengths is not None:
-            lengths = mx.array(lengths)
-            valid = mx.arange(pooled.shape[1]) < lengths[:, None]
-            scores = mx.where(valid[:, None], scores, mx.finfo(scores.dtype).min)
+        pmask = (
+            pool_cache.make_mask(L, offset)
+            if pool_cache is not None
+            else _pooled_mask(L, pooled.shape[1], self.compressor.compress_ratio, offset)
+        )
+        if pmask is not None:
+            scores = mx.where(
+                pmask if pmask.ndim == 3 else pmask[None],
+                scores,
+                mx.finfo(scores.dtype).min,
+            )
         k = min(self.index_topk, pooled.shape[1])
         return mx.argpartition(-scores, kth=k - 1, axis=-1)[..., :k]
 
@@ -1655,6 +684,8 @@ class LocalAttention(nn.Module):
             config.max_position_embeddings,
         )
 
+        self.sharding_group = None
+
     def __call__(
         self,
         x: mx.array,
@@ -1663,6 +694,7 @@ class LocalAttention(nn.Module):
     ) -> mx.array:
         B, L, _ = x.shape
         offset = cache.offset if cache is not None else 0
+        offset = mx.array(offset) if isinstance(offset, mx.array) else offset
 
         q = self.wq_b(self.q_norm(self.wq_a(x)))
         q = q.reshape(B, L, self.n_heads, self.head_dim)
@@ -1674,6 +706,7 @@ class LocalAttention(nn.Module):
         kv = self.rope(kv, offset)
         if cache is not None:
             kv, _ = cache.update_and_fetch(kv, mx.zeros((B, 1, L, 0)))
+        mask = _align_local_mask(mask, kv.shape[2])
 
         out = scaled_dot_product_attention(
             q,
@@ -1692,17 +725,15 @@ class LocalAttention(nn.Module):
         out = out.transpose(0, 2, 1, 3).flatten(-2)
         out = self.wo_b(out)
 
+        if self.sharding_group is not None:
+            out = mx.distributed.all_sum(out, group=self.sharding_group)
+
         return out
 
 
-def v4_attention_factory(config: ModelArgs, layer_idx: int) -> nn.Module:
-    """Instantiate the appropriate attention module for a given layer."""
-    if config.compress_ratios[layer_idx] == 0:
-        return LocalAttention(config, layer_idx)
-    return V4Attention(config, layer_idx)
+class CompressedAttention(nn.Module):
+    """DeepSeek V4 attention with pooled KV compression."""
 
-
-class V4Attention(nn.Module):
     def __init__(self, config: ModelArgs, layer_idx: int):
         super().__init__()
         self.config = config
@@ -1711,8 +742,6 @@ class V4Attention(nn.Module):
         self.hidden_size = config.hidden_size
         self.n_heads = config.num_attention_heads
         self.head_dim = config.head_dim
-        self.rope_head_dim = config.qk_rope_head_dim
-        self.nope_head_dim = self.head_dim - self.rope_head_dim
         self.o_groups = config.o_groups
         self.o_lora_rank = config.o_lora_rank
         self.scale = self.head_dim**-0.5
@@ -1724,10 +753,10 @@ class V4Attention(nn.Module):
         )
         self.wkv = nn.Linear(config.hidden_size, self.head_dim, bias=False)
         self.kv_norm = nn.RMSNorm(self.head_dim, eps=config.rms_norm_eps)
-        self.wo_a = nn.Linear(
+        self.wo_a = MultiLinear(
             self.n_heads * self.head_dim // config.o_groups,
-            config.o_groups * config.o_lora_rank,
-            bias=False,
+            config.o_lora_rank,
+            config.o_groups,
         )
         self.wo_b = nn.Linear(
             config.o_groups * config.o_lora_rank,
@@ -1735,82 +764,17 @@ class V4Attention(nn.Module):
             bias=config.attention_bias,
         )
         self.attn_sink = mx.zeros((self.n_heads,), dtype=mx.float32)
-        self._q_l2_norm_weight = (mx.ones((self.head_dim,)),)
-        self._cached_dtype = None
 
-        rope_theta = (
-            config.compress_rope_theta if self.compress_ratio else config.rope_theta
-        )
-        rope_scaling = config.rope_scaling if self.compress_ratio else None
+        # Compressed layers use Yarn-scaled RoPE
         self.rope = DeepseekV4RoPE(
             config.qk_rope_head_dim,
-            rope_theta,
-            rope_scaling,
+            config.compress_rope_theta,
+            config.rope_scaling,
             config.max_position_embeddings,
         )
-        self.compress_rope = self.rope
-        if self.compress_ratio:
-            self.compressor = Compressor(config, self.compress_ratio, self.head_dim)
-            if self.compress_ratio == 4:
-                self.indexer = Indexer(config, self.compress_ratio)
+        self.compressor = Compressor(config, self.compress_ratio, self.head_dim)
 
-    def _ensure_cached(self, dtype):
-        dtype_key = str(dtype)
-        if self._cached_dtype is not None and self._cached_dtype == dtype_key:
-            return
-        self._cached_dtype = dtype_key
-        self._attn_sink_cached = self.attn_sink.astype(dtype)
-        self._q_norm_weight_cached = self._q_l2_norm_weight[0].astype(dtype)
-        if isinstance(self.wo_a, nn.QuantizedLinear):
-            self._wo_a_weight = self.wo_a.weight.reshape(
-                self.o_groups, self.o_lora_rank, -1
-            )[:, None]
-            self._wo_a_scales = self.wo_a.scales.reshape(
-                self.o_groups, self.o_lora_rank, -1
-            )[:, None]
-            self._wo_a_biases = (
-                None
-                if self.wo_a.biases is None
-                else self.wo_a.biases.reshape(self.o_groups, self.o_lora_rank, -1)[
-                    :, None
-                ]
-            )
-        else:
-            group_feat = (self.n_heads * self.head_dim) // self.o_groups
-            self._wo_a_weight_reshaped = self.wo_a.weight.reshape(
-                self.o_groups, self.o_lora_rank, group_feat
-            )
-
-    def _grouped_output_projection(self, out: mx.array) -> mx.array:
-        B, _, L, _ = out.shape
-        heads_per_group = self.n_heads // self.o_groups
-        out = out.reshape(B, self.o_groups, heads_per_group, L, self.head_dim)
-        out = out.transpose(1, 0, 3, 2, 4)
-        out = out.reshape(self.o_groups, B, L, heads_per_group * self.head_dim)
-
-        if isinstance(self.wo_a, nn.QuantizedLinear):
-            out = mx.quantized_matmul(
-                out,
-                self._wo_a_weight,
-                scales=self._wo_a_scales,
-                biases=self._wo_a_biases,
-                transpose=True,
-                group_size=self.wo_a.group_size,
-                bits=self.wo_a.bits,
-                mode=self.wo_a.mode,
-            )
-            out = out.transpose(1, 2, 0, 3).reshape(
-                B, L, self.o_groups * self.o_lora_rank
-            )
-            if "bias" in self.wo_a:
-                out = out + self.wo_a.bias
-            return out
-
-        out = mx.einsum("gbsd,grd->bsgr", out, self._wo_a_weight_reshaped)
-        out = out.reshape(B, L, self.o_groups * self.o_lora_rank)
-        if "bias" in self.wo_a:
-            out = out + self.wo_a.bias
-        return out
+        self.sharding_group = None
 
     def __call__(
         self,
@@ -1819,140 +783,158 @@ class V4Attention(nn.Module):
         cache: Optional[Any] = None,
     ) -> mx.array:
         B, L, _ = x.shape
-        local_cache = cache
+        local_cache = cache[0] if cache is not None else None
+        pool_cache = cache[1] if cache is not None else None
         offset = local_cache.offset if local_cache is not None else 0
-        if isinstance(offset, mx.array):
-            offset = offset + 0
+        offset = mx.array(offset) if isinstance(offset, mx.array) else offset
+
+        q = self.wq_b(self.q_norm(self.wq_a(x)))
+        q = q.reshape(B, L, self.n_heads, self.head_dim)
+        q = mx.fast.rms_norm(q, None, self.config.rms_norm_eps)
+        q = q.transpose(0, 2, 1, 3)
+        q = self.rope(q, offset)
+
+        kv = self.kv_norm(self.wkv(x)).reshape(B, 1, L, self.head_dim)
+        kv = self.rope(kv, offset)
+        if local_cache is not None:
+            kv, _ = local_cache.update_and_fetch(kv, mx.zeros((B, 1, L, 0)))
+        mask = _align_local_mask(mask, kv.shape[2])
+
+        # Pool tokens into compressed KV and concatenate with local KV
+        pooled = self.compressor(x, pool_cache, offset)
+        pooled_mask = None
+        if pooled.shape[1] > 0:
+            pooled_mask = (
+                pool_cache.make_mask(L, offset)
+                if pool_cache is not None
+                else _pooled_mask(L, pooled.shape[1], self.compress_ratio, offset)
+            )
+            kv = mx.concatenate([kv, pooled[:, None]], axis=2)
+
+        mask = _extend_mask(mask, pooled_mask, kv.shape[2])
+
+        out = scaled_dot_product_attention(
+            q,
+            kv,
+            kv,
+            cache=local_cache,
+            scale=self.scale,
+            mask=mask,
+            sinks=self.attn_sink.astype(q.dtype),
+        )
+        out = self.rope(out, offset, inverse=True)
+
+        out = out.reshape(B, self.o_groups, -1, L, self.head_dim)
+        out = out.transpose(0, 1, 3, 2, 4).flatten(-2)
+        out = self.wo_a(out)
+        out = out.transpose(0, 2, 1, 3).flatten(-2)
+        out = self.wo_b(out)
+
+        if self.sharding_group is not None:
+            out = mx.distributed.all_sum(out, group=self.sharding_group)
+
+        return out
+
+
+class SparseCompressedAttention(nn.Module):
+    """DeepSeek V4 attention with sparse indexed pooled KV compression."""
+
+    def __init__(self, config: ModelArgs, layer_idx: int):
+        super().__init__()
+        self.config = config
+        self.layer_idx = layer_idx
+        self.compress_ratio = config.compress_ratios[layer_idx]
+        self.hidden_size = config.hidden_size
+        self.n_heads = config.num_attention_heads
+        self.head_dim = config.head_dim
+        self.o_groups = config.o_groups
+        self.o_lora_rank = config.o_lora_rank
+        self.scale = self.head_dim**-0.5
+
+        self.wq_a = nn.Linear(config.hidden_size, config.q_lora_rank, bias=False)
+        self.q_norm = nn.RMSNorm(config.q_lora_rank, eps=config.rms_norm_eps)
+        self.wq_b = nn.Linear(
+            config.q_lora_rank, self.n_heads * self.head_dim, bias=False
+        )
+        self.wkv = nn.Linear(config.hidden_size, self.head_dim, bias=False)
+        self.kv_norm = nn.RMSNorm(self.head_dim, eps=config.rms_norm_eps)
+        self.wo_a = MultiLinear(
+            self.n_heads * self.head_dim // config.o_groups,
+            config.o_lora_rank,
+            config.o_groups,
+        )
+        self.wo_b = nn.Linear(
+            config.o_groups * config.o_lora_rank,
+            config.hidden_size,
+            bias=config.attention_bias,
+        )
+        self.attn_sink = mx.zeros((self.n_heads,), dtype=mx.float32)
+
+        self.rope = DeepseekV4RoPE(
+            config.qk_rope_head_dim,
+            config.compress_rope_theta,
+            config.rope_scaling,
+            config.max_position_embeddings,
+        )
+        self.compressor = Compressor(config, self.compress_ratio, self.head_dim)
+        self.indexer = Indexer(config, self.compress_ratio)
+
+        self.sharding_group = None
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        B, L, _ = x.shape
+        local_cache = cache[0] if cache is not None else None
+        comp_cache = cache[1] if cache is not None else None
+        idx_cache = cache[2] if cache is not None else None
+        offset = local_cache.offset if local_cache is not None else 0
+        offset = mx.array(offset) if isinstance(offset, mx.array) else offset
+
         q_residual = self.q_norm(self.wq_a(x))
         q = self.wq_b(q_residual).reshape(B, L, self.n_heads, self.head_dim)
-        self._ensure_cached(q.dtype)
-        q = mx.fast.rms_norm(q, self._q_norm_weight_cached, self.config.rms_norm_eps)
+        q = mx.fast.rms_norm(q, None, self.config.rms_norm_eps)
         q = q.transpose(0, 2, 1, 3)
-        kv = self.kv_norm(self.wkv(x)).reshape(B, 1, L, self.head_dim)
-
         q = self.rope(q, offset)
+
+        kv = self.kv_norm(self.wkv(x)).reshape(B, 1, L, self.head_dim)
         kv = self.rope(kv, offset)
-
         if local_cache is not None:
-            kv, _ = local_cache.update_and_fetch(kv, kv)
-        full_kv = kv
-        local_kv_len = kv.shape[2]
+            kv, _ = local_cache.update_and_fetch(kv, mx.zeros((B, 1, L, 0)))
+        mask = _align_local_mask(mask, kv.shape[2])
 
-        pooled_mask = None
-        pooled_bias = None
-        sparse_pooled = None
-        sparse_topk = None
-        sparse_pooled_mask = None
-        if self.compress_ratio:
-            v4_cache = cache if isinstance(cache, DeepseekV4Cache) else None
-            pooled = self.compressor(x, self.compress_rope, v4_cache, offset)
-            if pooled.shape[1] > 0:
-                lengths = (
-                    v4_cache.pooled_lengths("compressor_state")
-                    if v4_cache is not None
-                    else None
-                )
-                use_indexer = isinstance(getattr(self, "indexer", None), Indexer)
-                max_pooled_length = pooled.shape[1] if lengths is None else max(lengths)
-                select_all = use_indexer and (
-                    max_pooled_length <= self.indexer.index_topk
-                )
-                if select_all:
-                    pooled = pooled[:, None]
-                    pooled_bias = math.log(L)
-                    if lengths is not None:
-                        lengths = mx.array(lengths)
-                        pooled_mask = (
-                            mx.arange(pooled.shape[2]) < lengths[:, None]
-                        ).reshape(B, 1, 1, -1)
-                elif use_indexer:
-                    topk = self.indexer(
-                        x, q_residual, self.compress_rope, self.rope, v4_cache, offset
-                    )
-                    if topk is not None:
-                        if L > 1:
-                            sparse_pooled = pooled
-                            sparse_topk = topk
-                            if lengths is not None:
-                                lengths = mx.array(lengths)
-                                sparse_pooled_mask = (
-                                    topk < lengths[:, None, None]
-                                ).reshape(B, 1, L, -1)
-                        else:
-                            if lengths is not None:
-                                lengths = mx.array(lengths)
-                                pooled_mask = (topk < lengths[:, None, None]).reshape(
-                                    B, 1, 1, -1
-                                )
-                            expanded = mx.broadcast_to(
-                                pooled[:, None, None, :, :],
-                                (B, 1, L, pooled.shape[1], self.head_dim),
-                            )
-                            idx = topk[:, None, :, :, None]
-                            pooled = mx.take_along_axis(
-                                expanded,
-                                mx.broadcast_to(idx, idx.shape[:-1] + (self.head_dim,)),
-                                axis=3,
-                            ).reshape(B, 1, -1, self.head_dim)
-                    else:
-                        pooled = pooled[:, None]
-                else:
-                    if lengths is not None:
-                        lengths = mx.array(lengths)
-                        pooled_mask = (
-                            mx.arange(pooled.shape[1]) < lengths[:, None]
-                        ).reshape(B, 1, 1, -1)
-                    pooled = pooled[:, None]
-                if sparse_topk is None:
-                    full_kv = mx.concatenate([full_kv, pooled], axis=2)
-
-        if mask is not None and mask.shape[-1] > local_kv_len:
-            mask = mask[..., -local_kv_len:]
-
-        if sparse_topk is not None:
-            out = _sparse_pooled_attention(
-                q,
-                full_kv,
-                sparse_pooled,
-                sparse_topk,
-                mask,
-                sparse_pooled_mask,
-                self.scale,
-                self._attn_sink_cached,
+        pooled = self.compressor(x, comp_cache, offset)
+        pmask = (
+            comp_cache.make_mask(L, offset)
+            if comp_cache is not None
+            else (
+                _pooled_mask(L, pooled.shape[1], self.compress_ratio, offset)
+                if pooled.shape[1] > 0
+                else None
             )
-        else:
-            if mask is not None and full_kv.shape[2] > mask.shape[-1]:
-                pad_shape = mask.shape[:-1] + (full_kv.shape[2] - mask.shape[-1],)
-                pad_pooled_mask = pooled_mask
-                if (
-                    pad_pooled_mask is not None
-                    and pad_pooled_mask.shape[-1] != pad_shape[-1]
-                ):
-                    pad_pooled_mask = pad_pooled_mask[..., -pad_shape[-1] :]
-                if pooled_bias is not None:
-                    dtype = q.dtype
-                    if mask.dtype == mx.bool_:
-                        mask = mx.where(
-                            mask,
-                            mx.array(0, dtype=dtype),
-                            mx.full((), mx.finfo(dtype).min, dtype=dtype),
-                        )
-                    pad = mx.full(pad_shape, pooled_bias, dtype=mask.dtype)
-                elif mask.dtype == mx.bool_:
-                    pad = mx.ones(pad_shape, dtype=mask.dtype)
-                    if pad_pooled_mask is not None:
-                        pad = pad & pad_pooled_mask
-                else:
-                    pad = mx.zeros(pad_shape, dtype=mask.dtype)
-                    if pad_pooled_mask is not None:
-                        pad = mx.where(
-                            pad_pooled_mask,
-                            pad,
-                            mx.full(
-                                pad_shape, mx.finfo(mask.dtype).min, dtype=mask.dtype
-                            ),
-                        )
-                mask = mx.concatenate([mask, pad], axis=-1)
+        )
+        topk = self.indexer(x, q_residual, self.rope, idx_cache, offset)
+        sinks = self.attn_sink.astype(q.dtype)
+
+        # Local attention
+        if pooled.shape[1] == 0:
+            out = scaled_dot_product_attention(
+                q,
+                kv,
+                kv,
+                cache=local_cache,
+                scale=self.scale,
+                mask=mask,
+                sinks=sinks,
+            )
+
+        # Compressed attention
+        elif pooled.shape[1] <= self.indexer.index_topk:
+            full_kv = mx.concatenate([kv, pooled[:, None]], axis=2)
+            mask = _extend_mask(mask, pmask, full_kv.shape[2])
             out = scaled_dot_product_attention(
                 q,
                 full_kv,
@@ -1960,11 +942,51 @@ class V4Attention(nn.Module):
                 cache=local_cache,
                 scale=self.scale,
                 mask=mask,
-                sinks=self._attn_sink_cached,
+                sinks=sinks,
             )
+
+        # Sparse compressed attention
+        else:
+            sparse_mask = None
+            if pmask is not None:
+                sparse_mask = mx.take_along_axis(
+                    pmask[None] if pmask.ndim == 2 else pmask,
+                    topk,
+                    axis=2,
+                )[:, None]
+            out = _sparse_pooled_attention(
+                q,
+                kv,
+                pooled,
+                topk,
+                mask,
+                sparse_mask,
+                self.scale,
+                sinks,
+            )
+
         out = self.rope(out, offset, inverse=True)
-        out = self._grouped_output_projection(out)
-        return self.wo_b(out)
+
+        out = out.reshape(B, self.o_groups, -1, L, self.head_dim)
+        out = out.transpose(0, 1, 3, 2, 4).flatten(-2)
+        out = self.wo_a(out)
+        out = out.transpose(0, 2, 1, 3).flatten(-2)
+        out = self.wo_b(out)
+
+        if self.sharding_group is not None:
+            out = mx.distributed.all_sum(out, group=self.sharding_group)
+
+        return out
+
+
+def v4_attention_factory(config: ModelArgs, layer_idx: int) -> nn.Module:
+    """Instantiate the appropriate attention module for a given layer."""
+    ratio = config.compress_ratios[layer_idx]
+    if ratio == 0:
+        return LocalAttention(config, layer_idx)
+    if ratio == 128:
+        return CompressedAttention(config, layer_idx)
+    return SparseCompressedAttention(config, layer_idx)
 
 
 class DeepseekV4Block(nn.Module):
@@ -1985,14 +1007,14 @@ class DeepseekV4Block(nn.Module):
         input_ids: mx.array,
     ) -> mx.array:
         residual = h
-        x, post, comb = self.attn_hc.collapse(h)
+        x, post, comb = self.attn_hc(h)
         x = self.attn(self.attn_norm(x), mask=mask, cache=cache)
-        h = self.attn_hc.expand(x, residual, post, comb)
+        h = hc_expand(x, residual, post, comb)
 
         residual = h
-        x, post, comb = self.ffn_hc.collapse(h)
+        x, post, comb = self.ffn_hc(h)
         x = self.ffn(self.ffn_norm(x), input_ids)
-        return self.ffn_hc.expand(x, residual, post, comb)
+        return hc_expand(x, residual, post, comb)
 
 
 class DeepseekV4Model(PipelineMixin, nn.Module):
@@ -2023,9 +1045,7 @@ class DeepseekV4Model(PipelineMixin, nn.Module):
 
         first_cache = cache[0]
         mask_cache = (
-            first_cache.local
-            if isinstance(first_cache, DeepseekV4Cache)
-            else first_cache
+            first_cache[0] if isinstance(first_cache, CacheList) else first_cache
         )
         mask = create_attention_mask(
             h[:, :, 0, :],
@@ -2043,8 +1063,8 @@ class DeepseekV4Model(PipelineMixin, nn.Module):
         if pipeline_rank != 0:
             h = mx.distributed.send(h, (pipeline_rank - 1) % pipeline_size)
             cache_item = cache[-1]
-            if isinstance(cache_item, DeepseekV4Cache):
-                cache_item = cache_item.local
+            if isinstance(cache_item, CacheList):
+                cache_item = cache_item[0]
             if cache_item is not None:
                 cache_item.keys = mx.depends(cache_item.keys, h)
 
@@ -2085,10 +1105,26 @@ class Model(nn.Module):
     def make_cache(self):
         caches = []
         for layer in self.layers:
-            if layer.attn.compress_ratio:
-                caches.append(DeepseekV4Cache(self.args.sliding_window))
-            else:
+            ratio = layer.attn.compress_ratio
+            if ratio == 0:
                 caches.append(RotatingKVCache(max_size=self.args.sliding_window))
+            elif isinstance(layer.attn, SparseCompressedAttention):
+                # local + compressor pool + indexer pool
+                caches.append(
+                    CacheList(
+                        RotatingKVCache(max_size=self.args.sliding_window),
+                        DeepseekV4PoolingCache(ratio),
+                        DeepseekV4PoolingCache(ratio),
+                    )
+                )
+            else:
+                # local + compressor pool
+                caches.append(
+                    CacheList(
+                        RotatingKVCache(max_size=self.args.sliding_window),
+                        PoolingCache(ratio),
+                    )
+                )
         return caches
 
     def sanitize(self, weights: Dict[str, mx.array]) -> Dict[str, mx.array]:
@@ -2181,9 +1217,19 @@ class Model(nn.Module):
                             f"model.layers.{layer_idx}.ffn.switch_mlp.{dst}.{suffix}"
                         ] = mx.stack(stacked)
 
+        # Fuse routed expert gate/up projections by concatenating output rows.
         for layer_idx in range(n_layers):
-            if self.args.compress_ratios[layer_idx] != 0:
-                continue
+            prefix = f"model.layers.{layer_idx}.ffn.switch_mlp"
+            for suffix in ("weight", "scales"):
+                gate_key = f"{prefix}.gate_proj.{suffix}"
+                up_key = f"{prefix}.up_proj.{suffix}"
+                if gate_key in weights and up_key in weights:
+                    weights[gate_key] = mx.concatenate(
+                        [weights.pop(gate_key), weights.pop(up_key)], axis=1
+                    )
+
+        # Reshape wo_a from nn.Linear (2D) to MultiLinear (3D) for all layers
+        for layer_idx in range(n_layers):
             prefix = f"model.layers.{layer_idx}.attn.wo_a"
             for key in (f"{prefix}.weight", f"{prefix}.scales", f"{prefix}.biases"):
                 if key in weights and weights[key].ndim == 2:
@@ -2196,13 +1242,17 @@ class Model(nn.Module):
     def shard(self, group: Optional[mx.distributed.Group] = None):
         group = group or mx.distributed.init()
         N = group.size()
+        rank = group.rank()
         for layer in self.model.layers:
+            layer.attn.sharding_group = group
             layer.attn.wq_b = shard_linear(
-                layer.attn.wq_b, "all-to-sharded", group=group
+                layer.attn.wq_b,
+                "all-to-sharded",
+                segments=self.args.o_groups,
+                group=group,
             )
-            layer.attn.wo_b = shard_linear(
-                layer.attn.wo_b, "sharded-to-all", group=group
-            )
+            shard_inplace(layer.attn.wo_a, "sharded-to-all", group=group)
+            layer.attn.attn_sink = mx.split(layer.attn.attn_sink, N)[rank]
             layer.attn.n_heads //= N
 
             layer.ffn.sharding_group = group
@@ -2215,6 +1265,11 @@ class Model(nn.Module):
             shard_inplace(
                 layer.ffn.shared_experts.up_proj, "all-to-sharded", group=group
             )
-            shard_inplace(layer.ffn.switch_mlp.gate_proj, "all-to-sharded", group=group)
+            shard_inplace(
+                layer.ffn.switch_mlp.gate_proj,
+                "all-to-sharded",
+                segments=2,
+                group=group,
+            )
             shard_inplace(layer.ffn.switch_mlp.down_proj, "sharded-to-all", group=group)
-            shard_inplace(layer.ffn.switch_mlp.up_proj, "all-to-sharded", group=group)
+            layer.ffn.switch_mlp.hidden_dims //= N

--- a/vllm_mlx/models/deepseek_v4.py
+++ b/vllm_mlx/models/deepseek_v4.py
@@ -294,19 +294,35 @@ def _apply_score_mask(scores: mx.array, mask: Optional[mx.array]) -> mx.array:
 
 
 def _extend_mask(mask: Optional[mx.array], pool_mask: Optional[mx.array], N: int):
-    if mask is None:
+    if mask is None and pool_mask is None:
         return None
 
-    if mask.ndim == 2:
+    if pool_mask is not None:
+        if pool_mask.ndim == 2:
+            pool_mask = pool_mask[None, None]
+        elif pool_mask.ndim == 3:
+            pool_mask = pool_mask[:, None]
+
+    if mask is None:
+        B, H, L, P = pool_mask.shape
+        mask = mx.ones((B, H, L, N - P), dtype=mx.bool_)
+    elif mask.ndim == 2:
         mask = mask[None, None]
     B, H, L, S = mask.shape
 
     if pool_mask is None:
         pool_mask = mx.ones((B, H, L, N - S), dtype=mx.bool_)
-    elif pool_mask.ndim == 2:
+    else:
         pool_mask = mx.broadcast_to(pool_mask, (B, H, L, N - S))
-    elif pool_mask.ndim == 3:
-        pool_mask = mx.broadcast_to(pool_mask[:, None], (B, H, L, N - S))
+
+    if mask.dtype != mx.bool_ and pool_mask.dtype == mx.bool_:
+        pool_mask = mx.where(
+            pool_mask,
+            mx.array(0, dtype=mask.dtype),
+            mx.array(mx.finfo(mask.dtype).min, dtype=mask.dtype),
+        )
+    else:
+        pool_mask = pool_mask.astype(mask.dtype)
 
     full_mask = mx.concatenate([mask, pool_mask], axis=-1)
 

--- a/vllm_mlx/models/deepseek_v4_cache.py
+++ b/vllm_mlx/models/deepseek_v4_cache.py
@@ -1,0 +1,768 @@
+# Copyright © 2026 Apple Inc.
+# DeepSeek V4 cache subset vendored from spicyneuron/mlx-lm@df50b7a3.
+
+from typing import List
+
+import mlx.core as mx
+
+from .. import _mlx_compat as _mlx_compat
+
+_mlx_compat.install()
+
+from mlx_lm.models.cache import _BaseCache
+
+
+class PoolingCache(_BaseCache):
+    """Cache for pooled (compressed) KV tokens with a remainder buffer.
+
+    Stores two things:
+      1. A growing pool of compressed tokens (step-allocated).
+      2. A small remainder buffer of tokens not yet forming a full window.
+    """
+
+    step = 256
+
+    def __init__(self, ratio: int):
+        self.ratio = ratio
+
+        self.buf_kv = None
+        self.buf_gate = None
+        self.remainder = 0
+
+        # The pool is appended to on every call. Resizing to fit each chunk
+        # would issue an mx.concatenate per call, piling up lazy-graph nodes
+        # until Metal's per-command-buffer resource limit crashes long runs.
+        # Instead, self._buf is the storage (grown in self.step chunks) and
+        # self.pooled is a logical-size view; mutation sites keep them in sync.
+        self._buf = None
+        self.pooled = None
+
+    @property
+    def offset(self):
+        return 0 if self.pooled is None else self.pooled.shape[1]
+
+    def accumulate_windows(self, kv: mx.array, gate: mx.array, offset):
+        B, L, D1 = kv.shape
+        _, _, D2 = gate.shape
+
+        if self.buf_kv is None:
+            self.buf_kv = mx.zeros((B, self.ratio, D1), dtype=kv.dtype)
+            self.buf_gate = mx.zeros((B, self.ratio, D2), dtype=gate.dtype)
+
+        # Prompt mode
+        if L > 1:
+            total = L + self.remainder
+            usable = (total // self.ratio) * self.ratio
+            new_remainder = total % self.ratio
+
+            if usable > 0:
+                r_kv = mx.concatenate(
+                    [
+                        self.buf_kv[:, : self.remainder],
+                        kv[:, : (usable - self.remainder)],
+                    ],
+                    axis=1,
+                )
+                r_gate = mx.concatenate(
+                    [
+                        self.buf_gate[:, : self.remainder],
+                        gate[:, : (usable - self.remainder)],
+                    ],
+                    axis=1,
+                )
+                r_base = offset - self.remainder
+                self.remainder = 0
+            else:
+                r_kv = mx.zeros((B, 0, D1), dtype=kv.dtype)
+                r_gate = mx.zeros((B, 0, D2), dtype=gate.dtype)
+                r_base = 0
+
+            if new_remainder > 0:
+                self.buf_kv[:, self.remainder : new_remainder] = kv[:, -new_remainder:]
+                self.buf_gate[:, self.remainder : new_remainder] = gate[
+                    :, -new_remainder:
+                ]
+            self.remainder = new_remainder
+
+            return r_kv, r_gate, r_base
+
+        # Decode mode
+        else:
+            self.buf_kv[:, self.remainder : self.remainder + 1] = kv
+            self.buf_gate[:, self.remainder : self.remainder + 1] = gate
+            self.remainder = (self.remainder + 1) % self.ratio
+
+            if self.remainder == 0:
+                r_kv = self.buf_kv
+                r_gate = self.buf_gate
+                r_base = offset - self.ratio + 1
+            else:
+                r_kv = mx.zeros((B, 0, D1), dtype=kv.dtype)
+                r_gate = mx.zeros((B, 0, D2), dtype=gate.dtype)
+                r_base = 0
+
+            return r_kv, r_gate, r_base
+
+    def update_and_fetch(self, px: mx.array):
+        B, N, D = px.shape
+        if N == 0:
+            if self.pooled is None:
+                return mx.zeros((B, 0, D), dtype=px.dtype)
+            return self.pooled
+
+        cur = 0 if self.pooled is None else self.pooled.shape[1]
+        new_len = cur + N
+
+        if self._buf is None:
+            cap = ((new_len + self.step - 1) // self.step) * self.step
+            self._buf = mx.zeros((B, cap, D), dtype=px.dtype)
+        elif self._buf.shape[1] < new_len:
+            cap = ((new_len + self.step - 1) // self.step) * self.step
+            pad = mx.zeros((B, cap - self._buf.shape[1], D), dtype=px.dtype)
+            self._buf = mx.concatenate([self._buf, pad], axis=1)
+
+        self._buf[:, cur:new_len] = px
+        self.pooled = self._buf[:, :new_len]
+        return self.pooled
+
+    def make_mask(self, L: int = 1, offset: int = 0):
+        """Build a causal validity mask for pooled positions.
+
+        Query at absolute position ``offset + j`` can attend to pooled token
+        ``i`` iff ``i < (offset + j) // ratio``.
+
+        Returns ``(N, P)`` bool mask, or ``None`` when every pooled position
+        is visible to every query (common during decode).
+        """
+        if self.pooled is None or L == 1:
+            return None
+
+        pool_idx = mx.arange(self.pooled.shape[1])
+        query_idx = mx.arange(offset + 1, offset + L + 1)
+        return pool_idx < query_idx[:, None] // self.ratio
+
+    @property
+    def state(self):
+        buf_kv = self.buf_kv[:, : self.remainder] if self.remainder > 0 else None
+        buf_gate = self.buf_gate[:, : self.remainder] if self.remainder > 0 else None
+        return (buf_kv, buf_gate, self.pooled)
+
+    @state.setter
+    def state(self, v):
+        buf_kv, buf_gate, pooled = v
+        self.remainder = 0
+        self.buf_kv = self.buf_gate = None
+        if buf_kv is not None:
+            self.accumulate_windows(buf_kv, buf_gate, 0)
+        self.pooled = pooled
+        self._buf = pooled
+
+    @property
+    def meta_state(self):
+        return str(self.ratio)
+
+    @meta_state.setter
+    def meta_state(self, v):
+        self.ratio = int(v)
+
+    @classmethod
+    def from_state(cls, state, meta_state):
+        obj = cls.__new__(cls)
+        obj.meta_state = meta_state
+        obj.state = state
+        return obj
+
+    def is_trimmable(self):
+        return self.pooled is None
+
+    def trim(self, n):
+        n = min(self.remainder, n)
+        self.remainder -= n
+        return n
+
+    def size(self):
+        return 0 if self.pooled is None else self.pooled.shape[1]
+
+    def empty(self):
+        return self.pooled is None and self.remainder == 0
+
+    @property
+    def nbytes(self):
+        total = 0
+        if self.buf_kv is not None:
+            total += self.buf_kv.nbytes + self.buf_gate.nbytes
+        pool = self._buf if self._buf is not None else self.pooled
+        if pool is not None:
+            total += pool.nbytes
+        return total
+
+    @classmethod
+    def merge(cls, caches):
+        return BatchPoolingCache.merge(caches)
+
+
+class BatchPoolingCache(_BaseCache):
+    """Batched pooling cache with per-element variable-length tracking."""
+
+    step = 256
+
+    def __init__(self, ratio: int, left_padding: List[int]):
+        self.ratio = ratio
+
+        if not all(p == 0 for p in left_padding):
+            raise RuntimeError("BatchPoolingCache does not support left padding")
+
+        batch_size = len(left_padding)
+
+        self.buf_kv = None
+        self.buf_gate = None
+        self.remainder = [0] * batch_size
+
+        # See PoolingCache.__init__.
+        self._buf = None
+        self.pooled = None
+        self._pool_lengths = [0] * batch_size
+
+        self._lengths = [2**31] * batch_size
+        self._processed = [0] * batch_size
+
+    @property
+    def offset(self):
+        return mx.array(self._pool_lengths, dtype=mx.int32)
+
+    def prepare(self, *, lengths=None, right_padding=None, left_padding=None):
+        if left_padding is not None:
+            raise RuntimeError("BatchPoolingCache does not support left padding")
+        if lengths is not None:
+            self._lengths = [p + l for p, l in zip(self._processed, lengths)]
+
+    def finalize(self):
+        self._lengths = [2**31] * len(self._pool_lengths)
+
+    def accumulate_windows(self, kv: mx.array, gate: mx.array, offset):
+        B, L, D1 = kv.shape
+        _, _, D2 = gate.shape
+        ratio = self.ratio
+
+        if self.buf_kv is None:
+            self.buf_kv = mx.zeros((B, ratio, D1), dtype=kv.dtype)
+            self.buf_gate = mx.zeros((B, ratio, D2), dtype=gate.dtype)
+
+        valid_lengths = [min(l - p, L) for l, p in zip(self._lengths, self._processed)]
+        if max(valid_lengths) != L:
+            raise RuntimeError()
+        for i in range(B):
+            self._processed[i] += valid_lengths[i]
+
+        totals = [vl + r for vl, r in zip(valid_lengths, self.remainder)]
+        usable = [(t // ratio) * ratio for t in totals]
+        max_usable = max(usable)
+        new_remainder = [t % ratio for t in totals]
+
+        # No sequence produced a full window yet
+        if max_usable == 0:
+            for i in range(B):
+                r = self.remainder[i]
+                vl = valid_lengths[i]
+                self.buf_kv[i, r : r + vl] = kv[i, :vl]
+                self.buf_gate[i, r : r + vl] = gate[i, :vl]
+            self.remainder = new_remainder
+
+            r_kv = mx.zeros((B, 0, D1), dtype=kv.dtype)
+            r_gate = mx.zeros((B, 0, D2), dtype=gate.dtype)
+            r_base = 0
+            return r_kv, r_gate, r_base
+
+        # At least one sequence completed a window
+        r_kv = mx.zeros((B, max_usable, D1), dtype=kv.dtype)
+        r_gate = mx.zeros((B, max_usable, D2), dtype=gate.dtype)
+        r_base = [0] * B
+
+        new_buf_kv = mx.zeros_like(self.buf_kv)
+        new_buf_gate = mx.zeros_like(self.buf_gate)
+
+        for i in range(B):
+            r = self.remainder[i]
+            vl = valid_lengths[i]
+            u = usable[i]
+            nr = new_remainder[i]
+
+            if u > 0:
+                # Tokens from the buffer (the leftover from last call)
+                if r > 0:
+                    r_kv[i, :r] = self.buf_kv[i, :r]
+                    r_gate[i, :r] = self.buf_gate[i, :r]
+
+                # Tokens from the new input that complete full windows
+                consume = u - r
+                r_kv[i, r : r + consume] = kv[i, :consume]
+                r_gate[i, r : r + consume] = gate[i, :consume]
+
+                r_base[i] = (
+                    offset[i] - r if isinstance(offset, mx.array) else offset - r
+                )
+
+            # Fill new remainder buffer from the tail of the input
+            if nr > 0:
+                if u > 0:
+                    # Old remainder was consumed into usable output;
+                    # new remainder is purely from the tail of new input.
+                    new_buf_kv[i, :nr] = kv[i, vl - nr : vl]
+                    new_buf_gate[i, :nr] = gate[i, vl - nr : vl]
+                else:
+                    # No full window produced: carry over old buffer and
+                    # append any new valid tokens.
+                    if r > 0:
+                        new_buf_kv[i, :r] = self.buf_kv[i, :r]
+                        new_buf_gate[i, :r] = self.buf_gate[i, :r]
+                    if vl > 0:
+                        new_buf_kv[i, r : r + vl] = kv[i, :vl]
+                        new_buf_gate[i, r : r + vl] = gate[i, :vl]
+
+        self.buf_kv = new_buf_kv
+        self.buf_gate = new_buf_gate
+        self.remainder = new_remainder
+
+        r_base = mx.array(r_base)
+        return r_kv, r_gate, r_base
+
+    def _pending_pool_counts(self):
+        """Per-row pooled tokens produced but not copied into ``self.pooled``."""
+        return [
+            (self._processed[i] - self.remainder[i]) // self.ratio
+            - self._pool_lengths[i]
+            for i in range(len(self.remainder))
+        ]
+
+    def update_and_fetch(self, px: mx.array):
+        B, N, D = px.shape
+
+        if N == 0:
+            if self.pooled is None:
+                return mx.zeros((B, 0, D), dtype=px.dtype)
+            return self.pooled
+
+        new_counts = self._pending_pool_counts()
+        max_new = max(new_counts)
+        if max_new == 0:
+            if self.pooled is None:
+                return mx.zeros((B, 0, D), dtype=px.dtype)
+            return self.pooled
+
+        max_pool = max(self._pool_lengths) + max_new
+
+        if self._buf is None:
+            cap = ((max_pool + self.step - 1) // self.step) * self.step
+            self._buf = mx.zeros((B, cap, D), dtype=px.dtype)
+        elif self._buf.shape[1] < max_pool:
+            cap = ((max_pool + self.step - 1) // self.step) * self.step
+            pad = mx.zeros((B, cap - self._buf.shape[1], D), dtype=px.dtype)
+            self._buf = mx.concatenate([self._buf, pad], axis=1)
+
+        for i in range(B):
+            nc = new_counts[i]
+            if nc > 0:
+                pl = self._pool_lengths[i]
+                self._buf[i, pl : pl + nc] = px[i, :nc]
+                self._pool_lengths[i] = pl + nc
+
+        self.pooled = self._buf[:, :max(self._pool_lengths)]
+        return self.pooled
+
+    def make_mask(self, L: int = 1, offset=0):
+        if self.pooled is None:
+            return None
+
+        B, P, _ = self.pooled.shape
+        pool_lengths = mx.array(self._pool_lengths)
+
+        # Length based mask
+        pool_idx = mx.arange(P)[None, None, :]
+        valid = pool_idx < pool_lengths[:, None, None]
+
+        # Decode so no need for causal masking
+        if L == 1:
+            if all(pl == P for pl in self._pool_lengths):
+                return None
+            return valid
+
+        # Prompt so we need to combine with causal
+        if isinstance(offset, mx.array):
+            query_pos = offset[:, None] + mx.arange(1, L + 1)
+        else:
+            query_pos = offset + mx.arange(1, L + 1)[None]
+
+        causal = pool_idx < (query_pos[..., None] // self.ratio)
+        mask = causal & valid
+        return mask
+
+    @property
+    def state(self):
+        return (self.buf_kv, self.buf_gate, self.pooled)
+
+    @state.setter
+    def state(self, v):
+        self.buf_kv, self.buf_gate, self.pooled = v
+        self._buf = self.pooled
+
+    @property
+    def meta_state(self):
+        return (self.ratio, self.remainder, self._pool_lengths, self._processed)
+
+    @meta_state.setter
+    def meta_state(self, v):
+        self.ratio, self.remainder, self._pool_lengths, self._processed = v
+
+    def is_trimmable(self):
+        return self.pooled is None
+
+    def trim(self, n):
+        n = min(min(self.remainder), n)
+        for i in range(len(self.remainder)):
+            self.remainder[i] -= n
+            self._processed[i] -= n
+        return n
+
+    def size(self):
+        return 0 if self.pooled is None else self.pooled.shape[1]
+
+    def empty(self):
+        return self.pooled is None and all(r == 0 for r in self.remainder)
+
+    @property
+    def nbytes(self):
+        total = 0
+        if self.buf_kv is not None:
+            total += self.buf_kv.nbytes + self.buf_gate.nbytes
+        pool = self._buf if self._buf is not None else self.pooled
+        if pool is not None:
+            total += pool.nbytes
+        return total
+
+    def filter(self, batch_indices):
+        if isinstance(batch_indices, mx.array):
+            idx_list = batch_indices.tolist()
+        else:
+            idx_list = list(batch_indices)
+
+        if self.buf_kv is not None:
+            self.buf_kv = self.buf_kv[batch_indices]
+            self.buf_gate = self.buf_gate[batch_indices]
+        if self.pooled is not None:
+            self.pooled = self.pooled[batch_indices]
+            self._buf = self.pooled
+
+        self.remainder = [self.remainder[i] for i in idx_list]
+        self._pool_lengths = [self._pool_lengths[i] for i in idx_list]
+        self._lengths = [self._lengths[i] for i in idx_list]
+        self._processed = [self._processed[i] for i in idx_list]
+
+    def extend(self, other):
+        # Merge the remainder buffers
+        if self.buf_kv is None and other.buf_kv is None:
+            pass
+        elif self.buf_kv is not None and other.buf_kv is not None:
+            self.buf_kv = mx.concatenate([self.buf_kv, other.buf_kv], axis=0)
+            self.buf_gate = mx.concatenate([self.buf_gate, other.buf_gate], axis=0)
+        elif self.buf_kv is None:
+            B = len(self.remainder)
+            D1 = other.buf_kv.shape[2]
+            D2 = other.buf_gate.shape[2]
+            self.buf_kv = mx.concatenate(
+                [mx.zeros((B, self.ratio, D1), dtype=other.buf_kv.dtype), other.buf_kv],
+                axis=0,
+            )
+            self.buf_gate = mx.concatenate(
+                [
+                    mx.zeros((B, self.ratio, D2), dtype=other.buf_gate.dtype),
+                    other.buf_gate,
+                ],
+                axis=0,
+            )
+        else:
+            B2 = len(other.remainder)
+            D1 = self.buf_kv.shape[2]
+            D2 = self.buf_gate.shape[2]
+            self.buf_kv = mx.concatenate(
+                [self.buf_kv, mx.zeros((B2, self.ratio, D1), dtype=self.buf_kv.dtype)],
+                axis=0,
+            )
+            self.buf_gate = mx.concatenate(
+                [
+                    self.buf_gate,
+                    mx.zeros((B2, self.ratio, D2), dtype=self.buf_gate.dtype),
+                ],
+                axis=0,
+            )
+
+        # Merge the pooled buffers
+        if self.pooled is None and other.pooled is None:
+            pass
+        else:
+            B1 = len(self.remainder)
+            B2 = len(other.remainder)
+            P1 = 0 if self.pooled is None else self.pooled.shape[1]
+            P2 = 0 if other.pooled is None else other.pooled.shape[1]
+            max_P = max(P1, P2)
+
+            if max_P > 0:
+                if self.pooled is not None:
+                    D = self.pooled.shape[2]
+                else:
+                    D = other.pooled.shape[2]
+                dt = (self.pooled if self.pooled is not None else other.pooled).dtype
+
+                def pad_pool(pooled, B, P):
+                    if pooled is None:
+                        return mx.zeros((B, max_P, D), dtype=dt)
+                    if P < max_P:
+                        pad = mx.zeros((pooled.shape[0], max_P - P, D), dtype=dt)
+                        return mx.concatenate([pooled, pad], axis=1)
+                    return pooled
+
+                self.pooled = mx.concatenate(
+                    [pad_pool(self.pooled, B1, P1), pad_pool(other.pooled, B2, P2)],
+                    axis=0,
+                )
+                self._buf = self.pooled
+
+        self.remainder = self.remainder + other.remainder
+        self._pool_lengths = self._pool_lengths + other._pool_lengths
+        self._lengths = self._lengths + other._lengths
+        self._processed = self._processed + other._processed
+
+    def extract(self, idx):
+        cache = PoolingCache(self.ratio)
+        pl = self._pool_lengths[idx]
+        r = self.remainder[idx]
+
+        if self.pooled is not None and pl > 0:
+            cache.pooled = mx.contiguous(self.pooled[idx : idx + 1, :pl])
+            cache._buf = cache.pooled
+
+        if self.buf_kv is not None and r > 0:
+            cache.buf_kv = mx.contiguous(self.buf_kv[idx : idx + 1])
+            cache.buf_gate = mx.contiguous(self.buf_gate[idx : idx + 1])
+            cache.remainder = r
+
+        return cache
+
+    @classmethod
+    def merge(cls, caches):
+        """Merge a list of PoolingCache instances into a BatchPoolingCache."""
+        B = len(caches)
+        if not all(c.ratio == caches[0].ratio for c in caches):
+            raise ValueError(
+                "BatchPoolingCache can only merge caches with the same ratio"
+            )
+        ratio = caches[0].ratio
+        batch_cache = cls(ratio, [0] * B)
+
+        # Check if all caches are empty
+        if all(c.empty() for c in caches):
+            return batch_cache
+
+        # Merge pooled buffers
+        pool_sizes = [c.size() for c in caches]
+        max_pool = max(pool_sizes)
+        if max_pool > 0:
+            D = next(c.pooled.shape[2] for c in caches if c.pooled is not None)
+            dt = next(c.pooled.dtype for c in caches if c.pooled is not None)
+            pooled = mx.zeros((B, max_pool, D), dtype=dt)
+            for i, c in enumerate(caches):
+                if c.pooled is not None:
+                    ps = c.pooled.shape[1]
+                    pooled[i, :ps] = c.pooled[0]
+            batch_cache.pooled = pooled
+            batch_cache._buf = pooled
+
+        batch_cache._pool_lengths = pool_sizes
+        batch_cache.remainder = [c.remainder for c in caches]
+        batch_cache._processed = [
+            c.remainder + ps * ratio for c, ps in zip(caches, pool_sizes)
+        ]
+
+        # Merge remainder buffers
+        has_buf = any(c.buf_kv is not None for c in caches)
+        if has_buf:
+            D1 = next(c.buf_kv.shape[2] for c in caches if c.buf_kv is not None)
+            D2 = next(c.buf_gate.shape[2] for c in caches if c.buf_gate is not None)
+            dt = next(c.buf_kv.dtype for c in caches if c.buf_kv is not None)
+            buf_kv = mx.zeros((B, ratio, D1), dtype=dt)
+            buf_gate = mx.zeros((B, ratio, D2), dtype=dt)
+            for i, c in enumerate(caches):
+                if c.buf_kv is not None and c.remainder > 0:
+                    buf_kv[i, : c.remainder] = c.buf_kv[0, : c.remainder]
+                    buf_gate[i, : c.remainder] = c.buf_gate[0, : c.remainder]
+            batch_cache.buf_kv = buf_kv
+            batch_cache.buf_gate = buf_gate
+
+        return batch_cache
+
+
+class DeepseekV4PoolingCache(PoolingCache):
+    """PoolingCache with DeepSeek V4 CSA cross-call overlap state."""
+
+    def __init__(self, ratio: int):
+        super().__init__(ratio)
+        self.overlap_kv = None
+        self.overlap_gate = None
+
+    def update_overlap_state(self, chunk_kv: mx.array, chunk_gate: mx.array):
+        half = chunk_kv.shape[-1] // 2
+        prior_kv, prior_gate = self.overlap_kv, self.overlap_gate
+        if prior_kv is None:
+            B, _, R, _ = chunk_kv.shape
+            prior_kv = mx.zeros((B, R, half), dtype=chunk_kv.dtype)
+            prior_gate = mx.full((B, R, half), -mx.inf, dtype=chunk_gate.dtype)
+
+        self.overlap_kv = chunk_kv[:, -1, :, :half]
+        self.overlap_gate = chunk_gate[:, -1, :, :half]
+        return prior_kv, prior_gate
+
+    @property
+    def state(self):
+        return super().state + (self.overlap_kv, self.overlap_gate)
+
+    @state.setter
+    def state(self, v):
+        *base, overlap_kv, overlap_gate = v
+        PoolingCache.state.fset(self, tuple(base))
+        self.overlap_kv = overlap_kv
+        self.overlap_gate = overlap_gate
+
+    def empty(self):
+        return (
+            super().empty()
+            and self.overlap_kv is None
+            and self.overlap_gate is None
+        )
+
+    @property
+    def nbytes(self):
+        total = super().nbytes
+        if self.overlap_kv is not None:
+            total += self.overlap_kv.nbytes + self.overlap_gate.nbytes
+        return total
+
+    @classmethod
+    def merge(cls, caches):
+        return BatchDeepseekV4PoolingCache.merge(caches)
+
+
+def _zero_overlap(template_kv, template_gate, n):
+    R, D = template_kv.shape[1:]
+    return (
+        mx.zeros((n, R, D), dtype=template_kv.dtype),
+        mx.full((n, R, D), -mx.inf, dtype=template_gate.dtype),
+    )
+
+
+class BatchDeepseekV4PoolingCache(BatchPoolingCache):
+    """Batched counterpart to DeepseekV4PoolingCache."""
+
+    def __init__(self, ratio: int, left_padding: List[int]):
+        super().__init__(ratio, left_padding)
+        self.overlap_kv = None
+        self.overlap_gate = None
+
+    def update_overlap_state(self, chunk_kv: mx.array, chunk_gate: mx.array):
+        B, _, R, D = chunk_kv.shape
+        half = D // 2
+
+        prior_kv, prior_gate = self.overlap_kv, self.overlap_gate
+        if prior_kv is None:
+            prior_kv = mx.zeros((B, R, half), dtype=chunk_kv.dtype)
+            prior_gate = mx.full((B, R, half), -mx.inf, dtype=chunk_gate.dtype)
+
+        overlap_kv = mx.array(prior_kv)
+        overlap_gate = mx.array(prior_gate)
+        for i, count in enumerate(self._pending_pool_counts()):
+            if count > 0:
+                overlap_kv[i] = chunk_kv[i, count - 1, :, :half]
+                overlap_gate[i] = chunk_gate[i, count - 1, :, :half]
+
+        self.overlap_kv = overlap_kv
+        self.overlap_gate = overlap_gate
+        return prior_kv, prior_gate
+
+    @property
+    def state(self):
+        return super().state + (self.overlap_kv, self.overlap_gate)
+
+    @state.setter
+    def state(self, v):
+        *base, overlap_kv, overlap_gate = v
+        BatchPoolingCache.state.fset(self, tuple(base))
+        self.overlap_kv = overlap_kv
+        self.overlap_gate = overlap_gate
+
+    def empty(self):
+        return (
+            super().empty()
+            and self.overlap_kv is None
+            and self.overlap_gate is None
+        )
+
+    @property
+    def nbytes(self):
+        total = super().nbytes
+        if self.overlap_kv is not None:
+            total += self.overlap_kv.nbytes + self.overlap_gate.nbytes
+        return total
+
+    def filter(self, batch_indices):
+        super().filter(batch_indices)
+        if self.overlap_kv is not None:
+            self.overlap_kv = self.overlap_kv[batch_indices]
+            self.overlap_gate = self.overlap_gate[batch_indices]
+
+    def extend(self, other):
+        self_batch = len(self.remainder)
+        other_batch = len(other.remainder)
+        self_kv, self_gate = self.overlap_kv, self.overlap_gate
+        other_kv, other_gate = other.overlap_kv, other.overlap_gate
+        super().extend(other)
+
+        if self_kv is None and other_kv is None:
+            return
+        if self_kv is None:
+            self_kv, self_gate = _zero_overlap(other_kv, other_gate, self_batch)
+        if other_kv is None:
+            other_kv, other_gate = _zero_overlap(self_kv, self_gate, other_batch)
+        self.overlap_kv = mx.concatenate([self_kv, other_kv], axis=0)
+        self.overlap_gate = mx.concatenate([self_gate, other_gate], axis=0)
+
+    def extract(self, idx):
+        base = super().extract(idx)
+        cache = DeepseekV4PoolingCache(self.ratio)
+        cache.pooled = base.pooled
+        cache._buf = base._buf
+        cache.buf_kv = base.buf_kv
+        cache.buf_gate = base.buf_gate
+        cache.remainder = base.remainder
+        if self.overlap_kv is not None and self._pool_lengths[idx] > 0:
+            cache.overlap_kv = mx.contiguous(self.overlap_kv[idx : idx + 1])
+            cache.overlap_gate = mx.contiguous(self.overlap_gate[idx : idx + 1])
+        return cache
+
+    @classmethod
+    def merge(cls, caches):
+        batch_cache = super().merge(caches)
+        template = next((c for c in caches if c.overlap_kv is not None), None)
+        if template is None:
+            return batch_cache
+
+        B = len(caches)
+        R, D = template.overlap_kv.shape[1:]
+        overlap_kv = mx.zeros((B, R, D), dtype=template.overlap_kv.dtype)
+        overlap_gate = mx.full(
+            (B, R, D), -mx.inf, dtype=template.overlap_gate.dtype
+        )
+        for i, c in enumerate(caches):
+            if c.overlap_kv is not None:
+                overlap_kv[i] = c.overlap_kv[0]
+                overlap_gate[i] = c.overlap_gate[0]
+        batch_cache.overlap_kv = overlap_kv
+        batch_cache.overlap_gate = overlap_gate
+        return batch_cache

--- a/vllm_mlx/models/deepseek_v4_cache.py
+++ b/vllm_mlx/models/deepseek_v4_cache.py
@@ -244,6 +244,9 @@ class BatchPoolingCache(_BaseCache):
         _, _, D2 = gate.shape
         ratio = self.ratio
 
+        if B == 0:
+            return kv, gate, mx.array([], dtype=mx.int32)
+
         if self.buf_kv is None:
             self.buf_kv = mx.zeros((B, ratio, D1), dtype=kv.dtype)
             self.buf_gate = mx.zeros((B, ratio, D2), dtype=gate.dtype)
@@ -591,9 +594,10 @@ class BatchPoolingCache(_BaseCache):
         if has_buf:
             D1 = next(c.buf_kv.shape[2] for c in caches if c.buf_kv is not None)
             D2 = next(c.buf_gate.shape[2] for c in caches if c.buf_gate is not None)
-            dt = next(c.buf_kv.dtype for c in caches if c.buf_kv is not None)
-            buf_kv = mx.zeros((B, ratio, D1), dtype=dt)
-            buf_gate = mx.zeros((B, ratio, D2), dtype=dt)
+            kv_dt = next(c.buf_kv.dtype for c in caches if c.buf_kv is not None)
+            gate_dt = next(c.buf_gate.dtype for c in caches if c.buf_gate is not None)
+            buf_kv = mx.zeros((B, ratio, D1), dtype=kv_dt)
+            buf_gate = mx.zeros((B, ratio, D2), dtype=gate_dt)
             for i, c in enumerate(caches):
                 if c.buf_kv is not None and c.remainder > 0:
                     buf_kv[i, : c.remainder] = c.buf_kv[0, : c.remainder]

--- a/vllm_mlx/models/deepseek_v4_cache.py
+++ b/vllm_mlx/models/deepseek_v4_cache.py
@@ -231,7 +231,7 @@ class BatchPoolingCache(_BaseCache):
         return mx.array(self._pool_lengths, dtype=mx.int32)
 
     def prepare(self, *, lengths=None, right_padding=None, left_padding=None):
-        if left_padding is not None:
+        if left_padding is not None and any(p != 0 for p in left_padding):
             raise RuntimeError("BatchPoolingCache does not support left padding")
         if lengths is not None:
             self._lengths = [p + l for p, l in zip(self._processed, lengths)]
@@ -366,7 +366,7 @@ class BatchPoolingCache(_BaseCache):
                 self._buf[i, pl : pl + nc] = px[i, :nc]
                 self._pool_lengths[i] = pl + nc
 
-        self.pooled = self._buf[:, :max(self._pool_lengths)]
+        self.pooled = self._buf[:, : max(self._pool_lengths)]
         return self.pooled
 
     def make_mask(self, L: int = 1, offset=0):
@@ -412,6 +412,10 @@ class BatchPoolingCache(_BaseCache):
     @meta_state.setter
     def meta_state(self, v):
         self.ratio, self.remainder, self._pool_lengths, self._processed = v
+        # ``_BaseCache.from_state`` restores metadata before tensor state.
+        # Length limits are request-local and are reset after every batch, so
+        # reconstruct their neutral value rather than checkpointing them.
+        self._lengths = [2**31] * len(self._pool_lengths)
 
     def is_trimmable(self):
         return self.pooled is None
@@ -632,11 +636,7 @@ class DeepseekV4PoolingCache(PoolingCache):
         self.overlap_gate = overlap_gate
 
     def empty(self):
-        return (
-            super().empty()
-            and self.overlap_kv is None
-            and self.overlap_gate is None
-        )
+        return super().empty() and self.overlap_kv is None and self.overlap_gate is None
 
     @property
     def nbytes(self):
@@ -698,11 +698,7 @@ class BatchDeepseekV4PoolingCache(BatchPoolingCache):
         self.overlap_gate = overlap_gate
 
     def empty(self):
-        return (
-            super().empty()
-            and self.overlap_kv is None
-            and self.overlap_gate is None
-        )
+        return super().empty() and self.overlap_kv is None and self.overlap_gate is None
 
     @property
     def nbytes(self):
@@ -756,9 +752,7 @@ class BatchDeepseekV4PoolingCache(BatchPoolingCache):
         B = len(caches)
         R, D = template.overlap_kv.shape[1:]
         overlap_kv = mx.zeros((B, R, D), dtype=template.overlap_kv.dtype)
-        overlap_gate = mx.full(
-            (B, R, D), -mx.inf, dtype=template.overlap_gate.dtype
-        )
+        overlap_gate = mx.full((B, R, D), -mx.inf, dtype=template.overlap_gate.dtype)
         for i, c in enumerate(caches):
             if c.overlap_kv is not None:
                 overlap_kv[i] = c.overlap_kv[0]

--- a/vllm_mlx/models/deepseek_v4_hyper_connection.py
+++ b/vllm_mlx/models/deepseek_v4_hyper_connection.py
@@ -238,6 +238,7 @@ class HyperConnection(nn.Module):
 
         use_ops = (
             self.training
+            or self.hc_mult != 4
             or mx.default_device() != mx.gpu
             or not mx.metal.is_available()
         )

--- a/vllm_mlx/models/deepseek_v4_hyper_connection.py
+++ b/vllm_mlx/models/deepseek_v4_hyper_connection.py
@@ -1,0 +1,286 @@
+# Copyright © 2026 Apple Inc.
+# Vendored from spicyneuron/mlx-lm@df50b7a3 for DeepSeek V4.
+
+from typing import Tuple
+
+import mlx.core as mx
+import mlx.nn as nn
+
+
+def _make_hc_sinkhorn_collapse_kernel():
+    """Fused sinkhorn + collapse: eliminates one dispatch per HC cycle.
+
+    1. BRANCHLESS SINKHORN: all 32 lanes in simd group 0 execute identical
+       instructions. Lanes >= HC use multiplicative mask (active=0) instead
+       of divergent branches — eliminates SIMD serialization.
+    2. PARALLEL SINKHORN: lanes 0-3 each own one comb row. Column norm
+       via simd_sum() — free SIMD shuffle.
+    3. NATIVE bfloat4 LOADS: single 64-bit load yields 4 bfloat16 values;
+       cast to float4 is a free hardware conversion.
+    4. FMA CHAINS: collapse uses fused multiply-add for 3 of 4 terms.
+    """
+    if mx.default_device() != mx.gpu or not mx.metal.is_available():
+        return None
+
+    source = """
+        uint tid  = thread_position_in_threadgroup.x;
+        uint row  = threadgroup_position_in_grid.x;
+        uint lane = tid % 32;
+        uint sg   = tid / 32;
+
+        constexpr int MIX      = (2 + HC) * HC;
+        constexpr int BASE_OFF = 2 * HC;
+        constexpr float EPS = EPS_INT * 1e-9;
+
+        const device float* mix      = (const device float*)mixes + row * MIX;
+        device float*       post_out = (device float*)post + row * HC;
+        device float*       comb_out = (device float*)comb + row * HC * HC;
+
+        threadgroup float pre_shared[HC];
+
+        // ================================================================
+        // PHASE 1: Branchless sinkhorn on simd group 0
+        //   All 32 lanes execute identical instructions. Lanes >= HC
+        //   compute on clamped indices but multiply by active=0, so they
+        //   contribute zero to simd_sum. No divergent branches in the loop.
+        // ================================================================
+        if (sg == 0) {
+            const float pre_scale  = scale[0];
+            const float post_scale = scale[1];
+            const float comb_scale = scale[2];
+
+            const float active = (lane < (uint)HC) ? 1.0f : 0.0f;
+            const uint  llane  = metal::min(lane, (uint)(HC - 1));
+
+            // Pre/post sigmoids: all lanes compute, only active lanes write
+            float pre_z  = mix[llane]      * pre_scale  + base[llane];
+            float post_z = mix[HC + llane] * post_scale + base[HC + llane];
+            float pre_v  = 1.0f / (1.0f + metal::fast::exp(-pre_z)) + EPS;
+            float post_v = 2.0f / (1.0f + metal::fast::exp(-post_z));
+
+            if (lane < (uint)HC) {
+                pre_shared[lane] = pre_v;
+                post_out[lane]   = post_v;
+            }
+
+            // Comb softmax: load + mask. Inactive lanes load row 0 (safe)
+            // but multiply by active=0 so they hold zeros.
+            float4 v = (*(const device float4*)(mix  + BASE_OFF + llane * HC)
+                            * comb_scale
+                      + *(const device float4*)(base + BASE_OFF + llane * HC))
+                     * active;
+
+            float row_max = metal::max(metal::max(v.x, v.y),
+                                       metal::max(v.z, v.w));
+            float4 e = metal::fast::exp(v - row_max) * active;
+            float4 r = e * (1.0f / (e.x + e.y + e.z + e.w + EPS))
+                     + EPS * active;
+
+            // Initial column normalization
+            float4 col_inv = 1.0f / (float4(
+                simd_sum(r.x), simd_sum(r.y),
+                simd_sum(r.z), simd_sum(r.w)
+            ) + EPS);
+            r *= col_inv;
+
+            // Sinkhorn iterations: zero branches in the loop body
+            for (int iter = 1; iter < ITERS; ++iter) {
+                // Row norm + re-clamp inactive lanes
+                r *= (1.0f / (r.x + r.y + r.z + r.w + EPS)) * active;
+
+                // Col norm via simd_sum
+                col_inv = 1.0f / (float4(
+                    simd_sum(r.x), simd_sum(r.y),
+                    simd_sum(r.z), simd_sum(r.w)
+                ) + EPS);
+                r *= col_inv;
+            }
+
+            if (lane < (uint)HC) {
+                *(device float4*)(comb_out + lane * HC) = r;
+            }
+        }
+
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        // ================================================================
+        // PHASE 2: Collapse — all 256 threads, vectorized
+        // ================================================================
+        const float p0 = pre_shared[0];
+        const float p1 = pre_shared[1];
+        const float p2 = pre_shared[2];
+        const float p3 = pre_shared[3];
+
+        const device T* x_row  = (const device T*)x_in
+                                         + row * (HC * D);
+        device U*       out_row = (device U*)collapsed
+                                         + row * D;
+
+        using T4 = vec<T, 4>;
+        using U4 = vec<U, 4>;
+        const device T4* x_row0 = (const device T4*)(x_row + 0*D);
+        const device T4* x_row1 = (const device T4*)(x_row + 1*D);
+        const device T4* x_row2 = (const device T4*)(x_row + 2*D);
+        const device T4* x_row3 = (const device T4*)(x_row + 3*D);
+        device U4*       out4   = (device U4*)out_row;
+
+        constexpr uint D4 = (uint)D / 4;
+
+        for (uint d4 = tid; d4 < D4; d4 += 256) {
+            float4 x0 = float4(x_row0[d4]);
+            float4 x1 = float4(x_row1[d4]);
+            float4 x2 = float4(x_row2[d4]);
+            float4 x3 = float4(x_row3[d4]);
+
+            float4 result = fma(float4(p0), x0,
+                            fma(float4(p1), x1,
+                            fma(float4(p2), x2, float4(p3) * x3)));
+
+            out4[d4] = U4(result);
+        }
+
+        // Scalar tail for D not divisible by 4
+        #if (D % 4) != 0
+        for (uint d = D4 * 4 + tid; d < (uint)D; d += 256) {
+            float val = p0*(float)x_row[0*D+d] + p1*(float)x_row[1*D+d]
+                      + p2*(float)x_row[2*D+d] + p3*(float)x_row[3*D+d];
+            out_row[d] = (U)val;
+        }
+        #endif
+    """
+
+    return mx.fast.metal_kernel(
+        name="hc_sinkhorn_collapse",
+        input_names=["x_in", "mixes", "scale", "base"],
+        output_names=["collapsed", "post", "comb"],
+        source=source,
+        ensure_row_contiguous=True,
+    )
+
+
+_hc_sinkhorn_collapse_kernel = _make_hc_sinkhorn_collapse_kernel()
+
+
+def _hc_kernel(x, y, mixes, scale, base, hc_mult, sinkhorn_iters, eps):
+    B, L, H, D = x.shape
+
+    return _hc_sinkhorn_collapse_kernel(
+        inputs=[x, mixes, scale, base],
+        template=[
+            ("T", x.dtype),
+            ("U", x.dtype),
+            ("HC", hc_mult),
+            ("ITERS", sinkhorn_iters),
+            ("D", D),
+            ("EPS_INT", round(eps / 1e-9)),
+        ],
+        grid=(B * L * 256, 1, 1),
+        threadgroup=(256, 1, 1),
+        output_shapes=[(B, L, D), (B, L, hc_mult), (B, L, hc_mult, hc_mult)],
+        output_dtypes=[x.dtype, mx.float32, mx.float32],
+    )
+
+
+@mx.compile
+def _hc_split_sinkhorn_ops(
+    mixes: mx.array,
+    scale: mx.array,
+    base: mx.array,
+    hc_mult: int,
+    sinkhorn_iters: int,
+    eps: float,
+) -> Tuple[mx.array, mx.array, mx.array]:
+    mixes = mixes.astype(mx.float32)
+    scale = scale.astype(mx.float32)
+    base = base.astype(mx.float32)
+    pre_scale, post_scale, comb_scale = scale[0], scale[1], scale[2]
+
+    pre = mx.sigmoid(mixes[..., :hc_mult] * pre_scale + base[:hc_mult]) + eps
+    post = 2 * mx.sigmoid(
+        mixes[..., hc_mult : 2 * hc_mult] * post_scale + base[hc_mult : 2 * hc_mult]
+    )
+    comb = mixes[..., 2 * hc_mult :].reshape(
+        *mixes.shape[:-1], hc_mult, hc_mult
+    ) * comb_scale + base[2 * hc_mult :].reshape(hc_mult, hc_mult)
+    comb = mx.softmax(comb, axis=-1, precise=True) + eps
+    comb = comb / (comb.sum(axis=-2, keepdims=True) + eps)
+    for _ in range(max(sinkhorn_iters - 1, 0)):
+        comb = comb / (comb.sum(axis=-1, keepdims=True) + eps)
+        comb = comb / (comb.sum(axis=-2, keepdims=True) + eps)
+    return pre, post, comb
+
+
+def _hc_ops(x, y, mixes, scale, base, hc_mult, sinkhorn_iters, eps):
+    pre, post, comb = _hc_split_sinkhorn_ops(
+        mixes, scale, base, hc_mult, sinkhorn_iters, eps
+    )
+    return (pre[..., None] * y).sum(axis=2).astype(x.dtype), post, comb
+
+
+class HyperConnection(nn.Module):
+    def __init__(self, config):
+        super().__init__()
+        self.hc_mult = config.hc_mult
+        self.sinkhorn_iters = config.hc_sinkhorn_iters
+        self.hc_eps = config.hc_eps
+        self.norm_eps = config.rms_norm_eps
+
+        mix = (2 + self.hc_mult) * self.hc_mult
+        self.fn = mx.zeros((mix, self.hc_mult * config.hidden_size), dtype=mx.float32)
+        self.base = mx.zeros((mix,), dtype=mx.float32)
+        self.scale = mx.ones((3,), dtype=mx.float32)
+
+    def __call__(self, x: mx.array):
+        B, L, H, D = x.shape
+        y = x.astype(mx.float32)
+        z = mx.fast.rms_norm(y.flatten(-2), None, self.norm_eps)
+        mixes = z @ self.fn.T
+
+        use_ops = (
+            self.training
+            or mx.default_device() != mx.gpu
+            or not mx.metal.is_available()
+        )
+        hc_func = _hc_ops if use_ops else _hc_kernel
+
+        return hc_func(
+            x,
+            y,
+            mixes,
+            self.scale,
+            self.base,
+            self.hc_mult,
+            self.sinkhorn_iters,
+            self.hc_eps,
+        )
+
+
+@mx.compile
+def _hc_expand_op(x, residual, post, comb):
+    y = post[..., None] * x[:, :, None, :].astype(mx.float32)
+    y = y + mx.matmul(comb.swapaxes(-1, -2), residual.astype(mx.float32))
+    return y.astype(x.dtype)
+
+
+def hc_expand(x, residual, post, comb):
+    return _hc_expand_op(x, residual, post, comb)
+
+
+class HyperHead(nn.Module):
+    def __init__(self, config):
+        super().__init__()
+        self.hc_mult = config.hc_mult
+        self.norm_eps = config.rms_norm_eps
+        self.hc_eps = config.hc_eps
+        self.fn = mx.zeros(
+            (self.hc_mult, self.hc_mult * config.hidden_size), dtype=mx.float32
+        )
+        self.base = mx.zeros((self.hc_mult,), dtype=mx.float32)
+        self.scale = mx.ones((1,), dtype=mx.float32)
+
+    def __call__(self, x: mx.array):
+        y = x.astype(mx.float32)
+        z = mx.fast.rms_norm(y.flatten(-2), None, self.norm_eps)
+        mixes = z @ self.fn.T
+        pre = mx.sigmoid(mixes * self.scale + self.base) + self.hc_eps
+        return (pre[..., None] * y).sum(axis=2).astype(x.dtype)

--- a/vllm_mlx/models/deepseek_v4_switch.py
+++ b/vllm_mlx/models/deepseek_v4_switch.py
@@ -1,0 +1,58 @@
+# Copyright © 2026 Apple Inc.
+# FusedSwitchGLU vendored from spicyneuron/mlx-lm@df50b7a3 for DeepSeek V4.
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from .. import _mlx_compat as _mlx_compat
+
+_mlx_compat.install()
+
+from mlx_lm.models.switch_layers import (
+    SwiGLU,
+    SwitchLinear,
+    _gather_sort,
+    _scatter_unsort,
+)
+
+
+class FusedSwitchGLU(nn.Module):
+    """Fused gate/up sparse expert projection used by DeepSeek V4."""
+
+    def __init__(
+        self,
+        input_dims: int,
+        hidden_dims: int,
+        num_experts: int,
+        activation=SwiGLU(),
+        bias: bool = False,
+    ):
+        super().__init__()
+        self.gate_proj = SwitchLinear(
+            input_dims, 2 * hidden_dims, num_experts, bias=bias
+        )
+        self.down_proj = SwitchLinear(hidden_dims, input_dims, num_experts, bias=bias)
+        self.activation = activation
+        self.hidden_dims = hidden_dims
+
+    def __call__(self, x, indices) -> mx.array:
+        x = mx.expand_dims(x, (-2, -3))
+        do_sort = indices.size >= 64
+        idx = indices
+        inv_order = None
+        if do_sort:
+            x, idx, inv_order = _gather_sort(x, indices)
+        if self.training:
+            idx = mx.stop_gradient(idx)
+
+        x_gate, x_up = mx.split(
+            self.gate_proj(x, idx, sorted_indices=do_sort),
+            [self.hidden_dims],
+            axis=-1,
+        )
+        x = self.down_proj(
+            self.activation(x_up, x_gate), idx, sorted_indices=do_sort
+        )
+        if do_sort:
+            x = _scatter_unsort(x, inv_order, indices.shape)
+        return x.squeeze(-2)

--- a/vllm_mlx/runtime/disk_kv_checkpoint.py
+++ b/vllm_mlx/runtime/disk_kv_checkpoint.py
@@ -491,6 +491,30 @@ def write_checkpoint(
     if cache is None or not cache:
         return None
 
+    # ``mlx_lm.load_prompt_cache`` reconstructs every cache by looking up its
+    # class name in ``mlx_lm.models.cache``. Vendored architectures can carry
+    # custom cache classes (DeepSeek V4 pooling caches are the first example),
+    # which may even make the upstream writer fail with ``std::bad_cast`` when
+    # their state includes optional buffers. Reject those shapes before doing
+    # filesystem work; the scheduler marks the request checkpoint-disabled
+    # after this clean ``None`` result instead of retrying or logging a scary
+    # serialization traceback while inference itself remains healthy.
+    try:
+        import mlx_lm.models.cache as _mlx_cache
+
+        pending = list(cache)
+        while pending:
+            item = pending.pop()
+            if getattr(_mlx_cache, type(item).__name__, None) is not type(item):
+                logger.debug(
+                    "[disk_kv_checkpoint] unsupported cache class %s; skipping",
+                    type(item).__name__,
+                )
+                return None
+            pending.extend(getattr(item, "caches", ()) or ())
+    except Exception:
+        return None
+
     with _DISK_LOCK:
         try:
             from mlx_lm.models.cache import save_prompt_cache

--- a/vllm_mlx/runtime/disk_kv_checkpoint.py
+++ b/vllm_mlx/runtime/disk_kv_checkpoint.py
@@ -513,6 +513,10 @@ def write_checkpoint(
                 return None
             pending.extend(getattr(item, "caches", ()) or ())
     except Exception:
+        logger.warning(
+            "[disk_kv_checkpoint] cache compatibility check failed; skipping",
+            exc_info=True,
+        )
         return None
 
     with _DISK_LOCK:


### PR DESCRIPTION
## Summary

- replace the stale DeepSeek V4 vendored runtime with the correctness-fixed `_ds4` implementation from `spicyneuron/mlx-lm@df50b7a3`
- vendor the required pooling-cache, hyper-connection, and fused sparse-GLU helpers missing from released mlx-lm
- route direct/local 0731 checkpoints to the official DSML tool parser and DeepSeek reasoning parser
- retain the official 0731 prompt encoder and recommend the checkpoint's `temperature=1.0`, `top_p=1.0` defaults
- skip disk KV checkpoint serialization cleanly for unregistered vendored cache classes

## Root cause

The old vendored numerical implementation diverged from the corrected DeepSeek V4 cache/attention path. Short arithmetic could succeed while longer prompts produced unrelated or repetitive text. Direct local-path serving also fell through to the generic DeepSeek parser configuration, and the default disk checkpoint writer attempted to serialize custom pooling caches that cannot round-trip through mlx-lm's class registry.

## Validation

- local wheel built and installed from `dist/rapid_mlx-0.11.4-py3-none-any.whl`
- real 155.6 GB `Vontra/DeepSeek-V4-Flash-0731-MXFP4-MLX` checkpoint loaded exclusively from the wheel
- correctness: arithmetic, probability, Python generation/debugging, Chinese fiction, English science, multi-turn memory, DSML tool calling
- protocol: streaming terminated with `[DONE]`; reasoning separated into `reasoning_content`; tool request returned OpenAI-compatible `tool_calls`
- concurrency: two simultaneous requests completed correctly at 17.7 tok/s each (~35.4 tok/s aggregate); post-concurrency request succeeded immediately
- single-request sustained generation: ~29-30 tok/s
- targeted regression suite: 377 passed
- complete unit run: 14,946 passed; 14 unrelated environment/baseline failures (12 tests require external servers, one pre-existing release-script assertion, and the MLX compat finding fixed afterward)
- post-review MLX compatibility + DeepSeek suite: 344 passed
- ruff check/format and `git diff --check`: passed
