### PR TITLE
fix(mtp): charge the drafter to the round that consumes it, and export the cost curve

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -76,6 +76,91 @@ into the same config path.
 | `{"method":"mtp","disable_auto_k":true}` | Disable the MTP EV depth controller for fixed-K parity benches. |
 | `{"method":"suffix","num_speculative_tokens":8}` | Enable explicit SuffixDecoding for high-overlap workloads. |
 
+#### MTP is not free — measure before you enable it
+
+MTP is **opt-in and should stay opt-in**. A high draft acceptance rate is
+not sufficient for it to pay, and on at least one otherwise-recommended
+model it is a large net loss.
+
+The speedup ceiling for chain-of-K MTP is
+
+```
+speedup <= (1 + K * accept) / cost_ratio(K + 1)
+```
+
+where `cost_ratio(N)` is what an `N`-position forward costs relative to a
+1-position decode forward on **your** hardware. The numerator is what
+speculation wins; the denominator is what verifying costs. Acceptance is
+a property of the drafter, `cost_ratio` is a property of the chip and the
+architecture, and only their ratio decides the outcome. Neither number
+transfers between machines: the same model and byte-identical acceptance
+measured +118% on one host and +13% on another.
+
+Worked example — `qwen3.6-35b-4bit` with `Qwen3.6-35B-A3B-MTP-4bit`,
+Mac mini M2 Pro / 32GB, `temperature=0`, medians over 4 repetitions:
+
+| | |
+|---|---|
+| draft acceptance | **0.857** — the drafter is excellent |
+| `cost_ratio(2)` | **1.70** — a 2-position forward costs 1.70x a decode forward |
+| predicted ceiling | `1.857 / 1.70` = **1.09x** |
+| measured, MTP on, fixed K=1 | 47.4 tok/s |
+| measured, MTP on, auto-K | 47.6 tok/s — the controller cannot rescue it |
+| measured, MTP off | 59.0 tok/s — **MTP is 20% slower** |
+
+(Acceptance and the fixed-K throughput are from the same run, so they
+describe the same work; the auto-K row is a separate run of the same
+protocol.)
+
+An 86% acceptance rate buys a 9% ceiling here, and per-round overhead
+consumes it. The architecture is why: this is a linear-attention hybrid,
+and its forward does not amortize a second position the way a
+pure-attention model's does. Enabling MTP on it costs a fifth of your
+throughput.
+
+To check your own combination, pin the depth and run a representative
+workload:
+
+```bash
+rapid-mlx serve <your-model> \
+  --speculative-config '{"method":"mtp","model":"<head>","disable_auto_k":true}'
+```
+
+then read off `/metrics`:
+
+```
+rapid_mlx_spec_decode_k_cost_ms{k="0",model_id="..."}   # park round, no drafter
+rapid_mlx_spec_decode_k_cost_ms{k="1",model_id="..."}   # drafting + verify round
+rapid_mlx_spec_decode_accept_ratio                      # acceptance
+```
+
+`disable_auto_k` is what makes the acceptance term meaningful:
+`accept_ratio` is a single number pooled over every depth the controller
+sampled, and deeper positions accept less often than shallow ones, so
+under auto-K it belongs to no particular K. Pinning the depth makes it
+belong to the K you are evaluating. The controller keeps measuring in
+this mode — it just stops choosing.
+
+The `k="0"` sample in fixed-K mode comes from the cold-start round each
+request opens with, so send enough requests (a dozen is plenty) for it to
+settle before reading the ratio.
+
+Each `k_cost_ms` bucket is a whole round — the target forward plus the
+drafting that produced the drafts that round consumed — so the two are
+directly comparable. A K=1 round emits `1 + accept` tokens on average
+against a park round's 1, which makes the decision rule:
+
+```
+enable MTP only if   (1 + K * accept)  >  k_cost_ms{k=K} / k_cost_ms{k=0}
+```
+
+The left side is what depth K wins you; the right side is what it costs.
+On `qwen3.6-35b-4bit` the left side is 1.857 and the right side is larger,
+which is the whole story. Note that both buckets carry MTP's own
+per-round overhead, so clearing this bar is necessary but not sufficient
+— a marginal result should be confirmed against a real MTP-off A/B before
+you turn it on.
+
 #### MTP sidecar heads are not standalone models
 
 The `*-mtp-4bit` aliases — `qwen3.6-27b-mtp-4bit`

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -161,6 +161,18 @@ per-round overhead, so clearing this bar is necessary but not sufficient
 — a marginal result should be confirmed against a real MTP-off A/B before
 you turn it on.
 
+> **Run this on a single model per process.** The two sides of the rule
+> come from series with *different identity scopes*: `k_cost_ms` is keyed
+> per checkpoint (`model_id`, from the per-model controller registry that
+> survives a model swap), while `accept_ratio` is a **process-global**
+> counter — it pools acceptance across every model *and* every depth the
+> process ever ran (the `family` label only splits a dashboard panel; it
+> is not a separate counter). So after a model swap, or with concurrent
+> models in one process, the cost curve and the acceptance term describe
+> different model/head combinations and the rule can read wrong. The
+> diagnostic above already assumes one model and `disable_auto_k`; keep it
+> that way — a fresh process per checkpoint — when you read the ratio.
+
 #### MTP sidecar heads are not standalone models
 
 The `*-mtp-4bit` aliases — `qwen3.6-27b-mtp-4bit`

--- a/tests/test_mtp_spec_decode.py
+++ b/tests/test_mtp_spec_decode.py
@@ -27,6 +27,10 @@ because Stage B Viterbi is currently holding the device).
 
 from __future__ import annotations
 
+import copy
+import dataclasses
+import types
+
 import pytest
 
 mx = pytest.importorskip("mlx.core")
@@ -909,6 +913,100 @@ def test_metrics_includes_park_and_k_chosen_counters():
         'rapid_mlx_spec_decode_k_chosen_rounds_total{family="gemma-4-12b-4bit",method="mtp"} 0'
         in body
     )
+
+
+def test_metrics_k_cost_curve_absent_cold_then_present_after_rounds():
+    """``rapid_mlx_spec_decode_k_cost_ms`` exports the controller's
+    per-depth cost EWMA — the premise ``park_total`` rests on.
+
+    Unlike the park/k_chosen series this one is NOT emitted at cold
+    start: a zero-valued cost would read as "a round is free" rather
+    than "no round has been measured", and a dashboard dividing by it
+    would show an infinite speedup. Absence is the honest cold state.
+    """
+    from vllm_mlx.routes.metrics import _render_spec_decode_mtp_counters
+    from vllm_mlx.spec_decode.mtp.accept_counter import (
+        reset_global_counter_for_tests,
+    )
+    from vllm_mlx.spec_decode.mtp.draft_k_controller_v2 import (
+        get_or_create_controller,
+        reset_controllers,
+    )
+
+    reset_global_counter_for_tests()
+    reset_controllers()
+
+    class _Cfg:
+        model_alias = "gemma-4-12b-4bit"
+
+    assert "rapid_mlx_spec_decode_k_cost_ms" not in "\n".join(
+        _render_spec_decode_mtp_counters(_Cfg())
+    )
+
+    ctrl = get_or_create_controller("test-model", max_k=1)
+    ctrl.cost.observe(0, 20.0)
+    ctrl.cost.observe(1, 30.0)
+
+    body = "\n".join(_render_spec_decode_mtp_counters(_Cfg()))
+    assert "# TYPE rapid_mlx_spec_decode_k_cost_ms gauge" in body
+    assert (
+        'rapid_mlx_spec_decode_k_cost_ms{method="mtp",'
+        'model_id="test-model",k="0"} 20.000' in body
+    )
+    assert (
+        'rapid_mlx_spec_decode_k_cost_ms{method="mtp",'
+        'model_id="test-model",k="1"} 30.000' in body
+    )
+    reset_controllers()
+
+
+def test_cost_curves_are_not_blended_across_controllers():
+    """Two target+drafter combinations must stay separate series.
+
+    Averaging them yields a cost ratio belonging to neither, published
+    under a ``family`` label naming only one — an operator reading it
+    would attribute the busier model's curve to whichever model they
+    happened to be looking at.
+    """
+    from vllm_mlx.routes.metrics import _render_spec_decode_mtp_counters
+    from vllm_mlx.spec_decode.mtp.accept_counter import (
+        reset_global_counter_for_tests,
+    )
+    from vllm_mlx.spec_decode.mtp.draft_k_controller_v2 import (
+        cost_curves_by_controller,
+        get_or_create_controller,
+        reset_controllers,
+    )
+
+    reset_global_counter_for_tests()
+    reset_controllers()
+    a = get_or_create_controller("model-a", max_k=1)
+    b = get_or_create_controller("model-b", max_k=1)
+    # Lopsided sample counts: under any visit-weighted blend "model-a"
+    # would swallow "model-b" entirely.
+    for _ in range(50):
+        a.cost.observe(0, 10.0)
+    b.cost.observe(0, 40.0)
+
+    curves = cost_curves_by_controller()
+    assert set(curves) == {"model-a", "model-b"}
+    assert curves["model-a"][0] == pytest.approx(10.0)
+    assert curves["model-b"][0] == pytest.approx(40.0)
+
+    class _Cfg:
+        model_alias = "gemma-4-12b-4bit"
+
+    body = "\n".join(_render_spec_decode_mtp_counters(_Cfg()))
+    assert 'model_id="model-a",k="0"} 10.000' in body
+    assert 'model_id="model-b",k="0"} 40.000' in body
+    # The per-controller series must NOT carry the route config's family:
+    # neither of these controllers is the "gemma-4-12b-4bit" the renderer
+    # was handed, and labelling them so would attribute one model's costs
+    # to another on any family-filtered dashboard.
+    for line in body.splitlines():
+        if line.startswith("rapid_mlx_spec_decode_k_cost_ms{"):
+            assert "family=" not in line, line
+    reset_controllers()
 
 
 def test_metrics_route_includes_spec_decode_series_at_cold_start():
