### PR TITLE
fix(agent): stop long repetition loops earlier

### DIFF
--- a/tests/test_repetition_guard.py
+++ b/tests/test_repetition_guard.py
@@ -23,6 +23,15 @@ def test_detects_long_exact_periodic_suffix():
     assert match.repeats == 6
 
 
+def test_long_loop_period_stops_after_three_copies():
+    pattern = list(range(61))
+    assert detect_repeated_token_suffix(pattern * 2) is None
+    match = detect_repeated_token_suffix(pattern * 3)
+    assert match is not None
+    assert match.period_tokens == 61
+    assert match.repeats == 3
+
+
 def test_ignores_short_stutter_and_near_repeat():
     assert detect_repeated_token_suffix([7] * 200) is None
     pattern = list(range(12))

--- a/vllm_mlx/repetition_guard.py
+++ b/vllm_mlx/repetition_guard.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from dataclasses import dataclass
+from math import ceil
 
 
 @dataclass(frozen=True)
@@ -25,16 +26,18 @@ def detect_repeated_token_suffix(
     *,
     min_period_tokens: int = 6,
     max_period_tokens: int = 128,
-    required_repeats: int = 6,
+    required_repeats: int = 3,
     min_repeated_tokens: int = 72,
     max_window_tokens: int = 768,
 ) -> RepetitionMatch | None:
     """Return an exact periodic-suffix match, or ``None``.
 
-    The defaults require six adjacent copies and at least 72 repeated tokens.
-    One-token stutters (punctuation, newlines, or intentional ``ha ha`` output)
-    therefore cannot trip the guard.  Work is bounded to the most recent 768
-    tokens and callers are expected to invoke it only every few decode steps.
+    The defaults require at least three adjacent copies and at least 72 repeated
+    tokens.  The effective repeat count is adaptive: a 12-token sentence needs
+    six copies, while a 61-token paragraph needs only three.  One-token stutters
+    (punctuation, newlines, or intentional ``ha ha`` output) therefore cannot
+    trip the guard.  Work is bounded to the most recent 768 tokens and callers
+    are expected to invoke it only every few decode steps.
     """
 
     if required_repeats < 2 or min_period_tokens < 1:
@@ -43,8 +46,9 @@ def detect_repeated_token_suffix(
     tokens = token_ids[-max_window_tokens:]
     max_period = min(max_period_tokens, len(tokens) // required_repeats)
     for period in range(min_period_tokens, max_period + 1):
-        repeated_tokens = period * required_repeats
-        if repeated_tokens < min_repeated_tokens:
+        repeats = max(required_repeats, ceil(min_repeated_tokens / period))
+        repeated_tokens = period * repeats
+        if repeated_tokens > len(tokens):
             continue
         suffix = tokens[-repeated_tokens:]
         pattern = suffix[:period]
@@ -59,5 +63,5 @@ def detect_repeated_token_suffix(
             suffix[offset : offset + period] == pattern
             for offset in range(period, repeated_tokens, period)
         ):
-            return RepetitionMatch(period_tokens=period, repeats=required_repeats)
+            return RepetitionMatch(period_tokens=period, repeats=repeats)
     return None


### PR DESCRIPTION
## What does this PR do?

Makes the agent repetition guard adaptive to loop length. It still requires at least 72 repeated tokens, but long periodic blocks now stop after three exact copies while short phrases require proportionally more copies.

## Why is this needed?

Follow-up to #1377. A real Codex + DeepSeek V4 session entered a 61-token paragraph loop. The guard worked, but requiring six copies allowed 424-464 completion tokens to reach the UI before stopping.

## AI assistance disclosure

Codex implemented and reviewed the threshold change and regression test. It was verified with unit tests, a rebuilt local wheel, a real mini Codex repository task, and live DeepSeek V4 forced-loop E2E.

> By submitting this PR I confirm I can explain the intent, risk, and behavior of every non-generated change in this PR.

## Test plan

- [x] 65 focused scheduler/stop/metrics tests passed
- [x] Ruff check and format passed
- [x] Unit control: 61-token block does not stop at 2 copies and stops at 3
- [x] Live DeepSeek E2E: 36-token paragraph stopped after 3 copies at 112 tokens / 6.48s
- [x] Real Codex 0.146.0 task on Mac mini completed pytest + file inspection + diagnosis without loops or false stops
- [x] No API changes

## Checklist

- [x] Tests pass locally
- [x] Lint passes
- [x] E2E verification completed
- [x] Critical-path positive and negative controls included
- [x] No documentation update required
- [x] No breaking changes