### PR TITLE
fix(release): run coherence sweep on macOS bash 3.2

### DIFF
--- a/scripts/coherence_sweep.sh
+++ b/scripts/coherence_sweep.sh
@@ -130,11 +130,15 @@ for MODEL in $MODELS; do
     tail -20 "$LOG" >&2
     infra_failed="$infra_failed $MODEL(boot)"
   else
-    GATE_ARGS=()
     if [ "$DISTILL" = "1" ]; then
-      GATE_ARGS+=(--reasoning-distill)
+      gate_command=("$PY" evals/coherence_gate.py --reasoning-distill)
+    else
+      # macOS still ships bash 3.2. With ``set -u``, expanding an empty
+      # array is an unbound-variable error there, so keep the no-argument
+      # command explicit instead of appending to an empty GATE_ARGS array.
+      gate_command=("$PY" evals/coherence_gate.py)
     fi
-    if "$PY" evals/coherence_gate.py "${GATE_ARGS[@]}"; then
+    if "${gate_command[@]}"; then
       echo "  ✓ $MODEL coherent"
     else
       gate_status=$?

--- a/tests/test_release_fleet.py
+++ b/tests/test_release_fleet.py
@@ -264,3 +264,10 @@ def test_release_gauntlet_invokes_manifest_driven_sweep():
     script = (REPO_ROOT / "scripts" / "release_check_m3.sh").read_text()
     assert "bash scripts/coherence_sweep.sh" in script
     assert 'FLEET_SCOPE="${FLEET_SCOPE:-auto}"' in script
+
+
+def test_coherence_sweep_avoids_empty_array_expansion_on_macos_bash():
+    script = (REPO_ROOT / "scripts" / "coherence_sweep.sh").read_text()
+    assert 'gate_command=("$PY" evals/coherence_gate.py)' in script
+    assert 'gate_command=("$PY" evals/coherence_gate.py --reasoning-distill)' in script
+    assert '"${GATE_ARGS[@]}"' not in script


### PR DESCRIPTION
## Why
macOS ships Bash 3.2, where expanding an empty array under `set -u` raises an unbound-variable error. This silently skipped the normal-model G0a coherence gate during release dogfood.

## Fix
Build an explicit non-empty gate command for both distill and normal models.

## Validation
- reproduced the Bash 3.2 empty-array failure
- `bash -n scripts/coherence_sweep.sh`
- `python3 -m pytest -q tests/test_release_fleet.py` (18 passed)
- `git diff --check`
- Codex review: clean