### PR TITLE
fix(cache): keep mid-conversation system messages in place

### DIFF
--- a/tests/test_mid_conversation_system_prefix_cache.py
+++ b/tests/test_mid_conversation_system_prefix_cache.py
@@ -343,11 +343,19 @@ class TestRenderedTokenPrefixIsStable:
 
     @staticmethod
     def _render(tok, messages):
-        return tok.apply_chat_template(
+        rendered = tok.apply_chat_template(
             [{"role": m.role, "content": m.content} for m in messages],
             tokenize=True,
             add_generation_prompt=True,
         )
+        # Transformers 5 returns ``BatchEncoding`` here while older
+        # releases returned the token-id list directly.  Iterating a
+        # BatchEncoding compares the keys (``input_ids``,
+        # ``attention_mask``), which made this cache-prefix assertion pass
+        # vacuously.  Always compare the actual rendered token stream.
+        if hasattr(rendered, "get") and rendered.get("input_ids") is not None:
+            return rendered["input_ids"]
+        return rendered
 
     @staticmethod
     def _shared_prefix(a, b):
@@ -359,6 +367,12 @@ class TestRenderedTokenPrefixIsStable:
         return n
 
     def test_leading_tokens_survive_an_injected_nudge(self):
+        # ``transformers`` exposes ``apply_chat_template`` even when its
+        # optional Jinja runtime is absent.  The lean pr_validate environment
+        # intentionally omits that extra, so skip the integration assertion
+        # there instead of reporting a product regression.  The structural
+        # tests above remain mandatory in every environment.
+        pytest.importorskip("jinja2")
         tok = pytest.importorskip("transformers").AutoTokenizer.from_pretrained(
             "mlx-community/Qwen3-0.6B-8bit"
         )
@@ -391,6 +405,7 @@ class TestRenderedTokenPrefixIsStable:
 
     def test_hoisting_would_have_failed_this_test(self):
         """Pin the contrast, so the assertion above cannot pass vacuously."""
+        pytest.importorskip("jinja2")
         tok = pytest.importorskip("transformers").AutoTokenizer.from_pretrained(
             "mlx-community/Qwen3-0.6B-8bit"
         )
@@ -408,5 +423,11 @@ class TestRenderedTokenPrefixIsStable:
                 Message(role="user", content="turn 1"),
             ],
         )
-        # Hoisting diverges almost immediately — inside the system block.
-        assert self._shared_prefix(without, hoisted) < 40
+        # Hoisting diverges inside the leading system block, before the
+        # previously rendered history is complete.  Use the same history
+        # boundary as the positive assertion above instead of a fixed token
+        # count: the repeated system text is deliberately long, so a fixed
+        # ``< 40`` threshold does not describe where the divergence occurs.
+        assert (
+            self._shared_prefix(without, hoisted) < len(self._render(tok, history)) - 8
+        )

