### PR TITLE
fix(lfm): stop tool-call markup leaking into streamed content

### DIFF
--- a/tests/test_lfm_tool_parser.py
+++ b/tests/test_lfm_tool_parser.py
@@ -380,6 +380,193 @@ class TestAutoParserLfmStreaming:
         assert result is None or "tool_calls" not in result
 
 
+def _stream(parser, chunks):
+    """Feed ``chunks`` through the streaming parser, return (content, calls).
+
+    Mirrors what ``StreamingPostProcessor._detect_tool_calls`` does with
+    the parser's return value, minus the postprocessor's own sanitizers —
+    so the assertions pin the PARSER's contract rather than the last-mile
+    scrubber that happened to mask half of this leak in production.
+    """
+    previous = ""
+    content = ""
+    calls = []
+    for chunk in chunks:
+        current = previous + chunk
+        result = parser.extract_tool_calls_streaming(previous, current, chunk)
+        if result is not None:
+            if result.get("content"):
+                content += result["content"]
+            for call in result.get("tool_calls") or []:
+                calls.append(call)
+        previous = current
+    # Stream end: held bytes are released only when no call ever fired,
+    # matching ``StreamingPostProcessor.finalize``.
+    if not calls:
+        content += parser.flush_held_content(previous)
+    return content, calls
+
+
+#: The exact wire text behind the reported leak. rapid-mlx itself writes
+#: ``[Calling tool: name({args})]`` into the prompt for every model whose
+#: parser reports no native tool format (``api/utils.py``) — LFM's does,
+#: and LFM2.5's chat template drops ``message.tool_calls`` — so the model
+#: is taught this dialect by its own history and reproduces it verbatim.
+LEAK_TEXT = (
+    '[Calling tool: browse({"url": "https://www.iana.org/help/example-domains", '
+    '"refresh": true})]'
+)
+
+#: Realistic detokenizer chunking for ``LEAK_TEXT``. The reported leak
+#: needs this exact split: ``[Calling tool`` lands in one delta (the
+#: global sanitizer eats it whole) and everything from ``:`` onward
+#: streams to the client.
+LEAK_CHUNKS = [
+    "[",
+    "Calling",
+    " tool",
+    ":",
+    " browse",
+    "({",
+    '"url"',
+    ": ",
+    '"https://www.iana.org/help/example-domains"',
+    ", ",
+    '"refresh"',
+    ": ",
+    "true",
+    "})",
+    "]",
+]
+
+LEAK_ARGS = {
+    "url": "https://www.iana.org/help/example-domains",
+    "refresh": True,
+}
+
+
+class TestLfmTextFormatEnvelope:
+    """``[Calling tool: name({...})]`` — the text-format degradation."""
+
+    def test_non_streaming_extracts_envelope_call(self):
+        parser = LfmToolParser()
+        result = parser.extract_tool_calls(LEAK_TEXT)
+
+        assert result.tools_called
+        assert len(result.tool_calls) == 1
+        assert result.tool_calls[0]["name"] == "browse"
+        assert json.loads(result.tool_calls[0]["arguments"]) == LEAK_ARGS
+        assert not result.content
+
+    def test_streaming_envelope_token_by_token_leaks_nothing(self):
+        """The reported P1: raw markup reached the visible message."""
+        parser = LfmToolParser()
+        content, calls = _stream(parser, LEAK_CHUNKS)
+
+        assert content == ""
+        assert len(calls) == 1
+        assert calls[0]["index"] == 0
+        assert calls[0]["function"]["name"] == "browse"
+        assert json.loads(calls[0]["function"]["arguments"]) == LEAK_ARGS
+
+    def test_streaming_envelope_char_by_char_leaks_nothing(self):
+        """Per-character deltas are the worst case for prefix holding."""
+        parser = LfmToolParser()
+        content, calls = _stream(parser, list(LEAK_TEXT))
+
+        assert content == ""
+        assert len(calls) == 1
+        assert json.loads(calls[0]["function"]["arguments"]) == LEAK_ARGS
+
+    def test_streaming_envelope_single_delta_leaks_nothing(self):
+        parser = LfmToolParser()
+        content, calls = _stream(parser, [LEAK_TEXT])
+
+        assert content == ""
+        assert len(calls) == 1
+        assert calls[0]["function"]["name"] == "browse"
+
+    def test_streaming_envelope_keeps_prose_preface(self):
+        """Prose before the call is content; the markup itself is not."""
+        parser = LfmToolParser()
+        content, calls = _stream(parser, ["One moment. "] + LEAK_CHUNKS)
+
+        assert content == "One moment. "
+        assert len(calls) == 1
+        assert calls[0]["function"]["name"] == "browse"
+
+    def test_streaming_two_envelope_blocks_continue_indices(self):
+        parser = LfmToolParser()
+        content, calls = _stream(
+            parser,
+            [
+                '[Calling tool: f({"a": 1})]',
+                " then ",
+                '[Calling tool: g({"b": 2})]',
+            ],
+        )
+
+        assert "Calling tool" not in content
+        assert [c["index"] for c in calls] == [0, 1]
+        assert [c["function"]["name"] for c in calls] == ["f", "g"]
+        assert len({c["id"] for c in calls}) == 2
+
+    def test_streaming_json_args_without_envelope_leaks_nothing(self):
+        """``[name({...})]`` — same dialect with the envelope dropped.
+
+        A single dict positional is unambiguously the arguments object,
+        so it must not be rejected into the visible content the way a
+        genuinely positional call (``[index(0)]``) is.
+        """
+        parser = LfmToolParser()
+        content, calls = _stream(parser, ['[browse({"url": ', '"https://x"})]'])
+
+        assert content == ""
+        assert len(calls) == 1
+        assert calls[0]["function"]["name"] == "browse"
+        assert json.loads(calls[0]["function"]["arguments"]) == {"url": "https://x"}
+
+    def test_unterminated_envelope_is_flushed_not_swallowed(self):
+        """A held prefix must be released when no call ever completes."""
+        parser = LfmToolParser()
+        content, calls = _stream(parser, ["Wait ", "[Calling", " tool", ": brow"])
+
+        assert calls == []
+        assert content == "Wait [Calling tool: brow"
+
+
+class TestLfmStreamingProseRegressions:
+    """Ordinary prose must keep streaming — the hold is not a censor."""
+
+    def test_bare_bracket_in_prose_streams_through(self):
+        parser = LfmToolParser()
+        content, calls = _stream(parser, ["Use ", "a[i", " to index", " the array."])
+
+        assert calls == []
+        assert content == "Use a[i to index the array."
+
+    def test_bracketed_prose_note_is_not_eaten(self):
+        parser = LfmToolParser()
+        content, calls = _stream(parser, ["See ", "[note", ": read", " this]", " ok"])
+
+        assert calls == []
+        assert content == "See [note: read this] ok"
+
+    def test_calling_prose_that_is_not_the_envelope_streams_through(self):
+        parser = LfmToolParser()
+        content, calls = _stream(parser, ["[Calling", " the", " doctor]", " now"])
+
+        assert calls == []
+        assert content == "[Calling the doctor] now"
+
+    def test_markdown_link_streams_through(self):
+        parser = LfmToolParser()
+        content, calls = _stream(parser, ["[docs", "](https://x)", " here"])
+
+        assert calls == []
+        assert content == "[docs](https://x) here"
+
+
 class TestPostprocessorLfmFinalize:
     """End-of-stream recovery must recognize pythonic markup."""
 
@@ -393,6 +580,52 @@ class TestPostprocessorLfmFinalize:
         cfg.tool_call_parser = None
         cfg.tool_parser_instance = parser
         return cfg
+
+    @staticmethod
+    def _make_output(text, finished=False):
+        out = MagicMock()
+        out.new_text = text
+        out.finished = finished
+        out.channel = None
+        out.finish_reason = "stop" if finished else None
+        out.prompt_tokens = 10
+        out.completion_tokens = 5
+        out.tokens = []
+        out.logprobs = None
+        out.tool_calls = None
+        return out
+
+    def test_streaming_envelope_emits_no_visible_content(self):
+        """End-to-end guard on the shipped path (issue: LFM leak).
+
+        Pre-fix this streamed ``: browse({"url": ...})]`` into the chat
+        bubble: the parser released ``[Calling tool`` as one delta, the
+        global sanitizer stripped exactly that span, and every remaining
+        byte reached the client as ordinary content.
+        """
+        pp = StreamingPostProcessor(self._make_cfg(LfmToolParser()))
+        pp.reset()
+        pp.tools_requested = True
+
+        content = ""
+        tool_calls = []
+        last = len(LEAK_CHUNKS) - 1
+        for i, chunk in enumerate(LEAK_CHUNKS):
+            for event in pp.process_chunk(self._make_output(chunk, finished=i == last)):
+                if event.content:
+                    content += event.content
+                if event.type == "tool_call":
+                    tool_calls += event.tool_calls
+        for event in pp.finalize():
+            if event.content:
+                content += event.content
+            if event.type == "tool_call":
+                tool_calls += event.tool_calls
+
+        assert content == ""
+        assert len(tool_calls) == 1
+        assert tool_calls[0]["function"]["name"] == "browse"
+        assert json.loads(tool_calls[0]["function"]["arguments"]) == LEAK_ARGS
 
     def test_finalize_recovers_pythonic_call_missed_by_streaming(self):
         """Regression: the plausible-markup pre-check only looked for

--- a/tests/test_lfm_tool_parser.py
+++ b/tests/test_lfm_tool_parser.py
@@ -573,45 +573,39 @@ class TestLfmTextFormatEnvelope:
             assert len(calls) == 1, text
             assert json.loads(calls[0]["function"]["arguments"]) == {"a": 1}, text
 
-    def test_unterminated_opener_does_not_mask_a_later_call(self):
-        """A malformed opener must not hide the valid block after it.
+    def test_call_inside_a_string_argument_is_never_dispatched(self):
+        """Markup inside another call's JSON string is data, not a call.
 
-        Bailing on the first unbalanced candidate treated everything that
-        followed as nested inside it, so the complete call was never
-        extracted and its raw markup was released as content instead.
+        Mid-stream the outer block is just unterminated, so hunting past
+        it for a block that closes finds the ``[g({})]`` sitting inside
+        ``f``'s argument and dispatches it at index 0 — which the
+        count-based dedup can never retract once ``f`` actually arrives.
+        The walk stops at the unterminated opener instead.
         """
