### PR TITLE
Harden benchmark methodology metadata

### DIFF
--- a/scripts/bench_attention.py
+++ b/scripts/bench_attention.py
@@ -31,11 +31,14 @@ ballpark — the achieved/peak ratio is what matters for the conclusion.
 from __future__ import annotations
 
 import argparse
-import json
 import time
 
 import mlx.core as mx
 
+try:
+    from scripts.bench_metadata import write_bench_json
+except ModuleNotFoundError:  # Direct execution outside the repository root.
+    from bench_metadata import write_bench_json
 from vllm_mlx.optimizations import detect_hardware
 
 
@@ -280,25 +283,21 @@ def main():
             )
 
     if args.json:
-        with open(args.json, "w") as f:
-            json.dump(
-                {
-                    "hardware": {
-                        "chip": hw.chip_name,
-                        "gpu_cores": hw.gpu_cores,
-                        "memory_bandwidth_gbs": hw.memory_bandwidth_gbs,
-                        "estimated_peak_tflops": peak_tflops,
-                    },
-                    "config": {
-                        "dtype": args.dtype,
-                        "causal": causal,
-                        "repeats": args.repeats,
-                    },
-                    "results": raw,
-                },
-                f,
-                indent=2,
-            )
+        payload = {
+            "hardware": {
+                "chip": hw.chip_name,
+                "gpu_cores": hw.gpu_cores,
+                "memory_bandwidth_gbs": hw.memory_bandwidth_gbs,
+                "estimated_peak_tflops": peak_tflops,
+            },
+            "config": {
+                "dtype": args.dtype,
+                "causal": causal,
+                "repeats": args.repeats,
+            },
+            "results": raw,
+        }
+        write_bench_json(args.json, payload, __file__)
         print()
         print(f"raw results → {args.json}")
 

--- a/scripts/bench_decode_tps.py
+++ b/scripts/bench_decode_tps.py
@@ -18,6 +18,11 @@ from datetime import datetime
 
 import httpx
 
+try:
+    from scripts.bench_metadata import write_bench_json
+except ModuleNotFoundError:  # Direct execution outside the repository root.
+    from bench_metadata import write_bench_json
+
 BASE_URL = "http://localhost:8000/v1"
 
 
@@ -267,8 +272,7 @@ def main():
     }
     out_path = f"reports/decode_tps_{args.label}.json"
     os.makedirs(os.path.dirname(out_path) or ".", exist_ok=True)
-    with open(out_path, "w") as f:
-        json.dump(output, f, indent=2, default=str)
+    write_bench_json(out_path, output, __file__, default=str)
     print(f"\n  Saved to {out_path}")
 
 

--- a/scripts/bench_deepseek_restart_cache.py
+++ b/scripts/bench_deepseek_restart_cache.py
@@ -24,6 +24,11 @@ import urllib.request
 import uuid
 from pathlib import Path
 
+try:
+    from scripts.bench_metadata import format_bench_json
+except ModuleNotFoundError:  # Direct execution outside the repository root.
+    from bench_metadata import format_bench_json
+
 
 def _get_json(url: str, timeout: float = 2.0) -> dict:
     with urllib.request.urlopen(url, timeout=timeout) as response:
@@ -245,7 +250,7 @@ def main() -> int:
             "ttft_verified": ttft_verified,
             "work_dir": None if auto_work_dir else str(work),
         }
-        print(json.dumps(summary, indent=2, sort_keys=True))
+        print(format_bench_json(summary, __file__, sort_keys=True))
         return 0 if succeeded else 1
     finally:
         if auto_work_dir:

--- a/scripts/bench_dflash.py
+++ b/scripts/bench_dflash.py
@@ -47,6 +47,11 @@ from statistics import median
 
 import httpx
 
+try:
+    from scripts.bench_metadata import write_bench_json
+except ModuleNotFoundError:  # Direct execution outside the repository root.
+    from bench_metadata import write_bench_json
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
@@ -562,7 +567,7 @@ def main(argv: list[str] | None = None) -> int:
         f"dflash_{args.model.replace('/', '_').lower()}.json"
     )
     output.parent.mkdir(parents=True, exist_ok=True)
-    output.write_text(json.dumps(summary, indent=2) + "\n")
+    write_bench_json(output, summary, __file__)
 
     logger.info("--- summary ---")
     for k in WORKLOADS:

