### PR TITLE
feat(pflash): per-alias pflash_keep_ratio override; verify bonsai-27b-2bit @0.50

### DIFF
--- a/tests/test_aliases_contract.py
+++ b/tests/test_aliases_contract.py
@@ -602,6 +602,28 @@ def test_pflash_keep_ratio_valid_value_is_accepted() -> None:
     assert isinstance(profile.pflash_keep_ratio, float)
 
 
+def test_pflash_keep_ratio_requires_verified_tier() -> None:
+    """A ``pflash_keep_ratio`` override on a non-verified alias must be rejected
+    at load time: the resolver applies the override whenever PFlash runs (incl.
+    an explicit ``--pflash always``), so allowing it on an unknown-tier alias
+    would silently shift explicitly-enabled PFlash behaviour (codex #1458 r2)."""
+    from vllm_mlx.model_aliases import _coerce
+
+    # default tier is "unknown"
+    with pytest.raises(ValueError, match="only valid with pflash_tier='verified'"):
+        _coerce("fake-alias", {"hf_path": "fake/Model", "pflash_keep_ratio": 0.5})
+    # explicit unknown is equally rejected
+    with pytest.raises(ValueError, match="only valid with pflash_tier='verified'"):
+        _coerce(
+            "fake-alias",
+            {
+                "hf_path": "fake/Model",
+                "pflash_tier": "unknown",
+                "pflash_keep_ratio": 0.5,
+            },
+        )
+
+
 # =============================================================================
 # DDTree speculative-decoding contract (issue #879)
 # =============================================================================

--- a/tests/test_aliases_contract.py
+++ b/tests/test_aliases_contract.py
@@ -78,6 +78,7 @@ ALLOWED_PROFILE_KEYS: frozenset[str] = frozenset(
         "min_memory_gb",
         "recommended_sampling",
         "pflash_tier",
+        "pflash_keep_ratio",
         "turboquant_tier",
     }
 )
@@ -276,16 +277,25 @@ def test_alias_pflash_tier_value_is_in_enum(alias: str) -> None:
     )
 
 
+# Aliases outside the Qwen3.5 / Qwen3.6 family that have been bench-validated
+# for pflash_tier=verified. Each MUST pin a ``pflash_keep_ratio`` override at
+# the ratio it was validated for — see the enforcement below. Ternary-Bonsai-27B
+# collapses mid-prompt recall at the 0.20 default (1/5 needle) but passes 5/5 at
+# 0.50, so it is verified WITH ``pflash_keep_ratio: 0.5``, never bare.
+_PFLASH_VERIFIED_NON_QWEN35_36 = frozenset({"bonsai-27b-2bit"})
+
+
 def test_pflash_verified_aliases_are_qwen35_or_qwen36() -> None:
