### PR TITLE
fix(scheduler): stop mlx-lm writing None into a mixed batch's processor slots

### DIFF
--- a/tests/test_mixed_batch_logits_processor_slots.py
+++ b/tests/test_mixed_batch_logits_processor_slots.py
@@ -34,11 +34,20 @@ import pytest
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 
+# BEFORE importing mlx_lm.generate, not after. That module captures
+# ``mx.new_thread_local_stream(...)`` at import time, and ``install()`` is what
+# makes that call safe on single-stream GPUs (#404) — the ordering invariant
+# both ``_mlx_compat`` and ``scheduler`` document. Importing mlx-lm first here
+# would pin the unusable stream for the rest of the pytest process, so a later
+# scheduler import installs the shim too late and inference fails with
+# "There is no Stream(gpu, 1) in current thread".
+from vllm_mlx import _mlx_compat  # noqa: E402
+
+_mlx_compat.install()
+
 pytest.importorskip("mlx_lm.generate", reason="requires MLX")
 
 from mlx_lm.generate import PromptProcessingBatch  # noqa: E402
-
-from vllm_mlx import _mlx_compat  # noqa: E402
 
 
 def _noop_processor(token_context, logits):

--- a/tests/test_mixed_batch_logits_processor_slots.py
+++ b/tests/test_mixed_batch_logits_processor_slots.py
@@ -173,7 +173,7 @@ def test_scheduler_import_installs_the_guard():
     In a SUBPROCESS, and deliberately outside the autouse fixture's reach.
     Asserting the flag in-process proves nothing: the fixture installs the
     guard before every test in this file, so the assertion would hold with
-    the ``scheduler.py`` call site deleted (review BLOCKING). The only
+    the ``scheduler.py`` call site deleted (raised in review). The only
     honest question is whether importing the scheduler — and nothing else —
     arms it.
     """
@@ -197,6 +197,6 @@ def test_scheduler_import_installs_the_guard():
     )
     # Both, not just the marker: a process can print WIRED and then die on
     # the way out, and a test that only greps stdout would call that a pass
-    # (review NIT).
+    # (raised in review).
     assert proc.returncode == 0, proc.stderr + proc.stdout
     assert "WIRED" in proc.stdout, proc.stderr + proc.stdout

--- a/tests/test_mixed_batch_logits_processor_slots.py
+++ b/tests/test_mixed_batch_logits_processor_slots.py
@@ -26,7 +26,13 @@ them.
 
 from __future__ import annotations
 
+import pathlib
+import subprocess
+import sys
+
 import pytest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 
 pytest.importorskip("mlx_lm.generate", reason="requires MLX")
 
@@ -163,8 +169,30 @@ def test_scheduler_import_installs_the_guard():
 
     A shim nobody calls is a shim that does not exist; this is the wire
     between the fix and the crash path.
-    """
-    import importlib
 