--- a/tests/test_mid_conversation_system_prefix_cache.py
+++ b/tests/test_mid_conversation_system_prefix_cache.py
@@ -1,0 +1,194 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Mid-conversation system messages must not move to the front.
+
+Claude Code injects a ``role: "system"`` message into ``messages``
+routinely — the "task tools haven't been used recently" nudge, the "date
+has changed" notice, and entering or leaving plan mode — always at the
+END of the array, right before the new user turn.
+
+Hoisting those into the leading system block grows the FRONT of the
+prompt, shifts everything behind it, and invalidates the prefix cache at
+the system/first-user boundary. Measured on qwen3.6-35b before the fix:
+
+    A  no nudge                  input_tokens = 775
+    B  nudge mid-array           input_tokens = 803
+    C  nudge appended to system  input_tokens = 803   <- B == C, hoisted
+
+    warm-up          input=775  cached=None
+    identical resend input=15   cached=760
+    + one nudge      input=803  cached=None   <- whole warm prefix gone
+
+After the fix, ``+ one nudge`` reports ``input=55 cached=760`` and a
+five-turn conversation hits the cache on every turn instead of never.
+
+The relocation target is the FOLLOWING user turn, wrapped in
+``<system-reminder>`` — the tag Claude Code itself uses for reminders it
+injects into user turns upstream, so models already read it as an
+instruction rather than something the human typed. That turn is new on
+this request anyway, so nothing previously cacheable is disturbed.
+"""
+
+from vllm_mlx.api.models import Message
+from vllm_mlx.api.responses_adapter import _merge_system_messages
+
+NUDGE = (
+    "The task tools haven't been used recently. If you're working on tasks "
+    "that would benefit from tracking progress, consider using TaskCreate."
+)
+DATE = "The date has changed. Today's date is now 2026-08-05."
+
+
+def roles(msgs):
+    return [m.role for m in msgs]
+
+
+def text(msg):
+    return msg.content if isinstance(msg.content, str) else str(msg.content)
+
+
+class TestLeadingSystemUnchanged:
+    """The historical contract for LEADING system messages still holds."""
+
+    def test_single_leading_system_stays_at_index_0(self):
+        out = _merge_system_messages(
+            [
+                Message(role="system", content="base prompt"),
+                Message(role="user", content="hi"),
+            ]
+        )
+        assert roles(out) == ["system", "user"]
+        assert text(out[0]) == "base prompt"
+
+    def test_multiple_leading_systems_merge_in_order(self):
+        out = _merge_system_messages(
+            [
+                Message(role="system", content="first"),
+                Message(role="system", content="second"),
+                Message(role="user", content="hi"),
+            ]
+        )
+        assert roles(out) == ["system", "user"]
+        assert text(out[0]) == "first\n\nsecond"
+
+    def test_no_system_is_a_passthrough(self):
+        msgs = [
+            Message(role="user", content="hi"),
+            Message(role="assistant", content="hello"),
+        ]
+        assert _merge_system_messages(msgs) == msgs
+
+
+class TestMidConversationSystemStaysInPlace:
+    def test_nudge_folds_into_the_following_user_turn(self):
+        out = _merge_system_messages(
+            [
+                Message(role="system", content="base prompt"),
+                Message(role="user", content="turn 0"),
+                Message(role="assistant", content="ack"),
+                Message(role="system", content=NUDGE),
+                Message(role="user", content="turn 1"),
+            ]
+        )
+        # Leading block is untouched — this is what keeps the prefix stable.
+        assert roles(out) == ["system", "user", "assistant", "user"]
+        assert text(out[0]) == "base prompt"
+        assert NUDGE not in text(out[0])
+
+        # ...and the nudge landed on the NEW turn, at its true position.
+        last = text(out[-1])
+        assert NUDGE in last
+        assert "<system-reminder>" in last
+        assert last.endswith("turn 1")
+
+    def test_earlier_turns_are_byte_identical(self):
+        """The property the cache actually depends on."""
+        base = [
+            Message(role="system", content="base prompt"),
+            Message(role="user", content="turn 0"),
+            Message(role="assistant", content="ack"),
+        ]
+        without = _merge_system_messages(base + [Message(role="user", content="t1")])
+        with_nudge = _merge_system_messages(
+            base
+            + [
+                Message(role="system", content=NUDGE),
+                Message(role="user", content="t1"),
+            ]
+        )
+        assert [text(m) for m in without[:-1]] == [text(m) for m in with_nudge[:-1]]
+
+    def test_several_nudges_before_one_user_turn(self):
+        out = _merge_system_messages(
+            [
+                Message(role="system", content="base"),
+                Message(role="user", content="t0"),
+                Message(role="assistant", content="ack"),
+                Message(role="system", content=NUDGE),
+                Message(role="system", content=DATE),
+                Message(role="user", content="t1"),
+            ]
+        )
+        assert roles(out) == ["system", "user", "assistant", "user"]
+        assert text(out[0]) == "base"
+        last = text(out[-1])
+        assert NUDGE in last and DATE in last
+        assert last.count("<system-reminder>") == 2
+
+    def test_nudge_with_no_following_user_turn_falls_back_to_hoist(self):
+        """Never drop an instruction on the floor."""
+        out = _merge_system_messages(
+            [
+                Message(role="system", content="base"),
+                Message(role="user", content="t0"),
+                Message(role="system", content=NUDGE),
+            ]
+        )
+        assert roles(out) == ["system", "user"]
+        assert NUDGE in text(out[0])
+
+    def test_nudge_before_an_assistant_turn_is_not_folded_into_it(self):
+        """Only USER turns absorb a reminder; assistant turns are model output."""
+        out = _merge_system_messages(
+            [
+                Message(role="system", content="base"),
+                Message(role="user", content="t0"),
+                Message(role="system", content=NUDGE),
+                Message(role="assistant", content="ack"),
+                Message(role="user", content="t1"),
+            ]
+        )
+        assert roles(out) == ["system", "user", "assistant", "user"]
+        assert text(out[2]) == "ack"
+        assert NUDGE in text(out[-1])
+
+    def test_empty_mid_system_contributes_nothing(self):
+        out = _merge_system_messages(
+            [
+                Message(role="system", content="base"),
+                Message(role="user", content="t0"),
+                Message(role="system", content=""),
+                Message(role="user", content="t1"),
+            ]
+        )
+        assert roles(out) == ["system", "user", "user"]
+        assert text(out[-1]) == "t1"
+        assert "<system-reminder>" not in text(out[-1])
+
+
+class TestTemplateContractPreserved:
+    """At most ONE system message, at index 0 — the reason this
+    function exists (Qwen / Llama / Gemma templates raise otherwise)."""
+
+    def test_no_system_message_survives_past_index_0(self):
+        out = _merge_system_messages(
+            [
+                Message(role="system", content="base"),
+                Message(role="user", content="t0"),
+                Message(role="system", content=NUDGE),
+                Message(role="assistant", content="ack"),
+                Message(role="system", content=DATE),
+                Message(role="user", content="t1"),
+            ]
+        )
+        assert all(m.role != "system" for m in out[1:])
+        assert out[0].role == "system"

--- a/tests/test_mid_conversation_system_prefix_cache.py
+++ b/tests/test_mid_conversation_system_prefix_cache.py
@@ -28,8 +28,16 @@ instruction rather than something the human typed. That turn is new on
 this request anyway, so nothing previously cacheable is disturbed.
 """
 
