### PR TITLE
fix(mac): give the sidebar's inline rename editor real keyboard focus

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
@@ -707,18 +707,33 @@ private struct MessageRow: View {
             userActions
         }
         .frame(maxWidth: .infinity, alignment: .trailing)
-        .task(id: isEditing) {
-            guard isEditing else { return }
-            editFieldFocused = true
-        }
     }
 
+    /// Editor for a sent user message.
+    ///
+    /// The focus request lives HERE, on the editor, rather than on the
+    /// enclosing bubble: a `.task(id: isEditing)` on the bubble runs in the
+    /// same update that flips ``isEditing``, i.e. before this ``TextEditor``
+    /// is in the responder chain, and a focus request made then is silently
+    /// dropped — the editor opened unfocused and everything the user typed
+    /// went to the chat composer instead (the same defect the sidebar's
+    /// inline rename had). Attaching `.task` to the editor means it cannot run
+    /// before the editor exists, and the yield defers the write to the next
+    /// scheduling point so it lands after the update that installs the backing
+    /// text view. (A yield is a scheduler hop, not a guaranteed runloop turn;
+    /// it is empirically sufficient here and preferable to guessing at a
+    /// sleep — same wording as ``SidebarView.renameField(_:)``.)
     private var userEditor: some View {
         TextEditor(text: $editDraft)
             .font(.body)
             .foregroundStyle(RapidTheme.userBubbleText)
             .scrollContentBackground(.hidden)
             .focused($editFieldFocused)
+            .task {
+                await Task.yield()
+                guard !Task.isCancelled else { return }
+                editFieldFocused = true
+            }
             .padding(.horizontal, 10)
             .padding(.vertical, 6)
             .frame(minWidth: 240, idealWidth: 420, maxWidth: 560, minHeight: 72, maxHeight: 160)

--- a/apps/rapid-mac/Sources/Rapid/UI/SidebarView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SidebarView.swift
@@ -57,6 +57,33 @@ struct SidebarView: View {
     @State private var renamingID: UUID?
     @State private var renameDraft = ""
 
+    /// Keyboard focus for the inline rename editor.
+    ///
+    /// Without this the editor was purely decorative: it never became first
+    /// responder, so every keystroke went to whatever already held focus (the
+    /// chat composer), and `.onSubmit` / `.onExitCommand` — which only fire
+    /// for the FOCUSED view — were unreachable, leaving the row stuck in edit
+    /// mode with no way out. See ``renameField(_:)``.
+    @FocusState private var renameFieldFocused: Bool
+
+    /// Whether the open editor has actually held focus at least once.
+    ///
+    /// Cancel-on-focus-loss has to distinguish "the user clicked away" from
+    /// "focus has not arrived yet": the editor is created unfocused and only
+    /// takes first responder on a later scheduling pass, so reacting to every
+    /// `false` would cancel the rename the instant it opened.
+    @State private var renameFieldDidFocus = false
+
+    /// Bumped once per rename the user opens, and used as the editor's
+    /// `.task` id.
+    ///
+    /// Keying the focus request on the ROW id would tie "re-request focus" to
+    /// "a different row", which is one edit session too coarse: re-opening
+    /// Rename on the row already being edited leaves the id unchanged, so the
+    /// task would not re-run and the editor would sit there unfocused. A
+    /// per-session counter re-runs it for every open, whichever row it lands on.
+    @State private var renameSession = 0
+
     /// Whether the Archived group is expanded. Collapsed by default — the
     /// whole point of archiving is to get those rows out of the way.
     @State private var showArchived = false
@@ -248,6 +275,10 @@ struct SidebarView: View {
         let archived = archivedConversations
         if !archived.isEmpty {
             Button {
+                // Collapsing the group would take an archived row's editor off
+                // screen along with the focus observer that resolves it, so the
+                // rename would sit pending and reappear on the next expand.
+                cancelRename()
                 showArchived.toggle()
             } label: {
                 HStack(spacing: RapidTheme.Space.xs) {
@@ -294,6 +325,12 @@ struct SidebarView: View {
             let showsControls = hovering || isActive || conv.isPinned
             ZStack(alignment: .trailing) {
                 SidebarRow(isSelected: isActive) {
+                    // Navigating away resolves any rename in progress rather
+                    // than leaving a second row in edit mode behind us. The
+                    // focus-loss cancel below normally gets there first; this
+                    // is the belt-and-braces path for the case where the
+                    // editor never took focus at all.
+                    cancelRename()
                     onSelectConversation(conv.id)
                 } content: {
                     // History rows carry no icon but keep the same leading
@@ -329,6 +366,10 @@ struct SidebarView: View {
                     label: conv.isPinned ? "Unpin conversation" : "Pin conversation",
                     size: RapidTheme.ControlHeight.mini
                 ) {
+                    // Same reasoning as the menu's Pin: a pin moves the row
+                    // into its own section, restructuring the list an open
+                    // editor lives in.
+                    cancelRename()
                     chat.setConversationPinned(conv.id, !conv.isPinned)
                 }
             }
@@ -354,21 +395,38 @@ struct SidebarView: View {
 
     /// The row's actions, shared by the hover menu and the right-click menu so
     /// the two can't drift apart.
+    ///
+    /// Every item that immediately mutates or relocates a conversation resolves
+    /// a rename in progress first. Pin and Archive move a row between sections,
+    /// which restructures the list an open editor lives in, taking the editor —
+    /// and with it the focus observer that would have cancelled the edit — off
+    /// screen; so the edit is resolved up front rather than left to a blur that
+    /// may never be observed. Delete is the documented exception (see below).
     @ViewBuilder
     private func rowMenuItems(_ conv: ChatConversation) -> some View {
         Button {
+            // Tear down any rename already in flight FIRST. Rename → Rename is
+            // one continuous edit as far as ``renameFieldFocused`` is
+            // concerned: leaving it `true` would rob the new editor of the
+            // `false → true` transition its focus gate watches for, and its own
+            // eventual blur would then be ignored. Ending the previous cycle
+            // outright is what guarantees the transition happens.
+            endRename()
             renameDraft = conv.title
             renamingID = conv.id
+            renameSession &+= 1
         } label: {
             Label("Rename", systemImage: "pencil")
         }
         Divider()
         Button {
+            cancelRename()
             chat.setConversationPinned(conv.id, !conv.isPinned)
         } label: {
             Label(conv.isPinned ? "Unpin" : "Pin", systemImage: conv.isPinned ? "pin.slash" : "pin")
         }
         Button {
+            cancelRename()
             chat.setConversationArchived(conv.id, !conv.isArchived)
         } label: {
             Label(
@@ -377,29 +435,110 @@ struct SidebarView: View {
             )
         }
         Divider()
+        // Delete is the one item that does NOT need an explicit cancel: it only
+        // stages a confirmation, and presenting that dialog takes keyboard
+        // focus, which the editor's blur handler resolves. Keeping this body a
+        // bare `pendingDeletion = conv` is also what the #1568 delete-gate
+        // guard pins.
         Button("Delete", role: .destructive) {
             pendingDeletion = conv
         }
     }
 
-    /// Inline rename editor, occupying the row it replaces. Return commits,
-    /// Escape (and losing focus) cancels — the standard Finder rename
-    /// contract, so a rename can't be committed by accidentally clicking away.
+    /// Inline rename editor, occupying the row it replaces.
+    ///
+    /// Return commits. Escape cancels, and so does losing focus — clicking
+    /// another row, or anything else that takes keyboard focus — so a rename
+    /// can never be committed by accidentally clicking away. The paths that
+    /// remove the editor WITHOUT necessarily moving focus (opening another
+    /// conversation, New Chat, Launch, collapsing the Archived group) call
+    /// ``cancelRename()`` directly rather than relying on the blur. (Switching
+    /// to another app
+    /// does NOT cancel: AppKit keeps first responder inside the window, so an
+    /// open rename survives a Cmd-Tab, which is the behaviour you want.)
+    ///
+    /// Finder itself commits on click-away; cancelling is the deliberate
+    /// choice here, because a discarded draft costs one retype while a
+    /// silently-committed wrong title is a change the user never sees happen.
+    ///
+    /// Two pieces of wiring make that contract real, and both were missing
+    /// when the editor first shipped:
+    ///
+    ///   * **Focus.** ``renameFieldFocused`` is bound with `.focused(...)` and
+    ///     requested from `.task`. Requesting focus in the same render pass
+    ///     that installs the field is a documented no-op — the backing AppKit
+    ///     field is not in the responder chain yet — whereas `.task` runs once
+    ///     the field is on screen. It is keyed on ``renameSession`` so every
+    ///     edit the user opens re-focuses, whichever row it lands on. Without
+    ///     focus, keystrokes went to the chat composer and `.onSubmit` /
+    ///     `.onExitCommand` (which only fire for the focused view) were both
+    ///     unreachable.
+    ///   * **Hit area.** A bare ``TextField`` is only its intrinsic ~16pt
+    ///     tall, so inside this 30pt row the pill drawn behind it was mostly
+    ///     dead space: a click on the obvious target landed on nothing,
+    ///     resigned first responder and focused nothing at all. The
+    ///     `.contentShape` + tap handler make the whole pill focus the field.
     private func renameField(_ conv: ChatConversation) -> some View {
         TextField("Conversation name", text: $renameDraft)
             .textFieldStyle(.plain)
             .font(RapidFont.body)
+            .focused($renameFieldFocused)
             .padding(.horizontal, RapidTheme.Space.sm)
             .frame(height: RapidTheme.ControlHeight.row)
             .background(
                 RoundedRectangle(cornerRadius: RapidTheme.Radius.row, style: .continuous)
                     .fill(RapidTheme.hoverFill)
             )
+            .contentShape(
+                RoundedRectangle(cornerRadius: RapidTheme.Radius.row, style: .continuous)
+            )
+            .onTapGesture { renameFieldFocused = true }
             .onSubmit {
                 chat.renameConversation(conv.id, to: renameDraft)
-                renamingID = nil
+                endRename()
             }
-            .onExitCommand { renamingID = nil }
+            .onExitCommand { cancelRename() }
+            .task(id: renameSession) {
+                renameFieldDidFocus = false
+                // Defer the request to the next scheduling point, so it lands
+                // after the update that installs this field rather than during
+                // it — a request made mid-update reaches no AppKit field and is
+                // silently dropped. (A yield is a scheduler hop, not a
+                // guaranteed runloop turn; it is empirically sufficient here
+                // and preferable to guessing at a sleep.)
+                await Task.yield()
+                guard !Task.isCancelled, renamingID == conv.id else { return }
+                renameFieldFocused = true
+            }
+            .onChange(of: renameFieldFocused) { _, focused in
+                guard renamingID == conv.id else { return }
+                if focused {
+                    renameFieldDidFocus = true
+                    return
+                }
+                // Only a loss AFTER focus was actually held is the user
+                // clicking away; the opening `false` is just the editor
+                // waiting for its first responder.
+                guard renameFieldDidFocus else { return }
+                cancelRename()
+            }
+    }
+
+    /// Dismiss the inline editor without committing. Safe to call when no
+    /// rename is open.
+    private func cancelRename() {
+        guard renamingID != nil else { return }
+        endRename()
+    }
+
+    /// Tear down the editor's state after a commit or a cancel. Clearing
+    /// ``renameFieldDidFocus`` here is what stops the focus-loss that
+    /// FOLLOWS the dismissal from being read as a second cancel.
+    private func endRename() {
+        renamingID = nil
+        renameDraft = ""
+        renameFieldDidFocus = false
+        renameFieldFocused = false
     }
 
     /// One nav row — icon in a fixed-width slot so every label starts on
@@ -410,7 +549,15 @@ struct SidebarView: View {
         isSelected: Bool,
         action: @escaping () -> Void
     ) -> some View {
-        SidebarRow(isSelected: isSelected, action: action) {
+        // Same reasoning as the history rows: leaving for New Chat / Launch
+        // resolves a rename in progress instead of stranding it.
+        SidebarRow(
+            isSelected: isSelected,
+            action: {
+                cancelRename()
+                action()
+            }
+        ) {
             HStack(spacing: RapidTheme.Space.sm) {
                 Image(systemName: systemImage)
                     .font(.system(size: 13, weight: .medium))

--- a/apps/rapid-mac/Tests/RapidTests/SidebarRenameFocusTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SidebarRenameFocusTests.swift
@@ -1,0 +1,230 @@
+import Foundation
+import Testing
+@testable import Rapid
+
+/// Regression guard: the sidebar's inline rename editor must actually take
+/// keyboard focus.
+///
+/// As shipped in #1568 the editor had no ``@FocusState`` and no
+/// `.focused(...)`, so nothing ever moved first responder to it. Live, that
+/// meant: the field appeared but every keystroke went to the chat composer at
+/// the bottom of the window (the title the user typed silently became a
+/// message draft); `.onSubmit` and `.onExitCommand` — which only fire for the
+/// FOCUSED view — were unreachable, so Return could not commit and Escape
+/// could not dismiss; and the row stayed in edit mode with no way out. On top
+/// of that the bare ``TextField`` is only its intrinsic ~16pt tall inside a
+/// 30pt row, so a click on the visible pill mostly landed on dead space,
+/// resigning first responder and focusing nothing.
+///
+/// Focus routing does not appear in a view-model test — the proof of the fix
+/// is the live run. These are the cheap tripwires that stop the wiring being
+/// deleted again, in the source-grep shape used by
+/// ``SidebarConversationDeleteConfirmationTests`` (ViewInspector is not in
+/// this target — #1492).
+@Suite("Sidebar rename editor takes focus")
+struct SidebarRenameFocusTests {
+    private static func source(_ relativePath: String) throws -> String {
+        let root = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()  // RapidTests
+            .deletingLastPathComponent()  // Tests
+            .deletingLastPathComponent()  // repo root
+        return try String(
+            contentsOf: root.appendingPathComponent(relativePath),
+            encoding: .utf8
+        )
+    }
+
+    private func sidebarSource() throws -> String {
+        try Self.source("Sources/Rapid/UI/SidebarView.swift")
+    }
+
+    /// The body of ``SidebarView.renameField(_:)``, comment- and
+    /// whitespace-stripped. Sliced out of the file first so assertions about
+    /// the editor cannot be satisfied by an identically-shaped modifier
+    /// somewhere else in the view (``.contentShape`` in particular is also
+    /// used by the ordinary row chrome).
+    private func renameFieldBody() throws -> String {
+        let source = try sidebarSource()
+        let start = try #require(
+            source.range(of: "private func renameField("),
+            "SidebarView no longer declares renameField(_:) — update this guard."
+        )
+        let end = try #require(
+            source.range(of: "private func cancelRename(", range: start.upperBound..<source.endIndex),
+            "renameField(_:) is no longer followed by cancelRename() — update this guard."
+        )
+        return CapabilityChipRenderGateSourceGuardTests.stripCommentsAndWhitespace(
+            String(source[start.upperBound..<end.lowerBound])
+        )
+    }
+
+    // MARK: - The field is focusable and gets focused
+
+    @Test("A FocusState is declared and bound to the rename field")
+    func focusStateIsBound() throws {
+        let stripped = CapabilityChipRenderGateSourceGuardTests
+            .stripCommentsAndWhitespace(try sidebarSource())
+        #expect(
+            stripped.contains("@FocusStateprivatevarrenameFieldFocused:Bool"),
+            "SidebarView must declare a @FocusState for the inline rename editor."
+        )
+        #expect(
+            try renameFieldBody().contains(".focused($renameFieldFocused)"),
+            "The rename TextField must be bound with .focused($renameFieldFocused) — without it nothing ever moves first responder to the field and every keystroke goes to the chat composer."
+        )
+    }
+
+    /// Asserted as ONE contiguous stripped literal rather than as separate
+    /// substrings: `renameFieldFocused=true` also appears in the tap handler,
+    /// so a split assertion would still pass with the focus request deleted
+    /// from the task.
+    @Test("Focus is requested from .task, not inline in the render pass")
+    func focusIsRequestedAfterTheFieldExists() throws {
+        #expect(
+            try renameFieldBody().contains(
+                ".task(id:renameSession){renameFieldDidFocus=falseawaitTask.yield()guard!Task.isCancelled,renamingID==conv.idelse{return}renameFieldFocused=true}"
+            ),
+            "The focus request must hang off .task(id: renameSession) — keyed on the EDIT, not the row, so re-opening Rename on the row already being edited re-focuses too — and must land after a yield (a same-update request reaches no AppKit field), guarded so a superseded task cannot focus the wrong row."
+        )
+    }
+
+    @Test("Clicking anywhere in the row's pill focuses the field")
+    func clickAnywhereFocuses() throws {
+        let body = try renameFieldBody()
+        #expect(
+            body.contains(".contentShape("),
+            "The rename editor needs a .contentShape covering the drawn pill: a bare TextField is only ~16pt tall inside the 30pt row, so most of the visible target was not hit-testable."
+        )
+        #expect(
+            body.contains(".onTapGesture{renameFieldFocused=true}"),
+            "A click on the rename row must focus the field."
+        )
+    }
+
+    // MARK: - The documented contract: Return commits, Escape / blur cancels
+
+    @Test("Escape and focus loss both cancel — the documented contract")
+    func escapeAndBlurCancel() throws {
+        let body = try renameFieldBody()
+        #expect(
+            body.contains(".onExitCommand{cancelRename()}"),
+            "Escape must dismiss the editor."
+        )
+        #expect(
+            body.contains(".onChange(of:renameFieldFocused)"),
+            "renameField's doc comment promises that losing focus cancels; that requires observing renameFieldFocused."
+        )
+        // One contiguous literal: `cancelRename()` also appears in
+        // .onExitCommand, so asserting it separately would still pass with the
+        // blur branch's body emptied out. The gate is asserted in the same
+        // literal because the two are only correct together — the editor's
+        // opening `false` (it exists but has not been given first responder
+        // yet) must NOT be read as the user clicking away, or the rename would
+        // cancel itself the instant it opened.
+        #expect(
+            body.contains("guardrenameFieldDidFocuselse{return}cancelRename()"),
+            "Cancel-on-focus-loss must cancel, and must be gated on focus having actually been held once."
+        )
+    }
+
+    @Test("Return commits through the model and tears the editor down")
+    func returnCommits() throws {
+        let body = try renameFieldBody()
+        #expect(
+            body.contains(".onSubmit{chat.renameConversation(conv.id,to:renameDraft)endRename()}"),
+            "Return must commit the rename and close the editor."
+        )
+        // The pre-fix shape cleared renamingID directly and left the focus
+        // flags stale, which is what made the follow-up focus loss look like
+        // a second cancel.
+        #expect(
+            !body.contains(".onExitCommand{renamingID=nil}"),
+            "The editor must route Escape through cancelRename(), not clear renamingID in place."
+        )
+    }
+
+    @Test("Teardown clears BOTH focus flags, so the trailing blur is inert")
+    func teardownClearsFocusState() throws {
+        let stripped = CapabilityChipRenderGateSourceGuardTests
+            .stripCommentsAndWhitespace(try sidebarSource())
+        #expect(
+            stripped.contains(
+                #"privatefuncendRename(){renamingID=nilrenameDraft=""renameFieldDidFocus=falserenameFieldFocused=false}"#
+            ),
+            "endRename() must clear renamingID, the draft AND both focus flags — leaving renameFieldDidFocus set makes the focus loss that follows a commit look like a fresh cancel."
+        )
+        // Starting a rename while another one is open has to end the first
+        // cycle outright: leaving renameFieldFocused true would deny the new
+        // editor the false -> true transition its gate watches for, and that
+        // editor's own blur would then never cancel. The session bump is what
+        // makes the editor's .task re-run for the new edit.
+        #expect(
+            stripped.contains(
+                "endRename()renameDraft=conv.titlerenamingID=conv.idrenameSession&+=1"
+            ),
+            "The Rename menu item must tear down any rename already in flight and bump the edit session before opening a new one."
+        )
+    }
+
+    @Test("Every path that removes the editor without a blur resolves the edit")
+    func nonBlurDismissalsResolveTheEdit() throws {
+        let stripped = CapabilityChipRenderGateSourceGuardTests
+            .stripCommentsAndWhitespace(try sidebarSource())
+        #expect(
+            stripped.contains("SidebarRow(isSelected:isActive){cancelRename()onSelectConversation(conv.id)}"),
+            "Opening another conversation must resolve a pending rename — otherwise a row that never took focus stays in edit mode forever."
+        )
+        #expect(
+            stripped.contains("SidebarRow(isSelected:isSelected,action:{cancelRename()action()})"),
+            "New Chat / Launch must resolve a pending rename too."
+        )
+        #expect(
+            stripped.contains("Button{cancelRename()showArchived.toggle()}"),
+            "Collapsing the Archived group takes an archived row's editor — and its focus observer — off screen together, so it must cancel explicitly."
+        )
+        // Pin and Archive move a row between sections, restructuring the list
+        // an open editor lives in. Both call sites of the pin toggle (the row's
+        // hover button and the menu item) plus Archive must resolve the edit.
+        #expect(
+            stripped.contains("cancelRename()chat.setConversationArchived(conv.id,!conv.isArchived)"),
+            "Archive / Unarchive must resolve a rename in progress — it relocates the row between sections."
+        )
+        let pinCancels = stripped.components(
+            separatedBy: "cancelRename()chat.setConversationPinned(conv.id,!conv.isPinned)"
+        ).count - 1
+        #expect(
+            pinCancels == 2,
+            "Both pin toggles (hover button + menu item) must resolve a rename in progress; found \(pinCancels) of 2."
+        )
+    }
+
+    // MARK: - The neighbouring surface: editing a sent message in ChatView
+
+    /// ``MessageRow``'s edit-a-sent-message editor is the same shape of
+    /// affordance, and — verified live on the same build — it had the same
+    /// defect in a subtler form: it DID own a ``@FocusState``, but requested
+    /// focus from a `.task(id: isEditing)` on the enclosing bubble, which runs
+    /// in the update that flips ``isEditing`` — before the ``TextEditor``
+    /// exists. The editor opened unfocused and typing went to the composer.
+    /// The request now hangs off the editor itself.
+    @Test("ChatView's sent-message editor requests focus from the editor itself")
+    func chatViewEditorRequestsFocusOnTheEditor() throws {
+        let source = try Self.source("Sources/Rapid/UI/ChatView.swift")
+        let stripped = CapabilityChipRenderGateSourceGuardTests
+            .stripCommentsAndWhitespace(source)
+        #expect(
+            stripped.contains("@FocusStateprivatevareditFieldFocused:Bool"),
+            "MessageRow must keep a @FocusState for the sent-message editor."
+        )
+        #expect(
+            stripped.contains(
+                ".focused($editFieldFocused).task{awaitTask.yield()guard!Task.isCancelledelse{return}editFieldFocused=true}"
+            ),
+            "The sent-message editor must request focus from a .task attached to the editor, after a yield — a request made while the bubble is still switching branches is dropped and the editor opens unfocused."
+        )
+        #expect(
+            !stripped.contains(".task(id:isEditing){guardisEditingelse{return}editFieldFocused=true}"),
+            "The focus request must not sit on the enclosing bubble: it runs before the TextEditor is in the responder chain."
+        )
+    }
+}


