### PR TITLE
fix(mac): publish releases to the canonical remote

### DIFF
--- a/apps/rapid-mac/RELEASING.md
+++ b/apps/rapid-mac/RELEASING.md
@@ -180,11 +180,13 @@ scripts/release-local.sh --publish rapid-mac-v0.11.0
 
 `--publish` does **not** build locally. It preflights (stable
 `rapid-mac-vX.Y.Z` tag, CHANGELOG entry present, tag == plist version, local
-`main` == `origin/main`, tag is new and strictly newer than the latest
+`main` == the release remote's `main`, tag is new and strictly newer than the latest
 rapid-mac release, and the root workflow triggers on the tag) then pushes the
 tag. `.github/workflows/rapid-mac-release.yml` then builds → signs →
 notarises → size-gates → attaches `rapid-mlx-desktop.dmg` to the GitHub
-Release. (You can equally `git push origin rapid-mac-v0.11.0` by hand;
+Release. The script auto-detects the remote whose URL is
+`raullenchai/Rapid-MLX`; set `RAPID_RELEASE_REMOTE=<name>` to select it
+explicitly. (You can equally `git push <release-remote> rapid-mac-v0.11.0` by hand;
 `--publish` only adds the guardrails.)
 
 Watch it:
@@ -213,8 +215,7 @@ already in homebrew-core); the desktop app never claims it.
 
 ## Open TODO(owner) items
 
-- **Release repo owner is `raullenchai`** (`raullenchai/Rapid-MLX`). The
-  release-local `--publish` lane pushes to whatever `origin` points at.
+- **Release repo owner is `raullenchai`** (`raullenchai/Rapid-MLX`).
 - **CDN mirror infra** (`RAPID_MAC_DIST_R2_BUCKET` / `RAPID_MAC_DIST_CDN_BASE`
   + Cloudflare secrets) only needs provisioning if you want a stable
   non-GitHub download URL. Optional.

