### PR TITLE
fix(status): report "idle" when no requests are in flight

### DIFF
--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -399,6 +399,43 @@ class TestHealthRoutes:
         finally:
             self._restore_config(orig)
 
+    def test_status_is_idle_when_no_requests_in_flight(self, mock_engine):
+        """`status` must reflect ACTIVE generation, not engine liveness.
+
+        Regression: the field used to key off ``stats["running"]`` — the
+        engine-loop lifecycle flag, True for the whole server lifetime — so a
+        live but idle server (running=True, num_running=0) wrongly reported
+        "generating" alongside num_running=0. Drive it off the in-flight count.
+        """
+        # A running engine with nothing in flight → idle (fails pre-fix).
+        mock_engine.get_stats.return_value = {
+            **mock_engine.get_stats.return_value,
+            "running": True,
+            "num_running": 0,
+            "num_waiting": 0,
+        }
+        orig = self._patch_config(engine=mock_engine, model_name="test-model")
+        try:
+            data = TestClient(self._make_app()).get("/v1/status").json()
+            assert data["status"] == "idle"
+            assert data["num_running"] == 0
+        finally:
+            self._restore_config(orig)
+
+        # Active requests → generating.
+        mock_engine.get_stats.return_value = {
+            **mock_engine.get_stats.return_value,
+            "running": True,
+            "num_running": 2,
+        }
+        orig = self._patch_config(engine=mock_engine, model_name="test-model")
+        try:
+            data = TestClient(self._make_app()).get("/v1/status").json()
+            assert data["status"] == "generating"
+            assert data["num_running"] == 2
+        finally:
+            self._restore_config(orig)
+
     def test_status_exposes_batch_generator_throughput(self, mock_engine):
         """Status surfaces generation_tps/prompt_tps from batch_generator stats.
 

--- a/vllm_mlx/routes/health.py
+++ b/vllm_mlx/routes/health.py
@@ -282,7 +282,14 @@ async def status():
         return 0.0 if v is None else v
 
     return {
-        "status": "generating" if stats.get("running") else "idle",
+        # "generating" must reflect ACTIVE token generation, not engine
+        # liveness. ``stats["running"]`` is the engine-loop lifecycle flag
+        # (True for the whole server lifetime), so keying off it reported
+        # "generating" on a fully idle server (with num_running=0 right below
+        # it — self-contradictory). Drive it off the in-flight request count
+        # from the scheduler instead; ``num_waiting`` is surfaced separately
+        # for queue depth.
+        "status": "generating" if stats.get("num_running") else "idle",
         "model": cfg.model_name,
         "uptime_s": round(stats.get("uptime_seconds", 0), 1),
         "steps_executed": stats.get("steps_executed", 0),


### PR DESCRIPTION
## Why

`/v1/status` computed `status` as `"generating" if stats.get("running") else "idle"`. But `stats["running"]` is the **engine-loop lifecycle flag** (`engine_core.py`: set `True` in `start()`, `False` only in `stop()`), i.e. `True` for essentially the entire server lifetime — not a signal that any request is currently generating tokens.

Result on an idle-but-live server: the response reported `status="generating"` while `num_running=0` in the very same payload — self-contradictory, and it makes any "is the server busy?" consumer (e.g. the desktop app's status indicator) read as permanently generating.

Found during a post-v0.12.4 review sweep.

## What

- `vllm_mlx/routes/health.py`: drive `status` off `stats.get("num_running")` (the in-flight count from `scheduler.get_stats()`, already surfaced in the same response) instead of the lifecycle flag. `num_waiting` stays exposed separately, so a queued-but-unscheduled request reads as `idle` with a non-zero wait count rather than as `generating` (which specifically means *tokens are being generated*).

## Tests

- New `TestHealthRoutes::test_status_is_idle_when_no_requests_in_flight`: a running engine with `num_running=0` → `"idle"`; `num_running=2` → `"generating"`. **Verified it fails on the pre-fix wiring** (`- idle / + generating`) and passes after.
- `TestHealthRoutes` (38 tests) green; `ruff` clean.

## Notes

The shared `mock_engine` fixture historically used the unrealistic combo `running=False, num_running=0` (which is why the original idle assertion passed despite the bug); the new test overrides `running=True` to reflect production, without disturbing the shared fixture.

🤖 AI-assisted: reproduced, root-caused, fixed, and tested with Claude Code (Opus 4.8). Human-reviewed before merge.