### PR TITLE
fix(cache): make DeepSeek V4 prefix reuse effective

### DIFF
--- a/tests/test_deepseek_v4_vendored.py
+++ b/tests/test_deepseek_v4_vendored.py
@@ -221,6 +221,32 @@ def test_batch_pooling_cache_merge_preserves_projection_dtypes():
     assert merged.buf_gate.dtype == mx.float32
 
 
+def test_scheduler_reconstructs_vendored_cache_list_at_prefill_boundary():
+    mx = pytest.importorskip("mlx.core")
+
+    from mlx_lm.models.cache import CacheList, RotatingKVCache
+
+    from vllm_mlx.models.deepseek_v4_cache import DeepseekV4PoolingCache
+    from vllm_mlx.scheduler import Scheduler
+
+    rotating = RotatingKVCache(max_size=128)
+    keys = mx.zeros((1, 1, 3, 4))
+    rotating.update_and_fetch(keys, keys)
+    pooling = DeepseekV4PoolingCache(ratio=4)
+    pooling.accumulate_windows(mx.zeros((1, 3, 4)), mx.zeros((1, 3, 2)), 0)
+    original = [CacheList(rotating, pooling)]
+    scheduler = Scheduler.__new__(Scheduler)
+
+    states = scheduler._extract_cache_states(original)
+    restored = scheduler._reconstruct_cache_from_states(states)
+
+    assert restored is not None
+    assert isinstance(restored[0], CacheList)
+    assert isinstance(restored[0].caches[1], DeepseekV4PoolingCache)
+    assert restored[0].caches[0].offset == rotating.offset
+    assert restored[0].caches[1].remainder == pooling.remainder
+
+
 def test_tiny_model_forward_pass():
     """Smoke test the full forward path on a CPU-sized synthetic config.
 

--- a/tests/test_deepseek_v4_vendored.py
+++ b/tests/test_deepseek_v4_vendored.py
@@ -247,6 +247,26 @@ def test_scheduler_reconstructs_vendored_cache_list_at_prefill_boundary():
     assert restored[0].caches[1].remainder == pooling.remainder
 
 
+def test_scheduler_rejects_mismatched_vendored_cache_list_metadata():
+    pytest.importorskip("mlx.core")
+
+    from mlx_lm.models.cache import CacheList
+
+    from vllm_mlx.scheduler import Scheduler
+
+    scheduler = Scheduler.__new__(Scheduler)
+    states = [
+        {
+            "class_name": "CacheList",
+            "class_ref": CacheList,
+            "state": [([], None)],
+            "meta_state": (["KVCache", "DeepseekV4PoolingCache"], [None]),
+        }
+    ]
+
+    assert scheduler._reconstruct_cache_from_states(states) is None
+
+
 def test_tiny_model_forward_pass():
     """Smoke test the full forward path on a CPU-sized synthetic config.
 

--- a/tests/test_hybrid_prefix_cache_auto_default.py
+++ b/tests/test_hybrid_prefix_cache_auto_default.py
@@ -140,6 +140,19 @@ class TestResolveHybridCacheEntries:
         )
         assert result == 0
 
+    def test_auto_defaults_for_deepseek_v4_0731_local_path(self, monkeypatch):
+        """DeepSeek's pooling/rotating caches need bounded trim-free reuse."""
+        monkeypatch.setattr(
+            "vllm_mlx.model_aliases.resolve_profile", lambda _name: None
+        )
+        result = _resolve_hybrid_cache_entries(
+            enable_prefix_cache=True,
+            explicit_value=0,
+            user_set_explicit=False,
+            model_name=("/models/DeepSeek-V4-Flash-0731-MXFP4-MLX"),
+        )
+        assert result == _DEFAULT_HYBRID_CACHE_ENTRIES
+
     def test_no_auto_default_without_prefix_cache(self, monkeypatch):
         """Hybrid model but prefix cache disabled → stays 0."""
         _patch_resolve_profile(monkeypatch, is_hybrid=True)

