### PR TITLE
fix(cli): stop reporting cached model size at ~2x reality

### DIFF
--- a/tests/test_cli_models.py
+++ b/tests/test_cli_models.py
@@ -4,8 +4,11 @@
 from __future__ import annotations
 
 import io
+import os
 import sys
 from unittest.mock import patch
+
+import pytest
 
 from vllm_mlx import cli
 from vllm_mlx.model_aliases import list_profiles
@@ -286,3 +289,243 @@ def test_scan_hf_cache_models_filters_to_models_only(tmp_path, monkeypatch):
     assert "mlx-community/FakeModel" in repos
     assert all("squad" not in r for r in repos)
     assert all("demo" not in r for r in repos)
+
+
+# ---------------------------------------------------------------------------
+# _dir_size_bytes — HF cache blob/snapshot double counting
+#
+# The HF cache stores every file once under ``blobs/<sha>`` and links it
+# from ``snapshots/<rev>/<file>``. Following those links tallies the same
+# bytes twice, which is how a 7.9 GB model came to be advertised as
+# "15.9 GiB on disk" in ``ls --cached`` and in the macOS app's
+# Settings → Models panel. These tests pin the count at "each distinct
+# file exactly once".
+# ---------------------------------------------------------------------------
+
+
+def _make_hf_cache_repo(root, blobs: dict[str, int]):
+    """Build ``root/blobs/<sha>`` files of the given byte sizes.
+
+    Returns the created ``blobs`` directory; callers add snapshots on top.
+    """
+    blob_dir = root / "blobs"
+    blob_dir.mkdir(parents=True)
+    for sha, size in blobs.items():
+        (blob_dir / sha).write_bytes(b"\0" * size)
+    return blob_dir
+
+
+def test_dir_size_counts_snapshot_symlinks_once(tmp_path):
+    """A blob plus its snapshot symlink is one file's worth of bytes."""
+    repo = tmp_path / "models--acme--Widget-4bit"
+    blob_dir = _make_hf_cache_repo(repo, {"sha_weights": 4096, "sha_config": 64})
+
+    snap = repo / "snapshots" / "rev1"
+    snap.mkdir(parents=True)
+    (snap / "model.safetensors").symlink_to(blob_dir / "sha_weights")
+    (snap / "config.json").symlink_to(blob_dir / "sha_config")
+
+    assert cli._dir_size_bytes(str(repo)) == 4096 + 64
+
+
+def test_dir_size_counts_blob_shared_by_two_revisions_once(tmp_path):
+    """Two cached revisions sharing one blob must not triple it.
+
+    ``rev2`` re-downloads only the weights; ``config.json`` is unchanged
+    so both snapshots link the same blob. The old follow-links walk
+    charged the user for three copies of a file that exists once.
+    """
+    repo = tmp_path / "models--acme--Widget-4bit"
+    blob_dir = _make_hf_cache_repo(
+        repo, {"sha_w1": 4096, "sha_w2": 2048, "sha_config": 64}
+    )
+
+    rev1 = repo / "snapshots" / "rev1"
+    rev1.mkdir(parents=True)
+    (rev1 / "model.safetensors").symlink_to(blob_dir / "sha_w1")
+    (rev1 / "config.json").symlink_to(blob_dir / "sha_config")
+
+    rev2 = repo / "snapshots" / "rev2"
+    rev2.mkdir(parents=True)
+    (rev2 / "model.safetensors").symlink_to(blob_dir / "sha_w2")
+    (rev2 / "config.json").symlink_to(blob_dir / "sha_config")
+
+    assert cli._dir_size_bytes(str(repo)) == 4096 + 2048 + 64
+
+
+def test_dir_size_counts_hardlinked_snapshot_once(tmp_path):
+    """Hardlinked caches need inode dedupe — skipping symlinks won't do it.
+
+    ``cp -al`` cache clones, restored CI caches and older hub versions
+    all produce a snapshot entry hardlinked to its blob. Both names are
+    regular files, so only ``(st_dev, st_ino)`` dedupe stops the double
+    count.
+    """
+    repo = tmp_path / "models--acme--Widget-4bit"
+    blob_dir = _make_hf_cache_repo(repo, {"sha_weights": 4096})
+
+    snap = repo / "snapshots" / "rev1"
+    snap.mkdir(parents=True)
+    os.link(blob_dir / "sha_weights", snap / "model.safetensors")
+
+    assert cli._dir_size_bytes(str(repo)) == 4096
+
+
+def test_dir_size_counts_copied_snapshot_twice(tmp_path):
+    """A genuinely *copied* blob really does occupy twice the disk.
+
+    Dedupe is by inode, not by name or content, so the count must not
+    collapse two independent copies — reporting 4096 here would
+    under-report what deleting the model frees.
+    """
+    repo = tmp_path / "models--acme--Widget-4bit"
+    blob_dir = _make_hf_cache_repo(repo, {"sha_weights": 4096})
+
+    snap = repo / "snapshots" / "rev1"
+    snap.mkdir(parents=True)
+    (snap / "model.safetensors").write_bytes(
+        (blob_dir / "sha_weights").read_bytes()  # real copy, distinct inode
+    )
+
+    assert cli._dir_size_bytes(str(repo)) == 8192
+
+
+def test_dir_size_follows_symlinked_root(tmp_path):
+    """A relocated cache entry reports its contents, not 0.
+
+    ``path`` is what the caller asked to measure, so it is resolved
+    before the walk. Links found *inside* are still skipped, so the
+    blob/snapshot pair is not double counted through the far side.
+    """
+    real = tmp_path / "elsewhere" / "Widget-4bit"
+    blob_dir = _make_hf_cache_repo(real, {"sha_weights": 4096})
+    snap = real / "snapshots" / "rev1"
+    snap.mkdir(parents=True)
+    (snap / "model.safetensors").symlink_to(blob_dir / "sha_weights")
+
+    hub = tmp_path / "hub"
+    hub.mkdir()
+    link = hub / "models--acme--Widget-4bit"
+    link.symlink_to(real, target_is_directory=True)
+
+    assert cli._dir_size_bytes(str(link)) == 4096
+
+
+def test_dir_size_does_not_traverse_symlinked_subdirectory(tmp_path):
+    """A directory symlink is not descended — no escapes, no loops."""
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "huge.bin").write_bytes(b"\0" * 100_000)
+
+    repo = tmp_path / "models--acme--Widget-4bit"
+    _make_hf_cache_repo(repo, {"sha_weights": 4096})
+    (repo / "escape").symlink_to(outside, target_is_directory=True)
+    (repo / "loop").symlink_to(repo, target_is_directory=True)
+
+    assert cli._dir_size_bytes(str(repo)) == 4096
+
+
+def test_dir_size_skips_unreadable_subdirectory(tmp_path):
+    """A directory we cannot open contributes 0 instead of raising."""
+    if os.geteuid() == 0:
+        pytest.skip("root can read any directory, so the mode has no effect")
+
+    repo = tmp_path / "models--acme--Widget-4bit"
+    _make_hf_cache_repo(repo, {"sha_weights": 4096})
+    locked = repo / "locked"
+    locked.mkdir()
+    (locked / "hidden.bin").write_bytes(b"\0" * 512)
+    os.chmod(locked, 0o000)
+    try:
+        assert cli._dir_size_bytes(str(repo)) == 4096
+    finally:
+        os.chmod(locked, 0o700)  # let tmp_path cleanup succeed
+
+
+def test_dir_size_without_usable_inodes_counts_every_file(tmp_path):
+    """Some network/FUSE mounts report ``st_ino == 0`` for everything.
+
+    Deduping on that identity would collapse the whole tree into one
+    file, so the fallback is to count each entry.
+    """
+    repo = tmp_path / "models--acme--Widget-4bit"
+    _make_hf_cache_repo(repo, {"sha_a": 4096, "sha_b": 2048})
+
+    real_scandir = os.scandir
+
+    class _NoInodeEntry:
+        def __init__(self, entry):
+            self._entry = entry
+
+        def __getattr__(self, name):
+            return getattr(self._entry, name)
+
+        def stat(self, *, follow_symlinks=True):
+            st = self._entry.stat(follow_symlinks=follow_symlinks)
+            fields = list(st)
+            fields[1] = 0  # st_ino
+            return os.stat_result(fields)
+
+    class _NoInodeScandir:
+        def __init__(self, path):
+            self._it = real_scandir(path)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            self._it.close()
+            return False
+
+        def __iter__(self):
+            for entry in self._it:
+                yield _NoInodeEntry(entry)
+
+    with patch.object(cli.os, "scandir", _NoInodeScandir):
+        assert cli._dir_size_bytes(str(repo)) == 4096 + 2048
+
+
+def test_dir_size_ignores_dangling_symlink(tmp_path):
+    """A broken link (interrupted pull, pruned blob) neither crashes nor counts."""
+    repo = tmp_path / "models--acme--Widget-4bit"
+    blob_dir = _make_hf_cache_repo(repo, {"sha_weights": 4096})
+
+    snap = repo / "snapshots" / "rev1"
+    snap.mkdir(parents=True)
+    (snap / "model.safetensors").symlink_to(blob_dir / "sha_weights")
+    (snap / "gone.safetensors").symlink_to(blob_dir / "sha_missing")
+
+    assert cli._dir_size_bytes(str(repo)) == 4096
+
+
+def test_dir_size_counts_plain_directory_normally(tmp_path):
+    """No HF structure at all — every regular file still counts, recursively."""
+    plain = tmp_path / "my-converted-model"
+    (plain / "nested").mkdir(parents=True)
+    (plain / "model.safetensors").write_bytes(b"\0" * 1000)
+    (plain / "config.json").write_bytes(b"\0" * 24)
+    (plain / "nested" / "tokenizer.json").write_bytes(b"\0" * 7)
+
+    assert cli._dir_size_bytes(str(plain)) == 1031
+
+
+def test_dir_size_missing_path_is_zero(tmp_path):
+    """A vanished directory reports 0, not an exception."""
+    assert cli._dir_size_bytes(str(tmp_path / "nope")) == 0
+
+
+def test_scan_hf_cache_models_reports_blob_bytes_not_double(tmp_path, monkeypatch):
+    """End-to-end: the ``ls --cached`` row carries the honest byte count."""
+    cache_root = tmp_path / "hub"
+    repo = cache_root / "models--acme--Widget-4bit"
+    blob_dir = _make_hf_cache_repo(repo, {"sha_weights": 8192})
+    snap = repo / "snapshots" / "rev1"
+    snap.mkdir(parents=True)
+    (snap / "model.safetensors").symlink_to(blob_dir / "sha_weights")
+
+    monkeypatch.setattr(
+        "huggingface_hub.constants.HF_HUB_CACHE", str(cache_root), raising=False
+    )
+    rows = cli._scan_hf_cache_models()
+    sizes = {repo_id: size for repo_id, size, _mtime in rows}
+    assert sizes["acme/Widget-4bit"] == 8192

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -4739,27 +4739,103 @@ def _format_bytes(n: int) -> str:
 
 
 def _dir_size_bytes(path: str) -> int:
-    """Recursive on-disk size of ``path`` (follows blob symlinks).
+    """Bytes of the distinct files under ``path``, each counted once.
 
-    HF cache stores model weights as ``blobs/<sha>`` files referenced via
-    symlinks under ``snapshots/<rev>/<file>``. ``os.scandir`` recurses
-    through both — we follow links so a snapshot's reported size matches
-    the user's mental model of "how much disk this model uses".
+    The HF cache keeps one copy of every model file under
+    ``blobs/<sha>`` and references it from ``snapshots/<rev>/<file>``.
+    Counting both sides tallies the same bytes twice, plus once more for
+    every extra cached revision, so a 7.9 GB model was reported as
+    15.9 GiB in ``ls --cached`` and in the macOS app's Settings → Models
+    panel. That number is what tells a user how much disk deleting the
+    model would free, so being 2x off is a lie — and it disagreed with
+    ``rapid-mlx rm``, which gets its figure from
+    ``huggingface_hub``'s own (correct) ``size_on_disk``.
+
+    Two rules keep the count honest:
+
+    * Only regular files are measured. Symlinks found during the walk
+      are skipped, not followed: their bytes live somewhere else and a
+      snapshot link is just a second name for a blob already counted.
+      A dangling link therefore costs nothing and raises nothing, and
+      a link cannot be descended into, so the walk neither loops nor
+      leaves the tree it was pointed at.
+    * Files are deduped by ``(st_dev, st_ino)``, so a hardlinked layout
+      (``cp -al`` cache clones, restored CI caches, older hub versions)
+      and a blob shared by several revisions each contribute once. When
+      the hub genuinely *copies* a blob into a snapshot instead of
+      linking it, the two copies have distinct inodes and are counted
+      twice — which is right, because they really do occupy twice the
+      disk.
+
+    Deduping by identity rather than by the ``blobs``/``snapshots``
+    directory names is deliberate: the name-based shortcut breaks on
+    hardlinked caches and on directories holding several revisions.
+    ``HFCacheByteMonitor.directoryByteCount`` in the macOS app takes the
+    same approach via ``fileResourceIdentifierKey``, so the two agree on
+    the same directory up to allocation granularity: this sums logical
+    ``st_size``, the Swift side sums allocated blocks, so every file
+    differs a little through block rounding and sparse or compressed
+    files can differ a lot (model weights are neither). ``st_size`` is
+    also the quantity ``huggingface_hub`` reports as
+    ``CachedRepoInfo.size_on_disk``, which is what ``rapid-mlx rm``
+    already prints — matching it makes the two surfaces agree.
+
+    ``path`` itself is resolved through symlinks before the walk starts:
+    it names the directory the caller wants measured, so a relocated
+    cache entry reports its real contents rather than 0, which would be
+    a fresh lie in the same column. Callers pass a
+    ``models--<org>--<repo>`` cache root (or any plain directory of real
+    files), never a bare ``snapshots/<rev>`` — that subtree owns no
+    bytes of its own, and sizing one is ``_snapshot_size_bytes``' job.
+
+    Missing or unreadable paths report 0 rather than raising: this feeds
+    a listing, not a decision. For the same reason the walk is not
+    hardened against another process swapping a subdirectory for a
+    symlink between the moment it is queued and the moment it is
+    scanned. Racing that window inflates a number in a table the user
+    asked for about their own cache; anyone able to run it can rewrite
+    the weights outright. Descriptor-relative traversal
+    (``O_DIRECTORY | O_NOFOLLOW`` plus ``dir_fd``) would close it and is
+    not worth the fd bookkeeping here.
     """
     total = 0
+    seen: set[tuple[int, int]] = set()
+    # Resolve once, up front, so the walk starts inside a real directory
+    # and every subdirectory below is reached without crossing a link.
     try:
-        for entry in os.scandir(path):
+        root = os.path.realpath(path)
+    except OSError:
+        return 0
+    stack = [root]
+    while stack:
+        current = stack.pop()
+        try:
+            with os.scandir(current) as it:
+                entries = list(it)
+        except OSError:
+            # Vanished mid-walk, or a directory we may not read.
+            continue
+        for entry in entries:
             try:
                 if entry.is_dir(follow_symlinks=False):
-                    total += _dir_size_bytes(entry.path)
-                else:
-                    # follow_symlinks=True so blob symlinks count their
-                    # underlying file size, matching ``du -sL``.
-                    total += entry.stat(follow_symlinks=True).st_size
+                    stack.append(entry.path)
+                    continue
+                if not entry.is_file(follow_symlinks=False):
+                    # Symlink, fifo, socket, device — nothing this
+                    # directory owns on disk.
+                    continue
+                st = entry.stat(follow_symlinks=False)
             except OSError:
                 continue
-    except OSError:
-        return total
+            # A few network/FUSE mounts report ``st_ino == 0`` for every
+            # file. Deduping on that would collapse the whole tree into
+            # a single file, so fall back to counting each entry.
+            if st.st_ino:
+                key = (st.st_dev, st.st_ino)
+                if key in seen:
+                    continue
+                seen.add(key)
+            total += st.st_size
     return total
 
 


### PR DESCRIPTION
## Why

Every cached model's on-disk size was reported at roughly **double reality**.

`vllm_mlx/cli.py::_dir_size_bytes` walked a `models--<org>--<repo>` directory in the Hugging Face cache and stat'ed every entry with `follow_symlinks=True`. The HF cache stores the real bytes once under `blobs/<sha>` and links them a second time from `snapshots/<rev>/<file>`. Following those links tallies the same bytes twice — and once more for every additional cached revision.

Measured on an M3 Ultra for `prism-ml/Ternary-Bonsai-27B-mlx-2bit`:

| | |
|---|---|
| `du -sh` on the directory | **7.9 G** (blobs 7.9 G, snapshots 0 B) |
| walk with `os.stat` (follows links) — old code | **15.87 GiB** |
| walk with `os.lstat` (does not follow) | 7.94 GiB |

**User-visible impact.** That doubled figure is what `rapid-mlx ls --cached` prints, and the macOS app parses it straight through (`ModelEntry.sizeOnDisk` → `SettingsModelsPanel.sizeCaption`), so Settings → Models showed **"bonsai-27b-2bit · 15.9 GiB on disk"** for a model occupying 7.9 GB. The same string backs the delete confirmation's "Frees N" copy. Anything telling a user how much space they'd reclaim by deleting a model was lying by ~2×.

It also disagreed with `rapid-mlx rm`, which takes its figure from `huggingface_hub`'s `CachedRepoInfo.size_on_disk` and was already correct — so the two surfaces in the same CLI quoted different sizes for the same model.

The function's docstring asserted the follow-links behaviour was deliberate and "matches `du -sL`". `du -sL` on the repo root double counts too, so the stated intent was simply wrong rather than a trade-off; the comment is corrected along with the code.

## What changed

`_dir_size_bytes` now counts each distinct file exactly once:

- **Only regular files are measured.** Symlinks found during the walk are skipped rather than followed — a snapshot link is just a second name for a blob already counted, a dangling link costs nothing and raises nothing, and a link can't be descended into so the walk neither loops nor leaves its tree.
- **Files are deduped by `(st_dev, st_ino)`**, not by the `blobs`/`snapshots` directory names. The name-based shortcut breaks on hardlinked layouts (`cp -al` cache clones, restored CI caches, older hub versions), where skipping symlinks alone would still over-count, and on directories holding several revisions that share a blob. A genuinely *copied* blob has a distinct inode and is still counted twice — correctly, since it really does occupy twice the disk.
- `st_ino == 0` (a few network/FUSE mounts) falls back to counting each entry, rather than collapsing the whole tree into one file.
- `path` is resolved through symlinks once, up front, so a relocated cache entry reports its real contents instead of 0 — which would be a fresh lie in the same column.

This mirrors the macOS app's reference implementation, `apps/rapid-mac/Sources/Rapid/Server/HFCacheByteMonitor.swift::directoryByteCount`, which dedupes on `fileResourceIdentifierKey` and skips symlinks. The two agree on the same directory up to allocation granularity (this sums logical `st_size`; the Swift side sums allocated blocks).

### Before / after on the real cache

| Model directory | Before | After | `du -sh` |
|---|---|---|---|
| `prism-ml/Ternary-Bonsai-27B-mlx-2bit` | 15.87 GiB | **7.9 GiB** | 7.9G |
| `mlx-community/DeepSeek-R1-Distill-Qwen-32B-4bit` | — | **17.2 GiB** | 17G |
| `mlx-community/gemma-3-12b-it-bf16` | — | **24.6 GiB** | 25G |
| `lucasnewman/f5-tts-mlx` | — | **1.3 GiB** | 1.3G |

`huggingface_hub.scan_cache_dir()` independently reports 8,521,085,419 B for the Bonsai repo against the new walk's 8,521,087,563 B — the ~2 KB delta is `refs/` and `.no_exist/` bookkeeping that hub excludes and a directory walk includes.

## Neighbouring call sites audited — all three left unchanged

| Site | Verdict |
|---|---|
| `cli.py` ~1287, `_check_memory_capacity`: `os.walk(model_name)` + `getsize` for a user-supplied `--model <local dir>` | **Correct as-is.** A `models--<org>--<repo>` cache *root* is not a loadable model path (no top-level `config.json`; mlx-lm would fail to load it regardless), so the doubling layout never reaches this branch meaningfully. A `snapshots/<rev>` dir *is* loadable and holds only links pointing **out** to blobs, so `getsize`-follows counts each byte exactly once. Switching it to the new helper would report 0 for that case and silently disable the kernel-panic pre-flight warning (#324). |
| `cli.py` ~1307, same function: walks `os.path.dirname(<cached config.json>)` | **Correct as-is.** That's `snapshots/<rev>/[subfolder]`; blobs are not inside the subtree, so following links counts each byte once. Measured on the real cache: 8,521,085,419 B for this walk vs 8,521,087,563 B for the new blobs-based count — ~1×, not 2×. |
| `cli.py` ~5027, `_snapshot_size_bytes` (post-`pull` summary) | **Correct as-is.** Same shape as above, and it answers a different question ("how much content did this pull produce") on a subtree that owns no bytes of its own. |

## Tests

`tests/test_cli_models.py` gains coverage that builds fake HF cache layouts in `tmp_path`:

- blob + snapshot symlink counted once (the core regression — the old walk returned 2×)
- two revisions sharing one blob (old walk returned 3×)
- hardlinked snapshot entry (skipping symlinks alone wouldn't catch it; old walk returned 2×)
- **copied** snapshot entry counted twice — dedupe must not collapse two real copies
- dangling/broken symlink: no crash, no bytes
- plain directory with no HF structure: still counted normally, recursively
- symlinked root: reports the referent's contents, not 0
- symlinked subdirectory (escape link + self-loop): not descended
- unreadable subdirectory (`chmod 000`): contributes 0 instead of raising
- `st_ino == 0` fallback: counts every file rather than collapsing the tree
- end-to-end through `_scan_hf_cache_models`, so the `ls --cached` row itself is pinned

`python3.12 -m pytest tests/ -k "cli or cache or first_run or models"` → 1880 passed, 5 skipped. `ruff check` and `ruff format --check` clean on both touched files (the two pre-existing failures in `apps/rapid-mac/scripts/probe-matrix.py` are untouched by this PR).

## Follow-up, not fixed here

`rm_command` on a *symlinked* cache entry would fail: `huggingface_hub`'s delete strategy calls `shutil.rmtree` on the repo path, which raises on a symlink. That's a pre-existing defect on a path this PR doesn't touch — worth a separate issue.

## Review

Codex review to convergence: 3 rounds, ending 0 BLOCKING / 0 MAJOR / 0 MINOR / 0 NIT. One finding is accepted-as-documented rather than fixed: a directory queued for the walk could be swapped for a symlink before it is scanned (TOCTOU). Closing it needs descriptor-relative traversal (`O_DIRECTORY | O_NOFOLLOW` plus `dir_fd`); the consequence of losing that race is an inflated number in a table the user asked for about their own cache, and any local process that can win it can already rewrite the weights, so it is not a trust boundary. The docstring names the race, the reasoning, and the declined fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
