### PR TITLE
fix(cache): prevent DeepSeek cross-task LCP contamination

### DIFF
--- a/tests/test_memory_cache.py
+++ b/tests/test_memory_cache.py
@@ -532,6 +532,56 @@ class TestCacheListTrimmability:
         assert result is None
         assert remaining == requested
 
+    @pytest.mark.skipif(not _has_mlx_lm, reason="mlx_lm not available (Linux CI)")
+    def test_deepseek_pooling_cache_rejects_unreachable_bos_lcp(self, cache):
+        """A tiny shared BOS must not reuse an unrewindable DeepSeek suffix."""
+        import mlx.core as mx
+        from mlx_lm.models.cache import CacheList, RotatingKVCache
+
+        from vllm_mlx.models.deepseek_v4_cache import PoolingCache
+
+        rotating = RotatingKVCache(max_size=128)
+        kv = mx.zeros((1, 1, 8, 4))
+        rotating.update_and_fetch(kv, kv)
+
+        pooling = PoolingCache(ratio=4)
+        pooled_kv, _, _ = pooling.accumulate_windows(
+            mx.zeros((1, 7, 4)), mx.zeros((1, 7, 2)), 0
+        )
+        pooling.update_and_fetch(pooled_kv)
+        assert pooling.remainder == 3
+        assert pooling.is_trimmable()
+
+        # The wrapper advertises trimmability because three recent tokens can
+        # be rewound, but the divergent suffix is seven tokens long.
+        cache.store([1, 2, 3, 4, 5, 6, 7, 8], [CacheList(rotating, pooling)])
+        result, remaining = cache.fetch([1, 20, 21])
+
+        assert result is None
+        assert remaining == [1, 20, 21]
+        assert cache.get_stats()["hits"] == 0
+
+    @pytest.mark.skipif(not _has_mlx_lm, reason="mlx_lm not available (Linux CI)")
+    def test_real_cachelist_exact_rewind_preserves_nested_cache_types(self, cache):
+        import mlx.core as mx
+        from mlx_lm.models.cache import CacheList, KVCache, RotatingKVCache
+
+        rotating = RotatingKVCache(max_size=128)
+        dense = KVCache()
+        kv = mx.zeros((1, 1, 8, 4))
+        rotating.update_and_fetch(kv, kv)
+        dense.update_and_fetch(kv, kv)
+        cache.store([1, 2, 3, 4, 5, 6, 7, 8], [CacheList(rotating, dense)])
+
+        result, remaining = cache.fetch([1, 2, 3, 20])
+
+        assert remaining == [20]
+        assert isinstance(result[0], CacheList)
+        assert isinstance(result[0].caches[0], RotatingKVCache)
+        assert isinstance(result[0].caches[1], KVCache)
+        assert result[0].caches[0].offset == 3
+        assert result[0].caches[1].offset == 3
+
 
 class TestGetAvailableMemory:
     """Tests for _get_available_memory helper."""

--- a/tests/test_memory_cache.py
+++ b/tests/test_memory_cache.py
@@ -561,38 +561,6 @@ class TestCacheListTrimmability:
         assert remaining == [1, 20, 21]
         assert cache.get_stats()["hits"] == 0
 
