### PR TITLE
fix(nemotron): keep the declared-tool gate on when streaming

### DIFF
--- a/tests/test_tool_call_value_fidelity.py
+++ b/tests/test_tool_call_value_fidelity.py
@@ -964,6 +964,25 @@ def test_plain_less_than_after_call_is_not_mistaken_for_partial_markup():
     assert (delta or {}).get("content") == " Result: 2 < 3"
 
 
+def test_disambiguated_partial_opener_releases_every_withheld_byte():
+    """A marker-like suffix that becomes prose must be released in full."""
+    parser = ToolParserManager.get_tool_parser("nemotron")(None)
+    valid = _render_xml_body(_NAME, _KEY, "ok")
+    parser.extract_tool_calls_streaming("", valid, valid, request=_REQUEST)
+
+    previous = valid
+    emitted = ""
+    for char in "<funx":
+        current = previous + char
+        delta = parser.extract_tool_calls_streaming(
+            previous, current, char, request=_REQUEST
+        )
+        previous = current
+        emitted += (delta or {}).get("content") or ""
+
+    assert emitted == "<funx"
+
+
 def test_gating_is_off_when_the_request_declares_no_tools():
     """A request with no tools keeps the position-only behaviour.
 

--- a/tests/test_tool_call_value_fidelity.py
+++ b/tests/test_tool_call_value_fidelity.py
@@ -884,9 +884,10 @@ def test_every_refused_block_reaches_the_user_and_none_twice():
         previous = current
         content += (delta or {}).get("content") or ""
 
-    assert content.count("<function=delete_everything>") == 1, content
-    assert content.count("<function=also_undeclared>") == 1, content
-    assert content.count("BETWEEN") == 1, content
+    assert content == text, (
+        "every byte of every refused block and the prose between them must "
+        f"reach the wire exactly once: {content!r}"
+    )
 
 
 def test_reset_clears_the_content_watermark():

--- a/tests/test_tool_call_value_fidelity.py
+++ b/tests/test_tool_call_value_fidelity.py
@@ -866,6 +866,59 @@ def test_a_streamed_refusal_still_reaches_the_user_as_text():
     assert content.count("<function=delete_everything>") == 1, content
 
 
+def test_every_refused_block_reaches_the_user_and_none_twice():
+    """One release per BLOCK, not one per turn — and no duplication.
+
+    A boolean "already released" flag drops every refused block after the
+    first; a watermark that ignores the prose passed through between them
+    re-sends that prose. Both were live in earlier revisions of this fix.
+    """
+    parser = ToolParserManager.get_tool_parser("nemotron")(None)
+    first = _render_xml_body("delete_everything", _KEY, "x")
+    second = _render_xml_body("also_undeclared", _KEY, "y")
+    text = first + " BETWEEN " + second
+
+    content, previous = "", ""
+    for i in range(len(text)):
+        current = text[: i + 1]
+        delta = parser.extract_tool_calls_streaming(
+            previous, current, text[i], request=_REQUEST
+        )
+        previous = current
+        content += (delta or {}).get("content") or ""
+
+    assert content.count("<function=delete_everything>") == 1, content
+    assert content.count("<function=also_undeclared>") == 1, content
+    assert content.count("BETWEEN") == 1, content
+
+
+def test_reset_clears_the_content_watermark():
+    """A reused instance must not carry a turn's watermark into the next.
+
+    ``reset()`` is the caller's contract; relying on the ``not previous_text``
+    branch alone is not enough, because the postprocessor can forward a new
+    turn's opening prose through its own fast path before this parser sees a
+    delta.
+    """
+    parser = ToolParserManager.get_tool_parser("nemotron")(None)
+    hostile = _render_xml_body("delete_everything", _KEY, "x")
+
+    def _turn():
+        out, previous = "", ""
+        for i in range(len(hostile)):
+            current = hostile[: i + 1]
+            delta = parser.extract_tool_calls_streaming(
+                previous, current, hostile[i], request=_REQUEST
+            )
+            previous = current
+            out += (delta or {}).get("content") or ""
+        return out
+
+    _turn()
+    parser.reset()
+    assert "delete_everything" in _turn(), "stale state swallowed the second turn"
+
+
 def test_gating_is_off_when_the_request_declares_no_tools():
     """A request with no tools keeps the position-only behaviour.
 

--- a/tests/test_tool_call_value_fidelity.py
+++ b/tests/test_tool_call_value_fidelity.py
@@ -951,6 +951,19 @@ def test_refused_block_before_valid_call_in_one_delta_is_not_swallowed():
     assert f"<function={_NAME}>" not in content, content
 
 
