### PR TITLE
fix(rapid-mac): stop leaking the bearer in cleartext in the connect-tools snippets

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/UI/ConnectToolsView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ConnectToolsView.swift
@@ -42,8 +42,21 @@ struct ConnectToolsView: View {
     /// in that state anyway, so this text is read, never pasted.
     private var snippetModel: String { resolvedModel ?? "<start a model first>" }
 
-    /// Same contract as ``snippetModel`` for the API key slot.
+    /// The REAL key, for the clipboard only (``ConnectTool.snippet``). Never
+    /// painted on screen — see ``snippetKeyMasked``.
     private var snippetKey: String { bearer.isEmpty ? "<starts with your server>" : bearer }
+
+    /// Masked key for the always-visible snippet (``ConnectTool.displaySnippet``).
+    /// The API-key ``CopyableRow`` above masks the bearer behind an eye toggle,
+    /// but the config snippets rendered right below it interpolated the raw key
+    /// in cleartext — so a screenshot of this page (the Launch "connect your
+    /// tools" surface users naturally share) leaked the bearer despite the dots
+    /// above. Render dots here; the real key still reaches the clipboard on Copy
+    /// and stays revealable via the API-key row's eye. Mirrors ``CopyableRow``'s
+    /// masking (bullets, length-capped so the key length isn't leaked either).
+    private var snippetKeyMasked: String {
+        bearer.isEmpty ? "<starts with your server>" : String(repeating: "•", count: min(bearer.count, 16))
+    }
 
     /// A config is only complete once the server is actually listening
     /// (so the port is real) AND it has minted a bearer AND a model is
@@ -212,6 +225,11 @@ struct ConnectToolsView: View {
                 Base URL: \(openAIBaseURL)
                 API key:  \(snippetKey)
                 Model:    \(snippetModel)
+                """,
+                displaySnippet: """
+                Base URL: \(openAIBaseURL)
+                API key:  \(snippetKeyMasked)
+                Model:    \(snippetModel)
                 """
             ),
             ConnectTool(
@@ -223,6 +241,11 @@ struct ConnectToolsView: View {
                 export ANTHROPIC_BASE_URL=\(anthropicBaseURL)
                 export ANTHROPIC_API_KEY=\(snippetKey)
                 export ANTHROPIC_MODEL=\(snippetModel)
+                """,
+                displaySnippet: """
+                export ANTHROPIC_BASE_URL=\(anthropicBaseURL)
+                export ANTHROPIC_API_KEY=\(snippetKeyMasked)
+                export ANTHROPIC_MODEL=\(snippetModel)
                 """
             ),
             ConnectTool(
@@ -233,6 +256,10 @@ struct ConnectToolsView: View {
                 snippet: """
                 export OPENAI_BASE_URL=\(openAIBaseURL)
                 export OPENAI_API_KEY=\(snippetKey)
+                """,
+                displaySnippet: """
+                export OPENAI_BASE_URL=\(openAIBaseURL)
+                export OPENAI_API_KEY=\(snippetKeyMasked)
                 """
             ),
         ]
@@ -276,7 +303,12 @@ private struct ConnectTool: Identifiable {
     let name: String
     let symbol: String
     let blurb: String
+    /// The config with the REAL key — placed on the clipboard by Copy, never
+    /// rendered on screen.
     let snippet: String
+    /// The same config with the key masked — the ONLY form painted on screen,
+    /// so a screenshot can't leak the bearer.
+    let displaySnippet: String
 }
 
 /// One tool row: icon, name, description, a Copy action, and the
@@ -363,7 +395,10 @@ private struct ConnectToolRow: View {
                     .frame(maxWidth: 420, alignment: .leading)
                     .padding(.top, RapidTheme.Space.sm)
 
-                Text(tool.snippet)
+                // Masked form only — the real key never touches the screen, so
+                // a screenshot of this page can't leak the bearer. Copy still
+                // puts the real key (``tool.snippet``) on the clipboard.
+                Text(tool.displaySnippet)
                     .font(RapidFont.code)
                     .foregroundStyle(.secondary)
                     .lineSpacing(3)


### PR DESCRIPTION
## Why

The "connect your tools" page (`ConnectToolsView`, the Launch surface — a page users naturally screenshot to share their setup) masks the API key in the `CopyableRow` (dots + an eye toggle), but then interpolated the **raw bearer in cleartext** into the Cursor / Claude Code / Codex config snippets rendered right below it:

- `snippetKey` returned the raw `bearer` unredacted.
- It was interpolated into each tool's `snippet` (`API key: <bearer>`, `export ANTHROPIC_API_KEY=<bearer>`, ...).
- The snippet `Text(tool.snippet)` is **always painted on screen** (not clipboard-only), so the masking on the row above was nullified — a screenshot of the page leaks the key.

Found during a post-v0.12.4 review sweep.

## What

- Split `ConnectTool` into two forms: `snippet` (real key — clipboard only, via Copy) and `displaySnippet` (key masked with bullets, length-capped like `CopyableRow` so the key length isn't leaked either).
- Render only `displaySnippet` in the always-visible code block. `copy()` still puts the real `snippet` on the clipboard, and the key remains revealable via the API-key row's existing eye toggle.

Net: the workflow is unchanged (Copy pastes a working config; reveal-on-demand still available), but the real bearer never touches the screen, so a screenshot of this page can't leak it.

## Tests

- `swift build` clean (4.6s). RapidTests are not wired into the SPM `testTarget` (documented in `Package.swift`), so there is no unit-test seam here; this is a static rendering-path change (visible `Text` now binds `displaySnippet`, clipboard binds `snippet`). Manually traced both bindings.

🤖 AI-assisted: found, root-caused, fixed, and build-verified with Claude Code (Opus 4.8). Human-reviewed before merge.