### PR TITLE
fix(rapid-mac): surface the memory-guard prompt inside Quickstart so first-run can't deadlock

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -197,7 +197,15 @@ struct ContentView: View {
         .alert(
             server.pendingMemoryWarning?.title ?? "",
             isPresented: Binding(
-                get: { server.pendingMemoryWarning != nil },
+                // #1503: when the Quickstart sheet is up it renders its OWN
+                // in-sheet copy of this decision (this alert is anchored on
+                // the parent, behind the full-window sheet, and cannot
+                // present over it). Suppress here so we don't double-present
+                // on macOS builds where an alert DOES stack above a sheet —
+                // gated on the exact predicate QuickstartView presents on.
+                get: {
+                    server.pendingMemoryWarning != nil && !memoryWarningHandledByQuickstart
+                },
                 // SwiftUI writes `false` here AFTER a button action runs.
                 // Both buttons already resolved the decision and cleared
                 // `pendingMemoryWarning`, so an unconditional cancel would
@@ -334,6 +342,21 @@ struct ContentView: View {
         case .idle, .ready:
             return false
         }
+    }
+
+    /// True when the Quickstart sheet is up AND owns the pending
+    /// memory-warning decision (#1503) — it renders its own in-sheet copy,
+    /// so this parent-anchored (and sheet-covered) alert must stand down to
+    /// avoid a double presentation. Keyed on the exact predicate
+    /// ``QuickstartView`` presents on, so the two surfaces can never
+    /// disagree about who owns the decision.
+    private var memoryWarningHandledByQuickstart: Bool {
+        quickstartVisible
+            && QuickstartView.memoryWarningToPresent(
+                phase: quickstart.phase,
+                pending: server.pendingMemoryWarning,
+                selectionAlias: quickstart.selection.alias
+            ) != nil
     }
 
     /// Alias the server is actively serving, or ``nil`` if no live state.

--- a/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
@@ -324,6 +324,21 @@ Open the picker any time to switch models.
     /// Back out of the chooser to the hero ("Back").
     func backToWelcome() { stage = .welcome }
 
+    /// Drop a serve that the pre-load memory guard declined back to the
+    /// model chooser (#1503). The handoff to ``ServerManager.start`` parks
+    /// on ``pendingMemoryWarning`` and returns WITHOUT changing
+    /// ``server.state``, so nothing ever moves ``phase`` out of
+    /// ``.starting`` on its own — the sheet would sit on "Starting…"
+    /// forever. When the user declines the risky load we return here:
+    /// NOT ``.failed`` (the download succeeded — only loading was refused),
+    /// and NOT ``.idle``/``.welcome`` (they already chose a model), but the
+    /// chooser, where they can free memory and retry, pick a smaller model,
+    /// or browse all. Leaving ``.starting`` is what releases the sheet.
+    func returnToChooser() {
+        phase = .idle
+        stage = .chooseModel
+    }
+
     /// Set the model the wizard will download. No-op once a download is
     /// in flight (``phase != .idle``) so a late tap can't retarget an
     /// active pull.
@@ -752,10 +767,30 @@ struct QuickstartView: View {
         case .downloading:
             centeredCard(progressStep: 2) { downloadingCard }
         case .starting, .ready:
-            // .ready is transitional — the parent swaps to ChatView, but
-            // a one-frame race can land here; the starting copy is a calm
-            // fallback so the user never sees a blank pane.
-            centeredCard(progressStep: 2) { startingCard }
+            // #1503: a serve handed off from Quickstart funnels through
+            // ServerManager's pre-load memory guard. On a Mac under heavy
+            // memory pressure the guard PARKS the load on
+            // ``server.pendingMemoryWarning`` and returns WITHOUT changing
+            // ``server.state``. The shared confirmation ``.alert`` is
+            // anchored on ContentView — BEHIND this full-window onboarding
+            // sheet — so it can never present: the sheet waits for a serve
+            // that will never arrive, and the guard waits for an answer the
+            // user can't reach. A hard deadlock the user sees as a permanent
+            // "Starting…". Surface the SAME decision inside the sheet, where
+            // it is reachable. (ContentView suppresses its covered alert for
+            // exactly this case via the same predicate.)
+            if let warning = QuickstartView.memoryWarningToPresent(
+                phase: coordinator.phase,
+                pending: server.pendingMemoryWarning,
+                selectionAlias: coordinator.selection.alias
+            ) {
+                centeredCard(progressStep: nil) { memoryWarningCard(warning) }
+            } else {
+                // .ready is transitional — the parent swaps to ChatView, but
+                // a one-frame race can land here; the starting copy is a calm
+                // fallback so the user never sees a blank pane.
+                centeredCard(progressStep: 2) { startingCard }
+            }
         case .failed(let message):
             centeredCard(progressStep: nil) { failedCard(message: message) }
         }
@@ -1027,6 +1062,88 @@ struct QuickstartView: View {
             .font(.callout)
             .foregroundStyle(.secondary)
             .multilineTextAlignment(.center)
+    }
+
+    /// In-sheet twin of ContentView's memory-warning ``.alert`` (#1503).
+    /// That alert is unreachable while this full-window onboarding sheet is
+    /// up, so a Quickstart serve that trips the pre-load memory guard would
+    /// otherwise strand the user on a permanent "Starting…". Same copy, same
+    /// two ``ServerManager`` actions — presented where the user is looking.
+    ///
+    /// "Load anyway" carries no ``.defaultAction`` shortcut on purpose: the
+    /// risky choice must not be what Return triggers. Cancel owns
+    /// ``.cancelAction`` so Esc DECLINES the load (the safe default) rather
+    /// than dismissing the sheet out from under the decision.
+    @ViewBuilder
+    private func memoryWarningCard(_ warning: ModelSizing.MemoryWarning) -> some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .fill(RapidTheme.amberTint)
+                .frame(width: 60, height: 60)
+            Image(systemName: "exclamationmark.triangle")
+                .font(.system(size: 28, weight: .regular))
+                .foregroundStyle(RapidTheme.amberDeep)
+        }
+        .accessibilityHidden(true)
+
+        VStack(spacing: 8) {
+            Text(warning.title)
+                .font(.title3.weight(.semibold))
+                .multilineTextAlignment(.center)
+            Text(warning.message)
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(warning.title). \(warning.message)")
+
+        Button {
+            // Re-enters ``start`` with the guard bypassed. We stay in
+            // ``.starting``; ``handleServerStateChange`` seeds the welcome
+            // and dismisses the sheet once the child reaches ``.ready``.
+            server.confirmPendingMemoryLoad(warning)
+        } label: {
+            Text(warning.confirmTitle)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 2)
+        }
+        .buttonStyle(.borderedProminent)
+        .controlSize(.large)
+        .accessibilityIdentifier("Quickstart.Memory.LoadAnyway")
+
+        Button {
+            // Drop the parked load and leave ``.starting`` for the chooser
+            // so the sheet stops waiting on a serve that will never come.
+            server.cancelPendingMemoryLoad()
+            coordinator.returnToChooser()
+        } label: {
+            Text("Cancel")
+                .frame(maxWidth: .infinity)
+        }
+        .buttonStyle(.bordered)
+        .controlSize(.large)
+        .keyboardShortcut(.cancelAction)
+        .accessibilityIdentifier("Quickstart.Memory.Cancel")
+    }
+
+    /// Which memory warning, if any, the Quickstart sheet must present
+    /// itself rather than delegate to ContentView's covered ``.alert``
+    /// (#1503). Returns the pending warning ONLY while we are actively
+    /// driving a serve (``phase == .starting``) AND the parked load is for
+    /// OUR selection — a warning carrying a different alias belongs to some
+    /// other start path and is not ours to resolve inside onboarding. Pure
+    /// so the deadlock scenario can be pinned without a SwiftUI host, and so
+    /// ContentView can gate its alert on the exact same condition.
+    static func memoryWarningToPresent(
+        phase: QuickstartCoordinator.Phase,
+        pending: ModelSizing.MemoryWarning?,
+        selectionAlias: String
+    ) -> ModelSizing.MemoryWarning? {
+        guard case .starting = phase else { return nil }
+        guard let pending, pending.alias == selectionAlias else { return nil }
+        return pending
     }
 
     /// Low-disk warning card. Non-blocking — the user can still

