### PR TITLE
Fix DeepSeek DSML leakage in Responses streams

### DIFF
--- a/tests/test_responses_bundle.py
+++ b/tests/test_responses_bundle.py
@@ -80,6 +80,7 @@ class _Engine:
         reasoning_text: str = "",
         tool_calls: list | None = None,
         finish_reason: str = "stop",
+        stream_chunks: list[str] | None = None,
     ):
         self.calls: list[SimpleNamespace] = []
         self.stream_calls: list[SimpleNamespace] = []
@@ -88,6 +89,7 @@ class _Engine:
         self._reasoning_text = reasoning_text
         self._tool_calls = tool_calls
         self._finish_reason = finish_reason
+        self._stream_chunks = stream_chunks
 
     async def chat(self, messages, **kwargs):
         self.calls.append(SimpleNamespace(messages=messages, kwargs=kwargs))
@@ -105,7 +107,7 @@ class _Engine:
         """Emit a tiny synthetic stream: three text chunks then EOS, with
         optional reasoning_text and tool_calls on the final chunk."""
         self.stream_calls.append(SimpleNamespace(messages=messages, kwargs=kwargs))
-        chunks = ["Hello", " from", " rapid"]
+        chunks = self._stream_chunks or ["Hello", " from", " rapid"]
         for i, c in enumerate(chunks):
             yield _GenerationOutput(
                 text="".join(chunks[: i + 1]),
@@ -188,6 +190,7 @@ def _make_client(monkeypatch, engine: _Engine) -> SimpleNamespace:
     return SimpleNamespace(
         client=TestClient(app),
         engine=engine,
+        cfg=cfg,
         previous_modules=previous_modules,
         previous_attrs=previous_attrs,
         reset_config=reset_config,
@@ -372,6 +375,89 @@ class TestR10CrossLaneReasoningParity:
 # ---------------------------------------------------------------------------
 # Yuki F6 — tool_choice enforcement on /v1/responses
 # ---------------------------------------------------------------------------
+
+
+class TestDeepSeekV4ResponsesStreaming:
+    """Raw DSML must not be duplicated into Codex-visible text deltas."""
+
+    def test_split_dsml_is_only_emitted_as_a_structured_function_call(
+        self, make_responses_client
+    ):
+        # Import registers the model-specific parser with ToolParserManager.
+        import vllm_mlx.tool_parsers.deepseek_v4_0731_tool_parser  # noqa: F401
+
+        wire_chunks = [
+            "<｜DS",
+            "ML｜tool_calls>\n<｜DSML｜invoke name=\"exec_command\">\n",
+            '<｜DSML｜parameter name="cmd" string="true">pwd && ls',
+            "</｜DSML｜parameter>\n</｜DSML｜invoke>\n</｜DSML｜tool_",
+            "calls>",
+        ]
+        state = make_responses_client(
+            stream_chunks=wire_chunks,
+            finish_reason="tool_calls",
+        )
+        state.cfg.enable_auto_tool_choice = True
+        state.cfg.tool_call_parser = "deepseek_v4_0731"
+
+        with state.client.stream(
+            "POST",
+            "/v1/responses",
+            json=_payload(
+                stream=True,
+                tools=[
+                    {
+                        "type": "function",
+                        "name": "exec_command",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {"cmd": {"type": "string"}},
+                            "required": ["cmd"],
+                        },
+                    }
+                ],
+            ),
+            headers=_AUTH,
+        ) as resp:
+            assert resp.status_code == 200, resp.text
+            body = "".join(resp.iter_text())
+
+        events = _parse_sse(body)
+        visible_text = "".join(
+            event.get("delta", "")
+            for name, event in events
+            if name == "response.output_text.delta"
+        )
+        assert "DSML" not in visible_text
+        assert visible_text == ""
+
+        calls = [
+            event["item"]
+            for name, event in events
+            if name == "response.output_item.added"
+            and event.get("item", {}).get("type") == "function_call"
+        ]
+        assert len(calls) == 1, events
+        assert calls[0]["name"] == "exec_command"
+        argument_deltas = "".join(
+            event.get("delta", "")
+            for name, event in events
+            if name == "response.function_call_arguments.delta"
+        )
+        assert json.loads(argument_deltas) == {"cmd": "pwd && ls"}
+
+        completed = [
+            event["response"]
+            for name, event in events
+            if name == "response.completed"
+        ]
+        assert len(completed) == 1
+        assert all("DSML" not in json.dumps(item) for item in completed[0]["output"])
+        completed_calls = [
+            item for item in completed[0]["output"] if item["type"] == "function_call"
+        ]
+        assert len(completed_calls) == 1
+        assert json.loads(completed_calls[0]["arguments"]) == {"cmd": "pwd && ls"}
 
 
 class TestF6ToolChoiceEnforcement:

--- a/tests/test_responses_bundle.py
+++ b/tests/test_responses_bundle.py
@@ -107,7 +107,11 @@ class _Engine:
         """Emit a tiny synthetic stream: three text chunks then EOS, with
         optional reasoning_text and tool_calls on the final chunk."""
         self.stream_calls.append(SimpleNamespace(messages=messages, kwargs=kwargs))
-        chunks = self._stream_chunks or ["Hello", " from", " rapid"]
+        chunks = (
+            self._stream_chunks
+            if self._stream_chunks is not None
+            else ["Hello", " from", " rapid"]
+        )
         for i, c in enumerate(chunks):
             yield _GenerationOutput(
                 text="".join(chunks[: i + 1]),
@@ -388,7 +392,7 @@ class TestDeepSeekV4ResponsesStreaming:
 
         wire_chunks = [
             "<｜DS",
-            "ML｜tool_calls>\n<｜DSML｜invoke name=\"exec_command\">\n",
+            'ML｜tool_calls>\n<｜DSML｜invoke name="exec_command">\n',
             '<｜DSML｜parameter name="cmd" string="true">pwd && ls',
             "</｜DSML｜parameter>\n</｜DSML｜invoke>\n</｜DSML｜tool_",
             "calls>",
@@ -447,9 +451,7 @@ class TestDeepSeekV4ResponsesStreaming:
         assert json.loads(argument_deltas) == {"cmd": "pwd && ls"}
 
         completed = [
-            event["response"]
-            for name, event in events
-            if name == "response.completed"
+            event["response"] for name, event in events if name == "response.completed"
         ]
         assert len(completed) == 1
         assert all("DSML" not in json.dumps(item) for item in completed[0]["output"])

--- a/tests/test_streaming_tool_filter.py
+++ b/tests/test_streaming_tool_filter.py
@@ -296,7 +296,7 @@ class TestDeepSeekV4StreamingToolFilter(unittest.TestCase):
         f = StreamingToolCallFilter()
         chunks = [
             "before <｜DS",
-            "ML｜tool_calls>\n<｜DSML｜invoke name=\"exec_command\">\n",
+            'ML｜tool_calls>\n<｜DSML｜invoke name="exec_command">\n',
             '<｜DSML｜parameter name="cmd" string="true">pwd && ls',
             "</｜DSML｜parameter>\n</｜DSML｜invoke>\n</｜DSML｜tool_",
             "calls> after",

--- a/tests/test_streaming_tool_filter.py
+++ b/tests/test_streaming_tool_filter.py
@@ -284,6 +284,28 @@ class TestToolCallTagsRegistry(unittest.TestCase):
             "by default (issue #686 regression)."
         )
 
+    def test_deepseek_v4_dsml_pair_registered(self):
+        from vllm_mlx.api.utils import get_tool_call_tags
+
+        tags = get_tool_call_tags()
+        assert ("<｜DSML｜tool_calls>", "</｜DSML｜tool_calls>") in tags
+
+
+class TestDeepSeekV4StreamingToolFilter(unittest.TestCase):
+    def test_split_dsml_envelope_is_suppressed_without_losing_plain_text(self):
+        f = StreamingToolCallFilter()
+        chunks = [
+            "before <｜DS",
+            "ML｜tool_calls>\n<｜DSML｜invoke name=\"exec_command\">\n",
+            '<｜DSML｜parameter name="cmd" string="true">pwd && ls',
+            "</｜DSML｜parameter>\n</｜DSML｜invoke>\n</｜DSML｜tool_",
+            "calls> after",
+        ]
+
+        result = "".join(f.process(chunk) for chunk in chunks) + f.flush()
+
+        assert result == "before  after"
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/vllm_mlx/api/utils.py
+++ b/vllm_mlx/api/utils.py
@@ -515,6 +515,7 @@ _MAX_TOOL_BUFFER_BYTES = 1_048_576  # 1 MB
 # register_tool_call_tag() or by passing extra_tags to StreamingToolCallFilter.
 _TOOL_CALL_TAGS: list[tuple[str, str]] = [
     ("<minimax:tool_call>", "</minimax:tool_call>"),
+    ("<｜DSML｜tool_calls>", "</｜DSML｜tool_calls>"),  # DeepSeek V4 0731
     ("<tool_call>", "</tool_call>"),  # hermes, qwen3
     ("<function=", "</function>"),
     ("[TOOL_CALL]", "[/TOOL_CALL]"),


### PR DESCRIPTION
## What changed

- register DeepSeek V4 0731's DSML tool-call envelope with the shared streaming filter
- add token-boundary coverage for the DSML opener and closer
- add an HTTP-level `/v1/responses` SSE regression proving raw DSML stays out of text while the structured function call is emitted exactly once

## Why / root cause

The DeepSeek parser correctly extracted DSML into a function call at stream completion, but `StreamingToolCallFilter` did not recognize the DSML envelope. `/v1/responses` therefore streamed the wire markup as visible text first and then emitted the parsed function call, producing duplicate/raw tool output in Codex.

## Validation

- `pytest -q tests/test_responses_bundle.py tests/test_streaming_tool_filter.py tests/test_deepseek_v4_0731.py tests/test_tool_call_streaming_parity.py` — 80 passed
- `ruff check vllm_mlx/api/utils.py tests/test_streaming_tool_filter.py tests/test_responses_bundle.py`
- local wheel E2E against `/Volumes/RTL-2T/models/DeepSeek-V4-Flash-0731-MXFP4-MLX`: zero DSML in SSE text; one structured `exec_command` call; 11.3 tok/s
