### PR TITLE
fix(mtp): match the Gemma 4 assistant's quantization to its sidecar

### DIFF
--- a/tests/test_mtp_gemma4_sidecar_quant.py
+++ b/tests/test_mtp_gemma4_sidecar_quant.py
@@ -1,0 +1,107 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Sidecar quantization inference for the Gemma 4 assistant drafter.
+
+Deliberately a SEPARATE file from ``test_mtp_gemma4_assistant_inject.py``:
+that module opens with ``pytest.importorskip("mlx.core")``, so everything in it
+is skipped wherever mlx is absent -- including the Linux CI runner. These
+checks are pure shape arithmetic and need no mlx, so keeping them here means
+they actually execute in CI instead of silently skipping.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from vllm_mlx.spec_decode.mtp.gemma4_inject import _infer_sidecar_quantization
+
+# ---------------------------------------------------------------------------
+# 7. Sidecar quantization inference
+#
+# mlx-community publishes the assistants at several widths (the 12B alone has
+# 4bit / 5bit / 6bit / 8bit / bf16 / mxfp4 / mxfp8 / nvfp4). The AssistantModel
+# is built full-precision, so the module must be quantized to match whatever
+# the sidecar actually carries -- read off its tensors, which are ground truth
+# for the packing, rather than from a config.json a checkpoint may omit.
+#
+# Numbers below are the real shapes from
+# ``mlx-community/gemma-4-12B-it-assistant-4bit``: pre_projection is an
+# nn.Linear(2 * 3840, 1024), so full-precision is (1024, 7680) and the 4-bit
+# affine packing is (1024, 7680 * 4 // 32) == (1024, 960) with scales
+# (1024, 7680 // 64) == (1024, 120).
+# ---------------------------------------------------------------------------
+
+
+class _FakeTensor:
+    """Stand-in for an mx.array -- the inference only reads ``.shape``."""
+
+    def __init__(self, *shape):
+        self.shape = shape
+
+
+_FP_OUT, _FP_IN = 1024, 7680
+
+
+def test_infer_sidecar_quantization_recovers_4bit_group64():
+
+    raw = {
+        "pre_projection.weight": _FakeTensor(_FP_OUT, 960),
+        "pre_projection.scales": _FakeTensor(_FP_OUT, 120),
+    }
+    assert _infer_sidecar_quantization(raw, _FP_OUT, _FP_IN) == {
+        "bits": 4,
+        "group_size": 64,
+    }
+
+
+def test_infer_sidecar_quantization_returns_none_for_full_precision():
+    """A bf16 sidecar carries no scales -- the module must stay unquantized."""
+
+    raw = {"pre_projection.weight": _FakeTensor(_FP_OUT, _FP_IN)}
+    assert _infer_sidecar_quantization(raw, _FP_OUT, _FP_IN) is None
+
+
+def test_infer_sidecar_quantization_rejects_truncated_quantized_sidecar():
+    """Packed weight but no scales: loading it into an nn.Linear would crash
+    at the first draft step, so refuse up front rather than later."""
+
+    raw = {"pre_projection.weight": _FakeTensor(_FP_OUT, 960)}
+    with pytest.raises(ValueError, match="truncated quantized sidecar"):
+        _infer_sidecar_quantization(raw, _FP_OUT, _FP_IN)
+
+
+def test_infer_sidecar_quantization_rejects_wrong_out_dim():
+    """A sidecar built for a different assistant size must not be mis-packed
+    into this one just because the key names line up."""
+
+    raw = {
+        "pre_projection.weight": _FakeTensor(999, 960),
+        "pre_projection.scales": _FakeTensor(999, 120),
+    }
+    with pytest.raises(ValueError, match="out-dim mismatch"):
+        _infer_sidecar_quantization(raw, _FP_OUT, _FP_IN)
+
+
+def test_infer_sidecar_quantization_rejects_bits_outside_mlx_affine_set():
+    """Derived bits=7 is not a width MLX affine quantization produces; feeding
+    it to nn.quantize would re-open the mismatch this inference closes."""
+
+    raw = {
+        "pre_projection.weight": _FakeTensor(_FP_OUT, _FP_IN * 7 // 32),
+        "pre_projection.scales": _FakeTensor(_FP_OUT, 120),
+    }
+    with pytest.raises(ValueError, match="outside MLX affine set"):
+        _infer_sidecar_quantization(raw, _FP_OUT, _FP_IN)
+
+
+def test_infer_sidecar_quantization_rejects_non_reproducing_packing():
+    """Divisibility alone is not enough -- the derived params must reproduce
+    the observed shapes exactly, or a coincidental match would pass."""
+
+    # scales imply group_size=64, but the packed weight implies bits=8 while
+    # carrying a column count that bits=8 would not produce for this in-dim.
+    raw = {
+        "pre_projection.weight": _FakeTensor(_FP_OUT, 960),
+        "pre_projection.scales": _FakeTensor(_FP_OUT, 7680),  # group_size 1
+    }
+    with pytest.raises(ValueError):
+        _infer_sidecar_quantization(raw, _FP_OUT, _FP_IN)

--- a/vllm_mlx/spec_decode/mtp/gemma4_inject.py
+++ b/vllm_mlx/spec_decode/mtp/gemma4_inject.py
@@ -394,6 +394,95 @@ def _build_assistant_model_args(
     return args
 
 
+# MLX affine quantization's practical value set — kept identical to
+# ``qwen3_5_inject._MLX_AFFINE_BITS`` / ``_MLX_AFFINE_GROUP_SIZES``. A sidecar
+# whose tensors imply something outside this set is anomalous, and feeding an
+# odd width into ``nn.quantize`` would re-open the mismatch this closes.
+_MLX_AFFINE_BITS = frozenset({2, 3, 4, 5, 6, 8})
+_MLX_AFFINE_GROUP_SIZES = frozenset({32, 64, 128})
+
+
+def _infer_sidecar_quantization(raw: dict, fp_out: int, fp_in: int) -> dict | None:
+    """Recover ``(bits, group_size)`` from the sidecar's own packed tensors.
+
+    Mirrors :func:`vllm_mlx.spec_decode.mtp.qwen3_5_inject._infer_sidecar_fc_quantization`,
+    anchored on ``pre_projection`` instead of ``fc`` because that is the layer
+    whose full-precision shape this consumer knows independently: it is an
+    ``nn.Linear(2 * backbone_hidden, hidden)`` built from Google's config.
+
+    Once MLX affine-quantizes a Linear, the packed ``weight`` has shape
+    ``(out, in * bits // 32)`` and ``scales`` has ``(out, in // group_size)``.
+    Given the full-precision ``(out, in)``, inverting those recovers the pair
+    exactly. The tensors are the ground truth — strictly more reliable than a
+    ``config.json`` proxy the checkpoint may omit or mis-declare.
+
+    Returns ``None`` when the sidecar is full-precision (no ``scales``), so the
+    caller leaves the assistant unquantised.
+
+    Raises:
+        ValueError: the packing cannot be trusted — scales present but shapes
+            inconsistent, derived params outside MLX's affine set, or a
+            truncated sidecar that kept a packed weight but lost its scales.
+    """
+    scales = raw.get("pre_projection.scales")
+    weight = raw.get("pre_projection.weight")
+    if scales is None:
+        # Full-precision sidecar. Guard the truncated-quantized case: a
+        # present ``weight`` must carry the exact full-precision shape,
+        # otherwise a packed tensor would be loaded into an ``nn.Linear``
+        # and crash at the first draft step.
+        if weight is not None:
+            got = tuple(int(d) for d in weight.shape)
+            if got != (fp_out, fp_in):
+                raise ValueError(
+                    f"pre_projection has no scales but weight shape {got} != "
+                    f"full-precision ({fp_out}, {fp_in}) — truncated quantized "
+                    f"sidecar (packed weight, missing scales)"
+                )
+        return None
+    if weight is None:
+        raise ValueError(
+            "pre_projection.scales present but pre_projection.weight missing"
+        )
+
+    w_shape = tuple(int(d) for d in weight.shape)
+    s_shape = tuple(int(d) for d in scales.shape)
+    if len(w_shape) != 2 or len(s_shape) != 2:
+        raise ValueError(
+            f"unexpected pre_projection tensor ranks: weight{w_shape} scales{s_shape}"
+        )
+    if w_shape[0] != fp_out or s_shape[0] != fp_out:
+        raise ValueError(
+            f"pre_projection out-dim mismatch: weight{w_shape} scales{s_shape} "
+            f"vs module out={fp_out}"
+        )
+    packed_cols, scale_cols = w_shape[1], s_shape[1]
+    if packed_cols <= 0 or scale_cols <= 0:
+        raise ValueError(
+            f"non-positive pre_projection packing cols: weight{w_shape} scales{s_shape}"
+        )
+    if fp_in % scale_cols != 0:
+        raise ValueError(f"in-dim {fp_in} not divisible by scales cols {scale_cols}")
+    group_size = fp_in // scale_cols
+    if (32 * packed_cols) % fp_in != 0:
+        raise ValueError(
+            f"packed weight cols {packed_cols} inconsistent with in-dim {fp_in}"
+        )
+    bits = (32 * packed_cols) // fp_in
+    if bits not in _MLX_AFFINE_BITS or group_size not in _MLX_AFFINE_GROUP_SIZES:
+        raise ValueError(
+            f"derived bits={bits} group_size={group_size} outside MLX affine set"
+        )
+    # Cross-check: the packing must reproduce exactly from the derived params,
+    # so a coincidental divisibility match cannot pass.
+    if packed_cols != fp_in * bits // 32 or scale_cols != fp_in // group_size:
+        raise ValueError(
+            f"inconsistent packing: weight{w_shape} scales{s_shape} do not "
+            f"reproduce from bits={bits} group_size={group_size}"
+        )
+    return {"bits": bits, "group_size": group_size}
+
+
 def _build_assistant_model(args: Any, backbone_hidden_size: int):
     """Instantiate the AssistantModel matching Google's safetensors layout.
 
@@ -726,6 +815,67 @@ def inject_mtp_support(
             )
             return False
         from mlx.utils import tree_flatten
+
+        # ── Match the assistant's quantization to the sidecar ────────────
+        # The module is built full-precision. mlx-community publishes the
+        # assistants at several widths (12B has 4bit / 5bit / 6bit / 8bit /
+        # bf16 / mxfp4 / mxfp8 / nvfp4), so a quantized one loaded into an
+        # FP module fails the shape check below — e.g. the 4-bit 12B assistant
+        # ships pre_projection.weight (1024, 960) against (1024, 7680)
+        # expected, 960 being 7680 * 4 // 32. Read the packing off the
+        # sidecar's own tensors and quantize to match, exactly as
+        # ``qwen3_5_inject`` does for the Qwen MTP head.
+        try:
+            fp_out, fp_in = (int(d) for d in assistant.pre_projection.weight.shape)
+        except Exception as exc:
+            logger.warning(
+                "[mtp.inject.gemma4] could not read pre_projection dims off the "
+                "freshly-built assistant (%s); refusing to guess the sidecar's "
+                "packing.",
+                exc,
+            )
+            return False
+        try:
+            sidecar_quant = _infer_sidecar_quantization(raw, fp_out, fp_in)
+        except ValueError as exc:
+            logger.warning(
+                "[mtp.inject.gemma4] sidecar %s has an inconsistent or "
+                "unsupported pre_projection packing (%s). Refusing to inject "
+                "rather than mis-pack the drafter.",
+                weights_file,
+                exc,
+            )
+            return False
+        if sidecar_quant is not None:
+            import mlx.nn as nn
+
+            # ``nn.quantize`` can itself raise — e.g. a layer narrower than
+            # the group size. That must land as a clean refusal, not escape
+            # and abort a request at the first draft step.
+            try:
+                nn.quantize(
+                    assistant,
+                    group_size=sidecar_quant["group_size"],
+                    bits=sidecar_quant["bits"],
+                    class_predicate=lambda _p, m: hasattr(m, "to_quantized"),
+                )
+            except Exception as exc:
+                logger.warning(
+                    "[mtp.inject.gemma4] sidecar %s implies %d-bit / "
+                    "group_size=%d, but quantizing the assistant to match "
+                    "failed (%s). Refusing to inject.",
+                    weights_file,
+                    sidecar_quant["bits"],
+                    sidecar_quant["group_size"],
+                    exc,
+                )
+                return False
+            logger.info(
+                "[mtp.inject.gemma4] quantized assistant to match sidecar: "
+                "%d-bit, group_size=%d.",
+                sidecar_quant["bits"],
+                sidecar_quant["group_size"],
+            )
 
         expected_pairs = list(tree_flatten(assistant.parameters()))
         expected_shapes = {k: tuple(v.shape) for k, v in expected_pairs}


### PR DESCRIPTION
fix(mtp): match the Gemma 4 assistant's quantization to its sidecar

## Why

`gemma4_inject` builds the AssistantModel full-precision and loads the sidecar
straight into it. mlx-community publishes the assistants at several widths
(the 12B alone has 4bit / 5bit / 6bit / 8bit / bf16 / mxfp4 / mxfp8 / nvfp4),
so every quantized one is rejected by the shape check:

    [mtp.inject.gemma4] 23 tensor(s) ... have shapes incompatible with the
    AssistantModel. First 4: [('pre_projection.weight', (1024, 960),
    (1024, 7680)), ...]. Refusing to inject.

960 == 7680 * 4 // 32 — the sidecar is 4-bit affine-packed and the module was
never quantized to match. `qwen3_5_inject` already solves exactly this for the
Qwen MTP head by reading `(bits, group_size)` off the sidecar's own tensors;
Gemma 4 simply never got the equivalent step.

Only `mlx-community/gemma-4-12B-it-assistant-bf16` and the four other
`*-assistant-bf16` repos could be paired at all, which is also why the gap went
unnoticed: the bf16 path happens to match an unquantized module by accident.

## What

`_infer_sidecar_quantization()` mirrors the Qwen helper, anchored on
`pre_projection` because that is the layer whose full-precision `(out, in)`
this consumer knows independently from Google's config. The sidecar tensors are
the ground truth for packing — more reliable than a `config.json` proxy a
checkpoint may omit or mis-declare. Inference is cross-checked (the derived
params must reproduce the observed shapes exactly, so a coincidental
divisibility match cannot pass) and constrained to MLX's affine set. Both the
inference and the `nn.quantize` call fail closed, since an escape here would
abort a request at the first draft step rather than fall back cleanly.

## Verified

Unit, on the real 12B 4-bit shapes: `(1024, 960)` + scales `(1024, 120)` against
full-precision `(1024, 7680)` derives `bits=4, group_size=64`. bf16 returns
None. Three malformed cases are refused: truncated-quantized (packed weight,
scales dropped), out-dim mismatch, and a derived `bits=7`.

Real weights on `mlx-community/gemma-4-12B-it-4bit` + `-assistant-4bit`
(M2 Pro): inject now succeeds where it previously refused.

## What this does NOT fix

Gemma 4 stays unregistered in `detect` / `dispatch`. With the 4-bit assistant
now loading, it fails end-to-end exactly as the bf16 one does: draft acceptance
0.0 on 3 of 4 prompts, greedy-lossless violated on 2 of 4, throughput 0.52x.
Acceptance 0.0 means nothing was accepted, so every token came from the
backbone and the output should have matched the baseline — so this is the
backbone path under this wiring, not drafter accuracy. One divergence is a
transposed pair (base `[236761, 236779, ...]` against mtp
`[236779, 236761, ...]`), which points at emission order rather than wrong
tokens.

Caveat on that second defect: the harness feeds raw prompts, and Gemma's
baseline output is visibly degenerate under them (one token repeating), so the
lossless comparison there wants a re-run with the chat template applied before
anyone treats it as fully characterised. The acceptance-0.0 result stands on
its own regardless — a drafter that cannot predict a repeating token is broken.

This PR is scoped to the quantization gap so that investigation starts from a
sidecar that at least loads at its published width.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>


---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
