### PR TITLE
fix(rapid-mac): add chat message actions and correct transcript

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
@@ -66,6 +66,11 @@ final class ChatViewModel {
 
     private var inflight: Task<Void, Never>?
 
+    /// Tests that exercise turn replay can disable disk I/O so seeded
+    /// transcripts never read or overwrite the user's conversation history.
+    /// Production keeps the default enabled.
+    private let persistsConversations: Bool
+
     /// v0.4.14: user-mutable sampling knobs. Optional in the init
     /// signature so existing tests don't have to spin one up — they
     /// fall back to the v0.4.12 hard-coded defaults via
@@ -86,12 +91,14 @@ final class ChatViewModel {
     init(
         client: ChatStreamClient = ChatStreamClient(),
         sampling: SamplingConfig? = nil,
-        server: ServerManager? = nil
+        server: ServerManager? = nil,
+        persistsConversations: Bool = true
     ) {
         self.client = client
         self.sampling = sampling
         self.server = server
-        self.conversations = ConversationStore.load()
+        self.persistsConversations = persistsConversations
+        self.conversations = persistsConversations ? ConversationStore.load() : []
     }
 
     // MARK: - Conversation history (M3)
@@ -133,7 +140,9 @@ final class ChatViewModel {
                 at: 0
             )
         }
-        ConversationStore.save(conversations)
+        if persistsConversations {
+            ConversationStore.save(conversations)
+        }
     }
 
     /// Load a saved conversation into the transcript, archiving whatever is
@@ -173,7 +182,9 @@ final class ChatViewModel {
             lastFailureKind = nil
         }
         conversations.removeAll { $0.id == id }
-        ConversationStore.save(conversations)
+        if persistsConversations {
+            ConversationStore.save(conversations)
+        }
     }
 
     // MARK: - In-memory message storage
@@ -803,6 +814,29 @@ final class ChatViewModel {
         let userText = messages[lastUserIndex].content
         messages = Array(messages.prefix(lastUserIndex))
         send(userText, alias: alias)
+    }
+
+    /// Retry the turn that produced a specific assistant message. This is
+    /// intentionally message-addressed: retrying an older response rewinds
+    /// to the user prompt immediately before it instead of regenerating the
+    /// latest turn by accident.
+    @discardableResult
+    func retryAssistantMessage(id: UUID, alias: String) -> Bool {
+        guard !isStreaming else { return false }
+        guard let assistantIndex = messages.firstIndex(where: {
+            $0.id == id && $0.role == .assistant
+        }) else { return false }
+        guard let userIndex = messages[..<assistantIndex].lastIndex(where: {
+            $0.role == .user
+        }) else { return false }
+
+        let userText = messages[userIndex].content
+        guard !userText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return false
+        }
+        messages = Array(messages.prefix(userIndex))
+        send(userText, alias: alias)
+        return true
     }
 
     /// Same as ``regenerateLast(alias:)`` but brings up ``newAlias``

--- a/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
@@ -288,7 +288,19 @@ struct ChatView: View {
                 MessageRow(
                     message: message,
                     isStreaming: viewModel.isStreaming,
-                    onRegenerate: regenerate
+                    onEdit: { newContent in
+                        viewModel.editUserMessage(
+                            id: message.id,
+                            newContent: newContent,
+                            alias: alias
+                        )
+                    },
+                    onRetry: {
+                        viewModel.retryAssistantMessage(
+                            id: message.id,
+                            alias: alias
+                        )
+                    }
                 )
                 .frame(maxWidth: contentMaxWidth, alignment: .leading)
                 .frame(maxWidth: .infinity, alignment: .center)
@@ -534,10 +546,6 @@ struct ChatView: View {
         viewModel.send(text, alias: alias)
     }
 
-    private func regenerate() {
-        guard !viewModel.isStreaming else { return }
-        viewModel.regenerateLast(alias: alias)
-    }
 }
 
 /// One transcript row — a user prompt bubble, an assistant answer
