### PR TITLE
fix(tools): forced tool_choice must not synthesize schema-invalid empty args (#1256)

### DIFF
--- a/tests/test_1256_forced_toolchoice_empty_args.py
+++ b/tests/test_1256_forced_toolchoice_empty_args.py
@@ -1,0 +1,468 @@
+# SPDX-License-Identifier: Apache-2.0
+"""#1256 — forced ``tool_choice`` must never report a successful tool call
+whose synthesised arguments fail the tool's ``required`` schema.
+
+Repro (from the issue): a single ``add`` tool whose schema requires ``a`` and
+``b``, prompt "Call add with a=7 and b=8", sent with ``tool_choice="required"``.
+The text parser surfaces no call, the forced-choice fallback synthesises one
+with empty ``"{}"`` arguments, and the response reports
+``finish_reason="tool_calls"`` — so a client executes a call the server already
+knows is schema-invalid.
+
+Fix (``routes/chat._forced_synth_schema_error`` + call sites in chat.py /
+responses.py): when the synthesised arguments don't provide every ``required``
+property, fail EXPLICITLY — 422 on the non-stream paths, drop-the-synth
+(``finish_reason="stop"``) on the streaming chat surface, ``response.failed``
+on the streaming responses surface — instead of shipping the bad call. A tool
+with NO required fields still synthesises ``"{}"`` as before.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from vllm_mlx.api.models import ChatCompletionRequest
+from vllm_mlx.config import reset_config
+from vllm_mlx.engine.base import GenerationOutput
+from vllm_mlx.routes.chat import _forced_synth_schema_error
+from vllm_mlx.routes.chat import router as chat_router
+
+
+def _tool(name: str, *, required: list[str] | None, props: dict | None = None):
+    """Build a request-tool-shaped object (``.function`` is a dict, matching the
+    pydantic ``Tool`` the routes access via ``t.function.get(...)``)."""
+    schema: dict[str, Any] = {
+        "type": "object",
+        "properties": props or {"a": {"type": "integer"}, "b": {"type": "integer"}},
+    }
+    if required is not None:
+        schema["required"] = required
+    return SimpleNamespace(
+        type="function", function={"name": name, "parameters": schema}
+    )
+
+
+# =====================================================================
+# Unit: _forced_synth_schema_error decision core (shared by all sites)
+# =====================================================================
+
+
+class TestForcedSynthSchemaError:
+    def test_missing_required_all(self):
+        tools = [_tool("add", required=["a", "b"])]
+        err = _forced_synth_schema_error("add", "{}", tools)
+        assert err is not None
+        # The draft-aware validator surfaces the first missing required property.
+        assert "required" in err.lower()
+
+    def test_missing_required_partial(self):
+        tools = [_tool("add", required=["a", "b"])]
+        err = _forced_synth_schema_error("add", '{"a": 7}', tools)
+        assert err is not None
+        assert "b" in err
+        # ``a`` was provided so it should not be reported as missing.
+        assert "'a'" not in err
+
+    def test_all_required_provided_returns_none(self):
+        tools = [_tool("add", required=["a", "b"])]
+        assert _forced_synth_schema_error("add", '{"a": 7, "b": 8}', tools) is None
+
+    def test_no_required_fields_returns_none(self):
+        tools = [_tool("ping", required=None)]
+        assert _forced_synth_schema_error("ping", "{}", tools) is None
+
+    def test_empty_required_list_returns_none(self):
+        tools = [_tool("ping", required=[])]
+        assert _forced_synth_schema_error("ping", "{}", tools) is None
+
+    def test_unknown_tool_name_returns_none(self):
+        tools = [_tool("add", required=["a", "b"])]
+        assert _forced_synth_schema_error("other", "{}", tools) is None
+
+    def test_malformed_arguments_treated_as_empty(self):
+        tools = [_tool("add", required=["a", "b"])]
+        # Non-JSON / non-object args provide nothing → required unmet.
+        assert _forced_synth_schema_error("add", "not json", tools) is not None
+        assert _forced_synth_schema_error("add", "[1, 2]", tools) is not None
+
+    def test_no_tools_returns_none(self):
+        assert _forced_synth_schema_error("add", "{}", None) is None
+        assert _forced_synth_schema_error("add", "{}", []) is None
+
+    def test_dict_shaped_tool_supported(self):
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "add",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"a": {"type": "integer"}},
+                        "required": ["a"],
+                    },
+                },
+            }
+        ]
+        assert _forced_synth_schema_error("add", "{}", tools) is not None
+        assert _forced_synth_schema_error("add", '{"a": 1}', tools) is None
+
+    def _tool_with_schema(self, name, schema):
+        return SimpleNamespace(
+            type="function", function={"name": name, "parameters": schema}
+        )
+
+    def test_composed_required_under_allof_is_caught(self):
+        # Tier 2: `required` nested under allOf has no top-level `required`,
+        # so only full draft-aware validation catches the empty synth.
+        schema = {
+            "type": "object",
+            "properties": {"city": {"type": "string"}},
+            "allOf": [{"required": ["city"]}],
+        }
+        tool = self._tool_with_schema("weather", schema)
+        assert _forced_synth_schema_error("weather", "{}", [tool]) is not None
+        assert _forced_synth_schema_error("weather", '{"city": "SF"}', [tool]) is None
+
+    def test_enum_violation_in_recovered_args_is_caught(self):
+        # Tier 2: no required fields, but a recovered value violates an enum.
+        schema = {
+            "type": "object",
+            "properties": {"unit": {"enum": ["c", "f"]}},
+        }
+        tool = self._tool_with_schema("weather", schema)
+        assert _forced_synth_schema_error("weather", '{"unit": "kelvin"}', [tool])
+        assert _forced_synth_schema_error("weather", '{"unit": "c"}', [tool]) is None
+        # No enum-constrained field present → empty synth is fine.
+        assert _forced_synth_schema_error("weather", "{}", [tool]) is None
+
+    def test_malformed_tool_schema_fails_open(self):
+        # A tool schema our validator can't evaluate must NOT block the synth
+        # (fail-open): return None rather than 422 on our own limitation.
+        bad = self._tool_with_schema("x", {"type": "not-a-real-type"})
+        assert _forced_synth_schema_error("x", "{}", [bad]) is None
+
+    def test_malformed_required_entry_does_not_crash(self):
+        # codex r4 MAJOR: a non-string `required` entry (``[["a"]]``) must not
+        # raise TypeError on the Tier-1 membership test; it fails open.
+        bad = self._tool_with_schema("x", {"type": "object", "required": [["a"]]})
+        assert _forced_synth_schema_error("x", "{}", [bad]) is None
+
+    def test_non_object_instance_validated_against_its_own_schema(self):
+        # codex r2 MAJOR: validate the ACTUAL decoded value, not a coerced {}.
+        # An array instance is valid against an array schema (no false reject)...
+        arr_schema = {"type": "array", "items": {"type": "integer"}}
+        arr_tool = self._tool_with_schema("nums", arr_schema)
+        assert _forced_synth_schema_error("nums", "[1, 2]", [arr_tool]) is None
+        # ...and invalid against an object schema (no false accept).
+        obj_schema = {"type": "object", "properties": {"a": {"type": "integer"}}}
+        obj_tool = self._tool_with_schema("obj", obj_schema)
+        assert _forced_synth_schema_error("obj", "[1, 2]", [obj_tool]) is not None
+        # Literal JSON ``null`` decodes to a real value, not a parse failure —
+        # invalid against an object schema (codex r3 MAJOR).
+        assert _forced_synth_schema_error("obj", "null", [obj_tool]) is not None
+
+
+# =====================================================================
+# Non-stream chat route: repro + control (TestClient + fake engine)
+# =====================================================================
+
+_ADD_TOOL_REQUIRED = [
+    {
+        "type": "function",
+        "function": {
+            "name": "add",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "a": {"type": "integer"},
+                    "b": {"type": "integer"},
+                },
+                "required": ["a", "b"],
+            },
+        },
+    }
+]
+
+_PING_TOOL_NO_REQUIRED = [
+    {
+        "type": "function",
+        "function": {
+            "name": "ping",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    }
+]
+
+
+class _PlainTextEngine:
+    """Fake engine whose model returns plain prose with NO tool-call markers —
+    the text parser extracts nothing, so the forced-choice fallback path runs."""
+
+    preserve_native_tool_format = False
+    is_mllm = False
+    supports_guided_generation = False
+    tokenizer = None
+    supports_tool_calls = True
+
+    def __init__(self, raw: str = "The sum is 15."):
+        self._text = raw
+        self._raw_text = raw
+
+    def build_prompt(self, messages, tools=None, enable_thinking=None):
+        return "PROMPT"
+
+    async def chat(self, messages, **kwargs):
+        return GenerationOutput(
+            text=self._text,
+            raw_text=self._raw_text,
+            prompt_tokens=4,
+            completion_tokens=8,
+            finished=True,
+            finish_reason="stop",
+        )
+
+    async def stream_chat(self, **kwargs):
+        for i, tok in enumerate(self._text.split()):
+            yield _FakeStreamingOutput(
+                (tok + " "), finished=(i == len(self._text.split()) - 1)
+            )
+
+
+def _make_client(engine) -> TestClient:
+    cfg = reset_config()
+    cfg.engine = engine
+    cfg.model_name = "qwen3-0.6b-4bit"
+    cfg.model_registry = None
+    cfg.no_thinking = True
+    cfg.reasoning_parser = None
+    cfg.reasoning_parser_name = None
+    cfg.tool_call_parser = "hermes"
+    app = FastAPI()
+    app.include_router(chat_router)
+    return TestClient(app)
+
+
+def _body(tool_choice, tools) -> dict:
+    return {
+        "model": "qwen3-0.6b-4bit",
+        "messages": [{"role": "user", "content": "Call add with a=7 and b=8."}],
+        "tools": tools,
+        "tool_choice": tool_choice,
+        "max_tokens": 64,
+    }
+
+
+def test_nonstream_required_missing_args_is_422_not_empty_call():
+    """``tool_choice="required"`` + a schema with required fields the model
+    didn't provide → 422, NOT a ``finish_reason="tool_calls"`` with ``{}``."""
+    client = _make_client(_PlainTextEngine())
+    resp = client.post(
+        "/v1/chat/completions", json=_body("required", _ADD_TOOL_REQUIRED)
+    )
+    assert resp.status_code == 422, resp.text
+    assert "1256" in resp.text or "required" in resp.text.lower()
+
+
+def test_nonstream_named_pin_missing_args_is_422():
+    """Named-function ``tool_choice`` with required fields unmet → 422."""
+    client = _make_client(_PlainTextEngine())
+    resp = client.post(
+        "/v1/chat/completions",
+        json=_body(
+            {"type": "function", "function": {"name": "add"}}, _ADD_TOOL_REQUIRED
+        ),
+    )
+    assert resp.status_code == 422, resp.text
+
+
+def test_nonstream_no_required_still_synthesizes_empty_call():
+    """Control: a tool with NO required fields still synthesises a ``{}`` call
+    (the #571/#447 forced-choice guarantee is preserved for that case)."""
+    client = _make_client(_PlainTextEngine())
+    resp = client.post(
+        "/v1/chat/completions", json=_body("required", _PING_TOOL_NO_REQUIRED)
+    )
+    assert resp.status_code == 200, resp.text
+    msg = resp.json()["choices"][0]["message"]
+    tcs = msg.get("tool_calls") or []
+    assert len(tcs) == 1
+    assert tcs[0]["function"]["name"] == "ping"
+    assert tcs[0]["function"]["arguments"] in ("{}", "")
+
+
+# =====================================================================
+# Streaming chat route: repro + control
+# =====================================================================
+
+
+class _FakeStreamingOutput:
+    def __init__(self, new_text: str, finished: bool):
+        self.new_text = new_text
+        self.text = new_text
+        self.finished = finished
+        self.finish_reason = "stop" if finished else None
+        self.channel = None
+        self.prompt_tokens = 10
+        self.completion_tokens = 5
+        self.cached_tokens = 0
+        self.tokens = []
+        self.logprobs = None
+        self.tool_calls = None
+        self.matched_stop = None
+        self.raw_text = new_text
+
+
+class _FakeStreamEngine:
+    def __init__(self, deltas: list[str]):
+        self._deltas = deltas
+        self.tokenizer = None
+        self.is_mllm = False
+        self.supports_tool_calls = True
+        self.supports_guided_generation = False
+
+    async def stream_chat(self, **kwargs):
+        for i, d in enumerate(self._deltas):
+            yield _FakeStreamingOutput(d, finished=(i == len(self._deltas) - 1))
+
+    def build_prompt(self, *args, **kwargs):
+        return "prompt"
+
+
+def _drive_stream(engine, request) -> tuple[list[dict], str | None]:
+    from vllm_mlx.routes.chat import stream_chat_completion
+
+    chunks: list[dict] = []
+
+    async def _run():
+        gen = stream_chat_completion(
+            engine, [{"role": "user", "content": "hi"}], request
+        )
+        async for sse in gen:
+            line = sse.strip()
+            if not line.startswith("data: "):
+                continue
+            body = line[len("data: ") :]
+            if body == "[DONE]":
+                break
+            try:
+                chunks.append(json.loads(body))
+            except json.JSONDecodeError:
+                continue
+
+    asyncio.run(_run())
+    finish = None
+    for c in reversed(chunks):
+        choices = c.get("choices") or []
+        if choices and choices[0].get("finish_reason"):
+            finish = choices[0]["finish_reason"]
+            break
+    return chunks, finish
+
+
+def _stream_request(tool_choice, tools):
+    return ChatCompletionRequest(
+        model="test",
+        messages=[{"role": "user", "content": "Call add with a=7 and b=8."}],
+        tools=tools,
+        tool_choice=tool_choice,
+        stream=True,
+        max_tokens=50,
+        chat_template_kwargs={"enable_thinking": False},
+    )
+
+
+@pytest.fixture()
+def _qwen_hermes_cfg(monkeypatch):
+    from vllm_mlx.config import server_config
+
+    cfg = server_config.get_config()
+    monkeypatch.setattr(cfg, "tool_call_parser", "hermes", raising=False)
+    monkeypatch.setattr(cfg, "reasoning_parser_name", "qwen3", raising=False)
+    monkeypatch.setattr(cfg, "enable_auto_tool_choice", True, raising=False)
+    monkeypatch.setattr(cfg, "gc_control", False, raising=False)
+    yield
+
+
+def _emitted_tool_calls(chunks) -> list[dict]:
+    out: list[dict] = []
+    for c in chunks:
+        for ch in c.get("choices") or []:
+            tcs = (ch.get("delta") or {}).get("tool_calls")
+            if tcs:
+                out.extend(tcs)
+    return out
+
+
+def test_stream_required_missing_args_does_not_fabricate_call(_qwen_hermes_cfg):
+    """Streaming ``required`` + required-field schema the model didn't fill →
+    NO synthesised ``delta.tool_calls`` (headers are out so we can't 422);
+    finish is ``stop``, never ``tool_calls`` with ``{}``."""
+    # Plain prose — the parser detects no call and cannot recover arguments.
+    deltas = ["The ", "sum ", "is ", "15."]
+    chunks, finish = _drive_stream(
+        _FakeStreamEngine(deltas), _stream_request("required", _ADD_TOOL_REQUIRED)
+    )
+    assert _emitted_tool_calls(chunks) == [], (
+        "streaming forced synth must not fabricate a schema-invalid empty call"
+    )
+    assert finish != "tool_calls"
+
+
+def test_stream_no_required_still_synthesizes(_qwen_hermes_cfg):
+    """Control: streaming ``required`` on a NO-required tool still synthesises
+    the guaranteed call (preserves #447)."""
+    deltas = ["The ", "answer", "."]
+    chunks, finish = _drive_stream(
+        _FakeStreamEngine(deltas), _stream_request("required", _PING_TOOL_NO_REQUIRED)
+    )
+    emitted = _emitted_tool_calls(chunks)
+    assert emitted, "no-required forced synth must still fire"
+    assert emitted[0]["function"]["name"] == "ping"
+    assert finish == "tool_calls"
+
+
+# =====================================================================
+# Responses route: _enforce_responses_tool_choice raises on unsatisfiable
+# =====================================================================
+
+
+def test_responses_enforce_raises_on_required_schema_unmet():
+    from fastapi import HTTPException
+
+    from vllm_mlx.api.responses_models import ResponsesRequest
+    from vllm_mlx.routes.responses import _enforce_responses_tool_choice
+
+    openai_req = ChatCompletionRequest(
+        model="test",
+        messages=[{"role": "user", "content": "Call add with a=7 and b=8."}],
+        tools=_ADD_TOOL_REQUIRED,
+        tool_choice="required",
+    )
+    resp_req = ResponsesRequest(model="test", input="x", tool_choice="required")
+
+    with pytest.raises(HTTPException) as ei:
+        _enforce_responses_tool_choice([], resp_req, openai_req)
+    assert ei.value.status_code == 422
+
+
+def test_responses_enforce_synthesizes_when_no_required():
+    from vllm_mlx.api.responses_models import ResponsesRequest
+    from vllm_mlx.routes.responses import _enforce_responses_tool_choice
+
+    openai_req = ChatCompletionRequest(
+        model="test",
+        messages=[{"role": "user", "content": "ping"}],
+        tools=_PING_TOOL_NO_REQUIRED,
+        tool_choice="required",
+    )
+    resp_req = ResponsesRequest(model="test", input="x", tool_choice="required")
+
+    out = _enforce_responses_tool_choice([], resp_req, openai_req)
+    assert out and out[0].function.name == "ping"

--- a/tests/test_447_stream_tool_choice_auto.py
+++ b/tests/test_447_stream_tool_choice_auto.py
@@ -507,7 +507,13 @@ class TestStreamSynthForcedToolChoice:
                         "parameters": {
                             "type": "object",
                             "properties": {"location": {"type": "string"}},
-                            "required": ["location"],
+                            # No ``required`` here on purpose: #1256 makes the
+                            # forced-choice synth REFUSE to fabricate a call
+                            # whose empty ``"{}"`` args miss required fields.
+                            # This #447 test asserts the synth-fires invariant,
+                            # so it uses a schema an empty call satisfies. The
+                            # required-field refusal has its own coverage in
+                            # tests/test_1256_forced_toolchoice_empty_args.py.
                         },
                     },
                 }

