### PR TITLE
fix(deepseek): stabilize Codex loops and adapt DSpark depth

### DIFF
--- a/tests/test_deepseek_v4_vendored.py
+++ b/tests/test_deepseek_v4_vendored.py
@@ -457,3 +457,15 @@ def test_deepseek_v4_dspark_drafts_checkpoint_block():
     mx.eval(output_ids, logits)
     assert output_ids.shape == (1, 6)
     assert logits.shape == (1, 5, 128)
+
+    short_proposal = model.dspark_forward(
+        mx.array([[4]], dtype=mx.int32),
+        model._last_dspark_hidden,
+        draft_cache,
+        max_draft_tokens=2,
+    )
+    assert short_proposal is not None
+    short_ids, short_logits = short_proposal
+    mx.eval(short_ids, short_logits)
+    assert short_ids.shape == (1, 3)
+    assert short_logits.shape == (1, 2, 128)

--- a/tests/test_dspark_scheduler.py
+++ b/tests/test_dspark_scheduler.py
@@ -6,7 +6,22 @@ from types import SimpleNamespace
 
 import mlx.core as mx
 
-from vllm_mlx.scheduler import _install_dspark, _replay_dspark_committed
+from vllm_mlx.scheduler import (
+    _adapt_dspark_depth,
+    _install_dspark,
+    _replay_dspark_committed,
+)
+
+
+def test_adaptive_depth_shrinks_cools_down_and_recovers() -> None:
+    depth, streak, cooldown = _adapt_dspark_depth(5, 5, 1, 5, 0)
+    assert (depth, streak, cooldown) == (4, 1, False)
+    depth, streak, cooldown = _adapt_dspark_depth(depth, 5, 0, 4, streak)
+    assert (depth, streak, cooldown) == (3, 2, False)
+    depth, streak, cooldown = _adapt_dspark_depth(depth, 5, 1, 3, streak)
+    assert (depth, streak, cooldown) == (1, 0, True)
+    # The post-cooldown K=1 probe can grow again after a full accept.
+    assert _adapt_dspark_depth(1, 5, 1, 1, 0) == (2, 0, False)
 
 
 class _Cache:

