### PR TITLE
feat(mirror): mirror one quantisation subfolder, not the whole repo

### DIFF
--- a/scripts/mirror_to_r2.py
+++ b/scripts/mirror_to_r2.py
@@ -160,14 +160,32 @@ def _hf_files(repo_id: str) -> list[FileMeta]:
 # subfolder. A subfolder holds weights and tokenizer; provenance and terms
 # sit at the top level, and a mirror that drops them hands users a copy of
 # the weights with no statement of what they may do with them.
-_ROOT_KEEP = {
-    "LICENSE",
-    "LICENSE.txt",
-    "LICENSE.md",
-    "NOTICE",
-    "NOTICE.txt",
-    "README.md",
-}
+#
+# Matched by STEM, case-insensitively, so a repo shipping ``NOTICE.md``,
+# ``LICENSE-MODEL`` or ``license.txt`` keeps its terms too. An exact-name
+# set silently dropped those while still reporting a successful mirror,
+# which is the worst possible way to get redistribution wrong (review
+# MINOR).
+_ROOT_KEEP_STEMS = ("license", "notice", "readme", "copying")
+
+
+def _is_root_keep(relpath: str) -> bool:
+    """True for a repo-root file that ships with every quantisation."""
+    lowered = relpath.lower()
+    return any(
+        lowered == stem
+        or lowered.startswith(stem + ".")
+        or lowered.startswith(stem + "-")
+        for stem in _ROOT_KEEP_STEMS
+    )
+
+
+# A quantisation subfolder must actually contain a loadable checkpoint.
+# Without this, ``--subfolder docs`` uploads a documentation directory,
+# verifies the objects it just wrote, and reports success — reproducing
+# the "mirror completed but pull still 404s" failure this flag exists to
+# prevent (review MAJOR).
+_WEIGHT_SUFFIXES = (".safetensors", ".npz", ".bin", ".gguf")
 
 
 def _select_subfolder(files: list[FileMeta], subfolder: str) -> list[FileMeta]:
