### PR TITLE
chore: bump version to 0.11.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.11.5"
+version = "0.11.6"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Summary

- release DeepSeek V4 warm-TTFT, parser containment, and cross-process prefix-cache persistence improvements
- include all changes merged to `main` through PR #1385, including the two additional non-DeepSeek PRs requested for this release
- bump package version from `0.11.5` to `0.11.6`

## Validation

- release subject validator: PASS
- functional PR #1385: MERGE-SAFE, GitHub CI all green
- full unit gate: 15,018 passed
- four-model Tier-1 stress gate: 8/8 per model
- wheel/sdist build, twine check, and clean-room smoke: PASS