### PR TITLE
fix(stream): bound tool-call streaming suppression so it can't wedge (#1359)

### DIFF
--- a/tests/test_streaming_suppression_budget.py
+++ b/tests/test_streaming_suppression_budget.py
@@ -171,3 +171,46 @@ def test_legit_short_tool_call_not_released():
     pp.process_chunk(_make_output("</tool_call>"))
     assert pp._tool_suppression_released is False
     assert pp.tool_calls_detected is True
+
+
+def test_no_release_once_a_tool_call_reached_the_wire():
+    """The ``_tool_calls_emitted_to_wire == 0`` guard: once a tool call has
+    streamed to the wire, a large following buffered block is a legitimate
+    continuation (e.g. a second call whose args stream), not a wedge — the
+    budget must NOT release, and nothing is accumulated into the suppression
+    buffer at all."""
+
+    class _EmitThenBufferParser(_NeverClosingToolParser):
+        def __init__(self):
+            super().__init__()
+            self._emitted = False
+
+        def extract_tool_calls_streaming(
+            self, previous_text, current_text, delta_text, request=None
+        ):
+            if "<tool_call>" in current_text and not self._emitted:
+                self._emitted = True
+                return {
+                    "tool_calls": [
+                        {
+                            "index": 0,
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {"name": "f", "arguments": "{}"},
+                        }
+                    ]
+                }
+            if self._emitted:
+                return None  # now buffering a large second block forever
+            return {"content": delta_text}
+
+    pp = StreamingPostProcessor(_make_cfg())
+    pp.reset()
+    pp.tool_parser = _EmitThenBufferParser()
+    pp.tool_markup_possible = True
+
+    pp.process_chunk(_make_output("<tool_call>"))
+    assert pp._tool_calls_emitted_to_wire > 0
+    pp.process_chunk(_make_output("z" * (_MAX_TOOL_SUPPRESSION_BYTES + 100)))
+    assert pp._tool_suppression_released is False  # guard held
+    assert pp._tool_suppressed_buffer == ""  # never accumulated past the guard

