### PR TITLE
fix(cli): honor --force-disk-check during serve prefetch

### DIFF
--- a/tests/test_cli_chat.py
+++ b/tests/test_cli_chat.py
@@ -1527,9 +1527,7 @@ def test_ensure_model_downloaded_calls_disk_check(monkeypatch):
     )
 
     cli._ensure_model_downloaded("mlx-community/Fake-Model-1B")
-    cli._ensure_model_downloaded(
-        "mlx-community/Fake-Model-1B", force_disk_check=True
-    )
+    cli._ensure_model_downloaded("mlx-community/Fake-Model-1B", force_disk_check=True)
     assert called == [
         ("mlx-community/Fake-Model-1B", False),
         ("mlx-community/Fake-Model-1B", True),

--- a/tests/test_cli_chat.py
+++ b/tests/test_cli_chat.py
@@ -1513,7 +1513,7 @@ def test_ensure_model_downloaded_calls_disk_check(monkeypatch):
     called: list = []
 
     def _fake_check(name, force=False):
-        called.append(name)
+        called.append((name, force))
 
     monkeypatch.setattr(cli, "_check_disk_space", _fake_check)
     # Make snapshot_download a no-op so we don't hit the network.
@@ -1527,7 +1527,13 @@ def test_ensure_model_downloaded_calls_disk_check(monkeypatch):
     )
 
     cli._ensure_model_downloaded("mlx-community/Fake-Model-1B")
-    assert called == ["mlx-community/Fake-Model-1B"]
+    cli._ensure_model_downloaded(
+        "mlx-community/Fake-Model-1B", force_disk_check=True
+    )
+    assert called == [
+        ("mlx-community/Fake-Model-1B", False),
+        ("mlx-community/Fake-Model-1B", True),
+    ]
 
 
 def test_ensure_model_downloaded_uses_strict_cache_probe(monkeypatch):

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1550,7 +1550,9 @@ def _try_mirror_prefetch(
     return download_with_mirror_fallback(model_name, on_pull_start=on_pull_start)
 
 
-def _ensure_model_downloaded(model_name: str) -> None:
+def _ensure_model_downloaded(
+    model_name: str, *, force_disk_check: bool = False
+) -> None:
     """Pre-fetch a model in the foreground so HF's tqdm progress is visible.
 
     Used by ``rapid-mlx chat``: the chat REPL spawns ``serve`` as a
@@ -1598,7 +1600,7 @@ def _ensure_model_downloaded(model_name: str) -> None:
         # HF cache filesystem. Clear the spinner first on that fatal path so
         # the abort message and the shell prompt after it land on clean lines.
         try:
-            _check_disk_space(model_name)
+            _check_disk_space(model_name, force=force_disk_check)
         except SystemExit:
             spinner.stop()
             raise
@@ -2580,7 +2582,13 @@ def serve_command(args):
     # revision parameter and could otherwise download repository HEAD first,
     # duplicating tens of gigabytes before the pinned snapshot is loaded.
     if not _is_wan_video:
-        _ensure_model_downloaded(args.model)
+        if getattr(args, "force_disk_check", False):
+            _ensure_model_downloaded(args.model, force_disk_check=True)
+        else:
+            # Keep the historical one-argument call on the default path; a
+            # number of embedders/tests replace this hook with a one-argument
+            # prefetch function.
+            _ensure_model_downloaded(args.model)
 
     # Import unified server
     from . import server


### PR DESCRIPTION
## Why
Mac mini DeepSeek release dogfood left an almost-complete 18.4GB download with 11.7GB free. `rapid-mlx serve ... --force-disk-check` still exited with the disk-space error because `serve_command` dropped the flag when calling `_ensure_model_downloaded`, whose second disk check always used `force=False`.

## Fix
Thread the explicit override into foreground prefetch. Preserve the historical one-argument hook call when the flag is absent for embedders and tests.

## Validation
- reproduced the advertised override failing in both CLI argument positions
- 3 focused prefetch/wiring tests passed
- 28 disk-space and server-load-order tests passed
- `git diff --check`