### PR TITLE
fix(deepseek-v4): cut warm TTFT and contain reasoning

### DIFF
--- a/tests/test_aliases_contract.py
+++ b/tests/test_aliases_contract.py
@@ -695,7 +695,7 @@ def test_bonsai_ternary_alias_wiring() -> None:
         )
 
 
-def test_deepseek_v4_flash_family_wires_deepseek_r1_reasoning_parser() -> None:
+def test_deepseek_v4_flash_family_wires_dedicated_reasoning_parser() -> None:
     """The DeepSeek-V4-Flash chat template emits ``<think>...</think>``
     blocks (gated by ``thinking_mode``). Without ``reasoning_parser`` set,
     that text leaks into ``choices[0].message.content`` as user-visible
@@ -714,8 +714,8 @@ def test_deepseek_v4_flash_family_wires_deepseek_r1_reasoning_parser() -> None:
     ]
     for alias in family:
         assert alias in profiles, f"{alias} missing from aliases.json"
-        assert profiles[alias].reasoning_parser == "deepseek_r1", (
-            f"{alias}: reasoning_parser must be 'deepseek_r1' (V4-Flash emits "
+        assert profiles[alias].reasoning_parser == "deepseek_v4", (
+            f"{alias}: reasoning_parser must be 'deepseek_v4' (V4-Flash emits "
             f"`<think>` blocks). Got {profiles[alias].reasoning_parser!r}."
         )
 

--- a/tests/test_deepseek_v4_0731.py
+++ b/tests/test_deepseek_v4_0731.py
@@ -25,7 +25,7 @@ def test_alias_points_at_0731_mxfp4_with_ultra_memory_floor():
     profile = list_profiles()["deepseek-v4-flash-0731-mxfp4"]
     assert profile.hf_path == "Vontra/DeepSeek-V4-Flash-0731-MXFP4-MLX"
     assert profile.tool_call_parser == "deepseek_v4_0731"
-    assert profile.reasoning_parser == "deepseek_r1"
+    assert profile.reasoning_parser == "deepseek_v4"
     assert profile.is_moe is True
     assert profile.min_memory_gb == 192
     assert profile.supports_spec_decode is False

--- a/tests/test_deepseek_v4_reasoning_parser.py
+++ b/tests/test_deepseek_v4_reasoning_parser.py
@@ -76,6 +76,35 @@ def test_thinking_mode_keeps_implicit_reasoning_across_many_chunks() -> None:
     assert "".join(content) == "There are 23 chickens and 12 rabbits."
 
 
+def test_unspecified_thinking_defaults_to_implicit_reasoning_streaming() -> None:
+    parser = DeepSeekV4ReasoningParser()
+    parser.configure_request(enable_thinking=None)
+
+    thought = parser.extract_reasoning_streaming(
+        "", "private scratch", "private scratch"
+    )
+    answer = parser.extract_reasoning_streaming(
+        "private scratch",
+        "private scratch</think>public answer",
+        "</think>public answer",
+    )
+
+    assert thought is not None and thought.reasoning == "private scratch"
+    assert thought.content is None
+    assert answer is not None and answer.content == "public answer"
+
+
+def test_unspecified_thinking_defaults_to_implicit_reasoning_nonstreaming() -> None:
+    parser = DeepSeekV4ReasoningParser()
+
+    reasoning, content = parser.extract_reasoning(
+        "private scratch</think>public answer", enable_thinking=None
+    )
+
+    assert reasoning == "private scratch"
+    assert content == "public answer"
+
+
 def test_dsml_tool_start_implicitly_closes_reasoning() -> None:
     parser = DeepSeekV4ReasoningParser()
     parser.configure_request(enable_thinking=True)

--- a/tests/test_deepseek_v4_reasoning_parser.py
+++ b/tests/test_deepseek_v4_reasoning_parser.py
@@ -1,3 +1,5 @@
+import pytest
+
 from vllm_mlx.config import ServerConfig
 from vllm_mlx.engine.base import GenerationOutput
 from vllm_mlx.reasoning.deepseek_v4_parser import DeepSeekV4ReasoningParser
@@ -33,6 +35,19 @@ def test_split_bare_close_never_leaks_to_content() -> None:
         previous = current
 
     assert "".join(emitted) == "donenext"
+
+
+def test_disabled_thinking_absorbs_opener_without_creating_reasoning() -> None:
+    parser = DeepSeekV4ReasoningParser()
+    parser.configure_request(enable_thinking=False)
+
+    parsed = parser.extract_reasoning_streaming(
+        "", "before<think>inside</think>after", "before<think>inside</think>after"
+    )
+
+    assert parsed is not None
+    assert parsed.reasoning is None
+    assert parsed.content == "beforeinsideafter"
 
 
 def test_thinking_mode_routes_reasoning_then_content() -> None:
@@ -145,3 +160,20 @@ def test_chat_postprocessor_keeps_sanitizer_active_when_thinking_disabled() -> N
 
     assert "".join(visible) == "ruff passed\nnext"
     assert "</think>" not in "".join(visible)
+
+
+def test_chat_postprocessor_fails_closed_on_request_config_error(monkeypatch) -> None:
+    class BrokenParser:
+        def configure_request(self, *, enable_thinking=None):
+            raise RuntimeError("cannot establish reasoning state")
+
+    cfg = ServerConfig()
+    cfg.reasoning_parser_name = "deepseek_v4"
+    monkeypatch.setattr(
+        StreamingPostProcessor,
+        "_create_reasoning_parser",
+        lambda self, _cfg: BrokenParser(),
+    )
+
+    with pytest.raises(RuntimeError, match="cannot establish reasoning state"):
+        StreamingPostProcessor(cfg, enable_thinking=None)

--- a/tests/test_deepseek_v4_reasoning_parser.py
+++ b/tests/test_deepseek_v4_reasoning_parser.py
@@ -6,8 +6,10 @@ from vllm_mlx.api.constants import REASONING_CUTOFF_SENTINEL
 from vllm_mlx.config import ServerConfig
 from vllm_mlx.engine.base import GenerationOutput
 from vllm_mlx.reasoning.deepseek_v4_parser import DeepSeekV4ReasoningParser
-from vllm_mlx.routes.chat import _uses_deepseek_v4_reasoning
-from vllm_mlx.service.helpers import _apply_reasoning_cutoff_notice
+from vllm_mlx.service.helpers import (
+    _apply_reasoning_cutoff_notice,
+    _uses_deepseek_v4_reasoning,
+)
 from vllm_mlx.service.postprocessor import StreamingPostProcessor
 
 
@@ -52,7 +54,7 @@ def test_disabled_thinking_absorbs_opener_without_creating_reasoning() -> None:
 
     assert parsed is not None
     assert parsed.reasoning is None
-    assert parsed.content == "beforeinsideafter"
+    assert parsed.content == "beforeafter"
 
 
 def test_thinking_mode_routes_reasoning_then_content() -> None:

--- a/tests/test_deepseek_v4_reasoning_parser.py
+++ b/tests/test_deepseek_v4_reasoning_parser.py
@@ -1,0 +1,91 @@
+from vllm_mlx.config import ServerConfig
+from vllm_mlx.engine.base import GenerationOutput
+from vllm_mlx.reasoning.deepseek_v4_parser import DeepSeekV4ReasoningParser
+from vllm_mlx.service.postprocessor import StreamingPostProcessor
+
+
+def test_chat_mode_absorbs_bare_think_close_after_content() -> None:
+    parser = DeepSeekV4ReasoningParser()
+    parser.configure_request(enable_thinking=False)
+
+    first = parser.extract_reasoning_streaming("", "ruff passed", "ruff passed")
+    close = parser.extract_reasoning_streaming(
+        "ruff passed", "ruff passed\n</think>", "\n</think>"
+    )
+
+    assert first is not None and first.content == "ruff passed"
+    assert close is not None and close.content == "\n"
+    assert "</think>" not in close.content
+
+
+def test_split_bare_close_never_leaks_to_content() -> None:
+    parser = DeepSeekV4ReasoningParser()
+    parser.configure_request(enable_thinking=False)
+
+    chunks = ["done<", "/thi", "nk>next"]
+    emitted = []
+    previous = ""
+    for chunk in chunks:
+        current = previous + chunk
+        result = parser.extract_reasoning_streaming(previous, current, chunk)
+        if result and result.content:
+            emitted.append(result.content)
+        previous = current
+
+    assert "".join(emitted) == "donenext"
+
+
+def test_thinking_mode_routes_reasoning_then_content() -> None:
+    parser = DeepSeekV4ReasoningParser()
+    parser.configure_request(enable_thinking=True)
+
+    thought = parser.extract_reasoning_streaming("", "inspect", "inspect")
+    answer = parser.extract_reasoning_streaming(
+        "inspect", "inspect</think>fixed", "</think>fixed"
+    )
+
+    assert thought is not None and thought.reasoning == "inspect"
+    assert answer is not None and answer.content == "fixed"
+    assert answer.reasoning is None
+
+
+def test_dsml_tool_start_implicitly_closes_reasoning() -> None:
+    parser = DeepSeekV4ReasoningParser()
+    parser.configure_request(enable_thinking=True)
+
+    parsed = parser.extract_reasoning_streaming(
+        "",
+        "plan<｜DSML｜tool_calls><｜DSML｜invoke",
+        "plan<｜DSML｜tool_calls><｜DSML｜invoke",
+    )
+
+    assert parsed is not None
+    assert parsed.reasoning == "plan"
+    assert parsed.content == "<｜DSML｜tool_calls><｜DSML｜invoke"
+
+
+def test_nonstream_chat_mode_absorbs_control_tokens() -> None:
+    parser = DeepSeekV4ReasoningParser()
+    reasoning, content = parser.extract_reasoning(
+        "first</think>second", enable_thinking=False
+    )
+
+    assert reasoning is None
+    assert content == "firstsecond"
+
+
+def test_chat_postprocessor_keeps_sanitizer_active_when_thinking_disabled() -> None:
+    cfg = ServerConfig()
+    cfg.reasoning_parser_name = "deepseek_v4"
+    processor = StreamingPostProcessor(cfg, enable_thinking=False)
+    processor.reset()
+
+    visible = []
+    for text in ("ruff passed\n<", "/think>", "next"):
+        events = processor.process_chunk(
+            GenerationOutput(text=text, new_text=text, tokens=[1], finished=False)
+        )
+        visible.extend(event.content for event in events if event.type == "content")
+
+    assert "".join(visible) == "ruff passed\nnext"
+    assert "</think>" not in "".join(visible)

--- a/tests/test_deepseek_v4_reasoning_parser.py
+++ b/tests/test_deepseek_v4_reasoning_parser.py
@@ -1,8 +1,13 @@
+from types import SimpleNamespace
+
 import pytest
 
+from vllm_mlx.api.constants import REASONING_CUTOFF_SENTINEL
 from vllm_mlx.config import ServerConfig
 from vllm_mlx.engine.base import GenerationOutput
 from vllm_mlx.reasoning.deepseek_v4_parser import DeepSeekV4ReasoningParser
+from vllm_mlx.routes.chat import _uses_deepseek_v4_reasoning
+from vllm_mlx.service.helpers import _apply_reasoning_cutoff_notice
 from vllm_mlx.service.postprocessor import StreamingPostProcessor
 
 
@@ -177,3 +182,34 @@ def test_chat_postprocessor_fails_closed_on_request_config_error(monkeypatch) ->
 
     with pytest.raises(RuntimeError, match="cannot establish reasoning state"):
         StreamingPostProcessor(cfg, enable_thinking=None)
+
+
+def test_truncated_deepseek_reasoning_notice_never_copies_reasoning_tail() -> None:
+    content = _apply_reasoning_cutoff_notice(
+        None,
+        "private scratch that must remain reasoning-only",
+        None,
+        "length",
+        include_reasoning_tail=False,
+    )
+
+    assert content == REASONING_CUTOFF_SENTINEL
+    assert "private scratch" not in content
+
+
+def test_runtime_deepseek_detection_covers_auto_config_forms() -> None:
+    empty_cfg = SimpleNamespace(
+        reasoning_parser_name=None,
+        reasoning_parser=None,
+        model_path="/models/DeepSeek-V4-Flash-0731-MXFP4-MLX",
+        model_name=None,
+    )
+    assert _uses_deepseek_v4_reasoning(empty_cfg)
+
+    generic_cfg = SimpleNamespace(
+        reasoning_parser_name=None,
+        reasoning_parser=None,
+        model_path="/models/other",
+        model_name=None,
+    )
+    assert _uses_deepseek_v4_reasoning(generic_cfg, DeepSeekV4ReasoningParser())

--- a/tests/test_deepseek_v4_reasoning_parser.py
+++ b/tests/test_deepseek_v4_reasoning_parser.py
@@ -49,6 +49,33 @@ def test_thinking_mode_routes_reasoning_then_content() -> None:
     assert answer.reasoning is None
 
 
+def test_thinking_mode_keeps_implicit_reasoning_across_many_chunks() -> None:
+    """DeepSeek V4 omits the opener; no heuristic may flip it to content."""
+    parser = DeepSeekV4ReasoningParser()
+    parser.configure_request(enable_thinking=True)
+
+    chunks = [
+        "We need answer. Need solve classic chickens rabbits. Need show",
+        " reasoning. Need be careful: chickens 2 legs, rabbits 4 legs.",
+        " c+r=35, 2c+4r=94.",
+        "</think>There are 23 chickens and 12 rabbits.",
+    ]
+    reasoning = []
+    content = []
+    previous = ""
+    for chunk in chunks:
+        current = previous + chunk
+        parsed = parser.extract_reasoning_streaming(previous, current, chunk)
+        if parsed is not None:
+            reasoning.append(parsed.reasoning or "")
+            content.append(parsed.content or "")
+        previous = current
+
+    assert "Need be careful" in "".join(reasoning)
+    assert "Need be careful" not in "".join(content)
+    assert "".join(content) == "There are 23 chickens and 12 rabbits."
+
+
 def test_dsml_tool_start_implicitly_closes_reasoning() -> None:
     parser = DeepSeekV4ReasoningParser()
     parser.configure_request(enable_thinking=True)

--- a/tests/test_hybrid_prefix_cache_growth.py
+++ b/tests/test_hybrid_prefix_cache_growth.py
@@ -499,16 +499,12 @@ def test_hybrid_bound_is_enforced(reuse_cache):
     assert stats["evictions"] >= 1
 
 
-def test_hybrid_bound_evicts_by_recency_not_insertion_order(reuse_cache):
-    """#1103 codex NIT-3: the bound is LRU, not FIFO — a cache fetch must
-    refresh an entry's recency so it survives a later eviction.
+def test_hybrid_bound_does_not_promote_unusable_exact_entry(reuse_cache):
+    """An exact snapshot that serves no tokens must not gain LRU priority.
 
-    ``test_hybrid_bound_is_enforced`` only ever stores (never fetches), so
-    insertion order == recency order there and it can't distinguish LRU from
-    FIFO. Here we store chain_a then chain_b, then FETCH chain_a (an unusable
-    exact entry that still bumps recency), then store chain_c. Under
-    LRU the least-recently-used is now chain_b, so chain_b — NOT the
-    first-inserted chain_a — must be the one evicted.
+    Otherwise repeated exact requests can protect an unusable full-prompt
+    snapshot while evicting the older message-boundary snapshot that actually
+    avoids full prefill.
     """
     chain_a = list(range(1000, 1100))
     chain_b = list(range(2000, 2100))
