### PR TITLE
Restore native AX semantics for settings toggles

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/UI/SettingsControlStyles.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SettingsControlStyles.swift
@@ -12,20 +12,11 @@ struct TrailingSettingsToggleStyle: ToggleStyle {
             set: { configuration.isOn = $0 }
         )
 
-        return HStack(alignment: .center, spacing: 16) {
+        return Toggle(isOn: binding) {
             configuration.label
                 .frame(maxWidth: .infinity, alignment: .leading)
-
-            Toggle("", isOn: binding)
-                .toggleStyle(.switch)
-                .labelsHidden()
         }
+        .toggleStyle(.switch)
         .frame(maxWidth: .infinity)
-        .accessibilityRepresentation {
-            Toggle(isOn: binding) {
-                configuration.label
-            }
-            .toggleStyle(.switch)
-        }
     }
 }

--- a/apps/rapid-mac/Sources/Rapid/UI/SidebarView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SidebarView.swift
@@ -102,12 +102,14 @@ struct SidebarView: View {
                 isSelected: false,
                 action: onNewChat
             )
+            .accessibilityIdentifier("Sidebar.NewChat")
             row(
                 title: "Launch",
                 systemImage: "paperplane",
                 isSelected: selection == .launch,
                 action: { selection = .launch }
             )