--- a/tests/test_streaming_suppression_budget.py
+++ b/tests/test_streaming_suppression_budget.py
@@ -1,0 +1,173 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for issue #1359 — streaming tool-call suppression must be
+bounded.
+
+A streaming ``/v1/chat/completions`` request whose model opens a tool-call
+block that never closes (a literal ``<tool_call>``/``<function=`` in generated
+code that skews the open/close balance, oversized/degenerate arguments, or a
+repetition loop) used to have every subsequent content delta suppressed
+forever — the tool parser returns ``None`` for each chunk, the SSE generator
+yields nothing, and the keepalive layer emits only ``: keepalive`` comments,
+so no client timeout can fire (2207 tokens generated, 1 chunk on the wire,
+518s). The postprocessor now bounds the suppression and releases the buffered
+content as text once the budget is exceeded.
+
+Pure-logic: a stub tool parser drives ``StreamingPostProcessor.process_chunk``.
+No model, no GPU.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from vllm_mlx.service.postprocessor import (
+    _MAX_TOOL_SUPPRESSION_BYTES,
+    StreamingPostProcessor,
+)
+
+
+def _make_cfg(**overrides):
+    cfg = MagicMock()
+    cfg.engine = None
+    cfg.reasoning_parser = None
+    cfg.reasoning_parser_name = None
+    cfg.enable_auto_tool_choice = True
+    cfg.tool_call_parser = None
+    cfg.tool_parser_instance = None
+    for k, v in overrides.items():
+        setattr(cfg, k, v)
+    return cfg
+
+
+def _make_output(text="", finished=False):
+    out = MagicMock()
+    out.new_text = text
+    out.finished = finished
+    out.channel = None
+    out.finish_reason = "stop" if finished else None
+    out.prompt_tokens = 10
+    out.completion_tokens = 5
+    out.tokens = []
+    out.logprobs = None
+    out.tool_calls = None
+    return out
+
+
+class _NeverClosingToolParser:
+    """Once it sees a ``<tool_call>`` opener it suppresses (returns ``None``)
+    for every subsequent delta, simulating a block whose close tag never
+    arrives (issue #1359)."""
+
+    def __init__(self):
+        self._opened = False
+
+    def extract_tool_calls_streaming(
+        self, previous_text, current_text, delta_text, request=None
+    ):
+        if "<tool_call>" in current_text:
+            self._opened = True
+        if self._opened:
+            return None  # never closes → suppress forever (pre-fix wedge)
+        return {"content": delta_text}
+
+    def has_pending_tool_call(self, text):
+        return "<tool_call>" in text
+
+    def extract_tool_calls(self, text, request=None):
+        r = MagicMock()
+        r.tools_called = False
+        r.tool_calls = []
+        return r
+
+    def flush_held_content(self, text):
+        return ""
+
+
+def _pp():
+    pp = StreamingPostProcessor(_make_cfg())
+    pp.reset()
+    pp.tool_parser = _NeverClosingToolParser()
+    pp.tool_markup_possible = True  # skip the no-markup fast path
+    return pp
+
+
+def _content(events):
+    return "".join(e.content or "" for e in events if e.type == "content")
+
+
+def test_unclosed_block_suppressed_under_budget():
+    pp = _pp()
+    # Content before the opener flows normally.
+    assert "Intro" in _content(pp.process_chunk(_make_output("Intro. ")))
+    # Opener → enter suppression.
+    assert _content(pp.process_chunk(_make_output("<tool_call>"))) == ""
+    # A body smaller than the budget stays suppressed (real tool calls close
+    # well under it), and nothing is released yet.
+    body = "The quick brown fox. " * 100  # ~2 KB
+    assert _content(pp.process_chunk(_make_output(body))) == ""
+    assert pp._tool_suppression_released is False
+
+
+def test_unclosed_block_released_after_budget():
+    pp = _pp()
+    pp.process_chunk(_make_output("<tool_call>"))
+    # One body past the budget must release the withheld text as content.
+    big = "The quick brown fox. " * (_MAX_TOOL_SUPPRESSION_BYTES // 20 + 10)
+    emitted = _content(pp.process_chunk(_make_output(big)))
+    assert pp._tool_suppression_released is True
+    assert "fox" in emitted  # the withheld content reached the wire
+
+
+def test_stream_resumes_as_content_after_release():
+    pp = _pp()
+    pp.process_chunk(_make_output("<tool_call>"))
+    pp.process_chunk(_make_output("x" * (_MAX_TOOL_SUPPRESSION_BYTES + 32)))
+    assert pp._tool_suppression_released is True
+    # Once released, tool detection is off for the turn: later deltas stream
+    # straight through as content instead of wedging.
+    assert "recovered" in _content(pp.process_chunk(_make_output("recovered tail")))
+
+
+def test_reset_clears_release_latch():
+    pp = _pp()
+    pp.process_chunk(_make_output("<tool_call>"))
+    pp.process_chunk(_make_output("y" * (_MAX_TOOL_SUPPRESSION_BYTES + 32)))
+    assert pp._tool_suppression_released is True
+    pp.reset()
+    assert pp._tool_suppression_released is False
+    assert pp._tool_suppressed_buffer == ""
+
+
+def test_legit_short_tool_call_not_released():
+    """A real tool call closes well under the budget → the stub that *does*
+    close must never trip the release path (no false positive)."""
+
+    class _ClosingToolParser(_NeverClosingToolParser):
+        def extract_tool_calls_streaming(
+            self, previous_text, current_text, delta_text, request=None
+        ):
+            if "</tool_call>" in current_text:
+                return {
+                    "tool_calls": [
+                        {
+                            "index": 0,
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {"name": "f", "arguments": "{}"},
+                        }
+                    ]
+                }
+            if "<tool_call>" in current_text:
+                return None  # buffering the small args body
+            return {"content": delta_text}
+
+    pp = StreamingPostProcessor(_make_cfg())
+    pp.reset()
+    pp.tool_parser = _ClosingToolParser()
+    pp.tool_markup_possible = True
+
+    pp.process_chunk(_make_output('<tool_call>{"name":"f",'))
+    pp.process_chunk(_make_output('"arguments":{}}'))
+    pp.process_chunk(_make_output("</tool_call>"))
+    assert pp._tool_suppression_released is False
+    assert pp.tool_calls_detected is True

--- a/vllm_mlx/service/postprocessor.py
+++ b/vllm_mlx/service/postprocessor.py
@@ -27,6 +27,20 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# Issue #1359 — bound how many bytes the streaming tool-call parser may
+# suppress while inside an unclosed tool-call block before we give up and
+# release the withheld text as content. Without a bound,
+# ``extract_tool_calls_streaming`` returns ``None`` for every delta as long as
+# the block stays open, so a block that never closes (a literal
+# ``<tool_call>``/``<function=`` in generated code that skews the open/close
+# balance, oversized/degenerate arguments, or a repetition loop) suppresses
+# content forever — the client then sees only SSE keepalives and no client
+# timeout can ever fire. 64 KB is far above any legitimate tool call (a few
+# hundred bytes; incremental-argument parsers emit tool_call deltas well
+# before this, which also trips the ``_tool_calls_emitted_to_wire`` guard) yet
+# bounds the stall to ~16 K tokens.
+_MAX_TOOL_SUPPRESSION_BYTES = 65536
+
 
 def _find_json_start(text: str) -> int:
     """Find the first `{` or `[` that is NOT inside `<think>...</think>` tags.
@@ -374,6 +388,15 @@ class StreamingPostProcessor:
         # site (channel-routed, reasoning, standard) AND in
         # ``_build_tool_call_event``. Read by ``_compute_finish_reason``.
         self._tool_calls_emitted_to_wire: int = 0
+        # Issue #1359 — bound tool-call streaming suppression.
+        # ``_tool_suppressed_buffer`` accumulates only the deltas the parser
+        # withheld (returned ``None``) while inside an unclosed tool-call block;
+        # if it passes ``_MAX_TOOL_SUPPRESSION_BYTES`` before any tool call has
+        # reached the wire, we release it as content and latch
+        # ``_tool_suppression_released`` so the rest of the turn streams as
+        # plain content instead of wedging behind SSE keepalives.
+        self._tool_suppressed_buffer: str = ""
+        self._tool_suppression_released: bool = False
         self.tool_markup_possible = False
         # R10-C8 (Mira r10-R1): tool-prose-prefix hold-back. When the
         # request declares ``tools`` and the model emits a UI-TARS-style
@@ -2309,6 +2332,10 @@ class StreamingPostProcessor:
         # prior turn's emitted-count into a new stream and lie to
         # ``_compute_finish_reason`` about the wire state.
         self._tool_calls_emitted_to_wire = 0
+        # Issue #1359 — clear the suppression-release latch/buffer so a re-used
+        # processor doesn't carry a prior turn's released state into a new stream.
+        self._tool_suppressed_buffer = ""
+        self._tool_suppression_released = False
         self.tool_markup_possible = False
         # R10-C8: clear the tool-prose hold-back so a re-used processor
         # doesn't ship the prior turn's buffered preamble bytes.
@@ -3542,6 +3569,9 @@ class StreamingPostProcessor:
             self.tool_parser
             and _fallback_text
             and not self.tool_calls_detected
+            # Issue #1359 — once the suppression budget released the block as
+            # content, don't re-surface it as a tool call at finalize.
+            and not self._tool_suppression_released
             and _has_plausible_markup
         ):
             result = self.tool_parser.extract_tool_calls(
@@ -3813,6 +3843,13 @@ class StreamingPostProcessor:
         Returns {"tool_calls": [...]} if tool calls detected.
         Returns {"content": "..."} for normal content pass-through.
         """
+        if self._tool_suppression_released:
+            # Issue #1359 — a prior unclosed tool-call block blew the
+            # suppression budget; tool detection is disabled for the rest of
+            # this turn so content streams instead of wedging behind keepalives.
+            self.tool_accumulated_text += content
+            return {"content": content}
+
         if not self.tool_markup_possible and "<" not in content and "[" not in content:
             # The hardcoded ``<``/``[`` heuristic catches every parser
             # whose wire markers open with one of those chars. The
@@ -3857,7 +3894,35 @@ class StreamingPostProcessor:
         )
 
         if tool_result is None:
