### PR TITLE
fix(anthropic): honor thinking controls on /v1/messages

### DIFF
--- a/tests/test_anthropic_adapter.py
+++ b/tests/test_anthropic_adapter.py
@@ -396,6 +396,46 @@ class TestAnthropicToOpenai:
         result = anthropic_to_openai(req)
         assert result.stream is True
 
+    @pytest.mark.parametrize(
+        ("kwargs", "expected"),
+        [
+            ({"enable_thinking": False}, False),
+            ({"chat_template_kwargs": {"enable_thinking": False}}, False),
+            ({"thinking": {"type": "disabled"}}, False),
+            (
+                {
+                    "enable_thinking": True,
+                    "chat_template_kwargs": {"enable_thinking": True},
+                    "thinking": {"type": "disabled"},
+                },
+                False,
+            ),
+            (
+                {
+                    "thinking": {"type": "enabled", "budget_tokens": 16},
+                },
+                True,
+            ),
+        ],
+    )
+    def test_thinking_controls_are_forwarded(self, kwargs, expected):
+        result = anthropic_to_openai(self._make_request(**kwargs))
+        ctk = result.chat_template_kwargs
+        actual = (
+            ctk.get("enable_thinking")
+            if isinstance(ctk, dict) and "enable_thinking" in ctk
+            else result.enable_thinking
+        )
+        assert actual is expected
+
+    def test_thinking_budget_still_forwards_with_enabled_type(self):
+        result = anthropic_to_openai(
+            self._make_request(
+                thinking={"type": "enabled", "budget_tokens": 16},
+            )
+        )
+        assert result.reasoning_max_tokens == 16
+
     def test_tools_conversion(self):
         req = self._make_request(
             tools=[

--- a/tests/test_anthropic_output_config.py
+++ b/tests/test_anthropic_output_config.py
@@ -251,9 +251,9 @@ class TestAnthropicToOpenaiOutputConfig:
         """Pick 1 has now landed. ``effort`` is translated through
         ``ANTHROPIC_EFFORT_TO_REASONING_MAX_TOKENS`` into a per-request
         ``reasoning_max_tokens`` on the OpenAI side. Every other OpenAI
-        field stays identical to the baseline request — only
-        ``reasoning_max_tokens`` changes, so the cap path is the single
-        wire effect.
+        field stays identical to the baseline request except for the
+        explicit thinking enablement that prevents shared default-off
+        policies from erasing the caller's reasoning intent.
 
         See ``tests/test_per_request_thinking_budget.py`` for the full
         effort-mapping test matrix; this case pins coexistence with
@@ -267,10 +267,11 @@ class TestAnthropicToOpenaiOutputConfig:
         # ``high`` → 8192 per the canonical Anthropic mapping.
         assert baseline.reasoning_max_tokens is None
         assert with_effort.reasoning_max_tokens == 8192
-        # Everything else must be identical so Pick 1 doesn't sneak in
-        # a side effect on the OpenAI surface.
-        baseline_dump = baseline.model_dump(exclude={"reasoning_max_tokens"})
-        with_effort_dump = with_effort.model_dump(exclude={"reasoning_max_tokens"})
+        assert with_effort.chat_template_kwargs == {"enable_thinking": True}
+        # Everything else must remain identical.
+        excluded = {"reasoning_max_tokens", "chat_template_kwargs"}
+        baseline_dump = baseline.model_dump(exclude=excluded)
+        with_effort_dump = with_effort.model_dump(exclude=excluded)
         assert baseline_dump == with_effort_dump
 
     def test_unsupported_format_raises(self):

--- a/tests/test_anthropic_route_streaming.py
+++ b/tests/test_anthropic_route_streaming.py
@@ -47,6 +47,19 @@ def _make_client(engine: _StreamingEngine) -> TestClient:
     return TestClient(app)
 
 
+def _make_reasoning_client(engine: _StreamingEngine) -> TestClient:
+    cfg = reset_config()
+    cfg.engine = engine
+    cfg.model_name = "test-model"
+    cfg.no_thinking = False
+    cfg.reasoning_parser_name = "qwen3"
+    cfg.model_registry = None
+
+    app = FastAPI()
+    app.include_router(router)
+    return TestClient(app)
+
+
 def _parse_sse_data(response_text: str) -> list[dict]:
     events = []
     for raw_event in response_text.split("\n\n"):
@@ -79,7 +92,7 @@ def test_anthropic_stream_route_no_thinking_template_answers_as_text():
         "/v1/messages",
         json={
             "model": "test-model",
-            "max_tokens": 32,
+            "max_tokens": 2048,
             "stream": True,
             "messages": [{"role": "user", "content": "answer directly"}],
         },
@@ -182,9 +195,102 @@ def test_anthropic_stream_route_reasoning_parser_with_no_thinking_answers_as_tex
     assert thinking_deltas == []
 
 
-def test_anthropic_stream_route_reasoning_parser_with_thinking_default_still_works():
-    """Inverse guard: when enable_thinking is NOT explicitly False (i.e.
-    default thinking-on for a reasoning model), the reasoning parser
+@pytest.mark.parametrize(
+    "request_extension",
+    [
+        {},
+        {"enable_thinking": False},
+        {"chat_template_kwargs": {"enable_thinking": False}},
+        {"thinking": {"type": "disabled"}},
+    ],
+    ids=["casual-default", "top-level", "template-kwargs", "native"],
+)
+def test_anthropic_stream_route_disables_thinking(request_extension):
+    """Every supported opt-out reaches the engine, including shared defaults."""
+    engine = _StreamingEngine(["Direct answer"])
+    client = _make_reasoning_client(engine)
+    payload = {
+        "model": "test-model",
+        "max_tokens": 32,
+        "stream": True,
+        "messages": [{"role": "user", "content": "answer directly"}],
+    }
+    payload.update(request_extension)
+
+    response = client.post("/v1/messages", json=payload)
+
+    assert response.status_code == 200, response.text
+    assert engine.calls[0]["kwargs"]["enable_thinking"] is False
+    events = _parse_sse_data(response.text)
+    assert not any(
+        event.get("delta", {}).get("type") == "thinking_delta" for event in events
+    )
+
+
+def test_anthropic_stream_route_tools_default_disables_thinking(monkeypatch):
+    """The tools policy reaches the engine independently of casual-chat logic."""
+    monkeypatch.setattr(
+        "vllm_mlx.routes.anthropic.maybe_auto_disable_thinking_for_casual_chat",
+        lambda request: False,
+    )
+    engine = _StreamingEngine(["Direct answer"])
+    client = _make_reasoning_client(engine)
+
+    response = client.post(
+        "/v1/messages",
+        json={
+            "model": "test-model",
+            "max_tokens": 32,
+            "stream": True,
+            "messages": [
+                {
+                    "role": "user",
+                    "content": "Inspect the scheduler and correlate cache misses.",
+                }
+            ],
+            "tools": [
+                {
+                    "name": "lookup",
+                    "description": "Look something up",
+                    "input_schema": {"type": "object"},
+                }
+            ],
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    assert engine.calls[0]["kwargs"]["enable_thinking"] is False
+
+
+@pytest.mark.parametrize("with_tools", [False, True], ids=["casual", "tools"])
+def test_anthropic_stream_route_effort_preserves_thinking_intent(with_tools):
+    """Anthropic output_config.effort must override both auto-disable policies."""
+    engine = _StreamingEngine(["<think>scratch</think>", "answer"])
+    client = _make_reasoning_client(engine)
+    payload = {
+        "model": "test-model",
+        "max_tokens": 2048,
+        "stream": True,
+        "output_config": {"effort": "low"},
+        "messages": [{"role": "user", "content": "answer directly"}],
+    }
+    if with_tools:
+        payload["tools"] = [
+            {
+                "name": "lookup",
+                "description": "Look something up",
+                "input_schema": {"type": "object"},
+            }
+        ]
+
+    response = client.post("/v1/messages", json=payload)
+
+    assert response.status_code == 200, response.text
+    assert engine.calls[0]["kwargs"]["enable_thinking"] is True
+
+
+def test_anthropic_stream_route_reasoning_parser_with_explicit_thinking_still_works():
+    """Inverse guard: when thinking is explicitly enabled, the reasoning parser
     must still be exercised so the existing #185 fix isn't regressed.
     The model emits a <think>…</think> block followed by the answer;
     the parser splits them, and the route emits thinking_delta then
@@ -211,13 +317,13 @@ def test_anthropic_stream_route_reasoning_parser_with_thinking_default_still_wor
             "model": "test-model",
             "max_tokens": 32,
             "stream": True,
+            "thinking": {"type": "enabled", "budget_tokens": 16},
             "messages": [{"role": "user", "content": "what is 6*7"}],
         },
     )
 
     assert response.status_code == 200
-    # No enable_thinking override on the request → kwargs absent or None.
-    assert engine.calls[0]["kwargs"].get("enable_thinking") is not False
+    assert engine.calls[0]["kwargs"].get("enable_thinking") is True
 
     events = _parse_sse_data(response.text)
 

--- a/tests/test_anthropic_stream_finalize.py
+++ b/tests/test_anthropic_stream_finalize.py
@@ -340,6 +340,7 @@ def test_c08_vibethinker_preamble_length_truncation_no_duplicate_emit():
             "model": "test-model",
             "max_tokens": 4,
             "stream": True,
+            "enable_thinking": True,
             "messages": [{"role": "user", "content": "ignored"}],
         },
     )
@@ -410,6 +411,7 @@ def test_c08_implicit_think_length_truncation_no_duplicate_emit():
             "model": "test-model",
             "max_tokens": 8,
             "stream": True,
+            "enable_thinking": True,
             "messages": [{"role": "user", "content": "count 1 2"}],
         },
     )
@@ -475,6 +477,7 @@ def test_c08_special_tokens_in_thinking_dont_break_duplicate_detection():
             "model": "test-model",
             "max_tokens": 3,
             "stream": True,
+            "enable_thinking": True,
             "messages": [{"role": "user", "content": "hi"}],
         },
     )
@@ -524,6 +527,7 @@ def test_c08_no_phantom_text_block_on_thinking_max_tokens_truncation():
             "model": "test-model",
             "max_tokens": 3,
             "stream": True,
+            "enable_thinking": True,
             "messages": [{"role": "user", "content": "Recite A B C..."}],
         },
     )

--- a/tests/test_anthropic_thinking_controls.py
+++ b/tests/test_anthropic_thinking_controls.py
@@ -1,0 +1,135 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression coverage for /v1/messages thinking-control parity."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from vllm_mlx.api.anthropic_adapter import anthropic_to_openai
+from vllm_mlx.api.anthropic_models import (
+    AnthropicMessage,
+    AnthropicRequest,
+    AnthropicToolDef,
+)
+from vllm_mlx.routes.anthropic import _apply_anthropic_thinking_defaults
+from vllm_mlx.service.helpers import _extract_thinking_from_request
+
+
+def _request(**kwargs) -> AnthropicRequest:
+    payload = {
+        "model": "default",
+        "messages": [AnthropicMessage(role="user", content="Say hi")],
+        "max_tokens": 800,
+    }
+    payload.update(kwargs)
+    return AnthropicRequest(**payload)
+
+
+def test_omitted_thinking_uses_casual_chat_default_off(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "vllm_mlx.service.helpers.get_config",
+        lambda: SimpleNamespace(reasoning_parser_name="qwen3", no_thinking=False),
+    )
+    converted = anthropic_to_openai(_request())
+    assert _extract_thinking_from_request(converted) is None
+
+    _apply_anthropic_thinking_defaults(converted)
+
+    assert _extract_thinking_from_request(converted) is False
+
+
+def test_tools_use_shared_default_off(monkeypatch) -> None:
+    # Isolate the tools policy: this must keep passing even if the independent
+    # casual-chat default is disabled or removed.
+    monkeypatch.setattr(
+        "vllm_mlx.routes.anthropic.maybe_auto_disable_thinking_for_casual_chat",
+        lambda request: False,
+    )
+    converted = anthropic_to_openai(
+        _request(
+            tools=[
+                AnthropicToolDef(
+                    name="lookup",
+                    description="Look something up",
+                    input_schema={"type": "object"},
+                )
+            ]
+        )
+    )
+
+    _apply_anthropic_thinking_defaults(converted)
+
+    assert _extract_thinking_from_request(converted) is False
+
+
+@pytest.mark.parametrize("explicit", [True, False])
+def test_tools_preserve_explicit_extension_preference(explicit: bool) -> None:
+    converted = anthropic_to_openai(
+        _request(
+            enable_thinking=explicit,
+            tools=[
+                AnthropicToolDef(
+                    name="lookup",
+                    description="Look something up",
+                    input_schema={"type": "object"},
+                )
+            ],
+        )
+    )
+
+    _apply_anthropic_thinking_defaults(converted)
+
+    assert _extract_thinking_from_request(converted) is explicit
+
+
+def test_native_enabled_budget_preserves_reasoning_intent() -> None:
+    converted = anthropic_to_openai(
+        _request(thinking={"type": "enabled", "budget_tokens": 16})
+    )
+
+    _apply_anthropic_thinking_defaults(converted)
+
+    assert _extract_thinking_from_request(converted) is True
+    assert converted.reasoning_max_tokens == 16
+
+
+def test_legacy_budget_only_shape_preserves_reasoning_intent() -> None:
+    converted = anthropic_to_openai(_request(thinking={"budget_tokens": 16}))
+
+    _apply_anthropic_thinking_defaults(converted)
+
+    assert _extract_thinking_from_request(converted) is True
+    assert converted.reasoning_max_tokens == 16
+
+
+def test_native_adaptive_thinking_is_accepted_and_enabled() -> None:
+    converted = anthropic_to_openai(_request(thinking={"type": "adaptive"}))
+
+    _apply_anthropic_thinking_defaults(converted)
+
+    assert _extract_thinking_from_request(converted) is True
+
+
+def test_output_effort_wins_over_legacy_disabled_thinking() -> None:
+    converted = anthropic_to_openai(
+        _request(
+            output_config={"effort": "low"},
+            thinking={"type": "disabled"},
+        )
+    )
+
+    _apply_anthropic_thinking_defaults(converted)
+
+    assert _extract_thinking_from_request(converted) is True
+    assert converted.reasoning_max_tokens == 512
+
+
+@pytest.mark.parametrize("thinking_type", ["disabled", "adaptive"])
+def test_non_fixed_thinking_modes_ignore_legacy_budget(thinking_type) -> None:
+    converted = anthropic_to_openai(
+        _request(thinking={"type": thinking_type, "budget_tokens": 16})
+    )
+
+    assert converted.reasoning_max_tokens is None

--- a/vllm_mlx/api/anthropic_adapter.py
+++ b/vllm_mlx/api/anthropic_adapter.py
@@ -198,6 +198,34 @@ def anthropic_to_openai(request: AnthropicRequest) -> ChatCompletionRequest:
     # ``AnthropicOutputConfigError``; the route converts that to HTTP 400.
     response_format = _convert_output_config(request.output_config)
 
+    # Preserve the same thinking controls accepted by the OpenAI-compatible
+    # routes. Anthropic's native controls are authoritative over compatibility
+    # extensions; the newer ``output_config.effort`` in turn wins over legacy
+    # ``thinking.type`` when both are supplied. Put the translated value in
+    # chat_template_kwargs, the highest-precedence per-request source used by
+    # service.helpers._resolve_enable_thinking.
+    chat_template_kwargs = dict(request.chat_template_kwargs or {})
+    has_output_effort = (
+        request.output_config is not None and request.output_config.effort is not None
+    )
+    if has_output_effort:
+        chat_template_kwargs["enable_thinking"] = True
+    if isinstance(request.thinking, dict) and not has_output_effort:
+        thinking_type = request.thinking.get("type")
+        if thinking_type == "disabled":
+            chat_template_kwargs["enable_thinking"] = False
+        elif thinking_type in ("enabled", "adaptive"):
+            chat_template_kwargs["enable_thinking"] = True
+        elif (
+            thinking_type is None
+            and isinstance(request.thinking.get("budget_tokens"), int)
+            and not isinstance(request.thinking.get("budget_tokens"), bool)
+            and request.thinking["budget_tokens"] >= 1
+        ):
+            # Preserve the pre-type Anthropic extension: a positive budget is
+            # itself an explicit request to think, not merely a cap.
+            chat_template_kwargs["enable_thinking"] = True
+
     return ChatCompletionRequest(
         model=request.model,
         messages=messages,
@@ -215,6 +243,8 @@ def anthropic_to_openai(request: AnthropicRequest) -> ChatCompletionRequest:
         tools=tools,
         tool_choice=tool_choice,
         response_format=response_format,
+        enable_thinking=request.enable_thinking,
+        chat_template_kwargs=chat_template_kwargs or None,
         # Pick 1 (this PR) — upstream vLLM PR #20859 + #42396 backport.
         # Translates ``output_config.effort`` (or legacy
         # ``thinking.budget_tokens``) into a per-request reasoning cap
@@ -245,8 +275,14 @@ def _resolve_reasoning_max_tokens(request: AnthropicRequest) -> int | None:
             request.output_config.effort
         )
     if isinstance(request.thinking, dict):
+        thinking_type = request.thinking.get("type")
         budget = request.thinking.get("budget_tokens")
-        if isinstance(budget, int) and budget >= 1:
+        if (
+            thinking_type not in ("disabled", "adaptive")
+            and isinstance(budget, int)
+            and not isinstance(budget, bool)
+            and budget >= 1
+        ):
             return budget
     return None
 

--- a/vllm_mlx/api/anthropic_models.py
+++ b/vllm_mlx/api/anthropic_models.py
@@ -399,9 +399,14 @@ class AnthropicRequest(BaseModel):
     # the pre-existing free-form-text + no-cap path so existing SDK
     # callers see no behavior change.
     output_config: AnthropicOutputConfig | None = None
-    # Legacy Anthropic ``thinking`` field (v0.20+) — mirrors the same
-    # idea but as a ``{"type": "enabled", "budget_tokens": N}`` shape.
-    # The adapter consults ``thinking.budget_tokens`` only when
+    # Rapid-MLX compatibility controls accepted by the OpenAI surfaces too.
+    # Declaring them here is load-bearing: Pydantic otherwise drops these
+    # extension fields before the Anthropic adapter can preserve them.
+    enable_thinking: bool | None = None
+    chat_template_kwargs: dict | None = None
+    # Native Anthropic ``thinking`` field (v0.20+) — mirrors the same
+    # idea as a ``{"type": "enabled", "budget_tokens": N}`` shape.
+    # The adapter translates both ``type`` and ``budget_tokens`` when
     # ``output_config.effort`` is unset (newer surface wins).
     thinking: dict | None = None
 

--- a/vllm_mlx/routes/anthropic.py
+++ b/vllm_mlx/routes/anthropic.py
@@ -63,7 +63,15 @@ from ..service.helpers import (
     count_prompt_tokens,
     enforce_context_length_for_messages,
     get_engine,
+    maybe_auto_disable_thinking_for_casual_chat,
+    maybe_auto_disable_thinking_for_tools,
 )
+
+
+def _apply_anthropic_thinking_defaults(openai_request: ChatCompletionRequest) -> None:
+    """Apply the shared chat/responses thinking defaults after adaptation."""
+    maybe_auto_disable_thinking_for_tools(openai_request)
+    maybe_auto_disable_thinking_for_casual_chat(openai_request)
 
 
 def _resolved_sampling_kwargs(openai_request) -> dict:
@@ -668,6 +676,7 @@ async def create_anthropic_message(
             openai_request = anthropic_to_openai(anthropic_request)
         except AnthropicOutputConfigError as e:
             raise HTTPException(status_code=400, detail=str(e))
+        _apply_anthropic_thinking_defaults(openai_request)
 
         # D-ANTHRO-TOOL-USAGE F3 (codex r3 BLOCKING #1+#2): suffix
         # injection MUST happen BEFORE the context-length DoS gate and
@@ -1266,6 +1275,7 @@ async def count_anthropic_tokens(request: Request):
         openai_request = anthropic_to_openai(anthropic_request)
     except AnthropicOutputConfigError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
+    _apply_anthropic_thinking_defaults(openai_request)
     # Codex r2 BLOCKING #2: ``preserve_native_tool_format`` is an
     # optional attribute on the engine contract — guard with
     # ``getattr`` so test stubs without it (or any future engine


### PR DESCRIPTION
## Summary

- preserve `enable_thinking` and `chat_template_kwargs` through the Anthropic request model and adapter
- translate native `thinking.type` (`enabled` / `disabled`) into the same per-request thinking control used by OpenAI-compatible routes
- apply the shared tools/casual-chat auto-disable policy to both `/v1/messages` generation and token counting
- add route-level regression coverage for all supported opt-outs and explicit-thinking inverse behavior

## Why

`/v1/messages` silently dropped Rapid-MLX thinking extensions and ignored native `thinking.type`, so Claude Code users could not turn thinking off. Requests with tools also skipped the shared auto-disable behavior, often consuming the output budget before emitting a tool call.

## Validation

- `430 passed` focused Anthropic/thinking suite
- full pytest body: `15588 passed`; 12 server-dependent tests failed only because no service was running at `127.0.0.1:8000`
- Ruff check and format clean