--- a/tests/test_metrics_route.py
+++ b/tests/test_metrics_route.py
@@ -112,6 +112,7 @@ _FULL_STATS = {
     "num_running": 3,
     "num_requests_processed": 17,
     "num_repetition_loop_stops": 3,
+    "num_repetition_loop_breaks": 2,
     "total_prompt_tokens": 1234,
     "total_completion_tokens": 5678,
     "steps_executed": 99,
@@ -143,6 +144,7 @@ def test_metrics_exposes_all_expected_series(metrics_client):
         "rapid_mlx_build_info",
         "rapid_mlx_requests_processed_total",
         "rapid_mlx_repetition_loop_stops_total",
+        "rapid_mlx_repetition_loop_breaks_total",
         "rapid_mlx_prompt_tokens_total",
         "rapid_mlx_completion_tokens_total",
         "rapid_mlx_requests_running",
@@ -171,6 +173,7 @@ def test_metrics_values_match_get_stats(metrics_client):
 
     assert "rapid_mlx_requests_processed_total 17" in body
     assert "rapid_mlx_repetition_loop_stops_total 3" in body
+    assert "rapid_mlx_repetition_loop_breaks_total 2" in body
     assert "rapid_mlx_prompt_tokens_total 1234" in body
     assert "rapid_mlx_completion_tokens_total 5678" in body
     assert "rapid_mlx_requests_running 3" in body

--- a/tests/test_repetition_guard.py
+++ b/tests/test_repetition_guard.py
@@ -3,7 +3,13 @@
 
 from unittest.mock import MagicMock
 
-from vllm_mlx.repetition_guard import detect_repeated_token_suffix
+import mlx.core as mx
+
+from vllm_mlx.repetition_guard import (
+    AgentRepetitionLogitsProcessor,
+    detect_repeated_token_suffix,
+    predict_repeated_token_suffix,
+)
 from vllm_mlx.request import Request, RequestStatus, SamplingParams
 from vllm_mlx.scheduler import Scheduler, SchedulerConfig
 
@@ -30,6 +36,34 @@ def test_long_loop_period_stops_after_three_copies():
     assert match is not None
     assert match.period_tokens == 61
     assert match.repeats == 3
+
+
+def test_predicts_only_the_token_that_would_extend_loop():
+    pattern = list(range(12))
+    # The hard guard needs six copies; the preventative path arms after five.
+    intervention = predict_repeated_token_suffix(pattern * 5)
+    assert intervention is not None
+    assert intervention.period_tokens == 12
+    assert intervention.repeats == 5
+    assert intervention.blocked_token_id == pattern[0]
+    assert predict_repeated_token_suffix(pattern * 4) is None
+
+
+def test_logits_processor_masks_predicted_token_once():
+    pattern = list(range(12))
+    processor = AgentRepetitionLogitsProcessor(pattern * 5)
+    logits = mx.zeros((1, 32))
+    processed = processor(mx.array([pattern[-1]]), logits)
+    mx.eval(processed)
+    assert float(processed[0, pattern[0]].item()) == float("-inf")
+    assert float(processed[0, pattern[1]].item()) == 0.0
+    assert processor.interventions == 1
+    # Speculative verification can invoke processors for several positions
+    # before the streamed history advances. Intervene only once per history.
+    second = processor(mx.array([pattern[-1]]), logits)
+    mx.eval(second)
+    assert float(second[0, pattern[0]].item()) == 0.0
+    assert processor.interventions == 1
 
 
 def test_ignores_short_stutter_and_near_repeat():

--- a/vllm_mlx/models/deepseek_v4.py
+++ b/vllm_mlx/models/deepseek_v4.py
@@ -1280,6 +1280,7 @@ class Model(nn.Module):
         anchor_ids: mx.array,
         main_hidden: mx.array,
         cache: list[RotatingKVCache],
+        max_draft_tokens: int | None = None,
     ) -> tuple[mx.array, mx.array, mx.array] | None:
         if not self.mtp:
             return None
@@ -1292,6 +1293,8 @@ class Model(nn.Module):
             return None
 
         K = self.args.dspark_block_size