-    importlib.import_module("vllm_mlx.scheduler")
-    assert getattr(PromptProcessingBatch, "_rapid_mlx_slot_guard", False)
+    In a SUBPROCESS, and deliberately outside the autouse fixture's reach.
+    Asserting the flag in-process proves nothing: the fixture installs the
+    guard before every test in this file, so the assertion would hold with
+    the ``scheduler.py`` call site deleted (review BLOCKING). The only
+    honest question is whether importing the scheduler — and nothing else —
+    arms it.
+    """
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import importlib;"
+            "m = importlib.import_module('mlx_lm.generate');"
+            "assert not getattr(m.PromptProcessingBatch, '_rapid_mlx_slot_guard', False),"
+            " 'guard armed before importing the scheduler — test is vacuous';"
+            "importlib.import_module('vllm_mlx.scheduler');"
+            "assert getattr(m.PromptProcessingBatch, '_rapid_mlx_slot_guard', False),"
+            " 'importing vllm_mlx.scheduler did not install the guard';"
+            "print('WIRED')",
+        ],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+        timeout=300,
+    )
+    assert "WIRED" in proc.stdout, proc.stderr + proc.stdout

--- a/tests/test_mixed_batch_logits_processor_slots.py
+++ b/tests/test_mixed_batch_logits_processor_slots.py
@@ -1,0 +1,170 @@
+# SPDX-License-Identifier: Apache-2.0
+"""A mixed batch must not put ``None`` in a per-sequence processor slot.
+
+#1525. Plain chat concurrent with a tool call — which is what every agent
+we support does — could kill the engine loop:
+
+    ERROR:rapid_mlx.engine_core:Engine loop error: 'NoneType' object is not iterable
+      mlx_lm/generate.py:1809  gen_batch = self._prompt_batch.split(split).generate(...)
+      mlx_lm/generate.py:1346  for processor in self.logits_processors[e]:
+    TypeError: 'NoneType' object is not iterable
+    INFO: "POST /v1/chat/completions HTTP/1.1" 503 Service Unavailable
+
+``PromptProcessingBatch.extend`` normalizes "no processors" to ``None``
+slots, guarded by ``any()`` — a whole-list question asked about a
+per-sequence list. All-empty and all-present are both safe; only the MIXED
+batch produces ``None``, and only after a split/merge reshuffles it, which
+is why it reproduced in 3 of 5 consecutive stress runs rather than every
+time.
+
+These tests drive the real mlx-lm classes rather than a stand-in: the
+defect is in upstream's bookkeeping, so a fake would only test the fake.
+No model and no weights are involved — the batch objects are built with
+``__new__`` and the lists that matter, exactly as the crash path leaves
+them.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("mlx_lm.generate", reason="requires MLX")
+
+from mlx_lm.generate import PromptProcessingBatch  # noqa: E402
+
+from vllm_mlx import _mlx_compat  # noqa: E402
+
+
+def _noop_processor(token_context, logits):
+    return logits
+
+
+def _batch(uids, processors):
+    """A PromptProcessingBatch carrying only the state ``extend`` touches."""
+    b = PromptProcessingBatch.__new__(PromptProcessingBatch)
+    b.uids = list(uids)
+    b.samplers = [None] * len(uids)
+    b.logits_processors = list(processors)
+    b.prompt_cache = []
+    b.tokens = [[] for _ in uids]
+    b.max_tokens = [64] * len(uids)
+    b.state_machines = [None] * len(uids)
+    return b
+
+
+@pytest.fixture(autouse=True)
+def _guard_installed():
+    _mlx_compat.install_batch_slot_guard()
+
+
+def _step_would_crash(batch) -> bool:
+    """Replay what ``GenerationBatch._step`` does with these slots."""
+    if not any(batch.logits_processors):
+        return False  # fast path: the loop is skipped entirely
+    for e in range(len(batch.uids)):
+        try:
+            for _ in batch.logits_processors[e]:
+                pass
+        except TypeError:
+            return True
+    return False
+
+
+def test_mixed_batch_leaves_no_none_slot():
+    """Two plain requests joined by one that carries a processor."""
+    plain = _batch([1, 2], [[], []])
+    grammar = _batch([3], [[_noop_processor]])
+
+    plain.extend(grammar)
+
+    assert None not in plain.logits_processors, plain.logits_processors
+    assert not _step_would_crash(plain)
+
+
+def test_mixed_batch_the_other_way_round():
+    """...and with the processor-carrying batch as the receiver."""
+    grammar = _batch([1], [[_noop_processor]])
+    plain = _batch([2, 3], [[], []])
+
+    grammar.extend(plain)
+
+    assert None not in grammar.logits_processors, grammar.logits_processors
+    assert not _step_would_crash(grammar)
+
+
+def test_the_processor_itself_survives_the_merge():
+    """Normalizing empty slots must not drop a real processor."""
+    plain = _batch([1], [[]])
+    grammar = _batch([2], [[_noop_processor]])
+
+    plain.extend(grammar)
+
+    kept = [s for s in plain.logits_processors if s]
+    assert kept == [[_noop_processor]], plain.logits_processors
+
+
+def test_slots_stay_aligned_with_uids():
+    plain = _batch([1, 2], [[], []])
+    grammar = _batch([3], [[_noop_processor]])
+
+    plain.extend(grammar)
+
+    assert len(plain.logits_processors) == len(plain.uids)
+    assert plain.logits_processors[2] == [_noop_processor]
+
+
+def test_none_slots_do_not_survive_a_filter():
+    """``filter`` keeps slots verbatim once ``any()`` is True."""
+    plain = _batch([1, 2], [[], []])
+    grammar = _batch([3], [[_noop_processor]])
+    plain.extend(grammar)
+
+    plain.prompt_cache = []
+    plain.filter([0, 1, 2])
+
+    assert None not in plain.logits_processors, plain.logits_processors
+    assert not _step_would_crash(plain)
+
+
+def test_all_empty_merge_keeps_the_fast_path():
+    """Normalization must not make ``any()`` newly True.
+
+    ``_step`` skips the entire processing loop when no sequence has a
+    processor. Filling slots with anything truthy would run a per-token
+    Python loop over every sequence for no reason.
+    """
+    a = _batch([1], [[]])
+    b = _batch([2], [[]])
+
+    a.extend(b)
+
+    assert not any(a.logits_processors), a.logits_processors
+
+
+def test_all_present_merge_is_unchanged():
+    a = _batch([1], [[_noop_processor]])
+    b = _batch([2], [[_noop_processor]])
+
+    a.extend(b)
+
+    assert a.logits_processors == [[_noop_processor], [_noop_processor]]
+
+
+def test_guard_is_idempotent():
+    """Installed twice must not wrap twice."""
+    _mlx_compat.install_batch_slot_guard()
+    once = PromptProcessingBatch.extend
+    _mlx_compat.install_batch_slot_guard()
+    assert PromptProcessingBatch.extend is once
+
+
+def test_scheduler_import_installs_the_guard():
+    """The guard has to be live for anyone who imports the scheduler.
+
+    A shim nobody calls is a shim that does not exist; this is the wire
+    between the fix and the crash path.
+    """
+    import importlib
+
+    importlib.import_module("vllm_mlx.scheduler")
+    assert getattr(PromptProcessingBatch, "_rapid_mlx_slot_guard", False)

