### PR TITLE
fix(release): boot DeepSeek coherence with a supported CLI flag

### DIFF
--- a/scripts/coherence_sweep.sh
+++ b/scripts/coherence_sweep.sh
@@ -110,7 +110,10 @@ for MODEL in $MODELS; do
   fi
   SERVE_ARGS=(--port "$PORT")
   if [ "$DISTILL" = "1" ]; then
-    SERVE_ARGS+=(--thinking)
+    # The serve CLI exposes the reasoning profile as ``--reasoning``;
+    # ``--thinking`` has never been a valid serve flag. The stale flag made
+    # every reasoning-distill fleet member fail before model load.
+    SERVE_ARGS+=(--reasoning)
   else
     SERVE_ARGS+=(--no-thinking)
   fi

--- a/tests/test_release_fleet.py
+++ b/tests/test_release_fleet.py
@@ -271,3 +271,9 @@ def test_coherence_sweep_avoids_empty_array_expansion_on_macos_bash():
     assert 'gate_command=("$PY" evals/coherence_gate.py)' in script
     assert 'gate_command=("$PY" evals/coherence_gate.py --reasoning-distill)' in script
     assert '"${GATE_ARGS[@]}"' not in script
+
+
+def test_reasoning_distill_sweep_uses_supported_serve_flag():
+    script = (REPO_ROOT / "scripts" / "coherence_sweep.sh").read_text()
+    assert "SERVE_ARGS+=(--reasoning)" in script
+    assert "SERVE_ARGS+=(--thinking)" not in script


### PR DESCRIPTION
## Why
Mac mini release-fleet dogfood reached the DeepSeek-R1 cell and failed before model load because `coherence_sweep.sh` passes `--thinking`, which the serve CLI does not recognize. This leaves the reasoning-distill family permanently untested.

## Fix
Use the supported `--reasoning` serve profile for reasoning-distill models while retaining `--reasoning-distill` scoring in the gate.

## Validation
- reproduced `unrecognized arguments: --thinking`
- verified `serve --help` exposes `--reasoning`
- `bash -n scripts/coherence_sweep.sh`
- `python3 -m pytest -q tests/test_release_fleet.py` (19 passed)
- `git diff --check`