### PR TITLE
fix(embeddings): release MLX buffers after each batch (#1380)

### DIFF
--- a/tests/test_embedding_clear_cache.py
+++ b/tests/test_embedding_clear_cache.py
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression test for issue #1380: the embedding engine must release MLX
+Metal buffers (``mx.clear_cache()``) after each completed batch, matching
+every LLM path in the engine.
+
+Without it the MLX allocator pool grows monotonically: ``padding=True`` makes
+the per-batch sequence length vary, so nearly every request asks for a buffer
+size the pool has never seen and cannot reuse (measured upstream: 2.3 GB → 24
+GB over 320 texts). Pure-logic test: mocked model + tokenizer, no model
+download and no GPU allocation.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+
+from vllm_mlx.embedding import EmbeddingEngine
+
+
+def _mock_engine() -> EmbeddingEngine:
+    eng = EmbeddingEngine("test-model")
+    mock_output = MagicMock()
+    mock_output.text_embeds.tolist.return_value = [[0.1, 0.2], [0.3, 0.4]]
+    eng._model = MagicMock(return_value=mock_output)
+
+    inner_tok = MagicMock(
+        return_value={
+            "input_ids": np.array([[1, 2], [3, 4]]),
+            "attention_mask": np.array([[1, 1], [1, 1]]),
+        }
+    )
+    tok = MagicMock()
+    tok._tokenizer = inner_tok
+    tok.pad_token_id = 0
+    eng._tokenizer = tok
+    return eng
+
+
+@patch("vllm_mlx.embedding.mx.clear_cache")
+def test_embed_releases_buffers_after_batch(mock_clear):
+    eng = _mock_engine()
+    result = eng.embed(["hello", "world"])
+    assert result == [[0.1, 0.2], [0.3, 0.4]]
+    mock_clear.assert_called_once()
+
+
+@patch("vllm_mlx.embedding.mx.clear_cache")
+def test_embed_tokens_releases_buffers_after_batch(mock_clear):
+    eng = _mock_engine()
+    result = eng.embed_tokens([[1, 2], [3, 4]])
+    assert result == [[0.1, 0.2], [0.3, 0.4]]
+    mock_clear.assert_called_once()
+
+
+@patch("vllm_mlx.embedding.mx.clear_cache")
+def test_clear_cache_runs_after_tolist(mock_clear):
+    """The release must happen AFTER ``.tolist()`` materializes the Python
+    lists — otherwise it would drop the buffers still backing the result."""
+    eng = _mock_engine()
+    order: list[str] = []
+    eng._model.return_value.text_embeds.tolist.side_effect = lambda: (
+        order.append("tolist") or [[0.1, 0.2], [0.3, 0.4]]
+    )
+    mock_clear.side_effect = lambda: order.append("clear")
+    eng.embed(["a", "b"])
+    assert order == ["tolist", "clear"]
+
+
+@patch("vllm_mlx.embedding.mx.clear_cache")
+def test_empty_token_batch_does_not_clear(mock_clear):
+    """No forward pass runs for an empty batch, so there is nothing to
+    release and clear_cache must not be called."""
+    eng = _mock_engine()
+    assert eng.embed_tokens([]) == []
+    mock_clear.assert_not_called()

--- a/tests/test_embedding_clear_cache.py
+++ b/tests/test_embedding_clear_cache.py
@@ -33,7 +33,12 @@ def _mock_engine() -> EmbeddingEngine:
     )
     tok = MagicMock()
     tok._tokenizer = inner_tok
+    # A real pad token id (0). Both attrs are set because embed_tokens'
+    # pad-id resolver falls through ``pad_token_id or _tokenizer.pad_token_id
+    # or 0`` — a bare MagicMock on the inner tokenizer would be treated as a
+    # truthy pad id and break mx.array() on the padded batch.
     tok.pad_token_id = 0
+    inner_tok.pad_token_id = 0
     eng._tokenizer = tok
     return eng
 

--- a/tests/test_embedding_clear_cache.py
+++ b/tests/test_embedding_clear_cache.py
@@ -75,3 +75,17 @@ def test_empty_token_batch_does_not_clear(mock_clear):
     eng = _mock_engine()
     assert eng.embed_tokens([]) == []
     mock_clear.assert_not_called()
