### PR TITLE
fix(qwen): preserve XML delimiters in string arguments

### DIFF
--- a/tests/test_qwen3coder_tool_parser_streaming.py
+++ b/tests/test_qwen3coder_tool_parser_streaming.py
@@ -180,6 +180,27 @@ def test_close_tag_never_leaks_into_emitted_fragment():
     )
 
 
+def test_json_encoded_string_preserves_embedded_xml_closers():
+    """The constrained #1542 wire must keep every XML marker as string data."""
+    parser = Qwen3CoderToolParser(tokenizer=None)
+    request = _request_with_tool("write", {"content": {"type": "string"}})
+    value = 'before </parameter> </function> </tool_call> after "quoted"'
+    encoded = json.dumps(value, ensure_ascii=False)
+    chunks = [
+        "<tool_call>\n",
+        "<function=write>\n",
+        "<parameter=content>\n",
+        encoded[:17],
+        encoded[17:38],
+        encoded[38:] + "\n</parameter>\n",
+        "</function>\n",
+        "</tool_call>",
+    ]
+
+    fragments = _argument_fragments(_feed(parser, chunks, request))
+    assert json.loads("".join(fragments)) == {"content": value}
+
+
 def test_streaming_json_matches_non_streaming():
     """Concatenating all streamed ``function.arguments`` fragments and
     ``json.loads``-ing the result must equal the arguments dict

--- a/tests/test_qwen3coder_xml_grammar_558.py
+++ b/tests/test_qwen3coder_xml_grammar_558.py
@@ -159,17 +159,11 @@ _XML_GOLDEN_LARK = (
     "tag_end: TAG_TEXT\n"
     "SEP: /[ \\t\\r\\n]*/\n"
     "TAG_TEXT: /(.|\\n)*/\n"
-    # The lazy string-value construct: XML_PARAM_TEXT admits ANY byte (``<``
-    # included); the lazy rule binds it to the FIRST ``</parameter>``.
-    "XML_PARAM_TEXT: /(.|\\n)*/\n"
-    'xml_param_value[lazy]: XML_PARAM_TEXT "</parameter>"\n'
     "\n"
-    # A string value is the lazy rule + only the trailing ``\\n`` separator
-    # (the rule already consumed ``\\n</parameter>``). An enum is a literal
-    # alternation, a scalar is ``%json``; both keep the ``\\n</parameter>\\n``
-    # close. Optional params are wrapped in ``( ... )?``.
+    # Strings ride %json so delimiter-looking bytes are payload inside the
+    # quoted JSON string rather than the XML close (#1542).
     'tag_0: <tool_call> "\\n<function=run_code>\\n" '
-    '"<parameter=code>\\n" xml_param_value "\\n" '
+    '"<parameter=code>\\n" %json {"type": "string"} "\\n</parameter>\\n" '
     '"<parameter=language>\\n" ("python" | "cpp") "\\n</parameter>\\n" '
     '( "<parameter=timeout>\\n" %json {"type": "integer"} "\\n</parameter>\\n" )? '
     '( "<parameter=verbose>\\n" %json {"type": "boolean"} "\\n</parameter>\\n" )? '
@@ -201,18 +195,13 @@ def test_xml_lark_frame_and_sentinels():
     assert '"</function>\\n"' in lark
 
 
-def test_xml_string_value_uses_lazy_rule_not_raw_charclass():
-    # GAP #1 fix, at the grammar-string level: a string param value must be the
-    # LAZY ``xml_param_value`` rule (any text up to the first ``</parameter>``),
-    # NOT the pilot's ``XMLSTR: /[^<]*/`` terminal that stopped at any ``<``.
+def test_xml_string_value_uses_json_string_not_delimiter_lazy_rule():
     from vllm_mlx.api.tool_grammar import build_tool_lark
 
     lark = build_tool_lark(XML_TOOLS, "required", [_xml_structure_info("run_code")])
-    # The lazy value construct is declared once and referenced for the string.
-    assert 'xml_param_value[lazy]: XML_PARAM_TEXT "</parameter>"' in lark
-    assert "XML_PARAM_TEXT: /(.|\\n)*/" in lark
-    assert '"<parameter=code>\\n" xml_param_value "\\n"' in lark
-    # The truncating raw terminal is GONE.
+    assert '"<parameter=code>\\n" %json {"type": "string"}' in lark
+    assert "xml_param_value" not in lark
+    assert "XML_PARAM_TEXT" not in lark
     assert "XMLSTR" not in lark
     assert "/[^<]*/" not in lark
 
@@ -224,7 +213,10 @@ def test_xml_required_vs_optional_framing():
 
     lark = build_tool_lark(XML_TOOLS, "required", [_xml_structure_info("run_code")])
     # Required string: bare (not inside a ``( ... )?`` group).
-    assert '"<parameter=code>\\n" xml_param_value "\\n" "<parameter=language>' in lark
+    assert (
+        '"<parameter=code>\\n" %json {"type": "string"} '
+        '"\\n</parameter>\\n" "<parameter=language>' in lark
+    )
     # Optional scalars: each wrapped in an optional group.
     assert (
         '( "<parameter=timeout>\\n" %json {"type": "integer"} "\\n</parameter>\\n" )?'
@@ -269,10 +261,7 @@ def test_xml_ref_defs_propagated_into_value_schema():
     assert f"%json {json.dumps(expected_schema)}" in lark
 
 
-def test_xml_no_string_param_tool_still_declares_lazy_rule():
-    # An XML tool with NO string params still declares the lazy rule (arg_style
-    # is xml). The unused rule must not break the grammar (a reference-free rule
-    # is tolerated) — the enforcement test below compiles exactly such a case.
+def test_xml_no_string_param_tool_has_no_string_helper_rule():
     from vllm_mlx.api.tool_grammar import build_tool_lark
 
     int_only = [
@@ -287,8 +276,8 @@ def test_xml_no_string_param_tool_still_declares_lazy_rule():
         }
     ]
     lark = build_tool_lark(int_only, "required", [_xml_structure_info("cfg")])
-    assert "xml_param_value[lazy]:" in lark
-    assert "xml_param_value" not in lark.split("\ntag_0:", 1)[1]  # unused in the tag
+    assert "xml_param_value" not in lark
+    assert "XML_PARAM_TEXT" not in lark
 
 
 # --------------------------------------------------------------------------
@@ -517,7 +506,7 @@ def _wire(code, *, language="python", timeout=None, verbose=None):
     """Build the Qwen3-Coder XML wire for the ``run_code`` tool."""
     s = (
         "<tool_call>\n<function=run_code>\n"
-        f"<parameter=code>\n{code}\n</parameter>\n"
+        f"<parameter=code>\n{json.dumps(code, ensure_ascii=False)}\n</parameter>\n"
         f"<parameter=language>\n{language}\n</parameter>\n"
     )
     if timeout is not None:
@@ -592,17 +581,13 @@ def test_xml_normal_value_still_round_trips_no_regression(tok, lltok):
 
 
 @_requires_llguidance
-def test_xml_value_containing_close_tag_closes_at_first(tok, lltok):
-    # FIRST-``</parameter>`` semantics (same as XGrammar, acceptable): a value
-    # that literally contains ``</parameter>`` closes THERE, so the trailing
-    # remainder is not part of a single value and the full wire is not a
-    # complete derivation (accepted < total). This pins the documented behavior.
+def test_xml_value_containing_close_tag_is_data_not_a_delimiter(tok, lltok):
     grammar = _xml_grammar(XML_TOOLS, "required", tok)
-    accepted, total, _ = _consume(grammar, lltok, tok, _wire("a</parameter>b"))
-    assert accepted < total, (
-        "a value literally containing </parameter> must close at the FIRST one "
-        "(XGrammar semantics), not swallow the rest of the wire"
-    )
+    wire = _wire("a</parameter>b")
+    accepted, total, accepting = _consume(grammar, lltok, tok, wire)
+    assert accepted == total and accepting
+    _, args = _parse(wire, XML_TOOLS)
+    assert args["code"] == "a</parameter>b"
 
 
 @_requires_llguidance
@@ -1019,7 +1004,7 @@ def test_representable_total_required_guard_never_raises():
 
 
 # ---- F3 REAL FIX: $ref resolved BEFORE the string-vs-%json decision ------
-def test_xml_ref_to_string_uses_raw_lazy_path_not_json():
+def test_xml_ref_to_string_uses_json_string_path():
     # Grammar-string level: a `$ref` -> string property emits the LAZY raw value
     # rule, NOT `%json` (whose quotes the parser would keep). The tool's only
     # param is a `$ref` -> string, so the whole grammar has NO `%json` at all.
@@ -1028,8 +1013,8 @@ def test_xml_ref_to_string_uses_raw_lazy_path_not_json():
     lark = build_tool_lark(
         XML_REF_STRING_TOOL, "required", [_xml_structure_info("geo")]
     )
-    assert '"<parameter=city>\\n" xml_param_value "\\n"' in lark
-    assert "%json" not in lark
+    assert '"<parameter=city>\\n" %json' in lark
+    assert "xml_param_value" not in lark
 
 
 def test_xml_ref_to_object_still_uses_json():
@@ -1051,7 +1036,7 @@ def test_xml_ref_to_string_roundtrips_without_quotes(tok, lltok):
     assert grammar is not None
     wire = (
         "<tool_call>\n<function=geo>\n"
-        "<parameter=city>\nParis\n</parameter>\n"
+        '<parameter=city>\n"Paris"\n</parameter>\n'
         "</function>\n</tool_call>"
     )
     accepted, total, accepting = _consume(grammar, lltok, tok, wire)

--- a/tests/test_tool_call_value_fidelity.py
+++ b/tests/test_tool_call_value_fidelity.py
@@ -197,11 +197,6 @@ KNOWN_BROKEN: dict[tuple[str, str, str], str] = {
     #     `vllm_mlx/tool_call_scan` fixes both for tool_calling.py, nemotron
     #     and hermes; porting is mechanical but touches qwen3coder's four
     #     instance-level regexes across the streaming and non-streaming paths.
-    ("qwen3_coder_xml", "xml_body", "literal_close_tool_call"): "own scan",
-    ("qwen3_coder_xml", "xml_body", "literal_close_parameter"): "own scan",
-    ("qwen3_coder_xml", "xml_body", "literal_close_function"): "own scan",
-    ("qwen3_coder_xml", "xml_body", "literal_open_parameter"): "own scan",
-    ("qwen3_coder_xml", "xml_body", "literal_open_and_close"): "own scan",
     ("minicpm", "minicpm_native", "literal_close_tool_call"): "own scan",
     ("minicpm", "minicpm_native", "literal_close_parameter"): "own scan",
     ("minicpm", "minicpm_native", "literal_close_function"): "own scan",

--- a/vllm_mlx/api/tool_grammar.py
+++ b/vllm_mlx/api/tool_grammar.py
@@ -395,39 +395,6 @@ def _emit_literal_with_sentinels(text: str, sentinels: tuple[str, ...]) -> str:
     return " ".join(p for p in parts if p)
 
 
-# The raw-string value construct used by the XML arg body (see
-# ``_emit_xml_param_value``). A Qwen3-Coder string parameter value is "any text
-# up to the FIRST literal ``</parameter>`` close tag" — so a value MAY contain a
-# literal ``<`` (a ``code`` arg such as ``a < b``, ``<html>...``, or C++
-# ``vector<int>``), it just may not contain the whole ``</parameter>`` delimiter.
-# We express that with llguidance's first-class LAZY lexeme (``rule[lazy]:``): a
-# lazy rule matches its leading text terminal MINIMALLY, stopping at the first
-# occurrence of the trailing literal. This is the exact idiom llguidance's own
-# ``StructTag.to_grammar`` uses for "text until a tag" (``_struct_tag.py``:
-# ``..._trig[lazy]: TAG_TEXT <trigger>``), and it mirrors XGrammar's ``qwen_xml``
-# style (value = any text up to the first ``</parameter>``).
-#
-# ``XML_PARAM_TEXT: /(.|\n)*/`` admits ANY byte (crucially including ``<``); the
-# lazy rule then binds it to the ``</parameter>`` delimiter so the value
-# terminates at the first close. The lazy rule consumes the value, the single
-# ``\n`` the wire puts BEFORE ``</parameter>``, AND the ``</parameter>`` tag
-# itself — so ``_emit_xml_param_value`` appends only the trailing ``\n`` (the
-# separator AFTER the close). The ``qwen3_coder`` parser strips the leading /
-# trailing ``\n`` from the captured value, so this reproduces the exact surface
-# form it round-trips. FIRST-``</parameter>`` semantics: a value that literally
-# contains ``</parameter>`` closes there (same as XGrammar — acceptable).
-# NOTE (previous limitation, now FIXED): the pilot used ``XMLSTR: /[^<]*/`` which
-# stopped at ANY ``<`` and thus SILENTLY TRUNCATED a ``<``-containing code arg.
-_XML_STRING_VALUE_TERMINAL = "XML_PARAM_TEXT"
-_XML_STRING_VALUE_RULE = "xml_param_value"
-# ``\\n`` here is a LITERAL backslash-n (the Lark regex ``/(.|\n)*/``), matching
-# how ``TAG_TEXT`` is declared; the trailing ``\n`` are real line breaks.
-_XML_STRING_TERMINAL_DECL = (
-    f"{_XML_STRING_VALUE_TERMINAL}: /(.|\\n)*/\n"
-    f'{_XML_STRING_VALUE_RULE}[lazy]: {_XML_STRING_VALUE_TERMINAL} "</parameter>"\n'
-)
-
-
 # The gemma4 string-value construct (#558 E4). A string value is wrapped in the
 # ``<|"|>`` marker, a SINGLE SPECIAL TOKEN (id 52 on the target tokenizer). The
 # value is a RULE ``<|"|> GEMMA_STR_TEXT <|"|>`` with BOTH ``<|"|>`` as RULE-LEVEL
@@ -1083,15 +1050,8 @@ def _emit_xml_param_value(subschema: Any, defs: dict[str, Any]) -> str:
       * ENUM -> an alternation of the literal enum values (raw string form for
         string enums, JSON scalar for numeric/bool enums), then the
         ``\\n</parameter>\\n`` close.
-      * STRING (non-enum) -> the LAZY ``xml_param_value`` rule (NOT ``%json``,
-        whose surrounding quotes the parser keeps verbatim, yielding
-        ``"\\"Paris\\""``). The lazy rule matches ANY text (``<`` included) up to
-        AND INCLUDING the first ``</parameter>`` — so it absorbs the value, the
-        ``\\n`` before ``</parameter>``, AND the ``</parameter>`` tag itself. The
-        close appended here is therefore just the trailing ``\\n`` separator (NO
-        ``</parameter>`` — the rule already consumed it). This is what lets a
-        ``<``-containing code arg (``a < b``, ``vector<int>``) round-trip instead
-        of truncating at the first ``<`` (the pilot's ``/[^<]*/`` bug).
+      * STRING (non-enum) -> a ``%json`` string. Its quoting/escaping layer makes
+        delimiter-looking text payload rather than XML structure (#1542).
       * EVERYTHING ELSE (number / integer / boolean / object / array / null) ->
         JSON-constrained via ``%json`` (these surface forms match the parser's
         int / float / bool / ``json.loads`` paths), then the ``\\n</parameter>\\n``
@@ -1101,17 +1061,10 @@ def _emit_xml_param_value(subschema: Any, defs: dict[str, Any]) -> str:
     ``%json`` value sub-schema so an internal ``$ref`` still resolves.
     """
     close_json = _lark_escape("\n</parameter>\n")
