### PR TITLE
fix(gemma4-26b): correct the MoE flag, replace fabricated suffix numbers, add a 32GB serve guide

### DIFF
--- a/docs/guides/gemma4-26b-32gb.md
+++ b/docs/guides/gemma4-26b-32gb.md
@@ -1,0 +1,184 @@
+# Gemma 4 26B-A4B on a 32GB Mac
+
+`gemma-4-26b-4bit` is a 128-expert MoE: 25.2B total parameters, 3.8B active
+per token, 30 layers, 256K context, 14.3 GiB of weights. On a 32GB Apple
+Silicon machine it is faster than the dense 12B on **both** prefill and
+decode while using **less** KV per token, so on any Mac that can hold it
+there is no throughput reason to prefer the 12B.
+
+Everything below was measured on a Mac mini M2 Pro / 32GB, macOS 26.5.2,
+mlx 0.31.2, single request, `temperature=0`, medians over 4-6 repetitions
+with a distinct prompt per repetition.
+
+## Recommended invocation
+
+```bash
+rapid-mlx serve gemma-4-26b-4bit \
+  --no-mllm \
+  --kv-cache-dtype bf16 \
+  --cache-memory-mb 512
+```
+
+Every one of those three flags is off the default path, and each is worth
+measurable throughput. They are explained below.
+
+## Why these flags
+
+### `--kv-cache-dtype bf16` — the default costs you up to 14%
+
+The server defaults to **int4** KV for this model, and says why:
+
+```
+KV cache dtype: int4 — Defaulting to int4 (memory-bandwidth-bound on
+M-series); model=mlx-community/gemma-4-26b-a4b-it-4bit not in safelist
+```
+
+The model gets quantized KV by *failing to appear on a list*, not because
+anyone measured it. Measured, quantizing KV is a straight loss here:
+
+| KV dtype | chat | codegen | code edit |
+|---|---:|---:|---:|
+| int4 (default) | 47.9 | 46.9 | 41.7 |
+| int8 | 47.6 | 46.6 | 40.1 |
+| **bf16** | **49.5** | **49.8** | **47.4** |
+
+(tok/s decode, higher is better)
+
+The reason is the architecture. Only 5 of the 30 layers use full attention
+(indices 5, 11, 17, 23, 29); the other 25 are sliding-window with a 1024
+window, so their cache is bounded. That puts the growing KV at
+
+```
+5 layers x 8 KV heads x 512 global_head_dim x 2 (K+V) x 2 B = 80 KB/token
+```
+
+against ~128 KB/token for the dense 12B. KV simply is not the bandwidth
+bottleneck on this model, so quantizing it buys nothing and the
+quantize/dequantize work is pure overhead.
+
+Note the checkpoint's own `config.json` is the authority here — the model
+card on the Hub describes 4 full-attention layers, and there are 5.
+
+### `--no-mllm` — text-only serving, for the prefix cache
+
+The checkpoint carries a `vision_config`, so auto-detection routes it to the
+MLLM lane. That lane does **not** use the prefix cache: a repeated
+502-token prompt re-prefills at 2.44s every single time, where the text lane
+answers in 0.28s once the prefix is cached.
+
+Cold prefill is the same speed in both lanes (~4.8 ms/token) — the entire
+advantage is cache reuse, which is exactly what agent traffic generates.
+Pass `--mllm` if you actually need image input.
+
+### `--cache-memory-mb 512` — buys headroom for free
+
+The default sizes the prefix cache at 20% of RAM (~3.2GB here). Shrinking it
+to 512MB cut peak Metal memory at a 16K-token prompt from 24.17 GB to
+**21.51 GB** with no measurable throughput cost at 4K or 8K. On a 32GB
+machine the allocation limit is 24.1GB, so 2.7GB of headroom is the
+difference between comfortable and one bad request from an abort.
+
+## What you get
+
+With the recommended three flags:
+
+| prompt | TTFT | decode | peak Metal |
+|---:|---:|---:|---:|
+| ~500 tok (cached prefix) | 0.28s | 47 tok/s | — |
+| 1K | 3.8s | 41.7 tok/s | 15.6 GB |
+| 4K | 15.0s | 38.0 tok/s | 16.3 GB |
+| 8K | 29.4s | 38.0 tok/s | 16.6 GB |
+
+Against `gemma-4-12b-4bit` on the same machine. Both models here run
+`--no-mllm --kv-cache-dtype bf16` *without* `--cache-memory-mb 512`, so the
+26B column differs slightly from the table above:
+
+| prompt | 26B TTFT | 12B TTFT | 26B decode | 12B decode |
+|---:|---:|---:|---:|---:|
+| 1K | **3.8s** | 9.9s | **41.7** | 19.6 |
+| 4K | **15.0s** | 37.9s | **38.0** | 19.4 |
+| 8K | **32.7s** | 81.8s | **32.8** | 17.6 |
+
+2.5x the prefill, 2x the decode, and 37% less KV per token, from a model
+with twice the parameters. That is the MoE trade working in your favour:
+only 3.8B parameters are active per token.
+
+## Limits worth knowing before you rely on it
+
+**Throughput becomes unreliable past ~12K tokens of context.** Up to 8K,
+decode is steady — six consecutive 8K requests measured 36.3-38.5 tok/s
+(±3%). At 12K the same six-run protocol gives 16.4-27.1 tok/s, and
+individual samples as low as 8.1. Time-to-first-token stays perfectly
+linear and reproducible throughout (±0.5%); only decode is affected. The
+cause is not prompt length, response content, machine load, or prefix-cache
+occupancy — all four were tested and ruled out. **If you need predictable
+throughput, keep contexts under ~8K.**
+
+**A 16K prompt drives peak Metal memory to 21.5GB** against a 24.1GB
+allocation limit. Metal allocation failure aborts the process rather than
+raising, so treat that as the working ceiling on a 32GB machine, not a
+target.
+
+**Leave SuffixDecoding off** (it is off by default; the server also says so
+at boot). Measured on this model:
+
+| workload | baseline | suffix K=8 |
+|---|---:|---:|
+| chat | 49.5 | 30.6 (**-38%**) |
+| codegen | 49.7 | 26.3 (**-47%**) |
+| code edit | 47.1 | 52.6 (+12%) |
+
+The cause is acceptance, not verify cost. Measured on this machine, a
+9-wide forward costs **6.13x** a 1-wide one on the 26B and **6.05x** on the
+dense 12B — so being MoE does not make speculation structurally more
+expensive here, which is worth stating because it is the intuitive guess
+and it is wrong. What that cost curve means is that a drafter has to land
+about **0.64 acceptance per token at K=8** simply to break even:
+
+| verify width | cost vs 1-wide | acceptance needed to break even |
+|---:|---:|---:|
+| 2 | 1.74x | 0.741 |
+| 4 | 3.12x | 0.707 |
+| 5 | 3.82x | 0.704 |
+| 9 | 6.13x | 0.641 |
+| 13 | 7.29x | 0.524 |
+
+A suffix tree reaches that on text it has already seen — hence the +12% on
+code edit — and nowhere near it on a fresh question, which is why ordinary
+traffic pays 6x for a verify that emits barely more than one token. A
+*trained* drafter is a different proposition against the same table; see
+the note on the official assistant models below.
+
+## Agent workloads
+
+Six consecutive `aider` edit rounds against the recommended configuration
+completed without a crash, a dropped connection, or a 503, at 14-36s per
+round. Server-side stability is not the limitation.
+
+Edit *quality* is. Across seven runs of one simple refactor task ("add type
+hints and docstrings"), six produced correct output and one wrote the
+model's own deliberation into the source file as comments while inverting a
+`random.uniform(0.5, 1.0)` range to `(0.5, 0.1)`. Enabling `--reasoning`
+neither caused nor prevented it — three runs with it and three without were
+all clean, and the failure came from a run in between. Budget for roughly
+one bad edit in seven on a task this size, and keep the tests green between
+rounds rather than trusting a batch of edits.
+
+## Things that do not apply
+
+- **MTP / the official assistant drafter.** Google ships a 0.4B, 4-layer
+  drafter for every Gemma 4 size, including this one
+  (`gemma-4-26b-assistant`), and this repo already implements the injection
+  path in `vllm_mlx/spec_decode/mtp/gemma4_inject.py`. It is nonetheless
+  unreachable: `_SUPPORTED_MODEL_TYPES` in `vllm_mlx/spec_decode/mtp/detect.py`
+  admits only `qwen3_5`, `qwen3_5_moe` and `hy_v3`, and the docstring records
+  that "Gemma 4 sidecar promotion remains disabled until it passes
+  end-to-end greedy-lossless validation". The drafter's config does line up
+  with this target (`backbone_hidden_size` 2816 matches the target's
+  `hidden_size`; its four `layer_types` match the target's last four), so the
+  validation is worth doing — but it has not been done, and nothing here
+  depends on it.
+- **DFlash / DDTree.** Both require >=8-bit precision and a declared drafter;
+  the 4-bit alias has neither.
+- **PFlash / TurboQuant.** Both tiers are still `unknown` for this alias.
+  Neither was exercised by the measurements above.

--- a/docs/guides/gemma4-26b-32gb.md
+++ b/docs/guides/gemma4-26b-32gb.md
@@ -3,8 +3,8 @@
 `gemma-4-26b-4bit` is a 128-expert MoE: 25.2B total parameters, 3.8B active
 per token, 30 layers, 256K context, 14.3 GiB of weights. On a 32GB Apple
 Silicon machine it is faster than the dense 12B on **both** prefill and
-decode while using **less** KV per token, so on any Mac that can hold it
-there is no throughput reason to prefer the 12B.
+decode, so on any Mac that can hold it there is no throughput reason to
+prefer the 12B.
 
 Everything below was measured on a Mac mini M2 Pro / 32GB, macOS 26.5.2,
 mlx 0.31.2, single request, `temperature=0`, medians over 4-6 repetitions
@@ -46,15 +46,25 @@ anyone measured it. Measured, quantizing KV is a straight loss here:
 
 The reason is the architecture. Only 5 of the 30 layers use full attention
 (indices 5, 11, 17, 23, 29); the other 25 are sliding-window with a 1024
-window, so their cache is bounded. That puts the growing KV at
+window, so their cache is bounded and only those 5 grow with context. Note
+that full-attention layers use `num_global_key_value_heads` (2), **not** the
+`num_key_value_heads` (8) that the sliding layers use — see
+`gemma4_vendored/language.py`, where `attention_k_eq_v` selects the global
+count. So the growing KV is
 
 ```
-5 layers x 8 KV heads x 512 global_head_dim x 2 (K+V) x 2 B = 80 KB/token
+5 layers x 2 global KV heads x 512 global_head_dim x 2 (K+V) x 2 B
+    = 20 KB/token
 ```
 
-against ~128 KB/token for the dense 12B. KV simply is not the bandwidth
-bottleneck on this model, so quantizing it buys nothing and the
+which is tiny — a 32K context costs 640MB. KV is nowhere near the bandwidth
+bottleneck on this model, so quantizing it buys nothing measurable and the
 quantize/dequantize work is pure overhead.
+
+For comparison the dense 12B is **16 KB/token** (8 full-attention layers but
+`num_global_key_value_heads = 1`), so the 26B actually carries slightly
+*more* growing KV per token, not less. Its advantage is throughput, not
+cache footprint.
 
 Note the checkpoint's own `config.json` is the authority here — the model
 card on the Hub describes 4 full-attention layers, and there are 5.
@@ -99,9 +109,10 @@ Against `gemma-4-12b-4bit` on the same machine. Both models here run
 | 4K | **15.0s** | 37.9s | **38.0** | 19.4 |
 | 8K | **32.7s** | 81.8s | **32.8** | 17.6 |
 
-2.5x the prefill, 2x the decode, and 37% less KV per token, from a model
-with twice the parameters. That is the MoE trade working in your favour:
-only 3.8B parameters are active per token.
+2.5x the prefill and 2x the decode from a model with twice the parameters.
+That is the MoE trade working in your favour: only 3.8B parameters are
+active per token. It costs 8GB more resident weights and slightly more KV
+per token; everything else moves the right way.
 
 ## Limits worth knowing before you rely on it
 

--- a/tests/test_gemma4_26b_moe_flag.py
+++ b/tests/test_gemma4_26b_moe_flag.py
@@ -1,0 +1,89 @@
+# SPDX-License-Identifier: Apache-2.0
+"""``is_moe`` must be consistent across the Gemma 4 26B-A4B family.
+
+Before this test the three quantizations of the *same* checkpoint disagreed:
+``gemma-4-26b-4bit`` had no ``is_moe`` key at all (so it resolved to the
+``False`` default), ``gemma-4-26b-qat-4bit`` said ``false``, and
+``gemma-4-26b-8bit`` said ``true``. The value had also been copied onto the
+assistant drafter, which is the one entry in the family that genuinely is
+dense.
+
+The ground truth is the checkpoint's own ``config.json``:
+
+* ``mlx-community/gemma-4-26b-a4b-it-4bit`` — ``text_config.num_experts =
+  128``, ``top_k_experts = 8``, ``moe_intermediate_size = 704``. All three
+  quantizations are conversions of that one checkpoint, so they cannot
+  disagree.
+* ``mlx-community/gemma-4-26B-A4B-it-assistant-bf16`` — ``model_type =
+  gemma4_assistant``, ``text_config.num_experts = None``, four dense
+  layers. It is the 0.4B speculative drafter, not a copy of the target.
+
+``is_moe`` is not cosmetic: :mod:`vllm_mlx.speculative.dflash.eligibility`
+rejects MoE aliases outright (drafter hidden-state fusion misfires on
+expert-routing churn) and :mod:`vllm_mlx._mxfp4_moe_guardrail` keys off it,
+so a dense-tagged MoE alias can pass a gate that exists to stop it. Today
+the 4-bit entries are also blocked by the ``precision >= 8-bit`` criterion,
+which is exactly why the mis-tag survived review — the wrong answer was
+masked by an unrelated gate rather than being harmless.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from vllm_mlx.model_aliases import list_profiles
+
+# Every alias below resolves to a conversion of the same 26B-A4B checkpoint.
+_MOE_TARGETS = (
+    "gemma-4-26b-4bit",
+    "gemma-4-26b-qat-4bit",
+    "gemma-4-26b-8bit",
+)
+
+# The ``-assistant`` entries are Google's 4-layer speculative drafters, one
+# per base size. None of them is MoE, including the one paired with the MoE
+# target.
+_DENSE_ASSISTANTS = (
+    "gemma-4-e2b-assistant",
+    "gemma-4-e4b-assistant",
+    "gemma-4-12b-assistant",
+    "gemma-4-26b-assistant",
+    "gemma-4-31b-assistant",
+    "gemma-4-12b-qat-assistant-4bit",
+)
+
+
+@pytest.mark.parametrize("alias", _MOE_TARGETS)
+def test_26b_targets_are_tagged_moe(alias: str) -> None:
+    profiles = list_profiles()
+    assert alias in profiles, f"{alias}: missing from aliases.json"
+    assert profiles[alias].is_moe is True, (
+        f"{alias}: is_moe={profiles[alias].is_moe!r}, expected True. "
+        f"gemma-4-26B-A4B is a 128-expert / top-8 MoE (25.2B total, 3.8B "
+        f"active); every quantization of it must agree."
+    )
+
+
+@pytest.mark.parametrize("alias", _DENSE_ASSISTANTS)
+def test_assistant_drafters_are_tagged_dense(alias: str) -> None:
+    profiles = list_profiles()
+    assert alias in profiles, f"{alias}: missing from aliases.json"
+    assert profiles[alias].is_moe is False, (
+        f"{alias}: is_moe={profiles[alias].is_moe!r}, expected False. The "
+        f"gemma-4-*-assistant checkpoints are 4-layer dense drafters "
+        f"(``num_experts: null``); the flag belongs on the target they "
+        f"draft for, not on the drafter."
+    )
+
+
+def test_26b_family_agrees_with_itself() -> None:
+    """The failure mode this file exists for: same checkpoint, three
+    quantizations, three different answers. Assert agreement directly so a
+    future entry that copies the wrong neighbour is caught even if the
+    expected value above is ever revised.
+    """
+    profiles = list_profiles()
+    flags = {a: profiles[a].is_moe for a in _MOE_TARGETS if a in profiles}
+    assert len(set(flags.values())) == 1, (
+        f"quantizations of one checkpoint disagree on is_moe: {flags}"
+    )

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -635,6 +635,7 @@
     "tool_call_parser": "gemma4",
     "reasoning_parser": "gemma4",
     "is_hybrid": false,
+    "is_moe": true,
     "supports_spec_decode": true,
     "suffix_decoding_tier": "avoid",
     "suffix_bench_speedup": {
@@ -708,7 +709,7 @@
     "tool_call_parser": "gemma4",
     "reasoning_parser": "gemma4",
     "is_hybrid": false,
-    "is_moe": false,
+    "is_moe": true,
     "supports_spec_decode": true,
     "recommended_sampling": {
       "temperature": 1.0,
@@ -877,7 +878,7 @@
     "tool_call_parser": "gemma4",
     "reasoning_parser": "gemma4",
     "is_hybrid": false,
-    "is_moe": true,
+    "is_moe": false,
     "supports_spec_decode": false,
     "recommended_sampling": {
       "temperature": 1.0,

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -639,7 +639,9 @@
     "supports_spec_decode": true,
     "suffix_decoding_tier": "avoid",
     "suffix_bench_speedup": {
-      "json_array": 0.203
+      "chat": 0.62,
+      "codegen": 0.53,
+      "code_edit": 1.12
     },
     "recommended_sampling": {
       "temperature": 1.0,


### PR DESCRIPTION
## What does this PR do?

Three things for `gemma-4-26b-4bit` (Gemma 4 26B-A4B, the 128-expert MoE), all found while profiling it end-to-end on a 32GB Mac.

**1. `is_moe` was inconsistent across one checkpoint's three quantizations.** `gemma-4-26b-4bit` had no key at all (so it resolved to the `False` default), `gemma-4-26b-qat-4bit` said `false`, `gemma-4-26b-8bit` said `true`. The value had also been copied onto `gemma-4-26b-assistant` — the one entry in the family that genuinely *is* dense (it is Google's 4-layer speculative drafter, `num_experts: null`, and the five other `gemma-4-*-assistant` entries already say `false`).

Ground truth is the checkpoint config: `text_config.num_experts = 128`, `top_k_experts = 8`, `moe_intermediate_size = 704`.

This is not cosmetic. `is_moe` gates DFlash eligibility (`speculative/dflash/eligibility.py` rejects MoE outright — drafter hidden-state fusion misfires on expert-routing churn) and the mxfp4 MoE guardrail, so a dense-tagged MoE alias can pass a gate that exists to stop it. The 4-bit entries happen to be blocked today by the separate `precision >= 8-bit` criterion, which is exactly why the mis-tag survived review — masked by an unrelated gate rather than harmless. `rapid-mlx info` also printed `Not MoE: ✓ yes (dense)` for a 128-expert model.

**2. The stored suffix-decoding speedup was derived from a broken eval.** `{"json_array": 0.203}` comes from `evals/results/suffix_gemma-4-26b_v2.json`, where the vanilla arm reports **353 tok/s** and every other workload was rejected as `tps>500.0_ceiling`. A 26B does not decode at 353 tok/s on Apple Silicon — measured throughput is ~50. Both sides of that ratio are junk, so the ratio is too, and the boot log was quoting it at operators (`json_array regresses to 0.20x`).

Re-measured, same machine, B=1, temperature 0, medians of 5 (4 for edit):

| workload | baseline | suffix K=8 | ratio |
|---|---:|---:|---:|
| chat | 49.5 | 30.6 | 0.62 |
| codegen | 49.7 | 26.3 | 0.53 |
| code_edit | 47.1 | 52.6 | 1.12 |

The `avoid` tier was the right call and stays. What changes is that it now rests on numbers anyone can reproduce.

**3. A serve guide**, because the defaults are wrong for this model in a way no operator would guess.

## Why is this needed?

The load-bearing finding is in the guide: **the default KV dtype costs up to 14% of decode throughput on this model.**

The server picks int4 and says why —

```
KV cache dtype: int4 — Defaulting to int4 (memory-bandwidth-bound on
M-series); model=mlx-community/gemma-4-26b-a4b-it-4bit not in safelist
```

— so the model gets quantized KV by *failing to appear on a list*, not because anyone measured it. Measured, quantizing is a straight loss:

| KV dtype | chat | codegen | code edit |
|---|---:|---:|---:|
| int4 (default) | 47.9 | 46.9 | 41.7 |
| int8 | 47.6 | 46.6 | 40.1 |
| **bf16** | **49.5** | **49.8** | **47.4** |

The architecture explains it: only 5 of 30 layers use full attention (indices 5, 11, 17, 23, 29), the other 25 being sliding-window with a 1024 window, so only 5 layers grow with context — and those use `num_global_key_value_heads` (2), not the `num_key_value_heads` (8) the sliding layers use. That is **20 KB/token**, or 640MB for a 32K context. KV was never remotely the bandwidth bottleneck here, so quantizing buys nothing measurable and the quantize/dequantize work is pure overhead.

There is a trap in the interaction: `--no-mllm` is what you want (the MLLM lane does not use the prefix cache at all — a repeated 502-token prompt re-prefills at 2.44s every time against 0.28s on the text lane), but taking it lands you on the int4 default and costs 13.7% on code-edit decode. Both flags together get the TTFT win without the decode loss. That combination is the guide's headline.

To be clear about what this PR does *not* claim: decode throughput at the recommended settings is unchanged from the out-of-box default (49.5 vs 49.7 chat). The wins are TTFT on repeated prompts (~8.8x), 2.7GB of peak-memory headroom at 16K, and not falling into the `--no-mllm`-alone trap.

The guide also records what the model can't do, since those cost time to find: throughput becomes unreliable past ~12K context (8K holds ±3% over six consecutive runs; 12K spreads 16.4-27.1 tok/s with individual samples at 8.1, while TTFT stays linear and reproducible throughout — prompt length, response content, machine load and prefix-cache occupancy were each tested and ruled out as the cause), a 16K prompt reaches 21.5GB against a 24.1GB allocation limit, and roughly one edit in seven on a small refactor task comes back corrupted.

## AI assistance disclosure

Claude (Opus 5) did the profiling, wrote the tests and the guide; I set the goal (make Gemma 4 26B the best it can be on a 32GB Mac) and reviewed the findings.

How it was verified, and where it is weak:

- **Single machine.** Every number here is from one Mac mini M2 Pro 32GB. 14.3GB of weights does not fit the 18GB second host, so the two-machine check that caught chip-dependent conclusions on the 12B work (#1419) was not possible. The bf16-KV argument is architectural — 20 KB/token is not bandwidth-bound — so it should hold across M-series, but that is reasoning, not measurement. Flagged in the guide's own text too.
- The `is_moe` change was verified at **runtime**, not just by inspection: server boots unchanged, the mxfp4 guardrail stays quiet (it needs mxfp4+distributed or nvfp4; this is affine 4-bit, and it warns rather than blocks in any case), `rapid-mlx info` flips to `Not MoE: ✗ no (MoE)`, and a completion request answers correctly.
- Three intermediate conclusions were **wrong and were corrected by later measurement**, and the surviving text reflects the corrections: the KV-per-token arithmetic was wrong twice, first by taking the Hub model card's 4 full-attention layers over the config's 5, then by using `num_key_value_heads` where full-attention layers use `num_global_key_value_heads` (codex review caught the second one — it is 20 KB/token, and the dense 12B is 16, so the 26B carries slightly *more* growing KV, not less, which is why that comparison was dropped rather than restated); the text lane does not prefill faster than the MLLM lane (both ~4.8 ms/token — the advantage is entirely prefix-cache reuse, and the earlier "5.3x faster cold" reading was a warm cache misread as cold); and an apparent 4.6x decode collapse at exactly 12000 tokens was an artifact of single-sampling a high-variance regime, not a property of that length.
- SuffixDecoding numbers come from a harness that sends a **distinct prompt per repetition** (`results/bench_lowoverlap.py`), after the same-prompt version silently turned a low-overlap measurement into a high-overlap one during #1419.

> By submitting this PR I confirm I can explain the intent, risk, and behavior of every non-generated change in this PR.

## Test plan

- `tests/test_gemma4_26b_moe_flag.py` (10 new) — pins `is_moe` for the three 26B target quantizations and the six `gemma-4-*-assistant` drafters, plus a test asserting the three quantizations of one checkpoint agree *with each other*, so a future entry that copies the wrong neighbour is caught even if the expected value is ever revised.
- Mutation spot-check: reverting `gemma-4-26b-qat-4bit` to `is_moe: false` fails 2 of the 10 (the parametrized case and the self-agreement test); restoring passes 10/10.
- `ruff check` / `ruff format --check` clean on the new test.
- Alias + model-alias suites: 2695 passed after rebasing onto `main`.
- Filtered suite (`-k "alias or moe or gemma4 or profile or dflash or ddtree or suffix"`) diffed against `main` in the same venv: identical FAILED list (2 pre-existing `test_no_mllm_flag` cases that try to download `bonsai-27b-2bit`), so **zero new failures**; the branch's +10 passes are the new file.

## Checklist

- [x] Tests pass locally (filtered suite diffed against `main`: zero new failures)
- [x] Lint passes (`ruff check && ruff format --check`)
- [x] Self-validated with `python3 -m scripts.pr_validate.pr_validate 1429` — scorecard in a comment
- [x] New tests were spot-checked to fail when the corresponding registry value is reverted
- [x] Updated README/docs if applicable — adds `docs/guides/gemma4-26b-32gb.md`; no flag or API change
- [x] No breaking changes to existing API
