### PR TITLE
fix(deepseek): prevent reasoning reopen after public output

### DIFF
--- a/tests/test_reasoning_budget_generation.py
+++ b/tests/test_reasoning_budget_generation.py
@@ -216,6 +216,21 @@ def test_force_mask_released_when_think_end_observed():
     assert bool(mx.all(proc([1, 10, THINK_END, 20], logits) == logits))
 
 
+def test_bounded_reasoning_suppresses_reopen_after_public_content():
+    proc = ReasoningBudgetLogitsProcessor(
+        THINK_END, 1, think_start_id=THINK_START, seeded_thinking=True
+    )
+    _ = proc([1], mx.zeros((128,)))
+    _ = proc([1, 10], mx.zeros((128,)))
+    _ = proc([1, 10, THINK_END], mx.zeros((128,)))
+
+    logits = mx.zeros((128,))
+    out = proc([1, 10, THINK_END, 20], logits)
+    assert out[0, THINK_START].item() == -math.inf
+    assert out[0, THINK_END].item() == 0.0
+    assert out[0, 20].item() == 0.0
+
+
 def test_force_override_dominates_a_prior_neg_inf_at_think_end():
     # The load-bearing #1 fix: the force is an OVERRIDE, not an additive mask.
     # Simulate a chained grammar that already drove </think> (and much else) to

--- a/tests/test_reasoning_budget_generation.py
+++ b/tests/test_reasoning_budget_generation.py
@@ -231,6 +231,19 @@ def test_bounded_reasoning_suppresses_reopen_after_public_content():
     assert out[0, 20].item() == 0.0
 
 
+def test_invalid_reopen_id_is_ignored_against_runtime_logits_width():
+    proc = ReasoningBudgetLogitsProcessor(
+        THINK_END, 1, think_start_id=-1, seeded_thinking=True
+    )
+    _ = proc([1], mx.zeros((128,)))
+    _ = proc([1, 10], mx.zeros((128,)))
+    _ = proc([1, 10, THINK_END], mx.zeros((128,)))
+
+    logits = mx.zeros((128,))
+    out = proc([1, 10, THINK_END, 20], logits)
+    assert bool(mx.all(out == logits))
+
+
 def test_force_override_dominates_a_prior_neg_inf_at_think_end():
     # The load-bearing #1 fix: the force is an OVERRIDE, not an additive mask.
     # Simulate a chained grammar that already drove </think> (and much else) to

