### PR TITLE
fix: land three review fixes that missed the #1511/#1512 merges

### DIFF
--- a/tests/test_adapters_import_without_mlx.py
+++ b/tests/test_adapters_import_without_mlx.py
@@ -1,0 +1,131 @@
+# SPDX-License-Identifier: Apache-2.0
+"""The wire adapters must work on a machine with no MLX.
+
+``anthropic_to_openai`` is a pure message-shape translation: Anthropic
+JSON in, OpenAI JSON out. No weights, no Metal, no engine. The whole
+``TestAnthropicToOpenai`` suite has always run on Linux CI for exactly
+that reason.
+
+Then this PR taught the adapter to consult ``get_config()`` for the
+mid-conversation-system flag, and ``vllm_mlx.config`` transitively did::
+
+    config/__init__ -> config.server_config -> engine.base
+                    -> engine_core -> import mlx.core
+
+which is fatal off Apple Silicon. Every test in that class died with
+``ModuleNotFoundError: No module named 'mlx'`` — on Linux only, so the
+macOS dev loop stayed green and CI caught it instead.
+
+The fix is not to swallow the ImportError: that would silently ignore an
+operator's explicit flag. It is for ``config`` not to reach into the
+engine at runtime in the first place (the annotation is type-only, and
+``server_config`` already has ``from __future__ import annotations``).
+
+These tests run in a subprocess with MLX blocked at the meta-path, which
+is the only honest way to assert it here — this suite's own process has
+MLX loaded long before any test starts. Mutation check: restore the
+module-scope ``from ..engine.base import BaseEngine`` and both fail.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+# Installed at sys.meta_path[0] so it is consulted before any real
+# finder, and raises rather than returning None — returning None would
+# merely fall through to the next finder and find the real MLX.
+_BLOCK_MLX = """
+import sys
+
+
+class _NoMLX:
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname == "mlx" or fullname.startswith("mlx."):
+            raise ImportError("mlx is unavailable in this environment")
+        return None
+
+
+sys.meta_path.insert(0, _NoMLX())
+"""
+
+
+def _run_without_mlx(body: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-c", _BLOCK_MLX + textwrap.dedent(body)],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+        timeout=180,
+    )
+
+
+def test_the_blocker_actually_blocks() -> None:
+    """Guard the guard: a blocker that silently no-ops proves nothing."""
+    proc = _run_without_mlx(
+        """
+        try:
+            import mlx.core  # noqa: F401
+        except ImportError:
+            print("BLOCKED")
+        else:
+            print("NOT-BLOCKED")
+        """
+    )
+    assert "BLOCKED" in proc.stdout, proc.stderr
+    assert "NOT-BLOCKED" not in proc.stdout
+
+
+def test_config_is_importable_without_mlx() -> None:
+    proc = _run_without_mlx(
+        """
+        from vllm_mlx.config import ServerConfig, get_config
+
+        cfg = get_config()
+        assert isinstance(cfg, ServerConfig)
+        # The type-only annotation must survive as an unevaluated string.
+        assert "BaseEngine" in ServerConfig.__annotations__["engine"]
+        assert "mlx" not in __import__("sys").modules
+        print("CONFIG-OK")
+        """
+    )
+    assert "CONFIG-OK" in proc.stdout, proc.stderr + proc.stdout
+
+
+@pytest.mark.parametrize("flag", [False, True])
+def test_anthropic_adapter_translates_without_mlx(flag: bool) -> None:
+    """The flag lookup itself must not need an engine, either way."""
+    proc = _run_without_mlx(
+        f"""
+        from vllm_mlx.api.anthropic_adapter import anthropic_to_openai
+        from vllm_mlx.api.anthropic_models import AnthropicMessage, AnthropicRequest
+        from vllm_mlx.config import get_config
+
+        get_config().relocate_mid_conversation_system = {flag}
+
+        req = AnthropicRequest(
+            model="test-model",
+            max_tokens=64,
+            system="be brief",
+            messages=[
+                AnthropicMessage(role="user", content="hello"),
+                AnthropicMessage(role="assistant", content="hi"),
+                AnthropicMessage(role="system", content="stay on topic"),
+                AnthropicMessage(role="user", content="continue"),
+            ],
+        )
+        result = anthropic_to_openai(req)
+        roles = [m.role for m in result.messages]
+        assert roles[0] == "system", roles
+        assert roles.count("system") == 1, roles
+        assert "mlx" not in __import__("sys").modules
+        print("ADAPTER-OK", roles)
+        """
+    )
+    assert "ADAPTER-OK" in proc.stdout, proc.stderr + proc.stdout

--- a/tests/test_adapters_import_without_mlx.py
+++ b/tests/test_adapters_import_without_mlx.py
@@ -131,24 +131,69 @@ def test_anthropic_adapter_translates_without_mlx(flag: bool) -> None:
     assert "ADAPTER-OK" in proc.stdout, proc.stderr + proc.stdout
 
 
-def test_annotations_stay_introspectable_without_mlx() -> None:
-    """``TYPE_CHECKING`` must not turn working introspection into NameError.
+def test_annotations_resolve_to_the_real_engine_type_without_mlx() -> None:
+    """Introspection must return ``BaseEngine`` itself, not a stand-in.
 
-    Moving the import behind ``TYPE_CHECKING`` leaves no runtime binding
-    for ``BaseEngine``, and ``typing.get_type_hints`` — which is how
-    dataclass-driven serializers and DI containers read annotations —
-    resolves names in the defining module's namespace. Without a runtime
-    alias it raises instead of returning the field types (review NIT).
+    ``typing.get_type_hints`` is how dataclass-driven serializers and DI
+    containers read annotations, and it resolves names in the defining
+    module's globals. Two tempting shortcuts both fail here:
+
+    * hiding the import behind ``TYPE_CHECKING`` leaves no runtime name at
+      all, so this raises ``NameError``;
+    * binding a placeholder such as ``Any`` makes it resolve — to the wrong
+      type, which is worse, because a container keyed on the annotation
+      silently stops matching instead of failing.
+
+    So assert the identity of what comes back, not merely that the key is
+    present. The weaker form claimed introspection was preserved while the
+    placeholder was in place.
     """
     proc = _run_without_mlx(
         """
         import typing
 
         from vllm_mlx.config import ServerConfig
+        from vllm_mlx.engine.base import BaseEngine
 
         hints = typing.get_type_hints(ServerConfig)
         assert "engine" in hints, sorted(hints)
+        assert BaseEngine in typing.get_args(hints["engine"]), hints["engine"]
+        assert "mlx" not in __import__("sys").modules
         print("HINTS-OK")
         """
     )
     assert "HINTS-OK" in proc.stdout, proc.stderr + proc.stdout
+
+
+def test_engine_package_defers_its_mlx_dependent_members() -> None:
+    """``import vllm_mlx.engine`` must not pull MLX in on its own.
+
+    This is the property the config fix rests on. ``base`` is stdlib-pure
+    and stays eager; ``engine_core`` and ``batched`` are PEP 562 lazies.
+    """
+    proc = _run_without_mlx(
+        """
+        import sys
+
+        import vllm_mlx.engine as engine
+
+        # The property the config fix rests on: the package alone is cheap.
+        assert "mlx" not in sys.modules, "importing the package pulled MLX in"
+        assert "vllm_mlx.engine_core" not in sys.modules
+        assert engine.BaseEngine.__name__ == "BaseEngine"
+
+        # The deferred members are still reachable by name...
+        assert "BatchedEngine" in dir(engine)
+        assert engine.BatchedEngine.__name__ == "BatchedEngine"
+        # ...and resolving one caches it, so the hook runs once.
+        assert engine.__dict__["BatchedEngine"] is engine.BatchedEngine
+
+        # An unknown name must still be an AttributeError, not a KeyError
+        # escaping the lookup table.
+        try:
+            engine.NoSuchMember
+        except AttributeError:
+            print("LAZY-OK")
+        """
+    )
+    assert "LAZY-OK" in proc.stdout, proc.stderr + proc.stdout

