### PR TITLE
fix(rapid-mac): focus sidebar rename field, sort archived, tidy row menu

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/UI/SidebarView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SidebarView.swift
@@ -260,8 +260,17 @@ struct SidebarView: View {
 
     /// Archived rows, newest-updated first. Kept out of ``sections`` so the
     /// main list can never accidentally render one.
+    ///
+    /// The sort is done here rather than trusted from the caller: the main
+    /// list's order is maintained incrementally by ``ConversationOrdering``,
+    /// which deliberately leaves a row's position alone for non-activity edits
+    /// — and archiving is one of those. So an archived row keeps whatever slot
+    /// it held in the live list, which says nothing about its rank among the
+    /// other archived ones.
     static func archived(for conversations: [ChatConversation]) -> [ChatConversation] {
-        conversations.filter { $0.isArchived }
+        conversations
+            .filter { $0.isArchived }
+            .sorted { $0.updatedAt > $1.updatedAt }
     }
 
     private var archivedConversations: [ChatConversation] {
@@ -402,47 +411,75 @@ struct SidebarView: View {
     /// and with it the focus observer that would have cancelled the edit — off
     /// screen; so the edit is resolved up front rather than left to a blur that
     /// may never be observed. Delete is the documented exception (see below).
+    ///
+    /// The whole set is wrapped in a `Group` carrying ``tint(nil)`` — a
+    /// `Group`'s modifiers apply to each child, and inside a `Menu` the
+    /// children are flattened back out into sibling `NSMenuItem`s, so this
+    /// does not nest them into a submenu.
+    ///
+    /// Why the tint has to be cleared: the scene applies
+    /// ``.tint(RapidTheme.brandAmber)`` app-wide (``RapidApp``), which reaches
+    /// this menu's content and makes SwiftUI hand AppKit *coloured*
+    /// (`isTemplate == false`) menu-item images. AppKit only recolours
+    /// TEMPLATE images to `selectedMenuItemTextColor` when a row highlights,
+    /// so the amber glyphs stayed amber while their text flipped to white —
+    /// the icon and its label disagreeing under the pointer. Dropping the
+    /// tint restores template rendering, so each glyph tracks its own row's
+    /// text colour at rest and on hover alike.
     @ViewBuilder
     private func rowMenuItems(_ conv: ChatConversation) -> some View {
-        Button {
-            // Tear down any rename already in flight FIRST. Rename → Rename is
-            // one continuous edit as far as ``renameFieldFocused`` is
-            // concerned: leaving it `true` would rob the new editor of the
-            // `false → true` transition its focus gate watches for, and its own
-            // eventual blur would then be ignored. Ending the previous cycle
-            // outright is what guarantees the transition happens.
-            endRename()
-            renameDraft = conv.title
-            renamingID = conv.id
-            renameSession &+= 1
-        } label: {
-            Label("Rename", systemImage: "pencil")
+        Group {
+            Button {
+                // Tear down any rename already in flight FIRST. Rename → Rename is
+                // one continuous edit as far as ``renameFieldFocused`` is
+                // concerned: leaving it `true` would rob the new editor of the
+                // `false → true` transition its focus gate watches for, and its own
+                // eventual blur would then be ignored. Ending the previous cycle
+                // outright is what guarantees the transition happens.
+                endRename()
+                renameDraft = conv.title
+                renamingID = conv.id
+                renameSession &+= 1
+            } label: {
+                Label("Rename", systemImage: "pencil")
+            }
+            Divider()
+            Button {
+                cancelRename()
+                chat.setConversationPinned(conv.id, !conv.isPinned)
+            } label: {
+                Label(
+                    conv.isPinned ? "Unpin" : "Pin",
+                    systemImage: conv.isPinned ? "pin.slash" : "pin"
+                )
+            }
+            Button {
+                cancelRename()
+                chat.setConversationArchived(conv.id, !conv.isArchived)
+            } label: {
+                Label(
+                    conv.isArchived ? "Unarchive" : "Archive",
+                    systemImage: conv.isArchived ? "tray.and.arrow.up" : "archivebox"
+                )
+            }
+            Divider()
+            // Delete is the one item that does NOT need an explicit cancel: it only
+            // stages a confirmation, and presenting that dialog takes keyboard
+            // focus, which the editor's blur handler resolves. Keeping the action
+            // body a bare `pendingDeletion = conv` is also what the #1568
+            // delete-gate guard pins.
+            //
+            // Spelled with a trailing `label:` closure rather than the shorter
+            // `Button("Delete", …)` so the destructive item carries an icon like
+            // every other entry above it — a title-only button renders with a
+            // blank icon gutter beside four icon-bearing siblings and looks broken.
+            Button(role: .destructive) {
+                pendingDeletion = conv
+            } label: {
+                Label("Delete", systemImage: "trash")
+            }
         }
-        Divider()
-        Button {
-            cancelRename()
-            chat.setConversationPinned(conv.id, !conv.isPinned)
-        } label: {
-            Label(conv.isPinned ? "Unpin" : "Pin", systemImage: conv.isPinned ? "pin.slash" : "pin")
-        }
-        Button {
-            cancelRename()
-            chat.setConversationArchived(conv.id, !conv.isArchived)
-        } label: {
-            Label(
-                conv.isArchived ? "Unarchive" : "Archive",
-                systemImage: conv.isArchived ? "tray.and.arrow.up" : "archivebox"
-            )
-        }
-        Divider()
-        // Delete is the one item that does NOT need an explicit cancel: it only
-        // stages a confirmation, and presenting that dialog takes keyboard
-        // focus, which the editor's blur handler resolves. Keeping this body a
-        // bare `pendingDeletion = conv` is also what the #1568 delete-gate
-        // guard pins.
-        Button("Delete", role: .destructive) {
-            pendingDeletion = conv
-        }
+        .tint(nil)
     }
 
     /// Inline rename editor, occupying the row it replaces.

--- a/apps/rapid-mac/Tests/RapidTests/SidebarConversationActionsTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SidebarConversationActionsTests.swift
@@ -164,6 +164,23 @@ struct SidebarConversationActionsTests {
         #expect(SidebarView.archived(for: [archived, active]).map(\.id) == [archived.id])
     }
 
+    /// ``archived(for:)`` sorts rather than inheriting the caller's order.
+    /// Archiving does not touch ``updatedAt`` or a row's slot in
+    /// ``ChatViewModel.conversations``, so the input can hand the archived
+    /// rows over in any order — the group still has to read newest-first.
+    @Test("Archived rows are ordered newest-updated first")
+    func archivedRowsAreSortedByRecency() {
+        let now = Date()
+        let stale = conversation(
+            title: "Filed long ago",
+            updatedAt: now.addingTimeInterval(-60 * 60 * 24 * 30),
+            isArchived: true
+        )
+        let recent = conversation(title: "Filed today", updatedAt: now, isArchived: true)
+
+        #expect(SidebarView.archived(for: [stale, recent]).map(\.id) == [recent.id, stale.id])
+    }
+
     // MARK: - Backward compatibility
 
     /// A history file written before pin/archive shipped must still decode.

--- a/apps/rapid-mac/Tests/RapidTests/SidebarConversationDeleteConfirmationTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SidebarConversationDeleteConfirmationTests.swift
@@ -62,8 +62,11 @@ struct SidebarConversationDeleteConfirmationTests {
         // The context-menu destructive button must set pendingDeletion, never
         // call the model's delete directly. This literal shape is exactly what
         // the old immediate-delete build lacked, so it fails against a revert.
+        // The item is spelled with a trailing `label:` closure so it carries a
+        // trash icon like its siblings, so the guard matches the action body
+        // rather than the title.
         #expect(
-            stripped.contains(#"Button("Delete",role:.destructive){pendingDeletion=conv}"#),
+            stripped.contains(#"Button(role:.destructive){pendingDeletion=conv}"#),
             "SidebarView's context-menu Delete must stage `pendingDeletion = conv`, not delete on the spot."
         )
         // And the pre-fix immediate shape must be gone from the context menu.


### PR DESCRIPTION
 ## What does this PR do?

  Four follow-up nits on the sidebar conversation row from #1568:

  - Rename field auto-focuses (via `.task(id:)`, so it also re-focuses when Rename is picked on another row while an editor is open).
  - `SidebarView.archived(for:)` actually sorts newest-updated first.
  - Delete carries a `trash` glyph instead of an empty icon gutter.
  - Row-menu glyphs follow the highlighted row's text colour.

  `SidebarView.swift` plus its two test files only.

  ## Why is this needed?

  Fixes #1573.

  - Rename was effectively broken: the field appeared but keystrokes and Return went to the row that opened it, so it needed a second click before accepting input.
  - Archiving touches neither `updatedAt` nor a row's slot in `ChatViewModel.conversations`, so the archived group listed rows in arbitrary order — the doc comment already claimed newest-first.
  - On hover the menu label flipped to white while the icon stayed amber: the app-wide `.tint(brandAmber)` reaches the menu content, so SwiftUI hands AppKit coloured (non-template) menu-item images, and AppKit only recolours template images on highlight.
  - Delete's blank icon gutter reads as a missing asset next to four icon-bearing siblings.