### PR TITLE
fix(tool-calling): reject ambiguous undeclared parameters

### DIFF
--- a/tests/test_tool_call_value_fidelity.py
+++ b/tests/test_tool_call_value_fidelity.py
@@ -536,7 +536,7 @@ _DISAMBIGUATING_PARSERS = ["hermes", "nemotron", "nemotron3"]
 
 @pytest.mark.parametrize("parser_name", _DISAMBIGUATING_PARSERS)
 @pytest.mark.parametrize(
-    "case,value", AMBIGUOUS_ORDERINGS, ids=[c for c, _ in AMBIGUOUS_ORDERINGS]
+    "case,value", [AMBIGUOUS_ORDERINGS[1]], ids=["open_then_close"]
 )
 def test_parser_itself_does_not_invent_parameters(parser_name, case, value):
     """Asserted against the NAMED parser, with no scanner fallback."""
@@ -554,7 +554,7 @@ def test_parser_itself_does_not_invent_parameters(parser_name, case, value):
 
 
 @pytest.mark.parametrize(
-    "case,value", AMBIGUOUS_ORDERINGS, ids=[c for c, _ in AMBIGUOUS_ORDERINGS]
+    "case,value", [AMBIGUOUS_ORDERINGS[1]], ids=["open_then_close"]
 )
 def test_ambiguous_marker_ordering_does_not_invent_parameters(case, value):
     """A value holding marker-shaped text must not become extra arguments.
@@ -578,6 +578,51 @@ def test_ambiguous_marker_ordering_does_not_invent_parameters(case, value):
     assert args[_KEY] == value, (
         f"[{case}] value truncated.\n  sent: {value!r}\n  got:  {args[_KEY]!r}"
     )
+
+
+@pytest.mark.parametrize("parser_name", _DISAMBIGUATING_PARSERS)
+@pytest.mark.parametrize(
+    "case,value",
+    [AMBIGUOUS_ORDERINGS[0], AMBIGUOUS_ORDERINGS[2]],
+    ids=["close_then_open", "open_then_close_then_open"],
+)
+def test_undeclared_sibling_after_close_refuses_parser_call(parser_name, case, value):
+    """An undeclared sibling after a close is ambiguous, so fail closed (#1541)."""
+    text = _render_xml_body(_NAME, _KEY, value)
+    assert _extract_parser_only(parser_name, text) == [], (
+        f"{parser_name} [{case}] executed an ambiguous call whose argument could "
+        "have been silently rewritten"
+    )
+
+
+@pytest.mark.parametrize(
+    "case,value",
+    [AMBIGUOUS_ORDERINGS[0], AMBIGUOUS_ORDERINGS[2]],
+    ids=["close_then_open", "open_then_close_then_open"],
+)
+def test_undeclared_sibling_after_close_refuses_fallback_call(case, value):
+    from vllm_mlx.api.tool_calling import parse_tool_calls
+
+    text = _render_xml_body(_NAME, _KEY, value)
+    _, calls = parse_tool_calls(text, _REQUEST)
+    assert not calls, (
+        f"[{case}] fallback executed an ambiguous call whose argument could have "
+        "been silently rewritten"
+    )
+
+
+def test_undeclared_sibling_never_splices_into_previous_value():
+    """Exact #1541 repro: a hallucinated parameter must not rewrite a path."""
+    from vllm_mlx.api.tool_calling import parse_tool_calls
+
+    text = (
+        f"<tool_call><function={_NAME}>"
+        f"<parameter={_KEY}>/ok</parameter>"
+        "<parameter=mode>force</parameter>"
+        "</function></tool_call>"
+    )
+    _, calls = parse_tool_calls(text, _REQUEST)
+    assert not calls
 
 
 @pytest.mark.parametrize("parser_name", _DISAMBIGUATING_PARSERS)

--- a/vllm_mlx/api/tool_calling.py
+++ b/vllm_mlx/api/tool_calling.py
@@ -545,9 +545,16 @@ def parse_tool_calls(
         # scanner exists to remove. Repeated names are NOT filtered: two
         # real elements with one name are last-value-wins here.
         declared = set(_get_tool_param_config(name, request)) or None
-        for p_name, val in split_marked_parameters(
-            params_block, r"<parameter=([^>]+)>", "</parameter>", valid_names=declared
-        ):
+        parsed_params = split_marked_parameters(
+            params_block,
+            r"<parameter=([^>]+)>",
+            "</parameter>",
+            valid_names=declared,
+            reject_undeclared_siblings=declared is not None,
+        )
+        if parsed_params is None:
+            continue
+        for p_name, val in parsed_params:
             try:
                 arguments[p_name] = json.loads(val)
             except (json.JSONDecodeError, ValueError):

--- a/vllm_mlx/tool_call_scan.py
+++ b/vllm_mlx/tool_call_scan.py
@@ -215,7 +215,9 @@ def split_marked_parameters(
     opener: str,
     closer: str,
     valid_names: frozenset[str] | set[str] | None = None,
-) -> list[tuple[str, str]]:
+    *,
+    reject_undeclared_siblings: bool = False,
+) -> list[tuple[str, str]] | None:
     """``(name, value)`` for each parameter in ``block``.
 
     ``opener`` must capture the parameter name in group 1. Values are
@@ -227,6 +229,18 @@ def split_marked_parameters(
     out: list[tuple[str, str]] = []
     i = 0
     while i < len(openers):
+        if reject_undeclared_siblings and valid_names is not None:
+            current_end = openers[i].end()
+            for candidate in openers[i + 1 :]:
+                if candidate.group(1).strip() in valid_names:
+                    continue
+                if closer in block[current_end : candidate.start()]:
+                    # Syntax cannot distinguish an undeclared sibling from
+                    # marker-shaped payload after a close.  Continuing would
+                    # splice the entire undeclared element into the previous
+                    # value (#1541).  Refuse the call rather than execute a
+                    # silently rewritten argument.
+                    return None
         segmented = segment_by_next_opener(block, openers, i, closer, valid_names)
         sibling = _next_sibling(block, openers, i, closer, valid_names)
         if segmented is not None:

--- a/vllm_mlx/tool_parsers/hermes_tool_parser.py
+++ b/vllm_mlx/tool_parsers/hermes_tool_parser.py
@@ -28,7 +28,7 @@ def generate_tool_id() -> str:
 
 def _parse_function_body(
     body: str, valid_names: set[str] | None = None
-) -> dict[str, Any]:
+) -> dict[str, Any] | None:
     """Parse the body of any ``<function=name>...</function>`` block.
 
     Called both for wrapped (``<tool_call><function=...>...``) and
@@ -62,9 +62,16 @@ def _parse_function_body(
     # ``</parameter>`` the value happened to contain and silently dropped
     # the rest (jundot/omlx#2507). Shared with the other implementations of
     # this wire format — see ``vllm_mlx/tool_call_scan``.
-    for p_name, p_value in split_marked_parameters(
-        body, r"<parameter=([^>]+)>", "</parameter>", valid_names=valid_names
-    ):
+    params = split_marked_parameters(
+        body,
+        r"<parameter=([^>]+)>",
+        "</parameter>",
+        valid_names=valid_names,
+        reject_undeclared_siblings=valid_names is not None,
+    )
+    if params is None:
+        return None
+    for p_name, p_value in params:
         arguments[p_name] = _parse_param_value(p_value)
     return arguments
 
@@ -296,6 +303,8 @@ class HermesToolParser(ToolParser):
                 args = _parse_function_body(
                     m.group(2), declared_parameter_names(name, request)
                 )
+                if args is None:
+                    return None
                 return (m.end(), name, json.dumps(args, ensure_ascii=False))
             return None
         if shape == "function_eq":
@@ -306,6 +315,8 @@ class HermesToolParser(ToolParser):
                 args = _parse_function_body(
                     m.group(2), declared_parameter_names(name, request)
                 )
+                if args is None:
+                    return None
                 return (m.end(), name, json.dumps(args, ensure_ascii=False))
             return None
         if shape == "function_open":
@@ -317,6 +328,8 @@ class HermesToolParser(ToolParser):
                 args = _parse_function_body(
                     args_body, declared_parameter_names(name, request)
                 )
+                if args is None:
+                    return None
                 if not args and args_body.strip().startswith("{"):
                     # Body looked like JSON but failed both paths — keep
                     # raw to avoid silently dropping argument content.

--- a/vllm_mlx/tool_parsers/nemotron_tool_parser.py
+++ b/vllm_mlx/tool_parsers/nemotron_tool_parser.py
@@ -259,7 +259,10 @@ class NemotronToolParser(ToolParser):
                 r"<parameter=([^>]+)>",
                 "</parameter>",
                 valid_names=declared_parameter_names(func_name, request),
+                reject_undeclared_siblings=True,
             )
+            if params is None:
+                continue
             if params:
                 arguments = {}
                 for param_name, param_value in params:


### PR DESCRIPTION
## Why

Closes #1541. An undeclared XML parameter after a completed declared parameter was skipped as a sibling boundary, causing its entire wire span to be appended to the previous value. A hallucinated `mode` could therefore silently rewrite a validated string such as `path`.

## What changed

Request-aware XML scanners now fail closed when syntax cannot distinguish an undeclared sibling from marker-shaped payload after a close. The fallback, Hermes, Nemotron, and Nemotron3 paths all reject the complete call instead of executing corrupted arguments. Marker text that has no preceding close remains literal payload, and repeated declared parameters retain last-value-wins behavior.

## Validation

- Exact #1541 reproduction now yields no executable call.
- Focused tool-calling matrix: 538 passed, 31 skipped.
- Ruff lint and format pass.
- Mutation/negative controls cover all three parser families and the generic fallback.