### PR TITLE
ci(release): tie release notes to the tagged commit + curated highlights

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -202,7 +202,7 @@ jobs:
           # the previous tag, not only the version-bump commit.
           fetch-depth: 0
 
-      - name: Build CHANGELOG body
+      - name: Build release notes
         id: changelog
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -210,67 +210,35 @@ jobs:
           FORCE: ${{ needs.detect.outputs.force }}
           ACTOR: ${{ github.actor }}
           REASON: ${{ github.event.inputs.reason }}
+          EVENT_SHA: ${{ github.sha }}
+          NOTES_FILE: ${{ runner.temp }}/release-notes.md
         run: |
-          # Find the last release tag to enumerate merged PRs since then.
-          PREV_TAG=$(git tag --list 'v*' --sort=-v:refname | head -1 || true)
+          set -euo pipefail
 
-          if [ -n "$PREV_TAG" ]; then
-            echo "Generating notes since $PREV_TAG"
-            COMMITS=$(git log "$PREV_TAG..HEAD" --pretty='- %s (%h)' || true)
-          else
-            COMMITS=$(git log -50 --pretty='- %s (%h)')
+          # Resolve the commit being released ONCE, here. This SHA is what the
+          # notes are generated from, what the ancestry assert checks against,
+          # and (via the step output below) what the tag is created at. Nothing
+          # downstream re-reads a bare ``HEAD``: two independent reads of "the
+          # current commit" is exactly how notes and tag drift apart.
+          RELEASE_SHA=$(git rev-parse --verify "${EVENT_SHA}^{commit}")
+          HEAD_SHA=$(git rev-parse --verify 'HEAD^{commit}')
+          if [ "$RELEASE_SHA" != "$HEAD_SHA" ]; then
+            echo "❌ checkout is at $HEAD_SHA but the release targets $RELEASE_SHA" >&2
+            echo "   (the notes would describe a different tree than the tag)" >&2
+            exit 1
           fi
 
-          # Credit every merged PR author other than the repository owner.
-          OWNER="${GITHUB_REPOSITORY%%/*}"
-          PR_NUMBERS=$(
-            {
-              git log "${PREV_TAG:+$PREV_TAG..}HEAD" --pretty='%s' |
-                sed -nE 's/.*\(#([0-9]+)\)$/\1/p'
-              git log "${PREV_TAG:+$PREV_TAG..}HEAD" --pretty='%s' |
-                sed -nE 's/^Merge pull request #([0-9]+).*/\1/p'
-            } | sort -nu
-          )
-          CONTRIBUTIONS=()
-          while IFS= read -r PR_NUMBER; do
-            [ -n "$PR_NUMBER" ] || continue
-            PR_JSON=$(gh pr view "$PR_NUMBER" \
-              --repo "$GITHUB_REPOSITORY" \
-              --json author,title,url 2>/dev/null) || continue
-            AUTHOR=$(jq -r '.author.login // empty' <<<"$PR_JSON")
-            if [ -z "$AUTHOR" ] || [ "$AUTHOR" = "$OWNER" ]; then
-              continue
-            fi
-            CONTRIBUTIONS+=("$(
-              jq -r '"- [@\(.author.login)](https://github.com/\(.author.login)) — [\(.title)](\(.url))"' \
-                <<<"$PR_JSON"
-            )")
-          done <<<"$PR_NUMBERS"
+          # The body goes to a file, not to $GITHUB_OUTPUT. The old heredoc
+          # (``body<<__EOF__``) could be escaped by any line equal to the
+          # delimiter — now reachable from human-authored highlights as well as
+          # commit subjects. A file has no delimiter to escape and never passes
+          # through ``${{ }}``.
+          RELEASE_SHA="$RELEASE_SHA" bash scripts/build_release_notes.sh > "$NOTES_FILE"
 
-          {
-            echo 'body<<__EOF__'
-            echo "## What's new in v$VERSION"
-            echo
-            if [ "$FORCE" = "true" ]; then
-              echo "> ⚠️ **Emergency release** — the Tier-1 agent gate was bypassed"
-              echo "> (forced by @$ACTOR). Reason: ${REASON:-<none given>}."
-              echo
-            fi
-            if [ -n "$COMMITS" ]; then
-              echo "$COMMITS"
-            else
-              echo "_(no changes recorded)_"
-            fi
-            echo
-            if [ "${#CONTRIBUTIONS[@]}" -gt 0 ]; then
-              echo "## Community contributors"
-              echo
-              printf '%s\n' "${CONTRIBUTIONS[@]}"
-              echo
-            fi
-            echo "Install: \`brew upgrade rapid-mlx\` or \`pip install -U rapid-mlx==$VERSION\` (or just \`rapid-mlx upgrade\`)."
-            echo '__EOF__'
-          } >> "$GITHUB_OUTPUT"
+          echo "release_sha=$RELEASE_SHA" >> "$GITHUB_OUTPUT"
+          echo "notes_file=$NOTES_FILE" >> "$GITHUB_OUTPUT"
+          echo "--- release notes ---"
+          cat "$NOTES_FILE"
 
       - name: Create tag and release
         env:
@@ -281,25 +249,55 @@ jobs:
           # PyPI/Homebrew. Falls back to ``GITHUB_TOKEN`` if the secret is absent
           # so forks don't break — the release just won't auto-publish.
           GH_TOKEN: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
-          # Pass untrusted strings (commit subjects from git log) via env, never
-          # via ``${{ }}`` interpolation into a ``run:`` block — otherwise a
-          # commit subject containing ``$(...)`` would execute on the runner with
-          # ``contents: write``.
           TAG: v${{ needs.detect.outputs.version }}
-          NOTES: ${{ steps.changelog.outputs.body }}
-          TARGET_SHA: ${{ github.sha }}
+          # Resolved once by the step above. The notes describe exactly this
+          # commit, so the tag must be created at exactly this commit.
+          RELEASE_SHA: ${{ steps.changelog.outputs.release_sha }}
+          # The body lives in a file on disk; it is never interpolated into this
+          # ``run:`` block, so a commit subject containing ``$(...)`` cannot
+          # execute on a runner holding ``contents: write``.
+          NOTES_FILE: ${{ steps.changelog.outputs.notes_file }}
         run: |
+          set -euo pipefail
+
           # Idempotency: re-check at create time too.
           if gh release view "$TAG" >/dev/null 2>&1; then
             echo "Release $TAG already exists — done"
             exit 0
           fi
 
-          # ``--notes-file -`` reads from stdin so the body is never expanded by
-          # the shell, even if it contains backticks or ``$(...)``.
-          printf '%s' "$NOTES" | gh release create "$TAG" \
-            --title "$TAG" \
-            --notes-file - \
-            --target "$TARGET_SHA"
+          # A tag can exist WITHOUT a Release object: a prior run that died
+          # between tag and release, a hand-pushed tag, a deleted release. The
+          # check above only sees Releases, so we would fall through to
+          # ``gh release create`` — and GitHub REUSES an existing tag and
+          # silently IGNORES ``--target``. The result is a published release
+          # whose notes describe $RELEASE_SHA attached to a tag pointing
+          # somewhere else. That is the one way this job can ship a release that
+          # lies about its own contents, so fail loudly instead of guessing.
+          git fetch --quiet --force origin "refs/tags/$TAG:refs/tags/$TAG" 2>/dev/null || true
+          if EXISTING=$(git rev-parse --verify --quiet "refs/tags/$TAG^{commit}"); then
+            if [ "$EXISTING" != "$RELEASE_SHA" ]; then
+              echo "❌ Tag $TAG already exists at $EXISTING, but these notes describe $RELEASE_SHA." >&2
+              echo "   GitHub ignores --target when the tag already exists, so publishing now" >&2
+              echo "   would attach these notes to a different tree." >&2
+              echo "   Fix by hand: delete the stale tag, or bump to a fresh version." >&2
+              exit 1
+            fi
+            echo "Tag $TAG already exists and points at the release commit — reusing it."
+          fi
 
