### PR TITLE
fix(responses): stabilize DeepSeek Codex long turns

### DIFF
--- a/tests/test_responses_engine_failure_envelope.py
+++ b/tests/test_responses_engine_failure_envelope.py
@@ -1076,6 +1076,12 @@ class TestResponsesStreamFailureEnvelope:
         )
         assert reasoning_done < message_added
         assert "response.function_call_arguments.delta" in names
+        text = "".join(
+            str(data.get("delta") or "")
+            for name, data in events
+            if name == "response.output_text.delta"
+        )
+        assert "I'll patch it." in text
 
     def test_auto_tool_choice_allows_textual_action_language(
         self, tool_intent_only_stop_client

--- a/tests/test_responses_engine_failure_envelope.py
+++ b/tests/test_responses_engine_failure_envelope.py
@@ -35,16 +35,21 @@ async def test_deepseek_codex_nonprogress_retry_is_internal(monkeypatch):
     import vllm_mlx.routes.responses as responses_route
 
     calls: list[bool] = []
+    visible_heartbeat_state: dict[str, object] = {}
 
     async def fake_stream(*args, nonprogress_retry=False, **kwargs):
         calls.append(nonprogress_retry)
+        state = kwargs["heartbeat_state"]
         if not nonprogress_retry:
+            state["response"] = {"id": "hidden-attempt"}
+            assert visible_heartbeat_state == {}
             yield 'data: {"type":"response.created","attempt":1}\n\n'
             yield (
                 'data: {"type":"response.failed","response":{"error":'
                 '{"code":"model_no_final_answer"}}}\n\n'
             )
         else:
+            state["response"] = {"id": "visible-attempt"}
             yield 'data: {"type":"response.created","attempt":2}\n\n'
             yield 'data: {"type":"response.completed","attempt":2}\n\n'
 
@@ -64,13 +69,14 @@ async def test_deepseek_codex_nonprogress_retry_is_internal(monkeypatch):
     events = [
         event
         async for event in responses_route._stream_responses_with_nonprogress_retry(
-            object(), object(), request
+            object(), object(), request, heartbeat_state=visible_heartbeat_state
         )
     ]
 
     assert calls == [False, True]
     assert all('"attempt":1' not in event for event in events)
     assert any('"type":"response.completed"' in event for event in events)
+    assert visible_heartbeat_state["response"] == {"id": "visible-attempt"}
 
 
 class _Tokenizer:

--- a/tests/test_responses_engine_failure_envelope.py
+++ b/tests/test_responses_engine_failure_envelope.py
@@ -75,6 +75,7 @@ async def test_deepseek_codex_nonprogress_retry_is_internal(monkeypatch):
 
     assert calls == [False, True]
     assert all('"attempt":1' not in event for event in events)
+    assert all('"type":"response.failed"' not in event for event in events)
     assert any('"type":"response.completed"' in event for event in events)
     assert visible_heartbeat_state["response"] == {"id": "visible-attempt"}
 

--- a/tests/test_responses_engine_failure_envelope.py
+++ b/tests/test_responses_engine_failure_envelope.py
@@ -29,6 +29,50 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 
+@pytest.mark.asyncio
+async def test_deepseek_codex_nonprogress_retry_is_internal(monkeypatch):
+    """A hidden-only first attempt must not leak a failed SSE lifecycle."""
+    import vllm_mlx.routes.responses as responses_route
+
+    calls: list[bool] = []
+
+    async def fake_stream(*args, nonprogress_retry=False, **kwargs):
+        calls.append(nonprogress_retry)
+        if not nonprogress_retry:
+            yield 'data: {"type":"response.created","attempt":1}\n\n'
+            yield (
+                'data: {"type":"response.failed","response":{"error":'
+                '{"code":"model_no_final_answer"}}}\n\n'
+            )
+        else:
+            yield 'data: {"type":"response.created","attempt":2}\n\n'
+            yield 'data: {"type":"response.completed","attempt":2}\n\n'
+
+    monkeypatch.setattr(responses_route, "_stream_responses", fake_stream)
+    monkeypatch.setattr(
+        responses_route,
+        "get_config",
+        lambda: SimpleNamespace(tool_call_parser="deepseek_v4_0731"),
+    )
+    request = SimpleNamespace(
+        tools=[
+            {"type": "function", "name": "exec_command"},
+            {"type": "function", "name": "write_stdin"},
+        ]
+    )
+
+    events = [
+        event
+        async for event in responses_route._stream_responses_with_nonprogress_retry(
+            object(), object(), request
+        )
+    ]
+
+    assert calls == [False, True]
+    assert all('"attempt":1' not in event for event in events)
+    assert any('"type":"response.completed"' in event for event in events)
+
+
 class _Tokenizer:
     chat_template = ""
 
@@ -209,6 +253,48 @@ class _ReasoningThenWhitespaceStopEngine:
             finish_reason="stop",
             finished=True,
             channel="content",
+        )
+
+
+class _ContentThenReasoningThenToolEngine:
+    """DeepSeek agent shape: action prose precedes renewed reasoning + DSML."""
+
+    preserve_native_tool_format = False
+
+    def __init__(self):
+        self.tokenizer = _Tokenizer()
+
+    async def stream_chat(self, messages, **kwargs):
+        yield _GenerationOutput(
+            text="I'll patch it.",
+            raw_text="I'll patch it.",
+            new_text="I'll patch it.",
+            prompt_tokens=7,
+            completion_tokens=4,
+            finish_reason=None,
+            finished=False,
+            channel="content",
+        )
+        yield _GenerationOutput(
+            text="Need the smallest edit.",
+            raw_text="Need the smallest edit.",
+            new_text="Need the smallest edit.",
+            completion_tokens=9,
+            finish_reason=None,
+            finished=False,
+            channel="reasoning",
+        )
+        yield _GenerationOutput(
+            completion_tokens=12,
+            finish_reason="tool_calls",
+            finished=True,
+            tool_calls=[
+                {
+                    "id": "call_patch",
+                    "name": "exec_command",
+                    "arguments": '{"cmd":"apply_patch <<PATCH\\nPATCH"}',
+                }
+            ],
         )
 
 
