### PR TITLE
fix(chat): the tool preamble needs a tool result, not just a tool

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
@@ -1027,11 +1027,13 @@ final class ChatViewModel {
             // Ambient anti-confabulation guidance, prepended for the wire body
             // only (never appended to the transcript) so the user's history
             // stays prose-only. Skipped when the transcript already opens with
-            // a system row, and when no tools are advertised.
+            // a system row, when no tools are advertised, and — the point of
+            // #1549 — on rounds that carry no tool result for it to talk about.
             history.insert(
                 contentsOf: ChatViewModel.ambientSystemMessages(
                     historyOpensWithSystem: history.first?.role == .system,
-                    toolsAdvertised: !definitions.isEmpty
+                    toolsAdvertised: !definitions.isEmpty,
+                    toolResultPresent: history.contains { $0.role == .tool }
                 ),
                 at: 0
             )
@@ -1232,19 +1234,39 @@ final class ChatViewModel {
         return "unknown tool '\(name)'\(list.isEmpty ? "" : " — available: \(list)"). Answer directly instead."
     }
 
-    /// Ambient anti-confabulation guidance — prepended to the wire body
-    /// whenever at least one tool is advertised.
+    /// Ambient anti-confabulation guidance — prepended to the wire body on
+    /// rounds where a tool result is actually in play.
     ///
     /// Small models routinely fire a tool, get faithful snippets back, then
     /// fabricate the rest of the list from training-data priors. The preamble
-    /// is the cheapest mitigation and costs nothing when no tool is offered.
+    /// is the cheapest mitigation against that.
+    ///
+    /// It is gated on a tool RESULT being present, not merely on a tool being
+    /// advertised. The rules it states ("if a fact is not in the tool result,
+    /// you DO NOT KNOW IT") describe how to read a result that exists; a model
+    /// shown them with no result in context can only conclude it knows nothing.
+    /// That is not hypothetical — issue #1549: with the built-in web tools
+    /// advertised by default, the preamble rode along on every first turn and
+    /// the shipped starter model answered "I don't have access to current or
+    /// external data" to *what is the capital of France?*, a question it
+    /// answers correctly the moment the preamble is absent.
+    ///
+    /// Both conditions are required rather than just the result: a transcript
+    /// can carry ``.tool`` rows from an earlier round after the user has since
+    /// disabled the tool, and re-asserting "your only source of truth is the
+    /// tool result" would then bind the model to a result it can no longer
+    /// refresh.
+    ///
     /// Returns an empty array when the transcript already opens with a
     /// ``role: "system"`` row so we never ship competing system messages.
     static func ambientSystemMessages(
         historyOpensWithSystem: Bool,
-        toolsAdvertised: Bool
+        toolsAdvertised: Bool,
+        toolResultPresent: Bool
     ) -> [ChatMessage] {
-        guard !historyOpensWithSystem, toolsAdvertised else { return [] }
+        guard !historyOpensWithSystem, toolsAdvertised, toolResultPresent else {
+            return []
+        }
         return [ChatMessage(role: .system, content: toolGuidancePreamble, status: .complete)]
     }
 

--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
@@ -1029,14 +1029,15 @@ final class ChatViewModel {
             // stays prose-only. Skipped when the transcript already opens with
             // a system row, when no tools are advertised, and — the point of
             // #1549 — on rounds that carry no tool result for it to talk about.
-            history.insert(
-                contentsOf: ChatViewModel.ambientSystemMessages(
-                    historyOpensWithSystem: history.first?.role == .system,
-                    toolsAdvertised: !definitions.isEmpty,
-                    toolResultPresent: history.contains { $0.role == .tool }
-                ),
-                at: 0
+            let ambient = ChatViewModel.ambientSystemMessages(
+                historyOpensWithSystem: history.first?.role == .system,
+                toolsAdvertised: !definitions.isEmpty,
+                toolResultPresent: ChatViewModel.carriesToolResultForThisTurn(history)
             )
+            // Inserted BEFORE the trim so its tokens are inside the budget the
+            // trim works to, not added on top of a body already sized to fill
+            // the window.
+            history.insert(contentsOf: ambient, at: 0)
             // v0.5.11 / issue #363: silent context-window trim against the
             // engine-reported window (captured on the last profile fetch),
             // falling back to the per-family heuristic in ``ModelInfoCatalog``.
@@ -1051,6 +1052,19 @@ final class ChatViewModel {
                 history,
                 contextWindow: ctxWindow
             )
+            // The trim drops the oldest rows to fit and deliberately preserves
+            // a leading system row, so on an over-budget turn it can carry the
+            // preamble through while taking the tool result it describes. That
+            // puts "your only source of truth is the tool result" on the wire
+            // with no tool result behind it — #1549 again, just needing a long
+            // enough conversation to reach. If the evidence didn't survive,
+            // neither does the instruction.
+            if !ambient.isEmpty,
+                history.first?.content == ChatViewModel.toolGuidancePreamble,
+                !ChatViewModel.carriesToolResultForThisTurn(history)
+            {
+                history.removeFirst()
+            }
             let request: ChatStreamClient.Request
             if let s = sampling {
                 let resolved = s.resolved(toolsEnabled: !definitions.isEmpty)
@@ -1259,6 +1273,20 @@ final class ChatViewModel {
     ///
     /// Returns an empty array when the transcript already opens with a
     /// ``role: "system"`` row so we never ship competing system messages.
+    /// Does this wire body carry a tool result for the turn being answered?
+    ///
+    /// Scoped to the rows after the last ``.user`` message, because a
+    /// ``.tool`` row from an earlier question is not evidence about this one.
+    /// Asking the whole transcript instead means a single weather lookup
+    /// re-arms the preamble for every ordinary question that follows it —
+    /// #1549 again, wearing a longer conversation.
+    static func carriesToolResultForThisTurn(_ history: [ChatMessage]) -> Bool {
+        let start =
+            history.lastIndex { $0.role == .user }
+            .map { history.index(after: $0) } ?? history.startIndex
+        return history[start...].contains { $0.role == .tool }
+    }
+
     static func ambientSystemMessages(
         historyOpensWithSystem: Bool,
         toolsAdvertised: Bool,

--- a/apps/rapid-mac/Tests/RapidTests/BuiltinToolsTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/BuiltinToolsTests.swift
@@ -182,6 +182,39 @@ final class BuiltinToolsTests {
         ).isEmpty)
     }
 
+    @Test("A tool result only counts for the turn it belongs to")
+    func toolResultScopedToTheCurrentTurn() {
+        func msg(_ role: ChatMessage.Role, _ text: String) -> ChatMessage {
+            ChatMessage(role: role, content: text, status: .complete)
+        }
+
+        // Turn 1 used a tool; turn 2 is an ordinary question. Scanning the
+        // whole transcript would re-arm the preamble here and reproduce
+        // #1549 from the second question onward.
+        let laterPlainTurn = [
+            msg(.user, "weather in Tokyo?"),
+            msg(.assistant, ""),
+            msg(.tool, "{\"temp_c\": 29.2}"),
+            msg(.assistant, "It's 29.2°C in Tokyo."),
+            msg(.user, "what is the capital of France?"),
+        ]
+        #expect(!ChatViewModel.carriesToolResultForThisTurn(laterPlainTurn))
+
+        // The round right after a tool returned — this is what the preamble
+        // exists for, so it must still count.
+        let midToolLoop = [
+            msg(.user, "weather in Tokyo?"),
+            msg(.assistant, ""),
+            msg(.tool, "{\"temp_c\": 29.2}"),
+        ]
+        #expect(ChatViewModel.carriesToolResultForThisTurn(midToolLoop))
+
+        // A transcript with no user row at all (defensive: the tool loop
+        // never produces one, but the helper must not crash or misread it).
+        #expect(!ChatViewModel.carriesToolResultForThisTurn([]))
+        #expect(ChatViewModel.carriesToolResultForThisTurn([msg(.tool, "{}")]))
+    }
+
     @Test("No second system row is injected when the transcript already opens with one")
     func ambientGuidanceDefersToExistingSystemRow() {
         // Two competing system messages is a documented chat-template foot-gun.

--- a/apps/rapid-mac/Tests/RapidTests/BuiltinToolsTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/BuiltinToolsTests.swift
@@ -142,20 +142,44 @@ final class BuiltinToolsTests {
 
     // MARK: - Ambient guidance
 
-    @Test("The anti-confabulation preamble rides along only when tools are advertised")
-    func ambientGuidanceGatedOnTools() {
+    @Test("The anti-confabulation preamble rides along once a tool result is in play")
+    func ambientGuidanceGatedOnToolResult() {
+        let withResult = ChatViewModel.ambientSystemMessages(
+            historyOpensWithSystem: false,
+            toolsAdvertised: true,
+            toolResultPresent: true
+        )
+        #expect(withResult.count == 1)
+        #expect(withResult.first?.role == .system)
+        #expect(withResult.first?.content == ChatViewModel.toolGuidancePreamble)
+    }
+
+    @Test("A tool merely being advertised does not summon the preamble (#1549)")
+    func ambientGuidanceStaysHomeUntilThereIsAResult() {
+        // The regression this guards is the whole first-turn experience. The
+        // built-in web tools are advertised by default, so before #1549 every
+        // opening message shipped a preamble telling the model that anything
+        // absent from "the tool result" was unknown to it — with no tool result
+        // in context. The shipped starter answered "I don't have access to
+        // current or external data" to *what is the capital of France?*.
         #expect(ChatViewModel.ambientSystemMessages(
             historyOpensWithSystem: false,
-            toolsAdvertised: false
+            toolsAdvertised: true,
+            toolResultPresent: false
         ).isEmpty)
+    }
 
-        let withTools = ChatViewModel.ambientSystemMessages(
+    @Test("A stale tool result cannot re-bind the model once the tool is gone")
+    func ambientGuidanceNeedsTheToolStillAdvertised() {
+        // A transcript keeps its ``.tool`` rows after the user disables the
+        // tool in Settings. Re-asserting "your only source of truth is the tool
+        // result" would then pin the model to a result it can no longer
+        // refresh, which is the same failure wearing older evidence.
+        #expect(ChatViewModel.ambientSystemMessages(
             historyOpensWithSystem: false,
-            toolsAdvertised: true
-        )
-        #expect(withTools.count == 1)
-        #expect(withTools.first?.role == .system)
-        #expect(withTools.first?.content == ChatViewModel.toolGuidancePreamble)
+            toolsAdvertised: false,
+            toolResultPresent: true
+        ).isEmpty)
     }
 
     @Test("No second system row is injected when the transcript already opens with one")
@@ -163,7 +187,8 @@ final class BuiltinToolsTests {
         // Two competing system messages is a documented chat-template foot-gun.
         #expect(ChatViewModel.ambientSystemMessages(
             historyOpensWithSystem: true,
-            toolsAdvertised: true
+            toolsAdvertised: true,
+            toolResultPresent: true
         ).isEmpty)
     }
 }


