### PR TITLE
test(pflash): harden server-module wiring test against sys.modules swaps

### DIFF
--- a/tests/test_pflash_server_module_wiring.py
+++ b/tests/test_pflash_server_module_wiring.py
@@ -25,18 +25,33 @@ engine/uvicorn boot.
 
 from __future__ import annotations
 
+import importlib
 import os
 import sys
 from unittest import mock
 
 import pytest
 
-import vllm_mlx.cli as cli  # noqa: F401  (bind before patching)
-import vllm_mlx.server as server
-
 
 class _StopError(Exception):
     """Short-circuit ``server.main()`` right after the PFlash step."""
+
+
+def _server_module():
+    """Resolve ``vllm_mlx.server`` from ``sys.modules`` at call time.
+
+    NOT a module-level ``import ... as server``: another test in the shared
+    process may ``sys.modules.pop("vllm_mlx.cli")`` / reimport (several route
+    tests do), which swaps the live module object. A binding captured at import
+    time would then be stale, so ``mock.patch.object`` on it would patch a
+    different object than the one ``server.main()`` actually calls into — the
+    real ``_port_preflight_or_die`` would run and, if port 8000 is taken by an
+    earlier test, abort with SystemExit. Fetching fresh (and patching by string
+    target below, which mock also resolves through ``sys.modules``) keeps the
+    patch and the code-under-test pointed at the same object regardless of
+    ordering.
+    """
+    return importlib.import_module("vllm_mlx.server")
 
 
 # ``server.main()`` writes serving config into module-level globals (API key,
@@ -63,6 +78,7 @@ _MISSING = object()
 
 @pytest.fixture(autouse=True)
 def _restore_server_globals():
+    server = _server_module()
     saved = {name: getattr(server, name, _MISSING) for name in _SERVER_GLOBALS}
     mcp_saved = os.environ.get("RAPID_MLX_MCP_CONFIG", _MISSING)
     try:
@@ -93,13 +109,24 @@ def _run_server_main_capturing_config(argv: list[str], *, lane=(False, False)):
         captured["is_mllm"] = is_mllm
         raise _StopError
 
+    server = _server_module()
+    # All patch targets are STRING paths so mock resolves each module through
+    # ``sys.modules`` at enter time — the same object ``server.main()`` reaches
+    # (``_port_preflight_or_die`` via its in-function ``from .cli import``).
+    # Using ``mock.patch.object`` on an import-time-captured module would miss
+    # after a ``sys.modules`` swap (see ``_server_module``).
+    #
+    # Only ``_StopError`` is allowed to escape — NOT SystemExit. If a preflight
+    # ever runs unpatched (e.g. port 8000 taken) it aborts via SystemExit, and
+    # we want that to fail LOUDLY here rather than be swallowed into an empty
+    # ``captured`` that then trips a confusing "cfg is None" assertion.
     with (
-        mock.patch.object(cli, "_port_preflight_or_die", lambda *a, **k: None),
-        mock.patch.object(server, "_ensure_routing_config", lambda *a, **k: None),
-        mock.patch.object(server, "resolve_serving_lane", lambda name, **kw: lane),
+        mock.patch("vllm_mlx.cli._port_preflight_or_die", lambda *a, **k: None),
+        mock.patch("vllm_mlx.server._ensure_routing_config", lambda *a, **k: None),
+        mock.patch("vllm_mlx.server.resolve_serving_lane", lambda name, **kw: lane),
         mock.patch("vllm_mlx.pflash.validate_model_support", _capture_validate),
         mock.patch.object(sys, "argv", ["vllm_mlx.server", *argv]),
-        pytest.raises((_StopError, SystemExit)),
+        pytest.raises(_StopError),
     ):
         server.main()
     return captured


### PR DESCRIPTION
## Why

The #1477 regression test (`test_pflash_server_module_wiring.py`) drives the real `server.main()` and patched its boundaries with `mock.patch.object(cli, ...)` / `mock.patch.object(server, ...)` on **import-time-captured** module objects.

Several route tests in the shared suite do `sys.modules.pop("vllm_mlx.cli")` + reimport, which replaces the live module object. After such a swap the captured `cli` binding is stale, so the patch lands on a different object than the one `server.main()`'s in-function `from .cli import _port_preflight_or_die` reaches. The **real** preflight then runs; when an earlier test has leaked a server on port 8000, it aborts via `SystemExit`, which the test's `pytest.raises((_StopError, SystemExit))` swallowed into an empty capture → the confusing `cfg is None` / "validate_model_support was never reached" failure.

Net: the test was order-dependent — green in #1477's own pr_validate, **red** under a different full-suite ordering (which is exactly what surfaced it in a later PR's `full_unit`). Reproduced deterministically with `sys.modules.pop("vllm_mlx.cli")` + a socket bound to 8000: 3 failed pre-fix, 3 pass post-fix.

## What

- Resolve `vllm_mlx.server` **fresh** from `sys.modules` at call time (`_server_module()`), used by both the helper and the global-restore fixture.
- Patch every boundary by **string target** (`"vllm_mlx.cli._port_preflight_or_die"`, `"vllm_mlx.server._ensure_routing_config"`, `"vllm_mlx.server.resolve_serving_lane"`), which `mock` also resolves through `sys.modules` at enter time — so the patch and the code-under-test always point at the same object regardless of reload order.
- Narrow the allowed escape to `_StopError` only (drop `SystemExit`), so any unpatched preflight fails loudly instead of masquerading as a missing capture.

Assertions are unchanged, so the guard against reverting the #1477 `server.py` wiring is preserved.

## Tests

- `test_pflash_server_module_wiring.py` (3) pass in isolation and combined with `test_routes.py` (70 total), `ruff` clean.
- Deterministic repro harness (`sys.modules.pop("vllm_mlx.cli")` + reimport + port 8000 bound): **3 failed before this change, 3 pass after**.

## Notes

Found while validating a later PR whose `full_unit` tripped this flake; the root cause is entirely in the test's patch mechanics, not in product code. Also cleaned up an orphaned test-leaked server that had been holding port 8000 locally (unrelated to this diff).

🤖 AI-assisted: root-caused, reproduced deterministically, and fixed with Claude Code (Opus 4.8). Human-reviewed before merge.