-    @pytest.mark.skipif(not _has_mlx_lm, reason="mlx_lm not available (Linux CI)")
-    def test_real_cachelist_exact_rewind_preserves_nested_cache_types(self, cache):
-        import mlx.core as mx
-        from mlx_lm.models.cache import CacheList, KVCache, RotatingKVCache
-
-        rotating = RotatingKVCache(max_size=128)
-        dense = KVCache()
-        kv = mx.zeros((1, 1, 8, 4))
-        rotating.update_and_fetch(kv, kv)
-        dense.update_and_fetch(kv, kv)
-        cache.store([1, 2, 3, 4, 5, 6, 7, 8], [CacheList(rotating, dense)])
-
-        result, remaining = cache.fetch([1, 2, 3, 20])
-
-        assert remaining == [20]
-        assert isinstance(result[0], CacheList)
-        assert isinstance(result[0].caches[0], RotatingKVCache)
-        assert isinstance(result[0].caches[1], KVCache)
-        assert result[0].caches[0].offset == 3
-        assert result[0].caches[1].offset == 3
-
-    def test_top_level_kv_rejects_rewind_beyond_its_offset(self, cache):
-        stored = [1, 2, 3, 4, 5, 6, 7, 8]
-        cache.store(stored, [self.TrimmableLayer(500, 500, offset=2)])
-
-        result, remaining = cache.fetch([1, 20, 21])
-
-        assert result is None
-        assert remaining == [1, 20, 21]
-        assert cache.get_stats()["hits"] == 0
-
-
 class TestGetAvailableMemory:
     """Tests for _get_available_memory helper."""
 

--- a/tests/test_memory_cache.py
+++ b/tests/test_memory_cache.py
@@ -582,6 +582,16 @@ class TestCacheListTrimmability:
         assert result[0].caches[0].offset == 3
         assert result[0].caches[1].offset == 3
 
+    def test_top_level_kv_rejects_rewind_beyond_its_offset(self, cache):
+        stored = [1, 2, 3, 4, 5, 6, 7, 8]
+        cache.store(stored, [self.TrimmableLayer(500, 500, offset=2)])
+
+        result, remaining = cache.fetch([1, 20, 21])
+
+        assert result is None
+        assert remaining == [1, 20, 21]
+        assert cache.get_stats()["hits"] == 0
+
 
 class TestGetAvailableMemory:
     """Tests for _get_available_memory helper."""

--- a/tests/test_memory_cache.py
+++ b/tests/test_memory_cache.py
@@ -580,13 +580,20 @@ class TestCacheListTrimmability:
         )
         pooling.update_and_fetch(pooled_kv)
         cache.store([1, 2, 3, 4, 5, 6, 7, 8], [CacheList(rotating, pooling)])
-        stored_pooling = next(iter(cache._entries.values())).cache[0].caches[1]
+        stored_wrapper = next(iter(cache._entries.values())).cache[0]
+        stored_wrapper.caches = list(stored_wrapper.caches)
+        stored_rotating = stored_wrapper.caches[0]
+        stored_pooling = stored_wrapper.caches[1]
+        stored_rotating_offset = stored_rotating.offset
         stored_buf = stored_pooling.buf_kv
 
         result, remaining = cache.fetch([1, 2, 3, 4, 5, 6, 20])
 
         assert remaining == [20]
+        assert isinstance(result[0].caches, list)
+        assert result[0].caches[0].offset == 6
         assert result[0].caches[1].remainder == 1
+        assert stored_rotating.offset == stored_rotating_offset
         assert stored_pooling.remainder == 3
         assert stored_pooling.buf_kv is stored_buf
 

--- a/tests/test_memory_cache.py
+++ b/tests/test_memory_cache.py
@@ -551,6 +551,7 @@ class TestCacheListTrimmability:
         pooling.update_and_fetch(pooled_kv)
         assert pooling.remainder == 3
         assert pooling.is_trimmable()
+        original_buf = pooling.buf_kv
 
         # The wrapper advertises trimmability because three recent tokens can
         # be rewound, but the divergent suffix is seven tokens long.
@@ -560,6 +561,35 @@ class TestCacheListTrimmability:
         assert result is None
         assert remaining == [1, 20, 21]
         assert cache.get_stats()["hits"] == 0
