### PR TITLE
fix(rapid-mac): say what actually happened when DuckDuckGo throttles web_search

### DIFF
--- a/apps/rapid-mac/CHANGELOG.md
+++ b/apps/rapid-mac/CHANGELOG.md
@@ -13,6 +13,18 @@ can actually understand.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Web search now says what actually went wrong.** DuckDuckGo — the free
+  backend Rapid uses out of the box — starts refusing searches from your Mac
+  after the first few, and Rapid read that refusal as an ordinary success with
+  no results. The tool card said "Web search couldn't finish. Check its
+  settings, then try again," which sent you to a Settings page where nothing
+  was wrong. It now names the situation ("DuckDuckGo is rate-limiting web
+  searches from this Mac") and offers a one-click jump to Settings → Tools,
+  where you can switch to Brave Search or Tavily. The Settings caption for
+  DuckDuckGo no longer claims it "works out of the box."
+
 ## [0.12.5] — 2026-08-05
 
 A stability release. The headline is a crash: a reply with a formula in it

--- a/apps/rapid-mac/Sources/Rapid/Services/FailureDiagnosis.swift
+++ b/apps/rapid-mac/Sources/Rapid/Services/FailureDiagnosis.swift
@@ -10,6 +10,11 @@ struct FailureDiagnosis: Equatable, Sendable {
         case engineNotRunning
         case webSearchOffline
         case webSearchUnavailable
+        /// The free DuckDuckGo backend throttled this machine. Distinct from
+        /// ``webSearchUnavailable`` because the remedy is different: nothing in
+        /// Settings is misconfigured, so "check its settings" sends the user to
+        /// a dead end. The only real fix is a different backend.
+        case webSearchRateLimited
         case commandPermissionDenied
         case commandFailed
         case fileNotFound
@@ -26,6 +31,10 @@ struct FailureDiagnosis: Equatable, Sendable {
         case openModelManagement
         case switchDownloadSource
         case openPermissions
+        /// Deep-link to Settings → Tools, where the web-search backend is
+        /// chosen and its key is pasted. Routed through ``SettingsRouter``
+        /// like the other "open Settings on THIS tab" actions.
+        case openWebSearchSettings
 
         var title: String {
             switch self {
@@ -34,6 +43,7 @@ struct FailureDiagnosis: Equatable, Sendable {
             case .openModelManagement: return "Open Model Management"
             case .switchDownloadSource: return "Switch source"
             case .openPermissions: return "Open Permissions"
+            case .openWebSearchSettings: return "Open Web Search Settings"
             }
         }
 
@@ -43,6 +53,7 @@ struct FailureDiagnosis: Equatable, Sendable {
             case .openModelManagement: return "square.stack.3d.up"
             case .switchDownloadSource: return "arrow.triangle.2.circlepath"
             case .openPermissions: return "hand.raised"
+            case .openWebSearchSettings: return "magnifyingglass"
             }
         }
     }
@@ -84,6 +95,15 @@ enum FailureDiagnoser {
         case .webSearchUnavailable:
             message = "Web search couldn't finish. Check its settings, then try again."
             action = .retry
+        case .webSearchRateLimited:
+            // Deliberately NOT "check its settings": everything in Settings is
+            // already correct when this fires. DuckDuckGo rate-limits the free
+            // endpoint per IP within a handful of searches, so the honest
+            // remedy is a different backend, and the message has to say which
+            // ones and where. Kept to one sentence of situation + one of
+            // remedy so it still reads inside the tool card.
+            message = "DuckDuckGo is rate-limiting web searches from this Mac. Switch to Brave Search or Tavily in Settings → Tools and add a free key."
+            action = .openWebSearchSettings
         case .commandPermissionDenied:
             message = "The command tried to change a protected location. Allow that folder, then try again."
             action = .openPermissions
@@ -135,6 +155,15 @@ enum FailureDiagnoser {
         guard isError else { return nil }
 
         if toolName == "web_search" {
+            // ``WebSearchTool`` stamps ``.webSearchRateLimited`` on the result
+            // directly, so this branch only matters for rows restored from an
+            // older transcript (no stored kind) — hence the narrow, DDG-anchored
+            // signals. A Brave/Tavily quota error must NOT land here: telling a
+            // Brave user to "switch to Brave" is the same dead end this fix is
+            // removing.
+            if raw.contains("duckduckgo"), containsAny(raw, duckDuckGoThrottleSignals) {
+                return .webSearchRateLimited
+            }
             return containsAny(raw, offlineSignals) ? .webSearchOffline : .webSearchUnavailable
         }
         if ["read_file", "list_directory", "write_file", "edit_file"].contains(toolName) {
@@ -235,6 +264,13 @@ enum FailureDiagnoser {
         "not connected to the internet", "network is unreachable", "network connection was lost",
         "could not resolve host", "cannot find host", "cannot connect", "connection refused",
         "connection reset", "dns", "offline", "timed out", "timeout",
+    ]
+
+    /// Throttle wording DuckDuckGo results have carried across releases.
+    /// Only consulted together with a ``duckduckgo`` mention (see
+    /// ``toolFailureKind``).
+    nonisolated private static let duckDuckGoThrottleSignals = [
+        "throttl", "rate limit", "rate-limit", "anti-bot", "blocked this request",
     ]
 
     nonisolated private static let missingFileSignals = [

--- a/apps/rapid-mac/Sources/Rapid/Services/FailureDiagnosis.swift
+++ b/apps/rapid-mac/Sources/Rapid/Services/FailureDiagnosis.swift
@@ -61,6 +61,33 @@ struct FailureDiagnosis: Equatable, Sendable {
     let kind: Kind
     let message: String
     let action: Action?
+
+    /// The recovery action a tool card may render inline, or nil for "render
+    /// no button". Two gates, both load-bearing:
+    ///
+    ///   * **Settings deep-links only.** ``.retry`` would have to rewind the
+    ///     whole chat turn; the assistant row above the card already owns that
+    ///     affordance. "Open Settings on the right tab" has nowhere else to
+    ///     live, so it is the one action the card offers.
+    ///   * **Only when the deep-link can actually run.** The card resolves
+    ///     ``SettingsRouter`` optionally so it still renders in a host that
+    ///     never injected one (previews, the snapshot harness). Those hosts
+    ///     have no Settings window to open either — and a visible button that
+    ///     does nothing is precisely the failure this diagnosis exists to
+    ///     remove, so the button must be absent rather than inert.
+    ///
+    /// Pure + static because the view that calls it is `private` inside
+    /// ChatView and a SwiftUI body can't be exercised from the test suite.
+    static func inlineToolCardAction(
+        for diagnosis: FailureDiagnosis?,
+        canRouteToSettings: Bool
+    ) -> Action? {
+        guard canRouteToSettings else { return nil }
+        switch diagnosis?.action {
+        case .openWebSearchSettings: return .openWebSearchSettings
+        default: return nil
+        }
+    }
 }
 
 /// Rule-based classification for common failures. Matching deliberately uses

--- a/apps/rapid-mac/Sources/Rapid/Tools/WebSearchProvider.swift
+++ b/apps/rapid-mac/Sources/Rapid/Tools/WebSearchProvider.swift
@@ -36,10 +36,17 @@ enum WebSearchProvider: String, CaseIterable, Codable, Identifiable, Sendable {
     /// Plain-English subtitle for the Settings picker. Tells the
     /// user what they're trading off (cost / signup) without
     /// having to read the docs.
+    ///
+    /// The DuckDuckGo line used to end "works out of the box." It
+    /// doesn't: the free HTML endpoint throttles per IP after a
+    /// handful of searches (measured 2026-08-05 — one 200, then 202
+    /// non-results pages for every query after it). A user who hits
+    /// that throttle and comes here looking for the problem must not
+    /// be told the backend is fine.
     var subtitle: String {
         switch self {
         case .duckduckgo:
-            return "No key required. HTML scrape; works out of the box."
+            return "No key required. Best-effort — throttled after a few searches; the keyed backends aren't."
         case .brave:
             return "Requires a free Brave Search API key. 2 000 queries/month."
         case .tavily:

--- a/apps/rapid-mac/Sources/Rapid/Tools/WebSearchTool.swift
+++ b/apps/rapid-mac/Sources/Rapid/Tools/WebSearchTool.swift
@@ -157,34 +157,91 @@ enum WebSearchTool {
         req.timeoutInterval = 15
         do {
             let (data, response) = try await cappedData(for: req)
-            guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
-                let code = (response as? HTTPURLResponse)?.statusCode ?? -1
+            let code = (response as? HTTPURLResponse)?.statusCode ?? -1
+            let html = String(data: data, encoding: .utf8)
+            // Throttle check runs BEFORE the 2xx guard. DDG answers a
+            // throttled caller two different ways and the old ordering
+            // mishandled both: HTTP 202 + a non-results page sailed
+            // through the ``(200..<300)`` guard as "success", and HTTP
+            // 429 fell out as a bare "returned HTTP 429". Both are the
+            // same situation for the user, so classify first.
+            if isDuckDuckGoThrottled(statusCode: code, html: html ?? "") {
+                return duckDuckGoThrottledResult(fallbackNote: fallbackNote)
+            }
+            guard (200..<300).contains(code) else {
                 return ToolCallResult(toolCallID: "", content: "\(toolName) error: DuckDuckGo returned HTTP \(code)", isError: true)
             }
-            guard let html = String(data: data, encoding: .utf8) else {
+            guard let html else {
                 return ToolCallResult(toolCallID: "", content: "\(toolName) error: non-UTF8 response", isError: true)
-            }
-            // DDG silently rate-limits repeat callers from a single
-            // IP/UA: the HTTP response is still 200 but the body is
-            // the "Unfortunately, bots use DuckDuckGo too." modal
-            // instead of result blocks. Without an explicit check
-            // ``parseDDGHTML`` returns an empty list and the model
-            // hears "no results found" — indistinguishable from a
-            // query that genuinely matched nothing. Surface the
-            // block so the assistant can either back off or tell
-            // the user to configure a paid backend.
-            if detectDDGAntiBot(html) {
-                return ToolCallResult(
-                    toolCallID: "",
-                    content: "\(toolName) error: DuckDuckGo blocked this request (anti-bot rate limit). Either wait a few minutes, or configure a paid backend in Settings → Tools → Web search (Brave: 2000 queries/month free; Tavily: 1000 queries/month free).",
-                    isError: true
-                )
             }
             let results = parseDDGHTML(html, cap: resultCap)
             return formatOutput(query: q, provider: .duckduckgo, results: results, fallbackNote: fallbackNote)
         } catch {
             return ToolCallResult(toolCallID: "", content: "\(toolName) error: \(error.localizedDescription)", isError: true)
         }
+    }
+
+    /// True when DuckDuckGo answered with its throttle signature instead of a
+    /// results page.
+    ///
+    /// Measured against ``https://html.duckduckgo.com/html/`` on 2026-08-05:
+    /// the first request of a session returns **200** with ten ``result__a``
+    /// blocks, and every request after it returns **202** with a ~14 KB page
+    /// that carries no result blocks — for five different queries, under both
+    /// a plain Safari UA and the tool's own UA. So it is per-IP throttling,
+    /// not UA sniffing, and 202 is its fingerprint.
+    ///
+    /// Three signals, in order:
+    ///
+    /// 1. **A real results page is never a throttle.** If the body carries a
+    ///    ``result__body`` class token we have hits to parse, whatever the
+    ///    status line says. This is what keeps a hypothetical 202-with-results
+    ///    from being misread: the signature is "202 with a *non-results*
+    ///    body", not 202 on its own.
+    /// 2. **202 / 429 / 403 with no result blocks** — 202 is the observed
+    ///    soft-throttle, 429 the explicit one, 403 the hard block.
+    /// 3. **The anti-bot modal on a 200** — the older, still-live shape that
+    ///    ``detectDDGAntiBot`` recognises.
+    static func isDuckDuckGoThrottled(statusCode: Int, html: String) -> Bool {
+        if containsResultBodyClassToken(html) { return false }
+        if statusCode == 202 || statusCode == 429 || statusCode == 403 { return true }
+        return detectDDGAntiBot(html)
+    }
+
+    /// Model-visible payload for a throttled DuckDuckGo search.
+    ///
+    /// Written as **facts about the backend**, not as instructions to the
+    /// assistant. The failure it replaced ("DuckDuckGo blocked this request
+    /// (anti-bot rate limit)") left enough room for a small model to conclude
+    /// it has no web access at all and answer "I can't browse the web" — which
+    /// contradicts the tool card the user is looking at. Naming the tool as
+    /// enabled, and the backend as the thing that ran out, closes that gap
+    /// without steering the model's prose.
+    static let duckDuckGoThrottleContent = """
+        web_search error: the DuckDuckGo backend rate-limited this Mac, so this query \
+        returned no results. The web_search tool is enabled and working — DuckDuckGo \
+        throttles its free endpoint per IP after a few searches, and usually recovers \
+        after a few minutes. The user can also switch the backend to Brave Search or \
+        Tavily in Settings → Tools → Web search (Brave: 2000 queries/month free; \
+        Tavily: 1000 queries/month free), which are not throttled this way.
+        """
+
+    /// Wraps ``duckDuckGoThrottleContent`` with the stable UI classification.
+    /// ``failureKind`` is stamped here rather than sniffed back out of the
+    /// prose by ``FailureDiagnoser`` so the tool card can never disagree with
+    /// what actually happened.
+    static func duckDuckGoThrottledResult(fallbackNote: String? = nil) -> ToolCallResult {
+        var content = duckDuckGoThrottleContent
+        // A user who picked Brave/Tavily but hasn't pasted a key yet is
+        // silently on DDG — that context matters far more once DDG has
+        // throttled, so carry the note through instead of dropping it.
+        if let fallbackNote { content += "\n\n" + fallbackNote }
+        return ToolCallResult(
+            toolCallID: "",
+            content: content,
+            isError: true,
+            failureKind: .webSearchRateLimited
+        )
     }
 
     static func runBrave(query q: String, apiKey: String) async -> ToolCallResult {

--- a/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
@@ -993,9 +993,16 @@ private struct ToolCallChip: View {
 
     /// Deep-link channel into Settings. Optional so the chip still renders in
     /// any host that hasn't injected the router (previews, snapshot harness) —
-    /// the non-optional form traps at lookup time.
+    /// the non-optional form traps at lookup time. Absence also suppresses the
+    /// inline button entirely; see ``FailureDiagnosis.inlineToolCardAction``.
     @Environment(SettingsRouter.self) private var settingsRouter: SettingsRouter?
-    @Environment(\.openSettings) private var openSettings
+    /// ``openWindow(id: "settings")``, NOT ``@Environment(\.openSettings)``.
+    /// This app has no SwiftUI ``Settings`` scene — it declares a real
+    /// ``Window("Settings", id: "settings")`` so the tray item can reach it
+    /// (see ``RapidApp``), and ``OpenSettingsAction`` against a missing
+    /// ``Settings`` scene is a silent no-op. ⌘, and the tray's "Settings…"
+    /// item both go through ``openWindow`` for the same reason.
+    @Environment(\.openWindow) private var openWindow
 
     /// Manual override. Tracks the user's last toggle so a click always wins
     /// over the auto-collapse-on-success rule; without it, expanding a
@@ -1041,23 +1048,27 @@ private struct ToolCallChip: View {
         return ChatTextSanitizer.sanitizeForDisplay(result.content)
     }
 
-    /// The one recovery action the chip offers inline. Only the Settings
-    /// deep-links are honoured here: "Retry" would need to rewind the whole
-    /// chat turn (the row-level Retry above already owns that), while
-    /// "open Settings on the right tab" is exactly what a tool-configuration
-    /// failure needs and has nowhere else to live.
+    /// The one recovery action the chip offers inline, or nil for no button.
+    /// Policy lives in ``FailureDiagnosis`` so it can be pinned by a test —
+    /// this view is private and a SwiftUI body isn't reachable from the suite.
     private var inlineAction: FailureDiagnosis.Action? {
-        switch failureDiagnosis?.action {
-        case .openWebSearchSettings: return .openWebSearchSettings
-        default: return nil
-        }
+        FailureDiagnosis.inlineToolCardAction(
+            for: failureDiagnosis,
+            canRouteToSettings: settingsRouter != nil
+        )
     }
 
     private func perform(_ action: FailureDiagnosis.Action) {
         switch action {
         case .openWebSearchSettings:
+            // Order matters: the router field must be set BEFORE the window
+            // opens. ``SettingsView`` consumes it from ``.onAppear`` (first
+            // open of the session) and ``.onChange`` (already-open window
+            // being re-focused); setting it after the open would race the
+            // ``.onAppear`` read and land the user on the last-used tab.
+            // Same pairing ``QuickstartView`` uses for its deep-links.
             settingsRouter?.requestedCategory = .tools
-            openSettings()
+            openWindow(id: "settings")
         case .retry, .restart, .openModelManagement, .switchDownloadSource, .openPermissions:
             break
         }

--- a/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
@@ -991,6 +991,12 @@ private struct ToolCallChip: View {
     let call: ToolCall
     let result: ChatMessage?
 
+    /// Deep-link channel into Settings. Optional so the chip still renders in
+    /// any host that hasn't injected the router (previews, snapshot harness) —
+    /// the non-optional form traps at lookup time.
+    @Environment(SettingsRouter.self) private var settingsRouter: SettingsRouter?
+    @Environment(\.openSettings) private var openSettings
+
     /// Manual override. Tracks the user's last toggle so a click always wins
     /// over the auto-collapse-on-success rule; without it, expanding a
     /// completed chip would be silently re-collapsed on the next body pass.
@@ -1020,14 +1026,41 @@ private struct ToolCallChip: View {
         return ChatTextSanitizer.sanitizeForDisplay(str)
     }
 
+    /// Stable diagnosis for a failed result. ``nil`` while the tool is still
+    /// running or when it succeeded.
+    private var failureDiagnosis: FailureDiagnosis? {
+        guard let result, result.status == .failed else { return nil }
+        return result.toolFailureDiagnosis(toolName: call.function.name)
+    }
+
     /// A failed result renders its stable diagnosis, never the raw tool
     /// payload — that stays in the model's context, not on screen.
     private var resultBody: String? {
         guard let result else { return nil }
-        if result.status == .failed {
-            return result.toolFailureDiagnosis(toolName: call.function.name).message
-        }
+        if let failureDiagnosis { return failureDiagnosis.message }
         return ChatTextSanitizer.sanitizeForDisplay(result.content)
+    }
+
+    /// The one recovery action the chip offers inline. Only the Settings
+    /// deep-links are honoured here: "Retry" would need to rewind the whole
+    /// chat turn (the row-level Retry above already owns that), while
+    /// "open Settings on the right tab" is exactly what a tool-configuration
+    /// failure needs and has nowhere else to live.
+    private var inlineAction: FailureDiagnosis.Action? {
+        switch failureDiagnosis?.action {
+        case .openWebSearchSettings: return .openWebSearchSettings
+        default: return nil
+        }
+    }
+
+    private func perform(_ action: FailureDiagnosis.Action) {
+        switch action {
+        case .openWebSearchSettings:
+            settingsRouter?.requestedCategory = .tools
+            openSettings()
+        case .retry, .restart, .openModelManagement, .switchDownloadSource, .openPermissions:
+            break
+        }
     }
 
     private var statusIcon: String {
@@ -1082,6 +1115,16 @@ private struct ToolCallChip: View {
                             .foregroundStyle(result?.status == .failed ? RapidTheme.statusError : .secondary)
                             .textSelection(.enabled)
                             .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                    if let action = inlineAction {
+                        Button {
+                            perform(action)
+                        } label: {
+                            Label(action.title, systemImage: action.systemImage)
+                        }
+                        .buttonStyle(.link)
+                        .font(.system(size: 11))
+                        .accessibilityIdentifier("ToolCallChip.\(action.rawValue)")
                     }
                 }
                 .padding(.horizontal, 10)

--- a/apps/rapid-mac/Sources/Rapid/UI/DownloadStrip.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/DownloadStrip.swift
@@ -104,7 +104,7 @@ struct DownloadStrip: View {
             downloads.retryDownload(alias: job.alias)
         case .switchDownloadSource:
             downloads.retryDownload(alias: job.alias, source: .huggingFace)
-        case .restart, .openModelManagement, .openPermissions:
+        case .restart, .openModelManagement, .openPermissions, .openWebSearchSettings:
             break
         }
     }

--- a/apps/rapid-mac/Sources/Rapid/UI/FailureDiagnosisView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/FailureDiagnosisView.swift
@@ -84,6 +84,7 @@ struct FailureDiagnosisView: View {
         case .modelOutOfMemory: return "memorychip"
         case .engineNotRunning, .modelLoadFailed: return "bolt.slash"
         case .webSearchOffline, .webSearchUnavailable: return "wifi.exclamationmark"
+        case .webSearchRateLimited: return "hourglass"
         case .commandPermissionDenied, .filePermissionDenied: return "hand.raised.fill"
         case .fileNotFound: return "doc.questionmark"
         case .downloadFailed, .downloadSourceUnavailable: return "arrow.down.circle"

--- a/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
@@ -694,6 +694,12 @@ Open the picker any time to switch models.
 struct QuickstartView: View {
     @Environment(SettingsRouter.self) private var settingsRouter
     @Environment(\.openSettings) private var openSettings
+    /// The mechanism that actually opens this app's Settings: it declares a
+    /// real ``Window("Settings", id: "settings")`` and no SwiftUI ``Settings``
+    /// scene, so ``openSettings()`` — used by the three cases below — is a
+    /// silent no-op. Those are a pre-existing dead deep-link, tracked
+    /// separately; the case added here uses the working path.
+    @Environment(\.openWindow) private var openWindow
     @Bindable var coordinator: QuickstartCoordinator
     @Bindable var downloads: DownloadManager
     @Bindable var server: ServerManager
@@ -1277,9 +1283,11 @@ struct QuickstartView: View {
             openSettings()
         case .openWebSearchSettings:
             // Not reachable from a download/model failure, but the deep-link
-            // is the same two lines wherever it fires.
+            // is the same two lines wherever it fires: set the target tab,
+            // then open the window (``SettingsView`` reads the router from
+            // ``.onAppear``, so the assignment has to come first).
             settingsRouter.requestedCategory = .tools
-            openSettings()
+            openWindow(id: "settings")
         }
     }
 

--- a/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
@@ -1275,6 +1275,11 @@ struct QuickstartView: View {
             // The minimal app has no Permissions tab; land on Models.
             settingsRouter.requestedCategory = .models
             openSettings()
+        case .openWebSearchSettings:
+            // Not reachable from a download/model failure, but the deep-link
+            // is the same two lines wherever it fires.
+            settingsRouter.requestedCategory = .tools
+            openSettings()
         }
     }
 
@@ -1287,6 +1292,7 @@ struct QuickstartView: View {
         case .openModelManagement: return "Quickstart.OpenModelManagement"
         case .switchDownloadSource: return "Quickstart.SwitchSource"
         case .openPermissions: return "Quickstart.OpenPermissions"
+        case .openWebSearchSettings: return "Quickstart.OpenWebSearchSettings"
         case nil: return nil
         }
     }

--- a/apps/rapid-mac/Tests/RapidTests/WebSearchThrottleTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/WebSearchThrottleTests.swift
@@ -1,0 +1,227 @@
+import Foundation
+import Testing
+@testable import Rapid
+
+/// Contracts for the DuckDuckGo throttle path.
+///
+/// Background (measured 2026-08-05 against
+/// ``https://html.duckduckgo.com/html/?q=…``): the first request of a session
+/// returns HTTP 200 with ten ``result__a`` blocks; every request after it
+/// returns HTTP **202** with a ~14 KB page carrying no result blocks — five
+/// different queries, both a plain Safari UA and the tool's own UA. So the
+/// endpoint throttles per IP, and 202-with-no-results is its fingerprint.
+///
+/// Before this pass, 202 sailed through the ``(200..<300)`` success guard, the
+/// parser found nothing, and the user got "Web search couldn't finish. Check
+/// its settings, then try again." — pointing at a Settings page where nothing
+/// is wrong. These tests pin the classification and the copy on both sides of
+/// the boundary: what the user reads, and what the model reads.
+@Suite("Web search throttle")
+struct WebSearchThrottleTests {
+
+    /// One real result block, in the class ordering DDG ships today.
+    private static let resultsPage = """
+        <html><body>
+        <div class="links_main links_deep result__body">
+          <a class="result__a" href="/l/?uddg=https%3A%2F%2Fwww.swift.org%2F">Swift.org</a>
+          <a class="result__snippet">Swift is a general-purpose programming language.</a>
+        </div>
+        </body></html>
+        """
+
+    /// The measured throttle body: a normal-looking page with no result blocks
+    /// and — importantly — none of the anti-bot markers the old detector
+    /// keyed on. Status code is the only signal available here.
+    private static let throttledPage = """
+        <html><head><title>DuckDuckGo</title></head><body>
+        <form action="/html/" method="post"><input name="q" value="current stable version of Swift"></form>
+        <div class="header">DuckDuckGo</div>
+        </body></html>
+        """
+
+    /// The older shape: HTTP 200 carrying the challenge modal.
+    private static let antiBotPage = """
+        <html><body>
+        <div class="anomaly-modal__title">Unfortunately, bots use DuckDuckGo too.</div>
+        <form action="/html/?cc=botnet"><input name="q" value="swift"></form>
+        </body></html>
+        """
+
+    // MARK: - Status-code classification
+
+    @Test("HTTP 202 with a non-results body is a throttle, not a success")
+    func status202WithoutResultsIsThrottled() {
+        // The regression this whole change exists for: 202 passed the 2xx
+        // guard, parsed to zero results, and the user was told to go check
+        // settings that were already correct.
+        #expect(WebSearchTool.isDuckDuckGoThrottled(
+            statusCode: 202,
+            html: Self.throttledPage
+        ))
+    }
+
+    @Test("HTTP 202 that still carries result blocks is NOT a throttle")
+    func status202WithResultsIsNotThrottled() {
+        // The signature is "202 with a non-results body", not 202 alone. A body
+        // with hits in it is a body we can parse, whatever the status line says.
+        #expect(!WebSearchTool.isDuckDuckGoThrottled(
+            statusCode: 202,
+            html: Self.resultsPage
+        ))
+    }
+
+    @Test("A plain 200 results page is never a throttle")
+    func status200WithResultsIsNotThrottled() {
+        #expect(!WebSearchTool.isDuckDuckGoThrottled(
+            statusCode: 200,
+            html: Self.resultsPage
+        ))
+    }
+
+    @Test("A 200 with zero hits and no challenge markers stays 'no results'")
+    func status200EmptyIsNotThrottled() {
+        // A query that genuinely matched nothing must keep reading as an empty
+        // result set — mislabelling it a throttle would send the user off to
+        // buy an API key for a search that simply has no answers.
+        #expect(!WebSearchTool.isDuckDuckGoThrottled(
+            statusCode: 200,
+            html: "<html><body><div class=\"no-results\">No results.</div></body></html>"
+        ))
+    }
+
+    @Test("Explicit rate-limit and block statuses are throttles too", arguments: [429, 403])
+    func rateLimitStatusesAreThrottled(code: Int) {
+        // These used to fall out of the non-2xx branch as a bare
+        // "DuckDuckGo returned HTTP 429", which is the same situation for the
+        // user as the 202 soft-throttle.
+        #expect(WebSearchTool.isDuckDuckGoThrottled(statusCode: code, html: Self.throttledPage))
+    }
+
+    @Test("The 200 anti-bot modal is still detected")
+    func antiBotModalStillDetected() {
+        #expect(WebSearchTool.isDuckDuckGoThrottled(statusCode: 200, html: Self.antiBotPage))
+        #expect(WebSearchTool.detectDDGAntiBot(Self.antiBotPage))
+    }
+
+    // MARK: - Model-visible payload
+
+    @Test("The throttle result is stamped with the rate-limited kind, not sniffed")
+    func throttleResultCarriesFailureKind() {
+        let result = WebSearchTool.duckDuckGoThrottledResult()
+        #expect(result.isError)
+        #expect(result.failureKind == .webSearchRateLimited)
+    }
+
+    @Test("The model-visible text names the backend as the limit, not the capability")
+    func throttleContentDoesNotReadAsMissingCapability() {
+        // This string is what reaches the model as the ``role: "tool"`` body —
+        // the UI diagnosis never does. The old text ("DuckDuckGo blocked this
+        // request (anti-bot rate limit)") left room for a small model to answer
+        // "I don't have the ability to browse the web", contradicting the tool
+        // card the user is looking at. Naming the tool as enabled closes that.
+        let content = WebSearchTool.duckDuckGoThrottleContent
+        #expect(content.contains("web_search tool is enabled and working"))
+        #expect(content.contains("rate-limited"))
+        #expect(content.contains("Brave Search"))
+        #expect(content.contains("Tavily"))
+        #expect(content.contains("Settings → Tools"))
+    }
+
+    @Test("A pending fallback note survives the throttle path")
+    func throttleResultKeepsFallbackNote() {
+        // "Brave is selected but no key is set" matters MORE once DDG has
+        // throttled — the old anti-bot branch dropped the note on the floor.
+        let note = "Note: Brave Search is selected but no API key is set."
+        let result = WebSearchTool.duckDuckGoThrottledResult(fallbackNote: note)
+        #expect(result.content.contains(note))
+        #expect(result.content.contains(WebSearchTool.duckDuckGoThrottleContent))
+    }
+
+    // MARK: - User-visible diagnosis
+
+    @Test("The user-visible message names DuckDuckGo and the real remedy")
+    func diagnosisCopyIsActionable() {
+        let diagnosis = FailureDiagnoser.diagnosis(for: .webSearchRateLimited)
+        #expect(diagnosis.message.contains("DuckDuckGo"))
+        #expect(diagnosis.message.contains("Brave Search"))
+        #expect(diagnosis.message.contains("Tavily"))
+        #expect(diagnosis.message.contains("Settings → Tools"))
+        // The dead end this replaced. Settings are not the problem when the
+        // free backend throttles, so the copy must not send the user there to
+        // "check" anything.
+        #expect(!diagnosis.message.contains("Check its settings"))
+    }
+
+    @Test("The rate-limited diagnosis offers the Settings deep-link, not Retry")
+    func diagnosisActionOpensWebSearchSettings() {
+        // Retry re-runs straight into the same per-IP throttle.
+        #expect(FailureDiagnoser.diagnosis(for: .webSearchRateLimited).action == .openWebSearchSettings)
+    }
+
+    @Test("Other web_search failures keep their existing copy")
+    func unrelatedWebSearchCopyUnchanged() {
+        let unavailable = FailureDiagnoser.diagnosis(for: .webSearchUnavailable)
+        #expect(unavailable.message == "Web search couldn't finish. Check its settings, then try again.")
+        #expect(unavailable.action == .retry)
+    }
+
+    // MARK: - Fallback classification (restored transcripts)
+
+    @Test("A restored throttle row without a stored kind still classifies")
+    func classifierRecognisesThrottleContent() {
+        let kind = FailureDiagnoser.toolFailureKind(
+            toolName: "web_search",
+            content: WebSearchTool.duckDuckGoThrottleContent,
+            isError: true
+        )
+        #expect(kind == .webSearchRateLimited)
+    }
+
+    @Test("The legacy anti-bot wording classifies as rate-limited too")
+    func classifierRecognisesLegacyAntiBotContent() {
+        let kind = FailureDiagnoser.toolFailureKind(
+            toolName: "web_search",
+            content: "web_search error: DuckDuckGo blocked this request (anti-bot rate limit).",
+            isError: true
+        )
+        #expect(kind == .webSearchRateLimited)
+    }
+
+    @Test("A Brave quota error is NOT relabelled as a DuckDuckGo throttle")
+    func classifierLeavesKeyedBackendQuotaAlone() {
+        // Telling a Brave user to switch to Brave would be the same dead end
+        // in a different costume.
+        let kind = FailureDiagnoser.toolFailureKind(
+            toolName: "web_search",
+            content: "web_search error: Brave free-tier limit hit (HTTP 429). Wait a few minutes or upgrade your plan.",
+            isError: true
+        )
+        #expect(kind == .webSearchUnavailable)
+    }
+
+    @Test("An offline web_search failure still classifies as offline")
+    func classifierKeepsOfflineBranch() {
+        let kind = FailureDiagnoser.toolFailureKind(
+            toolName: "web_search",
+            content: "web_search error: The Internet connection appears to be offline.",
+            isError: true
+        )
+        #expect(kind == .webSearchOffline)
+    }
+
+    // MARK: - Settings copy
+
+    @Test("The DuckDuckGo picker caption no longer claims it works out of the box")
+    func duckDuckGoSubtitleIsHonest() {
+        let subtitle = WebSearchProvider.duckduckgo.subtitle
+        #expect(!subtitle.lowercased().contains("works out of the box"))
+        #expect(subtitle.contains("No key required"))
+        #expect(subtitle.lowercased().contains("throttled"))
+    }
+
+    @Test("The keyed backends keep their signup-cost captions")
+    func keyedSubtitlesUnchanged() {
+        #expect(WebSearchProvider.brave.subtitle.contains("Brave Search API key"))
+        #expect(WebSearchProvider.tavily.subtitle.contains("Tavily API key"))
+    }
+}

--- a/apps/rapid-mac/Tests/RapidTests/WebSearchThrottleTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/WebSearchThrottleTests.swift
@@ -158,6 +158,46 @@ struct WebSearchThrottleTests {
         #expect(FailureDiagnoser.diagnosis(for: .webSearchRateLimited).action == .openWebSearchSettings)
     }
 
+    // MARK: - Inline tool-card button
+
+    @Test("The rate-limited card offers its button when Settings is reachable")
+    func inlineActionOfferedWhenRoutable() {
+        let diagnosis = FailureDiagnoser.diagnosis(for: .webSearchRateLimited)
+        #expect(FailureDiagnosis.inlineToolCardAction(
+            for: diagnosis,
+            canRouteToSettings: true
+        ) == .openWebSearchSettings)
+    }
+
+    @Test("No router, no button — an inert button is the bug being fixed")
+    func inlineActionSuppressedWithoutRouter() {
+        // The card resolves ``SettingsRouter`` optionally so it renders in
+        // hosts that never injected one. Those hosts also have no Settings
+        // window to open, so the button must be ABSENT, not merely harmless.
+        let diagnosis = FailureDiagnoser.diagnosis(for: .webSearchRateLimited)
+        #expect(FailureDiagnosis.inlineToolCardAction(
+            for: diagnosis,
+            canRouteToSettings: false
+        ) == nil)
+    }
+
+    @Test("Retry-shaped diagnoses get no inline button")
+    func inlineActionIgnoresRetry() {
+        // Retry has to rewind the chat turn; the assistant row above the card
+        // owns that. Rendering it here would be a second, weaker Retry.
+        for kind in [FailureDiagnosis.Kind.webSearchUnavailable, .webSearchOffline, .toolFailed] {
+            #expect(FailureDiagnosis.inlineToolCardAction(
+                for: FailureDiagnoser.diagnosis(for: kind),
+                canRouteToSettings: true
+            ) == nil)
+        }
+    }
+
+    @Test("A still-running or successful tool call gets no inline button")
+    func inlineActionNilWithoutDiagnosis() {
+        #expect(FailureDiagnosis.inlineToolCardAction(for: nil, canRouteToSettings: true) == nil)
+    }
+
     @Test("Other web_search failures keep their existing copy")
     func unrelatedWebSearchCopyUnchanged() {
         let unavailable = FailureDiagnoser.diagnosis(for: .webSearchUnavailable)


### PR DESCRIPTION
## Why

On a fresh profile with default settings, asking the model to search the web
produced this pair:

* tool card: **"Web search couldn't finish. Check its settings, then try again."**
* the model, immediately after: *"I'm sorry, but I currently don't have the
  ability to browse the web or check for real-time information."*

Two contradictory messages — the UI shows a `web_search` tool that just ran and
failed, the model says the capability doesn't exist. And following the advice
led nowhere: Settings → Tools showed DuckDuckGo selected with the caption
**"No key required. HTML scrape; works out of the box."** Nothing to change.

## Measured cause

DuckDuckGo rate-limits its HTML endpoint per IP, quickly, and independent of
User-Agent. From this machine against `html.duckduckgo.com/html/?q=…`:

* one early request → HTTP 200 with 10 `result__a` blocks
* every request after → **HTTP 202 with a ~14 KB non-results page**, across five
  different queries and two different UAs

`runDuckDuckGo` guarded with `(200..<300).contains(statusCode)`. **202 is inside
that range**, so the throttled response was treated as success, parsed to zero
results, and fell through to the bot-block branch. The code comment there already
anticipated the throttle and said the intent was to "tell the user to configure a
paid backend" — the string the user actually saw did not do that.

## What changed

**Detection.** `isDuckDuckGoThrottled(statusCode:html:)` runs *before* the 2xx
guard. The trigger is "202 / 429 / 403 with a non-results body", not the status
alone — a body carrying a `result__body` token is never a throttle whatever the
status line says, and a genuine 200-with-zero-hits still reads as "no results
found". 429 previously surfaced as a bare "returned HTTP 429", which is the same
situation for the user. The tool stamps `failureKind: .webSearchRateLimited` on
the result, so the card cannot disagree with what happened; the string-sniffing
classifier is only a fallback for transcripts restored without a stored kind.

**Three user-visible strings.**

| surface | before | after |
|---|---|---|
| tool card | `Web search couldn't finish. Check its settings, then try again.` | `DuckDuckGo is rate-limiting web searches from this Mac. Switch to Brave Search or Tavily in Settings → Tools and add a free key.` + an **Open Web Search Settings** button |
| Settings caption | `No key required. HTML scrape; works out of the box.` | `No key required. Best-effort — throttled after a few searches; the keyed backends aren't.` |
| model-visible payload | `web_search error: DuckDuckGo blocked this request (anti-bot rate limit)…` | states the tool is enabled and working, that the *backend* throttled per-IP and usually recovers, and names the two free keyed alternatives |

`.webSearchUnavailable` keeps its old copy for genuine misconfigurations like a
rejected Brave key.

**No system-prompt change.** `toolGuidancePreamble` is untouched — that is the
#1549 surface and it stays that way. What changed is the tool's own error
payload, scoped to the failing call. The old "blocked this request" plus the
preamble's "your training data is OUT OF DATE" is what left room for "I don't
have the ability to browse the web".

**The deep-link.** Review caught the first attempt calling `openSettings()`,
which needs a SwiftUI `Settings` scene this app deliberately does not declare —
the button rendered and did nothing. It now uses `openWindow(id: "settings")`,
matching `RapidApp.swift:186` / `:242`, with `requestedCategory` assigned
**before** the open: `SettingsView` consumes the request from `.onAppear` on
first open and `.onChange` when an already-open window is re-focused, so
assigning after races the read and drops the user on the last-used tab.

## Test plan

`swift build` clean. 16 new tests in `WebSearchThrottleTests` covering
classification, the copy, and the button policy (offered when routable,
**absent** — not disabled — without a router, never for retry-shaped diagnoses,
never for a running or successful call).

**`swift test` could not run here** (neither XCTest nor swift-testing ships with
this toolchain). To de-risk CI, the pure logic and the exact string literals were
extracted into standalone scripts and executed against verbatim copies of the
shipped code: 10 fixture/classification checks and 19 copy/classifier assertions
pass. That validates the expectations, not the swift-testing syntax.

**Not verified:** no runtime UI. The inline button's hidden/visible states, the
deep-link landing on the Tools tab, and the layout of the longer message are
compile-verified only, and nobody clicked the button — reproducing it live needs
a running engine, a loaded model and an active DuckDuckGo throttle. The mechanism
now matches the app's own proven call sites and the policy is unit-tested;
click-through is worth ten seconds of manual dogfood.

## Related

Four *pre-existing* `openSettings()` call sites are dead for the identical
reason — filed as #1578 rather than folded in here.