### PR TITLE
fix(deepseek): harden V4 DSML tool protocol

### DIFF
--- a/tests/test_deepseek_v4_0731.py
+++ b/tests/test_deepseek_v4_0731.py
@@ -123,6 +123,21 @@ def test_dsml_tool_schema_and_tool_result_are_encoded():
     assert "<tool_result>sunny</tool_result>" in prompt
 
 
+def test_dsml_parser_normalizes_codex_prefix_rule_string_to_array():
+    parser = ToolParserManager.get_tool_parser("deepseek_v4_0731")(None)
+    wire = (
+        "<｜DSML｜tool_calls>\n"
+        '<｜DSML｜invoke name="exec_command">\n'
+        '<｜DSML｜parameter name="cmd" string="true">pwd</｜DSML｜parameter>\n'
+        '<｜DSML｜parameter name="prefix_rule" string="true">git status'
+        "</｜DSML｜parameter>\n"
+        "</｜DSML｜invoke>\n</｜DSML｜tool_calls>"
+    )
+    result = parser.extract_tool_calls(wire)
+    arguments = json.loads(result.tool_calls[0]["arguments"])
+    assert arguments == {"cmd": "pwd", "prefix_rule": ["git status"]}
+
+
 def test_dsml_tool_schema_order_is_canonical_for_prefix_cache():
     messages = [
         {"role": "system", "content": "stable instructions"},
@@ -173,6 +188,40 @@ def test_dsml_tool_schema_order_is_canonical_for_prefix_cache():
         model_name="deepseek-v4-flash-0731-mxfp4",
     )
     assert first == second
+
+
+def test_dsml_prioritizes_core_agent_tools_without_losing_canonical_order():
+    messages = [{"role": "user", "content": "inspect the repository"}]
+    tools = [
+        {
+            "type": "function",
+            "function": {"name": "aaa_connector", "parameters": {"type": "object"}},
+        },
+        {
+            "type": "function",
+            "function": {
+                "name": "exec_command",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"cmd": {"type": "string"}},
+                    "required": ["cmd"],
+                },
+            },
+        },
+    ]
+
+    prompt = apply_chat_template(
+        _TokenizerWithoutTemplate(),
+        messages,
+        tools=tools,
+        enable_thinking=True,
+        model_name="deepseek-v4-flash-0731-mxfp4",
+    )
+
+    assert prompt.index('"name": "exec_command"') < prompt.index(
+        '"name": "aaa_connector"'
+    )
+    assert "Never emit an empty invoke" in prompt
 
 
 def test_dsml_ignores_connector_access_preamble_for_prefix_cache():

--- a/tests/test_deepseek_v4_0731.py
+++ b/tests/test_deepseek_v4_0731.py
@@ -135,7 +135,26 @@ def test_dsml_parser_normalizes_codex_prefix_rule_string_to_array():
     )
     result = parser.extract_tool_calls(wire)
     arguments = json.loads(result.tool_calls[0]["arguments"])
-    assert arguments == {"cmd": "pwd", "prefix_rule": ["git status"]}
+    assert arguments == {"cmd": "pwd", "prefix_rule": ["git", "status"]}
+
+
+def test_dsml_parser_preserves_quoted_prefix_rule_argument_boundaries():
+    parser = ToolParserManager.get_tool_parser("deepseek_v4_0731")(None)
+    output = (
+        '<｜DSML｜tool_calls><｜DSML｜invoke name="exec_command">'
+        '<｜DSML｜parameter name="cmd" string="true">pwd'
+        '</｜DSML｜parameter><｜DSML｜parameter name="prefix_rule" string="true">'
+        'git commit -m "hello world"</｜DSML｜parameter>'
+        "</｜DSML｜invoke></｜DSML｜tool_calls>"
+    )
+
+    result = parser.extract_tool_calls(output)
+
+    arguments = json.loads(result.tool_calls[0]["arguments"])
+    assert arguments == {
+        "cmd": "pwd",
+        "prefix_rule": ["git", "commit", "-m", "hello world"],
+    }
 
 
 def test_dsml_tool_schema_order_is_canonical_for_prefix_cache():

--- a/tests/test_deepseek_v4_0731.py
+++ b/tests/test_deepseek_v4_0731.py
@@ -157,6 +157,21 @@ def test_dsml_parser_preserves_quoted_prefix_rule_argument_boundaries():
     }
 
 
