### PR TITLE
fix(qwen): drop streamed tool string wrapper quotes

### DIFF
--- a/tests/test_qwen3coder_tool_parser_streaming.py
+++ b/tests/test_qwen3coder_tool_parser_streaming.py
@@ -201,6 +201,31 @@ def test_json_encoded_string_preserves_embedded_xml_closers():
     assert json.loads("".join(fragments)) == {"content": value}
 
 
+def test_json_string_after_split_formatting_space_drops_wrapper_quotes():
+    """Formatting whitespace arriving before a JSON quote stays wire-only.
+
+    Real Qwen3.6 streams can split ``<parameter>\n \"value\"`` after the
+    space.  The parser must not enter legacy raw-string streaming at that
+    boundary and turn the JSON wrapper quotes into literal argument bytes.
+    """
+    parser = Qwen3CoderToolParser(tokenizer=None)
+    request = _request_with_tool("read_file", {"path": {"type": "string"}})
+    value = "/tmp/.hermes-read-0123456789abcdef0123456789abcdef.txt"
+    encoded = json.dumps(value)
+    chunks = [
+        "<tool_call>\n",
+        "<function=read_file>\n",
+        "<parameter=path>\n ",
+        encoded[:16],
+        encoded[16:] + "\n</parameter>\n",
+        "</function>\n",
+        "</tool_call>",
+    ]
+
+    fragments = _argument_fragments(_feed(parser, chunks, request))
+    assert json.loads("".join(fragments)) == {"path": value}
+
+
 def test_streaming_json_matches_non_streaming():
     """Concatenating all streamed ``function.arguments`` fragments and
     ``json.loads``-ing the result must equal the arguments dict

--- a/tests/test_qwen3coder_tool_parser_streaming.py
+++ b/tests/test_qwen3coder_tool_parser_streaming.py
@@ -201,7 +201,20 @@ def test_json_encoded_string_preserves_embedded_xml_closers():
     assert json.loads("".join(fragments)) == {"content": value}
 
 
-def test_json_string_after_split_formatting_space_drops_wrapper_quotes():
+@pytest.mark.parametrize(
+    ("tool_name", "param_name", "value"),
+    [
+        (
+            "read_file",
+            "path",
+            "/tmp/.hermes-read-0123456789abcdef0123456789abcdef.txt",
+        ),
+        ("browse", "url", "https://example.com"),
+    ],
+)
+def test_json_string_after_split_formatting_space_drops_wrapper_quotes(
+    tool_name: str, param_name: str, value: str
+):
     """Formatting whitespace arriving before a JSON quote stays wire-only.
 
     Real Qwen3.6 streams can split ``<parameter>\n \"value\"`` after the
@@ -209,13 +222,12 @@ def test_json_string_after_split_formatting_space_drops_wrapper_quotes():
     boundary and turn the JSON wrapper quotes into literal argument bytes.
     """
     parser = Qwen3CoderToolParser(tokenizer=None)
-    request = _request_with_tool("read_file", {"path": {"type": "string"}})
-    value = "/tmp/.hermes-read-0123456789abcdef0123456789abcdef.txt"
+    request = _request_with_tool(tool_name, {param_name: {"type": "string"}})
     encoded = json.dumps(value)
     chunks = [
         "<tool_call>\n",
-        "<function=read_file>\n",
-        "<parameter=path>\n ",
+        f"<function={tool_name}>\n",
+        f"<parameter={param_name}>\n ",
         encoded[:16],
         encoded[16:] + "\n</parameter>\n",
         "</function>\n",
@@ -223,7 +235,7 @@ def test_json_string_after_split_formatting_space_drops_wrapper_quotes():
     ]
 
     fragments = _argument_fragments(_feed(parser, chunks, request))
-    assert json.loads("".join(fragments)) == {"path": value}
+    assert json.loads("".join(fragments)) == {param_name: value}
 
 
 def test_streaming_json_matches_non_streaming():

--- a/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
+++ b/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
@@ -581,7 +581,13 @@ class Qwen3CoderToolParser(ToolParser):
         first-close behavior.
         """
         i = value_start