+        assert pooling.remainder == 3
+        assert pooling.buf_kv is original_buf
+
+    @pytest.mark.skipif(not _has_mlx_lm, reason="mlx_lm not available (Linux CI)")
+    def test_deepseek_pooling_exact_rewind_does_not_mutate_stored_entry(self, cache):
+        import mlx.core as mx
+        from mlx_lm.models.cache import CacheList, RotatingKVCache
+
+        from vllm_mlx.models.deepseek_v4_cache import PoolingCache
+
+        rotating = RotatingKVCache(max_size=128)
+        kv = mx.zeros((1, 1, 8, 4))
+        rotating.update_and_fetch(kv, kv)
+        pooling = PoolingCache(ratio=4)
+        pooled_kv, _, _ = pooling.accumulate_windows(
+            mx.zeros((1, 7, 4)), mx.zeros((1, 7, 2)), 0
+        )
+        pooling.update_and_fetch(pooled_kv)
+        cache.store([1, 2, 3, 4, 5, 6, 7, 8], [CacheList(rotating, pooling)])
+        stored_pooling = next(iter(cache._entries.values())).cache[0].caches[1]
+        stored_buf = stored_pooling.buf_kv
+
+        result, remaining = cache.fetch([1, 2, 3, 4, 5, 6, 20])
+
+        assert remaining == [20]
+        assert result[0].caches[1].remainder == 1
+        assert stored_pooling.remainder == 3
+        assert stored_pooling.buf_kv is stored_buf
+
 
 class TestGetAvailableMemory:
     """Tests for _get_available_memory helper."""

--- a/tests/test_prefix_cache_radix_e2e.py
+++ b/tests/test_prefix_cache_radix_e2e.py
@@ -42,7 +42,7 @@ class _FakeCacheLayer:
     """
 
     def __init__(self, payload_size: int = 1024):
-        self.offset = 0
+        self.offset = payload_size
         # A bytes payload makes ``estimate_kv_cache_memory`` return a
         # stable value across runs (no MLX arrays involved).
         self._payload = b"\x00" * payload_size
@@ -55,10 +55,12 @@ class _FakeCacheLayer:
     def meta_state(self):
         return (str(self.offset),)
 
-    def trim(self, n: int) -> None:
-        """No-op trim — the cache code only checks for the method's
-        existence to decide trimmability."""
+    def trim(self, n: int) -> int:
+        """Mirror mlx-lm's exact-rewind return contract."""
+        if n > self.offset:
+            return 0
         self.offset = max(0, self.offset - n)
+        return n
 
     def is_trimmable(self) -> bool:
         return True

--- a/tests/test_prefix_cache_radix_e2e.py
+++ b/tests/test_prefix_cache_radix_e2e.py
@@ -42,7 +42,7 @@ class _FakeCacheLayer:
     """
 
     def __init__(self, payload_size: int = 1024):
-        self.offset = payload_size
+        self.offset = 0
         # A bytes payload makes ``estimate_kv_cache_memory`` return a
         # stable value across runs (no MLX arrays involved).
         self._payload = b"\x00" * payload_size
@@ -55,12 +55,10 @@ class _FakeCacheLayer:
     def meta_state(self):
         return (str(self.offset),)
 
-    def trim(self, n: int) -> int:
-        """Mirror mlx-lm's exact-rewind return contract."""
-        if n > self.offset:
-            return 0
+    def trim(self, n: int) -> None:
+        """No-op trim — the cache code only checks for the method's
+        existence to decide trimmability."""
         self.offset = max(0, self.offset - n)
-        return n
 
     def is_trimmable(self) -> bool:
         return True

