### PR TITLE
fix(video): resolve ffmpeg outside process PATH

### DIFF
--- a/tests/test_ltx23_video.py
+++ b/tests/test_ltx23_video.py
@@ -99,6 +99,18 @@ def test_ffmpeg_resolver_honors_executable_override(
     assert _resolve_ffmpeg() == str(override)
 
 
+def test_ffmpeg_resolver_makes_relative_override_absolute(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    override = tmp_path / "custom-ffmpeg"
+    override.write_bytes(b"#!/bin/sh\n")
+    override.chmod(0o755)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("FFMPEG_BINARY", "./custom-ffmpeg")
+
+    assert _resolve_ffmpeg() == str(override)
+
+
 def test_video_remux_uses_resolved_ffmpeg_absolute_path(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_ltx23_video.py
+++ b/tests/test_ltx23_video.py
@@ -111,6 +111,16 @@ def test_ffmpeg_resolver_makes_relative_override_absolute(
     assert _resolve_ffmpeg() == str(override)
 
 
+def test_ffmpeg_resolver_makes_relative_path_result_absolute(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("FFMPEG_BINARY", raising=False)
+    monkeypatch.setattr(video_lane.shutil, "which", lambda _: "bin/ffmpeg")
+
+    assert _resolve_ffmpeg() == str(tmp_path / "bin" / "ffmpeg")
+
+
 def test_video_remux_uses_resolved_ffmpeg_absolute_path(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_ltx23_video.py
+++ b/tests/test_ltx23_video.py
@@ -23,9 +23,9 @@ from vllm_mlx.model_aliases import resolve_profile
 from vllm_mlx.routes import video
 from vllm_mlx.runtime import video_lane
 from vllm_mlx.runtime.video_lane import (
-    _resolve_ffmpeg,
     VideoEngine,
     VideoRuntimeError,
+    _resolve_ffmpeg,
     require_video_runtime_or_exit,
 )
 
@@ -119,6 +119,20 @@ def test_ffmpeg_resolver_makes_relative_path_result_absolute(
     monkeypatch.setattr(video_lane.shutil, "which", lambda _: "bin/ffmpeg")
 
     assert _resolve_ffmpeg() == str(tmp_path / "bin" / "ffmpeg")
+
+
+def test_ffmpeg_resolver_does_not_treat_bare_override_as_local_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    local_binary = tmp_path / "ffmpeg"
+    local_binary.write_bytes(b"#!/bin/sh\n")
+    local_binary.chmod(0o755)
+    safe_binary = "/trusted/bin/ffmpeg"
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("FFMPEG_BINARY", "ffmpeg")
+    monkeypatch.setattr(video_lane.shutil, "which", lambda _: safe_binary)
+
+    assert _resolve_ffmpeg() == safe_binary
 
 
 def test_video_remux_uses_resolved_ffmpeg_absolute_path(

--- a/tests/test_ltx23_video.py
+++ b/tests/test_ltx23_video.py
@@ -23,6 +23,7 @@ from vllm_mlx.model_aliases import resolve_profile
 from vllm_mlx.routes import video
 from vllm_mlx.runtime import video_lane
 from vllm_mlx.runtime.video_lane import (
+    _resolve_ffmpeg,
     VideoEngine,
     VideoRuntimeError,
     require_video_runtime_or_exit,
@@ -56,6 +57,7 @@ def test_video_runtime_preflight_fails_before_download(
 ) -> None:
     monkeypatch.setattr("importlib.util.find_spec", lambda _: None)
     monkeypatch.setattr("shutil.which", lambda _: None)
+    monkeypatch.setattr(video_lane, "_FFMPEG_FALLBACK_PATHS", ())
 
     with pytest.raises(SystemExit) as exc:
         require_video_runtime_or_exit()
@@ -64,6 +66,58 @@ def test_video_runtime_preflight_fails_before_download(
     error = capsys.readouterr().err
     assert "rapid-mlx[video]" in error
     assert "brew install ffmpeg" in error
+
+
+def test_ffmpeg_resolver_uses_homebrew_fallback_when_path_is_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    binary = tmp_path / "ffmpeg-real"
+    binary.write_bytes(b"#!/bin/sh\n")
+    binary.chmod(0o755)
+    homebrew_link = tmp_path / "ffmpeg"
+    homebrew_link.symlink_to(binary)
+    monkeypatch.delenv("FFMPEG_BINARY", raising=False)
+    monkeypatch.setattr(video_lane.shutil, "which", lambda _: None)
+    monkeypatch.setattr(video_lane, "_FFMPEG_FALLBACK_PATHS", (homebrew_link,))
+
+    assert _resolve_ffmpeg() == str(homebrew_link)
+
+
+def test_ffmpeg_resolver_honors_executable_override(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    override = tmp_path / "custom-ffmpeg"
+    override.write_bytes(b"#!/bin/sh\n")
+    override.chmod(0o755)
+    monkeypatch.setenv("FFMPEG_BINARY", str(override))
+    monkeypatch.setattr(
+        video_lane.shutil,
+        "which",
+        lambda _: pytest.fail("PATH lookup must not override FFMPEG_BINARY"),
+    )
+
+    assert _resolve_ffmpeg() == str(override)
+
+
+def test_video_remux_uses_resolved_ffmpeg_absolute_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    output = tmp_path / "result.mp4"
+    output.write_bytes(b"mp4-with-audio")
+    resolved = "/opt/homebrew/bin/ffmpeg"
+    calls: list[list[str]] = []
+    monkeypatch.setattr(video_lane, "_resolve_ffmpeg", lambda: resolved)
+
+    def remux(command, **kwargs) -> None:
+        calls.append(command)
+        Path(command[-1]).write_bytes(b"video-only")
+
+    monkeypatch.setattr(video_lane.subprocess, "run", remux)
+
+    VideoEngine._remove_audio_track(output)
+
+    assert calls[0][0] == resolved
+    assert output.read_bytes() == b"video-only"
 
 
 def test_video_runtime_preflight_reports_python_311_floor(

--- a/vllm_mlx/runtime/video_lane.py
+++ b/vllm_mlx/runtime/video_lane.py
@@ -41,7 +41,7 @@ def _resolve_ffmpeg() -> str | None:
         return None
     resolved = shutil.which("ffmpeg")
     if resolved:
-        return resolved
+        return str(Path(resolved).absolute())
     for candidate in _FFMPEG_FALLBACK_PATHS:
         if candidate.is_file() and os.access(candidate, os.X_OK):
             return str(candidate)

--- a/vllm_mlx/runtime/video_lane.py
+++ b/vllm_mlx/runtime/video_lane.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import importlib.util
+import os
 import shutil
 import stat
 import subprocess
@@ -18,6 +19,31 @@ class VideoRuntimeError(RuntimeError):
 
 
 _PROCESS_GENERATION_LOCK = threading.Lock()
+
+_FFMPEG_FALLBACK_PATHS = (
+    Path("/opt/homebrew/bin/ffmpeg"),
+    Path("/usr/local/bin/ffmpeg"),
+    Path("/usr/bin/ffmpeg"),
+)
+
+
+def _resolve_ffmpeg() -> str | None:
+    """Resolve the ffmpeg binary consistently across the video lane."""
+    override = os.environ.get("FFMPEG_BINARY", "").strip()
+    if override:
+        override_path = Path(override).expanduser()
+        if override_path.is_file() and os.access(override_path, os.X_OK):
+            return str(override_path)
+        if override_path.name == override:
+            return shutil.which(override)
+        return None
+    resolved = shutil.which("ffmpeg")
+    if resolved:
+        return resolved
+    for candidate in _FFMPEG_FALLBACK_PATHS:
+        if candidate.is_file() and os.access(candidate, os.X_OK):
+            return str(candidate)
+    return None
 
 
 def validate_video_request(
@@ -86,7 +112,7 @@ def require_video_runtime_or_exit(model_name: str | None = None) -> None:
         )
         if not mlx_video_available or not wan_available:
             missing.append("the `rapid-mlx[video]` Python extra")
-    if shutil.which("ffmpeg") is None:
+    if _resolve_ffmpeg() is None:
         missing.append("ffmpeg (`brew install ffmpeg`)")
     if missing:
         print(
@@ -191,7 +217,7 @@ class VideoEngine:
                     guidance_scale=(6.0 if guidance_scale is None else guidance_scale),
                 )
             return
-        if shutil.which("ffmpeg") is None:
+        if _resolve_ffmpeg() is None:
             raise VideoRuntimeError(
                 "LTX-2.3 video generation requires ffmpeg. "
                 "Install it with `brew install ffmpeg`."
@@ -256,9 +282,12 @@ class VideoEngine:
                 video_only = Path(temporary.name)
             if video_only is None:  # pragma: no cover - assigned by the context manager
                 raise OSError("could not create a video-only temporary file")
+            ffmpeg = _resolve_ffmpeg()
+            if ffmpeg is None:
+                raise OSError("ffmpeg not found")
             subprocess.run(
                 [
-                    "ffmpeg",
+                    ffmpeg,
                     "-y",
                     "-i",
                     str(output_path),
@@ -311,9 +340,12 @@ class VideoEngine:
         if (requested_width, requested_height) != (width, height):
             cropped = output_path.with_name(f"{output_path.stem}.cropped.mp4")
             try:
+                ffmpeg = _resolve_ffmpeg()
+                if ffmpeg is None:
+                    raise OSError("ffmpeg not found")
                 subprocess.run(
                     [
-                        "ffmpeg",
+                        ffmpeg,
                         "-y",
                         "-i",
                         str(output_path),

--- a/vllm_mlx/runtime/video_lane.py
+++ b/vllm_mlx/runtime/video_lane.py
@@ -31,13 +31,19 @@ def _resolve_ffmpeg() -> str | None:
     """Resolve the ffmpeg binary consistently across the video lane."""
     override = os.environ.get("FFMPEG_BINARY", "").strip()
     if override:
+        has_path_separator = os.sep in override or bool(
+            os.altsep and os.altsep in override
+        )
+        if not has_path_separator:
+            resolved_override = shutil.which(override)
+            return (
+                str(Path(resolved_override).absolute()) if resolved_override else None
+            )
         override_path = Path(override).expanduser()
         if override_path.is_file() and os.access(override_path, os.X_OK):
             # Keep symlinks valid while preventing a relative override such as
             # ``./ffmpeg`` from becoming the PATH-searched argv[0] ``ffmpeg``.
             return str(override_path.absolute())
-        if override_path.name == override:
-            return shutil.which(override)
         return None
     resolved = shutil.which("ffmpeg")
     if resolved:

--- a/vllm_mlx/runtime/video_lane.py
+++ b/vllm_mlx/runtime/video_lane.py
@@ -33,7 +33,9 @@ def _resolve_ffmpeg() -> str | None:
     if override:
         override_path = Path(override).expanduser()
         if override_path.is_file() and os.access(override_path, os.X_OK):
-            return str(override_path)
+            # Keep symlinks valid while preventing a relative override such as
+            # ``./ffmpeg`` from becoming the PATH-searched argv[0] ``ffmpeg``.
+            return str(override_path.absolute())
         if override_path.name == override:
             return shutil.which(override)
         return None


### PR DESCRIPTION
## Summary
- resolve ffmpeg from `FFMPEG_BINARY`, process `PATH`, then common Homebrew/system locations
- validate executable regular files while preserving Homebrew symlink support
- use the resolved absolute binary for video remux and crop subprocesses
- add focused regression tests for PATH-less Homebrew launches, overrides, and subprocess wiring

Closes #1352

## Validation
- `pytest -q tests/test_ltx23_video.py tests/test_wan_video.py tests/test_cogvideox_video.py` — 71 passed
- `pytest -q --ignore=tests/integrations` — 15115 passed, 24 skipped, 18 deselected, 6 xfailed, 1 xpassed
- `git diff --check`