### PR TITLE
fix(dogfood): isolate Application Support too, not just preferences

### DIFF
--- a/apps/rapid-mac/scripts/dogfood-isolate.sh
+++ b/apps/rapid-mac/scripts/dogfood-isolate.sh
@@ -29,10 +29,13 @@
 #
 # Example:
 #   APP=$(./scripts/dogfood-isolate.sh "build/Rapid-MLX Desktop.app" /tmp/persona2-alex)
-#   open -n "$APP"
+#   /tmp/persona2-alex/launch.sh &        # NOT `open -n` — that drops $HOME
+#                                         # and silently re-shares the user's
+#                                         # Application Support (#1561)
 #   # ... run test ...
 #   pkill -f "$APP"                       # path-qualified — NEVER bare 'pkill -f Rapid'
 #   defaults delete "com.rapidmlx.rapid.dogfood-<id>"   # isolated bundle only
+#   rm -rf /tmp/persona2-alex             # takes the throwaway $HOME with it
 
 set -euo pipefail
 
@@ -281,13 +284,32 @@ log "signature verified"
 # inherit launchd's environment, not the caller's. The launcher therefore
 # execs the bundle's Mach-O directly, which does inherit it.
 HOME_DIR="$TARGET_ABS/home"
-rm -rf "$HOME_DIR"
+HOME_MARKER="$HOME_DIR/.dogfood-throwaway-home"
+# `rm -rf` on a path the caller half-chose needs its own guard. The layers
+# above vet <target-dir>, but they permit any ordinary directory — so
+# `dogfood-isolate.sh app.app ~/projects` would take `~/projects/home` with
+# it. Only ever delete a directory this script created and marked.
+if [[ -e "$HOME_DIR" ]]; then
+    if [[ ! -f "$HOME_MARKER" ]]; then
+        die "refusing to remove '$HOME_DIR' — it exists but carries no $(basename "$HOME_MARKER") marker, so this script did not create it. Pick an empty <target-dir>."
+    fi
+    rm -rf "$HOME_DIR"
+fi
 mkdir -p "$HOME_DIR/Library/Application Support"
+printf 'Created by dogfood-isolate.sh. Safe to delete with the target dir.\n' \
+    > "$HOME_MARKER"
 
-# The model cache is the one thing worth SHARING: it is tens of gigabytes,
-# read-mostly, and re-downloading it per run makes isolation unaffordable
-# (a fresh $HOME alone turns a 2-second launch into a 7.6 GB download).
-# Point HF_HOME at the real cache unless the caller wants a cold one.
+# The model cache is the one thing worth SHARING by default: it is tens of
+# gigabytes and mostly read, and re-downloading it per run makes isolation
+# unaffordable (a fresh $HOME alone turns a 2-second launch into a 7.6 GB
+# download — 67 GB on a machine whose RAM tier recommends the 122B).
+#
+# "Mostly" read, though, not read-only: auto-start rewrites bundled-model
+# symlinks and rebuilds Quickstart stubs inside the cache, and those can be
+# left pointing into this throwaway directory after it is deleted. So the
+# sharing is a deliberate, stated trade — use the cold cache whenever the
+# run is about model management, downloads, or first-start, and accept the
+# download cost there.
 REAL_HF_HOME="${HF_HOME:-$HOME/.cache/huggingface}"
 if [[ "${DOGFOOD_COLD_MODEL_CACHE:-0}" == "1" ]]; then
     HF_HOME_FOR_RUN="$HOME_DIR/.cache/huggingface"
@@ -320,6 +342,11 @@ cat > "$LAUNCHER" <<LAUNCHEOF
 set -euo pipefail
 export HOME="$HOME_DIR"
 export HF_HOME="$HF_HOME_FOR_RUN"
+# HF_HUB_CACHE wins over HF_HOME wherever both are read (see
+# BundledModel.userHFCacheURL), so an inherited one from the caller's shell
+# would quietly point the run back at their real cache — including under
+# DOGFOOD_COLD_MODEL_CACHE=1, where the whole point is that there isn't one.
+unset HF_HUB_CACHE
 exec "$TARGET_APP/Contents/MacOS/$EXECUTABLE" "\$@"
 LAUNCHEOF
 chmod +x "$LAUNCHER"
