### PR TITLE
test(deepseek): add progressive context soak harness

### DIFF
--- a/docs/plans/deepseek-v4-codex-stability.md
+++ b/docs/plans/deepseek-v4-codex-stability.md
@@ -1,0 +1,115 @@
+# DeepSeek V4 Codex stability plan
+
+This document tracks the work required to make DeepSeek-V4-Flash-0731 a
+reliable Codex engineering backend before speculative decoding is enabled for
+coding workloads.
+
+## Current baseline
+
+- A real implementation of GitHub issue #707 completed without a repetition
+  reconnect. The run used roughly 12 tool rounds, grew to a 17K-token prompt,
+  recovered from two genuine test failures, and produced a reviewable patch.
+- Independent validation passed 61 related tests (with one existing XPASS),
+  Ruff, and `git diff --check`.
+- The Rapid-MLX Codex/repetition/tool-call regression slice passes 194 tests.
+- DeepSeek Codex requests use a low-entropy stochastic default when the client
+  does not explicitly choose a temperature. This is currently the correctness
+  baseline.
+- Greedy DSpark is not part of the baseline: it improves decode performance,
+  but has reproduced deterministic malformed tool arguments.
+
+## Workstream boundaries
+
+### Stability baseline
+
+- Responses API event ordering and terminal failure envelopes
+- DeepSeek DSML schema canonicalization and tool-call validation
+- reasoning/think-tag containment
+- repetition detection and recovery
+- Codex action/progress guidance
+- disconnect and abort semantics
+
+Primary files include `routes/responses.py`, `service/helpers.py`,
+`repetition_guard.py`, `output_collector.py`, the DeepSeek tool parser, and
+their focused tests.
+
+### Long-context correctness and memory
+
+- prefix-boundary parity
+- pooling-cache trimming and rollback invariants
+- adaptive prefill and process-memory guards
+- progressive context soak tooling
+- safe recovery from Metal allocation failures
+
+Primary files include `deepseek_v4_cache.py`, `engine/batched.py`,
+`engine_core.py`, the non-speculative portions of `scheduler.py`, and the
+progressive-context tests and script.
+
+### Performance experiments (gated off for Codex)
+
+- stochastic DSpark verification and rollback
+- adaptive speculative depth
+- multi-row QMV verification
+- DeepSeek verify-attention kernels
+- switch/attention kernel experiments
+
+Primary files include `deepseek_v4_verify*.py`,
+`deepseek_v4_rollback.py`, speculative sections of `deepseek_v4.py` and
+`scheduler.py`, and `test_dspark_scheduler.py`.
+
+Performance work must remain eligible for an immediate baseline fallback. It
+must not become the implicit Codex path until every stability gate below is
+green.
+
+## Stability gates
+
+### Gate S0: deterministic regression suite
+
+- all focused Responses, parser, tool validation, repetition, and DeepSeek
+  scheduler tests pass
+- no lint errors or whitespace errors
+- explicit sampling parameters continue to override server defaults
+
+### Gate S1: medium real engineering task
+
+- 60–120 minutes or at least 30 tool rounds
+- natural context growth to at least 50K tokens
+- changes span at least five production/test files
+- at least one real failing test is diagnosed and fixed
+- zero repetition reconnects
+- zero malformed tool calls
+- no unchanged failing command is repeatedly executed
+- final patch passes independent review and focused regression tests
+
+### Gate S2: long progressive-context task
+
+- natural context growth to 150K–250K tokens
+- prefix-cache reuse across normal Codex turns
+- no Metal resource-limit failure or silent request truncation
+- zero repetition reconnects and malformed tool calls
+- successful compact/resume or equivalent long-session boundary test
+
+### Gate P1: performance reintroduction
+
+Starting from the S2 baseline, enable one optimization at a time:
+
+1. stochastic DSpark correctness
+2. prompt priming and exact rollback
+3. adaptive speculative depth
+4. multi-row QMV
+5. long-context cache/kernel optimizations
+
+Each step must replay the same engineering workload and preserve S0–S2. Raw
+decode throughput, end-to-end tool-round latency, TTFT, acceptance depth,
+fallback count, and memory peak must all be recorded. A faster result that
+reduces task success or tool-call correctness is rejected.
+
+## Immediate execution order
+
+1. Split and validate the stability baseline independently from speculative
+   performance code.
+2. Select a medium, cross-file Rapid-MLX issue and run Gate S1 against the
+   local-wheel server.
+3. Review and fix every failure exposed by S1, then repeat until clean.
+4. Run Gate S2 with progressively growing context.
+5. Freeze the stable configuration and begin P1 experiments.

