### PR TITLE
fix(gemma4): unbreak bench, unlock live KV quantization, expose the KV-projection override

### DIFF
--- a/tests/test_cli_bench.py
+++ b/tests/test_cli_bench.py
@@ -29,18 +29,25 @@ import pytest
 
 # ---------- shared helpers ---------------------------------------------------
 def _patch_mlx_lm_load(monkeypatch, fake_load) -> None:
-    """Patch ONLY the ``load`` attribute on the real ``mlx_lm`` module.
+    """Patch the loader ``bench`` actually calls.
 
-    ``bench_command`` and ``_run_submit_flow`` use ``from mlx_lm import
-    load`` at call time — that's ``getattr(sys.modules['mlx_lm'], 'load')``
-    resolved fresh each call. Replacing the whole module object would
-    break other imports (``mlx_lm.generate``, ``mlx_lm.utils``…) that
-    the engine's own imports trigger during ``bench_command`` setup.
-    Attribute patching leaves those intact.
+    ``bench_command`` and ``_run_submit_flow`` bind
+    ``from .utils.tokenizer import load_model_with_fallback as load`` at
+    call time — that's
+    ``getattr(sys.modules['vllm_mlx.utils.tokenizer'],
+    'load_model_with_fallback')`` resolved fresh each call. They used to
+    bind ``mlx_lm.load`` directly, but that loader has no
+    ``gemma4_unified`` architecture, so every ``gemma-4-12b-*`` alias
+    failed to load; the router in ``utils.tokenizer`` is what makes them
+    work. Patch that attribute rather than the module object so the other
+    imports (``mlx_lm.generate``, ``mlx_lm.utils``…) the engine triggers
+    during setup stay intact.
     """
-    import mlx_lm  # already loaded by the test-time environment
+    from vllm_mlx.utils import tokenizer as _tokenizer_mod
 
-    monkeypatch.setattr(mlx_lm, "load", fake_load, raising=True)
+    monkeypatch.setattr(
+        _tokenizer_mod, "load_model_with_fallback", fake_load, raising=True
+    )
 
 
 def _make_freeform_bench_args(model: str) -> argparse.Namespace:

--- a/tests/test_cli_bench_hybrid_cache_flag.py
+++ b/tests/test_cli_bench_hybrid_cache_flag.py
@@ -67,8 +67,12 @@ def _run_bench_capturing_scheduler_config(argv: list[str]) -> dict:
         mock.patch.object(cli, "_check_disk_space", lambda *a, **k: None),
         mock.patch.object(cli, "_check_memory_capacity", lambda *a, **k: None),
         mock.patch.object(cli, "_ensure_model_downloaded", lambda *a, **k: None),
-        # ``bench_command`` does ``from mlx_lm import load`` — patch at source.
-        mock.patch("mlx_lm.load", return_value=(object(), object())),
+        # ``bench_command`` binds ``load_model_with_fallback`` (the
+        # gemma4-aware router, not bare ``mlx_lm.load``) — patch at source.
+        mock.patch(
+            "vllm_mlx.utils.tokenizer.load_model_with_fallback",
+            return_value=(object(), object()),
+        ),
         # ``bench_command`` does ``from .scheduler import SchedulerConfig`` —
         # patch on the scheduler module so the local import binds the mock.
         mock.patch("vllm_mlx.scheduler.SchedulerConfig", _fake_scheduler_config),

--- a/tests/test_cli_metal_cap_kv_flag.py
+++ b/tests/test_cli_metal_cap_kv_flag.py
@@ -1,0 +1,127 @@
+# SPDX-License-Identifier: Apache-2.0
+"""``serve --metal-cap-kv-bytes-per-token`` plumbing.
+
+``Scheduler._infer_kv_dtype_bytes`` documents that quantized-KV
+deployments are NOT auto-detected and names
+``SchedulerConfig.metal_cap_kv_bytes_per_token`` as the operator escape
+hatch. That field existed only on the Python API, so a CLI user running
+``--kv-cache-turboquant`` / ``--kv-cache-quantization`` got a D-METAL-CAP
+admission projection computed at fp16 regardless of the codec — long
+prompts the codec would have fit were rejected with a 503.
+
+These tests pin the CLI surface and the wiring: the parsed value must
+reach ``SchedulerConfig``, and the default must stay 0 so the
+architecture-aware auto-derivation (and the OOM cliff it prevents) is
+untouched for everyone who does not set the flag.
+"""
+
+import sys
+from unittest import mock
+
+import pytest
+
+import vllm_mlx.cli as cli
+
+# Import the engine module EAGERLY, before ``SchedulerConfig`` is patched.
+# Modules that annotate ``SchedulerConfig | None`` evaluate that union at
+# import time; if the first import happens while the patch is active, the
+# union is built against the fake and raises
+# ``TypeError: unsupported operand type(s) for |``. Importing here binds
+# the real class first — the patch is then a pure name rebind and no class
+# body re-runs under it. Same guard as
+# ``tests/test_cli_bench_hybrid_cache_flag.py``.
+import vllm_mlx.engine_core as _engine_core  # noqa: E402,F401
+
+
+class _StopError(Exception):
+    """Raised once SchedulerConfig is built, to short-circuit engine boot."""
+
+
+def _capture_serve_scheduler_config(argv: list[str]) -> dict:
+    """Drive the REAL ``main()`` → ``serve_command`` and capture the kwargs
+    the serve path passes to ``SchedulerConfig(...)``.
+
+    Mirrors ``tests/test_cli_response_cache_flag.py`` — only the I/O
+    boundaries the serve path hits BEFORE construction are mocked, so
+    everything between argparse and ``SchedulerConfig(...)`` is real code.
+    """
+    captured: dict = {}
+
+    def _fake_scheduler_config(*args, **kwargs):
+        captured.update(kwargs)
+        raise _StopError
+
+    with (
+        mock.patch.object(cli, "_check_disk_space", lambda *a, **k: None),
+        mock.patch.object(cli, "_check_memory_capacity", lambda *a, **k: None),
+        mock.patch.object(cli, "_ensure_model_downloaded", lambda *a, **k: None),
+        mock.patch.object(
+            cli, "_gather_kv_cache_dtype_inputs", lambda *a, **k: ({}, None)
+        ),
+        mock.patch(
+            "vllm_mlx._version_check.prompt_upgrade_if_available",
+            return_value=False,
+        ),
+        mock.patch(
+            "vllm_mlx.utils.tokenizer.load_model_with_fallback",
+            return_value=(object(), object()),
+        ),
+        mock.patch("vllm_mlx.scheduler.SchedulerConfig", _fake_scheduler_config),
+        mock.patch.object(sys, "argv", ["rapid-mlx", *argv]),
+        mock.patch.object(sys.stdin, "isatty", return_value=False),
+        pytest.raises((_StopError, SystemExit)),
+    ):
+        cli.main()
+
+    assert captured, (
+        "SchedulerConfig was never constructed by the serve path — the flow "
+        "died before the metal-cap plumbing under test. If this fires after "
+        "unrelated serve-path changes, extend the boundary mocks above."
+    )
+    return captured
+
+
+def test_serve_metal_cap_kv_bytes_reaches_scheduler_config():
+    """MUTATION-KILL: deleting ``metal_cap_kv_bytes_per_token=...`` at the
+    serve ``SchedulerConfig(...)`` construction makes this FAIL."""
+    captured = _capture_serve_scheduler_config(
+        ["serve", "qwen3.5-4b-4bit", "--metal-cap-kv-bytes-per-token", "98304"]
+    )
+    assert captured.get("metal_cap_kv_bytes_per_token") == 98304
+
+
+def test_serve_metal_cap_kv_bytes_defaults_to_zero():
+    """0 is load-bearing: ``_resolve_kv_bytes_per_token`` only auto-derives
+    the architecture-aware figure when the override is falsy. A non-zero
+    default would silently disable the sliding-window / KV-sharing
+    refinement for every model."""
+    captured = _capture_serve_scheduler_config(["serve", "qwen3.5-4b-4bit"])
+    assert captured.get("metal_cap_kv_bytes_per_token") == 0
+
+
+def test_serve_metal_cap_kv_bytes_rejects_negative():
+    """Guarded by ``non_negative_int`` — a negative per-token figure would
+    make the projection shrink with prompt length and defeat the gate.
+
+    argparse rejects at parse time, i.e. BEFORE SchedulerConfig is
+    constructed, so this asserts on the parser directly rather than going
+    through ``_capture_serve_scheduler_config`` (whose post-condition is
+    that construction was reached).
+    """
+    with (
+        mock.patch.object(
+            sys,
+            "argv",
+            [
+                "rapid-mlx",
+                "serve",
+                "qwen3.5-4b-4bit",
+                "--metal-cap-kv-bytes-per-token",
+                "-1",
+            ],
+        ),
+        mock.patch.object(sys.stdin, "isatty", return_value=False),
+        pytest.raises(SystemExit) as exc,
+    ):
+        cli.main()
+    assert exc.value.code != 0, "a negative per-token figure must not be accepted"

--- a/tests/test_cli_response_cache_flag.py
+++ b/tests/test_cli_response_cache_flag.py
@@ -68,7 +68,10 @@ def _capture_serve_scheduler_config(argv: list[str]) -> dict:
             "vllm_mlx._version_check.prompt_upgrade_if_available",
             return_value=False,
         ),
-        mock.patch("mlx_lm.load", return_value=(object(), object())),
+        mock.patch(
+            "vllm_mlx.utils.tokenizer.load_model_with_fallback",
+            return_value=(object(), object()),
+        ),
         mock.patch("vllm_mlx.scheduler.SchedulerConfig", _fake_scheduler_config),
         mock.patch.object(sys, "argv", ["rapid-mlx", *argv]),
         mock.patch.object(sys.stdin, "isatty", return_value=False),

--- a/tests/test_probe_config_attr.py
+++ b/tests/test_probe_config_attr.py
@@ -1,0 +1,103 @@
+# SPDX-License-Identifier: Apache-2.0
+"""``_text_attention_args`` must read ``.config``, not only ``.args``.
+
+mlx-lm models expose their config as ``.args``; the mlx-vlm-derived
+architectures expose it as ``.config``. Gemma 4's ``Gemma4TextWrapper``
+has no ``.args`` at all and its ``.language_model`` carries a
+``TextConfig`` on ``.config``, so probing only ``.args`` returned
+``(None, None)`` and the engine logged
+
+    [kv-cache] live KV quantization disabled: head_dim (K=None, V=None)
+    unknown or not divisible by any supported group_size (32/64/128)
+
+for every ``gemma-4-12b-*`` alias — despite ``head_dim=256`` /
+``global_head_dim=512`` being divisible by all three. The live cache
+silently stayed bf16, which is expensive on an architecture whose KV runs
+~128 KB/token.
+
+These tests pin both halves of the contract: ``.config`` is now consulted,
+and ``.args`` still wins wherever it exists so no other model moves.
+"""
+
+from types import SimpleNamespace
+
+from vllm_mlx.quantized_batch_cache import (
+    _text_attention_args,
+    probe_kv_head_dims,
+    resolve_kv_quantization,
+)
+
+
+def _cfg(head_dim, **extra):
+    return SimpleNamespace(head_dim=head_dim, **extra)
+
+
+# ── the regression: language model carries .config, not .args ──────────
+
+
+def test_language_model_config_attr_is_probeable():
+    """Shape of Gemma4TextWrapper: no top-level .args, language_model.config
+    holds the text config. Pre-fix this probed to (None, None)."""
+    model = SimpleNamespace(
+        language_model=SimpleNamespace(config=_cfg(256)),
+    )
+    assert probe_kv_head_dims(model) == (256, 256)
+
+
+def test_gemma4_dims_enable_the_live_quantized_cache():
+    """MUTATION-KILL: the point of the probe fix. head_dim 256 divides every
+    supported group size, so the live cache must NOT be disabled."""
+    k, v = probe_kv_head_dims(
+        SimpleNamespace(language_model=SimpleNamespace(config=_cfg(256)))
+    )
+    for requested in (32, 64, 128):
+        group_size, live_disabled = resolve_kv_quantization(k, v, requested)
+        assert live_disabled is False
+        assert group_size == requested
+
+
+def test_top_level_config_text_config_is_probeable():
+    """A wrapper whose nested text config hangs off ``.config.text_config``
+    rather than ``.args.text_config``."""
+    model = SimpleNamespace(config=SimpleNamespace(text_config=_cfg(128)))
+    assert probe_kv_head_dims(model) == (128, 128)
+
+
+# ── the guard: .args keeps priority, fail-safe preserved ───────────────
+
+
+def test_args_wins_over_config_when_both_probeable():
+    """Every mlx-lm model has ``.args``; it must keep winning so this change
+    moves no existing model. A divergent ``.config`` must be ignored."""
+    lm = SimpleNamespace(args=_cfg(64), config=_cfg(256))
+    assert _text_attention_args(SimpleNamespace(language_model=lm)) is lm.args
+    assert probe_kv_head_dims(SimpleNamespace(language_model=lm)) == (64, 64)
+
+
+def test_text_only_model_with_args_unchanged():
+    """Neither multimodal signal present: the top-level args ARE the language
+    config, exactly as before."""
+    model = SimpleNamespace(args=_cfg(128, v_head_dim=64))
+    assert probe_kv_head_dims(model) == (128, 64)
+
+
+def test_unprobeable_language_model_still_fails_safe():
+    """A multimodal wrapper whose language config exposes no readable head dim
+    must still yield None so the live cache falls back to bf16 rather than
+    picking up vision/composite dims from the top level."""
+    model = SimpleNamespace(
+        args=SimpleNamespace(head_dim=999),  # vision/composite — must NOT leak
+        language_model=SimpleNamespace(config=SimpleNamespace()),
+    )
+    assert probe_kv_head_dims(model) == (None, None)
+
+
+def test_hidden_size_fallback_still_works_via_config():
+    """``.config`` goes through the same head_dim resolution as ``.args``,
+    including the hidden_size // num_attention_heads fallback."""
+    model = SimpleNamespace(
+        language_model=SimpleNamespace(
+            config=SimpleNamespace(hidden_size=3840, num_attention_heads=30)
+        )
+    )
+    assert probe_kv_head_dims(model) == (128, 128)

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -3335,6 +3335,10 @@ def serve_command(args):
         # #1103/#1122: bounded trim-free hybrid (recurrent-state) prefix reuse.
         # Auto-defaulted to 8 for hybrid models when prefix cache is enabled.
         hybrid_cache_entries=_hybrid_cache_entries,