@@ -189,15 +207,38 @@ def _select_subfolder(files: list[FileMeta], subfolder: str) -> list[FileMeta]:
     object layout on R2 stays a faithful copy of the source tree and the
     alias resolver can point at the subfolder directly.
     """
-    prefix = subfolder.strip("/") + "/"
+    stripped = subfolder.strip("/")
+    if not stripped:
+        raise ValueError(
+            f"--subfolder {subfolder!r} is empty. Pass a real subfolder name, "
+            "or omit the flag entirely to mirror the whole repo."
+        )
+
+    prefix = stripped + "/"
     selected = [f for f in files if f.relpath.startswith(prefix)]
+    available = sorted({f.relpath.split("/")[0] for f in files if "/" in f.relpath})
     if not selected:
-        available = sorted({f.relpath.split("/")[0] for f in files if "/" in f.relpath})
         raise ValueError(
             f"--subfolder {subfolder!r} matched no files. "
             f"Available subfolders: {available or '(none — flat repo)'}"
         )
-    roots = [f for f in files if "/" not in f.relpath and f.relpath in _ROOT_KEEP]
+
+    # A directory that exists is not necessarily a checkpoint. Require the
+    # two things a loader cannot start without, as DIRECT children of the
+    # subfolder: a config and at least one weight shard.
+    direct = {f.relpath[len(prefix) :] for f in selected}
+    direct = {name for name in direct if "/" not in name}
+    if "config.json" not in direct or not any(
+        name.endswith(_WEIGHT_SUFFIXES) for name in direct
+    ):
+        raise ValueError(
+            f"--subfolder {subfolder!r} does not look like a checkpoint: "
+            f"expected config.json and a weight file ({', '.join(_WEIGHT_SUFFIXES)}) "
+            f"directly inside it, found {sorted(direct)[:8]}. "
+            f"Available subfolders: {available or '(none — flat repo)'}"
+        )
+
+    roots = [f for f in files if "/" not in f.relpath and _is_root_keep(f.relpath)]
     return roots + selected
 
 
@@ -461,7 +502,11 @@ def mirror_repo(
         print("   MODE:     verify-only (no uploads)", flush=True)
 
     files = _hf_files(repo_id)
-    if subfolder:
+    # ``is not None``, not truthiness: ``--subfolder ""`` (an unset shell
+    # variable expanding to nothing) is a caller mistake, and treating it
+    # as "no filter" silently mirrors the full 20 GB repo the flag exists
+    # to avoid. _select_subfolder rejects it (review MAJOR).
+    if subfolder is not None:
         before = len(files)
         before_bytes = sum((f.size or 0) for f in files)
         files = _select_subfolder(files, subfolder)

--- a/scripts/mirror_to_r2.py
+++ b/scripts/mirror_to_r2.py
@@ -156,6 +156,51 @@ def _hf_files(repo_id: str) -> list[FileMeta]:
     return files
 
 
+# Files that live at the repo root and belong with EVERY quantisation
+# subfolder. A subfolder holds weights and tokenizer; provenance and terms
+# sit at the top level, and a mirror that drops them hands users a copy of
+# the weights with no statement of what they may do with them.
+_ROOT_KEEP = {
+    "LICENSE",
+    "LICENSE.txt",
+    "LICENSE.md",
+    "NOTICE",
+    "NOTICE.txt",
+    "README.md",
+}
+
+
+def _select_subfolder(files: list[FileMeta], subfolder: str) -> list[FileMeta]:
+    """Narrow ``files`` to one quantisation subfolder plus repo-root metadata.
+
+    Some upstreams now ship every quantisation of a model in ONE repo, as
+    sibling directories::
+
+        LiquidAI/LFM2.5-2.6B-MLX/
+          LICENSE  README.md  .gitattributes
+          4bit/  5bit/  6bit/  8bit/  bf16/  mxfp4/  mxfp8/  nvfp4/
+
+    Mirroring such a repo wholesale copies ~20 GB to serve the 1.6 GB anyone
+    actually pulls. Every other repo we mirror is one-quantisation-per-repo,
+    where "the repo" and "what we serve" are the same thing — which is why
+    this selector did not exist until the first subfolder repo showed up.
+
+    Keys keep their full in-repo path (``…-MLX/4bit/config.json``), so the
+    object layout on R2 stays a faithful copy of the source tree and the
+    alias resolver can point at the subfolder directly.
+    """
+    prefix = subfolder.strip("/") + "/"
+    selected = [f for f in files if f.relpath.startswith(prefix)]
+    if not selected:
+        available = sorted({f.relpath.split("/")[0] for f in files if "/" in f.relpath})
+        raise ValueError(
+            f"--subfolder {subfolder!r} matched no files. "
+            f"Available subfolders: {available or '(none — flat repo)'}"
+        )
+    roots = [f for f in files if "/" not in f.relpath and f.relpath in _ROOT_KEEP]
+    return roots + selected
+
+
 def _r2_client(endpoint_url: str, profile: str) -> Any:
     """Build a boto3 S3 client bound to the R2 endpoint / profile.
 
@@ -397,8 +442,15 @@ def mirror_repo(
     dry_run: bool = False,
     verify_only: bool = False,
     tmp_dir: Path | None = None,
+    subfolder: str | None = None,
 ) -> int:
-    """Mirror one HF repo to R2. Return process exit code (0 = ok)."""
+    """Mirror one HF repo to R2. Return process exit code (0 = ok).
+
+    ``subfolder`` narrows a multi-quantisation repo to one variant; see
+    ``_select_subfolder``. Omitted, the whole repo is mirrored, which is
+    correct for the one-quantisation-per-repo layout every other upstream
+    we mirror uses.
+    """
     started = time.monotonic()
     print(f"== mirror {repo_id} → r2://{bucket}/{repo_id}/ ==", flush=True)
     print(f"   endpoint: {endpoint_url}", flush=True)
