### PR TITLE
chore: bump version to 0.11.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.11.4"
+version = "0.11.5"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
Bump version 0.11.4 → 0.11.5. Version-only bump (`pyproject.toml`); no code in
this PR. Merging to `main` triggers `auto-release.yml` → Tier-1 agentic gate
(Studio) → tag `v0.11.5` + build + cosign + PyPI Trusted Publishing.

## Why

Cut release 0.11.5 to ship DeepSeek V4 Flash 0731 support (now stabilized
end-to-end) plus the L1 CI release gate and the per-version telemetry canary.

## What's in 0.11.5 (v0.11.4..80fa5eb3, 6 commits)

DeepSeek V4 Flash 0731 — new model + serving stabilization:
- feat: support DeepSeek V4 Flash 0731 (#1364)
- fix: support mixed-length DeepSeek V4 batches (#1365)
- fix: stabilize DeepSeek V4 Flash 0731 serving (#1369)
- fix(cache): make DeepSeek V4 prefix reuse effective (#1371)

Release-quality infrastructure:
- ci: L1 small-model GPU smoke on free macos-14 — coherence + tool-call (Qwen+Llama) (#1366)
- feat(telemetry): client-side output_degenerate signal for per-version canary (#1250) (#1266)

Only touches the pyproject version line (per the inverted bump-guard: feature/fix
PRs must not change the version; this dedicated bump PR is the one that does).

## Pre-merge validation

- L0 local: ruff check + format, GHA pinning, CLI↔config fidelity, parser
  microbench, unit subset (334 passed) — green.
- L2 local gauntlet (`release_check_m3.sh`, qwen3.5-9b-4bit): G0a fleet coherence
  (5/5 aliases), G0b + G5 stress + G6/G7 SDK correctness + G7b hermes agentic —
  confirmed GREEN before merge.
- Bump-guard: feature/fix commits do not touch the version line; this PR changes
  only `version = "0.11.4"` → `"0.11.5"`.

## Updated README/docs if applicable

N/A — version-only bump; no user-facing surface changes in this PR.