@@ -518,24 +514,19 @@ def test_hybrid_bound_evicts_by_recency_not_insertion_order(reuse_cache):
     reuse_cache.store(chain_b, _hybrid_cache())
 
     # BatchGenerator cannot consume this exact non-trimmable state because it
-    # re-forwards the final prompt token.  The lookup is therefore a miss, but
-    # touching the retained entry still refreshes its LRU recency.
+    # re-forwards the final prompt token. The miss must not refresh recency.
     result, remaining = reuse_cache.fetch(chain_a)
     assert result is None
     assert remaining == chain_a
 
-    # Now the LRU order is [chain_b (oldest), chain_a (newest)]. Storing
-    # chain_c pushes the count to 3 > bound 2, so the OLDEST (chain_b) goes.
+    # The LRU order remains [chain_a (oldest), chain_b (newest)]. Storing
+    # chain_c pushes the count to 3 > bound 2, so chain_a must be evicted.
     reuse_cache.store(chain_c, _hybrid_cache())
 
     stats = reuse_cache.get_stats()
     assert stats["non_trimmable_entries"] == 2, "Bound of 2 must hold"
-    assert tuple(chain_b) not in reuse_cache._entries, (
-        "chain_b was least-recently-used and must be evicted (LRU, not FIFO)"
-    )
-    assert tuple(chain_a) in reuse_cache._entries, (
-        "chain_a was refreshed by its fetch hit and must survive"
-    )
+    assert tuple(chain_a) not in reuse_cache._entries
+    assert tuple(chain_b) in reuse_cache._entries
     assert tuple(chain_c) in reuse_cache._entries
 
 

