### PR TITLE
test(rapid-mac): add three invariant golden flows and record the honest baseline

### DIFF
--- a/apps/rapid-mac/docs/gui-golden-flows.md
+++ b/apps/rapid-mac/docs/gui-golden-flows.md
@@ -1,13 +1,62 @@
 # AX-first GUI golden flows
 
-`scripts/gui-golden-flows.sh` runs the five release journeys against a built
-Rapid-MLX Desktop app without loading a real model:
+`scripts/gui-golden-flows.sh` runs the release journeys against a built
+Rapid-MLX Desktop app without loading a real model.
+
+**Journeys** — a user walking a path end to end:
 
 1. fresh install, consent, onboarding, and steady-state shell;
 2. Settings mutation and persistence across an app relaunch;
 3. basic chat, persisted conversation row, and restored transcript;
 4. a deliberately slow stream and semantic **Stop generating** action;
 5. model start, a one-shot sidecar crash, automatic respawn, and ready state.
+
+**Invariants** — properties that must hold, not paths a user walks. These were
+added after a release where every escaped defect landed on a surface no journey
+covered, and each one names the defect it would have caught:
+
+6. `update-state` — Settings → App must name the version the app actually is.
+7. `no-dead-controls` — every Settings panel must expose controls of its own.
+8. `catalog-integrity` — a model that cannot chat must never be offered as one.
+
+The distinction matters. A journey answers *"can someone do this?"*; an
+invariant answers *"is this still true everywhere?"*. The three defects below
+were all invisible to journey-shaped tests:
+
+| Flow | Would have caught | Why a journey missed it |
+| --- | --- | --- |
+| `update-state` | [#1612](https://github.com/raullenchai/Rapid-MLX/issues/1612) — the fallback update manifest sat at 0.11.0 for four releases | Nothing in a journey compares what the panel *says* to what the bundle *is* |
+| `no-dead-controls` | [#1595](https://github.com/raullenchai/Rapid-MLX/pull/1595) dead recovery buttons, [#1608](https://github.com/raullenchai/Rapid-MLX/pull/1608) toggles that reported success without changing value, [#1605](https://github.com/raullenchai/Rapid-MLX/issues/1605) a tray item that reported nowhere | A journey visits the controls it needs; these were the ones nobody scripted |
+| `catalog-integrity` | [#1603](https://github.com/raullenchai/Rapid-MLX/issues/1603) — eight video-generation models offered as chat models, dead-ending *after* a download of up to 64 GB | The picker renders them perfectly; the bug is that they are there at all |
+
+### Current baseline
+
+Run against `main` on 2026-08-07, on a build of this checkout:
+
+| Flow | Result |
+| --- | --- |
+| `update-state` | **PASS** — panel reads "Up to date — v0.12.6 is the latest release.", matching `CFBundleShortVersionString` |
+| `catalog-integrity` | **PASS** — `fake-video-alias` reaches neither the chat surface nor Model Management |
+| `no-dead-controls` | **FAILS on `tools`** — see below |
+
+`no-dead-controls` fails today, correctly: Settings → Tools renders three tool
+toggles, a backend radio group and a browsing toggle, and **none of them carry
+an identifier**. The controls work — they are real `AXCheckBox`/`AXRadioButton`
+with correct values — they are simply unaddressable. That is a coverage gap in
+product code, not a harness bug, and it is tracked separately. Expect this flow
+to go green when those identifiers land; until then it is the gate for that work.
+
+Two notes on writing assertions here, both learned the hard way while adding
+these:
+
+- The first version of `no-dead-controls` counted every `Settings.*` identifier
+  on the panel. The six `Settings.Category.*` buttons appear on *every* panel,
+  so the count was never below six and the flow went green on a completely
+  unlabelled Tools panel. Count the panel's **own** controls.
+- `catalog-integrity` proves it discriminates rather than trivially passing:
+  the non-video `fake-alias` appears 9 times in the same tree where
+  `fake-video-alias` appears 0 times. A test that asserts an absence must show
+  that the corresponding presence is detectable.
 
 Every journey gets a unique bundle identifier and throwaway `HOME` through
 `dogfood-isolate.sh`. The fake sidecar emits deterministic SSE and JSONL
@@ -29,7 +78,16 @@ Run one journey or retain its isolated persona for diagnosis:
 ```bash
 ./scripts/gui-golden-flows.sh --flow slow-stream-stop
 ./scripts/gui-golden-flows.sh --flow chat-restore --keep
+./scripts/gui-golden-flows.sh --flow no-dead-controls
 ```
+
+The suite needs a **local login session** — not SSH or tmux. It also needs the
+screen to stay awake: when the session goes idle, `CGSSessionScreenIsLocked`
+flips to `Yes`, every app reports zero windows through AX, and `screencapture`
+returns wallpaper. That looks exactly like a broken app. Hold the session with
+`caffeinate -dimsu -t <seconds>` for the length of the run — `-u` is the
+load-bearing flag, since plain `-d` stops display sleep but not the idle path —
+and re-read the lock state before trusting any window assertion.
 
 Set `RAPID_GUI_SOURCE_APP` to test a release candidate bundle and
 `RAPID_GUI_GOLDEN_OUT` to choose the artifact directory. Each run records AX

--- a/apps/rapid-mac/scripts/fake-rapid-mlx.sh
+++ b/apps/rapid-mac/scripts/fake-rapid-mlx.sh
@@ -252,6 +252,17 @@ def _emit_catalog(subcommand, alias):
         print("Alias                  Parser           Reasoning")
         print("---------------------  ---------------  ---------")
         print("fake-alias             hermes           qwen3")
+        # A video-generation row, in the tagged section the real engine
+        # emits (#1607). It has no tokenizer and cannot answer a chat
+        # request, so the desktop must filter it out of every catalog
+        # surface. Emitting it here lets `flow_catalog_integrity` prove the
+        # FILTER works, rather than asserting against whatever the real
+        # registry happens to contain today.
+        print()
+        print("Video models (1 aliases)")
+        print("Alias                  Size       Kind        HF id")
+        print("---------------------  ---------  ----------  ------")
+        print("fake-video-alias       13.3 GiB   [video:gen] fake/video-mlx")
         return True
     if subcommand == "ls":
         print("Cached models")

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -25,7 +25,8 @@ usage() {
 Usage: gui-golden-flows.sh [--flow NAME] [--keep]
 
 Flows: fresh-install, settings-persistence, chat-restore, slow-stream-stop,
-       model-crash-recovery, all
+       model-crash-recovery, update-state, no-dead-controls,
+       catalog-integrity, all
 
 Environment:
   RAPID_GUI_SOURCE_APP   built .app to test
@@ -407,6 +408,94 @@ flow_model_crash_recovery() {
     cleanup_persona
 }
 
+flow_update_state() {
+    # Settings > App must name the version the app actually IS.
+    #
+    # This is the cheap end of a real failure: the update manifest the app
+    # falls back on (dl.rapidmlx.com/latest.json) sat at 0.11.0 for four
+    # releases (#1612). Anything consuming a stale manifest reports a version
+    # that disagrees with CFBundleShortVersionString, and this assertion
+    # catches exactly that mismatch without needing network state.
+    start_persona update-state
+    dismiss_first_run
+    open_settings
+    see_main "$OUT/update-settings.json"
+    press "$OUT/update-settings.json" Settings.Category.app "$OUT/update-open-app.json"
+    wait_identifier Settings.App.UpToDate "$OUT/update-app-panel.json"
+
+    local shown expected
+    shown="$(element_field "$OUT/update-app-panel.json" Settings.App.UpToDate value)"
+    expected="$(/usr/libexec/PlistBuddy -c 'Print CFBundleShortVersionString' \
+        "$APP_SOURCE/Contents/Info.plist" 2>/dev/null)"
+    [[ -n "$expected" ]] || die "could not read CFBundleShortVersionString"
+    [[ "$shown" == *"$expected"* ]] \
+        || die "update panel says '$shown' but the app is $expected"
+    log "  update state names the running version ($expected)"
+    cleanup_persona
+}
+
+flow_no_dead_controls() {
+    # Every advertised Settings control must do something observable.
+    #
+    # Journey-shaped flows never found this class; an inventory-shaped one
+    # finds all of it. Recovery buttons that highlighted, accepted the click
+    # and did nothing (#1595); toggles that reported success without changing
+    # value (#1608); a tray item that fired and reported nowhere (#1605).
+    start_persona no-dead-controls
+    dismiss_first_run
+    open_settings
+    see_main "$OUT/dead-before.json"
+
+    local category
+    for category in models modelManagement tools appearance privacy app; do
+        press "$OUT/dead-before.json" "Settings.Category.$category" \
+            "$OUT/dead-open-$category.json" \
+            || die "Settings category $category is not pressable"
+        see_main "$OUT/dead-panel-$category.json"
+        # Count only the PANEL's own controls. The six `Settings.Category.*`
+        # buttons are present on every panel, so counting all `Settings.*`
+        # identifiers is vacuous — it goes green on a completely unlabelled
+        # panel, which is precisely the state Tools is in today.
+        local count
+        count="$(jq '[.data.ui_elements[]?
+                      | select((.identifier // "") | startswith("Settings."))
+                      | select((.identifier // "") | startswith("Settings.Category.") | not)]
+                     | length' "$OUT/dead-panel-$category.json")"
+        [[ "$count" -gt 0 ]] \
+            || die "Settings > $category exposes no identified controls of its own"
+        log "  $category: $count identified controls"
+    done
+    cleanup_persona
+}
+
+flow_catalog_integrity() {
+    # A model that cannot chat must never be offered as one.
+    #
+    # Eight video-generation aliases reached the picker and Model Management
+    # looking ordinary; selecting one dead-ended at "Couldn't start ... Try
+    # again" forever, reachable AFTER downloading up to 64 GB (#1603). The
+    # fake sidecar emits a `[video:gen]`-tagged row so this proves the FILTER,
+    # not today's registry contents.
+    start_persona catalog-integrity
+    dismiss_first_run
+    see_main "$OUT/catalog-main.json"
+
+    jq -e '[.data.ui_elements[]? | select([(.identifier // ""), (.value // ""), (.title // ""), (.description // "")] | map(tostring) | join(" ") | test("fake-video-alias"))] | length == 0' \
+        "$OUT/catalog-main.json" >/dev/null \
+        || die "a video-gen alias reached the chat surface"
+
+    open_settings
+    see_main "$OUT/catalog-settings.json"
+    press "$OUT/catalog-settings.json" Settings.Category.modelManagement \
+        "$OUT/catalog-open-mm.json"
+    see_main "$OUT/catalog-model-management.json"
+    jq -e '[.data.ui_elements[]? | select([(.identifier // ""), (.value // ""), (.title // ""), (.description // "")] | map(tostring) | join(" ") | test("fake-video-alias"))] | length == 0' \
+        "$OUT/catalog-model-management.json" >/dev/null \
+        || die "a video-gen alias reached Model Management"
+    log "  no video-gen alias on either catalog surface"
+    cleanup_persona
+}
+
 if [[ -d "$OUT_ROOT" && -n "$(ls -A "$OUT_ROOT" 2>/dev/null)" ]]; then
     RESULT_WRITTEN=1
     die "artifact directory is not empty: $OUT_ROOT"
@@ -419,12 +508,18 @@ case "$FLOW" in
     chat-restore) flow_chat_restore ;;
     slow-stream-stop) flow_slow_stream_stop ;;
     model-crash-recovery) flow_model_crash_recovery ;;
+    update-state) flow_update_state ;;
+    no-dead-controls) flow_no_dead_controls ;;
+    catalog-integrity) flow_catalog_integrity ;;
     all)
         flow_fresh_install
         flow_settings_persistence
         flow_chat_restore
         flow_slow_stream_stop
         flow_model_crash_recovery
+        flow_update_state
+        flow_no_dead_controls
+        flow_catalog_integrity
         ;;
     *) die "unknown flow: $FLOW" ;;
 esac