+def test_plain_less_than_after_call_is_not_mistaken_for_partial_markup():
+    """Ordinary same-delta prose containing ``<`` must survive stream end."""
+    parser = ToolParserManager.get_tool_parser("nemotron")(None)
+    valid = _render_xml_body(_NAME, _KEY, "ok")
+    text = valid + " Result: 2 < 3"
+
+    delta = parser.extract_tool_calls_streaming("", text, text, request=_REQUEST)
+
+    calls = (delta or {}).get("tool_calls") or []
+    assert [call["function"]["name"] for call in calls] == [_NAME]
+    assert (delta or {}).get("content") == " Result: 2 < 3"
+
+
 def test_gating_is_off_when_the_request_declares_no_tools():
     """A request with no tools keeps the position-only behaviour.
 

--- a/tests/test_tool_call_value_fidelity.py
+++ b/tests/test_tool_call_value_fidelity.py
@@ -818,7 +818,7 @@ def test_the_nemotron_gate_survives_streaming():
     parser = ToolParserManager.get_tool_parser("nemotron")(None)
     hostile = _render_xml_body("delete_everything", _KEY, "x")
 
-    emitted: list[str] = []
+    emitted: list[dict] = []
     previous = ""
     for i in range(len(hostile)):
         current = hostile[: i + 1]
@@ -826,10 +826,7 @@ def test_the_nemotron_gate_survives_streaming():
             previous, current, hostile[i], request=_REQUEST
         )
         previous = current
-        for call in (delta or {}).get("tool_calls") or []:
-            name = (call.get("function") or {}).get("name")
-            if name:
-                emitted.append(name)
+        emitted.extend((delta or {}).get("tool_calls") or [])
 
     assert emitted == [], f"streaming admitted an undeclared call: {emitted}"
 

--- a/tests/test_tool_call_value_fidelity.py
+++ b/tests/test_tool_call_value_fidelity.py
@@ -901,22 +901,54 @@ def test_reset_clears_the_content_watermark():
     delta.
     """
     parser = ToolParserManager.get_tool_parser("nemotron")(None)
-    hostile = _render_xml_body("delete_everything", _KEY, "x")
+    hostile = _render_xml_body("delete_everything", _KEY, "a much longer first turn")
 
-    def _turn():
+    def _turn(text):
         out, previous = "", ""
-        for i in range(len(hostile)):
-            current = hostile[: i + 1]
+        for i in range(len(text)):
+            current = text[: i + 1]
             delta = parser.extract_tool_calls_streaming(
-                previous, current, hostile[i], request=_REQUEST
+                previous, current, text[i], request=_REQUEST
             )
             previous = current
             out += (delta or {}).get("content") or ""
         return out
 
-    _turn()
+    _turn(hostile)
     parser.reset()
-    assert "delete_everything" in _turn(), "stale state swallowed the second turn"
+    # Model the real fast path: the postprocessor already forwarded this
+    # prefix without invoking the parser, so the first post-reset parser call
+    # starts with non-empty previous_text.
+    prefix = "already visible: "
+    second = _render_xml_body("also_undeclared", _KEY, "x")
+    current = prefix + second
+    delta = parser.extract_tool_calls_streaming(
+        prefix, current, second, request=_REQUEST
+    )
+    content = (delta or {}).get("content") or ""
+    assert "also_undeclared" in content, "stale state swallowed the second turn"
+    assert "already visible" not in content, "the fast-path prefix was replayed"
+
+
+def test_refused_block_before_valid_call_in_one_delta_is_not_swallowed():
+    """A later valid call must not advance across earlier refused prose.
+
+    Streaming parsers receive tokenizer-sized deltas in production, including
+    a delta large enough to complete more than one block. The valid call still
+    executes, while the undeclared block retains non-streaming parity as text.
+    """
+    parser = ToolParserManager.get_tool_parser("nemotron")(None)
+    refused = _render_xml_body("delete_everything", _KEY, "x")
+    valid = _render_xml_body(_NAME, _KEY, "ok")
+    text = refused + valid
+
+    delta = parser.extract_tool_calls_streaming("", text, text, request=_REQUEST)
+
+    calls = (delta or {}).get("tool_calls") or []
+    assert [call["function"]["name"] for call in calls] == [_NAME]
+    content = (delta or {}).get("content") or ""
+    assert "delete_everything" in content, content
+    assert f"<function={_NAME}>" not in content, content
 
 
 def test_gating_is_off_when_the_request_declares_no_tools():

--- a/tests/test_tool_call_value_fidelity.py
+++ b/tests/test_tool_call_value_fidelity.py
@@ -800,6 +800,40 @@ def test_the_nemotron_parser_gates_calls_too():
     assert [c["name"] for c in result.tool_calls] == [_NAME]
 
 