### PR DESCRIPTION
## Why

"Rename conversation" is unusable in the shipped build. #1568 added the inline rename editor to the sidebar; pin, archive, unarchive and retry-in-place from that PR all work, but rename does not. Verified live on `main` @ `bafe3ecd`:

1. Sidebar row → `···` → **Rename** swaps in the inline `TextField` as designed.
2. The field never takes keyboard focus. **Everything the user types goes into the message composer at the bottom of the window** — the title they meant to type silently becomes a chat message draft.
3. Clicking the row does not focus it either: it clears focus entirely and the keystrokes are dropped.
4. Because focus never arrives, `.onSubmit` and `.onExitCommand` — which only fire for the focused view — are unreachable, so **Escape cannot dismiss and Return cannot commit**. The row is stuck in edit mode. Clicking another row leaves it stuck.

## Root cause

`SidebarView.renameField(_:)` built a `TextField` with **no `@FocusState` and no `.focused(...)` anywhere**. Nothing ever moved first responder to it, so it stayed decorative while the chat composer's `NSTextView` kept the keyboard.

The hit area is the second half. A bare `TextField` is only its intrinsic ~16pt tall; `.frame(height: 30)` centres it in the row and `.background(...)` paints a 30pt pill that is not hit-testable. AX reported the field as `size 168x16` inside a 30pt row — so roughly half the visible target was dead space, and a click there resigned first responder and focused nothing.

