### PR TITLE
fix(rapid-mac): confirm before deleting a conversation from the sidebar

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/UI/SidebarView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SidebarView.swift
@@ -44,6 +44,12 @@ struct SidebarView: View {
     /// section builder) so the roll-over is an observable state change.
     @State private var referenceDate = Date()
 
+    /// The conversation a context-menu "Delete" has staged for removal, shown
+    /// in the confirmation dialog. Deleting a conversation is irreversible
+    /// (``ConversationStore.save`` atomically overwrites the on-disk store —
+    /// no trash, no undo), so — unlike navigating — it must be confirmed first.
+    @State private var pendingDeletion: ChatConversation?
+
     var body: some View {
         VStack(alignment: .leading, spacing: 1) {
             row(
@@ -85,6 +91,37 @@ struct SidebarView: View {
         .padding(.vertical, RapidTheme.Space.md)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
         .task { await dayBoundaryTicker() }
+        // A conversation is a HARD delete with no undo, so confirm first —
+        // mirrors the cached-model delete dialog. ``confirmationDialog`` over
+        // ``alert`` so the cancel-role button is Return-bound.
+        .confirmationDialog(
+            Self.deleteConfirmationTitle(for: pendingDeletion),
+            isPresented: Binding(
+                get: { pendingDeletion != nil },
+                set: { if !$0 { pendingDeletion = nil } }
+            ),
+            titleVisibility: .visible,
+            presenting: pendingDeletion
+        ) { conv in
+            Button("Delete", role: .destructive) {
+                chat.deleteConversation(conv.id)
+                pendingDeletion = nil
+            }
+            Button("Keep", role: .cancel) {
+                pendingDeletion = nil
+            }
+        } message: { _ in
+            Text("This permanently deletes the conversation. It can't be undone.")
+        }
+    }
+
+    /// Confirmation title for deleting a saved conversation. Unlike a cached
+    /// MODEL (re-downloadable, and already gated) a conversation delete is
+    /// irreversible, so this always fronts a confirmation.
+    nonisolated static func deleteConfirmationTitle(for conversation: ChatConversation?) -> String {
+        guard let conversation else { return "Delete this conversation?" }
+        let title = conversation.title.trimmingCharacters(in: .whitespacesAndNewlines)
+        return title.isEmpty ? "Delete this conversation?" : "Delete “\(title)”?"
     }
 
     /// The history list split into dated sections, newest first.
@@ -185,7 +222,7 @@ struct SidebarView: View {
         }
         .contextMenu {
             Button("Delete", role: .destructive) {
-                chat.deleteConversation(conv.id)
+                pendingDeletion = conv
             }
         }
     }

--- a/apps/rapid-mac/Tests/RapidTests/SidebarConversationDeleteConfirmationTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SidebarConversationDeleteConfirmationTests.swift
@@ -1,0 +1,96 @@
+import Foundation
+import Testing
+@testable import Rapid
+
+/// Regression guard: deleting a conversation from the sidebar must go through
+/// a confirmation. A conversation is a HARD delete — ``ConversationStore.save``
+/// atomically overwrites the on-disk store, with no trash and no undo — so
+/// unlike a cached MODEL (re-downloadable, and already gated by a dialog), a
+/// right-click "Delete" that fired immediately meant one misclick permanently
+/// destroyed a whole chat history. The fix stages the deletion into
+/// ``pendingDeletion`` and only removes it once the confirmation dialog's
+/// destructive button is pressed.
+///
+/// ViewInspector was removed from this target (#1492), so the wiring is pinned
+/// by a source-grep guard (same shape as the capability-chip / bidi suites)
+/// plus a behavioural check on the pure title helper.
+@Suite("Sidebar conversation delete requires confirmation")
+struct SidebarConversationDeleteConfirmationTests {
+    // MARK: - Behavioural: the confirmation copy
+
+    @Test("Title helper fronts the conversation's name")
+    func titleIncludesConversationName() {
+        let conv = ChatConversation(
+            id: UUID(),
+            title: "Quarterly planning notes",
+            messages: [],
+            createdAt: Date(),
+            updatedAt: Date()
+        )
+        let title = SidebarView.deleteConfirmationTitle(for: conv)
+        #expect(title.contains("Quarterly planning notes"))
+    }
+
+    @Test("Title helper falls back when there is no name (nil or blank)")
+    func titleFallsBackWhenBlank() {
+        #expect(SidebarView.deleteConfirmationTitle(for: nil) == "Delete this conversation?")
+        let blank = ChatConversation(
+            id: UUID(),
+            title: "   ",
+            messages: [],
+            createdAt: Date(),
+            updatedAt: Date()
+        )
+        #expect(SidebarView.deleteConfirmationTitle(for: blank) == "Delete this conversation?")
+    }
+
+    // MARK: - Source guard: the delete is gated
+
+    private func sidebarSource() throws -> String {
+        let root = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()  // RapidTests
+            .deletingLastPathComponent()  // Tests
+            .deletingLastPathComponent()  // repo root
+        let url = root.appendingPathComponent("Sources/Rapid/UI/SidebarView.swift")
+        return try String(contentsOf: url, encoding: .utf8)
+    }
+
+    @Test("Context-menu Delete STAGES a pending deletion — it does not delete immediately")
+    func contextMenuStagesRatherThanDeletes() throws {
+        let stripped = CapabilityChipRenderGateSourceGuardTests
+            .stripCommentsAndWhitespace(try sidebarSource())
+        // The context-menu destructive button must set pendingDeletion, never
+        // call the model's delete directly. This literal shape is exactly what
+        // the old immediate-delete build lacked, so it fails against a revert.
+        #expect(
+            stripped.contains(#"Button("Delete",role:.destructive){pendingDeletion=conv}"#),
+            "SidebarView's context-menu Delete must stage `pendingDeletion = conv`, not delete on the spot."
+        )
+        // And the pre-fix immediate shape must be gone from the context menu.
+        #expect(
+            !stripped.contains(#".contextMenu{Button("Delete",role:.destructive){chat.deleteConversation"#),
+            "SidebarView still deletes a conversation straight from the context menu with no confirmation."
+        )
+    }
+
+    @Test("A confirmation dialog is wired and is the only path to the delete")
+    func confirmationDialogGatesTheDelete() throws {
+        let stripped = CapabilityChipRenderGateSourceGuardTests
+            .stripCommentsAndWhitespace(try sidebarSource())
+        #expect(
+            stripped.contains(".confirmationDialog("),
+            "SidebarView must present a confirmationDialog before removing a conversation."
+        )
+        // The actual removal happens exactly once, inside the dialog's
+        // destructive button.
+        #expect(
+            stripped.contains("chat.deleteConversation(conv.id)"),
+            "The confirmed action must still route through chat.deleteConversation."
+        )
+        let deleteCallCount = stripped.components(separatedBy: "chat.deleteConversation(").count - 1
+        #expect(
+            deleteCallCount == 1,
+            "Expected exactly one chat.deleteConversation call site (the confirmed one); found \(deleteCallCount)."
+        )
+    }
+}

