### PR TITLE
chore(rapid-mac): cut app 0.12.5 (bundles engine 0.12.4)

### DIFF
--- a/apps/rapid-mac/CHANGELOG.md
+++ b/apps/rapid-mac/CHANGELOG.md
@@ -13,6 +13,69 @@ can actually understand.
 
 ## [Unreleased]
 
+## [0.12.5] — 2026-08-05
+
+A stability release. The headline is a crash: a reply with a formula in it
+took the whole app down, and an ordinary maths question was enough to
+produce one. The starter model that shipped with 0.12.1 also turned out to
+be unusable, so it has been replaced.
+
+### Fixed — crashes and hangs
+
+- **Maths no longer crashes the app.** When a reply contained a formula, the
+  app quit outright with a macOS crash dialog — a plain `2 + 2 = 4` was
+  enough. Formulas now show as their plain-text source instead of taking the
+  app down. (Typesetting them properly is still to come.)
+- **A silent server no longer hangs the chat.** Sending a message used to sit
+  there indefinitely if the model stopped responding; it now fails after a
+  bounded wait and the message stays retryable.
+- **Quitting no longer stalls or crashes**, and starting the app no longer
+  risks shutting down a Rapid-MLX server you started yourself in a terminal.
+
+### Fixed — first run
+
+- **The starter model has changed.** The previous one fell apart on ordinary
+  multi-step questions — doubling words, then looping until it ran out of
+  room. Measured on the same Mac and the same question: 0/4 correct before,
+  16/16 after, with the first answer arriving in about a second.
+- **Two models that could fail to answer are temporarily hidden.** Ministral 3
+  and Gemma 4 E2B looked like ordinary small chat models in the picker, but on
+  some Macs sending them a message produced no reply at all, or a reply that
+  made no sense. They stay hidden until that is fixed.
+- **8 GB Macs get a recommendation instead of a rejection**, and every RAM
+  size now gets a "smart" and (where it helps) a "fast" pick.
+
+### Fixed — chat and models
+
+- **Conversation history keeps its order.** Older chats could jump around in
+  the sidebar.
+- **The compose box grows with what you type**, and the transcript stops
+  yanking you back to the bottom while you are reading further up.
+- **Loading a model that will not fit is now blocked** with a warning based on
+  free memory at that moment, rather than freezing or panicking the Mac.
+- **"Speed on this Mac" shows live progress and an estimate** instead of an
+  unmoving spinner, and the size column no longer mixes download size with
+  memory use.
+
+### Fixed — connecting your tools
+
+- **Your API key is no longer shown in the clear** in the copyable setup
+  snippets on the Launch page.
+- **Cursor no longer gets a configuration that cannot work.** Cursor routes
+  requests through its own servers, so a `localhost` address was never
+  reachable; the app now says so and points at Claude Code, Cline, or
+  Continue for a local connection.
+
+### Changed
+
+- A refreshed visual system for the model list and its states.
+- Bundles the **Rapid-MLX 0.12.4** engine. What you should notice: replies
+  are faster on a long conversation because the model no longer re-reads
+  what it has already read; models that think before answering keep their
+  reasoning out of the answer; the app can tell whether a model is busy or
+  idle; and several models that used to fail to start — including the
+  Gemma 4 family — now load. LFM2.5 models are newly available.
+
 ## [0.12.1] — 2026-08-03
 
 The first **signed + notarised** release — it installs and opens without the

--- a/apps/rapid-mac/Resources/Info.plist
+++ b/apps/rapid-mac/Resources/Info.plist
@@ -19,9 +19,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.12.1</string>
+	<string>0.12.5</string>
 	<key>CFBundleVersion</key>
-	<string>148</string>
+	<string>149</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>14.0</string>
 	<key>NSHighResolutionCapable</key>


### PR DESCRIPTION
## Why

`rapid-mac-v0.12.1` (2026-08-03) is still the newest app tag. Every app fix
merged since then has been sitting on `main` with no path to a user — including
a hard crash.

The release-blocking one is **#1487**. Any reply the chat identified as
containing maths reached `Swift.fatalError` inside SwiftMath's generated
`Bundle.module` accessor and took the whole process down with a macOS crash
dialog. #1487's own reproduction is a plain `2 + 2 = 4`. Dogfooding the starter
model this release ships, **9 of 10 ordinary arithmetic prompts emit LaTeX** —
so this is the common path, not an edge case. Users on 0.12.1 hit it today.