--- a/tests/test_adapters_import_without_mlx.py
+++ b/tests/test_adapters_import_without_mlx.py
@@ -197,3 +197,41 @@ def test_engine_package_defers_its_mlx_dependent_members() -> None:
         """
     )
     assert "LAZY-OK" in proc.stdout, proc.stderr + proc.stdout
+
+
+def test_anthropic_streaming_reasoning_uses_the_reasoning_sanitizer() -> None:
+    """`</tool_call>` must not survive into a streamed `thinking_delta`.
+
+    The non-streaming path removed it while both streaming sites applied
+    only `strip_special_tokens`, which does not. Agents stream, so the leak
+    the fix was written for was still live on the path that matters.
+
+    Asserted structurally against the two call sites plus a behavioural
+    check of the sanitizer itself: driving the full Anthropic SSE loop needs
+    an engine, and this is the property that loop depends on.
+    """
+    import inspect
+
+    from vllm_mlx.api.utils import sanitize_reasoning_for_stream
+    from vllm_mlx.routes import anthropic as route
+
+    # The reasoning channel strips the closer; whitespace is preserved
+    # because streaming clients concatenate deltas verbatim.
+    assert sanitize_reasoning_for_stream(" x</tool_call>y ") == " xy "
+    assert sanitize_reasoning_for_stream(None) == ""
+
+    src = inspect.getsource(route)
+    for anchor in (
+        'if output_channel == "reasoning":',
+        "if delta_msg.reasoning:",
+    ):
+        after = src[src.index(anchor) : src.index(anchor) + 1400]
+        assert "sanitize_reasoning_for_stream(" in after, (
+            f"streaming reasoning site after {anchor!r} does not use the "
+            f"reasoning sanitizer"
+        )
+        head = after[: after.index("sanitize_reasoning_for_stream(")]
+        assert "strip_special_tokens(" not in head, (
+            f"streaming reasoning site after {anchor!r} still reaches "
+            f"strip_special_tokens first"
+        )

--- a/tests/test_adapters_import_without_mlx.py
+++ b/tests/test_adapters_import_without_mlx.py
@@ -129,3 +129,26 @@ def test_anthropic_adapter_translates_without_mlx(flag: bool) -> None:
         """
     )
     assert "ADAPTER-OK" in proc.stdout, proc.stderr + proc.stdout
+
+
+def test_annotations_stay_introspectable_without_mlx() -> None:
+    """``TYPE_CHECKING`` must not turn working introspection into NameError.
+
+    Moving the import behind ``TYPE_CHECKING`` leaves no runtime binding
+    for ``BaseEngine``, and ``typing.get_type_hints`` — which is how
+    dataclass-driven serializers and DI containers read annotations —
+    resolves names in the defining module's namespace. Without a runtime
+    alias it raises instead of returning the field types (review NIT).
+    """
+    proc = _run_without_mlx(
+        """
+        import typing
+
+        from vllm_mlx.config import ServerConfig
+
+        hints = typing.get_type_hints(ServerConfig)
+        assert "engine" in hints, sorted(hints)
+        print("HINTS-OK")
+        """
+    )
+    assert "HINTS-OK" in proc.stdout, proc.stderr + proc.stdout

--- a/tests/test_mid_conversation_system_prefix_cache.py
+++ b/tests/test_mid_conversation_system_prefix_cache.py
@@ -617,12 +617,21 @@ class TestFlagReachesTheAdapterEndToEnd:
                     and isinstance(tgt.value, ast.Name)
                     and tgt.value.id == "server"
                 ):
