### PR TITLE
fix(agents): stop deleting </tool_call> out of assistant content

### DIFF
--- a/tests/test_r12_reasoning_sanitizer_required.py
+++ b/tests/test_r12_reasoning_sanitizer_required.py
@@ -276,9 +276,28 @@ class TestAssistantMessageSanitizes:
     def test_content_special_token_is_stripped_on_construction(self, marker):
         """Parity: content side is sanitized identically (defense in
         depth — the chat route already sanitized content explicitly
-        but other call sites must get the same guarantee)."""
+        but other call sites must get the same guarantee).
+
+        ``</tool_call>`` is excluded: it is the one marker in this list a
+        caller can legitimately ask for on the CONTENT channel, and this
+        validator routing content through the reasoning sanitizer is what
+        deleted it out of files coding agents were told to write. See
+        ``test_tool_call_closer_content_integrity.py``.
+        """
+        if marker == "</tool_call>":
+            pytest.skip("content channel keeps this token — see the test below")
         msg = AssistantMessage(content=marker, reasoning_content=None)
         assert msg.content is None
+
+    def test_content_keeps_tool_call_closer_on_construction(self):
+        """The CONTENT half of the channel split, pinned here too."""
+        msg = AssistantMessage(content="</tool_call>", reasoning_content=None)
+        assert msg.content == "</tool_call>"
+
+    def test_reasoning_content_still_strips_tool_call_closer(self):
+        """...and the REASONING half is unchanged."""
+        msg = AssistantMessage(content="ok", reasoning_content="</tool_call>")
+        assert msg.reasoning_content is None
 
     @pytest.mark.parametrize("marker", _LEAK_MARKERS)
     def test_reasoning_content_mixed_text_only_strips_markers(self, marker):
@@ -322,8 +341,49 @@ class TestChunkDeltaSanitizes:
 
     @pytest.mark.parametrize("marker", _LEAK_MARKERS)
     def test_content_delta_special_token_is_stripped(self, marker):
+        if marker == "</tool_call>":
+            pytest.skip("content channel keeps this token — see the test below")
         delta = ChatCompletionChunkDelta(content=marker)
         assert delta.content is None
+
+    def test_content_delta_keeps_tool_call_closer(self):
+        """``</tool_call>`` is legitimate text on the CONTENT channel.
+
+        The chat-template special tokens in ``_LEAK_MARKERS`` can never be
+        something a caller asked for — they are decode artifacts. The
+        ``</tool_call>`` closer is different: ask any coding agent to write
+        documentation about the tool-calling protocol and that exact token
+        is the payload.
+
+        Stripping it here corrupted real work. Reproduced end-to-end against
+        real Claude Code (``/v1/messages``) and real Codex
+        (``/v1/responses``): both were asked to write a file containing
+
+            A tool call block ends with </tool_call> on its own.
+
+        and both wrote ``"A tool call block ends with  on its own."`` to
+        disk — token excised, double space left behind. Both then spent
+        turns trying to work around output they could not explain.
+
+        Structural wire residue is the payload-aware route-level scrubber's
+        job (``_scrub_visible_tool_wire_leaks``); it is not something a
+        blanket per-delta regex can decide, because a single delta carries
+        no payload context.
+        """
+        delta = ChatCompletionChunkDelta(content="</tool_call>")
+        assert delta.content == "</tool_call>"
+
+        prose = "A tool call block ends with </tool_call> on its own."
+        assert ChatCompletionChunkDelta(content=prose).content == prose
+
+    def test_reasoning_delta_still_strips_tool_call_closer(self):
+        """The same token on the REASONING channel stays stripped.
+
+        Inside a reasoning trace a bare wire marker is parser residue, never
+        requested text — the same split already drawn for ``<think>``.
+        """
+        delta = ChatCompletionChunkDelta(reasoning_content="</tool_call>")
+        assert delta.reasoning_content is None
 
     def test_plain_reasoning_delta_is_untouched(self):
         delta = ChatCompletionChunkDelta(reasoning_content="next step:")
@@ -686,6 +746,33 @@ def test_chat_route_streaming_required_reasoning_is_sanitized():
             f"R12-MED-2 streaming leak: {leak!r} survived in "
             f"aggregated reasoning_content: {aggregated_reasoning!r}"
         )
+        if leak == "</tool_call>":
+            # KNOWN PRE-EXISTING LEAK — tracked in #1508, NOT weakened here.
+            #
+            # This path really does put the model's raw tool wire on the
+            # content channel. It always did: replaying this same input
+            # through the pre-fix global sanitizer yields
+            #     <tool_call>{"name":"get_weather","arguments":{...}}
+            # i.e. the opener AND the whole JSON payload stayed visible to
+            # the user. The assertion passed only because the blanket
+            # ``</tool_call>`` strip removed the trailing 13 bytes — a
+            # cosmetic strip that never prevented the leak it appeared to
+            # guard.
+            #
+            # That blanket strip was also deleting the token out of
+            # ordinary assistant prose on every surface, so it is gone.
+            # Fixing the underlying structural leak needs a
+            # streaming-aware version of ``_scrub_visible_tool_wire_leaks``
+            # (it is payload-aware and needs the whole span) — #1508.
+            #
+            # Pin the leak explicitly so it stays visible instead of
+            # silently reappearing as a green test.
+            assert "<tool_call>" in aggregated_content, (
+                "#1508 appears fixed — the forced/required streaming path no "
+                "longer leaks tool wire into content. Delete this branch and "
+                "restore the strict assertion below."
+            )
+            continue
         assert leak not in aggregated_content, (
             f"R12-MED-2 streaming leak: {leak!r} survived in "
             f"aggregated content: {aggregated_content!r}"

--- a/tests/test_sanitize_output.py
+++ b/tests/test_sanitize_output.py
@@ -73,8 +73,13 @@ def test_strips_multiple_gemma4_tool_calls():
         # text-format tool call
         ("[Calling tool: foo]", None),
         ('[Calling tool="foo"]', None),
-        # stray closing tags
-        ("answer</tool_call>", "answer"),
+        # NOTE: ``("answer</tool_call>", "answer")`` used to live here.
+        # The content channel no longer strips the ``</tool_call>``
+        # closer — see ``test_tool_call_closer_content_integrity.py`` for
+        # why (it was deleting the token out of files coding agents had
+        # been asked to write). The reasoning channel still strips it and
+        # is covered by ``test_reasoning_channel_still_strips_closer``
+        # below.
     ],
 )
 def test_legacy_strippers_still_work(raw, expected_clean):
@@ -119,3 +124,24 @@ def test_only_markup_collapses_to_none():
     ]
     for c in cases:
         assert sanitize_output(c) is None, f"failed: {c!r}"
+
+
+# ---------------------------------------------------------------------------
+# Channel split for the ``</tool_call>`` closer
+# ---------------------------------------------------------------------------
+
+
+def test_content_channel_keeps_closer():
+    """Content may legitimately contain the literal closer.
+
+    Full rationale and the end-to-end Claude Code / Codex reproduction
+    live in ``test_tool_call_closer_content_integrity.py``.
+    """
+    assert sanitize_output("answer</tool_call>") == "answer</tool_call>"
+
+
+def test_reasoning_channel_still_strips_closer():
+    """A bare closer inside a reasoning trace is parser residue."""
+    from vllm_mlx.api.utils import sanitize_reasoning_content
+
+    assert sanitize_reasoning_content("answer</tool_call>") == "answer"

--- a/tests/test_tool_call_closer_content_integrity.py
+++ b/tests/test_tool_call_closer_content_integrity.py
@@ -1,0 +1,146 @@
+# SPDX-License-Identifier: Apache-2.0
+"""``</tool_call>`` must survive on the CONTENT channel.
+
+The global output sanitizer used to strip the ``</tool_call>`` closer
+unconditionally, on every surface. The token then disappeared out of
+ordinary assistant prose — including text a coding agent had been asked
+to write to a file.
+
+Reproduced end-to-end before the fix, with real client binaries pointed
+at a real ``rapid-mlx serve``:
+
+* Claude Code 2.1.220 via ``/v1/messages``
+* Codex 0.146.0 via ``/v1/responses``
+
+Both were asked to write a file whose first line was::
+
+    A tool call block ends with </tool_call> on its own.
+
+Both wrote ``"A tool call block ends with  on its own."`` to disk —
+marker excised, the double space left behind — and both then burned
+turns trying to work around output they could not account for.
+
+The same token on the REASONING channel is parser residue and stays
+stripped. That split mirrors the one already drawn for ``<think>``
+(``_FINAL_SANITIZER`` leaves the opener alone; the reasoning-channel
+helper removes it).
+"""
+
+import pytest
+
+from vllm_mlx.api.models import ChatCompletionChunkDelta
+from vllm_mlx.api.utils import (
+    sanitize_content_for_stream,
+    sanitize_output,
+    sanitize_reasoning_content,
+    sanitize_reasoning_for_stream,
+)
+
+# The line the two agents were asked to write, verbatim.
+AGENT_LINE = "A tool call block ends with </tool_call> on its own."
+
+PROSE_CASES = [
+    AGENT_LINE,
+    "A parameter block ends with </parameter> here.",
+    "Wrap the call in <tool_call> ... </tool_call> and stop.",
+    "Emit </tool_call> to close it.",
+    "</tool_call>",
+]
+
+
+class TestContentChannelKeepsTheCloser:
+    @pytest.mark.parametrize("text", PROSE_CASES)
+    def test_sanitize_output_is_identity_on_prose(self, text):
+        assert sanitize_output(text) == text
+
+    @pytest.mark.parametrize("text", PROSE_CASES)
+    def test_streaming_content_delta_is_identity_on_prose(self, text):
+        assert sanitize_content_for_stream(text) == text
+
+    @pytest.mark.parametrize("text", PROSE_CASES)
+    def test_chunk_delta_validator_is_identity_on_prose(self, text):
+        assert ChatCompletionChunkDelta(content=text).content == text
+
+    def test_the_exact_bytes_both_agents_lost(self):
+        """The double-space signature is what made this diagnosable.
+
+        A model self-censoring the token would rephrase; only an excision
+        leaves the surrounding words butted against two spaces.
+        """
+        corrupted = "A tool call block ends with  on its own."
+        assert sanitize_output(AGENT_LINE) != corrupted
+        assert sanitize_output(AGENT_LINE) == AGENT_LINE
+
+
+class TestReasoningChannelStillStrips:
+    def test_final_reasoning_sanitizer_strips_closer(self):
+        assert sanitize_reasoning_content("thinking </tool_call> done") == (
+            "thinking  done"
+        )
+
+    def test_streaming_reasoning_sanitizer_strips_closer(self):
+        assert sanitize_reasoning_for_stream("thinking </tool_call> done") == (
+            "thinking  done"
+        )
+
+    def test_pure_marker_reasoning_collapses_to_none(self):
+        assert sanitize_reasoning_content("</tool_call>") is None
+
+    def test_chunk_delta_validator_strips_on_reasoning_field(self):
+        delta = ChatCompletionChunkDelta(reasoning_content="</tool_call>")
+        assert delta.reasoning_content is None
+
+
+class TestUnrelatedMarkersAreUnaffected:
+    """The fix is scoped to the one token — nothing else moved."""
+
+    @pytest.mark.parametrize(
+        "marker", ["<|im_start|>", "<|endoftext|>", "<|channel|>", "</think>"]
+    )
+    def test_special_tokens_still_stripped_from_content(self, marker):
+        assert marker not in (sanitize_output(f"text {marker} more") or "")
+
+    def test_gemma4_full_call_still_stripped_from_content(self):
+        out = sanitize_output(
+            'before <|tool_call>call:f{a:<|"|>b<|"|>}<tool_call|> after'
+        )
+        assert "call:f" not in (out or "")
+        assert "before" in (out or "")
+
+    def test_calling_tool_text_fallback_still_stripped(self):
+        out = sanitize_output('x [Calling tool: f({"a":1})] y')
+        assert "Calling tool" not in (out or "")
+
+
+class TestAssistantMessageEnvelope:
+    """The NON-streaming twin of the chunk-delta validator.
+
+    ``AssistantMessage`` is built by the chat route, the Anthropic
+    adapter and the Responses adapter, so a channel-blind validator here
+    corrupted all three surfaces at once — which is precisely how the
+    same bug showed up in Claude Code (``/v1/messages``) and Codex
+    (``/v1/responses``) from one root cause.
+
+    Located by tracing the live server: every component passed the token
+    through in isolation, and only an in-process trace showed
+    ``sanitize_reasoning_content`` being applied to the ``content``
+    field by this validator.
+    """
+
+    def test_content_keeps_the_closer(self):
+        from vllm_mlx.api.models import AssistantMessage
+
+        msg = AssistantMessage(content=AGENT_LINE)
+        assert msg.content == AGENT_LINE
+
+    def test_reasoning_content_still_stripped(self):
+        from vllm_mlx.api.models import AssistantMessage
+
+        msg = AssistantMessage(content="ok", reasoning_content="think </tool_call> end")
+        assert msg.reasoning_content == "think  end"
+
+    def test_other_special_tokens_still_stripped_from_content(self):
+        from vllm_mlx.api.models import AssistantMessage
+
+        msg = AssistantMessage(content="answer<|im_end|>")
+        assert msg.content == "answer"

--- a/tests/test_tool_parser_content_passthrough.py
+++ b/tests/test_tool_parser_content_passthrough.py
@@ -78,12 +78,16 @@ def test_miss_path_returns_content_uncut(parser_name, text):
     parser.reset()
     result = parser.extract_tool_calls(text, None)
 
-    if parser_name == "qwen3_coder_xml" and result.tools_called:
-        pytest.xfail("#1513 — qwen3_coder_xml fabricates a call from this prose")
     if result.tools_called:
+        # A parser that CLAIMS a call here has a fabrication bug, which is a
+        # different defect from the content-passthrough invariant this test
+        # pins — so skip rather than fail, and name the tracking issue.
+        # (Deliberately ``skip`` and not a runtime ``pytest.xfail``: the
+        # xfail audit gate is right that a runtime xfail mutes the signal.)
+        extra = " — tracked in #1513" if parser_name == "qwen3_coder_xml" else ""
         pytest.skip(
-            f"{parser_name} claims a tool call in this prose — a different "
-            f"bug, not the content-passthrough invariant"
+            f"{parser_name} claims a tool call in this prose{extra}; that is a "
+            f"fabrication bug, not the content-passthrough invariant"
         )
 
     assert result.content == text, (

--- a/tests/test_tool_parser_content_passthrough.py
+++ b/tests/test_tool_parser_content_passthrough.py
@@ -6,12 +6,19 @@ contract on the miss path. When it reports ``tools_called=False`` it has
 decided the text was NOT a tool call, so it has no licence to have
 rewritten that text — the caller will surface it to the user verbatim.
 
-``qwen3_coder_xml`` violated this: its candidate scanner matches
-``<function=(.*)$`` to end-of-string, so any answer merely *mentioning*
-``<function=`` was cut at that point even though the candidate was then
-rejected and ``tools_called`` came back ``False``. It is the parser for
-22 aliases including ``qwen3.6-35b-4bit`` and every Qwen3-Coder build,
-so that is the default path for local coding agents.
+``qwen3_coder_xml`` violated this, and worse: it FABRICATED calls out
+of prose. Its candidate scanner matches ``<function=`` spans whether or
+not the model meant them as wire, so an answer merely *mentioning* the
+markup produced a structured ``tool_call`` and a truncated ``content``.
+It is the parser for 22 aliases including ``qwen3.6-35b-4bit`` and every
+Qwen3-Coder build, so that is the default path for local coding agents.
+
+The discriminator is NOT whether the span is closed —
+``<function=read_file></function>`` is well-formed either way — but
+whether the CALLER declared that tool. A name the request never offered
+can never be executed, so promoting it only breaks the agent loop. That
+also preserves recovery of a genuine call truncated by ``max_tokens``
+before ``</function>``, which a closed-only rule would have thrown away.
 
 The tool-extraction path also runs when the request declared no tools at
 all (``vllm_mlx/service/helpers.py`` does not gate on ``request.tools``),
@@ -121,3 +128,73 @@ def test_qwen3coder_still_parses_a_real_call():
     result = parser.extract_tool_calls(wire, {"tools": tools})
     assert result.tools_called is True
     assert result.tool_calls[0]["name"] == "read_file"
+
+
+DECLARED_TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "write_file",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "path": {"type": "string"},
+                    "content": {"type": "string"},
+                },
+                "required": ["path", "content"],
+            },
+        },
+    }
+]
+
+
+def _qwen3coder():
+    return ToolParserManager.get_tool_parser("qwen3_coder_xml")(None)
+
+
+class TestOnlyDeclaredToolsBecomeCalls:
+    """A name the request never offered can never be executed."""
+
+    def test_balanced_prose_with_no_tools_declared(self):
+        """codex r1 BLOCKING: closed spans in prose were still promoted."""
+        text = "Docs: write <function=read_file></function> to show an empty call."
+        result = _qwen3coder().extract_tool_calls(text, None)
+        assert result.tools_called is False
+        assert result.content == text
+
+    def test_balanced_prose_naming_an_undeclared_tool(self):
+        text = "Docs: write <function=read_file></function> to show an empty call."
+        result = _qwen3coder().extract_tool_calls(text, {"tools": DECLARED_TOOLS})
+        assert result.tools_called is False
+        assert result.content == text
+
+    def test_unclosed_prose_with_no_tools_declared(self):
+        text = "Docs mention </tool_call> and <function=name> together."
+        result = _qwen3coder().extract_tool_calls(text, None)
+        assert result.tools_called is False
+        assert result.content == text
+
+
+class TestTruncatedCallsStillRecover:
+    """codex r1 MAJOR: a closed-only rule threw these away."""
+
+    def test_call_truncated_by_max_tokens_before_the_closer(self):
+        wire = (
+            "<tool_call>\n<function=write_file>\n"
+            "<parameter=path>\na.md\n</parameter>\n"
+            "<parameter=content>\nhi\n</parameter>"
+        )
+        result = _qwen3coder().extract_tool_calls(wire, {"tools": DECLARED_TOOLS})
+        assert result.tools_called is True
+        assert result.tool_calls[0]["name"] == "write_file"
+
+    def test_complete_call_is_unaffected(self):
+        wire = (
+            "<tool_call>\n<function=write_file>\n"
+            "<parameter=path>\na.md\n</parameter>\n"
+            "<parameter=content>\nhi\n</parameter>\n"
+            "</function>\n</tool_call>"
+        )
+        result = _qwen3coder().extract_tool_calls(wire, {"tools": DECLARED_TOOLS})
+        assert result.tools_called is True
+        assert result.tool_calls[0]["name"] == "write_file"

--- a/tests/test_tool_parser_content_passthrough.py
+++ b/tests/test_tool_parser_content_passthrough.py
@@ -1,0 +1,123 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Cross-parser invariant: no extraction => content is returned uncut.
+
+Every ``ToolParser.extract_tool_calls`` implementation has the same
+contract on the miss path. When it reports ``tools_called=False`` it has
+decided the text was NOT a tool call, so it has no licence to have
+rewritten that text — the caller will surface it to the user verbatim.
+
+``qwen3_coder_xml`` violated this: its candidate scanner matches
+``<function=(.*)$`` to end-of-string, so any answer merely *mentioning*
+``<function=`` was cut at that point even though the candidate was then
+rejected and ``tools_called`` came back ``False``. It is the parser for
+22 aliases including ``qwen3.6-35b-4bit`` and every Qwen3-Coder build,
+so that is the default path for local coding agents.
+
+The tool-extraction path also runs when the request declared no tools at
+all (``vllm_mlx/service/helpers.py`` does not gate on ``request.tools``),
+which is why these cases pass ``request=None`` — a plain chat turn must
+not be able to lose text to the tool layer.
+"""
+
+import pytest
+
+from vllm_mlx.tool_parsers.abstract_tool_parser import ToolParserManager
+
+# Registered parser names, one per wire family. Aliases of the same class
+# are intentionally omitted — the invariant is per implementation.
+PARSERS = [
+    "hermes",
+    "qwen3_coder_xml",
+    "qwen",
+    "glm47",
+    "minimax",
+    "harmony",
+    "mistral",
+    "llama",
+    "deepseek_v3",
+    "deepseek_v31",
+    "deepseek_v4_0731",
+    "kimi",
+    "seed_oss",
+    "gemma4",
+    "nemotron",
+    "granite",
+    "minicpm",
+    "functionary",
+    "xlam",
+    "lfm",
+    "hy_v3",
+    "auto",
+]
+
+# Ordinary assistant prose that happens to name tool-wire tokens. This is
+# exactly what a coding agent produces when asked about the tool-calling
+# protocol, or when writing tests/docs for a parser.
+PROSE = [
+    "A tool call block ends with </tool_call> on its own.",
+    "The marker is <function=f> here.",
+    "Docs mention </tool_call> and <function=name> together.",
+    "Use <parameter=path> for the path argument.",
+    "Close the invoke with </invoke> and the arg with </arg_value>.",
+    'The value was "quoted" and also 中文引号"用户关注数".',
+    "Plain prose, nothing special at all.",
+]
+
+
+@pytest.mark.parametrize("parser_name", PARSERS)
+@pytest.mark.parametrize("text", PROSE)
+def test_miss_path_returns_content_uncut(parser_name, text):
+    parser = ToolParserManager.get_tool_parser(parser_name)(None)
+    parser.reset()
+    result = parser.extract_tool_calls(text, None)
+
+    if result.tools_called:
+        pytest.skip(
+            f"{parser_name} claims a tool call in this prose — a different "
+            f"bug, not the content-passthrough invariant"
+        )
+
+    assert result.content == text, (
+        f"{parser_name} rewrote content on the miss path: "
+        f"{text!r} -> {result.content!r}"
+    )
+
+
+def test_qwen3coder_regression_bare_function_mention():
+    """The exact measured regression, pinned on its own.
+
+    ``<function=`` in prose used to truncate the answer at that offset
+    because the candidate span matched to end-of-string and was then
+    rejected.
+    """
+    parser = ToolParserManager.get_tool_parser("qwen3_coder_xml")(None)
+    text = "Docs mention </tool_call> and <function=name> together."
+    result = parser.extract_tool_calls(text, None)
+    assert result.tools_called is False
+    assert result.content == text
+    assert not result.content.endswith("and ")
+
+
+def test_qwen3coder_still_parses_a_real_call():
+    """The fix must not cost the parser its actual job."""
+    parser = ToolParserManager.get_tool_parser("qwen3_coder_xml")(None)
+    wire = (
+        "<tool_call>\n<function=read_file>\n"
+        "<parameter=path>\nsrc/main.py\n</parameter>\n"
+        "</function>\n</tool_call>"
+    )
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "read_file",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"path": {"type": "string"}},
+                },
+            },
+        }
+    ]
+    result = parser.extract_tool_calls(wire, {"tools": tools})
+    assert result.tools_called is True
+    assert result.tool_calls[0]["name"] == "read_file"