-        if i < len(text) and text[i] == "\n":
+        # The XML template permits formatting whitespace between the parameter
+        # opener and its JSON-string value.  Treat that whitespace as wire, not
+        # as part of a legacy raw string.  In particular, token streaming can
+        # expose the whitespace one delta before the opening quote; failing to
+        # skip it makes the incremental path escape both JSON wrapper quotes
+        # into the user value (``/tmp/x`` becomes ``\"/tmp/x\"``).
+        while i < len(text) and text[i].isspace():
             i += 1
         if i >= len(text) or text[i] != '"':
             return text.find(self.parameter_end_token, i)
@@ -944,7 +950,8 @@ class Qwen3CoderToolParser(ToolParser):
                         value_text = value_text[1:]
 
                     end_idx = self._find_parameter_close(value_text, 0)
-                    if end_idx == -1 and not value_text.startswith('"'):
+                    json_string_pending = value_text.lstrip().startswith('"')
+                    if end_idx == -1 and not json_string_pending:
                         # Defensive fallback: model emitted next-param-prefix,
                         # </function>, or </tool_call> without a </parameter>.
                         # Use any of those as the close to avoid hanging
@@ -971,7 +978,7 @@ class Qwen3CoderToolParser(ToolParser):
                         self.in_param_name = None
                         self.in_param_emitted_chars = 0
                         self.in_param_opened = False
-                    else:
+                    elif not json_string_pending:
                         frag = self._emit_string_increment(
                             self.in_param_name, value_text
                         )
@@ -995,7 +1002,8 @@ class Qwen3CoderToolParser(ToolParser):
                     value_text = value_text[1:]
 
                 param_end_idx = self._find_parameter_close(value_text, 0)
-                if param_end_idx == -1 and not value_text.startswith('"'):
+                json_string_pending = value_text.lstrip().startswith('"')
+                if param_end_idx == -1 and not json_string_pending:
                     # Try next parameter or function end as delimiter
                     next_param = value_text.find(self.parameter_prefix)
                     func_end = value_text.find(self.function_end_token)
@@ -1013,7 +1021,7 @@ class Qwen3CoderToolParser(ToolParser):
                             # emit partial JSON (half an int isn't valid),
                             # so fall through to the existing break path.
                             if _is_string_param(current_param_name, param_config):
-                                if value_text.startswith('"'):
+                                if json_string_pending:
                                     break
                                 frag = self._emit_string_increment(
                                     current_param_name, value_text


### PR DESCRIPTION
## What changed

- recognize JSON-string tool parameters after XML formatting whitespace
- keep wrapper quotes buffered instead of emitting them as literal argument data
- add the Qwen3.6/Hermes chunk-boundary regression test

## Why

This is required because main regressed streamed Qwen3.6 tool arguments after v0.12.4: wrapper quotes became part of file paths, causing five stable Hermes harness failures and blocking the release.

## Root cause

The XML grammar JSON-encodes string parameters. When formatting whitespace arrived in a delta before the opening quote, the streaming parser entered its legacy raw-string path. It escaped both JSON wrapper quotes into `function.arguments`, so `/tmp/file` reached agents as `\"/tmp/file\"`. Hermes then correctly reported the quoted path missing and downstream workflows retried until timeout.

## Impact

Restores streamed tool argument fidelity for Qwen3.6 and fixes the stable Hermes `read_file`, code review, code-with-tests, git-analysis, and patch-file release regressions. The same corruption affected GUI `browse` URLs, where `https://example.com` became a quoted, invalid absolute URL.

## Test plan

- [x] Run parser regression and value-fidelity suites (449 passed, 28 skipped)
- [x] Reproduce the quoted-path failure with a real Qwen3.6-35B streaming probe before the fix
- [x] Validate the fixed 35B streaming probe on Mac Studio (`MATCH=True`)
- [x] Validate all five stable Hermes regression cases on Mac Studio
- [x] Validate the same parser path with Qwen3.6-27B and Hermes `read_file` on Mac mini
- [x] Cover both file-path and browse-URL string arguments in the chunk-boundary regression test