-    """``pflash_tier="verified"`` is reserved for the Qwen3.5 / Qwen3.6
-    family — the only architectures we've bench-validated for the
-    keep_ratio=0.20 default (PR #649: 3.87x-8.5x TTFT speedup with 100%
-    needle recall across tested cells). Promoting a non-Qwen3.5/3.6 alias
-    to ``"verified"`` should be a deliberate review-blocking change: it
-    flips the engine's default ``--pflash`` mode to ``"always"`` for that
-    alias, which silently shifts the quality/speed tradeoff for every
-    user who hadn't passed an explicit flag. Keep the gate tight until
-    there's matching bench evidence on a new family.
+    """``pflash_tier="verified"`` is reserved for the Qwen3.5 / Qwen3.6 family
+    (bench-validated at the keep_ratio=0.20 default in PR #649) PLUS an explicit
+    allowlist of other families we've since benched. Promoting a new alias to
+    ``"verified"`` should be a deliberate review-blocking change: it flips the
+    engine's default ``--pflash`` mode to ``"always"``, silently shifting the
+    quality/speed tradeoff for every user who hadn't passed an explicit flag.
+    A non-Qwen3.5/3.6 verified alias MUST also pin a ``pflash_keep_ratio``
+    override — bench evidence showed at least one such arch (Ternary-Bonsai-27B)
+    is NOT recall-safe at the 0.20 default, so bare-verifying it would ship a
+    silent mid-prompt-recall regression.
     """
     profiles = list_profiles()
     verified = sorted(a for a, p in profiles.items() if p.pflash_tier == "verified")
@@ -300,12 +310,27 @@ def test_pflash_verified_aliases_are_qwen35_or_qwen36() -> None:
         a
         for a in verified
         if not (a.startswith("qwen3.5-") or a.startswith("qwen3.6-"))
+        and a not in _PFLASH_VERIFIED_NON_QWEN35_36
     ]
     assert not offenders, (
         f"Aliases tagged pflash_tier=verified outside the Qwen3.5 / "
-        f"Qwen3.6 family: {offenders}. Either bench the family and "
-        "extend the allowlist in this test, or reset the tier to "
+        f"Qwen3.6 family: {offenders}. Either bench the arch and add it to "
+        "_PFLASH_VERIFIED_NON_QWEN35_36 in this test, or reset the tier to "
         "'unknown'."
+    )
+    # Enforce the recall-safety contract for the non-Qwen allowlist: each such
+    # alias must pin a keep_ratio override (proving it was validated at a
+    # specific, deliberately-chosen ratio rather than defaulting to 0.20).
+    missing_override = [
+        a
+        for a in _PFLASH_VERIFIED_NON_QWEN35_36
+        if a in profiles and profiles[a].pflash_keep_ratio is None
+    ]
+    assert not missing_override, (
+        f"Non-Qwen verified aliases without a pflash_keep_ratio pin: "
+        f"{missing_override}. A bench-validated non-Qwen arch must pin the "
+        "keep_ratio it was validated at (bonsai-27b-2bit is only 5/5 at 0.50; "
+        "1/5 at the 0.20 default) — bare-verifying ships a silent regression."
     )
 
 
@@ -538,6 +563,44 @@ def test_negative_control_dflash_missing_drafter_is_caught() -> None:
             "fake-alias",
             {"hf_path": "fake/Model", "supports_dflash": True},
         )
+
+
+def test_pflash_keep_ratio_out_of_range_is_rejected() -> None:
+    """A ``pflash_keep_ratio`` outside (0, 1] must fail loud at load time."""
+    from vllm_mlx.model_aliases import _coerce
+
+    for bad in (0.0, -0.1, 1.5, 2):
+        with pytest.raises(ValueError, match="pflash_keep_ratio"):
+            _coerce(
+                "fake-alias",
+                {"hf_path": "fake/Model", "pflash_keep_ratio": bad},
+            )
+
+
+def test_pflash_keep_ratio_non_number_is_rejected() -> None:
+    """A non-numeric ``pflash_keep_ratio`` (incl. bool) must be rejected —
+    ``True`` is an int subclass in Python and would otherwise slip through."""
+    from vllm_mlx.model_aliases import _coerce
+
+    for bad in ("0.5", True, [0.5]):
+        with pytest.raises(ValueError, match="pflash_keep_ratio"):
+            _coerce(
+                "fake-alias",
+                {"hf_path": "fake/Model", "pflash_keep_ratio": bad},
+            )
+
+
+def test_pflash_keep_ratio_valid_value_is_accepted() -> None:
+    """A valid override coerces onto the profile as a float."""
+    from vllm_mlx.model_aliases import _coerce
+
+    profile = _coerce(
+        "fake-alias",
+        {"hf_path": "fake/Model", "pflash_tier": "verified",
+         "pflash_keep_ratio": 0.5},
+    )
+    assert profile.pflash_keep_ratio == 0.5
+    assert isinstance(profile.pflash_keep_ratio, float)
 
 
 # =============================================================================

--- a/tests/test_aliases_contract.py
+++ b/tests/test_aliases_contract.py
@@ -596,8 +596,7 @@ def test_pflash_keep_ratio_valid_value_is_accepted() -> None:
 
     profile = _coerce(
         "fake-alias",
-        {"hf_path": "fake/Model", "pflash_tier": "verified",
-         "pflash_keep_ratio": 0.5},
+        {"hf_path": "fake/Model", "pflash_tier": "verified", "pflash_keep_ratio": 0.5},
     )
     assert profile.pflash_keep_ratio == 0.5
     assert isinstance(profile.pflash_keep_ratio, float)

--- a/tests/test_cli_bench.py
+++ b/tests/test_cli_bench.py
@@ -118,7 +118,7 @@ def test_bench_command_prefetches_via_mirror_before_hf_load(monkeypatch) -> None
     # detect_model_config). The order test doesn't depend on it.
     monkeypatch.setattr(
         "vllm_mlx.pflash.resolve_pflash_mode_default",
-        lambda args, *, model_name, is_multimodal=False: "off",
+        lambda args, *, model_name, is_multimodal=False, **_kw: "off",
     )
     # Route the ``from mlx_lm import load`` inside bench_command to
     # our mock. Patching ``mlx_lm.load`` on the module object makes
@@ -167,7 +167,7 @@ def test_bench_command_proceeds_when_mirror_prefetch_is_silent_noop(
     monkeypatch.setattr(cli, "_ensure_model_downloaded", _silent_prefetch)
     monkeypatch.setattr(
         "vllm_mlx.pflash.resolve_pflash_mode_default",
-        lambda args, *, model_name, is_multimodal=False: "off",
+        lambda args, *, model_name, is_multimodal=False, **_kw: "off",
     )
     _patch_mlx_lm_load(monkeypatch, _fake_load)
 
@@ -212,7 +212,7 @@ def test_bench_command_loads_weights_on_mlx_step_worker(monkeypatch) -> None:
     monkeypatch.setattr(cli, "_ensure_model_downloaded", lambda name: None)
     monkeypatch.setattr(
         "vllm_mlx.pflash.resolve_pflash_mode_default",
-        lambda args, *, model_name, is_multimodal=False: "off",
+        lambda args, *, model_name, is_multimodal=False, **_kw: "off",
     )
     _patch_mlx_lm_load(monkeypatch, _fake_load)
 
@@ -236,7 +236,7 @@ def _capture_bench_lane_signals(monkeypatch, cli):
     engine boot. Returns the ``seen`` dict."""
     seen: dict[str, object] = {}
 
-    def _capture_default(args, *, model_name, is_multimodal=False):
+    def _capture_default(args, *, model_name, is_multimodal=False, **_kw):
         seen["default_is_multimodal"] = is_multimodal
         return "off"
 

--- a/tests/test_pflash.py
+++ b/tests/test_pflash.py
@@ -16,6 +16,7 @@ from vllm_mlx.pflash import (
     compress_request_tokens,
     compress_tokens,
     config_from_args,
+    resolve_pflash_keep_ratio_default,
     resolve_pflash_mode_default,
     validate_model_support,
 )
@@ -205,6 +206,27 @@ class TestPFlashConfig:
         # behaviour is the conservative skip.
         assert config.skip_when_tools is False
 
+    def test_config_from_args_none_keep_ratio_falls_back_to_default(self):
+        # The CLI default for --pflash-keep-ratio is now a None sentinel
+        # (resolved to an alias override or 0.20 before construction). If the
+        # resolver never ran (bare SimpleNamespace, or the --enable-dflash
+        # path that skips PFlash resolution), config_from_args must fall back
+        # to 0.20 rather than fail PFlashConfig.validate on ``None``.
+        args = SimpleNamespace(
+            pflash="always",
+            pflash_threshold=1024,
+            pflash_keep_ratio=None,
+            pflash_min_keep_tokens=128,
+            pflash_sink_tokens=16,
+            pflash_tail_tokens=64,
+            pflash_block_size=32,
+            pflash_query_window=128,
+            pflash_stride_blocks=4,
+            pflash_include_tools=False,
+        )
+        config = config_from_args(args)
+        assert config.keep_ratio == 0.20
+
     def test_validate_rejects_multimodal_models(self):
         config = PFlashConfig(mode="auto")
         try:
@@ -372,6 +394,63 @@ class TestResolvePFlashModeDefault:
         )
         config = config_from_args(args)
         assert config.mode == "off"
