### PR TITLE
fix(desktop): retain mlx-vlm coherence cap

### DIFF
--- a/apps/rapid-mac/scripts/build-sidecar.sh
+++ b/apps/rapid-mac/scripts/build-sidecar.sh
@@ -270,7 +270,7 @@ fi
 # path. All other eager deps (transformers, requests, huggingface_hub,
 # safetensors, numpy, mlx) are already bundled by rapid-mlx's own
 # install above, so Pillow is the only additional dep we need.
-# We pin to the same ``>=0.6.3,!=0.6.4`` range that rapid-mlx's
+# We pin to the same ``>=0.6.3,!=0.6.4,<0.7`` range that rapid-mlx's
 # pyproject.toml [vision] extras pin so the bundled mlx-vlm tracks the
 # DiffusionGemma + gemma4_unified architecture support the loader needs.
 # (0.6.4 excluded: garbage vision output — rapid-mlx 0.11.1 serves Bonsai
@@ -283,7 +283,7 @@ echo "==> bundling mlx-vlm --no-deps + Pillow (gemma-4 + DiffusionGemma loader p
     --no-compile \
     --no-deps \
     --upgrade \
-    'mlx-vlm>=0.6.3,!=0.6.4' \
+    'mlx-vlm>=0.6.3,!=0.6.4,<0.7' \
     'Pillow>=10.0'
 
 # ----- step 3: strip dev / unused artifacts ----------------------------

--- a/tests/test_mlx_bound_guard.py
+++ b/tests/test_mlx_bound_guard.py
@@ -9,9 +9,12 @@ and the attestation check.
 from __future__ import annotations
 
 import importlib.util
+import re
 from pathlib import Path
 
 import pytest
+import tomllib
+from packaging.requirements import Requirement
 
 # Load the script directly (scripts/ is not an importable package).
 _SPEC = importlib.util.spec_from_file_location(
@@ -20,6 +23,8 @@ _SPEC = importlib.util.spec_from_file_location(
 )
 guard = importlib.util.module_from_spec(_SPEC)
 _SPEC.loader.exec_module(guard)
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
 
 
 _CORE = """\
@@ -105,6 +110,26 @@ class TestExtractMlxBounds:
         assert {SpecifierSet(s) for s in bounds["mlx-lm"]} == {
             SpecifierSet(">=0.31.3,<0.32")
         }
+
+
+def test_desktop_sidecar_uses_validated_mlx_vlm_bound():
+    """The signed Desktop bundle must not bypass the coherence-gated cap."""
+    pyproject = tomllib.loads((_REPO_ROOT / "pyproject.toml").read_text())
+    vision_specs = [
+        Requirement(spec)
+        for spec in pyproject["project"]["optional-dependencies"]["vision"]
+        if Requirement(spec).name == "mlx-vlm"
+    ]
+    assert len(vision_specs) == 1
+
+    sidecar = (
+        _REPO_ROOT / "apps" / "rapid-mac" / "scripts" / "build-sidecar.sh"
+    ).read_text()
+    matches = re.findall(r"['\"](mlx-vlm[^'\"]*)['\"]", sidecar)
+    assert len(matches) == 1, "expected exactly one mlx-vlm sidecar requirement"
+
+    desktop_spec = Requirement(matches[0])
+    assert desktop_spec.specifier == vision_specs[0].specifier
 
 
 class TestStrictMode:


### PR DESCRIPTION
## What changed

- add the validated `<0.7` mlx-vlm upper bound to the signed Desktop sidecar build
- add a regression test that semantically compares the sidecar requirement with the root `vision` extra

## Why

The Desktop build used `pip install --upgrade` with an uncapped mlx-vlm requirement, allowing a future 0.7+ release to bypass the repository coherence gate.

## Test plan

- [x] `python -m pytest -q tests/test_mlx_bound_guard.py tests/test_vision_extra_install.py` — 41 passed
- [x] `ruff check tests/test_mlx_bound_guard.py`
- [x] `bash -n apps/rapid-mac/scripts/build-sidecar.sh`
- [x] `git diff --check`