### PR TITLE
perf(dspark): add checkpoint verify and exact rollback

### DIFF
--- a/tests/test_deepseek_v4_vendored.py
+++ b/tests/test_deepseek_v4_vendored.py
@@ -558,3 +558,11 @@ def test_dspark_verify_matches_sequential_decode_cache_views():
         for entry in verify_cache
     ]
     assert sequential_offsets == verify_offsets
+
+    # Cache equivalence must survive the verify call, not merely produce the
+    # same rows once.  The following ordinary decode observes all cache state.
+    next_token = mx.array([[27]], dtype=mx.int32)
+    sequential_next = model(next_token, cache=sequential_cache)
+    verify_next = model(next_token, cache=verify_cache)
+    mx.eval(sequential_next, verify_next)
+    assert mx.allclose(sequential_next, verify_next, rtol=2e-3, atol=2e-3).item()

--- a/tests/test_deepseek_v4_vendored.py
+++ b/tests/test_deepseek_v4_vendored.py
@@ -60,6 +60,31 @@ def test_register_vendored_archs_is_idempotent():
     assert first is second
 
 
+def test_restored_pooling_cache_without_legacy_undo_field_is_safe():
+    """Persisted pre-rollback caches must remain inspectable after upgrade."""
+    import mlx.core as mx
+
+    from vllm_mlx.models.deepseek_v4_cache import PoolingCache
+
+    cache = PoolingCache.__new__(PoolingCache)
+    cache.pooled = mx.zeros((1, 1, 4))
+    cache.remainder = 0
+    assert not hasattr(cache, "_undo")
+    assert cache.is_trimmable() is False
+
+
+def test_restored_batch_pooling_cache_without_legacy_undo_field_is_safe():
+    import mlx.core as mx
+
+    from vllm_mlx.models.deepseek_v4_cache import BatchPoolingCache
+
+    cache = BatchPoolingCache.__new__(BatchPoolingCache)
+    cache.pooled = mx.zeros((1, 1, 4))
+    cache.remainder = [0]
+    assert not hasattr(cache, "_undo")
+    assert cache.is_trimmable() is False
+
+
 def test_deepseek_v4_rope_applies_per_row_integer_offsets():
     """Continuous batches may contain caches at different positions."""
     mx = pytest.importorskip("mlx.core")
@@ -469,3 +494,67 @@ def test_deepseek_v4_dspark_drafts_checkpoint_block():
     mx.eval(short_ids, short_logits)
     assert short_ids.shape == (1, 3)
     assert short_logits.shape == (1, 2, 128)
+
+
+def test_dspark_verify_matches_sequential_decode_cache_views():
+    """M-row verification must observe the same state as M ordinary steps."""
+    import copy
+
+    import mlx.core as mx
+
+    from vllm_mlx.models.deepseek_v4 import Model, ModelArgs
+    from vllm_mlx.models.deepseek_v4_rollback import armed
+
+    args = ModelArgs(
+        vocab_size=128,
+        hidden_size=64,
+        num_hidden_layers=4,
+        num_attention_heads=4,
+        q_lora_rank=16,
+        qk_rope_head_dim=4,
+        head_dim=16,
+        compress_ratios=[0, 4, 128, 0],
+        index_n_heads=4,
+        index_head_dim=8,
+        index_topk=4,
+        moe_intermediate_size=16,
+        n_routed_experts=4,
+        n_shared_experts=1,
+        num_experts_per_tok=2,
+        num_hash_layers=1,
+        hc_mult=2,
+        sliding_window=16,
+        o_groups=2,
+        o_lora_rank=8,
+        dspark_num_layers=3,
+        dspark_block_size=5,
+        dspark_noise_token_id=127,
+        dspark_target_layer_ids=[0, 1, 2],
+        dspark_markov_rank=8,
+    )
+    model = Model(args)
+    cache = model.make_cache()
+    prefix = mx.array([[i % 127 for i in range(20)]], dtype=mx.int32)
+    mx.eval(model(prefix, cache=cache), [entry.state for entry in cache])
+    sequential_cache = copy.deepcopy(cache)
+    verify_cache = copy.deepcopy(cache)
+    verify = mx.array([[21, 22, 23, 24, 25, 26]], dtype=mx.int32)
+
+    rows = []
+    for idx in range(verify.shape[1]):
+        rows.append(model(verify[:, idx : idx + 1], cache=sequential_cache))
+    sequential = mx.concatenate(rows, axis=1)
+    with armed():
+        batched = model(verify, cache=verify_cache)
+    mx.eval(sequential, batched)
+
+    assert mx.allclose(sequential, batched, rtol=2e-3, atol=2e-3).item()
+    sequential_offsets = [
+        entry[0].offset if hasattr(entry, "caches") else entry.offset
+        for entry in sequential_cache
+    ]
+    verify_offsets = [
+        entry[0].offset if hasattr(entry, "caches") else entry.offset
+        for entry in verify_cache
+    ]
+    assert sequential_offsets == verify_offsets

--- a/tests/test_dspark_scheduler.py
+++ b/tests/test_dspark_scheduler.py
@@ -13,6 +13,63 @@ from vllm_mlx.scheduler import (
 )
 
 
+def test_pooling_cache_rolls_back_across_compression_boundary() -> None:
+    from vllm_mlx.models.deepseek_v4_cache import PoolingCache
+    from vllm_mlx.models.deepseek_v4_rollback import armed, trim_all
+
+    cache = PoolingCache(4)
+    # Establish three pending values, then verify four inputs. Keeping the
+    # confirmed input crosses one boundary; the rejected suffix must vanish.
+    cache.accumulate_windows(mx.ones((1, 3, 2)), mx.ones((1, 3, 2)), 0)
+    with armed():
+        ready, _gate, _base = cache.accumulate_windows(
+            mx.ones((1, 4, 2)), mx.ones((1, 4, 2)), 3
+        )
+        cache.update_and_fetch(mx.ones((1, ready.shape[1] // 4, 2)))
+
+    assert trim_all([cache], 3)
+    assert cache.offset == 1
+    assert cache.remainder == 0
+
+
+def test_rotating_cache_rolls_back_after_rotation() -> None:
+    from mlx_lm.models.cache import RotatingKVCache
+
+    from vllm_mlx.models.deepseek_v4_rollback import (
+        armed,
+        install_rotating_undo,
+        trim_all,
+    )
+
+    install_rotating_undo()
+    cache = RotatingKVCache(max_size=4)
+    cache.update_and_fetch(mx.zeros((1, 1, 4, 2)), mx.zeros((1, 1, 4, 2)))
+    with armed():
+        cache.update_and_fetch(mx.ones((1, 1, 4, 2)), mx.ones((1, 1, 4, 2)))
+
+    assert trim_all([cache], 3)
+    assert cache.offset == 5
+
+
+def test_batch_rotating_cache_rolls_back_after_rotation() -> None:
+    from mlx_lm.models.cache import BatchRotatingKVCache
+
+    from vllm_mlx.models.deepseek_v4_rollback import (
+        armed,
+        install_rotating_undo,
+        trim_all,
+    )
+
+    install_rotating_undo()
+    cache = BatchRotatingKVCache(max_size=4, left_padding=[0])
+    cache.update_and_fetch(mx.zeros((1, 1, 4, 2)), mx.zeros((1, 1, 4, 2)))
+    with armed():
+        cache.update_and_fetch(mx.ones((1, 1, 4, 2)), mx.ones((1, 1, 4, 2)))
+
+    assert trim_all([cache], 3)
+    assert cache._offset == 5
+
+
 def test_adaptive_depth_shrinks_cools_down_and_recovers() -> None:
     depth, streak, cooldown = _adapt_dspark_depth(5, 5, 1, 5, 0)
     assert (depth, streak, cooldown) == (4, 1, False)
@@ -52,6 +109,27 @@ def test_replay_dspark_committed_excludes_unsurfaced_drafts() -> None:
     )
 
     assert restored[0].values == [10, 11]
+
+
+def test_prompt_capture_does_not_fabricate_dspark_history_after_prefix_hit() -> None:
+    from vllm_mlx.models.deepseek_v4 import Model
+
+    fake = SimpleNamespace(
+        _dspark_prime_ctx=None,
+        _target_cache_offset=lambda _cache: 100,
+        make_dspark_cache=lambda: (_ for _ in ()).throw(
+            AssertionError("must not create a logically offset empty cache")
+        ),
+    )
+
+    Model._capture_dspark_prompt(
+        fake,
+        mx.ones((1, 4), dtype=mx.uint32),
+        mx.zeros((1, 4, 8)),
+        [object()],
+    )
+
+    assert fake._dspark_prime_ctx is None
 
 
 def test_verify_failure_restores_target_cache_before_baseline_fallback() -> None:
@@ -102,3 +180,48 @@ def test_verify_failure_restores_target_cache_before_baseline_fallback() -> None
 
     assert tokens == [1]
     assert batch_gen._dspark_stats["errors"] == 1
+
+
+def test_stochastic_request_uses_plain_decode_until_multiround_gate_exists() -> None:
+    class _Model:
+        args = SimpleNamespace(dspark_block_size=5)
+        mtp = [object()]
+        _last_dspark_hidden = mx.zeros((1, 1, 2))
+
+        def make_dspark_cache(self):
+            return []
+
+        def dspark_forward(self, *_args, **_kwargs):
+            raise AssertionError("stochastic request must not enter DSpark")
+
+    class _GenerationBatch:
+        pass
+
+    gb = _GenerationBatch()
+    gb._next_tokens = mx.array([1])
+    gb.uids = [7]
+    gb.next = lambda: []
+    baseline_calls = []
+
+    def baseline_step():
+        baseline_calls.append(True)
+        return [9], [mx.zeros((8,))]
+
+    gb._step = baseline_step
+    request = SimpleNamespace(
+        sampling_params=SimpleNamespace(temperature=1.0, seed=None)
+    )
+    batch_gen = SimpleNamespace(_generation_batch=gb)
+
+    assert _install_dspark(
+        batch_gen,
+        _Model(),
+        {"request-7": request},
+        {7: "request-7"},
+        max_draft=5,
+    )
+    tokens, _logprobs = gb._step()
+
+    assert tokens == [9]
+    assert baseline_calls == [True]
+    assert batch_gen._dspark_stats["fallthrough_steps"] == 1

--- a/tests/test_dspark_scheduler.py
+++ b/tests/test_dspark_scheduler.py
@@ -42,13 +42,21 @@ def test_rotating_cache_rolls_back_after_rotation() -> None:
     )
 
     install_rotating_undo()
+    reference = RotatingKVCache(max_size=4)
+    reference.update_and_fetch(mx.zeros((1, 1, 4, 2)), mx.zeros((1, 1, 4, 2)))
+    reference.update_and_fetch(mx.ones((1, 1, 1, 2)), mx.ones((1, 1, 1, 2)))
     cache = RotatingKVCache(max_size=4)
     cache.update_and_fetch(mx.zeros((1, 1, 4, 2)), mx.zeros((1, 1, 4, 2)))
     with armed():
         cache.update_and_fetch(mx.ones((1, 1, 4, 2)), mx.ones((1, 1, 4, 2)))
 
     assert trim_all([cache], 3)
-    assert cache.offset == 5
+    assert (cache.offset, cache._idx) == (reference.offset, reference._idx)
+    assert mx.array_equal(cache.keys, reference.keys).item()
+    assert mx.array_equal(cache.values, reference.values).item()
+    assert mx.array_equal(
+        cache._temporal_order(cache.keys), reference._temporal_order(reference.keys)
+    ).item()
 
 
 def test_batch_rotating_cache_rolls_back_after_rotation() -> None:
@@ -61,13 +69,24 @@ def test_batch_rotating_cache_rolls_back_after_rotation() -> None:
     )
 
     install_rotating_undo()
+    reference = BatchRotatingKVCache(max_size=4, left_padding=[0])
+    reference.update_and_fetch(mx.zeros((1, 1, 4, 2)), mx.zeros((1, 1, 4, 2)))
+    reference.update_and_fetch(mx.ones((1, 1, 1, 2)), mx.ones((1, 1, 1, 2)))
     cache = BatchRotatingKVCache(max_size=4, left_padding=[0])
     cache.update_and_fetch(mx.zeros((1, 1, 4, 2)), mx.zeros((1, 1, 4, 2)))
     with armed():
         cache.update_and_fetch(mx.ones((1, 1, 4, 2)), mx.ones((1, 1, 4, 2)))
 
     assert trim_all([cache], 3)
-    assert cache._offset == 5
+    assert (cache._offset, cache._idx, cache.rotated) == (
+        reference._offset,
+        reference._idx,
+        reference.rotated,
+    )
+    assert mx.array_equal(cache.offset, reference.offset).item()
+    assert mx.array_equal(cache.left_padding, reference.left_padding).item()
+    assert mx.array_equal(cache.keys, reference.keys).item()
+    assert mx.array_equal(cache.values, reference.values).item()
 
 
 def test_adaptive_depth_shrinks_cools_down_and_recovers() -> None:

--- a/vllm_mlx/models/deepseek_v4.py
+++ b/vllm_mlx/models/deepseek_v4.py
@@ -5,7 +5,7 @@
 
 import math
 from dataclasses import dataclass, field
-from functools import partial
+from functools import lru_cache, partial
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import mlx.core as mx
@@ -29,6 +29,11 @@ from mlx_lm.models.mla import MultiLinear
 from mlx_lm.models.pipeline import PipelineMixin
 
 from .deepseek_v4_cache import DeepseekV4PoolingCache, PoolingCache
+from .deepseek_v4_rollback import install_rotating_undo
+from .deepseek_v4_verify import install as install_dspark_verify
+
+install_rotating_undo()
+install_dspark_verify()
 from .deepseek_v4_hyper_connection import HyperConnection, HyperHead, hc_expand
 from .deepseek_v4_switch import FusedSwitchGLU
 
@@ -568,15 +573,17 @@ class Compressor(nn.Module):
             freq_scale=compress_ratio,
         )
 
