### PR TITLE
fix(agents): stop `codex --setup` deleting the user's config

### DIFF
--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -65,7 +65,11 @@ jobs:
           #   `targeted_tests` see the same import surface they would
           #   if a contributor ran `make smoke` locally.
           pip install pyyaml requests pip-audit ruff rich mcp
-          pip install pytest pytest-asyncio pytest-cov pydantic fastapi jsonschema httpx psutil transformers
+          # tomli-w is a RUNTIME dep (agents/adapter.py merges ~/.codex/config.toml).
+          # This runner installs a curated list rather than the package, so a new
+          # runtime dependency has to be named here too or targeted_tests fails on
+          # import while the main-branch control passes.
+          pip install pytest pytest-asyncio pytest-cov pydantic fastapi jsonschema httpx psutil transformers tomli-w
 
       - name: Resolve PR number
         id: prnum

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,12 @@ dependencies = [
     # side needs a package, and this is the companion to the ``tomli`` the
     # [test] extra already pins. Pure Python, no transitive deps.
     "tomli-w>=1.0.0",
+    # The read side is stdlib ``tomllib`` from 3.11; 3.10 is still a supported
+    # floor and has no ``tomllib``, so the merge path needs the backport there.
+    # It was a [test]-only pin before, which would have made `codex --setup`
+    # abort with ModuleNotFoundError on 3.10 — and only when a config already
+    # existed, so every fresh-write test would still have passed.
+    'tomli>=2.0.1; python_version < "3.11"',
     "requests>=2.28.0",
     "rich>=13.8.0",
     "tabulate>=0.9.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,12 @@ dependencies = [
     # pillow is opt-in via [vision] extras — only the MLLM paths (mllm.py,
     # benchmark.py image mode) touch PIL, and mlx-vlm requires it anyway.
     "pyyaml>=6.0",
+    # Writing TOML, so ``rapid-mlx agents codex --setup`` can deep-merge into
+    # an existing ~/.codex/config.toml instead of replacing it (#1532).
+    # Reading is stdlib ``tomllib`` on our supported floor; only the write
+    # side needs a package, and this is the companion to the ``tomli`` the
+    # [test] extra already pins. Pure Python, no transitive deps.
+    "tomli-w>=1.0.0",
     "requests>=2.28.0",
     "rich>=13.8.0",
     "tabulate>=0.9.0",

--- a/tests/test_agent_setup_config_merge.py
+++ b/tests/test_agent_setup_config_merge.py
@@ -15,6 +15,15 @@ import textwrap
 import pytest
 import yaml
 
+# Same compatibility shim the production merge path uses. Importing plain
+# ``tomllib`` here would make every TOML test below fail with
+# ModuleNotFoundError on 3.10 — which ``requires-python`` still supports —
+# so these tests would stop covering the very fallback they exist to guard.
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover — Python 3.10 only
+    import tomli as tomllib
+
 from vllm_mlx.agents.adapter import (
     _deep_merge,
     _merge_file_config,
@@ -434,8 +443,6 @@ class TestTomlMerge:
     """)
 
     def _merged(self, tmp_path):
-        import tomllib
-
         existing = tmp_path / "config.toml"
         existing.write_text(self.USER_CONFIG)
         return tomllib.loads(_merge_file_config(existing, self.TEMPLATE, "toml"))
@@ -464,8 +471,6 @@ class TestTomlMerge:
 
     def test_user_keys_inside_our_own_table_survive(self, tmp_path):
         """``env_key`` is what the template's own comment tells users to add."""
-        import tomllib
-
         existing = tmp_path / "config.toml"
         existing.write_text(
             textwrap.dedent("""\
@@ -507,8 +512,6 @@ class TestTomlMerge:
         any of it to matter, and the codex profile is the only caller that
         can prove it.
         """
-        import tomllib
-
         from vllm_mlx.agents import get_profile
 
         monkeypatch.setenv("HOME", str(tmp_path))

--- a/tests/test_agent_setup_config_merge.py
+++ b/tests/test_agent_setup_config_merge.py
@@ -388,3 +388,147 @@ class TestEnvProfileUnchanged:
         assert isinstance(rendered, dict)
         assert rendered["BASE_URL"] == "http://localhost:8000/v1"
         assert rendered["MODEL"] == "my-model"
+
+
+# ---------------------------------------------------------------------------
+# 6. TOML merge — the only profile that reaches it is codex (#1532)
+# ---------------------------------------------------------------------------
+
+
+class TestTomlMerge:
+    """``--setup`` must not delete what it did not write.
+
+    ``toml`` used to fall into the "unknown type" branch of
+    ``_merge_file_config``, which returns the rendered template and lets the
+    caller write it over whatever was there. Codex is the only TOML profile,
+    so a single ``rapid-mlx agents codex --setup`` destroyed the user's
+    ``approval_policy``, every ``[mcp_servers.*]`` server and every
+    ``[projects.*]`` trust decision — silently, and reported it as a neutral
+    "Wrote config to …".
+
+    Mutation check: restore ``if config_type not in ("yaml", "json")`` and
+    every test in this class fails.
+    """
+
+    USER_CONFIG = textwrap.dedent("""\
+        model = "gpt-5.2-codex"
+        approval_policy = "on-request"
+        sandbox_mode = "workspace-write"
+
+        [mcp_servers.vnsh]
+        command = "npx"
+        args = ["-y", "vnsh-mcp@1.4.1"]
+
+        [projects."/Users/me/work"]
+        trust_level = "trusted"
+    """)
+
+    TEMPLATE = textwrap.dedent("""\
+        model = "my-model"
+        model_provider = "rapid-mlx"
+        model_context_window = 32768
+
+        [model_providers.rapid-mlx]
+        name = "Rapid-MLX (local)"
+        base_url = "http://localhost:8000/v1"
+    """)
+
+    def _merged(self, tmp_path):
+        import tomllib
+
+        existing = tmp_path / "config.toml"
+        existing.write_text(self.USER_CONFIG)
+        return tomllib.loads(_merge_file_config(existing, self.TEMPLATE, "toml"))
+
+    def test_user_scalars_survive(self, tmp_path):
+        parsed = self._merged(tmp_path)
+        assert parsed["approval_policy"] == "on-request"
+        assert parsed["sandbox_mode"] == "workspace-write"
+
+    def test_user_tables_survive(self, tmp_path):
+        """The blast radius that made this a data-loss bug rather than a nit."""
+        parsed = self._merged(tmp_path)
+        assert parsed["mcp_servers"]["vnsh"]["command"] == "npx"
+        assert parsed["mcp_servers"]["vnsh"]["args"] == ["-y", "vnsh-mcp@1.4.1"]
+        assert parsed["projects"]["/Users/me/work"]["trust_level"] == "trusted"
+
+    def test_template_still_wins_on_the_keys_it_sets(self, tmp_path):
+        """Preserving user data must not defeat the point of --setup."""
+        parsed = self._merged(tmp_path)
+        assert parsed["model"] == "my-model"
+        assert parsed["model_provider"] == "rapid-mlx"
+        assert parsed["model_context_window"] == 32768
+        assert parsed["model_providers"]["rapid-mlx"]["base_url"] == (
+            "http://localhost:8000/v1"
+        )
+
+    def test_user_keys_inside_our_own_table_survive(self, tmp_path):
+        """``env_key`` is what the template's own comment tells users to add."""
+        import tomllib
+
+        existing = tmp_path / "config.toml"
+        existing.write_text(
+            textwrap.dedent("""\
+                [model_providers.rapid-mlx]
+                name = "stale name"
+                base_url = "http://old:1234/v1"
+                env_key = "RAPID_MLX_API_KEY"
+            """)
+        )
+        parsed = tomllib.loads(_merge_file_config(existing, self.TEMPLATE, "toml"))
+        provider = parsed["model_providers"]["rapid-mlx"]
+        assert provider["env_key"] == "RAPID_MLX_API_KEY"
+        assert provider["base_url"] == "http://localhost:8000/v1"
+
+    def test_fresh_write_returns_template_verbatim(self, tmp_path):
+        """No file yet → no round trip, so the template's comments survive."""
+        missing = tmp_path / "config.toml"
+        assert _merge_file_config(missing, self.TEMPLATE, "toml") == self.TEMPLATE
+
+    def test_empty_file_treated_as_fresh(self, tmp_path):
+        existing = tmp_path / "config.toml"
+        existing.write_text("   \n\n")
+        assert _merge_file_config(existing, self.TEMPLATE, "toml") == self.TEMPLATE
+
+    def test_malformed_toml_raises_instead_of_overwriting(self, tmp_path):
+        """Parity with YAML/JSON: an unparseable file is reported, not erased."""
+        existing = tmp_path / "config.toml"
+        existing.write_text("this is not = = toml\n[unclosed\n")
+        with pytest.raises(_MergeParseError):
+            _merge_file_config(existing, self.TEMPLATE, "toml")
+
+    def test_setup_agent_config_merges_the_real_codex_profile(
+        self, tmp_path, monkeypatch
+    ):
+        """End to end, through the profile that actually ships.
+
+        The unit tests above would all pass with the wiring still broken —
+        ``cfg.type`` has to reach ``_merge_file_config`` as ``"toml"`` for
+        any of it to matter, and the codex profile is the only caller that
+        can prove it.
+        """
+        import tomllib
+
+        from vllm_mlx.agents import get_profile
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        codex_home = tmp_path / ".codex"
+        codex_home.mkdir()
+        config_path = codex_home / "config.toml"
+        config_path.write_text(self.USER_CONFIG)
+
+        profile = get_profile("codex")
+        assert profile is not None and profile.config.type == "toml"
+
+        summary = setup_agent_config(
+            profile, base_url="http://localhost:8000/v1", model_id="my-model"
+        )
+
+        parsed = tomllib.loads(config_path.read_text())
+        assert parsed["mcp_servers"]["vnsh"]["command"] == "npx"
+        assert parsed["projects"]["/Users/me/work"]["trust_level"] == "trusted"
+        assert parsed["approval_policy"] == "on-request"
+        assert parsed["model_provider"] == "rapid-mlx"
+        # And the operator is told which of the two things happened.
+        assert "Merged config into" in summary
+        assert "comments were not" in summary

--- a/tests/test_launch_cli.py
+++ b/tests/test_launch_cli.py
@@ -428,7 +428,7 @@ class TestCommon:
         def _refuse(*args, **kwargs):
             raise PermissionError("not a member of that group")
 
-        monkeypatch.setattr(_common.os, "chown", _refuse)
+        monkeypatch.setattr(_common.os, "fchown", _refuse)
 
         bak = _common.backup_existing(target)
 
@@ -436,6 +436,37 @@ class TestCommon:
         assert bak.read_bytes() == target.read_bytes()
         assert bak.stat().st_mode & 0o077 == 0, (
             "backup kept group/other access it could not vouch for"
+        )
+
+    def test_backup_never_touches_the_destination_by_name(self, tmp_path, monkeypatch):
+        """Ownership and mode go through the descriptor, never the path.
+
+        Anyone who can write the config's *directory* can unlink our backup
+        and leave a symlink where it was. A pathname-based chown/chmod would
+        then follow that symlink and re-permission someone else's file. The
+        O_EXCL create is what makes the name ours; addressing the descriptor
+        from then on is what keeps it ours.
+
+        A 0640 source is what forces the interesting path: the mode-narrowing
+        block only runs when the source has group/other bits, so a 0600 source
+        would pass this test without ever reaching a chown or a chmod.
+        """
+        target = tmp_path / "config.json"
+        target.write_text('{"apiKey": "sk-secret"}')
+        target.chmod(0o640)
+
+        def _boom(*args, **kwargs):
+            raise AssertionError("backup_existing addressed the backup by pathname")
+
+        monkeypatch.setattr(_common.os, "chown", _boom)
+        monkeypatch.setattr(_common.os, "chmod", _boom)
+
+        bak = _common.backup_existing(target)
+
+        assert bak is not None
+        assert bak.read_bytes() == target.read_bytes()
+        assert bak.stat().st_mode & 0o077 == 0o040, (
+            "expected the 0640 source's group bit to be reproduced via fchmod"
         )
 
     def test_load_json_lenient_missing(self, tmp_path):

--- a/tests/test_launch_cli.py
+++ b/tests/test_launch_cli.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -394,12 +395,23 @@ class TestCommon:
         assert bak.read_bytes() == target.read_bytes()
         assert bak.stat().st_mode & 0o777 == source_mode
 
-    def test_backup_matches_a_deliberately_open_source(self, tmp_path):
-        """Not "always 0600" — mirror the source, whatever it is.
+    def test_backup_matches_an_open_source_only_when_acls_are_readable(self, tmp_path):
+        """Mirror a deliberately-open source — but only where we can prove it.
 
-        A user who chmod'd their own config group-readable did so on
-        purpose; silently tightening the backup would make the recovery
-        copy behave differently from the thing it recovers.
+        A user who chmod'd their own config group-readable did so on purpose,
+        and silently tightening the backup makes the recovery copy behave
+        differently from the thing it recovers. That reasoning holds only
+        while the mode bits tell the whole story. An ACL can *deny* a
+        principal the bits would otherwise admit, and a freshly created file
+        carries none — so reproducing 0644 from a 0644-plus-deny-ACL source
+        hands the file to exactly the account it shut out.
+
+        On Linux the ACL shows up as a ``system.posix_acl_*`` xattr, so
+        absence is proof and the mode is reproduced. macOS has no
+        ``os.listxattr`` at all and its ACLs are not xattrs anyway, so
+        equivalence can never be established there and the backup stays
+        owner-only. Tighter than the source still restores; wider does not
+        un-leak.
         """
         target = tmp_path / "config.json"
         target.write_text('{"a": 1}')
@@ -408,7 +420,12 @@ class TestCommon:
         bak = _common.backup_existing(target)
 
         assert bak is not None
-        assert bak.stat().st_mode & 0o777 == 0o644
+        if hasattr(os, "listxattr"):
+            assert bak.stat().st_mode & 0o777 == 0o644
+        else:
+            assert bak.stat().st_mode & 0o777 == 0o600, (
+                "without an ACL API we cannot vouch for group/other access"
+            )
 
     def test_backup_drops_group_bits_when_the_group_cannot_be_matched(
         self, tmp_path, monkeypatch
@@ -465,9 +482,11 @@ class TestCommon:
 
         assert bak is not None
         assert bak.read_bytes() == target.read_bytes()
-        assert bak.stat().st_mode & 0o077 == 0o040, (
-            "expected the 0640 source's group bit to be reproduced via fchmod"
-        )
+        # The mode still has to have been applied — through the descriptor,
+        # since the pathname calls above would have raised. How wide it lands
+        # is the ACL policy's business (see the test above), so assert only
+        # that it is a mode this function could legitimately have chosen.
+        assert bak.stat().st_mode & 0o777 in (0o600, 0o640)
 
     def test_load_json_lenient_missing(self, tmp_path):
         assert _common.load_json_lenient(tmp_path / "missing.json") == {}

--- a/tests/test_launch_cli.py
+++ b/tests/test_launch_cli.py
@@ -367,6 +367,49 @@ class TestCommon:
         assert b1 is not None and b2 is not None
         assert b1 != b2
 
+    def test_backup_is_never_more_permissive_than_its_source(self, tmp_path):
+        """A backup must not widen access to what it copies.
+
+        ``atomic_write_json`` writes the config itself through ``mkstemp``,
+        so the live file is 0600 — and ``launch`` puts ``RAPID_MLX_API_KEY``
+        into it. The backup used to be a plain ``write_bytes``, i.e.
+        ``0666 & ~umask`` — 0644 on a default install — so every second
+        ``rapid-mlx launch`` dropped the live bearer token into a
+        world-readable file beside the protected one.
+
+        Mutation check: restore ``bak.write_bytes(path.read_bytes())`` and
+        this fails with 0644 (or whatever the ambient umask yields).
+        """
+        target = tmp_path / "config.json"
+        _common.atomic_write_json(target, {"apiKey": "sk-secret"})
+        source_mode = target.stat().st_mode & 0o777
+        assert source_mode == 0o600, (
+            "precondition: the config itself is written restrictively — if "
+            "this changed, the backup expectation below must change with it"
+        )
+
+        bak = _common.backup_existing(target)
+
+        assert bak is not None
+        assert bak.read_bytes() == target.read_bytes()
+        assert bak.stat().st_mode & 0o777 == source_mode
+
+    def test_backup_matches_a_deliberately_open_source(self, tmp_path):
+        """Not "always 0600" — mirror the source, whatever it is.
+
+        A user who chmod'd their own config group-readable did so on
+        purpose; silently tightening the backup would make the recovery
+        copy behave differently from the thing it recovers.
+        """
+        target = tmp_path / "config.json"
+        target.write_text('{"a": 1}')
+        target.chmod(0o644)
+
+        bak = _common.backup_existing(target)
+
+        assert bak is not None
+        assert bak.stat().st_mode & 0o777 == 0o644
+
     def test_load_json_lenient_missing(self, tmp_path):
         assert _common.load_json_lenient(tmp_path / "missing.json") == {}
 

--- a/tests/test_launch_cli.py
+++ b/tests/test_launch_cli.py
@@ -410,6 +410,34 @@ class TestCommon:
         assert bak is not None
         assert bak.stat().st_mode & 0o777 == 0o644
 
+    def test_backup_drops_group_bits_when_the_group_cannot_be_matched(
+        self, tmp_path, monkeypatch
+    ):
+        """Mode bits are numbers; what matters is who they authorize.
+
+        A new file takes the *directory's* group, not the source's. Copying
+        0640 from an ``alice:secrets`` config onto an ``alice:staff`` backup
+        keeps the number and changes the audience — every member of staff can
+        then read the API key. When the group cannot be adopted, the backup
+        stays owner-only: tighter than the source still restores.
+        """
+        target = tmp_path / "config.json"
+        target.write_text('{"apiKey": "sk-secret"}')
+        target.chmod(0o640)
+
+        def _refuse(*args, **kwargs):
+            raise PermissionError("not a member of that group")
+
+        monkeypatch.setattr(_common.os, "chown", _refuse)
+
+        bak = _common.backup_existing(target)
+
+        assert bak is not None
+        assert bak.read_bytes() == target.read_bytes()
+        assert bak.stat().st_mode & 0o077 == 0, (
+            "backup kept group/other access it could not vouch for"
+        )
+
     def test_load_json_lenient_missing(self, tmp_path):
         assert _common.load_json_lenient(tmp_path / "missing.json") == {}
 

--- a/vllm_mlx/agents/adapter.py
+++ b/vllm_mlx/agents/adapter.py
@@ -92,9 +92,9 @@ def setup_agent_config(
 ) -> str:
     """Write the agent's config file or print env vars to set up the integration.
 
-    For file-based configs (YAML/JSON), if the config file already exists
-    it is *merged* rather than overwritten — user customizations are
-    preserved while connection details are updated.
+    For file-based configs (YAML/JSON/TOML), if the config file already
+    exists it is *merged* rather than overwritten — user customizations
+    are preserved while connection details are updated.
 
     Returns a human-readable summary of what was done.
     """
@@ -163,6 +163,12 @@ def setup_agent_config(
             summary = f"Wrote config to {config_path}"
         else:
             summary = f"Merged config into {config_path} (custom keys preserved)"
+            if cfg.type == "toml":
+                # Say it plainly: the round trip through the parser keeps
+                # every key but drops comments, and a user who hand-wrote
+                # notes into ~/.codex/config.toml should hear that from us
+                # rather than discover it.
+                summary += "; comments were not"
         return summary
 
     return "No config to write (template not specified)"
@@ -178,8 +184,8 @@ def _merge_file_config(existing_path: Path, rendered: str, config_type: str) -> 
     if not existing_path.exists():
         return rendered
 
-    # toml / unknown — overwrite without reading (no merge support)
-    if config_type not in ("yaml", "json"):
+    # Unknown type — overwrite without reading (no merge support).
+    if config_type not in ("yaml", "json", "toml"):
         return rendered
 
     # Let OSError propagate — caller must not silently overwrite an
@@ -188,7 +194,43 @@ def _merge_file_config(existing_path: Path, rendered: str, config_type: str) -> 
 
     if config_type == "yaml":
         return _merge_yaml(existing_text, rendered)
+    if config_type == "toml":
+        return _merge_toml(existing_text, rendered)
     return _merge_json(existing_text, rendered)
+
+
+def _merge_toml(existing_text: str, rendered: str) -> str:
+    """Parse both TOML strings, deep-merge, and re-serialize.
+
+    Same error semantics as ``_merge_yaml``.
+
+    Until this existed, ``toml`` fell into the "unknown type" branch above
+    and ``--setup`` replaced the file wholesale. Codex is the only TOML
+    profile, so one ``rapid-mlx agents codex --setup`` deleted the user's
+    ``approval_policy``, every ``[mcp_servers.*]`` block and every
+    ``[projects.*]`` trust entry — with no backup, and a summary line that
+    said a neutral "Wrote config to …" while the code already knew it had
+    overwritten rather than merged (issue #1532).
+
+    Comments do not survive the round trip, which is the same trade the
+    JSON and YAML paths have always made. Losing the formatting of a
+    hand-tuned config is an annoyance; losing its contents is data loss.
+    """
+    import tomli_w
+    import tomllib
+
+    if not existing_text.strip():
+        return rendered
+    try:
+        existing = tomllib.loads(existing_text)
+    except Exception as exc:
+        raise _MergeParseError(f"invalid TOML: {exc}") from exc
+    try:
+        template = tomllib.loads(rendered)
+    except Exception as exc:
+        raise _MergeParseError(f"rendered template is not valid TOML: {exc}") from exc
+    merged = _deep_merge(existing, template)
+    return tomli_w.dumps(merged)
 
 
 def _merge_yaml(existing_text: str, rendered: str) -> str:

--- a/vllm_mlx/agents/adapter.py
+++ b/vllm_mlx/agents/adapter.py
@@ -217,7 +217,16 @@ def _merge_toml(existing_text: str, rendered: str) -> str:
     hand-tuned config is an annoyance; losing its contents is data loss.
     """
     import tomli_w
-    import tomllib
+
+    try:
+        import tomllib
+    except ModuleNotFoundError:  # pragma: no cover — Python 3.10 only
+        # ``tomllib`` is stdlib from 3.11; ``pyproject`` still supports 3.10,
+        # where a bare import would abort --setup with ModuleNotFoundError on
+        # the merge path only — every fresh-write test would stay green.
+        # ``tomli`` is the same parser under its pre-stdlib name and is now a
+        # runtime dependency under that marker, not just a [test] one.
+        import tomli as tomllib
 
     if not existing_text.strip():
         return rendered

--- a/vllm_mlx/launch/_common.py
+++ b/vllm_mlx/launch/_common.py
@@ -66,8 +66,19 @@ def backup_existing(path: Path) -> Path | None:
     # probe alone is a check-then-act, so two concurrent launches could
     # settle on the same counter and one would silently overwrite the
     # other's backup. Losing on the open just advances the counter.
+    # One open, then read AND stat through that same descriptor. Looking the
+    # pathname up twice lets an editor's atomic replace land in between, so the
+    # backup could hold the OLD secret while wearing the NEW file's looser
+    # mode.
     counter = 0
-    data = path.read_bytes()
+    src_fd = os.open(path, os.O_RDONLY)
+    try:
+        src = os.fstat(src_fd)
+        data = b""
+        while chunk := os.read(src_fd, 1 << 20):
+            data += chunk
+    finally:
+        os.close(src_fd)
     while True:
         try:
             fd = os.open(bak, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
@@ -83,7 +94,6 @@ def backup_existing(path: Path) -> Path | None:
     # a source that is itself group/world-readable keeps that, because
     # the backup should not be MORE exposed than what it copies, and
     # need not be less.
-    src = os.stat(path)
     mode = src.st_mode & 0o7777
     if mode & 0o077:
         # Group/other bits only mean "no wider than the source" if the
@@ -104,6 +114,21 @@ def backup_existing(path: Path) -> Path | None:
             mode &= 0o700
         else:
             if os.stat(bak).st_gid != src.st_gid:
+                mode &= 0o700
+        # An ACL can DENY a principal the mode bits would otherwise admit, and
+        # a freshly created file carries none. Reproducing 0644 without the
+        # deny entry hands the file to exactly the account the source shut
+        # out. There is no stdlib API to copy one, so when the source carries
+        # a security xattr the backup stays owner-only rather than pretending
+        # the numbers tell the whole story.
+        listxattr = getattr(os, "listxattr", None)
+        if listxattr is not None:
+            try:
+                if any(
+                    x.startswith("com.apple.system.Security") for x in listxattr(path)
+                ):
+                    mode &= 0o700
+            except OSError:
                 mode &= 0o700
     os.chmod(bak, mode)
     print(f"  backup: {bak}", file=sys.stderr)

--- a/vllm_mlx/launch/_common.py
+++ b/vllm_mlx/launch/_common.py
@@ -87,14 +87,16 @@ def backup_existing(path: Path) -> Path | None:
         # backup would hold the OLD secret while the ACL decision below came
         # from the NEW file. That is the same TOCTOU the single open already
         # closed for st_mode, just wearing a different field.
+        # ``None`` means "could not verify", which the mode policy below
+        # treats as "do not reproduce group/other bits". macOS ships no
+        # os.listxattr at all, and a macOS ACL is not an xattr we could read
+        # even if it did — so on the platform this project actually targets
+        # we can never establish ACL equivalence, and a 0644 source carrying
+        # a deny entry would otherwise yield a 0644 backup that denies
+        # nobody.
         listxattr = getattr(os, "listxattr", None)
-        if listxattr is None:
-            # macOS ships no os.listxattr, so a macOS ACL is invisible from
-            # here. Empty (rather than None) keeps the mode policy unchanged
-            # on that platform — the gap is real and stated, not silently
-            # turned into over-tightening every backup.
-            src_xattrs: tuple[str, ...] | None = ()
-        else:
+        src_xattrs: tuple[str, ...] | None = None
+        if listxattr is not None:
             try:
                 src_xattrs = tuple(listxattr(src_fd))
             except OSError:

--- a/vllm_mlx/launch/_common.py
+++ b/vllm_mlx/launch/_common.py
@@ -44,6 +44,14 @@ def backup_existing(path: Path) -> Path | None:
     Prints the backup location to stderr so a user reading the launch
     command's output sees "backup at <path>" without it being mixed
     into the success stdout (which scripts may parse).
+
+    The backup is created 0600 and then given the original's mode. A
+    plain ``write_bytes`` would have created it ``0666 & ~umask`` — 0644
+    on a default install — while :func:`atomic_write_json` hands the
+    config itself the 0600 that ``mkstemp`` produces. Since
+    ``rapid-mlx launch`` writes ``RAPID_MLX_API_KEY`` into these files,
+    that difference put the live bearer token in a world-readable file
+    next to the protected one, for any other local account to read.
     """
     if not path.exists():
         return None
@@ -53,11 +61,29 @@ def backup_existing(path: Path) -> Path | None:
     # (unlikely interactively but trivially reachable in tests). Walk
     # the suffix counter forward until we find an unused name; we don't
     # care about the counter value being meaningful.
+    #
+    # ``O_EXCL`` is what actually makes the name ours: the ``exists()``
+    # probe alone is a check-then-act, so two concurrent launches could
+    # settle on the same counter and one would silently overwrite the
+    # other's backup. Losing on the open just advances the counter.
     counter = 0
-    while bak.exists():
-        counter += 1
-        bak = path.with_suffix(path.suffix + f".bak.{ts}.{counter}")
-    bak.write_bytes(path.read_bytes())
+    data = path.read_bytes()
+    while True:
+        try:
+            fd = os.open(bak, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+        except FileExistsError:
+            counter += 1
+            bak = path.with_suffix(path.suffix + f".bak.{ts}.{counter}")
+            continue
+        with os.fdopen(fd, "wb") as fh:
+            fh.write(data)
+        break
+    # Match the original once the bytes are down. Created restrictive
+    # first so the contents are never briefly readable at a wider mode;
+    # a source that is itself group/world-readable keeps that, because
+    # the backup should not be MORE exposed than what it copies, and
+    # need not be less.
+    os.chmod(bak, os.stat(path).st_mode & 0o7777)
     print(f"  backup: {bak}", file=sys.stderr)
     return bak
 

--- a/vllm_mlx/launch/_common.py
+++ b/vllm_mlx/launch/_common.py
@@ -83,7 +83,29 @@ def backup_existing(path: Path) -> Path | None:
     # a source that is itself group/world-readable keeps that, because
     # the backup should not be MORE exposed than what it copies, and
     # need not be less.
-    os.chmod(bak, os.stat(path).st_mode & 0o7777)
+    src = os.stat(path)
+    mode = src.st_mode & 0o7777
+    if mode & 0o077:
+        # Group/other bits only mean "no wider than the source" if the
+        # backup answers to the same principals. A new file takes the
+        # DIRECTORY's group, which need not be the source's — copying
+        # 0640 from an alice:secrets config onto an alice:staff backup
+        # would hand the key to all of staff. Mode bits are numbers, not
+        # an audience.
+        #
+        # Adopt the source's group where the OS allows it (it does when
+        # the caller is a member, which is the ordinary case for one's
+        # own dotfiles), and otherwise keep the file owner-only. Refusing
+        # to widen is the safe direction: a backup that is tighter than
+        # its source still restores.
+        try:
+            os.chown(bak, -1, src.st_gid)
+        except (PermissionError, OSError):
+            mode &= 0o700
+        else:
+            if os.stat(bak).st_gid != src.st_gid:
+                mode &= 0o700
+    os.chmod(bak, mode)
     print(f"  backup: {bak}", file=sys.stderr)
     return bak
 

--- a/vllm_mlx/launch/_common.py
+++ b/vllm_mlx/launch/_common.py
@@ -74,9 +74,31 @@ def backup_existing(path: Path) -> Path | None:
     src_fd = os.open(path, os.O_RDONLY)
     try:
         src = os.fstat(src_fd)
-        data = b""
+        # ``chunks`` then one join, not ``data += chunk``: the latter copies
+        # the whole accumulated buffer every iteration, which is quadratic in
+        # file size.
+        chunks: list[bytes] = []
         while chunk := os.read(src_fd, 1 << 20):
-            data += chunk
+            chunks.append(chunk)
+        data = b"".join(chunks)
+        # Security metadata has to come off the SAME descriptor as the bytes
+        # and the mode. Reading it by pathname further down would let an
+        # editor's atomic replace answer for a file we did not copy: the
+        # backup would hold the OLD secret while the ACL decision below came
+        # from the NEW file. That is the same TOCTOU the single open already
+        # closed for st_mode, just wearing a different field.
+        listxattr = getattr(os, "listxattr", None)
+        if listxattr is None:
+            # macOS ships no os.listxattr, so a macOS ACL is invisible from
+            # here. Empty (rather than None) keeps the mode policy unchanged
+            # on that platform — the gap is real and stated, not silently
+            # turned into over-tightening every backup.
+            src_xattrs: tuple[str, ...] | None = ()
+        else:
+            try:
+                src_xattrs = tuple(listxattr(src_fd))
+            except OSError:
+                src_xattrs = None
     finally:
         os.close(src_fd)
     while True:
@@ -86,51 +108,58 @@ def backup_existing(path: Path) -> Path | None:
             counter += 1
             bak = path.with_suffix(path.suffix + f".bak.{ts}.{counter}")
             continue
-        with os.fdopen(fd, "wb") as fh:
-            fh.write(data)
         break
-    # Match the original once the bytes are down. Created restrictive
-    # first so the contents are never briefly readable at a wider mode;
-    # a source that is itself group/world-readable keeps that, because
-    # the backup should not be MORE exposed than what it copies, and
-    # need not be less.
-    mode = src.st_mode & 0o7777
-    if mode & 0o077:
-        # Group/other bits only mean "no wider than the source" if the
-        # backup answers to the same principals. A new file takes the
-        # DIRECTORY's group, which need not be the source's — copying
-        # 0640 from an alice:secrets config onto an alice:staff backup
-        # would hand the key to all of staff. Mode bits are numbers, not
-        # an audience.
-        #
-        # Adopt the source's group where the OS allows it (it does when
-        # the caller is a member, which is the ordinary case for one's
-        # own dotfiles), and otherwise keep the file owner-only. Refusing
-        # to widen is the safe direction: a backup that is tighter than
-        # its source still restores.
-        try:
-            os.chown(bak, -1, src.st_gid)
-        except (PermissionError, OSError):
-            mode &= 0o700
-        else:
-            if os.stat(bak).st_gid != src.st_gid:
-                mode &= 0o700
-        # An ACL can DENY a principal the mode bits would otherwise admit, and
-        # a freshly created file carries none. Reproducing 0644 without the
-        # deny entry hands the file to exactly the account the source shut
-        # out. There is no stdlib API to copy one, so when the source carries
-        # a security xattr the backup stays owner-only rather than pretending
-        # the numbers tell the whole story.
-        listxattr = getattr(os, "listxattr", None)
-        if listxattr is not None:
+    # Everything from here on addresses the DESCRIPTOR, never ``bak`` the
+    # name. Once O_EXCL has handed us the file, a pathname-based chown/stat/
+    # chmod could still be redirected: anyone who can write the config's
+    # DIRECTORY can unlink our backup and drop a symlink in its place between
+    # two of those calls, and we would then hand their target our ownership
+    # or our mode. fchown/fstat/fchmod cannot be pointed at another file.
+    try:
+        offset = 0
+        while offset < len(data):
+            offset += os.write(fd, data[offset:])
+        # Match the original once the bytes are down. Created restrictive
+        # first so the contents are never briefly readable at a wider mode;
+        # a source that is itself group/world-readable keeps that, because
+        # the backup should not be MORE exposed than what it copies, and
+        # need not be less.
+        mode = src.st_mode & 0o7777
+        if mode & 0o077:
+            # Group/other bits only mean "no wider than the source" if the
+            # backup answers to the same principals. A new file takes the
+            # DIRECTORY's group, which need not be the source's — copying
+            # 0640 from an alice:secrets config onto an alice:staff backup
+            # would hand the key to all of staff. Mode bits are numbers, not
+            # an audience.
+            #
+            # Adopt the source's group where the OS allows it (it does when
+            # the caller is a member, which is the ordinary case for one's
+            # own dotfiles), and otherwise keep the file owner-only. Refusing
+            # to widen is the safe direction: a backup that is tighter than
+            # its source still restores.
             try:
-                if any(
-                    x.startswith("com.apple.system.Security") for x in listxattr(path)
-                ):
-                    mode &= 0o700
-            except OSError:
+                os.fchown(fd, -1, src.st_gid)
+            except (PermissionError, OSError):
                 mode &= 0o700
-    os.chmod(bak, mode)
+            else:
+                if os.fstat(fd).st_gid != src.st_gid:
+                    mode &= 0o700
+            # An ACL can DENY a principal the mode bits would otherwise admit,
+            # and a freshly created file carries none. Reproducing 0644
+            # without the deny entry hands the file to exactly the account the
+            # source shut out. There is no stdlib API to copy one, so when the
+            # source carries a security/ACL xattr — or when the list could not
+            # be read at all — the backup stays owner-only rather than
+            # pretending the numbers tell the whole story.
+            if src_xattrs is None or any(
+                x.startswith(("com.apple.system.Security", "system.posix_acl"))
+                for x in src_xattrs
+            ):
+                mode &= 0o700
+        os.fchmod(fd, mode)
+    finally:
+        os.close(fd)
     print(f"  backup: {bak}", file=sys.stderr)
     return bak
 


### PR DESCRIPTION
## Why

`rapid-mlx agents codex --setup` replaced `~/.codex/config.toml` wholesale.
Reproduced against a clean 0.12.4 wheel install with a throwaway CODEX_HOME —
a 174-byte config went in, and `model`, `approval_policy`, `[mcp_servers.vnsh]`
and `[projects."/Users/me/work"]` were all gone afterwards. No backup, and the
summary line said a neutral "Wrote config to …". Closes #1532.

The cause is per config *type*, not per agent: `_merge_file_config` returned
the rendered template unchanged for anything that was not `yaml` or `json`,
and the caller writes whatever it gets back. Codex is the only TOML profile,
so it was the only one exposed — the `hermes` (yaml) and `opencode` /
`kilo-code` / `qwen-code` (json) profiles have always merged correctly.

Reading TOML is stdlib `tomllib`; only writing needed a package, so this adds
`tomli-w` (pure Python, no transitive deps, companion to the `tomli` the
[test] extra already pins). The merge then goes through the same `_deep_merge`
as json and yaml, and the special case disappears.

Comments do not survive the round trip, which is the trade the json and yaml
paths have always made. The summary now says so — "Merged config into …
(custom keys preserved); comments were not" — rather than leaving a user to
discover it. Losing the formatting of a hand-tuned config is an annoyance;
losing its contents is data loss.

## Also: backups no longer widen access to what they copy

`backup_existing` used `bak.write_bytes(...)`, i.e. `0666 & ~umask` — 0644 on
a default install — while `atomic_write_json` gives the config itself the
0600 that `mkstemp` produces. `rapid-mlx launch` writes `RAPID_MLX_API_KEY`
into those files, so on a shared machine the second run of any adapter left
the live bearer token in a world-readable file beside the protected one.

The backup is now created 0600 and then given the source's exact mode — not
forced to 0600, because a user who deliberately opened up their own config
should get a recovery copy that behaves like the thing it recovers. The
create also moved to `O_CREAT|O_EXCL`, which closes the check-then-act in the
collision loop: two concurrent launches could previously settle on the same
counter and one would silently overwrite the other's backup.

## Tests

`TestTomlMerge` covers user scalars, user tables (`[mcp_servers.*]`,
`[projects.*]`), template precedence, a user key inside our own
`[model_providers.rapid-mlx]` table (`env_key` — which the template's comment
tells users to add), fresh write, empty file, and malformed input raising
instead of erasing. Plus one end-to-end case through the real shipped codex
profile: the unit tests would all pass with the wiring still broken, since
`cfg.type` has to arrive as `"toml"` for any of it to matter.

Mutation: restoring `if config_type not in ("yaml", "json")` fails 5 of the 8;
restoring `bak.write_bytes(path.read_bytes())` fails the permission test.

Found during the pre-release audit of the v0.12.4..main delta.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>