### PR TITLE
fix(prefill): adapt long-context memory pressure

### DIFF
--- a/tests/test_adaptive_prefill.py
+++ b/tests/test_adaptive_prefill.py
@@ -1,7 +1,6 @@
 """Long-context adaptive prefill policy regression tests."""
 
 from types import SimpleNamespace
-from unittest.mock import patch
 
 from vllm_mlx.scheduler import Scheduler, SchedulerConfig
 
@@ -26,8 +25,6 @@ def _scheduler(*, prompt_tokens=100_000, active=0, rss=0, cap=100_000):
     scheduler._last_adaptive_prefill_size = 2048
     scheduler._adaptive_prefill_protected_chunks = 0
     scheduler._adaptive_prefill_reduced_chunks = 0
-    scheduler._adaptive_prefill_cache_clamped = False
-    scheduler._adaptive_prefill_cache_clamps = 0
     scheduler.running = {}
     return scheduler
 
@@ -101,34 +98,3 @@ def test_disabled_policy_is_exact_noop():
     scheduler = _scheduler(active=99_000)
     scheduler.config.adaptive_prefill = False
     assert scheduler._select_adaptive_prefill_size() == 2048
-
-
-def test_long_prefill_clamps_cache_once_and_restores_for_decode():
-    scheduler = _scheduler(active=82_000)
-    scheduler._resolve_metal_cap_bytes = lambda: 100 * 1024**3
-    with (
-        patch("vllm_mlx.scheduler.mx.set_cache_limit") as set_limit,
-        patch("vllm_mlx.scheduler.mx.clear_cache") as clear_cache,
-    ):
-        scheduler._apply_adaptive_prefill_size()
-        scheduler._apply_adaptive_prefill_size()
-        assert set_limit.call_count == 1
-        assert set_limit.call_args.args[0] == 4 * 1024**3
-        clear_cache.assert_called_once_with()
-        assert scheduler._adaptive_prefill_cache_clamps == 1
-
-        scheduler.batch_generator._currently_processing = []
-        scheduler.batch_generator._prompt_batch.tokens = []
-        scheduler._apply_adaptive_prefill_size()
-        assert set_limit.call_count == 2
-        assert set_limit.call_args.args[0] == 25 * 1024**3
-        assert clear_cache.call_count == 1
-        assert scheduler._adaptive_prefill_cache_clamped is False
-
-
-def test_cache_clamp_can_be_disabled_independently():
-    scheduler = _scheduler(active=82_000)
-    scheduler.config.adaptive_prefill_cache_limit_bytes = 0
-    with patch("vllm_mlx.scheduler.mx.set_cache_limit") as set_limit:
-        scheduler._apply_adaptive_prefill_size()
-    set_limit.assert_not_called()

--- a/tests/test_adaptive_prefill.py
+++ b/tests/test_adaptive_prefill.py
@@ -96,5 +96,21 @@ def test_apply_updates_future_and_in_progress_prompt_batches():
 
 def test_disabled_policy_is_exact_noop():
     scheduler = _scheduler(active=99_000)
+    scheduler._last_adaptive_prefill_size = 256
+    scheduler.batch_generator.prefill_step_size = 256
+    scheduler.batch_generator._prompt_batch.prefill_step_size = 256
     scheduler.config.adaptive_prefill = False
     assert scheduler._select_adaptive_prefill_size() == 2048
+    assert scheduler._apply_adaptive_prefill_size() == 2048
+    assert scheduler.batch_generator.prefill_step_size == 2048
+    assert scheduler.batch_generator._prompt_batch.prefill_step_size == 2048
+    assert scheduler._adaptive_prefill_protected_chunks == 0
+
+
+def test_zero_minimum_threshold_restores_on_idle():
+    scheduler = _scheduler(active=82_000)
+    scheduler.config.adaptive_prefill_min_tokens = 0
+    assert scheduler._apply_adaptive_prefill_size() == 512
+    scheduler.batch_generator._currently_processing = []
+    scheduler.batch_generator._prompt_batch.tokens = []
+    assert scheduler._apply_adaptive_prefill_size() == 2048