@@ -546,9 +554,14 @@ struct ChatView: View {
 private struct MessageRow: View {
     let message: ChatMessage
     let isStreaming: Bool
-    var onRegenerate: () -> Void = {}
+    var onEdit: (String) -> Bool = { _ in false }
+    var onRetry: () -> Bool = { false }
 
     @State private var reasoningExpanded: Bool = false
+    @State private var isEditing: Bool = false
+    @State private var editDraft: String = ""
+    @State private var copiedRecently: Bool = false
+    @FocusState private var editFieldFocused: Bool
 
     var body: some View {
         switch message.role {
@@ -564,19 +577,118 @@ private struct MessageRow: View {
     // MARK: User
 
     private var userBubble: some View {
-        HStack {
-            Spacer(minLength: 40)
-            Text(message.content)
-                .textSelection(.enabled)
-                .foregroundStyle(RapidTheme.userBubbleText)
-                .padding(.horizontal, 14)
-                .padding(.vertical, 10)
-                .background(
-                    RoundedRectangle(cornerRadius: RapidTheme.Radius.bubble, style: .continuous)
-                        .fill(RapidTheme.userBubble)
-                )
+        VStack(alignment: .trailing, spacing: RapidTheme.Space.xs) {
+            HStack {
+                Spacer(minLength: 40)
+                if isEditing {
+                    userEditor
+                } else {
+                    Text(message.content)
+                        .textSelection(.enabled)
+                        .foregroundStyle(RapidTheme.userBubbleText)
+                        .padding(.horizontal, 14)
+                        .padding(.vertical, 10)
+                        .background(
+                            RoundedRectangle(cornerRadius: RapidTheme.Radius.bubble, style: .continuous)
+                                .fill(RapidTheme.userBubble)
+                        )
+                }
+            }
+            userActions
         }
         .frame(maxWidth: .infinity, alignment: .trailing)
+        .task(id: isEditing) {
+            guard isEditing else { return }
+            editFieldFocused = true
+        }
+    }
+
+    private var userEditor: some View {
+        TextEditor(text: $editDraft)
+            .font(.body)
+            .foregroundStyle(RapidTheme.userBubbleText)
+            .scrollContentBackground(.hidden)
+            .focused($editFieldFocused)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .frame(minWidth: 240, idealWidth: 420, maxWidth: 560, minHeight: 72, maxHeight: 160)
+            .background(
+                RoundedRectangle(cornerRadius: RapidTheme.Radius.bubble, style: .continuous)
+                    .fill(RapidTheme.userBubble)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: RapidTheme.Radius.bubble, style: .continuous)
+                    .stroke(RapidTheme.utilityActionHover.opacity(0.7), lineWidth: 1)
+            )
+    }
+
+    @ViewBuilder
+    private var userActions: some View {
+        HStack(spacing: 2) {
+            if isEditing {
+                QuietIconButton(
+                    symbol: "xmark",
+                    label: "Cancel editing",
+                    size: RapidTheme.ControlHeight.mini
+                ) {
+                    cancelEditing()
+                }
+                QuietIconButton(
+                    symbol: "checkmark",
+                    label: "Save edited message",
+                    size: RapidTheme.ControlHeight.mini
+                ) {
+                    saveEditing()
+                }
+                .disabled(
+                    isStreaming
+                        || editDraft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                )
+            } else {
+                copyButton(text: message.content, label: "Copy message")
+                QuietIconButton(
+                    symbol: "pencil",
+                    label: "Edit message",
+                    size: RapidTheme.ControlHeight.mini
+                ) {
+                    editDraft = message.content
+                    isEditing = true
+                }
+                .disabled(isStreaming)
+            }
+        }
+    }
+
+    private func cancelEditing() {
+        editFieldFocused = false
+        editDraft = message.content
+        isEditing = false
+    }
+
+    private func saveEditing() {
+        guard onEdit(editDraft) else { return }
+        editFieldFocused = false
+        isEditing = false
+    }
+
+    @ViewBuilder
+    private func copyButton(text: String, label: String) -> some View {
+        QuietIconButton(
+            symbol: copiedRecently ? "checkmark" : "doc.on.doc",
+            label: label,
+            tint: copiedRecently ? RapidTheme.utilityActionSuccess : nil,
+            size: RapidTheme.ControlHeight.mini
+        ) {
+            copySanitizedToPasteboard(text)
+            copiedRecently = true
+        }
+        .disabled(text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+        .task(id: copiedRecently) {
+            guard copiedRecently else { return }
+            try? await Task.sleep(nanoseconds: 1_200_000_000)
+            guard !Task.isCancelled else { return }
+            copiedRecently = false
+        }
     }
 
     // MARK: Assistant
@@ -609,8 +721,29 @@ private struct MessageRow: View {
                     .font(.caption)
                     .foregroundStyle(.tertiary)
             }
+            assistantActions
         }
         .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var assistantActions: some View {
+        HStack(spacing: 2) {
+            copyButton(text: assistantCopyText, label: "Copy response")
+            QuietIconButton(
+                symbol: "arrow.clockwise",
+                label: "Retry response",
+                size: RapidTheme.ControlHeight.mini
+            ) {
+                _ = onRetry()
+            }
+            .disabled(isStreaming)
+        }
+    }
+
+    private var assistantCopyText: String {
+        message.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            ? message.reasoning
+            : message.content
     }
 
     private var reasoningDisclosure: some View {
@@ -645,21 +778,10 @@ private struct MessageRow: View {
     }
 
     private var failureCaption: some View {
-        HStack(spacing: 10) {
-            // A failed turn is an ERROR, so it takes the error token.
-            // It previously rendered in deep amber, which under this
-            // palette means brand / active / working — the same hue the
-            // product uses for a model that is starting up. Red is the
-            // only colour that means "this went wrong".
-            Text(message.errorMessage ?? "The model couldn't complete that request.")
-                .font(.footnote)
-                .foregroundStyle(RapidTheme.statusError)
-            Button("Regenerate", action: onRegenerate)
-                .buttonStyle(.link)
-                .font(.footnote)
-                .disabled(isStreaming)
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
+        Text(message.errorMessage ?? "The model couldn't complete that request.")
+            .font(.footnote)
+            .foregroundStyle(RapidTheme.statusError)
+            .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     /// A ``.complete`` row can still carry a soft, non-error caption —

--- a/apps/rapid-mac/Sources/Rapid/UI/TranscriptScrollPositionProbe.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/TranscriptScrollPositionProbe.swift
@@ -184,9 +184,12 @@ struct TranscriptScrollPositionProbe: NSViewRepresentable {
             let clipBounds = scrollView.contentView.bounds
             let distance: CGFloat
             if documentView.isFlipped {
-                distance = documentView.bounds.maxY - clipBounds.maxY
+                distance = documentView.bounds.maxY
+                    + scrollView.contentInsets.bottom
+                    - clipBounds.maxY
             } else {
-                distance = clipBounds.minY - documentView.bounds.minY
+                distance = clipBounds.minY
+                    - (documentView.bounds.minY - scrollView.contentInsets.bottom)
             }
             return distance <= bottomResumeSlack
         }
@@ -202,12 +205,17 @@ struct TranscriptScrollPositionProbe: NSViewRepresentable {
             let clipView = scrollView.contentView
             let targetY: CGFloat
             if documentView.isFlipped {
+                // SwiftUI's full-size macOS window contributes the transparent
+                // titlebar safe area through contentInsets. For a short
+                // transcript, zero is therefore below the natural top edge.
                 targetY = max(
-                    documentView.bounds.minY,
-                    documentView.bounds.maxY - clipView.bounds.height
+                    documentView.bounds.minY - scrollView.contentInsets.top,
+                    documentView.bounds.maxY
+                        + scrollView.contentInsets.bottom
+                        - clipView.bounds.height
                 )
             } else {
-                targetY = documentView.bounds.minY
+                targetY = documentView.bounds.minY - scrollView.contentInsets.bottom
             }
             clipView.scroll(to: NSPoint(x: clipView.bounds.minX, y: targetY))
             scrollView.reflectScrolledClipView(clipView)

--- a/apps/rapid-mac/Tests/RapidTests/ChatMessageActionsTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ChatMessageActionsTests.swift
@@ -1,0 +1,57 @@
+import Testing
+@testable import Rapid
+
+@MainActor
+@Suite("Chat message actions")
+struct ChatMessageActionsTests {
+    @Test("Editing an older user message drops the later turns and resends the edit")
+    func editOlderUserMessageRewindsConversation() {
+        let viewModel = ChatViewModel(persistsConversations: false)
+        let firstUser = ChatMessage(role: .user, content: "original question")
+        let firstAssistant = ChatMessage(role: .assistant, content: "first answer")
+        let secondUser = ChatMessage(role: .user, content: "follow-up")
+        let secondAssistant = ChatMessage(role: .assistant, content: "second answer")
+        viewModel.devSeedMessages([firstUser, firstAssistant, secondUser, secondAssistant])
+
+        let edited = viewModel.editUserMessage(
+            id: firstUser.id,
+            newContent: "  revised question  ",
+            alias: "test-model"
+        )
+        defer { viewModel.stopAndPersist() }
+
+        #expect(edited)
+        #expect(viewModel.messages.count == 2)
+        #expect(viewModel.messages[0].role == .user)
+        #expect(viewModel.messages[0].content == "revised question")
+        #expect(viewModel.messages[1].role == .assistant)
+        #expect(viewModel.messages[1].status == .streaming)
+        #expect(!viewModel.messages.contains(where: { $0.id == secondUser.id }))
+        #expect(!viewModel.messages.contains(where: { $0.id == secondAssistant.id }))
+    }
+
+    @Test("Retrying an older assistant response replays its preceding user turn")
+    func retryOlderAssistantRewindsToItsUserMessage() {
+        let viewModel = ChatViewModel(persistsConversations: false)
+        let firstUser = ChatMessage(role: .user, content: "first question")
+        let firstAssistant = ChatMessage(role: .assistant, content: "first answer")
+        let secondUser = ChatMessage(role: .user, content: "second question")
+        let secondAssistant = ChatMessage(role: .assistant, content: "second answer")
+        viewModel.devSeedMessages([firstUser, firstAssistant, secondUser, secondAssistant])
+
+        let retried = viewModel.retryAssistantMessage(
+            id: firstAssistant.id,
+            alias: "test-model"
+        )
+        defer { viewModel.stopAndPersist() }
+
+        #expect(retried)
+        #expect(viewModel.messages.count == 2)
+        #expect(viewModel.messages[0].role == .user)
+        #expect(viewModel.messages[0].content == "first question")
+        #expect(viewModel.messages[1].role == .assistant)
+        #expect(viewModel.messages[1].status == .streaming)
+        #expect(!viewModel.messages.contains(where: { $0.id == secondUser.id }))
+        #expect(!viewModel.messages.contains(where: { $0.id == secondAssistant.id }))
+    }
+}

--- a/apps/rapid-mac/scripts/verify-chat-scroll-runtime.sh
+++ b/apps/rapid-mac/scripts/verify-chat-scroll-runtime.sh
@@ -2,8 +2,11 @@
 set -eu
 
 ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
-CACHE="$ROOT/.build/codex-module-cache"
-BINARY="$ROOT/.build/chat-scroll-runtime-check"
+CACHE_ROOT=$(mktemp -d /tmp/rapid-chat-scroll-check.XXXXXX)
+CACHE="$CACHE_ROOT/modules"
+BINARY="$CACHE_ROOT/chat-scroll-runtime-check"
+
+trap 'rm -rf -- "$CACHE_ROOT"' EXIT
 
 mkdir -p "$CACHE"
 CLANG_MODULE_CACHE_PATH="$CACHE" \

--- a/apps/rapid-mac/scripts/verify-chat-scroll-runtime.swift
+++ b/apps/rapid-mac/scripts/verify-chat-scroll-runtime.swift
@@ -7,8 +7,12 @@ import SwiftUI
 
 @MainActor
 final class HarnessModel: ObservableObject {
-    @Published var rowCount = 120
+    @Published var rowCount: Int
     @Published var isPinnedToBottom = true
+
+    init(rowCount: Int = 120) {
+        self.rowCount = rowCount
+    }
 }
 
 @MainActor
@@ -39,7 +43,7 @@ private struct HarnessView: View {
             )
             .overlay(ScrollCaptureProbe(capture: capture).frame(width: 0, height: 0))
         }
-        .frame(width: 420, height: 320)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 }
 
@@ -87,18 +91,53 @@ struct ChatScrollRuntimeCheck {
         pump()
     }
 
+    static func bottomTargetY(_ scroll: NSScrollView, document: NSView) -> CGFloat {
+        if document.isFlipped {
+            return max(
+                document.bounds.minY - scroll.contentInsets.top,
+                document.bounds.maxY
+                    + scroll.contentInsets.bottom
+                    - scroll.contentView.bounds.height
+            )
+        }
+        return document.bounds.minY - scroll.contentInsets.bottom
+    }
+
+    static func bottomDistance(_ scroll: NSScrollView, document: NSView) -> CGFloat {
+        if document.isFlipped {
+            return document.bounds.maxY
+                + scroll.contentInsets.bottom
+                - scroll.contentView.bounds.maxY
+        }
+        return scroll.contentView.bounds.minY
+            - (document.bounds.minY - scroll.contentInsets.bottom)
+    }
+
     static func main() {
         let app = NSApplication.shared
         app.setActivationPolicy(.accessory)
-        let model = HarnessModel()
+        let model = HarnessModel(rowCount: 2)
         let capture = ScrollCapture()
-        let host = NSHostingView(rootView: HarnessView(model: model, capture: capture))
+        let host = NSHostingView(
+            rootView: NavigationSplitView {
+                Text("Rapid-MLX")
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+                    .navigationSplitViewColumnWidth(180)
+            } detail: {
+                HarnessView(model: model, capture: capture)
+                    .frame(minWidth: 440, minHeight: 320)
+            }
+            .frame(width: 900, height: 560)
+        )
         let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 420, height: 320),
-            styleMask: [.borderless],
+            contentRect: NSRect(x: 0, y: 0, width: 900, height: 560),
+            styleMask: [.titled, .closable, .resizable, .fullSizeContentView],
             backing: .buffered,
             defer: false
         )
+        window.title = "Rapid-MLX"
+        window.titlebarAppearsTransparent = true
+        window.toolbar = NSToolbar(identifier: "Rapid.ChatScrollCheck")
         window.contentView = host
         window.orderFrontRegardless()
         pump(0.8)
@@ -108,7 +147,62 @@ struct ChatScrollRuntimeCheck {
             exit(1)
         }
 
-        var bottomY = max(0, document.bounds.height - scroll.contentView.bounds.height)
+        // SwiftUI's full-size macOS window contributes a titlebar content
+        // inset to the transcript scroll view. Reproduce it explicitly so
+        // this check remains deterministic outside a full App scene.
+        scroll.automaticallyAdjustsContentInsets = false
+        scroll.contentInsets = NSEdgeInsets(top: 48, left: 0, bottom: 0, right: 0)
+        model.rowCount = 3
+        pump(0.2)
+        model.rowCount = 2
+        pump(0.2)
+
+        // A short conversation must remain wholly visible. This is the exact
+        // shape where an eager bottom anchor can leave the first user bubble
+        // above the clip view even though most of the transcript is blank;
+        // trying to reveal it then only produces AppKit's elastic snap-back.
+        let shortDocumentRect = document.bounds
+        let shortVisibleRect = scroll.documentVisibleRect
+        guard shortDocumentRect.height <= shortVisibleRect.height + 0.5,
+              shortVisibleRect.contains(shortDocumentRect)
+        else {
+            fputs("FAIL: short transcript hid content above the viewport\n", stderr)
+            fputs("\(metrics(scroll))\n", stderr)
+            exit(1)
+        }
+        let expectedShortY = document.bounds.minY - scroll.contentInsets.top
+        guard abs(scroll.contentView.bounds.minY - expectedShortY) <= 0.5 else {
+            fputs("FAIL: short transcript was pushed beneath its top content inset\n", stderr)
+            fputs(
+                "expectedY=\(expectedShortY) actualY=\(scroll.contentView.bounds.minY) "
+                    + "\(metrics(scroll))\n",
+                stderr
+            )
+            exit(1)
+        }
+
+        // A SwiftUI Window uses a full-size content view: the scroll view may
+        // geometrically extend beneath the translucent titlebar, but its
+        // scroll content must be inset by the overlap. Otherwise the first
+        // message is visible to NSScrollView yet blurred behind the titlebar,
+        // and attempting to reveal it only hits the elastic top boundary.
+        let scrollRectInHost = scroll.convert(scroll.bounds, to: host)
+        let safeContentTop = host.bounds.maxY - host.safeAreaInsets.top
+        let titlebarOverlap = max(0, scrollRectInHost.maxY - safeContentTop)
+        guard scroll.contentInsets.top + 0.5 >= titlebarOverlap else {
+            fputs("FAIL: transcript content extends beneath the titlebar\n", stderr)
+            fputs(
+                "overlap=\(titlebarOverlap) host.safe=\(host.safeAreaInsets) "
+                    + "scroll.frame=\(scrollRectInHost) \(metrics(scroll))\n",
+                stderr
+            )
+            exit(1)
+        }
+
+        model.rowCount = 120
+        pump(0.4)
+
+        var bottomY = bottomTargetY(scroll, document: document)
         move(scroll, toY: bottomY)
         guard model.isPinnedToBottom else {
             fputs("FAIL: initial transcript did not follow the bottom\n", stderr)
@@ -140,7 +234,7 @@ struct ChatScrollRuntimeCheck {
                 exit(1)
             }
 
-            bottomY = max(0, document.bounds.height - scroll.contentView.bounds.height)
+            bottomY = bottomTargetY(scroll, document: document)
             NotificationCenter.default.post(name: NSScrollView.willStartLiveScrollNotification, object: scroll)
             move(scroll, toY: bottomY)
             NotificationCenter.default.post(name: NSScrollView.didEndLiveScrollNotification, object: scroll)
@@ -156,13 +250,13 @@ struct ChatScrollRuntimeCheck {
                 pump(0.03)
             }
             pump(0.2)
-            let distance = document.bounds.height - scroll.contentView.bounds.maxY
+            let distance = bottomDistance(scroll, document: document)
             guard model.isPinnedToBottom && distance <= 2.5 else {
                 fputs("FAIL: cycle \(cycle) streamed content was not followed after resuming\n", stderr)
                 fputs("distance=\(distance) \(metrics(scroll))\n", stderr)
                 exit(1)
             }
-            bottomY = max(0, document.bounds.height - scroll.contentView.bounds.height)
+            bottomY = bottomTargetY(scroll, document: document)
         }
 
         // A GENTLE scroll must escape too. The cycles above jump 240 pt in one
@@ -191,14 +285,14 @@ struct ChatScrollRuntimeCheck {
         }
         NotificationCenter.default.post(name: NSScrollView.didEndLiveScrollNotification, object: scroll)
         pump(0.2)
-        let gentleDistance = document.bounds.height - scroll.contentView.bounds.maxY
+        let gentleDistance = bottomDistance(scroll, document: document)
         guard !model.isPinnedToBottom, gentleDistance > 2 else {
             fputs("FAIL: a gentle (sub-slack) scroll was dragged back to the bottom\n", stderr)
             fputs("distance=\(gentleDistance) pinned=\(model.isPinnedToBottom) \(metrics(scroll))\n", stderr)
             exit(1)
         }
 
-        print("PASS: paused scrolling and bottom-resume following survived 3 streaming cycles + gentle scroll")
+        print("PASS: titlebar insets, paused scrolling, bottom resume, and gentle scrolling")
         window.close()
     }
 }


### PR DESCRIPTION
## What does this PR do?

  This PR fixes two related chat interaction problems in the Rapid macOS app.

  ### Message actions

  - Adds persistent Copy and Edit icons below every user message.
  - Adds persistent Copy and Retry icons below every AI response.
  - Uses SF Symbols and the existing `QuietIconButton` style, including tooltips and accessibility labels.
  - Supports inline editing with Save and Cancel controls.
  - Truncates later turns and resends from the edited user message.
  - Retries the selected AI response instead of always regenerating the latest turn.
  - Copies the reasoning text when an AI response contains reasoning but no visible prose.
  - Keeps Copy available during streaming while disabling Edit and Retry actions.
  - Replaces the failed-response Regenerate text link with the consistent Retry icon.

  ### Transcript title-bar scrolling

  - Accounts for the backing `NSScrollView` content insets when calculating the valid scroll range.
  - Preserves the natural negative scroll origin introduced by a full-size macOS title bar.
  - Prevents short transcripts from being pushed underneath the title bar.
  - Stops the transcript from snapping back to an incorrect position after the user scrolls.
  - Extends the runtime regression harness to cover nonzero content insets and short transcripts.
  - Retains the existing streamed-response follow, pause, and resume behavior across repeated layout cycles.

  The PR also adds focused tests for editing and retrying older conversation turns.

  ## Why is this needed?

  Chat messages did not expose common actions after they were sent. Users had to select text manually to copy it, could not edit an earlier prompt in place, and could only retry the latest response. Reusing the existing “regenerate last” behavior for every AI response would also retry the wrong prompt when the action belonged to an older turn.

  This PR makes each action operate on the message where it appears:

  - editing a user message removes the later conversation and resends the edited prompt;
  - retrying an AI response finds its preceding user message, removes the later conversation, and regenerates that turn.

  The transcript also calculated its scroll bounds without considering `NSScrollView.contentInsets`. In a full-size macOS window, the title bar contributes a top inset, so the natural top position can be negative. Clamping that position to zero moved part of a short transcript beneath the title bar, and attempts to scroll it back into view would snap to the incorrect position.

  This PR includes the content inset in the scroll-range calculation, keeping short transcripts fully visible while preserving the existing stream-following behavior.