### PR TITLE
chore(harness): recapture perf baselines on 0.12.4

### DIFF
--- a/harness/baselines/bench-mlx-community--Qwen3.5-35B-A3B-8bit.json
+++ b/harness/baselines/bench-mlx-community--Qwen3.5-35B-A3B-8bit.json
@@ -1,6 +1,6 @@
 {
   "schema": 1,
-  "captured_at": "2026-07-27T23:32:13Z",
+  "captured_at": "2026-08-06T05:12:44Z",
   "family": "qwen3.5",
   "sample_runs": 3,
   "regression_threshold_pct": {
@@ -16,19 +16,19 @@
   "environment": {
     "hardware": {"chip": "Apple M3 Ultra", "memory_gb": 256},
     "software": {
-      "rapid_mlx_version": "0.11.0",
-      "rapid_mlx_commit": "6a445517007ffd14fcefdf58cbfca2008da1c5f0",
+      "rapid_mlx_version": "0.12.4",
+      "rapid_mlx_commit": "f2097169ce0fd294e96a889a9e31615b32141dd5",
       "python": "3.12.13",
       "macos": "26.5.2 (25F84)",
       "mlx": "0.31.2",
       "mlx_lm": "0.31.3",
-      "mlx_vlm": "0.6.3",
-      "mlx_audio": "0.4.3"
+      "mlx_vlm": "0.6.4",
+      "mlx_audio": "0.4.6"
     }
   },
   "metrics": {
-    "cold_request_ms_median": 243.38889122009277,
-    "warm_request_ms_median": 416.8100357055664,
-    "speedup_x": 0.5839324161379408
+    "cold_request_ms_median": 252.78306007385254,
+    "warm_request_ms_median": 375.77295303344727,
+    "speedup_x": 0.6727015822539855
   }
 }

--- a/harness/baselines/bench-mlx-community--Qwen3.6-27B-4bit.json
+++ b/harness/baselines/bench-mlx-community--Qwen3.6-27B-4bit.json
@@ -1,8 +1,8 @@
 {
   "schema": 1,
-  "captured_at": "2026-07-27T23:32:13Z",
+  "captured_at": "2026-08-06T05:13:56Z",
   "family": "qwen3.6",
-  "sample_runs": 2,
+  "sample_runs": 3,
   "regression_threshold_pct": {
     "cold_request_ms_median": 5,
     "warm_request_ms_median": 5
@@ -16,19 +16,19 @@
   "environment": {
     "hardware": {"chip": "Apple M3 Ultra", "memory_gb": 256},
     "software": {
-      "rapid_mlx_version": "0.11.0",
-      "rapid_mlx_commit": "6a445517007ffd14fcefdf58cbfca2008da1c5f0",
+      "rapid_mlx_version": "0.12.4",
+      "rapid_mlx_commit": "f2097169ce0fd294e96a889a9e31615b32141dd5",
       "python": "3.12.13",
       "macos": "26.5.2 (25F84)",
       "mlx": "0.31.2",
       "mlx_lm": "0.31.3",
-      "mlx_vlm": "0.6.3",
-      "mlx_audio": "0.4.3"
+      "mlx_vlm": "0.6.4",
+      "mlx_audio": "0.4.6"
     }
   },
   "metrics": {
-    "cold_request_ms_median": 544.592022895813,
-    "warm_request_ms_median": 822.5079774856567,
-    "speedup_x": 0.6621115391009199
+    "cold_request_ms_median": 378.0820369720459,
+    "warm_request_ms_median": 664.9401187896729,
+    "speedup_x": 0.5685956167906256
   }
 }

--- a/harness/baselines/bench-mlx-community--gpt-oss-20b-MXFP4-Q8.json
+++ b/harness/baselines/bench-mlx-community--gpt-oss-20b-MXFP4-Q8.json
@@ -1,8 +1,8 @@
 {
   "schema": 1,
-  "captured_at": "2026-07-27T23:32:13Z",
+  "captured_at": "2026-08-06T05:26:06Z",
   "family": "harmony",
-  "sample_runs": 2,
+  "sample_runs": 3,
   "regression_threshold_pct": {
     "cold_request_ms_median": 20,
     "warm_request_ms_median": 5
@@ -16,19 +16,19 @@
   "environment": {
     "hardware": {"chip": "Apple M3 Ultra", "memory_gb": 256},
     "software": {
-      "rapid_mlx_version": "0.11.0",
-      "rapid_mlx_commit": "6a445517007ffd14fcefdf58cbfca2008da1c5f0",
+      "rapid_mlx_version": "0.12.4",
+      "rapid_mlx_commit": "f2097169ce0fd294e96a889a9e31615b32141dd5",
       "python": "3.12.13",
       "macos": "26.5.2 (25F84)",
       "mlx": "0.31.2",
       "mlx_lm": "0.31.3",
-      "mlx_vlm": "0.6.3",
-      "mlx_audio": "0.4.3"
+      "mlx_vlm": "0.6.4",
+      "mlx_audio": "0.4.6"
     }
   },
   "metrics": {
-    "cold_request_ms_median": 179.10003662109375,
-    "warm_request_ms_median": 331.07757568359375,
-    "speedup_x": 0.5409609402004839
+    "cold_request_ms_median": 256.8378448486328,
+    "warm_request_ms_median": 348.24109077453613,
+    "speedup_x": 0.7375288317567295
   }
 }

--- a/harness/baselines/bench-unsloth--Qwen3.6-27B-MLX-8bit.json
+++ b/harness/baselines/bench-unsloth--Qwen3.6-27B-MLX-8bit.json
@@ -1,11 +1,11 @@
 {
   "schema": 1,
-  "captured_at": "2026-07-27T23:32:13Z",
+  "captured_at": "2026-08-06T05:27:31Z",
   "family": "qwen3.6",
   "sample_runs": 3,
   "regression_threshold_pct": {
     "cold_request_ms_median": 5,
-    "warm_request_ms_median": 5
+    "warm_request_ms_median": 16
   },
   "model": {
     "id": "unsloth/Qwen3.6-27B-MLX-8bit",
@@ -16,19 +16,19 @@
   "environment": {
     "hardware": {"chip": "Apple M3 Ultra", "memory_gb": 256},
     "software": {
-      "rapid_mlx_version": "0.11.0",
-      "rapid_mlx_commit": "6a445517007ffd14fcefdf58cbfca2008da1c5f0",
+      "rapid_mlx_version": "0.12.4",
+      "rapid_mlx_commit": "f2097169ce0fd294e96a889a9e31615b32141dd5",
       "python": "3.12.13",
       "macos": "26.5.2 (25F84)",
       "mlx": "0.31.2",
       "mlx_lm": "0.31.3",
-      "mlx_vlm": "0.6.3",
-      "mlx_audio": "0.4.3"
+      "mlx_vlm": "0.6.4",
+      "mlx_audio": "0.4.6"
     }
   },
   "metrics": {
-    "cold_request_ms_median": 545.6991195678711,
-    "warm_request_ms_median": 1098.9551544189453,
-    "speedup_x": 0.4965617726743369
+    "cold_request_ms_median": 514.0860080718994,
+    "warm_request_ms_median": 1067.0599937438965,
+    "speedup_x": 0.4817779797630427
   }
 }


### PR DESCRIPTION
## Why

`harness/baselines/` is what `pr_validate`'s `stress_e2e_bench` step compares a
PR against. Those four AR baselines were captured on **2026-07-27 at rapid-mlx
0.11.0**. This tree is 0.12.4. Everything merged in between — nine releases of
scheduler, cache and sampler work — was being folded into the delta the gate
attributed to whatever PR happened to be under review.

That is not hypothetical. Chasing a ~14% "regression" on #1517 cost most of a
session before a controlled same-machine A/B showed main carried the identical
delta. Refs #1520.

## What was measured

Documented profile (M3 Ultra / 256GB), three **independent** samples per model.
The server is restarted between samples, because that is what `pr_validate`
does and because the cold-start component is where the run-to-run variance
lives — sampling three times against one warm server would understate the noise
floor the threshold has to sit above. Committed metric = median of the three.

| model | cold samples (ms) | warm samples (ms) | committed | thr |
|---|---|---|---|---|
| `Qwen3.5-35B-A3B-8bit` | 252.8 / 253.1 / 252.0 | 378.0 / 375.8 / 375.1 | 252.8 / 375.8 | 5 / 5 |
| `Qwen3.6-27B-4bit` | 378.6 / 375.9 / 378.1 | 664.9 / 662.1 / 669.4 | 378.1 / 664.9 | 5 / 5 |
| `gpt-oss-20b-MXFP4-Q8` | 258.6 / 256.8 / 256.3 | 349.5 / 347.9 / 348.2 | 256.8 / 348.2 | 20 / 5 |
| `unsloth/Qwen3.6-27B-MLX-8bit` | 511.5 / 514.1 / 515.6 | 1067.1 / 1060.5 / 1174.8 | 514.1 / 1067.1 | 5 / 16 |

Thresholds are derived from the observed spread (`max deviation from median`,
+50% margin, rounded up) and **never lowered below the committed value** — a
refresh must not silently loosen a gate someone deliberately tightened.

One threshold moves: `unsloth/Qwen3.6-27B-MLX-8bit` warm, 5% → 16%. Its warm
median genuinely swings that far run to run (1060.5 → 1174.8 on back-to-back
clean captures). At 5% that model flags a regression on roughly one clean run
in three, which is worse than no gate at all.

Direction of travel is mostly *faster*: warm on Qwen3.5-35B improves
416.8 → 375.8ms, unsloth 1099.0 → 1067.1ms.

## Ordering dependency — SATISFIED

This needed #1520 to land first. `pr_validate` used to run the bench *after*
the stress and agent phases on the same server, while baselines are captured
on a fresh one; that protocol mismatch was worth ~14% cold, so merging these
fresh-captured numbers under the old gate would have handed every subsequent
PR a false regression.

**#1520 is merged (9c9e4b0d) and this branch is rebased onto it.** The bench
now runs first — `stress_e2e_bench.py:188` (bench) precedes `:213` (stress)
and `:254` (agents). Nothing here is blocked.

## Independently re-verified after the rebase

The committed numbers were re-measured with an interleaved capture on a quiet
machine, fresh server per sample, `Qwen3.5-35B-A3B-8bit`:

| source | cold medians |
|---|---|
| original 3-sample capture | 252.8 / 253.1 / 252.0 |
| re-measure, 2 samples | 255.7 / 252.5 |
| interleaved A/B, 3 samples | 255.2 / 252.6 / 249.8 |

Eight independent fresh-server medians spanning **2.4%**, so the committed
252.8 and its 5% threshold both hold. `gpt-oss-20b-MXFP4-Q8` likewise: 258.6 /
256.8 / 256.3 / 252.1 / 256.9, spread **2.6%**.

That last one matters beyond this PR. Its committed baseline is **179.1ms**
against a true quiet-machine value of ~253 — **+41%**, past its own 20%
threshold — so until this lands, `gpt-oss` reports a perf regression on every
high-blast-radius PR regardless of content. It is not a stale number that
merely lost precision; it is a gate that cannot pass.

One caveat, filed as #1527: the perf gate has no defence against GPU work the
machine does on its own behalf. During one gate run macOS's animated desktop
was decoding video on the GPU and cold came out ~35% high on two of four
models. These captures were taken with the machine quiet, and the 2.4%/2.6%
spreads above are what the metric looks like when it is.

## Not included

`bench-mlx-community--diffusiongemma-26B-A4B-it-4bit.json` is untouched and will
keep emitting a stale WARNING. It failed to load under the harness shim I used
to pin the server to a specific tree — an artifact of that shim's meta-path
manipulation breaking vendored-arch registration, not a product defect
(`pr_validate` loads the model fine). Recapturing it needs a different rig, so
it is left honestly stale rather than refreshed from a run I could not stand
behind. `release_check_m3.sh` calls the auditor without `--strict-stale`, so
this is a warning and not a gate failure.

## Verification

```
$ python3.12 scripts/release_baselines.py
baseline audit: 5/5 candidates covered
WARNING: stale bench-...-diffusiongemma-...json: captured 2026-07-27 before v0.12.4
```

Data-only change: no source file is touched, so there is nothing here for the
unit suite to exercise beyond `tests/test_release_baselines.py`, which validates
every file in `harness/baselines/` against `harness/baseline.schema.json`.
