### PR TITLE
feat(deepseek): add native DSpark speculative decoding

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -112,6 +112,10 @@ rapid-mlx serve qwen3.5-27b-8bit --speculative-config '{"method":"dflash"}' --po
 # DDTree speculative decoding (experimental, single-user)
 rapid-mlx serve qwen3.5-9b-8bit --speculative-config '{"method":"ddtree"}' --port 8000
 
+# DeepSeek V4 Flash checkpoint-native DSpark (block size is checkpoint-defined)
+rapid-mlx serve /path/to/DeepSeek-V4-Flash-0731-MLX \
+  --speculative-config '{"method":"dspark","num_speculative_tokens":5}' --port 8000
+
 # MTP fixed-K parity bench mode
 rapid-mlx serve <mtp-eligible-qwen-checkpoint> \
   --speculative-config '{"method":"mtp","num_speculative_tokens":1,"disable_auto_k":true}'

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -69,6 +69,7 @@ into the same config path.
 |--------|-------------|
 | `{"method":"dflash"}` | Enable the DFlash single-user bridge on validated aliases. |
 | `{"method":"ddtree"}` | Enable experimental DDTree verification on validated aliases. |
+| `{"method":"dspark","num_speculative_tokens":5}` | Enable checkpoint-native DSpark for a local DeepSeek V4 Flash checkpoint. The token count must match the checkpoint's complete DSpark block. Greedy single-request decoding is accelerated; unsupported request shapes safely use baseline decoding. |
 | `{"method":"mtp"}` | Enable MTP speculative decoding for checkpoints accepted by the existing MTP eligibility gate. |
 | `{"method":"mtp","model":"<sidecar-head-repo>"}` | Attach a standalone MTP **sidecar head** (e.g. `mlx-community/Qwen3.6-27B-MTP-4bit`) to a full base checkpoint. The base must be MTP-eligible; the head repo goes in the `model` field — **not** in the `serve` positional. See [MTP sidecar heads are not standalone models](#mtp-sidecar-heads-are-not-standalone-models) below. Gemma 4 sidecar MTP remains disabled after its greedy-lossless A/B failed. |
 | `{"method":"mtp","num_speculative_tokens":3}` | Set the MTP max-K controller ceiling. |

--- a/tests/test_deepseek_v4_0731.py
+++ b/tests/test_deepseek_v4_0731.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
+import copy
 import json
 from pathlib import Path
 
@@ -172,6 +173,84 @@ def test_dsml_tool_schema_order_is_canonical_for_prefix_cache():
         model_name="deepseek-v4-flash-0731-mxfp4",
     )
     assert first == second
+
+
+def test_dsml_ignores_connector_access_preamble_for_prefix_cache():
+    base = {
+        "type": "function",
+        "function": {
+            "name": "github_fetch",
+            "description": "Fetch an issue.",
+            "parameters": {"type": "object"},
+        },
+    }
+    gated = copy.deepcopy(base)
+    gated["function"]["description"] = (
+        "Access repositories, issues, and pull requests. Required for some "
+        "features such as Codex\n\n"
+        + base["function"]["description"]
+        + " This tool is part of plugin `GitHub`. Use this tool only after approval."
+    )
+    base["function"]["description"] += " Use this tool only after approval."
+    messages = [{"role": "user", "content": "inspect"}]
+    kwargs = {
+        "enable_thinking": False,
+        "model_name": "deepseek-v4-flash-0731-mxfp4",
+    }
+    assert apply_chat_template(
+        _TokenizerWithoutTemplate(), messages, tools=[base], **kwargs
+    ) == apply_chat_template(
+        _TokenizerWithoutTemplate(), messages, tools=[gated], **kwargs
+    )
+
+
+def test_dsml_ignores_plugin_inserted_sentence_delimiter_for_prefix_cache():
+    base = {
+        "type": "function",
+        "function": {
+            "name": "create_issue",
+            "description": "Create a GitHub issue",
+            "parameters": {"type": "object"},
+        },
+    }
+    activated = copy.deepcopy(base)
+    activated["function"]["description"] += (
+        ". This tool is part of plugin `GitHub`."
+    )
+    messages = [{"role": "user", "content": "inspect"}]
+    kwargs = {
+        "enable_thinking": False,
+        "model_name": "deepseek-v4-flash-0731-mxfp4",
+    }
+    assert apply_chat_template(
+        _TokenizerWithoutTemplate(), messages, tools=[base], **kwargs
+    ) == apply_chat_template(
+        _TokenizerWithoutTemplate(), messages, tools=[activated], **kwargs
+    )
+
+
+def test_dsml_ignores_dynamic_connector_metadata_for_prefix_cache():
+    base = {
+        "type": "function",
+        "name": "mcp__codex_apps__github",
+        "description": "Search GitHub tools.",
+        "parameters": {"type": "object"},
+        "tools": [{"name": "initial_tool"}],
+        "connector_id": "initial-link",
+    }
+    activated = copy.deepcopy(base)
+    activated["tools"] = [{"name": "initial_tool"}, {"name": "new_tool"}]
+    activated["connector_id"] = "activated-link"
+    messages = [{"role": "user", "content": "inspect"}]
+    kwargs = {
+        "enable_thinking": False,
+        "model_name": "deepseek-v4-flash-0731-mxfp4",
+    }
+    assert apply_chat_template(
+        _TokenizerWithoutTemplate(), messages, tools=[base], **kwargs
+    ) == apply_chat_template(
+        _TokenizerWithoutTemplate(), messages, tools=[activated], **kwargs
+    )
 
 
 def test_dsml_parser_returns_openai_tool_call():

--- a/tests/test_deepseek_v4_0731.py
+++ b/tests/test_deepseek_v4_0731.py
@@ -214,9 +214,7 @@ def test_dsml_ignores_plugin_inserted_sentence_delimiter_for_prefix_cache():
         },
     }
     activated = copy.deepcopy(base)