-    # The lazy rule already consumed ``\n</parameter>``; only the trailing
-    # separator newline (AFTER the close tag) remains for the string case.
-    close_lazy = _lark_escape("\n")
     if not isinstance(subschema, dict):
-        return f"{_XML_STRING_VALUE_RULE} {close_lazy}"
-    # F3 (#558 E3 codex converge): resolve a single-level local ``$ref`` BEFORE
-    # the enum/string-vs-``%json`` decision, so a ``$ref``->string takes the
-    # RAW-string (lazy) path and round-trips WITHOUT surrounding quotes — the
-    # pilot attached ``$defs`` only AFTER this decision, so a ``$ref``->string
-    # fell through to ``%json`` and emitted QUOTED JSON the parser returned with
-    # quotes preserved (``"\\"Paris\\""``). A ``$ref``->object still takes the
+        return f"%json {json.dumps({'type': 'string'})} {close_json}"
+    # Resolve a single-level local ``$ref`` before the string-vs-object decision.
+    # The parser decodes the JSON-string wire quotes; a ``$ref``->object takes the
     # ``%json`` path below (over the ORIGINAL ``$ref`` + merged ``$defs``, which
     # llguidance resolves internally). ``_resolve_local_ref`` returns the schema
     # unchanged when there is no ``$ref``; a ``None`` (unresolvable) is defensive
