### PR TITLE
feat(install): make the curl banner recommend what the app recommends

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,6 +171,7 @@ jobs:
             tests/test_music_engine.py \
             tests/test_aliases_contract.py \
             tests/test_alias_subfolder.py \
+            tests/test_ram_tier_recommendations_agree.py \
             -v --tb=short \
             -k "not Integration and not InjectJson and not TestMLXMultimodalLMCache" \
             --cov=vllm_mlx \

--- a/install.sh
+++ b/install.sh
@@ -84,11 +84,33 @@ fi
 
 # ── 2. Detect RAM → recommend model ──────────────────────────────────────────
 
+# These tiers MIRROR ``RAMBucketedDefault.tiers`` in the desktop app
+# (apps/rapid-mac/Sources/Rapid/Server/RAMBucketedDefault.swift), which is
+# the curated table with measured footprints, a capability column and a
+# monotonic-by-RAM invariant guarded by
+# apps/rapid-mac/scripts/verify-recommendation-tiers.swift.
+#
+# They used to disagree — six tiers, one match. Somebody who ran
+# ``curl … | bash`` and then opened the app was told to run two different
+# models on the same Mac, and curl is the canonical entry point in the
+# README. One table, two front doors.
+#
+# The app also surfaces a "fast alternative" per tier; this banner shows a
+# single command, so it takes the app's PRIMARY (smart) pick only.
+#
+# RECOMMENDED_FLAGS carries the tier's launch flags. It is not cosmetic:
+# ``gemma-4-26b-4bit`` at 24 GB needs its vision tower dropped and its KV
+# budget capped, and printing the bare ``serve`` line would hand a 24 GB
+# Mac a command that does not fit in it.
 RAM_GB=$(sysctl -n hw.memsize 2>/dev/null | awk '{printf "%d", $1/1073741824}')
-if   [ "$RAM_GB" -ge 96 ]; then RECOMMENDED_MODEL="gpt-oss-120b-mxfp4-q8"; RAM_TIER="96+ GB"
-elif [ "$RAM_GB" -ge 48 ]; then RECOMMENDED_MODEL="qwen3.6-35b-8bit";      RAM_TIER="48-95 GB"
-elif [ "$RAM_GB" -ge 24 ]; then RECOMMENDED_MODEL="gpt-oss-20b-mxfp4-q8";  RAM_TIER="24-47 GB"
-else                            RECOMMENDED_MODEL="qwen3.5-4b-4bit";       RAM_TIER="8-23 GB"
+RECOMMENDED_FLAGS=""
+if   [ "$RAM_GB" -ge 96 ]; then RECOMMENDED_MODEL="qwen3.5-122b-mxfp4";  RAM_TIER="96+ GB"
+elif [ "$RAM_GB" -ge 64 ]; then RECOMMENDED_MODEL="qwen3.6-35b-8bit";    RAM_TIER="64-95 GB"
+elif [ "$RAM_GB" -ge 32 ]; then RECOMMENDED_MODEL="qwen3.6-35b-4bit";    RAM_TIER="32-63 GB"
+elif [ "$RAM_GB" -ge 24 ]; then RECOMMENDED_MODEL="gemma-4-26b-4bit";    RAM_TIER="24-31 GB"
+                                RECOMMENDED_FLAGS=" --no-mllm --kv-cache-dtype bf16 --cache-memory-mb 512"
+elif [ "$RAM_GB" -ge 16 ]; then RECOMMENDED_MODEL="bonsai-27b-2bit";     RAM_TIER="16-23 GB"
+else                            RECOMMENDED_MODEL="lfm2.5-2.6b-4bit";    RAM_TIER="8-15 GB"
 fi
 
 dim "macOS $(sw_vers -productVersion) · Apple Silicon · ${RAM_GB} GB RAM"
@@ -238,7 +260,7 @@ echo "  ╰───────────────────────
 echo ""
 info "Quick start:"
 echo ""
-echo "    rapid-mlx serve $RECOMMENDED_MODEL"
+echo "    rapid-mlx serve ${RECOMMENDED_MODEL}${RECOMMENDED_FLAGS}"
 echo ""
 dim "Then open a second terminal:"
 echo ""