@@ -409,6 +461,16 @@ def mirror_repo(
         print("   MODE:     verify-only (no uploads)", flush=True)
 
     files = _hf_files(repo_id)
+    if subfolder:
+        before = len(files)
+        before_bytes = sum((f.size or 0) for f in files)
+        files = _select_subfolder(files, subfolder)
+        kept_bytes = sum((f.size or 0) for f in files)
+        print(
+            f"   subfolder: {subfolder!r} — {len(files)}/{before} files, "
+            f"{kept_bytes / 1e9:.3f} of {before_bytes / 1e9:.3f} GB",
+            flush=True,
+        )
     # HF sometimes doesn't expose sizes for a subset of siblings; treat
     # those as 0 for the aggregate banner (the actual bytes-uploaded
     # counter tracks the ground truth below).
@@ -624,6 +686,15 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Skip upload; only run the verification pass.",
     )
     p.add_argument(
+        "--subfolder",
+        default=None,
+        help=(
+            "Mirror only this quantisation subfolder (e.g. '4bit') from a "
+            "repo that ships several. Repo-root LICENSE/NOTICE/README are "
+            "always included. Default: mirror the whole repo."
+        ),
+    )
+    p.add_argument(
         "--tmp-dir",
         default=None,
         help="Scratch dir for per-file downloads (default: /tmp/mirror-<pid>)",
@@ -636,6 +707,7 @@ def main(argv: list[str] | None = None) -> int:
     tmp = Path(args.tmp_dir) if args.tmp_dir else None
     return mirror_repo(
         args.repo_id,
+        subfolder=args.subfolder,
         endpoint_url=args.endpoint_url,
         bucket=args.bucket,
         profile=args.profile,

--- a/tests/test_mirror_subfolder_selection.py
+++ b/tests/test_mirror_subfolder_selection.py
@@ -1,0 +1,147 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Subfolder selection for ``scripts/mirror_to_r2.py``.
+
+Upstreams have started shipping every quantisation of a model inside ONE
+repo as sibling directories. ``LiquidAI/LFM2.5-2.6B-MLX`` is the first one
+we serve: 60 files, 20.05 GB, of which the 4-bit variant anyone actually
+pulls is 7 files and 1.60 GB. Mirroring it wholesale would put 18.45 GB of
+unused weights on R2 — 92% waste — which is why nothing mirrored it and the
+8 GB tier's only recommended model 404s.
+
+Every other repo we mirror is one-quantisation-per-repo (the quantisation
+is in the repo NAME: ``…-MLX-4bit``), where "the repo" and "what we serve"
+are the same thing. That is why this selector did not exist before, and why
+the default must stay "mirror everything".
+
+Fixtures mirror the real layouts, taken from the HF API:
+
+  * LiquidAI/LFM2.5-2.6B-MLX — 3 root files + 8 quantisation subfolders
+  * openbmb/MiniCPM5-1B-MLX — 10 files, all at the root (flat, despite the
+    identical ``-MLX`` naming, which is why the selector keys on layout
+    rather than on the repo name)
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import sys
+
+import pytest
+
+# ``scripts/`` is not a package, so load the module by path. It must be
+# registered in ``sys.modules`` BEFORE exec: ``@dataclass`` resolves its
+# annotations through ``sys.modules[cls.__module__]``, which is None for an
+# unregistered module and fails collection with a bare AttributeError.
+_SPEC = importlib.util.spec_from_file_location(
+    "mirror_to_r2",
+    pathlib.Path(__file__).resolve().parent.parent / "scripts" / "mirror_to_r2.py",
+)
+mirror = importlib.util.module_from_spec(_SPEC)
+sys.modules["mirror_to_r2"] = mirror
+_SPEC.loader.exec_module(mirror)
+
+
+def _f(relpath: str, size: int = 1000) -> mirror.FileMeta:
+    return mirror.FileMeta(relpath=relpath, size=size, key=f"repo/{relpath}")
+
+
+_QUANTS = ("4bit", "5bit", "6bit", "8bit", "bf16", "mxfp4", "mxfp8", "nvfp4")
+
+SUBFOLDER_REPO = [
+    _f(".gitattributes", 1),
+    _f("LICENSE", 10_574),
+    _f("README.md", 5_000),
+    *[
+        _f(f"{q}/{name}", 200_000_000 if name.endswith(".safetensors") else 1_000)
+        for q in _QUANTS
+        for name in (
+            "chat_template.jinja",
+            "config.json",
+            "generation_config.json",
+            "model.safetensors",
+            "model.safetensors.index.json",
+            "tokenizer.json",
+            "tokenizer_config.json",
+        )
+    ],
+]
+
+FLAT_REPO = [
+    _f(".gitattributes"),
+    _f("README.md"),
+    _f("config.json"),
+    _f("model.safetensors"),
+    _f("tokenizer.json"),
+]
+
+
+def test_selects_only_the_requested_quantisation():
+    got = mirror._select_subfolder(SUBFOLDER_REPO, "4bit")
+    quant_dirs = {f.relpath.split("/")[0] for f in got if "/" in f.relpath}
+    assert quant_dirs == {"4bit"}, f"leaked other quantisations: {quant_dirs}"
+
+
+def test_keeps_repo_root_license_and_readme():
+    """The weights are in the subfolder; the terms are not.
+
+    A mirror that ships only ``4bit/`` hands users the weights with no
+    statement of what they may do with them — and these repos are not all
+    Apache-2.0.
+    """
+    got = {f.relpath for f in mirror._select_subfolder(SUBFOLDER_REPO, "4bit")}
+    assert "LICENSE" in got
+    assert "README.md" in got
+
+
+def test_drops_root_noise():
+    got = {f.relpath for f in mirror._select_subfolder(SUBFOLDER_REPO, "4bit")}
+    assert ".gitattributes" not in got
+
+
+def test_selection_is_the_expected_size():
+    """Guards the number that motivates the whole feature."""
+    got = mirror._select_subfolder(SUBFOLDER_REPO, "4bit")
+    full_bytes = sum(f.size for f in SUBFOLDER_REPO)
+    kept_bytes = sum(f.size for f in got)
+    assert len(got) == 9, [f.relpath for f in got]  # 7 weights + LICENSE + README
+    assert kept_bytes < full_bytes / 7, (
+        f"selection kept {kept_bytes / 1e9:.2f} GB of {full_bytes / 1e9:.2f} GB — "
+        f"expected roughly one eighth"
+    )
+
+
+def test_keys_keep_the_subfolder_path():
+    """R2 layout must stay a faithful copy of the source tree.
+
+    ``vllm_mlx/_mirror.py`` resolves ``<owner>/<repo>/<filename>``; flattening
+    ``4bit/config.json`` to ``config.json`` would silently collide with any
+    other quantisation mirrored later into the same repo prefix.
+    """
+    got = mirror._select_subfolder(SUBFOLDER_REPO, "4bit")
+    weights = [f for f in got if f.relpath.endswith(".safetensors")]
+    assert weights and all(f.relpath.startswith("4bit/") for f in weights)
+
+
+def test_trailing_slash_is_accepted():
+    assert mirror._select_subfolder(SUBFOLDER_REPO, "4bit/") == (
+        mirror._select_subfolder(SUBFOLDER_REPO, "4bit")
+    )
+
+
+def test_unknown_subfolder_fails_loudly_and_lists_options():
+    """Typos must not silently mirror the root metadata and nothing else.
+
+    Without the explicit check the selector would return just LICENSE +
+    README, the run would report success, and the model would 404 exactly
+    as it does today — a failure that looks like a completed mirror.
+    """
+    with pytest.raises(ValueError) as exc:
+        mirror._select_subfolder(SUBFOLDER_REPO, "4-bit")
+    assert "4bit" in str(exc.value), "error should list the available subfolders"
+
+
+def test_flat_repo_rejects_subfolder_rather_than_mirroring_nothing():
+    with pytest.raises(ValueError) as exc:
+        mirror._select_subfolder(FLAT_REPO, "4bit")
+    assert "flat repo" in str(exc.value)

--- a/tests/test_mirror_subfolder_selection.py
+++ b/tests/test_mirror_subfolder_selection.py
@@ -145,3 +145,95 @@ def test_flat_repo_rejects_subfolder_rather_than_mirroring_nothing():
     with pytest.raises(ValueError) as exc:
         mirror._select_subfolder(FLAT_REPO, "4bit")
     assert "flat repo" in str(exc.value)
+
+
+# --- review round 1 -------------------------------------------------------
+#
+# Three ways the selector reported success while producing something
+# unusable. Each is a "completed mirror that still 404s" — the exact
+# failure this flag exists to prevent, arriving through a different door.
+
+
+def test_empty_subfolder_is_rejected_not_treated_as_no_filter():
+    """``--subfolder "$QUANT"`` with QUANT unset must not mirror 20 GB.
+
+    An unset shell variable expands to an empty string, and a truthiness
+    check reads that as "no subfolder requested". The operator asked for
+    one quantisation and would have silently got the whole repo.
+    """
+    for empty in ("", "/", "//"):
+        with pytest.raises(ValueError) as exc:
+            mirror._select_subfolder(SUBFOLDER_REPO, empty)
+        assert "empty" in str(exc.value).lower(), str(exc.value)
+
+
+def test_non_checkpoint_directory_is_rejected():
+    """A directory that exists is not necessarily a checkpoint.
+
+    ``--subfolder docs`` used to upload the documentation, verify the
+    objects it had just written, and exit 0 — a mirror that completed and
+    served no model.
+    """
+    repo = [*SUBFOLDER_REPO, _f("docs/example.md"), _f("docs/img/diagram.png")]
+    with pytest.raises(ValueError) as exc:
+        mirror._select_subfolder(repo, "docs")
+    assert "checkpoint" in str(exc.value)
+
+
+def test_subfolder_needs_both_config_and_weights():
+    """Neither half alone is enough to load a model."""
+    config_only = [_f("LICENSE"), _f("4bit/config.json")]
+    with pytest.raises(ValueError):
+        mirror._select_subfolder(config_only, "4bit")
+
+    weights_only = [_f("LICENSE"), _f("4bit/model.safetensors")]
+    with pytest.raises(ValueError):
+        mirror._select_subfolder(weights_only, "4bit")
+
+
+def test_nested_config_does_not_satisfy_the_checkpoint_check():
+    """``4bit/extra/config.json`` is not the checkpoint's own config."""
+    nested = [
+        _f("LICENSE"),
+        _f("4bit/extra/config.json"),
+        _f("4bit/model.safetensors"),
+    ]
+    with pytest.raises(ValueError):
+        mirror._select_subfolder(nested, "4bit")
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "LICENSE",
+        "LICENSE.txt",
+        "LICENSE.md",
+        "LICENSE-MODEL",
+        "license",
+        "NOTICE",
+        "NOTICE.md",
+        "NOTICE.txt",
+        "README.md",
+        "COPYING",
+    ],
+)
+def test_root_terms_are_kept_whatever_the_upstream_calls_them(name: str):
+    """Redistribution terms must not be dropped over a filename variant.
+
+    An exact-name allowlist omitted ``NOTICE.md`` while keeping
+    ``NOTICE.txt`` and ``LICENSE.md`` — an arbitrary distinction that
+    silently ships weights without their terms.
+    """
+    repo = [_f(name), *[f for f in SUBFOLDER_REPO if "/" in f.relpath]]
+    got = {f.relpath for f in mirror._select_subfolder(repo, "4bit")}
+    assert name in got
+
+
+@pytest.mark.parametrize(
+    "name", [".gitattributes", "config.json", "model.safetensors", "licenses.py"]
+)
+def test_root_noise_is_still_dropped(name: str):
+    """Widening the terms match must not start sweeping in root weights."""
+    repo = [_f(name), *[f for f in SUBFOLDER_REPO if "/" in f.relpath]]
+    got = {f.relpath for f in mirror._select_subfolder(repo, "4bit")}
+    assert name not in got