--- a/tests/test_hybrid_prefix_cache_growth.py
+++ b/tests/test_hybrid_prefix_cache_growth.py
@@ -416,6 +416,26 @@ def test_hybrid_exact_match_falls_back_to_longest_strict_prefix(reuse_cache):
     assert reuse_cache._last_match_type == "prefix"
 
 
+def test_radix_hybrid_exact_match_falls_back_to_longest_strict_prefix():
+    """The radix fast path must walk past an unusable exact terminal."""
+    from vllm_mlx.runtime.radix_index import RadixPrefixIndex
+
+    config = MemoryCacheConfig(
+        max_memory_mb=10, max_entries=64, hybrid_reuse_max_entries=2
+    )
+    cache = MemoryAwarePrefixCache(MagicMock(), config, RadixPrefixIndex())
+    prompt = list(range(1000, 1100))
+    boundary = prompt[:-7]
+    cache.store(boundary, _hybrid_cache(), evict_prefixes=False)
+    cache.store(prompt, _hybrid_cache(), evict_prefixes=False)
+
+    result, remaining = cache.fetch(prompt)
+
+    assert result is not None
+    assert remaining == prompt[-7:]
+    assert cache._last_match_type == "prefix"
+
+
 def test_hybrid_prefix_extension_hit_when_enabled(reuse_cache):
     """The #214 growing-conversation shape works again under the opt-in:
     stored ``[P + R1]`` serves turn-2's ``[P + R1 + M2]`` as a prefix match

--- a/tests/test_hybrid_prefix_cache_growth.py
+++ b/tests/test_hybrid_prefix_cache_growth.py
@@ -386,15 +386,34 @@ def test_hybrid_store_retained_when_enabled(reuse_cache):
     assert reuse_cache.get_stats()["non_trimmable_entries"] == 1
 
 
-def test_hybrid_exact_match_hit_when_enabled(reuse_cache):
-    """Exact match is trim-free — a retained hybrid entry must serve it."""
+def test_hybrid_exact_match_without_shorter_snapshot_misses(reuse_cache):
+    """An exact recurrent-state entry cannot kick off generation.
+
+    BatchGenerator re-forwards the final prompt token, so the cached state
+    would first need to trim one token.  With no shorter snapshot available,
+    correctness requires a clean miss/full prefill.
+    """
     prompt = list(range(1000, 1100))
     reuse_cache.store(prompt, _hybrid_cache())
 
     result, remaining = reuse_cache.fetch(prompt)
 
-    assert result is not None, "Exact match needs no trim — hybrid entry must hit"
-    assert remaining == []
+    assert result is None
+    assert remaining == prompt
+
+
+def test_hybrid_exact_match_falls_back_to_longest_strict_prefix(reuse_cache):
+    """An unusable exact hit must not mask a resumable boundary snapshot."""
+    prompt = list(range(1000, 1100))
+    boundary = prompt[:-7]
+    reuse_cache.store(boundary, _hybrid_cache(), evict_prefixes=False)
+    reuse_cache.store(prompt, _hybrid_cache(), evict_prefixes=False)
+
+    result, remaining = reuse_cache.fetch(prompt)
+
+    assert result is not None
+    assert remaining == prompt[-7:]
+    assert reuse_cache._last_match_type == "prefix"
 
 
 def test_hybrid_prefix_extension_hit_when_enabled(reuse_cache):
@@ -461,13 +480,13 @@ def test_hybrid_bound_is_enforced(reuse_cache):
 
 
 def test_hybrid_bound_evicts_by_recency_not_insertion_order(reuse_cache):
-    """#1103 codex NIT-3: the bound is LRU, not FIFO — a cache HIT must
+    """#1103 codex NIT-3: the bound is LRU, not FIFO — a cache fetch must
     refresh an entry's recency so it survives a later eviction.
 
     ``test_hybrid_bound_is_enforced`` only ever stores (never fetches), so
     insertion order == recency order there and it can't distinguish LRU from
-    FIFO. Here we store chain_a then chain_b, then FETCH chain_a (an exact
-    trim-free hit that must bump it to most-recent), then store chain_c. Under
+    FIFO. Here we store chain_a then chain_b, then FETCH chain_a (an unusable
+    exact entry that still bumps recency), then store chain_c. Under
     LRU the least-recently-used is now chain_b, so chain_b — NOT the
     first-inserted chain_a — must be the one evicted.
     """
@@ -478,11 +497,12 @@ def test_hybrid_bound_evicts_by_recency_not_insertion_order(reuse_cache):
     reuse_cache.store(chain_a, _hybrid_cache())
     reuse_cache.store(chain_b, _hybrid_cache())
 
-    # Exact-match hit on chain_a — trim-free, so a retained hybrid entry
-    # serves it AND its recency is refreshed to most-recently-used.
+    # BatchGenerator cannot consume this exact non-trimmable state because it
+    # re-forwards the final prompt token.  The lookup is therefore a miss, but
+    # touching the retained entry still refreshes its LRU recency.
     result, remaining = reuse_cache.fetch(chain_a)
-    assert result is not None, "Exact match on chain_a must hit (trim-free)"
-    assert remaining == []
+    assert result is None
+    assert remaining == chain_a
 
     # Now the LRU order is [chain_b (oldest), chain_a (newest)]. Storing
     # chain_c pushes the count to 3 > bound 2, so the OLDEST (chain_b) goes.

--- a/tests/test_model_auto_config.py
+++ b/tests/test_model_auto_config.py
@@ -183,17 +183,9 @@ class TestDetectModelConfig:
         config = detect_model_config(model_path)
         assert config is not None
         assert config.tool_call_parser == "deepseek"
