### PR TITLE
chore(rapid-mac): 0.12.0 polish — drop rapid-desktop branding, Apache-2.0, fix Launch page

### DIFF
--- a/apps/rapid-mac/Casks/README.md
+++ b/apps/rapid-mac/Casks/README.md
@@ -5,17 +5,16 @@ notarised `.dmg` attached to each GitHub Release cut by
 `.github/workflows/rapid-mac-release.yml` (tag prefix `rapid-mac-v*`,
 asset name `rapid-mlx-desktop.dmg`).
 
-> **TODO(owner):** the release/tap repo owner is UNRESOLVED
-> (`masonjames/Rapid-MLX` vs `raullenchai/Rapid-MLX`). Every `OWNER`
-> placeholder below and in `rapid-mlx.rb` must be replaced once the push
-> target is decided.
+> **Note:** the release/tap repo owner is `raullenchai`
+> (`raullenchai/Rapid-MLX`), used throughout the commands below and in
+> `rapid-mlx.rb`.
 
 ## End-user install
 
 Once the tap is published, users install with:
 
 ```bash
-brew tap OWNER/tap
+brew tap raullenchai/tap
 brew install --cask rapid-mlx
 ```
 
@@ -23,10 +22,10 @@ brew install --cask rapid-mlx
 
 Homebrew expects custom taps in a repo named `homebrew-<tapname>`:
 
-1. Create a new public GitHub repo at `OWNER/homebrew-tap`.
+1. Create a new public GitHub repo at `raullenchai/homebrew-tap`.
 2. Copy `Casks/rapid-mlx.rb` from this repo to `Casks/rapid-mlx.rb`
