### PR TITLE
fix(rapid-mac): hide known-broken multimodal-only aliases from the model picker

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Server/ModelPickerVisibility.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ModelPickerVisibility.swift
@@ -34,6 +34,50 @@ enum ModelPickerVisibility {
     /// ``AppearanceConfig`` and the sidebar collapsed-section flags.
     static let showAllStorageKey: String = "rapid.picker.show_all_models.v1"
 
+    /// Aliases that are KNOWN-BROKEN for plain text chat on the bundled
+    /// engine and must never be offered as a selectable chat model.
+    ///
+    /// These are small **multimodal-only** checkpoints whose only small
+    /// SKU ships as a VLM. Serving them for text through the bundled
+    /// rapid-mlx routes to the mlx-vlm lane, where they either hang or
+    /// return incoherent output — the exact "switched the picker to X
+    /// and it spun forever with zero tokens" footgun. Evidence (issue
+    /// #1367, reproduced on a real macos-14 M1 runner, rapid-mlx 0.11.4
+    /// / mlx-vlm 0.6.3, and pinned in ``ci.yml``'s L1-smoke comment):
+    ///
+    ///   * ``gemma-4-e2b-*`` (the Gemma nano "effective-2B" MatFormer):
+    ///     **0/6** golden — total incoherence — on BOTH the mlx-vlm lane
+    ///     AND the ``--no-mllm`` text lane. It is not a quant artifact
+    ///     (0/6 is arch-level), so every e2b SKU shares the break:
+    ///     4/6/8-bit and the ``-assistant`` bf16 tune.
+    ///   * ``ministral-3b-4bit`` (Ministral-3-3B-Instruct-2512): the
+    ///     first chat completion **hangs** under the mlx-vlm lane
+    ///     (request times out at 90 s, server goes unreachable). It is
+    ///     usable (5/6, flaky) only via ``--no-mllm``, which the desktop
+    ///     does not wire per-alias — so the picker path always hits the
+    ///     hanging lane.
+    ///
+    /// Scope is deliberately EVIDENCE-BOUNDED to what #1367 measured.
+    /// The ``gemma-4-e4b-*`` / ``gemma-3n-*`` nano SKUs are NOT listed —
+    /// they were not tested, and hiding a model that might work is its
+    /// own harm (mirrors ``shouldShow``'s parse-failure "default to
+    /// shown" bias). Extend this set only when engine testing confirms a
+    /// new alias is broken for text chat.
+    static let knownBrokenForTextChat: Set<String> = [
+        "gemma-4-e2b-4bit",
+        "gemma-4-e2b-6bit",
+        "gemma-4-e2b-8bit",
+        "gemma-4-e2b-assistant",
+        "ministral-3b-4bit",
+    ]
+
+    /// True when ``alias`` is on the known-broken-for-text-chat
+    /// denylist above and must be hidden from the picker regardless of
+    /// size or the ``Show small models`` toggle.
+    static func isKnownBroken(_ alias: String) -> Bool {
+        knownBrokenForTextChat.contains(alias)
+    }
+
     /// Returns true when ``alias`` should be visible in the picker's
     /// "All models" alphabetical list.
     ///
@@ -54,6 +98,16 @@ enum ModelPickerVisibility {
         selectedAlias: String,
         includeAll: Bool
     ) -> Bool {
+        // Known-broken denylist is ABSOLUTE — it wins over both
+        // ``includeAll`` and the currently-selected exemption. Those
+        // two escape hatches are about SIZE ("power user wants the
+        // tinies" / "don't hide what I picked"); brokenness is a
+        // different axis. A model that hangs or garbles on every chat
+        // send is never a legitimate option, so ``Show small models``
+        // must not reveal it and a stale persisted selection must not
+        // keep it on the menu where it can be re-picked. See issue
+        // #1367 and ``knownBrokenForTextChat``.
+        if isKnownBroken(alias) { return false }
         if includeAll { return true }
         if !selectedAlias.isEmpty && alias == selectedAlias { return true }
         guard let params = parseSmallestParamsBillions(alias) else {
@@ -151,11 +205,22 @@ enum ModelPickerVisibility {
         selectedAlias: String,
         includeAll: Bool
     ) -> Int {
-        if includeAll { return 0 }
         return entries.reduce(0) { acc, entry in
-            shouldShow(alias: entry.alias, selectedAlias: selectedAlias, includeAll: includeAll)
-                ? acc
-                : acc + 1
+            // Count ONLY size-hidden aliases: they are what the footer
+            // ("N small (<1B) models hidden · toggle in Settings")
+            // describes and what the toggle actually recovers.
+            // Denylisted aliases are hidden for a different reason, are
+            // NOT toggle-recoverable, and would make the copy lie — so
+            // they are excluded from the count and vanish silently.
+            // (When ``includeAll`` is on, nothing is size-hidden, but a
+            // denylisted alias is still hidden — so it is still excluded
+            // here rather than short-circuiting the whole count to 0.)
+            if isKnownBroken(entry.alias) { return acc }
+            return shouldShow(
+                alias: entry.alias,
+                selectedAlias: selectedAlias,
+                includeAll: includeAll
+            ) ? acc : acc + 1
         }
     }
 

--- a/apps/rapid-mac/Tests/RapidTests/ModelPickerVisibilityTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ModelPickerVisibilityTests.swift
@@ -674,4 +674,107 @@ struct ModelPickerVisibilityTests {
                 == .tiny
         )
     }
+
+    // MARK: - known-broken denylist (issue #1367)
+
+    @Test("ministral-3b-4bit is HIDDEN even though 3B clears the size filter — mlx-vlm lane hangs on first chat (#1367)")
+    func brokenMinistralHiddenDespiteSize() {
+        // 3.0B parses well above the 1B floor, so ONLY the denylist
+        // keeps it off the menu. Without the denylist this is the exact
+        // reported footgun: pick it, send "hi", spin forever, 0 tokens.
+        #expect(
+            ModelPickerVisibility.shouldShow(
+                alias: "ministral-3b-4bit",
+                selectedAlias: "",
+                includeAll: false
+            ) == false
+        )
+    }
+
+    @Test("every gemma-4-e2b SKU is HIDDEN — 0/6 incoherent on both lanes, arch-level not quant-level (#1367)")
+    func brokenGemmaE2bFamilyHidden() {
+        for alias in [
+            "gemma-4-e2b-4bit",
+            "gemma-4-e2b-6bit",
+            "gemma-4-e2b-8bit",
+            "gemma-4-e2b-assistant",
+        ] {
+            #expect(
+                ModelPickerVisibility.shouldShow(
+                    alias: alias,
+                    selectedAlias: "",
+                    includeAll: false
+                ) == false,
+                "\(alias) must be hidden"
+            )
+        }
+    }
+
+    @Test("denylist WINS over includeAll — Show small models must not reveal a hanging model")
+    func denylistBeatsIncludeAll() {
+        #expect(
+            ModelPickerVisibility.shouldShow(
+                alias: "ministral-3b-4bit",
+                selectedAlias: "",
+                includeAll: true
+            ) == false
+        )
+    }
+
+    @Test("denylist WINS over the selected-alias exemption — a stale persisted pick of a broken model is not kept on the menu")
+    func denylistBeatsSelected() {
+        #expect(
+            ModelPickerVisibility.shouldShow(
+                alias: "gemma-4-e2b-4bit",
+                selectedAlias: "gemma-4-e2b-4bit",
+                includeAll: false
+            ) == false
+        )
+    }
+
+    @Test("evidence-bounded: untested e4b / 3n nano SKUs are NOT denylisted — hiding a maybe-working model is its own harm")
+    func untestedNanoNotDenylisted() {
+        // These clear both the size filter and the denylist, so they
+        // stay shown. #1367 measured only e2b + Ministral-3; the set
+        // must not creep to models with no failing evidence.
+        for alias in ["gemma-4-e4b-4bit", "gemma-3n-e2b-4bit", "gemma-3n-e4b-4bit"] {
+            #expect(ModelPickerVisibility.isKnownBroken(alias) == false, "\(alias)")
+            #expect(
+                ModelPickerVisibility.shouldShow(
+                    alias: alias,
+                    selectedAlias: "",
+                    includeAll: false
+                ) == true,
+                "\(alias) must stay shown"
+            )
+        }
+    }
+
+    @Test("filter drops denylisted aliases, and hiddenCount does NOT count them (footer copy is about size, not brokenness)")
+    func denylistFilteredAndNotCounted() {
+        let entries = [
+            ModelEntry(alias: "ministral-3b-4bit", hfRepo: nil, sizeOnDisk: nil, cached: true),
+            ModelEntry(alias: "qwen3-0.6b-4bit", hfRepo: nil, sizeOnDisk: nil, cached: true),
+            ModelEntry(alias: "qwen3.5-4b-4bit", hfRepo: nil, sizeOnDisk: nil, cached: true),
+        ]
+        let filtered = ModelPickerVisibility.filter(
+            entries,
+            selectedAlias: "qwen3.5-4b-4bit",
+            includeAll: false
+        )
+        // Broken (ministral) AND size-hidden (0.6b) both drop; only the
+        // 4B survives.
+        #expect(filtered.map(\.alias) == ["qwen3.5-4b-4bit"])
+        // But the footer count reflects ONLY the 1 size-hidden alias —
+        // the denylisted one is excluded so "N small models hidden ·
+        // toggle in Settings" stays truthful (the toggle won't reveal
+        // ministral).
+        #expect(
+            ModelPickerVisibility.hiddenCount(
+                entries,
+                selectedAlias: "qwen3.5-4b-4bit",
+                includeAll: false
+            ) == 1
+        )
+    }
 }


