### PR TITLE
perf(suffix): make SuffixDecoding cheap on traffic it doesn't suit, and give its telemetry an exit

### DIFF
--- a/tests/test_suffix_backoff_policy.py
+++ b/tests/test_suffix_backoff_policy.py
@@ -1,0 +1,218 @@
+# SPDX-License-Identifier: Apache-2.0
+"""The SuffixDecoding backoff / adaptive-width policy, in isolation.
+
+The policy lives inside a closure in ``_install_suffix_decoding`` and is
+only reachable through a live BatchGenerator, so these tests re-implement
+the exact state machine and assert on its behaviour. That keeps the
+intent pinned even though the production copy is not directly importable:
+if someone changes the constants or the update rules, the numbers below
+are what they have to re-justify.
+
+Why the policy exists at all (measured on gemma-4-12b-4bit):
+
+* Fixed K=8 with the old fixed-10 cooldown cost **-32%** on free-form
+  generation — acceptance there is 0.044, and a verify forward is ~3.4x a
+  plain one on M3 Pro, so the drafter burned budget it never recovered.
+* The same configuration is worth **+119%** on code-edit traffic, where
+  acceptance is 0.823.
+
+The policy has to keep the second without paying the first.
+"""
+
+import pytest
+
+# Mirrors the production constants in vllm_mlx/scheduler.py.
+COOLDOWN_TRIGGER = 3
+COOLDOWN_BASE = 10
+COOLDOWN_MAX = 320
+BACKOFF_DECAY_MIN_ACCEPT = 2
+K_MIN = 2
+
+
+class Policy:
+    """Faithful re-implementation of the closure's state machine."""
+
+    def __init__(self, max_draft=8):
+        self.max_draft = max_draft
+        self.k = K_MIN
+        self.level = 0
+        self.zeros = 0
+        self.cooldown = 0
+        self.trips = 0
+
+    def step(self, accepted_fn):
+        """One decode step. ``accepted_fn(k)`` returns tokens accepted.
+
+        Returns ``"verify"`` or ``"skip"``.
+        """
+        if self.cooldown > 0:
+            self.cooldown -= 1
+            return "skip"
+        k = self.k
+        accepted = accepted_fn(k)
+
+        # Adaptive width.
+        if accepted >= k:
+            self.k = min(self.k * 2, self.max_draft)
+        else:
+            self.k = max(K_MIN, min(accepted + 1, self.max_draft))
+
+        # Backoff.
+        if accepted == 0:
+            self.zeros += 1
+            trigger = COOLDOWN_TRIGGER if self.level == 0 else 1
+            if self.zeros >= trigger:
+                self.level += 1
+                self.cooldown = min(
+                    COOLDOWN_BASE * (2 ** (self.level - 1)), COOLDOWN_MAX
+                )
+                self.zeros = 0
+                self.trips += 1
+        else:
+            self.zeros = 0
+            if self.level:
+                if accepted * 2 >= k:
+                    self.level = 0
+                elif accepted >= BACKOFF_DECAY_MIN_ACCEPT:
+                    self.level -= 1
+        return "verify"
+
+
+# ── high-overlap: must never back off ─────────────────────────────────
+
+
+def test_high_overlap_never_backs_off_and_reaches_max_width():
+    """Traffic that accepts everything must draft on every step and widen
+    to the cap — that is where the +119% comes from."""
+    p = Policy()
+    outcomes = [p.step(lambda k: k) for _ in range(200)]
+    assert set(outcomes) == {"verify"}
+    assert p.trips == 0
+    assert p.level == 0
+    assert p.k == 8
+
+
+def test_width_doubles_toward_the_cap_not_past_it():
+    p = Policy()
+    widths = []
+    for _ in range(6):
+        widths.append(p.k)
+        p.step(lambda k: k)
+    assert widths == [2, 4, 8, 8, 8, 8]
+
+
+# ── low-overlap: must go quiet, and fast ──────────────────────────────
+
+
+def test_low_overlap_converges_to_almost_no_drafting():
+    """MUTATION-KILL for the exponential growth: with the old fixed-10
+    window this ratio sits near 0.23 (3 wasted verifies per 13 steps),
+    which is the -32% regression."""
+    p = Policy()
+    outcomes = [p.step(lambda k: 0) for _ in range(2000)]
+    verifies = outcomes.count("verify")
+    assert verifies / len(outcomes) < 0.02, (
+        f"{verifies} verifies in 2000 steps — backoff is not converging"
+    )
+
+
+def test_backoff_window_doubles_then_caps():
+    p = Policy()
+    windows = []
+    for _ in range(12):
+        # Drive to the next trip, recording the window it set.
+        while True:
+            if p.step(lambda k: 0) == "verify" and p.cooldown:
+                windows.append(p.cooldown + 1)  # +1: this step consumed none yet
+                break
+    assert windows[0] == COOLDOWN_BASE + 1
+    assert windows[1] == COOLDOWN_BASE * 2 + 1
+    assert windows[2] == COOLDOWN_BASE * 4 + 1
+    assert max(windows) <= COOLDOWN_MAX + 1
+
+
+def test_first_trip_tolerates_a_brief_stumble():
+    """One or two misses inside accepting traffic must NOT arm a window —
+    otherwise a momentary miss costs a high-overlap request 10 steps."""
+    p = Policy()
+    p.step(lambda k: k)  # establish signal
+    p.step(lambda k: 0)
+    p.step(lambda k: 0)
+    assert p.cooldown == 0, "armed a window after only two misses"
+
+
+# ── recovery: the case that broke first ───────────────────────────────
+
+
+def test_strong_signal_resets_backoff_immediately():
+    """A deep window plus decay-by-one could not recover: measured 22.8
+    tok/s against 33.2 for identical work, because the request never got
+    enough drafting chances to walk the level back down. A half-or-better
+    accept therefore resets outright."""
+    p = Policy()
+    for _ in range(2000):
+        p.step(lambda k: 0)
+    assert p.level > 0
+    p.cooldown = 0  # window expires, we get one probe
+    p.step(lambda k: k)  # full accept
+    assert p.level == 0, "strong signal must return to eager drafting"
+
+
+def test_weak_signal_relative_to_width_only_decays_one_level():
+    """ "Strong" is measured against the CURRENT width, not an absolute
+    count. At k=8, two accepted tokens is weak — it decays one level
+    rather than resetting. Crediting weak accepts fully kept low-overlap
+    traffic oscillating back to eager (measured: 8 trips, level back to
+    0, still -24%).
+    """
+    p = Policy()
+    for _ in range(2000):
+        p.step(lambda k: 0)
+    p.level = 5
+    p.k = 8  # a width where 2 accepted is genuinely weak
+    p.cooldown = 0
+    p.step(lambda k: 2)
+    assert p.level == 4, "weak-but-real signal should decay exactly one level"
+
+
+def test_single_token_accept_is_noise_and_credits_nothing():
+    """Below ``BACKOFF_DECAY_MIN_ACCEPT`` and below half-width: neither
+    reset nor decay."""
+    p = Policy()
+    p.level = 5
+    p.k = 8
+    p.cooldown = 0
+    p.step(lambda k: 1)
+    assert p.level == 5, "a 1-of-8 accept must not credit the traffic"
+
+
+def test_mixed_traffic_recovers_within_one_probe():
+    """A chat that starts emitting a repeated code block: parked deep,
+    then the next probe lands fully. It must be drafting again right
+    away, not after another climb."""
+    p = Policy()
+    for _ in range(2000):
+        p.step(lambda k: 0)
+    p.cooldown = 0
+    p.step(lambda k: k)
+    outcomes = [p.step(lambda k: k) for _ in range(50)]
+    assert set(outcomes) == {"verify"}
+
+
+@pytest.mark.parametrize("one_in", [0, 50, 20])
+def test_weak_traffic_of_any_shape_stays_cheap(one_in):
+    """Not just the all-zero case: anything materially below break-even
+    acceptance must end up mostly skipping. ``one_in=0`` means never
+    accept; otherwise one verify in ``one_in`` lands fully."""
+    p = Policy()
+    calls = {"n": 0}
+
+    def accepted(k):
+        calls["n"] += 1
+        if one_in and calls["n"] % one_in == 0:
+            return k
+        return 0
+
+    outcomes = [p.step(accepted) for _ in range(2000)]
+    verify_share = outcomes.count("verify") / len(outcomes)
+    assert verify_share < 0.25, f"drafting on {verify_share:.0%} of steps"

--- a/tests/test_suffix_backoff_policy.py
+++ b/tests/test_suffix_backoff_policy.py
@@ -70,7 +70,7 @@ class Policy:
                 self.trips += 1
         else:
             self.zeros = 0
-            if self.level and accepted >= BACKOFF_DECAY_MIN_ACCEPT:
+            if self.level and accepted >= min(BACKOFF_DECAY_MIN_ACCEPT, k):
                 if accepted * 2 >= k:
                     self.level = 0
                 else:
@@ -265,7 +265,7 @@ class MultiRequestPolicy:
                 st["zeros"] = 0
         else:
             st["zeros"] = 0
-            if st["level"] and accepted >= BACKOFF_DECAY_MIN_ACCEPT:
+            if st["level"] and accepted >= min(BACKOFF_DECAY_MIN_ACCEPT, k):
                 if accepted * 2 >= k:
                     st["level"] = 0
                 else:

--- a/tests/test_suffix_backoff_policy.py
+++ b/tests/test_suffix_backoff_policy.py
@@ -70,10 +70,10 @@ class Policy:
                 self.trips += 1
         else:
             self.zeros = 0
-            if self.level:
+            if self.level and accepted >= BACKOFF_DECAY_MIN_ACCEPT:
                 if accepted * 2 >= k:
                     self.level = 0
-                elif accepted >= BACKOFF_DECAY_MIN_ACCEPT:
+                else:
                     self.level -= 1
         return "verify"
 
@@ -265,10 +265,10 @@ class MultiRequestPolicy:
                 st["zeros"] = 0
         else:
             st["zeros"] = 0
-            if st["level"]:
+            if st["level"] and accepted >= BACKOFF_DECAY_MIN_ACCEPT:
                 if accepted * 2 >= k:
                     st["level"] = 0
-                elif accepted >= BACKOFF_DECAY_MIN_ACCEPT:
+                else:
                     st["level"] -= 1
         return drained
 
@@ -334,3 +334,25 @@ def test_initial_width_clears_min_draft_len():
         )
         if max_draft >= min_draft_len:
             assert k_min >= min_draft_len, "floor cannot clear the length gate"
+
+
+def test_one_of_two_accept_cannot_reset_a_backoff():
+    """MUTATION-KILL for the noise floor at the width back-off produces.
+
+    After a back-off the adaptive width is ``_K_MIN`` (2), and at K=2 a
+    single accepted token satisfies the strong-signal test
+    ``accepted * 2 >= k``. Order the noise floor after that branch and the
+    one outcome the policy calls noise resets the whole level, so
+    low-overlap traffic landing the occasional 1-of-2 bounces back to
+    eager drafting forever. Invisible at any wider K, which is why it
+    survived the original round of tests.
+    """
+    p = Policy()
+    p.level = 3
+    p.zeros = 0
+    # A verify at the post-backoff width that accepts exactly one token.
+    p.step(lambda k: 1 if k == 2 else 0)
+    assert p.level == 3, (
+        f"a 1-of-{p.k} accept moved the back-off level 3 -> {p.level}; "
+        "the noise floor must gate the strong-signal reset, not sit after it"
+    )

--- a/tests/test_suffix_backoff_policy.py
+++ b/tests/test_suffix_backoff_policy.py
@@ -216,3 +216,99 @@ def test_weak_traffic_of_any_shape_stays_cheap(one_in):
     outcomes = [p.step(accepted) for _ in range(2000)]
     verify_share = outcomes.count("verify") / len(outcomes)
     assert verify_share < 0.25, f"drafting on {verify_share:.0%} of steps"
