### PR TITLE
fix(agent): stop runaway exact repetition loops

### DIFF
--- a/tests/test_metrics_route.py
+++ b/tests/test_metrics_route.py
@@ -111,6 +111,7 @@ _FULL_STATS = {
     "num_waiting": 2,
     "num_running": 3,
     "num_requests_processed": 17,
+    "num_repetition_loop_stops": 3,
     "total_prompt_tokens": 1234,
     "total_completion_tokens": 5678,
     "steps_executed": 99,
@@ -141,6 +142,7 @@ def test_metrics_exposes_all_expected_series(metrics_client):
     expected_names = [
         "rapid_mlx_build_info",
         "rapid_mlx_requests_processed_total",
+        "rapid_mlx_repetition_loop_stops_total",
         "rapid_mlx_prompt_tokens_total",
         "rapid_mlx_completion_tokens_total",
         "rapid_mlx_requests_running",
@@ -168,6 +170,7 @@ def test_metrics_values_match_get_stats(metrics_client):
     body = metrics_client.client.get("/metrics").text
 
     assert "rapid_mlx_requests_processed_total 17" in body
+    assert "rapid_mlx_repetition_loop_stops_total 3" in body
     assert "rapid_mlx_prompt_tokens_total 1234" in body
     assert "rapid_mlx_completion_tokens_total 5678" in body
     assert "rapid_mlx_requests_running 3" in body

--- a/tests/test_repetition_guard.py
+++ b/tests/test_repetition_guard.py
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression coverage for the agent repetition-loop safety stop."""
+
+from unittest.mock import MagicMock
+
+from vllm_mlx.repetition_guard import detect_repeated_token_suffix
+from vllm_mlx.request import Request, RequestStatus, SamplingParams
+from vllm_mlx.scheduler import Scheduler, SchedulerConfig
+
+
+def _scheduler() -> Scheduler:
+    tokenizer = MagicMock()
+    tokenizer.encode = lambda text: list(range(len(text.split())))
+    tokenizer.decode = lambda tokens, **_kwargs: " ".join(map(str, tokens))
+    return Scheduler(MagicMock(), tokenizer, SchedulerConfig(max_num_seqs=2))
+
+
+def test_detects_long_exact_periodic_suffix():
+    pattern = list(range(12))
+    match = detect_repeated_token_suffix([999, 998] + pattern * 6)
+    assert match is not None
+    assert match.period_tokens == 12
+    assert match.repeats == 6
+
+
+def test_ignores_short_stutter_and_near_repeat():
+    assert detect_repeated_token_suffix([7] * 200) is None
+    pattern = list(range(12))
+    assert detect_repeated_token_suffix(pattern * 5) is None
+    assert detect_repeated_token_suffix(pattern * 5 + pattern[:-1] + [999]) is None
+
+
+def _drive_repeating_request(*, has_tools: bool):
+    scheduler = _scheduler()
+    pattern = list(range(12))
+    req = Request("repeat", "prompt", SamplingParams(max_tokens=1000))
+    req.status = RequestStatus.RUNNING
+    req.has_tools = has_tools
+    # The response below lands on both the sixth repetition and the scheduler's
+    # every-eight-token check boundary (72 output tokens).
+    req.output_token_ids = pattern * 5 + pattern[:-1]
+    scheduler.running[req.request_id] = req
+    scheduler.uid_to_request_id[1] = req.request_id
+
+    response = MagicMock(uid=1, token=pattern[-1], finish_reason=None, logprobs=None)
+    del response.prompt_cache
+    outputs, finished = scheduler._process_batch_responses([response])
+    return scheduler, req, outputs[0], finished
+
+
+def test_scheduler_stops_exact_loop_for_tool_request():
+    scheduler, req, output, finished = _drive_repeating_request(has_tools=True)
+    assert finished == {req.request_id}
+    assert req.status == RequestStatus.FINISHED_STOPPED
+    assert output.finished is True
+    assert output.finish_reason == "stop"
+    assert scheduler.num_repetition_loop_stops == 1
+    assert scheduler.get_stats()["num_repetition_loop_stops"] == 1
+
+
+def test_scheduler_does_not_change_plain_chat_semantics():
+    scheduler, req, output, finished = _drive_repeating_request(has_tools=False)
+    assert finished == set()
+    assert req.status == RequestStatus.RUNNING
+    assert output.finished is False
+    assert scheduler.num_repetition_loop_stops == 0

--- a/vllm_mlx/repetition_guard.py
+++ b/vllm_mlx/repetition_guard.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Conservative token-level guard for runaway agent repetitions.
+
+This intentionally operates on token ids rather than decoded text.  Exact token
+periodicity is cheap to test, independent of tokenizer whitespace behaviour, and
+avoids fuzzy heuristics that could truncate legitimate prose.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class RepetitionMatch:
+    """Description of the repeated suffix that caused a stop."""
+
+    period_tokens: int
+    repeats: int
+
+
+def detect_repeated_token_suffix(
+    token_ids: Sequence[int],
+    *,
+    min_period_tokens: int = 6,
+    max_period_tokens: int = 128,
+    required_repeats: int = 6,
+    min_repeated_tokens: int = 72,
+    max_window_tokens: int = 768,
+) -> RepetitionMatch | None:
+    """Return an exact periodic-suffix match, or ``None``.
+
+    The defaults require six adjacent copies and at least 72 repeated tokens.
+    One-token stutters (punctuation, newlines, or intentional ``ha ha`` output)
+    therefore cannot trip the guard.  Work is bounded to the most recent 768
+    tokens and callers are expected to invoke it only every few decode steps.
+    """
+
+    if required_repeats < 2 or min_period_tokens < 1:
+        raise ValueError("invalid repetition guard thresholds")
+
+    tokens = token_ids[-max_window_tokens:]
+    max_period = min(max_period_tokens, len(tokens) // required_repeats)
+    for period in range(min_period_tokens, max_period + 1):
+        repeated_tokens = period * required_repeats
+        if repeated_tokens < min_repeated_tokens:
+            continue
+        suffix = tokens[-repeated_tokens:]
+        pattern = suffix[:period]
+        # Do not disguise a one-token/newline stutter as a longer period
+        # merely because the same token also repeats in 12-token chunks.
+        if any(
+            period % smaller == 0 and pattern == pattern[:smaller] * (period // smaller)
+            for smaller in range(1, min_period_tokens)
+        ):
+            continue
+        if all(
+            suffix[offset : offset + period] == pattern
+            for offset in range(period, repeated_tokens, period)
+        ):
+            return RepetitionMatch(period_tokens=period, repeats=required_repeats)
+    return None

--- a/vllm_mlx/routes/metrics.py
+++ b/vllm_mlx/routes/metrics.py
@@ -983,6 +983,14 @@ def _render_prometheus(cfg: Any) -> str:
     )
     lines.extend(
         _fmt_metric(
+            "rapid_mlx_repetition_loop_stops_total",
+            "counter",
+            "Agent generations stopped after an exact repeated-token loop.",
+            int(_coerce_number(stats.get("num_repetition_loop_stops"))),
+        )
+    )
+    lines.extend(
+        _fmt_metric(
             "rapid_mlx_prompt_tokens_total",
             "counter",
             "Cumulative prompt tokens consumed across all requests.",

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -49,6 +49,7 @@ from .memory_cache import MemoryAwarePrefixCache, MemoryCacheConfig  # noqa: E40
 from .paged_cache import PagedCacheManager
 from .pflash import PFlashConfig, compress_request_tokens
 from .prefix_cache import BlockAwarePrefixCache, PrefixCacheManager
+from .repetition_guard import detect_repeated_token_suffix
 from .request import Request, RequestOutput, RequestStatus, SamplingParams
 from .utils.decode import IncrementalDecoder
 from .utils.mamba_cache import ensure_mamba_support
@@ -2162,6 +2163,10 @@ class Scheduler:
         self.num_requests_processed = 0
         self.total_prompt_tokens = 0
         self.total_completion_tokens = 0
+        # Agent-only safety stop for exact token loops.  This remains separate
+        # from normal completed-request accounting so operators can distinguish
+        # healthy EOS stops from model degeneration.
+        self.num_repetition_loop_stops = 0
         # PFlash observability (M-02 reframe). When PFlash compresses a
         # prompt the request bypasses the prefix-cache fetch + store
         # paths entirely (positional-fiction safety; see comment block
@@ -5295,6 +5300,32 @@ class Scheduler:
             # layer without tokenizer-family-specific casing.
             finish_reason = response.finish_reason
             stop_trimmed = False
+            # Agent models can occasionally enter a perfectly periodic decode
+            # loop after a tool interaction.  Once streamed, those deltas cannot
+            # be retracted, so stop it in the scheduler before thousands of
+            # useless tokens consume minutes of wall time.  Restrict this to
+            # tool-bearing requests and exact, long token repetition: ordinary
+            # chat/creative completions keep their historical semantics.
+            repetition_match = None
+            if (
+                finish_reason is None
+                and request.has_tools
+                and request.num_output_tokens % 8 == 0
+            ):
+                repetition_match = detect_repeated_token_suffix(
+                    request.output_token_ids
+                )
+                if repetition_match is not None:
+                    finish_reason = "stop"
+                    self.num_repetition_loop_stops += 1
+                    logger.warning(
+                        "Stopping agent request %s after exact token loop "
+                        "(period_tokens=%d repeats=%d completion_tokens=%d)",
+                        request_id,
+                        repetition_match.period_tokens,
+                        repetition_match.repeats,
+                        request.num_output_tokens,
+                    )
             stop_params = request.sampling_params.stop or []
             if finish_reason is None and stop_params:
                 decoder = getattr(request, "_decoder", None)
@@ -6178,6 +6209,7 @@ class Scheduler:
             "num_waiting": len(self.waiting),
             "num_running": len(self.running),
             "num_requests_processed": self.num_requests_processed,
+            "num_repetition_loop_stops": self.num_repetition_loop_stops,
             "total_prompt_tokens": self.total_prompt_tokens,
             "total_completion_tokens": self.total_completion_tokens,
             # M-02: PFlash observability counters. ``bypass_count`` is


### PR DESCRIPTION
## What does this PR do?

Adds a conservative token-level safety stop for exact periodic output loops on tool-bearing agent requests. It checks a bounded suffix every eight decode tokens, requires six adjacent copies and at least 72 repeated tokens, reports a standard `finish_reason="stop"`, and exposes `rapid_mlx_repetition_loop_stops_total`. Plain chat requests retain existing behavior.

## Why is this needed?

A real Codex + DeepSeek V4 Flash session repeated the same investigation sentence for 4,922 tokens / 234 seconds until client disconnect. The existing post-completion coherence telemetry cannot stop an in-flight runaway generation.

## AI assistance disclosure

Codex wrote and reviewed the implementation and tests in `vllm_mlx/repetition_guard.py`, `vllm_mlx/scheduler.py`, `vllm_mlx/routes/metrics.py`, and their tests. Verification included focused unit/integration tests, lint/format, a locally built wheel, and live DeepSeek V4 Flash agent requests.

> By submitting this PR I confirm I can explain the intent, risk, and behavior of every non-generated change in this PR. For any generated / boilerplate / scaffolded sections, I have identified them above and can describe how I verified them.

## Test plan

- `pytest` focused scheduler/stop/metrics suite: 64 passed
- broader repository run before external-service integrations: 3,706 passed, 108 skipped; 10 expected Hermes integration failures because no external test server was running
- `ruff check` and `ruff format --check` on changed Python files
- built and installed local 0.11.5 wheel
- live DeepSeek V4 Flash: normal tool call + tool-result continuation succeeded
- live DeepSeek V4 Flash: forced 100-copy repetition stopped at 80 tokens instead of running to 2,048; metric incremented to 1
- live performance: 384-token single request 24.8 tok/s cold-prefix, 26.5 tok/s prefix hit; concurrency 2 delivered 15.8 tok/s each (31.6 aggregate)

## Checklist

- [x] Focused and broad local tests pass; external-server-only Hermes cases documented above
- [x] Lint passes (`ruff check && ruff format --check`)
- [x] Self-validated with `python3 -m scripts.pr_validate.pr_validate <PR#>`
- [x] Critical scheduler test was spot-checked through positive and negative controls
- [x] README/docs not applicable
- [x] No breaking changes to existing API