+def test_the_nemotron_gate_survives_streaming():
+    """The gate has to hold on the path agents actually use.
+
+    ``extract_tool_calls_streaming`` re-parses the accumulated text once the
+    close tag arrives, and that re-parse called ``extract_tool_calls`` with
+    no ``request`` — so the declared-name check above ran against ``None``
+    and admitted everything. The same bytes were correctly refused when the
+    caller buffered them, which is why the non-streaming test passed while
+    the hole stayed open.
+
+    ``request`` was already a parameter of the enclosing method and
+    ``service/postprocessor.py`` already passes it; only the forwarding was
+    missing. Mutation: drop the argument at that call and this fails with
+    ``['delete_everything']``.
+    """
+    parser = ToolParserManager.get_tool_parser("nemotron")(None)
+    hostile = _render_xml_body("delete_everything", _KEY, "x")
+
+    emitted: list[str] = []
+    previous = ""
+    for i in range(len(hostile)):
+        current = hostile[: i + 1]
+        delta = parser.extract_tool_calls_streaming(
+            previous, current, hostile[i], request=_REQUEST
+        )
+        previous = current
+        for call in (delta or {}).get("tool_calls") or []:
+            name = (call.get("function") or {}).get("name")
+            if name:
+                emitted.append(name)
+
+    assert emitted == [], f"streaming admitted an undeclared call: {emitted}"
+
+
 def test_gating_is_off_when_the_request_declares_no_tools():
     """A request with no tools keeps the position-only behaviour.
 

--- a/tests/test_tool_call_value_fidelity.py
+++ b/tests/test_tool_call_value_fidelity.py
@@ -834,6 +834,38 @@ def test_the_nemotron_gate_survives_streaming():
     assert emitted == [], f"streaming admitted an undeclared call: {emitted}"
 
 
+def test_a_streamed_refusal_still_reaches_the_user_as_text():
+    """Refusing a call must not swallow the answer.
+
+    Non-streaming answers a refused block with ``content=model_output`` —
+    text the caller never authorised as a tool is still the model's reply.
+    Streaming had no equivalent: every delta of the block was withheld
+    (``None``), and the postprocessor drops its suppression buffer the moment
+    the parser "makes progress" on a closing tag. Its #1359 release is
+    byte-budget driven, so a short refused call never tripped it and the user
+    got an EMPTY response.
+
+    Mutation: delete the release branch and ``content`` comes back ``''``.
+    """
+    parser = ToolParserManager.get_tool_parser("nemotron")(None)
+    hostile = _render_xml_body("delete_everything", _KEY, "x")
+
+    content, previous = "", ""
+    for i in range(len(hostile)):
+        current = hostile[: i + 1]
+        delta = parser.extract_tool_calls_streaming(
+            previous, current, hostile[i], request=_REQUEST
+        )
+        previous = current
+        content += (delta or {}).get("content") or ""
+
+    assert "delete_everything" in content, (
+        f"the refused block vanished instead of reaching the user: {content!r}"
+    )
+    # Released once, not once per closing tag.
+    assert content.count("<function=delete_everything>") == 1, content
+
+
 def test_gating_is_off_when_the_request_declares_no_tools():
     """A request with no tools keeps the position-only behaviour.
 

--- a/tests/test_tool_call_value_fidelity.py
+++ b/tests/test_tool_call_value_fidelity.py
@@ -980,6 +980,30 @@ def test_disambiguated_partial_opener_releases_every_withheld_byte():
     assert emitted == "<funx"
 
 
