### PR TITLE
chore: bump version to 0.11.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.11.4"
+version = "0.11.5"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Summary
- bump package version from 0.11.4 to 0.11.5

## Release validation
- `make release-smoke` passed
- M3 fixed gauntlet G0a/G0b/G5/G7b/G6/G9/G8 passed
- DeepSeek V4 real `/v1/responses` and mini Codex tool/file E2E passed
- G12 random semantic sweep produced model-capability false negatives: UI-TARS was tested with generic tools; Llama LangChain provider smoke passed 6/6 but a deep agent task chose the wrong shell command. No Rapid protocol failure observed.

Dedicated release bump; merge with exact squash subject `chore: bump version to 0.11.5`.