-                    # ...and it must read the PARSED arg, not a literal.
-                    assert "relocate_mid_conversation_system" in ast.unparse(
-                        node.value
-                    ), f"assignment does not read the parsed arg: {ast.unparse(node)}"
-                    assert "args" in ast.unparse(node.value), (
-                        f"assignment does not read from args: {ast.unparse(node)}"
+                    # The RHS must be EXACTLY one of the accepted forms.
+                    # Substring matching was not enough (review BLOCKING):
+                    # `not args.relocate_mid_conversation_system` contains
+                    # both "args" and the attribute name, so an inverted
+                    # assignment — the flag doing the opposite of what it
+                    # documents — would have passed.
+                    rhs = ast.unparse(node.value)
+                    accepted = {
+                        "args.relocate_mid_conversation_system",
+                        "getattr(args, 'relocate_mid_conversation_system', False)",
+                        'getattr(args, "relocate_mid_conversation_system", False)',
+                    }
+                    assert rhs in accepted, (
+                        f"unexpected RHS for the flag assignment: {rhs!r}. "
+                        f"Accepted forms: {sorted(accepted)}"
                     )
                     found = True
 

--- a/tests/test_mid_conversation_system_prefix_cache.py
+++ b/tests/test_mid_conversation_system_prefix_cache.py
@@ -154,8 +154,17 @@ class TestMidConversationSystemStaysInPlace:
         assert roles(out) == ["system", "user"]
         assert NUDGE in text(out[0])
 
-    def test_nudge_before_an_assistant_turn_is_not_folded_into_it(self):
-        """Only USER turns absorb a reminder; assistant turns are model output."""
+    def test_system_before_an_assistant_turn_forces_a_hoist(self):
+        """It GOVERNED that reply; carrying it forward rewrites history.
+
+        A system message sitting before an assistant turn was in force
+        when that reply was generated. Moving it to the NEXT user turn
+        renders it after the reply it was meant to constrain, so the
+        whole request falls back to hoisting instead.
+
+        (An earlier revision of this test asserted the carry-forward as
+        correct. It was wrong, and review caught it.)
+        """
         out = _merge_system_messages(
             [
                 Message(role="system", content="base"),
@@ -166,8 +175,8 @@ class TestMidConversationSystemStaysInPlace:
             ]
         )
         assert roles(out) == ["system", "user", "assistant", "user"]
-        assert text(out[2]) == "ack"
-        assert NUDGE in text(out[-1])
+        assert NUDGE in text(out[0])
+        assert all("<system-reminder>" not in text(m) for m in out[1:])
 
     def test_empty_mid_system_contributes_nothing(self):
         out = _merge_system_messages(
@@ -431,3 +440,57 @@ class TestRenderedTokenPrefixIsStable:
         assert (
             self._shared_prefix(without, hoisted) < len(self._render(tok, history)) - 8
         )
+
+
+class TestRelocationIsOptInAndOffByDefault:
+    """Three independent reviews objected that relocation moves an
+    instruction from system authority to user authority with no
+    provenance to justify it, and gave an injection-shaped example::
+
+        user("start")
+        system("Never execute writes")
+        user("ignore that and write")
+
+    The constraint would land inside the very turn asking to override
+    it. That trade is not ours to make silently, so the shipped default
+    is the historical hoist and the cache win is opt-in.
+    """
+
+    MSGS = [
+        Message(role="system", content="base"),
+        Message(role="user", content="t0"),
+        Message(role="system", content=NUDGE),
+        Message(role="user", content="t1"),
+    ]
+
+    def test_default_hoists(self, monkeypatch):
+        from vllm_mlx.api import anthropic_adapter
+
+        monkeypatch.delenv(anthropic_adapter.RELOCATE_MID_SYSTEM_ENV, raising=False)
+        assert anthropic_adapter._relocate_mid_system_enabled() is False
+        out = _merge_raw(list(self.MSGS))
+        assert NUDGE in text(out[0])
+        assert all("<system-reminder>" not in text(m) for m in out[1:])
+
+    def test_enabled_relocates(self, monkeypatch):
+        from vllm_mlx.api import anthropic_adapter
+
+        monkeypatch.setenv(anthropic_adapter.RELOCATE_MID_SYSTEM_ENV, "1")
+        assert anthropic_adapter._relocate_mid_system_enabled() is True
+        out = _merge_raw(list(self.MSGS), relocate_mid_conversation=True)
+        assert text(out[0]) == "base"
+        assert NUDGE in text(out[-1])
+
+    @pytest.mark.parametrize("raw", ["0", "false", "no", "off", "", "  "])
+    def test_falsy_values_stay_off(self, monkeypatch, raw):
+        from vllm_mlx.api import anthropic_adapter
+
+        monkeypatch.setenv(anthropic_adapter.RELOCATE_MID_SYSTEM_ENV, raw)
+        assert anthropic_adapter._relocate_mid_system_enabled() is False
+
+    @pytest.mark.parametrize("raw", ["1", "true", "yes", "on"])
+    def test_truthy_values_turn_it_on(self, monkeypatch, raw):
+        from vllm_mlx.api import anthropic_adapter
+
+        monkeypatch.setenv(anthropic_adapter.RELOCATE_MID_SYSTEM_ENV, raw)
+        assert anthropic_adapter._relocate_mid_system_enabled() is True

--- a/tests/test_mid_conversation_system_prefix_cache.py
+++ b/tests/test_mid_conversation_system_prefix_cache.py
@@ -28,6 +28,8 @@ instruction rather than something the human typed. That turn is new on
 this request anyway, so nothing previously cacheable is disturbed.
 """
 
+import textwrap
+
 import pytest
 
 from vllm_mlx.api.models import Message
@@ -578,6 +580,58 @@ class TestFlagReachesTheAdapterEndToEnd:
         assert text(msgs[0]) == "base", "leading system must stay clean"
         assert NUDGE in text(msgs[-1])
         assert "<system-reminder>" in text(msgs[-1])
+
+    def test_cli_publishes_the_parsed_flag_to_the_server_global(self):
+        """Cover the cli.py assignment itself, not just its effect.
+
+        My own mutation check found this gap: with the bridge tests
+        alone, deleting `server._relocate_mid_conversation_system = ...`
+        from cli.py left the suite fully green, because those tests set
+        the global themselves.
+
+        This is a STRUCTURAL assertion rather than a runtime one.
+        `serve_command` cannot be run far enough in a unit test — it
+        resolves the alias, boots a model and starts uvicorn — and every
+        abort point I tried fires either before the assignment or after
+        the expensive work has begun. Asserting the wiring exists in the
+        source does kill the mutation, which is the property that
+        matters here; the bridge tests above cover everything downstream
+        of it.
+        """
+        import ast
+        import inspect
+
+        from vllm_mlx import cli
+
+        src = inspect.getsource(cli.serve_command)
+        tree = ast.parse(textwrap.dedent(src))
+
+        found = False
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Assign):
+                continue
+            for tgt in node.targets:
+                if (
+                    isinstance(tgt, ast.Attribute)
+                    and tgt.attr == "_relocate_mid_conversation_system"
+                    and isinstance(tgt.value, ast.Name)
+                    and tgt.value.id == "server"
+                ):
+                    # ...and it must read the PARSED arg, not a literal.
+                    assert "relocate_mid_conversation_system" in ast.unparse(
+                        node.value
+                    ), f"assignment does not read the parsed arg: {ast.unparse(node)}"
+                    assert "args" in ast.unparse(node.value), (
+                        f"assignment does not read from args: {ast.unparse(node)}"
+                    )
+                    found = True
+
+        assert found, (
+            "serve_command no longer publishes "
+            "--relocate-mid-conversation-system to "
+            "server._relocate_mid_conversation_system; the flag would parse "
+            "and then do nothing"
+        )
 
     def test_flag_absent_hoists(self):
         from vllm_mlx.api.anthropic_adapter import anthropic_to_openai

--- a/tests/test_mid_conversation_system_prefix_cache.py
+++ b/tests/test_mid_conversation_system_prefix_cache.py
@@ -453,7 +453,8 @@ class TestRelocationIsOptInAndOffByDefault:
 
     The constraint would land inside the very turn asking to override
     it. That trade is not ours to make silently, so the shipped default
-    is the historical hoist and the cache win is opt-in.
+    is the historical hoist and the cache win is opt-in via
+    ``serve --relocate-mid-conversation-system``.
     """
 
     MSGS = [
@@ -463,34 +464,39 @@ class TestRelocationIsOptInAndOffByDefault:
         Message(role="user", content="t1"),
     ]
 
-    def test_default_hoists(self, monkeypatch):
-        from vllm_mlx.api import anthropic_adapter
+    def test_default_is_off(self):
+        from vllm_mlx.config.server_config import ServerConfig
 
-        monkeypatch.delenv(anthropic_adapter.RELOCATE_MID_SYSTEM_ENV, raising=False)
-        assert anthropic_adapter._relocate_mid_system_enabled() is False
+        assert ServerConfig().relocate_mid_conversation_system is False
+
+    def test_default_hoists(self):
         out = _merge_raw(list(self.MSGS))
         assert NUDGE in text(out[0])
         assert all("<system-reminder>" not in text(m) for m in out[1:])
 
-    def test_enabled_relocates(self, monkeypatch):
-        from vllm_mlx.api import anthropic_adapter
-
-        monkeypatch.setenv(anthropic_adapter.RELOCATE_MID_SYSTEM_ENV, "1")
-        assert anthropic_adapter._relocate_mid_system_enabled() is True
+    def test_enabled_relocates(self):
         out = _merge_raw(list(self.MSGS), relocate_mid_conversation=True)
         assert text(out[0]) == "base"
         assert NUDGE in text(out[-1])
 
-    @pytest.mark.parametrize("raw", ["0", "false", "no", "off", "", "  "])
-    def test_falsy_values_stay_off(self, monkeypatch, raw):
+    def test_adapter_consults_the_config_flag(self, monkeypatch):
+        """The switch is a server flag, not an out-of-band env var."""
         from vllm_mlx.api import anthropic_adapter
 
-        monkeypatch.setenv(anthropic_adapter.RELOCATE_MID_SYSTEM_ENV, raw)
+        class _Cfg:
+            relocate_mid_conversation_system = True
+
+        monkeypatch.setattr("vllm_mlx.config.get_config", lambda: _Cfg(), raising=False)
+        assert anthropic_adapter._relocate_mid_system_enabled() is True
+
+        _Cfg.relocate_mid_conversation_system = False
         assert anthropic_adapter._relocate_mid_system_enabled() is False
 
-    @pytest.mark.parametrize("raw", ["1", "true", "yes", "on"])
-    def test_truthy_values_turn_it_on(self, monkeypatch, raw):
+    def test_adapter_defaults_off_when_config_is_absent(self, monkeypatch):
         from vllm_mlx.api import anthropic_adapter
 
-        monkeypatch.setenv(anthropic_adapter.RELOCATE_MID_SYSTEM_ENV, raw)
-        assert anthropic_adapter._relocate_mid_system_enabled() is True
+        def _boom():
+            raise RuntimeError("config not initialised")
+
+        monkeypatch.setattr("vllm_mlx.config.get_config", _boom, raising=False)
+        assert anthropic_adapter._relocate_mid_system_enabled() is False

--- a/tests/test_mid_conversation_system_prefix_cache.py
+++ b/tests/test_mid_conversation_system_prefix_cache.py
@@ -492,11 +492,100 @@ class TestRelocationIsOptInAndOffByDefault:
         _Cfg.relocate_mid_conversation_system = False
         assert anthropic_adapter._relocate_mid_system_enabled() is False
 
-    def test_adapter_defaults_off_when_config_is_absent(self, monkeypatch):
-        from vllm_mlx.api import anthropic_adapter
 
-        def _boom():
-            raise RuntimeError("config not initialised")
+class TestFlagReachesTheAdapterEndToEnd:
+    """Exercise the REAL chain, not each link in isolation.
 
-        monkeypatch.setattr("vllm_mlx.config.get_config", _boom, raising=False)
-        assert anthropic_adapter._relocate_mid_system_enabled() is False
+    Review MAJOR: the other tests here check `ServerConfig`'s default, the
+    merge helper, and a mocked `get_config()` separately. Delete either
+    plumbing assignment — `cli.py`'s `server._relocate_mid_conversation_system
+    = ...` or `server.py`'s `cfg.relocate_mid_conversation_system = ...` —
+    and every one of them stays green while
+    `rapid-mlx serve --relocate-mid-conversation-system` silently keeps
+    hoisting.
+
+    So: parse the real flag off the real parser, publish it the way the
+    server does, and assert an actual Anthropic request comes out
+    relocated.
+    """
+
+    @staticmethod
+    def _parse(argv):
+        """Drive the REAL ``main()`` parser, capturing args at dispatch.
+
+        Same technique as ``tests/test_cli_response_cache_flag.py`` — it
+        exercises the actual ``serve_parser`` registration rather than a
+        reconstructed stand-in, and nothing past parsing runs.
+        """
+        import sys
+        from unittest import mock
+
+        from vllm_mlx import cli
+
+        captured = {}
+
+        with (
+            mock.patch.object(
+                cli, "serve_command", lambda a: captured.setdefault("a", a)
+            ),
+            mock.patch.object(
+                sys, "argv", ["rapid-mlx", "serve", "qwen3.5-4b-4bit", *argv]
+            ),
+        ):
+            cli.main()
+        assert "a" in captured, "serve_command dispatch was never reached"
+        return captured["a"]
+
+    @staticmethod
+    def _publish(value):
+        from vllm_mlx import server
+
+        server._relocate_mid_conversation_system = value
+        server._sync_config()
+
+    @staticmethod
+    def _request():
+        from vllm_mlx.api.anthropic_models import AnthropicRequest
+
+        return AnthropicRequest(
+            model="m",
+            max_tokens=16,
+            system="base",
+            messages=[
+                {"role": "user", "content": "t0"},
+                {"role": "system", "content": NUDGE},
+                {"role": "user", "content": "t1"},
+            ],
+        )
+
+    @pytest.fixture(autouse=True)
+    def _restore(self):
+        from vllm_mlx import server
+
+        before = server._relocate_mid_conversation_system
+        yield
+        server._relocate_mid_conversation_system = before
+        server._sync_config()
+
+    def test_flag_present_relocates(self):
+        from vllm_mlx.api.anthropic_adapter import anthropic_to_openai
+
+        args = self._parse(["--relocate-mid-conversation-system"])
+        assert args.relocate_mid_conversation_system is True
+        self._publish(args.relocate_mid_conversation_system)
+
+        msgs = anthropic_to_openai(self._request()).messages
+        assert text(msgs[0]) == "base", "leading system must stay clean"
+        assert NUDGE in text(msgs[-1])
+        assert "<system-reminder>" in text(msgs[-1])
+
+    def test_flag_absent_hoists(self):
+        from vllm_mlx.api.anthropic_adapter import anthropic_to_openai
+
+        args = self._parse([])
+        assert args.relocate_mid_conversation_system is False
+        self._publish(args.relocate_mid_conversation_system)
+
+        msgs = anthropic_to_openai(self._request()).messages
+        assert NUDGE in text(msgs[0]), "default must hoist into the system block"
+        assert all("<system-reminder>" not in text(m) for m in msgs[1:])

--- a/tests/test_mid_conversation_system_prefix_cache.py
+++ b/tests/test_mid_conversation_system_prefix_cache.py
@@ -618,7 +618,7 @@ class TestFlagReachesTheAdapterEndToEnd:
                     and tgt.value.id == "server"
                 ):
                     # The RHS must be EXACTLY one of the accepted forms.
-                    # Substring matching was not enough (review BLOCKING):
+                    # Substring matching was not enough (raised in review):
                     # `not args.relocate_mid_conversation_system` contains
                     # both "args" and the attribute name, so an inverted
                     # assignment — the flag doing the opposite of what it

--- a/tests/test_tool_call_closer_content_integrity.py
+++ b/tests/test_tool_call_closer_content_integrity.py
@@ -144,3 +144,45 @@ class TestAssistantMessageEnvelope:
 
         msg = AssistantMessage(content="answer<|im_end|>")
         assert msg.content == "answer"
+
+
+class TestAnthropicThinkingBlockStillStrips:
+    """The `thinking` block is the reasoning channel on /v1/messages.
+
+    Splitting the sanitizers left `_sanitize_reasoning_channel` calling
+    the now content-only `sanitize_output`, so a bare `</tool_call>`
+    started surviving into `thinking`. Caught in review; pinned here.
+    """
+
+    def test_thinking_block_strips_the_closer(self):
+        from vllm_mlx.api.anthropic_adapter import _thinking_block_content
+
+        assert _thinking_block_content("x</tool_call>y", "answer") == "xy"
+
+    def test_thinking_block_keeps_ordinary_prose(self):
+        from vllm_mlx.api.anthropic_adapter import _thinking_block_content
+
+        assert (
+            _thinking_block_content("weighing the options", "answer")
+            == "weighing the options"
+        )
+
+
+class TestStreamingContentPathKeepsTheCloser:
+    """codex MINOR: the existing #1508 branch only asserts the OPENER
+    survives, so routing `_fast_sse_chunk` content back through the
+    reasoning sanitizer would still pass. Assert the CLOSER directly.
+    """
+
+    def test_fast_sse_chunk_content_keeps_the_closer(self):
+        assert sanitize_content_for_stream(AGENT_LINE) == AGENT_LINE
+        # ...while the reasoning half of the same helper pair does strip.
+        assert "</tool_call>" not in sanitize_reasoning_for_stream(AGENT_LINE)
+
+    def test_content_delta_and_reasoning_delta_diverge(self):
+        """Both fields, one envelope — the dispatch must not collapse."""
+        delta = ChatCompletionChunkDelta(
+            content=AGENT_LINE, reasoning_content=AGENT_LINE
+        )
+        assert delta.content == AGENT_LINE
+        assert "</tool_call>" not in (delta.reasoning_content or "")

--- a/tests/test_tool_call_closer_content_integrity.py
+++ b/tests/test_tool_call_closer_content_integrity.py
@@ -199,21 +199,48 @@ class TestStreamingSanitizerHelpersKeepTheCloser:
 class TestRescuePrefixBranchAlsoStrips:
     """The length-cut rescue branch is the OTHER call site that moved.
 
-    Review MINOR: the test above covers `_sanitize_reasoning_channel`, but
-    `_thinking_block_content` has a second path — when the turn was cut by
-    `max_tokens`, a prefix of the reasoning is surfaced through a
-    separate `sanitize_*` call. If only that line regressed to
-    `sanitize_output`, a `finish_reason="length"` response whose retained
-    prefix contains `</tool_call>` would leak it into `thinking` and every
-    other test here would stay green.
+    Review MINOR, twice: my first attempt at this test passed neither
+    ``finish_reason="length"`` nor rescue-shaped content, so it ran the
+    ORDINARY path and would have stayed green with the rescue line
+    reverted. Reviewer mutated that line in memory and confirmed it.
+
+    Entering the branch needs all three at once:
+
+    * ``finish_reason == "length"``
+    * ``text`` that satisfies ``is_rescue_payload`` (the cutoff sentinel)
+    * a reasoning trace LONGER than ``RESCUE_TAIL_LENGTH``, so a
+      non-empty prefix survives the tail slice
+
+    The assertion below is on the PREFIX, so the closer under test must
+    sit in the first ``len(reasoning) - RESCUE_TAIL_LENGTH`` characters.
     """
 
-    def test_length_cut_prefix_strips_the_closer(self):
+    def test_length_cut_rescue_prefix_strips_the_closer(self):
+        from vllm_mlx.api.anthropic_adapter import _thinking_block_content
+        from vllm_mlx.api.constants import (
+            REASONING_CUTOFF_SENTINEL,
+            RESCUE_TAIL_LENGTH,
+        )
+
+        # Closer up front, then enough filler that the prefix survives
+        # the tail slice.
+        reasoning = "planning </tool_call> the next step. " + (
+            "x" * RESCUE_TAIL_LENGTH * 2
+        )
+        rescue_text = f"{REASONING_CUTOFF_SENTINEL}\n\nsome tail"
+
+        out = _thinking_block_content(reasoning, rescue_text, "length")
+
+        assert out, "expected a non-empty thinking prefix from the rescue branch"
+        assert "planning" in out, (
+            f"did not enter the rescue-prefix branch; got {out[:80]!r}"
+        )
+        assert "</tool_call>" not in out, (
+            f"closer leaked through the rescue prefix: {out[:120]!r}"
+        )
+
+    def test_ordinary_path_still_strips_the_closer(self):
+        """The non-rescue path, for contrast — both must hold."""
         from vllm_mlx.api.anthropic_adapter import _thinking_block_content
 
-        reasoning = "planning </tool_call> the next step"
-        for content in (None, "", "answer"):
-            out = _thinking_block_content(reasoning, content)
-            assert "</tool_call>" not in (out or ""), (
-                f"closer leaked into thinking with content={content!r}: {out!r}"
-            )
+        assert _thinking_block_content("x</tool_call>y", "answer") == "xy"

--- a/tests/test_tool_call_closer_content_integrity.py
+++ b/tests/test_tool_call_closer_content_integrity.py
@@ -168,13 +168,21 @@ class TestAnthropicThinkingBlockStillStrips:
         )
 
 
