### PR TITLE
fix(cache): keep transient Codex priming out of reusable prefixes

### DIFF
--- a/tests/test_prefix_boundary_path_parity.py
+++ b/tests/test_prefix_boundary_path_parity.py
@@ -266,6 +266,74 @@ def test_prefix_boundary_prefers_latest_stable_message_boundary(monkeypatch):
     assert engine._compute_prefix_boundary(messages) == len(stable)
 
 
+def test_prefix_boundary_stops_before_transient_server_priming(monkeypatch):
+    """A server-only reminder is absent from the client's next request."""
+    engine, _ = _build_engine(monkeypatch)
+    engine._compute_prefix_boundary = BatchedEngine._compute_prefix_boundary.__get__(
+        engine, BatchedEngine
+    )
+    engine._tokenizer = _CharacterTokenizer()
+
+    def render(messages, tools=None, *, add_generation_prompt=True, **kwargs):
+        body = "|".join(
+            f"{message.get('role')}:{message.get('content')}" for message in messages
+        )
+        return body + ("|GEN" if add_generation_prompt else "")
+
+    monkeypatch.setattr(engine, "_apply_chat_template", render)
+    stable_messages = [
+        {"role": "system", "content": "system"},
+        {"role": "user", "content": "investigate"},
+        {"role": "assistant", "content": "prior work"},
+        {"role": "user", "content": "continue"},
+    ]
+    messages = [
+        *stable_messages,
+        {"role": "developer", "content": "temporary progress checkpoint"},
+    ]
+
+    boundary = engine._compute_prefix_boundary(
+        messages, transient_message_start=len(stable_messages)
+    )
+    real = render(messages)
+    future = render(
+        [
+            *stable_messages,
+            {"role": "assistant", "content": "__rapid_mlx_boundary_probe__"},
+        ],
+        add_generation_prompt=False,
+    )
+    expected = 0
+    for real_char, future_char in zip(real, future):
+        if real_char != future_char:
+            break
+        expected += 1
+
+    assert boundary == expected
+    assert boundary > 0
+    assert "temporary" not in real[:boundary]
+
+
+def test_transient_priming_marker_is_removed_before_chat_templating():
+    messages = [
+        {"role": "user", "content": "continue"},
+        {
+            "role": "developer",
+            "content": "server-only reminder",
+            "_rapid_mlx_transient_priming": True,
+        },
+    ]
+
+    cleaned, transient_start = BatchedEngine._prepare_cache_stable_messages(messages)
+
+    assert transient_start == 1
+    assert cleaned == [
+        {"role": "user", "content": "continue"},
+        {"role": "developer", "content": "server-only reminder"},
+    ]
+    assert messages[-1]["_rapid_mlx_transient_priming"] is True
+
+
 def test_prefix_boundary_falls_back_when_no_generation_form_is_not_prefix(
     monkeypatch,
 ):

--- a/tests/test_responses_route.py
+++ b/tests/test_responses_route.py
@@ -1413,6 +1413,7 @@ def test_codex_progress_reminder_does_not_assume_five_reads_are_enough():
     reminded = _inject_codex_progress_reminder([], request)
     assert "Do not rerun the same tests" in reminded[-1]["content"]
     assert "provide the final answer" in reminded[-1]["content"]
+    assert reminded[-1]["_rapid_mlx_transient_priming"] is True
 
 
 def test_codex_progress_does_not_mistake_prose_passed_for_test_success():

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -2068,6 +2068,10 @@ class BatchedEngine(BaseEngine):
         if not self._loaded:
             await self.start()
 
+        messages, transient_message_start = self._prepare_cache_stable_messages(
+            messages
+        )
+
         # Extract images/videos from messages (OpenAI multimodal format)
         # Note: We only use extracted media here, messages are already processed by server
         _, extracted_images, extracted_videos = extract_multimodal_content(messages)
@@ -2147,7 +2151,14 @@ class BatchedEngine(BaseEngine):
         # PR #435 was built to fix. Gating on ``is_hybrid`` keeps the fix
         # active where it's needed and inert where it broke things.
         if self._needs_prefix_boundary_snapshot():
-            prefix_boundary = self._compute_prefix_boundary(messages, tools)
+            if transient_message_start is None:
+                prefix_boundary = self._compute_prefix_boundary(messages, tools)
+            else:
+                prefix_boundary = self._compute_prefix_boundary(
+                    messages,
+                    tools,
+                    transient_message_start=transient_message_start,
+                )
             if prefix_boundary > 0:
                 kwargs["prefix_boundary"] = prefix_boundary
 
