### PR TITLE
fix(packaging): make [all] include a validated audio stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,8 @@ If `pip install rapid-mlx` says "no matching distribution", your Python is too o
 
 For image-input / VLM models (Qwen-VL, true multimodal), install the vision extra: `pip install 'rapid-mlx[vision]'` — see [Optional extras](https://rapidmlx.com/docs/extras.html).
 
+For the complete feature set — vision, chat, embeddings, and audio — install the `[all]` extra: `pip install 'rapid-mlx[all]'`. Audio alone is `pip install 'rapid-mlx[audio]'`; see [Optional extras](https://rapidmlx.com/docs/extras.html).
+
 </details>
 
 ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -209,7 +209,7 @@ chat = [
     "gradio>=4.0.0",
     "pytz>=2024.1",
 ]
-# All extras — union of vision + chat + embeddings.
+# All extras — union of vision + chat + embeddings + audio.
 # Expanded directly to avoid a self-dependency that breaks
 # pip install .[all] and editable installs.
 all = [
@@ -225,6 +225,21 @@ all = [
     # embeddings
     "mlx-embeddings>=0.1.0",
     # dflash (text-only path covered by mlx-vlm above; listed for clarity)
+    # audio
+    "mlx-audio>=0.2.9,<0.4.4",
+    "f5-tts-mlx==0.2.6",
+    "sounddevice>=0.4.0",
+    "soundfile>=0.12.0",
+    "scipy>=1.10.0",
+    "numba>=0.57.0",
+    "tiktoken>=0.5.0",
+    "misaki[zh,ja]>=0.5.0",
+    "spacy>=3.7.0",
+    "num2words>=0.5.0",
+    "loguru>=0.7.0",
+    "espeakng-loader>=0.2.0",
+    "phonemizer-fork>=3.3.0",
+    "cn2an>=0.5.0",
 ]
 # Test runtime — the *minimum* deps `pytest tests/` needs to import the
 # suite and collect every test without a plugin-missing error. Kept

--- a/tests/test_doctor_env_health.py
+++ b/tests/test_doctor_env_health.py
@@ -174,7 +174,10 @@ def test_missing_optional_package_marks_warning():
         # mlx-audio missing; the rest present.
         return None if dist == "mlx-audio" else "1.0.0"
 
-    with mock.patch.object(eh, "_safe_version", side_effect=fake_ver):
+    with (
+        mock.patch.object(eh, "_safe_version", side_effect=fake_ver),
+        mock.patch.object(eh, "_module_available", return_value=True),
+    ):
         section = eh.section_optional_packages()
 
     audio_row = next(c for c in section.checks if "mlx-audio" in c.label)
@@ -203,11 +206,62 @@ def test_supported_mlx_audio_version_marks_ok():
     def fake_ver(dist: str) -> str | None:
         return "0.4.3" if dist == "mlx-audio" else None
 
-    with mock.patch.object(eh, "_safe_version", side_effect=fake_ver):
+    with (
+        mock.patch.object(eh, "_safe_version", side_effect=fake_ver),
+        mock.patch.object(eh, "_module_available", return_value=True),
+    ):
         section = eh.section_optional_packages()
 
     audio_row = next(c for c in section.checks if "mlx-audio" in c.label)
     assert audio_row.status is eh.CheckStatus.OK
+
+
+def test_absent_audio_dependency_stack_marks_warning():
+    """An absent audio extra remains one concise optional-package warning."""
+    with mock.patch.object(eh, "_safe_version", return_value=None):
+        section = eh.section_optional_packages()
+
+    audio_rows = [c for c in section.checks if "mlx-audio" in c.label]
+    assert len(audio_rows) == 1
+    assert audio_rows[0].status is eh.CheckStatus.WARN
+
+
+def test_healthy_complete_audio_dependency_stack_marks_ok():
+    """When every audio dependency imports and mlx-audio is in range, all
+    audio rows are OK."""
+    with (
+        mock.patch.object(eh, "_safe_version", return_value="0.4.3"),
+        mock.patch.object(eh, "_module_available", return_value=True),
+    ):
+        section = eh.section_optional_packages()
+
+    audio_rows = [
+        c
+        for c in section.checks
+        if "audio" in c.label.lower() or "mlx-audio" in c.label
+    ]
+    assert audio_rows
+    assert all(c.status is eh.CheckStatus.OK for c in audio_rows), [
+        (c.label, c.status) for c in audio_rows
+    ]
+
+
+def test_incomplete_audio_dependency_import_stack_marks_warning():
+    """A present mlx-audio with a missing/broken audio dependency import is
+    WARN, not OK — the audio feature set is not actually usable."""
+    def fake_ver(dist: str) -> str | None:
+        return "0.4.3" if dist == "mlx-audio" else None
+
+    with (
+        mock.patch.object(eh, "_safe_version", side_effect=fake_ver),
+        mock.patch.object(
+            eh, "_module_available", side_effect=lambda module: module != "f5_tts_mlx"
+        ),
+    ):
+        section = eh.section_optional_packages()
+
+    broken = next(c for c in section.checks if "f5-tts-mlx" in c.label)
+    assert broken.status is eh.CheckStatus.WARN
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_doctor_env_health.py
+++ b/tests/test_doctor_env_health.py
@@ -249,6 +249,7 @@ def test_healthy_complete_audio_dependency_stack_marks_ok():
 def test_incomplete_audio_dependency_import_stack_marks_warning():
     """A present mlx-audio with a missing/broken audio dependency import is
     WARN, not OK — the audio feature set is not actually usable."""
+
     def fake_ver(dist: str) -> str | None:
         return "0.4.3" if dist == "mlx-audio" else None
 

--- a/tests/test_vision_extra_install.py
+++ b/tests/test_vision_extra_install.py
@@ -245,8 +245,7 @@ def test_all_extra_contains_complete_audio_extra() -> None:
     audio_names = {_split_spec(s)[0].lower() for s in _extra_specs(py, "audio")}
     all_names = {_split_spec(s)[0].lower() for s in _extra_specs(py, "all")}
     assert audio_names <= all_names, (
-        "`[all]` is missing audio dependencies: "
-        f"{sorted(audio_names - all_names)}"
+        f"`[all]` is missing audio dependencies: {sorted(audio_names - all_names)}"
     )
 
 

--- a/tests/test_vision_extra_install.py
+++ b/tests/test_vision_extra_install.py
@@ -227,7 +227,7 @@ def test_readme_quickstart_mentions_vision_extra() -> None:
 
 
 def test_all_extra_includes_mlx_vlm() -> None:
-    """``[all]`` is documented as the union of vision + chat + embeddings.
+    """``[all]`` is documented as the union of vision + chat + embeddings + audio.
     A user who installs ``rapid-mlx[all]`` expecting "everything"
     must NOT discover at request-time that mlx-vlm isn't there."""
     py = _load_pyproject()
@@ -236,6 +236,17 @@ def test_all_extra_includes_mlx_vlm() -> None:
     assert "mlx-vlm" in names, (
         f"`[all]` extra is documented as union-of-everything but does "
         f"not include mlx-vlm. Got specs={all_specs!r}."
+    )
+
+
+def test_all_extra_contains_complete_audio_extra() -> None:
+    """Every dependency promised by ``[audio]`` is also supplied by ``[all]``."""
+    py = _load_pyproject()
+    audio_names = {_split_spec(s)[0].lower() for s in _extra_specs(py, "audio")}
+    all_names = {_split_spec(s)[0].lower() for s in _extra_specs(py, "all")}
+    assert audio_names <= all_names, (
+        "`[all]` is missing audio dependencies: "
+        f"{sorted(audio_names - all_names)}"
     )
 
 

--- a/vllm_mlx/doctor/env_health.py
+++ b/vllm_mlx/doctor/env_health.py
@@ -147,6 +147,7 @@ def _module_available(module: str) -> bool:
     except (ImportError, AttributeError, ValueError):
         return False
 
+
 # ---------------------------------------------------------------------------
 # Section: System
 # ---------------------------------------------------------------------------

--- a/vllm_mlx/doctor/env_health.py
+++ b/vllm_mlx/doctor/env_health.py
@@ -21,6 +21,7 @@ Tests in ``tests/test_doctor_env_health.py`` cover each section's probe.
 from __future__ import annotations
 
 import importlib.metadata as _im
+import importlib.util as _iu
 import os
 import platform
 import shutil
@@ -118,6 +119,33 @@ OPTIONAL_PACKAGES: list[tuple[str, str, str]] = [
     ),
 ]
 
+# ``find_spec`` checks discoverability without importing heavyweight audio
+# packages such as scipy, numba, and spaCy.  Keep this aligned with the
+# runtime dependencies declared by the ``audio`` extra in pyproject.toml.
+_AUDIO_IMPORTS: tuple[tuple[str, str], ...] = (
+    ("mlx-audio", "mlx_audio"),
+    ("f5-tts-mlx", "f5_tts_mlx"),
+    ("sounddevice", "sounddevice"),
+    ("soundfile", "soundfile"),
+    ("scipy", "scipy"),
+    ("numba", "numba"),
+    ("tiktoken", "tiktoken"),
+    ("misaki", "misaki"),
+    ("spacy", "spacy"),
+    ("num2words", "num2words"),
+    ("loguru", "loguru"),
+    ("espeakng-loader", "espeakng_loader"),
+    ("phonemizer-fork", "phonemizer"),
+    ("cn2an", "cn2an"),
+)
+
+
+def _module_available(module: str) -> bool:
+    """Return whether *module* is discoverable, without importing it."""
+    try:
+        return _iu.find_spec(module) is not None
+    except (ImportError, AttributeError, ValueError):
+        return False
 
 # ---------------------------------------------------------------------------
 # Section: System
@@ -600,6 +628,24 @@ def section_optional_packages() -> Section:
                     ),
                 )
                 continue