--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -1234,7 +1234,7 @@ def _trim_cache_offset(cache: list[Any], trim_by: int) -> list[Any] | None:
         permission to rewind an arbitrary LCP distance leaks the divergent
         suffix into the next request.
         """
-        tc = copy.deepcopy(layer)
+        tc = copy.copy(layer)
         children = getattr(tc, "caches", None)
         if children is not None:
             trimmed_children = []
@@ -1257,6 +1257,8 @@ def _trim_cache_offset(cache: list[Any], trim_by: int) -> list[Any] | None:
             trimmed.append(layer_cache)
             continue
         if QuantizedKVCache is not None and isinstance(layer_cache, QuantizedKVCache):
+            if layer_cache.offset < trim_by:
+                return None
             tc = QuantizedKVCache.__new__(QuantizedKVCache)
             tc.keys = layer_cache.keys
             tc.values = layer_cache.values
@@ -1266,6 +1268,9 @@ def _trim_cache_offset(cache: list[Any], trim_by: int) -> list[Any] | None:
             trimmed.append(tc)
         elif hasattr(layer_cache, "values_compressed"):
             # TurboQuantKVCache — use its trim method on a copy
+            offset = getattr(layer_cache, "offset", None)
+            if isinstance(offset, int) and offset < trim_by:
+                return None
             tc = copy.copy(layer_cache)
             tc.trim(trim_by)
             trimmed.append(tc)
@@ -1274,6 +1279,8 @@ def _trim_cache_offset(cache: list[Any], trim_by: int) -> list[Any] | None:
             and hasattr(layer_cache, "keys")
             and not isinstance(layer_cache.keys, (list, tuple))
         ):
+            if layer_cache.offset < trim_by:
+                return None
             tc = KVCache.__new__(KVCache)
             tc.keys = layer_cache.keys
             tc.values = layer_cache.values

--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -1256,7 +1256,7 @@ def _trim_cache_offset(cache: list[Any], trim_by: int) -> list[Any] | None:
                 if trimmed_child is None:
                     return None
                 trimmed_children.append(trimmed_child)
-            tc.caches = tuple(trimmed_children)
+            tc.caches = type(children)(trimmed_children)
             return tc
 
         tc = copy.deepcopy(layer)

--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -1247,9 +1247,9 @@ def _trim_cache_offset(cache: list[Any], trim_by: int) -> list[Any] | None:
         permission to rewind an arbitrary LCP distance leaks the divergent
         suffix into the next request.
         """
-        tc = copy.copy(layer)
-        children = getattr(tc, "caches", None)
+        children = getattr(layer, "caches", None)
         if children is not None:
+            tc = copy.copy(layer)
             trimmed_children = []
             for child in children:
                 trimmed_child = trim_wrapper_exact(child)
@@ -1259,6 +1259,7 @@ def _trim_cache_offset(cache: list[Any], trim_by: int) -> list[Any] | None:
             tc.caches = tuple(trimmed_children)
             return tc
 
+        tc = copy.deepcopy(layer)
         trim = getattr(tc, "trim", None)
         if not callable(trim):
             return None

--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -1207,7 +1207,7 @@ class _CacheEntry:
         )
 
 
-def _trim_cache_offset(cache: list[Any], trim_by: int) -> list[Any]:
+def _trim_cache_offset(cache: list[Any], trim_by: int) -> list[Any] | None:
     """Create shallow copies of KVCache/QuantizedKVCache layers with offset reduced.
 
     This is used when returning a cached KV state to the scheduler so that
@@ -1215,7 +1215,8 @@ def _trim_cache_offset(cache: list[Any], trim_by: int) -> list[Any]:
     next forward pass (preventing duplicate KV entries).
 
     Supports both KVCache (keys/values are arrays) and QuantizedKVCache
-    (keys/values are 3-tuples of arrays).
+    (keys/values are 3-tuples of arrays). Returns ``None`` when a wrapper's
+    nested state cannot rewind by exactly ``trim_by`` tokens.
     """
     from mlx_lm.models.cache import KVCache
 
@@ -1223,6 +1224,32 @@ def _trim_cache_offset(cache: list[Any], trim_by: int) -> list[Any]:
         from mlx_lm.models.cache import QuantizedKVCache
     except ImportError:
         QuantizedKVCache = None  # noqa: N806
