### PR TITLE
ci(rapid-mac): block new interactive controls that carry no accessibility identifier

### DIFF
--- a/.github/workflows/rapid-mac-ci.yml
+++ b/.github/workflows/rapid-mac-ci.yml
@@ -11,6 +11,11 @@
 # and `swift test` can't resolve `import Testing` in this toolchain). Keep the
 # full-app compile gate and run focused dependency-free contract executables for
 # regressions that can be isolated from the removed test stack.
+#
+# Second gate: `accessibility-identifiers` keeps the GUI golden-flow harness from
+# silently losing coverage. It fails a PR that ADDS an interactive control with
+# no `.accessibilityIdentifier(...)` — see the script's module docstring for the
+# rationale, the escape hatch, and the shapes it deliberately does not detect.
 name: rapid-mac CI
 
 on:
@@ -19,6 +24,8 @@ on:
     paths:
       - "apps/rapid-mac/**"
       - ".github/workflows/rapid-mac-ci.yml"
+      # The gate script itself, so a change to the detector re-runs it.
+      - "scripts/check_rapid_mac_ax_identifiers.py"
 
 permissions:
   contents: read
@@ -29,6 +36,41 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Pure text lint over the diff — no Swift toolchain, no simulator, no app
+  # build. It runs on ubuntu in ~15s beside the multi-minute macOS build rather
+  # than inside it, so a missing identifier reads as its own red check with its
+  # own log instead of hiding at the bottom of a compile job.
+  accessibility-identifiers:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          # The gate is scoped to lines this PR ADDED, which needs the
+          # merge-base with the target branch — not a shallow single commit.
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+        with:
+          python-version: "3.12"
+
+      # checkout@v4 with fetch-depth 0 normally leaves origin/<base> in place;
+      # this is the same belt-and-braces fetch the mlx-bound-guard job in ci.yml
+      # does, so the merge-base lookup cannot fail on a runner that resolved
+      # refs differently.
+      - name: Fetch base branch
+        env:
+          BASE_BRANCH: ${{ github.base_ref || 'main' }}
+        run: git fetch --no-tags origin "${BASE_BRANCH}:refs/remotes/origin/${BASE_BRANCH}"
+
+      # Stdlib only — deliberately no pip install, so the gate cannot be taken
+      # down by an unrelated dependency resolution failure.
+      - name: Interactive controls carry an accessibility identifier
+        run: |
+          python scripts/check_rapid_mac_ax_identifiers.py \
+            --base-ref "origin/${{ github.base_ref || 'main' }}"
+
   build:
     # macos-15 → default Xcode 16 → Swift 6.0, matching Package.swift's
     # swift-tools-version and the release workflow's runner. macos-latest still

--- a/.github/workflows/rapid-mac-ci.yml
+++ b/.github/workflows/rapid-mac-ci.yml
@@ -24,8 +24,11 @@ on:
     paths:
       - "apps/rapid-mac/**"
       - ".github/workflows/rapid-mac-ci.yml"
-      # The gate script itself, so a change to the detector re-runs it.
+      # The gate script itself, so a change to the detector re-runs it...
       - "scripts/check_rapid_mac_ax_identifiers.py"
+      # ...and its regression suite, which is the only thing that runs when a
+      # PR touches the detector but no Swift at all.
+      - "tests/test_rapid_mac_ax_identifiers.py"
 
 permissions:
   contents: read
@@ -70,6 +73,36 @@ jobs:
         run: |
           python scripts/check_rapid_mac_ax_identifiers.py \
             --base-ref "origin/${{ github.base_ref || 'main' }}"
+
+
+  # The detector job above is a NO-OP on a PR that changes no Swift — which is
+  # exactly the shape of a PR that edits the detector. Without this suite, the
+  # wrapper-identifier fix, the qualifier fix or the carry-over accounting could
+  # all be reverted in a script-only PR with every job green, while the test
+  # pinning them failed locally.
+  #
+  # Its OWN job, not a step in the one above, because it needs pytest from PyPI
+  # and that job is deliberately stdlib-only: a registry incident must be able
+  # to redden the tests without also taking down the gate that needs no
+  # network at all.
+  accessibility-identifier-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+        with:
+          python-version: "3.12"
+
+      - name: Install pytest
+        run: pip install pytest
+
+      # ``-q`` but not ``-x``: a change to the detector usually breaks several
+      # pinned cases at once, and seeing all of them is the point.
+      - name: Gate regression suite
+        run: pytest tests/test_rapid_mac_ax_identifiers.py -q
 
   build:
     # macos-15 → default Xcode 16 → Swift 6.0, matching Package.swift's

--- a/apps/rapid-mac/docs/gui-golden-flows.md
+++ b/apps/rapid-mac/docs/gui-golden-flows.md
@@ -285,3 +285,52 @@ Both halves are now fixed: `start_model` waits on `wait_send_idle`, and
 `send_prompt` requires the composer to actually drain. The general rule: an
 assertion that a string is present anywhere is satisfied by the input field,
 the placeholder, the tooltip and the sidebar. Say *which element*.
+## The identifier gate
+
+Because every flow above finds its target by `AXIdentifier`, this suite's
+ceiling is exactly the set of controls that carry one — and that ceiling drops
+silently every time a feature ships an unlabelled control, because the app still
+works by hand. `scripts/check_rapid_mac_ax_identifiers.py` (wired into the
+`accessibility-identifiers` job in `.github/workflows/rapid-mac-ci.yml`) fails a
+PR that **adds** an interactive control under `apps/rapid-mac/Sources/` with no
+`.accessibilityIdentifier(...)`.
+
+It is scoped to lines the diff added. The pre-existing backlog is deliberately
+out of scope — a gate that failed on it would be un-landable, and a disabled
+gate is worse than none. `--audit` lists that backlog when you want to chip at
+it:
+
+```bash
+python scripts/check_rapid_mac_ax_identifiers.py --audit
+python scripts/check_rapid_mac_ax_identifiers.py --base-ref origin/main   # what CI runs
+```
+
+Name new identifiers with the existing `<Surface>.<Thing>` convention (the
+inventory lives in `docs/userflows.md`), and put them on the control itself —
+an identifier on the enclosing `HStack` does not give `AXPress` anything to
+press.
+
+### Opting out
+
+There is currently **no** known control on this surface that cannot carry an
+identifier. `confirmationDialog` / `alert` buttons were the standing suspicion —
+`docs/userflows.md` carried "Approval dialogs lack identifiers" as an open item
+for several releases — and the suspicion was measured rather than inherited: the
+presented dialog is an `AXSheet` whose `AXButton` children *do* carry the
+identifiers declared at the call site. So the escape hatch exists for a case
+nobody has produced yet, and `rg ax-exempt apps/rapid-mac` returning nothing is
+the expected state. If you find a real one, opt out explicitly, with a written
+reason, on the control's line or the line directly above it:
+
+```swift
+// ax-exempt: <what you measured that shows the identifier cannot be reached>
+Button("Allow once") { approve() }
+```
+
+The reason is mandatory — a bare `// ax-exempt:` fails the gate just like a
+missing identifier — and every opt-out is greppable, so the true manual-only
+surface stays countable instead of invisible:
+
+```bash
+rg ax-exempt apps/rapid-mac
+```