-          echo "✓ Released $TAG — publish.yml will now publish to PyPI"
+          gh release create "$TAG" \
+            --title "$TAG" \
+            --notes-file "$NOTES_FILE" \
+            --target "$RELEASE_SHA"
+
+          # Post-condition: the tag that actually got published must be the
+          # commit these notes were generated from.
+          git fetch --quiet --force origin "refs/tags/$TAG:refs/tags/$TAG"
+          PUBLISHED=$(git rev-parse --verify "refs/tags/$TAG^{commit}")
+          if [ "$PUBLISHED" != "$RELEASE_SHA" ]; then
+            echo "❌ published tag $TAG points at $PUBLISHED, expected $RELEASE_SHA" >&2
+            exit 1
+          fi
+
+          echo "✓ Released $TAG at $RELEASE_SHA — publish.yml will now publish to PyPI"

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -16,6 +16,11 @@ name: Auto-release on version bump
 # ``force_version`` set — that BYPASSES the gate and releases anyway. It is
 # audited (actor + reason are logged and stamped into the release notes). See
 # RELEASE.md § "Studio down / emergency release".
+#
+# RELEASE NOTES: built by ``scripts/build_release_notes.sh`` (extracted so it can
+# be tested offline — ``tests/release/test_build_release_notes.sh``). It prepends
+# ``docs/release-notes/vX.Y.Z.md`` from the release commit when that file exists,
+# and otherwise emits the plain commit list. See ``docs/release-notes/README.md``.
 
 on:
   push:

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -307,8 +307,19 @@ jobs:
           fi
           if [ -n "$REMOTE_TAG" ]; then
             git fetch --quiet --force origin "refs/tags/$TAG:refs/tags/$TAG"
+            # ls-remote already proved the tag EXISTS, so a peel that fails
+            # here is not "no tag" — it is a tag we cannot reason about (an
+            # annotated tag can legally point at a tree or blob). Falling
+            # through would hand it to ``gh release create``, which reuses the
+            # tag and ignores --target, and the post-condition would only
+            # notice after the release published and triggered downstream.
+            if ! EXISTING=$(git rev-parse --verify --quiet "refs/tags/$TAG^{commit}"); then
+              echo "❌ Tag $TAG exists on origin but does not peel to a commit." >&2
+              echo "   Refusing to publish against a tag whose target cannot be verified." >&2
+              exit 1
+            fi
           fi
-          if EXISTING=$(git rev-parse --verify --quiet "refs/tags/$TAG^{commit}"); then
+          if [ -n "${EXISTING:-}" ]; then
             if [ "$EXISTING" != "$RELEASE_SHA" ]; then
               echo "❌ Tag $TAG already exists at $EXISTING, but these notes describe $RELEASE_SHA." >&2
               echo "   GitHub ignores --target when the tag already exists, so publishing now" >&2

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -265,9 +265,24 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Idempotency: re-check at create time too.
-          if gh release view "$TAG" >/dev/null 2>&1; then
-            echo "Release $TAG already exists — done"
+          # Idempotency: re-check at create time too. An existing Release is
+          # only "already done" if it points at the commit these notes
+          # describe — a retry that resolved a different RELEASE_SHA must not
+          # report success over a release that documents another tree.
+          if EXISTING_REL=$(gh release view "$TAG" --json targetCommitish,tagName -q .targetCommitish 2>/dev/null); then
+            # targetCommitish can be a branch name for pre-existing releases;
+            # resolve through the tag, which is what actually ships.
+            if REL_SHA=$(git rev-parse --verify --quiet "refs/tags/$TAG^{commit}" 2>/dev/null); then
+              :
+            else
+              REL_SHA=$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$TAG" -q .object.sha 2>/dev/null || echo "")
+            fi
+            if [ -n "$REL_SHA" ] && [ "$REL_SHA" != "$RELEASE_SHA" ]; then
+              echo "❌ Release $TAG already exists at $REL_SHA, but these notes describe $RELEASE_SHA." >&2
+              echo "   Refusing to report success over a release that documents a different tree." >&2
+              exit 1
+            fi
+            echo "Release $TAG already exists at the release commit ($EXISTING_REL) — done"
             exit 0
           fi
 
@@ -279,7 +294,20 @@ jobs:
           # whose notes describe $RELEASE_SHA attached to a tag pointing
           # somewhere else. That is the one way this job can ship a release that
           # lies about its own contents, so fail loudly instead of guessing.
-          git fetch --quiet --force origin "refs/tags/$TAG:refs/tags/$TAG" 2>/dev/null || true
+          # ``git fetch <tag>`` fails both when the tag is absent (fine) and
+          # when the network/auth broke (NOT fine), and swallowing that with
+          # ``|| true`` would read a failed check as "no tag exists" — then
+          # ``gh release create`` reuses the remote tag, ignores --target, and
+          # the post-condition only catches it AFTER downstream workflows fired.
+          # ``ls-remote`` separates the two: exit 0 + empty means genuinely
+          # absent, non-zero means we could not check and must not guess.
+          if ! REMOTE_TAG=$(git ls-remote --tags origin "refs/tags/$TAG"); then
+            echo "❌ could not query origin for refs/tags/$TAG — refusing to guess." >&2
+            exit 1
+          fi
+          if [ -n "$REMOTE_TAG" ]; then
+            git fetch --quiet --force origin "refs/tags/$TAG:refs/tags/$TAG"
+          fi
           if EXISTING=$(git rev-parse --verify --quiet "refs/tags/$TAG^{commit}"); then
             if [ "$EXISTING" != "$RELEASE_SHA" ]; then
               echo "❌ Tag $TAG already exists at $EXISTING, but these notes describe $RELEASE_SHA." >&2

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,12 +8,42 @@ automated.
 ## TL;DR — cut a release
 
 1. Bump `version` in `pyproject.toml` to `X.Y.Z`.
