### PR TITLE
fix(tests): align community benchmark gates with schema v3

### DIFF
--- a/tests/test_bench_tier_submit_combo.py
+++ b/tests/test_bench_tier_submit_combo.py
@@ -329,7 +329,7 @@ def test_tier_all_submit_payload_shape():
 
     Locked invariants:
 
-    - ``schema_version == 2``
+    - ``schema_version == 3``
     - ``tier == 'all'``
     - ``smoke_result``, ``harness_result``, AND ``buckets`` all present
       (the schema requires ``buckets`` unconditionally — the speed
@@ -354,7 +354,7 @@ def test_tier_all_submit_payload_shape():
         harness_result=_HARNESS_PAYLOAD,
     )
 
-    assert payload["schema_version"] == 2
+    assert payload["schema_version"] == 3
     assert payload["tier"] == "all"
     assert payload["smoke_result"] == _SMOKE_PAYLOAD
     assert payload["harness_result"] == _HARNESS_PAYLOAD

--- a/tests/test_no_out_of_band_routing.py
+++ b/tests/test_no_out_of_band_routing.py
@@ -163,6 +163,11 @@ ALLOWED_RAPID_MLX_ENV_VARS: frozenset[str] = frozenset(
         # hatch for sandboxed / read-only-home environments. Pure state-file
         # placement knob — never selects a model, parser, or routing tier.
         "RAPID_MLX_STATE_DIR",
+        # Community benchmark board endpoint and local archive root. These
+        # affect upload/storage destinations only; neither is read by model,
+        # parser, scheduler, or request-routing code.
+        "RAPID_MLX_BENCH_BOARD_URL",
+        "RAPID_MLX_HOME",
         # Override where DDTree writes its patched draft-config mirror.
         # This is a cache placement/testing knob; model routing and DDTree
         # enablement still come from explicit CLI flags and alias metadata.

--- a/tests/test_payload_builder_v2_full.py
+++ b/tests/test_payload_builder_v2_full.py
@@ -83,7 +83,7 @@ def _build_full() -> dict:
 
 def test_full_payload_has_all_three_sections() -> None:
     payload = _build_full()
-    assert payload["schema_version"] == 2
+    assert payload["schema_version"] == 3
     assert payload["tier"] == "all"
     assert payload["smoke_result"] == _SMOKE
     assert payload["harness_result"] == _HARNESS

--- a/tests/test_payload_builder_v2_kwargs.py
+++ b/tests/test_payload_builder_v2_kwargs.py
@@ -9,7 +9,7 @@ it always did — modulo the version integer itself.
 This pins three properties:
 
 1. Default-kwargs ``build_submission_payload`` produces a payload
-   identical to a v1 payload except for ``schema_version`` (now 2).
+   identical to a v1 payload except for ``schema_version`` (now 3).
 2. ``tier="speed"`` produces a payload with ``"tier": "speed"`` added
    and nothing else changed.
 3. The payload still validates against the v2 schema.
@@ -93,7 +93,7 @@ def test_default_kwargs_match_v1_modulo_version() -> None:
     reconstruct here by mutating the version to 1).
     """
     payload = _build()
-    assert payload["schema_version"] == 2
+    assert payload["schema_version"] == 3
     # ``submission_id`` is uuid4-derived so it's not byte-stable across
     # runs; everything else IS deterministic given the frozen ``now``,
     # the hardcoded sampling, and the synthetic bench result.


### PR DESCRIPTION
## What changed

- update stale community benchmark payload assertions from schema v2 to v3
- allowlist the benchmark board endpoint and local archive directory environment variables as non-routing knobs

## Why

PR #1403 upgraded benchmark submissions to schema v3 and added HTTP/local archive configuration, but four full-suite guards retained the old v2/allowlist expectations. Clean `origin/main` consequently failed `pr_validate.full_unit`, blocking unrelated high-blast PRs.

## Validation

- 41 community benchmark and routing-boundary tests passed
- Ruff check and format passed
- `git diff --check` passed

## Test plan

- [x] Reproduce all four failures on clean main
- [x] Run the complete affected test files after the baseline correction
