### PR TITLE
fix(mac): stop Model Management and the readiness banner saying untrue things

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/DevSnapshot.swift
+++ b/apps/rapid-mac/Sources/Rapid/DevSnapshot.swift
@@ -35,6 +35,15 @@ enum DevSnapshot {
         try? FileManager.default.createDirectory(
             atPath: dir, withIntermediateDirectories: true)
 
+        // ``ContentView`` reads this from the environment (the browse
+        // tool's per-fetch approval dialog). Without it every capture
+        // below traps with "No Observable object of type
+        // BrowseApprovalStore found" before the first PNG is written —
+        // the harness had been dead since that dependency landed. A
+        // throwaway instance is right here: the snapshot never approves
+        // anything, it only needs the object to exist.
+        let browseApproval = BrowseApprovalStore()
+
         // Erase to AnyView so the long environment chain stays cheap to
         // type-check and the render call is monomorphic.
         func contentView(width: CGFloat, height: CGFloat) -> AnyView {
@@ -51,6 +60,7 @@ enum DevSnapshot {
                     .environment(installTracker)
                     .environment(quickstart)
                     .environment(dockPromptStore)
+                    .environment(browseApproval)
                     .frame(width: width, height: height)
             )
         }
@@ -175,6 +185,7 @@ enum DevSnapshot {
                 .noModel,
                 .needsDownload(alias: "qwen3.5-9b-4bit", sizeText: "5.0 GB"),
                 .needsStart(alias: "bonsai-1.7b-2bit"),
+                .unknownModel(alias: "mlx-community/Some-Custom-Repo"),
                 .downloading(
                     alias: "qwen3.5-9b-4bit",
                     detail: "1.2 GB / 5.0 GB · 24% · 8.4 MB/s · 7 min left",
@@ -239,6 +250,67 @@ enum DevSnapshot {
                      appearance: .aqua, to: "\(dir)/sidebar-light.png")
         renderHosted(sidebarOnly(), size: sidebarSize,
                      appearance: .darkAqua, to: "\(dir)/sidebar-dark.png")
+
+        // Settings → Model Management. The panel seeds its catalog
+        // synchronously from ``ModelCatalogCache``'s mirror, so warm the
+        // cache first or every capture is the spinner.
+        if let binary = server.binaryPath {
+            _ = await ModelCatalogCache.shared.entries(
+                binary: binary, generation: downloads.cacheGeneration
+            )
+        }
+        func modelManagement(width: CGFloat) -> AnyView {
+            AnyView(
+                SettingsModelManagementPanel()
+                    .environment(server)
+                    .environment(downloads)
+                    .frame(width: width, alignment: .top)
+                    .padding(20)
+                    .background(RapidTheme.surfaceCanvas)
+                    .tint(RapidTheme.brandAmber)
+            )
+        }
+        // Both the Settings window's default content width and its 720pt
+        // floor: the recommended card's action button clipped at BOTH, so
+        // a single wide capture would not have shown the bug or its fix.
+        renderHosted(modelManagement(width: 660), size: CGSize(width: 700, height: 1100),
+                     appearance: .aqua, to: "\(dir)/model-management-light.png")
+        renderHosted(modelManagement(width: 480), size: CGSize(width: 520, height: 1100),
+                     appearance: .aqua, to: "\(dir)/model-management-narrow.png")
+
+        // The table heading in every state the filter + search can put it
+        // in. A running panel can only ever be captured in one of them,
+        // and the heading is what this pass changed.
+        func headingStates() -> AnyView {
+            let cases: [(String, ModelCacheActions.ListHeading)] = [
+                ("no filter", ModelCacheActions.listHeading(
+                    filter: .all, query: "", visibleCount: 175, totalCount: 175)),
+                ("search \"qwen3.6\"", ModelCacheActions.listHeading(
+                    filter: .all, query: "qwen3.6", visibleCount: 4, totalCount: 175)),
+                ("Cached segment", ModelCacheActions.listHeading(
+                    filter: .cached, query: "", visibleCount: 3, totalCount: 175)),
+                ("Not cached + search", ModelCacheActions.listHeading(
+                    filter: .notCached, query: "gemma", visibleCount: 6, totalCount: 175)),
+                ("no matches", ModelCacheActions.listHeading(
+                    filter: .all, query: "zzz", visibleCount: 0, totalCount: 175)),
+            ]
+            return AnyView(
+                VStack(alignment: .leading, spacing: RapidTheme.Space.md) {
+                    ForEach(Array(cases.enumerated()), id: \.offset) { _, item in
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(item.0).font(.caption2).foregroundStyle(.tertiary)
+                            ModelsTableHeading(heading: item.1)
+                        }
+                    }
+                }
+                .padding(RapidTheme.Space.xl)
+                .frame(width: 420, alignment: .leading)
+                .background(RapidTheme.surfaceCanvas)
+                .tint(RapidTheme.brandAmber)
+            )
+        }
+        renderHosted(headingStates(), size: CGSize(width: 420, height: 300),
+                     appearance: .aqua, to: "\(dir)/model-management-heading-states.png")
 
         // Scenario 2: a populated chat transcript, so we can eyeball the
         // streaming bubble / markdown render path that an empty transcript

--- a/apps/rapid-mac/Sources/Rapid/Services/ModelCacheActions.swift
+++ b/apps/rapid-mac/Sources/Rapid/Services/ModelCacheActions.swift
@@ -281,6 +281,56 @@ enum ModelCacheActions {
         }
     }
 
+    /// The heading above the models table: what the table is showing,
+    /// and how many rows that actually is.
+    struct ListHeading: Equatable, Sendable {
+        /// Names the subset on screen. Rendered uppercased.
+        let title: String
+        /// "175" when nothing is narrowing the list, "4 of 175" when
+        /// something is.
+        let countText: String
+
+        /// One sentence for VoiceOver, since the rendered form is two
+        /// fragments separated by a middle dot.
+        var accessibilityLabel: String { "\(title), \(countText)" }
+    }
+
+    /// Derive the models-table heading.
+    ///
+    /// The panel used to render a fixed "All models" beside
+    /// ``catalog.count`` — the size of the WHOLE catalog — no matter what
+    /// the filter or the search box had done to the rows underneath. Type
+    /// three characters and the table showed four rows under a heading
+    /// that still said 175.
+    ///
+    /// So the count always describes what is on screen, and when
+    /// something has narrowed it the total follows as context ("4 of
+    /// 175") rather than the number silently changing meaning. The title
+    /// names the segment, which is the other half of "what am I looking
+    /// at". The search term is deliberately NOT echoed here: it is
+    /// legible in the field a few points above, and repeating it would be
+    /// the same duplication this panel is being cleaned of.
+    static func listHeading(
+        filter: FilterMode,
+        query: String,
+        visibleCount: Int,
+        totalCount: Int
+    ) -> ListHeading {
+        let title: String = {
+            switch filter {
+            case .all: return "All models"
+            case .cached: return "Cached"
+            case .notCached: return "Not cached"
+            }
+        }()
+        let searching = !query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        let narrowed = searching || filter != .all || visibleCount != totalCount
+        return ListHeading(
+            title: title,
+            countText: narrowed ? "\(visibleCount) of \(totalCount)" : "\(totalCount)"
+        )
+    }
+
     /// How the panel orders the filtered list.
     enum SortOrder: String, CaseIterable, Identifiable, Sendable {
         /// Family A→Z, then ascending size within each family.

--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -293,7 +293,7 @@ struct ContentView: View {
         ModelReadiness.resolve(
             serverState: server.state,
             alias: alias,
-            isAliasCached: cachedState(for: alias),
+            cacheState: cacheState(for: alias),
             sizeText: sizeText(for: alias),
             progress: progressSnapshot,
             failure: chat.lastError.map {
@@ -327,25 +327,27 @@ struct ContentView: View {
         )
     }
 
-    /// `nil` while the catalog is still loading — see the ``resolve``
-    /// docs for why that resolves to "start" rather than "download".
-    private func cachedState(for alias: String) -> Bool? {
-        guard !alias.isEmpty else { return nil }
+    /// What we know about this alias' weights — see the ``resolve`` docs
+    /// for why neither unknown state resolves to "download".
+    private func cacheState(for alias: String) -> ModelReadiness.CacheState {
+        guard !alias.isEmpty else { return .catalogPending }
         // #223's launch-time decision already established that this
         // alias needs pulling, and it lands before the catalog snapshot
         // does. Trusting it here means a cold first launch says
         // "isn't downloaded yet" immediately instead of flashing
         // "isn't running" for the second the catalog takes to load.
         if let pending = autoStartPendingDownload, pending.alias == alias {
-            return false
+            return .notOnDisk
         }
-        guard catalogLoaded else { return nil }
+        guard catalogLoaded else { return .catalogPending }
         guard let entry = catalogEntries.first(where: { $0.alias == alias }) else {
             // A custom alias the user typed isn't in the catalog. We
-            // genuinely don't know whether it's on disk.
-            return nil
+            // genuinely don't know whether it's on disk — and unlike the
+            // still-loading case, nothing is coming to tell us, so the
+            // banner must not claim it is already downloaded.
+            return .notInCatalog
         }
-        return entry.cached
+        return entry.cached ? .onDisk : .notOnDisk
     }
 
     /// Human download size for the readiness copy. Shares

--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -339,7 +339,13 @@ struct ContentView: View {
         if let pending = autoStartPendingDownload, pending.alias == alias {
             return .notOnDisk
         }
-        guard catalogLoaded else { return .catalogPending }
+        // An EMPTY catalog is not evidence that an alias is unknown.
+        // ``ModelCatalog.load`` returns `[]` as its failure sentinel (the
+        // `rapid-mlx models` subprocess failed), and ``catalogLoaded``
+        // flips to true either way. Treating that as "the catalog has
+        // spoken" would tell the user their model is unrecognised on the
+        // strength of a command that did not run.
+        guard catalogLoaded, !catalogEntries.isEmpty else { return .catalogPending }
         guard let entry = catalogEntries.first(where: { $0.alias == alias }) else {
             // A custom alias the user typed isn't in the catalog. We
             // genuinely don't know whether it's on disk — and unlike the

--- a/apps/rapid-mac/Sources/Rapid/UI/ModelReadiness.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ModelReadiness.swift
@@ -57,6 +57,18 @@ enum ModelReadiness: Equatable {
     case needsDownload(alias: String, sizeText: String?)
     /// A real alias is chosen and cached, but nothing is serving it.
     case needsStart(alias: String)
+    /// A real alias is chosen, nothing is serving it, and the catalog has
+    /// finished loading WITHOUT listing it — a custom model name the user
+    /// typed into "Type a model name…".
+    ///
+    /// Distinct from ``needsStart`` in exactly one respect, and it is the
+    /// reason the case exists: we have no evidence the weights are on
+    /// disk, so the copy must not claim they are. ``needsStart``'s detail
+    /// ("It's already downloaded") was being shown for these aliases,
+    /// contradicting the picker's own unknown-model glyph in the same row.
+    /// The action is identical — ``ServerManager`` pulls on demand — so
+    /// this changes only what the user is told, not what the button does.
+    case unknownModel(alias: String)
     /// Weights are being pulled. ``detail`` carries bytes/speed/ETA when
     /// the byte monitor has a signal; ``fraction`` drives a determinate bar.
     case downloading(alias: String, detail: String?, fraction: Double?)
@@ -150,6 +162,30 @@ enum ModelReadiness: Equatable {
         }
     }
 
+    /// What the app knows about the chosen alias' weights.
+    ///
+    /// A four-state value rather than a `Bool?` because "we don't know"
+    /// has two meanings with opposite consequences for the copy, and
+    /// collapsing them into `nil` is what let an unknown custom alias be
+    /// told "It's already downloaded":
+    ///
+    ///   * ``catalogPending`` is transient — the answer is seconds away,
+    ///     and guessing "not downloaded" would flash a scary
+    ///     multi-gigabyte warning at a model that is probably on disk.
+    ///   * ``notInCatalog`` is permanent for as long as the alias stays
+    ///     unknown. Nothing will arrive to correct it, so the copy has to
+    ///     be honest about not knowing.
+    enum CacheState: Equatable, Sendable {
+        /// The catalog lists this alias and its weights are on disk.
+        case onDisk
+        /// The catalog lists this alias and its weights are not on disk.
+        case notOnDisk
+        /// The catalog has not answered yet. Transient.
+        case catalogPending
+        /// The catalog has loaded and does not list this alias.
+        case notInCatalog
+    }
+
     /// A chat-level failure worth surfacing as a readiness problem.
     /// Only consulted when the server is not itself in flight — an
     /// in-progress start always outranks a stale error from the turn
@@ -180,18 +216,23 @@ enum ModelReadiness: Equatable {
     ///   5. A chat-level failure.
     ///   6. No model chosen.
     ///   7. Chosen but not cached → ``needsDownload``.
-    ///   8. Otherwise → ``needsStart``.
+    ///   8. Chosen but absent from a loaded catalog → ``unknownModel``.
+    ///   9. Otherwise → ``needsStart``.
     ///
-    /// - Parameter isAliasCached: `nil` means the catalog has not loaded
-    ///   yet. We resolve to ``needsStart`` in that case rather than
-    ///   ``needsDownload``: claiming a download is required when we do
-    ///   not know is the more misleading of the two errors, and the
-    ///   Start action behaves identically either way (``ServerManager``
-    ///   pulls on demand).
+    /// - Parameter cacheState: what we know about the weights. Both
+    ///   "don't know" states resolve to a start rather than a download —
+    ///   claiming a multi-gigabyte pull is required when we cannot prove
+    ///   it is the more misleading error, and the Start action behaves
+    ///   identically either way (``ServerManager`` pulls on demand). They
+    ///   differ only in the copy: ``catalogPending`` keeps
+    ///   ``needsStart``'s "it's already downloaded" (in a second the
+    ///   catalog will confirm it, and for the launch model it is nearly
+    ///   always true), while ``notInCatalog`` gets ``unknownModel``,
+    ///   which promises nothing about the disk.
     static func resolve(
         serverState: ServerState,
         alias: String,
-        isAliasCached: Bool?,
+        cacheState: CacheState,
         sizeText: String? = nil,
         progress: ProgressSnapshot? = nil,
         failure: Failure? = nil
@@ -274,10 +315,14 @@ enum ModelReadiness: Equatable {
 
         guard let name = selected else { return .noModel }
 
-        if isAliasCached == false {
+        switch cacheState {
+        case .notOnDisk:
             return .needsDownload(alias: name, sizeText: normalizedSize(sizeText))
+        case .notInCatalog:
+            return .unknownModel(alias: name)
+        case .onDisk, .catalogPending:
+            return .needsStart(alias: name)
         }
-        return .needsStart(alias: name)
     }
 
     // MARK: - Derived presentation
@@ -303,7 +348,7 @@ enum ModelReadiness: Equatable {
         switch self {
         case .engineMissing, .failed:      return .error
         case .noModel, .needsDownload,
-             .needsStart:                  return .idle
+             .needsStart, .unknownModel:   return .idle
         case .downloading, .starting:      return .working
         case .ready:                       return .ready
         }
@@ -322,7 +367,7 @@ enum ModelReadiness: Equatable {
         switch self {
         case .engineMissing, .noModel:
             return nil
-        case .needsDownload(let a, _), .needsStart(let a),
+        case .needsDownload(let a, _), .needsStart(let a), .unknownModel(let a),
              .downloading(let a, _, _), .starting(let a, _), .ready(let a):
             return a
         case .failed(let a, _, _):
@@ -341,7 +386,8 @@ enum ModelReadiness: Equatable {
         case .engineMissing:                    return nil
         case .noModel:                          return .chooseModel
         case .needsDownload(let a, _):          return .downloadAndStart(alias: a)
-        case .needsStart(let a):                return .start(alias: a)
+        case .needsStart(let a),
+             .unknownModel(let a):              return .start(alias: a)
         case .downloading, .starting, .ready:   return nil
         case .failed(_, _, let action):         return action
         }
@@ -364,7 +410,7 @@ enum ModelReadiness: Equatable {
             return "No model chosen"
         case .needsDownload(let a, _):
             return "\(a) isn't downloaded yet"
-        case .needsStart(let a):
+        case .needsStart(let a), .unknownModel(let a):
             return "\(a) isn't running"
         case .downloading(let a, _, _):
             return "Downloading \(a)"
@@ -393,6 +439,11 @@ enum ModelReadiness: Equatable {
             return "It downloads once, then starts in seconds."
         case .needsStart:
             return "It's already downloaded — starting takes a few seconds."
+        case .unknownModel:
+            // Deliberately promises nothing about the disk: this alias is
+            // not in the catalog, so we cannot say it is downloaded (the
+            // old copy did) and we cannot quote a download size either.
+            return "Rapid doesn't know this one — starting will download it first if it isn't on your Mac."
         case .downloading(_, let detail, _):
             return detail ?? "Starting the download…"
         case .starting(_, let detail):
@@ -412,7 +463,8 @@ enum ModelReadiness: Equatable {
         case .engineMissing:            return "Setup didn't finish"
         case .noModel:                  return "Choose a model first"
         case .needsDownload(let a, _):  return "Download \(a) first"
-        case .needsStart(let a):        return "Start \(a) first"
+        case .needsStart(let a),
+             .unknownModel(let a):      return "Start \(a) first"
         case .downloading(let a, _, _): return "Downloading \(a)…"
         case .starting(let a, _):       return "Starting \(a)…"
         case .ready:                    return "Send a message…"
@@ -430,7 +482,7 @@ enum ModelReadiness: Equatable {
             return "Choose a model before sending."
         case .needsDownload(let a, _):
             return "Download \(a) before sending."
-        case .needsStart(let a):
+        case .needsStart(let a), .unknownModel(let a):
             return "Start \(a) before sending."
         case .downloading(let a, _, _):
             return "\(a) is still downloading."
@@ -456,7 +508,7 @@ enum ModelReadiness: Equatable {
             return "Choose a model to start"
         case .needsDownload(let a, _):
             return "Download \(a) to start"
-        case .needsStart(let a):
+        case .needsStart(let a), .unknownModel(let a):
             return "Start \(a) to begin"
         case .downloading:
             return "Downloading your local model…"

--- a/apps/rapid-mac/Sources/Rapid/UI/ModelReadiness.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ModelReadiness.swift
@@ -440,10 +440,13 @@ enum ModelReadiness: Equatable {
         case .needsStart:
             return "It's already downloaded — starting takes a few seconds."
         case .unknownModel:
-            // Deliberately promises nothing about the disk: this alias is
-            // not in the catalog, so we cannot say it is downloaded (the
-            // old copy did) and we cannot quote a download size either.
-            return "Rapid doesn't know this one — starting will download it first if it isn't on your Mac."
+            // Deliberately promises nothing. We cannot say it is
+            // downloaded (the old copy did), we cannot quote a size, and
+            // we must not promise a download either: ``ServerManager``
+            // pulls on demand only for a name it accepts, and this one
+            // came from free text. State the one thing that is true —
+            // that we do not know — and let Start report the rest.
+            return "Rapid doesn't know this one, so it can't say whether it's already on your Mac."
         case .downloading(_, let detail, _):
             return detail ?? "Starting the download…"
         case .starting(_, let detail):

--- a/apps/rapid-mac/Sources/Rapid/UI/SettingsModelManagementPanel.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SettingsModelManagementPanel.swift
@@ -429,21 +429,18 @@ struct SettingsModelManagementPanel: View {
         // window — a fixed brand + meters + action row overflows and clips
         // the action button there (design review B1).
         HStack(alignment: .top, spacing: 12) {
-            VStack(alignment: .leading, spacing: 4) {
-                Label(isPrimary ? "Best pick" : "Faster",
-                      systemImage: isPrimary ? "star.fill" : "hare.fill")
-                    .font(.caption.weight(.bold))
-                    .labelStyle(.titleAndIcon)
-                if isPrimary {
-                    Text("BEST PICK")
-                        .scaledSystemFont(9, weight: .bold)
-                        .foregroundStyle(RapidTheme.brand)
-                        .padding(.horizontal, 6)
-                        .padding(.vertical, 1)
-                        .background(Capsule().fill(RapidTheme.brand.opacity(0.12)))
-                }
-            }
-            .frame(width: 74, alignment: .leading)
+            // One marker, not two. This column used to render "Best pick"
+            // as a label AND "BEST PICK" as a capsule directly beneath it
+            // — the same two words, stacked, on the same card. The label
+            // stays because it carries the star and reads at a glance; the
+            // capsule goes because the card's own brand tint, brand border
+            // and shadow already say "this is the featured one", and the
+            // table below still pills the same alias as RECOMMENDED.
+            Label(isPrimary ? "Best pick" : "Faster",
+                  systemImage: isPrimary ? "star.fill" : "hare.fill")
+                .font(.caption.weight(.bold))
+                .labelStyle(.titleAndIcon)
+                .frame(width: RecommendedCardLayout.markerColumnWidth, alignment: .leading)
 
             BrandIcon(alias: alias)
 
@@ -467,8 +464,20 @@ struct SettingsModelManagementPanel: View {
             }
             .frame(maxWidth: .infinity, alignment: .leading)
 
+            // ``fixedSize`` is the actual guarantee: it hands the action
+            // its intrinsic width so a label can never be compressed into
+            // an ellipsis. The frame is alignment only — a floor wide
+            // enough for the longest label this slot renders, so the two
+            // stacked cards line up, with no ceiling to clip against.
+            //
+            // The bug this replaces: a hard ``.frame(width: 92)`` around a
+            // caption + button cluster. The caption ate ~50pt and the
+            // prominent "Download" button was left with ~40, rendering as
+            // "Dow…" for every user whose best pick wasn't cached. Widening
+            // the Settings window did nothing — the clamp was on the card.
             recommendedAction(entry: entry, badge: badge)
-                .frame(width: 92, alignment: .trailing)
+                .fixedSize(horizontal: true, vertical: false)
+                .frame(minWidth: RecommendedCardLayout.actionColumnWidth, alignment: .trailing)
         }
         .padding(13)
         .background(
@@ -510,18 +519,24 @@ struct SettingsModelManagementPanel: View {
         return parts.joined(separator: " · ")
     }
 
+    /// The card's trailing slot: a status pill when there is nothing to
+    /// do, otherwise the one action button.
+    ///
+    /// No size caption here. ``pickStatsLine`` already opens with the
+    /// pick's footprint two columns to the left ("7.6 GB · 86%
+    /// capability · ~17 tok/s"), so a second "7.6 GB" beside the button
+    /// was the same fact twice on one card — and the two were computed
+    /// from different sources (the curated ``Pick.footprintGB`` vs
+    /// ``ModelSizing.estimate``), so they could disagree by a rounding
+    /// step while claiming to be the same number. It was also what
+    /// starved the button into "Dow…".
     @ViewBuilder
     private func recommendedAction(entry: ModelEntry, badge: ModelCacheActions.StatusBadge) -> some View {
         switch badge {
         case .cached, .inUse:
             statusBadgeView(badge)
         default:
-            HStack(spacing: 8) {
-                if case .notCached = badge, let gb = downloadSizeLabel(entry.alias) {
-                    Text(gb).font(.caption).foregroundStyle(.secondary)
-                }
-                actionButton(for: entry, badge: badge)
-            }
+            actionButton(for: entry, badge: badge)
         }
     }
 
@@ -529,19 +544,25 @@ struct SettingsModelManagementPanel: View {
 
     @ViewBuilder
     private var allModelsSection: some View {
+        // Resolved once and handed to both the heading and the list, so
+        // the number in the heading and the rows under it can never
+        // describe different sets.
+        let entries = visibleEntries
+        let heading = ModelCacheActions.listHeading(
+            filter: filterMode,
+            query: query,
+            visibleCount: entries.count,
+            totalCount: catalog.count
+        )
         VStack(alignment: .leading, spacing: 9) {
-            HStack(spacing: 6) {
-                Text("All models").font(.caption.weight(.semibold)).textCase(.uppercase)
-                Text("· \(catalog.count)").font(.caption).foregroundStyle(.tertiary)
-            }
-            .foregroundStyle(.secondary)
+            ModelsTableHeading(heading: heading)
             // The meter legend belongs HERE — these are the only rows that
             // render the Quality · Speed bars. The recommendation cards
             // above show the curated capability / speed stats instead, so a
             // top-of-panel legend misattributed them.
             meterLegend
             columnHeader
-            listSection
+            listSection(entries)
             if let footer = ModelCacheActions.diskUsageFooter(
                 ModelCacheActions.aggregateOnDiskBytes(catalog)
             ) {
@@ -576,7 +597,7 @@ struct SettingsModelManagementPanel: View {
             Spacer().frame(width: 30)
             Text("Model").frame(maxWidth: .infinity, alignment: .leading)
             Text("Quality · Speed").frame(width: 158, alignment: .leading)
-            Text("Size").frame(width: 84, alignment: .trailing)
+            Text("Size").frame(width: ModelTableLayout.sizeColumnWidth, alignment: .trailing)
         }
         .scaledSystemFont(10, weight: .semibold)
         .foregroundStyle(.tertiary)
@@ -635,10 +656,27 @@ struct SettingsModelManagementPanel: View {
         return "\(ctx)"
     }
 
-    private func downloadSizeLabel(_ alias: String) -> String? {
+    /// ESTIMATED download size for a model that is not on disk, derived
+    /// from the alias string by ``ModelSizing`` — not a measurement of
+    /// anything. The caller renders it with a leading "~" so it can't be
+    /// mistaken for the measured on-disk figure cached rows in the same
+    /// column now show; #1550 has a case where this estimate lands ~12%
+    /// under the real download.
+    nonisolated static func downloadSizeLabel(_ alias: String) -> String? {
         let fp = ModelSizing.estimate(alias: alias)
         guard fp.weightsGB > 0 else { return nil }
         return String(format: "%.1f GB", fp.weightsGB)
+    }
+
+    /// MEASURED size of a cached model, exactly as ``rapid-mlx ls``
+    /// reported it (and as Settings → Models quotes it, so the two
+    /// surfaces can't print different numbers for the same model).
+    /// Never an estimate: if the measurement is missing, the row shows no
+    /// size rather than substituting ``ModelSizing``'s guess.
+    nonisolated static func onDiskSizeLabel(_ entry: ModelEntry) -> String? {
+        guard let raw = entry.sizeOnDisk?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !raw.isEmpty else { return nil }
+        return raw
     }
 
     @ViewBuilder
@@ -694,11 +732,32 @@ struct SettingsModelManagementPanel: View {
     private func sizeAction(entry: ModelEntry, badge: ModelCacheActions.StatusBadge) -> some View {
         switch badge {
         case .cached:
-            HStack(spacing: 8) {
+            // The size is the point of this tab. A cached row used to show
+            // the check and the trash and nothing else, so the one surface
+            // whose job is reclaiming space never said how much any given
+            // model would reclaim — while its own "Size (largest first)"
+            // sort ordered the table by exactly that number.
+            HStack(spacing: ModelTableLayout.cellSpacing) {
                 Image(systemName: "checkmark.circle.fill")
                     .font(.caption)
                     .foregroundStyle(RapidTheme.green)
-                    .accessibilityLabel("On disk")
+                    .accessibilityHidden(true)
+                if let size = Self.onDiskSizeLabel(entry) {
+                    Text(size)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .help("Measured size on disk. Deleting frees this much.")
+                        .accessibilityLabel("On disk, \(size)")
+                } else {
+                    // No measurement from ``rapid-mlx ls``. Say "On disk"
+                    // and stop — substituting the alias-derived estimate
+                    // here would quote a guess as a measurement.
+                    Text("On disk")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
                 Button(role: .destructive) {
                     pendingDeletion = entry
                 } label: {
@@ -715,8 +774,13 @@ struct SettingsModelManagementPanel: View {
                 .foregroundStyle(.secondary)
         case .notCached:
             HStack(spacing: 8) {
-                if let gb = downloadSizeLabel(entry.alias) {
-                    Text(gb).font(.caption).foregroundStyle(.secondary)
+                if let gb = Self.downloadSizeLabel(entry.alias) {
+                    Text("~\(gb)")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .help("Estimated download size.")
+                        .accessibilityLabel("Estimated download, about \(gb)")
                 }
                 Button {
                     _ = downloads.startDownload(alias: entry.alias, hfPath: entry.hfRepo)
@@ -761,8 +825,7 @@ struct SettingsModelManagementPanel: View {
     }
 
     @ViewBuilder
-    private var listSection: some View {
-        let entries = visibleEntries
+    private func listSection(_ entries: [ModelEntry]) -> some View {
         if entries.isEmpty {
             Text(noMatchesCopy)
                 .font(.callout)
@@ -832,7 +895,7 @@ struct SettingsModelManagementPanel: View {
             metersView(alias: entry.alias)
                 .frame(width: 158)
             sizeAction(entry: entry, badge: badge)
-                .frame(width: 84, alignment: .trailing)
+                .frame(width: ModelTableLayout.sizeColumnWidth, alignment: .trailing)
         }
         .padding(.vertical, 8)
         .accessibilityElement(children: .contain)
@@ -1113,5 +1176,130 @@ struct SettingsModelManagementPanel: View {
         case .failure(let message):
             lastError = message
         }
+    }
+}
+
+/// The heading above the models table: the subset on screen and how many
+/// rows that is.
+///
+/// Its own view so the dev snapshot harness can render every filter state
+/// side by side without re-implementing markup the panel ships — the
+/// heading is the thing this pass changed, so it has to be reviewable in
+/// all four of its states, not just the one a running panel happens to be
+/// in.
+struct ModelsTableHeading: View {
+    let heading: ModelCacheActions.ListHeading
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Text(heading.title).font(.caption.weight(.semibold)).textCase(.uppercase)
+            Text("· \(heading.countText)")
+                .font(.caption)
+                .foregroundStyle(.tertiary)
+                .accessibilityIdentifier("Settings.ModelManagement.VisibleCount")
+        }
+        .foregroundStyle(.secondary)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(heading.accessibilityLabel)
+    }
+}
+
+/// Fixed geometry of a Recommended card, lifted out of the view body so
+/// the widths that decide whether a label renders in full are values a
+/// test can measure instead of literals buried in a modifier chain.
+///
+/// The card clipped its primary call to action to "Dow…" because the
+/// trailing slot was pinned to a hard 92pt that its own contents did not
+/// fit inside. Deriving the floor from the labels — rather than picking
+/// another literal and hoping — means adding a longer label, or bumping
+/// the control size, moves the column with it.
+enum RecommendedCardLayout {
+    /// Leading marker column ("Best pick" / "Faster").
+    static let markerColumnWidth: CGFloat = 74
+
+    /// Horizontal chrome around a ``controlSize(.small)`` push-button's
+    /// title: the bezel plus its internal padding. Deliberately generous
+    /// — an over-estimate only widens a right-aligned column by a couple
+    /// of points, while an under-estimate is the ellipsis we are fixing.
+    static let smallButtonChrome: CGFloat = 26
+
+    /// Horizontal chrome around a status pill's text — 8pt of capsule
+    /// padding on each side (see ``SettingsModelManagementPanel.pill``).
+    static let pillChrome: CGFloat = 16
+
+    /// Every button label the card's trailing slot can render. "Delete"
+    /// is included because ``actionButton`` still carries that branch,
+    /// even though the cached card currently resolves to a pill.
+    static let actionButtonTitles = ["Download", "Delete", "Cancel", "Retry"]
+
+    /// Every status pill the same slot can render.
+    static let actionPillTitles = ["On disk", "In use", "Serving"]
+
+    /// Intrinsic width of a small push-button with this title.
+    static func buttonWidth(title: String) -> CGFloat {
+        textWidth(title, font: .systemFont(ofSize: NSFont.smallSystemFontSize))
+            + smallButtonChrome
+    }
+
+    /// Intrinsic width of a status pill with this text.
+    static func pillWidth(text: String) -> CGFloat {
+        textWidth(text, font: .systemFont(ofSize: NSFont.smallSystemFontSize, weight: .medium))
+            + pillChrome
+    }
+
+    /// Floor for the card's trailing slot: the widest thing it renders.
+    /// The slot is free to grow past this (its content is `fixedSize`d);
+    /// the floor exists so the stacked cards' buttons line up.
+    static let actionColumnWidth: CGFloat = {
+        let widest = actionButtonTitles.map(buttonWidth(title:))
+            + actionPillTitles.map(pillWidth(text:))
+        return (widest.max() ?? 92).rounded(.up)
+    }()
+
+    /// Width of a `.caption` run — the font the removed size caption used,
+    /// kept so a test can show why it could not share the slot.
+    static func captionWidth(_ text: String) -> CGFloat {
+        textWidth(text, font: .systemFont(ofSize: 10))
+    }
+
+    fileprivate static func textWidth(_ string: String, font: NSFont) -> CGFloat {
+        (string as NSString).size(withAttributes: [.font: font]).width
+    }
+}
+
+/// Geometry of the "All models" table's trailing Size column.
+///
+/// The column is a fixed width shared by the header and every row —
+/// variable widths would put each row's meters at a different x and make
+/// the table ragged — so the width has to be chosen against the widest
+/// cell rather than the narrowest.
+///
+/// It was 84pt, sized when a cached cell held two glyphs and nothing
+/// between them. Now that it also carries the measured size, the biggest
+/// caches on a large Mac ("123.4 GiB") need ~88pt, so the column moves to
+/// 100 and the flexible model-name column gives up 16.
+enum ModelTableLayout {
+    /// Shared width of the Size column.
+    static let sizeColumnWidth: CGFloat = 100
+
+    /// Spacing between the glyph, the figure and the button in a cell.
+    static let cellSpacing: CGFloat = 6
+
+    /// A `.caption`-sized SF Symbol (state glyph) or the 11pt trash.
+    static let glyphWidth: CGFloat = 15
+
+    /// Width a cached cell needs: state glyph + measured size + delete.
+    static func cachedCellWidth(size: String) -> CGFloat {
+        glyphWidth
+            + cellSpacing
+            + RecommendedCardLayout.captionWidth(size)
+            + cellSpacing
+            + glyphWidth
+    }
+
+    /// Width a not-cached cell needs: estimate + download glyph. The 8pt
+    /// spacing is the one that branch renders.
+    static func notCachedCellWidth(size: String) -> CGFloat {
+        RecommendedCardLayout.captionWidth("~" + size) + 8 + glyphWidth
     }
 }

--- a/apps/rapid-mac/Sources/Rapid/UI/SettingsModelManagementPanel.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SettingsModelManagementPanel.swift
@@ -747,6 +747,7 @@ struct SettingsModelManagementPanel: View {
                         .font(.caption)
                         .foregroundStyle(.secondary)
                         .lineLimit(1)
+                        .minimumScaleFactor(ModelTableLayout.cellMinimumScaleFactor)
                         .help("Measured size on disk. Deleting frees this much.")
                         .accessibilityLabel("On disk, \(size)")
                 } else {
@@ -757,6 +758,7 @@ struct SettingsModelManagementPanel: View {
                         .font(.caption)
                         .foregroundStyle(.secondary)
                         .lineLimit(1)
+                        .minimumScaleFactor(ModelTableLayout.cellMinimumScaleFactor)
                 }
                 Button(role: .destructive) {
                     pendingDeletion = entry
@@ -781,6 +783,7 @@ struct SettingsModelManagementPanel: View {
                         .font(.caption)
                         .foregroundStyle(.secondary)
                         .lineLimit(1)
+                        .minimumScaleFactor(ModelTableLayout.cellMinimumScaleFactor)
                         .help("Measured size on disk. Stop this model before deleting it.")
                         .accessibilityLabel("On disk, \(size)")
                 }
@@ -788,6 +791,7 @@ struct SettingsModelManagementPanel: View {
                     .font(.caption.weight(.medium))
                     .foregroundStyle(.secondary)
                     .lineLimit(1)
+                    .minimumScaleFactor(ModelTableLayout.cellMinimumScaleFactor)
             }
         case .notCached:
             HStack(spacing: 8) {
@@ -796,6 +800,7 @@ struct SettingsModelManagementPanel: View {
                         .font(.caption)
                         .foregroundStyle(.secondary)
                         .lineLimit(1)
+                        .minimumScaleFactor(ModelTableLayout.cellMinimumScaleFactor)
                         .help("Estimated download size.")
                         .accessibilityLabel("Estimated download, about \(gb)")
                 }
@@ -1307,6 +1312,31 @@ enum ModelTableLayout {
 
     /// Spacing between the glyph, the figure and the button in a cell.
     static let cellSpacing: CGFloat = 6
+
+    /// How far a figure in the Size column may shrink before it starts
+    /// truncating. The cells apply this as `.minimumScaleFactor`.
+    ///
+    /// Settings is NOT inside ``rapidChatDynamicTypeClamp``, so these
+    /// `.caption` runs scale with the system text size, and a fixed-width
+    /// column plus `lineLimit(1)` means growth eventually clips the
+    /// number — which is the defect this column was widened to fix. A
+    /// 20% shrink floor buys roughly 1.25x of text growth before that
+    /// happens, covering the non-accessibility sizes. It is a bound, not
+    /// a Dynamic Type pass: at the AX sizes this table needs to reflow,
+    /// which is a change to every column and not this fix's business.
+    static let cellMinimumScaleFactor: CGFloat = 0.8
+
+    /// Does a cell of intrinsic width ``needed`` survive ``scale`` times
+    /// text growth without truncating, given the shrink floor?
+    ///
+    /// Deliberately conservative: it grows the WHOLE cell, including the
+    /// fixed glyphs and spacing that do not scale. The real cell grows by
+    /// less, so a pass here is a real pass; a fail may be pessimistic.
+    /// That is the right direction for a guard whose failure mode is a
+    /// clipped number.
+    static func fits(_ needed: CGFloat, atTextScale scale: CGFloat) -> Bool {
+        needed * scale * cellMinimumScaleFactor <= sizeColumnWidth
+    }
 
     /// A `.caption`-sized SF Symbol (state glyph) or the 11pt trash.
     static let glyphWidth: CGFloat = 15

--- a/apps/rapid-mac/Sources/Rapid/UI/SettingsModelManagementPanel.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SettingsModelManagementPanel.swift
@@ -769,9 +769,26 @@ struct SettingsModelManagementPanel: View {
                 .accessibilityIdentifier("Settings.ModelManagement.Delete.\(entry.alias)")
             }
         case .inUse:
-            Text("Serving")
-                .font(.caption.weight(.medium))
-                .foregroundStyle(.secondary)
+            // A serving model is a CACHED model, so it owes the same
+            // answer as any other cached row: how much disk it is using.
+            // Showing only "Serving" left the one model the user is most
+            // likely to be weighing as the single row with no size.
+            // There is still no delete here — the weights are mmap'd
+            // mid-serve — which is what "Serving" says.
+            HStack(spacing: ModelTableLayout.cellSpacing) {
+                if let size = Self.onDiskSizeLabel(entry) {
+                    Text(size)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .help("Measured size on disk. Stop this model before deleting it.")
+                        .accessibilityLabel("On disk, \(size)")
+                }
+                Text("Serving")
+                    .font(.caption.weight(.medium))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
         case .notCached:
             HStack(spacing: 8) {
                 if let gb = Self.downloadSizeLabel(entry.alias) {
@@ -1262,6 +1279,12 @@ enum RecommendedCardLayout {
         textWidth(text, font: .systemFont(ofSize: 10))
     }
 
+    /// Width of a `.caption.weight(.medium)` run — the table's "Serving"
+    /// label.
+    static func captionMediumWidth(_ text: String) -> CGFloat {
+        textWidth(text, font: .systemFont(ofSize: 10, weight: .medium))
+    }
+
     fileprivate static func textWidth(_ string: String, font: NSFont) -> CGFloat {
         (string as NSString).size(withAttributes: [.font: font]).width
     }
@@ -1301,5 +1324,13 @@ enum ModelTableLayout {
     /// spacing is the one that branch renders.
     static func notCachedCellWidth(size: String) -> CGFloat {
         RecommendedCardLayout.captionWidth("~" + size) + 8 + glyphWidth
+    }
+
+    /// Width a serving cell needs: measured size + the "Serving" label
+    /// that stands in for the (deliberately absent) delete button.
+    static func inUseCellWidth(size: String) -> CGFloat {
+        RecommendedCardLayout.captionWidth(size)
+            + cellSpacing
+            + RecommendedCardLayout.captionMediumWidth("Serving")
     }
 }

--- a/apps/rapid-mac/Tests/RapidTests/ModelCacheActionsTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ModelCacheActionsTests.swift
@@ -426,4 +426,98 @@ struct ModelCacheActionsTests {
         #expect(ModelCacheActions.SortOrder.nameAscending.displayLabel == "Name")
         #expect(ModelCacheActions.SortOrder.sizeDescending.displayLabel == "Size (largest first)")
     }
+
+    // MARK: - List heading
+
+    @Test("listHeading: unfiltered, the count is the whole catalog")
+    func listHeadingUnfiltered() {
+        let heading = ModelCacheActions.listHeading(
+            filter: .all, query: "", visibleCount: 175, totalCount: 175
+        )
+        #expect(heading.title == "All models")
+        #expect(heading.countText == "175")
+    }
+
+    /// The defect: the heading rendered ``catalog.count`` regardless of
+    /// what the search box had done to the rows beneath it, so four
+    /// visible models sat under a header claiming 175.
+    @Test("listHeading: a search query makes the count describe the rows shown")
+    func listHeadingWithQuery() {
+        let heading = ModelCacheActions.listHeading(
+            filter: .all, query: "qwen", visibleCount: 4, totalCount: 175
+        )
+        #expect(heading.countText == "4 of 175")
+        #expect(heading.countText.contains("4"))
+    }
+
+    /// Same defect through the other control: the segmented filter.
+    @Test("listHeading: the segment names itself and counts only its rows")
+    func listHeadingWithSegment() {
+        let cached = ModelCacheActions.listHeading(
+            filter: .cached, query: "", visibleCount: 3, totalCount: 175
+        )
+        #expect(cached.title == "Cached")
+        #expect(cached.countText == "3 of 175")
+
+        let notCached = ModelCacheActions.listHeading(
+            filter: .notCached, query: "", visibleCount: 172, totalCount: 175
+        )
+        #expect(notCached.title == "Not cached")
+        #expect(notCached.countText == "172 of 175")
+    }
+
+    /// A filter that happens to match everything still says so, rather
+    /// than collapsing to a bare total that would read as "unfiltered".
+    @Test("listHeading: a filter matching everything still reads N of N")
+    func listHeadingFilterMatchingEverything() {
+        let heading = ModelCacheActions.listHeading(
+            filter: .notCached, query: "", visibleCount: 175, totalCount: 175
+        )
+        #expect(heading.countText == "175 of 175")
+    }
+
+    /// Whitespace is not a search. The clear button leaves an empty
+    /// string but a stray space must not flip the heading into its
+    /// narrowed form while every row is still on screen.
+    @Test("listHeading: whitespace-only query is not narrowing")
+    func listHeadingWhitespaceQuery() {
+        let heading = ModelCacheActions.listHeading(
+            filter: .all, query: "   ", visibleCount: 175, totalCount: 175
+        )
+        #expect(heading.countText == "175")
+    }
+
+    /// Zero matches is the state most likely to be read as a bug, so it
+    /// has to be stated plainly rather than showing the catalog size.
+    @Test("listHeading: no matches counts zero, not the catalog")
+    func listHeadingNoMatches() {
+        let heading = ModelCacheActions.listHeading(
+            filter: .all, query: "zzz", visibleCount: 0, totalCount: 175
+        )
+        #expect(heading.countText == "0 of 175")
+        #expect(heading.accessibilityLabel == "All models, 0 of 175")
+    }
+
+    /// The count and the rows come from one filter pass, so whatever
+    /// ``filter`` returns is what the heading must report.
+    @Test("listHeading: the count agrees with filter() for the same inputs")
+    func listHeadingAgreesWithFilter() {
+        let entries = [
+            entry("qwen3.6-27b-4bit", cached: true),
+            entry("qwen3.5-9b-4bit", cached: false),
+            entry("phi-4-4bit", cached: true),
+        ]
+        for mode in ModelCacheActions.FilterMode.allCases {
+            for query in ["", "qwen", "phi", "nope"] {
+                let visible = ModelCacheActions.filter(entries, by: mode, query: query)
+                let heading = ModelCacheActions.listHeading(
+                    filter: mode,
+                    query: query,
+                    visibleCount: visible.count,
+                    totalCount: entries.count
+                )
+                #expect(heading.countText.hasPrefix("\(visible.count)"))
+            }
+        }
+    }
 }

--- a/apps/rapid-mac/Tests/RapidTests/ModelSurfaceRedesignTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ModelSurfaceRedesignTests.swift
@@ -339,6 +339,110 @@ struct ModelSurfaceRedesignTests {
         }
     }
 
+    /// The sweep above can only mean something if the two arrays really
+    /// are the labels the card renders — they are hand-maintained, and a
+    /// width derived from them would otherwise be self-certifying.
+    ///
+    /// So: grep the source. Every `Text("…")` inside the card's
+    /// ``actionButton`` and inside ``statusBadgeView``'s pill calls must
+    /// appear in one of the two arrays. Adding "Download again" to the
+    /// button without widening the column trips here rather than shipping
+    /// another ellipsis. Same pattern as
+    /// ``ToolUseCapabilitySourceGuardTests``.
+    @Test("recommended card: the measured label set matches the source")
+    func actionLabelArraysMatchTheSource() throws {
+        let source = try Self.loadPanelSource()
+        let known = Set(
+            RecommendedCardLayout.actionButtonTitles
+                + RecommendedCardLayout.actionPillTitles
+        )
+
+        let buttonBody = try Self.body(
+            of: "private func actionButton(for entry: ModelEntry, badge: ModelCacheActions.StatusBadge) -> some View {",
+            in: source
+        )
+        for label in Self.textLiterals(in: buttonBody) {
+            #expect(
+                known.contains(label),
+                """
+                actionButton renders Text("\(label)") but RecommendedCardLayout \
+                does not measure it, so the card's action column width was \
+                derived without it. Add it to actionButtonTitles.
+                """
+            )
+        }
+
+        let badgeBody = try Self.body(
+            of: "private func statusBadgeView(_ badge: ModelCacheActions.StatusBadge) -> some View {",
+            in: source
+        )
+        // The pills the CARD can reach. ``statusBadgeView`` is shared with
+        // states the card never routes to it, so only these two are
+        // required to be measured.
+        for label in ["On disk", "In use"] {
+            #expect(
+                badgeBody.contains("\"\(label)\""),
+                "statusBadgeView no longer renders the \"\(label)\" pill the card's width was measured against"
+            )
+            #expect(known.contains(label))
+        }
+    }
+
+    /// Panel source, located from ``#filePath`` so the test runs from any
+    /// working directory.
+    private static func loadPanelSource() throws -> String {
+        let root = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()  // RapidTests
+            .deletingLastPathComponent()  // Tests
+            .deletingLastPathComponent()  // apps/rapid-mac
+        return try String(
+            contentsOf: root.appendingPathComponent(
+                "Sources/Rapid/UI/SettingsModelManagementPanel.swift"
+            ),
+            encoding: .utf8
+        )
+    }
+
+    /// One function's body, scoped by matching the braces after its
+    /// signature. A "up to the next MARK" heuristic silently swallowed
+    /// the following functions, which would have made this guard pass on
+    /// labels it never actually saw.
+    private static func body(of signature: String, in source: String) throws -> String {
+        struct MissingDeclaration: Error { let signature: String }
+        guard let start = source.range(of: signature) else {
+            throw MissingDeclaration(signature: signature)
+        }
+        // ``signature`` ends with the opening brace, so start at depth 1.
+        var depth = 1
+        var end = start.upperBound
+        while end < source.endIndex, depth > 0 {
+            switch source[end] {
+            case "{": depth += 1
+            case "}": depth -= 1
+            default: break
+            }
+            if depth > 0 { end = source.index(after: end) }
+        }
+        guard depth == 0 else { throw MissingDeclaration(signature: signature) }
+        return String(source[start.upperBound..<end])
+    }
+
+    /// Every `Text("…")` string literal in a fragment of Swift source.
+    private static func textLiterals(in fragment: String) -> [String] {
+        var out: [String] = []
+        var remainder = Substring(fragment)
+        while let open = remainder.range(of: "Text(\"") {
+            let after = remainder[open.upperBound...]
+            guard let close = after.firstIndex(of: "\"") else { break }
+            let literal = String(after[..<close])
+            // Skip interpolated labels — they are not fixed strings and
+            // cannot be width-measured up front.
+            if !literal.contains("\\(") { out.append(literal) }
+            remainder = after[close...]
+        }
+        return out
+    }
+
     /// The specific label that broke, called out on its own so a
     /// regression names the reported symptom rather than a sweep index.
     @Test("recommended card: \"Download\" renders in full")
@@ -390,6 +494,20 @@ struct ModelSurfaceRedesignTests {
             #expect(
                 needed <= ModelTableLayout.sizeColumnWidth,
                 "\"~\(size)\" needs \(needed)pt, column is \(ModelTableLayout.sizeColumnWidth)pt"
+            )
+        }
+    }
+
+    /// The serving row is a cached row too — it owes the same size, and
+    /// the "Serving" label it carries instead of a delete button is wider
+    /// than that button, so it needs its own width check.
+    @Test("size column: a serving cell fits its size next to \"Serving\"")
+    func inUseCellFitsTheSizeColumn() {
+        for size in ["7.9 GiB", "35.2 GiB", "123.4 GiB"] {
+            let needed = ModelTableLayout.inUseCellWidth(size: size)
+            #expect(
+                needed <= ModelTableLayout.sizeColumnWidth,
+                "serving \"\(size)\" needs \(needed)pt, column is \(ModelTableLayout.sizeColumnWidth)pt"
             )
         }
     }

--- a/apps/rapid-mac/Tests/RapidTests/ModelSurfaceRedesignTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ModelSurfaceRedesignTests.swift
@@ -498,6 +498,48 @@ struct ModelSurfaceRedesignTests {
         }
     }
 
+    /// Settings is not inside the chat surface's Dynamic Type clamp, so
+    /// these `.caption` figures grow with the system text size against a
+    /// fixed-width column — the exact shape of the truncation this pass
+    /// is fixing, just triggered by the user's text setting instead of
+    /// the layout. The cells carry a shrink floor; this pins that the
+    /// floor actually covers the non-accessibility sizes (~1.25x) with
+    /// the largest figures.
+    @Test("size column: cells survive non-accessibility text growth")
+    func sizeCellsSurviveTextScaling() {
+        let scale: CGFloat = 1.25
+        for size in ["7.9 GiB", "123.4 GiB"] {
+            #expect(
+                ModelTableLayout.fits(
+                    ModelTableLayout.cachedCellWidth(size: size), atTextScale: scale
+                ),
+                "cached \"\(size)\" truncates at \(scale)x text"
+            )
+            #expect(
+                ModelTableLayout.fits(
+                    ModelTableLayout.inUseCellWidth(size: size), atTextScale: scale
+                ),
+                "serving \"\(size)\" truncates at \(scale)x text"
+            )
+        }
+        for size in ["0.5 GB", "123.4 GB"] {
+            #expect(
+                ModelTableLayout.fits(
+                    ModelTableLayout.notCachedCellWidth(size: size), atTextScale: scale
+                ),
+                "not cached \"~\(size)\" truncates at \(scale)x text"
+            )
+        }
+        // The floor is a bound, not a Dynamic Type pass — say so in the
+        // suite rather than implying the AX sizes are covered.
+        #expect(
+            !ModelTableLayout.fits(
+                ModelTableLayout.inUseCellWidth(size: "123.4 GiB"), atTextScale: 2.0
+            ),
+            "if this now passes, the column reflows and the comment on cellMinimumScaleFactor is stale"
+        )
+    }
+
     /// The serving row is a cached row too — it owes the same size, and
     /// the "Serving" label it carries instead of a delete button is wider
     /// than that button, so it needs its own width check.

--- a/apps/rapid-mac/Tests/RapidTests/ModelSurfaceRedesignTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ModelSurfaceRedesignTests.swift
@@ -308,4 +308,136 @@ struct ModelSurfaceRedesignTests {
         #expect(!ModelFavorites.isFavorite("qwen3.6-35b-4bit", defaults: defaults))
         #expect(ModelFavorites.load(defaults: defaults).isEmpty)
     }
+
+    // MARK: - Recommended card geometry
+
+    /// The reported defect: the best-pick card's primary call to action
+    /// rendered as "Dow…". Nothing truncated the label directly — the
+    /// slot it sat in was pinned to 92pt and its contents did not fit,
+    /// so AppKit ellipsised the title. Widening the window did not help
+    /// because the clamp was on the card, not the window.
+    ///
+    /// This measures the real thing: AppKit's own metrics for the small
+    /// system font, plus the button's chrome, against the width the card
+    /// gives that slot. Any future label, control size or padding change
+    /// that reintroduces the squeeze fails here.
+    @Test("recommended card: every action label fits the slot it renders in")
+    func recommendedActionLabelsFitTheirColumn() {
+        for title in RecommendedCardLayout.actionButtonTitles {
+            let needed = RecommendedCardLayout.buttonWidth(title: title)
+            #expect(
+                needed <= RecommendedCardLayout.actionColumnWidth,
+                "\"\(title)\" needs \(needed)pt but the action column offers \(RecommendedCardLayout.actionColumnWidth)pt"
+            )
+        }
+        for text in RecommendedCardLayout.actionPillTitles {
+            let needed = RecommendedCardLayout.pillWidth(text: text)
+            #expect(
+                needed <= RecommendedCardLayout.actionColumnWidth,
+                "\"\(text)\" needs \(needed)pt but the action column offers \(RecommendedCardLayout.actionColumnWidth)pt"
+            )
+        }
+    }
+
+    /// The specific label that broke, called out on its own so a
+    /// regression names the reported symptom rather than a sweep index.
+    @Test("recommended card: \"Download\" renders in full")
+    func downloadLabelIsNotTruncated() {
+        let needed = RecommendedCardLayout.buttonWidth(title: "Download")
+        #expect(needed <= RecommendedCardLayout.actionColumnWidth)
+        // And the width is genuinely derived from the labels rather than
+        // being a literal that happens to be large today.
+        #expect(RecommendedCardLayout.actionColumnWidth >= needed)
+        #expect(RecommendedCardLayout.actionColumnWidth < needed + 40)
+    }
+
+    /// Why the size caption had to leave the action slot: with it, the
+    /// old 92pt column could not fit "Download" alongside it, which is
+    /// exactly the arithmetic that produced "Dow…". Pinned so nobody
+    /// re-adds a caption there without hitting this.
+    @Test("recommended card: a caption beside the button re-creates the squeeze")
+    func sizeCaptionBesideTheButtonDoesNotFit() {
+        let legacyColumn: CGFloat = 92
+        let caption = RecommendedCardLayout.captionWidth("7.6 GB")
+        let button = RecommendedCardLayout.buttonWidth(title: "Download")
+        #expect(caption + 8 + button > legacyColumn)
+    }
+
+    // MARK: - Models table geometry
+
+    /// Defect 3's other half: now that a cached cell carries a figure and
+    /// not just two glyphs, the Size column has to be wide enough to hold
+    /// it — including on the machines with the largest caches, which are
+    /// exactly the users who go looking for this tab.
+    @Test("size column: a cached cell fits glyph + measured size + delete")
+    func cachedCellFitsTheSizeColumn() {
+        for size in ["7.9 GiB", "512 MiB", "123.4 GiB"] {
+            let needed = ModelTableLayout.cachedCellWidth(size: size)
+            #expect(
+                needed <= ModelTableLayout.sizeColumnWidth,
+                "\"\(size)\" needs \(needed)pt, column is \(ModelTableLayout.sizeColumnWidth)pt"
+            )
+        }
+        // Why the column had to move at all: the 84pt it replaced would
+        // have clipped the largest caches.
+        #expect(ModelTableLayout.cachedCellWidth(size: "123.4 GiB") > 84)
+    }
+
+    @Test("size column: a not-cached cell still fits after the ~ marker")
+    func notCachedCellFitsTheSizeColumn() {
+        for size in ["0.5 GB", "42.7 GB", "123.4 GB"] {
+            let needed = ModelTableLayout.notCachedCellWidth(size: size)
+            #expect(
+                needed <= ModelTableLayout.sizeColumnWidth,
+                "\"~\(size)\" needs \(needed)pt, column is \(ModelTableLayout.sizeColumnWidth)pt"
+            )
+        }
+    }
+
+    // MARK: - Size column: measured vs. estimated
+
+    /// A cached row must quote what was MEASURED on disk
+    /// (``ModelEntry.sizeOnDisk``, from `rapid-mlx ls`), verbatim, so the
+    /// Model Management table and Settings → Models cannot print
+    /// different numbers for the same model.
+    @Test("size column: a cached row quotes the measured on-disk size")
+    func cachedRowUsesMeasuredSize() {
+        let entry = ModelEntry(
+            alias: "bonsai-27b-2bit", hfRepo: nil, sizeOnDisk: "7.9 GiB", cached: true
+        )
+        #expect(SettingsModelManagementPanel.onDiskSizeLabel(entry) == "7.9 GiB")
+    }
+
+    /// No measurement, no number. Substituting the alias-derived
+    /// estimate here would dress a guess as a measurement — #1550 is the
+    /// same confusion in the download strip, where the estimate came in
+    /// ~12% under the real bytes.
+    @Test("size column: an unmeasured cached row shows nothing, not an estimate")
+    func cachedRowWithoutMeasurementFallsBackToNothing() {
+        let unmeasured = ModelEntry(
+            alias: "qwen3.5-9b-4bit", hfRepo: nil, sizeOnDisk: nil, cached: true
+        )
+        #expect(SettingsModelManagementPanel.onDiskSizeLabel(unmeasured) == nil)
+        // The estimate for that alias exists and is NOT what we show.
+        #expect(SettingsModelManagementPanel.downloadSizeLabel("qwen3.5-9b-4bit") != nil)
+
+        let blank = ModelEntry(
+            alias: "qwen3.5-9b-4bit", hfRepo: nil, sizeOnDisk: "   ", cached: true
+        )
+        #expect(SettingsModelManagementPanel.onDiskSizeLabel(blank) == nil)
+    }
+
+    /// The two numbers now share a column, so they must not share a
+    /// format: the estimate is rendered with a leading "~" by the row,
+    /// and the helper hands back the bare figure for that to be added to
+    /// exactly once.
+    @Test("size column: the download estimate is a bare figure the row marks as approximate")
+    func downloadEstimateIsBare() {
+        let estimate = SettingsModelManagementPanel.downloadSizeLabel("qwen3.5-9b-4bit")
+        #expect(estimate?.hasPrefix("~") == false)
+        #expect(estimate?.hasSuffix(" GB") == true)
+        // An alias ``ModelSizing`` cannot size at all yields no figure
+        // rather than "~0.0 GB".
+        #expect(SettingsModelManagementPanel.downloadSizeLabel("") == nil)
+    }
 }

--- a/apps/rapid-mac/Tests/RapidUXTests/ModelReadinessTests.swift
+++ b/apps/rapid-mac/Tests/RapidUXTests/ModelReadinessTests.swift
@@ -506,7 +506,7 @@ final class ModelReadinessTests: XCTestCase {
     /// banner simultaneously showed the unknown-model glyph, so the same
     /// row said two different things.
     func testUnknownAliasDoesNotClaimItIsDownloaded() {
-        let unknown = "mlx-community/Some Model With Spaces"
+        let unknown = "mlx-community/Some-Custom-Repo"
         let state = resolveCacheState(
             .idle,
             alias: unknown,
@@ -526,7 +526,7 @@ final class ModelReadinessTests: XCTestCase {
     /// ``needsStart`` — ``ServerManager`` pulls on demand, so Start is
     /// still the right and only button.
     func testUnknownAliasStillOffersStartAndStaysGated() {
-        let unknown = "mlx-community/Some Model With Spaces"
+        let unknown = "mlx-community/Some-Custom-Repo"
         let state = resolveCacheState(.idle, alias: unknown, cacheState: .notInCatalog)
         XCTAssertEqual(state.action, .start(alias: unknown))
         XCTAssertFalse(state.sendAllowed)
@@ -544,7 +544,7 @@ final class ModelReadinessTests: XCTestCase {
     /// a custom model the user started must reach ``ready`` and enable
     /// Send like any other.
     func testUnknownAliasStillReachesReadyWhenServing() {
-        let unknown = "mlx-community/Some Model With Spaces"
+        let unknown = "mlx-community/Some-Custom-Repo"
         let state = resolveCacheState(
             .ready(alias: unknown),
             alias: unknown,

--- a/apps/rapid-mac/Tests/RapidUXTests/ModelReadinessTests.swift
+++ b/apps/rapid-mac/Tests/RapidUXTests/ModelReadinessTests.swift
@@ -19,6 +19,11 @@ final class ModelReadinessTests: XCTestCase {
 
     // MARK: - Helpers
 
+    /// `cached: nil` is the TRANSIENT unknown — the catalog has not
+    /// answered yet. The permanently-unknown alias (a custom name the
+    /// catalog has loaded and does not contain) is a different input and
+    /// gets its own tests below; it is never reachable through this
+    /// helper, so every existing case here keeps its original meaning.
     private func resolve(
         _ state: ServerState,
         alias: String? = nil,
@@ -30,11 +35,34 @@ final class ModelReadinessTests: XCTestCase {
         ModelReadiness.resolve(
             serverState: state,
             alias: alias ?? self.alias,
-            isAliasCached: cached,
+            cacheState: cacheState(cached),
             sizeText: sizeText,
             progress: progress,
             failure: failure
         )
+    }
+
+    /// Same, for the cache states ``Bool?`` cannot express.
+    private func resolveCacheState(
+        _ state: ServerState,
+        alias: String? = nil,
+        cacheState: ModelReadiness.CacheState,
+        sizeText: String? = nil
+    ) -> ModelReadiness {
+        ModelReadiness.resolve(
+            serverState: state,
+            alias: alias ?? self.alias,
+            cacheState: cacheState,
+            sizeText: sizeText
+        )
+    }
+
+    private func cacheState(_ cached: Bool?) -> ModelReadiness.CacheState {
+        switch cached {
+        case .some(true):  return .onDisk
+        case .some(false): return .notOnDisk
+        case .none:        return .catalogPending
+        }
     }
 
     /// Every case, for sweeps that must hold universally.
@@ -45,6 +73,7 @@ final class ModelReadinessTests: XCTestCase {
             .needsDownload(alias: alias, sizeText: "5.0 GB"),
             .needsDownload(alias: alias, sizeText: nil),
             .needsStart(alias: alias),
+            .unknownModel(alias: alias),
             .downloading(alias: alias, detail: "1.2 / 5.0 GB · 24%", fraction: 0.24),
             .downloading(alias: alias, detail: nil, fraction: nil),
             .starting(alias: alias, detail: "Warming up…"),
@@ -460,6 +489,81 @@ final class ModelReadinessTests: XCTestCase {
         XCTAssertEqual(state, .needsStart(alias: alias))
     }
 
+    /// The same input stated explicitly: a still-loading catalog keeps
+    /// ``needsStart`` and its "already downloaded" copy. This is the
+    /// transient case the fallback was designed for, and it must not
+    /// regress when the permanently-unknown case is split out below.
+    func testCatalogPendingKeepsTheAlreadyDownloadedCopy() {
+        let state = resolveCacheState(.idle, cacheState: .catalogPending)
+        XCTAssertEqual(state, .needsStart(alias: alias))
+        XCTAssertEqual(state.detail, "It's already downloaded — starting takes a few seconds.")
+    }
+
+    /// The defect: an alias the loaded catalog does NOT contain — a
+    /// custom model name typed into "Type a model name…" — was falling
+    /// through to ``needsStart``, whose detail asserts the weights are
+    /// on disk. Nothing establishes that, and the picker chip beside the
+    /// banner simultaneously showed the unknown-model glyph, so the same
+    /// row said two different things.
+    func testUnknownAliasDoesNotClaimItIsDownloaded() {
+        let unknown = "mlx-community/Some Model With Spaces"
+        let state = resolveCacheState(
+            .idle,
+            alias: unknown,
+            cacheState: .notInCatalog
+        )
+        XCTAssertEqual(state, .unknownModel(alias: unknown))
+        let detail = state.detail ?? ""
+        XCTAssertFalse(
+            detail.lowercased().contains("already downloaded"),
+            "an alias we cannot find must not be described as downloaded: \(detail)"
+        )
+        XCTAssertFalse(detail.trimmingCharacters(in: .whitespaces).isEmpty)
+    }
+
+    /// Copy is the ONLY thing that changes. The step the user takes, the
+    /// gate on Send, and the status colour are identical to
+    /// ``needsStart`` — ``ServerManager`` pulls on demand, so Start is
+    /// still the right and only button.
+    func testUnknownAliasStillOffersStartAndStaysGated() {
+        let unknown = "mlx-community/Some Model With Spaces"
+        let state = resolveCacheState(.idle, alias: unknown, cacheState: .notInCatalog)
+        XCTAssertEqual(state.action, .start(alias: unknown))
+        XCTAssertFalse(state.sendAllowed)
+        XCTAssertFalse(state.isFailure)
+        XCTAssertEqual(state.statusRole, .idle)
+        XCTAssertEqual(state.headline, ModelReadiness.needsStart(alias: unknown).headline)
+        XCTAssertEqual(
+            state.composerPlaceholder,
+            ModelReadiness.needsStart(alias: unknown).composerPlaceholder
+        )
+    }
+
+    /// An unknown alias is only unknown while it is not running. Once the
+    /// engine is serving it, the live serve-state outranks the catalog —
+    /// a custom model the user started must reach ``ready`` and enable
+    /// Send like any other.
+    func testUnknownAliasStillReachesReadyWhenServing() {
+        let unknown = "mlx-community/Some Model With Spaces"
+        let state = resolveCacheState(
+            .ready(alias: unknown),
+            alias: unknown,
+            cacheState: .notInCatalog
+        )
+        XCTAssertEqual(state, .ready(alias: unknown))
+        XCTAssertTrue(state.sendAllowed)
+    }
+
+    /// A blank alias is "no model chosen" regardless of how the cache
+    /// state describes it — the unknown-alias branch must not intercept
+    /// the empty selection and start naming a placeholder.
+    func testUnknownCacheStateWithNoAliasIsStillNoModel() {
+        XCTAssertEqual(
+            resolveCacheState(.idle, alias: "", cacheState: .notInCatalog),
+            .noModel
+        )
+    }
+
     /// An empty size string means ``ModelSizing`` had no estimate. It
     /// must be dropped, not rendered as empty parentheses.
     func testBlankSizeTextIsDropped() {
@@ -678,6 +782,7 @@ final class ModelReadinessTests: XCTestCase {
         let named: [ModelReadiness] = [
             .needsDownload(alias: alias, sizeText: nil),
             .needsStart(alias: alias),
+            .unknownModel(alias: alias),
             .downloading(alias: alias, detail: nil, fraction: nil),
             .starting(alias: alias, detail: nil),
             .ready(alias: alias),


### PR DESCRIPTION
Four independent UI defects in `apps/rapid-mac`, each found by driving a real
build. They are one PR because they are one kind of bug: **the UI stating
something that is either unreadable or untrue.**

## 1. The Recommended card's primary button rendered as `Dow…`

Settings → Model Management → "RECOMMENDED FOR YOUR …", best-pick card, whenever
the pick is not cached — which is every user who has not downloaded it yet.

Nothing truncated the label. The card's trailing slot was a hard
`.frame(width: 92)` wrapped around a size caption **and** a
`.borderedProminent` `.controlSize(.small)` button. The caption takes ~31pt plus
8pt of spacing, so the button was offered ~53 of the ~78pt "Download" needs, and
AppKit ellipsised the title. Widening the Settings window to 1300pt does not help,
because the clamp is on the card, not the window.

Fix: the slot is `.fixedSize(horizontal: true)` — that is the actual guarantee
that a label can never be compressed — with a `minWidth` floor **derived** from
AppKit text metrics for every label the slot can render, so the two stacked cards
still line up and a future longer label moves the column with it instead of
clipping against it.

The size caption is gone rather than merely moved: `pickStatsLine` already opens
with the same footprint two columns to its left ("65.0 GB · 88% capability"), and
the two came from different sources (the curated `Pick.footprintGB` vs
`ModelSizing.estimate`), so the card was quoting one fact twice and could
disagree with itself by a rounding step.

**Judgement call — the duplicate "Best pick".** The card rendered `Best pick` as
a label *and* `BEST PICK` as a capsule directly beneath it: the same two words,
stacked, 4pt apart. The capsule goes and the label stays. The label carries the
star and reads at a glance; the card already signals primacy three other ways
(brand tint fill, brand border, raised shadow), and the alias still gets a
`RECOMMENDED` pill in the table below, so nothing is lost but the repetition.
The alt card's `Faster` label stays symmetrical with it.

Sibling states checked rather than assumed: `Cancel`, `Retry` and the `On disk` /
`In use` pills are all narrower than `Download` and were never at risk; the
`Delete` branch in `actionButton` is unreachable from the card today (a cached
pick resolves to the `On disk` pill) but is measured anyway.

## 2. "ALL MODELS · 175" kept counting the whole catalog under a filter

`Text("· \(catalog.count)")` — the unfiltered catalog size — rendered no matter
what the search box or the Cached / Not cached segment had done to the rows
underneath. Type three characters and four rows sat under a header claiming 175.

`ModelCacheActions.listHeading` now derives both halves from the same filter pass
the list renders, so heading and rows cannot describe different sets.

**Judgement call — how the filtered header should read.** The count always
describes what is on screen; when anything narrows it, the catalog total follows
as context rather than the number silently changing meaning:

| state | header |
|---|---|
| no filter | `ALL MODELS · 175` |
| search `qwen3.6` | `ALL MODELS · 4 of 175` |
| Cached segment | `CACHED · 3 of 175` |
| Not cached + search | `NOT CACHED · 6 of 175` |
| no matches | `ALL MODELS · 0 of 175` |

The title names the segment — that is the "what am I looking at" half. The search
term is deliberately **not** echoed: it is legible in the field a few points
above, and repeating it would be the same duplication defect as §1's badge.

## 3. A cached model never showed its size in the tab whose job is reclaiming space

A not-cached row showed its size and a download glyph; a cached row showed a green
check and a trash icon and nothing else. So the one surface whose own header says
"delete what you don't [need] to reclaim space" never said how much any given
model would reclaim — while its own "Size (largest first)" sort ordered the table
by exactly that number.

Cached rows now show `ModelEntry.sizeOnDisk`: the **measured** figure from
`rapid-mlx ls` (correct since #1584), verbatim, so this table and Settings →
Models cannot print different numbers for the same model. Never a substituted
estimate — an unmeasured row says "On disk" and stops.

Two consequences worth stating, because #1550 is an open case of exactly this
confusion:

* The **estimate** on not-cached rows (`ModelSizing.estimate`, parsed from the
  alias string) now renders as `~0.5 GB`. The two figures share a column and must
  not be mistaken for each other; #1550 has that estimate landing ~12% under the
  real download. Hover text on each says which is which.
* The serving row is a cached row too, so it shows its size next to `Serving`. It
  still has no delete button — the weights are mmap'd mid-serve.

The Size column moves 84 → 100pt (the biggest caches, `123.4 GiB`, need ~90),
which the flexible model-name column absorbs. The figures carry a shrink floor so
a user on larger system text loses the size to scaling rather than to truncation
— a bound for the non-accessibility sizes, not a Dynamic Type pass; at the AX
sizes this table needs to reflow, which is every column and not this fix's
business.

## 4. An unknown custom alias claimed "It's already downloaded"

Composer model chip → "Type a model name…" → anything not in the catalog → Use.
The banner read:

> **mlx-community/… isn't running** — It's already downloaded — starting takes a
> few seconds.

while the chip beside it, in the same row, showed the unknown-model
`questionmark.circle` glyph.

`ModelReadiness.resolve` branched on `isAliasCached: Bool?`, where `nil` meant two
different things: *"the catalog has not loaded yet"* (transient) and *"the catalog
has loaded and does not contain this alias"* (permanent). The documented rationale
for falling through to `.needsStart` is the transient case, and **that reasoning
is correct** — for the second the catalog takes to load, claiming a multi-gigabyte
download is required is the more misleading of the two errors. It simply does not
hold once the catalog has answered.

The two are now distinct `CacheState` cases. The transient one keeps `.needsStart`
and its copy verbatim, with its original test unchanged plus a new one stating the
case explicitly. The permanent one gets a new `.unknownModel` state whose copy
promises nothing:

> **… isn't running** — Rapid doesn't know this one, so it can't say whether it's
> already on your Mac.

The action, the send gate and the status colour are identical to `.needsStart` —
only the words change. The copy deliberately does **not** promise a download
either: `ServerManager.isValidAlias` rejects names with spaces, so the reported
alias could never have been pulled, and a banner that promised one would be the
same class of defect one step further along.

`ContentView.cacheState(for:)` additionally refuses to call an alias unknown on an
**empty** catalog: `ModelCatalog.load` returns `[]` as its failure sentinel, and
telling a user their model is unrecognised on the strength of a subprocess that
did not run would be the same lie in a different direction.

## Verification

`swift build` green. **Neither test target runs on this machine** — it has Command
Line Tools only, where both `import XCTest` and `import Testing` fail to resolve,
so this leans on CI's `build` job for `swift test --no-parallel`. To avoid landing
test files blind, the XCTest suite was typechecked against a stub XCTest module
and every expression the swift-testing cases use was typechecked against the built
module from a nonisolated context (`SettingsModelManagementPanel` is
`@MainActor`-inferred through `View`, hence the `nonisolated static` on the two
size-label helpers).

Live GUI verification was **not possible**: the machine's screen is locked, so
`screencapture` returns the wallpaper and a launched instance reports no windows.
The surfaces were instead rasterised through the app's own `DevSnapshot` harness —
real SwiftUI views, real catalog, in-process — which is how the four fixes above
were reviewed. **A human should still eyeball, when a screen is available:** the
Recommended card's action button rendering its full label at both the default and
minimum Settings width; the "All models" count under an active search and under
each filter segment; a cached row and a serving row showing their sizes; and the
readiness banner for a typed-in unknown model.

Guards added, in the existing style of each suite:

* Card and column widths asserted against real AppKit text metrics for every label
  the slots render, including the historical arithmetic that produced `Dow…`.
* A source-grep guard (like `ToolUseCapabilitySourceGuardTests`) that brace-matches
  `actionButton` / `statusBadgeView` and fails if the view renders a label the
  width derivation never measured — without it, the width sweep would have been
  self-certifying.
* The heading truth table, including whitespace-only queries and zero matches, and
  a cross-check that the count agrees with `filter()` for the same inputs.
* The measured-vs-estimated split: a cached row quotes `sizeOnDisk` verbatim, an
  unmeasured one shows nothing rather than the estimate, and the estimate helper
  returns a bare figure the row marks approximate.
* The new readiness case pinned alongside the transient one it was split from,
  including that an unknown alias still reaches `.ready` once it is actually
  serving.

## Also in here

`DevSnapshot` was trapping on its very first capture with *"No Observable object
of type BrowseApprovalStore found"* — dead since that dependency landed in
`ContentView`, so nothing it renders had been reviewable. Injected, plus Model
Management scenes. Dev-only and gated on `RAPID_DEV_SNAPSHOT_DIR`; it is the only
reason there was any visual review at all here.

## Looked at, not fixed

* **#1514** (readiness banner offers Retry for non-retriable failures) — same
  file, same family of problem, but it is a change to the banner's *action* model
  and this PR only changes what the banner *says*. Left open rather than widening
  the diff.
* **#1550** — not fixed, but §3 is careful not to make it worse: the measured and
  the estimated figure now share a column and are marked apart.
* The composer's custom-model sheet accepts free text that `isValidAlias` will
  later reject, so `Use` can seat an alias that Start can only fail on. Out of
  scope here; §4 makes the banner stop lying about it, not the input stop
  accepting it.

Codex review: converged at 0 BLOCKING / 0 MAJOR / 0 MINOR over three rounds; its
round-1 findings (the serving row's missing size, the empty-catalog sentinel, the
download promise in the new copy, and the self-certifying width sweep) are all
fixed above rather than argued with.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
