### PR TITLE
fix(models): retire broken Ministral 3B alias

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,16 +258,13 @@ jobs:
     # model comfortably. A 3-4B model is fine for a coherence/parser gate — it
     # is not a chat-quality eval, which stays on the 35B L2 tier.
     #
-    # Why only these two families (not Gemma / Mistral too): the *small* models
-    # in those families ship ONLY as multimodal checkpoints (Gemma nano,
-    # Ministral-3-2512). Serving them here is unreliable — via the mlx-vlm lane
-    # the text path is broken (gemma-4-e2b 0/6 golden, Ministral-3 request-hang
-    # under mlx-vlm 0.6.3); via ``--no-mllm`` (text lane) Ministral is flaky
-    # (5/6) and gemma-4-e2b returns 0/6 on this engine/runner even though the
-    # same model is coherent text-only on an older build. A permanently-red leg
-    # is worse than no leg, so those families are DEFERRED pending an engine fix
-    # (tracked as a follow-up issue). ``l1_smoke.sh`` already forces ``--no-mllm``
-    # so re-adding a multimodal small model later needs no install change.
+    # Why only these two families (not Gemma / Mistral too): their small
+    # checkpoints are multimodal. The broken Ministral-3 alias was retired after
+    # its default VLM route repeatedly hung (#1367). Gemma e2b now passes the
+    # coherence gate on M2/M3, but its historical macos-14/M1 0/6 result still
+    # needs a same-runner rerun before it becomes an always-on CI leg. The smoke
+    # script forces ``--no-mllm``, so adding a validated multimodal model later
+    # needs no install change.
     #
     # Kept a standalone check (NOT folded into the required ``tests`` aggregate)
     # so it can prove itself green on real PRs before a maintainer marks it a

--- a/apps/rapid-mac/Sources/Rapid/Server/ToolUseCapability.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ToolUseCapability.swift
@@ -249,9 +249,8 @@ enum ToolUseCapability {
         // emits a clean ``tool_calls`` (get_weather) with the mistral
         // parser. So ``mistral-`` / ``devstral`` are promoted back to
         // ``knownFamilies`` below (the disposition their comments
-        // always pointed to). Kept ``ministral-3b-4bit`` unclassified
-        // (.unknown) — different model, not benched, and it does not
-        // match the ``mistral-`` prefix anyway.
+        // always pointed to). The broken ``ministral-3b-4bit`` alias was
+        // removed from the engine catalog in #1367.
     ]
 
     /// Empirically verified family rows. Match rule: alias starts