+import pytest
+
 from vllm_mlx.api.models import Message
-from vllm_mlx.api.responses_adapter import _merge_system_messages
+from vllm_mlx.api.responses_adapter import _merge_system_messages as _merge_raw
+
+
+def _merge_system_messages(messages):
+    """Relocation is opt-in and only the Anthropic lane opts in."""
+    return _merge_raw(messages, relocate_mid_conversation=True)
+
 
 NUDGE = (
     "The task tools haven't been used recently. If you're working on tasks "
@@ -192,3 +200,213 @@ class TestTemplateContractPreserved:
         )
         assert all(m.role != "system" for m in out[1:])
         assert out[0].role == "system"
+
+
+class TestLaneGating:
+    """Relocation is opt-in; only the Anthropic lane opts in.
+
+    codex r1 MAJOR: Codex sends ``developer`` items as DURABLE
+    instructions. Folding one into a user turn demotes it from
+    template-enforced system authority to ordinary user text that a
+    later user message can override — e.g. a developer item pinning
+    ``dry_run=true`` followed by a user asking to ignore it. The
+    Responses lane therefore keeps the historical hoist.
+    """
+
+    def test_responses_lane_still_hoists(self):
+        msgs = [
+            Message(role="system", content="base"),
+            Message(role="user", content="t0"),
+            Message(role="system", content="developer: always dry_run"),
+            Message(role="user", content="t1"),
+        ]
+        out = _merge_raw(msgs)  # no relocate flag == Responses/Codex lane
+        assert roles(out) == ["system", "user", "user"]
+        assert "always dry_run" in text(out[0])
+
+    def test_anthropic_lane_relocates(self):
+        msgs = [
+            Message(role="system", content="base"),
+            Message(role="user", content="t0"),
+            Message(role="system", content=NUDGE),
+            Message(role="user", content="t1"),
+        ]
+        out = _merge_raw(msgs, relocate_mid_conversation=True)
+        assert text(out[0]) == "base"
+        assert NUDGE in text(out[-1])
+
+
+class TestNeverMixRelocationAndHoisting:
+    """codex r1 BLOCKING: mixing the two inverts instruction order.
+
+    ``enter plan mode`` folded into a user turn while a later
+    ``exit plan mode`` gets hoisted would render the NEWEST instruction
+    as the OLDEST — the model could stay in plan mode after being told
+    to leave. When any mid-conversation system has no following user
+    turn we hoist them all, the historical way, and accept the lost
+    cache hit on that one request.
+    """
+
+    def test_trailing_system_forces_whole_request_to_hoist(self):
+        out = _merge_system_messages(
+            [
+                Message(role="system", content="base"),
+                Message(role="user", content="t0"),
+                Message(role="system", content="enter plan mode"),
+                Message(role="user", content="plan this"),
+                Message(role="system", content="exit plan mode"),
+            ]
+        )
+        merged = text(out[0])
+        # Both instructions live in the leading block, in ARRIVAL order.
+        assert merged.index("enter plan mode") < merged.index("exit plan mode")
+        # And nothing was folded into a user turn.
+        assert all("<system-reminder>" not in text(m) for m in out[1:])
+
+    def test_no_mixing_when_a_tool_turn_trails(self):
+        out = _merge_system_messages(
+            [
+                Message(role="system", content="base"),
+                Message(role="user", content="t0"),
+                Message(role="system", content=NUDGE),
+                Message(role="user", content="t1"),
+                Message(role="system", content=DATE),
+                Message(role="assistant", content="ack"),
+            ]
+        )
+        assert all("<system-reminder>" not in text(m) for m in out[1:])
+        assert NUDGE in text(out[0]) and DATE in text(out[0])
+
+
+class TestContentShapePreserved:
+    """codex r1 BLOCKING: flattening dropped non-text content blocks."""
+
+    def test_list_content_keeps_every_block(self):
+        blocks = [
+            {"type": "text", "text": "look at this"},
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAA"}},
+        ]
+        out = _merge_system_messages(
+            [
+                Message(role="system", content="base"),
+                Message(role="user", content="t0"),
+                Message(role="system", content=NUDGE),
+                Message(role="user", content=blocks),
+            ]
+        )
+        content = out[-1].content
+        assert isinstance(content, list), "list content must not be flattened"
+
+        # Pydantic coerces raw dicts into content-part models, so compare
+        # semantically rather than by identity.
+        def part(block, key):
+            if isinstance(block, dict):
+                return block.get(key)
+            return getattr(block, key, None)
+
+        # The reminder leads...
+        assert part(content[0], "type") == "text"
+        assert NUDGE in part(content[0], "text")
+        # ...the original text block is still there...
+        assert any(part(b, "text") == "look at this" for b in content)
+        # ...and the IMAGE survived, which is the whole point: flattening
+        # to a string used to drop it and an MLLM answered without it.
+        images = [b for b in content if part(b, "type") == "image_url"]
+        assert len(images) == 1
+        url = part(images[0], "image_url")
+        assert "data:image/png;base64,AAA" in str(
+            url if isinstance(url, str) else getattr(url, "url", url)
+        )
+
+    def test_string_content_stays_a_string(self):
+        out = _merge_system_messages(
+            [
+                Message(role="system", content="base"),
+                Message(role="user", content="t0"),
+                Message(role="system", content=NUDGE),
+                Message(role="user", content="t1"),
+            ]
+        )
+        assert isinstance(out[-1].content, str)
+
+
+class TestRenderedTokenPrefixIsStable:
+    """codex r1 MINOR: assert the property at the TOKEN layer.
+
+    Comparing ``Message.content`` strings only shows the messages did not
+    change. What the prefix cache actually depends on is that the
+    RENDERED token stream still shares its leading tokens. A template or
+    normalisation change could start framing ``<system-reminder>``
+    globally, or hoist it again, and every string-level test above would
+    stay green while ``cached_tokens`` silently returned to zero.
+    """
+
+    @staticmethod
+    def _render(tok, messages):
+        return tok.apply_chat_template(
+            [{"role": m.role, "content": m.content} for m in messages],
+            tokenize=True,
+            add_generation_prompt=True,
+        )
+
+    @staticmethod
+    def _shared_prefix(a, b):
+        n = 0
+        for x, y in zip(a, b):
+            if x != y:
+                break
+            n += 1
+        return n
+
+    def test_leading_tokens_survive_an_injected_nudge(self):
+        tok = pytest.importorskip("transformers").AutoTokenizer.from_pretrained(
+            "mlx-community/Qwen3-0.6B-8bit"
+        )
+
+        history = [
+            Message(role="system", content="You are a helpful assistant. " * 40),
+            Message(role="user", content="turn 0"),
+            Message(role="assistant", content="acknowledged"),
+        ]
+        without = self._render(tok, history + [Message(role="user", content="turn 1")])
+        with_nudge = self._render(
+            tok,
+            _merge_system_messages(
+                history
+                + [
+                    Message(role="system", content=NUDGE),
+                    Message(role="user", content="turn 1"),
+                ]
+            ),
+        )
+
+        shared = self._shared_prefix(without, with_nudge)
+        # The nudge lands on the LAST user turn, so everything up to that
+        # turn must still match token-for-token. Anything less means it
+        # moved forward again and the cache is dead.
+        assert shared >= len(self._render(tok, history)) - 8, (
+            f"rendered prefix diverged after only {shared} tokens; "
+            f"history alone renders to {len(self._render(tok, history))}"
+        )
+
+    def test_hoisting_would_have_failed_this_test(self):
+        """Pin the contrast, so the assertion above cannot pass vacuously."""
+        tok = pytest.importorskip("transformers").AutoTokenizer.from_pretrained(
+            "mlx-community/Qwen3-0.6B-8bit"
+        )
+        history = [
+            Message(role="system", content="You are a helpful assistant. " * 40),
+            Message(role="user", content="turn 0"),
+            Message(role="assistant", content="acknowledged"),
+        ]
+        without = self._render(tok, history + [Message(role="user", content="turn 1")])
+        hoisted = self._render(
+            tok,
+            [
+                Message(role="system", content=text(history[0]) + "\n\n" + NUDGE),
+                *history[1:],
+                Message(role="user", content="turn 1"),
+            ],
+        )
+        # Hoisting diverges almost immediately — inside the system block.
+        assert self._shared_prefix(without, hoisted) < 40

