### PR TITLE
fix(deepseek): prevent reopening disabled thinking

### DIFF
--- a/tests/test_grammar_scheduler_realign_558.py
+++ b/tests/test_grammar_scheduler_realign_558.py
@@ -42,6 +42,7 @@ def _make_scheduler_stub():
         uid_to_request_processors={},
         _uids_with_grammar=set(),
         _uids_with_reasoning_budget={},
+        _uids_with_suppressed_tokens={},
         _known_stateful_processors=set(),
         _stateful_processor_objs={},
         _stateful_tombstones=set(),
@@ -61,7 +62,7 @@ def _make_scheduler_stub():
     return stub
 
 
-def _register(stub, uid, processors, grammar=None, budget=None):
+def _register(stub, uid, processors, grammar=None, budget=None, suppression=None):
     """Register a uid through the PRODUCTION bookkeeping helper.
 
     Delegates to ``Scheduler._register_uid_processors`` (the exact method the
@@ -74,7 +75,10 @@ def _register(stub, uid, processors, grammar=None, budget=None):
     same stateful set/tombstone machinery as grammar — a leaked force-close
     processor must be scrubbed from a foreign slot exactly like a grammar (codex).
     """
-    request = SimpleNamespace(reasoning_budget_logits_processor=budget)
+    request = SimpleNamespace(
+        reasoning_budget_logits_processor=budget,
+        suppressed_tokens_logits_processor=suppression,
+    )
     stub._register_uid_processors(
         uid, request, list(processors) if processors else None, grammar
     )
@@ -111,6 +115,22 @@ def test_realign_two_uids_grammar_not_leaked():
     lp = stub.batch_generator._generation_batch.logits_processors
     assert lp[0] == [glp], "uid 7 must keep its grammar processor"
     assert lp[1] == [], "uid 9 must NOT carry another uid's grammar processor"
+
+
+def test_realign_scrubs_finished_token_suppression_from_plain_request():
+    suppression = object()
+    stub = _make_scheduler_stub()
+    _register(stub, 7, [suppression], suppression=suppression)
+    assert stub._realign_guard_armed()
+
+    stub._forget_uid_grammar(7)
+    assert id(suppression) in stub._stateful_tombstones
+    stub.batch_generator = _FakeBatchGen(uids=[9], logits_processors=[[suppression]])
+
+    stub._realign_grammar_logits_processors()
+
+    assert stub.batch_generator._generation_batch.logits_processors == [[]]
+    assert id(suppression) not in stub._known_stateful_processors
 
 
 def test_realign_preserves_penalties_on_grammar_uid():

--- a/tests/test_reasoning_budget_generation.py
+++ b/tests/test_reasoning_budget_generation.py
@@ -25,11 +25,38 @@ import mlx.core as mx
 from vllm_mlx.api import reasoning_budget as rb
 from vllm_mlx.api.reasoning_budget import (
     ReasoningBudgetLogitsProcessor,
+    SuppressTokensLogitsProcessor,
     build_reasoning_budget_processor,
 )
 
 THINK_END = 99
 THINK_START = 50