--- a/apps/rapid-mac/Tests/RapidTests/ReleaseLocalScriptTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ReleaseLocalScriptTests.swift
@@ -8,6 +8,8 @@ struct ReleaseLocalScriptTests {
         let script = try String(contentsOf: Self.scriptURL, encoding: .utf8)
         #expect(script.contains("RAPID_RELEASE_REMOTE"))
         #expect(script.contains("raullenchai/Rapid-MLX"))
+        #expect(script.contains("RELEASE_FETCH_URL"))
+        #expect(script.contains("RELEASE_PUSH_URL"))
         #expect(script.contains(#"git push "$RELEASE_REMOTE" "$TAG""#))
         #expect(!script.contains(#"git push origin "$TAG""#))
         #expect(!script.contains("git rev-parse origin/main"))

--- a/apps/rapid-mac/Tests/RapidTests/ReleaseLocalScriptTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ReleaseLocalScriptTests.swift
@@ -10,6 +10,8 @@ struct ReleaseLocalScriptTests {
         #expect(script.contains("raullenchai/Rapid-MLX"))
         #expect(script.contains("RELEASE_FETCH_URL"))
         #expect(script.contains("RELEASE_PUSH_URL"))
+        #expect(script.contains(#"^https://github\.com/raullenchai/Rapid-MLX"#))
+        #expect(script.contains(#"^git@github\.com:raullenchai/Rapid-MLX"#))
         #expect(script.contains(#"git push "$RELEASE_REMOTE" "$TAG""#))
         #expect(!script.contains(#"git push origin "$TAG""#))
         #expect(!script.contains("git rev-parse origin/main"))

--- a/apps/rapid-mac/Tests/RapidTests/ReleaseLocalScriptTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ReleaseLocalScriptTests.swift
@@ -1,0 +1,23 @@
+import Foundation
+import Testing
+
+@Suite("Local release script")
+struct ReleaseLocalScriptTests {
+    @Test("Publish resolves and validates the canonical release remote")
+    func canonicalRemoteGuard() throws {
+        let script = try String(contentsOf: Self.scriptURL, encoding: .utf8)
+        #expect(script.contains("RAPID_RELEASE_REMOTE"))
+        #expect(script.contains("raullenchai/Rapid-MLX"))
+        #expect(script.contains(#"git push "$RELEASE_REMOTE" "$TAG""#))
+        #expect(!script.contains(#"git push origin "$TAG""#))
+        #expect(!script.contains("git rev-parse origin/main"))
+    }
+
+    private static var scriptURL: URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("scripts/release-local.sh")
+    }
+}

--- a/apps/rapid-mac/scripts/release-local.sh
+++ b/apps/rapid-mac/scripts/release-local.sh
@@ -136,6 +136,12 @@ fi
 
 # ── --publish : guarded tag push → CI does the real release ──────────────
 if [[ "$MODE" == "publish" ]]; then
+    is_canonical_release_url() {
+        [[ "$1" =~ ^https://github\.com/raullenchai/Rapid-MLX(\.git)?$ ]] \
+            || [[ "$1" =~ ^git@github\.com:raullenchai/Rapid-MLX(\.git)?$ ]] \
+            || [[ "$1" =~ ^ssh://git@github\.com/raullenchai/Rapid-MLX(\.git)?$ ]]
+    }
+
     # Resolve the repository that owns the release workflow. ``origin`` is a
     # convention, not an identity: contributor clones commonly point it at
     # upstream. An explicit override wins; otherwise require exactly one
@@ -146,8 +152,8 @@ if [[ "$MODE" == "publish" ]]; then
         while read -r remote; do
             fetch_url="$(git remote get-url --all "$remote" 2>/dev/null || true)"
             push_url="$(git remote get-url --push --all "$remote" 2>/dev/null || true)"
-            [[ "$fetch_url" =~ github\.com[:/]raullenchai/Rapid-MLX(\.git)?$ ]] \
-                && [[ "$push_url" =~ github\.com[:/]raullenchai/Rapid-MLX(\.git)?$ ]] \
+            is_canonical_release_url "$fetch_url" \
+                && is_canonical_release_url "$push_url" \
                 && MATCHING_REMOTES+=("$remote")
         done < <(git remote)
         [[ "${#MATCHING_REMOTES[@]}" -eq 1 ]] \
@@ -160,9 +166,9 @@ if [[ "$MODE" == "publish" ]]; then
         || fail "release remote '$RELEASE_REMOTE' must have exactly one fetch URL."
     [[ "$(printf '%s\n' "$RELEASE_PUSH_URL" | awk 'NF{n++} END{print n+0}')" -eq 1 ]] \
         || fail "release remote '$RELEASE_REMOTE' must have exactly one push URL."
-    [[ "$RELEASE_FETCH_URL" =~ github\.com[:/]raullenchai/Rapid-MLX(\.git)?$ ]] \
+    is_canonical_release_url "$RELEASE_FETCH_URL" \
         || fail "release remote '$RELEASE_REMOTE' fetches from '$RELEASE_FETCH_URL', not raullenchai/Rapid-MLX."
-    [[ "$RELEASE_PUSH_URL" =~ github\.com[:/]raullenchai/Rapid-MLX(\.git)?$ ]] \
+    is_canonical_release_url "$RELEASE_PUSH_URL" \
         || fail "release remote '$RELEASE_REMOTE' pushes to '$RELEASE_PUSH_URL', not raullenchai/Rapid-MLX."
 
     # Stable tags only — the CI publish + in-app updater have no prerelease

--- a/apps/rapid-mac/scripts/release-local.sh
+++ b/apps/rapid-mac/scripts/release-local.sh
@@ -136,6 +136,26 @@ fi
 
 # ── --publish : guarded tag push → CI does the real release ──────────────
 if [[ "$MODE" == "publish" ]]; then
+    # Resolve the repository that owns the release workflow. ``origin`` is a
+    # convention, not an identity: contributor clones commonly point it at
+    # upstream. An explicit override wins; otherwise require exactly one
+    # remote whose URL names the canonical release repository.
+    RELEASE_REMOTE="${RAPID_RELEASE_REMOTE:-}"
+    if [[ -z "$RELEASE_REMOTE" ]]; then
+        MATCHING_REMOTES=()
+        while read -r remote; do
+            url="$(git remote get-url --push "$remote" 2>/dev/null || true)"
+            [[ "$url" =~ github\.com[:/]raullenchai/Rapid-MLX(\.git)?$ ]] \
+                && MATCHING_REMOTES+=("$remote")
+        done < <(git remote)
+        [[ "${#MATCHING_REMOTES[@]}" -eq 1 ]] \
+            || fail "cannot uniquely resolve the raullenchai/Rapid-MLX release remote; set RAPID_RELEASE_REMOTE explicitly."
+        RELEASE_REMOTE="${MATCHING_REMOTES[0]}"
+    fi
+    RELEASE_URL="$(git remote get-url --push "$RELEASE_REMOTE" 2>/dev/null || true)"
+    [[ "$RELEASE_URL" =~ github\.com[:/]raullenchai/Rapid-MLX(\.git)?$ ]] \
+        || fail "release remote '$RELEASE_REMOTE' points to '$RELEASE_URL', not raullenchai/Rapid-MLX."
+
     # Stable tags only — the CI publish + in-app updater have no prerelease
     # channel, so an RC would be offered to stable users (codex r2 MAJOR).
     [[ "$TAG" =~ ^rapid-mac-v[0-9]+\.[0-9]+\.[0-9]+$ ]] \
@@ -153,28 +173,28 @@ if [[ "$MODE" == "publish" ]]; then
     [[ "$PLIST_VERSION" == "$VERSION" ]] \
         || fail "tag $TAG (=$VERSION) != Resources/Info.plist CFBundleShortVersionString ($PLIST_VERSION). Bump the plist first."
 
-    git fetch origin --tags --quiet
+    git fetch "$RELEASE_REMOTE" --tags --quiet
     [[ "$(git rev-parse --abbrev-ref HEAD)" == "main" ]] || fail "publish from main."
 
-    # HEAD must be exactly origin/main — reject BOTH unpushed local commits
+    # HEAD must be exactly the release remote's main — reject BOTH unpushed local commits
     # (which the tag would ship) AND being behind.
     LOCAL_SHA="$(git rev-parse HEAD)"
-    REMOTE_SHA="$(git rev-parse origin/main)"
+    REMOTE_SHA="$(git rev-parse "$RELEASE_REMOTE/main")"
     [[ "$LOCAL_SHA" == "$REMOTE_SHA" ]] \
-        || fail "local main ($LOCAL_SHA) != origin/main ($REMOTE_SHA) — push or pull --ff-only so they match before publishing."
+        || fail "local main ($LOCAL_SHA) != $RELEASE_REMOTE/main ($REMOTE_SHA) — push or pull --ff-only so they match before publishing."
     [[ -z "$(git status --porcelain)" ]] || fail "working tree is dirty — commit before publishing."
 
     # Tag must be new AND strictly newer than the highest published tag —
     # a v0.9.0 after v0.10.3 would roll latest.json backwards.
     if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null \
-       || git ls-remote --exit-code --tags origin "$TAG" >/dev/null 2>&1; then
+       || git ls-remote --exit-code --tags "$RELEASE_REMOTE" "$TAG" >/dev/null 2>&1; then
         fail "tag $TAG already exists — pick the next version."
     fi
     HIGHEST=""
     while read -r t; do
         [[ "$t" =~ ^rapid-mac-v[0-9]+\.[0-9]+\.[0-9]+$ ]] || continue   # ignore prereleases / odd tags / engine tags
         if [[ -z "$HIGHEST" ]] || version_gt "$t" "$HIGHEST"; then HIGHEST="$t"; fi
-    done < <(git ls-remote --tags --refs origin 'rapid-mac-v[0-9]*' 2>/dev/null | sed 's#.*/##')
+    done < <(git ls-remote --tags --refs "$RELEASE_REMOTE" 'rapid-mac-v[0-9]*' 2>/dev/null | sed 's#.*/##')
     if [[ -n "$HIGHEST" ]]; then
         version_gt "$TAG" "$HIGHEST" \
             || fail "tag $TAG is not newer than the latest release $HIGHEST — refusing a backwards release."
@@ -189,9 +209,9 @@ if [[ "$MODE" == "publish" ]]; then
         [[ "${FORCE_PUBLISH:-0}" == 1 ]] || fail "aborting (set FORCE_PUBLISH=1 to push the tag anyway)."
     fi
 
-    note "pushing $TAG → CI will build, notarise, and attach the DMG to the GitHub Release"
+    note "pushing $TAG to $RELEASE_REMOTE → CI will build, notarise, and attach the DMG to the GitHub Release"
     git tag "$TAG"
-    git push origin "$TAG"
+    git push "$RELEASE_REMOTE" "$TAG"
     note 'watch it: gh run watch $(gh run list --workflow=rapid-mac-release.yml --limit=1 --json databaseId -q ".[0].databaseId")'
     printf '\033[32m✅ %s pushed. CI is cutting the public release. (Nothing was built locally.)\033[0m\n' "$TAG"
     exit 0

--- a/apps/rapid-mac/scripts/release-local.sh
+++ b/apps/rapid-mac/scripts/release-local.sh
@@ -144,8 +144,8 @@ if [[ "$MODE" == "publish" ]]; then
     if [[ -z "$RELEASE_REMOTE" ]]; then
         MATCHING_REMOTES=()
         while read -r remote; do
-            fetch_url="$(git remote get-url "$remote" 2>/dev/null || true)"
-            push_url="$(git remote get-url --push "$remote" 2>/dev/null || true)"
+            fetch_url="$(git remote get-url --all "$remote" 2>/dev/null || true)"
+            push_url="$(git remote get-url --push --all "$remote" 2>/dev/null || true)"
             [[ "$fetch_url" =~ github\.com[:/]raullenchai/Rapid-MLX(\.git)?$ ]] \
                 && [[ "$push_url" =~ github\.com[:/]raullenchai/Rapid-MLX(\.git)?$ ]] \
                 && MATCHING_REMOTES+=("$remote")
@@ -154,8 +154,12 @@ if [[ "$MODE" == "publish" ]]; then
             || fail "cannot uniquely resolve the raullenchai/Rapid-MLX release remote; set RAPID_RELEASE_REMOTE explicitly."
         RELEASE_REMOTE="${MATCHING_REMOTES[0]}"
     fi
-    RELEASE_FETCH_URL="$(git remote get-url "$RELEASE_REMOTE" 2>/dev/null || true)"
-    RELEASE_PUSH_URL="$(git remote get-url --push "$RELEASE_REMOTE" 2>/dev/null || true)"
+    RELEASE_FETCH_URL="$(git remote get-url --all "$RELEASE_REMOTE" 2>/dev/null || true)"
+    RELEASE_PUSH_URL="$(git remote get-url --push --all "$RELEASE_REMOTE" 2>/dev/null || true)"
+    [[ "$(printf '%s\n' "$RELEASE_FETCH_URL" | awk 'NF{n++} END{print n+0}')" -eq 1 ]] \
+        || fail "release remote '$RELEASE_REMOTE' must have exactly one fetch URL."
+    [[ "$(printf '%s\n' "$RELEASE_PUSH_URL" | awk 'NF{n++} END{print n+0}')" -eq 1 ]] \
+        || fail "release remote '$RELEASE_REMOTE' must have exactly one push URL."
     [[ "$RELEASE_FETCH_URL" =~ github\.com[:/]raullenchai/Rapid-MLX(\.git)?$ ]] \
         || fail "release remote '$RELEASE_REMOTE' fetches from '$RELEASE_FETCH_URL', not raullenchai/Rapid-MLX."
     [[ "$RELEASE_PUSH_URL" =~ github\.com[:/]raullenchai/Rapid-MLX(\.git)?$ ]] \

--- a/apps/rapid-mac/scripts/release-local.sh
+++ b/apps/rapid-mac/scripts/release-local.sh
@@ -144,17 +144,22 @@ if [[ "$MODE" == "publish" ]]; then
     if [[ -z "$RELEASE_REMOTE" ]]; then
         MATCHING_REMOTES=()
         while read -r remote; do
-            url="$(git remote get-url --push "$remote" 2>/dev/null || true)"
-            [[ "$url" =~ github\.com[:/]raullenchai/Rapid-MLX(\.git)?$ ]] \
+            fetch_url="$(git remote get-url "$remote" 2>/dev/null || true)"
+            push_url="$(git remote get-url --push "$remote" 2>/dev/null || true)"
+            [[ "$fetch_url" =~ github\.com[:/]raullenchai/Rapid-MLX(\.git)?$ ]] \
+                && [[ "$push_url" =~ github\.com[:/]raullenchai/Rapid-MLX(\.git)?$ ]] \
                 && MATCHING_REMOTES+=("$remote")
         done < <(git remote)
         [[ "${#MATCHING_REMOTES[@]}" -eq 1 ]] \
             || fail "cannot uniquely resolve the raullenchai/Rapid-MLX release remote; set RAPID_RELEASE_REMOTE explicitly."
         RELEASE_REMOTE="${MATCHING_REMOTES[0]}"
     fi
-    RELEASE_URL="$(git remote get-url --push "$RELEASE_REMOTE" 2>/dev/null || true)"
-    [[ "$RELEASE_URL" =~ github\.com[:/]raullenchai/Rapid-MLX(\.git)?$ ]] \
-        || fail "release remote '$RELEASE_REMOTE' points to '$RELEASE_URL', not raullenchai/Rapid-MLX."
+    RELEASE_FETCH_URL="$(git remote get-url "$RELEASE_REMOTE" 2>/dev/null || true)"
+    RELEASE_PUSH_URL="$(git remote get-url --push "$RELEASE_REMOTE" 2>/dev/null || true)"
+    [[ "$RELEASE_FETCH_URL" =~ github\.com[:/]raullenchai/Rapid-MLX(\.git)?$ ]] \
+        || fail "release remote '$RELEASE_REMOTE' fetches from '$RELEASE_FETCH_URL', not raullenchai/Rapid-MLX."
+    [[ "$RELEASE_PUSH_URL" =~ github\.com[:/]raullenchai/Rapid-MLX(\.git)?$ ]] \
+        || fail "release remote '$RELEASE_REMOTE' pushes to '$RELEASE_PUSH_URL', not raullenchai/Rapid-MLX."
 
     # Stable tags only — the CI publish + in-app updater have no prerelease
     # channel, so an RC would be offered to stable users (codex r2 MAJOR).


### PR DESCRIPTION
Closes #1500

## Reproduction
`release-local.sh --publish` used `origin` for fetch, main comparison, tag discovery, and push. In contributor-style clones where origin is upstream, every guard inspects the wrong repository and the final command can publish the app tag there.

## Fix
- Honor `RAPID_RELEASE_REMOTE` when explicitly set.
- Otherwise require exactly one push remote whose URL is the canonical `raullenchai/Rapid-MLX` repository.
- Validate the selected remote URL before any fetch/tag mutation.
- Use that remote consistently for main parity, tag checks, and the final push.
- Update release docs and add a source-contract regression.

## Validation
- `bash -n apps/rapid-mac/scripts/release-local.sh`
- `swift build`

Do not merge until CI, Codex review, and `pr_validation` are green.