The doc comment claimed "Escape (and losing focus) cancels — the standard Finder rename contract", but the losing-focus half was never implemented.

## What changed

`SidebarView.swift`

- `@FocusState renameFieldFocused` bound with `.focused(...)`, requested from `.task` after a yield. A focus request made in the same update that installs the field reaches no AppKit field and is silently dropped — this is the well-known same-pass no-op, confirmed empirically rather than assumed. The task is keyed on a per-edit session counter so every Rename re-focuses, whichever row it lands on, and is guarded on `renamingID` so a superseded task cannot focus the wrong row.
- `.contentShape(RoundedRectangle(...))` + a tap handler, so the whole drawn pill focuses the field instead of only the 16pt glyph band. Click-to-place-caret and double-click word-select inside the field still work — the gesture only catches clicks in the padding.
- Cancel-on-focus-loss via `.onChange(of: renameFieldFocused)`, gated on focus having actually been held once so the editor's own opening `false` is not read as the user clicking away. The doc comment is rewritten to describe what actually ships (including that switching apps does *not* cancel — AppKit keeps first responder inside the window).
- A pending rename is resolved by every path that removes the editor without necessarily moving focus: opening another conversation, New Chat, Launch, collapsing the Archived group, and the Pin / Archive actions that relocate a row between sections. Delete is the documented exception — it only stages a confirmation, and presenting that dialog moves focus, which the blur handler resolves.