-2. Open a PR whose commit subject is exactly `chore: bump version to X.Y.Z`
+2. In the same PR, `git mv docs/release-notes/unreleased.md
+   docs/release-notes/vX.Y.Z.md` (optional — see "Release notes" below).
+3. Open a PR whose commit subject is exactly `chore: bump version to X.Y.Z`
    (GitHub's `(#N)` squash suffix is fine), and merge it to `main`.
-3. That's it. The pipeline below tags `vX.Y.Z`, publishes a GitHub Release,
+4. That's it. The pipeline below tags `vX.Y.Z`, publishes a GitHub Release,
    PyPI, and Homebrew — **after** the Tier-1 agent gate passes.
 
 Nothing else is manual. There is no separate "publish" button.
+
+## Release notes
+
+`scripts/build_release_notes.sh` builds the GitHub Release body. It reads
+**`docs/release-notes/vX.Y.Z.md` out of the commit being tagged**; if that file
+exists it becomes the top of the notes verbatim (prose, `## Highlights`,
+benchmark tables, caveats) and the auto commit list is appended below it under a
+collapsed `<details>`. If it's absent the release publishes exactly as before —
+a flat commit list. **A release is never blocked on prose.**
+
+Write the prose as you land the work, in `docs/release-notes/unreleased.md`, and
+rename it in the version-bump PR. Full guidance and a template:
+`docs/release-notes/README.md`.
+
+Two invariants the workflow enforces, so notes can never describe a tree other
+than the one being tagged:
+
+- The release commit is resolved **once** (from `github.sha`, asserted equal to
+  the checked-out `HEAD`) and that one SHA is used for the notes, the ancestry
+  assert, and `--target`.
+- The baseline is the nearest **ancestor** tag (`git describe`), not the highest
+  version string in the repo — those differ whenever a newer tag exists that the
+  release commit does not descend from.
+- If the tag already exists at a *different* commit, the job **fails loudly**
+  rather than publishing: `gh release create` reuses an existing tag and
+  silently ignores `--target`.
+
+Run the offline tests with `./tests/release/test_build_release_notes.sh`.
 
 ## The pipeline
 
@@ -122,6 +152,9 @@ it sparingly — it ships a version whose agent integrations were *not* verified
 
 ## Related docs
 
+- `docs/release-notes/README.md` — how curated release notes are written.
+- `scripts/build_release_notes.sh` + `tests/release/test_build_release_notes.sh`
+  — the notes builder and its offline tests.
 - `tests/integrations/agent_smoke.sh` — the gate script (canonical).
 - `tests/integrations/README.md` — the full agent × model integration matrix.
 - `landing/runbooks/agent-release-verification.md` (rapidmlx.com repo) — the

--- a/docs/development/releasing.md
+++ b/docs/development/releasing.md
@@ -53,7 +53,12 @@ The full path from "I want to release" to "users on `brew upgrade` see the new v
 
    The commit subject **must** match `chore: bump version to X.Y.Z` exactly — `auto-release.yml` parses it.
 
-3. **`auto-release.yml` fires** (~30s) — verifies the commit, checks the tag doesn't already exist, builds a CHANGELOG from `git log <prev-tag>..HEAD`, adds a linked **Community contributors** entry for every merged PR author other than the repository owner, and creates the GitHub Release.
+   While you're in this PR, also roll the release notes:
+   `git mv docs/release-notes/unreleased.md docs/release-notes/vX.Y.Z.md`,
+   tidy the prose, and recreate an empty `unreleased.md`. Optional — skipping
+   it just gives you a plain commit list. See `docs/release-notes/README.md`.
+
+3. **`auto-release.yml` fires** (~30s) — verifies the commit, checks the tag doesn't already exist, builds the release notes via `scripts/build_release_notes.sh` (curated `docs/release-notes/vX.Y.Z.md` if present, plus the commit list for `<nearest ancestor tag>..<release commit>`), adds a linked **Community contributors** entry for every merged PR author other than the repository owner, and creates the GitHub Release **at that same commit**.
 
 4. **`publish.yml` fires on `release: published`** (~3min) — builds sdist + wheel, uploads to PyPI (via the `pypi` deployment environment).
 

--- a/docs/release-notes/README.md
+++ b/docs/release-notes/README.md
@@ -1,0 +1,104 @@
+# Release notes — curated highlights
+
+A `git log` dump is a record, not release notes. It tells a reader *what
+commits happened*; it never tells them *what changed and why they should care*.
+A bash step in CI cannot write that, and we are not putting an LLM in the
+release path — so the prose has to be captured by a human **while the work is
+being done**, and merely assembled at release time. That is what this directory
+is.
+
+## How it works
+
+`.github/workflows/auto-release.yml` → `scripts/build_release_notes.sh` looks
+for **`docs/release-notes/v<X.Y.Z>.md`** *in the commit being tagged*.
+
+- **File present** → its contents are the top of the GitHub Release body,
+  verbatim, and the auto-generated commit list is appended below it inside a
+  collapsed `<details><summary>All changes</summary>`.
+- **File absent or empty** → the release publishes exactly as it always has: a
+  flat commit list, no `<details>`.
+
+**A release is never blocked on prose.** Forgetting to write highlights costs
+you nice notes, never a release.
+
+The machinery around the prose is unchanged either way: the
+`## What's new in vX.Y.Z` heading, the ⚠️ emergency-release banner when the
+Tier-1 agent gate was bypassed, the `## Community contributors` section, and the
+trailing `Install:` line are all still generated.
+
+## Writing them
+
+1. **While you work**, append to `unreleased.md`. It is a scratch file; no PR is
+   required to touch it and there is no schema to satisfy.
+2. **In the version-bump PR** (the one that sets `version` in `pyproject.toml`
+   and whose subject is `chore: bump version to X.Y.Z`), rename it:
+
+   ```bash
+   git mv docs/release-notes/unreleased.md docs/release-notes/vX.Y.Z.md
+   ```
+
+   Reread it as a whole, cut what turned out not to matter, and add the framing
+   paragraph. Then recreate an empty `unreleased.md` from the template at the
+   bottom of this file.
+
+That rename is the entire "roll into an archive and reset" step, and it happens
+in the PR that already exists for every release. Nothing in CI writes to the
+repository — the workflow only ever *reads* the release commit, so it needs no
+push permission on `main` and cannot race a concurrent merge.
+
+Naming the file after its version also makes stale prose structurally
+impossible: `v0.11.9.md` can only ever be published as v0.11.9. A forgotten
+reset cannot cause last release's highlights to ship again.
+
+The files accumulate here, so this directory doubles as a browsable, in-repo
+changelog.
+
+## What good looks like
+
+Model these on how a reader decides whether to upgrade.
+
+- **A short framing paragraph.** What is this release *about*? One or two
+  sentences. No single PR knows this; only a human looking at the whole range
+  does.
+- **A `## Highlights` section.** A handful of bolded, named items — not one per
+  PR, one per *thing a user would notice*. Each gets a paragraph explaining what
+  changed and why it matters, with the PR link inline. Three good ones beat
+  fifteen restated commit subjects.
+- **Tables wherever there are numbers.** A context sweep (1K…128K) of
+  prefill/decode tok/s; a feature-on/off table with a Change % column. Numbers
+  are the reason anyone believes the paragraph above them.
+- **Negative results, stated plainly.** This is not optional politeness, it is
+  what makes the positive numbers credible. If a feature wins on code and loses
+  on prose, say so and say what the engine does about it — "prose lands at
+  32–57% acceptance and does not consistently gain, so the adaptive controller
+  parks speculation there". A reader who finds one honest caveat will trust
+  every other number on the page; a reader who finds none will trust nothing.
+  Write the caveat in the same breath as the win, in the same paragraph or as a
+  row in the same table.
+- **Anything genuinely breaking, first**, before the wins.
+
+## Template
+
+Copy this into a fresh `unreleased.md` after each release.
+
+```markdown
+<!-- Scratch space for the next release's notes. Rename to vX.Y.Z.md in the
+     version-bump PR. See README.md in this directory. -->
+
+<!-- One or two sentences: what is this release about? -->
+
+## Highlights
+
+**<Named thing>** — what changed, and why a user should care. Include the
+numbers if there are numbers, and the caveat if there is a caveat. ([#1234](https://github.com/raullenchai/Rapid-MLX/pull/1234))
+
+| Context | Prefill tok/s | Decode tok/s |
+| ------: | ------------: | -----------: |
+|      1K |               |              |
+|    128K |               |              |
+
+| Workload | Off | On | Change | Acceptance |
+| -------- | --: | -: | -----: | ---------: |
+| Code     |     |    |        |            |
+| Prose    |     |    |        |            |
+```

--- a/docs/release-notes/unreleased.md
+++ b/docs/release-notes/unreleased.md
@@ -1,0 +1,4 @@
+<!-- Scratch space for the next release's notes. Append as you land work; in the
+     version-bump PR, `git mv` this to vX.Y.Z.md and recreate this file empty.
+     Whole-line HTML comments like this one are stripped before publishing.
+     See README.md in this directory for what good notes look like. -->

--- a/scripts/build_release_notes.sh
+++ b/scripts/build_release_notes.sh
@@ -72,11 +72,15 @@ RELEASE_SHA=$(git rev-parse --verify "${RELEASE_SHA}^{commit}")
 # with "_(no changes recorded)_" or a partial list.
 #
 # ``git describe`` walks ancestry, which is the property we actually want.
+# ``--first-parent`` keeps that walk on the mainline: without it a tag that
+# rode in on a merged side branch (fork at v1.0.0, tag v0.9.9, merge just
+# before v1.1.0) is "nearer" than the real previous release, and every
+# commit between them silently vanishes from the published notes.
 # ``--exclude $TAG`` keeps a re-run from selecting the version's own tag (which
 # would make the range empty).
 # --------------------------------------------------------------------------
 PREV_TAG=$(
-  git describe --tags --abbrev=0 --match 'v[0-9]*' --exclude "$TAG" \
+  git describe --first-parent --tags --abbrev=0 --match 'v[0-9]*' --exclude "$TAG" \
     "$RELEASE_SHA" 2>/dev/null || true
 )
 

--- a/scripts/build_release_notes.sh
+++ b/scripts/build_release_notes.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+#
+# Build the GitHub Release body for one version and print it on stdout.
+#
+# Extracted from .github/workflows/auto-release.yml so the logic can be run and
+# tested against real repository history without cutting a release
+# (see tests/release/test_build_release_notes.sh).
+#
+# THE CONTRACT
+#
+#   The notes describe EXACTLY the commit named by $RELEASE_SHA — the same SHA
+#   the tag is created at. Nothing in here reads a bare ``HEAD``, and nothing
+#   re-derives "the current commit" a second time. A release that lies about
+#   its own contents is worse than a release that fails to publish, so the
+#   auto-generated commit list is asserted to be reachable from $RELEASE_SHA
+#   before it is emitted.
+#
+# THE SHAPE
+#
+#   ## What's new in vX.Y.Z
+#   [⚠️ emergency-release banner, when FORCE=true]
+#   <docs/release-notes/vX.Y.Z.md, verbatim — prose, Highlights, tables>
+#   <details><summary>All changes</summary> …auto commit list… </details>
+#   ## Community contributors
+#   Install: …
+#
+#   When no highlights file exists the commit list is emitted flat and
+#   un-collapsed, i.e. byte-identical to the pre-highlights behaviour. Prose is
+#   never required: a release must never be blocked on someone having written
+#   it.
+#
+# Required env:
+#   VERSION            X.Y.Z being released
+#   RELEASE_SHA        commit being tagged
+# Optional env:
+#   FORCE              "true" → stamp the emergency (gate-bypassed) banner
+#   ACTOR / REASON     audit fields for that banner
+#   GITHUB_REPOSITORY  owner/repo, enables the contributor lookup via ``gh``
+#   HIGHLIGHTS_DIR     default docs/release-notes
+#   SKIP_CONTRIBUTORS  "1" → skip the ``gh`` calls (offline tests)
+
+set -euo pipefail
+
+: "${VERSION:?VERSION is required}"
+: "${RELEASE_SHA:?RELEASE_SHA is required}"
+FORCE="${FORCE:-false}"
+ACTOR="${ACTOR:-unknown}"
+REASON="${REASON:-}"
+REPO="${GITHUB_REPOSITORY:-}"
+HIGHLIGHTS_DIR="${HIGHLIGHTS_DIR:-docs/release-notes}"
+SKIP_CONTRIBUTORS="${SKIP_CONTRIBUTORS:-0}"
+
+TAG="v$VERSION"
+RELEASE_SHA=$(git rev-parse --verify "${RELEASE_SHA}^{commit}")
+
+# --------------------------------------------------------------------------
+# 1. Baseline.
+#
+# The baseline must be the newest tag that is an ANCESTOR of the commit being
+# released — not simply the highest version string that exists anywhere in the
+# repository.
+#
+# The old ``git tag --list 'v*' --sort=-v:refname | head -1`` picked the latter.
+# Those coincide on the happy path and diverge whenever a higher tag exists that
+# this commit does not descend from:
+#   * an emergency force_release of an older version (it skips the gate, so it
+#     can overtake a normal release still sitting in the 90-minute gate);
+#   * re-running the ``release`` job of an older run after newer tags landed
+#     (the re-run reuses ``detect``'s cached "tag is new" answer);
+#   * any two version bumps in flight at once.
+# In each case ``highest..HEAD`` is empty or truncated, and the release ships
+# with "_(no changes recorded)_" or a partial list.
+#
+# ``git describe`` walks ancestry, which is the property we actually want.
+# ``--exclude $TAG`` keeps a re-run from selecting the version's own tag (which
+# would make the range empty).
+# --------------------------------------------------------------------------
+PREV_TAG=$(
+  git describe --tags --abbrev=0 --match 'v[0-9]*' --exclude "$TAG" \
+    "$RELEASE_SHA" 2>/dev/null || true
+)
+
+if [ -n "$PREV_TAG" ]; then
+  if ! git merge-base --is-ancestor "$PREV_TAG" "$RELEASE_SHA"; then
+    echo "internal error: $PREV_TAG is not an ancestor of $RELEASE_SHA" >&2
+    exit 1
+  fi
+  RANGE="$PREV_TAG..$RELEASE_SHA"
+  COMMITS=$(git log "$RANGE" --pretty='- %s (%h)')
+  echo "baseline: $PREV_TAG → $RELEASE_SHA" >&2
+else
+  # First release in the repository: no ancestor tag to diff against.
+  RANGE="$RELEASE_SHA"
+  COMMITS=$(git log -50 "$RELEASE_SHA" --pretty='- %s (%h)')
+  echo "baseline: <none, first release> → $RELEASE_SHA" >&2
+fi
+
+# --------------------------------------------------------------------------
+# 2. Assert the generated list really describes the tree being tagged.
+#
+# Guaranteed by construction today; asserted anyway so a future edit to the
+# baseline logic fails the job instead of silently publishing a release whose
+# notes belong to a different tree.
+# --------------------------------------------------------------------------
+cited_shas() {
+  # Trailing "(<sha>)" of a list item — the citation format emitted above.
+  sed -nE 's/^- .*\(([0-9a-f]{7,40})\)[[:space:]]*$/\1/p'
+}
+
+while IFS= read -r sha; do
+  [ -n "$sha" ] || continue
+  if ! git merge-base --is-ancestor "$sha" "$RELEASE_SHA" 2>/dev/null; then
+    echo "❌ generated notes cite $sha, which is not an ancestor of $RELEASE_SHA" >&2
+    exit 1
+  fi
+done < <(printf '%s\n' "$COMMITS" | cited_shas)
+
+# --------------------------------------------------------------------------
+# 3. Human-authored highlights (optional).
+#
+# Read out of the release commit itself, not the working tree, so the prose can
+# only ever be the prose that was committed to the tree being tagged.
+# --------------------------------------------------------------------------
+HIGHLIGHTS=""
+HIGHLIGHTS_PATH="$HIGHLIGHTS_DIR/$TAG.md"
+if git cat-file -e "$RELEASE_SHA:$HIGHLIGHTS_PATH" 2>/dev/null; then
+  HIGHLIGHTS=$(
+    git show "$RELEASE_SHA:$HIGHLIGHTS_PATH" |
+      # Drop whole-line HTML comments so drafting guidance left in the template
+      # can never ship, then trim leading blank lines ($( ) trims trailing ones).
+      sed -E '/^[[:space:]]*<!--.*-->[[:space:]]*$/d' |
+      sed -e '/./,$!d'
+  )
+  if [ -n "$HIGHLIGHTS" ]; then
+    echo "highlights: $HIGHLIGHTS_PATH ($(printf '%s\n' "$HIGHLIGHTS" | wc -l | tr -d ' ') lines)" >&2
+  else
+    echo "highlights: $HIGHLIGHTS_PATH is empty — falling back to the commit list" >&2
+  fi
+else
+  echo "highlights: no $HIGHLIGHTS_PATH in the release tree — commit list only" >&2
+fi
+
+# A wrong SHA in hand-written prose is worth flagging, but it must not block the
+# release: notes are allowed to be absent or imperfect, never blocking.
+if [ -n "$HIGHLIGHTS" ]; then
+  while IFS= read -r sha; do
+    [ -n "$sha" ] || continue
+    git rev-parse --verify --quiet "${sha}^{commit}" >/dev/null || continue
+    if ! git merge-base --is-ancestor "$sha" "$RELEASE_SHA" 2>/dev/null; then
+      echo "⚠️  $HIGHLIGHTS_PATH cites $sha, which is not in this release" >&2
+    fi
+  done < <(printf '%s\n' "$HIGHLIGHTS" | cited_shas)
+fi
+
+# --------------------------------------------------------------------------
+# 4. Credit every merged PR author other than the repository owner.
+# --------------------------------------------------------------------------
+CONTRIBUTIONS=()
+if [ "$SKIP_CONTRIBUTORS" != "1" ] && [ -n "$REPO" ]; then
+  OWNER="${REPO%%/*}"
+  PR_NUMBERS=$(
+    {
+      git log "$RANGE" --pretty='%s' | sed -nE 's/.*\(#([0-9]+)\)$/\1/p'
+      git log "$RANGE" --pretty='%s' | sed -nE 's/^Merge pull request #([0-9]+).*/\1/p'
+    } | sort -nu
+  )
+  while IFS= read -r PR_NUMBER; do
+    [ -n "$PR_NUMBER" ] || continue
+    PR_JSON=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json author,title,url 2>/dev/null) || continue
+    AUTHOR=$(jq -r '.author.login // empty' <<<"$PR_JSON")
+    if [ -z "$AUTHOR" ] || [ "$AUTHOR" = "$OWNER" ]; then
+      continue
+    fi
+    CONTRIBUTIONS+=("$(
+      jq -r '"- [@\(.author.login)](https://github.com/\(.author.login)) — [\(.title)](\(.url))"' \
+        <<<"$PR_JSON"
+    )")
+  done <<<"$PR_NUMBERS"
+fi
+
+# --------------------------------------------------------------------------
+# 5. Assemble.
+# --------------------------------------------------------------------------
+echo "## What's new in $TAG"
+echo
+if [ "$FORCE" = "true" ]; then
+  echo "> ⚠️ **Emergency release** — the Tier-1 agent gate was bypassed"
+  echo "> (forced by @$ACTOR). Reason: ${REASON:-<none given>}."
+  echo
+fi
+
+if [ -n "$HIGHLIGHTS" ]; then
+  printf '%s\n' "$HIGHLIGHTS"
+  echo
+  echo "<details>"
+  echo "<summary>All changes</summary>"
+  echo
+  if [ -n "$COMMITS" ]; then
+    printf '%s\n' "$COMMITS"
+  else
+    echo "_(no changes recorded)_"
+  fi
+  echo
+  echo "</details>"
+elif [ -n "$COMMITS" ]; then
+  printf '%s\n' "$COMMITS"
+else
+  echo "_(no changes recorded)_"
+fi
+echo
+
+if [ "${#CONTRIBUTIONS[@]}" -gt 0 ]; then
+  echo "## Community contributors"
+  echo
+  printf '%s\n' "${CONTRIBUTIONS[@]}"
+  echo
+fi
+
+echo "Install: \`brew upgrade rapid-mlx\` or \`pip install -U rapid-mlx==$VERSION\` (or just \`rapid-mlx upgrade\`)."

