### PR TITLE
chore: bump version to 0.12.5

### DIFF
--- a/docs/release-notes/unreleased.md
+++ b/docs/release-notes/unreleased.md
@@ -2,9 +2,3 @@
      version-bump PR, `git mv` this to vX.Y.Z.md and recreate this file empty.
      Whole-line HTML comments like this one are stripped before publishing.
      See README.md in this directory for what good notes look like. -->
-
-- Removed the `ministral-3b-4bit` public alias. Its default multimodal route
-  accepts the model and reports ready, but the first text completion hangs in
-  the MLLM scheduler. Use another supported Mistral-family checkpoint; the raw
-  Hugging Face path remains available for developers investigating the upstream
-  compatibility issue tracked in #1367.

--- a/docs/release-notes/v0.12.5.md
+++ b/docs/release-notes/v0.12.5.md
@@ -1,0 +1,110 @@
+This release is about tool calling telling the truth. Ten separate defects
+land across the parsers, the streaming path and the prompt builder, all with
+the same shape: what a model meant to call was not what actually got called,
+or not what the user saw.
+
+## Highlights
+
+**Every streamed string tool argument could come back wrapped in quotes.** On
+the streaming path only, when a model's formatting whitespace arrived before
+the opening quote of a JSON-encoded value, the Qwen3-Coder XML parser took the
+wrapper quotes for argument bytes. `browse` received `"https://example.com"` —
+quotes included — and rejected it as not a valid URL. An agent asked to read a
+file received `"/path/to/file"` and was told the file does not exist. It
+reached any string argument, not only paths.
+
+Non-streaming was unaffected, which is what made it read as model weakness
+rather than a parser bug: same model, same prompt, same tools, the only
+variable `stream` — 4 of 4 correct without it, 5 of 5 corrupt with it. It was
+found from the other end, as five stable failures in the Hermes agent suite
+that looked like a 35B simply failing to use its tools.
+([#1600](https://github.com/raullenchai/Rapid-MLX/pull/1600))
+
+**`agents codex --setup` no longer deletes your Codex config.** The setup path
+rewrote `~/.codex/config.toml` from a template instead of merging into it, so
+anyone who had customised Codex lost that configuration the first time they
+pointed it at Rapid-MLX. It now deep-merges, backs the original up before
+touching it, and copies file metadata through the destination descriptor rather
+than by pathname — so the backup cannot be diverted by a symlink swapped in
+mid-write. ([#1539](https://github.com/raullenchai/Rapid-MLX/pull/1539))
+
+**Tool-call arguments survive the round trip.** Seven defects, one shape — a
+value the model emitted did not reach the tool:
+
+| Symptom | PR |
+| --- | --- |
+| Values mangled converting between wire formats | [#1518](https://github.com/raullenchai/Rapid-MLX/pull/1518) |
+| XML delimiters stripped out of string arguments | [#1552](https://github.com/raullenchai/Rapid-MLX/pull/1552) |
+| Undeclared parameters accepted ambiguously | [#1551](https://github.com/raullenchai/Rapid-MLX/pull/1551) |
+| Qwen truncating its own arguments at the length cutoff | [#1574](https://github.com/raullenchai/Rapid-MLX/pull/1574) |
+| Streamed arguments unvalidated on some parsers | [#1559](https://github.com/raullenchai/Rapid-MLX/pull/1559) |
+| Nemotron dropping the declared-tool gate while streaming | [#1540](https://github.com/raullenchai/Rapid-MLX/pull/1540) |
+| Forced-stream tool wire leaking into the response | [#1546](https://github.com/raullenchai/Rapid-MLX/pull/1546) |
+
+**LFM models no longer print their tool calls at you.** On the streaming path,
+LFM2.5 emitted raw markup into the visible answer — `: browse({"url": "…"})]`
+rendered above the tool card — while the call itself was recovered correctly, so
+it looked like a display glitch rather than a parser gap. It was not: for
+parsers without native tool-format support, the engine serialises prior calls
+into the prompt as `[Calling tool: name({args})]`, the model imitates its own
+transcript, and the parser only knew the pythonic `[name(arg=val)]` dialect.
+Reproduced 10/10 on a two-turn conversation, 0/10 after.
+([#1592](https://github.com/raullenchai/Rapid-MLX/pull/1592))
+
+The wider question that fix exposed — that six parsers, Qwen among them,
+inherit `SUPPORTS_NATIVE_TOOL_FORMAT = False` by omission and get that invented
+dialect even though their templates handle tool calls natively — is tracked in
+[#1593](https://github.com/raullenchai/Rapid-MLX/issues/1593) and is **not**
+fixed here. Qwen is robust enough to ignore it (0/6 leaks measured), so this is
+a fidelity issue rather than a breakage.
+
+**Concurrent chat and tool calls no longer kill the engine loop.** With a chat
+request and a tool call in flight together, `PromptProcessingBatch.extend` wrote
+`None` into mlx-lm's per-slot logits-processor list and took the whole scheduler
+down — reproducibly, in 3 of 5 runs.
+([#1526](https://github.com/raullenchai/Rapid-MLX/pull/1526))
+
+**`rapid-mlx ls` was reporting cached model sizes at roughly double reality.**
+It walked the Hugging Face cache following symlinks, counting each blob once
+under `blobs/` and again through every `snapshots/` link. Every "reclaim space"
+figure inherited the error, including the ones the Mac app renders.
+([#1584](https://github.com/raullenchai/Rapid-MLX/pull/1584))
+
+| Model | Before | After | `du -sh` |
+| --- | ---: | ---: | ---: |
+| Ternary-Bonsai-27B-mlx-2bit | 15.87 GiB | 7.9 GiB | 7.9G |
+| DeepSeek-R1-Distill-Qwen-32B-4bit | — | 17.2 GiB | 17G |
+| gemma-3-12b-it-bf16 | — | 24.6 GiB | 25G |
+
+Worth noting the two figures disagreed with each other, not just with reality:
+`rapid-mlx rm` used Hugging Face Hub's own `size_on_disk` and was correct all
+along, so the CLI quoted two different sizes for the same model depending on
+which command you asked.
+
+## Also fixed
+
+- **Anthropic route** — thinking controls are honoured on `/v1/messages`
+  ([#1478](https://github.com/raullenchai/Rapid-MLX/pull/1478)), and the blank
+  text block streamed between `thinking` and `tool_use` is gone
+  ([#1480](https://github.com/raullenchai/Rapid-MLX/pull/1480)).
+- **DeepSeek long turns** — reasoning budgets are enforced during decode
+  ([#1471](https://github.com/raullenchai/Rapid-MLX/pull/1471)), reasoning can
+  no longer reopen after public output has started
+  ([#1476](https://github.com/raullenchai/Rapid-MLX/pull/1476)), and
+  cross-task prefix-cache contamination is fixed
+  ([#1469](https://github.com/raullenchai/Rapid-MLX/pull/1469)).
+- **Prefix cache** — mid-conversation system messages stay where they were
+  written instead of being hoisted
+  ([#1512](https://github.com/raullenchai/Rapid-MLX/pull/1512)).
+- **Cursor** — the generated localhost config is usable again
+  ([#1491](https://github.com/raullenchai/Rapid-MLX/pull/1491)).
+- **`--force-disk-check`** is honoured during the serve prefetch
+  ([#1563](https://github.com/raullenchai/Rapid-MLX/pull/1563)).
+
+## Removed
+
+- Removed the `ministral-3b-4bit` public alias. Its default multimodal route
+  accepts the model and reports ready, but the first text completion hangs in
+  the MLLM scheduler. Use another supported Mistral-family checkpoint; the raw
+  Hugging Face path remains available for developers investigating the upstream
+  compatibility issue tracked in #1367.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.12.4"
+version = "0.12.5"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Why

Cuts engine v0.12.5. Merging this tags the release and publishes to PyPI via
`auto-release.yml`, which gates the tag on the Studio `tier1-agent-gate`.

## What is in it

`pyproject.toml` 0.12.4 → 0.12.5, plus the curated highlights in
`docs/release-notes/v0.12.5.md` (`unreleased.md` reset). No engine code — the
tree is byte-identical to `main` apart from these three files.

The release is about tool calling telling the truth: ten defects across the
parsers, the streaming path and the prompt builder, all with the same shape —
what a model meant to call was not what actually got called.

## Gate results

`make release-check-m3` on this commit's tree, on a GPU with nothing else
serving:

| Gate | Result |
| --- | --- |
| G0a release-fleet coherence | **6/6 golden cases on all 6 models** |
| G0b gauntlet-model coherence | **6/6** |
| G5 stress (8 scenarios incl. tool storm) | **8/8** |
| G6 parallel-cap | PASS |
| G7 Anthropic SDK · pydantic_ai · smolagents | PASS · PASS · 4/4 |
| G7b agent harness | FAIL — two probes, **both pre-existing** (below) |

Also green before the bump: `make release-smoke`, `make smoke` (ruff + CLI↔Config
audit + 16112 unit tests), `tests/release/test_build_release_notes.sh` 45/45.

### The two G7b failures are not regressions

`hermes_multi_step: TIMEOUT` and codex `e2e_file_read: TIMEOUT`. Both reproduce
on the last published release.

| Tree | hermes | which test failed |
| --- | --- | --- |
| v0.12.4 (`2f0e64c3`, last PyPI release) | 31p **1f** | `hermes_multi_step: TIMEOUT` |
| `main` before #1600 | 26p **6f** | read_file, write_and_run, code_with_tests, code_review, git_analysis, patch_file |
| `main` after #1600 | 31p **1f** | `hermes_multi_step: TIMEOUT` |

#1600 restored exact v0.12.4 parity — same pass count, same single failing
test, same failure mode. The five stable failures it fixed were the streamed
wrapper-quote bug, reproduced deterministically at 5/5 on the streaming path
and 0/4 without it.

codex `e2e_file_read` is tracked in #1598, with an A/B showing the tool call
itself succeeds in 0 ms on both trees; what does not happen is `codex exec`
terminating.

## Note for reviewers

The gauntlet's hermes profile edited `vllm_mlx/model_auto_config.py` in this
worktree while running — the deep agentic tests write into `cwd`. That edit was
reverted before this commit was finalised; the diff above is the whole change.

Closes nothing; enables the v0.12.5 tag.