+    # The early return must happen before any model call (guards against a
+    # future refactor moving the guard below the forward pass).
+    eng._model.assert_not_called()
+
+
+@patch("vllm_mlx.embedding.mx.clear_cache")
+def test_embed_tokens_ragged_batch_releases_buffers(mock_clear):
+    """The leak is triggered by varied-length batches (each new padded size
+    is a buffer the MLX pool can't reuse), so cover the ragged case: the
+    release must still run exactly once."""
+    eng = _mock_engine()
+    result = eng.embed_tokens([[1, 2, 3], [4]])  # lengths differ → padded
+    assert result == [[0.1, 0.2], [0.3, 0.4]]
+    mock_clear.assert_called_once()

--- a/vllm_mlx/embedding.py
+++ b/vllm_mlx/embedding.py
@@ -334,7 +334,19 @@ class EmbeddingEngine:
         embeds: mx.array = output.text_embeds
 
         # Convert to Python lists for JSON serialization
-        return embeds.tolist()
+        result = embeds.tolist()
+
+        # Release the Metal buffers this pass allocated (issue #1380). MLX
+        # keeps freed buffers in its allocator pool keyed by size, and the
+        # ``padding=True`` above makes the batch's sequence length vary from
+        # request to request — so nearly every batch asks for a size the pool
+        # has never seen and cannot reuse. Without this the pool only grows
+        # (measured: ~70 MB retained per input text, 2.3 GB → 24 GB over 320
+        # texts). Mirrors every LLM path in this engine, which already clear
+        # the cache after a forward.
+        mx.clear_cache()
+
+        return result
 
     def embed_tokens(self, token_batches: list[list[int]]) -> list[list[float]]:
         """Embed pre-tokenized inputs (OpenAI spec input formats 3 and 4).
@@ -392,7 +404,11 @@ class EmbeddingEngine:
 
         output = self._model(input_ids, attention_mask=attention_mask)
         embeds: mx.array = output.text_embeds
-        return embeds.tolist()
+        result = embeds.tolist()
+        # Same allocator-pool release as embed() (issue #1380): drop the
+        # per-batch Metal buffers now that the vectors are Python lists.
+        mx.clear_cache()
+        return result
 
     def count_tokens(self, texts: str | list[str]) -> int:
         """Token count for usage reporting.


### PR DESCRIPTION
## Why

`/v1/embeddings` never calls `mx.clear_cache()`, unlike every LLM path in this engine (engine_core, the MLLM scheduler/batch-generator, guided decoding). MLX keeps freed buffers in its allocator pool keyed by size, and `padding=True` makes the per-batch sequence length vary from request to request — so nearly every batch asks for a size the pool has never seen and cannot reuse. The pool only grows.

Reported in #1380 with upstream evidence (waybarrios/vllm-mlx#667, commit `6b41b1ad`): a fresh embeddings-only server retained ~70 MB per input text, going from **2.3 GB → 24 GB over 320 texts**; a week-old production process reached ~50 GB (49 GB unreclaimable IOAccelerator). The practical consumer (GitNexus) streams tens of thousands of code chunks through the endpoint during repository indexing, so this is a real OOM. It compounds #1381, which just raised the input-length ceiling.

## What

Release the per-batch Metal buffers with `mx.clear_cache()` right after `.tolist()` materializes the vectors into Python lists — in **both** `embed()` (string path) and `embed_tokens()` (pre-tokenized path). This mirrors the upstream fix and the existing idiom used everywhere else in the engine. Upstream measured the same run staying flat at ~3.5 GB afterward with unchanged throughput (19.2 vs 19.1 texts/s).

## Tests

`tests/test_embedding_clear_cache.py` (new) patches `vllm_mlx.embedding.mx.clear_cache` and asserts it runs exactly once per completed batch on both paths, runs *after* `.tolist()` (so it never drops the buffers still backing the result), and is *not* called for an empty batch. Pure-logic (mocked model/tokenizer) — no model download, no GPU. Existing `test_embeddings` / `test_embeddings_route` / `test_embedding_max_length` pass; `ruff check` + `ruff format --check` clean.

Closes #1380

🤖 Generated with [Claude Code](https://claude.com/claude-code)