+
+
+def test_suppress_tokens_processor_masks_only_valid_requested_ids():
+    processor = SuppressTokensLogitsProcessor([2, 2, -1, 99])
+    logits = processor(mx.array([1]), mx.zeros((1, 5)))
+    mx.eval(logits)
+
+    values = logits.tolist()[0]
+    assert values[2] == -math.inf
+    assert all(value == 0.0 for index, value in enumerate(values) if index != 2)
+
+
+def test_suppress_tokens_processor_reuses_width_mask(monkeypatch):
+    calls = 0
+    original_arange = mx.arange
+
+    def counted_arange(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        return original_arange(*args, **kwargs)
+
+    monkeypatch.setattr(mx, "arange", counted_arange)
+    processor = SuppressTokensLogitsProcessor([2])
+    processor(mx.array([1]), mx.zeros((1, 5)))
+    processor(mx.array([1, 2]), mx.zeros((1, 5)))
+    assert calls == 1
 
 
 def _feed(proc: ReasoningBudgetLogitsProcessor, seq: list[int]) -> str:

--- a/tests/test_responses_route.py
+++ b/tests/test_responses_route.py
@@ -6,6 +6,7 @@ Same lightweight-engine harness shape as ``test_anthropic_route_auth.py``
 """
 
 import json
+import math
 import sys
 import types
 from dataclasses import dataclass, field
@@ -1602,3 +1603,202 @@ def test_deepseek_codex_implicit_temperature_uses_low_entropy_default(monkeypatc
     assert (
         _resolved_responses_sampling_kwargs(chat, responses, None)["temperature"] == 0.7
     )
+
+
+def test_deepseek_thinking_false_suppresses_reopened_think_token(monkeypatch):
+    from types import SimpleNamespace
+
+    import mlx.core as mx
+
+    from vllm_mlx.routes.responses import _attach_deepseek_no_think_suppression
+
+    monkeypatch.setattr(
+        "vllm_mlx.api.reasoning_budget.resolve_think_token_ids",
+        lambda _tokenizer, _parser: (17, 18),
+    )
+    monkeypatch.setattr(
+        "vllm_mlx.routes.chat._engine_output_vocab_size", lambda _engine: 32
+    )
+    kwargs = {}
+    _attach_deepseek_no_think_suppression(
+        SimpleNamespace(tokenizer=object()),
+        SimpleNamespace(reasoning_parser_name="deepseek_v4"),
+        None,
+        True,
+        kwargs,
+    )
+
+    logits = kwargs["suppressed_tokens_logits_processor"](
+        mx.array([1, 2]), mx.zeros((1, 32))
+    )
+    mx.eval(logits)
+    assert logits[0, 17].item() == -math.inf
+    assert logits[0, 18].item() == 0.0
+
+
+def test_no_think_suppression_is_deepseek_and_explicit_false_only(monkeypatch):
+    from types import SimpleNamespace
+
+    from vllm_mlx.routes.responses import _attach_deepseek_no_think_suppression
+
+    monkeypatch.setattr(
+        "vllm_mlx.api.reasoning_budget.resolve_think_token_ids",
+        lambda _tokenizer, _parser: (17, 18),
+    )
+    monkeypatch.setattr(
+        "vllm_mlx.routes.chat._engine_output_vocab_size", lambda _engine: 32
+    )
+    engine = SimpleNamespace(tokenizer=object())
+
+    for cfg, explicit_no_thinking in (
+        (SimpleNamespace(reasoning_parser_name="deepseek_v4"), False),
+        (SimpleNamespace(reasoning_parser_name="qwen3"), True),
+    ):
+        kwargs = {}
+        _attach_deepseek_no_think_suppression(
+            engine, cfg, None, explicit_no_thinking, kwargs
+        )
+        assert "suppressed_tokens_logits_processor" not in kwargs
+
+
+def test_auto_disabled_thinking_does_not_activate_explicit_suppression(monkeypatch):
+    from types import SimpleNamespace
+
+    from vllm_mlx.api.models import ChatCompletionRequest
+    from vllm_mlx.routes.responses import _attach_deepseek_no_think_suppression
+    from vllm_mlx.service.helpers import _extract_thinking_from_request
+
+    request = ChatCompletionRequest(
+        model="m", messages=[{"role": "user", "content": "hello"}]
+    )
+    explicit_no_thinking = _extract_thinking_from_request(request) is False
+    request.chat_template_kwargs = {"enable_thinking": False}
+
+    kwargs = {}
+    _attach_deepseek_no_think_suppression(
+        SimpleNamespace(tokenizer=object()),
+        SimpleNamespace(reasoning_parser_name="deepseek_v4"),
+        None,
+        explicit_no_thinking,
+        kwargs,
+    )
+    assert "suppressed_tokens_logits_processor" not in kwargs
+
+
+@pytest.mark.parametrize("stream", [False, True])
+@pytest.mark.parametrize(
+    "no_think_fields",
+    [{"enable_thinking": False}, {"reasoning_effort": "none"}],
+)
+@pytest.mark.parametrize(
+    ("selected_model", "expect_suppression"),
+    [("deepseek-agent", True), ("qwen-default", False)],
+)
+def test_no_think_suppression_follows_requested_registry_model(
+    responses_client,
+    monkeypatch,
+    stream,
+    no_think_fields,
+    selected_model,
+    expect_suppression,
+):
+    from vllm_mlx.config import get_config
+    from vllm_mlx.runtime.model_registry import ModelEntry, ModelRegistry
+
+    cfg = get_config()
+    qwen_engine = _Engine()
+    deepseek_engine = _Engine()
+    registry = ModelRegistry()
+    registry.add(
+        ModelEntry(
+            engine=qwen_engine,
+            model_name="qwen-default",
+            model_path="qwen-default",
+            reasoning_parser="qwen3",
+        ),
+        is_default=True,
+    )
+    registry.add(
+        ModelEntry(
+            engine=deepseek_engine,
+            model_name="deepseek-agent",
+            model_path="DeepSeek-V4-Flash-0731",
+            reasoning_parser="deepseek_v4",
+        )
+    )
+    cfg.engine = qwen_engine
+    cfg.model_name = "qwen-default"
+    cfg.reasoning_parser_name = "qwen3"
+    cfg.model_registry = registry
+    monkeypatch.setattr(
+        "vllm_mlx.routes.chat._engine_output_vocab_size", lambda _engine: 256
+    )
+    monkeypatch.setattr(
+        "vllm_mlx.api.reasoning_budget.resolve_think_token_ids",
+        lambda _tokenizer, _parser: (17, 18),
+    )
+
+    response = responses_client.client.post(
+        "/v1/responses",
+        json=_payload(model=selected_model, stream=stream, **no_think_fields),
+        headers={"Authorization": "Bearer test-secret"},
+    )
+
+    assert response.status_code == 200
+    selected_engine = (
+        deepseek_engine if selected_model == "deepseek-agent" else qwen_engine
+    )
+    other_engine = (
+        qwen_engine if selected_engine is deepseek_engine else deepseek_engine
+    )
+    calls = selected_engine.stream_calls if stream else selected_engine.calls
+    assert len(calls) == 1
+    assert (
+        "suppressed_tokens_logits_processor" in calls[0].kwargs
+    ) is expect_suppression
+    assert not other_engine.calls and not other_engine.stream_calls
+
+
+def test_explicit_thinking_true_wins_over_reasoning_effort_none(responses_client):
+    response = responses_client.client.post(
+        "/v1/responses",
+        json=_payload(enable_thinking=True, reasoning_effort="none"),
+        headers={"Authorization": "Bearer test-secret"},
+    )
+
+    assert response.status_code == 200
+    kwargs = responses_client.engine.calls[-1].kwargs
+    assert kwargs["enable_thinking"] is True
+    assert "suppressed_tokens_logits_processor" not in kwargs
+
+
+def test_registry_engine_mismatch_fails_closed(monkeypatch):
+    from types import SimpleNamespace
+
+    from vllm_mlx.routes.responses import _attach_deepseek_no_think_suppression
+
+    selected_engine = SimpleNamespace(tokenizer=object())
+    stale_entry = SimpleNamespace(
+        engine=SimpleNamespace(tokenizer=object()),
+        reasoning_parser="deepseek_v4",
+        model_path="DeepSeek-V4-Flash-0731",
+        model_name="deepseek-agent",
+    )
+    cfg = SimpleNamespace(
+        model_registry=SimpleNamespace(get_entry=lambda _name: stale_entry),
+        reasoning_parser_name="deepseek_v4",
+        model_path="DeepSeek-V4-Flash-0731",
+    )
+    monkeypatch.setattr(
+        "vllm_mlx.api.reasoning_budget.resolve_think_token_ids",
+        lambda _tokenizer, _parser: (17, 18),
+    )
+    monkeypatch.setattr(
+        "vllm_mlx.routes.chat._engine_output_vocab_size", lambda _engine: 32
+    )
+
+    kwargs = {}
+    _attach_deepseek_no_think_suppression(
+        selected_engine, cfg, "deepseek-agent", True, kwargs
+    )
+    assert "suppressed_tokens_logits_processor" not in kwargs

--- a/vllm_mlx/api/reasoning_budget.py
+++ b/vllm_mlx/api/reasoning_budget.py
@@ -40,6 +40,34 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 
+class SuppressTokensLogitsProcessor:
+    """Statelessly prevent a small set of structural tokens from decoding."""
+
+    def __init__(self, token_ids: list[int] | tuple[int, ...]) -> None:
+        self._token_ids = tuple(dict.fromkeys(int(token_id) for token_id in token_ids))
+        self._masks: dict[int, Any | None] = {}
+
+    def __call__(self, _token_ids: Any, logits: Any) -> Any:
+        import mlx.core as mx
+
+        width = int(logits.shape[-1])
+        if width not in self._masks:
+            valid = tuple(
+                token_id for token_id in self._token_ids if 0 <= token_id < width
+            )
+            if valid:
+                suppressed = mx.array(valid)
+                self._masks[width] = mx.any(
+                    mx.arange(width)[:, None] == suppressed[None, :], axis=1
+                )
+            else:
+                self._masks[width] = None
+        mask = self._masks[width]
+        if mask is None:
+            return logits
+        return mx.where(mask[None, :], -mx.inf, logits)
+
+
 class ReasoningBudgetLogitsProcessor:
     """Force ``</think>`` once a per-request thinking-token budget is spent.
 

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -1726,6 +1726,9 @@ class BatchedEngine(BaseEngine):
         reasoning_budget_logits_processor = kwargs.pop(
             "reasoning_budget_logits_processor", None
         )
+        suppressed_tokens_logits_processor = kwargs.pop(
+            "suppressed_tokens_logits_processor", None
+        )
         if output_router_seed is None and isinstance(prompt, str):
             # ``build_prompt(enable_thinking=False)`` is part of the public
             # engine contract and returns the prepared Harmony string. A
@@ -1751,6 +1754,7 @@ class BatchedEngine(BaseEngine):
             requires_prompt_integrity=requires_prompt_integrity,
             grammar_logits_processor=grammar_logits_processor,
             reasoning_budget_logits_processor=reasoning_budget_logits_processor,
+            suppressed_tokens_logits_processor=suppressed_tokens_logits_processor,
         )
 
         if assistant_text_prefix:
@@ -1943,6 +1947,9 @@ class BatchedEngine(BaseEngine):
         reasoning_budget_logits_processor = kwargs.pop(
             "reasoning_budget_logits_processor", None
         )
+        suppressed_tokens_logits_processor = kwargs.pop(
+            "suppressed_tokens_logits_processor", None
+        )
         request_id = await self._engine.add_request(
             prompt=prompt,
             sampling_params=sampling_params,
@@ -1951,6 +1958,7 @@ class BatchedEngine(BaseEngine):
             requires_prompt_integrity=requires_prompt_integrity,
             grammar_logits_processor=grammar_logits_processor,
             reasoning_budget_logits_processor=reasoning_budget_logits_processor,
+            suppressed_tokens_logits_processor=suppressed_tokens_logits_processor,
         )
         # C-01 force-abort: publish the scheduler request id (text path)
         # so the route's disconnect_guard can call abort_request directly

--- a/vllm_mlx/engine_core.py
+++ b/vllm_mlx/engine_core.py
@@ -752,6 +752,7 @@ class EngineCore:
         requires_prompt_integrity: bool = False,
         grammar_logits_processor: Any | None = None,
         reasoning_budget_logits_processor: Any | None = None,
+        suppressed_tokens_logits_processor: Any | None = None,
     ) -> str:
         """
         Add a request for processing.
@@ -788,6 +789,7 @@ class EngineCore:
             requires_prompt_integrity=requires_prompt_integrity,
             grammar_logits_processor=grammar_logits_processor,
             reasoning_budget_logits_processor=reasoning_budget_logits_processor,
+            suppressed_tokens_logits_processor=suppressed_tokens_logits_processor,
         )
 
         # Throttle requests for hybrid models (GatedDeltaNet + Transformer).

--- a/vllm_mlx/request.py
+++ b/vllm_mlx/request.py
@@ -186,6 +186,10 @@ class Request:
     # -> the post-hoc reasoning cap in the postprocessor owns the request.
     reasoning_budget_logits_processor: Any | None = None
 
+    # Structural-token suppression for requests that must not re-enter a
+    # parser state after the prompt has explicitly closed it.
+    suppressed_tokens_logits_processor: Any | None = None
+
     # PFlash prompt compression state. When pflash_metadata["compressed"]
     # is True, prompt_token_ids is the compressed list and
     # original_prompt_token_ids holds the pre-compression sequence so

--- a/vllm_mlx/routes/responses.py
+++ b/vllm_mlx/routes/responses.py
@@ -436,6 +436,55 @@ def _resolved_responses_sampling_kwargs(
     return out
 
 
+def _attach_deepseek_no_think_suppression(
+    engine: BaseEngine,
+    cfg,
+    model_name: str | None,
+    explicit_no_thinking: bool,
+    chat_kwargs: dict,
+) -> None:
+    """Keep an explicitly non-thinking DeepSeek request out of ``<think>``."""
+    if not explicit_no_thinking:
+        return
+
+    model_cfg = cfg
+    registry = getattr(cfg, "model_registry", None)
+    if registry is not None:
+        try:
+            entry = registry.get_entry(model_name)
+        except KeyError:
+            return
+        if getattr(entry, "engine", None) is not engine:
+            return
+        from types import SimpleNamespace
+
+        model_cfg = SimpleNamespace(
+            reasoning_parser_name=getattr(entry, "reasoning_parser", None),
+            reasoning_parser=None,
+            model_path=getattr(entry, "model_path", None),
+            model_name=getattr(entry, "model_name", None),
+        )
+    if not _uses_deepseek_v4_reasoning(model_cfg):
+        return
+
+    from ..api.reasoning_budget import (
+        SuppressTokensLogitsProcessor,
+        resolve_think_token_ids,
+    )
+    from .chat import _engine_output_vocab_size
+
+    start_id, _end_id = resolve_think_token_ids(
+        getattr(engine, "tokenizer", None),
+        getattr(model_cfg, "reasoning_parser_name", None),
+    )
+    vocab_size = _engine_output_vocab_size(engine)
+    if start_id is None or vocab_size is None or not 0 <= start_id < vocab_size:
+        return
+    chat_kwargs["suppressed_tokens_logits_processor"] = SuppressTokensLogitsProcessor(
+        [start_id]
+    )
+
+
 def _should_start_in_thinking(chat_template: str, enable_thinking: bool | None) -> bool:
     """Thin wrapper over the shared
     ``service.helpers._should_start_in_thinking`` predicate.
