### PR TITLE
fix(rapid-mac): stop smoke.sh hanging forever — fake CLI contract + pipe EOF

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Server/ModelCatalog.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ModelCatalog.swift
@@ -539,6 +539,16 @@ enum ModelCatalog {
             processBox.set(task)
             do {
                 try task.run()
+                // The child now holds its own dup of both write ends, so
+                // drop OUR copies. While the parent keeps a write end
+                // open the pipe can never reach EOF — ``readPipeData``
+                // then blocks forever even after the child exits, and
+                // ``terminationHandler``'s ``drainGroup.wait()`` deadlocks
+                // the continuation with it. The launch-failure branch
+                // below has always closed them; the success path is where
+                // a long-lived or hung child actually makes it matter.
+                try? stdout.fileHandleForWriting.close()
+                try? stderr.fileHandleForWriting.close()
                 processBox.terminateIfCancelled()
             } catch {
                 // Close write ends so the drainers see EOF instead

--- a/apps/rapid-mac/scripts/fake-rapid-mlx.sh
+++ b/apps/rapid-mac/scripts/fake-rapid-mlx.sh
@@ -193,8 +193,66 @@ class Handler(BaseHTTPRequestHandler):
         self.wfile.write(payload)
 
 
+FAKE_REPO = "fake-org/fake-repo"
+
+
+def _emit_catalog(subcommand, alias):
+    """Print the canned output for a NON-``serve`` subcommand.
+
+    ``ModelCatalog`` shells out to ``models`` / ``ls`` / ``info`` to
+    populate the picker, and every one of those is a print-and-exit
+    command on the real binary. The formats below mirror what
+    ``ModelCatalog.parseAvailable`` / ``parseCached`` / ``parseInfoRepo``
+    actually parse (column-aligned rows behind a header + divider; an
+    ``Alias: <alias> -> <repo>`` line for ``info``).
+
+    Returns True when ``subcommand`` was handled, so ``main`` knows not
+    to fall through to the server.
+    """
+    if subcommand == "models":
+        print("Available models")
+        print("Alias                  Parser           Reasoning")
+        print("---------------------  ---------------  ---------")
+        print("fake-alias             hermes           qwen3")
+        return True
+    if subcommand == "ls":
+        print("Cached models")
+        print("Alias                  Repo                   Size")
+        print("---------------------  ---------------------  ------")
+        print(f"fake-alias             {FAKE_REPO}        1.2 GB")
+        return True
+    if subcommand == "info":
+        print(f"Alias: {alias} -> {FAKE_REPO}")
+        return True
+    return False
+
+
 def main():
     args = _parse_args(sys.argv)
+
+    # Only ``serve`` runs a server. Every other subcommand prints and
+    # exits, exactly like the real binary.
+    #
+    # This branch is the whole point of parsing ``subcommand``: without
+    # it the fake ignored the verb and started the HTTP server for ANY
+    # invocation. ``ModelCatalog.runRapidMlx(args: ["models"])`` (the
+    # catalog refresh on app launch) therefore spawned a child that
+    # never exited, so its pipe write ends never closed, so both
+    # ``readPipeData`` drainers blocked on an EOF that could not arrive
+    # and ``terminationHandler``'s ``drainGroup.wait()`` deadlocked the
+    # continuation. Net effect: ``scripts/smoke.sh`` hung forever
+    # instead of running its chat-lifecycle assertions, and left a
+    # stray listener squatting :8000 (which the next Rapid launch's
+    # PortSweep would then reap — along with any real rapid-mlx the
+    # developer had running on that port).
+    #
+    # Default-deny is deliberate: an unknown verb exits 0 with no
+    # output rather than falling through to the server, so a future
+    # ``ModelCatalog`` subcommand can't resurrect the hang.
+    if args.subcommand != "serve":
+        _emit_catalog(args.subcommand, args.alias)
+        sys.exit(0)
+
     # Match the real server's startup banner shape closely enough
     # that DownloadProgress's "Loading model with" detection fires
     # — this lets the SwiftUI overlay flip out of the spinner state

--- a/apps/rapid-mac/scripts/smoke.sh
+++ b/apps/rapid-mac/scripts/smoke.sh
@@ -1,21 +1,21 @@
 #!/usr/bin/env bash
 # smoke.sh — fast (sub-2s) end-to-end smoke for Rapid.app.
 #
-# Compiles the app and runs the chat lifecycle directive against the fake
-# rapid-mlx, so a code change can be verified without standing up a real model.
+# Compiles the app and checks the fake rapid-mlx honours the CLI contract
+# ``ModelCatalog`` depends on, so a code change can be verified in seconds
+# without standing up a real model.
 #
 # What it covers:
 #   * swift build (the package compiles)
-#   * ServerManager spawn / health-poll / state transitions
-#     (.idle → .starting → .ready → .stopped)
-#   * ChatStreamClient SSE decode (reasoning + content lanes,
-#     finish_reason routing, clean [DONE])
+#   * fake-rapid-mlx CLI contract: `models` / `ls` / `info` print and exit;
+#     an unknown verb exits rather than falling through to the server
 #
 # What it does NOT cover:
 #   * The Swift Testing unit suite — the SPM test target was stripped
-#     (see Package.swift), so `swift test` finds no tests / can't build. A
-#     fresh suite is tracked separately; until then this smoke is build +
-#     chat-lifecycle only.
+#     (see Package.swift), so `swift test` finds no tests / can't build.
+#   * The chat lifecycle (ServerManager state machine, ChatStreamClient SSE
+#     decode). The `RAPID_TEST_DRIVER` hook this script used to drive does
+#     not exist in `Sources/` — see the note at the foot of this file.
 #   * Real model inference (use ``RAPID_BIN=/opt/homebrew/bin/rapid-mlx``
 #     or unset RAPID_BIN for that)
 #   * SwiftUI view tree (Step 2 — ViewInspector)
@@ -32,23 +32,153 @@ echo "==> swift build"
 swift build >/dev/null
 
 echo
-echo "==> chat lifecycle vs fake rapid-mlx"
-start_ts="$(date +%s)"
-RAPID_BIN="$ROOT/scripts/fake-rapid-mlx.sh" \
-    RAPID_TEST_DRIVER='chat:fake-alias:hi there' \
-    .build/debug/Rapid >/tmp/rapid-smoke.log 2>&1
-end_ts="$(date +%s)"
+echo "==> fake rapid-mlx CLI contract"
+# ``ModelCatalog`` shells out to the rapid-mlx CLI for its catalog, and the
+# fake stands in for that binary. Assert the fake honours the same
+# print-and-exit contract the real one does, because when it does NOT the
+# failure is invisible and expensive: the fake used to ignore its subcommand
+# and start the HTTP server for EVERY verb, so ``runRapidMlx(args: ["models"])``
+# spawned a child that never exited, both pipe drainers blocked on an EOF that
+# could not arrive, and the caller deadlocked — while a stray listener squatted
+# :8000 for the next PortSweep to reap along with any real rapid-mlx the
+# developer had running there.
+#
+# Each probe is bounded so a regression fails in seconds naming the offending
+# verb instead of hanging the script (and CI) indefinitely.
+FAKE="$ROOT/scripts/fake-rapid-mlx.sh"
+PROBE_TIMEOUT_S="${PROBE_TIMEOUT_S:-10}"
 
-if ! grep -q "post-stop state=stopped" /tmp/rapid-smoke.log; then
-    echo "FAIL — chat smoke did not reach stopped state"
-    tail -20 /tmp/rapid-smoke.log
+# Validate the override before it is used as a loop bound. `[ x -ge y ]` on a
+# non-integer fails every iteration, and because `run_bounded` is called from
+# an `if !` condition `errexit` is suppressed there — so a typo like
+# `PROBE_TIMEOUT_S=10s` would silently disable the watchdog and let a hung
+# child run forever, which is precisely what this script exists to prevent.
+case "$PROBE_TIMEOUT_S" in
+    ''|*[!0-9]*)
+        echo "PROBE_TIMEOUT_S must be a positive integer number of seconds (got '$PROBE_TIMEOUT_S')" >&2
+        exit 2
+        ;;
+esac
+if [ "$PROBE_TIMEOUT_S" -lt 1 ]; then
+    echo "PROBE_TIMEOUT_S must be >= 1 (got '$PROBE_TIMEOUT_S')" >&2
+    exit 2
+fi
+
+# Bounded run, built from shell builtins only.
+#
+# Deliberately NOT `timeout(1)`: that is GNU coreutils, which stock macOS does
+# not ship (no /usr/bin/timeout, no BSD equivalent). Depending on it would make
+# this script exit 127 on any Mac without `brew install coreutils` — i.e. the
+# guard against hangs would itself be the thing that always fails.
+#
+# Also deliberately SIGKILL rather than coreutils' default SIGTERM: a regressed
+# fake that installs a SIGTERM handler (or blocks in a signal-unsafe spot) could
+# ignore a polite signal and hang the watchdog — reintroducing the exact failure
+# this is here to bound. Nothing here needs a graceful shutdown.
+#
+# Writes combined output to $2. Returns 124 on timeout, else the child's status.
+run_bounded() {
+    run_bounded_secs="$1"
+    run_bounded_out="$2"
+    shift 2
+    "$@" >"$run_bounded_out" 2>&1 &
+    run_bounded_pid=$!
+    run_bounded_waited=0
+    while kill -0 "$run_bounded_pid" 2>/dev/null; do
+        if [ "$run_bounded_waited" -ge "$run_bounded_secs" ]; then
+            # Signal the JOB, not the pid. A raw `kill -9 "$pid"` races pid
+            # recycling: the probe can exit and be reaped between the liveness
+            # test and the signal, by which point the number may belong to an
+            # unrelated process. `%%` resolves through bash's job table, which
+            # refuses ("no such job") once the job is gone — so the worst case
+            # is a no-op instead of killing a bystander.
+            kill -9 %% 2>/dev/null || true
+            # `wait` by pid is safe even if it is stale: wait never signals.
+            wait "$run_bounded_pid" 2>/dev/null || true
+            return 124
+        fi
+        sleep 1
+        run_bounded_waited=$((run_bounded_waited + 1))
+    done
+    # By pid, not `%%` — bash drops the job from its table as soon as it is
+    # reaped, and for a fast child that happens before we get here, so a
+    # jobspec `wait` would fail with "no such job" and lose the exit status.
+    wait "$run_bounded_pid"
+}
+
+probe_out="$(mktemp -t rapid-smoke-probe)"
+
+# Reap any still-running probe on the way out, however we leave.
+#
+# Why this matters: a regressed fake is a *server*. Non-interactive bash starts
+# asynchronous commands with SIGINT ignored and Python inherits that
+# disposition, so Ctrl-C kills this script while the child keeps listening on
+# :8000 — and the next Rapid launch's PortSweep then reaps whatever holds that
+# port, which may be the developer's own rapid-mlx. Cleanup therefore has to
+# cover interrupts, not just a normal exit.
+#
+# Why a jobspec rather than a `probe_child` variable holding `$!`: publishing
+# the pid is not atomic. A signal can be delivered between `cmd &` and the
+# assignment on the next line, running the trap while the variable is still
+# empty and leaking exactly the orphan this is meant to prevent. A stored pid
+# is also unsafe to signal later — once bash has reaped the job the number can
+# be recycled to an unrelated process, and cleanup runs twice (INT/TERM calls
+# it, then `exit` re-triggers it via EXIT). A jobspec has neither problem: it is
+# resolved against bash's job table at signal time, exists from the moment the
+# job is created, and is refused outright ("no such job") once reaped.
+#
+# Known residual: `%%` is positional, so it names "the most recent job", and
+# this script assumes that is the probe. That holds unless the shell already
+# had a job — a non-interactive bash sources `$BASH_ENV`, so a startup file
+# that backgrounds a helper would leave one. Matching by command text
+# (`%?fake-rapid-mlx`) does NOT fix this: bash records a job's UNEXPANDED
+# source text, which here is the literal `"$@"`, so the pattern can never
+# match (verified on 3.2.57). The alternatives are worse — a `$!` variable
+# reintroduces the publication race, and gating the kill on that variable
+# means leaking the orphan whenever the race is lost. Killing at most one
+# stray background job in a dev script, under a shell configuration this repo
+# does not use, is the better trade.
+cleanup() {
+    kill -9 %% 2>/dev/null || true
+    rm -f "$probe_out"
+}
+trap cleanup EXIT
+# 128 + signal number, the conventional shell exit status for a signalled run.
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
+
+probe_exits() {
+    verb="$1"; shift
+    expect="$1"; shift
+    if ! run_bounded "$PROBE_TIMEOUT_S" "$probe_out" "$FAKE" "$verb" "$@"; then
+        echo "FAIL — '$verb' did not exit cleanly within ${PROBE_TIMEOUT_S}s (it must print and exit, never serve)"
+        head -10 "$probe_out"
+        exit 1
+    fi
+    if ! grep -q "$expect" "$probe_out"; then
+        echo "FAIL — '$verb' output did not contain '$expect'"
+        head -10 "$probe_out"
+        exit 1
+    fi
+    echo "    ok  $verb"
+}
+probe_exits models "fake-alias"
+probe_exits ls "fake-org/fake-repo"
+probe_exits info "Alias: fake-alias" fake-alias
+# Default-deny: an unknown verb must still exit rather than fall through to
+# the server, so a future ModelCatalog subcommand cannot resurrect the hang.
+if ! run_bounded "$PROBE_TIMEOUT_S" "$probe_out" "$FAKE" some-future-verb; then
+    echo "FAIL — unknown verb did not exit within ${PROBE_TIMEOUT_S}s"
     exit 1
 fi
-if ! grep -q "finished reason=stop" /tmp/rapid-smoke.log; then
-    echo "FAIL — chat smoke did not reach finish_reason=stop"
-    tail -20 /tmp/rapid-smoke.log
-    exit 1
-fi
-content_chars="$(grep -E '^test_driver: total_content_chars=' /tmp/rapid-smoke.log | tail -1 | cut -d= -f2)"
-reasoning_chars="$(grep -E '^test_driver: total_reasoning_chars=' /tmp/rapid-smoke.log | tail -1 | cut -d= -f2)"
-echo "OK content=${content_chars}ch reasoning=${reasoning_chars}ch wall=$((end_ts - start_ts))s"
+echo "    ok  unknown verb exits (default-deny)"
+
+echo
+echo "OK — package compiles, fake CLI contract holds"
+# NOT covered here: the chat lifecycle (ServerManager state machine +
+# ChatStreamClient SSE decode). This script used to drive it via
+# ``RAPID_TEST_DRIVER``, but no such hook exists in ``Sources/`` — it was part
+# of the subsystem strip and only the caller survived the monorepo import
+# (#1406), so that invocation launched a plain GUI app that never exited and
+# hung the script forever. Reinstating the harness is tracked separately;
+# until then this script does not pretend to cover it.


### PR DESCRIPTION
Closes #1489.

## Why

`scripts/smoke.sh` never completes on a clean tree — measured at 3m26s, ended only by SIGKILL. #1482 swapped its dead `swift test` line for `swift build`, which unmasked two defects that early failure had been hiding, plus a third: the harness the script drives no longer exists.

A dev gate that hangs silently is worse than one that fails fast, and each run left a stray listener on `:8000` for the next `PortSweep` to reap — along with any real `rapid-mlx` the developer had running there. That happened during this investigation.

## What changed

**1. `fake-rapid-mlx.sh` now branches on its subcommand.** It parsed a `subcommand` positional and never used it (`grep args.subcommand` → 0 hits), so every verb started the HTTP server and `ModelCatalog.runRapidMlx(args: ["models"])` spawned a child that never exited. Now only `serve` serves; `models` / `ls` / `info` print output the existing parsers accept (`parseAvailable` / `parseCached` / `parseInfoRepo`) and exit 0. Unknown verbs are default-deny, so a future `ModelCatalog` subcommand cannot resurrect the hang.

**2. `ModelCatalog.runRapidMlx` closes the parent's pipe write ends on the success path.** The launch-failure branch always did; the success path did not. While the parent holds a write end the pipe cannot reach EOF, so both `readPipeData` drainers block even after the child exits and `terminationHandler`'s `drainGroup.wait()` deadlocks the continuation. Confirmed with `sample`: two threads parked at `ModelCatalog.swift:566`, child gone, two pipe FDs still open.

**3. The dead chat-lifecycle block is removed, not left pretending.** It drove `RAPID_TEST_DRIVER`, which appears nowhere in `Sources/` — only at `smoke.sh:38`. Across full history it exists only in the monorepo import (#1406): the hook was part of the stripped subsystems and just the caller survived. In its place the script asserts the fake's CLI contract, which is the regression guard for (1).

## Notes on the watchdog

Bounding the probes is deliberately **not** `timeout(1)` — that is GNU coreutils and stock macOS ships no equivalent (`/usr/bin/timeout` and `/bin/timeout` both absent), so depending on it would make the anti-hang guard itself exit 127 on any Mac without `brew install coreutils`.

Every `kill` goes through a jobspec (`%%`), never a raw pid: publishing `$!` is not atomic (a signal between `cmd &` and the assignment runs the trap with an empty variable), and a stored pid can be recycled between the liveness test and the signal. `%%` is resolved against bash's job table at signal time and refused once reaped, so the worst case is a no-op instead of SIGKILLing a bystander. `wait` still takes the pid — bash drops a reaped job before a fast child's `wait` runs, so a jobspec `wait` would lose the exit status, and `wait` never signals.

## Test plan

- [x] `smoke.sh` exits 0 in **0.6s** — the header's long-claimed "sub-2s" is true for the first time
- [x] Passes with `PATH=/usr/bin:/bin:/usr/sbin:/sbin` (no coreutils), proving no GNU dependency
- [x] Negative control: reverting the fake fix alone → exit 1 in **10.5s** with `FAIL — 'models' did not exit cleanly within 10s`, and **0 listeners left on :8000**
- [x] SIGTERM mid-probe → exit 143, 0 listeners
- [x] Real Ctrl-C through a pty → 0 listeners
- [x] Clean exit produces no stray stderr (cleanup with no live job)
- [x] `PROBE_TIMEOUT_S` validation: `'10s'` / `'0'` / `'-1'` / `'abc'` all exit 2 with a named error; `''` uses the default; `3` works
- [x] Watchdog exit-status propagation on bash 3.2.57 (what `/bin/bash` **and** `env bash` resolve to on macOS): timeout → 124, success → 0, failure → 1, `exit 42` → 42
- [x] `kill -9 %%` after a reap reports "no such job" rather than signalling
- [x] `swift build -c release` clean; `bash -n` clean on both scripts

Codex review: 4 rounds, findings on portability, signal choice, orphan-on-interrupt, `PROBE_TIMEOUT_S` validation and pid recycling all accepted and fixed.

**Known residual:** any pid-based shell watchdog retains a theoretical recycling window; the jobspec kills close it for every path that signals, and `wait`-by-pid cannot signal. Not further reducible in bash 3.2 without job-control process groups.

**Explicitly not fixed here:** a real chat-lifecycle smoke. That needs a `TestDriver` hook to be written — a feature, not a script fix — and is tracked in #1489.