### PR TITLE
fix(cache): persist reusable DeepSeek message boundaries first

### DIFF
--- a/tests/test_prefix_cache_persistence.py
+++ b/tests/test_prefix_cache_persistence.py
@@ -1397,18 +1397,20 @@ def test_shutdown_partial_commit_prioritizes_latest_message_boundary(tmp_path):
     """A reusable boundary must beat a longer non-trimmable completion tail."""
     cache_dir = tmp_path / "snap"
     cache = fresh_cache()
-    older_boundary = list(range(60))
-    latest_boundary = list(range(70))
+    older_boundary = list(range(70))
+    # Simulate context truncation/new-session turnover: the latest boundary can
+    # legitimately be shorter than an older one.
+    latest_boundary = list(range(60))
     completion_tail = list(range(100))
     cache.store(
         older_boundary,
-        make_kvcache(num_tokens=60),
+        make_kvcache(num_tokens=70),
         evict_prefixes=False,
         message_boundary=True,
     )
     cache.store(
         latest_boundary,
-        make_kvcache(num_tokens=70, fill=2.0),
+        make_kvcache(num_tokens=60, fill=2.0),
         evict_prefixes=False,
         message_boundary=True,
     )
@@ -1441,6 +1443,28 @@ def test_shutdown_partial_commit_prioritizes_latest_message_boundary(tmp_path):
 
     index = json.loads((cache_dir / "index.json").read_text())
     assert index["entries"][0]["message_boundary"] is True
+    assert index["entries"][0]["message_boundary_sequence"] == 2
+
+
+def test_shutdown_mixed_cache_preserves_deepest_prefix_priority(tmp_path):
+    cache_dir = tmp_path / "snap"
+    cache = fresh_cache()
+    boundary = list(range(10))
+    deepest_trimmable = list(range(100))
+    cache.store(boundary, make_kvcache(10), message_boundary=True)
+    cache.store(deepest_trimmable, make_kvcache(100), evict_prefixes=False)
+    cache._entries[tuple(boundary)].non_trimmable = True
+
+    calls = {"n": 0}
+
+    def predicate(predicted_sec=0.0):
+        calls["n"] += 1
+        return calls["n"] > 1
+
+    assert cache.save_to_disk(str(cache_dir), should_abort=predicate) is True
+    loaded_cache = fresh_cache()
+    assert loaded_cache.load_from_disk(str(cache_dir)) == 1
+    assert next(iter(loaded_cache._entries)) == tuple(deepest_trimmable)
 
 
 def test_message_boundary_marker_roundtrips_and_legacy_defaults_false(tmp_path):
@@ -1455,6 +1479,7 @@ def test_message_boundary_marker_roundtrips_and_legacy_defaults_false(tmp_path):
     loaded_cache = fresh_cache()
     assert loaded_cache.load_from_disk(str(tmp_path)) == 1
     assert next(iter(loaded_cache._entries.values())).message_boundary is True
+    assert next(iter(loaded_cache._entries.values())).message_boundary_sequence == 1
 
     index_path = tmp_path / "index.json"
     index = json.loads(index_path.read_text())
@@ -1463,6 +1488,7 @@ def test_message_boundary_marker_roundtrips_and_legacy_defaults_false(tmp_path):
     legacy_cache = fresh_cache()
     assert legacy_cache.load_from_disk(str(tmp_path)) == 1
     assert next(iter(legacy_cache._entries.values())).message_boundary is False
+    assert next(iter(legacy_cache._entries.values())).message_boundary_sequence == 0
 
 
 def test_deadline_save_skips_oversized_prefix_and_tries_smaller(tmp_path):

--- a/tests/test_prefix_cache_persistence.py
+++ b/tests/test_prefix_cache_persistence.py
@@ -1393,6 +1393,75 @@ def test_shutdown_partial_commit_prioritizes_longest_prefix(tmp_path):
     assert entry.tokens == tuple(range(100))
 
 