+            # Inside an (as yet) unclosed tool-call block — normally suppressed.
+            # Bound the suppression (issue #1359): if the block never closes,
+            # returning ``None`` for every delta wedges the stream behind SSE
+            # keepalives with no client timeout able to fire. Once we've
+            # withheld more than the budget WITHOUT any tool call reaching the
+            # wire, give up on tool detection for this turn and release the
+            # buffered text as content so the stream makes visible progress.
+            # Only the withheld (``None``) deltas are buffered here, so nothing
+            # already emitted as content is re-sent; the ``emitted_to_wire``
+            # guard leaves genuine (incrementally-streamed) tool calls alone.
+            if self._tool_calls_emitted_to_wire == 0:
+                self._tool_suppressed_buffer += content
+                if len(self._tool_suppressed_buffer) > _MAX_TOOL_SUPPRESSION_BYTES:
+                    released = self._tool_suppressed_buffer
+                    self._tool_suppression_released = True
+                    self._tool_suppressed_buffer = ""
+                    logger.warning(
+                        "Tool-call streaming suppression exceeded %d bytes "
+                        "without a closing tag; releasing buffered content as "
+                        "text and disabling tool detection for this request "
+                        "(issue #1359).",
+                        _MAX_TOOL_SUPPRESSION_BYTES,
+                    )
+                    return {"content": released}
             return None  # inside tool markup