### PR DESCRIPTION
## Why

`models.rapidmlx.com` has no copy of `lfm2.5-2.6b-4bit`, so `rapid-mlx pull` 404s on it. That alias is the **only** model the site recommends for an 8 GB Mac — `hardware-tiers.html` in two places, plus the `curl | bash` banner.

The weights are fine upstream. Nobody could mirror them.

`mirror_to_r2.py` takes a repo id and mirrors every sibling HF reports. That was correct for every repo we serve, because the upstream convention is one quantisation per repo with the quantisation in the **name** (`mlx-community/LFM2.5-8B-A1B-MLX-4bit`). `LiquidAI/LFM2.5-2.6B-MLX` is the first that isn't — eight quantisations as sibling directories in one repo:

```
LiquidAI/LFM2.5-2.6B-MLX/
  LICENSE  README.md  .gitattributes
  4bit/  5bit/  6bit/  8bit/  bf16/  mxfp4/  mxfp8/  nvfp4/
```

Measured against the live HF API:

| | files | size |
|---|---:|---:|
| whole repo | 60 | 20.05 GB |
| `4bit/` only | 9 | **1.60 GB** (8%) |

So the tool's only options were "copy 18.45 GB of weights nobody pulls" or "don't mirror it". The second is what happened.

This is not an oversight to fix by hand. LiquidAI publishes its whole MLX line this way, so every future model from them lands in the same hole.