--- a/tests/release/test_build_release_notes.sh
+++ b/tests/release/test_build_release_notes.sh
@@ -196,6 +196,32 @@ BODY=$(VERSION=0.1.0 RELEASE_SHA="$(git rev-parse HEAD)" SKIP_CONTRIBUTORS=1 bas
 contains "$(cat "$TMP/e4")" "first release" "no tags at all: falls back to git log -50"
 check "no tags at all: lists both commits" "$(grep -c '^- ' <<<"$BODY")" "2"
 
+# --- 2h. a tag that rode in on a merged SIDE BRANCH must not become the
+# baseline. Without --first-parent, `git describe` walks into merged parents
+# and finds v0.9.9 "nearer" than the real previous mainline release v2.0.0 —
+# which would silently drop every commit between them from the notes.
+SB3="$TMP/sandbox3"; mkdir -p "$SB3"; cd "$SB3"
+git init -q .; git config user.email t@t; git config user.name t; git config commit.gpgsign false
+printf 1 > a; git add -A; git commit -qm "feat: base"
+printf 2 > b; git add -A; git commit -qm "chore: bump version to 2.0.0"
+git tag v2.0.0 HEAD
+MAINLINE=$(git rev-parse HEAD)
+# real mainline work that MUST appear in the notes
+printf 3 > c; git add -A; git commit -qm "feat: mainline work (#42)"
+# a side branch forked from before the release, carrying an older tag
+git checkout -q -b side "$MAINLINE"
+printf 4 > d; git add -A; git commit -qm "feat: side work"
+git tag v0.9.9 HEAD
+git checkout -q -
+git merge -q --no-ff side -m "Merge side"
+printf 5 > e; git add -A; git commit -qm "chore: bump version to 2.1.0"
+V210=$(git rev-parse HEAD)
+BODY=$(VERSION=2.1.0 RELEASE_SHA="$V210" SKIP_CONTRIBUTORS=1 bash "$SCRIPT" 2>"$TMP/e5")
+contains "$(cat "$TMP/e5")" "baseline: v2.0.0" \
+  "side-branch tag does not hijack the baseline (--first-parent)"
+contains "$BODY" "mainline work" \
+  "commits after the real previous release still appear in the notes"
+
 echo
 printf 'passed %d, failed %d\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/tests/release/test_build_release_notes.sh
+++ b/tests/release/test_build_release_notes.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+#
+# Offline tests for scripts/build_release_notes.sh.
+#
+# The real workflow cannot be run without cutting a release, so the notes logic
+# is exercised here against (a) this repository's real history and (b) a
+# synthetic throwaway repo for the cases real history cannot produce on demand.
+#
+#   ./tests/release/test_build_release_notes.sh
+#
+# Requires: git, jq. Network/``gh`` are not required — contributor lookup is
+# switched off via SKIP_CONTRIBUTORS=1.
+
+set -euo pipefail
+
+REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+SCRIPT="$REPO_ROOT/scripts/build_release_notes.sh"
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+PASS=0
+FAIL=0
+
+ok()   { PASS=$((PASS + 1)); printf '  \033[32mPASS\033[0m %s\n' "$1"; }
+bad()  { FAIL=$((FAIL + 1)); printf '  \033[31mFAIL\033[0m %s\n' "$1"; }
+check() { if [ "$2" = "$3" ]; then ok "$1"; else bad "$1"; printf '        want: %s\n        got:  %s\n' "$3" "$2"; fi; }
+contains() { if grep -qF -- "$2" <<<"$1"; then ok "$3"; else bad "$3"; fi; }
+lacks()    { if grep -qF -- "$2" <<<"$1"; then bad "$3"; else ok "$3"; fi; }
+
+# ==========================================================================
+echo "== 1. real history: the notes describe exactly the tagged tree =="
+# ==========================================================================
+# Regression for the reported defect: v0.11.6's body must be the 7 commits that
+# are actually reachable from the tag, and every one must be an ancestor of it.
+cd "$REPO_ROOT"
+if git rev-parse --verify --quiet v0.11.6 >/dev/null && \
+   git rev-parse --verify --quiet v0.11.5 >/dev/null; then
+  SHA=$(git rev-parse v0.11.6^{commit})
+  BODY=$(VERSION=0.11.6 RELEASE_SHA="$SHA" SKIP_CONTRIBUTORS=1 bash "$SCRIPT" 2>"$TMP/err")
+
+  contains "$(cat "$TMP/err")" "baseline: v0.11.5" "baseline is the nearest ANCESTOR tag (v0.11.5)"
+
+  WANT=$(git log v0.11.5..v0.11.6 --pretty='- %s (%h)')
+  GOT=$(grep -E '^- ' <<<"$BODY" || true)
+  check "commit list == git log v0.11.5..v0.11.6" "$GOT" "$WANT"
+  check "commit count" "$(grep -c '^- ' <<<"$BODY")" "$(git rev-list --count v0.11.5..v0.11.6)"
+
+  # Every cited SHA reachable from the tag.
+  BAD=0
+  while IFS= read -r s; do
+    [ -n "$s" ] || continue
+    git merge-base --is-ancestor "$s" "$SHA" || BAD=$((BAD + 1))
+  done < <(sed -nE 's/^- .*\(([0-9a-f]{7,40})\)$/\1/p' <<<"$BODY")
+  check "every cited SHA is an ancestor of v0.11.6" "$BAD" "0"
+
+  contains "$BODY" "## What's new in v0.11.6" "heading preserved"
+  contains "$BODY" 'Install: `brew upgrade rapid-mlx`' "Install: line preserved"
+  lacks "$BODY" "<details>" "no <details> when there are no highlights"
+else
+  echo "  SKIP (tags v0.11.5/v0.11.6 not present in this clone)"
+fi
+
+# Sweep the last N releases: notes must equal the true ancestor range for each.
+echo "-- sweep: recent tags --"
+SWEPT=0
+for TAG in $(git tag --list 'v0.11.*' --sort=-v:refname | head -8); do
+  SHA=$(git rev-parse "$TAG^{commit}")
+  PREV=$(git describe --tags --abbrev=0 --match 'v[0-9]*' --exclude "$TAG" "$SHA" 2>/dev/null || true)
+  [ -n "$PREV" ] || continue
+  BODY=$(VERSION="${TAG#v}" RELEASE_SHA="$SHA" SKIP_CONTRIBUTORS=1 bash "$SCRIPT" 2>/dev/null)
+  GOT=$(grep -cE '^- ' <<<"$BODY" || true)
+  check "$TAG: $GOT commits == git rev-list $PREV..$TAG" "$GOT" "$(git rev-list --count "$PREV..$SHA")"
+  SWEPT=$((SWEPT + 1))
+done
+[ "$SWEPT" -gt 0 ] && echo "  (swept $SWEPT tags)"
+
+# ==========================================================================
+echo
+echo "== 2. synthetic repo: highlights, degradation, banner, baseline =="
+# ==========================================================================
+SB="$TMP/sandbox"
+mkdir -p "$SB/docs/release-notes"
+cd "$SB"
+git init -q .
+git config user.email t@t; git config user.name t; git config commit.gpgsign false
+cp "$SCRIPT" "$SB/build.sh"
+
+commit() { printf '%s\n' "$2" > "$1"; git add -A; git commit -qm "$3"; }
+
+commit a.txt 1 "feat: alpha (#1)"
+git tag v1.0.0
+commit b.txt 1 "fix: bravo (#2)"
+commit c.txt 1 "feat: charlie (#3)"
+commit d.txt 1 "chore: bump version to 1.1.0"
+V110=$(git rev-parse HEAD)
+
+# --- 2a. degrades to today's behaviour with no highlights file ---
+BODY=$(VERSION=1.1.0 RELEASE_SHA="$V110" SKIP_CONTRIBUTORS=1 bash build.sh 2>/dev/null)
+check "no highlights: 3 commits listed" "$(grep -c '^- ' <<<"$BODY")" "3"
+lacks "$BODY" "<details>" "no highlights: commit list is NOT collapsed"
+contains "$BODY" "## What's new in v1.1.0" "no highlights: heading present"
+contains "$BODY" "Install:" "no highlights: install line present"
+
+# --- 2b. highlights file present ---
+cat > docs/release-notes/v1.2.0.md <<'MD'
+<!-- drafting note that must not ship -->
+This release is about speculative decoding.
+
+## Highlights
+
+**DSpark speculation** — 2.1x on code. Prose lands at 32 to 57% acceptance and
+does not consistently gain, so the adaptive controller parks speculation there.
+
+| Workload | Off | On | Change | Acceptance |
+| -------- | --: | -: | -----: | ---------: |
+| Code     |  42 | 88 |  +110% |        71% |
+| Prose    |  44 | 45 |    +2% |     32-57% |
+MD
+commit e.txt 1 "feat: delta (#4)"   # picks up the notes file too (git add -A)
+commit f.txt 1 "chore: bump version to 1.2.0"
+V120=$(git rev-parse HEAD)
+git tag v1.1.0 "$V110"
+
+BODY=$(VERSION=1.2.0 RELEASE_SHA="$V120" SKIP_CONTRIBUTORS=1 bash build.sh 2>/dev/null)
+contains "$BODY" "This release is about speculative decoding." "highlights: prose prepended"
+contains "$BODY" "## Highlights" "highlights: section rendered"
+contains "$BODY" "| Prose    |  44 | 45 |    +2% |     32-57% |" "highlights: benchmark table intact"
+contains "$BODY" "does not consistently gain" "highlights: negative result intact"
+contains "$BODY" "<details>" "highlights: commit list collapsed"
+contains "$BODY" "<summary>All changes</summary>" "highlights: <details> summary"
+lacks "$BODY" "drafting note that must not ship" "highlights: HTML comments stripped"
+contains "$BODY" "Install:" "highlights: install line still last"
+# order: prose before <details> before Install
+check "highlights: prose is above All changes" \
+  "$([ "$(grep -n 'This release is about' <<<"$BODY" | cut -d: -f1)" -lt \
+      "$(grep -n '<details>' <<<"$BODY" | cut -d: -f1)" ] && echo yes || echo no)" "yes"
+
+# --- 2c. empty highlights file degrades ---
+: > docs/release-notes/v1.3.0.md
+commit g.txt 1 "fix: echo (#5)"
+commit h.txt 1 "chore: bump version to 1.3.0"
+V130=$(git rev-parse HEAD)
+git tag v1.2.0 "$V120"
+BODY=$(VERSION=1.3.0 RELEASE_SHA="$V130" SKIP_CONTRIBUTORS=1 bash build.sh 2>/dev/null)
+lacks "$BODY" "<details>" "empty highlights file: degrades to flat commit list"
+contains "$BODY" "- fix: echo (#5)" "empty highlights file: commits still listed"
+
+# --- 2d. emergency banner ---
+BODY=$(VERSION=1.3.0 RELEASE_SHA="$V130" FORCE=true ACTOR=raullenchai \
+       REASON="Studio offline" SKIP_CONTRIBUTORS=1 bash build.sh 2>/dev/null)
+contains "$BODY" "⚠️ **Emergency release**" "forced: banner rendered"
+contains "$BODY" "(forced by @raullenchai). Reason: Studio offline." "forced: actor + reason"
+BODY=$(VERSION=1.3.0 RELEASE_SHA="$V130" FORCE=true ACTOR=raullenchai \
+       SKIP_CONTRIBUTORS=1 bash build.sh 2>/dev/null)
+contains "$BODY" "Reason: <none given>." "forced: missing reason falls back"
+
+# --- 2e. THE BASELINE FIX ---
+# Two bumps in flight on linear main: v1.4.0's release job is still sitting in
+# the 90-minute Tier-1 gate when v1.5.0 is force-released (a forced release
+# skips the gate, so it can overtake). By the time v1.4.0's notes are built,
+# v1.5.0 is the highest tag in the repo AND a DESCENDANT of v1.4.0's commit —
+# so ``--sort=-v:refname | head -1`` yields a baseline that already contains
+# everything, and the range collapses to nothing.
+git tag v1.3.0 "$V130"
+commit i.txt 1 "fix: foxtrot (#6)"
+commit j.txt 1 "chore: bump version to 1.4.0"
+V140=$(git rev-parse HEAD)
+commit k.txt 1 "feat: golf (#7)"
+commit l.txt 1 "chore: bump version to 1.5.0"
+git tag v1.5.0 HEAD
+
+OLD_PREV=$(git tag --list 'v*' --sort=-v:refname | head -1)
+check "old logic picks the highest tag" "$OLD_PREV" "v1.5.0"
+check "old logic's range is EMPTY (would publish 'no changes recorded')" \
+  "$(git rev-list --count "$OLD_PREV..$V140")" "0"
+
+BODY=$(VERSION=1.4.0 RELEASE_SHA="$V140" SKIP_CONTRIBUTORS=1 bash build.sh 2>"$TMP/e2")
+contains "$(cat "$TMP/e2")" "baseline: v1.3.0" "new logic picks nearest ANCESTOR tag, not highest"
+check "new logic lists the 2 real commits" "$(grep -c '^- ' <<<"$BODY")" "2"
+lacks "$BODY" "_(no changes recorded)_" "new logic does not emit 'no changes recorded'"
+lacks "$BODY" "golf" "new logic excludes commits that came after the release"
+
+# --- 2f. re-run safety: the version's own tag must not become the baseline ---
+git tag v1.4.0 "$V140"
+BODY=$(VERSION=1.4.0 RELEASE_SHA="$V140" SKIP_CONTRIBUTORS=1 bash build.sh 2>"$TMP/e3")
+contains "$(cat "$TMP/e3")" "baseline: v1.3.0" "re-run with tag already present: baseline unchanged"
+check "re-run still lists 2 commits" "$(grep -c '^- ' <<<"$BODY")" "2"
+
+# --- 2g. first release ever (no ancestor tag) ---
+SB2="$TMP/sandbox2"; mkdir -p "$SB2"; cd "$SB2"
+git init -q .; git config user.email t@t; git config user.name t; git config commit.gpgsign false
+printf 1 > a; git add -A; git commit -qm "feat: first"
+printf 2 > b; git add -A; git commit -qm "chore: bump version to 0.1.0"
+BODY=$(VERSION=0.1.0 RELEASE_SHA="$(git rev-parse HEAD)" SKIP_CONTRIBUTORS=1 bash "$SCRIPT" 2>"$TMP/e4")
+contains "$(cat "$TMP/e4")" "first release" "no tags at all: falls back to git log -50"
+check "no tags at all: lists both commits" "$(grep -c '^- ' <<<"$BODY")" "2"
+
+echo
+printf 'passed %d, failed %d\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/tests/release/test_build_release_notes.sh
+++ b/tests/release/test_build_release_notes.sh
@@ -35,7 +35,7 @@ echo "== 1. real history: the notes describe exactly the tagged tree =="
 cd "$REPO_ROOT"
 if git rev-parse --verify --quiet v0.11.6 >/dev/null && \
    git rev-parse --verify --quiet v0.11.5 >/dev/null; then
-  SHA=$(git rev-parse v0.11.6^{commit})
+  SHA=$(git rev-parse "v0.11.6^{commit}")
   BODY=$(VERSION=0.11.6 RELEASE_SHA="$SHA" SKIP_CONTRIBUTORS=1 bash "$SCRIPT" 2>"$TMP/err")
 
   contains "$(cat "$TMP/err")" "baseline: v0.11.5" "baseline is the nearest ANCESTOR tag (v0.11.5)"
@@ -54,6 +54,7 @@ if git rev-parse --verify --quiet v0.11.6 >/dev/null && \
   check "every cited SHA is an ancestor of v0.11.6" "$BAD" "0"
 
   contains "$BODY" "## What's new in v0.11.6" "heading preserved"
+  # shellcheck disable=SC2016  # the backticks are literal markdown, not a subshell
   contains "$BODY" 'Install: `brew upgrade rapid-mlx`' "Install: line preserved"
   lacks "$BODY" "<details>" "no <details> when there are no highlights"
 else


### PR DESCRIPTION
## Why

Two defects in `auto-release.yml`'s release-notes generation.

**① The notes were a `git log` dump.** `git log --pretty='- %s (%h)'` tells a reader *what commits happened*; it never tells them *what changed and why they should upgrade*. A bash step can't write prose and we're not putting an LLM in the release path, so the prose has to be captured by a human while the work is done and merely assembled at release time.

**② The notes could describe a different tree than the tag.** Two independent reads of "the current commit" (`HEAD` for the notes, `github.sha` for the tag), and a baseline picked by version-string sort rather than by ancestry. Neither has fired yet — see the audit below — but both are one small change away from publishing a release that lies about its own contents.

---

## ② Root cause — and both stated hypotheses are wrong

I could not reproduce the reported v0.11.6 symptom, and I want to be direct about that rather than confirm it.

Against the live remote, `v0.11.6` → `7f0ffba9`, and all three "unreachable" commits **are** ancestors of it:

```
$ git log --oneline v0.11.5..v0.11.6      # 7 commits, not 4
7f0ffba9 chore: bump version to 0.11.6
d6e0148b fix(cache): persist and reuse DeepSeek V4 prefixes across restarts
ff54ad47 test: make G7 RAPID_MLX_BASE_URL guard test banner-format agnostic (#1382)
55f983b9 fix(deepseek-v4): cut warm TTFT and contain reasoning (#1383)
ef495bf4 feat(deepseek): add native DSpark speculative decoding (#1379)
585ae36d fix(agent): stop long repetition loops earlier (#1378)
0796ea7c fix(agent): stop runaway exact repetition loops (#1377)

$ git merge-base --is-ancestor ef495bf4 v0.11.6 && echo YES
YES        # same for 585ae36d and 0796ea7c
```

The published v0.11.6 body is exactly those 7 lines. I then audited **all 185 releases**: every SHA cited in every release body is an ancestor of its own tag — **0 bad citations**. And comparing each body against `git rev-list <nearest-ancestor-tag>..<tag>`, every release since **v0.11.1** has an exactly-correct range.

The pre-v0.11.1 mismatches are real but already fixed and unrelated: those bodies all cite exactly 2 commits regardless of range size (v0.10.16: cited 2, true 27) because the job checked out with `fetch-depth: 2`. Commit `940af51a` changed it to `fetch-depth: 0`.

So the evidence in the brief came from a stale clone — which is consistent with those three SHAs having been *merge* commits in an older `main` lineage.

**On the two hypotheses:**

- **(b) is wrong as a mechanism.** `actions/checkout` fetches `+<github.sha>:refs/remotes/origin/main` and checks out that start-point, so `HEAD` *is* `github.sha`, and `--target "$TARGET_SHA"` passes the same `github.sha`. They come from the same immutable event payload and cannot drift. The 90-minute gate window doesn't change that.
- **(a) is right about the smell, wrong about the symptom.** `--sort=-v:refname` orders correctly and version skips (v0.11.2, v0.10.13) are handled fine. But `head -1` picks the **globally highest tag**, not the newest tag that is an *ancestor* of the release commit. When they differ the range doesn't produce *wrong* commits — it produces **too few, usually zero**.

**The mechanism that can actually produce the reported symptom is a third one, in the create step.** The idempotency guard is `gh release view "$TAG"` — that checks for a **Release object**, not for the **tag**. A tag can exist without a Release (a prior run that died between tag and release; a hand-pushed tag; a deleted release). In that case we fall through to `gh release create`, and per GitHub's REST API, `target_commitish` is *"unused if the Git tag already exists"* — the tag is silently reused and `--target` ignored. The body was computed from `HEAD`, so you get precisely "notes describing one tree attached to a tag pointing at another". This is the one path in the job that can ship a lying release, and it was unguarded.

### What changed

- **Resolve the release commit once.** `RELEASE_SHA` is derived from `github.sha`, asserted equal to the checked-out `HEAD` (fails the job otherwise), exported as a step output, and used for the notes, the ancestry assert, and `--target`. No bare `HEAD` is read twice.
- **Baseline by ancestry:** `git describe --tags --abbrev=0 --match 'v[0-9]*' --exclude "$TAG" "$RELEASE_SHA"` replaces `git tag --list | sort | head -1`. `--exclude "$TAG"` stops a re-run from selecting the version's own tag (which would empty the range).
- **Pre-condition:** if the tag exists at a *different* commit → **hard fail** with an explanation, instead of silently publishing onto it.
- **Post-condition:** after `gh release create`, re-fetch the tag and assert it points at `RELEASE_SHA`.
- **Ancestry assert:** every SHA cited in the generated list must be reachable from `RELEASE_SHA`, else fail. (SHAs cited in *hand-written* prose only **warn** — notes must never block a release.)
- **Body moved from `$GITHUB_OUTPUT` to a file.** The old `body<<__EOF__` heredoc could be escaped by any line equal to the delimiter — newly reachable now that human-authored markdown is embedded, and already reachable via a commit subject. A file has no delimiter and never passes through `${{ }}`.

The concrete reachable cases for the baseline bug: a `force_release` (which skips the gate, so it can overtake a normal release still sitting in the 90-min gate) tagging a **descendant**; re-running an older `release` job after newer tags land (the re-run reuses `detect`'s cached "tag is new" answer). Both make `highest..HEAD` empty → `_(no changes recorded)_`. Test 2e reproduces this.

---

## ① Design chosen: (A), a curated file — `docs/release-notes/vX.Y.Z.md`

`scripts/build_release_notes.sh` reads `docs/release-notes/vX.Y.Z.md` **out of the commit being tagged**. Present → verbatim at the top, commit list appended under a collapsed `<details><summary>All changes</summary>`. Absent/empty → today's flat commit list.

**Why not (C), harvest `## Why` from PR bodies.** Tempting because `pr-validate` already enforces it, so the text exists at zero new author cost. But `## Why` is written to justify a change *to a reviewer* — it argues from defect to root cause and cites internal file paths and CI job names. Lifting 10–20 of them verbatim yields a wall of internal justification, not an announcement. Two structural blockers: it cannot produce the **framing paragraph** (no single PR knows what the release as a whole is about) and it cannot produce **cross-PR benchmark tables** (numbers live in a PR's comments, not its `## Why`). And it silently produces nothing for direct pushes — `7f0ffba9`, `d6e0148b`, `e3d0b6b8`, `b8ab5c5e` all landed on `main` with no `(#N)` at all, i.e. 4 of the last 12 release-range commits. So it's the *least* controllable option for the highest-value part of the notes, and it adds a rate-limited `gh pr view` per PR to the release path.

**Why not (B), per-PR fragments.** It does solve merge conflicts. But the target style is *editorial*: a framing paragraph, a handful of highlights **chosen** from many PRs, and tables that summarize a feature across several PRs. Fragments are per-PR by construction — they can't express "these three PRs are one highlight", can't drop the 12 PRs that don't matter, and assemble in arbitrary order. It also taxes every routine PR with a file. At ~10–20 PRs per release, conflict pressure on one file is low, so the problem it solves isn't one we have.

**Why (A) wins.** One file, fully human-controlled, expresses framing + curated highlights + tables + caveats naturally, zero burden on routine PRs, and degrades to exactly today's behaviour when empty.

**On "roll into a dated archive and reset":** the reset is a `git mv` in the version-bump PR, not a CI step. Having the workflow commit back to `main` would need push access to a protected branch and could race a concurrent merge — the workflow only ever *reads* the release commit. Naming the file after its version also makes stale prose **structurally impossible**: `v0.11.9.md` can only ever publish as v0.11.9, so a forgotten reset can't re-ship last release's highlights. The files accumulate, so `docs/release-notes/` doubles as a browsable in-repo changelog.

**On making caveats easy:** `docs/release-notes/README.md` puts the negative result in the template itself, with the omlx line as the worked example, and states *why* — a reader who finds one honest caveat trusts every other number on the page.

Kept intact: the `## What's new in vX.Y.Z` heading, the ⚠️ emergency banner with actor + reason, `## Community contributors`, the trailing `Install:` line. No new secret or permission.

---

## Testing

Logic extracted to `scripts/build_release_notes.sh` so it runs without cutting a release. `./tests/release/test_build_release_notes.sh` — **43 assertions, all passing** — against this repo's real history plus a synthetic repo for cases real history can't produce on demand.

**(i) `v0.11.5..v0.11.6` gives the 4… actually the 7 real commits.** The brief expected 4; the real range is 7, and the notes match it exactly:

```
== 1. real history: the notes describe exactly the tagged tree ==
  PASS baseline is the nearest ANCESTOR tag (v0.11.5)
  PASS commit list == git log v0.11.5..v0.11.6
  PASS commit count
  PASS every cited SHA is an ancestor of v0.11.6
  PASS heading preserved
  PASS Install: line preserved
  PASS no <details> when there are no highlights
-- sweep: recent tags --
  PASS v0.11.9: 9 commits == git rev-list v0.11.8..v0.11.9
  PASS v0.11.8: 2 commits == git rev-list v0.11.7..v0.11.8
  PASS v0.11.7: 2 commits == git rev-list v0.11.6..v0.11.7
  PASS v0.11.6: 7 commits == git rev-list v0.11.5..v0.11.6
  PASS v0.11.5: 8 commits == git rev-list v0.11.4..v0.11.5
  PASS v0.11.4: 18 commits == git rev-list v0.11.3..v0.11.4
  PASS v0.11.3: 59 commits == git rev-list v0.11.1..v0.11.3
  PASS v0.11.1: 39 commits == git rev-list v0.11.0..v0.11.1
```

**Degradation is byte-for-byte.** New script vs. the *published* v0.11.6 body:

```
$ diff <(gh release view v0.11.6 --json body -q .body) <(VERSION=0.11.6 RELEASE_SHA=$(git rev-parse v0.11.6) bash scripts/build_release_notes.sh)
IDENTICAL
```

**(ii) highlights assemble / degrade, and (iii) the banner:**

```
  PASS no highlights: 3 commits listed
  PASS no highlights: commit list is NOT collapsed
  PASS highlights: prose prepended
  PASS highlights: benchmark table intact
  PASS highlights: negative result intact
  PASS highlights: commit list collapsed
  PASS highlights: HTML comments stripped
  PASS highlights: prose is above All changes
  PASS empty highlights file: degrades to flat commit list
  PASS forced: banner rendered
  PASS forced: actor + reason
  PASS forced: missing reason falls back
  PASS old logic picks the highest tag
  PASS old logic's range is EMPTY (would publish 'no changes recorded')
  PASS new logic picks nearest ANCESTOR tag, not highest
  PASS new logic lists the 2 real commits
  PASS re-run with tag already present: baseline unchanged
  PASS no tags at all: falls back to git log -50
```

**Contributor section, live `gh`, real range** (`origin/main` as a hypothetical v0.11.10):

```
## Community contributors

- [@2005rishabh](https://github.com/2005rishabh) — [fix(auth): normalize bearer token whitespace for rate limit stability](https://github.com/raullenchai/Rapid-MLX/pull/1291)
```

**Rendered with highlights** (built on a throwaway commit over real history, then discarded):

<details>
<summary>Full rendered body</summary>

```markdown
## What's new in v0.11.10

0.11.10 is a dependency-pinning release: it stops a silent mlx upgrade from
degrading generation quality, and tightens auth token handling.

## Highlights

**mlx/mlx-lm/mlx-vlm are now upper-bounded** — an unpinned transitive bump could
land a wheel whose kernels we had never swept, and the failure mode was silent
quality loss rather than an import error. Bounds now move only behind a
coherence sweep. ([#1400](https://github.com/raullenchai/Rapid-MLX/pull/1400))

| Context | Prefill tok/s | Decode tok/s |
| ------: | ------------: | -----------: |
|      1K |         3,180 |         62.4 |
|    128K |         1,090 |         27.6 |

| Workload | Off | On | Change | Acceptance |
| -------- | --: | -: | -----: | ---------: |
| Code     |  42 | 88 |  +110% |        71% |
| Prose    |  44 | 45 |    +2% |     32-57% |

Prose lands at 32 to 57% acceptance and does not consistently gain, so the
adaptive controller parks speculation there.

<details>
<summary>All changes</summary>

- chore: bump version to 0.11.10 (6121832a)
- fix(deps): cap mlx/mlx-lm/mlx-vlm + gate bound bumps on a coherence sweep (#1248) (#1400) (4f03c49f)
- fix(auth): normalize bearer token whitespace for rate limit stability (#1291) (4d6fe3ec)

</details>

## Community contributors

- [@2005rishabh](https://github.com/2005rishabh) — [fix(auth): ...](https://github.com/raullenchai/Rapid-MLX/pull/1291)

Install: `brew upgrade rapid-mlx` or `pip install -U rapid-mlx==0.11.10` (or just `rapid-mlx upgrade`).
```

</details>

**Static checks:** `yaml.safe_load` parses; `shellcheck` clean on `build_release_notes.sh`, the test script, and all four workflow `run:` blocks extracted individually. No `.py` touched, so no `ruff` run needed.

## Safety

Diff of `auto-release.yml` grepped for `pull_request|self-hosted|rapidmlx-studio|needs:|force_release|force_version|runs-on|uses:` → **no matches**. Triggers remain `push` + `workflow_dispatch`; `tier1-agent-gate` and its `runs-on` are untouched; `release: needs: [detect, tier1-agent-gate]` unchanged; `force_release` semantics unchanged; no new action introduced (nothing to SHA-pin); no tags created, moved, or deleted.

## Not fixed

- **The `detect` → `release` TOCTOU is narrowed, not closed.** `detect` checks the tag doesn't exist, then the gate runs for up to 90 min. If a tag appears in that window we now *fail loudly* instead of publishing wrongly — but a genuine race still needs a human. Properly closing it needs a workflow-level `concurrency` group, which I did not add because it interacts with the gate's own `concurrency` group and with `force_release` overtaking, and that deserves its own PR.
- **I could not verify GitHub's tag-reuse behaviour empirically** — doing so would require creating a tag on the remote. The pre/post-condition guards are written from the REST API contract (`target_commitish` "unused if the Git tag already exists"); the post-condition assert is what makes it safe if that contract ever differs.
- **The `## Highlights` heading is not enforced.** The file is prepended verbatim, so a maintainer can write anything. Deliberate: schema validation on prose is exactly the kind of thing that blocks a release over formatting.