-class TestStreamingContentPathKeepsTheCloser:
-    """codex MINOR: the existing #1508 branch only asserts the OPENER
-    survives, so routing `_fast_sse_chunk` content back through the
-    reasoning sanitizer would still pass. Assert the CLOSER directly.
+class TestStreamingSanitizerHelpersKeepTheCloser:
+    """The per-delta helpers, asserted on the CLOSER specifically.
+
+    The pre-existing #1508 branch only checks that the OPENER survives, so
+    routing streamed content back through the reasoning sanitizer would
+    still have passed there.
+
+    NOTE these exercise the HELPERS, not `routes/chat.py::_fast_sse_chunk`
+    itself — that closure is defined inside the streaming generator and is
+    not reachable from a unit test. Its dispatch is a one-line
+    `field == "reasoning_content"` branch; an HTTP-level streaming test
+    would be needed to pin it end to end.
     """
 
-    def test_fast_sse_chunk_content_keeps_the_closer(self):
+    def test_content_stream_helper_keeps_the_closer(self):
         assert sanitize_content_for_stream(AGENT_LINE) == AGENT_LINE
         # ...while the reasoning half of the same helper pair does strip.
         assert "</tool_call>" not in sanitize_reasoning_for_stream(AGENT_LINE)
@@ -186,3 +194,26 @@ class TestStreamingContentPathKeepsTheCloser:
         )
         assert delta.content == AGENT_LINE
         assert "</tool_call>" not in (delta.reasoning_content or "")
+
+
+class TestRescuePrefixBranchAlsoStrips:
+    """The length-cut rescue branch is the OTHER call site that moved.
+
+    Review MINOR: the test above covers `_sanitize_reasoning_channel`, but
+    `_thinking_block_content` has a second path — when the turn was cut by
+    `max_tokens`, a prefix of the reasoning is surfaced through a
+    separate `sanitize_*` call. If only that line regressed to
+    `sanitize_output`, a `finish_reason="length"` response whose retained
+    prefix contains `</tool_call>` would leak it into `thinking` and every
+    other test here would stay green.
+    """
+
+    def test_length_cut_prefix_strips_the_closer(self):
+        from vllm_mlx.api.anthropic_adapter import _thinking_block_content
+
+        reasoning = "planning </tool_call> the next step"
+        for content in (None, "", "answer"):
+            out = _thinking_block_content(reasoning, content)
+            assert "</tool_call>" not in (out or ""), (
+                f"closer leaked into thinking with content={content!r}: {out!r}"
+            )

--- a/vllm_mlx/api/anthropic_adapter.py
+++ b/vllm_mlx/api/anthropic_adapter.py
@@ -36,7 +36,11 @@ from .models import (
     ToolDefinition,
 )
 from .responses_adapter import _merge_system_messages
-from .utils import sanitize_output, strip_reasoning_channel_markup
+from .utils import (
+    sanitize_output,
+    sanitize_reasoning_content,
+    strip_reasoning_channel_markup,
+)
 
 # F9: Anthropic's public spec uses ``id="toolu_<hex>"`` on every
 # ``tool_use`` block (and every matching ``tool_result.tool_use_id``).
@@ -318,7 +322,11 @@ def _sanitize_reasoning_channel(text: str | None) -> str | None:
     if not text:
         return None
     stripped = strip_reasoning_channel_markup(text)
-    sanitized = sanitize_output(stripped)
+    # Reasoning channel, so use the reasoning sanitizer — it additionally
+    # removes the ``</tool_call>`` closer, which the content sanitizer no
+    # longer does. Routing a thinking block through the content variant
+    # would leak a bare wire marker into ``thinking``.
+    sanitized = sanitize_reasoning_content(stripped)
     if not sanitized or not sanitized.strip():
         return None
     return sanitized
@@ -420,8 +428,9 @@ def _thinking_block_content(
             # structural truncation signal via ``stop_reason="max_tokens"``.
             return None
         # Channel markup already stripped above; only the general
-        # special-token catch-all remains.
-        sanitized = sanitize_output(prefix)
+        # special-token catch-all remains. Reasoning channel -> reasoning
+        # sanitizer (see ``_sanitize_reasoning_channel``).
+        sanitized = sanitize_reasoning_content(prefix)
         if not sanitized or not sanitized.strip():
             return None
         return sanitized

--- a/vllm_mlx/api/anthropic_adapter.py
+++ b/vllm_mlx/api/anthropic_adapter.py
@@ -99,35 +99,39 @@ def to_anthropic_tool_use_id(openai_id: str | None) -> str:
     return f"toolu_{secrets.token_hex(12)}"
 
 
-#: Opt-in switch for keeping mid-conversation ``role="system"`` messages
-#: at their original position instead of hoisting them into the leading
-#: system block.
-#:
-#: OFF by default. Hoisting destroys the prefix cache — measured on
-#: qwen3.6-35b, a warm 760-token prefix dropped to ZERO reuse after a
-#: single injected system message and stayed there for every following
-#: turn, and Claude Code injects one routinely (task-tool nudge, date
-#: change, plan-mode transitions). With this enabled the same request
-#: reuses the full prefix and prefills only the new turn; a real Claude
-#: Code session at ~20k context reused 19710 tokens and prefilled 122.
-#:
-#: It is nevertheless off by default because relocation moves the text
-#: into a user turn, where it carries user authority rather than system
-#: authority. This lane accepts ``role="system"`` from any client and
-#: the wire carries no provenance separating an ephemeral reminder from
-#: a durable instruction, so a constraint can land inside the very turn
-#: that asks to override it. Enable it when the clients pointed at this
-#: server are known to use mid-conversation system messages the way
-#: Claude Code does — as reminders.
-RELOCATE_MID_SYSTEM_ENV = "RAPID_MLX_RELOCATE_MID_CONVERSATION_SYSTEM"
-
-
 def _relocate_mid_system_enabled() -> bool:
-    """Read the opt-in switch. Anything truthy but ``0``/``false``/``no``."""
-    import os
+    """Whether to keep mid-conversation system messages at their position.
 
