### PR TITLE
fix(release): atomically claim release tags

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -56,6 +56,10 @@ jobs:
         env:
           # Pass untrusted-ish dispatch inputs via env, never ``${{ }}`` into the
           # run block.
+          # Read-only auth for the ``gh release view`` idempotency check below
+          # (auto-auth works, but the repo's other release jobs set this
+          # explicitly — keep the pattern).
+          GH_TOKEN: ${{ github.token }}
           EVENT: ${{ github.event_name }}
           FORCE_VERSION: ${{ github.event.inputs.force_version }}
           REASON: ${{ github.event.inputs.reason }}
@@ -87,9 +91,22 @@ jobs:
               exit 1
             fi
             if git ls-remote --tags origin "refs/tags/v$VERSION" | grep -q "v$VERSION"; then
-              echo "Tag v$VERSION already exists — nothing to do (idempotent)"
-              echo "should_release=false" >> "$GITHUB_OUTPUT"
-              echo "force=false" >> "$GITHUB_OUTPUT"
+              # The tag may already exist WITHOUT a Release (a prior run died
+              # between tag and Release, or the Release was deleted). detect
+              # must stay 'true' so the release job can recover it — only a
+              # Release that already exists stops us.
+              RELEASE_DRAFT=$(gh release view "v$VERSION" --repo "$GITHUB_REPOSITORY" \
+                --json isDraft -q .isDraft 2>/dev/null || echo "missing")
+              if [ "$RELEASE_DRAFT" = "false" ]; then
+                echo "Release v$VERSION already exists — nothing to do (idempotent)"
+                echo "should_release=false" >> "$GITHUB_OUTPUT"
+                echo "force=false" >> "$GITHUB_OUTPUT"
+                exit 0
+              fi
+              echo "Tag v$VERSION exists without a published Release — will recover"
+              echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+              echo "should_release=true" >> "$GITHUB_OUTPUT"
+              echo "force=true" >> "$GITHUB_OUTPUT"
               exit 0
             fi
             echo "version=$VERSION" >> "$GITHUB_OUTPUT"
@@ -120,16 +137,22 @@ jobs:
             exit 1
           fi
 
-          # Idempotency: if the tag already exists there is nothing to do.
-          if git ls-remote --tags origin "refs/tags/v$VERSION" | grep -q "v$VERSION"; then
-            echo "Tag v$VERSION already exists — skipping (idempotent)"
+          # Idempotency: if the Release already exists there is nothing to do.
+          # A tag alone does NOT stop us — it may be a tag with no Release (a
+          # prior run that died between tag and Release, a hand-pushed tag, a
+          # deleted Release). We must stay should_release=true so the release
+          # job can recover it. Only a Release that already exists is done.
+          RELEASE_DRAFT=$(gh release view "v$VERSION" --repo "$GITHUB_REPOSITORY" \
+            --json isDraft -q .isDraft 2>/dev/null || echo "missing")
+          if [ "$RELEASE_DRAFT" = "false" ]; then
+            echo "Release v$VERSION already exists — skipping (idempotent)"
             echo "should_release=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "should_release=true" >> "$GITHUB_OUTPUT"
-          echo "✓ Detected version bump → v$VERSION (pyproject matches, tag is new)"
+          echo "✓ Detected version bump → v$VERSION (pyproject matches, release missing)"
 
   # 2) The gate. Runs on the self-hosted Apple-Silicon runner (the Studio) —
   #    GitHub-hosted runners have no Metal, no weights, no agent binaries, so
@@ -276,84 +299,7 @@ jobs:
           NOTES_FILE: ${{ steps.changelog.outputs.notes_file }}
         run: |
           set -euo pipefail
