### PR TITLE
feat(rapid-mac): refine desktop visual system and model states

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/DevSnapshot.swift
+++ b/apps/rapid-mac/Sources/Rapid/DevSnapshot.swift
@@ -40,7 +40,7 @@ enum DevSnapshot {
         func contentView(width: CGFloat, height: CGFloat) -> AnyView {
             AnyView(
                 ContentView()
-                    .tint(RapidTheme.brand)
+                    .tint(RapidTheme.brandAmber)
                     .environment(server)
                     .environment(downloads)
                     .environment(chat)
@@ -55,10 +55,113 @@ enum DevSnapshot {
             )
         }
 
+        /// The Launch page inside the real split-view chrome, so the
+        /// captured frame shows what the user actually sees (sidebar +
+        /// page) rather than the page in isolation.
+        ///
+        /// ``ContentView`` owns its ``SidebarSection`` in private
+        /// ``@State``, so the harness cannot drive it to ``.launch``
+        /// from outside. Re-composing the same two views here is the
+        /// only way to capture that route; the scaffold deliberately
+        /// mirrors ``ContentView``'s ``NavigationSplitView`` shape so
+        /// the screenshot stays representative.
+        /// An `HStack`, deliberately, NOT a ``NavigationSplitView``.
+        ///
+        /// A hosted ``NavigationSplitView`` renders its DETAIL pane
+        /// correctly offscreen but leaves the SIDEBAR column blank —
+        /// AppKit's split-view controller wants a real on-screen window
+        /// to populate it. Since the point of this scene is to review
+        /// the rail's width and density against the detail pane, the
+        /// scaffold reproduces the split geometry manually so both
+        /// columns actually appear.
+        ///
+        /// Consequence to keep in mind when reading the image: the
+        /// system's sidebar toolbar/collapse chrome is absent, and the
+        /// divider is drawn here rather than by AppKit.
+        func launchView(width: CGFloat, height: CGFloat) -> AnyView {
+            AnyView(
+                HStack(spacing: 0) {
+                    SidebarView(
+                        selection: .constant(.launch),
+                        chat: chat,
+                        onNewChat: {},
+                        onSelectConversation: { _ in }
+                    )
+                    .frame(width: SidebarView.columnIdealWidth)
+                    .background(RapidTheme.surfaceSidebar)
+
+                    Rectangle()
+                        .fill(RapidTheme.hairline)
+                        .frame(width: 1)
+
+                    LaunchView(server: server, alias: "bonsai-1.7b-2bit")
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                        .background(RapidTheme.surfaceCanvas)
+                }
+                .tint(RapidTheme.brandAmber)
+                .environment(server)
+                .environment(downloads)
+                .environment(chat)
+                .environment(updater)
+                .environment(sampling)
+                .environment(appearance)
+                .environment(settingsRouter)
+                .environment(installTracker)
+                .environment(quickstart)
+                .environment(dockPromptStore)
+                .frame(width: width, height: height)
+            )
+        }
+
         // Scenario 1: the app as launched (idle / first-run, depending on
         // whether HF_HUB_CACHE points at a populated cache).
         render(contentView(width: 900, height: 640), to: "\(dir)/content-idle.png")
         render(contentView(width: 640, height: 560), to: "\(dir)/content-min.png")
+
+        // Scenario 1b (v1.0 visual foundation): the Light/Dark × surface
+        // matrix the Phase-1 review runs on. Chat and Launch are the two
+        // surfaces this phase repaints, so both are captured at the
+        // 900x640 review size in both appearances, plus one shot each at
+        // the 640x560 window floor to prove the layout survives it.
+        let reviewSize = CGSize(width: 900, height: 640)
+        let floorSize = CGSize(width: 640, height: 560)
+
+        renderHosted(contentView(width: 900, height: 640), size: reviewSize,
+                     appearance: .aqua, to: "\(dir)/chat-900x640-light.png")
+        renderHosted(contentView(width: 900, height: 640), size: reviewSize,
+                     appearance: .darkAqua, to: "\(dir)/chat-900x640-dark.png")
+        renderHosted(contentView(width: 640, height: 560), size: floorSize,
+                     appearance: .aqua, to: "\(dir)/chat-640x560-light.png")
+        renderHosted(launchView(width: 900, height: 640), size: reviewSize,
+                     appearance: .aqua, to: "\(dir)/launch-900x640-light.png")
+        renderHosted(launchView(width: 900, height: 640), size: reviewSize,
+                     appearance: .darkAqua, to: "\(dir)/launch-900x640-dark.png")
+        renderHosted(launchView(width: 640, height: 560), size: floorSize,
+                     appearance: .aqua, to: "\(dir)/launch-640x560-light.png")
+
+        // The rail on its own, at its shipping width, with seeded
+        // history so row density / truncation / the amber selected
+        // state are all reviewable. Needed because the hosted
+        // ``NavigationSplitView`` captures above render the sidebar
+        // column blank.
+        func sidebarOnly() -> AnyView {
+            AnyView(
+                SidebarView(
+                    selection: .constant(.launch),
+                    chat: chat,
+                    onNewChat: {},
+                    onSelectConversation: { _ in }
+                )
+                .frame(width: SidebarView.columnIdealWidth, height: 640)
+                .background(RapidTheme.surfaceSidebar)
+                .tint(RapidTheme.brandAmber)
+            )
+        }
+        let sidebarSize = CGSize(width: SidebarView.columnIdealWidth, height: 640)
+        renderHosted(sidebarOnly(), size: sidebarSize,
+                     appearance: .aqua, to: "\(dir)/sidebar-light.png")
+        renderHosted(sidebarOnly(), size: sidebarSize,
+                     appearance: .darkAqua, to: "\(dir)/sidebar-dark.png")
 
         // Scenario 2: a populated chat transcript, so we can eyeball the
         // streaming bubble / markdown render path that an empty transcript
@@ -86,6 +189,16 @@ enum DevSnapshot {
                     promptTokens: 12,
                     completionTokens: 58
                 )
+            ),
+            // A failed turn, so the transcript scene actually exercises
+            // the error branch of ``MessageRow``. Without it the failure
+            // caption's colour had no render path at all and could only
+            // be reviewed by reading the source.
+            ChatMessage(
+                role: .assistant,
+                content: "",
+                status: .failed,
+                errorMessage: "The model couldn't complete that request."
             ),
         ])
         // Let the transcript layout settle before capturing.
@@ -239,6 +352,15 @@ enum DevSnapshot {
         )
     }
 
