### PR TITLE
fix(codex): bound DeepSeek engineering action priming

### DIFF
--- a/tests/test_api_models.py
+++ b/tests/test_api_models.py
@@ -583,6 +583,7 @@ class TestModelsEndpoint:
             ]
         )
         assert resp.object == "list"
+        assert resp.models == []
         assert len(resp.data) == 2
 
 

--- a/tests/test_codex_profile.py
+++ b/tests/test_codex_profile.py
@@ -59,6 +59,8 @@ def test_codex_template_renders_to_valid_toml():
     # Top-level keys Codex reads.
     assert parsed["model"] == "qwen3.6-35b-4bit"
     assert parsed["model_provider"] == "rapid-mlx"
+    assert parsed["model_context_window"] == 32768
+    assert parsed["model_catalog_json"] == "{model_catalog_path}"
     # Provider block.
     providers = parsed["model_providers"]
     assert "rapid-mlx" in providers
@@ -75,6 +77,32 @@ def test_codex_template_renders_to_valid_toml():
         "Inline `api_key` is rejected by `codex --strict-config`. "
         'If you need to ship credentials, use `env_key = "VAR_NAME"`.'
     )
+
+
+def test_codex_setup_writes_startup_static_model_catalog(monkeypatch, tmp_path):
+    import json
+
+    from vllm_mlx.agents.adapter import setup_agent_config
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    profile = get_profile("codex")
+    summary = setup_agent_config(
+        profile,
+        base_url="http://127.0.0.1:8000/v1",
+        model_id="deepseek-v4-flash-0731",
+        context_length=1_048_576,
+    )
+
+    assert "config" in summary.lower()
+    config_path = tmp_path / ".codex" / "config.toml"
+    config = tomllib.loads(config_path.read_text())
+    catalog_path = tmp_path / ".codex" / "rapid-mlx-model-catalog.json"
+    assert config["model_catalog_json"] == str(catalog_path.resolve())
+    catalog = json.loads(catalog_path.read_text())
+    model = catalog["models"][0]
+    assert model["slug"] == "deepseek-v4-flash-0731"
+    assert model["context_window"] == 1_048_576
+    assert model["default_reasoning_level"] == "none"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_responses_route.py
+++ b/tests/test_responses_route.py
@@ -1438,16 +1438,53 @@ def test_codex_progress_reminder_switches_from_edit_to_test():
     assert "every explicit acceptance constraint" in reminded[-1]["content"]
     assert "do not rerun the same failing test unchanged" in reminded[-1]["content"]
 