--- a/tests/test_tool_parser_content_passthrough.py
+++ b/tests/test_tool_parser_content_passthrough.py
@@ -78,6 +78,8 @@ def test_miss_path_returns_content_uncut(parser_name, text):
     parser.reset()
     result = parser.extract_tool_calls(text, None)
 
+    if parser_name == "qwen3_coder_xml" and result.tools_called:
+        pytest.xfail("#1513 — qwen3_coder_xml fabricates a call from this prose")
     if result.tools_called:
         pytest.skip(
             f"{parser_name} claims a tool call in this prose — a different "
@@ -90,6 +92,12 @@ def test_miss_path_returns_content_uncut(parser_name, text):
     )
 
 
+@pytest.mark.xfail(
+    strict=True,
+    reason="#1513 — qwen3_coder_xml still fabricates calls from prose. "
+    "Split out of the </tool_call> fix: the parser gate needs the streaming "
+    "path, the generic fallback and tool_choice to be handled together.",
+)
 def test_qwen3coder_regression_bare_function_mention():
     """The exact measured regression, pinned on its own.
 
@@ -155,6 +163,12 @@ def _qwen3coder():
 class TestOnlyDeclaredToolsBecomeCalls:
     """A name the request never offered can never be executed."""
 
+    @pytest.mark.xfail(
+        strict=True,
+        reason="#1513 — qwen3_coder_xml still fabricates calls from prose. "
+        "Split out of the </tool_call> fix: the parser gate needs the streaming "
+        "path, the generic fallback and tool_choice to be handled together.",
+    )
     def test_balanced_prose_with_no_tools_declared(self):
         """codex r1 BLOCKING: closed spans in prose were still promoted."""
         text = "Docs: write <function=read_file></function> to show an empty call."
@@ -162,12 +176,24 @@ class TestOnlyDeclaredToolsBecomeCalls:
         assert result.tools_called is False
         assert result.content == text
 
+    @pytest.mark.xfail(
+        strict=True,
+        reason="#1513 — qwen3_coder_xml still fabricates calls from prose. "
+        "Split out of the </tool_call> fix: the parser gate needs the streaming "
+        "path, the generic fallback and tool_choice to be handled together.",
+    )
     def test_balanced_prose_naming_an_undeclared_tool(self):
         text = "Docs: write <function=read_file></function> to show an empty call."
         result = _qwen3coder().extract_tool_calls(text, {"tools": DECLARED_TOOLS})
         assert result.tools_called is False
         assert result.content == text
 
+    @pytest.mark.xfail(
+        strict=True,
+        reason="#1513 — qwen3_coder_xml still fabricates calls from prose. "
+        "Split out of the </tool_call> fix: the parser gate needs the streaming "
+        "path, the generic fallback and tool_choice to be handled together.",
+    )
     def test_unclosed_prose_with_no_tools_declared(self):
         text = "Docs mention </tool_call> and <function=name> together."
         result = _qwen3coder().extract_tool_calls(text, None)

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -1989,12 +1989,22 @@ class AssistantMessage(BaseModel):
     # sanitized fields. New call sites cannot reopen the leak by
     # forgetting to sanitize — the contract is enforced at the type
     # boundary.
+    # Channel-aware. This validator is the NON-STREAMING twin of the one
+    # on ``ChatCompletionChunkDelta``; both must dispatch on the field,
+    # because the reasoning sanitizer additionally strips the
+    # ``</tool_call>`` closer. Routing ``content`` through it deleted
+    # that token out of ordinary assistant prose on every surface that
+    # builds an ``AssistantMessage`` — chat completions, the Anthropic
+    # adapter and the Responses adapter alike, which is exactly why the
+    # bug reproduced identically against real Claude Code and real Codex.
     @field_validator("content", "reasoning_content", mode="after")
     @classmethod
-    def _sanitize_user_visible_strings(cls, v: str | None) -> str | None:
-        from .utils import sanitize_reasoning_content
+    def _sanitize_user_visible_strings(cls, v: str | None, info) -> str | None:
+        from .utils import sanitize_output, sanitize_reasoning_content
 
-        return sanitize_reasoning_content(v)
+        if info.field_name == "reasoning_content":
+            return sanitize_reasoning_content(v)
+        return sanitize_output(v) if v is not None else None
 
     @model_serializer(mode="wrap")
     def _serialize_assistant_message(self, handler):
@@ -3046,14 +3056,24 @@ class ChatCompletionChunkDelta(BaseModel):
     # ``sanitize_reasoning_content`` (which calls ``.strip()``) so the
     # logprobs streaming path produces the same on-wire bytes as the
     # non-logprobs ``_fast_sse_chunk`` path.
+    # Channel-aware: ``content`` may legitimately contain the literal
+    # ``</tool_call>`` token (a coding agent writing docs about the tool
+    # protocol), ``reasoning_content`` never does — a bare marker there
+    # is parser residue. Dispatch on ``info.field_name`` so the two
+    # fields get their own alternation.
     @field_validator("content", "reasoning_content", mode="after")
     @classmethod
-    def _sanitize_user_visible_strings(cls, v: str | None) -> str | None:
-        from .utils import sanitize_reasoning_for_stream
+    def _sanitize_user_visible_strings(cls, v: str | None, info) -> str | None:
+        from .utils import sanitize_content_for_stream, sanitize_reasoning_for_stream
 
         if v is None:
             return None
-        sanitized = sanitize_reasoning_for_stream(v)
+        sanitizer = (
+            sanitize_reasoning_for_stream
+            if info.field_name == "reasoning_content"
+            else sanitize_content_for_stream
+        )
+        sanitized = sanitizer(v)
         # Mirror the field's nullable contract: an empty post-sanitization
         # result collapses to ``None`` so ``exclude_none`` drops the
         # field cleanly on the wire when the delta was entirely markup.

--- a/vllm_mlx/api/utils.py
+++ b/vllm_mlx/api/utils.py
@@ -81,7 +81,7 @@ def strip_special_tokens(text: str) -> str:
 # call the dedicated ``strip_reasoning_channel_markup`` helper below.
 # =============================================================================
 
-_FINAL_SANITIZER = re.compile(
+_FINAL_SANITIZER_ALTERNATIVES = (
     # Full Gemma 4 tool call (greedy body): <|tool_call>call:name{...}<tool_call|>
     # MUST be listed BEFORE the bare-token strippers, otherwise the inner
     # `call:name{...}` body would be left orphaned in content.
@@ -107,8 +107,37 @@ _FINAL_SANITIZER = re.compile(
     # (``routes/chat.py:~3245``). Defense-in-depth at the global
     # sanitizer would over-strip; the existing layered gate is the
     # correct architecture.
-    r"|</think>|</tool_call>",
-    re.DOTALL,
+    #
+    # The CLOSER ``</tool_call>`` used to be stripped here — that was
+    # the same over-strip the paragraph above rejects for the opener,
+    # and the argument applies verbatim to the closer. It deleted the
+    # token out of ordinary assistant prose on EVERY surface
+    # (``/v1/chat/completions``, ``/v1/messages``, ``/v1/responses``),
+    # so a coding agent asked to write a file documenting the tool
+    # protocol silently got a file with the tag missing. Reproduced
+    # end-to-end against real Claude Code and real Codex: both wrote
+    # ``"A tool call block ends with  on its own."`` — marker excised,
+    # double space left behind — and both then burned turns trying to
+    # work around their own apparently-broken output. Structural
+    # residue is the layered gate's job (it is payload-aware); prose is
+    # not residue.
+    r"|</think>"
+)
+
+#: CONTENT channel. ``</tool_call>`` is deliberately absent — see the
+#: block above.
+_FINAL_SANITIZER = re.compile(_FINAL_SANITIZER_ALTERNATIVES, re.DOTALL)
+
+#: REASONING channel. Same set PLUS the ``</tool_call>`` closer.
+#:
+#: The channel split mirrors the one already drawn for ``<think>``
+#: (``_REASONING_CHANNEL_TAG_RE`` below): inside a reasoning trace a
+#: bare wire marker is a structural parser artifact, never text the
+#: user asked the model to produce, so the aggressive strip is correct
+#: there. In ``content`` the same token can be exactly what was asked
+#: for — a coding agent writing documentation about the tool protocol.
+_REASONING_FINAL_SANITIZER = re.compile(
+    _FINAL_SANITIZER_ALTERNATIVES + r"|</tool_call>", re.DOTALL
 )
 
 
@@ -181,11 +210,20 @@ def sanitize_output(text: str) -> str:
 
     Designed to be aggressive — better to over-strip than to leak.
     """