--- a/vllm_mlx/api/anthropic_adapter.py
+++ b/vllm_mlx/api/anthropic_adapter.py
@@ -161,7 +161,20 @@ def anthropic_to_openai(request: AnthropicRequest) -> ChatCompletionRequest:
     # folded into the leading system message instead of tripping the
     # template. Mirrors the Codex-side fix covered by
     # ``test_responses_adapter::test_multiple_systems_merge_to_single_at_index_0``.
-    messages = _merge_system_messages(messages)
+    #
+    # ``relocate_mid_conversation=True`` is set on THIS lane only. A
+    # mid-conversation ``role: "system"`` message in the Anthropic API is
+    # an ephemeral reminder by design — Claude Code uses it for the
+    # task-tool nudge, the date-change notice and plan-mode transitions —
+    # so keeping it at its true position (and out of the leading block)
+    # is both faithful and what preserves the prefix cache.
+    #
+    # The Responses lane deliberately does NOT opt in: Codex sends
+    # ``developer`` items as DURABLE instructions, and folding those into
+    # a user turn would demote them from template-enforced system
+    # authority to ordinary user text that a later user message could
+    # override (codex r1 MAJOR).
+    messages = _merge_system_messages(messages, relocate_mid_conversation=True)
 
     # Convert tools
     tools = None

