### PR TITLE
chore: bump version to 0.11.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.11.7"
+version = "0.11.8"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Summary

- supersede `0.11.7` so both delayed non-DeepSeek merges requested for this release are included: #1384 and #1386
- include DeepSeek V4 parser, warm-TTFT, DSpark, and cross-process prefix-cache persistence work through #1385
- bump package version from `0.11.7` to `0.11.8`

## Validation

- release subject validator: PASS
- prior release pipeline and Tier-1 agent gate: PASS
- release delta after `v0.11.7`: merged PR #1386