### PR TITLE
fix(deepseek): enforce Codex reasoning budgets during decode

### DIFF
--- a/tests/test_responses_route.py
+++ b/tests/test_responses_route.py
@@ -1802,3 +1802,96 @@ def test_registry_engine_mismatch_fails_closed(monkeypatch):
         selected_engine, cfg, "deepseek-agent", True, kwargs
     )
     assert "suppressed_tokens_logits_processor" not in kwargs
+
+
+@pytest.mark.parametrize(
+    ("codex_surface", "has_tools", "is_deepseek", "expected"),
+    [
+        (True, True, True, True),
+        (False, True, True, False),
+        (True, False, True, False),
+        (True, True, False, False),
+    ],
+)
+def test_deepseek_codex_reasoning_budget_is_narrowly_attached(
+    monkeypatch, codex_surface, has_tools, is_deepseek, expected
+):
+    from vllm_mlx.routes.responses import _attach_deepseek_codex_reasoning_budget
+
+    processor = object()
+    calls = []
+
+    def build(*args, **kwargs):
+        calls.append((args, kwargs))
+        return processor
+
+    monkeypatch.setattr(
+        "vllm_mlx.routes.responses._uses_deepseek_v4_reasoning",
+        lambda _cfg: is_deepseek,
+    )
+    monkeypatch.setattr(
+        "vllm_mlx.api.reasoning_budget.ReasoningBudgetLogitsProcessor", build
+    )
+    monkeypatch.setattr(
+        "vllm_mlx.routes.chat._engine_output_vocab_size", lambda _engine: 256
+    )
+    request = SimpleNamespace(
+        tools=[object()] if has_tools else [], reasoning_max_tokens=2048
+    )
+    engine = SimpleNamespace(
+        tokenizer=SimpleNamespace(get_vocab=lambda: {"</think>": 18})
+    )
+    cfg = SimpleNamespace(
+        model_path="DeepSeek-V4-Flash-0731",
+        model_name="deepseek-v4-flash-0731",
+        reasoning_parser_name="deepseek_v4",
+    )
+    kwargs = {}
+
+    _attach_deepseek_codex_reasoning_budget(
+        engine, cfg, request, True, codex_surface, kwargs
+    )
+
+    assert (kwargs.get("reasoning_budget_logits_processor") is processor) is expected
+    assert bool(calls) is expected
+    if expected:
+        assert calls[0][0] == (18, 2048)
+        assert calls[0][1] == {"seeded_thinking": True}
+
+
+@pytest.mark.parametrize(
+    ("vocab", "vocab_size", "resolved_thinking", "budget"),
+    [
+        ({}, 256, True, 2048),
+        ({"</think>": 256}, 256, True, 2048),
+        ({"</think>": 18}, None, True, 2048),
+        ({"</think>": 18}, 256, False, 2048),
+        ({"</think>": 18}, 256, True, None),
+    ],
+)
+def test_deepseek_codex_reasoning_budget_fails_closed(
+    monkeypatch, vocab, vocab_size, resolved_thinking, budget
+):
+    from vllm_mlx.routes.responses import _attach_deepseek_codex_reasoning_budget
+
+    monkeypatch.setattr(
+        "vllm_mlx.routes.responses._uses_deepseek_v4_reasoning", lambda _cfg: True
+    )
+    monkeypatch.setattr(
+        "vllm_mlx.routes.chat._engine_output_vocab_size",
+        lambda _engine: vocab_size,
+    )
+    engine = SimpleNamespace(tokenizer=SimpleNamespace(get_vocab=lambda: vocab))
+    cfg = SimpleNamespace(
+        model_path="DeepSeek-V4-Flash-0731",
+        model_name="deepseek-v4-flash-0731",
+        reasoning_parser_name="deepseek_v4",
+    )
+    request = SimpleNamespace(tools=[object()], reasoning_max_tokens=budget)
+    kwargs = {}
+
+    _attach_deepseek_codex_reasoning_budget(
+        engine, cfg, request, resolved_thinking, True, kwargs
+    )
+
+    assert "reasoning_budget_logits_processor" not in kwargs