+def test_dsml_parser_does_not_normalize_empty_prefix_rule():
+    parser = ToolParserManager.get_tool_parser("deepseek_v4_0731")(None)
+    output = (
+        '<｜DSML｜tool_calls><｜DSML｜invoke name="exec_command">'
+        '<｜DSML｜parameter name="cmd" string="true">pwd'
+        '</｜DSML｜parameter><｜DSML｜parameter name="prefix_rule" string="true">'
+        "   </｜DSML｜parameter></｜DSML｜invoke></｜DSML｜tool_calls>"
+    )
+
+    result = parser.extract_tool_calls(output)
+
+    arguments = json.loads(result.tool_calls[0]["arguments"])
+    assert arguments == {"cmd": "pwd", "prefix_rule": "   "}
+
+
 def test_dsml_tool_schema_order_is_canonical_for_prefix_cache():
     messages = [
         {"role": "system", "content": "stable instructions"},

--- a/tests/test_tool_choice_enforcement.py
+++ b/tests/test_tool_choice_enforcement.py
@@ -381,10 +381,7 @@ def test_t2_deepseek_v3_alias_uses_same_prefix_as_r1_0528():
 
 def test_t2_deepseek_v4_0731_forced_prefix_opens_named_dsml_invoke():
     prefix = _forced_tool_call_prefix("deepseek_v4_0731", "exec_command")
-    assert prefix == (
-        "<｜DSML｜tool_calls>\n"
-        '<｜DSML｜invoke name="exec_command">\n'
-    )
+    assert prefix == ('<｜DSML｜tool_calls>\n<｜DSML｜invoke name="exec_command">\n')
 
 
 def test_t2_chat_route_wires_deepseek_v31_prefix_to_engine():

--- a/tests/test_tool_choice_enforcement.py
+++ b/tests/test_tool_choice_enforcement.py
@@ -379,6 +379,14 @@ def test_t2_deepseek_v3_alias_uses_same_prefix_as_r1_0528():
     assert a is not None
 
 
+def test_t2_deepseek_v4_0731_forced_prefix_opens_named_dsml_invoke():
+    prefix = _forced_tool_call_prefix("deepseek_v4_0731", "exec_command")
+    assert prefix == (
+        "<｜DSML｜tool_calls>\n"
+        '<｜DSML｜invoke name="exec_command">\n'
+    )
+
+
 def test_t2_chat_route_wires_deepseek_v31_prefix_to_engine():
     """Through the FULL chat route: ``tool_choice="required"`` + single
     tool + ``deepseek_v31`` parser must ship a ``forced_assistant_prefix``

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -295,10 +295,7 @@ def _forced_tool_call_prefix(parser_name: str | None, function_name: str) -> str
         # model still sees the selected tool's schema and must emit every
         # required argument itself, while it can no longer spend the entire
         # turn in a prose/reasoning preamble before choosing a tool.
-        return (
-            "<｜DSML｜tool_calls>\n"
-            f'<｜DSML｜invoke name="{function_name}">\n'
-        )
+        return f'<｜DSML｜tool_calls>\n<｜DSML｜invoke name="{function_name}">\n'
     # Channel-routed (harmony / gemma4) and parsers whose wire shape
     # we have NOT audited: no prefix injection. The post-parse
     # synthesis path remains as a fallback (``_synthesize_forced_tool_call``).

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -287,6 +287,18 @@ def _forced_tool_call_prefix(parser_name: str | None, function_name: str) -> str
             "<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>"
             f"function<｜tool▁sep｜>{function_name}\n```json\n"
         )
+    if parser_name == "deepseek_v4_0731":
+        if not _SAFE_DEEPSEEK_TOOL_NAME_RE.fullmatch(function_name):
+            return None
+        # V4-Flash-0731 uses the checkpoint's textual DSML envelope.  Stop
+        # after the named invoke opener rather than opening a parameter: the
+        # model still sees the selected tool's schema and must emit every
+        # required argument itself, while it can no longer spend the entire
+        # turn in a prose/reasoning preamble before choosing a tool.
+        return (
+            "<｜DSML｜tool_calls>\n"
+            f'<｜DSML｜invoke name="{function_name}">\n'
+        )
     # Channel-routed (harmony / gemma4) and parsers whose wire shape
     # we have NOT audited: no prefix injection. The post-parse
     # synthesis path remains as a fallback (``_synthesize_forced_tool_call``).

--- a/vllm_mlx/tool_parsers/deepseek_v4_0731_tool_parser.py
+++ b/vllm_mlx/tool_parsers/deepseek_v4_0731_tool_parser.py
@@ -73,6 +73,17 @@ class DeepSeekV40731ToolParser(ToolParser):
                     except json.JSONDecodeError:
                         value = raw
                 arguments[param.group("name")] = value
+            # DeepSeek occasionally serializes Codex's optional reusable
+            # approval prefix as one string even though its schema is an
+            # array of strings. The representations are unambiguous and the
+            # client semantics are identical, so normalize before strict
+            # post-generation schema validation rather than reconnecting the
+            # entire agent turn.
+            if (
+                match.group("name") == "exec_command"
+                and isinstance(arguments.get("prefix_rule"), str)
+            ):
+                arguments["prefix_rule"] = [arguments["prefix_rule"]]
             calls.append(
                 {
                     "id": f"call_{uuid.uuid4().hex[:8]}",

--- a/vllm_mlx/tool_parsers/deepseek_v4_0731_tool_parser.py
+++ b/vllm_mlx/tool_parsers/deepseek_v4_0731_tool_parser.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import json
 import re
+import shlex
 import uuid
 from collections.abc import Sequence
 from typing import Any
@@ -73,17 +74,18 @@ class DeepSeekV40731ToolParser(ToolParser):
                     except json.JSONDecodeError:
                         value = raw
                 arguments[param.group("name")] = value
-            # DeepSeek occasionally serializes Codex's optional reusable
-            # approval prefix as one string even though its schema is an
-            # array of strings. The representations are unambiguous and the
-            # client semantics are identical, so normalize before strict
-            # post-generation schema validation rather than reconnecting the
-            # entire agent turn.
-            if (
-                match.group("name") == "exec_command"
-                and isinstance(arguments.get("prefix_rule"), str)
+            # DeepSeek occasionally serializes Codex's reusable approval
+            # prefix as a shell-like scalar even though it is an argv prefix.
+            # Preserve argument boundaries while normalizing it for strict
+            # schema validation. Leave malformed quoting unchanged so the
+            # validator rejects it instead of silently changing its meaning.
+            if match.group("name") == "exec_command" and isinstance(
+                arguments.get("prefix_rule"), str
             ):
-                arguments["prefix_rule"] = [arguments["prefix_rule"]]
+                try:
+                    arguments["prefix_rule"] = shlex.split(arguments["prefix_rule"])
+                except ValueError:
+                    pass
             calls.append(
                 {
                     "id": f"call_{uuid.uuid4().hex[:8]}",

--- a/vllm_mlx/tool_parsers/deepseek_v4_0731_tool_parser.py
+++ b/vllm_mlx/tool_parsers/deepseek_v4_0731_tool_parser.py
@@ -83,7 +83,9 @@ class DeepSeekV40731ToolParser(ToolParser):
                 arguments.get("prefix_rule"), str
             ):
                 try:
-                    arguments["prefix_rule"] = shlex.split(arguments["prefix_rule"])
+                    prefix_rule = shlex.split(arguments["prefix_rule"])
+                    if prefix_rule:
+                        arguments["prefix_rule"] = prefix_rule
                 except ValueError:
                     pass
             calls.append(

--- a/vllm_mlx/utils/deepseek_v4_0731.py
+++ b/vllm_mlx/utils/deepseek_v4_0731.py
@@ -22,6 +22,26 @@ THINK_START = "<think>"
 THINK_END = "</think>"
 DSML = "｜DSML｜"
 
+# Keep the small, universal engineering surface near the beginning of large
+# agent tool catalogs.  Codex can submit well over one hundred connector and
+# plugin tools; sorting every name alphabetically buried ``exec_command`` deep
+# in that prompt even when the task explicitly asked the model to inspect the
+# repository.  The order remains canonical (and therefore prefix-cacheable),
+# but gives the model's most frequently needed local tools the strongest prompt
+# position.
+_CORE_AGENT_TOOL_ORDER = {
+    name: index
+    for index, name in enumerate(
+        (
+            "exec_command",
+            "write_stdin",
+            "apply_patch",
+            "view_image",
+            "request_user_input",
+        )
+    )
+}
+
 
 def _json(value: Any) -> str:
     # Match the checkpoint's published encoder, including its whitespace.
@@ -65,7 +85,14 @@ def _tool_schemas(tools: list[dict]) -> str:
     # keys) between turns.  Since the schemas live in the system prefix, that
     # turns a harmless wire-order change into a 30K-token prefix-cache miss.
     # Tool order has no semantic meaning, so canonicalise both levels.
-    definitions.sort(key=lambda item: str(item.get("name", "")))
+    definitions.sort(
+        key=lambda item: (
+            _CORE_AGENT_TOOL_ORDER.get(
+                str(item.get("name", "")), len(_CORE_AGENT_TOOL_ORDER)
+            ),
+            str(item.get("name", "")),
+        )
+    )
     schemas = "\n".join(
         json.dumps(item, ensure_ascii=False, sort_keys=True) for item in definitions
     )
@@ -94,6 +121,7 @@ Otherwise, output directly after {THINK_END} with tool calls or final response.
 {schemas}
 
 You MUST strictly follow the above defined tool name and parameter schemas to invoke tool calls.
+Before closing an invoke, emit every parameter listed in that tool schema's `required` array. Never emit an empty invoke for a tool that has required parameters.
 """
 
 


### PR DESCRIPTION
## Summary

- keep core Codex engineering tools at a deterministic high-priority position in the DeepSeek V4 DSML schema catalog
- prime named DSML invocations for forced tool choice and require complete required parameters in the prompt contract
- normalize the unambiguous Codex `prefix_rule` string form to its array schema

## Why

Long Codex tool catalogs buried the local engineering surface and DeepSeek V4 could emit incomplete invokes or a scalar reusable approval prefix, causing avoidable reconnects despite an otherwise valid tool decision.

## Validation

- `python -m pytest tests/test_deepseek_v4_0731.py tests/test_tool_choice_enforcement.py -q` (97 passed)
- `ruff check` on all changed Python files
- `git diff origin/main --check`

Part 1 of the DeepSeek/Codex WIP split; intentionally excludes repetition recovery, action priming, long-context, and DSpark performance changes.