### PR TITLE
chore(rapid-mac): cut 0.12.0 + make release signing-optional (unsigned internal build)

### DIFF
--- a/.github/workflows/rapid-mac-release.yml
+++ b/.github/workflows/rapid-mac-release.yml
@@ -68,6 +68,14 @@ jobs:
       APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
       AC_API_KEY_ID: ${{ secrets.AC_API_KEY_ID }}
       AC_API_ISSUER_ID: ${{ secrets.AC_API_ISSUER_ID }}
+      # Signing is OPTIONAL. When the Developer ID + notary secrets are all
+      # present we Developer-ID sign + notarise (a clean, double-clickable
+      # release). When they are absent (e.g. an early internal-testing build
+      # before the Apple account is wired up) the job still runs: it produces
+      # an AD-HOC signed, un-notarised DMG and publishes it as a PRE-RELEASE
+      # with a "right-click → Open" note. Re-running the same tag once the
+      # secrets land upgrades it to a proper signed release.
+      SIGNED: ${{ secrets.MACOS_DEVID_CERT_P12_BASE64 != '' && secrets.MACOS_DEVID_CERT_PASSWORD != '' && secrets.AC_API_KEY_P8_BASE64 != '' && secrets.AC_API_KEY_ID != '' && secrets.AC_API_ISSUER_ID != '' }}
       # Absolute .app size ceiling — enforced by the "Bundle size gate"
       # step. The bundled sidecar (Contents/Resources/rapid-mlx) dominates.
       BUNDLE_SIZE_CAP_MB: "500"
@@ -100,6 +108,7 @@ jobs:
           python-version: '3.12'
 
       - name: Import Developer ID certificate into a temp keychain
+        if: env.SIGNED == 'true'
         env:
           CERT_P12_BASE64: ${{ secrets.MACOS_DEVID_CERT_P12_BASE64 }}
           CERT_PASSWORD: ${{ secrets.MACOS_DEVID_CERT_PASSWORD }}
@@ -142,6 +151,7 @@ jobs:
           echo "Imported identity: $IDENTITY"
 
       - name: Decode notarisation API key
+        if: env.SIGNED == 'true'
         env:
           AC_API_KEY_P8_BASE64: ${{ secrets.AC_API_KEY_P8_BASE64 }}
         run: |
@@ -225,6 +235,7 @@ jobs:
           fi
 
       - name: Notarise + staple Rapid-MLX Desktop.app
+        if: env.SIGNED == 'true'
         run: |
           set -euo pipefail
           ditto -c -k --keepParent "build/Rapid-MLX Desktop.app" "build/Rapid-MLX-Desktop.zip"
@@ -280,6 +291,7 @@ jobs:
         run: bash scripts/validate-dmg.sh build/rapid-mlx-desktop.dmg
 
       - name: Notarise + staple rapid-mlx-desktop.dmg
+        if: env.SIGNED == 'true'
         run: bash scripts/notarize.sh build/rapid-mlx-desktop.dmg build/rapid-mlx-desktop.dmg
 
       - name: Upload workflow artifact
@@ -309,6 +321,26 @@ jobs:
           if [[ -z "$NOTES_FILE" || ! -s "$NOTES_FILE" ]]; then
             echo "::error::RELEASE_NOTES_FILE is unset or empty."
             exit 1
+          fi
+          # Unsigned build: this DMG is ad-hoc signed + un-notarised, so it is
+          # ALWAYS a pre-release and carries a Gatekeeper note. macOS quarantines
+          # anything downloaded, and Gatekeeper hard-blocks an un-notarised app
+          # ("damaged / can't be opened"), so the download won't just
+          # double-click — prepend the standard right-click / xattr workaround.
+          if [[ "${SIGNED:-}" != "true" ]]; then
+            PRERELEASE="--prerelease"
+            {
+              echo "> ⚠️ **Unsigned internal build.** This DMG is ad-hoc signed and NOT notarised."
+              echo "> macOS Gatekeeper will block it on first open. To run it:"
+              echo ">"
+              echo "> 1. Drag **Rapid-MLX Desktop** to Applications, then **right-click the app → Open** (once), or"
+              echo "> 2. \`xattr -dr com.apple.quarantine \"/Applications/Rapid-MLX Desktop.app\"\`"
+              echo ">"
+              echo "> A signed + notarised build that opens with a normal double-click will replace this once signing is configured."
+              echo ""
+              cat "$NOTES_FILE"
+            } > "$NOTES_FILE.unsigned"
+            NOTES_FILE="$NOTES_FILE.unsigned"
           fi
           # The release object may already exist or not — handle both.
           if gh release view "$TAG" >/dev/null 2>&1; then