@@ -560,6 +646,18 @@ def reasoning_only_stop_client(monkeypatch):
 @pytest.fixture
 def reasoning_then_whitespace_stop_client(monkeypatch):
     holder = _build_client(monkeypatch, _ReasoningThenWhitespaceStopEngine)
+    yield holder
+    holder.cleanup()
+
+
+@pytest.fixture
+def content_then_reasoning_then_tool_client(monkeypatch):
+    holder = _build_client(monkeypatch, _ContentThenReasoningThenToolEngine)
+    from vllm_mlx.config import get_config
+
+    cfg = get_config()
+    cfg.model_name = "deepseek-v4-flash-0731"
+    cfg.tool_call_parser = "deepseek_v4_0731"
     yield holder
     holder.cleanup()
 
@@ -934,6 +1032,50 @@ class TestResponsesStreamFailureEnvelope:
         assert "response.completed" not in names, names
         failed = next(data for name, data in events if name == "response.failed")
         assert failed["response"]["error"]["code"] == "model_no_final_answer"
+
+    def test_deepseek_codex_buffers_content_across_renewed_reasoning(
+        self, content_then_reasoning_then_tool_client
+    ):
+        payload = {
+            **PAYLOAD,
+            "model": "deepseek-v4-flash-0731",
+            "stream": True,
+            "tools": [
+                {
+                    "type": "function",
+                    "name": "exec_command",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"cmd": {"type": "string"}},
+                        "required": ["cmd"],
+                    },
+                },
+                {
+                    "type": "function",
+                    "name": "write_stdin",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            ],
+        }
+        with content_then_reasoning_then_tool_client.client.stream(
+            "POST", "/v1/responses", json=payload, headers=HEADERS
+        ) as resp:
+            body = "".join(resp.iter_text())
+            assert resp.status_code == 200, body
+            events = _parse_sse(body)
+
+        names = [name for name, _ in events]
+        assert "response.failed" not in names, names
+        assert "response.completed" in names, names
+        reasoning_done = names.index("response.reasoning_summary_text.done")
+        message_added = next(
+            index
+            for index, (name, data) in enumerate(events)
+            if name == "response.output_item.added"
+            and data.get("item", {}).get("type") == "message"
+        )
+        assert reasoning_done < message_added
+        assert "response.function_call_arguments.delta" in names
 
     def test_auto_tool_choice_allows_textual_action_language(
         self, tool_intent_only_stop_client

--- a/tests/test_responses_engine_failure_envelope.py
+++ b/tests/test_responses_engine_failure_envelope.py
@@ -1081,7 +1081,14 @@ class TestResponsesStreamFailureEnvelope:
             if name == "response.output_item.added"
             and data.get("item", {}).get("type") == "message"
         )
+        function_call_added = next(
+            index
+            for index, (name, data) in enumerate(events)
+            if name == "response.output_item.added"
+            and data.get("item", {}).get("type") == "function_call"
+        )
         assert reasoning_done < message_added
+        assert message_added < function_call_added
         assert "response.function_call_arguments.delta" in names
         text = "".join(
             str(data.get("delta") or "")

--- a/tests/test_responses_route.py
+++ b/tests/test_responses_route.py
@@ -1486,6 +1486,54 @@ def test_codex_progress_reminder_recognizes_shell_file_creation_as_edit():
     )
 
 
+def test_codex_progress_reminder_recognizes_interactive_write_as_edit():
+    from vllm_mlx.api.responses_models import ResponsesRequest
+    from vllm_mlx.routes.responses import _inject_codex_progress_reminder
+
+    items = [
+        {
+            "type": "function_call",
+            "name": "write_stdin",
+            "call_id": "edit",
+            "arguments": '{"chars":"cat > fixed.py\\nnew content\\n"}',
+        }
+    ]
+    for index in range(8):
+        items.extend(
+            [
+                {
+                    "type": "function_call",
+                    "name": "exec_command",
+                    "call_id": f"check_{index}",
+                    "arguments": f'{{"cmd":"check {index}"}}',
+                },
+                {
+                    "type": "function_call_output",
+                    "call_id": f"check_{index}",
+                    "output": "ok",
+                },
+            ]
+        )
+
+    assert (
+        _inject_codex_progress_reminder(
+            [], ResponsesRequest(model="deepseek-v4", input=items)
+        )
+        == []
+    )
+
+
+def test_codex_progress_reminder_ignores_dev_null_redirection():
+    from vllm_mlx.routes.responses import _codex_call_performs_edit
+
+    assert not _codex_call_performs_edit(
+        "exec_command", '{"cmd":"cat source.py > /dev/null"}'
+    )
+    assert not _codex_call_performs_edit(
+        "exec_command", '{"cmd":"printf status | tee /dev/null"}'
+    )
+
+
 def test_codex_progress_does_not_mistake_prose_passed_for_test_success():
     from vllm_mlx.api.responses_models import ResponsesRequest
     from vllm_mlx.routes.responses import _inject_codex_progress_reminder

--- a/tests/test_responses_route.py
+++ b/tests/test_responses_route.py
@@ -1417,6 +1417,75 @@ def test_codex_progress_reminder_does_not_assume_five_reads_are_enough():
     assert reminded[-1]["_rapid_mlx_transient_priming"] is True
 
 