-    request.input.append(
-        {
-            "type": "function_call_output",
-            "call_id": "tests",
-            "output": "21 passed in 1.00s",
-        }
+    request.input.extend(
+        [
+            {
+                "type": "function_call",
+                "name": "exec_command",
+                "call_id": "tests",
+                "arguments": '{"cmd":"python -m pytest tests/test_x.py"}',
+            },
+            {
+                "type": "function_call_output",
+                "call_id": "tests",
+                "output": "21 passed in 1.00s",
+            },
+        ]
     )
     reminded = _inject_codex_progress_reminder([], request)
     assert "Do not rerun the same tests" in reminded[-1]["content"]
     assert "provide the final answer" in reminded[-1]["content"]
+
+
+def test_codex_progress_does_not_mistake_prose_passed_for_test_success():
+    from vllm_mlx.api.responses_models import ResponsesRequest
+    from vllm_mlx.routes.responses import _inject_codex_progress_reminder
+
+    request = ResponsesRequest(
+        model="deepseek-v4",
+        input=[
+            {
+                "type": "function_call",
+                "name": "exec_command",
+                "call_id": "edit",
+                "arguments": '{"cmd":"apply_patch <<PATCH"}',
+            },
+            *[
+                {
+                    "type": "function_call_output",
+                    "call_id": f"read_{index}",
+                    "output": "argument passed to function",
+                }
+                for index in range(5)
+            ],
+        ],
+    )
+
+    reminded = _inject_codex_progress_reminder([], request)
+    assert "running focused tests" in reminded[-1]["content"]
+    assert "provide the final answer" not in reminded[-1]["content"]
 
 
 def test_codex_action_prefix_breaks_post_edit_search_loop():

--- a/tests/test_responses_route.py
+++ b/tests/test_responses_route.py
@@ -1294,3 +1294,205 @@ class TestResponsesStreamR10C3:
         for fld in ("id", "created_at", "status", "model", "output", "usage"):
             assert fld in resp_obj, f"completed.response is missing `{fld}`"
         assert resp_obj["status"] == "completed"
+def test_deepseek_codex_exec_priming_is_bounded_to_early_tool_phase():
+    from vllm_mlx.api.responses_models import ResponsesRequest
+    from vllm_mlx.routes.responses import _should_prime_deepseek_codex_exec
+
+    tools = [
+        {
+            "type": "function",
+            "name": "exec_command",
+            "parameters": {
+                "type": "object",
+                "properties": {"cmd": {"type": "string"}},
+                "required": ["cmd"],
+            },
+        },
+        {
+            "type": "function",
+            "name": "write_stdin",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    ]
+    first = ResponsesRequest(model="deepseek-v4", input="Fix the issue", tools=tools)
+    assert _should_prime_deepseek_codex_exec(first, "deepseek_v4_0731") is True
+
+    continued = ResponsesRequest(
+        model="deepseek-v4",
+        input=[
+            {
+                "type": "function_call",
+                "name": "exec_command",
+                "call_id": "call_1",
+                "arguments": '{"cmd":"pwd"}',
+            },
+            {
+                "type": "function_call_output",
+                "call_id": "call_1",
+                "output": "/repo",
+            },
+        ],
+        tools=tools,
+    )
+    assert _should_prime_deepseek_codex_exec(continued, "deepseek_v4_0731") is True
+
+    exhausted_items = []
+    for index in range(6):
+        exhausted_items.extend(
+            [
+                {
+                    "type": "function_call",
+                    "name": "exec_command",
+                    "call_id": f"call_{index}",
+                    "arguments": '{"cmd":"pwd"}',
+                },
+                {
+                    "type": "function_call_output",
+                    "call_id": f"call_{index}",
+                    "output": "/repo",
+                },
+            ]
+        )
+    exhausted = ResponsesRequest(
+        model="deepseek-v4", input=exhausted_items, tools=tools
+    )
+    assert _should_prime_deepseek_codex_exec(exhausted, "deepseek_v4_0731") is False
+    assert _should_prime_deepseek_codex_exec(first, "qwen3") is False
+
+
+def test_rejects_immediately_repeated_tool_action():
+    from fastapi import HTTPException
+
+    from vllm_mlx.api.models import FunctionCall, ToolCall
+    from vllm_mlx.routes.responses import _reject_immediate_repeated_tool_call
+
+    history = [
+        {
+            "type": "function_call",
+            "name": "exec_command",
+            "call_id": "call_old",
+            "arguments": '{"cmd":"rg get_stats"}',
+        },
+        {
+            "type": "function_call_output",
+            "call_id": "call_old",
+            "output": "matches",
+        },
+    ]
+    repeated = [
+        ToolCall(
+            id="call_new",
+            type="function",
+            function=FunctionCall(
+                name="exec_command", arguments='{"cmd":"rg get_stats"}'
+            ),
+        )
+    ]
+    with pytest.raises(HTTPException, match="identical arguments"):
+        _reject_immediate_repeated_tool_call(repeated, history)
+
+    different = [
+        ToolCall(
+            id="call_new",
+            type="function",
+            function=FunctionCall(name="exec_command", arguments='{"cmd":"pwd"}'),
+        )
+    ]
+    _reject_immediate_repeated_tool_call(different, history)
+
+
+def test_codex_progress_reminder_switches_from_edit_to_test():
+    from vllm_mlx.api.responses_models import ResponsesRequest
+    from vllm_mlx.routes.responses import (
+        _codex_action_command_prefix,
+        _inject_codex_progress_reminder,
+    )
+
+    outputs = [
+        {
+            "type": "function_call_output",
+            "call_id": f"call_{index}",
+            "output": "ok",
+        }
+        for index in range(5)
+    ]
+    request = ResponsesRequest(model="deepseek-v4", input=outputs)
+    reminded = _inject_codex_progress_reminder([], request)
+    assert "must make the requested edit" in reminded[-1]["content"]
+    assert _codex_action_command_prefix(request).endswith(">apply_patch")
+
+    request.input = [
+        {
+            "type": "function_call",
+            "name": "exec_command",
+            "call_id": "edit",
+            "arguments": '{"cmd":"apply_patch <<PATCH"}',
+        },
+        *outputs,
+    ]
+    reminded = _inject_codex_progress_reminder([], request)
+    assert "running focused tests" in reminded[-1]["content"]
+    assert _codex_action_command_prefix(request) is None
+    assert "every explicit acceptance constraint" in reminded[-1]["content"]
+    assert "do not rerun the same failing test unchanged" in reminded[-1]["content"]
+
+    request.input.append(
+        {"type": "function_call_output", "call_id": "tests", "output": "21 passed in 1.00s"}
+    )
+    reminded = _inject_codex_progress_reminder([], request)
+    assert "Do not rerun the same tests" in reminded[-1]["content"]
+    assert "provide the final answer" in reminded[-1]["content"]
+
+
+def test_codex_action_prefix_breaks_post_edit_search_loop():
+    from vllm_mlx.api.responses_models import ResponsesRequest
+    from vllm_mlx.routes.responses import _codex_action_command_prefix
+
+    items = [
+        {"type": "function_call_output", "call_id": f"seed_{index}", "output": "ok"}
+        for index in range(5)
+    ]
+    items.append(
+        {"type": "function_call", "name": "exec_command", "call_id": "edit", "arguments": '{"cmd":"apply_patch <<PATCH\\n*** Update File: vllm_mlx/x.py"}'}
+    )
+    for command in ("git diff", "grep -rn symbol vllm_mlx", "rg symbol vllm_mlx"):
+        items.extend(
+            [
+                {"type": "function_call_output", "call_id": f"out_{command}", "output": "ok"},
+                {"type": "function_call", "name": "exec_command", "call_id": f"call_{command}", "arguments": f'{{"cmd":"{command}"}}'},
+            ]
+        )
+    request = ResponsesRequest(model="m", input=items)
+    assert _codex_action_command_prefix(request).endswith(">apply_patch")
+
+    items[5]["arguments"] = '{"cmd":"apply_patch <<PATCH\\n*** Update File: tests/test_x.py"}'
+    request = ResponsesRequest(model="m", input=items)
+    assert _codex_action_command_prefix(request).endswith(">python -m pytest")
+
+    items.extend(
+        [
+            {"type": "function_call", "name": "exec_command", "call_id": "test", "arguments": '{"cmd":"python -m pytest tests/test_x.py"}'},
+            {"type": "function_call_output", "call_id": "test", "output": "FAILED tests/test_x.py::test_x"},
+        ]
+    )
+    request = ResponsesRequest(model="m", input=items)
+    assert _codex_action_command_prefix(request).endswith(">apply_patch")
+
+
+def test_deepseek_codex_implicit_temperature_uses_low_entropy_default(monkeypatch):
+    from vllm_mlx.api.models import ChatCompletionRequest
+    from vllm_mlx.api.responses_models import ResponsesRequest
+    from vllm_mlx.routes.responses import _resolved_responses_sampling_kwargs
+
+    tools = [
+        {"type": "function", "name": name, "description": name, "parameters": {"type": "object", "properties": {}}}
+        for name in ("exec_command", "write_stdin")
+    ]
+    responses = ResponsesRequest(model="deepseek-v4-flash-0731", input="fix it", tools=tools)
+    chat = ChatCompletionRequest(model="deepseek-v4-flash-0731", messages=[{"role": "user", "content": "fix it"}])
+    monkeypatch.setattr("vllm_mlx.routes.responses._resolve_temperature", lambda value: 1.0 if value is None else value)
+    assert _resolved_responses_sampling_kwargs(chat, responses, None)["temperature"] == 0.2
+
+    responses.temperature = 0.7
+    chat.temperature = 0.7
+    assert _resolved_responses_sampling_kwargs(chat, responses, None)["temperature"] == 0.7

--- a/tests/test_responses_route.py
+++ b/tests/test_responses_route.py
@@ -1294,6 +1294,8 @@ class TestResponsesStreamR10C3:
         for fld in ("id", "created_at", "status", "model", "output", "usage"):
             assert fld in resp_obj, f"completed.response is missing `{fld}`"
         assert resp_obj["status"] == "completed"
+
+
 def test_deepseek_codex_exec_priming_is_bounded_to_early_tool_phase():
     from vllm_mlx.api.responses_models import ResponsesRequest
     from vllm_mlx.routes.responses import _should_prime_deepseek_codex_exec
@@ -1437,7 +1439,11 @@ def test_codex_progress_reminder_switches_from_edit_to_test():
     assert "do not rerun the same failing test unchanged" in reminded[-1]["content"]
 
     request.input.append(
-        {"type": "function_call_output", "call_id": "tests", "output": "21 passed in 1.00s"}
+        {
+            "type": "function_call_output",
+            "call_id": "tests",
+            "output": "21 passed in 1.00s",
+        }
     )
     reminded = _inject_codex_progress_reminder([], request)
     assert "Do not rerun the same tests" in reminded[-1]["content"]
@@ -1453,26 +1459,51 @@ def test_codex_action_prefix_breaks_post_edit_search_loop():
         for index in range(5)
     ]
     items.append(
-        {"type": "function_call", "name": "exec_command", "call_id": "edit", "arguments": '{"cmd":"apply_patch <<PATCH\\n*** Update File: vllm_mlx/x.py"}'}
+        {
+            "type": "function_call",
+            "name": "exec_command",
+            "call_id": "edit",
+            "arguments": '{"cmd":"apply_patch <<PATCH\\n*** Update File: vllm_mlx/x.py"}',
+        }
     )
     for command in ("git diff", "grep -rn symbol vllm_mlx", "rg symbol vllm_mlx"):
         items.extend(
             [
-                {"type": "function_call_output", "call_id": f"out_{command}", "output": "ok"},
-                {"type": "function_call", "name": "exec_command", "call_id": f"call_{command}", "arguments": f'{{"cmd":"{command}"}}'},
+                {
+                    "type": "function_call_output",
+                    "call_id": f"out_{command}",
+                    "output": "ok",
+                },
+                {
+                    "type": "function_call",
+                    "name": "exec_command",
+                    "call_id": f"call_{command}",
+                    "arguments": f'{{"cmd":"{command}"}}',
+                },
             ]
         )
     request = ResponsesRequest(model="m", input=items)
     assert _codex_action_command_prefix(request).endswith(">apply_patch")
 
-    items[5]["arguments"] = '{"cmd":"apply_patch <<PATCH\\n*** Update File: tests/test_x.py"}'
+    items[5]["arguments"] = (
+        '{"cmd":"apply_patch <<PATCH\\n*** Update File: tests/test_x.py"}'
+    )
     request = ResponsesRequest(model="m", input=items)
     assert _codex_action_command_prefix(request).endswith(">python -m pytest")
 
     items.extend(
         [
-            {"type": "function_call", "name": "exec_command", "call_id": "test", "arguments": '{"cmd":"python -m pytest tests/test_x.py"}'},
-            {"type": "function_call_output", "call_id": "test", "output": "FAILED tests/test_x.py::test_x"},
+            {
+                "type": "function_call",
+                "name": "exec_command",
+                "call_id": "test",
+                "arguments": '{"cmd":"python -m pytest tests/test_x.py"}',
+            },
+            {
+                "type": "function_call_output",
+                "call_id": "test",
+                "output": "FAILED tests/test_x.py::test_x",
+            },
         ]
     )
     request = ResponsesRequest(model="m", input=items)
@@ -1485,14 +1516,30 @@ def test_deepseek_codex_implicit_temperature_uses_low_entropy_default(monkeypatc
     from vllm_mlx.routes.responses import _resolved_responses_sampling_kwargs
 
     tools = [
-        {"type": "function", "name": name, "description": name, "parameters": {"type": "object", "properties": {}}}
+        {
+            "type": "function",
+            "name": name,
+            "description": name,
+            "parameters": {"type": "object", "properties": {}},
+        }
         for name in ("exec_command", "write_stdin")
     ]
-    responses = ResponsesRequest(model="deepseek-v4-flash-0731", input="fix it", tools=tools)
-    chat = ChatCompletionRequest(model="deepseek-v4-flash-0731", messages=[{"role": "user", "content": "fix it"}])
-    monkeypatch.setattr("vllm_mlx.routes.responses._resolve_temperature", lambda value: 1.0 if value is None else value)
-    assert _resolved_responses_sampling_kwargs(chat, responses, None)["temperature"] == 0.2
+    responses = ResponsesRequest(
+        model="deepseek-v4-flash-0731", input="fix it", tools=tools
+    )
+    chat = ChatCompletionRequest(
+        model="deepseek-v4-flash-0731", messages=[{"role": "user", "content": "fix it"}]
+    )
+    monkeypatch.setattr(
+        "vllm_mlx.routes.responses._resolve_temperature",
+        lambda value: 1.0 if value is None else value,
+    )
+    assert (
+        _resolved_responses_sampling_kwargs(chat, responses, None)["temperature"] == 0.2
+    )
 
     responses.temperature = 0.7
     chat.temperature = 0.7
-    assert _resolved_responses_sampling_kwargs(chat, responses, None)["temperature"] == 0.7
+    assert (
+        _resolved_responses_sampling_kwargs(chat, responses, None)["temperature"] == 0.7
+    )

--- a/tests/test_responses_route.py
+++ b/tests/test_responses_route.py
@@ -1362,47 +1362,6 @@ def test_deepseek_codex_exec_priming_is_bounded_to_early_tool_phase():
     assert _should_prime_deepseek_codex_exec(first, "qwen3") is False
 
 
-def test_rejects_immediately_repeated_tool_action():
-    from fastapi import HTTPException
-
-    from vllm_mlx.api.models import FunctionCall, ToolCall
-    from vllm_mlx.routes.responses import _reject_immediate_repeated_tool_call
-
-    history = [
-        {
-            "type": "function_call",
-            "name": "exec_command",
-            "call_id": "call_old",
-            "arguments": '{"cmd":"rg get_stats"}',
-        },
-        {
-            "type": "function_call_output",
-            "call_id": "call_old",
-            "output": "matches",
-        },
-    ]
-    repeated = [
-        ToolCall(
-            id="call_new",
-            type="function",
-            function=FunctionCall(
-                name="exec_command", arguments='{"cmd":"rg get_stats"}'
-            ),
-        )
-    ]
-    with pytest.raises(HTTPException, match="identical arguments"):
-        _reject_immediate_repeated_tool_call(repeated, history)
-
-    different = [
-        ToolCall(
-            id="call_new",
-            type="function",
-            function=FunctionCall(name="exec_command", arguments='{"cmd":"pwd"}'),
-        )
-    ]
-    _reject_immediate_repeated_tool_call(different, history)
-
-
 def test_codex_progress_reminder_switches_from_edit_to_test():
     from vllm_mlx.api.responses_models import ResponsesRequest
     from vllm_mlx.routes.responses import (

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -581,6 +581,16 @@ class TestModelsRoutes:
             ids = [m["id"] for m in r.json()["data"]]
             assert "test-model" in ids
             assert "test-alias" in ids
+            codex_models = r.json()["models"]
+            catalog = {m["slug"]: m for m in codex_models}
+            assert catalog["test-model"]["shell_type"] == "shell_command"
+            assert catalog["test-model"]["tool_mode"] == "direct"
+            assert catalog["test-model"]["default_reasoning_level"] == "none"
+            assert [
+                level["effort"]
+                for level in catalog["test-model"]["supported_reasoning_levels"]
+            ] == ["none", "low", "medium", "high"]
+            assert "coding agent" in catalog["test-model"]["base_instructions"]
         finally:
             self._restore(orig)
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -591,6 +591,12 @@ class TestModelsRoutes:
                 for level in catalog["test-model"]["supported_reasoning_levels"]
             ] == ["none", "low", "medium", "high"]
             assert "coding agent" in catalog["test-model"]["base_instructions"]
+            assert "Do not merely announce" in catalog["test-model"][
+                "base_instructions"
+            ]
+            assert "Make repository changes with apply_patch" in catalog[
+                "test-model"
+            ]["base_instructions"]
         finally:
             self._restore(orig)
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -591,12 +591,13 @@ class TestModelsRoutes:
                 for level in catalog["test-model"]["supported_reasoning_levels"]
             ] == ["none", "low", "medium", "high"]
             assert "coding agent" in catalog["test-model"]["base_instructions"]
-            assert "Do not merely announce" in catalog["test-model"][
-                "base_instructions"
-            ]
-            assert "Make repository changes with apply_patch" in catalog[
-                "test-model"
-            ]["base_instructions"]
+            assert (
+                "Do not merely announce" in catalog["test-model"]["base_instructions"]
+            )
+            assert (
+                "Make repository changes with apply_patch"
+                in catalog["test-model"]["base_instructions"]
+            )
         finally:
             self._restore(orig)
 

--- a/vllm_mlx/agents/adapter.py
+++ b/vllm_mlx/agents/adapter.py
@@ -127,9 +127,7 @@ def setup_agent_config(
             rendered = rendered.replace(
                 "{model_catalog_path}", str(catalog_path.resolve())
             )
-            catalog = {
-                "models": [build_codex_model_info(model_id, context_length)]
-            }
+            catalog = {"models": [build_codex_model_info(model_id, context_length)]}
             try:
                 _atomic_write(
                     catalog_path,

--- a/vllm_mlx/agents/adapter.py
+++ b/vllm_mlx/agents/adapter.py
@@ -118,6 +118,29 @@ def setup_agent_config(
         config_path = Path(os.path.expanduser(cfg.path))
         config_path.parent.mkdir(parents=True, exist_ok=True)
 
+        if profile.name == "codex" and isinstance(rendered, str):
+            import json
+
+            from .codex_catalog import build_codex_model_info
+
+            catalog_path = config_path.parent / "rapid-mlx-model-catalog.json"
+            rendered = rendered.replace(
+                "{model_catalog_path}", str(catalog_path.resolve())
+            )
+            catalog = {
+                "models": [build_codex_model_info(model_id, context_length)]
+            }
+            try:
+                _atomic_write(
+                    catalog_path,
+                    json.dumps(catalog, indent=2, ensure_ascii=False) + "\n",
+                )
+            except OSError as exc:
+                return (
+                    f"Cannot write Codex model catalog to {catalog_path} "
+                    f"({exc}). Check file permissions."
+                )
+
         try:
             merged_text = _merge_file_config(config_path, rendered, cfg.type)
         except OSError as exc:

--- a/vllm_mlx/agents/codex_catalog.py
+++ b/vllm_mlx/agents/codex_catalog.py
@@ -29,8 +29,20 @@ def build_codex_model_info(model_id: str, context_window: int | None) -> dict:
         "upgrade": None,
         "base_instructions": (
             "You are Codex, a coding agent working directly in the user's "
-            "repository. Continue until the requested change and relevant "
-            "tests are complete. Preserve unrelated user changes."
+            "repository. Use the available shell tools immediately to "
+            "inspect, edit, and test. Do not merely announce an action and "
+            "stop. Make repository changes with apply_patch instead of "
+            "printing a proposed patch as prose. When exec_command is the "
+            "selected tool, invoke the apply_patch executable through the "
+            "shell. Use no more than five inspection commands before making "
+            "the first edit. Before editing, identify every explicit acceptance "
+            "constraint in the user's request; after editing, compare the diff "
+            "against those constraints before declaring success. Never repeat an "
+            "unchanged search, file read, or failing test command. Use the "
+            "repository's supported interpreter and test toolchain, not an "
+            "incompatible system default. Once enough context is known, act "
+            "immediately. Continue until the requested change and relevant tests "
+            "are complete. Preserve unrelated user changes."
         ),
         "support_verbosity": False,
         "default_verbosity": None,

--- a/vllm_mlx/agents/codex_catalog.py
+++ b/vllm_mlx/agents/codex_catalog.py
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Static model metadata used by Codex for Rapid-MLX local models."""
+
+from __future__ import annotations
+
+
+def build_codex_model_info(model_id: str, context_window: int | None) -> dict:
+    """Return a complete Codex model-catalog entry.
+
+    The same descriptor is served dynamically by ``/v1/models`` and written
+    by ``rapid-mlx agents codex --setup``.  Keeping one builder prevents the
+    static first-turn catalog from drifting from later remote refreshes.
+    """
+    window = context_window or 262_144
+    return {
+        "slug": model_id,
+        "display_name": model_id,
+        "description": "Local model served by Rapid-MLX",
+        "default_reasoning_level": "none",
+        "supported_reasoning_levels": [
+            {"effort": effort, "description": f"{effort} reasoning"}
+            for effort in ("none", "low", "medium", "high")
+        ],
+        "shell_type": "shell_command",
+        "visibility": "list",
+        "supported_in_api": True,
+        "priority": 0,
+        "availability_nux": None,
+        "upgrade": None,
+        "base_instructions": (
+            "You are Codex, a coding agent working directly in the user's "
+            "repository. Continue until the requested change and relevant "
+            "tests are complete. Preserve unrelated user changes."
+        ),
+        "support_verbosity": False,
+        "default_verbosity": None,
+        "apply_patch_tool_type": None,
+        "truncation_policy": {"mode": "tokens", "limit": 10_000},
+        "supports_parallel_tool_calls": True,
+        "context_window": window,
+        "max_context_window": window,
+        "experimental_supported_tools": [],
+        "input_modalities": ["text"],
+        "tool_mode": "direct",
+    }

--- a/vllm_mlx/agents/profiles/codex.yaml
+++ b/vllm_mlx/agents/profiles/codex.yaml
@@ -19,6 +19,11 @@ config:
     # `model_provider` and then looks up the matching block below.
     model = "{model_id}"
     model_provider = "rapid-mlx"
+    model_context_window = {context_length}
+    # A startup-local catalog avoids Codex's asynchronous remote-catalog race:
+    # the first turn otherwise uses flagship fallback metadata before the
+    # Rapid-MLX /models request completes.
+    model_catalog_json = "{model_catalog_path}"
 
     [model_providers.rapid-mlx]
     name = "Rapid-MLX (local)"

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -2450,6 +2450,12 @@ class ModelsResponse(BaseModel):
 
     object: str = "list"
     data: list[ModelInfo]
+    # Codex CLI 0.146+ refreshes provider metadata from the same ``/models``
+    # URL but uses its catalog contract (``{"models": [...]}``) rather than
+    # the OpenAI discovery contract (``{"data": [...]}``). Routes can attach
+    # a local-model catalog alongside the canonical list; OpenAI-compatible
+    # clients ignore the additive field.
+    models: list[dict] = Field(default_factory=list)
 
 
 # =============================================================================

--- a/vllm_mlx/routes/models.py
+++ b/vllm_mlx/routes/models.py
@@ -15,6 +15,7 @@ import logging
 
 from fastapi import APIRouter, Depends, HTTPException
 
+from ..agents.codex_catalog import build_codex_model_info
 from ..api.models import ModelInfo, ModelsResponse
 from ..api.utils import is_mllm_model
 from ..config import get_config
@@ -899,6 +900,17 @@ def _build_model_info(model_id: str) -> ModelInfo:
     )
 
 
+def _build_codex_model_info(info: ModelInfo) -> dict:
+    """Build Codex's additive model-catalog shape for a local model.
+
+    Codex otherwise applies its flagship-model fallback metadata, which can
+    select code-mode-only tools and a very large OpenAI-specific instruction
+    prompt.  Local models are substantially more reliable with the direct
+    ``shell_command`` surface and an explicit act-before-narrating contract.
+    """
+    return build_codex_model_info(info.id, info.context_window)
+
+
 @router.get("/v1/models", dependencies=[Depends(verify_api_key)])
 async def list_models() -> ModelsResponse:
     """List available models (supports multi-model).
@@ -939,7 +951,12 @@ async def list_models() -> ModelsResponse:
     if locked:
         _append(_build_model_info(locked))
 
-    return ModelsResponse(data=models)
+    codex_models = [
+        _build_codex_model_info(info)
+        for info in models
+        if "text" in info.capabilities
+    ]
+    return ModelsResponse(data=models, models=codex_models)
 
 
 @router.get("/v1/models/{model_id:path}", dependencies=[Depends(verify_api_key)])

--- a/vllm_mlx/routes/models.py
+++ b/vllm_mlx/routes/models.py
@@ -952,9 +952,7 @@ async def list_models() -> ModelsResponse:
         _append(_build_model_info(locked))
 
     codex_models = [
-        _build_codex_model_info(info)
-        for info in models
-        if "text" in info.capabilities
+        _build_codex_model_info(info) for info in models if "text" in info.capabilities
     ]
     return ModelsResponse(data=models, models=codex_models)
 

--- a/vllm_mlx/routes/responses.py
+++ b/vllm_mlx/routes/responses.py
@@ -17,6 +17,7 @@ history every turn in ``input``.
 import asyncio
 import json
 import logging
+import re
 import time
 import uuid
 from collections.abc import AsyncIterator, Mapping
@@ -221,6 +222,10 @@ def _reject_immediate_repeated_tool_call(tool_calls: list, input_items: object) 
         if hasattr(function, "arguments")
         else function.get("arguments", "{}")
     )
+    # Repeating a continuation/poll is normal while a PTY command is still
+    # running. Only shell actions are candidates for semantic-loop rejection.
+    if str(name) != "exec_command":
+        return
     if (str(name), str(arguments)) == previous:
         raise HTTPException(
             status_code=400,
@@ -243,6 +248,7 @@ def _inject_codex_progress_reminder(
     has_edited = False
     has_test_passed = False
     has_test_failed = False
+    calls: dict[str, str] = {}
     for item in items:
         data = item.model_dump() if hasattr(item, "model_dump") else item
         if not isinstance(data, dict):
@@ -250,13 +256,21 @@ def _inject_codex_progress_reminder(
         if data.get("type") == "function_call_output":
             completed += 1
             output = str(data.get("output") or "")
-            if " passed" in output:
+            command = calls.get(str(data.get("call_id") or ""), "")
+            is_test = any(
+                marker in command
+                for marker in ("pytest", "unittest", "tox", "nox", "ruff", "mypy")
+            )
+            if is_test and re.search(r"(?m)^\s*\d+\s+passed(?:\s|,|$)", output):
                 # Pytest summaries have shapes such as ``21 passed in 1.0s``.
                 has_test_passed = True
-            if any(marker in output for marker in ("FAILED ", " FAILURES ", " ERROR ")):
+            if is_test and any(
+                marker in output for marker in ("FAILED ", " FAILURES ", " ERROR ")
+            ):
                 has_test_failed = True
         if data.get("type") == "function_call":
             arguments = str(data.get("arguments") or "")
+            calls[str(data.get("call_id") or "")] = arguments
             if "apply_patch" in arguments:
                 has_edited = True
                 has_test_passed = False
@@ -303,6 +317,7 @@ def _codex_action_command_prefix(responses_request: ResponsesRequest) -> str | N
     has_unresolved_failure = False
     has_successful_test = False
     commands_after_edit: list[str] = []
+    calls: dict[str, str] = {}
     for item in items:
         data = item.model_dump() if hasattr(item, "model_dump") else item
         if not isinstance(data, dict):
@@ -311,20 +326,36 @@ def _codex_action_command_prefix(responses_request: ResponsesRequest) -> str | N
             completed += 1
             if has_edited:
                 output = str(data.get("output") or "")
-                has_unresolved_failure = has_unresolved_failure or any(
-                    marker in output
+                command = calls.get(str(data.get("call_id") or ""), "")
+                is_test = any(
+                    marker in command
                     for marker in (
-                        "FAILED ",
-                        " FAILURES ",
-                        "Traceback (most recent call last)",
-                        " ERROR ",
+                        "pytest",
+                        "unittest",
+                        "tox",
+                        "nox",
+                        "ruff",
+                        "mypy",
                     )
                 )
-                has_successful_test = has_successful_test or (
-                    " passed" in output and not has_unresolved_failure
-                )
+                if is_test:
+                    has_unresolved_failure = has_unresolved_failure or any(
+                        marker in output
+                        for marker in (
+                            "FAILED ",
+                            " FAILURES ",
+                            "Traceback (most recent call last)",
+                            " ERROR ",
+                        )
+                    )
+                    has_successful_test = (
+                        has_successful_test
+                        or bool(re.search(r"(?m)^\s*\d+\s+passed(?:\s|,|$)", output))
+                        and not has_unresolved_failure
+                    )
         if data.get("type") == "function_call":
             arguments = str(data.get("arguments") or "")
+            calls[str(data.get("call_id") or "")] = arguments
             if "apply_patch" in arguments:
                 has_edited = True
                 has_test_edit = has_test_edit or any(
@@ -1232,7 +1263,9 @@ async def _non_stream(
     created_at = int(time.time())
 
     messages = _prepare_messages_for_engine(engine, openai_request)
-    messages = _inject_codex_progress_reminder(messages, responses_request)
+    codex_surface = _is_deepseek_codex_surface(responses_request, cfg.tool_call_parser)
+    if codex_surface:
+        messages = _inject_codex_progress_reminder(messages, responses_request)
 
     # r5-B C-10 / C-11: tool-coupled UI-TARS sysprompt injection. PR
     # #817 wired ``computer_20251022`` → ``computer`` tool translation
@@ -1272,7 +1305,10 @@ async def _non_stream(
         from .chat import _compute_forced_tool_prefix
 
         forced_prefix = _compute_forced_tool_prefix(cfg, openai_request)
-        forced_prefix = _codex_action_command_prefix(responses_request) or forced_prefix
+        if codex_surface:
+            forced_prefix = (
+                _codex_action_command_prefix(responses_request) or forced_prefix
+            )
         if forced_prefix:
             chat_kwargs["forced_assistant_prefix"] = forced_prefix
 
@@ -2189,7 +2225,11 @@ async def _stream_responses(
     )
     try:
         messages = _prepare_messages_for_engine(engine, openai_request)
-        messages = _inject_codex_progress_reminder(messages, responses_request)
+        codex_surface = _is_deepseek_codex_surface(
+            responses_request, cfg.tool_call_parser
+        )
+        if codex_surface:
+            messages = _inject_codex_progress_reminder(messages, responses_request)
 
         # r5-B C-10 / C-11: tool-coupled UI-TARS sysprompt injection on
         # the streaming responses lane. Same gate as the non-stream
@@ -2222,9 +2262,10 @@ async def _stream_responses(
             from .chat import _compute_forced_tool_prefix
 
             forced_prefix = _compute_forced_tool_prefix(cfg, openai_request)
-            forced_prefix = (
-                _codex_action_command_prefix(responses_request) or forced_prefix
-            )
+            if codex_surface:
+                forced_prefix = (
+                    _codex_action_command_prefix(responses_request) or forced_prefix
+                )
             if forced_prefix:
                 chat_kwargs["forced_assistant_prefix"] = forced_prefix
         resolved_thinking = _resolve_enable_thinking(openai_request)
@@ -3249,10 +3290,6 @@ async def _stream_responses(
                 and openai_request.tools
                 and cfg.tool_call_parser == "deepseek_v4_0731"
             ):
-                if _is_deepseek_codex_surface(responses_request, cfg.tool_call_parser):
-                    _reject_immediate_repeated_tool_call(
-                        tool_calls, responses_request.input
-                    )
                 _validate_tool_call_params(
                     tool_calls, openai_request.tools, enforce_required=True
                 )

--- a/vllm_mlx/routes/responses.py
+++ b/vllm_mlx/routes/responses.py
@@ -163,9 +163,10 @@ def _is_deepseek_codex_surface(
     responses_request: ResponsesRequest, tool_parser: str | None
 ) -> bool:
     """Identify the DeepSeek DSML + Codex PTY tool combination."""
-    if tool_parser is None and "deepseek-v4-flash-0731" in (
-        responses_request.model or ""
-    ).lower():
+    if (
+        tool_parser is None
+        and "deepseek-v4-flash-0731" in (responses_request.model or "").lower()
+    ):
         tool_parser = "deepseek_v4_0731"
     if tool_parser != "deepseek_v4_0731":
         return False
@@ -183,9 +184,7 @@ def _is_deepseek_codex_surface(
     return {"exec_command", "write_stdin"}.issubset(names)
 
 
-def _reject_immediate_repeated_tool_call(
-    tool_calls: list, input_items: object
-) -> None:
+def _reject_immediate_repeated_tool_call(tool_calls: list, input_items: object) -> None:
     """Reject a model call identical to the most recent agent call.
 
     Re-running an unchanged shell search is a semantic loop even when each
@@ -211,8 +210,10 @@ def _reject_immediate_repeated_tool_call(
         return
 
     current = tool_calls[0]
-    function = current.function if hasattr(current, "function") else current.get(
-        "function", current
+    function = (
+        current.function
+        if hasattr(current, "function")
+        else current.get("function", current)
     )
     name = function.name if hasattr(function, "name") else function.get("name", "")
     arguments = (
@@ -312,7 +313,12 @@ def _codex_action_command_prefix(responses_request: ResponsesRequest) -> str | N
                 output = str(data.get("output") or "")
                 has_unresolved_failure = has_unresolved_failure or any(
                     marker in output
-                    for marker in ("FAILED ", " FAILURES ", "Traceback (most recent call last)", " ERROR ")
+                    for marker in (
+                        "FAILED ",
+                        " FAILURES ",
+                        "Traceback (most recent call last)",
+                        " ERROR ",
+                    )
                 )
                 has_successful_test = has_successful_test or (
                     " passed" in output and not has_unresolved_failure
@@ -408,9 +414,8 @@ def _resolved_responses_sampling_kwargs(
 ) -> dict:
     """Apply Responses/Codex defaults without changing the base helper contract."""
     out = _resolved_sampling_kwargs(openai_request)
-    if (
-        responses_request.temperature is None
-        and _is_deepseek_codex_surface(responses_request, tool_parser)
+    if responses_request.temperature is None and _is_deepseek_codex_surface(
+        responses_request, tool_parser
     ):
         # The 0731 checkpoint ships temperature=1 in generation_config.
         # That is useful for chat, but in long Codex tool loops it causes
@@ -676,9 +681,7 @@ async def create_response(request: Request):
             # recognize this checkpoint directly when the CLI did not receive
             # an explicit --tool-call-parser value.
             priming_tool_parser = "deepseek_v4_0731"
-    if _should_prime_deepseek_codex_exec(
-        responses_request, priming_tool_parser
-    ):
+    if _should_prime_deepseek_codex_exec(responses_request, priming_tool_parser):
         responses_request.tool_choice = {
             "type": "function",
             "name": "exec_command",
@@ -1798,9 +1801,7 @@ async def _non_stream(
             tool_calls, responses_request, openai_request
         )
         if tool_calls and openai_request.tools:
-            if _is_deepseek_codex_surface(
-                responses_request, cfg.tool_call_parser
-            ):
+            if _is_deepseek_codex_surface(responses_request, cfg.tool_call_parser):
                 _reject_immediate_repeated_tool_call(
                     tool_calls, responses_request.input
                 )
@@ -3248,9 +3249,7 @@ async def _stream_responses(
                 and openai_request.tools
                 and cfg.tool_call_parser == "deepseek_v4_0731"
             ):
-                if _is_deepseek_codex_surface(
-                    responses_request, cfg.tool_call_parser
-                ):
+                if _is_deepseek_codex_surface(responses_request, cfg.tool_call_parser):
                     _reject_immediate_repeated_tool_call(
                         tool_calls, responses_request.input
                     )

--- a/vllm_mlx/routes/responses.py
+++ b/vllm_mlx/routes/responses.py
@@ -164,11 +164,19 @@ def _is_deepseek_codex_surface(
     responses_request: ResponsesRequest, tool_parser: str | None
 ) -> bool:
     """Identify the DeepSeek DSML + Codex PTY tool combination."""
-    if (
-        tool_parser is None
-        and "deepseek-v4-flash-0731" in (responses_request.model or "").lower()
-    ):
-        tool_parser = "deepseek_v4_0731"
+    if tool_parser is None:
+        cfg = get_config()
+        configured = " ".join(
+            str(value or "")
+            for value in (
+                responses_request.model,
+                cfg.model_name,
+                cfg.model_alias,
+                cfg.model_path,
+            )
+        ).lower()
+        if "deepseek-v4-flash-0731" in configured:
+            tool_parser = "deepseek_v4_0731"
     if tool_parser != "deepseek_v4_0731":
         return False
     names: set[str] = set()
@@ -183,58 +191,6 @@ def _is_deepseek_codex_surface(
         if isinstance(name, str):
             names.add(name)
     return {"exec_command", "write_stdin"}.issubset(names)
-
-
-def _reject_immediate_repeated_tool_call(tool_calls: list, input_items: object) -> None:
-    """Reject a model call identical to the most recent agent call.
-
-    Re-running an unchanged shell search is a semantic loop even when each
-    individual generation is token-coherent. Reject it before Codex executes
-    the command; a retry samples from the same grounded history without adding
-    another duplicate tool result.
-    """
-    if not tool_calls or not isinstance(input_items, list):
-        return
-
-    previous: tuple[str, str] | None = None
-    for item in reversed(input_items):
-        data = item.model_dump() if hasattr(item, "model_dump") else item
-        if not isinstance(data, dict) or data.get("type") != "function_call":
-            continue
-        name = data.get("name") or (data.get("function") or {}).get("name")
-        arguments = data.get("arguments")
-        if arguments is None and isinstance(data.get("function"), dict):
-            arguments = data["function"].get("arguments")
-        previous = (str(name or ""), str(arguments or "{}"))
-        break
-    if previous is None:
-        return
-
-    current = tool_calls[0]
-    function = (
-        current.function
-        if hasattr(current, "function")
-        else current.get("function", current)
-    )
-    name = function.name if hasattr(function, "name") else function.get("name", "")
-    arguments = (
-        function.arguments
-        if hasattr(function, "arguments")
-        else function.get("arguments", "{}")
-    )
-    # Repeating a continuation/poll is normal while a PTY command is still
-    # running. Only shell actions are candidates for semantic-loop rejection.
-    if str(name) != "exec_command":
-        return
-    if (str(name), str(arguments)) == previous:
-        raise HTTPException(
-            status_code=400,
-            detail=(
-                f"Model repeated the immediately preceding tool call '{name}' "
-                "with identical arguments; refusing an agent action loop. "
-                "Retry with a different action."
-            ),
-        )
 
 
 def _inject_codex_progress_reminder(
@@ -339,7 +295,7 @@ def _codex_action_command_prefix(responses_request: ResponsesRequest) -> str | N
                     )
                 )
                 if is_test:
-                    has_unresolved_failure = has_unresolved_failure or any(
+                    failed = any(
                         marker in output
                         for marker in (
                             "FAILED ",
@@ -348,11 +304,13 @@ def _codex_action_command_prefix(responses_request: ResponsesRequest) -> str | N
                             " ERROR ",
                         )
                     )
-                    has_successful_test = (
-                        has_successful_test
-                        or bool(re.search(r"(?m)^\s*\d+\s+passed(?:\s|,|$)", output))
-                        and not has_unresolved_failure
-                    )
+                    passed = bool(re.search(r"(?m)^\s*\d+\s+passed(?:\s|,|$)", output))
+                    if failed:
+                        has_unresolved_failure = True
+                        has_successful_test = False
+                    elif passed:
+                        has_unresolved_failure = False
+                        has_successful_test = True
         if data.get("type") == "function_call":
             arguments = str(data.get("arguments") or "")
             calls[str(data.get("call_id") or "")] = arguments
@@ -362,6 +320,7 @@ def _codex_action_command_prefix(responses_request: ResponsesRequest) -> str | N
                     marker in arguments for marker in ("tests/", "test_", "_test.")
                 )
                 has_unresolved_failure = False
+                has_successful_test = False
                 commands_after_edit = []
             elif has_edited:
                 commands_after_edit.append(arguments)
@@ -1837,10 +1796,6 @@ async def _non_stream(
             tool_calls, responses_request, openai_request
         )
         if tool_calls and openai_request.tools:
-            if _is_deepseek_codex_surface(responses_request, cfg.tool_call_parser):
-                _reject_immediate_repeated_tool_call(
-                    tool_calls, responses_request.input
-                )
             _validate_tool_call_params(
                 tool_calls, openai_request.tools, enforce_required=True
             )

--- a/vllm_mlx/routes/responses.py
+++ b/vllm_mlx/routes/responses.py
@@ -114,6 +114,247 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
+def _should_prime_deepseek_codex_exec(
+    responses_request: ResponsesRequest, tool_parser: str | None
+) -> bool:
+    """Return whether an early DeepSeek Codex turn should pin exec_command.
+
+    DeepSeek V4 reliably emits a valid DSML invocation when the tool name is
+    primed, but stochastic ``auto`` selection often stops in hidden output or
+    emits a prose plan before the first repository inspection.  Pin only the
+    bounded early tool phase. After six completed calls, release ``auto`` so
+    the model can either select a non-shell tool or provide its final answer.
+    """
+    if tool_parser != "deepseek_v4_0731":
+        return False
+    if responses_request.tool_choice not in (None, "auto"):
+        return False
+
+    tool_names: set[str] = set()
+    for tool in responses_request.tools or []:
+        data = tool.model_dump() if hasattr(tool, "model_dump") else tool
+        if not isinstance(data, dict):
+            continue
+        function = data.get("function")
+        name = data.get("name") or (
+            function.get("name") if isinstance(function, dict) else None
+        )
+        if isinstance(name, str):
+            tool_names.add(name)
+    # Codex exposes ``apply_patch`` as a custom tool whose wire shape can vary
+    # by client version, while its PTY pair is stable. Requiring both PTY tools
+    # keeps this scoped to a coding-agent surface rather than arbitrary apps
+    # that happen to expose one shell function.
+    if not {"exec_command", "write_stdin"}.issubset(tool_names):
+        return False
+
+    items = responses_request.input
+    if not isinstance(items, list):
+        return True
+    completed_calls = 0
+    for item in items:
+        data = item.model_dump() if hasattr(item, "model_dump") else item
+        if isinstance(data, dict) and data.get("type") == "function_call_output":
+            completed_calls += 1
+    return completed_calls < 6
+
+
+def _is_deepseek_codex_surface(
+    responses_request: ResponsesRequest, tool_parser: str | None
+) -> bool:
+    """Identify the DeepSeek DSML + Codex PTY tool combination."""
+    if tool_parser is None and "deepseek-v4-flash-0731" in (
+        responses_request.model or ""
+    ).lower():
+        tool_parser = "deepseek_v4_0731"
+    if tool_parser != "deepseek_v4_0731":
+        return False
+    names: set[str] = set()
+    for tool in responses_request.tools or []:
+        data = tool.model_dump() if hasattr(tool, "model_dump") else tool
+        if not isinstance(data, dict):
+            continue
+        function = data.get("function")
+        name = data.get("name") or (
+            function.get("name") if isinstance(function, dict) else None
+        )
+        if isinstance(name, str):
+            names.add(name)
+    return {"exec_command", "write_stdin"}.issubset(names)
+
+
+def _reject_immediate_repeated_tool_call(
+    tool_calls: list, input_items: object
+) -> None:
+    """Reject a model call identical to the most recent agent call.
+
+    Re-running an unchanged shell search is a semantic loop even when each
+    individual generation is token-coherent. Reject it before Codex executes
+    the command; a retry samples from the same grounded history without adding
+    another duplicate tool result.
+    """
+    if not tool_calls or not isinstance(input_items, list):
+        return
+
+    previous: tuple[str, str] | None = None
+    for item in reversed(input_items):
+        data = item.model_dump() if hasattr(item, "model_dump") else item
+        if not isinstance(data, dict) or data.get("type") != "function_call":
+            continue
+        name = data.get("name") or (data.get("function") or {}).get("name")
+        arguments = data.get("arguments")
+        if arguments is None and isinstance(data.get("function"), dict):
+            arguments = data["function"].get("arguments")
+        previous = (str(name or ""), str(arguments or "{}"))
+        break
+    if previous is None:
+        return
+
+    current = tool_calls[0]
+    function = current.function if hasattr(current, "function") else current.get(
+        "function", current
+    )
+    name = function.name if hasattr(function, "name") else function.get("name", "")
+    arguments = (
+        function.arguments
+        if hasattr(function, "arguments")
+        else function.get("arguments", "{}")
+    )
+    if (str(name), str(arguments)) == previous:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Model repeated the immediately preceding tool call '{name}' "
+                "with identical arguments; refusing an agent action loop. "
+                "Retry with a different action."
+            ),
+        )
+
+
+def _inject_codex_progress_reminder(
+    messages: list[dict], responses_request: ResponsesRequest
+) -> list[dict]:
+    """Put an action reminder near the generation boundary after exploration."""
+    items = responses_request.input
+    if not isinstance(items, list):
+        return messages
+    completed = 0
+    has_edited = False
+    has_test_passed = False
+    has_test_failed = False
+    for item in items:
+        data = item.model_dump() if hasattr(item, "model_dump") else item
+        if not isinstance(data, dict):
+            continue
+        if data.get("type") == "function_call_output":
+            completed += 1
+            output = str(data.get("output") or "")
+            if " passed" in output:
+                # Pytest summaries have shapes such as ``21 passed in 1.0s``.
+                has_test_passed = True
+            if any(marker in output for marker in ("FAILED ", " FAILURES ", " ERROR ")):
+                has_test_failed = True
+        if data.get("type") == "function_call":
+            arguments = str(data.get("arguments") or "")
+            if "apply_patch" in arguments:
+                has_edited = True
+                has_test_passed = False
+                has_test_failed = False
+    if completed < 5:
+        return messages
+
+    reminder = (
+        "Engineering progress checkpoint: enough repository context has been "
+        "collected. Do not run another search or repeat a file read. "
+    )
+    if has_edited:
+        if has_test_passed and not has_test_failed:
+            reminder += (
+                "Focused tests have passed. Do not rerun the same tests. Compare the "
+                "diff against the original acceptance constraints once, then provide "
+                "the final answer without another search or test command."
+            )
+        else:
+            reminder += (
+                "Before testing, compare the diff against every explicit acceptance "
+                "constraint in the original request. Correct any mismatch first. Continue "
+                "by running focused tests with the repository's supported interpreter/toolchain. "
+                "If a command fails because of the environment, diagnose and change the "
+                "environment or command; do not rerun the same failing test unchanged."
+            )
+    else:
+        reminder += (
+            "First re-check the original request's explicit acceptance constraints. "
+            "The next tool call must make the requested edit satisfying all of them; invoke "
+            "apply_patch through exec_command now."
+        )
+    return [*messages, {"role": "developer", "content": reminder}]
+
+
+def _codex_action_command_prefix(responses_request: ResponsesRequest) -> str | None:
+    """Return a DSML command-value prefix after Codex has explored enough."""
+    items = responses_request.input
+    if not isinstance(items, list):
+        return None
+    completed = 0
+    has_edited = False
+    has_test_edit = False
+    has_unresolved_failure = False
+    has_successful_test = False
+    commands_after_edit: list[str] = []
+    for item in items:
+        data = item.model_dump() if hasattr(item, "model_dump") else item
+        if not isinstance(data, dict):
+            continue
+        if data.get("type") == "function_call_output":
+            completed += 1
+            if has_edited:
+                output = str(data.get("output") or "")
+                has_unresolved_failure = has_unresolved_failure or any(
+                    marker in output
+                    for marker in ("FAILED ", " FAILURES ", "Traceback (most recent call last)", " ERROR ")
+                )
+                has_successful_test = has_successful_test or (
+                    " passed" in output and not has_unresolved_failure
+                )
+        if data.get("type") == "function_call":
+            arguments = str(data.get("arguments") or "")
+            if "apply_patch" in arguments:
+                has_edited = True
+                has_test_edit = has_test_edit or any(
+                    marker in arguments for marker in ("tests/", "test_", "_test.")
+                )
+                has_unresolved_failure = False
+                commands_after_edit = []
+            elif has_edited:
+                commands_after_edit.append(arguments)
+    if completed < 5:
+        return None
+    if has_edited:
+        if has_successful_test and not has_unresolved_failure:
+            return None
+        # Give the model room to review its diff, but stop the common semantic
+        # loop where it varies the path/pattern of the same grep indefinitely.
+        # If three post-edit tool turns pass without a regression-test edit,
+        # move it back into the edit phase.  Once tests exist, move it into a
+        # supported Python test invocation (Codex inherits the user's PATH).
+        if len(commands_after_edit) < 3:
+            return None
+        command = (
+            "python -m pytest"
+            if has_test_edit and not has_unresolved_failure
+            else "apply_patch"
+        )
+    else:
+        command = "apply_patch"
+    return (
+        "<｜DSML｜tool_calls>\n"
+        '<｜DSML｜invoke name="exec_command">\n'
+        '<｜DSML｜parameter name="cmd" string="true">'
+        f"{command}"
+    )
+
+
 def _resolve_context_safe_implicit_responses_max_tokens(
     engine: BaseEngine,
     prompt_tokens: int | None,
@@ -142,7 +383,9 @@ def _resolve_context_safe_implicit_responses_max_tokens(
     return min(resolved_max_tokens, remaining_tokens)
 
 
-def _resolved_sampling_kwargs(openai_request: ChatCompletionRequest) -> dict:
+def _resolved_sampling_kwargs(
+    openai_request: ChatCompletionRequest,
+) -> dict:
     """Resolve sampling params through the 4-layer cascade.
 
     Mirrors the helper in routes/anthropic.py so ``/v1/responses`` users
@@ -155,6 +398,30 @@ def _resolved_sampling_kwargs(openai_request: ChatCompletionRequest) -> dict:
         "stop": getattr(openai_request, "stop", None),
     }
     out.update(build_extended_sampling_kwargs(openai_request))
+    return out
+
+
+def _resolved_responses_sampling_kwargs(
+    openai_request: ChatCompletionRequest,
+    responses_request: ResponsesRequest,
+    tool_parser: str | None,
+) -> dict:
+    """Apply Responses/Codex defaults without changing the base helper contract."""
+    out = _resolved_sampling_kwargs(openai_request)
+    if (
+        responses_request.temperature is None
+        and _is_deepseek_codex_surface(responses_request, tool_parser)
+    ):
+        # The 0731 checkpoint ships temperature=1 in generation_config.
+        # That is useful for chat, but in long Codex tool loops it causes
+        # repeated/degenerate DSML and also opts out of the correctness-gated
+        # greedy DSpark path. Coding-agent requests that did not explicitly
+        # choose a temperature therefore use a low-entropy coding default.
+        # A literal greedy 0.0 currently exposes a reproducible DSpark failure
+        # where the second forced exec call has no ``cmd``; 0.2 stays on the
+        # correctness-gated plain sampler while sharply reducing temperature-1
+        # tool degeneration. Explicit client sampling always wins.
+        out["temperature"] = 0.2
     return out
 
 
@@ -391,6 +658,35 @@ async def create_response(request: Request):
     # detectors, the adapter's input-item builder, and any future tool
     # type-keyed dispatch can read ``tools[i].type`` directly.
     normalize_responses_tool_types(responses_request.tools)
+    cfg_for_priming = get_config()
+    priming_tool_parser = cfg_for_priming.tool_call_parser
+    if priming_tool_parser is None:
+        configured_model = " ".join(
+            str(value or "")
+            for value in (
+                cfg_for_priming.model_name,
+                cfg_for_priming.model_alias,
+                cfg_for_priming.model_path,
+            )
+        ).lower()
+        if "deepseek-v4-flash-0731" in configured_model:
+            # Auto parser selection is materialized later in the request
+            # pipeline and historically did not write the inferred name back
+            # to ServerConfig.  First-turn priming runs before that point, so
+            # recognize this checkpoint directly when the CLI did not receive
+            # an explicit --tool-call-parser value.
+            priming_tool_parser = "deepseek_v4_0731"
+    if _should_prime_deepseek_codex_exec(
+        responses_request, priming_tool_parser
+    ):
+        responses_request.tool_choice = {
+            "type": "function",
+            "name": "exec_command",
+        }
+        logger.info(
+            "DeepSeek Codex bounded tool-phase priming: pinning exec_command "
+            "during the first 6 completed tool rounds"
+        )
     validate_responses_tool_types(responses_request.tools)
     # Yuki F6 (0.8.5 dogfood): mirror the chat-completions tool_choice
     # gate so ``required`` / named-function tool_choice REJECTS shapes
@@ -933,6 +1229,7 @@ async def _non_stream(
     created_at = int(time.time())
 
     messages = _prepare_messages_for_engine(engine, openai_request)
+    messages = _inject_codex_progress_reminder(messages, responses_request)
 
     # r5-B C-10 / C-11: tool-coupled UI-TARS sysprompt injection. PR
     # #817 wired ``computer_20251022`` → ``computer`` tool translation
@@ -963,10 +1260,18 @@ async def _non_stream(
             openai_request.max_tokens,
             _resolve_enable_thinking(openai_request),
         ),
-        **_resolved_sampling_kwargs(openai_request),
+        **_resolved_responses_sampling_kwargs(
+            openai_request, responses_request, cfg.tool_call_parser
+        ),
     }
     if openai_request.tools:
         chat_kwargs["tools"] = convert_tools_for_template(openai_request.tools)
+        from .chat import _compute_forced_tool_prefix
+
+        forced_prefix = _compute_forced_tool_prefix(cfg, openai_request)
+        forced_prefix = _codex_action_command_prefix(responses_request) or forced_prefix
+        if forced_prefix:
+            chat_kwargs["forced_assistant_prefix"] = forced_prefix
 
     resolved_thinking = _resolve_enable_thinking(openai_request)
     if resolved_thinking is not None:
@@ -1493,6 +1798,12 @@ async def _non_stream(
             tool_calls, responses_request, openai_request
         )
         if tool_calls and openai_request.tools:
+            if _is_deepseek_codex_surface(
+                responses_request, cfg.tool_call_parser
+            ):
+                _reject_immediate_repeated_tool_call(
+                    tool_calls, responses_request.input
+                )
             _validate_tool_call_params(
                 tool_calls, openai_request.tools, enforce_required=True
             )
@@ -1877,6 +2188,7 @@ async def _stream_responses(
     )
     try:
         messages = _prepare_messages_for_engine(engine, openai_request)
+        messages = _inject_codex_progress_reminder(messages, responses_request)
 
         # r5-B C-10 / C-11: tool-coupled UI-TARS sysprompt injection on
         # the streaming responses lane. Same gate as the non-stream
@@ -1900,10 +2212,20 @@ async def _stream_responses(
                 openai_request.max_tokens,
                 _resolve_enable_thinking(openai_request),
             ),
-            **_resolved_sampling_kwargs(openai_request),
+            **_resolved_responses_sampling_kwargs(
+                openai_request, responses_request, cfg.tool_call_parser
+            ),
         }
         if openai_request.tools:
             chat_kwargs["tools"] = convert_tools_for_template(openai_request.tools)
+            from .chat import _compute_forced_tool_prefix
+
+            forced_prefix = _compute_forced_tool_prefix(cfg, openai_request)
+            forced_prefix = (
+                _codex_action_command_prefix(responses_request) or forced_prefix
+            )
+            if forced_prefix:
+                chat_kwargs["forced_assistant_prefix"] = forced_prefix
         resolved_thinking = _resolve_enable_thinking(openai_request)
         if resolved_thinking is not None:
             chat_kwargs["enable_thinking"] = resolved_thinking
@@ -2926,6 +3248,12 @@ async def _stream_responses(
                 and openai_request.tools
                 and cfg.tool_call_parser == "deepseek_v4_0731"
             ):
+                if _is_deepseek_codex_surface(
+                    responses_request, cfg.tool_call_parser
+                ):
+                    _reject_immediate_repeated_tool_call(
+                        tool_calls, responses_request.input
+                    )
                 _validate_tool_call_params(
                     tool_calls, openai_request.tools, enforce_required=True
                 )


### PR DESCRIPTION
## Summary
- serve Codex-native stable local model metadata when Codex probes `/v1/models`
- bound early DeepSeek exec priming and release it after completed tool calls
- add request-scoped progress/action guidance and reject immediate identical tool actions
- keep all behavior isolated to the DeepSeek V4 0731 + Codex PTY surface

## Validation
- 234 focused API/model/profile/Responses/routes tests passed
- Ruff check and format
- `git diff --check`

## Real-soak motivation
A clean-main local-wheel run reached 74K context over 22 tool turns but remained in repeated exploration and then hit consecutive exact-repetition reconnects. This PR is the bounded intervention being validated against that failure.