### PR TITLE
fix(chat): scrub forced-stream tool wire before emission

### DIFF
--- a/tests/test_grammar_processor_558.py
+++ b/tests/test_grammar_processor_558.py
@@ -267,6 +267,21 @@ def test_normalize_named_object_form():
     }
 
 
+def test_normalize_named_pydantic_shape():
+    """A stricter request model must not bypass named-choice consumers."""
+    from vllm_mlx.routes.chat import _normalize_tool_choice_for_grammar
+
+    class _NamedChoice:
+        def model_dump(self, *, exclude_none=False):
+            assert exclude_none is True
+            return {"type": "function", "function": {"name": "get_time"}}
+
+    assert _normalize_tool_choice_for_grammar(_NamedChoice()) == {
+        "mode": "named",
+        "name": "get_time",
+    }
+
+
 def test_normalize_bare_tool_name_string_is_never_named():
     # Deferred codex #2: a bare string that happens to equal a tool name is
     # an INVALID tool_choice enum, not a named selection. It must NOT be read

--- a/tests/test_r12_reasoning_sanitizer_required.py
+++ b/tests/test_r12_reasoning_sanitizer_required.py
@@ -806,3 +806,61 @@ def test_forced_stream_preserves_non_structural_tool_marker_prose():
         if isinstance((delta := choice.get("delta") or {}).get("content"), str)
     )
     assert content == "Use <tool_call> literally in docs."
