### PR TITLE
fix(rapid-mac): make code-block horizontal scrolling discoverable

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
@@ -1597,20 +1597,46 @@ extension MarkdownUI.Theme {
                 .markdownMargin(top: 8, bottom: 8)
         }
 }
+/// Carries the code block's scrollable content span up to
+/// ``CodeBlockWithCopy``. Measured inside the scroll view, so the
+/// value tracks the scroll offset as well as the content width.
+private struct CodeBlockContentSpanKey: PreferenceKey {
+    static let defaultValue = CodeBlockOverflow.ContentSpan.unmeasured
+
+    static func reduce(
+        value: inout CodeBlockOverflow.ContentSpan,
+        nextValue: () -> CodeBlockOverflow.ContentSpan
+    ) {
+        let next = nextValue()
+        if next.isMeasured { value = next }
+    }
+}
+
 /// Code block with a hover-revealed Copy button. ChatGPT Desktop
 /// hangs the copy affordance off the top-right; we mirror that and
 /// fade in on hover so the button doesn't distract during reading.
 /// The button briefly flips to a checkmark on click so the user
 /// knows the clipboard load actually happened.
+///
+/// Wide code scrolls horizontally rather than wrapping — a wrapped
+/// line mangles the indentation that Python and YAML carry meaning
+/// in. That scroll used to be undiscoverable: `showsIndicators:
+/// false` installs no scroller at all, so a line running past the
+/// 720pt message column read as truncated and users assumed the tail
+/// of the answer was gone (2026-08 dogfood). The indicator is on and
+/// the edges dissolve wherever content is hidden — see
+/// ``CodeBlockOverflow`` for the geometry and the measurement that
+/// established the text was never actually clipped.
 private struct CodeBlockWithCopy: View {
     let config: CodeBlockConfiguration
 
     @State private var hovering: Bool = false
     @State private var copiedRecently: Bool = false
+    @State private var contentSpan = CodeBlockOverflow.ContentSpan.unmeasured
 
     var body: some View {
         ZStack(alignment: .topTrailing) {
-            ScrollView(.horizontal, showsIndicators: false) {
+            ScrollView(.horizontal, showsIndicators: true) {
                 config.label
                     .relativeLineSpacing(.em(0.2))
                     .markdownTextStyle {
@@ -1618,9 +1644,26 @@ private struct CodeBlockWithCopy: View {
                         FontSize(.em(0.92))
                     }
                     .padding(10)
+                    .background(contentSpanReader)
             }
+            // Order matters twice here. ``mask`` before ``background``
+            // fades only the code, leaving the block's fill solid —
+            // the alternative, painting a gradient of the fill colour
+            // over the text, has to guess the composited colour and
+            // gets it wrong in one appearance or the other. And the
+            // mask sits OUTSIDE the scroll view so it stays anchored
+            // to the viewport instead of scrolling away with the
+            // text. Rendering-only: the AppKit scroll view underneath
+            // is untouched, so the gesture still works inside the
+            // faded strip.
+            .mask(fadeMask)
             .background(Color.secondary.opacity(0.12))
             .clipShape(RoundedRectangle(cornerRadius: 6))
+            // ``$contentSpan`` rather than ``self``: the action is
+            // ``@Sendable`` and ``CodeBlockConfiguration`` is not.
+            .onPreferenceChange(CodeBlockContentSpanKey.self) { [$contentSpan] span in
+                $contentSpan.wrappedValue = span
+            }
 
             copyButton
                 .padding(.top, 6)
@@ -1629,6 +1672,48 @@ private struct CodeBlockWithCopy: View {
                 .rapidAnimation(RapidMotion.quick, value: hovering)
         }
         .onHover { h in hovering = h }
+    }
+
+    /// Publishes the content's horizontal span. Lives in a
+    /// ``background`` so it inherits the content's frame exactly and
+    /// contributes nothing to layout.
+    private var contentSpanReader: some View {
+        GeometryReader { proxy in
+            let frame = proxy.frame(in: .global)
+            Color.clear.preference(
+                key: CodeBlockContentSpanKey.self,
+                value: CodeBlockOverflow.ContentSpan(minX: frame.minX, maxX: frame.maxX)
+            )
+        }
+    }
+
+    /// Opaque through the middle, transparent at whichever edge is
+    /// hiding content. Falls back to a flat opaque fill before the
+    /// first measurement lands and whenever the block fits, so a short
+    /// code block keeps crisp edges.
+    private var fadeMask: some View {
+        GeometryReader { proxy in
+            let frame = proxy.frame(in: .global)
+            let fade = CodeBlockOverflow.fade(
+                content: contentSpan,
+                viewportMinX: frame.minX,
+                viewportMaxX: frame.maxX
+            )
+            if fade.isEmpty || frame.width <= 0 {
+                Color.black
+            } else {
+                LinearGradient(
+                    stops: [
+                        .init(color: .black.opacity(fade.leading > 0 ? 0 : 1), location: 0),
+                        .init(color: .black, location: fade.leading / frame.width),
+                        .init(color: .black, location: 1 - fade.trailing / frame.width),
+                        .init(color: .black.opacity(fade.trailing > 0 ? 0 : 1), location: 1)
+                    ],
+                    startPoint: .leading,
+                    endPoint: .trailing
+                )
+            }
+        }
     }
 
     private var copyButton: some View {

--- a/apps/rapid-mac/Sources/Rapid/UI/CodeBlockOverflow.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/CodeBlockOverflow.swift
@@ -1,0 +1,117 @@
+import CoreGraphics
+
+/// Geometry behind the fenced-code-block edge fade.
+///
+/// ## The bug this exists to fix
+///
+/// A 2026-08 dogfood run answered a "merge overlapping intervals"
+/// question with a Python block whose demo lines all stopped dead at
+/// the same x position:
+///
+/// ```text
+/// print(merge_intervals([[1,3],[2,6],[8,10],[15,18]]))   #[[1, 6],[8, 10],[15, 1
+/// print(merge_intervals([]))                             #[[]
+/// ```
+///
+/// It reads as truncation, and it is not. The block's horizontal
+/// ``ScrollView`` hands the text its full intrinsic width — measured
+/// headlessly through ``NSHostingView`` at the real 720pt message
+/// column, that sample lays out at 822pt, so 102pt of code is present,
+/// laid out, and one two-finger swipe away. What was missing was any
+/// sign of it: the scroll view was built with `showsIndicators: false`,
+/// which installs no `NSScroller` at all, and macOS overlay scrollers
+/// are invisible at rest even when they exist. Clipped-and-lost and
+/// scrolled-out-of-view looked identical, so the reader concluded the
+/// answer was cut off.
+///
+/// The fix is an affordance, not a re-layout: turn the indicator on so
+/// the gesture has feedback, and dissolve the text into the block edge
+/// wherever content is actually hidden, so the boundary reads as "this
+/// continues" instead of "this ends here".
+///
+/// ## Why this is a separate type
+///
+/// The ramp is the only part with a right and a wrong answer, and it
+/// has edge cases worth pinning: an unmeasured block must not fade, a
+/// block scrolled to its end must not keep a stale fade, and a block
+/// narrower than two fades must not become all gradient. Factored out
+/// of the view, those are ordinary value assertions instead of a
+/// snapshot.
+enum CodeBlockOverflow {
+
+    /// Widest either edge fades, in points. Wide enough to read as a
+    /// deliberate soft edge on a 15pt-based monospaced line, narrow
+    /// enough that it never eats a whole token.
+    static let maxFadeWidth: CGFloat = 24
+
+    /// Horizontal span of a code block's scrollable content, in global
+    /// coordinates.
+    ///
+    /// Only the two x edges travel in the preference. The block grows
+    /// DOWNWARD on every streamed token, so folding height in here
+    /// would republish the preference — and re-render the fade —
+    /// on every single coalescer flush, for a number the fade never
+    /// reads.
+    struct ContentSpan: Equatable, Sendable {
+        var minX: CGFloat
+        var maxX: CGFloat
+
+        static let unmeasured = ContentSpan(minX: 0, maxX: 0)
+
+        /// A real measurement always has positive width. The default
+        /// preference value does not, which is what keeps the fade off
+        /// during the frame before the ``GeometryReader`` reports.
+        var isMeasured: Bool { maxX > minX }
+    }
+
+    /// How wide the fade is at each edge. Zero on an edge means the
+    /// content there is fully visible and the edge stays crisp.
+    struct Fade: Equatable, Sendable {
+        var leading: CGFloat
+        var trailing: CGFloat
+
+        static let none = Fade(leading: 0, trailing: 0)
+
+        var isEmpty: Bool { self == .none }
+    }
+
+    /// Fade widths for a code block whose content spans ``content``
+    /// inside a viewport spanning `viewportMinX...viewportMaxX`, all in
+    /// the same coordinate space.
+    ///
+    /// Because the content span is measured INSIDE the scroll view, it
+    /// tracks the scroll offset for free: scrolling right walks
+    /// `content.maxX` down toward `viewportMaxX`, so the trailing fade
+    /// closes itself as the user reaches the end of the line.
+    static func fade(
+        content: ContentSpan,
+        viewportMinX: CGFloat,
+        viewportMaxX: CGFloat,
+        maxFadeWidth: CGFloat = CodeBlockOverflow.maxFadeWidth
+    ) -> Fade {
+        let viewportWidth = viewportMaxX - viewportMinX
+        guard content.isMeasured, viewportWidth > 0, maxFadeWidth > 0 else {
+            return .none
+        }
+        // A block narrower than two full fades would render as nothing
+        // but gradient. Cap each edge at a third of the viewport so the
+        // middle is always the widest, fully-opaque region.
+        let cap = min(maxFadeWidth, viewportWidth / 3)
+        return Fade(
+            leading: ramp(hidden: viewportMinX - content.minX, cap: cap),
+            trailing: ramp(hidden: content.maxX - viewportMaxX, cap: cap)
+        )
+    }
+
+    /// Fade width for `hidden` points of content past an edge.
+    ///
+    /// Ramps with the hidden amount rather than snapping to full width,
+    /// so the last few points of a scroll dissolve the fade smoothly
+    /// instead of popping it off. Sub-point overhangs are treated as
+    /// flush — SwiftUI geometry lands on fractional values, and a 0.3pt
+    /// residue is not "there is more to read".
+    private static func ramp(hidden: CGFloat, cap: CGFloat) -> CGFloat {
+        guard hidden > 0.5 else { return 0 }
+        return min(cap, hidden)
+    }
+}

--- a/apps/rapid-mac/Tests/RapidTests/CodeBlockOverflowTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/CodeBlockOverflowTests.swift
@@ -1,0 +1,168 @@
+import CoreGraphics
+import Foundation
+import Testing
+@testable import Rapid
+
+/// The fenced-code-block edge fade (2026-08 dogfood: long Python
+/// lines stopped dead at the message-column edge and read as
+/// truncated output).
+///
+/// The measured facts this is built on, taken headlessly through
+/// `NSHostingView` at the real 720pt message column: the block's
+/// horizontal `ScrollView` gives the code its full intrinsic width
+/// — the bug's sample laid out at 822pt — so nothing was clipped,
+/// and `showsIndicators: false` installed no `NSScroller`, so
+/// nothing said so. The fade is the resting-state affordance; these
+/// pin when it appears and, just as importantly, when it must not.
+@Suite("CodeBlockOverflow — code block edge fade")
+struct CodeBlockOverflowTests {
+
+    private typealias Span = CodeBlockOverflow.ContentSpan
+    private typealias Fade = CodeBlockOverflow.Fade
+
+    /// The reported case: 822pt of code in a 720pt column, unscrolled.
+    private static let dogfoodContent = Span(minX: 0, maxX: 822)
+    private static let column: (min: CGFloat, max: CGFloat) = (0, 720)
+
+    private func fade(
+        _ content: Span,
+        viewport: (min: CGFloat, max: CGFloat) = CodeBlockOverflowTests.column,
+        maxFadeWidth: CGFloat = CodeBlockOverflow.maxFadeWidth
+    ) -> Fade {
+        CodeBlockOverflow.fade(
+            content: content,
+            viewportMinX: viewport.min,
+            viewportMaxX: viewport.max,
+            maxFadeWidth: maxFadeWidth
+        )
+    }
+
+    // MARK: - The reported bug
+
+    @Test("Code wider than the column fades at the trailing edge")
+    func trailingFadeOnOverflow() {
+        let result = fade(Self.dogfoodContent)
+        #expect(result.trailing == CodeBlockOverflow.maxFadeWidth)
+        // Nothing is hidden to the left yet — the block is unscrolled,
+        // so the leading edge must stay crisp.
+        #expect(result.leading == 0)
+    }
+
+    @Test("A code block that fits gets no fade at all")
+    func noFadeWhenContentFits() {
+        #expect(fade(Span(minX: 0, maxX: 600)).isEmpty)
+        // Exactly flush is still a fit.
+        #expect(fade(Span(minX: 0, maxX: 720)).isEmpty)
+    }
+
+    // MARK: - Scroll position
+
+    @Test("Scrolling right moves the fade to the leading edge")
+    func fadeFollowsScrollOffset() {
+        // Scrolled fully right: content.maxX has walked down onto the
+        // viewport's trailing edge, 102pt now hidden to the left.
+        let atEnd = fade(Span(minX: -102, maxX: 720))
+        #expect(atEnd.trailing == 0, "nothing left to reveal — the trailing fade must clear")
+        #expect(atEnd.leading == CodeBlockOverflow.maxFadeWidth)
+
+        // Mid-scroll: hidden on both sides, so both edges fade.
+        let midway = fade(Span(minX: -51, maxX: 771))
+        #expect(midway.leading == CodeBlockOverflow.maxFadeWidth)
+        #expect(midway.trailing == CodeBlockOverflow.maxFadeWidth)
+    }
+
+    @Test("The fade ramps down over the last points of the scroll")
+    func fadeRampsRatherThanPops() {
+        // 10pt of code still hidden -> a 10pt fade, not a full-width
+        // one that vanishes in a single frame at the end of the swipe.
+        #expect(fade(Span(minX: 0, maxX: 730)).trailing == 10)
+        #expect(fade(Span(minX: 0, maxX: 744)).trailing == CodeBlockOverflow.maxFadeWidth)
+    }
+
+    @Test("A sub-point overhang is treated as flush")
+    func subPointOverhangDoesNotFade() {
+        // SwiftUI geometry lands on fractional values; 0.3pt of
+        // residue is not "there is more to read", and fading on it
+        // would leave a permanent smudge on a block that fits.
+        #expect(fade(Span(minX: 0, maxX: 720.3)).isEmpty)
+        #expect(fade(Span(minX: -0.4, maxX: 720)).isEmpty)
+        // Past the half-point threshold it is real overflow.
+        #expect(fade(Span(minX: 0, maxX: 721)).trailing == 1)
+    }
+
+    // MARK: - Degenerate geometry
+
+    @Test("An unmeasured block does not fade")
+    func unmeasuredSpanDoesNotFade() {
+        // The frame before the GeometryReader reports. The default
+        // span sits at the origin, so a viewport offset from the
+        // window origin would otherwise look like content hidden to
+        // the left and fade a block nobody has measured yet.
+        #expect(fade(.unmeasured).isEmpty)
+        #expect(fade(.unmeasured, viewport: (312, 1032)).isEmpty)
+        #expect(Span.unmeasured.isMeasured == false)
+        #expect(Span(minX: 0, maxX: 822).isMeasured)
+    }
+
+    @Test("A zero-width viewport does not fade")
+    func zeroWidthViewportDoesNotFade() {
+        #expect(fade(Self.dogfoodContent, viewport: (0, 0)).isEmpty)
+        #expect(fade(Self.dogfoodContent, viewport: (100, 40)).isEmpty)
+    }
+
+    @Test("Neither edge can eat more than a third of a narrow block")
+    func fadeIsCappedOnNarrowBlocks() {
+        // A 60pt viewport with overflow on both sides: at the full
+        // 24pt each, the gradient would be 48 of 60 points and the
+        // block would be mostly smudge. The cap keeps the opaque
+        // middle the widest region, which also keeps the gradient
+        // stops monotonic.
+        let narrow = fade(Span(minX: -200, maxX: 400), viewport: (0, 60))
+        #expect(narrow.leading == 20)
+        #expect(narrow.trailing == 20)
+        #expect(narrow.leading + narrow.trailing < 60)
+    }
+
+    @Test("The fade honours a caller-supplied maximum")
+    func respectsCustomMaxFadeWidth() {
+        #expect(fade(Self.dogfoodContent, maxFadeWidth: 8).trailing == 8)
+        // A non-positive maximum disables the affordance outright
+        // rather than producing a degenerate gradient.
+        #expect(fade(Self.dogfoodContent, maxFadeWidth: 0).isEmpty)
+        #expect(fade(Self.dogfoodContent, maxFadeWidth: -4).isEmpty)
+    }
+
+    // MARK: - Gradient stop invariants
+
+    @Test("Fade widths always produce monotonic gradient stops")
+    func gradientStopsStayMonotonic() {
+        // ChatView turns these widths into LinearGradient stop
+        // locations at `leading / width` and `1 - trailing / width`.
+        // Out-of-order stops are undefined behaviour, so sweep the
+        // geometry that reaches that call.
+        let viewportWidths: [CGFloat] = [1, 12, 60, 300, 720, 1600]
+        let overhangs: [CGFloat] = [0, 0.4, 1, 10, 24, 500, 5000]
+        for width in viewportWidths {
+            for leadingHidden in overhangs {
+                for trailingHidden in overhangs {
+                    let result = fade(
+                        Span(minX: -leadingHidden, maxX: width + trailingHidden),
+                        viewport: (0, width)
+                    )
+                    let leadingStop = result.leading / width
+                    let trailingStop = 1 - result.trailing / width
+                    #expect(
+                        leadingStop <= trailingStop,
+                        """
+                        stops crossed at viewport \(width), \
+                        hidden \(leadingHidden)/\(trailingHidden): \
+                        \(leadingStop) > \(trailingStop)
+                        """
+                    )
+                    #expect(result.leading >= 0)
+                    #expect(result.trailing >= 0)
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Why

Fenced code blocks in chat looked cut off at the right edge. From a dogfood run,
a Python answer's demo lines all ended mid-word at the same x position:

```
    print(merge_intervals([[1,3],[2,6],[8,10],[15,18]]))   #[[1, 6],[8, 10],[15, 1
    print(merge_intervals([]))                             #[[]
    print(merge_intervals([[6,8],[1,4]]))                  #[[1, 4],[6, 8]] (unso
```

**The text was never clipped.** The block already had a horizontal `ScrollView`;
it just gave no sign that anything was hidden. Measured headlessly: at the real
message column width (`RapidTheme.Layout.contentMaxWidth = 720`) that sample
lays out at **822pt** — 102pt of code present, laid out, and one blind two-finger
swipe away.

Two things hid it:

* `ScrollView(.horizontal, showsIndicators: false)` at `ChatView.swift:1613`
  installs no `NSScroller` at all — dumping the AppKit tree,
  `hasHorizontalScroller` flips `false` → `true` purely on that flag.
* `scrollerStyle == .overlay`, so even an installed scroller stays invisible
  until you are already scrolling.

Clipped-and-lost and scrolled-out-of-view look identical, so a reader reasonably
concludes the tail of the answer is gone. That is the bug: not lost text, lost
*discoverability*.

## What changed

Horizontal scrolling stays — wrapping would mangle indentation-sensitive code.
It is now discoverable:

* `showsIndicators: true`.
* The code dissolves into the block edge wherever content is actually hidden.
  The span is measured *inside* the scroll view, so it tracks the scroll offset
  for free: the trailing fade closes itself as you reach the end of a line and a
  leading fade takes over.
* `.mask` sits **outside** the scroll view (anchored to the viewport rather than
  scrolling away) and **before** `.background`, so only glyphs fade and the block
  fill stays solid. It is rendering-only — the `NSScrollView` underneath is
  intact, so the gesture still works inside the faded strip.

`Sources/Rapid/UI/CodeBlockOverflow.swift` (new) holds the pure geometry;
`ChatView.swift` wires it into `CodeBlockWithCopy`.

The preference carries only the two x edges, not the whole frame: the block grows
downward on every token, and folding height in would republish on every
coalescer flush for a number the fade never reads. The fade is overlay-class and
cannot feed back into layout, so there is no mid-stream reflow. The vertical
transcript `ScrollView` is untouched.

`showsIndicators: true` is what `SettingsView.swift:786` already does — the
`false` here was the outlier, not a convention.

## Test plan

* `swift build` clean.
* 10 new tests in `CodeBlockOverflowTests`, and the **full 1562-test `RapidTests`
  suite passes**. `swift test` normally dies on `RapidUXTests` (`import XCTest`,
  no Xcode on this machine); a real run was obtained by temporarily dropping that
  target from `Package.swift` and pointing the linker at the CommandLineTools
  `Testing.framework` + `lib_TestingInterop.dylib` rpaths. **`Package.swift` is
  restored and is not part of this commit** — verified, `git diff` on it is empty.
* Headless renders confirm: the fade appears only on overflow, is identical in
  light and dark, is absent (crisp edges) on a block that fits, and — driving the
  real `NSScrollView` to its end — the trailing fade clears, the previously
  "truncated" comments render complete, and the leading fade takes over.

**Not verified:** no run of the assembled app, and no real trackpad gesture or
text selection through the masked strip. `.mask` is documented as
rendering-only and the `NSScrollView` provably survives it, but that is worth ten
seconds of manual dogfood before this is considered closed. CI's `swift test` on
macos-15 is also the first run on the CI OS — the local run was on macOS 26 with
the target temporarily reduced.

**Snapshots:** none needed. `Tests/RapidTests/__Snapshots__` covers only the
cheetah logo, model-picker bar, onboarding tour and empty sidebar — nothing
renders a transcript or code block. They are also gated behind
`RAPID_UI_SNAPSHOT_TESTS=1`, and a baseline recorded on macOS 26 would mismatch
on the CI OS.