### PR TITLE
fix(mac): report a declined browse as a choice, not a malfunction

### DIFF
--- a/apps/rapid-mac/CHANGELOG.md
+++ b/apps/rapid-mac/CHANGELOG.md
@@ -24,6 +24,15 @@ can actually understand.
   searches from this Mac") and offers a one-click jump to Settings → Tools,
   where you can switch to Brave Search or Tavily. The Settings caption for
   DuckDuckGo no longer claims it "works out of the box."
+- **Turning down a web page is no longer treated as a breakage.** When a model
+  asked to fetch a page and you chose "Don't allow", Rapid showed a red card
+  reading "The tool couldn't finish. Check its input, then try again" — telling
+  you something had gone wrong, blaming what you typed for it, and offering to
+  retry the thing you had just refused. Declining is now shown as what it is: a
+  quiet note saying "You didn't allow this, so there's nothing to show. Ask
+  again if you change your mind," with no error styling and no retry button.
+  Stopping a reply while the permission box is open is no longer recorded as
+  you having said no, either.
 
 ## [0.12.5] — 2026-08-05
 

--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatMessage.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatMessage.swift
@@ -238,6 +238,46 @@ struct ChatMessage: Identifiable, Codable, Equatable, Hashable {
         case toolNotCalledFlagged
         case toolCallArtifactSuppressed
         case createdAt
+        /// The outcome as THIS build understands it. ``failureKind`` carries
+        /// the same outcome narrowed to a value older builds can decode — see
+        /// ``encode(to:)``.
+        case failureKindV2
+    }
+
+    /// Hand-written so ``failureKind`` is persisted TWICE.
+    ///
+    /// ``FailureDiagnosis.Kind`` decodes strictly in every build already in
+    /// users' hands, and ``ConversationStore.load`` turns ONE undecodable
+    /// message into "the whole history is corrupt": the file is sided to
+    /// `conversations.corrupt-<uuid>.json` and the sidebar comes up empty.
+    /// So a raw value added after a release must never be written into the
+    /// key those builds read — that would cost a user who downgrades their
+    /// entire visible history, which is precisely the failure ``Role.unknown``
+    /// and ``Status.unknown`` exist to prevent on the other two enums.
+    ///
+    /// Hence: ``failureKind`` gets ``legacyPersistedKind`` (always a value
+    /// every shipped build knows, so an old build reads a slightly coarser
+    /// outcome and keeps the conversation), and ``failureKindV2`` — a key old
+    /// builds simply ignore — gets the real one. Adding a future kind needs
+    /// nothing here beyond its ``legacyPersistedKind`` mapping.
+    func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        try c.encode(id, forKey: .id)
+        try c.encode(role, forKey: .role)
+        try c.encode(content, forKey: .content)
+        try c.encode(reasoning, forKey: .reasoning)
+        try c.encode(status, forKey: .status)
+        try c.encodeIfPresent(errorMessage, forKey: .errorMessage)
+        try c.encodeIfPresent(failureKind?.legacyPersistedKind, forKey: .failureKind)
+        try c.encodeIfPresent(failureKind, forKey: .failureKindV2)
+        try c.encodeIfPresent(toolCalls, forKey: .toolCalls)
+        try c.encodeIfPresent(toolCallID, forKey: .toolCallID)
+        try c.encodeIfPresent(stats, forKey: .stats)
+        try c.encode(reasoningTruncated, forKey: .reasoningTruncated)
+        try c.encode(contentTruncated, forKey: .contentTruncated)
+        try c.encode(toolNotCalledFlagged, forKey: .toolNotCalledFlagged)
+        try c.encode(toolCallArtifactSuppressed, forKey: .toolCallArtifactSuppressed)
+        try c.encode(createdAt, forKey: .createdAt)
     }
 
     init(from decoder: Decoder) throws {
@@ -248,7 +288,16 @@ struct ChatMessage: Identifiable, Codable, Equatable, Hashable {
         self.reasoning = try c.decode(String.self, forKey: .reasoning)
         self.status = try c.decode(Status.self, forKey: .status)
         self.errorMessage = try c.decodeIfPresent(String.self, forKey: .errorMessage)
-        self.failureKind = try c.decodeIfPresent(FailureDiagnosis.Kind.self, forKey: .failureKind)
+        // Prefer the finer v2 value; fall back to the original key for rows
+        // written before it existed (and for rows an older build re-saved).
+        //
+        // Read v2 as a raw string rather than through ``Kind``'s tolerant
+        // decode: a value this build doesn't recognise came from a NEWER one,
+        // which wrote its closest known ancestor into ``failureKind`` — and
+        // that is strictly better than the blanket degrade to ``.toolFailed``.
+        let modernRaw = try c.decodeIfPresent(String.self, forKey: .failureKindV2)
+        let legacyKind = try c.decodeIfPresent(FailureDiagnosis.Kind.self, forKey: .failureKind)
+        self.failureKind = modernRaw.flatMap(FailureDiagnosis.Kind.init(rawValue:)) ?? legacyKind
         self.toolCalls = try c.decodeIfPresent([ToolCall].self, forKey: .toolCalls)
         self.toolCallID = try c.decodeIfPresent(String.self, forKey: .toolCallID)
         self.stats = try c.decodeIfPresent(MessageStats.self, forKey: .stats)

--- a/apps/rapid-mac/Sources/Rapid/Services/FailureDiagnosis.swift
+++ b/apps/rapid-mac/Sources/Rapid/Services/FailureDiagnosis.swift
@@ -1,8 +1,13 @@
 import Foundation
 
-/// A user-facing explanation for a known failure mode. Raw process,
-/// transport, and tool output stays in logs/model context; views render only
-/// this stable copy and, when available, one concrete recovery action.
+/// A user-facing explanation for a known outcome that stopped short of a
+/// result. Raw process, transport, and tool output stays in logs/model
+/// context; views render only this stable copy and, when available, one
+/// concrete recovery action.
+///
+/// Most kinds describe a genuine fault. One does not: ``Kind/userDeclined``
+/// is the user answering "no" to a permission prompt, which is an ordinary
+/// outcome and must never be dressed as a malfunction — see ``Severity``.
 struct FailureDiagnosis: Equatable, Sendable {
     enum Kind: String, CaseIterable, Codable, Equatable, Hashable, Sendable {
         case modelOutOfMemory
@@ -20,9 +25,60 @@ struct FailureDiagnosis: Equatable, Sendable {
         case fileNotFound
         case filePermissionDenied
         case toolFailed
+        case userDeclined
         case downloadFailed
         case downloadSourceUnavailable
         case requestFailed
+
+        /// Forward-tolerant decode, matching ``ChatMessage/Role`` and
+        /// ``ChatMessage/Status``: a raw value this build doesn't know (a
+        /// transcript written by a NEWER build, then a downgrade) degrades to
+        /// the generic ``.toolFailed`` rather than throwing. A throw here is
+        /// not local — ``ConversationStore/load`` treats one undecodable
+        /// message as a corrupt library and sides the whole history file, so
+        /// the user's sidebar reads as wiped.
+        init(from decoder: Decoder) throws {
+            let raw = try decoder.singleValueContainer().decode(String.self)
+            self = Kind(rawValue: raw) ?? .toolFailed
+        }
+
+        /// The nearest kind that EVERY shipped build already knows, used when
+        /// writing to a key older builds decode strictly. Cases present since
+        /// the first release map to themselves; anything added later names its
+        /// closest ancestor here. See ``ChatMessage/encode(to:)``.
+        var legacyPersistedKind: Kind {
+            switch self {
+            case .userDeclined:
+                return .toolFailed
+            // Added in #1580, after the same release ``userDeclined`` post-dates,
+            // so it carries the same hazard: an older build decoding this raw
+            // value throws, and one throw sides the ENTIRE history file.
+            // ``webSearchUnavailable`` is the honest ancestor — it is the kind
+            // this very condition used to land on, so an older build shows the
+            // copy it always showed for a throttled search.
+            case .webSearchRateLimited:
+                return .webSearchUnavailable
+            case .modelOutOfMemory, .modelLoadFailed, .engineNotRunning,
+                 .webSearchOffline, .webSearchUnavailable,
+                 .commandPermissionDenied, .commandFailed,
+                 .fileNotFound, .filePermissionDenied, .toolFailed,
+                 .downloadFailed, .downloadSourceUnavailable, .requestFailed:
+                return self
+            }
+        }
+    }
+
+    /// How a diagnosis should be PRESENTED, independent of what it says.
+    ///
+    /// Something the app (or the network, or the model) got wrong is an
+    /// ``error``: red, alarming, worth interrupting for. Something the USER
+    /// chose is a ``notice``: it explains why nothing came back and then gets
+    /// out of the way. Painting a deliberate "Don't allow" red tells the user
+    /// their own decision was a malfunction, and — because the copy on that
+    /// lane is written for faults — blames their input for it.
+    enum Severity: String, Equatable, Hashable, Sendable {
+        case error
+        case notice
     }
 
     enum Action: String, Equatable, Sendable {
@@ -62,9 +118,16 @@ struct FailureDiagnosis: Equatable, Sendable {
     let message: String
     let action: Action?
 
+    var severity: Severity { kind.severity }
+
     /// The recovery action a tool card may render inline, or nil for "render
-    /// no button". Two gates, both load-bearing:
+    /// no button". Three gates, all load-bearing:
     ///
+    ///   * **Errors only.** A ``Severity/notice`` is an outcome the USER chose
+    ///     (they answered "no" to a permission prompt), so there is nothing for
+    ///     the app to recover and no button to offer. Gating on severity rather
+    ///     than on `action == nil` keeps the card's rule in one place: a notice
+    ///     that ever gains an action still must not sprout a button here.
     ///   * **Settings deep-links only.** ``.retry`` would have to rewind the
     ///     whole chat turn; the assistant row above the card already owns that
     ///     affordance. "Open Settings on the right tab" has nowhere else to
@@ -76,16 +139,44 @@ struct FailureDiagnosis: Equatable, Sendable {
     ///     does nothing is precisely the failure this diagnosis exists to
     ///     remove, so the button must be absent rather than inert.
     ///
+    /// The action switch is exhaustive with no `default` for the same reason
+    /// ``Kind/severity`` is: a newly added action must state whether the tool
+    /// card offers it, rather than being silently swallowed.
+    ///
     /// Pure + static because the view that calls it is `private` inside
     /// ChatView and a SwiftUI body can't be exercised from the test suite.
     static func inlineToolCardAction(
         for diagnosis: FailureDiagnosis?,
         canRouteToSettings: Bool
     ) -> Action? {
-        guard canRouteToSettings else { return nil }
-        switch diagnosis?.action {
-        case .openWebSearchSettings: return .openWebSearchSettings
-        default: return nil
+        guard canRouteToSettings, let diagnosis, diagnosis.severity == .error else { return nil }
+        switch diagnosis.action {
+        case .openWebSearchSettings:
+            return .openWebSearchSettings
+        case .retry, .restart, .openModelManagement, .switchDownloadSource,
+             .openPermissions, .none:
+            return nil
+        }
+    }
+}
+
+extension FailureDiagnosis.Kind {
+    /// Deliberately an exhaustive switch with no `default`: a new kind must
+    /// state whether it is a fault the app is reporting or an outcome the user
+    /// chose, rather than inheriting the alarming lane by omission.
+    var severity: FailureDiagnosis.Severity {
+        switch self {
+        case .userDeclined:
+            return .notice
+        // A throttled backend is something that went wrong out in the world,
+        // not something the user picked — it stays on the error lane, and its
+        // copy and deep-link do the recovering.
+        case .modelOutOfMemory, .modelLoadFailed, .engineNotRunning,
+             .webSearchOffline, .webSearchUnavailable, .webSearchRateLimited,
+             .commandPermissionDenied, .commandFailed,
+             .fileNotFound, .filePermissionDenied, .toolFailed,
+             .downloadFailed, .downloadSourceUnavailable, .requestFailed:
+            return .error
         }
     }
 }
@@ -146,6 +237,19 @@ enum FailureDiagnoser {
         case .toolFailed:
             message = "The tool couldn't finish. Check its input, then try again."
             action = .retry
+        case .userDeclined:
+            // Nothing went wrong, so the copy states the outcome and stops.
+            // No action button: the app has nothing to fix and nothing to
+            // recover, and a prominent "Retry" would offer to re-run the exact
+            // thing the user just refused — one stray click away from the
+            // permission prompt existing for nothing. A user who declined by
+            // mistake simply asks again, and the transcript's own per-message
+            // Retry is still right there for a mis-click.
+            // "nothing to show" rather than "nothing happened": a redirect can
+            // be declined after the approved page has already been fetched, so
+            // the honest claim is about the result, not the whole exchange.
+            message = "You didn't allow this, so there's nothing to show. Ask again if you change your mind."
+            action = nil
         case .downloadFailed:
             message = "The model download didn't finish. Check your connection, then try again."
             action = .retry
@@ -162,6 +266,16 @@ enum FailureDiagnoser {
     /// Classifies a completed tool result. A non-nil return means the result
     /// should be styled as failed even if the tool itself returned structured
     /// output with `isError == false` (notably `run_command` exit failures).
+    ///
+    /// This is a FALLBACK for tools that report nothing but text. A tool that
+    /// knows what happened says so directly by setting
+    /// ``ToolCallResult/failureKind``, and the dispatch boundary
+    /// (``BuiltinToolRegistry/run``) prefers that over anything inferred here.
+    /// ``FailureDiagnosis/Kind/userDeclined`` in particular is ONLY ever
+    /// producer-set: "the user said no" is a fact the approval gate holds, not
+    /// something to re-derive by pattern-matching an English sentence that any
+    /// tool could word differently tomorrow (or that a fetched page could
+    /// contain verbatim).
     nonisolated static func toolFailureKind(
         toolName: String,
         content: String,

--- a/apps/rapid-mac/Sources/Rapid/Tools/BrowseApprovalStore.swift
+++ b/apps/rapid-mac/Sources/Rapid/Tools/BrowseApprovalStore.swift
@@ -22,7 +22,15 @@ final class BrowseApprovalStore {
 
     enum Decision: Equatable {
         case allowOnce
+        /// The USER said no — the sheet's "Don't allow", or dismissing it.
         case deny
+        /// The question was never put to the user: the tool call was cancelled
+        /// before (or while) the sheet was up, or a prompt was already open.
+        /// Distinct from ``deny`` because nobody decided anything, and the
+        /// difference is user-visible — a decline is reported as an ordinary
+        /// outcome the user chose, while this is not something to attribute to
+        /// them. See ``FailureDiagnosis.Kind.userDeclined``.
+        case unavailable
     }
 
     /// A pending prompt the UI surfaces as a confirm dialog.
@@ -61,17 +69,18 @@ final class BrowseApprovalStore {
     func requestApproval(url: String, host: String) async -> Decision {
         if mode == .autoApproveAll { return .allowOnce }
         // Re-entrancy guard — tool execution is serial, so a second pending
-        // request means something is wrong; deny rather than hang.
-        if pendingRequest != nil { return .deny }
+        // request means something is wrong; refuse rather than hang. NOT a
+        // decline: the user was never shown this URL.
+        if pendingRequest != nil { return .unavailable }
         return await withTaskCancellationHandler {
             await withCheckedContinuation { (continuation: CheckedContinuation<Decision, Never>) in
                 // Cancellation can land between the re-entrancy check above and
                 // here; the onCancel handler would then have found no
-                // continuation to resume. Re-check inside the body so we deny
+                // continuation to resume. Re-check inside the body so we bail
                 // immediately instead of installing a pending request that would
                 // surface an orphaned, never-answerable sheet.
                 if Task.isCancelled {
-                    continuation.resume(returning: .deny)
+                    continuation.resume(returning: .unavailable)
                     return
                 }
                 self.pendingContinuation = continuation
@@ -87,7 +96,9 @@ final class BrowseApprovalStore {
                 if let cont = self.pendingContinuation {
                     self.pendingContinuation = nil
                     self.pendingRequest = nil
-                    cont.resume(returning: .deny)
+                    // The sheet is being torn down because the turn was
+                    // cancelled, not because the user turned it down.
+                    cont.resume(returning: .unavailable)
                 }
             }
         }

--- a/apps/rapid-mac/Sources/Rapid/Tools/BrowseTool.swift
+++ b/apps/rapid-mac/Sources/Rapid/Tools/BrowseTool.swift
@@ -56,6 +56,26 @@ enum BrowseTool {
         let refresh: Bool?
     }
 
+    /// The user answered "Don't allow" at an approval prompt.
+    ///
+    /// A distinct type, not a sentence: the decline can surface from deep
+    /// inside ``fetchFollowingRedirects`` (a redirect that leaves the approved
+    /// origin re-prompts), and the only honest way for ``run`` to tell it apart
+    /// from a real fetch error is for the throw site to SAY which it is.
+    /// Matching on the wording instead would misfire the day someone rewords
+    /// this string — or the day a fetched page happens to contain it.
+    ///
+    /// ``message`` is the model-facing wire text. It stays plain and factual;
+    /// what the USER sees is ``FailureDiagnosis/Kind/userDeclined``.
+    struct ApprovalDeclined: LocalizedError, Equatable {
+        let message: String
+        /// Belt-and-braces: ``errorResult`` unwraps this type before anything
+        /// reads `localizedDescription`, but a future caller that doesn't would
+        /// otherwise hand the model Foundation's "The operation couldn't be
+        /// completed." placeholder instead of what actually happened.
+        var errorDescription: String? { message }
+    }
+
     static func run(
         arguments: String,
         approval: BrowseApprovalStore,
@@ -108,7 +128,11 @@ enum BrowseTool {
 
         switch await approval.requestApproval(url: rawURL, host: host) {
         case .deny:
-            return err(tool, "the user did not approve browsing \(host)")
+            return declined(tool, ApprovalDeclined(message: "the user did not approve browsing \(host)"))
+        case .unavailable:
+            // Nobody was asked, so this is NOT the user's decision and must not
+            // be reported as one.
+            return err(tool, approvalUnavailableMessage(host: host))
         case .allowOnce:
             break
         }
@@ -122,10 +146,7 @@ enum BrowseTool {
             // not be able to silently bounce the fetch to an unseen destination.
             let fetched = try await fetchFollowingRedirects(startURL: url) { redirectURL in
                 let rHost = redirectURL.host ?? redirectURL.absoluteString
-                switch await approval.requestApproval(url: redirectURL.absoluteString, host: rHost) {
-                case .allowOnce: return true
-                case .deny: return false
-                }
+                return await approval.requestApproval(url: redirectURL.absoluteString, host: rHost)
             }
             let rendered = await renderMarkdown(from: fetched)
             let entry = BrowseContentCache.Entry(
@@ -142,11 +163,55 @@ enum BrowseTool {
                 bytesFetched: fetched.data.count,
                 cacheExpiresAt: cache.expirationDate(for: entry)
             )
-        } catch let rejection as BrowseSSRFGuard.Rejection {
-            return err(tool, rejection.message)
         } catch {
-            return err(tool, error.localizedDescription)
+            return errorResult(tool: tool, error: error)
         }
+    }
+
+    /// How the redirect gate's answer ends the fetch, as a value: `nil` to
+    /// carry on, otherwise the error to throw.
+    ///
+    /// Pure and separate because the branch is otherwise unreachable from a
+    /// test — a redirect needs a live server, and the SSRF guard (correctly)
+    /// refuses the loopback address a local one would have. This is the exact
+    /// function the fetch loop calls, so the decline/abort distinction is
+    /// covered by the code that ships rather than by a lookalike.
+    static func redirectGateError(
+        _ decision: BrowseApprovalStore.Decision,
+        destination: URL
+    ) -> Error? {
+        let host = destination.host ?? "the destination"
+        switch decision {
+        case .allowOnce:
+            return nil
+        case .deny:
+            return ApprovalDeclined(message: "the user did not approve the redirect to \(host)")
+        case .unavailable:
+            // Never asked, so never declined — a plain failure.
+            return simpleError(approvalUnavailableMessage(host: host))
+        }
+    }
+
+    /// Wire text for "the approval prompt could not be put to the user". Kept
+    /// in one place so the initial gate and the redirect gate say the same
+    /// thing, and so neither is mistaken for the user's own answer.
+    static func approvalUnavailableMessage(host: String) -> String {
+        "the approval prompt for \(host) could not be shown (the request was cancelled, "
+            + "or another approval is already open)"
+    }
+
+    /// Turn a thrown fetch error into the result the model and the transcript
+    /// both read. Kept as one pure function (rather than a chain of `catch`
+    /// clauses) so the decline-vs-failure decision is testable without a
+    /// network round-trip — the redirect decline can only be reached mid-fetch.
+    static func errorResult(tool: String, error: Error) -> ToolCallResult {
+        if let declinedByUser = error as? ApprovalDeclined {
+            return declined(tool, declinedByUser)
+        }
+        if let rejection = error as? BrowseSSRFGuard.Rejection {
+            return err(tool, rejection.message)
+        }
+        return err(tool, error.localizedDescription)
     }
 
     // MARK: - Fetch (manual redirect following, SSRF-checked per hop)
@@ -160,11 +225,12 @@ enum BrowseTool {
 
     /// Follow redirects by hand so every hop is SSRF-validated before a socket
     /// opens. `startURL` is assumed already user-approved; `approveRedirect` is
-    /// consulted only when a redirect leaves an already-approved origin, and a
-    /// `false` return aborts the fetch.
+    /// consulted only when a redirect leaves an already-approved origin, and
+    /// anything but ``BrowseApprovalStore/Decision/allowOnce`` aborts the
+    /// fetch — see ``redirectGateError`` for which abort is which.
     static func fetchFollowingRedirects(
         startURL: URL,
-        approveRedirect: (URL) async -> Bool
+        approveRedirect: (URL) async -> BrowseApprovalStore.Decision
     ) async throws -> Fetched {
         var current = startURL
         var approvedOrigins: Set<String> = [origin(of: startURL)]
@@ -196,9 +262,8 @@ enum BrowseTool {
                 // otherwise a trusted host could bounce the fetch to an unseen one.
                 let nextOrigin = origin(of: next)
                 if !approvedOrigins.contains(nextOrigin) {
-                    guard await approveRedirect(next) else {
-                        throw simpleError("the user did not approve the redirect to \(next.host ?? "the destination")")
-                    }
+                    let decision = await approveRedirect(next)
+                    if let refusal = redirectGateError(decision, destination: next) { throw refusal }
                     if Task.isCancelled { throw simpleError("browse was cancelled") }
                     approvedOrigins.insert(nextOrigin)
                 }
@@ -416,6 +481,21 @@ enum BrowseTool {
 
     private static func err(_ tool: String, _ message: String) -> ToolCallResult {
         ToolCallResult(toolCallID: "", content: "\(tool) error: \(message)", isError: true)
+    }
+
+    /// A fetch the USER turned down. The wire content stays identical in shape
+    /// to any other unsuccessful result — the model still needs to be told, in
+    /// plain words, that it has no page and why — but the result carries an
+    /// explicit ``FailureDiagnosis/Kind/userDeclined`` so the transcript can
+    /// render a deliberate choice as the ordinary outcome it is instead of
+    /// reporting a malfunction and blaming the user's input for it.
+    private static func declined(_ tool: String, _ error: ApprovalDeclined) -> ToolCallResult {
+        ToolCallResult(
+            toolCallID: "",
+            content: "\(tool) error: \(error.message)",
+            isError: true,
+            failureKind: .userDeclined
+        )
     }
 
     private static func simpleError(_ message: String) -> NSError {

--- a/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
@@ -1039,6 +1039,12 @@ private struct ToolCallChip: View {
 
     /// Stable diagnosis for a failed result. ``nil`` while the tool is still
     /// running or when it succeeded.
+    ///
+    /// A tool the USER declined lands here too — it produced nothing, so it is
+    /// still ``.failed`` for every purpose that asks "did this tool deliver a
+    /// result?" (notably ``ChatViewModel.turnHadSuccessfulTool``). What the
+    /// diagnosis's ``FailureDiagnosis/severity`` changes is only how the chip
+    /// PAINTS it, and whether it offers a button — see ``inlineAction``.
     private var failureDiagnosis: FailureDiagnosis? {
         guard let result, result.status == .failed else { return nil }
         return result.toolFailureDiagnosis(toolName: call.function.name)
@@ -1079,13 +1085,23 @@ private struct ToolCallChip: View {
     }
 
     private var statusIcon: String {
-        guard let result else { return "ellipsis.circle" }
-        return result.status == .failed ? "exclamationmark.octagon.fill" : "checkmark.circle.fill"
+        guard result != nil else { return "ellipsis.circle" }
+        guard let failureDiagnosis else { return "checkmark.circle.fill" }
+        return failureDiagnosis.severity == .notice ? "hand.raised" : "exclamationmark.octagon.fill"
     }
 
     private var statusColor: Color {
-        guard let result else { return .secondary }
-        return result.status == .failed ? RapidTheme.statusError : .green
+        guard result != nil else { return .secondary }
+        guard let failureDiagnosis else { return .green }
+        return failureDiagnosis.severity == .notice ? .secondary : RapidTheme.statusError
+    }
+
+    /// Red is reserved for something that actually went wrong. A decline reads
+    /// in the same quiet secondary tone the transcript uses for its other
+    /// "this ended early, and that's fine" footers (e.g. "Stopped.").
+    private var resultBodyColor: Color {
+        guard let failureDiagnosis else { return .secondary }
+        return failureDiagnosis.severity == .notice ? .secondary : RapidTheme.statusError
     }
 
     var body: some View {
@@ -1127,7 +1143,7 @@ private struct ToolCallChip: View {
                         Divider()
                         Text(body)
                             .font(.system(size: 11, design: .monospaced))
-                            .foregroundStyle(result?.status == .failed ? RapidTheme.statusError : .secondary)
+                            .foregroundStyle(resultBodyColor)
                             .textSelection(.enabled)
                             .frame(maxWidth: .infinity, alignment: .leading)
                     }

--- a/apps/rapid-mac/Sources/Rapid/UI/FailureDiagnosisView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/FailureDiagnosisView.swift
@@ -48,7 +48,7 @@ struct FailureDiagnosisView: View {
 
     private var diagnosisIcon: some View {
         Image(systemName: iconName)
-            .foregroundStyle(.orange)
+            .foregroundStyle(diagnosis.severity == .notice ? Color.secondary : Color.orange)
             .accessibilityHidden(true)
     }
 
@@ -86,6 +86,9 @@ struct FailureDiagnosisView: View {
         case .webSearchOffline, .webSearchUnavailable: return "wifi.exclamationmark"
         case .webSearchRateLimited: return "hourglass"
         case .commandPermissionDenied, .filePermissionDenied: return "hand.raised.fill"
+        // Unfilled, and tinted secondary above: the user turned this down on
+        // purpose, so it reads as a note rather than a stop sign.
+        case .userDeclined: return "hand.raised"
         case .fileNotFound: return "doc.questionmark"
         case .downloadFailed, .downloadSourceUnavailable: return "arrow.down.circle"
         case .commandFailed, .toolFailed, .requestFailed: return "exclamationmark.triangle.fill"

--- a/apps/rapid-mac/Tests/RapidTests/DeclinedToolDiagnosisTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/DeclinedToolDiagnosisTests.swift
@@ -1,0 +1,469 @@
+import Foundation
+import Testing
+@testable import Rapid
+
+/// "The user said no" is not a malfunction.
+///
+/// The regression these lock down: a declined `browse` approval used to fall
+/// through to ``FailureDiagnosis/Kind/toolFailed``, so clicking **Don't allow**
+/// painted a red tool card reading *"The tool couldn't finish. Check its input,
+/// then try again."* — the app reporting a fault, blaming the user's own input
+/// for it, and offering to retry the very thing they had just refused.
+///
+/// Four properties are pinned here, and all four matter:
+///   1. A decline classifies as ``FailureDiagnosis/Kind/userDeclined`` and
+///      reads as an ordinary outcome (``FailureDiagnosis/Severity/notice``,
+///      no action button).
+///   2. The classification rides an explicit marker from the approval gate —
+///      never a guess at the wording of an English sentence.
+///   3. Only an actual "no" counts. A cancelled turn, or a prompt that could
+///      not be shown, is NOT the user's decision and must not be attributed
+///      to them.
+///   4. A GENUINE browse failure still classifies as a failure. A fix that
+///      quietly reclassified real errors as user choices would hide them.
+@MainActor
+@Suite("Declined tool diagnosis")
+final class DeclinedToolDiagnosisTests {
+    nonisolated(unsafe) private var createdSuiteNames: [String] = []
+    deinit { TestDefaultsScope.cleanup(suiteNames: createdSuiteNames) }
+
+    private func freshDefaults() -> UserDefaults {
+        let name = TestDefaultsScope.mintSuiteName(prefix: "rapid-decline-test-")
+        createdSuiteNames.append(name)
+        let d = UserDefaults(suiteName: name)!
+        d.removePersistentDomain(forName: name)
+        return d
+    }
+
+    /// Memory-only so a test never reads or writes the real browse cache — and
+    /// so the approval gate is actually reached (a fresh cache hit would serve
+    /// the page without prompting at all).
+    private func memoryOnlyCache() -> BrowseContentCache {
+        BrowseContentCache(diskDirectory: nil)
+    }
+
+    // MARK: - Declining the initial fetch
+
+    @Test("Clicking Don't allow on a browse prompt is a user decline, not a tool failure")
+    func declinedBrowseIsNotAFailure() async throws {
+        let approval = BrowseApprovalStore(defaults: freshDefaults())
+        async let pending = BrowseTool.run(
+            arguments: #"{"url":"https://example.com"}"#,
+            approval: approval,
+            cache: memoryOnlyCache()
+        )
+
+        // The gate suspends on the user; answer it the way the sheet's
+        // "Don't allow" button does.
+        try await waitForPendingApproval(approval)
+        approval.answer(.deny)
+        let result = await pending
+
+        #expect(result.failureKind == .userDeclined)
+        // The wire text stays factual and unchanged — the MODEL still has to be
+        // told, in plain words, that it has no page and why.
+        #expect(result.content == "browse error: the user did not approve browsing example.com")
+        #expect(result.isError)
+    }
+
+    @Test("A declined browse keeps its user-declined kind through tool dispatch")
+    func registryPreservesTheDeclinedKind() async throws {
+        // ``BuiltinToolRegistry`` re-classifies every result at the dispatch
+        // boundary. It must PREFER what the tool reported: re-deriving the kind
+        // from the text here would put the decline straight back on the
+        // toolFailed lane.
+        let approval = BrowseApprovalStore(defaults: freshDefaults())
+        let registry = BuiltinToolRegistry(
+            browseApproval: approval,
+            webSearch: WebSearchConfig(defaults: freshDefaults(), keychain: NoopKeychain())
+        )
+        async let pending = registry.run(
+            ToolCall(id: "call_1", name: "browse", arguments: #"{"url":"https://example.com"}"#)
+        )
+        try await waitForPendingApproval(approval)
+        approval.answer(.deny)
+        let result = await pending
+
+        #expect(result.failureKind == .userDeclined)
+        #expect(result.toolCallID == "call_1")
+    }
+
+    // MARK: - Only an actual "no" is a decline
+
+    @Test("A turn cancelled while the prompt is up is not blamed on the user")
+    func cancellationIsNotADecline() async throws {
+        // Pressing Stop tears the approval sheet down. The store used to report
+        // that as ``.deny``, which would now read back to the user as "you
+        // didn't allow this" — a decision they never made.
+        let approval = BrowseApprovalStore(defaults: freshDefaults())
+        let cache = memoryOnlyCache()
+        let task = Task {
+            await BrowseTool.run(
+                arguments: #"{"url":"https://example.com"}"#,
+                approval: approval,
+                cache: cache
+            )
+        }
+        try await waitForPendingApproval(approval)
+        task.cancel()
+        let result = await task.value
+
+        #expect(result.failureKind != .userDeclined)
+        #expect(result.isError)
+    }
+
+    @Test("A second prompt while one is already open is refused, not counted as a decline")
+    func reentrantApprovalIsNotADecline() async throws {
+        // Tool execution is serial, so a second pending prompt means something
+        // is wrong. The user never saw this URL, so the answer cannot be theirs.
+        let approval = BrowseApprovalStore(defaults: freshDefaults())
+        async let first = approval.requestApproval(url: "https://example.com", host: "example.com")
+        try await waitForPendingApproval(approval)
+
+        let second = await approval.requestApproval(url: "https://other.example", host: "other.example")
+        #expect(second == .unavailable)
+
+        approval.answer(.deny)
+        #expect(await first == .deny)
+    }
+
+    @Test("Auto-approve still lets a fetch through untouched")
+    func autoApproveIsUnaffected() async {
+        let approval = BrowseApprovalStore(defaults: freshDefaults())
+        approval.mode = .autoApproveAll
+        let decision = await approval.requestApproval(url: "https://example.com", host: "example.com")
+        #expect(decision == .allowOnce)
+    }
+
+    // MARK: - Declining a cross-origin redirect
+
+    @Test("Declining a redirect to another host is a user decline too")
+    func declinedRedirectIsNotAFailure() throws {
+        // ``redirectGateError`` is the exact function the fetch loop calls at
+        // the redirect gate. It is reachable directly only because it is pure:
+        // driving the loop itself would need a live redirecting server, and the
+        // SSRF guard rightly refuses the loopback address a local one needs.
+        let destination = try #require(URL(string: "https://elsewhere.example/page"))
+        let thrown = try #require(BrowseTool.redirectGateError(.deny, destination: destination))
+        #expect(thrown is BrowseTool.ApprovalDeclined)
+
+        let result = BrowseTool.errorResult(tool: "browse", error: thrown)
+        #expect(result.failureKind == .userDeclined)
+        #expect(result.content ==
+                "browse error: the user did not approve the redirect to elsewhere.example")
+    }
+
+    @Test("An allowed redirect does not end the fetch")
+    func allowedRedirectContinues() throws {
+        let destination = try #require(URL(string: "https://elsewhere.example/page"))
+        #expect(BrowseTool.redirectGateError(.allowOnce, destination: destination) == nil)
+    }
+
+    @Test("A redirect prompt that could not be shown is a failure, not a decline")
+    func unavailableRedirectPromptIsAFailure() throws {
+        let destination = try #require(URL(string: "https://elsewhere.example/page"))
+        let thrown = try #require(BrowseTool.redirectGateError(.unavailable, destination: destination))
+        #expect(!(thrown is BrowseTool.ApprovalDeclined))
+
+        let result = BrowseTool.errorResult(tool: "browse", error: thrown)
+        #expect(result.failureKind == nil)   // left to the dispatch-boundary classifier
+        #expect(result.isError)
+    }
+
+    // MARK: - Genuine failures must STILL be failures
+
+    @Test("A real fetch error is still a tool failure, not a user decline")
+    func genuineFetchErrorStaysAFailure() {
+        // Same seam, an ordinary error: nothing about the decline lane may
+        // swallow a fault the user needs to see.
+        let result = BrowseTool.errorResult(
+            tool: "browse",
+            error: NSError(
+                domain: "RapidBrowse",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "HTTP 503 from example.com"]
+            )
+        )
+        #expect(result.failureKind == nil)
+        #expect(result.isError)
+
+        let kind = FailureDiagnoser.toolFailureKind(
+            toolName: "browse",
+            content: result.content,
+            isError: result.isError
+        )
+        #expect(kind == .toolFailed)
+        #expect(FailureDiagnoser.diagnosis(for: .toolFailed).severity == .error)
+    }
+
+    @Test("A browse call the model malformed is still a tool failure end to end")
+    func malformedArgumentsStayAFailure() async {
+        let registry = BuiltinToolRegistry(
+            browseApproval: BrowseApprovalStore(defaults: freshDefaults()),
+            webSearch: WebSearchConfig(defaults: freshDefaults(), keychain: NoopKeychain())
+        )
+        // Never reaches the approval gate — it fails on its own merits.
+        let result = await registry.run(
+            ToolCall(id: "call_2", name: "browse", arguments: "not json")
+        )
+        #expect(result.isError)
+        #expect(result.failureKind == .toolFailed)
+        #expect(result.failureKind?.severity == .error)
+    }
+
+    @Test("Text that merely LOOKS like a decline is not promoted to one")
+    func declineIsNeverInferredFromWording() {
+        // The marker is carried by the approval gate, so a page (or a future
+        // tool wording its errors differently) cannot talk its way onto the
+        // quiet lane by containing the sentence.
+        let kind = FailureDiagnoser.toolFailureKind(
+            toolName: "browse",
+            content: "browse error: the user did not approve browsing example.com",
+            isError: true
+        )
+        #expect(kind == .toolFailed)
+    }
+
+    // MARK: - The copy the user actually reads
+
+    @Test("A decline reads as an outcome, with no action button and no blame")
+    func declinedCopyIsNeutral() {
+        let diagnosis = FailureDiagnoser.diagnosis(for: .userDeclined)
+        #expect(diagnosis.message ==
+                "You didn't allow this, so there's nothing to show. Ask again if you change your mind.")
+        // No "check its input" (the input was fine), and no retry button
+        // offering to re-run what the user just refused.
+        #expect(diagnosis.action == nil)
+        #expect(diagnosis.severity == .notice)
+    }
+
+    @Test("Only a user decline is a notice; every other kind stays an error")
+    func onlyDeclineIsANotice() {
+        for kind in FailureDiagnosis.Kind.allCases {
+            let expected: FailureDiagnosis.Severity = kind == .userDeclined ? .notice : .error
+            #expect(kind.severity == expected, "unexpected severity for \(kind.rawValue)")
+            #expect(FailureDiagnoser.diagnosis(for: kind).severity == expected)
+        }
+    }
+
+    @Test("A throttled backend is something that went wrong, not something the user chose")
+    func rateLimitStaysOnTheErrorLane() {
+        // #1580's kind arrived alongside this change. A rate limit is the world
+        // refusing, not the user — it keeps the red card and its deep-link.
+        let diagnosis = FailureDiagnoser.diagnosis(for: .webSearchRateLimited)
+        #expect(diagnosis.severity == .error)
+        #expect(diagnosis.action == .openWebSearchSettings)
+    }
+
+    @Test("A notice never grows an inline button on the tool card")
+    func noticeGetsNoInlineToolCardAction() {
+        // One rule decides what the card offers. Gating on severity rather than
+        // on `action == nil` means a notice that ever gains an action still
+        // can't sprout a button here — there is nothing for the app to recover
+        // from a decision the user made on purpose.
+        #expect(FailureDiagnosis.inlineToolCardAction(
+            for: FailureDiagnoser.diagnosis(for: .userDeclined),
+            canRouteToSettings: true
+        ) == nil)
+        // The error lane is untouched: #1580's deep-link still renders.
+        #expect(FailureDiagnosis.inlineToolCardAction(
+            for: FailureDiagnoser.diagnosis(for: .webSearchRateLimited),
+            canRouteToSettings: true
+        ) == .openWebSearchSettings)
+    }
+
+    // MARK: - Persistence
+
+    @Test("A decline this build wrote is still a decline when the transcript reopens")
+    func declinedKindSurvivesAnEncodeDecodeRound() throws {
+        // Covers rows written from here on. Declines saved by OLDER builds were
+        // persisted as ``.toolFailed`` and are read back as such by design —
+        // there is nothing in those rows to tell them apart from a real fault.
+        let data = try JSONEncoder().encode(declinedToolRow())
+        let restored = try JSONDecoder().decode(ChatMessage.self, from: data)
+        #expect(restored.failureKind == .userDeclined)
+        let diagnosis = restored.toolFailureDiagnosis(toolName: "browse")
+        #expect(diagnosis.kind == .userDeclined)
+        #expect(diagnosis.severity == .notice)
+        #expect(diagnosis.action == nil)
+    }
+
+    @Test("The original key keeps a value older builds can decode")
+    func newKindIsNotWrittenWhereOldBuildsReadStrictly() throws {
+        // ``FailureDiagnosis.Kind`` decodes strictly in every shipped build,
+        // and ``ConversationStore.load`` turns ONE undecodable message into
+        // "the whole history is corrupt" — so a downgrade would greet the user
+        // with an empty sidebar. The new raw value therefore lives only under
+        // a key older builds ignore.
+        let data = try JSONEncoder().encode(declinedToolRow())
+        let object = try #require(
+            try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        )
+        #expect(object["failureKind"] as? String == "toolFailed")
+        #expect(object["failureKindV2"] as? String == "userDeclined")
+    }
+
+    @Test("Every kind added after the last release keeps old builds readable")
+    func kindsNewerThanTheLastReleaseAllHaveAKnownAncestor() throws {
+        // `rapid-mac-v0.12.5` — the newest shipped tag — has neither of these
+        // raw values and decodes `failureKind` strictly, so BOTH carry the same
+        // hazard: one unknown value sides the entire history file. The encoder
+        // covers any kind automatically once ``legacyPersistedKind`` names an
+        // ancestor, so what needs pinning is the mapping.
+        let shippedInV0_12_5: Set<FailureDiagnosis.Kind> = [
+            .modelOutOfMemory, .modelLoadFailed, .engineNotRunning,
+            .webSearchOffline, .webSearchUnavailable,
+            .commandPermissionDenied, .commandFailed,
+            .fileNotFound, .filePermissionDenied, .toolFailed,
+            .downloadFailed, .downloadSourceUnavailable, .requestFailed,
+        ]
+        for kind in FailureDiagnosis.Kind.allCases {
+            #expect(
+                shippedInV0_12_5.contains(kind.legacyPersistedKind),
+                "\(kind.rawValue) maps to \(kind.legacyPersistedKind.rawValue), which no shipped build can decode"
+            )
+        }
+        #expect(FailureDiagnosis.Kind.userDeclined.legacyPersistedKind == .toolFailed)
+        // The condition this kind describes used to land on webSearchUnavailable,
+        // so that is what an older build should keep showing for it.
+        #expect(FailureDiagnosis.Kind.webSearchRateLimited.legacyPersistedKind == .webSearchUnavailable)
+    }
+
+    @Test("A rate-limited row is downgrade-safe and reopens as itself")
+    func rateLimitedRowUsesBothKeys() throws {
+        let row = ChatMessage(
+            role: .tool,
+            content: "web_search error: DuckDuckGo is throttling this Mac",
+            status: .failed,
+            failureKind: .webSearchRateLimited,
+            toolCallID: "call_1"
+        )
+        let object = try encodedObject(for: row)
+        #expect(object["failureKind"] as? String == "webSearchUnavailable")
+        #expect(object["failureKindV2"] as? String == "webSearchRateLimited")
+
+        let data = try JSONEncoder().encode(row)
+        let restored = try JSONDecoder().decode(ChatMessage.self, from: data)
+        #expect(restored.failureKind == .webSearchRateLimited)
+    }
+
+    @Test("A row written before the v2 key existed still decodes")
+    func legacyOnlyRowStillDecodes() throws {
+        var object = try encodedObject(for: ChatMessage(
+            role: .tool,
+            content: "read_file error: no such file",
+            status: .failed,
+            failureKind: .fileNotFound,
+            toolCallID: "call_1"
+        ))
+        object.removeValue(forKey: "failureKindV2")
+
+        let data = try JSONSerialization.data(withJSONObject: object)
+        let restored = try JSONDecoder().decode(ChatMessage.self, from: data)
+        #expect(restored.failureKind == .fileNotFound)
+    }
+
+    @Test("A kind from a NEWER build degrades instead of wiping the history")
+    func unknownKindDegradesRatherThanThrowing() throws {
+        // The mirror image of the downgrade guard above: this build must also
+        // survive a transcript written by a future one.
+        var object = try encodedObject(for: declinedToolRow())
+        object["failureKindV2"] = "someKindFromTheFuture"
+
+        let data = try JSONSerialization.data(withJSONObject: object)
+        let restored = try JSONDecoder().decode(ChatMessage.self, from: data)
+        #expect(restored.failureKind == .toolFailed)
+    }
+
+    @Test("An unknown future kind degrades to the ancestor that build named, not a generic one")
+    func unknownKindPrefersTheLegacyValueThatBuildWrote() throws {
+        // A future build writes its closest KNOWN ancestor into the original
+        // key precisely so an older build lands somewhere sensible. Degrading
+        // to a blanket ``.toolFailed`` instead would throw that away and, for
+        // e.g. a download-shaped kind, show the wrong recovery action.
+        var object = try encodedObject(for: ChatMessage(
+            role: .assistant,
+            status: .failed,
+            failureKind: .downloadSourceUnavailable
+        ))
+        object["failureKindV2"] = "someFutureDownloadKind"
+
+        let data = try JSONSerialization.data(withJSONObject: object)
+        let restored = try JSONDecoder().decode(ChatMessage.self, from: data)
+        #expect(restored.failureKind == .downloadSourceUnavailable)
+    }
+
+    @Test("The hand-written encoder still round-trips every field")
+    func fullMessageRoundTripsUnchanged() throws {
+        // ``encode(to:)`` is hand-written for the two-key failure kind, so a
+        // dropped line would silently lose part of every saved transcript.
+        let original = ChatMessage(
+            id: UUID(),
+            role: .assistant,
+            content: "body",
+            reasoning: "trace",
+            status: .failed,
+            errorMessage: "something to show",
+            failureKind: .userDeclined,
+            toolCalls: [ToolCall(id: "call_1", name: "browse", arguments: #"{"url":"https://example.com"}"#)],
+            toolCallID: "call_1",
+            stats: MessageStats(
+                elapsedSeconds: 2.5,
+                charCount: 128,
+                promptTokens: 42,
+                completionTokens: 7
+            ),
+            reasoningTruncated: true,
+            contentTruncated: true,
+            toolNotCalledFlagged: true,
+            toolCallArtifactSuppressed: true,
+            createdAt: Date(timeIntervalSinceReferenceDate: 700_000_000)
+        )
+        let data = try JSONEncoder().encode(original)
+        let restored = try JSONDecoder().decode(ChatMessage.self, from: data)
+        #expect(restored == original)
+    }
+
+    // MARK: - Helpers
+
+    private func declinedToolRow() -> ChatMessage {
+        ChatMessage(
+            role: .tool,
+            content: "browse error: the user did not approve browsing example.com",
+            status: .failed,
+            errorMessage: FailureDiagnoser.diagnosis(for: .userDeclined).message,
+            failureKind: .userDeclined,
+            toolCallID: "call_1"
+        )
+    }
+
+    private func encodedObject(for message: ChatMessage) throws -> [String: Any] {
+        let data = try JSONEncoder().encode(message)
+        return try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+    }
+
+    /// Suspend until the approval gate has published its prompt, so the test
+    /// answers a request that actually exists. Bounded by wall-clock rather
+    /// than by an iteration count — a loaded machine must not fail correct
+    /// code — and it still fails rather than hanging if the prompt never comes.
+    private func waitForPendingApproval(
+        _ approval: BrowseApprovalStore,
+        timeout: Duration = .seconds(10)
+    ) async throws {
+        let deadline = ContinuousClock.now.advanced(by: timeout)
+        while approval.pendingRequest == nil {
+            if ContinuousClock.now >= deadline { throw ApprovalNeverArrived() }
+            try await Task.sleep(for: .milliseconds(1))
+        }
+    }
+
+    private struct ApprovalNeverArrived: Error {}
+}
+
+/// Keychain double: the web-search key is irrelevant here, and the real
+/// keychain would prompt.
+private final class NoopKeychain: KeychainStoring, @unchecked Sendable {
+    func read(account: String) -> String? { nil }
+    func write(account: String, secret: String) -> Bool { true }
+    func delete(account: String) -> Bool { true }
+}


### PR DESCRIPTION
## Why

Ask a tool-capable model to `browse https://example.com`. The approval sheet appears — *"Fetch this web page?"* → **Don't allow** / **Allow once**. Click **Don't allow**, and the tool card turns red:

> The tool couldn't finish. Check its input, then try again.

…with a retry affordance. Nothing malfunctioned. The user made a deliberate choice, and the app reported it as a fault, blamed their input for it, and invited them to retry the exact thing they had just refused. `BrowseTool` returned an honest error string, `FailureDiagnoser.toolFailureKind` had no case for "the user declined", so it landed on `.toolFailed` — the copy written for a broken tool.

This makes a decline read as what it is.

## What the user sees now

The tool card carries a `hand.raised` glyph in the transcript's ordinary secondary tone — the same quiet register as the "Stopped." footer — instead of a red `exclamationmark.octagon.fill`, and says:

> **You didn't allow this, so there's nothing to show. Ask again if you change your mind.**

"there's nothing to show" rather than "nothing happened": a redirect can be declined *after* the approved page has already been fetched, so the honest claim is about the result, not the whole exchange.

### On the red card

A user-initiated decline should not be styled as an error, so it isn't. But the row stays `.failed` underneath, and that is deliberate — a declined tool produced no result, and `ChatViewModel.turnHadSuccessfulTool` (which gates the anti-hallucination "this model didn't call a tool" caption) must not count it as a success. So the change is presentational only: a new `FailureDiagnosis.Severity` (`error` / `notice`), derived from `Kind` by an **exhaustive switch with no `default`**, so every future kind has to state which lane it belongs on rather than inheriting the alarming one by omission.

### On the action button

`action = nil`. The app has nothing to fix and nothing to recover, and a prominent **Retry** would offer to re-run the refusal — one stray click from the permission prompt having existed for nothing. A user who declined by mistake simply asks again, and the transcript's own per-message Retry is still there for a mis-click. (`ToolCallChip` never renders `FailureDiagnosisView`'s action anyway, so this is the contract for every other surface, not a button removal.)

## Keyed off a marker, not a sentence

No substring rule was added. `FailureDiagnosis.Kind.userDeclined` is **only ever producer-set**:

* the initial gate returns `ToolCallResult(failureKind: .userDeclined)` directly;
* the redirect gate (reached deep inside `fetchFollowingRedirects`) throws a typed `BrowseTool.ApprovalDeclined`, and both funnel through a new pure `errorResult(tool:error:)`.

`BuiltinToolRegistry.run` already prefers a producer-set kind over the text classifier, so the marker survives dispatch untouched. A fetched page containing *"the user did not approve browsing…"* verbatim cannot talk its way onto the quiet lane — there is a test for exactly that.

## Only an actual "no" counts

`BrowseApprovalStore.requestApproval` returned `.deny` for three different things: the user declining, the turn being cancelled while the sheet was up, and a re-entrant prompt (an invariant violation). Attributing the last two to the user would be a new, quieter version of the same bug — telling someone they refused something they were never asked. `Decision` gained `.unavailable` for "the question was never put to the user", and both gates handle all three.

## Persistence: this must not cost anyone their history

`FailureDiagnosis.Kind` decodes strictly in every build already shipped, and `ConversationStore.load` turns **one** undecodable message into "the whole history is corrupt" — the file is sided to `conversations.corrupt-<uuid>.json` and the sidebar comes up empty. Writing a newly-added raw value into the key those builds read would cost a user who downgrades their entire visible history: precisely the failure `Role.unknown` and `Status.unknown` were made forward-tolerant to prevent on the other two enums.

So `ChatMessage.encode(to:)` (now hand-written, symmetric with the existing hand-written `init(from:)`) persists the kind twice — `failureKind` gets `legacyPersistedKind`, always a value every shipped build knows; `failureKindV2`, a key old builds ignore, gets the real one. Decode prefers v2, and when v2 holds a value from a *newer* build it falls back to the ancestor that build deliberately named rather than to a blanket `.toolFailed`. `Kind` also decodes forward-tolerantly now, so a future raw value never throws. Adding a kind later needs nothing here beyond its `legacyPersistedKind` mapping.

Declines saved by **older** builds stay red. They were persisted as `.toolFailed` and carry nothing that distinguishes them from a real fault; there is no migration to write.

## Tests

`Tests/RapidTests/DeclinedToolDiagnosisTests.swift` — 23 tests:

* **Declines** — `Don't allow` at the initial gate (driven through the real `BrowseApprovalStore` suspension), the kind surviving `BuiltinToolRegistry` dispatch, and the redirect gate.
* **Not declines** — a cancelled turn and a re-entrant prompt, both of which must stay off the quiet lane; auto-approve unaffected.
* **Genuine failures still fail** — a fetch error, a redirect prompt that couldn't be shown, malformed arguments end-to-end through the registry, and decline-shaped text that must *not* be promoted.
* **Copy** — the exact string, no action, notice severity; and that `.userDeclined` is the only notice among all `Kind.allCases`.
* **Persistence** — both keys as written, a legacy-only row, an unknown future kind degrading rather than throwing (twice: to `.toolFailed`, and to the ancestor a future build named), and a full-fidelity round-trip over every field, which is what guards the hand-written encoder.

A true end-to-end redirect test is not possible: it needs a live redirecting server, and `BrowseSSRFGuard` correctly refuses the loopback address a local one would have. `BrowseTool.redirectGateError` is therefore the pure function the fetch loop itself calls at that gate, so the covered code is the code that ships.

```
swift build   → Build complete
swift test    → 1635 tests passed (23 new)
```

Codex review converged to 0 BLOCKING / 0 MAJOR / 0 MINOR / 0 NIT over three rounds. Its round-1 findings — the downgrade history-loss chain and the overloaded `.deny` — are the two structural fixes above; both were real and neither was in the original scope.

## Rebased onto #1580

#1580 landed `FailureDiagnosis.Kind.webSearchRateLimited` and
`FailureDiagnosis.inlineToolCardAction(for:canRouteToSettings:)` while this was
open. Three things had to be decided rather than merged mechanically:

* **Severity of the new kind: `.error`.** A throttled backend is the world
  refusing, not something the user chose. Its red card and Settings deep-link
  are unchanged.
* **It has the same downgrade hazard, and now the same fix.** Checked against
  `rapid-mac-v0.12.5`, the newest shipped tag: it carries neither new kind and
  decodes `failureKind` strictly, so `webSearchRateLimited` would have sided a
  user's whole history on a downgrade exactly as `userDeclined` would. The
  two-key encoder covers any kind once an ancestor is named, so it needed only
  the mapping: `.webSearchUnavailable`, the kind this very condition used to
  land on, so an older build keeps showing the copy it always showed. Pinned by
  a test that walks `Kind.allCases` and asserts every ancestor is a value
  v0.12.5 can decode. (`Action` is not `Codable` and never persisted, so
  `.openWebSearchSettings` needs no equivalent.)
* **One rule for what a tool card offers, not two.** `inlineToolCardAction` is
  now the single decision point and gates on severity explicitly rather than
  leaving my `action == nil` and its action switch as overlapping mechanisms —
  a notice must not sprout a button even if it ever gains an action. Its switch
  is exhaustive with no `default` for the same reason `severity` is. Behaviour
  is identical for every input #1580's four tests cover, and for every input the
  production diagnoser can produce today.

`ToolCallChip` had independently grown the same computed property on both sides;
main's name (`failureDiagnosis`) won. A CHANGELOG entry was added under
`[Unreleased]`, the convention that arrived with #1580.

## Follow-up, not in this PR

Handed *"the user did not approve browsing example.com"*, the model still answered *"The tool does not have access to the webpage at the provided URL, and it cannot fetch or display content from that address"* — a fabricated capability limitation. `toolGuidancePreamble`'s six rules all concern not extrapolating beyond a **successful** result; none cover an unsuccessful one, where the model invents a *reason* rather than content. But this was observed on a **1.2B** model, which is not evidence enough to touch a prompt that #1549 already showed is easy to over-tune. Filed as #1582 with a reproduction plan on models in the range the app actually recommends.

Refs #1582