-        text = 'Before [2fa({"oops": 1}) [browse({"q": "x"})]'
-        parser = LfmToolParser()
-        result = parser.extract_tool_calls(text)
-
-        assert result.tools_called
-        assert [tc["name"] for tc in result.tool_calls] == ["browse"]
-        assert "[browse(" not in (result.content or "")
-
-        content, calls = _stream(LfmToolParser(), list(text))
-        assert [c["function"]["name"] for c in calls] == ["browse"]
-        assert "[browse(" not in content
-
-    def test_prose_after_a_call_survives_an_earlier_malformed_opener(self):
-        """A settled block ends the hold that an earlier opener started.
-
-        Otherwise a malformed opener before the call keeps holding every
-        byte after it, and the EOF flush is skipped once a call fires — so
-        the trailing prose is dropped instead of streamed.
-        """
-        text = '[oops({"a": 1}) [Calling tool: f({})] all done'
+        text = '[Calling tool: f({"x": "[g({})]"})]'
         content, calls = _stream(LfmToolParser(), list(text))
 
         assert [c["function"]["name"] for c in calls] == ["f"]
-        assert content.endswith(" all done")
-        assert "Calling tool" not in content
+        assert json.loads(calls[0]["function"]["arguments"]) == {"x": "[g({})]"}
+        assert content == ""
 
-    def test_unterminated_opener_probing_stays_bounded(self):
-        """Many unterminated openers must not make the walk quadratic."""
-        text = '[f({"a": 1}) ' * 4000 + "]"
-        start = time.perf_counter()
-        parse_lfm_tool_calls(text)
-        assert time.perf_counter() - start < 1.0
+    def test_unterminated_opener_masks_later_blocks_but_loses_nothing(self):
+        """An opener with no ``]`` stops the walk — the safe failure.
+
+        Its payload may contain anything, so a later block that closes is
+        not provably a separate call (see the string-argument test above).
+        Nothing is dispatched and nothing is swallowed: the whole span is
+        released as content at EOF.
+        """
+        text = 'Before [oops({"a": 1}) [browse({"q": "x"})]'
+        content, calls = _stream(LfmToolParser(), list(text))
+
+        assert calls == []
+        assert content == text
+
+        result = LfmToolParser().extract_tool_calls(text)
+        assert not result.tools_called
+        assert result.content == text
 
     def test_prose_after_call_in_same_delta_is_not_dropped(self):
         """Trailing prose sharing the closing delta must still be emitted.

--- a/tests/test_lfm_tool_parser.py
+++ b/tests/test_lfm_tool_parser.py
@@ -553,6 +553,26 @@ class TestLfmTextFormatEnvelope:
             assert result.tools_called, text
             assert json.loads(result.tool_calls[0]["arguments"]) == expected, text
 
+    def test_openai_legal_tool_names_are_recognised(self):
+        """Names follow the OpenAI charset, not Python identifier rules.
+
+        ``^[a-zA-Z0-9_-]{1,64}$`` is what the request validator accepts, so
+        ``my-tool`` and ``2fa`` are names a client can register. Rejecting
+        them here would stream the raw span while the finalize recovery
+        path (which does accept them) extracted the call anyway.
+        """
+        for text in (
+            '[Calling tool: my-tool({"a": 1})]',
+            '[my-tool({"a": 1})]',
+            '[Calling tool: 2fa({"a": 1})]',
+            '[2fa({"a": 1})]',
+        ):
+            parser = LfmToolParser()
+            content, calls = _stream(parser, list(text))
+            assert content == "", text
+            assert len(calls) == 1, text
+            assert json.loads(calls[0]["function"]["arguments"]) == {"a": 1}, text
+
     def test_prose_after_call_in_same_delta_is_not_dropped(self):
         """Trailing prose sharing the closing delta must still be emitted.
 
@@ -672,6 +692,16 @@ class TestLfmStreamingProseRegressions:
 
         assert [c["function"]["name"] for c in calls] == ["f"]
         assert content == "I can't do that, but "
+
+    def test_bracketed_identifier_prose_is_not_held_past_its_token(self):
+        """The wider name charset must not extend the hold into prose."""
+        parser = LfmToolParser()
+        content, calls = _stream(
+            parser, ["Due ", "[2026-08-06", " and later]", " we ship."]
+        )
+
+        assert calls == []
+        assert content == "Due [2026-08-06 and later] we ship."
 
     def test_bracket_scan_stays_linear(self):
         """Guard the O(n^2)-per-delta scan the first fix round introduced.

--- a/tests/test_lfm_tool_parser.py
+++ b/tests/test_lfm_tool_parser.py
@@ -2,6 +2,7 @@
 """Tests for Liquid/LFM tool call parser."""
 
 import json
+import time
 from unittest.mock import MagicMock
 
 from vllm_mlx.service.postprocessor import StreamingPostProcessor
@@ -534,6 +535,64 @@ class TestLfmTextFormatEnvelope:
         assert calls == []
         assert content == "Wait [Calling tool: brow"
 
+    def test_json_literals_are_not_stringified(self):
+        """``true`` / ``false`` / ``null`` are JSON, not Python bare names.
+
+        Parsing the payload with ``ast`` turns them into the strings
+        ``"true"`` / ``"false"`` / ``"null"``, which invokes the tool with
+        materially wrong arguments.
+        """
+        parser = LfmToolParser()
+        expected = {"refresh": True, "cached": False, "cursor": None, "n": 3}
+        for text in (
+            '[Calling tool: browse({"refresh": true, "cached": false, '
+            '"cursor": null, "n": 3})]',
+            '[browse({"refresh": true, "cached": false, "cursor": null, "n": 3})]',
+        ):
+            result = parser.extract_tool_calls(text)
+            assert result.tools_called, text
+            assert json.loads(result.tool_calls[0]["arguments"]) == expected, text
+
+    def test_prose_after_call_in_same_delta_is_not_dropped(self):
+        """Trailing prose sharing the closing delta must still be emitted.
+
+        Once a tool call fires the EOF flush is skipped, so anything the
+        tool-call return does not carry is lost for good.
+        """
+        parser = LfmToolParser()
+        content, calls = _stream(parser, ['[Calling tool: f({"a": 1})] all done'])
+
+        assert [c["function"]["name"] for c in calls] == ["f"]
+        assert content == " all done"
+
+    def test_prose_between_two_calls_in_same_delta_is_not_dropped(self):
+        parser = LfmToolParser()
+        content, calls = _stream(
+            parser, ["[Calling tool: f({})] then [Calling tool: g({})] end"]
+        )
+
+        assert [c["function"]["name"] for c in calls] == ["f", "g"]
+        assert content == " then  end"
+
+    def test_forced_prefix_seeded_by_postprocessor_is_not_re_emitted(self):
+        """``previous_text`` may be seeded with bytes never streamed here.
+
+        ``StreamingPostProcessor.seed_forced_assistant_prefix`` primes
+        ``tool_accumulated_text``; treating those bytes as unemitted would
+        replay the forced prefix into the visible message.
+        """
+        parser = LfmToolParser()
+        seeded = "Already sent. "
+        result = parser.extract_tool_calls_streaming(
+            previous_text=seeded,
+            current_text=seeded + "[f(x=1)]",
+            delta_text="[f(x=1)]",
+        )
+
+        assert result is not None
+        assert result["tool_calls"][0]["function"]["name"] == "f"
+        assert not result.get("content")
+
 
 class TestLfmStreamingProseRegressions:
     """Ordinary prose must keep streaming — the hold is not a censor."""
@@ -558,6 +617,38 @@ class TestLfmStreamingProseRegressions:
 
         assert calls == []
         assert content == "[Calling the doctor] now"
+
+    def test_apostrophe_in_prose_does_not_disable_markup_holding(self):
+        """A stray quote at bracket depth 0 is prose, not an open string.
+
+        Tracking quotes globally would make ``don't`` swallow every later
+        ``[``, so the markup after it would stream out raw.
+        """
+        parser = LfmToolParser()
+        content, calls = _stream(
+            parser, ["I can't do that, but ", '[Calling tool: f({"a": 1})]']
+        )
+
+        assert [c["function"]["name"] for c in calls] == ["f"]
+        assert content == "I can't do that, but "
+
+    def test_bracket_scan_stays_linear(self):
+        """Guard the O(n^2)-per-delta scan the first fix round introduced.
+
+        ``"[!" * n`` is all unbalanced openers: rescanning the suffix for
+        each one took ~0.85s at n=3200 and grew ~4x per doubling.
+        """
+        parser = LfmToolParser()
+        elapsed = []
+        for size in (2000, 8000):
+            text = "[!" * size
+            start = time.perf_counter()
+            parser._safe_content_prefix(text)
+            elapsed.append(time.perf_counter() - start)
+
+        # 4x the input must not cost anywhere near 16x the time.
+        assert elapsed[1] < 0.5
+        assert elapsed[1] < max(elapsed[0], 1e-4) * 8
 
     def test_markdown_link_streams_through(self):
         parser = LfmToolParser()

--- a/tests/test_lfm_tool_parser.py
+++ b/tests/test_lfm_tool_parser.py
@@ -573,6 +573,46 @@ class TestLfmTextFormatEnvelope:
             assert len(calls) == 1, text
             assert json.loads(calls[0]["function"]["arguments"]) == {"a": 1}, text
 
+    def test_unterminated_opener_does_not_mask_a_later_call(self):
+        """A malformed opener must not hide the valid block after it.
+
+        Bailing on the first unbalanced candidate treated everything that
+        followed as nested inside it, so the complete call was never
+        extracted and its raw markup was released as content instead.
+        """
+        text = 'Before [2fa({"oops": 1}) [browse({"q": "x"})]'
+        parser = LfmToolParser()
+        result = parser.extract_tool_calls(text)
+
+        assert result.tools_called
+        assert [tc["name"] for tc in result.tool_calls] == ["browse"]
+        assert "[browse(" not in (result.content or "")
+
+        content, calls = _stream(LfmToolParser(), list(text))
+        assert [c["function"]["name"] for c in calls] == ["browse"]
+        assert "[browse(" not in content
+
+    def test_prose_after_a_call_survives_an_earlier_malformed_opener(self):
+        """A settled block ends the hold that an earlier opener started.
+
+        Otherwise a malformed opener before the call keeps holding every
+        byte after it, and the EOF flush is skipped once a call fires — so
+        the trailing prose is dropped instead of streamed.
+        """
+        text = '[oops({"a": 1}) [Calling tool: f({})] all done'
+        content, calls = _stream(LfmToolParser(), list(text))
+
+        assert [c["function"]["name"] for c in calls] == ["f"]
+        assert content.endswith(" all done")
+        assert "Calling tool" not in content
+
+    def test_unterminated_opener_probing_stays_bounded(self):
+        """Many unterminated openers must not make the walk quadratic."""
+        text = '[f({"a": 1}) ' * 4000 + "]"
+        start = time.perf_counter()
+        parse_lfm_tool_calls(text)
+        assert time.perf_counter() - start < 1.0
+
     def test_prose_after_call_in_same_delta_is_not_dropped(self):
         """Trailing prose sharing the closing delta must still be emitted.
 

--- a/tests/test_lfm_tool_parser.py
+++ b/tests/test_lfm_tool_parser.py
@@ -618,6 +618,47 @@ class TestLfmStreamingProseRegressions:
         assert calls == []
         assert content == "[Calling the doctor] now"
 
+    def test_unfinished_prose_bracket_does_not_hide_the_real_opener(self):
+        """A quote inside an unclosed prose bracket must not mask markup.
+
+        Carrying quote state across the turn made everything after
+        ``[note "`` look like one long string, so the ``[Calling tool:``
+        that followed was never treated as an opener and streamed out raw.
+        """
+        parser = LfmToolParser()
+        content, calls = _stream(
+            parser,
+            [
+                'See [note "unfinished ',
+                "[",
+                "Calling",
+                " tool",
+                ":",
+                " f({})",
+                "]",
+            ],
+        )
+
+        assert [c["function"]["name"] for c in calls] == ["f"]
+        assert content == 'See [note "unfinished '
+
+    def test_backslash_in_prose_bracket_does_not_hide_the_real_opener(self):
+        parser = LfmToolParser()
+        content, calls = _stream(
+            parser, ["Path [dir\\ ", '[Calling tool: f({"a": 1})]']
+        )
+
+        assert [c["function"]["name"] for c in calls] == ["f"]
+        assert content == "Path [dir\\ "
+
+    def test_whitespace_between_call_and_prose_survives_chunk_boundary(self):
+        """Output must not depend on where the chunk boundary falls."""
+        together = _stream(LfmToolParser(), ["[f(x=1)] done"])
+        split = _stream(LfmToolParser(), ["[f(x=1)] ", "done"])
+
+        assert together[0] == " done"
+        assert split[0] == " done"
+
     def test_apostrophe_in_prose_does_not_disable_markup_holding(self):
         """A stray quote at bracket depth 0 is prose, not an open string.
 

--- a/tests/test_lfm_tool_parser.py
+++ b/tests/test_lfm_tool_parser.py
@@ -589,6 +589,35 @@ class TestLfmTextFormatEnvelope:
         assert json.loads(calls[0]["function"]["arguments"]) == {"x": "[g({})]"}
         assert content == ""
 
+    def test_call_inside_a_rejected_block_is_never_dispatched(self):
+        """A rejected block's payload is data too, not a place to search.
+
+        Resuming one character into a balanced-but-invalid block finds the
+        markup sitting in its string argument and dispatches it — the same
+        irreversible mistake as probing past an unterminated opener, just
+        with the outer block closed.
+        """
+        text = '[Calling tool: f({"x": "[Calling tool: g({})]"} trailing)]'
+        content, calls = _stream(LfmToolParser(), list(text))
+
+        assert calls == []
+        assert content == text
+        assert not LfmToolParser().extract_tool_calls(text).tools_called
+
+    def test_auto_parser_does_not_dispatch_from_a_rejected_block(self):
+        parser = AutoToolParser()
+        text = '[f(x=0, note="[g({})]", 1)]'
+
+        assert not parser.extract_tool_calls(text).tools_called
+
+    def test_sibling_block_after_a_rejected_one_is_still_found(self):
+        """Skipping a rejected block must not skip what follows it."""
+        parser = LfmToolParser()
+        content, calls = _stream(parser, list('[index(0)] then [f({"a": 1})]'))
+
+        assert [c["function"]["name"] for c in calls] == ["f"]
+        assert content == "[index(0)] then "
+
     def test_unterminated_opener_masks_later_blocks_but_loses_nothing(self):
         """An opener with no ``]`` stops the walk — the safe failure.
 

