### PR TITLE
fix(mac): pin and validate bundled vision stack

### DIFF
--- a/apps/rapid-mac/Tests/RapidTests/SidecarBuildScriptTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SidecarBuildScriptTests.swift
@@ -41,6 +41,18 @@ struct SidecarBuildScriptTests {
                 "Restricted builders need a single-process compileall override.")
     }
 
+    @Test("Desktop vision stack is exact-pinned and metadata-validated")
+    func visionStackIsReproducibleAndCompatible() throws {
+        let script = try String(contentsOf: Self.scriptURL, encoding: .utf8)
+
+        #expect(script.contains("'mlx-vlm==0.6.3'"))
+        #expect(!script.contains("'mlx-vlm>=0.6.3,!=0.6.4,<0.7'"),
+                "The no-deps sidecar install must never float within a range.")
+        #expect(script.contains("from packaging.requirements import Requirement"))
+        #expect(script.contains("actual not in req.specifier"),
+                "Post-install validation must reject incompatible installed dependency versions.")
+    }
+
     private static var scriptURL: URL {
         URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()

--- a/apps/rapid-mac/scripts/build-sidecar.sh
+++ b/apps/rapid-mac/scripts/build-sidecar.sh
@@ -270,21 +270,41 @@ fi
 # path. All other eager deps (transformers, requests, huggingface_hub,
 # safetensors, numpy, mlx) are already bundled by rapid-mlx's own
 # install above, so Pillow is the only additional dep we need.
-# We pin to the same ``>=0.6.3,!=0.6.4,<0.7`` range that rapid-mlx's
-# pyproject.toml [vision] extras pin so the bundled mlx-vlm tracks the
-# DiffusionGemma + gemma4_unified architecture support the loader needs.
-# (0.6.4 excluded: garbage vision output — rapid-mlx 0.11.1 serves Bonsai
-# 27B text-only via mlx-lm because of it; this ``--upgrade`` step would
-# otherwise resolve to that broken build.)
+# Pin exactly: this install deliberately uses --no-deps, so a range would let
+# the desktop silently float to an mlx-vlm release whose declared transformers
+# requirement conflicts with the engine's validated <5.13 cap (#1501).
 echo "==> bundling mlx-vlm --no-deps + Pillow (gemma-4 + DiffusionGemma loader path)"
 "$STAGE/python/bin/python3.12" -m pip install \
     --target "$STAGE/site-packages" \
     --no-warn-script-location \
     --no-compile \
     --no-deps \
-    --upgrade \
-    'mlx-vlm>=0.6.3,!=0.6.4,<0.7' \
+    'mlx-vlm==0.6.3' \
     'Pillow>=10.0'
+
+# ``--no-deps`` is intentional for bundle size, but it must not hide version
+# conflicts among distributions that ARE present. Missing optional heavy deps
+# remain allowed; every installed-to-installed edge must satisfy its metadata.
+PYTHONPATH="$STAGE/site-packages" PYTHONNOUSERSITE=1 "$STAGE/python/bin/python3.12" -s - <<'PY'
+from importlib import metadata
+from packaging.requirements import Requirement
+from packaging.utils import canonicalize_name
+
+installed = {canonicalize_name(dist.metadata["Name"]): dist.version for dist in metadata.distributions()}
+errors = []
+for dist in metadata.distributions():
+    owner = dist.metadata["Name"]
+    for raw in dist.requires or ():
+        req = Requirement(raw)
+        if req.marker and not req.marker.evaluate():
+            continue
+        actual = installed.get(canonicalize_name(req.name))
+        if actual is not None and req.specifier and actual not in req.specifier:
+            errors.append(f"{owner} requires {req}, but bundled {req.name}=={actual}")
+if errors:
+    raise SystemExit("incompatible bundled distributions:\n  " + "\n  ".join(sorted(errors)))
+print("==> bundled distribution metadata constraints: OK")
+PY
 
 # ----- step 3: strip dev / unused artifacts ----------------------------
 


### PR DESCRIPTION
Closes #1501

## Reproduction
The desktop sidecar installs `mlx-vlm` with `--no-deps --upgrade` from a range. That deterministically bypasses the bundled `transformers<5.13` constraint and floats each rebuild; the reported bundle landed on mlx-vlm 0.6.10, whose metadata requires transformers >=5.14.

## Fix
- Exact-pin the intentionally no-deps desktop install to validated `mlx-vlm==0.6.3`.
- Remove `--upgrade` from that install.
- Before trimming, validate every installed-to-installed distribution requirement using package metadata. Optional heavy dependencies omitted for bundle size remain allowed, while an incompatible version already present in the bundle fails the build.
- Add source-contract regressions for the exact pin and validation gate.

## Validation
- `bash -n apps/rapid-mac/scripts/build-sidecar.sh`
- `swift build`
- full sidecar build and Swift suite delegated to macOS CI

Do not merge until CI, Codex review, and `pr_validation` are green.