### PR TITLE
fix(deepseek): accept sampled DSML tool aliases

### DIFF
--- a/tests/test_deepseek_v4_0731.py
+++ b/tests/test_deepseek_v4_0731.py
@@ -168,6 +168,68 @@ def test_dsml_parser_normalizes_codex_prefix_rule_string_to_array():
     assert arguments == {"cmd": "pwd", "prefix_rule": ["git", "status"]}
 
 
+def test_dsml_parser_accepts_sampled_r_alias_and_drops_empty_enum_placeholder():
+    """Regression for the exact wire shape emitted during a 171K agent soak."""
+    parser = ToolParserManager.get_tool_parser("deepseek_v4_0731")(None)
+    wire = (
+        "inspection\n<｜DSML｜r:tool_calls>\n"
+        '<｜DSML｜r:invoke name="exec_command">\n'
+        '<｜DSML｜r:parameter name="cmd" string="true">pwd</｜DSML｜parameter>\n'
+        '<｜DSML｜r:parameter name="sandbox_permissions" string="false">'
+        "[]</｜DSML｜parameter>\n"
+        "</｜DSML｜invoke>\n</｜DSML｜tool_calls>"
+    )
+
+    result = parser.extract_tool_calls(wire)
+
+    assert result.tools_called is True
+    assert result.content == "inspection"
+    assert result.tool_calls[0]["name"] == "exec_command"
+    assert json.loads(result.tool_calls[0]["arguments"]) == {"cmd": "pwd"}
+
+
+def test_dsml_parser_drops_null_optional_enum_placeholder():
+    parser = ToolParserManager.get_tool_parser("deepseek_v4_0731")(None)
+    wire = (
+        "<｜DSML｜tool_calls>\n"
+        '<｜DSML｜invoke name="exec_command">\n'
+        '<｜DSML｜parameter name="cmd" string="true">pwd</｜DSML｜parameter>\n'
+        '<｜DSML｜parameter name="sandbox_permissions" string="false">'
+        "null</｜DSML｜parameter>\n"
+        "</｜DSML｜invoke>\n</｜DSML｜tool_calls>"
+    )
+
+    result = parser.extract_tool_calls(wire)
+
+    assert result.tools_called is True
+    assert json.loads(result.tool_calls[0]["arguments"]) == {"cmd": "pwd"}
+
+
+def test_dsml_r_alias_streaming_holds_split_opener_and_emits_once():
+    parser = ToolParserManager.get_tool_parser("deepseek_v4_0731")(None)
+    parser.reset()
+    wire = (
+        "checking<｜DSML｜r:tool_calls>\n"
+        '<｜DSML｜r:invoke name="exec_command">\n'
+        '<｜DSML｜r:parameter name="cmd" string="true">pwd'
+        "</｜DSML｜parameter>\n</｜DSML｜invoke>\n</｜DSML｜tool_calls>"
+    )
+    previous = ""
+    content: list[str] = []
+    calls: list[dict] = []
+    for char in wire:
+        current = previous + char
+        delta = parser.extract_tool_calls_streaming(previous, current, char)
+        if delta:
+            content.append(delta.get("content", ""))
+            calls.extend(delta.get("tool_calls", []))
+        previous = current
+
+    assert "".join(content) == "checking"
+    assert len(calls) == 1
+    assert calls[0]["function"]["name"] == "exec_command"
+
+
 def test_dsml_parser_restores_escaped_control_literals_in_string_parameter():
     parser = ToolParserManager.get_tool_parser("deepseek_v4_0731")(None)
     escaped = (

--- a/tests/test_deepseek_v4_reasoning_parser.py
+++ b/tests/test_deepseek_v4_reasoning_parser.py
@@ -142,6 +142,21 @@ def test_dsml_tool_start_implicitly_closes_reasoning() -> None:
     assert parsed.content == "<｜DSML｜tool_calls><｜DSML｜invoke"
 
 
+def test_dsml_sampled_r_tool_start_implicitly_closes_reasoning() -> None:
+    parser = DeepSeekV4ReasoningParser()
+    parser.configure_request(enable_thinking=True)
+
+    parsed = parser.extract_reasoning_streaming(
+        "",
+        "plan<｜DSML｜r:tool_calls><｜DSML｜r:invoke",
+        "plan<｜DSML｜r:tool_calls><｜DSML｜r:invoke",
+    )
+
+    assert parsed is not None
+    assert parsed.reasoning == "plan"
+    assert parsed.content == "<｜DSML｜r:tool_calls><｜DSML｜r:invoke"
+
+
 def test_nonstream_chat_mode_absorbs_control_tokens() -> None:
     parser = DeepSeekV4ReasoningParser()
     reasoning, content = parser.extract_reasoning(

--- a/tests/test_streaming_tool_filter.py
+++ b/tests/test_streaming_tool_filter.py
@@ -6,6 +6,11 @@ from vllm_mlx.api.utils import StreamingToolCallFilter
 
 
 class TestStreamingToolCallFilter(unittest.TestCase):
+    def test_suppresses_deepseek_sampled_r_alias(self):
+        f = StreamingToolCallFilter()
+        text = "visible<｜DSML｜r:tool_calls>hidden</｜DSML｜tool_calls>after"
+        assert f.process(text) == "visibleafter"
+
     def test_normal_text_passes_through(self):
         f = StreamingToolCallFilter()
         assert f.process("Hello world") == "Hello world"

--- a/vllm_mlx/api/utils.py
+++ b/vllm_mlx/api/utils.py
@@ -516,6 +516,7 @@ _MAX_TOOL_BUFFER_BYTES = 1_048_576  # 1 MB
 _TOOL_CALL_TAGS: list[tuple[str, str]] = [
     ("<minimax:tool_call>", "</minimax:tool_call>"),
     ("<｜DSML｜tool_calls>", "</｜DSML｜tool_calls>"),  # DeepSeek V4 0731
+    ("<｜DSML｜r:tool_calls>", "</｜DSML｜tool_calls>"),  # 0731 sampled alias
     ("<tool_call>", "</tool_call>"),  # hermes, qwen3
     ("<function=", "</function>"),
     ("[TOOL_CALL]", "[/TOOL_CALL]"),

--- a/vllm_mlx/reasoning/deepseek_v4_parser.py
+++ b/vllm_mlx/reasoning/deepseek_v4_parser.py
@@ -13,7 +13,13 @@ from .base import DeltaMessage, ReasoningParser
 _THINK_START = "<think>"
 _THINK_END = "</think>"
 _DSML_TOOL_START = "<｜DSML｜tool_calls>"
-_CONTROL_TOKENS = (_THINK_START, _THINK_END, _DSML_TOOL_START)
+_DSML_TOOL_START_R = "<｜DSML｜r:tool_calls>"
+_CONTROL_TOKENS = (
+    _THINK_START,
+    _THINK_END,
+    _DSML_TOOL_START,
+    _DSML_TOOL_START_R,
+)
 
 
 class DeepSeekV4ReasoningParser(ReasoningParser):

--- a/vllm_mlx/tool_parsers/deepseek_v4_0731_tool_parser.py
+++ b/vllm_mlx/tool_parsers/deepseek_v4_0731_tool_parser.py
@@ -52,15 +52,25 @@ class DeepSeekV40731ToolParser(ToolParser):
     EXPECTED_WIRE_FORMATS = ("deepseek_v4_dsml",)
     SUPPORTS_NATIVE_TOOL_FORMAT = True
     START = "<｜DSML｜tool_calls>"
+    START_R = "<｜DSML｜r:tool_calls>"
     END = "</｜DSML｜tool_calls>"
     INVOKE = re.compile(
-        r'<｜DSML｜invoke\s+name="(?P<name>[^"]+)">(?P<body>.*?)</｜DSML｜invoke>',
+        r'<｜DSML｜(?:r:)?invoke\s+name="(?P<name>[^"]+)">'
+        r"(?P<body>.*?)</｜DSML｜(?:r:)?invoke>",
         re.DOTALL,
     )
     PARAM = re.compile(
-        r'<｜DSML｜parameter\s+name="(?P<name>[^"]+)"\s+string="(?P<string>true|false)">(?P<value>.*?)</｜DSML｜parameter>',
+        r'<｜DSML｜(?:r:)?parameter\s+name="(?P<name>[^"]+)"\s+'
+        r'string="(?P<string>true|false)">(?P<value>.*?)'
+        r"</｜DSML｜(?:r:)?parameter>",
         re.DOTALL,
     )
+
+    @classmethod
+    def _first_start(cls, text: str) -> tuple[int, str] | None:
+        matches = ((text.find(tag), tag) for tag in (cls.START, cls.START_R))
+        present = [(index, tag) for index, tag in matches if index >= 0]
+        return min(present, default=None, key=lambda match: match[0])
 
     def reset(self) -> None:
         super().reset()
@@ -69,28 +79,33 @@ class DeepSeekV40731ToolParser(ToolParser):
     @classmethod
     def _safe_content_prefix(cls, text: str) -> str:
         """Hold any suffix that could grow into the DSML opener."""
-        start = text.find(cls.START)
-        if start >= 0:
-            return text[:start]
-        max_prefix = min(len(text), len(cls.START) - 1)
-        for size in range(max_prefix, 0, -1):
-            if cls.START.startswith(text[-size:]):
-                return text[:-size]
+        start = cls._first_start(text)
+        if start is not None:
+            return text[: start[0]]
+        for tag in (cls.START, cls.START_R):
+            max_prefix = min(len(text), len(tag) - 1)
+            for size in range(max_prefix, 0, -1):
+                if tag.startswith(text[-size:]):
+                    return text[:-size]
         return text
 
     def has_pending_tool_call(self, text: str) -> bool:
-        return self.START in text or self._safe_content_prefix(text) != text
+        return (
+            self._first_start(text) is not None
+            or self._safe_content_prefix(text) != text
+        )
 
     def flush_held_content(self, full_text: str) -> str:
         safe = self._safe_content_prefix(full_text)
-        return full_text[len(safe) :] if self.START not in full_text else ""
+        return full_text[len(safe) :] if self._first_start(full_text) is None else ""
 
     def extract_tool_calls(
         self, model_output: str, request: dict[str, Any] | None = None
     ):
-        if self.START not in model_output:
+        start = self._first_start(model_output)
+        if start is None:
             return ExtractedToolCallInformation(False, [], model_output)
-        content = model_output.split(self.START, 1)[0].strip() or None
+        content = model_output[: start[0]].strip() or None
         calls = []
         for match in self.INVOKE.finditer(model_output):
             arguments: dict[str, Any] = {}
@@ -118,6 +133,16 @@ class DeepSeekV40731ToolParser(ToolParser):
                         arguments["prefix_rule"] = prefix_rule
                 except ValueError:
                     pass
+            # Sampled 0731 output occasionally renders an omitted optional
+            # enum as JSON null or an empty collection. Omission is the only
+            # schema-valid representation; preserve non-empty values so the
+            # normal strict validator remains authoritative.
+            if (
+                match.group("name") == "exec_command"
+                and "sandbox_permissions" in arguments
+                and arguments.get("sandbox_permissions") in (None, [], {})
+            ):
+                arguments.pop("sandbox_permissions")
             calls.append(
                 {
                     "id": f"call_{uuid.uuid4().hex[:8]}",
@@ -143,7 +168,7 @@ class DeepSeekV40731ToolParser(ToolParser):
             self.reset()
         if self._stream_calls_emitted:
             return None
-        if self.START not in current_text:
+        if self._first_start(current_text) is None:
             previous_safe = self._safe_content_prefix(previous_text)
             current_safe = self._safe_content_prefix(current_text)
             newly_safe = current_safe[len(previous_safe) :]


### PR DESCRIPTION
## What changed

- Accept the `r:`-prefixed DSML opener, invoke, and parameter aliases sampled by DeepSeek-V4-Flash-0731.
- Treat the sampled alias as a reasoning boundary and suppress its raw envelope from streaming text.
- Drop only empty/null `sandbox_permissions` placeholders from `exec_command`; non-empty values still flow to strict schema validation.
- Cover full-response parsing, character-split streaming, reasoning routing, and raw-tag filtering.

## Why

A real long-running Codex engine A/B reached this exact wire shape. The prior parser treated it as text or forwarded `sandbox_permissions=[]`, which caused malformed tool calls and client reconnects even though the model's intended action was valid.

## Scope

This deliberately excludes the larger action-priming, long-context, and DSpark experiments. Those need separate review and soak evidence.

## Validation

- `225 passed`: tool parser, DeepSeek-V4 parser/reasoning, and streaming filter suites.
- `170 passed`: tool-choice and required-parameter enforcement plus the focused suites.
- `git diff --check` clean.