--- a/scripts/bench_diffusion_gemma.py
+++ b/scripts/bench_diffusion_gemma.py
@@ -53,6 +53,11 @@ import sys
 import time
 import urllib.request
 
+try:
+    from scripts.bench_metadata import write_bench_json
+except ModuleNotFoundError:  # Direct execution outside the repository root.
+    from bench_metadata import write_bench_json
+
 MODEL = "mlx-community/diffusiongemma-26B-A4B-it-4bit"
 PROMPT = (
     "Explain what a diffusion language model is and how it differs from an "
@@ -172,8 +177,7 @@ def main() -> int:
             f"{int(r['median_tokens'])} |"
         )
     out = {"model": MODEL, "base": base, "runs": args.runs, "sweep": rows}
-    with open("/tmp/diffgemma_bench.json", "w") as f:
-        json.dump(out, f, indent=2)
+    write_bench_json("/tmp/diffgemma_bench.json", out, __file__)
     print("\nRaw JSON: /tmp/diffgemma_bench.json")
     return 0
 

--- a/scripts/bench_engine_solo.py
+++ b/scripts/bench_engine_solo.py
@@ -15,6 +15,11 @@ from datetime import datetime
 
 import httpx
 
+try:
+    from scripts.bench_metadata import write_bench_json
+except ModuleNotFoundError:  # Direct execution outside the repository root.
+    from bench_metadata import write_bench_json
+
 TOOLS = [
     {
         "type": "function",
@@ -315,8 +320,7 @@ def main():
 
     out_path = f"reports/engine_parity_{args.label}.json"
     os.makedirs(os.path.dirname(out_path) or ".", exist_ok=True)
-    with open(out_path, "w") as f:
-        json.dump(output, f, indent=2, default=str)
+    write_bench_json(out_path, output, __file__, default=str)
     print(f"\n  Saved to {out_path}")
 
 

--- a/scripts/bench_metadata.py
+++ b/scripts/bench_metadata.py
@@ -1,0 +1,210 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Bench JSON metadata and compatibility helpers.
+
+Every ``scripts/bench_*.py`` JSON artifact carries two top-level keys:
+
+* ``_schema_version`` — an integer schema version for the artifact shape.
+* ``_methodology_hash`` — a SHA-256 of the emitting bench script's bytes,
+  so a methodology change forces a re-bench instead of silently merging
+  old and new numbers.
+
+Consumers that classify or aggregate bench JSON must call
+``assert_compatible`` before merging payloads. The explicit backward
+compatibility policy is:
+
+* ``SCHEMA_VERSION`` is the current artifact schema. It starts at ``1``.
+* A payload with ``_schema_version`` equal to ``SCHEMA_VERSION`` is
+  compatible with any other payload of the same version.
+* A payload with ``_schema_version`` missing or not an integer is
+  rejected: it cannot be trusted to mean anything.
+* A payload with ``_schema_version`` different from ``SCHEMA_VERSION``
+  is rejected. There is no silent cross-version merge. If a future
+  schema is additive-only, bump ``SCHEMA_VERSION`` and update this
+  policy explicitly; old artifacts remain readable but are not merged
+  into new aggregates.
+* ``_methodology_hash`` must be present and equal across all payloads
+  being merged. A different hash means the bench script changed, so the
+  numbers were produced under a different methodology and must not be
+  combined.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import string
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = 1
+JSON_BENCH_SCRIPTS = frozenset(
+    {
+        "bench_attention.py",
+        "bench_decode_tps.py",
+        "bench_deepseek_restart_cache.py",
+        "bench_dflash.py",
+        "bench_diffusion_gemma.py",
+        "bench_engine_solo.py",
+        "bench_readme_refresh.py",
+        "bench_suffix_decoding.py",
+        "bench_suffix_decoding_integrated.py",
+        "bench_vs_ollama.py",
+    }
+)
+NON_JSON_BENCH_SCRIPTS = frozenset(
+    {
+        "bench_cache_perf.py",
+        "bench_detok.py",
+        "bench_kv_cache.py",
+        "bench_metadata.py",
+        "bench_snapshot.py",
+    }
+)
+
+_MISSING = object()
+
+
+def methodology_hash_for_script(script_path: str | Path) -> str:
+    """Return the SHA-256 hex digest of ``script_path``'s bytes.
+
+    The hash is over the exact file bytes so any edit to the bench
+    script — prompt, workload, thresholds, measurement code — changes
+    the methodology hash and forces a re-bench.
+    """
+    return hashlib.sha256(Path(script_path).read_bytes()).hexdigest()
+
+
+def add_bench_metadata(
+    payload: dict[str, Any], script_path: str | Path
+) -> dict[str, Any]:
+    """Add ``_schema_version`` and ``_methodology_hash`` to ``payload``.
+
+    Returns a stamped copy. Existing keys are overwritten in the copy:
+    metadata is authoritative and cannot be spoofed by a payload body.
+    """
+    stamped = dict(payload)
+    stamped["_schema_version"] = SCHEMA_VERSION
+    stamped["_methodology_hash"] = methodology_hash_for_script(script_path)
+    return stamped
+
+
+def format_bench_json(
+    payload: dict[str, Any],
+    script_path: str | Path,
+    *,
+    indent: int = 2,
+    sort_keys: bool = False,
+    default: Any = None,
+) -> str:
+    """Stamp and serialize one benchmark artifact."""
+    script_name = Path(script_path).name
+    if script_name not in JSON_BENCH_SCRIPTS:
+        raise ValueError(
+            f"unregistered benchmark JSON emitter: {script_name}; "
+            "update JSON_BENCH_SCRIPTS"
+        )
+    return json.dumps(
+        add_bench_metadata(payload, script_path),
+        indent=indent,
+        sort_keys=sort_keys,
+        default=default,
+    )
+
+
+def write_bench_json(
+    destination: str | Path,
+    payload: dict[str, Any],
+    script_path: str | Path,
+    *,
+    indent: int = 2,
+    sort_keys: bool = False,
+    default: Any = None,
+) -> None:
+    """Stamp and write one benchmark artifact with a trailing newline."""
+    Path(destination).write_text(
+        format_bench_json(
+            payload,
+            script_path,
+            indent=indent,
+            sort_keys=sort_keys,
+            default=default,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def _schema_version(payload: Any) -> Any:
+    if not isinstance(payload, dict):
+        return _MISSING
+    return payload.get("_schema_version", _MISSING)
+
+
+def _methodology_hash(payload: Any) -> Any:
+    if not isinstance(payload, dict):
+        return _MISSING
+    return payload.get("_methodology_hash", _MISSING)
+
+
+def assert_compatible(*payloads: Any) -> None:
+    """Raise ``ValueError`` if any payload is not merge-compatible.
+
+    Compatibility requires every payload to be a dict carrying the
+    current ``_schema_version`` and a non-empty ``_methodology_hash``,
+    and all payloads to share the same ``_methodology_hash``.
+    """
+    if not payloads:
+        return
+    first_hash: str | None = None
+    for index, payload in enumerate(payloads):
+        label = f"payload[{index}]"
+        version = _schema_version(payload)
+        if version is _MISSING:
+            raise ValueError(f"{label} is missing _schema_version")
+        if not isinstance(version, int) or isinstance(version, bool):
+            raise ValueError(f"{label} has non-integer _schema_version: {version!r}")
+        if version != SCHEMA_VERSION:
+            raise ValueError(
+                f"{label} has _schema_version {version!r}; expected "
+                f"{SCHEMA_VERSION}. Methodology changes force a re-bench."
+            )
+        digest = _methodology_hash(payload)
+        if digest is _MISSING:
+            raise ValueError(f"{label} is missing _methodology_hash")
+        if (
+            not isinstance(digest, str)
+            or len(digest) != 64
+            or any(character not in string.hexdigits for character in digest)
+        ):
+            raise ValueError(f"{label} has invalid SHA-256 _methodology_hash")
+        digest = digest.lower()
+        if first_hash is None:
+            first_hash = digest
+        elif digest != first_hash:
+            raise ValueError(
+                f"{label} has _methodology_hash {digest!r}; expected "
+                f"{first_hash!r}. Bench scripts differ; refusing to merge."
+            )
+
+
+def load_compatible_bench_json(*paths: str | Path) -> list[dict[str, Any]]:
+    """Load artifacts only when their schema and methodology are compatible."""
+    payloads = [json.loads(Path(path).read_text()) for path in paths]
+    assert_compatible(*payloads)
+    return payloads
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate benchmark JSON before aggregation or classification."
+    )
+    parser.add_argument("artifacts", nargs="+", type=Path)
+    args = parser.parse_args(argv)
+    payloads = load_compatible_bench_json(*args.artifacts)
+    print(f"compatible benchmark artifacts: {len(payloads)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/bench_readme_refresh.py
+++ b/scripts/bench_readme_refresh.py
@@ -43,6 +43,11 @@ from pathlib import Path
 
 import requests
 
+try:
+    from scripts.bench_metadata import write_bench_json
+except ModuleNotFoundError:  # Direct execution outside the repository root.
+    from bench_metadata import write_bench_json
+
 REPO = Path(__file__).resolve().parent.parent
 RESULTS_DIR = REPO / "reports" / "benchmarks" / "readme-refresh"
 RESULTS_DIR.mkdir(parents=True, exist_ok=True)
@@ -660,29 +665,25 @@ def main():
     out_path = (
         Path(args.output) if args.output else RESULTS_DIR / f"results-{stamp}.json"
     )
-    out_path.write_text(
-        json.dumps(
+    output = {
+        "stamp": stamp,
+        "concurrency": args.concurrency,
+        "rounds": ROUNDS,
+        "max_tokens": MAX_TOKENS,
+        "results": [
             {
-                "stamp": stamp,
-                "concurrency": args.concurrency,
-                "rounds": ROUNDS,
-                "max_tokens": MAX_TOKENS,
-                "results": [
-                    {
-                        "model": r.model,
-                        "engine": r.engine,
-                        "arch_note": r.arch_note,
-                        "median_aggregate_tps": r.median_aggregate_tps(),
-                        "median_decode_tps_per_stream": r.median_decode_tps_per_stream(),
-                        "error": r.error,
-                        "rounds": [asdict(rnd) for rnd in r.rounds],
-                    }
-                    for r in all_results
-                ],
-            },
-            indent=2,
-        )
-    )
+                "model": r.model,
+                "engine": r.engine,
+                "arch_note": r.arch_note,
+                "median_aggregate_tps": r.median_aggregate_tps(),
+                "median_decode_tps_per_stream": r.median_decode_tps_per_stream(),
+                "error": r.error,
+                "rounds": [asdict(rnd) for rnd in r.rounds],
+            }
+            for r in all_results
+        ],
+    }
+    write_bench_json(out_path, output, __file__)
     print(f"\n=== Results saved: {out_path} ===", flush=True)
 
     # Markdown summary

--- a/scripts/bench_suffix_decoding.py
+++ b/scripts/bench_suffix_decoding.py
@@ -25,7 +25,6 @@ Usage:
 from __future__ import annotations
 
 import argparse
-import json
 import time
 from dataclasses import dataclass, field
 
@@ -33,6 +32,10 @@ import mlx.core as mx
 from mlx_lm import load
 from mlx_lm.models import cache as mlx_cache
 
+try:
+    from scripts.bench_metadata import write_bench_json
+except ModuleNotFoundError:  # Direct execution outside the repository root.
+    from bench_metadata import write_bench_json
 from vllm_mlx.speculative.suffix_decoding import SuffixDecodingDrafter
 
 # ---------- Workloads ------------------------------------------------------
@@ -569,8 +572,7 @@ def main():
                 for mid, results in all_results.items()
             },
         }
-        with open(args.json, "w") as f:
-            json.dump(out, f, indent=2)
+        write_bench_json(args.json, out, __file__)
         print(f"\nWrote raw results: {args.json}")
 
 

--- a/scripts/bench_suffix_decoding_integrated.py
+++ b/scripts/bench_suffix_decoding_integrated.py
@@ -65,6 +65,10 @@ import httpx
 REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
+try:
+    from scripts.bench_metadata import write_bench_json  # noqa: E402
+except ModuleNotFoundError:  # Direct execution outside the repository root.
+    from bench_metadata import write_bench_json  # noqa: E402
 from vllm_mlx.model_auto_config import (  # noqa: E402
     classify_suffix_decoding_tier,
 )
@@ -614,7 +618,7 @@ def main(argv: list[str] | None = None) -> int:
         f"suffix_{args.model.replace('/', '_').lower()}.json"
     )
     output.parent.mkdir(parents=True, exist_ok=True)