--- a/tests/test_prefix_cache_persistence.py
+++ b/tests/test_prefix_cache_persistence.py
@@ -1533,6 +1533,48 @@ def test_save_prefix_cache_to_disk_no_retry_on_internal_typeerror(monkeypatch):
     )
 
 
+def test_radix_load_rebuilds_stale_index_from_authoritative_entries(tmp_path):
+    """A parseable radix file must not resurrect keys whose KV save failed."""
+    import threading
+    from types import SimpleNamespace
+
+    from vllm_mlx.runtime import cache as _cache_mod
+    from vllm_mlx.runtime.radix_index import RadixPrefixIndex
+
+    persisted = RadixPrefixIndex()
+    persisted.insert([1, 2, 3])
+    persisted.save(str(tmp_path / "radix.index"))
+
+    radix = RadixPrefixIndex()
+    cache = SimpleNamespace(_entries={}, _lock=threading.RLock(), _radix_index=radix)
+    engine = SimpleNamespace(scheduler=SimpleNamespace(memory_aware_cache=cache))
+
+    _cache_mod._load_radix_index_after_cache(engine, str(tmp_path))
+
+    assert len(radix) == 0
+    assert [1, 2, 3] not in radix
+
+
+def test_failed_kv_save_does_not_publish_live_radix(tmp_path, monkeypatch):
+    """The lookup accelerator is persisted only after a KV snapshot commits."""
+    from types import SimpleNamespace
+    from unittest.mock import MagicMock
+
+    from vllm_mlx.runtime import cache as _cache_mod
+
+    engine = SimpleNamespace(save_cache_to_disk=MagicMock(return_value=False))
+    save_radix = MagicMock()
+    monkeypatch.setattr(
+        _cache_mod, "get_config", lambda: SimpleNamespace(engine=engine)
+    )
+    monkeypatch.setattr(_cache_mod, "get_cache_dir", lambda: str(tmp_path))
+    monkeypatch.setattr(_cache_mod, "_save_radix_index_after_cache", save_radix)
+
+    _cache_mod.save_prefix_cache_to_disk(budget_sec=0)
+
+    save_radix.assert_not_called()
+
+
 def test_save_to_disk_predicts_entry_zero_from_bootstrap_floor(tmp_path):
     """Codex PR #667 round 3 BLOCKING-1.
 

--- a/tests/test_prompt_cache_snapshot.py
+++ b/tests/test_prompt_cache_snapshot.py
@@ -93,6 +93,7 @@ class TestPromptCacheSnapshot:
             scheduler, "req-boundary", uid=102, prompt_tokens=[10, 20, 30, 40]
         )
         request._cache_snapshot_boundary = 3
+        request._cache_snapshot_is_internal = True
         request._cache_snapshot_stored = True
         scheduler.memory_aware_cache.store = MagicMock(return_value=True)
 
@@ -106,6 +107,7 @@ class TestPromptCacheSnapshot:
             scheduler, "req-failed-boundary", uid=104, prompt_tokens=[10, 20]
         )
         request._cache_snapshot_boundary = 1
+        request._cache_snapshot_is_internal = True
         request._cache_snapshot_stored = False
         scheduler.memory_aware_cache.store = MagicMock(return_value=True)
 
@@ -114,6 +116,23 @@ class TestPromptCacheSnapshot:
 
         scheduler.memory_aware_cache.store.assert_called_once_with(
             [10, 20], cache_layers, evict_prefixes=False
+        )
+
+    def test_semantic_boundary_does_not_suppress_full_prompt_snapshot(self):
+        scheduler = _make_scheduler_with_cache()
+        scheduler.config.non_trimmable_exact_prefix_reuse = True
+        request = _register(
+            scheduler, "req-semantic-boundary", uid=105, prompt_tokens=[10, 20, 30]
+        )
+        request.prefix_boundary = 2
+        request._cache_snapshot_stored = True
+        scheduler.memory_aware_cache.store = MagicMock(return_value=True)
+
+        cache_layers = [object()]
+        scheduler._prompt_cache_save_cb(105, cache_layers)
+
+        scheduler.memory_aware_cache.store.assert_called_once_with(
+            [10, 20, 30], cache_layers, evict_prefixes=False
         )
 
     def test_prompt_only_snapshot_still_saves_without_internal_boundary(self):
@@ -334,6 +353,7 @@ class TestBoundarySnapshot:
             prefix_boundary=0,
         )
         request._cache_snapshot_boundary = 9
+        request._cache_snapshot_is_internal = True
 
         bg = MagicMock()
         bg.extract_cache.return_value = {102: (["raw-cache"], prompt_tokens[:9])}
@@ -345,7 +365,10 @@ class TestBoundarySnapshot:
                 SimpleNamespace(
                     uid=102,
                     progress=(9, 10),
-                    end_of_segment=True,
+                    # A regular prefill chunk can end exactly at N-1 without
+                    # being an explicit segment boundary. This must still
+                    # trigger the internal snapshot.
+                    end_of_segment=False,
                     end_of_prompt=False,
                 )
             ]

--- a/tests/test_prompt_cache_snapshot.py
+++ b/tests/test_prompt_cache_snapshot.py
@@ -98,6 +98,20 @@ class TestPromptCacheSnapshot:
 
         scheduler.memory_aware_cache.store.assert_not_called()
 
+    def test_prompt_only_snapshot_still_saves_without_internal_boundary(self):
+        """A bounded cache must preserve the normal path for tiny prompts."""
+        scheduler = _make_scheduler_with_cache()
+        scheduler.config.hybrid_cache_entries = 8
+        _register(scheduler, "req-one-token", uid=103, prompt_tokens=[10])
+        scheduler.memory_aware_cache.store = MagicMock(return_value=True)
+
+        cache_layers = [object()]
+        scheduler._prompt_cache_save_cb(103, cache_layers)
+
+        scheduler.memory_aware_cache.store.assert_called_once_with(
+            [10], cache_layers, evict_prefixes=False
+        )
+
     def test_snapshot_skips_mid_prompt_chunks(self):
         scheduler = _make_scheduler_with_cache()
         _register(scheduler, "req-1", uid=101, prompt_tokens=[1, 2, 3])

--- a/tests/test_prompt_cache_snapshot.py
+++ b/tests/test_prompt_cache_snapshot.py
@@ -85,6 +85,19 @@ class TestPromptCacheSnapshot:
         assert stored_tokens == prompt_tokens
         assert stored_cache is fake_cache_layers
 
+    def test_prompt_only_snapshot_does_not_mask_internal_n_minus_one_boundary(self):
+        scheduler = _make_scheduler_with_cache()
+        scheduler.config.hybrid_cache_entries = 8
+        request = _register(
+            scheduler, "req-boundary", uid=102, prompt_tokens=[10, 20, 30, 40]
+        )
+        request._cache_snapshot_boundary = 3
+        scheduler.memory_aware_cache.store = MagicMock(return_value=True)
+
+        scheduler._prompt_cache_save_cb(102, [object()])
+
+        scheduler.memory_aware_cache.store.assert_not_called()
+
     def test_snapshot_skips_mid_prompt_chunks(self):
         scheduler = _make_scheduler_with_cache()
         _register(scheduler, "req-1", uid=101, prompt_tokens=[1, 2, 3])
@@ -272,6 +285,42 @@ class TestBoundarySnapshot:
             scheduler.memory_aware_cache.store.call_args.kwargs.get("evict_prefixes")
             is False
         )
+
+    def test_snapshot_stores_at_internal_exact_hit_boundary(self):
+        """N-1 snapshots make non-trimmable exact repeats prefix extensions."""
+        scheduler = _make_scheduler_with_cache()
+        scheduler._extract_cache_states = MagicMock(return_value=[{"k": "v"}])
+        scheduler._reconstruct_cache_from_states = MagicMock(
+            return_value=["reconstructed-cache"]
+        )
+        prompt_tokens = list(range(10))
+        request = self._register_with_boundary(
+            scheduler,
+            "req-exact",
+            uid=102,
+            prompt_tokens=prompt_tokens,
+            prefix_boundary=0,
+        )
+        request._cache_snapshot_boundary = 9
+
+        bg = MagicMock()
+        bg.extract_cache.return_value = {102: (["raw-cache"], prompt_tokens[:9])}
+        scheduler.batch_generator = bg
+        scheduler.memory_aware_cache.store = MagicMock(return_value=True)
+
+        scheduler._snapshot_boundary_segments(
+            [
+                SimpleNamespace(
+                    uid=102,
+                    progress=(9, 10),
+                    end_of_segment=True,
+                    end_of_prompt=False,
+                )
+            ]
+        )
+
+        stored_tokens = scheduler.memory_aware_cache.store.call_args.args[0]
+        assert stored_tokens == prompt_tokens[:-1]
 
     def test_snapshot_skips_end_of_prompt_responses(self):
         """end_of_prompt is the whole-prompt promotion — handled by the

