### PR TITLE
ci(rapid-mac): add a PR compile gate + fix smoke.sh dead `swift test`

### DIFF
--- a/.github/workflows/rapid-mac-ci.yml
+++ b/.github/workflows/rapid-mac-ci.yml
@@ -1,0 +1,44 @@
+# Compile gate for the rapid-mac desktop app on pull requests.
+#
+# Until now the ONLY workflow that touched apps/rapid-mac was
+# rapid-mac-release.yml, which fires solely on `rapid-mac-v*` tags — so a PR
+# could land a change that did not even compile, and nothing caught it until a
+# human cut a release. This job builds the Swift package on every PR that
+# touches the app, so a non-compiling change fails in review instead.
+#
+# Scope is deliberately just `swift build`: the SPM test target was stripped
+# (see apps/rapid-mac/Package.swift — the strip deleted the subsystems most of
+# the suite exercised, so it no longer compiles, and `swift test` can't resolve
+# `import Testing` in this toolchain). Re-wiring a fresh test suite is tracked
+# separately; a compile gate is the high-value floor that costs ~20s.
+name: rapid-mac CI
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "apps/rapid-mac/**"
+      - ".github/workflows/rapid-mac-ci.yml"
+
+permissions:
+  contents: read
+
+# One in-flight build per PR branch; a new push cancels the previous run.
+concurrency:
+  group: rapid-mac-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    # macos-15 → default Xcode 16 → Swift 6.0, matching Package.swift's
+    # swift-tools-version and the release workflow's runner. macos-latest still
+    # resolves to macos-14 (Swift 5.x) on GitHub-hosted runners.
+    runs-on: macos-15
+    defaults:
+      run:
+        working-directory: apps/rapid-mac
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - name: swift build
+        run: swift build

--- a/apps/rapid-mac/scripts/smoke.sh
+++ b/apps/rapid-mac/scripts/smoke.sh
@@ -1,19 +1,21 @@
 #!/usr/bin/env bash
 # smoke.sh — fast (sub-2s) end-to-end smoke for Rapid.app.
 #
-# Runs the Swift Testing unit suite + the chat lifecycle directive
-# against the fake rapid-mlx, so a code change can be verified
-# without standing up a real model.
+# Compiles the app and runs the chat lifecycle directive against the fake
+# rapid-mlx, so a code change can be verified without standing up a real model.
 #
 # What it covers:
-#   * swift test (14 cases — DownloadProgress, UpdateChecker,
-#     SessionStore roundtrip)
+#   * swift build (the package compiles)
 #   * ServerManager spawn / health-poll / state transitions
 #     (.idle → .starting → .ready → .stopped)
 #   * ChatStreamClient SSE decode (reasoning + content lanes,
 #     finish_reason routing, clean [DONE])
 #
 # What it does NOT cover:
+#   * The Swift Testing unit suite — the SPM test target was stripped
+#     (see Package.swift), so `swift test` finds no tests / can't build. A
+#     fresh suite is tracked separately; until then this smoke is build +
+#     chat-lifecycle only.
 #   * Real model inference (use ``RAPID_BIN=/opt/homebrew/bin/rapid-mlx``
 #     or unset RAPID_BIN for that)
 #   * SwiftUI view tree (Step 2 — ViewInspector)
@@ -23,13 +25,14 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$ROOT"
 
-echo "==> swift test"
-swift test
+echo "==> swift build"
+# Compile the package up front. This is the verification the old ``swift test``
+# line was meant to provide but couldn't (no test target → exit 1 on a clean
+# tree, killing the smoke before it ever reached the chat lifecycle below).
+swift build >/dev/null
 
 echo
 echo "==> chat lifecycle vs fake rapid-mlx"
-# Build first so we time the smoke, not the compile.
-swift build >/dev/null
 start_ts="$(date +%s)"
 RAPID_BIN="$ROOT/scripts/fake-rapid-mlx.sh" \
     RAPID_TEST_DRIVER='chat:fake-alias:hi there' \


### PR DESCRIPTION
## Why

Nothing in PR CI compiled the rapid-mac desktop app. The only workflow touching `apps/rapid-mac` is `rapid-mac-release.yml`, and it fires **solely on `rapid-mac-v*` tags** — never on PRs. So a change could land that didn't even compile and stay unnoticed until a human cut a release; ~10 recent app PRs were never auto-verified to build. (`ci.yml` / `pr-validate.yml`, the actual PR CI, reference no swift/rapid-mac step.)

Separately, `apps/rapid-mac/scripts/smoke.sh` opened with `swift test`, which on a clean tree exits 1 (`error: no tests found`) under `set -euo pipefail` — killing the smoke before the chat-lifecycle section, while its header advertised "Runs the Swift Testing unit suite (14 cases)". The SPM test target was deliberately stripped (documented in `Package.swift`), so `swift test` can't work here.

Found during a post-v0.12.4 review sweep.

## What

- **New `.github/workflows/rapid-mac-ci.yml`**: `on: pull_request` with `paths: [apps/rapid-mac/**, .github/workflows/rapid-mac-ci.yml]`, runs `swift build` on `macos-15` (Xcode 16 / Swift 6.0 — matches `Package.swift`'s tools version and the release runner; `macos-latest` still resolves to macos-14). Per-branch `concurrency` with cancel-in-progress. `permissions: contents: read`, checkout SHA-pinned to match the pinning gate.
- **`smoke.sh`**: replace the dead `swift test` with the `swift build` the smoke already needed (it built anyway further down), and correct the header to describe what it actually covers (build + chat lifecycle). The chat-lifecycle section itself is unchanged.

**Out of scope (tracked separately):** re-wiring an SPM test target. The `Package.swift` comment explains it was stripped because the strip removed the subsystems most tests exercised; rebuilding a suite is a larger effort than a compile gate.

## Tests

- `python scripts/check_gha_pinning.py` → 14 workflows clean (every `uses:` a 40-char SHA, including the new one).
- `python scripts/check_workflow_expressions.py` → OK (14 files).
- `swift build` in `apps/rapid-mac` → Build complete.
- `bash -n smoke.sh` → OK; the `swift build` step runs (the pre-existing chat-lifecycle step, which spawns the app against a fake sidecar, is unchanged).

🤖 AI-assisted: found, root-caused, and verified with Claude Code (Opus 4.8). Human-reviewed before merge.