### PR TITLE
fix(responses): validate streamed tool arguments for every parser

### DIFF
--- a/tests/test_responses_bundle.py
+++ b/tests/test_responses_bundle.py
@@ -462,9 +462,17 @@ class TestDeepSeekV4ResponsesStreaming:
         assert json.loads(completed_calls[0]["arguments"]) == {"cmd": "pwd && ls"}
 
     def test_streaming_rejects_invalid_structured_arguments_for_every_parser(
-        self, make_responses_client
+        self, make_responses_client, monkeypatch
     ):
         """Qwen/Hermes must get the same validation DeepSeek already had."""
+        # ``_check_admission_or_503`` lazily imports this one exception. Keep
+        # the HTTP fixture lightweight on Linux pr_validation, where MLX is
+        # intentionally unavailable and importing the real scheduler would
+        # fail before the mocked engine reaches the Responses route.
+        scheduler_stub = types.ModuleType("vllm_mlx.scheduler")
+        scheduler_stub.BackpressureError = type("BackpressureError", (Exception,), {})
+        monkeypatch.setitem(sys.modules, "vllm_mlx.scheduler", scheduler_stub)
+
         state = make_responses_client(
             tool_calls=[_make_function_call("get_weather", "12")],
             finish_reason="tool_calls",

--- a/tests/test_responses_bundle.py
+++ b/tests/test_responses_bundle.py
@@ -461,6 +461,52 @@ class TestDeepSeekV4ResponsesStreaming:
         assert len(completed_calls) == 1
         assert json.loads(completed_calls[0]["arguments"]) == {"cmd": "pwd && ls"}
 
+    def test_streaming_rejects_invalid_structured_arguments_for_every_parser(
+        self, make_responses_client
+    ):
+        """Qwen/Hermes must get the same validation DeepSeek already had."""
+        state = make_responses_client(
+            tool_calls=[_make_function_call("get_weather", "12")],
+            finish_reason="tool_calls",
+            stream_chunks=["tool preamble", "tool body"],
+        )
+        state.cfg.enable_auto_tool_choice = True
+        state.cfg.tool_call_parser = "hermes"
+
+        with state.client.stream(
+            "POST",
+            "/v1/responses",
+            json=_payload(
+                stream=True,
+                tool_choice="required",
+                tools=[
+                    {
+                        "type": "function",
+                        "name": "get_weather",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {"city": {"type": "string"}},
+                            "required": ["city"],
+                        },
+                    }
+                ],
+            ),
+            headers=_AUTH,
+        ) as resp:
+            assert resp.status_code == 200, resp.text
+            events = _parse_sse("".join(resp.iter_text()))
+
+        failed = [data for name, data in events if name == "response.failed"]
+        assert len(failed) == 1, events
+        assert failed[0]["response"]["error"]["code"] == "invalid_tool_arguments"
+        assert "JSON object" in failed[0]["response"]["error"]["message"]
+        assert not any(name == "response.completed" for name, _ in events)
+        assert not any(
+            name == "response.output_item.added"
+            and data.get("item", {}).get("type") == "function_call"
+            for name, data in events
+        )
+
     def test_empty_dsml_invoke_for_required_tool_fails_instead_of_reaching_codex(
         self, make_responses_client
     ):

--- a/vllm_mlx/routes/responses.py
+++ b/vllm_mlx/routes/responses.py
@@ -3802,11 +3802,12 @@ async def _stream_responses(
             tool_calls = _enforce_responses_tool_choice(
                 parsed_tool_calls, responses_request, openai_request
             )
-            if (
-                tool_calls
-                and openai_request.tools
-                and cfg.tool_call_parser == "deepseek_v4_0731"
-            ):
+            # Streaming must enforce the same post-parse schema contract as
+            # the non-streaming Responses lane. This used to be restricted to
+            # DeepSeek, so Hermes/Qwen calls such as ``arguments="12"`` could
+            # reach Codex as response.completed even though the declared tool
+            # requires a JSON object with required properties.
+            if tool_calls and openai_request.tools:
                 _validate_tool_call_params(
                     tool_calls, openai_request.tools, enforce_required=True
                 )


### PR DESCRIPTION
## Why
Mac mini release dogfood reproduced `/v1/responses` streaming a Hermes/Qwen function call with `arguments: "12"` and then emitting `response.completed`, even though the declared function requires a JSON object with a required `city` field. The non-stream path already rejects this; streaming only validated DeepSeek calls.

## Fix
Apply the existing required/schema validation to streamed tool calls for every parser. Invalid calls terminate with `response.failed` and never emit a function-call item or `response.completed`.

## Validation
- live Qwen3.5-4B repro on Mac mini
- `python3 -m pytest -q tests/test_responses_bundle.py tests/test_responses_engine_failure_envelope.py tests/test_responses_sse_event_order.py` (62 passed)
- `git diff --check`