### PR TITLE
feat(app): give 8 GB Macs a recommendation instead of a rejection

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Server/RAMBucketedDefault.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/RAMBucketedDefault.swift
@@ -21,9 +21,8 @@ import Foundation
 ///
 /// A machine with N GB gets the tier whose floor is the largest value
 /// ≤ N — so a 20 GB Mac gets the 18 GB pick (which fits), NOT the 24 GB
-/// pick (which would be borderline). Sub-16 GB Macs clamp to the 16 GB
-/// tier; the app's per-row fit warning still flags anything too big, and
-/// that tier's fast alternative does fit 8 GB.
+/// pick (which would be borderline). Sub-8 GB Macs clamp to the 8 GB
+/// tier; the app's per-row fit warning still flags anything too big.
 ///
 /// A tier only carries a **fast** alt when it beats the smart pick on
 /// speed by a margin worth a second card. The 24 & 32 GB smart picks are
@@ -32,8 +31,9 @@ import Foundation
 ///
 /// | RAM    | 🧠 Smart            | GB   | Cap | tok/s | 🚀 Fast                          |
 /// | ------ | ------------------- | ---- | --- | ----- | -------------------------------- |
-/// | 16 GB  | bonsai-27b-2bit     | 7.6  | 86% | 17.1  | lfm2.5-8b-a1b-4bit · 117 · chat  |
-/// | 18 GB  | bonsai-27b-2bit     | 7.6  | 86% | 17.1  | lfm2.5-8b-a1b-4bit · 117 · chat  |
+/// |  8 GB  | lfm2.5-2.6b-4bit    |  2.7 |  —  | 97.8  | — (only model that fits)         |
+/// | 16 GB  | bonsai-27b-2bit     | 10.7 | 86% | 17.8  | lfm2.5-8b-a1b-4bit · 121 · chat  |
+/// | 18 GB  | bonsai-27b-2bit     | 10.7 | 86% | 17.8  | lfm2.5-8b-a1b-4bit · 121 · chat  |
 /// | 24 GB  | gemma-4-26b-4bit    | 14.6 | 87% | 41.7  | — (smart pick already fast)      |
 /// | 32 GB  | qwen3.6-35b-4bit    | 20.0 | 87% | 60.0  | — (smart pick already fast)      |
 /// | 64 GB  | qwen3.6-35b-8bit    | 37.7 | 87% | —     | qwen3.6-35b-4bit · 87% · 60      |
@@ -44,8 +44,20 @@ import Foundation
 /// "Chat only" instead of its blended 62 % (which understates conversation
 /// and overstates tools/coding). Capability % and tok/s are the
 /// maintainer's measured scores (M2/M3); the 64/96 GB smart rows have no
-/// local tok/s measurement yet (rendered without a speed figure). The
-/// capability column is monotonic non-decreasing by RAM, with ONE
+/// local tok/s measurement yet (rendered without a speed figure).
+///
+/// The three small rows were re-measured together on one M2 Pro
+/// (mlx-lm 0.31.3) rather than carried over, because the GB column had
+/// drifted into meaning *weights on disk* for bonsai while the field is
+/// documented as active memory. Peak resident, 2 K-token prefill:
+/// lfm2.5-2.6b 2.70 GB / 97.8 tok/s, lfm2.5-8b-a1b 5.63 GB / 121.2 tok/s,
+/// bonsai-27b 10.69 GB / 17.8 tok/s. bonsai's old 7.6 GB was its weight
+/// bytes and understated its real footprint by 3.1 GB — on the 16 GB Mac
+/// that is exactly the tier it is recommended for. The column is
+/// display-only (``pickStatsLine``), so this corrects what users read,
+/// not what the app allows them to run.
+///
+/// The capability column is monotonic non-decreasing by RAM, with ONE
 /// deliberate tie documented at the tier: the 64 GB smart 8-bit is floored
 /// at its own faster 4-bit alt's 87 % (an 8-bit quant can't display weaker
 /// than its 4-bit; its edge is fidelity, not bench points). Every alias is