-   in `OWNER/homebrew-tap`.
-3. Push. End users can now `brew tap OWNER/tap` (Homebrew expands
+   in `raullenchai/homebrew-tap`.
+3. Push. End users can now `brew tap raullenchai/tap` (Homebrew expands
    that to the `homebrew-tap` repo).
 
 You can keep the canonical copy in this repo (`Casks/rapid-mlx.rb`)
@@ -41,7 +40,7 @@ After cutting a new tag (e.g. `rapid-mac-v0.11.0`):
 ```bash
 set -euo pipefail
 VERSION=0.11.0
-OWNER=OWNER   # TODO(owner): masonjames or raullenchai
+OWNER=raullenchai
 
 # 1. Pull the new DMG SHA from the GitHub Release
 SHA=$(curl -fsSL "https://github.com/${OWNER}/Rapid-MLX/releases/download/rapid-mac-v${VERSION}/rapid-mlx-desktop.dmg" \

--- a/apps/rapid-mac/Casks/rapid-mlx.rb
+++ b/apps/rapid-mac/Casks/rapid-mlx.rb
@@ -7,15 +7,11 @@ cask "rapid-mlx" do
   # verifying the wrong bytes.
   sha256 "0000000000000000000000000000000000000000000000000000000000000000"
 
-  # TODO(owner): the GitHub repo that hosts the tagged app releases is
-  # UNRESOLVED (masonjames/Rapid-MLX vs raullenchai/Rapid-MLX). Replace
-  # OWNER in BOTH the url and the verified: stanza once the push target is
-  # decided. The tag prefix is "rapid-mac-v" to match the release
-  # workflow (.github/workflows/rapid-mac-release.yml triggers on
-  # rapid-mac-v*), and the DMG asset name is "rapid-mlx-desktop.dmg" from
-  # scripts/dmg.sh.
-  url "https://github.com/OWNER/Rapid-MLX/releases/download/rapid-mac-v#{version}/rapid-mlx-desktop.dmg",
-      verified: "github.com/OWNER/Rapid-MLX/"
+  # The tag prefix is "rapid-mac-v" to match the release workflow
+  # (.github/workflows/rapid-mac-release.yml triggers on rapid-mac-v*), and
+  # the DMG asset name is "rapid-mlx-desktop.dmg" from scripts/dmg.sh.
+  url "https://github.com/raullenchai/Rapid-MLX/releases/download/rapid-mac-v#{version}/rapid-mlx-desktop.dmg",
+      verified: "github.com/raullenchai/Rapid-MLX/"
   name "Rapid-MLX"
   desc "Native SwiftUI Mac client for rapid-mlx local inference"
   homepage "https://rapidmlx.com/"

--- a/apps/rapid-mac/LICENSE
+++ b/apps/rapid-mac/LICENSE
@@ -1,55 +1,209 @@
-Rapid Desktop — End User License Agreement
-Copyright (c) 2026 MachineFi. All rights reserved.
+Rapid-MLX Desktop
+Copyright 2026 MachineFi Inc.
 
-This software ("Rapid", "the App") is licensed, not sold, to you by
-MachineFi under the terms below.
+Licensed under the Apache License, Version 2.0 (the "License"); you may not
+use this software except in compliance with the License. The full license
+text follows; you may also obtain a copy at
+http://www.apache.org/licenses/LICENSE-2.0
 
-1. Grant of License. MachineFi grants you a non-exclusive,
-   non-transferable, revocable license to install and use the App on
-   Apple computers you own or control, including in commercial and
-   workplace settings. No separate license or registration is required
-   for use inside a company, team, or organization. This matches the
-   permissive end-user pattern adopted by LM Studio and similar local-AI
-   tooling so a team can simply install and use the App at work.
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-2. Restrictions. You may not:
-   * redistribute, sell, rent, lease, sublicense, or otherwise transfer
-     the App or any portion of it to a third party
-   * reverse-engineer, decompile, disassemble, or attempt to derive the
-     source code of the App, except to the extent permitted by law
-   * remove or alter any proprietary notices in or on the App
-   * use the App in any application or context that violates applicable
-     law
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-3. Ownership. The App and all intellectual property rights in and to
-   the App remain the exclusive property of MachineFi. This agreement
-   does not transfer any ownership rights to you.
+   1. Definitions.
 
-4. Third-Party Components. The App incorporates open-source components
-   licensed by their respective copyright holders under permissive
-   licenses (Apache 2.0, MIT, BSD). See THIRD_PARTY.md for the full
-   list and license texts.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
 
-5. No Warranty. THE APP IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
-   KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
-   OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND
-   NON-INFRINGEMENT.
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
 
-6. Limitation of Liability. TO THE MAXIMUM EXTENT PERMITTED BY
-   APPLICABLE LAW, IN NO EVENT SHALL MACHINEFI BE LIABLE FOR ANY
-   INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, OR PUNITIVE DAMAGES
-   ARISING OUT OF OR RELATING TO YOUR USE OF THE APP.
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
 
-7. Termination. This license is effective until terminated. It will
-   terminate automatically without notice if you fail to comply with
-   any term. Upon termination you must cease all use of the App and
-   destroy all copies.
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
 
-8. Privacy. The App's data handling is described in PRIVACY.md. By
-   using the App you agree to the data practices described there.
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
 
-9. Governing Law. This agreement is governed by the laws of the
-   jurisdiction in which MachineFi is registered, without regard to
-   conflict-of-laws principles.
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
 
-For questions, contact: legal@machinefi.com
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/apps/rapid-mac/PRIVACY.md
+++ b/apps/rapid-mac/PRIVACY.md
@@ -228,7 +228,7 @@ distributions are out of scope but we will help triage.
     73WQ7ZGSWC"`, so a DMG signed by a *different* valid Developer
     ID team could also pass) is closed in practice by the HTTPS
     host-allowlist above and tracked by