--- a/apps/rapid-mac/Tests/RapidTests/QuickstartViewTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/QuickstartViewTests.swift
@@ -529,6 +529,94 @@ struct QuickstartViewTests {
             serverState: .ready(alias: QuickstartCoordinator.defaultChoice.alias)
         ))
     }
+
+    // MARK: - #1503 memory-guard deadlock
+
+    /// Build an ``.unsafe`` memory warning for an alias — the shape
+    /// ``ServerManager.start`` parks on when a Quickstart serve would push
+    /// live memory past the 85% panic line.
+    private func makeWarning(alias: String) -> ModelSizing.MemoryWarning {
+        ModelSizing.MemoryWarning(
+            alias: alias,
+            hfPath: nil,
+            isAutoRespawn: false,
+            severity: .unsafe,
+            footprintGB: 3.25,
+            freeGB: 0.7
+        )
+    }
+
+    /// The deadlock scenario itself: a serve we handed off has parked on the
+    /// memory guard (``phase == .starting``, warning for OUR selection). Old
+    /// code had no in-sheet surface for this — the covered ContentView alert
+    /// could never present and the sheet sat on "Starting…" forever. The
+    /// predicate must now hand the sheet the warning to render.
+    @Test("Parked memory warning for our alias while starting IS surfaced in-sheet")
+    func memoryWarningSurfacedWhenStartingOurAlias() {
+        let alias = QuickstartCoordinator.defaultChoice.alias
+        let warning = makeWarning(alias: alias)
+        let shown = QuickstartView.memoryWarningToPresent(
+            phase: .starting,
+            pending: warning,
+            selectionAlias: alias
+        )
+        #expect(shown == warning)
+    }
+
+    @Test("No warning pending while starting → normal Starting card, nothing surfaced")
+    func noMemoryWarningWhenNonePending() {
+        let shown = QuickstartView.memoryWarningToPresent(
+            phase: .starting,
+            pending: nil,
+            selectionAlias: QuickstartCoordinator.defaultChoice.alias
+        )
+        #expect(shown == nil)
+    }
+
+    @Test("A warning for a DIFFERENT alias is not ours to resolve inside onboarding")
+    func memoryWarningForForeignAliasIgnored() {
+        let shown = QuickstartView.memoryWarningToPresent(
+            phase: .starting,
+            pending: makeWarning(alias: "qwen3.5-9b-4bit"),
+            selectionAlias: QuickstartCoordinator.defaultChoice.alias
+        )
+        #expect(shown == nil)
+    }
+
+    @Test("A warning is only surfaced while starting — not mid-download / idle / ready")
+    func memoryWarningOnlyWhileStarting() {
+        let alias = QuickstartCoordinator.defaultChoice.alias
+        let warning = makeWarning(alias: alias)
+        #expect(
+            QuickstartView.memoryWarningToPresent(
+                phase: .downloading, pending: warning, selectionAlias: alias
+            ) == nil
+        )
+        #expect(
+            QuickstartView.memoryWarningToPresent(
+                phase: .idle, pending: warning, selectionAlias: alias
+            ) == nil
+        )
+        #expect(
+            QuickstartView.memoryWarningToPresent(
+                phase: .ready, pending: warning, selectionAlias: alias
+            ) == nil
+        )
+    }
+
+    /// Declining the risky load must LEAVE ``.starting`` — that is the whole
+    /// point, otherwise the sheet stays wedged. It returns to the chooser
+    /// (download already succeeded; only loading was refused), not ``.failed``
+    /// and not the hero.
+    @Test("returnToChooser leaves .starting for the chooser step")
+    func returnToChooserLeavesStarting() {
+        let coord = makeCoordinator()
+        coord.enterStarting()
+        #expect(coord.phase == .starting)
+        coord.returnToChooser()
+        #expect(coord.phase == .idle)
+        #expect(coord.stage == .chooseModel)
+    }
 }
 
 /// F-LWT-1 source-grep tripwire: catch a partial swap that leaves

