### PR TITLE
Fix release-blocking desktop and status regressions

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Server/DownloadManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/DownloadManager.swift
@@ -96,6 +96,8 @@ final class DownloadManager {
         /// job has already exited. Retained here so the manager can
         /// cancel the monitor on exit alongside the subprocess.
         fileprivate(set) var byteMonitor: HFCacheByteMonitor.Handle?
+        fileprivate var lastProgressAt: Date
+        fileprivate var lastObservedBytes: Int64?
 
         enum Status: Equatable {
             /// Subprocess is running. Most lines we see are tqdm ticks
@@ -130,6 +132,8 @@ final class DownloadManager {
             self.source = source
             self.failureKind = nil
             self.byteMonitor = nil
+            self.lastProgressAt = Date()
+            self.lastObservedBytes = nil
         }
 
         nonisolated static func == (lhs: Job, rhs: Job) -> Bool { lhs.id == rhs.id }
@@ -176,6 +180,8 @@ final class DownloadManager {
 
     private var processes: [String: Process] = [:]
     private var cancellingProcesses: [String: Process] = [:]
+    private var stalledProcesses: [String: Process] = [:]
+    private var stallWatchdogs: [String: Task<Void, Never>] = [:]
     private let cancellationTracker = DownloadCancellationTracker()
     private var stdoutPipes: [String: Pipe] = [:]
     private var stderrPipes: [String: Pipe] = [:]
@@ -186,6 +192,17 @@ final class DownloadManager {
     private let stderrTailCapacity: Int = 12
     nonisolated private static let maxOutputChunkBytes = 64 * 1024
     nonisolated private static let maxOutputLineBytes = 8 * 1024
+    /// Two minutes without a progress tick or byte growth is long enough to
+    /// distinguish a dead network path from an ordinary slow shard.
+    nonisolated static let downloadStallWindow: TimeInterval = 120
+
+    nonisolated static func isStalled(
+        lastProgressAt: Date,
+        now: Date,
+        window: TimeInterval = downloadStallWindow
+    ) -> Bool {
+        now.timeIntervalSince(lastProgressAt) >= window
+    }
 
     // MARK: - Construction
 
@@ -400,7 +417,47 @@ final class DownloadManager {
             hfPath: hfPath,
             totalBytes: totalBytes
         )
+        installStallWatchdog(alias: trimmed, process: process, job: job)
         return true
+    }
+
+    private func installStallWatchdog(alias: String, process: Process, job: Job) {
+        stallWatchdogs[alias]?.cancel()
+        stallWatchdogs[alias] = Task { @MainActor [weak self, weak job] in
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .seconds(5))
+                guard let self, let job, process.isRunning else { return }
+                // The network transfer is over. Model loading / shader
+                // compilation can legitimately be quiet for minutes and is
+                // covered by ServerManager's separate startup watchdog.
+                if case .warmingUp = job.progress.phase { return }
+                if let bytes = job.progress.bytesDownloaded,
+                   bytes != job.lastObservedBytes {
+                    job.lastObservedBytes = bytes
+                    job.lastProgressAt = Date()
+                }
+                guard Self.isStalled(
+                    lastProgressAt: job.lastProgressAt,
+                    now: Date()
+                ) else {
+                    continue
+                }
+                self.stalledProcesses[alias] = process
+                job.failureKind = .downloadFailed
+                job.status = .failed(
+                    message: "The download stopped making progress. Check your network and try again — saved partial data will be reused."
+                )
+                process.terminate()
+                let deadline = Date().addingTimeInterval(2)
+                while process.isRunning && Date() < deadline {
+                    try? await Task.sleep(for: .milliseconds(100))
+                }
+                if process.isRunning {
+                    kill(process.processIdentifier, SIGKILL)
+                }
+                return
+            }
+        }
     }
 
     /// Retry a terminal job while preserving the cache-monitor metadata.
@@ -413,6 +470,9 @@ final class DownloadManager {
         let trimmed = alias.trimmingCharacters(in: .whitespacesAndNewlines)
         guard let previous = jobs[trimmed] else { return false }
         guard previous.status != .running else { return false }
+        // A watchdog failure is surfaced before SIGTERM/SIGKILL reaps the old
+        // child. Do not overlap two writers against the same cache sidecars.
+        guard processes[trimmed] == nil else { return false }
         let hfPath = previous.hfPath
         let totalBytes = previous.totalBytes
         let nextSource = source ?? previous.source
@@ -592,6 +652,7 @@ final class DownloadManager {
         guard let job = jobs[alias] else { return }
         for line in lines {
             let consumed = job.progress.ingest(line)
+            if consumed { job.lastProgressAt = Date() }
             if isStderr && !consumed {
                 var tail = stderrTails[alias] ?? []
                 // Scrub before storage — the stderr tail feeds the
@@ -621,6 +682,11 @@ final class DownloadManager {
         }
         // Drain readability handlers so ARC can free the pipes.
         cleanupProcessBookkeeping(alias: alias, process: process)
+
+        if stalledProcesses.removeValue(forKey: alias) === process {
+            // The watchdog already installed the actionable retry state.
+            return
+        }
 
         if wasCancelling {
             job.status = .cancelled
@@ -812,6 +878,7 @@ final class DownloadManager {
     }
 
     private func cleanupProcessBookkeeping(alias: String, process: Process) {
+        stallWatchdogs.removeValue(forKey: alias)?.cancel()
         stdoutPipes[alias]?.fileHandleForReading.readabilityHandler = nil
         stderrPipes[alias]?.fileHandleForReading.readabilityHandler = nil
         stdoutPipes.removeValue(forKey: alias)

--- a/apps/rapid-mac/Sources/Rapid/Server/ModelSizing.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ModelSizing.swift
@@ -204,6 +204,9 @@ enum ModelSizing {
         let footprintGB: Double
         /// GB free at the moment the load was attempted.
         let freeGB: Double
+        /// Total unified memory. Needed because the guard is based on
+        /// projected utilisation, not on footprint-versus-free alone.
+        var totalGB: Double = 0
 
         var title: String {
             switch severity {
@@ -217,10 +220,19 @@ enum ModelSizing {
         var message: String {
             let need = max(1, Int(footprintGB.rounded()))
             let free = max(0, Int(freeGB.rounded()))
-            let facts = "\(alias) needs about \(need) GB, but only about \(free) GB is free right now — other apps or a running model are using memory."
+            guard totalGB > 0 else {
+                let facts = "\(alias) needs about \(need) GB, and about \(free) GB is free right now."
+                return facts + " Close some apps or pick a smaller model before loading it."
+            }
+            let usedGB = max(0, totalGB - freeGB)
+            let projectedPercent = Int(((usedGB + footprintGB) / totalGB * 100).rounded())
+            let threshold = severity == .unsafe ? 85.0 : 75.0
+            let toFree = max(0, usedGB + footprintGB - threshold / 100 * totalGB)
+            let freeAction = max(1, Int(toFree.rounded(.up)))
+            let facts = "Loading it would put memory use at about \(projectedPercent)% of \(Int(totalGB.rounded())) GB."
             switch severity {
             case .unsafe:
-                return facts + " Loading it may freeze or crash your Mac. Close some apps, or pick a smaller model."
+                return facts + " Past about 85%, macOS may freeze or restart. Free about \(freeAction) GB by closing some apps, or pick a smaller model."
             case .tight, .safe:
                 return facts + " It should load but may stall under longer chats. Consider closing some apps or picking a smaller model."
             }

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -894,7 +894,8 @@ final class ServerManager {
                     isAutoRespawn: isAutoRespawn,
                     severity: safety,
                     footprintGB: footprint.totalGB,
-                    freeGB: Double(snapshot.freeBytes) / Double(1 << 30)
+                    freeGB: Double(snapshot.freeBytes) / Double(1 << 30),
+                    totalGB: Double(snapshot.totalBytes) / Double(1 << 30)
                 )
                 memoryLoadConfirmed = false
                 // The user is now the decision-maker for this alias, so a

--- a/apps/rapid-mac/Tests/RapidTests/DownloadManagerTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/DownloadManagerTests.swift
@@ -348,6 +348,19 @@ struct DownloadManagerTests {
         }
     }
 
+    @Test("download stall watchdog only advances for actual progress")
+    func stallWindowUsesActualProgress() {
+        let now = Date()
+        #expect(DownloadManager.isStalled(
+            lastProgressAt: now.addingTimeInterval(-121),
+            now: now
+        ))
+        #expect(!DownloadManager.isStalled(
+            lastProgressAt: now.addingTimeInterval(-10),
+            now: now
+        ))
+    }
+
     // MARK: - Cache generation
     //
     // Dogfood report: "I deleted the two qwens in Settings, but the

--- a/apps/rapid-mac/Tests/RapidTests/ModelSizingTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ModelSizingTests.swift
@@ -202,15 +202,17 @@ struct ModelSizingTests {
         #expect(ModelSizing.memorySafety(footprint: g, usedBytes: 0, totalBytes: 0) == .safe)
     }
 
-    @Test("MemoryWarning copy names the model, the GB need, and the free GB")
+    @Test("MemoryWarning explains the projected utilisation and actionable headroom")
     func memoryWarningCopy() {
         let w = ModelSizing.MemoryWarning(
             alias: "gemma-4-12b", hfPath: nil, isAutoRespawn: false,
-            severity: .unsafe, footprintGB: 11.8, freeGB: 6.0
+            severity: .unsafe, footprintGB: 5.9, freeGB: 8.8, totalGB: 24.0
         )
         #expect(w.title.contains("gemma-4-12b"))
-        #expect(w.message.contains("12")) // rounded need
-        #expect(w.message.contains("6"))  // rounded free
+        #expect(w.message.contains("88%"))
+        #expect(w.message.contains("85%"))
+        #expect(w.message.contains("1 GB"))
+        #expect(!w.message.contains("only about 9 GB is free"))
         #expect(w.confirmTitle.localizedCaseInsensitiveContains("anyway"))
     }
 

--- a/tests/test_mirror_pull.py
+++ b/tests/test_mirror_pull.py
@@ -3522,6 +3522,64 @@ def test_progress_tracker_clamps_display_at_total():
         _mirror._PROGRESS_HEARTBEAT_SECONDS = saved
 
 
+def test_r2_transport_timeout_preserves_part_and_next_attempt_resumes(
+    tmp_path: Path,
+):
+    """A network-path drop keeps trusted streamed bytes for Range resume."""
+    target = tmp_path / "snapshot" / "model.safetensors"
+    sidecar = tmp_path / "sidecar"
+    part = sidecar / "model.part"
+    target.parent.mkdir(parents=True)
+    sidecar.mkdir(parents=True)
+
+    class _DropsMidBody(_FakeResponse):
+        def __init__(self):
+            super().__init__(200, b"", headers={"Content-Length": "1000"})
+            self.calls = 0
+
+        def read(self, _size=-1):
+            self.calls += 1
+            if self.calls == 1:
+                return b"x" * 400
+            raise TimeoutError("network changed")
+
+    with patch("urllib.request.urlopen", return_value=_DropsMidBody()):
+        ok, reason = _mirror._do_r2_download(
+            "https://models.example/model.safetensors",
+            target,
+            part,
+            1000,
+        )
+    assert not ok
+    assert reason == "TimeoutError"
+    assert part.read_bytes() == b"x" * 400
+
+    seen_range = None
+
+    def _resume(req, timeout=None):
+        nonlocal seen_range
+        seen_range = req.headers.get("Range")
+        return _FakeResponse(
+            206,
+            b"x" * 600,
+            headers={
+                "Content-Length": "600",
+                "Content-Range": "bytes 400-999/1000",
+            },
+        )
+
+    with patch("urllib.request.urlopen", side_effect=_resume):
+        ok, reason = _mirror._do_r2_download(
+            "https://models.example/model.safetensors",
+            target,
+            part,
+            1000,
+        )
+    assert ok, reason
+    assert seen_range == "bytes=400-"
+    assert target.read_bytes() == b"x" * 1000
+
+
 def test_safe_display_name_strips_control_chars():
     """Filenames from external HF metadata can't inject terminal escapes.
 

--- a/tests/test_scheduler_throughput_stats.py
+++ b/tests/test_scheduler_throughput_stats.py
@@ -1,0 +1,64 @@
+"""Regression coverage for text-model throughput in ``/v1/status``."""
+
+import time
+from unittest.mock import MagicMock
+
+from vllm_mlx.request import Request, RequestStatus, SamplingParams
+from vllm_mlx.scheduler import Scheduler, SchedulerConfig
+
+
+def _scheduler() -> Scheduler:
+    tokenizer = MagicMock()
+    tokenizer.encode = lambda value: list(range(len(value.split())))
+    return Scheduler(MagicMock(), tokenizer, SchedulerConfig(max_num_seqs=1))
+
+
+def test_text_scheduler_exports_live_batch_generator_throughput():
+    scheduler = _scheduler()
+    request = Request(
+        request_id="status-tps",
+        prompt="hello",
+        sampling_params=SamplingParams(max_tokens=20),
+    )
+    request.status = RequestStatus.RUNNING
+    request.num_prompt_tokens = 8
+    request.first_token_time = time.time() - 2.0
+    for token in range(10):
+        request.append_output_token(token)
+    scheduler.running[request.request_id] = request
+    scheduler._last_prompt_tps = 40.0
+
+    stats = scheduler.get_stats()
+    throughput = stats["batch_generator"]
+
+    assert throughput["prompt_tps"] == 40.0
+    assert 4.0 < throughput["generation_tps"] < 6.0
+
+
+def test_prompt_throughput_aggregates_requests_in_the_same_batch():
+    scheduler = _scheduler()
+    started = time.time() - 1.0
+    responses = []
+
+    for uid, prompt_tokens in enumerate((10, 20)):
+        request = Request(
+            request_id=f"batch-{uid}",
+            prompt="hello",
+            sampling_params=SamplingParams(max_tokens=20),
+        )
+        request.status = RequestStatus.RUNNING
+        request.num_prompt_tokens = prompt_tokens
+        request._prefill_started_at = started
+        request._decoder = MagicMock()
+        request._decoder.add_token.return_value = "x"
+        scheduler.running[request.request_id] = request
+        scheduler.uid_to_request_id[uid] = request.request_id
+
+        response = MagicMock(uid=uid, token=uid, finish_reason=None, logprobs=None)
+        del response.prompt_cache
+        responses.append(response)
+
+    scheduler._process_batch_responses(responses)
+
+    # Both requests prefetched concurrently for ~1 second: 10 + 20 tok/s.
+    assert 25.0 < scheduler._last_prompt_tps < 35.0

--- a/vllm_mlx/_mirror.py
+++ b/vllm_mlx/_mirror.py
@@ -63,10 +63,8 @@ _USER_AGENT = "Mozilla/5.0 (rapid-mlx mirror client)"
 # caches them ``public, max-age=300``. 10 s is plenty.
 _CATALOG_TIMEOUT = 10.0
 
-# Per-file timeout for R2 connect + initial response. Large shards stream
-# via ``resp.read()`` after this point, which uses the socket-level
-# default timeout (no per-read clock). 60 s matches the old
-# ``_try_mirror_prefetch`` value.
+# Per-file socket timeout for R2 connect, response, and each streaming read.
+# A silent path therefore fails within this bound and can resume from `.part`.
 _FILE_TIMEOUT = 60.0
 
 # Polite cap. Cloudflare can take more, but four parallel connections to
@@ -520,7 +518,8 @@ def _download_one_from_r2(
 
     Returns ``(True, "")`` on success. On any failure returns
     ``(False, <reason>)`` where reason is a short tag used for the
-    summary line. Cleans up partial ``.part`` files on failure.
+    summary line. Integrity failures remove ``.part``; retryable transport
+    failures preserve a non-empty prefix for the next ranged attempt.
 
     Supports resume via ``Range: bytes=<offset>-`` when a non-empty
     ``.part`` already exists from a prior aborted run.
@@ -775,7 +774,14 @@ def _do_r2_download(
         OSError,
         ValueError,
     ) as e:
-        _safe_unlink(tmp)
+        # Keep a non-empty prefix for retryable transport failures. The next
+        # attempt validates the server's 206/Content-Range response before
+        # appending, while all integrity failures above still unlink it.
+        try:
+            if not tmp.exists() or tmp.stat().st_size == 0:
+                _safe_unlink(tmp)
+        except OSError:
+            _safe_unlink(tmp)
         # ``chunks_credited`` may not be bound if the exception fired
         # before the chunk loop reached the credit branch (e.g. urlopen
         # raised). ``locals().get`` keeps the rollback safe in either

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -3102,6 +3102,10 @@ class Scheduler:
         self.num_requests_processed = 0
         self.total_prompt_tokens = 0
         self.total_completion_tokens = 0
+        # Last observed text-path throughput. The upstream BatchGenerator has
+        # no stats object, so derive rates from request timing in our wrapper.
+        self._last_prompt_tps = 0.0
+        self._last_generation_tps = 0.0
         # Agent-only safety stop for exact token loops.  This remains separate
         # from normal completed-request accounting so operators can distinguish
         # healthy EOS stops from model degeneration.
@@ -6311,6 +6315,7 @@ class Scheduler:
                 self.uid_to_request_id[uid] = request.request_id
                 request.batch_uid = uid
                 request.status = RequestStatus.RUNNING
+                request._prefill_started_at = time.time()
                 # #558 PR-3 / #558 budget: record this request's FULL processor
                 # list (grammar + penalties + budget) by uid as the authoritative
                 # state the per-tick realign guard rebuilds from — immune to
@@ -6359,6 +6364,7 @@ class Scheduler:
         """
         outputs = []
         finished_ids = set()
+        prompt_tps_this_batch = 0.0
 
         for response in responses:
             request_id = self.uid_to_request_id.get(response.uid)
@@ -6391,6 +6397,16 @@ class Scheduler:
                 import time as _time
 
                 request.first_token_time = _time.time()
+                prefill_s = request.first_token_time - getattr(
+                    request, "_prefill_started_at", request.arrival_time
+                )
+                if prefill_s > 0:
+                    prompt_tps_this_batch += request.num_prompt_tokens / prefill_s
+
+            if request.first_token_time is not None and request.num_output_tokens > 0:
+                generation_s = time.time() - request.first_token_time
+                if generation_s > 0:
+                    self._last_generation_tps = request.num_output_tokens / generation_s
 
             # Decode the new token using IncrementalDecoder for multi-byte
             # safety (emoji, CJK). Skip stop tokens — they are not content.
@@ -6643,6 +6659,8 @@ class Scheduler:
 
             outputs.append(output)
 
+        if prompt_tps_this_batch > 0:
+            self._last_prompt_tps = prompt_tps_this_batch
         return outputs, finished_ids
 
     def _safe_disk_checkpoint(self, request: Request, response: Any) -> None:
@@ -7383,6 +7401,15 @@ class Scheduler:
 
     def get_stats(self) -> dict[str, Any]:
         """Get scheduler statistics."""
+        now = time.time()
+        active_generation_rates = []
+        for request in self.running.values():
+            if request.first_token_time is not None and request.num_output_tokens > 0:
+                elapsed = now - request.first_token_time
+                if elapsed > 0:
+                    active_generation_rates.append(request.num_output_tokens / elapsed)
+        if active_generation_rates:
+            self._last_generation_tps = sum(active_generation_rates)
         stats = {
             "num_waiting": len(self.waiting),
             "num_running": len(self.running),
@@ -7391,6 +7418,10 @@ class Scheduler:
             "num_repetition_loop_breaks": self.num_repetition_loop_breaks,
             "total_prompt_tokens": self.total_prompt_tokens,
             "total_completion_tokens": self.total_completion_tokens,
+            "batch_generator": {
+                "prompt_tps": round(self._last_prompt_tps, 2),
+                "generation_tps": round(self._last_generation_tps, 2),
+            },
             # M-02: PFlash observability counters. ``bypass_count`` is
             # the number of requests where PFlash compression engaged
             # and the prefix-cache fetch/store was skipped;


### PR DESCRIPTION
## What changed

- Fix #1602 by explaining the projected unified-memory percentage, the 85% safety threshold, and the actionable amount of memory to free.
- Fix #1544 by preserving non-empty mirror `.part` files after retryable transport failures, resuming with a validated Range request, and adding a two-minute no-progress watchdog to the desktop downloader. The watchdog surfaces a retryable failure, safely reaps the old child, ignores unchanged cache observations, and stops once downloading reaches warm-up.
- Fix #1494 by tracking text-scheduler prompt and generation throughput and exposing it through the existing `batch_generator` status contract, including aggregate prompt TPS for concurrent requests.

## Root causes

- The memory warning showed footprint and free memory even though the guard decides from projected total utilization.
- Transport exceptions unconditionally deleted resumable mirror prefixes, while the desktop side had no bounded detector for a silent child.
- The non-MLLM scheduler had cumulative token counters but no timing-derived throughput stats for `/v1/status`.

## Validation

- Python 3.12: 153 tests passed (`test_scheduler_throughput_stats.py`, `test_routes.py`, `test_mirror_pull.py`).
- `ruff check` and `ruff format --check` passed on changed Python files.
- rapid-mac `swift build` passed.
- Live text-only dogfood with `qwen3-0.6b-4bit`: 700-token completion, 22 status samples; observed `prompt_tps=297.78`, `generation_tps=230.53` during generation and non-zero completed throughput.
- Three Codex review rounds; all P1/P2 findings addressed.

Closes #1602
Closes #1544
Closes #1494
