### PR TITLE
fix(engine): return partial output for repetition-guard stop instead of 503

### DIFF
--- a/tests/test_metal_error_recovery.py
+++ b/tests/test_metal_error_recovery.py
@@ -295,6 +295,45 @@ async def test_generate_still_raises_503_on_runtime_abort():
     assert "Metal" in str(raised)
 
 
+def test_merge_selects_error_and_kind_atomically():
+    """Aggregation must pick ``error`` and ``error_kind`` as a matched pair.
+    A newer genuine runtime abort (error set, error_kind None) merged over an
+    older "repetition" chunk must NOT inherit the stale "repetition" kind —
+    otherwise the engine would clear a real runtime error and return 200
+    instead of 503."""
+    collector = RequestOutputCollector(aggregate=True)
+    rid = "merge-pair-1"
+    # Older chunk: a repetition abort.
+    collector.put(
+        RequestOutput(
+            request_id=rid,
+            finished=True,
+            finish_reason="abort",
+            error="Model generation aborted: exact repetition loop detected",
+            error_kind="repetition",
+            output_text="haha",
+        )
+    )
+    # Newer chunk (producer got further ahead): a genuine runtime abort with no
+    # kind. Not drained in between → forces a merge.
+    collector.put(
+        RequestOutput(
+            request_id=rid,
+            finished=True,
+            finish_reason="abort",
+            error="Inference aborted: RuntimeError: Metal command buffer error",
+            error_kind=None,
+        )
+    )
+    merged = collector.get_nowait()
+    assert merged is not None
+    assert "Metal" in merged.error, "newer runtime error wins"
+    assert merged.error_kind is None, (
+        "error_kind must follow its own error — not inherit the stale "
+        "'repetition' kind, which would wrongly downgrade a 503 to 200"
+    )
+
+
 @pytest.mark.asyncio
 async def test_engine_loop_backs_off_on_persistent_failures():
     """When step() fails repeatedly the loop must back off — otherwise the

--- a/tests/test_metal_error_recovery.py
+++ b/tests/test_metal_error_recovery.py
@@ -159,6 +159,125 @@ async def test_stream_outputs_raises_on_error_field():
 
 
 @pytest.mark.asyncio
+async def test_stream_outputs_returns_partial_on_repetition_abort():
+    """Streaming path, repetition-guard hard-stop: unlike a Metal abort, this is
+    a graceful terminal stop whose partial output is valid. stream_outputs must
+    NOT raise — it must yield the (already-generated) chunk with the internal
+    "abort" finish_reason remapped to the spec-valid "length" and ``error``
+    cleared, so the client gets a clean terminal frame instead of a 503/error
+    SSE frame that discards the partial and invites an identical retry."""
+    engine = _make_engine()
+
+    rid = "stream-rep-1"
+    engine._output_collectors[rid] = RequestOutputCollector(aggregate=True)
+    engine._output_collectors[rid].put(
+        RequestOutput(
+            request_id=rid,
+            finished=True,
+            finish_reason="abort",
+            error=(
+                "Model generation aborted: exact repetition loop detected "
+                "(period_tokens=3, repeats=86)"
+            ),
+            error_kind="repetition",
+            output_text="hahaha",
+            completion_tokens=280,
+        )
+    )
+
+    raised = None
+    yields = []
+    try:
+        async for chunk in engine.stream_outputs(rid):
+            yields.append(chunk)
+    except InferenceAbortedError as exc:  # must NOT happen
+        raised = exc
+
+    assert raised is None, "repetition abort must not raise (it is graceful)"
+    assert len(yields) == 1, "the terminal partial chunk must be yielded"
+    assert yields[0].finish_reason == "length", "abort remapped to spec-valid length"
+    assert yields[0].error is None, "error cleared so no 503/error frame"
+    assert yields[0].output_text == "hahaha", "partial output preserved"
+
+
+@pytest.mark.asyncio
+async def test_generate_returns_partial_on_repetition_abort():
+    """Non-streaming path, repetition-guard hard-stop: generate() must RETURN the
+    partial output (200) with finish_reason remapped to "length" and error
+    cleared, instead of raising InferenceAbortedError (→ 503) and discarding it."""
+    engine = _make_engine()
+
+    rid = "gen-rep-1"
+    engine._output_collectors[rid] = RequestOutputCollector(aggregate=True)
+    ev = asyncio.Event()
+    ev.set()
+    engine._finished_events[rid] = ev
+    engine._output_collectors[rid].put(
+        RequestOutput(
+            request_id=rid,
+            finished=True,
+            finish_reason="abort",
+            error=(
+                "Model generation aborted: exact repetition loop detected "
+                "(period_tokens=3, repeats=86)"
+            ),
+            error_kind="repetition",
+            output_text="hahaha",
+            completion_tokens=280,
+        )
+    )
+
+    # Bypass the real enqueue — return the pre-seeded rid so generate() drains
+    # our repetition output and exercises the raise-or-return decision.
+    async def _fake_add_request(*_a, **_kw):
+        return rid
+
+    engine.add_request = _fake_add_request
+
+    result = await engine.generate(prompt="x", request_id=rid)
+    assert result is not None, "generate must return the partial, not raise"
+    assert result.finish_reason == "length", "abort remapped to spec-valid length"
+    assert result.error is None, "error cleared so the route returns 200 not 503"
+    assert result.output_text == "hahaha", "partial output preserved"
+
+
+@pytest.mark.asyncio
+async def test_generate_still_raises_503_on_runtime_abort():
+    """Guard: a genuine runtime abort (error_kind None, e.g. Metal) must STILL
+    raise InferenceAbortedError so the HTTP layer keeps mapping it to 503. Only
+    the repetition kind is exempted."""
+    engine = _make_engine()
+
+    rid = "gen-metal-1"
+    engine._output_collectors[rid] = RequestOutputCollector(aggregate=True)
+    ev = asyncio.Event()
+    ev.set()
+    engine._finished_events[rid] = ev
+    engine._output_collectors[rid].put(
+        RequestOutput(
+            request_id=rid,
+            finished=True,
+            finish_reason="abort",
+            error="Inference aborted: RuntimeError: Metal command buffer error",
+            error_kind=None,
+        )
+    )
+
+    async def _fake_add_request(*_a, **_kw):
+        return rid
+
+    engine.add_request = _fake_add_request
+
+    raised = None
+    try:
+        await engine.generate(prompt="x", request_id=rid)
+    except InferenceAbortedError as exc:
+        raised = exc
+    assert raised is not None, "runtime abort must still raise (→ 503)"
+    assert "Metal" in str(raised)
+
+
+@pytest.mark.asyncio
 async def test_engine_loop_backs_off_on_persistent_failures():
     """When step() fails repeatedly the loop must back off — otherwise the
     retry cadence floods logs at ~10 Hz and burns CPU spinning on a stuck

