### PR TITLE
fix(pr_validate): bench a server that has served nothing else

### DIFF
--- a/harness/README.md
+++ b/harness/README.md
@@ -30,6 +30,31 @@ Baseline files use `harness/baseline.schema.json` and record:
 - reviewed cold/warm regression thresholds (5% for stable AR paths; higher
   only when repeated captures document a wider noise floor).
 
+## Capture state: a FRESH server, always
+
+Both sides of the comparison must be measured the same way, so
+`stress_e2e_bench` benches **first** — on a server that has served
+nothing else — before the stress battery and the agent matrix touch it.
+Capture baselines the same way.
+
+This is load-bearing, not a detail. Measured on Qwen3.5-35B-A3B-8bit /
+M3 Ultra, each group highly reproducible within itself:
+
+| capture state | cold median |
+|---|---|
+| after stress + agent matrix | 287.6, 288.2 ms |
+| fresh server | 252.8, 253.1, 252.0 ms |
+
+A ~14% cold gap with under 0.5% spread inside each group. While the
+bench ran last, every PR was measured post-stress against a baseline
+captured fresh, so the 5% threshold could not survive the mismatch: the
+gate reported a "regression" for a change that only edits prompt
+assembly and a regex, and the identical delta showed up on main. Warm
+moves the other way (~4% faster once the engine is hot), which is what
+made the symptom read as noise.
+
+`tests/test_bench_runs_on_a_clean_server.py` pins the ordering.
+
 ## Refreshing a baseline
 
 `pr_validate` writes each fresh measurement to its run directory as

--- a/scripts/pr_validate/steps/stress_e2e_bench.py
+++ b/scripts/pr_validate/steps/stress_e2e_bench.py
@@ -160,6 +160,49 @@ class StressE2EBenchStep(Step):
             try:
                 with _server(choice, ctx) as server_log:
                     all_artifacts.append(server_log)
+
+                    # Bench FIRST, on a server that has served nothing
+                    # else. It used to run last, after the stress battery
+                    # and the whole agent matrix had hammered this same
+                    # process — so it measured residual state, not the
+                    # code under review.
+                    #
+                    # Measured on Qwen3.5-35B-A3B-8bit, M3 Ultra, both
+                    # highly reproducible within their own context:
+                    #
+                    #   after stress + agents : cold 287.6 / 288.2 ms
+                    #   fresh server          : cold 252.8 / 253.1 / 252.0 ms
+                    #
+                    # A ~14% cold gap with a <0.5% spread inside each
+                    # group. Baselines are captured on a fresh server
+                    # (harness/README.md), so every PR was measured
+                    # against a number produced in a different state and
+                    # the 5% threshold could not survive it — this gate
+                    # flagged a "regression" on a change that only edits
+                    # prompt assembly and a regex, and the same delta
+                    # appeared on main.
+                    #
+                    # Warm moves the other way (~4% faster post-stress,
+                    # the engine is hot), which is why the symptom looked
+                    # like noise rather than a protocol bug.
+                    bench_result = _capture_runner(
+                        "bench", lambda choice=choice: _run_bench(ctx, choice)
+                    )
+                    _record_manifest(
+                        manifest,
+                        kind="bench",
+                        choice=choice,
+                        status=bench_result["status"],
+                        summary=bench_result["summary"],
+                        artifact=bench_result.get("artifact"),
+                    )
+                    if _is_blocking_status(bench_result["status"]):
+                        any_fail = True
+                        all_findings.append(
+                            f"[BLOCKING] bench on {choice.model_id}: "
+                            + bench_result["summary"]
+                        )
+
                     # Stress.
                     stress_result = _capture_runner(
                         "stress", lambda choice=choice: _run_stress(ctx, choice)
@@ -222,24 +265,6 @@ class StressE2EBenchStep(Step):
                         if ag_result.get("artifact"):
                             all_artifacts.append(ag_result["artifact"])
 
-                    # Bench.
-                    bench_result = _capture_runner(
-                        "bench", lambda choice=choice: _run_bench(ctx, choice)
-                    )
-                    _record_manifest(
-                        manifest,
-                        kind="bench",
-                        choice=choice,
-                        status=bench_result["status"],
-                        summary=bench_result["summary"],
-                        artifact=bench_result.get("artifact"),
-                    )
-                    if _is_blocking_status(bench_result["status"]):
-                        any_fail = True
-                        all_findings.append(
-                            f"[BLOCKING] bench on {choice.model_id}: "
-                            + bench_result["summary"]
-                        )
                     if bench_result.get("artifact"):
                         all_artifacts.append(bench_result["artifact"])
 

--- a/scripts/pr_validate/steps/stress_e2e_bench.py
+++ b/scripts/pr_validate/steps/stress_e2e_bench.py
@@ -202,6 +202,12 @@ class StressE2EBenchStep(Step):
                             f"[BLOCKING] bench on {choice.model_id}: "
                             + bench_result["summary"]
                         )
