### PR TITLE
chore(rapid-mac): bump app to 0.12.1 (signed release)

### DIFF
--- a/apps/rapid-mac/CHANGELOG.md
+++ b/apps/rapid-mac/CHANGELOG.md
@@ -13,6 +13,27 @@ can actually understand.
 
 ## [Unreleased]
 
+## [0.12.1] — 2026-08-03
+
+The first **signed + notarised** release — it installs and opens without the
+Gatekeeper "unverified developer" warning that the 0.12.0 internal build hit.
+Two dogfood fixes and the latest engine.
+
+### App
+
+- **First-run onboarding no longer depends on the shared Hugging Face cache.**
+  A brand-new user who happens to have unrelated models on disk (e.g. Whisper
+  from another tool) now still gets the one-click Quickstart instead of being
+  dropped into the raw model picker. Onboarding keys on the app's own state.
+- **The menu-bar icon is now the brand cheetah**, matching the app icon (it
+  was a lightning bolt).
+
+### Engine
+
+- Bundles the **Rapid-MLX 0.12.1** inference engine: agent / DeepSeek
+  stability, prefix-cache correctness, Gemma 4 fixes, a validated audio stack,
+  and community-benchmark submission over HTTP.
+
 ## [0.12.0] — 2026-08-02
 
 The first release of Rapid-MLX Desktop as an **open-source** app in the

--- a/apps/rapid-mac/Resources/Info.plist
+++ b/apps/rapid-mac/Resources/Info.plist
@@ -19,9 +19,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.12.0</string>
+	<string>0.12.1</string>
 	<key>CFBundleVersion</key>
-	<string>147</string>
+	<string>148</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>14.0</string>
 	<key>NSHighResolutionCapable</key>


### PR DESCRIPTION
## Why
Cut the first **signed + notarised** Rapid-MLX Desktop release. 0.12.0 was an unsigned internal build that hit the Gatekeeper "unverified developer" wall; the Apple signing setup is now provisioned and **proven** (a `workflow_dispatch` dry-run produced a Developer-ID-signed, notarised, stapled DMG — `spctl -a` accepted, `stapler validate` OK, Team `73WQ7ZGSWC`).

## What
- `Info.plist`: `CFBundleShortVersionString` 0.12.0 → **0.12.1**, `CFBundleVersion` 147 → **148**
- `CHANGELOG.md`: `## [0.12.1]` section

## Release mechanics
After this merges, tagging `rapid-mac-v0.12.1` from main triggers `rapid-mac-release.yml`, which builds the sidecar from the engine at repo root (**now 0.12.1**, released via #1431), signs + notarises, and attaches the DMG to a **non-prerelease** GitHub Release (secrets present → `SIGNED=true`).

## Ships on top of 0.12.0
- App-owned first-run onboarding gate (no longer suppressed by unrelated HF-cache models) + brand cheetah menu-bar icon (#1430)
- Bundled engine bumped 0.11.9 → 0.12.1

Local build + headless dogfood of the bundled 0.12.1 sidecar will run before the tag is pushed (per the build-before-tag rule).