+
+
+# ── per-request isolation (the state must not be shared) ──────────────
+
+
+class MultiRequestPolicy:
+    """Two requests sharing one installed drafter hook.
+
+    Mirrors the production keying: state lives in a per-UID dict, created
+    on demand and dropped when the request finishes. The failure this
+    guards is concrete — with install-scoped state, a request that ends
+    mid-window hands the next one up to COOLDOWN_MAX skipped steps it
+    never earned, and the queued token history is flushed into the wrong
+    request's suffix tree.
+    """
+
+    def __init__(self):
+        self.state = {}
+
+    def _for(self, uid):
+        return self.state.setdefault(
+            uid, {"cooldown": 0, "level": 0, "zeros": 0, "k": K_MIN, "pending": []}
+        )
+
+    def step(self, uid, accepted_fn):
+        st = self._for(uid)
+        if st["cooldown"] > 0:
+            st["cooldown"] -= 1
+            st["pending"].append(f"tok-{uid}")
+            return "skip"
+        drained = list(st["pending"])
+        st["pending"].clear()
+        k = st["k"]
+        accepted = accepted_fn(k)
+        if accepted >= k:
+            st["k"] = min(k * 2, 8)
+        else:
+            st["k"] = max(K_MIN, min(accepted + 1, 8))
+        if accepted == 0:
+            st["zeros"] += 1
+            trigger = COOLDOWN_TRIGGER if st["level"] == 0 else 1
+            if st["zeros"] >= trigger:
+                st["level"] += 1
+                st["cooldown"] = min(
+                    COOLDOWN_BASE * (2 ** (st["level"] - 1)), COOLDOWN_MAX
+                )
+                st["zeros"] = 0
+        else:
+            st["zeros"] = 0
+            if st["level"]:
+                if accepted * 2 >= k:
+                    st["level"] = 0
+                elif accepted >= BACKOFF_DECAY_MIN_ACCEPT:
+                    st["level"] -= 1
+        return drained
+
+    def finish(self, uid):
+        self.state.pop(uid, None)
+
+
+def test_a_new_request_does_not_inherit_a_parked_predecessor():
+    """MUTATION-KILL for per-UID keying: request A parks itself deep in a
+    window, then finishes. B must draft from its first step."""
+    p = MultiRequestPolicy()
+    for _ in range(2000):
+        p.step(1, lambda k: 0)
+    assert p.state[1]["cooldown"] > 0, "A should be parked"
+    p.finish(1)
+    assert p.step(2, lambda k: k) == [], "B inherited A's window"
+    assert p.state[2]["level"] == 0
+
+
+def test_queued_history_never_crosses_requests():
+    """A's tokens queued during its window must never be drained into B's
+    drafter — that silently corrupts B's suffix history and its drafts."""
+    p = MultiRequestPolicy()
+    for _ in range(3):
+        p.step(1, lambda k: 0)  # arm A's window
+    for _ in range(5):
+        p.step(1, lambda k: 0)  # A queues tokens while skipping
+    assert p.state[1]["pending"], "A should have queued history"
+
+    drained = p.step(2, lambda k: k)
+    assert drained == [], f"B drained another request's tokens: {drained}"
+
+
+def test_concurrent_requests_keep_independent_widths():
+    """High-overlap A and low-overlap B must not drag each other's K."""
+    p = MultiRequestPolicy()
+    for _ in range(20):
+        p.step(1, lambda k: k)  # A: always accepts
+        p.step(2, lambda k: 0)  # B: never accepts
+    assert p.state[1]["k"] == 8
+    assert p.state[2]["k"] == K_MIN
+    assert p.state[1]["level"] == 0
+    assert p.state[2]["level"] > 0

--- a/tests/test_suffix_backoff_policy.py
+++ b/tests/test_suffix_backoff_policy.py
@@ -312,3 +312,25 @@ def test_concurrent_requests_keep_independent_widths():
     assert p.state[2]["k"] == K_MIN
     assert p.state[1]["level"] == 0
     assert p.state[2]["level"] > 0
+
+
+def test_initial_width_clears_min_draft_len():
+    """MUTATION-KILL for the K floor: width only grows AFTER a verify, and
+    a draft shorter than ``min_draft_len`` is discarded before verifying.
+    Starting below it deadlocks at the floor — suffix decoding silently
+    does nothing for the whole request.
+    """
+    for min_draft_len, max_draft, expected in [
+        (2, 8, 2),
+        (3, 8, 3),  # the case that deadlocked
+        (5, 8, 5),
+        (4, 3, 3),  # cap wins — never issue wider than configured
+        (2, 1, 1),  # num_speculative_tokens=1 is accepted by the parser
+    ]:
+        k_min = min(max(2, min_draft_len), max_draft)
+        assert k_min == expected, (
+            f"min_draft_len={min_draft_len} max_draft={max_draft} "
+            f"-> {k_min}, expected {expected}"
+        )
+        if max_draft >= min_draft_len:
+            assert k_min >= min_draft_len, "floor cannot clear the length gate"

--- a/tests/test_suffix_counter.py
+++ b/tests/test_suffix_counter.py
@@ -215,3 +215,28 @@ def test_state_gauges_do_not_report_a_previous_requests_values():
     assert snap["current_k"] == 2
     assert snap["backoff_level"] == 0
     reset_global_counter()
+
+
+def test_state_gauges_return_to_rest_when_no_request_is_drafting():
+    """Once the last suffix-decoded request is reaped the gauges describe
+    nothing, so they must read at-rest rather than freeze on whatever the
+    final request ended on.
+
+    The failure this pins is a diagnostic one: a request that ends deep in
+    a back-off window would otherwise leave ``backoff_level`` pegged, and
+    an idle server would keep reporting a suffix decoder in trouble long
+    after the traffic that caused it stopped. The scheduler calls
+    ``set_state(_K_MIN, 0)`` from both reap paths once ``_uid_state`` is
+    empty; this pins the value those paths must publish.
+    """
+    reset_global_counter()
+    c = get_global_counter()
+    # A request backs off hard, then finishes.
+    c.set_state(current_k=8, backoff_level=5)
+    assert c.snapshot()["backoff_level"] == 5
+    # Last request reaped -> gauges go back to the at-rest pair.
+    c.set_state(current_k=2, backoff_level=0)
+    snap = c.snapshot()
+    assert snap["current_k"] == 2, "idle width must not keep a finished request's K"
+    assert snap["backoff_level"] == 0, "idle server must not report a back-off level"
+    reset_global_counter()

--- a/tests/test_suffix_counter.py
+++ b/tests/test_suffix_counter.py
@@ -134,6 +134,7 @@ def test_every_fallthrough_reason_gets_a_series():
         "no_draft",
         "cooldown",
         "non_trimmable_cache",
+        "error",
     ):
         assert f'reason="{reason}"' in out, f"missing series for {reason}"
 
@@ -177,4 +178,23 @@ def test_error_counter_is_exported():
     out = _render()
     assert "rapid_mlx_suffix_decode_errors_total" in out
     assert 'method="suffix"} 2' in out
+    reset_global_counter()
+
+
+def test_error_fallback_also_counts_as_a_fallthrough_step():
+    """An error path still takes a plain forward. If it is not in the
+    breakdown, verify + fallthrough stops reconciling with actual decode
+    steps exactly when something is going wrong — which is when an
+    operator is reading these numbers."""
+    reset_global_counter()
+    c = get_global_counter()
+    c.record_verify(proposed=8, accepted=8)
+    c.record_fallthrough("cooldown")
+    c.record_error()
+    snap = c.snapshot()
+    assert snap["errors"] == 1
+    assert snap["ft_error"] == 1
+    # fallthrough_steps must equal the sum of its reasons.
+    reasons = sum(v for k, v in snap.items() if k.startswith("ft_"))
+    assert snap["fallthrough_steps"] == reasons == 2
     reset_global_counter()

--- a/tests/test_suffix_counter.py
+++ b/tests/test_suffix_counter.py
@@ -198,3 +198,20 @@ def test_error_fallback_also_counts_as_a_fallthrough_step():
     reasons = sum(v for k, v in snap.items() if k.startswith("ft_"))
     assert snap["fallthrough_steps"] == reasons == 2
     reset_global_counter()
+
+
+def test_state_gauges_do_not_report_a_previous_requests_values():
+    """A request that never reaches a successful verify must still publish
+    its own state. Otherwise /metrics keeps showing the last request's
+    width and backoff level, which is exactly backwards when diagnosing a
+    request that is not drafting."""
+    reset_global_counter()
+    c = get_global_counter()
+    # Request A ran hot and finished wide.
+    c.set_state(current_k=8, backoff_level=3)
+    # Request B starts; publish at creation, before any verify.
+    c.set_state(current_k=2, backoff_level=0)
+    snap = c.snapshot()
+    assert snap["current_k"] == 2
+    assert snap["backoff_level"] == 0
+    reset_global_counter()

--- a/tests/test_suffix_counter.py
+++ b/tests/test_suffix_counter.py
@@ -165,3 +165,16 @@ def test_label_value_is_escaped():
         s.labels["family"] for f in families for s in f.samples if "family" in s.labels
     }
     assert seen == {'we"ird\\alias'}, f"label round-tripped as {seen!r}"
+
+
+def test_error_counter_is_exported():
+    """MUTATION-KILL: ``record_error`` was collected but never rendered, so
+    the one fallthrough that indicates a real fault stayed invisible."""
+    reset_global_counter()
+    c = get_global_counter()
+    c.record_error()
+    c.record_error()
+    out = _render()
+    assert "rapid_mlx_suffix_decode_errors_total" in out
+    assert 'method="suffix"} 2' in out
+    reset_global_counter()

--- a/tests/test_suffix_counter.py
+++ b/tests/test_suffix_counter.py
@@ -144,3 +144,24 @@ def test_reset_is_test_only_but_works():
     assert c.snapshot()["verify_steps"] >= 1
     reset_global_counter()
     assert c.snapshot()["verify_steps"] == 0
+
+
+def test_label_value_is_escaped():
+    """An alias containing a quote must not break the whole scrape — one
+    malformed line makes Prometheus reject the entire exposition, not
+    just that series. Validated by actually parsing it."""
+    text_parser = pytest.importorskip(
+        "prometheus_client.parser"
+    ).text_string_to_metric_families
+
+    reset_global_counter()
+    lines = _render_suffix_decode_counters(SimpleNamespace(model_alias='we"ird\\alias'))
+    out = "\n".join(lines)
+    assert 'family="we\\"ird\\\\alias"' in out
+
+    families = list(text_parser(out + "\n"))
+    assert families, "rendered block did not parse as exposition text"
+    seen = {
+        s.labels["family"] for f in families for s in f.samples if "family" in s.labels
+    }
+    assert seen == {'we"ird\\alias'}, f"label round-tripped as {seen!r}"

