### PR TITLE
feat(rapid-mac): pin, rename and archive conversations; retry replays in place

### DIFF
--- a/apps/rapid-mac/Resources/Info.plist
+++ b/apps/rapid-mac/Resources/Info.plist
@@ -26,6 +26,8 @@
 	<string>14.0</string>
 	<key>NSHighResolutionCapable</key>
 	<true/>
+	<key>NSAccentColorName</key>
+	<string>AccentColor</string>
 	<key>NSNetworkVolumesUsageDescription</key>
 	<string>Rapid needs access when you choose a network drive for model storage or approve a file tool there. Click Allow to continue.</string>
 	<key>NSRemovableVolumesUsageDescription</key>

--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
@@ -202,7 +202,12 @@ final class ChatViewModel {
                 at: now
             ) { conversation in
                 conversation.messages = messages
-                conversation.title = title
+                // A renamed row keeps its name. Re-deriving unconditionally
+                // meant the next streamed token silently reverted the user's
+                // rename back to the first prompt's opening words.
+                if !conversation.hasCustomTitle {
+                    conversation.title = title
+                }
             }
         } else {
             conversations.insert(
@@ -216,9 +221,64 @@ final class ChatViewModel {
                 at: 0
             )
         }
-        if persistsConversations {
-            ConversationStore.save(conversations, to: conversationStoreURL)
-        }
+        saveConversations()
+    }
+
+    // MARK: - Conversation row actions (rename / pin / archive)
+
+    /// Rename a saved conversation.
+    ///
+    /// Trimmed, and blank input is rejected rather than accepted as an empty
+    /// row label — an unnamed row already has a sensible derived title, so
+    /// "clear the name" is better served by the caller not committing.
+    /// Setting ``hasCustomTitle`` is what stops ``persistActive`` re-deriving
+    /// the title from the transcript on the next save.
+    ///
+    /// A rename is not conversation *activity*, so ``updatedAt`` and the row's
+    /// position are left alone — the same reasoning ``ConversationOrdering``
+    /// applies to merely opening a conversation.
+    @discardableResult
+    func renameConversation(_ id: UUID, to newTitle: String) -> Bool {
+        let trimmed = newTitle.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return false }
+        guard let index = conversations.firstIndex(where: { $0.id == id }) else { return false }
+        conversations[index].title = trimmed
+        conversations[index].hasCustomTitle = true
+        saveConversations()
+        return true
+    }
+
+    /// Pin / unpin a conversation. Pinned rows get their own sidebar section
+    /// above the date buckets.
+    func setConversationPinned(_ id: UUID, _ pinned: Bool) {
+        guard let index = conversations.firstIndex(where: { $0.id == id }) else { return }
+        guard conversations[index].isPinned != pinned else { return }
+        conversations[index].isPinned = pinned
+        // Pinning something archived is contradictory — the row would be
+        // pinned to a list it isn't in. Surfacing it is the intent.
+        if pinned { conversations[index].isArchived = false }
+        saveConversations()
+    }
+
+    /// Archive / unarchive a conversation. Archiving is deliberately NOT a
+    /// delete: the transcript stays on disk and the row remains reachable
+    /// from the sidebar's Archived section, which is why — unlike Delete —
+    /// it needs no confirmation and is one click to undo.
+    ///
+    /// Archiving the OPEN conversation leaves it open. Closing the transcript
+    /// out from under the user would turn a filing action into an unexpected
+    /// navigation, and re-reading what you just archived is normal.
+    func setConversationArchived(_ id: UUID, _ archived: Bool) {
+        guard let index = conversations.firstIndex(where: { $0.id == id }) else { return }
+        guard conversations[index].isArchived != archived else { return }
+        conversations[index].isArchived = archived
+        if archived { conversations[index].isPinned = false }
+        saveConversations()
+    }
+
+    private func saveConversations() {
+        guard persistsConversations else { return }
+        ConversationStore.save(conversations, to: conversationStoreURL)
     }
 
     /// Load a saved conversation into the transcript, archiving whatever is
@@ -260,9 +320,7 @@ final class ChatViewModel {
             lastFailureAlias = nil
         }
         conversations.removeAll { $0.id == id }
-        if persistsConversations {
-            ConversationStore.save(conversations, to: conversationStoreURL)
-        }
+        saveConversations()
     }
 
     // MARK: - In-memory message storage
