### PR TITLE
chore: bump version to 0.12.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.12.1"
+version = "0.12.3"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Why

Patch release cutting the #1420 fix to PyPI/Homebrew.

## What's in 0.12.3 (engine)

- **fix(tokenizer): guard against unbundled chat-template/tool-parser modules (#1420)** — `rapid-mlx serve mlx-community/gemma-4-26b-a4b-it-4bit` (the desktop app's 24 GB recommended pick) crashed at startup with `ModuleNotFoundError: No module named 'mlx_lm.chat_templates.gemma4'` because mlx-lm 0.31.x dropped that module while the HF repo still declares `chat_template_type: "gemma4"`, with no fallback to the on-disk `chat_template.jinja`. The engine now neutralizes any declared `chat_template_type`/`tool_parser_type` whose mlx-lm module isn't bundled, so the model boots from its `.jinja` sidecar. Reported by an external user.

Only engine change since v0.12.1 (the other two `main` commits are rapid-mac app-only).

## Release gates

- Local pre-bump: `release-smoke` (clean-room install + import of every release surface) — **pass**. The fix's own CI already booted real models (`l1-smoke` llama3-3b + qwen3.5-4b, `test-apple-silicon`) and ran 12 golden tests; codex converged 0 BLOCKING / 0 MAJOR / 0 MINOR over 2 rounds.
- Authoritative: the self-hosted **tier1-agent-gate** (Studio) runs on this bump and is fail-closed — no tag/publish unless it passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
