### PR TITLE
fix(rapid-mac): tray "Check for updates…" reports somewhere instead of nothing

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/RapidApp.swift
+++ b/apps/rapid-mac/Sources/Rapid/RapidApp.swift
@@ -185,6 +185,14 @@ struct RapidApp: App {
                     AppDelegate.openSettingsWindow = {
                         openWindow(id: "settings")
                     }
+                    AppDelegate.openSettingsWindowAt = { category in
+                        // `route(to:open:)` assigns the pending category
+                        // BEFORE opening — that ordering is load-bearing, see
+                        // SettingsRouter.
+                        settingsRouter.route(to: category) {
+                            openWindow(id: "settings")
+                        }
+                    }
                 }
                 .task {
                     // First update check on launch, then re-check every
@@ -657,6 +665,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// ``sendAction`` from the status-item menu never reached it and the
     /// tray "Settings…" item silently did nothing.
     static var openSettingsWindow: (@MainActor () -> Void)?
+
+    /// Open Settings deep-linked to a category, for call sites outside the
+    /// SwiftUI environment (the tray reads its dependencies through
+    /// ``AppDelegate.shared`` and cannot see ``SettingsRouter`` directly).
+    ///
+    /// Exists because the tray's "Check for updates…" had nowhere to report
+    /// to: it fired the check and discarded the result, so a user on the
+    /// latest version clicked and saw nothing at all. Settings → App already
+    /// renders that state ("Up to date — vX.Y.Z is the latest release."), so
+    /// the item routes there rather than growing a second surface that could
+    /// disagree with the first.
+    static var openSettingsWindowAt: (@MainActor (SettingsView.Category?) -> Void)?
 
     /// Canonical termination ordering. Audit P1 wants the in-flight
     /// chat stream cancelled BEFORE the session envelope is

--- a/apps/rapid-mac/Sources/Rapid/UI/MenuBarController.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/MenuBarController.swift
@@ -222,7 +222,21 @@ final class MenuBarController: NSObject {
         case .update:
             openUpdateWindow()
         case .checkForUpdates:
+            // Fire the check AND take the user somewhere that reports it.
+            //
+            // This used to be `Task { _ = await updater?.check() }` — result
+            // discarded, no UI. When an update exists the menu grows an
+            // "Update available" item on the next open, so that path looked
+            // fine; when you are already current, clicking produced nothing
+            // observable at all, which is indistinguishable from a broken
+            // build or a click that missed (#1605).
+            //
+            // Settings → App already renders the outcome, including the
+            // running version, so route there rather than inventing a second
+            // surface that could drift from the first.
             Task { _ = await AppDelegate.shared.updater?.check() }
+            NSApp.activate(ignoringOtherApps: true)
+            AppDelegate.openSettingsWindowAt?(.app)
         case .about:
             if let server = AppDelegate.shared.server {
                 AboutPanel.show(server: server)


### PR DESCRIPTION
## Why

The handler discarded its own result:

```swift
case .checkForUpdates:
    Task { _ = await AppDelegate.shared.updater?.check() }
```

When an update *exists*, the menu grows an "Update available" item on the next
open, so that path looked fine. When you are already current, clicking produced
nothing observable — no sheet, no alert, no notification, no window change,
measured twice with 3–5 s waits. That is indistinguishable from a broken build
or a click that missed.

## What

Route it to the surface that already reports this, rather than inventing a
second one that could drift:

```
Settings.App.UpToDate  val="Up to date — v0.12.6 is the latest release."
```

`SettingsRouter.route(to:open:)` already existed for this (the version pill uses
it), but the tray reads dependencies through `AppDelegate.shared` and cannot see
the router — so this adds an `openSettingsWindowAt` bridge next to the existing
`openSettingsWindow`. The router’s documented ordering (assign the pending
category **before** opening) is preserved by going through `route(to:open:)`.

## Verification

Built this branch, swapped into an isolated persona, driven by AX:

| | windows |
| --- | --- |
| before | `Rapid-MLX` |
| after tray → Check for updates… | `Settings, Rapid-MLX` |

and the panel it lands on:

```
Settings.App.UpToDate [AXStaticText]
  val = "Up to date — v0.12.6 is the latest release."
```

`swift build` clean. `swift test` not run — this machine has Command Line Tools
only (no full Xcode), so the test target fails to build with `no such module
XCTest`; CI covers it.

## Scope

Narrows #1605. My original report claimed the *app* gives no feedback when up to
date — that was wrong, Settings → App always did. Only the tray item was silent,
so the fix is much smaller than the issue implied.

One thing I could not determine and did not change: pressing
`Settings.App.RecheckCTA` shows no observable transition —
`Settings.App.Checking` never appeared across a 1 s poll and the end state was
unchanged. Consistent with either an instant cached answer (the endpoint has a
5-minute edge cache) or a CTA that does nothing; not distinguishable from
outside. Noted on the issue.