### PR TITLE
test(qwen): pin wrapper-quote stripping in both directions

### DIFF
--- a/tests/test_qwen3coder_tool_parser_streaming.py
+++ b/tests/test_qwen3coder_tool_parser_streaming.py
@@ -427,3 +427,81 @@ def test_string_aliases_all_stream_incrementally(param_type):
         f"type={param_type!r}: expected incremental emission, got "
         f"{len(value_frags)} value-bearing fragments"
     )
+
+
+# ``(value, ensure_ascii settings worth running)``. Escaping is what this
+# exercises, so a value is only run under both settings when the two produce
+# different wires — for pure ASCII they are byte-identical and the second run
+# would assert nothing the first did not.
+_QUOTE_FIDELITY_VALUES = [
+    # the shape #1600 fixes — controls that must come out clean
+    ("https://example.com", (False,)),
+    ("https://example.com/a-b.c?q=1&r=2", (False,)),
+    ("/tmp/.hermes-read-0123456789abcdef0123456789abcdef.txt", (False,)),
+    # the mirror risk: content that GENUINELY carries the quotes
+    ('"hello world"', (False,)),
+    ('"opening only', (False,)),
+    ('closing only"', (False,)),
+    ('""', (False,)),
+    ('"</parameter> inside"', (False,)),
+    ('"trailing backslash \\"', (False,)),
+    # non-ASCII: the two settings differ, and with escaping on the mid-value
+    # cut lands inside a \uXXXX sequence
+    ('"天气预报 北京"', (True, False)),
+]
+
+
+def _quote_fidelity_cases():
+    for value, ascii_modes in _QUOTE_FIDELITY_VALUES:
+        for ensure_ascii in ascii_modes:
+            for cut in ("mid-value", "before-closing-quote"):
+                for lead in ("", " ", "\n "):
+                    yield pytest.param(value, ensure_ascii, cut, lead)
+
+
+@pytest.mark.parametrize(
+    ("value", "ensure_ascii", "cut", "lead"), _quote_fidelity_cases()
+)
+def test_wrapper_quotes_dropped_without_eating_real_quotes(
+    value: str, ensure_ascii: bool, cut: str, lead: str
+):
+    """Dropping the JSON wrapper quotes must not drop the value's own.
+
+    #1600 stops the wrapper quotes reaching the caller when formatting
+    whitespace splits the chunk before the opening quote. The failure mode
+    on the other side is a value whose real first and last bytes are ``"``
+    losing them as well — indistinguishable from the wrapper to anything
+    that strips by position rather than by JSON structure.
+
+    A live model cannot settle this: asked for a quoted phrase it usually
+    just omits the quotes. Drive the parser instead, and require the
+    streamed fragments to agree with non-streaming on the same wire.
+
+    Two body splits per value, because they ask different questions.
+    ``mid-value`` lands inside the content — inside a ``\\uXXXX`` escape for
+    the CJK case with ``ensure_ascii`` on, which is a shape real token
+    boundaries produce. ``before-closing-quote`` puts the wrapper's closing
+    quote alone in its own chunk, which is where a positional strip would
+    take the value's own trailing quote with it.
+    """
+    parser = Qwen3CoderToolParser(tokenizer=None)
+    request = _request_with_tool("write", {"content": {"type": "string"}})
+    encoded = json.dumps(value, ensure_ascii=ensure_ascii)
+    at = len(encoded) // 2 if cut == "mid-value" else len(encoded) - 1
+    chunks = [
+        "<tool_call>\n",
+        "<function=write>\n",
+        f"<parameter=content>\n{lead}",
+        encoded[:at],
+        encoded[at:] + "\n</parameter>\n",
+        "</function>\n",
+        "</tool_call>",
+    ]
+
+    streamed = json.loads("".join(_argument_fragments(_feed(parser, chunks, request))))
+    assert streamed == {"content": value}
+
+    parser.reset()
+    non_streaming = parser.extract_tool_calls("".join(chunks), request=request)
+    assert non_streaming.tools_called
+    assert json.loads(non_streaming.tool_calls[0]["arguments"]) == {"content": value}


### PR DESCRIPTION
## Why

#1600 fixed a real bug: on the streaming path only, the Qwen3-Coder XML parser
took the JSON wrapper quotes for argument bytes when the model's formatting
whitespace arrived before the opening quote. `browse` got
`"https://example.com"` — quotes included — and rejected it as not a valid URL;
an agent reading a file got `"/path/…"` and was told it does not exist.

Its regression test pins **one** direction: a path and a URL that must come out
clean. The mirror failure is unpinned. A value whose real first and last bytes
are `"` is indistinguishable from the wrapper to anything that strips by
position rather than by JSON structure, so an edit that started eating the
value's own quotes would leave every existing test green.

A live model cannot cover this direction. Asked for the exact phrase
`"hello world"` **including the quote marks**, Qwen3.6-35B just omits them — the
observed value is byte-identical whether the parser stripped them or the model
never emitted them. So this drives the parser directly, and holds the streamed
fragments to what non-streaming returns for the same wire.

## What

One parametrized test, 60 cases: ten values × both `ensure_ascii` settings ×
the three leading-whitespace shapes (`""`, `" "`, `"\n "`).

The ten values are three controls (two URLs, one hermes-shaped
`/tmp/.hermes-read-<32 hex>.txt` path) and seven that carry quotes as real
content — opening and closing, opening only, closing only, nothing but two
quotes, a quoted string wrapping an XML closer, one ending in a backslash
immediately before the closing quote, and a CJK phrase in quotes.

The body split is derived from the encoded length (`max(1, min(16, len-1))`)
rather than fixed at 16, so every case splits the value for real — at a
constant, `'""'` and `'"opening only'` would arrive whole and test one boundary
less. With `ensure_ascii` on, the CJK case splits inside a `\uXXXX` escape,
which is a shape real token boundaries produce.

## Verification

It discriminates — this is not a test that would pass either way:

| Tree | Result |
| --- | --- |
| `45b0ac46` (main, #1600 merged) | **60/60 pass** |
| `4e91710a` (the commit immediately before the fix) | **36/60 fail** |

Every pre-fix failure lands on `lead=" "` or `lead="\n "`; not one lands on
`lead=""`, which is exactly the boundary #1600 describes.

Whole file green on main: `tests/test_qwen3coder_tool_parser_streaming.py`
72 passed. `ruff check` and `ruff format --check` clean.

## Notes

Test-only — no engine code changes, so no behaviour change to review.

Related: #1600.
