### PR TITLE
fix(rapid-mac): prefer newer bundled runtime

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Server/ServerLocator.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerLocator.swift
@@ -26,7 +26,14 @@ import Foundation
 /// 1. **`RAPID_BIN`** — test / dev override env var. Highest priority so
 ///    integration tests can swap in a fake CLI without touching disk
 ///    and dev-checkout power users can point at their local build.
-/// 2. **runtime-override** — `~/Library/Application Support/Rapid/runtime-override/rapid-mlx/bin/rapid-mlx`
+/// 2. **managed sidecars, newest version wins** — compares the
+///    runtime-override and bundled `VERSION` files whenever both binaries
+///    exist. A stale or unversioned runtime override cannot shadow a newer,
+///    versioned sidecar shipped by an app update. The runtime override still
+///    wins when it is the same version or newer, and remains the only managed
+///    candidate for slim DMGs whose bundled slot is empty.
+///
+///    **runtime-override** — `~/Library/Application Support/Rapid/runtime-override/rapid-mlx/bin/rapid-mlx`
 ///    written by ``BootstrapCoordinator`` on first launch of the slim
 ///    bootstrapper DMG, or by the in-app updater when it pulls a
 ///    newer sidecar from `latest.json`. The `rapid-mlx/` wrapper
@@ -36,10 +43,10 @@ import Foundation
 ///    the same final ``rapid-mlx/bin/rapid-mlx`` suffix, so adding a
 ///    fourth lookup slot in the future stays symmetric. Survives
 ///    desktop upgrades because it lives outside `Contents/`.
-/// 3. **bundled** — `Contents/Resources/rapid-mlx/bin/rapid-mlx`
+///    **bundled** — `Contents/Resources/rapid-mlx/bin/rapid-mlx`
 ///    shipped inside a full-bundle DMG (today the slim DMG ships
 ///    empty here and relies entirely on the bootstrapper to
-///    populate slot 2). Last resort before returning nil.
+///    populate the runtime-override slot).
 ///
 /// Return value: ``nil`` when none of the three slots resolves —
 /// callers are expected to surface the missing-install UX (re-run