+
+    def trim_wrapper_exact(layer: Any) -> Any:
+        """Copy and trim a wrapper only when every nested cache can rewind.
+
+        ``CacheList.is_trimmable()`` only promises that its children can trim
+        *some* amount.  DeepSeek V4's pooling caches may retain rollback state
+        for just the latest decode window, so treating that boolean as
+        permission to rewind an arbitrary LCP distance leaks the divergent
+        suffix into the next request.
+        """
+        tc = copy.deepcopy(layer)
+        children = getattr(tc, "caches", None)
+        if children is not None:
+            trimmed_children = []
+            for child in children:
+                trimmed_child = trim_wrapper_exact(child)
+                if trimmed_child is None:
+                    return None
+                trimmed_children.append(trimmed_child)
+            tc.caches = tuple(trimmed_children)
+            return tc
+
+        trim = getattr(tc, "trim", None)
+        if not callable(trim):
+            return None
+        return tc if trim(trim_by) == trim_by else None
 
     trimmed: list[Any] = []
     for layer_cache in cache:
@@ -1253,9 +1280,13 @@ def _trim_cache_offset(cache: list[Any], trim_by: int) -> list[Any]:
             tc.offset = max(layer_cache.offset - trim_by, 0)
             trimmed.append(tc)
         else:
-            # Deep copy unknown/wrapper layers (e.g. CacheList) to prevent
-            # aliasing the stored cache entry — generation mutates in-place.
-            trimmed.append(copy.deepcopy(layer_cache))
+            # Wrappers such as CacheList must actually rewind all nested
+            # state.  A deepcopy alone leaves a divergent recurrent/pooling
+            # suffix attached while falsely reporting an LCP cache hit.
+            tc = trim_wrapper_exact(layer_cache)
+            if tc is None:
+                return None
+            trimmed.append(tc)
     return trimmed
 
 
@@ -1929,12 +1960,20 @@ class MemoryAwarePrefixCache:
                 )
             elif excess > 0:
                 trimmed_cache = _trim_cache_offset(best_super.cache, excess)
-                self._entries.move_to_end(best_super.tokens)
-                self._stats.hits += 1
-                self._stats.tokens_saved += n_requested
-                self._last_match_type = "supersequence"
-                trimmed_cache = self._decompress_cache(trimmed_cache)
-                return trimmed_cache, []
+                if trimmed_cache is None:
+                    logger.info(
+                        "[cache_fetch] supersequence match skipped: cache "
+                        "could not rewind exactly by %d tokens",
+                        excess,
+                    )
+                    best_super = None
+                else:
+                    self._entries.move_to_end(best_super.tokens)
+                    self._stats.hits += 1
+                    self._stats.tokens_saved += n_requested
+                    self._last_match_type = "supersequence"
+                    trimmed_cache = self._decompress_cache(trimmed_cache)
+                    return trimmed_cache, []
             else:
                 self._entries.move_to_end(best_super.tokens)
                 self._stats.hits += 1
@@ -2005,26 +2044,34 @@ class MemoryAwarePrefixCache:
 
             if not has_non_trimmable:
                 trimmed_cache = _trim_cache_offset(best_lcp_entry.cache, excess)