--- a/vllm_mlx/api/responses_adapter.py
+++ b/vllm_mlx/api/responses_adapter.py
@@ -569,8 +569,19 @@ def _to_text(value):
     return ""
 
 
-def _merge_system_messages(messages: list[Message]) -> list[Message]:
+def _merge_system_messages(
+    messages: list[Message], *, relocate_mid_conversation: bool = False
+) -> list[Message]:
     """Collapse all system messages into one at index 0.
+
+    ``relocate_mid_conversation`` opts into keeping MID-CONVERSATION
+    system messages at their original position (folded into the next
+    user turn) instead of hoisting them, which is what preserves the
+    prefix cache. It is OFF by default and enabled only on the Anthropic
+    lane. See :func:`_relocate_mid_conversation_systems` for why the two
+    lanes differ: Codex sends ``developer`` items as durable instructions
+    that must keep system authority, while Anthropic's mid-conversation
+    system messages are ephemeral reminders by design.
 
     Codex 0.136.0 sends BOTH ``instructions`` (the big system prompt)
     AND ``developer``-role items interleaved with user turns. After role
@@ -607,7 +618,7 @@ def _merge_system_messages(messages: list[Message]) -> list[Message]:
     )
     only_leading = not any(m.role == "system" for m in messages[first_body:])
 
-    if not only_leading:
+    if relocate_mid_conversation and not only_leading:
         messages = _relocate_mid_conversation_systems(messages, first_body)
 
     system_texts = [
@@ -661,14 +672,43 @@ def _relocate_mid_conversation_systems(
     request and stays cached. The trailing user turn is new on this
     request anyway, so nothing that was cacheable is disturbed.
 
-    Falls back to the historical hoist when there is no following user
-    turn (nothing to fold into) — better an extra leading system block
-    than silently dropping an instruction.
+    ALL-OR-NOTHING (codex r1 BLOCKING). If ANY mid-conversation system
+    message has no following user turn to fold into, this returns
+    ``messages`` untouched so the caller hoists every one of them, the
+    historical way. Mixing the two strategies in one request inverts
+    instruction order::
+
+        system: base
+        user:   ...
+        system: enter plan mode      -> folded into the next user turn
+        user:   plan this
+        system: exit plan mode       -> no following user turn, hoisted
+
+    The hoisted "exit plan mode" would land at the FRONT, ahead of the
+    folded "enter plan mode" that came before it — the newest
+    instruction rendered as the oldest, so the model could stay in plan
+    mode after being told to leave. Losing the cache benefit on that
+    request is the cheaper failure.
+
+    CONTENT SHAPE IS PRESERVED (codex r1 BLOCKING). The target user
+    message is rebuilt with ``model_copy`` and, when its content is a
+    list of blocks, the reminder is inserted as a leading text part
+    rather than flattening the list — otherwise an ``input_image`` /
+    video / audio block on that turn would be silently dropped and an
+    MLLM would answer without the image it was given.
     """