@@ -68,18 +75,22 @@ enum ServerLocator {
         bundleResourceURL: URL?,
         applicationSupportURL: URL?
     ) -> URL? {
-        var candidates: [(path: String, allowRelative: Bool)] = []
-
         // 1. ``RAPID_BIN`` — test/dev override. TestDriver chat smoke
         // uses this to swap in ``scripts/fake-rapid-mlx.sh`` so the
         // lifecycle test runs in <2 s. Power users running their own
         // dev checkout of rapid-mlx point this at it.
         if let override = environment["RAPID_BIN"],
-           !override.isEmpty {
-            candidates.append((override, true))
+           !override.isEmpty,
+           let resolved = executableURL(path: override, allowRelative: true) {
+            return resolved
         }
 
-        // 2. runtime-override — written by ``BootstrapCoordinator``
+        // Managed sidecars. Resolve both executable slots before choosing:
+        // when both exist, VERSION decides which release the desktop owns.
+        // This prevents an override left by an older app from shadowing the
+        // newer engine that arrived inside a desktop update (#1503).
+        //
+        // 2a. runtime-override — written by ``BootstrapCoordinator``
         // on first launch of the slim DMG, or by the in-app updater
         // when it pulls a newer rapid-mlx than the bundled one. The
         // ``rapid-mlx/`` wrapper directory matches the top-level entry
@@ -93,52 +104,125 @@ enum ServerLocator {
         // exposed v0.8.12 when slim DMG first went live on
         // ``latest.json``; v0.8.10/v0.8.11 silently fell back to the
         // canonical full DMG which hit the bundled slot instead.
-        if let override = applicationSupportURL?
+        let runtimeOverride = applicationSupportURL?
             .appendingPathComponent("runtime-override/rapid-mlx/bin/rapid-mlx")
-            .path {
-            candidates.append((override, false))
+        let resolvedRuntimeOverride = runtimeOverride.flatMap {
+            executableURL(path: $0.path, allowRelative: false)
         }
 
-        // 3. bundled — shipped inside the DMG at
+        // 2b. bundled — shipped inside the DMG at
         // ``Contents/Resources/rapid-mlx/bin/rapid-mlx``. The slim
         // bootstrapper DMG (v0.8.9 ε.2) ships this slot EMPTY and
         // relies on slot 2 (populated by ``BootstrapCoordinator`` on
         // first launch) to satisfy the lookup. Full-bundle DMGs
         // (developer builds, future ad-hoc artefacts) keep this slot
-        // populated as a zero-network fallback. RAPID_BIN and runtime-
-        // override still win above — they remain explicit choices the
-        // user made at that level, not a "what desktop ships"
-        // fallback.
-        if let bundled = bundleResourceURL?
+        // populated as a zero-network fallback. RAPID_BIN remains an
+        // unconditional explicit choice; app-managed overrides are compared
+        // with this slot so an old bootstrap artifact cannot pin the desktop
+        // to an older engine forever.
+        let bundled = bundleResourceURL?
             .appendingPathComponent("rapid-mlx/bin/rapid-mlx")
-            .path {
-            candidates.append((bundled, false))
+        let resolvedBundled = bundled.flatMap {
+            executableURL(path: $0.path, allowRelative: false)
         }
 
-        // v0.8.10 cutover: PATH / homebrew / pipx / uv fallback slots
-        // were removed. The desktop release owns its sidecar end-to-
-        // end via the bootstrapper; an unrelated user-installed
-        // ``rapid-mlx`` on PATH would silently shadow the version the
-        // release pipeline shipped, and "Rapid · up to date" would
-        // then describe a different binary than the one actually
-        // answering spawn requests. If all three slots above miss,
-        // ``find()`` returns nil and callers re-run the bootstrapper
-        // (the only supported install path) rather than scavenging
-        // for a sibling rapid-mlx of unknown provenance.
+        // There is intentionally no PATH / Homebrew / pipx / uv fallback:
+        // if both managed slots miss, callers re-run the supported bootstrap.
+        switch (resolvedRuntimeOverride, resolvedBundled) {
+        case let (runtime?, resolvedBundle?):
+            // Read metadata from the managed slot rather than the resolved
+            // executable target. That keeps VERSION discovery correct if a
+            // slot uses a symlinked launcher.
+            let runtimeVersion = runtimeOverride.flatMap { sidecarVersion(forBinary: $0) }
+            let bundledVersion = bundled.flatMap { sidecarVersion(forBinary: $0) }
+            return shouldPreferBundled(
+                runtimeOverrideVersion: runtimeVersion,
+                bundledVersion: bundledVersion
+            ) ? resolvedBundle : runtime
+        case let (runtime?, nil):
+            // Slim DMG: bootstrap owns the only populated sidecar slot.
+            return runtime
+        case let (nil, bundled?):
+            return bundled
+        case (nil, nil):
+            return nil
+        }
+    }
 
+    /// Decide between two executable, app-managed sidecars.
+    ///
+    /// A valid bundled version is the trust anchor because it shipped with the
+    /// app. A runtime override may shadow it only when its own VERSION parses
+    /// and is equal or newer. If the bundle has no valid VERSION we preserve
+    /// the historical override-first behaviour: developer/ad-hoc bundles may
+    /// omit version metadata, and an unverifiable bundle must not displace a
+    /// working bootstrap install.
+    static func shouldPreferBundled(
+        runtimeOverrideVersion: String?,
+        bundledVersion: String?
+    ) -> Bool {
+        guard let bundled = parsedVersion(bundledVersion) else { return false }
+        guard let runtime = parsedVersion(runtimeOverrideVersion) else { return true }
+        return compareVersion(runtime, bundled) == .orderedAscending
+    }
+
+    /// Read `<sidecar-root>/VERSION` for a `.../bin/rapid-mlx` candidate.
+    private static func sidecarVersion(forBinary binary: URL) -> String? {
+        let versionFile = binary
+            .deletingLastPathComponent() // bin/
+            .deletingLastPathComponent() // rapid-mlx/
+            .appendingPathComponent("VERSION")
+        guard let data = try? Data(contentsOf: versionFile),
+              let raw = String(data: data, encoding: .utf8) else {
+            return nil
+        }
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    /// Strict dotted-numeric parser matching the sidecar build gate.
+    private static func parsedVersion(_ raw: String?) -> [Int]? {
+        guard var value = raw?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !value.isEmpty else { return nil }
+        if value.hasPrefix("v") || value.hasPrefix("V") {
+            value.removeFirst()
+        }
+        let fields = value.split(separator: ".", omittingEmptySubsequences: false)
+        guard fields.count >= 2 else { return nil }
+        var parts: [Int] = []
+        parts.reserveCapacity(fields.count)
+        for field in fields {
+            guard !field.isEmpty,
+                  field.allSatisfy({ $0 >= "0" && $0 <= "9" }),
+                  let part = Int(field) else { return nil }
+            parts.append(part)
+        }
+        return parts
+    }
+
+    private static func compareVersion(_ lhs: [Int], _ rhs: [Int]) -> ComparisonResult {
+        let width = max(lhs.count, rhs.count)
+        for index in 0..<width {
+            let left = index < lhs.count ? lhs[index] : 0
+            let right = index < rhs.count ? rhs[index] : 0
+            if left < right { return .orderedAscending }
+            if left > right { return .orderedDescending }
+        }
+        return .orderedSame
+    }
+
+    private static func executableURL(path: String, allowRelative: Bool) -> URL? {
+        guard let normalized = normalizedPath(path, allowRelative: allowRelative) else {
+            return nil
+        }
+        var isDirectory: ObjCBool = false
         let fm = FileManager.default
-        for candidate in candidates {
-            guard let path = normalizedPath(candidate.path, allowRelative: candidate.allowRelative) else {
-                continue
-            }
-            var isDir: ObjCBool = false
-            if fm.fileExists(atPath: path, isDirectory: &isDir),
-               !isDir.boolValue,
-               fm.isExecutableFile(atPath: path) {
-                return URL(fileURLWithPath: path).resolvingSymlinksInPath()
-            }
+        guard fm.fileExists(atPath: normalized, isDirectory: &isDirectory),
+              !isDirectory.boolValue,
+              fm.isExecutableFile(atPath: normalized) else {
+            return nil
         }
-        return nil
+        return URL(fileURLWithPath: normalized).resolvingSymlinksInPath()
     }
 
     /// Reports which slot in the priority chain a resolved binary came

--- a/apps/rapid-mac/Tests/RapidTests/ServerLocatorVersionSelectionTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ServerLocatorVersionSelectionTests.swift
@@ -1,0 +1,173 @@
+import Foundation
+import Testing
+@testable import Rapid
+
+@Suite("ServerLocator managed-sidecar version selection — #1503")
+struct ServerLocatorVersionSelectionTests {
+    @Test("A stale runtime override cannot shadow a newer bundled sidecar")
+    func staleRuntimeUsesBundle() throws {
+        let fixture = try Fixture(runtimeVersion: "0.10.8", bundledVersion: "0.12.4")
+        defer { fixture.remove() }
+
+        let resolved = ServerLocator.find(
+            environment: [:],
+            bundleResourceURL: fixture.bundleResources,
+            applicationSupportURL: fixture.applicationSupport
+        )
+
+        #expect(resolved == fixture.bundledBinary.resolvingSymlinksInPath())
+    }
+
+    @Test("A newer runtime override still wins after an in-app engine update")
+    func newerRuntimeWins() throws {
+        let fixture = try Fixture(runtimeVersion: "0.13.0", bundledVersion: "0.12.4")
+        defer { fixture.remove() }
+
+        let resolved = ServerLocator.find(
+            environment: [:],
+            bundleResourceURL: fixture.bundleResources,
+            applicationSupportURL: fixture.applicationSupport
+        )
+
+        #expect(resolved == fixture.runtimeBinary.resolvingSymlinksInPath())
+    }
+
+    @Test("Equal managed versions preserve runtime-override priority")
+    func equalRuntimeWins() throws {
+        let fixture = try Fixture(runtimeVersion: "0.12.4", bundledVersion: "0.12.4")
+        defer { fixture.remove() }
+
+        let resolved = ServerLocator.find(
+            environment: [:],
+            bundleResourceURL: fixture.bundleResources,
+            applicationSupportURL: fixture.applicationSupport
+        )
+
+        #expect(resolved == fixture.runtimeBinary.resolvingSymlinksInPath())
+    }
+
+    @Test("An unversioned runtime override cannot shadow a versioned bundle")
+    func unversionedRuntimeUsesBundle() throws {
+        let fixture = try Fixture(runtimeVersion: nil, bundledVersion: "0.12.4")
+        defer { fixture.remove() }
+
+        let resolved = ServerLocator.find(
+            environment: [:],
+            bundleResourceURL: fixture.bundleResources,
+            applicationSupportURL: fixture.applicationSupport
+        )
+
+        #expect(resolved == fixture.bundledBinary.resolvingSymlinksInPath())
+    }
+
+    @Test("Slim DMG still uses runtime override when no bundled binary exists")
+    func slimDMGUsesRuntime() throws {
+        let fixture = try Fixture(
+            runtimeVersion: "0.12.4",
+            bundledVersion: nil,
+            createBundledBinary: false
+        )
+        defer { fixture.remove() }
+
+        let resolved = ServerLocator.find(
+            environment: [:],
+            bundleResourceURL: fixture.bundleResources,
+            applicationSupportURL: fixture.applicationSupport
+        )
+
+        #expect(resolved == fixture.runtimeBinary.resolvingSymlinksInPath())
+    }
+
+    @Test("Explicit RAPID_BIN remains higher priority than both managed slots")
+    func rapidBinStillWins() throws {
+        let fixture = try Fixture(runtimeVersion: "0.10.8", bundledVersion: "0.12.4")
+        defer { fixture.remove() }
+        let explicit = fixture.root.appendingPathComponent("explicit-rapid-mlx")
+        try Fixture.writeExecutable(at: explicit)
+
+        let resolved = ServerLocator.find(
+            environment: ["RAPID_BIN": explicit.path],
+            bundleResourceURL: fixture.bundleResources,
+            applicationSupportURL: fixture.applicationSupport
+        )
+
+        #expect(resolved == explicit.resolvingSymlinksInPath())
+    }
+
+    @Test("Managed comparison rejects malformed versions and accepts v-prefix")
+    func comparisonGrammar() {
+        #expect(ServerLocator.shouldPreferBundled(
+            runtimeOverrideVersion: "not-a-version",
+            bundledVersion: "0.12.4"
+        ))
+        #expect(!ServerLocator.shouldPreferBundled(
+            runtimeOverrideVersion: "v0.12.5",
+            bundledVersion: "0.12.4"
+        ))
+        #expect(!ServerLocator.shouldPreferBundled(
+            runtimeOverrideVersion: "0.10.8",
+            bundledVersion: "development"
+        ))
+        #expect(!ServerLocator.shouldPreferBundled(
+            runtimeOverrideVersion: "0.12.4.0",
+            bundledVersion: "0.12.4"
+        ))
+    }
+}
+
+private struct Fixture {
+    let root: URL
+    let applicationSupport: URL
+    let bundleResources: URL
+    let runtimeBinary: URL
+    let bundledBinary: URL
+
+    init(
+        runtimeVersion: String?,
+        bundledVersion: String?,
+        createBundledBinary: Bool = true
+    ) throws {
+        let fm = FileManager.default
+        root = fm.temporaryDirectory
+            .appendingPathComponent("rapid-server-locator-\(UUID().uuidString)", isDirectory: true)
+        applicationSupport = root.appendingPathComponent("support", isDirectory: true)
+        bundleResources = root.appendingPathComponent("resources", isDirectory: true)
+        runtimeBinary = applicationSupport
+            .appendingPathComponent("runtime-override/rapid-mlx/bin/rapid-mlx")
+        bundledBinary = bundleResources
+            .appendingPathComponent("rapid-mlx/bin/rapid-mlx")
+
+        try Self.writeExecutable(at: runtimeBinary)
+        if createBundledBinary {
+            try Self.writeExecutable(at: bundledBinary)
+        }
+        if let runtimeVersion {
+            try Self.writeVersion(runtimeVersion, forBinary: runtimeBinary)
+        }
+        if let bundledVersion, createBundledBinary {
+            try Self.writeVersion(bundledVersion, forBinary: bundledBinary)
+        }
+    }
+
+    func remove() {
+        try? FileManager.default.removeItem(at: root)
+    }
+
+    static func writeExecutable(at url: URL) throws {
+        let fm = FileManager.default
+        try fm.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try Data("#!/bin/sh\nexit 0\n".utf8).write(to: url, options: .atomic)
+        try fm.setAttributes([.posixPermissions: 0o755], ofItemAtPath: url.path)
+    }
+
+    private static func writeVersion(_ version: String, forBinary binary: URL) throws {
+        let root = binary.deletingLastPathComponent().deletingLastPathComponent()
+        try Data("\(version)\n".utf8).write(
+            to: root.appendingPathComponent("VERSION"),
+            options: .atomic
+        )
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Makes Desktop compare the managed runtime override and bundled sidecar `VERSION` files when both executables exist. The explicit `RAPID_BIN` escape hatch remains highest priority; a same-version or newer runtime override still wins; slim DMGs with only an override retain their existing behavior.

Adds focused Swift tests for stale, newer, equal, missing, and malformed version metadata plus the `RAPID_BIN` and slim-DMG paths.

## Why is this needed?

Fixes #1503. Desktop 0.12.5 can silently launch a stale runtime override instead of its bundled 0.12.4 engine. On an affected machine this leaves first launch waiting on an old engine even though the updated app contains a working newer one.

Root cause: `ServerLocator` selected the first executable candidate in a fixed override-before-bundle list and never inspected the managed sidecars' version metadata.

## AI assistance disclosure

Codex wrote and reviewed both changed files: `ServerLocator.swift` and `ServerLocatorVersionSelectionTests.swift`. The result was verified against the release scripts' real sidecar layout and `VERSION` contract, inspected against the reported 0.10.8-to-0.12.4 case, passed Swift frontend syntax parsing plus `git diff --check`, and completed a convergent Codex review with no findings.

> By submitting this PR I confirm I can explain the intent, risk, and behavior of every non-generated change in this PR. For any generated / boilerplate / scaffolded sections, I've identified them above and can describe how I verified them.

## Test plan

- [x] Swift frontend syntax parse passed for production and test files.
- [x] `git diff --check` passed.
- [x] Codex review converged with 0 P0 / 0 P1 / 0 findings; evidence is posted in the PR thread.
- [x] Supply-chain and description-quality gates passed in the first `pr_validate` run.
- [x] GitHub macOS CI will compile and execute the Swift suite before merge.
- [x] Full Desktop build and model dogfood are not required for this locator-only PR; release-layout paths were checked directly against `build.sh` and `build-sidecar-tarball.sh`.

## Checklist

- [x] New behavior has focused regression tests.
- [x] No dependency or workflow changes.
- [x] README changes are not applicable; `ServerLocator` behavior documentation was updated inline.
- [x] No breaking changes to existing API.