+
+
+class TestResolvePFlashKeepRatioDefault:
+    """Per-alias ``pflash_keep_ratio`` override (#287 follow-up).
+
+    Contract mirrors the mode resolver:
+    * explicit ``--pflash-keep-ratio`` (args value not None) wins;
+    * else the alias's ``pflash_keep_ratio`` if it pins one;
+    * else the engine default 0.20.
+    """
+
+    def _ns(self, keep_ratio):
+        return SimpleNamespace(pflash_keep_ratio=keep_ratio)
+
+    def test_alias_override_applies_when_no_flag(self):
+        # bonsai-27b-2bit is verified BUT only recall-safe at 0.50 (1/5 needle
+        # at the 0.20 default); it pins pflash_keep_ratio=0.5 in aliases.json.
+        ratio = resolve_pflash_keep_ratio_default(
+            self._ns(None), model_name="bonsai-27b-2bit"
+        )
+        assert ratio == 0.5
+
+    def test_explicit_flag_wins_over_alias_override(self):
+        ratio = resolve_pflash_keep_ratio_default(
+            self._ns(0.33), model_name="bonsai-27b-2bit"
+        )
+        assert ratio == 0.33
+
+    def test_verified_alias_without_override_uses_engine_default(self):
+        # qwen3.5-4b-4bit is verified at the default 0.20 and pins no override.
+        ratio = resolve_pflash_keep_ratio_default(
+            self._ns(None), model_name="qwen3.5-4b-4bit"
+        )
+        assert ratio == 0.20
+
+    def test_unknown_alias_without_override_uses_engine_default(self):
+        ratio = resolve_pflash_keep_ratio_default(
+            self._ns(None), model_name="qwen3-0.6b-4bit"
+        )
+        assert ratio == 0.20
+
+    def test_unrecognized_model_path_uses_engine_default(self):
+        ratio = resolve_pflash_keep_ratio_default(
+            self._ns(None), model_name="/no/such/model-xyz"
+        )
+        assert ratio == 0.20
+
+    def test_bonsai_mode_and_ratio_resolve_together(self):
+        # End-to-end: the verified tier flips mode to "always" AND the override
+        # supplies 0.50 — the exact pair a bare ``serve bonsai-27b-2bit`` wires.
+        mode = resolve_pflash_mode_default(
+            SimpleNamespace(pflash=None), model_name="bonsai-27b-2bit"
+        )
+        ratio = resolve_pflash_keep_ratio_default(
+            self._ns(None), model_name="bonsai-27b-2bit"
+        )
+        assert (mode, ratio) == ("always", 0.5)
 
 
 class TestCompressRequestTokens:

--- a/tests/test_pflash.py
+++ b/tests/test_pflash.py
@@ -16,6 +16,7 @@ from vllm_mlx.pflash import (
     compress_request_tokens,
     compress_tokens,
     config_from_args,
+    resolve_pflash_config,
     resolve_pflash_keep_ratio_default,
     resolve_pflash_mode_default,
     validate_model_support,
@@ -441,16 +442,52 @@ class TestResolvePFlashKeepRatioDefault:
         )
         assert ratio == 0.20
 