-        # V4-Flash chat template emits `<think>...</think>` blocks gated
-        # by ``thinking_mode``; ``deepseek_r1`` handles that format. The
-        # base ``deepseek-ai/DeepSeek-V4`` path is resolved via family
-        # detection (no aliases.json entry), so it currently gets no
-        # reasoning_parser — only the MLX variants benefit from the
-        # alias wiring. Track both shapes here so a refactor that flips
-        # the family default has to update this test consciously.
-        if model_path == "deepseek-ai/DeepSeek-V4":
-            assert config.reasoning_parser is None
-        else:
-            assert config.reasoning_parser == "deepseek_r1"
+        # Match vLLM/SGLang: V4 has a dedicated state machine which absorbs
+        # the protocol's bare ``</think>`` even when thinking is disabled.
+        assert config.reasoning_parser == "deepseek_v4"
         assert config.is_hybrid is False
         assert config.supports_spec_decode is True
 
@@ -201,7 +193,7 @@ class TestDetectModelConfig:
         """A local 0731 snapshot must retain the alias' dedicated wire format."""
         cfg = detect_model_config("/Volumes/models/DeepSeek-V4-Flash-0731-MXFP4-MLX")
         assert cfg.tool_call_parser == "deepseek_v4_0731"
-        assert cfg.reasoning_parser == "deepseek_r1"
+        assert cfg.reasoning_parser == "deepseek_v4"
         assert cfg.is_hybrid is False
         assert cfg.supports_spec_decode is False
 

