### PR TITLE
feat(rapid-mac): loopback-only telemetry endpoint override for local auditing

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Telemetry/TelemetryConfig.swift
+++ b/apps/rapid-mac/Sources/Rapid/Telemetry/TelemetryConfig.swift
@@ -14,8 +14,35 @@ import Foundation
 /// specific extras (``error_type``, ``stack_frames``, ``context``)
 /// without forking the Worker.
 enum TelemetryConfig {
-    /// Where event batches POST.
-    static let endpoint = URL(string: "https://telemetry.rapidmlx.com/v1/events")!
+    /// Production endpoint. See ``endpoint`` for the (loopback-only)
+    /// developer override.
+    static let productionEndpoint = URL(string: "https://telemetry.rapidmlx.com/v1/events")!
+
+    /// Where event batches POST. Normally ``productionEndpoint``. A
+    /// developer may set ``RAPID_MLX_TELEMETRY_ENDPOINT`` to a **loopback**
+    /// URL (`http://127.0.0.1:…` / `http://localhost:…`) to point the
+    /// pipeline at a local capture server and audit exactly what the app
+    /// sends. The override is restricted to loopback + `http` so it can
+    /// never redirect a real user's telemetry to an arbitrary remote host.
+    static var endpoint: URL {
+        resolveEndpoint(environment: ProcessInfo.processInfo.environment)
+    }
+
+    /// Testable core of ``endpoint``. Honors ``RAPID_MLX_TELEMETRY_ENDPOINT``
+    /// ONLY when it parses to a loopback ``http`` URL (``127.0.0.1`` /
+    /// ``localhost``); a remote host, an ``https`` remote, or garbage all
+    /// fall back to ``productionEndpoint`` so the override can never exfil
+    /// a real user's telemetry off-box.
+    static func resolveEndpoint(environment: [String: String]) -> URL {
+        if let raw = environment["RAPID_MLX_TELEMETRY_ENDPOINT"],
+           let url = URL(string: raw),
+           url.scheme == "http",
+           let host = url.host,
+           host == "127.0.0.1" || host == "localhost" {
+            return url
+        }
+        return productionEndpoint
+    }
 
     /// Schema version the Worker requires on every event.
     static let schemaVersion = 1


### PR DESCRIPTION
## Why
`TelemetryConfig` ships one hard-coded endpoint on purpose — *"the privacy contract reduces to the code in this directory plus this one URL; users can audit it."* This makes that literally true: a developer (or a privacy-conscious user) can point the pipeline at a **local capture server** and see exactly what the app sends.

Used it this session to verify the telemetry埋点 for 0.12.0: a single launch emitted a desktop `session_start` (`app: "rapid-desktop"`) + the engine's session events, all sharing one anonymous `client_id`, **zero PII paths** — and also surfaced #1415 (the app's internal CLI probes over-firing engine sessions).

## What
Add `RAPID_MLX_TELEMETRY_ENDPOINT`, honored **only** for a loopback `http` URL (`127.0.0.1` / `localhost`). A remote host, an https-remote, or unparseable input all fall back to the production endpoint, so the override can **never exfil a real user's telemetry off-box**. `resolveEndpoint(environment:)` mirrors the existing `isEnabled(defaults:)` injection pattern.

## Verification
- `swift build -c release` — clean.
- End-to-end: captured this app's real telemetry POSTs through the hook on a local server (session_start + engine sessions, shared client_id, 0 PII).
- No unit test added — the `Tests/RapidTests` target is currently excluded from the SPM manifest (pre-existing); the security guard is documented + verified functionally.