### PR TITLE
fix(rapid-mac): keep chat history order stable

### DIFF
--- a/.github/workflows/rapid-mac-ci.yml
+++ b/.github/workflows/rapid-mac-ci.yml
@@ -6,11 +6,11 @@
 # human cut a release. This job builds the Swift package on every PR that
 # touches the app, so a non-compiling change fails in review instead.
 #
-# Scope is deliberately just `swift build`: the SPM test target was stripped
-# (see apps/rapid-mac/Package.swift — the strip deleted the subsystems most of
-# the suite exercised, so it no longer compiles, and `swift test` can't resolve
-# `import Testing` in this toolchain). Re-wiring a fresh test suite is tracked
-# separately; a compile gate is the high-value floor that costs ~20s.
+# The SPM test target was stripped (see apps/rapid-mac/Package.swift — the strip
+# deleted the subsystems most of the suite exercised, so it no longer compiles,
+# and `swift test` can't resolve `import Testing` in this toolchain). Keep the
+# full-app compile gate and run focused dependency-free contract executables for
+# regressions that can be isolated from the removed test stack.
 name: rapid-mac CI
 
 on:
@@ -49,3 +49,6 @@ jobs:
       # nothing, so a regression in it would have reached a release.
       - name: verify recommendation + eligibility contracts
         run: swift scripts/verify-recommendation-tiers.swift
+
+      - name: Verify conversation history ordering
+        run: scripts/verify-conversation-ordering.sh