@@ -334,7 +361,10 @@ log "  cleanup later: defaults delete '$NEW_ID' && rm -rf '$TARGET_ABS'"
 log "  shutdown:      pkill -f '$TARGET_APP'    # path-qualified, do NOT use bare 'pkill -f Rapid'"
 log ""
 log "  STILL SHARED (not isolated by this script):"
-log "    * the model cache above, on purpose — see DOGFOOD_COLD_MODEL_CACHE=1"
+log "    * the model cache above, on purpose — and the app WRITES to it"
+log "      (bundled-model symlinks, Quickstart stubs). Use"
+log "      DOGFOOD_COLD_MODEL_CACHE=1 for anything about downloads,"
+log "      model management, or first-start."
 log "    * anything the app reaches by absolute path rather than via \$HOME"
 log "    * macOS TCC decisions are per bundle-id, so they DO reset — a run"
 log "      will re-prompt for permissions the user's real app already has"

--- a/apps/rapid-mac/scripts/dogfood-isolate.sh
+++ b/apps/rapid-mac/scripts/dogfood-isolate.sh
@@ -50,12 +50,19 @@ ARGUMENTS:
                    If the target already contains a copy of the .app, it is
                    removed first (idempotent re-runs are safe).
 
+ENVIRONMENT:
+    DOGFOOD_COLD_MODEL_CACHE=1
+                   Give the run an empty model cache too. Off by default:
+                   the cache is tens of gigabytes and read-mostly, and a
+                   cold one turns every launch into a multi-GB download.
+
 OUTPUT:
     Progress and diagnostics are written to STDERR.
     The absolute path to the isolated .app is written to STDOUT, so callers
     can capture it:
 
         APP=$(./scripts/dogfood-isolate.sh build/Rapid.app /tmp/harness)
+        /tmp/harness/launch.sh &        # NOT `open -n` — see below
 
 WHAT IT DOES:
     1. Copy <source.app> into <target-dir>/<source-basename>.
@@ -63,15 +70,34 @@ WHAT IT DOES:
        com.rapidmlx.rapid -> com.rapidmlx.rapid.dogfood-<8hex>.
     3. Strip the existing code signature (codesign --remove-signature).
     4. Re-sign ad-hoc (codesign --sign - --deep --force).
+    5. Mint a throwaway $HOME and write <target-dir>/launch.sh, which
+       execs the bundle with that $HOME set.
 
 WHY:
-    cfprefsd keys preferences on bundle identifier, not $HOME. Rewriting
-    the bundle-id is the only way to fully isolate plist state between a
-    dogfood test launch and the user's installed prod app.
+    Two different stores have to be isolated, and they need two different
+    mechanisms.
+
+    cfprefsd keys preferences on bundle identifier, not $HOME — so the
+    bundle-id rewrite is what isolates plist state.
+
+    Application Support is the other half. Several subsystems resolve
+    ~/Library/Application Support/Rapid by NAME, so a bundle-id rewrite
+    alone leaves the isolated instance reading and writing the user's real
+    sessions.json / owned-server.json / crash-markers, and enough
+    first-run state lives there that onboarding stops appearing on the
+    second run (#1561). ApplicationSupportLocator already prefers $HOME
+    when set, so a throwaway $HOME closes it.
+
+    `open -n` cannot deliver that $HOME: LaunchServices starts the app
+    from launchd's environment, not the caller's. `launch.sh` execs the
+    Mach-O directly instead, which inherits it.
 
 NEVER:
     * Touch ~/Library/Preferences/com.rapidmlx.rapid.plist (prod plist).
     * Modify /Applications/Rapid-MLX Desktop.app (prod app).
+    * Launch the isolated copy with `open -n` — that silently re-shares
+      the user's Application Support and makes the run a returning-user
+      run wearing a fresh bundle-id.
     * Run `pkill -f Rapid` against the isolated copy — always
       `pkill -f "<absolute path to isolated .app>"`.
 EOF
@@ -237,11 +263,81 @@ if ! codesign --verify --deep --strict "$TARGET_APP" >/dev/null 2>&1; then
 fi
 log "signature verified"
 
+# --- 5. throwaway $HOME + launcher -------------------------------------------
+# Rewriting the bundle-id isolates CFPreferences and nothing else. Several
+# subsystems resolve ~/Library/Application Support/Rapid by NAME, so without
+# this an "isolated" instance still reads and writes the user's real
+# sessions.json, owned-server.json and crash-markers/ — and enough first-run
+# state lives there that onboarding silently stops appearing on the second
+# run. Issue #1561: three consecutive runs with three fresh bundle-ids showed
+# the wizard exactly once, and the telemetry-consent prompt never, because
+# ~/.rapid-mlx/telemetry-consent.yaml is shared too.
+#
+# ``ApplicationSupportLocator`` already prefers $HOME when it is set and
+# absolute (that is what #419/#420 built it for), so a throwaway $HOME is all
+# that is needed — the app does the rest.
+#
+# ``open -n`` cannot carry this: GUI apps launched through LaunchServices
+# inherit launchd's environment, not the caller's. The launcher therefore
+# execs the bundle's Mach-O directly, which does inherit it.
+HOME_DIR="$TARGET_ABS/home"
+rm -rf "$HOME_DIR"
+mkdir -p "$HOME_DIR/Library/Application Support"
+
+# The model cache is the one thing worth SHARING: it is tens of gigabytes,
+# read-mostly, and re-downloading it per run makes isolation unaffordable
+# (a fresh $HOME alone turns a 2-second launch into a 7.6 GB download).
+# Point HF_HOME at the real cache unless the caller wants a cold one.
+REAL_HF_HOME="${HF_HOME:-$HOME/.cache/huggingface}"
+if [[ "${DOGFOOD_COLD_MODEL_CACHE:-0}" == "1" ]]; then
+    HF_HOME_FOR_RUN="$HOME_DIR/.cache/huggingface"
+    mkdir -p "$HF_HOME_FOR_RUN"
+    log "  model cache: COLD (DOGFOOD_COLD_MODEL_CACHE=1) — expect real downloads"
+else
+    HF_HOME_FOR_RUN="$REAL_HF_HOME"
+fi
+
+# The binary is named by CFBundleExecutable, which is NOT the bundle's
+# filename — this app ships "Rapid-MLX Desktop.app" wrapping MacOS/Rapid
+# (see #488: the display name was renamed, the .app filename deliberately
+# was not). Deriving it from the basename produces a launcher that cannot
+# exec anything.
+EXECUTABLE=$(/usr/libexec/PlistBuddy -c "Print :CFBundleExecutable" "$PLIST" 2>/dev/null || true)
+if [[ -z "$EXECUTABLE" ]]; then
+    die "could not read CFBundleExecutable from $PLIST"
+fi
+if [[ ! -x "$TARGET_APP/Contents/MacOS/$EXECUTABLE" ]]; then
+    die "CFBundleExecutable '$EXECUTABLE' is not executable in $TARGET_APP/Contents/MacOS"
+fi
+
+LAUNCHER="$TARGET_ABS/launch.sh"
+cat > "$LAUNCHER" <<LAUNCHEOF
+#!/usr/bin/env bash
+# Generated by dogfood-isolate.sh — launches the isolated copy with the
+# throwaway \$HOME that keeps its Application Support out of the user's.
+# Do NOT replace this with 'open -n': that goes through LaunchServices,
+# which drops the environment and re-shares the user's app state.
+set -euo pipefail
+export HOME="$HOME_DIR"
+export HF_HOME="$HF_HOME_FOR_RUN"
+exec "$TARGET_APP/Contents/MacOS/$EXECUTABLE" "\$@"
+LAUNCHEOF
+chmod +x "$LAUNCHER"
+
 # --- done --------------------------------------------------------------------
 log "isolated .app ready: $TARGET_APP"
 log "  new bundle-id: $NEW_ID"
-log "  cleanup later: defaults delete '$NEW_ID'"
+log "  throwaway HOME: $HOME_DIR"
+log "  model cache:    $HF_HOME_FOR_RUN"
+log "  LAUNCH WITH:   $LAUNCHER &          # NOT 'open -n' — that drops \$HOME"
+log "  cleanup later: defaults delete '$NEW_ID' && rm -rf '$TARGET_ABS'"
 log "  shutdown:      pkill -f '$TARGET_APP'    # path-qualified, do NOT use bare 'pkill -f Rapid'"
+log ""
+log "  STILL SHARED (not isolated by this script):"
+log "    * the model cache above, on purpose — see DOGFOOD_COLD_MODEL_CACHE=1"
+log "    * anything the app reaches by absolute path rather than via \$HOME"
+log "    * macOS TCC decisions are per bundle-id, so they DO reset — a run"
+log "      will re-prompt for permissions the user's real app already has"
 
 # STDOUT: just the path, for $(./scripts/dogfood-isolate.sh ...) capture.
 printf '%s\n' "$TARGET_APP"


### PR DESCRIPTION
## Why

`dogfood-isolate.sh` rewrites the bundle identifier, which isolates
CFPreferences and nothing else. Several subsystems resolve
`~/Library/Application Support/Rapid` by **name**, so an "isolated" instance
still read and wrote the user's real `owned-server.json` and `crash-markers/`,
and enough first-run state lives outside the plist that the run stopped being a
first run.

Observed across three consecutive runs, each with its own freshly minted
bundle-id:

| run | onboarding wizard | telemetry consent |
|---|---|---|
| 1 | shown | not shown |
| 2 | **not shown** | not shown |
| 3 | **not shown** | not shown |

Two of three "fresh install" runs were returning-user runs wearing a new
bundle-id — the same failure this script's own header describes for the plist,
one directory over. The telemetry-consent prompt had never been exercised by a
dogfood run at all, because `~/.rapid-mlx/telemetry-consent.yaml` is shared too.

## What changed

Both halves already existed and just were not used together.
`ApplicationSupportLocator` prefers `$HOME` when it is set and absolute — that
is what #419/#420 built it for, after a v0.8.8 dogfood instance read the user's
real `sessions.json`. So the script mints a throwaway `$HOME` next to the
throwaway bundle-id.

`open -n` cannot carry it: LaunchServices starts the app from launchd's
environment, not the caller's. The script writes a `launch.sh` that execs the
bundle's Mach-O directly, and the docs say plainly not to substitute `open -n`
— the old header example did exactly that, which would have undone the fix for
anyone following it.

The executable name comes from `CFBundleExecutable`, not the bundle filename:
this app ships `Rapid-MLX Desktop.app` wrapping `MacOS/Rapid` (#488 renamed the
display name and deliberately not the .app), so deriving it from the basename
produces a launcher that cannot exec anything. Caught by running the generated
launcher.

The model cache is deliberately **not** isolated by default — it is tens of
gigabytes, and a cold one turns every launch into a multi-GB download (67 GB on
a machine whose RAM tier recommends the 122B). `DOGFOOD_COLD_MODEL_CACHE=1` opts
in when the run is specifically about downloads, model management or
first-start. The log now states that the app *writes* to that cache (bundled
model symlinks, Quickstart stubs), rather than calling it read-only, and prints
everything else the script does not isolate so the next person reading a dogfood
report knows the boundary instead of assuming there isn't one.

From review:

* `rm -rf "$HOME_DIR"` ran on a path the caller half-chooses — the layers above
  vet `<target-dir>` against system prefixes and the source bundle, but permit
  any ordinary directory, so `dogfood-isolate.sh app.app ~/projects` would have
  taken `~/projects/home`. The script now writes a `.dogfood-throwaway-home`
  marker into the directory it creates and refuses to delete one without it.
* `HF_HUB_CACHE` takes precedence over `HF_HOME` wherever both are read
  (`BundledModel.userHFCacheURL`), so an inherited one would have pointed the run
  back at the real cache — including under `DOGFOOD_COLD_MODEL_CACHE=1`, where
  the whole point is that there isn't one. The launcher unsets it.

## Test plan

Run against a build of `main`:

* the generated `launch.sh` execs successfully (the `CFBundleExecutable` bug was
  found this way — the first version produced a launcher pointing at a
  non-existent `MacOS/Rapid-MLX Desktop`)
* the telemetry-consent prompt **and** the welcome wizard both appear, neither of
  which appeared on any dogfood run before this change
* `~/Library/Application Support/Rapid` mtimes are unchanged after a run; the
  state lands under `<target-dir>/home/Library/Application Support/` instead
* delete guard: a pre-existing `home/user-data.txt` survives and the run aborts
  with the reason; re-running against the script's own marked directory stays
  idempotent
* `DOGFOOD_COLD_MODEL_CACHE=1` produces a genuinely cold run — which is how
  #1564 (a brand-new user facing a 67.1 GB download after skipping the wizard)
  became reproducible at all

`bash -n` clean. The two `shellcheck` infos on the file are pre-existing
(SC2018/SC2019 on the `uuidgen | tr` line, untouched here).

Closes #1561