--- a/tests/test_adaptive_prefill.py
+++ b/tests/test_adaptive_prefill.py
@@ -1,0 +1,134 @@
+"""Long-context adaptive prefill policy regression tests."""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from vllm_mlx.scheduler import Scheduler, SchedulerConfig
+
+
+def _scheduler(*, prompt_tokens=100_000, active=0, rss=0, cap=100_000):
+    scheduler = Scheduler.__new__(Scheduler)
+    scheduler.config = SchedulerConfig(
+        prefill_step_size=2048,
+        adaptive_prefill=True,
+        adaptive_prefill_min_tokens=32_768,
+        adaptive_prefill_min_chunk_size=256,
+    )
+    scheduler.batch_generator = SimpleNamespace(
+        prefill_step_size=2048,
+        _prompt_batch=SimpleNamespace(prefill_step_size=2048, tokens=[[]]),
+        _currently_processing=[[[list(range(1))], 0, prompt_tokens]],
+        _unprocessed_sequences=[],
+    )
+    scheduler._resolve_metal_cap_bytes = lambda: cap
+    scheduler._current_metal_active_bytes = lambda: active
+    scheduler._current_process_resident_bytes = lambda: rss
+    scheduler._last_adaptive_prefill_size = 2048
+    scheduler._adaptive_prefill_protected_chunks = 0
+    scheduler._adaptive_prefill_reduced_chunks = 0
+    scheduler._adaptive_prefill_cache_clamped = False
+    scheduler._adaptive_prefill_cache_clamps = 0
+    scheduler.running = {}
+    return scheduler
+
+
+def test_short_prefill_keeps_configured_chunk():
+    scheduler = _scheduler(prompt_tokens=8_000, active=95_000)
+    assert scheduler._select_adaptive_prefill_size() == 2048
+
+
+def test_long_prefill_tightens_at_pressure_bands():
+    assert _scheduler(active=69_000)._select_adaptive_prefill_size() == 2048
+    assert _scheduler(active=70_000)._select_adaptive_prefill_size() == 1024
+    assert _scheduler(active=80_000)._select_adaptive_prefill_size() == 512
+    assert _scheduler(active=88_000)._select_adaptive_prefill_size() == 256
+
+
+def test_process_footprint_wins_over_mlx_active():
+    scheduler = _scheduler(active=50_000, rss=85_000)
+    assert scheduler._select_adaptive_prefill_size() == 512
+
+
+def test_cached_offset_counts_toward_long_context_guard():
+    scheduler = _scheduler(prompt_tokens=2_000, active=75_000)
+    scheduler.batch_generator._prompt_batch.tokens = [[0] * 100_000]
+    assert scheduler._active_prefill_token_count() == 102_000
+    assert scheduler._select_adaptive_prefill_size() == 1024
+
+
+def test_running_request_supplies_full_offset_when_mlx_only_exposes_suffix():
+    scheduler = _scheduler(prompt_tokens=16_000, active=75_000)
+    scheduler.running = {
+        "request": SimpleNamespace(model_prompt_tokens=96_000, num_prompt_tokens=96_000)
+    }
+    assert scheduler._active_prefill_token_count() == 96_000
+    assert scheduler._select_adaptive_prefill_size() == 1024
+
+
+def test_processed_prompt_tokens_are_not_double_counted():
+    scheduler = _scheduler(prompt_tokens=64_000, active=75_000)
+    scheduler.batch_generator._prompt_batch.tokens = [[0] * 1_024]
+    scheduler.batch_generator._currently_processing[0][1] = 1_024
+    assert scheduler._active_prefill_token_count() == 64_000
+
+
+def test_active_prefill_only_downshifts_until_prompt_completes():
+    scheduler = _scheduler(active=85_000)
+    assert scheduler._apply_adaptive_prefill_size() == 512
+    scheduler._current_metal_active_bytes = lambda: 65_000
+    scheduler._current_process_resident_bytes = lambda: 65_000
+    assert scheduler._apply_adaptive_prefill_size() == 512
+
+
+def test_policy_never_grows_operator_chunk_or_crosses_floor():
+    scheduler = _scheduler(active=99_000)
+    scheduler.config.prefill_step_size = 128
+    scheduler.config.adaptive_prefill_min_chunk_size = 256
+    assert scheduler._select_adaptive_prefill_size() == 128
+
+
+def test_apply_updates_future_and_in_progress_prompt_batches():
+    scheduler = _scheduler(active=82_000)
+    selected = scheduler._apply_adaptive_prefill_size()
+    assert selected == 512
+    assert scheduler.batch_generator.prefill_step_size == 512
+    assert scheduler.batch_generator._prompt_batch.prefill_step_size == 512
+    assert scheduler._adaptive_prefill_protected_chunks == 1
+    assert scheduler._adaptive_prefill_reduced_chunks == 1
+
+
+def test_disabled_policy_is_exact_noop():
+    scheduler = _scheduler(active=99_000)
+    scheduler.config.adaptive_prefill = False
+    assert scheduler._select_adaptive_prefill_size() == 2048
+
+
+def test_long_prefill_clamps_cache_once_and_restores_for_decode():
+    scheduler = _scheduler(active=82_000)
+    scheduler._resolve_metal_cap_bytes = lambda: 100 * 1024**3
+    with (
+        patch("vllm_mlx.scheduler.mx.set_cache_limit") as set_limit,
+        patch("vllm_mlx.scheduler.mx.clear_cache") as clear_cache,
+    ):
+        scheduler._apply_adaptive_prefill_size()
+        scheduler._apply_adaptive_prefill_size()
+        assert set_limit.call_count == 1
+        assert set_limit.call_args.args[0] == 4 * 1024**3
+        clear_cache.assert_called_once_with()
+        assert scheduler._adaptive_prefill_cache_clamps == 1
+
+        scheduler.batch_generator._currently_processing = []
+        scheduler.batch_generator._prompt_batch.tokens = []
+        scheduler._apply_adaptive_prefill_size()
+        assert set_limit.call_count == 2
+        assert set_limit.call_args.args[0] == 25 * 1024**3
+        assert clear_cache.call_count == 1
+        assert scheduler._adaptive_prefill_cache_clamped is False
+
+
+def test_cache_clamp_can_be_disabled_independently():
+    scheduler = _scheduler(active=82_000)
+    scheduler.config.adaptive_prefill_cache_limit_bytes = 0
+    with patch("vllm_mlx.scheduler.mx.set_cache_limit") as set_limit:
+        scheduler._apply_adaptive_prefill_size()
+    set_limit.assert_not_called()

--- a/tests/test_prefix_boundary_path_parity.py
+++ b/tests/test_prefix_boundary_path_parity.py
@@ -25,6 +25,11 @@ from vllm_mlx.engine.batched import BatchedEngine
 _SENTINEL_BOUNDARY = 42
 
 
