### PR TITLE
fix(release): give reasoning coherence gate answer headroom

### DIFF
--- a/evals/coherence_gate.py
+++ b/evals/coherence_gate.py
@@ -59,6 +59,12 @@ from vllm_mlx.coherence import (  # noqa: E402
 
 _DEFAULT_BASE_URL = os.environ.get("RAPID_MLX_BASE_URL", "http://127.0.0.1:8000/v1")
 
+# DeepSeek-R1-Distill can spend roughly 450 tokens reasoning about even a
+# one-word fact before emitting its conclusion.  The ordinary golden budgets
+# intentionally stay tiny, but reasoning mode needs enough room to reach the
+# answer instead of testing truncation behavior.
+_REASONING_BUDGET_MULTIPLIER = 16
+
 
 class InvalidServerResponseError(RuntimeError):
     """The server replied, but not with a valid chat-completion payload."""
@@ -72,7 +78,11 @@ def _generate(
     body = {
         "model": "default",
         "messages": [{"role": "user", "content": case.prompt}],
-        "max_tokens": case.max_tokens * 4 if thinking else case.max_tokens,
+        "max_tokens": (
+            case.max_tokens * _REASONING_BUDGET_MULTIPLIER
+            if thinking
+            else case.max_tokens
+        ),
         "temperature": 0.0,
         "stream": False,
         # Match the gauntlet's --no-thinking boot for ordinary families: the

--- a/tests/test_coherence.py
+++ b/tests/test_coherence.py
@@ -185,6 +185,29 @@ def test_evaluate_concluded_rejects_coherent_but_wrong() -> None:
     assert not evaluate_concluded(case, "<think>reasoning</think> Osaka")[0]
 
 
+def test_evaluate_concluded_accepts_only_a_terminal_boxed_answer() -> None:
+    case = next(c for c in GOLDEN if c.id == "arithmetic")
+    real_deepseek_shape = (
+        "To find the product, multiply and add the partial results. "
+        "Therefore the product is:\n\\[\n\\boxed{391}\n\\]"
+    )
+    passed, reason = evaluate_concluded(case, real_deepseek_shape)
+    assert passed
+    assert "terminal boxed" in reason
+
+    # Merely mentioning the expected result before a different conclusion must
+    # not turn the strict golden gate green.
+    assert not evaluate_concluded(case, r"Maybe \boxed{391}, but final: 392")[0]
+    assert not evaluate_concluded(case, r"Therefore: \boxed{392}")[0]
+
+    word_case = next(c for c in GOLDEN if c.id == "capital-japan")
+    assert evaluate_concluded(word_case, r"Therefore: \boxed{\text{Tokyo}}")[0]
+    assert evaluate_concluded(word_case, r"Therefore: \boxed{\mathrm{Tokyo}}")[0]
+    assert not evaluate_concluded(
+        word_case, r"Maybe \boxed{\text{Tokyo}}, but final: Osaka"
+    )[0]
+
+
 def test_evaluate_concluded_rejects_pure_reasoning_no_answer() -> None:
     case = next(c for c in GOLDEN if c.id == "arithmetic")
     passed, reason = evaluate_concluded(case, "<think>17 times 23 is 391...")
@@ -202,6 +225,40 @@ def test_reasoning_distill_untagged_prose_does_not_false_pass() -> None:
         "country in East Asia. Its largest city is Tokyo, which is where the "
         "government sits. I'm fairly sure the capital is Tok",
     )[0]
+
+
+@pytest.mark.parametrize(
+    ("thinking", "expected_max_tokens"), [(False, 32), (True, 512)]
+)
+def test_gate_gives_reasoning_distill_enough_budget_to_reach_its_conclusion(
+    monkeypatch: pytest.MonkeyPatch,
+    thinking: bool,
+    expected_max_tokens: int,
+) -> None:
+    case = next(c for c in GOLDEN if c.id == "capital-japan")
+    captured: dict[str, object] = {}
+
+    class Response:
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict[str, object]:
+            return {"choices": [{"message": {"content": "Tokyo"}}]}
+
+    def fake_post(_url: str, *, json: dict[str, object], timeout: float) -> Response:
+        captured.update(json)
+        assert timeout == 120.0
+        return Response()
+
+    monkeypatch.setattr(coherence_gate.httpx, "post", fake_post)
+    assert (
+        coherence_gate._generate(
+            "http://localhost:8000/v1", case, timeout=120.0, thinking=thinking
+        )
+        == "Tokyo"
+    )
+    assert captured["max_tokens"] == expected_max_tokens
+    assert captured["enable_thinking"] is thinking
 
 
 def test_gate_returns_infrastructure_code_for_midrun_transport_failure(

--- a/vllm_mlx/coherence.py
+++ b/vllm_mlx/coherence.py
@@ -63,12 +63,44 @@ _THINK_BLOCK_RE = re.compile(
     re.IGNORECASE,
 )
 
+# A reasoning model may put its terse final result in a terminal LaTeX box
+# after a visible explanation.  Only accept a box at the very end; searching
+# anywhere in the prose would let a model false-green merely by mentioning the
+# expected token before reaching a different conclusion.
+_LATEX_TEXT_WRAPPER_RE = re.compile(
+    r"\\(?:text|mathrm|operatorname)\{([^{}]+)\}", re.IGNORECASE
+)
+
 
 def strip_thinking(text: str) -> str:
     """Remove reasoning-channel markers/blocks, returning only visible text."""
     if not text:
         return text
     return _THINK_BLOCK_RE.sub("", text).strip()
+
+
+def _terminal_boxed_content(text: str) -> str | None:
+    """Return the balanced content of a terminal ``\\boxed{...}``, if any."""
+    marker = r"\boxed{"
+    start = text.rfind(marker)
+    if start < 0:
+        return None
+    content_start = start + len(marker)
+    depth = 1
+    for index in range(content_start, len(text)):
+        char = text[index]
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                suffix = text[index + 1 :].strip()
+                if suffix not in {"", r"\]"}:
+                    return None
+                content = text[content_start:index].strip()
+                wrapper = _LATEX_TEXT_WRAPPER_RE.fullmatch(content)
+                return wrapper.group(1) if wrapper else content
+    return None
 
 
 def _max_char_run(s: str) -> int:
@@ -278,6 +310,9 @@ def evaluate_concluded(case: GoldenCase, text: str) -> tuple[bool, str]:
         return False, "no concluded answer after stripping reasoning channel"
     if _matches_exact(concluded, case.expect):
         return True, f"concluded answer exactly matches {case.expect!r}"
+    boxed = _terminal_boxed_content(concluded)
+    if boxed is not None and _matches_exact(boxed, case.expect):
+        return True, f"terminal boxed conclusion exactly matches {case.expect!r}"
     return False, f"concluded answer not an exact match for {case.expect!r}"
 
 


### PR DESCRIPTION
## Repro
On a 32 GB Mac mini, DeepSeek-R1-Distill-Qwen-32B-4bit initially failed 5/6 coherence golden cases because 128 tokens truncated reasoning before the final answer. At 512 tokens it reached conclusions and passed 5/6; arithmetic correctly concluded with a terminal `\boxed{391}` after visible explanatory prose, which strict whole-content matching rejected.

## Fix
- Raise only the reasoning-distill gate budget multiplier from 4x to 16x; ordinary no-thinking gates retain their small budgets.
- Accept an exact expected value in a terminal LaTeX box as a concluded answer. The box must be at the end, so merely mentioning the correct token before a different conclusion still fails.

## Validation
- Real DeepSeek 32B control: 512-token request completed after 462 tokens
- Focused gate/fleet tests: 87 passed
- Ruff format/check clean
- Mac mini full 6-case reasoning-distill rerun pending on this revision