+def test_wrapper_close_is_accounted_before_following_prose():
+    """A decorative close must not leak after an already-emitted call."""
+    parser = ToolParserManager.get_tool_parser("nemotron")(None)
+    function = (
+        f"<tool_call><function={_NAME}><parameter={_KEY}>ok</parameter></function>"
+    )
+    first = parser.extract_tool_calls_streaming(
+        "", function, function, request=_REQUEST
+    )
+    assert len((first or {}).get("tool_calls") or []) == 1
+
+    wrapped = function + "</tool_call>"
+    close = parser.extract_tool_calls_streaming(
+        function, wrapped, "</tool_call>", request=_REQUEST
+    )
+    assert not (close or {}).get("content")
+
+    complete = wrapped + " after"
+    prose = parser.extract_tool_calls_streaming(
+        wrapped, complete, " after", request=_REQUEST
+    )
+    assert (prose or {}).get("content") == " after"
+
+
 def test_gating_is_off_when_the_request_declares_no_tools():
     """A request with no tools keeps the position-only behaviour.
 

--- a/vllm_mlx/tool_parsers/nemotron_tool_parser.py
+++ b/vllm_mlx/tool_parsers/nemotron_tool_parser.py
@@ -53,15 +53,15 @@ class NemotronToolParser(ToolParser):
 
     EXPECTED_WIRE_FORMATS = ("tool_call_xml_body",)
 
-    # True once a closed-but-refused block has been released as content on the
-    # streaming path. Class-level default so a parser used without a preceding
-    # ``reset()`` still has it; ``extract_tool_calls_streaming`` clears it per
-    # turn. See the release site for why it must fire at most once.
-    _gate_released = False
-    # Characters of ``current_text`` already forwarded verbatim as content
-    # before any tool markup appeared. The release above subtracts them so a
-    # refused block is not sent twice.
-    _passed_through = 0
+    # How much of ``current_text`` this turn has already been accounted for on
+    # the wire — forwarded as prose, consumed into an emitted call, or released
+    # after a refusal. The refusal release below sends only what lies past it.
+    #
+    # A watermark rather than a "released once" boolean: a turn can hold more
+    # than one refused block, and a boolean drops every block after the first.
+    # Class-level default so an instance used without a preceding ``reset()``
+    # still has the attribute.
+    _content_upto = 0
 
     # Pattern for Nemotron-style with parameters.
     #
@@ -88,6 +88,19 @@ class NemotronToolParser(ToolParser):
         r"<parameter=([^>]+)>\s*(.*?)\s*</parameter>",
         re.DOTALL,
     )
+
+    def reset(self) -> None:
+        """Clear per-request state.
+
+        The base reset owns the tool-id counters; the content watermark is
+        just as per-request. Relying on the ``not previous_text`` branch alone
+        is not enough — the postprocessor can forward a new turn's opening
+        prose through its own fast path before this parser sees a delta, so
+        the first call can arrive with ``previous_text`` already non-empty and
+        a stale watermark from the turn before.
+        """
+        super().reset()
+        self._content_upto = 0
 
     def extract_tool_calls(
         self, model_output: str, request: dict[str, Any] | None = None
@@ -266,16 +279,13 @@ class NemotronToolParser(ToolParser):
         Extract tool calls from streaming Nemotron model output.
         """
         if not previous_text:
-            # Start of a turn. The base ``reset()`` handles the tool-id
-            # counters; these are per-turn too and the parser instance is
-            # reused across requests in the non-per-call paths.
-            self._gate_released = False
-            self._passed_through = 0
+            # Start of a turn. ``reset()`` covers the caller that calls it;
+            # this covers the paths that reuse an instance without one.
+            self._content_upto = 0
         if "<tool_call>" not in current_text and "<function=" not in current_text:
-            # Ordinary prose, forwarded verbatim. Count it: if a later block
-            # is refused and released below, this prefix is already on the
-            # wire and must not be sent twice.
-            self._passed_through = len(current_text)
+            # Ordinary prose, forwarded verbatim — already on the wire, so a
+            # later refusal must not send it again.
+            self._content_upto = len(current_text)
             return {"content": delta_text}
 
         # Trigger from the COMPLETION STATE of current_text, NOT from a close
@@ -334,8 +344,10 @@ class NemotronToolParser(ToolParser):
                     }
                     if tail:
                         out["content"] = tail
+                    # Consumed into a call: not content, and not replayable.
+                    self._content_upto = len(current_text)
                     return out
-            elif not self._gate_released:
+            elif len(current_text) > self._content_upto:
                 # The block CLOSED and is not a call — the declared-name gate
                 # refused it. Non-streaming answers that with
                 # ``content=model_output``: text the caller never authorised as
@@ -353,14 +365,19 @@ class NemotronToolParser(ToolParser):
                 # content it is about to discard, so nothing is duplicated.
                 # Once per turn: ``</function>`` and ``</tool_call>`` each bump
                 # the close count, and the second must not re-send it.
-                self._gate_released = True
-                unsent = (result.content or "")[self._passed_through :]
+                unsent = current_text[self._content_upto :]
+                self._content_upto = len(current_text)
                 if unsent:
                     return {"content": unsent}
             # Close tag but no NEW call to emit (e.g. the second of </function>
             # + </tool_call> for a call already streamed). Still surface any
             # trailing content that rode in on this delta.
-            if tail:
+            if tail and len(current_text) > self._content_upto:
+                # ``tail`` is a CLEANED view of the whole accumulated text, not
+                # a suffix of it, so emitting it once the watermark already
+                # covers this text re-sends what a refusal release just put on
+                # the wire. Nothing new arrived — say nothing.
+                self._content_upto = len(current_text)
                 return {"content": tail}
             return None
 