--- a/tests/test_responses_route.py
+++ b/tests/test_responses_route.py
@@ -1839,7 +1839,7 @@ def test_deepseek_codex_reasoning_budget_is_narrowly_attached(
         tools=[object()] if has_tools else [], reasoning_max_tokens=2048
     )
     engine = SimpleNamespace(
-        tokenizer=SimpleNamespace(get_vocab=lambda: {"</think>": 18})
+        tokenizer=SimpleNamespace(get_vocab=lambda: {"<think>": 17, "</think>": 18})
     )
     cfg = SimpleNamespace(
         model_path="DeepSeek-V4-Flash-0731",
@@ -1856,7 +1856,7 @@ def test_deepseek_codex_reasoning_budget_is_narrowly_attached(
     assert bool(calls) is expected
     if expected:
         assert calls[0][0] == (18, 2048)
-        assert calls[0][1] == {"seeded_thinking": True}
+        assert calls[0][1] == {"think_start_id": 17, "seeded_thinking": True}
 
 
 @pytest.mark.parametrize(
@@ -1926,7 +1926,7 @@ def test_deepseek_codex_reasoning_boundary_is_cached_per_engine(monkeypatch):
     def get_vocab():
         nonlocal calls
         calls += 1
-        return {"</think>": 18}
+        return {"<think>": 17, "</think>": 18}
 
     monkeypatch.setattr(
         "vllm_mlx.routes.chat._engine_output_vocab_size", lambda _engine: 256
@@ -1943,7 +1943,7 @@ def test_deepseek_codex_reasoning_boundary_is_cached_per_engine(monkeypatch):
         _attach_deepseek_codex_reasoning_budget(engine, cfg, request, True, True, {})
 
     assert calls == 1
-    assert engine._rapid_mlx_deepseek_codex_reasoning_boundary == (18, 256)
+    assert engine._rapid_mlx_deepseek_codex_reasoning_boundary_v2 == (17, 18, 256)
 
 
 @pytest.mark.parametrize("stream", [False, True])
@@ -1963,7 +1963,7 @@ def test_responses_route_wires_deepseek_codex_reasoning_budget(
     cfg.reasoning_parser_name = "deepseek_v4"
     cfg.tool_call_parser = tool_parser
     engine = responses_client.engine
-    engine.tokenizer.get_vocab = lambda: {"</think>": 18}
+    engine.tokenizer.get_vocab = lambda: {"<think>": 17, "</think>": 18}
     monkeypatch.setattr(
         "vllm_mlx.routes.chat._engine_output_vocab_size", lambda _engine: 256
     )

--- a/vllm_mlx/api/reasoning_budget.py
+++ b/vllm_mlx/api/reasoning_budget.py
@@ -220,11 +220,20 @@ class ReasoningBudgetLogitsProcessor:
         if self._budget < 0:
             return logits
         if self._ended:
-            if self._reopen_suppressor is not None:
+            if (
+                self._reopen_suppressor is not None
+                and self._think_start_id is not None
+                and 0 <= self._think_start_id < int(logits.shape[-1])
+            ):
                 return self._reopen_suppressor(token_ids, logits)
             return logits
         phase = self._phase(token_ids)
-        if self._ended and self._reopen_suppressor is not None:
+        if (
+            self._ended
+            and self._reopen_suppressor is not None
+            and self._think_start_id is not None
+            and 0 <= self._think_start_id < int(logits.shape[-1])
+        ):
             return self._reopen_suppressor(token_ids, logits)
         if phase != "force":
             return logits

--- a/vllm_mlx/api/reasoning_budget.py
+++ b/vllm_mlx/api/reasoning_budget.py
@@ -219,6 +219,10 @@ class ReasoningBudgetLogitsProcessor:
         # cap costs nothing.
         if self._budget < 0:
             return logits
+        if self._ended:
+            if self._reopen_suppressor is not None:
+                return self._reopen_suppressor(token_ids, logits)
+            return logits
         phase = self._phase(token_ids)
         if self._ended and self._reopen_suppressor is not None:
             return self._reopen_suppressor(token_ids, logits)

--- a/vllm_mlx/api/reasoning_budget.py
+++ b/vllm_mlx/api/reasoning_budget.py
@@ -90,9 +90,11 @@ class ReasoningBudgetLogitsProcessor:
       already thinking is NOT exempt — it counts, else a model looping ``<think>``
       could stall the budget forever (see ``_commit_tail``). At budget, force
       ``think_end_id``.
-    * GENERATION — once ``think_end_id`` is seen, this processor is inert
-      (returns logits unchanged) so a chained grammar/penalty processor owns
-      the rest of the request. A latch makes this O(1) after the boundary.
+    * GENERATION — once ``think_end_id`` is seen, the processor suppresses a
+      later ``think_start_id`` while leaving every other logit unchanged. This
+      prevents a bounded reasoning turn from reopening hidden reasoning after
+      public content, which the Responses protocol cannot represent. A cached
+      one-token mask keeps this O(1) after the boundary.
 
     ``seeded_thinking`` selects between the TWO shapes a reasoning template can
     take: one that PREFILLS ``<think>`` into the prompt (seeded — the opener
@@ -148,6 +150,11 @@ class ReasoningBudgetLogitsProcessor:
         # ``think_end_id`` outside the logits width disables the budget instead
         # of masking to an all -inf row.
         self._oob_logged = False
+        self._reopen_suppressor = (
+            SuppressTokensLogitsProcessor([self._think_start_id])
+            if self._think_start_id is not None
+            else None
+        )
 
     # ---- phase machine (pure, unit-testable without mlx) -------------------
 
@@ -209,10 +216,13 @@ class ReasoningBudgetLogitsProcessor:
 
     def __call__(self, token_ids: Any, logits: Any) -> Any:
         # Unlimited budget is a pure no-op; skip even the tail walk so an unset
-        # cap costs nothing. The ended-latch short-circuits the O(1) tail.
-        if self._budget < 0 or self._ended:
+        # cap costs nothing.
+        if self._budget < 0:
             return logits
-        if self._phase(token_ids) != "force":
+        phase = self._phase(token_ids)
+        if self._ended and self._reopen_suppressor is not None:
+            return self._reopen_suppressor(token_ids, logits)
+        if phase != "force":
             return logits
         return self._force_distribution(logits)
 

--- a/vllm_mlx/routes/responses.py
+++ b/vllm_mlx/routes/responses.py
@@ -531,42 +531,47 @@ def _attach_deepseek_codex_reasoning_budget(
     # prefilled or is the first generated token. Treating it as seeded also avoids
     # losing that first marker when mlx-lm establishes the processor's cumulative
     # token baseline on its first callback.
-    cache_attr = "_rapid_mlx_deepseek_codex_reasoning_boundary"
+    cache_attr = "_rapid_mlx_deepseek_codex_reasoning_boundary_v2"
     boundary = getattr(engine, cache_attr, None)
     if not (
         isinstance(boundary, tuple)
-        and len(boundary) == 2
+        and len(boundary) == 3
         and all(isinstance(value, int) for value in boundary)
     ):
         tokenizer = getattr(engine, "tokenizer", None)
         try:
-            end_id = tokenizer.get_vocab().get("</think>")
+            vocab = tokenizer.get_vocab()
+            start_id = vocab.get("<think>")
+            end_id = vocab.get("</think>")
         except Exception as exc:
             raise RuntimeError(
                 "DeepSeek Codex reasoning budget unavailable: tokenizer cannot "
-                "resolve the </think> boundary"
+                "resolve the <think>/</think> boundaries"
             ) from exc
         vocab_size = _engine_output_vocab_size(engine)
         if (
-            not isinstance(end_id, int)
+            not isinstance(start_id, int)
+            or not isinstance(end_id, int)
             or vocab_size is None
+            or not 0 <= start_id < vocab_size
             or not 0 <= end_id < vocab_size
         ):
             raise RuntimeError(
-                "DeepSeek Codex reasoning budget unavailable: </think> is "
-                "missing or outside the model output vocabulary"
+                "DeepSeek Codex reasoning budget unavailable: <think> or "
+                "</think> is missing or outside the model output vocabulary"
             )
-        boundary = (end_id, vocab_size)
+        boundary = (start_id, end_id, vocab_size)
         try:
             setattr(engine, cache_attr, boundary)
         except (AttributeError, TypeError):
             # Slot-only engine facades still get the enforced processor; they
             # merely pay the one-token lookup again on their next request.
             pass
-    end_id, _vocab_size = boundary
+    start_id, end_id, _vocab_size = boundary
     chat_kwargs["reasoning_budget_logits_processor"] = ReasoningBudgetLogitsProcessor(
         end_id,
         getattr(openai_request, "reasoning_max_tokens", None),
+        think_start_id=start_id,
         seeded_thinking=True,
     )
 


### PR DESCRIPTION
## What changed

- Carry the validated DeepSeek `<think>` token id into the generation-time reasoning-budget processor.
- After the first `</think>` boundary, suppress only a later `<think>` token while leaving public text and tool-call logits unchanged.
- Cache and validate both reasoning boundary ids against the actual LM-head width.
- Add regressions for post-boundary reopen suppression and Responses wiring/cache behavior.

## Root cause

The medium Codex reasoning budget correctly forced `</think>`, but the processor became completely inert afterward. DeepSeek-V4-Flash-0731 could later sample `<think>` again after public output had begun. Codex cannot represent reasoning after public content and reconnected with `The model emitted reasoning after public content`.

This was reproduced twice in a real issue #1323 Codex soak at roughly 45K context after 25 read-only tool rounds. With this change, the same workload passed 47K context and 27 tool rounds without that reconnect. The task still exhibited model-level over-exploration, which is intentionally not addressed by this PR.

## Validation

- `ruff check` on changed files: passed
- Focused reasoning/Responses/parser/repetition suite: `362 passed`
- Scheduler logits-processor alignment checks: `2 passed`
- Full non-external-server suite: `15549 passed, 30 skipped, 18 deselected, 6 xfailed, 1 xpassed`
- Two external-server tests failed only because their hard-coded `127.0.0.1:8000` service was not running (`tests/test_event_loop.py`).

## Impact

Scoped to bounded reasoning requests that provide a validated `think_start_id`. Unlimited reasoning and processors without a start id preserve their existing behavior; ordinary public/tool logits are unchanged.