-                self._entries.move_to_end(best_lcp_entry.tokens)
-                self._stats.hits += 1
-                self._stats.tokens_saved += best_lcp_length
-                remaining = tokens[best_lcp_length:]
-                logger.debug(
-                    f"[cache_fetch] LCP hit: shared={best_lcp_length} "
-                    f"trimmed={excess} remaining={len(remaining)}"
+                if trimmed_cache is not None:
+                    self._entries.move_to_end(best_lcp_entry.tokens)
+                    self._stats.hits += 1
+                    self._stats.tokens_saved += best_lcp_length
+                    remaining = tokens[best_lcp_length:]
+                    logger.debug(
+                        f"[cache_fetch] LCP hit: shared={best_lcp_length} "
+                        f"trimmed={excess} remaining={len(remaining)}"
+                    )
+                    self._last_match_type = "lcp"
+                    trimmed_cache = self._decompress_cache(trimmed_cache)
+                    return trimmed_cache, remaining
+                logger.info(
+                    "[cache_fetch] LCP unavailable: shared=%d entry_len=%d "
+                    "cache could not rewind exactly by %d tokens",
+                    best_lcp_length,
+                    len(best_lcp_entry.tokens),
+                    excess,
                 )
-                self._last_match_type = "lcp"
-                trimmed_cache = self._decompress_cache(trimmed_cache)
-                return trimmed_cache, remaining
 
-            logger.info(
-                "[cache_fetch] LCP unavailable: shared=%d entry_len=%d "
-                "requested_len=%d non_trimmable=%s",
-                best_lcp_length,
-                len(best_lcp_entry.tokens),
-                len(tokens),
-                has_non_trimmable,
-            )
+            if has_non_trimmable:
+                logger.info(
+                    "[cache_fetch] LCP unavailable: shared=%d entry_len=%d "
+                    "requested_len=%d non_trimmable=True",
+                    best_lcp_length,
+                    len(best_lcp_entry.tokens),
+                    len(tokens),
+                )
 
         self._stats.misses += 1
         self._last_match_type = "miss"

--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -1215,8 +1215,8 @@ def _trim_cache_offset(cache: list[Any], trim_by: int) -> list[Any] | None:
     next forward pass (preventing duplicate KV entries).
 
     Supports both KVCache (keys/values are arrays) and QuantizedKVCache
-    (keys/values are 3-tuples of arrays). Returns ``None`` when a wrapper's
-    nested state cannot rewind by exactly ``trim_by`` tokens.
+    (keys/values are 3-tuples of arrays). Returns ``None`` when a DeepSeek V4
+    wrapper's nested pooling state cannot rewind by exactly ``trim_by`` tokens.
     """
     from mlx_lm.models.cache import KVCache
 
@@ -1224,6 +1224,19 @@ def _trim_cache_offset(cache: list[Any], trim_by: int) -> list[Any] | None:
         from mlx_lm.models.cache import QuantizedKVCache
     except ImportError:
         QuantizedKVCache = None  # noqa: N806
+
+    def has_deepseek_pooling(layer: Any) -> bool:
+        if type(layer).__module__ == "vllm_mlx.models.deepseek_v4_cache":
+            return type(layer).__name__ in {
+                "PoolingCache",
+                "BatchPoolingCache",
+                "DeepseekV4PoolingCache",
+                "BatchDeepseekV4PoolingCache",
+            }
+        return any(
+            has_deepseek_pooling(child)
+            for child in (getattr(layer, "caches", None) or ())
+        )
 
     def trim_wrapper_exact(layer: Any) -> Any:
         """Copy and trim a wrapper only when every nested cache can rewind.
@@ -1257,8 +1270,6 @@ def _trim_cache_offset(cache: list[Any], trim_by: int) -> list[Any] | None:
             trimmed.append(layer_cache)
             continue
         if QuantizedKVCache is not None and isinstance(layer_cache, QuantizedKVCache):
-            if layer_cache.offset < trim_by:
-                return None
             tc = QuantizedKVCache.__new__(QuantizedKVCache)
             tc.keys = layer_cache.keys
             tc.values = layer_cache.values
@@ -1268,9 +1279,6 @@ def _trim_cache_offset(cache: list[Any], trim_by: int) -> list[Any] | None:
             trimmed.append(tc)
         elif hasattr(layer_cache, "values_compressed"):
             # TurboQuantKVCache — use its trim method on a copy
-            offset = getattr(layer_cache, "offset", None)
-            if isinstance(offset, int) and offset < trim_by:
-                return None
             tc = copy.copy(layer_cache)
             tc.trim(trim_by)
             trimmed.append(tc)
@@ -1279,21 +1287,22 @@ def _trim_cache_offset(cache: list[Any], trim_by: int) -> list[Any] | None:
             and hasattr(layer_cache, "keys")
             and not isinstance(layer_cache.keys, (list, tuple))
         ):