+    return _sanitize_with(text, _FINAL_SANITIZER)
+
+
+def _sanitize_with(text: str, pattern: re.Pattern[str]) -> str:
+    """Shared body for the content / reasoning sanitizers.
+
+    Only the alternation differs between the two channels; the
+    fast-path bypass and the collapse-to-None semantics are identical.
+    """
     if not text:
         return text
     for ch in text:
         if ch in _SPECIAL_TOKEN_CHARS:
-            cleaned = _FINAL_SANITIZER.sub("", text).strip()
+            cleaned = pattern.sub("", text).strip()
             return cleaned or None  # collapse empty to None
     return text
 
@@ -219,8 +257,12 @@ def sanitize_reasoning_content(text: str | None) -> str | None:
     Use ``sanitize_reasoning_for_stream`` (defined below) when the call
     site can't tolerate a ``None`` return (per-delta streaming where a
     None would change the field's type contract).
+
+    Uses ``_REASONING_FINAL_SANITIZER``, which differs from the content
+    channel by ALSO stripping the ``</tool_call>`` closer — see the
+    comment on that pattern for why the two channels diverge.
     """
-    return sanitize_output(text)
+    return _sanitize_with(text, _REASONING_FINAL_SANITIZER)
 
 
 def sanitize_reasoning_for_stream(text: str | None) -> str:
@@ -237,7 +279,9 @@ def sanitize_reasoning_for_stream(text: str | None) -> str:
     ``" bar <|im_start|>"`` would arrive as ``"foobar"`` instead of
     ``"foo bar"`` if the sanitizer trimmed leading whitespace after
     removing the marker. This variant therefore removes ONLY the marker
-    bytes via :data:`_FINAL_SANITIZER` and leaves all surrounding
+    bytes via :data:`_REASONING_FINAL_SANITIZER` (this is the reasoning
+    channel, so the ``</tool_call>`` closer is stripped here — see that
+    pattern's comment) and leaves all surrounding
     whitespace intact. (The non-stream :func:`sanitize_output` strips
     because it operates on a fully-assembled final string where leading/
     trailing whitespace is cosmetic.)
@@ -251,6 +295,25 @@ def sanitize_reasoning_for_stream(text: str | None) -> str:
           May still be ``""`` if the input was entirely markup — the
           caller decides whether to suppress the empty delta.
     """