--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
@@ -111,18 +111,16 @@ final class ChatViewModel {
         guard messages.contains(where: { $0.role == .user }) else { return }
         let now = Date()
         let title = ConversationStore.title(from: messages)
-        if let idx = conversations.firstIndex(where: { $0.id == activeConversationID }) {
-            conversations[idx].messages = messages
-            conversations[idx].title = title
-            guard touching else {
-                // Content written back, position and timestamp left alone.
-                ConversationStore.save(conversations)
-                return
+        if conversations.contains(where: { $0.id == activeConversationID }) {
+            conversations = ConversationOrdering.updating(
+                conversations,
+                id: activeConversationID,
+                touching: touching,
+                at: now
+            ) { conversation in
+                conversation.messages = messages
+                conversation.title = title
             }
-            conversations[idx].updatedAt = now
-            // Bubble the just-touched conversation to the top.
-            let updated = conversations.remove(at: idx)
-            conversations.insert(updated, at: 0)
         } else {
             conversations.insert(
                 ChatConversation(

--- a/apps/rapid-mac/Sources/Rapid/Chat/ConversationHistory.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ConversationHistory.swift
@@ -11,6 +11,8 @@ struct ChatConversation: Identifiable, Codable, Equatable {
     var updatedAt: Date
 }
 
+extension ChatConversation: ConversationOrderingItem {}
+
 /// On-disk store for the conversation history. One JSON file under
 /// Application Support, keyed by bundle identifier so a dogfood-isolated
 /// instance (rewritten bundle id) keeps its own history separate from the

--- a/apps/rapid-mac/Sources/Rapid/Chat/ConversationOrdering.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ConversationOrdering.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+/// The small piece of conversation-history mutation that determines sidebar
+/// order. Keeping it independent of ``ChatViewModel`` makes the navigation
+/// contract executable without constructing the streaming stack.
+protocol ConversationOrderingItem: Identifiable {
+    var updatedAt: Date { get set }
+}
+
+enum ConversationOrdering {
+    /// Update an existing row and, only for real activity, mark it recent.
+    ///
+    /// Selecting a conversation snapshots the row being left, but that is a
+    /// navigation event rather than activity. In that case ``touching`` is
+    /// false and both its timestamp and array position must remain unchanged.
+    static func updating<Item: ConversationOrderingItem>(
+        _ items: [Item],
+        id: Item.ID,
+        touching: Bool,
+        at now: Date,
+        update: (inout Item) -> Void
+    ) -> [Item] where Item.ID: Equatable {
+        guard let index = items.firstIndex(where: { $0.id == id }) else {
+            return items
+        }
+
+        var result = items
+        update(&result[index])
+        guard touching else { return result }
+
+        result[index].updatedAt = now
+        let touched = result.remove(at: index)
+        result.insert(touched, at: 0)
+        return result
+    }
+}

--- a/apps/rapid-mac/scripts/verify-conversation-ordering.sh
+++ b/apps/rapid-mac/scripts/verify-conversation-ordering.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -eu
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+CACHE="$ROOT/.build/conversation-ordering-module-cache"
+BINARY="$ROOT/.build/conversation-ordering-check"
+
+mkdir -p "$CACHE"
+CLANG_MODULE_CACHE_PATH="$CACHE" \
+SWIFT_MODULECACHE_PATH="$CACHE" \
+swiftc -parse-as-library \
+    "$ROOT/Sources/Rapid/Chat/ConversationOrdering.swift" \
+    "$ROOT/scripts/verify-conversation-ordering.swift" \
+    -o "$BINARY"
+
+"$BINARY"

--- a/apps/rapid-mac/scripts/verify-conversation-ordering.swift
+++ b/apps/rapid-mac/scripts/verify-conversation-ordering.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+private struct StubConversation: ConversationOrderingItem, Equatable {
+    let id: String
+    var updatedAt: Date
+    var content: String
+}
+
+@main
+private enum VerifyConversationOrdering {
+    static func main() {
+        let old = Date(timeIntervalSince1970: 100)
+        let middle = Date(timeIntervalSince1970: 200)
+        let newest = Date(timeIntervalSince1970: 300)
+        let activityTime = Date(timeIntervalSince1970: 400)
+        let initial = [
+            StubConversation(id: "A", updatedAt: newest, content: "a"),
+            StubConversation(id: "B", updatedAt: middle, content: "b"),
+            StubConversation(id: "C", updatedAt: old, content: "c"),
+        ]
+
+        // Reproduction contract: leaving A to view B snapshots A's content,
+        // but browsing must not make A newer or move any row. Repeating the
+        // operation for B is the sequence that used to produce B,A,C.
+        let afterLeavingA = ConversationOrdering.updating(
+            initial, id: "A", touching: false, at: activityTime
+        ) { $0.content = "a-snapshot" }
+        let afterLeavingB = ConversationOrdering.updating(
+            afterLeavingA, id: "B", touching: false, at: activityTime
+        ) { $0.content = "b-snapshot" }
+
+        precondition(afterLeavingB.map(\.id) == ["A", "B", "C"],
+                     "selecting older chats must not reorder the sidebar")
+        precondition(afterLeavingB[0].updatedAt == newest,
+                     "navigation must not refresh updatedAt")
+        precondition(afterLeavingB[1].updatedAt == middle,
+                     "navigation must preserve the departed row timestamp")
+        precondition(afterLeavingB[1].content == "b-snapshot",
+                     "non-touching snapshots must still update content")
+
+        let afterActivity = ConversationOrdering.updating(
+            afterLeavingB, id: "C", touching: true, at: activityTime
+        ) { $0.content = "c-new-turn" }
+        precondition(afterActivity.map(\.id) == ["C", "A", "B"],
+                     "real conversation activity must move its row to the top")
+        precondition(afterActivity[0].updatedAt == activityTime,
+                     "real conversation activity must refresh updatedAt")
+
+        print("conversation ordering contract: ok")
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Locks the rapid-mac conversation-history ordering rule into a small, executable production helper. Browsing between saved chats updates the archived message snapshot without changing `updatedAt` or row position; real transcript activity still refreshes the timestamp and moves that chat to the top.

It adds a dependency-free regression executable and runs it from the rapid-mac PR workflow alongside `swift build`.

## Why is this needed?

A released desktop build treated navigation as conversation activity. Leaving one old chat to open another refreshed the departing chat and moved it to the top, so repeated clicks visibly shuffled the sidebar. Main contains the behavioral correction, but the stripped SwiftPM test target left that user-facing fix without an executable regression gate. This PR makes the corrected rule directly testable and prevents the ordering bug from returning.

## AI assistance disclosure

Codex reproduced the state transition, extracted the ordering helper, wrote the standalone regression contract, and connected it to CI. Every changed file was inspected in the final diff; the contract was run locally and the full rapid-mac Swift package was compiled successfully.

> By submitting this PR I confirm I can explain the intent, risk, and behavior of every non-generated change in this PR. For generated sections, I have identified the assistance above and verified the resulting behavior.

## Test plan

- [x] Reproduced the old `A,B,C → B,A,C` ordering drift with consecutive history selections.
- [x] Ran `apps/rapid-mac/scripts/verify-conversation-ordering.sh`.
- [x] Ran `swift build` from `apps/rapid-mac`.
- [x] Ran `git diff --check`.

## Checklist

- [x] Relevant tests pass locally.
- [x] No Python files changed; Python lint and pytest are not applicable.
- [x] No documentation update is required for this internal correctness fix.
- [x] No breaking API changes.