### PR DESCRIPTION
## Why

On a clean first run, with the wizard's own recommended starter and **no tools
connected by the user**, the app could not answer basic questions:

> **User:** What is the capital of France?
> **Rapid:** I don't have access to current or external data beyond what's in my training…

`ambientSystemMessages` injected `toolGuidancePreamble` whenever any tool was
*advertised*. The built-in web tools (#1533) are advertised by default, so it
rode along on every opening message. Its rules describe how to read a tool
result:

> Your ONLY source of truth for this turn is the tool result text. If a fact is
> not in the tool result, you DO NOT KNOW IT for the purposes of this answer.

Handed to a model with no tool result in context, that reads as "you know
nothing". Same server, same model, same sampling — the preamble was the only
variable:

| question | without preamble | with preamble |
|---|---|---|
| What is unified memory on Apple Silicon? | "…combines the CPU, GPU, and memory into a single, shared memory space…" | "I don't have enough information…" |
| **What is the capital of France?** | **"The capital of France is Paris."** | "I don't have access to current or external data…" |
| Name three programming languages. | "1. Python 2. JavaScript 3. Java" | "I don't have enough context to provide a precise answer, but…" |

It degraded general knowledge across the board, not just recency-sensitive
questions. The starter model is not at fault; it answers fine unprompted.

The code even said so: *"costs nothing when no tool is offered"*. That was true
while tools were opt-in. Once a tool is always offered, the cost is paid on
every turn — and the first turn is where it does the most damage.

## What changed

Gate on a tool **result** being present, not on a tool being advertised. The
anti-confabulation protection is unchanged where it was aimed — the round after
a tool returns — and absent where it only ever did harm.

Two follow-ups from review, both of which reproduced the bug with a slightly
longer conversation:

* the check is scoped to the rows after the last `.user`, so a weather question
  does not re-arm the preamble for every ordinary question after it;
* it is re-checked after the context-window trim, which preserves a leading
  system row while dropping old rows — so an over-budget turn could otherwise
  ship the preamble with the tool result it describes already trimmed away. The
  insertion stays before the trim so its tokens are inside the budget.

Both conditions (advertised **and** result present) are required: a transcript
keeps its `.tool` rows after the user disables the tool in Settings, and
re-asserting "your only source of truth is the tool result" would pin the model
to a result it can no longer refresh.

## Test plan

Verified end to end on the built app, fresh isolated profile
(`scripts/dogfood-isolate.sh`), driven through the GUI:

* "What is the capital of France?" → **"The capital of France is Paris."**
* "What is the weather in Tokyo right now?" → the `weather` tool fires and the
  answer is grounded in what it returned (29.5°C, humidity 78%) — the preamble
  still does its job on the round that has a result to talk about
* both of the above **in the same conversation**, tool question first, which is
  the case the scoping fix exists for

Unit coverage in `BuiltinToolsTests`: the existing test asserted the old
behaviour (advertising a tool is enough), so it encoded the bug and is
rewritten. Added regressions for the first-turn case, the disabled-tool-with-
stale-results case, and the turn-scoping of `carriesToolResultForThisTurn`.

`swift test` cannot run on this machine (no Xcode, so no XCTest for the sibling
`RapidUXTests` target); `swift build` is clean and CI runs the suite on
macos-15.

Closes #1549