### PR TITLE
fix(cache): persist deepest prefix first on shutdown

### DIFF
--- a/tests/test_prefix_cache_persistence.py
+++ b/tests/test_prefix_cache_persistence.py
@@ -1373,6 +1373,62 @@ def test_save_to_disk_partial_commit_on_abort(tmp_path):
     assert entry.tokens == tuple(range(11))
 
 
+def test_shutdown_partial_commit_prioritizes_longest_prefix(tmp_path):
+    """A tiny bootstrap entry must not consume the only shutdown slot."""
+    cache_dir = tmp_path / "snap"
+    cache = fresh_cache()
+    cache.store([1], make_kvcache(num_tokens=1))
+    cache.store(list(range(100)), make_kvcache(num_tokens=100, fill=2.0))
+
+    calls = {"n": 0}
+
+    def predicate(predicted_sec=0.0):
+        calls["n"] += 1
+        return calls["n"] > 1
+
+    assert cache.save_to_disk(str(cache_dir), should_abort=predicate) is True
+    loaded_cache = fresh_cache()
+    assert loaded_cache.load_from_disk(str(cache_dir)) == 1
+    entry = next(iter(loaded_cache._entries.values()))
+    assert entry.tokens == tuple(range(100))
+
+
+def test_deadline_save_skips_oversized_prefix_and_tries_smaller(tmp_path):
+    cache_dir = tmp_path / "snap"
+    cache = fresh_cache()
+    cache.store([1], make_kvcache(num_tokens=1))
+    cache.store(list(range(100)), make_kvcache(num_tokens=100, fill=2.0))
+    entry_sizes = sorted(entry.memory_bytes for entry in cache._entries.values())
+    threshold = sum(entry_sizes) / 2 / (150 * 1024 * 1024)
+
+    assert (
+        cache.save_to_disk(
+            str(cache_dir),
+            should_abort=lambda predicted_sec=0.0: predicted_sec > threshold,
+        )
+        is True
+    )
+    loaded_cache = fresh_cache()
+    assert loaded_cache.load_from_disk(str(cache_dir)) == 1
+    assert next(iter(loaded_cache._entries)) == (1,)
+
+
+def test_deadline_save_roundtrip_preserves_lru_eviction_order(tmp_path):
+    cache_dir = tmp_path / "snap"
+    cache = fresh_cache()
+    cache.store([1], make_kvcache(num_tokens=1))
+    cache.store(list(range(100)), make_kvcache(num_tokens=100, fill=2.0))
+
+    assert cache.save_to_disk(str(cache_dir), should_abort=lambda _seconds: False)
+    loaded_cache = fresh_cache()
+    assert loaded_cache.load_from_disk(str(cache_dir)) == 2
+    assert list(loaded_cache._entries) == [(1,), tuple(range(100))]
+
+    with loaded_cache._lock:
+        loaded_cache._evict_lru()
+    assert list(loaded_cache._entries) == [tuple(range(100))]
+
+
 def test_save_to_disk_aborts_before_first_entry_returns_false(tmp_path):
     """If the deadline already passed before the first write, ``should_abort``
     fires immediately, ``saved == 0``, and the staging dir is cleaned up
@@ -1762,9 +1818,9 @@ def test_save_to_disk_skips_entry_zero_when_predicted_exceeds_budget(tmp_path):
         return predicted_sec > 0  # trip on any forward-looking estimate
 
     assert cache.save_to_disk(str(cache_dir), should_abort=predicate) is False
-    assert len(seen_predicted) == 1, (
-        f"loop should abort on first predicate trip (entry 0), got "
-        f"{len(seen_predicted)} calls"
+    assert len(seen_predicted) == 2, (
+        f"loop should consider every candidate after a prediction rejects "
+        f"the largest, got {len(seen_predicted)} calls"
     )
     assert not (tmp_path / "snap").exists()
     assert not (tmp_path / "snap.new").exists()

--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -2641,9 +2641,18 @@ class MemoryAwarePrefixCache:
         # docstring contract — auto-detect and adapt instead of
         # raising TypeError. Codex PR #667 round 3 BLOCKING-2.
         check_abort = _adapt_should_abort(should_abort)
+        entries_to_save = list(self._entries.items())
+        lru_rank = {tokens_key: rank for rank, tokens_key in enumerate(self._entries)}
+        saved_lru_rank: dict[int, int] = {}
+        if check_abort is not None:
+            # A deadline-limited snapshot should preserve the deepest reusable
+            # frontier first. LRU order may begin with a tiny bootstrap entry,
+            # which can otherwise consume the only guaranteed shutdown slot
+            # and skew the observed-throughput estimate with fixed fsync cost.
+            entries_to_save.sort(key=lambda item: len(item[0]), reverse=True)
         total_bytes_written = 0
         total_write_seconds = 0.0
-        for i, (tokens_key, entry) in enumerate(self._entries.items()):
+        for i, (tokens_key, entry) in enumerate(entries_to_save):
             if total_write_seconds > 0:
                 observed_bps = total_bytes_written / total_write_seconds
             else:
@@ -2665,10 +2674,10 @@ class MemoryAwarePrefixCache:
                     f"entry {i}/{total_entries} "
                     f"(predicted {predicted_sec * 1000:.0f}ms write at "
                     f"{observed_bps / _BYTES_PER_MB:.0f}MB/s "
-                    f"[{bps_label}]) — committing {saved} entries that "
-                    f"finished before deadline"
+                    f"[{bps_label}]) — skipping this candidate and "
+                    f"considering smaller entries"
                 )
-                break
+                continue
             entry_path, tokens_path = _entry_paths(i)
             entry_t0 = _time.monotonic()
             try:
@@ -2735,6 +2744,7 @@ class MemoryAwarePrefixCache:
                         "cache_types": cache_types,
                     }
                 )
+                saved_lru_rank[i] = lru_rank[tokens_key]
                 saved += 1
                 # Feed the throughput estimator. We measure including
                 # both the safetensors write and the tokens sidecar so
@@ -2862,6 +2872,10 @@ class MemoryAwarePrefixCache:
                 f"{len(verified)} that round-tripped cleanly"
             )
 
+        # Serialization priority is not cache recency. Restore the original
+        # LRU order in the committed index so load_from_disk reconstructs the
+        # same eviction order even when deadline-aware writes ran longest-first.
+        verified.sort(key=lambda entry: saved_lru_rank[entry["index"]])
         index["entries"] = verified
         # Always pin num_entries to the actually-verified count. The initial
         # value was ``total_entries`` (set before the save loop) which is


### PR DESCRIPTION
## Summary
- sort prefix-cache entries longest-first only for deadline-aware shutdown saves
- keep historical LRU order for explicit/full saves
- verify a one-entry partial commit preserves the deepest reusable prefix

## Root cause
Shutdown persistence has a short deadline and may commit only one entry. LRU iteration can begin with a one-token bootstrap entry; writing it consumes the guaranteed slot and its fixed fsync overhead poisons the observed-throughput estimate, causing the real 100K+ frontier to be skipped.

## Validation
- 93 persistence/runtime/deferred-load tests passed
- Ruff format/check passed
- `git diff --check` passed

## Review focus
Only blockers/major correctness, persistence compatibility, partial-commit/index consistency, and high-value test gaps; no style nits.