+
+
+def test_forced_stream_replays_content_before_later_tool_call():
+    """Deferred forced events must retain model-generation chronology."""
+    ping_tool = [
+        {
+            "type": "function",
+            "function": {
+                "name": "ping",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+    ]
+    engine = _StreamingLeakEngine(
+        [
+            "<think>brief plan</think>",
+            "Before calling. ",
+            '<tool_call>{"name":"ping","arguments":{}}</tool_call>',
+        ]
+    )
+    cfg = reset_config()
+    cfg.engine = engine
+    cfg.model_name = "qwen3-0.6b-4bit"
+    cfg.model_registry = None
+    cfg.no_thinking = False
+    cfg.reasoning_parser = Qwen3ReasoningParser(tokenizer=None)
+    cfg.reasoning_parser_name = "qwen3"
+    cfg.tool_call_parser = "hermes"
+    app = FastAPI()
+    app.include_router(chat_router)
+    client = TestClient(app)
+
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "qwen3-0.6b-4bit",
+            "messages": [{"role": "user", "content": "Get weather."}],
+            "tools": ping_tool,
+            "tool_choice": "required",
+            "max_tokens": 50,
+            "stream": True,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+
+    chronology = []
+    for chunk in _parse_sse_stream(resp.content):
+        for choice in chunk.get("choices", []):
+            delta = choice.get("delta") or {}
+            if delta.get("content"):
+                chronology.append(("content", delta["content"]))
+            if delta.get("tool_calls"):
+                chronology.append(("tool_call", delta["tool_calls"]))
+
+    content_index = next(i for i, item in enumerate(chronology) if item[0] == "content")
+    tool_index = next(i for i, item in enumerate(chronology) if item[0] == "tool_call")
+    assert chronology[content_index][1] == "Before calling. "
+    assert content_index < tool_index, chronology

--- a/tests/test_r12_reasoning_sanitizer_required.py
+++ b/tests/test_r12_reasoning_sanitizer_required.py
@@ -693,7 +693,15 @@ _LEAKY_STREAM_PIECES = [
 ]
 
 
-def test_chat_route_streaming_required_reasoning_is_sanitized():
+@pytest.mark.parametrize(
+    "tool_choice",
+    [
+        "required",
+        {"type": "function", "function": {"name": "get_weather"}},
+    ],
+    ids=["required", "named"],
+)
+def test_chat_route_streaming_required_reasoning_is_sanitized(tool_choice):
     """Streaming variant of the Vlad r12 repro: aggregate every
     ``delta.reasoning_content`` SSE frame and assert no leaked
     special token survives. Pre-fix the streaming hot-path
@@ -719,7 +727,7 @@ def test_chat_route_streaming_required_reasoning_is_sanitized():
             "model": "qwen3-0.6b-4bit",
             "messages": [{"role": "user", "content": "What's the weather in Tokyo?"}],
             "tools": _WEATHER_TOOL,
-            "tool_choice": "required",
+            "tool_choice": tool_choice,
             "max_tokens": 200,
             "stream": True,
         },

--- a/tests/test_r12_reasoning_sanitizer_required.py
+++ b/tests/test_r12_reasoning_sanitizer_required.py
@@ -746,37 +746,13 @@ def test_chat_route_streaming_required_reasoning_is_sanitized():
             f"R12-MED-2 streaming leak: {leak!r} survived in "
             f"aggregated reasoning_content: {aggregated_reasoning!r}"
         )
-        if leak == "</tool_call>":
-            # KNOWN PRE-EXISTING LEAK — tracked in #1508, NOT weakened here.
-            #
-            # This path really does put the model's raw tool wire on the
-            # content channel. It always did: replaying this same input
-            # through the pre-fix global sanitizer yields
-            #     <tool_call>{"name":"get_weather","arguments":{...}}
-            # i.e. the opener AND the whole JSON payload stayed visible to
-            # the user. The assertion passed only because the blanket
-            # ``</tool_call>`` strip removed the trailing 13 bytes — a
-            # cosmetic strip that never prevented the leak it appeared to
-            # guard.
-            #
-            # That blanket strip was also deleting the token out of
-            # ordinary assistant prose on every surface, so it is gone.
-            # Fixing the underlying structural leak needs a
-            # streaming-aware version of ``_scrub_visible_tool_wire_leaks``
-            # (it is payload-aware and needs the whole span) — #1508.
-            #
-            # Pin the leak explicitly so it stays visible instead of
-            # silently reappearing as a green test.
-            assert "<tool_call>" in aggregated_content, (
-                "#1508 appears fixed — the forced/required streaming path no "
-                "longer leaks tool wire into content. Delete this branch and "
-                "restore the strict assertion below."
-            )
-            continue
         assert leak not in aggregated_content, (
             f"R12-MED-2 streaming leak: {leak!r} survived in "
             f"aggregated content: {aggregated_content!r}"
         )
+
+    assert '"name":"get_weather"' not in aggregated_content
+    assert '"arguments":{"city":"Tokyo"}' not in aggregated_content
 
     # The non-marker reasoning prose still made it through — we
     # didn't accidentally scrub the whole channel.
@@ -784,3 +760,41 @@ def test_chat_route_streaming_required_reasoning_is_sanitized():
         f"sanitizer over-strip: legitimate reasoning prose lost; "
         f"got reasoning={aggregated_reasoning!r}"
     )
+
+
+def test_forced_stream_preserves_non_structural_tool_marker_prose():
+    """Buffering #1508 must not delete documentation about marker syntax."""
+    engine = _StreamingLeakEngine(
+        ["<think>brief plan</think>", "Use <tool_call> literally in docs."]
+    )
+    cfg = reset_config()
+    cfg.engine = engine
+    cfg.model_name = "qwen3-0.6b-4bit"
+    cfg.model_registry = None
+    cfg.no_thinking = False
+    cfg.reasoning_parser = Qwen3ReasoningParser(tokenizer=None)
+    cfg.reasoning_parser_name = "qwen3"
+    cfg.tool_call_parser = "hermes"
+    app = FastAPI()
+    app.include_router(chat_router)
+    client = TestClient(app)
+
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "qwen3-0.6b-4bit",
+            "messages": [{"role": "user", "content": "Explain the marker."}],
+            "tools": _WEATHER_TOOL,
+            "tool_choice": "required",
+            "max_tokens": 50,
+            "stream": True,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    content = "".join(
+        delta["content"]
+        for chunk in _parse_sse_stream(resp.content)
+        for choice in chunk.get("choices", [])
+        if isinstance((delta := choice.get("delta") or {}).get("content"), str)
+    )
+    assert content == "Use <tool_call> literally in docs."

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -6121,20 +6121,64 @@ async def stream_chat_completion(
         # absent.
         processor.seed_forced_assistant_prefix(kwargs.get("forced_assistant_prefix"))
 
-        # A forced tool-choice stream cannot safely release content deltas until
-        # the terminal synth/validation decision is known. In particular, when
-        # schema validation refuses a synthesized call, the parser may already
-        # have surfaced the model's raw ``<tool_call>{...}</tool_call>`` bytes as
-        # content. Buffer this narrow path and structurally scrub the aggregate
-        # before anything reaches the client. Auto/none streams retain normal
-        # token-by-token latency.
+        # Forced-choice content needs a small streaming quarantine: a parser can
+        # surface raw ``<tool_call>{...}</tool_call>`` bytes as content before
+        # terminal synthesis/schema validation refuses the call (#1508). Hold
+        # only marker-like content, while safe prose, reasoning, and parsed tool
+        # calls retain normal streaming latency.
         _stream_tool_choice = _normalize_tool_choice_for_grammar(request.tool_choice)
         _buffer_forced_content = bool(
             request.tools
             and _stream_tool_choice
             and _stream_tool_choice.get("mode") in ("required", "named")
         )
-        _forced_stream_events: list[tuple[str, object]] = []
+        _forced_content_pending: list[tuple[str, ChoiceLogProbs | None]] = []
+        _forced_wire_quarantine = False
+        _forced_quarantine_tail = ""
+        _wire_prefixes = (
+            "<tool_call>",
+            "</tool_call>",
+            "<function=",
+            "<function>",
+            "</function>",
+            "<parameter=",
+            "</parameter>",
+            "<｜tool▁calls▁begin｜>",
+            "<｜tool▁call▁begin｜>",
+            "<｜tool▁sep｜>",
+            "<arg_key>",
+            "</arg_value>",
+            "<minimax:tool_call>",
+            "<invoke",
+            "</invoke>",
+            "<|python_tag|>",
+            "<|tool_calls_section_begin|>",
+            "[TOOL_CALLS]",
+            "[/TOOL_CALLS]",
+        )
+        _wire_closers = (
+            "</tool_call>",
+            "</function>",
+            "<｜tool▁calls▁end｜>",
+            "<｜tool▁call▁end｜>",
+            "</arg_value>",
+            "</minimax:tool_call>",
+            "</invoke>",
+            "<|tool_calls_section_end|>",
+            "[/TOOL_CALLS]",
+        )
+
+        def _may_be_tool_wire(text: str) -> bool:
+            if _contains_tool_wire_literal(text):
+                return True
+            starts = [i for i in (text.rfind("<"), text.rfind("[")) if i >= 0]
+            if not starts:
+                return False
+            suffix = text[max(starts) :]
+            return any(
+                marker.startswith(suffix) or suffix.startswith(marker)
+                for marker in _wire_prefixes
+            )
 
         # Track token counts for usage reporting
         prompt_tokens = 0
@@ -6230,20 +6274,63 @@ async def stream_chat_completion(
                         _build_chunk_logprobs(output) if want_logprobs else None
                     )
                     if _buffer_forced_content:
-                        _forced_stream_events.append(
-                            ("content", (event.content, _event_logprobs))
-                        )
+                        if _forced_wire_quarantine:
+                            # A channel boundary bisected marker-shaped content.
+                            # Discard content until its closer arrives; otherwise
+                            # dropping only the opener would leak the following
+                            # JSON payload as plain assistant text.
+                            _forced_quarantine_tail = (
+                                _forced_quarantine_tail + event.content
+                            )[-256:]
+                            if any(
+                                closer in _forced_quarantine_tail
+                                for closer in _wire_closers
+                            ):
+                                _forced_wire_quarantine = False
+                                _forced_quarantine_tail = ""
+                            continue
+                        if _forced_content_pending or _may_be_tool_wire(event.content):
+                            _forced_content_pending.append(
+                                (event.content, _event_logprobs)
+                            )
+                            _pending_raw = "".join(
+                                text for text, _ in _forced_content_pending
+                            )
+                            if _contains_structural_tool_wire_leak(_pending_raw):
+                                _clean_pending = _scrub_visible_tool_wire_leaks(
+                                    _pending_raw
+                                )
+                                _forced_content_pending.clear()
+                                if _clean_pending:
+                                    if first_token_ts is None:
+                                        first_token_ts = time.perf_counter()
+                                    yield _content_sse_chunk(_clean_pending, None)
+                            elif not _may_be_tool_wire(_pending_raw):
+                                # A partial candidate diverged into ordinary
+                                # prose (e.g. ``<funx``): replay every held byte.
+                                for _text, _logprobs in _forced_content_pending:
+                                    if _text:
+                                        if first_token_ts is None:
+                                            first_token_ts = time.perf_counter()
+                                        yield _content_sse_chunk(_text, _logprobs)
+                                _forced_content_pending.clear()
+                        else:
+                            if first_token_ts is None:
+                                first_token_ts = time.perf_counter()
+                            yield _content_sse_chunk(event.content, _event_logprobs)
                     else:
                         yield _content_sse_chunk(event.content, _event_logprobs)
 
                 elif event.type == "reasoning":
-                    _reasoning_sse = _fast_sse_chunk(
-                        event.reasoning, "reasoning_content"
-                    )
-                    if _buffer_forced_content:
-                        _forced_stream_events.append(("sse", _reasoning_sse))
-                    else:
-                        yield _reasoning_sse
+                    if _forced_content_pending:
+                        # A channel boundary makes later content non-contiguous.
+                        # Fail closed on the ambiguous marker-shaped fragment so
+                        # it cannot be spliced around this reasoning event.
+                        _forced_content_pending.clear()
+                        _forced_wire_quarantine = True
+                    if first_token_ts is None:
+                        first_token_ts = time.perf_counter()
+                    yield _fast_sse_chunk(event.reasoning, "reasoning_content")
 
                 elif event.type == "tool_call":
                     # r7-A R7-H1: streaming-lane parity with the
@@ -6309,10 +6396,15 @@ async def stream_chat_completion(
                     # double-emit the turn end.
                     if event.finish_reason is not None:
                         inline_terminal_finish_emitted = True
-                    if _buffer_forced_content:
-                        _forced_stream_events.append(("sse", _tc_sse))
-                    else:
-                        yield _tc_sse
+                    if _forced_content_pending:
+                        # A parsed tool call confirms the held marker-like bytes
+                        # were transport, not assistant prose.
+                        _forced_content_pending.clear()
+                    _forced_wire_quarantine = False
+                    _forced_quarantine_tail = ""
+                    if first_token_ts is None:
+                        first_token_ts = time.perf_counter()
+                    yield _tc_sse
 
                 elif event.type == "finish":
                     # Defer emission: finalize() (below) may recover a
@@ -6479,61 +6571,41 @@ async def stream_chat_completion(
                         _synth_target,
                     )
 
-        # Release the narrow forced-choice content buffer only after tool-call
-        # parsing, fallback recovery, synthesis, and schema validation have all
-        # finished. The structural detector examines the aggregate so a wire
-        # opener and closer split across engine deltas cannot evade it.
-        _forced_terminal_content_scrubbed = False
-        _forced_terminal_content = ""
+        # Finish/finalize content is the last contiguous content segment. Join
+        # it to any quarantined marker prefix so a wire span split at stream end
+        # is inspected as one logical content stream, then consume it here to
+        # avoid a second copy in the terminal chunk.
+        _forced_terminal_content_consumed = False
         if _buffer_forced_content:
-            # Replay in original event order. Only adjacent content deltas are
-            # coalesced for structural inspection; reasoning/tool events remain
-            # at their original positions relative to each content group.
-            _event_index = 0
-            while _event_index < len(_forced_stream_events):
-                _kind, _payload = _forced_stream_events[_event_index]
-                if _kind == "sse":
-                    if first_token_ts is None:
-                        first_token_ts = time.perf_counter()
-                    yield _payload
-                    _event_index += 1
-                    continue
-
-                _content_group: list[tuple[str, ChoiceLogProbs | None]] = []
-                while _event_index < len(_forced_stream_events):
-                    _group_kind, _group_payload = _forced_stream_events[_event_index]
-                    if _group_kind != "content":
-                        break
-                    _content_group.append(_group_payload)
-                    _event_index += 1
-                _group_raw = "".join(text for text, _ in _content_group)
-                if _contains_structural_tool_wire_leak(_group_raw):
-                    _group_clean = _scrub_visible_tool_wire_leaks(_group_raw)
-                    if _group_clean:
+            _finish_held = ""
+            if buffered_finish is not None:
+                _finish_held = buffered_finish[0].content or ""
+            _terminal_held = _finish_held + finalize_content
+            if _forced_wire_quarantine:
+                # The stream ended inside a quarantined wire fragment. Its
+                # remaining bytes are transport residue, never visible content.
+                _forced_terminal_content_consumed = bool(_terminal_held)
+                _forced_content_pending.clear()
+            elif _forced_content_pending or _may_be_tool_wire(_terminal_held):
+                _forced_terminal_content_consumed = True
+                _forced_content_pending.append((_terminal_held, None))
+                _pending_raw = "".join(text for text, _ in _forced_content_pending)
+                if _contains_structural_tool_wire_leak(_pending_raw):
+                    _final_content = _scrub_visible_tool_wire_leaks(_pending_raw)
+                    if _final_content:
                         if first_token_ts is None:
                             first_token_ts = time.perf_counter()
-                        # Rewriting across deltas invalidates their token-level
-                        # logprob alignment, so emit one clean group without it.
-                        yield _content_sse_chunk(_group_clean, None)
+                        yield _content_sse_chunk(_final_content, None)
                 else:
-                    for _text, _logprobs in _content_group:
+                    # No payload-bearing structure materialized by stream end:
+                    # preserve literal marker documentation and partial prose.
+                    for _text, _logprobs in _forced_content_pending:
                         if not _text:
                             continue
                         if first_token_ts is None:
                             first_token_ts = time.perf_counter()
                         yield _content_sse_chunk(_text, _logprobs)
-
-            # Finish/finalize content is chronologically after every buffered
-            # event, so scrub it separately and keep it in the terminal slot.
-            _finish_held = ""
-            if buffered_finish is not None:
-                _finish_held = buffered_finish[0].content or ""
-            _terminal_held = _finish_held + finalize_content
-            if _contains_structural_tool_wire_leak(_terminal_held):
-                _forced_terminal_content_scrubbed = True
-                _forced_terminal_content = _scrub_visible_tool_wire_leaks(
-                    _terminal_held
-                )
+                _forced_content_pending.clear()
 
         # Emit the terminal chunk. Three cases:
         #   (a) Streaming parser already emitted tool_calls during the
@@ -6558,8 +6630,8 @@ async def stream_chat_completion(
             # plain-text streams (deltas already drained content during
             # the loop), so this typically just adds the held suffix.
             terminal_content = (
-                _forced_terminal_content
-                if _forced_terminal_content_scrubbed
+                ""
+                if _forced_terminal_content_consumed
                 else (finish_event.content or "") + finalize_content
             )
 
@@ -6871,8 +6943,8 @@ async def stream_chat_completion(
                     ChatCompletionChunkChoice(
                         delta=ChatCompletionChunkDelta(
                             content=(
-                                _forced_terminal_content or None
-                                if _forced_terminal_content_scrubbed
+                                None
+                                if _forced_terminal_content_consumed
                                 else finalize_content or None
                             ),
                             reasoning_content=None,

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -317,13 +317,13 @@ def _compute_forced_tool_prefix(cfg, request) -> str | None:
     """
     if not (request.tools and getattr(request, "tool_choice", None) is not None):
         return None
+    normalized = _normalize_tool_choice_for_grammar(request.tool_choice)
     _forced_name: str | None = None
-    if (
-        isinstance(request.tool_choice, dict)
-        and request.tool_choice.get("type") == "function"
+    if normalized and normalized.get("mode") == "named":
+        _forced_name = normalized.get("name")
+    elif (
+        normalized and normalized.get("mode") == "required" and len(request.tools) == 1
     ):
-        _forced_name = (request.tool_choice.get("function") or {}).get("name")
-    elif request.tool_choice == "required" and len(request.tools) == 1:
         # OpenAI spec: ``required`` with a single tool is unambiguous — same
         # forcing semantics as a named choice.
         _forced_name = request.tools[0].function.get("name")
@@ -362,6 +362,19 @@ def _normalize_tool_choice_for_grammar(tool_choice) -> dict | None:
     drops ``request.tools``). A malformed object form (no usable name) also
     degrades to ``None`` — free-form, rather than fabricating a constraint.
     """
+    # Pydantic currently preserves this field as a raw dict, but callers and a
+    # future stricter request schema may supply a model instance. Normalize that
+    # representation once so every forced-choice consumer sees the same shape.
+    if not isinstance(tool_choice, dict):
+        model_dump = getattr(tool_choice, "model_dump", None)
+        if callable(model_dump):
+            try:
+                dumped = model_dump(exclude_none=True)
+            except (TypeError, ValueError):
+                dumped = None
+            if isinstance(dumped, dict):
+                tool_choice = dumped
+
     # Object form is the ONLY place a tool name appears: a named choice.
     if isinstance(tool_choice, dict):
         if tool_choice.get("type") == "function":
@@ -5578,9 +5591,10 @@ async def _create_chat_completion_impl(
     # model ignores ``tool_choice="required"`` and emits ordinary
     # prose. Scrub only when the visible text contains STRUCTURAL
     # parser-wire residue, not merely a literal token mention.
-    _is_forced_choice = request.tool_choice == "required" or (
-        isinstance(request.tool_choice, dict)
-        and request.tool_choice.get("type") == "function"
+    _normalized_tool_choice = _normalize_tool_choice_for_grammar(request.tool_choice)
+    _is_forced_choice = bool(
+        _normalized_tool_choice
+        and _normalized_tool_choice.get("mode") in ("required", "named")
     )
     _raw_text_for_reasoning = output.raw_text or output.text
     _raw_has_structural_wire = _contains_structural_tool_wire_leak(
@@ -6114,12 +6128,11 @@ async def stream_chat_completion(
         # content. Buffer this narrow path and structurally scrub the aggregate
         # before anything reaches the client. Auto/none streams retain normal
         # token-by-token latency.
-        _buffer_forced_content = bool(request.tools) and (
-            request.tool_choice == "required"
-            or (
-                isinstance(request.tool_choice, dict)
-                and request.tool_choice.get("type") == "function"
-            )
+        _stream_tool_choice = _normalize_tool_choice_for_grammar(request.tool_choice)
+        _buffer_forced_content = bool(
+            request.tools
+            and _stream_tool_choice
+            and _stream_tool_choice.get("mode") in ("required", "named")
         )
         _forced_content_parts: list[tuple[str, ChoiceLogProbs | None]] = []
 
@@ -6378,11 +6391,8 @@ async def stream_chat_completion(
             and request.tool_choice is not None
         ):
             _synth_target: str | None = None
-            if (
-                isinstance(request.tool_choice, dict)
-                and request.tool_choice.get("type") == "function"
-            ):
-                _pinned = (request.tool_choice.get("function") or {}).get("name")
+            if _stream_tool_choice and _stream_tool_choice.get("mode") == "named":
+                _pinned = _stream_tool_choice.get("name")
                 _submitted = {
                     t.function.get("name")
                     for t in request.tools
@@ -6390,7 +6400,11 @@ async def stream_chat_completion(
                 }
                 if _pinned and _pinned in _submitted:
                     _synth_target = _pinned
-            elif request.tool_choice == "required" and len(request.tools) == 1:
+            elif (
+                _stream_tool_choice
+                and _stream_tool_choice.get("mode") == "required"
+                and len(request.tools) == 1
+            ):
                 _synth_target = request.tools[0].function.get("name")
             if _synth_target:
                 _raw_text = (

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -6017,6 +6017,25 @@ async def stream_chat_completion(
             escaped = json.dumps(_sanitize(text))
             return f'{_sse_prefix}"{field}":{escaped}{_sse_suffix}'
 
+        def _content_sse_chunk(
+            text: str, chunk_logprobs: ChoiceLogProbs | None = None
+        ) -> str:
+            """Serialize one content delta, preserving requested logprobs."""
+            if not want_logprobs:
+                return _fast_sse_chunk(text, "content")
+            chunk = ChatCompletionChunk(
+                id=response_id,
+                created=_sse_created,
+                model=_resolve_model_name(request.model),
+                choices=[
+                    ChatCompletionChunkChoice(
+                        delta=ChatCompletionChunkDelta(content=text),
+                        logprobs=chunk_logprobs,
+                    )
+                ],
+            )
+            return f"data: {chunk.model_dump_json(exclude_none=True)}\n\n"
+
         # First chunk with role
         _first_sse = f'{_sse_prefix}"role":"assistant"{_sse_suffix}'
         if logger.isEnabledFor(logging.INFO):
@@ -6087,6 +6106,22 @@ async def stream_chat_completion(
         # the swallow-buffer state machine. No-op when the prefix is
         # absent.
         processor.seed_forced_assistant_prefix(kwargs.get("forced_assistant_prefix"))
+
+        # A forced tool-choice stream cannot safely release content deltas until
+        # the terminal synth/validation decision is known. In particular, when
+        # schema validation refuses a synthesized call, the parser may already
+        # have surfaced the model's raw ``<tool_call>{...}</tool_call>`` bytes as
+        # content. Buffer this narrow path and structurally scrub the aggregate
+        # before anything reaches the client. Auto/none streams retain normal
+        # token-by-token latency.
+        _buffer_forced_content = bool(request.tools) and (
+            request.tool_choice == "required"
+            or (
+                isinstance(request.tool_choice, dict)
+                and request.tool_choice.get("type") == "function"
+            )
+        )
+        _forced_content_parts: list[tuple[str, ChoiceLogProbs | None]] = []
 
         # Track token counts for usage reporting
         prompt_tokens = 0
@@ -6166,32 +6201,25 @@ async def stream_chat_completion(
                 # Telemetry: stamp TTFT on the first real output token
                 # (content / reasoning / tool_call). Cheap monotonic read
                 # gated to fire once; never touches the wire.
-                if first_token_ts is None and event.type in (
-                    "content",
-                    "reasoning",
-                    "tool_call",
+                if (
+                    first_token_ts is None
+                    and event.type
+                    in (
+                        "content",
+                        "reasoning",
+                        "tool_call",
+                    )
+                    and not (event.type == "content" and _buffer_forced_content)
                 ):
                     first_token_ts = time.perf_counter()
                 if event.type == "content":
-                    if not want_logprobs:
-                        _sse = _fast_sse_chunk(event.content, "content")
-                        if _sse:
-                            yield _sse
+                    _event_logprobs = (
+                        _build_chunk_logprobs(output) if want_logprobs else None
+                    )
+                    if _buffer_forced_content:
+                        _forced_content_parts.append((event.content, _event_logprobs))
                     else:
-                        chunk = ChatCompletionChunk(
-                            id=response_id,
-                            created=_sse_created,
-                            model=_resolve_model_name(request.model),
-                            choices=[
-                                ChatCompletionChunkChoice(
-                                    delta=ChatCompletionChunkDelta(
-                                        content=event.content,
-                                    ),
-                                    logprobs=_build_chunk_logprobs(output),
-                                )
-                            ],
-                        )
-                        yield f"data: {chunk.model_dump_json(exclude_none=True)}\n\n"
+                        yield _content_sse_chunk(event.content, _event_logprobs)
 
                 elif event.type == "reasoning":
                     yield _fast_sse_chunk(event.reasoning, "reasoning_content")
@@ -6426,6 +6454,36 @@ async def stream_chat_completion(
                         _synth_target,
                     )
 
+        # Release the narrow forced-choice content buffer only after tool-call
+        # parsing, fallback recovery, synthesis, and schema validation have all
+        # finished. The structural detector examines the aggregate so a wire
+        # opener and closer split across engine deltas cannot evade it.
+        _forced_content_scrubbed = False
+        if _buffer_forced_content:
+            _deferred_raw = "".join(text for text, _ in _forced_content_parts)
+            _finish_held = ""
+            if buffered_finish is not None:
+                _finish_held = buffered_finish[0].content or ""
+            _held_content = _deferred_raw + _finish_held + finalize_content
+            if _contains_structural_tool_wire_leak(_held_content):
+                _forced_content_scrubbed = True
+                _clean_held = _scrub_visible_tool_wire_leaks(_held_content)
+                if _clean_held:
+                    if first_token_ts is None:
+                        first_token_ts = time.perf_counter()
+                    # Scrubbing can span multiple original deltas, so their
+                    # per-token logprobs no longer map to the rewritten text.
+                    yield _content_sse_chunk(_clean_held, None)
+            else:
+                # No structural wire exists: replay the original chunks exactly
+                # so ordinary forced-choice prose and requested logprobs survive.
+                for _text, _logprobs in _forced_content_parts:
+                    if not _text:
+                        continue
+                    if first_token_ts is None:
+                        first_token_ts = time.perf_counter()
+                    yield _content_sse_chunk(_text, _logprobs)
+
         # Emit the terminal chunk. Three cases:
         #   (a) Streaming parser already emitted tool_calls during the
         #       loop → buffered_finish has finish_reason="tool_calls"
@@ -6448,7 +6506,11 @@ async def stream_chat_completion(
             # finish_event.content path is normally None for non-tool
             # plain-text streams (deltas already drained content during
             # the loop), so this typically just adds the held suffix.
-            terminal_content = (finish_event.content or "") + finalize_content
+            terminal_content = (
+                ""
+                if _forced_content_scrubbed
+                else (finish_event.content or "") + finalize_content
+            )
 
             # Issue #569 streaming rescue: if NOTHING was streamed as
             # ``content`` across the whole turn AND no ``tool_calls``
@@ -6757,7 +6819,11 @@ async def stream_chat_completion(
                 choices=[
                     ChatCompletionChunkChoice(
                         delta=ChatCompletionChunkDelta(
-                            content=finalize_content or None,
+                            content=(
+                                None
+                                if _forced_content_scrubbed
+                                else finalize_content or None
+                            ),
                             reasoning_content=None,
                             tool_calls=fallback_tool_calls or None,
                         ),

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -6134,7 +6134,7 @@ async def stream_chat_completion(
             and _stream_tool_choice
             and _stream_tool_choice.get("mode") in ("required", "named")
         )
-        _forced_content_parts: list[tuple[str, ChoiceLogProbs | None]] = []
+        _forced_stream_events: list[tuple[str, object]] = []
 
         # Track token counts for usage reporting
         prompt_tokens = 0
@@ -6222,7 +6222,7 @@ async def stream_chat_completion(
                         "reasoning",
                         "tool_call",
                     )
-                    and not (event.type == "content" and _buffer_forced_content)
+                    and not _buffer_forced_content
                 ):
                     first_token_ts = time.perf_counter()
                 if event.type == "content":
@@ -6230,12 +6230,20 @@ async def stream_chat_completion(
                         _build_chunk_logprobs(output) if want_logprobs else None
                     )
                     if _buffer_forced_content:
-                        _forced_content_parts.append((event.content, _event_logprobs))
+                        _forced_stream_events.append(
+                            ("content", (event.content, _event_logprobs))
+                        )
                     else:
                         yield _content_sse_chunk(event.content, _event_logprobs)
 
                 elif event.type == "reasoning":
-                    yield _fast_sse_chunk(event.reasoning, "reasoning_content")
+                    _reasoning_sse = _fast_sse_chunk(
+                        event.reasoning, "reasoning_content"
+                    )
+                    if _buffer_forced_content:
+                        _forced_stream_events.append(("sse", _reasoning_sse))
+                    else:
+                        yield _reasoning_sse
 
                 elif event.type == "tool_call":
                     # r7-A R7-H1: streaming-lane parity with the
@@ -6301,7 +6309,10 @@ async def stream_chat_completion(
                     # double-emit the turn end.
                     if event.finish_reason is not None:
                         inline_terminal_finish_emitted = True
-                    yield _tc_sse
+                    if _buffer_forced_content:
+                        _forced_stream_events.append(("sse", _tc_sse))
+                    else:
+                        yield _tc_sse
 
                 elif event.type == "finish":
                     # Defer emission: finalize() (below) may recover a
@@ -6472,31 +6483,57 @@ async def stream_chat_completion(
         # parsing, fallback recovery, synthesis, and schema validation have all
         # finished. The structural detector examines the aggregate so a wire
         # opener and closer split across engine deltas cannot evade it.
-        _forced_content_scrubbed = False
+        _forced_terminal_content_scrubbed = False
+        _forced_terminal_content = ""
         if _buffer_forced_content:
-            _deferred_raw = "".join(text for text, _ in _forced_content_parts)
+            # Replay in original event order. Only adjacent content deltas are
+            # coalesced for structural inspection; reasoning/tool events remain
+            # at their original positions relative to each content group.
+            _event_index = 0
+            while _event_index < len(_forced_stream_events):
+                _kind, _payload = _forced_stream_events[_event_index]
+                if _kind == "sse":
+                    if first_token_ts is None:
+                        first_token_ts = time.perf_counter()
+                    yield _payload
+                    _event_index += 1
+                    continue
+
+                _content_group: list[tuple[str, ChoiceLogProbs | None]] = []
+                while _event_index < len(_forced_stream_events):
+                    _group_kind, _group_payload = _forced_stream_events[_event_index]
+                    if _group_kind != "content":
+                        break
+                    _content_group.append(_group_payload)
+                    _event_index += 1
+                _group_raw = "".join(text for text, _ in _content_group)
+                if _contains_structural_tool_wire_leak(_group_raw):
+                    _group_clean = _scrub_visible_tool_wire_leaks(_group_raw)
+                    if _group_clean:
+                        if first_token_ts is None:
+                            first_token_ts = time.perf_counter()
+                        # Rewriting across deltas invalidates their token-level
+                        # logprob alignment, so emit one clean group without it.
+                        yield _content_sse_chunk(_group_clean, None)
+                else:
+                    for _text, _logprobs in _content_group:
+                        if not _text:
+                            continue
+                        if first_token_ts is None:
+                            first_token_ts = time.perf_counter()
+                        yield _content_sse_chunk(_text, _logprobs)
+
+            # Finish/finalize content is chronologically after every buffered
+            # event, so scrub it separately and keep it in the terminal slot.
             _finish_held = ""
             if buffered_finish is not None:
                 _finish_held = buffered_finish[0].content or ""
-            _held_content = _deferred_raw + _finish_held + finalize_content
-            if _contains_structural_tool_wire_leak(_held_content):
-                _forced_content_scrubbed = True
-                _clean_held = _scrub_visible_tool_wire_leaks(_held_content)
-                if _clean_held:
-                    if first_token_ts is None:
-                        first_token_ts = time.perf_counter()
-                    # Scrubbing can span multiple original deltas, so their
-                    # per-token logprobs no longer map to the rewritten text.
-                    yield _content_sse_chunk(_clean_held, None)
-            else:
-                # No structural wire exists: replay the original chunks exactly
-                # so ordinary forced-choice prose and requested logprobs survive.
-                for _text, _logprobs in _forced_content_parts:
-                    if not _text:
-                        continue
-                    if first_token_ts is None:
-                        first_token_ts = time.perf_counter()
-                    yield _content_sse_chunk(_text, _logprobs)
+            _terminal_held = _finish_held + finalize_content
+            if _contains_structural_tool_wire_leak(_terminal_held):
+                _forced_terminal_content_scrubbed = True
+                _forced_terminal_content = _scrub_visible_tool_wire_leaks(
+                    _terminal_held
+                )
 
         # Emit the terminal chunk. Three cases:
         #   (a) Streaming parser already emitted tool_calls during the
@@ -6521,8 +6558,8 @@ async def stream_chat_completion(
             # plain-text streams (deltas already drained content during
             # the loop), so this typically just adds the held suffix.
             terminal_content = (
-                ""
-                if _forced_content_scrubbed
+                _forced_terminal_content
+                if _forced_terminal_content_scrubbed
                 else (finish_event.content or "") + finalize_content
             )
 
@@ -6834,8 +6871,8 @@ async def stream_chat_completion(
                     ChatCompletionChunkChoice(
                         delta=ChatCompletionChunkDelta(
                             content=(
-                                None
-                                if _forced_content_scrubbed
+                                _forced_terminal_content or None
+                                if _forced_terminal_content_scrubbed
                                 else finalize_content or None
                             ),
                             reasoning_content=None,


### PR DESCRIPTION
## Why

Closes #1508. On streaming `tool_choice="required"`/named-function requests, content deltas were emitted before terminal fallback synthesis and schema validation completed. If synthesis was refused, the client had already received the model raw `<tool_call>{...}</tool_call>` envelope as assistant content.

## What changed

Forced-choice streams now buffer only content-channel deltas until parser fallback, synthesis, and schema validation finish. The complete held span is checked with the existing payload-aware structural detector:

- structural tool wire is scrubbed before any content reaches the client;
- ordinary prose, including literal marker documentation without a tool payload, is replayed unchanged;
- `auto` and `none` streams keep normal token-by-token latency;
- safe replay preserves original chunk logprobs; rewritten structural spans do not attach misleading token logprobs.

Reasoning and actual `delta.tool_calls` continue streaming normally.

## Validation

- The existing route repro no longer permits its #1508 exception: opener, closer, name, and arguments payload are absent from aggregated content.
- A negative control preserves `Use <tool_call> literally in docs.` exactly.
- Streaming/tool-choice regression matrix: `339 passed, 2 skipped` across 11 focused files.
- Ruff and formatting pass.