@@ -750,6 +799,13 @@ async def create_response(request: Request):
                 preserve_developer_role=(
                     cfg_for_adapter.tool_call_parser == "deepseek_v4_0731"
                 ),
+            )
+            # Capture the client's preference before server defaults and the
+            # automatic tool/schema heuristics may mutate the adapted request.
+            _explicit_thinking = _extract_thinking_from_request(openai_request)
+            explicit_no_thinking = _explicit_thinking is False or (
+                _explicit_thinking is None
+                and getattr(openai_request, "reasoning_effort", None) == "none"
             )
         except ValueError as e:
             raise HTTPException(status_code=400, detail=str(e))
@@ -1134,6 +1190,7 @@ async def create_response(request: Request):
                         engine,
                         openai_request,
                         responses_request,
+                        explicit_no_thinking=explicit_no_thinking,
                         request_id_holder=_resp_rid_holder,
                         heartbeat_state=_resp_heartbeat_state,
                     ),
@@ -1152,7 +1209,13 @@ async def create_response(request: Request):
                 headers={**SSE_RESPONSE_HEADERS, "Connection": "keep-alive"},
             )
 
-        return await _non_stream(engine, openai_request, responses_request, request)
+        return await _non_stream(
+            engine,
+            openai_request,
+            responses_request,
+            request,
+            explicit_no_thinking=explicit_no_thinking,
+        )
     finally:
         _release_admission_unless_committed(engine, _admission_committed)
 