+def test_shutdown_partial_commit_prioritizes_latest_message_boundary(tmp_path):
+    """A reusable boundary must beat a longer non-trimmable completion tail."""
+    cache_dir = tmp_path / "snap"
+    cache = fresh_cache()
+    older_boundary = list(range(60))
+    latest_boundary = list(range(70))
+    completion_tail = list(range(100))
+    cache.store(
+        older_boundary,
+        make_kvcache(num_tokens=60),
+        evict_prefixes=False,
+        message_boundary=True,
+    )
+    cache.store(
+        latest_boundary,
+        make_kvcache(num_tokens=70, fill=2.0),
+        evict_prefixes=False,
+        message_boundary=True,
+    )
+    cache.store(
+        completion_tail,
+        make_kvcache(num_tokens=100, fill=3.0),
+        evict_prefixes=False,
+    )
+    # Tiny real KVCache fixtures are trimmable. Mark these entries as the
+    # hybrid recurrent-state shape whose persistence ordering this test covers;
+    # their serialized cache bodies remain valid lightweight fixtures.
+    for entry in cache._entries.values():
+        entry.non_trimmable = True
+
+    calls = {"n": 0}
+
+    def predicate(predicted_sec=0.0):
+        calls["n"] += 1
+        return calls["n"] > 1
+
+    assert cache.save_to_disk(str(cache_dir), should_abort=predicate) is True
+    loaded_cache = fresh_cache()
+    assert loaded_cache.load_from_disk(str(cache_dir)) == 1
+    entry = next(iter(loaded_cache._entries.values()))
+    assert entry.tokens == tuple(latest_boundary)
+    assert entry.message_boundary is True
+
+    index = json.loads((cache_dir / "index.json").read_text())
+    assert index["entries"][0]["message_boundary"] is True
+
+
+def test_message_boundary_marker_roundtrips_and_legacy_defaults_false(tmp_path):
+    cache = fresh_cache()
+    cache.store(
+        list(range(11)),
+        make_kvcache(11),
+        message_boundary=True,
+    )
+    assert cache.save_to_disk(str(tmp_path)) is True
+
+    loaded_cache = fresh_cache()
+    assert loaded_cache.load_from_disk(str(tmp_path)) == 1
+    assert next(iter(loaded_cache._entries.values())).message_boundary is True
+
+    index_path = tmp_path / "index.json"
+    index = json.loads(index_path.read_text())
+    index["entries"][0].pop("message_boundary")
+    index_path.write_text(json.dumps(index))
+    legacy_cache = fresh_cache()
+    assert legacy_cache.load_from_disk(str(tmp_path)) == 1
+    assert next(iter(legacy_cache._entries.values())).message_boundary is False
+
+
 def test_deadline_save_skips_oversized_prefix_and_tries_smaller(tmp_path):
     cache_dir = tmp_path / "snap"
     cache = fresh_cache()

--- a/tests/test_prefix_cache_persistence.py
+++ b/tests/test_prefix_cache_persistence.py
@@ -1422,6 +1422,9 @@ def test_shutdown_partial_commit_prioritizes_latest_message_boundary(tmp_path):
     # their serialized cache bodies remain valid lightweight fixtures.
     for entry in cache._entries.values():
         entry.non_trimmable = True
+    # Fetching an older boundary refreshes its LRU position. Persistence must
+    # still select the deeper conversational frontier, not mutable recency.
+    cache.fetch(older_boundary)
 
     calls = {"n": 0}
 

--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -2128,9 +2128,7 @@ class MemoryAwarePrefixCache:
             )
 
         # Create entry and estimate memory (pure compute, no shared state).
-        entry = _CacheEntry.create(
-            tokens, cache, message_boundary=message_boundary
-        )
+        entry = _CacheEntry.create(tokens, cache, message_boundary=message_boundary)
 
         # Check if single entry exceeds limit
         if entry.memory_bytes > self._max_memory:
@@ -2674,15 +2672,12 @@ class MemoryAwarePrefixCache:
         if check_abort is not None:
             # For non-trimmable hybrid caches, a longer completion tail cannot
             # be cropped to the next request's message boundary. Prefer the
-            # newest explicit boundary first, then fall back to the deepest
-            # frontier for legacy/unmarked entries. LRU rank is ascending
-            # oldest->newest, hence the descending rank in this key.
+            # deepest explicit boundary first, then fall back to the deepest
+            # frontier for legacy/unmarked entries. Depth is stable when a
+            # fetch refreshes LRU order, unlike recency rank.
             entries_to_save.sort(
                 key=lambda item: (
                     item[1].message_boundary and item[1].non_trimmable,
-                    lru_rank[item[0]]
-                    if item[1].message_boundary and item[1].non_trimmable
-                    else len(item[0]),
                     len(item[0]),
                 ),
                 reverse=True,
@@ -3654,9 +3649,7 @@ class MemoryAwarePrefixCache:
                     protected=protected_import,
                     # Backward compatible with snapshots written before this
                     # marker existed.
-                    message_boundary=bool(
-                        entry_meta.get("message_boundary", False)
-                    ),
+                    message_boundary=bool(entry_meta.get("message_boundary", False)),
                 )
                 staged[tokens_key] = entry
                 staged_memory += memory