--- a/apps/rapid-mac/Tests/RapidTests/QuickstartViewTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/QuickstartViewTests.swift
@@ -649,3 +649,84 @@ struct QuickstartViewSourceGrepTests {
         #expect(QuickstartCoordinator.defaultChoice.hfRepo?.contains("4B") != true)
     }
 }
+
+/// #1503 render-wiring source guard.
+///
+/// The pure predicate ``QuickstartView.memoryWarningToPresent`` is unit-
+/// tested above, but a green predicate does NOT prove the deadlock is
+/// fixed: if the `.starting` branch stopped *calling* the predicate and
+/// rendering ``memoryWarningCard``, or the card stopped calling the
+/// ``ServerManager`` confirm/cancel actions, the sheet would sit on
+/// "Starting…" forever again while every logic test stayed green. There is
+/// no ViewInspector in this target (removed in #1492), so — mirroring the
+/// established ``CapabilityChipRenderGateSourceGuardTests`` pattern — we pin
+/// the wiring by scanning the source in canonical (comment/whitespace-
+/// stripped) form. Delete any load-bearing line and one of these trips.
+@MainActor
+@Suite("#1503 — Quickstart memory-warning render wiring source guard")
+struct QuickstartMemoryWiringSourceGuardTests {
+
+    /// SPM package root, derived from ``#filePath`` so the test runs from
+    /// any cwd. RapidTests → Tests → package root (``apps/rapid-mac``).
+    private static var packageRoot: URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()  // RapidTests
+            .deletingLastPathComponent()  // Tests
+            .deletingLastPathComponent()  // apps/rapid-mac
+    }
+
+    private func loadStripped(_ relativePath: String) throws -> String {
+        let url = Self.packageRoot.appendingPathComponent(relativePath)
+        let source = try String(contentsOf: url, encoding: .utf8)
+        // Reuse the canonical strip so these pins can't drift on the strip
+        // rules from the sibling render-gate guard.
+        return CapabilityChipRenderGateSourceGuardTests.stripCommentsAndWhitespace(source)
+    }
+
+    @Test("QuickstartView renders the memory-warning card from the .starting branch")
+    func startingBranchRendersMemoryCard() throws {
+        let src = try loadStripped("Sources/Rapid/UI/QuickstartView.swift")
+        // The predicate is actually INVOKED from the view body (the
+        // ``QuickstartView.`` qualifier distinguishes the call site from the
+        // ``static func`` definition) …
+        #expect(
+            src.contains("QuickstartView.memoryWarningToPresent("),
+            "QuickstartView no longer calls memoryWarningToPresent from its body — the .starting branch would never surface the parked warning and the #1503 deadlock returns."
+        )
+        // … and its result is rendered as the memory card, not swallowed.
+        #expect(
+            src.contains("memoryWarningCard(warning)"),
+            "QuickstartView no longer renders memoryWarningCard(warning) — the parked memory warning has no on-screen surface and the sheet wedges on 'Starting…' (#1503)."
+        )
+    }
+
+    @Test("memoryWarningCard wires both ServerManager actions and the chooser exit")
+    func cardWiresConfirmCancelAndReturn() throws {
+        let src = try loadStripped("Sources/Rapid/UI/QuickstartView.swift")
+        #expect(
+            src.contains("server.confirmPendingMemoryLoad(warning)"),
+            "The in-sheet card's confirm button no longer calls server.confirmPendingMemoryLoad — 'Load anyway' would be inert (#1503)."
+        )
+        #expect(
+            src.contains("server.cancelPendingMemoryLoad()"),
+            "The in-sheet card's cancel button no longer calls server.cancelPendingMemoryLoad — the parked load is never dropped (#1503)."
+        )
+        #expect(
+            src.contains("coordinator.returnToChooser()"),
+            "Cancel no longer calls returnToChooser — the coordinator stays in .starting and the sheet never releases (#1503)."
+        )
+    }
+
+    @Test("ContentView suppresses its covered alert via the shared predicate")
+    func contentViewGatesAlertOnPredicate() throws {
+        let src = try loadStripped("Sources/Rapid/UI/ContentView.swift")
+        #expect(
+            src.contains("server.pendingMemoryWarning!=nil&&!memoryWarningHandledByQuickstart"),
+            "ContentView's memory alert is no longer gated on memoryWarningHandledByQuickstart — it can double-present with the in-sheet card on macOS builds that stack an alert above a sheet (#1503)."
+        )
+        #expect(
+            src.contains("QuickstartView.memoryWarningToPresent("),
+            "ContentView's suppression helper no longer keys on the shared memoryWarningToPresent predicate — the two surfaces can drift on who owns the decision (#1503)."
+        )
+    }
+}


