### PR TITLE
fix(rapid-mac): live free-memory guard before model load (block OOM/panic)

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Server/BenchmarkRunner.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/BenchmarkRunner.swift
@@ -98,6 +98,22 @@ final class BenchmarkRunner {
             submitPhase = .failed("Pick a model first.")
             return
         }
+        // Same pre-load memory guard as ``run`` (#324). Submitting re-runs
+        // the FULL standardized workload — a cold model reload on top of
+        // whatever the app's sidecar already has resident — so it is the
+        // heavier of the two 2x-load paths, not a lighter one. Leaving it
+        // unguarded would let Publish walk straight into the near-crash
+        // that ``run`` now refuses.
+        if let snapshot = MemoryProbe.snapshot(),
+           ModelSizing.memorySafety(
+               footprint: ModelSizing.estimate(alias: alias),
+               usedBytes: snapshot.usedBytes,
+               totalBytes: snapshot.totalBytes
+           ) == .unsafe {
+            submitPhase = .failed(
+                "Not enough free memory to run the submission benchmark for \(alias) right now — it reloads the model on top of what's already running. Close some apps or restart the model, then try again.")
+            return
+        }
         submitPhase = .submitting
         // The CLI prints the exact payload and asks "submit? [y/N]" on
         // stdin. The app already showed its own consent, so answer "y".

--- a/apps/rapid-mac/Sources/Rapid/Server/BenchmarkRunner.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/BenchmarkRunner.swift
@@ -49,6 +49,22 @@ final class BenchmarkRunner {
             phase = .failed("Pick a model first.")
             return
         }