--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -1169,9 +1169,20 @@ class _CacheEntry:
     # Live-STORE entries are always ``protected=False`` (the opportunistic path
     # the bound governs). The bound governs OPPORTUNISTIC (unprotected) entries.
     protected: bool = False
+    # Exact message-boundary snapshots are the reusable restart frontier for
+    # hybrid caches that cannot be trimmed.  Keep this semantic marker across
+    # persistence cycles so a deadline-limited shutdown saves the latest
+    # usable boundary instead of a longer prompt+completion tail.
+    message_boundary: bool = False
 
     @classmethod
-    def create(cls, tokens: list[int], cache: list[Any]) -> _CacheEntry:
+    def create(
+        cls,
+        tokens: list[int],
+        cache: list[Any],
+        *,
+        message_boundary: bool = False,
+    ) -> _CacheEntry:
         """Create a cache entry with memory estimation.
 
         Live-store entries are EVICTABLE (``protected=False``) — the
@@ -1186,6 +1197,7 @@ class _CacheEntry:
             cache=cache,
             memory_bytes=memory,
             non_trimmable=_cache_has_non_trimmable(cache),
+            message_boundary=message_boundary,
         )
 
 
@@ -2013,7 +2025,12 @@ class MemoryAwarePrefixCache:
         return None, tokens
 
     def store(
-        self, tokens: list[int], cache: list[Any], evict_prefixes: bool = True
+        self,
+        tokens: list[int],
+        cache: list[Any],
+        evict_prefixes: bool = True,
+        *,
+        message_boundary: bool = False,
     ) -> bool:
         """
         Store KV cache for future reuse.
@@ -2030,6 +2047,10 @@ class MemoryAwarePrefixCache:
                 when storing prompt+output entries to preserve prompt-only
                 entries created by prompt_cache_save (those are the entries
                 that future requests will actually match).
+            message_boundary: Mark an exact conversational boundary. These
+                entries are preferred by deadline-limited disk persistence
+                because non-trimmable hybrid caches can only resume them at
+                their exact token length.
 
         Returns:
             True if stored successfully, False if rejected.
@@ -2078,6 +2099,8 @@ class MemoryAwarePrefixCache:
         # Holds the lock briefly so the bump is consistent with concurrent fetch.
         with self._lock:
             if tokens_key in self._entries:
+                if message_boundary:
+                    self._entries[tokens_key].message_boundary = True
                 self._entries.move_to_end(tokens_key)
                 return True
 
@@ -2105,7 +2128,9 @@ class MemoryAwarePrefixCache:
             )
 
         # Create entry and estimate memory (pure compute, no shared state).
-        entry = _CacheEntry.create(tokens, cache)
+        entry = _CacheEntry.create(
+            tokens, cache, message_boundary=message_boundary
+        )
 
         # Check if single entry exceeds limit
         if entry.memory_bytes > self._max_memory:
@@ -2120,6 +2145,8 @@ class MemoryAwarePrefixCache:
             # the same key while we were trimming/compressing outside the
             # lock. Just bump LRU and bail.
             if tokens_key in self._entries:
+                if message_boundary:
+                    self._entries[tokens_key].message_boundary = True
                 self._entries.move_to_end(tokens_key)
                 return True
 
@@ -2645,11 +2672,21 @@ class MemoryAwarePrefixCache:
         lru_rank = {tokens_key: rank for rank, tokens_key in enumerate(self._entries)}
         saved_lru_rank: dict[int, int] = {}
         if check_abort is not None:
-            # A deadline-limited snapshot should preserve the deepest reusable
-            # frontier first. LRU order may begin with a tiny bootstrap entry,
-            # which can otherwise consume the only guaranteed shutdown slot
-            # and skew the observed-throughput estimate with fixed fsync cost.
-            entries_to_save.sort(key=lambda item: len(item[0]), reverse=True)
+            # For non-trimmable hybrid caches, a longer completion tail cannot
+            # be cropped to the next request's message boundary. Prefer the
+            # newest explicit boundary first, then fall back to the deepest
+            # frontier for legacy/unmarked entries. LRU rank is ascending
+            # oldest->newest, hence the descending rank in this key.
+            entries_to_save.sort(
+                key=lambda item: (
+                    item[1].message_boundary and item[1].non_trimmable,
+                    lru_rank[item[0]]
+                    if item[1].message_boundary and item[1].non_trimmable
+                    else len(item[0]),
+                    len(item[0]),
+                ),
+                reverse=True,
+            )
         total_bytes_written = 0
         total_write_seconds = 0.0
         for i, (tokens_key, entry) in enumerate(entries_to_save):
@@ -2742,6 +2779,7 @@ class MemoryAwarePrefixCache:
                         "num_tokens": len(tokens_key),
                         "memory_bytes": entry.memory_bytes,
                         "cache_types": cache_types,
+                        "message_boundary": entry.message_boundary,
                     }
                 )
                 saved_lru_rank[i] = lru_rank[tokens_key]
@@ -3614,6 +3652,11 @@ class MemoryAwarePrefixCache:
                     #    persists opportunistic entries; see load_from_disk
                     #    docstring for the full restart cycle).
                     protected=protected_import,
+                    # Backward compatible with snapshots written before this
+                    # marker existed.
+                    message_boundary=bool(
+                        entry_meta.get("message_boundary", False)
+                    ),
                 )
                 staged[tokens_key] = entry
                 staged_memory += memory

--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -1174,6 +1174,10 @@ class _CacheEntry:
     # persistence cycles so a deadline-limited shutdown saves the latest
     # usable boundary instead of a longer prompt+completion tail.
     message_boundary: bool = False
