### PR TITLE
fix(rapid-mac): autosize composer and respect transcript scroll intent

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
@@ -267,6 +267,14 @@ struct ChatView: View {
             // tip; streamed frame changes then keep following from there.
             .onAppear { isPinnedToBottom = true }
             .onChange(of: messages.count) { _, _ in isPinnedToBottom = true }
+            // Switching conversations is navigation to a DIFFERENT tip, but it
+            // need not change `messages.count` — two conversations can have the
+            // same number of turns, and then the count-keyed reset above never
+            // fires. Without this, opening B inherits A's paused state and lands
+            // at A's old scroll offset instead of B's latest message.
+            .onChange(of: viewModel.activeConversationID) { _, _ in
+                isPinnedToBottom = true
+            }
         }
     }
 

--- a/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
@@ -199,8 +199,31 @@ struct ChatView: View {
 
     private let contentMaxWidth: CGFloat = RapidTheme.Layout.contentMaxWidth
     private let bottomSentinelID = "rapid-bottom-sentinel"
+    private let transcriptSpace = "rapid-transcript"
+    /// How far above the bottom the user may sit and still be treated as
+    /// "following the stream". One line of body text — enough to absorb
+    /// sub-pixel drift and the trailing-edge animation, small enough that
+    /// a deliberate scroll up immediately releases the pin.
+    private let bottomPinSlack: CGFloat = 24
+
+    /// Bottom edge of the transcript content in the scroll view's own
+    /// coordinate space, and the scroll view's visible height. Together
+    /// they give the distance from the bottom without polling.
+    @State private var contentBottom: CGFloat = 0
+    @State private var viewportHeight: CGFloat = 0
 
     private var messages: [ChatMessage] { viewModel.messages }
+
+    /// True while the user is parked at (or within ``bottomPinSlack`` of)
+    /// the trailing edge. Only then may streaming deltas move the scroll
+    /// position — otherwise reading back through the transcript mid-reply
+    /// would be yanked to the bottom on every token.
+    private var isPinnedToBottom: Bool {
+        // Before the first layout pass we have no measurements; default to
+        // pinned so a fresh transcript still follows the stream.
+        guard viewportHeight > 0 else { return true }
+        return contentBottom - viewportHeight <= bottomPinSlack
+    }
 
     var body: some View {
         VStack(spacing: 0) {
@@ -248,7 +271,26 @@ struct ChatView: View {
             ScrollViewReader { proxy in
                 ScrollView {
                     transcriptRows
+                        .background(
+                            GeometryReader { geo in
+                                Color.clear.preference(
+                                    key: ContentBottomKey.self,
+                                    value: geo.frame(in: .named(transcriptSpace)).maxY
+                                )
+                            }
+                        )
                 }
+                .coordinateSpace(name: transcriptSpace)
+                .background(
+                    GeometryReader { geo in
+                        Color.clear.preference(
+                            key: ViewportHeightKey.self,
+                            value: geo.size.height
+                        )
+                    }
+                )
+                .onPreferenceChange(ContentBottomKey.self) { contentBottom = $0 }
+                .onPreferenceChange(ViewportHeightKey.self) { viewportHeight = $0 }
                 // This branch mounts fresh the moment the transcript goes
                 // from empty to populated — selecting a long saved
                 // conversation, or launching straight into one. The
@@ -258,8 +300,18 @@ struct ChatView: View {
                 // appear (no animation: this is initial positioning, not a
                 // scroll the user should see move).
                 .onAppear { scrollToBottom(proxy, animated: false) }
-                .onChange(of: messages.last?.content) { _, _ in scrollToBottom(proxy) }
-                .onChange(of: messages.last?.reasoning) { _, _ in scrollToBottom(proxy) }
+                // Streaming deltas only move the view while the user is
+                // parked at the trailing edge. Scrolling up to re-read
+                // earlier text releases the pin, so the transcript stays
+                // put (and stays selectable) until the user scrolls back
+                // down. A brand-new message is a deliberate action by the
+                // user, so it always re-anchors.
+                .onChange(of: messages.last?.content) { _, _ in
+                    if isPinnedToBottom { scrollToBottom(proxy) }
+                }
+                .onChange(of: messages.last?.reasoning) { _, _ in
+                    if isPinnedToBottom { scrollToBottom(proxy) }
+                }
                 .onChange(of: messages.count) { _, _ in scrollToBottom(proxy) }
             }
         }
@@ -735,24 +787,24 @@ private struct ComposeField: View {
         // Top-aligned (NSTextView default), so the caret/placeholder sit
         // at the top-left and the field hugs one line by default.
         ZStack(alignment: .topLeading) {
-            // ``AutosizingTextView`` (the NSTextView subclass behind
-            // ``ComposeTextEditor``) reports its content's measured
-            // height as intrinsic size, so SwiftUI's
-            // ``.frame(minHeight: 28, maxHeight: 160)`` on the parent
-            // becomes a true elastic range: 28 pt for an empty draft
-            // (hugging the placeholder) → grows one line at a time
-            // → caps at 160 pt with internal scrolling beyond. The
-            // ghost-Text autosize trick that this view used to need
-            // was a no-op as long as the stock NSTextView returned
-            // ``noIntrinsicMetric`` (it always grew to the cap), so
-            // the trick is gone now.
+            // ``ComposeTextEditor`` reports the NSTextView's measured
+            // content height on every edit; we clamp it into
+            // ``[minHeight, maxHeight]`` and apply it below. Beyond the
+            // cap the editor scrolls internally (it is hosted in an
+            // NSScrollView) rather than pushing the window around.
             ComposeTextEditor(
                 text: $text,
                 focusToken: focusToken,
                 isStreaming: isStreaming,
                 onSubmit: onSubmit,
                 onCancel: onCancel,
-                onRecallLastUser: onRecallLastUser
+                onRecallLastUser: onRecallLastUser,
+                onMeasuredHeight: { measured in
+                    let clamped = min(max(measured, minHeight), maxHeight)
+                    if abs(clamped - contentHeight) > 0.5 {
+                        contentHeight = clamped
+                    }
+                }
             )
             if text.isEmpty {
                 Text(placeholder)
@@ -770,31 +822,55 @@ private struct ComposeField: View {
     }
 }
 
-/// ``NSTextView`` subclass that reports its content's measured height
-/// as ``intrinsicContentSize``. The stock ``NSTextView`` returns
-/// ``noIntrinsicMetric`` for both axes, which lets SwiftUI hand it the
-/// whole vertical budget of its parent — so a parent ``.frame(maxHeight:
-/// 160)`` becomes a *fixed* 160 pt box rather than a 28→160 pt elastic
-/// pill. By overriding ``intrinsicContentSize`` to ``usedRect`` +
-/// inset, SwiftUI's ``minHeight: 28, maxHeight: 160`` clamp becomes a
-/// real elastic range that hugs single-line content and grows to the
-/// cap as the user types. ``didChangeText`` invalidates so each edit
-/// re-asks SwiftUI to re-measure.
+/// ``NSTextView`` subclass that measures its own laid-out content and
+/// reports the height back to SwiftUI. The stock ``NSTextView`` returns
+/// ``noIntrinsicMetric`` for both axes, so a SwiftUI parent has no way
+/// to size the field to its text; ``ComposeField`` therefore drives the
+/// height explicitly from ``onMeasuredHeight``. ``didChangeText`` and
+/// width changes both re-measure, so wrapping caused by resizing the
+/// window grows the field just like typing does.
 final class AutosizingTextView: NSTextView {
-    override var intrinsicContentSize: NSSize {
-        guard let lm = layoutManager, let tc = textContainer else {
-            return NSSize(width: NSView.noIntrinsicMetric, height: 28)
-        }
+    /// Called with the measured content height whenever the text or the
+    /// view's width changes. The receiver owns the clamping; this only
+    /// reports what the layout manager actually used.
+    var onMeasuredHeight: ((CGFloat) -> Void)?
+
+    /// Height of the laid-out text plus the editor's vertical insets.
+    var measuredHeight: CGFloat {
+        guard let lm = layoutManager, let tc = textContainer else { return 28 }
         lm.ensureLayout(for: tc)
-        let used = lm.usedRect(for: tc)
-        return NSSize(
-            width: NSView.noIntrinsicMetric,
-            height: ceil(used.height) + textContainerInset.height * 2
-        )
+        return ceil(lm.usedRect(for: tc).height) + textContainerInset.height * 2
     }
+
+    override var intrinsicContentSize: NSSize {
+        NSSize(width: NSView.noIntrinsicMetric, height: measuredHeight)
+    }
+
     override func didChangeText() {
         super.didChangeText()
+        remeasure()
+    }
+
+    override func setFrameSize(_ newSize: NSSize) {
+        let widthChanged = abs(newSize.width - frame.width) > 0.5
+        super.setFrameSize(newSize)
+        // Re-wrap on a width change means a different line count, so the
+        // height the parent is holding is now stale.
+        if widthChanged { remeasure() }
+    }
+
+    /// Re-measures and republishes the content height. Call after any
+    /// programmatic edit — assigning ``string`` directly does not route
+    /// through ``didChangeText``.
+    func remeasure() {
         invalidateIntrinsicContentSize()
+        guard let onMeasuredHeight else { return }
+        let height = measuredHeight
+        // Both callers can run inside a layout or view-update pass;
+        // publishing SwiftUI state from there would mutate the view graph
+        // mid-update. Hop to the next runloop turn so the write lands in
+        // a clean cycle.
+        DispatchQueue.main.async { onMeasuredHeight(height) }
     }
 
     /// Bug 3-A residual P2: AppleScript / cliclick / VoiceOver target
@@ -830,12 +906,14 @@ private struct ComposeTextEditor: NSViewRepresentable {
     var onSubmit: () -> Void
     var onCancel: () -> Void
     var onRecallLastUser: () -> String?
+    /// Reports the editor's laid-out content height so ``ComposeField``
+    /// can size the field to the draft.
+    var onMeasuredHeight: (CGFloat) -> Void
 
-    func makeNSView(context: Context) -> NSTextView {
+    func makeNSView(context: Context) -> NSScrollView {
         let tv = AutosizingTextView()
         tv.delegate = context.coordinator
         tv.isRichText = false
-        tv.font = .systemFont(ofSize: NSFont.systemFontSize)
         tv.allowsUndo = true
         tv.drawsBackground = false
         tv.backgroundColor = .clear
@@ -856,23 +934,43 @@ private struct ComposeTextEditor: NSViewRepresentable {
         // is what lets us measure the true content height below.
         tv.isVerticallyResizable = true
         tv.isHorizontallyResizable = false
+        tv.autoresizingMask = [.width]
         tv.textContainer?.widthTracksTextView = true
         tv.textContainer?.heightTracksTextView = false
         tv.textContainer?.containerSize = NSSize(
             width: 0, height: CGFloat.greatestFiniteMagnitude
         )
+        tv.onMeasuredHeight = onMeasuredHeight
         // Bug 3-A residual P2: NSTextView already advertises role
         // ``.textArea`` by default, but with no label / identifier
         // AppleScript and cliclick can't tell which text area is the
         // chat compose vs the system-prompt editor or search bar.
         AutosizingTextView.applyComposeAccessibility(tv)
-        return tv
+
+        // Hosting the editor in a scroll view is what makes the height
+        // cap usable: past ``ComposeField.maxHeight`` the draft scrolls
+        // inside the field (and the caret stays visible) instead of
+        // being clipped out of reach.
+        let scroll = NSScrollView()
+        scroll.documentView = tv
+        scroll.hasVerticalScroller = false
+        scroll.hasHorizontalScroller = false
+        scroll.drawsBackground = false
+        scroll.borderType = .noBorder
+        scroll.autohidesScrollers = true
+        return scroll
     }
 
-    func updateNSView(_ view: NSTextView, context: Context) {
+    func updateNSView(_ scroll: NSScrollView, context: Context) {
+        guard let view = scroll.documentView as? AutosizingTextView else { return }
         if view.string != text {
             view.string = text
+            // A programmatic assignment does not fire ``didChangeText``,
+            // so the parent would keep the height of the previous draft
+            // (e.g. after Send clears it, or after Up-arrow recall).
+            view.remeasure()
         }
+        view.onMeasuredHeight = onMeasuredHeight
         context.coordinator.onSubmit = onSubmit
         context.coordinator.onCancel = onCancel
         context.coordinator.isStreaming = isStreaming
@@ -983,6 +1081,10 @@ private struct ComposeTextEditor: NSViewRepresentable {
                 else { return false }
                 textView.string = recalled
                 text.wrappedValue = recalled
+                // Direct ``string`` assignment skips ``didChangeText``, so
+                // the recalled draft would render at the old (one-line)
+                // height until the next keystroke.
+                (textView as? AutosizingTextView)?.remeasure()
                 // Park the caret at the END so the user can
                 // immediately append or hit ⌘A → retype. Anchoring
                 // at start would force a ⌘→ before the first edit.

--- a/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
@@ -198,32 +198,17 @@ struct ChatView: View {
     @State private var showBenchmark = false
 
     private let contentMaxWidth: CGFloat = RapidTheme.Layout.contentMaxWidth
-    private let bottomSentinelID = "rapid-bottom-sentinel"
-    private let transcriptSpace = "rapid-transcript"
-    /// How far above the bottom the user may sit and still be treated as
-    /// "following the stream". One line of body text — enough to absorb
-    /// sub-pixel drift and the trailing-edge animation, small enough that
-    /// a deliberate scroll up immediately releases the pin.
-    private let bottomPinSlack: CGFloat = 24
+    /// A live user gesture must reach the actual trailing edge before
+    /// stream following resumes. The AppKit probe then owns following
+    /// through every subsequent SwiftUI layout pass.
+    private let bottomResumeSlack: CGFloat = 2
 
-    /// Bottom edge of the transcript content in the scroll view's own
-    /// coordinate space, and the scroll view's visible height. Together
-    /// they give the distance from the bottom without polling.
-    @State private var contentBottom: CGFloat = 0
-    @State private var viewportHeight: CGFloat = 0
+    /// Updated directly from the hosting NSScrollView. A SwiftUI geometry
+    /// preference arrives after the scroll event, which leaves a window
+    /// where the next streamed token can still yank the reader downward.
+    @State private var isPinnedToBottom = true
 
     private var messages: [ChatMessage] { viewModel.messages }
-
-    /// True while the user is parked at (or within ``bottomPinSlack`` of)
-    /// the trailing edge. Only then may streaming deltas move the scroll
-    /// position — otherwise reading back through the transcript mid-reply
-    /// would be yanked to the bottom on every token.
-    private var isPinnedToBottom: Bool {
-        // Before the first layout pass we have no measurements; default to
-        // pinned so a fresh transcript still follows the stream.
-        guard viewportHeight > 0 else { return true }
-        return contentBottom - viewportHeight <= bottomPinSlack
-    }
 
     var body: some View {
         VStack(spacing: 0) {
@@ -268,52 +253,20 @@ struct ChatView: View {
             emptyState
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
         } else {
-            ScrollViewReader { proxy in
-                ScrollView {
-                    transcriptRows
-                        .background(
-                            GeometryReader { geo in
-                                Color.clear.preference(
-                                    key: ContentBottomKey.self,
-                                    value: geo.frame(in: .named(transcriptSpace)).maxY
-                                )
-                            }
+            ScrollView {
+                transcriptRows
+                    .background(
+                        TranscriptScrollPositionProbe(
+                            isPinnedToBottom: $isPinnedToBottom,
+                            bottomResumeSlack: bottomResumeSlack
                         )
-                }
-                .coordinateSpace(name: transcriptSpace)
-                .background(
-                    GeometryReader { geo in
-                        Color.clear.preference(
-                            key: ViewportHeightKey.self,
-                            value: geo.size.height
-                        )
-                    }
-                )
-                .onPreferenceChange(ContentBottomKey.self) { contentBottom = $0 }
-                .onPreferenceChange(ViewportHeightKey.self) { viewportHeight = $0 }
-                // This branch mounts fresh the moment the transcript goes
-                // from empty to populated — selecting a long saved
-                // conversation, or launching straight into one. The
-                // `messages.count` change that mounts it predates the
-                // `.onChange` handlers below, so a fresh ScrollView would
-                // open at the OLDEST message. Anchor to the latest on
-                // appear (no animation: this is initial positioning, not a
-                // scroll the user should see move).
-                .onAppear { scrollToBottom(proxy, animated: false) }
-                // Streaming deltas only move the view while the user is
-                // parked at the trailing edge. Scrolling up to re-read
-                // earlier text releases the pin, so the transcript stays
-                // put (and stays selectable) until the user scrolls back
-                // down. A brand-new message is a deliberate action by the
-                // user, so it always re-anchors.
-                .onChange(of: messages.last?.content) { _, _ in
-                    if isPinnedToBottom { scrollToBottom(proxy) }
-                }
-                .onChange(of: messages.last?.reasoning) { _, _ in
-                    if isPinnedToBottom { scrollToBottom(proxy) }
-                }
-                .onChange(of: messages.count) { _, _ in scrollToBottom(proxy) }
+                    )
             }
+            // The probe is the single owner of transcript positioning.
+            // A new message is deliberate navigation to the conversation
+            // tip; streamed frame changes then keep following from there.
+            .onAppear { isPinnedToBottom = true }
+            .onChange(of: messages.count) { _, _ in isPinnedToBottom = true }
         }
     }
 
@@ -335,20 +288,9 @@ struct ChatView: View {
             }
             Color.clear
                 .frame(height: 1)
-                .id(bottomSentinelID)
         }
         .padding(.horizontal, RapidTheme.Space.xl)
         .padding(.vertical, RapidTheme.Space.xl)
-    }
-
-    private func scrollToBottom(_ proxy: ScrollViewProxy, animated: Bool = true) {
-        guard animated else {
-            proxy.scrollTo(bottomSentinelID, anchor: .bottom)
-            return
-        }
-        withAnimation(.easeOut(duration: 0.15)) {
-            proxy.scrollTo(bottomSentinelID, anchor: .bottom)
-        }
     }
 
     private var emptyState: some View {
@@ -1235,25 +1177,6 @@ extension MarkdownUI.Theme {
                 .markdownMargin(top: 8, bottom: 8)
         }
 }
-/// LazyVStack's bottom edge in the transcript's named coord space.
-/// Streams into ``ChatView`` so it can derive "is the user at the
-/// bottom?" without polling.
-private struct ContentBottomKey: PreferenceKey {
-    static let defaultValue: CGFloat = 0
-    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
-        value = nextValue()
-    }
-}
-
-/// ScrollView's visible height. Paired with ``ContentBottomKey`` to
-/// compute the bottom-distance dead-band.
-private struct ViewportHeightKey: PreferenceKey {
-    static let defaultValue: CGFloat = 0
-    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
-        value = nextValue()
-    }
-}
-
 /// Code block with a hover-revealed Copy button. ChatGPT Desktop
 /// hangs the copy affordance off the top-right; we mirror that and
 /// fade in on hover so the button doesn't distract during reading.

--- a/apps/rapid-mac/Sources/Rapid/UI/TranscriptScrollPositionProbe.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/TranscriptScrollPositionProbe.swift
@@ -1,0 +1,184 @@
+import AppKit
+import SwiftUI
+
+/// Owns transcript follow-mode at the AppKit layer. User live-scroll gestures
+/// pause following until they return to the bottom; document frame changes
+/// keep a followed transcript pinned through every stage of SwiftUI layout.
+struct TranscriptScrollPositionProbe: NSViewRepresentable {
+    @Binding var isPinnedToBottom: Bool
+    let bottomResumeSlack: CGFloat
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(
+            isPinnedToBottom: $isPinnedToBottom,
+            bottomResumeSlack: bottomResumeSlack
+        )
+    }
+
+    func makeNSView(context: Context) -> NSView {
+        let probe = NSView(frame: .zero)
+        DispatchQueue.main.async {
+            context.coordinator.attach(to: probe)
+        }
+        return probe
+    }
+
+    func updateNSView(_ probe: NSView, context: Context) {
+        context.coordinator.update(
+            isPinnedToBottom: $isPinnedToBottom,
+            bottomResumeSlack: bottomResumeSlack
+        )
+        context.coordinator.attach(to: probe)
+    }
+
+    static func dismantleNSView(_ nsView: NSView, coordinator: Coordinator) {
+        coordinator.detach()
+    }
+
+    @MainActor
+    final class Coordinator: NSObject {
+        private var isPinnedToBottom: Binding<Bool>
+        private var bottomResumeSlack: CGFloat
+        private weak var scrollView: NSScrollView?
+        private weak var documentView: NSView?
+        private var isLiveScrolling = false
+
+        init(
+            isPinnedToBottom: Binding<Bool>,
+            bottomResumeSlack: CGFloat
+        ) {
+            self.isPinnedToBottom = isPinnedToBottom
+            self.bottomResumeSlack = bottomResumeSlack
+        }
+
+        func update(
+            isPinnedToBottom: Binding<Bool>,
+            bottomResumeSlack: CGFloat
+        ) {
+            self.isPinnedToBottom = isPinnedToBottom
+            self.bottomResumeSlack = bottomResumeSlack
+        }
+
+        func attach(to probe: NSView) {
+            guard let enclosingScrollView = probe.enclosingScrollView else { return }
+            if enclosingScrollView !== scrollView {
+                detach()
+                scrollView = enclosingScrollView
+                observeScrollView(enclosingScrollView)
+            }
+            observeDocumentViewIfNeeded()
+            if isPinnedToBottom.wrappedValue { scrollToBottom() }
+        }
+
+        func detach() {
+            NotificationCenter.default.removeObserver(self)
+            scrollView = nil
+            documentView = nil
+            isLiveScrolling = false
+        }
+
+        @objc private func liveScrollWillStart(_ notification: Notification) {
+            isLiveScrolling = true
+            // User intent wins before the first wheel/trackpad delta, so a
+            // simultaneous streamed layout cannot pull the gesture back.
+            setPinned(false)
+        }
+
+        @objc private func liveScrollDidEnd(_ notification: Notification) {
+            isLiveScrolling = false
+            if isAtBottom { setPinned(true) }
+        }
+
+        @objc private func boundsDidChange(_ notification: Notification) {
+            guard isLiveScrolling else { return }
+            setPinned(isAtBottom)
+        }
+
+        @objc private func documentFrameDidChange(_ notification: Notification) {
+            guard isPinnedToBottom.wrappedValue else { return }
+            scrollToBottom()
+            DispatchQueue.main.async { [weak self] in
+                guard let self, self.isPinnedToBottom.wrappedValue else { return }
+                self.scrollToBottom()
+            }
+        }
+
+        private func observeScrollView(_ scrollView: NSScrollView) {
+            scrollView.contentView.postsBoundsChangedNotifications = true
+            NotificationCenter.default.addObserver(
+                self,
+                selector: #selector(boundsDidChange(_:)),
+                name: NSView.boundsDidChangeNotification,
+                object: scrollView.contentView
+            )
+            NotificationCenter.default.addObserver(
+                self,
+                selector: #selector(liveScrollWillStart(_:)),
+                name: NSScrollView.willStartLiveScrollNotification,
+                object: scrollView
+            )
+            NotificationCenter.default.addObserver(
+                self,
+                selector: #selector(liveScrollDidEnd(_:)),
+                name: NSScrollView.didEndLiveScrollNotification,
+                object: scrollView
+            )
+        }
+
+        private func observeDocumentViewIfNeeded() {
+            guard let nextDocumentView = scrollView?.documentView else { return }
+            guard nextDocumentView !== documentView else { return }
+
+            if let documentView {
+                NotificationCenter.default.removeObserver(
+                    self,
+                    name: NSView.frameDidChangeNotification,
+                    object: documentView
+                )
+            }
+            documentView = nextDocumentView
+            nextDocumentView.postsFrameChangedNotifications = true
+            NotificationCenter.default.addObserver(
+                self,
+                selector: #selector(documentFrameDidChange(_:)),
+                name: NSView.frameDidChangeNotification,
+                object: nextDocumentView
+            )
+        }
+
+        private var isAtBottom: Bool {
+            guard let scrollView, let documentView else { return false }
+            let clipBounds = scrollView.contentView.bounds
+            let distance: CGFloat
+            if documentView.isFlipped {
+                distance = documentView.bounds.maxY - clipBounds.maxY
+            } else {
+                distance = clipBounds.minY - documentView.bounds.minY
+            }
+            return distance <= bottomResumeSlack
+        }
+
+        private func scrollToBottom() {
+            guard let scrollView, let documentView else { return }
+            let clipView = scrollView.contentView
+            let targetY: CGFloat
+            if documentView.isFlipped {
+                targetY = max(
+                    documentView.bounds.minY,
+                    documentView.bounds.maxY - clipView.bounds.height
+                )
+            } else {
+                targetY = documentView.bounds.minY
+            }
+            clipView.scroll(to: NSPoint(x: clipView.bounds.minX, y: targetY))
+            scrollView.reflectScrolledClipView(clipView)
+        }
+
+        private func setPinned(_ pinned: Bool) {
+            if pinned != isPinnedToBottom.wrappedValue {
+                isPinnedToBottom.wrappedValue = pinned
+            }
+            if pinned { scrollToBottom() }
+        }
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/UI/TranscriptScrollPositionProbe.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/TranscriptScrollPositionProbe.swift
@@ -90,16 +90,34 @@ struct TranscriptScrollPositionProbe: NSViewRepresentable {
         }
 
         @objc private func boundsDidChange(_ notification: Notification) {
-            guard isLiveScrolling else { return }
-            // Mid-gesture this may only RELEASE the pin, never restore it.
-            // ``isAtBottom`` is a slack comparison, so a gentle scroll whose
-            // per-event delta is within ``bottomResumeSlack`` still reads as
-            // "at the bottom" — re-pinning on it would let the next streamed
-            // frame yank the user straight back, which is precisely the
-            // hijacking this probe exists to stop, and the user could never
-            // escape by scrolling softly. Resuming is decided once the user
-            // has settled, in ``liveScrollDidEnd``.
-            if !isAtBottom { setPinned(false) }
+            // Our own ``scrollToBottom`` emits this too; it is not user intent.
+            guard !isProgrammaticScroll else { return }
+            if !isAtBottom {
+                // Any move away from the bottom releases the pin — whether or
+                // not AppKit bracketed it. A legacy mouse wheel can post bounds
+                // changes with NO willStartLiveScroll/didEndLiveScroll pair, and
+                // gating release on ``isLiveScrolling`` meant such a scroll never
+                // paused following: the next streamed frame yanked the reader
+                // straight back to the bottom.
+                setPinned(false)
+            } else if !isLiveScrolling {
+                // Back at the bottom on an UNBRACKETED scroll: no
+                // ``didEndLiveScroll`` is coming, so resume here. Deliberately
+                // not done mid-gesture — ``isAtBottom`` is a slack comparison,
+                // so re-pinning during a gesture would let a sub-slack gentle
+                // scroll be dragged back on every event.
+                setPinned(true)
+            }
+        }
+
+        /// The viewport itself resized (the composer grew from one line to
+        /// several, the window was resized). The document frame is unchanged,
+        /// so ``documentFrameDidChange`` never fires — yet a shorter viewport
+        /// means the newest content has slid out of sight while we still claim
+        /// to be following it. Re-anchor.
+        @objc private func clipFrameDidChange(_ notification: Notification) {
+            guard isPinnedToBottom.wrappedValue else { return }
+            scrollToBottom()
         }
 
         @objc private func documentFrameDidChange(_ notification: Notification) {
@@ -113,6 +131,13 @@ struct TranscriptScrollPositionProbe: NSViewRepresentable {
 
         private func observeScrollView(_ scrollView: NSScrollView) {
             scrollView.contentView.postsBoundsChangedNotifications = true
+            scrollView.contentView.postsFrameChangedNotifications = true
+            NotificationCenter.default.addObserver(
+                self,
+                selector: #selector(clipFrameDidChange(_:)),
+                name: NSView.frameDidChangeNotification,
+                object: scrollView.contentView
+            )
             NotificationCenter.default.addObserver(
                 self,
                 selector: #selector(boundsDidChange(_:)),
@@ -166,8 +191,14 @@ struct TranscriptScrollPositionProbe: NSViewRepresentable {
             return distance <= bottomResumeSlack
         }
 
+        /// True while ``scrollToBottom`` is driving the clip view, so the
+        /// bounds notification it emits is not mistaken for the user moving.
+        private var isProgrammaticScroll = false
+
         private func scrollToBottom() {
             guard let scrollView, let documentView else { return }
+            isProgrammaticScroll = true
+            defer { isProgrammaticScroll = false }
             let clipView = scrollView.contentView
             let targetY: CGFloat
             if documentView.isFlipped {

--- a/apps/rapid-mac/Sources/Rapid/UI/TranscriptScrollPositionProbe.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/TranscriptScrollPositionProbe.swift
@@ -91,7 +91,15 @@ struct TranscriptScrollPositionProbe: NSViewRepresentable {
 
         @objc private func boundsDidChange(_ notification: Notification) {
             guard isLiveScrolling else { return }
-            setPinned(isAtBottom)
+            // Mid-gesture this may only RELEASE the pin, never restore it.
+            // ``isAtBottom`` is a slack comparison, so a gentle scroll whose
+            // per-event delta is within ``bottomResumeSlack`` still reads as
+            // "at the bottom" — re-pinning on it would let the next streamed
+            // frame yank the user straight back, which is precisely the
+            // hijacking this probe exists to stop, and the user could never
+            // escape by scrolling softly. Resuming is decided once the user
+            // has settled, in ``liveScrollDidEnd``.
+            if !isAtBottom { setPinned(false) }
         }
 
         @objc private func documentFrameDidChange(_ notification: Notification) {

--- a/apps/rapid-mac/scripts/verify-chat-scroll-runtime.sh
+++ b/apps/rapid-mac/scripts/verify-chat-scroll-runtime.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+set -eu
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+CACHE="$ROOT/.build/codex-module-cache"
+BINARY="$ROOT/.build/chat-scroll-runtime-check"
+
+mkdir -p "$CACHE"
+CLANG_MODULE_CACHE_PATH="$CACHE" \
+SWIFT_MODULECACHE_PATH="$CACHE" \
+swiftc -parse-as-library \
+    "$ROOT/Sources/Rapid/UI/TranscriptScrollPositionProbe.swift" \
+    "$ROOT/scripts/verify-chat-scroll-runtime.swift" \
+    -o "$BINARY" \
+    -framework AppKit \
+    -framework SwiftUI
+
+"$BINARY"

--- a/apps/rapid-mac/scripts/verify-chat-scroll-runtime.swift
+++ b/apps/rapid-mac/scripts/verify-chat-scroll-runtime.swift
@@ -1,0 +1,171 @@
+import AppKit
+import SwiftUI
+
+// Runtime regression for transcript follow mode. This mounts a real SwiftUI
+// ScrollView and drives its backing NSScrollView through repeated user-scroll
+// and content-growth cycles.
+
+@MainActor
+final class HarnessModel: ObservableObject {
+    @Published var rowCount = 120
+    @Published var isPinnedToBottom = true
+}
+
+@MainActor
+final class ScrollCapture {
+    weak var scrollView: NSScrollView?
+}
+
+private struct HarnessView: View {
+    @ObservedObject var model: HarnessModel
+    let capture: ScrollCapture
+
+    var body: some View {
+        ScrollView {
+            LazyVStack(spacing: 8) {
+                ForEach(0..<model.rowCount, id: \.self) { row in
+                    Text("row \(row)")
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .frame(height: 24)
+                }
+                Color.clear.frame(height: 1)
+            }
+            .padding(24)
+            .background(
+                TranscriptScrollPositionProbe(
+                    isPinnedToBottom: $model.isPinnedToBottom,
+                    bottomResumeSlack: 2
+                )
+            )
+            .overlay(ScrollCaptureProbe(capture: capture).frame(width: 0, height: 0))
+        }
+        .frame(width: 420, height: 320)
+    }
+}
+
+private struct ScrollCaptureProbe: NSViewRepresentable {
+    let capture: ScrollCapture
+
+    func makeNSView(context: Context) -> NSView {
+        let probe = NSView(frame: .zero)
+        DispatchQueue.main.async { capture.scrollView = probe.enclosingScrollView }
+        return probe
+    }
+
+    func updateNSView(_ probe: NSView, context: Context) {
+        if capture.scrollView == nil {
+            DispatchQueue.main.async { capture.scrollView = probe.enclosingScrollView }
+        }
+    }
+}
+
+@main
+@MainActor
+struct ChatScrollRuntimeCheck {
+    static func pump(_ seconds: TimeInterval = 0.2) {
+        RunLoop.main.run(until: Date().addingTimeInterval(seconds))
+    }
+
+    static func metrics(_ scroll: NSScrollView) -> String {
+        let document = scroll.documentView
+        let parts = [
+            "doc.bounds=\(document?.bounds.debugDescription ?? "nil")",
+            "doc.frame=\(document?.frame.debugDescription ?? "nil")",
+            "doc.safe=\(String(describing: document?.safeAreaInsets))",
+            "clip.bounds=\(scroll.contentView.bounds.debugDescription)",
+            "clip.docRect=\(scroll.contentView.documentRect.debugDescription)",
+            "visible=\(scroll.documentVisibleRect.debugDescription)",
+            "insets=\(String(describing: scroll.contentInsets))",
+            "scrollerInsets=\(String(describing: scroll.scrollerInsets))"
+        ]
+        return parts.joined(separator: " ")
+    }
+
+    static func move(_ scroll: NSScrollView, toY y: CGFloat) {
+        scroll.contentView.scroll(to: NSPoint(x: 0, y: y))
+        scroll.reflectScrolledClipView(scroll.contentView)
+        pump()
+    }
+
+    static func main() {
+        let app = NSApplication.shared
+        app.setActivationPolicy(.accessory)
+        let model = HarnessModel()
+        let capture = ScrollCapture()
+        let host = NSHostingView(rootView: HarnessView(model: model, capture: capture))
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 420, height: 320),
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView = host
+        window.orderFrontRegardless()
+        pump(0.8)
+
+        guard let scroll = capture.scrollView, let document = scroll.documentView else {
+            fputs("FAIL: probe did not attach to a scroll view\n", stderr)
+            exit(1)
+        }
+
+        var bottomY = max(0, document.bounds.height - scroll.contentView.bounds.height)
+        move(scroll, toY: bottomY)
+        guard model.isPinnedToBottom else {
+            fputs("FAIL: initial transcript did not follow the bottom\n", stderr)
+            exit(1)
+        }
+
+        for cycle in 1...3 {
+            NotificationCenter.default.post(name: NSScrollView.willStartLiveScrollNotification, object: scroll)
+            move(scroll, toY: max(0, bottomY - 240))
+            NotificationCenter.default.post(name: NSScrollView.didEndLiveScrollNotification, object: scroll)
+            pump()
+            guard !model.isPinnedToBottom else {
+                fputs("FAIL: cycle \(cycle) upward scroll did not pause following\n", stderr)
+                fputs("\(metrics(scroll))\n", stderr)
+                exit(1)
+            }
+
+            let pausedY = scroll.contentView.bounds.minY
+            for _ in 0..<4 {
+                model.rowCount += 1
+                pump(0.03)
+            }
+            pump(0.2)
+            guard !model.isPinnedToBottom,
+                  abs(scroll.contentView.bounds.minY - pausedY) <= 0.5
+            else {
+                fputs("FAIL: cycle \(cycle) streamed content moved a paused transcript\n", stderr)
+                fputs("\(metrics(scroll))\n", stderr)
+                exit(1)
+            }
+
+            bottomY = max(0, document.bounds.height - scroll.contentView.bounds.height)
+            NotificationCenter.default.post(name: NSScrollView.willStartLiveScrollNotification, object: scroll)
+            move(scroll, toY: bottomY)
+            NotificationCenter.default.post(name: NSScrollView.didEndLiveScrollNotification, object: scroll)
+            pump()
+            guard model.isPinnedToBottom else {
+                fputs("FAIL: cycle \(cycle) returning to bottom did not resume following\n", stderr)
+                fputs("\(metrics(scroll))\n", stderr)
+                exit(1)
+            }
+
+            for _ in 0..<8 {
+                model.rowCount += 1
+                pump(0.03)
+            }
+            pump(0.2)
+            let distance = document.bounds.height - scroll.contentView.bounds.maxY
+            guard model.isPinnedToBottom && distance <= 2.5 else {
+                fputs("FAIL: cycle \(cycle) streamed content was not followed after resuming\n", stderr)
+                fputs("distance=\(distance) \(metrics(scroll))\n", stderr)
+                exit(1)
+            }
+            bottomY = max(0, document.bounds.height - scroll.contentView.bounds.height)
+        }
+
+        print("PASS: paused scrolling and bottom-resume following survived 3 streaming cycles")
+        window.close()
+    }
+}

--- a/apps/rapid-mac/scripts/verify-chat-scroll-runtime.swift
+++ b/apps/rapid-mac/scripts/verify-chat-scroll-runtime.swift
@@ -165,7 +165,40 @@ struct ChatScrollRuntimeCheck {
             bottomY = max(0, document.bounds.height - scroll.contentView.bounds.height)
         }
 
-        print("PASS: paused scrolling and bottom-resume following survived 3 streaming cycles")
+        // A GENTLE scroll must escape too. The cycles above jump 240 pt in one
+        // move, far outside `bottomResumeSlack`, so they never exercised the
+        // case where each per-event delta lands INSIDE the slack. If the
+        // mid-gesture handler is allowed to re-pin on a slack comparison, every
+        // small step reads as "still at the bottom", the next streamed frame
+        // snaps the transcript back down, and the user can never scroll away by
+        // moving softly — the exact hijacking this probe exists to prevent.
+        move(scroll, toY: bottomY)
+        pump()
+        guard model.isPinnedToBottom else {
+            fputs("FAIL: could not re-pin before the gentle-scroll check\n", stderr)
+            exit(1)
+        }
+        NotificationCenter.default.post(name: NSScrollView.willStartLiveScrollNotification, object: scroll)
+        for _ in 0..<8 {
+            // Step 1 pt above WHERE WE CURRENTLY ARE (not a precomputed
+            // absolute Y): if a streamed frame drags us back to the bottom,
+            // the next step starts from the bottom again and no distance ever
+            // accumulates — which is exactly the failure being detected.
+            let currentY = scroll.contentView.bounds.minY
+            move(scroll, toY: max(0, currentY - 1))   // 1 pt: inside the 2 pt slack
+            model.rowCount += 1                        // stream while the user reads
+            pump(0.03)
+        }
+        NotificationCenter.default.post(name: NSScrollView.didEndLiveScrollNotification, object: scroll)
+        pump(0.2)
+        let gentleDistance = document.bounds.height - scroll.contentView.bounds.maxY
+        guard !model.isPinnedToBottom, gentleDistance > 2 else {
+            fputs("FAIL: a gentle (sub-slack) scroll was dragged back to the bottom\n", stderr)
+            fputs("distance=\(gentleDistance) pinned=\(model.isPinnedToBottom) \(metrics(scroll))\n", stderr)
+            exit(1)
+        }
+
+        print("PASS: paused scrolling and bottom-resume following survived 3 streaming cycles + gentle scroll")
         window.close()
     }
 }


### PR DESCRIPTION
 ## What does this PR do?

  This PR fixes two related chat interaction problems in the Rapid macOS app.

  ### Autosizing message composer

  - Measures the `NSTextView` content height after edits and width changes.
  - Grows the composer from its single-line height up to the existing 120pt cap.
  - Hosts the editor inside an `NSScrollView` so longer drafts scroll internally.
  - Re-measures programmatic text changes, including clearing after Send and recalling the previous prompt with Up Arrow.
  - Keeps the caret visible and preserves the existing Return, Shift+Return, Cmd+Return, Escape, focus, and accessibility behavior.

  ### Transcript stream following

  - Stops automatic following immediately when the user scrolls up during a streamed response.
  - Keeps the reading position stable while additional tokens arrive.
  - Resumes following when the user returns to the real bottom of the transcript.
  - Uses the backing `NSScrollView` as the single owner of transcript positioning.
  - Follows document frame changes after `LazyVStack` completes layout, including a next-run-loop correction after AppKit updates its scrollable range.
  - Removes competing per-token `ScrollViewReader.scrollTo` calls that could override user input or leave the transcript slightly above the bottom.

  The PR also adds a real SwiftUI/AppKit runtime regression harness for the transcript follow behavior.

  ## Why is this needed?

  Multi-line drafts were rendered inside a composer whose height remained fixed at one line, so users could not see all the text they were writing.

  During streamed responses, the transcript also forced users back to the bottom when they scrolled up to reread or select earlier text. Earlier attempts to gate automatic scrolling by geometry still mixed up two separate concepts:

  - the user's intent to follow the latest response;
  - the transcript's physical distance from the bottom.

  When streamed content increased the document height, that layout change could incorrectly disable following. A `ScrollViewReader.scrollTo` could also run before `LazyVStack` completed its final layout, leaving a persistent gap and preventing automatic scrolling from resuming after the user returned to the bottom.

  This PR separates user intent from document layout and makes the backing `NSScrollView` responsible for maintaining the final scroll position.