### PR TITLE
fix(pr_validate): confirm a bench regression against the base, not a frozen number

### DIFF
--- a/scripts/pr_validate/steps/stress_e2e_bench.py
+++ b/scripts/pr_validate/steps/stress_e2e_bench.py
@@ -197,11 +197,10 @@ class StressE2EBenchStep(Step):
                         artifact=bench_result.get("artifact"),
                     )
                     if _is_blocking_status(bench_result["status"]):
-                        any_fail = True
-                        all_findings.append(
-                            f"[BLOCKING] bench on {choice.model_id}: "
-                            + bench_result["summary"]
-                        )
+                        # Deferred like stress and agents: the confirming
+                        # run needs BENCH_PORT, which this server still
+                        # holds. Resolved after the context exits.
+                        pending_failures.append(("bench", bench_result, None))
                     # Registered here, not after the matrix: the bench has
                     # already produced its artifact, and an exception in
                     # stress or in any agent below would otherwise discard
@@ -303,6 +302,16 @@ class StressE2EBenchStep(Step):
                     all_artifacts.append(base_result["server_artifact"])
 
                 label = _failure_label(kind, agent)
+                if kind == "bench":
+                    verdict = _resolve_bench_against_base(
+                        pr_result, base_result, choice.model_id
+                    )
+                    if verdict["preexisting"]:
+                        preexisting_count += 1
+                    else:
+                        any_fail = True
+                    all_findings.append(verdict["finding"])
+                    continue
                 if base_result["status"] == "fail" and base_result.get("executed"):
                     preexisting_count += 1
                     all_findings.append(
@@ -754,6 +763,73 @@ def _run_agent(
     }
 
 
+def _resolve_bench_against_base(
+    pr_result: dict[str, Any],
+    base_result: dict[str, Any],
+    model_id: str,
+) -> dict[str, Any]:
+    """Decide a bench failure using the base measured in this same run.
+
+    The recorded baseline already said "slow". That only means the diff
+    regressed if the code it replaces is faster on this machine, today —
+    see ``_run_bench``. Here the merge base has just been measured on a
+    fresh server, so the comparison is like for like and machine drift
+    appears in both numbers instead of only the PR's.
+
+    Returns ``{"preexisting": bool, "finding": str}``: ``preexisting`` when
+    the base reproduces the slowdown, which is the drift case #1547
+    describes and is reported rather than gated.
+    """
+    cmp_ = pr_result.get("bench_comparison") or {}
+    base_metrics = base_result.get("metrics") if isinstance(base_result, dict) else None
+    if not cmp_ or not base_metrics:
+        # No usable control (worktree failed, base server would not boot).
+        # The baseline verdict stands, but it is reported as unconfirmed
+        # rather than dressed up as a proven regression.
+        return {
+            "preexisting": False,
+            "finding": (
+                f"[BLOCKING] bench on {model_id}: {pr_result['summary']}; could not "
+                f"measure the base to confirm — {base_result.get('summary', 'no detail')}"
+            ),
+        }
+
+    base_cold_now = base_metrics["cold_request_ms_median"]
+    base_warm_now = base_metrics["warm_request_ms_median"]
+    cold_vs_base = (cmp_["cold"] / base_cold_now - 1) * 100 if base_cold_now else 0
+    warm_vs_base = (cmp_["warm"] / base_warm_now - 1) * 100 if base_warm_now else 0
+    cold_drift = (
+        (base_cold_now / cmp_["base_cold"] - 1) * 100 if cmp_["base_cold"] else 0
+    )
+    warm_drift = (
+        (base_warm_now / cmp_["base_warm"] - 1) * 100 if cmp_["base_warm"] else 0
+    )
+
+    if cold_vs_base > cmp_["cold_threshold"] or warm_vs_base > cmp_["warm_threshold"]:
+        return {
+            "preexisting": False,
+            "finding": (
+                f"[BLOCKING] bench on {model_id}: cold {cold_vs_base:+.1f}%, warm "
+                f"{warm_vs_base:+.1f}% vs the base measured in this run "
+                f"(threshold {cmp_['threshold_text']}); the base itself sits "
+                f"cold {cold_drift:+.1f}%, warm {warm_drift:+.1f}% off the recorded "
+                f"baseline, so this is on top of any drift, not explained by it"
+            ),
+        }
+    return {
+        "preexisting": True,
+        "finding": (
+            f"[PRE-EXISTING] bench on {model_id}: cold {cold_vs_base:+.1f}%, warm "
+            f"{warm_vs_base:+.1f}% vs the base measured in this run (within "
+            f"{cmp_['threshold_text']}) — the recorded baseline reads "
+            f"cold {cmp_['cold_slow']:+.1f}%, warm {cmp_['warm_slow']:+.1f}%, but the "
+            f"base reproduces cold {cold_drift:+.1f}%, warm {warm_drift:+.1f}% of it "
+            f"unchanged. The drift is the machine's, not this diff's; the baseline "
+            f"needs a refresh"
+        ),
+    }
+
+
 def _run_base_check(
     ctx: Context,
     choice: ModelChoice,
@@ -807,6 +883,21 @@ def _run_base_check(
                     artifact_prefix="base-",
                     isolate_pythonpath=True,
                 )
+            elif kind == "bench":
+                # Raw measurement only — the caller does the comparing,
+                # because the whole point is to compare PR against THIS
+                # number rather than against the recorded baseline.
+                measured = _measure_bench(ctx, choice, artifact_prefix="base-")
+                result = {
+                    "status": "pass",
+                    "summary": (
+                        f"base cold={measured['metrics']['cold_request_ms_median']:.0f}ms "
+                        f"warm={measured['metrics']['warm_request_ms_median']:.0f}ms"
+                    ),
+                    "artifact": measured["artifact"],
+                    "metrics": measured["metrics"],
+                    "executed": True,
+                }
             else:
                 result = {
                     "status": "error",
@@ -937,10 +1028,17 @@ def _repo_python_env(
     return env
 
 
-def _run_bench(ctx: Context, choice: ModelChoice) -> dict[str, Any]:
-    """Inline bench — measure cold TTFT + decode TPS, compare to
-    baseline. Implementation borrowed from the inline benchmark we ran
-    against PR #200; keeps this step dependency-free."""
+def _measure_bench(
+    ctx: Context, choice: ModelChoice, *, artifact_prefix: str = ""
+) -> dict[str, Any]:
+    """Measure cold + warm request medians against the server on
+    ``BENCH_PORT``, write them as an artifact, and return them.
+
+    Split out of :func:`_run_bench` so the identical measurement can be
+    taken on the PR checkout and on the merge base within one run — see
+    the drift check in ``_run_bench``. Implementation borrowed from the
+    inline benchmark we ran against PR #200; keeps this step
+    dependency-free."""
     import statistics
     import urllib.error
     import urllib.request
@@ -1005,8 +1103,38 @@ def _run_bench(ctx: Context, choice: ModelChoice) -> dict[str, Any]:
         "speedup_x": speedup,
     }
 
-    bench_path = ctx.artifact_path(f"bench-{_safe_name(choice.model_id)}.json")
+    bench_path = ctx.artifact_path(
+        f"{artifact_prefix}bench-{_safe_name(choice.model_id)}.json"
+    )
     bench_path.write_text(json.dumps(metrics, indent=2))
+    return {"metrics": metrics, "artifact": str(bench_path)}
+
+
+def _run_bench(ctx: Context, choice: ModelChoice) -> dict[str, Any]:
+    """Measure this checkout and gate it against the recorded baseline.
+
+    A frozen baseline answers "is this build slower than the day we
+    recorded it", which is only the question we care about while the
+    machine still behaves the way it did that day. It drifts — thermals,
+    background load, an OS or dependency bump — and when it does, every
+    PR inherits the drift and the gate reds uniformly. A gate that fails
+    everything teaches reviewers to wave it through, which is worse than
+    not having it (#1547: benching the baseline's OWN commit reproduced a
+    +13.8% warm "regression" against its own recorded numbers).
+
+    So the baseline stays the cheap first pass, and a failure is no
+    longer the verdict: it triggers the same on-base re-run this step
+    already trusts for stress and agent failures. The merge base is
+    measured back to back with the PR on this machine, in this session,
+    and the PR is then judged against THAT. Drift moves both numbers and
+    cancels; a real regression does not.
+    """
+    measured = _measure_bench(ctx, choice)
+    metrics = measured["metrics"]
+    cold = metrics["cold_request_ms_median"]
+    warm = metrics["warm_request_ms_median"]
+    speedup = metrics["speedup_x"]
+    bench_path = Path(measured["artifact"])
 
     # Compare to baseline if present.
     baseline_path = (
@@ -1076,6 +1204,13 @@ def _run_bench(ctx: Context, choice: ModelChoice) -> dict[str, Any]:
         else f"{cold_threshold:g}%"
     )
     if cold_slow > cold_threshold or warm_slow > warm_threshold:
+        # A baseline miss is a suspicion, not a verdict — see the docstring.
+        # The confirming measurement of the merge base CANNOT happen here:
+        # this runs inside the PR's ``_server`` context, which owns
+        # BENCH_PORT, and ``_server_in_repo`` refuses to boot a second
+        # server on a bound port. So the numbers travel out with the
+        # result and the caller resolves it once the port is free, through
+        # the same ``pending_failures`` path stress and agents already use.
         return {
             "status": "fail",
             "summary": (
@@ -1084,6 +1219,17 @@ def _run_bench(ctx: Context, choice: ModelChoice) -> dict[str, Any]:
             ),
             "artifact": str(bench_path),
             "executed": True,
+            "bench_comparison": {
+                "cold": cold,
+                "warm": warm,
+                "cold_slow": cold_slow,
+                "warm_slow": warm_slow,
+                "cold_threshold": cold_threshold,
+                "warm_threshold": warm_threshold,
+                "threshold_text": threshold_text,
+                "base_cold": base_cold,
+                "base_warm": base_warm,
+            },
         }
     return {
         "status": "pass",

--- a/scripts/pr_validate/steps/stress_e2e_bench.py
+++ b/scripts/pr_validate/steps/stress_e2e_bench.py
@@ -304,7 +304,10 @@ class StressE2EBenchStep(Step):
                 label = _failure_label(kind, agent)
                 if kind == "bench":
                     verdict = _resolve_bench_against_base(
-                        pr_result, base_result, choice.model_id
+                        pr_result,
+                        base_result,
+                        choice.model_id,
+                        files_changed=ctx.files_changed,
                     )
                     if verdict["preexisting"]:
                         preexisting_count += 1
@@ -763,10 +766,34 @@ def _run_agent(
     }
 
 
+# Files whose contents decide what the base worktree actually RUNS rather
+# than what it contains. The control checks out base source, but it uses the
+# environment installed right now — so a slowdown introduced by a dependency
+# bump or a packaging change lands in the base measurement too, and the two
+# agreeing proves nothing. When the diff touches one of these, the frozen
+# baseline keeps the last word.
+_ENVIRONMENT_DEFINING = (
+    "pyproject.toml",
+    "uv.lock",
+    "poetry.lock",
+    "setup.py",
+    "setup.cfg",
+)
+
+
+def _diff_defines_the_environment(files_changed: list[str]) -> bool:
+    return any(
+        Path(f).name in _ENVIRONMENT_DEFINING or Path(f).name.startswith("requirements")
+        for f in files_changed
+    )
+
+
 def _resolve_bench_against_base(
     pr_result: dict[str, Any],
     base_result: dict[str, Any],
     model_id: str,
+    *,
+    files_changed: list[str] | None = None,
 ) -> dict[str, Any]:
     """Decide a bench failure using the base measured in this same run.
 
@@ -805,7 +832,33 @@ def _resolve_bench_against_base(
         (base_warm_now / cmp_["base_warm"] - 1) * 100 if cmp_["base_warm"] else 0
     )
 
-    if cold_vs_base > cmp_["cold_threshold"] or warm_vs_base > cmp_["warm_threshold"]:
+    if _diff_defines_the_environment(files_changed or []):
+        return {
+            "preexisting": False,
+            "finding": (
+                f"[BLOCKING] bench on {model_id}: {pr_result['summary']}; the base "
+                f"measured cold {cold_vs_base:+.1f}%, warm {warm_vs_base:+.1f}% away, "
+                f"but this diff changes dependency/packaging files — the base worktree "
+                f"runs base SOURCE against the CURRENT environment, so it carries the "
+                f"same slowdown and cannot vouch for it"
+            ),
+        }
+
+    # The base is measured after the stress battery and the agent matrix have
+    # run for this model, so the machine is warmer than it was for the PR's
+    # bench on a fresh server. That biases the base SLOW, and a slow base is
+    # exactly what excuses a PR — the wrong direction. Requiring the base to
+    # independently breach the same threshold bounds it: a couple of percent
+    # of thermal drift can never buy an excuse because it never crosses, and
+    # only drift big enough to fail the gate on its own can.
+    base_breaches_baseline = (
+        cold_drift > cmp_["cold_threshold"] or warm_drift > cmp_["warm_threshold"]
+    )
+    if (
+        cold_vs_base > cmp_["cold_threshold"]
+        or warm_vs_base > cmp_["warm_threshold"]
+        or not base_breaches_baseline
+    ):
         return {
             "preexisting": False,
             "finding": (

--- a/tests/test_bench_confirms_a_regression_against_its_own_base.py
+++ b/tests/test_bench_confirms_a_regression_against_its_own_base.py
@@ -1,0 +1,256 @@
+# SPDX-License-Identifier: Apache-2.0
+"""A frozen baseline cannot tell a slow diff from a slow afternoon.
+
+`stress_e2e_bench` compared each PR's measurement against a number
+recorded on some earlier day. That answers "is this build slower than the
+day we recorded it", which stops being the question the moment the
+machine stops behaving the way it did that day — thermals, background
+load, a dependency bump.
+
+Issue #1547 is what that looks like in practice. Benching the baseline's
+OWN commit, on the machine that captured it, reproduced the "regression"
+it was supposed to disprove::
+
+    Qwen3.5-35B-A3B-8bit, warm request median
+      recorded baseline (f2097169, 05:12Z) : 375.8 ms
+      f2097169 re-measured that evening    : 427.5 ms   (+13.8%)
+      main                                 : 418.6 ms
+      the PR under review                  : 418.0 ms
+
+Every PR inherited the drift and the gate failed all of them
+identically, which is worse than having no gate: a check that is always
+red trains reviewers to click past it.
+
+So a baseline miss is no longer a verdict. It triggers the on-base re-run
+this step already trusts for stress and agent failures — the merge base
+is measured back to back with the PR, on this machine, in this session —
+and the PR is judged against THAT. Drift moves both numbers and cancels;
+a real regression does not.
+"""
+
+import json
+
+import pytest
+
+from scripts.pr_validate.steps import stress_e2e_bench
+
+
+@pytest.fixture
+def ctx(tmp_path):
+    """Minimal stand-in for the pieces of ``Context`` the bench touches."""
+
+    class _Ctx:
+        repo_root = tmp_path
+        work_dir = tmp_path / "artifacts"
+
+        def artifact_path(self, name):
+            p = self.work_dir / name
+            p.parent.mkdir(parents=True, exist_ok=True)
+            return p
+
+    return _Ctx()
+
+
+@pytest.fixture
+def choice():
+    return stress_e2e_bench.ModelChoice(
+        family="qwen3.5",
+        model_id="mlx-community/Qwen3.5-35B-A3B-8bit",
+        ram_gb_required=40.0,
+        quality_tier="tier1",
+        extra_args=[],
+    )
+
+
+@pytest.fixture
+def baseline(ctx, choice):
+    """A schema-v1 baseline recording 250/375 ms, 5% either side."""
+    safe = stress_e2e_bench._safe_name(choice.model_id)
+    path = ctx.repo_root / stress_e2e_bench.BASELINE_DIR / f"bench-{safe}.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "schema": 1,
+                "model": {"id": choice.model_id, "revision": "deadbeef"},
+                "metrics": {
+                    "cold_request_ms_median": 250.0,
+                    "warm_request_ms_median": 375.0,
+                },
+                "regression_threshold_pct": {
+                    "cold_request_ms_median": 5,
+                    "warm_request_ms_median": 5,
+                },
+                "environment": {"hardware": {"chip": "Apple M3 Ultra"}},
+            }
+        )
+    )
+    return path
+
+
+@pytest.fixture(autouse=True)
+def _pin_environment(monkeypatch):
+    """Keep the revision / chip preconditions out of the way — they have
+    their own guards, and neither is what these tests are about."""
+    monkeypatch.setattr(
+        stress_e2e_bench, "_cached_model_revision", lambda *a, **k: "deadbeef"
+    )
+    monkeypatch.setattr(stress_e2e_bench, "_current_chip", lambda: "Apple M3 Ultra")
+
+
+def _fake_measure(cold, warm):
+    def _inner(ctx, choice, *, artifact_prefix=""):
+        metrics = {
+            "model": choice.model_id,
+            "cold_request_ms_median": cold,
+            "warm_request_ms_median": warm,
+            "speedup_x": cold / warm if warm else 0,
+        }
+        path = ctx.artifact_path(
+            f"{artifact_prefix}bench-{stress_e2e_bench._safe_name(choice.model_id)}.json"
+        )
+        path.write_text(json.dumps(metrics))
+        return {"metrics": metrics, "artifact": str(path)}
+
+    return _inner
+
+
+def _base_measuring(cold, warm):
+    """``_run_base_check`` stand-in that reports the base at cold/warm."""
+
+    def _inner(ctx, choice, kind, agent):
+        assert kind == "bench", f"bench failure asked for a {kind!r} base check"
+        return {
+            "status": "pass",
+            "summary": f"base cold={cold:.0f}ms warm={warm:.0f}ms",
+            "artifact": "base.json",
+            "metrics": {
+                "cold_request_ms_median": cold,
+                "warm_request_ms_median": warm,
+            },
+            "executed": True,
+        }
+
+    return _inner
+
+
+def _pr_failure(cold, warm, ctx, choice, monkeypatch):
+    """Run the real ``_run_bench`` and return its (failing) result."""
+    monkeypatch.setattr(stress_e2e_bench, "_measure_bench", _fake_measure(cold, warm))
+    result = stress_e2e_bench._run_bench(ctx, choice)
+    assert result["status"] == "fail", result["summary"]
+    return result
+
+
+def _base(cold, warm):
+    return {
+        "status": "pass",
+        "summary": f"base cold={cold:.0f}ms warm={warm:.0f}ms",
+        "artifact": "base.json",
+        "metrics": {
+            "cold_request_ms_median": cold,
+            "warm_request_ms_median": warm,
+        },
+        "executed": True,
+    }
+
+
+def test_the_bench_defers_its_base_check_until_the_port_is_free(
+    ctx, choice, baseline, monkeypatch
+):
+    """``_run_bench`` runs inside the PR's server context, which owns
+    BENCH_PORT. A base server started from there can never bind, so the
+    confirming measurement must NOT happen inside ``_run_bench`` — it
+    carries its numbers out and the caller resolves them afterwards."""
+
+    def _explode(*a, **k):
+        raise AssertionError(
+            "_run_bench started a base check while the PR server still held BENCH_PORT"
+        )
+
+    monkeypatch.setattr(stress_e2e_bench, "_run_base_check", _explode)
+    result = _pr_failure(345.0, 418.0, ctx, choice, monkeypatch)
+    assert result["bench_comparison"], (
+        "the numbers the resolver needs did not travel out"
+    )
+
+
+def test_a_baseline_miss_the_base_also_reproduces_is_not_this_diffs_fault(
+    ctx, choice, baseline, monkeypatch
+):
+    """The #1547 shape: PR and base are both ~12% over the frozen number,
+    and identical to each other. Nothing regressed between them."""
+    pr = _pr_failure(345.0, 418.0, ctx, choice, monkeypatch)
+
+    verdict = stress_e2e_bench._resolve_bench_against_base(
+        pr, _base(344.0, 419.0), choice.model_id
+    )
+
+    assert verdict["preexisting"], verdict["finding"]
+    assert "[PRE-EXISTING]" in verdict["finding"]
+    # The report must not bury the drift — the baseline still needs a refresh.
+    assert "refresh" in verdict["finding"].lower()
+
+
+def test_a_regression_the_base_does_not_share_still_fails(
+    ctx, choice, baseline, monkeypatch
+):
+    """The control is only allowed to excuse drift it actually shares."""
+    pr = _pr_failure(300.0, 450.0, ctx, choice, monkeypatch)
+
+    verdict = stress_e2e_bench._resolve_bench_against_base(
+        pr, _base(250.0, 375.0), choice.model_id
+    )
+
+    assert not verdict["preexisting"], verdict["finding"]
+    assert "[BLOCKING]" in verdict["finding"]
+    assert "vs the base measured in this run" in verdict["finding"]
+
+
+def test_a_drifted_machine_does_not_hide_a_regression_stacked_on_top(
+    ctx, choice, baseline, monkeypatch
+):
+    """Drift and a real regression at once: the diff is still slower than
+    the base, so the base cannot excuse it."""
+    pr = _pr_failure(345.0, 481.0, ctx, choice, monkeypatch)
+
+    verdict = stress_e2e_bench._resolve_bench_against_base(
+        pr, _base(344.0, 418.0), choice.model_id
+    )
+
+    assert not verdict["preexisting"], verdict["finding"]
+
+
+def test_a_measurement_inside_the_baseline_is_never_deferred(
+    ctx, choice, baseline, monkeypatch
+):
+    """A green bench must resolve on the spot — no base measurement, and
+    nothing handed to the resolver."""
+    monkeypatch.setattr(stress_e2e_bench, "_measure_bench", _fake_measure(252.0, 380.0))
+
+    result = stress_e2e_bench._run_bench(ctx, choice)
+
+    assert result["status"] == "pass", result["summary"]
+    assert "bench_comparison" not in result
+
+
+def test_an_unmeasurable_base_reports_the_miss_without_claiming_it_is_confirmed(
+    ctx, choice, baseline, monkeypatch
+):
+    """No control (worktree failed, base server would not boot) means the
+    baseline verdict stands — stated as unconfirmed, not as proven."""
+    pr = _pr_failure(345.0, 418.0, ctx, choice, monkeypatch)
+
+    verdict = stress_e2e_bench._resolve_bench_against_base(
+        pr,
+        {
+            "status": "error",
+            "summary": "base check failed: git worktree add exited 128",
+            "executed": False,
+        },
+        choice.model_id,
+    )
+
+    assert not verdict["preexisting"], verdict["finding"]
+    assert "could not measure the base" in verdict["finding"]
+    assert "git worktree add exited 128" in verdict["finding"]

--- a/tests/test_bench_confirms_a_regression_against_its_own_base.py
+++ b/tests/test_bench_confirms_a_regression_against_its_own_base.py
@@ -254,3 +254,54 @@ def test_an_unmeasurable_base_reports_the_miss_without_claiming_it_is_confirmed(
     assert not verdict["preexisting"], verdict["finding"]
     assert "could not measure the base" in verdict["finding"]
     assert "git worktree add exited 128" in verdict["finding"]
+
+
+def test_thermal_scale_drift_cannot_buy_an_excuse(ctx, choice, baseline, monkeypatch):
+    """The base is measured after stress + the agent matrix, so the machine
+    is warmer than it was for the PR's bench on a fresh server. That biases
+    the base slow, and a slow base is what excuses a PR — the wrong
+    direction. A base that is only a couple of percent off must therefore
+    excuse nothing: it never breaches the gate on its own."""
+    # Numbers chosen to land in the gap this clause exists for — if the
+    # PR/base comparison alone already tripped, the clause would never be
+    # reached and this test would pass without testing it:
+    #   baseline warm 375, threshold 5% (trips above 393.75)
+    #   PR   warm 400  → +6.7% vs baseline, so the bench fails and we land here
+    #   base warm 385  → PR is only +3.9% vs base: WITHIN threshold
+    #   base drift     → +2.7% vs baseline: does NOT breach on its own
+    # Without the clause that combination reads as "drift, excused". With
+    # it, a base that never fails the gate cannot vouch for one that does.
+    pr = _pr_failure(255.0, 400.0, ctx, choice, monkeypatch)
+
+    verdict = stress_e2e_bench._resolve_bench_against_base(
+        pr, _base(252.0, 385.0), choice.model_id
+    )
+
+    assert not verdict["preexisting"], verdict["finding"]
+
+
+def test_a_dependency_change_is_never_excused_by_the_base(
+    ctx, choice, baseline, monkeypatch
+):
+    """The control checks out base SOURCE but runs it against the CURRENTLY
+    installed environment. A slowdown that arrived with a dependency bump
+    therefore lands in the base measurement too, and the two agreeing proves
+    nothing. When the diff touches packaging, the frozen baseline keeps the
+    last word."""
+    pr = _pr_failure(345.0, 418.0, ctx, choice, monkeypatch)
+
+    verdict = stress_e2e_bench._resolve_bench_against_base(
+        pr,
+        _base(344.0, 419.0),
+        choice.model_id,
+        files_changed=["pyproject.toml", "vllm_mlx/engine.py"],
+    )
+
+    assert not verdict["preexisting"], verdict["finding"]
+    assert "dependency/packaging" in verdict["finding"]
+
+    # Same numbers, ordinary source change → the base is allowed to speak.
+    ordinary = stress_e2e_bench._resolve_bench_against_base(
+        pr, _base(344.0, 419.0), choice.model_id, files_changed=["vllm_mlx/engine.py"]
+    )
+    assert ordinary["preexisting"], ordinary["finding"]


### PR DESCRIPTION
## Why

The perf gate compared each PR's measurement to a number recorded on an earlier
day. That answers "is this build slower than the day we recorded it", which
stops being the question the moment the machine stops behaving the way it did
that day.

Benching the baseline's **own commit**, on the machine that captured it,
reproduced the regression it was supposed to disprove:

| Qwen3.5-35B-A3B-8bit | cold median | warm median |
|---|---|---|
| recorded baseline (`f2097169`, 05:12Z) | 252.8 ms | 375.8 ms |
| `f2097169` re-measured that evening | 300.8 ms | **427.5 ms** |
| `main` | 345.2 ms | 418.6 ms |
| the PR under review | 344.0 ms | 418.0 ms |

The base commit measured *slower* than the PR it was supposed to exonerate.
Nothing had regressed; the machine had moved. Every PR inherited the drift and
the gate failed all of them identically — worse than no gate, because a check
that is always red teaches reviewers to click past it.

Cold is also far too noisy at n=5 to carry a 5% threshold. Observed spreads
within a single run: `[406, 222, 215, 312, 322]` on `main`/gpt-oss-20b,
`[600, 278, 301, 299, 353]` on `f2097169`/Qwen3.5-35B. Warm is the trustworthy
metric (under 1% within a run), and warm was consistently ~+11-14% on every
checkout including the baseline's own.

## What changed

A baseline miss is no longer the verdict. It triggers the same on-base re-run
this step already trusts for stress and agent failures: the merge base is
measured back to back with the PR, on this machine, in this session, and the PR
is judged against **that**. Drift moves both numbers and cancels; a real
regression does not.

The confirming measurement cannot happen inside `_run_bench` — that runs inside
the PR's `_server` context, which owns `BENCH_PORT`, and `_server_in_repo`
refuses to boot on a bound port. So the numbers travel out on the result and are
resolved through the existing `pending_failures` path once the port is free.

Two bounds on what the base is allowed to excuse, both from review:

* The base is measured after the stress battery and the agent matrix, so the
  machine is warmer than it was for the PR's bench on a fresh server. That
  biases the base *slow*, and a slow base is what excuses a PR. So the base must
  independently breach the same threshold before it may explain anything — a
  couple of percent of thermal drift can never buy an excuse because it never
  crosses. (Measuring the base *before* the workload would cost a second model
  load per model on every run, including the green ones; this bounds the same
  risk for free.)
* The control checks out base **source** but runs it against the environment
  installed right now, so a slowdown that arrived with a dependency bump lands
  in both measurements and the two agreeing proves nothing. When the diff
  touches pyproject / lockfiles / requirements / `setup.*`, the frozen baseline
  keeps the last word.

A green bench costs exactly what it did before — the extra model load is paid
only on the failure path.

## Test plan

`tests/test_bench_confirms_a_regression_against_its_own_base.py`, 8 cases,
driving the real `_run_bench` and `_resolve_bench_against_base`:

* the #1547 shape (PR and base both over the frozen number, identical to each
  other) → reported as pre-existing, with the baseline refresh called out
* a regression the base does not share → still fails
* drift *and* a regression stacked on top → still fails
* thermal-scale drift that never breaches on its own → cannot excuse
* a dependency-touching diff → never excused
* a green bench → resolves on the spot, no base measurement
* an unmeasurable base → the baseline verdict stands, reported as unconfirmed
* the deferral itself — `_run_bench` must not start a base check while the PR
  server holds the port

Mutation-verified: reverting the deferral fails 4; making the resolver always
excuse fails 2; dropping the breach requirement fails the thermal test; dropping
the dependency guard fails its own. (The first cut of the thermal test passed
against its own mutation — the numbers tripped the primary threshold before
reaching the clause — and was rewritten with numbers that land in the gap.)

`ruff check` + `ruff format --check` clean; the adjacent `pr_validate` /
baseline suites (74 tests) still pass.

Closes #1547