@@ -90,11 +102,32 @@ enum RAMBucketedDefault {
     }
 
     /// The fast/light pick shared by every tier whose smart pick is slow:
-    /// an 8B-A1B MoE at ~117 tok/s. A chat specialist, so it carries a
+    /// an 8B-A1B MoE at ~121 tok/s. A chat specialist, so it carries a
     /// "Chat only" caveat instead of its (misleadingly low) blended score.
     private static let lfm2FastPick = Pick(
-        alias: "lfm2.5-8b-a1b-4bit", footprintGB: 4.8, capabilityPct: 62,
-        tokensPerSec: 117.3, launchFlags: [], caveat: "Chat only")
+        alias: "lfm2.5-8b-a1b-4bit", footprintGB: 5.6, capabilityPct: 62,
+        tokensPerSec: 121.2, launchFlags: [], caveat: "Chat only")
+
+    /// The 8 GB tier's only pick: LFM2.5-2.6B, a 2.6 B dense model whose
+    /// 30 layers are 22 short-convolution blocks and just 8 GQA. Those 8
+    /// attention layers are why it belongs here — the KV cache costs
+    /// ~16 KB/token, so a 32 K conversation adds only ~0.5 GB on top of
+    /// 1.6 GB of weights. Measured on an M2 Pro: 2.70 GB peak,
+    /// 97.8 tok/s decode, 503 tok/s prefill.
+    ///
+    /// It carries a caveat rather than a capability %, and the caveat is
+    /// Liquid's own: they publish this model as "not recommended for
+    /// agentic coding and knowledge-heavy tasks". It is post-trained for
+    /// tool use and instruction following, and on those it beats models
+    /// ~4x its size — but our users drive coding agents, and putting a
+    /// bare "62%" on this card would invite exactly the use Liquid warns
+    /// against. ``capabilityPct`` is never rendered for a caveat pick; the
+    /// 62 below exists only to satisfy the monotonic-by-RAM invariant and
+    /// is deliberately the same band as the other caveat pick in the
+    /// family, not an independently measured score.
+    private static let lfm26Pick = Pick(
+        alias: "lfm2.5-2.6b-4bit", footprintGB: 2.7, capabilityPct: 62,
+        tokensPerSec: 97.8, launchFlags: [], caveat: "Not for coding")
 
     /// The fast/light pick for the big-MoE tiers: the 4-bit Qwen3.6-35B
     /// (same weights as the 32 GB smart pick) — near-equal capability to
