### PR TITLE
fix(rapid-mac): port sweep crash, deadlock, and shutdown stalls

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
@@ -377,6 +377,23 @@ final class ChatViewModel {
         inflight?.cancel()
     }
 
+    /// Stop AND snapshot, synchronously, for the app-termination path.
+    ///
+    /// ``stop()`` only *requests* cancellation; the streaming task's own
+    /// cleanup — ``isStreaming = false`` plus ``persistActive()`` — runs later
+    /// on the main actor. During termination the main actor is then blocked
+    /// for seconds reaping the server child, so that continuation never gets
+    /// to run before ``ConversationStore.flush()``, and the partial final turn
+    /// is written nowhere. Snapshot here instead, while we still hold the
+    /// actor. The task's own cleanup remains harmless: it re-persists the same
+    /// state if it ever gets to run.
+    func stopAndPersist() {
+        inflight?.cancel()
+        guard isStreaming else { return }
+        isStreaming = false
+        persistActive()
+    }
+
     /// Drop a stale chat-level error banner once the server provably
     /// reaches ``.ready`` again. The banner's copy is advice about a
     /// PAST failure ("Couldn't reach the model. Restart it from the

--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
@@ -390,6 +390,19 @@ final class ChatViewModel {
     func stopAndPersist() {
         inflight?.cancel()
         guard isStreaming else { return }
+        // Finalise through the SHARED cancellation contract before snapshotting.
+        // Persisting a message still marked ``.streaming`` writes a turn that
+        // reopens after relaunch as a permanent typing indicator, with no live
+        // task left to ever complete or cancel it. Same transition the normal
+        // stop path uses: ``.complete`` + "Stopped.", keeping whatever bytes
+        // already arrived.
+        if let idx = messages.indices.last,
+           messages[idx].role == .assistant,
+           messages[idx].status == .streaming,
+           var last = currentMessage(index: idx) {
+            Self.finaliseCancellation(message: &last)
+            updateMessage(at: idx, with: last)
+        }
         isStreaming = false
         persistActive()
     }

--- a/apps/rapid-mac/Sources/Rapid/RapidApp.swift
+++ b/apps/rapid-mac/Sources/Rapid/RapidApp.swift
@@ -67,7 +67,28 @@ struct RapidApp: App {
         TelemetryConsent.synchronizeExistingDecision()
         // Sweep orphan rapid-mlx processes from previous sessions BEFORE
         // anything else looks at our serve port.
-        PortSweep.sweep(port: PortAllocator.candidatePorts.first ?? 8000)
+        //
+        // Detached, NOT inline. This runs inside ``RapidApp.init`` —
+        // i.e. before the first window is drawn — and the sweep forks
+        // ``lsof`` (plus a ``ps`` per pid it finds) and can wait out a
+        // SIGTERM grace when it actually finds an orphan. Inline, that
+        // was dead time on the main thread with no UI on screen: the
+        // app appeared to hang on launch (Dock icon bouncing, no
+        // window) for as long as the sweep took.
+        //
+        // Fire-and-forget is correct here rather than something the
+        // launch path awaits. The sweep is an opportunistic cleanup of
+        // a PREVIOUS session's leftovers; nothing in this launch's
+        // startup depends on its result. The real guarantee that we
+        // don't collide with an orphan lives in
+        // ``ServerManager.start`` → ``PortAllocator.allocate()``,
+        // which re-sweeps each candidate port and bind-probes it
+        // before spawning. If this background sweep hasn't finished by
+        // the time the user picks a model, the allocator simply finds
+        // the orphan itself and reaps it there.
+        Task.detached(priority: .userInitiated) {
+            PortSweep.sweep(port: PortAllocator.candidatePorts.first ?? 8000)
+        }
         let manager = ServerManager()
         let samplingConfig = SamplingConfig()
         let appearanceConfig = AppearanceConfig()
@@ -528,8 +549,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         MainActor.assumeIsolated {
             AppDelegate.runTerminationSequence(
                 stopStream: { AppDelegate.shared.chat?.stop() },
-                shutdownServer: { AppDelegate.shared.server?.shutdownSync() },
-                shutdownDownloads: { AppDelegate.shared.downloads?.shutdownSync() }
+                signalServer: { AppDelegate.shared.server?.beginShutdown() },
+                signalDownloads: { AppDelegate.shared.downloads?.beginShutdown() },
+                reapServer: { AppDelegate.shared.server?.shutdownSync() },
+                reapDownloads: { AppDelegate.shared.downloads?.finishShutdown() }
             )
         }
         // Last write before AppKit pulls the plug — clears this
@@ -628,17 +651,47 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// Codex r1 NIT: prior version had the 5 calls inlined in
     /// `applicationWillTerminate`, with no test pinning the
     /// stop-first invariant against a future reorder.
+    ///
+    /// Teardown is SPLIT into a signal phase and a reap phase. The
+    /// previous shape called a single blocking `shutdownSync()` per
+    /// subsystem back-to-back, so their grace windows SUMMED: the
+    /// server's 5 s SIGTERM grace (+0.5 s post-SIGKILL settle) ran to
+    /// completion before the download manager even sent its first
+    /// SIGTERM, then that added its own 2 s — up to ~7.5 s of blocked
+    /// main thread. macOS gives `applicationWillTerminate` a finite
+    /// budget before force-killing the app, and everything after the
+    /// teardown (`ConversationStore.flush()`, and
+    /// `CrashReporter.recordCleanShutdown()` at the call site) is
+    /// exactly the work that must not be skipped — losing the latter
+    /// makes the NEXT launch misreport a clean quit as a crash.
+    ///
+    /// Signalling every child FIRST means the two grace windows
+    /// OVERLAP: the download children spend the server's 5 s grace
+    /// dying, so the download reap that follows almost always finds
+    /// them already gone and returns immediately. Worst case is now
+    /// bounded by the longest single grace rather than their sum, and
+    /// no grace period was shortened — the server's 5 s window is
+    /// load-bearing for rapid-mlx's prefix-cache flush.
     static func runTerminationSequence(
         stopStream: () -> Void,
-        shutdownServer: () -> Void,
-        shutdownDownloads: () -> Void
+        signalServer: () -> Void,
+        signalDownloads: () -> Void,
+        reapServer: () -> Void,
+        reapDownloads: () -> Void
     ) {
         // ORDER MATTERS — the audit P1 invariant is: stopStream BEFORE
-        // shutdownServer so the inflight URLSessionDataTask FIN reaches
-        // rapid-mlx before `shutdownServer` SIGTERMs the child.
+        // any teardown so the inflight URLSessionDataTask FIN reaches
+        // rapid-mlx before the child is SIGTERM'd.
         stopStream()
-        shutdownServer()
-        shutdownDownloads()
+        // Signal phase — non-blocking. Both subsystems get their
+        // SIGTERM before anyone waits, so the graces overlap.
+        signalServer()
+        signalDownloads()
+        // Reap phase — blocking. Server first: its grace is the long
+        // one, and by the time it returns the download children have
+        // had that entire window to exit.
+        reapServer()
+        reapDownloads()
         // Drain any queued conversation-history write so the last turn /
         // edit / deletion isn't lost when the process exits before the
         // async save lands.

--- a/apps/rapid-mac/Sources/Rapid/RapidApp.swift
+++ b/apps/rapid-mac/Sources/Rapid/RapidApp.swift
@@ -86,9 +86,10 @@ struct RapidApp: App {
         // before spawning. If this background sweep hasn't finished by
         // the time the user picks a model, the allocator simply finds
         // the orphan itself and reaps it there.
-        Task.detached(priority: .userInitiated) {
-            PortSweep.sweep(port: PortAllocator.candidatePorts.first ?? 8000)
-        }
+        // Held as an awaitable handle rather than a fire-and-forget task, so
+        // ``ServerManager.start`` can wait it out instead of racing it onto
+        // the same port. Still detached — launch never blocks on it.
+        PortSweep.startLaunchSweep(port: PortAllocator.candidatePorts.first ?? 8000)
         let manager = ServerManager()
         let samplingConfig = SamplingConfig()
         let appearanceConfig = AppearanceConfig()
@@ -548,7 +549,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // returns to AppKit.
         MainActor.assumeIsolated {
             AppDelegate.runTerminationSequence(
-                stopStream: { AppDelegate.shared.chat?.stop() },
+                stopStream: { AppDelegate.shared.chat?.stopAndPersist() },
                 signalServer: { AppDelegate.shared.server?.beginShutdown() },
                 signalDownloads: { AppDelegate.shared.downloads?.beginShutdown() },
                 reapServer: { AppDelegate.shared.server?.shutdownSync() },

--- a/apps/rapid-mac/Sources/Rapid/Server/DownloadManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/DownloadManager.swift
@@ -529,11 +529,28 @@ final class DownloadManager {
     /// ``ServerManager.shutdownSync``. We can't await Process.exit
     /// from ``applicationWillTerminate``, so SIGTERM + short blocking
     /// poll + SIGKILL.
-    func shutdownSync() {
-        let aliases = Array(processes.keys)
+    ///
+    /// Split into ``beginShutdown`` (signal, non-blocking) and
+    /// ``finishShutdown`` (reap, blocking) so the caller can overlap
+    /// this grace window with ``ServerManager``'s. Previously both
+    /// teardowns ran start-to-finish back-to-back on the main thread,
+    /// so the app quit path serialised the server's 5.5 s budget and
+    /// this 2 s one into 7.5 s of blocking — see
+    /// ``AppDelegate.runTerminationSequence``. Signalling here first
+    /// lets these children die WHILE the server grace is running, and
+    /// by the time ``finishShutdown`` polls they are almost always
+    /// already gone.
+    func beginShutdown() {
         for (_, process) in processes where process.isRunning {
             process.terminate()
         }
+    }
+
+    /// Second half of the split teardown: wait briefly for the
+    /// already-SIGTERM'd children, SIGKILL any survivor, then run the
+    /// normal per-alias bookkeeping so nothing is left half-torn-down.
+    func finishShutdown() {
+        let aliases = Array(processes.keys)
         let deadline = Date().addingTimeInterval(2.0)
         while Date() < deadline && processes.values.contains(where: { $0.isRunning }) {
             Thread.sleep(forTimeInterval: 0.1)

--- a/apps/rapid-mac/Sources/Rapid/Server/DownloadManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/DownloadManager.swift
@@ -172,6 +172,8 @@ final class DownloadManager {
 
     private var binaryPath: URL?
     private let resolvesBinaryAtStart: Bool
+    private var shutdownSignalledAt: Date?
+
     private var processes: [String: Process] = [:]
     private var cancellingProcesses: [String: Process] = [:]
     private let cancellationTracker = DownloadCancellationTracker()
@@ -541,17 +543,29 @@ final class DownloadManager {
     /// by the time ``finishShutdown`` polls they are almost always
     /// already gone.
     func beginShutdown() {
+        if shutdownSignalledAt == nil { shutdownSignalledAt = Date() }
         for (_, process) in processes where process.isRunning {
             process.terminate()
         }
     }
+
+    /// When the children were SIGTERM'd, so ``finishShutdown`` can measure
+    /// its grace from the SIGNAL rather than from the reap.
+    private static let downloadShutdownGrace: TimeInterval = 2.0
 
     /// Second half of the split teardown: wait briefly for the
     /// already-SIGTERM'd children, SIGKILL any survivor, then run the
     /// normal per-alias bookkeeping so nothing is left half-torn-down.
     func finishShutdown() {
         let aliases = Array(processes.keys)
-        let deadline = Date().addingTimeInterval(2.0)
+        // Measured from when the children were SIGNALLED, not from when we
+        // got round to reaping them. The server's grace runs first, so a
+        // fresh 2 s here would still SUM with it whenever a child ignores
+        // SIGTERM — which is exactly the serialisation this split exists to
+        // remove. Children that already had their whole window are reaped
+        // immediately; only genuinely-new time is ever spent.
+        let deadline = (shutdownSignalledAt ?? Date())
+            .addingTimeInterval(Self.downloadShutdownGrace)
         while Date() < deadline && processes.values.contains(where: { $0.isRunning }) {
             Thread.sleep(forTimeInterval: 0.1)
         }

--- a/apps/rapid-mac/Sources/Rapid/Server/PortSweep.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/PortSweep.swift
@@ -15,6 +15,29 @@ import Foundation
 /// SIGKILL anyone still alive. A developer running rapid-mlx in their
 /// own terminal can opt out via `RAPID_DESKTOP_NO_PORT_SWEEP=1`.
 enum PortSweep {
+    /// The opportunistic launch-time sweep, so a spawn can wait it out
+    /// instead of racing it. Detached at launch (never blocking the UI); a
+    /// ``ServerManager.start`` that lands while it is still running awaits it
+    /// via ``awaitLaunchSweep`` rather than allocating a port the sweep is
+    /// about to clear — otherwise an auto-start can spawn onto the candidate
+    /// port before the sweep's ``lsof`` snapshot, and the sweep then reaps the
+    /// server this launch just started.
+    @MainActor private static var launchSweep: Task<Void, Never>?
+
+    /// Kick off the launch sweep. Idempotent: a second call is a no-op.
+    @MainActor static func startLaunchSweep(port: Int) {
+        guard launchSweep == nil else { return }
+        launchSweep = Task.detached(priority: .userInitiated) {
+            sweep(port: port)
+        }
+    }
+
+    /// Await the launch sweep if one is in flight. Returns immediately when
+    /// none was started or it already finished.
+    @MainActor static func awaitLaunchSweep() async {
+        await launchSweep?.value
+    }
+
     /// The default port rapid-mlx serve binds on. ``PortAllocator``
     /// walks ``defaultPort … defaultPort + 9`` when the default port
     /// is held by a foreign process. ``sweep()`` (no arg) targets the

--- a/apps/rapid-mac/Sources/Rapid/Server/PortSweep.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/PortSweep.swift
@@ -26,6 +26,57 @@ enum PortSweep {
     /// port the running rapid-mlx is bound to) when wiring URLs.
     static var port: Int { defaultPort }
 
+    /// Upper bound on how long we wait for a SIGTERM'd process (group)
+    /// to exit before escalating to SIGKILL. Unchanged from the
+    /// original fixed ``Thread.sleep(1.5)`` — what changed is that we
+    /// now POLL toward this deadline instead of always burning it.
+    private static let sigtermGrace: TimeInterval = 1.5
+
+    /// Poll granularity while waiting for death. 50 ms is far below
+    /// human perception yet coarse enough that the ``kill(_:0)`` probes
+    /// cost nothing measurable.
+    private static let deathPollInterval: TimeInterval = 0.05
+
+    /// Block until ``isAlive`` reports false or ``grace`` elapses.
+    /// Returns true when the target actually died inside the window.
+    ///
+    /// Replaces an unconditional ``Thread.sleep(forTimeInterval: 1.5)``
+    /// after each SIGTERM. That sleep burned the FULL 1.5 s even when
+    /// uvicorn exited in 80 ms, and ``PortAllocator.allocate()`` runs
+    /// this sweep once per candidate port (8000…8009) — so a machine
+    /// with several stale ports paid 1.5 s each, serially, for
+    /// processes that were already gone. Polling keeps the identical
+    /// worst-case bound while collapsing the common case to roughly
+    /// one poll interval.
+    @discardableResult
+    private static func awaitDeath(
+        within grace: TimeInterval,
+        isAlive: () -> Bool
+    ) -> Bool {
+        let deadline = Date().addingTimeInterval(grace)
+        while Date() < deadline {
+            if !isAlive() { return true }
+            Thread.sleep(forTimeInterval: deathPollInterval)
+        }
+        return !isAlive()
+    }
+
+    /// ``kill(-pgid, 0)`` probes process-group liveness without
+    /// signalling. Errno ``EPERM`` means "the group exists but we lack
+    /// permission to signal it" — that is very much alive, so it must
+    /// NOT be read as death. Only ``ESRCH`` (no such group) is death.
+    private static func processGroupIsAlive(_ pgid: Int32) -> Bool {
+        if kill(-pgid, 0) == 0 { return true }
+        return errno == EPERM
+    }
+
+    /// Single-pid counterpart to ``processGroupIsAlive``. Same EPERM
+    /// caveat applies.
+    private static func pidIsAlive(_ pid: Int32) -> Bool {
+        if kill(pid, 0) == 0 { return true }
+        return errno == EPERM
+    }
+
     /// Sweep ``defaultPort`` — kept as a zero-arg overload for the
     /// app's launch hook which always runs against the canonical
     /// rapid-mlx port.
@@ -95,12 +146,12 @@ enum PortSweep {
                         "[server] sweep_port_\(port): PGID-kill \(record.pgid) (recorded pid \(record.pid), alias \(record.alias))\n".utf8
                     ))
                     _ = kill(-record.pgid, SIGTERM)
-                    Thread.sleep(forTimeInterval: 1.5)
-                    // ``kill(-pgid, 0)`` probes group liveness without
-                    // signalling. Errno EPERM means "process group
-                    // exists but we lack signal permission" — treat
-                    // as alive.
-                    if kill(-record.pgid, 0) == 0 || errno == EPERM {
+                    // Poll toward the grace deadline rather than
+                    // always sleeping through it — see ``awaitDeath``.
+                    awaitDeath(within: sigtermGrace) {
+                        processGroupIsAlive(record.pgid)
+                    }
+                    if processGroupIsAlive(record.pgid) {
                         _ = kill(-record.pgid, SIGKILL)
                     }
                     OwnedServerRecord.clear()
@@ -151,8 +202,12 @@ enum PortSweep {
             _ = kill(pid, SIGTERM)
         }
         // Give uvicorn a moment for graceful shutdown; observed up to ~1 s
-        // in the wild.
-        Thread.sleep(forTimeInterval: 1.5)
+        // in the wild. Polls instead of always burning the full grace —
+        // the overwhelmingly common case is "already gone in <100 ms",
+        // and this sweep runs once PER candidate port on the start path.
+        awaitDeath(within: sigtermGrace) {
+            owned.contains(where: pidIsAlive)
+        }
 
         // Codex round-2 finding: the previous SIGKILL pass took a
         // FRESH ``lsof`` snapshot and SIGKILL'd anything that looked
@@ -194,17 +249,9 @@ enum PortSweep {
         let task = Process()
         task.executableURL = URL(fileURLWithPath: "/usr/sbin/lsof")
         task.arguments = ["-nP", "-sTCP:LISTEN", "-ti", ":\(port)"]
-        let stdout = Pipe()
-        let stderr = Pipe()
-        task.standardOutput = stdout
-        task.standardError = stderr
-        do {
-            try task.run()
-        } catch {
+        guard let data = runCapturingStdout(task) else {
             return pidsOnPortFallback(port: port)
         }
-        task.waitUntilExit()
-        let data = drainPipeToEOF(stdout.fileHandleForReading)
         return parsePids(data)
     }
 
@@ -212,17 +259,74 @@ enum PortSweep {
         let task = Process()
         task.executableURL = URL(fileURLWithPath: "/usr/bin/lsof")
         task.arguments = ["-nP", "-sTCP:LISTEN", "-ti", ":\(port)"]
-        let stdout = Pipe()
-        let stderr = Pipe()
-        task.standardOutput = stdout
-        task.standardError = stderr
+        guard let data = runCapturingStdout(task) else { return [] }
+        return parsePids(data)
+    }
+
+    /// Run ``task`` to completion and return its stdout bytes, draining
+    /// stdout AND stderr concurrently. Returns nil only when the spawn
+    /// itself threw (missing binary) so callers can distinguish "couldn't
+    /// launch" from "launched and produced nothing".
+    ///
+    /// The concurrent drain is the load-bearing part. The previous shape
+    /// at all three call sites here was:
+    ///
+    ///     task.standardError = Pipe()   // created, NEVER read
+    ///     task.waitUntilExit()          // <- blocks forever
+    ///     drainPipeToEOF(stdout...)     // <- never reached
+    ///
+    /// A pipe holds ~64 KiB. Once a child fills an undrained pipe it
+    /// blocks in ``write(2)`` and never exits, while the parent blocks in
+    /// ``waitUntilExit()`` waiting for that exit — a textbook deadlock
+    /// with no timeout on either side. ``lsof`` reaches that volume on
+    /// machines with stale network mounts (a ``WARNING: can't stat()``
+    /// line per unreachable filesystem); reading stdout only AFTER the
+    /// wait means even stdout alone can hang on a long pid list.
+    ///
+    /// This mattered more than a stuck helper: ``PortSweep`` runs from
+    /// ``AppDelegate`` init and from the @MainActor start path, so the
+    /// deadlock froze the whole app at launch with no way out.
+    /// Verified: a repro of the old shape had to be SIGKILLed at 10 s.
+    ///
+    /// Both handles are drained on concurrent queues so neither pipe can
+    /// backpressure the child, and ``waitUntilExit`` is called only after
+    /// both reach EOF — which the child's exit guarantees, since exit
+    /// closes both write ends.
+    private static func runCapturingStdout(_ task: Process) -> Data? {
+        let stdoutPipe = Pipe()
+        let stderrPipe = Pipe()
+        task.standardOutput = stdoutPipe
+        task.standardError = stderrPipe
         do {
             try task.run()
         } catch {
-            return []
+            return nil
         }
+
+        // Read both ends concurrently. ``readToEndSafely`` degrades a
+        // bad descriptor to empty Data rather than raising the
+        // uncatchable NSException — see ``drainPipeToEOF``.
+        //
+        // stderr goes to a background queue and its bytes are DISCARDED
+        // — we drain it purely so the child can never block writing to
+        // a full pipe. stdout is then read on THIS thread, which both
+        // pipes being drained in parallel is all the deadlock fix
+        // requires. Keeping the captured result on the stack (rather
+        // than a shared `var` written from the background queue) is
+        // what keeps this free of cross-thread mutable state, so no
+        // lock is needed and the compiler's Sendable capture checking
+        // is satisfied by construction.
+        let stderrHandle = stderrPipe.fileHandleForReading
+        let stderrDrain = DispatchWorkItem { _ = stderrHandle.readToEndSafely() }
+        DispatchQueue.global(qos: .userInitiated).async(execute: stderrDrain)
+
+        let stdoutData = stdoutPipe.fileHandleForReading.readToEndSafely()
+
+        // Both reads must reach EOF before the wait — the child's exit
+        // closes both write ends, so this cannot outlive the child.
+        stderrDrain.wait()
         task.waitUntilExit()
-        return parsePids(drainPipeToEOF(stdout.fileHandleForReading))
+        return stdoutData
     }
 
     private static func parsePids(_ data: Data) -> [Int32] {
@@ -279,16 +383,7 @@ enum PortSweep {
         let task = Process()
         task.executableURL = URL(fileURLWithPath: "/bin/ps")
         task.arguments = ["-p", String(pid), "-o", "command="]
-        let stdout = Pipe()
-        task.standardOutput = stdout
-        task.standardError = Pipe()
-        do {
-            try task.run()
-        } catch {
-            return nil
-        }
-        task.waitUntilExit()
-        let data = drainPipeToEOF(stdout.fileHandleForReading)
+        guard let data = runCapturingStdout(task) else { return nil }
         guard let s = String(data: data, encoding: .utf8) else { return nil }
         let trimmed = s.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed.isEmpty ? nil : trimmed
@@ -539,9 +634,26 @@ enum PortSweep {
         // and the submodule run shape are reachable depending on
         // how rapid-mlx was installed.
         let tokens = argv.split(whereSeparator: { $0.isWhitespace }).map(String.init)
-        for i in 0..<(tokens.count - 1) where i + 1 < tokens.count {
-            guard tokens[i] == "-m" else { continue }
-            let modName = tokens[i + 1]
+        // Iterate over ADJACENT PAIRS, never a manually-constructed
+        // ``0..<(count - 1)``. On an empty argv that expression is
+        // ``0..<(-1)``, and Swift traps on Range construction
+        // (`lowerBound <= upperBound`) BEFORE the loop body or any
+        // `where` clause can guard it — the previous
+        // ``where i + 1 < tokens.count`` was dead code for exactly the
+        // input that crashes.
+        //
+        // Empty argv is reachable in production, not theoretical: a
+        // Python started with no arguments (``python3 < script.py``,
+        // a bare REPL, ``python -``) reports a single-token
+        // ``ps -o command=`` line, so ``splitCommand`` returns an
+        // empty argv tail. That token's basename is ``Python`` on the
+        // macOS framework build, which passes ``isPythonBasename``
+        // and routes straight here. Any such process merely LISTENING
+        // on a swept port crashed the app on launch, because
+        // ``RapidApp`` runs the sweep during ``AppDelegate`` init.
+        // Verified: repro trapped at this line with exit 133 (SIGTRAP).
+        for (flag, modName) in zip(tokens, tokens.dropFirst()) {
+            guard flag == "-m" else { continue }
             if modName == "vllm_mlx" || modName.hasPrefix("vllm_mlx.") {
                 return true
             }

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -322,6 +322,12 @@ final class ServerManager {
     /// True while we are deliberately stopping the child. The
     /// `terminationHandler` checks this to decide whether to surface the
     /// exit as `.stopped` (expected) or `.crashed` (unexpected).
+    /// Latches once the terminal SIGTERM has been delivered so a second
+    /// ``beginShutdown`` (the reap phase calls it again) cannot re-signal a
+    /// child that is already shutting down gracefully. Reset when a new
+    /// child is spawned so a restart is not permanently un-signallable.
+    private var didSignalShutdown = false
+
     private var expectedStop: Bool = false
 
     /// Issue #270: the current spawn cycle observed at least one
@@ -969,6 +975,7 @@ final class ServerManager {
         //     is false here; ``stop()`` can preempt by terminating
         //     ``child`` and the polling loop notices ``child == nil``
         //     and returns.
+        didSignalShutdown = false
         isOperating = true
 
         // Clear the log tail from any previous run so the user only
@@ -1031,9 +1038,23 @@ final class ServerManager {
         // second call landing on the actor while we're parked here
         // bails at the ``guard !isOperating`` at the top rather than
         // racing a second spawn onto a different port.
+        // Wait out the opportunistic launch sweep before allocating. It runs
+        // detached so launch is not blocked, but it reaps anything on the
+        // candidate port that LOOKS like rapid-mlx — including a server this
+        // launch just spawned, if an auto-start beat the sweep's `lsof` to the
+        // port. Awaiting it here keeps launch responsive while making a spawn
+        // and a sweep mutually exclusive.
+        await PortSweep.awaitLaunchSweep()
         let allocated = await Task.detached(priority: .userInitiated) {
             PortAllocator.allocate()
         }.value
+        // A quit can land while we were parked on the allocator above. Spawning
+        // now would put a child on the far side of `beginShutdown`, so nothing
+        // ever reaps it — an orphan holding the port for the next launch.
+        if didSignalShutdown {
+            isOperating = false
+            return
+        }
         guard let resolvedPort = allocated else {
             isOperating = false
             state = .crashed(
@@ -1426,8 +1447,18 @@ final class ServerManager {
         // the process actually exits, spawning a child that gets
         // orphaned. Cancel unconditionally here, before the child guard.
         cancelAutoRespawn()
+        // Actually idempotent, not merely "cheap to call twice".
+        // ``shutdownSync`` calls this again at the start of the reap
+        // phase, so without this latch the child receives a SECOND
+        // SIGTERM part-way through its first graceful shutdown —
+        // uvicorn reads that as "stop waiting, exit now" and abandons
+        // the prefix-cache serialisation that the 5 s grace below exists
+        // to protect, leaving the partial ``prefix_cache/<rev>.new/``
+        // this teardown is specifically written to avoid.
+        guard !didSignalShutdown else { return }
         guard let process = child else { return }
         guard process.isRunning || process.isProcessGroupAlive else { return }
+        didSignalShutdown = true
         expectedStop = true
         process.signalProcessGroup(SIGTERM)
     }

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -1012,7 +1012,29 @@ final class ServerManager {
         // common when the user runs vite / jupyter / fastapi on the
         // same machine. ``PortAllocator`` walks 8000..8009 and picks
         // the first port not held by a foreign process.
-        guard let resolvedPort = PortAllocator.allocate() else {
+        //
+        // Run OFF the main actor. ``allocate()`` is blocking work by
+        // nature: per candidate port it forks ``lsof`` (+ one ``ps``
+        // per pid it finds) and, when it finds a rapid-owned orphan,
+        // waits out a SIGTERM grace before probing the bind. Calling
+        // that synchronously from this @MainActor method froze the UI
+        // for the whole walk — with several occupied candidates the
+        // freeze ran into multiple seconds of unresponsive window and
+        // spinning beachball, right at the moment the user clicked a
+        // model. ``PortAllocator``/``PortSweep`` are plain nonisolated
+        // enums over process + socket syscalls with no shared mutable
+        // state, so hopping them onto a detached task is safe.
+        //
+        // The surrounding ``isOperating = true`` (set above, cleared
+        // on every exit path below) is what makes this new suspension
+        // point safe against ``start``'s documented reentrancy: a
+        // second call landing on the actor while we're parked here
+        // bails at the ``guard !isOperating`` at the top rather than
+        // racing a second spawn onto a different port.
+        let allocated = await Task.detached(priority: .userInitiated) {
+            PortAllocator.allocate()
+        }.value
+        guard let resolvedPort = allocated else {
             isOperating = false
             state = .crashed(
                 alias: trimmedAlias,
@@ -1388,7 +1410,16 @@ final class ServerManager {
     /// returning control to the OS. We send SIGTERM, wait a short
     /// blocking window, then SIGKILL — same pattern as `stop()` but
     /// without the async hops.
-    func shutdownSync() {
+    ///
+    /// Split into ``beginShutdown`` (signal, non-blocking) and this
+    /// reaping half so ``AppDelegate.runTerminationSequence`` can
+    /// signal BOTH this child and the download children before any
+    /// grace window starts, letting the two waits overlap instead of
+    /// summing. The grace budget itself is unchanged.
+    ///
+    /// Returns immediately when there is nothing to reap so the quit
+    /// path costs nothing in the common "server never started" case.
+    func beginShutdown() {
         // Issue #270: app is quitting. Even if no child is currently
         // alive, a pending auto-respawn task could fire AFTER
         // ``applicationWillTerminate`` returned to AppKit but BEFORE
@@ -1399,6 +1430,24 @@ final class ServerManager {
         guard process.isRunning || process.isProcessGroupAlive else { return }
         expectedStop = true
         process.signalProcessGroup(SIGTERM)
+    }
+
+    func shutdownSync() {
+        // ``beginShutdown`` is idempotent and cheap, so calling it here
+        // keeps this method correct as a standalone teardown even
+        // though the production quit path calls it separately first.
+        beginShutdown()
+        guard let process = child else { return }
+        guard process.isRunning || process.isProcessGroupAlive else { return }
+        // NOTE: the 5 s SIGTERM grace is deliberate and load-bearing,
+        // not slack to be trimmed — rapid-mlx's FastAPI shutdown hook
+        // serialises the in-memory prefix cache to disk here, and
+        // SIGKILLing mid-write leaves a partial ``prefix_cache/<rev>.new/``
+        // that forces a full re-prefill on the next launch. See the
+        // ``sigtermGracePeriod`` doc comment for the full rationale.
+        // What this path DOES avoid is burning the grace when the
+        // child is already gone: the poll below exits as soon as the
+        // process group dies.
         let deadline = Date().addingTimeInterval(5.0)
         while Date() < deadline && process.isProcessGroupAlive {
             Thread.sleep(forTimeInterval: 0.1)

--- a/apps/rapid-mac/Tests/RapidTests/TerminationOrderingTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/TerminationOrderingTests.swift
@@ -22,69 +22,101 @@ import Testing
 struct TerminationOrderingTests {
 
     /// The audit P1 invariant in one assertion: stopStream MUST
-    /// be the first call, finalizeStreaming MUST run before
-    /// flushStore (so the on-disk envelope sees the normalised
-    /// placeholders), and the server / downloads teardown comes
-    /// last so the SSE FIN propagates while rapid-mlx is still
-    /// alive enough to release its decoding slot.
-    @Test("runTerminationSequence calls stopStream first, then finalize, flush, server, downloads")
-    func sequence_pins_stop_first_then_finalize_flush_teardown() {
+    /// be the first call, and every child must be SIGNALLED before
+    /// anything BLOCKS reaping one — that overlap is what keeps the
+    /// quit path inside AppKit's terminate budget (the grace windows
+    /// used to sum to ~7.5 s).
+    @Test("runTerminationSequence signals both children before reaping either")
+    func sequence_pins_stop_first_then_signal_then_reap() {
         var calls: [String] = []
         AppDelegate.runTerminationSequence(
             stopStream: { calls.append("stop") },
-            finalizeStreaming: { calls.append("finalize") },
-            flushStore: { calls.append("flush") },
-            shutdownServer: { calls.append("server") },
-            shutdownDownloads: { calls.append("downloads") }
+            signalServer: { calls.append("signalServer") },
+            signalDownloads: { calls.append("signalDownloads") },
+            reapServer: { calls.append("reapServer") },
+            reapDownloads: { calls.append("reapDownloads") }
         )
-        #expect(calls == ["stop", "finalize", "flush", "server", "downloads"])
+        #expect(calls == [
+            "stop", "signalServer", "signalDownloads", "reapServer", "reapDownloads"
+        ])
+    }
+
+    /// The load-bearing half of the overlap fix, pinned independently
+    /// of exact ordering: NO blocking reap may start until BOTH
+    /// children have been signalled. If a future refactor collapses
+    /// this back into two sequential `shutdownSync()` calls, the
+    /// download SIGTERM slides after the server's 5 s grace and the
+    /// windows serialise again — this fires.
+    @Test("both signals strictly precede both reaps")
+    func signals_strictly_precede_reaps() {
+        var calls: [String] = []
+        AppDelegate.runTerminationSequence(
+            stopStream: { _ = calls },
+            signalServer: { calls.append("signalServer") },
+            signalDownloads: { calls.append("signalDownloads") },
+            reapServer: { calls.append("reapServer") },
+            reapDownloads: { calls.append("reapDownloads") }
+        )
+        let lastSignal = [
+            calls.firstIndex(of: "signalServer"),
+            calls.firstIndex(of: "signalDownloads")
+        ].compactMap { $0 }.max()
+        let firstReap = [
+            calls.firstIndex(of: "reapServer"),
+            calls.firstIndex(of: "reapDownloads")
+        ].compactMap { $0 }.min()
+        #expect(lastSignal != nil)
+        #expect(firstReap != nil)
+        if let s = lastSignal, let r = firstReap {
+            #expect(s < r, "every child must be signalled before any blocking reap begins")
+        }
     }
 
     /// A second, narrower assertion that survives if someone adds
     /// a NEW termination step in the middle — the audit invariant
-    /// is "stop first", not "exactly these 5 in this order".
+    /// is "stop first", not "exactly these steps in this order".
     /// Future-you adds a step → this pin survives; future-you
-    /// moves stop after finalize → this pin fires.
-    @Test("stopStream is strictly before finalizeStreaming under any future extension")
-    func stop_is_strictly_before_finalize() {
+    /// moves stop after the server signal → this pin fires.
+    @Test("stopStream is strictly before the server signal under any future extension")
+    func stop_is_strictly_before_server_signal() {
         var calls: [String] = []
         AppDelegate.runTerminationSequence(
             stopStream: { calls.append("stop") },
-            finalizeStreaming: { calls.append("finalize") },
-            flushStore: { _ = calls },
-            shutdownServer: { _ = calls },
-            shutdownDownloads: { _ = calls }
+            signalServer: { calls.append("signalServer") },
+            signalDownloads: { _ = calls },
+            reapServer: { _ = calls },
+            reapDownloads: { _ = calls }
         )
         let stopIndex = calls.firstIndex(of: "stop")
-        let finalizeIndex = calls.firstIndex(of: "finalize")
+        let signalIndex = calls.firstIndex(of: "signalServer")
         #expect(stopIndex != nil)
-        #expect(finalizeIndex != nil)
-        if let s = stopIndex, let f = finalizeIndex {
-            #expect(s < f, "stopStream must run before finalizeStreaming — audit P1 invariant")
+        #expect(signalIndex != nil)
+        if let s = stopIndex, let f = signalIndex {
+            #expect(s < f, "stopStream must run before the server SIGTERM — audit P1 invariant")
         }
     }
 
     /// Symmetrical pin for the OTHER end of the audit invariant:
-    /// stopStream MUST run before shutdownServer so the SSE FIN
+    /// stopStream MUST run before the server is reaped so the SSE FIN
     /// reaches rapid-mlx before SIGTERM. Same reasoning as the
-    /// finalize pin — if a future refactor moves the server
+    /// signal pin — if a future refactor moves the server
     /// teardown ahead of the stream cancel, this fires.
-    @Test("stopStream is strictly before shutdownServer")
+    @Test("stopStream is strictly before the server reap")
     func stop_is_strictly_before_server_teardown() {
         var calls: [String] = []
         AppDelegate.runTerminationSequence(
             stopStream: { calls.append("stop") },
-            finalizeStreaming: { _ = calls },
-            flushStore: { _ = calls },
-            shutdownServer: { calls.append("server") },
-            shutdownDownloads: { _ = calls }
+            signalServer: { _ = calls },
+            signalDownloads: { _ = calls },
+            reapServer: { calls.append("server") },
+            reapDownloads: { _ = calls }
         )
         let stopIndex = calls.firstIndex(of: "stop")
         let serverIndex = calls.firstIndex(of: "server")
         #expect(stopIndex != nil)
         #expect(serverIndex != nil)
         if let s = stopIndex, let v = serverIndex {
-            #expect(s < v, "stopStream must run before shutdownServer — audit P1 invariant (FIN before SIGTERM)")
+            #expect(s < v, "stopStream must run before the server teardown — audit P1 invariant (FIN before SIGTERM)")
         }
     }
 
@@ -104,10 +136,10 @@ struct TerminationOrderingTests {
                 vm.stop()
                 stopFired = true
             },
-            finalizeStreaming: {},
-            flushStore: {},
-            shutdownServer: {},
-            shutdownDownloads: {}
+            signalServer: {},
+            signalDownloads: {},
+            reapServer: {},
+            reapDownloads: {}
         )
         #expect(stopFired,
                 "stopStream closure must execute synchronously inside runTerminationSequence")


### PR DESCRIPTION
 Four defects in the process-lifecycle path. `PortSweep` runs from `AppDelegate.init` and from the `@MainActor` start path, so each one surfaces as a launch crash or a frozen UI rather than a stuck helper.

  **1. Range trap on empty argv (`PortSweep.swift`)** 
  `containsModuleFlag` built `0..<(tokens.count - 1)`, which is `0..<(-1)` when argv is empty — Swift traps on Range *construction*, before the existing `where i + 1 < tokens.count` guard is ever evaluated, so that clause was dead code for exactly the input that crashes. Reachable in production: a Python started with no arguments (`python3 < script.py`, a bare REPL) reports a single-token `ps -o command=` line whose basename
 is `Python`, which passes `isPythonBasename` and routes straight here. Any such process merely LISTENing on a swept port crashed the app on launch. Now iterates over adjacent token pairs.

  **2. Undrained-pipe deadlock (3 call sites)** 
  `pidsOnPort`, `pidsOnPortFallback` and `processCommand` each created a
  stderr `Pipe()` and never read it, and read stdout only *after* `waitUntilExit()`. Once a child fills the ~64 KiB pipe it blocks in `write(2)` while the parent blocks waiting for it to exit — no timeout on either side. Collapsed into one `runCapturingStdout` that drains both pipes concurrently. The repo already had `readToEndSafely()`/`PipeDrainer`; these sites just weren't using them.

  **3. Main-thread stalls**
  - Fixed `Thread.sleep(1.5)` after each SIGTERM → poll to death, same upper bound. `PortAllocator.allocate()` sweeps 8000-8009 serially, so the old shape paid the full delay per port even for already-dead processes.
  - Launch sweep and `PortAllocator.allocate()` moved off the main thread.

  **4. Serial shutdown grace windows** 
`ServerManager.shutdownSync` (5s + 0.5s) and `DownloadManager.shutdownSync` (2s) ran back-to-back on the main thread — up to ~7.5s blocked, against a finite AppKit terminate budget, with `ConversationStore.flush()` and
  `CrashReporter.recordCleanShutdown()` queued *behind* it (losing the latter makes the next launch misreport a clean quit as a crash). Each manager grows a `beginShutdown()`; `runTerminationSequence` signals every child before reaping any, so the grace windows overlap instead of summing.

  **No grace period was shortened.**
   The server's 5s window is deliberate and load-bearing — `rapid-mlx`'s FastAPI shutdown hook serialises the prefix cache to disk, and SIGKILLing mid-write leaves a partial `prefix_cache/<rev>.new/` that forces a full re-prefill next launch (see the `sigtermGracePeriod` doc comment).

  ## Measurements

  | | before | after |
  |---|---|---|
  | reap a real orphan | 1.83s | 0.37s |
  | healthy quit | 3.18s | 1.58s |
  | quit, server wedged past grace | 7.01s | 5.08s |

  Worst-case SIGTERM cap unchanged (1.85s) and SIGKILL escalation still
  frees the port.

  ## Verification

  ⚠️ **`swift test` does not run here** — the test target is commented out
  of `Package.swift`. Everything below was verified by compiling the *real*
  source files into standalone harnesses (not reimplemented logic), then
  deleted:

  - [x] Repro: argv-less Python holding :8000 → `Fatal error: Range
        requires lowerBound <= upperBound`, exit 133. After: skipped
        cleanly, exit 0.
  - [x] 8 classification cases pass (`-m vllm_mlx serve` ✓,
        `-m vllm_mlx.cli serve` ✓, `-m vllm_mlx pull` ✗, trailing `-m` ✗,
        brew ✓, shebang Form 3 ✓, `python hold.py` ✗, `vim` ✗).
  - [x] Deadlock: 4000-line stderr flood — before, SIGKILLed at 10s;
        after, returns immediately with stdout intact.
  - [x] Drain also verified for 205 KB stdout, both streams flooding at
        once, and missing-binary → `nil` (which `pidsOnPort` needs to
        distinguish in order to fall back to `/usr/bin/lsof`).
  - [x] Timings above measured with children that take time to honour
        SIGTERM (modelling the prefix-cache flush).
  - [x] `swift build` clean, no warnings.

  ### Needs manual UI testing
### Not verified (stated plainly rather than ticked)

These are GUI-interactive and were **not** run. They are recorded here so the
gap is visible rather than hidden behind a checked box:

- Force Quit with a model loaded, then relaunch, confirming the orphan is
  reaped. Note the launch sweep is no longer fire-and-forget — review changed
  it to an awaitable handle that `ServerManager.start` waits out, precisely so
  it cannot race the allocator onto the same port.
- Cmd-Q with a model loaded, confirming it feels faster (the measurements in
  the table above were taken by the author against real children).
- Starting a model while a foreign process holds :8000, confirming no
  beachball. A standalone harness for this was attempted during review but the
  file could not be compiled outside the app module; the code path is covered
  by reasoning and by `PortAllocator` walking 8000-8009 with a bind probe.



---

## Why this is being merged

Because three of the four defects are reachable in production today: the
argv-less `Range` trap is a hard launch **crash** (independently reproduced
during review — the shape on `main` exits 133/SIGTRAP), the undrained-pipe
deadlock **freezes the app at launch** on machines with stale network mounts,
and the serialized shutdown windows run against a finite AppKit terminate
budget with `CrashReporter.recordCleanShutdown()` queued behind them — losing
that makes the next launch misreport a clean quit as a crash.

Review found five further defects in the new code, all fixed on this branch:
a non-idempotent `beginShutdown` delivering a second SIGTERM (which makes
uvicorn abandon the prefix-cache write this PR's own grace exists to protect),
a download grace measured from reap time so the windows still summed, a
detached allocator that could spawn a child after teardown, a launch sweep
that could reap the server this launch just started, and a quit mid-response
persisting a permanently-`.streaming` turn.

Closes #1472.

`PortSweep` treating command-line resemblance as ownership was raised during
review, A/B classified as **pre-existing** (identical on `main`), and filed
separately as #1474 rather than scope-creeping this PR.