-    activated["function"]["description"] += (
-        ". This tool is part of plugin `GitHub`."
-    )
+    activated["function"]["description"] += ". This tool is part of plugin `GitHub`."
     messages = [{"role": "user", "content": "inspect"}]
     kwargs = {
         "enable_thinking": False,

--- a/tests/test_deepseek_v4_0731.py
+++ b/tests/test_deepseek_v4_0731.py
@@ -122,6 +122,58 @@ def test_dsml_tool_schema_and_tool_result_are_encoded():
     assert "<tool_result>sunny</tool_result>" in prompt
 
 
+def test_dsml_tool_schema_order_is_canonical_for_prefix_cache():
+    messages = [
+        {"role": "system", "content": "stable instructions"},
+        {"role": "user", "content": "do work"},
+    ]
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "parameters": {"properties": {"z": {"type": "string"}}},
+                "name": "zeta",
+                "description": "last",
+            },
+        },
+        {
+            "function": {
+                "description": "first",
+                "name": "alpha",
+                "parameters": {"type": "object"},
+            },
+            "type": "function",
+        },
+    ]
+    reordered = [
+        {
+            "type": "function",
+            "function": {
+                "name": "alpha",
+                "parameters": {"type": "object"},
+                "description": "first",
+            },
+        },
+        tools[0],
+    ]
+
+    first = apply_chat_template(
+        _TokenizerWithoutTemplate(),
+        messages,
+        tools=tools,
+        enable_thinking=False,
+        model_name="deepseek-v4-flash-0731-mxfp4",
+    )
+    second = apply_chat_template(
+        _TokenizerWithoutTemplate(),
+        messages,
+        tools=reordered,
+        enable_thinking=False,
+        model_name="deepseek-v4-flash-0731-mxfp4",
+    )
+    assert first == second
+
+
 def test_dsml_parser_returns_openai_tool_call():
     parser = ToolParserManager.get_tool_parser("deepseek_v4_0731")(None)
     output = (

--- a/tests/test_deepseek_v4_vendored.py
+++ b/tests/test_deepseek_v4_vendored.py
@@ -407,3 +407,53 @@ def test_tiny_model_decodes_merged_caches_with_different_offsets():
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
+
+
+def test_deepseek_v4_dspark_drafts_checkpoint_block():
+    import mlx.core as mx
+
+    from vllm_mlx.models.deepseek_v4 import Model, ModelArgs
+
+    args = ModelArgs(
+        vocab_size=128,
+        hidden_size=32,
+        intermediate_size=64,
+        moe_intermediate_size=16,
+        num_hidden_layers=3,
+        num_attention_heads=4,
+        n_routed_experts=8,
+        q_lora_rank=16,
+        qk_rope_head_dim=4,
+        num_experts_per_tok=2,
+        head_dim=8,
+        compress_ratios=[0, 0, 0],
+        hc_mult=4,
+        num_hash_layers=0,
+        sliding_window=16,
+        o_groups=2,
+        o_lora_rank=8,
+        dspark_num_layers=3,
+        dspark_block_size=5,
+        dspark_noise_token_id=127,
+        dspark_target_layer_ids=[0, 1, 2],
+        dspark_markov_rank=8,
+    )
+    model = Model(args)
+    target_cache = model.make_cache()
+    draft_cache = model.make_dspark_cache()
+    model(mx.array([[1, 2, 3]], dtype=mx.int32), cache=target_cache)
+    assert (
+        model.dspark_forward(
+            mx.array([[3]], dtype=mx.int32), model._last_dspark_hidden, draft_cache
+        )
+        is None
+    )
+    model(mx.array([[4]], dtype=mx.int32), cache=target_cache)
+    proposal = model.dspark_forward(
+        mx.array([[4]], dtype=mx.int32), model._last_dspark_hidden, draft_cache
+    )
+    assert proposal is not None
+    output_ids, logits = proposal
+    mx.eval(output_ids, logits)
+    assert output_ids.shape == (1, 6)
+    assert logits.shape == (1, 5, 128)

--- a/tests/test_dspark_detect.py
+++ b/tests/test_dspark_detect.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import json
+
+from vllm_mlx.spec_decode.dspark.detect import detect_dspark_metadata
+
+
+def _write_checkpoint(tmp_path, *, complete: bool = True):
+    (tmp_path / "inference").mkdir()
+    (tmp_path / "config.json").write_text(json.dumps({"model_type": "deepseek_v4"}))
+    (tmp_path / "inference" / "config.json").write_text(
+        json.dumps(
+            {
+                "n_mtp_layers": 3,
+                "dspark_block_size": 5,
+                "dspark_noise_token_id": 128799,
+                "dspark_target_layer_ids": [40, 41, 42],
+                "dspark_markov_rank": 256,
+            }
+        )
+    )
+    keys = {
+        "mtp.0.main_proj.weight": "model-1.safetensors",
+        "mtp.2.markov_head.markov_w1.weight": "model-1.safetensors",
+        "mtp.2.markov_head.markov_w2.weight": "model-1.safetensors",
+    }
+    if not complete:
+        keys.pop("mtp.2.markov_head.markov_w2.weight")
+    (tmp_path / "model.safetensors.index.json").write_text(
+        json.dumps({"weight_map": keys})
+    )
+
+
+def test_detects_complete_deepseek_v4_dspark_checkpoint(tmp_path):
+    _write_checkpoint(tmp_path)
+    metadata = detect_dspark_metadata(tmp_path)
+    assert metadata is not None
+    assert metadata.block_size == 5
+    assert metadata.target_layer_ids == (40, 41, 42)
+
+
+def test_rejects_stripped_dspark_checkpoint(tmp_path):
+    _write_checkpoint(tmp_path, complete=False)
+    assert detect_dspark_metadata(tmp_path) is None

--- a/tests/test_dspark_scheduler.py
+++ b/tests/test_dspark_scheduler.py
@@ -1,0 +1,89 @@
+"""DSpark scheduler rollback invariants."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import mlx.core as mx
+
+from vllm_mlx.scheduler import _install_dspark, _replay_dspark_committed
+
+
+class _Cache:
+    def __init__(self, values: list[int] | None = None):
+        self.values = list(values or [])
+        self.offset = len(self.values)
+
+    def is_trimmable(self) -> bool:
+        return False
+
+    def extract(self, _idx: int):
+        return _Cache(self.values)
+
+
+def test_replay_dspark_committed_excludes_unsurfaced_drafts() -> None:
+    class _Model:
+        _last_dspark_hidden = mx.zeros((1, 1, 2))
+
+        def __call__(self, tokens, *, cache):
+            cache[0].values.extend(int(token) for token in tokens[0].tolist())
+            cache[0].offset = len(cache[0].values)
+            self._last_dspark_hidden = mx.zeros((1, tokens.shape[1], 2))
+            return mx.zeros((1, tokens.shape[1], 8))
+
+    cache = [_Cache([10])]
+    restored = _replay_dspark_committed(
+        _Model(), cache, mx.array([[11, 12, 13]]), token_count=1
+    )
+
+    assert restored[0].values == [10, 11]
+
+
+def test_verify_failure_restores_target_cache_before_baseline_fallback() -> None:
+    class _DraftCache:
+        offset = 0
+
+        def is_trimmable(self) -> bool:
+            return False
+
+    class _Model:
+        args = SimpleNamespace(dspark_block_size=5)
+        mtp = [object()]
+        _last_dspark_hidden = mx.zeros((1, 1, 2))
+
+        def make_dspark_cache(self):
+            return [_DraftCache()]
+
+        def dspark_forward(self, _tokens, _hidden, cache):
+            cache[0].offset = 5
+            return mx.array([[1, 2, 3, 4, 5, 6]]), None
+
+        def __call__(self, _tokens, *, cache):
+            cache[0].values.append(999)
+            cache[0].offset += 1
+            raise RuntimeError("synthetic verify failure")
+
+    class _GenerationBatch:
+        pass
+
+    gb = _GenerationBatch()
+    gb._next_tokens = mx.array([1])
+    gb._next_logprobs = [mx.zeros((8,))]
+    gb.uids = [7]
+    gb.tokens = [[]]
+    gb.prompt_cache = [_Cache([10])]
+    gb.logits_processors = [[]]
+    gb.next = lambda: []
+
+    def baseline_step():
+        assert gb.prompt_cache[0].values == [10]
+        return [1], [mx.zeros((8,))]
+
+    gb._step = baseline_step
+    batch_gen = SimpleNamespace(_generation_batch=gb)
+
+    assert _install_dspark(batch_gen, _Model(), {}, {}, max_draft=5)
+    tokens, _logprobs = gb._step()
+
+    assert tokens == [1]
+    assert batch_gen._dspark_stats["errors"] == 1

--- a/tests/test_prefix_boundary_path_parity.py
+++ b/tests/test_prefix_boundary_path_parity.py
@@ -17,6 +17,7 @@ boundary handoff, the non-streaming path must do too.
 """
 
 import asyncio
+from types import SimpleNamespace
 from typing import Any
 
 from vllm_mlx.engine.batched import BatchedEngine
@@ -210,3 +211,27 @@ def test_non_hybrid_model_skips_boundary_both_paths(monkeypatch):
         f"stream path: non-hybrid model leaked boundary "
         f"into kwargs={stub.last_generate_kwargs!r}"
     )
+
+
+def test_nontrimmable_pure_attention_forwards_boundary_both_paths(monkeypatch):
+    """Pure attention with a detected non-trimmable cache needs snapshots."""
+    engine, stub = _build_engine(monkeypatch, is_hybrid=False)
+    engine._scheduler_config = SimpleNamespace(hybrid_cache_entries=8)
+    messages = [
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": "u1"},
+        {"role": "assistant", "content": "a1"},
+        {"role": "user", "content": "u2"},
+    ]
+
+    asyncio.run(engine.chat(messages=messages))
+    assert stub.last_generate_kwargs.get("prefix_boundary") == _SENTINEL_BOUNDARY
+
+    stub.last_generate_kwargs = None
+
+    async def _drain():
+        async for _ in engine.stream_chat(messages=messages):
+            break
+
+    asyncio.run(_drain())
+    assert stub.last_generate_kwargs.get("prefix_boundary") == _SENTINEL_BOUNDARY

--- a/tests/test_responses_adapter.py
+++ b/tests/test_responses_adapter.py
@@ -474,6 +474,28 @@ class TestResponsesToOpenai:
         assert chat.messages[0].role == "system"
         assert chat.messages[0].content == "Always reply in JSON."
 
+    def test_developer_role_can_be_preserved_for_native_encoder(self):
+        req = ResponsesRequest(
+            model="deepseek-v4-flash-0731",
+            instructions="Stable base instructions.",
+            input=[
+                ResponsesInputItem(type="message", role="user", content="First"),
+                ResponsesInputItem(
+                    type="message",
+                    role="developer",
+                    content="Per-turn plugin instructions.",
+                ),
+            ],
+        )
+        chat = responses_to_openai(req, preserve_developer_role=True)
+        assert [message.role for message in chat.messages] == [
+            "system",
+            "user",
+            "developer",
+        ]
+        assert chat.messages[0].content == "Stable base instructions."
+        assert chat.messages[2].content[0].text == "Per-turn plugin instructions."
+
     def test_developer_role_with_structured_content_does_not_raise(self):
         # Defensive: today every system message reaches the merge step
         # with a string content (`_message_item_to_chat` joins parts).

--- a/tests/test_speculative_config.py
+++ b/tests/test_speculative_config.py
@@ -56,6 +56,15 @@ def test_parse_dflash_speculative_config_accepts_drafter_model() -> None:
     assert cfg.tree_budget is None
 
 
+def test_parse_dspark_speculative_config_accepts_native_depth() -> None:
+    cfg = parse_speculative_config('{"method":"dspark","num_speculative_tokens":5}')
+
+    assert cfg is not None
+    assert cfg.method == "dspark"
+    assert cfg.model is None
+    assert cfg.num_speculative_tokens == 5
+
+
 def test_parse_speculative_config_normalizes_registered_alias() -> None:
     cfg = parse_speculative_config('{"method":"ngram"}')
 
@@ -130,6 +139,13 @@ def test_require_migrated_speculative_config_accepts_ddtree() -> None:
 
 def test_require_migrated_speculative_config_accepts_dflash() -> None:
     cfg = parse_speculative_config('{"method":"dflash"}')
+    assert cfg is not None
+
+    require_migrated_speculative_config(cfg)
+
+
+def test_require_migrated_speculative_config_accepts_dspark() -> None:
+    cfg = parse_speculative_config('{"method":"dspark"}')
     assert cfg is not None
 
     require_migrated_speculative_config(cfg)

--- a/vllm_mlx/api/responses_adapter.py
+++ b/vllm_mlx/api/responses_adapter.py
@@ -427,7 +427,9 @@ def _resolve_reasoning_effort(request: ResponsesRequest) -> str | None:
     return None
 
 