--- a/tests/test_sliding_window_prefix_reuse.py
+++ b/tests/test_sliding_window_prefix_reuse.py
@@ -116,7 +116,8 @@ def test_trim1_cannot_undo_last_token_on_rotated_cache():
 
 def test_hybrid_gate_retains_and_serves_rotated_sliding_window_entry():
     """#1103's knob is class-agnostic: N>0 retains a rotated RotatingKVCache
-    entry and serves it on exact + prefix-extension fetch; N=0 drops it."""
+    entry and serves prefix extensions; an exact request cannot reuse it
+    because generation kickoff would require trim(1). N=0 drops it."""
 
     def _mixed(n):
         kv = KVCache()
@@ -137,9 +138,9 @@ def test_hybrid_gate_retains_and_serves_rotated_sliding_window_entry():
     assert on.store(toks, _mixed(40), evict_prefixes=False) is True  # retained
 
     exact, remaining = on.fetch(toks)
-    assert exact is not None
-    assert on._last_match_type == "exact"
-    assert remaining == []
+    assert exact is None
+    assert on._last_match_type == "miss"
+    assert remaining == toks
 
     ext, remaining = on.fetch(toks + [40, 41, 42])
     assert ext is not None

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -388,28 +388,28 @@
   "deepseek-v4-flash-2bit": {
     "hf_path": "mlx-community/DeepSeek-V4-Flash-2bit-DQ",
     "tool_call_parser": "deepseek",
-    "reasoning_parser": "deepseek_r1",
+    "reasoning_parser": "deepseek_v4",
     "is_hybrid": false,
     "supports_spec_decode": true
   },
   "deepseek-v4-flash-8bit": {
     "hf_path": "mlx-community/DeepSeek-V4-Flash-8bit",
     "tool_call_parser": "deepseek",
-    "reasoning_parser": "deepseek_r1",
+    "reasoning_parser": "deepseek_v4",
     "is_hybrid": false,
     "supports_spec_decode": true
   },
   "deepseek-v4-flash-4bit": {
     "hf_path": "mlx-community/DeepSeek-V4-Flash-4bit",
     "tool_call_parser": "deepseek",
-    "reasoning_parser": "deepseek_r1",
+    "reasoning_parser": "deepseek_v4",
     "is_hybrid": false,
     "supports_spec_decode": true
   },
   "deepseek-v4-flash-0731-mxfp4": {
     "hf_path": "Vontra/DeepSeek-V4-Flash-0731-MXFP4-MLX",
     "tool_call_parser": "deepseek_v4_0731",
-    "reasoning_parser": "deepseek_r1",
+    "reasoning_parser": "deepseek_v4",
     "is_hybrid": false,
     "is_moe": true,
     "supports_spec_decode": false,

--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -1686,8 +1686,15 @@ class MemoryAwarePrefixCache:
         # on shared-system-prompt workloads.
         if self._radix_index is not None:
             try:
+                # A non-trimmable exact entry cannot seed generation because
+                # the scheduler re-forwards the final prompt token. Ask the
+                # radix directly for a strict prefix instead of accepting its
+                # unusable exact terminal and relying on the sorted fallback.
+                radix_query = (
+                    tokens_key[:-1] if unusable_non_trimmable_exact else tokens_key
+                )
                 matched_tokens, matched_key = self._radix_index.longest_prefix(
-                    tokens_key
+                    radix_query
                 )
             except Exception as exc:  # pragma: no cover — defensive
                 logger.warning(f"[radix] longest_prefix failed: {exc}")

--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -1650,11 +1650,6 @@ class MemoryAwarePrefixCache:
         unusable_non_trimmable_exact = bool(
             exact_entry is not None and exact_entry.non_trimmable
         )
-        if unusable_non_trimmable_exact:
-            # The entry is still live and was requested, so preserve ordinary
-            # LRU recency even though this execution path cannot consume it.
-            # A strict-prefix fallback below records the actual cache hit.
-            self._entries.move_to_end(tokens_key)
         if exact_entry is not None and not unusable_non_trimmable_exact:
             entry = exact_entry
             self._entries.move_to_end(tokens_key)

--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -1638,8 +1638,25 @@ class MemoryAwarePrefixCache:
         self, tokens: list[int], tokens_key: tuple[int, ...]
     ) -> tuple[list[Any] | None, list[int]]:
         # --- O(1) exact match ---
-        if tokens_key in self._entries:
-            entry = self._entries[tokens_key]
+        #
+        # The scheduler starts generation by forwarding the final prompt token
+        # once more.  A cache captured at the full N-token boundary therefore
+        # has to be trimmed to N-1 before it can be consumed.  Recurrent and
+        # DeepSeek-V4 pooling caches cannot do that.  Treat their exact entry as
+        # unusable here and continue looking for a strict stored prefix (the
+        # N-1 snapshot or a message boundary); returning the exact entry only
+        # makes the scheduler discard it and full-prefill the request.
+        exact_entry = self._entries.get(tokens_key)
+        unusable_non_trimmable_exact = bool(
+            exact_entry is not None and exact_entry.non_trimmable
+        )
+        if unusable_non_trimmable_exact:
+            # The entry is still live and was requested, so preserve ordinary
+            # LRU recency even though this execution path cannot consume it.
+            # A strict-prefix fallback below records the actual cache hit.
+            self._entries.move_to_end(tokens_key)
+        if exact_entry is not None and not unusable_non_trimmable_exact:
+            entry = exact_entry
             self._entries.move_to_end(tokens_key)
             self._stats.hits += 1
             self._stats.tokens_saved += len(tokens)
@@ -1675,7 +1692,11 @@ class MemoryAwarePrefixCache:
             except Exception as exc:  # pragma: no cover — defensive
                 logger.warning(f"[radix] longest_prefix failed: {exc}")
                 matched_key = None
-            if matched_key is not None and matched_key in self._entries:
+            if (
+                matched_key is not None
+                and matched_key in self._entries
+                and not (unusable_non_trimmable_exact and matched_key == tokens_key)
+            ):
                 # An exact match would have been caught by the O(1) dict
                 # lookup above, so any terminal we find here is strictly
                 # shorter than the query — i.e. a prefix match.
@@ -1721,6 +1742,8 @@ class MemoryAwarePrefixCache:
             for i in range(idx, len(sorted_keys)):
                 cached_key = sorted_keys[i]
                 cached_len = len(cached_key)
+                if unusable_non_trimmable_exact and cached_key == tokens_key:
+                    continue
                 if cached_len < len(tokens_key):
                     continue
                 # Check if tokens_key is a prefix of cached_key

--- a/vllm_mlx/model_auto_config.py
+++ b/vllm_mlx/model_auto_config.py
@@ -86,7 +86,7 @@ _MODEL_PATTERNS: list[tuple[re.Pattern, ModelConfig]] = [
         re.compile(r"deepseek.*v4.*flash.*0731", re.IGNORECASE),
         ModelConfig(
             tool_call_parser="deepseek_v4_0731",
-            reasoning_parser="deepseek_r1",
+            reasoning_parser="deepseek_v4",
             is_hybrid=False,
             supports_spec_decode=False,
         ),
@@ -100,7 +100,7 @@ _MODEL_PATTERNS: list[tuple[re.Pattern, ModelConfig]] = [
         re.compile(r"deepseek.*v4", re.IGNORECASE),
         ModelConfig(
             tool_call_parser="deepseek",
-            reasoning_parser=None,
+            reasoning_parser="deepseek_v4",
         ),
     ),
     # DeepSeek V3.1 (thinking-channel wire shape: NAME<sep>{json}).

--- a/vllm_mlx/reasoning/__init__.py
+++ b/vllm_mlx/reasoning/__init__.py
@@ -84,6 +84,7 @@ def _register_builtin_parsers():
         DeepSeekR1ReasoningParser,
         VibeThinkerReasoningParser,
     )
+    from .deepseek_v4_parser import DeepSeekV4ReasoningParser
     from .gemma4_parser import Gemma4ReasoningParser
     from .glm4_parser import Glm4ReasoningParser
     from .gpt_oss_parser import GptOssReasoningParser
@@ -100,6 +101,7 @@ def _register_builtin_parsers():
     register_parser("hy_v3", Hy3ReasoningParser)
     register_parser("hy3", Hy3ReasoningParser)
     register_parser("deepseek_r1", DeepSeekR1ReasoningParser)
+    register_parser("deepseek_v4", DeepSeekV4ReasoningParser)
     # ``vibethinker`` — DeepSeek-R1 variant with a 1024-char no-tag
     # threshold (vs. 64) to accommodate VibeThinker's preamble-before-
     # ``<think>`` shape. See ``VibeThinkerReasoningParser`` docstring

--- a/vllm_mlx/reasoning/deepseek_v4_parser.py
+++ b/vllm_mlx/reasoning/deepseek_v4_parser.py
@@ -33,7 +33,10 @@ class DeepSeekV4ReasoningParser(ReasoningParser):
         self._buffer = ""
 
     def configure_request(self, *, enable_thinking: bool | None = None) -> None:
-        self.reset_state(start_in_thinking=enable_thinking is True)
+        # DeepSeek V4 emits implicit scratch reasoning without an opening
+        # marker.  Treat an unspecified request like the model's default
+        # thinking mode; only an explicit False starts in visible content.
+        self.reset_state(start_in_thinking=enable_thinking is not False)
 
     @staticmethod
     def _partial_control_suffix(text: str) -> int:
@@ -103,7 +106,7 @@ class DeepSeekV4ReasoningParser(ReasoningParser):
         model_output: str,
         enable_thinking: bool | None = None,
     ) -> tuple[str | None, str | None]:
-        self.reset_state(start_in_thinking=enable_thinking is True)
+        self.reset_state(start_in_thinking=enable_thinking is not False)
         parsed = self._consume(model_output, final=True)
         if parsed is None:
             return None, None

--- a/vllm_mlx/reasoning/deepseek_v4_parser.py
+++ b/vllm_mlx/reasoning/deepseek_v4_parser.py
@@ -27,16 +27,27 @@ class DeepSeekV4ReasoningParser(ReasoningParser):
         super().__init__(tokenizer)
         self.reset_state()
 
-    def reset_state(self, *, start_in_thinking: bool = False):
+    def reset_state(
+        self,
+        *,
+        start_in_thinking: bool = False,
+        thinking_enabled: bool | None = None,
+    ):
         super().reset_state()
         self._in_reasoning = start_in_thinking
+        self._thinking_enabled = (
+            start_in_thinking if thinking_enabled is None else thinking_enabled
+        )
         self._buffer = ""
 
     def configure_request(self, *, enable_thinking: bool | None = None) -> None:
         # DeepSeek V4 emits implicit scratch reasoning without an opening
         # marker.  Treat an unspecified request like the model's default
         # thinking mode; only an explicit False starts in visible content.
-        self.reset_state(start_in_thinking=enable_thinking is not False)
+        self.reset_state(
+            start_in_thinking=enable_thinking is not False,
+            thinking_enabled=enable_thinking is not False,
+        )
 
     @staticmethod
     def _partial_control_suffix(text: str) -> int:
@@ -75,8 +86,11 @@ class DeepSeekV4ReasoningParser(ReasoningParser):
             emit(pending[:index])
             pending = pending[index + len(token) :]
             if token == _THINK_START:
-                # vLLM absorbs duplicate openers while already reasoning.
-                self._in_reasoning = True
+                # With thinking explicitly disabled both markers are only
+                # sanitizers; never create a reasoning channel the request
+                # opted out of. Otherwise absorb duplicate openers while
+                # remaining in reasoning mode.
+                self._in_reasoning = self._thinking_enabled
             elif token == _THINK_END:
                 # vLLM also absorbs a bare closer in CONTENT state.
                 self._in_reasoning = False
@@ -106,7 +120,10 @@ class DeepSeekV4ReasoningParser(ReasoningParser):
         model_output: str,
         enable_thinking: bool | None = None,
     ) -> tuple[str | None, str | None]:
-        self.reset_state(start_in_thinking=enable_thinking is not False)
+        self.reset_state(
+            start_in_thinking=enable_thinking is not False,
+            thinking_enabled=enable_thinking is not False,
+        )
         parsed = self._consume(model_output, final=True)
         if parsed is None:
             return None, None

--- a/vllm_mlx/reasoning/deepseek_v4_parser.py
+++ b/vllm_mlx/reasoning/deepseek_v4_parser.py
@@ -1,0 +1,121 @@
+# SPDX-License-Identifier: Apache-2.0
+"""DeepSeek V4 reasoning parser.
+
+The state transitions mirror the dedicated DeepSeek V4 parsers in vLLM and
+SGLang: a bare ``</think>`` is a control token even when thinking is disabled,
+and a DSML tool-call opener implicitly closes an unfinished reasoning block.
+"""
+
+from __future__ import annotations
+
+from .base import DeltaMessage, ReasoningParser
+
+_THINK_START = "<think>"
+_THINK_END = "</think>"
+_DSML_TOOL_START = "<｜DSML｜tool_calls>"
+_CONTROL_TOKENS = (_THINK_START, _THINK_END, _DSML_TOOL_START)
+
+
+class DeepSeekV4ReasoningParser(ReasoningParser):
+    """Incremental DeepSeek V4 ``<think>``/DSML state machine."""
+
+    # Unlike generic reasoning parsers, this parser must remain active in chat
+    # mode to absorb the protocol's bare ``</think>`` control token.
+    sanitize_when_thinking_disabled = True
+
+    def __init__(self, tokenizer=None):
+        super().__init__(tokenizer)
+        self.reset_state()
+
+    def reset_state(self, *, start_in_thinking: bool = False):
+        super().reset_state()
+        self._in_reasoning = start_in_thinking
+        self._buffer = ""
+
+    def configure_request(self, *, enable_thinking: bool | None = None) -> None:
+        self.reset_state(start_in_thinking=enable_thinking is True)
+
+    @staticmethod
+    def _partial_control_suffix(text: str) -> int:
+        best = 0
+        for token in _CONTROL_TOKENS:
+            for size in range(1, min(len(text), len(token) - 1) + 1):
+                if text.endswith(token[:size]):
+                    best = max(best, size)
+        return best
+
+    def _consume(self, text: str, *, final: bool = False) -> DeltaMessage | None:
+        pending = self._buffer + text
+        self._buffer = ""
+        content: list[str] = []
+        reasoning: list[str] = []
+
+        def emit(value: str) -> None:
+            if not value:
+                return
+            (reasoning if self._in_reasoning else content).append(value)
+
+        while pending:
+            matches = [
+                (idx, token)
+                for token in _CONTROL_TOKENS
+                if (idx := pending.find(token)) >= 0
+            ]
+            if not matches:
+                held = 0 if final else self._partial_control_suffix(pending)
+                emit(pending[:-held] if held else pending)
+                if held:
+                    self._buffer = pending[-held:]
+                break
+
+            index, token = min(matches, key=lambda match: match[0])
+            emit(pending[:index])
+            pending = pending[index + len(token) :]
+            if token == _THINK_START:
+                # vLLM absorbs duplicate openers while already reasoning.
+                self._in_reasoning = True
+            elif token == _THINK_END:
+                # vLLM also absorbs a bare closer in CONTENT state.
+                self._in_reasoning = False
+            else:
+                # A DSML tool call is always outside reasoning. Preserve its
+                # opener for the downstream DeepSeek V4 tool parser.
+                self._in_reasoning = False
+                content.append(token)
+
+        normal = "".join(content) or None
+        thought = "".join(reasoning) or None
+        if normal is None and thought is None:
+            return None
+        return DeltaMessage(content=normal, reasoning=thought)
+
+    def extract_reasoning_streaming(
+        self,
+        previous_text: str,
+        current_text: str,
+        delta_text: str,
+    ) -> DeltaMessage | None:
+        del previous_text, current_text
+        return self._consume(delta_text)
+
+    def extract_reasoning(
+        self,
+        model_output: str,
+        enable_thinking: bool | None = None,
+    ) -> tuple[str | None, str | None]:
+        self.reset_state(start_in_thinking=enable_thinking is True)
+        parsed = self._consume(model_output, final=True)
+        if parsed is None:
+            return None, None
+        return parsed.reasoning, parsed.content
+
+    def finalize_streaming(
+        self,
+        accumulated_text: str,
+        **_kwargs,
+    ) -> DeltaMessage | None:
+        del accumulated_text
+        return self._consume("", final=True)
+
+    def is_open_in_think(self, _accumulated_text: str) -> bool:
+        return self._in_reasoning

--- a/vllm_mlx/reasoning/deepseek_v4_parser.py
+++ b/vllm_mlx/reasoning/deepseek_v4_parser.py
@@ -38,6 +38,7 @@ class DeepSeekV4ReasoningParser(ReasoningParser):
         self._thinking_enabled = (
             start_in_thinking if thinking_enabled is None else thinking_enabled
         )
+        self._suppress_reasoning = False
         self._buffer = ""
 
     def configure_request(self, *, enable_thinking: bool | None = None) -> None:
@@ -65,7 +66,7 @@ class DeepSeekV4ReasoningParser(ReasoningParser):
         reasoning: list[str] = []
 
         def emit(value: str) -> None:
-            if not value:
+            if not value or self._suppress_reasoning:
                 return
             (reasoning if self._in_reasoning else content).append(value)
 
@@ -90,13 +91,16 @@ class DeepSeekV4ReasoningParser(ReasoningParser):
                 # sanitizers; never create a reasoning channel the request
                 # opted out of. Otherwise absorb duplicate openers while
                 # remaining in reasoning mode.
+                self._suppress_reasoning = not self._thinking_enabled
                 self._in_reasoning = self._thinking_enabled
             elif token == _THINK_END:
                 # vLLM also absorbs a bare closer in CONTENT state.
+                self._suppress_reasoning = False
                 self._in_reasoning = False
             else:
                 # A DSML tool call is always outside reasoning. Preserve its
                 # opener for the downstream DeepSeek V4 tool parser.
+                self._suppress_reasoning = False
                 self._in_reasoning = False
                 content.append(token)
 

--- a/vllm_mlx/routes/anthropic.py
+++ b/vllm_mlx/routes/anthropic.py
@@ -1944,7 +1944,11 @@ async def _stream_anthropic_messages(
     # bypass at postprocessor.py:217. The think_router branch below picks
     # up the work, and `_should_start_in_thinking` already returns False
     # for enable_thinking=False, so the answer streams as text.
-    if chat_kwargs.get("enable_thinking") is False:
+    if (
+        chat_kwargs.get("enable_thinking") is False
+        and getattr(reasoning_parser, "sanitize_when_thinking_disabled", False)
+        is not True
+    ):
         reasoning_parser = None
     # Issue #702 codex r2 BLOCKING: when the per-request alias is NOT
     # reasoning-capable, also bypass the parser entirely. Implicit-mode
@@ -1962,7 +1966,11 @@ async def _stream_anthropic_messages(
     if not _reasoning_enabled:
         reasoning_parser = None
     if reasoning_parser:
-        reasoning_parser.reset_state()
+        configure_request = getattr(reasoning_parser, "configure_request", None)
+        if callable(configure_request):
+            configure_request(enable_thinking=chat_kwargs.get("enable_thinking"))
+        else:
+            reasoning_parser.reset_state()
 
     # Per-request reasoning cap (upstream vLLM PR #20859 / #42396 backport).
     # Same chars-÷4 heuristic the OpenAI route uses so the same effective

--- a/vllm_mlx/routes/anthropic.py
+++ b/vllm_mlx/routes/anthropic.py
@@ -55,6 +55,7 @@ from ..service.helpers import (
     _resolve_temperature,
     _resolve_top_p,
     _tool_use_required_named_suffix,
+    _uses_deepseek_v4_reasoning,
     _validate_model_name,
     _validate_tool_call_params,
     _wait_with_disconnect,
@@ -1036,7 +1037,7 @@ async def create_anthropic_message(
             reasoning_text,
             tool_calls,
             finish_reason,
-            include_reasoning_tail=(cfg.reasoning_parser_name != "deepseek_v4"),
+            include_reasoning_tail=not _uses_deepseek_v4_reasoning(cfg),
         )
 
         openai_response = ChatCompletionResponse(

--- a/vllm_mlx/routes/anthropic.py
+++ b/vllm_mlx/routes/anthropic.py
@@ -1036,6 +1036,7 @@ async def create_anthropic_message(
             reasoning_text,
             tool_calls,
             finish_reason,
+            include_reasoning_tail=(cfg.reasoning_parser_name != "deepseek_v4"),
         )
 
         openai_response = ChatCompletionResponse(

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -119,6 +119,23 @@ _SAFE_DEEPSEEK_TOOL_NAME_RE = re.compile(r"^[A-Za-z0-9_-]{1,64}$")
 router = APIRouter()
 
 
+def _uses_deepseek_v4_reasoning(cfg, parser=None) -> bool:
+    """Resolve the active parser across CLI auto-config/runtime forms."""
+    if getattr(cfg, "reasoning_parser_name", None) == "deepseek_v4":
+        return True
+    candidates = (parser, getattr(cfg, "reasoning_parser", None))
+    if any(
+        candidate is not None
+        and candidate.__class__.__name__ == "DeepSeekV4ReasoningParser"
+        for candidate in candidates
+    ):
+        return True
+    model_ref = str(
+        getattr(cfg, "model_path", None) or getattr(cfg, "model_name", None) or ""
+    ).lower()
+    return "deepseek-v4" in model_ref or "deepseek_v4" in model_ref
+
+
 def _degenerate_signal(
     visible_text: str | None, telemetry_enabled: bool
 ) -> bool | None:
@@ -5645,16 +5662,23 @@ async def _create_chat_completion_impl(
         prompt_thinking_active = _should_start_in_thinking(
             _chat_template_str, resolved_thinking
         )
-        final_content = _rescue_silent_drop_from_reasoning(
-            final_content,
-            reasoning_text,
-            tool_calls,
-            finish_reason=finish_reason,
-            raw_text=output.raw_text or output.text,
-            reasoning_is_case4=reasoning_is_case4,
-            matched_stop=getattr(output, "matched_stop", None),
-            prompt_thinking_active=prompt_thinking_active,
+        deepseek_v4_mid_think = bool(
+            _uses_deepseek_v4_reasoning(cfg)
+            and finish_reason == "length"
+            and reasoning_text
+            and not final_content
         )
+        if not deepseek_v4_mid_think:
+            final_content = _rescue_silent_drop_from_reasoning(
+                final_content,
+                reasoning_text,
+                tool_calls,
+                finish_reason=finish_reason,
+                raw_text=output.raw_text or output.text,
+                reasoning_is_case4=reasoning_is_case4,
+                matched_stop=getattr(output, "matched_stop", None),
+                prompt_thinking_active=prompt_thinking_active,
+            )
         # Issue #858: cutoff sentinel is ON by default — restores PR #802
         # (H-01) semantics after the R-01 (#815) opt-in flip produced
         # empty-bubble regressions in every GUI client that only renders
@@ -5669,6 +5693,7 @@ async def _create_chat_completion_impl(
             reasoning_text,
             tool_calls,
             finish_reason,
+            include_reasoning_tail=not _uses_deepseek_v4_reasoning(cfg),
         )
 
     # Build logprobs for response if requested.
@@ -6486,16 +6511,24 @@ async def stream_chat_completion(
                 _effective_matched_stop = stream_matched_stop or getattr(
                     finish_event, "matched_stop", None
                 )
-                rescued_content = _rescue_silent_drop_from_reasoning(
-                    terminal_content or None,
-                    processor.accumulated_reasoning,
-                    None,
-                    finish_reason=finish_event.finish_reason,
-                    raw_text=synthetic_raw,
-                    reasoning_is_case4=reasoning_is_case4_stream,
-                    matched_stop=_effective_matched_stop,
-                    prompt_thinking_active=prompt_thinking_active_stream,
+                deepseek_v4_mid_think_stream = bool(
+                    _uses_deepseek_v4_reasoning(cfg, rp)
+                    and finish_event.finish_reason == "length"
+                    and processor.accumulated_reasoning
+                    and not terminal_content
                 )
+                rescued_content = terminal_content or None
+                if not deepseek_v4_mid_think_stream:
+                    rescued_content = _rescue_silent_drop_from_reasoning(
+                        terminal_content or None,
+                        processor.accumulated_reasoning,
+                        None,
+                        finish_reason=finish_event.finish_reason,
+                        raw_text=synthetic_raw,
+                        reasoning_is_case4=reasoning_is_case4_stream,
+                        matched_stop=_effective_matched_stop,
+                        prompt_thinking_active=prompt_thinking_active_stream,
+                    )
                 # The helper returns the rescued reasoning ONLY when
                 # all four predicates pass (empty/whitespace content,
                 # no tool calls, non-empty/non-whitespace reasoning).
@@ -6533,6 +6566,9 @@ async def stream_chat_completion(
                     processor.accumulated_reasoning,
                     None,
                     finish_event.finish_reason,
+                    include_reasoning_tail=not _uses_deepseek_v4_reasoning(
+                        cfg, processor.reasoning_parser
+                    ),
                 )
                 if cutoff_content and cutoff_content != (terminal_content or None):
                     terminal_content = cutoff_content

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -98,6 +98,7 @@ from ..service.helpers import (
     _scan_messages_for_lone_surrogates,
     _should_start_in_thinking,
     _tool_use_required_named_suffix,
+    _uses_deepseek_v4_reasoning,
     _validate_model_name,
     _validate_response_format,
     _validate_tool_call_params,
@@ -117,23 +118,6 @@ logger = logging.getLogger(__name__)
 _SAFE_DEEPSEEK_TOOL_NAME_RE = re.compile(r"^[A-Za-z0-9_-]{1,64}$")
 
 router = APIRouter()
-
-
-def _uses_deepseek_v4_reasoning(cfg, parser=None) -> bool:
-    """Resolve the active parser across CLI auto-config/runtime forms."""
-    if getattr(cfg, "reasoning_parser_name", None) == "deepseek_v4":
-        return True
-    candidates = (parser, getattr(cfg, "reasoning_parser", None))
-    if any(
-        candidate is not None
-        and candidate.__class__.__name__ == "DeepSeekV4ReasoningParser"
-        for candidate in candidates
-    ):
-        return True
-    model_ref = str(
-        getattr(cfg, "model_path", None) or getattr(cfg, "model_name", None) or ""
-    ).lower()
-    return "deepseek-v4" in model_ref or "deepseek_v4" in model_ref
 
 
 def _degenerate_signal(

--- a/vllm_mlx/routes/responses.py
+++ b/vllm_mlx/routes/responses.py
@@ -1509,6 +1509,7 @@ async def _non_stream(
         reasoning_text,
         tool_calls,
         finish_reason,
+        include_reasoning_tail=(cfg.reasoning_parser_name != "deepseek_v4"),
     )
 
     openai_response = ChatCompletionResponse(
@@ -3214,6 +3215,7 @@ async def _stream_responses(
                 reasoning_text=accumulated_reasoning_text,
                 tool_calls=None,
                 finish_reason=last_finish_reason,
+                include_reasoning_tail=(cfg.reasoning_parser_name != "deepseek_v4"),
             )
             if rescue_text:
                 rescue_output_index = len(completed_output)

--- a/vllm_mlx/routes/responses.py
+++ b/vllm_mlx/routes/responses.py
@@ -1955,10 +1955,18 @@ async def _stream_responses(
                 reasoning_parser = get_parser(cfg.reasoning_parser_name)()
             except Exception:
                 pass
-        if chat_kwargs.get("enable_thinking") is False:
+        if (
+            chat_kwargs.get("enable_thinking") is False
+            and getattr(reasoning_parser, "sanitize_when_thinking_disabled", False)
+            is not True
+        ):
             reasoning_parser = None
         if reasoning_parser:
-            reasoning_parser.reset_state()
+            configure_request = getattr(reasoning_parser, "configure_request", None)
+            if callable(configure_request):
+                configure_request(enable_thinking=chat_kwargs.get("enable_thinking"))
+            else:
+                reasoning_parser.reset_state()
 
         # Per-request reasoning cap (upstream vLLM PR #20859 backport).
         # Responses SSE drops reasoning to the floor (Codex doesn't read

--- a/vllm_mlx/routes/responses.py
+++ b/vllm_mlx/routes/responses.py
@@ -94,6 +94,7 @@ from ..service.helpers import (
     _resolve_max_tokens,
     _resolve_temperature,
     _resolve_top_p,
+    _uses_deepseek_v4_reasoning,
     _validate_model_name,
     _wait_with_disconnect,
     build_extended_sampling_kwargs,
@@ -1509,7 +1510,7 @@ async def _non_stream(
         reasoning_text,
         tool_calls,
         finish_reason,
-        include_reasoning_tail=(cfg.reasoning_parser_name != "deepseek_v4"),
+        include_reasoning_tail=not _uses_deepseek_v4_reasoning(cfg),
     )
 
     openai_response = ChatCompletionResponse(
@@ -3215,7 +3216,7 @@ async def _stream_responses(
                 reasoning_text=accumulated_reasoning_text,
                 tool_calls=None,
                 finish_reason=last_finish_reason,
-                include_reasoning_tail=(cfg.reasoning_parser_name != "deepseek_v4"),
+                include_reasoning_tail=not _uses_deepseek_v4_reasoning(cfg),
             )
             if rescue_text:
                 rescue_output_index = len(completed_output)

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -1288,6 +1288,23 @@ def _apply_reasoning_cutoff_notice(
     return _build_reasoning_rescue_payload(reasoning_text)
 
 
+def _uses_deepseek_v4_reasoning(cfg, parser=None) -> bool:
+    """Resolve DeepSeek V4 across explicit, auto-config, and runtime forms."""
+    if getattr(cfg, "reasoning_parser_name", None) == "deepseek_v4":
+        return True
+    candidates = (parser, getattr(cfg, "reasoning_parser", None))
+    if any(
+        candidate is not None
+        and candidate.__class__.__name__ == "DeepSeekV4ReasoningParser"
+        for candidate in candidates
+    ):
+        return True
+    model_ref = str(
+        getattr(cfg, "model_path", None) or getattr(cfg, "model_name", None) or ""
+    ).lower()
+    return "deepseek-v4" in model_ref or "deepseek_v4" in model_ref
+
+
 # OpenAI-spec closed enum for ``response_format.type``. Any value outside
 # this set used to be silently accepted (defaulted to "text" by
 # ``build_json_system_prompt``) so a client typo like ``"xml"`` or an

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -1211,6 +1211,8 @@ def _apply_reasoning_cutoff_notice(
     reasoning_text: str | None,
     tool_calls: list | None,
     finish_reason: str | None,
+    *,
+    include_reasoning_tail: bool = True,
 ) -> str | None:
     """R12-8 / H-01: rescue ``content`` when generation was cut short
     mid-think and the strict rescue path left it empty.
