### PR TITLE
fix(bench): load weights on the mlx-step worker so freeform bench isn't 0 tok/s

### DIFF
--- a/tests/test_cli_bench.py
+++ b/tests/test_cli_bench.py
@@ -173,6 +173,56 @@ def test_bench_command_proceeds_when_mirror_prefetch_is_silent_noop(
     assert load_called == ["mlx-community/Qwen3-1.7B-4bit"]
 
 
+def test_bench_command_loads_weights_on_mlx_step_worker(monkeypatch) -> None:
+    """Freeform ``rapid-mlx bench <alias>`` must load the weights ON the
+    mlx-step worker thread (#170), NOT the main / asyncio thread.
+
+    mlx-lm 0.31.3+ binds the module-level generation stream (and each
+    thread's auto-default stream) to whichever thread first touches MLX.
+    Loading the weights on the main thread and then generating on the
+    engine's worker raises "There is no Stream(gpu, N) in current thread"
+    on the very first batch step, so every request aborts and the run
+    silently reports ``0.00 tok/s`` (the app's "Speed on this Mac" card
+    then shows a confident, wrong zero). Pinning the load onto the
+    ``mlx-step`` worker — the executor AsyncEngineCore then reuses — is
+    the only configuration that survives ThreadLocalStream tagging, and
+    it mirrors the ``--submit`` community path + why ``serve`` works.
+    """
+    import threading
+
+    cli = importlib.import_module("vllm_mlx.cli")
+
+    load_thread: dict[str, str] = {}
+
+    def _fake_load(name: str):
+        load_thread["name"] = threading.current_thread().name
+        # Abort before the engine spins up — this test only pins WHERE the
+        # weights are loaded, not a full generation run.
+        raise ValueError("test-abort — captured load thread")
+
+    monkeypatch.setattr(cli, "_check_disk_space", lambda *a, **kw: None)
+    monkeypatch.setattr(cli, "_check_memory_capacity", lambda *a, **kw: None)
+    monkeypatch.setattr(cli, "_ensure_model_downloaded", lambda name: None)
+    monkeypatch.setattr(
+        "vllm_mlx.pflash.resolve_pflash_mode_default",
+        lambda args, *, model_name, is_multimodal=False: "off",
+    )
+    _patch_mlx_lm_load(monkeypatch, _fake_load)
+
+    args = _make_freeform_bench_args("mlx-community/Qwen3-1.7B-4bit")
+
+    with pytest.raises(SystemExit) as exc:
+        cli.bench_command(args)
+    assert exc.value.code == 1
+
+    loaded_on = load_thread.get("name", "")
+    assert loaded_on.startswith("mlx-step"), (
+        f"weights loaded on {loaded_on!r}, not an 'mlx-step' worker — "
+        "freeform bench would hit the cross-thread GPU-stream bug and "
+        "report 0 tok/s"
+    )
+
+
 def _capture_bench_lane_signals(monkeypatch, cli):
     """Wire the bench PFlash default + validation seams to record the
     ``is_multimodal`` / ``is_mllm`` they receive, and abort before the heavy

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -4404,7 +4404,14 @@ def bench_command(args):
         print(f"Loading model: {args.model}")
         try:
             validate_local_model_file(args.model)
-            model, tokenizer = load(args.model)
+            # Load the weights ON the mlx-step worker (created + explained at
+            # the ``bench_command`` call site below) and reuse that worker for
+            # AsyncEngineCore. mlx-lm 0.31.3+ binds the generation stream to
+            # whichever thread first touches MLX, so loading here — on the same
+            # worker the engine later steps on — is what keeps the first batch
+            # step from raising "There is no Stream(gpu, N) in current thread"
+            # (which aborts every request and reports 0.00 tok/s).
+            model, tokenizer = model_load_executor.submit(load, args.model).result()
         except Exception as e:
             # Opt-in telemetry (Phase 2.2 error wiring): mirror the
             # ``serve`` path — record a bucketed model-load failure
@@ -4523,7 +4530,12 @@ def bench_command(args):
         total_prompt_tokens = 0
         total_completion_tokens = 0
 
-        async with AsyncEngineCore(model, tokenizer, engine_config) as engine:
+        # Reuse the model-load worker as the engine's mlx-step thread so
+        # weights + forward passes + cache state stay on one owning thread
+        # (see the load-executor comment above).
+        async with AsyncEngineCore(
+            model, tokenizer, engine_config, executor=model_load_executor
+        ) as engine:
             await asyncio.sleep(0.1)  # Warm up
 
             start_time = time.perf_counter()
@@ -4563,7 +4575,34 @@ def bench_command(args):
         print(f"  Tokens/second: {total_completion_tokens / total_time:.2f}")
         print(f"  Throughput: {total_tokens / total_time:.2f} tok/s")
 
-    asyncio.run(run_benchmark())
+    import concurrent.futures
+
+    from .engine_core import _init_mlx_step_thread
+
+    # Create the single mlx-step worker BEFORE loading weights and reuse it
+    # for AsyncEngineCore so weights + forward passes + cache state all live
+    # on one owning thread (#170). mlx-lm 0.31.3+ binds the module-level
+    # generation stream to whichever thread first touches MLX; loading on the
+    # main thread and generating on the engine worker raises "There is no
+    # Stream(gpu, N) in current thread" on the first batch step → every
+    # request aborts → the run silently reports 0.00 tok/s (the app's "Speed
+    # on this Mac" card then shows a confident, wrong zero). Mirrors the
+    # proven ``bench --submit`` path (``_run``) and ``BatchedEngine._start_llm``
+    # — the exact reason ``serve``/``chat`` work and this freeform path did not.
+    model_load_executor = concurrent.futures.ThreadPoolExecutor(
+        max_workers=1,
+        thread_name_prefix="mlx-step",
+        initializer=_init_mlx_step_thread,
+    )
+    try:
+        asyncio.run(run_benchmark())
+    finally:
+        # Caller-supplied executors are NOT owned or shut down by
+        # AsyncEngineCore.stop(), so reap the worker here on every exit path
+        # (success, load error → sys.exit, Ctrl-C). The worker is idle by now
+        # — the engine closed its BatchGenerator on it during stop() — so the
+        # join returns immediately.
+        model_load_executor.shutdown(wait=True)
 
 
 def _format_bytes(n: int) -> str:

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -4594,15 +4594,31 @@ def bench_command(args):
         thread_name_prefix="mlx-step",
         initializer=_init_mlx_step_thread,
     )
+    interrupted = False
     try:
         asyncio.run(run_benchmark())
+    except KeyboardInterrupt:
+        interrupted = True
+        raise
     finally:
         # Caller-supplied executors are NOT owned or shut down by
-        # AsyncEngineCore.stop(), so reap the worker here on every exit path
-        # (success, load error → sys.exit, Ctrl-C). The worker is idle by now
-        # — the engine closed its BatchGenerator on it during stop() — so the
-        # join returns immediately.
-        model_load_executor.shutdown(wait=True)
+        # AsyncEngineCore.stop(), so reap the worker here on every exit path.
+        # On a normal or load-error (sys.exit) exit the worker is idle — the
+        # engine closed its BatchGenerator on it during stop(), or the load
+        # future already finished — so this join returns immediately.
+        # ``cancel_futures`` drops any still-queued (never-started) work.
+        #
+        # Ctrl-C landing INSIDE the native ``load`` (an uninterruptible mlx
+        # weight read) is a known, inherent limitation, NOT a regression from
+        # this change: pre-PR this path loaded on the MAIN thread, equally
+        # uninterruptible, so exit already blocked until the read finished.
+        # ``wait=False`` here just avoids re-blocking in this ``finally``;
+        # concurrent.futures' atexit hook still joins the non-daemon worker at
+        # interpreter shutdown, so the wall-clock is unchanged either way and
+        # no GPU work ever escapes the process. Truly aborting a native load
+        # mid-read would need ``os._exit`` and risk leaving Metal state dirty
+        # — not worth it for a benchmark command.
+        model_load_executor.shutdown(wait=not interrupted, cancel_futures=True)
 
 
 def _format_bytes(n: int) -> str:


### PR DESCRIPTION
## Why

`rapid-mlx bench <alias>` (the **freeform** path, no `--submit`) reported
`0.00 tok/s` for every model. Root cause: it loaded the weights on the
**main thread** via `mlx_lm.load(...)`, then generated on
`AsyncEngineCore`'s **worker thread**. Under mlx-lm 0.31.3+ ThreadLocalStream
tagging (#170), the first batch step then raises:

```
RuntimeError: There is no Stream(gpu, 0) in current thread.
```

The scheduler catches it, aborts every request, and the summary still
prints a clean `Throughput: 0.00 tok/s` with exit code 0 — a **silent**
failure. This is why `serve`/`chat` work (they load on the step worker)
but freeform `bench` did not. The `--submit` community path (`_run`) was
already correct; only the freeform display path was broken.

This directly breaks the desktop app's **"Speed on this Mac"** card, which
runs the freeform path first and was showing a confident, wrong
`0 tokens / second` (and offering to submit that 0 to the leaderboard).

## Fix

Create the single `mlx-step` `ThreadPoolExecutor` (initialized with
`_init_mlx_step_thread`) **before** loading, load the weights **on that
worker** via `executor.submit(load, ...)`, and pass the same executor to
`AsyncEngineCore` — so weights + forward passes + cache state all live on
one owning thread. This mirrors the proven `bench --submit` path (`_run`)
and `BatchedEngine._start_llm`.

The executor is created at the `bench_command` call site and shut down in
a `try/finally` around `asyncio.run(run_benchmark())`, so it's reaped on
every exit path (success, load-error → `sys.exit`, Ctrl-C) — caller-owned
executors are intentionally not shut down by `AsyncEngineCore.stop()`.

## Verification

```
$ rapid-mlx bench llama3-1b-4bit --num-prompts 3 --max-tokens 20
  Total completion tokens: 60
  Tokens/second: 426.00
  Throughput: 596.40 tok/s        # was 0.00 before this fix
```

## Tests

- New regression `test_bench_command_loads_weights_on_mlx_step_worker`
  pins the load onto an `mlx-step` worker (fails if it regresses back to
  the main thread).
- Existing `tests/test_cli_bench.py` (mirror-prefetch order, graceful
  no-op, hybrid text-lane) all still pass — 7/7 green.
- `ruff check` + `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)