-def responses_to_openai(request: ResponsesRequest) -> ChatCompletionRequest:
+def responses_to_openai(
+    request: ResponsesRequest, *, preserve_developer_role: bool = False
+) -> ChatCompletionRequest:
     """
     Convert a Responses-API request to an OpenAI Chat Completions request.
 
@@ -453,7 +455,9 @@ def responses_to_openai(request: ResponsesRequest) -> ChatCompletionRequest:
         messages.append(Message(role="user", content=request.input))
     else:
         for item in request.input:
-            converted = _convert_input_item(item)
+            converted = _convert_input_item(
+                item, preserve_developer_role=preserve_developer_role
+            )
             messages.extend(converted)
 
     # Codex 0.136.0 sends BOTH `instructions` (the big system prompt)
@@ -471,7 +475,8 @@ def responses_to_openai(request: ResponsesRequest) -> ChatCompletionRequest:
     # instructions sit *after* `instructions` (where Codex puts them
     # semantically — the per-turn directive refines the base system
     # prompt).
-    messages = _merge_system_messages(messages)
+    if not preserve_developer_role:
+        messages = _merge_system_messages(messages)
 
     tools = _convert_tools(request.tools)
     tool_choice = _convert_tool_choice(request.tool_choice)
@@ -880,10 +885,16 @@ def _parse_computer_action(arguments: str) -> dict:
 # ---------------------------------------------------------------------------
 
 
-def _convert_input_item(item: ResponsesInputItem) -> list[Message]:
+def _convert_input_item(
+    item: ResponsesInputItem, *, preserve_developer_role: bool = False
+) -> list[Message]:
     """Translate one Responses-API input item to 0+ Chat messages."""
     if item.type == "message":
-        return [_message_item_to_chat(item)]
+        return [
+            _message_item_to_chat(
+                item, preserve_developer_role=preserve_developer_role
+            )
+        ]
     if item.type == "function_call":
         return [_function_call_to_chat(item)]
     if item.type == "function_call_output":
@@ -914,9 +925,15 @@ _RESPONSES_TO_CHAT_ROLE = {
 }
 
 
-def _message_item_to_chat(item: ResponsesInputItem) -> Message:
+def _message_item_to_chat(
+    item: ResponsesInputItem, *, preserve_developer_role: bool = False
+) -> Message:
     raw_role = item.role or "user"
-    role = _RESPONSES_TO_CHAT_ROLE.get(raw_role, raw_role)
+    role = (
+        "developer"
+        if preserve_developer_role and raw_role == "developer"
+        else _RESPONSES_TO_CHAT_ROLE.get(raw_role, raw_role)
+    )
     content = item.content
 
     if isinstance(content, str):

--- a/vllm_mlx/api/responses_adapter.py
+++ b/vllm_mlx/api/responses_adapter.py
@@ -891,9 +891,7 @@ def _convert_input_item(
     """Translate one Responses-API input item to 0+ Chat messages."""
     if item.type == "message":
         return [
-            _message_item_to_chat(
-                item, preserve_developer_role=preserve_developer_role
-            )
+            _message_item_to_chat(item, preserve_developer_role=preserve_developer_role)
         ]
     if item.type == "function_call":
         return [_function_call_to_chat(item)]

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -2009,6 +2009,9 @@ def _normalize_speculative_config_or_exit(args):
         args.enable_dflash = True
         if config.model:
             args.dflash_drafter_path = config.model
+    elif config.method == "dspark":
+        args.spec_decode = "dspark"
+        args.dspark_num_speculative_tokens = config.num_speculative_tokens or 5
     elif config.method == "mtp":
         args.spec_decode = "mtp"
         if legacy_enable_mtp_requested:
@@ -3336,6 +3339,7 @@ def serve_command(args):
         mtp_num_draft_tokens=getattr(args, "mtp_num_draft_tokens", 1),
         mtp_optimistic=getattr(args, "mtp_optimistic", False),
         spec_decode=getattr(args, "spec_decode", "none"),
+        dspark_num_speculative_tokens=getattr(args, "dspark_num_speculative_tokens", 5),
         dflash_drafter_path=getattr(args, "dflash_drafter_path", "") or "",
         # Optional external MTP sidecar path. ``None`` is the "no
         # sidecar; native-MTP path only" sentinel.
@@ -3397,6 +3401,31 @@ def serve_command(args):
         print(
             "MTP: enabled via --speculative-config, "
             f"max_k={getattr(args, 'mtp_max_k', 1)}"
+        )
+    if getattr(args, "spec_decode", "none") == "dspark":
+        from vllm_mlx.spec_decode.dspark import detect_dspark_metadata
+
+        metadata = detect_dspark_metadata(args.model)
+        if metadata is None:
+            print(
+                "error: DSpark requires a complete DeepSeek V4 DSpark "
+                "checkpoint (3 mtp stages plus Markov heads).",
+                file=sys.stderr,
+            )
+            sys.exit(2)
+        requested_k = getattr(args, "dspark_num_speculative_tokens", 5)
+        if requested_k != metadata.block_size:
+            print(
+                "error: requested DSpark num_speculative_tokens="
+                f"{requested_k} does not match checkpoint block_size="
+                f"{metadata.block_size}. Rapid-MLX currently requires the "
+                "checkpoint's complete DSpark block.",
+                file=sys.stderr,
+            )
+            sys.exit(2)
+        print(
+            "DSpark: enabled via --speculative-config, "
+            f"max_k={requested_k}, checkpoint_k={metadata.block_size}"
         )
     # Native Qwen3.5/3.6 MTP via vendored mlx-lm PR #990. The
     # config-only entrypoint is ``--speculative-config '{"method":"mtp"}'``.

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -1225,10 +1225,15 @@ class BatchedEngine(BaseEngine):
             thread_name_prefix="mlx-step",
             initializer=_init_mlx_step_thread,
         )
+        load_kwargs = {"tokenizer_config": tokenizer_config}
+        if self._scheduler_config is not None and (
+            getattr(self._scheduler_config, "spec_decode", "none") == "dspark"
+        ):
+            load_kwargs["enable_dspark"] = True
         self._model, self._tokenizer = self._model_load_executor.submit(
             load_model_with_fallback,
             self._model_name,
-            tokenizer_config=tokenizer_config,
+            **load_kwargs,
         ).result()
 
         # 0.9.13 PR-A: new-arch MTP inject dispatcher (Gemma 4 external
@@ -2132,7 +2137,7 @@ class BatchedEngine(BaseEngine):
         # PR #435 only wired this into ``stream_chat`` so the fix was a no-op
         # for the very SDKs fishloa was hitting; this closes that gap.
         #
-        # Hybrid-only gate: the boundary split routes through
+        # Non-trimmable-cache gate: the boundary split routes through
         # ``BatchGenerator.insert_segments`` which on pure-Transformer models
         # (e.g. gpt-oss-20b-mxfp4-q8 harmony) corrupts the harmony tool-call channel
         # state across multi-turn-with-tools and the agent loops forever.
@@ -2141,7 +2146,7 @@ class BatchedEngine(BaseEngine):
         # (Mamba/DeltaNet+Transformer) have the "can't trim" constraint that
         # PR #435 was built to fix. Gating on ``is_hybrid`` keeps the fix
         # active where it's needed and inert where it broke things.
-        if self._is_hybrid_model():
+        if self._needs_prefix_boundary_snapshot():
             prefix_boundary = self._compute_prefix_boundary(messages, tools)
             if prefix_boundary > 0:
                 kwargs["prefix_boundary"] = prefix_boundary
@@ -2187,6 +2192,24 @@ class BatchedEngine(BaseEngine):
         try:
             return bool(self._engine.engine.model_config.is_hybrid)
         except (AttributeError, TypeError):
+            return False
+
+    def _needs_prefix_boundary_snapshot(self) -> bool:
+        """Whether growing conversations need an explicit message boundary.
+
+        Hybrid models need this because their recurrent cache state cannot be
+        trimmed.  Some pure-attention models have the same constraint (for
+        example DeepSeek V4's pooling KV cache).  The CLI detects those caches
+        and enables ``hybrid_cache_entries``; use that signal here instead of
+        incorrectly assuming every pure-attention cache is trimmable.
+        """
+        if self._is_hybrid_model():
+            return True
+        try:
+            return int(
+                getattr(self._scheduler_config, "hybrid_cache_entries", 0) or 0
+            ) > 0
+        except (TypeError, ValueError):
             return False
 
     def _compute_prefix_boundary(
@@ -2633,11 +2656,11 @@ class BatchedEngine(BaseEngine):
         if forced_assistant_prefix:
             prompt = prompt + forced_assistant_prefix
 
-        # Compute prefix boundary for cache — hybrid-only gate, see
+        # Compute prefix boundary for cache — non-trimmable-cache gate, see
         # ``chat()`` for the rationale. Path parity: stream and non-stream
         # must apply the same gating condition so a future change can't
         # silently regress one path while keeping the other green.
-        if self._is_hybrid_model():
+        if self._needs_prefix_boundary_snapshot():
             prefix_boundary = self._compute_prefix_boundary(messages, tools)
             if prefix_boundary > 0:
                 kwargs["prefix_boundary"] = prefix_boundary

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -2206,9 +2206,9 @@ class BatchedEngine(BaseEngine):
         if self._is_hybrid_model():
             return True
         try:
-            return int(
-                getattr(self._scheduler_config, "hybrid_cache_entries", 0) or 0
-            ) > 0
+            return (
+                int(getattr(self._scheduler_config, "hybrid_cache_entries", 0) or 0) > 0
+            )
         except (TypeError, ValueError):
             return False
 

--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -1834,6 +1834,15 @@ class MemoryAwarePrefixCache:
                 trimmed_cache = self._decompress_cache(trimmed_cache)
                 return trimmed_cache, remaining
 
+            logger.info(
+                "[cache_fetch] LCP unavailable: shared=%d entry_len=%d "
+                "requested_len=%d non_trimmable=%s",
+                best_lcp_length,
+                len(best_lcp_entry.tokens),
+                len(tokens),
+                has_non_trimmable,
+            )
+
         self._stats.misses += 1
         self._last_match_type = "miss"
 

--- a/vllm_mlx/models/deepseek_v4.py
+++ b/vllm_mlx/models/deepseek_v4.py
@@ -73,6 +73,11 @@ class ModelArgs(BaseModelArgs):
     index_head_dim: int = 128
     index_topk: int = 512
     num_nextn_predict_layers: int = 1
+    dspark_num_layers: int = 0
+    dspark_block_size: int = 0
+    dspark_noise_token_id: int = 0
+    dspark_target_layer_ids: List[int] = field(default_factory=list)
+    dspark_markov_rank: int = 256
     tie_word_embeddings: bool = False
     topk_method: str = "noaux_tc"
 
@@ -1059,7 +1064,13 @@ class DeepseekV4Model(PipelineMixin, nn.Module):
         self.norm = nn.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.hc_head = HyperHead(config)
 
-    def __call__(self, inputs: mx.array, cache: Optional[Any] = None) -> mx.array:
+    def __call__(
+        self,
+        inputs: mx.array,
+        cache: Optional[Any] = None,
+        *,
+        return_dspark_hidden: bool = False,
+    ) -> mx.array | tuple[mx.array, mx.array]:
         h = self.embed_tokens(inputs)
         h = mx.broadcast_to(
             h[:, :, None, :],
@@ -1087,8 +1098,12 @@ class DeepseekV4Model(PipelineMixin, nn.Module):
         if pipeline_rank < pipeline_size - 1:
             h = mx.distributed.recv_like(h, (pipeline_rank + 1))
 
+        dspark_hiddens = []
         for layer, layer_cache in zip(self.pipeline_layers, cache):
             h = layer(h, mask, layer_cache, inputs)
+            global_idx = layer.attn.layer_idx
+            if return_dspark_hidden and global_idx in self.args.dspark_target_layer_ids:
+                dspark_hiddens.append(h.mean(axis=2))
 
         if pipeline_rank != 0:
             h = mx.distributed.send(h, (pipeline_rank - 1) % pipeline_size)
@@ -1101,7 +1116,130 @@ class DeepseekV4Model(PipelineMixin, nn.Module):
         if pipeline_size > 1:
             h = mx.distributed.all_gather(h)[: h.shape[0]]
 
-        return self.norm(self.hc_head(h))
+        output = self.norm(self.hc_head(h))
+        if return_dspark_hidden:
+            if len(dspark_hiddens) != len(self.args.dspark_target_layer_ids):
+                raise RuntimeError(
+                    "DSpark hidden-state capture is not available with the "
+                    "current pipeline partition"
+                )
+            return output, mx.concatenate(dspark_hiddens, axis=-1)
+        return output
+
+
+class DSparkAttention(LocalAttention):
+    """DSpark local attention: each draft slot sees target KV plus itself."""
+
+    def update_main(self, main_x: mx.array, cache: RotatingKVCache) -> mx.array:
+        offset = cache.offset
+        kv = self.kv_norm(self.wkv(main_x)).reshape(
+            main_x.shape[0], 1, main_x.shape[1], self.head_dim
+        )
+        kv = self.rope(kv, offset)
+        return cache.update_and_fetch(
+            kv, mx.zeros((*kv.shape[:-1], 0), dtype=kv.dtype)
+        )[0]
+
+    def __call__(
+        self,
+        x: mx.array,
+        main_x: mx.array,
+        cache: RotatingKVCache,
+        *,
+        update_main: bool = True,
+    ) -> mx.array:
+        B, K, _ = x.shape
+        main_kv = self.update_main(main_x, cache) if update_main else cache.keys
+        if main_kv is None:
+            raise RuntimeError("DSpark target KV cache is empty")
+        draft_offset = cache.offset
+
+        q = self.wq_b(self.q_norm(self.wq_a(x)))
+        q = q.reshape(B, K, self.n_heads, self.head_dim)
+        q = mx.fast.rms_norm(q, None, self.config.rms_norm_eps)
+        q = q.transpose(0, 2, 1, 3)
+        q = self.rope(q, draft_offset)
+
+        draft_kv = self.kv_norm(self.wkv(x)).reshape(B, 1, K, self.head_dim)
+        draft_kv = self.rope(draft_kv, draft_offset)
+
+        # Flatten draft slots into the batch dimension. This gives every
+        # semi-autoregressive slot the same target window plus only its own KV.
+        main_len = main_kv.shape[2]
+        expanded_main = mx.broadcast_to(
+            main_kv[:, None], (B, K, 1, main_len, self.head_dim)
+        ).reshape(B * K, 1, main_len, self.head_dim)
+        own_kv = draft_kv.transpose(0, 2, 1, 3).reshape(B * K, 1, 1, self.head_dim)
+        verify_kv = mx.concatenate([expanded_main, own_kv], axis=2)
+        flat_q = q.transpose(0, 2, 1, 3).reshape(B * K, self.n_heads, 1, self.head_dim)
+        out = scaled_dot_product_attention(
+            flat_q,
+            verify_kv,
+            verify_kv,
+            cache=None,
+            scale=self.scale,
+            mask=None,
+            sinks=self.attn_sink.astype(flat_q.dtype),
+        )
+        out = out.reshape(B, K, self.n_heads, self.head_dim).transpose(0, 2, 1, 3)
+        out = self.rope(out, draft_offset, inverse=True)
+        out = out.reshape(B, self.o_groups, -1, K, self.head_dim)
+        out = out.transpose(0, 1, 3, 2, 4).flatten(-2)
+        out = self.wo_a(out)
+        out = out.transpose(0, 2, 1, 3).flatten(-2)
+        return self.wo_b(out)
+
+
+class DSparkMarkovHead(nn.Module):
+    def __init__(self, config: ModelArgs):
+        self.markov_w1 = nn.Embedding(config.vocab_size, config.dspark_markov_rank)
+        self.markov_w2 = nn.Linear(
+            config.dspark_markov_rank, config.vocab_size, bias=False
+        )
+
+    def __call__(self, token_ids: mx.array) -> tuple[mx.array, mx.array]:
+        embedding = self.markov_w1(token_ids)
+        return self.markov_w2(embedding), embedding
+
+
+class DSparkBlock(nn.Module):
+    def __init__(self, config: ModelArgs, stage_idx: int):
+        self.stage_idx = stage_idx
+        self.attn = DSparkAttention(config, config.num_hidden_layers + stage_idx)
+        self.ffn = DeepseekV4MoE(config, config.num_hidden_layers + stage_idx)
+        self.attn_norm = nn.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.ffn_norm = nn.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.attn_hc = HyperConnection(config)
+        self.ffn_hc = HyperConnection(config)
+        if stage_idx == 0:
+            self.main_proj = nn.Linear(
+                config.hidden_size * len(config.dspark_target_layer_ids),
+                config.hidden_size,
+                bias=False,
+            )
+            self.main_norm = nn.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        if stage_idx == config.dspark_num_layers - 1:
+            self.norm = nn.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+            self.markov_head = DSparkMarkovHead(config)
+            self.hc_head = HyperHead(config)
+
+    def __call__(
+        self,
+        h: mx.array,
+        main_x: mx.array,
+        cache: RotatingKVCache,
+        input_ids: mx.array,
+        *,
+        update_main: bool = True,
+    ) -> mx.array:
+        residual = h
+        x, post, comb = self.attn_hc(h)
+        x = self.attn(self.attn_norm(x), main_x, cache, update_main=update_main)
+        h = hc_expand(x, residual, post, comb)
+        residual = h
+        x, post, comb = self.ffn_hc(h)
+        x = self.ffn(self.ffn_norm(x), input_ids)
+        return hc_expand(x, residual, post, comb)
 
 
 class Model(nn.Module):
@@ -1111,9 +1249,79 @@ class Model(nn.Module):
         self.model_type = config.model_type
         self.model = DeepseekV4Model(config)
         self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
+        self.mtp = [DSparkBlock(config, idx) for idx in range(config.dspark_num_layers)]
+        self._last_dspark_hidden: mx.array | None = None
 
-    def __call__(self, inputs: mx.array, cache: Optional[Any] = None):
-        return self.lm_head(self.model(inputs, cache))
+    def __call__(
+        self,
+        inputs: mx.array,
+        cache: Optional[Any] = None,
+        *,
+        return_dspark_hidden: bool = False,
+    ):
+        capture_dspark = return_dspark_hidden or bool(self.mtp)
+        output = self.model(inputs, cache, return_dspark_hidden=capture_dspark)
+        if capture_dspark:
+            hidden, dspark_hidden = output
+            self._last_dspark_hidden = dspark_hidden
+            logits = self.lm_head(hidden)
+            if return_dspark_hidden:
+                return logits, dspark_hidden
+            return logits
+        if return_dspark_hidden:
+            raise AssertionError("unreachable DSpark capture branch")
+        return self.lm_head(output)
+
+    def make_dspark_cache(self) -> list[RotatingKVCache]:
+        return [RotatingKVCache(max_size=self.args.sliding_window) for _ in self.mtp]
+
+    def dspark_forward(
+        self,
+        anchor_ids: mx.array,
+        main_hidden: mx.array,
+        cache: list[RotatingKVCache],
+    ) -> tuple[mx.array, mx.array, mx.array] | None:
+        if not self.mtp:
+            return None
+        first = self.mtp[0]
+        main_x = first.main_norm(first.main_proj(main_hidden))
+        initial_prefill = cache[0].offset == 0
+        for block, layer_cache in zip(self.mtp, cache):
+            block.attn.update_main(main_x, layer_cache)
+        if initial_prefill:
+            return None
+
+        K = self.args.dspark_block_size
+        draft_ids = mx.full(
+            (anchor_ids.shape[0], K),
+            self.args.dspark_noise_token_id,
+            dtype=anchor_ids.dtype,
+        )
+        draft_ids[:, 0] = anchor_ids[:, -1]
+        h = self.model.embed_tokens(draft_ids)
+        h = mx.broadcast_to(
+            h[:, :, None, :],
+            (h.shape[0], h.shape[1], self.args.hc_mult, h.shape[-1]),
+        )
+        for block, layer_cache in zip(self.mtp, cache):
+            h = block(
+                h,
+                main_x[:, -1:],
+                layer_cache,
+                draft_ids,
+                update_main=False,
+            )
+
+        last = self.mtp[-1]
+        collapsed = last.hc_head(h)
+        draft_logits = self.lm_head(last.norm(collapsed))
+        output_ids = mx.zeros((anchor_ids.shape[0], K + 1), dtype=anchor_ids.dtype)
+        output_ids[:, 0] = anchor_ids[:, -1]
+        for idx in range(K):
+            bias, _ = last.markov_head(output_ids[:, idx])
+            draft_logits[:, idx] = draft_logits[:, idx] + bias
+            output_ids[:, idx + 1] = mx.argmax(draft_logits[:, idx], axis=-1)
+        return output_ids, draft_logits
 
     @property
     def layers(self):
@@ -1162,7 +1370,9 @@ class Model(nn.Module):
 
         new_weights = {}
         for k, v in weights.items():
-            if k.startswith("mtp."):
+            if k.startswith("mtp.") and not self.mtp:
+                continue
+            if ".confidence_head." in k:
                 continue
             parts = k.split(".")
             if len(parts) >= 2 and parts[0] == "layers":
@@ -1224,6 +1434,9 @@ class Model(nn.Module):
             for sub in ("attn", "ffn"):
                 for param in ("fn", "base", "scale"):
                     nk = nk.replace(f".hc_{sub}_{param}", f".{sub}_hc.{param}")
+            nk = nk.replace(".hc_head_fn", ".hc_head.fn")
+            nk = nk.replace(".hc_head_base", ".hc_head.base")
+            nk = nk.replace(".hc_head_scale", ".hc_head.scale")
             for old, new in w_remap.items():
                 nk = nk.replace(f".shared_experts.{old}.", f".shared_experts.{new}.")
             remapped[nk] = v
@@ -1247,9 +1460,36 @@ class Model(nn.Module):
                             f"model.layers.{layer_idx}.ffn.switch_mlp.{dst}.{suffix}"
                         ] = mx.stack(stacked)
 
+        for stage_idx in range(len(self.mtp)):
+            prefix = f"mtp.{stage_idx}.ffn.experts"
+            for src, dst in (
+                ("w1", "gate_proj"),
+                ("w2", "down_proj"),
+                ("w3", "up_proj"),
+            ):
+                for suffix in ("weight", "scales"):
+                    key0 = f"{prefix}.0.{src}.{suffix}"
+                    if key0 in weights:
+                        stacked = [
+                            weights.pop(f"{prefix}.{e}.{src}.{suffix}")
+                            for e in range(self.args.n_routed_experts)
+                        ]
+                        weights[f"mtp.{stage_idx}.ffn.switch_mlp.{dst}.{suffix}"] = (
+                            mx.stack(stacked)
+                        )
+
         # Fuse routed expert gate/up projections by concatenating output rows.
         for layer_idx in range(n_layers):
             prefix = f"model.layers.{layer_idx}.ffn.switch_mlp"
+            for suffix in ("weight", "scales"):
+                gate_key = f"{prefix}.gate_proj.{suffix}"
+                up_key = f"{prefix}.up_proj.{suffix}"
+                if gate_key in weights and up_key in weights:
+                    weights[gate_key] = mx.concatenate(
+                        [weights.pop(gate_key), weights.pop(up_key)], axis=1
+                    )
+        for stage_idx in range(len(self.mtp)):
+            prefix = f"mtp.{stage_idx}.ffn.switch_mlp"
             for suffix in ("weight", "scales"):
                 gate_key = f"{prefix}.gate_proj.{suffix}"
                 up_key = f"{prefix}.up_proj.{suffix}"
@@ -1261,6 +1501,13 @@ class Model(nn.Module):
         # Reshape wo_a from nn.Linear (2D) to MultiLinear (3D) for all layers
         for layer_idx in range(n_layers):
             prefix = f"model.layers.{layer_idx}.attn.wo_a"
+            for key in (f"{prefix}.weight", f"{prefix}.scales", f"{prefix}.biases"):
+                if key in weights and weights[key].ndim == 2:
+                    weights[key] = weights[key].reshape(
+                        self.args.o_groups, self.args.o_lora_rank, -1
+                    )
+        for stage_idx in range(len(self.mtp)):
+            prefix = f"mtp.{stage_idx}.attn.wo_a"
             for key in (f"{prefix}.weight", f"{prefix}.scales", f"{prefix}.biases"):
                 if key in weights and weights[key].ndim == 2:
                     weights[key] = weights[key].reshape(

--- a/vllm_mlx/routes/responses.py
+++ b/vllm_mlx/routes/responses.py
@@ -15,7 +15,6 @@ history every turn in ``input``.
 """
 
 import asyncio
-import hashlib
 import json
 import logging
 import time
@@ -398,7 +397,13 @@ async def create_response(request: Request):
         # it through the sanitized 400 envelope — no more ``str(e)``
         # echo that leaked the model class name and pydantic version.
         try:
-            openai_request = responses_to_openai(responses_request)
+            cfg_for_adapter = get_config()
+            openai_request = responses_to_openai(
+                responses_request,
+                preserve_developer_role=(
+                    cfg_for_adapter.tool_call_parser == "deepseek_v4_0731"
+                ),
+            )
         except ValueError as e:
             raise HTTPException(status_code=400, detail=str(e))
 
@@ -3559,30 +3564,3 @@ def _log_request(req: ResponsesRequest) -> None:
         f"input_items={n_items} total_chars={total_chars} "
         f"instructions_chars={instr_chars} tools={n_tools}"
     )