+def test_codex_progress_reminder_bounds_unresolved_read_only_exploration():
+    from vllm_mlx.api.responses_models import ResponsesRequest
+    from vllm_mlx.routes.responses import _inject_codex_progress_reminder
+
+    items = []
+    for index in range(8):
+        items.extend(
+            [
+                {
+                    "type": "function_call",
+                    "name": "exec_command",
+                    "call_id": f"read_{index}",
+                    "arguments": f'{{"cmd":"sed -n {index + 1}p file.py"}}',
+                },
+                {
+                    "type": "function_call_output",
+                    "call_id": f"read_{index}",
+                    "output": f"evidence {index}",
+                },
+            ]
+        )
+
+    reminded = _inject_codex_progress_reminder(
+        [], ResponsesRequest(model="deepseek-v4", input=items)
+    )
+
+    assert "eight read-only tool results" in reminded[-1]["content"]
+    assert "one concrete unresolved question" in reminded[-1]["content"]
+    assert "Do not edit while a material ambiguity remains" in reminded[-1]["content"]
+    assert reminded[-1]["_rapid_mlx_transient_priming"] is True
+
+
+def test_codex_progress_reminder_recognizes_shell_file_creation_as_edit():
+    from vllm_mlx.api.responses_models import ResponsesRequest
+    from vllm_mlx.routes.responses import _inject_codex_progress_reminder
+
+    items = [
+        {
+            "type": "function_call",
+            "name": "exec_command",
+            "call_id": "edit",
+            "arguments": '{"cmd":"cat > scripts/new.sh <<\\\'EOF\\\'"}',
+        }
+    ]
+    for index in range(8):
+        items.extend(
+            [
+                {
+                    "type": "function_call",
+                    "name": "exec_command",
+                    "call_id": f"check_{index}",
+                    "arguments": f'{{"cmd":"check {index}"}}',
+                },
+                {
+                    "type": "function_call_output",
+                    "call_id": f"check_{index}",
+                    "output": "ok",
+                },
+            ]
+        )
+
+    assert (
+        _inject_codex_progress_reminder(
+            [], ResponsesRequest(model="deepseek-v4", input=items)
+        )
+        == []
+    )
+
+
 def test_codex_progress_does_not_mistake_prose_passed_for_test_success():
     from vllm_mlx.api.responses_models import ResponsesRequest
     from vllm_mlx.routes.responses import _inject_codex_progress_reminder

--- a/tests/test_responses_route.py
+++ b/tests/test_responses_route.py
@@ -1532,6 +1532,16 @@ def test_codex_progress_reminder_ignores_dev_null_redirection():
     assert not _codex_call_performs_edit(
         "exec_command", '{"cmd":"printf status | tee /dev/null"}'
     )
+    assert not _codex_call_performs_edit(
+        "exec_command", '{"cmd":"cat file.py | rg \'x > y\'"}'
+    )
+    assert _codex_call_performs_edit(
+        "exec_command", '{"cmd":"printf content > fixed.py"}'
+    )
+    assert _codex_call_performs_edit("exec_command", '{"cmd":"touch fixed.py"}')
+    assert _codex_call_performs_edit(
+        "write_stdin", '{"chars":"Path(\\"x.py\\").write_text(\\"ok\\")"}'
+    )
 
 
 def test_codex_progress_does_not_mistake_prose_passed_for_test_success():

--- a/vllm_mlx/routes/responses.py
+++ b/vllm_mlx/routes/responses.py
@@ -284,16 +284,22 @@ def _codex_call_performs_edit(name: str, arguments: str) -> bool:
     if name == "apply_patch":
         return True
     command = arguments
+    argument_field = "chars" if name == "write_stdin" else "cmd"
     try:
         decoded = json.loads(arguments)
-        if isinstance(decoded, dict) and isinstance(decoded.get("cmd"), str):
-            command = decoded["cmd"]
+        if isinstance(decoded, dict) and isinstance(decoded.get(argument_field), str):
+            command = decoded[argument_field]
     except (TypeError, ValueError):
         # Some model-emitted argument objects escape apostrophes as ``\'``,
         # which is harmless to the shell command but invalid JSON.
-        match = re.search(r'"cmd"\s*:\s*"((?:\\.|[^"\\])*)"', arguments)
+        match = re.search(rf'"{argument_field}"\s*:\s*"((?:\\.|[^"\\])*)"', arguments)
         if match:
             command = match.group(1).replace(r"\'", "'").replace(r"\"", '"')