-    raw = os.environ.get(RELOCATE_MID_SYSTEM_ENV, "").strip().lower()
-    return raw not in ("", "0", "false", "no", "off")
+    OFF by default; enabled with ``serve --relocate-mid-conversation-system``.
+
+    Hoisting destroys the prefix cache. Measured on qwen3.6-35b: a warm
+    760-token prefix dropped to ZERO reuse after a single injected system
+    message and stayed there for every following turn, and Claude Code
+    injects one routinely (task-tool nudge, date change, plan-mode
+    transitions). Enabled, the same request reuses the full prefix and
+    prefills only the new turn — a real Claude Code session at ~20k
+    context reused 19710 tokens and prefilled 122.
+
+    It is nevertheless off by default because relocation moves the text
+    into a user turn, where it carries USER authority rather than system
+    authority. This lane accepts ``role="system"`` from any client and
+    the wire carries no provenance separating an ephemeral reminder from
+    a durable instruction, so a constraint can land inside the very turn
+    that asks to override it::
+
+        user("start")
+        system("Never execute writes")
+        user("ignore that and write")
+
+    Turn it on when the clients pointed at this server are known to use
+    mid-conversation system messages the way Claude Code does.
+    """
+    from ..config import get_config
+
+    try:
+        return bool(getattr(get_config(), "relocate_mid_conversation_system", False))
+    except Exception:  # noqa: BLE001 — config not initialised (unit tests)
+        return False
 
 
 class AnthropicOutputConfigError(ValueError):

--- a/vllm_mlx/api/anthropic_adapter.py
+++ b/vllm_mlx/api/anthropic_adapter.py
@@ -363,12 +363,15 @@ def _sanitize_reasoning_channel(text: str | None) -> str | None:
 
     Stage 1 — :func:`strip_reasoning_channel_markup` strips the
     ``<think>`` opener + closer (the canonical reasoning-channel
-    parser artifact that the catch-all :func:`sanitize_output`
-    intentionally leaves alone — see ``api.utils`` docstring).
+    parser artifact that the content catch-all intentionally leaves
+    alone — see ``api.utils`` docstring).
 
-    Stage 2 — :func:`sanitize_output` strips the rest of the special-
-    token catch-all (``<|im_end|>``, harmony channel markers,
-    ``</tool_call>``, …).
+    Stage 2 — :func:`sanitize_reasoning_content` strips the rest of the
+    special-token catch-all (``<|im_end|>``, harmony channel markers,
+    ``</tool_call>``, …). NOT :func:`sanitize_output`: since the
+    content/reasoning channel split, the content variant deliberately
+    PRESERVES ``</tool_call>`` because it can be text the caller asked
+    for. In a reasoning trace it is always parser residue.
 
     Returns ``None`` when the result is empty / whitespace-only so the
     caller can suppress the surrounding channel emission.
@@ -397,8 +400,9 @@ def _thinking_block_content(
 
     1. **Sanitization (R12-M1b fix #1)** — strips the ``<think>`` /
        ``</think>`` tags that the reasoning parser may have left in
-       the trace, then runs the canonical :func:`sanitize_output` for
-       the rest of the special-token catch-all. Mira r12 R-3 bonus
+       the trace, then runs :func:`sanitize_reasoning_content` for the
+       rest of the special-token catch-all (the REASONING variant — the
+       content one preserves ``</tool_call>``). Mira r12 R-3 bonus
        regression: at ``max_tokens=1`` on a thinking model, the prompt
        template's pre-injected ``<think>`` is the only token seen by
        the parser and it ended up as the literal ``thinking`` block

--- a/vllm_mlx/api/anthropic_adapter.py
+++ b/vllm_mlx/api/anthropic_adapter.py
@@ -109,7 +109,7 @@ def _relocate_mid_system_enabled() -> bool:
     Gemma accept at most one system message, at index 0. What it does is
     prepend the text to the FOLLOWING user turn, so the bytes stay where
     they were in the sequence instead of being hoisted to the front. That
-    is what preserves the prefix; the role changes (review NIT).
+    is what preserves the prefix; the role changes (raised in review).
 
     Hoisting destroys the prefix cache. Measured on qwen3.6-35b: a warm
     760-token prefix dropped to ZERO reuse after a single injected system
@@ -140,7 +140,7 @@ def _relocate_mid_system_enabled() -> bool:
     # swallowing everything here would turn a broken config publication into
     # an operator's explicit flag being silently ignored, with the measured
     # 20k-token prefix destroyed on every turn and nothing in the log to say
-    # why (review MAJOR).
+    # why (raised in review).
     return bool(get_config().relocate_mid_conversation_system)
 
 

--- a/vllm_mlx/api/anthropic_adapter.py
+++ b/vllm_mlx/api/anthropic_adapter.py
@@ -128,10 +128,13 @@ def _relocate_mid_system_enabled() -> bool:
     """
     from ..config import get_config
 