+        // Pre-load memory guard (#324). `rapid-mlx bench` spawns its own
+        // process that loads the full model — a *second* resident copy
+        // if the app's sidecar already has this alias loaded. Projecting
+        // the footprint onto live `usedBytes` (which already includes the
+        // first copy) catches that 2× case, so we refuse to spawn a bench
+        // that would push unified memory past the kernel-panic line.
+        if let snapshot = MemoryProbe.snapshot(),
+           ModelSizing.memorySafety(
+               footprint: ModelSizing.estimate(alias: alias),
+               usedBytes: snapshot.usedBytes,
+               totalBytes: snapshot.totalBytes
+           ) == .unsafe {
+            phase = .failed(
+                "Not enough free memory to benchmark \(alias) right now — it loads a second copy of the model on top of what's already running. Close some apps or restart the model, then try again.")
+            return
+        }
         phase = .running
         let output = await Self.runProcess(
             binary: binary, args: ["bench", alias], stdinLine: nil

--- a/apps/rapid-mac/Sources/Rapid/Server/ModelSizing.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ModelSizing.swift
@@ -142,6 +142,96 @@ enum ModelSizing {
         return .tooBig
     }
 
+    // MARK: - Live memory safety (pre-load guard)
+
+    /// Verdict for loading a model RIGHT NOW given live memory use.
+    ///
+    /// Unlike ``classify`` — which bands a footprint against a STATIC
+    /// 80%-of-total estimate and so only knows "does this model fit
+    /// this Mac at all" — this projects the footprint on top of what
+    /// is *actually in use this second*. A model that "fits the Mac"
+    /// is still flagged when other apps (or a model already loaded for
+    /// the benchmark's second copy) have eaten the free RAM. That gap
+    /// is the reported near-crash: gemma-4-12b classifies ``.fits`` on
+    /// a larger Mac, yet loading it with little free RAM pushed unified
+    /// memory past the danger line.
+    ///
+    /// #324: unified memory past ~85% of total can trip the iBoot
+    /// AMCC async-abort firmware path and **kernel-panic the whole
+    /// machine** rather than raise a userspace OOM — so ``.unsafe`` is
+    /// pinned to that ~85% danger line and is a must-confirm block,
+    /// never a silent proceed.
+    enum MemorySafety: String, Sendable, Equatable {
+        /// Projected use < 75% of total — comfortable.
+        case safe
+        /// 75-85% — will load but risks swap / stalls; warn.
+        case tight
+        /// ≥ 85% — at/over the kernel-panic danger line; block + confirm.
+        case unsafe
+    }
+
+    /// Project ``footprint`` onto ``usedBytes`` and bucket the result.
+    /// Returns ``.safe`` when the numbers are unreadable or the param
+    /// count is unknown — never block a load on missing data (the
+    /// loader still surfaces genuine failures downstream).
+    static func memorySafety(
+        footprint: Footprint,
+        usedBytes: UInt64,
+        totalBytes: UInt64
+    ) -> MemorySafety {
+        guard totalBytes > 0, footprint.paramsBillions != nil else { return .safe }
+        let gib = Double(1 << 30)
+        let footprintBytes = footprint.totalGB * gib
+        let projected = (Double(usedBytes) + footprintBytes) / Double(totalBytes)
+        if projected >= 0.85 { return .unsafe }
+        if projected >= 0.75 { return .tight }
+        return .safe
+    }
+
+    /// A pending "this load may exhaust memory" prompt. Held on
+    /// ``ServerManager`` as observable state so any model-start path
+    /// (picker, first message, auto-restart, quickstart) surfaces the
+    /// SAME confirmation without each call site re-implementing it.
+    /// Copy lives here (not in a view) so ``ModelSizingTests`` can pin
+    /// it without a SwiftUI host — same pattern as the tooBig alert.
+    struct MemoryWarning: Equatable, Sendable, Identifiable {
+        var id: String { alias }
+        let alias: String
+        let hfPath: String?
+        let isAutoRespawn: Bool
+        let severity: MemorySafety
+        /// Estimated GB the model needs.
+        let footprintGB: Double
+        /// GB free at the moment the load was attempted.
+        let freeGB: Double
+
+        var title: String {
+            switch severity {
+            case .unsafe:
+                return "\(alias) may crash your Mac right now"
+            case .tight, .safe:
+                return "\(alias) is a tight fit right now"
+            }
+        }
+
+        var message: String {
+            let need = max(1, Int(footprintGB.rounded()))
+            let free = max(0, Int(freeGB.rounded()))
+            let facts = "\(alias) needs about \(need) GB, but only about \(free) GB is free right now — other apps or a running model are using memory."
+            switch severity {
+            case .unsafe:
+                return facts + " Loading it may freeze or crash your Mac. Close some apps, or pick a smaller model."
+            case .tight, .safe:
+                return facts + " It should load but may stall under longer chats. Consider closing some apps or picking a smaller model."
+            }
+        }
+
+        /// The confirm button title — worded to match the risk.
+        var confirmTitle: String {
+            severity == .unsafe ? "Load anyway (risky)" : "Load anyway"
+        }
+    }
+
     // MARK: - Lineage ranking
 
     /// Lineage score borrowed from whichllm's ``MODEL_LINEAGE_VERSIONS``.

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -71,12 +71,20 @@ final class ServerManager {
     /// message even though the model does come up.
     private var memoryConfirmTask: Task<Void, Never>?
 
-    /// True while the confirmed launch is still running. Polled by
+    /// Confirmed launches still running, by sequence number. Polled by
     /// ``awaitConfirmedLaunch`` instead of awaiting the task's ``value``:
     /// awaiting a non-throwing Task is NOT cancellation-aware, so a caller
     /// that gets cancelled mid-wait (chat Stop, switching conversations)
     /// would stay suspended until a possibly-stalled download finished.
-    private var memoryConfirmInFlight = false
+    ///
+    /// Keyed per launch rather than a single flag: two confirmations can
+    /// overlap (confirm A while its pull settles, then park and CANCEL B),
+    /// and a shared flag would let B's cancel tell A's waiter that A had
+    /// finished — dropping A's chat turn while A was still coming up.
+    private var memoryConfirmRunning: Set<Int> = []
+
+    /// Monotonic id for the most recent confirmed launch.
+    private var memoryConfirmSeq = 0
 
     /// Alias the child is currently serving once `/healthz` answered 200,
     /// else `nil`. Authoritative source of truth for which model id any
@@ -631,7 +639,9 @@ final class ServerManager {
             if confirmed {
                 // Wait out the actual re-entered launch — no fixed bound,
                 // because it may legitimately sit on a background download.
-                await awaitConfirmedLaunch()
+                // Bind to THIS confirmation so an unrelated later cancel
+                // cannot end the wait early.
+                await awaitConfirmedLaunch(memoryConfirmSeq)
             }
         }
         // ``start`` returns silently when another caller already owns
@@ -683,8 +693,8 @@ final class ServerManager {
     /// pre-spawn download can take minutes) but cancellation-aware: the
     /// ``Task.sleep`` throws when the CALLER is cancelled, so we stop waiting
     /// and leave the launch itself running — the user did ask for it.
-    private func awaitConfirmedLaunch() async {
-        while memoryConfirmInFlight {
+    private func awaitConfirmedLaunch(_ seq: Int) async {
+        while memoryConfirmRunning.contains(seq) {
             do {
                 try await Task.sleep(nanoseconds: 200_000_000)
             } catch {
@@ -771,7 +781,9 @@ final class ServerManager {
         // Publish the task BEFORE clearing nothing else — both this and the
         // waiter run on the MainActor, so a waiter that observes
         // ``pendingMemoryWarning == nil`` is guaranteed to see this task.
-        memoryConfirmInFlight = true
+        memoryConfirmSeq += 1
+        let seq = memoryConfirmSeq
+        memoryConfirmRunning.insert(seq)
         memoryConfirmTask = Task { [weak self] in
             await self?.start(
                 alias: warning.alias,
@@ -779,7 +791,7 @@ final class ServerManager {
                 isAutoRespawn: warning.isAutoRespawn,
                 bypassMemoryGuard: true
             )
-            self?.memoryConfirmInFlight = false
+            self?.memoryConfirmRunning.remove(seq)
         }
     }
 
@@ -787,9 +799,12 @@ final class ServerManager {
     /// held request; ``state`` is untouched (it never left idle/stopped
     /// because ``start`` returned before spawning).
     func cancelPendingMemoryLoad() {
+        // Deliberately leaves ``memoryConfirmRunning`` alone: this cancels a
+        // load that was never started, so any launch still in flight belongs
+        // to an EARLIER confirmation and its waiter must not be told it
+        // finished.
         memoryLoadConfirmed = false
         memoryConfirmTask = nil
-        memoryConfirmInFlight = false
         pendingMemoryWarning = nil
     }
 

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -71,6 +71,13 @@ final class ServerManager {
     /// message even though the model does come up.
     private var memoryConfirmTask: Task<Void, Never>?
 
+    /// True while the confirmed launch is still running. Polled by
+    /// ``awaitConfirmedLaunch`` instead of awaiting the task's ``value``:
+    /// awaiting a non-throwing Task is NOT cancellation-aware, so a caller
+    /// that gets cancelled mid-wait (chat Stop, switching conversations)
+    /// would stay suspended until a possibly-stalled download finished.
+    private var memoryConfirmInFlight = false
+
     /// Alias the child is currently serving once `/healthz` answered 200,
     /// else `nil`. Authoritative source of truth for which model id any
     /// outgoing chat request should put in `model:` — picker bar state
@@ -622,10 +629,9 @@ final class ServerManager {
         if pendingMemoryWarning != nil {
             let confirmed = await awaitMemoryDecision()
             if confirmed {
-                // Await the actual re-entered launch. It may block on a
-                // background download well past any fixed timeout, so this
-                // waits on the task itself rather than polling for state.
-                await memoryConfirmTask?.value
+                // Wait out the actual re-entered launch — no fixed bound,
+                // because it may legitimately sit on a background download.
+                await awaitConfirmedLaunch()
             }
         }
         // ``start`` returns silently when another caller already owns
@@ -672,6 +678,20 @@ final class ServerManager {
         return memoryLoadConfirmed
     }
 
+
+    /// Waits for a confirmed memory-risky launch to finish. Unbounded (a
+    /// pre-spawn download can take minutes) but cancellation-aware: the
+    /// ``Task.sleep`` throws when the CALLER is cancelled, so we stop waiting
+    /// and leave the launch itself running — the user did ask for it.
+    private func awaitConfirmedLaunch() async {
+        while memoryConfirmInFlight {
+            do {
+                try await Task.sleep(nanoseconds: 200_000_000)
+            } catch {
+                return
+            }
+        }
+    }
 
     private func awaitStartupSettled(alias: String) async {
         while true {
@@ -751,6 +771,7 @@ final class ServerManager {
         // Publish the task BEFORE clearing nothing else — both this and the
         // waiter run on the MainActor, so a waiter that observes
         // ``pendingMemoryWarning == nil`` is guaranteed to see this task.
+        memoryConfirmInFlight = true
         memoryConfirmTask = Task { [weak self] in
             await self?.start(
                 alias: warning.alias,
@@ -758,6 +779,7 @@ final class ServerManager {
                 isAutoRespawn: warning.isAutoRespawn,
                 bypassMemoryGuard: true
             )
+            self?.memoryConfirmInFlight = false
         }
     }
 
@@ -767,6 +789,7 @@ final class ServerManager {
     func cancelPendingMemoryLoad() {
         memoryLoadConfirmed = false
         memoryConfirmTask = nil
+        memoryConfirmInFlight = false
         pendingMemoryWarning = nil
     }
 

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -63,6 +63,14 @@ final class ServerManager {
     /// (wait for the re-entered launch instead of reporting failure).
     private var memoryLoadConfirmed: Bool = false
 
+    /// The re-entered launch spawned by "Load anyway". ``ensureServing``
+    /// awaits this instead of polling for a state change: ``start`` can
+    /// legitimately sit in ``awaitDownloadSettlement`` (a background pull
+    /// still fetching the model) with ``state`` still idle for far longer
+    /// than any fixed bound, and timing out there would drop the user's
+    /// message even though the model does come up.
+    private var memoryConfirmTask: Task<Void, Never>?
+
     /// Alias the child is currently serving once `/healthz` answered 200,
     /// else `nil`. Authoritative source of truth for which model id any
     /// outgoing chat request should put in `model:` — picker bar state
@@ -614,11 +622,10 @@ final class ServerManager {
         if pendingMemoryWarning != nil {
             let confirmed = await awaitMemoryDecision()
             if confirmed {
-                // ``confirmPendingMemoryLoad`` re-enters ``start`` from
-                // the alert button's own Task, so the state machine may
-                // not have left idle yet; wait for it to pick up before
-                // the ``.starting`` settle below reads it.
-                await awaitStartupBegun(alias: trimmed)
+                // Await the actual re-entered launch. It may block on a
+                // background download well past any fixed timeout, so this
+                // waits on the task itself rather than polling for state.
+                await memoryConfirmTask?.value
             }
         }
         // ``start`` returns silently when another caller already owns
@@ -665,24 +672,6 @@ final class ServerManager {
         return memoryLoadConfirmed
     }
 
-    /// Waits for ``start`` to pick the alias up after a confirmed
-    /// memory-risky load. Bounded: a confirm that never reaches ``start``
-    /// must not hang ``ensureServing`` forever.
-    private func awaitStartupBegun(alias: String, timeout: TimeInterval = 5.0) async {
-        let deadline = Date().addingTimeInterval(timeout)
-        while Date() < deadline {
-            switch state {
-            case .starting(let current) where current == alias: return
-            case .ready(let current) where current == alias: return
-            default: break
-            }
-            do {
-                try await Task.sleep(nanoseconds: 100_000_000)
-            } catch {
-                return
-            }
-        }
-    }
 
     private func awaitStartupSettled(alias: String) async {
         while true {
@@ -756,15 +745,20 @@ final class ServerManager {
     /// the same run-loop turn the button fires — reading it here would
     /// race to nil and silently drop the load. Re-enters ``start`` with
     /// the guard bypassed.
-    func confirmPendingMemoryLoad(_ warning: ModelSizing.MemoryWarning) async {
+    func confirmPendingMemoryLoad(_ warning: ModelSizing.MemoryWarning) {
         memoryLoadConfirmed = true
         pendingMemoryWarning = nil
-        await start(
-            alias: warning.alias,
-            hfPath: warning.hfPath,
-            isAutoRespawn: warning.isAutoRespawn,
-            bypassMemoryGuard: true
-        )
+        // Publish the task BEFORE clearing nothing else — both this and the
+        // waiter run on the MainActor, so a waiter that observes
+        // ``pendingMemoryWarning == nil`` is guaranteed to see this task.
+        memoryConfirmTask = Task { [weak self] in
+            await self?.start(
+                alias: warning.alias,
+                hfPath: warning.hfPath,
+                isAutoRespawn: warning.isAutoRespawn,
+                bypassMemoryGuard: true
+            )
+        }
     }
 
     /// The user backed out of a memory-risky load. Just drops the
@@ -772,6 +766,7 @@ final class ServerManager {
     /// because ``start`` returned before spawning).
     func cancelPendingMemoryLoad() {
         memoryLoadConfirmed = false
+        memoryConfirmTask = nil
         pendingMemoryWarning = nil
     }
 
@@ -858,6 +853,15 @@ final class ServerManager {
                     freeGB: Double(snapshot.freeBytes) / Double(1 << 30)
                 )
                 memoryLoadConfirmed = false
+                // The user is now the decision-maker for this alias, so a
+                // queued auto-respawn must not answer for them. Parking a
+                // load leaves ``state`` untouched — still ``.crashed`` when
+                // the user hit Restart after a crash — so
+                // ``runScheduledAutoRespawn``'s state recheck would PASS and
+                // fire ``start(isAutoRespawn: true)``, which bypasses this
+                // guard and loads the very model the user may be about to
+                // decline. Cancel it; a confirm re-enters ``start`` explicitly.
+                cancelAutoRespawn()
                 return
             }
         }

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -49,6 +49,14 @@ final class ServerManager {
     /// Current lifecycle phase. Drives all UI state controls.
     private(set) var state: ServerState
 
+    /// Set when ``start`` declines a load because the model's footprint
+    /// on top of live memory use would risk exhausting RAM (#324). A
+    /// top-level view binds a confirmation alert to this; the user
+    /// either acknowledges the risk (``confirmPendingMemoryLoad``) or
+    /// backs out (``cancelPendingMemoryLoad``). ``nil`` when no load is
+    /// being held for confirmation.
+    var pendingMemoryWarning: ModelSizing.MemoryWarning?
+
     /// Alias the child is currently serving once `/healthz` answered 200,
     /// else `nil`. Authoritative source of truth for which model id any
     /// outgoing chat request should put in `model:` — picker bar state
@@ -684,7 +692,35 @@ final class ServerManager {
     /// transition (the bug Bug A removed), which incidentally also
     /// covered manual restarts. The default is ``false`` to make the
     /// behavior obvious at every public call site.
-    func start(alias: String, hfPath: String? = nil, isAutoRespawn: Bool = false) async {
+    /// The user acknowledged the memory warning and wants to load
+    /// anyway. Takes the ``warning`` by value (not off ``pendingMemory-
+    /// Warning``) because the alert's dismissal clears that property on
+    /// the same run-loop turn the button fires — reading it here would
+    /// race to nil and silently drop the load. Re-enters ``start`` with
+    /// the guard bypassed.
+    func confirmPendingMemoryLoad(_ warning: ModelSizing.MemoryWarning) async {
+        pendingMemoryWarning = nil
+        await start(
+            alias: warning.alias,
+            hfPath: warning.hfPath,
+            isAutoRespawn: warning.isAutoRespawn,
+            bypassMemoryGuard: true
+        )
+    }
+
+    /// The user backed out of a memory-risky load. Just drops the
+    /// held request; ``state`` is untouched (it never left idle/stopped
+    /// because ``start`` returned before spawning).
+    func cancelPendingMemoryLoad() {
+        pendingMemoryWarning = nil
+    }
+
+    func start(
+        alias: String,
+        hfPath: String? = nil,
+        isAutoRespawn: Bool = false,
+        bypassMemoryGuard: Bool = false
+    ) async {
         // Issue #278: a manual restart is the user taking over the
         // lifecycle — reset the budget at entry so a previously
         // exhausted counter doesn't make a quick post-restart crash
@@ -714,6 +750,47 @@ final class ServerManager {
                 message: "That model name isn't valid. Pick a model from the bar at the top."
             )
             return
+        }
+
+        // Pre-load memory guard (#324). Loading a model whose footprint,
+        // stacked on top of what is ALREADY resident, would push unified
+        // memory past ~90% of total can freeze or kernel-panic the whole
+        // Mac — a far worse outcome than declining to load. This is the
+        // single choke point every start path funnels through (picker,
+        // first message, auto-restart, quickstart), so the check + the
+        // confirmation prompt live here once instead of at each call site.
+        // Unlike the picker's static ``ModelSizing.classify`` (bands vs
+        // 80% of TOTAL), this projects the footprint onto LIVE used memory,
+        // catching the reported near-crash where a "fits the Mac" model
+        // still exhausts the RAM other apps left free. ``bypassMemoryGuard``
+        // is set only by the explicit "Load anyway" path, after the user
+        // acknowledged the risk in the prompt.
+        //
+        // Auto-respawn is exempt (``!isAutoRespawn``): the watchdog re-fires
+        // ``start(isAutoRespawn: true)`` on a fixed schedule, so returning
+        // early here would spin — set-warning → return → watchdog re-fires →
+        // repeat, forever, with a modal stuck on screen and no model serving.
+        // Respawn is also recovering a model that ALREADY fit when it first
+        // started; a genuine free-RAM drop is bounded by the respawn-attempt
+        // budget, and the user's manual restart still routes through the guard.
+        if !bypassMemoryGuard, !isAutoRespawn, let snapshot = MemoryProbe.snapshot() {
+            let footprint = ModelSizing.estimate(alias: trimmedAlias)
+            let safety = ModelSizing.memorySafety(
+                footprint: footprint,
+                usedBytes: snapshot.usedBytes,
+                totalBytes: snapshot.totalBytes
+            )
+            if safety != .safe {
+                pendingMemoryWarning = ModelSizing.MemoryWarning(
+                    alias: trimmedAlias,
+                    hfPath: hfPath,
+                    isAutoRespawn: isAutoRespawn,
+                    severity: safety,
+                    footprintGB: footprint.totalGB,
+                    freeGB: Double(snapshot.freeBytes) / Double(1 << 30)
+                )
+                return
+            }
         }
 
         // Issue #253: if a background ``rapid-mlx pull`` is already

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -754,7 +754,7 @@ final class ServerManager {
 
         // Pre-load memory guard (#324). Loading a model whose footprint,
         // stacked on top of what is ALREADY resident, would push unified
-        // memory past ~90% of total can freeze or kernel-panic the whole
+        // memory past ~85% of total can freeze or kernel-panic the whole
         // Mac — a far worse outcome than declining to load. This is the
         // single choke point every start path funnels through (picker,
         // first message, auto-restart, quickstart), so the check + the

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -57,6 +57,12 @@ final class ServerManager {
     /// being held for confirmation.
     var pendingMemoryWarning: ModelSizing.MemoryWarning?
 
+    /// How the user answered the most recent memory prompt. Read by
+    /// ``awaitMemoryDecision`` so ``ensureServing`` can tell "user backed
+    /// out" (an honest startup failure) from "user chose Load anyway"
+    /// (wait for the re-entered launch instead of reporting failure).
+    private var memoryLoadConfirmed: Bool = false
+
     /// Alias the child is currently serving once `/healthz` answered 200,
     /// else `nil`. Authoritative source of truth for which model id any
     /// outgoing chat request should put in `model:` — picker bar state
@@ -598,6 +604,23 @@ final class ServerManager {
             await stop()
         }
         await start(alias: trimmed, hfPath: hfPath)
+        // ``start`` also returns without spawning when the pre-load
+        // memory guard parks the load on a confirmation prompt. Reading
+        // ``isServing`` now would report "couldn't start the model"
+        // while the user is still looking at the dialog — and the action
+        // that triggered the load (typically a first chat message) would
+        // be marked failed and then silently dropped the moment the user
+        // picks "Load anyway". Wait for the answer instead.
+        if pendingMemoryWarning != nil {
+            let confirmed = await awaitMemoryDecision()
+            if confirmed {
+                // ``confirmPendingMemoryLoad`` re-enters ``start`` from
+                // the alert button's own Task, so the state machine may
+                // not have left idle yet; wait for it to pick up before
+                // the ``.starting`` settle below reads it.
+                await awaitStartupBegun(alias: trimmed)
+            }
+        }
         // ``start`` returns silently when another caller already owns
         // the launch (``isOperating`` set, or ``child`` non-nil), which
         // leaves us sitting in ``.starting``. Reporting failure there
@@ -626,6 +649,41 @@ final class ServerManager {
     /// genuinely in flight, and 200 ms is far below human perception
     /// against a 15-60 s load. Returns early on cancellation so a
     /// caller that gives up doesn't pin this task.
+    /// Blocks while a load is parked on the memory-confirmation prompt.
+    /// Returns whether the user chose to load anyway. Polls rather than
+    /// awaiting a continuation so a dismissed-without-answer alert (or a
+    /// build with no view bound to ``pendingMemoryWarning``) resolves via
+    /// ``cancelPendingMemoryLoad`` instead of stranding the caller.
+    private func awaitMemoryDecision() async -> Bool {
+        while pendingMemoryWarning != nil {
+            do {
+                try await Task.sleep(nanoseconds: 200_000_000)
+            } catch {
+                return false
+            }
+        }
+        return memoryLoadConfirmed
+    }
+
+    /// Waits for ``start`` to pick the alias up after a confirmed
+    /// memory-risky load. Bounded: a confirm that never reaches ``start``
+    /// must not hang ``ensureServing`` forever.
+    private func awaitStartupBegun(alias: String, timeout: TimeInterval = 5.0) async {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            switch state {
+            case .starting(let current) where current == alias: return
+            case .ready(let current) where current == alias: return
+            default: break
+            }
+            do {
+                try await Task.sleep(nanoseconds: 100_000_000)
+            } catch {
+                return
+            }
+        }
+    }
+
     private func awaitStartupSettled(alias: String) async {
         while true {
             guard case .starting(let current) = state, current == alias else { return }
@@ -699,6 +757,7 @@ final class ServerManager {
     /// race to nil and silently drop the load. Re-enters ``start`` with
     /// the guard bypassed.
     func confirmPendingMemoryLoad(_ warning: ModelSizing.MemoryWarning) async {
+        memoryLoadConfirmed = true
         pendingMemoryWarning = nil
         await start(
             alias: warning.alias,
@@ -712,6 +771,7 @@ final class ServerManager {
     /// held request; ``state`` is untouched (it never left idle/stopped
     /// because ``start`` returned before spawning).
     func cancelPendingMemoryLoad() {
+        memoryLoadConfirmed = false
         pendingMemoryWarning = nil
     }
 
@@ -780,7 +840,15 @@ final class ServerManager {
                 usedBytes: snapshot.usedBytes,
                 totalBytes: snapshot.totalBytes
             )
-            if safety != .safe {
+            // Only ``.unsafe`` (>= 85%, the panic line) blocks. ``.tight``
+            // is defined as "will load but risks swap / stalls" — holding
+            // it behind a modal would fire on ordinary loads (13 GiB used
+            // on a 32 GiB Mac + an 11.8 GiB model projects to 77.5%) and
+            // train the user to click through the one prompt that matters.
+            // Every mature local-model app draws the same line: refuse
+            // only what is genuinely dangerous, and surface "tight"
+            // passively — the picker's static sizing bands already do.
+            if safety == .unsafe {
                 pendingMemoryWarning = ModelSizing.MemoryWarning(
                     alias: trimmedAlias,
                     hfPath: hfPath,
@@ -789,6 +857,7 @@ final class ServerManager {
                     footprintGB: footprint.totalGB,
                     freeGB: Double(snapshot.freeBytes) / Double(1 << 30)
                 )
+                memoryLoadConfirmed = false
                 return
             }
         }

--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -187,7 +187,7 @@ struct ContentView: View {
                 server.cancelPendingMemoryLoad()
             }
             Button(warning.confirmTitle, role: .destructive) {
-                Task { await server.confirmPendingMemoryLoad(warning) }
+                server.confirmPendingMemoryLoad(warning)
             }
         } message: { warning in
             Text(warning.message)

--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -178,7 +178,17 @@ struct ContentView: View {
             server.pendingMemoryWarning?.title ?? "",
             isPresented: Binding(
                 get: { server.pendingMemoryWarning != nil },
-                set: { if !$0 { server.cancelPendingMemoryLoad() } }
+                // SwiftUI writes `false` here AFTER a button action runs.
+                // Both buttons already resolved the decision and cleared
+                // `pendingMemoryWarning`, so an unconditional cancel would
+                // immediately undo a "Load anyway" the user just picked.
+                // Only treat this as a dismissal when nothing resolved it
+                // (Esc, click-outside).
+                set: {
+                    if !$0, server.pendingMemoryWarning != nil {
+                        server.cancelPendingMemoryLoad()
+                    }
+                }
             ),
             presenting: server.pendingMemoryWarning
         ) { warning in

--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -174,6 +174,24 @@ struct ContentView: View {
                 )
             )
         }
+        .alert(
+            server.pendingMemoryWarning?.title ?? "",
+            isPresented: Binding(
+                get: { server.pendingMemoryWarning != nil },
+                set: { if !$0 { server.cancelPendingMemoryLoad() } }
+            ),
+            presenting: server.pendingMemoryWarning
+        ) { warning in
+            Button("Cancel", role: .cancel) {
+                if let running = runningAlias { alias = running }
+                server.cancelPendingMemoryLoad()
+            }
+            Button(warning.confirmTitle, role: .destructive) {
+                Task { await server.confirmPendingMemoryLoad(warning) }
+            }
+        } message: { warning in
+            Text(warning.message)
+        }
         .sheet(isPresented: firstRunSheetPresented) {
             firstRunSheet
         }

--- a/apps/rapid-mac/Tests/RapidTests/ModelSizingTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ModelSizingTests.swift
@@ -160,6 +160,46 @@ struct ModelSizingTests {
         #expect(ModelSizing.lineageScore("llama-3.3-8b") > ModelSizing.lineageScore("llama-3.1-8b"))
     }
 
+    // MARK: - Live memory safety (pre-load guard)
+
+    @Test("memorySafety: a model that fits TOTAL but not FREE is unsafe")
+    func liveGuardCatchesLowFreeMemory() {
+        let g = ModelSizing.estimate(alias: "gemma-4-12b") // ~11.8 GB
+        let gib: UInt64 = 1 << 30
+        // 64 GB Mac with 50 GB already used → ~14 GB free; projected ~96%
+        // → unsafe. This is the reported near-crash: static classify says
+        // "fits a 64 GB Mac", but live free RAM can't take it.
+        #expect(ModelSizing.memorySafety(footprint: g, usedBytes: 50 * gib, totalBytes: 64 * gib) == .unsafe)
+        // Same Mac idle → comfortable.
+        #expect(ModelSizing.memorySafety(footprint: g, usedBytes: 10 * gib, totalBytes: 64 * gib) == .safe)
+        // 32 GB Mac, 14 GB used → ~80% projected → tight (warn, allow).
+        #expect(ModelSizing.memorySafety(footprint: g, usedBytes: 14 * gib, totalBytes: 32 * gib) == .tight)
+    }
+
+    @Test("memorySafety: fails open on unknown params or unreadable probe")
+    func liveGuardFailsOpen() {
+        let gib: UInt64 = 1 << 30
+        // Custom alias with no parseable param count → never block.
+        let unknown = ModelSizing.estimate(alias: "some-private-checkpoint")
+        #expect(unknown.paramsBillions == nil)
+        #expect(ModelSizing.memorySafety(footprint: unknown, usedBytes: 60 * gib, totalBytes: 64 * gib) == .safe)
+        // Probe failure (total 0) → safe, so a broken syscall never blocks a load.
+        let g = ModelSizing.estimate(alias: "gemma-4-12b")
+        #expect(ModelSizing.memorySafety(footprint: g, usedBytes: 0, totalBytes: 0) == .safe)
+    }
+
+    @Test("MemoryWarning copy names the model, the GB need, and the free GB")
+    func memoryWarningCopy() {
+        let w = ModelSizing.MemoryWarning(
+            alias: "gemma-4-12b", hfPath: nil, isAutoRespawn: false,
+            severity: .unsafe, footprintGB: 11.8, freeGB: 6.0
+        )
+        #expect(w.title.contains("gemma-4-12b"))
+        #expect(w.message.contains("12")) // rounded need
+        #expect(w.message.contains("6"))  // rounded free
+        #expect(w.confirmTitle.localizedCaseInsensitiveContains("anyway"))
+    }
+
     // MARK: - Helpers
 
     private func mockMac(ramGB: Int) -> MacHardware {

--- a/apps/rapid-mac/Tests/RapidTests/ModelSizingTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ModelSizingTests.swift
@@ -176,6 +176,20 @@ struct ModelSizingTests {
         #expect(ModelSizing.memorySafety(footprint: g, usedBytes: 14 * gib, totalBytes: 32 * gib) == .tight)
     }
 
+    @Test("memorySafety: only >=85% blocks — the 75-85% band still loads")
+    func liveGuardBlocksOnlyAtDangerLine() {
+        let g = ModelSizing.estimate(alias: "gemma-4-12b") // ~11.8 GB
+        let gib: UInt64 = 1 << 30
+        // ServerManager holds a load for confirmation on `.unsafe` ONLY.
+        // 13 GiB used on a 32 GiB Mac projects to ~77.5%: a routine load
+        // on a mid-size Mac. It must classify `.tight`, not `.unsafe` —
+        // prompting here would fire on ordinary loads and train the user
+        // to click through the one prompt that actually matters.
+        #expect(ModelSizing.memorySafety(footprint: g, usedBytes: 13 * gib, totalBytes: 32 * gib) == .tight)
+        // Just over the 85% panic line on the same Mac → blocked.
+        #expect(ModelSizing.memorySafety(footprint: g, usedBytes: 16 * gib, totalBytes: 32 * gib) == .unsafe)
+    }
+
     @Test("memorySafety: fails open on unknown params or unreadable probe")
     func liveGuardFailsOpen() {
         let gib: UInt64 = 1 << 30


### PR DESCRIPTION
## Why (P0 safety — dogfood of 0.12.1)
Loading a model — via chat **or** the "Speed on this Mac" benchmark — nearly froze/kernel-panicked a real Mac **twice** during dogfood. The existing `ModelSizing.classify` gates against a **static 80%-of-total-RAM** estimate, so a model that "fits the Mac" still OOMs once other apps (or a resident model) have eaten the *free* RAM. Per #324, unified memory past ~85% can trip the firmware async-abort path and panic the whole machine, not just raise a userspace OOM.

## What
A **live** pre-load guard, applied at the single choke point:
- **`ModelSizing.memorySafety(footprint, usedBytes, totalBytes)`** — projects the model footprint onto **live** used memory (`MemoryProbe.snapshot()`): `.safe` (<75%) · `.tight` (75–85%) · `.unsafe` (≥85%, the #324 danger line). Fails **open** (`.safe`) on unknown params / unreadable probe — never blocks on missing data.
- **`ServerManager.start`** gains `bypassMemoryGuard`. On a non-safe verdict it sets observable `pendingMemoryWarning` and returns **without spawning**. Every manual start path (picker, first-message, quickstart, switch) funnels through here, so the check + prompt live once. **Auto-respawn is exempt** so the watchdog can't deadloop.
- **ContentView** presents a blocking confirm alert — *Cancel* / *Load anyway*. Confirm takes the warning **by value** to avoid the alert-dismiss clearing state before the async re-enter.
- **`BenchmarkRunner.run`** runs the same pre-check. Because `usedBytes` already includes the resident copy, `used + footprint` catches the benchmark's **2× model load** (a key amplifier of the near-crash).

## Verification
- `swift build` clean.
- Pure-logic threshold check (standalone) — **all pass**, including the reported scenario (gemma4-12b fits 64 GB total but with 50 GB used → **unsafe**), the 2× bench case (→ warn), and small models (→ safe). Footprint math ≈ 11.8 GB for gemma4-12b-4bit.
- Added `ModelSizingTests` cases for `memorySafety` (fits-total-not-free, fail-open, warning copy). *(Test target is excluded from the manifest — kept in sync for the v1.0 suite; build is the gate.)*

## codex
Round-1 review found + **fixed here**: 🚫 BLOCKING auto-respawn deadloop (guard now manual-only), ⚠️ MAJOR danger line 90%→85%, MINOR "kernel-panic" jargon dropped from user copy. (Kept the bench guard strict — the 2× load it blocks is exactly the near-crash.) **Round-2 confirmation deferred** — the local codex backend (:8000) is in use by the maintainer; re-run before merge.

## Release
**Do not auto-merge / auto-release** — this is one of several 0.12.1 dogfood fixes; the maintainer will batch + cut. First of the 5 reported issues (the P0). Follow-ups: bench submit re-run (#4), progress/ETA (#1), leaderboard machine codename (#3).