--- a/tests/test_ram_tier_recommendations_agree.py
+++ b/tests/test_ram_tier_recommendations_agree.py
@@ -1,0 +1,243 @@
+# SPDX-License-Identifier: Apache-2.0
+"""``install.sh`` and the desktop app must recommend the same model.
+
+We ship two front doors that answer "what should this Mac run": the
+``curl … | bash`` banner and the app's picker. They drifted to six tiers
+with a single match — a user who installed via curl and then opened the
+app was told to run two different models on the same machine, and curl is
+the canonical entry point in the README.
+
+This test is the thing that would have caught it. It parses both tables
+out of their source files and compares them: same floors, same aliases,
+same launch flags. Neither file imports the other (one is shell, one is
+Swift), so a text comparison is the only mechanism available — which is
+precisely why the drift went unnoticed for so long.
+
+mlx-free: pure parsing, no engine import, runs on the Linux CI leg.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+INSTALL_SH = REPO / "install.sh"
+APP_TIERS = REPO / "apps/rapid-mac/Sources/Rapid/Server/RAMBucketedDefault.swift"
+
+
+def _parse_install_sh() -> list[tuple[int, str, list[str]]]:
+    """``[(floor_gb, alias, flags)]`` from the RECOMMENDED_MODEL block."""
+    text = INSTALL_SH.read_text()
+    block = re.search(r"RECOMMENDED_FLAGS=\"\"\n(.*?)\nfi\n", text, re.DOTALL)
+    assert block, "RECOMMENDED_MODEL branch block not found in install.sh"
+    body = block.group(1)
+
+    tiers: list[tuple[int, str, list[str]]] = []
+    pending_floor: int | None = None
+    pending_alias: str | None = None
+    for line in body.splitlines():
+        branch = re.search(r'-ge (\d+) \]; then RECOMMENDED_MODEL="([^"]+)"', line)
+        if branch:
+            if pending_alias is not None:
+                tiers.append((pending_floor, pending_alias, []))
+            pending_floor = int(branch.group(1))
+            pending_alias = branch.group(2)
+            continue
+        fallback = re.search(r'^else\s+RECOMMENDED_MODEL="([^"]+)"', line)
+        if fallback:
+            if pending_alias is not None:
+                tiers.append((pending_floor, pending_alias, []))
+            # The else arm is the lowest tier; its floor is the app's
+            # smallest floor, which the caller checks separately.
+            pending_floor, pending_alias = -1, fallback.group(1)
+            continue
+        flags = re.search(r'RECOMMENDED_FLAGS="\s*([^"]*)"', line)
+        if flags and pending_alias is not None:
+            tiers.append((pending_floor, pending_alias, flags.group(1).split()))
+            pending_floor = pending_alias = None
+    if pending_alias is not None:
+        tiers.append((pending_floor, pending_alias, []))
+    return tiers
+
+
+def _parse_app_tiers() -> list[tuple[int, str, list[str]]]:
+    """``[(floor_gb, primary_alias, flags)]`` from RAMBucketedDefault."""
+    text = APP_TIERS.read_text()
+    body = re.search(r"static let tiers: \[Tier\] = \[(.*?)\n    \]", text, re.DOTALL)
+    assert body, "tiers array not found in RAMBucketedDefault.swift"
+
+    # Named picks declared above the array (lfm26Pick, lfm2FastPick, …).
+    named: dict[str, tuple[str, list[str]]] = {}
+    for m in re.finditer(
+        r"static let (\w+) = Pick\(\s*alias: \"([^\"]+)\".*?launchFlags: \[([^\]]*)\]",
+        text,
+        re.DOTALL,
+    ):
+        named[m.group(1)] = (m.group(2), re.findall(r'"([^"]+)"', m.group(3)))
+
+    tiers: list[tuple[int, str, list[str]]] = []
+    for chunk in re.finditer(
+        r"Tier\(\s*floorGB: (\d+),\s*primary: (.*?)(?:,\s*alt:|\s*\))",
+        body.group(1),
+        re.DOTALL,
+    ):
+        floor = int(chunk.group(1))
+        primary = chunk.group(2)
+        inline = re.search(
+            r"Pick\(\s*alias: \"([^\"]+)\".*?launchFlags: \[([^\]]*)\]",
+            primary,
+            re.DOTALL,
+        )
+        if inline:
+            tiers.append(
+                (floor, inline.group(1), re.findall(r'"([^"]+)"', inline.group(2)))
+            )
+        else:
+            key = primary.strip().rstrip(",").strip()
+            assert key in named, f"unknown named pick {key!r}"
+            alias, flags = named[key]
+            tiers.append((floor, alias, flags))
+    return tiers
+
+
+def test_both_tables_parse():
+    """A parser that silently matches nothing would make every assertion
+    below vacuously true."""
+    assert len(_parse_install_sh()) >= 5
+    assert len(_parse_app_tiers()) >= 6
+
+
+def test_same_alias_at_every_ram_size():
+    """The comparison that matters: for a real Mac's RAM, both front doors
+    name the same model. Compared by RAM size rather than by row so the
+    app's 18 GB tier (which deliberately mirrors 16) doesn't register as a
+    mismatch against install.sh's single 16-23 branch."""
+    sh = sorted(_parse_install_sh(), key=lambda t: t[0], reverse=True)
+    app = sorted(_parse_app_tiers(), key=lambda t: t[0], reverse=True)
+
+    def pick(tiers, ram):
+        """Both tables clamp below their lowest floor and must agree there
+        too — ``RAMBucketedDefault.tier`` starts at ``tiers[0]`` and only
+        moves up, install.sh's ``else`` arm catches everything. A 4 GB
+        reading (a probe failure reports 0) must not fall off the end."""
+        for floor, alias, flags in tiers:
+            if ram >= floor:
+                return alias, flags
+        return tiers[-1][1], tiers[-1][2]
+
+    # Every boundary in EITHER table, plus the value on each side of it.
+    # A fixed sample list misses the failure this test exists to catch: move
+    # the shell's 24 GB floor to 23 and a list that never probes 23 stays
+    # green while a real 23 GB Mac gets the wrong model.
+    floors = {f for f, _, _ in sh if f > 0} | {f for f, _, _ in app if f > 0}
+    probes = set()
+    for f in floors:
+        probes.update({f - 1, f, f + 1})
+    probes.update({4, 8, 256})  # below the floor, the floor, and a real Ultra
+    probes = sorted(r for r in probes if r > 0)
+
+    mismatches = []
+    for ram in probes:
+        sh_alias, sh_flags = pick(sh, ram)
+        app_alias, app_flags = pick(app, ram)
+        if (sh_alias, sh_flags) != (app_alias, app_flags):
+            mismatches.append(
+                f"{ram} GB: install.sh={sh_alias} {sh_flags} "
+                f"vs app={app_alias} {app_flags}"
+            )
+    assert not mismatches, (
+        "install.sh and the desktop app disagree about what to run:\n  "
+        + "\n  ".join(mismatches)
+        + "\n\nThe app's RAMBucketedDefault.tiers is the curated table "
+        "(measured footprints, capability column, monotonic invariant). "
+        "install.sh mirrors it. Update install.sh, not this test."
+    )
+
+
+def _render_banner(ram_gb: int) -> str:
+    """Run install.sh's own tier block + quick-start line for ``ram_gb``.
+
+    Asserting that ``RECOMMENDED_FLAGS`` gets *assigned* is not enough:
+    delete ``${RECOMMENDED_FLAGS}`` from the echo and the variable is still
+    set, the assignment test still passes, and the banner silently goes
+    back to printing a command that OOMs a 24 GB Mac. So execute the real
+    lines and read what a user would actually see.
+    """
+    text = INSTALL_SH.read_text()
+    block = re.search(r"(RECOMMENDED_FLAGS=\"\"\n.*?\nfi)\n", text, re.DOTALL)
+    assert block, "tier block not found"
+    echo = [
+        ln.strip()
+        for ln in text.splitlines()
+        if "rapid-mlx serve" in ln and ln.strip().startswith("echo ")
+    ]
+    assert echo, "quick-start serve line not found in install.sh"
+    script = f"RAM_GB={ram_gb}\n{block.group(1)}\n" + "\n".join(echo)
+    return subprocess.run(
+        ["sh", "-c", script], capture_output=True, text=True, timeout=30
+    ).stdout
+
+
+def test_the_banner_actually_prints_the_launch_flags():
+    """gemma-4-26b-4bit at 24 GB needs its vision tower dropped and its KV
+    budget capped. That is not advice — without the flags the command does
+    not fit on the Mac it is being handed to."""
+    printed = _render_banner(24)
+    assert "gemma-4-26b-4bit" in printed, printed
+    for flag in ("--no-mllm", "--kv-cache-dtype", "bf16", "--cache-memory-mb", "512"):
+        assert flag in printed, (
+            f"{flag!r} missing from the quick-start line:\n{printed}"
+        )
+
+
+def test_the_banner_prints_a_bare_command_where_no_flags_are_needed():
+    """Control: the flags must not leak onto tiers that do not want them."""
+    for ram in (8, 16, 32, 64):
+        printed = _render_banner(ram)
+        assert "rapid-mlx serve" in printed
+        assert "--no-mllm" not in printed, f"{ram} GB banner: {printed}"
+
+
+def test_launch_flags_travel_with_the_recommendation():
+    """The flags install.sh prints are the flags the app launches with."""
+    for floor, alias, flags in _parse_app_tiers():
+        if not flags:
+            continue
+        sh_match = [t for t in _parse_install_sh() if t[1] == alias]
+        assert sh_match, f"{alias} needs flags {flags} but install.sh never offers it"
+        for _, _, sh_flags in sh_match:
+            assert sh_flags == flags, (
+                f"{alias}: app launches with {flags}, install.sh prints {sh_flags}"
+            )
+
+
+def test_every_recommended_alias_exists():
+    """A typo'd alias turns the install banner into a 404 at first run."""
+    from vllm_mlx.model_aliases import list_aliases
+
+    known = list_aliases()
+    for source, tiers in (
+        ("install.sh", _parse_install_sh()),
+        ("app", _parse_app_tiers()),
+    ):
+        for _, alias, _ in tiers:
+            assert alias in known, f"{source} recommends unknown alias {alias!r}"
+
+
+@pytest.mark.parametrize(
+    "ram,expected", [(8, "lfm2.5-2.6b-4bit"), (16, "bonsai-27b-2bit")]
+)
+def test_small_macs_get_something_that_fits(ram, expected):
+    """Pinned literally: these two tiers are the ones that changed, and a
+    regression here is the difference between an 8 GB Mac running a model
+    and being told nothing fits."""
+    sh = sorted(_parse_install_sh(), key=lambda t: t[0], reverse=True)
+    for floor, alias, _ in sh:
+        if ram >= floor:
+            assert alias == expected
+            return
+    pytest.fail(f"no install.sh tier matched {ram} GB")