--- a/tests/test_mixed_batch_logits_processor_slots.py
+++ b/tests/test_mixed_batch_logits_processor_slots.py
@@ -195,4 +195,8 @@ def test_scheduler_import_installs_the_guard():
         cwd=REPO_ROOT,
         timeout=300,
     )
+    # Both, not just the marker: a process can print WIRED and then die on
+    # the way out, and a test that only greps stdout would call that a pass
+    # (review NIT).
+    assert proc.returncode == 0, proc.stderr + proc.stdout
     assert "WIRED" in proc.stdout, proc.stderr + proc.stdout

--- a/vllm_mlx/_mlx_compat.py
+++ b/vllm_mlx/_mlx_compat.py
@@ -190,7 +190,7 @@ def install_batch_slot_guard() -> None:
         # "mlx_lm isn't here" is the expected case off Apple Silicon and
         # stays quiet. "mlx_lm is here but importing it blew up on one of
         # its dependencies" is a broken install that would otherwise leave
-        # the guard silently disabled in production (review NIT).
+        # the guard silently disabled in production (raised in review).
         missing = getattr(exc, "name", None) or ""
         if missing == "mlx_lm" or missing.startswith("mlx_lm.") or missing == "mlx":
             return  # Linux CI / no MLX
@@ -208,7 +208,7 @@ def install_batch_slot_guard() -> None:
         # Renamed or restructured upstream. A shim that silently patches
         # the wrong thing is worse than one that declines — but declining
         # quietly is how a crash-prevention guard disappears across an
