### PR TITLE
fix(anthropic): drop the blank text block streamed between thinking and tool_use

### DIFF
--- a/tests/test_anthropic_route_streaming.py
+++ b/tests/test_anthropic_route_streaming.py
@@ -438,3 +438,83 @@ def test_anthropic_stream_omits_cache_fields_without_hit():
     assert usage["input_tokens"] == 100
     assert "cache_read_input_tokens" not in usage
     assert "cache_creation_input_tokens" not in usage
+
+
+class _ThinkThenToolEngine:
+    """Streams reasoning, then the template's ``</think>`` → ``<tool_call>``
+    separator ("\n\n") as a standalone delta, then a hermes tool call — the
+    exact shape that used to open a blank text block between the thinking and
+    tool_use blocks."""
+
+    preserve_native_tool_format = False
+    tokenizer = _ThinkingTemplateTokenizer()
+    _tokenizer = None
+
+    async def stream_chat(self, messages, **kwargs):
+        deltas = [
+            "<think>Let me check ",
+            "the weather.</think>",
+            "\n\n",
+            '<tool_call>\n{"name": "get_weather", ',
+            '"arguments": {"city": "SF"}}\n</tool_call>',
+        ]
+        for i, text in enumerate(deltas, start=1):
+            yield SimpleNamespace(new_text=text, prompt_tokens=14, completion_tokens=i)
+
+
+def test_anthropic_stream_no_blank_text_block_between_thinking_and_tool_use():
+    """Regression: the whitespace-only ``</think>``→``<tool_call>`` separator
+    must NOT stream as its own ``text`` content block. Streaming should match
+    non-stream ([thinking, tool_use]); previously it emitted
+    [thinking, text("\\n\\n"), tool_use]."""
+    from vllm_mlx.reasoning import get_parser
+
+    cfg = reset_config()
+    cfg.engine = _ThinkThenToolEngine()
+    cfg.model_name = "test-model"
+    cfg.no_thinking = False
+    cfg.reasoning_parser_name = "qwen3"
+    cfg.reasoning_parser = get_parser("qwen3")()
+    cfg.tool_call_parser = "hermes"
+    cfg.enable_auto_tool_choice = True
+    cfg.model_registry = None
+
+    app = FastAPI()
+    app.include_router(router)
+    client = TestClient(app)
+
+    response = client.post(
+        "/v1/messages",
+        json={
+            "model": "test-model",
+            "max_tokens": 256,
+            "stream": True,
+            "messages": [{"role": "user", "content": "weather in SF?"}],
+            "tools": [
+                {
+                    "name": "get_weather",
+                    "description": "get weather",
+                    "input_schema": {
+                        "type": "object",
+                        "properties": {"city": {"type": "string"}},
+                    },
+                }
+            ],
+        },
+    )
+    assert response.status_code == 200
+
+    events = _parse_sse_data(response.text)
+    block_types = [
+        e["content_block"]["type"]
+        for e in events
+        if e.get("type") == "content_block_start"
+    ]
+    text_deltas = [
+        e["delta"].get("text", "")
+        for e in events
+        if e.get("type") == "content_block_delta"
+        and e["delta"].get("type") == "text_delta"
+    ]
+    assert block_types == ["thinking", "tool_use"]
+    assert text_deltas == []

--- a/vllm_mlx/routes/anthropic.py
+++ b/vllm_mlx/routes/anthropic.py
@@ -1712,6 +1712,19 @@ async def _stream_anthropic_messages(
                     out.append(("text", text))
                     effective = "text"
             else:
+                if block_type == "text" and not text.strip() and effective != "text":
+                    # Whitespace-only TEXT piece that would OPEN a new text
+                    # block (none currently open — effective is None or
+                    # "thinking"). Drop it, mirroring the thinking arm above
+                    # and the non-stream ``.strip()`` parity: the tool filter
+                    # surfaces the ``</think>`` → ``<tool_call>`` template
+                    # separator ("\n\n") as a standalone text piece, which
+                    # otherwise streams as ``[thinking, text(""), tool_use]``
+                    # while non-stream (which strips whole-output whitespace)
+                    # yields ``[thinking, tool_use]``. Whitespace INSIDE an
+                    # already-open text block (effective == "text") is kept —
+                    # that is genuine intra-text spacing, not a blank opener.
+                    continue
                 out.append((block_type, text))
                 # ``block_type`` is already not "thinking" in this
                 # branch — track the effective open block as that type.


### PR DESCRIPTION
## Why

On the streaming Messages API (`/v1/messages`), a request that produced reasoning followed by a tool call streamed **three** content blocks:

```
[thinking, text("\n\n"), tool_use]
```

while the **non-streaming** path for the same model output produced:

```
[thinking, tool_use]
```

The `"\n\n"` is the chat template's `</think>` → `<tool_call>` separator. The tool filter surfaces it as a standalone `text` piece, and `_gate_thinking_pieces` passed non-thinking pieces through unconditionally — so streaming opened a whitespace-only `text` content block. Non-stream suppresses it because `clean_output_text` strips whole-output whitespace and the adapter gates on `if sanitized_text`.

The real Anthropic API never emits a blank text block, so our streamed output isn't replayable against the official endpoint (our own client tolerates it) — a wire-fidelity/parity gap. Found during a post-v0.12.4 review sweep.

## What

- `vllm_mlx/routes/anthropic.py` `_gate_thinking_pieces`: extend the existing **state-aware** whitespace guard (already applied to `thinking` pieces) symmetrically to `text` pieces — drop a whitespace-only text piece that would **open** a new text block (`effective != "text"`), matching the non-stream `.strip()` contract. Whitespace **inside** an already-open text block (`effective == "text"`) is kept, so genuine intra-text spacing and real leading-content responses are unaffected.

## Tests

- New `test_anthropic_stream_no_blank_text_block_between_thinking_and_tool_use`: streams a reasoning + hermes tool call carrying the `"\n\n"` separator; asserts block types `[thinking, tool_use]` and no text delta. **Verified it fails on the pre-fix code** (`index 1: 'text' != 'tool_use'`).
- Empirically confirmed the before/after wire shape: streaming `['thinking','text','tool_use']` + `text_deltas ['\n\n']` → `['thinking','tool_use']` + `[]`, now matching non-stream.
- The 25 existing anthropic streaming/finalize tests stay green; `ruff` clean.

## Notes

Deliberately minimal: only the block-**opening** whitespace case is dropped (the reported bug), the same case non-stream already elides. Trailing-whitespace-before-close is not trimmed, to avoid swallowing meaningful mid-stream whitespace without lookahead.

🤖 AI-assisted: reproduced, root-caused, fixed, and tested with Claude Code (Opus 4.8). Human-reviewed before merge.