### PR TITLE
feat(rapid-mac): unify model readiness UX (+ selected-model scoping fixes)

### DIFF
--- a/apps/rapid-mac/Package.swift
+++ b/apps/rapid-mac/Package.swift
@@ -60,6 +60,14 @@ let package = Package(
             name: "RapidTests",
             dependencies: ["Rapid"],
             path: "Tests/RapidTests"
+        ),
+        // Phase 1 model-readiness regression tests: the pure
+        // ``ModelReadiness`` state machine that gates Send and drives the
+        // readiness banner shared by Chat and Launch.
+        .testTarget(
+            name: "RapidUXTests",
+            dependencies: ["Rapid"],
+            path: "Tests/RapidUXTests"
         )
         // NOTE (2026-08-05): the RapidTests target is BACK in the manifest,
         // above. It had been excluded on the reasoning that the strip

--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
@@ -63,6 +63,18 @@ final class ChatViewModel {
     /// Structured counterpart to ``lastError`` used by the shared failure
     /// view to choose a recovery action without parsing display copy.
     private(set) var lastFailureKind: FailureDiagnosis.Kind?
+    /// Which model ``lastError`` is about.
+    ///
+    /// Without this the readiness surface had to guess, and it guessed
+    /// "whatever is selected right now" — so after `kimi-k2.6` failed to
+    /// start, choosing `bonsai-1.7b-2bit` re-labelled Kimi's error as
+    /// Bonsai's. A failure belongs to the model that actually failed;
+    /// recording the alias is what lets a later surface decide whether
+    /// the failure is still the user's current problem.
+    ///
+    /// Cleared in lockstep with ``lastError``. Note this scopes only the
+    /// BANNER — the failed turn stays in the transcript either way.
+    private(set) var lastFailureAlias: String?
 
     private var inflight: Task<Void, Never>?
 
@@ -153,6 +165,7 @@ final class ChatViewModel {
         activeConversationID = id
         lastError = nil
         lastFailureKind = nil
+        lastFailureAlias = nil
     }
 
     /// Delete a saved conversation. If it was the open one, drop to a fresh
@@ -171,6 +184,7 @@ final class ChatViewModel {
             isStreaming = false          // messages now empty → persistActive no-ops
             lastError = nil
             lastFailureKind = nil
+            lastFailureAlias = nil
         }
         conversations.removeAll { $0.id == id }
         ConversationStore.save(conversations)
@@ -221,6 +235,7 @@ final class ChatViewModel {
         activeConversationID = UUID()
         lastError = nil
         lastFailureKind = nil
+        lastFailureAlias = nil
     }
 
     /// DEV-ONLY: replace the transcript with a fixed set of messages so
@@ -257,6 +272,7 @@ final class ChatViewModel {
 
         lastError = nil
         lastFailureKind = nil
+        lastFailureAlias = nil
         isStreaming = true
 
         let epoch = conversationEpoch
@@ -340,6 +356,9 @@ final class ChatViewModel {
             updateMessage(at: placeholderIndex, with: placeholder)
         }
         lastError = message
+        // Attribute the failure to the alias that actually failed, not to
+        // whatever the picker happens to hold later.
+        lastFailureAlias = alias
         // Classify the banner as a model-load failure (#590) rather than
         // letting it fall back to chatFailureKind("Couldn't start …") →
         // the generic `.requestFailed` diagnosis, whose Retry action just
@@ -433,6 +452,8 @@ final class ChatViewModel {
     func clearStaleErrorBanner() {
         guard !isStreaming else { return }
         lastError = nil
+        lastFailureKind = nil
+        lastFailureAlias = nil
     }
 
     /// Pure transformation applied to the assistant placeholder when
@@ -821,6 +842,7 @@ final class ChatViewModel {
                     for: .modelLoadFailed,
                     modelAlias: trimmed
                 ).message
+                lastFailureAlias = trimmed
                 return
             }
         }
@@ -1179,6 +1201,7 @@ final class ChatViewModel {
             current.failureKind = failureKind
             lastFailureKind = failureKind
             lastError = actionable
+            lastFailureAlias = request.alias
             writeStreamMessage(at: placeholderIndex, epoch: epoch, current)
             // #478: speak the failure to a screen-reader user (the error
             // string), so a silent red bubble isn't the only signal.

--- a/apps/rapid-mac/Sources/Rapid/DevSnapshot.swift
+++ b/apps/rapid-mac/Sources/Rapid/DevSnapshot.swift
@@ -78,7 +78,17 @@ enum DevSnapshot {
         /// Consequence to keep in mind when reading the image: the
         /// system's sidebar toolbar/collapse chrome is absent, and the
         /// divider is drawn here rather than by AppKit.
-        func launchView(width: CGFloat, height: CGFloat) -> AnyView {
+        /// ``readiness`` is threaded through so the capture exercises the
+        /// SHARED value the real ``ContentView`` supplies, not
+        /// ``ConnectToolsView``'s nil-fallback sentence. Without it this
+        /// scene could not show that Chat and Launch render the same
+        /// banner, with the same words and the same action, for the same
+        /// state — which is the whole point of the readiness work.
+        func launchView(
+            width: CGFloat,
+            height: CGFloat,
+            readiness: ModelReadiness? = .needsStart(alias: "bonsai-1.7b-2bit")
+        ) -> AnyView {
             AnyView(
                 HStack(spacing: 0) {
                     SidebarView(
@@ -94,9 +104,14 @@ enum DevSnapshot {
                         .fill(RapidTheme.hairline)
                         .frame(width: 1)
 
-                    LaunchView(server: server, alias: "bonsai-1.7b-2bit")
-                        .frame(maxWidth: .infinity, maxHeight: .infinity)
-                        .background(RapidTheme.surfaceCanvas)
+                    LaunchView(
+                        server: server,
+                        alias: "bonsai-1.7b-2bit",
+                        readiness: readiness,
+                        onReadinessAction: { _ in }
+                    )
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .background(RapidTheme.surfaceCanvas)
                 }
                 .tint(RapidTheme.brandAmber)
                 .environment(server)
@@ -132,12 +147,74 @@ enum DevSnapshot {
                      appearance: .darkAqua, to: "\(dir)/chat-900x640-dark.png")
         renderHosted(contentView(width: 640, height: 560), size: floorSize,
                      appearance: .aqua, to: "\(dir)/chat-640x560-light.png")
+        renderHosted(contentView(width: 640, height: 560), size: floorSize,
+                     appearance: .darkAqua, to: "\(dir)/chat-640x560-dark.png")
         renderHosted(launchView(width: 900, height: 640), size: reviewSize,
                      appearance: .aqua, to: "\(dir)/launch-900x640-light.png")
         renderHosted(launchView(width: 900, height: 640), size: reviewSize,
                      appearance: .darkAqua, to: "\(dir)/launch-900x640-dark.png")
         renderHosted(launchView(width: 640, height: 560), size: floorSize,
                      appearance: .aqua, to: "\(dir)/launch-640x560-light.png")
+        renderHosted(launchView(width: 640, height: 560), size: floorSize,
+                     appearance: .darkAqua, to: "\(dir)/launch-640x560-dark.png")
+
+        // The readiness matrix: every ``ModelReadiness`` case rendered as
+        // the user sees it, with the three copy channels that must agree
+        // printed underneath.
+        //
+        // A live ``ContentView`` capture can only ever show whichever
+        // state the harness happens to be in (``noModel``, with no
+        // catalog and autostart off). The lifecycle states that matter
+        // most for review — mid-download, starting, failed — need a real
+        // server doing real work, which a snapshot run cannot stage. This
+        // renders the same view the composer renders, driven directly by
+        // the state values, so the banner / action / placeholder /
+        // tooltip / send-enabled contract is reviewable in one image.
+        func readinessMatrix() -> AnyView {
+            let states: [ModelReadiness] = [
+                .noModel,
+                .needsDownload(alias: "qwen3.5-9b-4bit", sizeText: "5.0 GB"),
+                .needsStart(alias: "bonsai-1.7b-2bit"),
+                .downloading(
+                    alias: "qwen3.5-9b-4bit",
+                    detail: "1.2 GB / 5.0 GB · 24% · 8.4 MB/s · 7 min left",
+                    fraction: 0.24
+                ),
+                .starting(alias: "bonsai-1.7b-2bit", detail: "Loading the model into memory…"),
+                .failed(
+                    alias: "qwen3.5-9b-4bit",
+                    message: FailureDiagnoser.diagnosis(for: .modelLoadFailed).message,
+                    action: .retry(alias: "qwen3.5-9b-4bit")
+                ),
+                .engineMissing,
+                .ready(alias: "bonsai-1.7b-2bit"),
+            ]
+            return AnyView(
+                VStack(alignment: .leading, spacing: RapidTheme.Space.lg) {
+                    ForEach(Array(states.enumerated()), id: \.offset) { _, state in
+                        VStack(alignment: .leading, spacing: RapidTheme.Space.xs) {
+                            ReadinessBanner(readiness: state, onAction: { _ in })
+                            Text(
+                                "send=\(state.sendAllowed ? "ENABLED" : "disabled")"
+                                + "  ·  placeholder: “\(state.composerPlaceholder)”"
+                                + "  ·  tooltip: “\(state.sendTooltip)”"
+                            )
+                            .font(RapidFont.code)
+                            .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+                .padding(RapidTheme.Space.xl)
+                .frame(width: 900, alignment: .leading)
+                .background(RapidTheme.surfaceCanvas)
+                .tint(RapidTheme.brandAmber)
+            )
+        }
+        let matrixSize = CGSize(width: 900, height: 900)
+        renderHosted(readinessMatrix(), size: matrixSize,
+                     appearance: .aqua, to: "\(dir)/readiness-matrix-light.png")
+        renderHosted(readinessMatrix(), size: matrixSize,
+                     appearance: .darkAqua, to: "\(dir)/readiness-matrix-dark.png")
 
         // The rail on its own, at its shipping width, with seeded
         // history so row density / truncation / the amber selected
@@ -210,7 +287,8 @@ enum DevSnapshot {
         render(
             AnyView(
                 ChatView(viewModel: chat, server: server,
-                         alias: .constant("bonsai-1.7b-2bit"), serverReady: true)
+                         alias: .constant("bonsai-1.7b-2bit"),
+                         readiness: .ready(alias: "bonsai-1.7b-2bit"))
                     .transcriptRows
                     .frame(width: 900)
                     .background(RapidTheme.canvas)
@@ -342,7 +420,7 @@ enum DevSnapshot {
                 viewModel: chat,
                 server: server,
                 alias: .constant(server.servingAlias ?? ""),
-                serverReady: true
+                readiness: .ready(alias: server.servingAlias ?? "bonsai-1.7b-2bit")
             )
             .environment(downloads)
             .environment(quickstart)

--- a/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
@@ -413,7 +413,17 @@ struct ChatView: View {
                 )
                 .frame(maxWidth: contentMaxWidth)
                 .frame(maxWidth: .infinity)
-            } else if let error = viewModel.lastError {
+            } else if let error = viewModel.lastError,
+                      ModelReadiness.turnErrorApplies(
+                          failureAlias: viewModel.lastFailureAlias,
+                          selectedAlias: alias
+                      ) {
+                // Only the CURRENT model's turn error (or an unattributed
+                // one) belongs here. Without the alias gate, switching to a
+                // healthy model and letting it reach ``ready`` would render
+                // the previous model's error under the fresh composer until
+                // the next send cleared it — a model-scoped error leaking
+                // across a model switch (#1505 follow-up).
                 InlineNotice(message: error, tone: .error)
                     .frame(maxWidth: contentMaxWidth)
                     .frame(maxWidth: .infinity)

--- a/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
@@ -182,10 +182,15 @@ struct ChatView: View {
     @Bindable var viewModel: ChatViewModel
     @Bindable var server: ServerManager
     @Binding var alias: String
-    var serverReady: Bool
-    /// When the next Send would trigger a cold model download, the
-    /// alias + a human size string so the empty state can hint at it.
-    var autoStartPendingDownload: (alias: String, sizeText: String?)? = nil
+    /// The single readiness value for this window, resolved once by
+    /// ``ContentView`` and shared with the Launch page. Both the chat
+    /// hero and the composer read their copy off this, so they cannot
+    /// describe the same lifecycle differently.
+    var readiness: ModelReadiness
+    /// Perform the readiness banner's next-step action (start, download
+    /// & start, retry). Owned by ``ContentView`` because starting a model
+    /// is a window-level concern, not a chat-surface one.
+    var onReadinessAction: (ModelReadiness.Action) -> Void = { _ in }
 
     /// Backing state for the composer's inline model picker (Ollama-style).
     /// The picker lives in the compose box now, not a top control bar.
@@ -196,6 +201,9 @@ struct ChatView: View {
     @State private var composeFocusToken: Int = 0
     @State private var showConnectTools = false
     @State private var showBenchmark = false
+    /// Incremented every time the user tries to send while gated. Drives
+    /// the banner's brief emphasis so a blocked Return is never silent.
+    @State private var blockedSendAttempts: Int = 0
 
     private let contentMaxWidth: CGFloat = RapidTheme.Layout.contentMaxWidth
     /// A live user gesture must reach the actual trailing edge before
@@ -328,8 +336,10 @@ struct ChatView: View {
                 // existence mid-session and shifted the layout.
                 //
                 // Now both always render whenever the transcript is
-                // empty, in every lifecycle state. Availability is
-                // expressed by ENABLEMENT, not by presence:
+                // empty, in every lifecycle state, and neither appears
+                // or disappears because chat history changed.
+                // Availability is expressed by ENABLEMENT, not by
+                // presence:
                 //
                 //   * Connect your tools is always actionable. The sheet
                 //     itself explains when the endpoint isn't ready yet
@@ -362,58 +372,48 @@ struct ChatView: View {
         )
     }
 
-    /// The line under "Ask anything".
+    /// The line under "Ask anything", and the quieter hint below it.
     ///
-    /// Three distinct states, none of which may render an internal
-    /// placeholder (`Loading`, `Starting`, …) where a model name goes:
+    /// Both come straight off ``ModelReadiness`` rather than being
+    /// re-derived here. That is the whole point of the type: the hero
+    /// and the composer are two renderings of one state, so they can no
+    /// longer say different things about the same moment. The two
+    /// strings the approved empty state already shipped ("Choose a model
+    /// to start", "Chatting with <alias>") are preserved verbatim by
+    /// ``ModelReadiness/emptyStateSubtitle``.
+    private var emptyStateSubtitle: String { readiness.emptyStateSubtitle }
+
+    private var downloadHint: String? { readiness.emptyStateHint }
+
+    /// Speed can only measure a model that is actually up.
     ///
-    ///   * nothing chosen yet  → an instruction, not a claim
-    ///   * coming up           → a status sentence
-    ///   * resolved            → the real alias
-    private var emptyStateSubtitle: String {
-        if case .starting = server.state {
-            return "Preparing your local model…"
-        }
-        if ModelDisplayName.isUnresolved(alias) {
-            // "Choose", not "Select" — one verb for this flow, matching
-            // the composer control and the picker's own tooltip.
-            return "Choose a model to start"
-        }
-        return "Chatting with \(alias)"
-    }
-
-    /// The download hint under the subtitle. Names the model only when
-    /// it is a real alias; otherwise stays generic rather than
-    /// interpolating a placeholder into the sentence.
-    private var downloadHint: String? {
-        guard let pending = autoStartPendingDownload else { return nil }
-        guard !ModelDisplayName.isUnresolved(pending.alias) else {
-            return "Your first message will download the selected model."
-        }
-        let size = pending.sizeText.map { " (\($0))" } ?? ""
-        return "Your first message will download \(pending.alias)\(size)."
-    }
-
-    /// Speed can only measure a model that is actually up. Keyed on the
-    /// live server state rather than the ``serverReady`` flag so the
-    /// button re-enables the moment the model finishes starting.
+    /// Presence is unconditional (the button always renders while the
+    /// transcript is empty); only enablement moves. Keyed on the shared
+    /// readiness value so the button re-enables the moment the model
+    /// reaches ready — no user action, no extra render trigger.
     private var benchmarkAvailable: Bool {
-        guard server.binaryPath != nil else { return false }
-        // Routed through the shared predicate rather than a bare
-        // ``isEmpty`` so every readiness decision in the app agrees on
-        // what counts as "no model" — an internal placeholder is not a
-        // model you can benchmark.
-        if case .ready = server.state {
-            return !ModelDisplayName.isUnresolved(alias)
-        }
-        return false
+        server.binaryPath != nil && readiness.isReady
     }
 
     // MARK: - Compose bar
 
     private var composeBar: some View {
         VStack(spacing: RapidTheme.Space.sm) {
-            if let error = viewModel.lastError {
+            // Exactly one notice slot. While the model is not ready the
+            // readiness banner owns it — it already folds the failure
+            // message in, so rendering the raw error underneath would be
+            // the same fact twice. Once the model is ready the slot
+            // reverts to turn-level errors (a 500 from a healthy server),
+            // which readiness has no opinion about.
+            if !readiness.isReady {
+                ReadinessBanner(
+                    readiness: readiness,
+                    attentionToken: blockedSendAttempts,
+                    onAction: onReadinessAction
+                )
+                .frame(maxWidth: contentMaxWidth)
+                .frame(maxWidth: .infinity)
+            } else if let error = viewModel.lastError {
                 InlineNotice(message: error, tone: .error)
                     .frame(maxWidth: contentMaxWidth)
                     .frame(maxWidth: .infinity)
@@ -428,10 +428,16 @@ struct ChatView: View {
             // tall and read as a card that happened to contain a text
             // area; this reads as a text field with controls in it.
             VStack(spacing: RapidTheme.Space.sm - 2) {
+                // The field stays live in every state — a user may draft
+                // while the model downloads, and that draft survives the
+                // transition to ready untouched. Only the send ACTION is
+                // gated; the placeholder names the blocking step so the
+                // reason is visible before a single character is typed.
                 ComposeField(
                     text: $draft,
                     focusToken: composeFocusToken,
                     isStreaming: viewModel.isStreaming,
+                    placeholder: readiness.composerPlaceholder,
                     onSubmit: send,
                     onCancel: { viewModel.stop() },
                     onRecallLastUser: {
@@ -514,12 +520,24 @@ struct ChatView: View {
             }
             .buttonStyle(.plain)
             .disabled(!sendEnabled)
-            .help("Send")
+            .help(readiness.sendTooltip)
             .accessibilityLabel("Send message")
+            // The tooltip alone is mouse-only. VoiceOver users get the
+            // same sentence as the control's hint, so "why is this
+            // dimmed" is answerable without a pointer.
+            .accessibilityHint(readiness.sendAllowed ? "" : readiness.sendTooltip)
         }
     }
 
+    /// Two independent gates. ``hasDraft`` is the ordinary "nothing to
+    /// send" case; ``readiness.sendAllowed`` is the lifecycle gate that
+    /// replaces the old behaviour where pressing Send on a cold model
+    /// silently kicked off a multi-gigabyte download behind a spinner.
     private var sendEnabled: Bool {
+        hasDraft && readiness.sendAllowed
+    }
+
+    private var hasDraft: Bool {
         !draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 
@@ -529,6 +547,21 @@ struct ChatView: View {
         let text = draft
         guard !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
         guard !viewModel.isStreaming else { return }
+        // Return reaches here even when the Send button is disabled —
+        // AppKit routes the key through ``ComposeTextEditor`` regardless
+        // of SwiftUI's button state. Previously that landed on a silent
+        // no-op: the keystroke did nothing and nothing said why.
+        //
+        // Two guarantees here. The draft is NOT cleared (it is still
+        // exactly what the user typed, ready to send the moment the
+        // model is up), and the attempt is acknowledged — the banner
+        // flashes and VoiceOver speaks the same sentence the Send
+        // tooltip carries.
+        guard readiness.sendAllowed else {
+            blockedSendAttempts &+= 1
+            VoiceOverAnnouncer.announce(readiness.sendTooltip)
+            return
+        }
         draft = ""
         composeFocusToken &+= 1
         viewModel.send(text, alias: alias)
@@ -536,6 +569,13 @@ struct ChatView: View {
 
     private func regenerate() {
         guard !viewModel.isStreaming else { return }
+        // Same contract as ``send``: a regenerate needs a live model, so
+        // acknowledge rather than silently drop it when there isn't one.
+        guard readiness.sendAllowed else {
+            blockedSendAttempts &+= 1
+            VoiceOverAnnouncer.announce(readiness.sendTooltip)
+            return
+        }
         viewModel.regenerateLast(alias: alias)
     }
 }

--- a/apps/rapid-mac/Sources/Rapid/UI/ConnectToolsView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ConnectToolsView.swift
@@ -23,6 +23,19 @@ struct ConnectToolsView: View {
     /// sheet to dismiss — showing a dead ✕ that does nothing was a real
     /// papercut. The sidebar owns navigation, so it passes false.
     var showsCloseButton: Bool = true
+    /// The window's shared readiness value, when the caller has one.
+    ///
+    /// Before this, the page derived readiness twice and locally, and
+    /// rendered BOTH results at once: a header line saying "start a
+    /// chat to generate the key" and a body notice saying "Start a
+    /// model to generate your local endpoint and key". Two verbs, two
+    /// placements, one condition — and neither offered a way to do the
+    /// thing it asked for. Supplying ``readiness`` replaces both with
+    /// the same banner (and the same next-step action) the composer
+    /// shows. ``nil`` keeps the legacy local sentence for the dev
+    /// snapshot harness, which has no live server to resolve against.
+    var readiness: ModelReadiness? = nil
+    var onReadinessAction: (ModelReadiness.Action) -> Void = { _ in }
 
     private var openAIBaseURL: String { "http://\(host):\(port)/v1" }
     private var anthropicBaseURL: String { "http://\(host):\(port)" }
@@ -112,7 +125,19 @@ struct ConnectToolsView: View {
             // always reachable (see ChatView's empty-state CTA), so
             // this is the surface that has to explain the "not yet"
             // case instead of the button hiding it.
-            if !configReady {
+            //
+            // One notice, never two. When the window supplies a shared
+            // readiness value it wins outright — it is the same object
+            // the composer renders, so the two surfaces cannot disagree,
+            // and unlike the old local sentence it carries the action
+            // that resolves the problem.
+            if let readiness, !readiness.isReady {
+                ReadinessBanner(readiness: readiness, onAction: onReadinessAction)
+            } else if !configReady {
+                // Either no readiness was supplied (dev snapshot), or the
+                // model is up but a value is still missing — a narrow
+                // case, but silence there would leave a half-filled
+                // config looking complete.
                 InlineNotice(message: readinessMessage, tone: .info)
             }
             endpointSection
@@ -131,19 +156,14 @@ struct ConnectToolsView: View {
                     subtitle: "Connect tools that support a local base URL. It's free and stays on your Mac.",
                     emphasis: .page
                 )
-                // #1470 fix: the key only exists while the server is running and
-                // is regenerated on every start. Without this hint the cards
-                // render `API key:` followed by nothing — a config that looks
-                // complete, copies clean, and fails at the far end with a 401.
-                if bearer.isEmpty {
-                    Label(
-                        "Server not running — start a chat to generate the key.",
-                        systemImage: "exclamationmark.circle"
-                    )
-                    .font(.caption)
-                    .foregroundStyle(.orange)
-                    .padding(.top, 4)
-                }
+                // The #1470 "start a chat to generate the key" hint used
+                // to live here, duplicating the body's readiness notice
+                // with a different verb. The fact it carried — the key
+                // only exists while the server runs — is preserved by
+                // the API key row's own placeholder ("Created when the
+                // server starts") and, when the caller supplies one, by
+                // the readiness banner below, which also says how to
+                // fix it. One statement, in one place, with an action.
             }
             Spacer()
             if showsCloseButton {

--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -41,6 +41,16 @@ struct ContentView: View {
     /// #223: launch-time auto-start "needs download" state — the empty
     /// state names the pending pull when non-nil.
     @State private var autoStartPendingDownload: (alias: String, sizeText: String?)?
+    /// Catalog snapshot, owned here rather than in ``ChatView`` so the
+    /// chat surface and the Launch page resolve readiness from the SAME
+    /// inputs. Two views calling the same pure function on different
+    /// catalogs would reintroduce exactly the drift ``ModelReadiness``
+    /// exists to remove. Empty until the first refresh lands.
+    @State private var catalogEntries: [ModelEntry] = []
+    /// False until the first catalog refresh completes. Distinguishes
+    /// "this alias is not downloaded" from "we don't know yet", which
+    /// are different sentences and different next steps.
+    @State private var catalogLoaded: Bool = false
     /// FU-1: persisted opt-out for the launch-time auto-start path.
     @AppStorage(AutoStartPreference.storageKey) private var autoStartOnLaunch: Bool = AutoStartPreference.defaultValue
 
@@ -242,6 +252,143 @@ struct ContentView: View {
             quickstartSheet
         }
         .task { await runLaunchAutoStart() }
+        // Keyed exactly as the picker's own catalog task: re-fetch when
+        // the engine binary appears and whenever the set of models on
+        // disk changes anywhere in the app. Routed through the shared
+        // ``ModelCatalogCache`` so owning a second reader here costs no
+        // extra subprocess.
+        .task(id: ModelPickerBar.PickerCatalogKey(
+            binaryPath: server.binaryPath,
+            cacheGeneration: downloads.cacheGeneration
+        )) {
+            await refreshCatalogSnapshot()
+        }
+    }
+
+    // MARK: - Readiness (the one shared lifecycle value)
+
+    /// The window's single readiness value.
+    ///
+    /// Resolved once per render and handed to both the chat surface and
+    /// the Launch page, so "what state is the model in" has exactly one
+    /// answer at any instant. See ``ModelReadiness`` for the precedence
+    /// rules and the copy contract.
+    private var readiness: ModelReadiness {
+        ModelReadiness.resolve(
+            serverState: server.state,
+            alias: alias,
+            isAliasCached: cachedState(for: alias),
+            sizeText: sizeText(for: alias),
+            progress: progressSnapshot,
+            failure: chat.lastError.map {
+                ModelReadiness.Failure(
+                    message: $0,
+                    kind: chat.lastFailureKind,
+                    // The alias the failure is ABOUT — not the one
+                    // currently selected. Passing `alias` here is what
+                    // let a failure follow the user onto whatever model
+                    // they picked next.
+                    alias: chat.lastFailureAlias
+                )
+            }
+        )
+    }
+
+    /// Progress is only read while the server is actually starting.
+    ///
+    /// This is an observation-scope decision, not a cosmetic one.
+    /// ``DownloadProgress`` republishes every 500 ms, and reading it in
+    /// this view's body registers ``ContentView`` — and therefore the
+    /// whole split view — as an observer. Gating on ``.starting`` keeps
+    /// that half-second churn confined to the window where the banner
+    /// genuinely needs it, instead of paying it for the entire session.
+    private var progressSnapshot: ModelReadiness.ProgressSnapshot? {
+        guard case .starting = server.state else { return nil }
+        return ModelReadiness.ProgressSnapshot(
+            activity: server.downloadProgress.startupActivity,
+            subtitle: server.downloadProgress.progressSubtitle,
+            fraction: server.downloadProgress.progressFraction
+        )
+    }
+
+    /// `nil` while the catalog is still loading — see the ``resolve``
+    /// docs for why that resolves to "start" rather than "download".
+    private func cachedState(for alias: String) -> Bool? {
+        guard !alias.isEmpty else { return nil }
+        // #223's launch-time decision already established that this
+        // alias needs pulling, and it lands before the catalog snapshot
+        // does. Trusting it here means a cold first launch says
+        // "isn't downloaded yet" immediately instead of flashing
+        // "isn't running" for the second the catalog takes to load.
+        if let pending = autoStartPendingDownload, pending.alias == alias {
+            return false
+        }
+        guard catalogLoaded else { return nil }
+        guard let entry = catalogEntries.first(where: { $0.alias == alias }) else {
+            // A custom alias the user typed isn't in the catalog. We
+            // genuinely don't know whether it's on disk.
+            return nil
+        }
+        return entry.cached
+    }
+
+    /// Human download size for the readiness copy. Shares
+    /// ``QuickstartView``'s formatter so onboarding and the composer
+    /// quote the same number in the same units for the same model.
+    private func sizeText(for alias: String) -> String? {
+        guard !alias.isEmpty else { return nil }
+        // The launch-time auto-start decision already formatted one for
+        // the alias it picked; prefer it so the two paths can't disagree
+        // by a rounding step.
+        if let pending = autoStartPendingDownload,
+           pending.alias == alias,
+           let text = pending.sizeText {
+            return text
+        }
+        let text = QuickstartView.sizeText(for: alias)
+        return text.isEmpty ? nil : text
+    }
+
+    private func refreshCatalogSnapshot() async {
+        guard let binary = server.binaryPath else { return }
+        let loaded = await ModelCatalogCache.shared.entries(
+            binary: binary,
+            generation: downloads.cacheGeneration
+        )
+        guard !Task.isCancelled else { return }
+        catalogEntries = loaded
+        catalogLoaded = true
+    }
+
+    /// Perform the readiness banner's next-step action.
+    ///
+    /// Lives here rather than in ``ChatView`` because starting a model is
+    /// a window-level concern — the Launch page raises the same actions.
+    /// Start routes through ``ServerManager.start``, which is the one
+    /// choke point that applies the launch flags and the live
+    /// free-memory guard (#1435), so this path inherits the same OOM
+    /// protection the implicit send-start path already had.
+    private func performReadinessAction(_ action: ModelReadiness.Action) {
+        switch action {
+        case .chooseModel:
+            // The model picker in the composer owns this step; the
+            // banner names it but deliberately renders no second
+            // control. See ``ModelReadiness.Action.isRenderable``.
+            break
+        case .downloadAndStart(let target), .start(let target):
+            startModel(target)
+        case .retry(let target):
+            // Clear the failure first, or the banner would stay in its
+            // failed state until the next server transition lands and
+            // the user would read "Couldn't start X" while X is starting.
+            chat.clearStaleErrorBanner()
+            startModel(target)
+        }
+    }
+
+    private func startModel(_ target: String) {
+        let hfPath = catalogEntries.first(where: { $0.alias == target })?.hfRepo
+        Task { await server.start(alias: target, hfPath: hfPath) }
     }
 
     // MARK: - Detail routing
@@ -254,7 +401,12 @@ struct ContentView: View {
         case .chat:
             mainArea
         case .launch:
-            LaunchView(server: server, alias: alias)
+            LaunchView(
+                server: server,
+                alias: alias,
+                readiness: readiness,
+                onReadinessAction: performReadinessAction
+            )
         }
     }
 
@@ -263,13 +415,13 @@ struct ContentView: View {
     @ViewBuilder
     private var mainArea: some View {
         switch ContentView.mainAreaBranch(for: server.state) {
-        case .chat(let serverReady):
+        case .chat:
             ChatView(
                 viewModel: chat,
                 server: server,
                 alias: $alias,
-                serverReady: serverReady,
-                autoStartPendingDownload: autoStartPendingDownload
+                readiness: readiness,
+                onReadinessAction: performReadinessAction
             )
         case .missing:
             missingOverlay
@@ -612,21 +764,24 @@ struct ContentView: View {
         }
     }
 
+    /// Which surface the detail pane shows.
+    ///
+    /// The branch used to carry a ``serverReady`` payload that
+    /// ``ChatView`` accepted and never read — readiness was decided
+    /// three other ways inside the view. ``ModelReadiness`` now owns
+    /// that question in one place, so the branch is back to the single
+    /// thing it actually decides: chat surface, or install overlay.
     enum MainAreaBranch: Equatable {
-        case chat(serverReady: Bool)
+        case chat
         case missing
     }
 
     static func mainAreaBranch(for state: ServerState) -> MainAreaBranch {
         switch state {
-        case .ready:
-            return .chat(serverReady: true)
-        case .starting:
-            return .chat(serverReady: false)
         case .missing:
             return .missing
-        case .idle, .stopped, .crashed:
-            return .chat(serverReady: false)
+        case .ready, .starting, .idle, .stopped, .crashed:
+            return .chat
         }
     }
 }

--- a/apps/rapid-mac/Sources/Rapid/UI/ModelPickerBar.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ModelPickerBar.swift
@@ -461,14 +461,24 @@ struct ModelPickerBar: View {
                 // remembered the alias's spelling would scroll right
                 // past the cached copy in the wrong section, then
                 // grumble that the alias was "missing".
-                quickstartSection
-                recommendedSection
-                allAliasesSection
-                Divider()
+                // Actions FIRST, then the catalog.
+                //
+                // The alias list runs to ~150 rows, so at the bottom
+                // these two were past several screens of scrolling — and
+                // "Type a model name…" is precisely what a user reaches
+                // for when they cannot find their model in that list, so
+                // burying it under the list made the escape hatch cost
+                // the most effort at the exact moment it was needed. The
+                // loading and empty branches above already lead with
+                // their actions; this makes all three agree.
                 Button("Refresh catalog") {
                     Task { await refreshCatalog(force: true) }
                 }
                 Button("Type a model name…") { showCustom = true }
+                Divider()
+                quickstartSection
+                recommendedSection
+                allAliasesSection
             }
         } label: {
             HStack(spacing: 6) {
@@ -554,14 +564,20 @@ struct ModelPickerBar: View {
         .menuIndicator(.hidden)
         .onHover { pickerHovering = $0 }
         .rapidAnimation(RapidMotion.quick, value: pickerHovering)
+        // One vocabulary across every readiness surface (see
+        // ``ModelReadiness``): you CHOOSE a model, DOWNLOAD it if
+        // needed, START it, and then it is READY. The picker is the
+        // control the readiness banner's "Choose a model in the box
+        // below" points at, so it has to use that exact word rather
+        // than a near-synonym.
         .help(pickerIsUnresolved
-              ? "Choose a model to run"
+              ? "Choose a model"
               : "Model: \(alias) — click to change")
         // Both glyphs are hidden from AX above, so this collapses to a
         // single AXMenuButton announced as "Model, <alias>, pop up button"
         // rather than spelling out SF Symbol names.
         .accessibilityLabel("Model")
-        .accessibilityValue(pickerIsUnresolved ? "None selected" : alias)
+        .accessibilityValue(pickerIsUnresolved ? "No model chosen" : alias)
         .accessibilityHint("Choose which model to run")
         .accessibilityIdentifier("ModelPickerBar.ModelMenu")
     }

--- a/apps/rapid-mac/Sources/Rapid/UI/ModelReadiness.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ModelReadiness.swift
@@ -517,16 +517,28 @@ enum ModelReadiness: Equatable {
     }
 
     /// Permissive rule for a NON-Send-enabling serve-state (``.starting``):
-    /// let it describe the current pick UNLESS a *different real model* is
-    /// selected. A placeholder serving name (an engine "Loading" mid-start)
-    /// or a not-yet-synced selection (the first frame at launch, before the
-    /// picker breadcrumb catches up to an auto-started model) both fall
-    /// through to `true` so the in-flight start stays visible; only a
-    /// deliberate pick of another real model suppresses it. (#1505.)
+    /// may the in-flight start describe the current pick?
+    ///
+    ///   * serving real, selected real → only when they are the same model.
+    ///   * serving real, selection not synced yet (placeholder) → yes: the
+    ///     launch frame where the picker breadcrumb lags the auto-started
+    ///     model. Show the real serving name.
+    ///   * serving is a placeholder (an engine "Loading" with no alias) →
+    ///     yes ONLY when the selection is also unresolved. If a *real* model
+    ///     B is selected we must NOT claim "Starting B" and suppress B's
+    ///     Start — we cannot prove the placeholder start is B's, so resolve
+    ///     B's own state instead. (#1505; codex r2.)
     static func serveStateSpeaksForSelection(serving: String, selected: String) -> Bool {
-        guard let servingName = displayable(serving) else { return true }
-        guard let selectedName = displayable(selected) else { return true }
-        return servingName == selectedName
+        switch (displayable(serving), displayable(selected)) {
+        case (.some(let servingName), .some(let selectedName)):
+            return servingName == selectedName
+        case (.some, .none):
+            return true
+        case (.none, .none):
+            return true
+        case (.none, .some):
+            return false
+        }
     }
 
     /// Strict rule for the Send-enabling ``.ready`` state: it may describe

--- a/apps/rapid-mac/Sources/Rapid/UI/ModelReadiness.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ModelReadiness.swift
@@ -1,0 +1,560 @@
+import Foundation
+
+/// The single authoritative answer to two questions the app was
+/// previously answering in four different places, inconsistently:
+///
+///   1. Can the user send a message right now?
+///   2. If not — what is happening, and what should they do about it?
+///
+/// ## Why this type exists
+///
+/// Before this, readiness was re-derived per surface and the surfaces
+/// disagreed. ``ChatView`` decided the empty-state subtitle from
+/// ``ServerState`` alone; the composer's Send button consulted only
+/// whether the draft was non-empty; ``ConnectToolsView`` rendered *two*
+/// readiness sentences at once with two different verbs ("start a chat"
+/// in the header, "Start a model" in the body); and the model picker
+/// showed a cache glyph that said nothing about whether anything was
+/// running. A user could see "Choose a model", a bright enabled Send
+/// button, and — on pressing it — a transcript row reading
+/// "Couldn't start ." with an empty model name.
+///
+/// ``ModelReadiness`` collapses all of that into one value derived once
+/// per render from one set of inputs. Every surface that talks about
+/// readiness reads its copy off this type, so they cannot drift.
+///
+/// ## The lifecycle it models
+///
+///     choose  →  download (if needed)  →  start  →  ready  →  send
+///
+/// The cases below are exactly the user-visible steps of that sequence,
+/// plus the two ways out of it (``failed``, ``engineMissing``). Note
+/// that ``needsDownload`` and ``needsStart`` are distinct: "chosen but
+/// not on disk" and "on disk but not running" are different situations
+/// with different costs (minutes vs seconds) and different copy, and
+/// conflating them is most of why users could not tell choosing from
+/// downloading from starting.
+///
+/// ## Sending is gated on ``ready``
+///
+/// ``sendAllowed`` is true only in ``ready``. This replaces the previous
+/// implicit contract where pressing Send on a cold model silently
+/// triggered a multi-gigabyte download behind an indeterminate spinner.
+/// The trade is deliberate: one extra click (the banner's Start action)
+/// buys the user a visible, cancellable, explicable startup. The draft
+/// is never consumed by a gated send — see ``ChatView.send``.
+///
+/// Pure and free of SwiftUI so the whole truth table is unit-testable
+/// without standing up a view host or a live subprocess.
+enum ModelReadiness: Equatable {
+    /// The engine binary is missing — setup never finished. Terminal
+    /// until the user reinstalls; ``ContentView`` owns this screen.
+    case engineMissing
+    /// No model chosen yet (empty alias, or an internal placeholder
+    /// that ``ModelDisplayName`` refuses to treat as a name).
+    case noModel
+    /// A real alias is chosen but its weights are not on disk.
+    case needsDownload(alias: String, sizeText: String?)
+    /// A real alias is chosen and cached, but nothing is serving it.
+    case needsStart(alias: String)
+    /// Weights are being pulled. ``detail`` carries bytes/speed/ETA when
+    /// the byte monitor has a signal; ``fraction`` drives a determinate bar.
+    case downloading(alias: String, detail: String?, fraction: Double?)
+    /// Weights are on disk and the child is loading them into Metal.
+    case starting(alias: String, detail: String?)
+    /// Serving. The only state in which ``sendAllowed`` is true.
+    case ready(alias: String)
+    /// The last start or turn failed. ``action`` is the recovery step.
+    case failed(alias: String?, message: String, action: Action?)
+
+    // MARK: - Recovery / next-step actions
+
+    /// The one concrete thing the user can do from a given state.
+    ///
+    /// ``chooseModel`` deliberately carries no button at the call site:
+    /// the model picker sits ~40pt away in the composer and is already
+    /// labelled "Choose a model", so rendering a second control with the
+    /// same words would be a duplicate action. The case exists so the
+    /// copy and the VoiceOver announcement can still name the step.
+    enum Action: Equatable {
+        case chooseModel
+        case downloadAndStart(alias: String)
+        case start(alias: String)
+        case retry(alias: String)
+
+        var title: String {
+            switch self {
+            case .chooseModel:      return "Choose a model"
+            case .downloadAndStart: return "Download & start"
+            case .start:            return "Start"
+            case .retry:            return "Retry"
+            }
+        }
+
+        var systemImage: String {
+            switch self {
+            case .chooseModel:      return "square.stack.3d.up"
+            case .downloadAndStart: return "icloud.and.arrow.down"
+            case .start:            return "play.fill"
+            case .retry:            return "arrow.clockwise"
+            }
+        }
+
+        /// True when the action should render as a real button. See the
+        /// ``chooseModel`` note above.
+        var isRenderable: Bool {
+            if case .chooseModel = self { return false }
+            return true
+        }
+
+        /// The alias this action operates on, when it has one.
+        var alias: String? {
+            switch self {
+            case .chooseModel:
+                return nil
+            case .downloadAndStart(let a), .start(let a), .retry(let a):
+                return a
+            }
+        }
+    }
+
+    /// Which status token the surface should paint. Mirrors the four
+    /// roles ``ServerStatusPill`` already maps ``ServerState`` onto, so
+    /// "amber means working, green means ready, red means broken" stays
+    /// one fact about the app rather than a per-view convention.
+    enum StatusRole: Equatable {
+        case idle
+        case working
+        case ready
+        case error
+    }
+
+    // MARK: - Inputs
+
+    /// A pure snapshot of ``DownloadProgress`` taken at render time.
+    /// Passing a snapshot rather than the `@Observable` object keeps
+    /// ``resolve`` callable from tests and off the main actor.
+    struct ProgressSnapshot: Equatable {
+        var activity: DownloadProgress.StartupActivity
+        var subtitle: String?
+        var fraction: Double?
+
+        init(
+            activity: DownloadProgress.StartupActivity,
+            subtitle: String? = nil,
+            fraction: Double? = nil
+        ) {
+            self.activity = activity
+            self.subtitle = subtitle
+            self.fraction = fraction
+        }
+    }
+
+    /// A chat-level failure worth surfacing as a readiness problem.
+    /// Only consulted when the server is not itself in flight — an
+    /// in-progress start always outranks a stale error from the turn
+    /// that triggered it.
+    struct Failure: Equatable {
+        var message: String
+        var kind: FailureDiagnosis.Kind?
+        var alias: String?
+
+        init(message: String, kind: FailureDiagnosis.Kind? = nil, alias: String? = nil) {
+            self.message = message
+            self.kind = kind
+            self.alias = alias
+        }
+    }
+
+    // MARK: - Resolution
+
+    /// Derive readiness from live state.
+    ///
+    /// Precedence, highest first — the ordering is the contract:
+    ///
+    ///   1. ``engineMissing`` — nothing else is meaningful without a binary.
+    ///   2. In-flight start (``downloading`` / ``starting``). Beats a
+    ///      stale failure: the user pressed Retry and it is working.
+    ///   3. ``ready``.
+    ///   4. A crashed child, which carries its own diagnostic message.
+    ///   5. A chat-level failure.
+    ///   6. No model chosen.
+    ///   7. Chosen but not cached → ``needsDownload``.
+    ///   8. Otherwise → ``needsStart``.
+    ///
+    /// - Parameter isAliasCached: `nil` means the catalog has not loaded
+    ///   yet. We resolve to ``needsStart`` in that case rather than
+    ///   ``needsDownload``: claiming a download is required when we do
+    ///   not know is the more misleading of the two errors, and the
+    ///   Start action behaves identically either way (``ServerManager``
+    ///   pulls on demand).
+    static func resolve(
+        serverState: ServerState,
+        alias: String,
+        isAliasCached: Bool?,
+        sizeText: String? = nil,
+        progress: ProgressSnapshot? = nil,
+        failure: Failure? = nil
+    ) -> ModelReadiness {
+        if case .missing = serverState { return .engineMissing }
+
+        if case .starting(let starting) = serverState {
+            // Defensive fallback rather than `?? starting`: if BOTH the
+            // serving alias and the picker's are placeholders, echoing
+            // the raw string would render "Starting Loading" or, worse,
+            // "Starting " with a trailing space. ``ModelDisplayName``
+            // already uses this phrase for the same situation.
+            let name = displayable(starting) ?? displayable(alias) ?? "your local model"
+            let activity = progress?.activity ?? .starting
+            if case .downloading = activity {
+                return .downloading(
+                    alias: name,
+                    detail: progress?.subtitle,
+                    fraction: progress?.fraction
+                )
+            }
+            return .starting(alias: name, detail: startingDetail(for: activity, subtitle: progress?.subtitle))
+        }
+
+        if case .ready(let serving) = serverState, let name = displayable(serving) {
+            return .ready(alias: name)
+        }
+
+        // A failure belongs to the model that FAILED, not to whatever the
+        // picker holds now.
+        //
+        // Both branches below used to fire unconditionally, so once
+        // `kimi-k2.6` crashed the banner was pinned to it: choosing
+        // `bonsai-1.7b-2bit` — or anything else — kept rendering Kimi's
+        // failure, its Retry, and its name in the placeholder and the
+        // tooltip. The chat-level branch was worse than stale, it was
+        // wrong: it read `failure.alias ?? alias`, so a failure with no
+        // recorded alias got re-attributed to the newly chosen model and
+        // accused it of an error it never had.
+        //
+        // Neither branch mutates ``ServerManager`` or drops the failed
+        // turn from the transcript. The child really did crash and the
+        // user really should still see that message in their history;
+        // what changes is only whether the failure is still THIS
+        // selection's problem.
+        let selected = displayable(alias)
+
+        if case .crashed(let crashed, let message) = serverState {
+            let name = displayable(crashed)
+            if failureApplies(failedAlias: name, selectedAlias: selected) {
+                return .failed(
+                    alias: name,
+                    message: crashMessage(raw: message, alias: name),
+                    action: name.map { ModelReadiness.Action.retry(alias: $0) }
+                )
+            }
+        }
+
+        if let failure {
+            let name = displayable(failure.alias)
+            if failureApplies(failedAlias: name, selectedAlias: selected) {
+                return .failed(
+                    alias: name,
+                    message: failureMessage(failure),
+                    action: name.map { ModelReadiness.Action.retry(alias: $0) }
+                )
+            }
+        }
+
+        guard let name = selected else { return .noModel }
+
+        if isAliasCached == false {
+            return .needsDownload(alias: name, sizeText: normalizedSize(sizeText))
+        }
+        return .needsStart(alias: name)
+    }
+
+    // MARK: - Derived presentation
+
+    /// True only when a message can actually be sent right now.
+    var sendAllowed: Bool {
+        if case .ready = self { return true }
+        return false
+    }
+
+    var isReady: Bool { sendAllowed }
+
+    /// True when the state is a fault the user has to act on, as opposed
+    /// to a step they have not taken yet or work already in flight.
+    var isFailure: Bool {
+        switch self {
+        case .failed, .engineMissing: return true
+        default:                      return false
+        }
+    }
+
+    var statusRole: StatusRole {
+        switch self {
+        case .engineMissing, .failed:      return .error
+        case .noModel, .needsDownload,
+             .needsStart:                  return .idle
+        case .downloading, .starting:      return .working
+        case .ready:                       return .ready
+        }
+    }
+
+    /// True while work is in flight, so a status dot knows to pulse.
+    var isWorking: Bool {
+        switch self {
+        case .downloading, .starting: return true
+        default:                      return false
+        }
+    }
+
+    /// The alias this state is about, when it has one.
+    var alias: String? {
+        switch self {
+        case .engineMissing, .noModel:
+            return nil
+        case .needsDownload(let a, _), .needsStart(let a),
+             .downloading(let a, _, _), .starting(let a, _), .ready(let a):
+            return a
+        case .failed(let a, _, _):
+            return a
+        }
+    }
+
+    /// Determinate progress, when a fraction is genuinely known.
+    var progressFraction: Double? {
+        if case .downloading(_, _, let fraction) = self { return fraction }
+        return nil
+    }
+
+    var action: Action? {
+        switch self {
+        case .engineMissing:                    return nil
+        case .noModel:                          return .chooseModel
+        case .needsDownload(let a, _):          return .downloadAndStart(alias: a)
+        case .needsStart(let a):                return .start(alias: a)
+        case .downloading, .starting, .ready:   return nil
+        case .failed(_, _, let action):         return action
+        }
+    }
+
+    // MARK: - Copy
+    //
+    // One vocabulary, used by every surface (item 4 of the Phase 1
+    // brief): you CHOOSE a model, DOWNLOAD it if needed, START it, and
+    // then it is READY. No surface may invent a fifth verb — the old
+    // "start a chat to generate the key" in Connect Tools is exactly the
+    // drift this section exists to prevent.
+
+    /// Short status line — the bold half of the readiness banner.
+    var headline: String {
+        switch self {
+        case .engineMissing:
+            return "Setup didn't finish"
+        case .noModel:
+            return "No model chosen"
+        case .needsDownload(let a, _):
+            return "\(a) isn't downloaded yet"
+        case .needsStart(let a):
+            return "\(a) isn't running"
+        case .downloading(let a, _, _):
+            return "Downloading \(a)"
+        case .starting(let a, _):
+            return "Starting \(a)"
+        case .ready(let a):
+            return "Ready — \(a)"
+        case .failed(let a, _, _):
+            return a.map { "Couldn't start \($0)" } ?? "Something went wrong"
+        }
+    }
+
+    /// The explanation under the headline. This is the "clearly explain
+    /// why sending is unavailable" half of the contract.
+    var detail: String? {
+        switch self {
+        case .engineMissing:
+            return "Rapid-MLX can't find its engine. Reopen the app to run setup again."
+        case .noModel:
+            // Points at the picker rather than duplicating it as a button.
+            return "Choose a model in the box below to get started."
+        case .needsDownload(_, let sizeText):
+            if let sizeText {
+                return "It downloads once (\(sizeText)), then starts in seconds."
+            }
+            return "It downloads once, then starts in seconds."
+        case .needsStart:
+            return "It's already downloaded — starting takes a few seconds."
+        case .downloading(_, let detail, _):
+            return detail ?? "Starting the download…"
+        case .starting(_, let detail):
+            return detail ?? "Loading the model into memory…"
+        case .ready:
+            return nil
+        case .failed(_, let message, _):
+            return message
+        }
+    }
+
+    /// Placeholder for the compose field. Terse — it names the blocking
+    /// step rather than repeating the banner's full sentence, so the two
+    /// are complementary instead of redundant.
+    var composerPlaceholder: String {
+        switch self {
+        case .engineMissing:            return "Setup didn't finish"
+        case .noModel:                  return "Choose a model first"
+        case .needsDownload(let a, _):  return "Download \(a) first"
+        case .needsStart(let a):        return "Start \(a) first"
+        case .downloading(let a, _, _): return "Downloading \(a)…"
+        case .starting(let a, _):       return "Starting \(a)…"
+        case .ready:                    return "Send a message…"
+        case .failed:                   return "Retry to continue"
+        }
+    }
+
+    /// Send-button tooltip. Doubles as the VoiceOver announcement when a
+    /// gated send is attempted, so both channels say the same thing.
+    var sendTooltip: String {
+        switch self {
+        case .engineMissing:
+            return "Rapid-MLX can't find its engine yet."
+        case .noModel:
+            return "Choose a model before sending."
+        case .needsDownload(let a, _):
+            return "Download \(a) before sending."
+        case .needsStart(let a):
+            return "Start \(a) before sending."
+        case .downloading(let a, _, _):
+            return "\(a) is still downloading."
+        case .starting(let a, _):
+            return "\(a) is still starting."
+        case .ready:
+            return "Send"
+        case .failed(let a, _, _):
+            return a.map { "\($0) isn't running — retry to continue." }
+                ?? "Not ready to send yet."
+        }
+    }
+
+    /// The line under "Ask anything" on the chat hero. Preserves the two
+    /// strings the approved empty state already shipped ("Choose a model
+    /// to start", "Chatting with <alias>") and extends the same voice to
+    /// the states that previously had none.
+    var emptyStateSubtitle: String {
+        switch self {
+        case .engineMissing:
+            return "Setup didn't finish"
+        case .noModel:
+            return "Choose a model to start"
+        case .needsDownload(let a, _):
+            return "Download \(a) to start"
+        case .needsStart(let a):
+            return "Start \(a) to begin"
+        case .downloading:
+            return "Downloading your local model…"
+        case .starting:
+            return "Preparing your local model…"
+        case .ready(let a):
+            return "Chatting with \(a)"
+        case .failed(let a, _, _):
+            return a.map { "Couldn't start \($0)" } ?? "Something went wrong"
+        }
+    }
+
+    /// The quieter third line on the hero. Nil whenever the subtitle
+    /// already says everything — an empty state should not stack three
+    /// sentences that mean the same thing.
+    var emptyStateHint: String? {
+        switch self {
+        case .needsDownload(_, let sizeText):
+            guard let sizeText else { return nil }
+            return "First download is about \(sizeText)."
+        case .downloading(_, let detail, _):
+            return detail
+        case .failed(_, let message, _):
+            return message
+        default:
+            return nil
+        }
+    }
+
+    /// Composed VoiceOver label for the readiness banner. Comma-joined
+    /// tokens are how AppKit consumes a composed label.
+    var accessibilityLabel: String {
+        var parts = [headline]
+        if let detail { parts.append(detail) }
+        return parts.joined(separator: ", ")
+    }
+
+    /// Is a recorded failure still the CURRENT selection's problem?
+    ///
+    /// Three cases, and the asymmetry between the last two is the point:
+    ///
+    ///   * Nothing chosen — show the failure. It is the most useful thing
+    ///     on screen, and there is no other model to describe instead.
+    ///   * A model is chosen and the failure names a model — show it only
+    ///     when they are the same model.
+    ///   * A model is chosen and the failure names nothing — suppress it.
+    ///     We cannot prove the failure is about this model, and blaming
+    ///     the user's fresh pick for an unattributable error is the worse
+    ///     of the two mistakes. The selection's own state is shown
+    ///     instead, which is always true.
+    ///
+    /// ``static`` so the rule can be pinned directly by tests rather than
+    /// only through the eight-case resolve matrix.
+    static func failureApplies(failedAlias: String?, selectedAlias: String?) -> Bool {
+        guard let selectedAlias else { return true }
+        guard let failedAlias else { return false }
+        return failedAlias == selectedAlias
+    }
+
+    // MARK: - Pure helpers
+
+    /// A name we are willing to show a user, or `nil`. Routed through
+    /// ``ModelDisplayName`` so an internal placeholder ("Loading",
+    /// "Starting", "") can never be interpolated into copy as if it
+    /// were a model — the defect behind "Couldn't start .".
+    private static func displayable(_ alias: String?) -> String? {
+        guard let alias else { return nil }
+        return ModelDisplayName.configValue(alias: alias)
+    }
+
+    /// Treat an empty size string (``ModelSizing`` has no estimate for
+    /// this alias) as absent rather than rendering "(  )".
+    private static func normalizedSize(_ sizeText: String?) -> String? {
+        guard let sizeText, !sizeText.trimmingCharacters(in: .whitespaces).isEmpty else {
+            return nil
+        }
+        return sizeText
+    }
+
+    /// Copy for the ``starting`` detail line, keyed off the same
+    /// ``StartupActivity`` the picker's own progress subtitle uses so
+    /// the two can never claim different phases.
+    private static func startingDetail(
+        for activity: DownloadProgress.StartupActivity,
+        subtitle: String?
+    ) -> String? {
+        switch activity {
+        case .warmingUp:  return "Warming up…"
+        case .loading:    return subtitle ?? "Loading the model into memory…"
+        case .starting:   return subtitle ?? "Starting the model…"
+        case .downloading: return subtitle
+        }
+    }
+
+    /// A crashed child's raw message is engine output. Prefer the
+    /// classified sentence; fall back to the raw text only when it is
+    /// short enough to already read as prose.
+    private static func crashMessage(raw: String, alias: String?) -> String {
+        let kind = FailureDiagnoser.modelLoadFailureKind(raw: raw)
+        return FailureDiagnoser.diagnosis(for: kind, modelAlias: alias).message
+    }
+
+    /// Prefer the structured diagnosis over the display string. This is
+    /// what puts ``ChatViewModel.lastFailureKind`` to work — it was
+    /// computed and discarded before.
+    private static func failureMessage(_ failure: Failure) -> String {
+        if let kind = failure.kind {
+            return FailureDiagnoser.diagnosis(for: kind, modelAlias: failure.alias).message
+        }
+        return failure.message
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/UI/ModelReadiness.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ModelReadiness.swift
@@ -198,7 +198,16 @@ enum ModelReadiness: Equatable {
     ) -> ModelReadiness {
         if case .missing = serverState { return .engineMissing }
 
-        if case .starting(let starting) = serverState {
+        // A live serve-state describes the SERVING model. It may speak for
+        // the current pick only under the rules below — otherwise a user who
+        // selects B while A is still serving would see B's surface driven by
+        // A. `.starting` uses the permissive rule (it never enables Send, so
+        // the only harm is a name, and at launch the picker breadcrumb
+        // legitimately lags the auto-started model); `.ready` uses the strict
+        // rule because it is the one Send-enabling state and must never light
+        // up against a model the dispatch path isn't holding. (#1505 follow-up.)
+        if case .starting(let starting) = serverState,
+           serveStateSpeaksForSelection(serving: starting, selected: alias) {
             // Defensive fallback rather than `?? starting`: if BOTH the
             // serving alias and the picker's are placeholders, echoing
             // the raw string would render "Starting Loading" or, worse,
@@ -216,7 +225,9 @@ enum ModelReadiness: Equatable {
             return .starting(alias: name, detail: startingDetail(for: activity, subtitle: progress?.subtitle))
         }
 
-        if case .ready(let serving) = serverState, let name = displayable(serving) {
+        if case .ready(let serving) = serverState,
+           readyDescribesSelection(serving: serving, selected: alias),
+           let name = displayable(serving) {
             return .ready(alias: name)
         }
 
@@ -503,6 +514,44 @@ enum ModelReadiness: Equatable {
         guard let selectedAlias else { return true }
         guard let failedAlias else { return false }
         return failedAlias == selectedAlias
+    }
+
+    /// Permissive rule for a NON-Send-enabling serve-state (``.starting``):
+    /// let it describe the current pick UNLESS a *different real model* is
+    /// selected. A placeholder serving name (an engine "Loading" mid-start)
+    /// or a not-yet-synced selection (the first frame at launch, before the
+    /// picker breadcrumb catches up to an auto-started model) both fall
+    /// through to `true` so the in-flight start stays visible; only a
+    /// deliberate pick of another real model suppresses it. (#1505.)
+    static func serveStateSpeaksForSelection(serving: String, selected: String) -> Bool {
+        guard let servingName = displayable(serving) else { return true }
+        guard let selectedName = displayable(selected) else { return true }
+        return servingName == selectedName
+    }
+
+    /// Strict rule for the Send-enabling ``.ready`` state: it may describe
+    /// the selection ONLY when a real serving model equals a real selected
+    /// model. If a different model is serving, or nothing is really selected
+    /// yet, ``.ready`` must NOT win — resolving the selection's own state
+    /// keeps Send gated instead of enabling it against an alias the dispatch
+    /// path (``ChatView.send(_:alias:)``) isn't holding. (#1505.)
+    static func readyDescribesSelection(serving: String, selected: String) -> Bool {
+        guard let servingName = displayable(serving),
+              let selectedName = displayable(selected) else { return false }
+        return servingName == selectedName
+    }
+
+    /// Whether a turn-level error attributed to ``failureAlias`` should
+    /// still show in the composer once the currently-selected model is
+    /// ready. An unattributed error (a generic 500 with no alias recorded)
+    /// always shows; an attributed one shows only for the model it came
+    /// from — so switching to a healthy model does not inherit the previous
+    /// model's error banner. Distinct from ``failureApplies`` (which
+    /// suppresses an unattributed *readiness* failure): a turn error with no
+    /// alias is about the turn the user just took, so it is shown. (#1505.)
+    static func turnErrorApplies(failureAlias: String?, selectedAlias: String?) -> Bool {
+        guard let failureAlias else { return true }
+        return failureAlias == selectedAlias
     }
 
     // MARK: - Pure helpers

--- a/apps/rapid-mac/Sources/Rapid/UI/ReadinessBanner.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ReadinessBanner.swift
@@ -1,0 +1,136 @@
+import SwiftUI
+
+/// The one rendering of ``ModelReadiness``.
+///
+/// Sits directly above the compose field and answers, in one row: what
+/// state the model is in, why sending is unavailable, and the single
+/// next thing to do about it. The chat hero reads its copy off the same
+/// ``ModelReadiness`` value (``emptyStateSubtitle`` / ``emptyStateHint``),
+/// so the two surfaces are two renderings of one fact rather than two
+/// independently-maintained descriptions.
+///
+/// Visual system: this is deliberately built from parts that already
+/// shipped — ``PulsingStateDot``, the ``RapidTheme`` status tokens, the
+/// ``InlineNotice`` tint pairing, and ``RapidPrimaryButtonStyle``. It
+/// introduces no new shape, colour, or type size. Amber remains the
+/// working/active hue; red is reserved for genuine faults; steel blue
+/// does not appear.
+///
+/// The action button takes the PRIMARY tier rather than the secondary
+/// one the empty state uses. That is not an escalation for its own sake:
+/// while the model is not ready the composer's Send button is disabled,
+/// so Start genuinely is the one high-emphasis action on this surface.
+/// It steps back down the moment Send becomes live, because the banner
+/// hides entirely in ``ModelReadiness/ready``.
+struct ReadinessBanner: View {
+    let readiness: ModelReadiness
+    /// Bumped by the composer each time a send is attempted while gated.
+    /// Drives a brief emphasis so a blocked Return is never silent.
+    var attentionToken: Int = 0
+    var onAction: (ModelReadiness.Action) -> Void
+
+    // Reduce Motion is handled inside the pieces this composes:
+    // ``PulsingStateDot`` suppresses its own breathing loop, and
+    // ``rapidAnimation`` resolves to an instant change. The emphasis
+    // below therefore still *happens* under Reduce Motion — it just
+    // snaps rather than fading, which is the correct behaviour for a
+    // feedback cue the user is waiting on.
+    @State private var attentionActive = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: RapidTheme.Space.sm) {
+            HStack(alignment: .center, spacing: RapidTheme.Space.sm) {
+                PulsingStateDot(color: tint, isAnimating: readiness.isWorking)
+                    .accessibilityHidden(true)
+
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(readiness.headline)
+                        .font(RapidFont.bodyEmphasis)
+                        .foregroundStyle(.primary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                    if let detail = readiness.detail {
+                        Text(detail)
+                            .font(RapidFont.caption)
+                            .foregroundStyle(.secondary)
+                            // Byte counts and ETAs update every 500 ms;
+                            // monospaced digits stop the line jittering
+                            // its own width as they tick.
+                            .monospacedDigit()
+                            .lineLimit(2)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+                if let action = readiness.action, action.isRenderable {
+                    Button {
+                        onAction(action)
+                    } label: {
+                        Label(action.title, systemImage: action.systemImage)
+                    }
+                    .buttonStyle(RapidPrimaryButtonStyle(
+                        height: RapidTheme.ControlHeight.small
+                    ))
+                    .fixedSize()
+                    .accessibilityIdentifier("Readiness.Action")
+                }
+            }
+
+            // Determinate only when a real fraction exists. An
+            // indeterminate bar here would compete with the pulsing dot
+            // for the same "something is happening" job while implying a
+            // precision we do not have.
+            if let fraction = readiness.progressFraction {
+                ProgressView(value: min(max(fraction, 0), 1), total: 1)
+                    .progressViewStyle(.linear)
+                    .tint(RapidTheme.brandPrimary)
+                    .accessibilityHidden(true)
+            }
+        }
+        .padding(.horizontal, RapidTheme.Space.md)
+        .padding(.vertical, RapidTheme.Space.sm)
+        .background(
+            RoundedRectangle(cornerRadius: RapidTheme.Radius.button, style: .continuous)
+                .fill(background)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: RapidTheme.Radius.button, style: .continuous)
+                .strokeBorder(
+                    tint.opacity(attentionActive ? 0.85 : 0.22),
+                    lineWidth: attentionActive ? 1.5 : 1
+                )
+        )
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel(readiness.accessibilityLabel)
+        .rapidAnimation(RapidMotion.quick, value: attentionActive)
+        .task(id: attentionToken) {
+            // Token 0 is the initial value — only a real bump (a blocked
+            // send) should flash, otherwise the banner would emphasise
+            // itself the moment it appears.
+            guard attentionToken > 0 else { return }
+            attentionActive = true
+            try? await Task.sleep(nanoseconds: 1_400_000_000)
+            guard !Task.isCancelled else { return }
+            attentionActive = false
+        }
+    }
+
+    /// The four status tokens, keyed off the same role vocabulary
+    /// ``ServerStatusPill`` uses for ``ServerState``.
+    private var tint: Color {
+        switch readiness.statusRole {
+        case .idle:    return RapidTheme.statusIdle
+        case .working: return RapidTheme.statusWorking
+        case .ready:   return RapidTheme.statusReady
+        case .error:   return RapidTheme.statusError
+        }
+    }
+
+    /// Subtle tint only — the same pairing ``InlineNotice`` uses, so a
+    /// readiness notice and an error notice sit on the same visual
+    /// footing when they alternate in the same slot.
+    private var background: Color {
+        readiness.isFailure ? RapidTheme.statusErrorTint : RapidTheme.brandPrimaryTint
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/UI/SidebarView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SidebarView.swift
@@ -260,6 +260,12 @@ private struct SidebarRow<Content: View>: View {
 struct LaunchView: View {
     @Bindable var server: ServerManager
     let alias: String
+    /// The window's shared readiness value. Optional so the dev snapshot
+    /// harness can render the page standalone; when supplied, the page
+    /// describes the model lifecycle in exactly the same words the chat
+    /// composer does, and offers the same next step.
+    var readiness: ModelReadiness? = nil
+    var onReadinessAction: (ModelReadiness.Action) -> Void = { _ in }
 
     var body: some View {
         ConnectToolsView(
@@ -272,7 +278,9 @@ struct LaunchView: View {
             // no-op button). A dedicated page-mode header lands with the
             // #1405 Launch redesign.
             onClose: {},
-            showsCloseButton: false
+            showsCloseButton: false,
+            readiness: readiness,
+            onReadinessAction: onReadinessAction
         )
     }
 }

--- a/apps/rapid-mac/Tests/RapidUXTests/ModelReadinessTests.swift
+++ b/apps/rapid-mac/Tests/RapidUXTests/ModelReadinessTests.swift
@@ -813,6 +813,17 @@ final class ModelReadinessTests: XCTestCase {
             resolve(.starting(alias: alias), alias: other, cached: true),
             .needsStart(alias: other)
         )
+        // codex r2: a PLACEHOLDER start (engine reports no alias) while a
+        // real model B is selected must not claim "Starting B" and swallow
+        // B's Start — we can't prove the start is B's, so resolve B.
+        XCTAssertEqual(
+            resolve(.starting(alias: ""), alias: other, cached: true),
+            .needsStart(alias: other)
+        )
+        // …but a placeholder start with NOTHING selected stays visible.
+        if case .starting = resolve(.starting(alias: ""), alias: "") {} else {
+            XCTFail("a placeholder start with no selection must still show as starting")
+        }
     }
 
     /// A turn-level error is shown in the ready composer only when it

--- a/apps/rapid-mac/Tests/RapidUXTests/ModelReadinessTests.swift
+++ b/apps/rapid-mac/Tests/RapidUXTests/ModelReadinessTests.swift
@@ -1,0 +1,781 @@
+import XCTest
+
+@testable import Rapid
+
+/// Contract tests for ``ModelReadiness`` — the single source of truth for
+/// "can the user send right now, and if not, what should they do?".
+///
+/// XCTest rather than swift-testing deliberately: the excluded legacy
+/// suite under `Tests/RapidTests` uses `import Testing`, and the package
+/// manifest records that the module does not resolve from the command
+/// line in this toolchain. XCTest always does, and a test that cannot be
+/// run is not a test.
+///
+/// Everything here is a pure value transform, so no SwiftUI host, no
+/// subprocess, and no live ``ServerManager`` is needed.
+final class ModelReadinessTests: XCTestCase {
+
+    private let alias = "qwen3.5-9b-4bit"
+
+    // MARK: - Helpers
+
+    private func resolve(
+        _ state: ServerState,
+        alias: String? = nil,
+        cached: Bool? = true,
+        sizeText: String? = nil,
+        progress: ModelReadiness.ProgressSnapshot? = nil,
+        failure: ModelReadiness.Failure? = nil
+    ) -> ModelReadiness {
+        ModelReadiness.resolve(
+            serverState: state,
+            alias: alias ?? self.alias,
+            isAliasCached: cached,
+            sizeText: sizeText,
+            progress: progress,
+            failure: failure
+        )
+    }
+
+    /// Every case, for sweeps that must hold universally.
+    private var allStates: [ModelReadiness] {
+        [
+            .engineMissing,
+            .noModel,
+            .needsDownload(alias: alias, sizeText: "5.0 GB"),
+            .needsDownload(alias: alias, sizeText: nil),
+            .needsStart(alias: alias),
+            .downloading(alias: alias, detail: "1.2 / 5.0 GB · 24%", fraction: 0.24),
+            .downloading(alias: alias, detail: nil, fraction: nil),
+            .starting(alias: alias, detail: "Warming up…"),
+            .ready(alias: alias),
+            .failed(alias: alias, message: "This model couldn't load.", action: .retry(alias: alias)),
+            .failed(alias: nil, message: "Something went wrong.", action: nil),
+        ]
+    }
+
+    // MARK: - The send gate
+
+    /// The core Phase 1 contract: sending is possible in exactly one
+    /// state. Everything else keeps the field live and the action dark.
+    func testSendAllowedOnlyWhenReady() {
+        for state in allStates {
+            if case .ready = state {
+                XCTAssertTrue(state.sendAllowed, "ready must allow send")
+            } else {
+                XCTAssertFalse(
+                    state.sendAllowed,
+                    "\(state) must not allow send"
+                )
+            }
+        }
+    }
+
+    /// A gated state must always be able to say WHY, in both the mouse
+    /// channel (tooltip) and the copy channel (banner headline). An
+    /// empty explanation is the silent-gate defect this phase removes.
+    func testEveryGatedStateExplainsItself() {
+        for state in allStates where !state.sendAllowed {
+            XCTAssertFalse(
+                state.sendTooltip.trimmingCharacters(in: .whitespaces).isEmpty,
+                "\(state) has no send tooltip"
+            )
+            XCTAssertFalse(
+                state.headline.trimmingCharacters(in: .whitespaces).isEmpty,
+                "\(state) has no headline"
+            )
+            XCTAssertFalse(
+                state.composerPlaceholder.trimmingCharacters(in: .whitespaces).isEmpty,
+                "\(state) has no composer placeholder"
+            )
+        }
+    }
+
+    /// Ready is the one state that must NOT nag: no banner detail, and a
+    /// plain "Send" tooltip rather than an explanation of a problem that
+    /// no longer exists.
+    func testReadyIsQuiet() {
+        let ready = ModelReadiness.ready(alias: alias)
+        XCTAssertNil(ready.detail)
+        XCTAssertNil(ready.action)
+        XCTAssertNil(ready.emptyStateHint)
+        XCTAssertEqual(ready.sendTooltip, "Send")
+        XCTAssertEqual(ready.composerPlaceholder, "Send a message…")
+    }
+
+    // MARK: - Placeholder-alias safety (the "Couldn't start ." defect)
+
+    /// The regression that motivated most of this: an unresolved alias
+    /// was interpolated into failure copy, producing "Couldn't start ."
+    /// with an empty model name. No surface may render a placeholder as
+    /// if it were a model.
+    func testUnresolvedAliasNeverBecomesAModelName() {
+        // "" plus every internal placeholder ``ModelDisplayName`` knows.
+        let placeholders = ["", "   ", "loading", "Loading", "STARTING",
+                            "warming up", "downloading", "unknown", "none"]
+        for placeholder in placeholders {
+            let state = resolve(.idle, alias: placeholder, cached: false)
+            XCTAssertEqual(
+                state, .noModel,
+                "\(placeholder.debugDescription) must resolve to .noModel"
+            )
+            XCTAssertNil(state.alias)
+            // And the copy must not contain the raw placeholder.
+            let trimmed = placeholder.trimmingCharacters(in: .whitespaces)
+            if !trimmed.isEmpty {
+                XCTAssertFalse(
+                    state.headline.lowercased().contains(trimmed.lowercased()),
+                    "headline leaked the placeholder \(placeholder.debugDescription)"
+                )
+            }
+        }
+    }
+
+    /// A `.ready` state carrying a placeholder alias is not ready — it
+    /// falls back to "choose a model" rather than claiming to be
+    /// chatting with nothing.
+    func testReadyWithPlaceholderAliasIsNotReady() {
+        let state = resolve(.ready(alias: ""), alias: "")
+        XCTAssertEqual(state, .noModel)
+        XCTAssertFalse(state.sendAllowed)
+    }
+
+    /// No user-facing string may ever contain an empty-name artefact
+    /// like a double space, a dangling "start ." or a trailing " —".
+    func testNoCopyContainsEmptyNameArtefacts() {
+        for state in allStates {
+            let strings = [
+                state.headline,
+                state.detail ?? "",
+                state.composerPlaceholder,
+                state.sendTooltip,
+                state.emptyStateSubtitle,
+                state.emptyStateHint ?? "",
+                state.accessibilityLabel,
+            ]
+            for string in strings where !string.isEmpty {
+                XCTAssertFalse(string.contains("  "), "double space in: \(string)")
+                XCTAssertFalse(string.contains(" ."), "dangling period in: \(string)")
+                XCTAssertFalse(string.hasSuffix(" —"), "dangling dash in: \(string)")
+                XCTAssertFalse(string.contains("()"), "empty parens in: \(string)")
+            }
+        }
+    }
+
+    // MARK: - Resolution precedence
+
+    func testEngineMissingWinsOverEverything() {
+        let state = resolve(
+            .missing,
+            cached: false,
+            failure: .init(message: "boom", kind: .modelLoadFailed)
+        )
+        XCTAssertEqual(state, .engineMissing)
+        XCTAssertFalse(state.sendAllowed)
+    }
+
+    /// An in-flight start outranks a stale failure. Otherwise pressing
+    /// Retry would leave the banner reading "Couldn't start X" while X
+    /// is visibly starting.
+    func testInFlightStartBeatsStaleFailure() {
+        let state = resolve(
+            .starting(alias: alias),
+            failure: .init(message: "old failure", kind: .modelLoadFailed)
+        )
+        guard case .starting(let name, _) = state else {
+            return XCTFail("expected .starting, got \(state)")
+        }
+        XCTAssertEqual(name, alias)
+    }
+
+    /// A crash outranks a chat-level failure and supplies its own
+    /// classified message plus a retry aimed at the crashed alias.
+    func testCrashedResolvesToFailedWithRetry() {
+        let state = resolve(
+            .crashed(alias: alias, message: "RuntimeError: out of memory"),
+            failure: .init(message: "unrelated", kind: .requestFailed)
+        )
+        guard case .failed(let name, let message, let action) = state else {
+            return XCTFail("expected .failed, got \(state)")
+        }
+        XCTAssertEqual(name, alias)
+        XCTAssertEqual(action, .retry(alias: alias))
+        // Classified, not raw engine output.
+        XCTAssertFalse(message.contains("RuntimeError"))
+        XCTAssertEqual(
+            message,
+            FailureDiagnoser.diagnosis(for: .modelOutOfMemory, modelAlias: alias).message
+        )
+    }
+
+    /// ``ChatViewModel.lastFailureKind`` was previously computed and
+    /// discarded. It must now choose the message the user reads.
+    func testChatFailureUsesStructuredDiagnosisOverRawMessage() {
+        let state = resolve(
+            .idle,
+            failure: .init(
+                message: "raw transport gibberish",
+                kind: .engineNotRunning,
+                alias: alias
+            )
+        )
+        guard case .failed(_, let message, let action) = state else {
+            return XCTFail("expected .failed, got \(state)")
+        }
+        XCTAssertEqual(
+            message,
+            FailureDiagnoser.diagnosis(for: .engineNotRunning, modelAlias: alias).message
+        )
+        XCTAssertEqual(action, .retry(alias: alias))
+    }
+
+    /// With no structured kind, the raw message is the fallback rather
+    /// than a generic sentence that loses information.
+    func testChatFailureWithoutKindKeepsItsMessage() {
+        let state = resolve(.idle, failure: .init(message: "Disk is full.", alias: alias))
+        guard case .failed(_, let message, _) = state else {
+            return XCTFail("expected .failed, got \(state)")
+        }
+        XCTAssertEqual(message, "Disk is full.")
+    }
+
+    // MARK: - Failure attribution (a failure belongs to ONE model)
+
+    /// Regression: `kimi-k2.6` fails to start, the user picks
+    /// `bonsai-1.7b-2bit`, and the banner keeps showing Kimi's failure —
+    /// including its Retry, its name in the placeholder, and its name in
+    /// the Send tooltip. Every further pick stayed on Kimi too, because
+    /// ``.crashed`` short-circuited before the selection was consulted.
+    private let crashed = "kimi-k2.6"
+
+    func testCrashedAliasMatchingSelectionStillFails() {
+        let state = resolve(
+            .crashed(alias: crashed, message: "load failed"),
+            alias: crashed,
+            cached: true
+        )
+        guard case .failed(let name, _, let action) = state else {
+            return XCTFail("expected .failed, got \(state)")
+        }
+        XCTAssertEqual(name, crashed)
+        XCTAssertEqual(action, .retry(alias: crashed), "Retry must target the failed model")
+        XCTAssertFalse(state.sendAllowed)
+    }
+
+    /// The fix: a crash on a DIFFERENT model than the one now selected
+    /// must not describe the new selection. Cached → needsStart.
+    func testCrashedAliasDiffersFromSelectionResolvesToNeedsStart() {
+        let state = resolve(
+            .crashed(alias: crashed, message: "load failed"),
+            alias: alias,
+            cached: true
+        )
+        XCTAssertEqual(state, .needsStart(alias: alias))
+        XCTAssertEqual(state.action, .start(alias: alias))
+        assertNoTraceOf(crashed, in: state)
+    }
+
+    /// Same, uncached → needsDownload with the download CTA.
+    func testCrashedAliasDiffersFromSelectionResolvesToNeedsDownload() {
+        let state = resolve(
+            .crashed(alias: crashed, message: "load failed"),
+            alias: alias,
+            cached: false,
+            sizeText: "5.0 GB"
+        )
+        XCTAssertEqual(state, .needsDownload(alias: alias, sizeText: "5.0 GB"))
+        XCTAssertEqual(state.action, .downloadAndStart(alias: alias))
+        assertNoTraceOf(crashed, in: state)
+    }
+
+    /// A stale chat-level failure must not follow the user either — this
+    /// is the second half of the bug. Previously the resolver read
+    /// `failure.alias ?? alias`, so a failure recorded against Kimi (or
+    /// with no alias at all) got re-attributed to the new pick.
+    func testStaleChatFailureDoesNotFollowTheNewSelection() {
+        let state = resolve(
+            .idle,
+            alias: alias,
+            cached: true,
+            failure: .init(message: "Kimi blew up", kind: .modelLoadFailed, alias: crashed)
+        )
+        XCTAssertEqual(state, .needsStart(alias: alias))
+        assertNoTraceOf(crashed, in: state)
+        assertNoTraceOf("blew up", in: state)
+    }
+
+    /// A chat failure that DOES belong to the selection still shows.
+    func testChatFailureMatchingSelectionStillShows() {
+        let state = resolve(
+            .idle,
+            alias: alias,
+            cached: true,
+            failure: .init(message: "x", kind: .modelLoadFailed, alias: alias)
+        )
+        guard case .failed(let name, _, let action) = state else {
+            return XCTFail("expected .failed, got \(state)")
+        }
+        XCTAssertEqual(name, alias)
+        XCTAssertEqual(action, .retry(alias: alias))
+    }
+
+    /// An unattributable failure must not be pinned on the user's fresh
+    /// pick. We show the selection's own (true) state instead.
+    func testUnattributedFailureDoesNotBlameTheSelection() {
+        let state = resolve(
+            .idle,
+            alias: alias,
+            cached: true,
+            failure: .init(message: "something went wrong", kind: nil, alias: nil)
+        )
+        XCTAssertEqual(state, .needsStart(alias: alias))
+    }
+
+    /// With nothing chosen there is no better thing to show, so the
+    /// failure stays visible rather than silently vanishing.
+    func testFailureStaysVisibleWhenNothingIsSelected() {
+        let state = resolve(
+            .crashed(alias: crashed, message: "load failed"),
+            alias: "",
+            cached: nil
+        )
+        guard case .failed(let name, _, _) = state else {
+            return XCTFail("expected .failed, got \(state)")
+        }
+        XCTAssertEqual(name, crashed)
+    }
+
+    /// The reported repro in full: crash, then pick three different
+    /// models in a row. None may fall back to Kimi's failure.
+    func testSuccessiveSelectionsAfterCrashNeverReturnToTheFailedModel() {
+        let picks = [
+            ("bonsai-1.7b-2bit", true),
+            ("qwen3.5-9b-4bit", false),
+            ("gemma-4-12b-4bit", true),
+        ]
+        for (pick, isCached) in picks {
+            let state = resolve(
+                .crashed(alias: crashed, message: "load failed"),
+                alias: pick,
+                cached: isCached,
+                // The stale chat error rides along the whole time.
+                failure: .init(message: "Kimi blew up", kind: .modelLoadFailed, alias: crashed)
+            )
+            XCTAssertEqual(
+                state,
+                isCached
+                    ? .needsStart(alias: pick)
+                    : .needsDownload(alias: pick, sizeText: nil),
+                "selection \(pick) regressed to a stale failure"
+            )
+            XCTAssertEqual(state.action?.alias, pick, "CTA must target \(pick)")
+            assertNoTraceOf(crashed, in: state)
+        }
+    }
+
+    /// Selecting the failed model AGAIN brings its failure back — the
+    /// failure is scoped, not discarded.
+    func testReselectingTheFailedModelRestoresItsFailure() {
+        let away = resolve(
+            .crashed(alias: crashed, message: "load failed"),
+            alias: alias,
+            cached: true
+        )
+        XCTAssertEqual(away, .needsStart(alias: alias))
+
+        let back = resolve(
+            .crashed(alias: crashed, message: "load failed"),
+            alias: crashed,
+            cached: true
+        )
+        guard case .failed(_, _, let action) = back else {
+            return XCTFail("expected .failed on reselect, got \(back)")
+        }
+        XCTAssertEqual(action, .retry(alias: crashed))
+    }
+
+    /// The attribution rule on its own, so a future refactor of
+    /// ``resolve`` cannot quietly change it.
+    func testFailureAppliesRule() {
+        // Nothing selected → always show.
+        XCTAssertTrue(ModelReadiness.failureApplies(failedAlias: "a", selectedAlias: nil))
+        XCTAssertTrue(ModelReadiness.failureApplies(failedAlias: nil, selectedAlias: nil))
+        // Same model → show.
+        XCTAssertTrue(ModelReadiness.failureApplies(failedAlias: "a", selectedAlias: "a"))
+        // Different model → suppress.
+        XCTAssertFalse(ModelReadiness.failureApplies(failedAlias: "a", selectedAlias: "b"))
+        // Unattributable + a real selection → suppress (never blame it).
+        XCTAssertFalse(ModelReadiness.failureApplies(failedAlias: nil, selectedAlias: "b"))
+    }
+
+    /// No user-facing string in ``state`` mentions ``needle``.
+    private func assertNoTraceOf(
+        _ needle: String,
+        in state: ModelReadiness,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let corpus = [
+            state.headline,
+            state.detail ?? "",
+            state.composerPlaceholder,
+            state.sendTooltip,
+            state.emptyStateSubtitle,
+            state.emptyStateHint ?? "",
+            state.accessibilityLabel,
+        ].joined(separator: " ")
+        XCTAssertFalse(
+            corpus.lowercased().contains(needle.lowercased()),
+            "user-facing copy still mentions “\(needle)”: \(corpus)",
+            file: file, line: line
+        )
+    }
+
+    // MARK: - Choose → download → start → ready
+
+    func testNoModelWhenNothingChosen() {
+        XCTAssertEqual(resolve(.idle, alias: "", cached: nil), .noModel)
+        XCTAssertEqual(resolve(.stopped, alias: "", cached: nil), .noModel)
+    }
+
+    func testChosenButUncachedNeedsDownload() {
+        let state = resolve(.idle, cached: false, sizeText: "5.0 GB")
+        XCTAssertEqual(state, .needsDownload(alias: alias, sizeText: "5.0 GB"))
+        XCTAssertEqual(state.action, .downloadAndStart(alias: alias))
+        XCTAssertTrue(state.detail?.contains("5.0 GB") == true)
+    }
+
+    func testChosenAndCachedNeedsStart() {
+        let state = resolve(.idle, cached: true)
+        XCTAssertEqual(state, .needsStart(alias: alias))
+        XCTAssertEqual(state.action, .start(alias: alias))
+    }
+
+    /// An unknown cache state must not claim a download is required. We
+    /// resolve to "start", which is true either way — ``ServerManager``
+    /// pulls on demand — rather than promising a multi-gigabyte wait we
+    /// have no evidence for.
+    func testUnknownCacheStateResolvesToStartNotDownload() {
+        let state = resolve(.idle, cached: nil)
+        XCTAssertEqual(state, .needsStart(alias: alias))
+    }
+
+    /// An empty size string means ``ModelSizing`` had no estimate. It
+    /// must be dropped, not rendered as empty parentheses.
+    func testBlankSizeTextIsDropped() {
+        let state = resolve(.idle, cached: false, sizeText: "   ")
+        XCTAssertEqual(state, .needsDownload(alias: alias, sizeText: nil))
+        XCTAssertEqual(state.detail, "It downloads once, then starts in seconds.")
+    }
+
+    func testDownloadingCarriesProgress() {
+        let state = resolve(
+            .starting(alias: alias),
+            progress: .init(
+                activity: .downloading,
+                subtitle: "1.2 GB / 5.0 GB · 24% · 8.4 MB/s",
+                fraction: 0.24
+            )
+        )
+        XCTAssertEqual(
+            state,
+            .downloading(
+                alias: alias,
+                detail: "1.2 GB / 5.0 GB · 24% · 8.4 MB/s",
+                fraction: 0.24
+            )
+        )
+        XCTAssertEqual(state.progressFraction, 0.24)
+        XCTAssertTrue(state.isWorking)
+        XCTAssertEqual(state.statusRole, .working)
+    }
+
+    /// Loading / warming up are NOT downloading. The word "Downloading"
+    /// may only appear when bytes are provably moving — the invariant
+    /// ``DownloadProgress.startupActivity`` exists to protect.
+    func testLoadingAndWarmingAreStartingNotDownloading() {
+        for activity in [DownloadProgress.StartupActivity.loading, .warmingUp, .starting] {
+            let state = resolve(
+                .starting(alias: alias),
+                progress: .init(activity: activity)
+            )
+            guard case .starting = state else {
+                return XCTFail("\(activity) must resolve to .starting, got \(state)")
+            }
+            XCTAssertNil(state.progressFraction, "\(activity) must not show a determinate bar")
+            XCTAssertFalse(
+                state.headline.lowercased().contains("download"),
+                "\(activity) must not say 'download'"
+            )
+        }
+    }
+
+    /// Only ``downloading`` gets a determinate bar. Everything else
+    /// would be implying precision we do not have.
+    func testOnlyDownloadingHasAProgressFraction() {
+        for state in allStates {
+            if case .downloading(_, _, let fraction) = state {
+                XCTAssertEqual(state.progressFraction, fraction)
+            } else {
+                XCTAssertNil(state.progressFraction, "\(state) must not report progress")
+            }
+        }
+    }
+
+    func testReadyWhenServing() {
+        let state = resolve(.ready(alias: alias))
+        XCTAssertEqual(state, .ready(alias: alias))
+        XCTAssertTrue(state.sendAllowed)
+        XCTAssertEqual(state.statusRole, .ready)
+        XCTAssertFalse(state.isWorking)
+    }
+
+    /// The full happy path, in order, asserting that send unlocks only
+    /// at the final step.
+    func testFullLifecycleSequence() {
+        let steps: [(ServerState, Bool?, ModelReadiness)] = [
+            (.idle, nil, .noModel),
+            (.idle, false, .needsDownload(alias: alias, sizeText: nil)),
+            (.ready(alias: alias), true, .ready(alias: alias)),
+        ]
+        for (serverState, cached, expected) in steps {
+            let aliasForStep: String = {
+                if case .noModel = expected { return "" }
+                return alias
+            }()
+            let state = resolve(serverState, alias: aliasForStep, cached: cached)
+            XCTAssertEqual(state, expected)
+        }
+
+        // The two in-flight steps need a progress snapshot to distinguish.
+        let downloading = resolve(
+            .starting(alias: alias),
+            progress: .init(activity: .downloading, fraction: 0.5)
+        )
+        let starting = resolve(
+            .starting(alias: alias),
+            progress: .init(activity: .loading)
+        )
+        XCTAssertFalse(downloading.sendAllowed)
+        XCTAssertFalse(starting.sendAllowed)
+        XCTAssertTrue(resolve(.ready(alias: alias)).sendAllowed)
+    }
+
+    // MARK: - Status roles
+
+    func testStatusRolesMapToTheFourTokens() {
+        XCTAssertEqual(ModelReadiness.engineMissing.statusRole, .error)
+        XCTAssertEqual(ModelReadiness.noModel.statusRole, .idle)
+        XCTAssertEqual(ModelReadiness.needsStart(alias: alias).statusRole, .idle)
+        XCTAssertEqual(
+            ModelReadiness.needsDownload(alias: alias, sizeText: nil).statusRole, .idle)
+        XCTAssertEqual(
+            ModelReadiness.downloading(alias: alias, detail: nil, fraction: nil).statusRole,
+            .working)
+        XCTAssertEqual(ModelReadiness.starting(alias: alias, detail: nil).statusRole, .working)
+        XCTAssertEqual(ModelReadiness.ready(alias: alias).statusRole, .ready)
+        XCTAssertEqual(
+            ModelReadiness.failed(alias: nil, message: "x", action: nil).statusRole, .error)
+    }
+
+    /// Only genuine faults take the error treatment. "You haven't
+    /// started it yet" is not a fault and must not paint red.
+    func testIsFailureIsReservedForFaults() {
+        XCTAssertTrue(ModelReadiness.engineMissing.isFailure)
+        XCTAssertTrue(ModelReadiness.failed(alias: nil, message: "x", action: nil).isFailure)
+        XCTAssertFalse(ModelReadiness.noModel.isFailure)
+        XCTAssertFalse(ModelReadiness.needsStart(alias: alias).isFailure)
+        XCTAssertFalse(
+            ModelReadiness.needsDownload(alias: alias, sizeText: nil).isFailure)
+        XCTAssertFalse(ModelReadiness.ready(alias: alias).isFailure)
+    }
+
+    // MARK: - Actions
+
+    /// ``chooseModel`` must not render a button: the picker already
+    /// carries those exact words 40pt away, and a second control saying
+    /// the same thing is the duplicate-action defect.
+    func testChooseModelIsNamedButNotRendered() {
+        let state = ModelReadiness.noModel
+        XCTAssertEqual(state.action, .chooseModel)
+        XCTAssertEqual(state.action?.isRenderable, false)
+        XCTAssertEqual(state.action?.title, "Choose a model")
+        XCTAssertNil(state.action?.alias)
+    }
+
+    func testActionableStatesRenderTheirButton() {
+        let renderable: [ModelReadiness] = [
+            .needsDownload(alias: alias, sizeText: nil),
+            .needsStart(alias: alias),
+            .failed(alias: alias, message: "x", action: .retry(alias: alias)),
+        ]
+        for state in renderable {
+            guard let action = state.action else {
+                return XCTFail("\(state) should offer an action")
+            }
+            XCTAssertTrue(action.isRenderable, "\(state) action should render")
+            XCTAssertEqual(action.alias, alias)
+            XCTAssertFalse(action.title.isEmpty)
+            XCTAssertFalse(action.systemImage.isEmpty)
+        }
+    }
+
+    /// In-flight states offer no action — progress is the answer, and a
+    /// button there would either duplicate Stop or do nothing.
+    func testInFlightStatesOfferNoAction() {
+        XCTAssertNil(
+            ModelReadiness.downloading(alias: alias, detail: nil, fraction: nil).action)
+        XCTAssertNil(ModelReadiness.starting(alias: alias, detail: nil).action)
+        XCTAssertNil(ModelReadiness.ready(alias: alias).action)
+    }
+
+    // MARK: - Terminology (one vocabulary across every surface)
+
+    /// choose / download / start / ready — and no synonyms. The old
+    /// Connect Tools header said "start a chat to generate the key"
+    /// while its body said "Start a model"; this pins the vocabulary so
+    /// that cannot come back.
+    func testVocabularyIsConsistent() {
+        let chooseCopy = ModelReadiness.noModel
+        XCTAssertTrue(chooseCopy.headline.contains("chosen"))
+        XCTAssertTrue(chooseCopy.detail?.contains("Choose a model") == true)
+        XCTAssertTrue(chooseCopy.emptyStateSubtitle.hasPrefix("Choose a model"))
+        XCTAssertTrue(chooseCopy.composerPlaceholder.contains("Choose a model"))
+        XCTAssertTrue(chooseCopy.sendTooltip.contains("Choose a model"))
+
+        let downloadCopy = ModelReadiness.needsDownload(alias: alias, sizeText: "5.0 GB")
+        for text in [downloadCopy.composerPlaceholder,
+                     downloadCopy.emptyStateSubtitle,
+                     downloadCopy.sendTooltip] {
+            XCTAssertTrue(text.contains("Download"), "expected 'Download' in: \(text)")
+        }
+
+        let startCopy = ModelReadiness.needsStart(alias: alias)
+        for text in [startCopy.composerPlaceholder,
+                     startCopy.emptyStateSubtitle,
+                     startCopy.sendTooltip] {
+            XCTAssertTrue(text.contains("Start"), "expected 'Start' in: \(text)")
+        }
+
+        // "select" / "pick" / "load" are the near-synonyms that caused
+        // the drift. None may appear in readiness copy.
+        let banned = ["select a model", "pick a model", "load a model", "start a chat"]
+        for state in allStates {
+            let corpus = [
+                state.headline, state.detail ?? "", state.composerPlaceholder,
+                state.sendTooltip, state.emptyStateSubtitle, state.emptyStateHint ?? "",
+            ].joined(separator: " ").lowercased()
+            for phrase in banned {
+                XCTAssertFalse(corpus.contains(phrase), "\(state) uses banned phrase '\(phrase)'")
+            }
+        }
+    }
+
+    /// Every state that is ABOUT a specific model names it in the
+    /// headline, so the user always knows which model the sentence
+    /// refers to.
+    func testHeadlineNamesTheModelWhenThereIsOne() {
+        let named: [ModelReadiness] = [
+            .needsDownload(alias: alias, sizeText: nil),
+            .needsStart(alias: alias),
+            .downloading(alias: alias, detail: nil, fraction: nil),
+            .starting(alias: alias, detail: nil),
+            .ready(alias: alias),
+        ]
+        for state in named {
+            XCTAssertTrue(
+                state.headline.contains(alias),
+                "headline should name the model: \(state.headline)"
+            )
+        }
+    }
+
+    /// The composer placeholder names the model only while it is BLOCKING
+    /// the send — "Download <alias> first" has to say which model you are
+    /// waiting on. Once ready it reverts to the neutral, approved "Send a
+    /// message…": the model's identity is carried by the picker chip and
+    /// the hero at that point, and repeating it in the field would be the
+    /// same fact three times.
+    ///
+    /// The first draft of this suite asserted the alias in EVERY named
+    /// state's placeholder, which contradicted ``testReadyIsQuiet`` — the
+    /// implementation was right and the expectation was wrong.
+    func testPlaceholderNamesTheModelOnlyWhileItBlocksSending() {
+        let blocking: [ModelReadiness] = [
+            .needsDownload(alias: alias, sizeText: nil),
+            .needsStart(alias: alias),
+            .downloading(alias: alias, detail: nil, fraction: nil),
+            .starting(alias: alias, detail: nil),
+        ]
+        for state in blocking {
+            XCTAssertFalse(state.sendAllowed)
+            XCTAssertTrue(
+                state.composerPlaceholder.contains(alias),
+                "blocking placeholder should name the model: \(state.composerPlaceholder)"
+            )
+        }
+        XCTAssertEqual(
+            ModelReadiness.ready(alias: alias).composerPlaceholder,
+            "Send a message…"
+        )
+    }
+
+    /// The empty state's two approved strings survive verbatim — the
+    /// visual redesign signed off on this copy and Phase 1 is not a
+    /// licence to rewrite it.
+    func testApprovedEmptyStateCopyIsPreserved() {
+        XCTAssertEqual(ModelReadiness.noModel.emptyStateSubtitle, "Choose a model to start")
+        XCTAssertEqual(
+            ModelReadiness.ready(alias: alias).emptyStateSubtitle,
+            "Chatting with \(alias)"
+        )
+        XCTAssertEqual(
+            ModelReadiness.starting(alias: alias, detail: nil).emptyStateSubtitle,
+            "Preparing your local model…"
+        )
+    }
+
+    // MARK: - Accessibility
+
+    /// The composed VoiceOver label must carry both halves, so a screen
+    /// reader user gets the same information a sighted user reads.
+    func testAccessibilityLabelComposesHeadlineAndDetail() {
+        let state = ModelReadiness.needsDownload(alias: alias, sizeText: "5.0 GB")
+        let label = state.accessibilityLabel
+        XCTAssertTrue(label.contains(state.headline))
+        XCTAssertTrue(label.contains(state.detail ?? "<missing>"))
+    }
+
+    func testAccessibilityLabelIsNeverEmpty() {
+        for state in allStates {
+            XCTAssertFalse(
+                state.accessibilityLabel.trimmingCharacters(in: .whitespaces).isEmpty,
+                "\(state) has an empty accessibility label"
+            )
+        }
+    }
+}
+
+/// The detail-pane branch. Reduced to the one thing it decides now that
+/// ``ModelReadiness`` owns readiness.
+///
+/// ``@MainActor`` because ``ContentView`` is a SwiftUI ``View``, which
+/// Swift 6 infers as main-actor-isolated — including its statics.
+@MainActor
+final class MainAreaBranchTests: XCTestCase {
+    func testOnlyMissingLeavesTheChatSurface() {
+        XCTAssertEqual(ContentView.mainAreaBranch(for: .missing), .missing)
+        for state: ServerState in [
+            .idle,
+            .stopped,
+            .starting(alias: "a"),
+            .ready(alias: "a"),
+            .crashed(alias: "a", message: "boom"),
+        ] {
+            XCTAssertEqual(
+                ContentView.mainAreaBranch(for: state), .chat,
+                "\(state) should keep the chat surface mounted"
+            )
+        }
+    }
+}

--- a/apps/rapid-mac/Tests/RapidUXTests/ModelReadinessTests.swift
+++ b/apps/rapid-mac/Tests/RapidUXTests/ModelReadinessTests.swift
@@ -754,6 +754,89 @@ final class ModelReadinessTests: XCTestCase {
             )
         }
     }
+
+    // MARK: - #1505 follow-up: serve-state must not describe a foreign selection
+
+    /// The Send-enabling `.ready` state may only describe the SELECTED
+    /// model. A user who picks B while A is still serving must NOT get a
+    /// bright Send button wired to a model that isn't running — resolve B's
+    /// own state instead, so the composer offers B's Start and Send stays
+    /// gated. (Regression: `.ready` previously described the serving alias
+    /// unconditionally, enabling a send that ``ChatView`` would dispatch
+    /// against the un-running selection.)
+    func testReadyForADifferentModelResolvesTheSelection() {
+        let other = "bonsai-1.7b-2bit"
+        let state = resolve(.ready(alias: alias), alias: other, cached: true)
+        XCTAssertEqual(state, .needsStart(alias: other))
+        XCTAssertFalse(state.sendAllowed, "Send must not enable for a model that isn't the one serving")
+
+        let cold = resolve(.ready(alias: alias), alias: other, cached: false)
+        XCTAssertEqual(cold, .needsDownload(alias: other, sizeText: nil))
+        XCTAssertFalse(cold.sendAllowed)
+    }
+
+    /// The launch pre-sync frame: the child is serving but the picker
+    /// breadcrumb hasn't synced yet (empty selection). `.ready` must not win
+    /// with an empty/foreign alias — Send stays gated until a real model is
+    /// actually selected, which the `onChange(of: server.state)` sync does a
+    /// frame later.
+    func testReadyWithNoSelectionYetIsNotSendable() {
+        let state = resolve(.ready(alias: alias), alias: "", cached: true)
+        XCTAssertFalse(state.sendAllowed)
+        XCTAssertEqual(state, .noModel)
+    }
+
+    /// The matching case is untouched: serving == selected → ready.
+    func testReadyForTheSelectedModelStaysReady() {
+        XCTAssertEqual(resolve(.ready(alias: alias), alias: alias), .ready(alias: alias))
+        XCTAssertTrue(readyDescribesSelectionRef(serving: alias, selected: alias))
+        XCTAssertFalse(readyDescribesSelectionRef(serving: alias, selected: "bonsai-1.7b-2bit"))
+        XCTAssertFalse(readyDescribesSelectionRef(serving: alias, selected: ""))
+    }
+
+    /// `.starting` is permissive (it never enables Send): a not-yet-synced
+    /// selection at launch keeps the in-flight start visible, but a
+    /// deliberate pick of a DIFFERENT real model resolves that model.
+    func testStartingIsPermissiveExceptForADifferentRealModel() {
+        // Launch: breadcrumb lags the auto-started model — still show it.
+        let launch = resolve(.starting(alias: alias), alias: "")
+        if case .starting = launch {} else {
+            XCTFail("a starting child with no selection yet must still show as starting, got \(launch)")
+        }
+        // Same model selected — unchanged.
+        if case .starting = resolve(.starting(alias: alias), alias: alias) {} else {
+            XCTFail("starting the selected model must show as starting")
+        }
+        // A different real model deliberately selected — resolve it.
+        let other = "bonsai-1.7b-2bit"
+        XCTAssertEqual(
+            resolve(.starting(alias: alias), alias: other, cached: true),
+            .needsStart(alias: other)
+        )
+    }
+
+    /// A turn-level error is shown in the ready composer only when it
+    /// belongs to the current model (or carries no alias at all). Switching
+    /// to a healthy model must not inherit the previous model's error.
+    func testTurnErrorScopedToSelection() {
+        XCTAssertTrue(
+            ModelReadiness.turnErrorApplies(failureAlias: nil, selectedAlias: alias),
+            "an unattributed turn error is about the current turn and must show"
+        )
+        XCTAssertTrue(
+            ModelReadiness.turnErrorApplies(failureAlias: alias, selectedAlias: alias)
+        )
+        XCTAssertFalse(
+            ModelReadiness.turnErrorApplies(failureAlias: crashed, selectedAlias: alias),
+            "a prior model's turn error must not leak onto a freshly selected model"
+        )
+    }
+
+    /// Local ref so the strict predicate is exercised directly, not only
+    /// through the eight-case resolve matrix.
+    private func readyDescribesSelectionRef(serving: String, selected: String) -> Bool {
+        ModelReadiness.readyDescribesSelection(serving: serving, selected: selected)
+    }
 }
 
 /// The detail-pane branch. Reduced to the one thing it decides now that


### PR DESCRIPTION
Supersedes #1505 (rebased onto current `main` + two review fixes). The feature commit is **authored by @loriz-art (Lori_IoTeX)** and preserved as-is; the second commit adds the fixes below.

## Summary (feature — @loriz-art)

- A single shared `ModelReadiness` state + `ReadinessBanner` across Chat and Launch, so the surfaces can't drift on "can I send / what do I do next".
- Explicit Download / Start / Starting / Ready / failure / recovery states; Send is gated to `ready` (the draft is never consumed by a gated send).
- Startup failures are **scoped to the model that failed**, so switching models immediately updates the UI (the "kimi crashed → banner pinned to kimi" bug).
- Refresh-catalog / manual-model entry moved to the top of long model menus.
- New `RapidUXTests` target with a readiness truth-table + failure-attribution suite.

## Review fixes on top (2nd commit)

Two correctness gaps surfaced in review (codex + an independent reviewer):

1. **`.ready` / `.starting` described the *serving* model unconditionally.** Picking B while A serves resolved to `.ready(A)` → an enabled Send that `ChatView.send(_:alias:)` would dispatch against B (the un-running selection), or a `.ready` with an empty alias in the launch frame before the picker breadcrumb syncs. `.ready` (the only Send-enabling state) now resolves only when a **real serving model equals a real selected model** (`readyDescribesSelection`); otherwise the selection resolves from its own state and Send stays gated. `.starting` gets the permissive twin (`serveStateSpeaksForSelection`) — it never enables Send, so a not-yet-synced launch selection keeps the in-flight start visible and only a deliberate pick of a **different real model** resolves that model.
2. **The ready composer rendered `viewModel.lastError` unconditionally**, resurrecting the *previous* model's turn error after a switch until the next send. Now gated on `turnErrorApplies(failureAlias:selectedAlias:)`: an unattributed turn error still shows; an attributed one shows only for the model it came from.

## Tests

- Feature: `RapidUXTests/ModelReadinessTests` (send-gate truth table, placeholder-alias safety, precedence, full failure-attribution suite).
- Fixes: 6 new cases pinning both fixes (ready for a foreign/empty selection resolves the selection and disables Send; matching case unchanged; `.starting` permissive except for a different real model; turn-error alias scoping).
- `swift build` + full `swift test` green apart from the pre-existing `DownloadManager — real rapid-mlx pull subprocess wiring` integration tests, which fail identically on `main` in this environment (no network / real pull subprocess).

## Notes

- Verified the rebase preserves recently-landed work: multimodal-alias filtering (#1496), bearer masking (#1481), conversation ordering (#1485), starter-model change, and the #1507 Quickstart memory-warning alert (no semantic conflict — the ContentView hunks auto-merged and the memory-warning gate is intact).
- No version bump.

Co-authored-by: Lori_IoTeX <lori@iotex.io>

🤖 Generated with [Claude Code](https://claude.com/claude-code)