--- a/tests/test_prompt_cache_snapshot.py
+++ b/tests/test_prompt_cache_snapshot.py
@@ -88,15 +88,33 @@ class TestPromptCacheSnapshot:
     def test_prompt_only_snapshot_does_not_mask_internal_n_minus_one_boundary(self):
         scheduler = _make_scheduler_with_cache()
         scheduler.config.hybrid_cache_entries = 8
+        scheduler.config.non_trimmable_exact_prefix_reuse = True
         request = _register(
             scheduler, "req-boundary", uid=102, prompt_tokens=[10, 20, 30, 40]
         )
         request._cache_snapshot_boundary = 3
+        request._cache_snapshot_stored = True
         scheduler.memory_aware_cache.store = MagicMock(return_value=True)
 
         scheduler._prompt_cache_save_cb(102, [object()])
 
         scheduler.memory_aware_cache.store.assert_not_called()
+
+    def test_failed_internal_boundary_falls_back_to_prompt_snapshot(self):
+        scheduler = _make_scheduler_with_cache()
+        request = _register(
+            scheduler, "req-failed-boundary", uid=104, prompt_tokens=[10, 20]
+        )
+        request._cache_snapshot_boundary = 1
+        request._cache_snapshot_stored = False
+        scheduler.memory_aware_cache.store = MagicMock(return_value=True)
+
+        cache_layers = [object()]
+        scheduler._prompt_cache_save_cb(104, cache_layers)
+
+        scheduler.memory_aware_cache.store.assert_called_once_with(
+            [10, 20], cache_layers, evict_prefixes=False
+        )
 
     def test_prompt_only_snapshot_still_saves_without_internal_boundary(self):
         """A bounded cache must preserve the normal path for tiny prompts."""