-    try:
-        return bool(getattr(get_config(), "relocate_mid_conversation_system", False))
-    except Exception:  # noqa: BLE001 — config not initialised (unit tests)
-        return False
+    # No try/except. ``_config`` is eagerly initialised at module import, so
+    # "config not initialised" is not a reachable production state — and
+    # swallowing everything here would turn a broken config publication into
+    # an operator's explicit flag being silently ignored, with the measured
+    # 20k-token prefix destroyed on every turn and nothing in the log to say
+    # why (review MAJOR).
+    return bool(get_config().relocate_mid_conversation_system)
 
 
 class AnthropicOutputConfigError(ValueError):

--- a/vllm_mlx/api/anthropic_adapter.py
+++ b/vllm_mlx/api/anthropic_adapter.py
@@ -99,6 +99,37 @@ def to_anthropic_tool_use_id(openai_id: str | None) -> str:
     return f"toolu_{secrets.token_hex(12)}"
 
 
+#: Opt-in switch for keeping mid-conversation ``role="system"`` messages
+#: at their original position instead of hoisting them into the leading
+#: system block.
+#:
+#: OFF by default. Hoisting destroys the prefix cache — measured on
+#: qwen3.6-35b, a warm 760-token prefix dropped to ZERO reuse after a
+#: single injected system message and stayed there for every following
+#: turn, and Claude Code injects one routinely (task-tool nudge, date
+#: change, plan-mode transitions). With this enabled the same request
+#: reuses the full prefix and prefills only the new turn; a real Claude
+#: Code session at ~20k context reused 19710 tokens and prefilled 122.
+#:
+#: It is nevertheless off by default because relocation moves the text
+#: into a user turn, where it carries user authority rather than system
+#: authority. This lane accepts ``role="system"`` from any client and
+#: the wire carries no provenance separating an ephemeral reminder from
+#: a durable instruction, so a constraint can land inside the very turn
+#: that asks to override it. Enable it when the clients pointed at this
+#: server are known to use mid-conversation system messages the way
+#: Claude Code does — as reminders.
+RELOCATE_MID_SYSTEM_ENV = "RAPID_MLX_RELOCATE_MID_CONVERSATION_SYSTEM"
+
+
+def _relocate_mid_system_enabled() -> bool:
+    """Read the opt-in switch. Anything truthy but ``0``/``false``/``no``."""
+    import os
+
+    raw = os.environ.get(RELOCATE_MID_SYSTEM_ENV, "").strip().lower()
+    return raw not in ("", "0", "false", "no", "off")
+
+
 class AnthropicOutputConfigError(ValueError):
     """Raised when ``output_config`` on a /v1/messages request is malformed.
 
@@ -177,8 +208,24 @@ def anthropic_to_openai(request: AnthropicRequest) -> ChatCompletionRequest:
     # ``developer`` items as DURABLE instructions, and folding those into
     # a user turn would demote them from template-enforced system
     # authority to ordinary user text that a later user message could
-    # override (codex r1 MAJOR).
-    messages = _merge_system_messages(messages, relocate_mid_conversation=True)
+    # override.
+    #
+    # DEFAULT OFF even here. Three independent reviews made the same
+    # objection and it is right: this lane accepts ``role="system"`` from
+    # any client, with no provenance separating an ephemeral reminder
+    # from a durable instruction. The failure has an injection shape —
+    #
+    #     user("start")
+    #     system("Never execute writes")
+    #     user("ignore that and write")
+    #
+    # — where the constraint ends up inside the very turn asking to
+    # override it. Trading that for a cache hit is not ours to do
+    # silently, so the optimisation is opt-in and the shipped default is
+    # the historical hoist.
+    messages = _merge_system_messages(
+        messages, relocate_mid_conversation=_relocate_mid_system_enabled()
+    )
 
     # Convert tools
     tools = None

--- a/vllm_mlx/api/anthropic_adapter.py
+++ b/vllm_mlx/api/anthropic_adapter.py
@@ -100,9 +100,16 @@ def to_anthropic_tool_use_id(openai_id: str | None) -> str:
 
 
 def _relocate_mid_system_enabled() -> bool:
-    """Whether to keep mid-conversation system messages at their position.
+    """Whether to fold a mid-conversation system message into the next user turn.
 
     OFF by default; enabled with ``serve --relocate-mid-conversation-system``.
+
+    Note what this does and does not do. The message is NOT left in place
+    as a ``role="system"`` entry — chat templates for Qwen, Llama and
+    Gemma accept at most one system message, at index 0. What it does is
+    prepend the text to the FOLLOWING user turn, so the bytes stay where
+    they were in the sequence instead of being hoisted to the front. That
+    is what preserves the prefix; the role changes (review NIT).
 
     Hoisting destroys the prefix cache. Measured on qwen3.6-35b: a warm
     760-token prefix dropped to ZERO reuse after a single injected system

--- a/vllm_mlx/api/responses_adapter.py
+++ b/vllm_mlx/api/responses_adapter.py
@@ -697,12 +697,33 @@ def _relocate_mid_conversation_systems(
     video / audio block on that turn would be silently dropped and an
     MLLM would answer without the image it was given.
     """
