### PR TITLE
docs(rapid-mac): record the Settings-toggle accessibility fix in 0.12.6

### DIFF
--- a/apps/rapid-mac/CHANGELOG.md
+++ b/apps/rapid-mac/CHANGELOG.md
@@ -87,6 +87,11 @@ Bundles the **Rapid-MLX 0.12.5** engine.
   stopped being true in 0.6.6.
 - **Model Management and the readiness banner stop saying untrue things** about
   what is installed, what is running, and what a button is about to do.
+- **Settings switches work with VoiceOver again.** The toggles in Settings
+  rendered as inert text to assistive technology: VoiceOver announced them as
+  labels rather than checkboxes, and activating one reported success without
+  changing anything. They are native checkboxes again, and the sidebar's New
+  Chat, Launch and conversation rows now carry stable identifiers.
 - **A model that wedges while starting no longer leaves the app stuck.** Rapid
   now notices and recovers instead of waiting forever.
 - **Web search now says what actually went wrong.** DuckDuckGo — the free


### PR DESCRIPTION
## Why

#1608 merged between the 0.12.6 CHANGELOG being written (#1609) and that bump
landing, so the section does not mention it. Tagging `rapid-mac-v0.12.6` now
would ship a release whose notes omit it.

It is user-visible, not internal: `TrailingSettingsToggleStyle` rendered a hidden
inner switch and rebuilt accessibility through `accessibilityRepresentation`, so
the Settings toggles appeared to assistive technology as inert text — VoiceOver
announced them as labels rather than checkboxes, and activating one reported
success without changing the value.

## What

One CHANGELOG entry under `[0.12.6]`. No code.

Blocks the `rapid-mac-v0.12.6` tag.