@@ -1132,12 +1085,15 @@ def _emit_xml_param_value(subschema: Any, defs: dict[str, Any]) -> str:
             literal = value if isinstance(value, str) else json.dumps(value)
             alts.append(_lark_escape(literal))
         return f"({' | '.join(alts)}) {close_json}"
-    # Lazy import: keep this module importable independently of api.tool_calling
+    # Keep this module importable independently of api.tool_calling
     # (no cycle today, but the lazy import future-proofs it).
     from .tool_calling import _schema_type
 
     if _schema_type(resolved) == "string":
-        return f"{_XML_STRING_VALUE_RULE} {close_lazy}"
+        value_schema = dict(subschema)
+        for def_key, def_val in defs.items():
+            value_schema.setdefault(def_key, def_val)
+        return f"%json {json.dumps(value_schema)} {close_json}"
     value_schema = dict(subschema)
     for def_key, def_val in defs.items():
         value_schema.setdefault(def_key, def_val)
@@ -1665,15 +1621,6 @@ def build_tool_lark(
         )
         prefix_ref = "bal_prefix"
 
-    # Declare the lazy string-value construct (``XML_PARAM_TEXT`` terminal +
-    # ``xml_param_value[lazy]`` rule) ONCE, iff any tag uses the XML arg body
-    # (``arg_style == "xml"``). A JSON-only tool-set (hermes/qwen/harmony) never
-    # emits it, so its grammar is byte-identical to before this change. The rule
-    # is declared whenever ANY xml tag is present (even one with no string
-    # params); llguidance tolerates the reference-free rule, and gating it on the
-    # per-param string check would need a second schema walk for no benefit.
-    if any(getattr(si, "arg_style", "json") == "xml" for si in structure_infos):
-        lark += _XML_STRING_TERMINAL_DECL
     # Same for the gemma4 string-value rule (``<|"|> GEMMA_STR_TEXT <|"|>``),
     # declared once iff any tag uses the gemma4 arg body. A JSON/XML-only tool-set
     # never emits it, so those grammars stay byte-identical.