@@ -2213,7 +2224,11 @@ class BatchedEngine(BaseEngine):
             return False
 
     def _compute_prefix_boundary(
-        self, messages: list[dict[str, Any]], tools: list[dict] | None = None
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict] | None = None,
+        *,
+        transient_message_start: int | None = None,
     ) -> int:
         """Compute the latest prefix that is stable across the next turn.
 
@@ -2243,6 +2258,32 @@ class BatchedEngine(BaseEngine):
             real_prompt = self._apply_chat_template(
                 messages, template_tools, add_generation_prompt=True
             )
+            tokenizer = self.tokenizer
+            if hasattr(tokenizer, "tokenizer"):
+                tokenizer = tokenizer.tokenizer
+
+            real_tokens = tokenizer.encode(real_prompt)
+
+            if transient_message_start is not None:
+                future_prompt = self._apply_chat_template(
+                    [
+                        *messages[:transient_message_start],
+                        {
+                            "role": "assistant",
+                            "content": "__rapid_mlx_boundary_probe__",
+                        },
+                    ],
+                    template_tools,
+                    add_generation_prompt=False,
+                )
+                future_tokens = tokenizer.encode(future_prompt)
+                transient_lcp = 0
+                for real_token, future_token in zip(real_tokens, future_tokens):
+                    if real_token != future_token:
+                        break
+                    transient_lcp += 1
+                return transient_lcp
+
             stable_prompt = self._apply_chat_template(
                 messages, template_tools, add_generation_prompt=False
             )
@@ -2258,11 +2299,6 @@ class BatchedEngine(BaseEngine):
                 add_generation_prompt=False,
             )
 
-            tokenizer = self.tokenizer
-            if hasattr(tokenizer, "tokenizer"):
-                tokenizer = tokenizer.tokenizer
-
-            real_tokens = tokenizer.encode(real_prompt)
             stable_tokens = tokenizer.encode(stable_prompt)
             next_turn_tokens = tokenizer.encode(next_turn_prompt)
             stable_lcp = 0
@@ -2306,6 +2342,29 @@ class BatchedEngine(BaseEngine):
             return min(lcp, next_turn_lcp) if stable_lcp else lcp
         except Exception:
             return 0
+
+    @staticmethod
+    def _prepare_cache_stable_messages(
+        messages: list[dict[str, Any]],
+    ) -> tuple[list[dict[str, Any]], int | None]:
+        """Strip internal priming metadata and locate its stable-prefix edge."""
+        transient_start = next(
+            (
+                index
+                for index, message in enumerate(messages)
+                if message.get("_rapid_mlx_transient_priming") is True
+            ),
+            None,
+        )
+        cleaned = [
+            {
+                key: value
+                for key, value in message.items()
+                if key != "_rapid_mlx_transient_priming"
+            }
+            for message in messages
+        ]
+        return cleaned, transient_start
 
     def _route_tokens_for_channels(
         self,
@@ -2657,6 +2716,10 @@ class BatchedEngine(BaseEngine):
         if not self._loaded:
             await self.start()
 
+        messages, transient_message_start = self._prepare_cache_stable_messages(
+            messages
+        )
+
         # Extract images/videos from messages (OpenAI multimodal format)
         # Note: We only use extracted media here, messages are already processed by server
         _, extracted_images, extracted_videos = extract_multimodal_content(messages)
@@ -2705,7 +2768,14 @@ class BatchedEngine(BaseEngine):
         # must apply the same gating condition so a future change can't
         # silently regress one path while keeping the other green.
         if self._needs_prefix_boundary_snapshot():
-            prefix_boundary = self._compute_prefix_boundary(messages, tools)
+            if transient_message_start is None:
+                prefix_boundary = self._compute_prefix_boundary(messages, tools)
+            else:
+                prefix_boundary = self._compute_prefix_boundary(
+                    messages,
+                    tools,
+                    transient_message_start=transient_message_start,
+                )
             if prefix_boundary > 0:
                 kwargs["prefix_boundary"] = prefix_boundary
 

--- a/vllm_mlx/routes/responses.py
+++ b/vllm_mlx/routes/responses.py
@@ -253,7 +253,18 @@ def _inject_codex_progress_reminder(
         )
     else:
         return messages
-    return [*messages, {"role": "developer", "content": reminder}]
+    return [
+        *messages,
+        {
+            "role": "developer",
+            "content": reminder,
+            # Server-only guidance is not returned in Responses output and the
+            # client therefore cannot replay it next turn. The batched engine
+            # removes this metadata before templating and snapshots only the
+            # stable message prefix preceding it.
+            "_rapid_mlx_transient_priming": True,
+        },
+    ]
 
 
 def _codex_action_command_prefix(responses_request: ResponsesRequest) -> str | None:


### PR DESCRIPTION
## What changed

- mark server-only Codex progress reminders as transient cache input
- remove the internal marker before chat-template rendering
- snapshot non-trimmable DeepSeek/hybrid cache at the stable client-replayable prefix before transient priming
- apply the same boundary behavior to streaming and non-streaming paths

## Why

Responses is stateless: Codex replays visible conversation items but cannot replay a developer reminder injected only inside Rapid-MLX. The old boundary snapshot included that reminder. Once the first reminder appeared, every later prompt diverged at that location, so logs showed new snapshots being saved while `cache_fetch cached=` remained stuck around 40–43K and TTFT grew to 50–75 seconds.

The new boundary compares the actual primed prompt with the next-turn client shape and stores only their common, replayable prefix. It does not weaken exact token matching or use the unrelated legacy trie path.

## Validation

- 276 cache, boundary, Responses, snapshot, pressure, and persistence tests passed
- Ruff check and format passed on all changed files
- `git diff --check` passed
- Real DeepSeek tokenizer smoke: old transient boundary was not reusable; safe boundary stopped before the server reminder

## Test plan

- [x] Cover transient boundary calculation with a deterministic next-turn prompt
- [x] Verify marker metadata never reaches chat-template rendering
- [x] Run streaming/non-streaming boundary and Responses regressions
- [x] Run broader memory/hybrid cache, pressure, and persistence suites
