### PR TITLE
fix(rapid-mac): let onboarding win the launch race against auto-start (#1589)

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Server/AutoStartDecision.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/AutoStartDecision.swift
@@ -147,8 +147,9 @@ enum AutoStartDecision: Equatable {
 
     /// Why a decision came back as ``.skip``. Surfaced as an
     /// associated value so the contract test can pin the precedence
-    /// (user-opt-out beats server-busy beats binary-missing beats
-    /// no-alias) without inspecting log output, and so a future
+    /// (user-opt-out beats consent-pending beats onboarding-pending
+    /// beats server-busy beats binary-missing beats no-alias) without
+    /// inspecting log output, and so a future
     /// telemetry counter can bucket without re-deriving the gate.
     /// ``CaseIterable`` is the load-bearing conformance for the
     /// cardinality contract in ``AutoStartDecisionTests`` (issue
@@ -165,12 +166,37 @@ enum AutoStartDecision: Equatable {
         /// or surface a ``promptDownload`` caption that would suggest
         /// they should click Start.
         case userOptedOut
+        /// #1589: the first-run telemetry consent sheet is still up. It
+        /// is a hard modal (``interactiveDismissDisabled`` + swallowed
+        /// external dismisses), so nothing the user can see benefits from
+        /// a model that loads behind it — while the cost is real: on the
+        /// reporter's Mac an 8.4 GB serve was committed before the user
+        /// had answered the first question the app asks them. Deferring
+        /// costs one button-click of latency, once, and only for the
+        /// upgrade cohort that still owes a consent answer while having a
+        /// model to resume. The launch hook re-runs when the answer lands.
+        case firstRunDecisionPending
+        /// #1589: Quickstart still owes this user onboarding
+        /// (``QuickstartCoordinator.onboardingOwed``). Auto-start exists
+        /// to restore *your last-used model*; a user who has never
+        /// finished onboarding has no last-used model, so there is
+        /// nothing to restore and inventing one both contradicts the
+        /// Settings copy and — because starting moves ``serverState`` off
+        /// ``.idle`` — suppresses the very wizard that was supposed to
+        /// choose the first model. Onboarding wins the race.
+        case onboardingPending
         /// The alias we would resume is a ``QuickstartCoordinator``
         /// retired starter — a model withdrawn for being unusable, not
         /// merely superseded. Auto-starting it would put the user back
         /// in the broken chat AND move ``serverState`` off ``.idle``,
         /// which suppresses the Quickstart rescue card that exists to
         /// get them off it. Skipping leaves the frame to that card.
+        ///
+        /// Narrower than ``onboardingPending`` and still reachable behind
+        /// it: a user who dismissed Quickstart under v1 (``legacyDone``)
+        /// with no ``lastServedAlias`` is not owed onboarding, yet the
+        /// alphabetical cached-fallback can still land on the retired
+        /// alias. This is the gate that catches them.
         case retiredStarter
         /// ``serverState`` is not ``.idle`` — either a previous
         /// ``.task`` already kicked an auto-start (re-entry), the
@@ -234,6 +260,8 @@ enum AutoStartDecision: Equatable {
         serverState: ServerState,
         rejectsAlias: (String) -> Bool = { _ in false },
         userOptedIn: Bool = true,
+        firstRunDecisionPending: Bool = false,
+        onboardingPending: Bool = false,
         isRetiredStarter: (String) -> Bool = { _ in false }
     ) -> AutoStartDecision {
         // FU-1 precedence #0 (highest): if the user has turned the
@@ -251,6 +279,25 @@ enum AutoStartDecision: Equatable {
         // threading the live ``@AppStorage`` value through.
         if !userOptedIn {
             return .skip(reason: .userOptedOut)
+        }
+
+        // #1589 precedence #0.5: the first-run surfaces own the launch
+        // before auto-start gets a turn. Both gates sit ABOVE the
+        // ``serverState`` switch deliberately — the whole defect was that
+        // auto-start moved the state first and every downstream predicate
+        // then read that self-inflicted ``.starting`` as evidence the user
+        // was not new. A gate placed below the switch could only observe
+        // the damage, never prevent it.
+        //
+        // Consent before onboarding, mirroring the identical ordering
+        // comment in ``ContentView.quickstartVisible`` — the two surfaces
+        // must agree on who asks first or they race for the same
+        // presentation channel.
+        if firstRunDecisionPending {
+            return .skip(reason: .firstRunDecisionPending)
+        }
+        if onboardingPending {
+            return .skip(reason: .onboardingPending)
         }
 
         // Idempotency precedence #1: only fire when state is `.idle`.

--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -260,7 +260,14 @@ struct ContentView: View {
         // the user has turned on auto-approve in Settings (resolved before a
         // request is ever published), so it only appears on a real prompt.
         .modifier(BrowseApprovalDialog(store: browseApproval))
-        .task { await runLaunchAutoStart() }
+        // #1589: keyed on the consent decision rather than fire-once, so
+        // the launch auto-start that stood down for the modal sheet gets
+        // its turn the moment the user answers it. The value only ever
+        // moves true → false (once per install), so this is a single
+        // re-run, and the first pass returns at the gate without an
+        // in-flight `server.start` for SwiftUI's task cancellation to
+        // interrupt. Users with no pending decision see one run, as before.
+        .task(id: telemetryConsentPending) { await runLaunchAutoStart() }
         // Keyed exactly as the picker's own catalog task: re-fetch when
         // the engine binary appears and whenever the set of models on
         // disk changes anywhere in the app. Routed through the shared
@@ -721,6 +728,22 @@ struct ContentView: View {
             serverState: server.state,
             rejectsAlias: rejectsAlias,
             userOptedIn: autoStartOnLaunch,
+            // #1589: the two first-run surfaces get the launch before
+            // auto-start does. Nothing loads behind the modal consent
+            // sheet, and nothing loads for a user Quickstart still owes
+            // onboarding to — auto-start restores a last-used model, it
+            // does not invent a first one.
+            firstRunDecisionPending: telemetryConsentPending,
+            // The SAME predicate the Quickstart sheet presents on (via
+            // ``QuickstartCoordinator.isEligible``), minus the server-state
+            // gate that this path is about to move. Asking it here rather
+            // than re-deriving "is this a new user" is the whole fix: the
+            // two paths cannot disagree if there is only one answer.
+            onboardingPending: QuickstartCoordinator.onboardingOwed(
+                done: quickstart.done,
+                legacyDone: quickstart.legacyDone,
+                lastServedAlias: ServerManager.lastServedAlias()
+            ),
             // Skip a retired starter only while the rescue is still on
             // offer. Once the user has completed or dismissed Quickstart,
             // `isEligible` stops showing the card — and an unconditional

--- a/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
@@ -655,6 +655,31 @@ Open the picker any time to switch models.
         return retiredStarters.contains(alias)
     }
 
+    /// Gates 1 + 2 of ``isEligible`` on their own: does this install still
+    /// owe the user onboarding? Persisted state only — no ``ServerState``,
+    /// no session flags.
+    ///
+    /// ## Why this is split out (issue #1589)
+    ///
+    /// Two code paths need the SAME answer at moments when they see
+    /// different ``ServerState``, so the server-state gate cannot be part
+    /// of the shared question:
+    ///
+    /// * ``ContentView.quickstartVisible`` asks on every render, by which
+    ///   point a server may legitimately be engaged.
+    /// * ``ContentView.runLaunchAutoStart`` must ask *before* it engages
+    ///   one — it is the thing that would move the state.
+    ///
+    /// Pre-fix, auto-start asked neither and simply started a model on any
+    /// Mac with something in the HF cache. That flipped ``serverState`` to
+    /// ``.starting`` before the sheet's predicate ever ran, and BOTH of
+    /// gate 3 here and ``ContentView.serverEngagedWithDifferentAlias`` then
+    /// read the app's own self-inflicted state as "this is not a new user".
+    /// The wizard became unreachable for everyone except users with a
+    /// completely empty cache. Routing both callers through this one
+    /// predicate is what stops the two halves drifting apart again — see
+    /// ``LaunchOnboardingOrderingTests``.
+    ///
     /// - Parameter legacyDone: the pre-v2 completion flag
     ///   (``legacyStorageKey``). Bumping ``storageKey`` to v2 is what
     ///   re-opens onboarding, but on its own it re-opens it for *everyone*
@@ -665,11 +690,10 @@ Open the picker any time to switch models.
     ///   version bump was never about. A v1 dismissal is therefore still
     ///   honoured; it is overridden only for the stranded cohort, which is
     ///   the entire reason the key moved.
-    static func isEligible(
+    static func onboardingOwed(
         done: Bool,
         legacyDone: Bool = false,
-        lastServedAlias: String?,
-        serverState: ServerState
+        lastServedAlias: String?
     ) -> Bool {
         guard !done else { return false }
         let stranded = isStranded(lastServedAlias)
@@ -679,6 +703,23 @@ Open the picker any time to switch models.
         if lastServedAlias != nil, !stranded {
             return false
         }
+        return true
+    }
+
+    /// ``onboardingOwed`` plus gate 3 — the presentation-time question.
+    /// Kept as the sheet's entry point so existing callers and tests read
+    /// unchanged; the persisted half now lives in one place.
+    static func isEligible(
+        done: Bool,
+        legacyDone: Bool = false,
+        lastServedAlias: String?,
+        serverState: ServerState
+    ) -> Bool {
+        guard onboardingOwed(
+            done: done,
+            legacyDone: legacyDone,
+            lastServedAlias: lastServedAlias
+        ) else { return false }
         switch serverState {
         case .idle, .stopped:
             return true

--- a/apps/rapid-mac/Sources/Rapid/UI/SettingsModelsPanel.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SettingsModelsPanel.swift
@@ -167,6 +167,13 @@ struct SettingsModelsPanel: View {
     /// Sits below ``pickerVisibilitySection`` because both are
     /// "model behavior on launch" toggles; the user reads them as a
     /// natural pair and the panel keeps its existing card rhythm.
+    ///
+    /// The body copy's "your last-used model" was aspirational until
+    /// #1589: on a first run there is no last-used model, and auto-start
+    /// picked one anyway (alphabetically, from whatever happened to be in
+    /// the shared HF cache). ``AutoStartDecision`` now stands down while
+    /// the first-run surfaces are still owed, so the sentence describes
+    /// what actually ships — and the second sentence says so out loud.
     @ViewBuilder
     private var autoStartOnLaunchSection: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -174,7 +181,7 @@ struct SettingsModelsPanel: View {
                 VStack(alignment: .leading, spacing: 2) {
                     Text("Auto-start model on launch")
                         .font(.callout.weight(.medium))
-                    Text("On launch, Rapid-MLX loads your last-used model into memory so the chat is interactive immediately. Turn off if you sometimes open Rapid-MLX just to browse past conversations — you can still start a model manually by picking one in the message box and sending.")
+                    Text("On launch, Rapid-MLX loads your last-used model into memory so the chat is interactive immediately. Nothing loads while first-run setup is still open. Turn off if you sometimes open Rapid-MLX just to browse past conversations — you can still start a model manually by picking one in the message box and sending.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
                         .fixedSize(horizontal: false, vertical: true)

--- a/apps/rapid-mac/Tests/RapidTests/AutoStartDecisionTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/AutoStartDecisionTests.swift
@@ -561,7 +561,7 @@ struct AutoStartDecisionTests {
     @Test("#356: SkipReason cardinality + case-name set is pinned — adding/renaming a case requires explicit test update")
     func skipReasonCardinality() {
         let allCases = AutoStartDecision.SkipReason.allCases
-        #expect(allCases.count == 5)
+        #expect(allCases.count == 7)
         // Pin the exact case-name set via the raw-string backing so a
         // rename (``.userOptedOut`` → ``.userExplicitlyOptedOut``)
         // surfaces here even though ``count`` is unchanged.
@@ -577,6 +577,15 @@ struct AutoStartDecisionTests {
             // precedence question it asks — where does the new gate sit? —
             // took several review rounds to answer instead of one red test.
             "retiredStarter",
+            // Added 2026-08-06 with the #1589 ordering fix. The audit this
+            // test demands: both sit ABOVE the ``serverState`` switch —
+            // below it they could only observe the race, not prevent it —
+            // and below ``userOptedOut``, which stays absolute. Relative
+            // order (consent, then onboarding) mirrors
+            // ``ContentView.quickstartVisible``. Precedence is pinned in
+            // ``LaunchOnboardingOrderingTests.skipPrecedenceLadder``.
+            "firstRunDecisionPending",
+            "onboardingPending",
         ])
     }
 }

--- a/apps/rapid-mac/Tests/RapidTests/LaunchOnboardingOrderingTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/LaunchOnboardingOrderingTests.swift
@@ -1,0 +1,398 @@
+import Foundation
+import Testing
+@testable import Rapid
+
+/// Issue #1589 — the launch auto-start raced the Quickstart onboarding
+/// wizard and always won, so on any Mac with something already in the
+/// shared Hugging Face cache the entire first-run wizard was unreachable.
+///
+/// ## The defect, precisely
+///
+/// ``ContentView.runLaunchAutoStart`` fired on launch and started the
+/// alphabetically-first cached alias. That moved ``ServerManager.state``
+/// to ``.starting`` *before* ``ContentView.quickstartVisible`` was ever
+/// evaluated, and the sheet's predicate then failed twice over on state
+/// the app had inflicted on itself:
+///
+///   * ``ContentView.serverEngagedWithDifferentAlias`` — true for
+///     ``.starting(alias)`` whenever the alias differs from the Quickstart
+///     starter, which it always did;
+///   * ``QuickstartCoordinator.isEligible`` gate 3 — false for
+///     ``.starting`` and ``.ready``.
+///
+/// Verified empirically on the reporter's Mac: identical fresh state,
+/// flipping only ``rapid.server.auto_start_on_launch.v1`` decided whether
+/// the wizard appeared at all.
+///
+/// ## Why these tests are shaped like this
+///
+/// The failure was a race between two code paths that never referenced
+/// each other, so neither path's own tests could catch it — each was
+/// individually correct. What was missing was a test of the ORDER. Every
+/// case below therefore asserts on BOTH sides of the race at once: what
+/// the launch gate decides, and what the wizard predicate says about the
+/// same user. A future change that desynchronises them fails here rather
+/// than shipping.
+// ``QuickstartCoordinator`` is ``@MainActor`` (it backs a SwiftUI view),
+// so the suite adopts the same isolation — matching ``QuickstartViewTests``.
+@MainActor
+@Suite("#1589 — launch auto-start must not outrace first-run onboarding")
+struct LaunchOnboardingOrderingTests {
+
+    /// Convenience: the launch gate exactly as ``ContentView`` calls it,
+    /// for a user sitting at the pre-auto-start ``.idle`` state.
+    private func launchDecision(
+        lastServedAlias: String?,
+        cachedAliases: Set<String>,
+        done: Bool = false,
+        legacyDone: Bool = false,
+        consentPending: Bool = false,
+        serverState: ServerState = .idle
+    ) -> AutoStartDecision {
+        AutoStartDecision.decide(
+            lastServedAlias: lastServedAlias,
+            bundledFallbackAlias: nil,
+            binaryReachable: true,
+            cachedAliases: cachedAliases,
+            serverState: serverState,
+            userOptedIn: true,
+            firstRunDecisionPending: consentPending,
+            onboardingPending: QuickstartCoordinator.onboardingOwed(
+                done: done,
+                legacyDone: legacyDone,
+                lastServedAlias: lastServedAlias
+            ),
+            isRetiredStarter: { alias in
+                !done && QuickstartCoordinator.retiredStarters.contains(alias)
+            }
+        )
+    }
+
+    // MARK: - Repro
+
+    /// The exact reported shape: never-onboarded user, empty app state,
+    /// but a populated shared HF cache (CLI user, reinstall, upgrade, or
+    /// a model pulled by any other route). Pre-fix this returned
+    /// ``.start(alias: "bonsai-27b-2bit")`` — an 8.4 GB 2-bit 27B nobody
+    /// chose — and the wizard never rendered.
+    @Test("#1589 repro: never-onboarded user with a cached model does NOT auto-start, and DOES see the wizard")
+    func neverOnboardedWithCachedModelDefersToWizard() {
+        let cached: Set<String> = ["bonsai-27b-2bit", "qwen3.5-4b-4bit"]
+
+        let decision = launchDecision(lastServedAlias: nil, cachedAliases: cached)
+        #expect(
+            decision == .skip(reason: .onboardingPending),
+            "auto-start must stand down for a user onboarding is still owed to"
+        )
+
+        // The other half of the race: because nothing started, the server
+        // is still `.idle` and the wizard's own predicate now passes.
+        #expect(QuickstartCoordinator.isEligible(
+            done: false,
+            lastServedAlias: nil,
+            serverState: .idle
+        ))
+        #expect(!ContentView.serverEngagedWithDifferentAlias(
+            state: .idle,
+            quickstartAlias: QuickstartCoordinator.defaultChoice.alias
+        ))
+    }
+
+    /// The pre-fix state, asserted from the wizard's side, so the test
+    /// file documents *why* the gate has to sit where it does. Had
+    /// auto-start been allowed to run, this is what the sheet would have
+    /// seen — and both predicates say "not a new user" purely because of
+    /// the app's own action.
+    @Test("#1589 mechanism: a self-inflicted .starting state defeats BOTH wizard predicates")
+    func selfInflictedStartingStateDefeatsTheWizard() {
+        let autoStarted = ServerState.starting(alias: "bonsai-27b-2bit")
+        #expect(!QuickstartCoordinator.isEligible(
+            done: false,
+            lastServedAlias: nil,
+            serverState: autoStarted
+        ), "gate 3 reads .starting as 'a model is already engaged'")
+        #expect(ContentView.serverEngagedWithDifferentAlias(
+            state: autoStarted,
+            quickstartAlias: QuickstartCoordinator.defaultChoice.alias
+        ), "and the alias differs from the starter, so the sheet cedes too")
+        // Which is why the gate is placed ABOVE the serverState switch in
+        // `decide`: a check that runs after the start can only observe the
+        // damage, never prevent it.
+    }
+
+    // MARK: - The case auto-start exists for must not regress
+
+    @Test("Returning user with a lastServedAlias still auto-starts exactly as before")
+    func returningUserStillAutoStarts() {
+        let decision = launchDecision(
+            lastServedAlias: "qwen3.5-4b-4bit",
+            cachedAliases: ["bonsai-27b-2bit", "qwen3.5-4b-4bit"]
+        )
+        #expect(decision == .start(alias: "qwen3.5-4b-4bit"))
+        // And the wizard stays away for them.
+        #expect(!QuickstartCoordinator.isEligible(
+            done: false,
+            lastServedAlias: "qwen3.5-4b-4bit",
+            serverState: .idle
+        ))
+    }
+
+    /// A returning user whose model is no longer on disk keeps the
+    /// download-prompt CTA — the new gates must not swallow it.
+    @Test("Returning user whose lastServedAlias is not cached still gets promptDownload")
+    func returningUserUncachedStillPromptsDownload() {
+        let decision = launchDecision(
+            lastServedAlias: "qwen3.5-4b-4bit",
+            cachedAliases: []
+        )
+        #expect(decision == .promptDownload(alias: "qwen3.5-4b-4bit"))
+    }
+
+    /// A user who completed onboarding but later cleared defaults (#298)
+    /// has no lastServedAlias, yet `done` is set — auto-start's cached
+    /// fallback is exactly what that shape needs and must survive.
+    @Test("Onboarded user with cleared lastServedAlias still auto-starts from the cached fallback")
+    func onboardedUserWithClearedAliasStillAutoStarts() {
+        let decision = launchDecision(
+            lastServedAlias: nil,
+            cachedAliases: ["qwen3.5-4b-4bit", "gemma3-1b-qat-4bit"],
+            done: true
+        )
+        #expect(decision == .start(alias: "gemma3-1b-qat-4bit"))
+    }
+
+    // MARK: - Stranded-starter carve-out (must keep working)
+
+    /// A user whose recorded starter was retired for being unusable is
+    /// deliberately treated as new. Auto-start must not resume the broken
+    /// model — doing so is what strands them, because the resulting
+    /// `.starting` suppresses the rescue card.
+    @Test("Stranded-starter user is treated as new: no auto-start, wizard eligible")
+    func strandedStarterTreatedAsNew() {
+        let retired = QuickstartCoordinator.retiredStarters.first!
+        #expect(QuickstartCoordinator.onboardingOwed(
+            done: false,
+            lastServedAlias: retired
+        ), "the retired-starter carve-out must survive the extraction")
+
+        let decision = launchDecision(
+            lastServedAlias: retired,
+            cachedAliases: [retired, "qwen3.5-4b-4bit"]
+        )
+        #expect(decision == .skip(reason: .onboardingPending))
+        #expect(QuickstartCoordinator.isEligible(
+            done: false,
+            lastServedAlias: retired,
+            serverState: .idle
+        ))
+    }
+
+    /// `.retiredStarter` is narrower than `.onboardingPending` but still
+    /// reachable behind it — a v1 dismisser with no lastServedAlias is not
+    /// owed onboarding, yet the alphabetical cached fallback can still
+    /// land on the retired alias. Pins that the older gate did not become
+    /// dead code.
+    @Test("retiredStarter remains reachable behind onboardingPending (v1 dismisser, cached fallback)")
+    func retiredStarterStillReachable() {
+        let retired = QuickstartCoordinator.retiredStarters.first!
+        // legacyDone + no lastServedAlias → not owed onboarding …
+        #expect(!QuickstartCoordinator.onboardingOwed(
+            done: false,
+            legacyDone: true,
+            lastServedAlias: nil
+        ))
+        // … but the cached fallback resolves to the retired alias.
+        let decision = launchDecision(
+            lastServedAlias: nil,
+            cachedAliases: [retired, "zzz-some-other-model"],
+            legacyDone: true
+        )
+        #expect(decision == .skip(reason: .retiredStarter))
+    }
+
+    // MARK: - Consent sheet
+
+    /// Nothing loads behind the modal first-run consent sheet. The sheet
+    /// is `interactiveDismissDisabled` and swallows external dismisses, so
+    /// the user cannot reach anything a warm model would serve — while an
+    /// 8.4 GB serve was being committed before they had answered the first
+    /// question the app asks.
+    @Test("Nothing auto-starts while the first-run consent sheet is still unanswered")
+    func consentPendingBlocksAutoStart() {
+        let decision = launchDecision(
+            lastServedAlias: "qwen3.5-4b-4bit",
+            cachedAliases: ["qwen3.5-4b-4bit"],
+            done: true,
+            consentPending: true
+        )
+        #expect(decision == .skip(reason: .firstRunDecisionPending))
+    }
+
+    /// Once answered, the same user's model comes up — the deferral is a
+    /// single re-run of the launch hook, not a permanent suppression.
+    @Test("Answering consent releases the deferred auto-start")
+    func consentAnsweredReleasesAutoStart() {
+        let decision = launchDecision(
+            lastServedAlias: "qwen3.5-4b-4bit",
+            cachedAliases: ["qwen3.5-4b-4bit"],
+            done: true,
+            consentPending: false
+        )
+        #expect(decision == .start(alias: "qwen3.5-4b-4bit"))
+    }
+
+    // MARK: - Precedence ladder
+
+    /// The skip reasons are a diagnostic surface, so their order has to be
+    /// stable and meaningful: the user's explicit opt-out outranks
+    /// everything, then consent, then onboarding, then mechanical state.
+    /// Consent-before-onboarding mirrors `quickstartVisible`, which defers
+    /// to the consent sheet for the same reason.
+    @Test("Skip precedence: userOptedOut > firstRunDecisionPending > onboardingPending > serverNotIdle")
+    func skipPrecedenceLadder() {
+        // Opt-out beats both new gates.
+        #expect(AutoStartDecision.decide(
+            lastServedAlias: nil,
+            bundledFallbackAlias: nil,
+            binaryReachable: true,
+            cachedAliases: ["qwen3.5-4b-4bit"],
+            serverState: .idle,
+            userOptedIn: false,
+            firstRunDecisionPending: true,
+            onboardingPending: true
+        ) == .skip(reason: .userOptedOut))
+
+        // Consent beats onboarding.
+        #expect(AutoStartDecision.decide(
+            lastServedAlias: nil,
+            bundledFallbackAlias: nil,
+            binaryReachable: true,
+            cachedAliases: ["qwen3.5-4b-4bit"],
+            serverState: .idle,
+            firstRunDecisionPending: true,
+            onboardingPending: true
+        ) == .skip(reason: .firstRunDecisionPending))
+
+        // Onboarding beats the mechanical serverState skip — the gate has
+        // to sit above the switch or it cannot prevent the race.
+        #expect(AutoStartDecision.decide(
+            lastServedAlias: nil,
+            bundledFallbackAlias: nil,
+            binaryReachable: true,
+            cachedAliases: ["qwen3.5-4b-4bit"],
+            serverState: .starting(alias: "bonsai-27b-2bit"),
+            onboardingPending: true
+        ) == .skip(reason: .onboardingPending))
+    }
+
+    /// Back-compat anchor, same shape as the existing `userOptedIn`
+    /// default pin: both new parameters default to "not pending" so every
+    /// pre-#1589 call site and test keeps its contract.
+    @Test("Both new gates default to false — pre-#1589 callers are unchanged")
+    func newGatesDefaultToFalse() {
+        let decision = AutoStartDecision.decide(
+            lastServedAlias: "qwen3.5-4b-4bit",
+            bundledFallbackAlias: nil,
+            binaryReachable: true,
+            cachedAliases: ["qwen3.5-4b-4bit"],
+            serverState: .idle
+        )
+        #expect(decision == .start(alias: "qwen3.5-4b-4bit"))
+    }
+
+    // MARK: - The desynchronisation guard
+
+    /// The invariant the whole fix exists to hold, over the full cross
+    /// product of the persisted first-run state: **auto-start never starts
+    /// a model for a user the wizard would still be offered to.**
+    ///
+    /// This is the assertion that would have failed before the fix, and it
+    /// is deliberately expressed in terms of the two public predicates
+    /// rather than their internals — so it keeps holding whichever side a
+    /// future change touches, and fails the moment they disagree.
+    @Test("Invariant: decide() never returns .start while the wizard is still eligible")
+    func autoStartAndWizardNeverDisagree() {
+        let aliasOptions: [String?] = [
+            nil,
+            "qwen3.5-4b-4bit",
+            QuickstartCoordinator.retiredStarters.first!,
+        ]
+        for done in [false, true] {
+            for legacyDone in [false, true] {
+                for lastServed in aliasOptions {
+                    let decision = launchDecision(
+                        lastServedAlias: lastServed,
+                        cachedAliases: [
+                            "bonsai-27b-2bit",
+                            "qwen3.5-4b-4bit",
+                            QuickstartCoordinator.retiredStarters.first!,
+                        ],
+                        done: done,
+                        legacyDone: legacyDone
+                    )
+                    let wizardEligible = QuickstartCoordinator.isEligible(
+                        done: done,
+                        legacyDone: legacyDone,
+                        lastServedAlias: lastServed,
+                        // `.idle` is what the wizard WOULD see if auto-start
+                        // keeps its hands off — the whole point of the fix.
+                        serverState: .idle
+                    )
+                    if wizardEligible {
+                        #expect(
+                            decision == .skip(reason: .onboardingPending),
+                            """
+                            wizard eligible but auto-start decided \(decision) \
+                            for done=\(done) legacyDone=\(legacyDone) \
+                            lastServed=\(lastServed ?? "nil")
+                            """
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    /// `onboardingOwed` must be exactly `isEligible` minus gate 3 — the
+    /// extraction is only safe if it did not quietly change the answer.
+    @Test("Extraction is behaviour-preserving: isEligible == onboardingOwed && serverState in {.idle, .stopped}")
+    func extractionPreservesEligibility() {
+        let aliasOptions: [String?] = [
+            nil,
+            "qwen3.5-4b-4bit",
+            QuickstartCoordinator.retiredStarters.first!,
+        ]
+        let states: [ServerState] = [
+            .idle,
+            .stopped,
+            .missing,
+            .ready(alias: "qwen3.5-4b-4bit"),
+            .starting(alias: "qwen3.5-4b-4bit"),
+            .crashed(alias: "qwen3.5-4b-4bit", message: "boom"),
+        ]
+        for done in [false, true] {
+            for legacyDone in [false, true] {
+                for lastServed in aliasOptions {
+                    let owed = QuickstartCoordinator.onboardingOwed(
+                        done: done,
+                        legacyDone: legacyDone,
+                        lastServedAlias: lastServed
+                    )
+                    for state in states {
+                        let stateAllows: Bool
+                        switch state {
+                        case .idle, .stopped: stateAllows = true
+                        case .ready, .starting, .crashed, .missing: stateAllows = false
+                        }
+                        #expect(QuickstartCoordinator.isEligible(
+                            done: done,
+                            legacyDone: legacyDone,
+                            lastServedAlias: lastServed,
+                            serverState: state
+                        ) == (owed && stateAllows))
+                    }
+                }
+            }
+        }
+    }
+}

--- a/apps/rapid-mac/scripts/verify-recommendation-tiers.swift
+++ b/apps/rapid-mac/scripts/verify-recommendation-tiers.swift
@@ -257,13 +257,26 @@ func isStranded(_ lastServedAlias: String?) -> Bool {
     return retiredStarters.contains(alias)
 }
 
-func isEligible(done: Bool, legacyDone: Bool = false, lastServedAlias: String?, serverState: FakeServerState) -> Bool {
+// Gates 1 + 2 only — the persisted "does this install still owe the user
+// onboarding?" half. #1589 split this out of isEligible in the source so the
+// launch auto-start path could ask the SAME question before it moves
+// serverState; the mirror follows the same shape.
+func onboardingOwed(done: Bool, legacyDone: Bool = false, lastServedAlias: String?) -> Bool {
     guard !done else { return false }
     let stranded = isStranded(lastServedAlias)
     guard !(legacyDone && !stranded) else { return false }
     if lastServedAlias != nil, !stranded {
         return false
     }
+    return true
+}
+
+func isEligible(done: Bool, legacyDone: Bool = false, lastServedAlias: String?, serverState: FakeServerState) -> Bool {
+    guard onboardingOwed(
+        done: done,
+        legacyDone: legacyDone,
+        lastServedAlias: lastServedAlias
+    ) else { return false }
     switch serverState {
     case .idle, .stopped: return true
     case .ready, .starting, .crashed, .missing: return false
@@ -309,8 +322,17 @@ func isRetiredStarter(_ alias: String) -> Bool { retiredStarters.contains(alias)
 
 func decideResume(lastServedAlias: String?, cachedAliases: Set<String>,
                   serverState: FakeServerState, userOptedIn: Bool = true,
-                  quickstartDone: Bool = false) -> FakeDecision {
+                  quickstartDone: Bool = false, legacyDone: Bool = false,
+                  firstRunDecisionPending: Bool = false) -> FakeDecision {
     if !userOptedIn { return .skip("userOptedOut") }
+    // #1589: both first-run gates sit ABOVE the serverState switch. Below it
+    // they could only observe the race, never prevent it — auto-start is the
+    // thing that moves the state every downstream predicate then reads.
+    if firstRunDecisionPending { return .skip("firstRunDecisionPending") }
+    if onboardingOwed(done: quickstartDone, legacyDone: legacyDone,
+                      lastServedAlias: lastServedAlias) {
+        return .skip("onboardingPending")
+    }
     guard case .idle = serverState else { return .skip("serverNotIdle") }
     guard let alias = lastServedAlias else { return .skip("noResolvableAlias") }
     if !quickstartDone && isRetiredStarter(alias) { return .skip("retiredStarter") }
@@ -318,9 +340,12 @@ func decideResume(lastServedAlias: String?, cachedAliases: Set<String>,
 }
 
 print("Auto-start vs retired starters:")
+// A stranded user is one the onboarding gate now catches first — the reason
+// changed from "retiredStarter" to the broader "onboardingPending", the
+// property (nothing is resumed, state stays .idle) did not.
 check(decideResume(lastServedAlias: "bonsai-1.7b-2bit",
                    cachedAliases: ["bonsai-1.7b-2bit"], serverState: .idle)
-        == .skip("retiredStarter"),
+        == .skip("onboardingPending"),
       "retired starter on disk is NOT resumed — state stays .idle so the card can show")
 check(decideResume(lastServedAlias: "qwen3.5-9b-4bit",
                    cachedAliases: ["qwen3.5-9b-4bit"], serverState: .idle)
@@ -342,9 +367,53 @@ check(!isEligible(done: true, lastServedAlias: "bonsai-1.7b-2bit", serverState: 
 // The end-to-end property the two halves buy together.
 check(decideResume(lastServedAlias: "bonsai-1.7b-2bit",
                    cachedAliases: ["bonsai-1.7b-2bit"], serverState: .idle)
-        == .skip("retiredStarter")
+        == .skip("onboardingPending")
       && isEligible(done: false, lastServedAlias: "bonsai-1.7b-2bit", serverState: .idle),
       "end-to-end: stranded user launches → no auto-start → card IS shown")
+
+// ---------------------------------------------------------------------------
+// #1589 — onboarding must win the launch race
+//
+// The reported defect: a never-onboarded user on a Mac with anything in the
+// shared HF cache got a model auto-started, which moved serverState off .idle
+// and made the wizard unreachable. The executable half of that contract.
+
+print("Onboarding vs launch auto-start (#1589):")
+check(decideResume(lastServedAlias: nil, cachedAliases: ["bonsai-27b-2bit"],
+                   serverState: .idle) == .skip("onboardingPending"),
+      "never-onboarded user with a cached model does NOT auto-start")
+check(isEligible(done: false, lastServedAlias: nil, serverState: .idle),
+      "…and because nothing started, the wizard IS eligible")
+check(!isEligible(done: false, lastServedAlias: nil, serverState: .starting),
+      "the pre-fix mechanism: an auto-started model would have hidden the wizard")
+check(decideResume(lastServedAlias: "qwen3.5-9b-4bit",
+                   cachedAliases: ["qwen3.5-9b-4bit"], serverState: .idle,
+                   quickstartDone: true) == .start("qwen3.5-9b-4bit"),
+      "returning user still gets their last-used model restored")
+check(decideResume(lastServedAlias: "qwen3.5-9b-4bit",
+                   cachedAliases: ["qwen3.5-9b-4bit"], serverState: .idle,
+                   quickstartDone: true, firstRunDecisionPending: true)
+        == .skip("firstRunDecisionPending"),
+      "nothing loads behind the unanswered first-run consent sheet")
+// The invariant, over the whole persisted state space: auto-start never
+// starts a model for a user the wizard would still be offered to.
+for done in [false, true] {
+    for legacy in [false, true] {
+        for last in [nil, "qwen3.5-9b-4bit", "bonsai-1.7b-2bit"] as [String?] {
+            let decision = decideResume(
+                lastServedAlias: last,
+                cachedAliases: ["qwen3.5-9b-4bit", "bonsai-1.7b-2bit", "bonsai-27b-2bit"],
+                serverState: .idle, quickstartDone: done, legacyDone: legacy)
+            let eligible = isEligible(done: done, legacyDone: legacy,
+                                      lastServedAlias: last, serverState: .idle)
+            var started = false
+            if case .start = decision { started = true }
+            check(!(eligible && started),
+                  "invariant: wizard eligible ⇒ no auto-start "
+                    + "(done=\(done) legacy=\(legacy) last=\(last ?? "nil"))")
+        }
+    }
+}
 
 print(fails == 0 ? "\nALL PASS" : "\n\(fails) FAILURE(S)")
 exit(fails == 0 ? 0 : 1)

--- a/tests/test_ram_tier_recommendations_agree.py
+++ b/tests/test_ram_tier_recommendations_agree.py
@@ -523,8 +523,18 @@ def test_eligibility_check_script_has_not_drifted_from_production():
     *above* that guard — an early return, a new precondition — diverged
     invisibly. The slice was never needed: ``_extract_func_body`` already
     returns brace-matched bodies without the signature, so the two sides
-    are directly comparable."""
-    for signature in ("func isEligible(", "func isStranded("):
+    are directly comparable.
+
+    ``onboardingOwed`` joined the list with #1589. It is now the predicate
+    that actually decides "is this a new user" — ``isEligible`` is a thin
+    wrapper over it, and the launch auto-start path consults it directly —
+    so leaving it unpinned would let the load-bearing half drift while the
+    wrapper above it stayed identical."""
+    for signature in (
+        "func onboardingOwed(",
+        "func isEligible(",
+        "func isStranded(",
+    ):
         prod = _extract_func_body(QUICKSTART_PROD, signature)
         copy = _extract_func_body(VERIFY_SCRIPT, signature)
         assert prod == copy, (
@@ -590,4 +600,63 @@ def test_auto_start_skips_retired_starters():
             f"{label}: the retired-starter guard moved after the on-disk "
             "check — a cached retired starter would be resumed before the "
             "guard ever runs"
+        )
+
+
+def test_launch_auto_start_defers_to_first_run_surfaces():
+    """#1589: the launch auto-start must not outrace the first-run surfaces.
+
+    The Swift suite covers ``AutoStartDecision.decide`` thoroughly, but it
+    calls the function directly. Both new gates default to ``false``, so
+    deleting either argument from the ``ContentView`` call site silently
+    restores the original bug with every unit test still green — the
+    parameter is simply never supplied and the gate never fires. The wiring
+    is the part that broke; it is the part that has to be pinned.
+
+    Source structure is the available lever: ``ContentView`` is a SwiftUI
+    view whose launch hook cannot be invoked from a test, and it is not
+    reachable from Python at all."""
+    caller = (REPO / "apps/rapid-mac/Sources/Rapid/UI/ContentView.swift").read_text()
+
+    assert "firstRunDecisionPending: telemetryConsentPending" in caller, (
+        "the launch hook stopped passing the telemetry-consent gate. The "
+        "parameter defaults to 'not pending', so a model would once again "
+        "load behind the modal first-run consent sheet"
+    )
+    assert "onboardingPending: QuickstartCoordinator.onboardingOwed(" in caller, (
+        "the launch hook stopped asking whether onboarding is still owed. "
+        "The parameter defaults to 'not pending', which is exactly the "
+        "pre-#1589 behaviour: auto-start invents a first model, serverState "
+        "leaves .idle, and the Quickstart wizard becomes unreachable"
+    )
+    # The gate is only worth anything if it consults the SAME predicate the
+    # wizard presents on. A hand-rolled re-derivation here is how the two
+    # halves drifted apart in the first place.
+    assert "QuickstartCoordinator.onboardingOwed(" in caller, (
+        "the launch hook must call QuickstartCoordinator.onboardingOwed "
+        "rather than re-deriving 'is this a new user' locally"
+    )
+
+    # Deferring for the consent sheet is only correct if the hook runs again
+    # once the answer lands. A bare `.task` fires once, which would strand a
+    # returning user on an idle server for the whole session.
+    assert (
+        ".task(id: telemetryConsentPending) { await runLaunchAutoStart() }" in caller
+    ), (
+        "the launch task is no longer keyed on the consent decision. With a "
+        "bare `.task` the auto-start that stood down for the consent sheet "
+        "never gets its turn, and a returning user's model never loads"
+    )
+
+    # And the gates must sit above the serverState switch: below it they can
+    # only observe the race, never prevent it.
+    decision = (
+        REPO / "apps/rapid-mac/Sources/Rapid/Server/AutoStartDecision.swift"
+    ).read_text()
+    for gate in ("firstRunDecisionPending {", "onboardingPending {"):
+        assert gate in decision, f"AutoStartDecision lost its {gate} gate"
+        assert decision.index(gate) < decision.index("switch serverState {"), (
+            f"AutoStartDecision: the {gate} gate moved below the serverState "
+            "switch. Auto-start is what MOVES serverState, so a gate placed "
+            "after it can only observe the damage, never prevent it"
         )


### PR DESCRIPTION
## The race

On a genuinely fresh install the Quickstart onboarding wizard never appeared. `runLaunchAutoStart` fired on launch, resolved the alphabetically-first cached alias, and started it — which moved `ServerManager.state` to `.starting` **before** `quickstartVisible` was ever evaluated. The sheet's predicate then failed twice over, on state the app had inflicted on itself:

- `ContentView.serverEngagedWithDifferentAlias` returns `true` for `.starting(alias)` whenever the alias differs from the Quickstart starter — and it always did;
- `QuickstartCoordinator.isEligible` gate 3 independently returns `false` for `.starting` / `.ready`.

Two code paths that never referenced each other, so neither one's tests could catch it: each was individually correct. Auto-start simply always won.

This did not hit the empty-cache case (nothing to auto-start), so it hit everyone else — CLI users, reinstalls, upgrades, anyone who pulled a model by any other route.

## The fix

**One predicate, asked in one place.** `QuickstartCoordinator.onboardingOwed(done:legacyDone:lastServedAlias:)` is extracted out of `isEligible` — gates 1 and 2, persisted state only, no `ServerState`. The server-state gate cannot be part of the shared question, because the two callers need the same answer at moments when they see different states: the sheet asks on every render, while auto-start must ask *before* it engages one. `isEligible` is now that predicate plus gate 3, and `runLaunchAutoStart` consults the same function rather than re-deriving "is this a new user".

`AutoStartDecision.decide` gains two gates, both **above** the `serverState` switch — below it they could only observe the race, never prevent it:

- `onboardingPending` — Quickstart still owes this user onboarding. Auto-start exists to restore *your last-used model*; a user who never finished onboarding has none, so there is nothing to restore and inventing one is what suppressed the wizard.
- `firstRunDecisionPending` — see below.

Both default to `false`, so every pre-existing caller and test keeps its contract.

## Decision on the consent sheet: nothing starts before it is answered

Yes, it should wait, and this PR implements that.

The first-run telemetry sheet is a hard modal — `interactiveDismissDisabled()`, external dismisses swallowed. Nothing the user can reach benefits from a model that loads behind it, while the cost is real and was being paid: on the reporter's Mac an ~8.4 GB serve was committed before the user had answered the first question the app asks them.

The cost of waiting is one button-click of latency, once. After this fix it is not even paid by genuinely new users — they are stopped by `onboardingPending` anyway. The cohort it actually affects is the upgrade path: someone who already has a `lastServedAlias` but whose consent answer is absent (upgraded from a pre-sheet build, or ran `rapid-mlx telemetry reset`). Holding their model for the seconds they spend on a privacy prompt is the right trade.

So the launch `.task` is re-keyed on `telemetryConsentPending`. The value only ever moves `true → false`, once per install, so it is a single re-run; the first pass returns at the gate with no in-flight `server.start` for SwiftUI's cancellation to interrupt, and `ModelCatalogCache` dispatches its load as an unstructured task, so a cancelled probe is not lost either.

## Settings copy

"Auto-start model on launch" promised to load "your last-used model" — aspirational on a first run, where there is no last-used model and one was loaded anyway. The behaviour now matches the sentence, and a second sentence states the deferral: *"Nothing loads while first-run setup is still open."*

## What did NOT change

- A returning user with a `lastServedAlias` auto-starts exactly as before.
- The `promptDownload` CTA for a returning user whose model is no longer on disk.
- The `defaults delete` / #298 shape: onboarded user, no `lastServedAlias`, still auto-starts from the cached fallback.
- The stranded-starter carve-out (`isStranded`). A user whose recorded starter was retired is still treated as new. The skip *reason* they produce moved from `.retiredStarter` to the broader `.onboardingPending`; the property — nothing is resumed, state stays `.idle`, the rescue card renders — is unchanged. `.retiredStarter` is **not** dead code: a v1 dismisser with no `lastServedAlias` is not owed onboarding, yet the alphabetical cached fallback can still land on the retired alias, and that gate is what catches them (pinned by a test).

## Verification

Unit tests pin the **ordering**, since the defect was a race between paths that never referenced each other — every case asserts on both sides at once (what the launch gate decides, and what the wizard predicate says about the same user). New `LaunchOnboardingOrderingTests` (13 tests) covers the repro, the returning user, the stranded starter, the consent gate, the precedence ladder, and an invariant over the full cross product of persisted first-run state: *`decide()` never returns `.start` while the wizard is still eligible.*

Because both new parameters default to `false`, deleting either argument from the `ContentView` call site would restore the bug with every unit test still green — so the wiring itself is pinned too (`test_launch_auto_start_defers_to_first_run_surfaces`): both arguments, the `.task(id:)` key, and the above-the-switch placement of both gates. Verified as a real tripwire by removing the wiring and watching it fail.

`scripts/verify-recommendation-tiers.swift` is a hand-written executable mirror of the gate that CI runs standalone; it and the Python drift test that pins it against production were both updated, and `onboardingOwed` was added to the pinned set.

- `swift build` clean; full swift-testing suite **1656 tests / 150 suites pass**. (The `RapidUXTests` XCTest target cannot run on this machine — Command Line Tools only, no Xcode — so CI's `build` job is the authority for that target.)
- `verify-recommendation-tiers.swift`, `verify-conversation-ordering.sh`, `verify-chat-timeout.swift` all pass.
- `ruff check` + `ruff format --check` clean.

### Live A/B on a real build

Isolated dogfood instance (throwaway bundle id + `$HOME`), freshly reset between runs, `rapid.server.auto_start_on_launch.v1` **never touched**:

| | control (`main` @ `d3d305cc`) | this branch |
|---|---|---|
| fresh state | `serve bonsai-27b-2bit` spawned on :8000, `rapid.serve.lastAlias=bonsai-27b-2bit`, **no wizard** | **no serve at all**; consent sheet over "bonsai-27b-2bit isn't running"; answering it reveals **"WELCOME TO RAPID-MLX / Fast, free AI that runs on your Mac"** → "Choose your first model" with the LFM2.5 · 1.2B starter |
| after completing onboarding, quit, relaunch | — | auto-start restores `lfm2.5-1b-4bit`, wizard stays away |

Closes #1589
