### PR TITLE
chore: bump version to 0.12.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.11.9"
+version = "0.12.1"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
Cuts **Rapid-MLX v0.12.1** — the first engine release since v0.11.9 (27 commits). Merging this `chore: bump version to 0.12.1` commit is what triggers `auto-release.yml` (tier1-agent-gate → tag → PyPI → Homebrew).

## Why
Bundle the accumulated engine + app work into a single aligned 0.12.1 (engine + desktop app on the same version heading into 1.0).

## What's in it
- **Agents (Codex/DeepSeek)**: stabilize engineering turns (#1428), evidence-aware/bounded priming (#1424/#1417), recover from unavailable test commands (#1418), terminate repetition (#1409), harden V4 DSML tool protocol (#1407), stabilize Codex loops + DSpark depth (#1402)
- **Inference/cache/memory**: exclude transient Codex priming from the reusable prefix (#1425); long-context prefill memory pressure (#1410); DSpark checkpoint verify + rollback (#1411)
- **Gemma 4**: 26B MoE flag + 32 GB guide (#1429); bench + live KV quant + KV-projection override (#1408)
- **Packaging/deps/auth**: validated audio stack in `[all]` (#1421); cap mlx/mlx-lm/mlx-vlm + coherence-gated bumps (#1248/#1400); bearer-token whitespace (#1291)
- **Benchmarks**: community submit over HTTP (#1403); freeform bench weight-load fix (#1404); schema v3 gates (#1426)
- **Desktop app** (`apps/rapid-mac`): the app (#1406), polish/Apache-2.0 (#1413), loopback telemetry (#1416), signing-optional workflow (#1422), download-only (#1427), app-owned first-run gate + cheetah tray icon (#1430)

`mlx`/`mlx-lm`/`mlx-vlm` **floors are unchanged** (only added `<0.32`/`<0.7` upper caps), so the runtime is byte-identical to v0.11.9.

## Validation (local, pre-bump)
- `make release-smoke` — clean-room wheel install + import ✅
- `make smoke` — lint + CLI↔config audit + **15,099 unit tests** ✅
- `make release-check-m3` (solo clean GPU): coherence sweep (Qwen3.5/3.6/Gemma4/gpt-oss, 6/6 each) ✅, stress 8/8 ✅, Anthropic/pydantic_ai/smolagents ✅, parallel-cap ✅, **opencode/hermes/aider/langchain agent harness ✅**
- Known artifact (not blocking): codex `e2e_file_read` times out on the weak `qwen3.5-9b-4bit` gauntlet model — a **pre-existing, documented** model-strength case (`tier_runner.py:568`, `release_check_m3.sh:492`), reproduced identically on a clean solo GPU. Per RELEASE.md the authoritative codex check is the **tier1-agent-gate on `qwen3.6-35b-8bit`**, which runs on merge and gates this publish.
- hy3-preview-4bit (154 GB) skipped from the local coherence sweep — won't fit on disk; its coherence can only regress from an mlx bump, and the mlx floors are unchanged.