+    /// Render at the host's current appearance via ``ImageRenderer``.
+    ///
+    /// Retained unchanged for the pre-v1.0 component scenes (Connect
+    /// Tools card body, Benchmark result, Consent, chat bubbles), which
+    /// are plain view trees that ``ImageRenderer`` rasterises correctly
+    /// and which benefit from its ``scale`` support.
+    ///
+    /// Full-window compositions must use ``renderHosted`` instead — see
+    /// the note there about ``NavigationSplitView``.
     @MainActor
     private static func render(_ view: AnyView, to path: String) {
         let renderer = ImageRenderer(content: view)
@@ -248,6 +370,80 @@ enum DevSnapshot {
               let rep = NSBitmapImageRep(data: tiff),
               let png = rep.representation(using: .png, properties: [:]) else {
             log("FAILED to render \(path)")
+            return
+        }
+        do {
+            try png.write(to: URL(fileURLWithPath: path))
+        } catch {
+            log("FAILED to write \(path): \(error)")
+        }
+    }
+
+    /// Render a full-window composition at a pinned appearance.
+    ///
+    /// **Why not ``ImageRenderer``.** ``ImageRenderer`` cannot rasterise
+    /// ``NavigationSplitView``: it emits a "prohibited" placeholder
+    /// glyph instead of the view tree. That is not new — every
+    /// `content-idle.png` / `content-min.png` this harness has ever
+    /// written was that placeholder, verified by rendering from a
+    /// pristine build of the parent commit. Any main-window screenshot
+    /// taken from the old path was therefore worthless, which also
+    /// means the split view has never actually been under visual
+    /// regression review.
+    ///
+    /// Hosting the view in a real (offscreen, borderless) ``NSWindow``
+    /// and calling ``cacheDisplay`` drives genuine AppKit layout, which
+    /// the split view needs. The window also gives us:
+    ///
+    ///   * a correct ``NSAppearance`` for the whole tree, which is what
+    ///     ``NSColor(name:dynamicProvider:)`` — i.e. every
+    ///     ``RapidTheme`` colour — resolves against, and
+    ///   * the display's backing scale, so the capture is 2x on Retina
+    ///     rather than the 1x a window-less ``NSHostingView`` yields.
+    ///
+    /// ``\.colorScheme`` is set alongside the appearance to cover the
+    /// SwiftUI-native side (materials, `.primary`/`.secondary`).
+    @MainActor
+    private static func renderHosted(
+        _ view: AnyView,
+        size: CGSize,
+        appearance appearanceName: NSAppearance.Name,
+        to path: String
+    ) {
+        let scheme: ColorScheme = appearanceName == .darkAqua ? .dark : .light
+        let hosting = NSHostingView(
+            rootView: view.environment(\.colorScheme, scheme)
+        )
+        hosting.frame = CGRect(origin: .zero, size: size)
+
+        let window = NSWindow(
+            contentRect: CGRect(origin: .zero, size: size),
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        window.appearance = NSAppearance(named: appearanceName)
+        window.contentView = hosting
+        window.setFrame(CGRect(origin: .zero, size: size), display: true)
+        hosting.layoutSubtreeIfNeeded()
+        window.displayIfNeeded()
+
+        // Let SwiftUI's first layout pass + any .task/.onAppear that
+        // affects layout settle before we snapshot. Spinning the
+        // runloop (rather than sleeping) lets those callbacks actually
+        // run — they are main-actor bound.
+        RunLoop.current.run(until: Date().addingTimeInterval(0.35))
+        hosting.layoutSubtreeIfNeeded()
+        window.displayIfNeeded()
+
+        guard let rep = hosting.bitmapImageRepForCachingDisplay(in: hosting.bounds) else {
+            log("FAILED to allocate bitmap for \(path)")
+            return
+        }
+        hosting.cacheDisplay(in: hosting.bounds, to: rep)
+
+        guard let png = rep.representation(using: .png, properties: [:]) else {
+            log("FAILED to encode \(path)")
             return
         }
         do {

--- a/apps/rapid-mac/Sources/Rapid/Server/BenchmarkRunner.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/BenchmarkRunner.swift
@@ -46,7 +46,7 @@ final class BenchmarkRunner {
 
     func run(binary: URL, alias: String, chip: String) async {
         guard !alias.isEmpty else {
-            phase = .failed("Pick a model first.")
+            phase = .failed("Choose a model first.")
             return
         }
         phase = .running
@@ -79,7 +79,7 @@ final class BenchmarkRunner {
 
     func submit(binary: URL, alias: String) async {
         guard !alias.isEmpty else {
-            submitPhase = .failed("Pick a model first.")
+            submitPhase = .failed("Choose a model first.")
             return
         }
         submitPhase = .submitting

--- a/apps/rapid-mac/Sources/Rapid/Server/ModelCatalog.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ModelCatalog.swift
@@ -347,14 +347,21 @@ enum ModelCatalog {
     /// Pure + `static` so the set is one list rather than a chain of
     /// `hasPrefix` calls buried in the parse loop.
     static func isBannerLine(_ line: String) -> Bool {
+        // Match the full banner grammar, not a bare word. An alias is
+        // ASCII `[A-Za-z0-9._-]` with no spaces or colons (``isSafeAlias``),
+        // so a genuine alias row for a model literally named "Loading",
+        // "Uvicorn", or "Traceback" is `<name><2+ spaces><size>` — which
+        // none of these prefixes match, while the real banners
+        // ("Loading model with …", "Uvicorn running on …", "Traceback
+        // (most recent call last):") all do. `INFO:`/`WARNING:`/`ERROR:`
+        // carry a colon and so can never collide with an alias.
         let bannerPrefixes = [
             "Loading model",
-            "Loading ",
             "INFO:",
             "WARNING:",
             "ERROR:",
-            "Uvicorn",
-            "Traceback",
+            "Uvicorn running",
+            "Traceback (",
         ]
         return bannerPrefixes.contains { line.hasPrefix($0) }
     }

--- a/apps/rapid-mac/Sources/Rapid/Server/ModelCatalog.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ModelCatalog.swift
@@ -315,6 +315,21 @@ enum ModelCatalog {
             // Model Management, auto-start).
             if line.hasPrefix("Audio models") { continue }
             if line.contains("[audio:") { continue }
+            // Skip engine/server banner lines that can share stdout with
+            // the table.
+            //
+            // The engine prints "Loading model with BatchedEngine: …"
+            // and uvicorn prints "INFO:     Uvicorn running on …". Both
+            // are prose, and the "first whitespace token is the alias"
+            // rule turns them into phantom models — which is exactly how
+            // a selectable model literally named "Loading" reached the
+            // picker, and from there ``recommendedDefault`` put the word
+            // "Loading" in the composer as if the user had chosen it.
+            //
+            // Matching on the banner prefix (rather than blacklisting
+            // the word) keeps a genuine alias that merely starts with
+            // those letters safe.
+            if isBannerLine(line) { continue }
             // First whitespace-delimited token is the alias.
             let token = line.split(maxSplits: 1, whereSeparator: { $0.isWhitespace }).first
             guard let alias = token.map(String.init), !alias.isEmpty else { continue }
@@ -322,6 +337,26 @@ enum ModelCatalog {
             entries.append((alias, nil))
         }
         return entries
+    }
+
+    /// Log/banner lines the engine or its HTTP server can interleave
+    /// with table output. None of these are catalog rows, and every one
+    /// of them would otherwise yield a phantom alias from its first
+    /// token ("Loading", "INFO:", "Uvicorn", …).
+    ///
+    /// Pure + `static` so the set is one list rather than a chain of
+    /// `hasPrefix` calls buried in the parse loop.
+    static func isBannerLine(_ line: String) -> Bool {
+        let bannerPrefixes = [
+            "Loading model",
+            "Loading ",
+            "INFO:",
+            "WARNING:",
+            "ERROR:",
+            "Uvicorn",
+            "Traceback",
+        ]
+        return bannerPrefixes.contains { line.hasPrefix($0) }
     }
 
     /// Parses ``rapid-mlx ls`` output. Each row has the alias in the
@@ -336,6 +371,9 @@ enum ModelCatalog {
             if line.hasPrefix("Cached models") { continue }
             if line.hasPrefix("Alias") { continue }
             if line.allSatisfy({ $0 == "─" || $0 == "-" || $0.isWhitespace }) { continue }
+            // Same banner guard as ``parseAvailable`` — `ls` shares the
+            // engine's stdout too.
+            if isBannerLine(line) { continue }
             // Multi-space splitting: each column is separated by 2+
             // spaces.  ``components(separatedBy: doubleSpaces)`` would
             // need a custom CharacterSet; cheaper to regex.

--- a/apps/rapid-mac/Sources/Rapid/UI/BenchmarkView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/BenchmarkView.swift
@@ -11,6 +11,9 @@ import SwiftUI
 struct BenchmarkView: View {
     @State private var runner: BenchmarkRunner
     @State private var showSubmitConsent = false
+    /// Collapsed by default — raw child output is diagnostic detail,
+    /// not the primary error surface.
+    @State private var showFailureDetails = false
 
     let binary: URL?
     let alias: String
@@ -49,12 +52,7 @@ struct BenchmarkView: View {
                     .fixedSize(horizontal: false, vertical: true)
             }
             Spacer()
-            Button(action: onClose) {
-                Image(systemName: "xmark.circle.fill")
-                    .font(.title2).foregroundStyle(.tertiary)
-            }
-            .buttonStyle(.plain)
-            .accessibilityLabel("Close")
+            SheetCloseButton(action: onClose)
         }
         .padding(20)
     }
@@ -218,20 +216,105 @@ struct BenchmarkView: View {
         .frame(width: 380)
     }
 
+    /// Failure state.
+    ///
+    /// ``BenchmarkRunner`` returns the last four lines of the child's
+    /// combined stdout+stderr on a non-zero exit, which for a Python
+    /// sidecar is a raw traceback tail. Rendering that as the primary
+    /// message told the user nothing actionable and looked like a
+    /// crash. The raw text is still preserved — it just moves behind a
+    /// collapsed disclosure, and a classified sentence takes the front.
     private func failedState(_ msg: String) -> some View {
-        VStack(spacing: 14) {
+        let diagnosis = BenchmarkView.classifyFailure(msg)
+        return VStack(spacing: RapidTheme.Space.md) {
             Image(systemName: "exclamationmark.triangle")
-                .font(.system(size: 32)).foregroundStyle(RapidTheme.amberDeep)
-                .padding(.top, 36)
-            Text(msg).font(.callout).foregroundStyle(.secondary)
+                .font(.system(size: 26))
+                .foregroundStyle(RapidTheme.brandPrimaryDeep)
+                .padding(.top, RapidTheme.Space.xl)
+                .accessibilityHidden(true)
+
+            Text(diagnosis.headline)
+                .font(RapidFont.body)
+                .foregroundStyle(.primary)
                 .multilineTextAlignment(.center)
                 .fixedSize(horizontal: false, vertical: true)
+
             Button("Try again") {
-                Task { await runner.run(binary: binary ?? URL(fileURLWithPath: "/"), alias: alias, chip: hardware.brandString) }
+                Task {
+                    await runner.run(
+                        binary: binary ?? URL(fileURLWithPath: "/"),
+                        alias: alias,
+                        chip: hardware.brandString
+                    )
+                }
             }
-            .buttonStyle(.bordered)
+            .buttonStyle(.rapidSecondary)
+
+            if diagnosis.showsDetails {
+                DisclosureGroup(isExpanded: $showFailureDetails) {
+                    ScrollView {
+                        Text(msg)
+                            .font(RapidFont.code)
+                            .foregroundStyle(.secondary)
+                            .textSelection(.enabled)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(RapidTheme.Space.sm)
+                    }
+                    .frame(maxHeight: 120)
+                    .background(
+                        RoundedRectangle(cornerRadius: RapidTheme.Radius.code, style: .continuous)
+                            .fill(RapidTheme.surfaceCode)
+                    )
+                } label: {
+                    Text("Show details")
+                        .font(RapidFont.caption)
+                        .foregroundStyle(.secondary)
+                }
+                .padding(.top, RapidTheme.Space.xs)
+            }
         }
         .frame(maxWidth: .infinity)
+    }
+
+    /// Maps a raw runner failure onto user-facing copy.
+    ///
+    /// Pure + `static` so the mapping can be unit-tested without
+    /// standing up the sheet, and so adding a case is a one-line change
+    /// in one place rather than a new branch in the view.
+    ///
+    /// ``showsDetails`` is false for messages we authored ourselves
+    /// (they are already the explanation) and true for anything that
+    /// came out of the child process.
+    static func classifyFailure(_ raw: String) -> (headline: String, showsDetails: Bool) {
+        let lowered = raw.lowercased()
+
+        if lowered.contains("address already in use")
+            || lowered.contains("errno 48")
+            || lowered.contains("eaddrinuse") {
+            return ("Couldn't start the benchmark because its local port is already in use.", true)
+        }
+        if lowered.contains("out of memory")
+            || lowered.contains("insufficient memory")
+            || lowered.contains("metal-cap") {
+            return ("Not enough memory to benchmark this model. Try a smaller model.", true)
+        }
+        if lowered.contains("no such file") || lowered.contains("not found") {
+            return ("Couldn't find the model files for this benchmark.", true)
+        }
+        if lowered.contains("connection") || lowered.contains("timed out") || lowered.contains("timeout") {
+            return ("The benchmark couldn't reach the local server. Try again.", true)
+        }
+        // Messages the runner authors itself are already plain English
+        // ("Choose a model first.", "Couldn't read the benchmark result.").
+        // Anything short and traceback-free is treated as one of those.
+        let looksLikeOurCopy = raw.count < 120
+            && !raw.contains("Traceback")
+            && !lowered.contains("error:")
+            && !raw.contains("  File \"")
+        if looksLikeOurCopy {
+            return (raw, false)
+        }
+        return ("The benchmark didn't finish. Try again.", true)
     }
 
     private func statRow(_ label: String, _ value: String) -> some View {
@@ -244,7 +327,8 @@ struct BenchmarkView: View {
         }
     }
 
+    /// Never renders an internal placeholder as a model name.
     private var displayAlias: String {
-        alias.isEmpty ? "your model" : alias
+        ModelDisplayName.configValue(alias: alias) ?? "your local model"
     }
 }

--- a/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
@@ -249,6 +249,15 @@ struct ChatView: View {
                 ScrollView {
                     transcriptRows
                 }
+                // This branch mounts fresh the moment the transcript goes
+                // from empty to populated — selecting a long saved
+                // conversation, or launching straight into one. The
+                // `messages.count` change that mounts it predates the
+                // `.onChange` handlers below, so a fresh ScrollView would
+                // open at the OLDEST message. Anchor to the latest on
+                // appear (no animation: this is initial positioning, not a
+                // scroll the user should see move).
+                .onAppear { scrollToBottom(proxy, animated: false) }
                 .onChange(of: messages.last?.content) { _, _ in scrollToBottom(proxy) }
                 .onChange(of: messages.last?.reasoning) { _, _ in scrollToBottom(proxy) }
                 .onChange(of: messages.count) { _, _ in scrollToBottom(proxy) }
@@ -280,7 +289,11 @@ struct ChatView: View {
         .padding(.vertical, RapidTheme.Space.xl)
     }
 
-    private func scrollToBottom(_ proxy: ScrollViewProxy) {
+    private func scrollToBottom(_ proxy: ScrollViewProxy, animated: Bool = true) {
+        guard animated else {
+            proxy.scrollTo(bottomSentinelID, anchor: .bottom)
+            return
+        }
         withAnimation(.easeOut(duration: 0.15)) {
             proxy.scrollTo(bottomSentinelID, anchor: .bottom)
         }

--- a/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
@@ -197,7 +197,7 @@ struct ChatView: View {
     @State private var showConnectTools = false
     @State private var showBenchmark = false
 
-    private let contentMaxWidth: CGFloat = 800
+    private let contentMaxWidth: CGFloat = RapidTheme.Layout.contentMaxWidth
     private let bottomSentinelID = "rapid-bottom-sentinel"
 
     private var messages: [ChatMessage] { viewModel.messages }
@@ -208,7 +208,7 @@ struct ChatView: View {
             Divider()
             composeBar
         }
-        .background(RapidTheme.canvas)
+        .background(RapidTheme.surfaceCanvas)
         // Drop a stale error banner once the server is provably ready.
         .onChange(of: server.state) { _, newState in
             if case .ready = newState { viewModel.clearStaleErrorBanner() }
@@ -234,14 +234,25 @@ struct ChatView: View {
 
     // MARK: - Transcript
 
+    @ViewBuilder
     private var transcript: some View {
-        ScrollViewReader { proxy in
-            ScrollView {
-                transcriptRows
+        if messages.isEmpty {
+            // v1.0: the empty state is centred in the transcript region
+            // instead of living inside the scroll flow behind a 96pt top
+            // pad. In the scroll flow it sat high and left the bottom
+            // two-thirds of the window blank, which is what made an
+            // otherwise-fine screen read as an unfinished poster.
+            emptyState
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else {
+            ScrollViewReader { proxy in
+                ScrollView {
+                    transcriptRows
+                }
+                .onChange(of: messages.last?.content) { _, _ in scrollToBottom(proxy) }
+                .onChange(of: messages.last?.reasoning) { _, _ in scrollToBottom(proxy) }
+                .onChange(of: messages.count) { _, _ in scrollToBottom(proxy) }
             }
-            .onChange(of: messages.last?.content) { _, _ in scrollToBottom(proxy) }
-            .onChange(of: messages.last?.reasoning) { _, _ in scrollToBottom(proxy) }
-            .onChange(of: messages.count) { _, _ in scrollToBottom(proxy) }
         }
     }
 
@@ -250,27 +261,23 @@ struct ChatView: View {
     /// ``ScrollView`` content to zero height).
     @ViewBuilder
     var transcriptRows: some View {
-        LazyVStack(alignment: .leading, spacing: 14) {
-            if messages.isEmpty {
-                emptyState
-            } else {
-                ForEach(messages) { message in
-                    MessageRow(
-                        message: message,
-                        isStreaming: viewModel.isStreaming,
-                        onRegenerate: regenerate
-                    )
-                    .frame(maxWidth: contentMaxWidth, alignment: .leading)
-                    .frame(maxWidth: .infinity, alignment: .center)
-                    .id(message.id)
-                }
+        LazyVStack(alignment: .leading, spacing: RapidTheme.Space.lg) {
+            ForEach(messages) { message in
+                MessageRow(
+                    message: message,
+                    isStreaming: viewModel.isStreaming,
+                    onRegenerate: regenerate
+                )
+                .frame(maxWidth: contentMaxWidth, alignment: .leading)
+                .frame(maxWidth: .infinity, alignment: .center)
+                .id(message.id)
             }
             Color.clear
                 .frame(height: 1)
                 .id(bottomSentinelID)
         }
-        .padding(.horizontal, 24)
-        .padding(.vertical, 24)
+        .padding(.horizontal, RapidTheme.Space.xl)
+        .padding(.vertical, RapidTheme.Space.xl)
     }
 
     private func scrollToBottom(_ proxy: ScrollViewProxy) {
@@ -280,65 +287,132 @@ struct ChatView: View {
     }
 
     private var emptyState: some View {
-        VStack(spacing: 10) {
-            ZStack {
-                Circle()
-                    .fill(RapidTheme.brandAmberTint)
-                    .frame(width: 60, height: 60)
-                Image(systemName: "bolt.fill")
-                    .font(.system(size: 27, weight: .semibold))
-                    .foregroundStyle(RapidTheme.brandAmber)
-            }
-            .padding(.bottom, 2)
-            Text("Ask anything")
-                .font(.title2.weight(.semibold))
-            Text("Chatting with \(alias.isEmpty ? "your local model" : alias)")
-                .font(.callout)
-                .foregroundStyle(.secondary)
-            if let pending = autoStartPendingDownload {
-                let size = pending.sizeText.map { " (\($0))" } ?? ""
-                Text("First message will download \(pending.alias)\(size).")
-                    .font(.footnote)
-                    .foregroundStyle(.tertiary)
-            }
-            if serverReady {
-                HStack(spacing: 10) {
-                    Button {
-                        showConnectTools = true
-                    } label: {
-                        Label("Connect your tools", systemImage: "link")
-                            .font(.callout.weight(.medium))
-                    }
-                    Button {
-                        showBenchmark = true
-                    } label: {
-                        Label("Speed on this Mac", systemImage: "gauge.with.dots.needle.67percent")
-                            .font(.callout.weight(.medium))
-                    }
+        EmptyState(
+            title: "Ask anything",
+            message: emptyStateSubtitle,
+            hint: downloadHint,
+            markDiameter: 92,
+            mark: {
+                // The brand moment on the app's main surface. 68pt
+                // inside a 92pt disc — at the previous 28/44 the mascot
+                // read as a favicon rather than the product's mark.
+                //
+                // 68 is deliberately ≥ 64: ``CheetahLogo`` switches to
+                // the 440×390 master above that threshold, so the
+                // artwork is downsampled from a large source (crisp at
+                // @2x) instead of being upscaled from the 56×50 crop.
+                // ``scaledToFit`` inside a square frame preserves the
+                // asset's own aspect ratio.
+                CheetahLogo(size: 68)
+            },
+            actions: {
+                // #CTA-bug: both actions used to be wrapped in
+                // `if serverReady`, so on a cold first launch — exactly
+                // when a new user most needs the second call-to-action —
+                // the row was absent entirely, and it then popped into
+                // existence mid-session and shifted the layout.
+                //
+                // Now both always render whenever the transcript is
+                // empty, in every lifecycle state. Availability is
+                // expressed by ENABLEMENT, not by presence:
+                //
+                //   * Connect your tools is always actionable. The sheet
+                //     itself explains when the endpoint isn't ready yet
+                //     and refuses to hand out incomplete values.
+                //   * Speed needs a live model to measure, so it
+                //     disables with a tooltip that says why.
+                Button {
+                    showConnectTools = true
+                } label: {
+                    Label("Connect your tools", systemImage: "link")
                 }
-                .buttonStyle(.bordered)
-                .tint(RapidTheme.brandAmber)
-                .padding(.top, 6)
+                .help("Point an editor or agent at your local server")
+
+                Button {
+                    showBenchmark = true
+                } label: {
+                    Label("Speed on this Mac", systemImage: "gauge.with.dots.needle.67percent")
+                }
+                // Enablement is derived from live server state, so the
+                // button flips to enabled on its own the moment the
+                // model reaches .ready — no user action, no re-render
+                // trigger needed beyond the @Observable read.
+                .disabled(!benchmarkAvailable)
+                .help(
+                    benchmarkAvailable
+                        ? "Measure this model's tokens per second on your Mac"
+                        : "Start a model to run a speed test."
+                )
             }
+        )
+    }
+
+    /// The line under "Ask anything".
+    ///
+    /// Three distinct states, none of which may render an internal
+    /// placeholder (`Loading`, `Starting`, …) where a model name goes:
+    ///
+    ///   * nothing chosen yet  → an instruction, not a claim
+    ///   * coming up           → a status sentence
+    ///   * resolved            → the real alias
+    private var emptyStateSubtitle: String {
+        if case .starting = server.state {
+            return "Preparing your local model…"
         }
-        .frame(maxWidth: .infinity)
-        .padding(.top, 96)
+        if ModelDisplayName.isUnresolved(alias) {
+            // "Choose", not "Select" — one verb for this flow, matching
+            // the composer control and the picker's own tooltip.
+            return "Choose a model to start"
+        }
+        return "Chatting with \(alias)"
+    }
+
+    /// The download hint under the subtitle. Names the model only when
+    /// it is a real alias; otherwise stays generic rather than
+    /// interpolating a placeholder into the sentence.
+    private var downloadHint: String? {
+        guard let pending = autoStartPendingDownload else { return nil }
+        guard !ModelDisplayName.isUnresolved(pending.alias) else {
+            return "Your first message will download the selected model."
+        }
+        let size = pending.sizeText.map { " (\($0))" } ?? ""
+        return "Your first message will download \(pending.alias)\(size)."
+    }
+
+    /// Speed can only measure a model that is actually up. Keyed on the
+    /// live server state rather than the ``serverReady`` flag so the
+    /// button re-enables the moment the model finishes starting.
+    private var benchmarkAvailable: Bool {
+        guard server.binaryPath != nil else { return false }
+        // Routed through the shared predicate rather than a bare
+        // ``isEmpty`` so every readiness decision in the app agrees on
+        // what counts as "no model" — an internal placeholder is not a
+        // model you can benchmark.
+        if case .ready = server.state {
+            return !ModelDisplayName.isUnresolved(alias)
+        }
+        return false
     }
 
     // MARK: - Compose bar
 
     private var composeBar: some View {
-        VStack(spacing: 8) {
+        VStack(spacing: RapidTheme.Space.sm) {
             if let error = viewModel.lastError {
-                errorBanner(error)
+                InlineNotice(message: error, tone: .error)
+                    .frame(maxWidth: contentMaxWidth)
+                    .frame(maxWidth: .infinity)
             }
-            // Ollama-style single compose box: the message field on top,
-            // a control row (inline model picker + send) underneath, all
-            // inside one rounded pill. The model picker lives here now —
-            // there is no top control bar — and the model comes up on the
-            // first send (implicit lifecycle via ChatViewModel.send →
-            // ServerManager.ensureServing).
-            VStack(spacing: 10) {
+            // One input, not a pill containing a second pill.
+            //
+            // v1.0 proportions: radius 22 → 12 (the single input
+            // radius), padding 14/12 → 10/8, inner spacing 10 → 6, and
+            // the field/controls stack now sits on ``surfaceRaised``
+            // with a hairline instead of a heavy grey ``composePill``
+            // fill. The old treatment made a two-line composer ~110pt
+            // tall and read as a card that happened to contain a text
+            // area; this reads as a text field with controls in it.
+            VStack(spacing: RapidTheme.Space.sm - 2) {
                 ComposeField(
                     text: $draft,
                     focusToken: composeFocusToken,
@@ -351,27 +425,28 @@ struct ChatView: View {
                 )
                 composerControls
             }
-            .padding(.horizontal, 14)
-            .padding(.vertical, 12)
+            .padding(.horizontal, RapidTheme.Space.md - 2)
+            .padding(.vertical, RapidTheme.Space.sm)
             .background(
-                RoundedRectangle(cornerRadius: 22, style: .continuous)
-                    .fill(RapidTheme.composePill)
+                RoundedRectangle(cornerRadius: RapidTheme.Radius.input, style: .continuous)
+                    .fill(RapidTheme.surfaceRaised)
             )
             .overlay(
-                RoundedRectangle(cornerRadius: 22, style: .continuous)
-                    .stroke(RapidTheme.composePillStroke, lineWidth: 1)
+                RoundedRectangle(cornerRadius: RapidTheme.Radius.input, style: .continuous)
+                    .strokeBorder(RapidTheme.hairlineStrong, lineWidth: 1)
             )
             .frame(maxWidth: contentMaxWidth)
             .frame(maxWidth: .infinity)
         }
-        .padding(.horizontal, 24)
-        .padding(.vertical, 14)
+        .padding(.horizontal, RapidTheme.Space.xl)
+        .padding(.top, RapidTheme.Space.md)
+        .padding(.bottom, RapidTheme.Space.lg)
     }
 
     /// Bottom row of the compose box: the inline model picker on the
     /// right, then the send/stop button — Ollama's `model ▾  ⬆` cluster.
     private var composerControls: some View {
-        HStack(spacing: 8) {
+        HStack(spacing: RapidTheme.Space.sm) {
             Spacer(minLength: 0)
             ModelPickerBar(
                 server: server,
@@ -384,37 +459,48 @@ struct ChatView: View {
         }
     }
 
-    private func errorBanner(_ error: String) -> some View {
-        Text(error)
-            .font(.footnote)
-            .foregroundStyle(RapidTheme.amberDeep)
-            .frame(maxWidth: contentMaxWidth, alignment: .leading)
-            .frame(maxWidth: .infinity)
-    }
-
+    /// Send / stop. v1.0 gives the send action the amber hierarchy:
+    /// when there is something to send it is the brightest thing in the
+    /// composer, and when there isn't it recedes to a neutral outline
+    /// rather than a filled-but-dead grey disc. Stop stays neutral-solid
+    /// — it is a correction, not the primary path.
     @ViewBuilder
     private var sendOrStopButton: some View {
         if viewModel.isStreaming {
             Button(action: { viewModel.stop() }) {
                 Image(systemName: "stop.fill")
-                    .font(.system(size: 15, weight: .bold))
+                    .font(.system(size: 12, weight: .bold))
                     .foregroundStyle(RapidTheme.sendButtonIcon)
-                    .frame(width: 34, height: 34)
+                    .frame(width: 28, height: 28)
                     .background(Circle().fill(RapidTheme.sendButton))
             }
             .buttonStyle(.plain)
             .help("Stop generating")
+            .accessibilityLabel("Stop generating")
         } else {
             Button(action: send) {
                 Image(systemName: "arrow.up")
-                    .font(.system(size: 15, weight: .bold))
-                    .foregroundStyle(RapidTheme.sendButtonIcon)
-                    .frame(width: 34, height: 34)
-                    .background(Circle().fill(sendEnabled ? RapidTheme.sendButton : RapidTheme.sendButtonDisabled))
+                    .font(.system(size: 12, weight: .bold))
+                    .foregroundStyle(
+                        sendEnabled ? RapidTheme.onBrandPrimary : Color.secondary
+                    )
+                    .frame(width: 28, height: 28)
+                    .background(
+                        Circle().fill(
+                            sendEnabled ? RapidTheme.brandPrimary : Color.clear
+                        )
+                    )
+                    .overlay(
+                        Circle().strokeBorder(
+                            sendEnabled ? .clear : RapidTheme.hairlineStrong,
+                            lineWidth: 1
+                        )
+                    )
             }
             .buttonStyle(.plain)
             .disabled(!sendEnabled)
             .help("Send")
+            .accessibilityLabel("Send message")
         }
     }
 
@@ -471,7 +557,7 @@ private struct MessageRow: View {
                 .padding(.horizontal, 14)
                 .padding(.vertical, 10)
                 .background(
-                    RoundedRectangle(cornerRadius: RapidTheme.userBubbleRadius, style: .continuous)
+                    RoundedRectangle(cornerRadius: RapidTheme.Radius.bubble, style: .continuous)
                         .fill(RapidTheme.userBubble)
                 )
         }
@@ -545,9 +631,14 @@ private struct MessageRow: View {
 
     private var failureCaption: some View {
         HStack(spacing: 10) {
+            // A failed turn is an ERROR, so it takes the error token.
+            // It previously rendered in deep amber, which under this
+            // palette means brand / active / working — the same hue the
+            // product uses for a model that is starting up. Red is the
+            // only colour that means "this went wrong".
             Text(message.errorMessage ?? "The model couldn't complete that request.")
                 .font(.footnote)
-                .foregroundStyle(RapidTheme.amberDeep)
+                .foregroundStyle(RapidTheme.statusError)
             Button("Regenerate", action: onRegenerate)
                 .buttonStyle(.link)
                 .font(.footnote)
@@ -933,12 +1024,15 @@ extension MarkdownUI.Theme {
             // move the streaming Text + MathView base in lockstep
             // (three literals, one size; see the streaming branch).
             FontSize(15)
-            // New York, the system serif — assistant prose only, the
-            // Claude Desktop split: serif for the model's voice, sans
-            // for every piece of chrome around it. Native enough to
-            // keep Dynamic Type + optical sizing for free, and a
-            // two-line revert if it doesn't land.
-            FontFamily(.system(.serif))
+            // v1.0.1: system sans, not New York.
+            //
+            // The serif was an editorial device — "serif for the
+            // model's voice, sans for the chrome" — and it read as a
+            // different application embedded inside this one. A
+            // desktop tool should feel like one product; the
+            // separation between model content and app chrome is
+            // carried by the 720pt measure, the paragraph rhythm
+            // below, and weight — not by a typeface switch.
             ForegroundColor(.primary)
         }
         .code {
@@ -947,21 +1041,23 @@ extension MarkdownUI.Theme {
             BackgroundColor(.secondary.opacity(0.15))
         }
         .strong { FontWeight(.semibold) }
-        .link { ForegroundColor(RapidTheme.brand) }
+        // Steel blue, spelled semantically: a markdown link is exactly
+        // the sanctioned use of the secondary brand colour. Same value
+        // as the legacy ``brand`` alias it replaces.
+        .link { ForegroundColor(RapidTheme.linkLabel) }
+        // v1.0.1: restrained heading scale. With the serif gone the
+        // old 1.45/1.25/1.1 ramp read as oversized — a serif carries
+        // a large size gracefully, a sans at 21.75pt inside a 15pt
+        // answer just looks like a heading pasted in from a document.
+        // 1.27/1.13/1.0-with-weight keeps three distinguishable
+        // levels while staying inside the answer's own rhythm.
         .heading1 { config in
-            // v0.5.9: shrink heading scale + tighten top breathing
-            // room. Earlier shape rendered H1 at 1.6 × 13 pt =
-            // 20.8 pt which is one heading-level larger than
-            // ChatGPT Desktop ships. Same logic for H2/H3 below.
-            // Halving the top padding closes the airy gap above
-            // every H-tag that made consecutive headed sections
-            // feel chapter-thick.
             config.label
                 .relativePadding(.top, length: .em(0.35))
                 .relativePadding(.bottom, length: .em(0.1))
                 .markdownTextStyle {
-                    FontWeight(.bold)
-                    FontSize(.em(1.45))
+                    FontWeight(.semibold)
+                    FontSize(.em(1.27))
                 }
         }
         .heading2 { config in
@@ -969,8 +1065,8 @@ extension MarkdownUI.Theme {
                 .relativePadding(.top, length: .em(0.3))
                 .relativePadding(.bottom, length: .em(0.1))
                 .markdownTextStyle {
-                    FontWeight(.bold)
-                    FontSize(.em(1.25))
+                    FontWeight(.semibold)
+                    FontSize(.em(1.13))
                 }
         }
         .heading3 { config in
@@ -979,7 +1075,7 @@ extension MarkdownUI.Theme {
                 .relativePadding(.bottom, length: .em(0.1))
                 .markdownTextStyle {
                     FontWeight(.semibold)
-                    FontSize(.em(1.1))
+                    FontSize(.em(1.0))
                 }
         }
         .paragraph { config in

--- a/apps/rapid-mac/Sources/Rapid/UI/CheetahLogo.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/CheetahLogo.swift
@@ -79,12 +79,34 @@ struct CheetahLogo: View {
             return image
         }
 
-        let anchor = Bundle(for: BundleFinder.self).bundleURL.deletingLastPathComponent()
-        let bundleURL = anchor.appendingPathComponent("Rapid_Rapid.bundle")
-        if let bundle = Bundle(url: bundleURL),
-           let url = bundle.url(forResource: name, withExtension: "png"),
-           let image = NSImage(contentsOf: url) {
-            return image
+        // Dev / test probe. Two anchors, because ``bundleURL`` means
+        // different things depending on how the binary is packaged:
+        //
+        //   * Inside a real .app it is the .app itself, so the resource
+        //     bundle is a SIBLING — hence `deletingLastPathComponent`.
+        //   * For a bare SwiftPM executable (`swift build`,
+        //     `.build/debug/Rapid`) it is ALREADY the directory holding
+        //     the executable, and SwiftPM drops `Rapid_Rapid.bundle`
+        //     right there — so stripping a component overshoots to
+        //     `.build/` and misses.
+        //
+        // Only the first anchor existed, which is why every `swift
+        // build` run silently fell through to the `hare.fill` fallback
+        // and dev screenshots showed a hare where the mascot should be.
+        // Probing both is additive: the production path is unchanged
+        // and still wins first.
+        let executableAnchor = Bundle(for: BundleFinder.self).bundleURL
+        let anchors = [
+            executableAnchor.deletingLastPathComponent(),
+            executableAnchor,
+        ]
+        for anchor in anchors {
+            let bundleURL = anchor.appendingPathComponent("Rapid_Rapid.bundle")
+            if let bundle = Bundle(url: bundleURL),
+               let url = bundle.url(forResource: name, withExtension: "png"),
+               let image = NSImage(contentsOf: url) {
+                return image
+            }
         }
 
         return nil

--- a/apps/rapid-mac/Sources/Rapid/UI/Components/EmptyState.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/Components/EmptyState.swift
@@ -1,0 +1,143 @@
+import SwiftUI
+
+/// The centred "nothing here yet" block: brand mark, title, one line of
+/// supporting copy, an optional hint, and optional secondary actions.
+///
+/// Sizing is deliberately restrained. The pre-v1.0 chat empty state
+/// used a 60pt disc with a 27pt glyph pinned 96pt from the top of the
+/// transcript, which pushed the whole composition off-centre and made
+/// a 640pt-tall window feel like a mostly-empty poster. Here the disc
+/// is 44pt, the block is vertically centred by its container, and the
+/// content column is width-capped so it stays a considered object
+/// rather than stretching with the window.
+///
+/// The mark is generic over its content rather than type-erased through
+/// ``AnyView``: the empty state's brand moment is a real bundled image
+/// (``CheetahLogo``) on the chat surface but a plain SF Symbol
+/// elsewhere, and both should stay statically typed so SwiftUI can
+/// diff them properly.
+///
+/// Actions are ``rapidSecondaryCompact`` by contract: an empty state
+/// offers side-doors, and none of them should out-shout the real
+/// primary action on the surface (in chat, the composer).
+struct EmptyState<Mark: View, Actions: View>: View {
+    let title: String
+    var message: String? = nil
+    /// A quieter third line — e.g. "First message will download X".
+    var hint: String? = nil
+    /// Diameter of the tinted backing disc. 44 suits a small SF Symbol;
+    /// the chat surface passes ~92 so the mascot reads as a real brand
+    /// moment rather than a favicon.
+    var markDiameter: CGFloat = 44
+    @ViewBuilder var mark: Mark
+    @ViewBuilder var actions: Actions
+
+    var body: some View {
+        VStack(spacing: RapidTheme.Space.md) {
+            ZStack {
+                Circle()
+                    .fill(RapidTheme.brandPrimaryTint)
+                    .frame(width: markDiameter, height: markDiameter)
+                mark
+            }
+            // The mark is decoration; the title carries the meaning.
+            .accessibilityHidden(true)
+            .padding(.bottom, RapidTheme.Space.xs)
+
+            VStack(spacing: RapidTheme.Space.xs) {
+                Text(title)
+                    .font(RapidFont.pageTitle)
+                    .foregroundStyle(.primary)
+                if let message {
+                    Text(message)
+                        .font(RapidFont.secondary)
+                        .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.center)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                if let hint {
+                    Text(hint)
+                        .font(RapidFont.caption)
+                        .foregroundStyle(.tertiary)
+                        .multilineTextAlignment(.center)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+
+            HStack(spacing: RapidTheme.Space.sm) {
+                actions
+            }
+            .buttonStyle(.rapidSecondaryCompact)
+            .padding(.top, RapidTheme.Space.xs)
+        }
+        .frame(maxWidth: 380)
+        .padding(.horizontal, RapidTheme.Space.xl)
+    }
+}
+
+// MARK: - Convenience initialisers
+
+extension EmptyState where Mark == EmptyStateSymbolMark {
+    /// SF Symbol mark — for surfaces that aren't the brand moment.
+    init(
+        symbol: String,
+        title: String,
+        message: String? = nil,
+        hint: String? = nil,
+        @ViewBuilder actions: () -> Actions
+    ) {
+        self.init(
+            title: title,
+            message: message,
+            hint: hint,
+            markDiameter: 44,
+            mark: { EmptyStateSymbolMark(symbol: symbol) },
+            actions: actions
+        )
+    }
+}
+
+extension EmptyState where Actions == EmptyView {
+    /// No side-door actions.
+    init(
+        title: String,
+        message: String? = nil,
+        hint: String? = nil,
+        markDiameter: CGFloat = 44,
+        @ViewBuilder mark: () -> Mark
+    ) {
+        self.init(
+            title: title,
+            message: message,
+            hint: hint,
+            markDiameter: markDiameter,
+            mark: mark,
+            actions: { EmptyView() }
+        )
+    }
+}
+
+extension EmptyState where Mark == EmptyStateSymbolMark, Actions == EmptyView {
+    /// SF Symbol mark, no actions.
+    init(symbol: String, title: String, message: String? = nil, hint: String? = nil) {
+        self.init(
+            title: title,
+            message: message,
+            hint: hint,
+            markDiameter: 44,
+            mark: { EmptyStateSymbolMark(symbol: symbol) },
+            actions: { EmptyView() }
+        )
+    }
+}
+
+/// The default SF Symbol mark, sized to sit inside the 44pt disc.
+struct EmptyStateSymbolMark: View {
+    let symbol: String
+
+    var body: some View {
+        Image(systemName: symbol)
+            .font(.system(size: 19, weight: .semibold))
+            .foregroundStyle(RapidTheme.brandPrimaryDeep)
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/UI/Components/InlineNotice.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/Components/InlineNotice.swift
@@ -1,0 +1,90 @@
+import SwiftUI
+
+/// A one-line contextual message with an optional trailing action.
+///
+/// Replaces the bare `Text(error).foregroundStyle(amberDeep)` banner
+/// pattern, which gave a failure no container, no icon, and no visual
+/// weight distinct from ordinary caption copy — so a real error read
+/// like a footnote.
+///
+/// Three tones, mapped to the status tokens so the meaning of a colour
+/// is the same here as in a status pill or a metric chip. Note that
+/// ``warning`` is amber and shares the brand hue: that is intentional,
+/// since amber already carries "something is in flight / needs
+/// attention" across the product. ``error`` is the only red.
+struct InlineNotice: View {
+    enum Tone {
+        case info
+        case warning
+        case error
+
+        /// v1.0.2: ``info`` is AMBER, not steel blue.
+        ///
+        /// An inline readiness notice is a "here's what's happening"
+        /// signal, and amber is the product's colour for that. Steel
+        /// blue survives only for genuine links
+        /// (``RapidTheme.linkLabel``), which is what "rare supporting
+        /// colour" has to mean if it is to mean anything.
+        var tint: Color {
+            switch self {
+            case .info:    return RapidTheme.brandPrimaryDeep
+            case .warning: return RapidTheme.brandPrimaryDeep
+            case .error:   return RapidTheme.statusError
+            }
+        }
+
+        /// Subtle tints only — never a saturated panel. These are
+        /// notices inside a page, not cards of their own.
+        var background: Color {
+            switch self {
+            case .info:    return RapidTheme.brandPrimaryTint
+            case .warning: return RapidTheme.brandPrimaryTint
+            case .error:   return RapidTheme.statusErrorTint
+            }
+        }
+
+        var symbol: String {
+            switch self {
+            case .info:    return "info.circle.fill"
+            case .warning: return "exclamationmark.triangle.fill"
+            case .error:   return "exclamationmark.octagon.fill"
+            }
+        }
+    }
+
+    let message: String
+    var tone: Tone = .warning
+    var actionTitle: String? = nil
+    var action: (() -> Void)? = nil
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline, spacing: RapidTheme.Space.sm) {
+            Image(systemName: tone.symbol)
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(tone.tint)
+                .accessibilityHidden(true)
+
+            Text(message)
+                .font(RapidFont.secondary)
+                .foregroundStyle(.primary)
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+            if let actionTitle, let action {
+                Button(actionTitle, action: action)
+                    .buttonStyle(RapidTertiaryButtonStyle(
+                        link: tone == .info,
+                        height: RapidTheme.ControlHeight.mini
+                    ))
+                    .fixedSize()
+            }
+        }
+        .padding(.horizontal, RapidTheme.Space.md)
+        .padding(.vertical, RapidTheme.Space.sm)
+        .background(
+            RoundedRectangle(cornerRadius: RapidTheme.Radius.button, style: .continuous)
+                .fill(tone.background)
+        )
+        .accessibilityElement(children: .contain)
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/UI/Components/MetricChip.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/Components/MetricChip.swift
@@ -1,0 +1,62 @@
+import SwiftUI
+
+/// A small live-telemetry read-out: status dot + monospaced value.
+///
+/// The three system pills (CPU / GPU / memory), the tok-s pill, and
+/// the desktop-version pill each hand-rolled this same shape with
+/// their own dot size, font literal, and `.green` / `.yellow` / `.red`
+/// picks. ``MetricChip`` is the one implementation, and — importantly —
+/// it routes colour through ``RapidTheme`` status tokens so a "warning"
+/// dot is the same amber the rest of the product uses for "working".
+///
+/// Monospaced is correct here (it's one of the four sanctioned uses:
+/// code, endpoints, keys, metrics) and specifically stops a
+/// live-updating number from re-laying-out its own row every tick.
+struct MetricChip: View {
+    /// Deliberately NOT spelled `none` — a case with that name shadows
+    /// `Optional.none` at every `.none` call site and produces
+    /// genuinely confusing inference errors.
+    enum Level {
+        /// No data yet. Reads as pending, not broken.
+        case noData
+        /// Normal / healthy.
+        case ok
+        /// Elevated — amber, matching the product's "working" state.
+        case warning
+        /// Bad — red.
+        case critical
+
+        var tint: Color {
+            switch self {
+            case .noData:   return RapidTheme.statusIdle.opacity(0.6)
+            case .ok:       return RapidTheme.statusReady
+            case .warning:  return RapidTheme.statusWorking
+            case .critical: return RapidTheme.statusError
+            }
+        }
+    }
+
+    let label: String
+    var level: Level = .noData
+    /// Draw the leading status dot. Off for chips that are purely
+    /// informational (a version string), on for live measurements.
+    var showsDot: Bool = true
+
+    var body: some View {
+        HStack(spacing: RapidTheme.Space.xs + 1) {
+            if showsDot {
+                Circle()
+                    .fill(level.tint)
+                    .frame(width: 6, height: 6)
+            }
+            Text(label)
+                .font(RapidFont.metric)
+                .foregroundStyle(
+                    level == .noData
+                        ? AnyShapeStyle(HierarchicalShapeStyle.tertiary)
+                        : AnyShapeStyle(HierarchicalShapeStyle.secondary)
+                )
+                .lineLimit(1)
+        }
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/UI/Components/QuietIconButton.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/Components/QuietIconButton.swift
@@ -1,0 +1,78 @@
+import SwiftUI
+
+/// A borderless glyph button with a real hit target and a hover wash.
+///
+/// Replaces two patterns that were spread across the surface:
+///
+///   * a bare `Image` inside `.buttonStyle(.plain)`, which gave the
+///     user a ~12pt target and no hover feedback at all; and
+///   * the permanently-filled grey `xmark.circle.fill` close control,
+///     which sat at full weight in the corner of every sheet whether
+///     or not the pointer was anywhere near it.
+///
+/// Colour follows the utility policy: neutral at rest, steel blue on
+/// hover, and an explicit tint only when the control is reporting
+/// state (a copy that just succeeded goes ready-green).
+struct QuietIconButton: View {
+    let symbol: String
+    /// Spoken label. Also the tooltip unless ``help`` overrides it.
+    let label: String
+    var help: String? = nil
+    /// Overrides the resting colour — for transient success states.
+    var tint: Color? = nil
+    var size: CGFloat = RapidTheme.ControlHeight.small
+    var action: () -> Void
+
+    @Environment(\.isEnabled) private var isEnabled
+    @State private var hovering = false
+
+    private var foreground: Color {
+        if let tint { return tint }
+        return hovering && isEnabled
+            ? RapidTheme.utilityActionHover
+            : RapidTheme.utilityActionLabel
+    }
+
+    /// Disabled glyphs stay legible at ~55%. A copy control that is
+    /// unavailable still has to be FINDABLE — its tooltip is what
+    /// explains how to make it available, so fading it to near-nothing
+    /// hides the explanation too.
+    private var resolvedOpacity: Double { isEnabled ? 1.0 : 0.55 }
+
+    var body: some View {
+        Button(action: action) {
+            Image(systemName: symbol)
+                .font(.system(size: 11, weight: .medium))
+                .foregroundStyle(foreground)
+                .frame(width: size, height: size)
+                .background(
+                    RoundedRectangle(cornerRadius: RapidTheme.Radius.button, style: .continuous)
+                        .fill(hovering && isEnabled ? RapidTheme.hoverFill : .clear)
+                )
+                .contentShape(
+                    RoundedRectangle(cornerRadius: RapidTheme.Radius.button, style: .continuous)
+                )
+                .opacity(resolvedOpacity)
+        }
+        .buttonStyle(.plain)
+        .onHover { hovering = $0 }
+        .rapidAnimation(RapidMotion.quick, value: hovering)
+        .help(help ?? label)
+        .accessibilityLabel(label)
+    }
+}
+
+/// The standard sheet dismiss control: a quiet ✕ that only gains weight
+/// under the pointer.
+struct SheetCloseButton: View {
+    var action: () -> Void
+
+    var body: some View {
+        QuietIconButton(
+            symbol: "xmark",
+            label: "Close",
+            help: "Close — Esc",
+            action: action
+        )
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/UI/Components/RapidButtonStyles.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/Components/RapidButtonStyles.swift
@@ -1,0 +1,279 @@
+import SwiftUI
+
+/// The app's four button tiers.
+///
+/// Before v1.0 every call site hand-rolled its own button: some used
+/// ``.borderedProminent`` (which paints the system accent, or — after
+/// the scene-root `.tint` — amber with unreadable white text), some
+/// built a `Capsule` with a hand-picked fill, some used `.bordered`
+/// with a `.tint` override. The result was five different heights and
+/// three different meanings for "this is the important one".
+///
+/// The tiers, and the single question that picks between them:
+///
+///   * ``rapidPrimary`` — is this THE action on this surface? Amber
+///     fill, graphite label. At most one per view.
+///   * ``rapidSecondary`` — a real action, but not the main one.
+///     Outlined, neutral label, optional steel-blue accent.
+///   * ``rapidTertiary`` — borderless text/icon. Present, not
+///     competing.
+///   * ``rapidDestructive`` — Stop, Delete, and nothing else.
+///
+/// All four share height, corner radius, icon size, and the full
+/// hover / pressed / disabled / focus set, so tiers can sit next to
+/// each other on one baseline without any per-site padding fixes.
+///
+/// Heights come from ``RapidTheme.ControlHeight``: primary is 36pt,
+/// everything else defaults to 32pt with a 28pt compact variant. That
+/// keeps every control at or above the 28pt hit-target floor.
+
+// MARK: - Primary
+
+/// Amber fill, graphite label. The one high-emphasis action.
+///
+/// The label colour is the load-bearing detail: white on #EFA23A is
+/// ~2.0:1 and was the single most common contrast failure in the
+/// pre-v1.0 surface. ``RapidTheme.onBrandPrimary`` is ~9:1.
+struct RapidPrimaryButtonStyle: ButtonStyle {
+    // Explicit init on every style in this file: a `private` stored
+    // property (the `@Environment` below) makes the SYNTHESISED
+    // memberwise initialiser private too, so call sites in other files
+    // could not construct these with arguments.
+    @Environment(\.isEnabled) private var isEnabled
+    /// Fill the available width — for full-width CTAs in cards/sheets.
+    var expands: Bool
+    var height: CGFloat
+
+    init(expands: Bool = false, height: CGFloat = RapidTheme.ControlHeight.large) {
+        self.expands = expands
+        self.height = height
+    }
+
+    func makeBody(configuration: Configuration) -> some View {
+        RapidButtonSurface(
+            configuration: configuration,
+            isEnabled: isEnabled,
+            expands: expands,
+            height: height,
+            foreground: RapidTheme.primaryActionLabel,
+            fill: RapidTheme.primaryActionFill,
+            stroke: nil
+        )
+    }
+}
+
+// MARK: - Secondary
+
+/// Outlined, neutral label. A real action that is not the primary one.
+///
+/// ``accented`` swaps the label to steel blue for utility/informational
+/// actions (Copy config, Test, Open docs) — the secondary brand colour
+/// doing secondary-brand work instead of filling primary buttons.
+struct RapidSecondaryButtonStyle: ButtonStyle {
+    @Environment(\.isEnabled) private var isEnabled
+    /// Treat this as a utility control: neutral at rest, steel blue
+    /// under the pointer. This is the default shape for Copy / Reveal /
+    /// per-row actions.
+    var utility: Bool
+    var expands: Bool
+    var height: CGFloat
+    /// Explicit label colour, overriding every default. Needed where a
+    /// button signals transient state through colour (Copy → Copied
+    /// flips to the ready green) — an outer `.foregroundStyle` can't
+    /// reach inside a ButtonStyle.
+    var foreground: Color?
+
+    init(
+        utility: Bool = false,
+        expands: Bool = false,
+        height: CGFloat = RapidTheme.ControlHeight.medium,
+        foreground: Color? = nil
+    ) {
+        self.utility = utility
+        self.expands = expands
+        self.height = height
+        self.foreground = foreground
+    }
+
+    func makeBody(configuration: Configuration) -> some View {
+        RapidButtonSurface(
+            configuration: configuration,
+            isEnabled: isEnabled,
+            expands: expands,
+            height: height,
+            foreground: foreground ?? RapidTheme.secondaryActionLabel,
+            hoverForeground: (foreground == nil && utility)
+                ? RapidTheme.utilityActionHover
+                : nil,
+            fill: RapidTheme.surfaceRaised,
+            stroke: RapidTheme.hairlineStrong
+        )
+    }
+}
+
+// MARK: - Tertiary
+
+/// Borderless text or icon button. No fill until hovered.
+struct RapidTertiaryButtonStyle: ButtonStyle {
+    @Environment(\.isEnabled) private var isEnabled
+    /// A genuine text link. This is one of the few sanctioned uses of
+    /// steel blue at rest.
+    var link: Bool
+    var height: CGFloat
+
+    init(link: Bool = false, height: CGFloat = RapidTheme.ControlHeight.small) {
+        self.link = link
+        self.height = height
+    }
+
+    func makeBody(configuration: Configuration) -> some View {
+        RapidButtonSurface(
+            configuration: configuration,
+            isEnabled: isEnabled,
+            expands: false,
+            height: height,
+            foreground: link ? RapidTheme.linkLabel : .primary,
+            hoverForeground: link ? nil : RapidTheme.utilityActionHover,
+            fill: .clear,
+            stroke: nil
+        )
+    }
+}
+
+// MARK: - Destructive
+
+/// Stop / Delete. Red fill, white label.
+struct RapidDestructiveButtonStyle: ButtonStyle {
+    @Environment(\.isEnabled) private var isEnabled
+    var expands: Bool
+    var height: CGFloat
+
+    init(expands: Bool = false, height: CGFloat = RapidTheme.ControlHeight.medium) {
+        self.expands = expands
+        self.height = height
+    }
+
+    func makeBody(configuration: Configuration) -> some View {
+        RapidButtonSurface(
+            configuration: configuration,
+            isEnabled: isEnabled,
+            expands: expands,
+            height: height,
+            foreground: RapidTheme.destructiveActionLabel,
+            fill: RapidTheme.destructiveActionFill,
+            stroke: nil
+        )
+    }
+}
+
+// MARK: - Shared surface
+
+/// The one place button chrome is drawn. Every tier routes through
+/// here, which is what keeps their metrics and interaction states
+/// identical by construction rather than by convention.
+private struct RapidButtonSurface: View {
+    let configuration: ButtonStyleConfiguration
+    let isEnabled: Bool
+    let expands: Bool
+    let height: CGFloat
+    let foreground: Color
+    /// Label colour under the pointer. ``nil`` keeps ``foreground``.
+    /// This is how utility controls earn steel blue on hover without
+    /// wearing it at rest.
+    var hoverForeground: Color? = nil
+    let fill: Color
+    let stroke: Color?
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var hovering = false
+
+    private var resolvedForeground: Color {
+        guard isEnabled, hovering, let hoverForeground else { return foreground }
+        return hoverForeground
+    }
+
+    var body: some View {
+        configuration.label
+            .font(RapidFont.bodyEmphasis)
+            .foregroundStyle(resolvedForeground)
+            // Icons inside a Label track the text size rather than the
+            // SF Symbol default, so a `Label("Copy", systemImage:)`
+            // can't render a glyph two sizes larger than its own word.
+            .imageScale(.small)
+            .lineLimit(1)
+            .padding(.horizontal, RapidTheme.Space.md)
+            .frame(maxWidth: expands ? .infinity : nil)
+            .frame(height: height)
+            .background(
+                RoundedRectangle(cornerRadius: RapidTheme.Radius.button, style: .continuous)
+                    .fill(fill)
+            )
+            .overlay {
+                // Hover and pressed are drawn as a wash ON TOP of the
+                // tier's own fill, so one pair of values reads correctly
+                // over amber, over white, and over nothing.
+                if isEnabled, configuration.isPressed || hovering {
+                    RoundedRectangle(cornerRadius: RapidTheme.Radius.button, style: .continuous)
+                        .fill(configuration.isPressed ? RapidTheme.pressedFill : RapidTheme.hoverFill)
+                }
+            }
+            .overlay {
+                if let stroke {
+                    RoundedRectangle(cornerRadius: RapidTheme.Radius.button, style: .continuous)
+                        .strokeBorder(stroke, lineWidth: 1)
+                }
+            }
+            .opacity(isEnabled ? 1 : RapidTheme.disabledOpacity)
+            .contentShape(RoundedRectangle(cornerRadius: RapidTheme.Radius.button, style: .continuous))
+            .onHover { hovering = $0 }
+            .rapidAnimation(RapidMotion.quick, value: hovering)
+            // A 1pt scale nudge on press. Suppressed under Reduce
+            // Motion, where the wash alone carries the feedback.
+            .scaleEffect(configuration.isPressed && !reduceMotion ? 0.98 : 1.0)
+            .rapidAnimation(RapidMotion.quick, value: configuration.isPressed)
+        // Focus ring: deliberately NOT overridden here. SwiftUI draws
+        // the system ring for a focused Button using the environment
+        // tint, and ``RapidApp`` tints every scene root with the brand
+        // amber — so keyboard focus already lands on the brand colour.
+        // Hand-rolling a ring would mean re-implementing focusability
+        // and would change Tab order, which is out of scope for a
+        // visual-only phase.
+    }
+}
+
+// MARK: - Ergonomics
+
+extension ButtonStyle where Self == RapidPrimaryButtonStyle {
+    /// The single high-emphasis action on a surface. Amber, graphite label.
+    static var rapidPrimary: RapidPrimaryButtonStyle { .init() }
+    /// Full-width primary — cards, sheets, onboarding footers.
+    static var rapidPrimaryWide: RapidPrimaryButtonStyle { .init(expands: true) }
+}
+
+extension ButtonStyle where Self == RapidSecondaryButtonStyle {
+    /// Outlined neutral action.
+    static var rapidSecondary: RapidSecondaryButtonStyle { .init() }
+    /// Outlined utility action — neutral at rest, steel blue on hover.
+    /// The default for Copy / per-row actions.
+    static var rapidSecondaryUtility: RapidSecondaryButtonStyle { .init(utility: true) }
+    /// 28pt outlined action for dense rows.
+    static var rapidSecondaryCompact: RapidSecondaryButtonStyle {
+        .init(height: RapidTheme.ControlHeight.small)
+    }
+    /// 28pt outlined utility action for dense rows.
+    static var rapidSecondaryCompactUtility: RapidSecondaryButtonStyle {
+        .init(utility: true, height: RapidTheme.ControlHeight.small)
+    }
+}
+
+extension ButtonStyle where Self == RapidTertiaryButtonStyle {
+    /// Borderless text / icon button. Neutral, steel blue on hover.
+    static var rapidTertiary: RapidTertiaryButtonStyle { .init() }
+    /// A genuine text link — steel blue at rest.
+    static var rapidLink: RapidTertiaryButtonStyle { .init(link: true) }
+}
+
+extension ButtonStyle where Self == RapidDestructiveButtonStyle {
+    /// Stop / Delete.
+    static var rapidDestructive: RapidDestructiveButtonStyle { .init() }
+}

--- a/apps/rapid-mac/Sources/Rapid/UI/Components/RapidTextField.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/Components/RapidTextField.swift
@@ -1,0 +1,59 @@
+import SwiftUI
+
+/// A text field wearing the product's own focus treatment.
+///
+/// `.textFieldStyle(.roundedBorder)` draws AppKit's bezel and, on
+/// focus, the system's bright blue ring — the single loudest blue in
+/// the app, on a surface whose brand colour is amber. This replaces it
+/// with `.plain` inside a container we draw:
+///
+///   * 1px hairline at rest,
+///   * 2px amber border on focus (focus is a primary-attention signal,
+///     so it gets the primary brand colour),
+///   * no glow, no bezel,
+///   * the standard input radius and a 36pt control height.
+///
+/// Behaviour is deliberately untouched: it is still a plain `TextField`,
+/// so first-responder handling, Return via `onSubmit`, Escape via the
+/// presenter's `.cancelAction`, text selection, and VoiceOver all work
+/// exactly as they did. The focus ring is suppressed with
+/// `.focusEffectDisabled()` only because we draw an equivalent one —
+/// focusability itself is unchanged.
+struct RapidTextField: View {
+    let placeholder: String
+    @Binding var text: String
+    /// Called on Return. The presenter still owns the default-action
+    /// button; this just makes Return-in-field do the same thing.
+    var onSubmit: (() -> Void)? = nil
+
+    @FocusState private var focused: Bool
+
+    var body: some View {
+        TextField(placeholder, text: $text)
+            .textFieldStyle(.plain)
+            .font(RapidFont.body)
+            .focused($focused)
+            .focusEffectDisabled()
+            .onSubmit { onSubmit?() }
+            .padding(.horizontal, RapidTheme.Space.md - 2)
+            .frame(height: RapidTheme.ControlHeight.large)
+            .background(
+                RoundedRectangle(cornerRadius: RapidTheme.Radius.input, style: .continuous)
+                    .fill(RapidTheme.surfaceRaised)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: RapidTheme.Radius.input, style: .continuous)
+                    .strokeBorder(
+                        focused ? RapidTheme.focusRing : RapidTheme.hairlineStrong,
+                        lineWidth: focused ? 2 : 1
+                    )
+            )
+            .rapidAnimation(RapidMotion.quick, value: focused)
+            .contentShape(
+                RoundedRectangle(cornerRadius: RapidTheme.Radius.input, style: .continuous)
+            )
+            // Clicking anywhere in the container focuses the field, not
+            // just the glyph run — the bezel used to provide this.
+            .onTapGesture { focused = true }
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/UI/Components/SectionHeader.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/Components/SectionHeader.swift
@@ -1,0 +1,93 @@
+import SwiftUI
+
+/// A page or group heading: title, optional supporting line, optional
+/// trailing accessory.
+///
+/// Exists so headings stop being re-invented per view. Before v1.0 the
+/// same conceptual heading appeared as `.title3.weight(.semibold)` in
+/// Connect Tools, `.title2.weight(.semibold)` in the missing-sidecar
+/// overlay, and a hand-tracked uppercase `scaledSystemFont(11)` in
+/// onboarding — three sizes for one role.
+///
+/// Two emphases:
+///   * ``page`` — the one title on a page. 20pt semibold.
+///   * ``section`` — a label over a group of rows. 11pt semibold,
+///     uppercase, tracked, secondary. Deliberately quiet: it organises
+///     content, it doesn't announce it.
+struct SectionHeader: View {
+    enum Emphasis {
+        case page
+        case section
+    }
+
+    let title: String
+    var subtitle: String? = nil
+    var emphasis: Emphasis = .section
+    /// Trailing control (a "See all", a count, a toggle).
+    var accessory: AnyView? = nil
+
+    init(
+        _ title: String,
+        subtitle: String? = nil,
+        emphasis: Emphasis = .section
+    ) {
+        self.title = title
+        self.subtitle = subtitle
+        self.emphasis = emphasis
+        self.accessory = nil
+    }
+
+    init<Accessory: View>(
+        _ title: String,
+        subtitle: String? = nil,
+        emphasis: Emphasis = .section,
+        @ViewBuilder accessory: () -> Accessory
+    ) {
+        self.title = title
+        self.subtitle = subtitle
+        self.emphasis = emphasis
+        self.accessory = AnyView(accessory())
+    }
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline, spacing: RapidTheme.Space.md) {
+            VStack(alignment: .leading, spacing: subtitle == nil ? 0 : RapidTheme.Space.xs) {
+                titleText
+                if let subtitle {
+                    Text(subtitle)
+                        .font(RapidFont.secondary)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+            if accessory != nil {
+                Spacer(minLength: RapidTheme.Space.sm)
+                accessory
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        // One AX element per heading, announced with the heading trait
+        // so VoiceOver's rotor can jump between sections.
+        .accessibilityElement(children: .combine)
+        .accessibilityAddTraits(.isHeader)
+    }
+
+    @ViewBuilder
+    private var titleText: some View {
+        switch emphasis {
+        case .page:
+            Text(title)
+                .font(RapidFont.pageTitle)
+                .foregroundStyle(.primary)
+        case .section:
+            // v1.0.1: Title Case, no tracking. ALL-CAPS + letter-spacing
+            // gave a purely organisational label more presence than the
+            // content under it — "ENDPOINT" was shouting at the values
+            // it labels. A quiet 11pt semibold in secondary does the
+            // same structural job without competing.
+            Text(title)
+                .font(RapidFont.sectionTitle)
+                .foregroundStyle(.secondary)
+        }
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/UI/Components/ServerStatusPill.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/Components/ServerStatusPill.swift
@@ -1,0 +1,70 @@
+import SwiftUI
+
+/// The canonical rendering of ``ServerState``: a tinted pill with a
+/// status dot and one word.
+///
+/// The mapping from lifecycle to colour lives here and only here, so
+/// "Ready is green, Starting is amber, Crashed is red, Idle is neutral"
+/// is a fact about the app rather than a convention each view
+/// re-implements. ``ModelPickerBar`` previously owned a private
+/// `stateColor` / `stateLabel` pair; this replaces it.
+///
+/// Pure inputs — it takes a ``ServerState``, not a ``ServerManager`` —
+/// so it renders in a snapshot harness with no live subprocess.
+struct ServerStatusPill: View {
+    let state: ServerState
+    /// Pulse the dot while work is in flight. Suppressed automatically
+    /// under Reduce Motion by ``PulsingStateDot``.
+    var animatesWhenWorking: Bool = true
+
+    var body: some View {
+        HStack(spacing: RapidTheme.Space.sm - 2) {
+            PulsingStateDot(color: tint, isAnimating: animatesWhenWorking && isWorking)
+            Text(label)
+                .font(RapidFont.secondary)
+                .foregroundStyle(.primary)
+                .lineLimit(1)
+        }
+        .padding(.horizontal, RapidTheme.Space.sm + 2)
+        .padding(.vertical, RapidTheme.Space.xs + 1)
+        .background(
+            RoundedRectangle(cornerRadius: RapidTheme.Radius.button, style: .continuous)
+                .fill(tint.opacity(0.10))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: RapidTheme.Radius.button, style: .continuous)
+                .strokeBorder(tint.opacity(0.22), lineWidth: 0.5)
+        )
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("Server status")
+        .accessibilityValue(label)
+    }
+
+    /// Lifecycle → status token. The single source of truth.
+    var tint: Color {
+        switch state {
+        case .idle, .stopped:  return RapidTheme.statusIdle
+        case .missing:         return RapidTheme.statusError
+        case .starting:        return RapidTheme.statusWorking
+        case .ready:           return RapidTheme.statusReady
+        case .crashed:         return RapidTheme.statusError
+        }
+    }
+
+    /// One word. Detail (alias, progress, ETA) belongs to whatever
+    /// surface owns the pill, not to the pill.
+    var label: String {
+        switch state {
+        case .idle, .stopped: return "Idle"
+        case .missing:        return "Setup needed"
+        case .starting:       return "Starting"
+        case .ready:          return "Ready"
+        case .crashed:        return "Crashed"
+        }
+    }
+
+    private var isWorking: Bool {
+        if case .starting = state { return true }
+        return false
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/UI/ConnectToolsView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ConnectToolsView.swift
@@ -26,7 +26,43 @@ struct ConnectToolsView: View {
 
     private var openAIBaseURL: String { "http://\(host):\(port)/v1" }
     private var anthropicBaseURL: String { "http://\(host):\(port)" }
-    private var modelName: String { alias.isEmpty ? "local" : alias }
+
+    /// The model id to publish in a config, or ``nil`` when no real
+    /// model is resolved yet. Deliberately not defaulted to a
+    /// plausible-looking literal — a copied config carrying a made-up
+    /// model name fails later, somewhere else, with a worse error.
+    private var resolvedModel: String? { ModelDisplayName.configValue(alias: alias) }
+
+    /// What the user sees in the `Model` row while nothing is resolved.
+    private var modelDisplay: String { resolvedModel ?? "Not started yet" }
+
+    /// The model slot inside a displayed snippet. When nothing is
+    /// resolved the snippet shows an obvious angle-bracket placeholder
+    /// rather than a plausible-looking literal — and Copy is disabled
+    /// in that state anyway, so this text is read, never pasted.
+    private var snippetModel: String { resolvedModel ?? "<start a model first>" }
+
+    /// Same contract as ``snippetModel`` for the API key slot.
+    private var snippetKey: String { bearer.isEmpty ? "<starts with your server>" : bearer }
+
+    /// A config is only complete once the server is actually listening
+    /// (so the port is real) AND it has minted a bearer AND a model is
+    /// resolved. Anything less and the snippets below would be a
+    /// half-filled template.
+    private var configReady: Bool {
+        port > 0 && !bearer.isEmpty && resolvedModel != nil
+    }
+
+    /// One concise sentence naming what is missing.
+    private var readinessMessage: String {
+        if resolvedModel == nil && bearer.isEmpty {
+            return "Start a model to generate your local endpoint and key."
+        }
+        if bearer.isEmpty {
+            return "Your API key is created when the local server starts."
+        }
+        return "Start a model to fill in the model name."
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -36,62 +72,114 @@ struct ConnectToolsView: View {
                 cardContent
             }
         }
-        .frame(width: 460, height: 560)
-        .background(RapidTheme.canvas)
+        // Sheet context keeps a fixed dialog size. Page context (the
+        // Launch sidebar section) now FILLS its column instead of
+        // sitting in a 460pt box inside a resizable pane — that fixed
+        // frame is why the page had a hard right edge and could not use
+        // the window it was given.
+        .modifier(ConnectToolsFrame(fixedSize: showsCloseButton))
+        .background(RapidTheme.surfaceCanvas)
     }
 
-    /// The scrollable card list. Factored out so the snapshot harness can
+    /// The scrollable content. Factored out so the snapshot harness can
     /// render it inside a fixed frame (``ImageRenderer`` collapses
     /// ``ScrollView`` content to zero height).
+    ///
+    /// v1.0 structure: one endpoint card and one tools card, each a
+    /// group of hairline-separated rows. Previously this was three
+    /// free-floating cards, each of which contained a second nested
+    /// card for its snippet — card-inside-card three times over, which
+    /// is what produced the tall, heavy stack.
     @ViewBuilder
     var cardContent: some View {
-        VStack(spacing: 12) {
-            ForEach(tools) { tool in
-                ConnectToolCard(tool: tool)
+        VStack(alignment: .leading, spacing: RapidTheme.Space.xl) {
+            // Honest about readiness rather than presenting a
+            // half-filled template as a working config. The sheet is
+            // always reachable (see ChatView's empty-state CTA), so
+            // this is the surface that has to explain the "not yet"
+            // case instead of the button hiding it.
+            if !configReady {
+                InlineNotice(message: readinessMessage, tone: .info)
             }
-            endpointFootnote
+            endpointSection
+            toolsSection
         }
-        .padding(20)
+        .frame(maxWidth: RapidTheme.Layout.pageMaxWidth, alignment: .leading)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(RapidTheme.Space.xl)
     }
 
     private var header: some View {
-        HStack(alignment: .top) {
-            VStack(alignment: .leading, spacing: 3) {
-                Text("Connect your tools")
-                    .font(.title3.weight(.semibold))
-                Text("Point any editor at your local server. It's free and stays on your Mac.")
-                    .font(.callout)
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
-            }
-            Spacer()
+        HStack(alignment: .top, spacing: RapidTheme.Space.md) {
+            SectionHeader(
+                "Connect your tools",
+                subtitle: "Point any editor at your local server. It's free and stays on your Mac.",
+                emphasis: .page
+            )
             if showsCloseButton {
-                Button {
-                    onClose()
-                } label: {
-                    Image(systemName: "xmark.circle.fill")
-                        .font(.title2)
-                        .foregroundStyle(.tertiary)
-                }
-                .buttonStyle(.plain)
-                .accessibilityLabel("Close")
+                SheetCloseButton(action: onClose)
             }
         }
-        .padding(20)
+        .frame(maxWidth: RapidTheme.Layout.pageMaxWidth, alignment: .leading)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, RapidTheme.Space.xl)
+        .padding(.vertical, RapidTheme.Space.lg)
     }
 
-    private var endpointFootnote: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            Divider()
-            Text("Endpoint")
-                .font(.caption.weight(.semibold))
-                .foregroundStyle(.secondary)
-            CopyableRow(label: "OpenAI base URL", value: openAIBaseURL)
-            CopyableRow(label: "Anthropic base URL", value: anthropicBaseURL)
-            CopyableRow(label: "API key", value: bearer, masked: true)
-            CopyableRow(label: "Model", value: modelName)
+    /// The live connection values, promoted above the per-tool rows.
+    ///
+    /// Every snippet below is assembled from exactly these four values,
+    /// so showing them once at the top means the per-tool rows no longer
+    /// have to repeat the full base URL + key + model three times.
+    private var endpointSection: some View {
+        VStack(alignment: .leading, spacing: RapidTheme.Space.sm) {
+            SectionHeader("Endpoint")
+            VStack(spacing: 0) {
+                // Base URLs are real information at all times — the
+                // loopback address and port are known before anything
+                // starts — so they render at full reading contrast and
+                // stay copyable. Only values that genuinely don't exist
+                // yet (the key, the model) recede and disable their
+                // Copy control.
+                CopyableRow(label: "OpenAI base URL", value: openAIBaseURL)
+                rowDivider
+                CopyableRow(label: "Anthropic base URL", value: anthropicBaseURL)
+                rowDivider
+                CopyableRow(
+                    label: "API key",
+                    value: bearer,
+                    masked: true,
+                    placeholder: "Created when the server starts"
+                )
+                rowDivider
+                CopyableRow(
+                    label: "Model",
+                    value: resolvedModel ?? "",
+                    placeholder: modelDisplay
+                )
+            }
+            .groupedCard()
         }
-        .padding(.top, 4)
+    }
+
+    private var toolsSection: some View {
+        VStack(alignment: .leading, spacing: RapidTheme.Space.sm) {
+            SectionHeader("Editors and agents")
+            VStack(spacing: 0) {
+                ForEach(Array(tools.enumerated()), id: \.element.id) { index, tool in
+                    if index > 0 { rowDivider }
+                    ConnectToolRow(tool: tool, isReady: configReady)
+                }
+            }
+            .groupedCard()
+        }
+    }
+
+    private var rowDivider: some View {
+        Rectangle()
+            .fill(RapidTheme.hairline)
+            .frame(height: 1)
+            .padding(.leading, RapidTheme.Space.md)
     }
 
     // MARK: - Tool definitions
@@ -105,8 +193,8 @@ struct ConnectToolsView: View {
                 blurb: "Settings → Models → add an OpenAI-compatible model with this base URL and key.",
                 snippet: """
                 Base URL: \(openAIBaseURL)
-                API key:  \(bearer)
-                Model:    \(modelName)
+                API key:  \(snippetKey)
+                Model:    \(snippetModel)
                 """
             ),
             ConnectTool(
@@ -116,8 +204,8 @@ struct ConnectToolsView: View {
                 blurb: "Export these before launching `claude` — it speaks the Anthropic format.",
                 snippet: """
                 export ANTHROPIC_BASE_URL=\(anthropicBaseURL)
-                export ANTHROPIC_API_KEY=\(bearer)
-                export ANTHROPIC_MODEL=\(modelName)
+                export ANTHROPIC_API_KEY=\(snippetKey)
+                export ANTHROPIC_MODEL=\(snippetModel)
                 """
             ),
             ConnectTool(
@@ -127,14 +215,45 @@ struct ConnectToolsView: View {
                 blurb: "Export these before launching `codex` — OpenAI-compatible.",
                 snippet: """
                 export OPENAI_BASE_URL=\(openAIBaseURL)
-                export OPENAI_API_KEY=\(bearer)
+                export OPENAI_API_KEY=\(snippetKey)
                 """
             ),
         ]
     }
 }
 
-/// One tool's copyable card.
+/// Applies the page-vs-sheet frame. A plain `if` around `.frame` would
+/// change the view's type between branches, so the choice is wrapped in
+/// a modifier instead.
+private struct ConnectToolsFrame: ViewModifier {
+    let fixedSize: Bool
+
+    func body(content: Content) -> some View {
+        if fixedSize {
+            content.frame(width: 460, height: 560)
+        } else {
+            content.frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        }
+    }
+}
+
+/// A group of rows presented as one card: raised fill, one card radius,
+/// one hairline. The rows inside are plain — no nested containers.
+private extension View {
+    func groupedCard() -> some View {
+        self
+            .background(
+                RoundedRectangle(cornerRadius: RapidTheme.Radius.card, style: .continuous)
+                    .fill(RapidTheme.surfaceRaised)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: RapidTheme.Radius.card, style: .continuous)
+                    .strokeBorder(RapidTheme.hairline, lineWidth: 1)
+            )
+    }
+}
+
+/// One tool's copyable config.
 private struct ConnectTool: Identifiable {
     let id: String
     let name: String
@@ -143,48 +262,108 @@ private struct ConnectTool: Identifiable {
     let snippet: String
 }
 
-private struct ConnectToolCard: View {
+/// One tool row: icon, name, description, a Copy action, and the
+/// snippet — all on a shared alignment grid.
+///
+/// The three changes that flatten this surface:
+///
+///   1. It is a ROW in a shared card, not its own card. No card-inside-
+///      card, and the three tools now read as one scannable list.
+///   2. Copy config steps down from `.borderedProminent` (a filled
+///      steel-blue block, repeated three times, which read as the most
+///      important thing on the page) to a compact outlined secondary
+///      with a steel-blue label — the utility action it actually is.
+///   3. The snippet sits on ``surfaceCode`` with tighter padding and a
+///      smaller mono size, so it reads as inset reference material
+///      rather than a second card.
+///
+/// Every tool, value, and action is preserved exactly.
+private struct ConnectToolRow: View {
     let tool: ConnectTool
+    /// False until the endpoint, key, and model are all real. Copying a
+    /// half-filled snippet is worse than not offering it.
+    var isReady: Bool = true
     @State private var copied = false
 
+    /// Fixed icon column. Everything textual in the row starts at
+    /// ``iconColumn`` + ``iconGap`` so title, description, and snippet
+    /// share one left edge.
+    private static let iconColumn: CGFloat = 20
+    private static let iconGap: CGFloat = 12
+    private static var textInset: CGFloat { iconColumn + iconGap }
+
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            HStack(spacing: 9) {
+        VStack(alignment: .leading, spacing: 0) {
+            // Header: icon | title | spacer | fixed-width action.
+            // ``firstTextBaseline`` rather than centre so the glyph sits
+            // on the title's baseline instead of floating between the
+            // title and the description below it.
+            HStack(alignment: .firstTextBaseline, spacing: Self.iconGap) {
                 Image(systemName: tool.symbol)
-                    .font(.system(size: 15, weight: .medium))
-                    .foregroundStyle(RapidTheme.brand)
-                    .frame(width: 22)
+                    .font(.system(size: 14, weight: .medium))
+                    // v1.0.2: amber. These are brand/integration marks
+                    // on a page that had drifted entirely neutral;
+                    // steel blue is off this surface altogether.
+                    .foregroundStyle(RapidTheme.brandPrimaryDeep)
+                    .frame(width: Self.iconColumn, alignment: .center)
+                    .accessibilityHidden(true)
+
                 Text(tool.name)
-                    .font(.headline)
-                Spacer()
-                Button {
-                    copy()
-                } label: {
+                    .font(RapidFont.bodyEmphasis)
+                    .lineLimit(1)
+
+                Spacer(minLength: RapidTheme.Space.md)
+
+                Button(action: copy) {
                     Label(copied ? "Copied" : "Copy config",
                           systemImage: copied ? "checkmark" : "doc.on.doc")
-                        .font(.callout.weight(.medium))
                 }
-                .buttonStyle(.borderedProminent)
-                .tint(copied ? RapidTheme.green : RapidTheme.brand)
+                .buttonStyle(RapidSecondaryButtonStyle(
+                    utility: true,
+                    height: RapidTheme.ControlHeight.small,
+                    foreground: copied ? RapidTheme.utilityActionSuccess : nil
+                ))
+                .disabled(!isReady)
+                // Fixed width so all three buttons form a clean right
+                // column instead of each sizing to its own label (the
+                // "Copied" flip would otherwise resize the button and
+                // shift the row).
+                .frame(width: 132)
+                .help(isReady
+                      ? "Copy this tool's configuration"
+                      : "Start a model to generate a valid key and configuration.")
+                .accessibilityLabel(copied ? "Copied \(tool.name) config" : "Copy \(tool.name) config")
             }
-            Text(tool.blurb)
-                .font(.callout)
-                .foregroundStyle(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
-            Text(tool.snippet)
-                .font(.system(.caption, design: .monospaced))
-                .foregroundStyle(.primary)
-                .textSelection(.enabled)
-                .padding(10)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .background(RapidTheme.sidebarSurface, in: RoundedRectangle(cornerRadius: 8))
+
+            // Description and snippet share the title's column.
+            VStack(alignment: .leading, spacing: 0) {
+                Text(tool.blurb)
+                    .font(RapidFont.secondary)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                    // Capped so a one-line blurb can't stretch to the
+                    // card edge and break after a single trailing word.
+                    .frame(maxWidth: 420, alignment: .leading)
+                    .padding(.top, RapidTheme.Space.sm)
+
+                Text(tool.snippet)
+                    .font(RapidFont.code)
+                    .foregroundStyle(.secondary)
+                    .lineSpacing(3)
+                    .textSelection(.enabled)
+                    .padding(.horizontal, RapidTheme.Space.md)
+                    .padding(.vertical, RapidTheme.Space.md - 2)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(
+                        RoundedRectangle(cornerRadius: RapidTheme.Radius.code, style: .continuous)
+                            .fill(RapidTheme.surfaceCode)
+                    )
+                    .padding(.top, RapidTheme.Space.md)
+            }
+            .padding(.leading, Self.textInset)
         }
-        .padding(14)
-        .background(RapidTheme.card, in: RoundedRectangle(cornerRadius: 12))
-        .overlay(
-            RoundedRectangle(cornerRadius: 12)
-                .stroke(RapidTheme.hairline, lineWidth: 1)
-        )
+        .padding(.horizontal, RapidTheme.Space.xl - 4)
+        .padding(.vertical, RapidTheme.Space.lg + 1)
     }
 
     private func copy() {
@@ -203,37 +382,65 @@ private struct CopyableRow: View {
     let label: String
     let value: String
     var masked: Bool = false
+    /// Shown instead of the value when there is nothing real to show.
+    /// Its presence also disables Copy — an empty clipboard write is a
+    /// silent failure the user only discovers in their editor.
+    var placeholder: String? = nil
     @State private var reveal = false
     @State private var copied = false
 
+    private var hasValue: Bool { !value.isEmpty }
+
     private var shown: String {
+        guard hasValue else { return placeholder ?? "—" }
         guard masked, !reveal else { return value }
         return String(repeating: "•", count: min(value.count, 16))
     }
 
     var body: some View {
-        HStack(spacing: 8) {
+        HStack(spacing: RapidTheme.Space.sm) {
             Text(label)
-                .font(.caption)
+                .font(RapidFont.secondary)
                 .foregroundStyle(.secondary)
-                .frame(width: 118, alignment: .leading)
+                .frame(width: 132, alignment: .leading)
+            // Monospaced is correct here — this is an endpoint / key /
+            // model id, one of the four sanctioned mono uses. The
+            // not-yet placeholder drops to the prose font and tertiary,
+            // so it can't be mistaken for a value worth copying.
+            // Values render at full contrast. A not-yet placeholder is
+            // one step down — clearly secondary, still comfortably
+            // readable. It is NOT `.tertiary`: that made whole rows look
+            // switched off when the row's own label and the sentence it
+            // carries are both perfectly legitimate information.
             Text(shown)
-                .font(.system(.caption, design: .monospaced))
+                .font(hasValue ? RapidFont.code : RapidFont.secondary)
+                .foregroundStyle(hasValue ? AnyShapeStyle(.primary) : AnyShapeStyle(.secondary))
                 .lineLimit(1)
                 .truncationMode(.middle)
+                // Always selectable: the two `textSelection` states are
+                // different types so they can't share a ternary, and
+                // the real guard against pasting a placeholder is the
+                // disabled Copy button below, not selection.
                 .textSelection(.enabled)
-            Spacer(minLength: 4)
-            if masked {
-                Button {
+            Spacer(minLength: RapidTheme.Space.xs)
+            if masked, hasValue {
+                QuietIconButton(
+                    symbol: reveal ? "eye.slash" : "eye",
+                    label: reveal ? "Hide key" : "Show key",
+                    size: RapidTheme.ControlHeight.mini
+                ) {
                     reveal.toggle()
-                } label: {
-                    Image(systemName: reveal ? "eye.slash" : "eye")
                 }
-                .buttonStyle(.plain)
-                .foregroundStyle(.secondary)
-                .accessibilityLabel(reveal ? "Hide key" : "Show key")
             }
-            Button {
+            QuietIconButton(
+                symbol: copied ? "checkmark" : "doc.on.doc",
+                label: "Copy \(label)",
+                help: hasValue
+                    ? "Copy \(label)"
+                    : "Start a model to generate a valid key and configuration.",
+                tint: copied ? RapidTheme.utilityActionSuccess : nil,
+                size: RapidTheme.ControlHeight.mini
+            ) {
                 NSPasteboard.general.clearContents()
                 NSPasteboard.general.setString(value, forType: .string)
                 copied = true
@@ -241,12 +448,10 @@ private struct CopyableRow: View {
                     try? await Task.sleep(nanoseconds: 1_200_000_000)
                     copied = false
                 }
-            } label: {
-                Image(systemName: copied ? "checkmark" : "doc.on.doc")
-                    .foregroundStyle(copied ? RapidTheme.green : RapidTheme.brand)
             }
-            .buttonStyle(.plain)
-            .accessibilityLabel("Copy \(label)")
+            .disabled(!hasValue)
         }
+        .padding(.horizontal, RapidTheme.Space.md)
+        .frame(height: RapidTheme.ControlHeight.medium)
     }
 }

--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -63,12 +63,26 @@ struct ContentView: View {
                     section = .chat
                 }
             )
-            .navigationSplitViewColumnWidth(min: 190, ideal: 230, max: 300)
+            // v1.0: the rail paints an explicit warm surface rather than
+            // inheriting the system sidebar material. The material is a
+            // cool translucent grey that fought the warm canvas beside
+            // it — the two planes read as belonging to different apps.
+            .background(RapidTheme.surfaceSidebar)
+            .navigationSplitViewColumnWidth(
+                min: SidebarView.columnMinWidth,
+                ideal: SidebarView.columnIdealWidth,
+                max: SidebarView.columnMaxWidth
+            )
         } detail: {
             detailArea
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .frame(minWidth: 520, minHeight: Self.minWindowHeight)
-                .background(RapidTheme.canvas)
+                // Detail floor drops 520 → 440 alongside the narrower
+                // rail: at the 640pt window floor the old pair
+                // (190 sidebar + 520 detail) over-committed the window
+                // by 70pt, which is what forced horizontal clipping
+                // instead of graceful compression.
+                .frame(minWidth: 440, minHeight: Self.minWindowHeight)
+                .background(RapidTheme.surfaceCanvas)
         }
         .onChange(of: server.state) { _, newState in
             // #223: clear the download-prompt CTA the moment the server
@@ -294,77 +308,74 @@ struct ContentView: View {
     private var missingOverlay: some View {
         VStack {
             Spacer()
-            VStack(spacing: 20) {
+            VStack(spacing: RapidTheme.Space.lg) {
                 ZStack {
-                    RoundedRectangle(cornerRadius: 16, style: .continuous)
-                        .fill(RapidTheme.brandTint)
-                        .frame(width: 60, height: 60)
+                    RoundedRectangle(cornerRadius: RapidTheme.Radius.card, style: .continuous)
+                        .fill(RapidTheme.brandPrimaryTint)
+                        .frame(width: 48, height: 48)
                     Image(systemName: "arrow.down.circle")
-                        .font(.system(size: 28, weight: .regular))
-                        .foregroundStyle(RapidTheme.brand)
+                        .font(.system(size: 22, weight: .regular))
+                        .foregroundStyle(RapidTheme.brandPrimaryDeep)
                 }
-                VStack(spacing: 8) {
+                .accessibilityHidden(true)
+                VStack(spacing: RapidTheme.Space.sm) {
                     Text("Setup didn't finish")
-                        .font(.title2.weight(.semibold))
-                    Text("Rapid isn't fully set up yet. Reopen Rapid-MLX to run the one-time setup again.")
-                        .font(.callout)
+                        .font(RapidFont.pageTitle)
+                    Text("Rapid-MLX isn't fully set up yet. Reopen Rapid-MLX to run the one-time setup again.")
+                        .font(RapidFont.secondary)
                         .foregroundStyle(.secondary)
                         .multilineTextAlignment(.center)
                         .fixedSize(horizontal: false, vertical: true)
                         .lineSpacing(2)
                 }
+                // Same two branches, same actions, same ordering as
+                // before — only the button tiers change. The recovery
+                // action (download the update, or recheck) is the amber
+                // primary; Quit steps down to secondary, since making
+                // "give up" the most prominent control on a recoverable
+                // failure was the wrong emphasis.
                 if let release = updater.availableUpdate,
                    let downloadURL = ContentView.missingOverlayDownloadURL(for: release) {
-                    VStack(spacing: 8) {
-                        Button {
+                    VStack(spacing: RapidTheme.Space.sm) {
+                        Button("Download update \(release.version)") {
                             NSWorkspace.shared.open(downloadURL)
-                        } label: {
-                            Text("Download update \(release.version)")
-                                .frame(maxWidth: .infinity)
                         }
-                        .buttonStyle(.borderedProminent)
-                        .controlSize(.large)
-                        HStack(spacing: 12) {
+                        .buttonStyle(.rapidPrimaryWide)
+                        HStack(spacing: RapidTheme.Space.sm) {
                             Button("Recheck") { server.refreshBinary() }
-                                .controlSize(.large)
+                                .buttonStyle(.rapidSecondary)
                             Button("Quit Rapid-MLX") { NSApp.terminate(nil) }
-                                .controlSize(.large)
+                                .buttonStyle(.rapidSecondary)
                         }
                     }
                 } else {
-                    HStack(spacing: 12) {
-                        Button {
-                            NSApp.terminate(nil)
-                        } label: {
-                            Text("Quit Rapid-MLX")
-                                .frame(maxWidth: .infinity)
-                        }
-                        .buttonStyle(.borderedProminent)
-                        .controlSize(.large)
+                    HStack(spacing: RapidTheme.Space.sm) {
                         Button("Recheck") { server.refreshBinary() }
-                            .controlSize(.large)
+                            .buttonStyle(.rapidPrimary)
+                        Button("Quit Rapid-MLX") { NSApp.terminate(nil) }
+                            .buttonStyle(.rapidSecondary)
                     }
                 }
                 Text("Rapid-MLX runs AI models on your Mac. Your chats stay on this computer — no messages are sent to the cloud.")
-                    .font(.caption)
+                    .font(RapidFont.caption)
                     .foregroundStyle(.secondary)
                     .multilineTextAlignment(.center)
                     .fixedSize(horizontal: false, vertical: true)
-                    .padding(.top, 4)
             }
-            .padding(28)
-            .frame(width: 420)
+            .padding(RapidTheme.Space.xl)
+            .frame(maxWidth: 400)
             .background(
-                RoundedRectangle(cornerRadius: RapidTheme.cardRadius, style: .continuous)
-                    .fill(RapidTheme.card)
+                RoundedRectangle(cornerRadius: RapidTheme.Radius.card, style: .continuous)
+                    .fill(RapidTheme.surfaceRaised)
             )
             .overlay(
-                RoundedRectangle(cornerRadius: RapidTheme.cardRadius, style: .continuous)
-                    .stroke(RapidTheme.hairline, lineWidth: 1)
+                RoundedRectangle(cornerRadius: RapidTheme.Radius.card, style: .continuous)
+                    .strokeBorder(RapidTheme.hairline, lineWidth: 1)
             )
-            .shadow(color: Color.black.opacity(0.06), radius: 18, x: 0, y: 8)
+            .shadow(color: Color.black.opacity(0.05), radius: 14, x: 0, y: 6)
             Spacer()
         }
+        .padding(.horizontal, RapidTheme.Space.xl)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(LeopardSpots(opacity: 0.06))
     }

--- a/apps/rapid-mac/Sources/Rapid/UI/ModelPickerBar.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ModelPickerBar.swift
@@ -451,7 +451,14 @@ struct ModelPickerBar: View {
     private var modelPicker: some View {
         Menu {
             if loadingCatalog && catalog.isEmpty {
-                Text("Fetching model list…")
+                // A plain ``Text`` in a SwiftUI Menu renders as a
+                // disabled, non-selectable row — which is exactly the
+                // affordance we want while the catalog is in flight.
+                // "Type a model name…" stays reachable so a user who
+                // knows what they want isn't blocked on the fetch.
+                Text("Fetching models…")
+                Divider()
+                Button("Type a model name…") { showCustom = true }
             } else if catalog.isEmpty {
                 // v0.4.29: previously this state was a dead end — a
                 // failed first-load (bootstrapper still installing
@@ -460,9 +467,12 @@ struct ModelPickerBar: View {
                 // "Type alias…" and no way back to a populated picker
                 // short of restarting the app. Retry is a one-click
                 // rescue.
-                Text("Model list unavailable")
+                // Honest terminal state: the fetch finished and there is
+                // nothing to offer. Non-selectable, and never an
+                // indefinite placeholder posing as a model.
+                Text("No models available")
                 Divider()
-                Button("Retry") {
+                Button("Refresh catalog") {
                     Task { await refreshCatalog(force: true) }
                 }
                 Button("Type a model name…") { showCustom = true }
@@ -502,8 +512,11 @@ struct ModelPickerBar: View {
                     // `.accessibilityElement(children: .ignore)` instead —
                     // it de-duplicates but downgrades the role to AXUnknown.
                     .accessibilityHidden(true)
-                Text(alias.isEmpty ? "Pick a model" : alias)
-                    .font(.body)
+                // Never renders an internal placeholder as if it were a
+                // chosen model — an unresolved alias reads as an
+                // instruction instead.
+                Text(pickerLabel)
+                    .font(RapidFont.secondary)
                     .foregroundStyle(aliasTextStyle)
                     .lineLimit(1)
                     // Middle truncation keeps both ends of a long alias
@@ -517,31 +530,23 @@ struct ModelPickerBar: View {
                     .foregroundStyle(chevronStyle)
                     .accessibilityHidden(true)
             }
-            .padding(.horizontal, 10)
-            // 10/5 at radius 8 are exactly the state badge's metrics, so
-            // the two pills in this row share one shape language — and it
-            // holds the bar at its historical 46 pt (the old flattened
-            // NSPopUpButton label was only 16 pt tall, so a 6 pt-padded
-            // pill would push the strip to 48).
-            .padding(.vertical, 5)
-            // v0.5: the picker reads as a calm input pill — a faint fill
-            // plus a hairline border, instead of a flat grey block.
-            // v0.10.7: both firm up on hover. Static chrome alone still
-            // reads as a status label; a control that *responds to the
-            // pointer* is what makes a bezel-less macOS control legible as
-            // interactive (same move as SessionsSidebar's rows).
-            // Deliberately neutral — no hue shift; RapidTheme.brand stays
-            // reserved for focus everywhere else in the app.
+            .padding(.horizontal, RapidTheme.Space.sm)
+            .frame(height: RapidTheme.ControlHeight.small)
+            // v1.0: inside the composer this chip sits ON an input
+            // surface, so its own bordered pill produced the
+            // field-inside-a-field look the redesign is removing. In
+            // ``composerStyle`` it is therefore borderless and picks up
+            // a fill only on hover; the standalone (non-composer) bar
+            // keeps a hairline so it still reads as a control on a bare
+            // toolbar. Model selection is a brand moment, so the
+            // resolved alias renders in deep amber rather than neutral.
             .background(
-                RoundedRectangle(cornerRadius: 8, style: .continuous)
-                    .fill(Color.secondary.opacity(pickerHovering ? 0.12 : 0.06))
+                RoundedRectangle(cornerRadius: RapidTheme.Radius.row, style: .continuous)
+                    .fill(pickerFill)
             )
             .overlay(
-                RoundedRectangle(cornerRadius: 8, style: .continuous)
-                    .stroke(
-                        pickerHovering ? Color.primary.opacity(0.22) : RapidTheme.hairline,
-                        lineWidth: 1
-                    )
+                RoundedRectangle(cornerRadius: RapidTheme.Radius.row, style: .continuous)
+                    .strokeBorder(pickerStroke, lineWidth: 1)
             )
             // The Spacer stretches the pill across the reserved frame, but
             // SwiftUI hit-tests the label's intrinsic content unless the
@@ -577,19 +582,48 @@ struct ModelPickerBar: View {
         .menuIndicator(.hidden)
         .onHover { pickerHovering = $0 }
         .rapidAnimation(RapidMotion.quick, value: pickerHovering)
-        .help(alias.isEmpty
+        .help(pickerIsUnresolved
               ? "Choose a model to run"
               : "Model: \(alias) — click to change")
         // Both glyphs are hidden from AX above, so this collapses to a
         // single AXMenuButton announced as "Model, <alias>, pop up button"
         // rather than spelling out SF Symbol names.
         .accessibilityLabel("Model")
-        .accessibilityValue(alias.isEmpty ? "None selected" : alias)
+        .accessibilityValue(pickerIsUnresolved ? "None selected" : alias)
         .accessibilityHint("Choose which model to run")
         .accessibilityIdentifier("ModelPickerBar.ModelMenu")
     }
 
-    /// The alias renders in `.primary`; only the "Pick a model"
+    /// Chip fill. Borderless-until-hover inside the composer; a faint
+    /// standing fill on the standalone bar.
+    private var pickerFill: Color {
+        if composerStyle {
+            return pickerHovering ? RapidTheme.hoverFill : .clear
+        }
+        return pickerHovering ? RapidTheme.hoverFill : Color.secondary.opacity(0.06)
+    }
+
+    /// Chip border. Suppressed inside the composer (the composer already
+    /// draws the field edge); a hairline that firms up on hover
+    /// elsewhere, so a bezel-less macOS control still reads as live.
+    private var pickerStroke: Color {
+        if composerStyle {
+            return pickerHovering ? RapidTheme.hairlineStrong : .clear
+        }
+        return pickerHovering ? RapidTheme.hairlineStrong : RapidTheme.hairline
+    }
+
+    /// What the composer chip shows. A real alias, or an instruction.
+    private var pickerLabel: String {
+        ModelDisplayName.configValue(alias: alias) ?? "Choose a model"
+    }
+
+    /// True when the chip is showing the instruction rather than a model.
+    private var pickerIsUnresolved: Bool {
+        ModelDisplayName.isUnresolved(alias)
+    }
+
+    /// The alias renders in `.primary`; only the "Choose a model"
     /// placeholder is `.secondary`, like an empty text field.
     ///
     /// Deliberately NOT the accent colour. A real NSPopUpButton draws its
@@ -600,7 +634,7 @@ struct ModelPickerBar: View {
     /// to the bezel and the chevron, not the text colour. The old blue
     /// was never authored anyway; it leaked from the NSPopUpButton tint.
     private var aliasTextStyle: HierarchicalShapeStyle {
-        alias.isEmpty ? .secondary : .primary
+        pickerIsUnresolved ? .secondary : .primary
     }
 
     /// The disclosure chevron brightens under the pointer — the cheapest
@@ -1427,6 +1461,12 @@ struct ModelPickerBar: View {
         return "questionmark.circle"
     }
 
+    /// v1.0: the pill chrome (dot + tint + shape) moved to the shared
+    /// ``ServerStatusPill`` so lifecycle → colour is defined once. This
+    /// wrapper keeps the picker's own richer label (which folds in the
+    /// alias and the collapse rules in ``displayedStateLabel``) and its
+    /// progress tooltip, both of which the shared pill deliberately
+    /// does not carry.
     private var stateBadge: some View {
         HStack(spacing: 6) {
             PulsingStateDot(color: stateColor, isAnimating: isAnimatedState)
@@ -1785,30 +1825,53 @@ struct ModelPickerBar: View {
         return "\(firstSentence) Continuing may cause swap thrashing, performance crashes, or system lock-up."
     }
 
+    /// v1.0.1: the last native-blue surface in the app.
+    ///
+    /// ``.roundedBorder`` drew AppKit's bezel plus the system focus
+    /// ring, so the brightest blue in the product appeared the moment
+    /// this field took focus — on a sheet whose primary action is
+    /// amber. ``RapidTextField`` draws an amber 2px focus border
+    /// instead and keeps focus, Return, Escape, and VoiceOver exactly
+    /// as they were: Return still commits via the field's `onSubmit`
+    /// AND the default-action button, Escape still cancels.
     private var customAliasSheet: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            Text("Custom model")
-                .font(.headline)
-            Text("Type a model name or a Hugging Face path. New models download when you press Start.")
-                .font(.callout)
-                .foregroundStyle(.secondary)
-            TextField("e.g. qwen3.6-35b", text: $customDraft)
-                .textFieldStyle(.roundedBorder)
-            HStack {
+        VStack(alignment: .leading, spacing: RapidTheme.Space.md) {
+            SectionHeader(
+                "Custom model",
+                subtitle: "Type a model name or a Hugging Face path. New models download when you press Start.",
+                emphasis: .page
+            )
+
+            RapidTextField(
+                placeholder: "e.g. qwen3.6-35b",
+                text: $customDraft,
+                onSubmit: commitCustomAlias
+            )
+
+            HStack(spacing: RapidTheme.Space.sm) {
                 Spacer()
                 Button("Cancel") { showCustom = false }
+                    .buttonStyle(.rapidSecondary)
                     .keyboardShortcut(.cancelAction)
-                Button("Use") {
-                    let trimmed = customDraft.trimmingCharacters(in: .whitespacesAndNewlines)
-                    if !trimmed.isEmpty { alias = trimmed }
-                    showCustom = false
-                }
-                .buttonStyle(.borderedProminent)
-                .keyboardShortcut(.return, modifiers: [])
+                Button("Use", action: commitCustomAlias)
+                    .buttonStyle(RapidPrimaryButtonStyle(
+                        height: RapidTheme.ControlHeight.medium
+                    ))
+                    .keyboardShortcut(.return, modifiers: [])
             }
+            .padding(.top, RapidTheme.Space.xs)
         }
-        .padding(20)
-        .frame(width: 360)
+        .padding(RapidTheme.Space.xl)
+        .frame(width: 380)
+        .background(RapidTheme.surfaceOverlay)
+    }
+
+    /// Commit the typed alias. Shared by Return-in-field and the Use
+    /// button so both paths behave identically.
+    private func commitCustomAlias() {
+        let trimmed = customDraft.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmed.isEmpty { alias = trimmed }
+        showCustom = false
     }
 
     private var isStartable: Bool {
@@ -1940,22 +2003,19 @@ struct ModelPickerBar: View {
         alias = target
     }
 
+    /// v1.0: delegates to ``ServerStatusPill``, which owns the single
+    /// lifecycle → colour mapping for the whole app.
+    ///
+    /// The semantics it inherits are the ones this property already
+    /// implemented — #129's collapse of ``.idle``/``.stopped`` onto one
+    /// off-state colour, amber for starting, green for ready — with two
+    /// corrections: the off-state is now the explicit ``statusIdle``
+    /// token rather than `.secondary` (which shifts with the
+    /// surrounding foreground style), and ``.missing`` reads as an
+    /// error rather than a neutral grey, since a missing sidecar is a
+    /// fault the user has to act on.
     private var stateColor: Color {
-        switch server.state {
-        case .missing: return .gray
-        // #129: ``.idle`` and ``.stopped`` were grey vs amber-tinted
-        // grey — the difference was too subtle to read as semantically
-        // distinct ("is amber a warning? what does the warm subtitle
-        // mean?"). Collapse both to a single off-state colour so the
-        // pill matches its collapsed copy. Matches Ollama / LM Studio.
-        case .idle, .stopped: return .secondary
-        // v0.6: loading uses the brand amber (cheetah energy); ready
-        // uses the brand green. Both come from RapidTheme so the dots
-        // and status pills match the rest of the palette.
-        case .starting: return RapidTheme.amber
-        case .ready: return RapidTheme.green
-        case .crashed: return .red
-        }
+        ServerStatusPill(state: server.state).tint
     }
 
     private var stateLabel: String {
@@ -2099,8 +2159,15 @@ struct ModelPickerBar: View {
                 loadingCatalog = false
             }
         }
-        let entries = await ModelCatalog.load(binary: binary)
+        let loaded = await ModelCatalog.load(binary: binary)
         guard !Task.isCancelled, catalogRefreshGeneration == refreshGeneration else { return }
+        // Belt-and-braces against a phantom alias reaching the UI.
+        // ``ModelCatalog.parseAvailable`` already drops engine banner
+        // lines, but this guard means a NEW banner shape can at worst
+        // produce a missing row — never a selectable fake model, and
+        // never a placeholder word promoted into ``alias`` by
+        // ``recommendedDefault`` below.
+        let entries = loaded.filter { !ModelDisplayName.isUnresolved($0.alias) }
         self.catalog = entries
         // Default selection: only apply if the current alias is blank or
         // not in the catalog (catalog absence still means manual pick).
@@ -2187,7 +2254,11 @@ struct ModelInfoPopover: View {
 /// Animated state dot. Steady-state for ready / idle / crashed; gentle
 /// breathing animation during ``starting`` so the user knows the
 /// model is still loading. Pure SwiftUI animation — no timer needed.
-private struct PulsingStateDot: View {
+///
+/// Internal (not `private`) since v1.0: ``ServerStatusPill`` is the
+/// shared rendering of ``ServerState`` and needs the same dot, so the
+/// dot can no longer be file-scoped to the picker.
+struct PulsingStateDot: View {
     let color: Color
     let isAnimating: Bool
 

--- a/apps/rapid-mac/Sources/Rapid/UI/RapidTheme.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/RapidTheme.swift
@@ -247,16 +247,381 @@ enum RapidTheme {
     }))
 
     // MARK: - Dimensions
-
-    /// Corner radius for the user bubble. 18 reads as a true
-    /// pill at the 2-line common case — anything smaller looks
-    /// like a square-with-rounded-corners chip.
-    static let userBubbleRadius: CGFloat = 18
+    //
+    // ``userBubbleRadius`` (18) was removed here: its only call site now
+    // reads ``Radius.bubble`` (14), and leaving the old constant behind
+    // would have been a second, divergent radius for the same shape —
+    // exactly the drift the ``Radius`` group exists to end.
 
     /// Compose pill corner radius. v0.5: tightened 22 → 18 to match
     /// the user bubble exactly — the larger radius read as a bubbly,
     /// oversized field; 18 is calmer and more "modern AI input."
-    static let composePillRadius: CGFloat = 18
+    /// v1.0 visual foundation: superseded by ``Radius.input`` (10) —
+    /// kept so the legacy token name still resolves, now pointing at
+    /// the single input radius rather than its own value.
+    static let composePillRadius: CGFloat = Radius.input
+
+    // MARK: - v1.0 semantic layer
+    //
+    // Everything below is the Phase-1 "visual foundation": a semantic
+    // vocabulary business views spend instead of writing literals.
+    //
+    // The brand hierarchy this encodes (and which the pre-v1.0 tokens
+    // above got backwards):
+    //
+    //   * AMBER (#EFA23A) is the FIRST brand colour. Primary CTAs,
+    //     selection, focus, working/progress states, key icons, the
+    //     cheetah moments.
+    //   * STEEL BLUE (#3A5C86) is SECONDARY. Informational data,
+    //     links, utility icons, engineering detail. It no longer fills
+    //     primary buttons.
+    //   * GREEN (#2E7D55) means Ready / success and nothing else.
+    //   * RED means error / destructive and nothing else.
+    //   * Warm neutrals carry every large surface, so the product reads
+    //     as a calm desktop app with an amber accent — not an orange
+    //     theme.
+    //
+    // The legacy tokens above are intentionally left in place and
+    // re-pointed here rather than deleted: they have call sites across
+    // the app, and a rename sweep is churn this phase doesn't need.
+
+    // MARK: Brand
+
+    /// The primary brand colour. Amber #EFA23A holds in both modes —
+    /// it is the product's single strongest visual memory, and shifting
+    /// it per-appearance would weaken the recall it exists to build.
+    static let brandPrimary = amber
+
+    /// Amber for small text and glyphs on a light surface. Raw
+    /// ``brandPrimary`` fails contrast under ~15pt on warm white, so
+    /// anything type-sized uses this deeper shade of the same hue.
+    static let brandPrimaryDeep = amberDeep
+
+    /// The calm amber wash behind selected rows, working states, and
+    /// brand-adjacent surfaces that must not become a saturated block.
+    static let brandPrimaryTint = amberTint
+
+    /// Foreground for content sitting ON a ``brandPrimary`` fill.
+    ///
+    /// Deliberately a near-black graphite, never white. White on
+    /// #EFA23A lands around 2.0:1 — below every WCAG threshold — and is
+    /// exactly the low-contrast default this phase was asked to remove.
+    /// Graphite on amber measures ~9:1.
+    static let onBrandPrimary = Color(nsColor: .init(name: nil, dynamicProvider: { _ in
+        NSColor(deviceRed: 0x24/255.0, green: 0x1A/255.0, blue: 0x08/255.0, alpha: 1.0)
+    }))
+
+    /// The secondary brand colour — steel blue. Data, links, secondary
+    /// icons, engineering detail. Aliases the legacy ``brand`` token.
+    static let brandSecondary = brand
+
+    /// Soft steel-blue wash. Aliases the legacy ``brandTint``.
+    static let brandSecondaryTint = brandTint
+
+    // MARK: Surfaces
+    //
+    // Four planes, warmest-and-lowest to raised. Light mode is a warm
+    // greyscale, NOT four shades of near-white; dark mode is authored
+    // on its own ramp rather than an inversion of the light one (the
+    // dark values carry a touch more blue so the amber accent stays
+    // warm against them).
+
+    /// The window canvas — the plane chat, pages, and empty states sit on.
+    static let surfaceCanvas = canvas
+
+    /// The sidebar rail. v1.0: re-warmed from the old cool #F3F5F9,
+    /// which read as a blue-grey slab beside the warm canvas and made
+    /// the whole left column feel like a different product.
+    static let surfaceSidebar = Color(nsColor: .init(name: nil, dynamicProvider: { appearance in
+        appearance.isDark ? NSColor(deviceRed: 0x1A/255.0, green: 0x1C/255.0, blue: 0x20/255.0, alpha: 1.0)
+                          : NSColor(deviceRed: 0xF2/255.0, green: 0xF0/255.0, blue: 0xEB/255.0, alpha: 1.0)
+    }))
+
+    /// A raised surface — cards, popovers, grouped rows.
+    static let surfaceRaised = Color(nsColor: .init(name: nil, dynamicProvider: { appearance in
+        appearance.isDark ? NSColor(deviceRed: 0x1E/255.0, green: 0x21/255.0, blue: 0x26/255.0, alpha: 1.0)
+                          : NSColor.white
+    }))
+
+    /// The ground under code, endpoints, and keys. Recessed relative to
+    /// ``surfaceRaised`` — a snippet should read as inset into a card,
+    /// not as a second card floating on top of one.
+    static let surfaceCode = Color(nsColor: .init(name: nil, dynamicProvider: { appearance in
+        appearance.isDark ? NSColor(deviceRed: 0x14/255.0, green: 0x16/255.0, blue: 0x1A/255.0, alpha: 1.0)
+                          : NSColor(deviceRed: 0xF4/255.0, green: 0xF2/255.0, blue: 0xED/255.0, alpha: 1.0)
+    }))
+
+    /// Sheets and popovers — a hair lighter than ``surfaceRaised`` in
+    /// dark mode so a sheet over a card still separates.
+    static let surfaceOverlay = Color(nsColor: .init(name: nil, dynamicProvider: { appearance in
+        appearance.isDark ? NSColor(deviceRed: 0x23/255.0, green: 0x26/255.0, blue: 0x2C/255.0, alpha: 1.0)
+                          : NSColor(deviceRed: 0xFC/255.0, green: 0xFB/255.0, blue: 0xF9/255.0, alpha: 1.0)
+    }))
+
+    /// A more present divider for structural separation (card headers,
+    /// grouped-row separators) where ``hairline`` disappears.
+    static let hairlineStrong = Color(nsColor: .init(name: nil, dynamicProvider: { appearance in
+        appearance.isDark ? NSColor(deviceRed: 0x32/255.0, green: 0x38/255.0, blue: 0x40/255.0, alpha: 1.0)
+                          : NSColor(deviceRed: 0xDD/255.0, green: 0xDA/255.0, blue: 0xD3/255.0, alpha: 1.0)
+    }))
+
+    // MARK: Status
+    //
+    // One colour per lifecycle meaning. Views switch on state and read
+    // a token; they never pick a hue themselves.
+
+    /// Not running, nothing pending. Deliberately neutral — an idle
+    /// server is not a warning.
+    static let statusIdle = Color(nsColor: .init(name: nil, dynamicProvider: { appearance in
+        appearance.isDark ? NSColor(deviceRed: 0x8A/255.0, green: 0x90/255.0, blue: 0x99/255.0, alpha: 1.0)
+                          : NSColor(deviceRed: 0x8A/255.0, green: 0x86/255.0, blue: 0x7E/255.0, alpha: 1.0)
+    }))
+
+    /// Starting, downloading, benchmarking — anything in flight. Amber,
+    /// which is also the brand colour: progress is on-brand by design.
+    static let statusWorking = brandPrimary
+
+    /// Ready / success. The only role green plays.
+    static let statusReady = green
+
+    /// Error / failure. The only role red plays.
+    static let statusError = Color(nsColor: .init(name: nil, dynamicProvider: { appearance in
+        appearance.isDark ? NSColor(deviceRed: 0xFF/255.0, green: 0x6B/255.0, blue: 0x5E/255.0, alpha: 1.0)
+                          : NSColor(deviceRed: 0xC0/255.0, green: 0x39/255.0, blue: 0x2B/255.0, alpha: 1.0)
+    }))
+
+    /// Tinted backing for an error surface (inline notices, failure rows).
+    static let statusErrorTint = Color(nsColor: .init(name: nil, dynamicProvider: { appearance in
+        appearance.isDark ? NSColor(deviceRed: 0x33/255.0, green: 0x1C/255.0, blue: 0x1A/255.0, alpha: 1.0)
+                          : NSColor(deviceRed: 0xFB/255.0, green: 0xEC/255.0, blue: 0xEA/255.0, alpha: 1.0)
+    }))
+
+    // MARK: Actions
+
+    /// Fill for the single highest-emphasis action on a surface.
+    static let primaryActionFill = brandPrimary
+    /// Label on ``primaryActionFill``.
+    static let primaryActionLabel = onBrandPrimary
+    /// Label/icon for a secondary (outlined) action. Neutral graphite.
+    ///
+    /// v1.0.1: was ``brandSecondary``. Painting every secondary control
+    /// steel blue turned a *supporting* colour into the most repeated
+    /// hue on the surface — three filled blue "Copy config" buttons, a
+    /// blue glyph on every endpoint row, a blue icon per tool. Steel
+    /// blue is now rare by default and earned on hover.
+    static let secondaryActionLabel = Color.primary
+    /// Fill for a destructive action.
+    static let destructiveActionFill = statusError
+    /// Label on ``destructiveActionFill``.
+    static let destructiveActionLabel = Color.white
+    /// A quiet, borderless action — present but not competing.
+    static let quietActionLabel = Color.secondary
+
+    // MARK: Utility controls
+    //
+    // Copy glyphs, reveal toggles, per-row actions: things that are
+    // genuinely useful but must not read as calls to action. Neutral at
+    // rest, steel blue under the pointer (the hover is where the
+    // secondary brand colour earns its place), ready-green on success.
+
+    /// Resting colour for a utility icon/label.
+    static let utilityActionLabel = Color.secondary
+    /// Hover colour for a utility icon/label.
+    ///
+    /// v1.0.2: amber, not steel blue. An active control lighting up is
+    /// a brand moment; routing every hover through the secondary colour
+    /// made steel blue the most frequently-seen accent in the app,
+    /// which is the opposite of "rare supporting colour".
+    static let utilityActionHover = brandPrimaryDeep
+    /// A utility action that just succeeded (copied, saved).
+    static let utilityActionSuccess = statusReady
+
+    /// Genuine text links. After v1.0.2 this is essentially the ENTIRE
+    /// remaining budget for steel blue: not buttons, not icons, not
+    /// hover, not notices — links, and the occasional single deliberate
+    /// technical accent on a surface that has earned one.
+    static let linkLabel = brandSecondary
+
+    /// Keyboard-focus ring. Amber, per the brand hierarchy: focus is a
+    /// primary-attention signal.
+    static let focusRing = brandPrimary
+
+    // MARK: Interaction
+
+    /// Hover wash over a neutral row or control.
+    static let hoverFill = Color.primary.opacity(0.055)
+    /// Pressed wash — one step firmer than hover.
+    static let pressedFill = Color.primary.opacity(0.10)
+    /// Multiplier applied to a control's opacity when disabled.
+    ///
+    /// v1.0.2: raised 0.40 → 0.62. A disabled control still has to be
+    /// READ — "Speed on this Mac" and "Copy config" both explain, via
+    /// their tooltips, what would make them available, and at 0.40 on a
+    /// warm canvas the label was close to invisible. 0.62 keeps the
+    /// unmistakable "not right now" signal while leaving the text
+    /// legible.
+    static let disabledOpacity: Double = 0.62
+
+    // MARK: - Spacing
+    //
+    // One rhythm for the whole app: 4 / 8 / 12 / 16 / 24 / 32. Page
+    // margins, section gaps, and control padding all come from here so
+    // they can never drift apart per-view.
+
+    enum Space {
+        /// 4 — icon-to-label, tight glyph gaps.
+        static let xs: CGFloat = 4
+        /// 8 — inside a control, between related chips.
+        static let sm: CGFloat = 8
+        /// 12 — row padding, gap between grouped rows.
+        static let md: CGFloat = 12
+        /// 16 — card padding, gap between cards.
+        static let lg: CGFloat = 16
+        /// 24 — page margin, gap between sections.
+        static let xl: CGFloat = 24
+        /// 32 — major vertical separation.
+        static let xxl: CGFloat = 32
+    }
+
+    // MARK: - Radii
+    //
+    // One radius per shape ROLE, not per view. The pre-v1.0 surface had
+    // 6/8/10/12/16/18/22 in play simultaneously, which is why nothing
+    // felt like it belonged to one system.
+
+    /// v1.0.1: tightened again. 12pt cards over 8pt buttons over 12pt
+    /// inputs still read as soft — three roundnesses competing. Cards,
+    /// buttons, and rows now share 8; inputs get 10 so a field is
+    /// distinguishable from a button at a glance; only chat bubbles
+    /// stay soft, because a message is the one thing that should feel
+    /// like an object rather than a control.
+    enum Radius {
+        /// Cards and grouped containers.
+        static let card: CGFloat = 8
+        /// Text fields and the composer.
+        static let input: CGFloat = 10
+        /// Buttons.
+        static let button: CGFloat = 8
+        /// Selectable rows — sidebar, lists, menu rows.
+        static let row: CGFloat = 8
+        /// Chat bubbles. Deliberately the one soft shape left.
+        static let bubble: CGFloat = 14
+        /// Inset code / endpoint blocks. Tighter than the card that
+        /// contains them so the inset reads as recessed, not nested.
+        static let code: CGFloat = 6
+    }
+
+    // MARK: - Control heights
+    //
+    // Accessibility floor is 28pt for anything clickable; a primary
+    // action is 36pt. Both are enforced by the shared button styles.
+
+    enum ControlHeight {
+        /// 24 — inline icon buttons inside dense rows. Only for
+        /// controls with a larger surrounding hit target.
+        static let mini: CGFloat = 24
+        /// 28 — the standard minimum tappable control.
+        static let small: CGFloat = 28
+        /// 32 — comfortable default for secondary buttons.
+        static let medium: CGFloat = 32
+        /// 36 — primary actions.
+        static let large: CGFloat = 36
+        /// 30 — sidebar / list row height.
+        static let row: CGFloat = 30
+    }
+
+    // MARK: - Layout
+
+    enum Layout {
+        /// Reading measure for chat + prose. Content never stretches
+        /// edge-to-edge on a wide window.
+        static let contentMaxWidth: CGFloat = 720
+        /// Max width for a settings/tool page's content column.
+        static let pageMaxWidth: CGFloat = 640
+        /// Fixed leading slot every row icon occupies, so labels align
+        /// down a column regardless of glyph width.
+        static let iconSlot: CGFloat = 18
+    }
+}
+
+// MARK: - User-facing model naming
+
+/// Turns an internal alias + lifecycle state into copy a person can read.
+///
+/// Exists because internal placeholders were reaching the surface as if
+/// they were model names. ``DownloadProgress.StartupActivity`` has a
+/// ``.loading`` phase whose label is the bare word "Loading", and an
+/// unresolved alias is the empty string — neither is a model, and
+/// neither should ever be rendered where a user expects one.
+///
+/// Pure and free-standing so every surface (chat empty state, Connect
+/// Tools, benchmark header) answers "what model am I using?" the same
+/// way, and so the mapping is unit-testable without SwiftUI.
+enum ModelDisplayName {
+    /// Internal placeholder strings that must never surface as a name.
+    /// Compared case-insensitively.
+    private static let placeholders: Set<String> = [
+        "loading", "starting", "warming up", "downloading", "unknown", "none",
+    ]
+
+    /// True when ``alias`` is absent or is an internal placeholder.
+    static func isUnresolved(_ alias: String) -> Bool {
+        let trimmed = alias.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty { return true }
+        return placeholders.contains(trimmed.lowercased())
+    }
+
+    /// The name to show in running prose ("Chatting with …").
+    ///
+    /// While the server is coming up we deliberately do NOT show the
+    /// alias, even when we know it: the honest statement is that the
+    /// model is being prepared, not that you are talking to it.
+    static func conversational(alias: String, state: ServerState) -> String {
+        if case .starting = state { return "Preparing your local model…" }
+        return isUnresolved(alias) ? "your local model" : alias
+    }
+
+    /// The name to show in a config value slot (Connect Tools' `Model`
+    /// row, copied snippets). ``nil`` means "no real value yet" — the
+    /// caller must not present a placeholder as a working config.
+    static func configValue(alias: String) -> String? {
+        isUnresolved(alias) ? nil : alias
+    }
+}
+
+// MARK: - Typography
+
+/// The type ramp. Eight roles, native SF throughout.
+///
+/// Monospaced is reserved for code, endpoints, keys, and metrics —
+/// never for prose. A monospaced sentence reads as terminal output,
+/// which is precisely the "this is a CLI with a window around it"
+/// impression the product is trying to shed.
+///
+/// Sizes are fixed rather than `Font.TextStyle`-relative because the
+/// desktop density target is tighter than the system defaults. Views
+/// that must honour Dynamic Type keep using ``scaledSystemFont``; this
+/// ramp covers the chrome.
+enum RapidFont {
+    /// Window / toolbar title.
+    static let windowTitle = Font.system(size: 15, weight: .semibold)
+    /// The one big title on a page. Chat empty state, page headers.
+    static let pageTitle = Font.system(size: 20, weight: .semibold)
+    /// A section label above a group of rows.
+    static let sectionTitle = Font.system(size: 11, weight: .semibold)
+    /// Default body copy and row labels.
+    static let body = Font.system(size: 13)
+    /// Emphasised body — a row's primary label.
+    static let bodyEmphasis = Font.system(size: 13, weight: .medium)
+    /// Supporting copy under a title or row label.
+    static let secondary = Font.system(size: 12)
+    /// The smallest supporting text: hints, footnotes, timestamps.
+    static let caption = Font.system(size: 11)
+    /// A number meant to be compared or watched. Monospaced digits so
+    /// a live-updating value doesn't jitter its own layout.
+    static let metric = Font.system(size: 11, design: .monospaced)
+    /// Code, endpoints, and API keys.
+    static let code = Font.system(size: 11, design: .monospaced)
 }
 
 private extension NSAppearance {

--- a/apps/rapid-mac/Sources/Rapid/UI/SidebarView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SidebarView.swift
@@ -13,6 +13,21 @@ enum SidebarSection: Hashable {
 /// is the primary column of ``ContentView``'s ``NavigationSplitView``, so
 /// macOS gives us the collapse toggle in the toolbar for free.
 struct SidebarView: View {
+    /// Column metrics. v1.0: narrowed from 190/230/300.
+    ///
+    /// At the old ideal the rail took ~35% of a 640pt window and ~26% of
+    /// a 900pt one for two nav rows and a usually-empty history list —
+    /// which is what made the mostly-blank column read as unfinished.
+    /// A 200pt rail still fits the longest conversation titles at this
+    /// row density while giving the detail pane the width it needs at
+    /// the 640pt floor.
+    ///
+    /// Exposed (rather than inlined at the ``ContentView`` call site) so
+    /// the snapshot harness composes the same column it ships.
+    static let columnMinWidth: CGFloat = 176
+    static let columnIdealWidth: CGFloat = 200
+    static let columnMaxWidth: CGFloat = 260
+
     @Binding var selection: SidebarSection
     /// The chat model — source of the conversation history list + the
     /// active conversation id (for highlighting).
@@ -23,7 +38,7 @@ struct SidebarView: View {
     var onSelectConversation: (UUID) -> Void
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 2) {
+        VStack(alignment: .leading, spacing: 1) {
             row(
                 title: "New Chat",
                 systemImage: "square.and.pencil",
@@ -38,24 +53,26 @@ struct SidebarView: View {
             )
 
             if !chat.conversations.isEmpty {
-                Text("Older")
-                    .font(.caption.weight(.medium))
-                    .foregroundStyle(.secondary)
-                    .padding(.horizontal, 10)
-                    .padding(.top, 12)
-                    .padding(.bottom, 2)
+                // Label only — grouping, ordering, and persistence are
+                // untouched.
+                SectionHeader("Recents")
+                    .padding(.horizontal, RapidTheme.Space.sm)
+                    .padding(.top, RapidTheme.Space.lg)
+                    .padding(.bottom, RapidTheme.Space.xs)
                 ScrollView {
-                    VStack(alignment: .leading, spacing: 2) {
+                    VStack(alignment: .leading, spacing: 1) {
                         ForEach(chat.conversations) { conv in
                             conversationRow(conv)
                         }
                     }
                 }
+                .scrollIndicators(.never)
             }
 
             Spacer(minLength: 0)
         }
-        .padding(8)
+        .padding(.horizontal, RapidTheme.Space.sm)
+        .padding(.vertical, RapidTheme.Space.md)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
     }
 
@@ -63,24 +80,18 @@ struct SidebarView: View {
     /// when it's the open one, with a right-click Delete.
     private func conversationRow(_ conv: ChatConversation) -> some View {
         let isActive = selection == .chat && conv.id == chat.activeConversationID
-        return Button {
+        return SidebarRow(isSelected: isActive) {
             onSelectConversation(conv.id)
-        } label: {
+        } content: {
+            // History rows carry no icon but keep the same leading inset
+            // as the nav rows above, so titles and nav labels align down
+            // one column instead of stepping in and out.
             Text(conv.title)
-                .font(.callout)
+                .font(RapidFont.body)
                 .lineLimit(1)
                 .truncationMode(.tail)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(.horizontal, 10)
-                .padding(.vertical, 6)
-                .background(
-                    RoundedRectangle(cornerRadius: 8, style: .continuous)
-                        .fill(isActive ? RapidTheme.brandAmberTint : Color.clear)
-                )
-                .contentShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+                .padding(.leading, RapidTheme.Layout.iconSlot + RapidTheme.Space.sm)
         }
-        .buttonStyle(.plain)
-        .foregroundStyle(isActive ? RapidTheme.brandAmber : Color.primary)
         .contextMenu {
             Button("Delete", role: .destructive) {
                 chat.deleteConversation(conv.id)
@@ -88,29 +99,66 @@ struct SidebarView: View {
         }
     }
 
-    /// One sidebar row — a borderless button that fills the column and
-    /// paints an amber-tinted rounded highlight when selected (matching
-    /// the design system's selection = amber role).
+    /// One nav row — icon in a fixed-width slot so every label starts on
+    /// the same x, whatever the glyph's natural width.
     private func row(
         title: String,
         systemImage: String,
         isSelected: Bool,
         action: @escaping () -> Void
     ) -> some View {
+        SidebarRow(isSelected: isSelected, action: action) {
+            HStack(spacing: RapidTheme.Space.sm) {
+                Image(systemName: systemImage)
+                    .font(.system(size: 13, weight: .medium))
+                    .frame(width: RapidTheme.Layout.iconSlot, alignment: .center)
+                Text(title)
+                    .font(RapidFont.body)
+                    .lineLimit(1)
+            }
+        }
+    }
+}
+
+/// Shared chrome for every sidebar row: fixed height, one row radius,
+/// amber selection, neutral hover.
+///
+/// The selected treatment is the product's canonical "this is chosen"
+/// signal — amber tint fill plus the deep-amber label. Deep amber (not
+/// raw ``brandPrimary``) because a 13pt label in #EFA23A on the light
+/// tint is under 3:1; the deeper shade of the same hue clears AA while
+/// reading as the same colour.
+private struct SidebarRow<Content: View>: View {
+    let isSelected: Bool
+    let action: () -> Void
+    @ViewBuilder let content: Content
+
+    @State private var hovering = false
+
+    var body: some View {
         Button(action: action) {
-            Label(title, systemImage: systemImage)
-                .font(.body)
+            content
                 .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(.horizontal, 10)
-                .padding(.vertical, 7)
+                .padding(.horizontal, RapidTheme.Space.sm)
+                .frame(height: RapidTheme.ControlHeight.row)
                 .background(
-                    RoundedRectangle(cornerRadius: 8, style: .continuous)
-                        .fill(isSelected ? RapidTheme.brandAmberTint : Color.clear)
+                    RoundedRectangle(cornerRadius: RapidTheme.Radius.row, style: .continuous)
+                        .fill(fill)
                 )
-                .contentShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+                .contentShape(
+                    RoundedRectangle(cornerRadius: RapidTheme.Radius.row, style: .continuous)
+                )
         }
         .buttonStyle(.plain)
-        .foregroundStyle(isSelected ? RapidTheme.brandAmber : Color.primary)
+        .foregroundStyle(isSelected ? RapidTheme.brandPrimaryDeep : Color.primary)
+        .onHover { hovering = $0 }
+        .rapidAnimation(RapidMotion.quick, value: hovering)
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
+    }
+
+    private var fill: Color {
+        if isSelected { return RapidTheme.brandPrimaryTint }
+        return hovering ? RapidTheme.hoverFill : .clear
     }
 }
 

--- a/apps/rapid-mac/Sources/Rapid/UI/SystemPills.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SystemPills.swift
@@ -40,15 +40,10 @@ struct CPUPill: View {
     @ViewBuilder
     private var content: some View {
         let pressure = CPUProbe.Pressure.classify(percent: displayedPercent)
-        HStack(spacing: 5) {
-            Circle()
-                .fill(color(for: pressure))
-                .frame(width: 6, height: 6)
-            Text("CPU \(CPUProbe.formatLabel(percent: displayedPercent))")
-                .font(.system(size: 10, design: .monospaced))
-                .foregroundStyle(.secondary)
-                .lineLimit(1)
-        }
+        MetricChip(
+            label: "CPU \(CPUProbe.formatLabel(percent: displayedPercent))",
+            level: Self.level(for: pressure)
+        )
         .help(Self.tooltip(percent: displayedPercent, pressure: pressure))
         // Collapse the HStack into a single VoiceOver element so the
         // override label below replaces the children's text — without
@@ -80,16 +75,22 @@ struct CPUPill: View {
         }
     }
 
-    static func color(for pressure: CPUProbe.Pressure) -> Color {
+    /// v1.0: pressure now maps onto the shared ``MetricChip.Level``
+    /// rather than raw SwiftUI colours. `.yellow` in particular was a
+    /// system hue that matched nothing else in the product — the
+    /// elevated state is the same amber the rest of the app uses for
+    /// "working".
+    static func level(for pressure: CPUProbe.Pressure) -> MetricChip.Level {
         switch pressure {
-        case .normal:   return .green
-        case .warning:  return .yellow
-        case .critical: return .red
+        case .normal:   return .ok
+        case .warning:  return .warning
+        case .critical: return .critical
         }
     }
 
-    private func color(for pressure: CPUProbe.Pressure) -> Color {
-        Self.color(for: pressure)
+    /// Retained for callers/tests that ask for the resolved colour.
+    static func color(for pressure: CPUProbe.Pressure) -> Color {
+        level(for: pressure).tint
     }
 
     static func tooltip(percent: Double, pressure: CPUProbe.Pressure) -> String {
@@ -134,21 +135,12 @@ struct TokensPerSecondPill: View {
     let messages: [ChatMessage]
 
     var body: some View {
-        HStack(spacing: 5) {
-            Circle()
-                .fill(dotColor)
-                .frame(width: 6, height: 6)
-            // Idle (no resolved value) drops to .tertiary so the chip
-            // visibly recedes from the "live data" CPU/GPU/RAM chips
-            // next to it — same treatment GPUPill uses for its own
-            // "GPU n/a" Intel-Mac fallback. Active rows keep
-            // .secondary to match CPU/GPU/RAM weight.
-            Text(label)
-                .font(.system(size: 10, design: .monospaced))
-                .foregroundStyle(resolvedTokensPerSecond == nil ? .tertiary : .secondary)
-                .lineLimit(1)
-        }
-        .help(tooltip)
+        // Idle (no resolved value) renders at ``MetricChip.Level.none``,
+        // which drops the label to .tertiary and dims the dot — the chip
+        // recedes from the live CPU/GPU/RAM chips beside it instead of
+        // claiming a reading it doesn't have.
+        MetricChip(label: label, level: level)
+            .help(tooltip)
         // See CPUPill — collapse children to suppress double-read.
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(accessibilityLabel)
@@ -214,12 +206,12 @@ struct TokensPerSecondPill: View {
         return "\(resolved.isEstimated ? "~" : "")\(rounded) tok/s"
     }
 
-    private var dotColor: Color {
+    private var level: MetricChip.Level {
         switch pressure {
-        case .fast:     return .green
-        case .moderate: return .yellow
-        case .slow:     return .red
-        case .unknown:  return Color.secondary.opacity(0.4)
+        case .fast:     return .ok
+        case .moderate: return .warning
+        case .slow:     return .critical
+        case .unknown:  return .noData
         }
     }
 
@@ -285,42 +277,32 @@ struct GPUPill: View {
     private var content: some View {
         if let snap = snapshot {
             let pressure = GPUProbe.Pressure.classify(percent: snap.percent)
-            HStack(spacing: 5) {
-                Circle()
-                    .fill(color(for: pressure))
-                    .frame(width: 6, height: 6)
-                Text("GPU \(GPUProbe.formatLabel(percent: snap.percent))")
-                    .font(.system(size: 10, design: .monospaced))
-                    .foregroundStyle(.secondary)
-                    .lineLimit(1)
-            }
+            MetricChip(
+                label: "GPU \(GPUProbe.formatLabel(percent: snap.percent))",
+                level: Self.level(for: pressure)
+            )
             .help(Self.tooltip(percent: snap.percent, pressure: pressure))
             // See CPUPill — collapse children to suppress double-read.
             .accessibilityElement(children: .ignore)
             .accessibilityLabel("GPU \(Int(snap.percent.rounded())) percent")
         } else {
-            HStack(spacing: 5) {
-                Circle()
-                    .fill(Color.secondary.opacity(0.4))
-                    .frame(width: 6, height: 6)
-                Text("GPU n/a")
-                    .font(.system(size: 10, design: .monospaced))
-                    .foregroundStyle(.tertiary)
-            }
-            .help("GPU probe unavailable — Intel Macs and sandboxed apps don't expose AGXAccelerator utilisation.")
+            MetricChip(label: "GPU n/a", level: .noData)
+                .help("GPU probe unavailable — Intel Macs and sandboxed apps don't expose AGXAccelerator utilisation.")
         }
     }
 
-    static func color(for pressure: GPUProbe.Pressure) -> Color {
+    /// See ``CPUPill.level(for:)`` — same mapping, same reasoning.
+    static func level(for pressure: GPUProbe.Pressure) -> MetricChip.Level {
         switch pressure {
-        case .normal:   return .green
-        case .warning:  return .yellow
-        case .critical: return .red
+        case .normal:   return .ok
+        case .warning:  return .warning
+        case .critical: return .critical
         }
     }
 
-    private func color(for pressure: GPUProbe.Pressure) -> Color {
-        Self.color(for: pressure)
+    /// Retained for callers/tests that ask for the resolved colour.
+    static func color(for pressure: GPUProbe.Pressure) -> Color {
+        level(for: pressure).tint
     }
 
     @MainActor


### PR DESCRIPTION
## Summary
- Establish a semantic Rapid-MLX desktop visual system centered on amber #EFA23A, with steel blue reserved for secondary utility actions.
- Refine Chat, Launch, sidebar, model picker, benchmark, and shared components across Light and Dark appearances.
- Fix model catalog banner parsing so startup output cannot become a phantom “Loading” model.

## Verification
- `swift build --package-path apps/rapid-mac`
- `SKIP_SIDECAR=1 bash apps/rapid-mac/scripts/build.sh`
- Light/Dark and compact DevSnapshot review

## Known gaps
- No Swift test target exists in the package.
- Interaction-only states such as hover/copy-success and Speed auto-enable were not covered by static snapshots.