--- a/apps/rapid-mac/CHANGELOG.md
+++ b/apps/rapid-mac/CHANGELOG.md
@@ -13,6 +13,37 @@ can actually understand.
 
 ## [Unreleased]
 
+## [0.12.0] — 2026-08-02
+
+The first release of Rapid-MLX Desktop as an **open-source** app in the
+`raullenchai/Rapid-MLX` monorepo (Apache-2.0). An internal-testing build
+ahead of 1.0.
+
+### App
+
+- **Ollama / ChatGPT-style layout.** A single-column chat with an inline
+  model picker in the compose box; the model starts on your first message
+  (no start/stop buttons). A sidebar with New Chat, a Launch page of
+  connect-your-tools cards, and your conversation history.
+- **Conversation history** persists privately on device (owner-only file
+  permissions) and survives quit.
+- **"Speed on this Mac"** benchmarks the current model on your hardware, with
+  an optional submit to the community leaderboard.
+- Fixed a dead close button on the Launch page.
+
+### Engine
+
+- Bundles the **Rapid-MLX 0.11.9** inference engine (plus the latest merged
+  fixes), including the freeform `bench` fix so "Speed on this Mac" reports a
+  real number.
+
+### Privacy
+
+- Telemetry stays **opt-in** and anonymous; the app and the embedded engine
+  share one client ID so an install is never double-counted. A new
+  loopback-only `RAPID_MLX_TELEMETRY_ENDPOINT` lets you audit exactly what is
+  sent by pointing it at a local server.
+
 ## [0.11.0] — 2026-07-28
 
 This release upgrades the bundled inference engine to **Rapid-MLX 0.11.1**

--- a/apps/rapid-mac/Resources/Info.plist
+++ b/apps/rapid-mac/Resources/Info.plist
@@ -19,9 +19,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.11.0</string>
+	<string>0.12.0</string>
 	<key>CFBundleVersion</key>
-	<string>146</string>
+	<string>147</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>14.0</string>
 	<key>NSHighResolutionCapable</key>


### PR DESCRIPTION
## Why
Cut the first **internal-testing** release of Rapid-MLX Desktop (0.12.0) and let us ship it **now, unsigned**, while the Apple Developer signing secrets are being set up in parallel.

## What
1. **App version → 0.12.0** (Info.plist `CFBundleShortVersionString` 0.11.0→0.12.0, build 146→147) + CHANGELOG `[0.12.0]`. Bundled engine stays **0.11.9** (+latest fixes) — app version ⊥ engine version until 1.0. Does NOT touch engine `pyproject.toml`, so no engine release is triggered.
2. **`rapid-mac-release.yml` signing is now optional.** When `MACOS_DEVID_CERT_*` + `AC_API_*` secrets are all present → Developer-ID sign + notarise (clean double-click install, unchanged). When absent → `SIGNED=false`: skip cert-import/notary/notarise, build ad-hoc via build.sh/dmg.sh, and publish as a **pre-release** with a Gatekeeper 'right-click → Open' note. Re-running the same tag once secrets land upgrades it to a signed release.

## Flow to ship the unsigned build
Merge this → tag `rapid-mac-v0.12.0` on main → the workflow builds the ad-hoc DMG and publishes an unsigned pre-release. (Validated first via a `workflow_dispatch` dry-run on this branch — builds the ad-hoc DMG + uploads the artifact, no release.)

## Dogfood of this exact build (adhoc, local)
All green: chat E2E, Connect-tools 7/7 (OpenAI+Anthropic+tools+auth), Speed-on-this-Mac 113 tok/s (#1404), telemetry (shared client_id, 0 PII), `rapid-mlx ls`, clean lifecycle. Faithful UI renders (Connect/consent/benchmark) polished. Installed + double-click-verified at /Applications.

Known issues (non-blocking): #1412 (prefix-cache desktop cap), #1415 (startup telemetry-probe inflation + bounded quit delay).