### PR DESCRIPTION
## Why

On a Mac under memory pressure, a **brand-new user's first launch can wedge forever on "Starting…"**.

The Quickstart download finishes and hands off to `ServerManager.start`, which — through the pre-load memory guard (#324) — projects the model's footprint onto *live used memory*. When that exceeds the ~85% panic line it **parks** the load on `pendingMemoryWarning` and returns **without changing `server.state`**. The shared confirmation is a single `.alert` anchored on `ContentView`, but Quickstart is a full-window modal `.sheet` layered above it — so the alert can never present.

The sheet waits for a serve that will never arrive; the guard waits for an answer the user can't reach. Hard deadlock: no serve subprocess, no listening port, permanent "Starting…". The only escape was pressing **Esc** to dismiss the sheet — undiscoverable.

## What

- **`QuickstartView` renders an in-sheet twin** of the memory-warning decision (same copy, same `ServerManager` confirm/cancel actions) whenever a serve it is driving parks on the guard. Gated by a pure predicate `memoryWarningToPresent(phase:pending:selectionAlias:)` that fires only while `.starting` and only for the alias Quickstart itself launched.
- **"Load anyway"** re-enters `start` with the guard bypassed (stays `.starting`, seeds + dismisses on `.ready`). **"Cancel"** drops the parked load and calls the new `QuickstartCoordinator.returnToChooser()`, which leaves `.starting` for the chooser — the one transition that releases the sheet (not `.failed`: the download succeeded; only loading was refused).
- **`ContentView` suppresses its own covered `.alert`** via the same predicate, so on macOS builds where an alert would stack above a sheet the decision can't double-present. One source of truth for who owns the prompt.

## Tests

- **5 new cases** in `QuickstartViewTests` pinning the predicate truth table (surfaces our parked warning while `.starting`; ignores `nil`, a foreign alias, and non-`.starting` phases) and `returnToChooser()` leaving `.starting` → `.idle`/`.chooseModel`.
- **Full `swift test`: 1493/1496 pass.** The 3 failures are the pre-existing `DownloadManager — real rapid-mlx pull subprocess wiring` integration tests, which fail **identically on pristine main** in this environment (no network / real pull subprocess) and are unrelated to this change.

## Notes

- **No version bump.** Scope is the Quickstart onboarding sheet — the only serve path that runs under a full-window sheet (the other sheet, telemetry consent, starts no model). The non-sheet paths (picker, first chat message, auto-restart) keep using the `ContentView` alert unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)