--- a/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
+++ b/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
@@ -32,6 +32,7 @@ from collections.abc import Sequence
 from typing import Any
 
 from ..api.tool_calling import _decode_json_like, _schema_type
+from ..tool_call_scan import split_marked_parameters
 from .abstract_tool_parser import (
     ExtractedToolCallInformation,
     ToolParser,
@@ -94,6 +95,12 @@ def _convert_param_value(
         return _decode_json_like(param_value)
 
     if param_type in ("string", "str", "text", "varchar", "char", "enum"):
+        try:
+            decoded = json.loads(param_value)
+        except (json.JSONDecodeError, TypeError):
+            decoded = None
+        if isinstance(decoded, str):
+            return decoded
         return param_value
     elif param_type.startswith(("int", "uint", "long", "short", "unsigned")):
         try:
@@ -164,8 +171,8 @@ class Qwen3CoderToolParser(ToolParser):
         The ARGUMENTS are an XML body, NOT a JSON object, so we return a
         ``StructureInfo`` with ``arg_style="xml"``: the builder emits one
         ``<parameter=KEY>\\nVALUE\\n</parameter>`` block per schema property, each
-        VALUE constrained per its sub-schema (raw text for strings, ``%json`` for
-        scalars / objects / arrays, an alternation for enums) — see
+        VALUE constrained per its sub-schema (JSON strings for free-form strings,
+        ``%json`` for scalars / objects / arrays, an alternation for enums) — see
         ``vllm_mlx.api.tool_grammar._emit_xml_arg_body``. Those surface forms are
         exactly what ``_parse_xml_function_call`` / ``_convert_param_value``
         round-trip back into JSON ``arguments``.
@@ -315,17 +322,33 @@ class Qwen3CoderToolParser(ToolParser):
         param_config = _get_arguments_config(function_name, tools)
         parameters = function_call_str[end_index + 1 :]
         param_dict = {}
+        parsed = (
+            split_marked_parameters(
+                parameters,
+                r"<parameter=([^>]+)>",
+                self.parameter_end_token,
+                valid_names=set(param_config) or None,
+            )
+            or []
+        )
+        for p_name, p_value in parsed:
+            param_dict[p_name] = _convert_param_value(
+                p_value, p_name, param_config, function_name
+            )
+        # Preserve the upstream recovery behavior for malformed free-form
+        # output that omitted one close tag: the positional scanner correctly
+        # protects complete JSON-string payloads, while this fallback recovers
+        # later declared parameters that would otherwise be swallowed by the
+        # unterminated predecessor. Never overwrite a value the safe scan found.
         for match_text in self.tool_call_parameter_regex.findall(parameters):
             try:
                 idx = match_text.index(">")
             except ValueError:
                 continue
             p_name = match_text[:idx]
-            p_value = str(match_text[idx + 1 :])
-            if p_value.startswith("\n"):
-                p_value = p_value[1:]
-            if p_value.endswith("\n"):
-                p_value = p_value[:-1]
+            if p_name in param_dict or p_name not in param_config:
+                continue
+            p_value = str(match_text[idx + 1 :]).strip("\n")
             param_dict[p_name] = _convert_param_value(
                 p_value, p_name, param_config, function_name
             )
@@ -336,15 +359,14 @@ class Qwen3CoderToolParser(ToolParser):
         }
 
     def _get_function_calls(self, model_output: str) -> list[str]:
-        matched_ranges = self.tool_call_regex.findall(model_output)
-        raw_tool_calls = [m[0] if m[0] else m[1] for m in matched_ranges]
-        if not raw_tool_calls:
-            raw_tool_calls = [model_output]
-
-        raw_function_calls = []
-        for tc in raw_tool_calls:
-            raw_function_calls.extend(self.tool_call_function_regex.findall(tc))
-        return [m[0] if m[0] else m[1] for m in raw_function_calls]
+        calls = []
+        for start in self._function_start_positions(model_output):
+            end = self._top_level_function_close(model_output, start)
+            if end == -1:
+                continue
+            body_start = start + len(self.tool_call_prefix)
+            calls.append(model_output[body_start:end])
+        return calls
 
     @staticmethod
     def _named_tool_choice(request: dict[str, Any] | None) -> str | None:
@@ -525,12 +547,37 @@ class Qwen3CoderToolParser(ToolParser):
                 header_end = text.find(">", next_param + param_open_len)
                 if header_end == -1:
                     return -1
-                pclose = text.find(self.parameter_end_token, header_end + 1)
+                pclose = self._find_parameter_close(text, header_end + 1)
                 if pclose == -1:
                     return -1
                 j = pclose + param_close_len
                 continue
             return next_close
+        return -1
+
+    def _find_parameter_close(self, text: str, value_start: int) -> int:
+        """Find the structural parameter close, skipping JSON-string payload.
+
+        Constrained XML strings are JSON encoded (#1542), so delimiter-looking
+        text inside the quotes is data. Legacy raw model output keeps the old
+        first-close behavior.
+        """
+        i = value_start
+        if i < len(text) and text[i] == "\n":
+            i += 1
+        if i >= len(text) or text[i] != '"':
+            return text.find(self.parameter_end_token, i)
+        i += 1
+        escaped = False
+        while i < len(text):
+            char = text[i]
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == '"':
+                return text.find(self.parameter_end_token, i + 1)
+            i += 1
         return -1
 
     def _top_level_function_close_count(
@@ -584,7 +631,7 @@ class Qwen3CoderToolParser(ToolParser):
                 header_end = text.find(">", next_param + param_open_len)
                 if header_end == -1:
                     return positions
-                close_pos = text.find(self.parameter_end_token, header_end + 1)
+                close_pos = self._find_parameter_close(text, header_end + 1)
                 if close_pos == -1:
                     return positions
                 i = close_pos + param_close_len
@@ -647,7 +694,8 @@ class Qwen3CoderToolParser(ToolParser):
                 self.accumulated_params = {}
                 if self.current_tool_index >= tool_count:
                     self.is_tool_call_started = False
-                return None
+                else:
+                    return None
 
         # Handle content before tool calls. Either opener (wrapper or bare
         # ``<function=``) transitions us out of content-only mode; the
@@ -775,15 +823,11 @@ class Qwen3CoderToolParser(ToolParser):
                     # tool call in one chunk to prevent header-only output
                     # when coarse deltas or max_tokens truncation leave no
                     # further parser calls.
-                    if self.function_end_token in tool_text:
+                    if func_close_idx != -1:
                         tools = None
                         if request and isinstance(request, dict):
                             tools = request.get("tools")
-                        fc = tool_text[
-                            func_start : tool_text.find(
-                                self.function_end_token, func_start
-                            )
-                        ]
+                        fc = tool_text[func_start : -len(self.function_end_token)]
                         parsed = self._parse_xml_function_call(fc, tools)
                         args = parsed["arguments"] if parsed else "{}"
                         self.json_started = True
@@ -881,8 +925,8 @@ class Qwen3CoderToolParser(ToolParser):
                     if value_text.startswith("\n"):
                         value_text = value_text[1:]
 
-                    end_idx = value_text.find(self.parameter_end_token)
-                    if end_idx == -1:
+                    end_idx = self._find_parameter_close(value_text, 0)
+                    if end_idx == -1 and not value_text.startswith('"'):
                         # Defensive fallback: model emitted next-param-prefix,
                         # </function>, or </tool_call> without a </parameter>.
                         # Use any of those as the close to avoid hanging
@@ -932,8 +976,8 @@ class Qwen3CoderToolParser(ToolParser):
                 if value_text.startswith("\n"):
                     value_text = value_text[1:]
 
-                param_end_idx = value_text.find(self.parameter_end_token)
-                if param_end_idx == -1:
+                param_end_idx = self._find_parameter_close(value_text, 0)
+                if param_end_idx == -1 and not value_text.startswith('"'):
                     # Try next parameter or function end as delimiter
                     next_param = value_text.find(self.parameter_prefix)
                     func_end = value_text.find(self.function_end_token)
@@ -951,6 +995,8 @@ class Qwen3CoderToolParser(ToolParser):
                             # emit partial JSON (half an int isn't valid),
                             # so fall through to the existing break path.
                             if _is_string_param(current_param_name, param_config):
+                                if value_text.startswith('"'):
+                                    break
                                 frag = self._emit_string_increment(
                                     current_param_name, value_text
                                 )
@@ -990,9 +1036,7 @@ class Qwen3CoderToolParser(ToolParser):
             # document instead of leaving the close stranded for a later
             # call (which may never come if the stream ended).
             close_pending = (
-                not self.in_param
-                and not self.json_closed
-                and self.function_end_token in tool_text
+                not self.in_param and not self.json_closed and func_close_idx != -1
             )
             if close_pending:
                 self.json_closed = True
@@ -1006,7 +1050,7 @@ class Qwen3CoderToolParser(ToolParser):
                 func_start = tool_text.find(self.tool_call_prefix) + len(
                     self.tool_call_prefix
                 )
-                func_content_end = tool_text.find(self.function_end_token, func_start)
+                func_content_end = len(tool_text) - len(self.function_end_token)
                 if func_content_end != -1:
                     fc = tool_text[func_start:func_content_end]
                     try:


### PR DESCRIPTION
## Why

Closes #1542. The Qwen3-Coder XML grammar represented free-form strings as text up to the first `</parameter>`. The matcher therefore forced generation to close at a literal delimiter inside file content, silently truncating the argument before parsing.

## What changed

Free-form XML string parameters now use a JSON-string value inside the existing XML frame. JSON quoting supplies the escaping layer the XML wire lacks, making `</parameter>`, `</function>`, and `</tool_call>` ordinary payload. The parser decodes those wire quotes and structural scanners skip delimiter-shaped text inside a quoted JSON string. Legacy unconstrained raw-string output and malformed-close recovery remain supported.

## Validation

- Real llguidance matcher + pinned Qwen3-Coder tokenizer accepts an embedded `</parameter>` and reaches a terminal state.
- Non-streaming and chunked streaming round-trip all three XML closers byte-for-byte.
- Extended grammar/parser matrix: 554 passed, 26 skipped.
- Ruff lint and format pass.