--- a/tests/test_metal_error_recovery.py
+++ b/tests/test_metal_error_recovery.py
@@ -212,6 +212,19 @@ async def test_generate_returns_partial_on_repetition_abort():
     ev = asyncio.Event()
     ev.set()
     engine._finished_events[rid] = ev
+    # Seed TWO chunks without draining so the collector AGGREGATES them (the
+    # producer-ahead path generate() actually hits in production). This is what
+    # catches error_kind being dropped by _merge_outputs — a single terminal
+    # chunk would bypass the merge entirely.
+    engine._output_collectors[rid].put(
+        RequestOutput(
+            request_id=rid,
+            new_text="haha",
+            new_token_ids=[1, 2],
+            output_text="haha",
+            completion_tokens=2,
+        )
+    )
     engine._output_collectors[rid].put(
         RequestOutput(
             request_id=rid,
@@ -222,6 +235,8 @@ async def test_generate_returns_partial_on_repetition_abort():
                 "(period_tokens=3, repeats=86)"
             ),
             error_kind="repetition",
+            new_text="ha",
+            new_token_ids=[3],
             output_text="hahaha",
             completion_tokens=280,
         )
@@ -239,6 +254,9 @@ async def test_generate_returns_partial_on_repetition_abort():
     assert result.finish_reason == "length", "abort remapped to spec-valid length"
     assert result.error is None, "error cleared so the route returns 200 not 503"
     assert result.output_text == "hahaha", "partial output preserved"
+    # Guard the exact regression codex flagged: error_kind must survive
+    # aggregation, else the merged terminal arrives as None and generate() 503s.
+    assert result.error_kind == "repetition", "error_kind survived _merge_outputs"
 
 
 @pytest.mark.asyncio

