### PR TITLE
fix(rapid-mac): make dead settings buttons and 404 links work

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/AboutPanel.swift
+++ b/apps/rapid-mac/Sources/Rapid/AboutPanel.swift
@@ -12,7 +12,14 @@ import SwiftUI
 enum AboutPanel {
     private static let website = "https://rapidmlx.com"
     private static let repoURL = "https://github.com/raullenchai/Rapid-MLX"
-    private static let privacyURL = "https://rapidmlx.com/privacy"
+    /// The policy in the repository, not `rapidmlx.com/privacy` — that page
+    /// has never been published and 404s, so the About window's "Privacy"
+    /// link opened nothing. `apps/rapid-mac/PRIVACY.md` is the real,
+    /// maintained document (and the same one Settings → Privacy now opens).
+    /// Point this back at the website once the page exists.
+    /// ``RepositoryLinkTargetsTests`` pins the path.
+    private static let privacyURL =
+        "https://github.com/raullenchai/Rapid-MLX/blob/main/apps/rapid-mac/PRIVACY.md"
 
     /// Retained so the window isn't deallocated the moment ``show``
     /// returns (an unheld ``NSWindow`` closes itself).

--- a/apps/rapid-mac/Sources/Rapid/Services/FailureDiagnosis.swift
+++ b/apps/rapid-mac/Sources/Rapid/Services/FailureDiagnosis.swift
@@ -81,12 +81,36 @@ struct FailureDiagnosis: Equatable, Sendable {
         case notice
     }
 
-    enum Action: String, Equatable, Sendable {
+    /// A recovery affordance a failure card may offer. Every case must be
+    /// something a view can actually carry out in THIS app — an action with no
+    /// destination is the defect this type exists to prevent, and it is worse
+    /// than no button because it fires at the moment the user has already been
+    /// let down once.
+    ///
+    /// ``CaseIterable`` on purpose: it lets the routing table
+    /// (``SettingsRouter/settingsCategory(for:)``) be pinned exhaustively by a
+    /// test, so a new case cannot be added without a stated destination.
+    ///
+    /// **Removed:** `openPermissions`. It titled a button "Open Permissions"
+    /// and had nowhere to send it — this app's ``SettingsView/Category`` set
+    /// is `models, modelManagement, tools, appearance, privacy, app`, and none
+    /// of those holds a folder-grant or file-access control (Settings →
+    /// Privacy is telemetry consent). Nor were the conditions that produced it
+    /// reachable: it was emitted only for ``Kind/commandPermissionDenied`` and
+    /// ``Kind/filePermissionDenied``, which ``FailureDiagnoser/toolFailureKind``
+    /// derives only for the tool names `run_command`, `read_file`,
+    /// `list_directory`, `write_file`, and `edit_file` — none of which this
+    /// build ships (see ``BuiltinToolRegistry``: filesystem and shell tools are
+    /// deliberately absent because there is no sandbox manager to gate them).
+    /// Routing it to the "closest" tab would only have moved the dead end and
+    /// kept a label that lies about what the user will find there, so the two
+    /// kinds now carry no action at all. The ``Kind`` cases stay — they are
+    /// persisted in transcripts and must keep decoding.
+    enum Action: String, CaseIterable, Equatable, Sendable {
         case retry
         case restart
         case openModelManagement
         case switchDownloadSource
-        case openPermissions
         /// Deep-link to Settings → Tools, where the web-search backend is
         /// chosen and its key is pasted. Routed through ``SettingsRouter``
         /// like the other "open Settings on THIS tab" actions.
@@ -98,7 +122,6 @@ struct FailureDiagnosis: Equatable, Sendable {
             case .restart: return "Restart"
             case .openModelManagement: return "Open Model Management"
             case .switchDownloadSource: return "Switch source"
-            case .openPermissions: return "Open Permissions"
             case .openWebSearchSettings: return "Open Web Search Settings"
             }
         }
@@ -108,7 +131,6 @@ struct FailureDiagnosis: Equatable, Sendable {
             case .retry, .restart: return "arrow.clockwise"
             case .openModelManagement: return "square.stack.3d.up"
             case .switchDownloadSource: return "arrow.triangle.2.circlepath"
-            case .openPermissions: return "hand.raised"
             case .openWebSearchSettings: return "magnifyingglass"
             }
         }
@@ -153,8 +175,7 @@ struct FailureDiagnosis: Equatable, Sendable {
         switch diagnosis.action {
         case .openWebSearchSettings:
             return .openWebSearchSettings
-        case .retry, .restart, .openModelManagement, .switchDownloadSource,
-             .openPermissions, .none:
+        case .retry, .restart, .openModelManagement, .switchDownloadSource, .none:
             return nil
         }
     }
@@ -223,8 +244,13 @@ enum FailureDiagnoser {
             message = "DuckDuckGo is rate-limiting web searches from this Mac. Switch to Brave Search or Tavily in Settings → Tools and add a free key."
             action = .openWebSearchSettings
         case .commandPermissionDenied:
-            message = "The command tried to change a protected location. Allow that folder, then try again."
-            action = .openPermissions
+            // No action, and no "allow that folder, then try again" — this app
+            // ships no shell tool and no place to grant a folder, so the old
+            // copy asked for a control that does not exist and the old button
+            // led nowhere. See ``FailureDiagnosis/Action``. What is left states
+            // the outcome and stops.
+            message = "The command tried to change a protected location, so it was blocked."
+            action = nil
         case .commandFailed:
             message = "The command didn't finish successfully. Check the command, then try again."
             action = .retry
@@ -232,8 +258,10 @@ enum FailureDiagnoser {
             message = "That file isn't there. Check its name or location, then try again."
             action = .retry
         case .filePermissionDenied:
-            message = "Rapid doesn't have access to that file. Allow access, then try again."
-            action = .openPermissions
+            // Same reasoning as ``commandPermissionDenied``: no file tools ship
+            // here, so there is no access to grant and nothing to open.
+            message = "Rapid doesn't have access to that file."
+            action = nil
         case .toolFailed:
             message = "The tool couldn't finish. Check its input, then try again."
             action = .retry

--- a/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
@@ -1091,10 +1091,10 @@ private struct ToolCallChip: View {
             // open of the session) and ``.onChange`` (already-open window
             // being re-focused); setting it after the open would race the
             // ``.onAppear`` read and land the user on the last-used tab.
-            // Same pairing ``QuickstartView`` uses for its deep-links.
-            settingsRouter?.requestedCategory = .tools
-            openWindow(id: "settings")
-        case .retry, .restart, .openModelManagement, .switchDownloadSource, .openPermissions:
+            // ``route`` owns that ordering and the tab choice; the same call
+            // ``QuickstartView`` uses for its deep-links.
+            settingsRouter?.route(action) { openWindow(id: "settings") }
+        case .retry, .restart, .openModelManagement, .switchDownloadSource:
             break
         }
     }

--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -896,11 +896,17 @@ private struct BrowseApprovalSheet: View {
 /// Settings scene (no deep-link override — lands on the user's last
 /// selected tab).
 struct SettingsGearButton: View {
-    @Environment(\.openSettings) private var openSettings
+    /// ``openWindow(id: "settings")``, NOT ``@Environment(\.openSettings)``:
+    /// this app declares a real ``Window("Settings", id: "settings")`` and no
+    /// SwiftUI ``Settings`` scene, so `OpenSettingsAction` targets a scene that
+    /// does not exist and silently does nothing. See ``SettingsRouter``.
+    @Environment(\.openWindow) private var openWindow
 
     var body: some View {
         Button {
-            openSettings()
+            // No router assignment: this affordance is "just open Settings",
+            // so it deliberately lands on the user's last selected tab.
+            openWindow(id: "settings")
         } label: {
             Image(systemName: "gearshape")
                 .font(.system(size: 14))
@@ -939,7 +945,9 @@ struct SettingsGearButton: View {
 /// would 404 for end users.
 struct DesktopVersionPill: View {
     @Bindable var updater: UpdateChecker
-    @Environment(\.openSettings) private var openSettings
+    /// ``openWindow(id: "settings")``, NOT ``@Environment(\.openSettings)`` —
+    /// see ``SettingsGearButton`` above and ``SettingsRouter``.
+    @Environment(\.openWindow) private var openWindow
     @Environment(SettingsRouter.self) private var router
 
     enum PillState: Equatable {
@@ -1004,8 +1012,11 @@ struct DesktopVersionPill: View {
 
     var body: some View {
         Button {
-            router.requestedCategory = .app
-            openSettings()
+            // ``route(to:open:)`` rather than an assignment followed by an
+            // open: ``SettingsView`` reads the router from ``.onAppear``, so
+            // the category has to land first, and the closure form makes that
+            // order impossible to invert here.
+            router.route(to: .app) { openWindow(id: "settings") }
         } label: {
             HStack(spacing: 5) {
                 if let tint = dotTint {

--- a/apps/rapid-mac/Sources/Rapid/UI/DownloadStrip.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/DownloadStrip.swift
@@ -22,6 +22,15 @@ import SwiftUI
 struct DownloadStrip: View {
     @Bindable var downloads: DownloadManager
 
+    /// Deep-link channel into Settings, resolved optionally so the strip still
+    /// renders in a host that never injected one (previews, the snapshot
+    /// harness) — the non-optional form traps at lookup time.
+    @Environment(SettingsRouter.self) private var settingsRouter: SettingsRouter?
+    /// ``openWindow(id: "settings")``, NOT ``@Environment(\.openSettings)``:
+    /// this app declares no SwiftUI ``Settings`` scene, so `OpenSettingsAction`
+    /// is a silent no-op here. See ``SettingsRouter``.
+    @Environment(\.openWindow) private var openWindow
+
     /// All known jobs, ordered: running first (by alias), then
     /// terminal states (alpha) so finished rows fall to the bottom
     /// and don't bury the live progress. Computed each render — the
@@ -104,7 +113,14 @@ struct DownloadStrip: View {
             downloads.retryDownload(alias: job.alias)
         case .switchDownloadSource:
             downloads.retryDownload(alias: job.alias, source: .huggingFace)
-        case .restart, .openModelManagement, .openPermissions, .openWebSearchSettings:
+        case .openModelManagement, .openWebSearchSettings:
+            // A download job only ever produces ``.retry`` /
+            // ``.switchDownloadSource`` today, so these are latent. Wiring
+            // them anyway costs two lines and keeps the strip from growing the
+            // dead button the Quickstart card just lost, the moment a new
+            // failure kind starts routing here.
+            settingsRouter?.route(action) { openWindow(id: "settings") }
+        case .restart:
             break
         }
     }

--- a/apps/rapid-mac/Sources/Rapid/UI/MenuBarController.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/MenuBarController.swift
@@ -276,25 +276,15 @@ final class MenuBarController: NSObject {
         }
     }
 
-    /// Open the Settings scene. SwiftUI installs ONE of two selectors on
-    /// ``NSApplication`` depending on the SDK link (``showSettingsWindow:``
-    /// on macOS 13+, ``showPreferencesWindow:`` on macOS 12-); dispatch via
-    /// runtime selector so an unrecognised one lands on NSApp's default as
-    /// a no-op rather than a crash.
-    private func openSettings() {
-        NSApp.activate(ignoringOtherApps: true)
-        // ``NSApp.responds(to:)`` returns FALSE for these — the SwiftUI
-        // ``Settings`` scene installs the handler on the responder CHAIN,
-        // not on ``NSApplication`` itself. Gating on ``responds(to:)``
-        // (the old code) therefore always fell through to the legacy
-        // selector, which no-ops on macOS 14+/26 → the tray "Settings"
-        // item did nothing. ``sendAction(_:to:nil:from:)`` walks the
-        // chain and returns whether it was handled, so try the modern
-        // selector first and only fall back if it genuinely wasn't taken.
-        if !NSApp.sendAction(Selector(("showSettingsWindow:")), to: nil, from: nil) {
-            NSApp.sendAction(Selector(("showPreferencesWindow:")), to: nil, from: nil)
-        }
-    }
+    // NOTE: a private `openSettings()` used to sit here, dispatching
+    // ``showSettingsWindow:`` / ``showPreferencesWindow:`` through
+    // ``NSApp.sendAction``. It was unreferenced — the ``.settings`` case above
+    // has gone through ``AppDelegate.openSettingsWindow`` (the
+    // ``openWindow(id: "settings")`` bridge) since the tray item was fixed —
+    // and it could not have worked if it were called: both selectors are
+    // installed by a SwiftUI ``Settings`` scene, which this app does not
+    // declare. Deleted rather than left as a plausible-looking helper for the
+    // next person to reach for. See ``SettingsRouter``.
 }
 
 // MARK: - NSMenuDelegate

--- a/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
@@ -693,12 +693,13 @@ Open the picker any time to switch models.
 /// ``QuickstartCoordinator`` reports the surface should show.
 struct QuickstartView: View {
     @Environment(SettingsRouter.self) private var settingsRouter
-    @Environment(\.openSettings) private var openSettings
-    /// The mechanism that actually opens this app's Settings: it declares a
-    /// real ``Window("Settings", id: "settings")`` and no SwiftUI ``Settings``
-    /// scene, so ``openSettings()`` — used by the three cases below — is a
-    /// silent no-op. Those are a pre-existing dead deep-link, tracked
-    /// separately; the case added here uses the working path.
+    /// The ONLY mechanism that opens this app's Settings. It declares a real
+    /// ``Window("Settings", id: "settings")`` and no SwiftUI ``Settings``
+    /// scene, so ``@Environment(\.openSettings)`` — which this view used to
+    /// hold — targets a scene that does not exist and does nothing at all.
+    /// That is the worst place for a dead button: the failure card is on
+    /// screen precisely because the user's first download or start already
+    /// failed. See ``SettingsRouter`` for the ordering rule.
     @Environment(\.openWindow) private var openWindow
     @Bindable var coordinator: QuickstartCoordinator
     @Bindable var downloads: DownloadManager
@@ -1274,20 +1275,16 @@ struct QuickstartView: View {
         case .restart:
             coordinator.enterStarting()
             Task { await server.start(alias: coordinator.selection.alias) }
-        case .openModelManagement:
-            settingsRouter.requestedCategory = .modelManagement
-            openSettings()
-        case .openPermissions:
-            // The minimal app has no Permissions tab; land on Models.
-            settingsRouter.requestedCategory = .models
-            openSettings()
-        case .openWebSearchSettings:
-            // Not reachable from a download/model failure, but the deep-link
-            // is the same two lines wherever it fires: set the target tab,
-            // then open the window (``SettingsView`` reads the router from
-            // ``.onAppear``, so the assignment has to come first).
-            settingsRouter.requestedCategory = .tools
-            openWindow(id: "settings")
+        case .openModelManagement, .openWebSearchSettings:
+            // One path for every Settings deep-link. ``route`` stages the
+            // target tab and only then runs the open — ``SettingsView`` reads
+            // the router from ``.onAppear``, so the assignment has to land
+            // first, and passing the open as a closure means this call site
+            // cannot get that order wrong.
+            //
+            // ``openWindow(id: "settings")``, NOT ``openSettings()`` — see the
+            // ``openWindow`` property above.
+            settingsRouter.route(action) { openWindow(id: "settings") }
         }
     }
 
@@ -1299,7 +1296,6 @@ struct QuickstartView: View {
         case .restart: return "Quickstart.Restart"
         case .openModelManagement: return "Quickstart.OpenModelManagement"
         case .switchDownloadSource: return "Quickstart.SwitchSource"
-        case .openPermissions: return "Quickstart.OpenPermissions"
         case .openWebSearchSettings: return "Quickstart.OpenWebSearchSettings"
         case nil: return nil
         }

--- a/apps/rapid-mac/Sources/Rapid/UI/SettingsRouter.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SettingsRouter.swift
@@ -3,22 +3,35 @@ import Observation
 
 /// Deep-link channel into the Settings window.
 ///
-/// macOS's ``@Environment(\.openSettings)`` action opens (or focuses)
-/// the Settings scene but doesn't accept a category — call sites can
-/// only say "open Settings," not "open Settings on the CLI panel."
-/// Users (2026-06-10) called this out: clicking the bottom-bar CLI
-/// status pill lands them on the default Tools tab and they have to
-/// hunt for the rapid-mlx CLI sidebar item before they can recheck /
-/// see the binary path.
+/// This app has **no SwiftUI `Settings` scene**. It declares a real
+/// ``Window("Settings", id: "settings")`` (see ``RapidApp``) so the
+/// menu-bar tray item can open it, and ⌘, is re-wired to the same
+/// window. The consequence every call site has to respect:
+/// ``@Environment(\.openSettings)`` — `OpenSettingsAction` — targets a
+/// scene that does not exist here and is a **silent no-op**. The only
+/// working path is ``@Environment(\.openWindow)`` with
+/// `openWindow(id: "settings")`.
+///
+/// `openWindow` also takes no category, so it can only say "open
+/// Settings," not "open Settings on the Tools panel." Users
+/// (2026-06-10) called this out: clicking the bottom-bar status pill
+/// landed them on the default tab and they had to hunt for the item
+/// they came for.
 ///
 /// ``SettingsRouter`` is a tiny ``@Observable`` shared via the SwiftUI
-/// environment. A call site sets ``requestedCategory`` to the desired
-/// tab and then invokes ``openSettings()``; ``SettingsView`` observes
-/// the field via ``.onAppear`` (covers the "first open this session"
-/// case) and ``.onChange`` (covers the "already-open Settings gets
-/// re-focused" case), applies the request, and clears it back to nil
-/// so a subsequent open without a request lands on the user's last
+/// environment that closes that gap. A call site sets
+/// ``requestedCategory`` to the desired tab and then calls
+/// `openWindow(id: "settings")`; ``SettingsView`` observes the field
+/// via ``.onAppear`` (covers the "first open this session" case) and
+/// ``.onChange`` (covers the "already-open Settings gets re-focused"
+/// case), applies the request, and clears it back to nil so a
+/// subsequent open without a request lands on the user's last
 /// selected tab.
+///
+/// **Order is load-bearing**: assign ``requestedCategory`` BEFORE
+/// opening the window. `SettingsView` reads it from `.onAppear`, so an
+/// assignment made afterwards races that read and drops the user on
+/// the last-used tab.
 ///
 /// Why an ``@Observable`` instead of a stored property on
 /// ``SettingsView``: SettingsView's ``@State`` lifetime is tied to
@@ -30,8 +43,66 @@ import Observation
 @Observable
 final class SettingsRouter {
     /// Pending deep-link target. Set by call sites just before
-    /// ``openSettings()``; consumed and cleared by ``SettingsView``
-    /// on appear / on change. Nil means "no override — land on the
-    /// user's last selected tab."
+    /// `openWindow(id: "settings")`; consumed and cleared by
+    /// ``SettingsView`` on appear / on change. Nil means "no override —
+    /// land on the user's last selected tab."
     var requestedCategory: SettingsView.Category?
+
+    /// Which Settings tab a failure-recovery action deep-links to, or `nil`
+    /// when the action is carried out in place (retry, restart, switch
+    /// download source) and must NOT open Settings at all.
+    ///
+    /// Pure, static, and exhaustive so the routing DECISION — not merely the
+    /// fact that some function ran — is pinned by the test suite. A SwiftUI
+    /// body is not reachable from the suite, which is exactly how three of
+    /// these buttons shipped wired to a no-op ``OpenSettingsAction``: nothing
+    /// could observe where they were supposed to land.
+    ///
+    /// No `default` clause, deliberately: a newly added
+    /// ``FailureDiagnosis/Action`` has to state its destination here (or state
+    /// that it has none) rather than inheriting "nowhere" by omission.
+    nonisolated static func settingsCategory(
+        for action: FailureDiagnosis.Action
+    ) -> SettingsView.Category? {
+        switch action {
+        case .openModelManagement:
+            // Settings → Model Management is the cache inspector: what is on
+            // disk, what to delete, what to download. That is the panel an
+            // out-of-memory or failed-load message is telling the user to go
+            // act in.
+            return .modelManagement
+        case .openWebSearchSettings:
+            // Settings → Tools owns the web-search backend picker and its key.
+            return .tools
+        case .retry, .restart, .switchDownloadSource:
+            // Handled by the view that owns the failed operation. Opening
+            // Settings for these would be a non-sequitur.
+            return nil
+        }
+    }
+
+    /// Deep-link to the tab ``action`` belongs on, running ``open`` — the
+    /// caller's `openWindow(id: "settings")` — once the target is staged.
+    /// Returns whether the window was opened; `false` means the action is
+    /// handled in place and Settings must stay shut.
+    ///
+    /// The closure is the point. A `prepare()`-then-`openWindow()` pair leaves
+    /// the ordering rule in the caller's hands, where it can be written the
+    /// wrong way round and produce a silent bug (the user lands on the
+    /// last-used tab instead of the one the button named). Taking the open as a
+    /// closure means the assignment cannot be sequenced after it.
+    @discardableResult
+    func route(_ action: FailureDiagnosis.Action, open: () -> Void) -> Bool {
+        guard let category = Self.settingsCategory(for: action) else { return false }
+        route(to: category, open: open)
+        return true
+    }
+
+    /// The same ordering guarantee for call sites that name their tab directly
+    /// rather than deriving it from a failure (the version pill → Settings →
+    /// App). Pass `nil` for "just open Settings, leave the tab alone."
+    func route(to category: SettingsView.Category?, open: () -> Void) {
+        requestedCategory = category
+        open()
+    }
 }

--- a/apps/rapid-mac/Sources/Rapid/UI/SettingsView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SettingsView.swift
@@ -310,8 +310,8 @@ struct SettingsView: View {
 
     /// Pop the pending deep-link target off the router and apply it.
     /// Clears the field back to nil so a subsequent
-    /// ``openSettings()`` without a request lands on whatever tab
-    /// the user was last on.
+    /// `openWindow(id: "settings")` without a request lands on whatever
+    /// tab the user was last on.
     private func consumeRouterRequest() {
         if let target = router.requestedCategory {
             categorySelection.selected = target
@@ -393,13 +393,22 @@ struct SettingsView: View {
                     .fixedSize(horizontal: false, vertical: true)
             }
 
+            // All three point at documents that exist in the repository. Two
+            // of them did not: "Privacy policy" opened rapidmlx.com/privacy,
+            // which 404s (the page has never been published), and
+            // "Open-source credits" opened blob/main/THIRD_PARTY.md — the
+            // repository ROOT — while the file has always lived one directory
+            // down, under apps/rapid-mac/. Both are now pointed at the real
+            // documents; ``RepositoryLinkTargetsTests`` fails the build if
+            // either path stops existing. When rapidmlx.com/privacy is
+            // published, the privacy link can move back to the website.
             HStack(spacing: 12) {
                 Link("Privacy policy",
-                     destination: URL(string: "https://rapidmlx.com/privacy")!)
+                     destination: URL(string: "https://github.com/raullenchai/Rapid-MLX/blob/main/apps/rapid-mac/PRIVACY.md")!)
                 Link("License (EULA)",
                      destination: URL(string: "https://github.com/raullenchai/Rapid-MLX/blob/main/LICENSE")!)
                 Link("Open-source credits",
-                     destination: URL(string: "https://github.com/raullenchai/Rapid-MLX/blob/main/THIRD_PARTY.md")!)
+                     destination: URL(string: "https://github.com/raullenchai/Rapid-MLX/blob/main/apps/rapid-mac/THIRD_PARTY.md")!)
             }
             .font(.callout)
 

--- a/apps/rapid-mac/THIRD_PARTY.md
+++ b/apps/rapid-mac/THIRD_PARTY.md
@@ -2,25 +2,64 @@
 
 Rapid-MLX Desktop incorporates open-source software from the following
 projects. Each is used under the terms of its original license. The
-full license texts are reproduced in the linked repositories.
+full license texts are reproduced in the linked repositories, and — for
+the bundled Python payload — inside the shipped app itself, under
+`Contents/Resources/rapid-mlx/site-packages/*.dist-info/licenses/`.
+
+This is the document the app's **Settings → Privacy → "Open-source
+credits"** link opens.
+
+**Scope.** Components this project declares directly: the Swift packages
+in `Package.swift` (plus the transitive ones actually linked into the
+binary), the engine requirements in the monorepo's root `pyproject.toml`,
+and what `scripts/build-sidecar.sh` installs by name. The full transitive
+Python closure is **not** enumerated — a shipped bundle also contains
+everything those packages pull in (`pydantic`, `starlette`, `safetensors`,
+`certifi`, `regex`, …), each under its own license and each carrying its
+own license file in the bundle. Optional engine extras (`[vision]`,
+`[audio]`, `[chat]`, and the rest) are **not** installed into the sidecar
+and are out of scope. Model weights downloaded at runtime carry their own
+separate licenses from their publishers.
 
 ## Swift packages
 
-* **swift-testing** — Apple Inc. — Apache License 2.0
-  https://github.com/swiftlang/swift-testing
-  Used by the test target only.
+Declared in `Package.swift`. `Package.resolved` is git-ignored (see
+`.gitignore`), so the manifest range is the shipped contract; the
+"resolved" column is what a clean `swift package resolve` produced at the
+time of writing. Run that command for the exact revisions in your build.
 
-* **ViewInspector** — Alexey Naumov — MIT License
-  https://github.com/nalexn/ViewInspector
-  Used by the test target only — SwiftUI view-tree introspection.
+### Direct
 
 * **swift-markdown-ui** — Guillermo González Real — MIT License
+  `from: "2.4.0"` (resolved 2.4.1)
   https://github.com/gonzalezreal/swift-markdown-ui
   Block-level markdown rendering for assistant messages.
 
-* **sentry-cocoa** — Functional Software, Inc. dba Sentry — MIT License
-  https://github.com/getsentry/sentry-cocoa
-  Delivery of feedback that a user explicitly submits from the app.
+* **SwiftMath** — Computer Inspirations — MIT License
+  `from: "1.7.0"` (resolved 1.7.3)
+  https://github.com/mgriebling/SwiftMath
+  LaTeX rendering for math/STEM model responses.
+
+### Transitive, but linked into the shipped binary
+
+Pulled in by `swift-markdown-ui`, so they are compiled into the app even
+though the manifest does not name them.
+
+* **NetworkImage** — Guille Gonzalez — MIT License (resolved 6.0.1)
+  https://github.com/gonzalezreal/NetworkImage
+
+* **swift-cmark** — John MacFarlane and contributors — BSD-2-Clause
+  (resolved 0.8.0)
+  https://github.com/swiftlang/swift-cmark
+  Its `COPYING` is BSD-2-Clause for cmark itself and additionally carries
+  MIT notices for code cmark vendors in turn — for example `houdini*`
+  © 2012 Vicent Martí, `buffer.[ch]` / `chunk.h` © 2012 GitHub, Inc., and
+  the utf8proc-derived `utf8.c` © 2009 Public Software Group e. V. — plus
+  CC-BY-SA-4.0 for the CommonMark spec fixture, which is test-only and not
+  shipped. That `COPYING` file, not this summary, is the complete notice.
+
+`Sources/RapidCrashHandler` is first-party C in this repository, not a
+third-party package.
 
 _Sparkle is on the roadmap as the eventual auto-update framework
 (see [issue #16](https://github.com/raullenchai/Rapid-MLX/issues/16))
@@ -37,16 +76,107 @@ Sparkle once it actually lands in `Package.resolved`._
   assets. © 2026 MachineFi. Embedded in the app bundle (not the
   source tree under an OSS license).
 
-## Server dependencies (informational)
+## Bundled engine (the `rapid-mlx` sidecar)
 
-The `rapid-mlx` server that Rapid-MLX Desktop talks to is a separate
-project licensed under Apache 2.0:
+Since v0.6.6 the `rapid-mlx` engine ships **inside** the app, staged by
+`scripts/build-sidecar.sh` at `Contents/Resources/rapid-mlx/`. It is the
+same Apache-2.0 project this app lives in:
 https://github.com/raullenchai/Rapid-MLX
 
-It in turn vendors mlx-lm, mlx-vlm, and openai-harmony — each under
-their respective Apache 2.0 / MIT licenses. Those are NOT bundled
-inside Rapid-MLX Desktop and are installed separately via `pip` /
-`pipx` / `brew`.
+### Interpreter
 
-For the complete machine-readable resolution of pinned versions,
-see `Package.resolved` at the repository root.
+* **CPython 3.12.13** — Python Software Foundation License 2.0
+  https://www.python.org/
+* **python-build-standalone** (the redistributable build, tag `20260610`)
+  — MPL-2.0
+  https://github.com/astral-sh/python-build-standalone
+
+Both pinned by `PBS_VERSION` / `PBS_TAG` in `scripts/build-sidecar.sh`.
+
+### Engine runtime dependencies
+
+The root `pyproject.toml` `[project].dependencies` block, installed in
+full. The ranges below are the **root manifest's**; the sidecar build
+narrows one of them, pinning `transformers>=5.5.0,<5.13` at install time
+(step 2 of `scripts/build-sidecar.sh`), so a shipped bundle never carries
+a `transformers` older than 5.5.0.
+
+| Component | Declared range | License | Project |
+| --- | --- | --- | --- |
+| mlx | `>=0.31.2,<0.32` | MIT | https://github.com/ml-explore/mlx |
+| mlx-lm | `>=0.31.3,<0.32` | MIT | https://github.com/ml-explore/mlx-lm |
+| transformers | `>=5.0.0,<5.13` | Apache-2.0 | https://github.com/huggingface/transformers |
+| tokenizers | `>=0.19.0` | Apache-2.0 | https://github.com/huggingface/tokenizers |
+| huggingface-hub | `>=0.23.0` | Apache-2.0 | https://github.com/huggingface/huggingface_hub |
+| numpy | `>=1.24.0` | BSD-3-Clause (also 0BSD, MIT, Zlib, CC0-1.0 components) | https://github.com/numpy/numpy |
+| tqdm | `>=4.66.0` | MPL-2.0 AND MIT | https://github.com/tqdm/tqdm |
+| pyyaml | `>=6.0` | MIT | https://github.com/yaml/pyyaml |
+| tomli-w | `>=1.0.0` | MIT | https://github.com/hukkin/tomli-w |
+| requests | `>=2.28.0` | Apache-2.0 | https://github.com/psf/requests |
+| rich | `>=13.8.0` | MIT | https://github.com/Textualize/rich |
+| tabulate | `>=0.9.0` | MIT | https://github.com/astanin/python-tabulate |
+| psutil | `>=5.9.0` | BSD-3-Clause | https://github.com/giampaolo/psutil |
+| fastapi | `>=0.100.0` | MIT | https://github.com/fastapi/fastapi |
+| uvicorn | `>=0.23.0` | BSD-3-Clause | https://github.com/Kludex/uvicorn |
+| mcp | `>=1.9.3` | MIT | https://github.com/modelcontextprotocol/python-sdk |
+| jsonschema | `>=4.0.0` | MIT | https://github.com/python-jsonschema/jsonschema |
+| argcomplete | `>=3.6` | Apache-2.0 | https://github.com/kislyuk/argcomplete |
+| websockets | `>=12.0` | BSD-3-Clause | https://github.com/python-websockets/websockets |
+| openai-harmony | `>=0.0.8` | Apache-2.0 | https://github.com/openai/harmony |
+| llguidance | `>=1.7.6` | MIT | https://github.com/microsoft/llguidance |
+
+Additionally installed by name with `--no-deps`, so the gemma-4 loader
+path works in a text-only bundle:
+
+| Component | Pin | License | Project |
+| --- | --- | --- | --- |
+| mlx-vlm | `==0.6.3` | MIT | https://github.com/Blaizzy/mlx-vlm |
+| Pillow | `>=10.0` | MIT-CMU | https://github.com/python-pillow/Pillow |
+
+### Third-party source vendored into the engine
+
+The engine vendors upstream code directly into its own tree, and that tree
+is installed into the sidecar — so this code travels in the app,
+predominantly as compiled bytecode (the sidecar build hoists `.pyc` files
+and drops the matching `.py` sources, keeping every `__init__.py` so
+packages stay importable; the in-tree `LICENSE` / `NOTICE` files are
+package data and are kept as-is). Each vendored file records its
+provenance in its own header or in a sibling `NOTICE` — always the
+upstream project, and in most cases the exact revision as well.
+
+**This list is not exhaustive**, and is not offered as one. Vendoring
+happens per model family and per subsystem, so the authoritative record
+is the per-file headers, not this table. To enumerate them for a given
+revision:
+
+```bash
+grep -rn "endored from\|orted from\|dapted from\|derive[sd] from" \
+    vllm_mlx/ videox_fun_mlx/
+```
+
+The largest and most self-contained components:
+
+| Component | Upstream | Upstream license | In-tree |
+| --- | --- | --- | --- |
+| MLX Stable Audio 3 | https://github.com/Stability-AI/stable-audio-3 | MIT | `vllm_mlx/audio/sa3/` (`LICENSE`, `NOTICE`) |
+| CogVideoX-Fun MLX | https://github.com/dgrauet/VideoX-Fun-mlx | Apache-2.0 | `videox_fun_mlx/` (`LICENSE`, `NOTICE`) |
+| TurboQuant Metal kernels | https://github.com/arozanov/turboquant-mlx | Apache-2.0 | `vllm_mlx/kernels/turboquant_fused.metal` |
+| Gemma 4 model classes | https://github.com/Blaizzy/mlx-vlm (v0.6.3) | MIT | `vllm_mlx/models/gemma4_vendored/` |
+| Hunyuan 3 model class | https://github.com/ml-explore/mlx-lm (PR #1211) | MIT | `vllm_mlx/models/hy_v3.py` |
+| DeepSeek V4 model classes | https://github.com/ml-explore/mlx-lm (`_ds4` branch, © Apple Inc.) | MIT | `vllm_mlx/models/deepseek_v4.py`, `deepseek_v4_cache.py`, `deepseek_v4_hyper_connection.py`, `deepseek_v4_switch.py` |
+| MTP speculative-decoding head + generator | https://github.com/ml-explore/mlx-lm (PR #990) | MIT | `vllm_mlx/spec_decode/mtp/head.py`, `generator.py` |
+| Request/status model, adapted | https://github.com/vllm-project/vllm | Apache-2.0 | `vllm_mlx/request.py` |
+| Several tool parsers, ported | https://github.com/vllm-project/vllm, https://github.com/sgl-project/sglang | Apache-2.0 | `vllm_mlx/tool_parsers/` |
+
+Two notes on reading that table:
+
+* The **licence column is the upstream project's**, which is what governs
+  redistribution of the vendored code. Many vendored files additionally
+  carry a rapid-mlx `SPDX-License-Identifier` header — that stamp reflects
+  this repository's own default and does not override the upstream terms
+  above.
+* The sibling files under `vllm_mlx/models/deepseek_v4_verify*.py` and
+  `deepseek_v4_rollback.py` are **first-party** rapid-mlx code (Apache-2.0)
+  that happens to share the prefix; they are not vendored.
+
+Paths are relative to the monorepo root, two levels above this file.

--- a/apps/rapid-mac/Tests/RapidTests/RepositoryLinkTargetsTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/RepositoryLinkTargetsTests.swift
@@ -1,0 +1,193 @@
+import Foundation
+import Testing
+
+/// Static integrity check for the in-repo GitHub links the app hard-codes.
+///
+/// Two shipped links opened nothing. "Open-source credits" pointed at
+/// `blob/main/THIRD_PARTY.md` — the repository ROOT — while the file has
+/// always lived one directory down under `apps/rapid-mac/`, so it 404'd. And
+/// the "Privacy policy" link (Settings, and again in the About window) pointed
+/// at `rapidmlx.com/privacy`, a page that has never been published, while a
+/// 259-line `apps/rapid-mac/PRIVACY.md` sat in the repo. Nothing in the build
+/// could notice either one: a `URL(string:)` literal is valid regardless of
+/// whether the far end resolves.
+///
+/// This suite closes that gap **without touching the network**. It reads the
+/// working tree only: every `https://github.com/raullenchai/Rapid-MLX/blob|tree|raw/<ref>/<path>`
+/// URL appearing anywhere under `Sources/Rapid/**` is mapped back to a
+/// repo-relative path, which must exist in this checkout. A file moved,
+/// renamed, or deleted without updating the link fails here, at `swift test`,
+/// instead of in a user's browser — and so does a new link that guesses the
+/// wrong directory, which is the exact mistake that shipped.
+///
+/// Scope and its limits, stated plainly so this is not mistaken for more than
+/// it is: this proves the path exists **on the branch under test**. It cannot
+/// prove the file has been pushed to `main` on GitHub, and it cannot say
+/// anything about URLs pointing OUTSIDE the repository (`rapidmlx.com/...`,
+/// model cards, …) — those would require a network call, which this suite
+/// deliberately never makes. The remedy for an off-repo dead link is to point
+/// it at something in-repo, which is what both privacy links now do.
+@Suite("In-repo GitHub link targets")
+struct RepositoryLinkTargetsTests {
+    /// Repository root, derived from this file's own compile-time location:
+    /// `<root>/apps/rapid-mac/Tests/RapidTests/<this file>`.
+    private static var repositoryRoot: URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()  // RapidTests
+            .deletingLastPathComponent()  // Tests
+            .deletingLastPathComponent()  // rapid-mac
+            .deletingLastPathComponent()  // apps
+            .deletingLastPathComponent()  // <root>
+    }
+
+    private static var sourcesRoot: URL {
+        repositoryRoot
+            .appendingPathComponent("apps/rapid-mac/Sources/Rapid", isDirectory: true)
+    }
+
+    /// `blob` / `tree` / `raw` all address a path inside the repo; only
+    /// bare `https://github.com/raullenchai/Rapid-MLX` (the project landing
+    /// page, used by the About panel) addresses no file and is skipped.
+    ///
+    /// Computed rather than a stored `static let`: `NSRegularExpression` is not
+    /// `Sendable` on every SDK this package builds against, and a stored static
+    /// of a non-`Sendable` type is a hard error under the Swift 6 language mode.
+    private static func linkPattern() throws -> NSRegularExpression {
+        try NSRegularExpression(
+            pattern: #"https://github\.com/raullenchai/Rapid-MLX/(?:blob|tree|raw)/[^/\s"'()]+/([^\s"'()<>]+)"#
+        )
+    }
+
+    private struct RepoLink {
+        let path: String
+        let sourceFile: String
+    }
+
+    /// Every in-repo GitHub path referenced from a Swift source file, with the
+    /// file that references it (so a failure names the call site to fix).
+    private static func repoLinks() throws -> [RepoLink] {
+        let fm = FileManager.default
+        let pattern = try linkPattern()
+        var links: [RepoLink] = []
+
+        guard let walker = fm.enumerator(
+            at: sourcesRoot,
+            includingPropertiesForKeys: [.isRegularFileKey]
+        ) else {
+            return links
+        }
+
+        for case let url as URL in walker where url.pathExtension == "swift" {
+            let text = try String(contentsOf: url, encoding: .utf8)
+            let range = NSRange(text.startIndex..<text.endIndex, in: text)
+            for match in pattern.matches(in: text, range: range) {
+                guard let captured = Range(match.range(at: 1), in: text) else { continue }
+                // Strip a `#fragment` / `?query` — neither is part of the path
+                // GitHub resolves against the tree.
+                var path = String(text[captured])
+                if let cut = path.firstIndex(where: { $0 == "#" || $0 == "?" }) {
+                    path = String(path[path.startIndex..<cut])
+                }
+                path = path.removingPercentEncoding ?? path
+                links.append(
+                    RepoLink(path: path, sourceFile: url.lastPathComponent)
+                )
+            }
+        }
+        return links
+    }
+
+    /// Guard on the guard: if `#filePath` arithmetic or the source layout ever
+    /// changes, the scan below would find nothing and pass vacuously. Fail
+    /// loudly instead.
+    @Test("the source tree the scan reads is actually there")
+    func sourceTreeIsReachable() {
+        var isDirectory: ObjCBool = false
+        let exists = FileManager.default.fileExists(
+            atPath: Self.sourcesRoot.path,
+            isDirectory: &isDirectory
+        )
+        #expect(exists && isDirectory.boolValue,
+                "expected a Sources/Rapid directory at \(Self.sourcesRoot.path)")
+    }
+
+    @Test("every hard-coded in-repo link points at a file that exists")
+    func everyInRepoLinkResolves() throws {
+        let links = try Self.repoLinks()
+
+        // The scan must find something — an over-tightened regex that matches
+        // nothing must not read as "all links are fine".
+        #expect(!links.isEmpty, "found no in-repo GitHub links to verify")
+
+        for link in links {
+            let target = Self.repositoryRoot.appendingPathComponent(link.path)
+            #expect(
+                FileManager.default.fileExists(atPath: target.path),
+                """
+                \(link.sourceFile) links to \(link.path), which does not exist \
+                in this checkout. The app would open a GitHub 404. Point the \
+                link at the real path — most likely the file lives under \
+                apps/rapid-mac/ rather than the repository root, which is \
+                exactly the mistake this test exists to catch. Do not delete \
+                the link if the app owes the user the document it promises.
+                """
+            )
+        }
+    }
+
+    /// Every user-facing link, pinned to the file that renders it AND the
+    /// document it must reach.
+    ///
+    /// Per-surface, not an aggregate set: the privacy policy is linked from two
+    /// different places, and a set-membership check stays green when one of
+    /// them regresses to an off-repo 404 while the other stays correct — which
+    /// is exactly the state this PR found the app in. Pinning `(source file,
+    /// path)` makes each surface fail on its own.
+    ///
+    /// Paths, not just "some link exists": the shipped bug was a link naming
+    /// the WRONG directory for a file that did exist.
+    @Test(
+        "each surface links to the document it promises",
+        arguments: [
+            // Settings → Privacy renders all three of these.
+            ("SettingsView.swift", "apps/rapid-mac/PRIVACY.md"),
+            ("SettingsView.swift", "LICENSE"),
+            ("SettingsView.swift", "apps/rapid-mac/THIRD_PARTY.md"),
+            // The About window's "Privacy" link — the second dead privacy link.
+            ("AboutPanel.swift", "apps/rapid-mac/PRIVACY.md"),
+        ]
+    )
+    func eachSurfaceLinksToItsDocument(sourceFile: String, path: String) throws {
+        let links = try Self.repoLinks()
+        #expect(
+            links.contains { $0.sourceFile == sourceFile && $0.path == path },
+            "\(sourceFile) no longer links to \(path)"
+        )
+        let target = Self.repositoryRoot.appendingPathComponent(path)
+        #expect(
+            FileManager.default.fileExists(atPath: target.path),
+            "\(path) is missing from the checkout"
+        )
+    }
+
+    /// The repository root holds a `LICENSE` but **not** `THIRD_PARTY.md` or
+    /// `PRIVACY.md` — those are app documents under `apps/rapid-mac/`. Asserted
+    /// so nobody "fixes" a future root-path link by creating a second, diverging
+    /// copy at the root instead of correcting the link.
+    @Test("the app documents live under apps/rapid-mac, not at the root")
+    func appDocumentsAreNotDuplicatedAtTheRoot() {
+        let fm = FileManager.default
+        for name in ["THIRD_PARTY.md", "PRIVACY.md"] {
+            #expect(
+                !fm.fileExists(
+                    atPath: Self.repositoryRoot.appendingPathComponent(name).path
+                ),
+                """
+                \(name) exists at the repository root as well as under \
+                apps/rapid-mac/. Two attribution/privacy documents drift apart; \
+                keep the app's copy and point links at it.
+                """
+            )
+        }
+    }
+}

--- a/apps/rapid-mac/Tests/RapidTests/SettingsDeepLinkRoutingTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SettingsDeepLinkRoutingTests.swift
@@ -1,0 +1,514 @@
+import Foundation
+import Testing
+
+@testable import Rapid
+
+/// Static guard against `OpenSettingsAction` coming back.
+///
+/// Issue #1578 asks for one explicitly: "either a lint/grep check that
+/// `openSettings()` never appears outside a doc comment, or deleting the
+/// `@Environment(\.openSettings)` properties entirely so the call doesn't
+/// compile." Both are done — the properties are gone, and this pins that they
+/// stay gone. Deletion alone is not a guard: nothing stops the next view from
+/// declaring the property again, and the failure mode is silent (the button
+/// renders, responds to the pointer, and does nothing).
+///
+/// Doc comments are exempt on purpose. Several call sites now carry a comment
+/// naming `@Environment(\.openSettings)` as the thing NOT to use, and that
+/// explanation is the reason the trap stays shut.
+@Suite("openSettings must not come back")
+struct OpenSettingsActionAbsenceTests {
+    private static var sourcesRoot: URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()  // RapidTests
+            .deletingLastPathComponent()  // Tests
+            .deletingLastPathComponent()  // rapid-mac
+            .appendingPathComponent("Sources/Rapid", isDirectory: true)
+    }
+
+    /// `AppDelegate.openSettingsWindow` is the WORKING bridge
+    /// (`openWindow(id: "settings")`) and shares a prefix with the broken API,
+    /// so match the two real spellings rather than the bare word.
+    /// `\s*` before the paren so `openSettings ()` cannot slip through.
+    private static func forbiddenPattern() throws -> NSRegularExpression {
+        try NSRegularExpression(pattern: #"\\\.openSettings|openSettings\s*\("#)
+    }
+
+    /// Blank out comments **and string literals**, so a doc comment naming the
+    /// API is not an offence while `/* … */ openSettings()` on one line still
+    /// is. Blanked characters become spaces rather than being deleted, so the
+    /// line and column numbers this suite reports stay honest.
+    ///
+    /// String literals are tracked for a reason that is not cosmetic. Without
+    /// it, `let url = "https://example.com"` opens a line comment at the `//`
+    /// inside the string, and every subsequent character on that line — up to
+    /// and including a real `openSettings()` — gets blanked. That is a false
+    /// NEGATIVE: the guard would go quiet exactly when it should fire. Blanking
+    /// literal contents fixes both directions at once, since a string that
+    /// merely mentions `openSettings(` then cannot raise a false alarm either.
+    ///
+    /// Handles nested block comments, `//` to end of line, escapes, multiline
+    /// `"""` literals, and raw `#"…"#` literals of any pound count. It is still
+    /// not a full Swift lexer: code inside a string interpolation is blanked
+    /// along with the literal, so `"\(openSettings())"` would slip past. That
+    /// is the one acknowledged blind spot, and it is not a shape anyone writes.
+    static func strippingCommentsAndStringLiterals(_ source: String) -> String {
+        enum Mode {
+            case code
+            case lineComment
+            case blockComment(depth: Int)
+            case string(pounds: Int, multiline: Bool)
+        }
+
+        var out = ""
+        out.reserveCapacity(source.count)
+        var mode = Mode.code
+        var index = source.startIndex
+
+        /// Does `literal` start at `position`, without running off the end?
+        func matches(_ literal: String, at position: String.Index) -> Bool {
+            var cursor = position
+            for character in literal {
+                guard cursor < source.endIndex, source[cursor] == character else { return false }
+                cursor = source.index(after: cursor)
+            }
+            return true
+        }
+
+        /// `count` characters on, clamped to `endIndex` so no step can trap.
+        func stepping(_ position: String.Index, by count: Int) -> String.Index {
+            source.index(position, offsetBy: count, limitedBy: source.endIndex) ?? source.endIndex
+        }
+
+        /// Blank `count` characters, preserving any newline among them so the
+        /// output stays line-for-line with the input.
+        func blank(_ count: Int) {
+            var cursor = index
+            for _ in 0..<count {
+                guard cursor < source.endIndex else { break }
+                out.append(source[cursor] == "\n" ? "\n" : " ")
+                cursor = source.index(after: cursor)
+            }
+        }
+
+        while index < source.endIndex {
+            let character = source[index]
+
+            switch mode {
+            case .lineComment:
+                if character == "\n" { mode = .code }
+                blank(1)
+                index = source.index(after: index)
+
+            case .blockComment(let depth):
+                // Swift block comments nest, so `/* /* */ */` must not end early.
+                if matches("*/", at: index) {
+                    mode = depth == 1 ? .code : .blockComment(depth: depth - 1)
+                    blank(2)
+                    index = stepping(index, by: 2)
+                } else if matches("/*", at: index) {
+                    mode = .blockComment(depth: depth + 1)
+                    blank(2)
+                    index = stepping(index, by: 2)
+                } else {
+                    blank(1)
+                    index = source.index(after: index)
+                }
+
+            case .string(let pounds, let multiline):
+                let closing = (multiline ? "\"\"\"" : "\"") + String(repeating: "#", count: pounds)
+                // In a raw literal the escape is `\` followed by that many `#`.
+                let escape = "\\" + String(repeating: "#", count: pounds)
+                if matches(closing, at: index) {
+                    mode = .code
+                    blank(closing.count)
+                    index = stepping(index, by: closing.count)
+                } else if matches(escape, at: index) {
+                    // Consume the escape AND the character it escapes, so a
+                    // `\"` cannot be mistaken for the terminator.
+                    blank(escape.count + 1)
+                    index = stepping(index, by: escape.count + 1)
+                } else {
+                    blank(1)
+                    index = source.index(after: index)
+                }
+
+            case .code:
+                // Raw string opener: one or more `#` immediately before a quote.
+                var pounds = 0
+                var probe = index
+                while probe < source.endIndex, source[probe] == "#" {
+                    pounds += 1
+                    probe = source.index(after: probe)
+                }
+                if pounds > 0, probe < source.endIndex, source[probe] == "\"" {
+                    let multiline = matches("\"\"\"", at: probe)
+                    let opener = pounds + (multiline ? 3 : 1)
+                    mode = .string(pounds: pounds, multiline: multiline)
+                    blank(opener)
+                    index = stepping(index, by: opener)
+                } else if character == "\"" {
+                    let multiline = matches("\"\"\"", at: index)
+                    let opener = multiline ? 3 : 1
+                    mode = .string(pounds: 0, multiline: multiline)
+                    blank(opener)
+                    index = stepping(index, by: opener)
+                } else if matches("//", at: index) {
+                    mode = .lineComment
+                    blank(2)
+                    index = stepping(index, by: 2)
+                } else if matches("/*", at: index) {
+                    mode = .blockComment(depth: 1)
+                    blank(2)
+                    index = stepping(index, by: 2)
+                } else {
+                    out.append(character)
+                    index = source.index(after: index)
+                }
+            }
+        }
+        return out
+    }
+
+    @Test("no source file calls openSettings() or holds the environment action")
+    func noOpenSettingsInSources() throws {
+        let fm = FileManager.default
+        let pattern = try Self.forbiddenPattern()
+        var offenders: [String] = []
+
+        let walker = try #require(fm.enumerator(at: Self.sourcesRoot, includingPropertiesForKeys: nil))
+        for case let url as URL in walker where url.pathExtension == "swift" {
+            let stripped = Self.strippingCommentsAndStringLiterals(try String(contentsOf: url, encoding: .utf8))
+            for (index, line) in stripped.components(separatedBy: .newlines).enumerated() {
+                let range = NSRange(line.startIndex..<line.endIndex, in: line)
+                guard pattern.firstMatch(in: line, range: range) != nil else { continue }
+                offenders.append(
+                    "\(url.lastPathComponent):\(index + 1): \(line.trimmingCharacters(in: .whitespaces))"
+                )
+            }
+        }
+
+        #expect(
+            offenders.isEmpty,
+            """
+            This app declares no SwiftUI `Settings` scene, so `OpenSettingsAction` \
+            is a silent no-op — a button that renders and does nothing. Use \
+            `@Environment(\\.openWindow)` + `openWindow(id: "settings")`, and go \
+            through `SettingsRouter.route(_:open:)` if a specific tab is wanted. \
+            Offenders:
+            \(offenders.joined(separator: "\n"))
+            """
+        )
+    }
+
+    /// The stripper is load-bearing — if it blanked too much, the scan above
+    /// would pass vacuously — so its behaviour is pinned directly.
+    @Test("the comment stripper keeps code and drops only comments")
+    func stripperBehaviour() throws {
+        let pattern = try Self.forbiddenPattern()
+        func hits(_ source: String) -> Int {
+            let stripped = OpenSettingsActionAbsenceTests.strippingCommentsAndStringLiterals(source)
+            let range = NSRange(stripped.startIndex..<stripped.endIndex, in: stripped)
+            return pattern.numberOfMatches(in: stripped, range: range)
+        }
+
+        // Exempt: the explanatory comments the fix deliberately leaves behind.
+        #expect(hits("/// use openSettings() never\n") == 0)
+        #expect(hits("// @Environment(\\.openSettings)\n") == 0)
+        #expect(hits("/* openSettings()\n   still a comment */\n") == 0)
+
+        // Caught: real code, including the shapes a naive line check misses.
+        #expect(hits("openSettings()\n") == 1)
+        #expect(hits("openSettings ()\n") == 1)
+        #expect(hits("@Environment(\\.openSettings) var x\n") == 1)
+        #expect(hits("/* c */ openSettings()\n") == 1)
+        #expect(hits("let x = 1 // note\nopenSettings()\n") == 1)
+
+        // Not caught: the working bridge, which shares the prefix.
+        #expect(hits("AppDelegate.openSettingsWindow?()\n") == 0)
+
+        // Swift block comments nest; an inner `*/` must not end the outer one.
+        #expect(hits("/* /* openSettings() */ openSettings() */\nlet a = 1\n") == 0)
+        // Code AFTER a nested comment closes is still code.
+        #expect(hits("/* /* x */ */ openSettings()\n") == 1)
+
+        // FALSE-NEGATIVE guard. A `//` inside a string literal must not open a
+        // comment — otherwise the rest of the line, including a real call, goes
+        // unseen. This app hard-codes https:// URLs all over its sources, so
+        // this is the everyday case, not a contrived one.
+        #expect(hits("let u = \"https://example.com\"; openSettings()\n") == 1)
+        #expect(hits("let u = #\"https://example.com\"#; openSettings()\n") == 1)
+        #expect(hits("let u = \"\"\"\nhttps://a\n\"\"\"\nopenSettings()\n") == 1)
+        // A `/*` inside a string must not open a block comment either, which
+        // would otherwise swallow every following line in the file.
+        #expect(hits("let s = \"/*\"\nopenSettings()\n") == 1)
+        // An escaped quote must not be read as the terminator.
+        #expect(hits("let s = \"a\\\" // b\"\nopenSettings()\n") == 1)
+
+        // FALSE-POSITIVE guard, the other half of the same mechanism: a string
+        // that merely mentions the API is not a call.
+        #expect(hits("let s = \"openSettings()\"\n") == 0)
+        #expect(hits("let s = #\"openSettings()\"#\n") == 0)
+    }
+
+    /// Degenerate inputs the scan will meet if a source file is ever empty,
+    /// a single character, or ends inside an unterminated comment. These must
+    /// return, not trap — the earlier implementation indexed past `endIndex`
+    /// and crashed the whole suite on an empty file.
+    @Test("the comment stripper survives degenerate input")
+    func stripperEdgeCases() {
+        let strip = OpenSettingsActionAbsenceTests.strippingCommentsAndStringLiterals
+        #expect(strip("") == "")
+        #expect(strip("x") == "x")
+        #expect(strip("/") == "/")
+        #expect(strip("//") == "  ")
+        #expect(strip("/*") == "  ")
+        #expect(strip("\"") == " ")
+        #expect(strip("#") == "#")
+        #expect(strip("let a = 1") == "let a = 1")
+        // Unterminated literals must terminate the walk, not run off the end.
+        #expect(strip("let s = \"abc").hasPrefix("let s = "))
+        #expect(strip("let s = #\"abc").hasPrefix("let s = "))
+        // Unterminated block comment: everything after it is blanked, while
+        // newlines survive so reported line numbers stay aligned with the file.
+        let unterminated = strip("a\n/* b\nc")
+        #expect(unterminated.hasPrefix("a\n"))
+        #expect(!unterminated.contains("b"))
+        #expect(!unterminated.contains("c"))
+        #expect(unterminated.filter { $0 == "\n" }.count == 2)
+    }
+
+    /// Line numbers in the failure message are only useful if they are right,
+    /// which is why comments are blanked to spaces rather than deleted.
+    @Test("stripping preserves line count and column positions")
+    func strippingPreservesLineGeometry() {
+        let source = """
+        let a = 1 // trailing
+        /* two
+           lines */ let b = 2
+        let c = 3
+        """
+        let stripped = OpenSettingsActionAbsenceTests.strippingCommentsAndStringLiterals(source)
+        let before = source.components(separatedBy: "\n")
+        let after = stripped.components(separatedBy: "\n")
+        #expect(before.count == after.count)
+        for (original, blanked) in zip(before, after) {
+            #expect(original.count == blanked.count)
+        }
+        // Code trailing a block-comment close on the same line survives, blanked
+        // only up to the `*/`, so its column position is unchanged.
+        #expect(after[2] == "            let b = 2")
+        #expect(after[3] == "let c = 3")
+    }
+
+    /// Guard on the guard: if the path arithmetic breaks, the scan above would
+    /// find nothing and pass vacuously.
+    @Test("the source tree the scan reads is actually there")
+    func sourceTreeIsReachable() {
+        var isDirectory: ObjCBool = false
+        let exists = FileManager.default.fileExists(
+            atPath: Self.sourcesRoot.path,
+            isDirectory: &isDirectory
+        )
+        #expect(exists && isDirectory.boolValue)
+    }
+}
+
+/// Where each failure-recovery button lands.
+///
+/// The bug this pins: ``QuickstartView`` held
+/// `@Environment(\.openSettings)` and called it for its recovery actions. This
+/// app declares no SwiftUI ``Settings`` scene — it uses a real
+/// `Window("Settings", id: "settings")` — so `OpenSettingsAction` was a silent
+/// no-op and those buttons did **nothing**, at the exact moment a first-run
+/// download or model start had already failed. Nothing observed it, because
+/// the routing decision lived inside a SwiftUI body and a body is not
+/// reachable from this suite.
+///
+/// So the decision was lifted out into
+/// ``SettingsRouter/settingsCategory(for:)`` — pure, static, exhaustive — and
+/// these tests assert the DESTINATION of every action, not merely that some
+/// function got called. A button rewired to the wrong tab, or to nowhere,
+/// fails here.
+@Suite("Settings deep-link routing")
+struct SettingsDeepLinkRoutingTests {
+    /// The whole table in one place. Written out literally, and checked for
+    /// totality against ``FailureDiagnosis/Action/allCases``, so a newly added
+    /// action cannot ship without someone stating where it goes.
+    private static let expected: [FailureDiagnosis.Action: SettingsView.Category?] = [
+        .openModelManagement: .modelManagement,
+        .openWebSearchSettings: .tools,
+        // Handled in place by the view that owns the failed operation; opening
+        // Settings for these would be a non-sequitur.
+        .retry: nil,
+        .restart: nil,
+        .switchDownloadSource: nil,
+    ]
+
+    @Test("the routing table covers every action")
+    func tableIsTotal() {
+        #expect(Set(Self.expected.keys) == Set(FailureDiagnosis.Action.allCases))
+    }
+
+    @Test("each action routes to the tab the table names")
+    func eachActionRoutesToItsTab() {
+        for (action, category) in Self.expected {
+            #expect(
+                SettingsRouter.settingsCategory(for: action) == category,
+                "\(action) should route to \(String(describing: category))"
+            )
+        }
+    }
+
+    /// The invariant that would have caught the shipped defect on its own: a
+    /// button whose label tells the user it will OPEN something has to have
+    /// somewhere to open.
+    @Test("every action titled \"Open …\" has a real destination")
+    func openTitledActionsHaveDestinations() {
+        for action in FailureDiagnosis.Action.allCases where action.title.hasPrefix("Open") {
+            #expect(
+                SettingsRouter.settingsCategory(for: action) != nil,
+                "\(action) is titled \"\(action.title)\" but routes nowhere"
+            )
+        }
+    }
+
+    // MARK: - Diagnosis → button → tab, end to end
+
+    @Test(
+        "a failed model start lands the user on Model Management",
+        arguments: [FailureDiagnosis.Kind.modelOutOfMemory, .modelLoadFailed]
+    )
+    func modelFailuresRouteToModelManagement(kind: FailureDiagnosis.Kind) throws {
+        let action = try #require(FailureDiagnoser.diagnosis(for: kind).action)
+        #expect(action == .openModelManagement)
+        #expect(SettingsRouter.settingsCategory(for: action) == .modelManagement)
+    }
+
+    @Test("a throttled web search lands the user on Tools")
+    func rateLimitedSearchRoutesToTools() throws {
+        let action = try #require(
+            FailureDiagnoser.diagnosis(for: .webSearchRateLimited).action
+        )
+        #expect(action == .openWebSearchSettings)
+        #expect(SettingsRouter.settingsCategory(for: action) == .tools)
+    }
+
+    /// No diagnosis may offer a button that opens nothing. This is the whole
+    /// defect class, asserted over every kind the app can produce.
+    @Test("no diagnosis offers an \"Open …\" button with nowhere to go")
+    func noDiagnosisOffersADeadButton() {
+        for kind in FailureDiagnosis.Kind.allCases {
+            guard let action = FailureDiagnoser.diagnosis(for: kind).action else { continue }
+            guard action.title.hasPrefix("Open") else { continue }
+            #expect(
+                SettingsRouter.settingsCategory(for: action) != nil,
+                "\(kind) offers \"\(action.title)\", which routes nowhere"
+            )
+        }
+    }
+
+    // MARK: - The retired openPermissions action
+
+    /// `openPermissions` is gone. It titled a button "Open Permissions" with
+    /// no tab to open: this app's ``SettingsView/Category`` set holds no
+    /// folder-grant or file-access control (Settings → Privacy is telemetry
+    /// consent), and the conditions that produced it are not reachable here —
+    /// ``FailureDiagnoser/toolFailureKind`` derives these two kinds only for
+    /// the tool names `run_command`, `read_file`, `list_directory`,
+    /// `write_file`, `edit_file`, and ``BuiltinToolRegistry`` deliberately
+    /// ships none of them.
+    ///
+    /// The ``Kind`` cases stay — they are persisted in transcripts and must
+    /// keep decoding — but they now carry no action, and their copy no longer
+    /// promises an "Allow…" control the app does not have.
+    @Test(
+        "permission-denied kinds no longer offer a button",
+        arguments: [FailureDiagnosis.Kind.commandPermissionDenied, .filePermissionDenied]
+    )
+    func permissionKindsCarryNoAction(kind: FailureDiagnosis.Kind) {
+        let diagnosis = FailureDiagnoser.diagnosis(for: kind)
+        #expect(diagnosis.action == nil)
+        #expect(!diagnosis.message.contains("Allow"))
+        // Still a fault, not a user choice — only the affordance changed.
+        #expect(diagnosis.severity == .error)
+    }
+
+    @Test("a legacy permission-denied row renders no inline tool-card button")
+    func permissionKindsRenderNoInlineButton() {
+        for kind in [FailureDiagnosis.Kind.commandPermissionDenied, .filePermissionDenied] {
+            #expect(
+                FailureDiagnosis.inlineToolCardAction(
+                    for: FailureDiagnoser.diagnosis(for: kind),
+                    canRouteToSettings: true
+                ) == nil
+            )
+        }
+    }
+
+    // MARK: - Ordering
+
+    /// ``SettingsView`` consumes ``SettingsRouter/requestedCategory`` from
+    /// `.onAppear`, so the category must be assigned BEFORE the window opens;
+    /// assigning afterwards races the read and drops the user on the last-used
+    /// tab. ``route`` takes the open as a closure precisely so a call site
+    /// cannot sequence the two the wrong way round.
+    ///
+    /// The spy reads ``requestedCategory`` from INSIDE the open closure — that
+    /// is the moment `SettingsView.onAppear` would run — so this pins the
+    /// ordering as observed by the window, not merely the end state.
+    @MainActor
+    @Test(
+        "route stages the tab before the window opens",
+        arguments: [
+            (FailureDiagnosis.Action.openModelManagement, SettingsView.Category.modelManagement),
+            (FailureDiagnosis.Action.openWebSearchSettings, SettingsView.Category.tools),
+        ]
+    )
+    func routeStagesBeforeOpening(
+        action: FailureDiagnosis.Action,
+        expected: SettingsView.Category
+    ) {
+        let router = SettingsRouter()
+        var categoryWhenWindowOpened: SettingsView.Category??
+        var opens = 0
+
+        let opened = router.route(action) {
+            opens += 1
+            categoryWhenWindowOpened = router.requestedCategory
+        }
+
+        #expect(opened)
+        #expect(opens == 1)
+        #expect(categoryWhenWindowOpened == expected)
+    }
+
+    @MainActor
+    @Test("route(to:) stages a directly-named tab before the window opens")
+    func routeToCategoryStagesBeforeOpening() {
+        let router = SettingsRouter()
+        var categoryWhenWindowOpened: SettingsView.Category??
+
+        // The version pill's deep-link: Settings → App.
+        router.route(to: .app) { categoryWhenWindowOpened = router.requestedCategory }
+
+        #expect(categoryWhenWindowOpened == .app)
+    }
+
+    @MainActor
+    @Test("route never opens the window for an in-place action")
+    func routeRefusesInPlaceActions() {
+        let router = SettingsRouter()
+        router.requestedCategory = .appearance
+
+        for action: FailureDiagnosis.Action in [.retry, .restart, .switchDownloadSource] {
+            var opened = false
+            #expect(router.route(action) { opened = true } == false)
+            #expect(!opened, "\(action) must not open Settings")
+            #expect(
+                router.requestedCategory == .appearance,
+                "\(action) must not overwrite a pending deep-link target"
+            )
+        }
+    }
+}


### PR DESCRIPTION
Two independent classes of user-facing dead end in `apps/rapid-mac`: links that
open a 404, and settings buttons that do nothing at all. Both are verified, both
ship today.

Closes #1578.
Refs #1587 — see "Privacy policy" below; this PR makes the link work but does
not settle where the policy should ultimately live, so #1587 stays open.

---

## 1. Dead settings buttons (#1578)

`@Environment(\.openSettings)` — `OpenSettingsAction` — only does anything when
the app declares a SwiftUI `Settings {}` scene. This app deliberately declares
none: it uses `Window("Settings", id: "settings")` (`RapidApp.swift:261`) and
opens it with `openWindow(id: "settings")`. Every `openSettings()` call site
therefore rendered a button that highlighted on hover, responded to the click,
and did nothing.

The Quickstart failure card is the worst of them. It is on screen *because* the
user's first download or model start already failed, and its recovery button was
inert.

**Fix.** Route through `SettingsRouter.route(_:open:)` (and `route(to:open:)`
for a call site that names its tab directly), which runs the caller's
`openWindow(id: "settings")` as a closure.

Ordering is load-bearing: `SettingsView` consumes
`SettingsRouter.requestedCategory` from `.onAppear`, so the category has to be
assigned *before* the window opens — assign it after and the user silently lands
on the last-used tab. Taking the open as a closure means a call site cannot
sequence the two the wrong way round, rather than leaving that rule to a comment.
The tests read `requestedCategory` from *inside* that closure — the moment
`.onAppear` would run — so they pin the ordering as the window observes it.

### Call sites

#1578 names four. This PR fixes those four and three more.

| # | Site | In #1578 | Reachable today |
|---|---|---|---|
| 1 | `ContentView.SettingsGearButton` | yes | no — `statusFooter` is not referenced from any body |
| 2 | `ContentView.DesktopVersionPill` | yes | no — same footer |
| 3 | `QuickstartView` → `.openModelManagement` | yes | **yes** |
| 4 | `QuickstartView` → `.openPermissions` | yes | see below |
| 5 | `ChatView.ToolCallChip` | no | yes — already correct, moved onto the shared helper so the tab is pinned by a test |
| 6 | `DownloadStrip.handleFailureAction` | no | no — `DownloadStrip` is not instantiated anywhere |
| 7 | `MenuBarController.openSettings()` | no | no — unreferenced |

Sites 1, 2 and 6 are unreachable in the shipping build. They are fixed anyway so
the bug does not come back the moment someone re-mounts the footer or the strip.

**One correction to #1578.** The issue says `MenuBarController.swift:284` "has
its own private `openSettings()` helper that goes through the window bridge, so
the tray is fine". The tray *is* fine, but not because of that helper — the
`.settings` menu case calls `AppDelegate.openSettingsWindow?()` directly. The
private helper dispatched `showSettingsWindow:` / `showPreferencesWindow:` via
`NSApp.sendAction`; both selectors are installed by a SwiftUI `Settings` scene,
which this app does not have. It was unreferenced dead code that could not have
worked, so it is deleted rather than left as a plausible-looking helper.

### The `openPermissions` decision

**Removed, not rerouted.** Routing it to the "closest" tab would have moved the
dead end rather than removed it, under a label that lies about what the user will
find. Two independent reasons:

- **There is no destination.** `SettingsView.Category` is `{models,
  modelManagement, tools, appearance, privacy, app}`. None of them holds a
  folder-grant or file-access control — Settings → Privacy is telemetry consent.
  A button titled "Open Permissions" landing on Models or Tools shows the user a
  panel with nothing about file access on it.
- **The conditions cannot occur here.** `.openPermissions` was produced only for
  `commandPermissionDenied` and `filePermissionDenied`, which
  `FailureDiagnoser.toolFailureKind` derives *only* for the tool names
  `run_command`, `read_file`, `list_directory`, `write_file`, `edit_file`.
  `BuiltinToolRegistry` ships none of them — it ships `web_search`, `browse`,
  `weather`, and its own comment records why: "Filesystem / shell tools are
  deliberately absent: this build has no `SandboxManager`, and a tool that
  touches the user's disk must not ship without one." There is no MCP client
  either.

So the two `Kind` cases now carry `action = nil`, and their copy no longer
promises an "Allow that folder" / "Allow access" control that does not exist.
The `Kind` cases themselves are **retained** — they are persisted in chat
transcripts and must keep decoding. `FailureDiagnosis.Action` is not `Codable`,
so dropping the case has no persistence impact. The only place those kinds can
still surface is a transcript restored from an older build, where the tool card
already rendered no button for them.

### Guard

#1578 asks for one, and offers two options: a grep check, or deleting the
properties so the call does not compile. Both are done. Every
`@Environment(\.openSettings)` property is gone, so a bare `openSettings()` no
longer compiles — but reintroducing the *property* would, so
`OpenSettingsActionAbsenceTests` also scans `Sources/Rapid/**` and fails if
`\.openSettings` or `openSettings(` reappears outside a comment.

The scan blanks comments **and string literals** to spaces (preserving line
geometry, so reported line/column numbers are right). String tracking is not
fastidiousness: without it, the `//` inside `let url = "https://example.com"` —
a shape these sources are full of — opens a line comment and blanks every
following character on that line, including a real call. That is a false
negative, the one direction a guard must not have. Blanking literals also stops
a string that merely *mentions* the API from raising a false alarm. The stripper
handles nested block comments, escapes, multiline `"""`, and raw `#"…"#`
literals, and its behaviour is pinned by its own tests including degenerate
input; the single acknowledged blind spot (code inside a string interpolation)
is documented at the function. Doc comments are exempt on purpose — several call
sites now carry a comment naming the API as the thing *not* to use, and that
explanation is what keeps the trap shut.

---

## 2. Dead links

Three shipped links opened nothing:

| Link | Was | Now |
|---|---|---|
| Settings → Privacy → "Open-source credits" | `blob/main/THIRD_PARTY.md` → **404** | `blob/main/apps/rapid-mac/THIRD_PARTY.md` |
| Settings → Privacy → "Privacy policy" | `rapidmlx.com/privacy` → **404** | `blob/main/apps/rapid-mac/PRIVACY.md` |
| About Rapid-MLX → "Privacy" | `rapidmlx.com/privacy` → **404** | `blob/main/apps/rapid-mac/PRIVACY.md` |

The credits link was a root-vs-subdirectory mistake: the file has always existed,
one directory down, at `apps/rapid-mac/THIRD_PARTY.md`. Fixed outright.

The two privacy links pointed at a page that has never been published, while a
maintained 259-line `apps/rapid-mac/PRIVACY.md` (last updated 2026-07-28) sits in
the repo. They now open that. **This does not settle #1587's open question** of
whether `rapidmlx.com/privacy` should be the canonical public home — I think it
probably should, since a policy behind a GitHub blob is a worse read for a
non-technical user and the URL is what a store listing or a support reply would
cite. But a working link to the real policy beats a dead link to an intended one,
and when the page is published these two constants move back in one line each.
#1587 stays open for that decision.

`LICENSE` was already correct (the root `LICENSE` resolves) and is untouched.
Noting one thing seen in passing and deliberately *not* changed: "License
(EULA)" points at the monorepo root `LICENSE` (the engine's Apache-2.0) rather
than `apps/rapid-mac/LICENSE` (the desktop app's own). Both resolve, so it is not
a dead end; flagging it rather than folding an unrequested change in.

### `THIRD_PARTY.md` corrected in place

It is now the document users actually reach, and its contents were wrong:

- listed **ViewInspector** and **sentry-cocoa** — neither is a dependency
  (ViewInspector was deleted from the manifest, Sentry was removed from the app);
- listed **swift-testing**, which is toolchain-provided, not a package dependency;
- omitted **SwiftMath**, **NetworkImage** and **swift-cmark**, all of which are
  linked into the shipped binary;
- pointed at "`Package.resolved` at the repository root", which is neither at the
  root nor in git (it is `.gitignore`d);
- claimed the engine's Python dependencies are "NOT bundled inside Rapid-MLX
  Desktop" — false since v0.6.6, when the sidecar started shipping inside
  `Contents/Resources/rapid-mlx/`.

Licenses were read from the packages themselves (`.build/checkouts/*/LICENSE`,
wheel `dist-info` metadata, the in-tree `NOTICE` files) rather than assumed. The
file now also covers the interpreter (CPython 3.12.13 / python-build-standalone),
the engine's declared runtime dependencies, and the third-party source **vendored
into the engine** that ships in the sidecar (Stable Audio 3, CogVideoX-Fun MLX,
TurboQuant kernels, and the vendored Gemma 4 / Hunyuan 3 / DeepSeek V4 model
classes). Its scope statement says plainly what it does and does not cover, so it
is not mistaken for an exhaustive bill of materials.

### Test

`RepositoryLinkTargetsTests` walks every hard-coded
`github.com/raullenchai/Rapid-MLX/blob|tree|raw/<ref>/<path>` URL under
`Sources/Rapid/**`, maps it back to a repo-relative path, and asserts that path
exists in the working tree. **Offline** — it reads the checkout, never the
network. It would have caught the credits 404 on the commit that introduced it.

Each user-facing link is additionally pinned as a `(source file, path)` pair
rather than aggregated into a set of paths: the privacy policy is linked from two
different surfaces, and a set-membership check stays green when one of them
regresses while the other stays correct — which is the state this PR found the
app in.

It also asserts the app documents are **not** duplicated at the repository root,
so a future root-path link is not "fixed" by creating a second copy that drifts.

---

## Follow-up, deliberately not in this PR

The assembled `.app` and DMG do not physically carry the Swift packages' license
texts — `build.sh` stages app resources and the sidecar, but never the notices.
(The Python half is fine: each wheel's `dist-info/licenses/` ships inside the
sidecar.) swift-cmark's BSD-2-Clause asks for the notice in materials provided
with the distribution, so this is a real gap. It is **pre-existing and untouched
by this PR**, and changing the release-assembly path on release day for a
link-correctness change is the wrong trade. Worth its own issue.

---

## Verification

- `swift build` — passes.
- `swift test --no-parallel` — 1,663 tests in 152 suites, green, for the
  `RapidTests` target.
- **Not run locally:** the `RapidUXTests` target is XCTest-only and this machine
  has Command Line Tools without Xcode, so `XCTest` does not resolve. That target
  is left to the CI `build` job, which runs both. (`RapidTests` needed a
  framework-search-path flag locally for the same reason; CI needs none.)
- Negative checks on both new guards: moving a linked document away makes the
  link test fail with the offending source file and path named, and
  reintroducing `@Environment(\.openSettings)` in a view makes the absence test
  fail naming the file and line.
- Codex review to convergence: 3 rounds, ending 0 BLOCKING / 0 MAJOR. Every
  finding was addressed rather than argued down — vendored-source inventory
  completeness and framing, an overbroad DeepSeek path glob, per-surface link
  pinning, two rounds on the comment/string stripper, the ordering test covering
  only the helper rather than the integration, an omitted utf8proc notice in the
  swift-cmark summary, and two wording claims that overstated what the sidecar
  ships. The one finding deliberately left open is the release-artifact license
  staging above, which Codex agreed is reasonable scope control.
- `swift scripts/verify-recommendation-tiers.swift` and
  `scripts/verify-conversation-ordering.sh` — pass.
- No Python touched, so no `ruff` run. No version bump: `pyproject.toml` and
  `Info.plist` are untouched.

### Not verified: the buttons were never clicked

**No GUI run happened, and none was possible.** The Mac this was built on has a
locked screen (`CGSSessionScreenIsLocked = Yes`); `screencapture` fails, and a
launched instance reports zero windows through the accessibility API even when it
is running fine, so a windowless launch or a failed screenshot would have proved
nothing either way. No `.app` was assembled and no instance was started — a
dogfood launch sweeps port 8000 and would have SIGTERMed a release gauntlet
running on this box.

So this PR rests on `swift build`, `swift test`, and static analysis of what the
code does. That is strong for the parts that are decidable statically — the
routing table, the ordering contract, the link paths, the absence of
`openSettings` — and it is exactly zero evidence that a click produces a window.

**What a human should check, on an unlocked screen:**

1. Quickstart failure card → the recovery button opens Settings **on Model
   Management**, not on the last-used tab. Easiest trigger: start a model too
   large for free memory, or pull the network mid-download.
2. A failed `web_search` tool card → its button opens Settings **on Tools**.
3. Settings → Privacy → all three links open real pages (no GitHub 404).
4. About Rapid-MLX → "Privacy" opens the policy.
5. Sanity: ⌘, and the tray "Settings…" item still work, and Settings opened
   twice in a row without a deep-link lands on the tab you left it on.

Items 1 and 2 are the ones worth the most attention: the ordering bug they guard
against is silent — the window still opens, just on the wrong tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
