### PR TITLE
fix(app): the GB column was two metrics wearing one hat

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Server/RAMBucketedDefault.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/RAMBucketedDefault.swift
@@ -31,9 +31,9 @@ import Foundation
 ///
 /// | RAM    | 🧠 Smart            | GB   | Cap | tok/s | 🚀 Fast                          |
 /// | ------ | ------------------- | ---- | --- | ----- | -------------------------------- |
-/// |  8 GB  | lfm2.5-2.6b-4bit    |  2.7 |  —  | 97.8  | — (only model that fits)         |
-/// | 16 GB  | bonsai-27b-2bit     | 10.7 | 86% | 17.8  | lfm2.5-8b-a1b-4bit · 121 · chat  |
-/// | 18 GB  | bonsai-27b-2bit     | 10.7 | 86% | 17.8  | lfm2.5-8b-a1b-4bit · 121 · chat  |
+/// |  8 GB  | lfm2.5-2.6b-4bit    |  2.0 |  —  | 97.8  | — (only model that fits)         |
+/// | 16 GB  | bonsai-27b-2bit     |  8.4 | 86% | 17.8  | lfm2.5-8b-a1b-4bit · 121 · chat  |
+/// | 18 GB  | bonsai-27b-2bit     |  8.4 | 86% | 17.8  | lfm2.5-8b-a1b-4bit · 121 · chat  |
 /// | 24 GB  | gemma-4-26b-4bit    | 14.6 | 87% | 41.7  | — (smart pick already fast)      |
 /// | 32 GB  | qwen3.6-35b-4bit    | 20.0 | 87% | 60.0  | — (smart pick already fast)      |
 /// | 64 GB  | qwen3.6-35b-8bit    | 37.7 | 87% | —     | qwen3.6-35b-4bit · 87% · 60      |
@@ -46,16 +46,20 @@ import Foundation
 /// maintainer's measured scores (M2/M3); the 64/96 GB smart rows have no
 /// local tok/s measurement yet (rendered without a speed figure).
 ///
-/// The three small rows were re-measured together on one M2 Pro
-/// (mlx-lm 0.31.3) rather than carried over, because the GB column had
-/// drifted into meaning *weights on disk* for bonsai while the field is
-/// documented as active memory. Peak resident, 2 K-token prefill:
-/// lfm2.5-2.6b 2.70 GB / 97.8 tok/s, lfm2.5-8b-a1b 5.63 GB / 121.2 tok/s,
-/// bonsai-27b 10.69 GB / 17.8 tok/s. bonsai's old 7.6 GB was its weight
-/// bytes and understated its real footprint by 3.1 GB — on the 16 GB Mac
-/// that is exactly the tier it is recommended for. The column is
-/// display-only (``pickStatsLine``), so this corrects what users read,
-/// not what the app allows them to run.
+/// The GB column is peak resident memory of the whole ``rapid-mlx serve``
+/// process tree, measured on an M3 Ultra. It must be measured THROUGH
+/// serve: the engine quantizes the KV cache to int4 by default, and a
+/// bare ``mlx_lm`` probe without that default reads about two gigabytes
+/// higher on a 27B. bonsai briefly shipped 10.7 GB here from exactly that
+/// mistake — an M2 Pro probe with an unquantized cache, reported via
+/// MLX's device high-water mark rather than RSS. Served, it is 8.4 GB on
+/// a short prompt and 8.5 GB on a 2 K-token one, so the figure is not
+/// especially workload-sensitive either.
+///
+/// The column had also drifted into meaning *weights on disk* for bonsai
+/// (7.6 GB) while the field is documented as active memory. tok/s are
+/// M2 Pro measurements. The column is display-only (``pickStatsLine``),
+/// so this corrects what users read, not what the app allows them to run.
 ///
 /// The capability column is monotonic non-decreasing by RAM, with ONE
 /// deliberate tie documented at the tier: the 64 GB smart 8-bit is floored