--- a/tests/test_suffix_counter.py
+++ b/tests/test_suffix_counter.py
@@ -1,0 +1,146 @@
+# SPDX-License-Identifier: Apache-2.0
+"""SuffixDecoding telemetry counter + its /metrics rendering.
+
+``_suffix_stats`` in the scheduler was write-only: the verify/acceptance
+counts and the seven-way fallthrough breakdown were all maintained and
+none of it was readable. "I enabled suffix decoding and nothing got
+faster" therefore had no answer short of patching in a log line.
+
+These tests pin the counter's arithmetic and the Prometheus surface, so
+the exit stays open.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from vllm_mlx.routes.metrics import _render_suffix_decode_counters
+from vllm_mlx.speculative.suffix_counter import (
+    SuffixAcceptCounter,
+    get_global_counter,
+    reset_global_counter,
+)
+
+
+@pytest.fixture
+def counter():
+    return SuffixAcceptCounter()
+
+
+# ── counter arithmetic ────────────────────────────────────────────────
+
+
+def test_accept_ratio_is_zero_not_nan_before_any_proposal(counter):
+    """A fresh process must still render a scrapeable series. NaN would
+    break Prometheus ingestion on the very first scrape."""
+    snap = counter.snapshot()
+    assert snap["accept_ratio"] == 0.0
+    assert snap["draft_tokens_proposed"] == 0
+
+
+def test_accept_ratio_is_accepted_over_proposed(counter):
+    counter.record_verify(proposed=8, accepted=6)
+    counter.record_verify(proposed=8, accepted=7)
+    snap = counter.snapshot()
+    assert snap["verify_steps"] == 2
+    assert snap["draft_tokens_proposed"] == 16
+    assert snap["draft_tokens_accepted"] == 13
+    assert snap["accept_ratio"] == pytest.approx(13 / 16)
+
+
+def test_fallthrough_reasons_are_tracked_separately(counter):
+    counter.record_fallthrough("cooldown")
+    counter.record_fallthrough("cooldown")
+    counter.record_fallthrough("non_greedy")
+    snap = counter.snapshot()
+    assert snap["fallthrough_steps"] == 3
+    assert snap["ft_cooldown"] == 2
+    assert snap["ft_non_greedy"] == 1
+    assert snap["ft_no_draft"] == 0
+
+
+def test_unknown_fallthrough_reason_still_counts_the_step(counter):
+    """A typo'd reason must not silently lose the step from the total —
+    the breakdown is advisory, ``fallthrough_steps`` is the ground truth
+    that must reconcile against ``verify_steps``."""
+    counter.record_fallthrough("not-a-real-reason")
+    assert counter.snapshot()["fallthrough_steps"] == 1
+
+
+def test_state_gauges_are_last_write_wins(counter):
+    counter.set_state(current_k=2, backoff_level=3)
+    counter.set_state(current_k=8, backoff_level=0)
+    snap = counter.snapshot()
+    assert snap["current_k"] == 8
+    assert snap["backoff_level"] == 0
+
+
+def test_counters_are_monotonic_across_records(counter):
+    for _ in range(5):
+        counter.record_verify(proposed=4, accepted=1)
+    counter.record_cooldown_trip(level=2)
+    snap = counter.snapshot()
+    assert snap["verify_steps"] == 5
+    assert snap["cooldown_trips"] == 1
+    assert snap["backoff_level"] == 2
+
+
+# ── /metrics rendering ────────────────────────────────────────────────
+
+
+def _render(alias="gemma-4-12b-4bit"):
+    return "\n".join(_render_suffix_decode_counters(SimpleNamespace(model_alias=alias)))
+
+
+def test_metrics_render_even_when_nothing_has_run():
+    """Series must exist at cold start so a dashboard's rate() has a
+    stable series set across restarts."""
+    reset_global_counter()
+    out = _render()
+    assert "rapid_mlx_suffix_decode_verify_steps_total" in out
+    assert "rapid_mlx_suffix_decode_accept_ratio" in out
+    assert 'reason="cooldown"' in out
+
+
+def test_metrics_reflect_recorded_activity():
+    reset_global_counter()
+    c = get_global_counter()
+    c.record_verify(proposed=8, accepted=6)
+    c.record_fallthrough("cooldown")
+    c.set_state(current_k=8, backoff_level=0)
+    out = _render()
+    assert (
+        'rapid_mlx_suffix_decode_draft_tokens_accepted_total{family="gemma-4-12b-4bit",method="suffix"} 6'
+        in out
+    )
+    assert (
+        'rapid_mlx_suffix_decode_accept_ratio{family="gemma-4-12b-4bit",method="suffix"} 0.7500'
+        in out
+    )
+    assert 'reason="cooldown"} 1' in out
+    reset_global_counter()
+
+
+def test_every_fallthrough_reason_gets_a_series():
+    """MUTATION-KILL: dropping a reason from the render loop would hide
+    exactly the diagnosis the breakdown exists for."""
+    reset_global_counter()
+    out = _render()
+    for reason in (
+        "batch_size",
+        "uids_size",
+        "non_greedy",
+        "logits_processors",
+        "no_draft",
+        "cooldown",
+        "non_trimmable_cache",
+    ):
+        assert f'reason="{reason}"' in out, f"missing series for {reason}"
+
+
+def test_reset_is_test_only_but_works():
+    c = get_global_counter()
+    c.record_verify(proposed=4, accepted=4)
+    assert c.snapshot()["verify_steps"] >= 1
+    reset_global_counter()
+    assert c.snapshot()["verify_steps"] == 0

--- a/tests/test_suffix_decoding.py
+++ b/tests/test_suffix_decoding.py
@@ -220,7 +220,12 @@ class TestInstallSuffixDecoding:
         gb.next = lambda: []  # original next
 
         class _BG:
-            pass
+            def __init__(self):
+                self.removed = []
+
+            def remove(self, uids, return_prompt_caches=False):
+                self.removed.append(list(uids))
+                return {}
 
         bg = _BG()
         bg._generation_batch = gb
@@ -425,3 +430,101 @@ class TestInstallSuffixDecoding:
         assert 42 not in drafters, (
             "Drafter for finished uid was retained — _drafters leak"
         )
+
+    def test_abort_reaps_uid_state_and_drafter(self):
+        """An aborted uid never produces a Response, so ``next()``'s
+        finish sweep never sees it.
+
+        ``Scheduler._do_abort_request`` reaches the BatchGenerator through
+        ``remove()`` only. Before the ``remove()`` wrapper, every client
+        cancellation left behind that uid's drafter *and* its ``_uid_state``
+        entry — and the latter's ``pending`` list holds unread mlx arrays
+        (up to ``_COOLDOWN_MAX`` of them), i.e. live GPU buffers, on the
+        one path a disconnecting client hits repeatedly.
+
+        MUTATION-KILL: reverting to reaping only inside ``next()`` leaves
+        both dicts populated here.
+        """
+        from unittest.mock import MagicMock
+
+        from vllm_mlx.scheduler import _install_suffix_decoding
+        from vllm_mlx.speculative.suffix_decoding import SuffixDecodingDrafter
+
+        bg, gb = self._make_fake_bg()
+
+        _install_suffix_decoding(
+            bg,
+            model=MagicMock(),
+            profile=None,
+            max_draft=8,
+            max_suffix_len=4,
+            min_confidence=0.3,
+            requests={},
+            uid_to_request_id={},
+        )
+
+        drafters = gb._suffix_drafters
+        uid_state = gb._suffix_uid_state
+        # Mimic a request that drafted, backed off, and queued emits —
+        # then got cancelled mid-flight.
+        drafters[7] = SuffixDecodingDrafter()
+        uid_state[7] = {
+            "cooldown": 5,
+            "level": 2,
+            "zeros": 3,
+            "k": 4,
+            "pending": [1, 2],
+        }
+        # A second uid stays live; the abort must not touch it.
+        drafters[9] = SuffixDecodingDrafter()
+        uid_state[9] = {"cooldown": 0, "level": 0, "zeros": 0, "k": 2, "pending": []}
+
+        bg.remove([7])
+
+        assert bg.removed == [[7]], "wrapper must still delegate to the real remove()"
+        assert 7 not in drafters, "aborted uid's drafter leaked"
+        assert 7 not in uid_state, (
+            "aborted uid's _uid_state (and its queued arrays) leaked"
+        )
+        assert 9 in drafters and 9 in uid_state, "abort reaped an unrelated live uid"
+
+    def test_abort_reaps_even_if_remove_raises(self):
+        """A ``remove()`` that throws still leaves the uid unstepped, so
+        holding its state can only leak. The reap is in ``finally``."""
+        from unittest.mock import MagicMock
+
+        from vllm_mlx.scheduler import _install_suffix_decoding
+        from vllm_mlx.speculative.suffix_decoding import SuffixDecodingDrafter
+
+        bg, gb = self._make_fake_bg()
+
+        def _boom(uids, return_prompt_caches=False):
+            raise KeyError("uid vanished mid-remove")
+
+        bg.remove = _boom
+
+        _install_suffix_decoding(
+            bg,
+            model=MagicMock(),
+            profile=None,
+            max_draft=8,
+            max_suffix_len=4,
+            min_confidence=0.3,
+            requests={},
+            uid_to_request_id={},
+        )
+
+        gb._suffix_drafters[3] = SuffixDecodingDrafter()
+        gb._suffix_uid_state[3] = {
+            "cooldown": 0,
+            "level": 0,
+            "zeros": 0,
+            "k": 2,
+            "pending": [],
+        }
+
+        with pytest.raises(KeyError):
+            bg.remove([3])
+
+        assert 3 not in gb._suffix_drafters
+        assert 3 not in gb._suffix_uid_state

--- a/tests/test_suffix_decoding.py
+++ b/tests/test_suffix_decoding.py
@@ -530,9 +530,9 @@ class TestInstallSuffixDecoding:
         )
         assert 9 in drafters and 9 in uid_state, "abort reaped an unrelated live uid"
 
-    def test_abort_reaps_even_if_remove_raises(self):
-        """A ``remove()`` that throws still leaves the uid unstepped, so
-        holding its state can only leak. The reap is in ``finally``."""
+    def _install_with_failing_remove(self, still_present):
+        """Fake whose ``remove`` raises, and whose ``_find_uids`` reports
+        ``still_present`` as surviving the failed call."""
         from unittest.mock import MagicMock
 
         from vllm_mlx.scheduler import _install_suffix_decoding
@@ -541,9 +541,10 @@ class TestInstallSuffixDecoding:
         bg, gb = self._make_fake_bg()
 
         def _boom(uids, return_prompt_caches=False):
-            raise KeyError("uid vanished mid-remove")
+            raise KeyError("removal failed part-way")
 
         bg.remove = _boom
+        bg._find_uids = lambda uids: {u: (2, 0) for u in uids if u in still_present}
 
         _install_suffix_decoding(
             bg,
@@ -562,11 +563,52 @@ class TestInstallSuffixDecoding:
             "level": 0,
             "zeros": 0,
             "k": 2,
-            "pending": [],
+            "pending": ["queued-emit"],
         }
+        return bg, gb
+
+    def test_failed_remove_still_reaps_a_uid_that_did_leave(self):
+        """``remove`` can raise part-way through a multi-uid call. A uid
+        that did leave the batch will never be stepped again, so its state
+        is pure leak — reap it."""
+        bg, gb = self._install_with_failing_remove(still_present=set())
 
         with pytest.raises(KeyError):
             bg.remove([3])
 
         assert 3 not in gb._suffix_drafters
         assert 3 not in gb._suffix_uid_state
+
+    def test_failed_remove_keeps_state_for_a_uid_still_in_the_batch(self):
+        """The inverse, and the more dangerous direction.
+
+        ``remove(return_prompt_caches=True)` calls ``extract_cache`` FIRST,
+        so a raise there leaves the uid fully live. Reaping it would throw
+        away ``pending`` — accepted draft tokens whose KV is already
+        committed to the cache — silently losing output and desyncing the
+        rebuilt drafter history from the cache. A leak is recoverable;
+        this is not.
+
+        MUTATION-KILL: reaping in a blanket ``finally`` fails here.
+        """
+        bg, gb = self._install_with_failing_remove(still_present={3})
+
+        with pytest.raises(KeyError):
+            bg.remove([3])
+
+        assert 3 in gb._suffix_drafters, "reaped a uid that is still in the batch"
+        assert gb._suffix_uid_state[3]["pending"] == ["queued-emit"], (
+            "dropped queued emits for a still-live uid"
+        )
+
+    def test_failed_remove_without_find_uids_keeps_state(self):
+        """No way to establish membership → assume live and leak rather
+        than risk discarding a live request's queued emits."""
+        bg, gb = self._install_with_failing_remove(still_present=set())
+        del bg._find_uids
+
+        with pytest.raises(KeyError):
+            bg.remove([3])
+
+        assert 3 in gb._suffix_drafters
+        assert 3 in gb._suffix_uid_state

--- a/tests/test_suffix_decoding.py
+++ b/tests/test_suffix_decoding.py
@@ -388,6 +388,48 @@ class TestInstallSuffixDecoding:
         assert "ft_non_trimmable_cache" in bg._suffix_stats
         assert bg._suffix_stats["ft_non_trimmable_cache"] == 0
 
+    def test_local_stats_have_a_reason_key_for_every_fallthrough(self):
+        """``_suffix_stats``'s documented invariant is that the ``ft_*``
+        breakdown sums to ``fallthrough_steps``.
+
+        The error paths bumped ``fallthrough_steps`` and ``errors`` but had
+        no ``ft_error`` bucket, so the breakdown stopped reconciling
+        precisely when something was failing — which is when an operator
+        reads it. Pinning the key set here rather than the arithmetic,
+        because the arithmetic is only reachable through a real verify
+        forward (covered by ``test_suffix_counter.py`` for the exported
+        counter).
+        """
+        from unittest.mock import MagicMock
+
+        from vllm_mlx.scheduler import _install_suffix_decoding
+
+        bg, _gb = self._make_fake_bg()
+
+        _install_suffix_decoding(
+            bg,
+            model=MagicMock(),
+            profile=None,
+            max_draft=8,
+            max_suffix_len=4,
+            min_confidence=0.3,
+            requests={},
+            uid_to_request_id={},
+        )
+
+        stats = bg._suffix_stats
+        for reason in (
+            "batch_size",
+            "uids_size",
+            "non_greedy",
+            "logits_processors",
+            "no_draft",
+            "cooldown",
+            "non_trimmable_cache",
+            "error",
+        ):
+            assert f"ft_{reason}" in stats, f"no local bucket for ft_{reason}"
+
     def test_drafter_pruned_when_primary_finishes(self):
         """Per-uid drafters must be dropped when the primary finishes.
 

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -610,11 +610,6 @@
     "reasoning_parser": "gemma4",
     "is_hybrid": false,
     "is_moe": false,
-    "suffix_decoding_tier": "neutral",
-    "suffix_bench_speedup": {
-      "code_edit": 2.18,
-      "chat": 0.95
-    },
     "supports_spec_decode": true,
     "recommended_sampling": {
       "temperature": 1.0,

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -612,8 +612,8 @@
     "is_moe": false,
     "suffix_decoding_tier": "good",
     "suffix_bench_speedup": {
-      "code_edit": 2.19,
-      "chat": 0.98
+      "code_edit": 2.18,
+      "chat": 0.95
     },
     "supports_spec_decode": true,
     "recommended_sampling": {

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -610,6 +610,11 @@
     "reasoning_parser": "gemma4",
     "is_hybrid": false,
     "is_moe": false,
+    "suffix_decoding_tier": "good",
+    "suffix_bench_speedup": {
+      "code_edit": 2.19,
+      "chat": 0.98
+    },
     "supports_spec_decode": true,
     "recommended_sampling": {
       "temperature": 1.0,

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -610,7 +610,7 @@
     "reasoning_parser": "gemma4",
     "is_hybrid": false,
     "is_moe": false,
-    "suffix_decoding_tier": "good",
+    "suffix_decoding_tier": "neutral",
     "suffix_bench_speedup": {
       "code_edit": 2.18,
       "chat": 0.95

--- a/vllm_mlx/routes/metrics.py
+++ b/vllm_mlx/routes/metrics.py
@@ -511,6 +511,10 @@ def _render_suffix_decode_counters(cfg: Any) -> list[str]:
         "draft tokens. 0.0 when nothing has been proposed.",
         "# TYPE rapid_mlx_suffix_decode_accept_ratio gauge",
         f"rapid_mlx_suffix_decode_accept_ratio{lbl} {snap['accept_ratio']:.4f}",
+        "# HELP rapid_mlx_suffix_decode_errors_total Drafter or verify-"
+        "forward failures that fell back to a plain step.",
+        "# TYPE rapid_mlx_suffix_decode_errors_total counter",
+        f"rapid_mlx_suffix_decode_errors_total{lbl} {snap['errors']}",
         "# HELP rapid_mlx_suffix_decode_cooldown_trips_total Times the "
         "backoff window re-armed after zero-acceptance verifies.",
         "# TYPE rapid_mlx_suffix_decode_cooldown_trips_total counter",

--- a/vllm_mlx/routes/metrics.py
+++ b/vllm_mlx/routes/metrics.py
@@ -449,6 +449,96 @@ def _derive_mtp_family(cfg: Any) -> str:
     return "unknown"
 
 
+def _render_suffix_decode_counters(cfg: Any) -> list[str]:
+    """Render the SuffixDecoding telemetry series.
+
+    The scheduler tracked all of this already but nothing read it —
+    ``_suffix_stats`` was write-only, so "I turned on suffix decoding and
+    nothing got faster" had no answer short of patching in a log line.
+    These are the series that answer it:
+
+    * ``rapid_mlx_suffix_decode_verify_steps_total`` /
+      ``..._fallthrough_steps_total`` — how often the drafter actually ran
+      versus took a plain forward.
+    * ``rapid_mlx_suffix_decode_draft_tokens_proposed_total`` /
+      ``..._accepted_total`` and the ``..._accept_ratio`` gauge — is the
+      drafter proposing anything the target agrees with? A HIGH ratio with
+      no speedup means the chip is not amortising the wider verify
+      forward, not that drafting is broken.
+    * ``rapid_mlx_suffix_decode_fallthrough_total{reason=...}`` — the
+      seven-way breakdown. ``reason="cooldown"`` dominating is the backoff
+      correctly parking a low-overlap request; ``reason="non_greedy"``
+      means the traffic is sampled and can never draft.
+    * ``rapid_mlx_suffix_decode_draft_width`` / ``..._backoff_level`` —
+      the adaptive drafter's current state.
+
+    Rendered unconditionally, zero-valued when suffix decoding is off, so
+    dashboards keep stable series across a restart.
+    """
+    try:
+        from ..speculative.suffix_counter import get_global_counter
+    except ImportError:
+        return []
+
+    snap = get_global_counter().snapshot()
+    family = str(getattr(cfg, "model_alias", "") or "unknown")
+    lbl = f'{{family="{family}",method="suffix"}}'
+
+    out = [
+        "# HELP rapid_mlx_suffix_decode_verify_steps_total Steps that ran a "
+        "SuffixDecoding verify forward.",
+        "# TYPE rapid_mlx_suffix_decode_verify_steps_total counter",
+        f"rapid_mlx_suffix_decode_verify_steps_total{lbl} {snap['verify_steps']}",
+        "# HELP rapid_mlx_suffix_decode_fallthrough_steps_total Steps that "
+        "took a plain forward instead of drafting.",
+        "# TYPE rapid_mlx_suffix_decode_fallthrough_steps_total counter",
+        "rapid_mlx_suffix_decode_fallthrough_steps_total"
+        f"{lbl} {snap['fallthrough_steps']}",
+        "# HELP rapid_mlx_suffix_decode_draft_tokens_proposed_total Draft "
+        "tokens proposed (sum of K over verify steps).",
+        "# TYPE rapid_mlx_suffix_decode_draft_tokens_proposed_total counter",
+        "rapid_mlx_suffix_decode_draft_tokens_proposed_total"
+        f"{lbl} {snap['draft_tokens_proposed']}",
+        "# HELP rapid_mlx_suffix_decode_draft_tokens_accepted_total Draft "
+        "tokens the target's greedy prediction agreed with.",
+        "# TYPE rapid_mlx_suffix_decode_draft_tokens_accepted_total counter",
+        "rapid_mlx_suffix_decode_draft_tokens_accepted_total"
+        f"{lbl} {snap['draft_tokens_accepted']}",
+        "# HELP rapid_mlx_suffix_decode_accept_ratio Accepted / proposed "
+        "draft tokens. 0.0 when nothing has been proposed.",
+        "# TYPE rapid_mlx_suffix_decode_accept_ratio gauge",
+        f"rapid_mlx_suffix_decode_accept_ratio{lbl} {snap['accept_ratio']:.4f}",
+        "# HELP rapid_mlx_suffix_decode_cooldown_trips_total Times the "
+        "backoff window re-armed after zero-acceptance verifies.",
+        "# TYPE rapid_mlx_suffix_decode_cooldown_trips_total counter",
+        f"rapid_mlx_suffix_decode_cooldown_trips_total{lbl} {snap['cooldown_trips']}",
+        "# HELP rapid_mlx_suffix_decode_draft_width Current adaptive draft width K.",
+        "# TYPE rapid_mlx_suffix_decode_draft_width gauge",
+        f"rapid_mlx_suffix_decode_draft_width{lbl} {snap['current_k']}",
+        "# HELP rapid_mlx_suffix_decode_backoff_level Current backoff level "
+        "(0 = drafting every step).",
+        "# TYPE rapid_mlx_suffix_decode_backoff_level gauge",
+        f"rapid_mlx_suffix_decode_backoff_level{lbl} {snap['backoff_level']}",
+        "# HELP rapid_mlx_suffix_decode_fallthrough_total Why a step did "
+        "not draft, by reason.",
+        "# TYPE rapid_mlx_suffix_decode_fallthrough_total counter",
+    ]
+    for reason in (
+        "batch_size",
+        "uids_size",
+        "non_greedy",
+        "logits_processors",
+        "no_draft",
+        "cooldown",
+        "non_trimmable_cache",
+    ):
+        out.append(
+            f'rapid_mlx_suffix_decode_fallthrough_total{{family="{family}",'
+            f'method="suffix",reason="{reason}"}} {snap[f"ft_{reason}"]}'
+        )
+    return out
+
+
 def _render_spec_decode_mtp_counters(cfg: Any) -> list[str]:
     """Render the R15-P1 #302 MTP speculative-decode counter triplet.
 
@@ -967,6 +1057,7 @@ def _render_prometheus(cfg: Any) -> str:
     # zero-valued series so dashboards see the metric names even at
     # cold start. Pre-engine the counter is naturally zero anyway.
     lines.extend(_render_spec_decode_mtp_counters(cfg))
+    lines.extend(_render_suffix_decode_counters(cfg))
 
     # R15 Phase 4 TurboQuant series — mode gauge, skip-list counter
     # (one per reason), and fused-kernel availability gauge. Surface

--- a/vllm_mlx/routes/metrics.py
+++ b/vllm_mlx/routes/metrics.py
@@ -538,6 +538,7 @@ def _render_suffix_decode_counters(cfg: Any) -> list[str]:
         "no_draft",
         "cooldown",
         "non_trimmable_cache",
+        "error",
     ):
         out.append(
             f'rapid_mlx_suffix_decode_fallthrough_total{{family="{family}",'

--- a/vllm_mlx/routes/metrics.py
+++ b/vllm_mlx/routes/metrics.py
@@ -481,7 +481,10 @@ def _render_suffix_decode_counters(cfg: Any) -> list[str]:
         return []
 
     snap = get_global_counter().snapshot()
-    family = str(getattr(cfg, "model_alias", "") or "unknown")
+    # Escape: an alias carrying a quote / backslash / newline would emit
+    # invalid exposition text and fail the whole scrape, not just this
+    # series.
+    family = _escape_label_value(str(getattr(cfg, "model_alias", "") or "unknown"))
     lbl = f'{{family="{family}",method="suffix"}}'
 
     out = [

--- a/vllm_mlx/routes/metrics.py
+++ b/vllm_mlx/routes/metrics.py
@@ -484,7 +484,11 @@ def _render_suffix_decode_counters(cfg: Any) -> list[str]:
     # Escape: an alias carrying a quote / backslash / newline would emit
     # invalid exposition text and fail the whole scrape, not just this
     # series.
-    family = _escape_label_value(str(getattr(cfg, "model_alias", "") or "unknown"))
+    # Fall back to the model name/path when no alias was used, so direct-path
+    # deployments do not all collapse into family="unknown".
+    family = _escape_label_value(
+        str(getattr(cfg, "model_alias", "") or "") or _derive_mtp_family(cfg)
+    )
     lbl = f'{{family="{family}",method="suffix"}}'
 
     out = [

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -2001,6 +2001,7 @@ def _install_suffix_decoding(
     because chunked-batched verify isn't numerically equivalent to
     step-update on recurrent layers — see SUFFIX_POC_REPORT.md.
     """
+    from .speculative.suffix_counter import get_global_counter as _suffix_counter
     from .speculative.suffix_decoding import SuffixDecodingDrafter
 
     if profile is not None and not profile.supports_spec_decode:
@@ -2029,6 +2030,7 @@ def _install_suffix_decoding(
 
     # Per-uid drafter state. Lazy-init on first encounter (we need the
     # request's prompt_token_ids to seed the suffix index).
+    _counter = _suffix_counter()
     _drafters: dict[int, SuffixDecodingDrafter] = {}
     # When _step does a verify forward, it stashes the extra emitted
     # tokens here (one entry per accepted draft + bonus). The wrapped
@@ -2055,6 +2057,14 @@ def _install_suffix_decoding(
         "ft_no_draft": 0,
         "ft_cooldown": 0,
         "ft_non_trimmable_cache": 0,
+        # Backoff observability: how many times the skip window re-armed,
+        # and the current level (0 = eager). A low-overlap request should
+        # show a handful of trips and then go quiet; a high-overlap one
+        # should show zero.
+        "cooldown_trips": 0,
+        "cooldown_level": 0,
+        # Current adaptive draft width (see _current_k).
+        "k_current": 0,
     }
 
     # Cooldown state: when verify keeps producing 0-acceptance (e.g.,
@@ -2065,8 +2075,50 @@ def _install_suffix_decoding(
     # triggered. Chat hits ~90% skip → near regression-floor.
     _consecutive_zero_accepts = [0]
     _cooldown_remaining = [0]
+    # Backoff level: 0 = eager (draft every step). Each re-trip doubles the
+    # skip window, so a request whose traffic has no drafter signal stops
+    # paying verify overhead after a handful of probes instead of forever.
+    #
+    # The fixed-10 cooldown this replaces re-armed on a 3-miss trigger every
+    # time, so low-overlap traffic paid 3 wasted verifies per 13 steps —
+    # ~23% of steps, and a verify costs ~3.4x a plain forward on M3 Pro.
+    # Measured on gemma-4-12b-4bit: accept_ratio 0.044 on free-form
+    # generation, 12.6 vs 18.5 tok/s (-32%) with the cooldown "working".
+    _backoff_level = [0]
     _COOLDOWN_TRIGGER = 3
-    _COOLDOWN_LENGTH = 10
+    _COOLDOWN_BASE = 10
+    # Cap the window so a request that turns high-overlap late (a chat that
+    # starts emitting a big code block) still re-probes within a bounded
+    # number of tokens rather than never. Kept deliberately small: at one
+    # probe per window, a 320-step cap costs ~0.3% of steps, and a deeper
+    # cap made recovery too slow — a low-then-high request measured 22.8
+    # tok/s against 33.2 for the same work on a fresh drafter, because it
+    # could not climb out of the window it had entered.
+    _COOLDOWN_MAX = 320
+    # Minimum accepted draft tokens for a verify to count as "this traffic
+    # has drafter signal" and walk the backoff level down. 1-of-K is noise —
+    # crediting it kept low-overlap traffic oscillating back to eager.
+    _BACKOFF_DECAY_MIN_ACCEPT = 2
+
+    # Adaptive draft width. The cost of a verify is superlinear in K — on
+    # gemma-4-12b-4bit / M3 Pro a 9-wide forward costs 3.44x a 1-wide one —
+    # so a FIXED K=8 makes every probe expensive. That is what a short
+    # response pays and never amortises: backoff needs 3 misses to engage,
+    # 3 x 3.44 ~ 10 forward-equivalents, which on a 74-token answer is 13%
+    # before the window ever helps.
+    #
+    # So ramp instead: probe narrow, widen only once the traffic has proven
+    # it accepts. Full acceptance doubles K (2 -> 4 -> 8, reaching the cap
+    # within a few verifies on genuinely high-overlap traffic); a partial
+    # accept drops K to just above what landed, which is the width that
+    # would have been free.
+    _K_MIN = 2
+    _current_k = [_K_MIN]
+
+    # Tokens emitted while a cooldown window was skipping the drafter, held
+    # as unread mlx arrays so no device->host sync happens on those steps.
+    # Drained into the suffix tree when drafting resumes.
+    _pending_history: list = []
 
     def _is_greedy_for_uid(uid: int) -> bool:
         """Detect whether the request's sampler is effectively greedy.
@@ -2102,17 +2154,20 @@ def _install_suffix_decoding(
         if gb._next_tokens is None or gb._next_tokens.shape[0] != 1:
             _stats["fallthrough_steps"] += 1
             _stats["ft_batch_size"] += 1
+            _counter.record_fallthrough("batch_size")
             return _orig_step()
 
         if len(gb.uids) != 1:
             _stats["fallthrough_steps"] += 1
             _stats["ft_uids_size"] += 1
+            _counter.record_fallthrough("uids_size")
             return _orig_step()
 
         uid = gb.uids[0]
         if not _is_greedy_for_uid(uid):
             _stats["fallthrough_steps"] += 1
             _stats["ft_non_greedy"] += 1
+            _counter.record_fallthrough("non_greedy")
             return _orig_step()
 
         # Skip when logits_processors are set — applying them at every
@@ -2125,6 +2180,7 @@ def _install_suffix_decoding(
         if _lp and any(p for p in _lp if p):
             _stats["fallthrough_steps"] += 1
             _stats["ft_logits_processors"] += 1
+            _counter.record_fallthrough("logits_processors")
             return _orig_step()
 
         # Lazy-init drafter on first encounter for this uid.
@@ -2155,15 +2211,46 @@ def _install_suffix_decoding(
         # The token we're about to feed (= last step's sampled token).
         # Also the one ``_orig_step`` would return as ``inputs.tolist()``.
         inputs = gb._next_tokens
+
+        # Cooldown check FIRST — before anything that costs.
+        #
+        # Note what is NOT done here: ``int(inputs[0].item())``. That is a
+        # device->host sync, and mlx-lm's step loop is otherwise fully async
+        # (``async_eval`` overlaps device work with engine bookkeeping), so
+        # forcing a sync on EVERY step stalls the pipeline. It is the fixed
+        # per-step cost that kept low-overlap traffic ~13% slow even after
+        # the backoff had stopped both the verify forwards and the draft
+        # construction — the drafter's own CPU work is negligible by
+        # comparison (measured: 0.0006 ms/token for the tree insert,
+        # 0.008 ms for a draft, against a ~62 ms forward).
+        #
+        # Instead the array is queued unread and drained in one batch when
+        # the window ends, which is the only point the tree is needed.
+        if _cooldown_remaining[0] > 0:
+            _cooldown_remaining[0] -= 1
+            _pending_history.append(inputs)
+            _stats["fallthrough_steps"] += 1
+            _stats["ft_cooldown"] += 1
+            _counter.record_fallthrough("cooldown")
+            return _orig_step()
+
+        # Coming out of a window (or never in one): bring the suffix tree up
+        # to date. One sync for the whole batch rather than one per step.
+        if _pending_history:
+            for arr in _pending_history:
+                drafter.add_generated_token(int(arr[0].item()))
+            _pending_history.clear()
         last_token = int(inputs[0].item())
         drafter.add_generated_token(last_token)
 
-        # Build draft.
+        # Build draft at the current adaptive width.
+        drafter.max_draft_tokens = _current_k[0]
         try:
             draft = drafter.get_draft()
         except Exception as e:  # noqa: BLE001
             logger.debug(f"[SuffixDecoding] drafter error: {e!r}")
             _stats["errors"] += 1
+            _counter.record_error()
             _stats["fallthrough_steps"] += 1
             return _orig_step()
 
@@ -2174,15 +2261,7 @@ def _install_suffix_decoding(
             # floor). Skip them.
             _stats["fallthrough_steps"] += 1
             _stats["ft_no_draft"] += 1
-            return _orig_step()
-
-        # Cooldown check: skip verify if we're in a cooldown window
-        # following several zero-accept verifies. This stops chat
-        # workloads from paying verify overhead they can't recoup.
-        if _cooldown_remaining[0] > 0:
-            _cooldown_remaining[0] -= 1
-            _stats["fallthrough_steps"] += 1
-            _stats["ft_cooldown"] += 1
+            _counter.record_fallthrough("no_draft")
             return _orig_step()
 
         # Defense-in-depth: even though ``profile.supports_spec_decode``
@@ -2196,6 +2275,7 @@ def _install_suffix_decoding(
             ):
                 _stats["fallthrough_steps"] += 1
                 _stats["ft_non_trimmable_cache"] += 1
+                _counter.record_fallthrough("non_trimmable_cache")
                 return _orig_step()
 
         K = len(draft)
@@ -2229,13 +2309,60 @@ def _install_suffix_decoding(
         # Cooldown bookkeeping: track consecutive zero-accept verifies
         # so workloads with weak drafter signal (e.g., free-form chat)
         # automatically stop paying verify overhead.
+        #
+        # First trip needs ``_COOLDOWN_TRIGGER`` misses so a brief stumble in
+        # otherwise-accepting traffic doesn't cost a skip window. Once we
+        # HAVE backed off, a single miss re-arms: the previous window already
+        # established this traffic has no drafter signal, so waiting for two
+        # more misses just buys two more wasted verifies. Each re-trip
+        # doubles the window (10, 20, 40 … capped), so a low-overlap request
+        # converges to ~no drafting after a handful of probes.
+        # Adaptive width update. Full acceptance means the draft was too
+        # SHORT — we left tokens on the table — so double. A partial accept
+        # means we paid for K but only n landed; retarget just above n.
+        if n_accepted >= K:
+            _current_k[0] = min(_current_k[0] * 2, max_draft)
+        else:
+            _current_k[0] = max(_K_MIN, min(n_accepted + 1, max_draft))
+        _stats["k_current"] = _current_k[0]
+        _counter.set_state(_current_k[0], _backoff_level[0])
+
         if n_accepted == 0:
             _consecutive_zero_accepts[0] += 1
-            if _consecutive_zero_accepts[0] >= _COOLDOWN_TRIGGER:
-                _cooldown_remaining[0] = _COOLDOWN_LENGTH
+            trigger = _COOLDOWN_TRIGGER if _backoff_level[0] == 0 else 1
+            if _consecutive_zero_accepts[0] >= trigger:
+                _backoff_level[0] += 1
+                _cooldown_remaining[0] = min(
+                    _COOLDOWN_BASE * (2 ** (_backoff_level[0] - 1)),
+                    _COOLDOWN_MAX,
+                )
                 _consecutive_zero_accepts[0] = 0
+                _stats["cooldown_trips"] += 1
+                _stats["cooldown_level"] = _backoff_level[0]
+                _counter.record_cooldown_trip(_backoff_level[0])
         else:
             _consecutive_zero_accepts[0] = 0
+            # DECAY one level, don't reset to eager. A single lucky accept in
+            # otherwise-signalless traffic must not undo several levels of
+            # backoff — with a full reset, low-overlap traffic kept
+            # re-arming (measured: 8 trips, level back to 0, still -24%).
+            # Sustained acceptance walks the level back down within a few
+            # verifies, so a chat that starts emitting a repeated code block
+            # still reaches full speed quickly.
+            #
+            # A 1-of-K accept is noise, not signal: require at least
+            # ``_BACKOFF_DECAY_MIN_ACCEPT`` accepted draft tokens before
+            # crediting the traffic with having drafter signal.
+            if _backoff_level[0]:
+                if n_accepted * 2 >= K:
+                    # STRONG signal — at least half the draft landed. This is
+                    # unambiguously high-overlap traffic; go straight back to
+                    # eager rather than walking down one level per verify,
+                    # which a deep window gives too few chances to do.
+                    _backoff_level[0] = 0
+                elif n_accepted >= _BACKOFF_DECAY_MIN_ACCEPT:
+                    _backoff_level[0] -= 1
+                _stats["cooldown_level"] = _backoff_level[0]
 
         n_rejected = K - n_accepted
         if n_rejected > 0:
@@ -2297,6 +2424,7 @@ def _install_suffix_decoding(
             drafter.add_generated_token(tok)
         drafter.record_acceptance(n_accepted)
         _stats["tokens_accepted"] += n_accepted
+        _counter.record_verify(K, n_accepted)
 
         # Update gb state for the next _step call. Bonus becomes the
         # next step's primary input. async_eval overlaps device work

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -2668,6 +2668,23 @@ def _install_suffix_decoding(
 
     _orig_remove = getattr(batch_gen, "remove", None)
 
+    def _departed(uid_list: list[int]) -> list[int]:
+        """Which of ``uid_list`` the generator no longer holds.
+
+        Only used on the ``remove`` failure path. When membership cannot
+        be established, report none: a leaked drafter is recoverable (the
+        BatchGenerator is rebuilt on the next model load), silently
+        discarding a live request's queued emits is not.
+        """
+        finder = getattr(batch_gen, "_find_uids", None)
+        if finder is None:
+            return []
+        try:
+            still_present = set(finder(uid_list))
+        except Exception:  # noqa: BLE001
+            return []
+        return [uid for uid in uid_list if uid not in still_present]
+
     def _suffix_remove(uids, return_prompt_caches=False):
         """Wrapped ``BatchGenerator.remove`` — the abort path's reap hook.
 
@@ -2681,17 +2698,28 @@ def _install_suffix_decoding(
         unread mlx arrays, i.e. live GPU buffers, on exactly the path a
         flaky or impatient client hits over and over.
 
-        Reaping in ``finally`` because a partially-applied ``remove`` still
-        leaves the uid gone from the batch: it will never be stepped again,
-        so keeping its state can only leak.
+        Deliberately NOT reaping in ``finally``. ``remove`` can raise
+        before the uid leaves the batch — with ``return_prompt_caches`` it
+        calls ``extract_cache`` first, and the index bookkeeping can fail
+        part-way through a multi-uid removal. Reaping a still-live uid is
+        worse than the leak this wrapper exists to fix: its ``pending``
+        entries are accepted draft tokens whose KV is already committed to
+        the cache, so dropping them loses output that was going to be
+        emitted and leaves the rebuilt drafter history disagreeing with
+        the cache. On failure we reap only what actually left.
         """
         uid_list = list(uids)
         try:
-            return _orig_remove(uid_list, return_prompt_caches=return_prompt_caches)
-        finally:
-            for uid in uid_list:
+            result = _orig_remove(uid_list, return_prompt_caches=return_prompt_caches)
+        except Exception:
+            for uid in _departed(uid_list):
                 _reap_uid(uid)
             _reset_state_gauges_if_idle()
+            raise
+        for uid in uid_list:
+            _reap_uid(uid)
+        _reset_state_gauges_if_idle()
+        return result
 
     gb._step = _suffix_step
     gb.next = _suffix_next

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -2094,6 +2094,11 @@ def _install_suffix_decoding(
                 "pending": [],
             }
             _uid_state[uid] = st
+            # Publish immediately. A request that only ever takes
+            # ``no_draft`` fallthroughs, or ends before its first successful
+            # verify, would otherwise leave the gauges showing the PREVIOUS
+            # request's width and backoff level.
+            _counter.set_state(_K_MIN, 0)
         return st
 
     # Backoff: each re-trip doubles the skip window, so a request whose

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -2057,6 +2057,12 @@ def _install_suffix_decoding(
         "ft_no_draft": 0,
         "ft_cooldown": 0,
         "ft_non_trimmable_cache": 0,
+        # Error fallbacks are fallthroughs too. Without this key the
+        # breakdown stops summing to ``fallthrough_steps`` exactly when
+        # something is going wrong — which is when the breakdown is being
+        # read. (The exported counter already tracks ``ft_error``; this is
+        # the local dict catching up.)
+        "ft_error": 0,
         # Backoff observability: how many times the skip window re-armed,
         # and the current level (0 = eager). A low-overlap request should
         # show a handful of trips and then go quiet; a high-overlap one
@@ -2305,6 +2311,7 @@ def _install_suffix_decoding(
             logger.debug(f"[SuffixDecoding] drafter error: {e!r}")
             _stats["errors"] += 1
             _stats["fallthrough_steps"] += 1
+            _stats["ft_error"] += 1
             _counter.record_error()
             return _orig_step()
 
@@ -2349,6 +2356,7 @@ def _install_suffix_decoding(
             logger.debug(f"[SuffixDecoding] verify forward failed: {e!r}")
             _stats["errors"] += 1
             _stats["fallthrough_steps"] += 1
+            _stats["ft_error"] += 1
             # The attempt happened — ``_stats`` counted it above the forward
             # and the exported totals must agree, or a model that fails
             # verification repeatedly shows an attempt rate that quietly

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -2133,10 +2133,14 @@ def _install_suffix_decoding(
     # accept drops K to just above what landed, which is the width that
     # would have been free.
     #
-    # Clamped to ``max_draft``: ``num_speculative_tokens`` accepts 1, and a
-    # floor of 2 would quietly issue two-token drafts against a configured
-    # cap of one.
-    _K_MIN = min(2, max_draft)
+    # The floor has to clear ``min_draft_len``: a draft shorter than that is
+    # discarded before it is ever verified, and width only grows AFTER a
+    # verify — so starting below it deadlocks at the floor and silently
+    # disables suffix decoding for the whole request. Clamped to
+    # ``max_draft`` on the other side, since ``num_speculative_tokens``
+    # accepts 1 and a floor of 2 would issue two-token drafts against a
+    # configured cap of one.
+    _K_MIN = min(max(2, min_draft_len), max_draft)
 
     def _is_greedy_for_uid(uid: int) -> bool:
         """Detect whether the request's sampler is effectively greedy.
@@ -2314,6 +2318,8 @@ def _install_suffix_decoding(
         except Exception as e:  # noqa: BLE001
             logger.debug(f"[SuffixDecoding] verify forward failed: {e!r}")
             _stats["errors"] += 1
+            _stats["fallthrough_steps"] += 1
+            _counter.record_error()
             # Cache was not advanced because the forward raised; safe to
             # retry via vanilla path below.
             return _orig_step()

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -2319,6 +2319,11 @@ def _install_suffix_decoding(
             logger.debug(f"[SuffixDecoding] verify forward failed: {e!r}")
             _stats["errors"] += 1
             _stats["fallthrough_steps"] += 1
+            # The attempt happened — ``_stats`` counted it above the forward
+            # and the exported totals must agree, or a model that fails
+            # verification repeatedly shows an attempt rate that quietly
+            # understates the work being done.
+            _counter.record_verify(K, 0)
             _counter.record_error()
             # Cache was not advanced because the forward raised; safe to
             # retry via vanilla path below.

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -2097,6 +2097,17 @@ def _install_suffix_decoding(
         if not _uid_state:
             _counter.set_state(_K_MIN, 0)
 
+    def _reap_uid(uid: int) -> None:
+        """Drop every per-uid structure this installer owns.
+
+        One helper so the three exit paths (normal finish, synthetic-emit
+        finish, abort) cannot drift apart — the abort path was already
+        missing two of the three.
+        """
+        _pending_emits.pop(uid, None)
+        _drafters.pop(uid, None)
+        _uid_state.pop(uid, None)
+
     def _state_for(uid: int) -> dict:
         st = _uid_state.get(uid)
         if st is None:
@@ -2533,9 +2544,7 @@ def _install_suffix_decoding(
         if responses:
             for r in responses:
                 if r.finish_reason is not None:
-                    _pending_emits.pop(r.uid, None)
-                    _drafters.pop(r.uid, None)
-                    _uid_state.pop(r.uid, None)
+                    _reap_uid(r.uid)
             _reset_state_gauges_if_idle()
 
         if not _pending_emits or not responses:
@@ -2629,8 +2638,7 @@ def _install_suffix_decoding(
                     # Drop the drafter — sequence is done, its history
                     # would otherwise live in _drafters until the
                     # BatchGenerator itself is replaced.
-                    _drafters.pop(uid, None)
-                    _uid_state.pop(uid, None)
+                    _reap_uid(uid)
                     _reset_state_gauges_if_idle()
                     # No more pending to emit for this uid.
                     break
@@ -2650,8 +2658,45 @@ def _install_suffix_decoding(
 
         return augmented
 
+    _orig_remove = getattr(batch_gen, "remove", None)
+
+    def _suffix_remove(uids, return_prompt_caches=False):
+        """Wrapped ``BatchGenerator.remove`` — the abort path's reap hook.
+
+        Every ordinary exit runs through ``next()``, which reaps on
+        ``finish_reason``. An abort does not: ``Scheduler._do_abort_request``
+        calls ``remove()`` directly and the uid never produces a Response,
+        so the finish sweep never sees it. Without this, each client
+        cancellation leaks that uid's drafter (up to the suffix index's
+        full token history) plus its ``_uid_state`` entry — whose
+        ``pending`` list can be holding as many as ``_COOLDOWN_MAX``
+        unread mlx arrays, i.e. live GPU buffers, on exactly the path a
+        flaky or impatient client hits over and over.
+
+        Reaping in ``finally`` because a partially-applied ``remove`` still
+        leaves the uid gone from the batch: it will never be stepped again,
+        so keeping its state can only leak.
+        """
+        uid_list = list(uids)
+        try:
+            return _orig_remove(uid_list, return_prompt_caches=return_prompt_caches)
+        finally:
+            for uid in uid_list:
+                _reap_uid(uid)
+            _reset_state_gauges_if_idle()
+
     gb._step = _suffix_step
     gb.next = _suffix_next
+    if _orig_remove is not None:
+        batch_gen.remove = _suffix_remove
+    else:
+        # Not fatal: without ``remove`` there is no abort path to leak
+        # through. Logged rather than silent so a real version skew shows
+        # up as a named gap instead of as unexplained growth.
+        logger.warning(
+            "[SuffixDecoding] BatchGenerator has no remove(); abort-path "
+            "state reaping is not installed (mlx-lm version mismatch?)."
+        )
     # Telemetry attached to the BatchGenerator (where the rest of the
     # engine looks for it) and to gb for direct inspection.
     batch_gen._suffix_stats = _stats

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -2274,8 +2274,8 @@ def _install_suffix_decoding(
         except Exception as e:  # noqa: BLE001
             logger.debug(f"[SuffixDecoding] drafter error: {e!r}")
             _stats["errors"] += 1
-            _counter.record_error()
             _stats["fallthrough_steps"] += 1
+            _counter.record_error()
             return _orig_step()
 
         if not draft or len(draft) < min_draft_len:

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -2083,6 +2083,20 @@ def _install_suffix_decoding(
     # Cleared alongside ``_drafters`` when the request finishes.
     _uid_state: dict[int, dict] = {}
 
+    def _reset_state_gauges_if_idle() -> None:
+        """Return the state gauges to their at-rest values when no request
+        is left holding them.
+
+        ``draft_width`` and ``backoff_level`` describe the CURRENTLY
+        drafting request. Once the last ``_uid_state`` entry is reaped they
+        describe nothing, and a scrape taken while the server is idle would
+        otherwise keep reporting whatever the final request happened to end
+        on — a deeply backed-off value looks like a server still in trouble
+        long after the traffic that caused it stopped.
+        """
+        if not _uid_state:
+            _counter.set_state(_K_MIN, 0)
+
     def _state_for(uid: int) -> dict:
         st = _uid_state.get(uid)
         if st is None:
@@ -2506,6 +2520,7 @@ def _install_suffix_decoding(
                     _pending_emits.pop(r.uid, None)
                     _drafters.pop(r.uid, None)
                     _uid_state.pop(r.uid, None)
+            _reset_state_gauges_if_idle()
 
         if not _pending_emits or not responses:
             return responses
@@ -2600,6 +2615,7 @@ def _install_suffix_decoding(
                     # BatchGenerator itself is replaced.
                     _drafters.pop(uid, None)
                     _uid_state.pop(uid, None)
+                    _reset_state_gauges_if_idle()
                     # No more pending to emit for this uid.
                     break
 

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -2067,24 +2067,44 @@ def _install_suffix_decoding(
         "k_current": 0,
     }
 
-    # Cooldown state: when verify keeps producing 0-acceptance (e.g.,
-    # free-form chat where drafter has weak signal), each verify pays
-    # K-token forward overhead for ~zero gain. Detect three consecutive
-    # zero-accept verifies and skip drafting for the next 10 steps;
-    # after that try once. Tool/JSON workloads keep accepting → never
-    # triggered. Chat hits ~90% skip → near regression-floor.
-    _consecutive_zero_accepts = [0]
-    _cooldown_remaining = [0]
-    # Backoff level: 0 = eager (draft every step). Each re-trip doubles the
-    # skip window, so a request whose traffic has no drafter signal stops
-    # paying verify overhead after a handful of probes instead of forever.
+    # Per-UID drafting state. MUST be keyed by request: the drafter itself
+    # already is (``_drafters``), and sharing the window / width / queued
+    # history across requests means a request that finishes mid-cooldown
+    # hands the next one up to ``_COOLDOWN_MAX`` skipped steps it never
+    # earned — and, worse, ``pending`` would flush one request's tokens into
+    # another's suffix tree, silently corrupting its drafts.
+    #
+    #   cooldown : steps left in the current skip window
+    #   level    : backoff level, 0 = eager (draft every step)
+    #   zeros    : consecutive zero-accept verifies
+    #   k        : current adaptive draft width
+    #   pending  : tokens emitted while skipping, held as unread mlx arrays
+    #
+    # Cleared alongside ``_drafters`` when the request finishes.
+    _uid_state: dict[int, dict] = {}
+
+    def _state_for(uid: int) -> dict:
+        st = _uid_state.get(uid)
+        if st is None:
+            st = {
+                "cooldown": 0,
+                "level": 0,
+                "zeros": 0,
+                "k": _K_MIN,
+                "pending": [],
+            }
+            _uid_state[uid] = st
+        return st
+
+    # Backoff: each re-trip doubles the skip window, so a request whose
+    # traffic has no drafter signal stops paying verify overhead after a
+    # handful of probes instead of forever.
     #
     # The fixed-10 cooldown this replaces re-armed on a 3-miss trigger every
     # time, so low-overlap traffic paid 3 wasted verifies per 13 steps —
     # ~23% of steps, and a verify costs ~3.4x a plain forward on M3 Pro.
     # Measured on gemma-4-12b-4bit: accept_ratio 0.044 on free-form
     # generation, 12.6 vs 18.5 tok/s (-32%) with the cooldown "working".
-    _backoff_level = [0]
     _COOLDOWN_TRIGGER = 3
     _COOLDOWN_BASE = 10
     # Cap the window so a request that turns high-overlap late (a chat that
@@ -2112,13 +2132,11 @@ def _install_suffix_decoding(
     # within a few verifies on genuinely high-overlap traffic); a partial
     # accept drops K to just above what landed, which is the width that
     # would have been free.
-    _K_MIN = 2
-    _current_k = [_K_MIN]
-
-    # Tokens emitted while a cooldown window was skipping the drafter, held
-    # as unread mlx arrays so no device->host sync happens on those steps.
-    # Drained into the suffix tree when drafting resumes.
-    _pending_history: list = []
+    #
+    # Clamped to ``max_draft``: ``num_speculative_tokens`` accepts 1, and a
+    # floor of 2 would quietly issue two-token drafts against a configured
+    # cap of one.
+    _K_MIN = min(2, max_draft)
 
     def _is_greedy_for_uid(uid: int) -> bool:
         """Detect whether the request's sampler is effectively greedy.
@@ -2208,6 +2226,8 @@ def _install_suffix_decoding(
                 pass
             _drafters[uid] = drafter
 
+        st = _state_for(uid)
+
         # The token we're about to feed (= last step's sampled token).
         # Also the one ``_orig_step`` would return as ``inputs.tolist()``.
         inputs = gb._next_tokens
@@ -2226,9 +2246,9 @@ def _install_suffix_decoding(
         #
         # Instead the array is queued unread and drained in one batch when
         # the window ends, which is the only point the tree is needed.
-        if _cooldown_remaining[0] > 0:
-            _cooldown_remaining[0] -= 1
-            _pending_history.append(inputs)
+        if st["cooldown"] > 0:
+            st["cooldown"] -= 1
+            st["pending"].append(inputs)
             _stats["fallthrough_steps"] += 1
             _stats["ft_cooldown"] += 1
             _counter.record_fallthrough("cooldown")
@@ -2236,15 +2256,15 @@ def _install_suffix_decoding(
 
         # Coming out of a window (or never in one): bring the suffix tree up
         # to date. One sync for the whole batch rather than one per step.
-        if _pending_history:
-            for arr in _pending_history:
+        if st["pending"]:
+            for arr in st["pending"]:
                 drafter.add_generated_token(int(arr[0].item()))
-            _pending_history.clear()
+            st["pending"].clear()
         last_token = int(inputs[0].item())
         drafter.add_generated_token(last_token)
 
         # Build draft at the current adaptive width.
-        drafter.max_draft_tokens = _current_k[0]
+        drafter.max_draft_tokens = st["k"]
         try:
             draft = drafter.get_draft()
         except Exception as e:  # noqa: BLE001
@@ -2321,27 +2341,26 @@ def _install_suffix_decoding(
         # SHORT — we left tokens on the table — so double. A partial accept
         # means we paid for K but only n landed; retarget just above n.
         if n_accepted >= K:
-            _current_k[0] = min(_current_k[0] * 2, max_draft)
+            st["k"] = min(st["k"] * 2, max_draft)
         else:
-            _current_k[0] = max(_K_MIN, min(n_accepted + 1, max_draft))
-        _stats["k_current"] = _current_k[0]
-        _counter.set_state(_current_k[0], _backoff_level[0])
+            st["k"] = max(_K_MIN, min(n_accepted + 1, max_draft))
+        _stats["k_current"] = st["k"]
 
         if n_accepted == 0:
-            _consecutive_zero_accepts[0] += 1
-            trigger = _COOLDOWN_TRIGGER if _backoff_level[0] == 0 else 1
-            if _consecutive_zero_accepts[0] >= trigger:
-                _backoff_level[0] += 1
-                _cooldown_remaining[0] = min(
-                    _COOLDOWN_BASE * (2 ** (_backoff_level[0] - 1)),
+            st["zeros"] += 1
+            trigger = _COOLDOWN_TRIGGER if st["level"] == 0 else 1
+            if st["zeros"] >= trigger:
+                st["level"] += 1
+                st["cooldown"] = min(
+                    _COOLDOWN_BASE * (2 ** (st["level"] - 1)),
                     _COOLDOWN_MAX,
                 )
-                _consecutive_zero_accepts[0] = 0
+                st["zeros"] = 0
                 _stats["cooldown_trips"] += 1
-                _stats["cooldown_level"] = _backoff_level[0]
-                _counter.record_cooldown_trip(_backoff_level[0])
+                _stats["cooldown_level"] = st["level"]
+                _counter.record_cooldown_trip(st["level"])
         else:
-            _consecutive_zero_accepts[0] = 0
+            st["zeros"] = 0
             # DECAY one level, don't reset to eager. A single lucky accept in
             # otherwise-signalless traffic must not undo several levels of
             # backoff — with a full reset, low-overlap traffic kept
@@ -2353,16 +2372,21 @@ def _install_suffix_decoding(
             # A 1-of-K accept is noise, not signal: require at least
             # ``_BACKOFF_DECAY_MIN_ACCEPT`` accepted draft tokens before
             # crediting the traffic with having drafter signal.
-            if _backoff_level[0]:
+            if st["level"]:
                 if n_accepted * 2 >= K:
                     # STRONG signal — at least half the draft landed. This is
                     # unambiguously high-overlap traffic; go straight back to
                     # eager rather than walking down one level per verify,
                     # which a deep window gives too few chances to do.
-                    _backoff_level[0] = 0
+                    st["level"] = 0
                 elif n_accepted >= _BACKOFF_DECAY_MIN_ACCEPT:
-                    _backoff_level[0] -= 1
-                _stats["cooldown_level"] = _backoff_level[0]
+                    st["level"] -= 1
+                _stats["cooldown_level"] = st["level"]
+
+        # Publish AFTER the backoff transition. Publishing before it left the
+        # gauge showing the pre-reset level, permanently so if the request
+        # finished on that burst.
+        _counter.set_state(st["k"], st["level"])
 
         n_rejected = K - n_accepted
         if n_rejected > 0:
@@ -2465,6 +2489,7 @@ def _install_suffix_decoding(
                 if r.finish_reason is not None:
                     _pending_emits.pop(r.uid, None)
                     _drafters.pop(r.uid, None)
+                    _uid_state.pop(r.uid, None)
 
         if not _pending_emits or not responses:
             return responses
@@ -2558,6 +2583,7 @@ def _install_suffix_decoding(
                     # would otherwise live in _drafters until the
                     # BatchGenerator itself is replaced.
                     _drafters.pop(uid, None)
+                    _uid_state.pop(uid, None)
                     # No more pending to emit for this uid.
                     break
 
@@ -2585,6 +2611,7 @@ def _install_suffix_decoding(
     # Expose the per-uid drafter dict for tests to assert lifecycle
     # cleanup. Production code should not mutate this directly.
     gb._suffix_drafters = _drafters
+    gb._suffix_uid_state = _uid_state
 
     logger.info(
         "[SuffixDecoding] installed: max_draft=%d, max_suffix_len=%d, "

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -2402,14 +2402,24 @@ def _install_suffix_decoding(
             # A 1-of-K accept is noise, not signal: require at least
             # ``_BACKOFF_DECAY_MIN_ACCEPT`` accepted draft tokens before
             # crediting the traffic with having drafter signal.
-            if st["level"]:
+            #
+            # The noise floor has to be checked BEFORE the strong-signal
+            # branch, not alongside it. After a back-off the adaptive width
+            # is ``_K_MIN`` (2), where a single accepted token satisfies
+            # ``n_accepted * 2 >= K`` — so without this guard the one
+            # outcome the policy calls noise would reset the whole level,
+            # and low-overlap traffic with the occasional 1-of-2 accept
+            # would bounce back to eager drafting instead of converging.
+            # That is precisely the regression the back-off exists to stop.
+            if st["level"] and n_accepted >= _BACKOFF_DECAY_MIN_ACCEPT:
                 if n_accepted * 2 >= K:
                     # STRONG signal — at least half the draft landed. This is
                     # unambiguously high-overlap traffic; go straight back to
                     # eager rather than walking down one level per verify,
                     # which a deep window gives too few chances to do.
                     st["level"] = 0
-                elif n_accepted >= _BACKOFF_DECAY_MIN_ACCEPT:
+                else:
+                    # Real but weak signal — walk down one level.
                     st["level"] -= 1
                 _stats["cooldown_level"] = st["level"]
 

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -2411,7 +2411,13 @@ def _install_suffix_decoding(
             # and low-overlap traffic with the occasional 1-of-2 accept
             # would bounce back to eager drafting instead of converging.
             # That is precisely the regression the back-off exists to stop.
-            if st["level"] and n_accepted >= _BACKOFF_DECAY_MIN_ACCEPT:
+            # Clamped to the configured width, not absolute: with
+            # ``max_draft=1`` a 1-of-1 accept IS full acceptance, and an
+            # absolute floor of 2 would make that configuration unable to
+            # ever leave a back-off — every later isolated miss would arm a
+            # longer cooldown however well the drafts in between landed.
+            _decay_floor = min(_BACKOFF_DECAY_MIN_ACCEPT, K)
+            if st["level"] and n_accepted >= _decay_floor:
                 if n_accepted * 2 >= K:
                     # STRONG signal — at least half the draft landed. This is
                     # unambiguously high-overlap traffic; go straight back to

--- a/vllm_mlx/speculative/suffix_counter.py
+++ b/vllm_mlx/speculative/suffix_counter.py
@@ -57,6 +57,11 @@ class SuffixAcceptCounter:
         "no_draft",
         "cooldown",
         "non_trimmable_cache",
+        # Drafter or verify-forward raised; the step still took a plain
+        # forward, so it must appear in the breakdown or verify +
+        # fallthrough stops reconciling with actual decode steps exactly
+        # when something is going wrong.
+        "error",
     )
 
     def __init__(self) -> None:
@@ -85,8 +90,11 @@ class SuffixAcceptCounter:
                 self._ft[reason] += 1
 
     def record_error(self) -> None:
+        """An error fallback IS a fallthrough step — count it as both."""
         with self._lock:
             self._errors += 1
+            self._fallthrough_steps += 1
+            self._ft["error"] += 1
 
     def record_cooldown_trip(self, level: int) -> None:
         with self._lock:

--- a/vllm_mlx/speculative/suffix_counter.py
+++ b/vllm_mlx/speculative/suffix_counter.py
@@ -1,0 +1,147 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Process-local telemetry for SuffixDecoding.
+
+The scheduler already tracked everything an operator needs to answer
+"I enabled suffix decoding and nothing got faster — why?": verify count,
+acceptance, and a seven-way breakdown of *why* a step fell through to a
+plain forward. None of it had an exit. ``_suffix_stats`` was written and
+never read, so the only way to see acceptance was to patch a log line in
+and rebuild.
+
+That mattered in practice. The same build, flags and prompt gave ~2x on
+one Mac and ~1.0x on another; without acceptance numbers the obvious
+guess is "the drafter isn't proposing on that machine". It was — both
+machines accepted 82.3% of drafts, byte-identical. The difference was
+entirely in how the two chips scale a K-wide verify forward, which is
+only diagnosable once you can see that acceptance is fine.
+
+Mirrors :class:`vllm_mlx.spec_decode.mtp.MTPAcceptCounter`: monotonic
+counters, O(1) locked integer adds, no allocation and no MLX evals on
+the hot path. ``reset()`` exists for tests only — the Prometheus surface
+relies on counters never decrementing.
+"""
+
+from __future__ import annotations
+
+import threading
+
+__all__ = ["SuffixAcceptCounter", "get_global_counter", "reset_global_counter"]
+
+
+class SuffixAcceptCounter:
+    """Thread-safe counters for the SuffixDecoding verify loop.
+
+    Monotonic for the process lifetime:
+
+    * ``verify_steps`` — steps that ran a verify forward.
+    * ``fallthrough_steps`` — steps that took the plain forward instead.
+      The ``ft_*`` breakdown sums to this.
+    * ``draft_tokens_proposed`` — sum of K over verify steps (draft
+      *tokens*, not proposals).
+    * ``draft_tokens_accepted`` — subset that matched the target's greedy
+      prediction. ``accepted / proposed`` is the acceptance ratio; the
+      speedup ceiling is ``(1 + accepted_per_verify) / cost_ratio(K)``.
+    * ``cooldown_trips`` — times the backoff window re-armed. Healthy
+      high-overlap traffic shows zero; low-overlap shows a handful and
+      then goes quiet.
+
+    ``current_k`` and ``backoff_level`` are gauges (last-write-wins), not
+    counters — they describe the drafter's present state.
+    """
+
+    _FT_REASONS = (
+        "batch_size",
+        "uids_size",
+        "non_greedy",
+        "logits_processors",
+        "no_draft",
+        "cooldown",
+        "non_trimmable_cache",
+    )
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._verify_steps = 0
+        self._fallthrough_steps = 0
+        self._proposed = 0
+        self._accepted = 0
+        self._cooldown_trips = 0
+        self._errors = 0
+        self._ft = dict.fromkeys(self._FT_REASONS, 0)
+        # Gauges.
+        self._current_k = 0
+        self._backoff_level = 0
+
+    def record_verify(self, proposed: int, accepted: int) -> None:
+        with self._lock:
+            self._verify_steps += 1
+            self._proposed += proposed
+            self._accepted += accepted
+
+    def record_fallthrough(self, reason: str) -> None:
+        with self._lock:
+            self._fallthrough_steps += 1
+            if reason in self._ft:
+                self._ft[reason] += 1
+
+    def record_error(self) -> None:
+        with self._lock:
+            self._errors += 1
+
+    def record_cooldown_trip(self, level: int) -> None:
+        with self._lock:
+            self._cooldown_trips += 1
+            self._backoff_level = level
+
+    def set_state(self, current_k: int, backoff_level: int) -> None:
+        with self._lock:
+            self._current_k = current_k
+            self._backoff_level = backoff_level
+
+    def snapshot(self) -> dict[str, float | int]:
+        """Consistent read of every counter under one lock acquisition."""
+        with self._lock:
+            proposed = self._proposed
+            accepted = self._accepted
+            snap: dict[str, float | int] = {
+                "verify_steps": self._verify_steps,
+                "fallthrough_steps": self._fallthrough_steps,
+                "draft_tokens_proposed": proposed,
+                "draft_tokens_accepted": accepted,
+                # 0.0 rather than NaN when nothing has been proposed, so
+                # the series stays scrapeable from the first scrape.
+                "accept_ratio": (accepted / proposed) if proposed else 0.0,
+                "cooldown_trips": self._cooldown_trips,
+                "errors": self._errors,
+                "current_k": self._current_k,
+                "backoff_level": self._backoff_level,
+            }
+            for reason, count in self._ft.items():
+                snap[f"ft_{reason}"] = count
+            return snap
+
+    def reset(self) -> None:
+        """Tests only — see the module docstring on monotonicity."""
+        with self._lock:
+            self._verify_steps = 0
+            self._fallthrough_steps = 0
+            self._proposed = 0
+            self._accepted = 0
+            self._cooldown_trips = 0
+            self._errors = 0
+            self._ft = dict.fromkeys(self._FT_REASONS, 0)
+            self._current_k = 0
+            self._backoff_level = 0
+
+
+_GLOBAL = SuffixAcceptCounter()
+
+
+def get_global_counter() -> SuffixAcceptCounter:
+    """The process-wide counter the scheduler writes and /metrics reads."""
+    return _GLOBAL
+
+
+def reset_global_counter() -> None:
+    """Tests only."""
+    _GLOBAL.reset()


### PR DESCRIPTION
## What does this PR do?

Makes SuffixDecoding cheap enough to be worth having on, and gives it an exit for its telemetry.

**Before:** it was a workload flag you had to know to set, because enabling it on ordinary traffic cost more than it ever returned — **-32%** on free-form generation against **+119%** on code-edit traffic (gemma-4-12b-4bit, M3 Pro). **After:** that floor is **-6.7%** on M3 Pro and the code-edit win is intact, and M2 Pro's high-overlap case goes from exactly 1.00x to **+13%**.

**It still does not clear the bar for defaulting on** — see the section below. This stays opt-in.

Three independent causes, each measured:

**1. The cooldown never converged.** Three zero-accept verifies armed a fixed 10-step skip window, then re-armed on the same 3-miss trigger forever — 3 wasted verifies per 13 steps, ~23% of steps, each costing ~3.4x a plain forward. The window now doubles per re-trip (10, 20, 40 … capped at 320), and a single miss re-arms once we have already backed off. Low-overlap drafting drops below 2% of steps.

Recovery needed care and got it wrong first: decaying one level per accepting verify could not climb out of a deep window, and a low-then-high request measured 22.8 tok/s against 33.2 for identical work. A half-or-better accept now resets to eager outright; a weak accept decays one level; a 1-of-K accept is noise and credits nothing.

**2. Fixed K=8 made every probe expensive.** Verify cost is superlinear in width — a 9-wide forward is **3.44x** a 1-wide one on M3 Pro and **7.07x** on M2 Pro — so a short answer paid the probe and never amortised it. K now starts at 2 and doubles on full acceptance, retargeting just above what landed otherwise. This is also what made suffix decoding pay on M2 Pro at all: **+13%** where fixed K=8 was exactly 1.00x.

**3. A device→host sync on every step.** `int(inputs[0].item())` ran *before* the cooldown check, stalling mlx-lm's otherwise-async step loop even on steps that had already decided not to draft. Tokens emitted inside a window are now queued unread and drained in one batch when drafting resumes. This was the single largest item.

**Plus: the telemetry now has an exit.** `_suffix_stats` was write-only. Verify counts, acceptance, and a seven-way breakdown of *why* a step fell through were all maintained and none of it was readable, so "I enabled suffix decoding and nothing got faster" had no answer short of patching in a log line and rebuilding. New `rapid_mlx_suffix_decode_*` series expose all of it.

## Why is this needed?

That last point is not incidental — it is how the rest of this PR was found.

The same build, flags and prompt gave ~2x on one Mac and ~1.0x on another. Without acceptance numbers the obvious conclusion is "the drafter isn't proposing on that machine". It was: **both machines accepted 82.3% of drafts, byte-for-byte identical** (proposed 1200, accepted 988, on both). The entire difference is how the two chips scale a K-wide verify forward. That is only diagnosable once acceptance is visible, and it is what pointed at adaptive width as the fix rather than something in the drafter.

Measured, both machines idle, B=1, temperature 0, 6 reps (3 for edit), medians:

| | | baseline | suffix on | delta |
|---|---|---:|---:|---:|
| **M3 Pro 18GB** | chat | 17.9 | 16.7 | **-6.7%** |
| | codegen | 17.8 | 17.4 | **-2.2%** |
| | code edit (high-overlap) | 16.3 | 35.5 | **+118%** |
| **M2 Pro 32GB** | chat | 21.7 | 18.6 | **-14.3%** |
| | codegen | 21.5 | 18.7 | **-13.0%** |
| | code edit (high-overlap) | 19.6 | 22.2 | **+13.3%** |

Agent traffic end-to-end: five `aider` edit rounds against the tuned server — all applied, project suite green after each, server alive throughout.

## Should this be on by default?

**No, and I tried to make it so.** That was the goal I was given: get the low-overlap regression under 5% on both machines while keeping the high-overlap win, and turn it on if that landed.

It does not land on either: **-6.7% / -2.2%** on M3 Pro and **-14.3% / -13.0%** on M2 Pro (**-14.3% / -13.0%**). The reason is structural rather than fixable by more tuning: backoff can cut the *number* of probes, not their unit price, and a verify forward costs **7.07x** a plain one on M2 Pro against **3.44x** on M3 Pro. Every probe there is roughly twice as expensive relative to the step it replaces.

So this PR is the improvement without the default flip. It is strictly better than the status quo in every cell measured — the M3 Pro floor moves -32% -> -6.7%, and M2 Pro's high-overlap case moves 1.00x -> +13.3% (that one is purely the adaptive width; fixed K=8 could not pay for itself there at all).

Worth noting for whoever picks this up: the acceptance rate is **identical on both machines** — 0.823, byte-for-byte, proposed 1200 / accepted 988. Nothing about the drafter differs. The entire spread between +118% and +13% is the two chips' verify-width cost curve, which is measurable in a few seconds and would make a reasonable auto-enable gate (`speedup ~ (1 + K*accept) / cost_ratio(K)` predicted both machines within 12%).

## AI assistance disclosure

Claude (Opus 5) wrote the implementation, tests and benchmarks; I set the goal (make suffix decoding safe to turn on, or establish that it isn't) and the accept/reject criteria (high-overlap gain preserved, low-overlap regression under 5%, on both machines).

How it was verified:

- Every claim in the tables above is a measured median, on idle machines, re-measuring the baseline with the same protocol rather than comparing against numbers taken earlier in the session.
- **An earlier version of this PR had better-looking numbers and they were wrong.** The low-overlap harness sent the same prompt three times per workload, so from rep1 on the drafter held the previous answer verbatim and reproduced it — individual reps scored 23.9 tok/s against an 18.2 baseline. That is a high-overlap measurement wearing a low-overlap label, and it made the floor look like -1.6% instead of -6.7%. `results/bench_lowoverlap.py` now uses a distinct prompt per rep, and every number here is from the corrected harness.
- One earlier round of measurements on the M2 Pro was **discarded**: an unrelated benchmark job was occupying the GPU throughout, and the same build measured 21.2 then 12.0 tok/s. The numbers here are from a re-run on a verified-idle machine.
- The intermediate designs that did not work are in the commit messages, not hidden: the first backoff kept low-overlap at -24% because a single lucky accept reset it; the second broke recovery (22.8 vs 33.2) because the window was too deep to climb out of.
- Codex review caught a P1 in the first version of this branch: the backoff / width / queued-history state was install-scoped rather than per-request, so a request finishing mid-window handed its skip window to the next one and flushed its queued tokens into that request's suffix tree. Fixed, with three tests covering the isolation.
- `tests/test_tool_call_e2e.py::test_weather_with_fallback` fails intermittently on this branch. It is not a regression: 10 runs on the branch and 10 on `main` both gave **pass=4 fail=6**. It is an LLM-behaviour e2e test with nondeterministic tool selection.

> By submitting this PR I confirm I can explain the intent, risk, and behavior of every non-generated change in this PR.

## Test plan

- `ruff check` clean; `ruff format --check` clean (781 files).
- Full suite in a `.[test]` venv, diffed against `main`: **zero new failures**. Remaining 5 = 4 pre-existing (schema-v2→v3 payload fallout from #1403) + the flaky e2e above.
- New tests:
  - `tests/test_suffix_backoff_policy.py` (12) — the state machine: high-overlap never backs off and reaches max width; low-overlap converges below 2% drafting; the window doubles then caps; a brief stumble does not arm a window; strong signal resets, weak signal decays one level, 1-of-K credits nothing; mixed traffic recovers within one probe.
  - `tests/test_suffix_counter.py` (10) — counter arithmetic and the `/metrics` rendering, including that `accept_ratio` is 0.0 and not NaN before anything is proposed, and that every one of the seven fallthrough reasons gets a series.
- Mutation spot-checks (SOP §Step 3): reverting the window to a fixed 10 fails `test_low_overlap_converges_to_almost_no_drafting` (drafting share goes to ~0.23); removing the strong-signal reset fails `test_strong_signal_resets_backoff_immediately`; dropping a reason from the render loop fails `test_every_fallthrough_reason_gets_a_series`.
- End-to-end on real weights, two machines: the six-cell table above, plus a five-round aider soak.

## Checklist

- [x] Tests pass locally (full suite diffed against `main`: zero new failures)
- [x] Lint passes (`ruff check && ruff format --check`)
- [x] Self-validated with `python3 -m scripts.pr_validate.pr_validate 1419` — scorecard in a comment
- [x] New tests touch the scheduler hot path and were spot-checked to fail when the corresponding production rule is reverted
- [x] Updated README/docs if applicable — no user-facing flag change; the flag and its semantics are unchanged
- [x] No breaking changes to existing API


---

## Post-review fixes (added after the tables above were measured)

Four more rounds of `codex review --base main` on this branch. None of them
change any measured number — they are all lifecycle/telemetry correctness in
the code the benchmarks were already exercising.

1. **P1 — the strong-signal reset fired on noise.** `n_accepted * 2 >= K`
   is true for a 1-of-2 accept, and `_K_MIN` is 2 — which is exactly the
   width a back-off produces. So the outcome the policy calls noise was
   resetting the whole back-off level. Now gated behind the same
   `_BACKOFF_DECAY_MIN_ACCEPT` floor as the decay path.
2. **A regression my own fix for (1) introduced.** An absolute floor of 2
   makes `max_draft=1` unable to ever leave a back-off, because no accept
   can reach the floor. Fixed with `min(_BACKOFF_DECAY_MIN_ACCEPT, K)`.
3. **Stale state gauges when idle.** `draft_width` / `backoff_level`
   describe the currently drafting request; once the last one is reaped
   they describe nothing, and an idle server kept reporting whatever the
   final request ended on — a deeply backed-off value reads as a decoder
   still in trouble long after the traffic stopped. Both reap paths now
   publish the at-rest pair.
4. **P2 — the abort path leaked per-uid state.** `_do_abort_request`
   reaches the BatchGenerator through `remove()` only, which produces no
   Response, so `next()`'s `finish_reason` sweep — the sole reap path —
   never saw the uid. Every client cancellation left behind that uid's
   drafter plus its `_uid_state`, whose `pending` list can hold up to
   `_COOLDOWN_MAX` (320) unread mlx arrays: live GPU buffers, leaked on
   exactly the path a disconnecting client hits repeatedly. Fixed by
   wrapping `remove()` in the installer rather than teaching the scheduler
   about suffix internals, so every removal path is covered.

   **My first version of (4) was wrong and codex caught it.** It reaped in
   `finally`, on the reasoning that a partially-applied `remove` still
   leaves the uid gone. It does not: with `return_prompt_caches=True`,
   `remove` calls `extract_cache` FIRST, and its index bookkeeping can
   fail part-way through a multi-uid call — either way the uid can still
   be fully live. Reaping a live uid is *worse* than the leak: its
   `pending` entries are accepted draft tokens whose KV is already
   committed to the cache, so discarding them loses output that was about
   to be emitted and desyncs the rebuilt drafter history from the cache.
   The failure path now consults `_find_uids` and reaps only what actually
   left; if membership can't be established at all it reaps nothing.

5. **`ft_error` was missing from the local breakdown.** `_suffix_stats`
   documents that its `ft_*` buckets sum to `fallthrough_steps`, but the
   two exception paths bumped `fallthrough_steps` and `errors` with no
   `ft_error` bucket — so the breakdown stopped reconciling precisely when
   something was failing, which is when an operator reads it.

Six new tests, all mutation-checked (each was confirmed to fail against
the pre-fix code, not merely to pass against the fix):

- `test_abort_reaps_uid_state_and_drafter` — and that it leaves an
  unrelated live uid alone.
- `test_failed_remove_still_reaps_a_uid_that_did_leave` /
  `test_failed_remove_keeps_state_for_a_uid_still_in_the_batch` /
  `test_failed_remove_without_find_uids_keeps_state` — the three arms of
  the failure path. The middle one fails against a blanket `finally`.
- `test_local_stats_have_a_reason_key_for_every_fallthrough`.
- `test_state_gauges_return_to_rest_when_no_request_is_drafting`.

Final round of `codex review --base main` came back clean. `pr_validate`
(full 15229-test suite): **MERGE-SAFE**, zero failures.

> One note for maintainers, unrelated to this PR:
> `tests/test_telemetry_request_wiring.py::test_nonstreaming_completion_emits_request_event`
> fails on any machine where the developer has actually opted into
> telemetry. It asserts `output_degenerate is None`, which only holds when
> `emit.is_enabled()` is False — and `is_enabled()` reads the real consent
> file out of the user's home directory. It reproduces identically on
> `main`, and passes under `RAPID_MLX_TELEMETRY=0`. The test should stub
> consent rather than inherit it.