-        # unattended dependency bump, so say so (review NIT).
+        # unattended dependency bump, so say so (raised in review).
         logger.warning(
             "rapid-mlx compat: mlx_lm.generate has no "
             "PromptProcessingBatch.extend to guard (mlx-lm %s) — the #1525 "

--- a/vllm_mlx/_mlx_compat.py
+++ b/vllm_mlx/_mlx_compat.py
@@ -131,3 +131,81 @@ def install() -> None:
     mx.new_thread_local_stream = patched_new_thread_local_stream
     mx._rapid_mlx_compat_installed = True
     logger.debug("MLX compat shim installed (#404 M5 single-stream guard).")
+
+
+def install_batch_slot_guard() -> None:
+    """Stop mlx-lm writing ``None`` into a batch's ``logits_processors``.
+
+    Separate from ``install()`` and separately idempotent: that shim must
+    run BEFORE ``mlx_lm.generate`` is imported (it patches a symbol that
+    module captures at import time), whereas this one patches a class
+    inside it and therefore must run AFTER. Callers import
+    ``mlx_lm.generate`` and then call this.
+
+    ``PromptProcessingBatch.extend`` normalizes "this batch has no logits
+    processors" to ``None`` slots::
+
+        if not any(self.logits_processors):
+            self.logits_processors = [None] * len(self.uids)
+        logits_processors = (
+            batch.logits_processors
+            if any(batch.logits_processors)
+            else [None] * len(batch.uids)
+        )
+
+    ``any()`` is a whole-list question but the slots are per-sequence, so
+    merging a no-processor batch into one that HAS a processor yields
+    ``[None, None, [proc]]``. From then on ``any(...)`` is True, so
+    ``filter`` keeps every slot verbatim and ``GenerationBatch._step``
+    reaches ``for processor in self.logits_processors[e]`` on a ``None``::
+
+        TypeError: 'NoneType' object is not iterable
+
+    which kills the engine loop and 503s every in-flight request. Only the
+    MIXED batch is affected — all-empty takes the ``else`` branch and
+    becomes ``[[]] * n``, all-present is iterable throughout. That is
+    exactly "plain chat concurrent with a tool call", i.e. every agent we
+    support, and it needs a split/merge to reshuffle the batch, which is
+    why it is intermittent: 3 of 5 consecutive stress runs on main.
+
+    ``[]`` is the correct normalization at both sites — it keeps ``any()``
+    False for the all-empty case, so the fast path still skips the whole
+    processing loop, and it stays iterable when mixed. We wrap rather than
+    reimplement ``extend`` so upstream stays authoritative for everything
+    else it does; we only clean up after it.
+
+    Upstream tracking: rapid-mlx #1525. Remove when a released mlx-lm
+    writes ``[]`` instead of ``None``.
+    """
+    try:
+        # ``import_module``, NOT ``from mlx_lm import generate``: mlx_lm's
+        # package namespace binds a top-level ``generate()`` FUNCTION that
+        # shadows the submodule of the same name, so the ``from`` form
+        # hands back a callable and every attribute lookup below silently
+        # misses.
+        from importlib import import_module
+
+        _generate = import_module("mlx_lm.generate")
+    except ImportError:
+        return  # Linux CI / no MLX
+
+    batch_cls = getattr(_generate, "PromptProcessingBatch", None)
+    original = getattr(batch_cls, "extend", None)
+    if original is None:
+        # Renamed or restructured upstream. A shim that silently patches
+        # the wrong thing is worse than one that declines.
+        return
+    if getattr(batch_cls, "_rapid_mlx_slot_guard", False):
+        return
+
+    def extend(self, batch):
+        original(self, batch)
+        slots = getattr(self, "logits_processors", None)
+        if slots is not None and any(slot is None for slot in slots):
+            self.logits_processors = [[] if s is None else s for s in slots]
+
+    extend.__doc__ = original.__doc__
+    extend.__name__ = original.__name__
+    batch_cls.extend = extend
+    batch_cls._rapid_mlx_slot_guard = True
+    logger.debug("MLX compat shim installed (#1525 logits_processors slot guard).")

--- a/vllm_mlx/_mlx_compat.py
+++ b/vllm_mlx/_mlx_compat.py
@@ -186,14 +186,36 @@ def install_batch_slot_guard() -> None:
         from importlib import import_module
 
         _generate = import_module("mlx_lm.generate")
-    except ImportError:
-        return  # Linux CI / no MLX
+    except ImportError as exc:
+        # "mlx_lm isn't here" is the expected case off Apple Silicon and
+        # stays quiet. "mlx_lm is here but importing it blew up on one of
+        # its dependencies" is a broken install that would otherwise leave
+        # the guard silently disabled in production (review NIT).
+        missing = getattr(exc, "name", None) or ""
+        if missing == "mlx_lm" or missing.startswith("mlx_lm.") or missing == "mlx":
+            return  # Linux CI / no MLX
+        logger.warning(
+            "rapid-mlx compat: could not import mlx_lm.generate (%s) — the "
+            "#1525 logits_processors slot guard is NOT installed. Mixed "
+            "chat+tool-call traffic may 503. Check the mlx-lm install.",
+            exc,
+        )
+        return
 
     batch_cls = getattr(_generate, "PromptProcessingBatch", None)
     original = getattr(batch_cls, "extend", None)
     if original is None:
         # Renamed or restructured upstream. A shim that silently patches
-        # the wrong thing is worse than one that declines.
+        # the wrong thing is worse than one that declines — but declining
+        # quietly is how a crash-prevention guard disappears across an
+        # unattended dependency bump, so say so (review NIT).
+        logger.warning(
+            "rapid-mlx compat: mlx_lm.generate has no "
+            "PromptProcessingBatch.extend to guard (mlx-lm %s) — the #1525 "
+            "slot guard is NOT installed. Either upstream fixed it (then "
+            "drop this shim) or it moved (then retarget it).",
+            getattr(import_module("mlx_lm"), "__version__", "unknown"),
+        )
         return
     if getattr(batch_cls, "_rapid_mlx_slot_guard", False):
         return

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -35,6 +35,13 @@ from mlx_lm.generate import BatchGenerator  # noqa: E402
 from mlx_lm.sample_utils import make_logits_processors, make_sampler  # noqa: E402
 from mlx_lm.tokenizer_utils import NaiveStreamingDetokenizer  # noqa: E402
 
+# ...and the batch-slot guard AFTER, because it patches a class that lives
+# inside the module imported above. Mixing a request that carries logits
+# processors with one that doesn't otherwise puts ``None`` in a per-sequence
+# slot that mlx-lm later iterates, killing the engine loop and 503-ing every
+# in-flight request (#1525).
+_mlx_compat.install_batch_slot_guard()
+
 from ._sampler_fast_path import (  # noqa: E402
     is_fused_top_p_eligible,
     make_fused_top_p_temp_sampler,


### PR DESCRIPTION
## Why

Plain chat concurrent with a tool call — which is what every agent we support
does — could kill the engine loop and hand a **503** to every in-flight
request:

```
ERROR:rapid_mlx.engine_core:Engine loop error: 'NoneType' object is not iterable
  mlx_lm/generate.py:1809  gen_batch = self._prompt_batch.split(split).generate(...)
  mlx_lm/generate.py:1288  self._step()
  mlx_lm/generate.py:1346  for processor in self.logits_processors[e]:
TypeError: 'NoneType' object is not iterable
INFO: "POST /v1/chat/completions HTTP/1.1" 503 Service Unavailable
```

Closes #1525.

## Root cause — upstream `PromptProcessingBatch.extend`

```python
if not any(self.logits_processors):
    self.logits_processors = [None] * len(self.uids)          # []  ->  None
...
logits_processors = (
    batch.logits_processors
    if any(batch.logits_processors)
    else [None] * len(batch.uids)                              # same
)
```

`any()` is a whole-list question; the slots are per-sequence. A no-processor
batch normalizes to `None` slots, and merging it with a batch that HAS one
yields `[None, None, [proc]]`. From then on `any(...)` is True, so `filter`
keeps every slot verbatim and `_step` iterates a `None`.

Homogeneous batches are safe in both directions — all-empty takes the `else`
branch and becomes `[[]] * n`, all-present is iterable throughout. **Only the
mixed batch crashes**, and only after a split/merge reshuffles it, which is
why this is intermittent rather than constant.

Reproducible with no model and no weights, purely in the list bookkeeping:

```python
from mlx_lm.generate import PromptProcessingBatch as PB
a, b = mk([1, 2], [[], []]), mk([3], [[noop]])
a.extend(b)
print(a.logits_processors)   # [None, None, [<function noop>]]
```

## The fix

Wrap `extend` and normalize `None` back to `[]`. That is the correct value at
both sites: it keeps `any()` False for the all-empty case, so `_step` still
skips the entire processing loop, and it stays iterable when mixed.

Wrapping rather than reimplementing keeps upstream authoritative for
everything else `extend` does — we only clean up after it, so an upstream
change to the merge semantics doesn't silently diverge from a copied body.
It lives in `vllm_mlx/_mlx_compat.py`, which already holds our other
upstream shim and its remove-when-fixed note.

`vllm_mlx/scheduler.py` installs it immediately *after* importing
`mlx_lm.generate`, the mirror of the existing `install()` which must run
*before* that import.

## Verification

`scripts/stress_test.py` case 6 "Mixed workload (4 concurrent, different
types)" on `mlx-community/Qwen3.5-35B-A3B-8bit`, M3 Ultra, five consecutive
runs against a freshly-started server each time:

| tree | result | engine-loop crashes |
|---|---|---|
| `main` @ 9c9e4b0d | **3 of 5 FAIL** (7/8 passed) | 15 |
| this branch | 5 of 5 PASS (8/8 passed) | 0 |

Nine unit tests drive the real mlx-lm classes rather than a stand-in — the
defect is in upstream's bookkeeping, so a fake would only test the fake. They
cover both merge directions, slot/uid alignment, survival through `filter`,
that a real processor is never dropped by the normalization, that the
all-empty fast path is not accidentally armed, and idempotency.

`test_scheduler_import_installs_the_guard` earned its place immediately: it
caught that `from mlx_lm import generate` binds mlx_lm's top-level
`generate()` **function**, which shadows the submodule of the same name, so
the first version of this shim silently patched nothing. A shim nobody calls
is a shim that does not exist.

Full unit suite: 15861 passed.

## Side effect worth noting

This also makes `pr_validate`'s stress gate honest. Its A/B logic is right —
if base fails too, the finding is recorded `[PRE-EXISTING]` rather than
blocking — but at a 60% reproduction rate the PR and base lanes were rolling
dice independently, so roughly 40% of runs produced a BLOCKING for a defect
the PR under review did not introduce.