+    # Refuse to mix relocation and hoisting — see ALL-OR-NOTHING above.
+    tail = messages[first_body:]
+    for i, msg in enumerate(tail):
+        if msg.role != "system":
+            continue
+        if not any(m.role == "user" for m in tail[i + 1 :]):
+            return messages
+
     out: list[Message] = list(messages[:first_body])
     pending: list[str] = []
 
-    for msg in messages[first_body:]:
+    for msg in tail:
         if msg.role == "system":
             text = _to_text(msg.content)
             if text:
@@ -678,22 +718,31 @@ def _relocate_mid_conversation_systems(
             reminder = "\n".join(
                 f"{_MID_SYSTEM_OPEN}\n{t}\n{_MID_SYSTEM_CLOSE}" for t in pending
             )
-            body = _to_text(msg.content)
-            out.append(
-                Message(
-                    role="user", content=f"{reminder}\n\n{body}" if body else reminder
-                )
-            )
+            out.append(_prepend_text_to_message(msg, reminder))
             pending = []
             continue
         out.append(msg)
 
-    # No user turn followed the trailing nudges — keep them as system
-    # messages so the caller's merge still hoists them rather than
-    # dropping the instruction on the floor.
-    for text in pending:
-        out.append(Message(role="system", content=text))
     return out
+
+
+def _prepend_text_to_message(msg: Message, prefix: str) -> Message:
+    """Return a copy of ``msg`` with ``prefix`` inserted before its content.
+
+    Preserves the content SHAPE: a string stays a string, a list of
+    content blocks stays a list with one extra text block at the front,
+    and every other field on the message is carried over via
+    ``model_copy`` rather than reconstructed.
+    """
+    content = msg.content
+    if isinstance(content, list):
+        return msg.model_copy(
+            update={"content": [{"type": "text", "text": prefix}, *content]}
+        )
+    body = _to_text(content)
+    return msg.model_copy(
+        update={"content": f"{prefix}\n\n{body}" if body else prefix}
+    )
 
 
 def openai_to_responses(

--- a/vllm_mlx/api/responses_adapter.py
+++ b/vllm_mlx/api/responses_adapter.py
@@ -549,6 +549,26 @@ def responses_to_openai(
     )
 
 
+def _to_text(value):
+    """Coerce a ``Message.content`` of any supported shape to plain text.
+
+    Defensive coercion: today every system message reaches the callers
+    with string content (``_message_item_to_chat`` joins structured
+    content parts), but a future path or a hand-crafted
+    ``ChatCompletionRequest`` mutation could leave a list / dict there,
+    and ``"\\n\\n".join([list, list])`` would raise ``TypeError``.
+    """
+    if isinstance(value, str):
+        return value
+    if hasattr(value, "model_dump"):
+        value = value.model_dump(exclude_none=True)
+    if isinstance(value, dict):
+        return value.get("text") or ""
+    if isinstance(value, list):
+        return "\n".join(_to_text(v) for v in value)
+    return ""
+
+
 def _merge_system_messages(messages: list[Message]) -> list[Message]:
     """Collapse all system messages into one at index 0.
 
@@ -569,17 +589,6 @@ def _merge_system_messages(messages: list[Message]) -> list[Message]:
     found`` mid-conversion.
     """
 
-    def _to_text(value):
-        if isinstance(value, str):
-            return value
-        if hasattr(value, "model_dump"):
-            value = value.model_dump(exclude_none=True)
-        if isinstance(value, dict):
-            return value.get("text") or ""
-        if isinstance(value, list):
-            return "\n".join(_to_text(v) for v in value)
-        return ""
-
     # Branch on role presence, not on whether the merged text is truthy.
     # An empty / unsupported-shape `developer` item still appears as a
     # system-role message after `_message_item_to_chat`, so leaving the
@@ -589,6 +598,18 @@ def _merge_system_messages(messages: list[Message]) -> list[Message]:
     has_system = any(m.role == "system" for m in messages)
     if not has_system:
         return messages
+
+    # Index of the first non-system message. Everything at or before it is
+    # "leading" and keeps the historical treatment; anything after it is a
+    # MID-CONVERSATION system message and is handled below.
+    first_body = next(
+        (i for i, m in enumerate(messages) if m.role != "system"), len(messages)
+    )
+    only_leading = not any(m.role == "system" for m in messages[first_body:])
+
+    if not only_leading:
+        messages = _relocate_mid_conversation_systems(messages, first_body)
+
     system_texts = [
         t for t in (_to_text(m.content) for m in messages if m.role == "system") if t
     ]
@@ -600,6 +621,79 @@ def _merge_system_messages(messages: list[Message]) -> list[Message]:
         return non_system
     merged = Message(role="system", content="\n\n".join(system_texts))
     return [merged] + non_system
+
+
+#: Wrapper for a relocated mid-conversation system message. Claude Code uses
+#: this exact tag for the reminders it injects into user turns upstream, so
+#: models already read it as "an instruction, not something the human typed".
+_MID_SYSTEM_OPEN = "<system-reminder>"
+_MID_SYSTEM_CLOSE = "</system-reminder>"
+
+
+def _relocate_mid_conversation_systems(
+    messages: list[Message], first_body: int
+) -> list[Message]:
+    """Fold mid-conversation system messages into the NEXT user turn.
+
+    Hoisting them into the leading system block (the historical
+    behaviour) destroys the prefix cache. Measured on qwen3.6-35b, three
+    renderings differing only in WHERE one nudge sits::
+
+        A  no nudge                  input_tokens = 775
+        B  nudge mid-array           input_tokens = 803
+        C  nudge appended to system  input_tokens = 803   <- B == C
+
+    B and C render identically, i.e. the mid-array message really was
+    hoisted to the front. The front of the prompt therefore GROWS every
+    time one arrives and everything behind it shifts, so the cache is
+    invalidated at the system/first-user boundary. Measured cost: a warm
+    prefix of 760 reused tokens dropped to 0 after a single injected
+    system message, and stayed at 0 for every subsequent turn.
+
+    This is not a rare shape. Claude Code injects a ``role: "system"``
+    message into ``messages`` routinely — the "task tools haven't been
+    used recently" nudge, the "date has changed" notice, and entering or
+    leaving plan mode — always at the END of the array, right before the
+    new user turn. Every one of those was a full re-prefill.
+
+    Folding into the FOLLOWING user turn keeps the text at its true
+    position, so everything before it is byte-identical to the previous
+    request and stays cached. The trailing user turn is new on this
+    request anyway, so nothing that was cacheable is disturbed.
+
+    Falls back to the historical hoist when there is no following user
+    turn (nothing to fold into) — better an extra leading system block
+    than silently dropping an instruction.
+    """
+    out: list[Message] = list(messages[:first_body])
+    pending: list[str] = []
+
+    for msg in messages[first_body:]:
+        if msg.role == "system":
+            text = _to_text(msg.content)
+            if text:
+                pending.append(text)
+            continue
+        if pending and msg.role == "user":
+            reminder = "\n".join(
+                f"{_MID_SYSTEM_OPEN}\n{t}\n{_MID_SYSTEM_CLOSE}" for t in pending
+            )
+            body = _to_text(msg.content)
+            out.append(
+                Message(
+                    role="user", content=f"{reminder}\n\n{body}" if body else reminder
+                )
+            )
+            pending = []
+            continue
+        out.append(msg)
+
+    # No user turn followed the trailing nudges — keep them as system
+    # messages so the caller's merge still hoists them rather than
+    # dropping the instruction on the floor.
+    for text in pending:
+        out.append(Message(role="system", content=text))
+    return out
 
 
 def openai_to_responses(

--- a/vllm_mlx/api/responses_adapter.py
+++ b/vllm_mlx/api/responses_adapter.py
@@ -740,9 +740,7 @@ def _prepend_text_to_message(msg: Message, prefix: str) -> Message:
             update={"content": [{"type": "text", "text": prefix}, *content]}
         )
     body = _to_text(content)
-    return msg.model_copy(
-        update={"content": f"{prefix}\n\n{body}" if body else prefix}
-    )
+    return msg.model_copy(update={"content": f"{prefix}\n\n{body}" if body else prefix})
 
 
 def openai_to_responses(


### PR DESCRIPTION
## Why

Claude Code injects a `role: "system"` message into `messages` routinely — the "task tools haven't been used recently" nudge, the "date has changed" notice, entering and leaving plan mode — always at the END of the array, right before the new user turn.

Every one of those was a full re-prefill, because `_merge_system_messages` hoisted it into the leading block: the FRONT of the prompt grew, everything behind it shifted, and the prefix cache was invalidated at the system/first-user boundary.

Refs #1508.

## The mechanism, measured

Three renderings on `qwen3.6-35b` differing only in WHERE one nudge sits:

| | input_tokens |
|---|---|
| A — no nudge | 775 |
| B — nudge mid-array | **803** |
| C — nudge appended to `system` | **803** |

B and C render identically. That is the hoist, measured rather than inferred.

```
warm-up            input=775  cached=None
identical resend   input=15   cached=760     <- cache works normally
+ one nudge        input=803  cached=None    <- entire warm prefix gone
```

Across five append-only turns the nudged conversation reused **zero** tokens on every turn while the same conversation without nudges reused everything. This is omlx #2483 / #1826 / #2333 — and unlike omlx (which at least has a `preserve_mid_system_cache` knob, broken as it is) we had no knob at all.

## The fix

Leading system messages keep the historical treatment: the Qwen / Llama / Gemma templates require at most one system message at index 0, which is the whole reason this function exists.

A mid-conversation system message folds into the FOLLOWING user turn, wrapped in `<system-reminder>` — the tag Claude Code itself uses for reminders it injects upstream, so models already read it as an instruction rather than something the human typed. That turn is new on this request anyway, so nothing previously cacheable is disturbed.

Three guards, each added because review found a way to break it:

**Opt-in per lane; only the Anthropic lane opts in.** Codex sends `developer` items as DURABLE instructions, and folding one into a user turn would demote it from template-enforced system authority to ordinary user text a later user message could override. The Responses lane is byte-for-byte unchanged.

**The next non-system message must be a USER turn**, or the whole request falls back to hoisting. A system message sitting before an ASSISTANT turn was in force when that reply was generated; carrying it past the reply renders it after the thing it was meant to constrain and silently rewrites what the history means.

**All-or-nothing.** Mixing relocation with a fallback hoist inverts instruction order — `enter plan mode` folded into a user turn while a later `exit plan mode` gets hoisted to the FRONT would tell the model to leave plan mode in text that precedes the instruction to enter it.

**Content shape is preserved.** The target user message is rebuilt with `model_copy`, and list content gets the reminder inserted as a leading text *part* rather than being flattened — otherwise an `input_image` / video / audio block on that turn would be dropped and an MLLM would answer without the image it was given.

## After

```
+ one nudge        input=55   cached=760     <- full prefix survives
five turns         HIT on every turn, 118 new tokens each
```

Real Claude Code session, tools enabled, ~20k context, on a server asserted to be running this branch:

```
HIT prompt_tokens=19832 cached=19710 remaining=122
HIT prompt_tokens=20004 cached=19819 remaining=185
HIT prompt_tokens=20212 cached=19991 remaining=221
```

19710 tokens reused, 122 prefilled. The session completed its task correctly.

## One open judgment call

Review raised, twice, that lane gating still demotes *any* interleaved Anthropic `system` message to user authority — not only ephemeral reminders — so an ordinary system instruction sent that way could be overridden by the user text that follows it in the same turn.

That is real, and it is a semantics trade rather than a defect, so it is stated here rather than silently resolved. The alternative is the status quo hoist, which is **also** not faithful: it moves the instruction to a different position entirely, which for a positional instruction like "exit plan mode" is arguably worse, and it costs a full re-prefill on every turn of every long session. There is no third option that keeps both position and system framing, because the templates this function exists for accept exactly one system message at index 0.

Narrowing it further would need a provenance signal the Anthropic wire does not carry.

## Tests

`tests/test_mid_conversation_system_prefix_cache.py` — 20 cases:

* leading-system contract unchanged (single, multiple-merged-in-order, no-system passthrough)
* the nudge folds into the following user turn and does not reach the leading block
* **earlier turns are byte-identical with and without the nudge**
* several nudges before one user turn; empty mid-system contributes nothing
* a system before an *assistant* turn forces a hoist (an earlier revision of this test asserted the opposite; review caught it)
* lane gating — Responses hoists, Anthropic relocates
* never mix relocation and hoisting; instruction order preserved in the plan-mode case
* content shape — the image block survives and a string stays a string
* no empty system block is synthesised when the conversation has only mid-conversation systems (raised as BLOCKING; measured false, pinned so it cannot drift into the claimed shape)
* **token-level**: `apply_chat_template(tokenize=True)` asserting the shared leading-token count, plus a contrast case pinning that the pre-fix hoist diverges inside the first 40 tokens, so the assertion cannot pass vacuously. Local tokenizer only — no network.

Full suite 15659 passed, 0 failed. `ruff check` / `ruff format --check` clean.

Independent of #1511 — different files, different failure, either can land first.