-    def __call__(
+    def project(self, x: mx.array) -> tuple[mx.array, mx.array]:
+        return self.wkv(x), self.wgate(x)
+
+    def consume(
         self,
-        x: mx.array,
+        kv: mx.array,
+        gate: mx.array,
         pool_cache: Optional[PoolingCache],
         offset: Union[int, mx.array],
     ) -> mx.array:
-        B, _, _ = x.shape
-        kv = self.wkv(x)
-        gate = self.wgate(x)
+        B = kv.shape[0]
         if pool_cache is None:
             usable = (kv.shape[1] // self.compress_ratio) * self.compress_ratio
             ready_kv, ready_gate = kv[:, :usable], gate[:, :usable]
@@ -587,7 +594,7 @@ class Compressor(nn.Module):
             )
 
         if ready_kv.size == 0:
-            new_pooled = mx.zeros((B, 0, self.head_dim), dtype=x.dtype)
+            new_pooled = mx.zeros((B, 0, self.head_dim), dtype=kv.dtype)
         else:
             kv = mx.unflatten(ready_kv, 1, (-1, self.compress_ratio))
             gate = mx.unflatten(ready_gate, 1, (-1, self.compress_ratio))
@@ -623,6 +630,14 @@ class Compressor(nn.Module):
             new_pooled = pool_cache.update_and_fetch(new_pooled)
 
         return new_pooled
+
+    def __call__(
+        self,
+        x: mx.array,
+        pool_cache: Optional[PoolingCache],
+        offset: Union[int, mx.array],
+    ) -> mx.array:
+        return self.consume(*self.project(x), pool_cache, offset)
 
 
 class Indexer(nn.Module):
@@ -676,6 +691,188 @@ class Indexer(nn.Module):
             )
         k = min(self.index_topk, pooled.shape[1])
         return mx.argpartition(-scores, kth=k - 1, axis=-1)[..., :k]
+
+
+def _dspark_verify_active(batch: int, length: int) -> bool:
+    from .deepseek_v4_rollback import is_armed
+
+    return is_armed() and batch == 1 and 1 < length <= 6
+
+
+def _consume_rotating_verify_rows(cache, kv: mx.array) -> list[mx.array]:
+    """Advance a B=1 ring as ordinary M=1 decode and retain every view."""
+    steps = int(kv.shape[2])
+    if cache is None:
+        return [kv[..., : idx + 1, :] for idx in range(steps)]
+    empty = mx.zeros((*kv.shape[:-1], 0), dtype=kv.dtype)
+    rows = []
+    for idx in range(steps):
+        row, _ = cache.update_and_fetch(
+            kv[..., idx : idx + 1, :], empty[..., idx : idx + 1, :]
+        )
+        rows.append(row + 0)
+    return rows
+
+
+@lru_cache(maxsize=128)
+def _rotating_snapshot_indices(ring_size: int, slots: tuple[int, ...]) -> mx.array:
+    rows = []
+    for upto in range(len(slots)):
+        indices = list(range(ring_size))
+        for update in range(upto + 1):
+            indices[slots[update]] = ring_size + update
+        rows.append(indices)
+    return mx.array(rows, dtype=mx.uint32)
+
+
+@dataclass(frozen=True)
+class _RotatingVerifyView:
+    source: mx.array
+    indices: mx.array
+
+
+def _stage_rotating_verify_view(cache, kv: mx.array) -> Optional[_RotatingVerifyView]:
+    try:
+        from omlx.custom_kernels.glm_moe_dsa import fast
+
+        if not fast.has_symbol("dspark_ring_gemm"):
+            return None
+    except Exception:
+        return None
+    if cache is None or cache.keys is None:
+        return None
+    logical = int(getattr(cache, "_offset", cache.offset))
+    ring_size = int(cache.max_size)
+    if int(cache.keys.shape[2]) != ring_size or logical < ring_size:
+        return None
+    steps = int(kv.shape[2])
+    fields = ("keys", "values", "offset", "_idx")
+    if hasattr(cache, "_offset"):
+        fields += ("left_padding", "_offset", "rotated")
+    snapshot = {
+        name: (getattr(cache, name) + 0 if isinstance(getattr(cache, name), mx.array) else getattr(cache, name))
+        for name in fields
+    }
+    empty = mx.zeros((*kv.shape[:-1], 0), dtype=kv.dtype)
+    cache._rapid_undo = (snapshot, kv, empty)
+
+    write_idx = int(cache._idx)
+    slots = []
+    rotated = bool(getattr(cache, "rotated", False))
+    rotated_writes = 0
+    for _ in range(steps):
+        if write_idx == ring_size:
+            write_idx = 0 if hasattr(cache, "_offset") else int(cache.keep)
+            rotated = True
+        if rotated:
+            rotated_writes += 1
+        slots.append(write_idx)
+        write_idx += 1
+    source = mx.concatenate([cache.keys, kv], axis=2)
+    indices = _rotating_snapshot_indices(ring_size, tuple(slots))
+    cache.keys = mx.take(source, indices[-1], axis=2)
+    cache._idx = write_idx
+    cache.offset = cache.offset + steps
+    if hasattr(cache, "_offset"):
+        cache._offset += steps
+        cache.rotated = rotated
+        if rotated_writes:
+            cache.left_padding = cache.left_padding - rotated_writes
+        cache.keys = mx.depends(cache.keys, (cache.left_padding, cache.offset))
+    return _RotatingVerifyView(source=source[0, 0], indices=indices)
+
+
+def _ring_mm(lhs, view: _RotatingVerifyView, transpose_rhs: bool):
+    from omlx.custom_kernels.glm_moe_dsa import fast
+
+    return fast.dspark_ring_gemm(
+        mx.contiguous(lhs[:, 0]),
+        mx.contiguous(view.source),
+        mx.contiguous(view.indices),
+        transpose_rhs,
+    )[:, None]
+
+
+def _materialize_rotating_verify_rows(view: _RotatingVerifyView) -> list[mx.array]:
+    rows = mx.take(view.source, view.indices, axis=0)
+    return [rows[idx : idx + 1, None] for idx in range(int(rows.shape[0]))]
+
+
+def _ring_sparse_attention(q, view, pooled, topk, scale, sinks):
+    idx = topk[:, None, :, :, None]
+    pooled = mx.take_along_axis(
+        mx.broadcast_to(
+            pooled[:, None, None],
+            (pooled.shape[0], 1, 1, pooled.shape[1], pooled.shape[2]),
+        ),
+        mx.broadcast_to(idx, idx.shape[:-1] + (pooled.shape[2],)),
+        axis=3,
+    ).squeeze(1)
+    q_rows = q * scale
+    local_scores = _ring_mm(q_rows.transpose(0, 2, 1, 3), view, True)
+    pooled_scores = q_rows.transpose(0, 2, 1, 3) @ pooled.swapaxes(-1, -2)
+    local_scores = local_scores.transpose(0, 2, 1, 3)
+    pooled_scores = pooled_scores.transpose(0, 2, 1, 3)
+    normalizer = mx.logaddexp(
+        mx.logsumexp(local_scores, -1, keepdims=True),
+        mx.logsumexp(pooled_scores, -1, keepdims=True),
+    )
+    normalizer = mx.logaddexp(normalizer, sinks[None, :, None, None])
+    local_weights = mx.exp(local_scores - normalizer)
+    pooled_weights = mx.exp(pooled_scores - normalizer)
+    local_out = _ring_mm(local_weights.transpose(0, 2, 1, 3), view, False)
+    pooled_out = pooled_weights.transpose(0, 2, 1, 3) @ pooled
+    return (local_out + pooled_out).transpose(0, 2, 1, 3).astype(q.dtype)
+
+
+def _consume_pooling_verify_rows(
+    compressor: Compressor,
+    kv: mx.array,
+    gate: mx.array,
+    cache: Optional[PoolingCache],
+    offset: Union[int, mx.array],
+) -> list[mx.array]:
+    """Expose the pooled cache visible after each M=1 verify token."""
+    return [
+        compressor.consume(
+            kv[:, idx : idx + 1],
+            gate[:, idx : idx + 1],
+            cache,
+            offset + idx,
+        )
+        for idx in range(int(kv.shape[1]))
+    ]
+
+
+def _decode_consistent_attention(
+    q: mx.array,
+    key_rows: list[mx.array],
+    scale: float,
+    sinks: mx.array,
+) -> mx.array:
+    from .deepseek_v4_verify_attention import exact_attention
+
+    return exact_attention(q, key_rows, scale, sinks)
+
+
+def _project_attention_output(attn, out: mx.array, offset) -> mx.array:
+    out = attn.rope(out, offset, inverse=True)
+    B, _, L, _ = out.shape
+    prepared = out.reshape(B, attn.o_groups, -1, L, attn.head_dim)
+    prepared = prepared.transpose(0, 1, 3, 2, 4).flatten(-2)
+    if _dspark_verify_active(B, L):
+        from .deepseek_v4_verify_qmv import (
+            exact_verify_multi_qmv,
+            multi_eligible,
+        )
+
+        if multi_eligible(attn.wo_a, prepared[0]):
+            projected = exact_verify_multi_qmv(attn.wo_a, prepared[0])[None]
+        else:
+            projected = attn.wo_a(prepared)
+    else:
+        projected = attn.wo_a(prepared)
+    return attn.wo_b(projected.transpose(0, 2, 1, 3).flatten(-2))
 
 
 class LocalAttention(nn.Module):
@@ -739,26 +936,26 @@ class LocalAttention(nn.Module):
 
         kv = self.kv_norm(self.wkv(x)).reshape(B, 1, L, self.head_dim)
         kv = self.rope(kv, offset)
-        if cache is not None:
+        verify_rows = _dspark_verify_active(B, L)
+        if verify_rows:
+            key_rows = _consume_rotating_verify_rows(cache, kv)
+            out = _decode_consistent_attention(
+                q, key_rows, self.scale, self.attn_sink.astype(q.dtype)
+            )
+        elif cache is not None:
             kv, _ = cache.update_and_fetch(kv, mx.zeros((B, 1, L, 0)))
-        mask = _align_local_mask(mask, kv.shape[2])
-
-        out = scaled_dot_product_attention(
-            q,
-            kv,
-            kv,
-            cache=cache,
-            scale=self.scale,
-            mask=mask,
-            sinks=self.attn_sink.astype(q.dtype),
-        )
-        out = self.rope(out, offset, inverse=True)
-
-        out = out.reshape(B, self.o_groups, -1, L, self.head_dim)
-        out = out.transpose(0, 1, 3, 2, 4).flatten(-2)
-        out = self.wo_a(out)
-        out = out.transpose(0, 2, 1, 3).flatten(-2)
-        out = self.wo_b(out)
+        if not verify_rows:
+            mask = _align_local_mask(mask, kv.shape[2])
+            out = scaled_dot_product_attention(
+                q,
+                kv,
+                kv,
+                cache=cache,
+                scale=self.scale,
+                mask=mask,
+                sinks=self.attn_sink.astype(q.dtype),
+            )
+        out = _project_attention_output(self, out, offset)
 
         if self.sharding_group is not None:
             out = mx.distributed.all_sum(out, group=self.sharding_group)
@@ -831,39 +1028,50 @@ class CompressedAttention(nn.Module):
 
         kv = self.kv_norm(self.wkv(x)).reshape(B, 1, L, self.head_dim)
         kv = self.rope(kv, offset)