--- a/tests/test_responses_bundle.py
+++ b/tests/test_responses_bundle.py
@@ -470,13 +470,18 @@ class TestF6ToolChoiceEnforcement:
     choice, synthesise a stub call so the OpenAI guarantee holds.
     """
 
+    # No ``required`` on purpose: these tests assert the forced-choice SYNTH
+    # fires (and, for streaming, that the synth suppresses the message item).
+    # #1256 makes the synth REFUSE (422) when a required field can't be filled
+    # from an empty synthesised call — a required schema here would turn the
+    # synth-fires assertions into 422s. The required-field refusal is covered
+    # by tests/test_1256_forced_toolchoice_empty_args.py.
     _PING_TOOL = {
         "type": "function",
         "name": "ping",
         "parameters": {
             "type": "object",
             "properties": {"msg": {"type": "string"}},
-            "required": ["msg"],
         },
     }
 

--- a/tests/test_tool_choice_enforcement.py
+++ b/tests/test_tool_choice_enforcement.py
@@ -123,6 +123,14 @@ def _make_client(
     return TestClient(app)
 
 
+# These fixtures deliberately omit ``required``: the tests below exercise
+# wire-leak scrubbing, forced-prefix wiring, and prose preservation when the
+# forced-choice fallback SYNTHESISES a call (mock models return no usable
+# arguments). #1256 makes that synth REFUSE (422 / drop) when a schema declares
+# required fields the empty ``"{}"`` args miss — so a required schema here would
+# turn every synth-fires assertion into a 422 and conflate two orthogonal
+# concerns. The required-field refusal has dedicated coverage in
+# tests/test_1256_forced_toolchoice_empty_args.py.
 _SOLO_TOOL = [
     {
         "type": "function",
@@ -134,7 +142,6 @@ _SOLO_TOOL = [
                     "a": {"type": "integer"},
                     "b": {"type": "integer"},
                 },
-                "required": ["a", "b"],
             },
         },
     },
@@ -152,7 +159,6 @@ _WEATHER_TOOL = [
                     "city": {"type": "string"},
                     "units": {"type": "string", "enum": ["c", "f"]},
                 },
-                "required": ["city"],
             },
         },
     },

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -2762,6 +2762,89 @@ def _synthesize_forced_tool_call(
     )
 
 
+def _forced_synth_schema_error(name: str, arguments: str | None, tools) -> str | None:
+    """Return an error string when a synthesized forced ``tool_choice`` fallback
+    call would violate the target tool's schema, else ``None`` (#1256).
+
+    Forced ``tool_choice`` synthesises a placeholder call — empty ``"{}"`` or
+    arguments recovered from the model's raw text — when the text parser
+    surfaced no call (see ``_synthesize_forced_tool_call``). If the target
+    tool's JSON schema declares ``required`` properties the synthesised
+    arguments don't provide, that call is schema-invalid: a client reading
+    ``finish_reason="tool_calls"`` would ``json.loads`` the arguments and
+    execute a broken call, trusting a guarantee the server cannot make. Callers
+    fail EXPLICITLY on a non-``None`` return — 422 on the non-stream paths;
+    drop-the-synth (the turn finishes with its real terminal reason,
+    ``stop``/``length``, never a fabricated ``tool_calls``) / ``response.failed``
+    on the streaming paths — rather than shipping the bad call.
+
+    Returns ``None`` (synth allowed) when the tool has no constraints the
+    synthesised arguments violate, the schema can't be resolved, or the
+    (possibly recovered) arguments already satisfy the schema.
+    """
+    if not tools:
+        return None
+    schema = None
+    for tool in tools:
+        fn = getattr(tool, "function", None)
+        if not isinstance(fn, dict) and isinstance(tool, dict):
+            fn = tool.get("function")
+        if not isinstance(fn, dict) or fn.get("name") != name:
+            continue
+        schema = fn.get("parameters")
+        break
+    if not isinstance(schema, dict):
+        return None
+    # Validate the ACTUAL decoded value against the schema. Only genuinely
+    # absent or unparseable synthesised arguments fall back to an empty object
+    # (the synth's ``"{}"`` default). Coercing a real decoded value would both
+    # false-reject (``[]`` against an array schema) and false-accept (``[]`` or
+    # literal ``null`` against an object schema) — so a SUCCESSFUL parse always
+    # uses its result verbatim, including a JSON ``null`` (codex r2/r3 MAJOR).
+    if not arguments:
+        instance = {}
+    else:
+        try:
+            instance = json.loads(arguments)
+        except (ValueError, TypeError):
+            instance = {}
+
+    # Validate the synthesised arguments against the tool's parameter schema
+    # with a DRAFT-AWARE ``jsonschema`` validator — the single source of truth,
+    # so the check honours exactly what the schema declares under its own draft:
+    # top-level AND composed (``allOf`` / ``$ref`` / ``if-then``) ``required``,
+    # ``enum`` / ``type`` / ranges, and per-draft quirks (e.g. Draft-7 ignores
+    # keywords sibling to ``$ref``). Hand-rolling a top-level ``required`` check
+    # alongside this would diverge from those semantics and false-reject valid
+    # calls, so we don't. ``check_schema`` runs first so a malformed tool schema
+    # fails OPEN. Fail OPEN on anything we can't evaluate — jsonschema missing
+    # (a hard dep), a malformed schema, an unresolved ``$ref`` — so a synth we
+    # can't judge is allowed through exactly as the model-emitted path is; we
+    # never block a valid call on our validator's limitations. The import shares
+    # this block so ``ValidationError`` is referenced only after it succeeds.
+    try:
+        from jsonschema import ValidationError
+        from jsonschema.validators import validator_for
+
+        validator_cls = validator_for(schema)
+        validator_cls.check_schema(schema)
+    except Exception:
+        return None
+    try:
+        validator_cls(schema).validate(instance)
+    except ValidationError as ve:
+        detail = getattr(ve, "message", str(ve))
+        return (
+            f'tool_choice forced a call to "{name}" but the synthesised '
+            f"arguments do not satisfy its schema: {detail}; refusing to "
+            "synthesize a schema-invalid tool call (#1256). Retry with a more "
+            'concrete user message or use tool_choice="auto".'
+        )
+    except Exception:
+        return None
+    return None
+
+
 def _normalize_ui_tars_tcs_for_chat(tool_calls: list | None) -> list | None:
     """Apply UI-TARS Computer-Use spec keys to a streaming-shaped tool_calls list.
 