+                    # Registered here, not after the matrix: the bench has
+                    # already produced its artifact, and an exception in
+                    # stress or in any agent below would otherwise discard
+                    # a measurement that was complete (review NIT).
+                    if bench_result.get("artifact"):
+                        all_artifacts.append(bench_result["artifact"])
 
                     # Stress.
                     stress_result = _capture_runner(
@@ -264,9 +270,6 @@ class StressE2EBenchStep(Step):
                             pending_failures.append(("agent", ag_result, agent))
                         if ag_result.get("artifact"):
                             all_artifacts.append(ag_result["artifact"])
-
-                    if bench_result.get("artifact"):
-                        all_artifacts.append(bench_result["artifact"])
 
             except _ServerStartError as e:
                 any_fail = True

--- a/tests/test_bench_runs_on_a_clean_server.py
+++ b/tests/test_bench_runs_on_a_clean_server.py
@@ -35,9 +35,18 @@ def _run_body():
     )
 
 
-def _capture_runner_labels_in_order():
-    """Labels passed to `_capture_runner`, in source order."""
-    labels = []
+def _capture_runner_lines():
+    """``{label: lineno}`` for each literal ``_capture_runner("<label>", ...)``.
+
+    Ordering comes from ``lineno``, never from traversal order:
+    ``ast.walk`` is breadth-first, so it yields shallower nodes before
+    deeper ones regardless of where they sit in the source. The bench
+    call and the agent-matrix call are at different nesting depths — the
+    latter lives inside a ``for`` — so a walk-order test would have
+    reported an order the file does not have, and would have kept
+    passing with the bench moved back to the end (review BLOCKING).
+    """
+    lines = {}
     for node in ast.walk(_run_body()):
         if not isinstance(node, ast.Call):
             continue
@@ -47,20 +56,36 @@ def _capture_runner_labels_in_order():
             continue
         first = node.args[0]
         if isinstance(first, ast.Constant) and isinstance(first.value, str):
-            labels.append(first.value)
-    return labels
+            lines[first.value] = first.lineno
+    return lines
 
 
-def test_bench_runs_before_stress_and_agents():
-    labels = _capture_runner_labels_in_order()
-    assert "bench" in labels, f"no bench runner found; got {labels}"
-    assert "stress" in labels, f"no stress runner found; got {labels}"
+def _agent_matrix_lineno():
+    """Line of ``for agent in registry["agents"]:`` — the matrix loop."""
+    for node in ast.walk(_run_body()):
+        if not isinstance(node, ast.For):
+            continue
+        it = node.iter
+        if (
+            isinstance(it, ast.Subscript)
+            and isinstance(it.value, ast.Name)
+            and it.value.id == "registry"
+            and isinstance(it.slice, ast.Constant)
+            and it.slice.value == "agents"
+        ):
+            return node.lineno
+    raise AssertionError("no `for agent in registry['agents']` loop found")
 