-    [issue #16](https://github.com/machinefi/rapid-desktop/issues/16)
+    [issue #16](https://github.com/raullenchai/Rapid-MLX/issues/16)
     for permanent fix via Sparkle's EdDSA appcast signing.
   * **No per-artifact SHA-256 enforcement yet.** The worker v1
     schema does not surface one; worker v2 (planned) will add
@@ -236,7 +236,7 @@ distributions are out of scope but we will help triage.
     enforcing it as a one-line wiring change.
   * **Sparkle with EdDSA per-artifact signature verification is on
     the roadmap** as
-    [issue #16](https://github.com/machinefi/rapid-desktop/issues/16).
+    [issue #16](https://github.com/raullenchai/Rapid-MLX/issues/16).
     Migration triggers (per the issue) are concrete operational
     signals — telemetry showing repeat update failures, user-reported
     silent misses, or a need for delta updates / staged rollout — not
@@ -247,7 +247,7 @@ distributions are out of scope but we will help triage.
 
   If you want to side-step the in-app installer entirely you can
   download the DMG from the
-  [GitHub Releases page](https://github.com/machinefi/rapid-desktop/releases/latest)
+  [GitHub Releases page](https://github.com/raullenchai/Rapid-MLX/releases/latest)
   and verify its origin yourself before installing.
 * **Tool providers you configure** — when you call a search / file /
   web tool, your prompt content is sent directly to that provider

--- a/apps/rapid-mac/README.md
+++ b/apps/rapid-mac/README.md
@@ -1,30 +1,63 @@
-# rapid-desktop
+# Rapid-MLX Desktop
 
-Native SwiftUI Mac client for [rapid-mlx](https://github.com/raullenchai/Rapid-MLX).
-Local-first inference with a ChatGPT-Desktop / Ollama feel — Apple Silicon,
-your weights, your prompts, your data.
+A native SwiftUI Mac app for local LLMs, built on
+[rapid-mlx](https://github.com/raullenchai/Rapid-MLX). It bundles the
+inference engine as a sidecar — no separate install, no Python to manage —
+and gives you a ChatGPT / Ollama-style experience that runs entirely on your
+Apple-Silicon Mac. Your weights, your prompts, your data, on device.
 
-## Status
-
-v0.5.16 (current). The SwiftUI surface is the only shipped client.
-The Tauri v0.1.13 build is archived on branch
-[`archive/tauri-v0.1`](https://github.com/machinefi/rapid-desktop/tree/archive/tauri-v0.1).
-
-Closed-source — see [LICENSE](LICENSE). Free for personal AND commercial use
-inside a company, team, or organization (no separate license required).
+Open source (Apache-2.0), part of the [`raullenchai/Rapid-MLX`](https://github.com/raullenchai/Rapid-MLX)
+monorepo.
 
 ## Install
 
 ```bash
-brew tap machinefi/tap
-brew install --cask rapid-desktop
+brew tap raullenchai/tap
+brew install --cask rapid-mlx
 ```
 
-Or download the latest signed + notarised `.dmg` directly from
-[GitHub Releases](https://github.com/machinefi/rapid-desktop/releases/latest).
-The Homebrew Cask manifest lives at
-[`Casks/rapid-desktop.rb`](Casks/rapid-desktop.rb) — see
-[`Casks/README.md`](Casks/README.md) for the publish flow.
+Or download the latest signed + notarised `.dmg` from
+[GitHub Releases](https://github.com/raullenchai/Rapid-MLX/releases?q=rapid-mac).
+The Homebrew Cask manifest lives at [`Casks/rapid-mlx.rb`](Casks/rapid-mlx.rb) —
+see [`Casks/README.md`](Casks/README.md) for the publish flow.
+
+## What it does
+
+- **Chat, local-first.** Streaming responses with a `thinking` / `content`
+  split for reasoning models (Qwen 3.5 / 3.6, GLM 4.7, DeepSeek V4). Markdown
+  and code rendering, copy-as-markdown, copy-code.
+- **Zero-friction model lifecycle.** Pick a model in the composer and it
+  starts on your first message — no start/stop buttons. Download models from
+  the picker (cached vs. all, per-alias size + memory hints) and switch
+  freely.
+- **Speed on this Mac.** A one-tap benchmark of the model on your hardware
+  that you can optionally submit to the community leaderboard.
+- **Connect your tools.** The bundled server speaks the OpenAI and Anthropic
+  wire formats on `127.0.0.1`, so any editor or agent that accepts a custom
+  base URL can use your local model for free. The Launch section gives you
+  copy-paste config per tool.
+- **Conversation history.** A sidebar of past chats, persisted privately on
+  device (owner-only permissions), with a fresh "New chat" a click away.
+- **Bundled engine.** The `rapid-mlx` engine ships inside the app as a
+  sidecar; the app spawns and supervises it, reaps it cleanly on quit, and
+  surfaces Downloading / Preparing / Warming-up phases so a slow first load
+  never looks like a crash.
+
+## Privacy
+
+- **Opt-in telemetry.** Off until you accept on first run, toggleable in
+  Settings → Privacy. Events go to `telemetry.rapidmlx.com` (a Cloudflare
+  Worker → R2) under one shared anonymous client ID so the app and the
+  embedded engine never double-count an install. Paths are PII-redacted
+  (`/Users/<name>/` scrubbed); chat content and attachments are never sent.
+- **Self-update.** On launch and every 6 hours the app checks
+  `https://rapidmlx.com/api/desktop-update?v=<app-version>`. The only value
+  sent is the app version; the Worker keeps aggregate version/country counts
+  and never stores the IP. Opt out with `RAPIDMLX_NO_UPDATE_CHECK=1` or
+  `DO_NOT_TRACK=1`.
+
+See [PRIVACY.md](PRIVACY.md) for the full field list, reset behavior, and
+retention.
 
 ## Build from source
 
@@ -33,188 +66,54 @@ bash scripts/build.sh
 open "build/Rapid-MLX Desktop.app"
 ```
 
-Requires Xcode 16 / Swift 6.0 (macOS 14+). Production releases are signed +
-notarised via `.github/workflows/release.yml`.
+`build.sh` compiles the SwiftUI executable and bundles the `rapid-mlx`
+sidecar (a python-build-standalone CPython + the engine + its deps) into
+`Contents/Resources/rapid-mlx/`. Set `SKIP_SIDECAR=1` for a fast dev build
+without the ~5–10 min sidecar step. Requires a recent Swift toolchain on
+macOS 14+.
 
-To enable in-app Sentry Feedback in a local app bundle, provide the public
-project DSN while building:
-
-```bash
-SENTRY_DSN='https://98bf167a934acfa87a2a45f048b57991@o512435.ingest.us.sentry.io/4511811466428416' bash scripts/build.sh
-```
-
-`swift run` reads the same environment variable at runtime. Release builds
-inject it from the `SENTRY_DSN` GitHub Actions secret into the app's
-`Info.plist`.
-
-## Features
-
-### Chat
-- SSE streaming with hybrid `thinking` / `content` split for
-  Qwen 3.5 / 3.6 + GLM 4.7 + DeepSeek V4.
-- Tool-calling end-to-end (calculator, datetime, weather, filesystem,
-  web_search). User-visible permission prompts; Keychain-stored API keys.
-- Markdown + code-block syntax highlighting, copy-as-markdown,
-  copy code block, copy plain.
-- Bidi / control-character sanitisation on every transcript + pasteboard
-  surface (audit batch 11).
-
-### Sessions
-- Sidebar with pin, rename, fork (branching), delete, multi-select,
-  export to `.md`.
-- Cmd+1..9 quick switch, ChatGPT-style date grouping, in-session search.
-- Atomic JSON persistence with serialised concurrent-write chain
-  (audit batch 5).
-
-### Server lifecycle
-- Auto-spawn `rapid-mlx serve`, surfaces Downloading / Preparing /
-  WarmingUp phases distinctly so users don't think a slow model load
-  is a crash.
-- Loopback-only readiness probe — `ServerManager` polls
-  `http://127.0.0.1:<port>/healthz` on the same loopback the spawned
-  child binds to. No auth gate today; per-launch token + Bearer
-  enforcement on `/v1/chat/completions` is tracked under
-  [issue #17](https://github.com/machinefi/rapid-desktop/issues/17)
-  (cross-repo, needs a coordinated `rapid-mlx` CLI change).
-- Background `rapid-mlx pull` downloads — fetch a new model while another
-  keeps serving.
-
-### Quick Ask
-- ⌥+Space global floating panel (Alfred / Raycast / ChatGPT-Desktop
-  pattern), user-rebindable.
-- Carbon `RegisterEventHotKey` with explicit `EventHotKeyID` verification
-  (audit batch 7).
-
-### Model picker
-- Cached vs. all aliases, green-dot for downloaded, per-alias size +
-  memory hint, recent-aliases shortcut.
-- Bounded-deletion contract: canonical-path + hard-prefix check before
-  `removeItem`; no rm-rf-on-edge-case (audit batch 10).
-
-### Attachments
-- Image (multimodal models) + text-file (any model).
-- MIME-sniff gate so a renamed `.html` can't ride into the multimodal
-  payload as `data:image/...` (audit batch 12).
-
-### Sampling
-- Temperature, top_p, top_k, repetition_penalty knobs.
-- Per-model presets driven by `rapid-mlx`'s recommended_sampling.
-- Out-of-range / NaN clamping on both load and write (audit batch 12).
-
-### Self-update
-- Polls `https://rapidmlx.com/api/desktop-update?v=<app-version>` on
-  launch and every 6 hours — a CF Worker returning the same release
-  manifest as the R2 object, which also counts the poll as an aggregate
-  active-install signal. The **only** data sent is the app version;
-  the Worker keeps aggregate version/country counts and never stores
-  the IP. Opt out with `RAPIDMLX_NO_UPDATE_CHECK=1` or `DO_NOT_TRACK=1`
-  (skips the request entirely). See [PRIVACY.md](PRIVACY.md).
-- Host-allowlist on every "Update available" CTA so a compromised
-  manifest can't redirect the DMG download to phishing (audit batch 2).
-- Sparkle migration on the roadmap ([#16](https://github.com/machinefi/rapid-desktop/issues/16)).
-
-### Telemetry (opt-in)
-- Explicit first-run choice; telemetry stays off until accepted and remains
-  toggleable in Settings → Privacy.
-- Desktop `session_start` + `error` and embedded-engine
-  `session_start` / `session_end` / sampled `request` / `error` events go to
-  `telemetry.rapidmlx.com` (Cloudflare Worker → R2) under one shared anonymous
-  client ID, so the app and sidecar do not double-count an install.
-- PII-redacted paths (`/Users/<name>/` scrubbed), 256 KB body cap,
-  redirect-free ephemeral URLSession, no-cookie, 4xx classified as
-  permanent (no retry-forever) (audit batch 8).
-- See [PRIVACY.md](PRIVACY.md) for the field list, reset behavior, and raw-data
-  retention.
-
-### Crash reporting
-- `NSException` + signal handlers write per-launch markers to
-  `~/Library/Application Support/Rapid/crash-markers/` (0600 perms).
-- Next launch flushes them as `error` events; permanent 4xx response
-  retires the marker, transient 5xx + network errors keep it for retry.
-
-### Feedback
-- Help and menu-bar entries open a native macOS feedback form for bug reports
-  and feature requests.
-- User-submitted text, optional email, and standard Sentry app/device context
-  are sent through Sentry. This context includes app, macOS, hardware, memory,
-  processor, power/thermal, locale, and time-zone details. Chat content and
-  attachments are never included.
-- Sentry's automatic crash, performance, session, metric, and breadcrumb
-  collection is disabled; the existing first-party crash pipeline remains the
-  only automatic diagnostics path.
-
-## Smoke test
+## Test
 
 ```bash
-bash scripts/smoke.sh
+bash scripts/smoke.sh      # fast end-to-end smoke against a fake rapid-mlx
+swift test                 # unit + snapshot suite
 ```
-
-`swift test` (~720 cases — DownloadProgress, UpdateChecker,
-SessionStore, ChatStreamClient SSE, sandbox + canonical-path contracts,
-audit-batch contracts, snapshot tests) + chat lifecycle against a fake
-`rapid-mlx`, end-to-end in under 15 s.
-
-## Release-smoke gate
-
-```bash
-bash scripts/release-smoke.sh
-```
-
-Catches v0.5.9-class ship-blockers (SPM `Bundle.module` accessor crashing
-inside the wrapped `.app` on first SwiftUI body read). Mandatory before
-tagging a release. Verifies every PNG declared in `Package.swift`
-resolves via `Bundle.main.url(forResource:)` against the assembled
-bundle, then `open`s the app, waits 15 s, and asserts a substantial
-layer-0 window owned by the launched PID actually rendered via
-`CGWindowListCopyWindowInfo`. Exit codes: 0 pass, 1 scene never
-rendered, 2 resource verification failed pre-launch.
 
 ## Architecture
 
 ```
 RapidApp (SwiftUI Scene root)
-├── ContentView                  — server state gating + chat surface
-│   ├── SessionsSidebar          — NavigationSplitView left pane
-│   ├── ModelPickerBar           — header alias picker + status badge
-│   └── ChatView                 — assistant / user bubbles + compose bar
-├── QuickAskPanel                — ⌥+Space NSPanel host
-├── Settings                     — sidebar tabs (NavigationSplitView,
-│                                        not the system Settings strip):
-│                                        Tools / Web Search / Sampling /
-│                                        Appearance / Quick Ask /
-│                                        Keyboard / Privacy / rapid-mlx
-└── MenuBarExtra                 — tray icon + update CTA + Quit
+├── ContentView              — NavigationSplitView: sidebar + detail
+│   ├── SidebarView          — New Chat · Launch · conversation history
+│   ├── ChatView             — single-column transcript + compose box
+│   │   └── ModelPickerBar   — inline model picker (implicit lifecycle)
+│   └── ConnectToolsView     — "Launch": copy-paste tool configs
+└── MenuBarExtra             — tray icon + update CTA + Quit
 ```
 
-State holders are `@Observable` classes injected via SwiftUI `environment`:
-`ServerManager`, `SessionStore`, `ChatViewModel`, `DownloadManager`,
-`SandboxManager`, `UpdateChecker`, `Installer`, `CLIVersionChecker`,
-`SamplingConfig`, `AppearanceConfig`, `OnboardingState`, `SettingsRouter`,
-`WebSearchConfig`, `QuickAskController`, `QuickAskConfig`, `LaunchAtLogin`.
-`BuiltinToolRegistry` is a plain `final class` (NOT `@Observable`) — only
-its `sandbox` child is injected. `DownloadProgress` is `@Observable` but
-owned by `DownloadManager` rather than injected directly into the env.
+State holders are `@Observable` classes injected via SwiftUI `environment`
+(`ServerManager`, `ChatViewModel`, `DownloadManager`, `QuickstartCoordinator`,
+`SamplingConfig`, `AppearanceConfig`, `SettingsRouter`, `UpdateChecker`,
+`Installer`, …). The bundled sidecar is resolved by `ServerLocator`
+(`RAPID_BIN` override → app-managed runtime-override → the bundled engine).
 
 ## Releasing
 
-Pushing a `v*` tag triggers `.github/workflows/release.yml`:
+Pushing a `rapid-mac-v*` tag triggers
+[`.github/workflows/rapid-mac-release.yml`](../../.github/workflows/rapid-mac-release.yml):
 
 1. Imports the `Developer ID Application` certificate into a temp keychain
-2. `bash scripts/build.sh` → `build/Rapid-MLX Desktop.app`
-3. `codesign --options runtime --timestamp` with hardened runtime
-4. `scripts/dmg.sh` → `rapid-mlx-desktop.dmg`
-5. `xcrun notarytool submit` via App Store Connect API key
-6. `xcrun stapler staple` on both `.app` and `.dmg`
-7. Attaches `rapid-mlx-desktop.dmg` to the GitHub Release (the R2 mirror
-   step in `release.yml` additionally publishes the legacy alias `Rapid.dmg` so pre-v0.5.22 inbound links continue to resolve)
+2. `bash scripts/build.sh` → `build/Rapid-MLX Desktop.app` (signed, hardened runtime)
+3. `xcrun notarytool submit` via the App Store Connect API key
+4. `xcrun stapler staple` on the `.app`
+5. `bash scripts/dmg.sh` → `rapid-mlx-desktop.dmg`, notarised + stapled
+6. Attaches the `.dmg` to the GitHub Release for the tag
 
-Required repo secrets:
-`MACOS_DEVID_CERT_P12_BASE64`, `MACOS_DEVID_CERT_PASSWORD`,
-`APPLE_TEAM_ID`, `AC_API_KEY_ID`, `AC_API_ISSUER_ID`,
-`AC_API_KEY_P8_BASE64`.
-
-`workflow_dispatch` does the same build but uploads as a workflow
-artifact (no release) for dry-runs.
+Required repo secrets: `MACOS_DEVID_CERT_P12_BASE64`,
+`MACOS_DEVID_CERT_PASSWORD`, `APPLE_TEAM_ID`, `AC_API_KEY_ID`,
+`AC_API_ISSUER_ID`, `AC_API_KEY_P8_BASE64` (see [RELEASING.md](RELEASING.md)).
+`workflow_dispatch` runs the same build but uploads a workflow artifact
+(no Release) for signing dry-runs.
 
 ## Security
 
@@ -222,5 +121,5 @@ Reporting a vulnerability: see [SECURITY.md](SECURITY.md).
 
 ## License
 
-Closed-source — see [LICENSE](LICENSE).
+Apache-2.0 — see [LICENSE](LICENSE).
 Third-party components: [THIRD_PARTY.md](THIRD_PARTY.md).

--- a/apps/rapid-mac/RELEASING-LOCAL.md
+++ b/apps/rapid-mac/RELEASING-LOCAL.md
@@ -1,11 +1,11 @@
-# Releasing rapid-desktop: local dogfood + CI for public
+# Releasing Rapid-MLX Desktop: local dogfood + CI for public
 
 Two lanes, split by **who the build is for**. The expensive, frequent case
 (dogfood) runs on your Mac for $0; the rare, user-facing case (public) runs
 on GitHub CI, which owns the distribution layer (auto-update + landing page).
 
 ```
-                        rapid-desktop release
+                  Rapid-MLX Desktop release
                               │
                  ┌────────────┴─────────────┐
                  │  who is this build for?   │

--- a/apps/rapid-mac/RELEASING.md
+++ b/apps/rapid-mac/RELEASING.md
@@ -209,10 +209,9 @@ gh run watch $(gh run list --workflow=rapid-mac-release.yml --limit=1 --json dat
 
 ## Open TODO(owner) items
 
-- **Release/tap repo owner is unresolved** (`masonjames/Rapid-MLX` vs
-  `raullenchai/Rapid-MLX`). `Casks/rapid-mlx.rb` and `Casks/README.md` carry
-  `OWNER` placeholders; the release-local `--publish` lane pushes to whatever
-  `origin` points at.
+- **Release/tap repo owner is `raullenchai`** (`raullenchai/Rapid-MLX`).
+  `Casks/rapid-mlx.rb` and `Casks/README.md` use this owner; the
+  release-local `--publish` lane pushes to whatever `origin` points at.
 - **CDN mirror infra** (`RAPID_MAC_DIST_R2_BUCKET` / `RAPID_MAC_DIST_CDN_BASE`
   + Cloudflare secrets) only needs provisioning if you want a stable
   non-GitHub download URL. Optional.

--- a/apps/rapid-mac/SECURITY.md
+++ b/apps/rapid-mac/SECURITY.md
@@ -24,7 +24,7 @@ severity, 4 weeks for low severity).
 ## Supported versions
 
 The latest minor release on the
-[releases page](https://github.com/machinefi/rapid-desktop/releases/latest)
+[releases page](https://github.com/raullenchai/Rapid-MLX/releases/latest)
 is the only version receiving security updates. We do not backport
 fixes to older versions; please upgrade.
 

--- a/apps/rapid-mac/Sources/Rapid/UI/ConnectToolsView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ConnectToolsView.swift
@@ -17,6 +17,12 @@ struct ConnectToolsView: View {
     let bearer: String
     let alias: String
     var onClose: () -> Void
+    /// Whether to render the top-right dismiss "✕". True in sheet context
+    /// (the caller's ``onClose`` dismisses the sheet). False when embedded
+    /// as a navigation PAGE (the Launch sidebar section), where there is no
+    /// sheet to dismiss — showing a dead ✕ that does nothing was a real
+    /// papercut. The sidebar owns navigation, so it passes false.
+    var showsCloseButton: Bool = true
 
     private var openAIBaseURL: String { "http://\(host):\(port)/v1" }
     private var anthropicBaseURL: String { "http://\(host):\(port)" }
@@ -59,15 +65,17 @@ struct ConnectToolsView: View {
                     .fixedSize(horizontal: false, vertical: true)
             }
             Spacer()
-            Button {
-                onClose()
-            } label: {
-                Image(systemName: "xmark.circle.fill")
-                    .font(.title2)
-                    .foregroundStyle(.tertiary)
+            if showsCloseButton {
+                Button {
+                    onClose()
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .font(.title2)
+                        .foregroundStyle(.tertiary)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Close")
             }
-            .buttonStyle(.plain)
-            .accessibilityLabel("Close")
         }
         .padding(20)
     }

--- a/apps/rapid-mac/Sources/Rapid/UI/SidebarView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SidebarView.swift
@@ -128,11 +128,12 @@ struct LaunchView: View {
             port: server.activePort,
             bearer: server.activeBearer ?? "",
             alias: alias,
-            // In page context the close affordance isn't shown as a sheet
-            // dismissal; ConnectToolsView still renders its X — wire it to
-            // nothing here (the sidebar owns navigation). A dedicated
-            // page-mode header lands with the #1405 Launch redesign.
-            onClose: {}
+            // Page context: the sidebar owns navigation, so there is no sheet
+            // to dismiss. Hide the close ✕ (it used to render as a dead
+            // no-op button). A dedicated page-mode header lands with the
+            // #1405 Launch redesign.
+            onClose: {},
+            showsCloseButton: false
         )
     }
 }

--- a/apps/rapid-mac/THIRD_PARTY.md
+++ b/apps/rapid-mac/THIRD_PARTY.md
@@ -1,6 +1,6 @@
-# Rapid Desktop — Third-Party Acknowledgements
+# Rapid-MLX Desktop — Third-Party Acknowledgements
 
-Rapid Desktop incorporates open-source software from the following
+Rapid-MLX Desktop incorporates open-source software from the following
 projects. Each is used under the terms of its original license. The
 full license texts are reproduced in the linked repositories.
 
@@ -23,7 +23,7 @@ full license texts are reproduced in the linked repositories.
   Delivery of feedback that a user explicitly submits from the app.
 
 _Sparkle is on the roadmap as the eventual auto-update framework
-(see [issue #16](https://github.com/machinefi/rapid-desktop/issues/16))
+(see [issue #16](https://github.com/raullenchai/Rapid-MLX/issues/16))
 but is not bundled in the current release stream. The shipped
 updater is the in-tree `Sources/Rapid/Updater/UpdateChecker.swift`
 + `Installer.swift` pair, which polls a Cloudflare Worker proxy of
@@ -39,13 +39,13 @@ Sparkle once it actually lands in `Package.resolved`._
 
 ## Server dependencies (informational)
 
-The `rapid-mlx` server that Rapid Desktop talks to is a separate
+The `rapid-mlx` server that Rapid-MLX Desktop talks to is a separate
 project licensed under Apache 2.0:
 https://github.com/raullenchai/Rapid-MLX
 
 It in turn vendors mlx-lm, mlx-vlm, and openai-harmony — each under
 their respective Apache 2.0 / MIT licenses. Those are NOT bundled
-inside Rapid Desktop and are installed separately via `pip` /
+inside Rapid-MLX Desktop and are installed separately via `pip` /
 `pipx` / `brew`.
 
 For the complete machine-readable resolution of pinned versions,


### PR DESCRIPTION
## Why
Repo/website tidy ahead of the **0.12.0 internal release**. The rapid-mac app was ported from the closed `rapid-desktop` repo and still carried its branding, a contradictory closed EULA (in an Apache-2.0 public repo), a README describing removed features, a literally-broken cask install URL, and a dead ✕ on the Launch page.

## What
**Branding** (product = *Rapid-MLX Desktop*; public repo = `raullenchai/Rapid-MLX`):
- **LICENSE** → Apache-2.0 (matches repo root + engine), © 2026 MachineFi Inc. — was a closed "All rights reserved" MachineFi EULA.
- **README** → full rewrite for the actual Ollama-style app (old one described removed Sentry/QuickAsk/SessionStore); correct install (`raullenchai/tap`, `rapid-mlx` cask), releasing (`rapid-mac-release.yml`, `rapid-mac-v*`), and links.
- **Cask + docs** → resolve `OWNER` placeholder to `raullenchai` (the cask `url` was broken), fix `machinefi/rapid-desktop` → `raullenchai/Rapid-MLX` links across PRIVACY/SECURITY/THIRD_PARTY/RELEASING/RELEASING-LOCAL/Casks.

**Launch page**: `ConnectToolsView` gains `showsCloseButton`; the Launch sidebar section passes `false` so it no longer renders a dead no-op ✕.

## Deliberately kept
Per product decision: `@machinefi.com` contact emails + `MachineFi Inc.` copyright (the signing entity), and the telemetry `app:` id / User-Agent `rapid-desktop` (metric continuity on the telemetry worker). CHANGELOG history untouched.

## Not included (tracked separately)
Version bump to 0.12.0 (app version derives from the engine `pyproject.toml`; coordinated with the engine cut). Sidecar prefix-cache desktop cap: #1412.

Verified: `swift build -c release` compiles the Launch-page change.