### PR TITLE
fix(release): give Codex tool probe completion headroom

### DIFF
--- a/scripts/release_check_m3.sh
+++ b/scripts/release_check_m3.sh
@@ -375,7 +375,7 @@ run_g7b() {
       -d '{
         "model": "gpt-5",
         "stream": true,
-        "max_output_tokens": 64,
+        "max_output_tokens": 128,
         "instructions": "You are a helpful agent.",
         "input": [
           {"type": "message", "role": "user", "content": "Call get_weather with city=SF"},

--- a/tests/test_release_baselines.py
+++ b/tests/test_release_baselines.py
@@ -387,3 +387,9 @@ def test_stress_consumer_rejects_unverifiable_revision(tmp_path, contents):
 def test_release_gauntlet_runs_baseline_audit():
     script = (REPO_ROOT / "scripts" / "release_check_m3.sh").read_text()
     assert '"$PY" scripts/release_baselines.py' in script
+
+
+def test_release_gauntlet_gives_codex_tool_probe_enough_output_budget():
+    script = (REPO_ROOT / "scripts" / "release_check_m3.sh").read_text()
+    codex_probe = script[script.index("# Part B.2 — codex-shape SSE") :]
+    assert '"max_output_tokens": 128' in codex_probe


### PR DESCRIPTION
## Repro
On the Mac mini with Qwen3.5-9B-4bit, the M3 Codex-shape Responses SSE probe failed at `max_output_tokens=64`: generation truncated before the required `city` argument, and the server correctly emitted `response.failed` under schema validation.

## Why
The release probe must provide enough generation headroom to test Codex Responses event compatibility. A 64-token truncation tests schema rejection instead, producing a false release failure even though a normal Codex-sized request succeeds.

## Fix
Raise only this forced-tool release probe to 128 output tokens. Server validation remains strict.

## Validation
- Real 9B matrix: 64 => 422 missing `city`; 128 and 256 => completed with `{"city":"SF"}`
- Real 128-token SSE: created -> output_item.added(function_call) -> arguments delta -> completed, args `{"city":"SF"}`
- `bash -n scripts/release_check_m3.sh`
- focused release tests: 47 passed
- Ruff and diff check clean