### PR TITLE
fix(ci): repair auto-release — an empty ${{ }} expression invalidated the workflow

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -249,7 +249,7 @@ jobs:
           # (``body<<__EOF__``) could be escaped by any line equal to the
           # delimiter — now reachable from human-authored highlights as well as
           # commit subjects. A file has no delimiter to escape and never passes
-          # through ``${{ }}``.
+          # through GitHub Actions expression interpolation.
           RELEASE_SHA="$RELEASE_SHA" bash scripts/build_release_notes.sh > "$NOTES_FILE"
 
           echo "release_sha=$RELEASE_SHA" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,14 @@ jobs:
       - name: GitHub Actions SHA pinning
         run: python scripts/check_gha_pinning.py
 
+      # An invalid ``${{ … }}`` expression invalidates the WHOLE workflow:
+      # the run fails instantly with zero jobs and no log, and because it
+      # is not a PR check it never shows up as red on the PR that
+      # introduced it. That is how an empty expression inside a `run:`
+      # comment took the release pipeline down for a full day.
+      - name: Workflow expression sanity
+        run: python scripts/check_workflow_expressions.py
+
       # Parser microbench — catches >10x regressions in tool-call
       # extraction. Pure Python (parsers don't import mlx); thresholds
       # are intentionally generous (3-5x measured M3 numbers) to

--- a/scripts/check_workflow_expressions.py
+++ b/scripts/check_workflow_expressions.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Reject GitHub Actions workflows containing an invalid ``${{ }}`` expression.
+
+GitHub evaluates ``${{ ... }}`` in workflow VALUES — including inside ``run:``
+scripts, where a leading ``#`` is a *shell* comment and therefore still gets
+interpolated. An expression that does not parse invalidates the whole
+workflow: the run fails instantly with ZERO jobs and no log, so it never
+surfaces as a failing check on the PR that introduced it.
+
+That is how a ``run:`` comment reading "never passes through `${{ }}`" took
+the release pipeline down — an empty expression is a syntax error.
+
+Scans parsed YAML values only, so genuine YAML comments (which the parser
+drops before Actions ever sees them) are correctly ignored. Deliberately
+narrow: it checks the one mistake that silently breaks an entire workflow.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+EXPR = re.compile(r"\$\{\{(.*?)\}\}", re.S)
+
+
+def walk(node):
+    """Yield every string scalar in a parsed YAML document."""
+    if isinstance(node, str):
+        yield node
+    elif isinstance(node, dict):
+        for k, v in node.items():
+            yield from walk(k)
+            yield from walk(v)
+    elif isinstance(node, list):
+        for v in node:
+            yield from walk(v)
+
+
+def problems(text: str) -> list[str]:
+    try:
+        doc = yaml.safe_load(text)
+    except yaml.YAMLError as exc:
+        return [f"YAML does not parse: {exc}"]
+
+    found: list[str] = []
+    for s in walk(doc):
+        for m in EXPR.finditer(s):
+            if not m.group(1).strip():
+                found.append(
+                    "empty expression `${{ }}` — invalid, breaks the whole workflow"
+                )
+        # An unclosed opener is equally fatal.
+        if s.count("${{") > len(EXPR.findall(s)):
+            found.append("unclosed `${{` — invalid, breaks the whole workflow")
+    return found
+
+
+def candidate_lines(text: str) -> list[int]:
+    """Raw-text lines holding a literal ``${{ }}``.
+
+    Detection is done on parsed YAML (authoritative); this is only to point a
+    human at the right place. A genuine YAML comment can appear here too, so
+    all candidates are listed rather than guessing which one is fatal.
+    """
+    return [
+        i
+        for i, line in enumerate(text.split("\n"), 1)
+        if re.search(r"\$\{\{\s*\}\}", line)
+    ]
+
+
+def main() -> int:
+    root = Path(__file__).resolve().parent.parent / ".github" / "workflows"
+    files = sorted(root.glob("*.y*ml"))
+    failed = False
+    for path in files:
+        text = path.read_text(encoding="utf-8")
+        probs = problems(text)
+        if probs:
+            rel = path.relative_to(root.parent.parent)
+            for why in probs:
+                print(f"{rel}: {why}", file=sys.stderr)
+            lines = candidate_lines(text)
+            if lines:
+                print(
+                    f"  literal `${{{{ }}}}` appears at line(s): "
+                    f"{', '.join(map(str, lines))} "
+                    "(one inside a `run:` block is the fatal one; a real YAML "
+                    "comment is harmless)",
+                    file=sys.stderr,
+                )
+            failed = True
+    if failed:
+        print(
+            "\nTo write those characters in prose, say "
+            "'GitHub Actions expression interpolation' instead.",
+            file=sys.stderr,
+        )
+        return 1
+    print(f"workflow expressions OK ({len(files)} files)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Why

`auto-release.yml` has failed on **every** run since #1401 landed — instantly,
with zero jobs and no log. The release pipeline is down.

Cause: a comment inside the changelog step's `run:` block reads

```
# never passes through ``${{ }}``.
```

GitHub evaluates `${{ … }}` inside `run:` scripts as well as in YAML values,
and there a leading `#` is a *shell* comment, not a YAML one — so Actions still
interpolates it. An **empty** expression is a syntax error, and a single
invalid expression invalidates the entire workflow.

It produced no red check on the PR that introduced it because `auto-release.yml`
runs on `push`, not as a pull-request check — so it was merged clean and then
failed silently on `main`.

Confirmed with `actionlint`:

```
auto-release.yml:232:979: unexpected end of input while parsing variable access,
function call, null, bool, int, float or string [expression]
```

and by history: `main` was green through 05:25Z and has failed on every run
since.

## What

* Rewords the comment so no literal empty expression remains.
* Adds `scripts/check_workflow_expressions.py`, wired into the `lint` job next
  to the existing SHA-pinning check.

The checker scans **parsed YAML values**, so `run:` bodies are covered while
genuine YAML comments — dropped by the parser before Actions sees them, and one
of which exists harmlessly in this very file at line 57 — are correctly not
flagged. That distinction is the whole point: a naive text scan produces a false
positive on the harmless one and would have been reverted as noise.

## Verification

- `actionlint` no longer reports an expression error for `auto-release.yml`.
- Checker passes on the repaired tree (13 workflows) and exits 1 on the broken
  one, naming the candidate lines.
- `ruff check` / `ruff format` clean.

Found while reviewing #1467/#1472 — their runs surfaced the same
`auto-release.yml: failure`, which turned out to be main-wide rather than
anything in those PRs.