+class _CharacterTokenizer:
+    def encode(self, text):
+        return [ord(char) for char in text]
+
+
 class _StubOutput:
     """Minimal stand-in for the GenerationOutput type returned by
     ``self._engine.generate`` / ``stream_generate``. Carries the fields
@@ -235,3 +240,54 @@ def test_nontrimmable_pure_attention_forwards_boundary_both_paths(monkeypatch):
 
     asyncio.run(_drain())
     assert stub.last_generate_kwargs.get("prefix_boundary") == _SENTINEL_BOUNDARY
+
+
+def test_prefix_boundary_prefers_latest_stable_message_boundary(monkeypatch):
+    """Exclude the transient generation suffix, not the latest user turn."""
+    engine, _ = _build_engine(monkeypatch)
+    engine._compute_prefix_boundary = BatchedEngine._compute_prefix_boundary.__get__(
+        engine, BatchedEngine
+    )
+    engine._tokenizer = _CharacterTokenizer()
+
+    def render(messages, tools=None, *, add_generation_prompt=True, **kwargs):
+        body = "|".join(str(message.get("content", "")) for message in messages)
+        return body + ("|ASSISTANT_GENERATION" if add_generation_prompt else "")
+
+    monkeypatch.setattr(engine, "_apply_chat_template", render)
+    messages = [
+        {"role": "system", "content": "system"},
+        {"role": "user", "content": "first"},
+        {"role": "assistant", "content": "answer"},
+        {"role": "user", "content": "latest"},
+    ]
+    stable = render(messages, add_generation_prompt=False)
+
+    assert engine._compute_prefix_boundary(messages) == len(stable)
+
+
+def test_prefix_boundary_falls_back_when_no_generation_form_is_not_prefix(
+    monkeypatch,
+):
+    """Third-party template drift keeps the conservative dummy-user LCP."""
+    engine, _ = _build_engine(monkeypatch)
+    engine._compute_prefix_boundary = BatchedEngine._compute_prefix_boundary.__get__(
+        engine, BatchedEngine
+    )
+    engine._tokenizer = _CharacterTokenizer()
+
+    def render(messages, tools=None, *, add_generation_prompt=True, **kwargs):
+        if not add_generation_prompt:
+            return "not-a-prefix"
+        latest = messages[-1].get("content", "")
+        return f"shared-history|{latest}|generation"
+
+    monkeypatch.setattr(engine, "_apply_chat_template", render)
+    messages = [
+        {"role": "system", "content": "system"},
+        {"role": "user", "content": "first"},
+        {"role": "assistant", "content": "answer"},
+        {"role": "user", "content": "latest"},
+    ]
+
+    assert engine._compute_prefix_boundary(messages) == len("shared-history|")

--- a/tests/test_prefix_boundary_path_parity.py
+++ b/tests/test_prefix_boundary_path_parity.py
@@ -291,3 +291,30 @@ def test_prefix_boundary_falls_back_when_no_generation_form_is_not_prefix(
     ]
 
     assert engine._compute_prefix_boundary(messages) == len("shared-history|")
+
+
+def test_prefix_boundary_rejects_last_user_rewrite_on_next_turn(monkeypatch):
+    engine, _ = _build_engine(monkeypatch)
+    engine._compute_prefix_boundary = BatchedEngine._compute_prefix_boundary.__get__(
+        engine, BatchedEngine
+    )
+    engine._tokenizer = _CharacterTokenizer()
+
+    def render(messages, tools=None, *, add_generation_prompt=True, **kwargs):
+        parts = []
+        for index, message in enumerate(messages):
+            content = str(message.get("content", ""))
+            is_final_user = index == len(messages) - 1 and message.get("role") == "user"
+            parts.append(f"LAST:{content}" if is_final_user else f"TURN:{content}")
+        body = "shared|" + "|".join(parts)
+        return body + ("|GEN" if add_generation_prompt else "")
+
+    monkeypatch.setattr(engine, "_apply_chat_template", render)
+    messages = [
+        {"role": "system", "content": "system"},
+        {"role": "user", "content": "latest"},
+    ]
+
+    boundary = engine._compute_prefix_boundary(messages)
+    assert boundary < len(render(messages, add_generation_prompt=False))
+    assert boundary == len("shared|TURN:system|")

--- a/tests/test_process_memory.py
+++ b/tests/test_process_memory.py
@@ -1,4 +1,5 @@
 import os
+import sys
 
 from vllm_mlx.runtime.process_memory import get_phys_footprint
 
@@ -9,3 +10,8 @@ def test_phys_footprint_is_nonnegative_for_current_process():
 
 def test_phys_footprint_accepts_explicit_pid():
     assert get_phys_footprint(os.getpid()) >= 0
+
+
+def test_phys_footprint_is_available_on_darwin():
+    if sys.platform == "darwin":
+        assert get_phys_footprint() > 0

--- a/tests/test_process_memory.py
+++ b/tests/test_process_memory.py
@@ -1,0 +1,11 @@
+import os
+
+from vllm_mlx.runtime.process_memory import get_phys_footprint
+
+
+def test_phys_footprint_is_nonnegative_for_current_process():
+    assert get_phys_footprint() >= 0
+
+
+def test_phys_footprint_accepts_explicit_pid():
+    assert get_phys_footprint(os.getpid()) >= 0

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -2215,13 +2215,17 @@ class BatchedEngine(BaseEngine):
     def _compute_prefix_boundary(
         self, messages: list[dict[str, Any]], tools: list[dict] | None = None
     ) -> int:
-        """Compute token count for the shared prefix across message variations.
+        """Compute the latest prefix that is stable across the next turn.
 
-        Uses a two-tokenization approach: tokenize the full prompt twice
-        (once as-is, once with the last user message replaced by a dummy)
-        and find the longest common prefix (LCP).  This gives the exact
-        boundary where different user suffixes diverge, avoiding template
-        discrepancies (e.g. Qwen3 <think> markers on last assistant).
+        The preferred boundary is the prompt rendered *without* the assistant
+        generation marker.  That includes the latest user message but excludes
+        the template-only suffix which is replaced by the real assistant turn
+        on the next request.  Saving there prevents non-trimmable hybrid and
+        DeepSeek-V4 caches from lagging one conversation turn.
+
+        Some third-party templates do not make the no-generation rendering a
+        strict prefix of the generation rendering.  For those, retain the
+        historical dummy-last-user LCP boundary as a conservative fallback.
         """
         # Find index of last user message
         last_user_idx = None
