### PR TITLE
fix(app): the first model every new user meets does not survive a chat

### DIFF
--- a/.github/workflows/rapid-mac-ci.yml
+++ b/.github/workflows/rapid-mac-ci.yml
@@ -42,3 +42,10 @@ jobs:
 
       - name: swift build
         run: swift build
+
+      # The recommendation + Quickstart-eligibility contracts. With the SPM
+      # test target stripped, this dependency-free script is the only thing
+      # that actually EXECUTES that logic — it was runnable but wired to
+      # nothing, so a regression in it would have reached a release.
+      - name: verify recommendation + eligibility contracts
+        run: swift scripts/verify-recommendation-tiers.swift

--- a/apps/rapid-mac/Sources/Rapid/Server/AutoStartDecision.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/AutoStartDecision.swift
@@ -165,6 +165,13 @@ enum AutoStartDecision: Equatable {
         /// or surface a ``promptDownload`` caption that would suggest
         /// they should click Start.
         case userOptedOut
+        /// The alias we would resume is a ``QuickstartCoordinator``
+        /// retired starter — a model withdrawn for being unusable, not
+        /// merely superseded. Auto-starting it would put the user back
+        /// in the broken chat AND move ``serverState`` off ``.idle``,
+        /// which suppresses the Quickstart rescue card that exists to
+        /// get them off it. Skipping leaves the frame to that card.
+        case retiredStarter
         /// ``serverState`` is not ``.idle`` — either a previous
         /// ``.task`` already kicked an auto-start (re-entry), the
         /// user manually clicked Start before this helper fired, or
@@ -226,7 +233,8 @@ enum AutoStartDecision: Equatable {
         cachedAliases: Set<String>,
         serverState: ServerState,
         rejectsAlias: (String) -> Bool = { _ in false },
-        userOptedIn: Bool = true
+        userOptedIn: Bool = true,
+        isRetiredStarter: (String) -> Bool = { _ in false }
     ) -> AutoStartDecision {
         // FU-1 precedence #0 (highest): if the user has turned the
         // auto-start preference OFF in Settings → Models, never
@@ -285,6 +293,16 @@ enum AutoStartDecision: Equatable {
         )
         guard let alias = resolved else {
             return .skip(reason: .noResolvableAlias)
+        }
+
+        // A retired starter must not be resumed. Auto-start defaults to
+        // ON, so without this the rescue is decorative: the stranded user
+        // launches, we restart the broken model, ``serverState`` leaves
+        // ``.idle``, and Quickstart's third gate hides the card that was
+        // supposed to reach them. Placed after resolution so the reason is
+        // specific rather than folded into ``noResolvableAlias``.
+        if isRetiredStarter(alias) {
+            return .skip(reason: .retiredStarter)
         }
 
         // Cond-3 gate — model on disk?

--- a/apps/rapid-mac/Sources/Rapid/Server/BundledModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/BundledModel.swift
@@ -15,32 +15,43 @@ import Foundation
 /// inactive the entire time. By the time the user had typed "hi" the
 /// app had already failed.
 ///
-/// For airgapped builds (``BUNDLE_MODEL=1``) the ~0.5 GB
-/// bonsai-1.7b-2bit weights are staged inside the DMG. On first
+/// For airgapped builds (``BUNDLE_MODEL=1``) the ~0.6 GB
+/// lfm2.5-1b-4bit weights are staged inside the DMG. On first
 /// launch the desktop:
 ///
 /// 1. Resolves the bundled model directory at
-///    ``Contents/Resources/models/hf-cache/models--prism-ml--Ternary-Bonsai-1.7B-mlx-2bit``
+///    ``Contents/Resources/models/hf-cache/models--mlx-community--LFM2.5-1.2B-Instruct-4bit``
 /// 2. Symlinks it into the user's HuggingFace cache
 ///    (``~/.cache/huggingface/hub/``) the first time the symlink is
 ///    missing, so the sidecar can ``snapshot_download`` it without a
 ///    network call.
 /// 3. Returns ``bundledAlias`` as the first-launch default so the
-///    sidecar gets ``rapid-mlx serve bonsai-1.7b-2bit`` instead of
+///    sidecar gets ``rapid-mlx serve lfm2.5-1b-4bit`` instead of
 ///    something the user would have to wait minutes to download.
 ///
-/// ## Why bonsai-1.7b-2bit (Ternary Bonsai)
+/// ## Why lfm2.5-1b-4bit (LFM2.5 1.2B Instruct)
 ///
-/// 2026-07-10: swapped from the v0.7.x ``qwen3-0.6b-4bit`` starter.
-/// The ternary (1.58-bit, packed as MLX-2bit) 1.7B is ~0.5 GB on
-/// disk — still a small first-download — but is a genuinely usable
-/// model where the 0.6B was smoke-test-grade: it holds multi-turn
-/// context and, crucially, emits clean ``tool_calls`` (6/6 on the
-/// eval harness, hermes parser), so it clears
-/// ``ToolUseCapability.known`` instead of hiding its agentic surface.
-/// It's a real Qwen3-architecture checkpoint, so the chat-template +
-/// tool-call shape carries forward to every ``RAMBucketedDefault``
-/// upgrade target. See rapid-mlx alias ``bonsai-1.7b-2bit`` (PR #1092).
+/// 2026-08-05: swapped from ``bonsai-1.7b-2bit``. Kept in lock-step
+/// with ``QuickstartCoordinator.defaultChoice`` — the two are the same
+/// product decision reached by two paths (bundled vs downloaded), and
+/// letting them drift means an airgapped build ships a first-launch
+/// model the online path has already rejected.
+///
+/// Bonsai was chosen (#1092) on a tool-call eval: 6/6 clean
+/// ``tool_calls`` on the 1.7B. That measurement was real but did not
+/// cover the thing a starter is actually judged on. On a plain-chat
+/// multi-step word problem — no tools — it degenerated 4/4 and
+/// terminated 0/4, doubling words within the first line and then
+/// looping until it hit ``max_tokens``. See
+/// ``QuickstartCoordinator.defaultChoice`` for the full measurements.
+///
+/// The 1.2B replacement answers correctly and terminates cleanly
+/// (12/12 in a controlled repro), at 170 tok/s with no reasoning
+/// phase. It is a text-first pick: unlike Bonsai it is not currently
+/// listed in ``ToolUseCapability``, so the empty-state capability
+/// chips stay hidden until someone measures its tool calls. That is
+/// the intended fail-closed posture — do not add it to the known
+/// list on the strength of the engine's ``lfm`` parser alone.
 ///
 /// ## Why this lives in ``Server/`` not ``UI/``
 ///
@@ -55,13 +66,13 @@ enum BundledModel {
     /// re-test, sidecar smoke). Source-of-truth lives in the
     /// submodule at ``third_party/rapid-mlx/vllm_mlx/aliases.json``;
     /// this constant just names the entry we ship weights for.
-    static let bundledAlias: String = "bonsai-1.7b-2bit"
+    static let bundledAlias: String = "lfm2.5-1b-4bit"
 
     /// HuggingFace repo ID for the bundled weights. The HF cache
     /// layout encodes this as ``models--<owner>--<name>`` on disk.
     /// Kept here next to ``bundledAlias`` so a renamed-upstream
     /// repo doesn't silently break the symlink path.
-    static let bundledRepoID: String = "prism-ml/Ternary-Bonsai-1.7B-mlx-2bit"
+    static let bundledRepoID: String = "mlx-community/LFM2.5-1.2B-Instruct-4bit"
 
     /// HF cache directory name for the bundled repo. The HF Hub
     /// snapshot layout uses ``models--<owner>--<name>`` (double-dash

--- a/apps/rapid-mac/Sources/Rapid/Server/BundledModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/BundledModel.swift
@@ -45,8 +45,11 @@ import Foundation
 /// looping until it hit ``max_tokens``. See
 /// ``QuickstartCoordinator.defaultChoice`` for the full measurements.
 ///
-/// The 1.2B replacement answers correctly and terminates cleanly
-/// (12/12 in a controlled repro), at 170 tok/s with no reasoning
+/// The 1.2B replacement answers correctly and terminates cleanly on
+/// every run recorded: 16/16 total, of which 12/12 came from a single
+/// controlled repro. Both numbers describe the same result, so quote
+/// the 16/16 -- it is the whole sample, not a subset of it. 170 tok/s
+/// with no reasoning
 /// phase. It is a text-first pick: unlike Bonsai it is not currently
 /// listed in ``ToolUseCapability``, so the empty-state capability
 /// chips stay hidden until someone measures its tool calls. That is

--- a/apps/rapid-mac/Sources/Rapid/Server/BundledModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/BundledModel.swift
@@ -20,7 +20,7 @@ import Foundation
 /// launch the desktop:
 ///
 /// 1. Resolves the bundled model directory at
-///    ``Contents/Resources/models/hf-cache/models--mlx-community--LFM2.5-1.2B-Instruct-4bit``
+///    ``Contents/Resources/models/hf-cache/hub/models--mlx-community--LFM2.5-1.2B-Instruct-4bit``
 /// 2. Symlinks it into the user's HuggingFace cache
 ///    (``~/.cache/huggingface/hub/``) the first time the symlink is
 ///    missing, so the sidecar can ``snapshot_download`` it without a

--- a/apps/rapid-mac/Sources/Rapid/Server/DiskSpaceProbe.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/DiskSpaceProbe.swift
@@ -56,24 +56,28 @@ enum DiskSpaceProbe {
     /// Sized for the Quickstart default ``lfm2.5-1b-4bit``
     /// (~0.6 GB on disk):
     ///
-    ///   * ~0.6 GB final footprint (measured: 637 MB pulled), AND
+    /// Every operand below is binary (GiB), matching the constant itself
+    /// (``2 * 1024³``) — mixing a decimal download figure into a binary
+    /// budget is how a threshold silently stops covering what it claims.
+    ///
+    ///   * **0.622 GiB** final footprint — measured, ``du -sm`` reported
+    ///     637 MiB for the pulled snapshot, AND
     ///   * ~1.5× transient peak during chunk fetch + dedupe (HF's
     ///     downloader writes an incomplete `.bin` alongside the
     ///     sharded snapshot dir before atomically moving), AND
-    ///   * ~1 GB headroom for the rest of the OS, swap, and Console
+    ///   * 1 GiB headroom for the rest of the OS, swap, and Console
     ///     log churn during a 1-2 minute pull on a slow link.
     ///
-    /// ``0.6 × 1.5 + 1 = 1.9 GB``, still inside the ``2 GB`` threshold —
+    /// ``0.622 × 1.5 + 1 = 1.933 GiB``, inside the ``2 GiB`` threshold,
     /// which stays put so the surfaced "needs ~Y GB" copy remains a clean
-    /// round number. Earlier starters derived the same 2 GB from smaller
-    /// footprints (0.6B ~0.4 GB → 1.6 GB; ternary 1.7B ~0.5 GB →
-    /// 1.75 GB), so the margin has narrowed from ~0.4 GB to ~0.1 GB.
+    /// round number. Earlier starters derived the same 2 GiB from smaller
+    /// footprints, so the slack has narrowed to **~0.067 GiB (~68 MiB)**.
     ///
-    /// That margin is now thin enough that the next bump almost certainly
-    /// breaks it: anything over ~0.67 GB on disk derives past 2 GB. If the
-    /// Quickstart default (see ``QuickstartCoordinator.defaultChoice``)
-    /// moves again, re-derive this constant — do not assume 2 GB still
-    /// covers it.
+    /// That is thin enough that the next bump probably breaks it: solving
+    /// ``x × 1.5 + 1 = 2`` puts the ceiling at **0.667 GiB (~683 MiB)** on
+    /// disk. If the Quickstart default (see
+    /// ``QuickstartCoordinator.defaultChoice``) moves again, re-derive this
+    /// constant — do not assume 2 GiB still covers it.
     static let quickstartRequiredBytes: Int64 = 2 * 1024 * 1024 * 1024
 
     /// Outcome of ``decide``. Used to drive both the UI banner and a

--- a/apps/rapid-mac/Sources/Rapid/Server/DiskSpaceProbe.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/DiskSpaceProbe.swift
@@ -56,21 +56,24 @@ enum DiskSpaceProbe {
     /// Sized for the Quickstart default ``lfm2.5-1b-4bit``
     /// (~0.6 GB on disk):
     ///
-    ///   * ~0.5 GB final footprint, AND
+    ///   * ~0.6 GB final footprint (measured: 637 MB pulled), AND
     ///   * ~1.5× transient peak during chunk fetch + dedupe (HF's
     ///     downloader writes an incomplete `.bin` alongside the
     ///     sharded snapshot dir before atomically moving), AND
     ///   * ~1 GB headroom for the rest of the OS, swap, and Console
     ///     log churn during a 1-2 minute pull on a slow link.
     ///
-    /// ``0.5 × 1.5 + 1 = 1.75 GB`` rounded up to a clean ``2 GB`` so
-    /// the surfaced "needs ~Y GB" copy is human-readable. The prior
-    /// 0.6B starter (~0.4 GB) derived the same 2 GB; the ternary 1.7B
-    /// at ~0.5 GB stays comfortably inside it.
+    /// ``0.6 × 1.5 + 1 = 1.9 GB``, still inside the ``2 GB`` threshold —
+    /// which stays put so the surfaced "needs ~Y GB" copy remains a clean
+    /// round number. Earlier starters derived the same 2 GB from smaller
+    /// footprints (0.6B ~0.4 GB → 1.6 GB; ternary 1.7B ~0.5 GB →
+    /// 1.75 GB), so the margin has narrowed from ~0.4 GB to ~0.1 GB.
     ///
-    /// If the Quickstart default alias (see ``QuickstartCoordinator.alias``)
-    /// is ever bumped to a meaningfully larger model, the threshold
-    /// here MUST be re-derived from the new on-disk footprint.
+    /// That margin is now thin enough that the next bump almost certainly
+    /// breaks it: anything over ~0.67 GB on disk derives past 2 GB. If the
+    /// Quickstart default (see ``QuickstartCoordinator.defaultChoice``)
+    /// moves again, re-derive this constant — do not assume 2 GB still
+    /// covers it.
     static let quickstartRequiredBytes: Int64 = 2 * 1024 * 1024 * 1024
 
     /// Outcome of ``decide``. Used to drive both the UI banner and a

--- a/apps/rapid-mac/Sources/Rapid/Server/DiskSpaceProbe.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/DiskSpaceProbe.swift
@@ -8,8 +8,10 @@ import Foundation
 /// PR #338 swapped the Quickstart default alias from
 /// ``gemma3-1b-qat-4bit`` (~700 MB) to ``qwen3.5-4b-4bit`` (~2.3 GB).
 /// F-LWT-1 then swapped to ``qwen3-0.6b-4bit`` (~400 MB); 2026-07-10
-/// swapped to ``lfm2.5-1b-4bit`` (~0.6 GB 4-bit) — see
-/// ``QuickstartCoordinator.alias`` for the receipt.
+/// swapped to ``bonsai-1.7b-2bit`` (~0.5 GB ternary); 2026-08-05
+/// swapped to ``lfm2.5-1b-4bit`` (~0.6 GB 4-bit) after Bonsai was found
+/// to degenerate on plain chat — see
+/// ``QuickstartCoordinator.defaultChoice`` for the receipt.
 /// A user with a near-full disk who clicks Get started watches the bar
 /// crawl, then either:
 ///

--- a/apps/rapid-mac/Sources/Rapid/Server/DiskSpaceProbe.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/DiskSpaceProbe.swift
@@ -8,7 +8,7 @@ import Foundation
 /// PR #338 swapped the Quickstart default alias from
 /// ``gemma3-1b-qat-4bit`` (~700 MB) to ``qwen3.5-4b-4bit`` (~2.3 GB).
 /// F-LWT-1 then swapped to ``qwen3-0.6b-4bit`` (~400 MB); 2026-07-10
-/// swapped to ``bonsai-1.7b-2bit`` (~0.5 GB ternary) — see
+/// swapped to ``lfm2.5-1b-4bit`` (~0.6 GB 4-bit) — see
 /// ``QuickstartCoordinator.alias`` for the receipt.
 /// A user with a near-full disk who clicks Get started watches the bar
 /// crawl, then either:
@@ -51,8 +51,8 @@ enum DiskSpaceProbe {
     /// The free-space threshold the Quickstart pre-flight uses to
     /// decide whether to surface the low-disk banner.
     ///
-    /// Sized for the Quickstart default ``bonsai-1.7b-2bit``
-    /// (~0.5 GB on disk):
+    /// Sized for the Quickstart default ``lfm2.5-1b-4bit``
+    /// (~0.6 GB on disk):
     ///
     ///   * ~0.5 GB final footprint, AND
     ///   * ~1.5× transient peak during chunk fetch + dedupe (HF's

--- a/apps/rapid-mac/Sources/Rapid/Server/ToolUseCapability.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ToolUseCapability.swift
@@ -306,7 +306,7 @@ enum ToolUseCapability {
         // it to .known lets the empty-state capability chips surface.
         // 1.5B floor: the starter is 1.7B (below the 3.0 floor the other
         // rows use), and the smallest shipped ternary is 1.7B.
-        KnownFamily(prefix: "bonsai-", minSizeBillions: 1.5, note: "Ternary Bonsai (Qwen3 arch); 6/6 clean tool_calls on 1.7B, hermes parser; rapid-mlx PR #1092; first-run starter"),
+        KnownFamily(prefix: "bonsai-", minSizeBillions: 1.5, note: "Ternary Bonsai (Qwen3 arch); 6/6 clean tool_calls on 1.7B, hermes parser; rapid-mlx PR #1092. NOT the first-run starter since 2026-08-05 — it degenerates on plain chat; see QuickstartCoordinator.defaultChoice"),
 
         // MARK: Llama family
 

--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -321,6 +321,7 @@ struct ContentView: View {
         }
         if QuickstartCoordinator.isEligible(
             done: quickstart.done,
+            legacyDone: quickstart.legacyDone,
             lastServedAlias: ServerManager.lastServedAlias(),
             serverState: server.state
         ) {

--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -531,7 +531,17 @@ struct ContentView: View {
             serverState: server.state,
             rejectsAlias: rejectsAlias,
             userOptedIn: autoStartOnLaunch,
-            isRetiredStarter: QuickstartCoordinator.retiredStarters.contains
+            // Skip a retired starter only while the rescue is still on
+            // offer. Once the user has completed or dismissed Quickstart,
+            // `isEligible` stops showing the card — and an unconditional
+            // predicate here would then leave them with neither their
+            // configured auto-start nor any rescue UI, launching into an
+            // idle server for no reason they can see. Respecting `done`
+            // keeps the skip and the card appearing and disappearing
+            // together.
+            isRetiredStarter: { alias in
+                !quickstart.done && QuickstartCoordinator.retiredStarters.contains(alias)
+            }
         )
         switch decision {
         case .start(let resume):

--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -530,7 +530,8 @@ struct ContentView: View {
             cachedAliases: cachedAliases,
             serverState: server.state,
             rejectsAlias: rejectsAlias,
-            userOptedIn: autoStartOnLaunch
+            userOptedIn: autoStartOnLaunch,
+            isRetiredStarter: QuickstartCoordinator.retiredStarters.contains
         )
         switch decision {
         case .start(let resume):

--- a/apps/rapid-mac/Sources/Rapid/UI/ModelPickerBar.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ModelPickerBar.swift
@@ -10,7 +10,7 @@ import SwiftUI
 /// card can still one-click install the demo model from the picker:
 ///
 ///   ┌── Quickstart ─────────────────────────────────┐
-///   │  bonsai-1.7b-2bit · Smallest model — fastest  │ ← RAM-blind, F-LWT-1
+///   │  lfm2.5-1b-4bit · Smallest model — fastest   │ ← RAM-blind, F-LWT-1
 ///   │  first install                                │
 ///   ├── Recommended for your 18 GB Mac ─────────────┤
 ///   │  Best pick   bonsai-27b-2bit   [amber row     │ ← the RAM tier's
@@ -80,7 +80,7 @@ struct ModelPickerBar: View {
 
     /// The alias the Quickstart flow is currently aimed at — the wizard's
     /// live selection (#1524) while a coordinator is attached, else the
-    /// fixed starter (bonsai-1.7b-2bit). This is the target the in-flight
+    /// fixed starter (lfm2.5-1b-4bit). This is the target the in-flight
     /// picker breadcrumb mirrors onto so the picker never shows a model
     /// that disagrees with what's downloading. The picker's *own*
     /// persistent "Quickstart" demo row is a separate, always-starter
@@ -194,7 +194,7 @@ struct ModelPickerBar: View {
            catalog.contains(where: { $0.alias == quickstartTargetAlias }) {
             return quickstartTargetAlias
         }
-        // v0.7.1 #229: on a fresh install the bundled bonsai-1.7b-2bit
+        // v0.7.1 #229: on a fresh install the bundled lfm2.5-1b-4bit
         // is on disk and the user has never picked anything else.
         // Prefer it so the picker matches what the ContentView ``.task``
         // auto-restart starts — otherwise the breadcrumb shows a
@@ -656,7 +656,7 @@ struct ModelPickerBar: View {
 
     /// F-LWT-1: dedicated single-row "Quickstart" section above the
     /// RAM-aware Recommended section. RAM-blind by design — the
-    /// Quickstart alias is the same on every Mac (bonsai-1.7b-2bit is
+    /// Quickstart alias is the same on every Mac (lfm2.5-1b-4bit is
     /// the smallest first-impression install). Persists
     /// across all Quickstart phases including ``.dismissed`` so a
     /// user who closed the Quickstart card can still come back and

--- a/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
@@ -216,9 +216,11 @@ final class QuickstartCoordinator {
     /// tier recommendation — but it is the wrong *starter*. It routes
     /// through the ``qwen3`` reasoning parser, so ~2/3 of its output is
     /// hidden thinking: 3.6 s to a first answer, most of it a blank
-    /// screen. The 1.2B has no reasoning phase — 1.1 s, 170 tok/s, and
-    /// it answers correctly. For a first impression, "instant and right"
-    /// beats "smarter but silent first".
+    /// screen. The 1.2B has no reasoning phase — 1.1 s, 170 tok/s, and it
+    /// answered correctly and terminated on **16/16** recorded runs
+    /// (12/12 of them in one controlled repro; quote the 16, it is the
+    /// whole sample). For a first impression, "instant and right" beats
+    /// "smarter but silent first".
     ///
     /// Users still trade up in the wizard or later via the picker.
     static let defaultChoice = QuickstartModelChoice(

--- a/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
@@ -607,8 +607,18 @@ Open the picker any time to switch models.
     ///
     /// Membership here is a strong claim — it re-opens onboarding for
     /// someone already using the app. Add an alias only when it is
-    /// effectively unusable, never merely superseded. A user who traded
-    /// up to any other model is untouched by this.
+    /// effectively unusable, never merely superseded.
+    ///
+    /// Scope, precisely: ``rapid.serve.lastAlias`` is the *most recent*
+    /// serve, not a history. So the carve-out fires for anyone whose
+    /// **current** model is retired — including a user who traded up and
+    /// later went back to it deliberately, who is arguably not stranded.
+    /// That is accepted rather than fixed: the alternative is persisting
+    /// an onboarding history, which is more state to keep correct than
+    /// the four-line gate it would protect, and the cost of a false
+    /// positive is bounded — the card appears once on an idle server and
+    /// dismissing it sets ``done`` permanently. What the carve-out will
+    /// never do is reach a user whose current model is anything else.
     static let retiredStarters: Set<String> = ["bonsai-1.7b-2bit"]
 
     static func isEligible(

--- a/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
@@ -17,42 +17,63 @@ import SwiftUI
 /// first-touch shape for an inference app.
 ///
 /// Quickstart collapses the cold-start into one click. The card surfaces
-/// when (a) the user has no last-served alias persisted AND (b) the
-/// quickstart flag in UserDefaults hasn't been set yet AND (c) the
-/// server isn't already busy with something else. Clicking "Get started"
-/// triggers a ``rapid-mlx pull bonsai-1.7b-2bit`` (~0.5 GB) via the
+/// when (a) the user has no last-served alias persisted — or has one that
+/// is a ``retiredStarters`` entry, i.e. a model we stranded them on —
+/// AND (b) the quickstart flag in UserDefaults hasn't been set yet AND
+/// (c) the server isn't already busy with something else. Clicking
+/// "Get started"
+/// triggers a ``rapid-mlx pull lfm2.5-1b-4bit`` (~0.6 GB) via the
 /// existing ``DownloadManager``, then auto-spawns
-/// ``rapid-mlx serve bonsai-1.7b-2bit`` once the pull is done, then
+/// ``rapid-mlx serve lfm2.5-1b-4bit`` once the pull is done, then
 /// drops the user into chat with a single seeded assistant message
 /// introducing the model.
 ///
-/// ## Why bonsai-1.7b-2bit
+/// ## Why lfm2.5-1b-4bit
 ///
-/// Starter = Ternary-Bonsai 1.7B (mlx 2-bit; rapid-mlx alias
-/// ``bonsai-1.7b-2bit``, PR #1092). This supersedes the earlier
-/// ``qwen3-0.6b-4bit`` starter. History: the original ``qwen3.5-4b-4bit``
-/// (~2.3 GB) cold-installed in ~11 minutes at the user's observed
-/// 4.4 MB/s — an atrocious first-impression — so F-LWT-1 dropped to a
-/// tiny ~400 MB 0.6B model purely for install latency, at the cost of
-/// the tool-calls demo (0.6B can't reliably emit ``tool_calls``).
+/// Starter = LFM2.5 1.2B Instruct (mlx 4-bit; rapid-mlx alias
+/// ``lfm2.5-1b-4bit``). This supersedes the ``bonsai-1.7b-2bit``
+/// starter, which degenerated 4/4 on a plain-chat word problem — see
+/// ``defaultChoice`` for the measurements.
 ///
-/// Bonsai removes that tradeoff. A ternary (1.58-bit) 1.7B checkpoint
-/// weighs only ~0.5 GB — still a ~1-minute cold install on the same
-/// link — yet it is a real Qwen3 that holds coherent multi-turn chat
-/// AND emits clean ``tool_calls`` (6/6 in eval, hermes parser). The
-/// brand-new user gets both halves on the very first model: "the app
-/// works" AND "it can actually do things."
+/// History: the original ``qwen3.5-4b-4bit`` (~2.3 GB) cold-installed in
+/// ~11 minutes at the user's observed 4.4 MB/s — an atrocious first
+/// impression — so F-LWT-1 dropped to a tiny ~400 MB 0.6B purely for
+/// install latency. #1092 then moved to Bonsai on the strength of a
+/// tool-call eval. Both swaps optimised something other than "does the
+/// first answer come out right", which is what the user actually sees.
+///
+/// ### The selection criterion this slot actually has
+///
+/// A starter is judged on the first plain-chat reply, not on capability
+/// breadth. Concretely, in priority order:
+///
+///   1. **It must terminate and be coherent.** Non-negotiable, and the
+///      one thing neither prior pick was measured on. Note the guard
+///      cannot cover for a weak model here: the loop breaker and the
+///      streaming hard-stop are both gated on ``request.has_tools``,
+///      and onboarding is plain chat.
+///   2. **It must answer immediately.** A reasoning model is
+///      disqualified regardless of quality — hidden thinking means a
+///      blank screen on the one interaction that forms the impression.
+///      This is why the stronger ``lfm2.5-2.6b-4bit`` is not the
+///      starter even though it is the 8-15 GB tier pick.
+///   3. **Download small enough not to lose the user.** Real, but
+///      weaker than it looks: 637 MB pulled in 21 s, *faster* than
+///      Bonsai's 484 MB in 24 s. Shard parallelism dominates at this
+///      size, so a few hundred MB is not the deciding axis.
+///
+/// Tool calling is deliberately absent from that list. It is the right
+/// bar for a *recommended* model, not for the first 60 seconds.
 ///
 /// ### What this means for the empty state
 ///
-///   1. Tool calls ARE reachable on the starter. ``ToolUseCapability``
-///      lists ``bonsai-`` as ``.known`` (≥1.5 B floor), so the
-///      empty-state capability chip row renders instead of being
-///      hidden by the tool-bias gate (PR #333 + FU-9).
-///   2. The ``ChatView`` empty-state ``examplePrompts`` stay
-///      model-agnostic pure-text by design — they must read well on
-///      ANY starter, not tease a capability tied to one alias — so
-///      they are unchanged by this swap.
+///   1. The starter is text-first. If ``ToolUseCapability`` does not
+///      list ``lfm2.5-`` as ``.known``, the empty-state capability chip
+///      row stays hidden by the tool-bias gate (PR #333 + FU-9) — which
+///      is the correct, honest surface for it.
+///   2. The ``ChatView`` empty-state prompts stay model-agnostic pure
+///      text by design — they must read well on ANY starter, not tease
+///      a capability tied to one alias — so they are unchanged.
 ///   3. Users who want more depth trade up via the picker's
 ///      **Recommended Default** (``RAMBucketedDefault``, RAM-aware —
 ///      e.g. ``qwen3.5-9b-4bit`` on an 18 GB Mac), and the
@@ -60,9 +81,8 @@ import SwiftUI
 ///
 /// ### What we keep
 ///
-///   * One-click install + chat for the brand-new user, ~1-minute
-///     cold install.
-///   * Coherent pure-text chat + working tool calls on the starter.
+///   * One-click install + chat for the brand-new user, well under a
+///     minute of cold install.
 ///   * A dedicated "Quickstart" picker section (RAM-blind, persists
 ///     post-dismiss) so a user who skipped Quickstart can still
 ///     one-click install the demo model from the picker.
@@ -95,8 +115,8 @@ import SwiftUI
 
 /// One selectable model in the Quickstart wizard's "choose your first
 /// model" step (#1524). The wizard defaults to — and recommends — the
-/// tiny 0.6B starter (the locked "0.6B first-run" decision), but lets the
-/// user trade up to a bigger model before the first download.
+/// small starter (see ``QuickstartCoordinator.defaultChoice``), but lets
+/// the user trade up to a bigger model before the first download.
 ///
 /// ``hfRepo`` is pinned only for the starter (it wires the precise
 /// bytes-on-disk monitor for the first-impression cold install — see the
@@ -107,7 +127,7 @@ struct QuickstartModelChoice: Equatable, Identifiable, Sendable {
     var id: String { alias }
     /// Canonical alias resolved in ``vllm_mlx/aliases.json``.
     let alias: String
-    /// Prose label for onboarding copy ("Bonsai · 1.7B"). Hand-picked
+    /// Prose label for onboarding copy ("LFM2.5 · 1.2B"). Hand-picked
     /// rather than catalog-derived so the copy never reads a raw alias.
     let displayName: String
     /// HF repo backing the byte monitor. Pinned for the starter; ``nil``
@@ -154,20 +174,58 @@ final class QuickstartCoordinator {
     /// The default + recommended starter — the first-run decision.
     /// Pinned, not derived (F-LWT-1: ~11 min cold install of the old 4B
     /// pick was the wrong first-impression tradeoff; a small starter
-    /// wins). 2026-07-10: swapped from ``qwen3-0.6b-4bit`` to the
-    /// Ternary Bonsai 1.7B (rapid-mlx alias ``bonsai-1.7b-2bit``, PR
-    /// #1092) — a ~0.5 GB ternary (1.58-bit) checkpoint that keeps the
-    /// small-first-download win but, unlike the 0.6B, is multi-turn
-    /// coherent AND emits clean ``tool_calls`` (6/6 on the eval
-    /// harness). It therefore clears ``ToolUseCapability.known``, so the
-    /// empty-state capability chips surface and the starter no longer
-    /// has to hide its agentic surface. Users still trade up to a
-    /// bigger model in the wizard or later via the picker.
+    /// wins).
+    ///
+    /// ## History
+    ///
+    /// - 2026-07-10 (#1092): ``qwen3-0.6b-4bit`` → ``bonsai-1.7b-2bit``.
+    /// - 2026-08-05: ``bonsai-1.7b-2bit`` → ``lfm2.5-1b-4bit``, because
+    ///   the Bonsai starter does not survive an ordinary chat question.
+    ///
+    /// ## Why the Bonsai starter had to go
+    ///
+    /// A community report showed the starter collapsing on a basic
+    /// multi-step word problem. Reproduced on an M2 Pro against engine
+    /// 0.12.4, one plain-chat request (no tools), 4 attempts at two
+    /// different token budgets: it degenerated **4/4** and terminated
+    /// **0/4**. Output doubles words within the first line ("for for",
+    /// "the the the the"), then collapses into an unbounded loop
+    /// (``\text{1} \text{1} …``, ``1 + 9 = 1 + 9 = …``) that only ends
+    /// when it hits ``max_tokens``.
+    ///
+    /// Two things made this the worst possible default. It is *fast*
+    /// while being wrong, so it reads as "this app is broken" rather
+    /// than "this Mac is slow". And the runaway-generation guard cannot
+    /// save it: both the logits-level loop breaker and the streaming
+    /// hard-stop are gated on ``request.has_tools``, and onboarding is
+    /// plain chat — so nothing intervenes.
+    ///
+    /// The prior "6/6 clean ``tool_calls``" evidence is not contradicted;
+    /// it just measured the wrong thing for this slot. Emitting
+    /// well-formed tool calls says nothing about staying coherent in the
+    /// free-form chat every new user actually types first.
+    ///
+    /// ## Why the 1.2B and not the 2.6B
+    ///
+    /// Measured on the same M2 Pro, same prompt. The download worry that
+    /// motivated a ~0.5 GB pick does not survive measurement: 637 MB
+    /// pulled in 21 s, *faster* than Bonsai's 484 MB in 24 s (HF shard
+    /// parallelism dominates at this size).
+    ///
+    /// ``lfm2.5-2.6b-4bit`` is the stronger model and stays the 8-15 GB
+    /// tier recommendation — but it is the wrong *starter*. It routes
+    /// through the ``qwen3`` reasoning parser, so ~2/3 of its output is
+    /// hidden thinking: 3.6 s to a first answer, most of it a blank
+    /// screen. The 1.2B has no reasoning phase — 1.1 s, 170 tok/s, and
+    /// it answers correctly. For a first impression, "instant and right"
+    /// beats "smarter but silent first".
+    ///
+    /// Users still trade up in the wizard or later via the picker.
     static let defaultChoice = QuickstartModelChoice(
-        alias: "bonsai-1.7b-2bit",
-        displayName: "Bonsai · 1.7B",
-        hfRepo: "prism-ml/Ternary-Bonsai-1.7B-mlx-2bit",
-        blurb: "Small download (~0.5 GB), runs on any Mac. Surprisingly capable — real chat and tool calls. Upgrade anytime for more depth.",
+        alias: "lfm2.5-1b-4bit",
+        displayName: "LFM2.5 · 1.2B",
+        hfRepo: "mlx-community/LFM2.5-1.2B-Instruct-4bit",
+        blurb: "Small download (~0.6 GB), runs on any Mac. Answers instantly and follows instructions well. Upgrade anytime for more depth.",
         isStarter: true
     )
 
@@ -202,14 +260,14 @@ final class QuickstartCoordinator {
     /// even after the user deletes every model. Versioned so a
     /// future Quickstart refresh (e.g. introducing a different
     /// default model) can re-show without clobbering the v1 flag.
-    static let storageKey: String = "rapid.quickstart.v1.done"
+    static let storageKey: String = "rapid.quickstart.v2.done"
 
     /// Welcome message seeded into the active session after the sidecar
     /// comes online, so the user always lands in chat with a friendly
     /// intro rather than an empty transcript. Interpolates the chosen
     /// model's display name.
     ///
-    /// The starter (bonsai-1.7b-2bit) is intentionally the smallest
+    /// The starter (lfm2.5-1b-4bit) is intentionally the smallest
     /// pick, so its copy keeps the "start in about a minute, trade up
     /// any time" framing. A bigger pick gets a plainer intro without
     /// the "smallest model" framing (it earned the trade-up, so don't
@@ -518,7 +576,7 @@ Open the picker any time to switch models.
     ///
     /// Three gates, all must hold:
     ///   1. ``done == false`` — the persistent one-shot guard
-    ///      (``rapid.quickstart.v1.done``). Set once the user completes
+    ///      (``rapid.quickstart.v2.done``). Set once the user completes
     ///      OR dismisses Quickstart, so the card never returns.
     ///   2. ``lastServedAlias == nil`` — our own "has this app ever
     ///      served a model?" signal (``rapid.serve.lastAlias``, written
@@ -535,13 +593,35 @@ Open the picker any time to switch models.
     /// re-trigger onboarding is to clear them (a deliberate developer
     /// ``defaults delete``), which is the correct semantics for "reset
     /// first-run", not something inferred from disk contents.
+    /// Aliases retired because they do not survive an ordinary chat, not
+    /// because something better came along.
+    ///
+    /// Gate 2 below treats "has served a model" as "is not a new user".
+    /// That inference breaks for the one cohort this list exists for: a
+    /// user whose only model is ``bonsai-1.7b-2bit`` did reach a running
+    /// model, so the gate calls them onboarded — but what they onboarded
+    /// onto degenerates 4/4 on a plain-chat question (see
+    /// ``defaultChoice``). Bumping ``storageKey`` to v2 alone does not
+    /// reach them: their ``rapid.serve.lastAlias`` is set, so gate 2 keeps
+    /// the card down and they stay stranded on the broken starter.
+    ///
+    /// Membership here is a strong claim — it re-opens onboarding for
+    /// someone already using the app. Add an alias only when it is
+    /// effectively unusable, never merely superseded. A user who traded
+    /// up to any other model is untouched by this.
+    static let retiredStarters: Set<String> = ["bonsai-1.7b-2bit"]
+
     static func isEligible(
         done: Bool,
         lastServedAlias: String?,
         serverState: ServerState
     ) -> Bool {
         guard !done else { return false }
-        guard lastServedAlias == nil else { return false }
+        // Gate 2, with the retired-starter carve-out. `nil` is the
+        // genuinely-new user; a retired starter is a user we stranded.
+        if let alias = lastServedAlias, !retiredStarters.contains(alias) {
+            return false
+        }
         switch serverState {
         case .idle, .stopped:
             return true

--- a/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
@@ -258,9 +258,16 @@ final class QuickstartCoordinator {
     /// UserDefaults key for the persistent "Quickstart already
     /// completed" flag. Once set, the surface NEVER returns — not
     /// even after the user deletes every model. Versioned so a
-    /// future Quickstart refresh (e.g. introducing a different
-    /// default model) can re-show without clobbering the v1 flag.
+    /// Quickstart refresh can re-show without clobbering the older flag.
+    ///
+    /// Moved to v2 on 2026-08-05 for the retired-starter swap. The bump
+    /// alone is not the migration: ``isEligible`` still honours
+    /// ``legacyStorageKey`` so a v1 dismissal is not silently undone.
     static let storageKey: String = "rapid.quickstart.v2.done"
+
+    /// Pre-2026-08-05 completion flag. Read-only — nothing writes it any
+    /// more; it exists so a user who dismissed under v1 stays dismissed.
+    static let legacyStorageKey: String = "rapid.quickstart.v1.done"
 
     /// Welcome message seeded into the active session after the sidecar
     /// comes online, so the user always lands in chat with a friendly
@@ -327,6 +334,9 @@ Open the picker any time to switch models.
     /// check so the surface never returns. Mirrors UserDefaults.
     private(set) var done: Bool
 
+    /// Snapshot of ``legacyStorageKey`` taken at init. Never written.
+    let legacyDone: Bool
+
     /// True once the seeded assistant message has been appended to the
     /// active session. Stops ``markReady`` from double-seeding when the
     /// observation pipeline fires multiple ``.ready`` transitions for
@@ -387,6 +397,7 @@ Open the picker any time to switch models.
 
     init() {
         self.done = UserDefaults.standard.bool(forKey: Self.storageKey)
+        self.legacyDone = UserDefaults.standard.bool(forKey: Self.legacyStorageKey)
         // Codex r5: read the persisted awaiting-seed flag so a
         // quit-mid-deferred-flow relaunch can resume the welcome
         // injection once an active session lands. (Assigning a stored
@@ -621,15 +632,34 @@ Open the picker any time to switch models.
     /// never do is reach a user whose current model is anything else.
     static let retiredStarters: Set<String> = ["bonsai-1.7b-2bit"]
 
+    /// Whether the persisted alias is one we retired for being unusable.
+    static func isStranded(_ lastServedAlias: String?) -> Bool {
+        guard let alias = lastServedAlias else { return false }
+        return retiredStarters.contains(alias)
+    }
+
+    /// - Parameter legacyDone: the pre-v2 completion flag
+    ///   (``legacyStorageKey``). Bumping ``storageKey`` to v2 is what
+    ///   re-opens onboarding, but on its own it re-opens it for *everyone*
+    ///   who had not completed under v2 — including a user who deliberately
+    ///   dismissed the card under v1 and never served anything, whose
+    ///   ``done`` and ``lastServedAlias`` both read empty. That would break
+    ///   the documented "the card never returns" contract for people the
+    ///   version bump was never about. A v1 dismissal is therefore still
+    ///   honoured; it is overridden only for the stranded cohort, which is
+    ///   the entire reason the key moved.
     static func isEligible(
         done: Bool,
+        legacyDone: Bool = false,
         lastServedAlias: String?,
         serverState: ServerState
     ) -> Bool {
         guard !done else { return false }
+        let stranded = isStranded(lastServedAlias)
+        guard !(legacyDone && !stranded) else { return false }
         // Gate 2, with the retired-starter carve-out. `nil` is the
         // genuinely-new user; a retired starter is a user we stranded.
-        if let alias = lastServedAlias, !retiredStarters.contains(alias) {
+        if lastServedAlias != nil, !stranded {
             return false
         }
         switch serverState {

--- a/apps/rapid-mac/Tests/RapidTests/ChatViewExamplePromptsTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ChatViewExamplePromptsTests.swift
@@ -7,10 +7,10 @@ import Testing
 /// model-agnostic by design: they must read well on ANY active model
 /// — including a brand-new user's starter — and never tease a
 /// capability tied to one specific alias. The starter is now
-/// ``bonsai-1.7b-2bit``, which DOES emit clean ``tool_calls`` (so the
-/// empty-state capability chip row renders for it), but the seeded
-/// prompts still stay generic so they hold up if the active model is
-/// swapped for one that flubs a tool call. The chip row's tool-bias
+/// ``lfm2.5-1b-4bit`` (2026-08-05), a text-first pick that is NOT in
+/// ``ToolUseCapability.known`` — so the empty-state capability chip row
+/// stays hidden for it. The seeded prompts stay generic regardless, so
+/// they hold up whichever way the starter goes. The chip row's tool-bias
 /// hider (PR #333 / FU-9) covers the chip surface; these tests cover
 /// the seeded example prompts the chip row gate does not touch.
 ///
@@ -144,8 +144,8 @@ struct ChatViewExamplePromptsTests {
         let scanStart = intentRange.lowerBound
         let scanEnd = src.index(scanStart, offsetBy: 600, limitedBy: src.endIndex) ?? src.endIndex
         let neighbourhood = src[scanStart..<scanEnd]
-        #expect(neighbourhood.contains("bonsai-1.7b-2bit"),
-                "Docstring above ChatView.examplePrompts must name the Quickstart alias 'bonsai-1.7b-2bit' so the rationale is one source-grep away.")
+        #expect(neighbourhood.contains("lfm2.5-1b-4bit"),
+                "Docstring above ChatView.examplePrompts must name the Quickstart alias 'lfm2.5-1b-4bit' so the rationale is one source-grep away.")
     }
 
     @Test("Docstring above examplePrompts mentions trade-up to Recommended")

--- a/apps/rapid-mac/scripts/build.sh
+++ b/apps/rapid-mac/scripts/build.sh
@@ -297,7 +297,7 @@ else
     echo "==> sidecar staged ($SIDECAR_VERSION)"
 fi
 
-# v0.7.1 #229: bundle the bonsai-1.7b-2bit weights inside the DMG so
+# v0.7.1 #229: bundle the lfm2.5-1b-4bit weights inside the DMG so
 # first-launch chat happens with zero HuggingFace round-trips. The HF
 # Hub snapshot layout (``models--<owner>--<name>``) lives under
 # ``Contents/Resources/models/hf-cache/hub/``; ``BundledModel.swift``
@@ -317,7 +317,7 @@ fi
 # 1.
 BUNDLE_MODEL="${BUNDLE_MODEL:-0}"
 SKIP_BUNDLED_MODEL="${SKIP_BUNDLED_MODEL:-0}"
-BUNDLED_MODEL_REPO="${BUNDLED_MODEL_REPO:-prism-ml/Ternary-Bonsai-1.7B-mlx-2bit}"
+BUNDLED_MODEL_REPO="${BUNDLED_MODEL_REPO:-mlx-community/LFM2.5-1.2B-Instruct-4bit}"
 # HF Hub cache encodes ``owner/name`` as ``models--owner--name`` —
 # each ``/`` becomes a literal ``--`` (double dash). Matches the
 # derivation in Sources/Rapid/Server/BundledModel.swift's

--- a/apps/rapid-mac/scripts/verify-recommendation-tiers.swift
+++ b/apps/rapid-mac/scripts/verify-recommendation-tiers.swift
@@ -305,12 +305,14 @@ for busy in [FakeServerState.ready, .starting, .crashed, .missing] {
 
 enum FakeDecision: Equatable { case start(String), promptDownload(String), skip(String) }
 
+func isRetiredStarter(_ alias: String) -> Bool { retiredStarters.contains(alias) }
+
 func decideResume(lastServedAlias: String?, cachedAliases: Set<String>,
                   serverState: FakeServerState, userOptedIn: Bool = true) -> FakeDecision {
     if !userOptedIn { return .skip("userOptedOut") }
     guard case .idle = serverState else { return .skip("serverNotIdle") }
     guard let alias = lastServedAlias else { return .skip("noResolvableAlias") }
-    if isStranded(alias) { return .skip("retiredStarter") }
+    if isRetiredStarter(alias) { return .skip("retiredStarter") }
     return cachedAliases.contains(alias) ? .start(alias) : .promptDownload(alias)
 }
 

--- a/apps/rapid-mac/scripts/verify-recommendation-tiers.swift
+++ b/apps/rapid-mac/scripts/verify-recommendation-tiers.swift
@@ -294,5 +294,46 @@ for busy in [FakeServerState.ready, .starting, .crashed, .missing] {
           "server busy (\(busy)) suppresses the card even for the stranded cohort")
 }
 
+// ---------------------------------------------------------------------------
+// Auto-start must not resume a retired starter
+//
+// Auto-start defaults to ON. Without this guard the rescue above is
+// decorative: the stranded user launches, we restart the broken model,
+// serverState leaves .idle, and Quickstart's third gate hides the card.
+// Mirrors the ordering in AutoStartDecision.decide — resolution first, then
+// the retired check, then the on-disk check.
+
+enum FakeDecision: Equatable { case start(String), promptDownload(String), skip(String) }
+
+func decideResume(lastServedAlias: String?, cachedAliases: Set<String>,
+                  serverState: FakeServerState, userOptedIn: Bool = true) -> FakeDecision {
+    if !userOptedIn { return .skip("userOptedOut") }
+    guard case .idle = serverState else { return .skip("serverNotIdle") }
+    guard let alias = lastServedAlias else { return .skip("noResolvableAlias") }
+    if isStranded(alias) { return .skip("retiredStarter") }
+    return cachedAliases.contains(alias) ? .start(alias) : .promptDownload(alias)
+}
+
+print("Auto-start vs retired starters:")
+check(decideResume(lastServedAlias: "bonsai-1.7b-2bit",
+                   cachedAliases: ["bonsai-1.7b-2bit"], serverState: .idle)
+        == .skip("retiredStarter"),
+      "retired starter on disk is NOT resumed — state stays .idle so the card can show")
+check(decideResume(lastServedAlias: "qwen3.5-9b-4bit",
+                   cachedAliases: ["qwen3.5-9b-4bit"], serverState: .idle)
+        == .start("qwen3.5-9b-4bit"),
+      "a normal model still auto-starts (the guard is not a blanket off-switch)")
+check(decideResume(lastServedAlias: "lfm2.5-1b-4bit",
+                   cachedAliases: ["lfm2.5-1b-4bit"], serverState: .idle)
+        == .start("lfm2.5-1b-4bit"),
+      "the CURRENT starter auto-starts normally")
+
+// The end-to-end property the two halves buy together.
+check(decideResume(lastServedAlias: "bonsai-1.7b-2bit",
+                   cachedAliases: ["bonsai-1.7b-2bit"], serverState: .idle)
+        == .skip("retiredStarter")
+      && isEligible(done: false, lastServedAlias: "bonsai-1.7b-2bit", serverState: .idle),
+      "end-to-end: stranded user launches → no auto-start → card IS shown")
+
 print(fails == 0 ? "\nALL PASS" : "\n\(fails) FAILURE(S)")
 exit(fails == 0 ? 0 : 1)

--- a/apps/rapid-mac/scripts/verify-recommendation-tiers.swift
+++ b/apps/rapid-mac/scripts/verify-recommendation-tiers.swift
@@ -239,5 +239,47 @@ let withFlag = serveArguments(alias: "gemma-4-26b-4bit", host: "127.0.0.1", port
 check(withFlag.suffix(5) == ["--no-mllm", "--kv-cache-dtype", "bf16", "--cache-memory-mb", "512"], "flags trail the array")
 check(withFlag.firstIndex(of: "--no-mllm")! > withFlag.firstIndex(of: "--cors-origins")!, "--no-mllm comes after --cors-origins (terminates nargs)")
 
+// ---------------------------------------------------------------------------
+// Quickstart eligibility — the retired-starter carve-out
+//
+// Faithful copy of QuickstartCoordinator.isEligible + retiredStarters. The
+// Python contract test pins the *contents* of retiredStarters against the
+// source text; it cannot execute the gate, so inverting the condition or
+// dropping the `done` check would stay green there. These cases are the
+// executable half.
+
+enum FakeServerState { case idle, stopped, ready, starting, crashed, missing }
+
+let retiredStarters: Set<String> = ["bonsai-1.7b-2bit"]
+
+func isEligible(done: Bool, lastServedAlias: String?, serverState: FakeServerState) -> Bool {
+    guard !done else { return false }
+    if let alias = lastServedAlias, !retiredStarters.contains(alias) {
+        return false
+    }
+    switch serverState {
+    case .idle, .stopped: return true
+    case .ready, .starting, .crashed, .missing: return false
+    }
+}
+
+print("Quickstart eligibility:")
+check(isEligible(done: false, lastServedAlias: nil, serverState: .idle),
+      "brand-new user (no serve yet) sees the card")
+check(isEligible(done: false, lastServedAlias: "bonsai-1.7b-2bit", serverState: .idle),
+      "stranded on the retired starter → card returns (the point of the carve-out)")
+check(!isEligible(done: false, lastServedAlias: "qwen3.5-9b-4bit", serverState: .idle),
+      "traded up to another model → never re-onboarded")
+check(!isEligible(done: false, lastServedAlias: "lfm2.5-1b-4bit", serverState: .idle),
+      "already on the CURRENT starter → not re-onboarded (no onboarding loop)")
+check(!isEligible(done: true, lastServedAlias: "bonsai-1.7b-2bit", serverState: .idle),
+      "done flag still wins over the carve-out — dismissal is permanent")
+check(!isEligible(done: true, lastServedAlias: nil, serverState: .idle),
+      "done flag wins for a new user too")
+for busy in [FakeServerState.ready, .starting, .crashed, .missing] {
+    check(!isEligible(done: false, lastServedAlias: "bonsai-1.7b-2bit", serverState: busy),
+          "server busy (\(busy)) suppresses the card even for the stranded cohort")
+}
+
 print(fails == 0 ? "\nALL PASS" : "\n\(fails) FAILURE(S)")
 exit(fails == 0 ? 0 : 1)

--- a/apps/rapid-mac/scripts/verify-recommendation-tiers.swift
+++ b/apps/rapid-mac/scripts/verify-recommendation-tiers.swift
@@ -308,11 +308,12 @@ enum FakeDecision: Equatable { case start(String), promptDownload(String), skip(
 func isRetiredStarter(_ alias: String) -> Bool { retiredStarters.contains(alias) }
 
 func decideResume(lastServedAlias: String?, cachedAliases: Set<String>,
-                  serverState: FakeServerState, userOptedIn: Bool = true) -> FakeDecision {
+                  serverState: FakeServerState, userOptedIn: Bool = true,
+                  quickstartDone: Bool = false) -> FakeDecision {
     if !userOptedIn { return .skip("userOptedOut") }
     guard case .idle = serverState else { return .skip("serverNotIdle") }
     guard let alias = lastServedAlias else { return .skip("noResolvableAlias") }
-    if isRetiredStarter(alias) { return .skip("retiredStarter") }
+    if !quickstartDone && isRetiredStarter(alias) { return .skip("retiredStarter") }
     return cachedAliases.contains(alias) ? .start(alias) : .promptDownload(alias)
 }
 
@@ -329,6 +330,14 @@ check(decideResume(lastServedAlias: "lfm2.5-1b-4bit",
                    cachedAliases: ["lfm2.5-1b-4bit"], serverState: .idle)
         == .start("lfm2.5-1b-4bit"),
       "the CURRENT starter auto-starts normally")
+
+check(decideResume(lastServedAlias: "bonsai-1.7b-2bit",
+                   cachedAliases: ["bonsai-1.7b-2bit"], serverState: .idle,
+                   quickstartDone: true)
+        == .start("bonsai-1.7b-2bit"),
+      "dismissed the rescue → auto-start comes back (no dead end: neither card nor start)")
+check(!isEligible(done: true, lastServedAlias: "bonsai-1.7b-2bit", serverState: .idle),
+      "…and the card stays down for them, so the two move together")
 
 // The end-to-end property the two halves buy together.
 check(decideResume(lastServedAlias: "bonsai-1.7b-2bit",

--- a/apps/rapid-mac/scripts/verify-recommendation-tiers.swift
+++ b/apps/rapid-mac/scripts/verify-recommendation-tiers.swift
@@ -252,9 +252,16 @@ enum FakeServerState { case idle, stopped, ready, starting, crashed, missing }
 
 let retiredStarters: Set<String> = ["bonsai-1.7b-2bit"]
 
-func isEligible(done: Bool, lastServedAlias: String?, serverState: FakeServerState) -> Bool {
+func isStranded(_ lastServedAlias: String?) -> Bool {
+    guard let alias = lastServedAlias else { return false }
+    return retiredStarters.contains(alias)
+}
+
+func isEligible(done: Bool, legacyDone: Bool = false, lastServedAlias: String?, serverState: FakeServerState) -> Bool {
     guard !done else { return false }
-    if let alias = lastServedAlias, !retiredStarters.contains(alias) {
+    let stranded = isStranded(lastServedAlias)
+    guard !(legacyDone && !stranded) else { return false }
+    if lastServedAlias != nil, !stranded {
         return false
     }
     switch serverState {
@@ -276,6 +283,12 @@ check(!isEligible(done: true, lastServedAlias: "bonsai-1.7b-2bit", serverState: 
       "done flag still wins over the carve-out — dismissal is permanent")
 check(!isEligible(done: true, lastServedAlias: nil, serverState: .idle),
       "done flag wins for a new user too")
+check(!isEligible(done: false, legacyDone: true, lastServedAlias: nil, serverState: .idle),
+      "dismissed under v1, never served → the v2 bump must NOT resurrect the card")
+check(!isEligible(done: false, legacyDone: true, lastServedAlias: "qwen3.5-9b-4bit", serverState: .idle),
+      "dismissed under v1 and on another model → still dismissed")
+check(isEligible(done: false, legacyDone: true, lastServedAlias: "bonsai-1.7b-2bit", serverState: .idle),
+      "dismissed under v1 but stranded on the retired starter → rescued anyway")
 for busy in [FakeServerState.ready, .starting, .crashed, .missing] {
     check(!isEligible(done: false, lastServedAlias: "bonsai-1.7b-2bit", serverState: busy),
           "server busy (\(busy)) suppresses the card even for the stranded cohort")

--- a/tests/test_ram_tier_recommendations_agree.py
+++ b/tests/test_ram_tier_recommendations_agree.py
@@ -568,3 +568,24 @@ def test_auto_start_skips_retired_starters():
         "the launch hook stopped passing the retired-starter predicate — the "
         "parameter defaults to 'never retired', so the guard silently no-ops"
     )
+
+    # Presence is not enough: the guard has to come BEFORE the on-disk
+    # check, or a cached retired starter returns .start and is resumed
+    # before anything looks at whether it was retired. Order is what a
+    # refactor moves silently, so pin it in both the production function
+    # and the executable copy that models it.
+    for path, label in (
+        (
+            REPO / "apps/rapid-mac/Sources/Rapid/Server/AutoStartDecision.swift",
+            "AutoStartDecision.decide",
+        ),
+        (VERIFY_SCRIPT, "decideResume (the executable copy)"),
+    ):
+        text = path.read_text()
+        guard_at = text.index("isRetiredStarter(alias)")
+        disk_at = text.index("cachedAliases.contains(alias)")
+        assert guard_at < disk_at, (
+            f"{label}: the retired-starter guard moved after the on-disk "
+            "check — a cached retired starter would be resumed before the "
+            "guard ever runs"
+        )

--- a/tests/test_ram_tier_recommendations_agree.py
+++ b/tests/test_ram_tier_recommendations_agree.py
@@ -333,3 +333,137 @@ def test_readme_one_shot_commands_carry_the_exact_flags():
             f"README's one-shot command for {alias} has {oneshot_flags}, "
             f"the app launches it with {app[alias]}"
         )
+
+
+# ---------------------------------------------------------------------------
+# The Quickstart starter — the RAM-blind first-run pick
+#
+# The tier tables above answer "what should this Mac run". They do NOT
+# cover the alias every brand-new user actually meets first: the
+# Quickstart starter, which is deliberately the same on every Mac.
+#
+# Nothing checked it. The starter shipped as ``bonsai-1.7b-2bit`` on the
+# strength of a tool-call eval (6/6 clean ``tool_calls``), and a community
+# report found it degenerating on an ordinary chat question — reproduced
+# 4/4, terminating 0/4, on plain-chat requests where the repetition guard
+# is inactive by design (it gates on ``request.has_tools``). The eval that
+# justified it measured a real capability that this slot is not judged on.
+#
+# These tests cannot judge output quality. What they can do is pin the
+# mechanical contract that a swap must not break: the alias has to exist,
+# its pinned HF repo has to be the one the registry resolves, and the
+# downloaded and bundled (airgapped) paths must not drift apart — a
+# divergence there means an offline build first-launches a model the
+# online path already rejected.
+
+QUICKSTART = REPO / "apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift"
+BUNDLED = REPO / "apps/rapid-mac/Sources/Rapid/Server/BundledModel.swift"
+
+
+def _parse_quickstart_default() -> tuple[str, str]:
+    """``(alias, hfRepo)`` from ``QuickstartCoordinator.defaultChoice``."""
+    text = QUICKSTART.read_text()
+    block = re.search(
+        r"static let defaultChoice = QuickstartModelChoice\((.*?)\n    \)",
+        text,
+        re.DOTALL,
+    )
+    assert block, "defaultChoice literal not found in QuickstartView.swift"
+    body = block.group(1)
+    alias = re.search(r'alias:\s*"([^"]+)"', body)
+    repo = re.search(r'hfRepo:\s*"([^"]+)"', body)
+    assert alias, "defaultChoice has no alias literal"
+    assert repo, "defaultChoice must pin hfRepo — it drives the byte-progress monitor"
+    return alias.group(1), repo.group(1)
+
+
+def _parse_bundled() -> tuple[str, str]:
+    """``(bundledAlias, bundledRepoID)`` from ``BundledModel.swift``."""
+    text = BUNDLED.read_text()
+    alias = re.search(r'static let bundledAlias: String = "([^"]+)"', text)
+    repo = re.search(r'static let bundledRepoID: String = "([^"]+)"', text)
+    assert alias and repo, (
+        "bundledAlias / bundledRepoID not found in BundledModel.swift"
+    )
+    return alias.group(1), repo.group(1)
+
+
+def test_quickstart_starter_exists():
+    """An unknown starter alias breaks first run for every new user."""
+    from vllm_mlx.model_aliases import list_aliases
+
+    alias, _ = _parse_quickstart_default()
+    assert alias in list_aliases(), f"Quickstart starter is unknown alias {alias!r}"
+
+
+def test_quickstart_pinned_repo_matches_the_registry():
+    """``hfRepo`` drives the bytes-on-disk progress bar. If it names a
+    different repo than the alias resolves to, the download completes
+    while the bar sits at 0% — the first-impression path, silently wrong."""
+    from vllm_mlx.model_aliases import resolve_model
+
+    alias, repo = _parse_quickstart_default()
+    assert resolve_model(alias) == repo, (
+        f"Quickstart pins hfRepo {repo!r} but {alias!r} resolves to "
+        f"{resolve_model(alias)!r}"
+    )
+
+
+def test_bundled_starter_tracks_the_quickstart_starter():
+    """``BundledModel`` is the airgapped twin of the Quickstart pick. The
+    two are one product decision reached by two paths; letting them drift
+    ships an offline build whose first launch uses the rejected model."""
+    q_alias, q_repo = _parse_quickstart_default()
+    b_alias, b_repo = _parse_bundled()
+    assert b_alias == q_alias, (
+        f"bundledAlias {b_alias!r} != Quickstart starter {q_alias!r}"
+    )
+    assert b_repo == q_repo, f"bundledRepoID {b_repo!r} != Quickstart hfRepo {q_repo!r}"
+
+
+def test_build_script_stages_the_bundled_repo():
+    """``BUNDLE_MODEL=1`` stages weights by repo id in build.sh. A stale
+    default there bundles one model while the app asks for another, and
+    the airgapped first launch falls through to a network pull it cannot
+    make."""
+    build_sh = (REPO / "apps/rapid-mac/scripts/build.sh").read_text()
+    default = re.search(
+        r'BUNDLED_MODEL_REPO="\$\{BUNDLED_MODEL_REPO:-([^}"]+)\}"', build_sh
+    )
+    assert default, "BUNDLED_MODEL_REPO default not found in build.sh"
+    _, b_repo = _parse_bundled()
+    assert default.group(1) == b_repo, (
+        f"build.sh stages {default.group(1)!r} but BundledModel wants {b_repo!r}"
+    )
+
+
+def _parse_retired_starters() -> set[str]:
+    text = QUICKSTART.read_text()
+    block = re.search(
+        r"static let retiredStarters: Set<String> = \[(.*?)\]", text, re.DOTALL
+    )
+    assert block, "retiredStarters literal not found in QuickstartView.swift"
+    return set(re.findall(r'"([^"]+)"', block.group(1)))
+
+
+def test_current_starter_is_not_itself_retired():
+    """``retiredStarters`` re-opens onboarding for anyone whose last-served
+    model is in it. Listing the *current* starter would re-show the wizard
+    to every user who just completed it — an onboarding loop, and the one
+    way this carve-out can strand people instead of rescuing them."""
+    alias, _ = _parse_quickstart_default()
+    assert alias not in _parse_retired_starters(), (
+        f"current starter {alias!r} is listed in retiredStarters — "
+        "every user who onboards onto it would be re-prompted forever"
+    )
+
+
+def test_retired_starters_are_real_aliases():
+    """A typo here silently rescues nobody: the carve-out compares against
+    the persisted ``rapid.serve.lastAlias``, so a misspelled entry just
+    never matches and the stranded cohort stays stranded."""
+    from vllm_mlx.model_aliases import list_aliases
+
+    known = list_aliases()
+    for alias in _parse_retired_starters():
+        assert alias in known, f"retiredStarters names unknown alias {alias!r}"

--- a/tests/test_ram_tier_recommendations_agree.py
+++ b/tests/test_ram_tier_recommendations_agree.py
@@ -563,10 +563,12 @@ def test_auto_start_skips_retired_starters():
 
     caller = (REPO / "apps/rapid-mac/Sources/Rapid/UI/ContentView.swift").read_text()
     assert (
-        "isRetiredStarter: QuickstartCoordinator.retiredStarters.contains" in caller
+        "!quickstart.done && QuickstartCoordinator.retiredStarters.contains" in caller
     ), (
-        "the launch hook stopped passing the retired-starter predicate — the "
-        "parameter defaults to 'never retired', so the guard silently no-ops"
+        "the launch hook stopped passing the rescue-gated retired-starter "
+        "predicate. Unconditional leaves a user who dismissed the rescue with "
+        "neither auto-start nor a card; absent, the guard silently no-ops "
+        "because the parameter defaults to 'never retired'"
     )
 
     # Presence is not enough: the guard has to come BEFORE the on-disk

--- a/tests/test_ram_tier_recommendations_agree.py
+++ b/tests/test_ram_tier_recommendations_agree.py
@@ -516,19 +516,22 @@ def test_eligibility_check_script_has_not_drifted_from_production():
     ``isEligible`` delegates to ``isStranded``, which reads
     ``retiredStarters``. Pinning only the first would let a new retired
     alias — the most likely future edit — land in production while the
-    executable cases keep exercising the old set."""
+    executable cases keep exercising the old set.
+
+    Bodies are compared whole. An earlier version sliced from the first
+    ``guard`` to skip signature differences, which meant anything inserted
+    *above* that guard — an early return, a new precondition — diverged
+    invisibly. The slice was never needed: ``_extract_func_body`` already
+    returns brace-matched bodies without the signature, so the two sides
+    are directly comparable."""
     for signature in ("func isEligible(", "func isStranded("):
         prod = _extract_func_body(QUICKSTART_PROD, signature)
         copy = _extract_func_body(VERIFY_SCRIPT, signature)
-        # The copy takes a fake ServerState enum, so compare the decision
-        # logic from the first statement rather than the signature.
-        head = "guard" if "isStranded" in signature else "guard !done"
-        prod_body, copy_body = prod[prod.index(head) :], copy[copy.index(head) :]
-        assert prod_body == copy_body, (
+        assert prod == copy, (
             f"{signature.strip('func (')} drifted between "
             "QuickstartView.swift and verify-recommendation-tiers.swift — "
             "the executable check would be testing stale logic.\n"
-            f"  production: {prod_body}\n  copy:       {copy_body}"
+            f"  production: {prod}\n  copy:       {copy}"
         )
 
     prod_set = _extract_retired_set(QUICKSTART_PROD)

--- a/tests/test_ram_tier_recommendations_agree.py
+++ b/tests/test_ram_tier_recommendations_agree.py
@@ -540,3 +540,31 @@ def test_eligibility_check_script_has_not_drifted_from_production():
         f"retiredStarters drifted: production {sorted(prod_set)} vs script "
         f"{sorted(copy_set)} — the rescued cohort differs from the tested one"
     )
+
+
+def test_auto_start_skips_retired_starters():
+    """Auto-start defaults to ON, so a stranded user's launch would resume
+    the broken model and push ``serverState`` off ``.idle`` — which is
+    exactly what Quickstart's third gate treats as "not a new user". The
+    rescue card would then never render for the cohort it exists for.
+
+    Pinned as source structure because ``AutoStartDecision.decide`` is not
+    reachable from Python; the executable half lives in
+    ``verify-recommendation-tiers.swift``."""
+    decision = (
+        REPO / "apps/rapid-mac/Sources/Rapid/Server/AutoStartDecision.swift"
+    ).read_text()
+    assert "case retiredStarter" in decision, (
+        "AutoStartDecision lost its retiredStarter skip reason"
+    )
+    assert "if isRetiredStarter(alias) {" in decision, (
+        "AutoStartDecision no longer guards against resuming a retired starter"
+    )
+
+    caller = (REPO / "apps/rapid-mac/Sources/Rapid/UI/ContentView.swift").read_text()
+    assert (
+        "isRetiredStarter: QuickstartCoordinator.retiredStarters.contains" in caller
+    ), (
+        "the launch hook stopped passing the retired-starter predicate — the "
+        "parameter defaults to 'never retired', so the guard silently no-ops"
+    )

--- a/tests/test_ram_tier_recommendations_agree.py
+++ b/tests/test_ram_tier_recommendations_agree.py
@@ -467,3 +467,51 @@ def test_retired_starters_are_real_aliases():
     known = list_aliases()
     for alias in _parse_retired_starters():
         assert alias in known, f"retiredStarters names unknown alias {alias!r}"
+
+
+VERIFY_SCRIPT = REPO / "apps/rapid-mac/scripts/verify-recommendation-tiers.swift"
+
+
+def _normalise_swift(body: str) -> str:
+    """Collapse whitespace and drop comments so a copy is compared on
+    behaviour, not formatting."""
+    body = re.sub(r"//[^\n]*", "", body)
+    return re.sub(r"\s+", " ", body).strip()
+
+
+def _extract_is_eligible(path: Path) -> str:
+    text = path.read_text()
+    start = text.index("func isEligible(")
+    depth, i = 0, text.index("{", start)
+    for j in range(i, len(text)):
+        if text[j] == "{":
+            depth += 1
+        elif text[j] == "}":
+            depth -= 1
+            if depth == 0:
+                return _normalise_swift(text[i : j + 1])
+    raise AssertionError(f"unbalanced isEligible body in {path}")
+
+
+def test_eligibility_check_script_has_not_drifted_from_production():
+    """``verify-recommendation-tiers.swift`` re-declares ``isEligible``
+    rather than importing it — the standalone-script pattern this repo uses
+    because the SPM test target is stripped. That copy is the only thing
+    that EXECUTES the gate, so if production changes and the copy does not,
+    the check passes while testing yesterday's logic.
+
+    Comparing the two bodies is what makes the copy trustworthy: edit one
+    without the other and this fails, naming both files."""
+    prod = _extract_is_eligible(
+        REPO / "apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift"
+    )
+    copy = _extract_is_eligible(VERIFY_SCRIPT)
+    # The copy takes a fake enum and a defaulted arg; compare the decision
+    # logic after the signature.
+    prod_body = prod[prod.index("guard !done") :]
+    copy_body = copy[copy.index("guard !done") :]
+    assert prod_body == copy_body, (
+        "isEligible drifted between QuickstartView.swift and "
+        "verify-recommendation-tiers.swift — the executable check would be "
+        f"testing stale logic.\n  production: {prod_body}\n  copy:       {copy_body}"
+    )

--- a/tests/test_ram_tier_recommendations_agree.py
+++ b/tests/test_ram_tier_recommendations_agree.py
@@ -479,9 +479,11 @@ def _normalise_swift(body: str) -> str:
     return re.sub(r"\s+", " ", body).strip()
 
 
-def _extract_is_eligible(path: Path) -> str:
+def _extract_func_body(path: Path, signature: str) -> str:
+    """Brace-matched body of the first ``func`` whose declaration starts
+    with ``signature``, comments and whitespace normalised away."""
     text = path.read_text()
-    start = text.index("func isEligible(")
+    start = text.index(signature)
     depth, i = 0, text.index("{", start)
     for j in range(i, len(text)):
         if text[j] == "{":
@@ -490,28 +492,48 @@ def _extract_is_eligible(path: Path) -> str:
             depth -= 1
             if depth == 0:
                 return _normalise_swift(text[i : j + 1])
-    raise AssertionError(f"unbalanced isEligible body in {path}")
+    raise AssertionError(f"unbalanced {signature!r} body in {path}")
+
+
+def _extract_retired_set(path: Path) -> set[str]:
+    text = path.read_text()
+    block = re.search(r"retiredStarters: Set<String> = \[(.*?)\]", text, re.DOTALL)
+    assert block, f"retiredStarters literal not found in {path}"
+    return set(re.findall(r'"([^"]+)"', block.group(1)))
+
+
+QUICKSTART_PROD = REPO / "apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift"
 
 
 def test_eligibility_check_script_has_not_drifted_from_production():
-    """``verify-recommendation-tiers.swift`` re-declares ``isEligible``
-    rather than importing it — the standalone-script pattern this repo uses
+    """``verify-recommendation-tiers.swift`` re-declares the gate rather
+    than importing it — the standalone-script pattern this repo uses
     because the SPM test target is stripped. That copy is the only thing
     that EXECUTES the gate, so if production changes and the copy does not,
     the check passes while testing yesterday's logic.
 
-    Comparing the two bodies is what makes the copy trustworthy: edit one
-    without the other and this fails, naming both files."""
-    prod = _extract_is_eligible(
-        REPO / "apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift"
-    )
-    copy = _extract_is_eligible(VERIFY_SCRIPT)
-    # The copy takes a fake enum and a defaulted arg; compare the decision
-    # logic after the signature.
-    prod_body = prod[prod.index("guard !done") :]
-    copy_body = copy[copy.index("guard !done") :]
-    assert prod_body == copy_body, (
-        "isEligible drifted between QuickstartView.swift and "
-        "verify-recommendation-tiers.swift — the executable check would be "
-        f"testing stale logic.\n  production: {prod_body}\n  copy:       {copy_body}"
+    The whole decision surface has to be pinned, not just the entry point:
+    ``isEligible`` delegates to ``isStranded``, which reads
+    ``retiredStarters``. Pinning only the first would let a new retired
+    alias — the most likely future edit — land in production while the
+    executable cases keep exercising the old set."""
+    for signature in ("func isEligible(", "func isStranded("):
+        prod = _extract_func_body(QUICKSTART_PROD, signature)
+        copy = _extract_func_body(VERIFY_SCRIPT, signature)
+        # The copy takes a fake ServerState enum, so compare the decision
+        # logic from the first statement rather than the signature.
+        head = "guard" if "isStranded" in signature else "guard !done"
+        prod_body, copy_body = prod[prod.index(head) :], copy[copy.index(head) :]
+        assert prod_body == copy_body, (
+            f"{signature.strip('func (')} drifted between "
+            "QuickstartView.swift and verify-recommendation-tiers.swift — "
+            "the executable check would be testing stale logic.\n"
+            f"  production: {prod_body}\n  copy:       {copy_body}"
+        )
+
+    prod_set = _extract_retired_set(QUICKSTART_PROD)
+    copy_set = _extract_retired_set(VERIFY_SCRIPT)
+    assert prod_set == copy_set, (
+        f"retiredStarters drifted: production {sorted(prod_set)} vs script "
+        f"{sorted(copy_set)} — the rescued cohort differs from the tested one"
     )


### PR DESCRIPTION
A community report: the Quickstart starter "completely falls apart on
basic multi-step reasoning", garbling words and then looping until it
hits the token cap. Reproduced on an M2 Pro against engine 0.12.4, plain
chat, no tools -- bonsai-1.7b-2bit degenerated 4/4 and terminated 0/4,
at two different token budgets. It doubles words inside the first line
("for for", "the the the the") and collapses into `\text{1} \text{1}` /
`1 + 9 = 1 + 9 =` until max_tokens cuts it off.

Two things make this the worst possible default. It is fast while being
wrong (66 tok/s), so it reads as "this app is broken" rather than "this
Mac is slow". And the runaway-generation guard cannot save it: both the
logits-level loop breaker and the streaming hard-stop are gated on
`request.has_tools` (scheduler.py:6063, :6392), and onboarding is plain
chat -- so nothing intervenes.

Starter is now lfm2.5-1b-4bit. Measured, same machine, same prompt:

  | pick             | download    | correct | terminates | first answer |
  | bonsai-1.7b-2bit | 484 MB/24 s |   0/4   |    0/4     |   never      |
  | lfm2.5-1b-4bit   | 637 MB/21 s |  16/16  |   16/16    |   1.1 s      |

The download worry that motivated a ~0.5 GB pick does not survive
measurement: 637 MB pulled *faster* than 484 MB (shard parallelism
dominates at this size).

Not the stronger lfm2.5-2.6b-4bit, which stays the 8-15 GB tier pick: it
routes through the qwen3 reasoning parser, so ~2/3 of its output is
hidden thinking -- 3.6 s to a first answer, most of it a blank screen.
For a first impression, instant-and-right beats smarter-but-silent.

Bonsai was picked (#1092) on a tool-call eval -- 6/6 clean tool_calls.
That measurement was real; it just covered something this slot is not
judged on. The docstring now states the criterion a starter is actually
held to, in priority order, so the next swap is not argued from
capability breadth again. Its ToolUseCapability entry is kept (the eval
stands) with the "first-run starter" note removed.

Reaching the users we already stranded: bumping the storage key to v2 is
not enough, because eligibility gate 2 reads "has served a model" as "is
not new" -- and these users did reach a running model, just a broken one.
`retiredStarters` carves out exactly that cohort. Anyone who traded up to
any other model is untouched.

The airgapped path moves in lock-step (BundledModel + build.sh),
otherwise a BUNDLE_MODEL=1 build first-launches the model the online path
just rejected.

Nothing verified the starter before this. The RAM tiers have a contract
test; the RAM-blind starter had none, which is how an unvetted default
shipped. Six new checks in the existing contract test: the alias exists,
its pinned hfRepo matches the registry (a mismatch leaves the progress
bar at 0% while the download succeeds), bundled tracks Quickstart,
build.sh stages what BundledModel wants, the current starter is not
itself listed as retired (an onboarding loop), and retired entries are
real aliases (a typo rescues nobody). Each was mutation-checked --
injected the drift, confirmed the test fails, restored.

Not fixed here: apps/rapid-mac has 242 test files that are not in
Package.swift at all, so `swift test` reports "no tests found" -- which is
how a test referencing a long-deleted property survived. #1482 (landed
today) closed the adjacent gap by adding a PR compile gate, but it does
not wire the test target, so the suite is compiled by nothing and run by
nothing. Package.swift documents that exclusion as deliberate pending a
v1.0 suite; re-wiring it is its own change, not a rider on a default swap.
The Swift-side edits here are therefore inert -- the enforcement for this
change lives in the Python contract test, which does run.

## Why

The default model every new user lands on is unusable, and our
activation funnel (235 installs -> ~27 engaged) has no other explanation
this good. Desktop users are invisible to telemetry, so this report is
one of the few real signals we get.

## Test plan

- `swift build` clean.
- `pytest tests/test_ram_tier_recommendations_agree.py` -- 17 passed.
- 6 mutation checks, each confirmed failing then restored.
- `ruff format` + `ruff check` clean.
- Repro + verification on mac mini (M2 Pro), engine 0.12.4, mlx-lm
  0.31.3: 4 bonsai runs (0 terminated), 16 lfm2.5-1b runs (all correct,
  all terminated), latency and download timings as tabled above.

