### PR TITLE
fix(deepseek): stop short loops before Metal exhaustion

### DIFF
--- a/tests/test_metal_error_recovery.py
+++ b/tests/test_metal_error_recovery.py
@@ -240,9 +240,7 @@ def test_scheduler_generation_error_is_not_reported_as_normal_length_finish():
     had failed.
     """
     tokenizer = MagicMock()
-    scheduler = Scheduler(
-        MagicMock(), tokenizer, SchedulerConfig(max_num_seqs=2)
-    )
+    scheduler = Scheduler(MagicMock(), tokenizer, SchedulerConfig(max_num_seqs=2))
     req = Request("metal-resource-limit", "prompt", SamplingParams(max_tokens=32768))
     req.status = RequestStatus.RUNNING
     scheduler.running[req.request_id] = req
@@ -257,5 +255,7 @@ def test_scheduler_generation_error_is_not_reported_as_normal_length_finish():
     assert len(output.outputs) == 1
     terminal = output.outputs[0]
     assert terminal.finished is True
+    assert terminal.finish_reason == "abort"
+    assert terminal.finish_reason != "length"
     assert terminal.error is not None
     assert "Resource limit" in terminal.error

--- a/tests/test_metal_error_recovery.py
+++ b/tests/test_metal_error_recovery.py
@@ -25,7 +25,14 @@ import pytest
 
 from vllm_mlx.engine_core import EngineConfig, EngineCore
 from vllm_mlx.output_collector import RequestOutputCollector
-from vllm_mlx.request import InferenceAbortedError, RequestOutput
+from vllm_mlx.request import (
+    InferenceAbortedError,
+    Request,
+    RequestOutput,
+    RequestStatus,
+    SamplingParams,
+)
+from vllm_mlx.scheduler import Scheduler, SchedulerConfig
 
 
 def _make_engine() -> EngineCore:
@@ -223,3 +230,32 @@ def test_metal_message_detection_patterns():
         assert any(
             n in s for n in ("Metal", "MTL", "command buffer", "gpu::check_error")
         ), f"{s!r} no longer matches any Metal heuristic"
+
+
+def test_scheduler_generation_error_is_not_reported_as_normal_length_finish():
+    """Regression for the 12k-step DeepSeek Metal resource-limit failure.
+
+    Scheduler-local recovery used to return ``finish_reason=length`` without
+    an error, causing Responses to emit ``response.completed`` after the GPU
+    had failed.
+    """
+    tokenizer = MagicMock()
+    scheduler = Scheduler(
+        MagicMock(), tokenizer, SchedulerConfig(max_num_seqs=2)
+    )
+    req = Request("metal-resource-limit", "prompt", SamplingParams(max_tokens=32768))
+    req.status = RequestStatus.RUNNING
+    scheduler.running[req.request_id] = req
+    scheduler.batch_generator = MagicMock()
+    scheduler.batch_generator.next.side_effect = RuntimeError(
+        "[metal::malloc] Resource limit (499000) exceeded"
+    )
+
+    output = scheduler.step()
+
+    assert output.finished_request_ids == {req.request_id}
+    assert len(output.outputs) == 1
+    terminal = output.outputs[0]
+    assert terminal.finished is True
+    assert terminal.error is not None
+    assert "Resource limit" in terminal.error

--- a/tests/test_repetition_guard.py
+++ b/tests/test_repetition_guard.py
@@ -39,6 +39,20 @@ def test_ignores_short_stutter_and_near_repeat():
     assert detect_repeated_token_suffix(pattern * 5 + pattern[:-1] + [999]) is None
 
 
+def test_stops_sustained_single_token_loop_before_resource_exhaustion():
+    """DeepSeek can collapse into a one-token CJK loop (for example 商店).
+
+    Keep the threshold high enough to tolerate intentional short stutters, but
+    stop the production failure well before it reaches ten thousand tokens and
+    exhausts Metal resource handles.
+    """
+    assert detect_repeated_token_suffix([7] * 255) is None
+    match = detect_repeated_token_suffix([7] * 256)
+    assert match is not None
+    assert match.period_tokens == 1
+    assert match.repeats == 256
+
+
 def _drive_repeating_request(*, has_tools: bool):
     scheduler = _scheduler()
     pattern = list(range(12))
@@ -73,3 +87,52 @@ def test_scheduler_does_not_change_plain_chat_semantics():
     assert req.status == RequestStatus.RUNNING
     assert output.finished is False
     assert scheduler.num_repetition_loop_stops == 0
+
+
+def test_scheduler_stops_single_token_loop_for_tool_request():
+    scheduler = _scheduler()
+    req = Request("repeat-short", "prompt", SamplingParams(max_tokens=20_000))
+    req.status = RequestStatus.RUNNING
+    req.has_tools = True
+    req.output_token_ids = [42] * 255
+    scheduler.running[req.request_id] = req
+    scheduler.uid_to_request_id[1] = req.request_id
+
+    response = MagicMock(uid=1, token=42, finish_reason=None, logprobs=None)
+    del response.prompt_cache
+    outputs, finished = scheduler._process_batch_responses([response])
+
+    assert finished == {req.request_id}
+    assert outputs[0].finished is True
+    assert scheduler.num_repetition_loop_stops == 1
+
+
+def test_long_diverse_stream_stress_has_no_false_positive():
+    """Exercise more tokens than the production failure with bounded scans."""
+    tokens: list[int] = []
+    for i in range(20_000):
+        # Deterministic, non-periodic-enough agent-like stream containing
+        # punctuation/newline stutters but no exact repeated suffix.
+        tokens.append((i * i + 31 * i + (i % 97) * 13) % 32_749)
+        if len(tokens) % 8 == 0:
+            assert detect_repeated_token_suffix(tokens) is None
+
+
+def test_guard_only_reads_bounded_suffix_under_large_history():
+    class _BoundedSequence:
+        def __init__(self, size: int):
+            self.size = size
+            self.requested_slice = None
+
+        def __len__(self):
+            return self.size
+
+        def __getitem__(self, key):
+            self.requested_slice = key
+            assert isinstance(key, slice)
+            assert key.start == -768 and key.stop is None
+            return list(range(768))
+
+    history = _BoundedSequence(1_000_000)
+    assert detect_repeated_token_suffix(history) is None
+    assert history.requested_slice == slice(-768, None, None)

--- a/vllm_mlx/repetition_guard.py
+++ b/vllm_mlx/repetition_guard.py
@@ -24,20 +24,23 @@ class RepetitionMatch:
 def detect_repeated_token_suffix(
     token_ids: Sequence[int],
     *,
-    min_period_tokens: int = 6,
+    min_period_tokens: int = 1,
     max_period_tokens: int = 128,
     required_repeats: int = 3,
     min_repeated_tokens: int = 72,
+    min_short_period_tokens: int = 256,
     max_window_tokens: int = 768,
 ) -> RepetitionMatch | None:
     """Return an exact periodic-suffix match, or ``None``.
 
     The defaults require at least three adjacent copies and at least 72 repeated
     tokens.  The effective repeat count is adaptive: a 12-token sentence needs
