### PR TITLE
fix(deepseek): materialize cache graphs during decode

### DIFF
--- a/tests/test_deepseek_v4_vendored.py
+++ b/tests/test_deepseek_v4_vendored.py
@@ -50,6 +50,41 @@ def test_register_vendored_archs_makes_mlx_lm_loader_find_it():
     assert hasattr(mod, "Model")
 
 
+def test_materialize_cache_arrays_flattens_existing_leaf_attributes(monkeypatch):
+    import mlx.core as mx
+
+    from vllm_mlx.models import deepseek_v4
+
+    class Leaf:
+        pass
+
+    class Composite:
+        pass
+
+    first = Leaf()
+    first.keys = mx.array([1])
+    first.metadata = 7
+    second = Leaf()
+    second.pooled = mx.array([2])
+    second.empty = None
+    composite = Composite()
+    composite.caches = (first, second)
+    calls = []
+    monkeypatch.setattr(deepseek_v4.mx, "eval", lambda *arrays: calls.append(arrays))
+
+    assert deepseek_v4._materialize_cache_arrays([composite, None]) == 2
+    assert calls == [(first.keys, second.pooled)]
+
+
+def test_materialize_cache_arrays_skips_empty_cache(monkeypatch):
+    from vllm_mlx.models import deepseek_v4
+
+    eval_calls = []
+    monkeypatch.setattr(deepseek_v4.mx, "eval", lambda *args: eval_calls.append(args))
+    assert deepseek_v4._materialize_cache_arrays(None) == 0
+    assert eval_calls == []
+
+
 def test_register_vendored_archs_is_idempotent():
     from vllm_mlx.utils.tokenizer import _register_vendored_archs
 

--- a/vllm_mlx/models/deepseek_v4.py
+++ b/vllm_mlx/models/deepseek_v4.py
@@ -1351,6 +1351,24 @@ class DeepseekV4Block(nn.Module):
         return hc_expand(x, residual, post, comb)
 
 
+def _materialize_cache_arrays(cache: Optional[Any]) -> int:
+    """Realize existing DeepSeek cache leaf arrays in one MLX evaluation."""
+    if cache is None:
+        return 0
+    arrays: list[mx.array] = []
+    for item in cache:
+        leaves = getattr(item, "caches", None) or (item,)
+        for leaf in leaves:
+            if leaf is None:
+                continue
+            arrays.extend(
+                value for value in vars(leaf).values() if isinstance(value, mx.array)
+            )
+    if arrays:
+        mx.eval(*arrays)
+    return len(arrays)
+
+
 class DeepseekV4Model(PipelineMixin, nn.Module):
     def __init__(self, config: ModelArgs):
         super().__init__()
@@ -1403,6 +1421,11 @@ class DeepseekV4Model(PipelineMixin, nn.Module):
             global_idx = layer.attn.layer_idx
             if return_dspark_hidden and global_idx in self.args.dspark_target_layer_ids:
                 dspark_hiddens.append(h.mean(axis=2))
+
+        # Functional cache updates otherwise retain prior lazy graphs. During
+        # long decodes that can exhaust Metal's resource-count limit even when
+        # byte memory remains healthy.
+        _materialize_cache_arrays(cache)
 
         if pipeline_rank != 0:
             h = mx.distributed.send(h, (pipeline_rank - 1) % pipeline_size)
@@ -1664,6 +1687,7 @@ class Model(nn.Module):
         for block, layer_cache in zip(self.mtp, cache):
             block.attn.update_main(main_x, layer_cache)
         if initial_prefill:
+            _materialize_cache_arrays(cache)
             return None
 
         K = self.args.dspark_block_size
@@ -1703,6 +1727,7 @@ class Model(nn.Module):
                 if draft_sampler is not None
                 else mx.argmax(row, axis=-1)
             )
+        _materialize_cache_arrays(cache)
         return output_ids, draft_logits
 
     @property


### PR DESCRIPTION
## Summary
- materialize current DeepSeek V4 cache leaf arrays after each main-model forward
- also detach DSpark MTP cache graphs after prefill/update and draft generation
- cover composite and empty cache traversal

## Root cause
DeepSeek V4 cache objects update functionally. Without realizing their current array attributes, long decode retains prior lazy graphs and accumulates one live Metal resource chain per layer/token. This can hit Metal's fixed `499000` resource-count limit while byte memory remains healthy.

## Validation
- `pytest -q tests/test_deepseek_v4_vendored.py tests/test_deepseek_v4_0731.py tests/test_dspark_scheduler.py tests/test_dspark_detect.py` (57 passed)
- `ruff format --check ...`
- `ruff check ...`
- `git diff --check`

## Review focus
Please focus on correctness, long-decode/DSpark regressions, compatibility, and missing high-value tests. Ignore style nits unless they affect correctness.