@@ -2234,10 +2238,34 @@ class BatchedEngine(BaseEngine):
         try:
             template_tools = convert_tools_for_template(tools) if tools else None
 
-            # Tokenize the real prompt
-            real_prompt = self._apply_chat_template(messages, template_tools)
+            # Tokenize the real generation prompt and the same conversation
+            # before its transient assistant-generation marker is appended.
+            real_prompt = self._apply_chat_template(
+                messages, template_tools, add_generation_prompt=True
+            )
+            stable_prompt = self._apply_chat_template(
+                messages, template_tools, add_generation_prompt=False
+            )
 
-            # Build a dummy variant with different last user content
+            tokenizer = self.tokenizer
+            if hasattr(tokenizer, "tokenizer"):
+                tokenizer = tokenizer.tokenizer
+
+            real_tokens = tokenizer.encode(real_prompt)
+            stable_tokens = tokenizer.encode(stable_prompt)
+            stable_lcp = 0
+            for real_token, stable_token in zip(real_tokens, stable_tokens):
+                if real_token != stable_token:
+                    break
+                stable_lcp += 1
+
+            # A useful snapshot must be strictly inside the generation prompt;
+            # equality produces no inter-segment boundary in BatchGenerator.
+            if stable_lcp == len(stable_tokens) and stable_lcp < len(real_tokens):
+                return stable_lcp
+
+            # Conservative fallback for templates whose no-generation form is
+            # not a strict prefix of their generation form.
             dummy_messages = list(messages)
             dummy_messages[last_user_idx] = {
                 **messages[last_user_idx],
@@ -2245,11 +2273,6 @@ class BatchedEngine(BaseEngine):
             }
             dummy_prompt = self._apply_chat_template(dummy_messages, template_tools)
 
-            tokenizer = self.tokenizer
-            if hasattr(tokenizer, "tokenizer"):
-                tokenizer = tokenizer.tokenizer
-
-            real_tokens = tokenizer.encode(real_prompt)
             dummy_tokens = tokenizer.encode(dummy_prompt)
 
             # Find LCP — the point where the two diverge is the boundary

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -2246,6 +2246,17 @@ class BatchedEngine(BaseEngine):
             stable_prompt = self._apply_chat_template(
                 messages, template_tools, add_generation_prompt=False
             )
+            next_turn_prompt = self._apply_chat_template(
+                [
+                    *messages,
+                    {
+                        "role": "assistant",
+                        "content": "__rapid_mlx_boundary_probe__",
+                    },
+                ],
+                template_tools,
+                add_generation_prompt=False,
+            )
 
             tokenizer = self.tokenizer
             if hasattr(tokenizer, "tokenizer"):
@@ -2253,6 +2264,7 @@ class BatchedEngine(BaseEngine):
 
             real_tokens = tokenizer.encode(real_prompt)
             stable_tokens = tokenizer.encode(stable_prompt)
+            next_turn_tokens = tokenizer.encode(next_turn_prompt)
             stable_lcp = 0
             for real_token, stable_token in zip(real_tokens, stable_tokens):
                 if real_token != stable_token:
@@ -2261,7 +2273,16 @@ class BatchedEngine(BaseEngine):
 
             # A useful snapshot must be strictly inside the generation prompt;
             # equality produces no inter-segment boundary in BatchGenerator.
-            if stable_lcp == len(stable_tokens) and stable_lcp < len(real_tokens):
+            next_turn_lcp = 0
+            for real_token, next_token in zip(real_tokens, next_turn_tokens):
+                if real_token != next_token:
+                    break
+                next_turn_lcp += 1
+            if (
+                stable_lcp == len(stable_tokens)
+                and next_turn_lcp >= len(stable_tokens)
+                and stable_lcp < len(real_tokens)
+            ):
                 return stable_lcp
 
             # Conservative fallback for templates whose no-generation form is
@@ -2282,7 +2303,7 @@ class BatchedEngine(BaseEngine):
                     break
                 lcp = j + 1
 
-            return lcp
+            return min(lcp, next_turn_lcp) if stable_lcp else lcp
         except Exception:
             return 0
 

--- a/vllm_mlx/routes/health.py
+++ b/vllm_mlx/routes/health.py
@@ -293,6 +293,13 @@ async def status():
         "total_completion_tokens": stats.get("total_completion_tokens", 0),
         "generation_tps": _tps("generation_tps"),
         "prompt_tps": _tps("prompt_tps"),