-    if logger.isEnabledFor(logging.DEBUG) and req.tools:
-        fingerprints = []
-        for tool in req.tools:
-            canonical = json.dumps(
-                tool, ensure_ascii=False, sort_keys=True, separators=(",", ":")
-            )
-            name = tool.get("name") or tool.get("function", {}).get("name") or "?"
-            digest = hashlib.sha256(canonical.encode()).hexdigest()[:10]
-            fingerprints.append(f"{name}:{digest}")
-            if name == "_add_comment_to_issue":
-                field_fingerprints = {
-                    key: hashlib.sha256(
-                        json.dumps(
-                            value,
-                            ensure_ascii=False,
-                            sort_keys=True,
-                            separators=(",", ":"),
-                        ).encode()
-                    ).hexdigest()[:10]
-                    for key, value in tool.items()
-                }
-                logger.debug(
-                    "[REQUEST] diagnostic tool fields %s: %s",
-                    name,
-                    field_fingerprints,
-                )
-        logger.debug("[REQUEST] tool fingerprints: %s", ",".join(fingerprints))

--- a/vllm_mlx/routes/responses.py
+++ b/vllm_mlx/routes/responses.py
@@ -15,6 +15,7 @@ history every turn in ``input``.
 """
 
 import asyncio
+import hashlib
 import json
 import logging
 import time
@@ -3558,3 +3559,30 @@ def _log_request(req: ResponsesRequest) -> None:
         f"input_items={n_items} total_chars={total_chars} "
         f"instructions_chars={instr_chars} tools={n_tools}"
     )
+    if logger.isEnabledFor(logging.DEBUG) and req.tools:
+        fingerprints = []
+        for tool in req.tools:
+            canonical = json.dumps(
+                tool, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+            )
+            name = tool.get("name") or tool.get("function", {}).get("name") or "?"
+            digest = hashlib.sha256(canonical.encode()).hexdigest()[:10]
+            fingerprints.append(f"{name}:{digest}")
+            if name == "_add_comment_to_issue":
+                field_fingerprints = {
+                    key: hashlib.sha256(
+                        json.dumps(
+                            value,
+                            ensure_ascii=False,
+                            sort_keys=True,
+                            separators=(",", ":"),
+                        ).encode()
+                    ).hexdigest()[:10]
+                    for key, value in tool.items()
+                }
+                logger.debug(
+                    "[REQUEST] diagnostic tool fields %s: %s",
+                    name,
+                    field_fingerprints,
+                )
+        logger.debug("[REQUEST] tool fingerprints: %s", ",".join(fingerprints))

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -1381,6 +1381,20 @@ def _config_vetted_mtp_supports_spec_decode(model_type: str | None) -> bool:
     return model_type in {"qwen3_5", "qwen3_5_moe", "hy_v3"}
 
 
+def _replay_dspark_committed(
+    model: Any,
+    cache_snapshot: list[Any],
+    verify_input: mx.array,
+    token_count: int,
+) -> list[Any]:
+    """Replay only committed target tokens into a pre-verify cache snapshot."""
+
+    committed = verify_input[:, :token_count]
+    replay_logits = model(committed, cache=cache_snapshot)
+    mx.eval(replay_logits, model._last_dspark_hidden)
+    return cache_snapshot
+
+
 def _install_dspark(
     batch_gen: "BatchGenerator",
     model: Any,
@@ -1508,10 +1522,15 @@ def _install_dspark(
         except Exception as exc:  # noqa: BLE001
             logger.warning("[DSpark] verify failed; falling back: %r", exc)
             _stats["errors"] += 1
+            # Verification may have advanced a non-trimmable target cache
+            # before raising.  Baseline decoding must resume from the exact
+            # pre-verify state, never from speculative state.
+            gb.prompt_cache = target_cache_snapshot
             for cache, old_offset in zip(dspark_cache, offsets_before):
                 delta = cache.offset - old_offset
                 if delta > 0 and cache.is_trimmable():
                     cache.trim(delta)
+            _caches.pop(uid, None)
             return _orig_step()
 
         accepted = 0
@@ -1609,6 +1628,18 @@ def _install_dspark(
             return responses
         for response in responses:
             if response.finish_reason is not None:
+                replay_state = _pending_replay.get(response.uid)
+                if replay_state is not None:
+                    snapshot, verify_input = replay_state
+                    # ``GenerationBatch.next`` has already extracted the
+                    # finishing row and filtered it out of the live batch.
+                    # Rebuild the response-owned cache with only the primary
+                    # token that was actually surfaced, excluding queued
+                    # accepted draft tokens.
+                    restored = _replay_dspark_committed(
+                        model, snapshot, verify_input, 1
+                    )
+                    response.prompt_cache = [cache.extract(0) for cache in restored]
                 _finish_uid(response.uid)
         if not _pending:
             return responses

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -370,6 +370,10 @@ class SchedulerConfig:
     # that retention bound is also useful to callers with ordinary caches.
     non_trimmable_exact_prefix_reuse: bool = False
 
+    # DeepSeek V4's checkpoint-native DSpark block drafter. This stays at the
+    # end of the dataclass field list to preserve positional compatibility.
+    dspark_num_speculative_tokens: int = 5
+
     def __post_init__(self) -> None:
         if self.response_cache_entries < 0:
             raise ValueError("response_cache_entries must be >= 0")
@@ -399,12 +403,21 @@ class SchedulerConfig:
             # (codex R3: silent rewrite to ``'none'`` was UX drift).
             self.enable_suffix_decoding = True
 
-        if self.spec_decode not in (None, "none", "mtp", "dflash", "suffix"):
+        if self.spec_decode not in (
+            None,
+            "none",
+            "mtp",
+            "dflash",
+            "dspark",
+            "suffix",
+        ):
             raise ValueError(
                 f"SchedulerConfig(spec_decode={self.spec_decode!r}) is not "
-                "supported; expected one of 'none', 'mtp', 'dflash', or 'suffix'."
+                "supported; expected one of 'none', 'mtp', 'dflash', "
+                "'dspark', or 'suffix'."
             )
-
+        if self.dspark_num_speculative_tokens <= 0:
+            raise ValueError("dspark_num_speculative_tokens must be > 0")
         if self.mtp_optimistic and self.spec_decode == "mtp":
             # Unified spec-decode interface (PR #1050) always routes MTP
             # through the vendored ``mtp_generate_step`` hot loop, which
@@ -1366,6 +1379,317 @@ def _config_vetted_mtp_supports_spec_decode(model_type: str | None) -> bool:
     """
 
     return model_type in {"qwen3_5", "qwen3_5_moe", "hy_v3"}