+
+    # Output sinks do not modify the project and should not suppress the
+    # exploration checkpoint.
+    command = re.sub(r"(?:>>|>)\s*/dev/null\b", "", command)
+    command = re.sub(r"\btee(?:\s+-\S+)*\s+/dev/null\b", "", command)
 
     shell_write = re.compile(
         r"(?:^|[\n;&|])\s*(?:"
@@ -2347,6 +2353,10 @@ async def _stream_responses_with_nonprogress_retry(
             yield event
         return
 
+    # Transport liveness and cancellation remain owned by the outer
+    # ``_disconnect_guard`` in ``create_response``. While lifecycle events are
+    # held here, that guard keeps polling disconnects and emits parsed
+    # Responses heartbeats from ``heartbeat_state`` at the configured interval.
     buffered: list[str] = []
     buffered_bytes = 0
     committed = False
@@ -2667,6 +2677,7 @@ async def _stream_responses(
         _defer_public_text = _forced_choice_active or bool(
             codex_surface
             and openai_request.tools
+            and openai_request.tool_choice != "none"
             and cfg.tool_call_parser == "deepseek_v4_0731"
         )
         deferred_text: list[str] = []

--- a/vllm_mlx/routes/responses.py
+++ b/vllm_mlx/routes/responses.py
@@ -18,6 +18,7 @@ import asyncio
 import json
 import logging
 import re
+import tempfile
 import time
 import uuid
 from collections.abc import AsyncIterator, Mapping
@@ -115,7 +116,6 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 _NONPROGRESS_RETRY_BUFFER_LIMIT = 4 * 1024 * 1024
-_DEFERRED_PUBLIC_TEXT_LIMIT = 4 * 1024 * 1024
 
 
 def _should_prime_deepseek_codex_exec(
@@ -2404,7 +2404,7 @@ async def _stream_responses_with_nonprogress_retry(
             buffered.clear()
             if not event_buffered:
                 yield event
-        elif '"code":"model_no_final_answer"' in event.replace(" ", ""):
+        elif _responses_event_is_nonprogress_failure(event):
             retry_nonprogress = True
 
     if committed:
@@ -2450,6 +2450,23 @@ def _responses_event_commits_progress(event: str) -> bool:
             item_type = data.get("item", {}).get("type")
             if item_type in {"function_call", "computer_call"}:
                 return True
+    return False
+
+
+def _responses_event_is_nonprogress_failure(event: str) -> bool:
+    """Match only the terminal failure envelope, never model-authored text."""
+    for line in event.splitlines():
+        if not line.startswith("data: "):
+            continue
+        try:
+            data = json.loads(line[6:])
+        except (TypeError, ValueError):
+            continue
+        return bool(
+            data.get("type") == "response.failed"
+            and data.get("response", {}).get("error", {}).get("code")
+            == "model_no_final_answer"
+        )
     return False
 
 
@@ -2695,15 +2712,39 @@ async def _stream_responses(
         # public text for DeepSeek Codex tool turns until generation finishes,
         # when the complete reasoning/message/tool ordering is known. Ordinary
         # chat streams and other models retain token-by-token text delivery.
-        _defer_public_text = _forced_choice_active or bool(
+        _deepseek_defer_public_text = bool(
             codex_surface
             and openai_request.tools
             and openai_request.tool_choice != "none"
             and cfg.tool_call_parser == "deepseek_v4_0731"
         )
+        _defer_public_text = _forced_choice_active or _deepseek_defer_public_text
         deferred_text: list[str] = []
-        deferred_text_bytes = 0
-        deferred_text_overflow = False
+        # DeepSeek auto-tool turns can defer much more prose than legacy
+        # forced-choice synthesis. Spill beyond 1 MiB instead of growing an
+        # unbounded Python list; the file is closed when the generator exits.
+        deferred_text_file = (
+            tempfile.SpooledTemporaryFile(
+                max_size=1024 * 1024, mode="w+", encoding="utf-8"
+            )
+            if _deepseek_defer_public_text
+            else None
+        )
+
+        def _clear_deferred_text() -> None:
+            deferred_text.clear()
+            if deferred_text_file is not None:
+                deferred_text_file.close()
+
+        def _take_deferred_text() -> str:
+            if deferred_text_file is not None:
+                deferred_text_file.seek(0)
+                value = deferred_text_file.read()
+                deferred_text_file.close()
+                return value
+            value = "".join(deferred_text)
+            deferred_text.clear()
+            return value
 
         _tokenizer = engine.tokenizer
         _chat_template = ""
@@ -3077,19 +3118,14 @@ async def _stream_responses(
             yielded — final flush decision happens after the engine
             stream completes and we know whether synthesis is needed.
             """
-            nonlocal accumulated_text, deferred_text_bytes, deferred_text_overflow
+            nonlocal accumulated_text
             if not delta:
                 return
             if _defer_public_text:
-                delta_bytes = len(delta.encode("utf-8"))
-                if deferred_text_bytes + delta_bytes > _DEFERRED_PUBLIC_TEXT_LIMIT:
-                    deferred_text.clear()
-                    deferred_text_overflow = True
-                    return
-                if deferred_text_overflow:
-                    return
-                deferred_text.append(delta)
-                deferred_text_bytes += delta_bytes
+                if deferred_text_file is not None:
+                    deferred_text_file.write(delta)
+                else:
+                    deferred_text.append(delta)
                 return
             if not message_open:
                 for ev in await _open_message_item():
@@ -3126,14 +3162,11 @@ async def _stream_responses(
             ``output_text.delta`` so the client still sees the
             assistant's actual text content.
             """
-            nonlocal accumulated_text, deferred_text_bytes
-            if will_synthesise or not deferred_text:
-                deferred_text.clear()
-                deferred_text_bytes = 0
+            nonlocal accumulated_text
+            if will_synthesise:
+                _clear_deferred_text()
                 return
-            joined = "".join(deferred_text)
-            deferred_text.clear()
-            deferred_text_bytes = 0
+            joined = _take_deferred_text()
             if not joined:
                 return
             if not message_open:
@@ -3666,27 +3699,6 @@ async def _stream_responses(
         # are out — emit a ``response.failed`` event with the same
         # error envelope instead so the client sees a clean shutdown
         # signal.
-        if deferred_text_overflow:
-            logger.warning(
-                "DeepSeek Codex deferred public text exceeded %d bytes",
-                _DEFERRED_PUBLIC_TEXT_LIMIT,
-            )
-            yield _emit(
-                "response.failed",
-                {
-                    "type": "response.failed",
-                    "response": {
-                        **_initial_response_payload,
-                        "status": "failed",
-                        "error": {
-                            "code": "deferred_text_limit_exceeded",
-                            "message": "Deferred agent output exceeded the safe buffer limit.",
-                        },
-                    },
-                },
-            )
-            return
-
         try:
             tool_calls = _enforce_responses_tool_choice(
                 parsed_tool_calls, responses_request, openai_request
@@ -3703,7 +3715,7 @@ async def _stream_responses(
             # Drop any deferred buffered text — the request failed
             # under forced choice, the deferred prose has no
             # legitimate destination on the wire.
-            deferred_text.clear()
+            _clear_deferred_text()
             err_detail = forced_choice_err.detail
             if isinstance(err_detail, dict):
                 err_envelope = err_detail.get("error", {})

--- a/vllm_mlx/routes/responses.py
+++ b/vllm_mlx/routes/responses.py
@@ -2590,6 +2590,7 @@ async def _stream_responses(
                 openai_request, responses_request, cfg.tool_call_parser
             ),
         }
+        forced_prefix = None
         if openai_request.tools:
             chat_kwargs["tools"] = convert_tools_for_template(openai_request.tools)
             from .chat import _compute_forced_tool_prefix
@@ -2687,6 +2688,7 @@ async def _stream_responses(
             codex_surface
             and openai_request.tools
             and openai_request.tool_choice != "none"
+            and forced_prefix
             and cfg.tool_call_parser == "deepseek_v4_0731"
         )
         deferred_text: list[str] = []

--- a/vllm_mlx/routes/responses.py
+++ b/vllm_mlx/routes/responses.py
@@ -18,6 +18,7 @@ import asyncio
 import json
 import logging
 import re
+import shlex
 import tempfile
 import time
 import uuid
@@ -302,17 +303,54 @@ def _codex_call_performs_edit(name: str, arguments: str) -> bool:
     command = re.sub(r"(?:>>|>)\s*/dev/null\b", "", command)
     command = re.sub(r"\btee(?:\s+-\S+)*\s+/dev/null\b", "", command)
 
-    shell_write = re.compile(
-        r"(?:^|[\n;&|])\s*(?:"
-        r"apply_patch\b|"
-        r"cat\b[^\n;]*(?:>>|>)|"
-        r"tee(?:\s+-\S+)*\s+[^\n;]+|"
-        r"sed\s+(?:-[A-Za-z]*i[A-Za-z]*|--in-place)\b"
-        r")"
-    )
-    if shell_write.search(command):
+    try:
+        lexer = shlex.shlex(command, posix=True, punctuation_chars="|&;<>")
+        lexer.whitespace_split = True
+        lexer.commenters = ""
+        tokens = list(lexer)
+    except ValueError:
+        tokens = []
+    for index, token in enumerate(tokens):
+        if token in {">", ">>"}:
+            target = tokens[index + 1] if index + 1 < len(tokens) else ""
+            if target and target != "/dev/null":
+                return True
+    mutating_commands = {
+        "apply_patch",
+        "cp",
+        "install",
+        "ln",
+        "mkdir",
+        "mv",
+        "rm",
+        "rmdir",
+        "touch",
+        "truncate",
+    }
+    command_words = [
+        token
+        for index, token in enumerate(tokens)
+        if index == 0 or tokens[index - 1] in {";", "&&", "||", "|"}
+    ]
+    if any(word.rsplit("/", 1)[-1] in mutating_commands for word in command_words):
         return True
-    if not re.search(r"(?:^|[\s/])python(?:\d+(?:\.\d+)?)?\b", command):
+    for index, token in enumerate(tokens):
+        if token.rsplit("/", 1)[-1] != "tee":
+            continue
+        destinations = [
+            value
+            for value in tokens[index + 1 :]
+            if value not in {";", "&&", "||", "|"} and not value.startswith("-")
+        ]
+        if any(value != "/dev/null" for value in destinations):
+            return True
+    if re.search(
+        r"(?:^|[\n;&|])\s*sed\s+(?:-[A-Za-z]*i[A-Za-z]*|--in-place)\b", command
+    ):
+        return True
+    if name != "write_stdin" and not re.search(
+        r"(?:^|[\s/])python(?:\d+(?:\.\d+)?)?\b", command
+    ):
         return False
     return bool(
         re.search(r"\.(?:write_text|write_bytes)\s*\(", command)

--- a/vllm_mlx/routes/responses.py
+++ b/vllm_mlx/routes/responses.py
@@ -114,6 +114,8 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
+_NONPROGRESS_RETRY_BUFFER_LIMIT = 4 * 1024 * 1024
+
 
 def _should_prime_deepseek_codex_exec(
     responses_request: ResponsesRequest, tool_parser: str | None
@@ -232,22 +234,7 @@ def _inject_codex_progress_reminder(
             call_id = str(data.get("call_id") or "")
             calls[call_id] = arguments
             call_names[call_id] = str(data.get("name") or "")
-            if any(
-                marker in arguments
-                for marker in (
-                    "apply_patch",
-                    "cat >",
-                    "cat >>",
-                    "tee ",
-                    "sed -i",
-                    ".write_text(",
-                    ".write_bytes(",
-                    'open(p,"w")',
-                    'open(p, "w")',
-                    "open(p,'w')",
-                    "open(p, 'w')",
-                )
-            ):
+            if _codex_call_performs_edit(call_names[call_id], arguments):
                 has_edited = True
                 has_test_passed = False
                 has_test_failed = False
@@ -290,6 +277,43 @@ def _inject_codex_progress_reminder(
             "_rapid_mlx_transient_priming": True,
         },
     ]
+
+
+def _codex_call_performs_edit(name: str, arguments: str) -> bool:
+    """Recognize common coding-agent writes without matching search literals."""
+    if name == "apply_patch":
+        return True
+    command = arguments
+    try:
+        decoded = json.loads(arguments)
+        if isinstance(decoded, dict) and isinstance(decoded.get("cmd"), str):
+            command = decoded["cmd"]
+    except (TypeError, ValueError):
+        # Some model-emitted argument objects escape apostrophes as ``\'``,
+        # which is harmless to the shell command but invalid JSON.
+        match = re.search(r'"cmd"\s*:\s*"((?:\\.|[^"\\])*)"', arguments)
+        if match:
+            command = match.group(1).replace(r"\'", "'").replace(r"\"", '"')
+
+    shell_write = re.compile(
+        r"(?:^|[\n;&|])\s*(?:"
+        r"apply_patch\b|"
+        r"cat\b[^\n;]*(?:>>|>)|"
+        r"tee(?:\s+-\S+)*\s+[^\n;]+|"
+        r"sed\s+(?:-[A-Za-z]*i[A-Za-z]*|--in-place)\b"
+        r")"
+    )
+    if shell_write.search(command):
+        return True
+    if not re.search(r"(?:^|[\s/])python(?:\d+(?:\.\d+)?)?\b", command):
+        return False
+    return bool(
+        re.search(r"\.(?:write_text|write_bytes)\s*\(", command)
+        or re.search(
+            r"\bopen\s*\([^,\n]+,\s*(['\"])[^'\"]*[wax+][^'\"]*\1",
+            command,
+        )
+    )
 
 
 def _codex_action_command_prefix(responses_request: ResponsesRequest) -> str | None:
@@ -2324,6 +2348,8 @@ async def _stream_responses_with_nonprogress_retry(
         return
 
     buffered: list[str] = []
+    buffered_bytes = 0
+    committed = False
     retry_nonprogress = False
     async for event in _stream_responses(
         engine,
@@ -2333,10 +2359,29 @@ async def _stream_responses_with_nonprogress_retry(
         request_id_holder=request_id_holder,
         heartbeat_state=heartbeat_state,
     ):
+        if committed:
+            yield event
+            continue
         buffered.append(event)
-        if '"code":"model_no_final_answer"' in event.replace(" ", ""):
+        buffered_bytes += len(event.encode("utf-8"))
+        if _responses_event_commits_progress(event):
+            committed = True
+        elif buffered_bytes >= _NONPROGRESS_RETRY_BUFFER_LIMIT:
+            logger.warning(
+                "DeepSeek Codex retry buffer reached %d bytes; preserving streaming "
+                "and disabling the transparent retry for this turn",
+                buffered_bytes,
+            )
+            committed = True
+        if committed:
+            for pending in buffered:
+                yield pending
+            buffered.clear()
+        elif '"code":"model_no_final_answer"' in event.replace(" ", ""):
             retry_nonprogress = True
 
+    if committed:
+        return
     if not retry_nonprogress:
         for event in buffered:
             yield event
@@ -2357,6 +2402,25 @@ async def _stream_responses_with_nonprogress_retry(
         nonprogress_retry=True,
     ):
         yield event
+
+
+def _responses_event_commits_progress(event: str) -> bool:
+    """Return whether an SSE event proves this attempt has public progress."""
+    for line in event.splitlines():
+        if not line.startswith("data: "):
+            continue
+        try:
+            data = json.loads(line[6:])
+        except (TypeError, ValueError):
+            continue
+        event_type = data.get("type")
+        if event_type == "response.output_text.delta":
+            return bool(str(data.get("delta") or "").strip())
+        if event_type == "response.output_item.added":
+            item_type = data.get("item", {}).get("type")
+            if item_type in {"function_call", "computer_call"}:
+                return True
+    return False
 
 
 async def _stream_responses(

--- a/vllm_mlx/routes/responses.py
+++ b/vllm_mlx/routes/responses.py
@@ -2356,7 +2356,10 @@ async def _stream_responses_with_nonprogress_retry(
     # Transport liveness and cancellation remain owned by the outer
     # ``_disconnect_guard`` in ``create_response``. While lifecycle events are
     # held here, that guard keeps polling disconnects and emits parsed
-    # Responses heartbeats from ``heartbeat_state`` at the configured interval.
+    # Responses heartbeats at the configured interval. Keep the attempt's
+    # lifecycle private until it commits so a heartbeat cannot expose an ID
+    # that will be discarded by the transparent retry.
+    attempt_heartbeat_state: dict[str, object] = {}
     buffered: list[str] = []
     buffered_bytes = 0
     committed = False
@@ -2367,7 +2370,7 @@ async def _stream_responses_with_nonprogress_retry(
         responses_request,
         explicit_no_thinking=explicit_no_thinking,
         request_id_holder=request_id_holder,
-        heartbeat_state=heartbeat_state,
+        heartbeat_state=attempt_heartbeat_state,
     ):
         if committed:
             yield event
@@ -2384,6 +2387,9 @@ async def _stream_responses_with_nonprogress_retry(
             )
             committed = True
         if committed:
+            if heartbeat_state is not None:
+                heartbeat_state.clear()
+                heartbeat_state.update(attempt_heartbeat_state)
             for pending in buffered:
                 yield pending
             buffered.clear()
@@ -2393,6 +2399,9 @@ async def _stream_responses_with_nonprogress_retry(
     if committed:
         return
     if not retry_nonprogress:
+        if heartbeat_state is not None:
+            heartbeat_state.clear()
+            heartbeat_state.update(attempt_heartbeat_state)
         for event in buffered:
             yield event
         return

--- a/vllm_mlx/routes/responses.py
+++ b/vllm_mlx/routes/responses.py
@@ -115,6 +115,7 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 _NONPROGRESS_RETRY_BUFFER_LIMIT = 4 * 1024 * 1024
+_DEFERRED_PUBLIC_TEXT_LIMIT = 4 * 1024 * 1024
 
 
 def _should_prime_deepseek_codex_exec(
@@ -2373,19 +2374,27 @@ async def _stream_responses_with_nonprogress_retry(
         heartbeat_state=attempt_heartbeat_state,
     ):
         if committed:
+            if heartbeat_state is not None:
+                heartbeat_state.clear()
+                heartbeat_state.update(attempt_heartbeat_state)
             yield event
             continue
-        buffered.append(event)
-        buffered_bytes += len(event.encode("utf-8"))
+        event_bytes = len(event.encode("utf-8"))
+        event_buffered = False
+        if buffered_bytes + event_bytes >= _NONPROGRESS_RETRY_BUFFER_LIMIT:
+            committed = True
+        else:
+            buffered.append(event)
+            buffered_bytes += event_bytes
+            event_buffered = True
         if _responses_event_commits_progress(event):
             committed = True
-        elif buffered_bytes >= _NONPROGRESS_RETRY_BUFFER_LIMIT:
+        elif committed:
             logger.warning(
                 "DeepSeek Codex retry buffer reached %d bytes; preserving streaming "
                 "and disabling the transparent retry for this turn",
-                buffered_bytes,
+                buffered_bytes + event_bytes,
             )
-            committed = True
         if committed:
             if heartbeat_state is not None:
                 heartbeat_state.clear()
@@ -2393,6 +2402,8 @@ async def _stream_responses_with_nonprogress_retry(
             for pending in buffered:
                 yield pending
             buffered.clear()
+            if not event_buffered:
+                yield event
         elif '"code":"model_no_final_answer"' in event.replace(" ", ""):
             retry_nonprogress = True
 
@@ -2688,10 +2699,11 @@ async def _stream_responses(
             codex_surface
             and openai_request.tools
             and openai_request.tool_choice != "none"
-            and forced_prefix
             and cfg.tool_call_parser == "deepseek_v4_0731"
         )
         deferred_text: list[str] = []
+        deferred_text_bytes = 0
+        deferred_text_overflow = False
 
         _tokenizer = engine.tokenizer
         _chat_template = ""
@@ -3065,11 +3077,19 @@ async def _stream_responses(
             yielded — final flush decision happens after the engine
             stream completes and we know whether synthesis is needed.
             """
-            nonlocal accumulated_text
+            nonlocal accumulated_text, deferred_text_bytes, deferred_text_overflow
             if not delta:
                 return
             if _defer_public_text:
+                delta_bytes = len(delta.encode("utf-8"))
+                if deferred_text_bytes + delta_bytes > _DEFERRED_PUBLIC_TEXT_LIMIT:
+                    deferred_text.clear()
+                    deferred_text_overflow = True
+                    return
+                if deferred_text_overflow:
+                    return
                 deferred_text.append(delta)
+                deferred_text_bytes += delta_bytes
                 return
             if not message_open:
                 for ev in await _open_message_item():
@@ -3106,12 +3126,14 @@ async def _stream_responses(
             ``output_text.delta`` so the client still sees the
             assistant's actual text content.
             """
-            nonlocal accumulated_text
+            nonlocal accumulated_text, deferred_text_bytes
             if will_synthesise or not deferred_text:
                 deferred_text.clear()
+                deferred_text_bytes = 0
                 return
             joined = "".join(deferred_text)
             deferred_text.clear()
+            deferred_text_bytes = 0
             if not joined:
                 return
             if not message_open:
@@ -3644,6 +3666,27 @@ async def _stream_responses(
         # are out — emit a ``response.failed`` event with the same
         # error envelope instead so the client sees a clean shutdown
         # signal.
+        if deferred_text_overflow:
+            logger.warning(
+                "DeepSeek Codex deferred public text exceeded %d bytes",
+                _DEFERRED_PUBLIC_TEXT_LIMIT,
+            )
+            yield _emit(
+                "response.failed",
+                {
+                    "type": "response.failed",
+                    "response": {
+                        **_initial_response_payload,
+                        "status": "failed",
+                        "error": {
+                            "code": "deferred_text_limit_exceeded",
+                            "message": "Deferred agent output exceeded the safe buffer limit.",
+                        },
+                    },
+                },
+            )
+            return
+
         try:
             tool_calls = _enforce_responses_tool_choice(
                 parsed_tool_calls, responses_request, openai_request

--- a/vllm_mlx/routes/responses.py
+++ b/vllm_mlx/routes/responses.py
@@ -242,8 +242,8 @@ def _inject_codex_progress_reminder(
                     "sed -i",
                     ".write_text(",
                     ".write_bytes(",
-                    "open(p,\"w\")",
-                    "open(p, \"w\")",
+                    'open(p,"w")',
+                    'open(p, "w")',
                     "open(p,'w')",
                     "open(p, 'w')",
                 )

--- a/vllm_mlx/routes/responses.py
+++ b/vllm_mlx/routes/responses.py
@@ -19,7 +19,6 @@ import json
 import logging
 import re
 import shlex
-import tempfile
 import time
 import uuid
 from collections.abc import AsyncIterator, Mapping
@@ -2757,29 +2756,16 @@ async def _stream_responses(
             and cfg.tool_call_parser == "deepseek_v4_0731"
         )
         _defer_public_text = _forced_choice_active or _deepseek_defer_public_text
+        # This buffer is bounded by the request's already-resolved scheduler
+        # ``max_tokens`` budget (32K by default for Codex), not by wall time or
+        # context length. Keeping it in memory avoids blocking file I/O and
+        # cancellation-time descriptor cleanup on the async request path.
         deferred_text: list[str] = []
-        # DeepSeek auto-tool turns can defer much more prose than legacy
-        # forced-choice synthesis. Spill beyond 1 MiB instead of growing an
-        # unbounded Python list; the file is closed when the generator exits.
-        deferred_text_file = (
-            tempfile.SpooledTemporaryFile(
-                max_size=1024 * 1024, mode="w+", encoding="utf-8"
-            )
-            if _deepseek_defer_public_text
-            else None
-        )
 
         def _clear_deferred_text() -> None:
             deferred_text.clear()
-            if deferred_text_file is not None:
-                deferred_text_file.close()
 
         def _take_deferred_text() -> str:
-            if deferred_text_file is not None:
-                deferred_text_file.seek(0)
-                value = deferred_text_file.read()
-                deferred_text_file.close()
-                return value
             value = "".join(deferred_text)
             deferred_text.clear()
             return value
@@ -3160,10 +3146,7 @@ async def _stream_responses(
             if not delta:
                 return
             if _defer_public_text:
-                if deferred_text_file is not None:
-                    deferred_text_file.write(delta)
-                else:
-                    deferred_text.append(delta)
+                deferred_text.append(delta)
                 return
             if not message_open:
                 for ev in await _open_message_item():

--- a/vllm_mlx/routes/responses.py
+++ b/vllm_mlx/routes/responses.py
@@ -232,7 +232,22 @@ def _inject_codex_progress_reminder(
             call_id = str(data.get("call_id") or "")
             calls[call_id] = arguments
             call_names[call_id] = str(data.get("name") or "")
-            if "apply_patch" in arguments:
+            if any(
+                marker in arguments
+                for marker in (
+                    "apply_patch",
+                    "cat >",
+                    "cat >>",
+                    "tee ",
+                    "sed -i",
+                    ".write_text(",
+                    ".write_bytes(",
+                    "open(p,\"w\")",
+                    "open(p, \"w\")",
+                    "open(p,'w')",
+                    "open(p, 'w')",
+                )
+            ):
                 has_edited = True
                 has_test_passed = False
                 has_test_failed = False
@@ -251,6 +266,15 @@ def _inject_codex_progress_reminder(
             "three times. Use its existing result. Re-check the requested constraints "
             "and choose a materially different evidence-gathering, editing, or testing "
             "action. Preserve any user-specified interpreter and toolchain."
+        )
+    elif not has_edited and len(actions) >= 8:
+        reminder = (
+            "Engineering exploration checkpoint: at least eight read-only tool "
+            "results are already available and no edit has been made. Before another "
+            "broad read, identify the one concrete unresolved question that blocks a "
+            "safe change and inspect only the evidence needed to answer it. If no "
+            "such question remains, move to the smallest grounded failing test or "
+            "implementation change. Do not edit while a material ambiguity remains."
         )
     else:
         return messages
@@ -1277,7 +1301,7 @@ async def create_response(request: Request):
             _resp_heartbeat_state: dict[str, object] = {}
             return StreamingResponse(
                 _disconnect_guard(
-                    _stream_responses(
+                    _stream_responses_with_nonprogress_retry(
                         engine,
                         openai_request,
                         responses_request,
@@ -2266,6 +2290,75 @@ async def _emit_computer_call_item(tc, output_index: int) -> AsyncIterator[str]:
     )
 
 
+async def _stream_responses_with_nonprogress_retry(
+    engine: BaseEngine,
+    openai_request: ChatCompletionRequest,
+    responses_request: ResponsesRequest,
+    *,
+    explicit_no_thinking: bool = False,
+    request_id_holder: list | None = None,
+    heartbeat_state: dict[str, object] | None = None,
+) -> AsyncIterator[str]:
+    """Hide one DeepSeek reasoning-only stop behind a bounded retry.
+
+    Codex otherwise reconnects the whole Responses turn when the model ends
+    after hidden reasoning.  Buffer only this model/surface combination so a
+    failed attempt has not committed an SSE lifecycle, then retry once with a
+    transient completion reminder.  Successful turns and every other surface
+    retain their existing streaming behaviour.
+    """
+    cfg = get_config()
+    retryable_surface = _is_deepseek_codex_surface(
+        responses_request, cfg.tool_call_parser
+    )
+    if not retryable_surface:
+        async for event in _stream_responses(
+            engine,
+            openai_request,
+            responses_request,
+            explicit_no_thinking=explicit_no_thinking,
+            request_id_holder=request_id_holder,
+            heartbeat_state=heartbeat_state,
+        ):
+            yield event
+        return
+
+    buffered: list[str] = []
+    retry_nonprogress = False
+    async for event in _stream_responses(
+        engine,
+        openai_request,
+        responses_request,
+        explicit_no_thinking=explicit_no_thinking,
+        request_id_holder=request_id_holder,
+        heartbeat_state=heartbeat_state,
+    ):
+        buffered.append(event)
+        if '"code":"model_no_final_answer"' in event.replace(" ", ""):
+            retry_nonprogress = True
+
+    if not retry_nonprogress:
+        for event in buffered:
+            yield event
+        return
+
+    logger.warning(
+        "DeepSeek Codex reasoning-only stop: retrying once inside the server"
+    )
+    if request_id_holder is not None:
+        request_id_holder[0] = None
+    async for event in _stream_responses(
+        engine,
+        openai_request,
+        responses_request,
+        explicit_no_thinking=explicit_no_thinking,
+        request_id_holder=request_id_holder,
+        heartbeat_state=heartbeat_state,
+        nonprogress_retry=True,
+    ):
+        yield event
+
+
 async def _stream_responses(
     engine: BaseEngine,
     openai_request: ChatCompletionRequest,
@@ -2274,6 +2367,7 @@ async def _stream_responses(
     explicit_no_thinking: bool = False,
     request_id_holder: list | None = None,
     heartbeat_state: dict[str, object] | None = None,
+    nonprogress_retry: bool = False,
 ) -> AsyncIterator[str]:
     """Stream a Responses-API SSE event sequence Codex CLI can parse.
 
@@ -2373,6 +2467,19 @@ async def _stream_responses(
         )
         if codex_surface:
             messages = _inject_codex_progress_reminder(messages, responses_request)
+            if nonprogress_retry:
+                messages = [
+                    *messages,
+                    {
+                        "role": "developer",
+                        "content": (
+                            "The previous generation stopped inside private reasoning. "
+                            "Complete this turn now with exactly one public answer or "
+                            "one valid tool call; do not end in reasoning alone."
+                        ),
+                        "_rapid_mlx_transient_priming": True,
+                    },
+                ]
 
         # r5-B C-10 / C-11: tool-coupled UI-TARS sysprompt injection on
         # the streaming responses lane. Same gate as the non-stream
@@ -2485,6 +2592,18 @@ async def _stream_responses(
                     and _forced_tc.get("type") == "function"
                 )
             )
+        )
+        # DeepSeek-V4 can briefly leave reasoning to announce an action, then
+        # re-enter reasoning before emitting the actual DSML tool call. Once a
+        # Responses message item is opened, that channel transition is
+        # irreversible and Codex rejects the later reasoning item. Buffer
+        # public text for DeepSeek Codex tool turns until generation finishes,
+        # when the complete reasoning/message/tool ordering is known. Ordinary
+        # chat streams and other models retain token-by-token text delivery.
+        _defer_public_text = _forced_choice_active or bool(
+            codex_surface
+            and openai_request.tools
+            and cfg.tool_call_parser == "deepseek_v4_0731"
         )
         deferred_text: list[str] = []
 
@@ -2863,7 +2982,7 @@ async def _stream_responses(
             nonlocal accumulated_text
             if not delta:
                 return
-            if _forced_choice_active:
+            if _defer_public_text:
                 deferred_text.append(delta)
                 return
             if not message_open:


### PR DESCRIPTION
## Summary

- preserve valid Responses event ordering when DeepSeek briefly exits and re-enters reasoning before a tool call
- retry one reasoning-only completion inside the server without exposing a failed SSE lifecycle to Codex
- add a conservative exploration checkpoint after eight read-only actions, while recognizing shell and Python file writes as edits

## Root cause

DeepSeek-V4-Flash-0731 can emit public action text before returning to reasoning and then producing DSML. Streaming that text immediately permanently opens a Responses message item, so the later reasoning item is invalid for Codex. Separately, a reasoning-only stop was exposed as `response.failed`, causing Codex to reconnect the entire turn. The prior progress heuristic also recognized only `apply_patch`, so real shell/Python edits were misclassified as continued exploration.

## Scope

The buffering and bounded retry are gated to DeepSeek V4 on the Codex Responses tool surface. Other models and routes retain their existing streaming behavior.

## Validation

- 347 adjacent Codex/DeepSeek/Responses tests passed
- ruff passed
- `git diff --check` passed
- real #1462 engineering soak completed with zero reconnects, malformed tool calls, or repetition aborts; efficiency and first-pass implementation quality remain a separate open acceptance gap