### PR TITLE
feat(models): serve LFM2.5-2.6B, whose eight quants share one repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,6 +169,8 @@ jobs:
             tests/test_telemetry_consent.py \
             tests/test_community_bench_upload.py \
             tests/test_music_engine.py \
+            tests/test_aliases_contract.py \
+            tests/test_alias_subfolder.py \
             -v --tb=short \
             -k "not Integration and not InjectJson and not TestMLXMultimodalLMCache" \
             --cov=vllm_mlx \

--- a/tests/test_alias_subfolder.py
+++ b/tests/test_alias_subfolder.py
@@ -1,0 +1,782 @@
+# SPDX-License-Identifier: Apache-2.0
+"""``subfolder``: one repo, one folder per quantization.
+
+Liquid AI ships ``LiquidAI/LFM2.5-2.6B-MLX`` as eight complete MLX
+checkpoints in sibling directories (``4bit/``, ``5bit/``, ``6bit/``,
+``8bit/``, ``bf16/``, ``mxfp4/``, ``mxfp8/``, ``nvfp4/``) instead of one
+repo per quant, and there is no flat conversion on the Hub. ``mlx_lm.load``
+has no subfolder parameter, so the repo id has to become a concrete
+directory somewhere. These tests pin *where* — and, just as importantly,
+pin that it does NOT happen anywhere else: the download gate, the R2
+mirror catalog, ``model_sizes`` and telemetry all key on the bare repo id.
+
+mlx-free by construction (no weights, no ``mlx`` import) so it runs on the
+Linux CI leg as well as Apple Silicon.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from vllm_mlx.model_aliases import (
+    _coerce,
+    resolve_model,
+    resolve_profile,
+    resolve_subfolder,
+    subfolder_allow_patterns,
+)
+from vllm_mlx.utils.tokenizer import _resolve_subfolder_checkpoint
+
+ALIAS = "lfm2.5-2.6b-4bit"
+REPO = "LiquidAI/LFM2.5-2.6B-MLX"
+
+
+# --------------------------------------------------------------------------
+# The shipped alias
+# --------------------------------------------------------------------------
+
+
+def test_alias_declares_the_4bit_subfolder():
+    profile = resolve_profile(ALIAS)
+    assert profile is not None, f"{ALIAS} missing from aliases.json"
+    assert profile.hf_path == REPO
+    assert profile.subfolder == "4bit"
+
+
+def test_hf_path_stays_a_bare_repo_id():
+    """The subfolder must NOT be folded into ``hf_path``.
+
+    ``resolve_model`` feeds the download gate, ``model_sizes``, the mirror
+    catalog and telemetry redaction — all of which treat the value as an
+    ``org/name`` repo id. A three-segment path would 404 against the HF
+    API and silently miss the mirror.
+    """
+    resolved = resolve_model(ALIAS)
+    assert resolved == REPO
+    assert resolved.count("/") == 1
+
+
+def test_most_aliases_have_no_subfolder():
+    """Guard against a copy-paste that pins a subfolder repo-wide."""
+    from vllm_mlx.model_aliases import list_profiles
+
+    with_subfolder = {
+        alias for alias, p in list_profiles().items() if p.subfolder is not None
+    }
+    assert with_subfolder == {ALIAS}, (
+        "A new subfolder alias landed without updating this test. That is "
+        "fine — but confirm the download path passes allow_patterns for it, "
+        "or the pull fetches every quant in the repo."
+    )
+
+
+# --------------------------------------------------------------------------
+# Schema validation — subfolder becomes a filesystem path, so it is
+# validated as a relative downward one at registry load.
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "/etc",  # absolute
+        "../../etc",  # escapes the snapshot
+        "4bit/../../../etc",  # escapes mid-path
+        "4bit\\weights",  # backslash separator
+        "C:/Users/x",  # drive-qualified — os.path.isabs is False on POSIX
+        "c:weights",  # drive-relative, same discard behaviour on Windows
+        # Legal relative paths, but the value is also spliced into an HF
+        # allow_patterns glob — each of these widens the download past the
+        # one folder the alias declares.
+        "4bit*",  # also matches 4bit-extra/, 4bitfoo/
+        "[48]bit",  # matches both 4bit/ and 8bit/
+        "**",  # the whole repo
+        "?bit",
+        "!4bit",
+        "4bit/",  # trailing slash → join produces a stray separator
+        "",  # empty
+        123,  # not a string
+    ],
+)
+def test_rejects_paths_that_leave_the_snapshot(bad):
+    with pytest.raises(ValueError, match="subfolder"):
+        _coerce("evil", {"hf_path": "org/repo", "subfolder": bad})
+
+
+@pytest.mark.parametrize("good", ["4bit", "mxfp4", "quants/4bit"])
+def test_accepts_a_relative_downward_path(good):
+    assert _coerce("ok", {"hf_path": "org/repo", "subfolder": good}).subfolder == good
+
+
+def test_absent_subfolder_is_none_not_empty_string():
+    """``None`` and ``""`` must not both mean "no subfolder" — the loader
+    branches on truthiness, but ``resolve_subfolder`` is also compared for
+    equality in the ambiguity guard."""
+    assert _coerce("plain", {"hf_path": "org/repo"}).subfolder is None
+
+
+# --------------------------------------------------------------------------
+# The ambiguity guard: two quants of one repo can't both be recovered
+# --------------------------------------------------------------------------
+
+
+def test_two_aliases_on_one_repo_with_different_subfolders_is_rejected():
+    """The loader recovers the subfolder by ``hf_path → first alias``.
+
+    Two aliases on one repo agree about every other profile field, so
+    "first wins" is harmless there. ``subfolder`` is the exception: 4-bit
+    and 8-bit legitimately disagree, and picking the first would serve the
+    wrong weights under the right name. Fail at registry load instead.
+    """
+    from vllm_mlx.model_aliases import _assert_subfolder_is_unambiguous
+
+    profiles = {
+        "m-4bit": _coerce("m-4bit", {"hf_path": REPO, "subfolder": "4bit"}),
+        "m-8bit": _coerce("m-8bit", {"hf_path": REPO, "subfolder": "8bit"}),
+    }
+    with pytest.raises(ValueError, match="different 'subfolder' values"):
+        _assert_subfolder_is_unambiguous(profiles)
+
+
+def test_two_aliases_on_one_repo_agreeing_is_fine():
+    from vllm_mlx.model_aliases import _assert_subfolder_is_unambiguous
+
+    profiles = {
+        "a": _coerce("a", {"hf_path": REPO, "subfolder": "4bit"}),
+        "b": _coerce("b", {"hf_path": REPO, "subfolder": "4bit"}),
+    }
+    _assert_subfolder_is_unambiguous(profiles)  # does not raise
+
+
+def test_shipped_registry_is_unambiguous():
+    """The real aliases.json, not a fixture."""
+    from vllm_mlx.model_aliases import _assert_subfolder_is_unambiguous, list_profiles
+
+    _assert_subfolder_is_unambiguous(list_profiles())
+
+
+# --------------------------------------------------------------------------
+# Reverse lookup — by the time the text lane loads, the alias the user
+# typed is long gone and only the resolved repo id remains.
+# --------------------------------------------------------------------------
+
+
+def test_subfolder_is_recoverable_from_the_resolved_repo_id():
+    assert resolve_subfolder(REPO) == "4bit"
+    assert resolve_subfolder(ALIAS) == "4bit"
+
+
+def test_unknown_and_flat_models_report_no_subfolder():
+    assert resolve_subfolder("mlx-community/LFM2.5-8B-A1B-MLX-4bit") is None
+    assert resolve_subfolder("some/model-nobody-registered") is None
+
+
+# --------------------------------------------------------------------------
+# Download filtering — the whole point of the field is not paying for the
+# seven quants you didn't ask for.
+# --------------------------------------------------------------------------
+
+
+def test_allow_patterns_fetch_only_the_declared_folder():
+    assert subfolder_allow_patterns(ALIAS) == ["4bit/*"]
+    assert subfolder_allow_patterns(REPO) == ["4bit/*"]
+
+
+def test_allow_patterns_is_none_for_flat_repos():
+    """``None``, not ``["*"]`` — callers branch on it to keep the
+    historical single-argument ``snapshot_download(repo)`` call shape."""
+    assert subfolder_allow_patterns("mlx-community/LFM2.5-8B-A1B-MLX-4bit") is None
+
+
+def test_allow_pattern_prefix_matches_the_real_repo_layout():
+    """The pattern is also sliced to a prefix for the size estimate; a
+    ``4bit/*`` glob and a ``4bit/`` prefix must select the same files."""
+    patterns = subfolder_allow_patterns(ALIAS)
+    prefix = patterns[0][:-1]
+    assert prefix == "4bit/"
+    for name in ("4bit/config.json", "4bit/model.safetensors"):
+        assert name.startswith(prefix)
+    for name in ("8bit/model.safetensors", "README.md", "bf16/config.json"):
+        assert not name.startswith(prefix)
+
+
+# --------------------------------------------------------------------------
+# The load-time join — the one place a repo id becomes a directory.
+# --------------------------------------------------------------------------
+
+
+def test_flat_repo_id_passes_through_untouched():
+    name = "mlx-community/LFM2.5-8B-A1B-MLX-4bit"
+    assert _resolve_subfolder_checkpoint(name) == name
+
+
+def test_local_path_passes_through_even_if_its_name_matches_an_alias(
+    tmp_path, monkeypatch
+):
+    """A local checkpoint directory is already the thing to load. Deriving
+    a subfolder for it from a reverse alias lookup would append a folder
+    that isn't there.
+
+    The directory is named EXACTLY the alias and referred to by that
+    relative name, so the registry lookup genuinely fires and only the
+    ``os.path.exists`` guard can save it. A tmp path that matches no alias
+    would pass with the guard deleted, testing nothing.
+    """
+    local = tmp_path / ALIAS
+    local.mkdir()
+    (local / "config.json").write_text("{}")
+    monkeypatch.chdir(tmp_path)
+
+    assert resolve_subfolder(ALIAS) == "4bit", "precondition: name IS an alias"
+    assert os.path.exists(ALIAS), "precondition: it is also a real directory"
+    assert _resolve_subfolder_checkpoint(ALIAS) == ALIAS
+
+
+def test_joins_the_subfolder_onto_the_snapshot(monkeypatch, tmp_path):
+    snapshot = tmp_path / "snapshots" / "deadbeef"
+    (snapshot / "4bit").mkdir(parents=True)
+    (snapshot / "4bit" / "config.json").write_text("{}")
+    # Complete checkpoint: the returned directory is validated against
+    # mlx-lm's own ``model*.safetensors`` glob before it is handed over.
+    (snapshot / "4bit" / "model.safetensors").write_bytes(b"\x00" * 16)
+
+    seen: dict[str, object] = {}
+
+    def fake_snapshot_download(repo_id, **kwargs):
+        seen["repo_id"] = repo_id
+        seen["allow_patterns"] = kwargs.get("allow_patterns")
+        return str(snapshot)
+
+    import huggingface_hub
+
+    monkeypatch.setattr(huggingface_hub, "snapshot_download", fake_snapshot_download)
+
+    out = _resolve_subfolder_checkpoint(REPO)
+
+    assert out == os.path.join(str(snapshot), "4bit")
+    assert seen["repo_id"] == REPO, "must download the repo, not repo/subfolder"
+    assert seen["allow_patterns"] == ["4bit/*"], (
+        "without the filter this pulls all eight quantizations (~20 GB)"
+    )
+    assert json.loads(Path(out, "config.json").read_text()) == {}
+
+
+def test_download_failure_raises_instead_of_returning_the_repo_id(monkeypatch):
+    """Returning the bare repo id would send mlx-lm to its own UNFILTERED
+    snapshot_download: the user waits out ~20 GB and then fails anyway,
+    because the repo root is not a checkpoint. Fail immediately instead."""
+    import huggingface_hub
+
+    def boom(repo_id, **kwargs):
+        raise OSError("no network")
+
+    monkeypatch.setattr(huggingface_hub, "snapshot_download", boom)
+    with pytest.raises(RuntimeError, match="not in the local cache"):
+        _resolve_subfolder_checkpoint(REPO)
+
+
+def test_offline_with_a_warm_cache_still_loads(monkeypatch, tmp_path):
+    """The strict error above must not brick a machine that already has
+    the checkpoint on disk — retry the cache before giving up."""
+    import huggingface_hub
+
+    snapshot = tmp_path / "snap"
+    ckpt = snapshot / "4bit"
+    ckpt.mkdir(parents=True)
+    # A real cached checkpoint, not just an empty directory — an empty one
+    # would satisfy the isdir() check while being unloadable, so the test
+    # would pass on a path that cannot actually serve.
+    (ckpt / "config.json").write_text('{"model_type": "lfm2"}')
+    (ckpt / "model.safetensors").write_bytes(b"\x00" * 16)
+
+    calls: list[bool] = []
+
+    def offline_then_cache(repo_id, **kwargs):
+        local_only = kwargs.get("local_files_only", False)
+        calls.append(local_only)
+        if not local_only:
+            raise OSError("no network")
+        return str(snapshot)
+
+    monkeypatch.setattr(huggingface_hub, "snapshot_download", offline_then_cache)
+
+    resolved = _resolve_subfolder_checkpoint(REPO)
+    assert resolved == str(ckpt)
+    assert calls == [False, True], "must try the network first, then the cache"
+    # What the loader is handed must be openable: mlx-lm globs
+    # ``model*.safetensors`` at the directory it is given, non-recursively.
+    assert Path(resolved, "config.json").exists()
+    assert list(Path(resolved).glob("model*.safetensors")), (
+        "the returned directory must be where mlx-lm's loader glob will hit"
+    )
+
+
+def test_flat_repos_are_untouched_by_the_strict_path(monkeypatch):
+    """The strictness applies only to subfolder aliases — a flat repo must
+    never reach snapshot_download here at all."""
+    import huggingface_hub
+
+    def tripwire(repo_id, **kwargs):
+        raise AssertionError("flat repo must not be downloaded by this helper")
+
+    monkeypatch.setattr(huggingface_hub, "snapshot_download", tripwire)
+    name = "mlx-community/LFM2.5-8B-A1B-MLX-4bit"
+    assert _resolve_subfolder_checkpoint(name) == name
+
+
+def test_missing_subfolder_after_download_raises(monkeypatch, tmp_path):
+    """Publisher renamed or dropped the folder. Say so — silently loading
+    the repo root would either fail obscurely or, worse, succeed against
+    some other checkpoint that happens to sit there."""
+    snapshot = tmp_path / "snap"
+    snapshot.mkdir()
+
+    import huggingface_hub
+
+    monkeypatch.setattr(
+        huggingface_hub, "snapshot_download", lambda repo_id, **kw: str(snapshot)
+    )
+    with pytest.raises(RuntimeError, match="reorganized the repo"):
+        _resolve_subfolder_checkpoint(REPO)
+
+
+# --------------------------------------------------------------------------
+# Everything that reaches INTO the checkpoint. Each of these was found by
+# running ``rapid-mlx serve lfm2.5-2.6b-4bit`` and watching it fail a
+# different way — the unit tests above all passed while the command was
+# still unusable, so these pin the specific symptoms.
+# --------------------------------------------------------------------------
+
+
+def test_prefix_is_empty_for_flat_repos_so_callers_can_prepend_blindly():
+    from vllm_mlx.model_aliases import checkpoint_prefix
+
+    assert checkpoint_prefix(REPO) == "4bit/"
+    assert checkpoint_prefix("mlx-community/LFM2.5-8B-A1B-MLX-4bit") == ""
+    assert checkpoint_prefix("nobody/registered-this") == ""
+    # The whole point of "" over None: ``f"{prefix}config.json"`` is
+    # correct for both kinds of repo with no branch at the call site.
+    assert f"{checkpoint_prefix('nobody/registered-this')}config.json" == "config.json"
+
+
+def test_metadata_read_looks_inside_the_checkpoint(monkeypatch, tmp_path):
+    """Symptom: ``Could not materialize the checkpoint config ... before
+    selecting the serving lane`` — a hard startup failure. ``config.json``
+    is at ``4bit/config.json``, so the root probe found nothing and the
+    MLLM-vs-text routing had no evidence to work from."""
+    import vllm_mlx.model_metadata as mm
+
+    snapshot = tmp_path / "snapshots" / "cafe"
+    (snapshot / "4bit").mkdir(parents=True)
+    (snapshot / "4bit" / "config.json").write_text('{"model_type": "lfm2"}')
+
+    asked: list[str] = []
+
+    def fake_cached(repo_id, filename, **kwargs):
+        asked.append(filename)
+        target = snapshot / filename
+        return target if target.exists() else None
+
+    monkeypatch.setattr(mm, "_cached_file", lambda name, fn: fake_cached(name, fn))
+
+    meta = mm.read_cached_model_metadata(REPO)
+
+    assert asked[0] == "4bit/config.json", (
+        f"probed {asked[0]!r} — the repo root has no config.json"
+    )
+    assert meta is not None
+    assert meta.config == {"model_type": "lfm2"}
+    assert meta.snapshot_dir.name == "4bit", (
+        "snapshot_dir must be the checkpoint directory, not the repo root — "
+        "everything downstream resolves sibling files against it"
+    )
+
+
+def test_size_estimate_counts_only_the_alias_checkpoint(monkeypatch):
+    """Symptom: ``Estimated size: 18.7 GiB`` on a 1.6 GB model, then a
+    kernel-panic warning and a confirm prompt. The repo holds eight
+    complete quantizations; seven of them are not being downloaded."""
+    import vllm_mlx._download_gate as gate
+
+    class Sib:
+        def __init__(self, name, size):
+            self.rfilename, self.size, self.lfs = name, size, None
+
+    info = type(
+        "Info",
+        (),
+        {
+            "siblings": [
+                Sib("4bit/model.safetensors", 1_583_152_892),
+                Sib("4bit/config.json", 2202),
+                Sib("8bit/model.safetensors", 2_866_086_056),
+                Sib("bf16/model-00001-of-00002.safetensors", 5_329_406_264),
+                Sib("README.md", 2804),
+            ]
+        },
+    )()
+    monkeypatch.setattr(gate, "_model_info_with_timeout", lambda r, t: info)
+
+    total = gate.estimate_repo_size_bytes(REPO)
+    assert total == 1_583_152_892 + 2202
+    assert total < 2 * 1024**3, "must not sum the repo's other quantizations"
+
+
+def test_size_estimate_unchanged_for_flat_repos(monkeypatch):
+    import vllm_mlx._download_gate as gate
+
+    class Sib:
+        def __init__(self, name, size):
+            self.rfilename, self.size, self.lfs = name, size, None
+
+    info = type(
+        "Info",
+        (),
+        {"siblings": [Sib("model.safetensors", 100), Sib("config.json", 5)]},
+    )()
+    monkeypatch.setattr(gate, "_model_info_with_timeout", lambda r, t: info)
+    assert gate.estimate_repo_size_bytes("mlx-community/LFM2.5-8B-A1B-MLX-4bit") == 105
+
+
+def test_cache_probe_descends_before_asking_if_complete(tmp_path):
+    """Symptom: the download gate re-prompts on every serve because a
+    fully-cached checkpoint reads as absent — ``model*.safetensors`` is
+    inside ``4bit/``, and the loader glob is non-recursive."""
+    from vllm_mlx._download_gate import _descend_to_checkpoint
+
+    snap = tmp_path / "sha"
+    (snap / "4bit").mkdir(parents=True)
+    assert _descend_to_checkpoint(str(snap), REPO) == str(snap / "4bit")
+    # Flat repo: identity.
+    assert _descend_to_checkpoint(
+        str(snap), "mlx-community/LFM2.5-8B-A1B-MLX-4bit"
+    ) == str(snap)
+
+
+def test_cache_probe_does_not_invent_a_directory(tmp_path):
+    """Publisher reorganised the repo: report the root (which will then
+    read as incomplete) rather than a path that does not exist."""
+    from vllm_mlx._download_gate import _descend_to_checkpoint
+
+    snap = tmp_path / "sha"
+    snap.mkdir()
+    assert _descend_to_checkpoint(str(snap), REPO) == str(snap)
+
+
+def test_mirror_declines_subfolder_repos(monkeypatch):
+    """The R2 mirror hydrates whole repos and has no per-folder mode.
+
+    Letting it run on a subfolder repo would pull all eight quantizations
+    behind a progress bar that says "Pulling LiquidAI/LFM2.5-2.6B-MLX".
+    None of these repos is mirrored today; this guard is what keeps
+    mirroring one later from silently reintroducing the 20 GB pull.
+    """
+    import vllm_mlx.cli as cli
+
+    called: list[str] = []
+
+    def tripwire(*a, **kw):
+        called.append("mirror ran")
+        return True
+
+    import vllm_mlx._mirror as mirror
+
+    monkeypatch.setattr(mirror, "download_with_mirror_fallback", tripwire)
+
+    assert cli._try_mirror_prefetch(REPO) is False
+    assert called == [], "mirror must not be consulted for a subfolder repo"
+
+    # Control: a flat repo still goes through the mirror.
+    assert cli._try_mirror_prefetch("mlx-community/LFM2.5-8B-A1B-MLX-4bit") is True
+    assert called == ["mirror ran"]
+
+
+def test_registry_fails_closed_on_every_load_not_just_the_first(monkeypatch):
+    """A caught validation error must not leave a usable registry behind.
+
+    ``_load`` memoizes into module globals. Publishing before validating
+    meant the first call raised, the caller caught it, and every call
+    after that hit the memoized fast path and happily used the registry
+    the assertion had just rejected — fail-open after a single swallowed
+    exception.
+    """
+    import json as _json
+
+    import vllm_mlx.model_aliases as ma
+
+    ambiguous = {
+        "m-4bit": {"hf_path": REPO, "subfolder": "4bit"},
+        "m-8bit": {"hf_path": REPO, "subfolder": "8bit"},
+    }
+    monkeypatch.setattr(ma, "_aliases", None)
+    monkeypatch.setattr(ma, "_hf_to_alias", None)
+    monkeypatch.setattr(_json, "load", lambda fh: ambiguous)
+
+    for attempt in range(3):
+        with pytest.raises(ValueError, match="different 'subfolder' values"):
+            ma._load()
+        assert ma._aliases is None, (
+            f"attempt {attempt}: registry was published despite failing validation"
+        )
+
+
+def test_subfolder_cannot_widen_the_download_glob():
+    """The field's promise is "only this folder". A subfolder that is a
+    legal path but an active glob quietly breaks that promise — and it is
+    the download filter, not the path join, where it does damage."""
+    import fnmatch
+
+    patterns = subfolder_allow_patterns(ALIAS)
+    assert patterns == ["4bit/*"]
+    for other in ("8bit/model.safetensors", "bf16/config.json", "README.md"):
+        assert not fnmatch.fnmatch(other, patterns[0]), (
+            f"{other} must not match the 4-bit alias's allow_patterns"
+        )
+
+
+def test_alias_spelling_downloads_the_repo_not_the_alias(monkeypatch, tmp_path):
+    """``server.load_model`` is a public entry point: a programmatic caller
+    reaches it with the bare alias, skipping the CLI's pre-resolution.
+    ``resolve_subfolder`` answers for both spellings, so the subfolder is
+    detected either way — but the Hub only knows the repo id, and asking it
+    for "lfm2.5-2.6b-4bit" is a 404."""
+    import huggingface_hub
+
+    snapshot = tmp_path / "snap"
+    ckpt = snapshot / "4bit"
+    ckpt.mkdir(parents=True)
+    (ckpt / "config.json").write_text("{}")
+    (ckpt / "model.safetensors").write_bytes(b"\x00" * 16)
+    asked: list[str] = []
+
+    def fake(repo_id, **kwargs):
+        asked.append(repo_id)
+        return str(snapshot)
+
+    monkeypatch.setattr(huggingface_hub, "snapshot_download", fake)
+
+    out = _resolve_subfolder_checkpoint(ALIAS)
+    assert out == os.path.join(str(snapshot), "4bit")
+    assert asked == [REPO], f"asked the Hub for {asked} — the alias is not a repo id"
+
+
+# --------------------------------------------------------------------------
+# The reasoning_parser flip on lfm2.5-8b-a1b-4bit. It shipped as null while
+# the model emits <think> and, at a 256-token budget, never closes it — so
+# the raw tag reached users of our 16 GB "fast" recommendation. These pin
+# the parser now declared for it against the shapes actually observed on an
+# M2 Pro, including the unclosed one.
+# --------------------------------------------------------------------------
+
+
+def test_lfm_family_declares_a_reasoning_parser():
+    """Both LFM2.5 aliases we have measured emit <think>; neither may ship
+    with the parser left null again."""
+    for alias in ("lfm2.5-2.6b-4bit", "lfm2.5-8b-a1b-4bit"):
+        profile = resolve_profile(alias)
+        assert profile is not None, alias
+        assert profile.reasoning_parser == "qwen3", (
+            f"{alias} emits <think> — a null parser leaks the raw tag into "
+            "the user's chat window"
+        )
+        assert profile.tool_call_parser == "lfm"
+
+
+def test_declared_parser_separates_the_output_these_models_actually_emit():
+    from vllm_mlx.reasoning import get_parser
+
+    parser = get_parser("qwen3")()
+
+    # Shape 1 — lfm2.5-8b-a1b: emits the opening tag itself, closes it.
+    reasoning, content = parser.extract_reasoning(
+        "<think>Let me work this out. 17 * 23 = 391.</think>391"
+    )
+    assert content == "391"
+    assert "391" in reasoning and "<think>" not in (content or "")
+
+    # Shape 2 — lfm2.5-2.6b: the chat template pre-injects <think>, so the
+    # completion starts INSIDE the reasoning block with no opening tag.
+    reasoning, content = parser.extract_reasoning(
+        "The user asks for a product. 17 * 20 = 340, plus 51.</think>391"
+    )
+    assert content == "391", "implicit-think mode must still yield clean content"
+    assert "340" in reasoning
+
+
+def test_unclosed_think_does_not_leak_into_content():
+    """The 256-token observation: both models were still reasoning when the
+    budget ran out, so NO closing tag was ever emitted. Whatever the split,
+    a bare ``<think>`` must not reach the content field."""
+    from vllm_mlx.reasoning import get_parser
+
+    parser = get_parser("qwen3")()
+    truncated = "<think>We need to produce exactly three sentences. The content"
+    reasoning, content = parser.extract_reasoning(truncated)
+    assert "<think>" not in (content or "")
+    assert "</think>" not in (content or "")
+
+
+def test_pull_narrows_to_the_checkpoint_and_says_so(monkeypatch, capsys, tmp_path):
+    """``pull`` fetches only the served folder — for the bare repo id too.
+
+    Every other consumer already reaches inside on the repo id: the gate
+    quotes the subfolder's size, ``is_repo_cached`` probes it, the loader
+    opens it. Pulling the whole repo would make that quote a lie and leave
+    seven checkpoints on disk that nothing can serve. What the earlier
+    version got wrong was doing it silently.
+    """
+    import argparse
+
+    import vllm_mlx.cli as cli
+
+    snapshot = tmp_path / "snap"
+    (snapshot / "4bit").mkdir(parents=True)
+    seen: dict = {}
+
+    def fake_dl(rid, **kw):
+        seen["repo"] = rid
+        seen["allow"] = kw.get("allow_patterns")
+        return str(snapshot)
+
+    monkeypatch.setattr("huggingface_hub.snapshot_download", fake_dl)
+    monkeypatch.setattr(cli, "_try_mirror_prefetch", lambda *a, **kw: False)
+
+    cli.pull_command(argparse.Namespace(model=REPO, _original_alias=None))
+
+    assert seen["allow"] == ["4bit/*"]
+    out = capsys.readouterr().out
+    assert "4bit/" in out and "one checkpoint per quantization" in out, (
+        f"narrowing must be announced, got: {out!r}"
+    )
+
+
+def test_pull_of_a_flat_repo_is_unfiltered(monkeypatch, tmp_path):
+    """The generic contract is untouched for every ordinary repo."""
+    import argparse
+
+    import vllm_mlx.cli as cli
+
+    seen: dict = {}
+
+    def fake_dl(rid, **kw):
+        seen["allow"] = kw.get("allow_patterns", "ABSENT")
+        return str(tmp_path)
+
+    monkeypatch.setattr("huggingface_hub.snapshot_download", fake_dl)
+    monkeypatch.setattr(cli, "_try_mirror_prefetch", lambda *a, **kw: False)
+
+    cli.pull_command(
+        argparse.Namespace(
+            model="mlx-community/LFM2.5-8B-A1B-MLX-4bit", _original_alias=None
+        )
+    )
+    assert seen["allow"] == "ABSENT", (
+        "flat repos must keep the historical single-argument call shape"
+    )
+
+
+def test_incomplete_cached_checkpoint_is_rejected(monkeypatch, tmp_path):
+    """A directory is not a checkpoint.
+
+    An earlier pull that ran out of disk leaves ``4bit/`` present with its
+    shards missing. Returning that path produces a confusing mid-load
+    failure inside mlx-lm instead of "your cache is incomplete"."""
+    import huggingface_hub
+
+    snapshot = tmp_path / "snap"
+    (snapshot / "4bit").mkdir(parents=True)
+    (snapshot / "4bit" / "config.json").write_text("{}")  # no weights
+
+    def offline_then_cache(repo_id, **kwargs):
+        if not kwargs.get("local_files_only", False):
+            raise OSError("no network")
+        return str(snapshot)
+
+    monkeypatch.setattr(huggingface_hub, "snapshot_download", offline_then_cache)
+
+    with pytest.raises(RuntimeError, match="incomplete"):
+        _resolve_subfolder_checkpoint(REPO)
+
+
+def test_disk_check_keeps_the_prefix_when_the_cache_probe_throws(monkeypatch):
+    """The cache probe is best-effort and swallows its own failures. It must
+    not take the size estimate down with it.
+
+    Free space here (4 GB) fits the 1.6 GB checkpoint but not the repo's
+    9.7 GB of quantizations. Before the fix, one flaky
+    ``try_to_load_from_cache`` reset the prefix and this machine was told to
+    free up disk for seven checkpoints it was never going to download.
+    """
+    import huggingface_hub
+
+    import vllm_mlx.cli as cli
+
+    monkeypatch.setattr(
+        huggingface_hub,
+        "try_to_load_from_cache",
+        lambda *a, **kw: (_ for _ in ()).throw(OSError("cache unreadable")),
+    )
+
+    class Sib:
+        def __init__(self, name, size):
+            self.rfilename, self.size = name, size
+
+    monkeypatch.setattr(
+        huggingface_hub,
+        "model_info",
+        lambda repo_id, **kw: type(
+            "I",
+            (),
+            {
+                "siblings": [
+                    Sib("4bit/model.safetensors", 1_600_000_000),
+                    Sib("bf16/model.safetensors", 5_300_000_000),
+                    Sib("8bit/model.safetensors", 2_800_000_000),
+                ]
+            },
+        )(),
+    )
+
+    four_gb = 4 * 1000**3
+    monkeypatch.setattr(
+        cli.os,
+        "statvfs",
+        lambda p: type("S", (), {"f_bavail": four_gb // 4096, "f_frsize": 4096})(),
+    )
+
+    # Returns normally: only the 1.6 GB checkpoint is counted.
+    cli._check_disk_space(REPO)
+
+    # Control — a flat repo of the same total genuinely does not fit, and
+    # the check must still refuse it. This is what proves the assertion
+    # above is about the prefix and not about the check being inert.
+    monkeypatch.setattr(
+        huggingface_hub,
+        "model_info",
+        lambda repo_id, **kw: type(
+            "I", (), {"siblings": [Sib("model.safetensors", 9_700_000_000)]}
+        )(),
+    )
+    with pytest.raises(SystemExit):
+        cli._check_disk_space("mlx-community/LFM2.5-8B-A1B-MLX-4bit")
+
+
+def test_completeness_is_checked_on_the_success_path_too(monkeypatch, tmp_path):
+    """A publisher who reorganizes the repo can leave ``config.json`` with no
+    weights beside it. That arrives via a perfectly SUCCESSFUL download, so
+    checking only after the offline fallback would let it through."""
+    import huggingface_hub
+
+    snapshot = tmp_path / "snap"
+    (snapshot / "4bit").mkdir(parents=True)
+    (snapshot / "4bit" / "config.json").write_text("{}")  # no shards
+
+    monkeypatch.setattr(
+        huggingface_hub, "snapshot_download", lambda rid, **kw: str(snapshot)
+    )
+    with pytest.raises(RuntimeError, match="incomplete"):
+        _resolve_subfolder_checkpoint(REPO)

--- a/tests/test_aliases_contract.py
+++ b/tests/test_aliases_contract.py
@@ -45,6 +45,11 @@ from vllm_mlx.tool_parsers import ToolParserManager
 ALLOWED_PROFILE_KEYS: frozenset[str] = frozenset(
     {
         "hf_path",
+        # In-repo directory holding this alias's checkpoint, for
+        # publishers who ship every quantization as a sibling folder of
+        # ONE repo (LiquidAI/LFM2.5-2.6B-MLX). Applied at load and at
+        # download; ``hf_path`` stays a bare repo id everywhere else.
+        "subfolder",
         "modality",
         # State-pin (parallel to ``is_hybrid``): serve a vision-config
         # checkpoint through the text-only mlx-lm lane. Translated to the

--- a/tests/test_no_out_of_band_routing.py
+++ b/tests/test_no_out_of_band_routing.py
@@ -1320,6 +1320,15 @@ def test_alias_profile_str_fields_are_explicitly_listed():
     ALLOWED_STR_FIELDS: frozenset[str] = frozenset(
         {
             "hf_path",  # HF repo path, open-ended URL-like string
+            # In-repo directory holding this alias's checkpoint, for
+            # publishers who ship one folder per quantization in a single
+            # repo (LiquidAI/LFM2.5-2.6B-MLX). NOT a routing switch: it
+            # never selects a lane or a parser, it only names a path
+            # segment. Its value space is constrained at JSON load —
+            # relative, downward, no glob metacharacters, no drive letter
+            # — and a repo whose declared folder is absent fails loud at
+            # load rather than silently falling back to the repo root.
+            "subfolder",
             "tool_call_parser",  # parser key, see PARSER_REGISTRY
             "reasoning_parser",  # parser key, see PARSER_REGISTRY
             "suffix_decoding_tier",  # one of VALID_SUFFIX_TIERS — non-routing data

--- a/vllm_mlx/_download_gate.py
+++ b/vllm_mlx/_download_gate.py
@@ -11,8 +11,11 @@ because the spawned ``serve`` subprocess captured stdout to a logfile,
 the user saw a blank screen and assumed the CLI was hung.
 
 This module is the user-visible safety net. It is intentionally
-self-contained (no rapid-mlx imports) so it stays cheap to import from
-``cli.main()`` on every invocation.
+self-contained at MODULE level (no rapid-mlx imports) so it stays cheap
+to import from ``cli.main()`` on every invocation. The two subfolder
+helpers below reach into ``model_aliases`` through function-local
+imports, which preserves that property — the registry is only read on
+the paths that already touch the filesystem or the Hub.
 
 Public API:
 
@@ -169,6 +172,23 @@ def _model_info_with_timeout(repo_id: str, timeout: float):
     return result.get("info")
 
 
+def _descend_to_checkpoint(snap_dir: str, repo_id: str) -> str:
+    """The directory mlx-lm will actually glob inside ``snap_dir``.
+
+    Identity for the ordinary flat repo. For a subfolder-per-quant repo
+    it appends the declared folder — but only if that folder is really
+    there, so a publisher who reorganises the repo degrades to the
+    (honest) "not cached" answer instead of an exception.
+    """
+    from .model_aliases import checkpoint_prefix
+
+    prefix = checkpoint_prefix(repo_id)
+    if not prefix:
+        return snap_dir
+    candidate = os.path.join(snap_dir, prefix.rstrip("/"))
+    return candidate if os.path.isdir(candidate) else snap_dir
+
+
 def estimate_repo_size_bytes(repo_id: str) -> int | None:
     """Best-effort total size of weight + tokenizer files in ``repo_id``.
 
@@ -176,16 +196,27 @@ def estimate_repo_size_bytes(repo_id: str) -> int | None:
     when available) across files whose extension marks them as weight
     or tokenizer payload. ``None`` on any failure (network down, gated
     repo, HF outage, timeout) — callers should fall through silently.
+
+    For a repo that ships one folder per quantization, only the folder
+    this alias actually downloads is counted. Summing the whole repo
+    told a user that ``serve lfm2.5-2.6b-4bit`` was about to pull
+    18.7 GiB when the real transfer is 1.6 GiB — a confirm prompt that
+    scares people away from a download that would have taken seconds.
     """
     try:
         info = _model_info_with_timeout(repo_id, _HF_API_TIMEOUT_SECONDS)
     except Exception:
         return None
 
+    from .model_aliases import checkpoint_prefix
+
+    prefix = checkpoint_prefix(repo_id)
     siblings = getattr(info, "siblings", None) or []
     total = 0
     for sib in siblings:
         name = getattr(sib, "rfilename", "") or ""
+        if prefix and not name.startswith(prefix):
+            continue
         if not _is_weight_file(name):
             continue
         total += _sibling_size(sib)
@@ -432,6 +463,12 @@ def is_repo_cached(repo_id: str) -> bool:
         snap_dir = os.path.join(snap_root, resolved_sha)
         if not os.path.isdir(snap_dir):
             return False
+        # One repo, one folder per quantization (LiquidAI/LFM2.5-2.6B-MLX):
+        # the checkpoint mlx-lm will glob is the subfolder, not the
+        # snapshot root. Descend before asking "is this complete?" —
+        # otherwise a fully cached 4-bit checkpoint reads as uncached and
+        # the gate re-prompts on every single serve.
+        snap_dir = _descend_to_checkpoint(snap_dir, repo_id)
         return _snapshot_is_complete(snap_dir)
     except Exception:
         pass

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -1796,10 +1796,18 @@
     "supports_spec_decode": false,
     "is_moe": true
   },
+  "lfm2.5-2.6b-4bit": {
+    "hf_path": "LiquidAI/LFM2.5-2.6B-MLX",
+    "subfolder": "4bit",
+    "tool_call_parser": "lfm",
+    "reasoning_parser": "qwen3",
+    "is_hybrid": false,
+    "supports_spec_decode": false
+  },
   "lfm2.5-8b-a1b-4bit": {
     "hf_path": "mlx-community/LFM2.5-8B-A1B-MLX-4bit",
     "tool_call_parser": "lfm",
-    "reasoning_parser": null,
+    "reasoning_parser": "qwen3",
     "is_hybrid": false,
     "supports_spec_decode": false,
     "is_moe": true

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -931,17 +931,29 @@ def _check_disk_space(model_name: str, force: bool = False) -> None:
     if os.path.exists(model_name):
         return
 
+    # Which directory inside the repo this alias actually needs. Resolved
+    # OUTSIDE the cache probe below: that probe is best-effort and swallows
+    # its own failures, and folding the prefix into it meant one flaky
+    # ``try_to_load_from_cache`` call silently reverted the size estimate to
+    # the whole repo — demanding disk for eight quantizations and refusing a
+    # machine with ample room for the one being fetched.
+    from vllm_mlx.model_aliases import checkpoint_prefix
+
+    _prefix = checkpoint_prefix(model_name)
+
     # Skip if model is already in the HF cache.
     try:
         from huggingface_hub import try_to_load_from_cache
 
-        cached = try_to_load_from_cache(model_name, "config.json")
+        cached = try_to_load_from_cache(model_name, f"{_prefix}config.json")
         if isinstance(cached, str) and os.path.exists(cached):
             return
     except Exception:
         pass
 
     # Query HF for repo size + free space on the actual HF cache filesystem.
+    # Only this alias's checkpoint counts — a subfolder-per-quant repo would
+    # otherwise demand disk for seven quantizations nobody asked for.
     try:
         from huggingface_hub import model_info
         from huggingface_hub.constants import HF_HUB_CACHE
@@ -950,7 +962,7 @@ def _check_disk_space(model_name: str, force: bool = False) -> None:
         model_size_bytes = sum(
             (s.size or 0)
             for s in (getattr(info, "siblings", None) or [])
-            if hasattr(s, "size")
+            if hasattr(s, "size") and (not _prefix or s.rfilename.startswith(_prefix))
         )
         if model_size_bytes == 0:
             return  # Can't determine size — skip rather than guess.
@@ -1281,9 +1293,16 @@ def _check_memory_capacity(model_name: str) -> None:
         else:
             from huggingface_hub import model_info, try_to_load_from_cache
 
-            cached = try_to_load_from_cache(model_name, "config.json")
+            from vllm_mlx.model_aliases import checkpoint_prefix
+
+            # One repo, one folder per quantization: the working set is
+            # this alias's folder, not the eight-checkpoint repo. Sizing
+            # the whole repo made a 1.6 GB model project a 28 GB working
+            # set and fire the kernel-panic warning on a 32 GB Mac.
+            prefix = checkpoint_prefix(model_name)
+            cached = try_to_load_from_cache(model_name, f"{prefix}config.json")
             if isinstance(cached, str) and os.path.exists(cached):
-                # Already-downloaded model: walk the snapshot directory.
+                # Already-downloaded model: walk the checkpoint directory.
                 snapshot_dir = os.path.dirname(cached)
                 for root, _dirs, files in os.walk(snapshot_dir):
                     for f in files:
@@ -1297,6 +1316,7 @@ def _check_memory_capacity(model_name: str) -> None:
                     (s.size or 0)
                     for s in (getattr(info, "siblings", None) or [])
                     if hasattr(s, "size")
+                    and (not prefix or s.rfilename.startswith(prefix))
                 )
     except Exception:
         return  # Network / auth failure — fall through.
@@ -1511,6 +1531,16 @@ def _try_mirror_prefetch(
     bugs in the mirror module surface as real stack traces instead of
     silently routing to ``snapshot_download``.
     """
+    from vllm_mlx.model_aliases import resolve_subfolder
+
+    # The mirror mirrors whole repos; it has no notion of "just this
+    # folder". For a repo that ships one checkpoint per quantization that
+    # would hydrate every quant, so decline and let the HF path run with
+    # ``allow_patterns``. None of these repos is mirrored today — this is
+    # here so that mirroring one later can't silently turn a 1.6 GB pull
+    # into a 20 GB one.
+    if resolve_subfolder(model_name):
+        return False
     try:
         from vllm_mlx._mirror import download_with_mirror_fallback
     except ImportError:
@@ -1584,6 +1614,14 @@ def _ensure_model_downloaded(model_name: str) -> None:
     try:
         from huggingface_hub import model_info, snapshot_download
 
+        from vllm_mlx.model_aliases import subfolder_allow_patterns
+
+        # Repos that ship one folder per quantization: fetch and measure
+        # ONLY this alias's folder. Without the filter a 1.6 GB 4-bit pull
+        # reports and downloads the repo's whole ~20 GB quant matrix.
+        allow_patterns = subfolder_allow_patterns(model_name)
+        _prefix = allow_patterns[0][:-1] if allow_patterns else None
+
         size_gb = 0.0
         try:
             info = model_info(model_name, files_metadata=True)
@@ -1591,6 +1629,7 @@ def _ensure_model_downloaded(model_name: str) -> None:
                 (s.size or 0)
                 for s in (getattr(info, "siblings", None) or [])
                 if hasattr(s, "size")
+                and (_prefix is None or s.rfilename.startswith(_prefix))
             )
             size_gb = size_bytes / (1024**3)
         except Exception:
@@ -1612,7 +1651,10 @@ def _ensure_model_downloaded(model_name: str) -> None:
                 f"fetching {model_name} from HuggingFace ..."
             )
 
-        snapshot_download(model_name)
+        if allow_patterns:
+            snapshot_download(model_name, allow_patterns=allow_patterns)
+        else:
+            snapshot_download(model_name)
         print()
     except SystemExit:
         # _check_disk_space aborts via sys.exit(1) — let it through.
@@ -4976,6 +5018,18 @@ def _snapshot_size_bytes(path) -> int:
 
 def _print_pull_summary(repo_id: str, snapshot_dir, elapsed: float) -> None:
     """Emit the one-line ``Downloaded ... — <size> in <duration>`` summary."""
+    import os as _os
+
+    from vllm_mlx.model_aliases import resolve_subfolder
+
+    # A filtered pull fetched one folder, but the snapshot root may also
+    # hold quant folders left by earlier pulls of a sibling alias. Sizing
+    # the root would report those as part of THIS download.
+    _sub = resolve_subfolder(repo_id)
+    if _sub:
+        _candidate = _os.path.join(str(snapshot_dir), _sub)
+        if _os.path.isdir(_candidate):
+            snapshot_dir = _candidate
     size = _snapshot_size_bytes(snapshot_dir)
     print(
         f"  Downloaded {repo_id} — {_format_bytes(size)} in "
@@ -5024,7 +5078,33 @@ def pull_command(args):
     # error reporting.
     print(f"\n  Pulling {repo_id} from HuggingFace ...")
     try:
-        path = snapshot_download(repo_id)
+        from vllm_mlx.model_aliases import resolve_subfolder
+
+        # A repo that ships one folder per quantization holds many times
+        # more than any one alias needs — unfiltered, this fetches all
+        # eight LFM2.5-2.6B checkpoints (~20 GB) to serve 1.6 GB of them.
+        #
+        # The narrowing applies even when the operator typed the bare repo
+        # id rather than the alias, because every other consumer already
+        # keys on the repo id and reaches inside: the download gate sizes
+        # the subfolder, ``is_repo_cached`` probes the subfolder, and the
+        # loader opens the subfolder. Pulling the whole repo here would
+        # make the gate's "1.5 GiB" quote a lie and leave seven
+        # checkpoints on disk that nothing can serve. It is announced
+        # rather than silent so ``pull <repo-id>`` never quietly does
+        # something narrower than it was asked.
+        _subfolder = resolve_subfolder(repo_id)
+        if _subfolder:
+            print(
+                f"  This repo ships one checkpoint per quantization; "
+                f"fetching only {_subfolder}/ (the folder rapid-mlx serves)."
+            )
+        _allow = [f"{_subfolder}/*"] if _subfolder else None
+        path = (
+            snapshot_download(repo_id, allow_patterns=_allow)
+            if _allow
+            else snapshot_download(repo_id)
+        )
     except HFValidationError:
         # Malformed HF repo id (e.g. ``foo/bar/baz``) — surface the same
         # friendly "unknown model" hint the alias path uses instead of a

--- a/vllm_mlx/model_aliases.py
+++ b/vllm_mlx/model_aliases.py
@@ -121,6 +121,13 @@ def _coerce(alias: str, value: object) -> AliasProfile:
     _ALLOWED_PROFILE_KEYS = frozenset(
         {
             "hf_path",
+            # Directory inside ``hf_path`` holding this alias's checkpoint.
+            # For publishers who ship every quantization as a sibling
+            # folder of ONE repo (LiquidAI/LFM2.5-2.6B-MLX → ``4bit/``,
+            # ``8bit/``, ``bf16/``, …) rather than one repo per quant.
+            # See ModelProfile.subfolder for why this is not folded into
+            # ``hf_path``.
+            "subfolder",
             "modality",
             # State-pin (parallel to ``is_hybrid`` / ``is_moe``): serve
             # this checkpoint through the text mlx-lm lane even though its
@@ -174,6 +181,54 @@ def _coerce(alias: str, value: object) -> AliasProfile:
             f"alias {alias!r}: 'hf_path' must be a non-empty string, "
             f"got {type(hf_path).__name__}={hf_path!r}"
         )
+
+    # ``subfolder`` becomes a path segment joined onto a snapshot
+    # directory, so it is validated as a *relative, downward* path here —
+    # the one place that sees the raw JSON. An absolute path or a ``..``
+    # segment would let an aliases.json edit point the loader at an
+    # arbitrary directory outside the HF cache; a backslash would do the
+    # same on a case-insensitive filesystem that normalises it. Rejecting
+    # at load time keeps every downstream consumer free to treat the value
+    # as a trusted relative path.
+    subfolder = value.get("subfolder")
+    if subfolder is not None:
+        if not isinstance(subfolder, str) or not subfolder:
+            raise ValueError(
+                f"alias {alias!r}: 'subfolder' must be a non-empty string when "
+                f"present, got {type(subfolder).__name__}={subfolder!r}"
+            )
+        # ``os.path.join`` DISCARDS everything to its left when the right
+        # operand is absolute, so an absolute ``subfolder`` silently
+        # relocates the load outside the HF cache instead of erroring.
+        # ``os.path.isabs`` alone is not enough: it is platform-dependent
+        # and returns False for ``C:/x`` on POSIX, so a drive-qualified
+        # path would pass validation on the machine that reviews the JSON
+        # and escape on the machine that loads it. Reject both spellings
+        # everywhere.
+        # The value is BOTH a path segment and the literal prefix of an HF
+        # ``allow_patterns`` glob. Validating it only as a path would let
+        # ``4bit*``, ``[48]bit`` or ``**`` through — each still a legal
+        # relative path, each widening the download past the one directory
+        # the alias declares, which is the entire guarantee this field
+        # exists to make. Reject the metacharacters instead of escaping
+        # them: no real publisher names a folder ``model[0]``, and a
+        # rejected alias is a loud edit-time error.
+        glob_meta = set("*?[]!")
+        drive_qualified = len(subfolder) >= 2 and subfolder[1] == ":"
+        if (
+            subfolder.startswith("/")
+            or os.path.isabs(subfolder)
+            or drive_qualified
+            or "\\" in subfolder
+            or ".." in subfolder.split("/")
+            or subfolder.endswith("/")
+            or glob_meta & set(subfolder)
+        ):
+            raise ValueError(
+                f"alias {alias!r}: 'subfolder' must be a relative path inside "
+                f"the repo with no '..' segment and no trailing slash, got "
+                f"{subfolder!r}"
+            )
     raw_speedup = value.get("suffix_bench_speedup")
     speedup: tuple[tuple[str, float], ...] | None
     if raw_speedup is None:
@@ -399,6 +454,7 @@ def _coerce(alias: str, value: object) -> AliasProfile:
 
     return AliasProfile(
         hf_path=hf_path,
+        subfolder=subfolder,
         modality=modality,
         is_text_only=is_text_only,
         tool_call_parser=value.get("tool_call_parser"),
@@ -429,13 +485,98 @@ def _load() -> dict[str, AliasProfile]:
         path = os.path.join(os.path.dirname(__file__), "aliases.json")
         with open(path) as f:
             raw = json.load(f)
-        _aliases = {alias: _coerce(alias, v) for alias, v in raw.items()}
+        parsed = {alias: _coerce(alias, v) for alias, v in raw.items()}
+        # Validate BEFORE publishing to the module globals. Assigning first
+        # would leave a caught exception with a populated ``_aliases``, and
+        # every later ``_load()`` would take the memoized fast path and use
+        # the registry this check just rejected — failing open exactly once
+        # and then silently forever.
+        _assert_subfolder_is_unambiguous(parsed)
         # Build reverse index in JSON-insertion order so the "first alias
         # wins" rule is deterministic.
-        _hf_to_alias = {}
-        for alias, profile in _aliases.items():
-            _hf_to_alias.setdefault(profile.hf_path, alias)
+        index: dict[str, str] = {}
+        for alias, profile in parsed.items():
+            index.setdefault(profile.hf_path, alias)
+        _aliases, _hf_to_alias = parsed, index
     return _aliases
+
+
+def _assert_subfolder_is_unambiguous(profiles: dict[str, AliasProfile]) -> None:
+    """Reject an aliases.json where ``subfolder`` cannot be recovered.
+
+    ``resolve_subfolder`` reaches the loader through the reverse
+    ``hf_path → first alias`` index, because by the time the text lane
+    loads, the user-typed alias has already been resolved to a bare repo
+    id. "First alias wins" is harmless for every other profile field —
+    two aliases on one repo agree about the parsers and capability gates
+    — but ``subfolder`` is the one field where they would legitimately
+    DISAGREE: ``…-2.6b-4bit`` and ``…-2.6b-8bit`` are the same repo and
+    different directories.
+
+    Rather than silently serve 8-bit weights to someone who asked for
+    4-bit, fail at registry load. Lifting this restriction means
+    threading the alias (not just the resolved path) down to
+    ``load_model_with_fallback`` — a deliberate piece of work, not
+    something to back into by adding a JSON line.
+    """
+    by_path: dict[str, dict[str, str | None]] = {}
+    for alias, profile in profiles.items():
+        by_path.setdefault(profile.hf_path, {})[alias] = profile.subfolder
+    for hf_path, members in by_path.items():
+        if len(set(members.values())) > 1:
+            raise ValueError(
+                f"aliases {sorted(members)} share hf_path {hf_path!r} but "
+                f"declare different 'subfolder' values "
+                f"({ {a: s for a, s in members.items()} }). The loader "
+                "recovers the subfolder by reverse-lookup from the resolved "
+                "hf_path, so it cannot tell them apart. Give each quant its "
+                "own repo, or thread the alias through to "
+                "utils.tokenizer.load_model_with_fallback."
+            )
+
+
+def checkpoint_prefix(name: str) -> str:
+    """``"4bit/"`` when ``name``'s checkpoint lives in a repo subfolder.
+
+    The single implementation shared by every consumer that has to reach
+    a file inside the checkpoint — cache probes (``config.json``),
+    size estimates, and completeness checks. Returns ``""`` for the
+    ordinary flat repo, so callers can prepend it unconditionally.
+
+    Fail-soft: an unreadable registry yields ``""``, i.e. the historical
+    whole-repo behaviour, never an exception. These callers run on the
+    startup path and several of them are explicitly best-effort.
+    """
+    try:
+        subfolder = resolve_subfolder(name)
+    except Exception:
+        return ""
+    return f"{subfolder}/" if subfolder else ""
+
+
+def subfolder_allow_patterns(name: str) -> list[str] | None:
+    """``allow_patterns`` that fetch only ``name``'s checkpoint, or ``None``.
+
+    A repo that ships every quantization side by side is many times larger
+    than the one directory a given alias needs — ``LiquidAI/LFM2.5-2.6B-MLX``
+    is ~20 GB across eight quants, of which ``4bit/`` is 1.6 GB. Every
+    caller that downloads or measures such a repo must pass these
+    patterns, or the user waits for (and stores) seven checkpoints they
+    did not ask for.
+    """
+    subfolder = resolve_subfolder(name)
+    return [f"{subfolder}/*"] if subfolder else None
+
+
+def resolve_subfolder(name: str) -> str | None:
+    """The in-repo directory holding ``name``'s checkpoint, if any.
+
+    Accepts either a user-typed alias or the already-resolved HF repo id
+    (``resolve_profile`` handles both). Returns ``None`` for the ordinary
+    case where the repo root IS the checkpoint.
+    """
+    profile = resolve_profile(name)
+    return profile.subfolder if profile is not None else None
 
 
 def resolve_model(name: str) -> str:

--- a/vllm_mlx/model_metadata.py
+++ b/vllm_mlx/model_metadata.py
@@ -209,14 +209,24 @@ def _cached_file(model_name: str, filename: str) -> Path | None:
 
 
 def read_cached_model_metadata(model_name: str) -> ModelMetadata | None:
-    """Read metadata for a cached HF repository, never triggering download."""
-    config_path = _cached_file(model_name, "config.json")
+    """Read metadata for a cached HF repository, never triggering download.
+
+    A publisher like Liquid AI puts eight complete checkpoints in one
+    repo, so ``config.json`` does not exist at the repo root. Without the
+    prefix every read here reports "no config", and the caller routes the
+    model as if its architecture were unknown — which on the serve path
+    is a hard startup failure, not a degraded guess.
+    """
+    from .model_aliases import checkpoint_prefix
+
+    prefix = checkpoint_prefix(model_name)
+    config_path = _cached_file(model_name, f"{prefix}config.json")
     snapshot_dir = config_path.parent if config_path is not None else None
     if snapshot_dir is None:
-        template_path = _cached_file(model_name, "chat_template.jinja")
+        template_path = _cached_file(model_name, f"{prefix}chat_template.jinja")
         snapshot_dir = template_path.parent if template_path is not None else None
     if snapshot_dir is None:
-        tokenizer_path = _cached_file(model_name, "tokenizer_config.json")
+        tokenizer_path = _cached_file(model_name, f"{prefix}tokenizer_config.json")
         snapshot_dir = tokenizer_path.parent if tokenizer_path is not None else None
     if snapshot_dir is None:
         return None

--- a/vllm_mlx/model_profile.py
+++ b/vllm_mlx/model_profile.py
@@ -100,6 +100,21 @@ class ModelProfile:
     """
 
     hf_path: str = ""
+    # Directory INSIDE ``hf_path`` that holds this alias's weights, for
+    # publishers who ship every quantization of one model as sibling
+    # folders of a single repo instead of one repo per quant. Liquid AI
+    # does this: ``LiquidAI/LFM2.5-2.6B-MLX`` carries ``4bit/``, ``6bit/``,
+    # ``8bit/``, ``bf16/``, ``mxfp4/`` … each a complete MLX checkpoint.
+    # ``None`` (the overwhelming majority) means the repo root IS the
+    # checkpoint.
+    #
+    # ``hf_path`` deliberately stays a bare ``org/name`` repo id: the
+    # download gate, the R2 mirror catalog, ``model_sizes`` and telemetry
+    # all key on it, and folding the directory into the id would break
+    # every one of them. The subfolder is applied at exactly one place —
+    # ``utils.tokenizer.load_model_with_fallback`` — where a repo id
+    # becomes a concrete on-disk path.
+    subfolder: str | None = None
 
     # --- Parser defaults ---
     tool_call_parser: str | None = None

--- a/vllm_mlx/model_sizes.json
+++ b/vllm_mlx/model_sizes.json
@@ -4,6 +4,7 @@
     "Jackrong/MLX-Qwopus3.5-27B-v3-4bit": 15153228040,
     "Jackrong/MLX-Qwopus3.5-27B-v3-8bit": null,
     "Jackrong/MLX-Qwopus3.5-9B-v3-4bit": 5058235850,
+    "LiquidAI/LFM2.5-2.6B-MLX": 1601103345,
     "dgrauet/CogVideoX-Fun-V1.5-5b-InP-mlx": 21098224120,
     "dgrauet/CogVideoX-Fun-V1.5-5b-InP-mlx-q4": 14261048411,
     "dgrauet/CogVideoX-Fun-V1.5-5b-InP-mlx-q8": 16640010695,

--- a/vllm_mlx/utils/tokenizer.py
+++ b/vllm_mlx/utils/tokenizer.py
@@ -757,6 +757,107 @@ def _post_load_ubc_evict(model_name: str) -> None:
         logger.debug(f"Defect 4 post-load UBC evict skipped (non-fatal): {e}")
 
 
+def _resolve_subfolder_checkpoint(model_name: str) -> str:
+    """Turn ``org/repo`` into ``…/snapshots/<sha>/<subfolder>`` when the
+    alias for that repo pins one; otherwise return ``model_name`` as-is.
+
+    Only the declared subfolder is fetched — ``allow_patterns`` keeps a
+    ``rapid-mlx serve lfm2.5-2.6b-4bit`` from pulling the repo's other
+    seven quantizations (~20 GB for LFM2.5-2.6B-MLX).
+
+    A local path is passed through untouched — it is already a checkpoint
+    directory, and re-deriving a subfolder from a reverse alias lookup on a
+    local path would be wrong. So is a repo with no declared subfolder.
+
+    Once a subfolder IS declared this must not fall back to the bare repo
+    id. Handing an unresolved remote id to ``mlx_lm.load`` sends it to its
+    own *unfiltered* ``snapshot_download`` — the caller would wait out the
+    full ~20 GB repo and then still fail, because the repo root is not a
+    checkpoint for this publisher. Raise instead: an immediate, named error
+    beats a very expensive one. The offline path is preserved explicitly by
+    retrying against the local cache before giving up.
+    """
+    import os
+
+    if os.path.exists(model_name):
+        return model_name
+    # Registry errors PROPAGATE. Swallowing them and returning the bare
+    # repo id is precisely the outcome this helper exists to prevent: for
+    # a subfolder repo, mlx-lm would then run its own unfiltered
+    # ``snapshot_download`` and pull every quantization before failing.
+    # A malformed aliases.json is a hard error everywhere else too
+    # (``resolve_model`` loads the same registry at CLI startup), so this
+    # is consistent, not a new failure mode.
+    from ..model_aliases import resolve_model, resolve_subfolder
+
+    subfolder = resolve_subfolder(model_name)
+    if not subfolder:
+        return model_name
+    # ``resolve_subfolder`` answers for BOTH spellings — the alias the user
+    # typed and the repo id the CLI resolves it to. The Hub only knows the
+    # latter. ``server.load_model`` is also a public entry point that
+    # programmatic callers reach with a bare alias, skipping the CLI's
+    # pre-resolution, so normalize here instead of assuming someone
+    # upstream already did.
+    repo_id = resolve_model(model_name)
+
+    from huggingface_hub import snapshot_download
+
+    patterns = [f"{subfolder}/*"]
+    try:
+        local = snapshot_download(repo_id, allow_patterns=patterns)
+    except Exception as online_exc:
+        # The Hub call failed. The cause could be anything — no network, a
+        # gated repo, a bad token, a full disk — and we deliberately do NOT
+        # try to tell them apart: the recovery is the same for all of them,
+        # namely "is it already on disk?", and a wrong guess about the cause
+        # is worse than not guessing. So the diagnosis below says what we
+        # observed, not why.
+        try:
+            local = snapshot_download(
+                repo_id, allow_patterns=patterns, local_files_only=True
+            )
+        except Exception:
+            raise RuntimeError(
+                f"Could not fetch the {subfolder!r} subfolder of {repo_id}, "
+                f"and it is not in the local cache. This publisher ships one "
+                f"checkpoint per quantization folder, so the repo root cannot "
+                f"be loaded instead. Original error: {online_exc}"
+            ) from online_exc
+        logger.warning(
+            "Could not reach %s (%s) — falling back to the cached %r subfolder.",
+            repo_id,
+            online_exc,
+            subfolder,
+        )
+
+    resolved = os.path.join(local, subfolder)
+    if not os.path.isdir(resolved):
+        raise RuntimeError(
+            f"{repo_id} declares subfolder {subfolder!r} but {resolved} "
+            "does not exist after download — the publisher has probably "
+            "reorganized the repo. Update the alias rather than loading the "
+            "repo root, which is not a checkpoint."
+        )
+    # A directory is not a checkpoint. An interrupted or disk-full pull
+    # leaves the folder present with its shards missing, and a publisher who
+    # reorganizes the repo can leave a config.json with no weights beside
+    # it. Both reach here on the SUCCESS path too, so the check belongs
+    # after both branches, not only after the offline fallback. Reuse the
+    # download gate's implementation — it already mirrors mlx-lm's own
+    # ``model*.safetensors`` glob and shard-index validation.
+    from .._download_gate import _snapshot_is_complete
+
+    if not _snapshot_is_complete(resolved):
+        raise RuntimeError(
+            f"The {subfolder!r} subfolder of {repo_id} is present but "
+            "incomplete — its weight shards are missing. A previous download "
+            "did not finish, or the publisher reorganized the repo."
+        )
+    logger.info("Loading %s from its %r subfolder", repo_id, subfolder)
+    return resolved
+
+
 def load_model_with_fallback(
     model_name: str,
     tokenizer_config: dict = None,
@@ -773,6 +874,16 @@ def load_model_with_fallback(
     Returns:
         Tuple of (model, tokenizer)
     """
+    # Publishers who ship one repo per model with a folder per quant
+    # (``LiquidAI/LFM2.5-2.6B-MLX`` → ``4bit/``, ``8bit/``, ``bf16/`` …)
+    # need the repo id turned into a concrete directory before mlx-lm
+    # sees it — ``mlx_lm.load`` has no subfolder parameter. This is the
+    # ONLY place that happens: everything upstream (download gate, R2
+    # mirror catalog, ``model_sizes``, telemetry) keeps working with the
+    # bare repo id. No-op for the ~99% of aliases whose repo root is the
+    # checkpoint.
+    model_name = _resolve_subfolder_checkpoint(model_name)
+
     # ``mlx_lm.load`` may import config.json::model_file.  Validate that
     # caller-supplied local path once at this shared boundary before any native
     # or fallback loader runs.  Remote repository ids are intentionally a no-op


### PR DESCRIPTION
## Why

Liquid AI released LFM2.5-2.6B — a 2.6B agentic model that is the first
checkpoint we can honestly recommend to an 8 GB Mac. Measured on an M2 Pro:
**1.58 GB weights, 2.70 GB peak, 97.8 tok/s decode**. For comparison on the
same machine, our current 16 GB picks are `lfm2.5-8b-a1b-4bit` at 5.63 GB peak
/ 121.2 tok/s and `bonsai-27b-2bit` at 10.69 GB peak / 17.8 tok/s.

It was unservable. The MLX weights only exist as `LiquidAI/LFM2.5-2.6B-MLX`,
which ships **eight complete checkpoints in sibling folders** (`4bit/`,
`5bit/`, `6bit/`, `8bit/`, `bf16/`, `mxfp4/`, `mxfp8/`, `nvfp4/`) rather than
one repo per quantization. Neither `mlx-community` nor `lmstudio-community` has
published a flat conversion, and the base repo can't be loaded at all — mlx-lm's
`Lfm2 ModelArgs` requires `block_ff_dim`, which only the `-MLX` conversions add.

## What

A `subfolder` alias field, applied at exactly the four places that reach into a
checkpoint. `hf_path` stays a bare `org/name` repo id everywhere else, because
the R2 mirror catalog, `model_sizes` and telemetry redaction all key on it.

Only the loader site was predictable. The other three surfaced by running
`rapid-mlx serve lfm2.5-2.6b-4bit` — the unit tests were green while the
command was still unusable:

| Site | Symptom |
|---|---|
| `load_model_with_fallback` | mlx-lm has no subfolder param |
| `estimate_repo_size_bytes` | "Estimated size: 18.7 GiB" + kernel-panic warning, for a 1.6 GB model |
| `is_repo_cached` | warm cache read as absent → confirm prompt on every serve |
| `read_cached_model_metadata` | no root `config.json` → serve died with "Could not materialize the checkpoint config before selecting the serving lane" |

`allow_patterns` keeps a 1.6 GB pull from fetching the repo's other seven quants.

**Ambiguity guard.** The loader recovers the subfolder by reverse-lookup from
the resolved `hf_path`, so two aliases on one repo declaring *different*
subfolders are indistinguishable to it. Every other profile field is safe under
"first alias wins"; this one is not — 4-bit and 8-bit legitimately disagree.
Rejected at registry load rather than silently serving the wrong weights under
the right name. Lifting the restriction means threading the alias down to
`load_model_with_fallback`, which is deliberate work, not a JSON line.

**Unrelated-looking but same evidence:** `lfm2.5-8b-a1b-4bit` had
`reasoning_parser: null`. It emits `<think>` and does not close it within 256
tokens, so the raw tag was reaching users — on our 16 GB "fast" recommendation.
Fixed here because the measurement that found it is the measurement in this PR.
`lfm2.5-1b-4bit` and `lfm2-24b-a2b-4bit` reference `<think>` in their templates
too but are **not** touched — I have no measurement for them.

## Verification

Mac mini (M2 Pro, mlx-lm 0.31.3, mlx 0.31.2), `rapid-mlx serve lfm2.5-2.6b-4bit`:

- `Download size: ~1.5 GiB` (was 18.7 GiB); `is_repo_cached: True`; flat-repo
  control `mlx-community/LFM2.5-8B-A1B-MLX-4bit` still reports 4.5 GiB
- boots clean: `tool=lfm, reasoning=qwen3`, no gate prompt, no memory warning
- `/v1/chat/completions`: `reasoning_content` holds the reasoning, `content` is
  `391`, no `<think>` leakage
- tool call: `finish_reason=tool_calls`, `get_weather({"city": "Tokyo", "unit": "celsius"})`

33 new mlx-free tests. `test_alias_subfolder.py` **and** `test_aliases_contract.py`
added to the Linux CI list — the contract test had no CI coverage on either leg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)