--- a/tests/test_repetition_guard.py
+++ b/tests/test_repetition_guard.py
@@ -113,6 +113,10 @@ def test_scheduler_fails_exact_loop_for_tool_request():
     assert output.finish_reason == "abort"
     assert output.error is not None
     assert "repetition" in output.error.lower()
+    # The scheduler marks the abort KIND so the engine can return the partial
+    # output as 200 (finish_reason remapped) rather than raising 503 like a
+    # genuine runtime abort. Other abort sources leave error_kind None.
+    assert output.error_kind == "repetition"
     assert scheduler.num_repetition_loop_stops == 1
     assert scheduler.get_stats()["num_repetition_loop_stops"] == 1
 

--- a/vllm_mlx/engine_core.py
+++ b/vllm_mlx/engine_core.py
@@ -1094,14 +1094,31 @@ class EngineCore:
                     # Engine loop sets ``error`` when it aborts a request mid-
                     # flight (e.g. Metal RuntimeError that propagated to Python).
                     # Raise so streaming HTTP handlers can map to 503 instead of
-                    # silently yielding an empty terminal chunk (#353).
+                    # silently yielding an empty terminal chunk (#353) — EXCEPT
+                    # the repetition-guard hard-stop. That is a graceful, terminal
+                    # stop whose partial output (already streamed) is valid, so
+                    # remap its internal "abort" finish_reason to the spec-valid
+                    # "length", clear the error, and fall through to the normal
+                    # terminal-chunk path below (the scheduler already set
+                    # ``output.finished=True``). This delivers a clean
+                    # finish_reason=length chunk instead of a generic
+                    # internal_error SSE frame.
                     if output.error:
-                        from .request import InferenceAbortedError
+                        if output.error_kind == "repetition":
+                            logger.warning(
+                                f"[stream_outputs] {request_id[:12]} "
+                                f"repetition-guard stop; finishing stream with "
+                                f"finish_reason=length ({_token_count} tokens)"
+                            )
+                            output.finish_reason = "length"
+                            output.error = None
+                        else:
+                            from .request import InferenceAbortedError
 
-                        logger.warning(
-                            f"[stream_outputs] {request_id[:12]} engine aborted: {output.error}"
-                        )
-                        raise InferenceAbortedError(output.error)
+                            logger.warning(
+                                f"[stream_outputs] {request_id[:12]} engine aborted: {output.error}"
+                            )
+                            raise InferenceAbortedError(output.error)
 
                     yield output
 
@@ -1195,8 +1212,24 @@ class EngineCore:
 
             # Engine loop sets error= when it aborts the request (e.g. Metal
             # runtime error). Surface as InferenceAbortedError so the HTTP
-            # layer maps to 503 (#353).
+            # layer maps to 503 (#353) — EXCEPT the repetition-guard hard-stop,
+            # which is a deliberate, graceful termination whose partial output
+            # is valid. For that case return the partial as a normal result
+            # (finish_reason remapped from the internal "abort" to the spec-valid
+            # "length" — the same precedent the engine loop uses for forced
+            # terminations) so the agent gets 200 + the truncated text instead
+            # of a 503 that discards it and invites an identical retry → re-loop.
             if final_output.error:
+                if final_output.error_kind == "repetition":
+                    logger.warning(
+                        f"[generate] {request_id[:12]} repetition-guard stop; "
+                        f"returning partial ({final_output.completion_tokens} "
+                        f"tokens) as finish_reason=length instead of 503"
+                    )
+                    final_output.finish_reason = "length"
+                    final_output.error = None
+                    return final_output
+
                 from .request import InferenceAbortedError
 
                 raise InferenceAbortedError(final_output.error)

--- a/vllm_mlx/output_collector.py
+++ b/vllm_mlx/output_collector.py
@@ -138,6 +138,20 @@ class RequestOutputCollector:
         merged_new_token_ids = existing.new_token_ids + new.new_token_ids
         merged_new_text = existing.new_text + new.new_text
 