### PR DESCRIPTION
AX-first GUI dogfood, continued from #1613.

## Why

The five existing flows are **journeys** — a user walking a path end to end.
Every defect that escaped the 0.12.6 release landed on a surface no journey
covered. This adds the complementary shape: **invariants**, properties that must
hold everywhere.

| New flow | Would have caught | Why a journey missed it |
| --- | --- | --- |
| `update-state` | #1612 — the fallback update manifest sat at 0.11.0 for four releases | Nothing compares what the panel *says* to what the bundle *is* |
| `no-dead-controls` | #1595 dead recovery buttons, #1608 toggles reporting success without changing value, #1605 a tray item reporting nowhere | A journey visits the controls it needs; these were the ones nobody scripted |
| `catalog-integrity` | #1603 — eight video-generation models offered as chat models, dead-ending *after* up to 64 GB of download | The picker renders them perfectly; the bug is that they are there at all |

## Baseline — including a failure

Run against this checkout, local login session:

| Flow | Result |
| --- | --- |
| `update-state` | **PASS** — reads "Up to date — v0.12.6 is the latest release.", matching `CFBundleShortVersionString` |
| `catalog-integrity` | **PASS** — `fake-video-alias` reaches neither the chat surface nor Model Management |
| `no-dead-controls` | **FAILS on `tools`** |

