### PR TITLE
chore: bump version to 0.11.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.11.6"
+version = "0.11.7"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Summary

- supersede `0.11.6` so the release includes PR #1384, which completed its merge seconds after the `v0.11.6` tag was created
- include both requested non-DeepSeek G7 test PRs (#1382 and #1384) together with DeepSeek V4 improvements through #1385
- bump package version from `0.11.6` to `0.11.7`

## Validation

- release subject validator: PASS
- `v0.11.6` release pipeline and Tier-1 agent gate: PASS
- only source delta after `v0.11.6`: merged test-only PR #1384