-    bench_at = labels.index("bench")
-    stress_at = labels.index("stress")
-    assert bench_at < stress_at, (
+
+def test_bench_runs_before_the_stress_battery():
+    lines = _capture_runner_lines()
+    assert "bench" in lines, f"no bench runner found; got {sorted(lines)}"
+    assert "stress" in lines, f"no stress runner found; got {sorted(lines)}"
+
+    order = sorted(lines, key=lines.get)
+    assert lines["bench"] < lines["stress"], (
         "the bench must run BEFORE the stress battery, on a server that has "
-        f"served nothing else. Runner order is {labels}. Benching afterwards "
+        f"served nothing else. Runner order is {order}. Benching afterwards "
         "measures residual state and cannot be compared against a baseline "
         "captured on a fresh server — a ~14% cold gap on Qwen3.5-35B-A3B-8bit."
     )
@@ -68,10 +93,10 @@ def test_bench_runs_before_stress_and_agents():
 
 def test_bench_runs_before_the_agent_matrix():
     """The agent matrix is the heavier half of the contamination."""
-    src = inspect.getsource(stress_e2e_bench.StressE2EBenchStep.run)
-    bench_at = src.index('_capture_runner(\n                        "bench"')
-    agents_at = src.index('for agent in registry["agents"]')
-    assert bench_at < agents_at, (
+    lines = _capture_runner_lines()
+    assert "bench" in lines, f"no bench runner found; got {sorted(lines)}"
+
+    assert lines["bench"] < _agent_matrix_lineno(), (
         "the bench must run before the agent matrix; benching after it "
         "measures a server that has already served every agent battery"
     )

--- a/tests/test_bench_runs_on_a_clean_server.py
+++ b/tests/test_bench_runs_on_a_clean_server.py
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: Apache-2.0
+"""The perf bench must measure a server that has served nothing else.
+
+`stress_e2e_bench` used to run the bench LAST, after the stress battery
+and the whole agent matrix had hammered the same server process. It
+therefore measured residual state rather than the code under review,
+while baselines are captured on a fresh server
+(`harness/README.md`) — two different protocols compared against each
+other.
+
+Measured on Qwen3.5-35B-A3B-8bit / M3 Ultra, each group highly
+reproducible within itself::
+
+    after stress + agents : cold 287.6, 288.2 ms
+    fresh server          : cold 252.8, 253.1, 252.0 ms
+
+A ~14% cold gap with under 0.5% spread inside each group — far past the
+5% threshold, so the gate reported a "regression" for a change that only
+edits prompt assembly and a regex, and the identical delta appeared on
+main. Warm moved the other way (~4% faster once the engine is hot),
+which is what made the symptom look like noise.
+
+Ordering is the fix, so ordering is what this pins.
+"""
+
+import ast
+import inspect
+
+from scripts.pr_validate.steps import stress_e2e_bench
+
+
+def _run_body():
+    return ast.parse(
+        inspect.getsource(stress_e2e_bench.StressE2EBenchStep.run).lstrip()
+    )
+
+
+def _capture_runner_labels_in_order():
+    """Labels passed to `_capture_runner`, in source order."""
+    labels = []
+    for node in ast.walk(_run_body()):
+        if not isinstance(node, ast.Call):
+            continue
+        fn = node.func
+        name = getattr(fn, "id", None) or getattr(fn, "attr", None)
+        if name != "_capture_runner" or not node.args:
+            continue
+        first = node.args[0]
+        if isinstance(first, ast.Constant) and isinstance(first.value, str):
+            labels.append(first.value)
+    return labels
+
+
+def test_bench_runs_before_stress_and_agents():
+    labels = _capture_runner_labels_in_order()
+    assert "bench" in labels, f"no bench runner found; got {labels}"
+    assert "stress" in labels, f"no stress runner found; got {labels}"
+
+    bench_at = labels.index("bench")
+    stress_at = labels.index("stress")
+    assert bench_at < stress_at, (
+        "the bench must run BEFORE the stress battery, on a server that has "
+        f"served nothing else. Runner order is {labels}. Benching afterwards "
+        "measures residual state and cannot be compared against a baseline "
+        "captured on a fresh server — a ~14% cold gap on Qwen3.5-35B-A3B-8bit."
+    )
+
+
+def test_bench_runs_before_the_agent_matrix():
+    """The agent matrix is the heavier half of the contamination."""
+    src = inspect.getsource(stress_e2e_bench.StressE2EBenchStep.run)
+    bench_at = src.index('_capture_runner(\n                        "bench"')
+    agents_at = src.index('for agent in registry["agents"]')
+    assert bench_at < agents_at, (
+        "the bench must run before the agent matrix; benching after it "
+        "measures a server that has already served every agent battery"
+    )


### PR DESCRIPTION
## Why

The perf bench ran **last** — after the stress battery and the entire agent matrix had hammered the same server process. It therefore measured residual state, while baselines are captured on a fresh server per `harness/README.md`. Two different protocols, compared against each other.

Measured on `Qwen3.5-35B-A3B-8bit` / M3 Ultra, each group highly reproducible within itself:

| capture state | cold median |
|---|---|
| after stress + agent matrix | 287.6, 288.2 ms |
| fresh server | 252.8, 253.1, 252.0 ms |

A **~14% cold gap with under 0.5% spread inside each group.** Far past the 5% threshold, so the gate was structurally unable to pass: it flagged a "regression" on #1517 — a change that only edits prompt assembly and a regex — and the identical delta reproduced on `main`.

Warm moves the *other* way (~4% faster once the engine is hot), which is exactly what made the symptom read as run-to-run noise instead of a protocol bug.

## How it was actually found

Three wrong guesses first, each stated before there was data to support it:

1. **Concurrent GPU load** — a 20GB serve of mine was up during the first run. Killed it, re-ran clean: `cold +18.4%` vs `+18.2%`. Refuted.
2. **Stale baseline** — captured 2026-07-27 at 0.11.0, ten days and two minor versions back. But benching `main` against it gave `+4.3%`, under threshold. Refuted.
3. **Run-to-run variance** — three independent fresh-server samples came back 252.8 / 253.1 / 252.0. Refuted.

What settled it was a controlled comparison: same machine, same protocol, minutes apart, `main` vs the PR → 253.8 vs 251.2 ms, both fine. Both *contexts* were individually stable; the difference was the context itself.

## The fix

Ordering. The bench moves to first inside the same `_server` block, so no extra model load is paid — stress and the agent matrix follow it.

* `tests/test_bench_runs_on_a_clean_server.py` pins it and fails if the bench is moved back after either stage (verified by mutation).
* `harness/README.md` documents the capture-state contract, with the measurements, so the next baseline refresh matches.

## Sequencing

Baselines still carry their 0.11.0 numbers and are refreshed in a **follow-up** PR. This one lands first on purpose: the reverse order would compare fresh-captured baselines (252.8 ms) against post-stress measurements (288 ms) and fail every PR in between.

Worth noting `scripts/release_baselines.py` was already warning that all five baselines are stale (`captured before v0.12.4`) — it just does not block by default, so nobody acted on it.

## Verification

Full suite **15852 passed, 0 failed**. `ruff check` / `ruff format --check` clean. `scripts/release_baselines.py` audit unchanged (same five staleness warnings, no new findings).
