### PR TITLE
fix(release-gauntlet): pre-flight detects console-script 'rapid-mlx serve' too

### DIFF
--- a/scripts/release_check_m3.sh
+++ b/scripts/release_check_m3.sh
@@ -96,9 +96,23 @@ fi
 # full validation cycle — see knowledge/release-check-m3-tuning-backlog §E.)
 # Override with RAPID_MLX_ALLOW_CONCURRENT=1 if you are certain the other
 # workload won't touch the GPU or our ports.
+#
+# Detection must catch BOTH invocation forms a concurrent serve can take:
+#   * ``python -m vllm_mlx.cli serve`` — the ``-m`` module form (the gauntlet's
+#     own subprocesses use this; excluded via the release_check_m3 filter below).
+#   * ``.../bin/rapid-mlx serve`` — the installed console-script entry point. A
+#     real DeepSeek serve running as ``.venv/bin/rapid-mlx serve ... --port 8765``
+#     slipped past the old ``vllm_mlx\.cli``-only pattern and GPU-contended a
+#     gauntlet into a false-failed G12 (2026-07-30). Match the console form too.
+#
+# The console pattern is anchored ``(^|[ /])rapid-mlx`` so it matches whether the
+# entry point sits at a path (``.venv/bin/rapid-mlx``) or at the very start of the
+# ``ps`` row (a bare ``rapid-mlx serve``). ``ps -Aww -o pid=,command=`` is used
+# (not ``-o pid,command``) so long argv/env lines are not truncated — a serve
+# hidden behind a long wrapper/env prefix would otherwise defeat this safety gate.
 if [ "${RAPID_MLX_ALLOW_CONCURRENT:-0}" != "1" ]; then
-  _concurrent=$(ps -Ao pid,command 2>/dev/null \
-    | grep -E 'vllm_mlx\.cli (serve|bench)|scripts\.pr_validate' \
+  _concurrent=$(ps -Aww -o pid=,command= 2>/dev/null \
+    | grep -E 'vllm_mlx\.cli (serve|bench)|(^|[ /])rapid-mlx (serve|bench)|scripts\.pr_validate' \
     | grep -Ev 'grep|release_check_m3|coherence_sweep|wait-then-validate' || true)
   if [ -n "$_concurrent" ]; then
     echo "ERROR: another rapid-mlx serve / pr_validate is running on this box." >&2


### PR DESCRIPTION
## What

Broaden the release gauntlet's concurrent-serve pre-flight
(`scripts/release_check_m3.sh`) to also detect the **console-script** invocation
`.../bin/rapid-mlx serve|bench`, not only the `python -m vllm_mlx.cli serve|bench`
module form.

## Why (root-cause of the qwopus "guided-decode crash", #1375)

A DeepSeek serve was running on the box as `.venv/bin/rapid-mlx serve ... --port
8765` (the installed entry point). The pre-flight's detection grep only matched
`vllm_mlx\.cli (serve|bench)`, so it **did not** see that process and did **not**
refuse — the gauntlet ran with a concurrent GPU workload.

That is the true origin of the reported failure. Two `rapid-mlx serve` processes
each set their Metal limit to 90% of the full device (`mx.set_memory_limit`,
`engine/batched.py`, unchanged since #46), so together they oversubscribe the
GPU. Under that real memory pressure the G12 sweep's small guided-decode / forward
allocation tripped `RuntimeError: [metal::malloc] Resource limit (499000)
exceeded`, and the hermes rounds timed out at 360s.

**It is not a guided-decode regression and not qwopus-specific.** Verified on
current `main`: `qwopus-9b-4bit` (`Jackrong/MLX-Qwopus3.5-9B-v3-4bit`) serves
strict `json_schema` guided output correctly — 1 request + a 5-way concurrent
burst all return valid JSON, zero `metal::malloc` errors — once the box is not
oversubscribed.

## Change

```
- | grep -E 'vllm_mlx\.cli (serve|bench)|scripts\.pr_validate' \
+ | grep -E 'vllm_mlx\.cli (serve|bench)|[ /]rapid-mlx (serve|bench)|scripts\.pr_validate' \
```

Plus a comment documenting both invocation forms.

## Verification

- `bash -n` clean.
- Pattern matches: `.venv/bin/rapid-mlx serve --port 8765`, `rapid-mlx bench …`,
  `python -m vllm_mlx.cli serve …`, `scripts.pr_validate`.
- Pattern does NOT match: `rapid-mlx models`, `bash scripts/release_check_m3.sh`,
  unrelated `python …` processes.

Closes #1375.
