### PR TITLE
fix(mac): recover from launch-time model wedges

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Server/QuickstartModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/QuickstartModel.swift
@@ -380,8 +380,11 @@ enum QuickstartModel {
             stubRevisionMarker, isDirectory: true
         )
         do {
-            try fileManager.removeItem(at: refsMain)
             try fileManager.removeItem(at: quickstartSnapshot)
+            // Keep the ownership marker until the destructive step succeeds;
+            // a transient snapshot-removal failure must remain retryable on
+            // the next launch.
+            try fileManager.removeItem(at: refsMain)
             if try fileManager.contentsOfDirectory(atPath: refs.path).isEmpty {
                 try fileManager.removeItem(at: refs)
             }

--- a/apps/rapid-mac/Sources/Rapid/Server/QuickstartModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/QuickstartModel.swift
@@ -347,17 +347,20 @@ enum QuickstartModel {
         let refsMain = cacheDir
             .appendingPathComponent("refs", isDirectory: true)
             .appendingPathComponent("main")
-        guard let data = try? Data(contentsOf: refsMain),
-              let content = String(data: data, encoding: .utf8) else {
-            return false
-        }
-        let trimmed = content.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard trimmed == stubRevisionMarker else { return false }
+        guard markerMatches(at: refsMain) else { return false }
         let snapshotDir = cacheDir
             .appendingPathComponent("snapshots", isDirectory: true)
             .appendingPathComponent(stubRevisionMarker, isDirectory: true)
         var isDir: ObjCBool = false
         return fileManager.fileExists(atPath: snapshotDir.path, isDirectory: &isDir) && isDir.boolValue
+    }
+
+    private static func markerMatches(at refsMain: URL) -> Bool {
+        guard let data = try? Data(contentsOf: refsMain),
+              let content = String(data: data, encoding: .utf8) else {
+            return false
+        }
+        return content.trimmingCharacters(in: .whitespacesAndNewlines) == stubRevisionMarker
     }
 
     /// Remove only the two directories this installer owns when its source
@@ -369,8 +372,7 @@ enum QuickstartModel {
         fileManager: FileManager
     ) -> InstallOutcome? {
         let attrs = try? fileManager.attributesOfItem(atPath: cacheDir.path)
-        guard attrs?[.type] as? FileAttributeType == .typeDirectory,
-              isOurStub(cacheDir: cacheDir, fileManager: fileManager) else {
+        guard attrs?[.type] as? FileAttributeType == .typeDirectory else {
             return nil
         }
         let refs = cacheDir.appendingPathComponent("refs", isDirectory: true)
@@ -379,8 +381,26 @@ enum QuickstartModel {
         let quickstartSnapshot = snapshots.appendingPathComponent(
             stubRevisionMarker, isDirectory: true
         )
+        guard markerMatches(at: refsMain) else { return nil }
+        // Never traverse a cache-internal directory symlink. The marker read
+        // above can follow one, so ownership alone is insufficient for safe
+        // deletion; both parents must lstat as real directories.
+        let refsAttrs = try? fileManager.attributesOfItem(atPath: refs.path)
+        guard refsAttrs?[.type] as? FileAttributeType == .typeDirectory else {
+            return .failed("stale Quickstart refs path is not a real directory; refusing cleanup")
+        }
+        let snapshotsAttrs = try? fileManager.attributesOfItem(atPath: snapshots.path)
+        if let snapshotsType = snapshotsAttrs?[.type] as? FileAttributeType,
+           snapshotsType != .typeDirectory {
+            return .failed("stale Quickstart snapshots path is not a real directory; refusing cleanup")
+        }
         do {
-            try fileManager.removeItem(at: quickstartSnapshot)
+            // A previous attempt may already have removed the snapshot. The
+            // marker remains the retry token until every destructive step is
+            // complete.
+            if (try? fileManager.attributesOfItem(atPath: quickstartSnapshot.path)) != nil {
+                try fileManager.removeItem(at: quickstartSnapshot)
+            }
             // Keep the ownership marker until the destructive step succeeds;
             // a transient snapshot-removal failure must remain retryable on
             // the next launch.
@@ -388,7 +408,8 @@ enum QuickstartModel {
             if try fileManager.contentsOfDirectory(atPath: refs.path).isEmpty {
                 try fileManager.removeItem(at: refs)
             }
-            if try fileManager.contentsOfDirectory(atPath: snapshots.path).isEmpty {
+            if snapshotsAttrs != nil,
+               try fileManager.contentsOfDirectory(atPath: snapshots.path).isEmpty {
                 try fileManager.removeItem(at: snapshots)
             }
             let remaining = try fileManager.contentsOfDirectory(atPath: cacheDir.path)

--- a/apps/rapid-mac/Sources/Rapid/Server/QuickstartModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/QuickstartModel.swift
@@ -374,10 +374,20 @@ enum QuickstartModel {
             return nil
         }
         let refs = cacheDir.appendingPathComponent("refs", isDirectory: true)
+        let refsMain = refs.appendingPathComponent("main")
         let snapshots = cacheDir.appendingPathComponent("snapshots", isDirectory: true)
+        let quickstartSnapshot = snapshots.appendingPathComponent(
+            stubRevisionMarker, isDirectory: true
+        )
         do {
-            try fileManager.removeItem(at: refs)
-            try fileManager.removeItem(at: snapshots)
+            try fileManager.removeItem(at: refsMain)
+            try fileManager.removeItem(at: quickstartSnapshot)
+            if try fileManager.contentsOfDirectory(atPath: refs.path).isEmpty {
+                try fileManager.removeItem(at: refs)
+            }
+            if try fileManager.contentsOfDirectory(atPath: snapshots.path).isEmpty {
+                try fileManager.removeItem(at: snapshots)
+            }
             let remaining = try fileManager.contentsOfDirectory(atPath: cacheDir.path)
             if remaining.isEmpty {
                 try fileManager.removeItem(at: cacheDir)

--- a/apps/rapid-mac/Sources/Rapid/Server/QuickstartModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/QuickstartModel.swift
@@ -395,6 +395,20 @@ enum QuickstartModel {
             return .failed("stale Quickstart snapshots path is not a real directory; refusing cleanup")
         }
         do {
+            // Re-lstat immediately before mutation. A sync daemon may swap
+            // any checked directory between ownership validation and here.
+            let rootRecheck = try fileManager.attributesOfItem(atPath: cacheDir.path)
+            let refsRecheck = try fileManager.attributesOfItem(atPath: refs.path)
+            guard rootRecheck[.type] as? FileAttributeType == .typeDirectory,
+                  refsRecheck[.type] as? FileAttributeType == .typeDirectory else {
+                return .failed("stale Quickstart cache path changed during cleanup; refusing mutation")
+            }
+            if snapshotsAttrs != nil {
+                let snapshotsRecheck = try fileManager.attributesOfItem(atPath: snapshots.path)
+                guard snapshotsRecheck[.type] as? FileAttributeType == .typeDirectory else {
+                    return .failed("stale Quickstart snapshots path changed during cleanup; refusing mutation")
+                }
+            }
             // A previous attempt may already have removed the snapshot. The
             // marker remains the retry token until every destructive step is
             // complete.

--- a/apps/rapid-mac/Sources/Rapid/Server/QuickstartModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/QuickstartModel.swift
@@ -192,6 +192,10 @@ enum QuickstartModel {
         /// No Quickstart install under the install root for this
         /// alias (slim-DMG never ran, or user pruned the install).
         case noQuickstartModel
+        /// The Quickstart source is gone and the stale HF-cache stub we
+        /// previously fabricated was removed. A real cache entry is never
+        /// eligible for this cleanup.
+        case removedStaleStub
         /// Resolving the user HF cache failed (no HOME / HF_HOME).
         case userCacheUnavailable
         /// FileManager raised during mkdir / symlink / write.
@@ -244,15 +248,18 @@ enum QuickstartModel {
         environment: [String: String] = ProcessInfo.processInfo.environment,
         fileManager: FileManager = .default
     ) -> InstallOutcome {
-        guard let flatModelDir = resolveFlatModelDir(
+        let flatModelDir = resolveFlatModelDir(
             alias: spec.alias,
             installRoot: installRoot,
             fileManager: fileManager
-        ) else {
-            return .noQuickstartModel
-        }
+        )
         guard let userCache = BundledModel.userHFCacheURL(environment: environment) else {
             return .userCacheUnavailable
+        }
+        let cacheDir = userCache.appendingPathComponent(spec.cacheDirName, isDirectory: true)
+        guard let flatModelDir else {
+            return removeStaleStubIfOwned(cacheDir: cacheDir, fileManager: fileManager)
+                ?? .noQuickstartModel
         }
         do {
             try fileManager.createDirectory(
@@ -263,8 +270,6 @@ enum QuickstartModel {
         } catch {
             return .failed("create user cache dir: \(error.localizedDescription)")
         }
-
-        let cacheDir = userCache.appendingPathComponent(spec.cacheDirName, isDirectory: true)
 
         // Three "already correct" shapes — return early without
         // mutation. Order matters:
@@ -353,6 +358,34 @@ enum QuickstartModel {
             .appendingPathComponent(stubRevisionMarker, isDirectory: true)
         var isDir: ObjCBool = false
         return fileManager.fileExists(atPath: snapshotDir.path, isDirectory: &isDir) && isDir.boolValue
+    }
+
+    /// Remove only the two directories this installer owns when its source
+    /// model disappeared. Keeping an unrelated ``blobs`` directory avoids
+    /// deleting data from a partial/real Hub download that happened to share
+    /// the cache entry after our stub was created.
+    private static func removeStaleStubIfOwned(
+        cacheDir: URL,
+        fileManager: FileManager
+    ) -> InstallOutcome? {
+        let attrs = try? fileManager.attributesOfItem(atPath: cacheDir.path)
+        guard attrs?[.type] as? FileAttributeType == .typeDirectory,
+              isOurStub(cacheDir: cacheDir, fileManager: fileManager) else {
+            return nil
+        }
+        let refs = cacheDir.appendingPathComponent("refs", isDirectory: true)
+        let snapshots = cacheDir.appendingPathComponent("snapshots", isDirectory: true)
+        do {
+            try fileManager.removeItem(at: refs)
+            try fileManager.removeItem(at: snapshots)
+            let remaining = try fileManager.contentsOfDirectory(atPath: cacheDir.path)
+            if remaining.isEmpty {
+                try fileManager.removeItem(at: cacheDir)
+            }
+            return .removedStaleStub
+        } catch {
+            return .failed("remove stale Quickstart stub: \(error.localizedDescription)")
+        }
     }
 
     /// Verify every leaf symlink in our stub still points at the

--- a/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
@@ -187,6 +187,9 @@ struct ChatView: View {
     /// hero and the composer read their copy off this, so they cannot
     /// describe the same lifecycle differently.
     var readiness: ModelReadiness
+    /// Explicit picker gesture signal used by launch auto-start arbitration.
+    /// Catalog-driven default selection intentionally does not call this.
+    var onUserModelSelection: () -> Void = {}
     /// Perform the readiness banner's next-step action (start, download
     /// & start, retry). Owned by ``ContentView`` because starting a model
     /// is a window-level concern, not a chat-surface one.
@@ -531,7 +534,8 @@ struct ChatView: View {
                 downloads: downloads,
                 alias: $alias,
                 quickstart: quickstart,
-                composerStyle: true
+                composerStyle: true,
+                onUserSelection: onUserModelSelection
             )
             sendOrStopButton
         }

--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -21,6 +21,10 @@ struct ContentView: View {
     @Environment(BrowseApprovalStore.self) private var browseApproval
 
     @State private var alias: String = ""
+    /// Monotonic signal from picker row taps. Catalog initialization also
+    /// writes ``alias``, so the value alone cannot distinguish automation
+    /// from a real user override while launch probing is suspended.
+    @State private var userSelectionRevision: UInt = 0
     /// Which detail surface the sidebar shows (chat vs the Launch page).
     @State private var section: SidebarSection = .chat
     /// An absent telemetry preference is an undecided first run, not
@@ -426,6 +430,7 @@ struct ContentView: View {
                 server: server,
                 alias: $alias,
                 readiness: readiness,
+                onUserModelSelection: { userSelectionRevision &+= 1 },
                 onReadinessAction: performReadinessAction
             )
         case .missing:
@@ -674,6 +679,7 @@ struct ContentView: View {
         _ = QuickstartModel.installAllSnapshotSymlinks()
 
         let aliasAtEntry = alias
+        let userSelectionRevisionAtEntry = userSelectionRevision
         var cachedAliases: Set<String> = []
         if let binary = server.binaryPath {
             let entries = await ModelCatalogCache.shared.entries(
@@ -686,7 +692,11 @@ struct ContentView: View {
             autoStartPendingDownload = nil
             return
         }
-        if Self.launchSelectionWasReplaced(aliasAtEntry: aliasAtEntry, currentAlias: alias) {
+        if Self.launchSelectionWasReplaced(
+            aliasAtEntry: aliasAtEntry,
+            currentAlias: alias,
+            userSelectionChanged: userSelectionRevision != userSelectionRevisionAtEntry
+        ) {
             autoStartPendingDownload = nil
             return
         }
@@ -747,9 +757,11 @@ struct ContentView: View {
     /// must stand down.
     nonisolated static func launchSelectionWasReplaced(
         aliasAtEntry: String,
-        currentAlias: String
+        currentAlias: String,
+        userSelectionChanged: Bool = false
     ) -> Bool {
-        !aliasAtEntry.isEmpty && !currentAlias.isEmpty && currentAlias != aliasAtEntry
+        userSelectionChanged
+            || (!aliasAtEntry.isEmpty && !currentAlias.isEmpty && currentAlias != aliasAtEntry)
     }
 
     // MARK: - Pure helpers (testable seams)

--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -745,7 +745,7 @@ struct ContentView: View {
     /// override. Once launch entered with a concrete selection, however, a
     /// different non-empty alias means the user took control and auto-start
     /// must stand down.
-    static func launchSelectionWasReplaced(
+    nonisolated static func launchSelectionWasReplaced(
         aliasAtEntry: String,
         currentAlias: String
     ) -> Bool {

--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -686,7 +686,7 @@ struct ContentView: View {
             autoStartPendingDownload = nil
             return
         }
-        if alias != aliasAtEntry, !alias.isEmpty {
+        if Self.launchSelectionWasReplaced(aliasAtEntry: aliasAtEntry, currentAlias: alias) {
             autoStartPendingDownload = nil
             return
         }
@@ -738,6 +738,18 @@ struct ContentView: View {
         case .skip:
             autoStartPendingDownload = nil
         }
+    }
+
+    /// Catalog loading may populate an initially-empty picker while the
+    /// launch probe awaits subprocesses. That is initialization, not a user
+    /// override. Once launch entered with a concrete selection, however, a
+    /// different non-empty alias means the user took control and auto-start
+    /// must stand down.
+    static func launchSelectionWasReplaced(
+        aliasAtEntry: String,
+        currentAlias: String
+    ) -> Bool {
+        !aliasAtEntry.isEmpty && !currentAlias.isEmpty && currentAlias != aliasAtEntry
     }
 
     // MARK: - Pure helpers (testable seams)

--- a/apps/rapid-mac/Sources/Rapid/UI/ModelPickerBar.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ModelPickerBar.swift
@@ -1707,7 +1707,10 @@ struct ModelPickerBar: View {
     /// button so both paths behave identically.
     private func commitCustomAlias() {
         let trimmed = customDraft.trimmingCharacters(in: .whitespacesAndNewlines)
-        if !trimmed.isEmpty { alias = trimmed }
+        if !trimmed.isEmpty {
+            onUserSelection()
+            alias = trimmed
+        }
         showCustom = false
     }
 

--- a/apps/rapid-mac/Sources/Rapid/UI/ModelPickerBar.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ModelPickerBar.swift
@@ -77,6 +77,9 @@ struct ModelPickerBar: View {
     /// send). All the catalog/recommendation/download/delete logic still
     /// applies; only the surrounding control strip is dropped.
     var composerStyle: Bool = false
+    /// Called only for explicit model-row gestures, never when catalog
+    /// initialization fills an empty selection.
+    var onUserSelection: () -> Void = {}
 
     /// The alias the Quickstart flow is currently aimed at — the wizard's
     /// live selection (#1524) while a coordinator is attached, else the
@@ -713,6 +716,7 @@ struct ModelPickerBar: View {
     /// ``entryLabel`` comment for the same trap).
     private func quickstartRow(entry: ModelEntry) -> some View {
         return Button {
+            onUserSelection()
             alias = entry.alias
         } label: {
             Label(
@@ -922,6 +926,7 @@ struct ModelPickerBar: View {
         // inside a ``Menu`` is silently dropped once the dropdown becomes
         // an NSMenu — and doubles as the row's accessibility label.
         return Button {
+            onUserSelection()
             alias = entry.alias
         } label: {
             // The image slot carries download state, uniformly with
@@ -1038,6 +1043,7 @@ struct ModelPickerBar: View {
     private func aliasButton(_ entry: ModelEntry) -> some View {
         let bucket = ModelPickerVisibility.qualityBucket(for: entry.alias)
         return Button {
+            onUserSelection()
             alias = entry.alias
         } label: {
             entryLabel(entry, bucket: bucket)

--- a/apps/rapid-mac/Tests/RapidTests/AutoStartDecisionTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/AutoStartDecisionTests.swift
@@ -499,6 +499,19 @@ struct AutoStartDecisionTests {
         #expect(AutoStartPreference.defaultValue == true)
     }
 
+    @Test("launch catalog initialization does not cancel auto-start")
+    func launchCatalogInitializationIsNotUserOverride() {
+        #expect(!ContentView.launchSelectionWasReplaced(
+            aliasAtEntry: "", currentAlias: "bonsai-1.7b-2bit"
+        ))
+        #expect(ContentView.launchSelectionWasReplaced(
+            aliasAtEntry: "bonsai-1.7b-2bit", currentAlias: "qwen3.5-4b-4bit"
+        ))
+        #expect(!ContentView.launchSelectionWasReplaced(
+            aliasAtEntry: "bonsai-1.7b-2bit", currentAlias: "bonsai-1.7b-2bit"
+        ))
+    }
+
     /// FU-1 mid-session flip safety: a user who toggles the pref ON
     /// mid-session (the toggle was OFF at process launch, the user
     /// then flipped it on in Settings) must still be able to use

--- a/apps/rapid-mac/Tests/RapidTests/AutoStartDecisionTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/AutoStartDecisionTests.swift
@@ -505,6 +505,9 @@ struct AutoStartDecisionTests {
             aliasAtEntry: "", currentAlias: "bonsai-1.7b-2bit"
         ))
         #expect(ContentView.launchSelectionWasReplaced(
+            aliasAtEntry: "", currentAlias: "qwen3.5-4b-4bit", userSelectionChanged: true
+        ))
+        #expect(ContentView.launchSelectionWasReplaced(
             aliasAtEntry: "bonsai-1.7b-2bit", currentAlias: "qwen3.5-4b-4bit"
         ))
         #expect(!ContentView.launchSelectionWasReplaced(

--- a/apps/rapid-mac/Tests/RapidTests/QuickstartModelTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/QuickstartModelTests.swift
@@ -409,6 +409,34 @@ struct QuickstartModelTests {
         #expect(FileManager.default.fileExists(atPath: sentinel.path))
     }
 
+    @Test("missing source removes Quickstart leaves but preserves coexisting HF revisions")
+    func missingSourcePreservesCoexistingHFRevision() throws {
+        let env = try TestEnv.make()
+        defer { env.tearDown() }
+        let spec = QuickstartModel.knownAliases["bonsai-1.7b-2bit"]!
+        let flat = try stageFlatModel(alias: spec.alias, installRoot: env.installRoot)
+        #expect(QuickstartModel.installSnapshotSymlink(
+            spec: spec, installRoot: env.installRoot, environment: env.envDict
+        ) == .installed)
+        let cacheDir = env.userHubURL.appendingPathComponent(spec.cacheDirName)
+        let pinnedRef = cacheDir.appendingPathComponent("refs/v1")
+        let realSnapshot = cacheDir.appendingPathComponent("snapshots/abc123")
+        try Data("abc123".utf8).write(to: pinnedRef)
+        try FileManager.default.createDirectory(at: realSnapshot, withIntermediateDirectories: true)
+        let realWeight = realSnapshot.appendingPathComponent("weights.safetensors")
+        try Data("real".utf8).write(to: realWeight)
+        try FileManager.default.removeItem(at: flat.deletingLastPathComponent())
+
+        #expect(QuickstartModel.installSnapshotSymlink(
+            spec: spec, installRoot: env.installRoot, environment: env.envDict
+        ) == .removedStaleStub)
+        #expect(FileManager.default.fileExists(atPath: pinnedRef.path))
+        #expect(FileManager.default.fileExists(atPath: realWeight.path))
+        #expect(!FileManager.default.fileExists(
+            atPath: cacheDir.appendingPathComponent("snapshots/quickstart").path
+        ))
+    }
+
     @Test("installSnapshotSymlink is userCacheUnavailable without HOME / HF env")
     func installNoUserCache() throws {
         let env = try TestEnv.make()

--- a/apps/rapid-mac/Tests/RapidTests/QuickstartModelTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/QuickstartModelTests.swift
@@ -375,6 +375,40 @@ struct QuickstartModelTests {
         ) == .noQuickstartModel)
     }
 
+    @Test("missing Quickstart source removes only our dangling HF cache stub")
+    func missingSourceRemovesOwnedDanglingStub() throws {
+        let env = try TestEnv.make()
+        defer { env.tearDown() }
+        let spec = QuickstartModel.knownAliases["bonsai-1.7b-2bit"]!
+        let flat = try stageFlatModel(alias: spec.alias, installRoot: env.installRoot)
+        #expect(QuickstartModel.installSnapshotSymlink(
+            spec: spec, installRoot: env.installRoot, environment: env.envDict
+        ) == .installed)
+        try FileManager.default.removeItem(at: flat.deletingLastPathComponent())
+
+        #expect(QuickstartModel.installSnapshotSymlink(
+            spec: spec, installRoot: env.installRoot, environment: env.envDict
+        ) == .removedStaleStub)
+        let cacheDir = env.userHubURL.appendingPathComponent(spec.cacheDirName)
+        #expect(!FileManager.default.fileExists(atPath: cacheDir.path))
+    }
+
+    @Test("missing Quickstart source never removes a real HF cache entry")
+    func missingSourcePreservesRealCache() throws {
+        let env = try TestEnv.make()
+        defer { env.tearDown() }
+        let spec = QuickstartModel.knownAliases["bonsai-1.7b-2bit"]!
+        let cacheDir = env.userHubURL.appendingPathComponent(spec.cacheDirName)
+        try FileManager.default.createDirectory(at: cacheDir, withIntermediateDirectories: true)
+        let sentinel = cacheDir.appendingPathComponent("user-data")
+        try Data("keep".utf8).write(to: sentinel)
+
+        #expect(QuickstartModel.installSnapshotSymlink(
+            spec: spec, installRoot: env.installRoot, environment: env.envDict
+        ) == .noQuickstartModel)
+        #expect(FileManager.default.fileExists(atPath: sentinel.path))
+    }
+
     @Test("installSnapshotSymlink is userCacheUnavailable without HOME / HF env")
     func installNoUserCache() throws {
         let env = try TestEnv.make()


### PR DESCRIPTION
Closes #1548

## Reproduction
- With the Quickstart install root absent, `installSnapshotSymlink` returned before inspecting its fabricated HF cache entry, leaving dangling fixture-backed symlinks visible to model discovery.
- Launch auto-start captured an empty picker alias, catalog refresh populated it during the async probe, and the post-probe guard treated that initialization as a user override. The hook returned after `ls`/`models`/`info` without calling `serve`.

## Fix
- Prune only Rapid-owned Quickstart stubs (fingerprinted by `refs/main = quickstart`) when their source is gone; preserve real caches, cache-dir symlinks, and unrelated blobs.
- Allow empty-to-populated catalog initialization through the auto-start guard while retaining cancellation for a changed concrete selection.
- Add isolated temp-cache regressions; no test uses the ambient HF cache.

## Validation
- `swift build`
- focused tests added for dangling-stub cleanup, real-cache preservation, and launch selection arbitration
- local `swift test` is currently blocked before execution by main's separate `RapidUXTests` target importing XCTest under CommandLineTools (`no such module XCTest`); GitHub macOS CI is authoritative.

## Landing gate
Do not merge until CI, Codex review, and `pr_validation` are green.