### PR TITLE
fix(cache): checkpoint long-context boundaries while idle

### DIFF
--- a/tests/test_idle_prefix_cache_checkpoint.py
+++ b/tests/test_idle_prefix_cache_checkpoint.py
@@ -1,0 +1,159 @@
+"""Runtime idle-checkpoint regression tests."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+
+from vllm_mlx import server
+from vllm_mlx.runtime import cache as runtime_cache
+
+
+def test_runtime_checkpoint_limits_snapshot_to_one_candidate(monkeypatch, tmp_path):
+    predicates = []
+
+    class Engine:
+        def save_cache_to_disk(self, _path, should_abort=None):
+            predicates.append(should_abort)
+            assert should_abort(99.0) is False
+            assert should_abort(0.0) is True
+            return True
+
+    class Config:
+        engine = Engine()
+
+    monkeypatch.setattr(runtime_cache, "get_config", lambda: Config())
+    monkeypatch.setattr(runtime_cache, "get_cache_dir", lambda: str(tmp_path))
+    monkeypatch.setattr(runtime_cache, "_save_radix_index_after_cache", lambda *_: None)
+
+    assert runtime_cache.checkpoint_prefix_cache_to_disk() is True
+    assert len(predicates) == 1
+
+
+def test_runtime_checkpoint_skips_legacy_engine_that_cannot_limit_entries(
+    monkeypatch,
+):
+    calls = []
+
+    class Engine:
+        def save_cache_to_disk(self, _path):
+            calls.append(True)
+            return True
+
+    class Config:
+        engine = Engine()
+
+    monkeypatch.setattr(runtime_cache, "get_config", lambda: Config())
+    assert runtime_cache.checkpoint_prefix_cache_to_disk() is False
+    assert calls == []
+
+
+def test_idle_checkpoint_runs_only_for_dirty_idle_cache(monkeypatch):
+    calls = []
+    loop_thread = threading.get_ident()
+
+    class Engine:
+        def get_stats(self):
+            return {"num_running": 0, "num_waiting": 0}
+
+        def get_cache_stats(self):
+            return {
+                "content_generation": 2,
+                "persisted_generation": 1,
+                "entry_count": 1,
+            }
+
+    def checkpoint():
+        calls.append(threading.get_ident())
+        stop.set()
+        return True
+
+    async def run():
+        nonlocal stop
+        stop = asyncio.Event()
+        monkeypatch.setattr(server, "_engine", Engine())
+        monkeypatch.setattr(server, "_prefix_cache_load_task", None)
+        monkeypatch.setattr(server, "_prefix_cache_snapshot_exists", lambda: True)
+        monkeypatch.setattr(server, "_checkpoint_prefix_cache_to_disk", checkpoint)
+        await server._idle_prefix_cache_checkpoint_loop(stop, 0.01)
+
+    stop = None
+    asyncio.run(run())
+    assert len(calls) == 1
+    assert calls[0] != loop_thread
+
+
+def test_idle_checkpoint_skips_clean_and_busy_cache(monkeypatch):
+    calls = []
+
+    class Engine:
+        def __init__(self):
+            self.polls = 0
+
+        def get_stats(self):
+            self.polls += 1
+            if self.polls == 1:
+                return {"num_running": 1, "num_waiting": 0}
+            stop.set()
+            return {"num_running": 0, "num_waiting": 0}
+
+        def get_cache_stats(self):
+            return {
+                "content_generation": 3,
+                "persisted_generation": 3,
+                "entry_count": 1,
+            }
+
+    async def run():
+        nonlocal stop
+        stop = asyncio.Event()
+        monkeypatch.setattr(server, "_engine", Engine())
+        monkeypatch.setattr(server, "_prefix_cache_load_task", None)
+        monkeypatch.setattr(server, "_prefix_cache_snapshot_exists", lambda: True)
+        monkeypatch.setattr(
+            server,
+            "_checkpoint_prefix_cache_to_disk",
+            lambda: calls.append(True),
+        )
+        await server._idle_prefix_cache_checkpoint_loop(stop, 0.01)
+
+    stop = None
+    asyncio.run(run())
+    assert calls == []
+
+
+def test_idle_checkpoint_rebuilds_missing_committed_snapshot(monkeypatch):
+    calls = []
+
+    class Engine:
+        def get_stats(self):
+            return {"num_running": 0, "num_waiting": 0}
+
+        def get_cache_stats(self):
+            return {
+                "content_generation": 1,
+                "persisted_generation": 1,
+                "entry_count": 1,
+            }
+
+    def checkpoint():
+        calls.append(True)
+        stop.set()
+
+    async def run():
+        nonlocal stop
+        stop = asyncio.Event()
+        monkeypatch.setattr(server, "_engine", Engine())
+        monkeypatch.setattr(server, "_prefix_cache_load_task", None)
+        monkeypatch.setattr(server, "_prefix_cache_snapshot_exists", lambda: False)
+        monkeypatch.setattr(server, "_checkpoint_prefix_cache_to_disk", checkpoint)
+        await server._idle_prefix_cache_checkpoint_loop(stop, 0.01)
+
+    stop = None
+    asyncio.run(run())
+    assert calls == [True]
+
+
+def test_checkpoint_interval_invalid_value_falls_back(monkeypatch):
+    monkeypatch.setenv("RAPID_MLX_PREFIX_CACHE_CHECKPOINT_SECONDS", "invalid")
+    assert server._prefix_cache_checkpoint_interval() == 300.0

--- a/tests/test_prefix_cache_persistence.py
+++ b/tests/test_prefix_cache_persistence.py
@@ -1362,6 +1362,7 @@ def test_save_to_disk_partial_commit_on_abort(tmp_path):
     index = json.loads((cache_dir / "index.json").read_text())
     assert index["num_entries"] == 1
     assert len(index["entries"]) == 1
+    assert index["total_memory_bytes"] == index["entries"][0]["memory_bytes"]
     assert (cache_dir / "entry_0.safetensors").exists()
     assert (cache_dir / "entry_0_tokens.bin").exists()
 
@@ -1371,6 +1372,22 @@ def test_save_to_disk_partial_commit_on_abort(tmp_path):
     assert loaded == 1
     entry = next(iter(cache2._entries.values()))
     assert entry.tokens == tuple(range(11))
+
+
+def test_persistence_generation_stays_dirty_after_later_remove(tmp_path):
+    cache = fresh_cache()
+    tokens = list(range(11))
+    cache.store(tokens, make_kvcache(num_tokens=11))
+    before = cache.get_stats()
+    assert before["content_generation"] > before["persisted_generation"]
+
+    assert cache.save_to_disk(str(tmp_path / "snap")) is True
+    saved = cache.get_stats()
+    assert saved["content_generation"] == saved["persisted_generation"]
+
+    assert cache.remove(tokens) is True
+    removed = cache.get_stats()
+    assert removed["content_generation"] > removed["persisted_generation"]
 
 
 def test_shutdown_partial_commit_prioritizes_longest_prefix(tmp_path):

--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -1743,6 +1743,12 @@ class MemoryAwarePrefixCache:
         #     (0 on an aborted replace / empty load), computed under _lock.
         self._last_save_outcome: str = "empty"
         self._last_load_bytes: int = 0
+        # Monotonic content revision used by the server's idle checkpoint
+        # loop.  A checkpoint records the exact revision it serialized on the
+        # MLX step thread; a later store therefore remains visibly dirty even
+        # if it races immediately after the atomic disk commit.
+        self._content_generation: int = 0
+        self._persisted_generation: int = 0
 
         # Guards _entries / _sorted_keys mutations against concurrent
         # fetch/store/evict from multiple threads (asyncio loop + mlx-step).
@@ -2111,6 +2117,7 @@ class MemoryAwarePrefixCache:
                     existing = self._entries[tokens_key]
                     existing.message_boundary = True
                     existing.message_boundary_sequence = self._message_boundary_sequence
+                    self._content_generation += 1
                 self._entries.move_to_end(tokens_key)
                 return True
 
@@ -2158,6 +2165,7 @@ class MemoryAwarePrefixCache:
                     existing = self._entries[tokens_key]
                     existing.message_boundary = True
                     existing.message_boundary_sequence = self._message_boundary_sequence
+                    self._content_generation += 1
                 self._entries.move_to_end(tokens_key)
                 return True
 
@@ -2238,6 +2246,7 @@ class MemoryAwarePrefixCache:
             # re-open the #1025 leak. Only the hybrid store path pays the scan.
             if entry.non_trimmable:
                 self._enforce_hybrid_bound_locked()
+            self._content_generation += 1
 
         logger.debug(
             f"Stored cache: {len(tokens)} tokens, "
@@ -2285,6 +2294,7 @@ class MemoryAwarePrefixCache:
         self._stats.evictions += 1
         self._stats.entry_count = len(self._entries)
         self._stats.current_memory_bytes = self._current_memory
+        self._content_generation += 1
 
         logger.debug(
             f"[{reason}] removed {len(tokens_key)} tokens, "
@@ -2377,6 +2387,7 @@ class MemoryAwarePrefixCache:
             self._current_memory -= entry.memory_bytes
             self._stats.entry_count = len(self._entries)
             self._stats.current_memory_bytes = self._current_memory
+            self._content_generation += 1
         return True
 
     def clear(self) -> None:
@@ -2414,6 +2425,7 @@ class MemoryAwarePrefixCache:
                 save_drift_drops=carried_save_drift_drops,
                 non_trimmable_skips=carried_non_trimmable_skips,
             )
+            self._content_generation += 1
         logger.debug("Cache cleared")
 
     def get_stats(self) -> dict[str, Any]:
@@ -2435,6 +2447,8 @@ class MemoryAwarePrefixCache:
             out["non_trimmable_entries"] = sum(
                 1 for e in self._entries.values() if e.non_trimmable
             )
+            out["content_generation"] = self._content_generation
+            out["persisted_generation"] = self._persisted_generation
         if self._radix_index is not None:
             try:
                 out["radix"] = self._radix_index.stats()
@@ -2564,6 +2578,8 @@ class MemoryAwarePrefixCache:
 
         self._last_save_outcome = "failed"
         t0 = _time.monotonic()
+        with self._lock:
+            save_generation = self._content_generation
 
         try:
             import mlx_lm.models.cache  # noqa: F401
@@ -2938,6 +2954,9 @@ class MemoryAwarePrefixCache:
         # ships alongside, or load_from_disk's ``num_entries`` read drifts
         # from reality and downstream callers report a phantom count.
         index["num_entries"] = len(index["entries"])
+        index["total_memory_bytes"] = sum(
+            int(entry["memory_bytes"]) for entry in index["entries"]
+        )
 
         # Pass 3 — orphan-file sweep. The atomic rename publishes the
         # entire ``.new/`` directory tree, so any file we wrote but the
@@ -3152,6 +3171,11 @@ class MemoryAwarePrefixCache:
         # at least one entry landed AND the atomic rename published it. A
         # zero-commit / un-renamed result stays "failed" (set above).
         self._last_save_outcome = "committed" if committed else "failed"
+        if committed:
+            with self._lock:
+                self._persisted_generation = max(
+                    self._persisted_generation, save_generation
+                )
         return committed
 
     def load_from_disk(
@@ -3952,6 +3976,15 @@ class MemoryAwarePrefixCache:
         # rolled back out of the cache — they must NOT count toward the loaded
         # total the caller (and the import route's ``entries_loaded``) sees.
         loaded -= radix_rolled_back
+
+        if loaded > 0:
+            with self._lock:
+                self._content_generation += 1
+                # A startup load into an empty cache exactly matches the
+                # committed disk snapshot.  Merge imports can coexist with
+                # unsaved live entries and must remain dirty.
+                if len(self._entries) == loaded:
+                    self._persisted_generation = self._content_generation
 
         dt = _time.monotonic() - t0
         summary = (

--- a/vllm_mlx/runtime/cache.py
+++ b/vllm_mlx/runtime/cache.py
@@ -216,6 +216,59 @@ def save_prefix_cache_to_disk(budget_sec: float | None = None) -> None:
         logger.warning(f"[lifespan] Failed to save cache to disk: {e}", exc_info=True)
 
 
+def checkpoint_prefix_cache_to_disk() -> bool:
+    """Persist one reusable frontier while the server is idle.
+
+    Unlike the shutdown flush, this runs before any SIGTERM deadline exists.
+    Limiting the snapshot to the first persistence-priority candidate keeps the
+    pause bounded and prevents a periodic checkpoint from rewriting every
+    multi-GB LRU entry.  ``save_to_disk`` orders an explicit message boundary
+    first for DeepSeek's non-trimmable cache, so one entry is sufficient to
+    preserve the latest resumable conversation frontier.
+    """
+    cfg = get_config()
+    if cfg.engine is None:
+        return False
+
+    # The one-entry bound depends on the deadline-predicate contract. Legacy
+    # third-party engines without that kwarg would otherwise take the fallback
+    # path and rewrite their entire cache from this periodic task.
+    import inspect
+
+    try:
+        save_sig = inspect.signature(cfg.engine.save_cache_to_disk)
+    except (TypeError, ValueError):
+        logger.info("[lifespan] Idle prefix checkpoint skipped: unknown engine API")
+        return False
+    if "should_abort" not in save_sig.parameters and not any(
+        p.kind == inspect.Parameter.VAR_KEYWORD for p in save_sig.parameters.values()
+    ):
+        logger.info("[lifespan] Idle prefix checkpoint skipped: legacy engine API")
+        return False
+
+    calls = 0
+
+    def stop_after_first(_predicted_sec: float = 0.0) -> bool:
+        nonlocal calls
+        calls += 1
+        return calls > 1
+
+    try:
+        d = get_cache_dir()
+        logger.info(f"[lifespan] Idle-checkpointing one prefix boundary to {d}")
+        saved = bool(_call_save_cache_to_disk(cfg.engine, d, stop_after_first))
+        if saved:
+            # Do not serialize the live radix here: the one-entry snapshot is
+            # intentionally a subset of the in-memory cache. A missing radix
+            # is rebuilt from the committed entry at startup; saving the live
+            # multi-entry radix would publish terminal keys with no KV files.
+            logger.info(f"[lifespan] Idle prefix checkpoint saved to {d}")
+        return saved
+    except Exception as e:
+        logger.warning(f"[lifespan] Idle prefix checkpoint failed: {e}", exc_info=True)
+        return False
+
+
 def _save_radix_index_after_cache(engine, cache_dir: str) -> None:
     """Best-effort radix-index persistence."""
     cache = _resolve_memory_aware_cache(engine)
@@ -336,3 +389,8 @@ def get_cache_dir() -> str:
     return os.path.join(
         os.path.expanduser("~"), ".cache", "rapid-mlx", "prefix_cache", leaf
     )
+
+
+def prefix_cache_snapshot_exists() -> bool:
+    """Return whether the current model has a committed disk snapshot."""
+    return os.path.isfile(os.path.join(get_cache_dir(), "index.json"))

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -196,6 +196,8 @@ _engine: BaseEngine | None = None
 # so shutdown can await a still-running load to completion before the shutdown
 # save and engine teardown.
 _prefix_cache_load_task = None  # asyncio.Task | None
+_prefix_cache_checkpoint_task = None  # asyncio.Task | None
+_prefix_cache_checkpoint_stop = None  # asyncio.Event | None
 _model_name: str | None = None
 _model_alias: str | None = None  # Short alias used to start the model (if any)
 # Task #292 (Bo R13/R14): operator opt-in for ``/v1/audio/*`` routes on a
@@ -309,8 +311,12 @@ _pinned_system_prompt_hash: str | None = None  # Hash of pinned system prompt
 
 
 from .runtime.cache import (
+    checkpoint_prefix_cache_to_disk as _checkpoint_prefix_cache_to_disk,
+)
+from .runtime.cache import (
     load_prefix_cache_from_disk as _load_prefix_cache_from_disk,
 )
+from .runtime.cache import prefix_cache_snapshot_exists as _prefix_cache_snapshot_exists
 from .runtime.cache import (
     save_prefix_cache_to_disk as _save_prefix_cache_to_disk,
 )
@@ -385,6 +391,66 @@ async def _drain_deferred_prefix_cache_load() -> None:
         await task
     except Exception as _e:  # noqa: BLE001
         logger.debug(f"[lifespan] deferred prefix-cache load cleanup: {_e}")
+
+
+def _prefix_cache_checkpoint_interval() -> float:
+    """Return idle-checkpoint cadence; zero disables the background task."""
+    raw = os.environ.get("RAPID_MLX_PREFIX_CACHE_CHECKPOINT_SECONDS", "300")
+    try:
+        return max(0.0, float(raw))
+    except (TypeError, ValueError):
+        logger.warning(
+            "Invalid RAPID_MLX_PREFIX_CACHE_CHECKPOINT_SECONDS=%r; using 300s",
+            raw,
+        )
+        return 300.0
+
+
+async def _idle_prefix_cache_checkpoint_loop(
+    stop: asyncio.Event, interval_sec: float
+) -> None:
+    """Persist one dirty message boundary during a naturally idle window."""
+    await _drain_deferred_prefix_cache_load()
+    while not stop.is_set():
+        try:
+            await asyncio.wait_for(stop.wait(), timeout=interval_sec)
+            continue
+        except TimeoutError:
+            pass
+
+        engine = _engine
+        if engine is None:
+            continue
+        try:
+            stats = engine.get_stats()
+            cache_stats = engine.get_cache_stats() or {}
+            if stats.get("num_running", 0) or stats.get("num_waiting", 0):
+                continue
+            if (
+                "content_generation" not in cache_stats
+                or int(cache_stats.get("entry_count", 0)) <= 0
+            ):
+                continue
+            generation = int(cache_stats.get("content_generation", 0))
+            persisted = int(cache_stats.get("persisted_generation", 0))
+            if generation <= persisted and _prefix_cache_snapshot_exists():
+                continue
+            await asyncio.to_thread(_checkpoint_prefix_cache_to_disk)
+        except Exception as exc:  # noqa: BLE001 — best-effort optimization
+            logger.warning("Idle prefix-cache checkpoint failed: %s", exc)
+
+
+async def _stop_idle_prefix_cache_checkpoint() -> None:
+    """Wake and drain the idle checkpoint worker before engine teardown."""
+    global _prefix_cache_checkpoint_stop, _prefix_cache_checkpoint_task
+    task = _prefix_cache_checkpoint_task
+    stop = _prefix_cache_checkpoint_stop
+    if stop is not None:
+        stop.set()
+    if task is not None:
+        await task
+    _prefix_cache_checkpoint_task = None
+    _prefix_cache_checkpoint_stop = None
 
 
 def _do_tool_grammar_warmup(tokenizer, parser_cls) -> bool:
@@ -492,6 +558,8 @@ async def _warmup_tool_grammar(engine) -> None:
 async def lifespan(app: FastAPI):
     """FastAPI lifespan for startup/shutdown events."""
     global _engine, _mcp_manager
+    global _prefix_cache_checkpoint_stop, _prefix_cache_checkpoint_task
+    global _prefix_cache_load_task
 
     # Install process-death observability BEFORE any executor is created.
     # Two complementary mechanisms (codex r3 NIT clarification):
@@ -716,8 +784,15 @@ async def lifespan(app: FastAPI):
     # fully-installed cache, never a partially-populated one. Worst case a few
     # early requests recompute their prefix; they never see a wedged server.
     if _engine is not None and hasattr(_engine, "load_cache_from_disk"):
-        global _prefix_cache_load_task
         _prefix_cache_load_task = asyncio.create_task(_deferred_load_prefix_cache())
+        checkpoint_interval = _prefix_cache_checkpoint_interval()
+        if checkpoint_interval > 0:
+            _prefix_cache_checkpoint_stop = asyncio.Event()
+            _prefix_cache_checkpoint_task = asyncio.create_task(
+                _idle_prefix_cache_checkpoint_loop(
+                    _prefix_cache_checkpoint_stop, checkpoint_interval
+                )
+            )
 
     # Print the real "Ready:" banner now — only here is the port truly
     # accepting connections AND the engine warmed up. The CLI's earlier
@@ -770,6 +845,11 @@ async def lifespan(app: FastAPI):
         from .routes.video import shutdown_video_jobs
 
         await shutdown_video_jobs()
+
+        # Stop the pre-SIGTERM checkpoint loop before the final deadline-bound
+        # save. If a one-entry checkpoint is already in flight, drain it before
+        # touching the same staging directory or tearing down the MLX engine.
+        await _stop_idle_prefix_cache_checkpoint()
 
         # Let the deferred prefix-cache load (#1350) finish before we save or
         # tear down the engine — see the helper's docstring for why we await


### PR DESCRIPTION
## Summary

Persist one latest reusable prefix-cache boundary during idle server windows, before shutdown begins. Track cache content and checkpoint generations so the task only writes dirty state, and retain the existing conservative deadline-bound shutdown flush unchanged.

## Why

DeepSeek-V4 at 120K produced a ~2.4GB in-memory cache that writes in 0.9–1.8s on the test M3 Ultra, but the safe 150MB/s shutdown predictor correctly refuses to assume that speed on every supported filesystem. The result was a restart paying cold prefill even though the server had been idle before termination. Raising the global throughput assumption was rejected in #1466 because it weakened slow-storage safety.

This moves the useful work out of the SIGTERM critical path: once every 300s (configurable, zero disables), an idle engine atomically saves exactly one persistence-priority boundary. A missing radix is rebuilt from that committed entry on startup. Legacy engines that cannot enforce the one-entry bound and non-memory-aware caches are skipped.

## Validation

- ruff: clean
- focused cache/lifecycle tests: 96 passed
- real DeepSeek-V4 120K fault injection:
  - idle checkpoint committed one 120,004-token message boundary in under 3s
  - process was then killed with SIGKILL, bypassing shutdown save entirely
  - fresh process loaded the one-entry snapshot
  - cache hit 120,004 / 120,014 tokens
  - restart TTFT 2.06s
  - exact output CACHE_RESTART_OK, no reasoning leak

## Safety

- default shutdown bootstrap remains 150MB/s
- idle checkpoint is single-entry and only runs with zero running/waiting requests
- shutdown drains an in-flight checkpoint before final save/engine teardown
- generation tracking covers stores, explicit removes, evictions, clears, loads, and commits
- partial snapshot metadata reports only committed entries; live multi-entry radix is not persisted beside a one-entry snapshot
