### PR TITLE
issues: a form desktop-app users can actually fill in

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -8,6 +8,10 @@ body:
         Thanks for reporting! Please fill in every required field — issues missing a serve command or repro steps usually can't be acted on.
 
         For **slowdowns / low throughput**, use the **Performance Issue** template instead.
+
+        Using the **desktop app** (installed from a `.dmg`, no terminal)? Use the
+        **Desktop App Issue** template instead — this form requires a serve command and
+        server logs that the app never shows you.
   - type: input
     id: version
     attributes:

--- a/.github/ISSUE_TEMPLATE/desktop_bug.yml
+++ b/.github/ISSUE_TEMPLATE/desktop_bug.yml
@@ -1,0 +1,110 @@
+name: Desktop App Issue (Mac)
+description: A problem with the Rapid-MLX Desktop app — the window, chat, model downloads, settings, or updates
+labels: ["bug", "desktop-app"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        This form is for the **desktop app** — the thing you install from a `.dmg` and click.
+
+        If you run `rapid-mlx serve` in a terminal, use the **Bug Report** form instead; it asks
+        for the serve command and server logs, which this one deliberately does not.
+
+        **The fastest way to get this fixed:** open **Settings → App → Diagnostics →
+        "Export diagnostics…"**, then drag the saved file into the "Diagnostics report" box
+        below. It carries your app version, Mac model, macOS version and a scrubbed log tail —
+        no prompts, no file contents, no personal data — and it answers most of what we would
+        otherwise have to ask you for.
+  - type: input
+    id: app_version
+    attributes:
+      label: App version
+      description: Menu bar → **About Rapid-MLX…**. Copy the whole line, including the number in brackets.
+      placeholder: "e.g. 0.12.6 (150)"
+    validations:
+      required: true
+  - type: input
+    id: prior_version
+    attributes:
+      label: Last version where it worked (if this is a regression)
+      description: Leave blank if this is your first install, or you don't know.
+      placeholder: "e.g. 0.12.5"
+  - type: input
+    id: hardware
+    attributes:
+      label: Mac model and memory
+      description: Apple menu → **About This Mac**.
+      placeholder: "e.g. MacBook Pro M3 Max, 64 GB"
+    validations:
+      required: true
+  - type: input
+    id: macos
+    attributes:
+      label: macOS version
+      description: Apple menu → **About This Mac**. The app needs macOS 14 (Sonoma) or newer.
+      placeholder: "e.g. Sequoia 15.3"
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Where in the app does this happen?
+      description: Pick the closest one — it decides who picks the issue up.
+      options:
+        - "First-run setup wizard"
+        - "Chat window (asking, answering, tools, formatting)"
+        - "Conversation list / sidebar (rename, pin, archive, delete)"
+        - "Models — downloading, picking, or starting one"
+        - "Settings"
+        - "Menu-bar icon / Dock / window behaviour"
+        - "Updating the app"
+        - "Installing or launching for the first time"
+        - "Speed — answers arrive slowly, or the app feels sluggish"
+        - "Somewhere else / not sure"
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened? What did you expect instead?
+      placeholder: |
+        Actual: <what the app did>
+        Expected: <what you thought it would do>
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      description: >
+        Click by click, starting from opening the app. Say which button you pressed and what
+        you saw after each one. If it only happens sometimes, say roughly how often.
+      placeholder: |
+        1. Open Rapid-MLX
+        2. Right-click a conversation in the sidebar → Rename
+        3. Type a new name and press Return
+        4. What I saw: the name didn't change and my text ended up in the message box
+    validations:
+      required: true
+  - type: textarea
+    id: media
+    attributes:
+      label: Screenshot or screen recording
+      description: >
+        Drag the file in here. For anything visual — a wrong layout, a button that does
+        nothing, text that overflows — this is usually worth more than any description.
+        Screenshot: ⇧⌘4. Screen recording: ⇧⌘5.
+  - type: textarea
+    id: diagnostics
+    attributes:
+      label: Diagnostics report
+      description: >
+        Settings → App → Diagnostics → "Export diagnostics…", then drag the saved file in here
+        (or paste its contents). Optional, but it is the difference between us reproducing this
+        today and asking you three follow-up questions first.
+  - type: input
+    id: model
+    attributes:
+      label: Which model was loaded?
+      description: Leave blank if no model was running, or if this happened before you picked one.
+      placeholder: "e.g. lfm2.5-2.6b-4bit"

--- a/.github/ISSUE_TEMPLATE/performance_issue.yml
+++ b/.github/ISSUE_TEMPLATE/performance_issue.yml
@@ -11,6 +11,10 @@ body:
 
         For non-perf bugs (crashes, wrong output, broken tool calls), use **Bug Report** instead.
 
+        Using the **desktop app** (installed from a `.dmg`, no terminal)? Use the **Desktop App
+        Issue** template and pick the "Speed" area — this form requires a serve command and
+        per-request timings that the app never shows you.
+
   - type: input
     id: current_version
     attributes:


### PR DESCRIPTION
## Why

Every bug form we ship is shaped for the server. `bug_report.yml` makes
**Full serve command**, **Streaming or non-streaming?**, **Server logs** and a
`curl` reproduction all *required* — none of which exist for someone who
installed a `.dmg` and clicked a button. `performance_issue.yml` is worse: it
requires before/after tok/s measurements the app never shows.

So a GUI reporter's only options are to invent values for four required fields
or give up. `blank_issues_enabled: false` means there is no escape hatch for
anyone outside the org.

The tracker shows the result. The `desktop-app` label already exists, but of the
~30 most recent issues only #1548 and #1544 carry it, while more than half are
desktop reports (`rapid-mac:`, `Desktop:`, Settings, tray, sidebar, wizard…).
Categorisation was left to whoever triaged, so it mostly didn't happen.

## What

- **New `desktop_bug.yml` — "Desktop App Issue (Mac)"**, asking for what a GUI
  bug actually needs: the About-window version string, an area dropdown that
  routes triage, click-by-click steps, and a screenshot/recording field. It
  labels `["bug", "desktop-app"]` on submission, so routing no longer depends on
  someone remembering.
- It points at **Settings → App → Diagnostics → "Export diagnostics…"** — the
  one-click scrubbed report (`DiagnosticsBundle.swift`) that already carries app
  version, chip, RAM, macOS and a log tail. One attachment replaces most of what
  the server form interrogates for.
- **Speed is an *area* inside the desktop form**, not a second form: the perf
  template's required baselines are as unfillable from the app as a serve
  command is.
- `bug_report.yml` and `performance_issue.yml` now state who they are *not* for.

## Verification

All six forms parsed and checked against the GitHub issue-form schema — types,
required `label`/`value`/`options`, `id` charset and uniqueness, `validations.required`
booleans, and `markdown` blocks carrying neither `id` nor `validations`. All pass.
Both labels applied by the new form (`bug`, `desktop-app`) exist in the repo.

Nothing links to these files by name, so adding one is safe: the only reference
anywhere is a prose mention of `config.yml` in `spam-issue-guard.yml`, and the
site's single entry point is the bare `/issues/new`, which lands on the picker.

## Out of scope (pre-existing, found while verifying)

`performance_issue.yml` applies a **`performance` label that does not exist** in
the repo — so perf reports have been arriving unlabelled since the form landed.
Fixing it is a repo-settings change (create the label), not a code change, so
it is not in this PR.