### PR TITLE
fix(rapid-mac): recognise \( \) and \[ \] LaTeX math delimiters

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/UI/Markdown/LaTeXMarkdownView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/Markdown/LaTeXMarkdownView.swift
@@ -2,9 +2,9 @@ import SwiftUI
 import MarkdownUI
 
 /// Issue #131: drop-in replacement for ``Markdown(content)`` that
-/// renders ``$$...$$`` **display math** through ``SwiftMath``
-/// while leaving inline ``$...$`` math as literal source inside
-/// the surrounding markdown.
+/// renders **display math** (``$$...$$`` and ``\[...\]``) through
+/// ``SwiftMath`` while leaving inline math (``$...$`` / ``\(...\)``)
+/// as literal source inside the surrounding markdown.
 ///
 /// ## v1 scope: display math only
 ///
@@ -26,6 +26,20 @@ import MarkdownUI
 /// ``$...$`` source — same as before this PR, no regression.
 /// A follow-up issue can iterate inline math with a flow layout
 /// or a Markdown-block-aware splitter.
+///
+/// The 2026-08 bracket-delimiter fix (see ``LaTeXSegmenter``) did
+/// NOT lift that deferral, and one more constraint was found while
+/// re-checking it: routing inline math through MarkdownUI's
+/// ``InlineImageProvider`` — the one composition path that keeps a
+/// table row or list item intact — caches the rendered image on
+/// ``.task(id: inlines)`` in MarkdownUI's ``InlineText``. The cache
+/// key is the parsed inline nodes, so it does not re-fire when only
+/// the colour scheme or Dynamic-Type size changes, and glyph colour
+/// is baked into the image. A light/dark toggle would leave stale
+/// black-on-black formulas behind unless the rendering parameters
+/// are smuggled into the image URL to perturb the key. That is a
+/// design worth doing deliberately, not as a rider on a delimiter
+/// fix.
 ///
 /// ## Hot path
 ///

--- a/apps/rapid-mac/Sources/Rapid/UI/Markdown/LaTeXSegmenter.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/Markdown/LaTeXSegmenter.swift
@@ -284,6 +284,34 @@ enum LaTeXSegmenter {
         return lastConsumedBlockEnd
     }
 
