### PR TITLE
fix(rapid-mac): live progress + ETA for "Speed on this Mac" bench and submit

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Server/BenchmarkRunner.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/BenchmarkRunner.swift
@@ -12,6 +12,15 @@ import Foundation
 ///     rapidmlx.com/api/benchmarks). The CLI asks for a y/N consent on
 ///     stdin; the app shows its OWN consent first, then pipes "y" so the
 ///     user only answers once.
+///
+/// Both paths are multi-minute for a large model — a cold model load
+/// plus (for submit) a full standardized short+long workload. The CLI
+/// emits little incremental output, so a plain spinner reads as "hung".
+/// We stream the child's stdout to advance a coarse stage label, run a
+/// one-second ticker for a live elapsed clock, and show a size-derived
+/// ETA so the user knows roughly how long to wait. The elapsed clock is
+/// the source of truth; the ETA is an estimate that gracefully degrades
+/// to "almost there…" once a slow Mac blows past it.
 @MainActor
 @Observable
 final class BenchmarkRunner {
@@ -29,30 +38,200 @@ final class BenchmarkRunner {
         case failed(String)
     }
 
+    /// Live progress for the running/submitting states: a coarse stage,
+    /// an elapsed clock, and a rough ETA. Drives the progress bar +
+    /// caption so a multi-minute bench never looks frozen.
+    struct Progress: Equatable, Sendable {
+        enum Kind: Equatable, Sendable { case benchmark, submit }
+
+        /// Coarse, monotonically-advancing stage inferred from the
+        /// child's stdout. We only ever move forward so a late stray
+        /// line can't rewind the label.
+        enum Stage: Int, Equatable, Sendable, Comparable {
+            case starting = 0
+            case loading = 1
+            case measuring = 2
+            case uploading = 3
+
+            static func < (lhs: Stage, rhs: Stage) -> Bool {
+                lhs.rawValue < rhs.rawValue
+            }
+
+            func label(for kind: Kind) -> String {
+                switch self {
+                case .starting: return "Starting…"
+                case .loading: return "Loading the model…"
+                case .measuring: return "Measuring throughput…"
+                case .uploading: return "Publishing to the leaderboard…"
+                }
+            }
+        }
+
+        var kind: Kind
+        var stage: Stage = .starting
+        var elapsedSeconds: Int = 0
+        /// Rough total-duration estimate in seconds; ``nil`` when the
+        /// alias carries no parseable size (custom model) → the UI falls
+        /// back to an indeterminate bar + bare elapsed clock.
+        var etaSeconds: Int?
+
+        /// Advance the stage from one streamed stdout line. Best-effort:
+        /// the freeform bench prints "Loading model …" then the Results
+        /// block; the standardized submit runner adds an upload phase.
+        mutating func observe(_ line: String) {
+            let l = line.lowercased()
+            let next: Stage?
+            if l.contains("uploading") || l.contains("submitting")
+                || l.contains("leaderboard") || l.contains("on the board")
+                || l.contains("posting") {
+                next = .uploading
+            } else if l.contains("running benchmark") || l.contains("throughput")
+                || l.contains("tokens/second") || l.contains("results")
+                || l.contains("long prompt") || l.contains("round")
+                || l.contains("warm") {
+                // "Running benchmark with N prompts …" is the freeform CLI's
+                // marker that the measured generation has begun — it prints
+                // right before the (silent) decode, so it's what actually
+                // flips the card off "Loading…" during measurement. The
+                // later "Results:/Throughput" lines only arrive once decode
+                // is already done.
+                next = .measuring
+            } else if l.contains("loading model") || l.contains("loading the model") {
+                next = .loading
+            } else {
+                next = nil
+            }
+            if let next, next > stage { stage = next }
+        }
+
+        var stageLabel: String { stage.label(for: kind) }
+
+        /// `m:ss` elapsed clock.
+        var elapsedClock: String {
+            String(format: "%d:%02d", elapsedSeconds / 60, elapsedSeconds % 60)
+        }
+
+        /// Determinate-bar fraction, capped below 1.0 so the bar never
+        /// claims "done" before the process actually exits. ``nil`` when
+        /// we have no ETA → the UI shows an indeterminate bar.
+        var fraction: Double? {
+            guard let eta = etaSeconds, eta > 0 else { return nil }
+            return min(0.95, Double(elapsedSeconds) / Double(eta))
+        }
+
+        /// One-line caption under the bar. Answers "how many minutes?"
+        /// up front, then reassures rather than lying once we pass the
+        /// estimate.
+        var caption: String {
+            guard let eta = etaSeconds else { return "Elapsed \(elapsedClock)" }
+            if elapsedSeconds >= eta - 5 {
+                return "Elapsed \(elapsedClock) · almost there…"
+            }
+            let remaining = eta - elapsedSeconds
+            let mins = max(1, Int((Double(remaining) / 60.0).rounded(.up)))
+            return "Elapsed \(elapsedClock) · about \(mins) min left"
+        }
+    }
+
     private(set) var phase: Phase = .idle
     private(set) var submitPhase: SubmitPhase = .idle
+    /// Non-nil only while a bench or submit is in flight.
+    private(set) var progress: Progress?
+
+    private var ticker: Task<Void, Never>?
+    /// The in-flight run/submit. Owned here (not by the view's button) so
+    /// closing the sheet or starting another run can cancel it — which
+    /// terminates the underlying `rapid-mlx bench` child so a closed card
+    /// can't leave a GPU-bound benchmark running or overlap two runs.
+    private var inFlight: Task<Void, Never>?
 
     /// Public leaderboard the submission lands on.
     static let boardURL = URL(string: "https://rapidmlx.com/leaderboard")!
 
     /// DEV-ONLY: force a phase so the snapshot harness can render the
     /// result / submitted states without a live sidecar.
-    func devSeed(phase: Phase, submit: SubmitPhase = .idle) {
+    func devSeed(phase: Phase, submit: SubmitPhase = .idle, progress: Progress? = nil) {
         self.phase = phase
         self.submitPhase = submit
+        self.progress = progress
+    }
+
+    // MARK: - Lifecycle / cancellation
+
+    /// Start a benchmark, owning the task so the view can cancel it.
+    /// Supersedes any in-flight run (which terminates its child process).
+    /// The generation is allocated *synchronously here* (not inside the
+    /// task body): a task cancelled before it starts still runs its body,
+    /// so binding "who is current" at launch time — not execution time —
+    /// is what lets the stale task's top guard reject it before it mutates
+    /// any state (codex round-3 MAJOR).
+    func launchRun(binary: URL, alias: String, chip: String) {
+        inFlight?.cancel()
+        // Clear a superseded submit's transient phase so it can't linger
+        // as a stale "Submitting…" behind the new run (UI-gated today, but
+        // keeps the "one transient phase at a time" invariant honest).
+        if submitPhase == .submitting { submitPhase = .idle }
+        runGeneration &+= 1
+        let gen = runGeneration
+        inFlight = Task { [weak self] in
+            await self?.run(binary: binary, alias: alias, chip: chip, generation: gen)
+        }
+    }
+
+    /// Start a community-leaderboard submit, owned the same way.
+    func launchSubmit(binary: URL, alias: String) {
+        inFlight?.cancel()
+        if phase == .running { phase = .idle }
+        runGeneration &+= 1
+        let gen = runGeneration
+        inFlight = Task { [weak self] in
+            await self?.submit(binary: binary, alias: alias, generation: gen)
+        }
+    }
+
+    /// Cancel the in-flight run/submit — terminates the `rapid-mlx bench`
+    /// child. Call from the view's `.onDisappear` so a closed card never
+    /// leaves a benchmark burning the GPU in the background. Bumping the
+    /// generation also neutralizes any task that hasn't run its top guard
+    /// yet.
+    func cancelActive() {
+        inFlight?.cancel()
+        inFlight = nil
+        // Bumping the generation neutralizes a not-yet-started task, but
+        // that also makes the cancelled run's deferred endProgress(gen)
+        // no-op — so tear the progress/ticker down here directly rather
+        // than leave a frozen bar behind if this runner is reused. Reset
+        // only the transient in-flight phases; a completed .done result
+        // (with a pending submit) is preserved.
+        runGeneration &+= 1
+        ticker?.cancel()
+        ticker = nil
+        progress = nil
+        if phase == .running { phase = .idle }
+        if submitPhase == .submitting { submitPhase = .idle }
     }
 
     // MARK: - Benchmark (display)
 
-    func run(binary: URL, alias: String, chip: String) async {
+    func run(binary: URL, alias: String, chip: String, generation gen: UInt64) async {
+        // Superseded/cancelled before we even started, or another run has
+        // already advanced past us: do nothing, touch no state.
+        guard !Task.isCancelled, runGeneration == gen else { return }
         guard !alias.isEmpty else {
             phase = .failed("Choose a model first.")
             return
         }
         phase = .running
-        let output = await Self.runProcess(
-            binary: binary, args: ["bench", alias], stdinLine: nil
-        )
+        beginProgress(gen, kind: .benchmark, alias: alias)
+        defer { endProgress(gen) }
+
+        let output = await runStreaming(
+            binary: binary, args: ["bench", alias], stdinLine: nil, generation: gen)
+        // Cancelled (sheet closed) or superseded (another run bumped the
+        // generation): the child was terminated and the output is a
+        // spurious failure — leave the UI state untouched rather than
+        // flashing an error on a dead card or clobbering the newer run.
+        guard !Task.isCancelled, runGeneration == gen else { return }
         switch output {
         case .failure(let msg):
             phase = .failed(msg)
@@ -77,17 +256,22 @@ final class BenchmarkRunner {
 
     // MARK: - Submit (community leaderboard)
 
-    func submit(binary: URL, alias: String) async {
+    func submit(binary: URL, alias: String, generation gen: UInt64) async {
+        guard !Task.isCancelled, runGeneration == gen else { return }
         guard !alias.isEmpty else {
             submitPhase = .failed("Choose a model first.")
             return
         }
         submitPhase = .submitting
+        beginProgress(gen, kind: .submit, alias: alias)
+        defer { endProgress(gen) }
+
         // The CLI prints the exact payload and asks "submit? [y/N]" on
         // stdin. The app already showed its own consent, so answer "y".
-        let output = await Self.runProcess(
-            binary: binary, args: ["bench", alias, "--submit"], stdinLine: "y\n"
-        )
+        // (The runner treats a single "y" — or even EOF — as consent.)
+        let output = await runStreaming(
+            binary: binary, args: ["bench", alias, "--submit"], stdinLine: "y\n", generation: gen)
+        guard !Task.isCancelled, runGeneration == gen else { return }
         switch output {
         case .failure(let msg):
             submitPhase = .failed(msg)
@@ -106,6 +290,62 @@ final class BenchmarkRunner {
                 submitPhase = .submitted
             }
         }
+    }
+
+    // MARK: - Progress lifecycle
+
+    /// Monotonic id for the current run. `@MainActor` jobs are reentrant
+    /// and not FIFO, so when a new run supersedes an old one the old task
+    /// can resume *after* the new one has already installed its progress.
+    /// Every progress mutation and teardown is gated on this token so a
+    /// superseded run can only ever touch its own state — never the
+    /// replacement's ticker/progress (codex round-2 MAJOR).
+    private var runGeneration: UInt64 = 0
+
+    /// Begin a run for the (already-allocated) generation `gen`: seed
+    /// progress and start the one-second elapsed ticker. The generation is
+    /// minted synchronously in ``launchRun``/``launchSubmit`` so it binds
+    /// "who is current" at launch, not here.
+    private func beginProgress(_ gen: UInt64, kind: Progress.Kind, alias: String) {
+        progress = Progress(kind: kind, etaSeconds: Self.etaSeconds(alias: alias, kind: kind))
+        ticker?.cancel()
+        // A `Task` created in a @MainActor method inherits the main
+        // actor, so the mutation below is main-actor-isolated. The
+        // generation guard stops a superseded run's ticker.
+        ticker = Task { [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: 1_000_000_000)
+                guard let self, !Task.isCancelled, self.runGeneration == gen else { return }
+                self.progress?.elapsedSeconds += 1
+            }
+        }
+    }
+
+    /// Tear down progress — but only if this run is still the current
+    /// one. A superseded run's `defer` must not clobber its replacement's
+    /// ticker/progress.
+    private func endProgress(_ gen: UInt64) {
+        guard runGeneration == gen else { return }
+        ticker?.cancel()
+        ticker = nil
+        progress = nil
+    }
+
+    /// Coarse total-duration estimate. Load time is dominated by the
+    /// weight bytes (disk read + Metal upload) and generation is a fixed
+    /// token budget, so both scale roughly with parameter count. These
+    /// constants are a UX ballpark calibrated against the bundled models
+    /// on Apple Silicon (~4B ≈ 1 min, ~12B ≈ 2 min, ~30B ≈ 4–5 min); the
+    /// live elapsed clock, not this number, is the source of truth. The
+    /// submit path re-runs the full standardized short+long workload, so
+    /// it takes ~1.6× the freeform pass. Returns ``nil`` for a custom
+    /// alias with no parseable size.
+    nonisolated static func etaSeconds(alias: String, kind: Progress.Kind) -> Int? {
+        let footprint = ModelSizing.estimate(alias: alias)
+        guard let params = footprint.paramsBillions else { return nil }
+        let base = 20.0 + params * 8.0
+        let mult = kind == .submit ? 1.6 : 1.0
+        return Int((base * mult).rounded())
     }
 
     // MARK: - Parsing
@@ -144,18 +384,79 @@ final class BenchmarkRunner {
 
     // MARK: - Subprocess
 
-    private enum RunOutput {
+    enum RunOutput: Sendable {
         case success(String)
         case failure(String)
     }
 
+    /// Thread-safe holder for the running child so a cancellation on the
+    /// consuming task (sheet closed / superseded run) can `terminate()` it
+    /// from a different thread than the worker that spawned it.
+    private final class ProcessHandle: @unchecked Sendable {
+        private let lock = NSLock()
+        private var process: Process?
+        private var terminated = false
+
+        /// Adopt the spawned process. If a cancel already arrived before
+        /// the process was recorded, terminate it immediately.
+        func adopt(_ p: Process) {
+            lock.lock()
+            let killNow = terminated
+            process = p
+            lock.unlock()
+            if killNow, p.isRunning { p.terminate() }
+        }
+
+        func terminate() {
+            lock.lock()
+            terminated = true
+            let p = process
+            lock.unlock()
+            if let p, p.isRunning { p.terminate() }
+        }
+    }
+
     /// Runs `binary args…`, optionally writing one line to stdin, and
-    /// returns combined stdout+stderr text. Off the main actor.
-    private nonisolated static func runProcess(
-        binary: URL, args: [String], stdinLine: String?
-    ) async -> RunOutput {
-        await withCheckedContinuation { continuation in
-            DispatchQueue.global(qos: .userInitiated).async {
+    /// returns combined stdout+stderr text — streaming stdout lines
+    /// through ``Progress/observe(_:)`` so the stage label advances
+    /// live. Reads run off the main actor; each observed line hops back
+    /// to advance ``progress``. On task cancellation the child is
+    /// terminated (closing its stdout ends the stream promptly).
+    private func runStreaming(binary: URL, args: [String], stdinLine: String?, generation gen: UInt64) async -> RunOutput {
+        let handle = ProcessHandle()
+        return await withTaskCancellationHandler {
+            for await event in Self.stream(handle: handle, binary: binary, args: args, stdinLine: stdinLine) {
+                switch event {
+                case .line(let line):
+                    // Only advance the stage if this is still the current
+                    // run — a superseded run's stale lines must not mutate
+                    // the replacement's progress.
+                    if runGeneration == gen { progress?.observe(line) }
+                case .finished(let output):
+                    return output
+                }
+            }
+            // Stream ended without a terminal event (should not happen).
+            return .failure("The benchmark stopped unexpectedly.")
+        } onCancel: {
+            handle.terminate()
+        }
+    }
+
+    private enum StreamEvent: Sendable {
+        case line(String)
+        case finished(RunOutput)
+    }
+
+    /// Spawn `binary args…` and surface each stdout line as it arrives,
+    /// then a single terminal ``.finished``. stderr is drained
+    /// concurrently so its pipe buffer can't stall the child. The spawned
+    /// process is handed to ``handle`` so a cancel can terminate it.
+    private nonisolated static func stream(
+        handle: ProcessHandle, binary: URL, args: [String], stdinLine: String?
+    ) -> AsyncStream<StreamEvent> {
+        AsyncStream { continuation in
+            let worker = Task.detached(priority: .userInitiated) {
                 let task = Process()
                 task.executableURL = binary
                 task.arguments = args
@@ -169,32 +470,60 @@ final class BenchmarkRunner {
                 do {
                     try task.run()
                 } catch {
-                    continuation.resume(returning: .failure(
-                        "Couldn't start the benchmark: \(error.localizedDescription)"))
+                    continuation.yield(.finished(.failure(
+                        "Couldn't start the benchmark: \(error.localizedDescription)")))
+                    continuation.finish()
                     return
                 }
+                // Hand the live process to the shared handle so a cancel
+                // (onCancel / onTermination) can terminate it. If a cancel
+                // already landed, adopt() kills it right away.
+                handle.adopt(task)
                 if let line = stdinLine {
                     inPipe.fileHandleForWriting.write(Data(line.utf8))
                     try? inPipe.fileHandleForWriting.close()
                 }
-                // Read fully before waitUntilExit to avoid a pipe-buffer
-                // deadlock on a chatty child.
-                let outData = out.fileHandleForReading.readDataToEndOfFile()
-                let errData = err.fileHandleForReading.readDataToEndOfFile()
+
+                // Drain stderr concurrently — the child writes framework
+                // warnings there and a full pipe would block generation.
+                let errHandle = err.fileHandleForReading
+                let errTask = Task.detached { errHandle.readDataToEndOfFile() }
+
+                var stdoutAccum = ""
+                do {
+                    for try await line in out.fileHandleForReading.bytes.lines {
+                        stdoutAccum += line + "\n"
+                        continuation.yield(.line(line))
+                    }
+                } catch {
+                    // Read interrupted (e.g. process killed); fall through
+                    // to report the exit status.
+                }
+                // If we were cancelled, make sure the child is dead so the
+                // waitUntilExit below returns instead of blocking forever.
+                if Task.isCancelled { handle.terminate() }
                 task.waitUntilExit()
-                let combined = (String(data: outData, encoding: .utf8) ?? "")
-                    + "\n"
-                    + (String(data: errData, encoding: .utf8) ?? "")
+                let errText = String(data: await errTask.value, encoding: .utf8) ?? ""
+                let combined = stdoutAccum + "\n" + errText
                 if task.terminationStatus == 0 {
-                    continuation.resume(returning: .success(combined))
+                    continuation.yield(.finished(.success(combined)))
                 } else {
                     let tail = combined
                         .split(separator: "\n")
                         .suffix(4)
                         .joined(separator: " ")
-                    continuation.resume(returning: .failure(
-                        tail.isEmpty ? "Benchmark exited with code \(task.terminationStatus)." : tail))
+                    continuation.yield(.finished(.failure(
+                        tail.isEmpty
+                            ? "Benchmark exited with code \(task.terminationStatus)."
+                            : tail)))
                 }
+                continuation.finish()
+            }
+            // Consumer stopped iterating (normal finish OR cancel): kill the
+            // child and stop the worker so it can't outlive the stream.
+            continuation.onTermination = { _ in
+                handle.terminate()
+                worker.cancel()
             }
         }
     }

--- a/apps/rapid-mac/Sources/Rapid/Server/BenchmarkRunner.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/BenchmarkRunner.swift
@@ -480,7 +480,15 @@ final class BenchmarkRunner {
                 // already landed, adopt() kills it right away.
                 handle.adopt(task)
                 if let line = stdinLine {
-                    inPipe.fileHandleForWriting.write(Data(line.utf8))
+                    // `FileHandle.write(_:)` raises an ObjC exception on EPIPE,
+                    // which Swift cannot catch — it terminates the app. That is
+                    // reachable here: `adopt` above kills the child immediately
+                    // if a cancel already landed (Publish, then close the card),
+                    // so stdin can be gone before this write. The throwing
+                    // `write(contentsOf:)` surfaces the same condition as a
+                    // Swift error we can ignore — a child that is no longer
+                    // there does not need its "y".
+                    try? inPipe.fileHandleForWriting.write(contentsOf: Data(line.utf8))
                     try? inPipe.fileHandleForWriting.close()
                 }
 

--- a/apps/rapid-mac/Sources/Rapid/UI/BenchmarkView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/BenchmarkView.swift
@@ -39,6 +39,9 @@ struct BenchmarkView: View {
         }
         .frame(width: 440, height: 480)
         .background(RapidTheme.canvas)
+        // Closing the card cancels any in-flight bench/submit so it can't
+        // keep burning the GPU in the background after the sheet is gone.
+        .onDisappear { runner.cancelActive() }
     }
 
     private var header: some View {
@@ -86,7 +89,7 @@ struct BenchmarkView: View {
                 .multilineTextAlignment(.center)
                 .fixedSize(horizontal: false, vertical: true)
             Button {
-                Task { await runner.run(binary: binary ?? URL(fileURLWithPath: "/"), alias: alias, chip: hardware.brandString) }
+                runner.launchRun(binary: binary ?? URL(fileURLWithPath: "/"), alias: alias, chip: hardware.brandString)
             } label: {
                 Label("Benchmark this Mac", systemImage: "play.fill")
                     .frame(maxWidth: .infinity)
@@ -100,14 +103,53 @@ struct BenchmarkView: View {
     }
 
     private var runningState: some View {
-        VStack(spacing: 14) {
-            ProgressView().controlSize(.large).padding(.top, 40)
-            Text("Benchmarking \(displayAlias)…")
-                .font(.callout.weight(.medium))
-            Text("Running a standardized short + long workload. This takes a moment.")
-                .font(.footnote)
-                .foregroundStyle(.secondary)
-                .multilineTextAlignment(.center)
+        VStack(spacing: 16) {
+            Image(systemName: "gauge.with.dots.needle.67percent")
+                .font(.system(size: 34))
+                .foregroundStyle(RapidTheme.brandAmber)
+                .padding(.top, 28)
+            Text("Benchmarking \(displayAlias)")
+                .font(.callout.weight(.semibold))
+            benchProgress(
+                runner.progress,
+                fallback: "Running a standardized short + long workload.")
+                .padding(.horizontal, 8)
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    /// Live progress used by both the freeform benchmark and the submit
+    /// re-bench: a determinate bar toward the ETA (indeterminate when the
+    /// model size is unknown), the current stage, and an elapsed + ETA
+    /// caption so a multi-minute run never reads as frozen.
+    @ViewBuilder
+    private func benchProgress(_ progress: BenchmarkRunner.Progress?, fallback: String) -> some View {
+        VStack(spacing: 10) {
+            if let p = progress {
+                Group {
+                    if let fraction = p.fraction {
+                        ProgressView(value: fraction)
+                    } else {
+                        ProgressView()
+                    }
+                }
+                .progressViewStyle(.linear)
+                .tint(RapidTheme.amber)
+                Text(p.stageLabel)
+                    .font(.callout.weight(.medium))
+                Text(p.caption)
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                    .monospacedDigit()
+            } else {
+                ProgressView()
+                    .progressViewStyle(.linear)
+                    .tint(RapidTheme.amber)
+                Text(fallback)
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+            }
         }
         .frame(maxWidth: .infinity)
     }
@@ -153,7 +195,7 @@ struct BenchmarkView: View {
                 .buttonStyle(.borderedProminent)
                 .tint(RapidTheme.brand)
                 Button("Run again") {
-                    Task { await runner.run(binary: binary ?? URL(fileURLWithPath: "/"), alias: alias, chip: hardware.brandString) }
+                    runner.launchRun(binary: binary ?? URL(fileURLWithPath: "/"), alias: alias, chip: hardware.brandString)
                 }
                 .buttonStyle(.plain)
                 .font(.callout)
@@ -163,10 +205,8 @@ struct BenchmarkView: View {
                 consentSheet(result)
             }
         case .submitting:
-            HStack(spacing: 8) {
-                ProgressView().controlSize(.small)
-                Text("Submitting…").font(.callout).foregroundStyle(.secondary)
-            }
+            benchProgress(runner.progress, fallback: "Submitting…")
+                .padding(.top, 4)
         case .submitted:
             VStack(spacing: 8) {
                 Label("On the board", systemImage: "checkmark.seal.fill")
@@ -206,7 +246,7 @@ struct BenchmarkView: View {
                 Spacer()
                 Button("Publish") {
                     showSubmitConsent = false
-                    Task { await runner.submit(binary: binary ?? URL(fileURLWithPath: "/"), alias: alias) }
+                    runner.launchSubmit(binary: binary ?? URL(fileURLWithPath: "/"), alias: alias)
                 }
                 .buttonStyle(.borderedProminent)
                 .tint(RapidTheme.brand)
@@ -240,13 +280,11 @@ struct BenchmarkView: View {
                 .fixedSize(horizontal: false, vertical: true)
 
             Button("Try again") {
-                Task {
-                    await runner.run(
-                        binary: binary ?? URL(fileURLWithPath: "/"),
-                        alias: alias,
-                        chip: hardware.brandString
-                    )
-                }
+                runner.launchRun(
+                    binary: binary ?? URL(fileURLWithPath: "/"),
+                    alias: alias,
+                    chip: hardware.brandString
+                )
             }
             .buttonStyle(.rapidSecondary)
 

--- a/apps/rapid-mac/Tests/RapidTests/BenchmarkProgressTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/BenchmarkProgressTests.swift
@@ -1,0 +1,113 @@
+import Foundation
+import Testing
+@testable import Rapid
+
+/// Contract for the live-progress model behind "Speed on this Mac" —
+/// the fix for the two dogfood reports: a freeform bench with no
+/// progress/ETA (#1) and a Submit button that "loads forever" while the
+/// standardized re-bench runs silently (#4).
+@Suite("BenchmarkRunner.Progress — live stage + ETA")
+struct BenchmarkProgressTests {
+    typealias Progress = BenchmarkRunner.Progress
+
+    // MARK: - Stage inference from streamed stdout
+
+    @Test("Advances loading → measuring → uploading as lines stream in")
+    func stageAdvances() {
+        var p = Progress(kind: .submit)
+        #expect(p.stage == .starting)
+        p.observe("Loading model qwen3.5-4b (mlx-community/…)…")
+        #expect(p.stage == .loading)
+        p.observe("  Long prompt target: ~2048 tokens")
+        #expect(p.stage == .measuring)
+        p.observe("Throughput: 120.4 tok/s")
+        #expect(p.stage == .measuring)
+        p.observe("Uploading to the leaderboard…")
+        #expect(p.stage == .uploading)
+    }
+
+    @Test("Stage only moves forward — a late stray line can't rewind it")
+    func stageMonotonic() {
+        var p = Progress(kind: .benchmark)
+        p.observe("Uploading…")
+        #expect(p.stage == .uploading)
+        // A trailing framework log mentioning "loading" must not drag the
+        // label back to an earlier phase.
+        p.observe("loading model weights cache warm")
+        #expect(p.stage == .uploading)
+    }
+
+    @Test("The freeform CLI's 'Running benchmark with …' line flips off Loading")
+    func measuringMarkerIsTheRealProgressLine() {
+        // The freeform bench prints "Running benchmark with N prompts …"
+        // right before the (silent) decode; the Results/Throughput lines
+        // only land after decode. Without this the card is stuck on
+        // "Loading…" for the whole measurement (codex MINOR).
+        var p = Progress(kind: .benchmark)
+        p.observe("Loading model: qwen3.5-4b")
+        #expect(p.stage == .loading)
+        p.observe("Running benchmark with 3 prompts, max_tokens=256")
+        #expect(p.stage == .measuring)
+    }
+
+    @Test("Unrecognised lines leave the stage untouched")
+    func stageIgnoresNoise() {
+        var p = Progress(kind: .benchmark)
+        p.observe("Loading model foo")
+        p.observe("some unrelated framework chatter")
+        #expect(p.stage == .loading)
+    }
+
+    // MARK: - ETA estimate
+
+    @Test("ETA scales with model size and is larger for submit")
+    func etaScalesWithSize() {
+        let small = BenchmarkRunner.etaSeconds(alias: "qwen3.5-4b", kind: .benchmark)
+        let big = BenchmarkRunner.etaSeconds(alias: "qwen3.6-27b-8bit", kind: .benchmark)
+        #expect(small != nil && big != nil)
+        #expect((big ?? 0) > (small ?? 0), "a 27B should take longer than a 4B")
+
+        let free = BenchmarkRunner.etaSeconds(alias: "gemma-4-12b", kind: .benchmark)!
+        let submit = BenchmarkRunner.etaSeconds(alias: "gemma-4-12b", kind: .submit)!
+        #expect(submit > free, "submit re-runs the full standardized workload")
+    }
+
+    @Test("ETA is nil for a custom alias with no parseable size")
+    func etaNilForUnknown() {
+        #expect(BenchmarkRunner.etaSeconds(alias: "my-custom-model", kind: .benchmark) == nil)
+    }
+
+    // MARK: - Caption + bar fraction
+
+    @Test("Caption answers 'how many minutes' up front, then reassures")
+    func captionCountsDownThenReassures() {
+        var p = Progress(kind: .benchmark, etaSeconds: 120)
+        p.elapsedSeconds = 10
+        #expect(p.caption.contains("min left"))
+        #expect(p.caption.contains("0:10"))
+        // Past the estimate we stop lying and switch to reassurance.
+        p.elapsedSeconds = 130
+        #expect(p.caption.contains("almost there"))
+    }
+
+    @Test("Caption falls back to a bare elapsed clock when ETA is unknown")
+    func captionWithoutETA() {
+        var p = Progress(kind: .benchmark, etaSeconds: nil)
+        p.elapsedSeconds = 65
+        #expect(p.caption == "Elapsed 1:05")
+    }
+
+    @Test("Bar fraction tracks elapsed/ETA but never claims 100% early")
+    func fractionCappedBelowOne() {
+        var p = Progress(kind: .benchmark, etaSeconds: 100)
+        p.elapsedSeconds = 50
+        #expect(abs((p.fraction ?? 0) - 0.5) < 0.001)
+        // Even long past the ETA the determinate bar stays < 1.0 so it
+        // can't flash "done" before the process actually exits.
+        p.elapsedSeconds = 1000
+        #expect((p.fraction ?? 0) <= 0.95)
+        // No ETA → no determinate fraction (UI shows an indeterminate bar).
+        let unknown = Progress(kind: .benchmark, etaSeconds: nil)
+        #expect(unknown.fraction == nil)
+    }
+}


### PR DESCRIPTION
## Why

Two dogfood reports on the shipped **0.12.1** "Speed on this Mac" bench card:

- **#1 — no progress / ETA.** The benchmark shows a bare spinner. On a 12B
  model that's a silent multi-minute wait that reads as "hung".
- **#4 — Submit "loads forever".** Submitting re-runs the *full* standardized
  B=1 workload (cold model reload + short/long buckets) — required for a
  comparable leaderboard number, so it's legitimately several minutes — again
  behind a static spinner.

Same root cause: `runProcess` buffered the child's output to EOF and the UI
never surfaced motion. `rapid-mlx bench` emits little incremental output, so a
plain `ProgressView` can't reflect real progress.

## What

Stream the subprocess and drive a live progress model:

- **`BenchmarkRunner.stream()`** — an `AsyncStream` yielding each stdout line as
  it arrives (stderr drained concurrently so its pipe can't stall generation).
- **One-second ticker** keeps an elapsed clock moving even while the child is
  silent mid-generation.
- **`Progress`** carries a coarse monotonic stage (Loading → Measuring →
  Publishing) inferred from streamed lines, plus a size-derived **ETA**
  (params-scaled; submit ~1.6×). Caption answers "about N min left" up front and
  degrades to "almost there…" once a slow Mac passes the estimate. The elapsed
  clock — not the ETA — is the source of truth; the bar is capped <1.0 so it
  never flashes "done" early.
- **`BenchmarkView`** renders the same progress in the running *and* submitting
  states.

## Robustness (codex convergence, gpt-5.6, 5 rounds)

- **Cancellation / orphaned GPU process (R1 MAJOR).** run/submit is owned by the
  runner as `inFlight`, cancelled from the card's `.onDisappear` and when
  superseded; cancellation terminates the `rapid-mlx bench` child via a
  lock-guarded `ProcessHandle` + `withTaskCancellationHandler`. Closing the card
  can't leave a benchmark burning the GPU or overlap two runs.
- **Stage stuck on "Loading…" (R1 MINOR).** The freeform CLI's real measurement
  marker is `Running benchmark with N prompts …`; `observe()` now matches it.
- **Supersession race (R2/R3 MAJOR).** `@MainActor` jobs are reentrant and a
  task cancelled before it starts still runs its body. run/submit is bound to a
  monotonic `runGeneration` token minted **synchronously at launch**; every
  mutation (top guard, post-await guard, ticker, line-observe, teardown) is
  gated on it, so only the current task can touch phase/progress.
- **Frozen cancelled run on reuse (R4 MINOR).** `cancelActive()` tears down the
  ticker/progress directly and resets the transient in-flight phases.

Final codex pass: no remaining BLOCKING/MAJOR.

## Testing

`swift build` clean. `RapidTests` is excluded from the SwiftPM manifest (v1.0
strip), so the pure `Progress` logic is verified by a standalone script (stage
inference incl. the measurement marker, monotonicity, ETA scaling,
caption/fraction — all green); `BenchmarkProgressTests.swift` is kept in sync
for the future suite. Behavioural (live bench) dogfood happens at release-cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
