### PR TITLE
fix(tokenizer): guard against unbundled chat-template/tool-parser modules (#1420)

### DIFF
--- a/tests/test_chat_template_type_guard.py
+++ b/tests/test_chat_template_type_guard.py
@@ -1,0 +1,132 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for issue #1420 — Gemma 4 startup crash on an
+``unbundled`` chat-template module.
+
+``mlx_lm.tokenizer_utils.load`` imports a module by name whenever the
+model's ``tokenizer_config.json`` declares ``chat_template_type`` /
+``tool_parser_type``::
+
+    if chat_template_type := cfg.get("chat_template_type", False):
+        importlib.import_module(f"mlx_lm.chat_templates.{chat_template_type}")
+
+mlx-lm 0.31.x dropped ``mlx_lm/chat_templates/gemma4.py`` while
+``mlx-community/gemma-4-26b-a4b-it-4bit`` still declares
+``"chat_template_type": "gemma4"``, so the import raises
+``ModuleNotFoundError`` and the server dies at startup with no fallback to
+the model's on-disk ``chat_template.jinja``.
+
+``_neutralize_unbundled_template_types`` runs before ``mlx_lm.load`` and
+sets any such field to ``None`` (falsy → mlx-lm's ``:= get(..., False)``
+guard skips the import), letting the model boot from its ``.jinja`` sidecar.
+The guard is package-specific: ``gemma4`` is MISSING as a chat template but
+PRESENT as a tool parser, so it must be neutralized on the former path and
+preserved on the latter.
+"""
+
+import json
+
+from vllm_mlx.utils.tokenizer import (
+    _neutralize_unbundled_template_types,
+    _read_tokenizer_config_json,
+)
+
+
+def _write_cfg(model_dir, **fields):
+    """Write a minimal tokenizer_config.json into ``model_dir``."""
+    cfg = {"tokenizer_class": "PreTrainedTokenizerFast", **fields}
+    (model_dir / "tokenizer_config.json").write_text(json.dumps(cfg))
+    return str(model_dir)
+
+
+def test_missing_chat_template_type_is_neutralized(tmp_path):
+    # gemma4 is NOT bundled under mlx_lm.chat_templates → must be stripped.
+    model = _write_cfg(tmp_path, chat_template_type="gemma4")
+    out = _neutralize_unbundled_template_types(model, {})
+    assert out == {"chat_template_type": None}
+
+
+def test_bundled_chat_template_type_is_preserved(tmp_path):
+    # deepseek_v32 IS bundled under mlx_lm.chat_templates → leave it alone
+    # (returned dict is the untouched input, not a rewritten copy).
+    model = _write_cfg(tmp_path, chat_template_type="deepseek_v32")
+    passed = {}
+    out = _neutralize_unbundled_template_types(model, passed)
+    assert out is passed
+    assert "chat_template_type" not in out
+
+
+def test_guard_is_package_specific(tmp_path):
+    # gemma4 is missing as a chat template but PRESENT as a tool parser:
+    # neutralize the chat-template field, keep the tool-parser field.
+    model = _write_cfg(tmp_path, chat_template_type="gemma4", tool_parser_type="gemma4")
+    out = _neutralize_unbundled_template_types(model, {})
+    assert out == {"chat_template_type": None}
+    assert "tool_parser_type" not in out
+
+
+def test_missing_tool_parser_type_is_neutralized(tmp_path):
+    model = _write_cfg(tmp_path, tool_parser_type="no_such_parser_xyz")
+    out = _neutralize_unbundled_template_types(model, {})
+    assert out == {"tool_parser_type": None}
+
+
+def test_both_missing_fields_neutralized_together(tmp_path):
+    model = _write_cfg(
+        tmp_path, chat_template_type="gemma4", tool_parser_type="no_such_parser_xyz"
+    )
+    out = _neutralize_unbundled_template_types(model, {})
+    assert out == {"chat_template_type": None, "tool_parser_type": None}
+
+
+def test_no_declared_type_returns_input_unchanged(tmp_path):
+    model = _write_cfg(tmp_path)  # no chat_template_type / tool_parser_type
+    passed = {"trust_remote_code": True}
+    out = _neutralize_unbundled_template_types(model, passed)
+    assert out is passed  # identity — no copy, no work on the happy path
+
+
+def test_probe_failure_returns_input_unchanged(tmp_path):
+    # Neither a local model dir nor a resolvable repo id → the probe returns
+    # None and the loader proceeds with the caller's config untouched.
+    passed = {"trust_remote_code": True}
+    out = _neutralize_unbundled_template_types(str(tmp_path / "does-not-exist"), passed)
+    assert out is passed
+
+
+def test_falsy_caller_override_is_respected(tmp_path):
+    # Caller already neutralized the field → don't fight it.
+    model = _write_cfg(tmp_path, chat_template_type="gemma4")
+    passed = {"chat_template_type": None}
+    out = _neutralize_unbundled_template_types(model, passed)
+    assert out is passed
+
+
+def test_truthy_caller_override_is_not_clobbered(tmp_path):
+    # codex r1 MAJOR: a caller who explicitly requests a DIFFERENT (bundled)
+    # template must keep it — the on-disk "gemma4" must NOT cause the
+    # caller's "deepseek_v32" to be overwritten to None. mlx-lm uses the
+    # caller's value (kwargs win), so we leave the whole config untouched.
+    model = _write_cfg(tmp_path, chat_template_type="gemma4")
+    passed = {"chat_template_type": "deepseek_v32"}
+    out = _neutralize_unbundled_template_types(model, passed)
+    assert out is passed
+    assert out["chat_template_type"] == "deepseek_v32"
+
+
+def test_truthy_tool_parser_override_is_not_clobbered(tmp_path):
+    model = _write_cfg(tmp_path, tool_parser_type="no_such_parser_xyz")
+    passed = {"tool_parser_type": "mistral"}
+    out = _neutralize_unbundled_template_types(model, passed)
+    assert out is passed
+    assert out["tool_parser_type"] == "mistral"
+
+
+def test_read_tokenizer_config_json_local_dir(tmp_path):
+    _write_cfg(tmp_path, chat_template_type="gemma4")
+    cfg = _read_tokenizer_config_json(str(tmp_path))
+    assert cfg is not None
+    assert cfg["chat_template_type"] == "gemma4"
+
+
+def test_read_tokenizer_config_json_missing_returns_none(tmp_path):
+    assert _read_tokenizer_config_json(str(tmp_path / "nope")) is None

--- a/vllm_mlx/utils/tokenizer.py
+++ b/vllm_mlx/utils/tokenizer.py
@@ -799,6 +799,120 @@ def load_model_with_fallback(
     return result
 
 
+# mlx-lm's tokenizer loader (``mlx_lm.tokenizer_utils.load``) imports a
+# chat-template / tool-parser module BY NAME whenever the model's
+# ``tokenizer_config.json`` declares one, with no guard:
+#     if chat_template_type := cfg.get("chat_template_type", False):
+#         importlib.import_module(f"mlx_lm.chat_templates.{chat_template_type}")
+#     if tool_parser_type := cfg.get("tool_parser_type", ...):
+#         importlib.import_module(f"mlx_lm.tool_parsers.{tool_parser_type}")
+# When the *bundled* mlx-lm doesn't ship that module the import raises
+# ``ModuleNotFoundError`` and the server dies at startup with NO fallback to
+# the model's on-disk ``chat_template.jinja``. #1420: mlx-lm 0.31.x dropped
+# ``mlx_lm/chat_templates/gemma4.py`` while ``mlx-community/gemma-4-26b-a4b-it-4bit``
+# still declares ``"chat_template_type": "gemma4"`` → every such Gemma 4
+# checkpoint 500s on ``rapid-mlx serve`` (regression vs 0.6.71, which
+# shipped the module). Weights load BEFORE the tokenizer in ``mlx_lm.load``,
+# so a catch-and-retry would re-load multi-GB weights — we neutralize the
+# offending field up front instead.
+_UNBUNDLED_TEMPLATE_FIELDS: tuple[tuple[str, str], ...] = (
+    ("chat_template_type", "mlx_lm.chat_templates"),
+    ("tool_parser_type", "mlx_lm.tool_parsers"),
+)
+
+
+def _read_tokenizer_config_json(model_name: str) -> dict | None:
+    """Best-effort read of a model's ``tokenizer_config.json``.
+
+    Local dir → read directly. HF repo id → fetch ONLY that one small file
+    (never the weights) via the hub cache. Returns ``None`` on any failure
+    so the caller falls through to the unmodified load path — this is a
+    pre-load probe and must never itself break loading.
+    """
+    try:
+        local = Path(model_name)
+        if local.is_dir():
+            cfg_path = local / "tokenizer_config.json"
+            if not cfg_path.is_file():
+                return None
+        else:
+            from huggingface_hub import hf_hub_download
+
+            try:
+                # Cache-only first: a model that's already downloaded (the
+                # common case, and always so for the desktop app which pulls
+                # before it serves) resolves with NO network — we don't add a
+                # hub round-trip to every serve start, and stay functional
+                # offline.
+                cfg_path = Path(
+                    hf_hub_download(
+                        model_name, "tokenizer_config.json", local_files_only=True
+                    )
+                )
+            except Exception:
+                # Not cached yet (a fresh ``serve <repo-id>``): fetch just
+                # this one small file so a first load of a Gemma 4 checkpoint
+                # is guarded too. The weights download on the very next step.
+                cfg_path = Path(hf_hub_download(model_name, "tokenizer_config.json"))
+        with open(cfg_path) as f:
+            return json.load(f)
+    except Exception as e:  # noqa: BLE001 — a probe must not break loading
+        logger.debug("tokenizer_config.json probe failed for %s: %s", model_name, e)
+        return None
+
+
+def _neutralize_unbundled_template_types(
+    model_name: str, tokenizer_config: dict
+) -> dict:
+    """Guard against #1420: strip any ``chat_template_type`` /
+    ``tool_parser_type`` whose ``mlx_lm`` module the bundled mlx-lm doesn't
+    ship, so ``mlx_lm.load`` skips the crashing ``import_module`` and the
+    model boots from its ``chat_template.jinja`` sidecar instead.
+
+    Returns the original dict unchanged when there is nothing to neutralize
+    (the common case — no field declared, or its module IS bundled), so the
+    happy path pays only one small config read.
+    """
+    cfg = _read_tokenizer_config_json(model_name)
+    if not cfg:
+        return tokenizer_config
+
+    import importlib.util as _iu
+
+    patched: dict | None = None
+    for field, pkg in _UNBUNDLED_TEMPLATE_FIELDS:
+        # The caller's tokenizer_config override wins over the on-disk value
+        # in mlx-lm (kwargs → AutoTokenizer init_kwargs → the ``:= get()``
+        # branch), so if the caller has already specified this field — any
+        # value, truthy or falsy — it owns it: don't probe the on-disk value
+        # and don't clobber a deliberately-requested bundled template
+        # (codex r1 MAJOR: a truthy override was being overwritten to None).
+        if field in tokenizer_config:
+            continue
+        type_name = cfg.get(field)
+        if not type_name or not isinstance(type_name, str):
+            continue
+        module = f"{pkg}.{type_name}"
+        try:
+            spec = _iu.find_spec(module)
+        except (ImportError, ValueError):
+            spec = None
+        if spec is None:
+            if patched is None:
+                patched = dict(tokenizer_config)
+            patched[field] = None
+            logger.warning(
+                "%s declares %s=%r but bundled mlx-lm ships no %s — "
+                "neutralizing it so the model loads from its chat_template.jinja "
+                "sidecar rather than crashing at startup (#1420).",
+                model_name,
+                field,
+                type_name,
+                module,
+            )
+    return patched if patched is not None else tokenizer_config
+
+
 def _load_model_with_fallback_impl(
     model_name: str,
     tokenizer_config: dict = None,
@@ -812,6 +926,13 @@ def _load_model_with_fallback_impl(
 
     _register_vendored_archs()
     tokenizer_config = tokenizer_config or {}
+    # #1420: neutralize any declared chat-template / tool-parser type whose
+    # mlx-lm module isn't bundled, BEFORE any load() — covers the native
+    # Gemma 4 path, its legacy-wrapper fallback, and the general path, all of
+    # which feed this dict to ``mlx_lm.load`` / ``load_tokenizer``.
+    tokenizer_config = _neutralize_unbundled_template_types(
+        model_name, tokenizer_config
+    )
 
     # Check if model needs fallback (e.g., Nemotron)
     if _needs_tokenizer_fallback(model_name):


### PR DESCRIPTION
## Why

`rapid-mlx serve mlx-community/gemma-4-26b-a4b-it-4bit` (the desktop app's **24 GB recommended pick**) crashes at startup:

```
ModuleNotFoundError: No module named 'mlx_lm.chat_templates.gemma4'
ERROR:    Application startup failed. Exiting.
```

Reported by an external user in #1420 as a regression vs 0.6.71.

## Root cause

mlx-lm's `tokenizer_utils.load` imports a module **by name** whenever the model's `tokenizer_config.json` declares `chat_template_type` / `tool_parser_type`, with no guard:

```python
if chat_template_type := cfg.get("chat_template_type", False):
    importlib.import_module(f"mlx_lm.chat_templates.{chat_template_type}")
```

mlx-lm 0.31.x **dropped** `mlx_lm/chat_templates/gemma4.py`, but the HF repo still declares `"chat_template_type": "gemma4"`, so the import raises with **no fallback to the model's on-disk `chat_template.jinja`** — even though it's right there in the model dir.

## Fix

`_neutralize_unbundled_template_types()` runs before `mlx_lm.load` and, for any declared `chat_template_type` / `tool_parser_type` whose `mlx_lm` module isn't importable (`find_spec` is `None`), sets it to `None` in a **copy** of `tokenizer_config`. mlx-lm's `if x := cfg.get(..., False)` guard then skips the crashing import and transformers loads the `chat_template.jinja` sidecar instead.

- **Package-specific** — `gemma4` is missing under `chat_templates` but *present* under `tool_parsers`, so the guard probes each package separately and never over-neutralizes.
- **Caller override wins** — if the caller already specified the field (any value), it's left untouched (mlx-lm's kwargs override the on-disk value).
- **Cheap + offline-safe** — reads only `tokenizer_config.json` (cache-first via `local_files_only=True`, so no network on the serve hot path for an already-downloaded model; single-file network fetch only on a genuine first load), and fails safe to the unmodified load path.
- **No behaviour change when the module exists.** Weights load before the tokenizer in `mlx_lm.load`, so we neutralize up front rather than catch-and-retry (which would re-load multi-GB weights).

## Verification

- **Repro + fix, end to end** (reusing the cached Gemma 4 26B tokenizer + a `chat_template_type: "gemma4"` config): before → the exact `ModuleNotFoundError`; after → loads OK and `tokenizer.chat_template` equals the on-disk `chat_template.jinja`.
- **12 golden tests** (`tests/test_chat_template_type_guard.py`): missing vs bundled type, package-specificity, both fields, truthy/falsy caller-override precedence, probe-failure fail-safe, local config read.
- 39 load-path/tokenizer tests pass; ruff check + format clean.
- **Codex** (gpt-5.6) converged over 2 rounds — caught a real MAJOR (a truthy caller override was being clobbered), now fixed. Final: **0 BLOCKING / 0 MAJOR / 0 MINOR**.

Closes #1420.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
