### PR TITLE
fix(deps): cap mlx/mlx-lm/mlx-vlm + gate bound bumps on a coherence sweep (#1248)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,43 @@ jobs:
           pip install pydantic transformers jsonschema openai-harmony
           python scripts/microbench_parsers.py
 
+  mlx-bound-guard:
+    # #1248 — a change to an mlx / mlx-lm / mlx-vlm version bound can re-open the
+    # upstream-heuristic break that shipped garbage (#1234). It must be gated on a
+    # full-family output-coherence sweep (#1247), attested via the
+    # `mlx-coherence-swept` label or a `Coherence-Sweep:` PR-body trailer. No-op
+    # unless a guarded specifier actually changes. PR-only: it diffs the head
+    # against the PR base, which a push-to-main event has no meaningful analogue
+    # for (origin/main == the pushed commit).
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+        with:
+          python-version: "3.12"
+
+      - name: Install packaging
+        run: |
+          python -m pip install --upgrade pip
+          pip install packaging
+
+      - name: Fetch base branch
+        env:
+          BASE_BRANCH: ${{ github.base_ref || 'main' }}
+        run: git fetch --no-tags origin "${BASE_BRANCH}:refs/remotes/origin/${BASE_BRANCH}"
+
+      - name: Guard mlx/mlx-lm/mlx-vlm version bounds
+        env:
+          MLX_BOUND_BASE_REF: origin/${{ github.base_ref || 'main' }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+        run: python scripts/check_mlx_bound_move.py
+
   type-check:
     runs-on: ubuntu-latest
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,8 +41,17 @@ dependencies = [
     # default_stream / new_stream / new_thread_local_stream) are materialised
     # on T2 via np.array(arr). The shim adopts the worker's process-wide
     # default — the only path that round-trips cleanly across threads.
-    "mlx>=0.31.2",
-    "mlx-lm>=0.31.3",  # 0.31.1+ required for presence_penalty/frequency_penalty kwargs on make_logits_processors (#512); 0.31.3 added thread-local generation_stream but cross-thread eval is still broken (see shim sites).
+    # Upper caps <0.32 (release-blocker, #1248): mlx / mlx-lm are floor-only
+    # pinned but move fast, so a bare ``pip install rapid-mlx`` silently resolves
+    # to a NEWER, untested minor (mlx 0.32.0 is already published). The Qwen3.6
+    # garbage incident (#1234) was caused by a heuristic change INSIDE
+    # ``mlx_lm.models.qwen3_5.sanitize`` under an existing model — an upstream
+    # minor we never validated. Cap to the validated 0.31.x line (mlx 0.31.2 /
+    # mlx-lm 0.31.3); raising either bound is a gated coherence event — see
+    # scripts/check_mlx_bound_move.py and #1247. Patch releases within 0.31.x
+    # stay allowed.
+    "mlx>=0.31.2,<0.32",
+    "mlx-lm>=0.31.3,<0.32",  # 0.31.1+ required for presence_penalty/frequency_penalty kwargs on make_logits_processors (#512); 0.31.3 added thread-local generation_stream but cross-thread eval is still broken (see shim sites). Upper cap <0.32 (#1248).
     # mlx-vlm is opt-in via [vision] extras (saves ~322 MB for text-only users)
     #
     # Upper cap <5.13 (release-blocker): mlx-lm and mlx-vlm both float
@@ -141,7 +150,7 @@ vision = [
     # resolves a fresh install straight to the broken build. All five extras
     # that pull mlx-vlm carry this exclusion — enforced by
     # tests/test_vision_extra_install.py so a new extra can't silently regress.
-    "mlx-vlm>=0.6.3,!=0.6.4",
+    "mlx-vlm>=0.6.3,!=0.6.4,<0.7",  # upper cap <0.7 (#1248): pin to validated 0.6.x line; raising it is a gated coherence event (scripts/check_mlx_bound_move.py).
     "opencv-python>=4.8.0",
     "torch>=2.3.0",
     "torchvision>=0.18.0",
@@ -155,7 +164,7 @@ vision = [
 # the vision extras do. Only enable if you serve a DFlash-eligible alias
 # (e.g. qwen3.5-27b-8bit) with --speculative-config '{"method":"dflash"}'.
 dflash = [
-    "mlx-vlm>=0.6.3,!=0.6.4",
+    "mlx-vlm>=0.6.3,!=0.6.4,<0.7",  # upper cap <0.7 (#1248): pin to validated 0.6.x line; raising it is a gated coherence event (scripts/check_mlx_bound_move.py).
 ]
 # MTP (Multi-Token Prediction) speculative decoding — Gemma 4 external
 # assistant path via ``--speculative-config '{"method":"mtp","model":"<path>"}'``.
@@ -205,7 +214,7 @@ chat = [
 # pip install .[all] and editable installs.
 all = [
     # vision
-    "mlx-vlm>=0.6.3,!=0.6.4",
+    "mlx-vlm>=0.6.3,!=0.6.4,<0.7",  # upper cap <0.7 (#1248): pin to validated 0.6.x line; raising it is a gated coherence event (scripts/check_mlx_bound_move.py).
     "opencv-python>=4.8.0",
     "torch>=2.3.0",
     "torchvision>=0.18.0",
@@ -258,7 +267,7 @@ test = [
     # ``pytest tests/`` without hand-installed local extras.
     "aiohttp>=3.9.0",
     "pillow>=10.0.0",
-    "mlx-vlm>=0.6.3,!=0.6.4; platform_system == 'Darwin'",
+    "mlx-vlm>=0.6.3,!=0.6.4,<0.7; platform_system == 'Darwin'",  # upper cap <0.7 (#1248): pin to validated 0.6.x line; raising it is a gated coherence event.
     "mlx-audio>=0.2.9,<0.4.4; platform_system == 'Darwin'",
     # Powers the property-based invariant suite in tests/property/ — encodes
     # numeric/validation invariants over the whole input space (e.g. the
@@ -288,7 +297,7 @@ dev = [
     'tomli>=2.0.1; python_version < "3.11"',
     "aiohttp>=3.9.0",
     "pillow>=10.0.0",
-    "mlx-vlm>=0.6.3,!=0.6.4; platform_system == 'Darwin'",
+    "mlx-vlm>=0.6.3,!=0.6.4,<0.7; platform_system == 'Darwin'",  # upper cap <0.7 (#1248): pin to validated 0.6.x line; raising it is a gated coherence event.
     "mlx-audio>=0.2.9,<0.4.4; platform_system == 'Darwin'",
     # Mirror of the [test] entry — keep `dev` a strict superset of `test`
     # (enforced by tests/test_pr_validate_test_env.py).

--- a/scripts/check_mlx_bound_move.py
+++ b/scripts/check_mlx_bound_move.py
@@ -1,0 +1,288 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Gate: a PR that changes an ``mlx`` / ``mlx-lm`` / ``mlx-vlm`` version bound must
+carry proof that a full-family output-coherence sweep was run (#1247, #1248).
+
+Why (incident-grounded): the Qwen3.6 garbage (#1234) came from a heuristic change
+*inside* ``mlx_lm`` under an existing model, not from our code. Our ``mlx*`` deps
+are now capped (pyproject.toml), so a plain ``pip install rapid-mlx`` resolves to
+the validated minor. Touching one of those pins — raising a cap, dropping an
+exclusion, moving the floor — can re-open the exact door that shipped garbage, so
+it must be a deliberate, evidenced event, not a silent diff.
+
+Design — fail CLOSED, coarse but sound. Version-set math over PEP 440 (epochs,
+pre/post/dev/local, ``===``, wildcards, ``~=``) is subtle enough that a "flag only
+loosening" classifier is easy to get subtly wrong in the unsafe direction. So this
+gate flags ANY change to a guarded package's normalized version specifier and
+requires an explicit human attestation. Tightening / adding a cap is thus also
+gated, but its attestation is a one-line note — cheap, and every change to these
+coherence-critical pins deserves a conscious sign-off. (Reordering a specifier or
+changing only an environment marker is NOT a change — the specifier normalizes.)
+
+This runs on every PR (see .github/workflows/ci.yml). No-op unless a guarded
+specifier actually changes. When it does, it fails UNLESS the PR attests via:
+
+  * a label ``mlx-coherence-swept`` on the PR, or
+  * a ``Coherence-Sweep: <url-or-note>`` trailer line in the PR body.
+
+Until the always-on coherence gate (#1247) exists to attach a machine-verified
+artifact, the attestation is the human checkpoint. When #1247 lands, tighten the
+``_attestation_ok`` branch to verify the real artifact instead of trusting a
+label/trailer.
+
+Pure-logic core (``extract_mlx_bounds`` / ``detect_bound_changes``) is unit-tested
+in tests/test_mlx_bound_guard.py — no network, no GPU.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+
+import tomllib
+from packaging.requirements import Requirement
+from packaging.utils import canonicalize_name
+
+# The packages whose version bounds are coherence-sensitive. ``mlx`` and
+# ``mlx-lm`` drive text decode; ``mlx-vlm`` drives vision + spec-decode. These
+# are already PEP 503-canonical; ``canonicalize_name`` is applied to parsed
+# requirement names so alternate spellings (``mlx_vlm``, ``MLX.VLM``) still match.
+GUARDED_PACKAGES = frozenset({"mlx", "mlx-lm", "mlx-vlm"})
+
+# Leading distribution-name token of a requirement string, used to classify a
+# requirement that ``packaging`` could not parse (so a malformed *guarded* pin
+# still fails closed).
+_NAME_PREFIX = re.compile(r"^\s*([A-Za-z0-9._-]+)")
+
+ATTEST_LABEL = "mlx-coherence-swept"
+ATTEST_TRAILER = "Coherence-Sweep:"
+
+
+class MalformedGuardedRequirementError(ValueError):
+    """A guarded (``mlx*``) dependency string that packaging cannot parse."""
+
+
+def _iter_declared_dependencies(data: dict):
+    """Yield every requirement string declared anywhere pip/build reads them.
+
+    Covers ``project.dependencies``, every ``project.optional-dependencies``
+    group, PEP 735 ``dependency-groups`` (string entries only — ``include-group``
+    tables carry no requirement), and ``build-system.requires``. Parsing real
+    TOML tables means unrelated quoted strings — notably ``keywords = ["mlx"]`` —
+    are never mistaken for a dependency.
+    """
+    project = data.get("project", {})
+    if isinstance(project, dict):
+        deps = project.get("dependencies", [])
+        if isinstance(deps, list):
+            yield from (d for d in deps if isinstance(d, str))
+        optional = project.get("optional-dependencies", {})
+        if isinstance(optional, dict):
+            for group in optional.values():
+                if isinstance(group, list):
+                    yield from (d for d in group if isinstance(d, str))
+
+    groups = data.get("dependency-groups", {})
+    if isinstance(groups, dict):
+        for group in groups.values():
+            if isinstance(group, list):
+                yield from (d for d in group if isinstance(d, str))
+
+    build_system = data.get("build-system", {})
+    if isinstance(build_system, dict):
+        requires = build_system.get("requires", [])
+        if isinstance(requires, list):
+            yield from (r for r in requires if isinstance(r, str))
+
+
+def extract_mlx_bounds(
+    pyproject_text: str, *, strict: bool = False
+) -> dict[str, set[str]]:
+    """Map each guarded package to the SET of version specifiers it is pinned at.
+
+    A package can appear in several dependency groups (core / [vision] / [spec] /
+    audio), each potentially with its own specifier; we collect the distinct
+    normalized specifier strings so a change in ANY occurrence is caught.
+    Environment markers (``; platform_system == 'Darwin'``) are ignored — only the
+    version specifier is coherence-relevant.
+
+    ``strict`` (used for the PR-head pyproject) raises rather than silently
+    skipping when the TOML is malformed or a *guarded* requirement won't parse, so
+    a syntax slip can't quietly disable the gate. Non-guarded parse failures are
+    always ignored — other CI gates own those.
+    """
+    try:
+        data = tomllib.loads(pyproject_text)
+    except tomllib.TOMLDecodeError:
+        if strict:
+            raise
+        return {pkg: set() for pkg in GUARDED_PACKAGES}
+
+    bounds: dict[str, set[str]] = {pkg: set() for pkg in GUARDED_PACKAGES}
+    for dep in _iter_declared_dependencies(data):
+        try:
+            req = Requirement(dep)
+        except Exception as exc:
+            # Couldn't parse — if the leading name token canonicalizes to a
+            # guarded package, fail closed rather than let a syntax slip hide it.
+            if strict:
+                match = _NAME_PREFIX.match(dep)
+                if match and canonicalize_name(match.group(1)) in GUARDED_PACKAGES:
+                    raise MalformedGuardedRequirementError(dep) from exc
+            continue
+        # PEP 503 canonicalization so alternate spellings (``mlx_vlm``,
+        # ``MLX.VLM``) map to the same guarded key and can't slip past.
+        name = canonicalize_name(req.name)
+        if name in GUARDED_PACKAGES:
+            # ``str(SpecifierSet)`` normalizes ordering, so ">=0.6.3,<0.7" and
+            # "<0.7,>=0.6.3" compare equal — only real specifier changes flag.
+            bounds[name].add(str(req.specifier))
+    return bounds
+
+
+def detect_bound_changes(old_text: str, new_text: str) -> list[str]:
+    """Descriptions of every guarded-package version-specifier change.
+
+    Fail-closed: ANY change to a guarded package's normalized specifier set is
+    reported (see module docstring for why we don't try to classify loosening vs
+    tightening). Reordering / marker-only edits normalize away and are silent.
+    """
+    old = extract_mlx_bounds(old_text)
+    new = extract_mlx_bounds(new_text, strict=True)
+    changes: list[str] = []
+    for pkg in sorted(GUARDED_PACKAGES):
+        if old[pkg] == new[pkg]:
+            continue
+        before = ", ".join(sorted(old[pkg])) or "(absent)"
+        after = ", ".join(sorted(new[pkg])) or "(absent)"
+        changes.append(f"{pkg}: {before}  ->  {after}")
+    return changes
+
+
+def _attestation_ok(pr_body: str, pr_labels: str, forced: bool) -> bool:
+    """True if the PR carries a coherence-sweep attestation (label or trailer)."""
+    if forced:
+        return True
+    labels = {label.strip().lower() for label in pr_labels.split(",") if label.strip()}
+    if ATTEST_LABEL in labels:
+        return True
+    for line in pr_body.splitlines():
+        if line.strip().lower().startswith(ATTEST_TRAILER.lower()):
+            # Require a non-empty note after the trailer (a URL or run id).
+            note = line.split(":", 1)[1].strip()
+            if note:
+                return True
+    return False
+
+
+def _git_show(ref_path: str) -> str | None:
+    """Return the file content at ``ref_path`` (``ref:path``), or None if absent."""
+    try:
+        return subprocess.check_output(
+            ["git", "show", ref_path], text=True, stderr=subprocess.DEVNULL
+        )
+    except subprocess.CalledProcessError:
+        return None
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--base-ref",
+        default=os.environ.get("MLX_BOUND_BASE_REF", "origin/main"),
+        help="Git ref of the base branch to diff pyproject.toml against.",
+    )
+    parser.add_argument(
+        "--pyproject",
+        default="pyproject.toml",
+        help="Path to the working-tree pyproject.toml (the PR head version).",
+    )
+    args = parser.parse_args(argv)
+
+    # Fail CLOSED on infrastructure problems: a required merge gate must never be
+    # silently disabled by a ref-plumbing mistake or a syntax slip.
+    old_text = _git_show(f"{args.base_ref}:{args.pyproject}")
+    if old_text is None:
+        print(
+            f"[mlx-bound-guard] ERROR: cannot read base {args.base_ref}:{args.pyproject}. "
+            "The gate needs the base branch fetched (git fetch origin <base>). "
+            "Failing closed.",
+            file=sys.stderr,
+        )
+        return 1
+
+    try:
+        with open(args.pyproject, encoding="utf-8") as fh:
+            new_text = fh.read()
+    except OSError as exc:
+        print(
+            f"[mlx-bound-guard] ERROR: cannot read {args.pyproject}: {exc}. "
+            "Failing closed.",
+            file=sys.stderr,
+        )
+        return 1
+
+    try:
+        changes = detect_bound_changes(old_text, new_text)
+    except tomllib.TOMLDecodeError as exc:
+        print(
+            f"[mlx-bound-guard] ERROR: {args.pyproject} is not valid TOML ({exc}). "
+            "Failing closed.",
+            file=sys.stderr,
+        )
+        return 1
+    except MalformedGuardedRequirementError as exc:
+        print(
+            f"[mlx-bound-guard] ERROR: unparseable mlx* requirement {str(exc)!r} in "
+            f"{args.pyproject}. Failing closed.",
+            file=sys.stderr,
+        )
+        return 1
+
+    if not changes:
+        print("[mlx-bound-guard] no mlx/mlx-lm/mlx-vlm bound change — OK.")
+        return 0
+
+    forced = os.environ.get("MLX_BOUND_ATTESTED", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+    }
+    attested = _attestation_ok(
+        os.environ.get("PR_BODY", ""),
+        os.environ.get("PR_LABELS", ""),
+        forced,
+    )
+
+    print("[mlx-bound-guard] detected mlx* version-bound change(s):")
+    for change in changes:
+        print(f"    {change}")
+
+    if attested:
+        print(
+            "[mlx-bound-guard] coherence-sweep attestation present "
+            f"(label '{ATTEST_LABEL}' or '{ATTEST_TRAILER}' trailer) — allowed."
+        )
+        return 0
+
+    print(
+        "\n[mlx-bound-guard] BLOCKED (#1248): a change to an mlx/mlx-lm/mlx-vlm "
+        "version pin can re-open the upstream-heuristic break that shipped garbage "
+        "(#1234).\n"
+        "If this LOOSENS a bound (raise/remove a cap, drop an != exclusion, move "
+        "the floor), first run the full-family output-coherence sweep (#1247) "
+        "across ALL model families — the break lands under EXISTING models, not "
+        "only new ones. If it only tightens / adds a cap, a one-line note is "
+        "enough. Attest either way by:\n"
+        f"  * adding the '{ATTEST_LABEL}' label to this PR, or\n"
+        f"  * adding a '{ATTEST_TRAILER} <sweep run url / summary / note>' line to "
+        "the PR body.\n",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_mlx_bound_guard.py
+++ b/tests/test_mlx_bound_guard.py
@@ -1,0 +1,222 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the mlx/mlx-lm/mlx-vlm version-bound guard (#1248).
+
+Pure-logic — no network, no GPU, no git. Covers dependency extraction (across
+every pyproject source), the fail-closed change detector, strict-mode failure,
+and the attestation check.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+# Load the script directly (scripts/ is not an importable package).
+_SPEC = importlib.util.spec_from_file_location(
+    "check_mlx_bound_move",
+    Path(__file__).resolve().parent.parent / "scripts" / "check_mlx_bound_move.py",
+)
+guard = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(guard)
+
+
+_CORE = """\
+[project]
+name = "rapid-mlx"
+# The 'mlx' keyword must NOT be mistaken for a dependency (regression guard).
+keywords = ["llm", "mlx", "apple-silicon"]
+dependencies = [
+    "numpy>=1.0",
+    "mlx>=0.31.2,<0.32",
+    "mlx-lm>=0.31.3,<0.32",
+    "transformers>=5.0.0,<5.13",
+]
+
+[project.optional-dependencies]
+vision = [
+    "mlx-vlm>=0.6.3,!=0.6.4,<0.7",
+    "mlx-vlm>=0.6.3,!=0.6.4,<0.7; platform_system == 'Darwin'",
+]
+"""
+
+
+def _pp(*deps: str) -> str:
+    """Wrap dependency strings in a minimal valid pyproject for extraction tests."""
+    body = ",\n    ".join(f'"{d}"' for d in deps)
+    return f'[project]\nname = "x"\ndependencies = [\n    {body},\n]\n'
+
+
+class TestExtractMlxBounds:
+    def test_extracts_each_guarded_package_distinctly(self):
+        from packaging.specifiers import SpecifierSet
+
+        bounds = guard.extract_mlx_bounds(_CORE)
+        # Compare semantically — extract_mlx_bounds stores the normalized
+        # ``str(SpecifierSet)`` (order-independent), not the source order.
+        assert {SpecifierSet(s) for s in bounds["mlx"]} == {
+            SpecifierSet(">=0.31.2,<0.32")
+        }
+        assert {SpecifierSet(s) for s in bounds["mlx-lm"]} == {
+            SpecifierSet(">=0.31.3,<0.32")
+        }
+        # Both mlx-vlm entries share the same specifier (marker ignored) -> one.
+        assert {SpecifierSet(s) for s in bounds["mlx-vlm"]} == {
+            SpecifierSet(">=0.6.3,!=0.6.4,<0.7")
+        }
+
+    def test_ignores_non_mlx_and_prefix_lookalikes(self):
+        text = _pp("mlx-audio>=0.2.9,<0.4.4", "transformers<5.13", "mlxfoo==1.0")
+        bounds = guard.extract_mlx_bounds(text)
+        assert bounds["mlx"] == set()
+        assert bounds["mlx-lm"] == set()
+        assert bounds["mlx-vlm"] == set()
+
+    def test_keyword_mlx_is_not_a_dependency(self):
+        # The ``keywords = ["mlx", ...]`` entry in _CORE must be ignored.
+        assert "" not in guard.extract_mlx_bounds(_CORE)["mlx"]
+
+    def test_mlx_does_not_swallow_mlx_lm_or_mlx_vlm(self):
+        text = _pp("mlx>=0.31.2", "mlx-lm>=0.31.3", "mlx-vlm>=0.6.3")
+        bounds = guard.extract_mlx_bounds(text)
+        assert bounds["mlx"] == {">=0.31.2"}
+        assert bounds["mlx-lm"] == {">=0.31.3"}
+        assert bounds["mlx-vlm"] == {">=0.6.3"}
+
+    def test_pep503_name_aliases_are_canonicalized(self):
+        # mlx_vlm / MLX-VLM / mlx.vlm are all valid spellings of mlx-vlm and must
+        # NOT slip past the guard (canonicalize_name).
+        for alias in ("mlx_vlm>=0.7", "MLX-VLM>=0.7", "mlx.vlm>=0.7"):
+            bounds = guard.extract_mlx_bounds(_pp(alias))
+            assert bounds["mlx-vlm"] == {">=0.7"}, alias
+
+    def test_scans_dependency_groups_and_build_system(self):
+        from packaging.specifiers import SpecifierSet
+
+        text = (
+            '[build-system]\nrequires = ["mlx>=0.31.2,<0.32"]\n\n'
+            '[dependency-groups]\ndev = ["mlx-lm>=0.31.3,<0.32"]\n'
+        )
+        bounds = guard.extract_mlx_bounds(text)
+        assert {SpecifierSet(s) for s in bounds["mlx"]} == {
+            SpecifierSet(">=0.31.2,<0.32")
+        }
+        assert {SpecifierSet(s) for s in bounds["mlx-lm"]} == {
+            SpecifierSet(">=0.31.3,<0.32")
+        }
+
+
+class TestStrictMode:
+    def test_malformed_guarded_requirement_raises_in_strict(self):
+        text = _pp("mlx-lm>=0.31.3", "mlx >>>= broken")
+        with pytest.raises(guard.MalformedGuardedRequirementError):
+            guard.extract_mlx_bounds(text, strict=True)
+
+    def test_malformed_guarded_requirement_skipped_when_not_strict(self):
+        text = _pp("mlx-lm>=0.31.3", "mlx >>>= broken")
+        bounds = guard.extract_mlx_bounds(text)  # non-strict
+        assert bounds["mlx-lm"] == {">=0.31.3"}
+
+    def test_malformed_non_guarded_requirement_never_raises(self):
+        # A broken NON-mlx requirement is not our gate's concern.
+        text = _pp("mlx-lm>=0.31.3", "some-pkg >>>= broken")
+        assert guard.extract_mlx_bounds(text, strict=True)["mlx-lm"] == {">=0.31.3"}
+
+    def test_malformed_guarded_alias_raises_in_strict(self):
+        # A malformed alias spelling of a guarded package must still fail closed.
+        text = _pp("mlx_vlm >>>= broken")
+        with pytest.raises(guard.MalformedGuardedRequirementError):
+            guard.extract_mlx_bounds(text, strict=True)
+
+    def test_malformed_toml_raises_in_strict(self):
+        with pytest.raises(Exception):
+            guard.extract_mlx_bounds("this is [ not valid = toml", strict=True)
+
+    def test_malformed_toml_yields_empty_when_not_strict(self):
+        bounds = guard.extract_mlx_bounds("this is [ not valid = toml")
+        assert bounds == {p: set() for p in guard.GUARDED_PACKAGES}
+
+
+class TestDetectBoundChanges:
+    def test_identical_is_no_change(self):
+        assert guard.detect_bound_changes(_CORE, _CORE) == []
+
+    def test_reordered_specifier_is_not_a_change(self):
+        reordered = _CORE.replace(
+            '"mlx-vlm>=0.6.3,!=0.6.4,<0.7"', '"mlx-vlm<0.7,>=0.6.3,!=0.6.4"'
+        )
+        assert guard.detect_bound_changes(_CORE, reordered) == []
+
+    def test_marker_only_change_is_not_a_change(self):
+        # Only the version specifier is coherence-relevant; markers are ignored.
+        toggled = _CORE.replace(
+            "\"mlx-vlm>=0.6.3,!=0.6.4,<0.7; platform_system == 'Darwin'\"",
+            '"mlx-vlm>=0.6.3,!=0.6.4,<0.7"',
+        )
+        assert guard.detect_bound_changes(_CORE, toggled) == []
+
+    # --- every real specifier change is flagged (fail-closed) ---
+
+    def test_raising_upper_bound_is_flagged(self):
+        bumped = _CORE.replace('"mlx-lm>=0.31.3,<0.32"', '"mlx-lm>=0.31.3,<0.33"')
+        changes = guard.detect_bound_changes(_CORE, bumped)
+        assert len(changes) == 1 and changes[0].startswith("mlx-lm:")
+
+    def test_removing_cap_entirely_is_flagged(self):
+        uncapped = _CORE.replace('"mlx>=0.31.2,<0.32"', '"mlx>=0.31.2"')
+        assert any(
+            c.startswith("mlx:") for c in guard.detect_bound_changes(_CORE, uncapped)
+        )
+
+    def test_pure_floor_bump_is_flagged(self):
+        # BLOCKING-class case: >=0.31.2 -> >=0.32 forces an untested minor.
+        old = _CORE.replace('"mlx>=0.31.2,<0.32"', '"mlx>=0.31.2"')
+        new = _CORE.replace('"mlx>=0.31.2,<0.32"', '"mlx>=0.32"')
+        assert any(c.startswith("mlx:") for c in guard.detect_bound_changes(old, new))
+
+    def test_dropping_ne_exclusion_is_flagged(self):
+        deexcluded = _CORE.replace(
+            '"mlx-vlm>=0.6.3,!=0.6.4,<0.7"', '"mlx-vlm>=0.6.3,<0.7"'
+        )
+        assert any(
+            c.startswith("mlx-vlm:")
+            for c in guard.detect_bound_changes(_CORE, deexcluded)
+        )
+
+    def test_adding_a_cap_is_flagged(self):
+        # Fail-closed: even tightening is gated (its attestation is a one-liner).
+        uncapped = _CORE.replace('"mlx>=0.31.2,<0.32"', '"mlx>=0.31.2"')
+        assert any(
+            c.startswith("mlx:") for c in guard.detect_bound_changes(uncapped, _CORE)
+        )
+
+    def test_skewing_one_of_multiple_vlm_occurrences_is_flagged(self):
+        skewed = _CORE.replace(
+            "\"mlx-vlm>=0.6.3,!=0.6.4,<0.7; platform_system == 'Darwin'\"",
+            "\"mlx-vlm>=0.6.3,!=0.6.4,<0.8; platform_system == 'Darwin'\"",
+        )
+        assert any(
+            c.startswith("mlx-vlm:") for c in guard.detect_bound_changes(_CORE, skewed)
+        )
+
+
+class TestAttestation:
+    def test_label_grants_attestation(self):
+        assert guard._attestation_ok("", "some-label, mlx-coherence-swept", False)
+
+    def test_trailer_with_note_grants_attestation(self):
+        body = "Fixes stuff.\n\nCoherence-Sweep: https://ci/run/123 all families green"
+        assert guard._attestation_ok(body, "", False)
+
+    def test_empty_trailer_does_not_grant(self):
+        assert not guard._attestation_ok("Coherence-Sweep:   ", "", False)
+
+    def test_no_attestation_is_false(self):
+        assert not guard._attestation_ok("just a normal body", "bug,p0", False)
+
+    def test_forced_env_grants(self):
+        assert guard._attestation_ok("", "", True)
+
+    def test_label_match_is_case_insensitive_and_trimmed(self):
+        assert guard._attestation_ok("", "  MLX-Coherence-Swept  ", False)


### PR DESCRIPTION
## What
Closes #1248 (umbrella #320).

1. **Add tested upper caps** to `mlx` / `mlx-lm` / `mlx-vlm`, pinned to the validated line:
   - `mlx>=0.31.2,<0.32`, `mlx-lm>=0.31.3,<0.32`, `mlx-vlm>=0.6.3,!=0.6.4,<0.7` (all 5 occurrences across core / `[vision]` / `[spec]` / audio extras).
2. **New PR-level gate** `scripts/check_mlx_bound_move.py` + `ci.yml` job `mlx-bound-guard` that **blocks a PR which changes an mlx\* version pin** unless it attests the coherence sweep.

## Why (incident-grounded)
The Qwen3.6 garbage (#1234) came from a heuristic change **inside** `mlx_lm` under an *existing* model — an upstream minor we never validated. But these deps were floor-only pinned with no ceiling, so a plain `pip install rapid-mlx` **today** silently resolves `mlx 0.32.0` (unvalidated; `0.31.2` is what shipped). We already cap `transformers<5.13` and `mlx-audio<0.4.4` for exactly this reason — `mlx*` just never got the same treatment.

## Gate semantics (fail-closed)
Version-set math over PEP 440 (epochs, pre/post/dev/local, `===`, wildcards, `~=`) is easy to get subtly wrong in the *unsafe* direction, so the guard does not try to classify loosening vs tightening. It flags **any** change to a guarded package's normalized version specifier and requires an explicit attestation. Reordering a specifier or changing only an environment marker normalizes away and is silent. It fails **closed** on infra/parse problems (unreadable base, malformed head TOML, unparseable `mlx*` requirement) so a ref-plumbing slip can't silently disable it. PR-only (a push-to-main has no meaningful base to diff).

Attest via the `mlx-coherence-swept` label **or** a `Coherence-Sweep: <run/summary/note>` trailer. For a real loosening, run the full-family sweep (#1247) first; for a pure tightening/cap-add, a one-line note suffices. When #1247 lands, `_attestation_ok` upgrades to verifying the real artifact.

## Test plan
- `python3.12 -m pytest tests/test_mlx_bound_guard.py -q` — 25 passed (extraction across all pyproject sources incl. PEP 735 `dependency-groups` + `build-system.requires`; `keywords=["mlx"]` ignored; every specifier change flagged; strict-mode fail-closed; attestation). No GPU, no network.
- Functional smoke: adding caps (this PR) → **flagged** (fail-closed), passes only with the trailer below; simulated raise → blocked without attestation; unreadable base ref → **fails closed** (exit 1).
- `ruff check && ruff format --check` clean; `pyproject.toml` re-parses (20 deps); installed 0.31.2/0.31.3/0.6.3 satisfy the caps, `0.32.0`/`0.7.0` blocked.

## Checklist
- [x] Tests pass locally
- [x] Lint passes (`ruff check && ruff format --check`)
- [x] Self-validated via `pr_validate`
- [x] New tests touch a release-safety path — detection fails if a pin change slips through
- [x] Updated README/docs if applicable — N/A (dep policy self-documents via the guard's failure message + inline pyproject comments)
- [x] No breaking changes to existing API

Coherence-Sweep: N/A — this PR only ADDS upper caps to the already-validated line (mlx 0.31.2 / mlx-lm 0.31.3 / mlx-vlm 0.6.3 are the installed+shipped versions). It is a strict tightening: no newer, unvalidated version becomes installable, so no sweep is required. The gate flags it only because it is fail-closed on *any* pin change.