@@ -2411,3 +2509,476 @@ def test_generator_records_counter_on_accept_and_reject():
     assert snap.accepts == 2, f"expected 2 accepts; got {snap}"
     assert snap.tokens_saved == 2
     assert snap.accept_ratio == pytest.approx(2 / 3)
+
+
+def test_drafter_wall_time_is_charged_to_the_round_that_consumes_it():
+    """``cost(K>=1)`` must include the drafting that produced the K drafts.
+
+    Drafting happens at the tail of round N, after round N's timer has
+    already been read, so a naive implementation charges it to nobody:
+    ``cost(1)`` measures only the target's verify forward. The EV
+    comparator then divides ``committed(K) / cost(K)`` by a cost missing
+    the one term that most distinguishes K>=1 from K=0, and systematically
+    under-prices drafting.
+
+    Driven by a virtual clock that advances only when the model is
+    called, so the recorded costs are exact rather than thresholded. A
+    real ``time.sleep`` would make this a wall-clock race: a loaded host
+    or MLX first-touch initialization can inflate the K=0 forward past
+    any absolute cutoff, and the cost EWMA's innovation clamp would keep
+    it there for the rest of the test.
+    """
+    import time as _time
+
+    from vllm_mlx.spec_decode.mtp.accept_counter import MTPAcceptCounter
+    from vllm_mlx.spec_decode.mtp.draft_k_controller_v2 import (
+        get_or_create_controller,
+        reset_controllers,
+    )
+    from vllm_mlx.spec_decode.mtp.generator import mtp_generate_step
+
+    FORWARD_S = 0.010  # every backbone forward
+    DRAFT_S = 0.050  # every drafter call, deliberately the larger term
+
+    clock = {"t": 0.0}
+
+    class _ClockedModel(_MockedQwen35Model):
+        def __call__(self, *args, **kwargs):
+            clock["t"] += FORWARD_S
+            return super().__call__(*args, **kwargs)
+
+        def mtp_forward(self, *args, **kwargs):
+            clock["t"] += DRAFT_S
+            return super().mtp_forward(*args, **kwargs)
+
+    reset_controllers()
+    # Long enough for the controller's bootstrap to seed both K=0 and
+    # K=1; every draft matches its verify position so drafting is always
+    # accepted and K=1 rounds keep being chosen.
+    backbone = [7] + [11, 13] * 40
+    model = _ClockedModel(backbone, [11] * 80)
+    prompt = mx.array([1], dtype=mx.uint32)
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(_time, "perf_counter", lambda: clock["t"])
+        list(
+            mtp_generate_step(
+                prompt,
+                model,
+                max_tokens=40,
+                accept_counter=MTPAcceptCounter(),
+                model_id="slow-drafter",
+                max_k=1,
+            )
+        )
+
+    curve = get_or_create_controller("slow-drafter", max_k=1).cost.samples()
+    assert 0 in curve and 1 in curve, f"controller never sampled both depths: {curve}"
+    park_ms, _ = curve[0]
+    draft_ms, _ = curve[1]
+
+    # A park round is one backbone forward and consumes no drafts.
+    assert park_ms == pytest.approx(FORWARD_S * 1000.0), (
+        f"K=0 cost {park_ms:.1f}ms != the one forward it ran "
+        f"({FORWARD_S * 1000.0:.0f}ms) — drafting is being charged to a "
+        "round that consumed no drafts"
+    )
+    # A K=1 round is one verify forward PLUS the drafting that produced
+    # the draft it consumed. Without the carry this is FORWARD_S alone.
+    assert draft_ms == pytest.approx((FORWARD_S + DRAFT_S) * 1000.0), (
+        f"K=1 cost {draft_ms:.1f}ms != forward + drafter "
+        f"({(FORWARD_S + DRAFT_S) * 1000.0:.0f}ms) — the drafter is not "
+        "being charged to the round that consumed its output"
+    )
+    reset_controllers()
+
+
+def test_fixed_k_mode_still_records_the_cost_curve():
+    """``disable_auto_k=True`` must keep OBSERVING even though it stops
+    the controller from CHOOSING.
+
+    Fixed-K is the mode an operator measures in — under auto-K the
+    acceptance ratio is pooled across every depth the controller sampled,
+    so it describes no particular K. If fixed-K dropped the controller
+    entirely, ``k_cost_ms`` would be empty in exactly the configuration
+    the docs tell operators to measure with.
+
+    Behaviour must not change: K stays pinned at 1, so no round parks.
+    """
+    from vllm_mlx.spec_decode.mtp.accept_counter import MTPAcceptCounter
+    from vllm_mlx.spec_decode.mtp.draft_k_controller_v2 import (
+        get_or_create_controller,
+        reset_controllers,
+    )
+    from vllm_mlx.spec_decode.mtp.generator import mtp_generate_step
+
+    reset_controllers()
+    backbone = [7] + [11, 13] * 20
+    model = _MockedQwen35Model(backbone, [11] * 40)
+
+    list(
+        mtp_generate_step(
+            mx.array([1], dtype=mx.uint32),
+            model,
+            max_tokens=20,
+            accept_counter=MTPAcceptCounter(),
+            model_id="fixed-k-model",
+            max_k=1,
+            disable_auto_k=True,
+        )
+    )
+
+    ctrl = get_or_create_controller("fixed-k-model", max_k=1)
+    curve = ctrl.cost.samples()
+    assert 1 in curve, f"fixed-K recorded no cost for K=1: {curve}"
+    assert curve[1][1] > 0, "K=1 sampled zero times"
+    # The controller never CHOSE a depth, so the only K=0 round is the
+    # cold-start one every request begins with (no drafts exist yet).
+    # That single sample is not an accident to be suppressed — it is the
+    # denominator the fixed-K decision rule needs, and there is exactly
+    # one per request.
+    assert ctrl.park_count == 1, (
+        f"expected exactly the one cold-start K=0 round, got "
+        f"{ctrl.park_count} — the controller is selecting depth when it "
+        "must only observe"
+    )
+    assert set(ctrl.k_histogram) == {0, 1}, (
+        f"fixed-K ran depths {sorted(ctrl.k_histogram)}, expected the "
+        "cold-start K=0 plus pinned K=1"
+    )
+    assert 0 in curve, (
+        "no K=0 reference recorded — the fixed-K decision rule has no "
+        "denominator to divide by"
+    )
+    reset_controllers()
+
+
+def test_derive_controller_key_is_stable_and_discriminating():
+    """The fallback registry key must be stable across restarts AND
+    distinct between different models.
+
+    Both halves are load-bearing. It reaches ``/metrics`` as the
+    ``model_id`` label, so an ``id()``-derived key would mint a fresh
+    series every boot; and equal keys share one ``DepthController``, so a
+    collision between different models would let one model's learned
+    costs drive the other's depth selection.
+    """
+    from vllm_mlx.spec_decode.mtp.draft_k_controller_v2 import (
+        derive_controller_key,
+    )
+
+    class _Args:
+        model_type = "qwen3_5_moe"
+        num_hidden_layers = 40
+        hidden_size = 4096
+        vocab_size = 151936
+
+    class _Model:
+        args = _Args()
+
+    a, b = _Model(), _Model()
+    key = derive_controller_key(a)
+
+    # Stable: two distinct instances of the same model shape agree, so a
+    # restart reproduces the key.
+    assert derive_controller_key(b) == key
+    # Carries no address.
+    assert hex(id(a))[2:] not in key and str(id(a)) not in key
+    assert "qwen3_5_moe" in key and "num_hidden_layers=40" in key
+
+    # Discriminating: a different shape must not collide.
+    class _OtherArgs(_Args):
+        num_hidden_layers = 64
+
+    class _OtherModel:
+        args = _OtherArgs()
+
+    assert derive_controller_key(_OtherModel()) != key
+
+    # The drafter's shape is folded in, so the same target with a
+    # different-sized head is a different key.
+    class _Head:
+        layers = [object(), object()]
+
+    class _WithHead(_Model):
+        mtp = _Head()
+
+    assert derive_controller_key(_WithHead()) != key
+
+    # Nested dict config: Qwen3.5/3.6's outer args carries only
+    # ``model_type`` plus a plain-dict ``text_config``. Reading just the
+    # top level as an object yields "model_type=qwen3_5_moe" and nothing
+    # else — every model of the family would then share one controller.
+    class _NestedArgs:
+        model_type = "qwen3_5_moe"
+        text_config = {"num_hidden_layers": 40, "hidden_size": 2048}
+
+    class _NestedModel:
+        args = _NestedArgs()
+
+    nested_key = derive_controller_key(_NestedModel())
+    assert "num_hidden_layers=40" in nested_key, (
+        f"nested dict config did not resolve: {nested_key}"
+    )
+    assert "hidden_size=2048" in nested_key
+
+    class _NestedArgsWider(_NestedArgs):
+        text_config = {"num_hidden_layers": 40, "hidden_size": 5120}
+
+    class _WiderModel:
+        args = _NestedArgsWider()
+
+    assert derive_controller_key(_WiderModel()) != nested_key
+
+    # Quantization is not shape, but two quantizations of one
+    # architecture differ substantially in what a forward costs — sharing
+    # a cost curve between them would be a real mis-attribution.
+    class _Q4:
+        model_type = "qwen3_5"
+        num_hidden_layers = 64
+        quantization = {"bits": 4, "group_size": 64}
+
+    class _Q8(_Q4):
+        quantization = {"bits": 8, "group_size": 64}
+
+    # One class, swapped args — the key opens with the model's class name,
+    # so two differently-named test classes would differ for that reason
+    # rather than for the one under test.
+    class _Quantized:
+        def __init__(self, args):
+            self.args = args
+
+    assert derive_controller_key(_Quantized(_Q4())) != derive_controller_key(
+        _Quantized(_Q8())
+    )
+
+    # Rendered in a fixed order so dict iteration cannot perturb the key.
+    class _Q4Reordered(_Q4):
+        quantization = {"group_size": 64, "bits": 4}
+
+    assert derive_controller_key(_Quantized(_Q4Reordered())) == derive_controller_key(
+        _Quantized(_Q4())
+    )
+
+    # Degrades without raising when the model exposes no config at all.
+    class _Bare:
+        pass
+
+    assert derive_controller_key(_Bare())
+
+
+def test_derive_controller_key_reads_quantization_off_the_modules():
+    """Quantization must come from the instantiated layers, not config.
+
+    mlx-lm's ``TextModelArgs.from_dict()`` drops the checkpoint's
+    ``quantization`` block, so a config-only lookup finds nothing on
+    exactly the quantized models this needs to tell apart — leaving a
+    4-bit and an 8-bit build of one architecture sharing a cost curve.
+    The quantized modules themselves always carry it.
+    """
+    from vllm_mlx.spec_decode.mtp.draft_k_controller_v2 import (
+        derive_controller_key,
+    )
+
+    class _Layer:
+        def __init__(self, bits, group_size):
+            self.bits = bits
+            self.group_size = group_size
+
+    class _Model:
+        """No config surface at all — mirrors the post-``from_dict`` state."""
+
+        def __init__(self, layers):
+            self._layers = layers
+
+        def named_modules(self):
+            return [(str(i), m) for i, m in enumerate(self._layers)]
+
+    k4 = derive_controller_key(_Model([_Layer(4, 64), _Layer(4, 64)]))
+    k8 = derive_controller_key(_Model([_Layer(8, 64), _Layer(8, 64)]))
+    assert "quant=4b/g64" in k4
+    assert "quant=8b/g64" in k8
+    assert k4 != k8
+
+    # A mixed-precision build is described, not reduced to whichever
+    # layer happened to be visited first — and the order it is visited
+    # in must not change the key.
+    mixed_a = derive_controller_key(_Model([_Layer(4, 64), _Layer(8, 64)]))
+    mixed_b = derive_controller_key(_Model([_Layer(8, 64), _Layer(4, 64)]))
+    assert mixed_a == mixed_b
+    assert "quant=4b/g64+8b/g64" in mixed_a
+    assert mixed_a != k4
+
+    # Unquantized: no marker rather than a misleading one.
+    class _Plain:
+        def named_modules(self):
+            return [("0", object())]
+
+    assert "quant=" not in derive_controller_key(_Plain())
+
+
+def test_engine_core_threads_checkpoint_name_into_scheduler_config():
+    """The engine knows which checkpoint it loaded; the scheduler must
+    learn it, because the MTP controller registry is process-global.
+
+    Without a name the registry key falls back to the model's shape, and
+    two checkpoints sharing an architecture, quantization and MTP-head
+    size collapse onto one ``DepthController`` — one model's observed
+    costs then drive the other's depth selection.
+    """
+    from vllm_mlx.scheduler import SchedulerConfig
+
+    assert "model_name" in {f.name for f in dataclasses.fields(SchedulerConfig)}, (
+        "SchedulerConfig lost the model_name field the controller key "
+        "resolution chain depends on"
+    )
+    assert SchedulerConfig().model_name is None
+
+    from vllm_mlx.engine_core import _resolve_model_identity
+
+    engine_a = types.SimpleNamespace(model_name="engine/a", model_path=None)
+    engine_b = types.SimpleNamespace(model_name="engine/b", model_path=None)
+
+    # A blank config takes the engine's checkpoint.
+    cfg = SchedulerConfig()
+    cfg.model_name = _resolve_model_identity(engine_a, cfg.model_name)
+    assert cfg.model_name == "engine/a"
+
+    # THE RELOAD CASE: the same config object reused by a second engine
+    # must pick up the SECOND checkpoint. A fill-a-blank guard would
+    # leave "engine/a" here and hand the new model the old model's
+    # process-global controller.
+    cfg.model_name = _resolve_model_identity(engine_b, cfg.model_name)
+    assert cfg.model_name == "engine/b"
+
+    # And the engine must not write inference back into a config it does
+    # not own: a shared SchedulerConfig stays pristine, so a second,
+    # UNNAMED engine cannot mistake the first engine's inferred name for
+    # its own explicit configuration.
+    shared = SchedulerConfig()
+    for engine in (engine_a, engine_b):
+        local = copy.copy(shared)
+        local.model_name = _resolve_model_identity(engine, local.model_name)
+        assert local.model_name == engine.model_name
+    assert shared.model_name is None
+    anonymous = types.SimpleNamespace(model_name=None, model_path=None)
+    local = copy.copy(shared)
+    local.model_name = _resolve_model_identity(anonymous, local.model_name)
+    assert local.model_name is None, (
+        "an unnamed engine inherited a previous engine's identity and "
+        "would be keyed as that model"
+    )
+
+    # Idempotent: re-resolving with the same engine does not drift.
+    assert _resolve_model_identity(engine_b, cfg.model_name) == "engine/b"
+
+    # An engine with no identity of its own falls back to the config.
+    anon = types.SimpleNamespace(model_name=None, model_path=None)
+    assert _resolve_model_identity(anon, "configured/name") == "configured/name"
+    assert _resolve_model_identity(anon, None) is None
+
+    # ``model_path`` serves when ``model_name`` is absent.
+    pathy = types.SimpleNamespace(model_name=None, model_path="/models/foo")
+    assert _resolve_model_identity(pathy, None) == "/models/foo"
+
+
+def test_mtp_controller_key_separates_sidecars():
+    """The controller learns an ACCEPTANCE profile, and acceptance is a
+    property of the target/drafter pair, not the target alone.
+
+    The registry is process-global and never reset in production, so a
+    key ignoring the sidecar would let the first head's profile drive
+    depth selection for a different head after a reload.
+    """
+    from vllm_mlx.scheduler import _mtp_controller_key
+
+    base = _mtp_controller_key("qwen3.6-35b", None)
+    a = _mtp_controller_key("qwen3.6-35b", "mlx-community/Head-A")
+    b = _mtp_controller_key("qwen3.6-35b", "mlx-community/Head-B")
+
+    assert base == "qwen3.6-35b"
+    assert a != b
+    assert a != base and b != base
+    assert "qwen3.6-35b" in a and "Head-A" in a
+
+    # A different target with the same head is still distinct.
+    assert _mtp_controller_key("qwen3.6-27b", "mlx-community/Head-A") != a
+
+    # No target name -> None, so the caller falls through to the
+    # shape-derived key rather than keying on a bare sidecar path.
+    assert _mtp_controller_key(None, "mlx-community/Head-A") is None
+    assert _mtp_controller_key("", "mlx-community/Head-A") is None
+
+
+def test_scheduler_config_model_name_is_the_last_field():
+    """``SchedulerConfig`` is constructed positionally by external
+    callers, so a field added mid-list silently rebinds every argument
+    after it. ``model_name`` must stay at the end.
+    """
+    from vllm_mlx.scheduler import SchedulerConfig
+
+    names = [f.name for f in dataclasses.fields(SchedulerConfig)]
+    assert names[-1] == "model_name", (
+        f"model_name must be the last field to preserve positional "
+        f"construction; it is at index {names.index('model_name')} of "
+        f"{len(names)}"
+    )
+
+
+def test_fixed_k_observer_leaves_the_ceiling_to_whoever_selects_depth():
+    """An observer-only fixed-K run must not fix ``max_k`` for later runs.
+
+    The registry normally keeps whatever ceiling the FIRST caller set.
+    That makes an observer's ceiling a trap in both directions: seeding
+    the configured value (3 by default) would let a later auto-K run —
+    one an SSM cache forces to clamp to 1 — inherit 3 and select past its
+    clamp; seeding the 1 this mode can actually reach would cap a later
+    auto-K run at chain-of-1 forever. So the observer's ceiling is
+    provisional and the first selecting caller replaces it.
+    """
+    from vllm_mlx.spec_decode.mtp.accept_counter import MTPAcceptCounter
+    from vllm_mlx.spec_decode.mtp.draft_k_controller_v2 import (
+        get_or_create_controller,
+        reset_controllers,
+    )
+    from vllm_mlx.spec_decode.mtp.generator import mtp_generate_step
+
+    def _observe_only(max_k):
+        """Run a fixed-K generation, which records but never selects."""
+        reset_controllers()
+        list(
+            mtp_generate_step(
+                mx.array([1], dtype=mx.uint32),
+                _MockedQwen35Model([7] + [11, 13] * 20, [11] * 40),
+                max_tokens=12,
+                accept_counter=MTPAcceptCounter(),
+                model_id="ceiling-model",
+                max_k=max_k,
+                disable_auto_k=True,
+            )
+        )
+        # Peek without adopting — an authoritative read would itself set
+        # the ceiling this test is trying to observe.
+        return get_or_create_controller("ceiling-model", max_k=99, authoritative=False)
+
+    # The observer only ever ran K in {0, 1}, and says so provisionally.
+    ctrl = _observe_only(max_k=3)
+    assert ctrl.max_k == 1
+    assert ctrl.ceiling_is_authoritative is False
+    assert ctrl.pick_k() <= 1
+
+    # A later auto-K run clamped to 1 (the SSM case) keeps 1.
+    ctrl = _observe_only(max_k=3)
+    assert get_or_create_controller("ceiling-model", max_k=1).max_k == 1
+
+    # A later auto-K run configured for 3 gets 3 — the observer must not
+    # have capped it.
+    ctrl = _observe_only(max_k=3)
+    adopted = get_or_create_controller("ceiling-model", max_k=3)
+    assert adopted.max_k == 3
+    assert adopted.ceiling_is_authoritative is True
+
+    # Once authoritative, the pre-existing "first config wins" rule is
+    # unchanged: a conflicting later ceiling is ignored.
+    assert get_or_create_controller("ceiling-model", max_k=2).max_k == 3
+    reset_controllers()