Also reaching users for the first time: the starter-model swap (#1484 — the one
that shipped in 0.12.1 measured 0/4 correct and 0/4 terminating), chat history
ordering (#1485), the bounded send timeout (#1488), composer autosize and
scroll intent (#1467), port-sweep / shutdown fixes (#1472), the pre-load
free-memory guard (#1435), the cleartext-bearer fix (#1481), and the
multimodal-only alias filter (#1496).

## What changed

Two files. `CFBundleShortVersionString` 0.12.1 → 0.12.5, `CFBundleVersion`
148 → 149 (the monotonic build counter, 146 → 147 → 148 historically), and a
hand-written user-facing CHANGELOG section.

The engine version line is separate and stays at **0.12.4**. Nothing asserts
the two match — `release-local.sh --publish` preflights only `tag == plist` —
so this is deliberate, not a mismatch. `pyproject.toml` is untouched.

## Verified on the artifact this branch builds

Not on a dev binary — `scripts/build.sh` from a clean `build/`:

- app reports **0.12.5 / build 149**; bundled engine **0.12.4**
- `codesign --verify --deep --strict` passes; nothing but `Contents/` at the
  `.app` root
- the math guard, compiled into `Contents/MacOS/` so `Bundle.main` is the real
  wrapper, returns `false` — the crashing path is unreachable and formulas
  degrade to plain source
- end-to-end chat through the app's own ServerManager + ChatStreamClient:
  sidecar started, reached ready, streamed a complete reply
- `verify-recommendation-tiers.swift`, `verify-conversation-ordering.sh`,
  `verify-chat-timeout.swift`, `smoke.sh` — all pass
- `ruff check` + `ruff format --check` clean at CI's scope (`vllm_mlx/ tests/`)
- codex review converged **0 BLOCKING / 0 MAJOR** (2 rounds; round 1's six
  MAJORs were CHANGELOG-accuracy calls — three were real and the copy was
  fixed, three were resolved by supplying the PR bodies codex had not seen)

## Known, and deliberately not in this release

Formulas still display as their LaTeX source rather than being typeset:
SwiftMath's resource bundle cannot be placed where its accessor looks without
`codesign` rejecting the app. #1487 traded "renders, then crashes" for "shows
source, never crashes"; restoring real typesetting needs the dependency
vendored, which is a supply-chain decision and not something to fold into a
release cut.

## Next step after merge

Tag from the squashed SHA:

```
git push raullenchai rapid-mac-v0.12.5
```

**Not** `release-local.sh --publish` — it hardcodes `origin`, which in this
repo is `waybarrios/vllm-mlx`, so it would push the release tag to the
upstream. Filed separately.

---

## Issue #1367 — carried in this release, re-measured on the shipping sidecar

#1496 (already on `main`, in this release) hides `ministral-3b-4bit` and
`gemma-4-e2b-*` from the picker because #1367 measured them hanging or
returning nonsense. That issue was filed against **mlx-vlm 0.6.3** on an
**M1** runner; this release bundles **0.6.10**. Re-ran #1367's golden set
through the bundled binary this branch builds:

| alias | lane | result |
|---|---|---|
| `gemma-4-e2b-4bit` | mllm (auto) | **6/6** — was 0/6 on 0.6.3 / M1 |
| `ministral-3b-4bit` | mllm (auto) | **still hangs** |
| `ministral-3b-4bit` | `--no-mllm` | **6/6** |

The Ministral hang now has a root cause, and it is not a timeout:

```
ERROR:rapid_mlx.mllm_scheduler:Error in MLLM process loop:
    Model.__call__() missing 1 required positional argument: 'mask'
```

565 identical lines during one 90 s request, `steps_executed: 0` throughout.
The scheduler's process loop swallows the exception and re-loops, so the
caller gets neither a response nor an error. Full write-up on #1367.

**Effect on this release:** the denylist entry for `ministral-3b-4bit` is
confirmed necessary against the exact sidecar being shipped. The
`gemma-4-e2b` entry is *unverified on this hardware* — #1367 itself records
6/6 on M3 versus 0/6 on M1 for that model, so a green M3 run cannot refute it.
Hiding it stays the safe side of the trade. Neither finding changes the diff;
both are recorded so the release is not claiming more than was measured.

The CHANGELOG line for #1496 was corrected as a result — it originally said
"image- and audio-only models", which is wrong: these are multimodal models
that *can* do text, hidden because the vision lane breaks their text output.