+    /// Strict form of the indented-code test, used by the closer scan.
+    /// True only where CommonMark would actually OPEN an indented code
+    /// block: at a line start, indented 4+ spaces (or a tab), AND
+    /// preceded by a blank line or the start of input.
+    ///
+    /// ``endOfIndentedCodeBlock`` alone answers "does this line look
+    /// indented", which is the right question when deciding whether to
+    /// scan a region for math openers and the wrong one when deciding
+    /// whether to abandon a formula already in progress — see the note
+    /// on ``findBracketClose``.
+    private static func startsIndentedCodeBlock(_ s: String, at index: String.Index) -> Bool {
+        guard isAtLineStart(s, at: index), isIndentedCodeLine(s, lineStart: index) else {
+            return false
+        }
+        if index == s.startIndex { return true }
+        // ``index`` is at a line start, so the character before it is
+        // the newline that ended the previous line. Walk back over that
+        // line and require it to be blank.
+        let newline = s.index(before: index)
+        var previousLineStart = newline
+        while previousLineStart > s.startIndex {
+            let before = s.index(before: previousLineStart)
+            if s[before] == "\n" { break }
+            previousLineStart = before
+        }
+        return isBlankLine(s, lineStart: previousLineStart, lineEnd: newline)
+    }
+
     private static func isIndentedCodeLine(_ s: String, lineStart: String.Index) -> Bool {
         guard lineStart < s.endIndex else { return false }
         if s[lineStart] == "\t" { return true }
@@ -424,15 +452,83 @@ enum LaTeXSegmenter {
     /// break and the ``]`` right after it is a literal bracket, so the
     /// run closes at the final ``\]`` and not at the third character
     /// of ``\\]``.
+    ///
+    /// ## Code regions are skipped, exactly like the opener scan
+    ///
+    /// A closer that lives inside a fenced block, a code span or an
+    /// indented code block does NOT close the run. Without this, an
+    /// unclosed ``\[`` in prose reaches forward and matches the ``\]``
+    /// a user wrote *inside* a code sample — swallowing the prose and
+    /// the code block in between into one "formula". The opener scan
+    /// is careful to skip those three regions; the closer scan has to
+    /// be equally careful or the care is one-sided.
+    ///
+    /// The indented-code test is deliberately STRICTER here than in
+    /// the opener scan, which treats any 4-space line as code. The two
+    /// mistakes are not symmetric: a false skip in the opener scan
+    /// only means "do not look for math here", which loses nothing,
+    /// while a false skip here abandons a real formula. Math bodies
+    /// are very commonly indented —
+    ///
+    /// ```
+    /// \[
+    ///     P = \frac{47}{0.85} \]
+    /// ```
+    ///
+    /// — so this requires what CommonMark actually requires to OPEN an
+    /// indented code block: a preceding blank line (or the start of
+    /// input). The indented continuation of a ``\[`` line is not a
+    /// code block under that rule, and its closer is still honoured.
+    ///
+    /// ## Nested openers: first closer wins, same-kind opener bails
+    ///
+    /// LaTeX cannot nest ``\( … \( … \) … \)`` — a second opener of
+    /// the same kind before any closer is therefore strong evidence
+    /// the FIRST opener was prose, not math. The scan gives up, the
+    /// caller emits that opener as literal text and rescans from just
+    /// past it, so ``Use \( to group, then \(x\).`` keeps the prose
+    /// and still renders ``x``.
+    ///
+    /// A nested opener of the OTHER kind does not bail. Rejecting the
+    /// outer run there would drop the whole formula back to CommonMark,
+    /// which strips the delimiters to bare brackets — the original bug.
+    /// Keeping it degrades instead to ``MathView``'s literal-source
+    /// fallback, which is strictly more informative.
+    ///
+    /// Beyond those two rules the first closer wins. A stray ``\[`` in
+    /// prose followed much later by a stray ``\]`` does become one math
+    /// run; that is accepted, because CommonMark would have rendered
+    /// both as bare brackets anyway, and because models do not emit
+    /// lone bracket escapes in prose.
     private static func findBracketClose(_ s: String, from bodyStart: String.Index, displayMode: Bool) -> String.Index? {
         let closer: Character = displayMode ? "]" : ")"
+        let opener: Character = displayMode ? "[" : "("
         var i = bodyStart
         while i < s.endIndex {
             let c = s[i]
+
+            // Code regions — a closer inside one does not close the run.
+            if startsIndentedCodeBlock(s, at: i),
+               let codeBlockEnd = endOfIndentedCodeBlock(s, lineStart: i) {
+                i = codeBlockEnd
+                continue
+            }
+            if c == "`", isFenceStart(s, at: i) {
+                i = endOfFencedBlock(s, fenceStart: i)
+                continue
+            }
+            if c == "`" {
+                i = endOfInlineCode(s, openStart: i)
+                continue
+            }
+
             if c == "\\" {
                 let next = s.index(after: i)
                 if next == s.endIndex { return nil }
                 if s[next] == closer { return i }
+                // Nested opener of the same kind — the first opener was
+                // prose. Give up so the caller can rescan past it.
+                if s[next] == opener { return nil }
                 i = s.index(after: next)
                 continue
             }

--- a/apps/rapid-mac/Sources/Rapid/UI/Markdown/LaTeXSegmenter.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/Markdown/LaTeXSegmenter.swift
@@ -20,6 +20,30 @@ import Foundation
 ///   Single-line only (a literal newline ends the inline run so a
 ///   stray dollar sign in prose doesn't swallow the rest of the
 ///   reply into "math").
+/// * ``\[ ... \]`` — display math, LaTeX bracket form.
+/// * ``\( ... \)`` — inline math, LaTeX bracket form.
+///
+/// The bracket forms are NOT optional extras: they are what
+/// instruction-tuned models actually emit. A 2026-08 dogfood run
+/// (`bonsai-27b-2bit`, reproduced on a DeepSeek model) emitted only
+/// bracket delimiters for a plain word problem — no ``$`` anywhere.
+/// Missing them is not a cosmetic gap, because the raw body then
+/// reaches MarkdownUI and CommonMark's backslash-escape rule eats
+/// the delimiters: ``\(``, ``\)``, ``\[`` and ``\]`` all wrap ASCII
+/// punctuation, so they collapse to bare ``(``, ``)``, ``[``, ``]``
+/// while ``\frac`` / ``\times`` (backslash + letter, not a valid
+/// escape) survive verbatim. The user sees
+/// ``( P = \frac{47}{0.85} \approx 55.29 )`` — delimiters silently
+/// stripped, LaTeX left as source. Verified directly:
+/// ``AttributedString(markdown: #"So: \[ 0.85P = 47 \]"#)`` yields
+/// ``So: [ 0.85P = 47 ]``.
+///
+/// Delimiter STYLE is not preserved. ``\( x \)`` and ``$x$`` both
+/// produce ``.math(latex: "x", displayMode: false)`` — the choice
+/// carries no meaning downstream, and normalising keeps the segment
+/// enum (and every equality assertion built on it) unchanged. The
+/// round-trip property below therefore holds up to that
+/// normalisation.
 ///
 /// Anti-cases we intentionally do NOT treat as math:
 ///
@@ -32,6 +56,12 @@ import Foundation
 ///   shell prose, not math. The segmenter skips ``...`` runs.
 /// * **Escaped dollar** — ``\$`` stays a literal dollar sign and
 ///   never opens a math run.
+/// * **Escaped backslash before a bracket** — ``\\(`` is CommonMark's
+///   escaped backslash followed by a literal paren, so it does NOT
+///   open inline math. Same for ``\\[``.
+/// * **Unclosed bracket opener** — ``Use \( to group`` has no ``\)``,
+///   so the opener stays literal markdown rather than swallowing the
+///   rest of the reply.
 /// * **Bare dollar in prose** — ``it costs $20 today`` has only one
 ///   ``$`` so there's no closing pair; the segmenter requires a
 ///   close before the next blank line / EOF before opening math.
@@ -69,8 +99,10 @@ enum LaTeXSegmenter {
     /// Split ``input`` into alternating ``.markdown`` / ``.math``
     /// segments. The returned array reconstructs ``input`` exactly
     /// when ``.markdown`` bodies are concatenated and ``.math``
-    /// bodies are re-wrapped with their delimiters, so a future
-    /// "round-trip" sanity test can pin the contract.
+    /// bodies are re-wrapped with ``$``/``$$``, so a "round-trip"
+    /// sanity test can pin the contract. Bodies written with the
+    /// bracket delimiters round-trip onto their ``$``-form (see the
+    /// normalisation note in the type doc).
     ///
     /// Empty ``.markdown("")`` segments are NOT emitted — the caller
     /// just sees ``[.math, .math]`` if two math runs sit
@@ -112,11 +144,38 @@ enum LaTeXSegmenter {
                 continue
             }
 
-            // Escaped dollar — literal, skip both characters.
-            if c == "\\",
-               input.index(after: cursor) < input.endIndex,
-               input[input.index(after: cursor)] == "$" {
-                cursor = input.index(cursor, offsetBy: 2)
+            // Backslash: either a LaTeX bracket-delimiter opener
+            // (``\(`` / ``\[``) or a CommonMark escape (``\$``, ``\\``,
+            // ``\_``, …). Both consume TWO characters, so a doubled
+            // backslash can never be re-read as a delimiter opener:
+            // ``\\(`` is an escaped backslash followed by a literal
+            // paren, not math.
+            if c == "\\", input.index(after: cursor) < input.endIndex {
+                let markerIndex = input.index(after: cursor)
+                let marker = input[markerIndex]
+                if marker == "(" || marker == "[" {
+                    // ``\[`` is display, ``\(`` is inline — the
+                    // bracket forms carry the same meaning as
+                    // ``$$``/``$`` and normalise onto the same cases.
+                    let isDisplay = (marker == "[")
+                    let bodyStart = input.index(after: markerIndex)
+                    if let bodyEnd = findBracketClose(input, from: bodyStart, displayMode: isDisplay) {
+                        // Emit any leading plain markdown.
+                        if plainStart < cursor {
+                            segments.append(.markdown(String(input[plainStart..<cursor])))
+                        }
+                        let latex = String(input[bodyStart..<bodyEnd])
+                        segments.append(.math(latex: latex, displayMode: isDisplay))
+                        // The closer is two characters: ``\)`` / ``\]``.
+                        let closeEnd = input.index(bodyEnd, offsetBy: 2)
+                        plainStart = closeEnd
+                        cursor = closeEnd
+                        continue
+                    }
+                }
+                // ``\$``, an opener with no closer, or any other
+                // backslash escape — literal. Skip both characters.
+                cursor = input.index(after: markerIndex)
                 continue
             }
 
@@ -351,6 +410,48 @@ enum LaTeXSegmenter {
             i = s.index(after: i)
         }
         return bodyStart  // unclosed → consume only the open
+    }
+
+    /// Find the closing ``\)`` (inline) / ``\]`` (display) for a
+    /// bracket-delimited math run whose body starts at ``bodyStart``.
+    /// Returns the index of the closing BACKSLASH — the body is
+    /// ``bodyStart..<result`` and the closer occupies two characters —
+    /// or ``nil`` when no closer is found.
+    ///
+    /// A backslash inside the body always consumes the character that
+    /// follows it. That is what keeps LaTeX's own row break, ``\\``,
+    /// from faking a closer: in ``\[ a \\] b \]`` the ``\\`` is a row
+    /// break and the ``]`` right after it is a literal bracket, so the
+    /// run closes at the final ``\]`` and not at the third character
+    /// of ``\\]``.
+    private static func findBracketClose(_ s: String, from bodyStart: String.Index, displayMode: Bool) -> String.Index? {
+        let closer: Character = displayMode ? "]" : ")"
+        var i = bodyStart
+        while i < s.endIndex {
+            let c = s[i]
+            if c == "\\" {
+                let next = s.index(after: i)
+                if next == s.endIndex { return nil }
+                if s[next] == closer { return i }
+                i = s.index(after: next)
+                continue
+            }
+            // Inline-math paragraph guard: an unclosed ``\(`` must not
+            // swallow the rest of the reply. Unlike ``$``, a bare
+            // ``\(`` in prose is vanishingly rare (it is CommonMark's
+            // escape for a literal paren, which models never emit), so
+            // a SINGLE newline is tolerated — models do wrap long
+            // inline runs — and only a blank line ends the search.
+            // Display math keeps the lenient ``$$`` behaviour because
+            // multi-line ``\[ … \]`` blocks are the norm.
+            if !displayMode, c == "\n" {
+                let next = s.index(after: i)
+                if next == s.endIndex { return nil }
+                if s[next] == "\n" { return nil }
+            }
+            i = s.index(after: i)
+        }
+        return nil
     }
 
     /// Find the closing ``$`` (or ``$$``) for a math run starting

--- a/apps/rapid-mac/Tests/RapidTests/LaTeXSegmenterTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/LaTeXSegmenterTests.swift
@@ -351,13 +351,19 @@ struct LaTeXSegmenterTests {
         ])
     }
 
-    // MARK: - Bracket anti-cases
+    // MARK: - Bracket anti-cases (opener scan)
     //
     // NOTE for future maintainers: every test in THIS section also
     // passes against the pre-fix segmenter, which treated bracket
     // delimiters as plain text and so could never produce a false
     // positive. They do not pin the fix — they pin that the fix stays
     // conservative. The tests above are the ones that fail on a revert.
+    //
+    // These four also only exercise the OPENER scan: the opener sits
+    // inside the code region, so the run never starts and the closer
+    // scan is never entered. The "closer scan" section below covers
+    // the mirror image — opener in prose, closer inside the region —
+    // which is where the interesting failures live.
 
     @Test("Unclosed \\( stays literal markdown")
     func unclosedBracketOpener() {
@@ -395,6 +401,90 @@ struct LaTeXSegmenterTests {
     func bracketMathInIndentedCodeSurvives() {
         let body = "Before:\n\n    echo \"\\( x \\)\"\n\nAfter."
         #expect(LaTeXSegmenter.segment(body) == [.markdown(body)])
+    }
+
+    // MARK: - Closer scan
+    //
+    // Every test here has an opener in PROSE and a candidate closer
+    // somewhere the scan must not honour, so the run is actually
+    // started and `findBracketClose` actually walks. That is the gap
+    // the opener-side anti-cases above leave open.
+
+    @Test("Nested \\( : the first opener is prose, the second renders")
+    func nestedInlineOpenerIsProse() {
+        // LaTeX cannot nest inline math, so a second \( before any
+        // closer means the first one was never math. Without the bail
+        // the first opener reaches the SECOND expression's closer and
+        // eats the prose between them.
+        let segments = LaTeXSegmenter.segment(#"Use \( to group, then \(x\)."#)
+        #expect(segments == [
+            .markdown(#"Use \( to group, then "#),
+            .math(latex: "x", displayMode: false),
+            .markdown(".")
+        ])
+    }
+
+    @Test("Nested \\[ : the first opener is prose, the second renders")
+    func nestedDisplayOpenerIsProse() {
+        let segments = LaTeXSegmenter.segment(#"Use \[ then \[x\]."#)
+        #expect(segments == [
+            .markdown(#"Use \[ then "#),
+            .math(latex: "x", displayMode: true),
+            .markdown(".")
+        ])
+    }
+
+    @Test("A nested opener of the OTHER kind does not abandon the run")
+    func nestedOtherKindOpenerKeepsRun() {
+        // Deliberate asymmetry: bailing here would hand the formula
+        // back to CommonMark, which strips \[ \] to bare brackets —
+        // the original bug. Keeping it degrades to MathView's
+        // literal-source fallback instead, which shows more.
+        let segments = LaTeXSegmenter.segment(#"\[ a \( b \) c \]"#)
+        #expect(segments == [.math(latex: #" a \( b \) c "#, displayMode: true)])
+    }
+
+    @Test("A closer inside a fenced code block does not close the run")
+    func closerInsideFenceIsNotAClose() {
+        let body = "Use \\[ to open.\n\n```tex\n\\]\n```\n\nDone."
+        #expect(LaTeXSegmenter.segment(body) == [.markdown(body)])
+    }
+
+    @Test("A closer inside a code span does not close the run")
+    func closerInsideCodeSpanIsNotAClose() {
+        let body = #"Use \[ to open, and `\]` to close."#
+        #expect(LaTeXSegmenter.segment(body) == [.markdown(body)])
+    }
+
+    @Test("A closer inside an indented code block does not close the run")
+    func closerInsideIndentedCodeIsNotAClose() {
+        let body = "Use \\[ to open.\n\n    echo \"\\]\"\n\nDone."
+        #expect(LaTeXSegmenter.segment(body) == [.markdown(body)])
+    }
+
+    @Test("An indented CONTINUATION line still closes the run")
+    func indentedContinuationStillCloses() {
+        // The counterweight to the three tests above. Math bodies are
+        // routinely indented, and an indented line that merely follows
+        // the `\[` line is not a CommonMark code block — there is no
+        // blank line before it. Testing indentation alone (what the
+        // opener scan does) would abandon this formula.
+        let segments = LaTeXSegmenter.segment("\\[\n    P = 47 \\]")
+        #expect(segments == [.math(latex: "\n    P = 47 ", displayMode: true)])
+    }
+
+    @Test("First closer wins for a stray opener in plain prose")
+    func firstCloserWinsInProse() {
+        // Pinning the decision, not an accident of the scan: with no
+        // nested opener and no code region in between, the first
+        // closer closes. Accepted because CommonMark would have
+        // rendered both bracket escapes as bare brackets anyway.
+        let segments = LaTeXSegmenter.segment(#"Use \[ then later \] here."#)
+        #expect(segments == [
+            .markdown("Use "),
+            .math(latex: " then later ", displayMode: true),
+            .markdown(" here.")
+        ])
     }
 
     // MARK: - The two dogfood answers, verbatim

--- a/apps/rapid-mac/Tests/RapidTests/LaTeXSegmenterTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/LaTeXSegmenterTests.swift
@@ -270,6 +270,202 @@ struct LaTeXSegmenterTests {
         ])
     }
 
+    // MARK: - LaTeX bracket delimiters, \( … \) and \[ … \]
+    //
+    // 2026-08 dogfood regression. `bonsai-27b-2bit` (reproduced on a
+    // DeepSeek model) answered a plain word problem using ONLY the
+    // bracket delimiters — no `$` anywhere. The segmenter knew only
+    // `$`, so the whole body went to MarkdownUI, and CommonMark's
+    // backslash-escape rule ate the delimiters: `\(`, `\)`, `\[`, `\]`
+    // all wrap ASCII punctuation, so they collapse to bare brackets,
+    // while `\frac` / `\times` (backslash + letter, not an escape)
+    // survive verbatim. Verified independently:
+    //   AttributedString(markdown: #"So: \[ 0.85P = 47 \]"#)
+    //     → "So: [ 0.85P = 47 ]"
+    // which is byte-for-byte what the dogfood screenshots showed.
+
+    @Test("Inline bracket math \\( … \\) splits like $ … $")
+    func inlineBracketMath() {
+        let segments = LaTeXSegmenter.segment(#"Let \( P \) be the price."#)
+        #expect(segments == [
+            .markdown("Let "),
+            .math(latex: " P ", displayMode: false),
+            .markdown(" be the price.")
+        ])
+    }
+
+    @Test("Display bracket math \\[ … \\] splits like $$ … $$")
+    func displayBracketMath() {
+        let segments = LaTeXSegmenter.segment(#"So: \[ 0.85P = 47 \]"#)
+        #expect(segments == [
+            .markdown("So: "),
+            .math(latex: " 0.85P = 47 ", displayMode: true)
+        ])
+    }
+
+    @Test("Multi-line display bracket math")
+    func multiLineDisplayBracketMath() {
+        let segments = LaTeXSegmenter.segment("\\[\nf(x) = ax^2\n\\]")
+        #expect(segments == [.math(latex: "\nf(x) = ax^2\n", displayMode: true)])
+    }
+
+    @Test("LaTeX row break \\\\ inside \\[ … \\] does not fake a closer")
+    func rowBreakDoesNotClose() {
+        // ``\\`` is LaTeX's row break. Read one character at a time its
+        // second backslash + a following ``]`` would look like ``\]``,
+        // truncating the formula. The scanner must consume both.
+        let segments = LaTeXSegmenter.segment(#"\[ a \\ b \]"#)
+        #expect(segments == [.math(latex: #" a \\ b "#, displayMode: true)])
+    }
+
+    @Test("\\right] inside display math does not close the run early")
+    func rightBracketDoesNotClose() {
+        let segments = LaTeXSegmenter.segment(#"\[ x \in \left[0,1\right] \]"#)
+        #expect(segments == [.math(latex: #" x \in \left[0,1\right] "#, displayMode: true)])
+    }
+
+    @Test("Dollar and bracket delimiters mix in one body")
+    func mixedDollarAndBracketDelimiters() {
+        let segments = LaTeXSegmenter.segment(#"$a$ and \(b\) and $$c$$ and \[d\]"#)
+        #expect(segments == [
+            .math(latex: "a", displayMode: false),
+            .markdown(" and "),
+            .math(latex: "b", displayMode: false),
+            .markdown(" and "),
+            .math(latex: "c", displayMode: true),
+            .markdown(" and "),
+            .math(latex: "d", displayMode: true)
+        ])
+    }
+
+    @Test("Inline bracket math may wrap across a single newline")
+    func inlineBracketWrapsOneNewline() {
+        // Unlike ``$``, ``\(`` is unambiguous, so the single-line guard
+        // that protects prose dollars is not needed here — only a blank
+        // line ends the search.
+        let segments = LaTeXSegmenter.segment("Val \\( a +\nb \\) done.")
+        #expect(segments == [
+            .markdown("Val "),
+            .math(latex: " a +\nb ", displayMode: false),
+            .markdown(" done.")
+        ])
+    }
+
+    // MARK: - Bracket anti-cases
+    //
+    // NOTE for future maintainers: every test in THIS section also
+    // passes against the pre-fix segmenter, which treated bracket
+    // delimiters as plain text and so could never produce a false
+    // positive. They do not pin the fix — they pin that the fix stays
+    // conservative. The tests above are the ones that fail on a revert.
+
+    @Test("Unclosed \\( stays literal markdown")
+    func unclosedBracketOpener() {
+        let body = #"Use \( to open a group."#
+        #expect(LaTeXSegmenter.segment(body) == [.markdown(body)])
+    }
+
+    @Test("\\\\( is an escaped backslash, not a math opener")
+    func escapedBackslashBeforeParen() {
+        let body = #"Escaped: \\(not math\\)"#
+        #expect(LaTeXSegmenter.segment(body) == [.markdown(body)])
+    }
+
+    @Test("Inline bracket math stops at a blank line")
+    func inlineBracketStopsAtParagraphBreak() {
+        // An opener the model forgot to close must not swallow the
+        // rest of the reply into "math".
+        let body = "Start \\( x\n\nEnd \\) done."
+        #expect(LaTeXSegmenter.segment(body) == [.markdown(body)])
+    }
+
+    @Test("Bracket math inside a fenced code block stays literal")
+    func bracketMathInFenceSurvives() {
+        let body = "Snippet:\n\n```tex\n\\( x \\) and \\[ y \\]\n```\n\nAfter."
+        #expect(LaTeXSegmenter.segment(body) == [.markdown(body)])
+    }
+
+    @Test("Bracket math inside a code span stays literal")
+    func bracketMathInCodeSpanSurvives() {
+        let body = #"Write `\(x\)` for inline math."#
+        #expect(LaTeXSegmenter.segment(body) == [.markdown(body)])
+    }
+
+    @Test("Bracket math inside an indented code block stays literal")
+    func bracketMathInIndentedCodeSurvives() {
+        let body = "Before:\n\n    echo \"\\( x \\)\"\n\nAfter."
+        #expect(LaTeXSegmenter.segment(body) == [.markdown(body)])
+    }
+
+    // MARK: - The two dogfood answers, verbatim
+
+    /// The shirt-discount answer exactly as `bonsai-27b-2bit` emitted
+    /// it. The user-visible contract is the assertion below: NOTHING
+    /// that MarkdownUI will mangle may remain in a `.markdown`
+    /// segment.
+    private static let discountAnswer = #"""
+    Let \( P \) be the original price of the shirt.
+    A 15% discount means you pay \( 100\% - 15\% = 85\% \) of the original price.
+    So: \[ 0.85P = 47 \]
+    Solving for \( P \): \[ P = \frac{47}{0.85} \approx 55.29 \]
+    Answer: The original price was $55.29.
+    """#
+
+    private static let billSplitAnswer = #"""
+    Let \( B \) = Bob's payment
+    Alice pays 40% more than Bob: \( A = 1.4B \)
+    Substitute \( A = 1.4B \): \[ C = \frac{1}{2}(2.4B) = 1.2B \]
+    """#
+
+    /// Concatenation of everything that would be handed to MarkdownUI.
+    private static func markdownHandedToRenderer(_ body: String) -> String {
+        LaTeXSegmenter.segment(body).compactMap { segment -> String? in
+            guard case .markdown(let text) = segment else { return nil }
+            return text
+        }.joined()
+    }
+
+    @Test("Discount answer: no delimiter or LaTeX command reaches MarkdownUI")
+    func discountAnswerFullySegmented() {
+        let markdown = Self.markdownHandedToRenderer(Self.discountAnswer)
+        // Delimiters: CommonMark would strip these to bare brackets.
+        #expect(!markdown.contains(#"\("#))
+        #expect(!markdown.contains(#"\)"#))
+        #expect(!markdown.contains(#"\["#))
+        #expect(!markdown.contains(#"\]"#))
+        // Commands: CommonMark leaves these as visible source.
+        #expect(!markdown.contains(#"\frac"#))
+        #expect(!markdown.contains(#"\approx"#))
+    }
+
+    @Test("Bill-split answer: no delimiter or LaTeX command reaches MarkdownUI")
+    func billSplitAnswerFullySegmented() {
+        let markdown = Self.markdownHandedToRenderer(Self.billSplitAnswer)
+        #expect(!markdown.contains(#"\("#))
+        #expect(!markdown.contains(#"\)"#))
+        #expect(!markdown.contains(#"\["#))
+        #expect(!markdown.contains(#"\]"#))
+        #expect(!markdown.contains(#"\frac"#))
+    }
+
+    @Test("Dogfood answer: the two display formulas become display-math segments")
+    func discountAnswerDisplayMath() {
+        let display = LaTeXSegmenter.segment(Self.discountAnswer).compactMap { segment -> String? in
+            guard case .math(let latex, let displayMode) = segment, displayMode else { return nil }
+            return latex
+        }
+        #expect(display == [" 0.85P = 47 ", #" P = \frac{47}{0.85} \approx 55.29 "#])
+    }
+
+    @Test("Dogfood answer: trailing currency is NOT swallowed as math")
+    func discountAnswerCurrencyUntouched() {
+        // "$55.29." ends the reply. The currency guard must keep it in
+        // markdown — a lone trailing `$` has no closer anyway, but this
+        // pins that the bracket work did not disturb it.
+        let segments = LaTeXSegmenter.segment(Self.discountAnswer)
+        #expect(segments.last == LaTeXSegment.markdown("\nAnswer: The original price was $55.29."))
+    }
+
     @Test("Round-trip: segments concatenated with delimiters re-form input")
     func roundTrip() {
         let inputs = [
@@ -291,5 +487,44 @@ struct LaTeXSegmenterTests {
             #expect(reconstructed == body,
                     "segmenter must be lossless: '\(body)' → '\(reconstructed)'")
         }
+    }
+
+    @Test("Round-trip: bracket delimiters normalise onto their $ form")
+    func roundTripBracketNormalises() {
+        // Delimiter STYLE is deliberately not preserved — `\(x\)` and
+        // `$x$` mean the same thing and produce the same segment. So
+        // the round-trip lands on the `$` form, not byte-for-byte
+        // input. This pins that choice.
+        let segments = LaTeXSegmenter.segment(#"Let \(x\) then \[y\]"#)
+        let reconstructed = segments.map { seg -> String in
+            switch seg {
+            case .markdown(let s): return s
+            case .math(let latex, let display):
+                return display ? "$$\(latex)$$" : "$\(latex)$"
+            }
+        }.joined()
+        #expect(reconstructed == "Let $x$ then $$y$$")
+    }
+
+    @Test("displayMathOnly: bracket-sourced inline math folds back as $ … $")
+    func displayMathOnlyBracketInlineCollapse() {
+        // v1 still does not RENDER inline math (see the deferral note
+        // on ``LaTeXMarkdownView``). What changes with the bracket fix
+        // is that the fold-back emits `$A = 1.4B$` rather than letting
+        // CommonMark strip `\( … \)` down to a bare `( A = 1.4B )`.
+        let segs = LaTeXSegmenter.segment(#"Alice pays: \( A = 1.4B \) total."#)
+        #expect(LaTeXMarkdownView.displayMathOnly(segs) == [
+            .markdown("Alice pays: $ A = 1.4B $ total.")
+        ])
+    }
+
+    @Test("displayMathOnly: bracket display math survives as its own segment")
+    func displayMathOnlyBracketDisplaySurvives() {
+        let segs = LaTeXSegmenter.segment(#"So: \[ 0.85P = 47 \] done."#)
+        #expect(LaTeXMarkdownView.displayMathOnly(segs) == [
+            .markdown("So: "),
+            .math(latex: " 0.85P = 47 ", displayMode: true),
+            .markdown(" done.")
+        ])
     }
 }


### PR DESCRIPTION
## Why

Math in chat answers rendered as broken prose. From a dogfood run
(`bonsai-27b-2bit`, reproduced on a DeepSeek model), verbatim from screen:

```
Let ( P ) be the original price of the shirt.
So: [ 0.85P = 47 ]
Solving for ( P ): [ P = \frac{47}{0.85} \approx 55.29 ]
```

`LaTeXSegmenter` only knew the dollar forms, `$…$` and `$$…$$`. Both answers used
only the bracket forms, `\(…\)` and `\[…\]` — no `$` anywhere. No math segment
was produced, so the whole body went to MarkdownUI, and CommonMark's
backslash-escape rule did the visible damage: `\(`, `\)`, `\[`, `\]` all escape
ASCII punctuation and collapse to bare brackets, while `\frac` / `\times` /
`\approx` are backslash + *letter*, not a valid escape, and survive as source.

Verified rather than reasoned:

```
AttributedString(markdown: #"So: \[ 0.85P = 47 \]"#)  ->  "So: [ 0.85P = 47 ]"
AttributedString(markdown: #"Let \( P \) be..."#)     ->  "Let ( P ) be..."
```

Byte-for-byte what was on screen.

## What changed

The segmenter opens math on `\(` / `\[` and closes on `\)` / `\]`. A backslash
always consumes the next character, which stops LaTeX's own `\\` row break from
faking a closer and stops CommonMark's `\\(` from opening math.

Delimiter *style* is not preserved: `\(x\)` and `$x$` both yield
`.math(latex: "x", displayMode: false)`. The choice carries no meaning
downstream, and normalising leaves the segment enum — and every equality
assertion built on it — unchanged. The round-trip contract in the type doc now
says "up to that normalisation".

Review found the closer scan was one-sided — it looked for the first closer with
no notion of nesting and none of the code-region skipping the *opener* scan
does. Fixed, and the nesting rule is now a decision rather than an accident:

* A second opener of the **same kind** before any closer means the first was
  prose. The scan gives up, the opener is emitted literally, and scanning
  resumes just past it — so `Use \( to group, then \(x\).` keeps the prose and
  still renders the second expression.
* A nested opener of the **other kind** deliberately does *not* bail. Rejecting
  the outer run hands it back to CommonMark, which strips the delimiters — the
  original bug. Keeping it degrades to `MathView`'s literal-source fallback,
  which shows strictly more.
* Otherwise first-closer-wins.

The closer scan skips fenced blocks, code spans and indented code. Its
indented-code test is deliberately **stricter** than the opener scan's: it
requires the preceding blank line CommonMark actually requires. The two mistakes
are not symmetric — a false skip in the opener scan only declines to look for
math, while a false skip in the closer scan abandons a real formula, and math
bodies are routinely indented. Mutation-proven load-bearing (see below).

## Test plan

50 tests. `swift build` clean.

**Mutation results.** Reverting only the closer-scan commit fails 5 of 8 new
tests (both nested-opener cases, and closer-inside fence / code-span /
indented-code). The 3 survivors pin decisions that were already correct, so they
guard against over-correction rather than revert — called out in the file so
nobody mistakes them for coverage. Swapping the strict indented test for the
opener scan's naive one fails exactly the indented-continuation test. A full
revert to pre-fix fails 19 of 28. No pre-existing test regressed.

**Termination fuzz.** A hang here freezes the UI thread and the new code jumps
through three helpers that must all advance strictly: 300,000 adversarial inputs
over `` \ ( ) [ ] $ ` ␠ ⏎ ⇥ a 1 % { } ``, no hang, and segment bodies always a
subsequence of the input with delimiter counts in bounds.

**An earlier round's anti-cases were weaker than they looked** — all four
code-region cases put the *opener* inside the region, so the run never started
and the closer scan was never entered. Noted in-file; the new section covers the
mirror image.

**`swift test` could not run here** — the `Testing` module itself is absent from
this CommandLineTools-only toolchain, not just XCTest. All 50 tests were executed
through a mechanical transliteration (macros stripped, `#expect` → a function)
compiled against the real segmenter, so every expression is type-checked and
run. The swift-testing macro layer is unverified; CI on macos-15 is the gate.

## What this does NOT fix

Shipped `.app` bundles carry no SwiftMath resource, so `mathFontsAvailable` is
false and math takes the literal-source fallback regardless — filed as #1576.
The user-visible change here is from delimiters silently stripped into
broken-looking prose, to `$$…$$` in selectable secondary monospace. Better, and
a strict prerequisite for real rendering, but not glyphs.

A sibling gap is untouched: `findClose`, the `$`/`$$` scanner, has the same shape
of unbounded scan. It predates this branch, so per the repo's A/B rule it is left
for its own change.