### PR TITLE
Add AX-first GUI golden userflows

### DIFF
--- a/apps/rapid-mac/docs/gui-golden-flows.md
+++ b/apps/rapid-mac/docs/gui-golden-flows.md
@@ -1,0 +1,59 @@
+# AX-first GUI golden flows
+
+`scripts/gui-golden-flows.sh` runs the five release journeys against a built
+Rapid-MLX Desktop app without loading a real model:
+
+1. fresh install, consent, onboarding, and steady-state shell;
+2. Settings mutation and persistence across an app relaunch;
+3. basic chat, persisted conversation row, and restored transcript;
+4. a deliberately slow stream and semantic **Stop generating** action;
+5. model start, a one-shot sidecar crash, automatic respawn, and ready state.
+
+Every journey gets a unique bundle identifier and throwaway `HOME` through
+`dogfood-isolate.sh`. The fake sidecar emits deterministic SSE and JSONL
+lifecycle evidence, so the suite does not download a model or put meaningful
+pressure on unified memory.
+
+## Run
+
+Build the current checkout, then run all flows:
+
+```bash
+cd apps/rapid-mac
+SKIP_SIDECAR=1 BUNDLE_MODEL=0 ./scripts/build.sh
+./scripts/gui-golden-flows.sh
+```
+
+Run one journey or retain its isolated persona for diagnosis:
+
+```bash
+./scripts/gui-golden-flows.sh --flow slow-stream-stop
+./scripts/gui-golden-flows.sh --flow chat-restore --keep
+```
+
+Set `RAPID_GUI_SOURCE_APP` to test a release candidate bundle and
+`RAPID_GUI_GOLDEN_OUT` to choose the artifact directory. Each run records AX
+trees, actions, fake-sidecar events, logs, and a top-level `result.json`.
+
+## Why this is not coordinate automation
+
+The checked-in `rapid-ax.swift` helper talks directly to macOS Accessibility.
+It finds controls by stable `AXIdentifier`, performs `AXPress`, sets native text
+values, and serializes roles/descriptions/values for assertions. Peekaboo is
+kept for permission checks, window discovery, menu interaction, and screenshots.
+The only coordinate fallback is the documented first-run SwiftUI consent-sheet
+fallback, derived from AX bounds, for older accessibility stacks.
+
+This makes normal actions independent of window position, resolution, theme,
+and most layout changes. It also avoids Peekaboo snapshot publication failures
+seen while the ready-state UI is updating. The app does not need to own the
+foreground for ordinary AX actions; menu operations and screenshots may briefly
+activate it, so release CI should still use a dedicated logged-in macOS session.
+
+## Adding a flow
+
+Prefer a stable `.accessibilityIdentifier(...)` in product code, then assert
+observable user state rather than sleeps or pixels. Keep model behavior behind
+the fake sidecar unless the purpose of the flow is real inference quality. A
+real-model dogfood pass remains a separate, explicitly memory-budgeted release
+stage.