+        if max_draft_tokens is not None:
+            K = max(1, min(K, int(max_draft_tokens)))
         draft_ids = mx.full(
             (anchor_ids.shape[0], K),
             self.args.dspark_noise_token_id,

--- a/vllm_mlx/repetition_guard.py
+++ b/vllm_mlx/repetition_guard.py
@@ -12,6 +12,8 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from math import ceil
 
+import mlx.core as mx
+
 
 @dataclass(frozen=True)
 class RepetitionMatch:
@@ -19,6 +21,15 @@ class RepetitionMatch:
 
     period_tokens: int
     repeats: int
+
+
+@dataclass(frozen=True)
+class RepetitionIntervention:
+    """The next token that would extend a near-certain exact loop."""
+
+    period_tokens: int
+    repeats: int
+    blocked_token_id: int
 
 
 def detect_repeated_token_suffix(
@@ -70,3 +81,86 @@ def detect_repeated_token_suffix(
         ):
             return RepetitionMatch(period_tokens=period, repeats=repeats)
     return None
+
+
+def predict_repeated_token_suffix(
+    token_ids: Sequence[int],
+    *,
+    min_period_tokens: int = 1,
+    max_period_tokens: int = 128,
+    required_repeats: int = 3,
+    min_repeated_tokens: int = 72,
+    min_short_period_tokens: int = 256,
+    max_window_tokens: int = 768,
+) -> RepetitionIntervention | None:
+    """Return the one token that would complete the guard's next loop copy.
+
+    This is the preventative counterpart to :func:`detect_repeated_token_suffix`.
+    It waits until one copy before the hard-stop threshold, then identifies the
+    exact next token implied by the periodic suffix.  Masking only that token is
+    enough to let sampling escape without aborting an already-streaming request.
+    """
+
+    if required_repeats < 2 or min_period_tokens < 1:
+        raise ValueError("invalid repetition guard thresholds")
+    tokens = token_ids[-max_window_tokens:]
+    max_period = min(max_period_tokens, len(tokens) // (required_repeats - 1))
+    for period in range(min_period_tokens, max_period + 1):
+        repeated_floor = min_short_period_tokens if period < 6 else min_repeated_tokens
+        stop_repeats = max(required_repeats, ceil(repeated_floor / period))
+        precursor_repeats = stop_repeats - 1
+        precursor_tokens = period * precursor_repeats
+        if precursor_tokens > len(tokens):
+            continue
+        suffix = tokens[-precursor_tokens:]
+        pattern = suffix[:period]
+        if any(
+            period % smaller == 0 and pattern == pattern[:smaller] * (period // smaller)
+            for smaller in range(1, period)
+        ):
+            continue
+        if all(
+            suffix[offset : offset + period] == pattern
+            for offset in range(period, precursor_tokens, period)
+        ):
+            return RepetitionIntervention(
+                period_tokens=period,
+                repeats=precursor_repeats,
+                blocked_token_id=pattern[0],
+            )
+    return None
+
+
+class AgentRepetitionLogitsProcessor:
+    """Break exact agent loops before the scheduler has to abort the stream.
+
+    The hot path only scans a bounded Python token-id suffix.  An MLX mask is
+    allocated solely when an intervention is required, so normal decoding pays
+    no per-token GPU work.  A small intervention cap leaves the existing hard
+    stop authoritative for a model that repeatedly falls back into a loop.
+    """
+
+    def __init__(self, output_token_ids: list[int], *, max_interventions: int = 3):
+        self.output_token_ids = output_token_ids
+        self.max_interventions = max_interventions
+        self.interventions = 0
+        self.last_match: RepetitionIntervention | None = None
+        self._last_intervention_length = -1
+
+    def __call__(self, _tokens: mx.array, logits: mx.array) -> mx.array:
+        if self.interventions >= self.max_interventions:
+            return logits
+        history_length = len(self.output_token_ids)
+        if history_length == self._last_intervention_length:
+            return logits
+        match = predict_repeated_token_suffix(self.output_token_ids)
+        if match is None:
+            return logits
+        token_id = match.blocked_token_id
+        if token_id < 0 or token_id >= logits.shape[-1]:
+            return logits
+        self.interventions += 1
+        self.last_match = match
+        self._last_intervention_length = history_length
+        token_mask = mx.arange(logits.shape[-1]) == token_id
+        return mx.where(token_mask[None, :], -mx.inf, logits)

--- a/vllm_mlx/routes/metrics.py
+++ b/vllm_mlx/routes/metrics.py
@@ -1007,6 +1007,14 @@ def _render_prometheus(cfg: Any) -> str:
     )
     lines.extend(
         _fmt_metric(
+            "rapid_mlx_repetition_loop_breaks_total",
+            "counter",
+            "Agent generations steered away from an exact token loop before abort.",
+            int(_coerce_number(stats.get("num_repetition_loop_breaks"))),
+        )
+    )
+    lines.extend(
+        _fmt_metric(
             "rapid_mlx_prompt_tokens_total",
             "counter",
             "Cumulative prompt tokens consumed across all requests.",

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -11,6 +11,7 @@ The scheduler follows vLLM's design with:
 - Continuous batching via BatchGenerator
 """
 
+import inspect
 import logging
 import os
 import threading
@@ -49,7 +50,10 @@ from .memory_cache import MemoryAwarePrefixCache, MemoryCacheConfig  # noqa: E40
 from .paged_cache import PagedCacheManager
 from .pflash import PFlashConfig, compress_request_tokens
 from .prefix_cache import BlockAwarePrefixCache, PrefixCacheManager
-from .repetition_guard import detect_repeated_token_suffix
+from .repetition_guard import (
+    AgentRepetitionLogitsProcessor,
+    detect_repeated_token_suffix,
+)
 from .request import Request, RequestOutput, RequestStatus, SamplingParams
 from .utils.decode import IncrementalDecoder
 from .utils.mamba_cache import ensure_mamba_support
@@ -1395,6 +1399,26 @@ def _replay_dspark_committed(
     return cache_snapshot
 
 
+def _adapt_dspark_depth(
+    current_depth: int,
+    max_depth: int,
+    accepted: int,
+    proposed: int,
+    low_accept_streak: int,
+) -> tuple[int, int, bool]:
+    """Adjust DSpark depth and report whether a baseline cooldown is due."""
+
+    if proposed > 0 and accepted == proposed:
+        return min(max_depth, current_depth + 1), 0, False
+    if accepted <= 1:
+        next_depth = max(1, current_depth - 1)
+        next_streak = low_accept_streak + 1
+        if next_streak >= 3:
+            return 1, 0, True
+        return next_depth, next_streak, False
+    return current_depth, 0, False
+
+
 def _install_dspark(
     batch_gen: "BatchGenerator",
     model: Any,
@@ -1437,7 +1461,11 @@ def _install_dspark(
     # reached part-way through its accepted tokens. DeepSeek V4's pooling
     # caches are not trimmable, so exact replay is the only safe rollback.
     _pending_replay: dict[int, tuple[Any, mx.array]] = {}
-    _disabled_uids: set[int] = set()
+    _depths: dict[int, int] = {}
+    _cooldowns: dict[int, int] = {}
+    _supports_variable_depth = (
+        "max_draft_tokens" in inspect.signature(model.dspark_forward).parameters
+    )
     _stats = {
         "verify_steps": 0,
         "draft_tokens_proposed": 0,
@@ -1456,6 +1484,10 @@ def _install_dspark(
                 "draft_tokens_proposed": 0,
                 "tokens_accepted": 0,
                 "full_accept_rounds": 0,
+                "fallback_events": 0,
+                "low_accept_streak": 0,
+                "min_depth": draft_k,
+                "max_depth": draft_k,
             },
         )
 
@@ -1475,7 +1507,9 @@ def _install_dspark(
             return _orig_step()
         uid = gb.uids[0]
         uid_stats = _request_stats(uid)
-        if uid in _disabled_uids:
+        cooldown = _cooldowns.get(uid, 0)
+        if cooldown > 0:
+            _cooldowns[uid] = cooldown - 1
             _stats["fallthrough_steps"] += 1
             return _orig_step()
         if not _is_greedy(uid):
@@ -1491,9 +1525,18 @@ def _install_dspark(
             _stats["fallthrough_steps"] += 1
             return _orig_step()
         dspark_cache = _caches.setdefault(uid, model.make_dspark_cache())
+        current_k = _depths.setdefault(uid, draft_k)
         offsets_before = [cache.offset for cache in dspark_cache]
         try:
-            proposal = model.dspark_forward(inputs[:, None], hidden, dspark_cache)
+            if _supports_variable_depth:
+                proposal = model.dspark_forward(
+                    inputs[:, None],
+                    hidden,
+                    dspark_cache,
+                    max_draft_tokens=current_k,
+                )
+            else:
+                proposal = model.dspark_forward(inputs[:, None], hidden, dspark_cache)
         except Exception as exc:  # noqa: BLE001
             logger.warning("[DSpark] draft failed; falling back: %r", exc)
             _stats["errors"] += 1
@@ -1503,7 +1546,7 @@ def _install_dspark(
             return _orig_step()
 
         output_ids, _ = proposal
-        draft = [int(v) for v in output_ids[0, 1 : draft_k + 1].tolist()]
+        draft = [int(v) for v in output_ids[0, 1 : current_k + 1].tolist()]
         K = len(draft)
         _stats["verify_steps"] += 1
         _stats["draft_tokens_proposed"] += K
@@ -1592,12 +1635,26 @@ def _install_dspark(
             _pending_replay[uid] = (target_cache_snapshot, verify_input)
         _stats["tokens_accepted"] += accepted
         uid_stats["tokens_accepted"] += accepted
-        rounds = int(uid_stats["verify_steps"])
-        average_accept = float(uid_stats["tokens_accepted"]) / float(rounds)
-        if (rounds >= 3 and average_accept < 1.5) or (
-            rounds >= 6 and average_accept < 2.0
-        ):
-            _disabled_uids.add(uid)
+        # oMLX's most important operational lesson is that a fixed speculative
+        # depth is wrong for coding agents: acceptance changes sharply across
+        # prose, JSON and tool-call boundaries.  Use a conservative AIMD-like
+        # controller here. Full accepts grow depth; weak rounds shrink it; three
+        # weak rounds take a short baseline cooldown and then probe again at K=1
+        # instead of permanently disabling DSpark for the rest of the request.
+        current_k, low_streak, needs_cooldown = _adapt_dspark_depth(
+            current_k,
+            draft_k,
+            accepted,
+            K,
+            int(uid_stats["low_accept_streak"]),
+        )
+        uid_stats["low_accept_streak"] = low_streak
+        _depths[uid] = current_k
+        uid_stats["min_depth"] = min(int(uid_stats["min_depth"]), current_k)
+        uid_stats["max_depth"] = max(int(uid_stats["max_depth"]), current_k)
+        if needs_cooldown:
+            _cooldowns[uid] = 16
+            uid_stats["fallback_events"] = int(uid_stats["fallback_events"]) + 1
         return [last_token], [primary_lp]
 
     def _finish_uid(uid: int) -> None:
@@ -1607,7 +1664,8 @@ def _install_dspark(
         rounds = int(request_stats.get("verify_steps", 0))
         logger.info(
             "[DSpark] completed uid=%s rounds=%d accepted=%d/%d "
-            "avg_accept=%.2f full_accept=%d/%d adaptive_fallback=%s",
+            "avg_accept=%.2f full_accept=%d/%d depth=%d..%d "
+            "fallback_events=%d",
             uid,
             rounds,
             accepts,
@@ -1615,12 +1673,15 @@ def _install_dspark(
             accepts / rounds if rounds else 0.0,
             int(request_stats.get("full_accept_rounds", 0)),
             rounds,
-            uid in _disabled_uids,
+            int(request_stats.get("min_depth", 0)),
+            int(request_stats.get("max_depth", 0)),
+            int(request_stats.get("fallback_events", 0)),
         )
         _pending.pop(uid, None)
         _pending_replay.pop(uid, None)
         _caches.pop(uid, None)
-        _disabled_uids.discard(uid)
+        _depths.pop(uid, None)
+        _cooldowns.pop(uid, None)
 
     def _dspark_next():
         responses = _orig_next()
@@ -2522,6 +2583,7 @@ class Scheduler:
         # from normal completed-request accounting so operators can distinguish
         # healthy EOS stops from model degeneration.
         self.num_repetition_loop_stops = 0
+        self.num_repetition_loop_breaks = 0
         # PFlash observability (M-02 reframe). When PFlash compresses a
         # prompt the request bypasses the prefix-cache fetch + store
         # paths entirely (positional-fiction safety; see comment block
@@ -5369,6 +5431,14 @@ class Scheduler:
             _glp = getattr(request, "grammar_logits_processor", None)
             if _glp is not None:
                 request_processors.append(_glp)
+            # Prevent an exact agent loop before it reaches the streaming
+            # hard-stop below.  The processor is deliberately tool-request
+            # only and masks a single predicted token only after the output is
+            # one full copy short of the conservative abort threshold.
+            if request.has_tools:
+                _loop_breaker = AgentRepetitionLogitsProcessor(request.output_token_ids)
+                request._repetition_logits_processor = _loop_breaker
+                request_processors.append(_loop_breaker)
             # Penalty knobs (#355) — only add the processor when at least
             # one penalty is non-default. mlx-lm's make_logits_processors
             # returns an empty list when all knobs are at defaults, but
@@ -5664,6 +5734,23 @@ class Scheduler:
             # layer without tokenizer-family-specific casing.
             finish_reason = response.finish_reason
             stop_trimmed = False
+            _loop_breaker = getattr(request, "_repetition_logits_processor", None)
+            if isinstance(_loop_breaker, AgentRepetitionLogitsProcessor):
+                _reported = getattr(request, "_reported_repetition_breaks", 0)
+                if _loop_breaker.interventions > _reported:
+                    _new_breaks = _loop_breaker.interventions - _reported
+                    self.num_repetition_loop_breaks += _new_breaks
+                    request._reported_repetition_breaks = _loop_breaker.interventions
+                    _match = _loop_breaker.last_match
+                    logger.warning(
+                        "Broke exact token loop for agent request %s "
+                        "before stream abort (period_tokens=%s repeats=%s "
+                        "interventions=%d)",
+                        request_id,
+                        getattr(_match, "period_tokens", "unknown"),
+                        getattr(_match, "repeats", "unknown"),
+                        _loop_breaker.interventions,
+                    )
             # Agent models can occasionally enter a perfectly periodic decode
             # loop after a tool interaction.  Once streamed, those deltas cannot
             # be retracted, so stop it in the scheduler before thousands of
@@ -6586,6 +6673,7 @@ class Scheduler:
             "num_running": len(self.running),
             "num_requests_processed": self.num_requests_processed,
             "num_repetition_loop_stops": self.num_repetition_loop_stops,
+            "num_repetition_loop_breaks": self.num_repetition_loop_breaks,
             "total_prompt_tokens": self.total_prompt_tokens,
             "total_completion_tokens": self.total_completion_tokens,
             # M-02: PFlash observability counters. ``bypass_count`` is


### PR DESCRIPTION
## Summary

- prevent exact token repetition loops before they abort an already-streaming Codex request by masking only the next token that would extend the periodic suffix
- retain the existing hard abort as a bounded fallback and expose preventative interventions via logs and Prometheus
- replace DSpark fixed K=5 + permanent low-acceptance disable with variable K=1..5, short baseline cooldowns, and recovery probes
- let the vendored DeepSeek V4 DSpark head compute only the selected draft depth

## Production reproduction

A real Codex task with 131 tools reproduced the reported failure on v0.11.9:

- 37k-token prompt
- `temperature=1.0`, DSpark `rounds=0`
- exact loop: `period_tokens=22 repeats=4 completion_tokens=336`
- scheduler aborted the stream, causing Codex `Reconnecting... 1/5`

This proves the reconnect is triggered by vanilla sampled decoding, not speculative verification.

## Real-model validation

DeepSeek-V4-Flash-0731 MXFP4 on M3 Ultra 256GB:

- same deterministic 148-token coding response: 21.6 -> 23.2 tok/s (+7.4% single-run A/B)
- adaptive DSpark exercised depths 1..5 and recovered after cooldown (`fallback_events=1`)
- real Codex ran ~8 minutes / 61k context across repeated tool turns without another exact-loop abort or reconnect

## Tests

- 396 passed, 9 skipped across DeepSeek/DSpark/scheduler/prefix-cache targeted suite
- 15,130 passed, 125 skipped, 6 xfailed across the broad suite
- two broad-suite failures require a separately running localhost:8000 integration server
- one mock-compatibility failure found by the broad suite was fixed; focused rerun: 91 passed
- Ruff and `git diff --check` pass