-
-          # Idempotency: re-check at create time too. An existing Release is
-          # only "already done" if it points at the commit these notes
-          # describe — a retry that resolved a different RELEASE_SHA must not
-          # report success over a release that documents another tree.
-          if EXISTING_REL=$(gh release view "$TAG" --json targetCommitish,tagName -q .targetCommitish 2>/dev/null); then
-            # targetCommitish can be a branch name for pre-existing releases;
-            # resolve through the tag, which is what actually ships.
-            if REL_SHA=$(git rev-parse --verify --quiet "refs/tags/$TAG^{commit}" 2>/dev/null); then
-              :
-            else
-              REL_SHA=$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$TAG" -q .object.sha 2>/dev/null || echo "")
-            fi
-            if [ -n "$REL_SHA" ] && [ "$REL_SHA" != "$RELEASE_SHA" ]; then
-              echo "❌ Release $TAG already exists at $REL_SHA, but these notes describe $RELEASE_SHA." >&2
-              echo "   Refusing to report success over a release that documents a different tree." >&2
-              exit 1
-            fi
-            echo "Release $TAG already exists at the release commit ($EXISTING_REL) — done"
-            exit 0
-          fi
-
-          # A tag can exist WITHOUT a Release object: a prior run that died
-          # between tag and release, a hand-pushed tag, a deleted release. The
-          # check above only sees Releases, so we would fall through to
-          # ``gh release create`` — and GitHub REUSES an existing tag and
-          # silently IGNORES ``--target``. The result is a published release
-          # whose notes describe $RELEASE_SHA attached to a tag pointing
-          # somewhere else. That is the one way this job can ship a release that
-          # lies about its own contents, so fail loudly instead of guessing.
-          # ``git fetch <tag>`` fails both when the tag is absent (fine) and
-          # when the network/auth broke (NOT fine), and swallowing that with
-          # ``|| true`` would read a failed check as "no tag exists" — then
-          # ``gh release create`` reuses the remote tag, ignores --target, and
-          # the post-condition only catches it AFTER downstream workflows fired.
-          # ``ls-remote`` separates the two: exit 0 + empty means genuinely
-          # absent, non-zero means we could not check and must not guess.
-          if ! REMOTE_TAG=$(git ls-remote --tags origin "refs/tags/$TAG"); then
-            echo "❌ could not query origin for refs/tags/$TAG — refusing to guess." >&2
-            exit 1
-          fi
-          if [ -n "$REMOTE_TAG" ]; then
-            git fetch --quiet --force origin "refs/tags/$TAG:refs/tags/$TAG"
-            # ls-remote already proved the tag EXISTS, so a peel that fails
-            # here is not "no tag" — it is a tag we cannot reason about (an
-            # annotated tag can legally point at a tree or blob). Falling
-            # through would hand it to ``gh release create``, which reuses the
-            # tag and ignores --target, and the post-condition would only
-            # notice after the release published and triggered downstream.
-            if ! EXISTING=$(git rev-parse --verify --quiet "refs/tags/$TAG^{commit}"); then
-              echo "❌ Tag $TAG exists on origin but does not peel to a commit." >&2
-              echo "   Refusing to publish against a tag whose target cannot be verified." >&2
-              exit 1
-            fi
-          fi
-          if [ -n "${EXISTING:-}" ]; then
-            if [ "$EXISTING" != "$RELEASE_SHA" ]; then
-              echo "❌ Tag $TAG already exists at $EXISTING, but these notes describe $RELEASE_SHA." >&2
-              echo "   GitHub ignores --target when the tag already exists, so publishing now" >&2
-              echo "   would attach these notes to a different tree." >&2
-              echo "   Fix by hand: delete the stale tag, or bump to a fresh version." >&2
-              exit 1
-            fi
-            echo "Tag $TAG already exists and points at the release commit — reusing it."
-          fi
-
-          gh release create "$TAG" \
-            --title "$TAG" \
-            --notes-file "$NOTES_FILE" \
-            --target "$RELEASE_SHA"
-
-          # Post-condition: the tag that actually got published must be the
-          # commit these notes were generated from.
-          git fetch --quiet --force origin "refs/tags/$TAG:refs/tags/$TAG"
-          PUBLISHED=$(git rev-parse --verify "refs/tags/$TAG^{commit}")
-          if [ "$PUBLISHED" != "$RELEASE_SHA" ]; then
-            echo "❌ published tag $TAG points at $PUBLISHED, expected $RELEASE_SHA" >&2
-            exit 1
-          fi
-
-          echo "✓ Released $TAG at $RELEASE_SHA — publish.yml will now publish to PyPI"
+          # Atomic tag claim + tag-without-Release recovery (issue #1462).
+          # Extracted to scripts/create_release.sh so the TOCTOU and recovery
+          # paths are testable offline against a mock ``gh``.
+          bash scripts/create_release.sh