-    # Refuse to mix relocation and hoisting — see ALL-OR-NOTHING above.
+    # Relocate ONLY when every mid-conversation system message is
+    # immediately followed (modulo other system messages) by a USER turn.
+    # Otherwise bail and let the caller hoist them all.
+    #
+    # Two hazards this closes, both found in review:
+    #
+    #  * Mixing relocation and hoisting inverts instruction order — see
+    #    ALL-OR-NOTHING in the docstring.
+    #  * A system message sitting before an ASSISTANT turn GOVERNED that
+    #    turn when the reply was generated. Carrying it forward to the
+    #    next user turn renders it AFTER the reply it was meant to
+    #    constrain, silently rewriting the history's meaning::
+    #
+    #        user:      t0
+    #        system:    <governs the next reply>
+    #        assistant: <reply>          <- generated under that system msg
+    #        user:      t1
+    #
+    #    Claude Code's nudges are always immediately before the new user
+    #    turn, so requiring that shape costs nothing on the path this
+    #    optimisation exists for.
     tail = messages[first_body:]
     for i, msg in enumerate(tail):
         if msg.role != "system":
             continue
-        if not any(m.role == "user" for m in tail[i + 1 :]):
+        nxt = next((m for m in tail[i + 1 :] if m.role != "system"), None)
+        if nxt is None or nxt.role != "user":
             return messages
 
     out: list[Message] = list(messages[:first_body])

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -2930,6 +2930,9 @@ def serve_command(args):
 
     # Configure system prompt pinning
     server._pin_system_prompt = args.pin_system_prompt
+    server._relocate_mid_conversation_system = getattr(
+        args, "relocate_mid_conversation_system", False
+    )
 
     # Configure tool calling
     if args.enable_auto_tool_choice and args.tool_call_parser:
@@ -8304,6 +8307,19 @@ Examples:
         action="store_true",
         default=False,
         help="Auto-pin system prompt in prefix cache to prevent eviction under memory pressure",