+    # Monotonic creation/update order for message boundaries. Unlike LRU rank
+    # or token depth, this remains meaningful after a fetch, context truncation,
+    # and process restart.
+    message_boundary_sequence: int = 0
 
     @classmethod
     def create(
@@ -1182,6 +1186,7 @@ class _CacheEntry:
         cache: list[Any],
         *,
         message_boundary: bool = False,
+        message_boundary_sequence: int = 0,
     ) -> _CacheEntry:
         """Create a cache entry with memory estimation.
 
@@ -1198,6 +1203,7 @@ class _CacheEntry:
             memory_bytes=memory,
             non_trimmable=_cache_has_non_trimmable(cache),
             message_boundary=message_boundary,
+            message_boundary_sequence=message_boundary_sequence,
         )
 
 
@@ -1698,6 +1704,7 @@ class MemoryAwarePrefixCache:
         # OrderedDict maintains insertion order for LRU
         # Key: tuple(tokens), Value: _CacheEntry
         self._entries: OrderedDict[tuple[int, ...], _CacheEntry] = OrderedDict()
+        self._message_boundary_sequence = 0
 
         # Sorted index of token keys for efficient prefix/supersequence lookup.
         # Tuple lexicographic ordering means a prefix key P is always < any
@@ -2100,7 +2107,10 @@ class MemoryAwarePrefixCache:
         with self._lock:
             if tokens_key in self._entries:
                 if message_boundary:
-                    self._entries[tokens_key].message_boundary = True
+                    self._message_boundary_sequence += 1
+                    existing = self._entries[tokens_key]
+                    existing.message_boundary = True
+                    existing.message_boundary_sequence = self._message_boundary_sequence
                 self._entries.move_to_end(tokens_key)
                 return True
 
@@ -2144,7 +2154,10 @@ class MemoryAwarePrefixCache:
             # lock. Just bump LRU and bail.
             if tokens_key in self._entries:
                 if message_boundary:
-                    self._entries[tokens_key].message_boundary = True
+                    self._message_boundary_sequence += 1
+                    existing = self._entries[tokens_key]
+                    existing.message_boundary = True
+                    existing.message_boundary_sequence = self._message_boundary_sequence
                 self._entries.move_to_end(tokens_key)
                 return True
 
@@ -2199,6 +2212,9 @@ class MemoryAwarePrefixCache:
             # Store entry. Insert into _entries before _sorted_keys so
             # that even if a future change drops the lock, fetch never
             # observes a key in sorted_keys that's missing from entries.
+            if message_boundary:
+                self._message_boundary_sequence += 1
+                entry.message_boundary_sequence = self._message_boundary_sequence
             self._entries[tokens_key] = entry
             self._current_memory += entry.memory_bytes
             bisect.insort(self._sorted_keys, tokens_key)
@@ -2675,9 +2691,13 @@ class MemoryAwarePrefixCache:
             # deepest explicit boundary first, then fall back to the deepest
             # frontier for legacy/unmarked entries. Depth is stable when a
             # fetch refreshes LRU order, unlike recency rank.
+            all_non_trimmable = all(entry.non_trimmable for _, entry in entries_to_save)
             entries_to_save.sort(
                 key=lambda item: (
-                    item[1].message_boundary and item[1].non_trimmable,
+                    all_non_trimmable and item[1].message_boundary,
+                    item[1].message_boundary_sequence
+                    if all_non_trimmable and item[1].message_boundary
+                    else 0,
                     len(item[0]),
                 ),
                 reverse=True,
@@ -2775,6 +2795,7 @@ class MemoryAwarePrefixCache:
                         "memory_bytes": entry.memory_bytes,
                         "cache_types": cache_types,
                         "message_boundary": entry.message_boundary,
+                        "message_boundary_sequence": (entry.message_boundary_sequence),
                     }
                 )
                 saved_lru_rank[i] = lru_rank[tokens_key]
@@ -3650,6 +3671,11 @@ class MemoryAwarePrefixCache:
                     # Backward compatible with snapshots written before this
                     # marker existed.
                     message_boundary=bool(entry_meta.get("message_boundary", False)),
+                    message_boundary_sequence=(
+                        int(entry_meta.get("message_boundary_sequence", 0))
+                        if entry_meta.get("message_boundary", False)
+                        else 0
+                    ),
                 )
                 staged[tokens_key] = entry
                 staged_memory += memory
@@ -3906,6 +3932,14 @@ class MemoryAwarePrefixCache:
             # actually looking for. Kept inside the same critical section
             # as the install so a scraper reads a consistent stats block.
             self._stats.load_skipped += corrupt_skipped
+            if self._entries:
+                self._message_boundary_sequence = max(
+                    self._message_boundary_sequence,
+                    max(
+                        entry.message_boundary_sequence
+                        for entry in self._entries.values()
+                    ),
+                )
 
         # #1100 codex round 4 (#3): authoritative loaded-byte total, summed
         # from the entries actually installed in THIS load (under the lock

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -3825,7 +3825,10 @@ class Scheduler:
                 # path — keep boundary entries so later turns with the
                 # same prefix but different suffix still hit.
                 stored = self.memory_aware_cache.store(
-                    prefix_tokens, reconstructed, evict_prefixes=False
+                    prefix_tokens,
+                    reconstructed,
+                    evict_prefixes=False,
+                    message_boundary=True,
                 )
             except Exception as exc:
                 logger.debug(


### PR DESCRIPTION
## What changed

- mark scheduler snapshots taken at exact message boundaries
- persist that marker in the prefix-cache index with backward-compatible loading
- under a shutdown deadline, prefer the newest reusable non-trimmable boundary over a longer completion tail
- preserve the existing deepest-prefix priority for trimmable and legacy entries

## Why / root cause

DeepSeek V4's hybrid cache cannot trim a longer cached completion back to the next request's message boundary. The 3.5-second shutdown budget often permits only one entry, while persistence previously selected the longest token sequence. That saved a completion tail which shared almost the entire next prompt but was unusable, forcing a full cold prefill after restart.

## User impact

In a real Codex session, the broken path loaded a 64,738-token completion entry and missed a 63K prompt. With this change, a deadline-limited shutdown saved the latest 66,674-token message boundary; after restart the same session hit all 66,674 cached tokens, prefilled only 84 tokens, and reached first token in 2.0 seconds instead of 270.1 seconds cold.

## Validation

- `94 passed`: `tests/test_prefix_cache_persistence.py` and `tests/test_prefix_boundary_path_parity.py`
- `240 passed`: persistence, boundary parity, DeepSeek parser, reasoning budget, and Responses route suites
- real M3 Ultra shutdown/restart black-box validation with DeepSeek-V4-Flash-0731 MXFP4

The separate generation-time reasoning-budget experiment was removed after a real Codex soak exposed a `model_no_final_answer` retry; it is intentionally not part of this PR.