### PR DESCRIPTION
## Why
The picker's "All models" list only filters by **size** (<1B). Small **multimodal-only** checkpoints clear that filter — `ministral-3b-4bit` (3B), `gemma-4-e2b-*` (2B) — and surface as selectable chat models. But on the bundled engine they route to the **mlx-vlm lane**, where they either **hang** or return **incoherent** text: the exact "switched the picker to X, sent 'hi', spun forever with zero tokens" footgun (issue #1367, same dead-spinner class as #1488).

## What
- Add `ModelPickerVisibility.knownBrokenForTextChat` — an **evidence-bounded** denylist (`gemma-4-e2b` 4/6/8-bit + `-assistant`; `ministral-3b-4bit`) + `isKnownBroken(_:)`. Scope is exactly what #1367 measured; untested `e4b`/`3n` nano SKUs are deliberately **not** listed (hiding a maybe-working model is its own harm, mirroring the parse-failure "default to shown" bias).
- `shouldShow`: denylist is **absolute** — wins over both `includeAll` ("Show small models") and the selected-alias exemption (those are *size* escape-hatches; brokenness is a different axis).
- `hiddenCount`: exclude denylisted aliases so the "N small (<1B) models hidden · toggle in Settings" footer stays truthful (the toggle doesn't reveal them).

## Tests
- 6 regression tests: ministral/e2b hidden despite clearing the size floor; denylist beats `includeAll` and beats `selected`; untested e4b/3n stay shown; `filter` drops broken aliases while `hiddenCount` excludes them.
- `swift test --filter ModelPicker` → **66 passed**; `swift build` clean; `verify-recommendation-tiers` **ALL PASS**.

## Notes
- Evidence: #1367 reproduced on a real macos-14 M1 runner (rapid-mlx 0.11.4 / mlx-vlm 0.6.3), pinned in `ci.yml`'s L1-smoke comment — `gemma-4-e2b` 0/6 golden on **both** lanes, Ministral-3 first-chat hang under mlx-vlm.
- Written with AI assistance (Claude); reviewed by the author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)