@@ -370,8 +369,7 @@ enum ToolUseCapability {
         // Bench on the bundled engine: devstral-v2-24b-4bit → clean
         // ``tool_calls`` (get_weather). Parser fix is family-level, so
         // the 24B bench validates the routing for the 119B siblings
-        // too. 3.0 floor keeps the unrelated 3B ``ministral-`` model
-        // out (it also doesn't match the ``mistral-`` prefix).
+        // too.
         KnownFamily(prefix: "mistral-", minSizeBillions: 3.0, note: "mistral parser (rapid-mlx #1071/#1077, bundled 7b6a787); [TOOL_CALLS] format parsed cleanly; devstral-v2-24b family-bench confirms routing"),
         KnownFamily(prefix: "devstral", minSizeBillions: 3.0, note: "mistral parser (rapid-mlx #1071/#1077, bundled 7b6a787); devstral-v2-24b-4bit benched clean on the bundled engine"),
         // nemotron — hermes parser; cycle-7 headline confirmed engine

--- a/apps/rapid-mac/Tests/RapidTests/ToolUseCapabilityCatalogCoverageTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ToolUseCapabilityCatalogCoverageTests.swift
@@ -244,9 +244,6 @@ struct ToolUseCapabilityCatalogCoverageTests {
         // minimax — minimax parser; M2.x is 235B MoE family
         "minimax-m2.5-4bit": .known,
         "minimax-m2.7-mxfp4": .known,
-        // ministral-3b — Mistral-family 3B, hermes parser; loop never
-        // benched the 3B explicitly. .unknown.
-        "ministral-3b-4bit": .unknown,
         // mistral-24b — Mistral-family. The 2026-07-09 parser-misconfig
         // leak is fixed now that the "mistral" parser ships bundled
         // (rapid-mlx #1071/#1077, submodule 7b6a787; devstral-v2-24b

--- a/docs/release-notes/unreleased.md
+++ b/docs/release-notes/unreleased.md
@@ -2,3 +2,9 @@
      version-bump PR, `git mv` this to vX.Y.Z.md and recreate this file empty.
      Whole-line HTML comments like this one are stripped before publishing.
      See README.md in this directory for what good notes look like. -->
+
+- Removed the `ministral-3b-4bit` public alias. Its default multimodal route
+  accepts the model and reports ready, but the first text completion hangs in
+  the MLLM scheduler. Use another supported Mistral-family checkpoint; the raw
+  Hugging Face path remains available for developers investigating the upstream
+  compatibility issue tracked in #1367.

--- a/harness/scorecard/latest.md
+++ b/harness/scorecard/latest.md
@@ -33,7 +33,6 @@ _Generated: 2026-04-16T07:10:38_
 - **kimi-48b-4bit** — not found in HF_HUB_CACHE / ~/.cache/huggingface / ~/.lmstudio
 - **kimi-k2.5-3bit** — not found in HF_HUB_CACHE / ~/.cache/huggingface / ~/.lmstudio
 - **minimax-m2.5-4bit** — not found in HF_HUB_CACHE / ~/.cache/huggingface / ~/.lmstudio
-- **ministral-3b-4bit** — not found in HF_HUB_CACHE / ~/.cache/huggingface / ~/.lmstudio
 - **mistral-24b-4bit** — not found in HF_HUB_CACHE / ~/.cache/huggingface / ~/.lmstudio
 - **phi-4-14b-4bit** — not found in HF_HUB_CACHE / ~/.cache/huggingface / ~/.lmstudio
 - **qwen3-coder-4bit** — not found in HF_HUB_CACHE / ~/.cache/huggingface / ~/.lmstudio

--- a/scripts/l1_smoke.sh
+++ b/scripts/l1_smoke.sh
@@ -69,11 +69,11 @@ fi
 # --no-mllm: force the text-only mlx-lm lane. This gate only exercises the
 # TEXT coherence + tool-call parser paths, never vision, so the LM backbone is
 # all we need. It is a no-op for text-only models, but for a small model that
-# is *detected* as multimodal (Gemma nano, Ministral-3-2512) it (a) skips the
+# is *detected* as multimodal (for example Gemma nano) it (a) skips the
 # ``[vision]`` / mlx-vlm requirement so a lean ``pip install -e .`` suffices,
-# and (b) avoids the mlx-vlm text-generation path, which returns incoherent
-# output / hangs for these models (measured 2026-07-31: gemma-4-e2b 0/6 golden,
-# Ministral-3 request-hang under mlx-vlm 0.6.3). ``resolve_serving_lane`` maps
+# and (b) avoids an unvalidated mlx-vlm text-generation path. The retired
+# Ministral-3 alias hung there; Gemma e2b now passes on M2/M3 but its historical
+# M1 runner failure remains tracked in #1367. ``resolve_serving_lane`` maps
 # ``--no-mllm`` -> ``force_text`` -> the text lane, matching engine semantics.
 nohup "$RMLX" serve "$ALIAS" --port "$PORT" --no-thinking --no-mllm > "$LOG" 2>&1 &
 SERVE_PID=$!

--- a/tests/test_cli_models.py
+++ b/tests/test_cli_models.py
@@ -149,9 +149,10 @@ def test_retired_ministral_alias_fails_before_server_start(capsys):
 
     assert exc.value.code == 1
     assert not serve.called
-    output = capsys.readouterr().out
-    assert "alias was retired" in output
-    assert "--no-mllm" in output
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "alias was retired" in captured.err
+    assert "--no-mllm" in captured.err
 
 
 # ----------------------------------------------------------------------

--- a/tests/test_cli_models.py
+++ b/tests/test_cli_models.py
@@ -136,6 +136,24 @@ def test_models_command_subparser_smoke():
     assert exc.value.code == 0
 
 
+def test_retired_ministral_alias_fails_before_server_start(capsys):
+    """The known-broken short alias must stop in CLI preflight, not load a model."""
+    import pytest
+
+    with (
+        patch.object(sys, "argv", ["rapid-mlx", "serve", "ministral-3b-4bit"]),
+        patch.object(cli, "serve_command") as serve,
+        pytest.raises(SystemExit) as exc,
+    ):
+        cli.main()
+
+    assert exc.value.code == 1
+    assert not serve.called
+    output = capsys.readouterr().out
+    assert "alias was retired" in output
+    assert "--no-mllm" in output
+
+
 # ----------------------------------------------------------------------
 # D2 — --cached / ls view
 # ----------------------------------------------------------------------

--- a/tests/test_model_aliases.py
+++ b/tests/test_model_aliases.py
@@ -31,14 +31,14 @@ def test_retired_alias_full_hf_path_remains_available_for_text_only_testing():
     assert resolve_model(hf_path) == hf_path
 
 
-def test_retired_alias_is_not_shadowed_by_same_named_local_directory(
+def test_local_directory_named_like_retired_alias_keeps_path_precedence(
     tmp_path, monkeypatch
 ):
+    """A real local path is not alias support and keeps the path-first contract."""
     retired = "ministral-3b-4bit"
     (tmp_path / retired).mkdir()
     monkeypatch.chdir(tmp_path)
-    with pytest.raises(RetiredModelAliasError, match="alias was retired"):
-        resolve_model(retired)
+    assert resolve_model(retired) == retired
 
 
 def test_full_path_passes_through():

--- a/tests/test_model_aliases.py
+++ b/tests/test_model_aliases.py
@@ -5,7 +5,12 @@ import os
 
 import pytest
 
-from vllm_mlx.model_aliases import list_aliases, resolve_model, suggest_similar
+from vllm_mlx.model_aliases import (
+    RetiredModelAliasError,
+    list_aliases,
+    resolve_model,
+    suggest_similar,
+)
 
 
 def test_known_alias_resolves():
@@ -13,11 +18,17 @@ def test_known_alias_resolves():
     assert resolve_model("llama3-3b-4bit") == "mlx-community/Llama-3.2-3B-Instruct-4bit"
 
 
-def test_broken_ministral_3b_alias_is_not_advertised():
+def test_broken_ministral_3b_alias_is_rejected_before_loading():
     """#1367: the default VLM route hangs on its first text completion."""
     retired = "ministral-3b-4bit"
     assert retired not in list_aliases()
-    assert resolve_model(retired) == retired
+    with pytest.raises(RetiredModelAliasError, match="alias was retired"):
+        resolve_model(retired)
+
+
+def test_retired_alias_full_hf_path_remains_available_for_text_only_testing():
+    hf_path = "mlx-community/Ministral-3-3B-Instruct-2512-4bit"
+    assert resolve_model(hf_path) == hf_path
 
 
 def test_full_path_passes_through():

--- a/tests/test_model_aliases.py
+++ b/tests/test_model_aliases.py
@@ -13,6 +13,13 @@ def test_known_alias_resolves():
     assert resolve_model("llama3-3b-4bit") == "mlx-community/Llama-3.2-3B-Instruct-4bit"
 
 
+def test_broken_ministral_3b_alias_is_not_advertised():
+    """#1367: the default VLM route hangs on its first text completion."""
+    retired = "ministral-3b-4bit"
+    assert retired not in list_aliases()
+    assert resolve_model(retired) == retired
+
+
 def test_full_path_passes_through():
     assert resolve_model("mlx-community/Foo-Bar") == "mlx-community/Foo-Bar"
     assert resolve_model("/Users/me/local-model") == "/Users/me/local-model"

--- a/tests/test_model_aliases.py
+++ b/tests/test_model_aliases.py
@@ -31,6 +31,16 @@ def test_retired_alias_full_hf_path_remains_available_for_text_only_testing():
     assert resolve_model(hf_path) == hf_path
 
 
+def test_retired_alias_is_not_shadowed_by_same_named_local_directory(
+    tmp_path, monkeypatch
+):
+    retired = "ministral-3b-4bit"
+    (tmp_path / retired).mkdir()
+    monkeypatch.chdir(tmp_path)
+    with pytest.raises(RetiredModelAliasError, match="alias was retired"):
+        resolve_model(retired)
+
+
 def test_full_path_passes_through():
     assert resolve_model("mlx-community/Foo-Bar") == "mlx-community/Foo-Bar"
     assert resolve_model("/Users/me/local-model") == "/Users/me/local-model"

--- a/tests/test_model_auto_config.py
+++ b/tests/test_model_auto_config.py
@@ -2012,17 +2012,14 @@ class TestMistralFamilyToolParser:
     """
 
     # Every in-tree Mistral-family alias. Resolution goes through the
-    # alias profile (single source of truth) in ``aliases.json``. Note
-    # ``ministral-3b-4bit`` is included even though the ``mistral|devstral``
-    # regex does NOT match "Ministral" — its alias profile is the authority
-    # (#1071 codex round 1). This list is kept exhaustive; the
+    # alias profile (single source of truth) in ``aliases.json``. This list
+    # is kept exhaustive; the
     # ``test_every_mistral_family_alias_is_covered`` guard below fails if a
     # new Mistral-family alias is added without a ``mistral`` parser.
     _MISTRAL_ALIASES = (
         "mistral-24b-4bit",
         "devstral-24b-4bit",
         "devstral-v2-24b-4bit",
-        "ministral-3b-4bit",
         "mistral-small-4-119b",
         "mistral-small-4-119b-4bit",
         "mistral-small-4-119b-8bit",

--- a/tests/test_model_profiles_ssot.py
+++ b/tests/test_model_profiles_ssot.py
@@ -71,8 +71,7 @@ def test_every_alias_has_explicit_profile_fields() -> None:
 
 
 def test_no_orphan_aliases() -> None:
-    """The pre-SSOT audit found 6 orphans with no profile (bonsai×3,
-    ministral, nemotron×2). After P1 every alias must resolve."""
+    """Every advertised alias must resolve to an explicit profile."""
     aliases = list_aliases()
     for alias in aliases:
         cfg = detect_model_config(alias)
@@ -88,7 +87,6 @@ def test_orphan_aliases_now_covered() -> None:
     must itself resolve — so it takes their slot in this guard."""
     for orphan in (
         "bonsai-1.7b-2bit",
-        "ministral-3b-4bit",
         "nemotron-30b-4bit",
     ):
         profile = resolve_profile(orphan)

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -1163,18 +1163,6 @@
     "is_hybrid": true,
     "supports_spec_decode": false
   },
-  "ministral-3b-4bit": {
-    "hf_path": "mlx-community/Ministral-3-3B-Instruct-2512-4bit",
-    "tool_call_parser": "mistral",
-    "reasoning_parser": null,
-    "is_hybrid": false,
-    "supports_spec_decode": true,
-    "suffix_decoding_tier": "avoid",
-    "suffix_bench_speedup": {
-      "chat": 0.838,
-      "json_array": 1.08
-    }
-  },
   "hermes4-70b-4bit": {
     "hf_path": "lmstudio-community/Hermes-4-70B-MLX-4bit",
     "tool_call_parser": "hermes",

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -9280,9 +9280,13 @@ Examples:
         and args.model
         and getattr(args, "command", None) != "doctor"
     ):
-        from vllm_mlx.model_aliases import resolve_model
+        from vllm_mlx.model_aliases import RetiredModelAliasError, resolve_model
 
-        resolved = resolve_model(args.model)
+        try:
+            resolved = resolve_model(args.model)
+        except RetiredModelAliasError as exc:
+            print(f"\n  Error: {exc}")
+            raise SystemExit(1) from None
         if resolved != args.model:
             # Keep stdout pure JSON for machine-readable modes (jlens --json);
             # the human-facing alias banner goes to stderr there.

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -9285,7 +9285,7 @@ Examples:
         try:
             resolved = resolve_model(args.model)
         except RetiredModelAliasError as exc:
-            print(f"\n  Error: {exc}")
+            print(f"\n  Error: {exc}", file=sys.stderr)
             raise SystemExit(1) from None
         if resolved != args.model:
             # Keep stdout pure JSON for machine-readable modes (jlens --json);

--- a/vllm_mlx/model_aliases.py
+++ b/vllm_mlx/model_aliases.py
@@ -89,6 +89,20 @@ _aliases: dict[str, "AliasProfile"] | None = None
 _hf_to_alias: dict[str, str] | None = None
 
 
+class RetiredModelAliasError(ValueError):
+    """Raised when a known-broken short alias must fail before model loading."""
+
+
+_RETIRED_MODEL_ALIASES: dict[str, str] = {
+    "ministral-3b-4bit": (
+        "The 'ministral-3b-4bit' alias was retired because its default "
+        "multimodal route can hang on the first text completion. For explicit "
+        "text-only testing, use 'mlx-community/Ministral-3-3B-Instruct-2512-4bit' "
+        "with --no-mllm."
+    ),
+}
+
+
 # ``AliasProfile`` is a DEPRECATED alias of the unified ``ModelProfile``
 # (defined in the import-light ``model_profile`` module). Retained so the
 # ~20 call sites that import ``AliasProfile`` by name keep resolving; a
@@ -620,6 +634,7 @@ def resolve_model(name: str) -> str:
 
     If name contains '/' it's already a full path — pass through.
     If a local file/directory with the name exists, prefer that.
+    If name is a retired, known-broken alias, raise before any download or load.
     If name matches an alias, return the mapped HF path.
     Otherwise return unchanged.
     """
@@ -627,6 +642,8 @@ def resolve_model(name: str) -> str:
         return name
     if os.path.exists(name):
         return name
+    if reason := _RETIRED_MODEL_ALIASES.get(name):
+        raise RetiredModelAliasError(reason)
     profile = _load().get(name)
     return profile.hf_path if profile is not None else name
 

--- a/vllm_mlx/model_aliases.py
+++ b/vllm_mlx/model_aliases.py
@@ -633,17 +633,17 @@ def resolve_model(name: str) -> str:
     """Resolve a model alias to its full HuggingFace path.
 
     If name contains '/' it's already a full path — pass through.
-    If name is a retired, known-broken alias, raise before any download or load.
     If a local file/directory with the name exists, prefer that.
+    If name is a retired, known-broken alias, raise before any download or load.
     If name matches an alias, return the mapped HF path.
     Otherwise return unchanged.
     """
     if "/" in name:
         return name
-    if reason := _RETIRED_MODEL_ALIASES.get(name):
-        raise RetiredModelAliasError(reason)
     if os.path.exists(name):
         return name
+    if reason := _RETIRED_MODEL_ALIASES.get(name):
+        raise RetiredModelAliasError(reason)
     profile = _load().get(name)
     return profile.hf_path if profile is not None else name
 

--- a/vllm_mlx/model_aliases.py
+++ b/vllm_mlx/model_aliases.py
@@ -633,17 +633,17 @@ def resolve_model(name: str) -> str:
     """Resolve a model alias to its full HuggingFace path.
 
     If name contains '/' it's already a full path — pass through.
-    If a local file/directory with the name exists, prefer that.
     If name is a retired, known-broken alias, raise before any download or load.
+    If a local file/directory with the name exists, prefer that.
     If name matches an alias, return the mapped HF path.
     Otherwise return unchanged.
     """
     if "/" in name:
         return name
-    if os.path.exists(name):
-        return name
     if reason := _RETIRED_MODEL_ALIASES.get(name):
         raise RetiredModelAliasError(reason)
+    if os.path.exists(name):
+        return name
     profile = _load().get(name)
     return profile.hf_path if profile is not None else name
 

--- a/vllm_mlx/model_sizes.json
+++ b/vllm_mlx/model_sizes.json
@@ -51,6 +51,7 @@
     "mlx-community/Meta-Llama-3.1-8B-Instruct-8bit": 8541691351,
     "mlx-community/MiniCPM5-1B-OptiQ-4bit": 916858811,
     "mlx-community/MiniMax-M2.7-4bit-mxfp4": 121537496794,
+    "mlx-community/Ministral-3-3B-Instruct-2512-4bit": 2779142485,
     "mlx-community/Mistral-Small-3.1-24B-Instruct-2503-4bit": 14119055427,
     "mlx-community/Mistral-Small-4-119B-2603-4bit": 67790336757,
     "mlx-community/Mistral-Small-4-119B-2603-8bit": 127279723730,

--- a/vllm_mlx/model_sizes.json
+++ b/vllm_mlx/model_sizes.json
@@ -51,7 +51,6 @@
     "mlx-community/Meta-Llama-3.1-8B-Instruct-8bit": 8541691351,
     "mlx-community/MiniCPM5-1B-OptiQ-4bit": 916858811,
     "mlx-community/MiniMax-M2.7-4bit-mxfp4": 121537496794,
-    "mlx-community/Ministral-3-3B-Instruct-2512-4bit": 2779142485,
     "mlx-community/Mistral-Small-3.1-24B-Instruct-2503-4bit": 14119055427,
     "mlx-community/Mistral-Small-4-119B-2603-4bit": 67790336757,
     "mlx-community/Mistral-Small-4-119B-2603-8bit": 127279723730,


### PR DESCRIPTION
## What does this PR do?

Removes the public `ministral-3b-4bit` alias and its catalog metadata so `rapid-mlx models` and Rapid Desktop no longer advertise a checkpoint whose default multimodal route hangs on the first text completion. Historical benchmark evidence stays in `evals/results`; current catalog-derived surfaces and release notes are updated.

The retired short alias now fails fast on stderr before download or model startup. The raw Hugging Face path remains accepted for explicit text-only investigation, local-path precedence remains intact, and its size metadata is retained for disk/download preflight.

## Why is this needed?

Refs #1367. Revalidation on current `main` reproduced the Ministral failure with both supported mlx-vlm lines: 0.6.3 cannot load `PixtralProcessor` without PyTorch/Torchvision, while 0.6.10 reaches ready and then loops on `Model.__call__() missing 1 required positional argument: 'mask'` until the first completion times out. Users selecting the advertised alias therefore get a server that cannot answer.

Gemma e2b was separately revalidated and remains supported: 48/48 coherence cases passed on M2 Pro and 42/42 on M3 Pro across mlx-vlm 0.6.3/0.6.10; original v0.11.4 source also passed 30/30 on M3 Pro. The historical M1 discrepancy remains tracked in #1367 and is not conflated with this removal.

## AI assistance disclosure

Codex performed the reproduction, implementation, and iterative adversarial review. Review converged to zero findings. The maintainer-directed validation used real M2 Pro and M3 Pro servers, the repository coherence gate, Python and Swift tests, lint, GitHub CI, and `pr_validate`.

> By submitting this PR I confirm I can explain the intent, risk, and behavior of every non-generated change in this PR. For generated or historical scorecard content, I can describe how its catalog consistency was verified.

## Test plan

- [x] Reproduced the default Ministral VLM failure with mlx-vlm 0.6.3 and 0.6.10.
- [x] Verified `--no-mllm` is coherent (18/18) and the retired short alias exits 1 before startup.
- [x] Ran affected alias/catalog/CLI suites: 3,059 passed.
- [x] Ran `ToolUseCapabilityCatalogCoverageTests` through SwiftPM.
- [x] Ran final diff-aware suite: 827 passed.
- [x] Ran final full pytest suite hermetically: 15,586 passed, 53 skipped, 6 xfailed, 1 xpassed.
- [x] Ran Ruff check/format and workflow expression/action-pinning checks.
- [x] Ran Codex review to convergence: 0 blocking, 0 nits.
- [x] Ran `pr_validate`: MERGE-SAFE. Stress was skipped via documented env gate because the host RAM probe reported 0GB usable; real M2/M3 model validation covers this alias-only preflight change.
- [x] GitHub required checks pass.
- [x] Updated release notes and #1367 with cross-hardware evidence.

## Checklist

- [x] Targeted tests pass locally.
- [x] Lint and format checks pass.
- [x] Documentation is updated.
- [x] No dependency or public API surface was added; one known-broken convenience alias is intentionally retired.

## Out of scope

- Fixing mlx-vlm's Ministral language-model `mask` calling convention.
- Removing generic parser detection for other Ministral-family Hugging Face repositories.
- Closing the historical M1-only Gemma coherence discrepancy without a current same-runner rerun.