@@ -1281,6 +1283,8 @@ def _apply_reasoning_cutoff_notice(
         return final_content
     if not reasoning_text or not reasoning_text.strip():
         return final_content
+    if not include_reasoning_tail:
+        return REASONING_CUTOFF_SENTINEL
     return _build_reasoning_rescue_payload(reasoning_text)
 
 

--- a/vllm_mlx/service/postprocessor.py
+++ b/vllm_mlx/service/postprocessor.py
@@ -310,6 +310,12 @@ class StreamingPostProcessor:
         # ``enable_thinking`` via the non-streaming ``extract_reasoning``
         # kwarg path or via their own template-driven branching.
         if self.reasoning_parser is not None:
+            _configure = getattr(self.reasoning_parser, "configure_request", None)
+            if callable(_configure):
+                try:
+                    _configure(enable_thinking=enable_thinking)
+                except Exception:
+                    pass
             _set = getattr(self.reasoning_parser, "set_enable_thinking", None)
             if callable(_set):
                 try:
@@ -1460,6 +1466,15 @@ class StreamingPostProcessor:
         """
         if self.enable_thinking is not False:
             return True
+        # DeepSeek V4's protocol permits a bare ``</think>`` while already
+        # in CONTENT state.  Its dedicated parser therefore remains on even
+        # when thinking was disabled, matching vLLM's CONTENT/THINK_END
+        # transition (absorb marker, stay in CONTENT).
+        if (
+            getattr(self.reasoning_parser, "sanitize_when_thinking_disabled", False)
+            is True
+        ):
+            return True
         if self._explicit_think_seen:
             return True
         # R10-C7 (2026-06-23): if ``_process_standard`` has already
@@ -2351,7 +2366,11 @@ class StreamingPostProcessor:
         self._standard_content_observed = False
 
         if self.reasoning_parser:
-            self.reasoning_parser.reset_state()
+            _configure = getattr(self.reasoning_parser, "configure_request", None)
+            if callable(_configure):
+                _configure(enable_thinking=self.enable_thinking)
+            else:
+                self.reasoning_parser.reset_state()
             # R10-M1: ``reset_state`` clears the parser's per-request
             # ``enable_thinking`` override; re-propagate the dispatcher's
             # captured value so a re-used processor continues to honour

--- a/vllm_mlx/service/postprocessor.py
+++ b/vllm_mlx/service/postprocessor.py
@@ -312,10 +312,10 @@ class StreamingPostProcessor:
         if self.reasoning_parser is not None:
             _configure = getattr(self.reasoning_parser, "configure_request", None)
             if callable(_configure):
-                try:
-                    _configure(enable_thinking=enable_thinking)
-                except Exception:
-                    pass
+                # Request-aware parser configuration is a safety boundary:
+                # continuing after failure can route implicit scratch text to
+                # content using the parser's constructor defaults.
+                _configure(enable_thinking=enable_thinking)
             _set = getattr(self.reasoning_parser, "set_enable_thinking", None)
             if callable(_set):
                 try:


### PR DESCRIPTION
## What does this PR do?

- Adds a protocol-aware DeepSeek V4 reasoning parser and wires request-aware parsing through Chat, Anthropic, and Responses paths.
- Makes exact non-trimmable prefix-cache hits fall back to the longest usable strict prefix instead of silently full-prefilling.
- Adds regressions for streamed internal reasoning containment and exact-prompt cache reuse.

## Why is this needed?

DeepSeek-V4-Flash-0731 with DSpark decoded at ~25 tok/s, but an exact repeated 8,131-token prompt still took ~24.6s TTFT because the unusable full-length cache snapshot masked an 8,113-token message-boundary snapshot. The generic DeepSeek-R1 reasoning parser also emitted part of DeepSeek V4 internal scratch reasoning as user-visible content.

With this change, the same real local MXFP4 model and prompt improved from 25.830s cold / 24.6s baseline warm TTFT to 0.318s warm TTFT (81.23x versus cold) while preserving byte-identical output. Decode remained 25.81-26.11 tok/s. An explicit-thinking stream produced 322 reasoning characters in the reasoning channel, clean final content, and no literal `<think>` or `</think>` leakage in raw SSE, reasoning, or content.

## AI assistance disclosure

Codex reviewed the existing unpublished DeepSeek/DSpark work, compared the behavior with upstream vLLM and SGLang implementations, wrote/reworked the parser, cache fix, and regression tests across the files in this PR, and ran the validations below. Every diff was manually scoped and reviewed; unrelated local files were excluded.

> By submitting this PR I confirm I can explain the intent, risk, and behavior of every non-generated change in this PR. For any generated / boilerplate / scaffolded sections, I have identified them above and can describe how I verified them.

## Test plan

- `python -m pytest -q` — 15,061 passed; 13 environment/baseline failures: 12 connection-refused tests requiring local API servers, plus one pre-existing release-check banner assertion.
- Full suite excluding those three unrelated groups — 15,057 passed, 122 skipped, 18 deselected, 6 xfailed, 1 xpassed.
- 3,229 targeted parser/cache/route/config tests passed on the clean PR branch.
- `ruff check` and `ruff format --check` passed.
- Built and installed a local 0.11.5 wheel, confirmed imports came from site-packages, and served `/Volumes/RTL-2T/models/DeepSeek-V4-Flash-0731-MXFP4-MLX` with DSpark K=5.
- Real-model exact-repeat benchmark: 8,131 prompt tokens, 124 completion tokens; cold TTFT 25.830s, warm TTFT 0.318s, decode 25.81-26.11 tok/s, byte-identical output.
- Real-model explicit-thinking benchmark: TTFT 0.247s, 29.43 tok/s, reasoning isolated from final content, no think-tag leakage.

## Checklist

- [x] Tests pass locally (`python3 -m pytest tests/ -x`)
- [x] Lint passes (`ruff check && ruff format --check`)
- [x] Self-validated with `python3 -m scripts.pr_validate.pr_validate <PR#>`
- [x] Critical parser/cache regressions were spot-checked against the observed failures
- [x] README/docs not applicable
- [x] No breaking changes to existing API