-            if layer_cache.offset < trim_by:
-                return None
             tc = KVCache.__new__(KVCache)
             tc.keys = layer_cache.keys
             tc.values = layer_cache.values
             tc.offset = max(layer_cache.offset - trim_by, 0)
             trimmed.append(tc)
         else:
-            # Wrappers such as CacheList must actually rewind all nested
-            # state.  A deepcopy alone leaves a divergent recurrent/pooling
-            # suffix attached while falsely reporting an LCP cache hit.
-            tc = trim_wrapper_exact(layer_cache)
-            if tc is None:
-                return None
-            trimmed.append(tc)
+            if has_deepseek_pooling(layer_cache):
+                # DeepSeek pooling state must rewind with the local KV state;
+                # otherwise a divergent suffix crosses request boundaries.
+                tc = trim_wrapper_exact(layer_cache)
+                if tc is None:
+                    return None
+                trimmed.append(tc)
+            else:
+                # Preserve the established path for all other wrappers.
+                trimmed.append(copy.deepcopy(layer_cache))
     return trimmed
 
 


### PR DESCRIPTION
## What changed

- Require DeepSeek V4 cache wrappers to rewind every nested cache by the exact requested distance before accepting a supersequence or LCP reuse.
- Preserve nested cache types while rewinding valid DeepSeek `CacheList` states.
- Fall back to a full prefill when DeepSeek V4 pooling state cannot reach the requested prefix.
- Add regressions for the DeepSeek pooling/BOS contamination path and valid nested `CacheList` reuse.

## Root cause

`CacheList.is_trimmable()` only means its children can currently rewind some amount. The memory cache treated it as permission to rewind an arbitrary LCP distance, while `_trim_cache_offset` merely deep-copied unknown wrappers without trimming them. A divergent request that shared only the chat-template prefix could therefore inherit the previous DeepSeek pooling suffix and be reported as a cache hit.

This matters because a cache hit must be semantically identical to cold prefill; reusing an unreachable nested state crosses request-isolation boundaries and can make an agent act on text that was never in its prompt.

## Impact

Cross-task DeepSeek requests no longer inherit semantic state from a prior prompt. Exact-prefix multi-turn reuse is unchanged, valid DeepSeek trim-based reuse remains available when every nested cache can perform the requested rewind, and non-DeepSeek wrapper paths are unchanged.

## Validation

- Deterministic pre-fix reproduction on `origin/main`: divergent BOS request incorrectly returned a one-token hit.
- Fixed unit reproduction: unrewindable DeepSeek pooling suffix returns MISS.
- Real model: loaded the original persisted 57/89-token entries that preceded the contaminated soak; a fresh request logged `could not rewind exactly by 55 tokens`, returned `cached_tokens=0`, and answered `42` without prior-task content.
- Initial focused suite: 206 passed across memory cache, persistence, DeepSeek vendored cache, and TurboQuant tests.
- Review follow-up: narrowed exact rewind to DeepSeek V4 pooling wrappers so unrelated model families retain their established cache behavior.
- Final focused suite: 218 passed across memory cache, radix E2E, persistence, DeepSeek vendored cache, and TurboQuant tests.
- Final Codex adversarial review: zero blocker and zero nit.
- Latest-commit broader regression: 15,403 passed, 30 skipped, 6 xfailed, 1 xpassed.
- Two full stress matrices were run before the change was scoped to DeepSeek-only behavior. Their non-DeepSeek failures were an existing intermittent `logits_processors=None` batching race (different model each run) plus a Qwen3.5 cold benchmark compared with a stale Rapid-MLX 0.11.0 baseline; clean main independently measured 204ms cold median. A third identical stress run was not repeated after non-DeepSeek cache behavior was restored byte-for-byte.
