### PR TITLE
chore: bump version to 0.12.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.12.3"
+version = "0.12.4"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Why

Cut **0.12.4** — a patch release rolling up everything merged since v0.12.3 (13 PRs, #1442–#1455).

Highlights:
- **fix(audio):** pre-resolve Kokoro's spaCy G2P model at the route gate so the first `/v1/audio/speech` request can't 500 (#1254) — verified end-to-end on a fresh `[audio]` install (200 + real WAV, gate installs `en_core_web_sm`).
- **deepseek:** materialize cache graphs during decode (#1448), accept sampled DSML tool aliases (#1446), prevent reopening disabled thinking (#1452).
- **cache:** replay tokens across prompt boundaries (#1449), auto-enable prefix reuse for dense-recurrent aliases (#1445), persist deepest prefix first on shutdown (#1451).
- **engine:** return partial output for repetition-guard stop instead of 503 (#1450).
- **app/install:** 8 GB Macs get a recommendation instead of a rejection (#1443), curl banner recommends what the app recommends (#1447), GB-column metric fix (#1453).
- **models:** serve LFM2.5-2.6B (eight quants, one repo) (#1442).

## Gates

`release-smoke` ✓. `release-check-m3` on the tier1 model **qwen3.6-35b-8bit** ✓ across coherence, throughput/stress, G5–G9, the G7b agent harness (codex/opencode/hermes/aider/langchain), and parser microbench. The 9B run's G7b failures (codex timeout / opencode 503) were confirmed model-strength — they pass on 35B. The G12 random-coverage gate false-failed on a weak random sample (`hermes3-8b-4bit`, wrong-answer) while the other sampled model passed → not a regression; tracked in #1456.

Merging this triggers `auto-release.yml`: the Studio tier1-agent-gate is the authoritative pre-publish check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)