+    )
+    serve_parser.add_argument(
+        "--relocate-mid-conversation-system",
+        action="store_true",
+        default=False,
+        help=(
+            "Keep a mid-conversation system message at its position (folded "
+            "into the next user turn) instead of hoisting it into the leading "
+            "system block. Preserves the prefix cache for clients that inject "
+            "reminders mid-session (Claude Code); OFF by default because the "
+            "relocated text carries user authority rather than system "
+            "authority."
+        ),
     )
     # Multimodal option
     serve_parser.add_argument(

--- a/vllm_mlx/config/server_config.py
+++ b/vllm_mlx/config/server_config.py
@@ -9,9 +9,17 @@ accessible from routes and middleware via `get_config()`.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from ..engine.base import BaseEngine
+if TYPE_CHECKING:
+    # Type-only. Importing it for real drags the whole engine in —
+    # ``engine.base`` -> ``engine_core`` -> ``import mlx.core`` — which
+    # makes ``vllm_mlx.config`` unimportable anywhere MLX is absent
+    # (Linux CI, and any pure-adapter unit test). ``ServerConfig`` only
+    # ever names the type in an annotation, and ``from __future__ import
+    # annotations`` above keeps annotations unevaluated, so nothing needs
+    # the symbol at runtime.
+    from ..engine.base import BaseEngine
 
 
 @dataclass

--- a/vllm_mlx/config/server_config.py
+++ b/vllm_mlx/config/server_config.py
@@ -20,6 +20,14 @@ if TYPE_CHECKING:
     # annotations`` above keeps annotations unevaluated, so nothing needs
     # the symbol at runtime.
     from ..engine.base import BaseEngine
+else:
+    # ...but a name that exists only for the type checker is a name that
+    # ``typing.get_type_hints(ServerConfig)`` cannot resolve, and that is
+    # how dataclass-introspecting tools read annotations. Without this
+    # binding they would go from working to ``NameError`` (review NIT).
+    # ``Any`` keeps introspection resolvable at runtime while the real
+    # type is what every static checker sees.
+    BaseEngine = Any
 
 
 @dataclass

--- a/vllm_mlx/config/server_config.py
+++ b/vllm_mlx/config/server_config.py
@@ -173,6 +173,12 @@ class ServerConfig:
     pin_system_prompt: bool = False
     pinned_system_prompt_hash: str | None = None
 
+    # Keep a mid-conversation ``role="system"`` message at its original
+    # position (folded into the following user turn) instead of hoisting
+    # it into the leading system block. OFF by default — see
+    # ``anthropic_adapter._relocate_mid_system_enabled`` for the trade.
+    relocate_mid_conversation_system: bool = False
+
     # --- Audio lane (task #292) ---
     # Operator opt-in for ``/v1/audio/*`` routes on a TEXT-only server.
     # Pre-fix the audio router was unconditionally attached even when

--- a/vllm_mlx/config/server_config.py
+++ b/vllm_mlx/config/server_config.py
@@ -9,25 +9,22 @@ accessible from routes and middleware via `get_config()`.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
-if TYPE_CHECKING:
-    # Type-only. Importing it for real drags the whole engine in —
-    # ``engine.base`` -> ``engine_core`` -> ``import mlx.core`` — which
-    # makes ``vllm_mlx.config`` unimportable anywhere MLX is absent
-    # (Linux CI, and any pure-adapter unit test). ``ServerConfig`` only
-    # ever names the type in an annotation, and ``from __future__ import
-    # annotations`` above keeps annotations unevaluated, so nothing needs
-    # the symbol at runtime.
-    from ..engine.base import BaseEngine
-else:
-    # ...but a name that exists only for the type checker is a name that
-    # ``typing.get_type_hints(ServerConfig)`` cannot resolve, and that is
-    # how dataclass-introspecting tools read annotations. Without this
-    # binding they would go from working to ``NameError`` (review NIT).
-    # ``Any`` keeps introspection resolvable at runtime while the real
-    # type is what every static checker sees.
-    BaseEngine = Any
+# A real runtime import, deliberately. It used to drag the whole engine in
+# — ``vllm_mlx.engine`` eagerly imported ``engine_core``, which does
+# ``import mlx.core`` at module scope — so naming ``BaseEngine`` here made
+# ``vllm_mlx.config`` unimportable anywhere MLX is absent, and a wire
+# adapter that consults ``get_config()`` died on Linux CI.
+#
+# The fix is in ``vllm_mlx/engine/__init__.py``, which now imports only the
+# stdlib-pure ``base`` eagerly and defers the MLX-dependent members to PEP
+# 562. Hiding this behind ``TYPE_CHECKING`` instead would have left
+# ``typing.get_type_hints(ServerConfig)`` unable to resolve the name, and a
+# runtime stand-in would have made it answer with the wrong type; keeping
+# the import real and cheap is correct for the runtime and the type checker
+# at once.
+from ..engine.base import BaseEngine
 
 
 @dataclass

--- a/vllm_mlx/engine/__init__.py
+++ b/vllm_mlx/engine/__init__.py
@@ -3,11 +3,26 @@
 Engine abstraction for rapid-mlx inference.
 
 BatchedEngine is the sole engine — continuous batching for all workloads.
+
+``base`` is pure stdlib (abc/dataclasses/typing) and is imported eagerly.
+``engine_core`` and ``batched`` reach ``import mlx.core`` at module scope,
+so they are imported on first attribute access (PEP 562) instead.
+
+That split is what lets a name like ``BaseEngine`` be used in an
+annotation without dragging the engine onto the import path.
+``config.server_config`` does exactly that, and while this package
+imported everything eagerly, ``import vllm_mlx.config`` transitively
+required MLX — which killed the whole ``TestAnthropicToOpenai`` suite on
+Linux CI, since a wire adapter has no business needing Metal.
+
+The alternative was to hide the import behind ``TYPE_CHECKING`` on the
+consumer side, but a name that exists only for the type checker is a name
+``typing.get_type_hints`` cannot resolve, and binding a runtime stand-in
+makes introspection answer with the WRONG type. Making the import cheap
+is the fix that leaves both the runtime and the type checker correct.
 """
 
-from ..engine_core import AsyncEngineCore, EngineConfig, EngineCore
 from .base import BaseEngine, GenerationOutput
-from .batched import BatchedEngine
 
 __all__ = [
     "BaseEngine",
@@ -17,3 +32,32 @@ __all__ = [
     "AsyncEngineCore",
     "EngineConfig",
 ]
+
+_LAZY = {
+    "EngineCore": ("..engine_core", "EngineCore"),
+    "AsyncEngineCore": ("..engine_core", "AsyncEngineCore"),
+    "EngineConfig": ("..engine_core", "EngineConfig"),
+    "BatchedEngine": (".batched", "BatchedEngine"),
+}
+
+
+def __getattr__(name: str):
+    """Resolve the MLX-dependent members on first use (PEP 562).
+
+    Caches into the module globals so the import cost is paid once and
+    later lookups skip this hook entirely.
+    """
+    try:
+        module_name, attr = _LAZY[name]
+    except KeyError:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}") from None
+
+    from importlib import import_module
+
+    value = getattr(import_module(module_name, __name__), attr)
+    globals()[name] = value
+    return value
+
+
+def __dir__() -> list[str]:
+    return sorted(__all__)

--- a/vllm_mlx/engine/__init__.py
+++ b/vllm_mlx/engine/__init__.py
@@ -60,4 +60,12 @@ def __getattr__(name: str):
 
 
 def __dir__() -> list[str]:
-    return sorted(__all__)
+    """Real module contents PLUS the names that are still deferred.
+
+    Returning only ``__all__`` would hide ordinary module attributes and
+    anything already imported, which breaks the introspection and
+    completion that ``dir()`` exists to serve. The union is what a reader
+    expects: everything that is here, and everything that would be if
+    asked for.
+    """
+    return sorted(set(globals()) | set(__all__))

--- a/vllm_mlx/routes/anthropic.py
+++ b/vllm_mlx/routes/anthropic.py
@@ -30,6 +30,7 @@ from ..api.utils import (
     clean_output_text,
     extract_multimodal_content,
     sanitize_output,
+    sanitize_reasoning_for_stream,
     strip_special_tokens,
     strip_thinking_tags,
 )
@@ -2117,7 +2118,16 @@ async def _stream_anthropic_messages(
                 # must opt in here before reaching the client.
                 pieces_routed: list[tuple[str, str]] = []
                 if output_channel == "reasoning":
-                    reasoning = strip_special_tokens(delta_text)
+                    # The REASONING sanitizer, not just special-token
+                    # stripping. `strip_special_tokens` leaves `</tool_call>`
+                    # intact, so a reasoning delta carrying that marker
+                    # reached the client verbatim in a `thinking_delta` while
+                    # the non-streaming path removed it. Agents stream, so the
+                    # streaming path is the one that matters. The `_for_stream`
+                    # variant preserves whitespace — deltas are concatenated
+                    # verbatim, so trimming one corrupts the boundary with the
+                    # next.
+                    reasoning = sanitize_reasoning_for_stream(delta_text)
                     if reasoning:
                         # Per-request reasoning cap — split into kept
                         # (thinking) and overflow (text) so Claude-Code
@@ -2243,7 +2253,9 @@ async def _stream_anthropic_messages(
                     continue
                 pieces: list[tuple[str, str]] = []
                 if delta_msg.reasoning:
-                    reasoning = strip_special_tokens(delta_msg.reasoning)
+                    # See the note at the channel-routed site above: the
+                    # reasoning channel needs the reasoning sanitizer.
+                    reasoning = sanitize_reasoning_for_stream(delta_msg.reasoning)
                     if reasoning:
                         kept, overflow = _account_for_reasoning(reasoning)
                         if kept:

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -303,6 +303,11 @@ _no_thinking: bool = (
     False  # --no-thinking: force enable_thinking=False in chat template
 )
 
+#: Keep a mid-conversation ``role="system"`` message at its position
+#: instead of hoisting it into the leading system block. Set from
+#: ``serve --relocate-mid-conversation-system``; OFF by default.
+_relocate_mid_conversation_system: bool = False
+
 # Pinned prefix cache (Tier 0 optimization)
 _pin_system_prompt: bool = False  # Auto-pin system prompt prefix cache blocks
 _pinned_system_prompt_hash: str | None = None  # Hash of pinned system prompt
@@ -2056,6 +2061,7 @@ def _sync_config() -> None:
     cfg.body_receive_timeout_seconds = _body_receive_timeout_seconds
     cfg.gc_control = _gc_control
     cfg.no_thinking = _no_thinking
+    cfg.relocate_mid_conversation_system = _relocate_mid_conversation_system
     cfg.thinking_token_budget = _thinking_token_budget
     cfg.pin_system_prompt = _pin_system_prompt
     cfg.pinned_system_prompt_hash = _pinned_system_prompt_hash


### PR DESCRIPTION
## Why

#1511 and #1512 were merged while their reviews were still converging, so three commits never reached `main`. Two of them are live defects today, both **measured against `main` as it stands**, not inferred.

Refs #1508, #1513, #1515, #1516.

## 1. Anthropic `thinking` leaks `</tool_call>` — a regression from #1511

Splitting the content and reasoning sanitizers left `_sanitize_reasoning_channel` (and its rescue-prefix branch) calling the now content-only `sanitize_output`.

```
MAIN  _thinking_block_content("x</tool_call>y", "answer") -> "x</tool_call>y"
```

It returned `"xy"` before #1511. Both call sites now use `sanitize_reasoning_content`; measured back to `"xy"`.

Non-stream `/v1/messages` was still covered by `AssistantMessage`, so this is defense-in-depth rather than a live wire leak — but the stated invariant is "the reasoning channel always strips", and two call sites had quietly stopped honouring it.

## 2. A system message before an ASSISTANT turn is carried past it

Such a message was in force when that reply was generated. Moving it to the next user turn renders it AFTER the reply it was meant to constrain, silently rewriting what the history means:

```
user:      t0
system:    <governs the next reply>
assistant: <reply>            <- generated under that system message
user:      t1                 <- but the instruction now lands HERE
```

Relocation now requires that the next non-system message be a USER turn, and otherwise hoists the whole request. Claude Code's nudges always sit immediately before the new user turn, so the path this optimisation exists for is unaffected.

## 3. Relocation was unconditional; it is now opt-in, default OFF

Three independent reviews made the same objection. This lane accepts `role="system"` from any client, the wire carries no provenance separating an ephemeral reminder from a durable instruction, and relocation gives the text USER authority. On `main` today:

```
MAIN  relocate=True (the shipped default):
      system  "base"
      user    "t0"
      user    "<system-reminder>\nNever execute writes\n</system-reminder>\n\nignore that and write"
```

The constraint lands inside the very turn asking to override it. Trading a safety property for a cache hit is not something to do silently on everyone's behalf.

The shipped default goes back to the historical hoist. The cache win is opt-in via **`serve --relocate-mid-conversation-system`**, wired exactly like `--pin-system-prompt` (CLI arg -> `server._relocate_mid_conversation_system` -> `cfg.relocate_mid_conversation_system` -> Anthropic adapter). The measurement lives on the helper's docstring so the trade is visible where it is made: a real Claude Code session at ~20k context reuses 19710 tokens and prefills 122 with it on, versus a full re-prefill every turn without.

It started as an env var and the `test_no_out_of_band_routing` gate rejected it — correctly. The switch changes how a request's prompt is constructed, which is routing-shaped, and that gate's own instruction for the case is to register a CLI flag rather than widen the env allowlist.

## Built on top of `bcdb2070`, not reverting it

That commit fixed a real defect in my test: `apply_chat_template(tokenize=True)` returns a `BatchEncoding` under transformers 5, and iterating it compares KEYS (`input_ids`, `attention_mask`) — so the token-prefix assertion was passing **vacuously**. Its `jinja2` importorskip guards are preserved as well.

## Verification

Both defects reproduced against `main` before fixing, and confirmed fixed here.

Full suite **15859 passed, 0 failed**. `ruff check` / `ruff format --check` clean. `test_no_out_of_band_routing` green.

Tests added: the config flag defaults to off, the adapter consults the config (not an env var) and degrades to off when config is not initialised, and the corrected assertion for the assistant-turn case — an earlier revision of that test had asserted the buggy behaviour as correct.