@@ -873,8 +931,16 @@ final class ChatViewModel {
     /// Edit a user turn in place: replace its prose, drop everything
     /// that came after it, and re-send. Matches ChatGPT Desktop's
     /// "edit message" pattern — the edit point becomes the new
-    /// conversation tip. The prior transcript is retained as a sidebar branch
-    /// so later turns are never destroyed by the replay.
+    /// conversation tip.
+    ///
+    /// The replay stays on the CURRENT conversation id. An earlier build
+    /// forked to a fresh id here so the pre-edit transcript survived as a
+    /// recoverable branch, but the branch was indistinguishable from a real
+    /// chat in the sidebar: every edit and every Retry silently spawned a
+    /// duplicate row with the same title, so a few regenerations buried the
+    /// history list under near-identical entries. Rewinding in place is what
+    /// ChatGPT and Claude desktop do, and it is what the row the user is
+    /// looking at appears to promise.
     @discardableResult
     func editUserMessage(
         id: UUID,
@@ -885,10 +951,6 @@ final class ChatViewModel {
         let trimmed = newContent.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return false }
         guard let idx = messages.firstIndex(where: { $0.id == id && $0.role == .user }) else { return false }
-        // Preserve the original transcript under its current conversation id,
-        // then continue the edit as a new branch. A one-click edit of an older
-        // turn must never overwrite all later turns on disk.
-        forkConversationForReplay()
         messages = Array(messages.prefix(idx))
         send(trimmed, alias: alias)
         return true
@@ -923,21 +985,11 @@ final class ChatViewModel {
         guard !userText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             return false
         }
-        // The selected response and every later turn remain available in the
-        // original sidebar conversation; the regenerated path gets a new id.
-        forkConversationForReplay()
+        // In place, on the SAME conversation id — see ``editUserMessage``
+        // for why the old fork-into-a-branch behaviour was removed.
         messages = Array(messages.prefix(userIndex))
         send(userText, alias: alias)
         return true
-    }
-
-    /// Snapshot the current transcript and move subsequent replay mutations
-    /// onto a fresh conversation id. This is a lightweight conversation branch:
-    /// the UI can keep its simple linear transcript while Edit/Retry remains
-    /// lossless and the original is recoverable from the sidebar.
-    private func forkConversationForReplay() {
-        persistActive(touching: false)
-        activeConversationID = UUID()
     }
 
     /// Same as ``regenerateLast(alias:)`` but brings up ``newAlias``

--- a/apps/rapid-mac/Sources/Rapid/Chat/ConversationHistory.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ConversationHistory.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// A saved conversation — the unit the sidebar "Older" list shows and the
+/// A saved conversation — the unit the sidebar history list shows and the
 /// on-disk history persists. ``ChatMessage`` is already ``Codable``, so a
 /// conversation serialises as-is.
 struct ChatConversation: Identifiable, Codable, Equatable {
@@ -9,6 +9,59 @@ struct ChatConversation: Identifiable, Codable, Equatable {
     var messages: [ChatMessage]
     let createdAt: Date
     var updatedAt: Date
+
+    /// Pinned rows sort into their own section above the date buckets and
+    /// stay there regardless of how stale ``updatedAt`` gets.
+    var isPinned: Bool = false
+
+    /// Archived rows leave the main list entirely. They are NOT deleted —
+    /// the transcript is untouched on disk — they just stop competing for
+    /// attention with active work, and are reachable through the sidebar's
+    /// Archived disclosure.
+    var isArchived: Bool = false
+
+    /// Set once the user renames the row. ``ChatViewModel.persistActive``
+    /// re-derives ``title`` from the first user turn on every save, which
+    /// would silently stomp a manual rename on the next streamed token;
+    /// this flag is what makes the derivation skip an owned title.
+    var hasCustomTitle: Bool = false
+
+    init(
+        id: UUID,
+        title: String,
+        messages: [ChatMessage],
+        createdAt: Date,
+        updatedAt: Date,
+        isPinned: Bool = false,
+        isArchived: Bool = false,
+        hasCustomTitle: Bool = false
+    ) {
+        self.id = id
+        self.title = title
+        self.messages = messages
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+        self.isPinned = isPinned
+        self.isArchived = isArchived
+        self.hasCustomTitle = hasCustomTitle
+    }
+
+    /// Hand-written so a history file written before pin/archive shipped
+    /// still decodes. The synthesised initialiser treats every stored
+    /// property as required, so a missing `isPinned` key would throw —
+    /// and ``ConversationStore.load`` turns one throw into "the whole
+    /// history is corrupt", i.e. an apparently wiped sidebar on upgrade.
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        id = try c.decode(UUID.self, forKey: .id)
+        title = try c.decode(String.self, forKey: .title)
+        messages = try c.decode([ChatMessage].self, forKey: .messages)
+        createdAt = try c.decode(Date.self, forKey: .createdAt)
+        updatedAt = try c.decode(Date.self, forKey: .updatedAt)
+        isPinned = try c.decodeIfPresent(Bool.self, forKey: .isPinned) ?? false
+        isArchived = try c.decodeIfPresent(Bool.self, forKey: .isArchived) ?? false
+        hasCustomTitle = try c.decodeIfPresent(Bool.self, forKey: .hasCustomTitle) ?? false
+    }
 }
 
 extension ChatConversation: ConversationOrderingItem {}

--- a/apps/rapid-mac/Sources/Rapid/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/apps/rapid-mac/Sources/Rapid/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x1F",
+          "green" : "0x82",
+          "red" : "0xC9"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x3A",
+          "green" : "0xA2",
+          "red" : "0xEF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/apps/rapid-mac/Sources/Rapid/UI/SidebarView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SidebarView.swift
@@ -50,6 +50,23 @@ struct SidebarView: View {
     /// no trash, no undo), so — unlike navigating — it must be confirmed first.
     @State private var pendingDeletion: ChatConversation?
 
+    /// The conversation currently being renamed inline, plus its draft text.
+    /// Inline (rather than a sheet) because a rename is a one-field edit on a
+    /// row the user is already pointing at; a modal for it reads as a much
+    /// heavier action than it is.
+    @State private var renamingID: UUID?
+    @State private var renameDraft = ""
+
+    /// Whether the Archived group is expanded. Collapsed by default — the
+    /// whole point of archiving is to get those rows out of the way.
+    @State private var showArchived = false
+
+    /// Which history row the pointer is over. Tracked here rather than inside
+    /// ``SidebarRow`` because the pin / ··· controls are siblings of the row
+    /// button (a `Menu` inside a `Button` label is unclickable), so they need
+    /// a hover signal the row itself doesn't own.
+    @State private var hoveredConversationID: UUID?
+
     var body: some View {
         VStack(alignment: .leading, spacing: 1) {
             row(
@@ -80,6 +97,7 @@ struct SidebarView: View {
                                 conversationRow(conv)
                             }
                         }
+                        archivedSection
                     }
                 }
                 .scrollIndicators(.never)
@@ -158,9 +176,14 @@ struct SidebarView: View {
         let conversations: [ChatConversation]
     }
 
-    /// Bucket conversations by recency. ``now`` is injected rather than read
-    /// inside, matching ``RelativeTimestamp`` — it keeps the function pure so
-    /// the day boundaries can be exercised without waiting for midnight.
+    /// Bucket conversations for the main list. ``now`` is injected rather than
+    /// read inside, matching ``RelativeTimestamp`` — it keeps the function pure
+    /// so the day boundaries can be exercised without waiting for midnight.
+    ///
+    /// Pinned rows are lifted into their own leading section and are exempt
+    /// from the date buckets entirely: a pin means "keep this where I can see
+    /// it", which a "Previous 7 Days" heading would immediately undo. Archived
+    /// rows are excluded here — ``archivedConversations`` owns them.
     ///
     /// Uses `Calendar` (not a fixed 86 400s divisor) because the buckets are
     /// *calendar* days: something sent at 23:55 belongs to "Yesterday" once
@@ -171,6 +194,7 @@ struct SidebarView: View {
         now: Date,
         calendar: Calendar = .current
     ) -> [HistorySection] {
+        var pinned: [ChatConversation] = []
         var today: [ChatConversation] = []
         var yesterday: [ChatConversation] = []
         var week: [ChatConversation] = []
@@ -182,8 +206,10 @@ struct SidebarView: View {
         let startOfToday = calendar.startOfDay(for: now)
         let weekCutoff = calendar.date(byAdding: .day, value: -7, to: startOfToday)
 
-        for conv in conversations {
-            if calendar.isDate(conv.updatedAt, inSameDayAs: now) {
+        for conv in conversations where !conv.isArchived {
+            if conv.isPinned {
+                pinned.append(conv)
+            } else if calendar.isDate(conv.updatedAt, inSameDayAs: now) {
                 today.append(conv)
             } else if calendar.isDateInYesterday(conv.updatedAt) {
                 yesterday.append(conv)
@@ -195,6 +221,7 @@ struct SidebarView: View {
         }
 
         return [
+            ("Pinned", pinned),
             ("Today", today),
             ("Yesterday", yesterday),
             ("Previous 7 Days", week),
@@ -204,27 +231,175 @@ struct SidebarView: View {
         .map { HistorySection(title: $0.0, conversations: $0.1) }
     }
 
-    /// One history row — the conversation's derived title, amber-selected
-    /// when it's the open one, with a right-click Delete.
-    private func conversationRow(_ conv: ChatConversation) -> some View {
-        let isActive = selection == .chat && conv.id == chat.activeConversationID
-        return SidebarRow(isSelected: isActive) {
-            onSelectConversation(conv.id)
-        } content: {
-            // History rows carry no icon but keep the same leading inset
-            // as the nav rows above, so titles and nav labels align down
-            // one column instead of stepping in and out.
-            Text(conv.title)
-                .font(RapidFont.body)
-                .lineLimit(1)
-                .truncationMode(.tail)
-                .padding(.leading, RapidTheme.Layout.iconSlot + RapidTheme.Space.sm)
-        }
-        .contextMenu {
-            Button("Delete", role: .destructive) {
-                pendingDeletion = conv
+    /// Archived rows, newest-updated first. Kept out of ``sections`` so the
+    /// main list can never accidentally render one.
+    static func archived(for conversations: [ChatConversation]) -> [ChatConversation] {
+        conversations.filter { $0.isArchived }
+    }
+
+    private var archivedConversations: [ChatConversation] {
+        SidebarView.archived(for: chat.conversations)
+    }
+
+    /// The collapsed Archived group. Renders nothing at all when empty, so a
+    /// user who never archives anything never sees the affordance.
+    @ViewBuilder
+    private var archivedSection: some View {
+        let archived = archivedConversations
+        if !archived.isEmpty {
+            Button {
+                showArchived.toggle()
+            } label: {
+                HStack(spacing: RapidTheme.Space.xs) {
+                    Image(systemName: showArchived ? "chevron.down" : "chevron.right")
+                        .font(.system(size: 9, weight: .semibold))
+                    SectionHeader("Archived (\(archived.count))")
+                }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(.secondary)
+            .padding(.horizontal, RapidTheme.Space.sm)
+            .padding(.top, RapidTheme.Space.lg)
+            .padding(.bottom, RapidTheme.Space.xs)
+
+            if showArchived {
+                ForEach(archived) { conv in
+                    conversationRow(conv)
+                }
             }
         }
+    }
+
+    /// One history row — the conversation's derived title, amber-selected
+    /// when it's the open one, with a hover-revealed pin toggle and overflow
+    /// menu (and the same actions duplicated on right-click, since a context
+    /// menu is what a macOS user reaches for first).
+    ///
+    /// The controls are an OVERLAY rather than trailing content inside the
+    /// row's button: a `Menu` nested in a `Button` label is decorative — the
+    /// outer button swallows the click, so the ··· would just open the
+    /// conversation. Layering them as siblings keeps each one hittable.
+    @ViewBuilder
+    private func conversationRow(_ conv: ChatConversation) -> some View {
+        if renamingID == conv.id {
+            renameField(conv)
+        } else {
+            let isActive = selection == .chat && conv.id == chat.activeConversationID
+            // Controls appear on hover OR on the selected row; a pinned row
+            // always shows its pin, because otherwise the only signal that a
+            // row is pinned would be its position, which reads as an
+            // unexplained ordering bug.
+            let hovering = hoveredConversationID == conv.id
+            let showsControls = hovering || isActive || conv.isPinned
+            ZStack(alignment: .trailing) {
+                SidebarRow(isSelected: isActive) {
+                    onSelectConversation(conv.id)
+                } content: {
+                    // History rows carry no icon but keep the same leading
+                    // inset as the nav rows above, so titles and nav labels
+                    // align down one column instead of stepping in and out.
+                    Text(conv.title)
+                        .font(RapidFont.body)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                        .padding(.leading, RapidTheme.Layout.iconSlot + RapidTheme.Space.sm)
+                        // Reserve the controls' width so revealing them
+                        // re-truncates the title instead of overlapping it.
+                        .padding(.trailing, showsControls ? Self.rowControlsWidth : 0)
+                }
+                if showsControls {
+                    rowControls(conv, showsPin: hovering || isActive)
+                }
+            }
+            .onHover { hoveredConversationID = $0 ? conv.id : nil }
+            .contextMenu { rowMenuItems(conv) }
+        }
+    }
+
+    /// Width the pin + ··· pair occupies, reserved in the title's layout.
+    private static let rowControlsWidth =
+        RapidTheme.ControlHeight.mini * 2 + RapidTheme.Space.xs
+
+    private func rowControls(_ conv: ChatConversation, showsPin: Bool) -> some View {
+        HStack(spacing: 0) {
+            if showsPin || conv.isPinned {
+                QuietIconButton(
+                    symbol: conv.isPinned ? "pin.slash" : "pin",
+                    label: conv.isPinned ? "Unpin conversation" : "Pin conversation",
+                    size: RapidTheme.ControlHeight.mini
+                ) {
+                    chat.setConversationPinned(conv.id, !conv.isPinned)
+                }
+            }
+            Menu {
+                rowMenuItems(conv)
+            } label: {
+                Image(systemName: "ellipsis")
+                    .font(.system(size: 11, weight: .semibold))
+                    .frame(
+                        width: RapidTheme.ControlHeight.mini,
+                        height: RapidTheme.ControlHeight.mini
+                    )
+                    .contentShape(Rectangle())
+            }
+            .menuStyle(.borderlessButton)
+            .menuIndicator(.hidden)
+            .fixedSize()
+            .accessibilityLabel("Conversation actions")
+        }
+        .foregroundStyle(.secondary)
+        .padding(.trailing, RapidTheme.Space.xs)
+    }
+
+    /// The row's actions, shared by the hover menu and the right-click menu so
+    /// the two can't drift apart.
+    @ViewBuilder
+    private func rowMenuItems(_ conv: ChatConversation) -> some View {
+        Button {
+            renameDraft = conv.title
+            renamingID = conv.id
+        } label: {
+            Label("Rename", systemImage: "pencil")
+        }
+        Divider()
+        Button {
+            chat.setConversationPinned(conv.id, !conv.isPinned)
+        } label: {
+            Label(conv.isPinned ? "Unpin" : "Pin", systemImage: conv.isPinned ? "pin.slash" : "pin")
+        }
+        Button {
+            chat.setConversationArchived(conv.id, !conv.isArchived)
+        } label: {
+            Label(
+                conv.isArchived ? "Unarchive" : "Archive",
+                systemImage: conv.isArchived ? "tray.and.arrow.up" : "archivebox"
+            )
+        }
+        Divider()
+        Button("Delete", role: .destructive) {
+            pendingDeletion = conv
+        }
+    }
+
+    /// Inline rename editor, occupying the row it replaces. Return commits,
+    /// Escape (and losing focus) cancels — the standard Finder rename
+    /// contract, so a rename can't be committed by accidentally clicking away.
+    private func renameField(_ conv: ChatConversation) -> some View {
+        TextField("Conversation name", text: $renameDraft)
+            .textFieldStyle(.plain)
+            .font(RapidFont.body)
+            .padding(.horizontal, RapidTheme.Space.sm)
+            .frame(height: RapidTheme.ControlHeight.row)
+            .background(
+                RoundedRectangle(cornerRadius: RapidTheme.Radius.row, style: .continuous)
+                    .fill(RapidTheme.hoverFill)
+            )
+            .onSubmit {
+                chat.renameConversation(conv.id, to: renameDraft)
+                renamingID = nil
+            }
+            .onExitCommand { renamingID = nil }
     }
 
     /// One nav row — icon in a fixed-width slot so every label starts on

--- a/apps/rapid-mac/Tests/RapidTests/ChatMessageActionsTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ChatMessageActionsTests.swift
@@ -66,8 +66,8 @@ struct ChatMessageActionsTests {
         #expect(!viewModel.messages.contains(where: { $0.id == secondAssistant.id }))
     }
 
-    @Test("Retrying an older response preserves the original conversation as a branch")
-    func retryOlderAssistantPreservesOriginalBranch() throws {
+    @Test("Retrying an older response replays in place, without spawning a sidebar entry")
+    func retryOlderAssistantStaysOnTheSameConversation() throws {
         let store = try isolatedStoreURL()
         defer { try? FileManager.default.removeItem(at: store.root) }
         let viewModel = ChatViewModel(conversationStoreURL: store.file)
@@ -75,8 +75,7 @@ struct ChatMessageActionsTests {
         let firstAssistant = ChatMessage(role: .assistant, content: "first answer")
         let secondUser = ChatMessage(role: .user, content: "second question")
         let secondAssistant = ChatMessage(role: .assistant, content: "second answer")
-        let original = [firstUser, firstAssistant, secondUser, secondAssistant]
-        viewModel.devSeedMessages(original)
+        viewModel.devSeedMessages([firstUser, firstAssistant, secondUser, secondAssistant])
         let originalID = viewModel.activeConversationID
 
         let retried = viewModel.retryAssistantMessage(
@@ -84,17 +83,19 @@ struct ChatMessageActionsTests {
             alias: "test-model"
         )
         #expect(retried)
-        #expect(viewModel.activeConversationID != originalID)
+        #expect(viewModel.activeConversationID == originalID)
         viewModel.stopAndPersist()
         ConversationStore.flush()
 
+        // Exactly one row on disk: the retry rewrote the conversation it was
+        // fired from rather than forking a duplicate-titled branch beside it.
         let reloaded = ChatViewModel(conversationStoreURL: store.file)
-        let preserved = reloaded.conversations.first(where: { $0.id == originalID })
-        #expect(preserved?.messages == original)
+        #expect(reloaded.conversations.count == 1)
+        #expect(reloaded.conversations.first?.id == originalID)
     }
 
-    @Test("Editing an older message preserves the original conversation as a branch")
-    func editOlderUserPreservesOriginalBranch() throws {
+    @Test("Editing an older message replays in place, without spawning a sidebar entry")
+    func editOlderUserStaysOnTheSameConversation() throws {
         let store = try isolatedStoreURL()
         defer { try? FileManager.default.removeItem(at: store.root) }
         let viewModel = ChatViewModel(conversationStoreURL: store.file)
@@ -102,8 +103,7 @@ struct ChatMessageActionsTests {
         let firstAssistant = ChatMessage(role: .assistant, content: "first answer")
         let secondUser = ChatMessage(role: .user, content: "second question")
         let secondAssistant = ChatMessage(role: .assistant, content: "second answer")
-        let original = [firstUser, firstAssistant, secondUser, secondAssistant]
-        viewModel.devSeedMessages(original)
+        viewModel.devSeedMessages([firstUser, firstAssistant, secondUser, secondAssistant])
         let originalID = viewModel.activeConversationID
 
         let edited = viewModel.editUserMessage(
@@ -112,12 +112,12 @@ struct ChatMessageActionsTests {
             alias: "test-model"
         )
         #expect(edited)
-        #expect(viewModel.activeConversationID != originalID)
+        #expect(viewModel.activeConversationID == originalID)
         viewModel.stopAndPersist()
         ConversationStore.flush()
 
         let reloaded = ChatViewModel(conversationStoreURL: store.file)
-        let preserved = reloaded.conversations.first(where: { $0.id == originalID })
-        #expect(preserved?.messages == original)
+        #expect(reloaded.conversations.count == 1)
+        #expect(reloaded.conversations.first?.id == originalID)
     }
 }

--- a/apps/rapid-mac/Tests/RapidTests/SidebarConversationActionsTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SidebarConversationActionsTests.swift
@@ -1,0 +1,197 @@
+import Foundation
+import Testing
+@testable import Rapid
+
+/// The sidebar's per-row actions: rename, pin, archive.
+///
+/// The interesting behaviour is all in the model + the pure section builder,
+/// so these are behavioural tests rather than the source-grep shape used by
+/// ``SidebarConversationDeleteConfirmationTests`` (ViewInspector is not in
+/// this target — #1492).
+@MainActor
+@Suite("Sidebar conversation actions")
+struct SidebarConversationActionsTests {
+    private func isolatedStoreURL() throws -> (root: URL, file: URL) {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("rapid-sidebar-actions-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(
+            at: root,
+            withIntermediateDirectories: true
+        )
+        return (root, root.appendingPathComponent("conversations.json"))
+    }
+
+    /// A model with exactly one conversation on disk.
+    ///
+    /// Goes through ``send`` + ``stopAndPersist`` rather than
+    /// ``devSeedMessages`` alone: seeding only fills the message buffer, and
+    /// the snapshot into ``conversations`` hangs off the end of a turn.
+    /// ``stopAndPersist`` cancels the (unroutable) request before it can
+    /// stream anything, leaving a persisted single-turn conversation.
+    private func seededModel(_ store: URL) -> ChatViewModel {
+        let model = ChatViewModel(conversationStoreURL: store)
+        model.send("how do I pin a chat", alias: "test-model")
+        model.stopAndPersist()
+        return model
+    }
+
+    private func conversation(
+        title: String = "Chat",
+        updatedAt: Date = Date(),
+        isPinned: Bool = false,
+        isArchived: Bool = false
+    ) -> ChatConversation {
+        ChatConversation(
+            id: UUID(),
+            title: title,
+            messages: [],
+            createdAt: updatedAt,
+            updatedAt: updatedAt,
+            isPinned: isPinned,
+            isArchived: isArchived
+        )
+    }
+
+    // MARK: - Rename
+
+    @Test("Rename trims, persists, and survives a reload")
+    func renamePersists() throws {
+        let store = try isolatedStoreURL()
+        defer { try? FileManager.default.removeItem(at: store.root) }
+        let model = seededModel(store.file)
+        let id = model.activeConversationID
+
+        #expect(model.renameConversation(id, to: "  Pinning notes  "))
+        ConversationStore.flush()
+
+        let reloaded = ChatViewModel(conversationStoreURL: store.file)
+        let conv = reloaded.conversations.first(where: { $0.id == id })
+        #expect(conv?.title == "Pinning notes")
+        #expect(conv?.hasCustomTitle == true)
+    }
+
+    @Test("Rename rejects blank input rather than clearing the row label")
+    func renameRejectsBlank() throws {
+        let store = try isolatedStoreURL()
+        defer { try? FileManager.default.removeItem(at: store.root) }
+        let model = seededModel(store.file)
+        let id = model.activeConversationID
+        let before = model.conversations.first?.title
+
+        #expect(!model.renameConversation(id, to: "   "))
+        #expect(model.conversations.first?.title == before)
+    }
+
+    /// The regression this flag exists for: ``persistActive`` re-derives the
+    /// title from the first user turn on every save, so without the
+    /// ``hasCustomTitle`` guard the very next persisted turn reverted the
+    /// user's rename back to the opening words of their prompt.
+    @Test("A renamed conversation keeps its name across later saves")
+    func renameSurvivesLaterPersists() throws {
+        let store = try isolatedStoreURL()
+        defer { try? FileManager.default.removeItem(at: store.root) }
+        let model = seededModel(store.file)
+        let id = model.activeConversationID
+        #expect(model.renameConversation(id, to: "Pinning notes"))
+
+        // A later turn on the same conversation re-runs the title derivation.
+        model.send("and archive?", alias: "test-model")
+        model.stopAndPersist()
+
+        #expect(model.conversations.first(where: { $0.id == id })?.title == "Pinning notes")
+    }
+
+    // MARK: - Pin / archive
+
+    @Test("Pinning and archiving persist and are mutually exclusive")
+    func pinAndArchiveArePersistedAndExclusive() throws {
+        let store = try isolatedStoreURL()
+        defer { try? FileManager.default.removeItem(at: store.root) }
+        let model = seededModel(store.file)
+        let id = model.activeConversationID
+
+        model.setConversationPinned(id, true)
+        // Archiving a pinned row clears the pin: a row can't be pinned to the
+        // top of a list it has been filed out of.
+        model.setConversationArchived(id, true)
+        #expect(model.conversations.first?.isPinned == false)
+        #expect(model.conversations.first?.isArchived == true)
+
+        // ...and pinning an archived row brings it back into the main list.
+        model.setConversationPinned(id, true)
+        #expect(model.conversations.first?.isArchived == false)
+        ConversationStore.flush()
+
+        let reloaded = ChatViewModel(conversationStoreURL: store.file)
+        #expect(reloaded.conversations.first?.isPinned == true)
+    }
+
+    @Test("Archiving the open conversation leaves it open")
+    func archivingOpenConversationDoesNotNavigate() throws {
+        let store = try isolatedStoreURL()
+        defer { try? FileManager.default.removeItem(at: store.root) }
+        let model = seededModel(store.file)
+        let id = model.activeConversationID
+
+        model.setConversationArchived(id, true)
+        #expect(model.activeConversationID == id)
+        #expect(!model.messages.isEmpty)
+    }
+
+    // MARK: - Sectioning
+
+    @Test("Pinned rows lift into their own leading section, exempt from date buckets")
+    func pinnedRowsGetTheirOwnSection() {
+        let old = Date().addingTimeInterval(-60 * 60 * 24 * 30)
+        let pinned = conversation(title: "Pinned but stale", updatedAt: old, isPinned: true)
+        let today = conversation(title: "Today's chat")
+        let sections = SidebarView.sections(for: [pinned, today], now: Date())
+
+        #expect(sections.first?.title == "Pinned")
+        #expect(sections.first?.conversations.map(\.id) == [pinned.id])
+        // The pinned row must NOT also appear under "Older".
+        #expect(!sections.contains { $0.title == "Older" })
+    }
+
+    @Test("Archived rows are excluded from the main sections and listed separately")
+    func archivedRowsAreSplitOut() {
+        let archived = conversation(title: "Filed away", isArchived: true)
+        let active = conversation(title: "Live chat")
+        let sections = SidebarView.sections(for: [archived, active], now: Date())
+
+        let listed = sections.flatMap(\.conversations).map(\.id)
+        #expect(listed == [active.id])
+        #expect(SidebarView.archived(for: [archived, active]).map(\.id) == [archived.id])
+    }
+
+    // MARK: - Backward compatibility
+
+    /// A history file written before pin/archive shipped must still decode.
+    /// The synthesised ``Codable`` conformance treats every stored property as
+    /// required, so a missing `isPinned` key would THROW — and
+    /// ``ConversationStore.load`` reads one throw as "the whole file is
+    /// corrupt", sides it off to `.corrupt-*`, and returns empty. That is an
+    /// apparently wiped sidebar on upgrade, which is why the hand-written
+    /// ``init(from:)`` defaults the new keys instead.
+    @Test("A pre-pin/archive history file still decodes, defaulting the new flags")
+    func legacyHistoryDecodesWithDefaults() throws {
+        let legacy = """
+        [{
+          "id": "6F3F2B2F-6F94-4B49-9C1E-6B4B0A5E1D77",
+          "title": "Legacy chat",
+          "messages": [],
+          "createdAt": 700000000,
+          "updatedAt": 700000000
+        }]
+        """
+        let decoded = try JSONDecoder().decode(
+            [ChatConversation].self,
+            from: Data(legacy.utf8)
+        )
+        #expect(decoded.count == 1)
+        #expect(decoded.first?.title == "Legacy chat")
+        #expect(decoded.first?.isPinned == false)
+        #expect(decoded.first?.isArchived == false)
+        #expect(decoded.first?.hasCustomTitle == false)
+    }
+}

--- a/apps/rapid-mac/scripts/build.sh
+++ b/apps/rapid-mac/scripts/build.sh
@@ -124,6 +124,32 @@ else
     echo "warning: benchmark-scores.json missing — picker hover tooltip will show dashed bars only" >&2
 fi
 
+# App accent colour. AppKit paints NSMenu highlights, checkboxes and focus
+# rings with the app's accent colour, and nothing in SwiftUI reaches those:
+# ``.tint()`` styles SwiftUI's own views only, so without this the ··· row
+# menu highlighted in stock macOS system blue — the one colour the v0.6
+# palette deliberately avoids.
+#
+# The lookup is Info.plist ``NSAccentColorName`` → a NAMED COLOR inside a
+# COMPILED Assets.car. A raw .xcassets directory is not readable at
+# runtime, so it has to go through actool. actool ships with Xcode, not
+# the Command Line Tools: a machine with only the CLT builds a .app whose
+# menus fall back to system blue rather than failing the build, which is a
+# cosmetic degradation and not worth blocking a local build over.
+ASSETS_SRC="$ROOT/Sources/Rapid/Resources/Assets.xcassets"
+if [[ -d "$ASSETS_SRC" ]]; then
+    if ACTOOL="$(xcrun --find actool 2>/dev/null)"; then
+        "$ACTOOL" "$ASSETS_SRC" \
+            --compile "$CONTENTS/Resources" \
+            --platform macosx \
+            --minimum-deployment-target 14.0 \
+            --output-format human-readable-text \
+            >/dev/null
+    else
+        echo "warning: actool not found (Xcode not selected) — menus will use the system accent colour" >&2
+    fi
+fi
+
 # v0.6.6: embed rapid-mlx sidecar (issue #171). MONOREPO: the sidecar is
 # built from the rapid-mlx engine that lives at the repository ROOT (two
 # levels up from apps/rapid-mac). There is NO git submodule here — the


### PR DESCRIPTION
## What does this PR do?

  - Regenerates retried responses within the current conversation instead of creating a duplicate conversation.
  - Keeps edited messages in the current conversation as well.
  - Adds an overflow and context menu to sidebar conversations with:
    - Rename
    - Pin / Unpin
    - Archive / Unarchive
    - Delete
  - Keeps pinned conversations at the top of the sidebar.
  - Moves archived conversations into a collapsible Archived section.
  - Requires confirmation before deleting a conversation.
  - Preserves custom titles across subsequent messages.
  - Persists the new conversation metadata while remaining compatible with existing history files.
  - Applies the Rapid accent color to native macOS menus and controls.

  ## Why is this needed?

  Retrying a response previously created a new conversation, resulting in duplicate entries in the sidebar instead of
  regenerating the response in place.

  The sidebar also lacked basic actions for organizing conversation history.

  Fixes #1567.