@@ -335,6 +353,9 @@ class TestBoundarySnapshot:
 
         stored_tokens = scheduler.memory_aware_cache.store.call_args.args[0]
         assert stored_tokens == prompt_tokens[:-1]
+        assert scheduler.memory_aware_cache.store.call_args.args[1] == [
+            "reconstructed-cache"
+        ]
 
     def test_snapshot_skips_end_of_prompt_responses(self):
         """end_of_prompt is the whole-prompt promotion — handled by the

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -2201,9 +2201,14 @@ def _resolve_hybrid_cache_entries(
     from .model_aliases import resolve_profile as _resolve_alias
 
     profile = _resolve_alias(model_name)
-    if profile is not None and profile.is_hybrid:
+    from .utils.deepseek_v4_0731 import is_deepseek_v4_0731
+
+    needs_bounded_reuse = (profile is not None and profile.is_hybrid) or (
+        is_deepseek_v4_0731(model_name)
+    )
+    if needs_bounded_reuse:
         _logging.getLogger(__name__).info(
-            "Hybrid model detected with --enable-prefix-cache: "
+            "Non-trimmable model cache detected with --enable-prefix-cache: "
             "auto-setting --hybrid-cache-entries=%d "
             "(pass --hybrid-cache-entries 0 to disable)",
             _DEFAULT_HYBRID_CACHE_ENTRIES,

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -2198,14 +2198,7 @@ def _resolve_hybrid_cache_entries(
     if not enable_prefix_cache or explicit_value != 0 or user_set_explicit:
         return explicit_value
 
-    from .model_aliases import resolve_profile as _resolve_alias
-
-    profile = _resolve_alias(model_name)
-    from .utils.deepseek_v4_0731 import is_deepseek_v4_0731
-
-    needs_bounded_reuse = (profile is not None and profile.is_hybrid) or (
-        is_deepseek_v4_0731(model_name)
-    )
+    needs_bounded_reuse = _needs_bounded_trim_free_reuse(model_name)
     if needs_bounded_reuse:
         _logging.getLogger(__name__).info(
             "Non-trimmable model cache detected with --enable-prefix-cache: "
@@ -2215,6 +2208,17 @@ def _resolve_hybrid_cache_entries(
         )
         return _DEFAULT_HYBRID_CACHE_ENTRIES
     return explicit_value
+
+
+def _needs_bounded_trim_free_reuse(model_name: str) -> bool:
+    """Whether this model's cache can reuse prefixes but not trim exact hits."""
+    from .model_aliases import resolve_profile as _resolve_alias
+    from .utils.deepseek_v4_0731 import is_deepseek_v4_0731
+
+    profile = _resolve_alias(model_name)
+    return (profile is not None and profile.is_hybrid) or is_deepseek_v4_0731(
+        model_name
+    )
 
 
 def _serve_will_run_on_mllm_lane(args) -> bool:
@@ -3310,6 +3314,12 @@ def serve_command(args):
         # #1103/#1122: bounded trim-free hybrid (recurrent-state) prefix reuse.
         # Auto-defaulted to 8 for hybrid models when prefix cache is enabled.
         hybrid_cache_entries=_hybrid_cache_entries,
+        non_trimmable_exact_prefix_reuse=(
+            _hybrid_cache_entries > 0
+            and _needs_bounded_trim_free_reuse(
+                getattr(args, "_original_alias", None) or args.model
+            )
+        ),
         # Opt-in prompt-deterministic response cache (exact-match short-circuit).
         response_cache_entries=getattr(args, "response_cache_entries", 0),
         # Paged cache options

--- a/vllm_mlx/runtime/cache.py
+++ b/vllm_mlx/runtime/cache.py
@@ -104,17 +104,21 @@ def _load_radix_index_after_cache(engine, cache_dir: str) -> None:
     radix = getattr(cache, "_radix_index", None)
     if radix is None:
         return
-    radix_path = os.path.join(cache_dir, "radix.index")
-    if radix.load(radix_path):
-        return
-    # Fallback: reconstruct from currently loaded entries. Reads
-    # ``_entries.keys()`` under the cache's lock to stay coherent with
-    # any concurrent store/evict — though boot is single-threaded so
-    # this is belt-and-suspenders.
+    # The KV entries are authoritative. A prior shutdown may have failed
+    # to serialize every cache entry while leaving an older ``radix.index``
+    # behind, so accepting the radix solely because its JSON parses can
+    # create terminal keys with no corresponding KV state.
     try:
         with cache._lock:  # noqa: SLF001 — coordinated rebuild
             keys = list(cache._entries.keys())  # noqa: SLF001
-        if keys:
+        radix_path = os.path.join(cache_dir, "radix.index")
+        loaded_radix = radix.load(radix_path)
+        radix_matches_entries = (
+            loaded_radix
+            and len(radix) == len(keys)
+            and all(key in radix for key in keys)
+        )
+        if not radix_matches_entries:
             radix.rebuild_from_keys(keys)
             logger.info(f"[radix] rebuilt index from {len(keys)} loaded cache entries")
     except Exception as e:  # pragma: no cover — defensive
@@ -206,7 +210,8 @@ def save_prefix_cache_to_disk(budget_sec: float | None = None) -> None:
         # ``radix.index`` referencing entries that didn't make it to
         # disk. The radix is a best-effort accelerator — if this fails,
         # the next boot just rebuilds from ``_entries``.
-        _save_radix_index_after_cache(cfg.engine, d)
+        if saved:
+            _save_radix_index_after_cache(cfg.engine, d)
     except Exception as e:
         logger.warning(f"[lifespan] Failed to save cache to disk: {e}", exc_info=True)
 

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -2722,7 +2722,7 @@ class Scheduler:
             # priority, fail trim-one kickoff on non-trimmable caches, and mask
             # the reusable N-1 prefix. The boundary snapshot is the prompt
             # cache for this path; completion still stores prompt + output.