## What changed

`--subfolder 4bit`. **Off by default** — without it the behaviour is byte-for-byte what it was, which matters because every currently-mirrored repo needs the whole-repo path.

Two details that are easy to get wrong:

- **Repo-root `LICENSE` / `NOTICE` / `README.md` are always included.** The weights are in the subfolder; the terms are not. A mirror of `4bit/` alone hands users weights with no statement of what they may do with them — and these repos are not all Apache-2.0 (this one is `lfm1.0`, which has a redistribution clause requiring the license travel with the copy).
- **Keys keep the full in-repo path** (`…-MLX/4bit/config.json`). Flattening would collide the moment a second quantisation of the same repo is mirrored, and `vllm_mlx/_mirror.py` resolves `<owner>/<repo>/<file>` against the source tree anyway.

An unknown subfolder raises and lists what's available, rather than returning just the root metadata — that would upload two files, report success, and leave the model 404ing exactly as it does now. A failure shaped like a completed mirror is worse than a loud one.

## Tests

8 cases, fixtures taken from the real layouts of both:

- `LiquidAI/LFM2.5-2.6B-MLX` — nested
- `openbmb/MiniCPM5-1B-MLX` — **flat despite the identical `-MLX` suffix**, which is why the selector keys on layout rather than on the repo name

Also verified against live HF metadata, not just fixtures: 60 files / 20.05 GB narrows to 9 files / 1.60 GB with `4bit/` intact in every key.

## Not in this PR

**The upload itself.** It needs the `r2` AWS profile, which this machine doesn't have — that step is yours to run:

```
python scripts/mirror_to_r2.py LiquidAI/LFM2.5-2.6B-MLX --subfolder 4bit --dry-run
python scripts/mirror_to_r2.py LiquidAI/LFM2.5-2.6B-MLX --subfolder 4bit
```

`indextts` / `indextts-1.5` (1.43 GB, flat repo) are also unmirrored but unrelated — plain `mirror_to_r2.py <repo>` covers them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)