### PR TITLE
fix(pflash): preserve prompts without middle budget

### DIFF
--- a/tests/test_pflash_endpoints_only.py
+++ b/tests/test_pflash_endpoints_only.py
@@ -1,19 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Unit tests for PFlash endpoints-only detection.
+"""Regression tests for PFlash's former endpoints-only data loss.
 
 When ``sink_tokens + tail_tokens`` meet or exceed the keep budget, PFlash keeps
-only the leading sink and trailing tail and drops the entire middle span. With
-the default ``always``-mode settings (sink 256 + tail 2048, min_keep 2048,
-keep_ratio 0.20) this happens for every prompt shorter than ~11.5k tokens, yet
-``compressed`` stays True and ``reason`` stays ``"compressed"``. These tests pin
-the observability added for that regime — ``PFlashResult.endpoints_only`` /
-``middle_tokens_kept`` and the matching ``compress_request_tokens`` metadata —
-and assert the normal compression path stays unflagged.
+only the leading sink and trailing tail can fit. With the verified ``always``
+defaults this affects ordinary 2.3k-11.5k token agent conversations. PFlash must
+now preserve those prompts rather than return a normal success after deleting
+their entire middle.
 """
 
-import logging
-
-import vllm_mlx.pflash as pflash
 from vllm_mlx.pflash import (
     PFlashConfig,
     compress_request_tokens,
@@ -22,16 +16,18 @@ from vllm_mlx.pflash import (
 
 
 class TestPFlashEndpointsOnly:
-    def test_default_always_config_collapses_short_prompt(self):
+    def test_default_always_config_preserves_short_prompt(self):
         # 3k tokens under the default always-mode config: keep_budget == 2048 but
-        # sink(256)+tail(2048) == 2304 > budget, so the whole middle is dropped
-        # and kept_tokens (2304) even exceeds the nominal budget.
-        result = compress_tokens(list(range(3000)), PFlashConfig(mode="always"))
-        assert result.compressed is True
-        assert result.reason == "compressed"
+        # sink(256)+tail(2048) == 2304 > budget. The old implementation dropped
+        # the whole middle and even kept more than its nominal budget.
+        tokens = list(range(3000))
+        result = compress_tokens(tokens, PFlashConfig(mode="always"))
+        assert result.tokens == tokens
+        assert result.compressed is False
+        assert result.reason == "insufficient_middle_budget"
         assert result.middle_tokens_kept == 0
-        assert result.endpoints_only is True
-        assert result.kept_tokens == 2304
+        assert result.endpoints_only is False
+        assert result.kept_tokens == 3000
 
     def test_generous_budget_keeps_middle_and_is_not_flagged(self):
         # 20k tokens: 0.2 * 20k == 4000 budget leaves room for middle blocks.
@@ -42,11 +38,14 @@ class TestPFlashEndpointsOnly:
         assert result.middle_tokens_kept > 0
         assert result.endpoints_only is False
 
-    def test_metadata_surfaces_endpoints_only(self):
-        _, metadata = compress_request_tokens(
-            list(range(3000)), PFlashConfig(mode="always")
-        )
-        assert metadata["endpoints_only"] is True
+    def test_metadata_surfaces_safe_refusal(self):
+        tokens = list(range(3000))
+        kept, metadata = compress_request_tokens(tokens, PFlashConfig(mode="always"))
+        assert kept == tokens
+        assert metadata["compressed"] is False
+        assert metadata["reason"] == "insufficient_middle_budget"
+        assert metadata["dropped_tokens"] == 0
+        assert metadata["endpoints_only"] is False
         assert metadata["middle_tokens_kept"] == 0
 
     def test_metadata_middle_tokens_kept_positive_on_normal_compression(self):
@@ -75,25 +74,20 @@ class TestPFlashEndpointsOnly:
         assert result.middle_tokens_kept > 0
         assert result.endpoints_only is False
 
-    def test_endpoints_only_warns_at_most_once_per_process(self, caplog):
-        # Reset the module-global warn-once flag so the assertion is independent
-        # of test ordering / prior process state.
-        pflash._ENDPOINTS_ONLY_WARNED = False
-        try:
-            with caplog.at_level(logging.WARNING, logger="vllm_mlx.pflash"):
-                # First endpoints-only collapse: must emit exactly one warning.
-                first = compress_tokens(list(range(3000)), PFlashConfig(mode="always"))
-                assert first.endpoints_only is True
-                # A second, separate collapse must NOT log again.
-                second = compress_tokens(list(range(4000)), PFlashConfig(mode="always"))
-                assert second.endpoints_only is True
-
-            endpoints_warnings = [
-                rec
-                for rec in caplog.records
-                if rec.levelno == logging.WARNING
-                and "PFlash endpoints-only" in rec.getMessage()
-            ]
-            assert len(endpoints_warnings) == 1
-        finally:
-            pflash._ENDPOINTS_ONLY_WARNED = False
+    def test_boundary_requires_positive_middle_budget(self):
+        cfg = PFlashConfig(
+            mode="always",
+            keep_ratio=0.5,
+            min_keep_tokens=1,
+            sink_tokens=2,
+            tail_tokens=2,
+            block_size=1,
+        )
+        # Four-token budget is exactly consumed by the endpoints: preserve.
+        exact = compress_tokens(list(range(8)), cfg)
+        assert exact.compressed is False
+        assert exact.reason == "insufficient_middle_budget"
+        # One extra token funds real middle selection: compression may engage.
+        above = compress_tokens(list(range(10)), cfg)
+        assert above.compressed is True
+        assert above.middle_tokens_kept == 1

--- a/tests/test_pflash_needle.py
+++ b/tests/test_pflash_needle.py
@@ -116,10 +116,21 @@ def test_pflash_default_preserves_needle(ctx_tokens: int, position_frac: float) 
     )
     result = compress_tokens(prompt, config)
 
-    assert result.compressed is True, (
-        f"ctx={ctx_tokens} pos={position_frac}: compressor returned unchanged "
-        f"(reason={result.reason!r}) — verified-tier default must compress"
-    )
+    if ctx_tokens <= 8_192:
+        # The default endpoint reservation consumes the full 20% budget in
+        # this range. Safety wins over a fake compression success that drops
+        # the whole body: the prompt must be byte-for-byte unchanged.
+        assert result.compressed is False
+        assert result.reason == "insufficient_middle_budget"
+        assert result.tokens == prompt
+    else:
+        # The 16k cell still proves the compressor engages once the budget can
+        # fund real middle selection; the recall assertion below is therefore
+        # not allowed to pass trivially on an always-no-op implementation.
+        assert result.compressed is True, (
+            f"ctx={ctx_tokens} pos={position_frac}: compressor returned unchanged "
+            f"(reason={result.reason!r}) despite a real middle budget"
+        )
     kept = set(result.tokens)
     missing = [tok for tok in needle if tok not in kept]
     assert not missing, (

--- a/vllm_mlx/pflash.py
+++ b/vllm_mlx/pflash.py
@@ -25,23 +25,12 @@ This adaptation differs from the fork in three places:
 from __future__ import annotations
 
 import logging
-import threading
 from collections import Counter
 from dataclasses import dataclass
 from math import ceil
 from typing import Any, Literal
 
 logger = logging.getLogger(__name__)
-
-# Warn at most once per process when compression degrades to "endpoints-only"
-# (leading sink + trailing tail consume the entire keep budget, so the whole
-# middle span is dropped). It is a config-level footgun rather than a per-request
-# event, so one warning is the right dosage; per-request occurrences are still
-# exposed via the ``endpoints_only`` / ``middle_tokens_kept`` metadata for metrics.
-# The lock makes the check-then-set atomic so concurrent requests can't both
-# observe ``False`` and each emit the "once" warning.
-_ENDPOINTS_ONLY_WARNED = False
-_ENDPOINTS_ONLY_WARN_LOCK = threading.Lock()
 
 PFlashMode = Literal["off", "auto", "always"]
 
@@ -101,9 +90,9 @@ class PFlashResult:
     original_tokens: int
     kept_tokens: int
     # Number of *middle* tokens (between the leading sink and trailing tail) that
-    # survived compression. 0 on a compressed result means the sink+tail budget
-    # left no room for body content — see ``endpoints_only``. Defaults to 0 so
-    # existing keyword construction (e.g. ``_unchanged``) is unaffected.
+    # survived compression. A zero-middle budget now refuses compression rather
+    # than deleting the body. Defaults to 0 so existing keyword construction
+    # (e.g. ``_unchanged``) is unaffected.
     middle_tokens_kept: int = 0
 
     @property
@@ -114,16 +103,12 @@ class PFlashResult:
 
     @property
     def endpoints_only(self) -> bool:
-        """True when a *compressed* result kept zero middle tokens.
+        """True when a compressed result kept zero middle tokens.
 
-        In this regime ``sink_tokens + tail_tokens`` met or exceeded the keep
-        budget, so PFlash retained only the leading sink and trailing tail and
-        dropped the entire middle span. Mid-document recall collapses to ~0 here
-        (a paraphrased or body-resident answer is simply not in the kept set),
-        even though ``compressed`` is True and ``reason`` is ``"compressed"``.
-        A compressed result always has a non-empty middle span — an all-endpoints
-        prompt short-circuits to ``reason="budget"`` unchanged — so this flag is
-        an unambiguous signal of the degenerate budget, not of a short prompt.
+        The compressor now refuses this lossy state with
+        ``reason="insufficient_middle_budget"`` and returns the prompt unchanged,
+        so production results should always report False. The property remains
+        for metadata compatibility and as a defensive invariant signal.
         """
         return self.compressed and self.middle_tokens_kept == 0
 
@@ -418,6 +403,15 @@ def compress_tokens(
     # flag the degenerate "endpoints-only" regime.
     middle_span = tail_start - sink_end
     remaining_budget = keep_budget - len(keep_positions)
+    if middle_span > 0 and remaining_budget <= 0:
+        # The endpoints already consume the entire keep budget. Compressing in
+        # this regime used to return a normal success after silently deleting
+        # every token in the body — exactly where ordinary 2.3k-11.5k agent
+        # conversations land under the verified Qwen3.5/3.6 defaults. There is
+        # no middle selection to score, so preserve the prompt instead. These
+        # prompts are also too short for the long-prefill win PFlash targets.
+        return _unchanged(tokens, "insufficient_middle_budget")
+
     middle_selected = 0
     if remaining_budget > 0:
         scored_blocks = _score_middle_blocks(
@@ -439,34 +433,6 @@ def compress_tokens(
             middle_selected += take
             if middle_selected >= remaining_budget:
                 break
-
-    if middle_span > 0 and middle_selected == 0:
-        # Endpoints-only: sink+tail consumed the whole budget, so the entire
-        # middle span is dropped and mid-document recall falls to ~0. Warn once
-        # (it is a config-level footgun) with the numbers an operator needs.
-        global _ENDPOINTS_ONLY_WARNED
-        should_warn = False
-        if not _ENDPOINTS_ONLY_WARNED:
-            # Double-checked locking: cheap unlocked read on the hot path, then
-            # take the lock only to atomically re-check and flip the flag so a
-            # single winner emits the once-per-process warning below.
-            with _ENDPOINTS_ONLY_WARN_LOCK:
-                if not _ENDPOINTS_ONLY_WARNED:
-                    _ENDPOINTS_ONLY_WARNED = True
-                    should_warn = True
-        if should_warn:
-            logger.warning(
-                "PFlash endpoints-only: sink(%d)+tail(%d) meet or exceed the keep "
-                "budget (%d) for a %d-token prompt, so all %d middle tokens are "
-                "dropped and mid-document recall falls to ~0. Raise "
-                "--pflash-keep-ratio / --pflash-min-keep-tokens or lower "
-                "--pflash-sink-tokens / --pflash-tail-tokens to retain body context.",
-                sink_end,
-                n_tokens - tail_start,
-                keep_budget,
-                n_tokens,
-                middle_span,
-            )
 
     kept = [tokens[i] for i in sorted(keep_positions)]
     if len(kept) >= n_tokens:


### PR DESCRIPTION
## Why

Closes #1534. The verified Qwen3.5/Qwen3.6 default resolves PFlash to `always`, but under the default 20% keep ratio the 256-token sink plus 2,048-token tail consume the complete budget for ordinary 2.3k–11.5k token prompts. Main returned HTTP success after deleting every middle token.

## What changed

When a prompt has a real middle span but the keep budget cannot fund any of it, PFlash now refuses compression and returns the original tokens with `reason="insufficient_middle_budget"`. Longer prompts with a positive middle budget continue through the existing scorer and compression path.

The obsolete warn-once path was removed: this condition is now a safe, explicit no-op surfaced through existing request metadata.

## Validation

- Reproduced main: a 3,000-token prompt compressed to 2,304 endpoint tokens with `middle_tokens_kept == 0`.
- Fixed result: all 3,000 tokens retained, zero dropped, `compressed == false`.
- Boundary coverage: exact endpoint budget refuses; one extra middle-budget token permits compression.
- Needle matrix retains prompts unchanged at 4k/8k and still proves real compression plus needle recall at 16k.
- `64 passed` across PFlash, needle, server wiring, and bench CLI tests.
- Ruff and format checks pass.