`no-dead-controls` fails **correctly**. Settings → Tools renders three tool
toggles, a backend radio group and a browsing toggle, and none carry an
identifier. The controls work — real `AXCheckBox`/`AXRadioButton` with correct
values — they are simply unaddressable. That is a product-code gap being fixed
separately; this flow is its gate. I would rather land a flow that fails
honestly than tune it until it goes green.

## Two assertion bugs of my own

Both caught before this landed, both written into the doc:

- The first `no-dead-controls` counted every `Settings.*` identifier on the
  panel. The six `Settings.Category.*` buttons appear on **every** panel, so the
  count could never drop below six — it went green on a completely unlabelled
  Tools panel. It now counts the panel’s own controls.
- `catalog-integrity` is shown to **discriminate** rather than trivially pass:
  the non-video `fake-alias` appears 9 times in the same tree where
  `fake-video-alias` appears 0 times. A test asserting an absence has to show
  the corresponding presence is detectable.

## Harness change

`fake-rapid-mlx.sh` now emits a `[video:gen]`-tagged row in the sectioned format
the real engine produces, so `catalog-integrity` tests the **filter** rather than
whatever the real registry happens to hold today.

## Also documented

The session requirement the harness has always had but never stated: a **local
login session**, held awake with `caffeinate -dimsu -t <seconds>` — `-u` is the
load-bearing flag, plain `-d` stops display sleep but not the idle path. When the
session goes idle, `CGSSessionScreenIsLocked` flips to `Yes`, every app reports
zero windows through AX and `screencapture` returns wallpaper — indistinguishable
from a broken build. I lost time to exactly this today.

Related: #1613, #1603, #1605, #1612.