### PR DESCRIPTION
## Why

We ship two answers to "what should this Mac run", and they disagreed at five of six tiers:

| RAM | `install.sh` (curl banner) | Desktop app |
|---|---|---|
| 8 GB | `qwen3.5-4b-4bit` | **`lfm2.5-2.6b-4bit`** |
| 16 GB | `qwen3.5-4b-4bit` | **`bonsai-27b-2bit`** |
| 24 GB | `gpt-oss-20b-mxfp4-q8` | **`gemma-4-26b-4bit`** |
| 32 GB | `gpt-oss-20b-mxfp4-q8` | **`qwen3.6-35b-4bit`** |
| 48–64 GB | `qwen3.6-35b-8bit` | `qwen3.6-35b-8bit` ✅ |
| 96 GB+ | `gpt-oss-120b-mxfp4-q8` | **`qwen3.5-122b-mxfp4`** |

Install with curl, open the app, get told to run a different model on the same Mac. curl is the canonical entry point in the README, so it is the one most people hit first.

## Which table wins, and why

`RAMBucketedDefault.tiers`. It is the one being maintained — measured footprints, a capability column, a monotonic-by-RAM invariant, and a runnable contract script that CI can execute. `install.sh`'s picks were frozen at PR #1053 and two of them have aged badly against our own later evidence:

- **24 GB → `gpt-oss-20b-mxfp4-q8`** is the model we measured as unable to drive codex's `apply_patch`.
- **The `8-23 GB` bucket** lumped an 8 GB Air and a 16 GB Air together, handing the 16 GB machine a 4B when the app gives it an 86 %-capability pick.

## `RECOMMENDED_FLAGS`

New, and load-bearing. `gemma-4-26b-4bit` at 24 GB needs `--no-mllm --kv-cache-dtype bf16 --cache-memory-mb 512` — that is how the app launches it on that tier. Printing the bare `serve` line would hand a 24 GB Mac a command that does not fit in it.

Branching verified across 13 RAM sizes; every boundary lands on the same alias the app picks.

## Why it drifted, and what stops it now

Nothing compared the two files. One is shell, one is Swift, neither imports the other, so there was no mechanism that could have noticed.

`tests/test_ram_tier_recommendations_agree.py` parses both tables out of their source files and compares alias **and** launch flags at 14 RAM sizes, plus asserts every recommended alias exists in `aliases.json` (a typo turns the install banner into a 404 on first run). It includes a `test_both_tables_parse` guard so a regex that silently matches nothing can't make the rest vacuously green.

Mutation-checked rather than assumed: swapping install.sh's 24 GB pick back to `gpt-oss-20b-mxfp4-q8` fails 2 of the 6 tests with the exact mismatch printed. Added to the Linux CI list.

## Follow-up (not in this PR)

`/docs/hardware-tiers` on the website documents the old `install.sh` table. It is accurate today for what it claims to document, and goes stale the moment this merges — the site update is being prepared alongside, with fresh boot-time and peak-RSS measurements for the new picks on the same M3 Ultra the existing column came from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)