-    six copies, while a 61-token paragraph needs only three.  One-token stutters
-    (punctuation, newlines, or intentional ``ha ha`` output) therefore cannot
-    trip the guard.  Work is bounded to the most recent 768 tokens and callers
-    are expected to invoke it only every few decode steps.
+    six copies, while a 61-token paragraph needs only three.  Periods below six
+    tokens use the higher ``min_short_period_tokens`` threshold, tolerating
+    intentional stutters while still catching the sustained one-token CJK loop
+    that previously ran for 10k+ tokens and exhausted Metal resource handles.
+    Work is bounded to the most recent 768 tokens and callers are expected to
+    invoke it only every few decode steps.
     """
 
     if required_repeats < 2 or min_period_tokens < 1:
@@ -46,17 +49,22 @@ def detect_repeated_token_suffix(
     tokens = token_ids[-max_window_tokens:]
     max_period = min(max_period_tokens, len(tokens) // required_repeats)
     for period in range(min_period_tokens, max_period + 1):
-        repeats = max(required_repeats, ceil(min_repeated_tokens / period))
+        repeated_floor = (
+            min_short_period_tokens if period < 6 else min_repeated_tokens
+        )
+        repeats = max(required_repeats, ceil(repeated_floor / period))
         repeated_tokens = period * repeats
         if repeated_tokens > len(tokens):
             continue
         suffix = tokens[-repeated_tokens:]
         pattern = suffix[:period]
-        # Do not disguise a one-token/newline stutter as a longer period
-        # merely because the same token also repeats in 12-token chunks.
+        # Evaluate a loop at its primitive period.  Otherwise 200 copies of a
+        # single token would masquerade as a 6-token pattern and inherit the
+        # lower long-period threshold.
         if any(
-            period % smaller == 0 and pattern == pattern[:smaller] * (period // smaller)
-            for smaller in range(1, min_period_tokens)
+            period % smaller == 0
+            and pattern == pattern[:smaller] * (period // smaller)
+            for smaller in range(1, period)
         ):
             continue
         if all(

--- a/vllm_mlx/repetition_guard.py
+++ b/vllm_mlx/repetition_guard.py
@@ -49,9 +49,7 @@ def detect_repeated_token_suffix(
     tokens = token_ids[-max_window_tokens:]
     max_period = min(max_period_tokens, len(tokens) // required_repeats)
     for period in range(min_period_tokens, max_period + 1):
-        repeated_floor = (
-            min_short_period_tokens if period < 6 else min_repeated_tokens
-        )
+        repeated_floor = min_short_period_tokens if period < 6 else min_repeated_tokens
         repeats = max(required_repeats, ceil(repeated_floor / period))
         repeated_tokens = period * repeats
         if repeated_tokens > len(tokens):
@@ -62,8 +60,7 @@ def detect_repeated_token_suffix(
         # single token would masquerade as a 6-token pattern and inherit the
         # lower long-period threshold.
         if any(
-            period % smaller == 0
-            and pattern == pattern[:smaller] * (period // smaller)
+            period % smaller == 0 and pattern == pattern[:smaller] * (period // smaller)
             for smaller in range(1, period)
         ):
             continue

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -6356,6 +6356,10 @@ class Scheduler:
             except Exception as e:
                 import traceback
 
+                abort_error = (
+                    "Inference aborted after generation error: "
+                    f"{type(e).__name__}: {e}"
+                )
                 logger.error(
                     f"Error in batch generation step: {e}\n{traceback.format_exc()}"
                 )
@@ -6375,6 +6379,7 @@ class Scheduler:
                             # ``RequestOutput.error`` still see the abort
                             # details. (#v0.6.63 onboarding sweep)
                             finish_reason="length",
+                            error=abort_error,
                         )
                     )
                 output.finished_request_ids = aborted_ids

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -6357,8 +6357,7 @@ class Scheduler:
                 import traceback
 
                 abort_error = (
-                    "Inference aborted after generation error: "
-                    f"{type(e).__name__}: {e}"
+                    f"Inference aborted after generation error: {type(e).__name__}: {e}"
                 )
                 logger.error(
                     f"Error in batch generation step: {e}\n{traceback.format_exc()}"
@@ -6371,14 +6370,11 @@ class Scheduler:
                         RequestOutput(
                             request_id=rid,
                             finished=True,
-                            # OpenAI ChatCompletion only accepts {stop, length,
-                            # tool_calls, content_filter, function_call}. We
-                            # report "length" for aborted requests so spec-
-                            # validating clients (openai-python, pydantic-ai)
-                            # can parse the response; callers reading
-                            # ``RequestOutput.error`` still see the abort
-                            # details. (#v0.6.63 onboarding sweep)
-                            finish_reason="length",
+                            # This is an internal terminal output.  The engine
+                            # raises on ``error`` before route serializers see
+                            # it, so keep its state truthful rather than
+                            # masquerading as a successful token-budget cap.
+                            finish_reason="abort",
                             error=abort_error,
                         )
                     )


### PR DESCRIPTION
## Summary

- detect sustained 1–5 token agent loops with a conservative 256-token floor, closing the DeepSeek V4 `商店`-style degeneration gap
- preserve primitive-period classification so short loops cannot masquerade as longer, lower-threshold patterns
- propagate scheduler-local Metal generation failures through `RequestOutput.error` instead of reporting a normal `length` completion
- add bounded-window and 20k-token stress coverage

## Production reproduction

A 46,475-token DeepSeek V4 Flash Responses request degenerated into a repeated short CJK loop, generated 10,844 completion tokens, then hit `[metal::malloc] Resource limit (499000) exceeded` around scheduler step 12,032. Recovery aborted the request but emitted a terminal output without `error`, so the engine logged `finished normally` and Responses returned success.

## Test plan

- [x] New tests fail before the fix for both the short-token loop and false-normal Metal completion
- [x] `pytest -q tests/test_repetition_guard.py tests/test_metal_error_recovery.py` (16 passed)
- [x] Responses/CLI focused regression set (123 passed)
- [x] Ruff + `git diff --check`
- [x] Full suite: 15,088 passed; 19 unrelated failures (12 require the intentionally stopped localhost:8000 integration service; 7 are pre-existing embedding PR test/signature mismatches)

## Safety

The guard remains restricted to tool-bearing requests. Short periods require 256 repeated tokens, while normal long-period behavior is unchanged. Detection reads only the trailing 768 tokens regardless of total context length.