### PR TITLE
fix(embeddings): configurable max input length, never truncate silently (#1381)

### DIFF
--- a/tests/test_cli_embeddings_extra.py
+++ b/tests/test_cli_embeddings_extra.py
@@ -78,9 +78,11 @@ def test_load_embedding_helper_proceeds_when_extra_installed(monkeypatch):
     helper reaches the loader (the success-path smoke check).
 
     Pin the call shape too: ``load_fn`` is invoked with the resolved
-    embedding-model name as a positional arg and ``lock=True`` kw —
-    the boot path always locks the engine so the H-09 route guard
-    has a non-None ``embedding_model_locked`` to consult.
+    embedding-model name as a positional arg, ``lock=True``, and the
+    embedding input-length settings (issue #1381) — which default to
+    ``max_length="auto"`` / ``overflow_policy="truncate"`` when the CLI
+    flags are omitted. The boot path always locks the engine so the H-09
+    route guard has a non-None ``embedding_model_locked`` to consult.
     """
     from vllm_mlx.cli import _load_embedding_model_or_exit
 
@@ -88,9 +90,11 @@ def test_load_embedding_helper_proceeds_when_extra_installed(monkeypatch):
 
     captured: dict = {}
 
-    def _fake_loader(name, *, lock):
+    def _fake_loader(name, *, lock, max_length="auto", overflow_policy="truncate"):
         captured["name"] = name
         captured["lock"] = lock
+        captured["max_length"] = max_length
+        captured["overflow_policy"] = overflow_policy
 
     args = SimpleNamespace(embedding_model="mlx-community/some-embed-model")
     _load_embedding_model_or_exit(args, _fake_loader)
@@ -98,6 +102,8 @@ def test_load_embedding_helper_proceeds_when_extra_installed(monkeypatch):
     assert captured == {
         "name": "mlx-community/some-embed-model",
         "lock": True,
+        "max_length": "auto",
+        "overflow_policy": "truncate",
     }
 
 

--- a/tests/test_embedding_max_length.py
+++ b/tests/test_embedding_max_length.py
@@ -1,0 +1,254 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for configurable embedding max input length (issue #1381).
+
+These exercise the pure resolution / overflow logic with a mocked model and
+tokenizer, so they need no ``mlx_embeddings`` model download and never touch
+the GPU. The acceptance matrix from the issue is covered: Qwen3-Embedding at
+32K, BERT at 512, explicit lower overrides, over-model values, both overflow
+policies, and mixed-length batches.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from vllm_mlx.embedding import (
+    _FALLBACK_MAX_LENGTH,
+    _MODEL_MAX_SENTINEL_THRESHOLD,
+    EmbeddingEngine,
+    EmbeddingInputTooLongError,
+    normalize_max_length_setting,
+)
+
+# HuggingFace's "unset" sentinel for tokenizer.model_max_length.
+_HF_SENTINEL = 1_000_000_000_000_000_019_884_624_838_656
+
+
+class _FakeConfig:
+    def __init__(self, **attrs):
+        for key, value in attrs.items():
+            setattr(self, key, value)
+
+
+class _FakeModel:
+    def __init__(self, config=None):
+        if config is not None:
+            self.config = config
+
+
+class _FakeTokenizer:
+    """Minimal tokenizer stand-in: one token per whitespace-delimited word."""
+
+    def __init__(self, model_max_length=None):
+        if model_max_length is not None:
+            self.model_max_length = model_max_length
+
+    def encode(self, text):
+        return text.split()
+
+
+def make_engine(
+    *,
+    model_max=None,
+    tok_max=None,
+    max_length="auto",
+    overflow_policy="truncate",
+    resolve=True,
+):
+    eng = EmbeddingEngine(
+        "fake-model", max_length=max_length, overflow_policy=overflow_policy
+    )
+    config = _FakeConfig(
+        **({"max_position_embeddings": model_max} if model_max is not None else {})
+    )
+    eng._model = _FakeModel(config=config)
+    eng._tokenizer = _FakeTokenizer(model_max_length=tok_max)
+    if resolve:
+        eng._resolve_effective_max_length()
+    return eng
+
+
+# --------------------------------------------------------------------------
+# normalize_max_length_setting
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("auto", "auto"),
+        ("AUTO", "auto"),
+        ("  auto ", "auto"),
+        ("1024", 1024),
+        (4096, 4096),
+        (1, 1),
+    ],
+)
+def test_normalize_valid(value, expected):
+    assert normalize_max_length_setting(value) == expected
+
+
+@pytest.mark.parametrize("value", ["0", "-5", "foo", "", 0, -1, True, False, 3.5])
+def test_normalize_invalid(value):
+    with pytest.raises(ValueError):
+        normalize_max_length_setting(value)
+
+
+def test_bad_overflow_policy_rejected():
+    with pytest.raises(ValueError):
+        EmbeddingEngine("m", overflow_policy="nope")
+
+
+def test_bad_max_length_rejected_at_construction():
+    with pytest.raises(ValueError):
+        EmbeddingEngine("m", max_length="not-a-number")
+
+
+# --------------------------------------------------------------------------
+# _discover_model_max_length + effective length resolution
+# --------------------------------------------------------------------------
+
+
+def test_discover_from_model_config():
+    eng = make_engine(model_max=32768, resolve=False)
+    assert eng._discover_model_max_length() == 32768
+
+
+def test_discover_from_tokenizer_when_no_config():
+    eng = make_engine(model_max=None, tok_max=512, resolve=False)
+    assert eng._discover_model_max_length() == 512
+
+
+def test_discover_ignores_hf_sentinel_on_tokenizer():
+    eng = make_engine(model_max=None, tok_max=_HF_SENTINEL, resolve=False)
+    assert eng._discover_model_max_length() is None
+    assert _HF_SENTINEL >= _MODEL_MAX_SENTINEL_THRESHOLD
+
+
+def test_discover_ignores_sentinel_on_config_falls_back_to_tokenizer():
+    eng = make_engine(model_max=_HF_SENTINEL, tok_max=512, resolve=False)
+    assert eng._discover_model_max_length() == 512
+
+
+def test_discover_none_when_nothing_declared():
+    eng = make_engine(model_max=None, tok_max=None, resolve=False)
+    assert eng._discover_model_max_length() is None
+
+
+def test_auto_uses_model_max():
+    # Qwen3-Embedding-4B: 32K context.
+    eng = make_engine(model_max=32768, max_length="auto")
+    assert eng.effective_max_length == 32768
+
+
+def test_auto_falls_back_when_unknown():
+    eng = make_engine(model_max=None, tok_max=None, max_length="auto")
+    assert eng.effective_max_length == _FALLBACK_MAX_LENGTH
+
+
+def test_bert_at_512():
+    eng = make_engine(model_max=512, max_length="auto")
+    assert eng.effective_max_length == 512
+
+
+def test_explicit_override_below_model_max():
+    eng = make_engine(model_max=32768, max_length=1024)
+    assert eng.effective_max_length == 1024
+
+
+def test_explicit_override_above_model_max_is_clamped(caplog):
+    with caplog.at_level(logging.WARNING):
+        eng = make_engine(model_max=32768, max_length=99999)
+    assert eng.effective_max_length == 32768
+    assert "clamping" in caplog.text.lower()
+
+
+def test_explicit_override_when_model_max_unknown():
+    eng = make_engine(model_max=None, tok_max=None, max_length=4096)
+    assert eng.effective_max_length == 4096
+
+
+# --------------------------------------------------------------------------
+# overflow policy
+# --------------------------------------------------------------------------
+
+
+def test_truncate_policy_warns_and_counts(caplog):
+    eng = make_engine(model_max=512, overflow_policy="truncate")
+    with caplog.at_level(logging.WARNING):
+        eng._enforce_overflow([600, 100])  # one over the 512 limit
+    assert eng.num_truncations == 1
+    assert "truncat" in caplog.text.lower()
+
+
+def test_truncate_policy_counts_each_over_input():
+    eng = make_engine(model_max=512, overflow_policy="truncate")
+    eng._enforce_overflow([600, 700, 100])  # two over
+    assert eng.num_truncations == 2
+
+
+def test_truncate_policy_no_overflow_is_silent(caplog):
+    eng = make_engine(model_max=512, overflow_policy="truncate")
+    with caplog.at_level(logging.WARNING):
+        eng._enforce_overflow([100, 200, 511, 512])
+    assert eng.num_truncations == 0
+    assert caplog.text == ""
+
+
+def test_error_policy_raises_with_counts():
+    eng = make_engine(model_max=512, overflow_policy="error")
+    with pytest.raises(EmbeddingInputTooLongError) as exc_info:
+        eng._enforce_overflow([100, 600, 900])
+    err = exc_info.value
+    assert err.observed_tokens == 600  # first over-limit input
+    assert err.allowed_tokens == 512
+    assert err.index == 1
+    assert eng.num_truncations == 0  # error policy never truncates
+
+
+def test_error_policy_passes_when_within_limit():
+    eng = make_engine(model_max=512, overflow_policy="error")
+    eng._enforce_overflow([100, 512])  # 512 == limit, not over
+    assert eng.num_truncations == 0
+
+
+# --------------------------------------------------------------------------
+# count_tokens is capped at the effective limit (usage no longer over-reports)
+# --------------------------------------------------------------------------
+
+
+def test_count_tokens_capped_at_effective_limit():
+    eng = make_engine(model_max=512, max_length="auto")
+    long_text = " ".join(["tok"] * 600)  # 600 "tokens"
+    # Capped at 512, not the pre-truncation 600.
+    assert eng.count_tokens([long_text]) == 512
+
+
+def test_count_tokens_sums_capped_per_input():
+    eng = make_engine(model_max=512, max_length="auto")
+    texts = [" ".join(["a"] * 600), "short one here"]
+    assert eng.count_tokens(texts) == 512 + 3
+
+
+def test_count_tokens_uncapped_within_limit():
+    eng = make_engine(model_max=32768, max_length="auto")
+    assert eng.count_tokens(["one two three four"]) == 4
+
+
+# --------------------------------------------------------------------------
+# acceptance scenarios straight from the issue
+# --------------------------------------------------------------------------
+
+
+def test_qwen3_embedding_32k_long_input_not_truncated():
+    eng = make_engine(model_max=32768, max_length="auto", overflow_policy="truncate")
+    eng._enforce_overflow([1000, 4096, 8192])  # all < 32768
+    assert eng.num_truncations == 0
+
+
+def test_mixed_length_batch_only_over_limit_counted():
+    eng = make_engine(model_max=512, max_length="auto", overflow_policy="truncate")
+    eng._enforce_overflow([100, 600])  # one within, one over
+    assert eng.num_truncations == 1

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -870,9 +870,27 @@ def _load_embedding_model_or_exit(args, load_fn) -> None:
     # safetensors mid-load, Metal OOM, schema mismatch) surface with
     # their real trace — pr_validate codex r1 NIT closure (the prior
     # ``"not found"`` substring match was too loose).
+    # Validate the embedding input-length setting up front so a bad value
+    # is a clean usage error (exit 2), not a mid-load crash (issue #1381).
+    from .embedding import normalize_max_length_setting
+
+    try:
+        max_length = normalize_max_length_setting(
+            getattr(args, "embedding_max_length", "auto")
+        )
+    except ValueError as exc:
+        print(f"error: --embedding-max-length {exc}", file=sys.stderr)
+        sys.exit(2)
+    overflow_policy = getattr(args, "embedding_overflow_policy", "truncate")
+
     not_found_exc_classes = _embedding_not_found_exception_classes()
     try:
-        load_fn(args.embedding_model, lock=True)
+        load_fn(
+            args.embedding_model,
+            lock=True,
+            max_length=max_length,
+            overflow_policy=overflow_policy,
+        )
     except not_found_exc_classes as exc:
         print(
             f"\n  Error: --embedding-model '{original_embed}' could not "
@@ -8126,6 +8144,37 @@ Examples:
             "Pre-load an embedding model at startup (e.g. "
             "mlx-community/embeddinggemma-300m-6bit). Requires the "
             "[embeddings] extra: pip install 'rapid-mlx[embeddings]'."
+        ),
+    )
+    # Embedding input-length controls (issue #1381). Prevents silent
+    # 512-token truncation: derive a model-aware limit and make overflow
+    # observable / configurable.
+    serve_parser.add_argument(
+        "--embedding-max-length",
+        type=str,
+        default="auto",
+        metavar="TOKENS",
+        help=(
+            "Max input length (tokens) for --embedding-model. 'auto' "
+            "(default) derives it from the model's declared maximum "
+            "(config.max_position_embeddings, else tokenizer.model_max_length); "
+            "or pass a positive integer to set a lower operational ceiling. "
+            "Inputs above the effective limit are handled per "
+            "--embedding-overflow-policy (never truncated silently)."
+        ),
+    )
+    serve_parser.add_argument(
+        "--embedding-overflow-policy",
+        type=str,
+        choices=["truncate", "error"],
+        default="truncate",
+        help=(
+            "How to handle embedding inputs longer than "
+            "--embedding-max-length: 'truncate' (default) discards the tail "
+            "but logs a warning and increments the "
+            "rapid_mlx_embedding_truncations_total metric (never silent); "
+            "'error' rejects the request with a 400 carrying the observed "
+            "and allowed token counts."
         ),
     )
     # Parent-PID watchdog (rapid-desktop issue #449). When set, the

--- a/vllm_mlx/embedding.py
+++ b/vllm_mlx/embedding.py
@@ -19,6 +19,40 @@ logger = logging.getLogger(__name__)
 # the same actionable line no matter which surface tripped the guard.
 EMBEDDINGS_EXTRA_INSTALL_HINT = "Install with: pip install 'rapid-mlx[embeddings]'"
 
+# HuggingFace stamps ``tokenizer.model_max_length`` with a huge sentinel
+# (``VERY_LARGE_INTEGER`` ≈ 1e30) when the tokenizer config declares no real
+# limit. Any "maximum" at or above this threshold is treated as *unset*
+# rather than as a genuine multi-quadrillion-token context (issue #1381).
+_MODEL_MAX_SENTINEL_THRESHOLD = 1_000_000
+# Conservative fallback when neither the model config nor the tokenizer
+# declares a usable maximum. Matches the historical hardcoded ceiling, so a
+# model with no discoverable limit keeps its prior behavior — except the
+# truncation is now surfaced (warning + metric) instead of silent.
+_FALLBACK_MAX_LENGTH = 512
+
+# Operator-facing overflow policies for inputs longer than the effective
+# max input length.
+OVERFLOW_POLICIES = ("truncate", "error")
+
+
+class EmbeddingInputTooLongError(Exception):
+    """Raised under the ``error`` overflow policy when an embedding input
+    exceeds the effective max input length.
+
+    The ``/v1/embeddings`` route maps this to a structured 4xx carrying the
+    observed and allowed token counts so the caller can react precisely
+    instead of silently indexing a truncated vector (issue #1381).
+    """
+
+    def __init__(self, *, observed_tokens: int, allowed_tokens: int, index: int):
+        self.observed_tokens = observed_tokens
+        self.allowed_tokens = allowed_tokens
+        self.index = index
+        super().__init__(
+            f"input {index} has {observed_tokens} tokens, which exceeds the "
+            f"configured embedding max input length of {allowed_tokens}"
+        )
+
 
 def mlx_embeddings_available() -> bool:
     """Probe whether ``mlx_embeddings`` is importable.
@@ -69,18 +103,73 @@ def require_mlx_embeddings_or_exit() -> None:
     sys.exit(2)
 
 
+def normalize_max_length_setting(max_length: int | str) -> int | str:
+    """Validate an operator ``--embedding-max-length`` value.
+
+    Accepts the literal ``"auto"`` (case-insensitive) or a positive
+    integer (int, or its string form). Returns ``"auto"`` or an ``int``.
+    Raises ``ValueError`` otherwise.
+    """
+    if isinstance(max_length, bool):
+        raise ValueError(
+            "embedding max_length must be 'auto' or a positive integer, "
+            f"got {max_length!r}"
+        )
+    if isinstance(max_length, str):
+        if max_length.strip().lower() == "auto":
+            return "auto"
+        try:
+            max_length = int(max_length)
+        except ValueError:
+            raise ValueError(
+                "embedding max_length must be 'auto' or a positive integer, "
+                f"got {max_length!r}"
+            ) from None
+    if not isinstance(max_length, int):
+        raise ValueError(
+            "embedding max_length must be 'auto' or a positive integer, "
+            f"got {max_length!r}"
+        )
+    if max_length < 1:
+        raise ValueError(f"embedding max_length must be >= 1, got {max_length}")
+    return max_length
+
+
 class EmbeddingEngine:
     """
     Wrapper around mlx-embeddings for text embedding generation.
 
     Supports lazy model loading and batch embedding with proper
-    tokenization and pooling.
+    tokenization and pooling. The effective max input length is resolved
+    against the loaded model (issue #1381): inputs longer than the limit
+    are never truncated silently — under the ``truncate`` policy they emit
+    a warning and bump a metric, and under ``error`` they raise
+    :class:`EmbeddingInputTooLongError`.
     """
 
-    def __init__(self, model_name: str):
+    def __init__(
+        self,
+        model_name: str,
+        *,
+        max_length: int | str = "auto",
+        overflow_policy: str = "truncate",
+    ):
         self.model_name = model_name
         self._model = None
         self._tokenizer = None
+        if overflow_policy not in OVERFLOW_POLICIES:
+            raise ValueError(
+                f"overflow_policy must be one of {OVERFLOW_POLICIES}, "
+                f"got {overflow_policy!r}"
+            )
+        self._max_length_setting = normalize_max_length_setting(max_length)
+        self.overflow_policy = overflow_policy
+        # Resolved against the loaded model in ``load()``.
+        self.effective_max_length: int | None = None
+        # Observable, non-silent signal (issue #1381): number of inputs
+        # whose tail was discarded under the ``truncate`` policy. Exposed
+        # on ``/metrics`` as ``rapid_mlx_embedding_truncations_total``.
+        self.num_truncations = 0
 
     @property
     def is_loaded(self) -> bool:
@@ -95,10 +184,104 @@ class EmbeddingEngine:
         self._model, self._tokenizer = load(self.model_name)
         elapsed = time.perf_counter() - start
         logger.info(f"Embedding model loaded in {elapsed:.2f}s: {self.model_name}")
+        self._resolve_effective_max_length()
 
     def _ensure_loaded(self) -> None:
         if not self.is_loaded:
             self.load()
+
+    def _discover_model_max_length(self) -> int | None:
+        """Best-effort model-declared max input length, or ``None``.
+
+        Prefers the model's ``config.max_position_embeddings`` (the
+        authoritative positional-embedding ceiling), then a couple of
+        common aliases, then ``tokenizer.model_max_length`` — guarding
+        HuggingFace's large "unset" sentinel so it reads as unknown rather
+        than a real limit.
+        """
+        model_cfg = getattr(self._model, "config", None)
+        if model_cfg is None:
+            model_cfg = getattr(self._model, "args", None)
+        if model_cfg is not None:
+            for attr in ("max_position_embeddings", "max_seq_len", "n_positions"):
+                val = getattr(model_cfg, attr, None)
+                if (
+                    isinstance(val, int)
+                    and not isinstance(val, bool)
+                    and 0 < val < _MODEL_MAX_SENTINEL_THRESHOLD
+                ):
+                    return val
+        inner_tok = getattr(self._tokenizer, "_tokenizer", self._tokenizer)
+        tok_max = getattr(inner_tok, "model_max_length", None)
+        if (
+            isinstance(tok_max, int)
+            and not isinstance(tok_max, bool)
+            and 0 < tok_max < _MODEL_MAX_SENTINEL_THRESHOLD
+        ):
+            return tok_max
+        return None
+
+    def _resolve_effective_max_length(self) -> None:
+        """Resolve ``effective_max_length`` from the operator setting and
+        the loaded model's declared maximum."""
+        model_max = self._discover_model_max_length()
+        setting = self._max_length_setting
+        if setting == "auto":
+            self.effective_max_length = model_max or _FALLBACK_MAX_LENGTH
+            source = "model" if model_max else "fallback"
+        else:
+            requested = int(setting)
+            if model_max is not None and requested > model_max:
+                logger.warning(
+                    "Requested --embedding-max-length=%d exceeds the model's "
+                    "declared maximum of %d; clamping to %d.",
+                    requested,
+                    model_max,
+                    model_max,
+                )
+                self.effective_max_length = model_max
+            else:
+                self.effective_max_length = requested
+            source = "operator"
+        logger.info(
+            "Embedding effective max input length: %d tokens "
+            "(source=%s, overflow_policy=%s)",
+            self.effective_max_length,
+            source,
+            self.overflow_policy,
+        )
+
+    def _enforce_overflow(self, lengths: list[int]) -> None:
+        """Apply the overflow policy to per-input true token ``lengths``.
+
+        Under ``error`` raise :class:`EmbeddingInputTooLongError` on the first
+        over-limit input. Under ``truncate`` emit a warning and bump the
+        ``num_truncations`` metric so the discarded tail is never silent
+        (issue #1381). No-op when nothing exceeds the limit.
+        """
+        limit = self.effective_max_length
+        if not limit:
+            return
+        over = [(i, n) for i, n in enumerate(lengths) if n > limit]
+        if not over:
+            return
+        if self.overflow_policy == "error":
+            idx, observed = over[0]
+            raise EmbeddingInputTooLongError(
+                observed_tokens=observed, allowed_tokens=limit, index=idx
+            )
+        self.num_truncations += len(over)
+        worst = max(n for _, n in over)
+        logger.warning(
+            "Embedding truncation: %d of %d input(s) exceeded the %d-token "
+            "limit (largest=%d tokens); the tail was discarded. Raise "
+            "--embedding-max-length or set --embedding-overflow-policy error "
+            "to reject over-limit inputs instead.",
+            len(over),
+            len(lengths),
+            limit,
+            worst,
+        )
 
     def embed(self, texts: str | list[str]) -> list[list[float]]:
         """
@@ -109,6 +292,10 @@ class EmbeddingEngine:
 
         Returns:
             List of embedding vectors (one per input text).
+
+        Raises:
+            EmbeddingInputTooLongError: under the ``error`` overflow policy when
+                an input exceeds ``effective_max_length``.
         """
         self._ensure_loaded()
 
@@ -120,11 +307,21 @@ class EmbeddingEngine:
         # GemmaTokenizer lacks batch_encode_plus, and the model's __call__
         # expects positional `inputs` not `input_ids` as a kwarg).
         inner_tok = getattr(self._tokenizer, "_tokenizer", self._tokenizer)
+
+        # Measure true (un-truncated) lengths first so overflow is
+        # observable and the resolved effective limit — not a hardcoded
+        # 512 — governs truncation (issue #1381).
+        measured = inner_tok(texts, truncation=False, padding=False)
+        lengths = [len(ids) for ids in measured["input_ids"]]
+        self._enforce_overflow(lengths)
+
+        # Let the tokenizer perform the (special-token-aware) truncation and
+        # padding for the actual forward pass.
         encoded = inner_tok(
             texts,
             padding=True,
             truncation=True,
-            max_length=512,
+            max_length=self.effective_max_length,
             return_tensors="np",
         )
 
@@ -153,16 +350,25 @@ class EmbeddingEngine:
 
         Returns:
             List of embedding vectors (one per input).
+
+        Raises:
+            EmbeddingInputTooLongError: under the ``error`` overflow policy when
+                an input exceeds ``effective_max_length``.
         """
         self._ensure_loaded()
 
         if not token_batches:
             return []
 
+        lengths = [len(ids) for ids in token_batches]
+        self._enforce_overflow(lengths)
+
         # Pad each sequence to the longest in the batch, capped at the
-        # same 512 ceiling as the str path so client-controlled
-        # ``input`` cannot allocate unbounded memory.
-        max_len = min(max(len(ids) for ids in token_batches), 512)
+        # resolved effective limit (issue #1381) — the same ceiling the str
+        # path uses — so client-controlled ``input`` cannot allocate
+        # unbounded memory.
+        limit = self.effective_max_length or _FALLBACK_MAX_LENGTH
+        max_len = min(max(lengths), limit)
         pad_id = (
             getattr(self._tokenizer, "pad_token_id", None)
             or getattr(
@@ -189,21 +395,28 @@ class EmbeddingEngine:
         return embeds.tolist()
 
     def count_tokens(self, texts: str | list[str]) -> int:
-        """Approximate token count for usage reporting."""
+        """Token count for usage reporting.
+
+        Capped at ``effective_max_length`` per input so the reported usage
+        matches the tokens actually embedded rather than over-reporting the
+        pre-truncation length (issue #1381).
+        """
         self._ensure_loaded()
 
         if isinstance(texts, str):
             texts = [texts]
 
+        limit = self.effective_max_length
         total = 0
         for text in texts:
             try:
                 tokens = self._tokenizer.encode(text)
                 if isinstance(tokens, list) or hasattr(tokens, "__len__"):
-                    total += len(tokens)
+                    n = len(tokens)
                 else:
-                    total += tokens.size
+                    n = tokens.size
             except Exception:
                 # Fallback: rough estimate of ~4 chars per token
-                total += max(1, len(text) // 4)
+                n = max(1, len(text) // 4)
+            total += min(n, limit) if limit else n
         return total

--- a/vllm_mlx/routes/embeddings.py
+++ b/vllm_mlx/routes/embeddings.py
@@ -29,7 +29,7 @@ router = APIRouter()
 )
 async def create_embeddings(request: EmbeddingRequest) -> EmbeddingResponse:
     """Create embeddings for the given input text(s)."""
-    from ..embedding import EMBEDDINGS_EXTRA_INSTALL_HINT
+    from ..embedding import EMBEDDINGS_EXTRA_INSTALL_HINT, EmbeddingInputTooLongError
     from ..server import load_embedding_model
 
     cfg = get_config()
@@ -175,16 +175,42 @@ async def create_embeddings(request: EmbeddingRequest) -> EmbeddingResponse:
             )
 
         start_time = time.perf_counter()
-        if token_batches is not None:
-            # count_tokens for pre-tokenized: trust the caller's count
-            # (capped at 512 same as embed_tokens does).
-            prompt_tokens = sum(min(len(b), 512) for b in token_batches)
-            embeddings = cfg.embedding_engine.embed_tokens(token_batches)
-            n_inputs = len(token_batches)
-        else:
-            prompt_tokens = cfg.embedding_engine.count_tokens(texts)
-            embeddings = cfg.embedding_engine.embed(texts)
-            n_inputs = len(texts)
+        # Report the tokens actually embedded — capped at the engine's
+        # resolved effective limit rather than a hardcoded 512 (issue #1381).
+        eff_limit = getattr(cfg.embedding_engine, "effective_max_length", None)
+        if not isinstance(eff_limit, int) or eff_limit <= 0:
+            eff_limit = 512
+        try:
+            if token_batches is not None:
+                prompt_tokens = sum(min(len(b), eff_limit) for b in token_batches)
+                embeddings = cfg.embedding_engine.embed_tokens(token_batches)
+                n_inputs = len(token_batches)
+            else:
+                prompt_tokens = cfg.embedding_engine.count_tokens(texts)
+                embeddings = cfg.embedding_engine.embed(texts)
+                n_inputs = len(texts)
+        except EmbeddingInputTooLongError as exc:
+            # overflow_policy == "error": reject with the observed/allowed
+            # token counts so the caller can react instead of silently
+            # indexing a truncated vector.
+            raise HTTPException(
+                status_code=400,
+                detail={
+                    "error": {
+                        "message": (
+                            f"Input {exc.index} has {exc.observed_tokens} tokens, "
+                            f"which exceeds the embedding model's configured max "
+                            f"input length of {exc.allowed_tokens}. Shorten the "
+                            f"input, or restart the server with a higher "
+                            f"--embedding-max-length (or "
+                            f"--embedding-overflow-policy truncate)."
+                        ),
+                        "type": "invalid_request_error",
+                        "code": "input_too_long",
+                        "param": "input",
+                    }
+                },
+            )
         elapsed = time.perf_counter() - start_time
         logger.info(
             f"Embeddings: {n_inputs} inputs, {prompt_tokens} tokens in {elapsed:.2f}s"

--- a/vllm_mlx/routes/metrics.py
+++ b/vllm_mlx/routes/metrics.py
@@ -907,6 +907,22 @@ def _render_prometheus(cfg: Any) -> str:
         )
     )
 
+    # Embedding truncations (issue #1381). Non-silent signal: how many
+    # inputs had their tail discarded for exceeding the effective max input
+    # length under the ``truncate`` overflow policy. Only emitted when an
+    # embedding model is loaded.
+    _embedding_engine = getattr(cfg, "embedding_engine", None)
+    if _embedding_engine is not None:
+        lines.extend(
+            _fmt_metric(
+                "rapid_mlx_embedding_truncations_total",
+                "counter",
+                "Embedding inputs whose tail was discarded for exceeding the "
+                "max input length.",
+                int(getattr(_embedding_engine, "num_truncations", 0) or 0),
+            )
+        )
+
     # R15 #300: KV cache dtype as a labeled gauge. Operators need to see
     # the EFFECTIVE dtype the resolver picked (post-safelist + post-
     # reasoning-pin), not just the requested flag value. Emitted as

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -231,6 +231,11 @@ _mcp_executor = None
 # Global embedding engine (lazy loaded)
 _embedding_engine = None
 _embedding_model_locked: str | None = None  # Set when --embedding-model is used
+# Operator embedding-length config (issue #1381). Set once from the CLI and
+# reused by route-triggered loads so both the pre-load and lazy paths build
+# the engine with the same limits.
+_embedding_max_length: int | str = "auto"
+_embedding_overflow_policy: str = "truncate"
 
 # API key authentication
 _api_key: str | None = None
@@ -1314,12 +1319,26 @@ def load_embedding_model(
     *,
     lock: bool = False,
     reuse_existing: bool = True,
+    max_length: int | str | None = None,
+    overflow_policy: str | None = None,
 ) -> None:
-    """Load or reuse the embedding model engine when configured."""
+    """Load or reuse the embedding model engine when configured.
+
+    ``max_length`` / ``overflow_policy`` (issue #1381) are remembered in
+    module globals when provided (the CLI passes them once at startup), so
+    route-triggered lazy loads — which call this without them — build the
+    engine with the same operator-configured limits.
+    """
     global _embedding_engine, _embedding_model_locked
+    global _embedding_max_length, _embedding_overflow_policy
 
     if not model_name:
         return
+
+    if max_length is not None:
+        _embedding_max_length = max_length
+    if overflow_policy is not None:
+        _embedding_overflow_policy = overflow_policy
 
     if lock:
         _embedding_model_locked = model_name
@@ -1333,7 +1352,11 @@ def load_embedding_model(
 
     from .embedding import EmbeddingEngine
 
-    _embedding_engine = EmbeddingEngine(model_name)
+    _embedding_engine = EmbeddingEngine(
+        model_name,
+        max_length=_embedding_max_length,
+        overflow_policy=_embedding_overflow_policy,
+    )
     _embedding_engine.load()
 
     # Sync into config for route modules


### PR DESCRIPTION
## Why

`EmbeddingEngine.embed()` hardcoded the tokenizer at `truncation=True, max_length=512`, so any input past 512 tokens was **silently truncated** — the response has a valid shape and HTTP 200, but the discarded tail quietly degrades vector-index retrieval. This bites real users (issue #1381: GitNexus indexing code chunks with Qwen3-Embedding-4B, whose architecture supports 32K context). Two related defects: the pre-tokenized path (`embed_tokens()`) capped at 512 the same way, and usage over-reported the full pre-truncation token count.

## What

Resolve a model-aware effective limit and make overflow observable (never silent):

- **Model-derived default**: `auto` derives the limit from `config.max_position_embeddings`, then `tokenizer.model_max_length`, guarding HuggingFace's large "unset" sentinel. Falls back to 512 only when nothing is declared (and logs it).
- **`--embedding-max-length <auto|int>`**: operator ceiling for a lower memory/service limit; an explicit value is validated against and clamped to the model maximum.
- **`--embedding-overflow-policy {truncate,error}`**:
  - `truncate` (default) discards the tail but logs a warning and increments `rapid_mlx_embedding_truncations_total` on `/metrics` — no longer silent.
  - `error` returns a structured `400` (`code: "input_too_long"`) carrying the observed and allowed token counts.
- Applied consistently to **string and pre-tokenized** inputs; usage reporting is capped at the effective limit (fixes the over-report).

## Tests

`tests/test_embedding_max_length.py` (new, 37 cases) covers the issue's acceptance matrix with a mocked model/tokenizer (no model download, no GPU): Qwen3-Embedding @ 32K, BERT @ 512, explicit lower override, over-model clamp, the HF sentinel, both overflow policies, usage-count capping, and mixed-length batches. Existing `test_embeddings` / `test_embeddings_route` / `test_cli_embeddings_extra` / `test_metrics_route` pass (the CLI loader-contract test was updated for the new kwargs). `ruff check` + `ruff format --check` clean.

## Deferred (follow-ups, noted on the issue)

- Total-padded-token batch bounding (issue pt. 5) — bound a batch by summed padded tokens, not item count, so raising the ceiling can't create an oversized Metal allocation.
- The MLX allocator-cache leak in the embedding path (#1380).

Closes #1381

🤖 Generated with [Claude Code](https://claude.com/claude-code)