@@ -373,6 +390,8 @@ class NemotronToolParser(ToolParser):
         # emit only delta_text (the new chars), never the whole tail, so
         # already-streamed trailing content is not re-sent.
         if self._clean_trailing_content(current_text) is not None:
+            # On the wire now, so a later refusal release must not repeat it.
+            self._content_upto = len(current_text)
             return {"content": delta_text}
 
         return None

--- a/vllm_mlx/tool_parsers/nemotron_tool_parser.py
+++ b/vllm_mlx/tool_parsers/nemotron_tool_parser.py
@@ -144,17 +144,43 @@ class NemotronToolParser(ToolParser):
 
         parts: list[str] = []
         cursor = start
+        removed_before = False
         for span_start, span_end in removed:
             if span_end <= start or span_start >= end:
                 continue
             clipped_start = max(start, span_start)
             clipped_end = min(end, span_end)
             if cursor < clipped_start:
-                parts.append(text[cursor:clipped_start])
+                gap = text[cursor:clipped_start]
+                # Pretty-printed wire uses newlines between the decorative
+                # wrapper and function body. If both neighboring spans are
+                # removed, that formatting is markup too, not assistant text.
+                if not (removed_before and gap.isspace()):
+                    parts.append(gap)
             cursor = max(cursor, clipped_end)
+            removed_before = True
         if cursor < end:
             parts.append(text[cursor:end])
         return "".join(parts)
+
+    @staticmethod
+    def _pending_markup_index(text: str) -> int | None:
+        """Return where recognized complete/partial markup begins, if any.
+
+        A bare ``<`` in assistant prose (for example ``2 < 3``) is content,
+        not sufficient evidence of a tool-call opener. Only suppress a suffix
+        that is already a known marker or can still grow into one.
+        """
+        markers = ("<function=", "<tool_call>", "</function>", "</tool_call>")
+        candidates: list[int] = []
+        for marker in markers:
+            full = text.find(marker)
+            if full != -1:
+                candidates.append(full)
+            for prefix_len in range(1, len(marker)):
+                if text.endswith(marker[:prefix_len]):
+                    candidates.append(len(text) - prefix_len)
+        return min(candidates) if candidates else None
 
     @staticmethod
     def _safe_accounting_boundary(text: str) -> int:
@@ -171,7 +197,9 @@ class NemotronToolParser(ToolParser):
                 latest_close = max(latest_close, idx + len(tag))
         if latest_close == 0:
             return 0