+        "adaptive_prefill": {
+            "chunk_size": stats.get("adaptive_prefill_chunk_size"),
+            "protected_chunks": stats.get("adaptive_prefill_protected_chunks", 0),
+            "reduced_chunks": stats.get("adaptive_prefill_reduced_chunks", 0),
+            "cache_clamped": stats.get("adaptive_prefill_cache_clamped", False),
+            "cache_clamps": stats.get("adaptive_prefill_cache_clamps", 0),
+        },
         "metal": {
             "active_memory_gb": stats.get("metal_active_memory_gb"),
             "peak_memory_gb": stats.get("metal_peak_memory_gb"),

--- a/vllm_mlx/routes/health.py
+++ b/vllm_mlx/routes/health.py
@@ -297,8 +297,6 @@ async def status():
             "chunk_size": stats.get("adaptive_prefill_chunk_size"),
             "protected_chunks": stats.get("adaptive_prefill_protected_chunks", 0),
             "reduced_chunks": stats.get("adaptive_prefill_reduced_chunks", 0),
-            "cache_clamped": stats.get("adaptive_prefill_cache_clamped", False),
-            "cache_clamps": stats.get("adaptive_prefill_cache_clamps", 0),
         },
         "metal": {
             "active_memory_gb": stats.get("metal_active_memory_gb"),

--- a/vllm_mlx/runtime/process_memory.py
+++ b/vllm_mlx/runtime/process_memory.py
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Authoritative macOS process-memory pressure measurement.
+
+The implementation follows the ``proc_pid_rusage(RUSAGE_INFO_V4)`` approach
+used by oMLX. ``phys_footprint`` includes IOAccelerator-backed allocations that
+ordinary RSS can omit on Apple Silicon, making it the useful companion to MLX's
+active-memory counter for long-context admission decisions.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import os
+import sys
+
+
+class _RusageInfoV4(ctypes.Structure):
+    # Layout from macOS <sys/resource.h>. Keep all fields through
+    # ri_interval_max_phys_footprint so the kernel can fill the V4 struct.
+    _fields_ = [
+        ("ri_uuid", ctypes.c_uint8 * 16),
+        ("ri_user_time", ctypes.c_uint64),
+        ("ri_system_time", ctypes.c_uint64),
+        ("ri_pkg_idle_wkups", ctypes.c_uint64),
+        ("ri_interrupt_wkups", ctypes.c_uint64),
+        ("ri_pageins", ctypes.c_uint64),
+        ("ri_wired_size", ctypes.c_uint64),
+        ("ri_resident_size", ctypes.c_uint64),
+        ("ri_phys_footprint", ctypes.c_uint64),
+        ("ri_proc_start_abstime", ctypes.c_uint64),
+        ("ri_proc_exit_abstime", ctypes.c_uint64),
+        ("ri_child_user_time", ctypes.c_uint64),
+        ("ri_child_system_time", ctypes.c_uint64),
+        ("ri_child_pkg_idle_wkups", ctypes.c_uint64),
+        ("ri_child_interrupt_wkups", ctypes.c_uint64),
+        ("ri_child_pageins", ctypes.c_uint64),
+        ("ri_child_elapsed_abstime", ctypes.c_uint64),
+        ("ri_diskio_bytesread", ctypes.c_uint64),
+        ("ri_diskio_byteswritten", ctypes.c_uint64),
+        ("ri_cpu_time_qos_default", ctypes.c_uint64),
+        ("ri_cpu_time_qos_maintenance", ctypes.c_uint64),
+        ("ri_cpu_time_qos_background", ctypes.c_uint64),
+        ("ri_cpu_time_qos_utility", ctypes.c_uint64),
+        ("ri_cpu_time_qos_legacy", ctypes.c_uint64),
+        ("ri_cpu_time_qos_user_initiated", ctypes.c_uint64),
+        ("ri_cpu_time_qos_user_interactive", ctypes.c_uint64),
+        ("ri_billed_system_time", ctypes.c_uint64),
+        ("ri_serviced_system_time", ctypes.c_uint64),
+        ("ri_logical_writes", ctypes.c_uint64),
+        ("ri_lifetime_max_phys_footprint", ctypes.c_uint64),
+        ("ri_instructions", ctypes.c_uint64),
+        ("ri_cycles", ctypes.c_uint64),
+        ("ri_billed_energy", ctypes.c_uint64),
+        ("ri_serviced_energy", ctypes.c_uint64),
+        ("ri_interval_max_phys_footprint", ctypes.c_uint64),
+        ("ri_runnable_time", ctypes.c_uint64),
+    ]
+
+
+_proc_pid_rusage = None
+if sys.platform == "darwin":
+    try:
+        _libproc = ctypes.CDLL("/usr/lib/libproc.dylib", use_errno=True)
+        _proc_pid_rusage = _libproc.proc_pid_rusage
+        _proc_pid_rusage.argtypes = [ctypes.c_int, ctypes.c_int, ctypes.c_void_p]
+        _proc_pid_rusage.restype = ctypes.c_int
+    except OSError:
+        _proc_pid_rusage = None
+
+
+def get_phys_footprint(pid: int | None = None) -> int:
+    """Return macOS ``phys_footprint`` bytes, or zero when unavailable."""
+    if _proc_pid_rusage is None:
+        return 0
+    info = _RusageInfoV4()
+    rc = _proc_pid_rusage(pid or os.getpid(), 4, ctypes.byref(info))
+    return int(info.ri_phys_footprint) if rc == 0 else 0

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -391,7 +391,6 @@ class SchedulerConfig:
     # with growing KV state and the current forward's transient allocations.
     # Temporarily cap it, then restore the device-scaled default when prefill
     # completes. Zero disables only this cache-limit guard.
-    adaptive_prefill_cache_limit_bytes: int = 4 * 1024 * 1024 * 1024
 
     def __post_init__(self) -> None:
         if self.response_cache_entries < 0:
@@ -2655,8 +2654,6 @@ class Scheduler:
         self._last_adaptive_prefill_size = self.config.prefill_step_size
         self._adaptive_prefill_protected_chunks = 0
         self._adaptive_prefill_reduced_chunks = 0
-        self._adaptive_prefill_cache_clamped = False
-        self._adaptive_prefill_cache_clamps = 0
         # D-METAL-CAP / D-METAL-PFX: cached hard cap in bytes for fast
         # admission checks. Computed lazily on first use so unit tests
         # that build a Scheduler against a fake model with no Metal
@@ -3907,7 +3904,6 @@ class Scheduler:
         minimum_prompt = int(
             getattr(self.config, "adaptive_prefill_min_tokens", 32_768)
         )
-        self._apply_adaptive_prefill_cache_limit(prompt_tokens >= minimum_prompt)
         if prompt_tokens >= minimum_prompt:
             # Pressure samples can wobble around a threshold as allocator
             # slabs are materialized and released. Growing the chunk again in
@@ -3937,53 +3933,6 @@ class Scheduler:
             )
             self._last_adaptive_prefill_size = selected
         return selected