+
+
+def _install_dspark(
+    batch_gen: "BatchGenerator",
+    model: Any,
+    requests: dict[str, Any],
+    uid_to_request_id: dict[int, str],
+    max_draft: int,
+) -> bool:
+    """Install DeepSeek V4's checkpoint-native DSpark draft/verify loop.
+
+    V1 is deliberately single-request and greedy. Target verification remains
+    authoritative, including request logits processors; finite-precision batch
+    evaluation may still choose a different token when target logits are tied.
+    """
+
+    if not all(
+        hasattr(model, name)
+        for name in ("dspark_forward", "make_dspark_cache", "_last_dspark_hidden")
+    ):
+        logger.warning("[DSpark] disabled: loaded model lacks DSpark runtime hooks")
+        return False
+    if not getattr(model, "mtp", None):
+        logger.warning("[DSpark] disabled: checkpoint did not load DSpark weights")
+        return False
+
+    checkpoint_k = int(getattr(model.args, "dspark_block_size", 0))
+    if checkpoint_k <= 0:
+        logger.warning("[DSpark] disabled: checkpoint has no valid block size")
+        return False
+    draft_k = min(int(max_draft), checkpoint_k)
+    gb = getattr(batch_gen, "_generation_batch", None)
+    if gb is None:
+        logger.warning("[DSpark] disabled: incompatible mlx-lm BatchGenerator")
+        return False
+
+    _orig_step = gb._step
+    _orig_next = gb.next
+    _caches: dict[int, list[Any]] = {}
+    _pending: dict[int, list[tuple[int, mx.array]]] = {}
+    # Retain enough state to roll back a verify round if a stop condition is
+    # reached part-way through its accepted tokens. DeepSeek V4's pooling
+    # caches are not trimmable, so exact replay is the only safe rollback.
+    _pending_replay: dict[int, tuple[Any, mx.array]] = {}
+    _disabled_uids: set[int] = set()
+    _stats = {
+        "verify_steps": 0,
+        "draft_tokens_proposed": 0,
+        "tokens_accepted": 0,
+        "fallthrough_steps": 0,
+        "errors": 0,
+        "full_accept_rounds": 0,
+    }
+    _uid_stats: dict[int, dict[str, float | int]] = {}
+
+    def _request_stats(uid: int) -> dict[str, float | int]:
+        return _uid_stats.setdefault(
+            uid,
+            {
+                "verify_steps": 0,
+                "draft_tokens_proposed": 0,
+                "tokens_accepted": 0,
+                "full_accept_rounds": 0,
+            },
+        )
+
+    def _is_greedy(uid: int) -> bool:
+        request_id = uid_to_request_id.get(uid)
+        request = requests.get(request_id) if request_id else None
+        params = getattr(request, "sampling_params", None)
+        return params is None or params.temperature in (None, 0.0)
+
+    def _dspark_step():
+        if (
+            gb._next_tokens is None
+            or gb._next_tokens.shape[0] != 1
+            or len(gb.uids) != 1
+        ):
+            _stats["fallthrough_steps"] += 1
+            return _orig_step()
+        uid = gb.uids[0]
+        uid_stats = _request_stats(uid)
+        if uid in _disabled_uids:
+            _stats["fallthrough_steps"] += 1
+            return _orig_step()
+        if not _is_greedy(uid):
+            _stats["fallthrough_steps"] += 1
+            return _orig_step()
+        processors = getattr(gb, "logits_processors", None)
+        request_processors = processors[0] if processors and processors[0] else []
+
+        inputs = gb._next_tokens
+        last_token = int(inputs[0].item())
+        hidden = getattr(model, "_last_dspark_hidden", None)
+        if hidden is None or hidden.shape[0] != 1:
+            _stats["fallthrough_steps"] += 1
+            return _orig_step()
+        dspark_cache = _caches.setdefault(uid, model.make_dspark_cache())
+        offsets_before = [cache.offset for cache in dspark_cache]
+        try:
+            proposal = model.dspark_forward(inputs[:, None], hidden, dspark_cache)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("[DSpark] draft failed; falling back: %r", exc)
+            _stats["errors"] += 1
+            _caches.pop(uid, None)
+            return _orig_step()
+        if proposal is None:
+            return _orig_step()
+
+        output_ids, _ = proposal
+        draft = [int(v) for v in output_ids[0, 1 : draft_k + 1].tolist()]
+        K = len(draft)
+        _stats["verify_steps"] += 1
+        _stats["draft_tokens_proposed"] += K
+        uid_stats["verify_steps"] += 1
+        uid_stats["draft_tokens_proposed"] += K
+        import copy
+
+        target_cache_snapshot = copy.deepcopy(gb.prompt_cache)
+        try:
+            verify_input = mx.concatenate(
+                [inputs[:, None], mx.array([draft], dtype=inputs.dtype)], axis=1
+            )
+            verify_logits = model(verify_input, cache=gb.prompt_cache)
+            verify_hidden = model._last_dspark_hidden
+            mx.eval(verify_logits, verify_hidden)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("[DSpark] verify failed; falling back: %r", exc)
+            _stats["errors"] += 1
+            for cache, old_offset in zip(dspark_cache, offsets_before):
+                delta = cache.offset - old_offset
+                if delta > 0 and cache.is_trimmable():
+                    cache.trim(delta)
+            return _orig_step()
+
+        accepted = 0
+        preds_list: list[int] = []
+        processed_logprobs: list[mx.array] = []
+        token_context = None
+        if request_processors:
+            token_context = gb._token_context[0].update_and_fetch(inputs)
+        for idx in range(K + 1):
+            sample_logits = verify_logits[0:1, idx]
+            for processor in request_processors:
+                sample_logits = processor(token_context, sample_logits)
+            logprobs = sample_logits - mx.logsumexp(
+                sample_logits, axis=-1, keepdims=True
+            )
+            pred = int(mx.argmax(logprobs[0], axis=-1).item())
+            preds_list.append(pred)
+            processed_logprobs.append(logprobs[0])
+            if idx == K or pred != draft[idx]:
+                break
+            accepted += 1
+            if request_processors:
+                token_context = gb._token_context[0].update_and_fetch(
+                    mx.array([draft[idx]], dtype=inputs.dtype)
+                )
+        rejected = K - accepted
+        if accepted == K:
+            _stats["full_accept_rounds"] += 1
+            uid_stats["full_accept_rounds"] += 1
+        if rejected:
+            # DeepSeek V4 pooling caches cannot trim once a compressed window
+            # has been materialised. Restore the pre-verify snapshot and replay
+            # only the committed prefix instead. This is the lossless fallback
+            # for partial acceptance; full-accept rounds keep the fast path.
+            gb.prompt_cache = target_cache_snapshot
+            committed_input = verify_input[:, : accepted + 1]
+            replay_logits = model(committed_input, cache=gb.prompt_cache)
+            replay_hidden = model._last_dspark_hidden
+            mx.eval(replay_logits, replay_hidden)
+            verify_hidden = replay_hidden
+
+        # Only target states for committed inputs may seed the next proposal.
+        model._last_dspark_hidden = verify_hidden[:, : accepted + 1]
+        primary_lp = (
+            gb._next_logprobs[0]
+            if gb._next_logprobs is not None and len(gb._next_logprobs) > 0
+            else processed_logprobs[0]
+        )
+        extras = draft[:accepted]
+        extra_lps = processed_logprobs[:accepted]
+        bonus = preds_list[accepted]
+        bonus_lp = processed_logprobs[accepted]
+        gb._next_tokens = mx.array([bonus], dtype=inputs.dtype)
+        gb._next_logprobs = [bonus_lp]
+        mx.async_eval(gb._next_tokens, bonus_lp)
+        gb.tokens[0].append(last_token)
+        _pending[uid] = list(zip(extras, extra_lps))
+        if extras:
+            _pending_replay[uid] = (target_cache_snapshot, verify_input)
+        _stats["tokens_accepted"] += accepted
+        uid_stats["tokens_accepted"] += accepted
+        rounds = int(uid_stats["verify_steps"])
+        average_accept = float(uid_stats["tokens_accepted"]) / float(rounds)
+        if (rounds >= 3 and average_accept < 1.5) or (
+            rounds >= 6 and average_accept < 2.0
+        ):
+            _disabled_uids.add(uid)
+        return [last_token], [primary_lp]
+
+    def _finish_uid(uid: int) -> None:
+        request_stats = _uid_stats.pop(uid, {})
+        attempts = int(request_stats.get("draft_tokens_proposed", 0))
+        accepts = int(request_stats.get("tokens_accepted", 0))
+        rounds = int(request_stats.get("verify_steps", 0))
+        logger.info(
+            "[DSpark] completed uid=%s rounds=%d accepted=%d/%d "
+            "avg_accept=%.2f full_accept=%d/%d adaptive_fallback=%s",
+            uid,
+            rounds,
+            accepts,
+            attempts,
+            accepts / rounds if rounds else 0.0,
+            int(request_stats.get("full_accept_rounds", 0)),
+            rounds,
+            uid in _disabled_uids,
+        )
+        _pending.pop(uid, None)
+        _pending_replay.pop(uid, None)
+        _caches.pop(uid, None)
+        _disabled_uids.discard(uid)
+
+    def _dspark_next():
+        responses = _orig_next()
+        if not responses:
+            return responses
+        for response in responses:
+            if response.finish_reason is not None:
+                _finish_uid(response.uid)
+        if not _pending:
+            return responses
+
+        augmented = list(responses)
+        for response in responses:
+            if response.finish_reason is not None:
+                continue
+            pending = _pending.pop(response.uid, None)
+            replay_state = _pending_replay.pop(response.uid, None)
+            if not pending:
+                continue
+            try:
+                row = gb.uids.index(response.uid)
+            except ValueError:
+                continue
+            for emit_idx, (token, logprobs) in enumerate(pending):
+                gb.tokens[row].append(token)
+                gb._num_tokens[row] += 1
+                finish_reason = None
+                match_sequence = None
+                current_state = None
+                try:
+                    new_state, match_sequence, current_state = gb.state_machines[
+                        row
+                    ].match(gb._matcher_states[row], token)
+                    gb._matcher_states[row] = new_state
+                    if match_sequence is not None and current_state is None:
+                        finish_reason = "stop"
+                except Exception:  # noqa: BLE001
+                    pass
+                if finish_reason is None and gb._num_tokens[row] >= gb.max_tokens[row]:
+                    finish_reason = "length"
+                if finish_reason is not None:
+                    unused = len(pending) - emit_idx - 1
+                    if unused and replay_state is not None:
+                        snapshot, verify_input = replay_state
+                        gb.prompt_cache = snapshot
+                        # Commit the primary plus only the accepted tokens that
+                        # have actually been surfaced through this response.
+                        committed = verify_input[:, : emit_idx + 2]
+                        replay_logits = model(committed, cache=gb.prompt_cache)
+                        mx.eval(replay_logits, model._last_dspark_hidden)
+                    augmented.append(
+                        gb.Response(
+                            uid=response.uid,
+                            token=token,
+                            logprobs=logprobs,
+                            finish_reason=finish_reason,
+                            current_state=current_state,
+                            match_sequence=match_sequence,
+                            prompt_cache=gb.extract_cache(row),
+                            all_tokens=gb.tokens[row],
+                        )
+                    )
+                    gb.filter([i for i in range(len(gb.uids)) if i != row])
+                    _finish_uid(response.uid)
+                    break
+                augmented.append(
+                    gb.Response(
+                        uid=response.uid,
+                        token=token,
+                        logprobs=logprobs,
+                        finish_reason=None,
+                        current_state=current_state,
+                        match_sequence=match_sequence,
+                        prompt_cache=None,
+                        all_tokens=None,
+                    )
+                )
+        return augmented
+
+    gb._step = _dspark_step
+    gb.next = _dspark_next
+    batch_gen._dspark_stats = _stats
+    logger.info(
+        "[DSpark] installed (greedy B=1, checkpoint K=%d, max K=%d)",
+        checkpoint_k,
+        draft_k,
+    )
+    return True
 
 
 def _install_suffix_decoding(
@@ -2676,6 +3000,15 @@ class Scheduler:
                     if getattr(self, "model_config", None) is not None
                     else None,
                 )