--- a/scripts/create_release.sh
+++ b/scripts/create_release.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+#
+# Create a GitHub Release whose tag we atomically claim at $RELEASE_SHA.
+#
+# Extracted from .github/workflows/auto-release.yml so the TOCTOU + recovery
+# logic can be tested offline against a mock ``gh`` (no real release needed).
+#
+# WHY THIS EXISTS (issue #1462)
+#
+#   1. TOCTOU: a separate ``git ls-remote`` pre-check proves the tag is absent,
+#      but another writer can push it before ``gh release create`` runs. GitHub
+#      reuses an existing tag and silently ignores ``--target``, so the release
+#      would publish notes describing $RELEASE_SHA against someone else's tag.
+#      We claim the tag atomically FIRST via the git refs API (which fails if
+#      the ref exists), and only then create the Release against the tag we own.
+#
+#   2. Recovery: if the tag was already created (a prior run that died between
+#      tag and Release, a hand-pushed tag, a deleted Release), we create the
+#      Release against it — but ONLY when it points at exactly $RELEASE_SHA.
+#      Otherwise we fail loudly rather than attach these notes to a different
+#      tree (GitHub ignores ``--target`` once the tag exists).
+#
+# Required env:
+#   GH_TOKEN            token with contents: write (RELEASE_PAT preferred)
+#   TAG                 ``vX.Y.Z``
+#   RELEASE_SHA         commit the tag must point at
+#   NOTES_FILE          path to the release body
+#   GITHUB_REPOSITORY   owner/repo, e.g. raullenchai/Rapid-MLX
+# Optional env:
+#   GH                  the gh binary (default ``gh``; tests inject a mock)
+#
+# Exit 0 and prints ``released <TAG> at <SHA>`` on success.
+
+set -euo pipefail
+
+: "${GH_TOKEN:?create_release.sh: GH_TOKEN is required}"
+: "${TAG:?create_release.sh: TAG is required}"
+: "${RELEASE_SHA:?create_release.sh: RELEASE_SHA is required}"
+: "${NOTES_FILE:?create_release.sh: NOTES_FILE is required}"
+: "${GITHUB_REPOSITORY:?create_release.sh: GITHUB_REPOSITORY is required}"
+GH_BIN="${GH:-gh}"
+[ -f "$NOTES_FILE" ] || { echo "❌ notes file missing: $NOTES_FILE" >&2; exit 1; }
+AUTOMATION_MARKER="<!-- rapid-mlx-auto-release:$TAG:$RELEASE_SHA -->"
+DRAFT_NOTES_FILE=$(mktemp)
+trap 'rm -f "$DRAFT_NOTES_FILE"' EXIT
+{
+  printf '%s\n' "$AUTOMATION_MARKER"
+  cat "$NOTES_FILE"
+} > "$DRAFT_NOTES_FILE"
+
+resolve_tag_commit() {
+  # Start from the explicit tag namespace so a same-named branch can never
+  # satisfy verification, then peel annotated tag objects to a commit.
+  local object_line object_type object_sha
+  object_line=$(
+    "$GH_BIN" api "repos/$GITHUB_REPOSITORY/git/ref/tags/$TAG" \
+      --jq '.object | [.type, .sha] | @tsv' 2>/dev/null
+  ) || return 1
+  IFS=$'\t' read -r object_type object_sha <<<"$object_line"
+  for _ in 1 2 3 4 5; do
+    case "$object_type" in
+      commit)
+        [ -n "$object_sha" ] || return 1
+        printf '%s\n' "$object_sha"
+        return 0
+        ;;
+      tag)
+        object_line=$(
+          "$GH_BIN" api "repos/$GITHUB_REPOSITORY/git/tags/$object_sha" \
+            --jq '.object | [.type, .sha] | @tsv' 2>/dev/null
+        ) || return 1
+        IFS=$'\t' read -r object_type object_sha <<<"$object_line"
+        ;;
+      *) return 1 ;;
+    esac
+  done
+  return 1
+}
+
+verify_existing_release() {
+  local release_line release_sha
+  if ! release_line=$(
+    "$GH_BIN" release view "$TAG" --json targetCommitish,tagName,isDraft \
+      --jq '[.targetCommitish, .isDraft] | @tsv' 2>/dev/null
+  ); then
+    return 1
+  fi
+  IFS=$'\t' read -r EXISTING_RELEASE EXISTING_IS_DRAFT <<<"$release_line"
+  case "$EXISTING_IS_DRAFT" in true|false) ;; *) return 2 ;; esac
+  if [ "$EXISTING_IS_DRAFT" = "true" ]; then
+    local release_body
+    release_body=$(
+      "$GH_BIN" release view "$TAG" --json body -q .body 2>/dev/null
+    ) || return 2
+    if [ "${release_body%%$'\n'*}" != "$AUTOMATION_MARKER" ]; then
+      echo "❌ Draft Release $TAG was not created by this workflow." >&2
+      echo "   Refusing to overwrite or publish a manually staged draft." >&2
+      return 2
+    fi
+  fi
+  release_sha=$(resolve_tag_commit || true)
+  if [ -z "$release_sha" ]; then
+    echo "❌ Release $TAG exists, but its tag could not be resolved to a commit." >&2
+    echo "   Refusing to report idempotent success without verifying the shipped tree." >&2
+    return 2
+  fi
+  if [ "$release_sha" != "$RELEASE_SHA" ]; then
+    echo "❌ Release $TAG already exists at $release_sha, but these notes describe $RELEASE_SHA." >&2
+    echo "   Refusing to report success over a release that documents a different tree." >&2
+    return 2
+  fi
+  return 0
+}
+
+finish_verified_existing_release() {
+  if [ "$EXISTING_IS_DRAFT" = "true" ]; then
+    "$GH_BIN" release edit "$TAG" \
+      --title "$TAG" \
+      --notes-file "$NOTES_FILE" \
+      --draft=false
+    local published_sha
+    published_sha=$(resolve_tag_commit || true)
+    if [ "$published_sha" != "$RELEASE_SHA" ]; then
+      echo "❌ published tag $TAG points at ${published_sha:-<unknown>}, expected $RELEASE_SHA" >&2
+      return 2
+    fi
+    echo "released $TAG at $RELEASE_SHA"
+  else
+    echo "Release $TAG already exists at the release commit ($EXISTING_RELEASE) — done"
+  fi
+}
+
+# --- Idempotency: an existing Release is only "done" if it matches. -----
+if verify_existing_release; then
+  finish_verified_existing_release
+  exit 0
+else
+  VERIFY_STATUS=$?
+  [ "$VERIFY_STATUS" -eq 1 ] || exit "$VERIFY_STATUS"
+fi
+
+# --- Atomically claim the tag. -------------------------------------------
+# POST /git/refs fails (422) if refs/tags/$TAG already exists, closing the
+# TOCTOU that a separate pre-check + ``gh release create --target`` left open.
+if ! "$GH_BIN" api -X POST "repos/$GITHUB_REPOSITORY/git/refs" \
+    -f "ref=refs/tags/$TAG" -f "sha=$RELEASE_SHA" >/dev/null 2>&1; then
+  # Claim lost the race (tag exists) — recover ONLY if it is our tag.
+  EXISTING=$(resolve_tag_commit || true)
+  if [ -z "$EXISTING" ]; then
+    echo "❌ could not create refs/tags/$TAG and could not read it back — refusing to guess." >&2
+    exit 1
+  fi
+  if [ "$EXISTING" != "$RELEASE_SHA" ]; then
+    echo "❌ Tag $TAG already exists at $EXISTING, but these notes describe $RELEASE_SHA." >&2
+    echo "   GitHub ignores --target when the tag already exists, so publishing now" >&2
+    echo "   would attach these notes to a different tree." >&2
+    echo "   Fix by hand: delete the stale tag, or bump to a fresh version." >&2
+    exit 1
+  fi
+  echo "Tag $TAG already exists and points at the release commit — reusing it."
+  # A concurrent run may have created the Release after our initial check.
+  if verify_existing_release; then
+    finish_verified_existing_release
+    exit 0
+  else
+    VERIFY_STATUS=$?
+    [ "$VERIFY_STATUS" -eq 1 ] || exit "$VERIFY_STATUS"
+  fi
+fi
+
+# --- Create the Release against the tag we own. --------------------------
+if ! CREATE_ERROR=$(
+  "$GH_BIN" release create "$TAG" \
+    --title "$TAG" \
+    --notes-file "$DRAFT_NOTES_FILE" \
+    --target "$RELEASE_SHA" \
+    --draft 2>&1
+); then
+  # Close the second race: another run can publish after our re-check but
+  # before this create. Treat that as idempotent success only after verifying
+  # its tag still names the requested commit.
+  if verify_existing_release; then
+    finish_verified_existing_release
+    exit 0
+  else
+    VERIFY_STATUS=$?
+    [ "$VERIFY_STATUS" -eq 1 ] || exit "$VERIFY_STATUS"
+  fi
+  printf '%s\n' "$CREATE_ERROR" >&2
+  exit 1
+fi
+
+# Verify while the Release is still a draft. A bad tag therefore cannot fire
+# the downstream ``release: published`` workflow before this guard runs.
+PUBLISHED=$(resolve_tag_commit || true)
+if [ "$PUBLISHED" != "$RELEASE_SHA" ]; then
+  echo "❌ draft release tag $TAG points at ${PUBLISHED:-<unknown>}, expected $RELEASE_SHA" >&2
+  exit 1
+fi
+
+"$GH_BIN" release edit "$TAG" \
+  --title "$TAG" \
+  --notes-file "$NOTES_FILE" \
+  --draft=false
+
+# Defense in depth for an out-of-policy force-update after the pre-publish
+# check. Repository policy should deny updates/deletions of release tags.
+PUBLISHED=$(resolve_tag_commit || true)
+if [ "$PUBLISHED" != "$RELEASE_SHA" ]; then
+  echo "❌ published tag $TAG points at ${PUBLISHED:-<unknown>}, expected $RELEASE_SHA" >&2
+  exit 1
+fi
+
+echo "released $TAG at $RELEASE_SHA"