`ChatView.swift` — checked the neighbouring surface as part of this. `MessageRow`'s edit-a-sent-message editor **had the same defect in a subtler form**: it owned an `editFieldFocused` `@FocusState`, but requested focus from a `.task(id: isEditing)` on the enclosing bubble, which runs in the update that flips `isEditing` — before the `TextEditor` exists. Verified live: it opened unfocused and typing went to the composer. The request now hangs off the editor itself.

## Live evidence

Built with `scripts/build.sh`, isolated with `scripts/dogfood-isolate.sh`, driven with `cliclick` + `screencapture` + accessibility dumps. Auto-start was disabled for the run; no model was loaded and no second `rapid-mlx serve` was started.

**Before** — open Rename, type `ZZTOP` without clicking anything:

```
AXTextField | focused=false | val=Alpha planning notes | pos=749,313 size=168,16
AXTextArea  | focused=false | val=ZZTOP                | pos=1079,877 size=700,30   <- composer
```

Then click inside the row but outside the 16pt band, and type `XY`:

```
AXTextField | focused=false | val=Alpha planning notes   <- nothing focused, XY dropped
AXTextArea  | focused=false | val=ZZTOP
```

Escape then does nothing (nothing is focused), and clicking another row leaves row 1 still rendering the editor — stuck.