@@ -5328,6 +5411,15 @@ async def _create_chat_completion_impl(
                             raw_text=output.raw_text or output.text,
                         )
                     ]
+                    # #1256: never report a successful forced call whose
+                    # synthesised arguments fail the tool's ``required`` schema.
+                    _synth_err = _forced_synth_schema_error(
+                        _solo_name,
+                        tool_calls[0].function.arguments,
+                        request.tools,
+                    )
+                    if _synth_err:
+                        raise HTTPException(status_code=422, detail=_synth_err)
             if not tool_calls:
                 raise HTTPException(
                     status_code=422,
@@ -5396,6 +5488,15 @@ async def _create_chat_completion_impl(
                             raw_text=output.raw_text or output.text,
                         )
                     ]
+                    # #1256: refuse a synthesised pinned call whose arguments
+                    # fail the pinned tool's ``required`` schema.
+                    _synth_err = _forced_synth_schema_error(
+                        _target,
+                        tool_calls[0].function.arguments,
+                        request.tools,
+                    )
+                    if _synth_err:
+                        raise HTTPException(status_code=422, detail=_synth_err)
                 elif not _names and not _target_is_submitted:
                     # Codex R1 BLOCKING (#675): named tool_choice points
                     # at a function that is not in ``request.tools`` —