-    output.write_text(json.dumps(summary, indent=2) + "\n")
+    write_bench_json(output, summary, __file__)
     logger.info("--- summary ---")
     for k in WORKLOADS:
         if k in skipped:

--- a/scripts/bench_vs_ollama.py
+++ b/scripts/bench_vs_ollama.py
@@ -31,6 +31,11 @@ from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 
+try:
+    from scripts.bench_metadata import write_bench_json
+except ModuleNotFoundError:  # Direct execution outside the repository root.
+    from bench_metadata import write_bench_json
+
 DEFAULT_OUTPUT_DIR = Path("reports/benchmarks/ollama-comparison")
 PORT_BIND_ATTEMPTS = 3
 
@@ -558,7 +563,7 @@ def write_outputs(result: dict, output_dir: Path) -> dict[str, Path]:
     stamp = safe_timestamp(result["metadata"]["timestamp"])
     json_path = output_dir / f"{stamp}.json"
     markdown_path = output_dir / f"{stamp}.md"
-    json_path.write_text(json.dumps(result, indent=2), encoding="utf-8")
+    write_bench_json(json_path, result, __file__)
     markdown_path.write_text(render_markdown(result), encoding="utf-8")
     return {"json": json_path, "markdown": markdown_path}
 

--- a/tests/test_bench_metadata.py
+++ b/tests/test_bench_metadata.py
@@ -1,0 +1,170 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for scripts/bench_metadata.py (#320 Tier S2)."""
+
+from __future__ import annotations
+
+import ast
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts import bench_metadata as meta
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _payload(**overrides):
+    base = {
+        "_schema_version": meta.SCHEMA_VERSION,
+        "_methodology_hash": "a" * 64,
+        "value": 1,
+    }
+    base.update(overrides)
+    return base
+
+
+class TestMetadataEmission:
+    def test_add_metadata_sets_schema_and_hash(self, tmp_path):
+        script = tmp_path / "bench_x.py"
+        script.write_text("print('hello')\n")
+        payload = meta.add_bench_metadata({"value": 1}, script)
+
+        assert payload["_schema_version"] == meta.SCHEMA_VERSION
+        assert (
+            payload["_methodology_hash"]
+            == hashlib.sha256(script.read_bytes()).hexdigest()
+        )
+
+    def test_registry_covers_every_bench_script(self):
+        discovered = {path.name for path in (ROOT / "scripts").glob("bench_*.py")}
+
+        assert discovered == meta.JSON_BENCH_SCRIPTS | meta.NON_JSON_BENCH_SCRIPTS
+        assert not meta.JSON_BENCH_SCRIPTS & meta.NON_JSON_BENCH_SCRIPTS
+
+    @pytest.mark.parametrize("script_name", meta.JSON_BENCH_SCRIPTS)
+    def test_json_emitter_uses_central_writer(self, script_name):
+        script = ROOT / "scripts" / script_name
+        tree = ast.parse(script.read_text(), filename=str(script))
+        calls = {
+            node.func.id
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+        }
+
+        assert calls & {"write_bench_json", "format_bench_json"}, (
+            f"{script_name} bypasses the centralized benchmark JSON writer"
+        )
+        bypasses = []
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call) or not isinstance(
+                node.func, ast.Attribute
+            ):
+                continue
+            if (
+                isinstance(node.func.value, ast.Name)
+                and node.func.value.id == "json"
+                and node.func.attr == "dump"
+            ):
+                bypasses.append(node.lineno)
+            if node.func.attr == "write_text" and any(
+                isinstance(child, ast.Call)
+                and isinstance(child.func, ast.Attribute)
+                and isinstance(child.func.value, ast.Name)
+                and child.func.value.id == "json"
+                and child.func.attr == "dumps"
+                for child in ast.walk(node)
+            ):
+                bypasses.append(node.lineno)
+
+        assert not bypasses, (
+            f"{script_name} has raw JSON artifact writer(s) at {bypasses}"
+        )
+
+    def test_writer_rejects_unregistered_emitter(self, tmp_path):
+        script = tmp_path / "bench_unregistered.py"
+        script.write_text("pass\n")
+
+        with pytest.raises(ValueError, match="unregistered benchmark JSON emitter"):
+            meta.format_bench_json({}, script)
+
+    def test_writer_emits_stamped_json_without_mutating_payload(self, tmp_path):
+        destination = tmp_path / "result.json"
+        script = ROOT / "scripts" / "bench_attention.py"
+        payload = {"result": 42}
+
+        meta.write_bench_json(destination, payload, script)
+
+        artifact = json.loads(destination.read_text())
+        assert payload == {"result": 42}
+        assert artifact["result"] == 42
+        assert artifact["_schema_version"] == meta.SCHEMA_VERSION
+        assert (
+            artifact["_methodology_hash"]
+            == hashlib.sha256(script.read_bytes()).hexdigest()
+        )
+
+    def test_add_metadata_copies_payload_and_overwrites_spoofed_keys(self, tmp_path):
+        script = tmp_path / "bench_x.py"
+        script.write_text("x = 1\n")
+        original = {"_schema_version": 99, "_methodology_hash": "spoofed"}
+        payload = meta.add_bench_metadata(original, script)
+
+        assert original == {"_schema_version": 99, "_methodology_hash": "spoofed"}
+        assert payload["_schema_version"] == meta.SCHEMA_VERSION
+        assert (
+            payload["_methodology_hash"]
+            == hashlib.sha256(script.read_bytes()).hexdigest()
+        )
+
+
+class TestDeterministicHash:
+    def test_hash_changes_with_script_bytes(self, tmp_path):
+        script = tmp_path / "bench_x.py"
+        script.write_text("a = 1\n")
+        h1 = meta.methodology_hash_for_script(script)
+        script.write_text("a = 2\n")
+        h2 = meta.methodology_hash_for_script(script)
+
+        assert h1 != h2
+        assert len(h1) == 64
+        assert len(h2) == 64
+
+
+class TestCompatibility:
+    def test_same_payloads_are_compatible(self):
+        meta.assert_compatible(_payload(), _payload())
+
+    def test_missing_schema_rejected(self):
+        payload = _payload()
+        payload.pop("_schema_version")
+        with pytest.raises(ValueError, match="_schema_version"):
+            meta.assert_compatible(payload)
+
+    def test_non_integer_schema_rejected(self):
+        with pytest.raises(ValueError, match="non-integer"):
+            meta.assert_compatible(_payload(_schema_version="1"))
+
+    def test_different_schema_rejected(self):
+        with pytest.raises(ValueError, match="re-bench"):
+            meta.assert_compatible(_payload(), _payload(_schema_version=2))
+
+    def test_missing_hash_rejected(self):
+        payload = _payload()
+        payload.pop("_methodology_hash")
+        with pytest.raises(ValueError, match="_methodology_hash"):
+            meta.assert_compatible(payload)
+
+    @pytest.mark.parametrize("digest", ["invalid", "g" * 64, "a" * 63])
+    def test_invalid_hash_rejected(self, digest):
+        with pytest.raises(ValueError, match="invalid SHA-256"):
+            meta.assert_compatible(_payload(_methodology_hash=digest))
+
+    def test_different_hash_rejected(self):
+        with pytest.raises(ValueError, match="refusing to merge"):
+            meta.assert_compatible(_payload(), _payload(_methodology_hash="b" * 64))
+
+    def test_non_dict_payload_rejected(self):
+        with pytest.raises(ValueError, match="_schema_version"):
+            meta.assert_compatible([], _payload())