@@ -108,9 +141,18 @@ enum RAMBucketedDefault {
     /// the standalone ``scripts/verify-recommendation-tiers.swift`` contract
     /// check against the bundled ``aliases.json``.
     static let tiers: [Tier] = [
+        // 8 GB was a hole, not a tier. These Macs clamped up to the 16 GB
+        // picks, then ``isRecommendedPick``'s floor guard correctly refused
+        // to exempt them from the ``.tooBig`` gate — so launch auto-start
+        // rejected the only thing it was offered and fell through to
+        // ``SafeDefaultFallback``. The user's first run was a model the app
+        // had just told them not to run. Nothing in the catalog fit until
+        // LFM2.5-2.6B: 2.70 GB peak leaves room for macOS on an 8 GB
+        // machine, where the old tier's 5.6 GB "fast" alt did not.
+        Tier(floorGB: 8, primary: lfm26Pick, alt: nil),
         Tier(
             floorGB: 16,
-            primary: Pick(alias: "bonsai-27b-2bit", footprintGB: 7.6, capabilityPct: 86, tokensPerSec: 17.1, launchFlags: []),
+            primary: Pick(alias: "bonsai-27b-2bit", footprintGB: 10.7, capabilityPct: 86, tokensPerSec: 17.8, launchFlags: []),
             alt: lfm2FastPick
         ),
         // 18 GB intentionally MIRRORS the 16 GB tier (bonsai smart + lfm2.5
@@ -123,7 +165,7 @@ enum RAMBucketedDefault {
         // edit. gemma-4-12b remains available in the full "All models" list.
         Tier(
             floorGB: 18,
-            primary: Pick(alias: "bonsai-27b-2bit", footprintGB: 7.6, capabilityPct: 86, tokensPerSec: 17.1, launchFlags: []),
+            primary: Pick(alias: "bonsai-27b-2bit", footprintGB: 10.7, capabilityPct: 86, tokensPerSec: 17.8, launchFlags: []),
             alt: lfm2FastPick
         ),
         // 24 & 32 GB: the smart pick is already MoE-fast (42 / 60 tok/s),

--- a/apps/rapid-mac/Tests/RapidTests/ModelPickerBarTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ModelPickerBarTests.swift
@@ -144,18 +144,18 @@ struct ModelPickerBarTests {
         // Pin against the real table, not synthetic picks, so a future
         // edit to the 16 GB tier's numbers has to update this expectation.
         let tier16 = RAMBucketedDefault.tier(forPhysicalRAMGB: 16)
-        // Literal expectations pin the actual curated numbers (86 / 17.1)
+        // Literal expectations pin the actual curated numbers (86 / 17.8)
         // AND the tagline format — a change to either the copy or the
         // table's numbers must update this assertion.
         let taglineP = ModelPickerBar.recommendedTagline(pick: tier16.primary, isPrimary: true)
-        #expect(taglineP == "Best pick for your Mac · 86% capability · ~17 tok/s")
+        #expect(taglineP == "Best pick for your Mac · 86% capability · ~18 tok/s")
 
         #expect(tier16.alt != nil, "16 GB tier carries a faster alternative")
         if let alt = tier16.alt {
             // The fast chat specialist shows its "Chat only" caveat in place
             // of the blended 62 % (which understates conversation quality).
             let taglineA = ModelPickerBar.recommendedTagline(pick: alt, isPrimary: false)
-            #expect(taglineA == "Faster, lighter alternative · ~117 tok/s · Chat only")
+            #expect(taglineA == "Faster, lighter alternative · ~121 tok/s · Chat only")
         }
 
         // A tier with no local tok/s measurement (64 GB → 35b-8bit) omits

--- a/apps/rapid-mac/Tests/RapidTests/RAMBucketedDefaultTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/RAMBucketedDefaultTests.swift
@@ -10,6 +10,7 @@ import Testing
 /// 24 GB pick. Table (see ``RAMBucketedDefault`` docstring for the full
 /// numbers):
 ///
+///    8 GB  → lfm2.5-2.6b-4bit  (· Not for coding — only model that fits)
 ///   16 GB  → bonsai-27b-2bit   (+ fast lfm2.5-8b-a1b-4bit · Chat only)
 ///   18 GB  → bonsai-27b-2bit   (mirrors 16 GB) (+ fast lfm2.5-8b-a1b-4bit)
 ///   24 GB  → gemma-4-26b-4bit  (--no-mllm --kv-cache-dtype bf16 --cache-memory-mb 512)
@@ -29,7 +30,7 @@ struct RAMBucketedDefaultTests {
 
     @Test("Each RAM lands on the tier whose floor is the largest ≤ its RAM")
     func aliasPerRAM() {
-        #expect(RAMBucketedDefault.alias(forPhysicalRAMGB: 8) == "bonsai-27b-2bit")     // sub-16 clamps up
+        #expect(RAMBucketedDefault.alias(forPhysicalRAMGB: 8) == "lfm2.5-2.6b-4bit")   // 8 GB is its own tier now
         #expect(RAMBucketedDefault.alias(forPhysicalRAMGB: 16) == "bonsai-27b-2bit")
         #expect(RAMBucketedDefault.alias(forPhysicalRAMGB: 17) == "bonsai-27b-2bit")
         #expect(RAMBucketedDefault.alias(forPhysicalRAMGB: 18) == "bonsai-27b-2bit")   // 18 mirrors 16
@@ -49,20 +50,26 @@ struct RAMBucketedDefaultTests {
 
     @Test("Pathological zero / negative RAM clamps to the smallest tier, no crash")
     func degenerateRAM() {
-        #expect(RAMBucketedDefault.alias(forPhysicalRAMGB: 0) == "bonsai-27b-2bit")
-        #expect(RAMBucketedDefault.alias(forPhysicalRAMGB: -1) == "bonsai-27b-2bit")
+        #expect(RAMBucketedDefault.alias(forPhysicalRAMGB: 0) == "lfm2.5-2.6b-4bit")
+        #expect(RAMBucketedDefault.alias(forPhysicalRAMGB: -1) == "lfm2.5-2.6b-4bit")
     }
 
     // MARK: - Picks (primary + optional alt)
 
     @Test("Each tier surfaces a smart pick + a fast alt where speed warrants it")
     func smartAndFastPicks() {
+        // 8 GB: one pick, and it carries the publisher's own caveat rather
+        // than a capability % — nothing else in the catalog fits.
+        let smallest = RAMBucketedDefault.picks(forPhysicalRAMGB: 8)
+        #expect(smallest.count == 1)
+        #expect(smallest[0].alias == "lfm2.5-2.6b-4bit")
+        #expect(smallest[0].caveat == "Not for coding")
         // 16/18 GB: slow smart pick → a fast lfm2.5 alt (chat specialist).
-        let smallest = RAMBucketedDefault.picks(forPhysicalRAMGB: 16)
-        #expect(smallest.count == 2)
-        #expect(smallest[0].alias == "bonsai-27b-2bit")
-        #expect(smallest[1].alias == "lfm2.5-8b-a1b-4bit")
-        #expect(smallest[1].caveat == "Chat only")
+        let tier16 = RAMBucketedDefault.picks(forPhysicalRAMGB: 16)
+        #expect(tier16.count == 2)
+        #expect(tier16[0].alias == "bonsai-27b-2bit")
+        #expect(tier16[1].alias == "lfm2.5-8b-a1b-4bit")
+        #expect(tier16[1].caveat == "Chat only")
         // 18 GB mirrors 16 GB (bonsai smart + lfm2.5 fast).
         let tier18 = RAMBucketedDefault.picks(forPhysicalRAMGB: 18)
         #expect(tier18.count == 2)
@@ -101,11 +108,16 @@ struct RAMBucketedDefaultTests {
         #expect(RAMBucketedDefault.isRecommendedPick(alias: "lfm2.5-8b-a1b-4bit", physicalRAMGB: 16))
         #expect(RAMBucketedDefault.isRecommendedPick(alias: "bonsai-27b-2bit", physicalRAMGB: 18))   // 18 mirrors 16
         #expect(!RAMBucketedDefault.isRecommendedPick(alias: "gemma-4-12b-4bit", physicalRAMGB: 18)) // dropped from picks
-        // Floor gate: an 8 GB Mac is SHOWN the 16 GB tier's picks but does
-        // NOT sit in that tier, so the picks stay subject to the .tooBig
-        // gate — bypassing it there would re-open the OOM hole.
+        // An 8 GB Mac now SITS IN a tier, so its own pick is exempt from the
+        // .tooBig gate — that exemption is the whole point of the tier, since
+        // before it every pick offered to an 8 GB Mac was rejected at launch.
+        #expect(RAMBucketedDefault.isRecommendedPick(alias: "lfm2.5-2.6b-4bit", physicalRAMGB: 8))
+        // The bigger models are still NOT exempt there: they are not this
+        // tier's picks, so the OOM hole stays closed.
         #expect(!RAMBucketedDefault.isRecommendedPick(alias: "bonsai-27b-2bit", physicalRAMGB: 8))
         #expect(!RAMBucketedDefault.isRecommendedPick(alias: "lfm2.5-8b-a1b-4bit", physicalRAMGB: 8))
+        // Below the lowest floor there is still no exemption for anything.
+        #expect(!RAMBucketedDefault.isRecommendedPick(alias: "lfm2.5-2.6b-4bit", physicalRAMGB: 4))
         // The fast alt is a recommended pick on its own tiers (64/96 GB),
         // so it also skips the .tooBig gate there.
         #expect(RAMBucketedDefault.isRecommendedPick(alias: "qwen3.6-35b-4bit", physicalRAMGB: 64))

--- a/apps/rapid-mac/scripts/verify-recommendation-tiers.swift
+++ b/apps/rapid-mac/scripts/verify-recommendation-tiers.swift
@@ -33,16 +33,19 @@ struct Tier: Equatable {
     let alt: Pick?
     var picks: [Pick] { alt.map { [primary, $0] } ?? [primary] }
 }
-let lfm2FastPick = Pick(alias: "lfm2.5-8b-a1b-4bit", footprintGB: 4.8, capabilityPct: 62,
-                        tokensPerSec: 117.3, launchFlags: [], caveat: "Chat only")
+let lfm2FastPick = Pick(alias: "lfm2.5-8b-a1b-4bit", footprintGB: 5.6, capabilityPct: 62,
+                        tokensPerSec: 121.2, launchFlags: [], caveat: "Chat only")
+let lfm26Pick = Pick(alias: "lfm2.5-2.6b-4bit", footprintGB: 2.7, capabilityPct: 62,
+                     tokensPerSec: 97.8, launchFlags: [], caveat: "Not for coding")
 let qwen35bFastPick = Pick(alias: "qwen3.6-35b-4bit", footprintGB: 20.0, capabilityPct: 87,
                            tokensPerSec: 60.0, launchFlags: [])
 let tiers: [Tier] = [
+    Tier(floorGB: 8, primary: lfm26Pick, alt: nil),
     Tier(floorGB: 16,
-         primary: Pick(alias: "bonsai-27b-2bit", footprintGB: 7.6, capabilityPct: 86, tokensPerSec: 17.1, launchFlags: []),
+         primary: Pick(alias: "bonsai-27b-2bit", footprintGB: 10.7, capabilityPct: 86, tokensPerSec: 17.8, launchFlags: []),
          alt: lfm2FastPick),
     Tier(floorGB: 18,  // mirrors 16 GB (bonsai + lfm2.5) — no "more RAM, worse pick" dip
-         primary: Pick(alias: "bonsai-27b-2bit", footprintGB: 7.6, capabilityPct: 86, tokensPerSec: 17.1, launchFlags: []),
+         primary: Pick(alias: "bonsai-27b-2bit", footprintGB: 10.7, capabilityPct: 86, tokensPerSec: 17.8, launchFlags: []),
          alt: lfm2FastPick),
     Tier(floorGB: 24,
          primary: Pick(alias: "gemma-4-26b-4bit", footprintGB: 14.6, capabilityPct: 87, tokensPerSec: 41.7,
@@ -97,7 +100,13 @@ var fails = 0
 func check(_ c: Bool, _ m: String) { if c { print("  ✓ \(m)") } else { print("  ✗ FAIL: \(m)"); fails += 1 } }
 
 print("Tier mapping (round DOWN to nearest floor):")
-check(alias(forPhysicalRAMGB: 8)  == "bonsai-27b-2bit",     "8GB clamps to 16 tier")
+check(alias(forPhysicalRAMGB: 8)  == "lfm2.5-2.6b-4bit",    "8GB has its own tier")
+check(alias(forPhysicalRAMGB: 4)  == "lfm2.5-2.6b-4bit",    "sub-8GB clamps DOWN to the 8 tier")
+// MacHardware can report 0 on a probe failure; it must not crash or pick a
+// 122B model. Mirrors RAMBucketedDefaultTests.pathologicalRAM.
+check(alias(forPhysicalRAMGB: 0)  == "lfm2.5-2.6b-4bit",    "0GB clamps to the smallest tier")
+check(alias(forPhysicalRAMGB: -1) == "lfm2.5-2.6b-4bit",    "negative RAM clamps to the smallest tier")
+check(alias(forPhysicalRAMGB: 15) == "lfm2.5-2.6b-4bit",    "15GB rounds DOWN to 8, not up to 16")
 check(alias(forPhysicalRAMGB: 16) == "bonsai-27b-2bit",     "16GB → bonsai-27b-2bit")
 check(alias(forPhysicalRAMGB: 17) == "bonsai-27b-2bit",     "17GB → still 16 tier")
 check(alias(forPhysicalRAMGB: 18) == "bonsai-27b-2bit",     "18GB → bonsai (mirrors 16 tier)")
@@ -141,7 +150,7 @@ for ram in [16.0, 18.0, 64.0, 96.0] {
 check(picks(forPhysicalRAMGB: 64)[0].capabilityPct == 87, "64GB 8-bit floored at its 4-bit's 87%")
 
 print("Smart-pick capability is monotonic non-decreasing by RAM (no 'more RAM, worse pick' dip):")
-let floors = [16.0, 18.0, 24.0, 32.0, 64.0, 96.0]
+let floors = [8.0, 16.0, 18.0, 24.0, 32.0, 64.0, 96.0]
 for (a, b) in zip(floors, floors.dropFirst()) {
     let ca = picks(forPhysicalRAMGB: a)[0].capabilityPct
     let cb = picks(forPhysicalRAMGB: b)[0].capabilityPct
@@ -155,16 +164,24 @@ check(!tiers.flatMap(\.picks).contains { $0.alias == "gemma-4-12b-4bit" }, "gemm
 print("Fast chat-specialist shows a 'Chat only' caveat instead of a misleading capability %:")
 let fast16 = picks(forPhysicalRAMGB: 16)[1]
 check(fast16.caveat == "Chat only", "16GB fast (lfm2.5) carries the Chat only caveat")
-check(pickStatsLine(fast16) == "4.8 GB · ~117 tok/s · Chat only", "lfm2.5 stats line drops the % for the caveat")
+check(pickStatsLine(fast16) == "5.6 GB · ~121 tok/s · Chat only", "lfm2.5 stats line drops the % for the caveat")
+// Liquid publishes 2.6B as "not recommended for agentic coding" — our users
+// drive coding agents, so the card must say so instead of showing a bare %.
+let smart8 = picks(forPhysicalRAMGB: 8)[0]
+check(picks(forPhysicalRAMGB: 8).count == 1, "8GB has a single pick (nothing else fits)")
+check(smart8.caveat == "Not for coding", "8GB pick carries the coding caveat")
+check(pickStatsLine(smart8) == "2.7 GB · ~98 tok/s · Not for coding", "8GB stats line drops the % for the caveat")
+check(smart8.footprintGB < 4.0, "8GB pick must leave room for macOS on an 8GB machine")
 let fast96 = picks(forPhysicalRAMGB: 96)[1]
 check(fast96.caveat == nil, "96GB fast (qwen3.6-35b-4bit) is general-purpose — no caveat")
 check(pickStatsLine(fast96) == "20.0 GB · 87% capability · ~60 tok/s", "general-purpose fast pick keeps its capability %")
 let smart16 = picks(forPhysicalRAMGB: 16)[0]
-check(pickStatsLine(smart16) == "7.6 GB · 86% capability · ~17 tok/s", "smart pick stats line unchanged")
+check(pickStatsLine(smart16) == "10.7 GB · 86% capability · ~18 tok/s", "bonsai renders its measured PEAK, not its weight bytes")
 let smart96 = picks(forPhysicalRAMGB: 96)[0]
 check(pickStatsLine(smart96) == "65.0 GB · 88% capability", "no-tok/s smart pick omits the speed figure")
 
 print("Launch flags travel with the recommendation, gated by RAM:")
+check(launchFlags(forAlias: "lfm2.5-2.6b-4bit", physicalRAMGB: 8).isEmpty, "8GB lfm2.5-2.6b → no flags")
 check(launchFlags(forAlias: "bonsai-27b-2bit", physicalRAMGB: 18).isEmpty, "18GB bonsai → no flags")
 check(launchFlags(forAlias: "gemma-4-26b-4bit", physicalRAMGB: 24) == ["--no-mllm", "--kv-cache-dtype", "bf16", "--cache-memory-mb", "512"], "24GB gemma-26b → kv trio")
 check(launchFlags(forAlias: "qwen3.6-35b-4bit", physicalRAMGB: 32).isEmpty, "35b-4bit → no flags")
@@ -172,10 +189,12 @@ check(launchFlags(forAlias: "qwen3.6-35b-4bit", physicalRAMGB: 32).isEmpty, "35b
 check(launchFlags(forAlias: "gemma-4-26b-4bit", physicalRAMGB: 64).isEmpty, "gemma-26b on 64GB (not its tier) keeps vision")
 check(launchFlags(forAlias: "some-random", physicalRAMGB: 32).isEmpty, "unknown alias → no flags")
 
-print("isRecommendedPick is floor-gated (closes the sub-16 OOM hole):")
+print("isRecommendedPick is floor-gated (the floor is now 8 GB, not 16):")
 check(isRecommendedPick(alias: "bonsai-27b-2bit", physicalRAMGB: 16), "bonsai IS recommended on 16GB (in tier)")
 check(isRecommendedPick(alias: "lfm2.5-8b-a1b-4bit", physicalRAMGB: 16), "lfm2.5 alt IS recommended on 16GB")
-check(!isRecommendedPick(alias: "bonsai-27b-2bit", physicalRAMGB: 8), "bonsai NOT recommended on 8GB (clamped below floor → .tooBig gate applies)")
+check(isRecommendedPick(alias: "lfm2.5-2.6b-4bit", physicalRAMGB: 8), "lfm2.5-2.6b IS recommended on 8GB (its own tier)")
+check(!isRecommendedPick(alias: "bonsai-27b-2bit", physicalRAMGB: 8), "bonsai still NOT recommended on 8GB (not in the 8 tier)")
+check(!isRecommendedPick(alias: "lfm2.5-2.6b-4bit", physicalRAMGB: 4), "sub-floor 4GB Mac gets NO exemption even from its own tier pick")
 check(isRecommendedPick(alias: "bonsai-27b-2bit", physicalRAMGB: 18), "bonsai recommended on 18GB (mirrors 16 tier)")
 check(!isRecommendedPick(alias: "gemma-4-12b-4bit", physicalRAMGB: 18), "gemma-12b NOT recommended anywhere (dropped from picks)")
 check(isRecommendedPick(alias: "gemma-4-26b-4bit", physicalRAMGB: 24), "gemma-26b recommended on 24GB")
@@ -203,7 +222,11 @@ print("Launch auto-start never rejects the curated recommendation (codex r6 MAJO
 check(!rejectsForAutoStart(alias: "bonsai-27b-2bit", modelSizingSaysTooBig: true, physicalRAMGB: 16),
       "16GB: recommended bonsai NOT rejected despite ModelSizing .tooBig")
 check(rejectsForAutoStart(alias: "bonsai-27b-2bit", modelSizingSaysTooBig: true, physicalRAMGB: 8),
-      "8GB: bonsai below floor → NOT recommended → auto-start still rejects .tooBig")
+      "8GB: bonsai is not this tier's pick → auto-start still rejects .tooBig")
+// The hole this tier closes: before it, EVERY pick offered to an 8 GB Mac was
+// rejected by auto-start, so first run fell through to SafeDefaultFallback.
+check(!rejectsForAutoStart(alias: "lfm2.5-2.6b-4bit", modelSizingSaysTooBig: true, physicalRAMGB: 8),
+      "8GB: its own tier pick survives auto-start (the hole this tier closes)")
 check(rejectsForAutoStart(alias: "some-huge-70b", modelSizingSaysTooBig: true, physicalRAMGB: 16),
       "non-recommended .tooBig alias is still rejected")
 check(!rejectsForAutoStart(alias: "some-small-model", modelSizingSaysTooBig: false, physicalRAMGB: 16),

--- a/tests/test_hybrid_prefix_cache_auto_default.py
+++ b/tests/test_hybrid_prefix_cache_auto_default.py
@@ -209,9 +209,7 @@ class TestResolveHybridCacheEntries:
         ``--enable-prefix-cache`` stored nothing and every agent turn
         re-prefilled the whole context.
         """
-        _patch_resolve_profile(
-            monkeypatch, is_hybrid=False, is_hybrid_explicit=True
-        )
+        _patch_resolve_profile(monkeypatch, is_hybrid=False, is_hybrid_explicit=True)
         result = _resolve_hybrid_cache_entries(
             enable_prefix_cache=True,
             explicit_value=0,
@@ -222,9 +220,7 @@ class TestResolveHybridCacheEntries:
 
     def test_pinned_nonhybrid_recurrent_respects_explicit_zero(self, monkeypatch):
         """Even for a pinned-nonhybrid recurrent model, an explicit 0 wins."""
-        _patch_resolve_profile(
-            monkeypatch, is_hybrid=False, is_hybrid_explicit=True
-        )
+        _patch_resolve_profile(monkeypatch, is_hybrid=False, is_hybrid_explicit=True)
         result = _resolve_hybrid_cache_entries(
             enable_prefix_cache=True,
             explicit_value=0,


### PR DESCRIPTION
## Why

Stacked on #1442 (which makes `lfm2.5-2.6b-4bit` servable at all).

An 8 GB Mac had no recommendation. It clamped up to the 16 GB tier, and
`isRecommendedPick`'s floor guard then correctly declined to exempt those picks
from the `.tooBig` gate — so `runLaunchAutoStart` rejected the only thing it had
been offered and fell through to `SafeDefaultFallback`. The user's first run was
a model the app had just told them not to run. The old docstring claimed "that
tier's fast alternative does fit 8 GB" about `lfm2.5-8b-a1b-4bit`; measured, it
peaks at 5.63 GB, which does not leave room for macOS on an 8 GB machine.

## What

A `floorGB: 8` tier whose single pick is `lfm2.5-2.6b-4bit`. 22 of its 30 layers
are short convolutions and only 8 are GQA, so KV costs ~16 KB/token — a 32 K
conversation adds ~0.5 GB on top of 1.6 GB of weights.

The card carries **"Not for coding"** instead of a capability %. That is Liquid's
own published guidance ("not recommended for agentic coding and knowledge-heavy
tasks"). It is genuinely strong at tool use and instruction following — it beats
Qwen3.5-9B on ToolSandbox, Multi-IF and IFStruct — but our users drive coding
agents, and a bare percentage would invite exactly the use the publisher warns
against. `capabilityPct` is never rendered for a caveat pick; the stored 62 only
satisfies the monotonic-by-RAM invariant and is deliberately the same band as
the family's other caveat pick, not an independent score.

## The 16 GB rows were wrong

Re-measuring all three small picks together on one M2 Pro (mlx-lm 0.31.3, peak
resident, 2 K-token prefill) turned up a drift in what the GB column meant:

| alias | shown | measured peak | decode |
|---|---|---|---|
| lfm2.5-2.6b-4bit | — | **2.70 GB** | 97.8 tok/s |
| lfm2.5-8b-a1b-4bit | 4.8 GB / 117.3 | **5.63 GB** | 121.2 tok/s |
| bonsai-27b-2bit | 7.6 GB / 17.1 | **10.69 GB** | 17.8 tok/s |

bonsai's 7.6 was its weight bytes — the field is documented as active memory, and
it understated the real footprint by 3.1 GB on the exact tier where it is the
recommendation. The tok/s figures held up (17.1 → 17.8, 117.3 → 121.2), so the
speed column was sound and only the memory column had drifted.

The column is display-only (`pickStatsLine` / `ModelPickerBar` tagline), so this
corrects what users read, not what the app lets them run.

## Verification

- `swift apps/rapid-mac/scripts/verify-recommendation-tiers.swift` → ALL PASS,
  with new checks: 8 GB gets its own tier, sub-8 GB clamps down to it, 15 GB
  rounds down rather than up, the tier's pick survives auto-start, bigger models
  are still rejected there, and the monotonic-capability chain now starts at 8.
- `swift build` clean.
- `RAMBucketedDefaultTests` / `ModelPickerBarTests` updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)