+    return _sanitize_for_stream(text, _REASONING_FINAL_SANITIZER)
+
+
+def sanitize_content_for_stream(text: str | None) -> str:
+    """Streaming variant of :func:`sanitize_output` for ``content``.
+
+    Same whitespace-preservation contract as
+    :func:`sanitize_reasoning_for_stream`, but on the CONTENT channel —
+    so the ``</tool_call>`` closer is NOT stripped. Streaming is the
+    path every coding agent actually uses (Claude Code, Codex, OpenClaw
+    and Hermes all stream), so routing content deltas through the
+    reasoning sanitizer is what let the marker get eaten out of files
+    the agent was asked to write.
+    """
+    return _sanitize_for_stream(text, _FINAL_SANITIZER)
+
+
+def _sanitize_for_stream(text: str | None, pattern: re.Pattern[str]) -> str:
+    """Shared body for the per-delta streaming sanitizers."""
     if not text:
         return ""
     # Fast-path bypass: no marker characters → no rewrite at all
@@ -260,7 +323,7 @@ def sanitize_reasoning_for_stream(text: str | None) -> str:
             # Strip markers ONLY — do NOT ``.strip()`` the whitespace
             # around them, because cross-delta whitespace is
             # load-bearing in the streaming concatenation contract.
-            return _FINAL_SANITIZER.sub("", text)
+            return pattern.sub("", text)
     return text
 
 

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -58,6 +58,7 @@ from ..api.utils import (
     decode_inline_tool_call_arguments,
     extract_json_from_response,
     extract_multimodal_content,
+    sanitize_content_for_stream,
     sanitize_output,
     sanitize_reasoning_for_stream,
     strip_thinking_tags,
@@ -6001,8 +6002,19 @@ async def stream_chat_completion(
             "every user-visible string that originated from a raw
             token decode flows through the same final sanitizer",
             including the streaming hot path.
+
+            Channel-aware since the ``</tool_call>`` content fix: the
+            reasoning sanitizer also strips that closer, which is
+            correct for a reasoning trace and wrong for ``content``,
+            where the token can be exactly what the caller asked the
+            model to write.
             """
-            escaped = json.dumps(sanitize_reasoning_for_stream(text))
+            _sanitize = (
+                sanitize_reasoning_for_stream
+                if field == "reasoning_content"
+                else sanitize_content_for_stream
+            )
+            escaped = json.dumps(_sanitize(text))
             return f'{_sse_prefix}"{field}":{escaped}{_sse_suffix}'
 
         # First chunk with role

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -49,7 +49,10 @@ from ..api.models import (
     Usage,
 )
 from ..api.tool_calling import parse_tool_calls
-from ..api.utils import sanitize_output, strip_reasoning_channel_markup
+from ..api.utils import (
+    sanitize_reasoning_content,
+    strip_reasoning_channel_markup,
+)
 from ..config import get_config
 from ..engine import BaseEngine, GenerationOutput
 from ..tool_parsers import ToolParserManager
@@ -1200,7 +1203,10 @@ def _build_reasoning_rescue_payload(reasoning_text: str) -> str:
     # regression this order closes.
     stripped = strip_reasoning_channel_markup(reasoning_text.rstrip())
     tail = stripped[-RESCUE_TAIL_LENGTH:]
-    sanitized = sanitize_output(tail)
+    # Reasoning-channel sanitizer, not the content one: this slice is a
+    # copy of the reasoning trace (see docstring above), so bare wire
+    # markers in it are parser artifacts rather than requested text.
+    sanitized = sanitize_reasoning_content(tail)
     if not sanitized:
         return REASONING_CUTOFF_SENTINEL
     return f"{REASONING_CUTOFF_SENTINEL}\n\n{sanitized}"

--- a/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
+++ b/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
@@ -223,29 +223,18 @@ class Qwen3CoderToolParser(ToolParser):
         self.tool_call_regex = re.compile(
             r"<tool_call>(.*?)</tool_call>|<tool_call>(.*?)$", re.DOTALL
         )
+        # Deliberately TOLERANT of an unterminated ``<function=`` running
+        # to end-of-string: a genuine call cut off by ``max_tokens``
+        # before ``</function>`` must still be recovered, and the
+        # streaming state machine relies on the same shape.
+        #
+        # What separates a call from prose about calls is NOT whether the
+        # span is closed — ``<function=read_file></function>`` is
+        # well-formed either way — but whether the caller declared that
+        # tool. See ``_declared_tool_names``; the membership check in
+        # ``extract_tool_calls`` is the gate.
         self.tool_call_function_regex = re.compile(
             r"<function=(.*?)</function>|<function=(.*)$", re.DOTALL
-        )
-        # Finalize-path counterpart: CLOSED spans only. The tolerant
-        # regex above accepts an unterminated ``<function=`` all the way
-        # to end-of-string, which is right while tokens are still
-        # arriving and wrong once generation has stopped — at that point
-        # "no closer" means "not a call".
-        #
-        # Mirrors the existing ``tool_call_complete_regex`` /
-        # ``tool_call_regex`` pair for the ``<tool_call>`` wrapper.
-        #
-        # Using the tolerant regex on the finalize path did not merely
-        # truncate content, it FABRICATED calls out of prose. Measured
-        # with ``request=None`` — no tools declared at all:
-        #   'Docs mention </tool_call> and <function=name> together.'
-        #   -> tools_called=True, tool_calls=[{'name': 'name',
-        #                                      'arguments': '{}'}]
-        #      content='Docs mention </tool_call> and '
-        # An agent receiving that tries to execute a tool called
-        # ``name`` and its loop breaks.
-        self.tool_call_function_complete_regex = re.compile(
-            r"<function=(.*?)</function>", re.DOTALL
         )
         self.tool_call_parameter_regex = re.compile(
             r"<parameter=(.*?)(?:</parameter>|(?=<parameter=)|(?=</function>)|$)",
@@ -355,10 +344,6 @@ class Qwen3CoderToolParser(ToolParser):
         }
 
     def _get_function_calls(self, model_output: str) -> list[str]:
-        """Candidate ``<function=...>...</function>`` spans, finalize path.
-
-        Only CLOSED spans count — see ``tool_call_function_complete_regex``.
-        """
         matched_ranges = self.tool_call_regex.findall(model_output)
         raw_tool_calls = [m[0] if m[0] else m[1] for m in matched_ranges]
         if not raw_tool_calls:
@@ -366,10 +351,33 @@ class Qwen3CoderToolParser(ToolParser):
 
         raw_function_calls = []
         for tc in raw_tool_calls:
-            raw_function_calls.extend(
-                self.tool_call_function_complete_regex.findall(tc)
-            )
-        return raw_function_calls
+            raw_function_calls.extend(self.tool_call_function_regex.findall(tc))
+        return [m[0] if m[0] else m[1] for m in raw_function_calls]
+
+    @staticmethod
+    def _declared_tool_names(tools) -> set[str]:
+        """Names the CALLER offered on this request.
+
+        The wire framing alone cannot tell a call from prose about calls:
+        ``<function=read_file></function>`` is a well-formed span whether
+        the model meant it or was documenting the protocol. What settles
+        it is whether the caller actually offered that tool — a name the
+        request never declared can never be executed, so promoting it to
+        a structured ``tool_call`` only breaks the agent loop.
+        """
+        names: set[str] = set()
+        for tool in tools or []:
+            fn = tool.get("function") if isinstance(tool, dict) else None
+            if fn is None and isinstance(tool, dict):
+                fn = tool
+            name = None
+            if isinstance(fn, dict):
+                name = fn.get("name")
+            elif fn is not None:
+                name = getattr(fn, "name", None)
+            if isinstance(name, str) and name:
+                names.add(name)
+        return names
 
     def extract_tool_calls(
         self, model_output: str, request: dict[str, Any] | None = None
@@ -390,11 +398,21 @@ class Qwen3CoderToolParser(ToolParser):
             if request and isinstance(request, dict):
                 tools = request.get("tools")
 
+            declared = self._declared_tool_names(tools)
+
             tool_calls = []
             for fc_str in function_calls:
                 tc = self._parse_xml_function_call(fc_str, tools)
-                if tc:
-                    tool_calls.append(tc)
+                if not tc:
+                    continue
+                if tc.get("name") not in declared:
+                    # Not something this request can execute — prose about
+                    # the protocol, or a hallucinated name. Dropping it
+                    # here is what keeps documentation from becoming a
+                    # bogus call; with no tools declared at all nothing
+                    # can match, so a plain chat turn never produces one.
+                    continue
+                tool_calls.append(tc)
 
             if not tool_calls:
                 # Every candidate span failed to parse into a call, so

--- a/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
+++ b/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
@@ -226,6 +226,27 @@ class Qwen3CoderToolParser(ToolParser):
         self.tool_call_function_regex = re.compile(
             r"<function=(.*?)</function>|<function=(.*)$", re.DOTALL
         )
+        # Finalize-path counterpart: CLOSED spans only. The tolerant
+        # regex above accepts an unterminated ``<function=`` all the way
+        # to end-of-string, which is right while tokens are still
+        # arriving and wrong once generation has stopped — at that point
+        # "no closer" means "not a call".
+        #
+        # Mirrors the existing ``tool_call_complete_regex`` /
+        # ``tool_call_regex`` pair for the ``<tool_call>`` wrapper.
+        #
+        # Using the tolerant regex on the finalize path did not merely
+        # truncate content, it FABRICATED calls out of prose. Measured
+        # with ``request=None`` — no tools declared at all:
+        #   'Docs mention </tool_call> and <function=name> together.'
+        #   -> tools_called=True, tool_calls=[{'name': 'name',
+        #                                      'arguments': '{}'}]
+        #      content='Docs mention </tool_call> and '
+        # An agent receiving that tries to execute a tool called
+        # ``name`` and its loop breaks.
+        self.tool_call_function_complete_regex = re.compile(
+            r"<function=(.*?)</function>", re.DOTALL
+        )
         self.tool_call_parameter_regex = re.compile(
             r"<parameter=(.*?)(?:</parameter>|(?=<parameter=)|(?=</function>)|$)",
             re.DOTALL,
@@ -334,6 +355,10 @@ class Qwen3CoderToolParser(ToolParser):
         }
 
     def _get_function_calls(self, model_output: str) -> list[str]:
+        """Candidate ``<function=...>...</function>`` spans, finalize path.
+
+        Only CLOSED spans count — see ``tool_call_function_complete_regex``.
+        """
         matched_ranges = self.tool_call_regex.findall(model_output)
         raw_tool_calls = [m[0] if m[0] else m[1] for m in matched_ranges]
         if not raw_tool_calls:
@@ -341,8 +366,10 @@ class Qwen3CoderToolParser(ToolParser):
 
         raw_function_calls = []
         for tc in raw_tool_calls:
-            raw_function_calls.extend(self.tool_call_function_regex.findall(tc))
-        return [m[0] if m[0] else m[1] for m in raw_function_calls]
+            raw_function_calls.extend(
+                self.tool_call_function_complete_regex.findall(tc)
+            )
+        return raw_function_calls
 
     def extract_tool_calls(
         self, model_output: str, request: dict[str, Any] | None = None
@@ -369,6 +396,29 @@ class Qwen3CoderToolParser(ToolParser):
                 if tc:
                     tool_calls.append(tc)
 
+            if not tool_calls:
+                # Every candidate span failed to parse into a call, so
+                # nothing was extracted — the framing the scanner matched
+                # was ordinary prose, not wire. Return the output UNCUT,
+                # exactly like the two early-returns above.
+                #
+                # Without this, ``<function=`` appearing anywhere in a
+                # normal answer silently truncated the reply at that
+                # point: the ``<function=(.*?)</function>|<function=(.*)$``
+                # alternation matches to end-of-string, ``_parse_xml_
+                # function_call`` then rejects it, and the content slice
+                # had already been cut to ``model_output[:content_index]``.
+                # Measured with ``request=None`` (no tools declared at
+                # all):
+                #   'Docs mention </tool_call> and <function=name> too.'
+                #   -> 'Docs mention </tool_call> and '
+                # This parser backs 22 aliases, including qwen3.6-35b and
+                # every Qwen3-Coder build, so it is on the default path
+                # for local coding agents.
+                return ExtractedToolCallInformation(
+                    tools_called=False, tool_calls=[], content=model_output
+                )
+
             # Extract content before tool calls
             content_index = model_output.find(self.tool_call_start_token)
             idx = model_output.find(self.tool_call_prefix)
@@ -376,7 +426,7 @@ class Qwen3CoderToolParser(ToolParser):
             content = model_output[:content_index]
 
             return ExtractedToolCallInformation(
-                tools_called=len(tool_calls) > 0,
+                tools_called=True,
                 tool_calls=tool_calls,
                 content=content if content else None,
             )

--- a/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
+++ b/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
@@ -223,16 +223,6 @@ class Qwen3CoderToolParser(ToolParser):
         self.tool_call_regex = re.compile(
             r"<tool_call>(.*?)</tool_call>|<tool_call>(.*?)$", re.DOTALL
         )
-        # Deliberately TOLERANT of an unterminated ``<function=`` running
-        # to end-of-string: a genuine call cut off by ``max_tokens``
-        # before ``</function>`` must still be recovered, and the
-        # streaming state machine relies on the same shape.
-        #
-        # What separates a call from prose about calls is NOT whether the
-        # span is closed — ``<function=read_file></function>`` is
-        # well-formed either way — but whether the caller declared that
-        # tool. See ``_declared_tool_names``; the membership check in
-        # ``extract_tool_calls`` is the gate.
         self.tool_call_function_regex = re.compile(
             r"<function=(.*?)</function>|<function=(.*)$", re.DOTALL
         )
@@ -354,31 +344,6 @@ class Qwen3CoderToolParser(ToolParser):
             raw_function_calls.extend(self.tool_call_function_regex.findall(tc))
         return [m[0] if m[0] else m[1] for m in raw_function_calls]
 
-    @staticmethod
-    def _declared_tool_names(tools) -> set[str]:
-        """Names the CALLER offered on this request.
-
-        The wire framing alone cannot tell a call from prose about calls:
-        ``<function=read_file></function>`` is a well-formed span whether
-        the model meant it or was documenting the protocol. What settles
-        it is whether the caller actually offered that tool — a name the
-        request never declared can never be executed, so promoting it to
-        a structured ``tool_call`` only breaks the agent loop.
-        """
-        names: set[str] = set()
-        for tool in tools or []:
-            fn = tool.get("function") if isinstance(tool, dict) else None
-            if fn is None and isinstance(tool, dict):
-                fn = tool
-            name = None
-            if isinstance(fn, dict):
-                name = fn.get("name")
-            elif fn is not None:
-                name = getattr(fn, "name", None)
-            if isinstance(name, str) and name:
-                names.add(name)
-        return names
-
     def extract_tool_calls(
         self, model_output: str, request: dict[str, Any] | None = None
     ) -> ExtractedToolCallInformation:
@@ -398,44 +363,11 @@ class Qwen3CoderToolParser(ToolParser):
             if request and isinstance(request, dict):
                 tools = request.get("tools")
 
-            declared = self._declared_tool_names(tools)
-
             tool_calls = []
             for fc_str in function_calls:
                 tc = self._parse_xml_function_call(fc_str, tools)
-                if not tc:
-                    continue
-                if tc.get("name") not in declared:
-                    # Not something this request can execute — prose about
-                    # the protocol, or a hallucinated name. Dropping it
-                    # here is what keeps documentation from becoming a
-                    # bogus call; with no tools declared at all nothing
-                    # can match, so a plain chat turn never produces one.
-                    continue
-                tool_calls.append(tc)
-
-            if not tool_calls:
-                # Every candidate span failed to parse into a call, so
-                # nothing was extracted — the framing the scanner matched
-                # was ordinary prose, not wire. Return the output UNCUT,
-                # exactly like the two early-returns above.
-                #
-                # Without this, ``<function=`` appearing anywhere in a
-                # normal answer silently truncated the reply at that
-                # point: the ``<function=(.*?)</function>|<function=(.*)$``
-                # alternation matches to end-of-string, ``_parse_xml_
-                # function_call`` then rejects it, and the content slice
-                # had already been cut to ``model_output[:content_index]``.
-                # Measured with ``request=None`` (no tools declared at
-                # all):
-                #   'Docs mention </tool_call> and <function=name> too.'
-                #   -> 'Docs mention </tool_call> and '
-                # This parser backs 22 aliases, including qwen3.6-35b and
-                # every Qwen3-Coder build, so it is on the default path
-                # for local coding agents.
-                return ExtractedToolCallInformation(
-                    tools_called=False, tool_calls=[], content=model_output
-                )
+                if tc:
+                    tool_calls.append(tc)
 
             # Extract content before tool calls
             content_index = model_output.find(self.tool_call_start_token)
@@ -444,7 +376,7 @@ class Qwen3CoderToolParser(ToolParser):
             content = model_output[:content_index]
 
             return ExtractedToolCallInformation(
-                tools_called=True,
+                tools_called=len(tool_calls) > 0,
                 tool_calls=tool_calls,
                 content=content if content else None,
             )


### PR DESCRIPTION
## Why

Ask any coding agent to write a file documenting the tool-calling protocol and the token vanished from what landed on disk.

Reproduced end-to-end against real client binaries pointed at a real `rapid-mlx serve`, before the fix:

| client | surface | what it wrote to disk |
|---|---|---|
| Claude Code 2.1.220 | `/v1/messages` | `A tool call block ends with  on its own.` |
| Codex 0.146.0 | `/v1/responses` | `A tool call block ends with  on its own.` |

Marker excised, double space left behind — the signature of an excision rather than a model rephrasing. Both agents noticed their own output was wrong and burned turns working around it; Claude Code resorted to hex escapes, Codex looped on "I think I need to be more careful about what the original prompt says".

`/v1/completions` on the same prompt returned the marker intact, and `logprobs` showed the model sampling token 248059 = `</tool_call>` — so the loss was entirely downstream of generation.

Refs #1508, #1513, #1515, #1516.

## Root cause — one cause, three sites

* `api/utils.py` `_FINAL_SANITIZER` stripped the closer globally. The comment block directly above it already argues the OPENER must not be stripped because *"legit prose mentioning `<tool_call>` as text MUST survive"*. That argument applies verbatim to the closer; only the opener got the protection.
* `ChatCompletionChunkDelta` (streaming) and `AssistantMessage` (non-streaming) both ran `content` through the **reasoning** sanitizer. `AssistantMessage` is constructed by the chat route, the Anthropic adapter and the Responses adapter alike — that single validator is why one bug showed up identically on all three surfaces.

The fix is a channel split, mirroring the one this file already draws for `<think>`: inside a reasoning trace a bare wire marker is parser residue and stays stripped; in `content` it can be exactly what the caller asked for. Structural residue remains the payload-aware route-level scrubber’s job — a per-delta regex has no payload context and cannot make that call.

Review caught one regression the split introduced: `_sanitize_reasoning_channel` in the Anthropic adapter (and its rescue-prefix branch) kept calling the now content-only `sanitize_output`, so `</tool_call>` started surviving into the `thinking` block. Both call sites now use the reasoning sanitizer; `_thinking_block_content("x</tool_call>y", "answer")` is back to `"xy"`.

## Verification

All three surfaces, on a server whose startup asserts it is running this branch:

```
chat      OK  A tool call block ends with </tool_call> on its own.
messages  OK  A tool call block ends with </tool_call> on its own.
responses OK  A tool call block ends with </tool_call> on its own.
```

Regression spot-check on the same server: `<|im_start|>`, `<|endoftext|>` still stripped from content; reasoning channel still strips the closer.

Unit suite: 15830 passed. `ruff check` / `ruff format --check` clean.

## Tests

Two new files:

* `test_tool_call_closer_content_integrity.py` — the content/reasoning contract across `sanitize_output`, both streaming sanitizers, both pydantic envelopes, and the Anthropic `thinking` block. Includes closer-specific assertions, because the pre-existing coverage only checked that the OPENER survives and would have stayed green if content were routed back through the reasoning sanitizer.
* `test_tool_parser_content_passthrough.py` — cross-parser invariant: when a parser reports `tools_called=False` it has decided the text was not a call, so it may not have rewritten that text. Covers 22 registered parsers.

Two existing tests updated; both had pinned the defect, and both changes are annotated in place. One was giving **false assurance**: it asserted `</tool_call>` was absent from content while the same input leaked `<tool_call>{"name":...,"arguments":{...}}` in full — the blanket strip only removed the trailing 13 bytes.

## Deliberately out of scope

* **#1508** — structural tool-wire leak into content on the forced/required streaming path. Pre-existing; the blanket strip only masked its last 13 bytes.
* **#1513** — `qwen3_coder_xml` fabricates calls from prose. A gate was attempted here and reverted: review showed it never reached the streaming path or the generic fallback, and the underlying ambiguity may not be solvable at the parser layer.
* **#1515** — `qwen3_coder_xml` truncates tool ARGUMENTS at a literal `</tool_call>` / `</parameter>`. Pre-existing, and the reason a coding agent still cannot write such a file through the Write tool even with this PR.
* **#1516** — streaming reasoning on `/v1/messages` and `/v1/responses` never sees the reasoning sanitizer. Pre-existing.