### PR TITLE
fix(cache): persist long-context boundaries on shutdown

### DIFF
--- a/tests/test_prefix_cache_persistence.py
+++ b/tests/test_prefix_cache_persistence.py
@@ -1497,7 +1497,7 @@ def test_deadline_save_skips_oversized_prefix_and_tries_smaller(tmp_path):
     cache.store([1], make_kvcache(num_tokens=1))
     cache.store(list(range(100)), make_kvcache(num_tokens=100, fill=2.0))
     entry_sizes = sorted(entry.memory_bytes for entry in cache._entries.values())
-    threshold = sum(entry_sizes) / 2 / (150 * 1024 * 1024)
+    threshold = sum(entry_sizes) / 2 / (500 * 1024 * 1024)
 
     assert (
         cache.save_to_disk(
@@ -1869,7 +1869,7 @@ def test_save_to_disk_predicts_entry_zero_from_bootstrap_floor(tmp_path):
     """Codex PR #667 round 3 BLOCKING-1.
 
     Entry 0 must receive a non-zero forward-looking ``predicted_sec``
-    derived from the 150 MB/s bootstrap floor — round 2 passed 0 here
+    derived from the 500 MB/s bootstrap floor — round 2 passed 0 here
     and let a catastrophically large first entry straddle the SIGTERM
     grace deadline, leaving ``cache_dir.new/`` orphaned. The estimate
     scales with ``entry.memory_bytes`` so a too-large entry-0 trips
@@ -1887,9 +1887,11 @@ def test_save_to_disk_predicts_entry_zero_from_bootstrap_floor(tmp_path):
 
     cache.save_to_disk(str(cache_dir), should_abort=predicate)
     assert len(seen_predicted) == 1
-    assert seen_predicted[0] > 0, (
+    entry = next(iter(cache._entries.values()))
+    expected = entry.memory_bytes / (500 * 1024 * 1024)
+    assert seen_predicted[0] == pytest.approx(expected), (
         f"entry 0 must receive a non-zero predicted_sec (bootstrap "
-        f"150 MB/s × entry size) — round 2 used 0 here and let huge "
+        f"500 MB/s × entry size) — round 2 used 0 here and let huge "
         f"entries straddle the deadline (codex round 3 BLOCKING-1). "
         f"Got {seen_predicted[0]}"
     )

--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -2660,21 +2660,18 @@ class MemoryAwarePrefixCache:
         # orphaned; this is the bug the deadline gate exists to prevent).
         #
         # Bootstrap floor for entry 0 (no observed sample yet) is
-        # 150 MB/s — calibrated so:
-        #   - typical Gemma 4 26B entry (~250 MB) predicts ~1.7 s,
-        #     comfortably fitting the 3.1 s safe budget (3.5 s budget −
-        #     0.4 s commit headroom);
-        #   - genuinely oversized entry (~600 MB+) predicts >4 s and
-        #     correctly trips before write starts — would straddle
-        #     deadline either way.
+        # 500 MB/s. A real DeepSeek-V4 120k restart benchmark wrote three
+        # entries / 2,397 MB in 0.9 s (~2.66 GB/s), while the former 150 MB/s
+        # estimate predicted ~16 s and skipped every reusable boundary under
+        # the default 3.5 s shutdown budget. 500 MB/s retains >5x headroom
+        # against that measured path while allowing one 0.8-1.1 GB long-context
+        # boundary to seed the observed-throughput estimator.
         # Round 1 used 50 MB/s and over-predicted typical entries
         # (codex round 2 BLOCKING-1). Round 2 used 0 and let huge
         # entries straddle the deadline (codex round 3 BLOCKING-1).
-        # 150 MB/s is the goldilocks middle ground: 3× round 1, gives
-        # real-world observed throughput (~875 MB/s during the
-        # original incident) ~6× safety margin while still catching
-        # genuinely-too-large entries.
-        _BOOTSTRAP_BYTES_PER_SEC = 150 * _BYTES_PER_MB
+        # Entries above ~1.55 GB still predict beyond the 3.1 s safe window
+        # and are skipped before their uninterruptible write begins.
+        _BOOTSTRAP_BYTES_PER_SEC = 500 * _BYTES_PER_MB
         # Support BOTH zero-arg and one-arg ``should_abort`` predicates
         # at the per-entry layer. The new contract is
         # ``Callable[[float], bool]`` (forward-looking) but external


### PR DESCRIPTION
## Summary

Raise the first-entry persistence throughput bootstrap from 150 MB/s to 500 MB/s so reusable long-context boundaries can seed the measured-throughput estimator within the default 3.5-second shutdown budget.

## Root cause

The conservative 150 MB/s estimate predicted roughly 16 seconds for a real DeepSeek-V4 120K cache set and skipped every useful boundary, even though the same 2,397 MB set persisted in 0.9 seconds. Restarts therefore lost deep boundaries and paid cold prefill again.

The 500 MB/s bootstrap remains more than 5x below the measured path. Entries above roughly 1.55 GB are still rejected before an uninterruptible write can cross the 3.1-second safe window.

## Validation

- ruff: clean
- focused persistence tests: 84 passed
- full suite: 15,550 passed; 135 skipped; 18 deselected; 6 xfailed; 1 xpassed
- 12 live-server failures were expected with no service on 127.0.0.1:8000 (10 Hermes integration, 2 event-loop)
- real DeepSeek-V4 120K restart test under the default 3.5-second budget:
  - saved 3/3 entries, 2,397 MB, in 1.8 seconds
  - fresh process loaded all 3 entries
  - cache hit 120,004 / 120,014 tokens
  - restart TTFT 2.05 seconds
  - exact output CACHE_RESTART_OK, no reasoning leak