### PR DESCRIPTION
Closes #320 (Tier S2).

## What changed

- add `_schema_version` and a SHA-256 `_methodology_hash` to every JSON-emitting `scripts/bench_*.py` artifact
- centralize artifact serialization so emitters cannot bypass stamping
- maintain one production registry covering every `bench_*.py` script; new scripts must explicitly opt into JSON or non-JSON status
- provide a multi-artifact validation CLI/loader that rejects missing, invalid, cross-schema, and cross-methodology inputs before aggregation or classification

## Methodology scope

Per #320 S2, `_methodology_hash` is specifically the hash of the emitting bench script. Imported package code is intentionally outside this field: expanding it to a transitive dependency graph would change the issue contract and make artifacts vary with unrelated implementation edits.

## Why

Benchmark results could previously survive benchmark-script methodology changes without any machine-readable signal, allowing stale or incompatible data to be classified together.

## Validation

- `ruff check` on all changed files
- 88 focused tests passed
- 473 broader benchmark/model-config tests passed
- full suite on the first revision: 15,464 passed; final validation rerun pending
- negative gates reject unregistered emitters and raw `json.dump` / `write_text(json.dumps(...))` artifact paths

## Runtime impact

No scheduler, model, route, parser, or inference code changes. The only user-visible behavior is two reserved top-level keys in benchmark JSON output.