### PR TITLE
Fix release-blocking chat, Responses, and tool parser regressions

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
@@ -809,7 +809,8 @@ final class ChatViewModel {
     /// Edit a user turn in place: replace its prose, drop everything
     /// that came after it, and re-send. Matches ChatGPT Desktop's
     /// "edit message" pattern — the edit point becomes the new
-    /// conversation tip, no branching, no orphan replies.
+    /// conversation tip. The prior transcript is retained as a sidebar branch
+    /// so later turns are never destroyed by the replay.
     @discardableResult
     func editUserMessage(
         id: UUID,
@@ -820,7 +821,10 @@ final class ChatViewModel {
         let trimmed = newContent.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return false }
         guard let idx = messages.firstIndex(where: { $0.id == id && $0.role == .user }) else { return false }
-        // Truncate everything from the edited row onward, then resend.
+        // Preserve the original transcript under its current conversation id,
+        // then continue the edit as a new branch. A one-click edit of an older
+        // turn must never overwrite all later turns on disk.
+        forkConversationForReplay()
         messages = Array(messages.prefix(idx))
         send(trimmed, alias: alias)
         return true
@@ -855,9 +859,21 @@ final class ChatViewModel {
         guard !userText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             return false
         }
+        // The selected response and every later turn remain available in the
+        // original sidebar conversation; the regenerated path gets a new id.
+        forkConversationForReplay()
         messages = Array(messages.prefix(userIndex))
         send(userText, alias: alias)
         return true
+    }
+
+    /// Snapshot the current transcript and move subsequent replay mutations
+    /// onto a fresh conversation id. This is a lightweight conversation branch:
+    /// the UI can keep its simple linear transcript while Edit/Retry remains
+    /// lossless and the original is recoverable from the sidebar.
+    private func forkConversationForReplay() {
+        persistActive(touching: false)
+        activeConversationID = UUID()
     }
 
     /// Same as ``regenerateLast(alias:)`` but brings up ``newAlias``

--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
@@ -82,6 +82,7 @@ final class ChatViewModel {
     /// transcripts never read or overwrite the user's conversation history.
     /// Production keeps the default enabled.
     private let persistsConversations: Bool
+    private let conversationStoreURL: URL?
 
     /// v0.4.14: user-mutable sampling knobs. Optional in the init
     /// signature so existing tests don't have to spin one up — they
@@ -104,13 +105,17 @@ final class ChatViewModel {
         client: ChatStreamClient = ChatStreamClient(),
         sampling: SamplingConfig? = nil,
         server: ServerManager? = nil,
-        persistsConversations: Bool = true
+        persistsConversations: Bool = true,
+        conversationStoreURL: URL? = nil
     ) {
         self.client = client
         self.sampling = sampling
         self.server = server
         self.persistsConversations = persistsConversations
-        self.conversations = persistsConversations ? ConversationStore.load() : []
+        self.conversationStoreURL = conversationStoreURL
+        self.conversations = persistsConversations
+            ? ConversationStore.load(from: conversationStoreURL)
+            : []
     }
 
     // MARK: - Conversation history (M3)
@@ -153,7 +158,7 @@ final class ChatViewModel {
             )
         }
         if persistsConversations {
-            ConversationStore.save(conversations)
+            ConversationStore.save(conversations, to: conversationStoreURL)
         }
     }
 
@@ -197,7 +202,7 @@ final class ChatViewModel {
         }
         conversations.removeAll { $0.id == id }
         if persistsConversations {
-            ConversationStore.save(conversations)
+            ConversationStore.save(conversations, to: conversationStoreURL)
         }
     }
 