+            .accessibilityIdentifier("Sidebar.Launch")
 
             if !chat.conversations.isEmpty {
                 // Date-grouped history (#1470), titled with the shared
@@ -345,6 +347,7 @@ struct SidebarView: View {
                         // re-truncates the title instead of overlapping it.
                         .padding(.trailing, showsControls ? Self.rowControlsWidth : 0)
                 }
+                .accessibilityIdentifier("Sidebar.Conversation.\(conv.id.uuidString)")
                 if showsControls {
                     rowControls(conv, showsPin: hovering || isActive)
                 }

--- a/apps/rapid-mac/scripts/gui-ax-smoke.sh
+++ b/apps/rapid-mac/scripts/gui-ax-smoke.sh
@@ -23,7 +23,7 @@ observe_app() {
     local destination="$1"
     pb list windows --app "$APP" --json > "$OUT/windows-current.json"
     MAIN_WINDOW_ID="$(jq -r --arg app "$APP" \
-        '.data.windows[] | select(.title == $app and .isMainWindow == true) | .window_id' \
+        '.data.windows | (map(select(.title == $app and .isMainWindow == true))[0] // map(select(.title == $app))[0]) | .window_id // empty' \
         "$OUT/windows-current.json" | head -1)"
     [[ -n "$MAIN_WINDOW_ID" ]] || die "main window for $APP not found"
     pb see --window-id "$MAIN_WINDOW_ID" --json > "$destination" || true
@@ -59,7 +59,7 @@ jq -e '.success and ([.data.permissions[] | select(.isRequired) | .isGranted] | 
 
 pb list windows --app "$APP" --json > "$OUT/windows-initial.json"
 MAIN_WINDOW_ID="$(jq -r --arg app "$APP" \
-    '.data.windows[] | select(.title == $app and .isMainWindow == true) | .window_id' \
+    '.data.windows | (map(select(.title == $app and .isMainWindow == true))[0] // map(select(.title == $app))[0]) | .window_id // empty' \
     "$OUT/windows-initial.json" | head -1)"
 [[ -n "$MAIN_WINDOW_ID" ]] || die "main window for $APP not found"
 observe_app "$OUT/main.json" || die "could not inspect main window or modal sheet"
@@ -96,7 +96,7 @@ if jq -e '.data.ui_elements[]? | select(.identifier == "DockHidePrompt.NoButton"
     observe_app "$OUT/main.json" || die "could not inspect app after Dock prompt"
 fi
 
-for identifier in rapid.chat.compose ChatView.SendOrStopButton ModelPickerBar.ModelMenu; do
+for identifier in Sidebar.NewChat Sidebar.Launch rapid.chat.compose ChatView.SendOrStopButton ModelPickerBar.ModelMenu; do
     jq -e --arg id "$identifier" \
         '.data.ui_elements[]? | select(.identifier == $id)' "$OUT/main.json" >/dev/null \
         || die "main window missing AX identifier: $identifier"
@@ -121,8 +121,23 @@ for category in models modelManagement tools appearance privacy app; do
         || die "Settings missing category identifier: $category"
 done
 
-APPEARANCE_ID="$(jq -r '.data.ui_elements[] | select(.identifier == "Settings.Category.appearance") | .id' "$OUT/settings.json")"
-SNAPSHOT="$(jq -r '.data.snapshot_id' "$OUT/settings.json")"
+# The shared trailing-toggle style must preserve the native checkbox role and
+# the identifiers attached by each settings panel. A visually-correct switch
+# can otherwise degrade into inert AX text, which breaks both VoiceOver and
+# semantic automation while remaining invisible in screenshots.
+press_identifier "$OUT/settings.json" "Settings.Category.models" "$OUT/open-models.json" \
+    || die "could not AXPress Settings.Category.models"
+sleep 0.5
+pb see --window-id "$SETTINGS_WINDOW_ID" --json > "$OUT/models.json"
+for identifier in Settings.Models.ShowAllModelsToggle Settings.Models.AutoStartOnLaunchToggle; do
+    jq -e --arg id "$identifier" \
+        '.data.ui_elements[]? | select(.identifier == $id and .role == "checkbox")' \
+        "$OUT/models.json" >/dev/null \
+        || die "Models toggle is not exposed as a native AX checkbox: $identifier"
+done
+
+APPEARANCE_ID="$(jq -r '.data.ui_elements[] | select(.identifier == "Settings.Category.appearance") | .id' "$OUT/models.json")"
+SNAPSHOT="$(jq -r '.data.snapshot_id' "$OUT/models.json")"
 pb perform-action --on "$APPEARANCE_ID" --action AXPress --snapshot "$SNAPSHOT" --json \
     > "$OUT/open-appearance.json"
 sleep 0.5


### PR DESCRIPTION
## What changed

- preserve native macOS checkbox semantics in the shared trailing Settings toggle style
- add stable AX identifiers for New Chat, Launch, and conversation rows
- extend the AX GUI smoke to assert the settings switches are real checkboxes
- make the smoke repeatable when Settings is already the key window or open on another category

## Why / root cause

`TrailingSettingsToggleStyle` rendered a hidden inner switch and rebuilt accessibility through `accessibilityRepresentation`. The identifiers attached by callers did not reach the native control: the visual switches appeared only as inert AX text, and AXPress reported success without changing their values.

## Impact

VoiceOver and semantic GUI agents can now identify and operate the Settings switches. The regression test also catches future cases where a visually-correct custom control loses its native accessibility role.

## Validation

- exact `origin/main` local wheel and app build at `d594e2f4`
- fresh-install AX smoke and two consecutive steady-state AX smoke runs
- verified `Settings.Models.ShowAllModelsToggle` changes its isolated UserDefaults value via AXPress
- visually compared the Models panel before/after; trailing alignment is unchanged
- real onboarding → cached LFM2.5-1.2B start → GUI chat → persisted conversation → New Chat → conversation restore
- Launch page base URL/Codex config clipboard copy and API-key reveal/hide
- graceful app shutdown also terminated the owned server
- `swift build -c release`
- `bash apps/rapid-mac/scripts/smoke.sh`
- `bash -n apps/rapid-mac/scripts/gui-ax-smoke.sh`
- `git diff --check`
- Codex review: no actionable findings

Local `swift test` cannot import XCTest with the host's Command Line Tools-only selection; the rapid-mac GitHub runner uses full Xcode and is expected to cover the complete suite.
