### PR TITLE
fix(rapid-mac): six desktop UX defects (lands #1470)

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
@@ -99,13 +99,26 @@ final class ChatViewModel {
     /// Snapshot the active conversation into ``conversations`` + disk. A
     /// no-op until the user has actually sent something (no empty rows in
     /// the sidebar). Title is derived from the first user message.
-    private func persistActive() {
+    ///
+    /// - Parameter touching: whether this counts as *activity*. Only a real
+    ///   change to the transcript should refresh ``updatedAt`` and bubble the
+    ///   row to the top. Merely opening a conversation to read it, or leaving
+    ///   it to start a new one, archives the buffer without claiming the user
+    ///   did anything to it — otherwise clicking through history silently
+    ///   reshuffles the sidebar, and the list stops reflecting when each
+    ///   conversation was last *worked on*.
+    private func persistActive(touching: Bool = true) {
         guard messages.contains(where: { $0.role == .user }) else { return }
         let now = Date()
         let title = ConversationStore.title(from: messages)
         if let idx = conversations.firstIndex(where: { $0.id == activeConversationID }) {
             conversations[idx].messages = messages
             conversations[idx].title = title
+            guard touching else {
+                // Content written back, position and timestamp left alone.
+                ConversationStore.save(conversations)
+                return
+            }
             conversations[idx].updatedAt = now
             // Bubble the just-touched conversation to the top.
             let updated = conversations.remove(at: idx)
@@ -136,7 +149,7 @@ final class ChatViewModel {
         // is what gets persisted and a mid-stream switch doesn't leave the
         // incoming conversation showing Stop.
         isStreaming = false
-        persistActive()
+        persistActive(touching: false)
         guard let conv = conversations.first(where: { $0.id == id }) else { return }
         messages = conv.messages
         activeConversationID = id
@@ -205,7 +218,7 @@ final class ChatViewModel {
         // chat stuck showing Stop (isStreaming never reset). Setting it
         // false here also archives the just-closed conversation via didSet.
         isStreaming = false
-        persistActive()
+        persistActive(touching: false)
         messages.removeAll()
         activeConversationID = UUID()
         lastError = nil

--- a/apps/rapid-mac/Sources/Rapid/Chat/ConversationHistory.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ConversationHistory.swift
@@ -56,7 +56,15 @@ enum ConversationStore {
             try? fm.moveItem(at: url, to: backup)
             return []
         }
-        return decoded
+        // Sort here rather than trusting the file's array order. ``save``
+        // writes whatever order the in-memory array happens to be in, which
+        // ``ChatViewModel.persistActive`` keeps newest-first only as a side
+        // effect of its ``insert(at: 0)`` bubbling. Any path that doesn't go
+        // through that bubble — a hand-edited file, a future bulk import, a
+        // partially-applied migration — would surface out of order in the
+        // sidebar with nothing to correct it. Guaranteeing the invariant at
+        // the data boundary costs one sort and removes the whole class.
+        return decoded.sorted { $0.updatedAt > $1.updatedAt }
     }
 
     /// Serial queue for history writes: every save re-encodes the whole

--- a/apps/rapid-mac/Sources/Rapid/Server/ModelCatalogCache.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ModelCatalogCache.swift
@@ -1,0 +1,147 @@
+import Foundation
+
+/// Process-wide cache in front of ``ModelCatalog/load(binary:hubCacheOverride:)``.
+///
+/// Every catalog read forks **at least two** `rapid-mlx` subprocesses — `models`
+/// and `ls`, plus one `info` per cached sibling — and five separate surfaces
+/// call it (both settings panels, the composer's model picker, launch
+/// auto-start, and deletion). None of them shared anything, so simply moving
+/// between Models and Model Management paid for a fresh round of process
+/// spawns and showed a spinner each time.
+///
+/// ## Staleness is bounded, not merely time-limited
+///
+/// Entries are keyed on ``DownloadManager/cacheGeneration``, the counter the app
+/// already bumps whenever the on-disk model set changes (download finished,
+/// alias deleted, models folder repointed). A cached snapshot is therefore
+/// invalidated by the *event* that makes it wrong rather than by a timer that
+/// might fire too late — an expiring TTL would still hand out a stale
+/// "downloaded" badge for however long it had left to run.
+///
+/// A short TTL is kept **on top of** that as a backstop for changes nothing
+/// announces: a model deleted from `~/.cache/huggingface` by another tool, or
+/// by `rapid-mlx` from a terminal.
+///
+/// ## Serving stale while revalidating
+///
+/// ``entries(binary:generation:)`` returns any usable snapshot immediately and
+/// refreshes in the background. The first read of a generation has nothing to
+/// serve and awaits the real load; every read after that is instant. Callers
+/// distinguish the two via ``cached(binary:generation:)`` so they can show a
+/// spinner only when there is genuinely nothing to show.
+actor ModelCatalogCache {
+    static let shared = ModelCatalogCache()
+
+    /// Backstop for out-of-band changes (see above).
+    ///
+    /// Five minutes, not seconds: ``cacheGeneration`` already catches every
+    /// mutation the app makes, so this only has to bound how long an edit made
+    /// *outside* the app can go unnoticed. An earlier 30s value expired while
+    /// the user was simply reading the Settings panel — measured MISSes at
+    /// age=33s and age=40s during ordinary tab switching — which is exactly
+    /// the needless refetch this cache exists to remove.
+    private static let ttl: TimeInterval = 300
+
+    private struct Snapshot {
+        let entries: [ModelEntry]
+        let generation: UInt
+        let fetchedAt: Date
+        /// The override in force when this was captured. Pointing the models
+        /// folder somewhere else changes what "cached" means for every alias,
+        /// so a snapshot taken under a different root cannot be reused.
+        let overridePath: String?
+    }
+
+    private var snapshot: Snapshot?
+
+    /// Mirror of ``snapshot`` readable without `await`.
+    ///
+    /// SwiftUI builds `@State` initial values synchronously, so a view cannot
+    /// consult an actor before its first frame. Without this, a panel that
+    /// re-appears starts at `catalog = []` + `loading = true`, renders the
+    /// spinner, and only replaces it once the `.task` resumes — the cache
+    /// removes the subprocess cost but the *flash* remains, which is the part
+    /// the user actually sees.
+    ///
+    /// `nonisolated(unsafe)` is sound here for the same reason the actor is
+    /// enough elsewhere: writes happen only from inside the actor (a single
+    /// serialised context), and the value is a `let`-only struct of immutable
+    /// members. A reader can observe a slightly older snapshot, never a torn
+    /// one — and "slightly older" is exactly what a cache promises.
+    nonisolated(unsafe) private static var lastSnapshot: Snapshot?
+
+    /// Synchronous peek for `@State` seeding. Returns entries only when they
+    /// would also satisfy ``cached(binary:generation:)``.
+    nonisolated static func seed(generation: UInt) -> [ModelEntry]? {
+        guard let snap = lastSnapshot,
+              snap.generation == generation,
+              snap.overridePath == ModelsFolderPreference.validatedOverrideURL()?.path,
+              Date().timeIntervalSince(snap.fetchedAt) < ttl
+        else { return nil }
+        return snap.entries
+    }
+
+    /// In-flight load, so N simultaneous views trigger one set of subprocesses
+    /// instead of N. Without this the first paint after launch — picker plus
+    /// auto-start plus whichever panel is open — would fan out.
+    private var inFlight: Task<[ModelEntry], Never>?
+
+    /// A snapshot only if one is currently valid; never triggers a load.
+    ///
+    /// Views use this to decide whether to show a loading state: `nil` means
+    /// "nothing to display yet", not "nothing exists".
+    func cached(binary: URL, generation: UInt) -> [ModelEntry]? {
+        guard let snapshot, isFresh(snapshot, generation: generation) else {
+            return nil
+        }
+        return snapshot.entries
+    }
+
+    /// The catalog, served from cache when possible.
+    ///
+    /// Returns immediately with a valid snapshot; otherwise awaits a real load
+    /// (joining one already running rather than starting a second).
+    func entries(binary: URL, generation: UInt) async -> [ModelEntry] {
+        if let snapshot, isFresh(snapshot, generation: generation) {
+            return snapshot.entries
+        }
+        if let inFlight {
+            return await inFlight.value
+        }
+        let override = ModelsFolderPreference.validatedOverrideURL()
+        let task = Task<[ModelEntry], Never> {
+            await ModelCatalog.load(binary: binary, hubCacheOverride: override)
+        }
+        inFlight = task
+        let loaded = await task.value
+        // Stamp with the generation captured at call time. If a mutation
+        // landed mid-load the counter has already moved on, so this snapshot
+        // is born stale and the next read refetches — which is the correct
+        // outcome: the load observed the world before the change.
+        snapshot = Snapshot(
+            entries: loaded,
+            generation: generation,
+            fetchedAt: Date(),
+            overridePath: override?.path
+        )
+        Self.lastSnapshot = snapshot
+        inFlight = nil
+        return loaded
+    }
+
+    /// Drop the snapshot. For callers that mutate the model set themselves and
+    /// want the next read to be authoritative without waiting on the
+    /// generation counter to propagate.
+    func invalidate() {
+        snapshot = nil
+        Self.lastSnapshot = nil
+    }
+
+    private func isFresh(_ snapshot: Snapshot, generation: UInt) -> Bool {
+        guard snapshot.generation == generation else { return false }
+        guard snapshot.overridePath == ModelsFolderPreference.validatedOverrideURL()?.path else {
+            return false
+        }
+        return Date().timeIntervalSince(snapshot.fetchedAt) < Self.ttl
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/Server/ModelCatalogCache.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ModelCatalogCache.swift
@@ -50,6 +50,10 @@ actor ModelCatalogCache {
         /// folder somewhere else changes what "cached" means for every alias,
         /// so a snapshot taken under a different root cannot be reused.
         let overridePath: String?
+        /// The rapid-mlx executable that produced this catalog. A dev build and
+        /// the shipped binary can enumerate different models, so a snapshot
+        /// from one must not be served after the app switches binaries.
+        let binaryPath: String
     }
 
     private var snapshot: Snapshot?
@@ -59,21 +63,36 @@ actor ModelCatalogCache {
     /// SwiftUI builds `@State` initial values synchronously, so a view cannot
     /// consult an actor before its first frame. Without this, a panel that
     /// re-appears starts at `catalog = []` + `loading = true`, renders the
-    /// spinner, and only replaces it once the `.task` resumes — the cache
-    /// removes the subprocess cost but the *flash* remains, which is the part
-    /// the user actually sees.
+    /// spinner, and only replaces it once the `.task` resumes.
     ///
-    /// `nonisolated(unsafe)` is sound here for the same reason the actor is
-    /// enough elsewhere: writes happen only from inside the actor (a single
-    /// serialised context), and the value is a `let`-only struct of immutable
-    /// members. A reader can observe a slightly older snapshot, never a torn
-    /// one — and "slightly older" is exactly what a cache promises.
+    /// Every access goes through ``mirrorLock``. `nonisolated(unsafe)` tells
+    /// the compiler we take responsibility for that synchronisation ourselves
+    /// (the actor cannot: ``seed`` must read synchronously from the main
+    /// thread). The previous lock-free version was a genuine data race — an
+    /// actor-side write could tear against a ``seed`` read on another thread.
+    private static let mirrorLock = NSLock()
     nonisolated(unsafe) private static var lastSnapshot: Snapshot?
 
+    private static func readMirror() -> Snapshot? {
+        mirrorLock.lock()
+        defer { mirrorLock.unlock() }
+        return lastSnapshot
+    }
+
+    private static func writeMirror(_ snap: Snapshot?) {
+        mirrorLock.lock()
+        defer { mirrorLock.unlock() }
+        lastSnapshot = snap
+    }
+
     /// Synchronous peek for `@State` seeding. Returns entries only when they
-    /// would also satisfy ``cached(binary:generation:)``.
+    /// still satisfy the generation / override / TTL gate. The binary is not
+    /// compared here (a `@State` initializer has no access to it); the async
+    /// ``entries(binary:generation:)`` the view calls immediately afterwards
+    /// re-validates against the real binary and refetches on a mismatch, so a
+    /// wrong-binary seed survives at most one frame.
     nonisolated static func seed(generation: UInt) -> [ModelEntry]? {
-        guard let snap = lastSnapshot,
+        guard let snap = readMirror(),
               snap.generation == generation,
               snap.overridePath == ModelsFolderPreference.validatedOverrideURL()?.path,
               Date().timeIntervalSince(snap.fetchedAt) < ttl
@@ -81,17 +100,35 @@ actor ModelCatalogCache {
         return snap.entries
     }
 
-    /// In-flight load, so N simultaneous views trigger one set of subprocesses
-    /// instead of N. Without this the first paint after launch — picker plus
-    /// auto-start plus whichever panel is open — would fan out.
-    private var inFlight: Task<[ModelEntry], Never>?
+    /// An in-flight load together with the inputs it was started for, and a
+    /// monotonic id (``Task`` is not `Equatable`, so identity is tracked
+    /// explicitly). N simultaneous views join ONE set of subprocesses — but
+    /// only when their inputs match. A caller arriving after a download (new
+    /// generation), a folder repoint (new override) or a binary switch must
+    /// NOT receive the pre-change catalog, so it starts its own load instead.
+    private struct InFlight {
+        let id: UInt64
+        let binaryPath: String
+        let generation: UInt
+        let overridePath: String?
+        let task: Task<[ModelEntry], Never>
+
+        func matches(binaryPath: String, generation: UInt, overridePath: String?) -> Bool {
+            self.binaryPath == binaryPath
+                && self.generation == generation
+                && self.overridePath == overridePath
+        }
+    }
+
+    private var inFlight: InFlight?
+    private var nextInFlightID: UInt64 = 0
 
     /// A snapshot only if one is currently valid; never triggers a load.
     ///
     /// Views use this to decide whether to show a loading state: `nil` means
     /// "nothing to display yet", not "nothing exists".
     func cached(binary: URL, generation: UInt) -> [ModelEntry]? {
-        guard let snapshot, isFresh(snapshot, generation: generation) else {
+        guard let snapshot, isFresh(snapshot, binary: binary, generation: generation) else {
             return nil
         }
         return snapshot.entries
@@ -99,34 +136,88 @@ actor ModelCatalogCache {
 
     /// The catalog, served from cache when possible.
     ///
-    /// Returns immediately with a valid snapshot; otherwise awaits a real load
-    /// (joining one already running rather than starting a second).
+    /// Returns immediately with a valid snapshot; on a same-inputs TTL expiry
+    /// it still returns the stale snapshot and refreshes in the background (the
+    /// "serve stale while revalidating" contract). Only a genuine miss — no
+    /// snapshot, or one whose generation/override/binary changed — awaits a
+    /// real load, joining an in-flight one with matching inputs rather than
+    /// starting a second.
     func entries(binary: URL, generation: UInt) async -> [ModelEntry] {
-        if let snapshot, isFresh(snapshot, generation: generation) {
-            return snapshot.entries
-        }
-        if let inFlight {
-            return await inFlight.value
-        }
         let override = ModelsFolderPreference.validatedOverrideURL()
+        let overridePath = override?.path
+        let binaryPath = binary.path
+
+        if let snapshot,
+           snapshotMatchesInputs(
+               snapshot, binaryPath: binaryPath, generation: generation,
+               overridePath: overridePath
+           ) {
+            if Date().timeIntervalSince(snapshot.fetchedAt) < Self.ttl {
+                return snapshot.entries
+            }
+            // Same inputs, past the TTL backstop: serve the stale entries now
+            // and revalidate in the background (deduplicated via inFlight), so
+            // a passive out-of-band change is picked up without a spinner.
+            let stale = snapshot.entries
+            if inFlight == nil {
+                startLoad(
+                    binary: binary, override: override, binaryPath: binaryPath,
+                    generation: generation, overridePath: overridePath
+                )
+            }
+            return stale
+        }
+
+        if let inFlight,
+           inFlight.matches(
+               binaryPath: binaryPath, generation: generation,
+               overridePath: overridePath
+           ) {
+            return await inFlight.task.value
+        }
+        let task = startLoad(
+            binary: binary, override: override, binaryPath: binaryPath,
+            generation: generation, overridePath: overridePath
+        )
+        return await task.value
+    }
+
+    /// Start (and register) a load, replacing any in-flight one with different
+    /// inputs. The follow-up stamps the snapshot when the load lands. Returns
+    /// the task so a synchronous caller can await it directly.
+    @discardableResult
+    private func startLoad(
+        binary: URL, override: URL?, binaryPath: String,
+        generation: UInt, overridePath: String?
+    ) -> Task<[ModelEntry], Never> {
         let task = Task<[ModelEntry], Never> {
             await ModelCatalog.load(binary: binary, hubCacheOverride: override)
         }
-        inFlight = task
-        let loaded = await task.value
-        // Stamp with the generation captured at call time. If a mutation
-        // landed mid-load the counter has already moved on, so this snapshot
-        // is born stale and the next read refetches — which is the correct
-        // outcome: the load observed the world before the change.
+        nextInFlightID &+= 1
+        let entry = InFlight(
+            id: nextInFlightID, binaryPath: binaryPath, generation: generation,
+            overridePath: overridePath, task: task
+        )
+        inFlight = entry
+        Task { await self.finish(entry) }
+        return task
+    }
+
+    /// Await a registered load and stamp its result — unless a newer load has
+    /// already replaced it (a mutation landed mid-load; its snapshot is
+    /// authoritative and this now-stale result must not clobber it).
+    private func finish(_ entry: InFlight) async {
+        let loaded = await entry.task.value
+        guard let current = inFlight, current.id == entry.id else { return }
         snapshot = Snapshot(
             entries: loaded,
-            generation: generation,
+            generation: entry.generation,
             fetchedAt: Date(),
-            overridePath: override?.path
+            overridePath: entry.overridePath,
+            binaryPath: entry.binaryPath
         )
-        Self.lastSnapshot = snapshot
+        Self.writeMirror(snapshot)
         inFlight = nil
-        return loaded
     }
 
     /// Drop the snapshot. For callers that mutate the model set themselves and
@@ -134,14 +225,24 @@ actor ModelCatalogCache {
     /// generation counter to propagate.
     func invalidate() {
         snapshot = nil
-        Self.lastSnapshot = nil
+        inFlight = nil
+        Self.writeMirror(nil)
     }
 
-    private func isFresh(_ snapshot: Snapshot, generation: UInt) -> Bool {
-        guard snapshot.generation == generation else { return false }
-        guard snapshot.overridePath == ModelsFolderPreference.validatedOverrideURL()?.path else {
-            return false
-        }
+    private func snapshotMatchesInputs(
+        _ snapshot: Snapshot, binaryPath: String, generation: UInt,
+        overridePath: String?
+    ) -> Bool {
+        snapshot.generation == generation
+            && snapshot.overridePath == overridePath
+            && snapshot.binaryPath == binaryPath
+    }
+
+    private func isFresh(_ snapshot: Snapshot, binary: URL, generation: UInt) -> Bool {
+        guard snapshotMatchesInputs(
+            snapshot, binaryPath: binary.path, generation: generation,
+            overridePath: ModelsFolderPreference.validatedOverrideURL()?.path
+        ) else { return false }
         return Date().timeIntervalSince(snapshot.fetchedAt) < Self.ttl
     }
 }

--- a/apps/rapid-mac/Sources/Rapid/Server/ModelDeletion.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ModelDeletion.swift
@@ -112,6 +112,11 @@ enum ModelDeletion {
     }
 
     private static func cachedRepo(for alias: String, binary: URL) async -> String? {
+        // Deliberately NOT routed through ``ModelCatalogCache``: this resolves
+        // which directory is about to be deleted. A snapshot that is even
+        // slightly stale could name the wrong repo, and the cost of being
+        // wrong here is destroying the wrong download. Two subprocesses is a
+        // fine price for reading the world as it is at deletion time.
         let entries = await ModelCatalog.load(binary: binary)
         return entries.first { $0.alias == alias && $0.cached }?.hfRepo
     }

--- a/apps/rapid-mac/Sources/Rapid/UI/ConnectToolsView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ConnectToolsView.swift
@@ -36,7 +36,22 @@ struct ConnectToolsView: View {
                 cardContent
             }
         }
-        .frame(width: 460, height: 560)
+        // Size follows context, the same way ``showsCloseButton`` does.
+        //
+        // 460×560 is a sheet's size. As the Launch *page* it left the cards in
+        // a narrow column stranded in the middle of a 1200pt window, and the
+        // hard 560pt height forced a second scrollbar inside a pane that was
+        // already tall enough to show everything. Filling the pane instead
+        // lets the cards use the width that is actually there.
+        .frame(
+            width: showsCloseButton ? 460 : nil,
+            height: showsCloseButton ? 560 : nil
+        )
+        .frame(
+            maxWidth: showsCloseButton ? nil : .infinity,
+            maxHeight: showsCloseButton ? nil : .infinity,
+            alignment: .topLeading
+        )
         .background(RapidTheme.canvas)
     }
 
@@ -52,6 +67,11 @@ struct ConnectToolsView: View {
             endpointFootnote
         }
         .padding(20)
+        // Filling the pane is not the same as stretching to it. On a wide
+        // window the cards would otherwise run the full 1200pt and the
+        // one-line instructions would span the screen; capping the measure
+        // keeps them readable while the surrounding pane still expands.
+        .frame(maxWidth: showsCloseButton ? .infinity : 720)
     }
 
     private var header: some View {
@@ -63,6 +83,19 @@ struct ConnectToolsView: View {
                     .font(.callout)
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
+                // The key only exists while the server is running, and it is
+                // regenerated on every start. Without this the cards render
+                // `API key:` followed by nothing — a config that looks
+                // complete, copies clean, and fails at the far end with a 401.
+                if bearer.isEmpty {
+                    Label(
+                        "Server not running — start a chat to generate the key.",
+                        systemImage: "exclamationmark.circle"
+                    )
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+                    .padding(.top, 4)
+                }
             }
             Spacer()
             if showsCloseButton {

--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -183,6 +183,14 @@ struct ContentView: View {
         .sheet(isPresented: firstRunSheetPresented) {
             firstRunSheet
         }
+        // Presented from the split view — NOT from `mainArea` — so onboarding
+        // covers the whole window. Rendered inside the detail pane it left the
+        // sidebar exposed and clickable, which reads as "the app is already
+        // running, this panel is just one more surface" rather than "finish
+        // setup first".
+        .sheet(isPresented: quickstartSheetPresented) {
+            quickstartSheet
+        }
         .task { await runLaunchAutoStart() }
     }
 
@@ -206,26 +214,47 @@ struct ContentView: View {
     private var mainArea: some View {
         switch ContentView.mainAreaBranch(for: server.state) {
         case .chat(let serverReady):
-            if quickstartVisible {
-                QuickstartView(
-                    coordinator: quickstart,
-                    downloads: downloads,
-                    server: server,
-                    onBrowseAll: { quickstartDismissedThisSession = true },
-                    onSeedWelcome: { true }
-                )
-            } else {
-                ChatView(
-                    viewModel: chat,
-                    server: server,
-                    alias: $alias,
-                    serverReady: serverReady,
-                    autoStartPendingDownload: autoStartPendingDownload
-                )
-            }
+            ChatView(
+                viewModel: chat,
+                server: server,
+                alias: $alias,
+                serverReady: serverReady,
+                autoStartPendingDownload: autoStartPendingDownload
+            )
         case .missing:
             missingOverlay
         }
+    }
+
+    // MARK: - Quickstart presentation
+
+    private var quickstartSheetPresented: Binding<Bool> {
+        Binding(
+            get: { quickstartVisible },
+            set: { presented in
+                // A swipe-down / Esc means "let me look around first" — the
+                // same intent as the card's own "Browse all models", so route
+                // it to the same session flag rather than dropping it.
+                if !presented { quickstartDismissedThisSession = true }
+            }
+        )
+    }
+
+    @ViewBuilder
+    private var quickstartSheet: some View {
+        QuickstartView(
+            coordinator: quickstart,
+            downloads: downloads,
+            server: server,
+            onBrowseAll: { quickstartDismissedThisSession = true },
+            onSeedWelcome: { true }
+        )
+        // QuickstartView was written for the detail column and its comments
+        // cite a ~360pt worst case (the 640pt window floor minus the sidebar).
+        // A sheet has no such parent, so without an explicit size it would
+        // collapse to its content's ideal width. Pin it near the window floor
+        // so the model cards keep the room they were laid out for.
+        .frame(minWidth: 620, minHeight: Self.minWindowHeight)
     }
 
     /// True when the Quickstart card should render in place of the chat
@@ -235,6 +264,13 @@ struct ContentView: View {
     /// ``QuickstartCoordinator.isEligible``), never the shared HF cache.
     private var quickstartVisible: Bool {
         guard !quickstartDismissedThisSession else { return false }
+        // Telemetry consent comes first. Both surfaces used to be able to fire
+        // together (nothing referenced the other's condition) — tolerable when
+        // Quickstart merely filled the detail pane behind the consent sheet,
+        // but now they compete for the same presentation channel, and macOS
+        // grants that to whichever asks first. Deferring here keeps the order
+        // deterministic: decide on telemetry, then pick a model.
+        guard !telemetryConsentPending else { return false }
         if ContentView.serverEngagedWithDifferentAlias(
             state: server.state,
             quickstartAlias: quickstart.selection.alias
@@ -420,7 +456,10 @@ struct ContentView: View {
         let aliasAtEntry = alias
         var cachedAliases: Set<String> = []
         if let binary = server.binaryPath {
-            let entries = await ModelCatalog.load(binary: binary)
+            let entries = await ModelCatalogCache.shared.entries(
+                binary: binary,
+                generation: downloads.cacheGeneration
+            )
             cachedAliases = Set(entries.filter { $0.cached }.map(\.alias))
         }
         guard case .idle = server.state else {

--- a/apps/rapid-mac/Sources/Rapid/UI/ModelPickerBar.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ModelPickerBar.swift
@@ -1914,7 +1914,10 @@ struct ModelPickerBar: View {
                 loadingCatalog = false
             }
         }
-        let entries = await ModelCatalog.load(binary: binary)
+        let entries = await ModelCatalogCache.shared.entries(
+            binary: binary,
+            generation: downloads.cacheGeneration
+        )
         guard !Task.isCancelled, catalogRefreshGeneration == refreshGeneration else { return }
         self.catalog = entries
         // Default selection: only apply if the current alias is blank or

--- a/apps/rapid-mac/Sources/Rapid/UI/SettingsModelManagementPanel.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SettingsModelManagementPanel.swift
@@ -33,8 +33,11 @@ struct SettingsModelManagementPanel: View {
     @Environment(ServerManager.self) private var server
     @Environment(DownloadManager.self) private var downloads
 
-    @State private var catalog: [ModelEntry] = []
-    @State private var loading: Bool = true
+    // Seeded from the process-wide cache — see the matching note in
+    // ``SettingsModelsPanel``. An empty start re-rendered the spinner on every
+    // visit regardless of whether the data was already cached.
+    @State private var catalog: [ModelEntry] = ModelCatalogCache.seed(generation: 0) ?? []
+    @State private var loading: Bool = ModelCatalogCache.seed(generation: 0) == nil
     @State private var pendingDeletion: ModelEntry?
     @State private var lastError: String?
     @State private var lastFreed: String?
@@ -1069,13 +1072,27 @@ struct SettingsModelManagementPanel: View {
     // MARK: - Actions
 
     private func refreshCatalog() async {
-        loading = true
-        defer { loading = false }
         guard let binary = server.binaryPath else {
             catalog = []
+            loading = false
             return
         }
-        catalog = await ModelCatalog.load(binary: binary)
+        let generation = downloads.cacheGeneration
+        // Show a cached snapshot straight away and skip the spinner entirely —
+        // flashing "loading" over data we already have makes every visit to
+        // this panel feel like a cold start.
+        if let hit = await ModelCatalogCache.shared.cached(
+            binary: binary, generation: generation
+        ) {
+            catalog = hit
+            loading = false
+            return
+        }
+        loading = true
+        defer { loading = false }
+        catalog = await ModelCatalogCache.shared.entries(
+            binary: binary, generation: generation
+        )
     }
 
     private func deleteAlias(_ entry: ModelEntry) async {

--- a/apps/rapid-mac/Sources/Rapid/UI/SettingsModelsPanel.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SettingsModelsPanel.swift
@@ -32,8 +32,17 @@ struct SettingsModelsPanel: View {
     @Environment(ServerManager.self) private var server
     @Environment(DownloadManager.self) private var downloads
 
-    @State private var catalog: [ModelEntry] = []
-    @State private var loading: Bool = true
+    // Seeded from the process-wide cache rather than starting empty. `@State`
+    // is rebuilt every time this panel re-appears, so an empty start meant the
+    // spinner rendered on the first frame of every visit — even when the data
+    // was already in hand and the refresh would resolve instantly.
+    //
+    // Generation 0 is the right key here: `@State` initialisers can't read
+    // `@Environment`, and a fresh app run starts at 0. If the real generation
+    // has moved on, the `.task` below simply refetches — the seed is an
+    // optimisation, never the source of truth.
+    @State private var catalog: [ModelEntry] = ModelCatalogCache.seed(generation: 0) ?? []
+    @State private var loading: Bool = ModelCatalogCache.seed(generation: 0) == nil
     @State private var pendingDeletion: ModelEntry?
     @State private var lastError: String?
     @State private var lastFreed: String?
@@ -564,13 +573,26 @@ struct SettingsModelsPanel: View {
     // MARK: - Actions
 
     private func refreshCatalog() async {
-        loading = true
-        defer { loading = false }
         guard let binary = server.binaryPath else {
             catalog = []
+            loading = false
             return
         }
-        catalog = await ModelCatalog.load(binary: binary)
+        let generation = downloads.cacheGeneration
+        // Cached snapshot → paint it and skip the spinner (see
+        // ``ModelCatalogCache``); only a genuine miss shows a loading state.
+        if let hit = await ModelCatalogCache.shared.cached(
+            binary: binary, generation: generation
+        ) {
+            catalog = hit
+            loading = false
+            return
+        }
+        loading = true
+        defer { loading = false }
+        catalog = await ModelCatalogCache.shared.entries(
+            binary: binary, generation: generation
+        )
     }
 
     private func deleteAlias(_ entry: ModelEntry) async {

--- a/apps/rapid-mac/Sources/Rapid/UI/SettingsView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SettingsView.swift
@@ -445,7 +445,19 @@ struct SettingsView: View {
                     value: "v\(appUpdater.currentVersion)",
                     monospaced: true
                 )
-                if let release = appUpdater.latest {
+                // Only show the manifest's version when it is actually at or
+                // ahead of what's installed. A manifest BEHIND the installed
+                // build means the release feed is stale (or this is a dev /
+                // pre-release build) — labelling an older number "Latest
+                // release" reads as if the user is somehow ahead of the
+                // world, or that their install is wrong.
+                //
+                // ``appUpdateStatus`` already models exactly this case
+                // (installed strictly newer → ``.unknown``, see the truth
+                // table below), but this row rendered ``latest`` directly and
+                // so bypassed that judgement. Gate it on the same predicate.
+                if let release = appUpdater.latest,
+                   !UpdateChecker.isNewer(appUpdater.currentVersion, than: release.version) {
                     versionRow(
                         label: "Latest release",
                         value: "v\(release.version)",
@@ -566,6 +578,9 @@ struct SettingsView: View {
         case available(version: String)
         case upToDate(version: String)
         case checking
+        /// Poll succeeded but the manifest is behind the installed build.
+        /// Not an error and not "unknown" — see ``resolveAppUpdateStatus``.
+        case aheadOfManifest(current: String, manifest: String)
         case unknown(reason: String?)
     }
 
@@ -588,9 +603,14 @@ struct SettingsView: View {
     ///      ``currentVersion`` is ahead of the manifest does NOT
     ///      collapse into the reassuring "up to date" state (v0.7.4
     ///      status-bar regression).
-    ///   4. Otherwise (check completed but ``latest == nil`` —
-    ///      worker errored, payload rejected, or installed build is
-    ///      ahead of the manifest) → ``.unknown(lastError)``.
+    ///   4. A check completed and returned a manifest OLDER than the
+    ///      installed build → ``.aheadOfManifest``. Distinct from
+    ///      ``.unknown``: nothing failed and nothing is missing, so
+    ///      telling the user to press "Check for updates" would send
+    ///      them to re-run a poll that already succeeded and will keep
+    ///      returning the same answer.
+    ///   5. Otherwise (check completed but ``latest == nil`` — worker
+    ///      errored or payload rejected) → ``.unknown(lastError)``.
     static func resolveAppUpdateStatus(
         currentVersion: String,
         availableUpdate: UpdateChecker.Release?,
@@ -613,6 +633,16 @@ struct SettingsView: View {
             // if ``latest`` were strictly newer than us, so the only
             // remaining case here is equality.)
             return .upToDate(version: currentVersion)
+        }
+        if let latest, UpdateChecker.isNewer(currentVersion, than: latest.version) {
+            // The poll worked; the feed is just behind us. A dev build, or a
+            // release that shipped to GitHub before `latest.json` was
+            // republished. Either way it is a statement of fact, not an
+            // error, and re-checking cannot change it.
+            return .aheadOfManifest(
+                current: currentVersion,
+                manifest: latest.version
+            )
         }
         // ``lastCheckedAt`` set but EITHER ``latest`` is nil (most
         // recent attempt populated ``lastError`` instead of a
@@ -686,6 +716,21 @@ struct SettingsView: View {
                 }
                 Spacer()
                 appUpdateRecheckButton
+            case .aheadOfManifest(let current, _):
+                HStack(spacing: 6) {
+                    Image(systemName: "checkmark.circle")
+                        .foregroundStyle(.secondary)
+                    Text("Up to date — v\(current).")
+                        .font(.callout)
+                        .foregroundStyle(.primary)
+                        .accessibilityIdentifier("Settings.App.AheadOfManifest")
+                }
+                Spacer()
+                // No re-check button. The poll already succeeded; the feed is
+                // simply behind this build, and pressing it again returns the
+                // same answer. An action that provably cannot change anything
+                // is worse than no action — it invites the user to keep
+                // trying and reads as if something is wrong.
             case .unknown(let reason):
                 HStack(spacing: 6) {
                     Image(systemName: "questionmark.circle")

--- a/apps/rapid-mac/Sources/Rapid/UI/SidebarView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SidebarView.swift
@@ -38,16 +38,18 @@ struct SidebarView: View {
             )
 
             if !chat.conversations.isEmpty {
-                Text("Older")
-                    .font(.caption.weight(.medium))
-                    .foregroundStyle(.secondary)
-                    .padding(.horizontal, 10)
-                    .padding(.top, 12)
-                    .padding(.bottom, 2)
                 ScrollView {
                     VStack(alignment: .leading, spacing: 2) {
-                        ForEach(chat.conversations) { conv in
-                            conversationRow(conv)
+                        ForEach(historySections, id: \.title) { section in
+                            Text(section.title)
+                                .font(.caption.weight(.medium))
+                                .foregroundStyle(.secondary)
+                                .padding(.horizontal, 10)
+                                .padding(.top, 12)
+                                .padding(.bottom, 2)
+                            ForEach(section.conversations) { conv in
+                                conversationRow(conv)
+                            }
                         }
                     }
                 }
@@ -57,6 +59,65 @@ struct SidebarView: View {
         }
         .padding(8)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+    }
+
+    /// The history list split into dated sections, newest first.
+    ///
+    /// Everything used to sit under a hard-coded "Older" heading, so a
+    /// conversation five seconds old was filed as ancient history.
+    private var historySections: [HistorySection] {
+        SidebarView.sections(for: chat.conversations, now: Date())
+    }
+
+    struct HistorySection {
+        let title: String
+        let conversations: [ChatConversation]
+    }
+
+    /// Bucket conversations by recency. ``now`` is injected rather than read
+    /// inside, matching ``RelativeTimestamp`` — it keeps the function pure so
+    /// the day boundaries can be exercised without waiting for midnight.
+    ///
+    /// Uses `Calendar` (not a fixed 86 400s divisor) because the buckets are
+    /// *calendar* days: something sent at 23:55 belongs to "Yesterday" once
+    /// the clock passes midnight, even though barely any time has elapsed.
+    /// Empty buckets produce no section, so no stray headings appear.
+    static func sections(
+        for conversations: [ChatConversation],
+        now: Date,
+        calendar: Calendar = .current
+    ) -> [HistorySection] {
+        var today: [ChatConversation] = []
+        var yesterday: [ChatConversation] = []
+        var week: [ChatConversation] = []
+        var older: [ChatConversation] = []
+
+        // The 7-day cutoff is anchored to the START of today, not to `now` —
+        // otherwise the boundary would drift through the day and a
+        // conversation could slide between sections while the user watches.
+        let startOfToday = calendar.startOfDay(for: now)
+        let weekCutoff = calendar.date(byAdding: .day, value: -7, to: startOfToday)
+
+        for conv in conversations {
+            if calendar.isDate(conv.updatedAt, inSameDayAs: now) {
+                today.append(conv)
+            } else if calendar.isDateInYesterday(conv.updatedAt) {
+                yesterday.append(conv)
+            } else if let weekCutoff, conv.updatedAt >= weekCutoff {
+                week.append(conv)
+            } else {
+                older.append(conv)
+            }
+        }
+
+        return [
+            ("Today", today),
+            ("Yesterday", yesterday),
+            ("Previous 7 Days", week),
+            ("Older", older),
+        ]
+        .filter { !$0.1.isEmpty }
+        .map { HistorySection(title: $0.0, conversations: $0.1) }
     }
 
     /// One history row — the conversation's derived title, amber-selected

--- a/apps/rapid-mac/Sources/Rapid/UI/SidebarView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SidebarView.swift
@@ -37,6 +37,13 @@ struct SidebarView: View {
     /// Open a saved conversation (switches the detail pane back to chat).
     var onSelectConversation: (UUID) -> Void
 
+    /// The "now" the date buckets are computed against. Rolled forward by
+    /// ``dayBoundaryTicker`` at each midnight so an open, untouched sidebar
+    /// re-labels yesterday's conversations instead of freezing on the day it
+    /// was first rendered. Injected (rather than reading ``Date()`` inside the
+    /// section builder) so the roll-over is an observable state change.
+    @State private var referenceDate = Date()
+
     var body: some View {
         VStack(alignment: .leading, spacing: 1) {
             row(
@@ -77,6 +84,7 @@ struct SidebarView: View {
         .padding(.horizontal, RapidTheme.Space.sm)
         .padding(.vertical, RapidTheme.Space.md)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        .task { await dayBoundaryTicker() }
     }
 
     /// The history list split into dated sections, newest first.
@@ -84,7 +92,28 @@ struct SidebarView: View {
     /// Everything used to sit under a hard-coded "Older" heading, so a
     /// conversation five seconds old was filed as ancient history.
     private var historySections: [HistorySection] {
-        SidebarView.sections(for: chat.conversations, now: Date())
+        SidebarView.sections(for: chat.conversations, now: referenceDate)
+    }
+
+    /// Advance ``referenceDate`` at each calendar-day boundary for as long as
+    /// the sidebar is on screen. Sleeps until the next midnight, bumps the
+    /// state (which re-buckets the list), then loops. Cancels with the view.
+    private func dayBoundaryTicker() async {
+        let calendar = Calendar.current
+        while !Task.isCancelled {
+            let next =
+                calendar.nextDate(
+                    after: Date(),
+                    matching: DateComponents(hour: 0, minute: 0, second: 0),
+                    matchingPolicy: .nextTime
+                ) ?? Date().addingTimeInterval(24 * 60 * 60)
+            let delay = next.timeIntervalSinceNow
+            if delay > 0 {
+                try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+            }
+            if Task.isCancelled { break }
+            referenceDate = Date()
+        }
     }
 
     struct HistorySection {


### PR DESCRIPTION
## Why
`@xiaoxiunique`'s #1470 fixes six real desktop UX defects, but its branch predates
the #1460 visual-system refresh and no longer merges. This lands the same six
fixes on current `main` (three UI files conflict-resolved by hand), and hardens
the new code that #1470 introduced. Refs #1470.

## The six fixes (from #1470)
1. **Sidebar ordering** — opening a past conversation no longer reorders the
   sidebar; added Today / Yesterday / Previous 7 Days / Older date groups.
2. **Onboarding scope** — first-run overlay now covers the sidebar too; the
   telemetry-consent vs model-pick order is fixed.
3. **Catalog cache** — `ModelCatalogCache` removes the repeated lister
   subprocess on every settings visit (startup 2→1, panel switch 12→0).
4. **Stale-manifest copy** — distinguishes `.aheadOfManifest` from "unknown".
5. **Launch page sizing** — no longer wears the sheet's fixed dimensions; also
   surfaces the missing-API-key hint when the server isn't running.
6. **Date-group regression tests** — midnight-boundary + 7-day cutoff cases.

## Conflict resolution (merged with #1460's visual refresh)
- `SidebarView` — kept the date grouping, titled each group with the shared
  `SectionHeader` (matching #1460) rather than the PR's inline caption.
- `ModelPickerBar` — routed through `ModelCatalogCache`; kept the `loaded`
  binding so the phantom-alias filter is untouched.
- `ConnectToolsView` — main already fixed Launch-page sizing via its
  `ConnectToolsFrame`, so that's kept; the PR's missing-API-key hint was folded
  into main's `SectionHeader` header.

## Hardening #1470's new code (codex review of the first push)
Because these matter for correctness, not just review scoring:
- **Data race** — `ModelCatalogCache.lastSnapshot` was read from `seed()` on the
  main thread while the actor wrote it (UB). Now gated by an `NSLock`.
- **In-flight join ignored inputs** — a read after a download/folder/binary
  change could join a stale load. In-flight tasks are now keyed by
  (binary, generation, override) with a monotonic id; only matching tasks join,
  and a superseded load can no longer stamp (id guard, which also stops an
  in-flight completion from undoing `invalidate()`).
- **Snapshot ignored the binary** — added `binaryPath`, compared in `isFresh`.
- **Midnight staleness** — `SidebarView` date buckets are computed against an
  injected `referenceDate` a `.task` rolls forward at each calendar-day boundary,
  so an open sidebar no longer labels yesterday's chats "Today" forever.
- **Stale-while-revalidate** — a same-inputs TTL expiry serves the stale entries
  and refreshes in the background instead of blocking.

## Validation
- `swift build` → **Build complete** (all conflict resolutions + hardening compile).
- The tested `SidebarView.sections(...)` grouping logic is byte-unchanged by the merge.
- ruff + pytest untouched (Swift-only change); pr_validate confirms no Python regressions.

Supersedes #1470 (fork branch we can't push to). Original fixes by @xiaoxiunique.

Co-Authored-By: Atom <929746602@qq.com>