--- a/apps/rapid-mac/Sources/Rapid/Chat/ConversationHistory.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ConversationHistory.swift
@@ -19,7 +19,8 @@ extension ChatConversation: ConversationOrderingItem {}
 /// real app's. Writes are atomic; a missing / unreadable file reads as an
 /// empty history (first run).
 enum ConversationStore {
-    static func fileURL() -> URL {
+    static func fileURL(override: URL? = nil) -> URL {
+        if let override { return override }
         // Must go through the locator: a direct FileManager call ignores
         // $HOME overrides, which is the #419/#420 shape a dogfood build
         // depends on (and what ApplicationSupportLocatorTests forbids).
@@ -34,8 +35,8 @@ enum ConversationStore {
         return dir.appendingPathComponent("conversations.json")
     }
 
-    static func load() -> [ChatConversation] {
-        let url = fileURL()
+    static func load(from override: URL? = nil) -> [ChatConversation] {
+        let url = fileURL(override: override)
         let fm = FileManager.default
         // A genuinely MISSING file is a normal first run → empty history.
         guard fm.fileExists(atPath: url.path) else { return [] }
@@ -86,10 +87,14 @@ enum ConversationStore {
     /// growth would stall the UI. The snapshot is passed by value (Codable
     /// value types), so the background write sees a stable copy, and the
     /// serial ``writeQueue`` keeps ordering.
-    static func save(_ conversations: [ChatConversation]) {
+    static func save(_ conversations: [ChatConversation], to override: URL? = nil) {
         writeQueue.async {
             guard let data = try? JSONEncoder().encode(conversations) else { return }
-            let url = fileURL()
+            let url = fileURL(override: override)
+            try? FileManager.default.createDirectory(
+                at: url.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
             // Owner-only (0600): chat transcripts are private. The atomic
             // write would otherwise inherit the umask default (often 0644 =
             // world-readable), exposing history to other local users.

--- a/apps/rapid-mac/Tests/RapidTests/ChatMessageActionsTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ChatMessageActionsTests.swift
@@ -1,9 +1,20 @@
+import Foundation
 import Testing
 @testable import Rapid
 
 @MainActor
 @Suite("Chat message actions")
 struct ChatMessageActionsTests {
+    private func isolatedStoreURL() throws -> (root: URL, file: URL) {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("rapid-chat-actions-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(
+            at: root,
+            withIntermediateDirectories: true
+        )
+        return (root, root.appendingPathComponent("conversations.json"))
+    }
+
     @Test("Editing an older user message drops the later turns and resends the edit")
     func editOlderUserMessageRewindsConversation() {
         let viewModel = ChatViewModel(persistsConversations: false)
@@ -56,8 +67,10 @@ struct ChatMessageActionsTests {
     }
 
     @Test("Retrying an older response preserves the original conversation as a branch")
-    func retryOlderAssistantPreservesOriginalBranch() {
-        let viewModel = ChatViewModel(persistsConversations: false)
+    func retryOlderAssistantPreservesOriginalBranch() throws {
+        let store = try isolatedStoreURL()
+        defer { try? FileManager.default.removeItem(at: store.root) }
+        let viewModel = ChatViewModel(conversationStoreURL: store.file)
         let firstUser = ChatMessage(role: .user, content: "first question")
         let firstAssistant = ChatMessage(role: .assistant, content: "first answer")
         let secondUser = ChatMessage(role: .user, content: "second question")
@@ -70,17 +83,21 @@ struct ChatMessageActionsTests {
             id: firstAssistant.id,
             alias: "test-model"
         )
-        defer { viewModel.stopAndPersist() }
-
         #expect(retried)
         #expect(viewModel.activeConversationID != originalID)
-        let preserved = viewModel.conversations.first(where: { $0.id == originalID })
+        viewModel.stopAndPersist()
+        ConversationStore.flush()
+
+        let reloaded = ChatViewModel(conversationStoreURL: store.file)
+        let preserved = reloaded.conversations.first(where: { $0.id == originalID })
         #expect(preserved?.messages == original)
     }
 
     @Test("Editing an older message preserves the original conversation as a branch")
-    func editOlderUserPreservesOriginalBranch() {
-        let viewModel = ChatViewModel(persistsConversations: false)
+    func editOlderUserPreservesOriginalBranch() throws {
+        let store = try isolatedStoreURL()
+        defer { try? FileManager.default.removeItem(at: store.root) }
+        let viewModel = ChatViewModel(conversationStoreURL: store.file)
         let firstUser = ChatMessage(role: .user, content: "first question")
         let firstAssistant = ChatMessage(role: .assistant, content: "first answer")
         let secondUser = ChatMessage(role: .user, content: "second question")
@@ -94,11 +111,13 @@ struct ChatMessageActionsTests {
             newContent: "edited question",
             alias: "test-model"
         )
-        defer { viewModel.stopAndPersist() }
-
         #expect(edited)
         #expect(viewModel.activeConversationID != originalID)
-        let preserved = viewModel.conversations.first(where: { $0.id == originalID })
+        viewModel.stopAndPersist()
+        ConversationStore.flush()
+
+        let reloaded = ChatViewModel(conversationStoreURL: store.file)
+        let preserved = reloaded.conversations.first(where: { $0.id == originalID })
         #expect(preserved?.messages == original)
     }
 }

--- a/apps/rapid-mac/Tests/RapidTests/ChatMessageActionsTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ChatMessageActionsTests.swift
@@ -54,4 +54,51 @@ struct ChatMessageActionsTests {
         #expect(!viewModel.messages.contains(where: { $0.id == secondUser.id }))
         #expect(!viewModel.messages.contains(where: { $0.id == secondAssistant.id }))
     }
+
+    @Test("Retrying an older response preserves the original conversation as a branch")
+    func retryOlderAssistantPreservesOriginalBranch() {
+        let viewModel = ChatViewModel(persistsConversations: false)
+        let firstUser = ChatMessage(role: .user, content: "first question")
+        let firstAssistant = ChatMessage(role: .assistant, content: "first answer")
+        let secondUser = ChatMessage(role: .user, content: "second question")
+        let secondAssistant = ChatMessage(role: .assistant, content: "second answer")
+        let original = [firstUser, firstAssistant, secondUser, secondAssistant]
+        viewModel.devSeedMessages(original)
+        let originalID = viewModel.activeConversationID
+
+        let retried = viewModel.retryAssistantMessage(
+            id: firstAssistant.id,
+            alias: "test-model"
+        )
+        defer { viewModel.stopAndPersist() }
+
+        #expect(retried)
+        #expect(viewModel.activeConversationID != originalID)
+        let preserved = viewModel.conversations.first(where: { $0.id == originalID })
+        #expect(preserved?.messages == original)
+    }
+
+    @Test("Editing an older message preserves the original conversation as a branch")
+    func editOlderUserPreservesOriginalBranch() {
+        let viewModel = ChatViewModel(persistsConversations: false)
+        let firstUser = ChatMessage(role: .user, content: "first question")
+        let firstAssistant = ChatMessage(role: .assistant, content: "first answer")
+        let secondUser = ChatMessage(role: .user, content: "second question")
+        let secondAssistant = ChatMessage(role: .assistant, content: "second answer")
+        let original = [firstUser, firstAssistant, secondUser, secondAssistant]
+        viewModel.devSeedMessages(original)
+        let originalID = viewModel.activeConversationID
+
+        let edited = viewModel.editUserMessage(
+            id: firstUser.id,
+            newContent: "edited question",
+            alias: "test-model"
+        )
+        defer { viewModel.stopAndPersist() }
+
+        #expect(edited)
+        #expect(viewModel.activeConversationID != originalID)
+        let preserved = viewModel.conversations.first(where: { $0.id == originalID })
+        #expect(preserved?.messages == original)
+    }
 }

--- a/tests/test_responses_engine_failure_envelope.py
+++ b/tests/test_responses_engine_failure_envelope.py
@@ -17,6 +17,7 @@ shape so a future regression that re-introduces the silent path
 trips a CI failure rather than waiting for another dogfood report.
 """
 
+import asyncio
 import json
 import sys
 import types
@@ -40,30 +41,35 @@ async def test_deepseek_codex_nonprogress_retry_is_internal(monkeypatch):
     async def fake_stream(*args, nonprogress_retry=False, **kwargs):
         calls.append(nonprogress_retry)
         state = kwargs["heartbeat_state"]
+        public_id = kwargs.get("response_id_override")
         if not nonprogress_retry:
             state["response"] = {"id": "hidden-attempt"}
-            assert visible_heartbeat_state == {}
-            yield 'data: {"type":"response.created","attempt":1}\n\n'
+            assert visible_heartbeat_state["response"]["id"] == public_id
+            yield json.dumps(
+                {"type": "response.created", "response": {"id": public_id}}
+            ).join(["data: ", "\n\n"])
             yield (
                 'data: {"type":"response.failed","response":{"error":'
                 '{"code":"model_no_final_answer"}}}\n\n'
             )
         else:
             state["response"] = {"id": "visible-attempt"}
-            yield 'data: {"type":"response.created","attempt":2}\n\n'
             yield 'data: {"type":"response.completed","attempt":2}\n\n'
 
     monkeypatch.setattr(responses_route, "_stream_responses", fake_stream)
     monkeypatch.setattr(
         responses_route,
         "get_config",
-        lambda: SimpleNamespace(tool_call_parser="deepseek_v4_0731"),
+        lambda: SimpleNamespace(tool_call_parser="deepseek_v4_0731", model_name=None),
     )
     request = SimpleNamespace(
+        model="test-model",
+        parallel_tool_calls=False,
+        tool_choice="auto",
         tools=[
             {"type": "function", "name": "exec_command"},
             {"type": "function", "name": "write_stdin"},
-        ]
+        ],
     )
 
     events = [
@@ -74,10 +80,99 @@ async def test_deepseek_codex_nonprogress_retry_is_internal(monkeypatch):
     ]
 
     assert calls == [False, True]
-    assert all('"attempt":1' not in event for event in events)
+    assert all("hidden-attempt" not in event for event in events)
     assert all('"type":"response.failed"' not in event for event in events)
     assert any('"type":"response.completed"' in event for event in events)
     assert visible_heartbeat_state["response"] == {"id": "visible-attempt"}
+
+
+@pytest.mark.asyncio
+async def test_deepseek_retry_never_sends_heartbeat_before_response_created(
+    monkeypatch,
+):
+    """A slow hidden attempt must not put an invalid lifecycle event first."""
+    import vllm_mlx.routes.responses as responses_route
+    from vllm_mlx.service.helpers import _disconnect_guard
+
+    class ConnectedRequest:
+        async def is_disconnected(self):
+            return False
+
+    async def fake_stream(*args, nonprogress_retry=False, **kwargs):
+        state = kwargs["heartbeat_state"]
+        sequence = kwargs["sequence_counter"]
+
+        def emit(event_type, extra=""):
+            payload = (
+                f'{{"type":"{event_type}","sequence_number":{sequence[0]}{extra}}}'
+            )
+            sequence[0] += 1
+            return f"event: {event_type}\ndata: {payload}\n\n"
+
+        state["response"] = {
+            "id": "visible-attempt" if nonprogress_retry else "hidden-attempt"
+        }
+        state["sequence_number"] = sequence
+        if kwargs.get("emit_initial_lifecycle", True):
+            yield emit("response.created")
+            yield emit("response.in_progress")
+        if not nonprogress_retry:
+            # Longer than the test keepalive interval: this is a 20+ second
+            # prefill/reasoning pause in production.
+            await asyncio.sleep(0.03)
+            yield emit(
+                "response.failed",
+                ',"response":{"error":{"code":"model_no_final_answer"}}',
+            )
+        else:
+            yield emit("response.completed")
+
+    monkeypatch.setattr(responses_route, "_stream_responses", fake_stream)
+    monkeypatch.setattr(
+        responses_route,
+        "get_config",
+        lambda: SimpleNamespace(tool_call_parser="deepseek_v4_0731", model_name=None),
+    )
+    request = SimpleNamespace(
+        model="test-model",
+        parallel_tool_calls=False,
+        tool_choice="auto",
+        tools=[
+            {"type": "function", "name": "exec_command"},
+            {"type": "function", "name": "write_stdin"},
+        ],
+    )
+    visible_state: dict[str, object] = {}
+    stream = responses_route._stream_responses_with_nonprogress_retry(
+        object(), object(), request, heartbeat_state=visible_state
+    )
+    events = [
+        event
+        async for event in _disconnect_guard(
+            stream,
+            ConnectedRequest(),
+            keepalive_seconds=0.01,
+            keepalive_factory=lambda: responses_route._responses_keepalive_sse(
+                visible_state
+            ),
+        )
+    ]
+
+    data_events = [
+        json.loads(line[6:])
+        for event in events
+        for line in event.splitlines()
+        if line.startswith("data: ")
+    ]
+    first_data = data_events[0]
+    assert first_data["type"] == "response.created"
+    assert first_data["sequence_number"] == 0
+    assert [event["sequence_number"] for event in data_events] == list(
+        range(len(data_events))
+    )
+    assert sum(event["type"] == "response.created" for event in data_events) == 1
+    assert all(event["type"] != "response.failed" for event in data_events)
+    assert any(event["type"] == "response.completed" for event in data_events), events
 
 
 class _Tokenizer:

--- a/tests/test_responses_engine_failure_envelope.py
+++ b/tests/test_responses_engine_failure_envelope.py
@@ -110,7 +110,9 @@ async def test_deepseek_retry_never_sends_heartbeat_before_response_created(
             return f"event: {event_type}\ndata: {payload}\n\n"
 
         state["response"] = {
-            "id": "visible-attempt" if nonprogress_retry else "hidden-attempt"
+            "id": kwargs["response_id_override"]
+            if nonprogress_retry
+            else "hidden-attempt"
         }
         state["sequence_number"] = sequence
         if kwargs.get("emit_initial_lifecycle", True):
@@ -173,6 +175,11 @@ async def test_deepseek_retry_never_sends_heartbeat_before_response_created(
     assert sum(event["type"] == "response.created" for event in data_events) == 1
     assert all(event["type"] != "response.failed" for event in data_events)
     assert any(event["type"] == "response.completed" for event in data_events), events
+    public_id = first_data["response"]["id"]
+    assert all(
+        event.get("response", {}).get("id", public_id) == public_id
+        for event in data_events
+    )
 
 
 class _Tokenizer:

--- a/tests/test_tool_parser_content_passthrough.py
+++ b/tests/test_tool_parser_content_passthrough.py
@@ -154,6 +154,13 @@ DECLARED_TOOLS = [
         },
     }
 ]
+READ_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "read_file",
+        "parameters": {"type": "object", "properties": {}},
+    },
+}
 
 
 def _qwen3coder():
@@ -188,6 +195,24 @@ class TestOnlyDeclaredToolsBecomeCalls:
         result = _qwen3coder().extract_tool_calls(text, request)
         assert result.tools_called is False
         assert result.content == text
+
+    def test_named_tool_choice_rejects_a_different_declared_name(self):
+        text = "<function=write_file></function>"
+        request = {
+            "tools": [*DECLARED_TOOLS, READ_TOOL],
+            "tool_choice": {
+                "type": "function",
+                "function": {"name": "read_file"},
+            },
+        }
+        result = _qwen3coder().extract_tool_calls(text, request)
+        assert result.tools_called is False
+        assert result.content == text
+
+        streaming = _qwen3coder().extract_tool_calls_streaming(
+            "", text, text, request=request
+        )
+        assert streaming == {"content": text}
 
     @pytest.mark.parametrize(
         "request_payload",
@@ -273,6 +298,42 @@ class TestOnlyDeclaredToolsBecomeCalls:
                 text,
                 Request(),
                 structured_tool_calls=structured,
+            )
+        finally:
+            cfg.enable_auto_tool_choice, cfg.tool_call_parser = saved
+
+        assert content == text
+        assert calls is None
+
+    def test_service_helper_enforces_named_tool_choice_on_structured_calls(
+        self, monkeypatch
+    ):
+        text = "The model selected a different declared tool."
+
+        class Request:
+            def model_dump(self):
+                return {
+                    "tools": [*DECLARED_TOOLS, READ_TOOL],
+                    "tool_choice": {
+                        "type": "function",
+                        "function": {"name": "read_file"},
+                    },
+                }
+
+        cfg = get_config()
+        saved = (cfg.enable_auto_tool_choice, cfg.tool_call_parser)
+        cfg.enable_auto_tool_choice = True
+        cfg.tool_call_parser = "qwen3_coder_xml"
+        monkeypatch.setattr(
+            helpers,
+            "parse_tool_calls",
+            lambda *args, **kwargs: pytest.fail("named choice was bypassed"),
+        )
+        try:
+            content, calls = helpers._parse_tool_calls_with_parser(
+                text,
+                Request(),
+                structured_tool_calls=[{"name": "write_file", "arguments": "{}"}],
             )
         finally:
             cfg.enable_auto_tool_choice, cfg.tool_call_parser = saved

--- a/tests/test_tool_parser_content_passthrough.py
+++ b/tests/test_tool_parser_content_passthrough.py
@@ -214,6 +214,32 @@ class TestOnlyDeclaredToolsBecomeCalls:
         )
         assert streaming == {"content": text}
 
+    def test_matching_named_choice_allows_a_bare_zero_arg_call(self):
+        text = "<function=write_file></function>"
+        request = {
+            "tools": DECLARED_TOOLS,
+            "tool_choice": {
+                "type": "function",
+                "function": {"name": "write_file"},
+            },
+        }
+        result = _qwen3coder().extract_tool_calls(text, request)
+        assert result.tools_called is True
+        assert result.tool_calls[0]["name"] == "write_file"
+
+        parser = _qwen3coder()
+        previous = ""
+        calls = []
+        for chunk in ["<function=write_file>", "</function>"]:
+            current = previous + chunk
+            delta = parser.extract_tool_calls_streaming(
+                previous, current, chunk, request=request
+            )
+            if delta:
+                calls.extend(delta.get("tool_calls", []))
+            previous = current
+        assert any(call["function"]["name"] == "write_file" for call in calls)
+
     @pytest.mark.parametrize(
         "chunks",
         [

--- a/tests/test_tool_parser_content_passthrough.py
+++ b/tests/test_tool_parser_content_passthrough.py
@@ -28,6 +28,8 @@ not be able to lose text to the tool layer.
 
 import pytest
 
+from vllm_mlx.config import get_config
+from vllm_mlx.service import helpers
 from vllm_mlx.tool_parsers.abstract_tool_parser import ToolParserManager
 
 # Registered parser names, one per wire family. Aliases of the same class
@@ -96,12 +98,6 @@ def test_miss_path_returns_content_uncut(parser_name, text):
     )
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="#1513 — qwen3_coder_xml still fabricates calls from prose. "
-    "Split out of the </tool_call> fix: the parser gate needs the streaming "
-    "path, the generic fallback and tool_choice to be handled together.",
-)
 def test_qwen3coder_regression_bare_function_mention():
     """The exact measured regression, pinned on its own.
 
@@ -167,12 +163,6 @@ def _qwen3coder():
 class TestOnlyDeclaredToolsBecomeCalls:
     """A name the request never offered can never be executed."""
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="#1513 — qwen3_coder_xml still fabricates calls from prose. "
-        "Split out of the </tool_call> fix: the parser gate needs the streaming "
-        "path, the generic fallback and tool_choice to be handled together.",
-    )
     def test_balanced_prose_with_no_tools_declared(self):
         """codex r1 BLOCKING: closed spans in prose were still promoted."""
         text = "Docs: write <function=read_file></function> to show an empty call."
@@ -180,29 +170,115 @@ class TestOnlyDeclaredToolsBecomeCalls:
         assert result.tools_called is False
         assert result.content == text
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="#1513 — qwen3_coder_xml still fabricates calls from prose. "
-        "Split out of the </tool_call> fix: the parser gate needs the streaming "
-        "path, the generic fallback and tool_choice to be handled together.",
-    )
     def test_balanced_prose_naming_an_undeclared_tool(self):
         text = "Docs: write <function=read_file></function> to show an empty call."
         result = _qwen3coder().extract_tool_calls(text, {"tools": DECLARED_TOOLS})
         assert result.tools_called is False
         assert result.content == text
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="#1513 — qwen3_coder_xml still fabricates calls from prose. "
-        "Split out of the </tool_call> fix: the parser gate needs the streaming "
-        "path, the generic fallback and tool_choice to be handled together.",
-    )
     def test_unclosed_prose_with_no_tools_declared(self):
         text = "Docs mention </tool_call> and <function=name> together."
         result = _qwen3coder().extract_tool_calls(text, None)
         assert result.tools_called is False
         assert result.content == text
+
+    def test_tool_choice_none_never_promotes_a_declared_name(self):
+        text = "Docs: write <function=write_file></function> to show an empty call."
+        request = {"tools": DECLARED_TOOLS, "tool_choice": "none"}
+        result = _qwen3coder().extract_tool_calls(text, request)
+        assert result.tools_called is False
+        assert result.content == text
+
+    @pytest.mark.parametrize(
+        "request_payload",
+        [
+            None,
+            {"tools": DECLARED_TOOLS, "tool_choice": "none"},
+            {
+                "tools": [
+                    {
+                        "type": "function",
+                        "function": {"name": "read_file", "parameters": {}},
+                    }
+                ]
+            },
+        ],
+    )
+    def test_streaming_prose_is_not_promoted_without_an_allowed_tool(
+        self, request_payload
+    ):
+        parser = _qwen3coder()
+        chunks = [
+            "Docs: write ",
+            "<function=",
+            "write_file>",
+            "</function> to show an empty call.",
+        ]
+        previous = ""
+        content = []
+        calls = []
+        for chunk in chunks:
+            current = previous + chunk
+            result = parser.extract_tool_calls_streaming(
+                previous,
+                current,
+                chunk,
+                request=request_payload,
+            )
+            if result:
+                content.append(result.get("content", ""))
+                calls.extend(result.get("tool_calls", []))
+            previous = current
+
+        assert calls == []
+        assert "".join(content) == "".join(chunks)
+
+    def test_streaming_undeclared_span_in_one_chunk_is_preserved(self):
+        parser = _qwen3coder()
+        text = "Docs: <function=write_file></function> is the wire form."
+        request = {
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {"name": "read_file", "parameters": {}},
+                }
+            ]
+        }
+        result = parser.extract_tool_calls_streaming("", text, text, request=request)
+        assert result == {"content": text}
+
+    @pytest.mark.parametrize(
+        "structured", [None, [{"name": "read_file", "arguments": "{}"}]]
+    )
+    def test_service_helper_cannot_repromote_an_undeclared_span(
+        self, monkeypatch, structured
+    ):
+        text = "Docs: <function=read_file></function> is the wire form."
+
+        class Request:
+            def model_dump(self):
+                return {"tools": DECLARED_TOOLS}
+
+        cfg = get_config()
+        saved = (cfg.enable_auto_tool_choice, cfg.tool_call_parser)
+        cfg.enable_auto_tool_choice = True
+        cfg.tool_call_parser = "qwen3_coder_xml"
+        monkeypatch.setattr(
+            helpers,
+            "parse_tool_calls",
+            lambda *args, **kwargs: pytest.fail("generic fallback re-promoted prose"),
+        )
+        try:
+            content, calls = helpers._parse_tool_calls_with_parser(
+                text,
+                Request(),
+                structured_tool_calls=structured,
+            )
+        finally:
+            cfg.enable_auto_tool_choice, cfg.tool_call_parser = saved
+
+        assert content == text
+        assert calls is None
 
 
 class TestTruncatedCallsStillRecover:

--- a/tests/test_tool_parser_content_passthrough.py
+++ b/tests/test_tool_parser_content_passthrough.py
@@ -215,6 +215,48 @@ class TestOnlyDeclaredToolsBecomeCalls:
         assert streaming == {"content": text}
 
     @pytest.mark.parametrize(
+        "chunks",
+        [
+            ["Docs: <function=write_file></function> is the wire form."],
+            [
+                "Docs: ",
+                "<function=write_file>",
+                "</function> is the wire form.",
+            ],
+        ],
+    )
+    def test_declared_zero_arg_bare_prose_is_not_executable(self, chunks):
+        text = "".join(chunks)
+        request = {"tools": DECLARED_TOOLS, "tool_choice": "auto"}
+        result = _qwen3coder().extract_tool_calls(text, request)
+        assert result.tools_called is False
+        assert result.content == text
+
+        parser = _qwen3coder()
+        previous = ""
+        content = []
+        calls = []
+        for chunk in chunks:
+            current = previous + chunk
+            delta = parser.extract_tool_calls_streaming(
+                previous, current, chunk, request=request
+            )
+            if delta:
+                content.append(delta.get("content", ""))
+                calls.extend(delta.get("tool_calls", []))
+            previous = current
+        assert calls == []
+        assert "".join(content) == text
+
+    def test_wrapped_zero_arg_declared_call_remains_executable(self):
+        wire = "<tool_call><function=write_file></function></tool_call>"
+        result = _qwen3coder().extract_tool_calls(
+            wire, {"tools": DECLARED_TOOLS, "tool_choice": "auto"}
+        )
+        assert result.tools_called is True
+        assert result.tool_calls[0]["name"] == "write_file"
+
+    @pytest.mark.parametrize(
         "request_payload",
         [
             None,

--- a/vllm_mlx/routes/responses.py
+++ b/vllm_mlx/routes/responses.py
@@ -2445,11 +2445,11 @@ async def _stream_responses_with_nonprogress_retry(
         sequence_counter=attempt_sequence,
         emit_initial_lifecycle=False,
     ):
-        if heartbeat_state is not None:
-            heartbeat_state.clear()
-            heartbeat_state.update(attempt_heartbeat_state)
-            heartbeat_state["sequence_number"] = public_sequence
         if committed:
+            if heartbeat_state is not None:
+                heartbeat_state.clear()
+                heartbeat_state.update(attempt_heartbeat_state)
+                heartbeat_state["sequence_number"] = public_sequence
             yield _responses_resequence_event(event, public_sequence)
             continue
         event_bytes = len(event.encode("utf-8"))
@@ -2469,6 +2469,10 @@ async def _stream_responses_with_nonprogress_retry(
                 buffered_bytes + event_bytes,
             )
         if committed:
+            if heartbeat_state is not None:
+                heartbeat_state.clear()
+                heartbeat_state.update(attempt_heartbeat_state)
+                heartbeat_state["sequence_number"] = public_sequence
             for pending in buffered:
                 yield _responses_resequence_event(pending, public_sequence)
             buffered.clear()

--- a/vllm_mlx/routes/responses.py
+++ b/vllm_mlx/routes/responses.py
@@ -2397,6 +2397,37 @@ async def _stream_responses_with_nonprogress_retry(
     # Responses heartbeats at the configured interval. Keep the attempt's
     # lifecycle private until it commits so a heartbeat cannot expose an ID
     # that will be discarded by the transparent retry.
+    # The transparent retry owns one public Responses lifecycle. Expose its
+    # created/in-progress pair immediately and let both engine attempts share
+    # the same id. Public events and keepalives use their own counter so buffered
+    # or discarded attempt events cannot leave gaps in the visible sequence.
+    public_response_id = f"resp_{uuid.uuid4().hex[:24]}"
+    public_created_at = int(time.time())
+    public_sequence = [0]
+    attempt_sequence = [0]
+    public_response = _responses_initial_payload(
+        response_id=public_response_id,
+        created_at=public_created_at,
+        served_model=cfg.model_name or responses_request.model,
+        responses_request=responses_request,
+    )
+    if heartbeat_state is not None:
+        heartbeat_state["response"] = public_response
+        heartbeat_state["sequence_number"] = public_sequence
+    yield _responses_resequence_event(
+        _sse(
+            "response.created",
+            {"type": "response.created", "response": public_response},
+        ),
+        public_sequence,
+    )
+    yield _responses_resequence_event(
+        _sse(
+            "response.in_progress",
+            {"type": "response.in_progress", "response": public_response},
+        ),
+        public_sequence,
+    )
     attempt_heartbeat_state: dict[str, object] = {}
     buffered: list[str] = []
     buffered_bytes = 0
@@ -2409,12 +2440,17 @@ async def _stream_responses_with_nonprogress_retry(
         explicit_no_thinking=explicit_no_thinking,
         request_id_holder=request_id_holder,
         heartbeat_state=attempt_heartbeat_state,
+        response_id_override=public_response_id,
+        created_at_override=public_created_at,
+        sequence_counter=attempt_sequence,
+        emit_initial_lifecycle=False,
     ):
+        if heartbeat_state is not None:
+            heartbeat_state.clear()
+            heartbeat_state.update(attempt_heartbeat_state)
+            heartbeat_state["sequence_number"] = public_sequence
         if committed:
-            if heartbeat_state is not None:
-                heartbeat_state.clear()
-                heartbeat_state.update(attempt_heartbeat_state)
-            yield event
+            yield _responses_resequence_event(event, public_sequence)
             continue
         event_bytes = len(event.encode("utf-8"))
         event_buffered = False
@@ -2433,25 +2469,19 @@ async def _stream_responses_with_nonprogress_retry(
                 buffered_bytes + event_bytes,
             )
         if committed:
-            if heartbeat_state is not None:
-                heartbeat_state.clear()
-                heartbeat_state.update(attempt_heartbeat_state)
             for pending in buffered:
-                yield pending
+                yield _responses_resequence_event(pending, public_sequence)
             buffered.clear()
             if not event_buffered:
-                yield event
+                yield _responses_resequence_event(event, public_sequence)
         elif _responses_event_is_nonprogress_failure(event):
             retry_nonprogress = True
 
     if committed:
         return
     if not retry_nonprogress:
-        if heartbeat_state is not None:
-            heartbeat_state.clear()
-            heartbeat_state.update(attempt_heartbeat_state)
         for event in buffered:
-            yield event
+            yield _responses_resequence_event(event, public_sequence)
         return
 
     logger.warning(
@@ -2467,6 +2497,10 @@ async def _stream_responses_with_nonprogress_retry(
         request_id_holder=request_id_holder,
         heartbeat_state=heartbeat_state,
         nonprogress_retry=True,
+        response_id_override=public_response_id,
+        created_at_override=public_created_at,
+        sequence_counter=public_sequence,
+        emit_initial_lifecycle=False,
     ):
         yield event
 
@@ -2488,6 +2522,45 @@ def _responses_event_commits_progress(event: str) -> bool:
             if item_type in {"function_call", "computer_call"}:
                 return True
     return False
+
+
+def _responses_resequence_event(event: str, sequence: list[int]) -> str:
+    """Assign the next public sequence number to one buffered SSE event."""
+    for line in event.splitlines():
+        if not line.startswith("data: "):
+            continue
+        try:
+            data = json.loads(line[6:])
+        except (TypeError, ValueError):
+            return event
+        event_type = data.get("type")
+        if not isinstance(event_type, str):
+            return event
+        data["sequence_number"] = sequence[0]
+        sequence[0] += 1
+        return _sse(event_type, data)
+    return event
+
+
+def _responses_initial_payload(
+    *,
+    response_id: str,
+    created_at: int,
+    served_model: str,
+    responses_request: ResponsesRequest,
+) -> dict:
+    """Build the shared response object used by initial lifecycle events."""
+    return {
+        "id": response_id,
+        "object": "response",
+        "created_at": created_at,
+        "status": "in_progress",
+        "model": served_model,
+        "output": [],
+        "parallel_tool_calls": bool(responses_request.parallel_tool_calls),
+        "tool_choice": responses_request.tool_choice or "auto",
+        "tools": responses_request.tools or [],
+    }
 
 
 def _responses_event_is_nonprogress_failure(event: str) -> bool:
@@ -2516,6 +2589,10 @@ async def _stream_responses(
     request_id_holder: list | None = None,
     heartbeat_state: dict[str, object] | None = None,
     nonprogress_retry: bool = False,
+    response_id_override: str | None = None,
+    created_at_override: int | None = None,
+    sequence_counter: list[int] | None = None,
+    emit_initial_lifecycle: bool = True,
 ) -> AsyncIterator[str]:
     """Stream a Responses-API SSE event sequence Codex CLI can parse.
 
@@ -2547,8 +2624,8 @@ async def _stream_responses(
     we always finalize.
     """
     cfg = get_config()
-    response_id = f"resp_{uuid.uuid4().hex[:24]}"
-    created_at = int(time.time())
+    response_id = response_id_override or f"resp_{uuid.uuid4().hex[:24]}"
+    created_at = created_at_override or int(time.time())
     start_time = time.perf_counter()
     served_model = cfg.model_name or responses_request.model
 
@@ -2556,7 +2633,7 @@ async def _stream_responses(
     # required on every Responses-API event. Monotonic counter starting
     # at 0, incremented per yielded event. Wrap ``_sse`` via a helper so
     # the bookkeeping stays in one place.
-    _seq = [0]
+    _seq = sequence_counter if sequence_counter is not None else [0]
     if heartbeat_state is not None:
         heartbeat_state["sequence_number"] = _seq
 
@@ -2571,26 +2648,22 @@ async def _stream_responses(
     # so consumers like openai-python ``Response.model_validate`` accept
     # the streaming payload too. ``output`` starts empty and is rebuilt
     # below before ``response.completed`` is emitted.
-    _initial_response_payload = {
-        "id": response_id,
-        "object": "response",
-        "created_at": created_at,
-        "status": "in_progress",
-        "model": served_model,
-        "output": [],
-        "parallel_tool_calls": bool(responses_request.parallel_tool_calls),
-        "tool_choice": responses_request.tool_choice or "auto",
-        "tools": responses_request.tools or [],
-    }
+    _initial_response_payload = _responses_initial_payload(
+        response_id=response_id,
+        created_at=created_at,
+        served_model=served_model,
+        responses_request=responses_request,
+    )
     if heartbeat_state is not None:
         heartbeat_state["response"] = _initial_response_payload
-    yield _emit(
-        "response.created",
-        {
-            "type": "response.created",
-            "response": _initial_response_payload,
-        },
-    )
+    if emit_initial_lifecycle:
+        yield _emit(
+            "response.created",
+            {
+                "type": "response.created",
+                "response": _initial_response_payload,
+            },
+        )
     # R10-C3: the OpenAI Responses SSE spec mandates ``response.in_progress``
     # between ``response.created`` and the first ``response.output_item.added``.
     # The ``openai-python`` SDK transitions internal state on it (sets
@@ -2601,13 +2674,14 @@ async def _stream_responses(
     # arrives without the intermediate transition. Sven r10-R1 captured
     # exactly this on 0.8.11. Payload mirrors ``created`` because no
     # generation state has changed yet, just the lifecycle marker.
-    yield _emit(
-        "response.in_progress",
-        {
-            "type": "response.in_progress",
-            "response": _initial_response_payload,
-        },
-    )
+    if emit_initial_lifecycle:
+        yield _emit(
+            "response.in_progress",
+            {
+                "type": "response.in_progress",
+                "response": _initial_response_payload,
+            },
+        )
     try:
         messages = _prepare_messages_for_engine(engine, openai_request)
         codex_surface = _is_deepseek_codex_surface(

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -2742,6 +2742,21 @@ def _validate_model_name(request_model: str) -> None:
 # ── Tool call parsing ──────────────────────────────────────────────
 
 
+def _request_declared_tool_names(request_dict: dict | None) -> set[str]:
+    """Executable function names after applying tool_choice=none."""
+    if not isinstance(request_dict, dict) or request_dict.get("tool_choice") == "none":
+        return set()
+    names: set[str] = set()
+    for tool in request_dict.get("tools") or []:
+        if not isinstance(tool, dict):
+            continue
+        function = tool.get("function")
+        name = function.get("name") if isinstance(function, dict) else tool.get("name")
+        if isinstance(name, str) and name:
+            names.add(name)
+    return names
+
+
 def _parse_tool_calls_with_parser(
     output_text: str,
     request=None,
@@ -2763,7 +2778,19 @@ def _parse_tool_calls_with_parser(
     #515 codex round-12 / round-14 BLOCKING). ``output_text`` becomes
     the user-facing content directly in that case.
     """
+    cfg = get_config()
+    request_dict = request.model_dump() if request else None
+    declared: set[str] | None = None
+    if cfg.tool_call_parser == "qwen3_coder_xml":
+        declared = _request_declared_tool_names(request_dict)
+        if not declared:
+            return output_text or "", None
+
     if structured_tool_calls:
+        if declared is not None and any(
+            tc.get("name") not in declared for tc in structured_tool_calls
+        ):
+            return output_text or "", None
         tool_calls = [
             ToolCall(
                 id=tc.get("id", f"call_{uuid.uuid4().hex[:8]}"),
@@ -2776,9 +2803,6 @@ def _parse_tool_calls_with_parser(
             for tc in structured_tool_calls
         ]
         return output_text or "", tool_calls
-
-    cfg = get_config()
-    request_dict = request.model_dump() if request else None
 
     tokenizer = None
     if cfg.engine is not None and hasattr(cfg.engine, "_tokenizer"):
@@ -2817,6 +2841,8 @@ def _parse_tool_calls_with_parser(
         parser = parser_cls(tokenizer)
     except Exception as e:
         logger.warning(f"Failed to create tool parser '{cfg.tool_call_parser}': {e}")
+        if cfg.tool_call_parser == "qwen3_coder_xml":
+            return output_text or "", None
         return parse_tool_calls(output_text, request_dict)
 
     try:
@@ -2836,6 +2862,11 @@ def _parse_tool_calls_with_parser(
             ]
             return result.content or "", tool_calls
         else:
+            if cfg.tool_call_parser == "qwen3_coder_xml":
+                # The Qwen parser made an authoritative declared-name decision.
+                # Falling through to the generic parser would re-promote the
+                # exact undeclared/tool_choice=none span it rejected.
+                return result.content or "", None
             return parse_tool_calls(output_text, request_dict)
     except Exception as e:
         # Opt-in telemetry (Phase 2.2 error wiring): the configured tool
@@ -2849,6 +2880,8 @@ def _parse_tool_calls_with_parser(
 
         _telemetry_emit.error(category="tool_parse", exc=e, phase="chat")
         logger.warning(f"Tool parser error: {e}")
+        if cfg.tool_call_parser == "qwen3_coder_xml":
+            return output_text or "", None
         return parse_tool_calls(output_text, request_dict)
 
 

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -2754,6 +2754,14 @@ def _request_declared_tool_names(request_dict: dict | None) -> set[str]:
         name = function.get("name") if isinstance(function, dict) else tool.get("name")
         if isinstance(name, str) and name:
             names.add(name)
+    choice = request_dict.get("tool_choice")
+    if isinstance(choice, dict):
+        function = choice.get("function")
+        selected = (
+            function.get("name") if isinstance(function, dict) else choice.get("name")
+        )
+        if isinstance(selected, str) and selected:
+            return names.intersection({selected})
     return names
 
 

--- a/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
+++ b/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
@@ -347,7 +347,23 @@ class Qwen3CoderToolParser(ToolParser):
         return [m[0] if m[0] else m[1] for m in raw_function_calls]
 
     @staticmethod
-    def _declared_tool_names(request: dict[str, Any] | None) -> set[str]:
+    def _named_tool_choice(request: dict[str, Any] | None) -> str | None:
+        if not isinstance(request, dict):
+            return None
+        choice = request.get("tool_choice")
+        if isinstance(choice, dict):
+            function = choice.get("function")
+            selected = (
+                function.get("name")
+                if isinstance(function, dict)
+                else choice.get("name")
+            )
+            if isinstance(selected, str) and selected:
+                return selected
+        return None
+
+    @classmethod
+    def _declared_tool_names(cls, request: dict[str, Any] | None) -> set[str]:
         """Return executable tool names offered by this request."""
         if not isinstance(request, dict) or request.get("tool_choice") == "none":
             return set()
@@ -363,16 +379,9 @@ class Qwen3CoderToolParser(ToolParser):
                 name = tool.get("name")
             if isinstance(name, str) and name:
                 names.add(name)
-        choice = request.get("tool_choice")
-        if isinstance(choice, dict):
-            function = choice.get("function")
-            selected = (
-                function.get("name")
-                if isinstance(function, dict)
-                else choice.get("name")
-            )
-            if isinstance(selected, str) and selected:
-                return names.intersection({selected})
+        selected = cls._named_tool_choice(request)
+        if selected:
+            return names.intersection({selected})
         return names
 
     def extract_tool_calls(
@@ -392,12 +401,15 @@ class Qwen3CoderToolParser(ToolParser):
 
             tools = request.get("tools") if isinstance(request, dict) else None
             declared = self._declared_tool_names(request)
+            selected = self._named_tool_choice(request)
 
             tool_calls = []
             for fc_str in function_calls:
+                candidate_name = fc_str.split(">", 1)[0]
                 if (
                     self.tool_call_start_token not in model_output
                     and self.parameter_prefix not in fc_str
+                    and candidate_name != selected
                 ):
                     # Wrapper-less calls are supported for #978 models, but a
                     # zero-argument bare span is indistinguishable from prose
@@ -738,6 +750,10 @@ class Qwen3CoderToolParser(ToolParser):
                     if (
                         not self._pending_tool_wrapped
                         and self.parameter_prefix not in tool_text
+                        and self.current_function_name
+                        != self._named_tool_choice(
+                            request if request is not None else self._streaming_request
+                        )
                     ):
                         if self.function_end_token not in tool_text:
                             # Wait for a possible first parameter before

--- a/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
+++ b/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
@@ -252,6 +252,7 @@ class Qwen3CoderToolParser(ToolParser):
         self.accumulated_params = {}
         self._streaming_request = None
         self._pending_tool_start: int | None = None
+        self._pending_tool_wrapped = False
         self.prev_tool_call_arr = []
         self.in_param_emitted_chars = 0
         self.in_param_opened = False
@@ -394,6 +395,18 @@ class Qwen3CoderToolParser(ToolParser):
 
             tool_calls = []
             for fc_str in function_calls:
+                if (
+                    self.tool_call_start_token not in model_output
+                    and self.parameter_prefix not in fc_str
+                ):
+                    # Wrapper-less calls are supported for #978 models, but a
+                    # zero-argument bare span is indistinguishable from prose
+                    # documenting the wire format. Require either canonical
+                    # framing or parameter structure before model text can
+                    # become executable data.
+                    return ExtractedToolCallInformation(
+                        tools_called=False, tool_calls=[], content=model_output
+                    )
                 tc = self._parse_xml_function_call(fc_str, tools)
                 if not tc:
                     continue
@@ -633,6 +646,15 @@ class Qwen3CoderToolParser(ToolParser):
                 self.is_tool_call_started = True
                 opener_pos = self._first_opener_pos(delta_text)
                 self._pending_tool_start = len(previous_text) + opener_pos
+                wrapper_start = current_text.find(
+                    self.tool_call_start_token, self._pending_tool_start
+                )
+                function_start = current_text.find(
+                    self.tool_call_prefix, self._pending_tool_start
+                )
+                self._pending_tool_wrapped = wrapper_start >= 0 and (
+                    function_start < 0 or wrapper_start <= function_start
+                )
                 header_start = current_text.find(
                     self.tool_call_prefix, self._pending_tool_start
                 )
@@ -642,6 +664,16 @@ class Qwen3CoderToolParser(ToolParser):
                     if header_end >= 0:
                         candidate_name = current_text[name_start:header_end]
                         if candidate_name not in declared:
+                            saved_request = self._streaming_request
+                            self._reset_streaming_state()
+                            self._streaming_request = saved_request
+                            return {"content": delta_text}
+                        candidate_text = current_text[header_start:]
+                        if (
+                            not self._pending_tool_wrapped
+                            and self.function_end_token in candidate_text
+                            and self.parameter_prefix not in candidate_text
+                        ):
                             saved_request = self._streaming_request
                             self._reset_streaming_state()
                             self._streaming_request = saved_request
@@ -695,6 +727,22 @@ class Qwen3CoderToolParser(ToolParser):
                 if func_end != -1:
                     self.current_function_name = tool_text[func_start:func_end]
                     if self.current_function_name not in declared:
+                        start = self._pending_tool_start
+                        rejected = (
+                            current_text[start:] if start is not None else delta_text
+                        )
+                        saved_request = self._streaming_request
+                        self._reset_streaming_state()
+                        self._streaming_request = saved_request
+                        return {"content": rejected}
+                    if (
+                        not self._pending_tool_wrapped
+                        and self.parameter_prefix not in tool_text
+                    ):
+                        if self.function_end_token not in tool_text:
+                            # Wait for a possible first parameter before
+                            # emitting an irreversible tool-call header.
+                            return None
                         start = self._pending_tool_start
                         rejected = (
                             current_text[start:] if start is not None else delta_text

--- a/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
+++ b/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
@@ -251,6 +251,7 @@ class Qwen3CoderToolParser(ToolParser):
         self.json_closed = False
         self.accumulated_params = {}
         self._streaming_request = None
+        self._pending_tool_start: int | None = None
         self.prev_tool_call_arr = []
         self.in_param_emitted_chars = 0
         self.in_param_opened = False
@@ -344,6 +345,25 @@ class Qwen3CoderToolParser(ToolParser):
             raw_function_calls.extend(self.tool_call_function_regex.findall(tc))
         return [m[0] if m[0] else m[1] for m in raw_function_calls]
 
+    @staticmethod
+    def _declared_tool_names(request: dict[str, Any] | None) -> set[str]:
+        """Return executable tool names offered by this request."""
+        if not isinstance(request, dict) or request.get("tool_choice") == "none":
+            return set()
+        names: set[str] = set()
+        for tool in request.get("tools") or []:
+            if not isinstance(tool, dict):
+                continue
+            function = tool.get("function")
+            if isinstance(function, dict):
+                name = function.get("name")
+            else:
+                # Responses-native tools are flat: {type, name, parameters}.
+                name = tool.get("name")
+            if isinstance(name, str) and name:
+                names.add(name)
+        return names
+
     def extract_tool_calls(
         self, model_output: str, request: dict[str, Any] | None = None
     ) -> ExtractedToolCallInformation:
@@ -359,15 +379,28 @@ class Qwen3CoderToolParser(ToolParser):
                     tools_called=False, tool_calls=[], content=model_output
                 )
 
-            tools = None
-            if request and isinstance(request, dict):
-                tools = request.get("tools")
+            tools = request.get("tools") if isinstance(request, dict) else None
+            declared = self._declared_tool_names(request)
 
             tool_calls = []
             for fc_str in function_calls:
                 tc = self._parse_xml_function_call(fc_str, tools)
-                if tc:
-                    tool_calls.append(tc)
+                if not tc:
+                    continue
+                if tc.get("name") not in declared:
+                    # Framing alone cannot distinguish executable wire from
+                    # prose documenting that wire. A name the caller did not
+                    # offer (including every name under tool_choice=none) is
+                    # never executable, so preserve the entire answer as text.
+                    return ExtractedToolCallInformation(
+                        tools_called=False, tool_calls=[], content=model_output
+                    )
+                tool_calls.append(tc)
+
+            if not tool_calls:
+                return ExtractedToolCallInformation(
+                    tools_called=False, tool_calls=[], content=model_output
+                )
 
             # Extract content before tool calls
             content_index = model_output.find(self.tool_call_start_token)
@@ -544,6 +577,15 @@ class Qwen3CoderToolParser(ToolParser):
         if not delta_text:
             return None
 
+        declared = self._declared_tool_names(
+            request if request is not None else self._streaming_request
+        )
+        if not declared:
+            # No executable tool exists for this request. Bypass the XML state
+            # machine entirely so protocol examples stream byte-for-byte and
+            # tool_choice=none cannot be overturned by model-authored markup.
+            return {"content": delta_text}
+
         delta_token_ids = delta_token_ids or []
         self.accumulated_text = current_text
 
@@ -580,6 +622,20 @@ class Qwen3CoderToolParser(ToolParser):
             if self._has_new_opener(delta_text, delta_token_ids):
                 self.is_tool_call_started = True
                 opener_pos = self._first_opener_pos(delta_text)
+                self._pending_tool_start = len(previous_text) + opener_pos
+                header_start = current_text.find(
+                    self.tool_call_prefix, self._pending_tool_start
+                )
+                if header_start >= 0:
+                    name_start = header_start + len(self.tool_call_prefix)
+                    header_end = current_text.find(">", name_start)
+                    if header_end >= 0:
+                        candidate_name = current_text[name_start:header_end]
+                        if candidate_name not in declared:
+                            saved_request = self._streaming_request
+                            self._reset_streaming_state()
+                            self._streaming_request = saved_request
+                            return {"content": delta_text}
                 content_before = (
                     delta_text[:opener_pos] if opener_pos < len(delta_text) else ""
                 )
@@ -628,6 +684,15 @@ class Qwen3CoderToolParser(ToolParser):
                 func_end = tool_text.find(">", func_start)
                 if func_end != -1:
                     self.current_function_name = tool_text[func_start:func_end]
+                    if self.current_function_name not in declared:
+                        start = self._pending_tool_start
+                        rejected = (
+                            current_text[start:] if start is not None else delta_text
+                        )
+                        saved_request = self._streaming_request
+                        self._reset_streaming_state()
+                        self._streaming_request = saved_request
+                        return {"content": rejected}
                     self._current_tool_id = _generate_tool_id()
                     self.header_sent = True
                     self.in_function = True

--- a/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
+++ b/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
@@ -362,6 +362,16 @@ class Qwen3CoderToolParser(ToolParser):
                 name = tool.get("name")
             if isinstance(name, str) and name:
                 names.add(name)
+        choice = request.get("tool_choice")
+        if isinstance(choice, dict):
+            function = choice.get("function")
+            selected = (
+                function.get("name")
+                if isinstance(function, dict)
+                else choice.get("name")
+            )
+            if isinstance(selected, str) and selected:
+                return names.intersection({selected})
         return names
 
     def extract_tool_calls(


### PR DESCRIPTION
## What does this PR do?

Closes three P1 regressions found during the post-0.12.1 release review:

- emits one public Responses lifecycle before a buffered DeepSeek retry can stall, while keeping heartbeat and retry sequence numbers contiguous;
- preserves the original Desktop transcript as a sidebar branch before Edit or Retry truncates the active path;
- prevents `qwen3_coder_xml` from promoting prose, `tool_choice: none`, or undeclared names into executable tool calls across streaming, non-streaming, generic-fallback, and structured-call paths.

## Why is this needed?

The current release candidate can send `response.in_progress` before `response.created` during a slow hidden retry, can irreversibly delete later chat turns when replaying an older message, and can execute tool-shaped prose that the caller never authorized. These are release-blocking protocol, data-loss, and tool-authorization failures identified while reviewing #1506, #1509, and #1513.

## AI assistance disclosure

Codex reproduced the failures, wrote the implementation and regression tests, reviewed the final diff, and ran the validation listed below. Every changed path was manually inspected for lifecycle ordering, persistence behavior, and tool authorization boundaries.

> By submitting this PR I confirm I can explain the intent, risk, and behavior of every non-generated change in this PR. For any generated / boilerplate / scaffolded sections, I've identified them above and can describe how I verified them.

## Test plan

- Red/green spot-check: new Responses heartbeat test failed with `response.in_progress` first before the fix.
- Red/green spot-check: Qwen parser regressions failed for no tools, `tool_choice: none`, undeclared tools, and streaming before the fix.
- `pytest -q tests/test_responses_engine_failure_envelope.py tests/test_responses_route.py tests/test_tool_parser_content_passthrough.py tests/test_tool_call_closer_content_integrity.py tests/test_tool_call_streaming_parity.py tests/test_chat_route_tool_choice_enforcement.py tests/test_r12_reasoning_sanitizer_required.py tests/test_sanitize_output.py` (456 passed, 4 skipped)
- `swift test --no-parallel --filter 'ChatMessageActionsTests'` (4 passed)
- Quickstart/memory-warning Swift regression matrix (42 passed)
- `ruff check` and `ruff format --check` on changed Python files
- `python3 -m compileall -q vllm_mlx`
- `make release-smoke`
- Full local `pytest -q tests/ -x` collection on the host Python was blocked by its missing optional `anthropic` SDK; PR validation and GitHub CI run in project test-extras environments.

## Checklist

- [x] Relevant tests pass locally; full host-only collection limitation is documented above
- [x] Lint passes (`ruff check && ruff format --check`)
- [x] Self-validation invoked; rerunning in an isolated venv after the host Python's PEP 668 guard blocked dependency installation
- [x] Critical parser/protocol tests were spot-checked red before the production fix
- [x] README/docs not applicable
- [x] No breaking changes to existing API