+        # Operator override for the D-METAL-CAP projection; 0 keeps the
+        # architecture-aware auto-derivation. Needed by quantized-KV
+        # deployments, whose real footprint the fp16 estimate over-states.
+        metal_cap_kv_bytes_per_token=getattr(args, "metal_cap_kv_bytes_per_token", 0),
         non_trimmable_exact_prefix_reuse=(
             _hybrid_cache_entries > 0
             and _needs_bounded_trim_free_reuse(
@@ -7493,6 +7497,33 @@ Examples:
             "workloads. An identical exact re-request of a rotated "
             "sliding-window prompt falls back to a full prefill (byte-equal to "
             "cold)."
+        ),
+    )
+    # Operator override for the D-METAL-CAP admission projection. The
+    # auto-derived figure assumes an UNCOMPRESSED fp16 KV cache — see
+    # ``Scheduler._infer_kv_dtype_bytes``, which documents that quantized-KV
+    # deployments are not auto-detected and names this knob as the escape
+    # hatch. It was reachable only from the Python API, so a CLI user running
+    # ``--kv-cache-turboquant`` / ``--kv-cache-quantization`` got an admission
+    # projection that ignored the codec entirely and 503'd long prompts the
+    # codec would have fit. Default 0 preserves auto-derivation exactly.
+    serve_parser.add_argument(
+        "--metal-cap-kv-bytes-per-token",
+        type=non_negative_int,
+        default=0,
+        metavar="BYTES",
+        help=(
+            "Override the per-token KV-cache size the D-METAL-CAP admission "
+            "gate projects, in bytes. 0 (default) auto-derives an "
+            "architecture-aware fp16 figure. Set this when running a "
+            "quantized KV cache (--kv-cache-turboquant / "
+            "--kv-cache-quantization), whose real footprint the auto-derived "
+            "figure over-estimates — an over-estimate only costs you spurious "
+            "503s, but on a memory-tight Mac that is the difference between a "
+            "long prompt being served and being rejected. UNDER-setting it "
+            "risks the OOM cliff the gate exists to prevent: lower it only to "
+            "a value you have measured. Overrides the architecture-aware "
+            "estimator wholesale (sliding-window and recurrent terms included)."
         ),
     )
     # Opt-in prompt-deterministic RESPONSE CACHE (exact-match short-circuit).

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -3980,7 +3980,6 @@ def _run_submit_flow(
     from pathlib import Path
 
     from huggingface_hub.utils import RepositoryNotFoundError
-    from mlx_lm import load
 
     from .community_bench.hardware import collect as collect_hw
     from .community_bench.hardware import is_apple_silicon
@@ -3992,6 +3991,11 @@ def _run_submit_flow(
     from .engine_core import AsyncEngineCore, EngineConfig
     from .model_aliases import resolve_profile
     from .scheduler import SchedulerConfig
+
+    # Same gemma4 routing fix as ``bench_command``: ``mlx_lm.load`` cannot
+    # construct ``gemma4_unified``, so every ``gemma-4-12b-*`` alias failed
+    # to load here and could never be submitted to the community corpus.
+    from .utils.tokenizer import load_model_with_fallback as load
 
     if not is_apple_silicon():
         print(
@@ -4325,8 +4329,14 @@ def bench_command(args):
     if getattr(args, "submit", False):
         sys.exit(_run_submit_flow(args))
 
-    from mlx_lm import load
-
+    # Use the SAME loader ``serve`` uses, not the bare ``mlx_lm.load``.
+    # ``mlx_lm`` has no ``gemma4_unified`` architecture (the model classes
+    # live in mlx-vlm), so a bare ``load`` raises "Model type
+    # gemma4_unified not supported" for EVERY ``gemma-4-12b-*`` alias and
+    # bench can never run them — even though ``serve`` runs them fine.
+    # ``load_model_with_fallback`` carries the gemma4 router (plus the
+    # vendored-arch and tokenizer-fallback routes) and calls
+    # ``validate_local_model_file`` internally.
     from .engine_core import AsyncEngineCore, EngineConfig
     from .pflash import config_from_args as _pflash_config_from_args
     from .pflash import resolve_pflash_mode_default as _pflash_resolve_default
@@ -4334,6 +4344,7 @@ def bench_command(args):
     from .request import SamplingParams
     from .scheduler import SchedulerConfig
     from .utils.model_file_guard import validate_local_model_file
+    from .utils.tokenizer import load_model_with_fallback as load
 
     _check_disk_space(args.model, force=getattr(args, "force_disk_check", False))
     _check_memory_capacity(args.model)

--- a/vllm_mlx/quantized_batch_cache.py
+++ b/vllm_mlx/quantized_batch_cache.py
@@ -591,6 +591,39 @@ def _head_dim_from_args(args: Any) -> int | None:
     return None
 
 
+def _args_or_config(obj: Any) -> Any:
+    """The attention-dim config on ``obj``: ``.args`` first, then ``.config``.
+
+    mlx-lm models expose their config as ``.args``, but the mlx-vlm-derived
+    architectures expose it as ``.config`` — Gemma 4's ``Gemma4TextWrapper``
+    has no ``.args`` at all, and its ``.language_model`` (an mlx-vlm
+    ``LanguageModel``) carries a ``TextConfig`` on ``.config``. Probing only
+    ``.args`` therefore returned ``(None, None)`` for every ``gemma-4-12b-*``
+    alias, which disabled the live quantized KV cache outright:
+
+        [kv-cache] live KV quantization disabled: head_dim (K=None, V=None)
+        unknown or not divisible by any supported group_size (32/64/128)
+
+    even though Gemma 4's dims (``head_dim=256``, ``global_head_dim=512``)
+    are divisible by all three. That silent bf16 fallback is expensive on
+    this architecture specifically — Gemma 4 12B's KV runs ~128 KB/token.
+
+    ``.args`` keeps priority so every model that has one is byte-identical
+    to before; ``.config`` is consulted only when ``.args`` is missing or
+    carries no readable head dim. Returns whichever object exists when
+    neither is probeable, so callers still fail safe to bf16.
+    """
+    if obj is None:
+        return None
+    args = getattr(obj, "args", None)
+    if _head_dim_from_args(args) is not None:
+        return args
+    config = getattr(obj, "config", None)
+    if _head_dim_from_args(config) is not None:
+        return config
+    return args if args is not None else config
+
+
 def _text_attention_args(model: Any) -> Any:
     """The args object carrying the *language* model's attention dims.
 
@@ -616,8 +649,13 @@ def _text_attention_args(model: Any) -> Any:
     """
     args = getattr(model, "args", None)
     lm = getattr(model, "language_model", None)
-    lm_args = getattr(lm, "args", None) if lm is not None else None
+    lm_args = _args_or_config(lm)
     text_cfg = getattr(args, "text_config", None) if args is not None else None
+    if text_cfg is None:
+        # mlx-vlm-derived wrappers carry the nested text config under
+        # ``.config`` rather than ``.args`` (see _args_or_config).
+        top_cfg = getattr(model, "config", None)
+        text_cfg = getattr(top_cfg, "text_config", None) if top_cfg else None
 
     # Prefer a probeable language-specific config (multimodal wrappers).
     if _head_dim_from_args(lm_args) is not None:


### PR DESCRIPTION
## What does this PR do?

Three independent fixes that together make the `gemma-4-12b-*` aliases actually usable:

1. **`bench` could not load any Gemma 4 12B alias.** `bench_command` and `_run_submit_flow` bound `mlx_lm.load` directly. mlx-lm has no `gemma4_unified` architecture (the classes live in mlx-vlm), so every `gemma-4-12b-*` alias died with `Error loading model: Model type gemma4_unified not supported.` — even though `rapid-mlx serve` runs those aliases fine, because `serve` goes through `utils.tokenizer.load_model_with_fallback`, which carries the gemma4 router. Both bench paths now bind that same loader.

   This originally also carried a fix for the stream-affinity half of the same bug (loading on the asyncio loop thread, then stepping the engine on the `mlx-step` worker → `RuntimeError: There is no Stream(gpu, 0) in current thread.`). **#1404 landed that independently while this was in progress**, and its version is better — it hoists the executor above `run_benchmark` and hardens the Ctrl-C path. This PR has been rebased onto it and now only swaps the loader; the threading work here is dropped in favour of #1404's.

2. **Live KV quantization was silently disabled on every Gemma 4 alias.** `_text_attention_args` looked for the language model's attention dims on `.args`. mlx-lm models have that attribute; the mlx-vlm-derived architectures do not — `Gemma4TextWrapper` has no `.args` at all, and its `.language_model` carries a `TextConfig` on `.config`. So `probe_kv_head_dims` returned `(None, None)` and the engine logged

   ```
   [kv-cache] live KV quantization disabled: head_dim (K=None, V=None) unknown
   or not divisible by any supported group_size (32/64/128)
   ```

   then served a bf16 live cache — despite Gemma 4's real dims (`head_dim=256`, `global_head_dim=512`) being divisible by all three. Nothing about this model justified the fallback; the probe just could not see it. That matters here specifically: Gemma 4 12B's KV runs **~128 KB/token** (8 full-attention layers × 8 KV heads × 512 `global_head_dim` × 2 × 2 B), several times a same-class Llama/Qwen, so KV is the binding constraint on a 16–32 GB Mac — and the one mitigation for it was off.

3. **`--metal-cap-kv-bytes-per-token` had no CLI surface.** `Scheduler._infer_kv_dtype_bytes` documents that quantized-KV deployments are not auto-detected and names `SchedulerConfig.metal_cap_kv_bytes_per_token` as the operator escape hatch — but that field had no flag and no env var, so the documented escape hatch was reachable only from the Python API. With `--kv-cache-turboquant k8v4` active the D-METAL-CAP projection is byte-identical to the fp16 path, so a long prompt is rejected by a check that cannot see the codec that would have made it fit.

## Why is this needed?

`gemma-4-12b-*` is a shipped, README-recommended alias family. Today:

- `rapid-mlx bench gemma-4-12b-4bit` **cannot run at all** (item 1), so the family cannot be benchmarked or submitted to the community corpus.
- Serving works, but the KV-cache mitigation that this architecture needs more than most is off by default because of a missing `getattr` (item 2).
- The documented workaround for quantized-KV admission is unreachable from the CLI (item 3).

Measured on an M3 Pro 18 GB, `mlx-community/gemma-4-12B-it-4bit`:

| | before | after |
|---|---|---|
| `rapid-mlx bench gemma-4-12b-4bit` | `Model type gemma4_unified not supported` | completes, 13.6–15.5 tok/s |
| `probe_kv_head_dims(model)` | `(None, None)` | `(256, 256)` |
| `resolve_kv_quantization(…, 64)` | `live_disabled=True` | `(64, live_disabled=False)` |
| `serve --kv-cache-dtype int8` | `live KV quantization disabled` warning | `KV cache quantization: 8-bit, group_size=64` |

Reproduced independently on a second machine (Mac mini, M2 Pro 32 GB, macOS 26.5.2): bench completes at 15.45 tok/s, probe returns `(256, 256)`.

No default behaviour changes. `.args` keeps priority in the probe wherever it exists, so every model that already probed successfully is byte-identical, and an unprobeable language config still yields `None` so the live cache fails safe to bf16 rather than picking up vision/composite dims. `--metal-cap-kv-bytes-per-token` defaults to `0`, which keeps the architecture-aware auto-derivation and the OOM cliff it prevents exactly as before.

## AI assistance disclosure

Claude (Opus 5) wrote the implementation and the tests in this PR, working from a profiling session on the two machines above; I directed the investigation, chose the scope, and reviewed each change.

How the output was verified, beyond the test suite:

- Each of the three fixes was checked against the **actual failing behaviour** it claims to fix — the loader fix by running `rapid-mlx bench` before/after, the probe fix by loading the real checkpoint and printing `probe_kv_head_dims` / `resolve_kv_quantization`, the flag by reading it back out of `SchedulerConfig` and off `serve --help`. Numbers in the table above are measured, not inferred.
- Independently reproduced on a second machine (M2 Pro 32 GB) from a clean install.
- Full suite diffed against `main` on the same host: **141 pre-existing failures before, 141 after, zero new** (the pre-existing set is dominated by missing optional extras — audio/video — in this environment).
- One thing deliberately **not** included: a fix for the D-METAL-CAP eviction dead band. It was implemented, measured, and reverted — evicting at admission and re-admitting fired correctly (active 9.17 → 8.6 GB) but then died in prefill with `[METAL] Insufficient Memory` → `Fatal Python error: Aborted`, because the admission projection models KV only and never the prefill working set. Trading a recoverable 503 for a process abort is a bad trade. Flagging it here because it is the real gap behind item 3, and it needs the prefill working set modelled before admission can safely be made more permissive.

> By submitting this PR I confirm I can explain the intent, risk, and behavior of every non-generated change in this PR.

## Test plan

- `ruff check vllm_mlx/ tests/` → clean; `ruff format --check` → 778 files already formatted.
- Full suite vs `main` on M3 Pro 18 GB: 141 failures on both, **zero new** (`comm -13` of the sorted FAILED lists is empty).
- New tests:
  - `tests/test_probe_config_attr.py` (7 tests) — pins that `.config` is consulted, that `.args` still wins wherever it exists, that the Gemma 4 dims enable the live cache, and that an unprobeable language config still fails safe to `None`.
  - `tests/test_cli_metal_cap_kv_flag.py` (3 tests) — the parsed value reaches `SchedulerConfig`, the default stays `0`, and a negative value is rejected at parse time.
- Updated tests: `test_cli_bench.py`, `test_cli_bench_hybrid_cache_flag.py`, `test_cli_response_cache_flag.py` repointed from patching `mlx_lm.load` to patching the loader the bench flow now binds.
- Mutation spot-checks on the new tests (per SOP §Step 3): deleting `metal_cap_kv_bytes_per_token=…` at the serve `SchedulerConfig(...)` construction fails `test_serve_metal_cap_kv_bytes_reaches_scheduler_config`; reverting `_args_or_config` to read only `.args` fails `test_language_model_config_attr_is_probeable` and `test_gemma4_dims_enable_the_live_quantized_cache`.
- End-to-end on real weights, both machines: `rapid-mlx bench gemma-4-12b-4bit` completes; `serve --no-mllm --kv-cache-dtype int8` reports the quantized live cache and answers correctly.

## Checklist

- [x] Tests pass locally (full suite diffed against `main`: zero new failures)
- [x] Lint passes (`ruff check && ruff format --check`)
- [x] Self-validated with `python3 -m scripts.pr_validate.pr_validate 1408` — scorecard posted as a PR comment
- [x] New tests touch scheduler / CLI paths and were spot-checked to fail when the corresponding production line is broken
- [x] Updated README/docs if applicable — no docs change needed; the three fixes restore documented behaviour rather than adding any
- [x] No breaking changes to existing API
