### PR TITLE
fix(agent): surface repetition guard as failure

### DIFF
--- a/tests/test_repetition_guard.py
+++ b/tests/test_repetition_guard.py
@@ -71,12 +71,14 @@ def _drive_repeating_request(*, has_tools: bool):
     return scheduler, req, outputs[0], finished
 
 
-def test_scheduler_stops_exact_loop_for_tool_request():
+def test_scheduler_fails_exact_loop_for_tool_request():
     scheduler, req, output, finished = _drive_repeating_request(has_tools=True)
     assert finished == {req.request_id}
-    assert req.status == RequestStatus.FINISHED_STOPPED
+    assert req.status == RequestStatus.FINISHED_ABORTED
     assert output.finished is True
-    assert output.finish_reason == "stop"
+    assert output.finish_reason == "abort"
+    assert output.error is not None
+    assert "repetition" in output.error.lower()
     assert scheduler.num_repetition_loop_stops == 1
     assert scheduler.get_stats()["num_repetition_loop_stops"] == 1
 
@@ -89,7 +91,7 @@ def test_scheduler_does_not_change_plain_chat_semantics():
     assert scheduler.num_repetition_loop_stops == 0
 
 
-def test_scheduler_stops_single_token_loop_for_tool_request():
+def test_scheduler_fails_single_token_loop_for_tool_request():
     scheduler = _scheduler()
     req = Request("repeat-short", "prompt", SamplingParams(max_tokens=20_000))
     req.status = RequestStatus.RUNNING
@@ -104,6 +106,8 @@ def test_scheduler_stops_single_token_loop_for_tool_request():
 
     assert finished == {req.request_id}
     assert outputs[0].finished is True
+    assert outputs[0].finish_reason == "abort"
+    assert outputs[0].error is not None
     assert scheduler.num_repetition_loop_stops == 1
 
 

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -5671,6 +5671,7 @@ class Scheduler:
             # tool-bearing requests and exact, long token repetition: ordinary
             # chat/creative completions keep their historical semantics.
             repetition_match = None
+            repetition_error: str | None = None
             if (
                 finish_reason is None
                 and request.has_tools
@@ -5680,7 +5681,13 @@ class Scheduler:
                     request.output_token_ids
                 )
                 if repetition_match is not None:
-                    finish_reason = "stop"
+                    finish_reason = "abort"
+                    repetition_error = (
+                        "Model generation aborted: exact repetition loop "
+                        "detected "
+                        f"(period_tokens={repetition_match.period_tokens}, "
+                        f"repeats={repetition_match.repeats})"
+                    )
                     self.num_repetition_loop_stops += 1
                     logger.warning(
                         "Stopping agent request %s after exact token loop "
@@ -5773,9 +5780,12 @@ class Scheduler:
                     request.set_finished(RequestStatus.FINISHED_STOPPED)
                 elif response.finish_reason == "length":
                     request.set_finished(RequestStatus.FINISHED_LENGTH_CAPPED)
+                elif response.finish_reason == "abort":
+                    request.set_finished(RequestStatus.FINISHED_ABORTED)
 
                 output.finished = True
                 output.finish_reason = response.finish_reason
+                output.error = repetition_error
                 finished_ids.add(request_id)
 
                 if stop_trimmed:

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -5785,7 +5785,8 @@ class Scheduler:
 
                 output.finished = True
                 output.finish_reason = response.finish_reason
-                output.error = repetition_error
+                if repetition_error is not None:
+                    output.error = repetition_error
                 finished_ids.add(request_id)
 
                 if stop_trimmed:


### PR DESCRIPTION
## Summary

- mark exact agent repetition-loop termination as an aborted generation with an explicit error
- prevent Codex and other agents from treating a guard-truncated garbage response as a successful stop
- retain the bounded 256-token short-loop resource protection from #1393

## Real reproduction

While running Codex 0.146.0 against the local DeepSeek V4 Flash wheel on issue #1352, the model emitted `ambigu` repeatedly. Rapid-MLX correctly stopped it at 304 completion tokens (`period_tokens=1`, `repeats=256`) but logged `finished normally`; Codex emitted `turn.completed` and exited successfully without changing any files.

## Test plan

- [x] Updated regression assertions fail before implementation (`FINISHED_STOPPED` / `stop`)
- [x] `ruff check` and `ruff format`
- [x] `pytest -q tests/test_repetition_guard.py tests/test_metal_error_recovery.py tests/test_responses_engine_failure_envelope.py` (34 passed)