+        # ``error`` and ``error_kind`` are a MATCHED PAIR — a discriminator is
+        # only meaningful for its own error string. Select them ATOMICALLY:
+        # if the newer chunk carries an error, take BOTH its ``error`` and its
+        # ``error_kind`` (even when the kind is None); otherwise inherit BOTH
+        # from the existing buffer. Selecting them independently could pair a
+        # newer genuine runtime abort (error set, error_kind None) with an
+        # older "repetition" kind, making the engine clear the runtime error
+        # and return 200 instead of 503. (Both branches preserve the prior
+        # ``new.error or existing.error`` behaviour for the ``error`` field.)
+        if new.error:
+            merged_error, merged_error_kind = new.error, new.error_kind
+        else:
+            merged_error, merged_error_kind = existing.error, existing.error_kind
+
         return RequestOutput(
             request_id=new.request_id,
             new_token_ids=merged_new_token_ids,
@@ -151,16 +165,14 @@ class RequestOutputCollector:
             cached_tokens=new.cached_tokens,
             logprobs=new.logprobs,  # Use latest token's logprobs
             # Terminal scheduler failures (exact repetition, explicit abort,
-            # Metal recovery) must survive aggregation. Dropping this field
-            # turns an aborted generation into a successful blank response.
-            error=new.error or existing.error,
-            # ``error_kind`` is the companion discriminator to ``error`` — it
-            # must survive aggregation for the SAME reason. If it were dropped,
-            # an aggregated repetition abort would arrive with error_kind=None
-            # and the engine would raise 503 (discarding the partial) instead of
-            # returning it as 200. Prefer the newer chunk's value, falling back
-            # to the existing buffer so a later plain flush can't demote it.
-            error_kind=new.error_kind or existing.error_kind,
+            # Metal recovery) must survive aggregation. Dropping ``error`` turns
+            # an aborted generation into a successful blank response; dropping
+            # ``error_kind`` (the companion discriminator) turns an aggregated
+            # repetition abort into a 503 that discards the partial. Both are
+            # selected atomically above so a runtime error never inherits a
+            # stale "repetition" kind.
+            error=merged_error,
+            error_kind=merged_error_kind,
             # H-03: prefer the newer chunk's matched_stop (the scheduler
             # pins it exactly once on the chunk where the stop fires);
             # fall back to the existing buf so we never demote a

--- a/vllm_mlx/output_collector.py
+++ b/vllm_mlx/output_collector.py
@@ -154,6 +154,13 @@ class RequestOutputCollector:
             # Metal recovery) must survive aggregation. Dropping this field
             # turns an aborted generation into a successful blank response.
             error=new.error or existing.error,
+            # ``error_kind`` is the companion discriminator to ``error`` — it
+            # must survive aggregation for the SAME reason. If it were dropped,
+            # an aggregated repetition abort would arrive with error_kind=None
+            # and the engine would raise 503 (discarding the partial) instead of
+            # returning it as 200. Prefer the newer chunk's value, falling back
+            # to the existing buffer so a later plain flush can't demote it.
+            error_kind=new.error_kind or existing.error_kind,
             # H-03: prefer the newer chunk's matched_stop (the scheduler
             # pins it exactly once on the chunk where the stop fires);
             # fall back to the existing buf so we never demote a

--- a/vllm_mlx/request.py
+++ b/vllm_mlx/request.py
@@ -323,6 +323,20 @@ class RequestOutput:
     # so positional constructor args for the pre-existing fields keep
     # their indices.
     matched_stop: str | None = None
+    # Distinguishes WHY the request aborted, when ``error`` is set. The engine
+    # raises InferenceAbortedError (→ HTTP 503) for genuine mid-flight failures
+    # (Metal runtime errors, engine-loop crashes) where the partial output may
+    # be corrupt. A repetition-guard hard-stop is different: the scheduler
+    # deliberately terminated a runaway exact-token loop on a has_tools request,
+    # and the partial output up to that point is VALID. Those set
+    # ``error_kind="repetition"`` so the engine returns 200 + partial (with
+    # ``finish_reason`` remapped to a spec-valid value) instead of raising 503 —
+    # which would discard the partial AND invite the agent to blindly retry the
+    # identical prompt straight back into the same loop. ``None`` (or any value
+    # other than ``"repetition"``) keeps the legacy raise→503 path. Appended at
+    # the end of the dataclass so positional constructor args for the pre-existing
+    # fields keep their indices.
+    error_kind: str | None = None
 
     @property
     def usage(self) -> dict[str, int]:

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -6489,6 +6489,12 @@ class Scheduler:
                 output.finish_reason = response.finish_reason
                 if repetition_error is not None:
                     output.error = repetition_error
+                    # Mark this abort as the graceful repetition-guard stop so
+                    # the engine returns the partial output as 200 (finish_reason
+                    # remapped) instead of raising 503 like a genuine runtime
+                    # abort. Other abort sources (Metal/OOM recovery) leave
+                    # error_kind None → they stay on the raise→503 path.
+                    output.error_kind = "repetition"
                 finished_ids.add(request_id)
 
                 if stop_trimmed:


### PR DESCRIPTION
## Why

When the repetition guard hard-stops a runaway exact-token loop on a `has_tools` (agent) request, the client gets **HTTP 503 and the partial output is discarded**. Two problems for agents:

1. **Partial work lost** — the tokens already generated (e.g. ~280) are thrown away; 503 has no body.
2. **Retry into the same loop** — 503 shares the *same* engine path as genuine Metal-runtime aborts (where "retry a smaller request" is the correct advice), so an agent framework reads `503 + Retry-After` as "service down" and re-sends the identical prompt → straight back into the same loop → 503 again.

This disproportionately hits small/fast models: measured on qwen3.5-4b-4bit, a 30-turn tool-agent loop triggered **2 guard hard-stops** (one surfaced as a 503), vs **0** on 9b/27b/35b.

Root cause: the guard stop (`scheduler.py`, `detect_repeated_token_suffix`) sets `finish_reason="abort"` + `output.error`; the engine raises `InferenceAbortedError` whenever `output.error` is truthy (`engine_core.py` generate + stream_outputs), which `routes/chat.py` maps to 503 — the partial output is fully intact at the raise site but never returned. Critically, `finish_reason="abort"` alone is **not** a sufficient discriminator: the genuine Metal/OOM generation-error-recovery path also sets `finish_reason="abort"`.

## What

- **`RequestOutput.error_kind`** (new field): distinguishes the abort cause when `error` is set. The scheduler sets `error_kind="repetition"` for the guard hard-stop; all other abort sources (Metal runtime, engine-loop crash, OOM recovery) leave it `None`.
- **Engine (both paths)**: for `error_kind == "repetition"`, return (`generate`) / yield (`stream_outputs`) the partial output with `finish_reason` remapped from the internal `"abort"` to the spec-valid **`"length"`** (the same precedent the engine loop already uses for forced terminations) and `error` cleared — instead of raising. Genuine runtime aborts (`error_kind None`) keep the raise→503 path **unchanged**.
- **No route change**: the engine simply returns a normal `RequestOutput`; `routes/chat.py` produces 200 naturally. 503 remains for real runtime aborts.

Net effect for agents: a repetition-terminated turn now returns **200 + the partial text + `finish_reason="length"`**, so the agent sees the (truncated) output and does not blindly retry into the loop.

## Tests

- `test_repetition_guard.py::test_scheduler_fails_exact_loop_for_tool_request` extended: asserts `output.error_kind == "repetition"` is set (scheduler-level marking).
- `test_metal_error_recovery.py` (new, hermetic engine-level, mirrors the existing abort harness):
  - `test_stream_outputs_returns_partial_on_repetition_abort` — streaming: yields the terminal chunk with `finish_reason="length"`, `error=None`, partial preserved; does **not** raise.
  - `test_generate_returns_partial_on_repetition_abort` — non-streaming: `generate()` returns the partial (`finish_reason="length"`, `error=None`) instead of raising.
  - `test_generate_still_raises_503_on_runtime_abort` — guard: a Metal-shaped abort (`error_kind None`) still raises `InferenceAbortedError` → 503.
- Existing Metal-abort tests (`test_stream_outputs_raises_on_error_field`, `test_engine_loop_fails_in_flight_requests_on_step_exception`, `test_scheduler_generation_error_is_not_reported_as_normal_length_finish`) continue to pass — the genuine-503 path is untouched.
- Local: the affected suites (`test_repetition_guard.py`, `test_metal_error_recovery.py`, `test_request.py`) pass; ruff clean.

## Notes

- Does not touch `spec_decode/`, vendored models, or the 503 mapping for real runtime aborts. No version bump.
- `finish_reason="length"` is the spec-valid signal for a truncated (non-natural-stop) completion; the detailed repetition reason stays in server logs and the `num_repetition_loop_stops` metric.

---
🤖 This PR was authored with assistance from Claude Code (Opus 4.8).