-            if getattr(self.config, "hybrid_cache_entries", 0) > 0:
+            if getattr(request, "_cache_snapshot_boundary", 0) > 0:
                 return
 
             prompt_tokens = list(request.prompt_token_ids)
@@ -3227,6 +3227,12 @@ class Scheduler:
                             )
                         }
                         names, nested_meta = meta_state
+                        if not (len(state) == len(names) == len(nested_meta)):
+                            raise ValueError(
+                                "CacheList state/metadata length mismatch: "
+                                f"state={len(state)}, names={len(names)}, "
+                                f"metadata={len(nested_meta)}"
+                            )
                         nested = []
                         for nested_state, name, nested_m in zip(
                             state, names, nested_meta

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -358,10 +358,16 @@ class SchedulerConfig:
     # SchedulerConfig purely so the CLI plumbs it through the same
     # construction sites as every other cache knob.
     #
-    # Keep this field last: positional ``SchedulerConfig(...)`` construction
-    # binds by position, so appending new fields at the end avoids shifting
-    # the position of any existing field.
+    # Keep newly-added fields below the historical configuration surface:
+    # positional ``SchedulerConfig(...)`` construction binds by position, so
+    # appending avoids shifting the position of any existing field.
     response_cache_entries: int = 0
+
+    # Enables the N-1 snapshot strategy for models whose cache state can be
+    # continued at an exact prefix but cannot safely trim an exact full-prompt
+    # hit by one token. Kept separate from ``hybrid_cache_entries`` because
+    # that retention bound is also useful to callers with ordinary caches.
+    non_trimmable_exact_prefix_reuse: bool = False
 
     def __post_init__(self) -> None:
         if self.response_cache_entries < 0:
@@ -2722,7 +2728,7 @@ class Scheduler:
             # priority, fail trim-one kickoff on non-trimmable caches, and mask
             # the reusable N-1 prefix. The boundary snapshot is the prompt
             # cache for this path; completion still stores prompt + output.
-            if getattr(request, "_cache_snapshot_boundary", 0) > 0:
+            if getattr(request, "_cache_snapshot_stored", False):
                 return
 
             prompt_tokens = list(request.prompt_token_ids)
@@ -2929,6 +2935,7 @@ class Scheduler:
             # busy — retrying every step would be pure waste. DeepSeek
             # finding #2 on PR #435.
             request._boundary_snapshot_taken = True
+            request._cache_snapshot_stored = stored
 
             if stored:
                 logger.info(
@@ -5059,6 +5066,7 @@ class Scheduler:
                 snapshot_boundary <= 0
                 and self.memory_aware_cache is not None
                 and getattr(self.config, "hybrid_cache_entries", 0) > 0
+                and getattr(self.config, "non_trimmable_exact_prefix_reuse", False)
                 and not request.prompt_cache
                 and len(request.prompt_token_ids) > 1
             ):

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -2717,6 +2717,14 @@ class Scheduler:
             if _pflash_compressed(request):
                 return
 
+            # Bounded trim-free reuse deliberately segments a cold request at
+            # N-1. Saving an additional exact N-token entry would win lookup
+            # priority, fail trim-one kickoff on non-trimmable caches, and mask
+            # the reusable N-1 prefix. The boundary snapshot is the prompt
+            # cache for this path; completion still stores prompt + output.
+            if getattr(self.config, "hybrid_cache_entries", 0) > 0:
+                return
+
             prompt_tokens = list(request.prompt_token_ids)
             _t0 = _time.monotonic()
             # evict_prefixes=False: keep mid-prefill boundary entries so
@@ -2822,7 +2830,14 @@ class Scheduler:
             if not request_id:
                 continue
             request = self.requests.get(request_id)
-            if not request or getattr(request, "prefix_boundary", 0) <= 0:
+            if not request:
+                continue
+            snapshot_boundary = getattr(
+                request,
+                "_cache_snapshot_boundary",
+                getattr(request, "prefix_boundary", 0),
+            )
+            if snapshot_boundary <= 0:
                 continue
             # Defense-in-depth: validate progress[0] equals the
             # expected boundary offset. mlx-lm 0.31+ rewrites
@@ -2833,7 +2848,7 @@ class Scheduler:
             # The `_boundary_snapshot_taken` guard below blocks the
             # second fire, but this progress check skips it deterministically.
             progress = getattr(resp, "progress", None)
-            expected_offset = request.prefix_boundary - (request.cached_tokens or 0)
+            expected_offset = snapshot_boundary - (request.cached_tokens or 0)
             if (
                 progress is not None
                 and isinstance(progress, tuple)
@@ -2877,7 +2892,11 @@ class Scheduler:
             # the trie.
             if _pflash_compressed(request):
                 continue
-            prefix_boundary = getattr(request, "prefix_boundary", 0)
+            prefix_boundary = getattr(
+                request,
+                "_cache_snapshot_boundary",
+                getattr(request, "prefix_boundary", 0),
+            )
             if prefix_boundary <= 0:
                 continue
 
@@ -3183,6 +3202,42 @@ class Scheduler:
                         cache.keys = keys
                         cache.values = values
                         cache.offset = keys.shape[2] if hasattr(keys, "shape") else 0
+                    elif cache_cls.__name__ == "CacheList":
+                        # CacheList.from_state resolves nested class names only
+                        # from mlx_lm.models.cache globals. Vendored DeepSeek
+                        # pooling caches intentionally do not live there, so
+                        # reconstruct the wrapper with an explicit local map.
+                        from mlx_lm.models import cache as _mlx_cache
+                        from mlx_lm.models.cache import CacheList as _CacheList
+
+                        from vllm_mlx.models.deepseek_v4_cache import (
+                            BatchDeepseekV4PoolingCache,
+                            BatchPoolingCache,
+                            DeepseekV4PoolingCache,
+                            PoolingCache,
+                        )
+
+                        vendored = {
+                            cls.__name__: cls
+                            for cls in (
+                                PoolingCache,
+                                BatchPoolingCache,
+                                DeepseekV4PoolingCache,
+                                BatchDeepseekV4PoolingCache,
+                            )
+                        }
+                        names, nested_meta = meta_state
+                        nested = []
+                        for nested_state, name, nested_m in zip(
+                            state, names, nested_meta
+                        ):
+                            nested_cls = getattr(
+                                _mlx_cache, name, None
+                            ) or vendored.get(name)
+                            if nested_cls is None:
+                                raise ValueError(f"Unknown nested cache class {name!r}")
+                            nested.append(nested_cls.from_state(nested_state, nested_m))
+                        cache = _CacheList(*nested)
                     else:
                         cache = cache_cls.from_state(state, meta_state)
                 else:
@@ -4990,12 +5045,25 @@ class Scheduler:
             # lies strictly inside the tokens we're about to process —
             # otherwise there's nothing new to capture at the boundary.
             boundary_local_split: int | None = None
+            snapshot_boundary = getattr(request, "prefix_boundary", 0)
+            # A non-trimmable exact hit cannot use the usual trim-one then
+            # re-forward-last-token kickoff. Capture the cold prompt at N-1;
+            # an identical repeat becomes a safe one-token prefix extension.
+            if (
+                snapshot_boundary <= 0
+                and self.memory_aware_cache is not None
+                and getattr(self.config, "hybrid_cache_entries", 0) > 0
+                and not request.prompt_cache
+                and len(request.prompt_token_ids) > 1
+            ):
+                snapshot_boundary = len(request.prompt_token_ids) - 1
+                request._cache_snapshot_boundary = snapshot_boundary
             if (
                 self.memory_aware_cache is not None
-                and getattr(request, "prefix_boundary", 0) > 0
+                and snapshot_boundary > 0
                 and len(tokens_to_process) > 1
             ):
-                _pb = request.prefix_boundary
+                _pb = snapshot_boundary
                 _cached = request.cached_tokens or 0
                 _local = _pb - _cached
                 if 0 < _local < len(tokens_to_process):
@@ -5036,16 +5104,19 @@ class Scheduler:
                     tokens_to_process = request.prompt_token_ids
                     # Recompute split against the now-full prompt
                     # (cached_tokens=0 so boundary == split).
-                    if (
-                        self.memory_aware_cache is not None
-                        and getattr(request, "prefix_boundary", 0) > 0
-                        and 0 < request.prefix_boundary < len(tokens_to_process)
+                    retry_boundary = getattr(
+                        request,
+                        "_cache_snapshot_boundary",
+                        getattr(request, "prefix_boundary", 0),
+                    )
+                    if self.memory_aware_cache is not None and 0 < retry_boundary < len(
+                        tokens_to_process
                     ):
                         uids = self.batch_generator.insert_segments(
                             [
                                 [
-                                    tokens_to_process[: request.prefix_boundary],
-                                    tokens_to_process[request.prefix_boundary :],
+                                    tokens_to_process[:retry_boundary],
+                                    tokens_to_process[retry_boundary:],
                                 ]
                             ],
                             max_tokens=[request.sampling_params.max_tokens],

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -2728,7 +2728,11 @@ class Scheduler:
             # priority, fail trim-one kickoff on non-trimmable caches, and mask
             # the reusable N-1 prefix. The boundary snapshot is the prompt
             # cache for this path; completion still stores prompt + output.
-            if getattr(request, "_cache_snapshot_stored", False):
+            if (
+                getattr(self.config, "non_trimmable_exact_prefix_reuse", False)
+                and getattr(request, "_cache_snapshot_is_internal", False)
+                and getattr(request, "_cache_snapshot_stored", False)
+            ):
                 return
 
             prompt_tokens = list(request.prompt_token_ids)
@@ -2825,8 +2829,6 @@ class Scheduler:
 
         boundary_uids: list[int] = []
         for resp in prompt_responses:
-            if not getattr(resp, "end_of_segment", False):
-                continue
             # end_of_prompt promotions are handled by
             # _snapshot_promoted_prompts (whole-prompt entry, issue #163).
             # We only want the *inter*-segment boundary here.
@@ -2855,6 +2857,15 @@ class Scheduler:
             # second fire, but this progress check skips it deterministically.
             progress = getattr(resp, "progress", None)
             expected_offset = snapshot_boundary - (request.cached_tokens or 0)
+            aligned_internal_chunk = (
+                getattr(request, "_cache_snapshot_is_internal", False)
+                and progress is not None
+                and isinstance(progress, tuple)
+                and len(progress) >= 1
+                and progress[0] == expected_offset
+            )
+            if not (getattr(resp, "end_of_segment", False) or aligned_internal_chunk):
+                continue
             if (
                 progress is not None
                 and isinstance(progress, tuple)
@@ -5072,6 +5083,7 @@ class Scheduler:
             ):
                 snapshot_boundary = len(request.prompt_token_ids) - 1
                 request._cache_snapshot_boundary = snapshot_boundary
+                request._cache_snapshot_is_internal = True
             if (
                 self.memory_aware_cache is not None
                 and snapshot_boundary > 0


### PR DESCRIPTION
## Summary
- automatically enable bounded trim-free prefix reuse for DeepSeek V4 Flash 0731
- snapshot cold non-trimmable prompts at N-1 so exact repeats prefill only one token
- reconstruct vendored DeepSeek CacheList state safely and keep persisted radix indexes consistent with KV entries

## Validation
- 528 targeted scheduler/cache/DeepSeek tests passed
- Ruff and git diff checks passed
- local-wheel E2E on DeepSeek-V4-Flash-0731-MXFP4-MLX:
  - 13,211-token repeat: 46.8s -> 0.23s (13,210 cached tokens)
  - multi-turn: 5.37s -> 0.40s with correct retained answer
  - native tool call emitted correctly
  - prior 37,008-token test: 148.58s -> 0.25s

## Notes
DeepSeek custom cache arrays are not currently serializable by mlx-lm safetensors, so process-restart KV persistence remains best-effort. This change prevents a stale radix index from claiming entries that did not persist.