### PR TITLE
fix(models): stop offering video-generation models as chat models

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Server/ModelCatalog.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ModelCatalog.swift
@@ -59,45 +59,21 @@ enum ModelCatalog {
         binary: URL,
         hubCacheOverride: URL? = ModelsFolderPreference.validatedOverrideURL()
     ) async -> [ModelEntry] {
-        async let availableTask: [(String, String?)] = listAvailable(binary: binary)
+        async let availableTask: (entries: [(String, String?)], excluded: Set<String>) =
+            listAvailableWithExclusions(binary: binary)
         async let cachedTask: [(String, String?, String?)] = listCached(
             binary: binary,
             hubCacheOverride: hubCacheOverride
         )
 
-        let available = await availableTask
+        let (available, excludedAliases) = await availableTask
         let cached = await cachedTask
 
-        // Build a quick lookup of cached aliases for the merge below.
-        var cachedIndex: [String: (hfRepo: String?, size: String?)] = [:]
-        for (alias, hf, size) in cached where !alias.isEmpty && alias != "(unmapped)" {
-            cachedIndex[alias] = (hf, size)
-        }
-
-        var entries: [ModelEntry] = []
-        var seenAliases: Set<String> = []
-        for (alias, hfHint) in available {
-            seenAliases.insert(alias)
-            let cachedHit = cachedIndex[alias]
-            entries.append(ModelEntry(
-                alias: alias,
-                hfRepo: cachedHit?.hfRepo ?? hfHint,
-                sizeOnDisk: cachedHit?.size,
-                cached: cachedHit != nil
-            ))
-        }
-        // A cached model with no row in ``rapid-mlx models`` is unusual
-        // but possible if the user pinned an alias by hand in their
-        // rapid-mlx config. Surface them anyway so they show up in the
-        // picker (otherwise the user can't pick them without typing).
-        for (alias, hf, size) in cached where !alias.isEmpty && alias != "(unmapped)" && !seenAliases.contains(alias) {
-            entries.append(ModelEntry(
-                alias: alias,
-                hfRepo: hf,
-                sizeOnDisk: size,
-                cached: true
-            ))
-        }
+        var entries = mergeAvailableAndCached(
+            available: available,
+            cached: cached,
+            excluded: excludedAliases
+        )
 
         // Repo-aware cached marking (issue #576): a bare alias like
         // ``qwen3-0.6b`` and its default-quant alias ``qwen3-0.6b-4bit``
@@ -261,6 +237,114 @@ enum ModelCatalog {
         return parseAvailable(output)
     }
 
+    /// Merges the ``models`` and ``ls`` listings into catalog rows.
+    ///
+    /// Pure so the exclusion rule is testable without spawning the
+    /// engine: the decisive condition is that a cached alias which was
+    /// deliberately withheld from ``models`` must NOT be re-admitted here.
+    static func mergeAvailableAndCached(
+        available: [(String, String?)],
+        cached: [(String, String?, String?)],
+        excluded: Set<String>
+    ) -> [ModelEntry] {
+        var cachedIndex: [String: (hfRepo: String?, size: String?)] = [:]
+        for (alias, hf, size) in cached where !alias.isEmpty && alias != "(unmapped)" {
+            cachedIndex[alias] = (hf, size)
+        }
+
+        var entries: [ModelEntry] = []
+        var seenAliases: Set<String> = []
+        for (alias, hfHint) in available {
+            seenAliases.insert(alias)
+            let cachedHit = cachedIndex[alias]
+            entries.append(ModelEntry(
+                alias: alias,
+                hfRepo: cachedHit?.hfRepo ?? hfHint,
+                sizeOnDisk: cachedHit?.size,
+                cached: cachedHit != nil
+            ))
+        }
+        // A cached model with no row in ``rapid-mlx models`` is unusual
+        // but possible if the user pinned an alias by hand in their
+        // rapid-mlx config. Surface them anyway so they show up in the
+        // picker (otherwise the user can't pick them without typing) —
+        // except for the ones ``parseAvailable`` deliberately withheld.
+        // ``rapid-mlx ls`` has no modality tag, so without this check a
+        // cached audio or video model has no row in ``models`` for
+        // exactly the reason it must stay hidden, and would be re-admitted
+        // here on that basis (#1603).
+        for (alias, hf, size) in cached
+        where !alias.isEmpty
+            && alias != "(unmapped)"
+            && !seenAliases.contains(alias)
+            && !excluded.contains(alias) {
+            entries.append(ModelEntry(
+                alias: alias,
+                hfRepo: hf,
+                sizeOnDisk: size,
+                cached: true
+            ))
+        }
+        return entries
+    }
+
+    /// Runs ``rapid-mlx models`` and returns both the chat-capable rows
+    /// and the aliases deliberately withheld from them.
+    ///
+    /// ``rapid-mlx ls`` carries no modality tag, so filtering
+    /// ``parseAvailable`` alone is not enough: ``load`` re-admits any
+    /// cached alias that has no row in ``models``, which would hand a
+    /// cached audio or video model straight back to the picker through
+    /// the side door. Pairing the two parses closes that (#1603).
+    private static func listAvailableWithExclusions(
+        binary: URL
+    ) async -> (entries: [(String, String?)], excluded: Set<String>) {
+        let output = await runRapidMlx(binary: binary, args: ["models"])
+        return (parseAvailable(output), parseExcludedAliases(output))
+    }
+
+    /// True when the line carries a non-chat Kind tag in its own column.
+    ///
+    /// Matching the bare substring ``"[audio:"`` would let any row whose
+    /// HF id or description happened to contain those characters
+    /// disappear from the catalog. Require a whole whitespace-delimited
+    /// token of the shape the engine actually prints — ``[audio:tts]``,
+    /// ``[audio:stt]``, ``[video:gen]`` — without hardcoding the
+    /// subtypes, which the engine derives from its registries and may
+    /// extend.
+    static func hasNonChatKindTag(_ line: String) -> Bool {
+        for field in line.split(whereSeparator: { $0.isWhitespace }) {
+            guard field.hasPrefix("["), field.hasSuffix("]") else { continue }
+            let body = field.dropFirst().dropLast()
+            guard let colon = body.firstIndex(of: ":") else { continue }
+            let kind = body[body.startIndex..<colon]
+            let subtype = body[body.index(after: colon)...]
+            guard kind == "audio" || kind == "video" else { continue }
+            guard !subtype.isEmpty, subtype.allSatisfy({ $0.isLetter || $0 == "-" }) else {
+                continue
+            }
+            return true
+        }
+        return false
+    }
+
+    /// Aliases ``parseAvailable`` drops for being a non-chat modality.
+    ///
+    /// Deliberately narrow: only rows carrying an explicit engine-side
+    /// Kind tag count. Banner lines, dividers and headers are noise, not
+    /// exclusions, and must not end up suppressing a real model.
+    static func parseExcludedAliases(_ output: String) -> Set<String> {
+        var excluded: Set<String> = []
+        for rawLine in output.split(separator: "\n", omittingEmptySubsequences: true) {
+            let line = String(rawLine).trimmingCharacters(in: .whitespaces)
+            guard hasNonChatKindTag(line) else { continue }
+            let token = line.split(maxSplits: 1, whereSeparator: { $0.isWhitespace }).first
+            guard let alias = token.map(String.init), isSafeAlias(alias) else { continue }
+            excluded.insert(alias)
+        }
+        return excluded
+    }
+
     /// Runs ``rapid-mlx ls`` (cached models). Returns
     /// ``(alias, hfRepo, sizeOnDisk)`` tuples. ``hubCacheOverride``
     /// (issue #503) points the probe at the user's chosen models folder
@@ -315,6 +399,19 @@ enum ModelCatalog {
             // Model Management, auto-start).
             if line.hasPrefix("Audio models") { continue }
             if line.contains("[audio:") { continue }
+            // Video-generation aliases, same reasoning and same shape.
+            // A ``video-gen`` model has no tokenizer and no
+            // ``stream_chat``, so it can never answer a chat request; the
+            // sidecar exits 2 before binding a port when the video extras
+            // are absent, and the user is told only "Couldn't start X.
+            // Try again" — advice that will fail identically forever,
+            // after a download of up to 64 GiB (#1603). The engine tags
+            // these rows ``[video:gen]`` under a "Video models (N
+            // aliases)" section; skip the header (its first token would
+            // otherwise pass ``isSafeAlias`` and leak a phantom "Video"
+            // model) and every tagged row.
+            if line.hasPrefix("Video models") { continue }
+            if hasNonChatKindTag(line) { continue }
             // Skip engine/server banner lines that can share stdout with
             // the table.
             //

--- a/apps/rapid-mac/Tests/RapidTests/DownloadCatalogHardeningTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/DownloadCatalogHardeningTests.swift
@@ -81,6 +81,118 @@ struct DownloadCatalogHardeningTests {
         }
     }
 
+    @Test("parseAvailable drops video-gen aliases + the section-header phantom")
+    func catalogParserDropsVideoAliases() {
+        // Same shape as the audio case. A `video-gen` model has no
+        // tokenizer and no `stream_chat`, so it can never answer a chat
+        // request — offering one costs the user up to 64 GiB of download
+        // and ends at "Couldn't start X. Try again", forever (#1603).
+        let output =
+            """
+              Available models (2 aliases)
+              ────────────────────────────────────────
+              Alias                 Tools      Reasoning
+              qwen3.6-27b           hermes     qwen3
+              bonsai-1.7b-2bit      hermes     —
+
+              Video models (3 aliases)
+              ────────────────────────────────────────
+              Alias                 Size       Kind        HF id
+              cogvideox-fun-5b-q4   13.3 GiB   [video:gen] dgrauet/CogVideoX-Fun-V1.5-5b-InP-mlx-q4
+              ltx-2.3-mlx-q4        21.2 GiB   [video:gen] notapalindrome/ltx23-mlx-av-q4
+              wan2.2-t2v-a14b-bf16  64.3 GiB   [video:gen] rickylin20260522/Wan2.2-T2V-A14B-mlx
+            """
+        let aliases = ModelCatalog.parseAvailable(output).map { $0.0 }
+        #expect(aliases == ["qwen3.6-27b", "bonsai-1.7b-2bit"])
+        for banned in [
+            "Video", "cogvideox-fun-5b-q4", "ltx-2.3-mlx-q4", "wan2.2-t2v-a14b-bf16",
+        ] {
+            #expect(!aliases.contains(banned), "video/phantom alias leaked: \(banned)")
+        }
+
+        // The same rows must be reported as *deliberately* excluded, so
+        // `load` can refuse to re-admit them off `rapid-mlx ls` — which
+        // carries no modality tag of its own.
+        let excluded = ModelCatalog.parseExcludedAliases(output)
+        #expect(excluded == ["cogvideox-fun-5b-q4", "ltx-2.3-mlx-q4", "wan2.2-t2v-a14b-bf16"])
+        #expect(!excluded.contains("qwen3.6-27b"))
+        #expect(!excluded.contains("Video"))
+    }
+
+    @Test("parseExcludedAliases covers audio too, and ignores untagged noise")
+    func excludedAliasesCoversAudioAndIgnoresNoise() {
+        let excluded = ModelCatalog.parseExcludedAliases(
+            """
+              Available models (1 aliases)
+              ────────────────────────────────────────
+              qwen3.6-27b           hermes     qwen3
+              Loading model with BatchedEngine: qwen3.6-27b
+
+              Audio models (2 aliases)
+              ────────────────────────────────────────
+              kokoro                [audio:tts] kokoro     mlx-community/Kokoro-82M-bf16
+              whisper               [audio:stt] whisper    mlx-community/whisper-large-v3-mlx
+            """
+        )
+        #expect(excluded == ["kokoro", "whisper"])
+        // Only explicitly tagged rows count — a banner line or a plain
+        // text row must never suppress a real model.
+        #expect(!excluded.contains("qwen3.6-27b"))
+        #expect(!excluded.contains("Loading"))
+    }
+
+    @Test("a withheld alias is not re-admitted through the cached listing")
+    func excludedAliasesAreNotReadmittedFromCache() {
+        // The decisive half of #1603. `rapid-mlx ls` carries no modality
+        // tag, and the merge re-admits any cached alias with no row in
+        // `models` — which is exactly the state a correctly-filtered
+        // video model is in. Without the exclusion check the fix is
+        // one-sided and the model returns through the side door.
+        let available = [("qwen3.6-27b", String?.none)]
+        let cached: [(String, String?, String?)] = [
+            ("qwen3.6-27b", "mlx-community/Qwen3.6-27B-4bit", "16 GiB"),
+            ("cogvideox-fun-5b-q4", "dgrauet/CogVideoX-Fun-V1.5-5b-InP-mlx-q4", "13.3 GiB"),
+            ("kokoro", "mlx-community/Kokoro-82M-bf16", "0.3 GiB"),
+            // A hand-pinned text alias with no `models` row must still be
+            // surfaced — the re-admission path exists for this case.
+            ("my-custom-llama", "me/llama-mlx", "8 GiB"),
+        ]
+
+        let merged = ModelCatalog.mergeAvailableAndCached(
+            available: available,
+            cached: cached,
+            excluded: ["cogvideox-fun-5b-q4", "kokoro"]
+        )
+        let aliases = merged.map(\.alias)
+        #expect(aliases.contains("qwen3.6-27b"))
+        #expect(aliases.contains("my-custom-llama"))
+        #expect(!aliases.contains("cogvideox-fun-5b-q4"))
+        #expect(!aliases.contains("kokoro"))
+
+        // Guard the guard: with no exclusions the same input re-admits
+        // them, so the assertions above are testing the condition and not
+        // some unrelated filter.
+        let unfiltered = ModelCatalog.mergeAvailableAndCached(
+            available: available,
+            cached: cached,
+            excluded: []
+        )
+        #expect(unfiltered.map(\.alias).contains("cogvideox-fun-5b-q4"))
+    }
+
+    @Test("Kind-tag matching requires a real column token, not a substring")
+    func nonChatKindTagIsColumnScoped() {
+        #expect(ModelCatalog.hasNonChatKindTag("kokoro [audio:tts] kokoro mlx/Kokoro"))
+        #expect(ModelCatalog.hasNonChatKindTag("cog 13.3 GiB [video:gen] org/repo"))
+        // A model whose repo or description merely contains the
+        // characters must not vanish from the catalog.
+        #expect(!ModelCatalog.hasNonChatKindTag("weird-model hermes org/repo[audio:tts]x"))
+        #expect(!ModelCatalog.hasNonChatKindTag("weird-model hermes org/audio:tts"))
+        #expect(!ModelCatalog.hasNonChatKindTag("qwen3.6-27b hermes qwen3 ✓ avoid — —"))
+        #expect(!ModelCatalog.hasNonChatKindTag("odd [audio:] org/repo"))
+        #expect(!ModelCatalog.hasNonChatKindTag("odd [image:gen] org/repo"))
+    }
+
     @Test("ModelInfoCatalog sanitizes repo ids before UI link construction")
     func modelInfoSanitizesHuggingFaceRepo() {
         let safe = ModelInfoCatalog.info(for: "qwen3-8b", hfRepo: "mlx-community/Qwen3-8B-4bit")

--- a/tests/test_cli_models.py
+++ b/tests/test_cli_models.py
@@ -26,14 +26,65 @@ def _capture_models_output() -> str:
     return buf.getvalue()
 
 
+def _split_by_modality() -> tuple[dict, dict]:
+    """``(text_profiles, video_profiles)`` — the split the listing renders."""
+    profiles = list_profiles()
+    video = {
+        a: p
+        for a, p in profiles.items()
+        if getattr(p, "modality", "text") == "video-gen"
+    }
+    return {a: p for a, p in profiles.items() if a not in video}, video
+
+
 def test_models_command_lists_all_aliases():
-    """Every alias in aliases.json must appear in the table."""
+    """Every alias in aliases.json must appear somewhere in the output.
+
+    The listing is split by modality: chat-capable aliases in the main
+    table, video-generation aliases in their own tagged section (#1603).
+    Every alias is still listed — the split is about telling a GUI
+    catalog consumer which ones can answer a chat request, not about
+    hiding them from the CLI.
+    """
     out = _capture_models_output()
     profiles = list_profiles()
     assert len(profiles) >= 20, "expected 20+ aliases (per project goal)"
     for alias in profiles:
         assert alias in out, f"alias {alias!r} missing from `rapid-mlx models` output"
-    assert f"({len(profiles)} aliases)" in out
+
+    text_profiles, video_profiles = _split_by_modality()
+    assert f"({len(text_profiles)} aliases)" in out
+    assert len(text_profiles) + len(video_profiles) == len(profiles)
+
+
+def test_models_command_sections_video_aliases_out_of_the_text_table():
+    """Video-gen aliases must not sit in the chat table, and must carry a Kind tag.
+
+    A ``video-gen`` model has no tokenizer and no ``stream_chat``, so it
+    can never answer ``/v1/chat/completions``. The desktop catalog reads
+    this output and had no way to tell one apart from a chat model, so it
+    offered up-to-64 GiB downloads that dead-end at "Couldn't start"
+    (#1603). The section header and the ``[video:gen]`` tag are the
+    contract it filters on — mirroring ``[audio:tts]`` / ``[audio:stt]``.
+    """
+    _, video_profiles = _split_by_modality()
+    if not video_profiles:
+        pytest.skip("no video-gen aliases in the registry")
+
+    out = _capture_models_output()
+    head, _, video_section = out.partition("Video models (")
+    assert video_section, "expected a 'Video models (N aliases)' section"
+    assert f"{len(video_profiles)} aliases)" in video_section.split("\n", 1)[0]
+
+    for alias in video_profiles:
+        assert alias not in head, (
+            f"video alias {alias!r} leaked into the chat table — a catalog "
+            "consumer would offer it as a chat model"
+        )
+        assert alias in video_section
+    # Every video row carries the Kind tag the desktop filters on.
+    tagged = [ln for ln in video_section.splitlines() if "[video:gen]" in ln]
+    assert len(tagged) == len(video_profiles)
 
 
 def test_models_command_shows_capability_columns():

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -4968,7 +4968,21 @@ def models_command(args):
         _print_cached_models()
         return
 
-    profiles = list_profiles()
+    all_profiles = list_profiles()
+    # Video-generation aliases are not chat models: they have no
+    # tokenizer and no ``stream_chat``, so ``/v1/chat/completions`` on one
+    # is an AttributeError, and ``serve`` exits 2 before binding a port
+    # when the video extras are absent. Listing them inline in the text
+    # table is how a GUI catalog consumer ends up offering a 64 GiB
+    # download that can never chat (#1603). Split them into their own
+    # tagged section, exactly as audio aliases already are, so a consumer
+    # can tell the two kinds apart without hardcoding alias names.
+    video_profiles = {
+        alias: p
+        for alias, p in all_profiles.items()
+        if getattr(p, "modality", "text") == "video-gen"
+    }
+    profiles = {a: p for a, p in all_profiles.items() if a not in video_profiles}
     print()
     print(f"  Available models ({len(profiles)} aliases)")
 
@@ -5068,6 +5082,32 @@ def models_command(args):
                 f"{entry.family:<12} {entry.hf_id:<40}"
             )
         print(audio_sep)
+
+    # Video-generation aliases, in their own tagged section for the same
+    # reason audio has one: they are not chat models, and a catalog
+    # consumer must be able to tell that from the output rather than by
+    # hardcoding names (#1603). The ``[video:gen]`` Kind tag mirrors
+    # ``[audio:tts]`` / ``[audio:stt]``.
+    if video_profiles:
+        video_alias_width = max(
+            24, max((len(a) for a in video_profiles), default=0) + 2
+        )
+        print()
+        print(f"  Video models ({len(video_profiles)} aliases)")
+        video_sep = "  " + "─" * width
+        print(video_sep)
+        print(
+            f"  {'Alias':<{video_alias_width}} {'Size':<10} {'Kind':<11} {'HF id':<40}"
+        )
+        print(video_sep)
+        for alias in sorted(video_profiles):
+            p = video_profiles[alias]
+            print(
+                f"  {alias:<{video_alias_width}} "
+                f"{format_size(p.hf_path):<10} {'[video:gen]':<11} "
+                f"{p.hf_path:<40}"
+            )
+        print(video_sep)
 
     print()
     print(


### PR DESCRIPTION
## Why

A `video-gen` alias has no tokenizer and no `stream_chat`, so it can never answer
`/v1/chat/completions`. The desktop listed all eight of them in the composer's model
picker and in Settings → Model Management as ordinary chat models — no sticker, no
warning. Selecting one spawns `rapid-mlx serve`, which exits 2 before binding a port
when the video extras are absent; the app then says *"Couldn't start `<alias>`. Try
again, or pick a different model"* — advice that will fail identically forever. The
engine's actionable stderr goes to the sidecar log the user has no terminal into.

The user can reach that state **after** downloading the model. The eight aliases run
13.3–64.3 GiB.

Observed against the bundled engine in a built app:

```
$ 'Rapid-MLX Desktop.app/Contents/Resources/rapid-mlx/bin/rapid-mlx' models | grep -iE 'cogvideo|wan2|ltx'
  cogvideox-fun-5b-q4      13.3 GiB   —   —   ✗   unknown   —   —
  wan2.2-t2v-a14b-bf16     64.3 GiB   —   —   ✗   unknown   —   —
  …
```

## Why nothing caught it

The app's only modality filter matches the `[audio:` Kind tag the engine prints for
audio aliases. Video rows were emitted in the **main** table with no tag and no
section, so that filter was structurally unable to see them — in the same build, 41
output lines carry the audio markers and zero video lines do.

`ModelPickerVisibility` (#1496) is a five-element denylist of vision SKUs,
deliberately evidence-bounded to what #1367 measured, and names no video alias.
`ServerModelProfile.modality` is decoded and never read; its only fetch site runs
*after* the model is already serving, so it could not gate the picker anyway.

## What changed

Mirrors the audio precedent rather than growing a denylist.

- **Engine** — `rapid-mlx models` renders video-gen aliases in their own
  `Video models (N aliases)` section, each row tagged `[video:gen]`. Every alias is
  still listed; the split is about letting a catalog consumer tell the kinds apart,
  not about hiding anything from the CLI.
- **App** — `ModelCatalog.parseAvailable` skips that section header and every tagged
  row, exactly as it already does for `[audio:`.
- **App** — new `parseExcludedAliases` reports what was withheld, and `load` refuses
  to re-admit those aliases off `rapid-mlx ls`.

That last part is load-bearing. `ls` carries no modality tag, and `load` re-admits any
cached alias with no row in `models` — which is *precisely* the state a
correctly-filtered video model is in. Without it the fix would be one-sided. It also
closes the same hole for audio, which is reachable today.

Filtering in `ModelCatalog` covers both surfaces, since Model Management reads the
same `catalog`.

## Verification

End-to-end on a running build, with `cogvideox-fun-5b-q4` **still 13.3 GiB in the HF
cache** — the case that previously sorted to the top of "All models" with a
downloaded checkmark:

| Surface | Before | After |
| --- | --- | --- |
| Composer model picker | `cogvideox-fun-5b-q4` listed under All models | gone; list starts `bonsai-27b-2bit`, `deepseek-r1-32b-4bit` |
| Settings → Model Management | video models listed with Download buttons | `No matches for "video"`, catalog **175 → 167** |

167 = 175 − 8, i.e. exactly the video aliases and nothing else.

Engine: `tests/test_cli_models.py` 29 passed, including a new test asserting no video
alias appears in the chat table and that every video row carries the tag. App: two new
tests in `DownloadCatalogHardeningTests`, mirroring the existing audio case and
covering `parseExcludedAliases`. `ruff check` + `ruff format --check` clean; app
`swift build` clean.

Note: `swift test` cannot run on my box (Command Line Tools only, no full Xcode — the
test target imports XCTest), so the app tests are validated by `rapid-mac-ci.yml`.

Closes #1603.