-
-    def _default_metal_cache_limit(self) -> int:
-        """Mirror the engine's device-scaled free-cache policy."""
-        cap = self._resolve_metal_cap_bytes()
-        if cap <= 0:
-            return 32 * 1024 * 1024 * 1024
-        return min(
-            cap,
-            max(2 * 1024 * 1024 * 1024, min(32 * 1024 * 1024 * 1024, cap // 4)),
-        )
-
-    def _apply_adaptive_prefill_cache_limit(self, long_prefill: bool) -> None:
-        """Reserve transient headroom without penalising ordinary decode.
-
-        ``mx.clear_cache`` alone only drops buffers that happen to be free at
-        that instant; the allocator can immediately grow back to its normal
-        32 GiB ceiling on the next prompt chunk. Lowering the ceiling for the
-        lifetime of a long prefill makes that headroom durable. The transition
-        is edge-triggered, so neither ``set_cache_limit`` nor ``clear_cache``
-        lands in the per-token decode hot path.
-        """
-        requested = max(
-            0, int(getattr(self.config, "adaptive_prefill_cache_limit_bytes", 0))
-        )
-        should_clamp = (
-            bool(getattr(self.config, "adaptive_prefill", True))
-            and long_prefill
-            and requested > 0
-        )
-        clamped = bool(getattr(self, "_adaptive_prefill_cache_clamped", False))
-        if should_clamp == clamped:
-            return
-        limit = (
-            min(requested, self._default_metal_cache_limit())
-            if should_clamp
-            else self._default_metal_cache_limit()
-        )
-        mx.set_cache_limit(limit)
-        if should_clamp:
-            mx.clear_cache()
-            self._adaptive_prefill_cache_clamps += 1
-        self._adaptive_prefill_cache_clamped = should_clamp
-        logger.info(
-            "[adaptive_prefill] Metal cache limit %s %.1fGB",
-            "clamped to" if should_clamp else "restored to",
-            limit / 1e9,
-        )
 
     def _infer_kv_dtype_bytes(self, model_config: Any) -> int:
         """Best-effort KV-cache dtype-bytes inference.
@@ -6937,12 +6886,6 @@ class Scheduler:
             ),
             "adaptive_prefill_reduced_chunks": getattr(
                 self, "_adaptive_prefill_reduced_chunks", 0
-            ),
-            "adaptive_prefill_cache_clamped": getattr(
-                self, "_adaptive_prefill_cache_clamped", False
-            ),
-            "adaptive_prefill_cache_clamps": getattr(
-                self, "_adaptive_prefill_cache_clamps", 0
             ),
         }
         # R15-P1 (task #296): disk-backed KV checkpoint counters.

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -3969,7 +3969,11 @@ class Scheduler:
         clamped = bool(getattr(self, "_adaptive_prefill_cache_clamped", False))
         if should_clamp == clamped:
             return
-        limit = min(requested, self._default_metal_cache_limit()) if should_clamp else self._default_metal_cache_limit()
+        limit = (
+            min(requested, self._default_metal_cache_limit())
+            if should_clamp
+            else self._default_metal_cache_limit()
+        )
         mx.set_cache_limit(limit)
         if should_clamp:
             mx.clear_cache()

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -378,6 +378,21 @@ class SchedulerConfig:
     # end of the dataclass field list to preserve positional compatibility.
     dspark_num_speculative_tokens: int = 5
 
+    # Long-context prefill guard. mlx-lm already processes one bounded prompt
+    # chunk per BatchGenerator.next() and materializes cache state between
+    # chunks. What it cannot know is how much unified-memory headroom the
+    # surrounding server (model + retained prefixes + other requests) has.
+    # Appended here to preserve positional SchedulerConfig compatibility.
+    adaptive_prefill: bool = True
+    adaptive_prefill_min_tokens: int = 32_768
+    adaptive_prefill_min_chunk_size: int = 256
+    # The ordinary Metal free-cache limit is intentionally generous for
+    # decode throughput. During a very long prefill that same cache competes
+    # with growing KV state and the current forward's transient allocations.
+    # Temporarily cap it, then restore the device-scaled default when prefill
+    # completes. Zero disables only this cache-limit guard.
+    adaptive_prefill_cache_limit_bytes: int = 4 * 1024 * 1024 * 1024
+
     def __post_init__(self) -> None:
         if self.response_cache_entries < 0:
             raise ValueError("response_cache_entries must be >= 0")
@@ -2637,6 +2652,11 @@ class Scheduler:
         self._step_count = 0
         self._clear_cache_interval = 32
         self._memory_log_interval = 256
+        self._last_adaptive_prefill_size = self.config.prefill_step_size
+        self._adaptive_prefill_protected_chunks = 0
+        self._adaptive_prefill_reduced_chunks = 0
+        self._adaptive_prefill_cache_clamped = False
+        self._adaptive_prefill_cache_clamps = 0
         # D-METAL-CAP / D-METAL-PFX: cached hard cap in bytes for fast
         # admission checks. Computed lazily on first use so unit tests
         # that build a Scheduler against a fake model with no Metal
@@ -3767,6 +3787,199 @@ class Scheduler:
             return int(mx.get_active_memory())
         except Exception:
             return 0
+
+    def _current_process_resident_bytes(self) -> int:
+        """Best-effort process footprint for unified-memory pressure.
+
+        MLX active memory omits Python objects, token buffers and some Metal
+        driver allocations. macOS ``phys_footprint`` is the authoritative
+        kernel ledger; RSS is retained as a portable fallback for Linux CI.
+        """
+        try:
+            from .runtime.process_memory import get_phys_footprint
+
+            footprint = get_phys_footprint()
+            if footprint > 0:
+                return footprint
+        except Exception:
+            pass
+        try:
+            import psutil
+
+            return int(psutil.Process().memory_info().rss)
+        except Exception:
+            return 0
+
+    def _active_prefill_token_count(self) -> int:
+        """Return the largest final context offset currently prefetched.
+
+        Workspace at a long attention offset can be large even when a prefix
+        hit leaves only a tiny suffix. Count cached/all-token history plus the
+        remaining segments, not merely the suffix workload.
+        """
+        bg = getattr(self, "batch_generator", None)
+        processing = getattr(bg, "_currently_processing", ()) if bg else ()
+        prompt_batch = getattr(bg, "_prompt_batch", None) if bg else None
+        prior_tokens = getattr(prompt_batch, "tokens", ()) if prompt_batch else ()
+        largest = 0
+        for index, item in enumerate(processing):
+            try:
+                already_cached = (
+                    len(prior_tokens[index]) if index < len(prior_tokens) else 0
+                )
+                processed = int(item[1])
+                remaining = max(0, int(item[2]) - processed)
+                largest = max(largest, already_cached + remaining)
+            except (IndexError, TypeError, ValueError):
+                continue
+        # Requests have not entered ``_currently_processing`` on their first
+        # scheduler tick yet. Include queued BatchGenerator segments so the
+        # first cold chunk is guarded too.
+        queued = getattr(bg, "_unprocessed_sequences", ()) if bg else ()
+        for item in queued:
+            try:
+                largest = max(
+                    largest,
+                    len(item[4]) + sum(len(seg) for seg in item[1]),
+                )
+            except (IndexError, TypeError):
+                continue
+        # mlx-lm may represent a prefix-cache hit as a fresh prompt batch
+        # containing only the uncached suffix. In that transition window
+        # ``prior_tokens`` therefore understates the resident KV offset. The
+        # public Request retains the full model prompt length; use it while a
+        # prefill queue is actually active, but never during decode (where it
+        # would keep the low cache ceiling armed for the whole completion).
+        if processing or queued:
+            for request in getattr(self, "running", {}).values():
+                try:
+                    largest = max(
+                        largest,
+                        int(request.model_prompt_tokens or request.num_prompt_tokens),
+                    )
+                except (AttributeError, TypeError, ValueError):
+                    continue
+        return largest
+
+    def _select_adaptive_prefill_size(self) -> int:
+        """Choose a memory-safe size for the next long-prompt chunk.
+
+        The thresholds intentionally start tightening at 70%: the 97k-token
+        DeepSeek-V4 repro showed a roughly 50 GB transient gap between steady
+        active memory and the prefill peak, so waiting until 90% is too late.
+        """
+        configured = max(1, int(getattr(self.config, "prefill_step_size", 2048)))
+        if not getattr(self.config, "adaptive_prefill", True):
+            return configured
+        minimum_prompt = max(
+            1, int(getattr(self.config, "adaptive_prefill_min_tokens", 32_768))
+        )
+        if self._active_prefill_token_count() < minimum_prompt:
+            return configured
+        cap = self._resolve_metal_cap_bytes()
+        if cap <= 0:
+            return configured
+        footprint = max(
+            self._current_metal_active_bytes(), self._current_process_resident_bytes()
+        )
+        ratio = footprint / cap
+        floor = max(
+            1, int(getattr(self.config, "adaptive_prefill_min_chunk_size", 256))
+        )
+        if ratio >= 0.88:
+            target = 256
+        elif ratio >= 0.80:
+            target = 512
+        elif ratio >= 0.70:
+            target = 1024
+        else:
+            target = configured
+        return min(configured, max(floor, target))
+
+    def _apply_adaptive_prefill_size(self) -> int:
+        """Apply the selected size to mlx-lm's current and future batches."""
+        bg = getattr(self, "batch_generator", None)
+        if bg is None:
+            return 0
+        selected = self._select_adaptive_prefill_size()
+        prompt_tokens = self._active_prefill_token_count()
+        configured = max(1, int(getattr(self.config, "prefill_step_size", 2048)))
+        minimum_prompt = int(
+            getattr(self.config, "adaptive_prefill_min_tokens", 32_768)
+        )
+        self._apply_adaptive_prefill_cache_limit(prompt_tokens >= minimum_prompt)
+        if prompt_tokens >= minimum_prompt:
+            # Pressure samples can wobble around a threshold as allocator
+            # slabs are materialized and released. Growing the chunk again in
+            # the same prefill causes oscillation and can recreate the peak we
+            # just avoided. A completed prompt naturally restores configured
+            # size on the next decode/idle tick.
+            previous = getattr(self, "_last_adaptive_prefill_size", configured)
+            selected = min(selected, previous)
+            self._adaptive_prefill_protected_chunks += 1
+            if selected < configured:
+                self._adaptive_prefill_reduced_chunks += 1
+        bg.prefill_step_size = selected
+        prompt_batch = getattr(bg, "_prompt_batch", None)
+        if prompt_batch is not None:
+            prompt_batch.prefill_step_size = selected
+        previous = getattr(self, "_last_adaptive_prefill_size", None)
+        if previous != selected:
+            logger.info(
+                "[adaptive_prefill] chunk %s -> %s tokens prompt=%s "
+                "metal=%.1fGB rss=%.1fGB cap=%.1fGB",
+                previous,
+                selected,
+                prompt_tokens,
+                self._current_metal_active_bytes() / 1e9,
+                self._current_process_resident_bytes() / 1e9,
+                self._resolve_metal_cap_bytes() / 1e9,
+            )
+            self._last_adaptive_prefill_size = selected
+        return selected
+
+    def _default_metal_cache_limit(self) -> int:
+        """Mirror the engine's device-scaled free-cache policy."""
+        cap = self._resolve_metal_cap_bytes()
+        if cap <= 0:
+            return 32 * 1024 * 1024 * 1024
+        return min(
+            cap,
+            max(2 * 1024 * 1024 * 1024, min(32 * 1024 * 1024 * 1024, cap // 4)),
+        )
+
+    def _apply_adaptive_prefill_cache_limit(self, long_prefill: bool) -> None:
+        """Reserve transient headroom without penalising ordinary decode.
+
+        ``mx.clear_cache`` alone only drops buffers that happen to be free at
+        that instant; the allocator can immediately grow back to its normal
+        32 GiB ceiling on the next prompt chunk. Lowering the ceiling for the
+        lifetime of a long prefill makes that headroom durable. The transition
+        is edge-triggered, so neither ``set_cache_limit`` nor ``clear_cache``
+        lands in the per-token decode hot path.
+        """
+        requested = max(
+            0, int(getattr(self.config, "adaptive_prefill_cache_limit_bytes", 0))
+        )
+        should_clamp = (
+            bool(getattr(self.config, "adaptive_prefill", True))
+            and long_prefill
+            and requested > 0
+        )
+        clamped = bool(getattr(self, "_adaptive_prefill_cache_clamped", False))
+        if should_clamp == clamped:
+            return
+        limit = min(requested, self._default_metal_cache_limit()) if should_clamp else self._default_metal_cache_limit()
+        mx.set_cache_limit(limit)
+        if should_clamp:
+            mx.clear_cache()
+            self._adaptive_prefill_cache_clamps += 1
+        self._adaptive_prefill_cache_clamped = should_clamp
+        logger.info(
+            "[adaptive_prefill] Metal cache limit %s %.1fGB",
+            "clamped to" if should_clamp else "restored to",
+            limit / 1e9,
+        )
 
     def _infer_kv_dtype_bytes(self, model_config: Any) -> int:
         """Best-effort KV-cache dtype-bytes inference.
@@ -6392,6 +6605,10 @@ class Scheduler:
                     # the plain decode hot path (codex #558-PR3).
                     if self._realign_guard_armed():
                         self._realign_grammar_logits_processors()
+                    # mlx-lm consumes at most one prompt chunk in this call.
+                    # Tighten that chunk before dispatch when a long cold or
+                    # cache-miss prefill is approaching the unified-memory cap.
+                    self._apply_adaptive_prefill_size()
                     raw_next = self.batch_generator.next()
                     output.has_work = True
 
@@ -6707,6 +6924,21 @@ class Scheduler:
             "num_metal_cap_violations": self.num_metal_cap_violations,
             "num_prefix_cache_pressure_evictions": (
                 self.num_prefix_cache_pressure_evictions
+            ),
+            "adaptive_prefill_chunk_size": getattr(
+                self, "_last_adaptive_prefill_size", self.config.prefill_step_size
+            ),
+            "adaptive_prefill_protected_chunks": getattr(
+                self, "_adaptive_prefill_protected_chunks", 0
+            ),
+            "adaptive_prefill_reduced_chunks": getattr(
+                self, "_adaptive_prefill_reduced_chunks", 0
+            ),
+            "adaptive_prefill_cache_clamped": getattr(
+                self, "_adaptive_prefill_cache_clamped", False
+            ),
+            "adaptive_prefill_cache_clamps": getattr(
+                self, "_adaptive_prefill_cache_clamps", 0
             ),
         }
         # R15-P1 (task #296): disk-backed KV checkpoint counters.

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -3898,11 +3898,18 @@ class Scheduler:
         bg = getattr(self, "batch_generator", None)
         if bg is None:
             return 0
+        configured = max(1, int(getattr(self.config, "prefill_step_size", 2048)))
+        if not getattr(self.config, "adaptive_prefill", True):
+            bg.prefill_step_size = configured
+            prompt_batch = getattr(bg, "_prompt_batch", None)
+            if prompt_batch is not None:
+                prompt_batch.prefill_step_size = configured
+            self._last_adaptive_prefill_size = configured
+            return configured
         selected = self._select_adaptive_prefill_size()
         prompt_tokens = self._active_prefill_token_count()
-        configured = max(1, int(getattr(self.config, "prefill_step_size", 2048)))
-        minimum_prompt = int(
-            getattr(self.config, "adaptive_prefill_min_tokens", 32_768)
+        minimum_prompt = max(
+            1, int(getattr(self.config, "adaptive_prefill_min_tokens", 32_768))
         )
         if prompt_tokens >= minimum_prompt:
             # Pressure samples can wobble around a threshold as allocator


### PR DESCRIPTION
## Summary

- size prefill chunks from live process/Metal pressure instead of a fixed long-context step
- clamp Metal cache policy for high-memory model serving and expose process RSS in health diagnostics
- keep prefix-boundary and ordinary prefill paths on the same adaptive policy

## Why

DeepSeek V4 prompts naturally grow across long Codex sessions. Fixed chunk/cache choices can retain too much transient memory, pushing generation toward Metal resource exhaustion even when the model and KV state fit. This change makes prefill conservative under observed pressure while preserving larger chunks when headroom is available.

This is the long-context/cache group from the stability WIP. It excludes Codex priming, DSpark verify/rollback, and soak tooling.

## Validation

- ruff check + format on all changed files
- 21 focused adaptive-prefill, prefix-boundary parity, and process-memory tests passed
- full PR validation follows after adversarial review