@@ -1233,6 +1296,8 @@ async def _non_stream(
     openai_request: ChatCompletionRequest,
     responses_request: ResponsesRequest,
     request: Request,
+    *,
+    explicit_no_thinking: bool = False,
 ) -> Response:
     cfg = get_config()
     created_at = int(time.time())
@@ -1290,6 +1355,13 @@ async def _non_stream(
     resolved_thinking = _resolve_enable_thinking(openai_request)
     if resolved_thinking is not None:
         chat_kwargs["enable_thinking"] = resolved_thinking
+    _attach_deepseek_no_think_suppression(
+        engine,
+        cfg,
+        responses_request.model,
+        explicit_no_thinking,
+        chat_kwargs,
+    )
 
     start_time = time.perf_counter()
     timeout = cfg.default_timeout
@@ -2100,6 +2172,7 @@ async def _stream_responses(
     openai_request: ChatCompletionRequest,
     responses_request: ResponsesRequest,
     *,
+    explicit_no_thinking: bool = False,
     request_id_holder: list | None = None,
     heartbeat_state: dict[str, object] | None = None,
 ) -> AsyncIterator[str]:
@@ -2242,6 +2315,13 @@ async def _stream_responses(
         resolved_thinking = _resolve_enable_thinking(openai_request)
         if resolved_thinking is not None:
             chat_kwargs["enable_thinking"] = resolved_thinking
+        _attach_deepseek_no_think_suppression(
+            engine,
+            cfg,
+            responses_request.model,
+            explicit_no_thinking,
+            chat_kwargs,
+        )
         # C-01: thread the request_id holder so disconnect_guard can
         # force-call scheduler.abort_request on client RST.
         if request_id_holder is not None:

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -2866,6 +2866,9 @@ class Scheduler:
         # processor is still handled: ``_forget_uid_grammar`` tombstones it, and
         # the tombstone re-arms the guard for the scrub tick.
         self._uids_with_reasoning_budget: dict[int, Any] = {}
+        # Stateless, but still a hard per-request invariant: positional slot
+        # desync must never leak a suppression mask to another request/model.
+        self._uids_with_suppressed_tokens: dict[int, Any] = {}
         # Identity set of every STATEFUL per-request processor currently in
         # flight (by ``id()``) — a grammar OR a reasoning-budget force-close.
         # Lets a slot be scrubbed of ANY such processor before its uid's
@@ -5587,6 +5590,11 @@ class Scheduler:
             # scrubbing tick.
             self._known_stateful_processors.add(id(_rblp))
             self._stateful_processor_objs[id(_rblp)] = _rblp
+        _stlp = getattr(request, "suppressed_tokens_logits_processor", None)
+        if _stlp is not None:
+            self._uids_with_suppressed_tokens[uid] = _stlp
+            self._known_stateful_processors.add(id(_stlp))
+            self._stateful_processor_objs[id(_stlp)] = _stlp
 
     def _forget_uid_grammar(self, uid: int) -> None:
         """Drop #558 PR-3 per-uid processor state for a uid leaving the batch.
@@ -5606,6 +5614,7 @@ class Scheduler:
         """
         self._uids_with_grammar.discard(uid)
         self._uids_with_reasoning_budget.pop(uid, None)
+        self._uids_with_suppressed_tokens.pop(uid, None)
         procs = self.uid_to_request_processors.pop(uid, None)
         if not procs:
             return
@@ -5650,6 +5659,7 @@ class Scheduler:
         return bool(
             self._uids_with_grammar
             or self._stateful_tombstones
+            or self._uids_with_suppressed_tokens
             or any(
                 not getattr(p, "_ended", False)
                 for p in self._uids_with_reasoning_budget.values()
@@ -6103,6 +6113,9 @@ class Scheduler:
             _rblp = getattr(request, "reasoning_budget_logits_processor", None)
             if _rblp is not None:
                 request_processors.append(_rblp)
+            _stlp = getattr(request, "suppressed_tokens_logits_processor", None)
+            if _stlp is not None:
+                request_processors.append(_stlp)
             request_logits_processors = (
                 [request_processors] if request_processors else None
             )


### PR DESCRIPTION
## Summary
- suppress the DeepSeek V4 `<think>` opener at decode time when Responses explicitly resolves thinking to false
- forward the stateless structural-token processor through both streaming and non-streaming engine paths
- leave thinking-enabled, unspecified-thinking, and non-DeepSeek requests unchanged

## Root cause
The 0731 prompt can explicitly close/disable thinking, but the model may later sample `<think>` again during a long agent turn. That re-enters the reasoning parser state and can leak reasoning or corrupt the expected content/tool boundary. Prompt shaping alone cannot enforce the invariant at decode time.

## Validation
- 144 Responses, reasoning-budget, and scheduler processor-isolation tests passed
- Ruff format/check passed
- `git diff --check` passed

## Review focus
Only blockers/major correctness, cross-model isolation, logits-processor composition, streaming parity, or high-value test gaps; no style nits.