### PR TITLE
fix(codex): recover from unavailable test commands

### DIFF
--- a/tests/test_responses_route.py
+++ b/tests/test_responses_route.py
@@ -1485,7 +1485,7 @@ def test_codex_action_prefix_breaks_post_edit_search_loop():
         '{"cmd":"apply_patch <<PATCH\\n*** Update File: tests/test_x.py"}'
     )
     request = ResponsesRequest(model="m", input=items)
-    assert _codex_action_command_prefix(request).endswith(">python -m pytest")
+    assert _codex_action_command_prefix(request).endswith(">python3 -m pytest")
 
     items.extend(
         [
@@ -1503,7 +1503,11 @@ def test_codex_action_prefix_breaks_post_edit_search_loop():
         ]
     )
     request = ResponsesRequest(model="m", input=items)
-    assert _codex_action_command_prefix(request).endswith(">apply_patch")
+    assert _codex_action_command_prefix(request) is None
+
+    items[-1]["output"] = "zsh:1: command not found: python"
+    request = ResponsesRequest(model="m", input=items)
+    assert _codex_action_command_prefix(request) is None
 
 
 def test_deepseek_codex_implicit_temperature_uses_low_entropy_default(monkeypatch):

--- a/vllm_mlx/routes/responses.py
+++ b/vllm_mlx/routes/responses.py
@@ -302,6 +302,8 @@ def _codex_action_command_prefix(responses_request: ResponsesRequest) -> str | N
                             " FAILURES ",
                             "Traceback (most recent call last)",
                             " ERROR ",
+                            "command not found",
+                            "No such file or directory",
                         )
                     )
                     passed = bool(re.search(r"(?m)^\s*\d+\s+passed(?:\s|,|$)", output))
@@ -329,6 +331,11 @@ def _codex_action_command_prefix(responses_request: ResponsesRequest) -> str | N
     if has_edited:
         if has_successful_test and not has_unresolved_failure:
             return None
+        # Let the model diagnose a grounded tool failure. Prefixing another
+        # command here can force the exact unavailable interpreter forever
+        # (for example ``python`` on a macOS host exposing only ``python3``).
+        if has_unresolved_failure:
+            return None
         # Give the model room to review its diff, but stop the common semantic
         # loop where it varies the path/pattern of the same grep indefinitely.
         # If three post-edit tool turns pass without a regression-test edit,
@@ -337,7 +344,7 @@ def _codex_action_command_prefix(responses_request: ResponsesRequest) -> str | N
         if len(commands_after_edit) < 3:
             return None
         command = (
-            "python -m pytest"
+            "python3 -m pytest"
             if has_test_edit and not has_unresolved_failure
             else "apply_patch"
         )


### PR DESCRIPTION
## What changed

- recognize missing-command and missing-file test invocation failures as unresolved
- stop forcing an action prefix after a grounded test-command failure so Codex can diagnose it
- use `python3 -m pytest` for the bounded post-edit test prefix
- add regression coverage for failed tests and unavailable interpreters

## Root cause

The post-edit action prefix hard-coded `python -m pytest`. On macOS environments exposing only `python3`, the generated command failed with `command not found`; because that output was not classified as a failure, the same prefix was forced again on the next turn. This created an unchanged failing-command loop during a real DeepSeek Codex soak.

## Validation

- `52 passed` — `tests/test_responses_route.py`
- reproduced in a real DeepSeek-V4-Flash-0731 Codex engineering run before the fix
