### PR TITLE
test(embeddings): cover max-length loader options

### DIFF
--- a/tests/test_audio_alias_registry.py
+++ b/tests/test_audio_alias_registry.py
@@ -1098,8 +1098,8 @@ class TestAudioServeHonorsEmbeddingModel:
 
         calls = []
 
-        def _capture(name, lock=False):
-            calls.append((name, lock))
+        def _capture(name, lock=False, **kwargs):
+            calls.append((name, lock, kwargs))
 
         with (
             patch.object(cli, "_run_uvicorn"),
@@ -1120,6 +1120,10 @@ class TestAudioServeHonorsEmbeddingModel:
         # First positional arg is the model id; lock=True mirrors text mode.
         assert calls[0][0] == "mlx-community/all-MiniLM-L6-v2-4bit"
         assert calls[0][1] is True
+        assert calls[0][2] == {
+            "max_length": "auto",
+            "overflow_policy": "truncate",
+        }
 
     def test_audio_mode_without_embedding_does_not_call_loader(self):
         """No-regression: ``serve kokoro`` (no --embedding-model) must

--- a/tests/test_embedding_max_length.py
+++ b/tests/test_embedding_max_length.py
@@ -191,6 +191,7 @@ def test_truncate_policy_counts_each_over_input():
 
 def test_truncate_policy_no_overflow_is_silent(caplog):
     eng = make_engine(model_max=512, overflow_policy="truncate")
+    caplog.clear()
     with caplog.at_level(logging.WARNING):
         eng._enforce_overflow([100, 200, 511, 512])
     assert eng.num_truncations == 0

--- a/tests/test_embeddings_extra_guard.py
+++ b/tests/test_embeddings_extra_guard.py
@@ -608,15 +608,20 @@ class TestEmbeddingModelAliasResolution:
         monkeypatch.setattr("vllm_mlx.embedding.mlx_embeddings_available", lambda: True)
         captured: dict = {}
 
-        def _fake_loader(name, *, lock):
+        def _fake_loader(name, *, lock, **kwargs):
             captured["name"] = name
             captured["lock"] = lock
+            captured["kwargs"] = kwargs
 
         args = SimpleNamespace(embedding_model="embeddinggemma-300m-6bit")
         _load_embedding_model_or_exit(args, _fake_loader)
         # The loader must see the resolved HF path, not the alias.
         assert captured["name"] == "mlx-community/embeddinggemma-300m-6bit", captured
         assert captured["lock"] is True
+        assert captured["kwargs"] == {
+            "max_length": "auto",
+            "overflow_policy": "truncate",
+        }
         # And ``args.embedding_model`` is mutated to the resolved
         # form so downstream banner + config emits the canonical id.
         assert args.embedding_model == "mlx-community/embeddinggemma-300m-6bit"
@@ -632,7 +637,7 @@ class TestEmbeddingModelAliasResolution:
         monkeypatch.setattr("vllm_mlx.embedding.mlx_embeddings_available", lambda: True)
         captured: dict = {}
 
-        def _fake_loader(name, *, lock):
+        def _fake_loader(name, *, lock, **_kwargs):
             captured["name"] = name
 
         args = SimpleNamespace(embedding_model="mlx-community/some-embed-7b")
@@ -667,7 +672,7 @@ class TestEmbeddingModelAliasResolution:
         except ImportError:
             exc_cls = FileNotFoundError
 
-        def _fake_loader(name, *, lock):
+        def _fake_loader(name, *, lock, **_kwargs):
             raise exc_cls(f"Model not found for path or HF repo: {name}.")
 
         args = SimpleNamespace(embedding_model="definitely-not-an-alias-xyz")
@@ -699,7 +704,7 @@ class TestEmbeddingModelAliasResolution:
         class CorruptSafetensorsError(RuntimeError):
             pass
 
-        def _fake_loader(name, *, lock):
+        def _fake_loader(name, *, lock, **_kwargs):
             raise CorruptSafetensorsError("header mismatch on tensor block 3")
 
         args = SimpleNamespace(embedding_model="mlx-community/foo")
@@ -720,7 +725,7 @@ class TestEmbeddingModelAliasResolution:
 
         monkeypatch.setattr("vllm_mlx.embedding.mlx_embeddings_available", lambda: True)
 
-        def _fake_loader(name, *, lock):
+        def _fake_loader(name, *, lock, **_kwargs):
             raise ValueError("config field 'rope_theta' not found in tensor map")
 
         args = SimpleNamespace(embedding_model="mlx-community/foo")


### PR DESCRIPTION
## Summary

- update embedding loader mocks for the newly added max-length and overflow-policy kwargs
- assert default option forwarding in both text and audio serve paths
- clear setup-time informational logs before testing that non-overflow enforcement stays silent

## Context

The recently merged embedding max-length change updated production loader calls but left seven full-suite tests on the old mock signature/log-capture assumptions. This restores a green main baseline without changing runtime behavior.

## Test plan

- [x] `ruff check` and `ruff format` on changed files
- [x] `pytest -q tests/test_audio_alias_registry.py tests/test_embedding_max_length.py tests/test_embeddings_extra_guard.py` (189 passed, 2 skipped)