--- a/apps/rapid-mac/scripts/fake-rapid-mlx.sh
+++ b/apps/rapid-mac/scripts/fake-rapid-mlx.sh
@@ -40,6 +40,17 @@ import time
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 
+try:
+    with open(os.path.join(os.environ.get("HOME", ""), ".rapid-golden-fake.json"), encoding="utf-8") as stream:
+        FILE_CONFIG = json.load(stream)
+except (OSError, ValueError):
+    FILE_CONFIG = {}
+
+
+def _setting(name, default=None):
+    return os.environ.get(name, FILE_CONFIG.get(name, default))
+
+
 def _parse_args(argv):
     """Match the real rapid-mlx CLI shape closely enough that
     ServerManager's spawn arguments work unmodified.
@@ -74,7 +85,24 @@ CONTENT_CHUNKS = [
 REASONING_CHUNKS = [
     "Let", " me", " think", " about", " the", " prompt", "."
 ]
-INTER_TOKEN_SLEEP_S = 0.01  # ~20 deltas in 200 ms — fast enough for smoke
+try:
+    INTER_TOKEN_SLEEP_S = float(_setting("FAKE_INTER_TOKEN_SLEEP_S", "0.01"))
+except ValueError:
+    INTER_TOKEN_SLEEP_S = 0.01
+try:
+    CONTENT_REPEAT = max(1, int(_setting("FAKE_CONTENT_REPEAT", "1")))
+except ValueError:
+    CONTENT_REPEAT = 1
+
+
+def _event(name, **fields):
+    """Append machine-readable lifecycle evidence for GUI golden flows."""
+    path = _setting("FAKE_EVENT_LOG")
+    if not path:
+        return
+    record = {"event": name, "time": time.time(), **fields}
+    with open(path, "a", encoding="utf-8") as stream:
+        stream.write(json.dumps(record, sort_keys=True) + "\n")
 
 
 def _sse(data):
@@ -128,6 +156,7 @@ class Handler(BaseHTTPRequestHandler):
         length = int(self.headers.get("content-length", "0") or "0")
         if length:
             self.rfile.read(length)
+        _event("chat_request")
 
         self.send_response(200)
         self.send_header("Content-Type", "text/event-stream")
@@ -143,18 +172,25 @@ class Handler(BaseHTTPRequestHandler):
         # ChatStreamClient sees partial deltas followed by EOF
         # WITHOUT a [DONE] sentinel or a finish_reason chunk — the
         # exact failure mode v0.4.5 maps to ``.streamTruncated``.
-        die_after_chunks_raw = os.environ.get("FAKE_DIE_AFTER_CHUNKS", "")
+        die_after_chunks_raw = _setting("FAKE_DIE_AFTER_CHUNKS", "")
         try:
             die_after_chunks = int(die_after_chunks_raw)
         except ValueError:
             die_after_chunks = 0
+        die_once_state = _setting("FAKE_DIE_ONCE_STATE")
+        if die_after_chunks > 0 and die_once_state:
+            try:
+                marker_fd = os.open(die_once_state, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+                os.close(marker_fd)
+            except FileExistsError:
+                die_after_chunks = 0
+        content_emitted = 0
         try:
             for r in REASONING_CHUNKS:
                 self.wfile.write(_sse(_delta(reasoning=r)))
                 self.wfile.flush()
                 time.sleep(INTER_TOKEN_SLEEP_S)
-            content_emitted = 0
-            for c in CONTENT_CHUNKS:
+            for c in CONTENT_CHUNKS * CONTENT_REPEAT:
                 self.wfile.write(_sse(_delta(content=c)))
                 self.wfile.flush()
                 content_emitted += 1
@@ -179,9 +215,11 @@ class Handler(BaseHTTPRequestHandler):
             self.wfile.flush()
             self.wfile.write(b"data: [DONE]\n\n")
             self.wfile.flush()
-        except BrokenPipeError:
+            _event("chat_finished", chunks=content_emitted)
+        except (BrokenPipeError, ConnectionResetError):
             # Client disconnected mid-stream — fine, the smoke
             # cancelled the stream on its own.
+            _event("chat_cancelled", chunks=content_emitted)
             return
 
     def _json(self, status, body):
@@ -252,6 +290,8 @@ def main():
     if args.subcommand != "serve":
         _emit_catalog(args.subcommand, args.alias)
         sys.exit(0)
+
+    _event("server_started", alias=args.alias, pid=os.getpid())
 
     # Match the real server's startup banner shape closely enough
     # that DownloadProgress's "Loading model with" detection fires

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -1,0 +1,436 @@
+#!/usr/bin/env bash
+# Release-grade AX-first GUI journeys for Rapid-MLX Desktop.
+#
+# Each flow runs in a unique bundle-id + HOME, targets elements by semantic
+# accessibility identifiers, and writes JSON/screenshot evidence. The bundled
+# fake sidecar keeps the suite deterministic and prevents model-related OOMs.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+APP_SOURCE="${RAPID_GUI_SOURCE_APP:-$ROOT/build/Rapid-MLX Desktop.app}"
+OUT_ROOT="${RAPID_GUI_GOLDEN_OUT:-/tmp/rapid-gui-golden-$(date -u +%Y%m%dT%H%M%SZ)}"
+BRIDGE="${PEEKABOO_BRIDGE_SOCKET:-$HOME/Library/Application Support/Peekaboo/daemon.sock}"
+FLOW="all"
+KEEP=0
+APP_PID=""
+PERSONA=""
+OUT=""
+MAIN_WINDOW_ID=""
+BUNDLE_ID=""
+AX_DRIVER=""
+RESULT_WRITTEN=0
+
+usage() {
+    cat <<'EOF'
+Usage: gui-golden-flows.sh [--flow NAME] [--keep]
+
+Flows: fresh-install, settings-persistence, chat-restore, slow-stream-stop,
+       model-crash-recovery, all
+
+Environment:
+  RAPID_GUI_SOURCE_APP   built .app to test
+  RAPID_GUI_GOLDEN_OUT  artifact directory
+  PEEKABOO_BRIDGE_SOCKET Peekaboo bridge socket
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --flow) FLOW="${2:?--flow requires a name}"; shift 2 ;;
+        --keep) KEEP=1; shift ;;
+        -h|--help) usage; exit 0 ;;
+        *) usage >&2; exit 2 ;;
+    esac
+done
+
+log() { printf '[gui-golden] %s\n' "$*"; }
+die() { printf '[gui-golden] FAIL: %s\n' "$*" >&2; exit 1; }
+pb() { peekaboo "$@" --bridge-socket "$BRIDGE"; }
+
+cleanup_persona() {
+    if [[ -n "$APP_PID" ]] && kill -0 "$APP_PID" 2>/dev/null; then
+        kill "$APP_PID" 2>/dev/null || true
+        wait "$APP_PID" 2>/dev/null || true
+    fi
+    APP_PID=""
+    if [[ -n "$OUT" && -f "$OUT/fake-events.jsonl" ]]; then
+        while read -r fake_pid; do
+            [[ "$fake_pid" =~ ^[0-9]+$ ]] || continue
+            local command
+            command="$(ps -p "$fake_pid" -o command= 2>/dev/null || true)"
+            if [[ "$command" == *"serve fake-alias"* ]]; then
+                kill "$fake_pid" 2>/dev/null || true
+            fi
+        done < <(jq -r 'select(.event == "server_started") | .pid' "$OUT/fake-events.jsonl" 2>/dev/null | sort -u)
+    fi
+    if [[ "$KEEP" == 0 && -n "$BUNDLE_ID" ]]; then
+        defaults delete "$BUNDLE_ID" >/dev/null 2>&1 || true
+    fi
+    if [[ "$KEEP" == 0 && -n "$PERSONA" && -d "$PERSONA" ]]; then
+        rm -rf "$PERSONA"
+    fi
+    PERSONA=""
+    BUNDLE_ID=""
+}
+
+finish() {
+    local status=$?
+    set +e
+    if [[ "$status" -ne 0 && "$RESULT_WRITTEN" == 0 && -d "$OUT_ROOT" ]]; then
+        jq -n --arg status fail --arg flow "$FLOW" --arg app "$APP_SOURCE" \
+            --argjson exit_code "$status" \
+            '{status: $status, flow: $flow, app: $app, exit_code: $exit_code}' \
+            > "$OUT_ROOT/result.json" 2>/dev/null || true
+    fi
+    cleanup_persona
+}
+trap finish EXIT
+trap 'cleanup_persona; exit 130' INT
+trap 'cleanup_persona; exit 143' TERM
+
+require_tools() {
+    [[ -d "$APP_SOURCE" ]] || die "built app not found: $APP_SOURCE"
+    for tool in peekaboo jq; do
+        command -v "$tool" >/dev/null || die "$tool is required"
+    done
+    AX_DRIVER="$OUT_ROOT/rapid-ax"
+    swiftc "$ROOT/scripts/rapid-ax.swift" -o "$AX_DRIVER"
+    pb permissions status --json > "$OUT_ROOT/permissions.json"
+    jq -e '.success and ([.data.permissions[] | select(.isRequired) | .isGranted] | all)' \
+        "$OUT_ROOT/permissions.json" >/dev/null \
+        || die "Peekaboo needs Accessibility and Screen Recording permissions"
+}
+
+start_persona() {
+    local name="$1"
+    shift
+    cleanup_persona
+    OUT="$OUT_ROOT/$name"
+    PERSONA="$(mktemp -d "/tmp/rapid-golden-${name}.XXXXXX")"
+    mkdir -p "$OUT"
+    "$ROOT/scripts/dogfood-isolate.sh" "$APP_SOURCE" "$PERSONA" \
+        > "$OUT/isolated-app.txt" 2> "$OUT/isolate.log"
+    local isolated_app
+    isolated_app="$(cat "$OUT/isolated-app.txt")"
+    BUNDLE_ID="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$isolated_app/Contents/Info.plist")"
+    local config="$PERSONA/home/.rapid-golden-fake.json"
+    jq -n --arg event_log "$OUT/fake-events.jsonl" '{FAKE_EVENT_LOG: $event_log}' > "$config"
+    local assignment key value updated
+    for assignment in "$@"; do
+        key="${assignment%%=*}"
+        value="${assignment#*=}"
+        updated="$config.next"
+        jq --arg key "$key" --arg value "$value" '.[$key] = $value' "$config" > "$updated"
+        mv "$updated" "$config"
+    done
+    env RAPID_BIN="$ROOT/scripts/fake-rapid-mlx.sh" \
+        FAKE_EVENT_LOG="$OUT/fake-events.jsonl" "$@" \
+        "$PERSONA/launch.sh" > "$OUT/app.log" 2>&1 &
+    APP_PID=$!
+    wait_for_window
+}
+
+relaunch_persona() {
+    stop_app
+    env RAPID_BIN="$ROOT/scripts/fake-rapid-mlx.sh" \
+        FAKE_EVENT_LOG="$OUT/fake-events.jsonl" \
+        "$PERSONA/launch.sh" >> "$OUT/app.log" 2>&1 &
+    APP_PID=$!
+    wait_for_window
+}
+
+stop_app() {
+    if [[ -n "$APP_PID" ]] && kill -0 "$APP_PID" 2>/dev/null; then
+        kill "$APP_PID" 2>/dev/null || true
+        for _ in {1..20}; do
+            kill -0 "$APP_PID" 2>/dev/null || break
+            sleep 0.1
+        done
+        kill -9 "$APP_PID" 2>/dev/null || true
+        wait "$APP_PID" 2>/dev/null || true
+    fi
+    APP_PID=""
+}
+
+wait_for_window() {
+    local windows="$OUT/windows.json"
+    for _ in {1..80}; do
+        kill -0 "$APP_PID" 2>/dev/null || die "app exited before opening a window"
+        pb list windows --app "PID:$APP_PID" --json > "$windows" 2>/dev/null || true
+        MAIN_WINDOW_ID="$(jq -r '(.data.windows // []) | map(select(.title == "Rapid-MLX"))[0].window_id // empty' "$windows" 2>/dev/null)"
+        [[ -n "$MAIN_WINDOW_ID" ]] && return
+        sleep 0.25
+    done
+    die "main window did not appear"
+}
+
+see_main() {
+    local destination="$1"
+    pb list windows --app "PID:$APP_PID" --json > "$OUT/windows-current.json"
+    local current_main
+    current_main="$(jq -r '(.data.windows // []) | map(select(.title == "Rapid-MLX"))[0].window_id // empty' "$OUT/windows-current.json")"
+    [[ -n "$current_main" ]] && MAIN_WINDOW_ID="$current_main"
+    "$AX_DRIVER" dump "$APP_PID" > "$destination"
+}
+
+wait_identifier() {
+    local identifier="$1" destination="$2" attempts="${3:-80}"
+    for ((i=0; i<attempts; i++)); do
+        see_main "$destination"
+        if jq -e --arg id "$identifier" '.data.ui_elements[]? | select(.identifier == $id)' "$destination" >/dev/null; then
+            return
+        fi
+        sleep 0.25
+    done
+    die "timed out waiting for AX identifier $identifier"
+}
+
+element_field() {
+    local tree="$1" identifier="$2" field="$3"
+    jq -r --arg id "$identifier" --arg field "$field" \
+        '.data.ui_elements[] | select(.identifier == $id) | .[$field] // empty' "$tree" | head -1
+}
+
+press() {
+    local tree="$1" identifier="$2" evidence="$3"
+    jq -e --arg id "$identifier" '.data.ui_elements[]? | select(.identifier == $id)' "$tree" >/dev/null \
+        || { printf '[gui-golden] AX identifier missing: %s\n' "$identifier" >&2; return 1; }
+    "$AX_DRIVER" press "$APP_PID" "$identifier" > "$evidence" || return 1
+    jq -e '.success' "$evidence" >/dev/null \
+        || { printf '[gui-golden] AXPress failed: %s\n' "$identifier" >&2; return 1; }
+}
+
+dismiss_first_run() {
+    local tree="$OUT/first-run.json"
+    see_main "$tree"
+    if jq -e '.data.ui_elements[]? | select(.identifier == "TelemetryConsent.DontShare")' "$tree" >/dev/null; then
+        if ! press "$tree" TelemetryConsent.DontShare "$OUT/consent.json" 2>/dev/null; then
+            read -r x y < <(jq -r '.data.ui_elements[] | select(.identifier == "TelemetryConsent.DontShare") | [(.bounds.x + .bounds.width / 2), (.bounds.y + .bounds.height / 2)] | @tsv' "$tree")
+            pb click --coords "$x,$y" --global-coords --app "PID:$APP_PID" --json > "$OUT/consent-coordinate-fallback.json"
+        fi
+        sleep 0.5
+        see_main "$tree"
+    fi
+    if jq -e '.data.ui_elements[]? | select(.identifier == "Quickstart.Skip")' "$tree" >/dev/null; then
+        press "$tree" Quickstart.Skip "$OUT/quickstart-skip.json"
+        sleep 0.5
+        see_main "$tree"
+    fi
+    if jq -e '.data.ui_elements[]? | select(.identifier == "DockHidePrompt.NoButton")' "$tree" >/dev/null; then
+        press "$tree" DockHidePrompt.NoButton "$OUT/dock-no.json"
+        sleep 0.5
+    fi
+    wait_identifier rapid.chat.compose "$OUT/steady.json"
+}
+
+open_settings() {
+    pb menu click --app "PID:$APP_PID" --item 'Settings…' --json > "$OUT/open-settings.json"
+    for _ in {1..40}; do
+        pb list windows --app "PID:$APP_PID" --json > "$OUT/settings-windows.json"
+        SETTINGS_WINDOW_ID="$(jq -r '.data.windows[]? | select(.title == "Settings") | .window_id' "$OUT/settings-windows.json" | head -1)"
+        [[ -n "$SETTINGS_WINDOW_ID" ]] && return
+        sleep 0.25
+    done
+    die "Settings window did not open"
+}
+
+see_settings() {
+    "$AX_DRIVER" dump "$APP_PID" > "$1"
+}
+
+start_model() {
+    wait_identifier Readiness.Action "$OUT/readiness-start.json"
+    press "$OUT/readiness-start.json" Readiness.Action "$OUT/start-model.json"
+    for _ in {1..120}; do
+        see_main "$OUT/readiness-ready.json"
+        if jq -e '.data.ui_elements[]? | select(.identifier == "ChatView.SendOrStopButton" and .description == "Send message")' "$OUT/readiness-ready.json" >/dev/null \
+            && grep -q '"event": "server_started"' "$OUT/fake-events.jsonl" 2>/dev/null; then return; fi
+        sleep 0.25
+    done
+    die "fake model did not become ready"
+}
+
+send_prompt() {
+    local prompt="$1" prefix="$2"
+    see_main "$OUT/${prefix}-compose.json"
+    "$AX_DRIVER" set-value "$APP_PID" rapid.chat.compose "$prompt" > "$OUT/${prefix}-type.json"
+    see_main "$OUT/${prefix}-draft.json"
+    press "$OUT/${prefix}-draft.json" ChatView.SendOrStopButton "$OUT/${prefix}-send.json"
+}
+
+assert_tree_text() {
+    local tree="$1" needle="$2"
+    jq -e --arg needle "$needle" '(.data.ui_elements | tostring) | contains($needle)' "$tree" >/dev/null \
+        || die "AX tree does not contain expected text: $needle"
+}
+
+flow_fresh_install() {
+    log "1/5 fresh install and onboarding"
+    start_persona fresh-install
+    see_main "$OUT/consent-visible.json"
+    jq -e '.data.ui_elements[]? | select(.identifier == "TelemetryConsent.DontShare")' "$OUT/consent-visible.json" >/dev/null \
+        || die "fresh install did not show telemetry consent"
+    dismiss_first_run
+    for id in Sidebar.NewChat Sidebar.Launch rapid.chat.compose ChatView.SendOrStopButton ModelPickerBar.ModelMenu; do
+        jq -e --arg id "$id" '.data.ui_elements[]? | select(.identifier == $id)' "$OUT/steady.json" >/dev/null \
+            || die "post-onboarding shell missing $id"
+    done
+    pb image --window-id "$MAIN_WINDOW_ID" --path "$OUT/final.png" --json > "$OUT/final-image.json"
+    cleanup_persona
+}
+
+flow_settings_persistence() {
+    log "2/5 settings and persistence"
+    start_persona settings-persistence
+    dismiss_first_run
+    open_settings
+    see_settings "$OUT/settings-root.json"
+    press "$OUT/settings-root.json" Settings.Category.models "$OUT/settings-models-open.json"
+    sleep 0.3
+    see_settings "$OUT/models-before.json"
+    local preference_key="rapid.picker.show_all_models.v1"
+    press "$OUT/models-before.json" Settings.Models.ShowAllModelsToggle "$OUT/models-toggle.json"
+    for _ in {1..20}; do
+        [[ "$(defaults read "$BUNDLE_ID" "$preference_key" 2>/dev/null || true)" == 1 ]] && break
+        sleep 0.1
+    done
+    [[ "$(defaults read "$BUNDLE_ID" "$preference_key" 2>/dev/null || true)" == 1 ]] \
+        || die "GUI toggle did not persist true to isolated preferences"
+    see_settings "$OUT/models-after.json"
+    relaunch_persona
+    dismiss_first_run
+    open_settings
+    see_settings "$OUT/settings-relaunch.json"
+    press "$OUT/settings-relaunch.json" Settings.Category.models "$OUT/settings-models-reopen.json"
+    sleep 0.3
+    see_settings "$OUT/models-persisted.json"
+    press "$OUT/models-persisted.json" Settings.Models.ShowAllModelsToggle "$OUT/models-toggle-after-relaunch.json"
+    for _ in {1..20}; do
+        [[ "$(defaults read "$BUNDLE_ID" "$preference_key" 2>/dev/null || true)" == 0 ]] && break
+        sleep 0.1
+    done
+    [[ "$(defaults read "$BUNDLE_ID" "$preference_key" 2>/dev/null || true)" == 0 ]] \
+        || die "relaunch did not restore the persisted toggle state"
+    cleanup_persona
+}
+
+flow_chat_restore() {
+    log "3/5 basic chat and session restore"
+    start_persona chat-restore
+    dismiss_first_run
+    start_model
+    send_prompt "golden restore marker" chat
+    for _ in {1..100}; do
+        see_main "$OUT/chat-complete.json"
+        if jq -e '(.data.ui_elements | tostring) | contains("deterministic content")' "$OUT/chat-complete.json" >/dev/null; then break; fi
+        sleep 0.2
+    done
+    assert_tree_text "$OUT/chat-complete.json" "golden restore marker"
+    assert_tree_text "$OUT/chat-complete.json" "deterministic content"
+    relaunch_persona
+    dismiss_first_run
+    wait_identifier Sidebar.NewChat "$OUT/chat-restored.json"
+    assert_tree_text "$OUT/chat-restored.json" "golden restore marker"
+    local conversation_id
+    conversation_id="$(jq -r '.data.ui_elements[] | select((.identifier // "") | startswith("Sidebar.Conversation.")) | .identifier' "$OUT/chat-restored.json" | head -1)"
+    [[ -n "$conversation_id" ]] || die "restored conversation row was not exposed to AX"
+    press "$OUT/chat-restored.json" "$conversation_id" "$OUT/open-restored-conversation.json"
+    sleep 0.2
+    see_main "$OUT/chat-restored-transcript.json"
+    assert_tree_text "$OUT/chat-restored-transcript.json" "deterministic content"
+    cleanup_persona
+}
+
+flow_slow_stream_stop() {
+    log "4/5 controlled slow stream and Stop"
+    start_persona slow-stream-stop FAKE_INTER_TOKEN_SLEEP_S=0.01 FAKE_CONTENT_REPEAT=20000
+    dismiss_first_run
+    start_model
+    send_prompt "golden stop marker" slow
+    for _ in {1..40}; do
+        see_main "$OUT/slow-streaming.json"
+        if [[ "$(element_field "$OUT/slow-streaming.json" ChatView.SendOrStopButton description)" == "Stop generating" ]]; then break; fi
+        sleep 0.1
+    done
+    [[ "$(element_field "$OUT/slow-streaming.json" ChatView.SendOrStopButton description)" == "Stop generating" ]] \
+        || die "send button never transitioned to Stop generating"
+    press "$OUT/slow-streaming.json" ChatView.SendOrStopButton "$OUT/slow-stop.json"
+    for _ in {1..40}; do
+        see_main "$OUT/slow-stopped.json"
+        [[ "$(element_field "$OUT/slow-stopped.json" ChatView.SendOrStopButton description)" == "Send message" ]] && break
+        sleep 0.1
+    done
+    [[ "$(element_field "$OUT/slow-stopped.json" ChatView.SendOrStopButton description)" == "Send message" ]] \
+        || die "Stop did not restore Send state"
+    for _ in {1..100}; do
+        grep -q '"event": "chat_cancelled"' "$OUT/fake-events.jsonl" 2>/dev/null && break
+        sleep 0.05
+    done
+    grep -q '"event": "chat_cancelled"' "$OUT/fake-events.jsonl" \
+        || die "fake server did not observe stream cancellation"
+    if grep -q '"event": "chat_finished"' "$OUT/fake-events.jsonl"; then
+        die "slow response finished instead of being stopped early"
+    fi
+    jq -n '{success: true, assertion: "UI returned to Send and server observed cancellation"}' \
+        > "$OUT/stop-assertion.json"
+    cleanup_persona
+}
+
+flow_model_crash_recovery() {
+    log "5/5 model lifecycle and crash recovery"
+    start_persona model-crash-recovery FAKE_DIE_AFTER_CHUNKS=2 \
+        FAKE_DIE_ONCE_STATE="$OUT_ROOT/model-crash-recovery/died-once"
+    dismiss_first_run
+    start_model
+    send_prompt "golden crash marker" crash
+    for _ in {1..160}; do
+        see_main "$OUT/crash-recovered.json"
+        local starts
+        starts="$(grep -c '"event": "server_started"' "$OUT/fake-events.jsonl" 2>/dev/null || true)"
+        if [[ "$starts" -ge 2 ]] && jq -e '.data.ui_elements[]? | select(.identifier == "ChatView.SendOrStopButton")' "$OUT/crash-recovered.json" >/dev/null; then
+            break
+        fi
+        sleep 0.25
+    done
+    [[ "$(grep -c '"event": "server_started"' "$OUT/fake-events.jsonl" 2>/dev/null || true)" -ge 2 ]] \
+        || die "server did not respawn after the simulated crash"
+    for _ in {1..80}; do
+        see_main "$OUT/crash-ready.json"
+        if [[ "$(element_field "$OUT/crash-ready.json" ChatView.SendOrStopButton description)" == "Send message" ]]; then break; fi
+        sleep 0.25
+    done
+    [[ "$(element_field "$OUT/crash-ready.json" ChatView.SendOrStopButton description)" == "Send message" ]] \
+        || die "model was not ready after crash recovery"
+    jq -n --argjson starts "$(grep -c '"event": "server_started"' "$OUT/fake-events.jsonl")" \
+        '{success: true, assertion: "sidecar crashed once, respawned, and returned to ready", server_starts: $starts}' \
+        > "$OUT/recovery-assertion.json"
+    cleanup_persona
+}
+
+if [[ -d "$OUT_ROOT" && -n "$(ls -A "$OUT_ROOT" 2>/dev/null)" ]]; then
+    RESULT_WRITTEN=1
+    die "artifact directory is not empty: $OUT_ROOT"
+fi
+mkdir -p "$OUT_ROOT"
+require_tools
+case "$FLOW" in
+    fresh-install) flow_fresh_install ;;
+    settings-persistence) flow_settings_persistence ;;
+    chat-restore) flow_chat_restore ;;
+    slow-stream-stop) flow_slow_stream_stop ;;
+    model-crash-recovery) flow_model_crash_recovery ;;
+    all)
+        flow_fresh_install
+        flow_settings_persistence
+        flow_chat_restore
+        flow_slow_stream_stop
+        flow_model_crash_recovery
+        ;;
+    *) die "unknown flow: $FLOW" ;;
+esac
+
+jq -n --arg status pass --arg flow "$FLOW" --arg app "$APP_SOURCE" \
+    '{status: $status, flow: $flow, app: $app}' > "$OUT_ROOT/result.json"
+RESULT_WRITTEN=1
+log "PASS — $FLOW"
+log "artifacts: $OUT_ROOT"

--- a/apps/rapid-mac/scripts/rapid-ax.swift
+++ b/apps/rapid-mac/scripts/rapid-ax.swift
@@ -1,0 +1,124 @@
+#!/usr/bin/env swift
+// Minimal native Accessibility driver for deterministic Rapid GUI journeys.
+// It deliberately exposes only semantic operations: dump, press and set-value.
+import ApplicationServices
+import Foundation
+
+func fail(_ message: String) -> Never {
+    FileHandle.standardError.write(("rapid-ax: \(message)\n").data(using: .utf8)!)
+    exit(1)
+}
+
+guard CommandLine.arguments.count >= 3,
+      let pid = pid_t(CommandLine.arguments[2]) else {
+    fail("usage: rapid-ax <dump|press|set-value> <pid> [identifier] [value]")
+}
+
+let command = CommandLine.arguments[1]
+let application = AXUIElementCreateApplication(pid)
+var visited = Set<CFHashCode>()
+var records = [[String: Any]]()
+var match: AXUIElement?
+let wanted = CommandLine.arguments.count > 3 ? CommandLine.arguments[3] : nil
+
+func attribute(_ element: AXUIElement, _ name: CFString) -> AnyObject? {
+    var value: CFTypeRef?
+    guard AXUIElementCopyAttributeValue(element, name, &value) == .success else { return nil }
+    return value
+}
+
+func string(_ element: AXUIElement, _ name: CFString) -> String? {
+    attribute(element, name) as? String
+}
+
+func jsonValue(_ value: AnyObject?) -> Any? {
+    switch value {
+    case let text as String: return text
+    case let number as NSNumber: return number
+    default: return nil
+    }
+}
+
+func point(_ element: AXUIElement, _ name: CFString) -> CGPoint? {
+    guard let wrapped = attribute(element, name), CFGetTypeID(wrapped) == AXValueGetTypeID() else { return nil }
+    var result = CGPoint.zero
+    guard AXValueGetValue(wrapped as! AXValue, .cgPoint, &result) else { return nil }
+    return result
+}
+
+func size(_ element: AXUIElement, _ name: CFString) -> CGSize? {
+    guard let wrapped = attribute(element, name), CFGetTypeID(wrapped) == AXValueGetTypeID() else { return nil }
+    var result = CGSize.zero
+    guard AXValueGetValue(wrapped as! AXValue, .cgSize, &result) else { return nil }
+    return result
+}
+
+func walk(_ element: AXUIElement, depth: Int) {
+    guard depth <= 40, records.count < 12_000 else { return }
+    let identity = CFHash(element)
+    guard visited.insert(identity).inserted else { return }
+
+    let identifier = string(element, kAXIdentifierAttribute as CFString)
+    var record: [String: Any] = ["depth": depth]
+    if let identifier { record["identifier"] = identifier }
+    if let role = string(element, kAXRoleAttribute as CFString) { record["role"] = role }
+    if let title = string(element, kAXTitleAttribute as CFString), !title.isEmpty { record["title"] = title }
+    if let description = string(element, kAXDescriptionAttribute as CFString), !description.isEmpty { record["description"] = description }
+    if let help = string(element, kAXHelpAttribute as CFString), !help.isEmpty { record["help"] = help }
+    if let value = jsonValue(attribute(element, kAXValueAttribute as CFString)) { record["value"] = value }
+    if let origin = point(element, kAXPositionAttribute as CFString),
+       let extent = size(element, kAXSizeAttribute as CFString) {
+        record["bounds"] = [
+            "x": origin.x, "y": origin.y,
+            "width": extent.width, "height": extent.height
+        ]
+    }
+    records.append(record)
+
+    if match == nil, identifier == wanted { match = element }
+    guard let children = attribute(element, kAXChildrenAttribute as CFString) as? [AXUIElement] else { return }
+    for child in children {
+        // The application root also owns the global menu bar. Traversing it
+        // captures unrelated macOS Recent Items in test artifacts and adds
+        // thousands of irrelevant nodes. Golden flows only need app windows;
+        // sheets and popovers remain descendants of those windows.
+        if depth == 0, string(child, kAXRoleAttribute as CFString) != kAXWindowRole as String {
+            continue
+        }
+        walk(child, depth: depth + 1)
+    }
+}
+
+walk(application, depth: 0)
+
+if command == "dump" {
+    let payload: [String: Any] = [
+        "success": true,
+        "data": ["pid": pid, "ui_elements": records]
+    ]
+    let data = try! JSONSerialization.data(withJSONObject: payload, options: [.prettyPrinted, .sortedKeys])
+    FileHandle.standardOutput.write(data)
+    FileHandle.standardOutput.write(Data("\n".utf8))
+    exit(0)
+}
+
+guard let identifier = wanted, let target = match else {
+    fail("identifier not found: \(wanted ?? "<missing>")")
+}
+
+switch command {
+case "press":
+    let result = AXUIElementPerformAction(target, kAXPressAction as CFString)
+    guard result == .success else { fail("AXPress \(identifier) failed: \(result.rawValue)") }
+case "set-value":
+    guard CommandLine.arguments.count > 4 else { fail("set-value requires a value") }
+    let value = CommandLine.arguments[4] as CFString
+    let focusResult = AXUIElementSetAttributeValue(target, kAXFocusedAttribute as CFString, kCFBooleanTrue)
+    guard focusResult == .success else { fail("focus \(identifier) failed: \(focusResult.rawValue)") }
+    let result = AXUIElementSetAttributeValue(target, kAXValueAttribute as CFString, value)
+    guard result == .success else { fail("set value \(identifier) failed: \(result.rawValue)") }
+default:
+    fail("unknown command: \(command)")
+}
+
+print("{\"success\":true,\"identifier\":\"\(identifier)\",\"action\":\"\(command)\"}")


### PR DESCRIPTION
## What changed

- add five release-grade AX-first GUI golden journeys: fresh install/onboarding, Settings persistence, chat/session restore, slow-stream Stop, and model crash recovery
- add a native Swift Accessibility driver for semantic dump/press/set-value operations
- extend the fake sidecar with deterministic slow-stream, lifecycle event, cancellation, and one-shot crash controls
- document local and release-candidate usage

## Why

The existing GUI smoke covered selector presence but not complete user journeys, and coordinate automation was too brittle for release regression testing. These flows use isolated bundle IDs and HOME directories, stable AX identifiers, deterministic fake inference, and machine-readable evidence without loading a real model.

## Impact

Release candidates can run repeatable GUI regression coverage in a logged-in macOS session without model downloads or meaningful unified-memory pressure. Normal actions are independent of window position and resolution; Peekaboo remains only for permissions, window/menu integration, screenshots, and a narrow consent-sheet fallback.

## Validation

- latest main local release build: `SKIP_SIDECAR=1 BUNDLE_MODEL=0 bash scripts/build.sh`
- full five-flow suite passed repeatedly; final artifacts: `/tmp/rapid-golden-final`
- end-to-end slow-stream cancellation confirmed by server `chat_cancelled` evidence
- failure-result artifact path validated
- `bash scripts/smoke.sh`
- `shellcheck`
- `git diff --check`
- `codex review --base origin/main`: no correctness findings