### PR TITLE
chore: bump version to 0.11.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.11.8"
+version = "0.11.9"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Summary

Cut Rapid-MLX v0.11.9 with the fixes accumulated since v0.11.8, including DeepSeek V4 runaway-generation protection and error propagation, forced-tool schema correctness, deferred prefix-cache loading, bounded streaming suppression, embedding memory cleanup, and ffmpeg discovery outside service-manager PATHs.

## Validation

- DeepSeek real Codex/Hermes exercises completed on M3 Ultra
- PR #1397: MERGE-SAFE, 15,103 unit tests, 4×3 stress/integration/bench matrix
- constituent PR CI green