--- a/apps/rapid-mac/Tests/RapidTests/SidebarConversationDeleteConfirmationTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SidebarConversationDeleteConfirmationTests.swift
@@ -81,12 +81,17 @@ struct SidebarConversationDeleteConfirmationTests {
             stripped.contains(".confirmationDialog("),
             "SidebarView must present a confirmationDialog before removing a conversation."
         )
-        // The actual removal happens exactly once, inside the dialog's
-        // destructive button.
+        // The removal must live INSIDE the confirmation's destructive button —
+        // the one that also clears `pendingDeletion` (a shape only the dialog
+        // button has; the context-menu button sets `pendingDeletion = conv`).
+        // Asserting the full button body pins the delete to the confirmed path,
+        // so moving it back to an immediate context-menu action fails here even
+        // if a confirmationDialog still exists elsewhere.
         #expect(
-            stripped.contains("chat.deleteConversation(conv.id)"),
-            "The confirmed action must still route through chat.deleteConversation."
+            stripped.contains(#"role:.destructive){chat.deleteConversation(conv.id)pendingDeletion=nil}"#),
+            "chat.deleteConversation must be the body of the confirmation dialog's destructive button (which then clears pendingDeletion), not an unconfirmed call site."
         )
+        // And it is the ONLY delete call site.
         let deleteCallCount = stripped.components(separatedBy: "chat.deleteConversation(").count - 1
         #expect(
             deleteCallCount == 1,


### PR DESCRIPTION
## Why

Right-clicking a conversation in the sidebar and choosing "Delete" removed it **immediately**: `deleteConversation` calls `ConversationStore.save`, which atomically overwrites the on-disk store — no trash, no undo, no recovery path. One misclick permanently destroyed an entire chat history with no warning.

The protection was also inverted against the app's own conventions: deleting a cached **model** (which can simply be re-downloaded) already prompts with a confirmation dialog, while the **irreversible** conversation delete did not.

## What

Sidebar conversation delete now stages the target into `pendingDeletion` and only removes it once a `confirmationDialog`'s destructive button is pressed — mirroring the cached-model delete flow. Adds a pure `deleteConfirmationTitle(for:)` helper that fronts the conversation's name (blank/nil fallback).

## Tests

`SidebarConversationDeleteConfirmationTests`: behavioural title-helper checks + a source guard (ViewInspector was removed in #1492) asserting the context-menu Delete stages `pendingDeletion` rather than deleting on the spot, a `confirmationDialog` is wired, and `chat.deleteConversation` has exactly one call site. They key on shapes the pre-fix build lacked, so they fail against a revert.

Full `swift test --no-parallel` green except the 3 pre-existing `DownloadManager — real rapid-mlx pull subprocess wiring` env tests (identical on main).

## Notes

Behaviour-only sidebar change; no store/API change. Deleting the open conversation still tears down the live transcript — now behind the confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