--- a/tests/release/test_create_release.sh
+++ b/tests/release/test_create_release.sh
@@ -1,0 +1,339 @@
+#!/usr/bin/env bash
+#
+# Offline tests for scripts/create_release.sh (issue #1462).
+#
+# The real workflow cannot be run without cutting a release, so the tag-claim
+# and tag-without-Release recovery logic is exercised here against a mock
+# ``gh`` that records the exact API calls made and tracks the tag's state.
+#
+#   ./tests/release/test_create_release.sh
+#
+# Requires: bash. No network/gh/git required.
+
+set -euo pipefail
+
+REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+SCRIPT="$REPO_ROOT/scripts/create_release.sh"
+WORKFLOW="$REPO_ROOT/.github/workflows/auto-release.yml"
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+PASS=0
+FAIL=0
+
+ok()   { PASS=$((PASS + 1)); printf '  \033[32mPASS\033[0m %s\n' "$1"; }
+bad()  { FAIL=$((FAIL + 1)); printf '  \033[31mFAIL\033[0m %s\n' "$1"; }
+contains() { if grep -qF -- "$2" <<<"$1"; then ok "$3"; else bad "$3"; printf '        want substring: %s\n        got:            %s\n' "$2" "$1"; fi; }
+lacks()    { if grep -qF -- "$2" <<<"$1"; then bad "$3"; else ok "$3"; fi; }
+
+SHA_GOOD="1111111111111111111111111111111111111111"
+SHA_BAD="2222222222222222222222222222222222222222"
+
+# ==========================================================================
+echo "== 0. workflow wiring keeps tag-without-Release recovery reachable =="
+# ==========================================================================
+NORMAL_DETECT=$(sed -n '/# --- Normal push path/,/# 2) The gate/p' "$WORKFLOW")
+lacks "$NORMAL_DETECT" "git ls-remote --tags" \
+  "normal detect does not skip merely because a tag exists"
+contains "$NORMAL_DETECT" 'RELEASE_DRAFT=$(gh release view "v$VERSION"' \
+  "normal detect checks published-vs-draft state"
+contains "$NORMAL_DETECT" 'if [ "$RELEASE_DRAFT" = "false" ]; then' \
+  "only a published Release enters the idempotent skip branch"
+FALSE_OUTPUT_LINE=$(grep -n 'echo "should_release=false"' <<<"$NORMAL_DETECT" | head -1 | cut -d: -f1)
+TRUE_OUTPUT_LINE=$(grep -n 'echo "should_release=true"' <<<"$NORMAL_DETECT" | tail -1 | cut -d: -f1)
+[ -n "$FALSE_OUTPUT_LINE" ] && [ -n "$TRUE_OUTPUT_LINE" ] && \
+  [ "$FALSE_OUTPUT_LINE" -lt "$TRUE_OUTPUT_LINE" ] && \
+  ok "draft/missing Release falls through to should_release=true" || \
+  bad "draft/missing Release falls through to should_release=true"
+contains "$(cat "$WORKFLOW")" "Tag v\$VERSION exists without a published Release — will recover" \
+  "forced dispatch keeps bare-tag recovery reachable"
+contains "$(cat "$WORKFLOW")" "bash scripts/create_release.sh" \
+  "release job invokes the atomic helper"
+
+# Run the script with a stateful mock ``gh``. Env vars:
+#   MOCK_RELEASE_VIEW   "yes" -> release view succeeds (Release exists)
+#   MOCK_RELEASE_DRAFT  "yes" -> existing Release is an unpublished draft
+#   MOCK_RELEASE_MARKED "yes" -> draft carries the workflow ownership marker
+#   MOCK_MARKER_NOT_FIRST "yes" -> marker appears only inside manual notes
+#   MOCK_WRONG_TAG_MARKER "yes" -> marker belongs to another tag at same SHA
+#   MOCK_TAG_REF        SHA the tag already points at ("" = absent)
+#   MOCK_CLAIM_FAILS    "yes" -> the atomic refs POST fails (tag exists)
+#   MOCK_CREATE_FAILS   "yes" -> gh release create fails
+#   MOCK_REF_UNREADABLE "yes" -> tag cannot be peeled to a commit
+#   MOCK_TAG_TYPE       "tag" models an annotated tag object
+#   MOCK_CONCURRENT_RELEASE "yes" -> losing tag claim observes a new Release
+#   MOCK_CREATE_RACE    "yes" -> create loses to a concurrent Release writer
+run_script() {
+  export GH="$TMP/mock-gh"
+  : > "$TMP/calls"
+  cat > "$GH" <<MOCK
+#!/usr/bin/env bash
+set -euo pipefail
+cmd="\$1"; shift
+printf '%s %s\n' "\$cmd" "\$*" >> "$TMP/calls"
+case "\$cmd" in
+  release)
+    sub="\$1"; shift
+    if [ "\$sub" = "view" ]; then
+      if [ "${MOCK_RELEASE_VIEW:-}" = "yes" ] || [ -s "$TMP/release-state" ]; then
+        if [[ "\$*" == *"--json body"* ]]; then
+          if [ "${MOCK_WRONG_TAG_MARKER:-}" = "yes" ]; then
+            echo '<!-- rapid-mlx-auto-release:v9.9.9:$SHA_GOOD -->'
+          elif [ "${MOCK_MARKER_NOT_FIRST:-}" = "yes" ]; then
+            printf 'manual preface\n<!-- rapid-mlx-auto-release:v1.2.3:$SHA_GOOD -->\n'
+          elif [ "${MOCK_RELEASE_MARKED:-}" = "yes" ] || \
+             [ "\$(cat "$TMP/release-state" 2>/dev/null)" = "draft-marked" ]; then
+            echo '<!-- rapid-mlx-auto-release:v1.2.3:$SHA_GOOD -->'
+          else
+            echo 'manually staged draft notes'
+          fi
+          exit 0
+        fi
+        if [ "${MOCK_RELEASE_DRAFT:-}" = "yes" ] || \
+           [[ "\$(cat "$TMP/release-state" 2>/dev/null)" == draft* ]]; then
+          printf 'v1.2.3\ttrue\n'
+        else
+          printf 'v1.2.3\tfalse\n'
+        fi
+      else
+        exit 1
+      fi
+    elif [ "\$sub" = "create" ]; then
+      if [ "${MOCK_CREATE_RACE:-}" = "yes" ]; then
+        echo yes > "$TMP/release-state"
+        exit 1
+      fi
+      if [ "${MOCK_CREATE_FAILS:-}" = "yes" ]; then exit 1; fi
+      NOTES_ARG=""
+      while [ "\$#" -gt 0 ]; do
+        if [ "\$1" = "--notes-file" ] && [ "\$#" -ge 2 ]; then
+          NOTES_ARG="\$2"
+          break
+        fi
+        shift
+      done
+      if [ -n "\$NOTES_ARG" ] && grep -qF \
+        '<!-- rapid-mlx-auto-release:v1.2.3:$SHA_GOOD -->' "\$NOTES_ARG"; then
+        echo draft-marked > "$TMP/release-state"
+      else
+        echo draft > "$TMP/release-state"
+      fi
+      echo "created-v1.2.3" >&2
+    elif [ "\$sub" = "edit" ]; then
+      echo published > "$TMP/release-state"
+    else
+      exit 2
+    fi
+    ;;
+  api)
+    if [ "\$1" = "-X" ] && [ "\$2" = "POST" ]; then
+      # Atomic claim: on success the tag now exists at the claimed SHA.
+      if [ "${MOCK_CLAIM_FAILS:-}" = "yes" ]; then
+        if [ "${MOCK_CONCURRENT_RELEASE:-}" = "yes" ]; then
+          echo yes > "$TMP/release-state"
+        fi
+        exit 1
+      fi
+      SUBMITTED_REF=""
+      SUBMITTED_SHA=""
+      shift 3
+      while [ "\$#" -gt 0 ]; do
+        if [ "\$1" = "-f" ] && [ "\$#" -ge 2 ]; then
+          case "\$2" in
+            ref=*) SUBMITTED_REF="\${2#ref=}" ;;
+            sha=*) SUBMITTED_SHA="\${2#sha=}" ;;
+          esac
+          shift 2
+        else
+          shift
+        fi
+      done
+      [ "\$SUBMITTED_REF" = "refs/tags/v1.2.3" ] || exit 3
+      [ "\$SUBMITTED_SHA" = "$SHA_GOOD" ] || exit 3
+      echo "\$SUBMITTED_SHA" > "$TMP/ref-state"
+      echo '{"ref":"refs/tags/v1.2.3"}'
+    elif [[ "\$1" == repos/o/r/git/tags/* ]]; then
+      if [ "${MOCK_REF_UNREADABLE:-}" = "yes" ]; then exit 1; fi
+      printf 'commit\t%s\n' "${MOCK_TAG_REF:-$SHA_GOOD}"
+    else
+      # Resolve the explicit tag ref. Annotated tags are peeled by a second
+      # git/tags/<object> request above.
+      if [ "${MOCK_REF_UNREADABLE:-}" = "yes" ]; then exit 1; fi
+      if [ -s "$TMP/ref-state" ]; then
+        printf 'commit\t%s\n' "\$(cat "$TMP/ref-state")"
+        exit 0
+      fi
+      if [ -n "${MOCK_TAG_REF:-}" ]; then
+        if [ "${MOCK_TAG_TYPE:-commit}" = "tag" ]; then
+          printf 'tag\tannotated-object-sha\n'
+        else
+          printf 'commit\t%s\n' "\$MOCK_TAG_REF"
+        fi
+        exit 0
+      fi
+      exit 1
+    fi
+    ;;
+  *)
+    exit 2
+    ;;
+esac
+MOCK
+  chmod +x "$GH"
+  : > "$TMP/ref-state"
+  : > "$TMP/release-state"
+  printf 'notes for v1.2.3\n' > "$TMP/notes.md"
+  # Env-prefix vars on the run_script call are function-scoped, not exported,
+  # so push the mock knobs into the child explicitly.
+  export MOCK_RELEASE_VIEW MOCK_CLAIM_FAILS MOCK_TAG_REF MOCK_CREATE_FAILS
+  export MOCK_RELEASE_DRAFT MOCK_RELEASE_MARKED MOCK_REF_UNREADABLE MOCK_TAG_TYPE
+  export MOCK_CONCURRENT_RELEASE MOCK_CREATE_RACE
+  if GH_TOKEN=test TAG=v1.2.3 RELEASE_SHA="$SHA_GOOD" \
+     NOTES_FILE="$TMP/notes.md" GITHUB_REPOSITORY="o/r" \
+     bash "$SCRIPT" >"$TMP/out" 2>"$TMP/err"; then
+    echo "0"
+  else
+    echo "1"
+  fi
+}
+
+run_case() (
+  export MOCK_RELEASE_VIEW=no MOCK_RELEASE_DRAFT=no MOCK_RELEASE_MARKED=no
+  export MOCK_MARKER_NOT_FIRST=no
+  export MOCK_WRONG_TAG_MARKER=no
+  export MOCK_CLAIM_FAILS=no MOCK_TAG_REF="" MOCK_TAG_TYPE=commit
+  export MOCK_CREATE_FAILS=no MOCK_CREATE_RACE=no MOCK_REF_UNREADABLE=no
+  export MOCK_CONCURRENT_RELEASE=no
+  for setting in "$@"; do
+    export "$setting"
+  done
+  run_script
+)
+
+call_order() { grep '^' "$TMP/calls" 2>/dev/null || true; }
+
+# ==========================================================================
+echo "== 1. TOCTOU closed: tag is claimed atomically BEFORE release create =="
+# ==========================================================================
+RC=$(run_case)
+[ "$RC" = "0" ] && ok "fresh release succeeds" || bad "fresh release succeeds (rc=$RC)"
+POS=$(grep -n '^api -X POST repos/o/r/git/refs' "$TMP/calls" | head -1 | cut -d: -f1)
+CRT=$(grep -n '^release create' "$TMP/calls" | head -1 | cut -d: -f1)
+[ -n "$POS" ] && [ -n "$CRT" ] && [ "$POS" -lt "$CRT" ] && \
+  ok "refs POST precedes gh release create" || bad "refs POST precedes gh release create"
+contains "$(cat "$TMP/out")" "released v1.2.3 at $SHA_GOOD" "success banner printed"
+contains "$(call_order)" "release create v1.2.3 --title v1.2.3" \
+  "Release is created only after the tag claim"
+CREATE_CALL=$(grep '^release create' "$TMP/calls" | head -1)
+contains "$CREATE_CALL" "--draft" "release create starts as a draft"
+contains "$(call_order)" \
+  "release edit v1.2.3 --title v1.2.3 --notes-file $TMP/notes.md --draft=false" \
+  "verified draft is explicitly published"
+
+# Negative control: prove the mock fails if production submits the wrong SHA,
+# rather than hard-coding a successful claim independently of request args.
+GOOD_SCRIPT="$SCRIPT"
+BROKEN_SCRIPT="$TMP/create-release-wrong-sha.sh"
+sed 's/-f "sha=$RELEASE_SHA"/-f "sha=wrong-sha"/' "$GOOD_SCRIPT" > "$BROKEN_SCRIPT"
+SCRIPT="$BROKEN_SCRIPT"
+RC=$(run_case)
+SCRIPT="$GOOD_SCRIPT"
+[ "$RC" = "1" ] && ok "mock rejects an incorrect claimed SHA" \
+  || bad "mock rejects an incorrect claimed SHA (rc=$RC)"
+lacks "$(call_order)" "release create" "wrong claim never reaches Release creation"
+
+# ==========================================================================
+echo "== 2. tag-without-Release recovery: claim fails, tag matches -> recover =="
+# ==========================================================================
+RC=$(run_case MOCK_CLAIM_FAILS=yes MOCK_TAG_REF="$SHA_GOOD")
+[ "$RC" = "0" ] && ok "recovery succeeds when existing tag matches RELEASE_SHA" \
+  || bad "recovery succeeds when existing tag matches RELEASE_SHA (rc=$RC)"
+contains "$(cat "$TMP/out")" "already exists and points at the release commit" "reuse banner printed"
+contains "$(cat "$TMP/out")" "released v1.2.3" "release still created"
+
+RC=$(run_case MOCK_CLAIM_FAILS=yes MOCK_TAG_REF="$SHA_GOOD" MOCK_TAG_TYPE=tag)
+[ "$RC" = "0" ] && ok "annotated tag is peeled to its commit" \
+  || bad "annotated tag is peeled to its commit (rc=$RC)"
+contains "$(call_order)" "git/ref/tags/v1.2.3" \
+  "verification starts from the explicit tag namespace"
+
+RC=$(run_case MOCK_CLAIM_FAILS=yes MOCK_TAG_REF="$SHA_GOOD" \
+  MOCK_CONCURRENT_RELEASE=yes)
+[ "$RC" = "0" ] && ok "concurrent Release after lost claim is idempotent" \
+  || bad "concurrent Release after lost claim is idempotent (rc=$RC)"
+lacks "$(call_order)" "release create" \
+  "lost-claim recovery does not race a concurrent Release create"
+
+# ==========================================================================
+echo "== 3. stale tag mismatch: claim fails, tag points elsewhere -> hard fail =="
+# ==========================================================================
+RC=$(run_case MOCK_CLAIM_FAILS=yes MOCK_TAG_REF="$SHA_BAD")
+[ "$RC" = "1" ] && ok "mismatched tag fails loudly" || bad "mismatched tag fails loudly (rc=$RC)"
+lacks "$(call_order)" "release create" "no gh release create on a stale tag"
+
+# ==========================================================================
+echo "== 4. idempotent: Release already exists -> done, no claim/create =="
+# ==========================================================================
+RC=$(run_case MOCK_RELEASE_VIEW=yes MOCK_TAG_REF="$SHA_GOOD")
+[ "$RC" = "0" ] && ok "existing Release is idempotent-done" || bad "existing Release is idempotent-done (rc=$RC)"
+lacks "$(call_order)" "api -X POST" "no tag claim when Release already exists"
+lacks "$(call_order)" "release create" "no release create when Release already exists"
+
+RC=$(run_case MOCK_RELEASE_VIEW=yes MOCK_RELEASE_DRAFT=yes \
+  MOCK_RELEASE_MARKED=yes MOCK_TAG_REF="$SHA_GOOD")
+[ "$RC" = "0" ] && ok "matching draft Release is resumed" \
+  || bad "matching draft Release is resumed (rc=$RC)"
+contains "$(call_order)" \
+  "release edit v1.2.3 --title v1.2.3 --notes-file $TMP/notes.md --draft=false" \
+  "recovery replaces draft title/notes before publishing"
+contains "$(cat "$TMP/out")" "released v1.2.3 at $SHA_GOOD" \
+  "resumed draft reports published success"
+
+RC=$(run_case MOCK_RELEASE_VIEW=yes MOCK_RELEASE_DRAFT=yes \
+  MOCK_RELEASE_MARKED=no MOCK_TAG_REF="$SHA_GOOD")
+[ "$RC" = "1" ] && ok "manual draft is never auto-published" \
+  || bad "manual draft is never auto-published (rc=$RC)"
+lacks "$(call_order)" "release edit" "manual draft remains untouched"
+
+RC=$(run_case MOCK_RELEASE_VIEW=yes MOCK_RELEASE_DRAFT=yes \
+  MOCK_MARKER_NOT_FIRST=yes MOCK_TAG_REF="$SHA_GOOD")
+[ "$RC" = "1" ] && ok "marker outside the first line does not claim ownership" \
+  || bad "marker outside the first line does not claim ownership (rc=$RC)"
+lacks "$(call_order)" "release edit" "embedded marker cannot publish manual draft"
+
+RC=$(run_case MOCK_RELEASE_VIEW=yes MOCK_RELEASE_DRAFT=yes \
+  MOCK_WRONG_TAG_MARKER=yes MOCK_TAG_REF="$SHA_GOOD")
+[ "$RC" = "1" ] && ok "same-SHA marker copied from another tag is rejected" \
+  || bad "same-SHA marker copied from another tag is rejected (rc=$RC)"
+lacks "$(call_order)" "release edit" "cross-tag copied draft remains untouched"
+
+# Existing Release idempotency must remain fail-closed when its tag cannot be
+# resolved.  Otherwise a transient API/auth failure can falsely bless a
+# Release whose shipped tree was never verified.
+RC=$(run_case MOCK_RELEASE_VIEW=yes MOCK_TAG_REF="$SHA_GOOD" \
+  MOCK_REF_UNREADABLE=yes)
+[ "$RC" = "1" ] && ok "existing Release with unreadable tag fails closed" \
+  || bad "existing Release with unreadable tag fails closed (rc=$RC)"
+lacks "$(call_order)" "release create" "unverifiable existing Release is not recreated"
+
+# ==========================================================================
+echo "== 5. release create failure leaves tag claimed (recovery reaches it) =="
+# ==========================================================================
+RC=$(run_case MOCK_CREATE_FAILS=yes)
+[ "$RC" = "1" ] && ok "release create failure propagates" || bad "release create failure propagates (rc=$RC)"
+POS=$(grep -n '^api -X POST' "$TMP/calls" | head -1 | cut -d: -f1)
+CRT=$(grep -n '^release create' "$TMP/calls" | head -1 | cut -d: -f1)
+[ -n "$POS" ] && [ -n "$CRT" ] && [ "$POS" -lt "$CRT" ] && \
+  ok "tag still claimed before the failed create (recoverable next run)" || \
+  bad "tag still claimed before the failed create (recoverable next run)"
+
+RC=$(run_case MOCK_CREATE_RACE=yes)
+[ "$RC" = "0" ] && ok "concurrent Release that wins create race is idempotent" \
+  || bad "concurrent Release that wins create race is idempotent (rc=$RC)"
+contains "$(cat "$TMP/out")" "already exists at the release commit" \
+  "create-race success is reported after verification"
+
+# ==========================================================================
+echo
+echo "tests/release/test_create_release.sh: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
## What changed

- atomically claim release tags through the Git refs API before publishing
- keep tag-without-Release and workflow-owned draft recovery reachable
- bind draft ownership to an exact first-line `TAG + SHA` marker
- peel explicit lightweight/annotated tag refs and handle concurrent writers idempotently
- verify marker/tag, replace with clean generated notes, then publish; manual/copied drafts remain untouched
- add isolated offline race, recovery, ownership, wiring, and negative-control coverage

## Why

The previous check-then-create sequence had a TOCTOU window where another writer could create the tag before `gh release create`, which then ignores `--target`. Detection also skipped every existing tag, making recovery from a tag or workflow draft without a published Release unreachable.

Closes #1462.

## Test plan

- [x] `bash tests/release/test_create_release.sh` — 41 passed
- [x] `bash tests/release/test_build_release_notes.sh` — 45 passed
- [x] `python -m pytest -q tests/test_validate_release_subject.py` — 16 passed
- [x] `python scripts/check_workflow_expressions.py` — 14 workflows OK
- [x] `shellcheck scripts/create_release.sh`
- [x] `bash -n scripts/create_release.sh tests/release/test_create_release.sh`
- [x] `git diff --check`