### PR TITLE
fix(pflash): apply per-alias keep_ratio on the `python -m vllm_mlx.server` entrypoint

### DIFF
--- a/tests/test_pflash_server_module_wiring.py
+++ b/tests/test_pflash_server_module_wiring.py
@@ -1,0 +1,100 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Wiring guard for the legacy ``python -m vllm_mlx.server`` entrypoint.
+
+``tests/test_pflash_cli_wiring.py`` proves the ``serve``/``bench`` *commands*
+route PFlash resolution through :func:`vllm_mlx.pflash.resolve_pflash_config`.
+This file proves the THIRD serving entrypoint — ``vllm_mlx.server.main()`` —
+does the same, so the two paths cannot drift.
+
+Regression for #1458: ``server.main()`` used to resolve PFlash with
+``resolve_pflash_mode_default`` + ``config_from_args`` directly. That pair
+applies the tier-based *mode* default but NOT a per-alias ``pflash_keep_ratio``
+override, so a verified alias pinned at a non-default ratio (bonsai-27b-2bit
+@0.50, whose mid-prompt needle recall collapses to 1/5 at the 0.20 engine
+default) auto-enabled PFlash at the lossy 0.20 here while ``rapid-mlx serve``
+used 0.50. This asserts the EFFECTIVE config that reaches the scheduler, so a
+revert to the old two-call form (which would capture keep_ratio 0.20) fails.
+
+Fully offline: the resolver runs for real (``detect_model_config`` reads the
+bonsai alias profile from the local index); every I/O boundary the entrypoint
+hits before the PFlash step is mocked, and the ``validate_model_support`` hook —
+called immediately after ``resolve_pflash_config`` with the built config as its
+first positional arg — captures that config and short-circuits before any
+engine/uvicorn boot.
+"""
+
+from __future__ import annotations
+
+import sys
+from unittest import mock
+
+import pytest
+
+import vllm_mlx.cli as cli  # noqa: F401  (bind before patching)
+import vllm_mlx.server as server
+
+
+class _StopError(Exception):
+    """Short-circuit ``server.main()`` right after the PFlash step."""
+
+
+def _run_server_main_capturing_config(argv: list[str], *, lane=(False, False)):
+    """Drive the REAL ``server.main()`` and return the ``PFlashConfig`` it
+    resolved (captured at the ``validate_model_support`` call that immediately
+    follows ``resolve_pflash_config``). ``lane`` is the ``(is_mllm, auto_text)``
+    tuple the serving-lane resolver returns."""
+    captured: dict = {}
+
+    def _capture_validate(config, *, model_name, is_mllm=False):
+        captured["config"] = config
+        captured["model_name"] = model_name
+        captured["is_mllm"] = is_mllm
+        raise _StopError
+
+    with (
+        mock.patch.object(cli, "_port_preflight_or_die", lambda *a, **k: None),
+        mock.patch.object(server, "_ensure_routing_config", lambda *a, **k: None),
+        mock.patch.object(server, "resolve_serving_lane", lambda name, **kw: lane),
+        mock.patch(
+            "vllm_mlx.pflash.validate_model_support", _capture_validate
+        ),
+        mock.patch.object(sys, "argv", ["vllm_mlx.server", *argv]),
+        pytest.raises((_StopError, SystemExit)),
+    ):
+        server.main()
+    return captured
+
+
+def test_server_module_applies_per_alias_keep_ratio_override():
+    # bonsai-27b-2bit pins pflash_tier=verified + pflash_keep_ratio=0.50.
+    # Text lane (is_mllm False) → verified tier auto-enables PFlash "always".
+    captured = _run_server_main_capturing_config(["--model", "bonsai-27b-2bit"])
+    cfg = captured.get("config")
+    assert cfg is not None, "validate_model_support was never reached"
+    assert cfg.mode == "always"
+    # The whole point of #1458: the alias override reaches this entrypoint too.
+    # Old two-call wiring captured 0.20 here; the shared resolver yields 0.50.
+    assert cfg.keep_ratio == pytest.approx(0.5)
+    assert captured["is_mllm"] is False
+
+
+def test_server_module_explicit_keep_ratio_flag_still_wins():
+    captured = _run_server_main_capturing_config(
+        ["--model", "bonsai-27b-2bit", "--pflash-keep-ratio", "0.33"]
+    )
+    cfg = captured.get("config")
+    assert cfg is not None
+    assert cfg.keep_ratio == pytest.approx(0.33)
+
+
+def test_server_module_forwards_multimodal_lane_verdict():
+    # MLLM lane → server must forward is_multimodal=True so the verified-tier
+    # auto-ON is suppressed (PFlash cannot serve the MLLM lane). If server
+    # dropped the lane verdict, the verified alias would still resolve "always".
+    captured = _run_server_main_capturing_config(
+        ["--model", "bonsai-27b-2bit"], lane=(True, False)
+    )
+    cfg = captured.get("config")
+    assert cfg is not None
+    assert captured["is_mllm"] is True
+    assert cfg.mode == "off"

--- a/tests/test_pflash_server_module_wiring.py
+++ b/tests/test_pflash_server_module_wiring.py
@@ -25,6 +25,7 @@ engine/uvicorn boot.
 
 from __future__ import annotations
 
+import os
 import sys
 from unittest import mock
 
@@ -36,6 +37,47 @@ import vllm_mlx.server as server
 
 class _StopError(Exception):
     """Short-circuit ``server.main()`` right after the PFlash step."""
+
+
+# ``server.main()`` writes serving config into module-level globals (API key,
+# timeouts, sampling defaults, and — via alias auto-config — the tool-call /
+# reasoning parser names). Driving it here would leak that state into the shared
+# test process (e.g. a later ``/models`` route test seeing an auto-detected
+# ``tool_call_parser``), so snapshot and restore them around every test.
+_SERVER_GLOBALS = (
+    "_api_key",
+    "_default_timeout",
+    "_rate_limiter",
+    "_default_temperature",
+    "_default_top_p",
+    "_default_top_k",
+    "_enable_audio_lane",
+    "_enable_auto_tool_choice",
+    "_tool_call_parser",
+    "_enable_tool_logits_bias",
+    "_reasoning_parser",
+    "_reasoning_parser_name",
+)
+_MISSING = object()
+
+
+@pytest.fixture(autouse=True)
+def _restore_server_globals():
+    saved = {name: getattr(server, name, _MISSING) for name in _SERVER_GLOBALS}
+    mcp_saved = os.environ.get("RAPID_MLX_MCP_CONFIG", _MISSING)
+    try:
+        yield
+    finally:
+        for name, value in saved.items():
+            if value is _MISSING:
+                if hasattr(server, name):
+                    delattr(server, name)
+            else:
+                setattr(server, name, value)
+        if mcp_saved is _MISSING:
+            os.environ.pop("RAPID_MLX_MCP_CONFIG", None)
+        else:
+            os.environ["RAPID_MLX_MCP_CONFIG"] = mcp_saved
 
 
 def _run_server_main_capturing_config(argv: list[str], *, lane=(False, False)):
@@ -55,9 +97,7 @@ def _run_server_main_capturing_config(argv: list[str], *, lane=(False, False)):
         mock.patch.object(cli, "_port_preflight_or_die", lambda *a, **k: None),
         mock.patch.object(server, "_ensure_routing_config", lambda *a, **k: None),
         mock.patch.object(server, "resolve_serving_lane", lambda name, **kw: lane),
-        mock.patch(
-            "vllm_mlx.pflash.validate_model_support", _capture_validate
-        ),
+        mock.patch("vllm_mlx.pflash.validate_model_support", _capture_validate),
         mock.patch.object(sys, "argv", ["vllm_mlx.server", *argv]),
         pytest.raises((_StopError, SystemExit)),
     ):

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -2635,8 +2635,7 @@ Examples:
     # was silently dropped — same bug class as #400. The unified rapid-mlx
     # CLI builds a richer SchedulerConfig in cli.py; the standalone path only
     # exposes a small subset of flags, so we plumb just those.
-    from .pflash import config_from_args as _server_pflash_config_from_args
-    from .pflash import resolve_pflash_mode_default as _server_pflash_resolve_default
+    from .pflash import resolve_pflash_config as _server_pflash_resolve_config
     from .pflash import validate_model_support as _server_pflash_validate
     from .scheduler import SchedulerConfig
 
@@ -2666,11 +2665,20 @@ Examples:
         force_mllm=_srv_force_mllm,
         force_text=_srv_force_text,
     )
-    args.pflash = _server_pflash_resolve_default(
-        args, model_name=args.model, is_multimodal=_srv_is_mllm
-    )
+    # Resolve mode AND per-alias keep_ratio through the single shared helper —
+    # the same call ``cli.py`` uses for ``serve``/``bench``. Going through
+    # ``resolve_pflash_config`` (rather than ``resolve_pflash_mode_default`` +
+    # ``config_from_args`` directly) is what applies a per-alias
+    # ``pflash_keep_ratio`` override (#1458): a verified alias pinned at a
+    # non-default ratio (e.g. bonsai-27b-2bit @0.50, whose mid-prompt recall
+    # collapses to 1/5 at the 0.20 engine default) would otherwise auto-enable
+    # PFlash at the lossy 0.20 here while ``rapid-mlx serve`` used 0.50 — the
+    # two serving entrypoints must not drift. It mutates ``args.pflash`` and
+    # ``args.pflash_keep_ratio`` in place so later readers see resolved values.
     try:
-        server_pflash_config = _server_pflash_config_from_args(args)
+        server_pflash_config = _server_pflash_resolve_config(
+            args, model_name=args.model, is_multimodal=_srv_is_mllm
+        )
         _server_pflash_validate(
             server_pflash_config,
             model_name=args.model,


### PR DESCRIPTION
## Why

`python -m vllm_mlx.server` (the legacy standalone serving entrypoint) resolved PFlash with `resolve_pflash_mode_default` + `config_from_args` **directly**, instead of the shared `resolve_pflash_config` helper that `rapid-mlx serve`/`bench` route through (#1458).

That pair applies the tier-based **mode** default (`verified` alias → `always`) but **not** the per-alias `pflash_keep_ratio` override — only `resolve_pflash_keep_ratio_default` (called by `resolve_pflash_config`) does. `config_from_args` merely maps the CLI `None` sentinel to the `0.20` engine default.

Result: a verified alias pinned at a non-default ratio auto-enabled PFlash at the lossy `0.20` on this entrypoint while `rapid-mlx serve` used the pinned value. Today the only such alias is **bonsai-27b-2bit @0.50**, whose commit message (#1458) documents mid-prompt needle recall collapsing to **1/5 at 0.20 vs 5/5 at 0.50**. So `python -m vllm_mlx.server --model bonsai-27b-2bit` silently shipped the bad-recall ratio the override exists to prevent, and the two serving paths disagreed.

Scope: `-m vllm_mlx.server` only (the `rapid-mlx`/`rmlx` console entry goes through `cli.py` and was correct), and only verified aliases carrying a custom `pflash_keep_ratio`. No crash — a quality/correctness regression.

## What

- `vllm_mlx/server.py` `main()`: replace the `resolve_pflash_mode_default` + `config_from_args` pair with a single `resolve_pflash_config(args, model_name=args.model, is_multimodal=_srv_is_mllm)`, mirroring `cli.py`. Mode **and** keep_ratio now resolve identically on all three serving entrypoints. Explicit `--pflash-keep-ratio` still wins; the MLLM lane still suppresses the verified auto-ON.

## Tests

- New `tests/test_pflash_server_module_wiring.py` drives the real `server.main()` (offline; preamble I/O mocked) and captures the effective `PFlashConfig` at the `validate_model_support` hook that immediately follows resolution:
  - bonsai text lane → `mode="always"`, `keep_ratio=0.50` (**the regression guard**);
  - explicit `--pflash-keep-ratio 0.33` → honored;
  - MLLM lane → `is_multimodal=True` forwarded → verified auto-ON suppressed (`mode="off"`).
- Verified the key assertion **fails on the pre-fix wiring** (Obtained `0.2`, Expected `0.5`) and passes after — a revert to the two-call form re-fails it.
- `tests/test_pflash*.py` + `tests/test_aliases_contract.py`: 2723 passed. `ruff check` clean.

## Notes

Found during a post-v0.12.4 review sweep of landed PRs. Mirrors the existing `tests/test_pflash_cli_wiring.py` philosophy: a command that stops invoking the shared resolver must fail a wiring test.

🤖 AI-assisted: reproduced, root-caused, fixed, and tested with Claude Code (Opus 4.8). Human-reviewed before merge.