+
+        if getattr(self.config, "spec_decode", "none") == "dspark":
+            _install_dspark(
+                bg,
+                model=self.model,
+                requests=self.requests,
+                uid_to_request_id=self.uid_to_request_id,
+                max_draft=getattr(self.config, "dspark_num_speculative_tokens", 5),
+            )
 
         # Install SuffixDecoding (drafter-free spec-decode).
         if self.config.enable_suffix_decoding:

--- a/vllm_mlx/spec_decode/config.py
+++ b/vllm_mlx/spec_decode/config.py
@@ -44,6 +44,7 @@ _COMMON_KEYS = frozenset(
 _METHOD_KEYS = {
     "ddtree": frozenset({"model", "num_speculative_tokens", "tree_budget"}),
     "dflash": frozenset({"model"}),
+    "dspark": frozenset({"num_speculative_tokens"}),
     "mtp": frozenset({"model", "num_speculative_tokens", "disable_auto_k"}),
     "suffix": frozenset(
         {

--- a/vllm_mlx/spec_decode/dspark/__init__.py
+++ b/vllm_mlx/spec_decode/dspark/__init__.py
@@ -1,0 +1,5 @@
+"""DeepSeek V4 checkpoint-native DSpark speculative decoding."""
+
+from .detect import DSparkMetadata, detect_dspark_metadata
+
+__all__ = ["DSparkMetadata", "detect_dspark_metadata"]

--- a/vllm_mlx/spec_decode/dspark/detect.py
+++ b/vllm_mlx/spec_decode/dspark/detect.py
@@ -1,0 +1,74 @@
+"""Fail-closed detection for DeepSeek V4 DSpark checkpoints."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+@dataclass(frozen=True)
+class DSparkMetadata:
+    num_layers: int
+    block_size: int
+    noise_token_id: int
+    target_layer_ids: tuple[int, ...]
+    markov_rank: int
+
+
+_REQUIRED_TENSORS = frozenset(
+    {
+        "mtp.0.main_proj.weight",
+        "mtp.2.markov_head.markov_w1.weight",
+        "mtp.2.markov_head.markov_w2.weight",
+    }
+)
+
+
+def _read_json(path: Path) -> dict[str, Any] | None:
+    try:
+        value = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+    return value if isinstance(value, dict) else None
+
+
+def detect_dspark_metadata(model_path: str | Path) -> DSparkMetadata | None:
+    """Return DSpark metadata only for a complete local checkpoint.
+
+    DeepSeek's Hugging Face config currently carries only the legacy
+    ``num_nextn_predict_layers`` field. The authoritative DSpark geometry is
+    shipped in ``inference/config.json``; tensor presence is verified against
+    the safetensors index so stripped conversions fail closed.
+    """
+
+    root = Path(model_path)
+    config = _read_json(root / "config.json")
+    inference = _read_json(root / "inference" / "config.json")
+    index = _read_json(root / "model.safetensors.index.json")
+    if config is None or config.get("model_type") != "deepseek_v4":
+        return None
+    if inference is None or index is None:
+        return None
+    weight_map = index.get("weight_map")
+    if not isinstance(weight_map, dict) or not _REQUIRED_TENSORS.issubset(weight_map):
+        return None
+
+    try:
+        num_layers = int(inference["n_mtp_layers"])
+        block_size = int(inference["dspark_block_size"])
+        noise_token_id = int(inference["dspark_noise_token_id"])
+        target_layer_ids = tuple(int(v) for v in inference["dspark_target_layer_ids"])
+        markov_rank = int(inference["dspark_markov_rank"])
+    except (KeyError, TypeError, ValueError):
+        return None
+    if num_layers != 3 or block_size <= 0 or not target_layer_ids or markov_rank <= 0:
+        return None
+    return DSparkMetadata(
+        num_layers=num_layers,
+        block_size=block_size,
+        noise_token_id=noise_token_id,
+        target_layer_ids=target_layer_ids,
+        markov_rank=markov_rank,
+    )

--- a/vllm_mlx/spec_decode/registry.py
+++ b/vllm_mlx/spec_decode/registry.py
@@ -78,6 +78,13 @@ register_spec_decoder(
 )
 register_spec_decoder(
     SpecDecoderPlugin(
+        method="dspark",
+        description="DeepSeek V4 native semi-autoregressive block drafter",
+        config_enabled=True,
+    )
+)
+register_spec_decoder(
+    SpecDecoderPlugin(
         method="mtp",
         description="Model-side multi-token prediction head",
         config_enabled=True,

--- a/vllm_mlx/utils/deepseek_v4_0731.py
+++ b/vllm_mlx/utils/deepseek_v4_0731.py
@@ -29,7 +29,14 @@ def _json(value: Any) -> str:
 
 def _tool_schemas(tools: list[dict]) -> str:
     definitions = [t.get("function", t) for t in tools]
-    schemas = "\n".join(_json(t) for t in definitions)
+    # Agent clients may reorder otherwise-identical tools (and JSON object
+    # keys) between turns.  Since the schemas live in the system prefix, that
+    # turns a harmless wire-order change into a 30K-token prefix-cache miss.
+    # Tool order has no semantic meaning, so canonicalise both levels.
+    definitions.sort(key=lambda item: str(item.get("name", "")))
+    schemas = "\n".join(
+        json.dumps(item, ensure_ascii=False, sort_keys=True) for item in definitions
+    )
     return f"""## Tools
 
 You have access to a set of tools to help answer the user's question. You can invoke tools by writing a "<{DSML}tool_calls>" block like the following:

--- a/vllm_mlx/utils/deepseek_v4_0731.py
+++ b/vllm_mlx/utils/deepseek_v4_0731.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import copy
 import json
+import re
 from typing import Any
 
 BOS = "<｜begin▁of▁sentence｜>"
@@ -28,7 +29,35 @@ def _json(value: Any) -> str:
 
 
 def _tool_schemas(tools: list[dict]) -> str:
-    definitions = [t.get("function", t) for t in tools]
+    # Only function-schema fields affect model tool calling. Agent clients may
+    # attach runtime connector metadata (for example a changing nested
+    # ``tools`` inventory on Codex's GitHub gateway); serialising that metadata
+    # into the prompt invalidates a 30K+ prefix without changing semantics.
+    definitions = [
+        {
+            key: copy.deepcopy(value)
+            for key, value in t.get("function", t).items()
+            if key in {"name", "description", "parameters", "strict"}
+        }
+        for t in tools
+    ]
+    for definition in definitions:
+        description = definition.get("description")
+        if isinstance(description, str):
+            paragraphs = description.split("\n\n")
+            if paragraphs and "Required for some features such as Codex" in paragraphs[0]:
+                description = "\n\n".join(paragraphs[1:])
+            # Codex decorates connector tools with this redundant suffix after
+            # the connector is activated.  Removing it keeps the otherwise
+            # identical 30K+ system/tool prefix cacheable across tool rounds.
+            description = re.sub(
+                r" This tool is part of plugin `[^`]+`\.", "", description
+            )
+            # The decorator also inserts a sentence-delimiter period when the
+            # source description did not already have one.  Canonicalising a
+            # final period is semantically neutral and keeps Codex's 30K+
+            # system/tool prefix stable after connector activation.
+            definition["description"] = description.rstrip().removesuffix(".")
     # Agent clients may reorder otherwise-identical tools (and JSON object
     # keys) between turns.  Since the schemas live in the system prefix, that
     # turns a harmless wire-order change into a 30K-token prefix-cache miss.

--- a/vllm_mlx/utils/deepseek_v4_0731.py
+++ b/vllm_mlx/utils/deepseek_v4_0731.py
@@ -45,7 +45,10 @@ def _tool_schemas(tools: list[dict]) -> str:
         description = definition.get("description")
         if isinstance(description, str):
             paragraphs = description.split("\n\n")
-            if paragraphs and "Required for some features such as Codex" in paragraphs[0]:
+            if (
+                paragraphs
+                and "Required for some features such as Codex" in paragraphs[0]
+            ):
                 description = "\n\n".join(paragraphs[1:])
             # Codex decorates connector tools with this redundant suffix after
             # the connector is activated.  Removing it keeps the otherwise

--- a/vllm_mlx/utils/tokenizer.py
+++ b/vllm_mlx/utils/tokenizer.py
@@ -757,7 +757,12 @@ def _post_load_ubc_evict(model_name: str) -> None:
         logger.debug(f"Defect 4 post-load UBC evict skipped (non-fatal): {e}")
 
 
-def load_model_with_fallback(model_name: str, tokenizer_config: dict = None):
+def load_model_with_fallback(
+    model_name: str,
+    tokenizer_config: dict = None,
+    *,
+    enable_dspark: bool = False,
+):
     """
     Load model and tokenizer with fallback for non-standard tokenizers.
 
@@ -773,7 +778,14 @@ def load_model_with_fallback(model_name: str, tokenizer_config: dict = None):
     # or fallback loader runs.  Remote repository ids are intentionally a no-op
     # here; see validate_local_model_file for the containment boundary.
     validate_local_model_file(model_name)
-    result = _load_model_with_fallback_impl(model_name, tokenizer_config)
+    if enable_dspark:
+        result = _load_model_with_fallback_impl(
+            model_name, tokenizer_config, enable_dspark=True
+        )
+    else:
+        # Preserve the historical two-argument call shape for downstream
+        # wrappers and tests that instrument this internal dispatch boundary.
+        result = _load_model_with_fallback_impl(model_name, tokenizer_config)
     # Defect 4: evict UBC mirror of safetensors shards on Darwin so
     # the (mmap mirror + materialised weights) burst does not double
     # the load-window memory footprint. Runs ONLY after a successful
@@ -787,7 +799,12 @@ def load_model_with_fallback(model_name: str, tokenizer_config: dict = None):
     return result
 
 
-def _load_model_with_fallback_impl(model_name: str, tokenizer_config: dict = None):
+def _load_model_with_fallback_impl(
+    model_name: str,
+    tokenizer_config: dict = None,
+    *,
+    enable_dspark: bool = False,
+):
     """Inner load implementation — kept separate so the public wrapper can
     install a try/finally for the Defect 4 UBC eviction without rewriting
     every return branch in the loader."""
@@ -801,7 +818,7 @@ def _load_model_with_fallback_impl(model_name: str, tokenizer_config: dict = Non
         logger.info(
             f"Model {model_name} requires tokenizer fallback, loading directly..."
         )
-        return _load_with_tokenizer_fallback(model_name)
+        return _load_with_tokenizer_fallback(model_name, enable_dspark=enable_dspark)
 
     # Vendored architectures (e.g. deepseek_v4) — transformers' AutoConfig
     # doesn't know about them, so mlx-lm's high-level load() blows up
@@ -812,7 +829,7 @@ def _load_model_with_fallback_impl(model_name: str, tokenizer_config: dict = Non
             f"Model {model_name} uses a vendored architecture, "
             "skipping AutoConfig path and loading directly..."
         )
-        return _load_with_tokenizer_fallback(model_name)
+        return _load_with_tokenizer_fallback(model_name, enable_dspark=enable_dspark)
 
     # Gemma 4: mlx-lm 0.31+ supports it natively. Only use our wrapper
     # for older mlx-lm versions that lack gemma4 model support. Several
@@ -892,7 +909,9 @@ def _load_model_with_fallback_impl(model_name: str, tokenizer_config: dict = Non
             or "does not recognize this architecture" in str(e)
         ):
             logger.warning(f"Standard tokenizer loading failed, using fallback: {e}")
-            return _load_with_tokenizer_fallback(model_name)
+            return _load_with_tokenizer_fallback(
+                model_name, enable_dspark=enable_dspark
+            )
         # Fallback for models with extra/missing weights (e.g., vision tower, MTP layers).
         # Retry with strict=False to discard extra weights.
         elif "parameters not in model" in str(e) or (
@@ -1007,7 +1026,7 @@ def _load_non_strict(model_name: str, tokenizer_config: dict = None):
     return model, tokenizer
 
 
-def _load_with_tokenizer_fallback(model_name: str):
+def _load_with_tokenizer_fallback(model_name: str, *, enable_dspark: bool = False):
     """Load model with fallback tokenizer for non-standard models like Nemotron."""
     from mlx_lm.utils import load_model
 
@@ -1027,7 +1046,9 @@ def _load_with_tokenizer_fallback(model_name: str):
     # nests the transformer under ``model`` and renames shared-expert
     # projections, so mlx-lm would otherwise apply the global MXFP4 default to
     # MXFP8 attention tensors and reject their packed shapes.
-    model_config = _deepseek_v4_quantization_override(model_path)
+    model_config = _deepseek_v4_quantization_override(
+        model_path, enable_dspark=enable_dspark
+    )
 
     # Load model
     model, _ = load_model(model_path, model_config=model_config)
@@ -1091,7 +1112,9 @@ def _load_with_tokenizer_fallback(model_name: str):
     return model, tokenizer
 
 
-def _deepseek_v4_quantization_override(model_path: Path) -> dict | None:
+def _deepseek_v4_quantization_override(
+    model_path: Path, *, enable_dspark: bool = False
+) -> dict | None:
     """Translate standalone DeepSeek-V4 quantization paths for mlx-lm.
 
     Returns a ``model_config`` overlay only for ``model_type=deepseek_v4``.
@@ -1127,4 +1150,21 @@ def _deepseek_v4_quantization_override(model_path: Path) -> dict | None:
                 f".ffn.shared_experts.{old}", f".ffn.shared_experts.{new}"
             )
         translated[new_path] = value
-    return {"quantization": translated}
+    overlay = {"quantization": translated}
+    try:
+        from ..spec_decode.dspark import detect_dspark_metadata
+
+        dspark = detect_dspark_metadata(model_path) if enable_dspark else None
+    except Exception:  # pragma: no cover - optional checkpoint metadata
+        dspark = None
+    if dspark is not None:
+        overlay.update(
+            {
+                "dspark_num_layers": dspark.num_layers,
+                "dspark_block_size": dspark.block_size,
+                "dspark_noise_token_id": dspark.noise_token_id,
+                "dspark_target_layer_ids": list(dspark.target_layer_ids),
+                "dspark_markov_rank": dspark.markov_rank,
+            }
+        )
+    return overlay


### PR DESCRIPTION
## Summary
- add checkpoint-native DSpark draft/verify decoding for DeepSeek V4 Flash 0731
- detect and load the checkpoint MTP/DSpark heads only when explicitly enabled
- add CLI configuration, documentation, cache handling, and regression coverage
- improve non-trimmable DeepSeek cache boundary handling for agent workloads

## Validation
- 194 targeted DSpark/DeepSeek tests passed before the latest cache diagnostics
- 120 DeepSeek, DSpark, config, and prefix-boundary tests passed
- 133 Responses route/adapter tests passed
- Ruff passed on changed paths
- real 156GB local wheel loaded and served successfully
- mini Codex exercised real /v1/responses tool rounds; DSpark observed 2.6-2.9 accepted tokens/round

## Status
Draft while production Codex validation continues. GitHub connector tool schemas currently change between turns, limiting the reusable prompt prefix to about 5.4K of 36K tokens; this is being diagnosed before review/validation/land.