--- a/apps/rapid-mac/docs/userflows.md
+++ b/apps/rapid-mac/docs/userflows.md
@@ -359,6 +359,8 @@ First run has **two distinct surfaces**, shown in order:
 
 **No identifier (can't be AX-driven):** nothing on the current surface is known to be unreachable. The note that used to sit here named the MCP `ToolApprovalDialog` and a sandbox approval prompt — neither exists in `apps/rapid-mac`; this app's tool approval is the `browse` sheet listed above. `confirmationDialog`/`alert` buttons were the remaining doubt, and they were measured on a build of the current tree: the presented dialog is an `AXSheet` whose `AXButton` children do carry the identifiers declared at the call site.
 
+**Keeping this inventory from rotting.** The list above used to grow only when someone remembered to add an identifier. It is now defended by a CI gate: `scripts/check_rapid_mac_ax_identifiers.py` (job `accessibility-identifiers` in `.github/workflows/rapid-mac-ci.yml`) fails any PR that *adds* an interactive control under `apps/rapid-mac/Sources/` without `.accessibilityIdentifier(...)`. A control that genuinely cannot carry one opts out with a reasoned, greppable `// ax-exempt: <why>` marker on the control's line or the line above — no such control is known on the current surface (the `confirmationDialog`/`alert` doubt was measured and closed, see above), so `rg ax-exempt apps/rapid-mac` finding nothing is correct. The gate is scoped to added lines, so the *existing* gaps below are not blocked by it; `--audit` enumerates them. See `docs/gui-golden-flows.md` § "The identifier gate".
+
 ---
 
 ## Test harness limits

--- a/scripts/check_rapid_mac_ax_identifiers.py
+++ b/scripts/check_rapid_mac_ax_identifiers.py
@@ -1,0 +1,694 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Gate: a PR may not ADD an interactive rapid-mac control without an
+``.accessibilityIdentifier(...)``.
+
+Why (grounded, not hypothetical). The desktop app's only real GUI test harness —
+``apps/rapid-mac/scripts/gui-golden-flows.sh`` driving ``rapid-ax.swift`` — finds
+and presses controls by ``AXIdentifier`` and nothing else (see
+``apps/rapid-mac/docs/gui-golden-flows.md``). Its ceiling is therefore *exactly*
+the set of controls that carry one. Every feature that ships an unlabelled
+control silently lowers that ceiling, and nobody notices because the app still
+works by hand. Settings -> Tools is the live proof: three tool toggles, the
+web-search backend radio group, its key field + Save button and the browsing
+toggle are all real, working ``AXCheckBox``/``AXRadioButton``/``AXTextField``
+elements that no automated flow can reach. ``docs/userflows.md`` has also carried
+"Approval dialogs lack identifiers" as an open item across several releases.
+
+Design decisions, and why each one is the way it is:
+
+* **Added lines only.** The existing backlog is real and is tracked separately.
+  A gate that fails on it would be un-landable, get disabled inside a week, and
+  leave us worse off than having no gate. So the unit of enforcement is "this
+  diff introduced a new unlabelled control".
+
+* **Carry-over suppression.** A violation whose control declaration is textually
+  identical to one already present in the base version of the same file is not
+  reported, so reformatting / moving / re-indenting known-bad code does not
+  suddenly light up. Matching is a multiset over ``(kind, normalised head
+  line)``: copy an unlabelled control a second time and the copy IS reported.
+
+* **Precision over recall.** A gate that cries wolf gets ignored, and an ignored
+  gate is worse than none because it manufactures confidence. Where the two
+  trade off, this script chooses to miss. Concretely it walks the real postfix
+  chain of each control (balanced delimiters over a comment/string-masked copy
+  of the source), so an identifier attached five modifiers later still counts,
+  and it deliberately skips ``Commands`` scenes (the AX driver never walks the
+  menu bar). What it does not detect is listed under "Known blind spots" below.
+
+* **An escape hatch that costs something.** SwiftUI ``confirmationDialog`` /
+  ``alert`` buttons genuinely cannot be reached this way. Those get an explicit,
+  greppable marker with a written reason on the same line::
+
+      Button("Allow once") { … }  // ax-exempt: confirmationDialog buttons live
+                                  // outside the app's AX tree
+
+  ``rg ax-exempt apps/rapid-mac`` enumerates every one of them. A marker with no
+  reason (or a one-word reason) is itself a failure, so the cost cannot be
+  dodged by typing ``// ax-exempt:`` and moving on.
+
+Known blind spots (deliberate — each would cost more false positives than it
+buys):
+
+* interactivity bolted onto a non-control view (``.onTapGesture``, ``.gesture``,
+  ``.contextMenu``, ``.swipeActions``, ``.draggable``);
+* bespoke ``View`` structs that are interactive without literally naming a
+  SwiftUI control type at the point of use (the wrapper's own ``Button`` is
+  still checked where the wrapper is *defined*);
+* AppKit surfaces bridged through ``NSViewRepresentable`` (the chat composer's
+  ``AutosizingTextView`` is the app's real example);
+* ``Commands`` / menu-bar items, skipped on purpose;
+* a control whose identifier is applied to an enclosing container rather than
+  the control itself — reported, because ``AXPress`` needs the control.
+
+Pure-logic core (``mask_source`` / ``find_violations``) is unit-tested in
+tests/test_rapid_mac_ax_identifiers.py — no network, no Swift toolchain, no GPU.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Only the app's shipping UI. Tests, scripts and the crash handler are out of
+# scope: nothing there renders a control a golden flow needs to drive.
+SCOPE_PREFIX = "apps/rapid-mac/Sources/"
+
+# SwiftUI control types a golden flow has to drive or assert on. Static text,
+# spacers, shapes and decorative images are intentionally absent — labelling
+# those would be noise, and the harness asserts on their *text*, not their id.
+CONTROL_KINDS = (
+    "Button",
+    "Toggle",
+    "Picker",
+    "DatePicker",
+    "ColorPicker",
+    "TextField",
+    "SecureField",
+    "TextEditor",
+    "Menu",
+    "Stepper",
+    "Slider",
+    "NavigationLink",
+    "Link",
+)
+
+# ``(?<![A-Za-z0-9_.])`` keeps ``SendButton``, ``pickerStyle`` and
+# ``Foo.Button`` out; the trailing ``[({]`` keeps type references
+# (``Button<Label>``, ``struct Button: View``) out. What is left is a control
+# being *constructed*.
+_CONTROL_RE = re.compile(r"(?<![A-Za-z0-9_.])(" + "|".join(CONTROL_KINDS) + r")\s*[({]")
+
+# Scenes whose contents the AX driver never walks. ``rapid-ax.swift`` skips
+# every non-window child of the application element precisely so the global menu
+# bar stays out of the dumps, and ``gui-golden-flows.sh`` drives menus by title
+# through ``peekaboo menu click``. An identifier on a command item would be
+# decoration, so requiring one would be a pure false positive.
+_COMMAND_SCOPE_RE = re.compile(
+    r"(?<![A-Za-z0-9_.])(?:CommandGroup|CommandMenu)\s*\(|\.commands\s*\{"
+)
+
+# ``func makeBody(configuration:)`` is the ButtonStyle / ToggleStyle /
+# LabelStyle protocol requirement. A control built in there is the *rendering*
+# of whatever control the caller declared — ``TrailingSettingsToggleStyle`` is
+# the app's live example. An identifier here would be stamped onto every toggle
+# that adopts the style, which is worse than none, so the caller is the only
+# correct place to put it and this scope is skipped.
+_STYLE_BODY_RE = re.compile(
+    r"(?<![A-Za-z0-9_.])func\s+makeBody\s*(\()\s*configuration\s*:"
+)
+
+_IDENTIFIER_RE = re.compile(r"\.accessibilityIdentifier\s*\(")
+
+EXEMPT_MARKER = "ax-exempt:"
+# No ``$`` anchor: ``.`` already stops at a newline, and a block comment's
+# captured text can carry one, which an anchored pattern would refuse to match.
+_EXEMPT_RE = re.compile(re.escape(EXEMPT_MARKER) + r"(.*)")
+
+# A reason has to actually be a reason. Ten characters is roughly "two words",
+# which is the floor at which the marker starts carrying information for the
+# next reviewer instead of just silencing the gate.
+MIN_EXEMPT_REASON_CHARS = 10
+
+_IDENT_START = re.compile(r"[A-Za-z_]")
+_TRAILING_LABEL_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*\s*:\s*\{")
+_STRING_OPEN_RE = re.compile(r'(#*)("""|")')
+
+_OPENERS = {"(": ")", "[": "]", "{": "}"}
+_CLOSERS = {")", "]", "}"}
+
+
+@dataclass(frozen=True)
+class Violation:
+    """One added interactive control with no reachable identifier."""
+
+    path: str
+    line: int  # 1-based, the line the control is declared on
+    kind: str
+    source: str  # the declaration line, stripped
+    reason: str  # why it failed ("no accessibility identifier" / bad marker)
+
+    @property
+    def key(self) -> tuple[str, str]:
+        """Identity used for carry-over suppression against the base revision.
+
+        Whitespace is collapsed so a re-indent or a line re-wrap does not read
+        as a brand-new control.
+        """
+        return (self.kind, re.sub(r"\s+", " ", self.source).strip())
+
+    def __str__(self) -> str:
+        return f"{self.path}:{self.line}: {self.kind} — {self.reason}"
+
+
+# --------------------------------------------------------------------------
+# Lexing: mask comments and string literals so the structural scan below can
+# trust every brace, paren and dot it sees.
+# --------------------------------------------------------------------------
+
+
+def mask_source(src: str) -> tuple[str, dict[int, str]]:
+    """Blank out comments and string literals, preserving offsets and newlines.
+
+    Returns ``(masked, comments_by_line)``. ``masked`` has the exact same length
+    and line structure as ``src`` — every comment/string character becomes a
+    space — so a match offset in ``masked`` is a valid offset in ``src``.
+    ``comments_by_line`` maps a 1-based line number to the comment text found on
+    it, which is where ``ax-exempt:`` markers are looked for.
+
+    Handles Swift's line comments, *nested* block comments, escapes, string
+    interpolation (treated as string content: we never need to find a control
+    inside ``\\(…)``), multi-line ``\"\"\"`` literals, and raw strings with any
+    number of ``#`` delimiters.
+    """
+    out = list(src)
+    comments: dict[int, list[str]] = {}
+    n = len(src)
+    i = 0
+    line = 1
+    block_depth = 0
+    # Context stack: ("str", hashes, multiline) or ("interp", paren_depth).
+    stack: list[tuple] = []
+
+    def blank(start: int, stop: int) -> None:
+        nonlocal line
+        for k in range(start, min(stop, n)):
+            if src[k] == "\n":
+                line += 1
+            else:
+                out[k] = " "
+
+    def in_string() -> bool:
+        return any(frame[0] == "str" for frame in stack)
+
+    while i < n:
+        if block_depth > 0:
+            if src.startswith("/*", i):
+                block_depth += 1
+                blank(i, i + 2)
+                i += 2
+                continue
+            if src.startswith("*/", i):
+                block_depth -= 1
+                blank(i, i + 2)
+                i += 2
+                continue
+            comments.setdefault(line, []).append(src[i])
+            blank(i, i + 1)
+            i += 1
+            continue
+
+        top = stack[-1] if stack else None
+        if top is not None and top[0] == "str":
+            _, hashes, multiline = top
+            escape = "\\" + "#" * hashes
+            if src.startswith(escape + "(", i):
+                blank(i, i + len(escape) + 1)
+                stack.append(("interp", 1))
+                i += len(escape) + 1
+                continue
+            if src.startswith(escape, i):
+                blank(i, i + len(escape) + 1)
+                i += len(escape) + 1
+                continue
+            closer = ('"""' if multiline else '"') + "#" * hashes
+            if src.startswith(closer, i):
+                blank(i, i + len(closer))
+                stack.pop()
+                i += len(closer)
+                continue
+            blank(i, i + 1)
+            i += 1
+            continue
+
+        # Normal code — either at top level or inside a ``\(…)`` interpolation.
+        # Interpolation contents are still blanked (``in_string()`` is true),
+        # but they are lexed properly so a nested literal cannot desync us.
+        if src.startswith("//", i):
+            end = src.find("\n", i)
+            end = n if end == -1 else end
+            comments.setdefault(line, []).append(src[i:end])
+            blank(i, end)
+            i = end
+            continue
+        if src.startswith("/*", i):
+            block_depth = 1
+            blank(i, i + 2)
+            i += 2
+            continue
+
+        opener = _STRING_OPEN_RE.match(src, i)
+        if opener:
+            hashes = len(opener.group(1))
+            multiline = opener.group(2) == '"""'
+            blank(i, opener.end())
+            stack.append(("str", hashes, multiline))
+            i = opener.end()
+            continue
+
+        ch = src[i]
+        if top is not None and top[0] == "interp":
+            if ch == "(":
+                stack[-1] = ("interp", top[1] + 1)
+            elif ch == ")":
+                if top[1] <= 1:
+                    stack.pop()
+                else:
+                    stack[-1] = ("interp", top[1] - 1)
+
+        if in_string():
+            blank(i, i + 1)
+        elif ch == "\n":
+            line += 1
+        i += 1
+
+    # Block comments accumulate one character per entry while line comments
+    # arrive whole, so the parts are joined with nothing between them — a
+    # separator here would shred "ax-exempt:" inside a /* … */ into letters and
+    # make the marker silently unrecognisable in block-comment form.
+    return "".join(out), {ln: "".join(parts) for ln, parts in comments.items()}
+
+
+# --------------------------------------------------------------------------
+# Structural scan over the masked source.
+# --------------------------------------------------------------------------
+
+
+def _consume_balanced(masked: str, start: int) -> int:
+    """Return the offset just past the delimiter group opening at ``start``."""
+    stack = [_OPENERS[masked[start]]]
+    i = start + 1
+    n = len(masked)
+    while i < n and stack:
+        ch = masked[i]
+        if ch in _OPENERS:
+            stack.append(_OPENERS[ch])
+        elif ch in _CLOSERS:
+            if ch == stack[-1]:
+                stack.pop()
+            else:
+                # Unbalanced (or something the mask got wrong). Bail rather
+                # than run to EOF and swallow the rest of the file.
+                return i + 1
+        i += 1
+    return i
+
+
+def _skip_space(masked: str, i: int) -> int:
+    n = len(masked)
+    while i < n and masked[i].isspace():
+        i += 1
+    return i
+
+
+def _expression_end(masked: str, delim: int) -> int:
+    """Walk a control's whole postfix expression: trailing closures + modifiers.
+
+    ``delim`` is the ``(`` or ``{`` that opens the constructor. The walk stops
+    at the first token that cannot continue a postfix chain, which in a
+    ``@ViewBuilder`` body is the next sibling view or the closing brace. Erring
+    toward consuming slightly too much is deliberate: over-consuming can only
+    cause a miss, under-consuming causes a false alarm.
+    """
+    i = _consume_balanced(masked, delim)
+    n = len(masked)
+    while True:
+        j = _skip_space(masked, i)
+        if j >= n:
+            return i
+        ch = masked[j]
+        if ch in _OPENERS:
+            i = _consume_balanced(masked, j)
+            continue
+        if ch in "?!":
+            i = j + 1
+            continue
+        if ch == ".":
+            k = j + 1
+            if k < n and _IDENT_START.match(masked[k]):
+                while k < n and (masked[k].isalnum() or masked[k] == "_"):
+                    k += 1
+                i = k
+                continue
+            return i
+        # Swift's second (and later) trailing closure: ``} label: { … }``.
+        label = _TRAILING_LABEL_RE.match(masked, j)
+        if label:
+            i = _consume_balanced(masked, label.end() - 1)
+            continue
+        return i
+
+
+def _skipped_scopes(masked: str) -> list[tuple[int, int]]:
+    """Char ranges whose controls are deliberately not required to be labelled."""
+    spans: list[tuple[int, int]] = []
+    for m in _COMMAND_SCOPE_RE.finditer(masked):
+        delim = m.end() - 1
+        if masked[delim] in _OPENERS:
+            spans.append((m.start(), _expression_end(masked, delim)))
+    for m in _STYLE_BODY_RE.finditer(masked):
+        after_args = _consume_balanced(masked, m.start(1))
+        body = masked.find("{", after_args)
+        if body != -1:
+            spans.append((m.start(), _consume_balanced(masked, body)))
+    return spans
+
+
+def _exemption(comments: dict[int, str], head_line: int) -> tuple[bool, str | None]:
+    """Look for an ``ax-exempt:`` marker on the control's line or the line above.
+
+    Returns ``(found, reason)``. ``reason`` is ``None`` when the marker is there
+    but the written justification is missing or too thin — which is a failure in
+    its own right, not a pass.
+    """
+    for candidate in (head_line, head_line - 1):
+        text = comments.get(candidate)
+        if not text:
+            continue
+        m = _EXEMPT_RE.search(text)
+        if not m:
+            continue
+        reason = m.group(1).strip().lstrip("-—:").strip()
+        if len(reason) < MIN_EXEMPT_REASON_CHARS:
+            return True, None
+        return True, reason
+    return False, None
+
+
+def find_violations(path: str, src: str) -> list[Violation]:
+    """Every interactive control in ``src`` with no reachable identifier."""
+    masked, comments = mask_source(src)
+    lines = src.splitlines()
+    skipped = _skipped_scopes(masked)
+    violations: list[Violation] = []
+
+    for m in _CONTROL_RE.finditer(masked):
+        start = m.start()
+        if any(lo <= start < hi for lo, hi in skipped):
+            continue
+        delim = m.end() - 1
+        end = _expression_end(masked, delim)
+        if _IDENTIFIER_RE.search(masked, start, end):
+            continue
+
+        head_line = masked.count("\n", 0, start) + 1
+        marked, reason = _exemption(comments, head_line)
+        if marked and reason:
+            continue
+
+        source = lines[head_line - 1].strip() if head_line <= len(lines) else ""
+        if marked:
+            why = (
+                f"'{EXEMPT_MARKER}' marker with no usable reason — write at least "
+                f"{MIN_EXEMPT_REASON_CHARS} characters saying why this control "
+                "cannot carry an identifier"
+            )
+        else:
+            why = "no .accessibilityIdentifier(…) on this control"
+        violations.append(
+            Violation(
+                path=path,
+                line=head_line,
+                kind=m.group(1),
+                source=source,
+                reason=why,
+            )
+        )
+    return violations
+
+
+# --------------------------------------------------------------------------
+# git plumbing
+# --------------------------------------------------------------------------
+
+
+def _git(*args: str) -> str:
+    return subprocess.run(
+        ["git", *args],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+
+
+def _merge_base(base_ref: str, head_ref: str) -> str:
+    return _git("merge-base", base_ref, head_ref).strip()
+
+
+def changed_swift_files(base: str, head: str) -> dict[str, str]:
+    """Map each changed in-scope Swift file to the path it had on ``base``.
+
+    Rename-aware (``-M``): a file renamed in the PR is compared against its
+    pre-rename blob, so moving a panel full of known-unlabelled controls is not
+    read as adding a panel full of new ones. Deletions are dropped — there is
+    nothing left to label.
+    """
+    out = _git(
+        "diff",
+        "--name-status",
+        "-M",
+        "--diff-filter=ACMR",
+        base,
+        head,
+        "--",
+        SCOPE_PREFIX,
+    )
+    paths: dict[str, str] = {}
+    for raw in out.splitlines():
+        fields = raw.split("\t")
+        status = fields[0]
+        if status.startswith("R") and len(fields) >= 3:
+            old, new = fields[1], fields[2]
+        else:
+            old = new = fields[-1]
+        if new.endswith(".swift"):
+            paths[new] = old
+    return paths
+
+
+_HUNK_RE = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@")
+
+
+def added_lines(base: str, head: str, path: str) -> set[int]:
+    """1-based line numbers added to ``path`` between ``base`` and ``head``."""
+    diff = _git("diff", "--unified=0", "-M", base, head, "--", path)
+    added: set[int] = set()
+    for raw in diff.splitlines():
+        m = _HUNK_RE.match(raw)
+        if m:
+            start = int(m.group(1))
+            count = 1 if m.group(2) is None else int(m.group(2))
+            added.update(range(start, start + count))
+    return added
+
+
+def _blob(rev: str, path: str) -> str | None:
+    proc = subprocess.run(
+        ["git", "show", f"{rev}:{path}"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+    )
+    return proc.stdout if proc.returncode == 0 else None
+
+
+def suppress_carried(
+    head_violations: list[Violation],
+    base_violations: list[Violation],
+    touched: set[int],
+) -> list[Violation]:
+    """Report the head violations this diff is actually responsible for.
+
+    Multiset arithmetic over the WHOLE file, not just the added lines: the base
+    revision funds a fixed number of violations per ``(kind, normalised line)``,
+    and only the excess is new. Move or re-indent an existing unlabelled control
+    and it is absorbed; duplicate one and the copy is reported, because the base
+    only funds one of the two.
+
+    Untouched occurrences claim the base budget first. They are carried over by
+    definition, so letting an *added* line spend the budget instead — which is
+    what happens with a naive in-order walk when the copy lands above the
+    original — would launder a genuine duplication into a pass.
+    """
+    budget = Counter(v.key for v in base_violations)
+    for v in head_violations:
+        if v.line not in touched and budget[v.key] > 0:
+            budget[v.key] -= 1
+
+    kept: list[Violation] = []
+    for v in head_violations:
+        if v.line not in touched:
+            continue
+        if budget[v.key] > 0:
+            budget[v.key] -= 1
+            continue
+        kept.append(v)
+    return kept
+
+
+def new_violations(base: str, head: str, path: str, base_path: str) -> list[Violation]:
+    """Violations this diff is responsible for, in one file.
+
+    Two filters, in order: the control must be declared on a line this diff
+    added, and it must not be a carry-over of an identical violation that
+    already existed in the base revision of the same file.
+    """
+    head_src = _blob(head, path)
+    if head_src is None:
+        return []
+    touched = added_lines(base, head, path)
+    head_violations = find_violations(path, head_src)
+    candidates = [v for v in head_violations if v.line in touched]
+    if not candidates:
+        return []
+
+    base_src = _blob(base, base_path)
+    if base_src is None:  # new file — everything in it is this PR's doing
+        return candidates
+    return suppress_carried(head_violations, find_violations(path, base_src), touched)
+
+
+# --------------------------------------------------------------------------
+# CLI
+# --------------------------------------------------------------------------
+
+
+def _report(violations: list[Violation]) -> None:
+    for v in violations:
+        print(f"::error file={v.path},line={v.line}::{v.kind}: {v.reason}")
+        print(f"  {v.path}:{v.line}")
+        print(f"    {v.source}")
+        print(f"    -> {v.reason}")
+
+
+_FAIL_ADVICE = f"""
+[ax-identifier-gate] BLOCKED — the controls above are new and cannot be reached
+by apps/rapid-mac/scripts/gui-golden-flows.sh, which finds every element through
+AXIdentifier (see apps/rapid-mac/docs/gui-golden-flows.md). Shipping them
+unlabelled quietly lowers what the GUI suite is able to cover.
+
+Fix — attach a stable identifier to the control itself, matching the existing
+'<Surface>.<Thing>' convention inventoried in apps/rapid-mac/docs/userflows.md:
+
+    Toggle("Browse", isOn: $on)
+        .accessibilityIdentifier("Settings.Tools.BrowseToggle")
+
+If the control genuinely cannot carry one — SwiftUI confirmationDialog / alert
+buttons are the known case — opt out explicitly, with a reason, on the control's
+line or the line directly above it:
+
+    // {EXEMPT_MARKER} confirmationDialog buttons render outside the app's AX tree
+    Button("Allow once") {{ approve() }}
+
+Every opt-out is greppable: rg '{EXEMPT_MARKER}' apps/rapid-mac
+"""
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Fail when a PR adds an interactive rapid-mac control with no "
+            ".accessibilityIdentifier(…)."
+        )
+    )
+    parser.add_argument(
+        "--base-ref",
+        default="origin/main",
+        help="branch the PR targets (default: origin/main)",
+    )
+    parser.add_argument(
+        "--head-ref",
+        default="HEAD",
+        help=(
+            "revision under test (default: HEAD). Together with --base-ref this "
+            "replays the gate over any historical commit: "
+            "--base-ref <sha>~1 --head-ref <sha>"
+        ),
+    )
+    parser.add_argument(
+        "--audit",
+        action="store_true",
+        help=(
+            "ignore the diff and report EVERY unlabelled control under "
+            f"{SCOPE_PREFIX} — the existing backlog, not the gate"
+        ),
+    )
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        help="with --audit, restrict the sweep to these files",
+    )
+    args = parser.parse_args(argv)
+
+    if args.audit:
+        files = args.paths or sorted(
+            str(p.relative_to(REPO_ROOT))
+            for p in (REPO_ROOT / SCOPE_PREFIX).rglob("*.swift")
+        )
+        found: list[Violation] = []
+        for path in files:
+            src = (REPO_ROOT / path).read_text(encoding="utf-8")
+            found.extend(find_violations(path, src))
+        for v in found:
+            print(str(v))
+        print(f"\n[ax-identifier-gate] audit: {len(found)} unlabelled control(s)")
+        return 1 if found else 0
+
+    base = _merge_base(args.base_ref, args.head_ref)
+    files = changed_swift_files(base, args.head_ref)
+    if not files:
+        print(
+            f"[ax-identifier-gate] no {SCOPE_PREFIX} Swift files changed "
+            "— nothing to check."
+        )
+        return 0
+
+    print(f"[ax-identifier-gate] base {base[:12]}, {len(files)} changed file(s):")
+    for path in sorted(files):
+        print(f"    {path}")
+
+    violations: list[Violation] = []
+    for path, base_path in sorted(files.items()):
+        violations.extend(new_violations(base, args.head_ref, path, base_path))
+
+    if not violations:
+        print(
+            "[ax-identifier-gate] PASS — every control this PR adds is "
+            "reachable by AXIdentifier."
+        )
+        return 0
+
+    _report(violations)
+    print(_FAIL_ADVICE, file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_rapid_mac_ax_identifiers.py
+++ b/scripts/check_rapid_mac_ax_identifiers.py
@@ -16,16 +16,24 @@ elements that no automated flow can reach. ``docs/userflows.md`` has also carrie
 
 Design decisions, and why each one is the way it is:
 
-* **Added lines only.** The existing backlog is real and is tracked separately.
-  A gate that fails on it would be un-landable, get disabled inside a week, and
-  leave us worse off than having no gate. So the unit of enforcement is "this
-  diff introduced a new unlabelled control".
+* **This diff's doing, not the backlog's.** The existing backlog is real and is
+  tracked separately. A gate that fails on it would be un-landable, get disabled
+  inside a week, and leave us worse off than having no gate. Two things count as
+  this diff's doing: declaring an unlabelled control on a line it added, and
+  taking the identifier off one that had it — which lowers the harness's ceiling
+  just as much, and is the easier accident, since the declaration line does not
+  change and an added-lines filter never looks at it.
 
-* **Carry-over suppression.** A violation whose control declaration is textually
-  identical to one already present in the base version of the same file is not
-  reported, so reformatting / moving / re-indenting known-bad code does not
-  suddenly light up. Matching is a multiset over ``(kind, normalised head
-  line)``: copy an unlabelled control a second time and the copy IS reported.
+* **Carry-over suppression is per hunk.** A violation identical to one the SAME
+  hunk removed is absorbed, so re-indenting / re-wrapping / re-ordering
+  known-bad code does not suddenly light up. Deliberately not a file-wide
+  budget: that let labelling a control in one place pay for a genuinely new
+  unlabelled one somewhere else, and the PR came out green having both fixed and
+  broken one. The cost is that moving an unlabelled control across a file reads
+  as new — the same answer this gate already gave for extracting it into a new
+  file, and the fix it asks for is the one we want anyway. Identity is the
+  declaration line with trailing comments removed, so re-wording a comment does
+  not rename a control.
 
 * **Precision over recall.** A gate that cries wolf gets ignored, and an ignored
   gate is worse than none because it manufactures confidence. Where the two
@@ -35,30 +43,75 @@ Design decisions, and why each one is the way it is:
   and it deliberately skips ``Commands`` scenes (the AX driver never walks the
   menu bar). What it does not detect is listed under "Known blind spots" below.
 
-* **An escape hatch that costs something.** SwiftUI ``confirmationDialog`` /
-  ``alert`` buttons genuinely cannot be reached this way. Those get an explicit,
-  greppable marker with a written reason on the same line::
+* **An escape hatch that costs something.** A control that genuinely cannot
+  carry an identifier gets an explicit, greppable marker with a written reason
+  on the same line::
 
-      Button("Allow once") { … }  // ax-exempt: confirmationDialog buttons live
-                                  // outside the app's AX tree
+      Button("Allow once") { … }  // ax-exempt: <what you measured that shows
+                                  // the identifier cannot be reached>
 
-  ``rg ax-exempt apps/rapid-mac`` enumerates every one of them. A marker with no
-  reason (or a one-word reason) is itself a failure, so the cost cannot be
-  dodged by typing ``// ax-exempt:`` and moving on.
+  No such control is known on the current surface. ``confirmationDialog`` /
+  ``alert`` buttons were the standing suspicion, and it was measured rather than
+  inherited: the presented dialog is an ``AXSheet`` whose ``AXButton`` children
+  DO carry the identifiers declared at the call site (see ``docs/userflows.md``).
+  So ``rg ax-exempt apps/rapid-mac`` finding nothing is the expected state, and
+  an exemption has to bring new evidence. A marker with no reason (or a one-word
+  reason) is itself a failure, so the cost cannot be dodged by typing
+  ``// ax-exempt:`` and moving on.
 
 Known blind spots (deliberate — each would cost more false positives than it
 buys):
 
 * interactivity bolted onto a non-control view (``.onTapGesture``, ``.gesture``,
   ``.contextMenu``, ``.swipeActions``, ``.draggable``);
+* a control built through Swift's *contextual* member lookup, where the type
+  and the constructor are in different places::
+
+      let saveButton: Button<Text> = .init(action: save) { Text("Save") }
+
+  ``Button<Text>`` there is a type annotation and ``.init`` names no control,
+  so neither half looks like a construction. Detecting it means resolving types,
+  which this lint does not do, and guessing at a bare ``.init(`` would fire on
+  every non-control initializer in the app;
+* an EXPLICITLY generic control built with a trailing closure and no parens
+  (``Button<Text> { save() } label: { … }``). After a generic argument list only
+  ``(`` counts, because ``var b: Button<Text> {`` is a return type followed by a
+  property body and reading that brace as a constructor blocked PRs whose real
+  control was labelled. Spelling the generic out is unnecessary and
+  non-idiomatic here — SwiftUI infers it — so the miss costs less than the
+  false alarm did;
 * bespoke ``View`` structs that are interactive without literally naming a
   SwiftUI control type at the point of use (the wrapper's own ``Button`` is
   still checked where the wrapper is *defined*);
 * AppKit surfaces bridged through ``NSViewRepresentable`` (the chat composer's
   ``AutosizingTextView`` is the app's real example);
 * ``Commands`` / menu-bar items, skipped on purpose;
+* an identifier attached to a *parenthesised* control
+  (``(Button(…)).accessibilityIdentifier(…)``) — the balanced walk stops at the
+  enclosing ``)``, so the control is reported. Making those parens transparent
+  requires deciding whether a ``(`` is grouping or an argument list, which the
+  preceding character cannot answer (a closure call ends in ``}``; ``return``
+  ends in a letter), and both attempts produced something worse than the miss —
+  including crediting ``Card(Button(…))``'s identifier to the Button, the exact
+  defect this gate exists to catch. Attach the identifier to the control;
+* moving a file AND adding a new one at its old path in the same PR. ``-M``
+  cannot pair that (the source path still exists), and ``-C`` would — but
+  ``-C`` cannot tell it apart from *adding a copy of an existing file*, which is
+  genuinely new unlabelled surface. The moved file's backlog is reported. Label
+  it, or split the move and the replacement into two PRs;
+* laundering a new gap through a fix in the SAME hunk. Carry-over is a count
+  within one hunk, so replacing an unlabelled control with a labelled one AND
+  an unlabelled one, all inside the same run of changed lines, nets to zero and
+  passes. Distinguishing "the same control moved" from "one fixed, one added"
+  needs per-line identity that a text diff does not carry. The window is
+  narrow — with zero context a hunk is exactly the changed lines, so the two
+  edits have to be adjacent — and the file-wide version of this hole (fix
+  anywhere funds a regression anywhere) is closed;
 * a control whose identifier is applied to an enclosing container rather than
-  the control itself — reported, because ``AXPress`` needs the control.
+  the control itself — reported, because ``AXPress`` needs the control. The
+  mirror image is reported too: an identifier on a control NESTED inside an
+  unlabelled one does not label the parent, because the parent's own postfix
+  chain is what is searched.
 
 Pure-logic core (``mask_source`` / ``find_violations``) is unit-tested in
 tests/test_rapid_mac_ax_identifiers.py — no network, no Swift toolchain, no GPU.
@@ -71,7 +124,7 @@ import re
 import subprocess
 import sys
 from collections import Counter
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -93,17 +146,64 @@ CONTROL_KINDS = (
     "SecureField",
     "TextEditor",
     "Menu",
+    "DisclosureGroup",
     "Stepper",
     "Slider",
     "NavigationLink",
     "Link",
+    # First-party controls that render a real, pressable element. Omitting them
+    # made the docstring's claim — that everything undetected is listed under
+    # "Known blind spots" — untrue: ``ShareLink(item:)`` is an ordinary button
+    # to a user and was invisible to the gate.
+    "ShareLink",
+    "SettingsLink",
+    "HelpLink",
+    "PasteButton",
+    "EditButton",
+    "RenameButton",
+    "MultiDatePicker",
 )
 
-# ``(?<![A-Za-z0-9_.])`` keeps ``SendButton``, ``pickerStyle`` and
-# ``Foo.Button`` out; the trailing ``[({]`` keeps type references
-# (``Button<Label>``, ``struct Button: View``) out. What is left is a control
-# being *constructed*.
-_CONTROL_RE = re.compile(r"(?<![A-Za-z0-9_.])(" + "|".join(CONTROL_KINDS) + r")\s*[({]")
+# ``(?<![A-Za-z0-9_])`` keeps ``SendButton`` and ``pickerStyle`` out; the
+# trailing ``[({]`` keeps type references (``Button<Label>``, ``struct Button:
+# View``) out. What is left is a control being *constructed*.
+#
+# The dot is deliberately NOT in the lookbehind. ``SwiftUI.Button(…)`` IS the
+# control, and a dot-rejecting lookbehind let a fully qualified construction
+# walk straight past the gate — but spelling the qualifier into the pattern
+# instead (``(?:SwiftUI\s*\.\s*)?``) is worse than useless: the optional group
+# simply does not participate, the match starts at ``Button`` either way, and
+# ``Chrome . Button`` matches too (whitespace may surround Swift member access),
+# falsely blocking somebody else's type that happens to share a name. So the
+# pattern is permissive and ``_qualifier_before`` decides in code.
+# ``Button<Text>(action:)`` and ``Button.init("Save", action:)`` are ordinary
+# constructions that a name-then-delimiter pattern walks straight past. One
+# level of nested generics is enough for real SwiftUI (``Button<Label<Text>>``);
+# beyond that the pattern gives up rather than guess.
+#
+# After a generic argument list ONLY ``(`` counts. ``{`` there is a property
+# body, not a constructor::
+#
+#     private var saveButton: Button<Text> {   // <- return type, then a body
+#         Button("Save") { save() }
+#             .accessibilityIdentifier("Toolbar.Save")
+#     }
+#
+# Reading that as a construction reported a phantom unlabelled Button and
+# blocked a PR whose real control was correctly labelled. Nobody writes
+# ``Button<Text> { … }`` as a construction — the generic is inferred — so
+# requiring the paren costs nothing and removes the whole false-positive class.
+_CONTROL_RE = re.compile(
+    r"(?<![A-Za-z0-9_])("
+    + "|".join(CONTROL_KINDS)
+    + r")\s*(?:"
+    + r"<(?:[^<>]|<[^<>]*>)*>\s*(?:\.\s*init\s*)?\("  # generic: paren only
+    + r"|(?:\.\s*init\s*)?[({]"  # bare: paren or trailing closure
+    + r")"
+)
+
+# The only namespace whose ``X.Button(…)`` is the SwiftUI control.
+QUALIFIER_ALLOWED = "SwiftUI"
 
 # Scenes whose contents the AX driver never walks. ``rapid-ax.swift`` skips
 # every non-window child of the application element precisely so the global menu
@@ -124,7 +224,10 @@ _STYLE_BODY_RE = re.compile(
     r"(?<![A-Za-z0-9_.])func\s+makeBody\s*(\()\s*configuration\s*:"
 )
 
-_IDENTIFIER_RE = re.compile(r"\.accessibilityIdentifier\s*\(")
+# The one modifier that makes a control reachable. Named ONCE: every message,
+# every docstring and the matcher itself derive from this, so there is no
+# second literal to fall out of step with the check.
+IDENTIFIER_MODIFIER = "accessibilityIdentifier"
 
 EXEMPT_MARKER = "ax-exempt:"
 # No ``$`` anchor: ``.`` already stops at a newline, and a block comment's
@@ -174,6 +277,12 @@ class Violation:
 
 
 def mask_source(src: str) -> tuple[str, dict[int, str]]:
+    """``(masked, comments_by_line)`` — see ``_mask`` for the full contract."""
+    masked, comments, _ = _mask(src)
+    return masked, comments
+
+
+def _mask(src: str) -> tuple[str, dict[int, str], dict[int, set[int]]]:
     """Blank out comments and string literals, preserving offsets and newlines.
 
     Returns ``(masked, comments_by_line)``. ``masked`` has the exact same length
@@ -189,6 +298,34 @@ def mask_source(src: str) -> tuple[str, dict[int, str]]:
     """
     out = list(src)
     comments: dict[int, list[str]] = {}
+    # Every column (0-based) a comment occupies, per line. The carry-over
+    # identity below is the declaration line's *code*, so the comment has to
+    # come out of it — and as a set of columns rather than a truncation point,
+    # because a comment can also LEAD the line::
+    #
+    #     /* old explanation */ Button("Save") { save() }
+    #
+    # Truncating at its start would leave the empty string, which every other
+    # control then matches; keeping the line whole (the earlier compromise)
+    # meant re-wording that comment renamed the control and reported a
+    # long-standing gap as new. Deleting exactly the comment's columns is right
+    # in both positions, and for more than one comment on a line.
+    comment_cols: dict[int, set[int]] = {}
+
+    def note_comment_span(start_at: int, stop_at: int) -> None:
+        # Walks characters so a span crossing a newline lands on the right
+        # line: a block comment is one span in the source and several in the
+        # per-line view this returns.
+        ln = line
+        col = start_at - (src.rfind("\n", 0, start_at) + 1)
+        for k in range(start_at, min(stop_at, n)):
+            if src[k] == "\n":
+                ln += 1
+                col = 0
+                continue
+            comment_cols.setdefault(ln, set()).add(col)
+            col += 1
+
     n = len(src)
     i = 0
     line = 1
@@ -211,15 +348,18 @@ def mask_source(src: str) -> tuple[str, dict[int, str]]:
         if block_depth > 0:
             if src.startswith("/*", i):
                 block_depth += 1
+                note_comment_span(i, i + 2)
                 blank(i, i + 2)
                 i += 2
                 continue
             if src.startswith("*/", i):
                 block_depth -= 1
+                note_comment_span(i, i + 2)
                 blank(i, i + 2)
                 i += 2
                 continue
             comments.setdefault(line, []).append(src[i])
+            note_comment_span(i, i + 1)
             blank(i, i + 1)
             i += 1
             continue
@@ -253,11 +393,13 @@ def mask_source(src: str) -> tuple[str, dict[int, str]]:
         if src.startswith("//", i):
             end = src.find("\n", i)
             end = n if end == -1 else end
+            note_comment_span(i, end)
             comments.setdefault(line, []).append(src[i:end])
             blank(i, end)
             i = end
             continue
         if src.startswith("/*", i):
+            note_comment_span(i, i + 2)
             block_depth = 1
             blank(i, i + 2)
             i += 2
@@ -292,7 +434,11 @@ def mask_source(src: str) -> tuple[str, dict[int, str]]:
     # arrive whole, so the parts are joined with nothing between them — a
     # separator here would shred "ax-exempt:" inside a /* … */ into letters and
     # make the marker silently unrecognisable in block-comment form.
-    return "".join(out), {ln: "".join(parts) for ln, parts in comments.items()}
+    return (
+        "".join(out),
+        {ln: "".join(parts) for ln, parts in comments.items()},
+        comment_cols,
+    )
 
 
 # --------------------------------------------------------------------------
@@ -365,6 +511,85 @@ def _expression_end(masked: str, delim: int) -> int:
         return i
 
 
+def _skip_space_back(masked: str, i: int) -> int:
+    while i >= 0 and masked[i].isspace():
+        i -= 1
+    return i
+
+
+def _has_own_identifier(masked: str, delim: int, end: int) -> bool:
+    """Does the control's OWN postfix chain carry ``.accessibilityIdentifier``?
+
+    Searching the whole ``[start, end)`` span instead lets a *child* label its
+    unlabelled parent, because the span includes trailing-closure bodies::
+
+        Menu("Actions") {                       // <- unlabelled, must fail
+            Button("Rename") { … }
+                .accessibilityIdentifier("Sidebar.Rename")
+        }
+
+    The identifier there belongs to the Button. ``AXPress`` on the Menu has
+    nothing to aim at, so a flow still cannot open it — exactly the blind spot
+    this gate exists to close, silently satisfied by the child.
+
+    So walk the same postfix chain ``_expression_end`` walks, and look only at
+    the ``.name`` tokens it visits at depth 0, stepping OVER every nested
+    delimiter group rather than into it.
+    """
+    i = _consume_balanced(masked, delim)
+    n = len(masked)
+    while i < end:
+        j = _skip_space(masked, i)
+        if j >= end:
+            return False
+        ch = masked[j]
+        if ch in _OPENERS:
+            i = _consume_balanced(masked, j)
+            continue
+        if ch in "?!":
+            i = j + 1
+            continue
+        if ch == ".":
+            k = j + 1
+            if k < n and _IDENT_START.match(masked[k]):
+                name_start = k
+                while k < n and (masked[k].isalnum() or masked[k] == "_"):
+                    k += 1
+                if masked[name_start:k] == IDENTIFIER_MODIFIER:
+                    return True
+                i = k
+                continue
+            return False
+        label = _TRAILING_LABEL_RE.match(masked, j)
+        if label:
+            i = _consume_balanced(masked, label.end() - 1)
+            continue
+        return False
+    return False
+
+
+def _qualifier_before(masked: str, start: int) -> str | None:
+    """The member-access qualifier immediately left of ``start``, if any.
+
+    ``None`` means the control is named bare. Whitespace may surround Swift's
+    member-access dot, so this walks backwards rather than pattern-matching.
+    """
+    dot = _skip_space_back(masked, start - 1)
+    if dot < 0 or masked[dot] != ".":
+        return None
+    end = _skip_space_back(masked, dot - 1)
+    i = end
+    while i >= 0 and (masked[i].isalnum() or masked[i] == "_"):
+        i -= 1
+    name = masked[i + 1 : end + 1] if i < end else ""
+    # The WHOLE qualifier, not its last component: ``Chrome.SwiftUI.Button`` is
+    # somebody's nested namespace, and returning just ``SwiftUI`` would treat it
+    # as the real control and block it.
+    if _skip_space_back(masked, i) >= 0 and masked[_skip_space_back(masked, i)] == ".":
+        return f"<nested>.{name}"
+    return name
+
+
 def _skipped_scopes(masked: str) -> list[tuple[int, int]]:
     """Char ranges whose controls are deliberately not required to be labelled."""
     spans: list[tuple[int, int]] = []
@@ -401,20 +626,38 @@ def _exemption(comments: dict[int, str], head_line: int) -> tuple[bool, str | No
     return False, None
 
 
+def _strip_comments(raw: str, columns: set[int] | None) -> str:
+    """``raw`` with every comment character on the line removed.
+
+    The carry-over identity below is the declaration line's text, so a comment
+    on that line is part of it — meaning *editing the comment* renames the
+    control as far as this gate is concerned, and a long-standing unlabelled
+    control lights up as brand new because somebody reworded a note. Comments
+    have no bearing on whether ``AXPress`` can reach a control, so they are cut
+    out of the identity, wherever on the line they sit.
+    """
+    if not columns:
+        return raw
+    return "".join(ch for col, ch in enumerate(raw) if col not in columns)
+
+
 def find_violations(path: str, src: str) -> list[Violation]:
     """Every interactive control in ``src`` with no reachable identifier."""
-    masked, comments = mask_source(src)
+    masked, comments, comment_cols = _mask(src)
     lines = src.splitlines()
     skipped = _skipped_scopes(masked)
     violations: list[Violation] = []
 
     for m in _CONTROL_RE.finditer(masked):
         start = m.start()
+        qualifier = _qualifier_before(masked, start)
+        if qualifier is not None and qualifier != QUALIFIER_ALLOWED:
+            continue
         if any(lo <= start < hi for lo, hi in skipped):
             continue
         delim = m.end() - 1
         end = _expression_end(masked, delim)
-        if _IDENTIFIER_RE.search(masked, start, end):
+        if _has_own_identifier(masked, delim, end):
             continue
 
         head_line = masked.count("\n", 0, start) + 1
@@ -422,7 +665,8 @@ def find_violations(path: str, src: str) -> list[Violation]:
         if marked and reason:
             continue
 
-        source = lines[head_line - 1].strip() if head_line <= len(lines) else ""
+        raw = lines[head_line - 1] if head_line <= len(lines) else ""
+        source = _strip_comments(raw, comment_cols.get(head_line)).strip()
         if marked:
             why = (
                 f"'{EXEMPT_MARKER}' marker with no usable reason — write at least "
@@ -430,7 +674,7 @@ def find_violations(path: str, src: str) -> list[Violation]:
                 "cannot carry an identifier"
             )
         else:
-            why = "no .accessibilityIdentifier(…) on this control"
+            why = f"no .{IDENTIFIER_MODIFIER}(…) on this control"
         violations.append(
             Violation(
                 path=path,
@@ -469,44 +713,173 @@ def changed_swift_files(base: str, head: str) -> dict[str, str]:
     pre-rename blob, so moving a panel full of known-unlabelled controls is not
     read as adding a panel full of new ones. Deletions are dropped — there is
     nothing left to label.
+
+    ``-M`` only, deliberately — NOT ``-C``. Copy detection would also pair the
+    case ``-M`` cannot see (move ``Panel.swift`` to ``Moved/Panel.swift`` AND
+    add a new ``Panel.swift``, where the source path still exists so git records
+    a modify plus an add), and it does. But it cannot tell that apart from
+    *adding a copy of an existing file*, which is genuinely new unlabelled
+    surface — same ``C src dst`` record, same "source still exists in head",
+    opposite correct answer. Between a false positive on an unusual refactor
+    and silently admitting a whole new panel of unreachable controls, this gate
+    takes the false positive: it is the one failure a contributor can see and
+    fix in seconds, and admitting new unlabelled surface is the exact thing the
+    gate exists to prevent. Listed under "Known blind spots".
     """
     out = _git(
         "diff",
         "--name-status",
         "-M",
+        "-z",
         "--diff-filter=ACMR",
         base,
         head,
         "--",
         SCOPE_PREFIX,
     )
+    # ``-z``: NUL-delimited, so paths arrive verbatim. Line-oriented output
+    # QUOTES anything non-ASCII — ``Résumé.swift`` comes back as
+    # ``"R\303\251sum\303\251.swift"``, whose trailing character is a quote,
+    # so the ``.swift`` test failed and the file was never examined at all.
+    # With ``-z`` a rename is three fields (status, old, new) and everything
+    # else is two, in one flat stream.
+    fields = [f for f in out.split("\0") if f]
     paths: dict[str, str] = {}
-    for raw in out.splitlines():
-        fields = raw.split("\t")
-        status = fields[0]
-        if status.startswith("R") and len(fields) >= 3:
-            old, new = fields[1], fields[2]
+    i = 0
+    while i < len(fields):
+        status = fields[i]
+        if status.startswith("R") and i + 2 < len(fields):
+            old, new = fields[i + 1], fields[i + 2]
+            i += 3
+        elif i + 1 < len(fields):
+            old = new = fields[i + 1]
+            i += 2
         else:
-            old = new = fields[-1]
+            break
         if new.endswith(".swift"):
             paths[new] = old
     return paths
 
 
-_HUNK_RE = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@")
+_HUNK_RE = re.compile(r"^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@")
 
 
-def added_lines(base: str, head: str, path: str) -> set[int]:
-    """1-based line numbers added to ``path`` between ``base`` and ``head``."""
-    diff = _git("diff", "--unified=0", "-M", base, head, "--", path)
-    added: set[int] = set()
+def _unquote_path(raw: str) -> str:
+    """Decode git's C-style quoting of a patch-header path.
+
+    ``changed_swift_files`` reads paths from ``-z`` output, which is verbatim,
+    but a patch HEADER has no NUL form: git writes
+    ``+++ "b/…/R\303\251sum\303\251.swift"`` for anything non-ASCII. Comparing
+    that literal against the decoded path attributed no hunks to the file, so a
+    line inserted above a pre-existing gap in ``Résumé.swift`` shifted it, the
+    carry-over match missed, and the gate announced an identifier removal that
+    never happened.
+    """
+    if not (raw.startswith('"') and raw.endswith('"') and len(raw) >= 2):
+        return raw
+    # Octal escapes are UTF-8 BYTES: decode the escapes to latin-1 code points,
+    # take those back to bytes, then decode as UTF-8.
+    try:
+        return (
+            raw[1:-1]
+            .encode("latin-1", "backslashreplace")
+            .decode("unicode_escape")
+            .encode("latin-1")
+            .decode("utf-8")
+        )
+    except (UnicodeDecodeError, UnicodeEncodeError):
+        return raw
+
+
+@dataclass(frozen=True)
+class Hunk:
+    """One ``--unified=0`` hunk: the base lines it removed paired with the head
+    lines it put in their place. Either side may be empty."""
+
+    base_start: int
+    base_count: int
+    head_start: int
+    head_count: int
+
+    def has_base(self, line: int) -> bool:
+        return self.base_start <= line < self.base_start + self.base_count
+
+    def has_head(self, line: int) -> bool:
+        return self.head_start <= line < self.head_start + self.head_count
+
+
+def diff_hunks(
+    base: str, head: str, path: str, base_path: str | None = None
+) -> list[Hunk]:
+    """The ``--unified=0`` hunks for one file, in order.
+
+    Zero context is what makes a hunk a usable unit of blame: each one is
+    exactly the lines this diff removed paired with exactly the lines it added
+    in their place, with no shared context blurring the boundary.
+
+    BOTH paths go in the pathspec when the file moved, exactly as
+    ``changed_swift_files`` resolved them. ``-M`` can only pair a rename it can
+    see, and a pathspec naming just the destination hides the source: git emits
+    ``new file mode`` with one ``@@ -0,0 +1,N @@``, so moving a panel full of
+    known gaps is reported as adding every one of them.
+
+    Naming two paths means the output can carry two file sections — a move plus
+    a same-named replacement produces both — so hunks are attributed by their
+    ``+++ b/…`` header rather than swept up together. Merging them mixes one
+    file's added lines into another file's budget, which is how a move beside a
+    replacement reported the moved file's entire backlog as new.
+    """
+    paths = [path] if base_path in (None, path) else [base_path, path]
+    diff = _git("diff", "--unified=0", "-M", base, head, "--", *paths)
+    hunks: list[Hunk] = []
+    current: str | None = None
     for raw in diff.splitlines():
+        if raw.startswith("+++ "):
+            target = _unquote_path(raw[4:])
+            current = target[2:] if target.startswith("b/") else target
+            continue
         m = _HUNK_RE.match(raw)
-        if m:
-            start = int(m.group(1))
-            count = 1 if m.group(2) is None else int(m.group(2))
-            added.update(range(start, start + count))
+        if not m or current != path:
+            continue
+        hunks.append(
+            Hunk(
+                base_start=int(m.group(1)),
+                base_count=1 if m.group(2) is None else int(m.group(2)),
+                head_start=int(m.group(3)),
+                head_count=1 if m.group(4) is None else int(m.group(4)),
+            )
+        )
+    return hunks
+
+
+def added_lines(
+    base: str, head: str, path: str, base_path: str | None = None
+) -> set[int]:
+    """1-based line numbers added to ``path`` between ``base`` and ``head``."""
+    added: set[int] = set()
+    for h in diff_hunks(base, head, path, base_path):
+        added.update(range(h.head_start, h.head_start + h.head_count))
     return added
+
+
+def head_line_to_base(hunks: list[Hunk], line: int) -> int:
+    """Where an UNCHANGED head line sat in the base revision.
+
+    Only meaningful for a line no hunk added; every hunk that ends before it
+    shifts it by however many lines that hunk grew or shrank the file.
+
+    ``max(head_count, 1)`` is load-bearing. A pure deletion is ``@@ -7,2 +6,0 @@``
+    — head 6 is the line the deletion follows, NOT a line the hunk covers — so
+    ``head_start + head_count`` is 6 and a naive ``<=`` shifts line 6 itself.
+    That mapped a surviving carried-over violation to the wrong base line, found
+    nothing there, and reported it as an identifier this diff had removed:
+    deleting any labelled control lit up an unrelated control above it.
+    """
+    delta = 0
+    for h in hunks:
+        if line >= h.head_start + max(h.head_count, 1):
+            delta += h.head_count - h.base_count
+    return line - delta
 
 
 def _blob(rev: str, path: str) -> str | None:
@@ -522,57 +895,135 @@ def _blob(rev: str, path: str) -> str | None:
 def suppress_carried(
     head_violations: list[Violation],
     base_violations: list[Violation],
-    touched: set[int],
+    hunks: list[Hunk],
 ) -> list[Violation]:
     """Report the head violations this diff is actually responsible for.
 
-    Multiset arithmetic over the WHOLE file, not just the added lines: the base
-    revision funds a fixed number of violations per ``(kind, normalised line)``,
-    and only the excess is new. Move or re-indent an existing unlabelled control
-    and it is absorbed; duplicate one and the copy is reported, because the base
-    only funds one of the two.
+    Carry-over is decided PER HUNK, not per file. A hunk is the lines this diff
+    removed paired with the lines it put in their place, so an unlabelled
+    control that was re-indented, re-wrapped, re-ordered or had its trailing
+    comment edited is funded by the identical violation the same hunk removed,
+    and is absorbed. Two things a file-wide budget got wrong, each of which let
+    a real regression through:
 
-    Untouched occurrences claim the base budget first. They are carried over by
-    definition, so letting an *added* line spend the budget instead — which is
-    what happens with a naive in-order walk when the copy lands above the
-    original — would launder a genuine duplication into a pass.
+    * **Fixing an old gap must not fund a new one.** Labelling a control in one
+      part of the file removes a violation from the file-wide tally, and the
+      freed budget then absorbed a genuinely new unlabelled control somewhere
+      else — the PR came out green having both fixed and broken one. Budget is
+      local to the hunk that freed it, so a fix in hunk A cannot pay for a
+      regression in hunk B.
+
+    * **Editing a comment must not rename a control.** Identity is the
+      declaration line's text, so re-wording a trailing comment used to make a
+      years-old unlabelled control read as brand new. ``Violation.source`` now
+      excludes trailing comments, so the base and head copies match.
+
+    Untouched head lines are the caller's problem, not this function's: they map
+    back to a base line, and whether *that* line was already a violation is the
+    whole question (see ``_identifier_removals``). They neither claim nor need
+    budget here.
+
+    The deliberate cost: moving an unlabelled control from one part of a file to
+    another lands in two different hunks and IS reported. That is the same
+    answer this gate already gave for extracting it into a new file, and the fix
+    — label the control you just moved, or write an ``ax-exempt:`` reason — is
+    the outcome the gate wants anyway.
     """
-    budget = Counter(v.key for v in base_violations)
-    for v in head_violations:
-        if v.line not in touched and budget[v.key] > 0:
-            budget[v.key] -= 1
+    budget: Counter[tuple[int, tuple[str, str]]] = Counter()
+    for v in base_violations:
+        for i, h in enumerate(hunks):
+            if h.has_base(v.line):
+                budget[(i, v.key)] += 1
+                break
 
     kept: list[Violation] = []
     for v in head_violations:
-        if v.line not in touched:
+        slot = next((i for i, h in enumerate(hunks) if h.has_head(v.line)), None)
+        if slot is None:
             continue
-        if budget[v.key] > 0:
-            budget[v.key] -= 1
+        if budget[(slot, v.key)] > 0:
+            budget[(slot, v.key)] -= 1
             continue
         kept.append(v)
     return kept
 
 
+def _identifier_removals(
+    head_violations: list[Violation],
+    base_violations: list[Violation],
+    hunks: list[Hunk],
+    touched: set[int],
+) -> list[Violation]:
+    """Controls this diff UNLABELLED without touching their declaration line.
+
+    Deleting a ``.accessibilityIdentifier(…)`` takes a control out of the golden
+    flows' reach just as surely as never adding one, and it is the likelier
+    accident: when the modifier sits on its own line — the dominant style in
+    this app — the declaration line does not change at all, so an added-lines
+    filter never even looks at it.
+
+    The test is exact rather than statistical: an unchanged head line sits at a
+    known base line and holds the same text. If the control there is unlabelled
+    now but was not a violation then, this diff is what unlabelled it.
+
+    Matched on ``(base line, key)`` and consumed, not on the line number alone.
+    One line can hold two controls — ``Menu("x") { Button("y") { … } }`` — and a
+    line-only test let the pre-existing gap vouch for its neighbour: delete the
+    identifier off the Menu and the Button already on that line marked the line
+    "known bad", so the newly unreachable Menu was suppressed.
+    """
+    carried: Counter[tuple[int, tuple[str, str]]] = Counter(
+        (v.line, v.key) for v in base_violations
+    )
+    removals: list[Violation] = []
+    for v in head_violations:
+        if v.line in touched:
+            continue
+        slot = (head_line_to_base(hunks, v.line), v.key)
+        if carried[slot] > 0:
+            carried[slot] -= 1
+            continue
+        removals.append(
+            replace(
+                v,
+                reason=(
+                    f"this diff removed the .{IDENTIFIER_MODIFIER}(…) that made "
+                    "this control reachable"
+                ),
+            )
+        )
+    return removals
+
+
 def new_violations(base: str, head: str, path: str, base_path: str) -> list[Violation]:
     """Violations this diff is responsible for, in one file.
 
-    Two filters, in order: the control must be declared on a line this diff
-    added, and it must not be a carry-over of an identical violation that
-    already existed in the base revision of the same file.
+    Two ways to be responsible: declare a new unlabelled control on a line this
+    diff added, or take the identifier off one that already had it.
     """
     head_src = _blob(head, path)
     if head_src is None:
         return []
-    touched = added_lines(base, head, path)
     head_violations = find_violations(path, head_src)
-    candidates = [v for v in head_violations if v.line in touched]
-    if not candidates:
+    if not head_violations:
         return []
 
+    touched = added_lines(base, head, path, base_path)
     base_src = _blob(base, base_path)
-    if base_src is None:  # new file — everything in it is this PR's doing
-        return candidates
-    return suppress_carried(head_violations, find_violations(path, base_src), touched)
+    if base_src is None:
+        # New file — everything in it is this PR's doing. If the diff produced
+        # no hunks at all (``.gitattributes`` marking ``*.swift`` binary is the
+        # way that happens), ``touched`` is empty and filtering by it would
+        # report nothing: a whole new panel of unreachable controls, admitted
+        # in silence. A file that exists only in head has every line added by
+        # definition, so fall back to that rather than to zero.
+        return [v for v in head_violations if not touched or v.line in touched]
+
+    hunks = diff_hunks(base, head, path, base_path)
+    base_violations = find_violations(path, base_src)
+    found = suppress_carried(head_violations, base_violations, hunks)
+    found.extend(_identifier_removals(head_violations, base_violations, hunks, touched))
+    return sorted(found, key=lambda v: v.line)
 
 
 # --------------------------------------------------------------------------
@@ -598,13 +1049,14 @@ Fix — attach a stable identifier to the control itself, matching the existing
 '<Surface>.<Thing>' convention inventoried in apps/rapid-mac/docs/userflows.md:
 
     Toggle("Browse", isOn: $on)
-        .accessibilityIdentifier("Settings.Tools.BrowseToggle")
+        .{IDENTIFIER_MODIFIER}("Settings.Tools.BrowseToggle")
 
-If the control genuinely cannot carry one — SwiftUI confirmationDialog / alert
-buttons are the known case — opt out explicitly, with a reason, on the control's
-line or the line directly above it:
+No control on this surface is currently known to be unable to carry one — the
+confirmationDialog / alert doubt was measured and closed (docs/userflows.md). If
+you have found a real one, opt out explicitly, with the evidence, on the
+control's line or the line directly above it:
 
-    // {EXEMPT_MARKER} confirmationDialog buttons render outside the app's AX tree
+    // {EXEMPT_MARKER} <what you measured that shows it cannot be reached>
     Button("Allow once") {{ approve() }}
 
 Every opt-out is greppable: rg '{EXEMPT_MARKER}' apps/rapid-mac
@@ -615,7 +1067,7 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description=(
             "Fail when a PR adds an interactive rapid-mac control with no "
-            ".accessibilityIdentifier(…)."
+            f".{IDENTIFIER_MODIFIER}(…)."
         )
     )
     parser.add_argument(

--- a/tests/test_rapid_mac_ax_identifiers.py
+++ b/tests/test_rapid_mac_ax_identifiers.py
@@ -410,39 +410,46 @@ def _violation(line: int, source: str) -> gate.Violation:
     )
 
 
+def _hunk(base_start, base_count, head_start, head_count) -> gate.Hunk:
+    return gate.Hunk(base_start, base_count, head_start, head_count)
+
+
 def test_carried_violation_is_suppressed_across_a_reindent():
-    """The declaration line is 'added' by the diff, but it is the same control."""
+    """The declaration line is 'added' by the diff, but it is the same control:
+    the very hunk that added it is the one that removed the original."""
     base = [_violation(10, 'Button("Save") { save() }')]
     head = [_violation(42, 'Button("Save")   { save() }')]
-    assert gate.suppress_carried(head, base, {42}) == []
+    assert gate.suppress_carried(head, base, [_hunk(10, 1, 42, 1)]) == []
 
 
-def test_untouched_violations_are_never_reported():
+def test_untouched_violations_are_never_reported_here():
+    """Nothing outside a hunk is reported by this function; whether an untouched
+    control was just unlabelled is _identifier_removals' question."""
     base = [_violation(10, 'Button("Save") { save() }')]
     head = [_violation(10, 'Button("Save") { save() }')]
-    assert gate.suppress_carried(head, base, set()) == []
+    assert gate.suppress_carried(head, base, []) == []
 
 
 def test_duplicating_a_carried_violation_reports_the_copy():
-    """The base funds ONE unlabelled Save button; the second copy is new."""
+    """The hunk that added line 24 removed nothing, so nothing funds the copy."""
     base = [_violation(10, 'Button("Save") { save() }')]
     head = [
         _violation(10, 'Button("Save") { save() }'),  # untouched original
         _violation(24, 'Button("Save") { save() }'),  # the pasted copy
     ]
-    kept = gate.suppress_carried(head, base, {24})
+    kept = gate.suppress_carried(head, base, [_hunk(23, 0, 24, 1)])
     assert [v.line for v in kept] == [24]
 
 
 def test_copy_pasted_above_the_original_still_reports():
-    """Regression: an in-order walk let the added copy spend the base budget,
-    leaving the untouched original to absorb the blame and the diff to pass."""
+    """Regression: a file-wide budget let the added copy spend it, leaving the
+    untouched original to absorb the blame and the diff to pass."""
     base = [_violation(30, 'Button("Save") { save() }')]
     head = [
         _violation(10, 'Button("Save") { save() }'),  # the pasted copy, added
         _violation(30, 'Button("Save") { save() }'),  # untouched original
     ]
-    kept = gate.suppress_carried(head, base, {10})
+    kept = gate.suppress_carried(head, base, [_hunk(9, 0, 10, 1)])
     assert [v.line for v in kept] == [10]
 
 
@@ -452,7 +459,417 @@ def test_a_genuinely_new_control_survives_suppression():
         _violation(10, 'Button("Save") { save() }'),
         _violation(42, 'Button("Delete") { delete() }'),
     ]
-    assert [v.line for v in gate.suppress_carried(head, base, {42})] == [42]
+    kept = gate.suppress_carried(head, base, [_hunk(41, 0, 42, 1)])
+    assert [v.line for v in kept] == [42]
+
+
+def test_fixing_one_gap_does_not_fund_a_new_one_elsewhere():
+    """Labelling the Save button at line 10 removes a violation from the
+    file-wide tally; a file-wide budget then absorbed the brand-new unlabelled
+    Save button at line 80, and the PR came out green having both fixed and
+    broken one. Budget is local to the hunk that freed it."""
+    base = [_violation(10, 'Button("Save") { save() }')]
+    head = [_violation(80, 'Button("Save") { save() }')]
+    hunks = [
+        _hunk(10, 1, 10, 1),  # the fix: the line rewritten with an identifier
+        _hunk(79, 0, 80, 1),  # the regression: a new unlabelled control
+    ]
+    assert [v.line for v in gate.suppress_carried(head, base, hunks)] == [80]
+
+
+def test_same_hunk_laundering_is_a_known_blind_spot():
+    """Pinned, not endorsed. Inside ONE hunk carry-over is still a count, so
+    replacing an unlabelled control with a labelled one AND a new unlabelled one
+    nets to zero. Telling that apart from "the same control moved" needs
+    per-line identity a text diff does not carry; the file-wide version of the
+    hole — a fix anywhere funding a regression anywhere — is closed above.
+    Change this test if the gate ever learns to tell them apart."""
+    base = [_violation(10, 'Button("Save") { save() }')]
+    head = [_violation(11, 'Button("Save") { save() }')]
+    assert gate.suppress_carried(head, base, [_hunk(10, 1, 10, 2)]) == []
+
+
+def test_editing_a_comment_does_not_rename_a_control():
+    """Identity was the raw declaration line, so re-wording a trailing comment
+    made a years-old unlabelled control read as brand new. Comments have no
+    bearing on whether AXPress can reach it."""
+    src_base = """struct V: View {
+    var body: some View {
+        Button("Save") { save() }  // TODO: wire this up
+    }
+}
+"""
+    src_head = src_base.replace("// TODO: wire this up", "// FIXME: still pending")
+    base = gate.find_violations("Fixture.swift", src_base)
+    head = gate.find_violations("Fixture.swift", src_head)
+    assert [v.line for v in base] == [3] and [v.line for v in head] == [3]
+    assert gate.suppress_carried(head, base, [_hunk(3, 1, 3, 1)]) == []
+
+
+def test_a_comment_that_starts_the_line_is_kept_in_the_identity():
+    """Truncating there would collapse the identity to the empty string, which
+    every other control would then match."""
+    v = gate.find_violations(
+        "Fixture.swift",
+        """struct V: View {
+    var body: some View {
+        /* x */ Button("Save") { save() }
+    }
+}
+""",
+    )
+    assert v and "Button" in v[0].key[1]
+
+
+# --------------------------------------------------------------------------
+# Identifier removal: taking a label off is as damaging as never adding one.
+# --------------------------------------------------------------------------
+
+
+def test_deleting_an_identifier_is_reported_though_no_line_was_added():
+    """The declaration line does not change when the modifier lived on its own
+    line, so an added-lines-only filter never even looks at it."""
+    head = [_violation(3, 'Button("Save") { save() }')]
+    # The base's only violation was at line 9 — NOT the control at head line 3,
+    # which was labelled and no longer is.
+    base = [_violation(9, 'Button("Other") { other() }')]
+    removals = gate._identifier_removals(head, base, [_hunk(4, 1, 4, 0)], set())
+    assert [v.line for v in removals] == [3]
+    assert gate.IDENTIFIER_MODIFIER in removals[0].reason
+
+
+def test_an_untouched_carry_over_is_not_read_as_a_removal():
+    head = [_violation(3, 'Button("Save") { save() }')]
+    base = [_violation(3, 'Button("Save") { save() }')]
+    assert gate._identifier_removals(head, base, [], set()) == []
+
+
+def test_a_gap_on_the_same_line_does_not_vouch_for_its_neighbour():
+    """One line can hold two controls — ``Menu("x") { Button("y") { … } }``.
+    Matching on the line number alone let the pre-existing Button gap mark the
+    line "known bad", so deleting the Menu's identifier was suppressed."""
+    line = 'Menu("Actions") { Button("Rename") { rename() } }'
+    base = [gate.Violation("F.swift", 3, "Button", line, "x")]
+    head = [
+        gate.Violation("F.swift", 3, "Button", line, "x"),  # the old gap
+        gate.Violation("F.swift", 3, "Menu", line, "x"),  # just unlabelled
+    ]
+    removals = gate._identifier_removals(head, base, [_hunk(4, 1, 4, 0)], set())
+    assert [v.kind for v in removals] == ["Menu"]
+
+
+def test_head_line_to_base_undoes_the_shift_of_earlier_hunks():
+    assert gate.head_line_to_base([_hunk(4, 0, 5, 2)], 20) == 18  # 2 inserted
+    assert gate.head_line_to_base([_hunk(5, 2, 4, 0)], 20) == 22  # 2 deleted
+
+
+def test_a_pure_deletion_does_not_shift_the_line_it_follows():
+    """``@@ -7,2 +6,0 @@`` — head 6 is the line the deletion FOLLOWS, not a line
+    the hunk covers. Shifting it mapped a surviving carried-over violation to the
+    wrong base line, found nothing there, and reported it as an identifier this
+    diff had removed: deleting any labelled control lit up the control above it.
+    """
+    deletion = [_hunk(7, 2, 6, 0)]
+    assert gate.head_line_to_base(deletion, 6) == 6  # before the cut: unmoved
+    assert gate.head_line_to_base(deletion, 7) == 9  # after it: shifted by 2
+
+
+def test_deleting_a_labelled_control_does_not_blame_its_neighbour():
+    head = [_violation(6, 'Button("Save") { save() }')]
+    base = [_violation(6, 'Button("Save") { save() }')]
+    removals = gate._identifier_removals(head, base, [_hunk(7, 2, 6, 0)], set())
+    assert removals == []
+
+
+# --------------------------------------------------------------------------
+# A child's identifier must not satisfy its unlabelled parent.
+# --------------------------------------------------------------------------
+
+
+def test_a_child_identifier_does_not_label_its_parent():
+    """The parent's postfix span includes its trailing closure, so a search over
+    the whole span found the CHILD's identifier and passed the Menu. AXPress on
+    the Menu still has nothing to aim at."""
+    src = """struct V: View {
+    var body: some View {
+        Menu("Actions") {
+            Button("Rename") { rename() }
+                .accessibilityIdentifier("Sidebar.Rename")
+        }
+    }
+}
+"""
+    assert [(v.kind, v.line) for v in gate.find_violations("F.swift", src)] == [
+        ("Menu", 3)
+    ]
+
+
+def test_the_parents_own_modifier_chain_still_counts():
+    src = """struct V: View {
+    var body: some View {
+        Menu("Actions") {
+            Button("Rename") { rename() }
+                .accessibilityIdentifier("Sidebar.Rename")
+        }
+        .menuStyle(.borderlessButton)
+        .accessibilityIdentifier("Sidebar.Actions")
+    }
+}
+"""
+    assert gate.find_violations("F.swift", src) == []
+
+
+def test_an_identifier_five_modifiers_later_still_counts():
+    src = """struct V: View {
+    var body: some View {
+        Button("Save") { save() }
+            .buttonStyle(.borderless)
+            .disabled(false)
+            .help("Save it")
+            .keyboardShortcut("s")
+            .accessibilityIdentifier("Toolbar.Save")
+    }
+}
+"""
+    assert gate.find_violations("F.swift", src) == []
+
+
+def test_a_swiftui_qualified_control_is_still_a_control():
+    """``SwiftUI.Button(…)`` IS the control; the qualifier-rejecting lookbehind
+    let a fully qualified construction walk straight past the gate."""
+    src = """\
+struct V: View {
+    var body: some View {
+        SwiftUI.Button("Delete") { delete() }
+    }
+}
+"""
+    assert [(v.kind, v.line) for v in gate.find_violations("F.swift", src)] == [
+        ("Button", 3)
+    ]
+
+
+def test_another_namespaces_button_is_still_not_a_control():
+    src = """\
+struct V: View {
+    var body: some View {
+        Chrome.Button("Delete") { delete() }
+    }
+}
+"""
+    assert gate.find_violations("F.swift", src) == []
+
+
+def test_bare_grouping_parentheses_are_a_known_blind_spot():
+    """Pinned, not endorsed. The balanced walk stops at the enclosing ``)``, so
+    an identifier attached to a parenthesised control is missed and the control
+    is reported. Two attempts to make those parens transparent both produced
+    something worse — the first credited ``Card(Button(…))``'s identifier to the
+    Button, the second turned ``return (Button(…))`` into a false alarm — because
+    "is this paren an argument list or grouping?" cannot be answered from the
+    character in front of it: a closure call ends in ``}``, and ``return`` ends
+    in a letter. A gate that reports an unusual shape is recoverable in seconds;
+    one that credits a wrapper's identifier to the control inside it is the
+    exact defect the gate exists to catch. So the walk stays literal, and the
+    fix is to attach the identifier to the control itself."""
+    src = """\
+struct V: View {
+    var body: some View {
+        (
+            Button("Save") { save() }
+        )
+        .accessibilityIdentifier("Toolbar.Save")
+    }
+}
+"""
+    assert [(v.kind, v.line) for v in gate.find_violations("F.swift", src)] == [
+        ("Button", 4)
+    ]
+
+
+def test_a_wrappers_identifier_is_never_credited_to_the_control_it_holds():
+    """The direction that must never regress: an identifier on the enclosing
+    thing gives ``AXPress`` nothing to press."""
+    for wrapper in [
+        'Card(Button("Save") { save() })',
+        '{ child in HStack { child } }(Button("Save") { save() })',
+    ]:
+        src = f"""\
+struct V: View {{
+    var body: some View {{
+        {wrapper}
+            .accessibilityIdentifier("Row")
+    }}
+}}
+"""
+        assert [v.kind for v in gate.find_violations("F.swift", src)] == ["Button"], (
+            wrapper
+        )
+
+
+def test_a_qualified_control_with_spaces_around_the_dot_is_still_theirs():
+    """Whitespace may surround Swift member access, so a lookbehind cannot
+    decide the qualifier: ``Chrome . Button`` matched at ``Button`` with only a
+    space behind it and was falsely blocked."""
+    for spelling in ["Chrome.Button", "Chrome . Button", "Chrome\n            .Button"]:
+        src = f"""\
+struct V: View {{
+    var body: some View {{
+        {spelling}("Delete") {{ delete() }}
+    }}
+}}
+"""
+        assert gate.find_violations("F.swift", src) == [], spelling
+
+
+def test_generic_and_init_constructions_are_still_constructions():
+    """A name-then-delimiter pattern walked straight past both of these, so a
+    PR could add an unreachable SwiftUI button and the gate stayed green."""
+    for spelling in [
+        'Button<Text>(action: save) { Text("Save") }',
+        'Button.init("Save", action: save)',
+        'SwiftUI.Button.init("Save", action: save)',
+        'Button<Label<Text, Image>>(action: save) { Text("Save") }',
+    ]:
+        src = f"""\
+struct V: View {{
+    var body: some View {{
+        {spelling}
+    }}
+}}
+"""
+        assert [v.kind for v in gate.find_violations("F.swift", src)] == ["Button"], (
+            spelling
+        )
+
+
+def test_a_generic_return_type_is_not_a_construction():
+    """``private var saveButton: Button<Text> {`` is a return type followed by a
+    property body. Reading that ``{`` as a constructor reported a phantom
+    unlabelled Button and blocked a PR whose real control was labelled."""
+    src = """\
+struct V: View {
+    private var saveButton: Button<Text> {
+        Button("Save") { save() }
+            .accessibilityIdentifier("Toolbar.Save")
+    }
+    var body: some View { saveButton }
+}
+"""
+    assert gate.find_violations("F.swift", src) == []
+
+
+def test_a_generic_type_reference_is_still_not_a_construction():
+    """The trailing delimiter is what separates the two, and it has to keep
+    doing that now that generics are allowed in between."""
+    src = """\
+struct V: View {
+    let style: Button<Text>.Type = Button<Text>.self
+    var body: some View { EmptyView() }
+}
+"""
+    assert gate.find_violations("F.swift", src) == []
+
+
+def test_first_party_controls_are_in_the_inventory():
+    """Omitting these made the docstring's claim — that everything undetected
+    is listed under "Known blind spots" — untrue. ShareLink is an ordinary
+    button to a user."""
+    for kind in ("ShareLink", "PasteButton", "EditButton", "MultiDatePicker"):
+        assert kind in gate.CONTROL_KINDS, kind
+    src = """\
+struct V: View {
+    var body: some View {
+        ShareLink(item: reportURL)
+    }
+}
+"""
+    assert [v.kind for v in gate.find_violations("F.swift", src)] == ["ShareLink"]
+
+
+def test_a_nested_namespace_ending_in_swiftui_is_still_theirs():
+    """Reading only the qualifier's last component made ``Chrome.SwiftUI.Button``
+    look like the real control and falsely blocked it."""
+    src = """\
+struct V: View {
+    var body: some View {
+        Chrome.SwiftUI.Button("Delete") { delete() }
+    }
+}
+"""
+    assert gate.find_violations("F.swift", src) == []
+
+
+def test_swiftui_qualified_with_spaces_is_still_a_control():
+    src = """\
+struct V: View {
+    var body: some View {
+        SwiftUI . Button("Delete") { delete() }
+    }
+}
+"""
+    assert [v.kind for v in gate.find_violations("F.swift", src)] == ["Button"]
+
+
+def test_a_real_argument_list_is_not_treated_as_grouping():
+    """Only parens holding nothing but the control are transparent."""
+    src = """\
+struct V: View {
+    var body: some View {
+        wrap(Button("Save") { save() }, other)
+            .accessibilityIdentifier("Toolbar.Wrapper")
+    }
+}
+"""
+    assert [(v.kind, v.line) for v in gate.find_violations("F.swift", src)] == [
+        ("Button", 3)
+    ]
+
+
+def test_rewording_a_leading_block_comment_does_not_rename_the_control():
+    """The earlier compromise kept the whole line when a comment LED it, so
+    re-wording that comment reported a long-standing gap as brand new."""
+    src_base = """\
+struct V: View {
+    var body: some View {
+        /* old explanation */ Button("Save") { save() }
+    }
+}
+"""
+    src_head = src_base.replace("old explanation", "a different note entirely")
+    base = gate.find_violations("F.swift", src_base)
+    head = gate.find_violations("F.swift", src_head)
+    assert [v.line for v in base] == [3] and [v.line for v in head] == [3]
+    assert base[0].key == head[0].key
+    assert gate.suppress_carried(head, base, [_hunk(3, 1, 3, 1)]) == []
+
+
+def test_stripping_comments_still_leaves_a_distinguishing_identity():
+    """Deleting only the comment's columns, rather than truncating the line, is
+    what keeps two different controls from collapsing to the same key."""
+    src = """\
+struct V: View {
+    var body: some View {
+        /* a */ Button("Save") { save() }
+        /* b */ Button("Cancel") { cancel() }
+    }
+}
+"""
+    keys = [v.key for v in gate.find_violations("F.swift", src)]
+    assert len(keys) == 2 and keys[0] != keys[1]
+    assert all("/*" not in k[1] for k in keys)
+
+
+def test_disclosure_group_is_a_control():
+    src = """struct V: View {
+    var body: some View {
+        DisclosureGroup("Advanced") { Text("x") }
+    }
+}
+"""
+    assert [(v.kind, v.line) for v in gate.find_violations("F.swift", src)] == [
+        ("DisclosureGroup", 3)
+    ]
 
 
 # --------------------------------------------------------------------------

--- a/tests/test_rapid_mac_ax_identifiers.py
+++ b/tests/test_rapid_mac_ax_identifiers.py
@@ -1,0 +1,490 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the rapid-mac accessibility-identifier gate.
+
+Pure-logic — no git, no network, no Swift toolchain, no GPU. The gate is a lint
+over Swift source text, so everything here is a string in and a list of
+violations out. The last section runs the real ``apps/rapid-mac/Sources`` tree
+through the masker to catch a lexer desync on Swift the fixtures do not model.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Load the script directly (scripts/ is not an importable package). Registering
+# it in sys.modules is load-bearing: the module defines a @dataclass, and
+# dataclasses resolves field types through sys.modules[cls.__module__].
+_SPEC = importlib.util.spec_from_file_location(
+    "check_rapid_mac_ax_identifiers",
+    _REPO_ROOT / "scripts" / "check_rapid_mac_ax_identifiers.py",
+)
+gate = importlib.util.module_from_spec(_SPEC)
+sys.modules["check_rapid_mac_ax_identifiers"] = gate
+_SPEC.loader.exec_module(gate)
+
+
+def flags(src: str) -> list[tuple[str, int]]:
+    """(kind, line) for every violation the gate reports in ``src``."""
+    return [(v.kind, v.line) for v in gate.find_violations("Fixture.swift", src)]
+
+
+# --------------------------------------------------------------------------
+# The core contract: added interactive control without an identifier.
+# --------------------------------------------------------------------------
+
+
+def test_unlabelled_button_is_flagged():
+    src = """\
+struct Panel: View {
+    var body: some View {
+        Button("Save") { save() }
+    }
+}
+"""
+    assert flags(src) == [("Button", 3)]
+
+
+def test_identifier_directly_on_the_control_passes():
+    src = """\
+struct Panel: View {
+    var body: some View {
+        Button("Save") { save() }
+            .accessibilityIdentifier("Settings.Tools.Save")
+    }
+}
+"""
+    assert flags(src) == []
+
+
+def test_identifier_further_down_the_modifier_chain_passes():
+    """The whole point of walking the chain instead of grepping one line."""
+    src = """\
+struct Panel: View {
+    var body: some View {
+        Toggle(isOn: $on) {
+            VStack {
+                Text("Approve every page automatically")
+                Text("Skips the confirmation for unattended use.")
+            }
+        }
+        .toggleStyle(TrailingSettingsToggleStyle())
+        .disabled(locked)
+        .help("Browsing approval")
+        .accessibilityLabel("Approve every page automatically")
+        .accessibilityHint("Applies to the browse tool only.")
+        .accessibilityIdentifier("Settings.Tools.BrowseAutoApproveToggle")
+    }
+}
+"""
+    assert flags(src) == []
+
+
+def test_identifier_on_a_sibling_does_not_cover_this_control():
+    """Over-consuming the chain would silently credit the wrong control."""
+    src = """\
+struct Panel: View {
+    var body: some View {
+        HStack {
+            Button("Save") { save() }
+            Button("Cancel") { cancel() }
+                .accessibilityIdentifier("Settings.Tools.Cancel")
+        }
+    }
+}
+"""
+    assert flags(src) == [("Button", 4)]
+
+
+def test_identifier_on_the_container_does_not_cover_the_control():
+    """Documented behaviour: AXPress needs the control, not its HStack."""
+    src = """\
+struct Panel: View {
+    var body: some View {
+        HStack {
+            Button("Save") { save() }
+        }
+        .accessibilityIdentifier("Settings.Tools.Row")
+    }
+}
+"""
+    assert flags(src) == [("Button", 4)]
+
+
+def test_every_declared_control_kind_is_detected():
+    body = "\n".join(f"        {kind}()" for kind in gate.CONTROL_KINDS)
+    src = f"struct Panel: View {{\n    var body: some View {{\n{body}\n    }}\n}}\n"
+    assert [k for k, _ in flags(src)] == list(gate.CONTROL_KINDS)
+
+
+def test_static_and_decorative_views_are_out_of_scope():
+    src = """\
+struct Panel: View {
+    var body: some View {
+        VStack {
+            Text("Tools")
+            Image(systemName: "wrench")
+            Spacer()
+            Divider()
+            ProgressView()
+        }
+    }
+}
+"""
+    assert flags(src) == []
+
+
+def test_multiple_trailing_closures_keep_one_chain():
+    """`Menu { … } label: { … }` is one expression, identifier at the end."""
+    src = """\
+struct Panel: View {
+    var body: some View {
+        Menu {
+            Button("Rename") { rename() }
+                .accessibilityIdentifier("Sidebar.Row.Rename")
+        } label: {
+            Image(systemName: "ellipsis")
+        }
+        .menuStyle(.borderlessButton)
+        .accessibilityIdentifier("Sidebar.Row.Menu")
+    }
+}
+"""
+    assert flags(src) == []
+
+
+# --------------------------------------------------------------------------
+# Shapes that must NOT be mistaken for a control (false-positive guards).
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        "SendButton(action: send)",  # a custom view whose name ends in Button
+        "MyToggleGroup(items: items)",
+        "        .buttonStyle(.plain)",
+        "        .pickerStyle(.radioGroup)",
+        "        .menuStyle(.borderlessButton)",
+        "    let style: Button<Text>.Type = Button<Text>.self",
+        "struct Button: View { var body: some View { EmptyView() } }",
+        "        Chrome.Button.render()",
+    ],
+)
+def test_non_construction_tokens_are_not_controls(line):
+    src = f"struct Panel: View {{\n    var body: some View {{\n{line}\n    }}\n}}\n"
+    assert flags(src) == []
+
+
+def test_controls_named_inside_comments_and_strings_are_ignored():
+    src = '''\
+struct Panel: View {
+    /// Historically this row shipped a `Button("Retry") { retry() }` with no
+    /// identifier — see docs/userflows.md.
+    var body: some View {
+        // Button("Ghost") { }
+        Text("Button(\\"Quoted\\") { }")
+        Text("""
+            Button("Fenced") {
+                still not code
+            }
+            """)
+    }
+}
+'''
+    assert flags(src) == []
+
+
+def test_raw_string_delimiters_do_not_desync_the_lexer():
+    src = """\
+struct Panel: View {
+    var body: some View {
+        Text(#"a raw "quoted" Button("Nope") { } string"#)
+        Button("Real") { fire() }
+    }
+}
+"""
+    assert flags(src) == [("Button", 4)]
+
+
+def test_string_interpolation_containing_braces_is_survivable():
+    src = """\
+struct Panel: View {
+    var body: some View {
+        Text("Model: \\(alias.isEmpty ? "none" : alias) ready")
+        Button("Real") { fire() }
+    }
+}
+"""
+    assert flags(src) == [("Button", 4)]
+
+
+def test_nested_block_comments_are_survivable():
+    src = """\
+struct Panel: View {
+    var body: some View {
+        /* outer /* inner Button("Ghost") { } */ still comment */
+        Button("Real") { fire() }
+    }
+}
+"""
+    assert flags(src) == [("Button", 4)]
+
+
+def test_command_menu_items_are_out_of_scope():
+    """rapid-ax.swift never walks the menu bar; an id there is decoration."""
+    src = """\
+struct RapidApp: App {
+    var body: some Scene {
+        Window("Rapid-MLX", id: "main") { ContentView() }
+            .commands {
+                CommandGroup(replacing: .appSettings) {
+                    Button("Settings…") { openSettings() }
+                }
+                CommandMenu("Conversation") {
+                    Button("Open in New Window") { pop() }
+                }
+            }
+    }
+}
+"""
+    assert flags(src) == []
+
+
+def test_style_makebody_is_out_of_scope():
+    """An id here would be stamped on every caller adopting the style."""
+    src = """\
+struct TrailingSettingsToggleStyle: ToggleStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        Toggle(isOn: binding) { configuration.label }
+            .toggleStyle(.switch)
+    }
+}
+"""
+    assert flags(src) == []
+
+
+def test_style_makebody_scope_closes_at_its_own_body():
+    """The skip must not leak into the next view in the same file."""
+    src = """\
+struct PlainStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        Button("inner") { }
+    }
+}
+
+struct Panel: View {
+    var body: some View {
+        Button("outer") { fire() }
+    }
+}
+"""
+    assert flags(src) == [("Button", 9)]
+
+
+# --------------------------------------------------------------------------
+# The escape hatch has to cost something.
+# --------------------------------------------------------------------------
+
+
+def test_exempt_marker_with_a_reason_on_the_same_line_passes():
+    src = """\
+struct Panel: View {
+    var body: some View {
+        Button("Allow once") { approve() }  // ax-exempt: confirmationDialog buttons render outside the app's AX tree
+    }
+}
+"""
+    assert flags(src) == []
+
+
+def test_exempt_marker_on_the_line_above_passes():
+    src = """\
+struct Panel: View {
+    var body: some View {
+        // ax-exempt: confirmationDialog buttons render outside the app's AX tree
+        Button("Allow once") { approve() }
+    }
+}
+"""
+    assert flags(src) == []
+
+
+def test_exempt_marker_two_lines_above_does_not_reach():
+    src = """\
+struct Panel: View {
+    var body: some View {
+        // ax-exempt: confirmationDialog buttons render outside the app's AX tree
+
+        Button("Allow once") { approve() }
+    }
+}
+"""
+    assert flags(src) == [("Button", 5)]
+
+
+@pytest.mark.parametrize(
+    "marker", ["// ax-exempt:", "// ax-exempt: dialog", "// ax-exempt:  -- "]
+)
+def test_exempt_marker_without_a_real_reason_is_itself_a_failure(marker):
+    src = f"""\
+struct Panel: View {{
+    var body: some View {{
+        {marker}
+        Button("Allow once") {{ approve() }}
+    }}
+}}
+"""
+    violations = gate.find_violations("Fixture.swift", src)
+    assert len(violations) == 1
+    assert gate.EXEMPT_MARKER in violations[0].reason
+
+
+def test_exempt_marker_in_block_comment_form_is_recognised():
+    """Regression: a per-character join shredded the marker into letters."""
+    src = """\
+struct Panel: View {
+    var body: some View {
+        /* ax-exempt: confirmationDialog buttons live outside the AX tree */
+        Button("Allow once") { approve() }
+    }
+}
+"""
+    assert flags(src) == []
+
+
+def test_marker_must_sit_on_the_last_comment_line_before_the_control():
+    """The lookup is deliberately narrow — the control's line or the one
+    directly above it. A marker stranded on the first line of a multi-line
+    comment does not reach, which keeps the rule the same one everyone already
+    knows from `# noqa` / `swiftlint:disable:next` instead of a bespoke
+    proximity heuristic."""
+    stranded = """\
+struct Panel: View {
+    var body: some View {
+        /* ax-exempt: confirmationDialog buttons live outside the AX tree
+           so no golden flow can ever press this one. */
+        Button("Allow once") { approve() }
+    }
+}
+"""
+    assert flags(stranded) == [("Button", 5)]
+
+    adjacent = """\
+struct Panel: View {
+    var body: some View {
+        /* No golden flow can ever press this one:
+           ax-exempt: confirmationDialog buttons live outside the AX tree */
+        Button("Allow once") { approve() }
+    }
+}
+"""
+    assert flags(adjacent) == []
+
+
+def test_exempt_marker_inside_a_string_is_not_a_marker():
+    src = """\
+struct Panel: View {
+    var body: some View {
+        Text("ax-exempt: this is prose, not a suppression")
+        Button("Allow once") { approve() }
+    }
+}
+"""
+    assert flags(src) == [("Button", 4)]
+
+
+# --------------------------------------------------------------------------
+# Carry-over suppression: reformatting known-bad code must not light up.
+# --------------------------------------------------------------------------
+
+
+def _violation(line: int, source: str) -> gate.Violation:
+    return gate.Violation(
+        path="Fixture.swift", line=line, kind="Button", source=source, reason="x"
+    )
+
+
+def test_carried_violation_is_suppressed_across_a_reindent():
+    """The declaration line is 'added' by the diff, but it is the same control."""
+    base = [_violation(10, 'Button("Save") { save() }')]
+    head = [_violation(42, 'Button("Save")   { save() }')]
+    assert gate.suppress_carried(head, base, {42}) == []
+
+
+def test_untouched_violations_are_never_reported():
+    base = [_violation(10, 'Button("Save") { save() }')]
+    head = [_violation(10, 'Button("Save") { save() }')]
+    assert gate.suppress_carried(head, base, set()) == []
+
+
+def test_duplicating_a_carried_violation_reports_the_copy():
+    """The base funds ONE unlabelled Save button; the second copy is new."""
+    base = [_violation(10, 'Button("Save") { save() }')]
+    head = [
+        _violation(10, 'Button("Save") { save() }'),  # untouched original
+        _violation(24, 'Button("Save") { save() }'),  # the pasted copy
+    ]
+    kept = gate.suppress_carried(head, base, {24})
+    assert [v.line for v in kept] == [24]
+
+
+def test_copy_pasted_above_the_original_still_reports():
+    """Regression: an in-order walk let the added copy spend the base budget,
+    leaving the untouched original to absorb the blame and the diff to pass."""
+    base = [_violation(30, 'Button("Save") { save() }')]
+    head = [
+        _violation(10, 'Button("Save") { save() }'),  # the pasted copy, added
+        _violation(30, 'Button("Save") { save() }'),  # untouched original
+    ]
+    kept = gate.suppress_carried(head, base, {10})
+    assert [v.line for v in kept] == [10]
+
+
+def test_a_genuinely_new_control_survives_suppression():
+    base = [_violation(10, 'Button("Save") { save() }')]
+    head = [
+        _violation(10, 'Button("Save") { save() }'),
+        _violation(42, 'Button("Delete") { delete() }'),
+    ]
+    assert [v.line for v in gate.suppress_carried(head, base, {42})] == [42]
+
+
+# --------------------------------------------------------------------------
+# The real tree. Not a coverage assertion — a lexer soak test.
+# --------------------------------------------------------------------------
+
+
+def _real_sources() -> list[Path]:
+    root = _REPO_ROOT / gate.SCOPE_PREFIX
+    return sorted(root.rglob("*.swift")) if root.is_dir() else []
+
+
+def test_masker_preserves_offsets_and_line_structure_on_the_real_tree():
+    files = _real_sources()
+    assert files, "apps/rapid-mac/Sources should contain Swift files"
+    for path in files:
+        src = path.read_text(encoding="utf-8")
+        masked, _ = gate.mask_source(src)
+        assert len(masked) == len(src), path
+        assert masked.count("\n") == src.count("\n"), path
+        # Masking only ever replaces a character with a space.
+        assert all(m == c or m == " " for m, c in zip(masked, src)), path
+
+
+def test_gate_runs_over_the_real_tree_without_exploding():
+    """Every reported line must exist, and every control the app already
+    labels must stay unreported — the tree is the fixture the gate ships
+    against."""
+    for path in _real_sources():
+        src = path.read_text(encoding="utf-8")
+        lines = src.splitlines()
+        for v in gate.find_violations(str(path), src):
+            assert 1 <= v.line <= len(lines)
+            assert v.source == lines[v.line - 1].strip()
+            assert ".accessibilityIdentifier" not in v.source


### PR DESCRIPTION
## Why

`apps/rapid-mac/scripts/gui-golden-flows.sh` drives the app through `rapid-ax.swift`, which finds and presses **every** element by `AXIdentifier` — nothing else. So the GUI suite's coverage ceiling *is* the set of controls that carry one, and that ceiling drops silently every time a feature ships an unlabelled control, because the app still works by hand and no check goes red.

This is not hypothetical:

* **Settings → Tools** renders three tool toggles, the web-search backend radio group, its API-key field + Save button and the browsing toggle. All are real, working `AXCheckBox` / `AXRadioButton` / `AXTextField` elements — none carries an identifier, so no automated flow can reach any of them.
* `apps/rapid-mac/docs/userflows.md` has carried *"Approval dialogs lack identifiers"* as an open item across several releases.
* A tree-wide sweep finds **96 unlabelled interactive controls** against 46 labelled ones. The harness can reach a third of the app's controls.

## What this adds

`scripts/check_rapid_mac_ax_identifiers.py`, wired as a new `accessibility-identifiers` job in `.github/workflows/rapid-mac-ci.yml` (ubuntu, stdlib-only, ~15 s, beside the existing macOS `swift build` job rather than inside it, so a missing identifier reads as its own red check with its own log).

**It fails a PR that ADDS an interactive SwiftUI control under `apps/rapid-mac/Sources/` with no `.accessibilityIdentifier(...)`.**

### How the detector works

1. **Mask.** Comments and string literals are blanked to spaces, preserving byte offsets and line structure. Handles line comments, *nested* block comments, escapes, `\(…)` interpolation, `"""…"""`, and raw strings with any number of `#` delimiters. So every brace, paren and dot the next step sees is real code.
2. **Find control heads.** `(?<![A-Za-z0-9_.])(Button|Toggle|Picker|DatePicker|ColorPicker|TextField|SecureField|TextEditor|Menu|Stepper|Slider|NavigationLink|Link)\s*[({]` — a control being *constructed*. The lookbehind excludes `SendButton`, `.pickerStyle`, `Foo.Button`; the trailing `[({]` excludes type references (`Button<Label>`, `struct Button: View`).
3. **Walk the real chain.** From the opening delimiter, balance delimiters, then keep consuming trailing closures (including Swift's second `} label: { … }` form) and `.modifier(…)` links until a token that cannot continue a postfix expression. So an identifier five modifiers down still counts — the app's longest real case is `ModelPickerBar.ModelMenu`, **158 lines** below its `Menu`, and it is correctly credited.
4. **Scope to the diff.** Report only controls whose declaration line the diff **added**, then subtract carry-overs (below).

**Exact failure mode:** exit 1, one `::error file=…,line=…` GitHub annotation per finding (inline on the PR diff) plus a plain-text block naming the file, line, the declaration source line, and the reason; then a stderr block explaining the fix and the opt-out. Exit 0 prints `PASS` or `nothing to check`.

### Escape hatch that costs something

`confirmationDialog` / `alert` buttons genuinely render outside the app's AX tree. Opt out on the control's line or the line directly above:

```swift
// ax-exempt: confirmationDialog buttons render outside the app's AX tree
Button("Allow once") { approve() }
```

The reason is **mandatory** (≥10 chars) — a bare `// ax-exempt:` fails with its own distinct message, so the hatch can't be used by reflex. Every opt-out is greppable: `rg ax-exempt apps/rapid-mac`.

### Scoping decisions

* **Added lines only.** Failing on the 96-control backlog would make this un-landable and it would be off within a week. `--audit` enumerates the backlog for whoever wants to chip at it.
* **Carry-over suppression.** Multiset over `(kind, whitespace-normalised declaration line)` per file, against the base blob. Re-indenting or moving known-bad code is absorbed; **copying** an unlabelled control is not, because the base only funds one. Untouched occurrences claim the base budget before added ones.
* **Rename-aware** (`git diff -M`), so moving a panel full of known gaps isn't read as adding a panel full of new ones.

## Evidence — both directions

All six scenarios run against `SettingsToolsPanel.swift` on a real branch, gate invoked exactly as CI does.

| # | Scenario | Expected | Got |
|---|---|---|---|
| A | Add a brand-new unlabelled `Toggle` | FAIL | **exit 1** |
| B | Same `Toggle`, identifier at the end of a 3-modifier chain | PASS | **exit 0** |
| C | Same `Toggle`, `// ax-exempt:` **with** a written reason | PASS | **exit 0** |
| D | Same `Toggle`, bare `// ax-exempt:` (no reason) | FAIL | **exit 1** |
| E | Pure re-indent of an **existing** unlabelled toggle (its declaration line *is* in the diff's added lines) | PASS | **exit 0** |
| F | Verbatim **duplicate** of an existing unlabelled toggle | FAIL | **exit 1** |

<details>
<summary>Raw output</summary>

```
======== A  new unlabelled Toggle           (expect FAIL) ========
[ax-identifier-gate] base 481272ea804c, 1 changed file(s):
    apps/rapid-mac/Sources/Rapid/UI/SettingsToolsPanel.swift
::error file=apps/rapid-mac/Sources/Rapid/UI/SettingsToolsPanel.swift,line=214::Toggle: no .accessibilityIdentifier(…) on this control
  apps/rapid-mac/Sources/Rapid/UI/SettingsToolsPanel.swift:214
    Toggle(isOn: browseBlockDownloadsBinding) {
    -> no .accessibilityIdentifier(…) on this control
EXIT=1
======== B  same Toggle, identifier added   (expect PASS) ========
[ax-identifier-gate] PASS — every control this PR adds is reachable by AXIdentifier.
EXIT=0
======== C  opt-out WITH a reason           (expect PASS) ========
[ax-identifier-gate] PASS — every control this PR adds is reachable by AXIdentifier.
EXIT=0
======== D  bare '// ax-exempt:'            (expect FAIL) ========
::error file=…/SettingsToolsPanel.swift,line=215::Toggle: 'ax-exempt:' marker with no usable reason — write at least 10 characters saying why this control cannot carry an identifier
EXIT=1
======== E  re-indent an EXISTING gap       (expect PASS) ========
[ax-identifier-gate] PASS — every control this PR adds is reachable by AXIdentifier.
EXIT=0
======== F  DUPLICATE an existing gap       (expect FAIL) ========
::error file=…/SettingsToolsPanel.swift,line=214::Toggle: no .accessibilityIdentifier(…) on this control
EXIT=1
```
</details>

A self-review pass also caught a second bug before push: the comment capture joined block-comment characters with spaces, which shredded `ax-exempt:` inside a `/* … */` into single letters and made the marker silently unrecognisable in block-comment form. Fixed and pinned by two tests, one of which also nails down the deliberately narrow lookup (the control's line or the one directly above — the same rule as `# noqa` / `swiftlint:disable:next`, not a bespoke proximity heuristic).

**Scenario F found a real bug in my own first cut** and is now pinned by two unit tests: the naive in-order suppression let a pasted copy spend the base budget while the untouched original absorbed the blame, so duplication passed. Fixed by letting untouched occurrences claim the budget first. Re-running the historical replay after the fix turned up 6 more genuine findings that the buggy version had been laundering (both `Cancel` buttons in an alert instead of one, etc.).

### Does it fire on today's `main`? Yes — and every fire is a genuine gap.

I replayed the gate over **the last 40 real merged commits** that touched `apps/rapid-mac/Sources` (`--base-ref <sha>~1 --head-ref <sha>`):

* **33 / 40 pass clean.**
* **7 / 40 would have been blocked**, 30 findings total. I read all 30. **Zero are detector errors** — in every case the control has no `.accessibilityIdentifier` anywhere in its chain, on the container, or on any caller.

| Commit | Findings | What they are |
|---|---|---|
| `c2e40a1b` #1577 (**HEAD of main**) | 1 | The sidebar row menu's **Delete** item. The confirmation sheet it opens has identifiers (`DeleteSessionConfirm.*`); the menu item that opens it does not, so a flow can't get to the sheet. |
| `bb6e90d4` #? web tools | 9 | The six `SettingsToolsPanel` controls named in this PR's motivation, plus 3 dialog buttons. **The gate would have caught the documented gap on the commit that created it.** |
| `12b76172` pin/rename/archive | 6 | Sidebar row `Menu`, its 3 items, the inline rename `TextField`. |
| `a06ced1f` visual system | 9 | `QuietIconButton` / `RapidTextField` / `InlineNotice` wrapper bodies + 6 real controls. |
| `8b9d4dc4`, `2a1900fe` | 2 each | `confirmationDialog` / `alert` buttons — exactly the `ax-exempt` case, ~1 comment line each. |
| `f2097169` | 1 | The inline message-edit `TextEditor`. |

Roughly half the historical fires are dialog buttons (one comment line each); the rest are coverage gaps a reviewer would genuinely want to see. Tree-wide audit for context: **142 in-scope controls, 46 labelled, 96 not, 4 in deliberately-skipped scopes.**

## What it deliberately does NOT catch

Precision over recall — a gate that cries wolf gets ignored, and an ignored gate is worse than none because it manufactures confidence. Not detected:

* Interactivity bolted onto a non-control view: `.onTapGesture`, `.gesture`, `.contextMenu`, `.swipeActions`, `.draggable`.
* Bespoke `View` structs that are interactive without naming a SwiftUI control type at the point of use. (The wrapper's own `Button` is still checked where the wrapper is *defined*.)
* AppKit bridged through `NSViewRepresentable` — the chat composer's `AutosizingTextView` is the app's real example, and `rapid.chat.compose` gets its identifier from the AppKit side.
* `Commands` / `CommandGroup` / `CommandMenu` items — skipped on purpose. `rapid-ax.swift` explicitly refuses to walk the menu bar and `gui-golden-flows.sh` drives menus by title through `peekaboo menu click`, so an identifier there would be decoration.
* `ButtonStyle` / `ToggleStyle` `makeBody(configuration:)` bodies — skipped on purpose. An identifier there is stamped on every caller adopting the style, which is worse than none. (`TrailingSettingsToggleStyle` is the live case.)
* Anything outside `apps/rapid-mac/Sources/`.
* Renaming an *identifier* to a duplicate of an existing one. Uniqueness is a separate concern.

## Where it could misfire — say it now, not later

1. **Reusable wrapper components** (`QuietIconButton`, `RapidTextField`, `InlineNotice`). Today no caller labels them, so flagging the wrapper is correct. But if a caller ever writes `QuietIconButton(…).accessibilityIdentifier("X")` — which does work, SwiftUI applies it to the wrapper's root — then editing the wrapper's own `Button` line would flag a control that *is* reachable. **This is the most likely false positive.** Fix is either an `identifier:` parameter forwarded by the wrapper (better — self-documenting) or `// ax-exempt: callers attach the identifier at the call site`.
2. **Identifier on the container, not the control.** `HStack { Button(…) }.accessibilityIdentifier("Row")` flags the Button. I judged this correct (`AXPress` needs the control) but it is a defensible disagreement.
3. **Editing the declaration line of an existing unlabelled control.** Carry-over suppression absorbs pure moves/re-indents, but changing the text — e.g. renaming the action in `Button("Save") { commitKey(…) }` — reads as new. "You touched it, label it" is arguably right, but it is a surprise the first time.
4. **Chain-walk over-consumption.** The walker errs toward consuming *too much*, which can only cause a miss, never a false alarm. Verified on the real tree: 46 labelled controls credited to **46 distinct** `.accessibilityIdentifier` sites — no control borrows a sibling's.
5. **A malformed/unclosed literal** could desync the masker. `_consume_balanced` bails at the first mismatched closer rather than running to EOF, and a masker-invariant test (length + newline count + only-blanks-to-spaces) runs over every real Swift file.

## Tests

39 unit tests in `tests/test_rapid_mac_ax_identifiers.py` (stdlib + pytest; no git, no Swift toolchain, no GPU), running in the existing `test-matrix` job. Covers the core contract, chain-walk edge cases, every non-construction token shape, comment/string/raw-string/interpolation/nested-block-comment masking, the `Commands` and `makeBody` skips, all four escape-hatch states, and the carry-over multiset — plus a soak over the real `Sources` tree.

**Recall check:** every bare occurrence of one of the 13 control-kind tokens in the entire `Sources` tree, outside strings and comments, is recognised as a control head — **0 missed**.

## Verification run locally

* `python3.12 -m pytest tests/test_rapid_mac_ax_identifiers.py` — 39 passed
* `ruff check vllm_mlx/ tests/` — clean; `ruff format --check vllm_mlx/ tests/` — 806 files already formatted
* `python scripts/check_gha_pinning.py` — 14 workflows clean
* `python scripts/check_workflow_expressions.py` — OK (14 files)
* The gate against this PR's own branch — `nothing to check` (exit 0), since this PR touches no `Sources` Swift
* `swift build` in `apps/rapid-mac` — **Build complete (48.74s)**, exit 0

**`swift test` does NOT pass locally, and I am not claiming otherwise.** This machine has Command Line Tools only (`xcode-select -p` → `/Library/Developer/CommandLineTools`), which is exactly the documented limitation:

```
Tests/RapidUXTests/ModelReadinessTests.swift:1:8: error: no such module 'XCTest'
error: fatalError
```

That is an environment limit, not a regression from this PR — the diff contains **zero** Swift changes, so the `build` job's result is by construction identical to `main`'s. CI on `macos-15` with full Xcode is the authority here.

Closes nothing; the 96-control backlog is intentionally left open and is now enumerable with `--audit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