--- a/tests/test_responses_route.py
+++ b/tests/test_responses_route.py
@@ -1860,17 +1860,15 @@ def test_deepseek_codex_reasoning_budget_is_narrowly_attached(
 
 
 @pytest.mark.parametrize(
-    ("vocab", "vocab_size", "resolved_thinking", "budget"),
+    ("vocab", "vocab_size"),
     [
-        ({}, 256, True, 2048),
-        ({"</think>": 256}, 256, True, 2048),
-        ({"</think>": 18}, None, True, 2048),
-        ({"</think>": 18}, 256, False, 2048),
-        ({"</think>": 18}, 256, True, None),
+        ({}, 256),
+        ({"</think>": 256}, 256),
+        ({"</think>": 18}, None),
     ],
 )
-def test_deepseek_codex_reasoning_budget_fails_closed(
-    monkeypatch, vocab, vocab_size, resolved_thinking, budget
+def test_deepseek_codex_reasoning_budget_rejects_unsafe_metadata(
+    monkeypatch, vocab, vocab_size
 ):
     from vllm_mlx.routes.responses import _attach_deepseek_codex_reasoning_budget
 
@@ -1887,6 +1885,29 @@ def test_deepseek_codex_reasoning_budget_fails_closed(
         model_name="deepseek-v4-flash-0731",
         reasoning_parser_name="deepseek_v4",
     )
+    request = SimpleNamespace(tools=[object()], reasoning_max_tokens=2048)
+    kwargs = {}
+
+    with pytest.raises(RuntimeError, match="reasoning budget unavailable"):
+        _attach_deepseek_codex_reasoning_budget(
+            engine, cfg, request, True, True, kwargs
+        )
+
+    assert "reasoning_budget_logits_processor" not in kwargs
+
+
+@pytest.mark.parametrize(("resolved_thinking", "budget"), [(False, 2048), (True, None)])
+def test_deepseek_codex_reasoning_budget_keeps_explicit_opt_outs(
+    resolved_thinking, budget
+):
+    from vllm_mlx.routes.responses import _attach_deepseek_codex_reasoning_budget
+
+    engine = SimpleNamespace(tokenizer=SimpleNamespace())
+    cfg = SimpleNamespace(
+        model_path="DeepSeek-V4-Flash-0731",
+        model_name="deepseek-v4-flash-0731",
+        reasoning_parser_name="deepseek_v4",
+    )
     request = SimpleNamespace(tools=[object()], reasoning_max_tokens=budget)
     kwargs = {}
 
@@ -1895,6 +1916,34 @@ def test_deepseek_codex_reasoning_budget_fails_closed(
     )
 
     assert "reasoning_budget_logits_processor" not in kwargs
+
+
+def test_deepseek_codex_reasoning_boundary_is_cached_per_engine(monkeypatch):
+    from vllm_mlx.routes.responses import _attach_deepseek_codex_reasoning_budget
+
+    calls = 0
+
+    def get_vocab():
+        nonlocal calls
+        calls += 1
+        return {"</think>": 18}
+
+    monkeypatch.setattr(
+        "vllm_mlx.routes.chat._engine_output_vocab_size", lambda _engine: 256
+    )
+    engine = SimpleNamespace(tokenizer=SimpleNamespace(get_vocab=get_vocab))
+    cfg = SimpleNamespace(
+        model_path="DeepSeek-V4-Flash-0731",
+        model_name="deepseek-v4-flash-0731",
+        reasoning_parser_name="deepseek_v4",
+    )
+    request = SimpleNamespace(tools=[object()], reasoning_max_tokens=2048)
+
+    for _ in range(2):
+        _attach_deepseek_codex_reasoning_budget(engine, cfg, request, True, True, {})
+
+    assert calls == 1
+    assert engine._rapid_mlx_deepseek_codex_reasoning_boundary == (18, 256)
 
 
 @pytest.mark.parametrize("stream", [False, True])

--- a/tests/test_responses_route.py
+++ b/tests/test_responses_route.py
@@ -1895,3 +1895,52 @@ def test_deepseek_codex_reasoning_budget_fails_closed(
     )
 
     assert "reasoning_budget_logits_processor" not in kwargs
+
+
+@pytest.mark.parametrize("stream", [False, True])
+@pytest.mark.parametrize(
+    ("tool_parser", "expected"),
+    [("deepseek_v4_0731", True), ("qwen3", False)],
+)
+def test_responses_route_wires_deepseek_codex_reasoning_budget(
+    monkeypatch, responses_client, stream, tool_parser, expected
+):
+    from vllm_mlx.api.reasoning_budget import ReasoningBudgetLogitsProcessor
+    from vllm_mlx.config import get_config
+
+    cfg = get_config()
+    cfg.model_name = "deepseek-v4-flash-0731"
+    cfg.model_path = "DeepSeek-V4-Flash-0731"
+    cfg.reasoning_parser_name = "deepseek_v4"
+    cfg.tool_call_parser = tool_parser
+    engine = responses_client.engine
+    engine.tokenizer.get_vocab = lambda: {"</think>": 18}
+    monkeypatch.setattr(
+        "vllm_mlx.routes.chat._engine_output_vocab_size", lambda _engine: 256
+    )
+    tools = [
+        {
+            "type": "function",
+            "name": name,
+            "description": name,
+            "parameters": {"type": "object", "properties": {}},
+        }
+        for name in ("exec_command", "write_stdin")
+    ]
+
+    response = responses_client.client.post(
+        "/v1/responses",
+        json=_payload(
+            model="deepseek-v4-flash-0731",
+            input="inspect the repository",
+            tools=tools,
+            reasoning={"effort": "medium"},
+            stream=stream,
+        ),
+        headers={"Authorization": "Bearer test-secret"},
+    )
+
+    assert response.status_code == 200, response.text
+    calls = engine.stream_calls if stream else engine.calls
+    processor = calls[-1].kwargs.get("reasoning_budget_logits_processor")
+    assert isinstance(processor, ReasoningBudgetLogitsProcessor) is expected

--- a/vllm_mlx/routes/responses.py
+++ b/vllm_mlx/routes/responses.py
@@ -485,6 +485,63 @@ def _attach_deepseek_no_think_suppression(
     )
 
 
+def _attach_deepseek_codex_reasoning_budget(
+    engine: BaseEngine,
+    cfg,
+    openai_request: ChatCompletionRequest,
+    resolved_thinking: bool | None,
+    codex_surface: bool,
+    chat_kwargs: dict,
+) -> None:
+    """Enforce the Codex reasoning tier while generation is still in ``think``.
+
+    The generic chat builder conservatively skips requests with tools because an
+    ungated grammar may already be inside a tool envelope when a budget fires.
+    DeepSeek V4's Codex/DSML path has a token-delimited ``</think>`` boundary and
+    parses tools only after that boundary, so forcing the boundary is safe here.
+    Without this coupling, Responses only trims hidden reasoning after decode;
+    long agent turns can therefore spend thousands of invisible tokens without
+    ever reaching the next action even though ``reasoning_max_tokens`` is set.
+    """
+    if (
+        not codex_surface
+        or not openai_request.tools
+        or not _uses_deepseek_v4_reasoning(cfg)
+    ):
+        return
+
+    if (
+        _effective_enable_thinking(
+            resolved_thinking, cfg.model_path or cfg.model_name
+        )
+        is not True
+        or getattr(openai_request, "reasoning_max_tokens", None) is None
+    ):
+        return
+
+    from ..api.reasoning_budget import ReasoningBudgetLogitsProcessor
+    from .chat import _engine_output_vocab_size
+
+    # This checkpoint's assistant turn is structurally in the reasoning lane:
+    # depending on the vendored tokenizer/template, the opening marker is either
+    # prefilled or is the first generated token. Treating it as seeded also avoids
+    # losing that first marker when mlx-lm establishes the processor's cumulative
+    # token baseline on its first callback.
+    tokenizer = getattr(engine, "tokenizer", None)
+    try:
+        end_id = tokenizer.get_vocab().get("</think>")
+    except Exception:
+        return
+    vocab_size = _engine_output_vocab_size(engine)
+    if not isinstance(end_id, int) or vocab_size is None or not 0 <= end_id < vocab_size:
+        return
+    chat_kwargs["reasoning_budget_logits_processor"] = ReasoningBudgetLogitsProcessor(
+        end_id,
+        getattr(openai_request, "reasoning_max_tokens", None),
+        seeded_thinking=True,
+    )
+
+
 def _should_start_in_thinking(chat_template: str, enable_thinking: bool | None) -> bool:
     """Thin wrapper over the shared
     ``service.helpers._should_start_in_thinking`` predicate.
@@ -1360,6 +1417,14 @@ async def _non_stream(
         cfg,
         responses_request.model,
         explicit_no_thinking,
+        chat_kwargs,
+    )
+    _attach_deepseek_codex_reasoning_budget(
+        engine,
+        cfg,
+        openai_request,
+        resolved_thinking,
+        codex_surface,
         chat_kwargs,
     )
 
@@ -2320,6 +2385,14 @@ async def _stream_responses(
             cfg,
             responses_request.model,
             explicit_no_thinking,
+            chat_kwargs,
+        )
+        _attach_deepseek_codex_reasoning_budget(
+            engine,
+            cfg,
+            openai_request,
+            resolved_thinking,
+            codex_surface,
             chat_kwargs,
         )
         # C-01: thread the request_id holder so disconnect_guard can

--- a/vllm_mlx/routes/responses.py
+++ b/vllm_mlx/routes/responses.py
@@ -502,6 +502,12 @@ def _attach_deepseek_codex_reasoning_budget(
     Without this coupling, Responses only trims hidden reasoning after decode;
     long agent turns can therefore spend thousands of invisible tokens without
     ever reaching the next action even though ``reasoning_max_tokens`` is set.
+
+    Once a request qualifies, missing boundary metadata is a server invariant
+    violation rather than an opt-out: silently retaining the post-hoc trim would
+    re-open the unbounded-decode failure this path exists to prevent. Streaming
+    converts this error into ``response.failed``; non-streaming returns the
+    route's normal server-error envelope.
     """
     if (
         not codex_surface
@@ -525,18 +531,39 @@ def _attach_deepseek_codex_reasoning_budget(
     # prefilled or is the first generated token. Treating it as seeded also avoids
     # losing that first marker when mlx-lm establishes the processor's cumulative
     # token baseline on its first callback.
-    tokenizer = getattr(engine, "tokenizer", None)
-    try:
-        end_id = tokenizer.get_vocab().get("</think>")
-    except Exception:
-        return
-    vocab_size = _engine_output_vocab_size(engine)
-    if (
-        not isinstance(end_id, int)
-        or vocab_size is None
-        or not 0 <= end_id < vocab_size
+    cache_attr = "_rapid_mlx_deepseek_codex_reasoning_boundary"
+    boundary = getattr(engine, cache_attr, None)
+    if not (
+        isinstance(boundary, tuple)
+        and len(boundary) == 2
+        and all(isinstance(value, int) for value in boundary)
     ):
-        return
+        tokenizer = getattr(engine, "tokenizer", None)
+        try:
+            end_id = tokenizer.get_vocab().get("</think>")
+        except Exception as exc:
+            raise RuntimeError(
+                "DeepSeek Codex reasoning budget unavailable: tokenizer cannot "
+                "resolve the </think> boundary"
+            ) from exc
+        vocab_size = _engine_output_vocab_size(engine)
+        if (
+            not isinstance(end_id, int)
+            or vocab_size is None
+            or not 0 <= end_id < vocab_size
+        ):
+            raise RuntimeError(
+                "DeepSeek Codex reasoning budget unavailable: </think> is "
+                "missing or outside the model output vocabulary"
+            )
+        boundary = (end_id, vocab_size)
+        try:
+            setattr(engine, cache_attr, boundary)
+        except (AttributeError, TypeError):
+            # Slot-only engine facades still get the enforced processor; they
+            # merely pay the one-token lookup again on their next request.
+            pass
+    end_id, _vocab_size = boundary
     chat_kwargs["reasoning_budget_logits_processor"] = ReasoningBudgetLogitsProcessor(
         end_id,
         getattr(openai_request, "reasoning_max_tokens", None),

--- a/vllm_mlx/routes/responses.py
+++ b/vllm_mlx/routes/responses.py
@@ -511,9 +511,7 @@ def _attach_deepseek_codex_reasoning_budget(
         return
 
     if (
-        _effective_enable_thinking(
-            resolved_thinking, cfg.model_path or cfg.model_name
-        )
+        _effective_enable_thinking(resolved_thinking, cfg.model_path or cfg.model_name)
         is not True
         or getattr(openai_request, "reasoning_max_tokens", None) is None
     ):
@@ -533,7 +531,11 @@ def _attach_deepseek_codex_reasoning_budget(
     except Exception:
         return
     vocab_size = _engine_output_vocab_size(engine)
-    if not isinstance(end_id, int) or vocab_size is None or not 0 <= end_id < vocab_size:
+    if (
+        not isinstance(end_id, int)
+        or vocab_size is None
+        or not 0 <= end_id < vocab_size
+    ):
         return
     chat_kwargs["reasoning_budget_logits_processor"] = ReasoningBudgetLogitsProcessor(
         end_id,


### PR DESCRIPTION
## What changed

- enforce the translated Codex `reasoning_max_tokens` tier during DeepSeek V4 generation, including tool-enabled Responses requests
- resolve `</think>` once from the live tokenizer vocabulary, validate it against the actual LM-head width, and cache the boundary per engine
- preserve normal behavior outside the DeepSeek V4 + Codex + tools surface, but explicitly fail a qualifying request when its boundary cannot be installed safely

## Root cause

The Responses route translated Codex `reasoning_effort` into a reasoning budget, but tool-enabled DeepSeek requests only trimmed hidden reasoning after generation. The generic generation-time processor intentionally skips ungated tool requests, so a DeepSeek Codex turn could spend thousands of invisible tokens without ever reaching its DSML action despite having a configured tier.

This needs a route-specific fix because applying the processor to every tool-capable model could force a reasoning marker while another parser is already inside a tool envelope. DeepSeek V4's Codex/DSML boundary has the narrower structural guarantee required to do this safely.

DeepSeek V4's DSML parser treats the token-delimited `</think>` boundary as the transition into tool output. This PR installs the existing generation-time budget processor specifically on that proven surface.

## User impact

In a real 74K–76K-context Codex soak, previously unbounded hidden-planning turns were capped and produced valid follow-up tool calls. Observed capped completions were 2,148–2,240 total tokens for a 2,048-token reasoning tier (the remainder was the tool envelope), with zero malformed calls or reconnects. Prefix-cache continuation remained effective, requiring only 446–813 new prompt tokens.

This does not claim to solve model-level engineering judgment: local and cloud DeepSeek A/B both continued low-value read-only exploration on issue #1456. That failed task is deliberately not represented as a passing soak.

## Validation

- `python -m pytest -q tests/test_responses_route.py tests/test_reasoning_budget_generation.py` — 145 passed
- `ruff check vllm_mlx/routes/responses.py tests/test_responses_route.py` — clean
- real local DeepSeek V4 Flash 0731 Codex Responses soak at 74K–76K context