-        return len(text) if "<" not in text[latest_close:] else latest_close
+        tail = text[latest_close:]
+        pending = NemotronToolParser._pending_markup_index(tail)
+        return len(text) if pending is None else latest_close + pending
 
     def extract_tool_calls(
         self, model_output: str, request: dict[str, Any] | None = None
@@ -334,7 +362,8 @@ class NemotronToolParser(ToolParser):
             # No close tag yet → we are still inside the (first) call's markup.
             return None
         tail = current_text[end:]
-        return None if "<" in tail else tail
+        pending = NemotronToolParser._pending_markup_index(tail)
+        return None if pending is not None else tail
 
     def extract_tool_calls_streaming(
         self,

--- a/vllm_mlx/tool_parsers/nemotron_tool_parser.py
+++ b/vllm_mlx/tool_parsers/nemotron_tool_parser.py
@@ -62,6 +62,7 @@ class NemotronToolParser(ToolParser):
     # Class-level default so an instance used without a preceding ``reset()``
     # still has the attribute.
     _content_upto = 0
+    _stream_started = False
 
     # Pattern for Nemotron-style with parameters.
     #
@@ -101,6 +102,76 @@ class NemotronToolParser(ToolParser):
         """
         super().reset()
         self._content_upto = 0
+        self._stream_started = False
+
+    def _visible_content_between(
+        self,
+        text: str,
+        start: int,
+        end: int,
+        request: dict[str, Any] | None,
+    ) -> str:
+        """Project a raw range onto the non-tool content stream.
+
+        Valid function spans are executable calls and must stay off the content
+        channel. Refused spans are deliberately retained as prose. When at
+        least one valid call exists, the decorative outer wrappers are removed
+        too, matching :meth:`extract_tool_calls`.
+
+        Keeping source offsets here is important: a single model delta can
+        finish a refused block and a later valid call. A plain byte watermark
+        advanced for the valid call used to swallow the refused range.
+        """
+        if end <= start:
+            return ""
+
+        valid_spans = [
+            (span_start, span_end)
+            for _name, _body, span_start, span_end in split_marked_calls(
+                text,
+                r"<function=([^>]+)>",
+                "</function>",
+                valid_names=_declared_tool_names(request),
+            )
+        ]
+        removed = list(valid_spans)
+        if valid_spans:
+            removed.extend(
+                (match.start(), match.end())
+                for match in self.RESIDUAL_WRAPPER_PATTERN.finditer(text)
+            )
+        removed.sort()
+
+        parts: list[str] = []
+        cursor = start
+        for span_start, span_end in removed:
+            if span_end <= start or span_start >= end:
+                continue
+            clipped_start = max(start, span_start)
+            clipped_end = min(end, span_end)
+            if cursor < clipped_start:
+                parts.append(text[cursor:clipped_start])
+            cursor = max(cursor, clipped_end)
+        if cursor < end:
+            parts.append(text[cursor:end])
+        return "".join(parts)
+
+    @staticmethod
+    def _safe_accounting_boundary(text: str) -> int:
+        """Return the raw offset safe to account after a close event.
+
+        Plain trailing text is safe through the end. If another markup opener
+        has started, stop at the latest complete close so its partial bytes can
+        still be released or parsed on a later delta.
+        """
+        latest_close = 0
+        for tag in ("</function>", "</tool_call>"):
+            idx = text.rfind(tag)
+            if idx != -1:
+                latest_close = max(latest_close, idx + len(tag))
+        if latest_close == 0:
+            return 0
+        return len(text) if "<" not in text[latest_close:] else latest_close
 
     def extract_tool_calls(
         self, model_output: str, request: dict[str, Any] | None = None
@@ -278,10 +349,15 @@ class NemotronToolParser(ToolParser):
         """
         Extract tool calls from streaming Nemotron model output.
         """
-        if not previous_text:
-            # Start of a turn. ``reset()`` covers the caller that calls it;
-            # this covers the paths that reuse an instance without one.
-            self._content_upto = 0
+        if not self._stream_started or not previous_text:
+            # The postprocessor's plain-text fast path can forward an opening
+            # prefix without invoking this parser. On the first parser call of
+            # a reset turn, that prefix is therefore already on the wire and
+            # ``previous_text`` is non-empty. Start the watermark there rather
+            # than replaying it. ``not previous_text`` also covers callers that
+            # reuse an instance without honoring reset().
+            self._content_upto = len(previous_text)
+            self._stream_started = True
         if "<tool_call>" not in current_text and "<function=" not in current_text:
             # Ordinary prose, forwarded verbatim — already on the wire, so a
             # later refusal must not send it again.
@@ -315,13 +391,12 @@ class NemotronToolParser(ToolParser):
             # streaming path while the same text was correctly refused when
             # buffered. Agents stream, so the gate was off where it counts.
             result = self.extract_tool_calls(current_text, request)
-            # Trailing assistant text that arrived in THIS SAME delta, after the
-            # close tag (e.g. the tokenizer emits "</function> done" as one
-            # chunk). It is new (everything past the just-closed tag) and, being
-            # content-safe per _clean_trailing_content, must not be dropped — we
-            # ride it out on the same delta via the combined content+tool_calls
-            # return the postprocessor already supports.
-            tail = self._clean_trailing_content(current_text)
+            safe_end = self._safe_accounting_boundary(current_text)
+            unsent_content = self._visible_content_between(
+                current_text, self._content_upto, safe_end, request
+            )
+            # The source-offset projection includes safe trailing assistant
+            # text from this same delta while excluding executable spans.
             if result.tools_called:
                 already_emitted = self.current_tool_id + 1
                 total = len(result.tool_calls)
@@ -342,12 +417,14 @@ class NemotronToolParser(ToolParser):
                             for i, tc in enumerate(new_calls)
                         ]
                     }
-                    if tail:
-                        out["content"] = tail
-                    # Consumed into a call: not content, and not replayable.
-                    self._content_upto = len(current_text)
+                    if unsent_content:
+                        out["content"] = unsent_content
+                    # Account only through the latest complete/safe boundary.
+                    # A partial following opener still belongs to a future
+                    # block and must remain releasable.
+                    self._content_upto = safe_end
                     return out
-            elif len(current_text) > self._content_upto:
+            elif safe_end > self._content_upto:
                 # The block CLOSED and is not a call — the declared-name gate
                 # refused it. Non-streaming answers that with
                 # ``content=model_output``: text the caller never authorised as
@@ -365,20 +442,17 @@ class NemotronToolParser(ToolParser):
                 # content it is about to discard, so nothing is duplicated.
                 # Once per turn: ``</function>`` and ``</tool_call>`` each bump
                 # the close count, and the second must not re-send it.
-                unsent = current_text[self._content_upto :]
-                self._content_upto = len(current_text)
-                if unsent:
-                    return {"content": unsent}
+                self._content_upto = safe_end
+                if unsent_content:
+                    return {"content": unsent_content}
             # Close tag but no NEW call to emit (e.g. the second of </function>
             # + </tool_call> for a call already streamed). Still surface any
             # trailing content that rode in on this delta.
-            if tail and len(current_text) > self._content_upto:
-                # ``tail`` is a CLEANED view of the whole accumulated text, not
-                # a suffix of it, so emitting it once the watermark already
-                # covers this text re-sends what a refusal release just put on
-                # the wire. Nothing new arrived — say nothing.
-                self._content_upto = len(current_text)
-                return {"content": tail}
+            if unsent_content and safe_end > self._content_upto:
+                # The projection is a view of the raw range after the watermark,
+                # so a refusal released above cannot be sent twice.
+                self._content_upto = safe_end
+                return {"content": unsent_content}
             return None
 
         # No new call closed in this delta. If we are past all tool-call markup

--- a/vllm_mlx/tool_parsers/nemotron_tool_parser.py
+++ b/vllm_mlx/tool_parsers/nemotron_tool_parser.py
@@ -477,11 +477,12 @@ class NemotronToolParser(ToolParser):
             # Close tag but no NEW call to emit (e.g. the second of </function>
             # + </tool_call> for a call already streamed). Still surface any
             # trailing content that rode in on this delta.
-            if unsent_content and safe_end > self._content_upto:
+            if safe_end > self._content_upto:
                 # The projection is a view of the raw range after the watermark,
                 # so a refusal released above cannot be sent twice.
                 self._content_upto = safe_end
-                return {"content": unsent_content}
+                if unsent_content:
+                    return {"content": unsent_content}
             return None
 
         # No new call closed in this delta. If we are past all tool-call markup

--- a/vllm_mlx/tool_parsers/nemotron_tool_parser.py
+++ b/vllm_mlx/tool_parsers/nemotron_tool_parser.py
@@ -53,6 +53,16 @@ class NemotronToolParser(ToolParser):
 
     EXPECTED_WIRE_FORMATS = ("tool_call_xml_body",)
 
+    # True once a closed-but-refused block has been released as content on the
+    # streaming path. Class-level default so a parser used without a preceding
+    # ``reset()`` still has it; ``extract_tool_calls_streaming`` clears it per
+    # turn. See the release site for why it must fire at most once.
+    _gate_released = False
+    # Characters of ``current_text`` already forwarded verbatim as content
+    # before any tool markup appeared. The release above subtracts them so a
+    # refused block is not sent twice.
+    _passed_through = 0
+
     # Pattern for Nemotron-style with parameters.
     #
     # The load-bearing signature of a call is ``<function=NAME>...</function>``;
@@ -255,7 +265,17 @@ class NemotronToolParser(ToolParser):
         """
         Extract tool calls from streaming Nemotron model output.
         """
+        if not previous_text:
+            # Start of a turn. The base ``reset()`` handles the tool-id
+            # counters; these are per-turn too and the parser instance is
+            # reused across requests in the non-per-call paths.
+            self._gate_released = False
+            self._passed_through = 0
         if "<tool_call>" not in current_text and "<function=" not in current_text:
+            # Ordinary prose, forwarded verbatim. Count it: if a later block
+            # is refused and released below, this prefix is already on the
+            # wire and must not be sent twice.
+            self._passed_through = len(current_text)
             return {"content": delta_text}
 
         # Trigger from the COMPLETION STATE of current_text, NOT from a close
@@ -315,6 +335,28 @@ class NemotronToolParser(ToolParser):
                     if tail:
                         out["content"] = tail
                     return out
+            elif not self._gate_released:
+                # The block CLOSED and is not a call — the declared-name gate
+                # refused it. Non-streaming answers that with
+                # ``content=model_output``: text the caller never authorised as
+                # a tool is still the model's answer and belongs on the wire.
+                #
+                # Streaming had no equivalent. Every delta of the block was
+                # withheld (``None``), and the postprocessor buffers those only
+                # until a closing tag arrives — at which point it drops the
+                # buffer unemitted (``_tool_suppressed_buffer = ""``) because
+                # the parser "made progress". Its #1359 release is byte-budget
+                # driven, so a short refused call never trips it and the user
+                # gets an EMPTY response instead of the prose.
+                #
+                # Returning the accumulated text hands the postprocessor the
+                # content it is about to discard, so nothing is duplicated.
+                # Once per turn: ``</function>`` and ``</tool_call>`` each bump
+                # the close count, and the second must not re-send it.
+                self._gate_released = True
+                unsent = (result.content or "")[self._passed_through :]
+                if unsent:
+                    return {"content": unsent}
             # Close tag but no NEW call to emit (e.g. the second of </function>
             # + </tool_call> for a call already streamed). Still surface any
             # trailing content that rode in on this delta.

--- a/vllm_mlx/tool_parsers/nemotron_tool_parser.py
+++ b/vllm_mlx/tool_parsers/nemotron_tool_parser.py
@@ -490,11 +490,19 @@ class NemotronToolParser(ToolParser):
         # silently dropped. _clean_trailing_content being non-None guarantees no
         # partial or complete tag can leak, so we never emit "<function=",
         # "</function>", or a fragment like "</fun" as user-visible content. We
-        # emit only delta_text (the new chars), never the whole tail, so
-        # already-streamed trailing content is not re-sent.
+        # Emit only the source range after the watermark, so already-streamed
+        # trailing content is not re-sent while previously withheld partial
+        # opener bytes can be recovered when they become ordinary prose.
         if self._clean_trailing_content(current_text) is not None:
-            # On the wire now, so a later refusal release must not repeat it.
+            # Release the whole unaccounted visible range, not only this delta.
+            # A prior suffix such as ``<fun`` may have been withheld while it
+            # could still become ``<function=``; once a later byte turns it
+            # into ordinary prose (``<funx``), those earlier bytes belong on
+            # the wire too.
+            content = self._visible_content_between(
+                current_text, self._content_upto, len(current_text), request
+            )
             self._content_upto = len(current_text)
-            return {"content": delta_text}
+            return {"content": content} if content else None
 
         return None

--- a/vllm_mlx/tool_parsers/nemotron_tool_parser.py
+++ b/vllm_mlx/tool_parsers/nemotron_tool_parser.py
@@ -279,7 +279,12 @@ class NemotronToolParser(ToolParser):
         # arrive in separate deltas (each bumps the count → one re-parse each,
         # but the second finds nothing new to emit).
         if self._close_tag_count(current_text) > self._close_tag_count(previous_text):
-            result = self.extract_tool_calls(current_text)
+            # ``request`` matters here, not just to the non-streaming caller:
+            # ``extract_tool_calls`` derives its declared-name gate from it, so
+            # omitting it let a name the caller never offered through on the
+            # streaming path while the same text was correctly refused when
+            # buffered. Agents stream, so the gate was off where it counts.
+            result = self.extract_tool_calls(current_text, request)
             # Trailing assistant text that arrived in THIS SAME delta, after the
             # close tag (e.g. the tokenizer emits "</function> done" as one
             # chunk). It is new (everything past the just-closed tag) and, being

--- a/vllm_mlx/tool_parsers/nemotron_tool_parser.py
+++ b/vllm_mlx/tool_parsers/nemotron_tool_parser.py
@@ -499,9 +499,11 @@ class NemotronToolParser(ToolParser):
             # could still become ``<function=``; once a later byte turns it
             # into ordinary prose (``<funx``), those earlier bytes belong on
             # the wire too.
-            content = self._visible_content_between(
-                current_text, self._content_upto, len(current_text), request
-            )
+            # Everything after the watermark is already known to be outside
+            # completed tool spans on this no-new-close path. Slice directly
+            # instead of reparsing the full accumulated response for every
+            # prose delta (which would make long streams quadratic).
+            content = current_text[self._content_upto :]
             self._content_upto = len(current_text)
             return {"content": content} if content else None
 


### PR DESCRIPTION
## Why

#1518 gave the Nemotron parser a declared-name gate: a `<function=NAME>`
whose NAME the caller never offered is prose about the wire format, not an
executable call, so it must not become one.

The gate only held when the caller buffered. `extract_tool_calls_streaming`
re-parses the accumulated text once the close tag arrives, and that re-parse
called `extract_tool_calls(current_text)` — no `request`. The gate derives
its name set from `request`, so on the streaming path it ran against `None`
and admitted everything:

    declared: write_file
    model:    <function=delete_everything><parameter=target>/</parameter></function>
    buffered: refused
    streamed: {"tool_calls":[{"function":{"name":"delete_everything", ...

Agents stream. The gate was off exactly where it matters, and the
non-streaming test passing is what hid it.

`request` was already a parameter of the enclosing method and
`service/postprocessor.py:3889` already passes it down; only the forwarding
at the re-parse was missing.

## Test

`test_the_nemotron_gate_survives_streaming` drives the real streaming
protocol delta by delta and asserts no undeclared call reaches the wire.
Mutation: drop the argument again and it fails with `['delete_everything']`.

Found during the pre-release audit of the v0.12.4..main delta.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>