+            if dist == "mlx-audio":
+                missing = [
+                    distribution
+                    for distribution, module in _AUDIO_IMPORTS
+                    if not _module_available(module)
+                ]
+                if missing:
+                    missing_text = ", ".join(missing)
+                    s.add(
+                        f"{label} {ver} incomplete — missing: {missing_text} "
+                        f"(`{hint}`)",
+                        CheckStatus.WARN,
+                        detail=(
+                            f"distribution={dist} version={ver} "
+                            f"missing={missing_text} hint={hint}"
+                        ),
+                    )
+                    continue
             # #1126: mlx-vlm imports Pillow (PIL) at load. A present
             # mlx-vlm with an absent PIL (Homebrew `pip install --no-deps
             # mlx-vlm`) is a FALSE positive — metadata says "installed" but


### PR DESCRIPTION
Closes #1255.

- make `[all]` include the complete supported `[audio]` dependency set
- make `rapid-mlx doctor` warn for unsupported or incomplete audio stacks
- use lightweight `find_spec` probes so doctor does not import scipy/numba/spaCy
- keep the entirely absent optional audio stack to one concise warning
- add packaging, doctor, and documentation regressions

Validation:
- 62 passed, 2 skipped (focused audio/doctor/extra tests)
- Ruff clean on changed Python files

This PR was used as the real DeepSeek/Codex engineering soak task. The model reached ~55K context with no reconnect or malformed tool call; independent review corrected its incomplete first implementation before publication.