-        if local_cache is not None:
-            kv, _ = local_cache.update_and_fetch(kv, mx.zeros((B, 1, L, 0)))
-        mask = _align_local_mask(mask, kv.shape[2])
-
-        # Pool tokens into compressed KV and concatenate with local KV
-        pooled = self.compressor(x, pool_cache, offset)
-        pooled_mask = None
-        if pooled.shape[1] > 0:
-            pooled_mask = (
-                pool_cache.make_mask(L, offset)
-                if pool_cache is not None
-                else _pooled_mask(L, pooled.shape[1], self.compress_ratio, offset)
+        verify_rows = _dspark_verify_active(B, L)
+        if verify_rows:
+            compressed_kv, compressed_gate = self.compressor.project(x)
+            pooled_rows = _consume_pooling_verify_rows(
+                self.compressor,
+                compressed_kv,
+                compressed_gate,
+                pool_cache,
+                offset,
             )
-            kv = mx.concatenate([kv, pooled[:, None]], axis=2)
-
-        mask = _extend_mask(mask, pooled_mask, kv.shape[2])
-
-        out = scaled_dot_product_attention(
-            q,
-            kv,
-            kv,
-            cache=local_cache,
-            scale=self.scale,
-            mask=mask,
-            sinks=self.attn_sink.astype(q.dtype),
-        )
-        out = self.rope(out, offset, inverse=True)
-
-        out = out.reshape(B, self.o_groups, -1, L, self.head_dim)
-        out = out.transpose(0, 1, 3, 2, 4).flatten(-2)
-        out = self.wo_a(out)
-        out = out.transpose(0, 2, 1, 3).flatten(-2)
-        out = self.wo_b(out)
+            local_rows = _consume_rotating_verify_rows(local_cache, kv)
+            key_rows = [
+                mx.concatenate([local, pooled[:, None]], axis=2)
+                if pooled.shape[1]
+                else local
+                for local, pooled in zip(local_rows, pooled_rows)
+            ]
+            out = _decode_consistent_attention(
+                q, key_rows, self.scale, self.attn_sink.astype(q.dtype)
+            )
+        elif local_cache is not None:
+            kv, _ = local_cache.update_and_fetch(kv, mx.zeros((B, 1, L, 0)))
+        if not verify_rows:
+            mask = _align_local_mask(mask, kv.shape[2])
+            pooled = self.compressor(x, pool_cache, offset)
+            pooled_mask = None
+            if pooled.shape[1] > 0:
+                pooled_mask = (
+                    pool_cache.make_mask(L, offset)
+                    if pool_cache is not None
+                    else _pooled_mask(L, pooled.shape[1], self.compress_ratio, offset)
+                )
+                kv = mx.concatenate([kv, pooled[:, None]], axis=2)
+            mask = _extend_mask(mask, pooled_mask, kv.shape[2])
+            out = scaled_dot_product_attention(
+                q,
+                kv,
+                kv,
+                cache=local_cache,
+                scale=self.scale,
+                mask=mask,
+                sinks=self.attn_sink.astype(q.dtype),
+            )
+        out = _project_attention_output(self, out, offset)
 
         if self.sharding_group is not None:
             out = mx.distributed.all_sum(out, group=self.sharding_group)
@@ -937,76 +1145,157 @@ class SparseCompressedAttention(nn.Module):
 
         kv = self.kv_norm(self.wkv(x)).reshape(B, 1, L, self.head_dim)
         kv = self.rope(kv, offset)
-        if local_cache is not None:
+        verify_rows = _dspark_verify_active(B, L)
+        if verify_rows:
+            comp_kv, comp_gate = self.compressor.project(x)
+            idx_kv, idx_gate = self.indexer.compressor.project(x)
+            pooled_rows = _consume_pooling_verify_rows(
+                self.compressor, comp_kv, comp_gate, comp_cache, offset
+            )
+            index_rows = _consume_pooling_verify_rows(
+                self.indexer.compressor, idx_kv, idx_gate, idx_cache, offset
+            )
+            ring_view = _stage_rotating_verify_view(local_cache, kv)
+            local_rows = (
+                None
+                if ring_view is not None
+                else _consume_rotating_verify_rows(local_cache, kv)
+            )
+            index_q = self.indexer.wq_b(q_residual).reshape(
+                B, L, self.indexer.n_heads, self.indexer.head_dim
+            )
+            index_q = self.rope(index_q.transpose(0, 2, 1, 3), offset)
+            index_weights = self.indexer.weights_proj(x).astype(mx.float32)
+            outputs = [None] * L
+            sparse_rows = []
+            sinks = self.attn_sink.astype(q.dtype)
+            for idx, (local, pooled, index_pooled) in enumerate(
+                zip(local_rows or [None] * L, pooled_rows, index_rows)
+            ):
+                q_row = q[:, :, idx : idx + 1]
+                if pooled.shape[1] == 0:
+                    if local is None:
+                        local = _materialize_rotating_verify_rows(ring_view)[idx]
+                    row_out = _decode_consistent_attention(
+                        q_row, [local], self.scale, sinks
+                    )
+                elif pooled.shape[1] <= self.indexer.index_topk:
+                    if local is None:
+                        local = _materialize_rotating_verify_rows(ring_view)[idx]
+                    full = mx.concatenate([local, pooled[:, None]], axis=2)
+                    row_out = _decode_consistent_attention(
+                        q_row, [full], self.scale, sinks
+                    )
+                else:
+                    iq = index_q[:, :, idx : idx + 1].astype(mx.float32)
+                    scores = iq @ index_pooled[:, None].swapaxes(-1, -2).astype(
+                        mx.float32
+                    )
+                    scores = mx.maximum(scores, 0) * self.indexer.scale
+                    weights = index_weights[:, idx : idx + 1]
+                    weights = weights * (self.indexer.n_heads**-0.5)
+                    scores = (scores * weights.swapaxes(-1, -2)[..., None]).sum(
+                        axis=1
+                    )
+                    k = min(self.indexer.index_topk, index_pooled.shape[1])
+                    topk = mx.argpartition(-scores, kth=k - 1, axis=-1)[..., :k]
+                    if ring_view is not None:
+                        sparse_rows.append((idx, q_row, pooled, topk))
+                        continue
+                    else:
+                        row_out = _sparse_pooled_attention(
+                            q_row,
+                            local,
+                            pooled,
+                            topk,
+                            None,
+                            None,
+                            self.scale,
+                            sinks,
+                        )
+                outputs[idx] = row_out
+
+            # Pooling can cross at most one compression boundary in a DSpark
+            # verify block. Batch rows with the same pooled length so the native
+            # ring kernel sees all candidate tokens in one launch instead of L
+            # independent single-row launches.
+            while sparse_rows:
+                pooled_length = int(sparse_rows[0][2].shape[1])
+                group = [row for row in sparse_rows if int(row[2].shape[1]) == pooled_length]
+                sparse_rows = [
+                    row for row in sparse_rows if int(row[2].shape[1]) != pooled_length
+                ]
+                indices = [row[0] for row in group]
+                q_batch = mx.concatenate(
+                    [row[1].transpose(0, 2, 1, 3) for row in group], axis=0
+                ).transpose(0, 2, 1, 3)
+                pooled_batch = mx.concatenate([row[2] for row in group], axis=0)
+                topk_batch = mx.concatenate([row[3] for row in group], axis=0)
+                group_view = _RotatingVerifyView(
+                    source=ring_view.source,
+                    indices=mx.take(ring_view.indices, mx.array(indices), axis=0),
+                )
+                group_out = _ring_sparse_attention(
+                    q_batch,
+                    group_view,
+                    pooled_batch,
+                    topk_batch,
+                    self.scale,
+                    sinks,
+                )
+                for group_idx, output_idx in enumerate(indices):
+                    outputs[output_idx] = group_out[group_idx : group_idx + 1]
+            out = mx.concatenate(outputs, axis=2)
+        elif local_cache is not None:
             kv, _ = local_cache.update_and_fetch(kv, mx.zeros((B, 1, L, 0)))
-        mask = _align_local_mask(mask, kv.shape[2])
-
-        pooled = self.compressor(x, comp_cache, offset)
-        pmask = (
-            comp_cache.make_mask(L, offset)
-            if comp_cache is not None
-            else (
-                _pooled_mask(L, pooled.shape[1], self.compress_ratio, offset)
-                if pooled.shape[1] > 0
-                else None
+        if not verify_rows:
+            mask = _align_local_mask(mask, kv.shape[2])
+            pooled = self.compressor(x, comp_cache, offset)
+            pmask = (
+                comp_cache.make_mask(L, offset)
+                if comp_cache is not None
+                else (
+                    _pooled_mask(L, pooled.shape[1], self.compress_ratio, offset)
+                    if pooled.shape[1] > 0
+                    else None
+                )
             )
-        )
-        topk = self.indexer(x, q_residual, self.rope, idx_cache, offset)
-        sinks = self.attn_sink.astype(q.dtype)
-
-        # Local attention
-        if pooled.shape[1] == 0:
-            out = scaled_dot_product_attention(
-                q,
-                kv,
-                kv,
-                cache=local_cache,
-                scale=self.scale,
-                mask=mask,
-                sinks=sinks,
-            )
-
-        # Compressed attention
-        elif pooled.shape[1] <= self.indexer.index_topk:
-            full_kv = mx.concatenate([kv, pooled[:, None]], axis=2)
-            mask = _extend_mask(mask, pmask, full_kv.shape[2])
-            out = scaled_dot_product_attention(
-                q,
-                full_kv,
-                full_kv,
-                cache=local_cache,
-                scale=self.scale,
-                mask=mask,
-                sinks=sinks,
-            )
-
-        # Sparse compressed attention
-        else:
-            sparse_mask = None
-            if pmask is not None:
-                sparse_mask = mx.take_along_axis(
-                    pmask[None] if pmask.ndim == 2 else pmask,
+            topk = self.indexer(x, q_residual, self.rope, idx_cache, offset)
+            sinks = self.attn_sink.astype(q.dtype)
+            if pooled.shape[1] == 0:
+                out = scaled_dot_product_attention(
+                    q, kv, kv, cache=local_cache, scale=self.scale, mask=mask, sinks=sinks
+                )
+            elif pooled.shape[1] <= self.indexer.index_topk:
+                full_kv = mx.concatenate([kv, pooled[:, None]], axis=2)
+                mask = _extend_mask(mask, pmask, full_kv.shape[2])
+                out = scaled_dot_product_attention(
+                    q,
+                    full_kv,
+                    full_kv,
+                    cache=local_cache,
+                    scale=self.scale,
+                    mask=mask,
+                    sinks=sinks,
+                )
+            else:
+                sparse_mask = None
+                if pmask is not None:
+                    sparse_mask = mx.take_along_axis(
+                        pmask[None] if pmask.ndim == 2 else pmask, topk, axis=2
+                    )[:, None]
+                out = _sparse_pooled_attention(
+                    q,
+                    kv,
+                    pooled,
                     topk,
-                    axis=2,
-                )[:, None]
-            out = _sparse_pooled_attention(
-                q,
-                kv,
-                pooled,
-                topk,
-                mask,
-                sparse_mask,
-                self.scale,
-                sinks,
-            )
+                    mask,
+                    sparse_mask,
+                    self.scale,
+                    sinks,
+                )
 
-        out = self.rope(out, offset, inverse=True)
-
-        out = out.reshape(B, self.o_groups, -1, L, self.head_dim)
-        out = out.transpose(0, 1, 3, 2, 4).flatten(-2)
-        out = self.wo_a(out)
-        out = out.transpose(0, 2, 1, 3).flatten(-2)
-        out = self.wo_b(out)
+        out = _project_attention_output(self, out, offset)
 
         if self.sharding_group is not None:
             out = mx.distributed.all_sum(out, group=self.sharding_group)
@@ -1251,6 +1540,63 @@ class Model(nn.Module):
         self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
         self.mtp = [DSparkBlock(config, idx) for idx in range(config.dspark_num_layers)]
         self._last_dspark_hidden: mx.array | None = None
+        self._dspark_prime_ctx = None
+
+    @staticmethod
+    def _target_cache_offset(cache) -> int | None:
+        if not cache:
+            return None
+        for entry in cache:
+            candidates = (entry, *(getattr(entry, "caches", ()) or ()))
+            for candidate in candidates:
+                offset = getattr(candidate, "offset", None)
+                if type(offset) is int:
+                    return offset
+                if offset is not None and getattr(offset, "size", 0) == 1:
+                    return int(offset.reshape(()).item())
+        return None
+
+    def _capture_dspark_prompt(self, inputs, hidden, target_cache) -> None:
+        """Fold B=1 prefill chunks into a committed DSpark context cache."""
+        if inputs.ndim != 2 or inputs.shape[0] != 1 or inputs.shape[1] <= 1:
+            return
+        offset_after = self._target_cache_offset(target_cache)
+        if offset_after is None:
+            return
+        start = offset_after - int(inputs.shape[1])
+        ctx = self._dspark_prime_ctx
+        if ctx is None:
+            # A target prefix-cache hit only evaluates the uncached suffix, so
+            # the corresponding target-layer hidden history is unavailable.
+            # Never manufacture an empty rotating cache at a large logical
+            # offset: RotatingKVCache quite correctly rejects that inconsistent
+            # physical/logical state (and Codex then loses DSpark for the
+            # request). Start a fresh DSpark history from subsequently decoded
+            # tokens instead.
+            if start != 0:
+                return
+            caches = self.make_dspark_cache()
+            ctx = (caches, start)
+        elif ctx[1] != start:
+            self._dspark_prime_ctx = None
+            return
+        caches = ctx[0]
+        first = self.mtp[0]
+        main_x = first.main_norm(first.main_proj(hidden))
+        for block, layer_cache in zip(self.mtp, caches):
+            block.attn.update_main(main_x, layer_cache)
+        self._dspark_prime_ctx = (caches, offset_after)
+        mx.async_eval([cache.keys for cache in caches if cache.keys is not None])
+
+    def take_dspark_primed(self, target_cache):
+        ctx = self._dspark_prime_ctx
+        self._dspark_prime_ctx = None
+        if ctx is None:
+            return None
+        offset = self._target_cache_offset(target_cache)
+        if offset is None or ctx[1] != offset - 1:
+            return None
+        return ctx[0]
 
     def __call__(
         self,
@@ -1264,6 +1610,10 @@ class Model(nn.Module):
         if capture_dspark:
             hidden, dspark_hidden = output
             self._last_dspark_hidden = dspark_hidden
+            from .deepseek_v4_rollback import is_armed
+
+            if cache is not None and not is_armed():
+                self._capture_dspark_prompt(inputs, dspark_hidden, cache)
             logits = self.lm_head(hidden)
             if return_dspark_hidden:
                 return logits, dspark_hidden
@@ -1281,6 +1631,7 @@ class Model(nn.Module):
         main_hidden: mx.array,
         cache: list[RotatingKVCache],
         max_draft_tokens: int | None = None,
+        draft_sampler=None,
     ) -> tuple[mx.array, mx.array, mx.array] | None:
         if not self.mtp:
             return None
@@ -1323,7 +1674,12 @@ class Model(nn.Module):
         for idx in range(K):
             bias, _ = last.markov_head(output_ids[:, idx])
             draft_logits[:, idx] = draft_logits[:, idx] + bias
-            output_ids[:, idx + 1] = mx.argmax(draft_logits[:, idx], axis=-1)
+            row = draft_logits[:, idx]
+            output_ids[:, idx + 1] = (
+                draft_sampler(row, idx)
+                if draft_sampler is not None
+                else mx.argmax(row, axis=-1)
+            )
         return output_ids, draft_logits
 
     @property

--- a/vllm_mlx/models/deepseek_v4.py
+++ b/vllm_mlx/models/deepseek_v4.py
@@ -1540,7 +1540,7 @@ class Model(nn.Module):
         self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
         self.mtp = [DSparkBlock(config, idx) for idx in range(config.dspark_num_layers)]
         self._last_dspark_hidden: mx.array | None = None
-        self._dspark_prime_ctx = None
+        self._dspark_prime_ctx: dict[int, tuple[list, int]] = {}
 
     @staticmethod
     def _target_cache_offset(cache) -> int | None:
@@ -1564,7 +1564,9 @@ class Model(nn.Module):
         if offset_after is None:
             return
         start = offset_after - int(inputs.shape[1])
-        ctx = self._dspark_prime_ctx
+        cache_key = id(target_cache)
+        contexts = getattr(self, "_dspark_prime_ctx", None)
+        ctx = contexts.get(cache_key) if isinstance(contexts, dict) else None
         if ctx is None:
             # A target prefix-cache hit only evaluates the uncached suffix, so
             # the corresponding target-layer hidden history is unavailable.
@@ -1578,19 +1580,29 @@ class Model(nn.Module):
             caches = self.make_dspark_cache()
             ctx = (caches, start)
         elif ctx[1] != start:
-            self._dspark_prime_ctx = None
+            if isinstance(contexts, dict):
+                contexts.pop(cache_key, None)
             return
         caches = ctx[0]
         first = self.mtp[0]
         main_x = first.main_norm(first.main_proj(hidden))
         for block, layer_cache in zip(self.mtp, caches):
             block.attn.update_main(main_x, layer_cache)
-        self._dspark_prime_ctx = (caches, offset_after)
+        if not isinstance(contexts, dict):
+            contexts = {}
+            self._dspark_prime_ctx = contexts
+        contexts[cache_key] = (caches, offset_after)
+        while len(contexts) > 32:
+            contexts.pop(next(iter(contexts)))
         mx.async_eval([cache.keys for cache in caches if cache.keys is not None])
 
     def take_dspark_primed(self, target_cache):
-        ctx = self._dspark_prime_ctx
-        self._dspark_prime_ctx = None
+        contexts = getattr(self, "_dspark_prime_ctx", None)
+        ctx = (
+            contexts.pop(id(target_cache), None)
+            if isinstance(contexts, dict)
+            else None
+        )
         if ctx is None:
             return None
         offset = self._target_cache_offset(target_cache)

--- a/vllm_mlx/models/deepseek_v4.py
+++ b/vllm_mlx/models/deepseek_v4.py
@@ -750,7 +750,11 @@ def _stage_rotating_verify_view(cache, kv: mx.array) -> Optional[_RotatingVerify
     if hasattr(cache, "_offset"):
         fields += ("left_padding", "_offset", "rotated")
     snapshot = {
-        name: (getattr(cache, name) + 0 if isinstance(getattr(cache, name), mx.array) else getattr(cache, name))
+        name: (
+            getattr(cache, name) + 0
+            if isinstance(getattr(cache, name), mx.array)
+            else getattr(cache, name)
+        )
         for name in fields
     }
     empty = mx.zeros((*kv.shape[:-1], 0), dtype=kv.dtype)
@@ -1194,9 +1198,7 @@ class SparseCompressedAttention(nn.Module):
                     scores = mx.maximum(scores, 0) * self.indexer.scale
                     weights = index_weights[:, idx : idx + 1]
                     weights = weights * (self.indexer.n_heads**-0.5)
-                    scores = (scores * weights.swapaxes(-1, -2)[..., None]).sum(
-                        axis=1
-                    )
+                    scores = (scores * weights.swapaxes(-1, -2)[..., None]).sum(axis=1)
                     k = min(self.indexer.index_topk, index_pooled.shape[1])
                     topk = mx.argpartition(-scores, kth=k - 1, axis=-1)[..., :k]
                     if ring_view is not None:
@@ -1221,7 +1223,9 @@ class SparseCompressedAttention(nn.Module):
             # independent single-row launches.
             while sparse_rows:
                 pooled_length = int(sparse_rows[0][2].shape[1])
-                group = [row for row in sparse_rows if int(row[2].shape[1]) == pooled_length]
+                group = [
+                    row for row in sparse_rows if int(row[2].shape[1]) == pooled_length
+                ]
                 sparse_rows = [
                     row for row in sparse_rows if int(row[2].shape[1]) != pooled_length
                 ]
@@ -1264,7 +1268,13 @@ class SparseCompressedAttention(nn.Module):
             sinks = self.attn_sink.astype(q.dtype)
             if pooled.shape[1] == 0:
                 out = scaled_dot_product_attention(
-                    q, kv, kv, cache=local_cache, scale=self.scale, mask=mask, sinks=sinks
+                    q,
+                    kv,
+                    kv,
+                    cache=local_cache,
+                    scale=self.scale,
+                    mask=mask,
+                    sinks=sinks,
                 )
             elif pooled.shape[1] <= self.indexer.index_topk:
                 full_kv = mx.concatenate([kv, pooled[:, None]], axis=2)
@@ -1540,7 +1550,7 @@ class Model(nn.Module):
         self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
         self.mtp = [DSparkBlock(config, idx) for idx in range(config.dspark_num_layers)]
         self._last_dspark_hidden: mx.array | None = None
-        self._dspark_prime_ctx: dict[int, tuple[list, int]] = {}
+        self._dspark_prime_ctx: dict[int, tuple[object, list, int]] = {}
 
     @staticmethod
     def _target_cache_offset(cache) -> int | None:
@@ -1578,12 +1588,12 @@ class Model(nn.Module):
             if start != 0:
                 return
             caches = self.make_dspark_cache()
-            ctx = (caches, start)
-        elif ctx[1] != start:
+            ctx = (target_cache, caches, start)
+        elif ctx[0] is not target_cache or ctx[2] != start:
             if isinstance(contexts, dict):
                 contexts.pop(cache_key, None)
             return
-        caches = ctx[0]
+        caches = ctx[1]
         first = self.mtp[0]
         main_x = first.main_norm(first.main_proj(hidden))
         for block, layer_cache in zip(self.mtp, caches):
@@ -1591,7 +1601,10 @@ class Model(nn.Module):
         if not isinstance(contexts, dict):
             contexts = {}
             self._dspark_prime_ctx = contexts
-        contexts[cache_key] = (caches, offset_after)
+        # Retain and verify the cache object itself.  A bounded strong
+        # reference prevents Python from reusing its id for a later request
+        # while stale priming state is still present.
+        contexts[cache_key] = (target_cache, caches, offset_after)
         while len(contexts) > 32:
             contexts.pop(next(iter(contexts)))
         mx.async_eval([cache.keys for cache in caches if cache.keys is not None])
@@ -1599,16 +1612,14 @@ class Model(nn.Module):
     def take_dspark_primed(self, target_cache):
         contexts = getattr(self, "_dspark_prime_ctx", None)
         ctx = (
-            contexts.pop(id(target_cache), None)
-            if isinstance(contexts, dict)
-            else None
+            contexts.pop(id(target_cache), None) if isinstance(contexts, dict) else None
         )
         if ctx is None:
             return None
         offset = self._target_cache_offset(target_cache)
-        if offset is None or ctx[1] != offset - 1:
+        if offset is None or ctx[0] is not target_cache or ctx[2] != offset - 1:
             return None
-        return ctx[0]
+        return ctx[1]
 
     def __call__(
         self,

--- a/vllm_mlx/models/deepseek_v4_cache.py
+++ b/vllm_mlx/models/deepseek_v4_cache.py
@@ -36,6 +36,7 @@ class PoolingCache(_BaseCache):
         # self.pooled is a logical-size view; mutation sites keep them in sync.
         self._buf = None
         self.pooled = None
+        self._undo = None
 
     @property
     def offset(self):
@@ -48,6 +49,31 @@ class PoolingCache(_BaseCache):
         if self.buf_kv is None:
             self.buf_kv = mx.zeros((B, self.ratio, D1), dtype=kv.dtype)
             self.buf_gate = mx.zeros((B, self.ratio, D2), dtype=gate.dtype)
+
+        from .deepseek_v4_rollback import is_armed
+
+        if is_armed() and L <= 8:
+            if L == 1 and self._undo is not None:
+                undo = self._undo
+                self._undo = (
+                    *undo[:4],
+                    mx.concatenate([undo[4], kv], axis=1),
+                    mx.concatenate([undo[5], gate], axis=1),
+                    *undo[6:],
+                )
+            else:
+                self._undo = (
+                    None if self.remainder == 0 else self.buf_kv[:, : self.remainder] + 0,
+                    None if self.remainder == 0 else self.buf_gate[:, : self.remainder] + 0,
+                    self.remainder,
+                    0 if self.pooled is None else self.pooled.shape[1],
+                    kv,
+                    gate,
+                    getattr(self, "overlap_kv", None),
+                    getattr(self, "overlap_gate", None),
+                )
+        else:
+            self._undo = None
 
         # Prompt mode
         if L > 1:
@@ -150,6 +176,11 @@ class PoolingCache(_BaseCache):
     @state.setter
     def state(self, v):
         buf_kv, buf_gate, pooled = v
+        # Rollback history is generation-ephemeral and is intentionally not
+        # serialized. Older persisted prefix entries may also have been
+        # created before the field existed, so every restore must initialize
+        # it explicitly before is_trimmable() can inspect the cache.
+        self._undo = None
         self.remainder = 0
         self.buf_kv = self.buf_gate = None
         if buf_kv is not None:
@@ -173,11 +204,56 @@ class PoolingCache(_BaseCache):
         return obj
 
     def is_trimmable(self):
-        return self.pooled is None
+        return self.pooled is None or self.remainder > 0 or self._can_undo(1)
+
+    def _can_undo(self, n):
+        undo = getattr(self, "_undo", None)
+        return undo is not None and undo[4].shape[1] >= n
 
     def trim(self, n):
-        n = min(self.remainder, n)
-        self.remainder -= n
+        if n <= self.remainder:
+            self.remainder -= n
+            self._undo = None
+            return n
+        if not self._can_undo(n):
+            return 0
+        (
+            buf_kv,
+            buf_gate,
+            old_remainder,
+            old_pool_len,
+            kv,
+            gate,
+            old_overlap_kv,
+            old_overlap_gate,
+        ) = self._undo
+        self._undo = None
+        keep = kv.shape[1] - n
+        prefix_kv = kv[:, :keep]
+        prefix_gate = gate[:, :keep]
+        if buf_kv is not None:
+            prefix_kv = mx.concatenate([buf_kv, prefix_kv], axis=1)
+            prefix_gate = mx.concatenate([buf_gate, prefix_gate], axis=1)
+        completed = prefix_kv.shape[1] // self.ratio
+        pool_len = old_pool_len + completed
+        self.pooled = None if pool_len == 0 else self._buf[:, :pool_len]
+        used = completed * self.ratio
+        remainder_kv = prefix_kv[:, used:]
+        remainder_gate = prefix_gate[:, used:]
+        self.remainder = remainder_kv.shape[1]
+        if self.remainder:
+            self.buf_kv[:, : self.remainder] = remainder_kv
+            self.buf_gate[:, : self.remainder] = remainder_gate
+        if hasattr(self, "overlap_kv"):
+            if completed:
+                last_kv = mx.unflatten(prefix_kv[:, used - self.ratio : used], 1, (-1, self.ratio))[:, -1]
+                last_gate = mx.unflatten(prefix_gate[:, used - self.ratio : used], 1, (-1, self.ratio))[:, -1]
+                half = last_kv.shape[-1] // 2
+                self.overlap_kv = last_kv[..., :half]
+                self.overlap_gate = last_gate[..., :half]
+            else:
+                self.overlap_kv = old_overlap_kv
+                self.overlap_gate = old_overlap_gate
         return n
 
     def size(self):
@@ -225,6 +301,7 @@ class BatchPoolingCache(_BaseCache):
 
         self._lengths = [2**31] * batch_size
         self._processed = [0] * batch_size
+        self._undo = None
 
     @property
     def offset(self):
@@ -250,6 +327,32 @@ class BatchPoolingCache(_BaseCache):
         if self.buf_kv is None:
             self.buf_kv = mx.zeros((B, ratio, D1), dtype=kv.dtype)
             self.buf_gate = mx.zeros((B, ratio, D2), dtype=gate.dtype)
+
+        from .deepseek_v4_rollback import is_armed
+
+        if is_armed() and B == 1 and L <= 8:
+            if L == 1 and self._undo is not None:
+                undo = self._undo
+                self._undo = (
+                    *undo[:5],
+                    mx.concatenate([undo[5], kv], axis=1),
+                    mx.concatenate([undo[6], gate], axis=1),
+                    *undo[7:],
+                )
+            else:
+                self._undo = (
+                    self.buf_kv + 0,
+                    self.buf_gate + 0,
+                    list(self.remainder),
+                    list(self._pool_lengths),
+                    list(self._processed),
+                    kv,
+                    gate,
+                    getattr(self, "overlap_kv", None),
+                    getattr(self, "overlap_gate", None),
+                )
+        else:
+            self._undo = None
 
         valid_lengths = [min(l - p, L) for l, p in zip(self._lengths, self._processed)]
         if max(valid_lengths) != L:
@@ -407,6 +510,7 @@ class BatchPoolingCache(_BaseCache):
     def state(self, v):
         self.buf_kv, self.buf_gate, self.pooled = v
         self._buf = self.pooled
+        self._undo = None
 
     @property
     def meta_state(self):
@@ -421,13 +525,66 @@ class BatchPoolingCache(_BaseCache):
         self._lengths = [2**31] * len(self._pool_lengths)
 
     def is_trimmable(self):
-        return self.pooled is None
+        return self.pooled is None or min(self.remainder) > 0 or self._can_undo(1)
+
+    def _can_undo(self, n):
+        undo = getattr(self, "_undo", None)
+        return (
+            undo is not None
+            and len(self.remainder) == 1
+            and undo[5].shape[1] >= n
+        )
 
     def trim(self, n):
-        n = min(min(self.remainder), n)
-        for i in range(len(self.remainder)):
-            self.remainder[i] -= n
-            self._processed[i] -= n
+        if n <= min(self.remainder):
+            for i in range(len(self.remainder)):
+                self.remainder[i] -= n
+                self._processed[i] -= n
+            self._undo = None
+            return n
+        if not self._can_undo(n):
+            return 0
+        (
+            buf_kv,
+            buf_gate,
+            old_remainder,
+            old_pool_lengths,
+            old_processed,
+            kv,
+            gate,
+            old_overlap_kv,
+            old_overlap_gate,
+        ) = self._undo
+        self._undo = None
+        keep = kv.shape[1] - n
+        prefix_kv = mx.concatenate([buf_kv[:, : old_remainder[0]], kv[:, :keep]], axis=1)
+        prefix_gate = mx.concatenate(
+            [buf_gate[:, : old_remainder[0]], gate[:, :keep]], axis=1
+        )
+        completed = prefix_kv.shape[1] // self.ratio
+        pool_len = old_pool_lengths[0] + completed
+        self._pool_lengths = [pool_len]
+        self._processed = [old_processed[0] + keep]
+        self.pooled = None if pool_len == 0 else self._buf[:, :pool_len]
+        used = completed * self.ratio
+        remainder_kv = prefix_kv[:, used:]
+        remainder_gate = prefix_gate[:, used:]
+        self.remainder = [remainder_kv.shape[1]]
+        self.buf_kv = buf_kv
+        self.buf_gate = buf_gate
+        if self.remainder[0]:
+            self.buf_kv[:, : self.remainder[0]] = remainder_kv
+            self.buf_gate[:, : self.remainder[0]] = remainder_gate
+        if hasattr(self, "overlap_kv"):
+            if completed:
+                last_kv = mx.unflatten(prefix_kv[:, used - self.ratio : used], 1, (-1, self.ratio))[:, -1]
+                last_gate = mx.unflatten(prefix_gate[:, used - self.ratio : used], 1, (-1, self.ratio))[:, -1]
+                half = last_kv.shape[-1] // 2
+                self.overlap_kv = last_kv[..., :half]
+                self.overlap_gate = last_gate[..., :half]
+            else:
+                self.overlap_kv = old_overlap_kv
+                self.overlap_gate = old_overlap_gate
         return n
 
     def size(self):

--- a/vllm_mlx/models/deepseek_v4_rollback.py
+++ b/vllm_mlx/models/deepseek_v4_rollback.py
@@ -8,6 +8,7 @@ pooling caches implement the analogous record in ``deepseek_v4_cache``.
 
 from __future__ import annotations
 
+import copy
 import threading
 from contextlib import contextmanager
 
@@ -58,6 +59,8 @@ def install_rotating_undo() -> None:
                         value = getattr(self, name)
                         if isinstance(value, mx.array):
                             value = value + 0
+                        elif isinstance(value, (dict, list, set, tuple)):
+                            value = copy.deepcopy(value)
                         snapshot[name] = value
                     self._rapid_undo = (snapshot, keys, values)
             else:

--- a/vllm_mlx/models/deepseek_v4_rollback.py
+++ b/vllm_mlx/models/deepseek_v4_rollback.py
@@ -1,0 +1,117 @@
+"""Exact short-window rollback for DeepSeek V4 speculative verification.
+
+The target cache is advanced by ``[confirmed, draft...]`` in one verify
+forward.  A rejected suffix must be removed without replaying the 304B
+backbone.  Rotating caches need an undo record after rotation has started;
+pooling caches implement the analogous record in ``deepseek_v4_cache``.
+"""
+
+from __future__ import annotations
+
+import threading
+from contextlib import contextmanager
+
+import mlx.core as mx
+
+_STATE = threading.local()
+
+
+def is_armed() -> bool:
+    return bool(getattr(_STATE, "armed", False))
+
+
+@contextmanager
+def armed():
+    previous = is_armed()
+    _STATE.armed = True
+    try:
+        yield
+    finally:
+        _STATE.armed = previous
+
+
+def install_rotating_undo() -> None:
+    """Attach a one-update undo log to mlx-lm's rotating cache once."""
+    from mlx_lm.models.cache import BatchRotatingKVCache, RotatingKVCache
+
+    def patch(cls, fields):
+        if getattr(cls, "_rapid_dspark_undo", False):
+            return
+        original_update = cls.update_and_fetch
+        original_is_trimmable = cls.is_trimmable
+        original_trim = cls.trim
+
+        def update_and_fetch(self, keys, values):
+            steps = int(keys.shape[2])
+            if is_armed() and 1 <= steps <= 8:
+                existing = self._rapid_undo
+                if steps == 1 and existing is not None:
+                    snapshot, old_keys, old_values = existing
+                    self._rapid_undo = (
+                        snapshot,
+                        mx.concatenate([old_keys, keys], axis=2),
+                        mx.concatenate([old_values, values], axis=2),
+                    )
+                else:
+                    snapshot = {}
+                    for name in fields:
+                        value = getattr(self, name)
+                        if isinstance(value, mx.array):
+                            value = value + 0
+                        snapshot[name] = value
+                    self._rapid_undo = (snapshot, keys, values)
+            else:
+                self._rapid_undo = None
+            return original_update(self, keys, values)
+
+        def is_trimmable(self):
+            return original_is_trimmable(self) or self._rapid_undo is not None
+
+        def trim(self, n):
+            if original_is_trimmable(self):
+                self._rapid_undo = None
+                return original_trim(self, n)
+            undo = self._rapid_undo
+            self._rapid_undo = None
+            if undo is None:
+                return 0
+            snapshot, keys, values = undo
+            keep = int(keys.shape[2]) - int(n)
+            if keep < 0:
+                return 0
+            for name, value in snapshot.items():
+                setattr(self, name, value)
+            if keep:
+                original_update(self, keys[..., :keep, :], values[..., :keep, :])
+            return int(n)
+
+        cls.update_and_fetch = update_and_fetch
+        cls.is_trimmable = is_trimmable
+        cls.trim = trim
+        cls._rapid_undo = None
+        cls._rapid_dspark_undo = True
+
+    patch(RotatingKVCache, ("keys", "values", "offset", "_idx"))
+    patch(
+        BatchRotatingKVCache,
+        ("keys", "values", "offset", "left_padding", "_idx", "_offset", "rotated"),
+    )
+
+
+def can_trim(cache, n: int) -> bool:
+    children = getattr(cache, "caches", None)
+    if children is not None:
+        return all(can_trim(child, n) for child in children)
+    can_undo = getattr(cache, "_can_undo", None)
+    if callable(can_undo) and can_undo(n):
+        return True
+    check = getattr(cache, "is_trimmable", None)
+    return bool(callable(check) and check())
+
+
+def trim_all(caches, n: int) -> bool:
+    if n <= 0:
+        return True
+    if not all(can_trim(cache, n) for cache in caches):
+        return False
+    return all(cache.trim(n) == n for cache in caches)

--- a/vllm_mlx/models/deepseek_v4_switch.py
+++ b/vllm_mlx/models/deepseek_v4_switch.py
@@ -8,12 +8,23 @@ from .. import _mlx_compat as _mlx_compat
 
 _mlx_compat.install()
 
-from mlx_lm.models.switch_layers import (
-    SwiGLU,
-    SwitchLinear,
-    _gather_sort,
-    _scatter_unsort,
-)
+try:
+    # oMLX's audited Apple-Silicon extension supplies MXFP4 block-list MoE
+    # kernels.  Keep this optional: stock Rapid-MLX continues to use mlx-lm
+    # when the native bundle is not installed.
+    from omlx.patches.deepseek_v4.switch_layers import (
+        SwiGLU,
+        SwitchLinear,
+        _gather_sort,
+        _scatter_unsort,
+    )
+except (ImportError, OSError):
+    from mlx_lm.models.switch_layers import (
+        SwiGLU,
+        SwitchLinear,
+        _gather_sort,
+        _scatter_unsort,
+    )
 
 
 class FusedSwitchGLU(nn.Module):
@@ -37,7 +48,12 @@ class FusedSwitchGLU(nn.Module):
 
     def __call__(self, x, indices) -> mx.array:
         x = mx.expand_dims(x, (-2, -3))
-        do_sort = indices.size >= 64
+        # DSpark verifies at most six rows; with eight routed experts that is
+        # 48 routes.  The native block-list kernel is already profitable at
+        # this size on M3 Ultra, while mlx-lm's generic path keeps its original
+        # 64-route sorting threshold.
+        native_blocks = SwitchLinear.__module__.startswith("omlx.")
+        do_sort = indices.size >= (32 if native_blocks else 64)
         idx = indices
         inv_order = None
         if do_sort:

--- a/vllm_mlx/models/deepseek_v4_verify.py
+++ b/vllm_mlx/models/deepseek_v4_verify.py
@@ -1,0 +1,39 @@
+"""Decode-equivalent multi-row projections for DSpark target verify."""
+
+from __future__ import annotations
+
+
+def install() -> None:
+    import mlx.nn as nn
+
+    from .deepseek_v4_rollback import is_armed
+    from .deepseek_v4_verify_qmv import (
+        dense_eligible,
+        eligible,
+        exact_verify_gemv,
+        exact_verify_qmv,
+    )
+
+    linear = nn.Linear
+    if not getattr(linear, "_rapid_dspark_verify", False):
+        original = linear.__call__
+
+        def linear_call(self, x):
+            if is_armed() and dense_eligible(self, x):
+                return exact_verify_gemv(self, x)
+            return original(self, x)
+
+        linear.__call__ = linear_call
+        linear._rapid_dspark_verify = True
+
+    quantized = nn.QuantizedLinear
+    if not getattr(quantized, "_rapid_dspark_verify", False):
+        original_q = quantized.__call__
+
+        def quantized_call(self, x):
+            if is_armed() and eligible(self, x):
+                return exact_verify_qmv(self, x)
+            return original_q(self, x)
+
+        quantized.__call__ = quantized_call
+        quantized._rapid_dspark_verify = True

--- a/vllm_mlx/models/deepseek_v4_verify_attention.py
+++ b/vllm_mlx/models/deepseek_v4_verify_attention.py
@@ -1,0 +1,175 @@
+# Copyright © 2026 Apple Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Batch-invariant short-row attention for embedded DeepSeek DSpark.
+
+DeepSeek-V4 uses 64 query heads and one KV head.  MLX collapses those heads
+into GEMM's M dimension for ordinary one-token decode, but a DSpark verify
+batch with one physical KV view per row takes the batched GEMV route instead.
+The two routes are mathematically equivalent but not bitwise equivalent.
+
+These kernels keep the per-head reduction fixed for both decode and verify.
+Multiple verify rows share one dispatch while retaining independent KV views.
+"""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import Sequence
+
+import mlx.core as mx
+
+
+_ROWWISE_SOURCE = r"""
+    const uint lane = thread_index_in_simdgroup;
+    const int output_index = int(threadgroup_position_in_grid.y);
+    const int row = output_index / (M * N);
+    const int rem = output_index - row * M * N;
+    const int m = rem / N;
+    const int n = rem - m * N;
+    float accum = 0.0f;
+    for (int k = int(lane); k < K; k += 32) {
+        const int lhs_idx = (row * M + m) * K + k;
+        const int rhs_idx = TRANSPOSE_RHS
+            ? (row * N + n) * K + k
+            : (row * K + k) * N + n;
+        accum += float(lhs[lhs_idx]) * float(rhs[rhs_idx]);
+    }
+    accum = simd_sum(accum);
+    if (lane == 0) {
+        output[output_index] = T(accum);
+    }
+"""
+
+
+@lru_cache(maxsize=1)
+def _rowwise_kernel():
+    return mx.fast.metal_kernel(
+        name="rapid_dspark_rowwise_gemm",
+        input_names=["lhs", "rhs"],
+        output_names=["output"],
+        source=_ROWWISE_SOURCE,
+        ensure_row_contiguous=True,
+    )
+
+
+def _metal_rowwise_gemm(
+    lhs: mx.array, rhs: mx.array, transpose_rhs: bool
+) -> mx.array:
+    rows, m, k = map(int, lhs.shape)
+    n = int(rhs.shape[1] if transpose_rhs else rhs.shape[2])
+    (output,) = _rowwise_kernel()(
+        inputs=[lhs, rhs],
+        template=[
+            ("T", lhs.dtype),
+            ("M", m),
+            ("N", n),
+            ("K", k),
+            ("TRANSPOSE_RHS", transpose_rhs),
+        ],
+        grid=(32, rows * m * n, 1),
+        threadgroup=(32, 1, 1),
+        output_shapes=[(rows, m, n)],
+        output_dtypes=[lhs.dtype],
+    )
+    return output
+
+
+def rowwise_gemm(lhs: mx.array, rhs: mx.array, transpose_rhs: bool) -> mx.array:
+    """Dispatch independent M=64 Steel GEMMs in one grid when available."""
+    try:
+        architecture = str(mx.device_info().get("architecture", ""))
+        if architecture.endswith(("d", "g", "p")):
+            from omlx.custom_kernels.glm_moe_dsa import fast
+
+            if fast.has_symbol("dspark_rowwise_gemm"):
+                return fast.dspark_rowwise_gemm(
+                    mx.contiguous(lhs),
+                    mx.contiguous(rhs),
+                    transpose_rhs,
+                )
+    except Exception:
+        pass
+    return lhs @ (rhs.swapaxes(-1, -2) if transpose_rhs else rhs)
+
+
+def exact_attention(
+    queries: mx.array,
+    key_rows: Sequence[mx.array],
+    scale: float,
+    sinks: mx.array | None,
+) -> mx.array:
+    """Attend M query rows to M same-length KV snapshots.
+
+    ``queries`` is ``[1, H, M, D]`` and every key row is ``[1, 1, S, D]``.
+    The return layout is ``[1, H, M, D]``.  Different key lengths are kept
+    correct with small same-length groups rather than padding the softmax.
+    """
+    if len(key_rows) != int(queries.shape[2]):
+        raise ValueError("one DeepSeek KV view is required for each query row")
+
+    scaled_rows = queries * mx.array(scale, dtype=queries.dtype)
+    outputs = []
+    start = 0
+    while start < len(key_rows):
+        stop = start + 1
+        group_length = int(key_rows[start].shape[2])
+        while (
+            stop < len(key_rows)
+            and int(key_rows[stop].shape[2]) == group_length
+        ):
+            stop += 1
+
+        query_batch = scaled_rows[0, :, start:stop].transpose(1, 0, 2)
+        keys = mx.concatenate(key_rows[start:stop], axis=0)[:, 0]
+        scores = rowwise_gemm(query_batch, keys, True)
+
+        if sinks is None:
+            weights = mx.softmax(scores, axis=-1, precise=True)
+        else:
+            sink_scores = mx.broadcast_to(
+                sinks.astype(scores.dtype)[None, :, None],
+                (*scores.shape[:-1], 1),
+            )
+            weights = mx.softmax(
+                mx.concatenate([sink_scores, scores], axis=-1),
+                axis=-1,
+                precise=True,
+            )[..., 1:]
+        group_output = rowwise_gemm(weights, keys, False)
+        outputs.append(group_output.transpose(1, 0, 2)[None])
+        start = stop
+
+    return outputs[0] if len(outputs) == 1 else mx.concatenate(outputs, axis=2)
+
+
+def exact_local_scores(
+    queries: mx.array,
+    key_rows: Sequence[mx.array],
+    scale: float,
+) -> mx.array:
+    """Return batch-invariant local scores for sparse split attention."""
+    if len(key_rows) != int(queries.shape[2]):
+        raise ValueError("one DeepSeek KV view is required for each query row")
+    if any(int(row.shape[2]) != int(key_rows[0].shape[2]) for row in key_rows):
+        raise ValueError("sparse local KV views must have equal lengths")
+    query_batch = (
+        queries * mx.array(scale, dtype=queries.dtype)
+    )[0].transpose(1, 0, 2)
+    keys = mx.concatenate(key_rows, axis=0)[:, 0]
+    return rowwise_gemm(query_batch, keys, True).transpose(1, 0, 2)[None]
+
+
+def exact_local_values(weights: mx.array, key_rows: Sequence[mx.array]) -> mx.array:
+    """Apply sparse local weights with the same decode/verify reduction."""
+    weight_rows = weights[0].transpose(1, 0, 2)
+    keys = mx.concatenate(key_rows, axis=0)[:, 0]
+    return rowwise_gemm(weight_rows, keys, False).transpose(1, 0, 2)[None]
+
+
+__all__ = [
+    "exact_attention",
+    "exact_local_scores",
+    "exact_local_values",
+    "rowwise_gemm",
+]

--- a/vllm_mlx/models/deepseek_v4_verify_attention.py
+++ b/vllm_mlx/models/deepseek_v4_verify_attention.py
@@ -90,7 +90,7 @@ def rowwise_gemm(lhs: mx.array, rhs: mx.array, transpose_rhs: bool) -> mx.array:
                 )
     except Exception:
         pass
-    return lhs @ (rhs.swapaxes(-1, -2) if transpose_rhs else rhs)
+    return _metal_rowwise_gemm(lhs, rhs, transpose_rhs)
 
 
 def exact_attention(

--- a/vllm_mlx/models/deepseek_v4_verify_qmv.py
+++ b/vllm_mlx/models/deepseek_v4_verify_qmv.py
@@ -1,0 +1,593 @@
+# Copyright © 2026 Apple Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Exact multi-row QMV for DeepSeek DSpark target verification.
+
+The Metal body preserves MLX ``qmv_fast``'s per-row arithmetic and 32-lane
+reduction order.  It only changes the outer schedule: a simdgroup reuses each
+weight byte across all verify rows before advancing K.  That makes M=2..6
+bitwise equivalent to M independent decode calls without streaming the weight
+matrix M times.  Six rows cover DSpark's five-draft verification block.
+"""
+
+from __future__ import annotations
+
+from functools import lru_cache
+
+import mlx.core as mx
+
+_HEADER = r"""
+#include <metal_simdgroup>
+#include <metal_stdlib>
+using namespace metal;
+
+struct OMLXFP8E4M3 {
+    operator float16_t() {
+        uint16_t value = (bits & 127) << 7;
+        half converted = as_type<half>(value);
+        converted *= 256.0;
+        auto sign = bits & 128;
+        return sign ? -converted : converted;
+    }
+    operator float() {
+        return static_cast<float>(this->operator float16_t());
+    }
+    uint8_t bits;
+};
+
+struct OMLXFP8E8M0 {
+    operator float() {
+        uint32_t value = bits == 0
+            ? 0x400000
+            : (static_cast<uint32_t>(bits) << 23);
+        return as_type<float>(value);
+    }
+    uint8_t bits;
+};
+
+inline float omlx_fp8_weight(uint8_t value) {
+    return float(*(thread OMLXFP8E4M3*)(&value));
+}
+
+inline float omlx_fp8_scale(uint8_t value) {
+    return float(*(thread OMLXFP8E8M0*)(&value));
+}
+
+template <int V>
+inline float omlx_mxfp8_dot(
+    const device uint8_t* weight,
+    const thread float* input,
+    float scale) {
+    float accum = 0.0f;
+    for (int idx = 0; idx < V; ++idx) {
+        accum += input[idx] * omlx_fp8_weight(weight[idx]);
+    }
+    return scale * accum;
+}
+"""
+
+_SOURCE = r"""
+    // Matches MLX qmv_fast for 8-bit modes: two uint32 packs (8 values)
+    // per lane, 32 lanes, two simdgroups, four output rows per simdgroup.
+    constexpr int VALUES_PER_THREAD = 8;
+    constexpr int BLOCK_SIZE = VALUES_PER_THREAD * 32;
+    constexpr int RESULTS_PER_SIMDGROUP = 4;
+    constexpr int OUTPUTS_PER_THREADGROUP = 8;
+
+    const uint simd_group = simdgroup_index_in_threadgroup;
+    const uint lane = thread_index_in_simdgroup;
+    const int output_base =
+        int(threadgroup_position_in_grid.y) * OUTPUTS_PER_THREADGROUP
+        + int(simd_group) * RESULTS_PER_SIMDGROUP;
+    if (output_base >= N) {
+        return;
+    }
+
+    const device uint8_t* weight_ptr = (const device uint8_t*)weight
+        + output_base * K + int(lane) * VALUES_PER_THREAD;
+    const device T* input_ptr = (const device T*)input
+        + int(lane) * VALUES_PER_THREAD;
+    device T* output_ptr = (device T*)output + output_base;
+
+    float accum[M][RESULTS_PER_SIMDGROUP] = {{0}};
+
+    if constexpr (MXFP8) {
+        const device uint8_t* scale_ptr = (const device uint8_t*)scales
+            + output_base * (K / GS)
+            + int(lane) / (GS / VALUES_PER_THREAD);
+
+        for (int k = 0; k < K; k += BLOCK_SIZE) {
+            float input_values[M][VALUES_PER_THREAD];
+            for (int row = 0; row < M; ++row) {
+                for (int idx = 0; idx < VALUES_PER_THREAD; ++idx) {
+                    input_values[row][idx] = float(input_ptr[row * K + idx]);
+                }
+            }
+            for (int result = 0; result < RESULTS_PER_SIMDGROUP; ++result) {
+                const device uint8_t* row_weight = weight_ptr + result * K;
+                const device uint8_t* row_scale =
+                    scale_ptr + result * (K / GS);
+                const float scale = omlx_fp8_scale(row_scale[0]);
+                for (int row = 0; row < M; ++row) {
+                    accum[row][result] += omlx_mxfp8_dot<VALUES_PER_THREAD>(
+                        row_weight, input_values[row], scale);
+                }
+            }
+            weight_ptr += BLOCK_SIZE;
+            scale_ptr += BLOCK_SIZE / GS;
+            input_ptr += BLOCK_SIZE;
+        }
+    } else {
+        const device T* scale_ptr = (const device T*)scales
+            + output_base * (K / GS)
+            + int(lane) / (GS / VALUES_PER_THREAD);
+        const device T* bias_ptr = (const device T*)biases
+            + output_base * (K / GS)
+            + int(lane) / (GS / VALUES_PER_THREAD);
+
+        for (int k = 0; k < K; k += BLOCK_SIZE) {
+            float input_values[M][VALUES_PER_THREAD];
+            float input_sums[M] = {0};
+            for (int row = 0; row < M; ++row) {
+                for (int idx = 0; idx < VALUES_PER_THREAD; ++idx) {
+                    const float value = float(input_ptr[row * K + idx]);
+                    input_values[row][idx] = value;
+                    input_sums[row] += value;
+                }
+            }
+            for (int result = 0; result < RESULTS_PER_SIMDGROUP; ++result) {
+                const device uint8_t* row_weight = weight_ptr + result * K;
+                const device T* row_scale = scale_ptr + result * (K / GS);
+                const device T* row_bias = bias_ptr + result * (K / GS);
+                const float scale = float(row_scale[0]);
+                const float bias = float(row_bias[0]);
+                for (int row = 0; row < M; ++row) {
+                    float dot = 0.0f;
+                    for (int idx = 0; idx < VALUES_PER_THREAD; ++idx) {
+                        dot += input_values[row][idx] * float(row_weight[idx]);
+                    }
+                    accum[row][result] +=
+                        scale * dot + input_sums[row] * bias;
+                }
+            }
+            weight_ptr += BLOCK_SIZE;
+            scale_ptr += BLOCK_SIZE / GS;
+            bias_ptr += BLOCK_SIZE / GS;
+            input_ptr += BLOCK_SIZE;
+        }
+    }
+
+    for (int row = 0; row < M; ++row) {
+        for (int result = 0; result < RESULTS_PER_SIMDGROUP; ++result) {
+            const float value = simd_sum(accum[row][result]);
+            if (lane == 0) {
+                output_ptr[row * N + result] = T(value);
+            }
+        }
+    }
+"""
+
+_MULTI_SOURCE = r"""
+    constexpr int VALUES_PER_THREAD = 8;
+    constexpr int BLOCK_SIZE = VALUES_PER_THREAD * 32;
+    constexpr int RESULTS_PER_SIMDGROUP = 4;
+    constexpr int OUTPUTS_PER_THREADGROUP = 8;
+    constexpr int BLOCKS_PER_GROUP = N / OUTPUTS_PER_THREADGROUP;
+
+    const uint simd_group = simdgroup_index_in_threadgroup;
+    const uint lane = thread_index_in_simdgroup;
+    const int flat_block = int(threadgroup_position_in_grid.y);
+    const int group = flat_block / BLOCKS_PER_GROUP;
+    const int group_block = flat_block - group * BLOCKS_PER_GROUP;
+    const int output_base =
+        group_block * OUTPUTS_PER_THREADGROUP
+        + int(simd_group) * RESULTS_PER_SIMDGROUP;
+
+    const device uint8_t* weight_ptr = (const device uint8_t*)weight
+        + (group * N + output_base) * K
+        + int(lane) * VALUES_PER_THREAD;
+    const device T* input_ptr = (const device T*)input
+        + group * M * K + int(lane) * VALUES_PER_THREAD;
+    device T* output_ptr = (device T*)output
+        + group * M * N + output_base;
+    const device uint8_t* scale_ptr = (const device uint8_t*)scales
+        + (group * N + output_base) * (K / GS)
+        + int(lane) / (GS / VALUES_PER_THREAD);
+
+    float accum[M][RESULTS_PER_SIMDGROUP] = {{0}};
+    for (int k = 0; k < K; k += BLOCK_SIZE) {
+        float input_values[M][VALUES_PER_THREAD];
+        for (int row = 0; row < M; ++row) {
+            for (int idx = 0; idx < VALUES_PER_THREAD; ++idx) {
+                input_values[row][idx] = float(input_ptr[row * K + idx]);
+            }
+        }
+        for (int result = 0; result < RESULTS_PER_SIMDGROUP; ++result) {
+            const device uint8_t* row_weight = weight_ptr + result * K;
+            const device uint8_t* row_scale =
+                scale_ptr + result * (K / GS);
+            const float scale = omlx_fp8_scale(row_scale[0]);
+            for (int row = 0; row < M; ++row) {
+                accum[row][result] += omlx_mxfp8_dot<VALUES_PER_THREAD>(
+                    row_weight, input_values[row], scale);
+            }
+        }
+        weight_ptr += BLOCK_SIZE;
+        scale_ptr += BLOCK_SIZE / GS;
+        input_ptr += BLOCK_SIZE;
+    }
+
+    for (int row = 0; row < M; ++row) {
+        for (int result = 0; result < RESULTS_PER_SIMDGROUP; ++result) {
+            const float value = simd_sum(accum[row][result]);
+            if (lane == 0) {
+                output_ptr[row * N + result] = T(value);
+            }
+        }
+    }
+"""
+
+_DENSE_SOURCE = r"""
+    // Matches MLX GEMVKernel<T, 8, 1, 1, 32, 4, 4>: eight simdgroups,
+    // four output rows per simdgroup, and four K values per lane. The only
+    // added dimension is M independent accumulators sharing each weight load.
+    constexpr int THREAD_ROWS = 4;
+    constexpr int THREAD_COLS = 4;
+    constexpr int OUTPUTS_PER_THREADGROUP = 32;
+    constexpr int K_BLOCK = 128;
+
+    const uint simd_group = simdgroup_index_in_threadgroup;
+    const uint lane = thread_index_in_simdgroup;
+    const int output_base =
+        int(threadgroup_position_in_grid.x) * OUTPUTS_PER_THREADGROUP
+        + int(simd_group) * THREAD_ROWS;
+    if (output_base >= N) {
+        return;
+    }
+
+    int k_base = int(lane) * THREAD_COLS;
+    float accum[M][THREAD_ROWS] = {{0}};
+    for (int block = 0; block < K; block += K_BLOCK) {
+        float input_values[M][THREAD_COLS];
+        for (int row = 0; row < M; ++row) {
+            for (int col = 0; col < THREAD_COLS; ++col) {
+                input_values[row][col] =
+                    float(input[row * K + k_base + col]);
+            }
+        }
+
+        for (int result = 0; result < THREAD_ROWS; ++result) {
+            const device T* row_weight =
+                weight + (output_base + result) * K + k_base;
+            float weight_values[THREAD_COLS];
+            for (int col = 0; col < THREAD_COLS; ++col) {
+                weight_values[col] = float(row_weight[col]);
+            }
+            for (int row = 0; row < M; ++row) {
+                for (int col = 0; col < THREAD_COLS; ++col) {
+                    accum[row][result] +=
+                        weight_values[col] * input_values[row][col];
+                }
+            }
+        }
+        k_base += K_BLOCK;
+    }
+
+    for (int row = 0; row < M; ++row) {
+        for (int result = 0; result < THREAD_ROWS; ++result) {
+            for (ushort step = 16; step >= 1; step >>= 1) {
+                accum[row][result] +=
+                    simd_shuffle_down(accum[row][result], step);
+            }
+            if (lane == 0) {
+                output[row * N + output_base + result] =
+                    T(accum[row][result]);
+            }
+        }
+    }
+"""
+
+# DSpark's reference head promotes the checkpoint's BF16 values to FP32 before
+# the projection. Reuse the same GEMV schedule while retaining BF16 storage;
+# only the output store differs from the decode-exact BF16 path above.
+_DENSE_FP32_SOURCE = _DENSE_SOURCE.replace(
+    "T(accum[row][result])", "accum[row][result]"
+)
+
+
+@lru_cache(maxsize=1)
+def _kernel():
+    return mx.fast.metal_kernel(
+        name="rapid_deepseek_verify_qmv_exact",
+        input_names=["input", "weight", "scales", "biases"],
+        output_names=["output"],
+        header=_HEADER,
+        source=_SOURCE,
+        ensure_row_contiguous=True,
+    )
+
+
+@lru_cache(maxsize=1)
+def _dense_kernel():
+    return mx.fast.metal_kernel(
+        name="rapid_deepseek_verify_gemv_exact",
+        input_names=["input", "weight"],
+        output_names=["output"],
+        source=_DENSE_SOURCE,
+        ensure_row_contiguous=True,
+    )
+
+
+@lru_cache(maxsize=1)
+def _dense_fp32_kernel():
+    return mx.fast.metal_kernel(
+        name="rapid_deepseek_dspark_head_fp32",
+        input_names=["input", "weight"],
+        output_names=["output"],
+        source=_DENSE_FP32_SOURCE,
+        ensure_row_contiguous=True,
+    )
+
+
+@lru_cache(maxsize=1)
+def _multi_kernel():
+    return mx.fast.metal_kernel(
+        name="rapid_deepseek_verify_multi_qmv_exact",
+        input_names=["input", "weight", "scales"],
+        output_names=["output"],
+        header=_HEADER,
+        source=_MULTI_SOURCE,
+        ensure_row_contiguous=True,
+    )
+
+
+def eligible(module, inputs: mx.array) -> bool:
+    """Return whether ``module(inputs)`` has an exact fast-kernel layout."""
+    if inputs.ndim < 2 or module.weight.ndim != 2:
+        return False
+    input_dims = int(inputs.shape[-1])
+    rows = int(inputs.size) // input_dims
+    output_dims = int(module.scales.shape[0])
+    mode = getattr(module, "mode", "affine")
+    return (
+        2 <= rows <= 6
+        and int(module.bits) == 8
+        and mode in ("mxfp8", "affine")
+        and int(module.group_size) in (32, 64, 128)
+        and inputs.dtype in (mx.bfloat16, mx.float16)
+        and input_dims % 512 == 0
+        and output_dims >= 2048
+        and output_dims % 8 == 0
+    )
+
+
+def exact_verify_qmv(module, inputs: mx.array) -> mx.array:
+    """Apply an eligible quantized linear with decode-identical reductions."""
+    input_dims = int(inputs.shape[-1])
+    rows = int(inputs.size) // input_dims
+    output_dims = int(module.scales.shape[0])
+    flat = inputs.reshape(rows, input_dims)
+    mode = getattr(module, "mode", "affine")
+    biases = module.get("biases")
+    if biases is None:
+        biases = module.scales
+
+    (output,) = _kernel()(
+        inputs=[flat, module.weight, module.scales, biases],
+        template=[
+            ("T", inputs.dtype),
+            ("M", rows),
+            ("K", input_dims),
+            ("N", output_dims),
+            ("GS", int(module.group_size)),
+            ("MXFP8", mode == "mxfp8"),
+        ],
+        # mx.fast uses thread-grid dimensions. This is one (32, 2, 1)
+        # threadgroup for each eight output rows.
+        grid=(32, output_dims // 4, 1),
+        threadgroup=(32, 2, 1),
+        output_shapes=[(rows, output_dims)],
+        output_dtypes=[inputs.dtype],
+    )
+    output = output.reshape((*inputs.shape[:-1], output_dims))
+    if "bias" in module:
+        output = output + module.bias
+    return output
+
+
+def pair_eligible(module_a, module_b, inputs: mx.array) -> bool:
+    """Return whether two MXFP8 linears can share the exact native grid."""
+    required = ("bits", "group_size", "mode", "weight", "scales")
+    if any(
+        not all(hasattr(module, name) for name in required)
+        for module in (module_a, module_b)
+    ):
+        return False
+    if inputs.ndim < 2 or module_a.weight.ndim != 2 or module_b.weight.ndim != 2:
+        return False
+    input_dims = int(inputs.shape[-1])
+    rows = int(inputs.size) // input_dims
+    try:
+        from omlx.custom_kernels.glm_moe_dsa import fast
+
+        native = fast.has_symbol("dspark_exact_mxfp8_qmv_pair")
+    except Exception:
+        native = False
+    return (
+        native
+        and 2 <= rows <= 6
+        and inputs.dtype in (mx.bfloat16, mx.float16)
+        and input_dims % 512 == 0
+        and int(module_a.bits) == int(module_b.bits) == 8
+        and int(module_a.group_size) == int(module_b.group_size) == 32
+        and getattr(module_a, "mode", "affine") == "mxfp8"
+        and getattr(module_b, "mode", "affine") == "mxfp8"
+        and module_a.weight.shape == module_b.weight.shape
+        and module_a.scales.shape == module_b.scales.shape
+        and module_a.weight.dtype == module_b.weight.dtype == mx.uint32
+        and module_a.scales.dtype == module_b.scales.dtype == mx.uint8
+        and int(module_a.scales.shape[1]) * 32 == input_dims
+        and int(module_a.scales.shape[0]) % 8 == 0
+    )
+
+
+def exact_verify_qmv_pair(module_a, module_b, inputs: mx.array):
+    """Apply two MXFP8 linears with independent M=1-identical reductions."""
+    from omlx.custom_kernels.glm_moe_dsa import fast
+
+    input_dims = int(inputs.shape[-1])
+    rows = int(inputs.size) // input_dims
+    output_dims = int(module_a.scales.shape[0])
+    flat = mx.contiguous(inputs.reshape(rows, input_dims))
+    paired = fast.dspark_exact_mxfp8_qmv_pair(
+        flat,
+        module_a.weight,
+        module_a.scales,
+        module_b.weight,
+        module_b.scales,
+    )
+    paired = paired.reshape((2, *inputs.shape[:-1], output_dims))
+    output_a, output_b = paired[0], paired[1]
+    if "bias" in module_a:
+        output_a = output_a + module_a.bias
+    if "bias" in module_b:
+        output_b = output_b + module_b.bias
+    return output_a, output_b
+
+
+def multi_eligible(module, inputs: mx.array) -> bool:
+    """Return whether a grouped MultiLinear has the exact shared-row path."""
+    if not all(
+        hasattr(module, name)
+        for name in ("weight", "scales", "bits", "group_size", "mode")
+    ):
+        return False
+    if inputs.ndim < 3 or module.weight.ndim != 3:
+        return False
+    groups = int(module.scales.shape[0])
+    input_dims = int(inputs.shape[-1])
+    rows = int(inputs.size) // (groups * input_dims)
+    output_dims = int(module.scales.shape[1])
+    return (
+        2 <= rows <= 6
+        and int(module.bits) == 8
+        and getattr(module, "mode", "affine") == "mxfp8"
+        and int(module.group_size) == 32
+        and inputs.dtype in (mx.bfloat16, mx.float16)
+        and input_dims % 512 == 0
+        and output_dims % 8 == 0
+    )
+
+
+def exact_verify_multi_qmv(module, inputs: mx.array) -> mx.array:
+    """Apply grouped mxfp8 projection with decode-identical reductions."""
+    groups = int(module.scales.shape[0])
+    input_dims = int(inputs.shape[-1])
+    rows = int(inputs.size) // (groups * input_dims)
+    output_dims = int(module.scales.shape[1])
+    grouped = inputs.reshape(groups, rows, input_dims)
+    (output,) = _multi_kernel()(
+        inputs=[grouped, module.weight, module.scales],
+        template=[
+            ("T", inputs.dtype),
+            ("M", rows),
+            ("K", input_dims),
+            ("N", output_dims),
+            ("GS", int(module.group_size)),
+        ],
+        grid=(32, groups * output_dims // 4, 1),
+        threadgroup=(32, 2, 1),
+        output_shapes=[(groups, rows, output_dims)],
+        output_dtypes=[inputs.dtype],
+    )
+    return output
+
+
+def dense_eligible(module, inputs: mx.array) -> bool:
+    """Return whether a dense linear has MLX's large-output GEMV geometry."""
+    if inputs.ndim < 2 or module.weight.ndim != 2:
+        return False
+    input_dims = int(inputs.shape[-1])
+    rows = int(inputs.size) // input_dims
+    output_dims = int(module.weight.shape[0])
+    return (
+        2 <= rows <= 6
+        and inputs.dtype in (mx.bfloat16, mx.float16)
+        and module.weight.dtype == inputs.dtype
+        and input_dims % 128 == 0
+        and output_dims >= 4096
+        and output_dims % 32 == 0
+    )
+
+
+def exact_verify_gemv(module, inputs: mx.array) -> mx.array:
+    """Apply a dense linear with MLX M=1 GEMV's exact reduction order."""
+    input_dims = int(inputs.shape[-1])
+    rows = int(inputs.size) // input_dims
+    output_dims = int(module.weight.shape[0])
+    flat = inputs.reshape(rows, input_dims)
+    (output,) = _dense_kernel()(
+        inputs=[flat, module.weight],
+        template=[
+            ("T", inputs.dtype),
+            ("M", rows),
+            ("K", input_dims),
+            ("N", output_dims),
+        ],
+        grid=((output_dims // 32) * 256, 1, 1),
+        threadgroup=(256, 1, 1),
+        output_shapes=[(rows, output_dims)],
+        output_dtypes=[inputs.dtype],
+    )
+    output = output.reshape((*inputs.shape[:-1], output_dims))
+    if "bias" in module:
+        output = output + module.bias
+    return output
+
+
+def dspark_head_gemv(module, inputs: mx.array) -> mx.array:
+    """Project a DSpark head with BF16 storage and FP32 arithmetic/output."""
+    input_dims = int(inputs.shape[-1])
+    rows = int(inputs.size) // input_dims
+    output_dims = int(module.weight.shape[0])
+    if not (
+        1 <= rows <= 6
+        and inputs.dtype in (mx.bfloat16, mx.float16)
+        and module.weight.dtype == inputs.dtype
+        and input_dims % 128 == 0
+        and output_dims >= 4096
+        and output_dims % 32 == 0
+    ):
+        return module(inputs.astype(mx.float32))
+
+    flat = inputs.reshape(rows, input_dims)
+    (output,) = _dense_fp32_kernel()(
+        inputs=[flat, module.weight],
+        template=[
+            ("T", inputs.dtype),
+            ("M", rows),
+            ("K", input_dims),
+            ("N", output_dims),
+        ],
+        grid=((output_dims // 32) * 256, 1, 1),
+        threadgroup=(256, 1, 1),
+        output_shapes=[(rows, output_dims)],
+        output_dtypes=[mx.float32],
+    )
+    output = output.reshape((*inputs.shape[:-1], output_dims))
+    if "bias" in module:
+        output = output + module.bias.astype(mx.float32)
+    return output
+
+
+__all__ = [
+    "dense_eligible",
+    "dspark_head_gemv",
+    "eligible",
+    "exact_verify_qmv_pair",
+    "exact_verify_gemv",
+    "exact_verify_multi_qmv",
+    "exact_verify_qmv",
+    "multi_eligible",
+    "pair_eligible",
+]

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -1433,6 +1433,26 @@ def _adapt_dspark_depth(
     return current_depth, 0, False
 
 
+def _dspark_sampling_logprobs(logits: mx.array, params: Any) -> mx.array:
+    """Return the exact normalized distribution used by mlx-lm sampling."""
+    from mlx_lm.sample_utils import apply_min_p, apply_top_k, apply_top_p
+
+    logprobs = logits - mx.logsumexp(logits, axis=-1, keepdims=True)
+    top_p = float(getattr(params, "top_p", 0.0) or 0.0)
+    min_p = float(getattr(params, "min_p", 0.0) or 0.0)
+    top_k = int(getattr(params, "top_k", 0) or 0)
+    temperature = float(getattr(params, "temperature", 0.0) or 0.0)
+    if 0.0 < top_p < 1.0:
+        logprobs = apply_top_p(logprobs, top_p)
+    if min_p:
+        logprobs = apply_min_p(logprobs, min_p)
+    if 0 < top_k < logprobs.shape[-1]:
+        logprobs = apply_top_k(logprobs, top_k)
+    if temperature > 0.0:
+        logprobs = logprobs / temperature
+    return logprobs - mx.logsumexp(logprobs, axis=-1, keepdims=True)
+
+
 def _install_dspark(
     batch_gen: "BatchGenerator",
     model: Any,
@@ -1480,6 +1500,13 @@ def _install_dspark(
     _supports_variable_depth = (
         "max_draft_tokens" in inspect.signature(model.dspark_forward).parameters
     )
+    # The 0731 checkpoint predicts five rows, but the target verify kernel has
+    # a measured K=5 shape cliff on Apple Silicon: compared with K=4 it costs
+    # ~54% more for only ~6% more committed tokens on a coding workload. Keep
+    # the checkpoint capability intact while capping the adaptive runtime at
+    # the empirically efficient shape. Non-variable third-party hooks retain
+    # their original fixed depth.
+    runtime_max_k = min(draft_k, 4) if _supports_variable_depth else draft_k
     _stats = {
         "verify_steps": 0,
         "draft_tokens_proposed": 0,
@@ -1488,9 +1515,9 @@ def _install_dspark(
         "errors": 0,
         "full_accept_rounds": 0,
     }
-    _uid_stats: dict[int, dict[str, float | int]] = {}
+    _uid_stats: dict[int, dict[str, Any]] = {}
 
-    def _request_stats(uid: int) -> dict[str, float | int]:
+    def _request_stats(uid: int) -> dict[str, Any]:
         return _uid_stats.setdefault(
             uid,
             {
@@ -1499,17 +1526,21 @@ def _install_dspark(
                 "tokens_accepted": 0,
                 "full_accept_rounds": 0,
                 "fallback_events": 0,
+                "draft_ms": 0.0,
+                "verify_ms": 0.0,
+                "sample_ms": 0.0,
+                "rollback_ms": 0.0,
                 "low_accept_streak": 0,
-                "min_depth": draft_k,
-                "max_depth": draft_k,
+                "min_depth": runtime_max_k,
+                "max_depth": runtime_max_k,
+                "depth_stats": {},
             },
         )
 
-    def _is_greedy(uid: int) -> bool:
+    def _sampling_params(uid: int):
         request_id = uid_to_request_id.get(uid)
         request = requests.get(request_id) if request_id else None
-        params = getattr(request, "sampling_params", None)
-        return params is None or params.temperature in (None, 0.0)
+        return getattr(request, "sampling_params", None)
 
     def _dspark_step():
         if (
@@ -1526,11 +1557,26 @@ def _install_dspark(
             _cooldowns[uid] = cooldown - 1
             _stats["fallthrough_steps"] += 1
             return _orig_step()
-        if not _is_greedy(uid):
+        params = _sampling_params(uid)
+        # Seeded decoding has a stricter baseline-stream reproducibility
+        # contract. Keep it on the ordinary path until DSpark owns a separate
+        # per-request acceptance key without perturbing the target sampler.
+        if params is not None and getattr(params, "seed", None) is not None:
             _stats["fallthrough_steps"] += 1
             return _orig_step()
         processors = getattr(gb, "logits_processors", None)
         request_processors = processors[0] if processors and processors[0] else []
+        stochastic = params is not None and params.temperature not in (None, 0.0)
+        if stochastic:
+            # The residual sampler is mathematically correct for one isolated
+            # proposal, but real multi-round Codex runs exposed state/RNG
+            # divergence and severe repetition at temperature=1. Keep user
+            # output authoritative by taking mlx-lm's ordinary sampler until
+            # stochastic DSpark has a per-request RNG stream plus a real-model
+            # multi-round distribution-equivalence gate. Greedy DSpark remains
+            # enabled and retains its speedup.
+            _stats["fallthrough_steps"] += 1
+            return _orig_step()
 
         inputs = gb._next_tokens
         last_token = int(inputs[0].item())
@@ -1538,9 +1584,32 @@ def _install_dspark(
         if hidden is None or hidden.shape[0] != 1:
             _stats["fallthrough_steps"] += 1
             return _orig_step()
-        dspark_cache = _caches.setdefault(uid, model.make_dspark_cache())
-        current_k = _depths.setdefault(uid, draft_k)
+        dspark_cache = _caches.get(uid)
+        if dspark_cache is None:
+            take_primed = getattr(model, "take_dspark_primed", None)
+            dspark_cache = take_primed(gb.prompt_cache) if take_primed else None
+            if dspark_cache is None:
+                dspark_cache = model.make_dspark_cache()
+            _caches[uid] = dspark_cache
+        current_k = _depths.setdefault(uid, runtime_max_k)
         offsets_before = [cache.offset for cache in dspark_cache]
+        q_logprobs: list[mx.array] = []
+        q_context = None
+        if request_processors:
+            q_context = mx.concatenate([gb._token_context[0].tokens, inputs])
+
+        def _sample_draft(row_logits, _idx):
+            nonlocal q_context
+            for processor in request_processors:
+                row_logits = processor(q_context, row_logits)
+            row_q = _dspark_sampling_logprobs(row_logits, params)
+            token = mx.random.categorical(row_q)
+            q_logprobs.append(row_q[0])
+            if request_processors:
+                q_context = mx.concatenate([q_context, token.reshape(-1)])
+            return token
+
+        phase_t0 = time.perf_counter()
         try:
             if _supports_variable_depth:
                 proposal = model.dspark_forward(
@@ -1548,6 +1617,7 @@ def _install_dspark(
                     hidden,
                     dspark_cache,
                     max_draft_tokens=current_k,
+                    draft_sampler=_sample_draft if stochastic else None,
                 )
             else:
                 proposal = model.dspark_forward(inputs[:, None], hidden, dspark_cache)
@@ -1561,6 +1631,9 @@ def _install_dspark(
 
         output_ids, _ = proposal
         draft = [int(v) for v in output_ids[0, 1 : current_k + 1].tolist()]
+        uid_stats["draft_ms"] = float(uid_stats["draft_ms"]) + (
+            time.perf_counter() - phase_t0
+        ) * 1000
         K = len(draft)
         _stats["verify_steps"] += 1
         _stats["draft_tokens_proposed"] += K
@@ -1569,13 +1642,19 @@ def _install_dspark(
         import copy
 
         target_cache_snapshot = copy.deepcopy(gb.prompt_cache)
+        phase_t0 = time.perf_counter()
         try:
             verify_input = mx.concatenate(
                 [inputs[:, None], mx.array([draft], dtype=inputs.dtype)], axis=1
             )
-            verify_logits = model(verify_input, cache=gb.prompt_cache)
+            from .models.deepseek_v4_rollback import armed
+
+            with armed():
+                verify_logits = model(verify_input, cache=gb.prompt_cache)
             verify_hidden = model._last_dspark_hidden
             mx.eval(verify_logits, verify_hidden)
+            verify_elapsed_ms = (time.perf_counter() - phase_t0) * 1000
+            uid_stats["verify_ms"] = float(uid_stats["verify_ms"]) + verify_elapsed_ms
         except Exception as exc:  # noqa: BLE001
             logger.warning("[DSpark] verify failed; falling back: %r", exc)
             _stats["errors"] += 1
@@ -1590,6 +1669,7 @@ def _install_dspark(
             _caches.pop(uid, None)
             return _orig_step()
 
+        phase_t0 = time.perf_counter()
         accepted = 0
         preds_list: list[int] = []
         processed_logprobs: list[mx.array] = []
@@ -1600,10 +1680,21 @@ def _install_dspark(
             sample_logits = verify_logits[0:1, idx]
             for processor in request_processors:
                 sample_logits = processor(token_context, sample_logits)
-            logprobs = sample_logits - mx.logsumexp(
-                sample_logits, axis=-1, keepdims=True
+            logprobs = (
+                _dspark_sampling_logprobs(sample_logits, params)
+                if stochastic
+                else sample_logits
+                - mx.logsumexp(sample_logits, axis=-1, keepdims=True)
             )
-            pred = int(mx.argmax(logprobs[0], axis=-1).item())
+            if stochastic:
+                processed_logprobs.append(logprobs[0])
+                if idx < K and request_processors:
+                    token_context = mx.concatenate(
+                        [token_context, mx.array([draft[idx]], dtype=inputs.dtype)]
+                    )
+                continue
+            else:
+                pred = int(mx.argmax(logprobs[0], axis=-1).item())
             preds_list.append(pred)
             processed_logprobs.append(logprobs[0])
             if idx == K or pred != draft[idx]:
@@ -1613,21 +1704,62 @@ def _install_dspark(
                 token_context = gb._token_context[0].update_and_fetch(
                     mx.array([draft[idx]], dtype=inputs.dtype)
                 )
+        if stochastic:
+            p_rows = mx.stack(processed_logprobs[:K])
+            q_rows = mx.stack(q_logprobs)
+            draft_idx = mx.array(draft, dtype=mx.uint32)[:, None]
+            p_token = mx.take_along_axis(mx.exp(p_rows), draft_idx, axis=1).squeeze(1)
+            q_token = mx.take_along_axis(mx.exp(q_rows), draft_idx, axis=1).squeeze(1)
+            accept_flags = mx.random.uniform(shape=(K,)) < mx.minimum(
+                1.0, p_token / q_token
+            )
+            residual = mx.maximum(mx.exp(p_rows) - mx.exp(q_rows), 0)
+            residual_sum = mx.sum(residual, axis=-1, keepdims=True)
+            residual = mx.where(
+                residual_sum > 0,
+                residual / residual_sum,
+                mx.exp(p_rows),
+            )
+            residual_tokens = mx.random.categorical(mx.log(residual))
+            bonus_token = mx.random.categorical(processed_logprobs[K])
+            resolved = mx.concatenate(
+                [
+                    accept_flags.astype(mx.int32),
+                    residual_tokens.astype(mx.int32),
+                    bonus_token.reshape(1).astype(mx.int32),
+                ]
+            ).tolist()
+            flags = resolved[:K]
+            accepted = next((idx for idx, flag in enumerate(flags) if not flag), K)
+            bonus = resolved[K + accepted] if accepted < K else resolved[-1]
+            preds_list = draft[:accepted] + [bonus]
+        uid_stats["sample_ms"] = float(uid_stats["sample_ms"]) + (
+            time.perf_counter() - phase_t0
+        ) * 1000
         rejected = K - accepted
         if accepted == K:
             _stats["full_accept_rounds"] += 1
             uid_stats["full_accept_rounds"] += 1
         if rejected:
-            # DeepSeek V4 pooling caches cannot trim once a compressed window
-            # has been materialised. Restore the pre-verify snapshot and replay
-            # only the committed prefix instead. This is the lossless fallback
-            # for partial acceptance; full-accept rounds keep the fast path.
-            gb.prompt_cache = target_cache_snapshot
-            committed_input = verify_input[:, : accepted + 1]
-            replay_logits = model(committed_input, cache=gb.prompt_cache)
-            replay_hidden = model._last_dspark_hidden
-            mx.eval(replay_logits, replay_hidden)
-            verify_hidden = replay_hidden
+            from .models.deepseek_v4_rollback import trim_all
+
+            phase_t0 = time.perf_counter()
+            if not trim_all(gb.prompt_cache, rejected):
+                # Compatibility fallback for an unknown/new cache class. It
+                # is exact but expensive; supported DeepSeek caches use their
+                # short-window undo records and never replay the backbone.
+                logger.warning(
+                    "[DSpark] cache rollback unsupported; replaying committed prefix"
+                )
+                gb.prompt_cache = target_cache_snapshot
+                committed_input = verify_input[:, : accepted + 1]
+                replay_logits = model(committed_input, cache=gb.prompt_cache)
+                replay_hidden = model._last_dspark_hidden
+                mx.eval(replay_logits, replay_hidden)
+                verify_hidden = replay_hidden
+            uid_stats["rollback_ms"] = float(uid_stats["rollback_ms"]) + (
+                time.perf_counter() - phase_t0
+            ) * 1000
 
         # Only target states for committed inputs may seed the next proposal.
         model._last_dspark_hidden = verify_hidden[:, : accepted + 1]
@@ -1649,6 +1781,14 @@ def _install_dspark(
             _pending_replay[uid] = (target_cache_snapshot, verify_input)
         _stats["tokens_accepted"] += accepted
         uid_stats["tokens_accepted"] += accepted
+        depth_stats = uid_stats["depth_stats"]
+        depth_bucket = depth_stats.setdefault(
+            current_k, {"rounds": 0, "accepted": 0, "proposed": 0, "verify_ms": 0.0}
+        )
+        depth_bucket["rounds"] += 1
+        depth_bucket["accepted"] += accepted
+        depth_bucket["proposed"] += K
+        depth_bucket["verify_ms"] += verify_elapsed_ms
         # oMLX's most important operational lesson is that a fixed speculative
         # depth is wrong for coding agents: acceptance changes sharply across
         # prose, JSON and tool-call boundaries.  Use a conservative AIMD-like
@@ -1657,7 +1797,7 @@ def _install_dspark(
         # instead of permanently disabling DSpark for the rest of the request.
         current_k, low_streak, needs_cooldown = _adapt_dspark_depth(
             current_k,
-            draft_k,
+            runtime_max_k,
             accepted,
             K,
             int(uid_stats["low_accept_streak"]),
@@ -1676,10 +1816,16 @@ def _install_dspark(
         attempts = int(request_stats.get("draft_tokens_proposed", 0))
         accepts = int(request_stats.get("tokens_accepted", 0))
         rounds = int(request_stats.get("verify_steps", 0))
+        depth_stats = request_stats.get("depth_stats", {})
+        depth_summary = ",".join(
+            f"k{k}:{v['rounds']}r/{v['accepted']}a/{v['proposed']}p/{v['verify_ms']:.0f}ms"
+            for k, v in sorted(depth_stats.items())
+        )
         logger.info(
             "[DSpark] completed uid=%s rounds=%d accepted=%d/%d "
             "avg_accept=%.2f full_accept=%d/%d depth=%d..%d "
-            "fallback_events=%d",
+            "fallback_events=%d timing[draft=%.1fms verify=%.1fms "
+            "sample=%.1fms rollback=%.1fms] by_depth=[%s]",
             uid,
             rounds,
             accepts,
@@ -1690,6 +1836,11 @@ def _install_dspark(
             int(request_stats.get("min_depth", 0)),
             int(request_stats.get("max_depth", 0)),
             int(request_stats.get("fallback_events", 0)),
+            float(request_stats.get("draft_ms", 0.0)),
+            float(request_stats.get("verify_ms", 0.0)),
+            float(request_stats.get("sample_ms", 0.0)),
+            float(request_stats.get("rollback_ms", 0.0)),
+            depth_summary,
         )
         _pending.pop(uid, None)
         _pending_replay.pop(uid, None)
@@ -1791,9 +1942,10 @@ def _install_dspark(
     gb.next = _dspark_next
     batch_gen._dspark_stats = _stats
     logger.info(
-        "[DSpark] installed (greedy B=1, checkpoint K=%d, max K=%d)",
+        "[DSpark] installed (greedy-only; stochastic requests use plain "
+        "decode, checkpoint K=%d, runtime max K=%d)",
         checkpoint_k,
-        draft_k,
+        runtime_max_k,
     )
     return True
 

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -1631,9 +1631,9 @@ def _install_dspark(
 
         output_ids, _ = proposal
         draft = [int(v) for v in output_ids[0, 1 : current_k + 1].tolist()]
-        uid_stats["draft_ms"] = float(uid_stats["draft_ms"]) + (
-            time.perf_counter() - phase_t0
-        ) * 1000
+        uid_stats["draft_ms"] = (
+            float(uid_stats["draft_ms"]) + (time.perf_counter() - phase_t0) * 1000
+        )
         K = len(draft)
         _stats["verify_steps"] += 1
         _stats["draft_tokens_proposed"] += K
@@ -1683,8 +1683,7 @@ def _install_dspark(
             logprobs = (
                 _dspark_sampling_logprobs(sample_logits, params)
                 if stochastic
-                else sample_logits
-                - mx.logsumexp(sample_logits, axis=-1, keepdims=True)
+                else sample_logits - mx.logsumexp(sample_logits, axis=-1, keepdims=True)
             )
             if stochastic:
                 processed_logprobs.append(logprobs[0])
@@ -1733,9 +1732,9 @@ def _install_dspark(
             accepted = next((idx for idx, flag in enumerate(flags) if not flag), K)
             bonus = resolved[K + accepted] if accepted < K else resolved[-1]
             preds_list = draft[:accepted] + [bonus]
-        uid_stats["sample_ms"] = float(uid_stats["sample_ms"]) + (
-            time.perf_counter() - phase_t0
-        ) * 1000
+        uid_stats["sample_ms"] = (
+            float(uid_stats["sample_ms"]) + (time.perf_counter() - phase_t0) * 1000
+        )
         rejected = K - accepted
         if accepted == K:
             _stats["full_accept_rounds"] += 1
@@ -1757,9 +1756,10 @@ def _install_dspark(
                 replay_hidden = model._last_dspark_hidden
                 mx.eval(replay_logits, replay_hidden)
                 verify_hidden = replay_hidden
-            uid_stats["rollback_ms"] = float(uid_stats["rollback_ms"]) + (
-                time.perf_counter() - phase_t0
-            ) * 1000
+            uid_stats["rollback_ms"] = (
+                float(uid_stats["rollback_ms"])
+                + (time.perf_counter() - phase_t0) * 1000
+            )
 
         # Only target states for committed inputs may seed the next proposal.
         model._last_dspark_hidden = verify_hidden[:, : accepted + 1]

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -1741,12 +1741,20 @@ def _install_dspark(
             from .models.deepseek_v4_rollback import trim_all
 
             phase_t0 = time.perf_counter()
-            if not trim_all(gb.prompt_cache, rejected):
+            rollback_error = None
+            try:
+                rollback_ok = trim_all(gb.prompt_cache, rejected)
+            except Exception as exc:  # noqa: BLE001
+                rollback_error = exc
+                rollback_ok = False
+            if not rollback_ok:
                 # Compatibility fallback for an unknown/new cache class. It
                 # is exact but expensive; supported DeepSeek caches use their
                 # short-window undo records and never replay the backbone.
                 logger.warning(
-                    "[DSpark] cache rollback unsupported; replaying committed prefix"
+                    "[DSpark] cache rollback %s; replaying committed prefix%s",
+                    "failed" if rollback_error is not None else "unsupported",
+                    f": {rollback_error!r}" if rollback_error is not None else "",
                 )
                 gb.prompt_cache = target_cache_snapshot
                 committed_input = verify_input[:, : accepted + 1]

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -1497,9 +1497,9 @@ def _install_dspark(
     _pending_replay: dict[int, tuple[Any, mx.array]] = {}
     _depths: dict[int, int] = {}
     _cooldowns: dict[int, int] = {}
-    _supports_variable_depth = (
-        "max_draft_tokens" in inspect.signature(model.dspark_forward).parameters
-    )
+    _dspark_parameters = inspect.signature(model.dspark_forward).parameters
+    _supports_variable_depth = "max_draft_tokens" in _dspark_parameters
+    _supports_draft_sampler = "draft_sampler" in _dspark_parameters
     # The 0731 checkpoint predicts five rows, but the target verify kernel has
     # a measured K=5 shape cliff on Apple Silicon: compared with K=4 it costs
     # ~54% more for only ~6% more committed tokens on a coding workload. Keep
@@ -1611,16 +1611,14 @@ def _install_dspark(
 
         phase_t0 = time.perf_counter()
         try:
+            draft_kwargs: dict[str, Any] = {}
             if _supports_variable_depth:
-                proposal = model.dspark_forward(
-                    inputs[:, None],
-                    hidden,
-                    dspark_cache,
-                    max_draft_tokens=current_k,
-                    draft_sampler=_sample_draft if stochastic else None,
-                )
-            else:
-                proposal = model.dspark_forward(inputs[:, None], hidden, dspark_cache)
+                draft_kwargs["max_draft_tokens"] = current_k
+            if _supports_draft_sampler:
+                draft_kwargs["draft_sampler"] = _sample_draft if stochastic else None
+            proposal = model.dspark_forward(
+                inputs[:, None], hidden, dspark_cache, **draft_kwargs
+            )
         except Exception as exc:  # noqa: BLE001
             logger.warning("[DSpark] draft failed; falling back: %r", exc)
             _stats["errors"] += 1


### PR DESCRIPTION
## Summary

- verify DSpark draft rows in one checkpointed target-model pass
- add exact cache rollback primitives for accepted prefixes and rejection recovery
- add multi-row QMV/attention verification paths with conservative fallback
- record draft, verify, sampling, and rollback timing for real performance diagnosis

## Why

The existing DSpark path produced no useful speculative rounds on real DeepSeek V4 workloads. This implementation targets the expensive serial verify path while preserving exact cache and sampling semantics when drafts are rejected.

This PR is deliberately isolated from Codex priming, long-context policy, and soak tooling.

## Validation

- 29 focused DeepSeek vendored-model and DSpark scheduler tests passed
- ruff check/format passed on all non-vendored changed files
- adversarial review and live DeepSeek benchmark follow