--- a/scripts/progressive_context_soak.py
+++ b/scripts/progressive_context_soak.py
@@ -83,6 +83,7 @@ def run_turn(
     first_token_at = None
     output_parts: list[str] = []
     usage = (0, 0)
+    completed = False
     with client.stream(
         "POST", f"{url}/responses", json=payload, timeout=timeout
     ) as resp:
@@ -91,6 +92,11 @@ def run_turn(
             if not line.startswith("data: ") or line == "data: [DONE]":
                 continue
             event = json.loads(line[6:])
+            event_type = event.get("type")
+            if event_type in {"response.failed", "error"}:
+                raise RuntimeError(f"response stream failed: {event!r}")
+            if event_type == "response.completed":
+                completed = True
             delta = event.get("delta")
             if isinstance(delta, str) and delta:
                 if first_token_at is None:
@@ -99,6 +105,10 @@ def run_turn(
             found_usage = _extract_usage(event)
             if found_usage is not None:
                 usage = found_usage
+    if not completed:
+        raise RuntimeError("response stream ended without response.completed")
+    if usage[0] <= 0:
+        raise RuntimeError(f"response completed without valid input usage: {usage!r}")
     end = time.perf_counter()
     text = "".join(output_parts)
     return (
@@ -127,7 +137,11 @@ def main() -> int:
     args = parser.parse_args()
 
     stages = [int(x) for x in args.stages.split(",") if x.strip()]
-    if not stages or stages != sorted(stages) or stages[0] <= 0:
+    if (
+        not stages
+        or stages[0] <= 0
+        or any(current <= previous for previous, current in zip(stages, stages[1:]))
+    ):
         parser.error("--stages must be positive, ascending comma-separated integers")
 
     items: list[dict] = [
@@ -184,7 +198,7 @@ def main() -> int:
                     ),
                 }
             ]
-            compact_result, _ = run_turn(
+            compact_result, compact_output = run_turn(
                 client,
                 url=args.url,
                 model=args.model,
@@ -195,6 +209,11 @@ def main() -> int:
             compact_result.target_tokens = 0
             results.append(compact_result)
             print(json.dumps({"compact": asdict(compact_result)}, sort_keys=True))
+            normalized = compact_output.strip().rstrip(".! ").casefold()
+            if normalized != "ok":
+                raise RuntimeError(
+                    f"compact/resume returned unexpected output: {compact_output!r}"
+                )
 
     report = {
         "results": [asdict(r) for r in results],
@@ -205,7 +224,7 @@ def main() -> int:
     if args.json_out:
         with open(args.json_out, "w", encoding="utf-8") as handle:
             json.dump(report, handle, indent=2, sort_keys=True)
-    return 0
+    return 0 if report["passed"] else 1
 
 
 if __name__ == "__main__":

--- a/scripts/progressive_context_soak.py
+++ b/scripts/progressive_context_soak.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""Grow one OpenAI Responses conversation like a long-running Codex session.
+
+Unlike a synthetic single-shot long prompt, this sends the full conversation on
+every turn while adding only a small suffix. A healthy prefix cache should make
+prefill work proportional to the suffix, not to the total context.
+
+Example:
+  .venv/bin/python scripts/progressive_context_soak.py \
+    --url http://127.0.0.1:8000/v1 --model deepseek-v4-flash-0731 \
+    --stages 32000,64000,128000,200000,300000 --compact
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import time
+from dataclasses import asdict, dataclass
+
+import httpx
+
+
+@dataclass
+class TurnResult:
+    target_tokens: int
+    prompt_tokens: int
+    completion_tokens: int
+    ttft_seconds: float
+    elapsed_seconds: float
+    output_chars: int
+    repetition_period: int | None
+
+
+def repetition_period(text: str, *, repeats: int = 3, max_period: int = 512) -> int | None:
+    """Return a repeated tail period, matching the failure Codex reconnects on."""
+    if not text:
+        return None
+    limit = min(max_period, len(text) // repeats)
+    for period in range(1, limit + 1):
+        tail = text[-period:]
+        if text.endswith(tail * repeats):
+            return period
+    return None
+
+
+def padding_for_tokens(needed: int) -> str:
+    # A leading-space common word is one token in the DeepSeek tokenizer. The
+    # usage feedback loop corrects any tokenizer-specific error on later turns.
+    return " context" * max(0, needed)
+
+
+def _extract_usage(event: dict) -> tuple[int, int] | None:
+    response = event.get("response") or event
+    usage = response.get("usage") if isinstance(response, dict) else None
+    if not isinstance(usage, dict):
+        return None
+    prompt = usage.get("input_tokens", usage.get("prompt_tokens", 0))
+    completion = usage.get("output_tokens", usage.get("completion_tokens", 0))
+    return int(prompt or 0), int(completion or 0)
+
+
+def run_turn(
+    client: httpx.Client,
+    *,
+    url: str,
+    model: str,
+    items: list[dict],
+    max_output_tokens: int,
+    timeout: float,
+) -> tuple[TurnResult, str]:
+    payload = {
+        "model": model,
+        "input": items,
+        "stream": True,
+        "max_output_tokens": max_output_tokens,
+        "reasoning": {"effort": "medium"},
+    }
+    start = time.perf_counter()
+    first_token_at = None
+    output_parts: list[str] = []
+    usage = (0, 0)
+    with client.stream("POST", f"{url}/responses", json=payload, timeout=timeout) as resp:
+        resp.raise_for_status()
+        for line in resp.iter_lines():
+            if not line.startswith("data: ") or line == "data: [DONE]":
+                continue
+            event = json.loads(line[6:])
+            delta = event.get("delta")
+            if isinstance(delta, str) and delta:
+                if first_token_at is None:
+                    first_token_at = time.perf_counter()
+                output_parts.append(delta)
+            found_usage = _extract_usage(event)
+            if found_usage is not None:
+                usage = found_usage
+    end = time.perf_counter()
+    text = "".join(output_parts)
+    return (
+        TurnResult(
+            target_tokens=0,
+            prompt_tokens=usage[0],
+            completion_tokens=usage[1],
+            ttft_seconds=(first_token_at or end) - start,
+            elapsed_seconds=end - start,
+            output_chars=len(text),
+            repetition_period=repetition_period(text),
+        ),
+        text,
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--url", default="http://127.0.0.1:8000/v1")
+    parser.add_argument("--model", default="deepseek-v4-flash-0731")
+    parser.add_argument(
+        "--stages", default="32000,64000,128000,200000,300000"
+    )
+    parser.add_argument("--max-output-tokens", type=int, default=64)
+    parser.add_argument("--timeout", type=float, default=3600)
+    parser.add_argument("--compact", action="store_true")
+    parser.add_argument("--json-out")
+    args = parser.parse_args()
+
+    stages = [int(x) for x in args.stages.split(",") if x.strip()]
+    if not stages or stages != sorted(stages) or stages[0] <= 0:
+        parser.error("--stages must be positive, ascending comma-separated integers")
+
+    items: list[dict] = [
+        {
+            "role": "user",
+            "content": "We are maintaining Rapid-MLX. Preserve all prior context and reply only with a short progress checkpoint.",
+        }
+    ]
+    results: list[TurnResult] = []
+    observed_prompt_tokens = 0
+
+    with httpx.Client() as client:
+        for target in stages:
+            # The first estimate is deliberately conservative. After each turn,
+            # server-reported usage closes the loop for the next target.
+            needed = max(1, target - observed_prompt_tokens)
+            items.append(
+                {
+                    "role": "user",
+                    "content": "Append-only project evidence:\n" + padding_for_tokens(needed),
+                }
+            )
+            result, output = run_turn(
+                client,
+                url=args.url,
+                model=args.model,
+                items=items,
+                max_output_tokens=args.max_output_tokens,
+                timeout=args.timeout,
+            )
+            result.target_tokens = target
+            results.append(result)
+            observed_prompt_tokens = result.prompt_tokens
+            items.append({"role": "assistant", "content": output or "checkpoint"})
+            print(json.dumps(asdict(result), sort_keys=True), flush=True)
+            if result.repetition_period is not None:
+                raise RuntimeError(
+                    f"exact repetition loop at target {target}: "
+                    f"period={result.repetition_period}"
+                )
+
+        if args.compact:
+            # Simulate Codex compaction: replace the old branch with a concise
+            # summary, then verify the server remains healthy and memory/cache
+            # policy can age out the abandoned long branch.
+            items = [
+                {
+                    "role": "user",
+                    "content": (
+                        "Compacted project state: Rapid-MLX long-context soak "
+                        f"reached {observed_prompt_tokens} tokens successfully. "
+                        "Continue from this summary and answer with OK."
+                    ),
+                }
+            ]
+            compact_result, _ = run_turn(
+                client,
+                url=args.url,
+                model=args.model,
+                items=items,
+                max_output_tokens=16,
+                timeout=args.timeout,
+            )
+            compact_result.target_tokens = 0
+            results.append(compact_result)
+            print(json.dumps({"compact": asdict(compact_result)}, sort_keys=True))
+
+    report = {
+        "results": [asdict(r) for r in results],
+        "max_prompt_tokens": max(r.prompt_tokens for r in results),
+        "median_ttft_seconds": statistics.median(r.ttft_seconds for r in results),
+        "passed": all(r.repetition_period is None for r in results),
+    }
+    if args.json_out:
+        with open(args.json_out, "w", encoding="utf-8") as handle:
+            json.dump(report, handle, indent=2, sort_keys=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/progressive_context_soak.py
+++ b/scripts/progressive_context_soak.py
@@ -33,7 +33,9 @@ class TurnResult:
     repetition_period: int | None
 
 
-def repetition_period(text: str, *, repeats: int = 3, max_period: int = 512) -> int | None:
+def repetition_period(
+    text: str, *, repeats: int = 3, max_period: int = 512
+) -> int | None:
     """Return a repeated tail period, matching the failure Codex reconnects on."""
     if not text:
         return None
@@ -81,7 +83,9 @@ def run_turn(
     first_token_at = None
     output_parts: list[str] = []
     usage = (0, 0)
-    with client.stream("POST", f"{url}/responses", json=payload, timeout=timeout) as resp:
+    with client.stream(
+        "POST", f"{url}/responses", json=payload, timeout=timeout
+    ) as resp:
         resp.raise_for_status()
         for line in resp.iter_lines():
             if not line.startswith("data: ") or line == "data: [DONE]":
@@ -115,9 +119,7 @@ def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--url", default="http://127.0.0.1:8000/v1")
     parser.add_argument("--model", default="deepseek-v4-flash-0731")
-    parser.add_argument(
-        "--stages", default="32000,64000,128000,200000,300000"
-    )
+    parser.add_argument("--stages", default="32000,64000,128000,200000,300000")
     parser.add_argument("--max-output-tokens", type=int, default=64)
     parser.add_argument("--timeout", type=float, default=3600)
     parser.add_argument("--compact", action="store_true")
@@ -145,7 +147,8 @@ def main() -> int:
             items.append(
                 {
                     "role": "user",
-                    "content": "Append-only project evidence:\n" + padding_for_tokens(needed),
+                    "content": "Append-only project evidence:\n"
+                    + padding_for_tokens(needed),
                 }
             )
             result, output = run_turn(

--- a/tests/test_progressive_context_soak.py
+++ b/tests/test_progressive_context_soak.py
@@ -1,0 +1,22 @@
+from scripts.progressive_context_soak import _extract_usage, repetition_period
+
+
+def test_repetition_period_detects_exact_tail_loop():
+    assert repetition_period("prefix" + "abcdef" * 3) == 6
+
+
+def test_repetition_period_ignores_normal_text():
+    assert repetition_period("a normal non-repeating model response") is None
+
+
+def test_extract_usage_accepts_responses_completed_shape():
+    assert _extract_usage(
+        {"response": {"usage": {"input_tokens": 123, "output_tokens": 7}}}
+    ) == (123, 7)
+
+
+def test_extract_usage_accepts_chat_compat_names():
+    assert _extract_usage({"usage": {"prompt_tokens": 9, "completion_tokens": 2}}) == (
+        9,
+        2,
+    )


### PR DESCRIPTION
## Summary
- add a Responses API harness that grows one conversation through 32K–300K token stages
- detect exact repeated tails and record TTFT/usage per stage
- exercise compact/resume and document the Codex stability gates

## Validation
- `python -m pytest -q tests/test_progressive_context_soak.py` (4 passed)
- Ruff check and format
- `git diff --check`