@@ -105,15 +109,15 @@ enum RAMBucketedDefault {
     /// an 8B-A1B MoE at ~121 tok/s. A chat specialist, so it carries a
     /// "Chat only" caveat instead of its (misleadingly low) blended score.
     private static let lfm2FastPick = Pick(
-        alias: "lfm2.5-8b-a1b-4bit", footprintGB: 5.6, capabilityPct: 62,
+        alias: "lfm2.5-8b-a1b-4bit", footprintGB: 5.3, capabilityPct: 62,
         tokensPerSec: 121.2, launchFlags: [], caveat: "Chat only")
 
     /// The 8 GB tier's only pick: LFM2.5-2.6B, a 2.6 B dense model whose
     /// 30 layers are 22 short-convolution blocks and just 8 GQA. Those 8
     /// attention layers are why it belongs here — the KV cache costs
     /// ~16 KB/token, so a 32 K conversation adds only ~0.5 GB on top of
-    /// 1.6 GB of weights. Measured on an M2 Pro: 2.70 GB peak,
-    /// 97.8 tok/s decode, 503 tok/s prefill.
+    /// 1.6 GB of weights. Served on an M3 Ultra it peaks at 2.0 GB; on an
+    /// M2 Pro it decodes at 97.8 tok/s and prefills at 503 tok/s.
     ///
     /// It carries a caveat rather than a capability %, and the caveat is
     /// Liquid's own: they publish this model as "not recommended for
@@ -126,7 +130,7 @@ enum RAMBucketedDefault {
     /// is deliberately the same band as the other caveat pick in the
     /// family, not an independently measured score.
     private static let lfm26Pick = Pick(
-        alias: "lfm2.5-2.6b-4bit", footprintGB: 2.7, capabilityPct: 62,
+        alias: "lfm2.5-2.6b-4bit", footprintGB: 2.0, capabilityPct: 62,
         tokensPerSec: 97.8, launchFlags: [], caveat: "Not for coding")
 
     /// The fast/light pick for the big-MoE tiers: the 4-bit Qwen3.6-35B
@@ -148,11 +152,11 @@ enum RAMBucketedDefault {
         // ``SafeDefaultFallback``. The user's first run was a model the app
         // had just told them not to run. Nothing in the catalog fit until
         // LFM2.5-2.6B: 2.70 GB peak leaves room for macOS on an 8 GB
-        // machine, where the old tier's 5.6 GB "fast" alt did not.
+        // machine, where the 16 GB tier's 5.3 GB "fast" alt did not.
         Tier(floorGB: 8, primary: lfm26Pick, alt: nil),
         Tier(
             floorGB: 16,
-            primary: Pick(alias: "bonsai-27b-2bit", footprintGB: 10.7, capabilityPct: 86, tokensPerSec: 17.8, launchFlags: []),
+            primary: Pick(alias: "bonsai-27b-2bit", footprintGB: 8.4, capabilityPct: 86, tokensPerSec: 17.8, launchFlags: []),
             alt: lfm2FastPick
         ),
         // 18 GB intentionally MIRRORS the 16 GB tier (bonsai smart + lfm2.5
@@ -165,7 +169,7 @@ enum RAMBucketedDefault {
         // edit. gemma-4-12b remains available in the full "All models" list.
         Tier(
             floorGB: 18,
-            primary: Pick(alias: "bonsai-27b-2bit", footprintGB: 10.7, capabilityPct: 86, tokensPerSec: 17.8, launchFlags: []),
+            primary: Pick(alias: "bonsai-27b-2bit", footprintGB: 8.4, capabilityPct: 86, tokensPerSec: 17.8, launchFlags: []),
             alt: lfm2FastPick
         ),
         // 24 & 32 GB: the smart pick is already MoE-fast (42 / 60 tok/s),

--- a/apps/rapid-mac/scripts/verify-recommendation-tiers.swift
+++ b/apps/rapid-mac/scripts/verify-recommendation-tiers.swift
@@ -33,19 +33,19 @@ struct Tier: Equatable {
     let alt: Pick?
     var picks: [Pick] { alt.map { [primary, $0] } ?? [primary] }
 }
-let lfm2FastPick = Pick(alias: "lfm2.5-8b-a1b-4bit", footprintGB: 5.6, capabilityPct: 62,
+let lfm2FastPick = Pick(alias: "lfm2.5-8b-a1b-4bit", footprintGB: 5.3, capabilityPct: 62,
                         tokensPerSec: 121.2, launchFlags: [], caveat: "Chat only")
-let lfm26Pick = Pick(alias: "lfm2.5-2.6b-4bit", footprintGB: 2.7, capabilityPct: 62,
+let lfm26Pick = Pick(alias: "lfm2.5-2.6b-4bit", footprintGB: 2.0, capabilityPct: 62,
                      tokensPerSec: 97.8, launchFlags: [], caveat: "Not for coding")
 let qwen35bFastPick = Pick(alias: "qwen3.6-35b-4bit", footprintGB: 20.0, capabilityPct: 87,
                            tokensPerSec: 60.0, launchFlags: [])
 let tiers: [Tier] = [
     Tier(floorGB: 8, primary: lfm26Pick, alt: nil),
     Tier(floorGB: 16,
-         primary: Pick(alias: "bonsai-27b-2bit", footprintGB: 10.7, capabilityPct: 86, tokensPerSec: 17.8, launchFlags: []),
+         primary: Pick(alias: "bonsai-27b-2bit", footprintGB: 8.4, capabilityPct: 86, tokensPerSec: 17.8, launchFlags: []),
          alt: lfm2FastPick),
     Tier(floorGB: 18,  // mirrors 16 GB (bonsai + lfm2.5) — no "more RAM, worse pick" dip
-         primary: Pick(alias: "bonsai-27b-2bit", footprintGB: 10.7, capabilityPct: 86, tokensPerSec: 17.8, launchFlags: []),
+         primary: Pick(alias: "bonsai-27b-2bit", footprintGB: 8.4, capabilityPct: 86, tokensPerSec: 17.8, launchFlags: []),
          alt: lfm2FastPick),
     Tier(floorGB: 24,
          primary: Pick(alias: "gemma-4-26b-4bit", footprintGB: 14.6, capabilityPct: 87, tokensPerSec: 41.7,
@@ -164,19 +164,19 @@ check(!tiers.flatMap(\.picks).contains { $0.alias == "gemma-4-12b-4bit" }, "gemm
 print("Fast chat-specialist shows a 'Chat only' caveat instead of a misleading capability %:")
 let fast16 = picks(forPhysicalRAMGB: 16)[1]
 check(fast16.caveat == "Chat only", "16GB fast (lfm2.5) carries the Chat only caveat")
-check(pickStatsLine(fast16) == "5.6 GB · ~121 tok/s · Chat only", "lfm2.5 stats line drops the % for the caveat")
+check(pickStatsLine(fast16) == "5.3 GB · ~121 tok/s · Chat only", "lfm2.5 stats line drops the % for the caveat")
 // Liquid publishes 2.6B as "not recommended for agentic coding" — our users
 // drive coding agents, so the card must say so instead of showing a bare %.
 let smart8 = picks(forPhysicalRAMGB: 8)[0]
 check(picks(forPhysicalRAMGB: 8).count == 1, "8GB has a single pick (nothing else fits)")
 check(smart8.caveat == "Not for coding", "8GB pick carries the coding caveat")
-check(pickStatsLine(smart8) == "2.7 GB · ~98 tok/s · Not for coding", "8GB stats line drops the % for the caveat")
+check(pickStatsLine(smart8) == "2.0 GB · ~98 tok/s · Not for coding", "8GB stats line drops the % for the caveat")
 check(smart8.footprintGB < 4.0, "8GB pick must leave room for macOS on an 8GB machine")
 let fast96 = picks(forPhysicalRAMGB: 96)[1]
 check(fast96.caveat == nil, "96GB fast (qwen3.6-35b-4bit) is general-purpose — no caveat")
 check(pickStatsLine(fast96) == "20.0 GB · 87% capability · ~60 tok/s", "general-purpose fast pick keeps its capability %")
 let smart16 = picks(forPhysicalRAMGB: 16)[0]
-check(pickStatsLine(smart16) == "10.7 GB · 86% capability · ~18 tok/s", "bonsai renders its measured PEAK, not its weight bytes")
+check(pickStatsLine(smart16) == "8.4 GB · 86% capability · ~18 tok/s", "bonsai renders its served PEAK, not its weight bytes")
 let smart96 = picks(forPhysicalRAMGB: 96)[0]
 check(pickStatsLine(smart96) == "65.0 GB · 88% capability", "no-tok/s smart pick omits the speed figure")
 


### PR DESCRIPTION
## Why

#1443 set the three small picks' `footprintGB` from a bare `mlx_lm` probe on an M2 Pro. Wrong instrument — and I only caught it by going back to measure something else.

That probe read MLX's device-allocation high-water mark with an **unquantized KV cache**. The app launches `rapid-mlx serve`, which quantizes the KV cache to **int4 by default** — worth roughly two gigabytes on a 27B. The column was describing a configuration the app never runs.

It also carried a claim that did not survive checking. The docs I wrote alongside #1443 said peak memory was strongly workload-dependent, citing `bonsai-27b-2bit` at 8.4 GB on a short prompt and 10.7 GB on a 2K prefill. Re-running the long prompt on the **same M3 Ultra** gives **8.5 GB**. The prompt was never the variable.

## What

All three rows now come from one instrument — peak RSS of the whole `rapid-mlx serve` process tree, M3 Ultra, one run:

| alias | was | now |
|---|---:|---:|
| `bonsai-27b-2bit` | 10.7 GB | **8.4 GB** |
| `lfm2.5-8b-a1b-4bit` | 5.6 GB | **5.3 GB** |
| `lfm2.5-2.6b-4bit` | 2.7 GB | **2.0 GB** |

The field is display-only (`pickStatsLine` / picker tagline), so this changes what users read, not what the app lets them run.

The weights-vs-footprint finding from #1443 still stands, just smaller than I claimed: the column had drifted into showing bonsai's **7.6 GB of weight tensors** against **8.4 GB** served.

The doc comment now says explicitly that this column must be measured *through* `serve`, and why — so the next person does not reach for a bare `mlx_lm` script and re-introduce the same gap.

## Verification

- `verify-recommendation-tiers.swift` → ALL PASS, with the literal stats-line expectations updated (`8.4 GB · 86% capability · ~18 tok/s`, `2.0 GB · ~98 tok/s · Not for coding`, `5.3 GB · ~121 tok/s · Chat only`).
- `swift build` clean.
- The site's `/docs/hardware-tiers` note and the new blog post were corrected in the same batch, so the three surfaces agree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)