-    def test_bonsai_mode_and_ratio_resolve_together(self):
-        # End-to-end: the verified tier flips mode to "always" AND the override
-        # supplies 0.50 — the exact pair a bare ``serve bonsai-27b-2bit`` wires.
-        mode = resolve_pflash_mode_default(
-            SimpleNamespace(pflash=None), model_name="bonsai-27b-2bit"
+    def _full_ns(self, **overrides):
+        base = dict(
+            pflash=None,
+            pflash_keep_ratio=None,
+            pflash_threshold=32_768,
+            pflash_min_keep_tokens=2_048,
+            pflash_sink_tokens=256,
+            pflash_tail_tokens=2_048,
+            pflash_block_size=128,
+            pflash_query_window=512,
+            pflash_stride_blocks=8,
+            pflash_include_tools=False,
         )
-        ratio = resolve_pflash_keep_ratio_default(
-            self._ns(None), model_name="bonsai-27b-2bit"
-        )
-        assert (mode, ratio) == ("always", 0.5)
+        base.update(overrides)
+        return SimpleNamespace(**base)
+
+    def test_resolve_pflash_config_wires_bonsai_mode_and_ratio_end_to_end(self):
+        # Guards the actual serve/bench WIRING, not just the resolvers: a bare
+        # ``serve bonsai-27b-2bit`` routes through resolve_pflash_config, which
+        # must resolve mode→"always" AND keep_ratio→0.5 from the alias and bake
+        # both into the built PFlashConfig. If either resolver call is dropped
+        # from the helper, one of these assertions fails (a test that called the
+        # resolvers directly would still pass — codex #1458 BLOCKING).
+        args = self._full_ns()
+        config = resolve_pflash_config(args, model_name="bonsai-27b-2bit")
+        assert config.mode == "always"
+        assert config.keep_ratio == 0.5
+        # The helper also materializes the resolved values back onto args so
+        # later readers (engine wiring) see them, not the None sentinels.
+        assert args.pflash == "always"
+        assert args.pflash_keep_ratio == 0.5
+
+    def test_resolve_pflash_config_explicit_keep_ratio_flag_wins(self):
+        # An explicit --pflash-keep-ratio must survive the shared wiring even
+        # when the alias pins its own override.
+        args = self._full_ns(pflash_keep_ratio=0.33)
+        config = resolve_pflash_config(args, model_name="bonsai-27b-2bit")
+        assert config.mode == "always"
+        assert config.keep_ratio == 0.33
+
+    def test_resolve_pflash_config_unknown_alias_stays_off_at_default(self):
+        # A non-verified alias: mode stays off and keep_ratio falls to 0.20.
+        args = self._full_ns()
+        config = resolve_pflash_config(args, model_name="qwen3-0.6b-4bit")
+        assert config.mode == "off"
+        assert config.keep_ratio == 0.20
 
 
 class TestCompressRequestTokens:

--- a/tests/test_pflash_cli_wiring.py
+++ b/tests/test_pflash_cli_wiring.py
@@ -1,0 +1,117 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Command-level wiring: ``serve`` and ``bench`` must route PFlash resolution
+through :func:`vllm_mlx.pflash.resolve_pflash_config`.
+
+`tests/test_pflash.py` proves the helper resolves mode + keep_ratio correctly.
+These tests prove the two COMMANDS actually call it (with the right model name
+and multimodal verdict) and propagate its returned config — a mutation that
+deletes the ``resolve_pflash_config(...)`` call from either command makes the
+corresponding test fail (codex #1458 r2 BLOCKING: the helper-only test stayed
+green if a command stopped invoking it).
+
+Fully offline: every I/O boundary the commands hit before the PFlash step is
+mocked, and the ``resolve_pflash_config`` stub short-circuits with a sentinel
+error so nothing past it (engine boot, uvicorn, weight load) runs.
+"""
+
+from __future__ import annotations
+
+import sys
+from unittest import mock
+
+import pytest
+
+import vllm_mlx.cli as cli
+
+# Bind the real engine_core before any test patches scheduler internals.
+import vllm_mlx.engine_core as _engine_core  # noqa: E402,F401
+
+
+class _StopError(Exception):
+    """Raised inside the resolve_pflash_config stub to short-circuit the command
+    right after the PFlash wiring point, before any heavy boot."""
+
+
+def _run_serve_capturing_pflash(argv: list[str], *, lane=(False, False)) -> dict:
+    """Drive the REAL ``main()`` → ``serve_command`` and capture the arguments
+    the serve path passes to ``resolve_pflash_config``. ``lane`` is the
+    ``(is_mllm, auto_text_fallback)`` the serving-lane resolver returns — the
+    first element is what serve must forward as ``is_multimodal``."""
+    seen: dict = {}
+
+    def _stub(args, *, model_name, is_multimodal=False):
+        seen["model_name"] = model_name
+        seen["is_multimodal"] = is_multimodal
+        seen["args_is"] = args
+        raise _StopError
+
+    with (
+        mock.patch.object(cli, "_check_disk_space", lambda *a, **k: None),
+        mock.patch.object(cli, "_check_memory_capacity", lambda *a, **k: None),
+        mock.patch.object(cli, "_ensure_model_downloaded", lambda *a, **k: None),
+        mock.patch(
+            "vllm_mlx._version_check.prompt_upgrade_if_available",
+            return_value=False,
+        ),
+        mock.patch("vllm_mlx.api.utils.resolve_serving_lane", lambda name, **kw: lane),
+        mock.patch("vllm_mlx.pflash.resolve_pflash_config", _stub),
+        mock.patch.object(sys, "argv", ["rapid-mlx", *argv]),
+        mock.patch.object(sys.stdin, "isatty", return_value=False),
+        pytest.raises((_StopError, SystemExit)),
+    ):
+        cli.main()
+    return seen
+
+
+def test_serve_command_routes_pflash_through_resolve_pflash_config():
+    from vllm_mlx.model_aliases import resolve_model
+
+    seen = _run_serve_capturing_pflash(["serve", "bonsai-27b-2bit"])
+    # By the PFlash step the command has already resolved the alias to its
+    # hf_path — that resolved name is what must reach resolve_pflash_config
+    # (detect_model_config resolves the profile back via the hf_path index).
+    assert seen.get("model_name") == resolve_model("bonsai-27b-2bit")
+    # Text-lane model → serve forwards is_multimodal=False.
+    assert seen.get("is_multimodal") is False
+
+
+def test_serve_command_forwards_multimodal_lane_verdict():
+    # When the serving-lane resolver flags an MLLM lane, serve must forward
+    # is_multimodal=True so resolve_pflash_config can suppress the verified
+    # auto-ON (PFlash can't serve the MLLM lane).
+    seen = _run_serve_capturing_pflash(["serve", "qwen3.5-4b-4bit"], lane=(True, False))
+    assert seen.get("is_multimodal") is True
+
+
+def _run_bench_capturing_pflash(argv: list[str]) -> dict:
+    """Same, for the ``bench`` command. Bench has no MLLM lane, so it always
+    forwards ``is_multimodal=False``."""
+    seen: dict = {}
+
+    def _stub(args, *, model_name, is_multimodal=False):
+        seen["model_name"] = model_name
+        seen["is_multimodal"] = is_multimodal
+        raise _StopError
+
+    with (
+        mock.patch.object(cli, "_check_disk_space", lambda *a, **k: None),
+        mock.patch.object(cli, "_check_memory_capacity", lambda *a, **k: None),
+        mock.patch.object(cli, "_ensure_model_downloaded", lambda *a, **k: None),
+        mock.patch(
+            "vllm_mlx.api.utils.resolve_serving_lane",
+            lambda name, **kw: (False, False),
+        ),
+        mock.patch("vllm_mlx.pflash.resolve_pflash_config", _stub),
+        mock.patch.object(sys, "argv", ["rapid-mlx", *argv]),
+        pytest.raises((_StopError, SystemExit)),
+    ):
+        cli.main()
+    return seen
+
+
+def test_bench_command_routes_pflash_through_resolve_pflash_config():
+    from vllm_mlx.model_aliases import resolve_model
+
+    seen = _run_bench_capturing_pflash(["bench", "bonsai-27b-2bit"])
+    assert seen.get("model_name") == resolve_model("bonsai-27b-2bit")
+    assert seen.get("is_multimodal") is False

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -1333,7 +1333,9 @@
     "reasoning_parser": "qwen3",
     "is_hybrid": false,
     "is_hybrid_explicit": true,
-    "supports_spec_decode": false
+    "supports_spec_decode": false,
+    "pflash_tier": "verified",
+    "pflash_keep_ratio": 0.5
   },
   "smollm3-3b-4bit": {
     "hf_path": "mlx-community/SmolLM3-3B-4bit",

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1700,10 +1700,12 @@ def _add_pflash_args(parser) -> None:
     parser.add_argument(
         "--pflash-keep-ratio",
         type=float,
-        default=0.20,
-        help="Fraction of prompt tokens to keep when compressing "
-        "(default: 0.20 — matches the bench-validated profile in PR #649: "
-        "TTFT 3.87x-8.5x, needle recall 5/5 across tested cells).",
+        default=None,
+        help="Fraction of prompt tokens to keep when compressing. Unset lets "
+        "the engine resolve it: a per-alias ``pflash_keep_ratio`` override if "
+        "the alias pins one (e.g. 0.50 for a ternary arch), else the default "
+        "0.20 (the bench-validated profile in PR #649: TTFT 3.87x-8.5x, needle "
+        "recall 5/5). An explicit value here always wins.",
     )
     parser.add_argument(
         "--pflash-min-keep-tokens",
@@ -2650,6 +2652,7 @@ def serve_command(args):
     from .api.utils import resolve_serving_lane
     from .pflash import (
         config_from_args,
+        resolve_pflash_keep_ratio_default,
         resolve_pflash_mode_default,
         validate_model_support,
     )
@@ -2668,6 +2671,12 @@ def serve_command(args):
         )
         args.pflash = resolve_pflash_mode_default(
             args, model_name=args.model, is_multimodal=_serve_is_mllm
+        )
+        # Same None-sentinel resolution for keep_ratio: a verified alias that
+        # pins ``pflash_keep_ratio`` (e.g. bonsai-27b-2bit @ 0.50, safe recall)
+        # gets its ratio here; an explicit --pflash-keep-ratio still wins.
+        args.pflash_keep_ratio = resolve_pflash_keep_ratio_default(
+            args, model_name=args.model
         )
         try:
             pflash_config = config_from_args(args)
@@ -4405,6 +4414,9 @@ def bench_command(args):
     # ``validate_local_model_file`` internally.
     from .engine_core import AsyncEngineCore, EngineConfig
     from .pflash import config_from_args as _pflash_config_from_args
+    from .pflash import (
+        resolve_pflash_keep_ratio_default as _pflash_resolve_keep_ratio,
+    )
     from .pflash import resolve_pflash_mode_default as _pflash_resolve_default
     from .pflash import validate_model_support as _bench_pflash_validate
     from .request import SamplingParams
@@ -4465,6 +4477,11 @@ def bench_command(args):
         )
     args.pflash = _pflash_resolve_default(
         args, model_name=args.model, is_multimodal=False
+    )
+    # Mirror serve: resolve the per-alias keep_ratio override (None-sentinel)
+    # so bench measures the SAME effective ratio serve would run.
+    args.pflash_keep_ratio = _pflash_resolve_keep_ratio(
+        args, model_name=args.model
     )
     try:
         bench_pflash_config = _pflash_config_from_args(args)

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -2651,9 +2651,7 @@ def serve_command(args):
     # validation path the user-explicit case takes.
     from .api.utils import resolve_serving_lane
     from .pflash import (
-        config_from_args,
-        resolve_pflash_keep_ratio_default,
-        resolve_pflash_mode_default,
+        resolve_pflash_config,
         validate_model_support,
     )
 
@@ -2669,17 +2667,13 @@ def serve_command(args):
             force_mllm=getattr(args, "mllm", False),
             force_text=getattr(args, "no_mllm", False),
         )
-        args.pflash = resolve_pflash_mode_default(
-            args, model_name=args.model, is_multimodal=_serve_is_mllm
-        )
-        # Same None-sentinel resolution for keep_ratio: a verified alias that
-        # pins ``pflash_keep_ratio`` (e.g. bonsai-27b-2bit @ 0.50, safe recall)
-        # gets its ratio here; an explicit --pflash-keep-ratio still wins.
-        args.pflash_keep_ratio = resolve_pflash_keep_ratio_default(
-            args, model_name=args.model
-        )
+        # Resolve BOTH per-alias PFlash defaults (mode + keep_ratio, e.g.
+        # bonsai-27b-2bit → always @ 0.50) and build the config in one shared
+        # helper; an explicit --pflash / --pflash-keep-ratio still wins inside.
         try:
-            pflash_config = config_from_args(args)
+            pflash_config = resolve_pflash_config(
+                args, model_name=args.model, is_multimodal=_serve_is_mllm
+            )
             validate_model_support(
                 pflash_config,
                 model_name=args.model,
@@ -4413,11 +4407,7 @@ def bench_command(args):
     # vendored-arch and tokenizer-fallback routes) and calls
     # ``validate_local_model_file`` internally.
     from .engine_core import AsyncEngineCore, EngineConfig
-    from .pflash import config_from_args as _pflash_config_from_args
-    from .pflash import (
-        resolve_pflash_keep_ratio_default as _pflash_resolve_keep_ratio,
-    )
-    from .pflash import resolve_pflash_mode_default as _pflash_resolve_default
+    from .pflash import resolve_pflash_config as _pflash_resolve_config
     from .pflash import validate_model_support as _bench_pflash_validate
     from .request import SamplingParams
     from .scheduler import SchedulerConfig
@@ -4475,16 +4465,13 @@ def bench_command(args):
             f"Note: {args.model!r} is a hybrid VLM — benching on the text-only "
             "mlx-lm lane, matching 'serve' auto-downgrade (#352)."
         )
-    args.pflash = _pflash_resolve_default(
-        args, model_name=args.model, is_multimodal=False
-    )
-    # Mirror serve: resolve the per-alias keep_ratio override (None-sentinel)
-    # so bench measures the SAME effective ratio serve would run.
-    args.pflash_keep_ratio = _pflash_resolve_keep_ratio(
-        args, model_name=args.model
-    )
+    # Same shared wiring as serve: resolve mode + per-alias keep_ratio override
+    # and build the config, so bench measures the SAME effective PFlash config
+    # serve would run. is_multimodal=False — bench has no MLLM lane (see above).
     try:
-        bench_pflash_config = _pflash_config_from_args(args)
+        bench_pflash_config = _pflash_resolve_config(
+            args, model_name=args.model, is_multimodal=False
+        )
         _bench_pflash_validate(
             bench_pflash_config,
             model_name=args.model,

--- a/vllm_mlx/model_aliases.py
+++ b/vllm_mlx/model_aliases.py
@@ -270,10 +270,13 @@ def _coerce(alias: str, value: object) -> AliasProfile:
         )
 
     # Optional per-alias PFlash keep_ratio override. Absent → ``None`` →
-    # engine default 0.20. When present it must be a real fraction in
-    # (0, 1]; validated here so a typo fails loud at load time next to
-    # ``pflash_tier``. Only meaningful together with pflash_tier=verified
-    # (it certifies recall AT this ratio); harmless but inert otherwise.
+    # engine default 0.20. When present it must be a real fraction in (0, 1]
+    # AND the alias must be pflash_tier=verified — the field's ONLY purpose is
+    # to pin the ratio a verified alias was recall-validated at (the resolver
+    # applies it whenever PFlash runs, incl. an explicit ``--pflash always``,
+    # so allowing it on an unknown-tier alias would silently shift explicitly
+    # enabled PFlash behaviour). Both validated here so a typo / misuse fails
+    # loud at load time next to ``pflash_tier``.
     pflash_keep_ratio = value.get("pflash_keep_ratio")
     if pflash_keep_ratio is not None:
         if isinstance(pflash_keep_ratio, bool) or not isinstance(
@@ -285,6 +288,13 @@ def _coerce(alias: str, value: object) -> AliasProfile:
             raise ValueError(
                 f"alias {alias!r}: pflash_keep_ratio={pflash_keep_ratio!r} "
                 "must be > 0.0 and <= 1.0"
+            )
+        if pflash_tier != "verified":
+            raise ValueError(
+                f"alias {alias!r}: pflash_keep_ratio is only valid with "
+                f"pflash_tier='verified' (got {pflash_tier!r}). The override "
+                "pins the ratio a VERIFIED alias was recall-validated at; it "
+                "has no meaning on an unbenched alias."
             )
 
     turboquant_tier = value.get("turboquant_tier", "unknown")

--- a/vllm_mlx/model_aliases.py
+++ b/vllm_mlx/model_aliases.py
@@ -279,9 +279,7 @@ def _coerce(alias: str, value: object) -> AliasProfile:
         if isinstance(pflash_keep_ratio, bool) or not isinstance(
             pflash_keep_ratio, (int, float)
         ):
-            raise ValueError(
-                f"alias {alias!r}: pflash_keep_ratio must be a number"
-            )
+            raise ValueError(f"alias {alias!r}: pflash_keep_ratio must be a number")
         pflash_keep_ratio = float(pflash_keep_ratio)
         if not (0.0 < pflash_keep_ratio <= 1.0):
             raise ValueError(

--- a/vllm_mlx/model_aliases.py
+++ b/vllm_mlx/model_aliases.py
@@ -58,6 +58,12 @@ VALID_SUFFIX_TIERS: frozenset[str] = frozenset({"unknown", "neutral", "good", "a
 # - ``unknown``:  not benched / no decision (default, engine keeps PFlash off)
 # - ``verified``: bench-validated speedup + recall on this alias; engine
 #                 defaults PFlash to ``always`` unless the user overrides
+#
+# The recall validation is AT the keep_ratio the alias will actually run:
+# by default 0.20, or the per-alias ``pflash_keep_ratio`` override when set.
+# Some arches (e.g. Ternary-Bonsai-27B) collapse mid-prompt recall at 0.20
+# (1/5 needle) but pass 5/5 at 0.50 — such an alias is verified *with* a
+# ``pflash_keep_ratio`` pin, never bare at the lossy default.
 VALID_PFLASH_TIERS: frozenset[str] = frozenset({"unknown", "verified"})
 
 # Canonical enum for ``turboquant_tier``. ``"k8v4_verified"`` flips the
@@ -163,6 +169,7 @@ def _coerce(alias: str, value: object) -> AliasProfile:
             "min_memory_gb",
             "recommended_sampling",
             "pflash_tier",
+            "pflash_keep_ratio",
             "turboquant_tier",
         }
     )
@@ -261,6 +268,26 @@ def _coerce(alias: str, value: object) -> AliasProfile:
             f"alias {alias!r}: pflash_tier={pflash_tier!r} not in "
             f"{sorted(VALID_PFLASH_TIERS)}"
         )
+
+    # Optional per-alias PFlash keep_ratio override. Absent → ``None`` →
+    # engine default 0.20. When present it must be a real fraction in
+    # (0, 1]; validated here so a typo fails loud at load time next to
+    # ``pflash_tier``. Only meaningful together with pflash_tier=verified
+    # (it certifies recall AT this ratio); harmless but inert otherwise.
+    pflash_keep_ratio = value.get("pflash_keep_ratio")
+    if pflash_keep_ratio is not None:
+        if isinstance(pflash_keep_ratio, bool) or not isinstance(
+            pflash_keep_ratio, (int, float)
+        ):
+            raise ValueError(
+                f"alias {alias!r}: pflash_keep_ratio must be a number"
+            )
+        pflash_keep_ratio = float(pflash_keep_ratio)
+        if not (0.0 < pflash_keep_ratio <= 1.0):
+            raise ValueError(
+                f"alias {alias!r}: pflash_keep_ratio={pflash_keep_ratio!r} "
+                "must be > 0.0 and <= 1.0"
+            )
 
     turboquant_tier = value.get("turboquant_tier", "unknown")
     if not isinstance(turboquant_tier, str):
@@ -474,6 +501,7 @@ def _coerce(alias: str, value: object) -> AliasProfile:
         ddtree_tree_budget=ddtree_tree_budget,
         recommended_sampling=recommended_sampling,
         pflash_tier=pflash_tier,
+        pflash_keep_ratio=pflash_keep_ratio,
         turboquant_tier=turboquant_tier,
         min_memory_gb=min_memory_gb,
     )

--- a/vllm_mlx/model_profile.py
+++ b/vllm_mlx/model_profile.py
@@ -202,6 +202,13 @@ class ModelProfile:
     # families per #287). Explicit CLI ``--pflash {off,auto,always}``
     # still wins; this only changes the no-flag default.
     pflash_tier: str = "unknown"
+    # Per-alias PFlash keep_ratio override (#287 follow-up). ``None`` means
+    # "use the engine default 0.20". Set to a float in (0, 1] when an alias
+    # is verified at a keep_ratio OTHER than the engine default — e.g. a
+    # ternary-quant arch whose mid-prompt recall only survives at a laxer
+    # ratio. ``pflash_tier="verified"`` then certifies recall AT THIS ratio,
+    # not at 0.20. Explicit ``--pflash-keep-ratio`` on the CLI still wins.
+    pflash_keep_ratio: float | None = None
     # TurboQuant K8V4 default-on tier. See ``VALID_TURBOQUANT_TIERS``.
     turboquant_tier: str = "unknown"
     # DDTree speculative-decoding eligibility (#879). Intentionally

--- a/vllm_mlx/pflash.py
+++ b/vllm_mlx/pflash.py
@@ -140,10 +140,19 @@ def config_from_args(args: Any) -> PFlashConfig:
     not *opt-in by accident anywhere else*.
     """
     mode = args.pflash if args.pflash is not None else "off"
+    # ``pflash_keep_ratio`` mirrors ``pflash`` (mode): the CLI sentinel default
+    # is ``None`` and :func:`resolve_pflash_keep_ratio_default` materializes it
+    # (explicit flag > per-alias override > engine default 0.20) before we get
+    # here. Fall back to 0.20 if that resolver never ran (unit tests that build
+    # a bare SimpleNamespace, or the ``--enable-dflash`` path that skips PFlash
+    # resolution) so a forgotten resolve never fails validation with ``None``.
+    keep_ratio = args.pflash_keep_ratio
+    if keep_ratio is None:
+        keep_ratio = 0.20
     return PFlashConfig(
         mode=mode,
         threshold=args.pflash_threshold,
-        keep_ratio=args.pflash_keep_ratio,
+        keep_ratio=keep_ratio,
         min_keep_tokens=args.pflash_min_keep_tokens,
         sink_tokens=args.pflash_sink_tokens,
         tail_tokens=args.pflash_tail_tokens,
@@ -251,6 +260,39 @@ def resolve_pflash_mode_default(
         )
         return "always"
     return "off"
+
+
+def resolve_pflash_keep_ratio_default(args: Any, *, model_name: str) -> float:
+    """Resolve ``args.pflash_keep_ratio`` when the user passed nothing on the CLI.
+
+    Precedence (mirrors :func:`resolve_pflash_mode_default`):
+
+    * If ``args.pflash_keep_ratio`` is already a number (user passed
+      ``--pflash-keep-ratio``), it wins — return it unchanged.
+    * Else if the model's alias profile pins a ``pflash_keep_ratio``, use it.
+      This is how an alias verified at a NON-default ratio (e.g. a ternary
+      arch whose mid-prompt recall only survives at 0.50) gets its safe
+      ratio applied whenever PFlash auto-enables — without it, a bare
+      ``pflash_tier=verified`` would run the lossy 0.20 default.
+    * Else the engine default 0.20.
+
+    Returns the float to assign back to ``args.pflash_keep_ratio`` before
+    :func:`config_from_args`. Kept separate from construction so unit tests
+    can build a ``SimpleNamespace`` with ``pflash_keep_ratio=None`` and assert
+    the resolved value directly.
+    """
+    if args.pflash_keep_ratio is not None:
+        return args.pflash_keep_ratio
+    # Late import for the same reason as resolve_pflash_mode_default: keep
+    # importing ``pflash`` cheap for callers that never resolve a default.
+    try:
+        from .model_auto_config import detect_model_config
+    except ImportError:
+        return 0.20
+    cfg = detect_model_config(model_name)
+    if cfg is not None and cfg.pflash_keep_ratio is not None:
+        return cfg.pflash_keep_ratio
+    return 0.20
 
 
 def validate_model_support(

--- a/vllm_mlx/pflash.py
+++ b/vllm_mlx/pflash.py
@@ -163,8 +163,35 @@ def config_from_args(args: Any) -> PFlashConfig:
     ).validate()
 
 
+# Sentinel for "the caller has not pre-resolved the alias profile — detect it
+# yourself". Distinct from ``None``, which is the legitimate "detected, but this
+# path is not an alias" result. Lets ``resolve_pflash_config`` detect the
+# profile ONCE and hand it to both resolvers instead of each re-detecting on the
+# no-flag startup path (codex #1458 NIT: same metadata was detected twice).
+_DETECT = object()
+
+
+def _detect_or(model_name: str, pre: Any) -> Any:
+    """Return ``pre`` if the caller already resolved the profile, else detect it.
+
+    Detection import errors (broken/partial install) degrade to ``None`` — the
+    same conservative "no alias decision" both resolvers already fall back to.
+    """
+    if pre is not _DETECT:
+        return pre
+    try:
+        from .model_auto_config import detect_model_config
+    except ImportError:
+        return None
+    return detect_model_config(model_name)
+
+
 def resolve_pflash_mode_default(
-    args: Any, *, model_name: str, is_multimodal: bool = False
+    args: Any,
+    *,
+    model_name: str,
+    is_multimodal: bool = False,
+    _detected_config: Any = _DETECT,
 ) -> str:
     """Resolve ``args.pflash`` when the user passed nothing on the CLI.
 
@@ -204,23 +231,12 @@ def resolve_pflash_mode_default(
     """
     if args.pflash is not None:
         return args.pflash
-    # Late import: ``model_auto_config`` pulls in ``model_aliases``
-    # (which loads aliases.json) and regex compilation. Defer the
-    # cost so importing ``pflash`` stays cheap for callers that
-    # never resolve a default (e.g. ``compress_tokens`` users).
-    #
-    # Catch ImportError ONLY — it's the legitimate degenerate case
-    # (broken install, partial uninstall). A malformed ``aliases.json``
-    # raises ``ValueError`` from ``_coerce``; the user must see that.
-    # Letting it propagate here keeps codex r3 NIT honest: a
-    # blanket ``except Exception`` would silently default every alias
-    # to PFlash off on a real loader regression, hiding the bug on the
-    # one startup path where this helper is authoritative for defaults.
-    try:
-        from .model_auto_config import detect_model_config
-    except ImportError:
-        return "off"
-    cfg = detect_model_config(model_name)
+    # Resolve the alias profile (or reuse one ``resolve_pflash_config`` already
+    # detected). ``_detect_or`` does the late import so importing ``pflash``
+    # stays cheap for callers that never resolve a default, and degrades a
+    # broken install to ``None`` = PFlash off (a malformed ``aliases.json``
+    # still raises ValueError from ``_coerce`` — the user must see that).
+    cfg = _detect_or(model_name, _detected_config)
     if cfg is not None and cfg.pflash_tier == "verified":
         # A multimodal (MLLM/VLM) model can NOT run PFlash — the MLLM lane
         # is rejected outright by ``validate_model_support``. Auto-enabling
@@ -262,7 +278,9 @@ def resolve_pflash_mode_default(
     return "off"
 
 
-def resolve_pflash_keep_ratio_default(args: Any, *, model_name: str) -> float:
+def resolve_pflash_keep_ratio_default(
+    args: Any, *, model_name: str, _detected_config: Any = _DETECT
+) -> float:
     """Resolve ``args.pflash_keep_ratio`` when the user passed nothing on the CLI.
 
     Precedence (mirrors :func:`resolve_pflash_mode_default`):
@@ -283,16 +301,45 @@ def resolve_pflash_keep_ratio_default(args: Any, *, model_name: str) -> float:
     """
     if args.pflash_keep_ratio is not None:
         return args.pflash_keep_ratio
-    # Late import for the same reason as resolve_pflash_mode_default: keep
-    # importing ``pflash`` cheap for callers that never resolve a default.
-    try:
-        from .model_auto_config import detect_model_config
-    except ImportError:
-        return 0.20
-    cfg = detect_model_config(model_name)
+    cfg = _detect_or(model_name, _detected_config)
     if cfg is not None and cfg.pflash_keep_ratio is not None:
         return cfg.pflash_keep_ratio
     return 0.20
+
+
+def resolve_pflash_config(
+    args: Any, *, model_name: str, is_multimodal: bool = False
+) -> PFlashConfig:
+    """Resolve BOTH per-alias PFlash defaults (mode + keep_ratio) and build the
+    validated :class:`PFlashConfig`. This is the single wiring shared by the
+    ``serve`` and ``bench`` commands so the two never drift — and so the
+    end-to-end alias→config path is testable in one call (a test that asserts
+    both effective values here fails if either resolver is unwired, which a
+    test calling the resolvers directly would not catch).
+
+    Mutates ``args.pflash`` and ``args.pflash_keep_ratio`` in place (both were
+    the CLI None-sentinels until now) so any later reader sees the resolved
+    values, then returns the built config. ``validate_model_support`` is left
+    to the caller because its ``is_mllm`` verdict and error handling differ
+    between the two commands.
+    """
+    # Detect the alias profile ONCE and share it with both resolvers (each
+    # would otherwise re-detect on the no-flag path). Skip detection entirely
+    # when the user pinned both flags — neither resolver would consult it.
+    if args.pflash is None or args.pflash_keep_ratio is None:
+        detected = _detect_or(model_name, _DETECT)
+    else:
+        detected = _DETECT
+    args.pflash = resolve_pflash_mode_default(
+        args,
+        model_name=model_name,
+        is_multimodal=is_multimodal,
+        _detected_config=detected,
+    )
+    args.pflash_keep_ratio = resolve_pflash_keep_ratio_default(
+        args, model_name=model_name, _detected_config=detected
+    )
+    return config_from_args(args)
 
 
 def validate_model_support(


### PR DESCRIPTION
## Why
`bonsai-27b-2bit` (Ternary-Bonsai-27B, dense-recurrent / Qwen3.5-27B ternary quant) has a heavy cold-prefill cost, so PFlash long-prompt compression is its single most useful prefill lever. It was `pflash_tier=unknown` (漏标), so PFlash defaulted **off**.

Naively adding `pflash_tier=verified` (the "one-line JSON" fix) would be **wrong**: the verified tier runs PFlash at the engine default `keep_ratio=0.20`, and a depth-scanned needle test (needle buried in the *compressible middle*, not the always-preserved sink) shows bonsai's mid-prompt recall collapses to **1/5** at 0.20 — a silent quality regression. It only passes **5/5** at `keep_ratio=0.50` (still ~2.2× TTFT vs off).

| keep_ratio | needle recall | TTFT (11k prompt) |
|---|---|---|
| 0.20 (verified default) | 1/5 ❌ | 27s |
| 0.35 | 3/5 ❌ | 46s |
| **0.50** | **5/5 ✅** | 66s |

The tier schema had no way to say "verified, but at a different ratio" — so verifying bonsai safely required a new mechanism.

## What
- **New optional alias field `pflash_keep_ratio`** (schema validation in `model_aliases._coerce` + allowlist, profile field in `model_profile.py`). `None` → engine default 0.20.
- **`resolve_pflash_keep_ratio_default()`** in `pflash.py`, mirroring `resolve_pflash_mode_default`'s None-sentinel precedence: **explicit `--pflash-keep-ratio` > per-alias override > engine default 0.20**. Wired at both the `serve` and `bench` call sites (before `config_from_args`).
- `--pflash-keep-ratio` CLI default becomes `None`; `config_from_args` falls back to `0.20` when unresolved (mirrors how mode's `None` → `off`).
- **Tag `bonsai-27b-2bit`: `pflash_tier=verified` + `pflash_keep_ratio=0.5`** — a bare `rapid-mlx serve bonsai-27b-2bit` now auto-enables PFlash at the recall-safe ratio.
- The verified-alias contract test now **requires** any non-Qwen3.5/3.6 verified alias to pin a `pflash_keep_ratio`, encoding that bonsai is unsafe at the 0.20 default.

## Tests
- `test_pflash.py`: keep_ratio resolver precedence (alias override / explicit-wins / default), `config_from_args` None fallback, end-to-end mode+ratio pair for bonsai.
- `test_aliases_contract.py`: `_coerce` range/type rejection (out-of-range, non-number incl. bool), valid-value coercion, non-Qwen-verified-must-pin-keep_ratio gate.
- Full targeted suite: `test_pflash.py test_aliases_contract.py test_model_aliases.py test_cli_bench.py test_no_out_of_band_routing.py` → **2759 passed**; ruff clean.
- **Live** (mac-mini M2 Pro 32GB): bare `serve bonsai-27b-2bit` → PFlash auto-`always`, log shows `pflash_tier=verified`; depth needle **5/5 @ TTFT ~66s** vs **1/5 @ 0.20**.

## Notes
- No version bump. One change: the keep_ratio-override mechanism + the single alias tag it exists to support.
- CLI/env explicit overrides are unchanged and still win.

🤖 This PR was authored by Claude (Opus 4.8) under human direction.