--- a/vllm_mlx/tool_parsers/lfm_tool_parser.py
+++ b/vllm_mlx/tool_parsers/lfm_tool_parser.py
@@ -4,6 +4,16 @@ LFM / Liquid tool call parser for vllm-mlx.
 
 Handles Liquid AI's LFM model tool calling format:
 - Bracketed pythonic format: [func_name(arg1=val1, arg2=val2)]
+- Text-format envelope: [Calling tool: func_name({"arg1": "val1"})]
+
+The second dialect is one rapid-mlx teaches the model itself. ``LfmToolParser``
+reports ``SUPPORTS_NATIVE_TOOL_FORMAT = False`` (LFM chat templates drop
+``message.tool_calls`` entirely, so preserving the native shape would erase
+tool calls from the history), which makes ``api/utils.py`` serialise prior
+assistant calls into the prompt as ``[Calling tool: name({args})]``. Models
+imitate the transcript they are shown, so this form comes back on the wire
+and has to be understood here — see the module note on
+``_find_unclosed_markup_start``.
 """
 
 import ast
@@ -27,6 +37,43 @@ logger = logging.getLogger(__name__)
 # pre-check so all three agree on what counts as LFM markup.
 LFM_CALL_START = re.compile(r"\[\s*([A-Za-z_]\w*)\s*\(", re.DOTALL)
 _LFM_PARTIAL_START = re.compile(r"\[\s*(?:[A-Za-z_]\w*\s*(?:\(.*)?)?$", re.DOTALL)
+
+# ``[Calling tool: name({...})]`` — the text-format envelope described in
+# the module docstring. Case-sensitive on purpose: it mirrors both the
+# producer (``api/utils.py`` writes this exact literal) and the recovery
+# parsers that already understand it (``AutoToolParser.QWEN_BRACKET_PATTERN``,
+# ``api/tool_calling._iter_calling_tool_calls``). A looser matcher here
+# than in the recovery path is precisely the divergence that let this
+# markup stream to the client in the first place.
+TEXT_CALL_START = re.compile(r"\[\s*Calling\s+tool\s*:", re.DOTALL)
+
+# ``name(<json object>)`` — the envelope's payload.
+_TEXT_CALL_BODY = re.compile(r"([A-Za-z_][\w.-]*)\s*\((.*)\)", re.DOTALL)
+
+
+def _prefix_alternation(word: str) -> str:
+    """Regex source matching any non-empty prefix of ``word``.
+
+    ``"tool"`` becomes ``t(?:o(?:o(?:l)?)?)?`` — used to keep a partially
+    streamed envelope opener held back until enough bytes arrive to tell
+    markup from prose.
+    """
+    pattern = ""
+    for char in reversed(word):
+        pattern = re.escape(char) + (f"(?:{pattern})?" if pattern else "")
+    return pattern
+
+
+# Suffix of the accumulated text that may still GROW into ``TEXT_CALL_START``
+# (or into its argument payload, once the ``:`` has landed).
+_TEXT_CALL_PARTIAL_START = re.compile(
+    r"\[\s*(?:"
+    + _prefix_alternation("Calling")
+    + r"(?:\s+(?:"
+    + _prefix_alternation("tool")
+    + r"(?:\s*(?::.*)?)?)?)?)?$",
+    re.DOTALL,
+)
 
 
 def generate_tool_id() -> str:
@@ -65,9 +112,21 @@ def eval_node(node: ast.AST) -> Any:
 
 
 def _find_lfm_call_start(text: str, start: int = 0) -> int:
-    """Return the next ``[name(`` style LFM call start, or ``-1``."""
-    match = LFM_CALL_START.search(text, start)
-    return -1 if match is None else match.start()
+    """Return the next LFM call start, or ``-1``.
+
+    Both dialects count: the pythonic ``[name(`` and the text-format
+    ``[Calling tool:`` envelope. Whichever comes first wins so a turn
+    mixing the two is still walked left to right.
+    """
+    starts = [
+        match.start()
+        for match in (
+            LFM_CALL_START.search(text, start),
+            TEXT_CALL_START.search(text, start),
+        )
+        if match is not None
+    ]
+    return min(starts) if starts else -1
 
 
 def _extract_balanced_bracket_block(
@@ -117,15 +176,78 @@ def _extract_balanced_bracket_block(
     return None, text
 
 
+def _arguments_object(node: ast.AST) -> dict[str, Any] | None:
+    """Return the arguments mapping for a lone positional argument.
+
+    ``[browse({"url": "x"})]`` is the envelope's payload with the
+    ``Calling tool:`` prefix dropped — a single dict positional IS the
+    arguments object, unambiguously. Anything else (scalars, several
+    positionals, non-string keys) stays ``None`` so the caller rejects
+    the block.
+    """
+    if not isinstance(node, ast.Dict):
+        return None
+    value = eval_node(node)
+    if not isinstance(value, dict):
+        return None
+    if not all(isinstance(key, str) for key in value):
+        return None
+    return value
+
+
+def _parse_text_format_block(block: str) -> list[dict[str, Any]]:
+    """Parse a ``[Calling tool: name({...})]`` block into tool-call dicts.
+
+    Returns an empty list for anything that is not exactly that shape
+    (prose such as ``[Calling tool: see the docs]``), leaving the block
+    in the content.
+    """
+    marker = TEXT_CALL_START.match(block)
+    if marker is None:
+        return []
+
+    body = block[marker.end() :].strip()
+    if not body.endswith("]"):
+        return []
+    call = _TEXT_CALL_BODY.fullmatch(body[:-1].strip())
+    if call is None:
+        return []
+
+    raw_arguments = call.group(2).strip()
+    if not raw_arguments:
+        arguments: Any = {}
+    else:
+        try:
+            arguments = json.loads(raw_arguments)
+        except (json.JSONDecodeError, ValueError):
+            return []
+        if not isinstance(arguments, dict):
+            return []
+
+    return [
+        {
+            "id": generate_tool_id(),
+            "name": call.group(1),
+            "arguments": json.dumps(arguments, ensure_ascii=False),
+        }
+    ]
+
+
 def _parse_call_block(block: str) -> list[dict[str, Any]]:
     """Parse one balanced ``[...]`` block into tool-call dicts.
 
     Returns an empty list when the block is not a clean LFM call list.
-    A call carrying positional arguments rejects the WHOLE block:
+    A call carrying positional arguments rejects the WHOLE block —
     positional values cannot be mapped to named tool parameters, and
     emitting the call with empty/partial arguments would silently invoke
-    the tool wrong. Rejected blocks stay in the content instead.
+    the tool wrong. The one exception is a lone dict positional
+    (``[browse({"url": "x"})]``), which is the JSON arguments object of
+    the text-format dialect. Rejected blocks stay in the content instead.
     """
+    text_format_calls = _parse_text_format_block(block)
+    if text_format_calls:
+        return text_format_calls
+
     try:
         tree = ast.parse(block.strip())
     except SyntaxError:
@@ -141,9 +263,14 @@ def _parse_call_block(block: str) -> list[dict[str, Any]]:
     for elt in node.elts:
         if not (isinstance(elt, ast.Call) and isinstance(elt.func, ast.Name)):
             return []
+        arguments: dict[str, Any] = {}
         if elt.args:
-            return []
-        arguments = {}
+            if elt.keywords or len(elt.args) != 1:
+                return []
+            positional = _arguments_object(elt.args[0])
+            if positional is None:
+                return []
+            arguments = positional
         for kw in elt.keywords:
             if kw.arg is None:
                 return []
@@ -251,22 +378,8 @@ class LfmToolParser(ToolParser):
     @classmethod
     def _safe_content_prefix(cls, text: str) -> str:
         """Return text safe to emit without leaking partial LFM markup."""
-        start = _find_unclosed_lfm_call_start(text)
-        if start != -1:
-            return text[:start]
-
-        # Hold a tail that could still become ``[func(`` once more tokens
-        # arrive — but only while the bracket block is still unbalanced. A
-        # closed block is either an already-extracted tool call or plain
-        # content; holding it would suppress everything after a completed
-        # call for the rest of the stream.
-        last_bracket = text.rfind("[")
-        if last_bracket != -1 and _LFM_PARTIAL_START.fullmatch(text[last_bracket:]):
-            block, _ = _extract_balanced_bracket_block(text, last_bracket)
-            if block is None:
-                return text[:last_bracket]
-
-        return text
+        start = _find_unclosed_markup_start(text)
+        return text if start == -1 else text[:start]
 
     @classmethod
     def _emit_safe_content(
@@ -296,7 +409,7 @@ class LfmToolParser(ToolParser):
         if "[" not in current_text:
             return {"content": delta_text}
 
-        if LFM_CALL_START.search(current_text) is not None and "]" in delta_text:
+        if _find_lfm_call_start(current_text) != -1 and "]" in delta_text:
             result = self.extract_tool_calls(current_text)
             if (
                 result.tools_called
@@ -354,3 +467,50 @@ def _find_unclosed_lfm_call_start(text: str) -> int:
             return start
 
         search_from = start + len(bracket_block)
+
+
+def _may_grow_into_markup(tail: str) -> bool:
+    """True when ``tail`` (which begins at a ``[``) may still become markup."""
+    return bool(
+        _LFM_PARTIAL_START.fullmatch(tail) or _TEXT_CALL_PARTIAL_START.fullmatch(tail)
+    )
+
+
+def _find_unclosed_markup_start(text: str) -> int:
+    """Index of the first ``[`` that may still grow into tool markup.
+
+    Everything from that index on is held back: emitting it would leak
+    half-formed markup, and the bytes are cheap to keep until the block
+    either closes (tool call, or plain content released in one piece) or
+    the stream ends (``flush_held_content``).
+
+    Two properties matter, and the LFM streaming leak came from missing
+    both:
+
+    * The scan runs LEFT to RIGHT. Anchoring on the LAST ``[`` (the old
+      behaviour) breaks as soon as the argument payload contains one of
+      its own — the opener is released while the rest of the span is
+      still held, so the client sees a headless fragment.
+    * The hold covers the WHOLE opener, including the multi-word
+      ``[Calling tool:`` envelope. Releasing an opener the moment it
+      stops looking like ``[name(`` is what let ``[Calling tool`` reach
+      the wire, where the global sanitizer stripped exactly that span
+      and left ``: browse({...})]`` in the visible message.
+    """
+    search_from = 0
+    while True:
+        idx = text.find("[", search_from)
+        if idx == -1:
+            return -1
+
+        bracket_block, _ = _extract_balanced_bracket_block(text, idx)
+        if bracket_block is not None:
+            # Closed: either an already-extracted call or plain content.
+            # Holding it would suppress the rest of the stream.
+            search_from = idx + len(bracket_block)
+            continue
+        if _may_grow_into_markup(text[idx:]):
+            return idx
+        # Unbalanced but unmistakably prose (``a[i is fine``). A later
+        # ``[`` in the same span may still be a real opener.
+        search_from = idx + 1

--- a/vllm_mlx/tool_parsers/lfm_tool_parser.py
+++ b/vllm_mlx/tool_parsers/lfm_tool_parser.py
@@ -36,7 +36,12 @@ logger = logging.getLogger(__name__)
 # AutoToolParser and the streaming postprocessor's plausible-markup
 # pre-check so all three agree on what counts as LFM markup.
 LFM_CALL_START = re.compile(r"\[\s*([A-Za-z_]\w*)\s*\(", re.DOTALL)
-_LFM_PARTIAL_START = re.compile(r"\[\s*(?:[A-Za-z_]\w*\s*(?:\(.*)?)?$", re.DOTALL)
+
+# Suffix that may still GROW into ``LFM_CALL_START``. Deliberately free of
+# any ``.*``: it is evaluated once per ``[`` on every streamed delta, and a
+# trailing ``.*`` made each test cost the length of the remaining text. The
+# already-complete opener is matched by ``LFM_CALL_START`` itself.
+_LFM_PARTIAL_START = re.compile(r"\[\s*(?:[A-Za-z_]\w*\s*\(?)?$", re.DOTALL)
 
 # ``[Calling tool: name({...})]`` — the text-format envelope described in
 # the module docstring. Case-sensitive on purpose: it mirrors both the
@@ -64,14 +69,15 @@ def _prefix_alternation(word: str) -> str:
     return pattern
 
 
-# Suffix of the accumulated text that may still GROW into ``TEXT_CALL_START``
-# (or into its argument payload, once the ``:`` has landed).
+# Suffix that may still GROW into ``TEXT_CALL_START``. Same no-``.*`` rule as
+# ``_LFM_PARTIAL_START``: once the ``:`` has landed ``TEXT_CALL_START`` itself
+# matches, so this only has to cover the opener still being typed.
 _TEXT_CALL_PARTIAL_START = re.compile(
     r"\[\s*(?:"
     + _prefix_alternation("Calling")
     + r"(?:\s+(?:"
     + _prefix_alternation("tool")
-    + r"(?:\s*(?::.*)?)?)?)?)?$",
+    + r"\s*:?)?)?)?$",
     re.DOTALL,
 )
 
@@ -129,14 +135,14 @@ def _find_lfm_call_start(text: str, start: int = 0) -> int:
     return min(starts) if starts else -1
 
 
-def _extract_balanced_bracket_block(
-    text: str, start_idx: int
-) -> tuple[str | None, str]:
-    """
-    Return the balanced bracket block at ``start_idx`` and remaining text.
+def _balanced_block_end(text: str, start_idx: int) -> int:
+    """Index just past the balanced bracket block at ``start_idx``, or ``-1``.
 
     Nested brackets and quoted strings are accounted for so values like
     ``items=[1, 2]`` or ``query="]"`` do not prematurely close the block.
+    Quote state starts fresh at ``start_idx`` — a stray quote earlier in the
+    turn ("can't", an unfinished prose bracket) must never hide the markup
+    that follows it.
     """
     depth = 0
     in_string = False
@@ -169,11 +175,9 @@ def _extract_balanced_bracket_block(
         elif char == "]":
             depth -= 1
             if depth == 0:
-                bracket_block = text[start_idx : i + 1]
-                remaining = text[:start_idx] + text[i + 1 :]
-                return bracket_block, remaining
+                return i + 1
 
-    return None, text
+    return -1
 
 
 def _build_json_args_call(name: str, raw_arguments: str) -> list[dict[str, Any]]:
@@ -307,19 +311,19 @@ def _iter_call_blocks(text: str) -> list[tuple[int, int, list[dict[str, Any]]]]:
         start = _find_lfm_call_start(text, search_from)
         if start == -1:
             return blocks
-        block, _ = _extract_balanced_bracket_block(text, start)
-        if block is None:
+        end = _balanced_block_end(text, start)
+        if end == -1:
             return blocks
 
         try:
-            block_calls = _parse_call_block(block)
+            block_calls = _parse_call_block(text[start:end])
         except Exception as exc:
             logger.debug("Failed to parse LFM tool call: %s", exc)
             block_calls = []
 
         if block_calls:
-            blocks.append((start, start + len(block), block_calls))
-            search_from = start + len(block)
+            blocks.append((start, end, block_calls))
+            search_from = end
         else:
             search_from = start + 1
 
@@ -511,7 +515,11 @@ class LfmToolParser(ToolParser):
                 # before the tool-call event (the llama-parser precedent,
                 # StreamingPostProcessor._detect_tool_calls).
                 content = self._unconsumed_content(previous_text, current_text, blocks)
-                if content.strip():
+                if content:
+                    # Every byte, whitespace included: ``_unconsumed_content``
+                    # has already advanced the watermark past them, so
+                    # dropping whitespace here would make the output depend
+                    # on where the chunk boundary happened to fall.
                     out["content"] = content
                 return out
 
@@ -526,80 +534,40 @@ def _find_unclosed_lfm_call_start(text: str) -> int:
         if start == -1:
             return -1
 
-        bracket_block, _ = _extract_balanced_bracket_block(text, start)
-        if bracket_block is None:
+        end = _balanced_block_end(text, start)
+        if end == -1:
             return start
 
-        search_from = start + len(bracket_block)
+        search_from = end
 
 
-def _may_grow_into_markup(tail: str) -> bool:
-    """True when ``tail`` (which begins at a ``[``) may still become markup."""
+def _may_grow_into_markup(text: str, idx: int) -> bool:
+    """True when the suffix at ``idx`` (a ``[``) is or may become markup.
+
+    Matched with ``pos`` rather than a slice: this runs once per ``[`` on
+    every streamed delta, and slicing the tail would make each test cost
+    the length of the remaining text.
+    """
     return bool(
-        _LFM_PARTIAL_START.fullmatch(tail) or _TEXT_CALL_PARTIAL_START.fullmatch(tail)
+        LFM_CALL_START.match(text, idx)
+        or TEXT_CALL_START.match(text, idx)
+        or _LFM_PARTIAL_START.fullmatch(text, idx)
+        or _TEXT_CALL_PARTIAL_START.fullmatch(text, idx)
     )
 
 
-def _unclosed_bracket_starts(text: str) -> list[int]:
-    """Indices of every ``[`` still open at the end of ``text``, outermost first.
-
-    One left-to-right pass, so this stays linear where a
-    ``_extract_balanced_bracket_block`` call per ``[`` would be quadratic
-    (``"[!" * n`` re-scans the whole suffix for every opener, and the
-    streaming path runs this on every delta).
-
-    Quote and escape state is tracked only INSIDE a block. At depth 0 an
-    apostrophe is just prose — treating ``don't`` as an open string would
-    swallow every ``[`` in the rest of the turn, including real markup.
-    Inside a block the state matches ``_extract_balanced_bracket_block``
-    exactly, which is what protects ``query="]"``.
-    """
-    stack: list[int] = []
-    in_string = False
-    string_char = ""
-    escaped = False
-
-    for i, char in enumerate(text):
-        if not stack:
-            if char == "[":
-                stack.append(i)
-            continue
-
-        if escaped:
-            escaped = False
-            continue
-        if char == "\\":
-            escaped = True
-            continue
-        if in_string:
-            if char == string_char:
-                in_string = False
-            continue
-        if char in ('"', "'"):
-            in_string = True
-            string_char = char
-            continue
-
-        if char == "[":
-            stack.append(i)
-        elif char == "]":
-            stack.pop()
-
-    return stack
-
-
 def _find_unclosed_markup_start(text: str) -> int:
-    """Index of the outermost still-open ``[`` that may become tool markup.
+    """Index of the first ``[`` that is markup and has no matching ``]``.
 
     Everything from that index on is held back: emitting it would leak
     half-formed markup, and the bytes are cheap to keep until the block
     either closes (tool call, or plain content released in one piece) or
     the stream ends (``flush_held_content``).
 
-    Two properties matter, and the LFM streaming leak came from missing
-    both:
+    Three properties matter, and the LFM streaming leak came from missing
+    the first two:
 
-    * The scan runs OUTERMOST first. Anchoring on the LAST ``[`` (the old
+    * The scan runs LEFT to RIGHT. Anchoring on the LAST ``[`` (the old
       behaviour) breaks as soon as the argument payload contains one of
       its own — the opener is released while the rest of the span is
       still held, so the client sees a headless fragment.
@@ -608,11 +576,28 @@ def _find_unclosed_markup_start(text: str) -> int:
       stops looking like ``[name(`` is what let ``[Calling tool`` reach
       the wire, where the global sanitizer stripped exactly that span
       and left ``: browse({...})]`` in the visible message.
+    * Balance is judged per candidate, with quote state starting fresh at
+      that ``[``. Carrying quote state across the whole turn would let an
+      unfinished prose bracket (``See [note "unfinished``) hide the real
+      opener that follows it inside the apparent string.
 
-    An unbalanced ``[`` that is unmistakably prose (``a[i is fine``) is
-    skipped: a ``[`` nested inside it may still be a real opener.
+    Cost is linear in ``len(text)``: the markup test is bounded (no
+    ``.*``), so the balance scan only runs for genuine candidates, and
+    each balanced candidate advances the cursor past its own block.
     """
-    for idx in _unclosed_bracket_starts(text):
-        if _may_grow_into_markup(text[idx:]):
+    search_from = 0
+    while True:
+        idx = text.find("[", search_from)
+        if idx == -1:
+            return -1
+        if not _may_grow_into_markup(text, idx):
+            # Unmistakably prose (``a[i is fine``). A ``[`` nested inside
+            # it may still be a real opener, so keep looking.
+            search_from = idx + 1
+            continue
+        end = _balanced_block_end(text, idx)
+        if end == -1:
             return idx
-    return -1
+        # Closed: either an already-extracted call or plain content.
+        # Holding it would suppress the rest of the stream.
+        search_from = end

--- a/vllm_mlx/tool_parsers/lfm_tool_parser.py
+++ b/vllm_mlx/tool_parsers/lfm_tool_parser.py
@@ -326,14 +326,16 @@ def _iter_call_blocks(text: str) -> list[tuple[int, int, list[dict[str, Any]]]]:
     content bytes — the streaming path needs that to emit prose that
     shares a delta with a completed call instead of dropping it.
 
-    The walk STOPS at the first opener with no matching ``]``, rather than
-    hunting for a later block that might close. Mid-stream that opener is
-    simply the call still being written, and its argument payload can
-    contain anything — including a literal ``[g({})]`` inside a JSON
-    string. Probing past it would dispatch that string's contents as a
-    tool call, at an index the count-based dedup below can never retract
-    once the real call arrives. A malformed opener therefore masks any
-    block after it; that text stays content, which is the safe failure.
+    The walk NEVER descends into a block's payload, whether that block was
+    accepted or rejected, and STOPS at the first opener with no matching
+    ``]``. A payload can contain anything — including a literal
+    ``[g({})]`` inside a JSON string argument — and dispatching a tool
+    call out of another call's string data is irreversible: the
+    count-based dedup below can never retract it once the real call
+    arrives. So a rejected block resumes at its own end, and an
+    unterminated opener (mid-stream, simply the call still being written)
+    masks whatever follows. Both leave the text as content, the safe
+    failure.
     """
     blocks: list[tuple[int, int, list[dict[str, Any]]]] = []
     search_from = 0
@@ -354,9 +356,9 @@ def _iter_call_blocks(text: str) -> list[tuple[int, int, list[dict[str, Any]]]]:
 
         if block_calls:
             blocks.append((start, end, block_calls))
-            search_from = end
-        else:
-            search_from = start + 1
+        # Sibling blocks after this span are still discovered; only its
+        # own payload is off limits.
+        search_from = end
 
 
 def parse_lfm_tool_calls(model_output: str) -> tuple[list[dict[str, Any]], str]:

--- a/vllm_mlx/tool_parsers/lfm_tool_parser.py
+++ b/vllm_mlx/tool_parsers/lfm_tool_parser.py
@@ -52,8 +52,28 @@ _LFM_PARTIAL_START = re.compile(r"\[\s*(?:[A-Za-z_]\w*\s*\(?)?$", re.DOTALL)
 # markup stream to the client in the first place.
 TEXT_CALL_START = re.compile(r"\[\s*Calling\s+tool\s*:", re.DOTALL)
 
+# Tool names in the text-format dialect follow the OpenAI function-name
+# charset (``api/models._FUNCTION_NAME_PATTERN``) plus ``.``, matching what
+# the cross-format recovery parser accepts — NOT Python identifier rules.
+# ``my-tool`` and ``2fa`` are legal names a client may register, and the
+# streaming path has to hold their markup back for the same reason as any
+# other: otherwise the recovery path extracts the call at finalize while
+# the raw span has already streamed to the user.
+_TOOL_NAME = r"[A-Za-z0-9_.-]{1,64}"
+
+# ``[name({`` — the envelope with its ``Calling tool:`` prefix dropped.
+# The ``{`` is required so this can only claim the JSON-arguments dialect,
+# never a pythonic call (``[index(0)]``) or ordinary prose.
+JSON_CALL_START = re.compile(r"\[\s*" + _TOOL_NAME + r"\s*\(\s*\{", re.DOTALL)
+
+# Suffix that may still grow into ``JSON_CALL_START``. Same no-``.*`` rule
+# as the other partial patterns.
+_JSON_CALL_PARTIAL_START = re.compile(
+    r"\[\s*(?:" + _TOOL_NAME + r"\s*(?:\(\s*\{?)?)?$", re.DOTALL
+)
+
 # ``name(<json object>)`` — the envelope's payload.
-_TEXT_CALL_BODY = re.compile(r"([A-Za-z_][\w.-]*)\s*\((.*)\)", re.DOTALL)
+_TEXT_CALL_BODY = re.compile(r"(" + _TOOL_NAME + r")\s*\((.*)\)", re.DOTALL)
 
 
 def _prefix_alternation(word: str) -> str:
@@ -120,15 +140,17 @@ def eval_node(node: ast.AST) -> Any:
 def _find_lfm_call_start(text: str, start: int = 0) -> int:
     """Return the next LFM call start, or ``-1``.
 
-    Both dialects count: the pythonic ``[name(`` and the text-format
-    ``[Calling tool:`` envelope. Whichever comes first wins so a turn
-    mixing the two is still walked left to right.
+    All three dialects count: the pythonic ``[name(``, the text-format
+    ``[Calling tool:`` envelope, and its prefix-less ``[name({`` form.
+    Whichever comes first wins so a turn mixing them is still walked left
+    to right.
     """
     starts = [
         match.start()
         for match in (
             LFM_CALL_START.search(text, start),
             TEXT_CALL_START.search(text, start),
+            JSON_CALL_START.search(text, start),
         )
         if match is not None
     ]
@@ -361,7 +383,10 @@ class LfmToolParser(ToolParser):
     """
 
     SUPPORTS_NATIVE_TOOL_FORMAT = False
-    EXPECTED_WIRE_FORMATS = ("pythonic_bracket",)
+    # ``calling_tool_text`` is not aspirational: because this parser reports
+    # no native tool format, ``api/utils.py`` writes prior tool calls into
+    # the prompt in exactly that shape and the model echoes it back.
+    EXPECTED_WIRE_FORMATS = ("pythonic_bracket", "calling_tool_text")
 
     def __init__(self, tokenizer=None):
         super().__init__(tokenizer)
@@ -551,8 +576,10 @@ def _may_grow_into_markup(text: str, idx: int) -> bool:
     return bool(
         LFM_CALL_START.match(text, idx)
         or TEXT_CALL_START.match(text, idx)
+        or JSON_CALL_START.match(text, idx)
         or _LFM_PARTIAL_START.fullmatch(text, idx)
         or _TEXT_CALL_PARTIAL_START.fullmatch(text, idx)
+        or _JSON_CALL_PARTIAL_START.fullmatch(text, idx)
     )
 
 

--- a/vllm_mlx/tool_parsers/lfm_tool_parser.py
+++ b/vllm_mlx/tool_parsers/lfm_tool_parser.py
@@ -319,6 +319,16 @@ def _parse_call_block(block: str) -> list[dict[str, Any]]:
     return calls
 
 
+#: How many unterminated openers ``_iter_call_blocks`` steps over before
+#: giving up. An opener whose ``]`` never arrives makes every later block
+#: look nested inside it, so bailing on the first one loses a perfectly
+#: good call that follows malformed markup. Stepping over it costs one
+#: full-tail scan, hence a budget: well-formed output needs none, real
+#: malformed output needs one or two, and a crafted response full of
+#: unterminated openers cannot turn the walk quadratic.
+_MAX_UNTERMINATED_PROBES = 8
+
+
 def _iter_call_blocks(text: str) -> list[tuple[int, int, list[dict[str, Any]]]]:
     """Return ``(start, end, calls)`` for every parsed call block, in order.
 
@@ -328,6 +338,7 @@ def _iter_call_blocks(text: str) -> list[tuple[int, int, list[dict[str, Any]]]]:
     """
     blocks: list[tuple[int, int, list[dict[str, Any]]]] = []
     search_from = 0
+    probes_left = _MAX_UNTERMINATED_PROBES
 
     while True:
         start = _find_lfm_call_start(text, search_from)
@@ -335,7 +346,12 @@ def _iter_call_blocks(text: str) -> list[tuple[int, int, list[dict[str, Any]]]]:
             return blocks
         end = _balanced_block_end(text, start)
         if end == -1:
-            return blocks
+            # Nothing later can close either when no ``]`` remains at all.
+            if probes_left <= 0 or text.find("]", start) == -1:
+                return blocks
+            probes_left -= 1
+            search_from = start + 1
+            continue
 
         try:
             block_calls = _parse_call_block(text[start:end])
@@ -439,10 +455,18 @@ class LfmToolParser(ToolParser):
         )
 
     @classmethod
-    def _safe_content_prefix(cls, text: str) -> str:
-        """Return text safe to emit without leaking partial LFM markup."""
-        start = _find_unclosed_markup_start(text)
-        return text if start == -1 else text[:start]
+    def _safe_content_prefix(cls, text: str, floor: int = 0) -> str:
+        """Return text safe to emit without leaking partial LFM markup.
+
+        ``floor`` is the offset past which the text is already settled —
+        everything before it has been emitted as content or consumed as a
+        call block. Markup that starts before the floor must not keep
+        holding bytes that come after a completed call: a malformed opener
+        earlier in the turn would otherwise swallow the rest of the reply,
+        and the EOF flush is skipped once a call has fired.
+        """
+        start = _find_unclosed_markup_start(text[floor:] if floor else text)
+        return text if start == -1 else text[: floor + start]
 
     def _emitted_boundary(self, previous_text: str) -> int:
         """Bytes of the accumulated text already accounted for.
@@ -453,12 +477,13 @@ class LfmToolParser(ToolParser):
         must not be re-emitted as content. ``_consumed_len`` only raises
         the floor for what the tool-call branch consumed on top.
         """
-        return max(len(self._safe_content_prefix(previous_text)), self._consumed_len)
+        settled = self._safe_content_prefix(previous_text, self._consumed_len)
+        return max(len(settled), self._consumed_len)
 
     def _emit_safe_content(
         self, previous_text: str, current_text: str
     ) -> dict[str, Any] | None:
-        safe_current = self._safe_content_prefix(current_text)
+        safe_current = self._safe_content_prefix(current_text, self._consumed_len)
         boundary = self._emitted_boundary(previous_text)
         if len(safe_current) <= boundary:
             return None
@@ -485,7 +510,9 @@ class LfmToolParser(ToolParser):
                 pieces.append(current_text[cursor:start])
             cursor = max(cursor, end)
 
-        safe_end = len(self._safe_content_prefix(current_text))
+        # Past the last block only markup that starts THERE can still hold
+        # bytes back; anything earlier is settled by construction.
+        safe_end = len(self._safe_content_prefix(current_text, cursor))
         if safe_end > cursor:
             pieces.append(current_text[cursor:safe_end])
             cursor = safe_end
@@ -495,7 +522,8 @@ class LfmToolParser(ToolParser):
 
     def flush_held_content(self, full_text: str) -> str:
         """Release any held non-tool bracket prefix at stream end."""
-        return full_text[len(self._safe_content_prefix(full_text)) :]
+        settled = self._safe_content_prefix(full_text, self._consumed_len)
+        return full_text[len(settled) :]
 
     def extract_tool_calls_streaming(
         self,

--- a/vllm_mlx/tool_parsers/lfm_tool_parser.py
+++ b/vllm_mlx/tool_parsers/lfm_tool_parser.py
@@ -319,26 +319,24 @@ def _parse_call_block(block: str) -> list[dict[str, Any]]:
     return calls
 
 
-#: How many unterminated openers ``_iter_call_blocks`` steps over before
-#: giving up. An opener whose ``]`` never arrives makes every later block
-#: look nested inside it, so bailing on the first one loses a perfectly
-#: good call that follows malformed markup. Stepping over it costs one
-#: full-tail scan, hence a budget: well-formed output needs none, real
-#: malformed output needs one or two, and a crafted response full of
-#: unterminated openers cannot turn the walk quadratic.
-_MAX_UNTERMINATED_PROBES = 8
-
-
 def _iter_call_blocks(text: str) -> list[tuple[int, int, list[dict[str, Any]]]]:
     """Return ``(start, end, calls)`` for every parsed call block, in order.
 
     Offsets are into ``text`` itself so callers can tell block bytes from
     content bytes — the streaming path needs that to emit prose that
     shares a delta with a completed call instead of dropping it.
+
+    The walk STOPS at the first opener with no matching ``]``, rather than
+    hunting for a later block that might close. Mid-stream that opener is
+    simply the call still being written, and its argument payload can
+    contain anything — including a literal ``[g({})]`` inside a JSON
+    string. Probing past it would dispatch that string's contents as a
+    tool call, at an index the count-based dedup below can never retract
+    once the real call arrives. A malformed opener therefore masks any
+    block after it; that text stays content, which is the safe failure.
     """
     blocks: list[tuple[int, int, list[dict[str, Any]]]] = []
     search_from = 0
-    probes_left = _MAX_UNTERMINATED_PROBES
 
     while True:
         start = _find_lfm_call_start(text, search_from)
@@ -346,12 +344,7 @@ def _iter_call_blocks(text: str) -> list[tuple[int, int, list[dict[str, Any]]]]:
             return blocks
         end = _balanced_block_end(text, start)
         if end == -1:
-            # Nothing later can close either when no ``]`` remains at all.
-            if probes_left <= 0 or text.find("]", start) == -1:
-                return blocks
-            probes_left -= 1
-            search_from = start + 1
-            continue
+            return blocks
 
         try:
             block_calls = _parse_call_block(text[start:end])
@@ -455,18 +448,10 @@ class LfmToolParser(ToolParser):
         )
 
     @classmethod
-    def _safe_content_prefix(cls, text: str, floor: int = 0) -> str:
-        """Return text safe to emit without leaking partial LFM markup.
-
-        ``floor`` is the offset past which the text is already settled —
-        everything before it has been emitted as content or consumed as a
-        call block. Markup that starts before the floor must not keep
-        holding bytes that come after a completed call: a malformed opener
-        earlier in the turn would otherwise swallow the rest of the reply,
-        and the EOF flush is skipped once a call has fired.
-        """
-        start = _find_unclosed_markup_start(text[floor:] if floor else text)
-        return text if start == -1 else text[: floor + start]
+    def _safe_content_prefix(cls, text: str) -> str:
+        """Return text safe to emit without leaking partial LFM markup."""
+        start = _find_unclosed_markup_start(text)
+        return text if start == -1 else text[:start]
 
     def _emitted_boundary(self, previous_text: str) -> int:
         """Bytes of the accumulated text already accounted for.
@@ -477,13 +462,12 @@ class LfmToolParser(ToolParser):
         must not be re-emitted as content. ``_consumed_len`` only raises
         the floor for what the tool-call branch consumed on top.
         """
-        settled = self._safe_content_prefix(previous_text, self._consumed_len)
-        return max(len(settled), self._consumed_len)
+        return max(len(self._safe_content_prefix(previous_text)), self._consumed_len)
 
     def _emit_safe_content(
         self, previous_text: str, current_text: str
     ) -> dict[str, Any] | None:
-        safe_current = self._safe_content_prefix(current_text, self._consumed_len)
+        safe_current = self._safe_content_prefix(current_text)
         boundary = self._emitted_boundary(previous_text)
         if len(safe_current) <= boundary:
             return None
@@ -510,9 +494,10 @@ class LfmToolParser(ToolParser):
                 pieces.append(current_text[cursor:start])
             cursor = max(cursor, end)
 
-        # Past the last block only markup that starts THERE can still hold
-        # bytes back; anything earlier is settled by construction.
-        safe_end = len(self._safe_content_prefix(current_text, cursor))
+        # No unterminated opener can precede an extracted block — the walk
+        # in ``_iter_call_blocks`` stops at the first one — so the hold, if
+        # any, starts after the blocks and this prefix is never short.
+        safe_end = len(self._safe_content_prefix(current_text))
         if safe_end > cursor:
             pieces.append(current_text[cursor:safe_end])
             cursor = safe_end
@@ -522,8 +507,7 @@ class LfmToolParser(ToolParser):
 
     def flush_held_content(self, full_text: str) -> str:
         """Release any held non-tool bracket prefix at stream end."""
-        settled = self._safe_content_prefix(full_text, self._consumed_len)
-        return full_text[len(settled) :]
+        return full_text[len(self._safe_content_prefix(full_text)) :]
 
     def extract_tool_calls_streaming(
         self,

--- a/vllm_mlx/tool_parsers/lfm_tool_parser.py
+++ b/vllm_mlx/tool_parsers/lfm_tool_parser.py
@@ -176,23 +176,33 @@ def _extract_balanced_bracket_block(
     return None, text
 
 
-def _arguments_object(node: ast.AST) -> dict[str, Any] | None:
-    """Return the arguments mapping for a lone positional argument.
+def _build_json_args_call(name: str, raw_arguments: str) -> list[dict[str, Any]]:
+    """Build a one-element tool-call list from a JSON arguments payload.
 
-    ``[browse({"url": "x"})]`` is the envelope's payload with the
-    ``Calling tool:`` prefix dropped — a single dict positional IS the
-    arguments object, unambiguously. Anything else (scalars, several
-    positionals, non-string keys) stays ``None`` so the caller rejects
-    the block.
+    The payload MUST be parsed as JSON, never as a Python literal: the
+    dialect writes ``true`` / ``false`` / ``null``, which ``ast`` reads as
+    bare names and ``eval_node`` would turn into the strings ``"true"`` /
+    ``"false"`` / ``"null"`` — a tool invoked with materially wrong
+    arguments. Anything that is not a JSON object rejects the block.
     """
-    if not isinstance(node, ast.Dict):
-        return None
-    value = eval_node(node)
-    if not isinstance(value, dict):
-        return None
-    if not all(isinstance(key, str) for key in value):
-        return None
-    return value
+    raw = raw_arguments.strip()
+    if not raw:
+        arguments: Any = {}
+    else:
+        try:
+            arguments = json.loads(raw)
+        except (json.JSONDecodeError, ValueError):
+            return []
+        if not isinstance(arguments, dict):
+            return []
+
+    return [
+        {
+            "id": generate_tool_id(),
+            "name": name,
+            "arguments": json.dumps(arguments, ensure_ascii=False),
+        }
+    ]
 
 
 def _parse_text_format_block(block: str) -> list[dict[str, Any]]:
@@ -212,41 +222,44 @@ def _parse_text_format_block(block: str) -> list[dict[str, Any]]:
     call = _TEXT_CALL_BODY.fullmatch(body[:-1].strip())
     if call is None:
         return []
+    return _build_json_args_call(call.group(1), call.group(2))
 
-    raw_arguments = call.group(2).strip()
-    if not raw_arguments:
-        arguments: Any = {}
-    else:
-        try:
-            arguments = json.loads(raw_arguments)
-        except (json.JSONDecodeError, ValueError):
-            return []
-        if not isinstance(arguments, dict):
-            return []
 
-    return [
-        {
-            "id": generate_tool_id(),
-            "name": call.group(1),
-            "arguments": json.dumps(arguments, ensure_ascii=False),
-        }
-    ]
+def _parse_bracket_json_block(block: str) -> list[dict[str, Any]]:
+    """Parse ``[name({...})]`` — the envelope with its prefix dropped.
+
+    Only a payload that already starts with ``{`` is claimed here; a
+    pythonic call (``[f(x=1)]``, ``[index(0)]``) falls through to the AST
+    path below, which keeps its stricter rules.
+    """
+    inner = block.strip()
+    if not (inner.startswith("[") and inner.endswith("]")):
+        return []
+    call = _TEXT_CALL_BODY.fullmatch(inner[1:-1].strip())
+    if call is None:
+        return []
+    if not call.group(2).strip().startswith("{"):
+        return []
+    return _build_json_args_call(call.group(1), call.group(2))
 
 
 def _parse_call_block(block: str) -> list[dict[str, Any]]:
     """Parse one balanced ``[...]`` block into tool-call dicts.
 
-    Returns an empty list when the block is not a clean LFM call list.
-    A call carrying positional arguments rejects the WHOLE block —
-    positional values cannot be mapped to named tool parameters, and
-    emitting the call with empty/partial arguments would silently invoke
-    the tool wrong. The one exception is a lone dict positional
-    (``[browse({"url": "x"})]``), which is the JSON arguments object of
-    the text-format dialect. Rejected blocks stay in the content instead.
+    Three shapes are accepted: the ``[Calling tool: name({json})]``
+    envelope, its prefix-less ``[name({json})]`` form, and the pythonic
+    ``[name(arg=val), ...]`` list.
+
+    Returns an empty list when the block is none of those. In the
+    pythonic form a call carrying positional arguments rejects the WHOLE
+    block: positional values cannot be mapped to named tool parameters,
+    and emitting the call with empty/partial arguments would silently
+    invoke the tool wrong. Rejected blocks stay in the content instead.
     """
-    text_format_calls = _parse_text_format_block(block)
-    if text_format_calls:
-        return text_format_calls
+    for parse in (_parse_text_format_block, _parse_bracket_json_block):
+        calls = parse(block)
+        if calls:
+            return calls
 
     try:
         tree = ast.parse(block.strip())
@@ -259,18 +272,13 @@ def _parse_call_block(block: str) -> list[dict[str, Any]]:
     if not isinstance(node, ast.List):
         return []
 
-    calls: list[dict[str, Any]] = []
+    calls = []
     for elt in node.elts:
         if not (isinstance(elt, ast.Call) and isinstance(elt.func, ast.Name)):
             return []
-        arguments: dict[str, Any] = {}
         if elt.args:
-            if elt.keywords or len(elt.args) != 1:
-                return []
-            positional = _arguments_object(elt.args[0])
-            if positional is None:
-                return []
-            arguments = positional
+            return []
+        arguments = {}
         for kw in elt.keywords:
             if kw.arg is None:
                 return []
@@ -285,41 +293,57 @@ def _parse_call_block(block: str) -> list[dict[str, Any]]:
     return calls
 
 
-def parse_lfm_tool_calls(model_output: str) -> tuple[list[dict[str, Any]], str]:
-    """Parse LFM pythonic tool calls and return ``(tool_calls, cleaned_text)``.
+def _iter_call_blocks(text: str) -> list[tuple[int, int, list[dict[str, Any]]]]:
+    """Return ``(start, end, calls)`` for every parsed call block, in order.
 
-    Every ``[name(...)]`` block in the output is considered — LFM may emit
-    several separate blocks, not just one list. Blocks that don't parse as
-    clean call lists (prose, positional args) are left in the content.
+    Offsets are into ``text`` itself so callers can tell block bytes from
+    content bytes — the streaming path needs that to emit prose that
+    shares a delta with a completed call instead of dropping it.
     """
-    tool_calls: list[dict[str, Any]] = []
-    text = model_output
+    blocks: list[tuple[int, int, list[dict[str, Any]]]] = []
     search_from = 0
 
     while True:
         start = _find_lfm_call_start(text, search_from)
         if start == -1:
-            break
-        block, remaining = _extract_balanced_bracket_block(text, start)
+            return blocks
+        block, _ = _extract_balanced_bracket_block(text, start)
         if block is None:
-            break
+            return blocks
 
         try:
             block_calls = _parse_call_block(block)
         except Exception as exc:
-            logger.debug("Failed to parse LFM pythonic tool call: %s", exc)
+            logger.debug("Failed to parse LFM tool call: %s", exc)
             block_calls = []
 
         if block_calls:
-            tool_calls.extend(block_calls)
-            text = remaining
-            search_from = start
+            blocks.append((start, start + len(block), block_calls))
+            search_from = start + len(block)
         else:
             search_from = start + 1
 
-    if not tool_calls:
+
+def parse_lfm_tool_calls(model_output: str) -> tuple[list[dict[str, Any]], str]:
+    """Parse LFM tool calls and return ``(tool_calls, cleaned_text)``.
+
+    Every call block in the output is considered — LFM may emit several
+    separate blocks, not just one list. Blocks that don't parse as clean
+    calls (prose, positional args) are left in the content.
+    """
+    blocks = _iter_call_blocks(model_output)
+    if not blocks:
         return [], model_output
-    return tool_calls, text
+
+    tool_calls: list[dict[str, Any]] = []
+    kept: list[str] = []
+    cursor = 0
+    for start, end, block_calls in blocks:
+        tool_calls.extend(block_calls)
+        kept.append(model_output[cursor:start])
+        cursor = end
+    kept.append(model_output[cursor:])
+    return tool_calls, "".join(kept)
 
 
 @ToolParserManager.register_module(["lfm", "liquid"])
@@ -349,10 +373,20 @@ class LfmToolParser(ToolParser):
         # Parser instances are per-request (see StreamingPostProcessor), so
         # this counter never leaks across streams.
         self._emitted_tool_count = 0
+        # Bytes of the accumulated text already accounted for — emitted as
+        # content OR consumed as a tool-call block. Tracking one watermark
+        # instead of diffing ``previous_text`` against ``current_text`` is
+        # what lets the tool-call branch emit prose that shares a delta
+        # with a completed block: after the call is built, everything from
+        # the watermark up to the safe boundary that is not block bytes is
+        # still content and must reach the client. The EOF flush is skipped
+        # once a call fires, so anything not emitted here is lost.
+        self._consumed_len = 0
 
     def reset(self) -> None:
         super().reset()
         self._emitted_tool_count = 0
+        self._consumed_len = 0
 
     def has_pending_tool_call(self, text: str) -> bool:
         return _find_unclosed_lfm_call_start(text) != -1
@@ -381,15 +415,54 @@ class LfmToolParser(ToolParser):
         start = _find_unclosed_markup_start(text)
         return text if start == -1 else text[:start]
 
-    @classmethod
+    def _emitted_boundary(self, previous_text: str) -> int:
+        """Bytes of the accumulated text already accounted for.
+
+        ``previous_text`` is authoritative — the postprocessor may seed it
+        with a forced-``tool_choice`` assistant prefix the parser never
+        saw as a delta (``seed_forced_assistant_prefix``), and those bytes
+        must not be re-emitted as content. ``_consumed_len`` only raises
+        the floor for what the tool-call branch consumed on top.
+        """
+        return max(len(self._safe_content_prefix(previous_text)), self._consumed_len)
+
     def _emit_safe_content(
-        cls, previous_text: str, current_text: str
+        self, previous_text: str, current_text: str
     ) -> dict[str, Any] | None:
-        safe_current = cls._safe_content_prefix(current_text)
-        safe_previous = cls._safe_content_prefix(previous_text)
-        if len(safe_current) <= len(safe_previous):
+        safe_current = self._safe_content_prefix(current_text)
+        boundary = self._emitted_boundary(previous_text)
+        if len(safe_current) <= boundary:
             return None
-        return {"content": safe_current[len(safe_previous) :]}
+        self._consumed_len = len(safe_current)
+        return {"content": safe_current[boundary:]}
+
+    def _unconsumed_content(
+        self,
+        previous_text: str,
+        current_text: str,
+        blocks: list[tuple[int, int, Any]],
+    ) -> str:
+        """Content bytes not yet emitted and not part of a call block.
+
+        Advances the watermark past everything it returns, so a later
+        delta cannot re-emit the same bytes.
+        """
+        pieces: list[str] = []
+        cursor = self._emitted_boundary(previous_text)
+        for start, end, _ in blocks:
+            if end <= cursor:
+                continue
+            if start > cursor:
+                pieces.append(current_text[cursor:start])
+            cursor = max(cursor, end)
+
+        safe_end = len(self._safe_content_prefix(current_text))
+        if safe_end > cursor:
+            pieces.append(current_text[cursor:safe_end])
+            cursor = safe_end
+
+        self._consumed_len = max(self._consumed_len, cursor)
+        return "".join(pieces)
 
     def flush_held_content(self, full_text: str) -> str:
         """Release any held non-tool bracket prefix at stream end."""
@@ -410,14 +483,12 @@ class LfmToolParser(ToolParser):
             return {"content": delta_text}
 
         if _find_lfm_call_start(current_text) != -1 and "]" in delta_text:
-            result = self.extract_tool_calls(current_text)
-            if (
-                result.tools_called
-                and len(result.tool_calls) > self._emitted_tool_count
-            ):
+            blocks = _iter_call_blocks(current_text)
+            total_calls = sum(len(calls) for _, _, calls in blocks)
+            if total_calls > self._emitted_tool_count:
                 base = self._emitted_tool_count
-                new_calls = result.tool_calls[base:]
-                self._emitted_tool_count = len(result.tool_calls)
+                new_calls = [tc for _, _, calls in blocks for tc in calls][base:]
+                self._emitted_tool_count = total_calls
                 out: dict[str, Any] = {
                     "tool_calls": [
                         {
@@ -432,23 +503,16 @@ class LfmToolParser(ToolParser):
                         for i, tc in enumerate(new_calls)
                     ]
                 }
-                # If a prose preface and the first completed call land in
-                # the SAME delta (batched chunk / finalize / single-shot
-                # stream), the leading prose was never emitted — and once a
-                # tool fires, the EOF ``flush_held_content`` path is skipped,
-                # so it would be lost. Emit the un-emitted leading content in
-                # the same return; the postprocessor renders the content
-                # event before the tool-call event (the llama-parser
-                # precedent, StreamingPostProcessor._detect_tool_calls). Only
-                # the FIRST emission needs this — content between/after later
-                # blocks streams through ``_emit_safe_content`` normally.
-                if base == 0:
-                    first_block = _find_lfm_call_start(current_text)
-                    already = len(self._safe_content_prefix(previous_text))
-                    if 0 <= already < first_block:
-                        lead = current_text[already:first_block]
-                        if lead.strip():
-                            out["content"] = lead
+                # Prose that shares a delta with a completed call (batched
+                # chunk / finalize / single-shot stream) was never emitted,
+                # and once a tool fires the EOF ``flush_held_content`` path
+                # is skipped — so it has to go out in this same return or
+                # it is lost. The postprocessor renders the content event
+                # before the tool-call event (the llama-parser precedent,
+                # StreamingPostProcessor._detect_tool_calls).
+                content = self._unconsumed_content(previous_text, current_text, blocks)
+                if content.strip():
+                    out["content"] = content
                 return out
 
         return self._emit_safe_content(previous_text, current_text)
@@ -476,8 +540,56 @@ def _may_grow_into_markup(tail: str) -> bool:
     )
 
 
+def _unclosed_bracket_starts(text: str) -> list[int]:
+    """Indices of every ``[`` still open at the end of ``text``, outermost first.
+
+    One left-to-right pass, so this stays linear where a
+    ``_extract_balanced_bracket_block`` call per ``[`` would be quadratic
+    (``"[!" * n`` re-scans the whole suffix for every opener, and the
+    streaming path runs this on every delta).
+
+    Quote and escape state is tracked only INSIDE a block. At depth 0 an
+    apostrophe is just prose — treating ``don't`` as an open string would
+    swallow every ``[`` in the rest of the turn, including real markup.
+    Inside a block the state matches ``_extract_balanced_bracket_block``
+    exactly, which is what protects ``query="]"``.
+    """
+    stack: list[int] = []
+    in_string = False
+    string_char = ""
+    escaped = False
+
+    for i, char in enumerate(text):
+        if not stack:
+            if char == "[":
+                stack.append(i)
+            continue
+
+        if escaped:
+            escaped = False
+            continue
+        if char == "\\":
+            escaped = True
+            continue
+        if in_string:
+            if char == string_char:
+                in_string = False
+            continue
+        if char in ('"', "'"):
+            in_string = True
+            string_char = char
+            continue
+
+        if char == "[":
+            stack.append(i)
+        elif char == "]":
+            stack.pop()
+
+    return stack
+
+
 def _find_unclosed_markup_start(text: str) -> int:
-    """Index of the first ``[`` that may still grow into tool markup.
+    """Index of the outermost still-open ``[`` that may become tool markup.
 
     Everything from that index on is held back: emitting it would leak
     half-formed markup, and the bytes are cheap to keep until the block
@@ -487,7 +599,7 @@ def _find_unclosed_markup_start(text: str) -> int:
     Two properties matter, and the LFM streaming leak came from missing
     both:
 
-    * The scan runs LEFT to RIGHT. Anchoring on the LAST ``[`` (the old
+    * The scan runs OUTERMOST first. Anchoring on the LAST ``[`` (the old
       behaviour) breaks as soon as the argument payload contains one of
       its own — the opener is released while the rest of the span is
       still held, so the client sees a headless fragment.
@@ -496,21 +608,11 @@ def _find_unclosed_markup_start(text: str) -> int:
       stops looking like ``[name(`` is what let ``[Calling tool`` reach
       the wire, where the global sanitizer stripped exactly that span
       and left ``: browse({...})]`` in the visible message.
-    """
-    search_from = 0
-    while True:
-        idx = text.find("[", search_from)
-        if idx == -1:
-            return -1
 
-        bracket_block, _ = _extract_balanced_bracket_block(text, idx)
-        if bracket_block is not None:
-            # Closed: either an already-extracted call or plain content.
-            # Holding it would suppress the rest of the stream.
-            search_from = idx + len(bracket_block)
-            continue
+    An unbalanced ``[`` that is unmistakably prose (``a[i is fine``) is
+    skipped: a ``[`` nested inside it may still be a real opener.
+    """
+    for idx in _unclosed_bracket_starts(text):
         if _may_grow_into_markup(text[idx:]):
             return idx
-        # Unbalanced but unmistakably prose (``a[i is fine``). A later
-        # ``[`` in the same span may still be a real opener.
-        search_from = idx + 1
+    return -1


### PR DESCRIPTION
## Why

On the streaming `/v1/chat/completions` path, LFM / Liquid models leaked raw
tool-call markup into the assistant's visible message. In the shipped macOS
app the chat bubble rendered

```
: browse({"url": "https://www.iana.org/help/example-domains"})]
```

directly above a correctly-populated tool card. Deterministic: 10/10 on
streaming, 0/5 non-streaming with the identical request.

**Root cause — we taught the model the format, then failed to read it back.**
`LfmToolParser` reports `SUPPORTS_NATIVE_TOOL_FORMAT = False`, which is
correct: LFM chat templates ignore `message.tool_calls`, so preserving the
native shape would erase tool calls from the history entirely. The
consequence is that `api/utils.py` serialises prior assistant calls into the
prompt as the literal text `[Calling tool: name({args})]`. The model imitates
its own transcript and emits that dialect back on the wire — but the parser
only understood the pythonic `[name(arg=val)]` form.

So `_safe_content_prefix` held `[Calling` (it still matched the partial
`[name(` pattern), then released `[Calling tool` in a single delta the moment
it stopped matching. `sanitize_output`'s `\[Calling\s+tool[^\]]*\]?`
alternative stripped exactly that released span and emitted nothing — which
is why the first content delta on the wire is literally `":"` — and every
subsequent byte streamed to the user verbatim. The call itself was still
recovered, but only at `finalize()` by the cross-format fallback, which is
why the tool card looked right while the text leaked.

Non-streaming was clean because it runs the same cross-format recovery over
the whole text at once, with the span removed from the content.

## What changed

Both halves the report identified, because either alone leaves a hole:

**(a) The parser now understands the dialect it is fed.**
`[Calling tool: name({json})]` and the prefix-less `[name({json})]` are
recognised in the streaming and non-streaming paths alike, so the span is
suppressed as markup and the call is emitted mid-stream as a structured
`delta.tool_calls` instead of surfacing only at finalize. Arguments are
parsed as JSON, never via `ast` — the dialect writes `true`/`false`/`null`,
which Python reads as bare names and would have turned into the *strings*
`"true"`/`"false"`/`"null"`, invoking the tool with wrong arguments. Tool
names follow the OpenAI charset the request validator enforces
(`^[a-zA-Z0-9_-]{1,64}$`, plus `.` as the recovery parser accepts), so
`my-tool` and `2fa` are handled rather than leaked.

**(b) A held prefix is never split.** The hold now covers the whole opener
and is anchored left-to-right instead of at `rfind("[")`, so a `[` inside an
argument payload can no longer release the opener while the rest of the span
stays held. Balance is judged per candidate with quote state starting fresh
at that `[`, so an unfinished prose bracket (`See [note "unfinished`) cannot
mask the real opener that follows it. And when a call and surrounding prose
share one delta, the prose is emitted with the call — the EOF flush is
skipped once a tool fires, so anything not carried there is lost for good.

Two safety rules fell out of review and are now pinned by tests: the block
walk never descends into a payload, neither past an unterminated opener nor
inside a rejected balanced one. `[Calling tool: f({"x": "[g({})]"})]` must
dispatch `f` with `{"x": "[g({})]"}` — never `g`, which no count-based dedup
could retract once streamed.

## Regressions guarded

A bare `[` in prose still streams, `[note: something]` is not eaten,
`[Calling the doctor]` is not mistaken for the envelope, markdown links pass
through, `[2026-08-06` is not held past its token, an apostrophe in prose
does not disable markup holding, multiple blocks keep continuing indices and
unique ids, `[index(0)]` is still rejected as content, and the non-streaming
path is unchanged.

## Verification

- **Live**, same machine / model / request history,
  `rapid-mlx serve lfm2.5-1b-4bit`: **10/10 leaks before, 0/10 after**. The
  first content delta pre-fix is `":"`, matching the report byte for byte.
  Post-fix the turn carries a single `browse` tool call with correct JSON
  arguments and empty content. Fresh tool calls, bracketed prose and
  ordinary chat re-checked unaffected.
- 55 tests in `tests/test_lfm_tool_parser.py` (23 new); full suite
  `python3.12 -m pytest tests --ignore=tests/integrations` → 16289 passed.
- Randomised invariant check, 30k texts built from adversarial atoms ×
  three chunkings (char-by-char, single-shot, random 1-5 char): streamed
  content equals the text minus extracted block spans, streamed calls match
  the non-streaming extraction, indices `0..n-1`, ids unique. 0 failures.
- `_safe_content_prefix` is linear in the accumulated text (it runs on every
  delta): flat 4×-per-4× on `[!`, `[`, `[a(x)]`, `[f(`, `[Calling tool: `,
  `[aaaa!` and long-JSON-argument shapes up to 480KB.
- `ruff check` and `ruff format --check` clean.

Codex review to convergence (0 BLOCKING, 0 MAJOR on the changed files).
Two findings were declined with main-parity evidence rather than fixed:
an unterminated opener masking later blocks (verified byte-identical
behaviour on `main` for the pythonic equivalent, and round-5 review showed
that "fixing" it dispatches string data as tool calls), and the EOF drop of
a held tail after a call has fired (`postprocessor.py:3754`, a family-wide
contract for every streaming parser — reversing it would flush partial
markup to clients on all of them). A third, in the untouched
`AutoToolParser`, is filed separately as #1591.
