### PR TITLE
fix(rapid-mac): six desktop UX defects — sidebar ordering, onboarding scope, catalog cache, stale-manifest copy

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
@@ -99,13 +99,26 @@ final class ChatViewModel {
     /// Snapshot the active conversation into ``conversations`` + disk. A
     /// no-op until the user has actually sent something (no empty rows in
     /// the sidebar). Title is derived from the first user message.
-    private func persistActive() {
+    ///
+    /// - Parameter touching: whether this counts as *activity*. Only a real
+    ///   change to the transcript should refresh ``updatedAt`` and bubble the
+    ///   row to the top. Merely opening a conversation to read it, or leaving
+    ///   it to start a new one, archives the buffer without claiming the user
+    ///   did anything to it — otherwise clicking through history silently
+    ///   reshuffles the sidebar, and the list stops reflecting when each
+    ///   conversation was last *worked on*.
+    private func persistActive(touching: Bool = true) {
         guard messages.contains(where: { $0.role == .user }) else { return }
         let now = Date()
         let title = ConversationStore.title(from: messages)
         if let idx = conversations.firstIndex(where: { $0.id == activeConversationID }) {
             conversations[idx].messages = messages
             conversations[idx].title = title
+            guard touching else {
+                // Content written back, position and timestamp left alone.
+                ConversationStore.save(conversations)
+                return
+            }
             conversations[idx].updatedAt = now
             // Bubble the just-touched conversation to the top.
             let updated = conversations.remove(at: idx)
@@ -136,7 +149,7 @@ final class ChatViewModel {
         // is what gets persisted and a mid-stream switch doesn't leave the
         // incoming conversation showing Stop.
         isStreaming = false
-        persistActive()
+        persistActive(touching: false)
         guard let conv = conversations.first(where: { $0.id == id }) else { return }
         messages = conv.messages
         activeConversationID = id
@@ -205,7 +218,7 @@ final class ChatViewModel {
         // chat stuck showing Stop (isStreaming never reset). Setting it
         // false here also archives the just-closed conversation via didSet.
         isStreaming = false
-        persistActive()
+        persistActive(touching: false)
         messages.removeAll()
         activeConversationID = UUID()
         lastError = nil

--- a/apps/rapid-mac/Sources/Rapid/Chat/ConversationHistory.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ConversationHistory.swift
@@ -56,7 +56,15 @@ enum ConversationStore {
             try? fm.moveItem(at: url, to: backup)
             return []
         }
-        return decoded
+        // Sort here rather than trusting the file's array order. ``save``
+        // writes whatever order the in-memory array happens to be in, which
+        // ``ChatViewModel.persistActive`` keeps newest-first only as a side
+        // effect of its ``insert(at: 0)`` bubbling. Any path that doesn't go
+        // through that bubble — a hand-edited file, a future bulk import, a
+        // partially-applied migration — would surface out of order in the
+        // sidebar with nothing to correct it. Guaranteeing the invariant at
+        // the data boundary costs one sort and removes the whole class.
+        return decoded.sorted { $0.updatedAt > $1.updatedAt }
     }
 
     /// Serial queue for history writes: every save re-encodes the whole

--- a/apps/rapid-mac/Sources/Rapid/Server/ModelCatalogCache.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ModelCatalogCache.swift
@@ -1,0 +1,147 @@
+import Foundation
+
+/// Process-wide cache in front of ``ModelCatalog/load(binary:hubCacheOverride:)``.
+///
+/// Every catalog read forks **at least two** `rapid-mlx` subprocesses — `models`
+/// and `ls`, plus one `info` per cached sibling — and five separate surfaces
+/// call it (both settings panels, the composer's model picker, launch
+/// auto-start, and deletion). None of them shared anything, so simply moving
+/// between Models and Model Management paid for a fresh round of process
+/// spawns and showed a spinner each time.
+///
+/// ## Staleness is bounded, not merely time-limited
+///
+/// Entries are keyed on ``DownloadManager/cacheGeneration``, the counter the app
+/// already bumps whenever the on-disk model set changes (download finished,
+/// alias deleted, models folder repointed). A cached snapshot is therefore
+/// invalidated by the *event* that makes it wrong rather than by a timer that
+/// might fire too late — an expiring TTL would still hand out a stale
+/// "downloaded" badge for however long it had left to run.
+///
+/// A short TTL is kept **on top of** that as a backstop for changes nothing
+/// announces: a model deleted from `~/.cache/huggingface` by another tool, or
+/// by `rapid-mlx` from a terminal.
+///
+/// ## Serving stale while revalidating
+///
+/// ``entries(binary:generation:)`` returns any usable snapshot immediately and
+/// refreshes in the background. The first read of a generation has nothing to
+/// serve and awaits the real load; every read after that is instant. Callers
+/// distinguish the two via ``cached(binary:generation:)`` so they can show a
+/// spinner only when there is genuinely nothing to show.
+actor ModelCatalogCache {
+    static let shared = ModelCatalogCache()
+
+    /// Backstop for out-of-band changes (see above).
+    ///
+    /// Five minutes, not seconds: ``cacheGeneration`` already catches every
+    /// mutation the app makes, so this only has to bound how long an edit made
+    /// *outside* the app can go unnoticed. An earlier 30s value expired while
+    /// the user was simply reading the Settings panel — measured MISSes at
+    /// age=33s and age=40s during ordinary tab switching — which is exactly
+    /// the needless refetch this cache exists to remove.
+    private static let ttl: TimeInterval = 300
+
+    private struct Snapshot {
+        let entries: [ModelEntry]
+        let generation: UInt
+        let fetchedAt: Date
+        /// The override in force when this was captured. Pointing the models
+        /// folder somewhere else changes what "cached" means for every alias,
+        /// so a snapshot taken under a different root cannot be reused.
+        let overridePath: String?
+    }
+
+    private var snapshot: Snapshot?
+
+    /// Mirror of ``snapshot`` readable without `await`.
+    ///
+    /// SwiftUI builds `@State` initial values synchronously, so a view cannot
+    /// consult an actor before its first frame. Without this, a panel that
+    /// re-appears starts at `catalog = []` + `loading = true`, renders the
+    /// spinner, and only replaces it once the `.task` resumes — the cache
+    /// removes the subprocess cost but the *flash* remains, which is the part
+    /// the user actually sees.
+    ///
+    /// `nonisolated(unsafe)` is sound here for the same reason the actor is
+    /// enough elsewhere: writes happen only from inside the actor (a single
+    /// serialised context), and the value is a `let`-only struct of immutable
+    /// members. A reader can observe a slightly older snapshot, never a torn
+    /// one — and "slightly older" is exactly what a cache promises.
+    nonisolated(unsafe) private static var lastSnapshot: Snapshot?
+
+    /// Synchronous peek for `@State` seeding. Returns entries only when they
+    /// would also satisfy ``cached(binary:generation:)``.
+    nonisolated static func seed(generation: UInt) -> [ModelEntry]? {
+        guard let snap = lastSnapshot,
+              snap.generation == generation,
+              snap.overridePath == ModelsFolderPreference.validatedOverrideURL()?.path,
+              Date().timeIntervalSince(snap.fetchedAt) < ttl
+        else { return nil }
+        return snap.entries
+    }
+
+    /// In-flight load, so N simultaneous views trigger one set of subprocesses
+    /// instead of N. Without this the first paint after launch — picker plus
+    /// auto-start plus whichever panel is open — would fan out.
+    private var inFlight: Task<[ModelEntry], Never>?
+
+    /// A snapshot only if one is currently valid; never triggers a load.
+    ///
+    /// Views use this to decide whether to show a loading state: `nil` means
+    /// "nothing to display yet", not "nothing exists".
+    func cached(binary: URL, generation: UInt) -> [ModelEntry]? {
+        guard let snapshot, isFresh(snapshot, generation: generation) else {
+            return nil
+        }
+        return snapshot.entries
+    }
+
+    /// The catalog, served from cache when possible.
+    ///
+    /// Returns immediately with a valid snapshot; otherwise awaits a real load
+    /// (joining one already running rather than starting a second).
+    func entries(binary: URL, generation: UInt) async -> [ModelEntry] {
+        if let snapshot, isFresh(snapshot, generation: generation) {
+            return snapshot.entries
+        }
+        if let inFlight {
+            return await inFlight.value
+        }
+        let override = ModelsFolderPreference.validatedOverrideURL()
+        let task = Task<[ModelEntry], Never> {
+            await ModelCatalog.load(binary: binary, hubCacheOverride: override)
+        }
+        inFlight = task
+        let loaded = await task.value
+        // Stamp with the generation captured at call time. If a mutation
+        // landed mid-load the counter has already moved on, so this snapshot
+        // is born stale and the next read refetches — which is the correct
+        // outcome: the load observed the world before the change.
+        snapshot = Snapshot(
+            entries: loaded,
+            generation: generation,
+            fetchedAt: Date(),
+            overridePath: override?.path
+        )
+        Self.lastSnapshot = snapshot
+        inFlight = nil
+        return loaded
+    }
+
+    /// Drop the snapshot. For callers that mutate the model set themselves and
+    /// want the next read to be authoritative without waiting on the
+    /// generation counter to propagate.
+    func invalidate() {
+        snapshot = nil
+        Self.lastSnapshot = nil
+    }
+
+    private func isFresh(_ snapshot: Snapshot, generation: UInt) -> Bool {
+        guard snapshot.generation == generation else { return false }
+        guard snapshot.overridePath == ModelsFolderPreference.validatedOverrideURL()?.path else {
+            return false
+        }
+        return Date().timeIntervalSince(snapshot.fetchedAt) < Self.ttl
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/Server/ModelDeletion.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ModelDeletion.swift
@@ -112,6 +112,11 @@ enum ModelDeletion {
     }
 
     private static func cachedRepo(for alias: String, binary: URL) async -> String? {
+        // Deliberately NOT routed through ``ModelCatalogCache``: this resolves
+        // which directory is about to be deleted. A snapshot that is even
+        // slightly stale could name the wrong repo, and the cost of being
+        // wrong here is destroying the wrong download. Two subprocesses is a
+        // fine price for reading the world as it is at deletion time.
         let entries = await ModelCatalog.load(binary: binary)
         return entries.first { $0.alias == alias && $0.cached }?.hfRepo
     }

--- a/apps/rapid-mac/Sources/Rapid/UI/ConnectToolsView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ConnectToolsView.swift
@@ -36,7 +36,22 @@ struct ConnectToolsView: View {
                 cardContent
             }
         }
-        .frame(width: 460, height: 560)
+        // Size follows context, the same way ``showsCloseButton`` does.
+        //
+        // 460×560 is a sheet's size. As the Launch *page* it left the cards in
+        // a narrow column stranded in the middle of a 1200pt window, and the
+        // hard 560pt height forced a second scrollbar inside a pane that was
+        // already tall enough to show everything. Filling the pane instead
+        // lets the cards use the width that is actually there.
+        .frame(
+            width: showsCloseButton ? 460 : nil,
+            height: showsCloseButton ? 560 : nil
+        )
+        .frame(
+            maxWidth: showsCloseButton ? nil : .infinity,
+            maxHeight: showsCloseButton ? nil : .infinity,
+            alignment: .topLeading
+        )
         .background(RapidTheme.canvas)
     }
 
@@ -52,6 +67,11 @@ struct ConnectToolsView: View {
             endpointFootnote
         }
         .padding(20)
+        // Filling the pane is not the same as stretching to it. On a wide
+        // window the cards would otherwise run the full 1200pt and the
+        // one-line instructions would span the screen; capping the measure
+        // keeps them readable while the surrounding pane still expands.
+        .frame(maxWidth: showsCloseButton ? .infinity : 720)
     }
 
     private var header: some View {
@@ -63,6 +83,19 @@ struct ConnectToolsView: View {
                     .font(.callout)
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
+                // The key only exists while the server is running, and it is
+                // regenerated on every start. Without this the cards render
+                // `API key:` followed by nothing — a config that looks
+                // complete, copies clean, and fails at the far end with a 401.
+                if bearer.isEmpty {
+                    Label(
+                        "Server not running — start a chat to generate the key.",
+                        systemImage: "exclamationmark.circle"
+                    )
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+                    .padding(.top, 4)
+                }
             }
             Spacer()
             if showsCloseButton {

--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -183,6 +183,14 @@ struct ContentView: View {
         .sheet(isPresented: firstRunSheetPresented) {
             firstRunSheet
         }
+        // Presented from the split view — NOT from `mainArea` — so onboarding
+        // covers the whole window. Rendered inside the detail pane it left the
+        // sidebar exposed and clickable, which reads as "the app is already
+        // running, this panel is just one more surface" rather than "finish
+        // setup first".
+        .sheet(isPresented: quickstartSheetPresented) {
+            quickstartSheet
+        }
         .task { await runLaunchAutoStart() }
     }
 
@@ -206,26 +214,47 @@ struct ContentView: View {
     private var mainArea: some View {
         switch ContentView.mainAreaBranch(for: server.state) {
         case .chat(let serverReady):
-            if quickstartVisible {
-                QuickstartView(
-                    coordinator: quickstart,
-                    downloads: downloads,
-                    server: server,
-                    onBrowseAll: { quickstartDismissedThisSession = true },
-                    onSeedWelcome: { true }
-                )
-            } else {
-                ChatView(
-                    viewModel: chat,
-                    server: server,
-                    alias: $alias,
-                    serverReady: serverReady,
-                    autoStartPendingDownload: autoStartPendingDownload
-                )
-            }
+            ChatView(
+                viewModel: chat,
+                server: server,
+                alias: $alias,
+                serverReady: serverReady,
+                autoStartPendingDownload: autoStartPendingDownload
+            )
         case .missing:
             missingOverlay
         }
+    }
+
+    // MARK: - Quickstart presentation
+
+    private var quickstartSheetPresented: Binding<Bool> {
+        Binding(
+            get: { quickstartVisible },
+            set: { presented in
+                // A swipe-down / Esc means "let me look around first" — the
+                // same intent as the card's own "Browse all models", so route
+                // it to the same session flag rather than dropping it.
+                if !presented { quickstartDismissedThisSession = true }
+            }
+        )
+    }
+
+    @ViewBuilder
+    private var quickstartSheet: some View {
+        QuickstartView(
+            coordinator: quickstart,
+            downloads: downloads,
+            server: server,
+            onBrowseAll: { quickstartDismissedThisSession = true },
+            onSeedWelcome: { true }
+        )
+        // QuickstartView was written for the detail column and its comments
+        // cite a ~360pt worst case (the 640pt window floor minus the sidebar).
+        // A sheet has no such parent, so without an explicit size it would
+        // collapse to its content's ideal width. Pin it near the window floor
+        // so the model cards keep the room they were laid out for.
+        .frame(minWidth: 620, minHeight: Self.minWindowHeight)
     }
 
     /// True when the Quickstart card should render in place of the chat
@@ -235,6 +264,13 @@ struct ContentView: View {
     /// ``QuickstartCoordinator.isEligible``), never the shared HF cache.
     private var quickstartVisible: Bool {
         guard !quickstartDismissedThisSession else { return false }
+        // Telemetry consent comes first. Both surfaces used to be able to fire
+        // together (nothing referenced the other's condition) — tolerable when
+        // Quickstart merely filled the detail pane behind the consent sheet,
+        // but now they compete for the same presentation channel, and macOS
+        // grants that to whichever asks first. Deferring here keeps the order
+        // deterministic: decide on telemetry, then pick a model.
+        guard !telemetryConsentPending else { return false }
         if ContentView.serverEngagedWithDifferentAlias(
             state: server.state,
             quickstartAlias: quickstart.selection.alias
@@ -420,7 +456,10 @@ struct ContentView: View {
         let aliasAtEntry = alias
         var cachedAliases: Set<String> = []
         if let binary = server.binaryPath {
-            let entries = await ModelCatalog.load(binary: binary)
+            let entries = await ModelCatalogCache.shared.entries(
+                binary: binary,
+                generation: downloads.cacheGeneration
+            )
             cachedAliases = Set(entries.filter { $0.cached }.map(\.alias))
         }
         guard case .idle = server.state else {

--- a/apps/rapid-mac/Sources/Rapid/UI/ModelPickerBar.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ModelPickerBar.swift
@@ -1914,7 +1914,10 @@ struct ModelPickerBar: View {
                 loadingCatalog = false
             }
         }
-        let entries = await ModelCatalog.load(binary: binary)
+        let entries = await ModelCatalogCache.shared.entries(
+            binary: binary,
+            generation: downloads.cacheGeneration
+        )
         guard !Task.isCancelled, catalogRefreshGeneration == refreshGeneration else { return }
         self.catalog = entries
         // Default selection: only apply if the current alias is blank or

--- a/apps/rapid-mac/Sources/Rapid/UI/SettingsModelManagementPanel.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SettingsModelManagementPanel.swift
@@ -33,8 +33,11 @@ struct SettingsModelManagementPanel: View {
     @Environment(ServerManager.self) private var server
     @Environment(DownloadManager.self) private var downloads
 
-    @State private var catalog: [ModelEntry] = []
-    @State private var loading: Bool = true
+    // Seeded from the process-wide cache — see the matching note in
+    // ``SettingsModelsPanel``. An empty start re-rendered the spinner on every
+    // visit regardless of whether the data was already cached.
+    @State private var catalog: [ModelEntry] = ModelCatalogCache.seed(generation: 0) ?? []
+    @State private var loading: Bool = ModelCatalogCache.seed(generation: 0) == nil
     @State private var pendingDeletion: ModelEntry?
     @State private var lastError: String?
     @State private var lastFreed: String?
@@ -1069,13 +1072,27 @@ struct SettingsModelManagementPanel: View {
     // MARK: - Actions
 
     private func refreshCatalog() async {
-        loading = true
-        defer { loading = false }
         guard let binary = server.binaryPath else {
             catalog = []
+            loading = false
             return
         }
-        catalog = await ModelCatalog.load(binary: binary)
+        let generation = downloads.cacheGeneration
+        // Show a cached snapshot straight away and skip the spinner entirely —
+        // flashing "loading" over data we already have makes every visit to
+        // this panel feel like a cold start.
+        if let hit = await ModelCatalogCache.shared.cached(
+            binary: binary, generation: generation
+        ) {
+            catalog = hit
+            loading = false
+            return
+        }
+        loading = true
+        defer { loading = false }
+        catalog = await ModelCatalogCache.shared.entries(
+            binary: binary, generation: generation
+        )
     }
 
     private func deleteAlias(_ entry: ModelEntry) async {

--- a/apps/rapid-mac/Sources/Rapid/UI/SettingsModelsPanel.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SettingsModelsPanel.swift
@@ -32,8 +32,17 @@ struct SettingsModelsPanel: View {
     @Environment(ServerManager.self) private var server
     @Environment(DownloadManager.self) private var downloads
 
-    @State private var catalog: [ModelEntry] = []
-    @State private var loading: Bool = true
+    // Seeded from the process-wide cache rather than starting empty. `@State`
+    // is rebuilt every time this panel re-appears, so an empty start meant the
+    // spinner rendered on the first frame of every visit — even when the data
+    // was already in hand and the refresh would resolve instantly.
+    //
+    // Generation 0 is the right key here: `@State` initialisers can't read
+    // `@Environment`, and a fresh app run starts at 0. If the real generation
+    // has moved on, the `.task` below simply refetches — the seed is an
+    // optimisation, never the source of truth.
+    @State private var catalog: [ModelEntry] = ModelCatalogCache.seed(generation: 0) ?? []
+    @State private var loading: Bool = ModelCatalogCache.seed(generation: 0) == nil
     @State private var pendingDeletion: ModelEntry?
     @State private var lastError: String?
     @State private var lastFreed: String?
@@ -564,13 +573,26 @@ struct SettingsModelsPanel: View {
     // MARK: - Actions
 
     private func refreshCatalog() async {
-        loading = true
-        defer { loading = false }
         guard let binary = server.binaryPath else {
             catalog = []
+            loading = false
             return
         }
-        catalog = await ModelCatalog.load(binary: binary)
+        let generation = downloads.cacheGeneration
+        // Cached snapshot → paint it and skip the spinner (see
+        // ``ModelCatalogCache``); only a genuine miss shows a loading state.
+        if let hit = await ModelCatalogCache.shared.cached(
+            binary: binary, generation: generation
+        ) {
+            catalog = hit
+            loading = false
+            return
+        }
+        loading = true
+        defer { loading = false }
+        catalog = await ModelCatalogCache.shared.entries(
+            binary: binary, generation: generation
+        )
     }
 
     private func deleteAlias(_ entry: ModelEntry) async {

--- a/apps/rapid-mac/Sources/Rapid/UI/SettingsView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SettingsView.swift
@@ -445,7 +445,19 @@ struct SettingsView: View {
                     value: "v\(appUpdater.currentVersion)",
                     monospaced: true
                 )
-                if let release = appUpdater.latest {
+                // Only show the manifest's version when it is actually at or
+                // ahead of what's installed. A manifest BEHIND the installed
+                // build means the release feed is stale (or this is a dev /
+                // pre-release build) — labelling an older number "Latest
+                // release" reads as if the user is somehow ahead of the
+                // world, or that their install is wrong.
+                //
+                // ``appUpdateStatus`` already models exactly this case
+                // (installed strictly newer → ``.unknown``, see the truth
+                // table below), but this row rendered ``latest`` directly and
+                // so bypassed that judgement. Gate it on the same predicate.
+                if let release = appUpdater.latest,
+                   !UpdateChecker.isNewer(appUpdater.currentVersion, than: release.version) {
                     versionRow(
                         label: "Latest release",
                         value: "v\(release.version)",
@@ -566,6 +578,9 @@ struct SettingsView: View {
         case available(version: String)
         case upToDate(version: String)
         case checking
+        /// Poll succeeded but the manifest is behind the installed build.
+        /// Not an error and not "unknown" — see ``resolveAppUpdateStatus``.
+        case aheadOfManifest(current: String, manifest: String)
         case unknown(reason: String?)
     }
 
@@ -588,9 +603,14 @@ struct SettingsView: View {
     ///      ``currentVersion`` is ahead of the manifest does NOT
     ///      collapse into the reassuring "up to date" state (v0.7.4
     ///      status-bar regression).
-    ///   4. Otherwise (check completed but ``latest == nil`` —
-    ///      worker errored, payload rejected, or installed build is
-    ///      ahead of the manifest) → ``.unknown(lastError)``.
+    ///   4. A check completed and returned a manifest OLDER than the
+    ///      installed build → ``.aheadOfManifest``. Distinct from
+    ///      ``.unknown``: nothing failed and nothing is missing, so
+    ///      telling the user to press "Check for updates" would send
+    ///      them to re-run a poll that already succeeded and will keep
+    ///      returning the same answer.
+    ///   5. Otherwise (check completed but ``latest == nil`` — worker
+    ///      errored or payload rejected) → ``.unknown(lastError)``.
     static func resolveAppUpdateStatus(
         currentVersion: String,
         availableUpdate: UpdateChecker.Release?,
@@ -613,6 +633,16 @@ struct SettingsView: View {
             // if ``latest`` were strictly newer than us, so the only
             // remaining case here is equality.)
             return .upToDate(version: currentVersion)
+        }
+        if let latest, UpdateChecker.isNewer(currentVersion, than: latest.version) {
+            // The poll worked; the feed is just behind us. A dev build, or a
+            // release that shipped to GitHub before `latest.json` was
+            // republished. Either way it is a statement of fact, not an
+            // error, and re-checking cannot change it.
+            return .aheadOfManifest(
+                current: currentVersion,
+                manifest: latest.version
+            )
         }
         // ``lastCheckedAt`` set but EITHER ``latest`` is nil (most
         // recent attempt populated ``lastError`` instead of a
@@ -686,6 +716,21 @@ struct SettingsView: View {
                 }
                 Spacer()
                 appUpdateRecheckButton
+            case .aheadOfManifest(let current, _):
+                HStack(spacing: 6) {
+                    Image(systemName: "checkmark.circle")
+                        .foregroundStyle(.secondary)
+                    Text("Up to date — v\(current).")
+                        .font(.callout)
+                        .foregroundStyle(.primary)
+                        .accessibilityIdentifier("Settings.App.AheadOfManifest")
+                }
+                Spacer()
+                // No re-check button. The poll already succeeded; the feed is
+                // simply behind this build, and pressing it again returns the
+                // same answer. An action that provably cannot change anything
+                // is worse than no action — it invites the user to keep
+                // trying and reads as if something is wrong.
             case .unknown(let reason):
                 HStack(spacing: 6) {
                     Image(systemName: "questionmark.circle")

--- a/apps/rapid-mac/Sources/Rapid/UI/SidebarView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SidebarView.swift
@@ -38,16 +38,18 @@ struct SidebarView: View {
             )
 
             if !chat.conversations.isEmpty {
-                Text("Older")
-                    .font(.caption.weight(.medium))
-                    .foregroundStyle(.secondary)
-                    .padding(.horizontal, 10)
-                    .padding(.top, 12)
-                    .padding(.bottom, 2)
                 ScrollView {
                     VStack(alignment: .leading, spacing: 2) {
-                        ForEach(chat.conversations) { conv in
-                            conversationRow(conv)
+                        ForEach(historySections, id: \.title) { section in
+                            Text(section.title)
+                                .font(.caption.weight(.medium))
+                                .foregroundStyle(.secondary)
+                                .padding(.horizontal, 10)
+                                .padding(.top, 12)
+                                .padding(.bottom, 2)
+                            ForEach(section.conversations) { conv in
+                                conversationRow(conv)
+                            }
                         }
                     }
                 }
@@ -57,6 +59,65 @@ struct SidebarView: View {
         }
         .padding(8)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+    }
+
+    /// The history list split into dated sections, newest first.
+    ///
+    /// Everything used to sit under a hard-coded "Older" heading, so a
+    /// conversation five seconds old was filed as ancient history.
+    private var historySections: [HistorySection] {
+        SidebarView.sections(for: chat.conversations, now: Date())
+    }
+
+    struct HistorySection {
+        let title: String
+        let conversations: [ChatConversation]
+    }
+
+    /// Bucket conversations by recency. ``now`` is injected rather than read
+    /// inside, matching ``RelativeTimestamp`` — it keeps the function pure so
+    /// the day boundaries can be exercised without waiting for midnight.
+    ///
+    /// Uses `Calendar` (not a fixed 86 400s divisor) because the buckets are
+    /// *calendar* days: something sent at 23:55 belongs to "Yesterday" once
+    /// the clock passes midnight, even though barely any time has elapsed.
+    /// Empty buckets produce no section, so no stray headings appear.
+    static func sections(
+        for conversations: [ChatConversation],
+        now: Date,
+        calendar: Calendar = .current
+    ) -> [HistorySection] {
+        var today: [ChatConversation] = []
+        var yesterday: [ChatConversation] = []
+        var week: [ChatConversation] = []
+        var older: [ChatConversation] = []
+
+        // The 7-day cutoff is anchored to the START of today, not to `now` —
+        // otherwise the boundary would drift through the day and a
+        // conversation could slide between sections while the user watches.
+        let startOfToday = calendar.startOfDay(for: now)
+        let weekCutoff = calendar.date(byAdding: .day, value: -7, to: startOfToday)
+
+        for conv in conversations {
+            if calendar.isDate(conv.updatedAt, inSameDayAs: now) {
+                today.append(conv)
+            } else if calendar.isDateInYesterday(conv.updatedAt) {
+                yesterday.append(conv)
+            } else if let weekCutoff, conv.updatedAt >= weekCutoff {
+                week.append(conv)
+            } else {
+                older.append(conv)
+            }
+        }
+
+        return [
+            ("Today", today),
+            ("Yesterday", yesterday),
+            ("Previous 7 Days", week),
+            ("Older", older),
+        ]
+        .filter { !$0.1.isEmpty }
+        .map { HistorySection(title: $0.0, conversations: $0.1) }
     }
 
     /// One history row — the conversation's derived title, amber-selected


### PR DESCRIPTION
## What does this PR do?

Six independent fixes found by using the desktop app as a new user would, then
reading the code behind each symptom. All confined to `apps/rapid-mac`.

| | symptom | cause |
|---|---|---|
| 1 | opening a conversation reordered the sidebar | `persistActive()` stamps `updatedAt` for all four callers, including the two that only navigate |
| 2 | everything filed under "Older", including a chat 5s old | the heading was hard-coded; no bucketing existed |
| 3 | spinner + two subprocesses on every Settings visit | `ModelCatalog.load` had no cache and five unrelated callers |
| 4 | onboarding left the sidebar exposed and clickable | Quickstart rendered inside the split view's `detail:` branch |
| 5 | "Latest release v0.11.0" + "status unknown — press Check for updates" | `.unknown` conflated three situations; the version row bypassed the resolver |
| 6 | Launch page as a narrow column with a nested scrollbar | `ConnectToolsView` kept its sheet frame (460×560) when used as a page |

Each is its own commit with the reasoning in the message.

## Why is this needed?

Every item is a user-visible defect reproduced on a current build, not a
refactor or a coverage exercise:

- **#1** the history list stops meaning "last worked on" — reading reorders it.
- **#4** setup reads as one more panel beside a working app instead of something
  to finish, and the sidebar stays live underneath. The two first-run surfaces
  also had no ordering relationship — nothing in `quickstartVisible` referenced
  `telemetryConsentPending` — so both could fire at once.
- **#5** the app tells the user to press a button that provably cannot change
  the answer. The underlying feed really is stale (`/api/desktop-update` and the
  `latest.json` fallback both return 0.11.0 while `rapid-mac-v0.12.1` is out) —
  that part is release plumbing and out of scope here, but the app shouldn't
  repeat it as if it were news.
- **#6** the Launch page is where the product's differentiator lives, and it
  renders as a 460pt column in the middle of a 1200pt window. It also shows
  `API key:` followed by nothing before the server starts — a config that looks
  complete, copies clean, and 401s at the far end.
- **#3** is measured, not felt: startup 2 subprocess spawns → 1, twelve panel
  switches 12 → 0.

Two of these turned out to be **half-finished intent already in the codebase**,
which is partly why I trusted the direction:

- `showsCloseButton` exists because a dead ✕ in page mode "was a real papercut"
  (#6) — the button was handled, the frame was not.
- `resolveAppUpdateStatus` already refuses to call a stale manifest "up to date"
  (the v0.7.4 regression) — but the version row rendered `appUpdater.latest`
  directly and bypassed that judgement (#5).

## AI assistance disclosure

**AI-assisted throughout, and I can explain every change.** Claude (Claude Code)
read the code, proposed each fix, and wrote the diffs and commit messages; I
directed the investigation, chose the approach at each decision point, and ran
the verification below. Every file in the diff was AI-touched. No generated
scaffold or boilerplate.

Two things worth flagging about the process, because they changed the outcome:

- The catalog cache (#3) initially "passed" on the metric I picked — subprocess
  count hit zero — while the spinner the user actually sees was still there.
  `@State` is rebuilt when a panel re-appears, so the panels started empty and
  painted the spinner before the `.task` could resume. That is what
  `seed(generation:)` is for. **The first fix measured cost, not the symptom.**
- The sidebar (#1) was verified against a running build, not reasoning: four
  conversations, five clicks including back-and-forth, order unchanged. An
  earlier round of that test looked like conversations were disappearing — that
  was my test data (four rows sharing one `messages` array, so all four derived
  the same title), not the code.

## Test plan

No Python touched, so `ruff` / `pytest` / `pr_validate` don't apply — this is
entirely `apps/rapid-mac` Swift. What I ran:

- `swift build` — clean, no warnings introduced.
- `scripts/build.sh` — full `.app` assembles and launches.
- `scripts/verify-recommendation-tiers.swift` → **ALL PASS**.
- `scripts/verify-app-resources.swift build/Rapid-MLX\ Desktop.app` → OK
  (2 assets + 44 localizable keys).
- **Date bucketing (#2)** — standalone `swift` script against a pinned reference
  time, in the `verify-*.swift` style. 12 cases, including the three that are
  easy to get wrong: 23:55 yesterday (→ Yesterday, not Previous 7 Days),
  00:00 exactly seven days back (in), one second earlier (out).
- **Sidebar order (#1)** — seeded four conversations with distinct content and
  known timestamps, clicked through them five times including revisits; order
  identical throughout, nothing lost.
- **Catalog cache (#3)** — counted `rapid-mlx` spawns during startup and during
  twelve Models ↔ Model Management switches: 2 → 1 and 12 → 0.
- **Launch page (#6)** and **Settings → App (#5)** — verified visually on the
  built app.

Not verified end-to-end: **#4 (onboarding)** builds and the presentation moved
to the split view, but reproducing it needs a wiped first-run state
(`rapid.quickstart.v1.done` + the telemetry key), which I set up but did not
walk through screen by screen. Worth a maintainer's eye on the sheet sizing in
particular.

## Checklist

- [x] Tests pass locally — Swift-side equivalents; no Python in this diff
- [x] Lint passes — n/a (`ruff` has nothing to check here)
- [ ] Self-validated with `pr_validate` — the pipeline's gating steps (`lint`,
      `targeted_tests`, `full_unit`) key on `.py` in the diff; there is none.
      Happy to run it if you'd rather see the scorecard anyway.
- [x] New behaviour spot-checked against a running build, not just compiled
- [ ] Updated README/docs — no user-facing docs describe these surfaces
- [x] No breaking changes to existing API