**After** — open Rename, type without clicking anything:

```
AXTextField | focused=true  | val=FinalPass | pos=741,306 size=184,30   <- full row pill
AXTextArea  | focused=false | val=                                      <- composer untouched
```

- Return commits: the row re-renders with the new title and `conversations.json` shows `("RenamedByKeyboard", hasCustomTitle=true)`.
- Escape discards the draft and restores the old title.
- Moving focus to the composer cancels the rename and restores the old title (the documented contract).
- Rename row A → Rename row B without dismissing: exactly one editor exists (B's, focused, holding text typed immediately), A resolves back to its old title, and B's blur still cancels.
- Clicking another row resolves the pending edit and opens that conversation.
- Renaming an archived row, then collapsing the Archived group, resolves the edit — nothing stranded on re-expand.
- ChatView: clicking a sent message's pencil and typing immediately now lands in the message editor, not the composer.

## Tests

`swift build` passes. The swift-testing suite is green (1560 tests). New `SidebarRenameFocusTests` pins the focus wiring, the hit area, the Escape/blur contract, `endRename()`'s exact teardown, the Rename-before-Rename ordering, every non-blur dismissal path, and ChatView's editor-attached focus request. These are tripwires, not proof — unit tests cannot see focus routing, which is why the live run above is the evidence.

Codex review to convergence: 0 BLOCKING, 0 MAJOR, 0 MINOR (three rounds; the MAJOR and MINORs it raised on rounds 1 and 2 are folded in and re-verified live).

Refs #1568.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