+
+        # Parser made progress (emitted content or resolved the block) — drop
+        # any partial suppression buffer so a later block is bounded afresh.
+        self._tool_suppressed_buffer = ""
 
         if "tool_calls" in tool_result:
             self.tool_calls_detected = True


### PR DESCRIPTION
## Why

On streaming `/v1/chat/completions`, once the tool parser sees a tool-call opener (`<tool_call>`, `<function=`) it returns `None` for every subsequent delta until the block closes. `StreamingPostProcessor` suppressed those deltas with **no byte/token bound**, so a block that never closes held all content indefinitely. The SSE generator then yields nothing and the keepalive layer emits only `: keepalive` comments — so **no client timeout at any layer can fire** (issue #1359: 2207 tokens generated, 1 chunk on the wire, 518s; the request outlived its `X-Stainless-Timeout: 300`). From the client it's indistinguishable from a server that never answered.

The never-closing block has several triggers, all of which this bounds: a literal `<tool_call>`/`<function=` in generated code that skews the open/close balance (very plausible for a coder model, `--tool-call-parser qwen3_coder` → HermesToolParser), oversized/degenerate arguments, or a repetition loop inside the block. `StreamingToolCallFilter` (responses/anthropic path) already caps at 1 MB — but the **chat path has no cap at all**.

Confirmed chain: `_disconnect_guard` keepalives ⟸ `stream_chat_completion` never yields ⟸ `process_chunk` returns `[]` ⟸ `_detect_tool_calls` returns `None` while the parser reports an incomplete block — with no bound anywhere.

## What

Add the missing bound at the common chokepoint (`_detect_tool_calls`), so it protects every tool parser:

- Buffer only the **withheld** (`None`) deltas since the block opened, and only while **no tool call has reached the wire** (`_tool_calls_emitted_to_wire == 0`) — genuine, incrementally-streamed tool calls are never touched.
- Once that buffer exceeds `_MAX_TOOL_SUPPRESSION_BYTES` (**64 KB** — orders of magnitude above any real tool call, yet ~16 K tokens instead of the ~250 K a 1 MB cap would allow), **release the withheld text as content** and latch tool-suppression off for the rest of the turn so the stream makes visible progress (the reporter's preferred outcome: "content deltas flushed to the wire").
- Guard the `finalize()` tool-recovery so a released block isn't re-surfaced as a tool call.

Note: the repetition-loop trigger is *also* mitigated on current `main` by the repetition guard (#1377/#1378) for tool-bearing requests; this fix covers the non-repetition variants (false-positive opener in code, oversized/degenerate args) that the guard doesn't.

## Tests

`tests/test_streaming_suppression_budget.py` (new) drives `StreamingPostProcessor.process_chunk` with a stub never-closing parser (no model, no GPU): asserts suppression under budget, release + resumed content-flow after budget, latch reset across `reset()`, and that a legit short tool call is never released. Regression: `test_postprocessor` (116), `test_447_stream_tool_choice_auto` (14), `test_streaming_tool_filter` (30), `test_tool_call_streaming_parity` (10), `test_tool_parsers` (156) all pass. `ruff check` + `ruff format --check` clean.

The reporter notes there is **no deterministic reproduction** (the 518s request replayed byte-for-byte three times ran normally), so this is validated by root-cause + unit tests rather than a live repro.

Closes #1359

🤖 Generated with [Claude Code](https://claude.com/claude-code)