--- a/tests/test_mtp_spec_decode.py
+++ b/tests/test_mtp_spec_decode.py
@@ -2817,14 +2817,14 @@ def test_derive_controller_key_reads_quantization_off_the_modules():
     assert "quant=" not in derive_controller_key(_Plain())
 
 
-def test_engine_core_threads_checkpoint_name_into_scheduler_config():
-    """The engine knows which checkpoint it loaded; the scheduler must
-    learn it, because the MTP controller registry is process-global.
-
-    Without a name the registry key falls back to the model's shape, and
-    two checkpoints sharing an architecture, quantization and MTP-head
-    size collapse onto one ``DepthController`` — one model's observed
-    costs then drive the other's depth selection.
+def test_resolve_model_identity_prefers_engine_checkpoint_over_stale_config():
+    """Unit test of the ``_resolve_model_identity`` HELPER only — the engine's
+    own loaded checkpoint wins over a (possibly stale, shared) configured name,
+    and the resolution is idempotent so a reused config object stays safe. The
+    ACTUAL ``EngineCore.__init__`` wiring (copy + assign) is covered separately
+    by ``test_engine_core_init_wires_resolved_model_name_onto_a_scheduler_copy``,
+    which constructs the engine; this test deliberately does not, so keep the
+    two distinct (codex #1441).
     """
     from vllm_mlx.scheduler import SchedulerConfig
 
@@ -2946,13 +2946,18 @@ def test_mtp_controller_key_separates_sidecars():
     a = _mtp_controller_key("qwen3.6-35b", "mlx-community/Head-A")
     b = _mtp_controller_key("qwen3.6-35b", "mlx-community/Head-B")
 
-    assert base == "qwen3.6-35b"
+    assert "qwen3.6-35b" in base
     assert a != b
     assert a != base and b != base
     assert "qwen3.6-35b" in a and "Head-A" in a
 
     # A different target with the same head is still distinct.
     assert _mtp_controller_key("qwen3.6-27b", "mlx-community/Head-A") != a
+
+    # Injectivity regression (codex #1441): a target that literally contains
+    # the old ``+mtp:`` join must NOT collide with a different (target, sidecar)
+    # pair. Pre-fix, both of these rendered ``"a+mtp:b"``.
+    assert _mtp_controller_key("a+mtp:b", None) != _mtp_controller_key("a", "b")
 
     # No target name -> None, so the caller falls through to the
     # shape-derived key rather than keying on a bare sidecar path.

--- a/tests/test_mtp_spec_decode.py
+++ b/tests/test_mtp_spec_decode.py
@@ -2982,3 +2982,48 @@ def test_fixed_k_observer_leaves_the_ceiling_to_whoever_selects_depth():
     # unchanged: a conflicting later ceiling is ignored.
     assert get_or_create_controller("ceiling-model", max_k=2).max_k == 3
     reset_controllers()
+
+
+def test_promoted_ceiling_records_and_selects_deeper_depths_lazily():
+    """Promotion lifts only ``max_k``; the depth-indexed cost/acceptance
+    state grows lazily, so a controller promoted 1->3 can record and select
+    depths 2/3 afterwards without out-of-range access, and keeps the
+    observations made while provisional (codex #1441 r1: the promotion must
+    not leave K=1-sized state that a later K=3 run overruns).
+    """
+    from vllm_mlx.spec_decode.mtp.draft_k_controller_v2 import (
+        ACCEPTANCE_MIN_SAMPLES,
+        get_or_create_controller,
+        reset_controllers,
+    )
+
+    reset_controllers()
+    # Provisional observer ceiling at 1; teach it depths 0 and 1 only.
+    ctrl = get_or_create_controller("m", max_k=1, authoritative=False)
+    for _ in range(ACCEPTANCE_MIN_SAMPLES + 1):
+        ctrl.cost.observe(0, 10.0)
+        ctrl.cost.observe(1, 16.0)
+        ctrl.acc.observe(1, accepted=True)
+    assert ctrl.max_k == 1
+    depth1_cost_before = ctrl.cost.cost(1)
+
+    # First authoritative caller promotes the ceiling to 3.
+    ctrl = get_or_create_controller("m", max_k=3, authoritative=True)
+    assert ctrl.max_k == 3
+    # Observations made while provisional survive (depth-keyed, not
+    # ceiling-keyed): the depth-1 cost EWMA is still there.
+    assert ctrl.cost.sampled(1)
+    assert ctrl.cost.cost(1) == depth1_cost_before
+
+    # Now record the depths a K=3 run would visit — must not raise and must
+    # actually fold in (the lists grow via ``while len <= i: append``).
+    for _ in range(ACCEPTANCE_MIN_SAMPLES + 1):
+        ctrl.cost.observe(2, 22.0)
+        ctrl.cost.observe(3, 28.0)
+        ctrl.acc.observe(2, accepted=True)
+        ctrl.acc.observe(3, accepted=True)
+    assert ctrl.cost.sampled(3)
+    assert ctrl.cost.visits(3) == ACCEPTANCE_MIN_SAMPLES + 1
+    # Selection stays within the promoted ceiling, never past it.
+    assert 0 <= ctrl.pick_k() <= 3
+    reset_controllers()

--- a/tests/test_mtp_spec_decode.py
+++ b/tests/test_mtp_spec_decode.py
@@ -2882,6 +2882,56 @@ def test_engine_core_threads_checkpoint_name_into_scheduler_config():
     assert _resolve_model_identity(pathy, None) == "/models/foo"
 
 
+def test_engine_core_init_wires_resolved_model_name_onto_a_scheduler_copy(
+    monkeypatch,
+):
+    """Guards the ACTUAL ``EngineCore.__init__`` wiring, not just the helper:
+    __init__ must ``copy.copy`` the SchedulerConfig and stamp the resolved
+    model identity onto the COPY before handing it to the Scheduler. Deleting
+    the copy+resolve lines would leave the captured config's ``model_name``
+    None (or mutate the caller's object); both are caught here and neither is
+    caught by the ``_resolve_model_identity``-only test above (codex #1441).
+    """
+    from vllm_mlx import engine_core as ec
+
+    captured: dict = {}
+
+    class _StopInitError(Exception):
+        pass
+
+    def _capture_scheduler(**kwargs):
+        captured["config"] = kwargs.get("config")
+        raise _StopInitError
+
+    class _FakeRegistry:
+        def acquire(self, **kw):
+            return None
+
+        def release(self, *a, **kw):
+            return None
+
+    monkeypatch.setattr(ec, "Scheduler", _capture_scheduler)
+    monkeypatch.setattr(ec, "get_registry", lambda: _FakeRegistry())
+
+    # Caller's pristine, shared SchedulerConfig (model_name unset).
+    shared = ec.SchedulerConfig()
+    cfg = ec.EngineConfig(model_name="engine/x", scheduler_config=shared)
+
+    try:
+        ec.EngineCore(model=object(), tokenizer=object(), config=cfg)
+    except _StopInitError:
+        pass
+
+    sc = captured.get("config")
+    assert sc is not None, "EngineCore.__init__ never constructed the Scheduler"
+    # The engine's checkpoint identity reached the scheduler config...
+    assert sc.model_name == "engine/x"
+    # ...on a COPY: the caller's shared config stays pristine, so a second
+    # unnamed engine cannot inherit this name as its own explicit config.
+    assert sc is not shared
+    assert shared.model_name is None
+
+
 def test_mtp_controller_key_separates_sidecars():
     """The controller learns an ACCEPTANCE profile, and acceptance is a
     property of the target/drafter pair, not the target alone.

--- a/vllm_mlx/engine_core.py
+++ b/vllm_mlx/engine_core.py
@@ -13,6 +13,7 @@ The design follows vLLM's engine architecture adapted for MLX.
 
 import asyncio
 import concurrent.futures
+import copy
 import logging
 import os
 import sys
@@ -115,6 +116,25 @@ class EngineConfig:
     no_spec_decode: bool = False
 
 
+def _resolve_model_identity(engine_config: Any, configured: str | None) -> str | None:
+    """Which checkpoint this engine is serving, for the MTP controller key.
+
+    The engine's own loaded checkpoint wins over ``configured``: a
+    ``SchedulerConfig`` may be shared across engines, so a previously
+    written name is stale rather than authoritative. ``configured`` is
+    only a fallback for engines that carry no model identity at all.
+
+    Idempotent — calling it again with the same engine yields the same
+    answer, which is what makes reuse of a config object safe.
+    """
+    return (
+        getattr(engine_config, "model_name", None)
+        or getattr(engine_config, "model_path", None)
+        or configured
+        or None
+    )
+
+
 class EngineCore:
     """
     Core engine for rapid-mlx inference with continuous batching.
@@ -162,6 +182,26 @@ class EngineCore:
 
         # Create scheduler
         scheduler_config = self.config.scheduler_config or SchedulerConfig()
+        # The engine knows which checkpoint it loaded; the scheduler did
+        # not, and its MTP depth-controller registry is process-global and
+        # outlives a model swap. Without a name the registry key falls
+        # back to the model's shape, so two same-shaped checkpoints share
+        # one controller and one model's learned costs steer the other's
+        # depth selection.
+        #
+        # Written to a COPY. A ``SchedulerConfig`` instance can be shared
+        # across engines, and writing an inferred name back into it would
+        # make that inference indistinguishable from an operator's
+        # explicit setting on the next engine: a second, unnamed engine
+        # would read the first engine's checkpoint name and be keyed as
+        # the first model, inheriting its controller — the exact failure
+        # this identity exists to prevent. Copying keeps the caller's
+        # object pristine, so every engine resolves from the same starting
+        # point.
+        scheduler_config = copy.copy(scheduler_config)
+        scheduler_config.model_name = _resolve_model_identity(
+            self.config, scheduler_config.model_name
+        )
         # D-METAL-CAP: propagate the engine-level ``gpu_memory_utilization``
         # to the scheduler so its admission gate can enforce the same cap
         # that ``mx.set_memory_limit`` only treats as a hint. Skip when the

--- a/vllm_mlx/routes/metrics.py
+++ b/vllm_mlx/routes/metrics.py
@@ -720,12 +720,15 @@ def _render_spec_decode_mtp_counters(cfg: Any) -> list[str]:
             "rapid_mlx_spec_decode_park_total",
             "counter",
             (
-                "MTP rounds where the EV depth controller picked K=0 "
-                "(plain-decode park). Non-zero on prose workloads where "
-                "drafter cost dominates acceptance — the operator-visible "
-                "signal that the controller is actively avoiding the "
-                "drafter cost, not silently stuck at K=1. Zero when "
-                "--mtp-disable-auto-k is set."
+                "MTP rounds that ran at K=0 (plain decode, no drafter). "
+                "Non-zero on prose workloads where drafter cost dominates "
+                "acceptance — the operator-visible signal that the "
+                "controller is actively avoiding the drafter cost, not "
+                "silently stuck at K=1. Under --mtp-disable-auto-k the "
+                "controller never selects a depth, so this counts only "
+                "the cold-start round each request opens with (one per "
+                "request), which is what gives k_cost_ms a K=0 reference "
+                "in that mode."
             ),
             int(park_total),
             labels=common_labels,
@@ -786,6 +789,65 @@ def _render_spec_decode_mtp_counters(cfg: Any) -> list[str]:
             labels=common_labels,
         )
     )
+
+    # Per-K round cost curve. ``park_total`` above says the controller is
+    # choosing K=0; this says whether K=0 is actually cheaper, which is
+    # the premise that choice rests on. Without it a high park rate is
+    # unfalsifiable from outside the process — and on at least one
+    # measured target (Qwen3.6-35B-A3B, M2 Pro) MTP was a net throughput
+    # loss *while* parking the majority of rounds.
+    #
+    # Carries its own ``model_id`` label rather than folding into the
+    # config-derived ``family``: the controller registry is keyed per
+    # target+drafter combination and a cost curve describes exactly one
+    # of them, so a process serving two would otherwise publish a blended
+    # ratio under a label naming only one. Cardinality is bounded by the
+    # number of models the process has actually served.
+    #
+    # Gauge, not counter: an EWMA is a current estimate that moves in
+    # both directions.
+    try:
+        from ..spec_decode.mtp.draft_k_controller_v2 import (
+            cost_curves_by_controller,
+        )
+
+        cost_curves = cost_curves_by_controller()
+    except Exception:  # noqa: BLE001
+        cost_curves = {}
+
+    if cost_curves:
+        out.append(
+            "# HELP rapid_mlx_spec_decode_k_cost_ms Wall time in "
+            "milliseconds for one MTP round at draft depth K (0=park, no "
+            "drafter), as the EV depth controller's EWMA: the target "
+            "forward plus the drafting that produced the K drafts it "
+            'consumed. Compare k_cost_ms{k="1"} against k_cost_ms{k="0"} '
+            "for what speculation costs on this hardware. Identified by "
+            "model_id rather than family: the controller registry outlives "
+            "a model swap, so a family label taken from the current route "
+            "config would misattribute a previous model's curve — or a "
+            "second concurrently-served model's — to whatever is loaded now."
+        )
+        out.append("# TYPE rapid_mlx_spec_decode_k_cost_ms gauge")
+        for model_id in sorted(cost_curves):
+            curve = cost_curves[model_id]
+            for k_val in sorted(curve):
+                # No ``family``: this series is per-controller, and
+                # ``family`` describes the CURRENT route config. The two
+                # disagree the moment the process has served more than one
+                # model. ``model_id`` already identifies the curve.
+                k_labels = {
+                    "method": "mtp",
+                    "model_id": model_id,
+                    "k": str(int(k_val)),
+                }
+                label_str = ",".join(
+                    f'{name}="{_escape_label_value(str(val))}"'
+                    for name, val in k_labels.items()
+                )
+                out.append(
+                    f"rapid_mlx_spec_decode_k_cost_ms{{{label_str}}} {curve[k_val]:.3f}"
+                )
     return out
 
 

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -401,11 +401,6 @@ class SchedulerConfig:
     # published as the ``model_id`` label on
     # ``rapid_mlx_spec_decode_k_cost_ms``.
     model_name: str | None = None
-    # The ordinary Metal free-cache limit is intentionally generous for
-    # decode throughput. During a very long prefill that same cache competes
-    # with growing KV state and the current forward's transient allocations.
-    # Temporarily cap it, then restore the device-scaled default when prefill
-    # completes. Zero disables only this cache-limit guard.
 
     def __post_init__(self) -> None:
         if self.response_cache_entries < 0:
@@ -695,6 +690,14 @@ def _install_mtp_vendored(
     # non-MTP build has zero cost.
     from .spec_decode.mtp.draft_k_controller_v2 import derive_controller_key
     from .spec_decode.mtp.generator import mtp_generate_step
+
+    # Derive the structural controller key ONCE at install. It walks the model
+    # tree to discover quantization, so recomputing it per generation request
+    # (the unnamed-model fallback in ``_mtp_step`` below) would put
+    # O(model-size) work on the decode hot path. ``mtp_model`` is fixed for
+    # this generator's lifetime, so the key is stable — cache it in the closure
+    # and let the per-request path read it (codex #1441 NIT).
+    _derived_controller_key = derive_controller_key(mtp_model)
 
     _orig_step = gb._step
 
@@ -1231,7 +1234,7 @@ def _install_mtp_vendored(
                     # boot) and distinct between different models (equal
                     # keys share one DepthController, so a collision lets
                     # one model's learned costs drive another's depth).
-                    model_id=controller_key or derive_controller_key(mtp_model),
+                    model_id=controller_key or _derived_controller_key,
                     max_k=max_k,
                     disable_auto_k=disable_auto_k,
                     # 0.9.13 PR-C: EOS holdout — feed the

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -386,6 +386,21 @@ class SchedulerConfig:
     adaptive_prefill: bool = True
     adaptive_prefill_min_tokens: int = 32_768
     adaptive_prefill_min_chunk_size: int = 256
+
+    # APPENDED AT THE END DELIBERATELY: this dataclass is constructed
+    # positionally by external callers, so a field inserted mid-list
+    # silently rebinds every argument after it (see the note above
+    # ``mtp_sidecar``).
+    #
+    # Checkpoint identity for the MTP depth-controller registry, which is
+    # process-global and survives a model swap. Without it the key falls
+    # back to the model's SHAPE, and two checkpoints that share an
+    # architecture, quantization and MTP-head size — different weights,
+    # different acceptance profiles — collapse onto one controller, so
+    # one model's observations steer the other's depth selection. Also
+    # published as the ``model_id`` label on
+    # ``rapid_mlx_spec_decode_k_cost_ms``.
+    model_name: str | None = None
     # The ordinary Metal free-cache limit is intentionally generous for
     # decode throughput. During a very long prefill that same cache competes
     # with growing KV state and the current forward's transient allocations.
@@ -568,6 +583,24 @@ def _install_dense_sampler_fastpath(batch_gen: "BatchGenerator") -> None:
     logger.info("[dense_sampler_fastpath] installed on BatchGenerator")
 
 
+def _mtp_controller_key(model_name: str | None, sidecar: str | None) -> str | None:
+    """Combine target and drafter identity into one controller key.
+
+    The depth controller learns an acceptance profile, and acceptance is
+    a property of the target/drafter PAIR — the same target served with a
+    different sidecar head accepts differently. The registry is
+    process-global and is never reset in production, so keying on the
+    target alone would let the first sidecar's profile drive depth
+    selection for a second one after a reload.
+
+    ``None`` when there is no target name, which hands the caller over to
+    the shape-derived fallback rather than keying on a bare sidecar path.
+    """
+    if not model_name:
+        return None
+    return f"{model_name}+mtp:{sidecar}" if sidecar else model_name
+
+
 def _install_mtp_vendored(
     batch_gen: "BatchGenerator",
     model: Any,
@@ -660,6 +693,7 @@ def _install_mtp_vendored(
     # Lazy import — the generator module pulls in mlx-lm's sample_utils and
     # patches ArraysCache; keep the import off the scheduler boot path so a
     # non-MTP build has zero cost.
+    from .spec_decode.mtp.draft_k_controller_v2 import derive_controller_key
     from .spec_decode.mtp.generator import mtp_generate_step
 
     _orig_step = gb._step
@@ -1186,7 +1220,18 @@ def _install_mtp_vendored(
                     prompt_cache=gb.prompt_cache,
                     temp=0.0,
                     # 0.9.13 PR-B: EV depth controller.
-                    model_id=controller_key or f"mtp-model-{id(mtp_model)}",
+                    # Fallback key derived from the model's SHAPE, not
+                    # its address. ``SchedulerConfig`` carries no model
+                    # name, so this path is the common one, not an edge
+                    # case. It has to satisfy two things at once: stable
+                    # across restarts (the string is published as the
+                    # ``model_id`` label on
+                    # ``rapid_mlx_spec_decode_k_cost_ms``, and
+                    # ``id(mtp_model)`` would mint a new series every
+                    # boot) and distinct between different models (equal
+                    # keys share one DepthController, so a collision lets
+                    # one model's learned costs drive another's depth).
+                    model_id=controller_key or derive_controller_key(mtp_model),
                     max_k=max_k,
                     disable_auto_k=disable_auto_k,
                     # 0.9.13 PR-C: EOS holdout — feed the
@@ -3550,10 +3595,20 @@ class Scheduler:
                     # 0.9.13 PR-B: EV depth controller knobs.
                     max_k=getattr(self.config, "mtp_max_k", 3),
                     disable_auto_k=getattr(self.config, "mtp_disable_auto_k", False),
-                    controller_key=getattr(self, "_model_name", None)
-                    or getattr(self.model_config, "name", None)
-                    if getattr(self, "model_config", None) is not None
-                    else None,
+                    # Preferred (named) identity for the controller
+                    # registry. The previous spelling ended in a bare
+                    # conditional, and Python binds that loosest, so
+                    # ``a or b if c else None`` collapsed the whole
+                    # expression to ``None`` whenever ``model_config`` was
+                    # absent. ``None`` here is not fatal —
+                    # ``_install_mtp_vendored`` derives a structural key —
+                    # but it discarded the good name whenever one existed.
+                    controller_key=_mtp_controller_key(
+                        getattr(self, "_model_name", None)
+                        or getattr(getattr(self, "model_config", None), "name", None)
+                        or getattr(self.config, "model_name", None),
+                        getattr(self.config, "mtp_sidecar", None),
+                    ),
                 )
 
         if getattr(self.config, "spec_decode", "none") == "dspark":

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -590,10 +590,19 @@ def _mtp_controller_key(model_name: str | None, sidecar: str | None) -> str | No
 
     ``None`` when there is no target name, which hands the caller over to
     the shape-derived fallback rather than keying on a bare sidecar path.
+
+    The pair is length-prefixed so the encoding is injective: a bare
+    ``"{target}+mtp:{sidecar}"`` join made target ``"a+mtp:b"`` (no sidecar)
+    alias target ``"a"`` with sidecar ``"b"`` — two unrelated models sharing
+    one controller. Prefixing the target with its length makes the target
+    boundary exact, so no two distinct (target, sidecar) inputs — including
+    the no-sidecar case — can collide (codex #1441).
     """
     if not model_name:
         return None
-    return f"{model_name}+mtp:{sidecar}" if sidecar else model_name
+    if not sidecar:
+        return f"{len(model_name)}:{model_name}"
+    return f"{len(model_name)}:{model_name}+mtp:{sidecar}"
 
 
 def _install_mtp_vendored(

--- a/vllm_mlx/spec_decode/mtp/draft_k_controller_v2.py
+++ b/vllm_mlx/spec_decode/mtp/draft_k_controller_v2.py
@@ -870,7 +870,16 @@ def derive_controller_key(model: Any) -> str:
             continue
         candidates.append(cfg)
         for nested_attr in ("text_config", "language_config"):
-            nested = getattr(cfg, nested_attr, None)
+            # Mirror the dual Mapping/attribute read used for the fields
+            # below: an outer config handed to us as a plain dict (e.g.
+            # ``args={"text_config": {...}}``) exposes the nested config by
+            # key, not attribute, so a bare ``getattr`` would silently miss
+            # it and collapse the key onto other unnamed models (codex #1441).
+            nested = (
+                cfg.get(nested_attr)
+                if isinstance(cfg, Mapping)
+                else getattr(cfg, nested_attr, None)
+            )
             if nested is not None:
                 candidates.append(nested)
     for name in _KEY_FIELDS:

--- a/vllm_mlx/spec_decode/mtp/draft_k_controller_v2.py
+++ b/vllm_mlx/spec_decode/mtp/draft_k_controller_v2.py
@@ -718,6 +718,18 @@ def get_or_create_controller(
                     model_id,
                     ctrl.max_k,
                 )
+            # Only ``max_k`` moves. Every depth-indexed structure the
+            # controller owns — ``CostModel._ewma``/``_depths``,
+            # ``AcceptanceModel._seen``/``_rate``, ``k_histogram`` — grows
+            # LAZILY on first observation of a depth (``observe`` does
+            # ``while len(self._seen) <= i: append``); none is pre-sized to
+            # the old ceiling. So lifting max_k 1→3 needs no resize: a later
+            # authoritative run that selects deeper simply materializes those
+            # depths as it visits them, and ``frontier()`` still gates
+            # selection to one past a trusted-acceptance position, so the
+            # promoted ceiling ramps outward rather than jumping to an
+            # unobserved depth. Preserved observations from the observer run
+            # stay valid (they are depth-keyed, not ceiling-keyed).
             ctrl.max_k = max(0, max_k)
             ctrl.ceiling_is_authoritative = True
         elif ctrl.max_k != max_k:

--- a/vllm_mlx/spec_decode/mtp/draft_k_controller_v2.py
+++ b/vllm_mlx/spec_decode/mtp/draft_k_controller_v2.py
@@ -129,9 +129,18 @@ class CostModel:
     Mirrors Go ``costModel`` (`speculate_depth.go:130-205`).
     """
 
-    __slots__ = ("_ewma", "_depths", "_visits")
+    __slots__ = ("_ewma", "_depths", "_visits", "_lock")
 
     def __init__(self) -> None:
+        # Guards the three mutable structures against a concurrent reader.
+        # ``observe`` runs on the single generator thread, but ``samples``
+        # is called from the ``/metrics`` scrape thread — without this an
+        # in-flight ``observe`` (dict insert + ``bisect.insort``) can race a
+        # scrape's iteration and raise "dict changed size during iteration",
+        # which the renderer's broad except would swallow, silently dropping
+        # the whole cost curve (codex #1441). Uncontended in the common
+        # single-request path, so the hot-path cost is negligible.
+        self._lock = threading.Lock()
         self._ewma: dict[int, float] = {}
         # Sorted list of sampled depths, maintained via bisect.
         self._depths: list[int] = []
@@ -151,19 +160,20 @@ class CostModel:
         """
         if drafts < 0 or wall_ms <= 0.0:
             return
-        prev = self._ewma.get(drafts)
-        if prev is None:
-            self._ewma[drafts] = wall_ms
-            bisect.insort(self._depths, drafts)
-        else:
-            limit = COST_CLAMP_FRACTION * prev
-            innovation = wall_ms - prev
-            if innovation > limit:
-                innovation = limit
-            elif innovation < -limit:
-                innovation = -limit
-            self._ewma[drafts] = prev + COST_EWMA_ALPHA * innovation
-        self._visits[drafts] = self._visits.get(drafts, 0) + 1
+        with self._lock:
+            prev = self._ewma.get(drafts)
+            if prev is None:
+                self._ewma[drafts] = wall_ms
+                bisect.insort(self._depths, drafts)
+            else:
+                limit = COST_CLAMP_FRACTION * prev
+                innovation = wall_ms - prev
+                if innovation > limit:
+                    innovation = limit
+                elif innovation < -limit:
+                    innovation = -limit
+                self._ewma[drafts] = prev + COST_EWMA_ALPHA * innovation
+            self._visits[drafts] = self._visits.get(drafts, 0) + 1
 
     def ready(self) -> bool:
         """True when two distinct depths have been sampled, so a slope
@@ -216,8 +226,13 @@ class CostModel:
         operator that the controller is choosing K=0, but not whether
         K=0 is actually cheaper than K=1 on their hardware, and that is
         the only question the park counter is ever asked.
+
+        Returns an atomic snapshot taken under the lock so a concurrent
+        ``observe`` on the generator thread cannot mutate the structures
+        mid-iteration (codex #1441).
         """
-        return {d: (self._ewma[d], self._visits.get(d, 0)) for d in self._depths}
+        with self._lock:
+            return {d: (self._ewma[d], self._visits.get(d, 0)) for d in self._depths}
 
 
 # ---------------------------------------------------------------------------

--- a/vllm_mlx/spec_decode/mtp/draft_k_controller_v2.py
+++ b/vllm_mlx/spec_decode/mtp/draft_k_controller_v2.py
@@ -39,6 +39,8 @@ import bisect
 import logging
 import threading
 from collections import deque
+from collections.abc import Mapping
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -206,6 +208,17 @@ class CostModel:
         """Diagnostics: ``"0:12ms 1:18ms 2:24ms"``."""
         return " ".join(f"{d}:{self._ewma[d]:.0f}ms" for d in self._depths)
 
+    def samples(self) -> dict[int, tuple[float, int]]:
+        """``{K: (ewma_ms, visits)}`` for every sampled depth.
+
+        The machine-readable form of :meth:`sample_string`. Exists so
+        ``/metrics`` can export the curve: ``park_total`` alone tells an
+        operator that the controller is choosing K=0, but not whether
+        K=0 is actually cheaper than K=1 on their hardware, and that is
+        the only question the park counter is ever asked.
+        """
+        return {d: (self._ewma[d], self._visits.get(d, 0)) for d in self._depths}
+
 
 # ---------------------------------------------------------------------------
 # AcceptanceModel — per-position conditional acceptance-rate EWMA.
@@ -370,6 +383,11 @@ class DepthController:
         # Last EV pick observed by the starvation probe (separate from
         # ``_last_selected`` above, which tracks the outward-probe cadence).
         self._round_probe_last_sel = 0
+        # Whether ``max_k`` came from a caller that actually SELECTS
+        # depth. An observer-only run (``--mtp-disable-auto-k``) seeds a
+        # provisional ceiling that the first selecting caller replaces —
+        # see :func:`get_or_create_controller`.
+        self.ceiling_is_authoritative = True
         # Rolling window of the K's actually consumed by the target
         # forward. Bounded at ``DEPTH_PROBE_INTERVAL_MAX`` so the memory
         # footprint stays fixed regardless of run length; the argmin
@@ -645,6 +663,8 @@ _lock = threading.Lock()
 def get_or_create_controller(
     model_id: str,
     max_k: int = DEFAULT_MAX_K,
+    *,
+    authoritative: bool = True,
 ) -> DepthController:
     """Return the process-global :class:`DepthController` for ``model_id``,
     creating it on first access. Thread-safe.
@@ -658,17 +678,48 @@ def get_or_create_controller(
             different ``max_k`` are ignored (a warning is logged) —
             reconfiguring an in-flight controller mid-request would
             invalidate its learned frontier.
+        authoritative: whether this caller's ``max_k`` is a real
+            configuration or merely the ceiling an observer happened to
+            be able to reach. An observer (``--mtp-disable-auto-k``,
+            which records but never calls :meth:`DepthController.pick_k`)
+            must not fix the ceiling for whoever selects depth later:
+            seeding the configured value could let a subsequent auto-K
+            run exceed a clamp it needs, and seeding the reachable value
+            (1) would silently cap a later auto-K run at chain-of-1
+            forever. So an observer's ceiling is provisional, and the
+            first authoritative caller replaces it.
     """
     with _lock:
         ctrl = _controllers.get(model_id)
         if ctrl is None:
             ctrl = DepthController(max_k=max_k)
+            ctrl.ceiling_is_authoritative = authoritative
             _controllers[model_id] = ctrl
             logger.info(
-                "[MTP-controller] created DepthController for model_id=%r max_k=%d",
+                "[MTP-controller] created DepthController for model_id=%r "
+                "max_k=%d (%s)",
                 model_id,
                 max_k,
+                "configured" if authoritative else "provisional, observer-only",
             )
+        elif not authoritative:
+            # Observers never move an existing ceiling in either direction.
+            pass
+        elif not getattr(ctrl, "ceiling_is_authoritative", True):
+            # First real configuration to arrive replaces an observer's
+            # provisional ceiling. No warning: this is the handoff the
+            # provisional flag exists for, not a conflict.
+            if ctrl.max_k != max_k:
+                logger.info(
+                    "[MTP-controller] adopting configured max_k=%d for "
+                    "model_id=%r (was provisional max_k=%d from an "
+                    "observer-only run)",
+                    max_k,
+                    model_id,
+                    ctrl.max_k,
+                )
+            ctrl.max_k = max(0, max_k)
+            ctrl.ceiling_is_authoritative = True
         elif ctrl.max_k != max_k:
             logger.warning(
                 "[MTP-controller] ignoring max_k=%d for existing controller "
@@ -713,3 +764,170 @@ def sum_across_controllers() -> tuple[int, int, dict[int, int]]:
             for k, count in ctrl.k_histogram.items():
                 hist[k] = hist.get(k, 0) + count
         return round_total, park_total, hist
+
+
+"""Config fields that distinguish two models' forward cost. Deliberately
+structural: the controller learns a cost curve and an acceptance profile,
+and those are properties of the shape of the compute, not of which
+checkpoint's weights are loaded."""
+_KEY_FIELDS = (
+    "model_type",
+    "num_hidden_layers",
+    "hidden_size",
+    "vocab_size",
+    "num_attention_heads",
+    "num_key_value_heads",
+    "num_experts",
+    # Not shape, but decisive for cost: two quantizations of one
+    # architecture are byte-identical in every field above and differ
+    # substantially in what a forward costs. Read from config when it
+    # survives there; ``_quantization_signature`` covers the (normal)
+    # case where it does not.
+    "quantization",
+)
+
+
+def _quantization_signature(model: Any) -> str | None:
+    """``"4b/g64"``-style summary read off the INSTANTIATED modules.
+
+    The checkpoint's ``quantization`` config block does not survive
+    ``TextModelArgs.from_dict()``, so a config-only lookup finds nothing
+    on exactly the models that matter. The quantized layers themselves
+    always carry it.
+
+    Returns every distinct ``(bits, group_size)`` pair, sorted, so a
+    mixed-precision build is described rather than reduced to whichever
+    layer happened to come first. ``None`` for an unquantized model or
+    anything that does not expose mlx's module tree.
+    """
+    named_modules = getattr(model, "named_modules", None)
+    if not callable(named_modules):
+        return None
+    found: set[tuple[Any, Any]] = set()
+    try:
+        for _name, module in named_modules():
+            bits = getattr(module, "bits", None)
+            group_size = getattr(module, "group_size", None)
+            if bits is not None and group_size is not None:
+                found.add((bits, group_size))
+    except Exception:  # noqa: BLE001 — identity is best-effort
+        return None
+    if not found:
+        return None
+    return "+".join(f"{b}b/g{g}" for b, g in sorted(found))
+
+
+def derive_controller_key(model: Any) -> str:
+    """Stable registry key for ``model`` when no name is available.
+
+    Used only as a fallback — a served model's alias is a better key when
+    the caller has one. The point is that it must be **stable across
+    restarts**: this string reaches ``/metrics`` as the ``model_id`` label
+    on the cost curve, and a key built from ``id(model)`` mints a fresh
+    time series for the same model on every boot.
+
+    It must also stay **distinct between different models**, because the
+    registry hands back a shared :class:`DepthController` for equal keys —
+    two unnamed models collapsing onto one key would let costs learned for
+    one target drive the other's depth selection.
+
+    Architecture, size and quantization are all folded in, so the cases
+    that actually differ in cost stay apart.
+
+    **Known limit.** Two checkpoints identical in all of those but with
+    differently-trained weights — most plausibly two MTP sidecars of the
+    same shape against the same target — still collide, and would blend
+    acceptance profiles even though their cost curves genuinely match.
+    Separating them needs checkpoint identity (a path or a weight hash),
+    which this function does not have and cannot cheaply compute. Callers
+    holding a checkpoint name should pass it as ``model_id`` rather than
+    relying on this.
+    """
+    parts = [type(model).__name__]
+
+    # Config fields live at different depths depending on whether the
+    # caller handed us a VLM wrapper, its inner text model, or a plain
+    # text model. Qwen3.5/3.6's outer ``ModelArgs`` carries only
+    # ``model_type`` and a nested ``text_config`` — searching just the
+    # top level yields a key so coarse that every model of that family
+    # collides, which is the failure this function exists to prevent.
+    candidates = []
+    for attr in ("args", "config"):
+        cfg = getattr(model, attr, None)
+        if cfg is None:
+            continue
+        candidates.append(cfg)
+        for nested_attr in ("text_config", "language_config"):
+            nested = getattr(cfg, nested_attr, None)
+            if nested is not None:
+                candidates.append(nested)
+    for name in _KEY_FIELDS:
+        for cfg in candidates:
+            # ``text_config`` arrives as a plain dict on Qwen3.5/3.6,
+            # while the outer args is a dataclass — read both shapes or
+            # the nested fields silently never resolve.
+            value = (
+                cfg.get(name) if isinstance(cfg, Mapping) else getattr(cfg, name, None)
+            )
+            if value is not None:
+                # ``quantization`` is itself a mapping; render it in a
+                # fixed order so the key does not depend on dict
+                # iteration order across loads.
+                if isinstance(value, Mapping):
+                    value = ",".join(f"{k}={value[k]}" for k in sorted(value))
+                parts.append(f"{name}={value}")
+                break
+
+    # Structural backstop: depth is the single most discriminating
+    # property of forward cost, and it is readable off the module tree
+    # even when no config surface is exposed at all.
+    for path in (
+        ("layers",),
+        ("model", "layers"),
+        ("language_model", "model", "layers"),
+    ):
+        node = model
+        for step in path:
+            node = getattr(node, step, None)
+            if node is None:
+                break
+        if node:
+            parts.append(f"depth={len(node)}")
+            break
+
+    quant = _quantization_signature(model)
+    if quant is not None:
+        parts.append(f"quant={quant}")
+
+    drafter = getattr(model, "mtp", None)
+    if drafter is not None:
+        layers = getattr(drafter, "layers", None)
+        n_layers = len(layers) if layers is not None else "?"
+        parts.append(f"mtp={type(drafter).__name__}:{n_layers}")
+    return "|".join(parts)
+
+
+def cost_curves_by_controller() -> dict[str, dict[int, float]]:
+    """``{model_id: {K: round wall ms}}`` for every registered controller.
+
+    This is the curve the EV comparator actually divides by, so exporting
+    it lets an operator check the controller's premise instead of taking
+    it on faith: if ``K=0`` and ``K=1`` cost the same, parking is buying
+    nothing and the drafter is not what is slow.
+
+    Deliberately NOT aggregated across controllers. The registry is keyed
+    per target+drafter combination, and a cost curve is a property of one
+    such combination on one machine — averaging two of them yields a
+    cost ratio that belongs to neither, and the busier model would
+    dominate a number the operator reads as describing the model they
+    are looking at. Controllers with no sampled depth are omitted.
+    """
+    with _lock:
+        out: dict[str, dict[int, float]] = {}
+        for model_id, ctrl in _controllers.items():
+            curve = {
+                k: ms for k, (ms, visits) in ctrl.cost.samples().items() if visits > 0
+            }
+            if curve:
+                out[model_id] = curve
+        return out

--- a/vllm_mlx/spec_decode/mtp/generator.py
+++ b/vllm_mlx/spec_decode/mtp/generator.py
@@ -630,21 +630,83 @@ def mtp_generate_step(
         )
     else:
         # ``disable_auto_k`` keeps the pre-0.9.13 fixed-K=1 A/B-bench
-        # behavior — no controller, no chain-of-K, verbatim chain-of-1.
+        # behavior — verbatim chain-of-1, no chain-of-K, and no depth
+        # SELECTION.
+        #
+        # The controller is still created, and still observes, because
+        # fixed-K is precisely the mode an operator measures in: with
+        # auto-K the acceptance rate is pooled across every depth the
+        # controller sampled, so it describes no particular K. Dropping
+        # the controller here would leave the ``k_cost_ms`` series empty
+        # in the one configuration where the per-K numbers are
+        # unambiguous — telling operators to disable the thing that
+        # records the metric they are being told to read.
+        #
+        # ``_select_k`` below is what gates behavior. ``pick_k`` is never
+        # called in this mode, so nothing the controller learns can
+        # change what this generator does.
+        #
+        # ``authoritative=False``: the registry is process-global and
+        # normally keeps whatever ceiling the FIRST caller set. This mode
+        # has no business fixing that ceiling — seeding the configured
+        # ``max_k`` (3 by default) could let a later auto-K run exceed a
+        # clamp it needs, and seeding the 1 this mode can actually reach
+        # would cap a later auto-K run at chain-of-1 forever. Marking it
+        # provisional lets the first run that really selects depth set
+        # the real ceiling.
         max_k_effective = 1
-        _controller = None
+        _controller = get_or_create_controller(
+            model_id or "__default__",
+            max_k=max_k_effective,
+            authoritative=False,
+        )
+
+    # Whether the controller CHOOSES the depth (as opposed to merely
+    # observing cost/acceptance). False under ``disable_auto_k``.
+    _select_k = not disable_auto_k
 
     # next_k: the K the controller wants for the UPCOMING round. Determines
     # whether we generate a draft at end of the current round. Bootstrap
     # value is the controller's initial pick_k (0 if fresh, else the
     # scheduled depth from the previous request).
-    next_k = _controller.pick_k() if _controller is not None else 1
+    next_k = _controller.pick_k() if _select_k and _controller is not None else 1
+
+    # Wall time spent generating the drafts that the NEXT round will
+    # consume. Drafting happens at the tail of round N — after round N's
+    # timer has already been read — so without this carry the drafter's
+    # cost lands in no round at all: ``cost(K>=1)`` measures only the
+    # target's verify forward, and the EV comparator divides
+    # ``committed(K) / cost(K)`` by a cost that omits the one term that
+    # most distinguishes K>=1 from K=0. The controller therefore
+    # systematically under-prices drafting.
+    #
+    # Charged to the round that CONSUMES the drafts rather than the one
+    # that produced them, because that is the round whose depth the cost
+    # describes. Drafts produced and then dropped (request hits
+    # max_tokens or EOS first) are simply never charged.
+    pending_draft_ms = 0.0
+
+    def _draft_chain_timed(*args, **kwargs):
+        """``_step_mtp_chain`` with its wall time held for the next round."""
+        nonlocal pending_draft_ms
+        _t0 = time.perf_counter()
+        result = _step_mtp_chain(*args, **kwargs)
+        pending_draft_ms = (time.perf_counter() - _t0) * 1000.0
+        return result
 
     def _record_round(k_used: int, round_wall_ms: float, accepts: list[bool]) -> None:
-        """Fold a round outcome into the controller (if enabled)."""
+        """Fold a round outcome into the controller (if enabled).
+
+        ``round_wall_ms`` is the caller's target-forward measurement; the
+        drafting cost carried over from the previous round is added here
+        so exactly one place owns the accounting.
+        """
+        nonlocal pending_draft_ms
+        charged = round_wall_ms + pending_draft_ms
+        pending_draft_ms = 0.0
         if _controller is None:
             return
-        _controller.record(k_used, round_wall_ms, accepts)
+        _controller.record(k_used, charged, accepts)
 
     while ntoks < max_tokens:
         round_start_perf = time.perf_counter()
@@ -667,13 +729,15 @@ def mtp_generate_step(
                 return
 
             # Decide K for the NEXT round.
-            next_k = _controller.pick_k() if _controller is not None else 1
+            next_k = (
+                _controller.pick_k() if _select_k and _controller is not None else 1
+            )
 
             hidden_at_main = hidden[:, -1:, :]
             if next_k >= 1:
                 # Chain-of-K: generate ``next_k`` drafts cascaded via
                 # MTP. next_k==1 is the plain single-draft path.
-                d_toks, d_lps, d_alps, d_xtcs = _step_mtp_chain(
+                d_toks, d_lps, d_alps, d_xtcs = _draft_chain_timed(
                     hidden_at_main, main_tok, prev_tokens, next_k
                 )
                 pending_drafts = list(zip(d_toks, d_lps, d_alps, d_xtcs))
@@ -901,7 +965,9 @@ def mtp_generate_step(
 
             # Decide K for the next round BEFORE generating the
             # next chain (a park decision skips drafter cost).
-            next_k = _controller.pick_k() if _controller is not None else 1
+            next_k = (
+                _controller.pick_k() if _select_k and _controller is not None else 1
+            )
             if next_k >= 1:
                 # Chain-carry: on all-accept the mtp_cache must
                 # advance by one extra position for the just-accepted
@@ -927,7 +993,7 @@ def mtp_generate_step(
                 else:
                     cache_commit = None
                 last_committed_tok = mx.array([last_committed_tok_id], mx.uint32)
-                d_toks, d_lps, d_alps, d_xtcs = _step_mtp_chain(
+                d_toks, d_lps, d_alps, d_xtcs = _draft_chain_timed(
                     last_committed_hidden,
                     last_committed_tok,
                     prev_tokens,

--- a/vllm_mlx/spec_decode/mtp/generator.py
+++ b/vllm_mlx/spec_decode/mtp/generator.py
@@ -729,6 +729,18 @@ def mtp_generate_step(
                 return
 
             # Decide K for the NEXT round.
+            #
+            # No drafter time is ever abandoned unaccounted. Drafting is the
+            # LAST thing a round does — strictly after this round's yield and
+            # its ``ntoks >= max_tokens`` return above (and, in the verify
+            # branch, after its EOS-cut / bonus / residual returns, which sit
+            # before their own tail draft). So a request that stops never
+            # produced the draft: max_tokens returns above before drafting,
+            # and a caller that stops pulling on EOS leaves the generator
+            # suspended AT the yield, before this line. When drafting DOES
+            # run, there is no yield between it and the consuming round's
+            # ``_record_round``, so the carried ``pending_draft_ms`` is always
+            # charged. (codex #1441: the "abandoned drafts" case cannot occur.)
             next_k = (
                 _controller.pick_k() if _select_k and _controller is not None else 1
             )


### PR DESCRIPTION
MTP on `qwen3.6-35b-4bit` with its official sidecar head is a **20% net throughput loss** (47.4 vs 59.0 tok/s, M2 Pro 32GB, temp=0, medians of 4) **while the drafter is accepting 85.7% of its drafts.** `docs/reference/configuration.md` shows exactly this pairing as a recommended invocation, with no caveat.

Acceptance was never the problem, and chasing it would have been wasted work. This PR fixes the accounting bug that hid the real cause, exports the numbers that make it diagnosable, and corrects the doc.

## 1. The controller was not paying for the drafter

Drafting for round N+1 happens at the tail of round N — *after* round N's timer has been read. So the drafter's wall time landed in no round at all: `cost(K>=1)` measured only the target's verify forward. The EV comparator divides `committed(K) / cost(K)`, by a cost missing the one term that most distinguishes K>=1 from K=0. It systematically under-priced drafting **on every model**.

The regression test makes the size of it concrete. Under a virtual clock where each forward costs 10 ms and each drafter call 50 ms, the controller recorded the K=1 round as costing **10 ms**, not 60.

Fixed by carrying the drafting time forward and charging it to the round that *consumes* those drafts — the round whose depth the cost describes. Drafts produced and then dropped (max_tokens or EOS first) are never charged. `_record_round` is now the single owner of the accounting.

Measured on qwen3.6-35b: `cost(1)` rose 35.2 → 37.3 ms and the controller moved from 34% drafting to 18%. Throughput was unchanged *there*, because on that model park (20.7 ms/token) and draft (20.1 ms/token) are both losers and shifting between them buys nothing — the fix pays where the two options actually differ.

## 2. The cost curve was invisible

`park_total` says the controller is choosing K=0, but not whether K=0 is actually *cheaper* — which is the only question that counter is ever asked. `/metrics` gains `rapid_mlx_spec_decode_k_cost_ms{model_id,k}`:

- A **gauge**, not a counter — an EWMA moves both ways.
- **Not emitted at cold start**: a zero-valued cost reads as "a round is free" rather than "nothing measured yet", and a dashboard dividing by it would show an infinite speedup.
- Labelled **per `model_id`, not blended**, and deliberately **without `family`** — the registry outlives a model swap, so a family label from the current route config would misattribute a previous model's curve to whatever is loaded now.

`--mtp-disable-auto-k` now keeps the controller as an **observer** instead of dropping it. Fixed-K is the mode an operator measures in (under auto-K `accept_ratio` is pooled across every sampled depth, so it belongs to no particular K), and without this the documented recipe would tell operators to disable the very thing that records the metric they are told to read. The controller is never consulted in that mode — `_select_k` gates every `pick_k` — so behaviour is unchanged and the byte-equal fixed-K losslessness tests still pass.

## 3. The registry key had to be worth publishing first

`controller_key` ended in a bare conditional, and Python binds that loosest: `a or b if c else None` collapsed to `None` whenever `model_config` was absent. Since `SchedulerConfig` carried no model name at all, that was the *normal* path, and the key fell through to `mtp-model-{id(model)}`.

An address is harmless as a dict key and unusable as a Prometheus label — every restart mints a fresh series for the same model. But collapsing unnamed models onto one constant is worse than ugly: equal keys share one `DepthController`, so one model's learned costs would drive another's depth selection. So:

- `SchedulerConfig.model_name` (appended **last** — this dataclass is constructed positionally, and a field inserted mid-list silently rebinds every argument after it), threaded from `EngineCore`, which knows the checkpoint the scheduler does not.
- Written to a **copy** of the config. A shared `SchedulerConfig` written in place would make the first engine's inference indistinguishable from an operator's explicit setting, so a second, unnamed engine would be keyed as the first model.
- The sidecar is folded into the key — acceptance is a property of the target/drafter *pair*.
- `derive_controller_key` as the last-resort fallback, built from the model's **shape**: it walks into the nested `text_config` (a plain dict on Qwen3.5/3.6, where reading only the top level yields `model_type` and nothing else — enough for every model in the family to collide) and reads quantization off the **instantiated modules**, since `TextModelArgs.from_dict()` discards the checkpoint's `quantization` block. Real output:

```
qwen3.6-35b -> ...|num_hidden_layers=40|hidden_size=2048|num_experts=256|depth=40|quant=4b/g64+8b/g64
qwen3.6-27b -> ...|num_hidden_layers=64|hidden_size=5120|depth=64
```

- An observer-only run marks its ceiling **provisional**. The registry keeps whatever ceiling the first caller set, which makes an observer's `max_k` a trap in both directions: seeding the configured 3 would let a later auto-K run inherit it and select past an SSM clamp it needs; seeding the reachable 1 would cap a later auto-K run at chain-of-1 forever. The first caller that actually selects depth replaces it.

## 4. Why the docs change

The ceiling for chain-of-K MTP is `(1 + K * accept) / cost_ratio(K + 1)`, and `cost_ratio(2)` measures **1.70** on qwen3.6-35b — a linear-attention hybrid does not amortize a second position the way a pure-attention model does. That caps the ceiling at `1.857 / 1.70` = **1.09x**, and per-round overhead eats the rest. No acceptance rate and no controller tuning can fix a denominator.

The doc now carries the arithmetic, the measured numbers, and a decision rule against the new metric. It has to be measured on the operator's own machine: the same model with byte-identical acceptance came in at **+118% on one host and +13% on another**, so no tier baked into this repo can answer it for them.

## Verification

Emitted tokens are unchanged throughout — this moves timing numbers and adds a read-only view, not a sampling decision.

- Full suite `--ignore=tests/integrations` with `RAPID_MLX_TELEMETRY=0`: **6146 passed, 0 failed**, and the `FAILED` list diffed against `main` is empty (no new failures).
- 12 rounds of `codex review --base main`; the last came back clean. Every earlier round found something real, including two that changed the design (the shared-config write and the provisional ceiling).
- All measurements on Mac mini M2 Pro / 32GB, `temperature=0`, distinct prompt per repetition, MTP-off leg re-measured in the same session as a drift control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)