@@ -6249,38 +6350,60 @@ async def stream_chat_completion(
                 _synth_call = _synthesize_forced_tool_call(
                     _synth_target, raw_text=_raw_text
                 )
-                # Convert the ``ToolCall`` pydantic object into the
-                # streaming-shape dict the terminal-merge path expects
-                # (``{"index","id","type","function":{"name","arguments"}}``)
-                # so it serializes identically to the parser-emitted
-                # deltas. ``index=0`` is the canonical singleton-call
-                # index used elsewhere in the streaming postprocessor.
-                fallback_tool_calls.append(
-                    {
-                        "index": 0,
-                        "id": _synth_call.id,
-                        "type": "function",
-                        "function": {
-                            "name": _synth_call.function.name,
-                            "arguments": _synth_call.function.arguments,
-                        },
-                    }
+                # #1256: on the streaming surface headers are already on the
+                # wire so we cannot 422 mid-flight. If the synthesised call's
+                # arguments fail the target tool's schema, DON'T fabricate it —
+                # leave ``fallback_tool_calls`` empty so the turn finishes with
+                # its REAL terminal reason (``stop`` normally, or ``length`` if
+                # the model truncated — we deliberately don't mask that) instead
+                # of shipping a ``tool_calls`` chunk the client would execute as
+                # a broken call. Mirrors the non-stream 422 in spirit within the
+                # route's "no mid-stream 422" constraint.
+                _synth_err = _forced_synth_schema_error(
+                    _synth_target, _synth_call.function.arguments, request.tools
                 )
-                # Codex r1 NIT #1 (PR #948): bump the wire-truth counter
-                # so the PR #859 "finish_reason=tool_calls ⇒ ≥1 tool_call
-                # delta on the wire" invariant holds — the terminal merge
-                # at chat.py:~4280 IS about to emit a ``delta.tool_calls``
-                # chunk for this synth, so the counter must reflect that
-                # for any downstream gate / log that reads it.
-                processor._tool_calls_emitted_to_wire += 1
-                logger.info(
-                    "[SSE-FORCED-SYNTH-#447] forced tool_choice produced no "
-                    "tool_call deltas; synthesizing terminal call to %r "
-                    "(args recovered from raw text where possible) to honor "
-                    "the OpenAI tool_call-guaranteed contract — mirrors the "
-                    "non-stream synthesis path.",
-                    _synth_target,
-                )
+                if _synth_err:
+                    logger.warning(
+                        "[SSE-FORCED-SYNTH-#1256] refusing to synthesize a "
+                        "schema-invalid forced call to %r: %s; finishing "
+                        "without a fabricated tool_call (real terminal reason "
+                        "preserved).",
+                        _synth_target,
+                        _synth_err,
+                    )
+                else:
+                    # Convert the ``ToolCall`` pydantic object into the
+                    # streaming-shape dict the terminal-merge path expects
+                    # (``{"index","id","type","function":{"name","arguments"}}``)
+                    # so it serializes identically to the parser-emitted
+                    # deltas. ``index=0`` is the canonical singleton-call
+                    # index used elsewhere in the streaming postprocessor.
+                    fallback_tool_calls.append(
+                        {
+                            "index": 0,
+                            "id": _synth_call.id,
+                            "type": "function",
+                            "function": {
+                                "name": _synth_call.function.name,
+                                "arguments": _synth_call.function.arguments,
+                            },
+                        }
+                    )
+                    # Codex r1 NIT #1 (PR #948): bump the wire-truth counter
+                    # so the PR #859 "finish_reason=tool_calls ⇒ ≥1 tool_call
+                    # delta on the wire" invariant holds — the terminal merge
+                    # at chat.py:~4280 IS about to emit a ``delta.tool_calls``
+                    # chunk for this synth, so the counter must reflect that
+                    # for any downstream gate / log that reads it.
+                    processor._tool_calls_emitted_to_wire += 1
+                    logger.info(
+                        "[SSE-FORCED-SYNTH-#447] forced tool_choice produced no "
+                        "tool_call deltas; synthesizing terminal call to %r "
+                        "(args recovered from raw text where possible) to honor "
+                        "the OpenAI tool_call-guaranteed contract — mirrors the "
+                        "non-stream synthesis path.",
+                        _synth_target,
+                    )
 
         # Emit the terminal chunk. Three cases:
         #   (a) Streaming parser already emitted tool_calls during the

--- a/vllm_mlx/routes/responses.py
+++ b/vllm_mlx/routes/responses.py
@@ -196,7 +196,10 @@ def _enforce_responses_tool_choice(
         synthesise a call to X
       * ``auto`` / ``none`` / unrecognised shapes → pass through.
     """
-    from ..routes.chat import _synthesize_forced_tool_call
+    from ..routes.chat import (
+        _forced_synth_schema_error,
+        _synthesize_forced_tool_call,
+    )
 
     tc = responses_request.tool_choice
     if tc is None or not openai_request.tools:
@@ -251,7 +254,26 @@ def _enforce_responses_tool_choice(
                     "guaranteed contract (Yuki F6).",
                     name,
                 )
-                return [_synthesize_forced_tool_call(name)]
+                _synth = _synthesize_forced_tool_call(name)
+                # #1256: fail explicitly rather than return a schema-invalid
+                # synthesised call. On the streaming surface this 422 is caught
+                # and re-emitted as a ``response.failed`` event (see caller).
+                _synth_err = _forced_synth_schema_error(
+                    name, _synth.function.arguments, openai_request.tools
+                )
+                if _synth_err:
+                    raise HTTPException(
+                        status_code=422,
+                        detail={
+                            "error": {
+                                "message": _synth_err,
+                                "type": "invalid_request_error",
+                                "code": "tool_choice_required_unsynthesizable",
+                                "param": "tool_choice",
+                            }
+                        },
+                    )
+                return [_synth]
         # Multi-tool ``required`` with no model call — local inference
         # cannot guess which of N tools the user intended. Chat.py
         # raises 422 in the same situation (~L1891-1902); mirror that
@@ -292,7 +314,25 @@ def _enforce_responses_tool_choice(
                 "(Yuki F6).",
                 target,
             )
-            return [_synthesize_forced_tool_call(target)]
+            _synth = _synthesize_forced_tool_call(target)
+            # #1256: a pinned tool whose schema requires fields can't be
+            # satisfied by an empty synthesised call — fail explicitly.
+            _synth_err = _forced_synth_schema_error(
+                target, _synth.function.arguments, openai_request.tools
+            )
+            if _synth_err:
+                raise HTTPException(
+                    status_code=422,
+                    detail={
+                        "error": {
+                            "message": _synth_err,
+                            "type": "invalid_request_error",
+                            "code": "tool_choice_named_unsynthesizable",
+                            "param": "tool_choice",
+                        }
+                    },
+                )
+            return [_synth]
     return tool_calls
 
 


### PR DESCRIPTION
## Why

Issue #1256 (dpearson2699): under a forced `tool_choice` (`"required"` with a single tool, or the named-function form), when the text parser surfaces no call the routes **synthesise** a fallback call so the OpenAI *tool-call-guaranteed* contract holds (#571 / #447 / Yuki-F6). The synthesised `arguments` default to `"{}"` (or whatever is recoverable from raw text). If the target tool's schema declares `required` properties the synth doesn't provide, the response still reported `finish_reason: "tool_calls"` with `arguments: "{}"` — so a client `json.loads` it and executes a call **the server already knew was schema-invalid**. The `tool_choice: "auto"` control produced the correct `{"a":7,"b":8}`, so this is purely the forced-fallback path.

## What

New `routes/chat._forced_synth_schema_error(name, arguments, tools)` → returns an error string when a `required` property is unmet, else `None`. It checks the **actual (possibly recovered) arguments**, so a valid recovery is still accepted — it only fires when the synth genuinely can't satisfy the schema. Wired into every synthesis site:

| Surface | Site | Behaviour on unmet `required` |
|---|---|---|
| chat non-stream | `required`-solo + named-pin | **HTTP 422** |
| chat streaming | #447 parity synth | **don't fabricate**; finish `stop` (headers already sent → no mid-stream 422, matching the route's existing constraint) |
| responses | `_enforce_responses_tool_choice` (both sites) | **422** — the streaming caller already converts it to a `response.failed` event |

A tool with **no** required fields still synthesises `"{}"` exactly as before — the guarantee is preserved wherever it can be honoured safely.

## Tests

`tests/test_1256_forced_toolchoice_empty_args.py`:
- **helper decision core** (9 cases): all-missing, partial, all-provided, no-required, empty-required, unknown tool, malformed args, no tools, dict-shaped tool.
- **non-stream repro** → 422 for `required`-solo and named-pin; **control** (no-required) → 200 with the synth call.
- **streaming repro** → no fabricated `delta.tool_calls`, `finish != tool_calls`; **control** → synth still fires.
- **responses** `_enforce_responses_tool_choice` → 422 on unmet required; synth on no-required.

Three existing forced-synth fixtures (`test_447` / `test_tool_choice_enforcement` / `test_responses_bundle`) dropped their **incidental** `required` schemas: those tests assert wire-leak-scrubbing / forced-prefix-wiring / prose-preservation / synth-fires behaviour that is orthogonal to arg-schema — a `required` field would now (correctly) turn each into a 422 and conflate two concerns. The required-field refusal is covered by the new file. No test asserted a `required`-driven rejection on those fixtures.

Full forced-tool-choice + responses + streaming test set: **395 passing**. Ruff check + format clean.

Closes #1256

🤖 Generated with [Claude Code](https://claude.com/claude-code)