### PR TITLE
fix(rapid-mac): add low-memory quickstart recovery

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/UI/OnboardingComponents.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/OnboardingComponents.swift
@@ -141,6 +141,52 @@ struct OnboardingAttrChip: View {
 
 // MARK: - Model choice cards
 
+/// The explicit below-quality-floor escape hatch. It looks distinct from
+/// both the recommended starter and benchmarked trade-ups, and puts the
+/// capability cost on screen so "lower memory" is never read as "same model,
+/// only faster".
+struct QuickstartLowMemoryCard: View {
+    let choice: QuickstartModelChoice
+    let selected: Bool
+    let sizeText: String
+    let onTap: () -> Void
+
+    var body: some View {
+        Button(action: onTap) {
+            HStack(alignment: .top, spacing: 11) {
+                BrandIcon(alias: choice.alias, size: 32)
+                VStack(alignment: .leading, spacing: 4) {
+                    HStack(spacing: 7) {
+                        Text(choice.displayName).scaledSystemFont(13, weight: .semibold)
+                        Text("LOWEST MEMORY")
+                            .scaledSystemFont(8.5, weight: .bold)
+                            .foregroundStyle(RapidTheme.green)
+                            .padding(.horizontal, 6).padding(.vertical, 2)
+                            .background(Capsule().fill(RapidTheme.green.opacity(0.12)))
+                        Spacer()
+                        if !sizeText.isEmpty {
+                            Text(sizeText).scaledSystemFont(11).foregroundStyle(.secondary)
+                        }
+                    }
+                    Text(choice.blurb)
+                        .scaledSystemFont(11)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                selectionGlyph(selected: selected, size: 18)
+            }
+            .padding(.horizontal, 14).padding(.vertical, 11)
+            .background(cardFill(selected: selected))
+            .overlay(cardStroke(selected: selected))
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.pressableCard)
+        .accessibilityIdentifier("Quickstart.Choice.\(choice.alias)")
+        .accessibilityAddTraits(selected ? .isSelected : [])
+        .accessibilityLabel("\(choice.displayName). Lowest memory. \(choice.blurb) Download \(sizeText)")
+    }
+}
+
 /// The recommended starter card: brand icon + name + "START HERE" badge
 /// + a qualitative blurb + attribute chips (NO meters — the starter
 /// card is deliberately qualitative; decision (b)). Selectable; the whole card is the

--- a/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
@@ -124,6 +124,12 @@ import SwiftUI
 /// fall back to tqdm file-count progress; both drive an identical
 /// download → serve → seed pipeline.
 struct QuickstartModelChoice: Equatable, Identifiable, Sendable {
+    enum Tier: Equatable, Sendable {
+        case starter
+        case lowMemory
+        case tradeUp
+    }
+
     var id: String { alias }
     /// Canonical alias resolved in ``vllm_mlx/aliases.json``.
     let alias: String
@@ -135,9 +141,14 @@ struct QuickstartModelChoice: Equatable, Identifiable, Sendable {
     let hfRepo: String?
     /// One-line blurb shown under the name in the chooser.
     let blurb: String
-    /// True for the recommended starter — the default selection, the
-    /// "START HERE" badge, and the qualitative (meter-free) card.
-    let isStarter: Bool
+    /// Where this choice belongs in the deliberately short onboarding
+    /// ladder. Sub-1B models stay hidden from the normal picker because
+    /// they are materially less capable, but ``lowMemory`` gives a user
+    /// who cannot safely load the starter an honest escape hatch.
+    let tier: Tier
+
+    var isStarter: Bool { tier == .starter }
+    var isLowMemory: Bool { tier == .lowMemory }
 }
 
 /// Persistent state owner + state machine for the Quickstart surface.
@@ -228,7 +239,20 @@ final class QuickstartCoordinator {
         displayName: "LFM2.5 · 1.2B",
         hfRepo: "mlx-community/LFM2.5-1.2B-Instruct-4bit",
         blurb: "Small download (~0.6 GB), runs on any Mac. Answers instantly and follows instructions well. Upgrade anytime for more depth.",
-        isStarter: true
+        tier: .starter
+    )
+
+    /// Deliberately weaker than the starter. The normal model picker hides
+    /// sub-1B models to protect users from accidentally choosing quality
+    /// below the product floor; onboarding surfaces this one explicitly as
+    /// a memory-first fallback and names the trade-off instead of pretending
+    /// it is an equivalent recommendation.
+    static let lowMemoryChoice = QuickstartModelChoice(
+        alias: "qwen3-0.6b-4bit",
+        displayName: "Qwen 3 · 0.6B",
+        hfRepo: "mlx-community/Qwen3-0.6B-4bit",
+        blurb: "Lowest memory and fastest startup. Good for basic chat, but less accurate and not recommended for tools.",
+        tier: .lowMemory
     )
 
     /// The curated onboarding ladder: the starter first (default
@@ -241,19 +265,20 @@ final class QuickstartCoordinator {
     /// ``ModelSizing`` / ``BenchScoresCatalog`` at render.
     static let onboardingChoices: [QuickstartModelChoice] = [
         defaultChoice,
+        lowMemoryChoice,
         QuickstartModelChoice(
             alias: "qwen3.5-4b-4bit",
             displayName: "Qwen 3.5 · 4B",
             hfRepo: nil,
             blurb: "Better everyday quality. Still light on disk.",
-            isStarter: false
+            tier: .tradeUp
         ),
         QuickstartModelChoice(
             alias: "qwen3.5-9b-4bit",
             displayName: "Qwen 3.5 · 9B",
             hfRepo: nil,
             blurb: "Strong all-rounder if you have the RAM to spare.",
-            isStarter: false
+            tier: .tradeUp
         ),
     ]
 
@@ -446,7 +471,7 @@ Open the picker any time to switch models.
             displayName: alias,
             hfRepo: nil,
             blurb: "",
-            isStarter: alias == defaultChoice.alias
+            tier: alias == defaultChoice.alias ? .starter : .tradeUp
         )
     }
 
@@ -978,7 +1003,8 @@ struct QuickstartView: View {
     }
 
     /// Step 2 — the model chooser: recommended starter (default
-    /// selection) + bigger trade-ups + "Browse all models". The primary
+    /// selection) + an honest low-memory fallback + bigger trade-ups +
+    /// "Browse all models". The primary
     /// footer button kicks off the download for the current selection.
     @ViewBuilder
     private var chooseModelStep: some View {
@@ -1004,13 +1030,27 @@ struct QuickstartView: View {
                         .padding(.bottom, 16)
                     }
 
+                    Text("NEED THE LIGHTEST OPTION?")
+                        .scaledSystemFont(10, weight: .semibold).tracking(1)
+                        .foregroundStyle(.tertiary)
+                        .padding(.bottom, 9)
+
+                    ForEach(choices.filter { $0.isLowMemory }) { choice in
+                        QuickstartLowMemoryCard(
+                            choice: choice,
+                            selected: coordinator.selection.alias == choice.alias,
+                            sizeText: Self.sizeText(for: choice.alias)
+                        ) { coordinator.select(choice) }
+                        .padding(.bottom, 16)
+                    }
+
                     Text("OR PICK A BIGGER ONE")
                         .scaledSystemFont(10, weight: .semibold).tracking(1)
                         .foregroundStyle(.tertiary)
                         .padding(.bottom, 9)
 
                     VStack(spacing: 9) {
-                        ForEach(choices.filter { !$0.isStarter }) { choice in
+                        ForEach(choices.filter { $0.tier == .tradeUp }) { choice in
                             QuickstartCompactCard(
                                 choice: choice,
                                 selected: coordinator.selection.alias == choice.alias,
@@ -1124,6 +1164,7 @@ struct QuickstartView: View {
     /// than dismissing the sheet out from under the decision.
     @ViewBuilder
     private func memoryWarningCard(_ warning: ModelSizing.MemoryWarning) -> some View {
+        let fallback = Self.lowMemoryRecoveryChoice(for: warning)
         ZStack {
             RoundedRectangle(cornerRadius: 16, style: .continuous)
                 .fill(RapidTheme.amberTint)
@@ -1147,6 +1188,24 @@ struct QuickstartView: View {
         .accessibilityElement(children: .combine)
         .accessibilityLabel("\(warning.title). \(warning.message)")
 
+        if let fallback {
+            Button {
+                server.cancelPendingMemoryLoad()
+                coordinator.returnToChooser()
+                coordinator.select(fallback)
+                startQuickstart()
+            } label: {
+                Text("Switch to \(fallback.displayName)")
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 2)
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.large)
+            .keyboardShortcut(.defaultAction)
+            .accessibilityIdentifier("Quickstart.Memory.SwitchToLowMemory")
+            .accessibilityLabel("Switch to \(fallback.displayName), the lowest-memory option")
+        }
+
         Button {
             // Re-enters ``start`` with the guard bypassed. We stay in
             // ``.starting``; ``handleServerStateChange`` seeds the welcome
@@ -1157,7 +1216,7 @@ struct QuickstartView: View {
                 .frame(maxWidth: .infinity)
                 .padding(.vertical, 2)
         }
-        .buttonStyle(.borderedProminent)
+        .buttonStyle(.bordered)
         .controlSize(.large)
         .accessibilityIdentifier("Quickstart.Memory.LoadAnyway")
 
@@ -1174,6 +1233,29 @@ struct QuickstartView: View {
         .controlSize(.large)
         .keyboardShortcut(.cancelAction)
         .accessibilityIdentifier("Quickstart.Memory.Cancel")
+    }
+
+    /// Return the curated low-memory fallback only when the same snapshot
+    /// that blocked the original load says the replacement falls below the
+    /// 85% danger line. This prevents a reassuring "Switch" button from
+    /// merely leading to a second warning. If the snapshot is unavailable,
+    /// Cancel still returns to the chooser and the fallback remains visible,
+    /// but the warning does not claim it is safe.
+    static func lowMemoryRecoveryChoice(
+        for warning: ModelSizing.MemoryWarning
+    ) -> QuickstartModelChoice? {
+        let fallback = QuickstartCoordinator.lowMemoryChoice
+        guard warning.alias != fallback.alias, warning.totalGB > 0 else { return nil }
+        let footprint = ModelSizing.estimate(alias: fallback.alias)
+        guard footprint.totalGB < warning.footprintGB else { return nil }
+        let gib = Double(1 << 30)
+        let usedGB = max(0, warning.totalGB - warning.freeGB)
+        let safety = ModelSizing.memorySafety(
+            footprint: footprint,
+            usedBytes: UInt64((usedGB * gib).rounded()),
+            totalBytes: UInt64((warning.totalGB * gib).rounded())
+        )
+        return safety == .unsafe ? nil : fallback
     }
 
     /// Which memory warning, if any, the Quickstart sheet must present

--- a/apps/rapid-mac/Tests/RapidTests/QuickstartViewTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/QuickstartViewTests.swift
@@ -542,8 +542,58 @@ struct QuickstartViewTests {
             isAutoRespawn: false,
             severity: .unsafe,
             footprintGB: 3.25,
-            freeGB: 0.7
+            freeGB: 0.7,
+            totalGB: 18
         )
+    }
+
+    @Test("Low-memory recovery is offered only when it clears the live danger line")
+    func lowMemoryRecoveryMustActuallyBeSafer() {
+        // On an 18 GB Mac, 12.2 GB already used makes the 3.36 GB starter
+        // unsafe (~86.4%) while the 3.03 GB 0.6B fallback stays below 85%.
+        let recoverable = ModelSizing.MemoryWarning(
+            alias: QuickstartCoordinator.defaultChoice.alias,
+            hfPath: QuickstartCoordinator.defaultChoice.hfRepo,
+            isAutoRespawn: false,
+            severity: .unsafe,
+            footprintGB: ModelSizing.estimate(alias: QuickstartCoordinator.defaultChoice.alias).totalGB,
+            freeGB: 5.8,
+            totalGB: 18
+        )
+        #expect(
+            QuickstartView.lowMemoryRecoveryChoice(for: recoverable)?.alias
+                == QuickstartCoordinator.lowMemoryChoice.alias
+        )
+
+        // Under heavier pressure the 0.6B would trip the same guard. Do not
+        // advertise a reassuring switch that merely opens a second warning.
+        let noSafeEscape = ModelSizing.MemoryWarning(
+            alias: QuickstartCoordinator.defaultChoice.alias,
+            hfPath: nil,
+            isAutoRespawn: false,
+            severity: .unsafe,
+            footprintGB: recoverable.footprintGB,
+            freeGB: 5.0,
+            totalGB: 18
+        )
+        #expect(QuickstartView.lowMemoryRecoveryChoice(for: noSafeEscape) == nil)
+    }
+
+    @Test("The fallback never recommends switching to itself or from an unverifiable snapshot")
+    func lowMemoryRecoveryAvoidsLoopsAndUnknownSnapshots() {
+        let fallback = QuickstartCoordinator.lowMemoryChoice
+        let selfWarning = ModelSizing.MemoryWarning(
+            alias: fallback.alias, hfPath: fallback.hfRepo, isAutoRespawn: false,
+            severity: .unsafe, footprintGB: 3.1, freeGB: 6, totalGB: 18
+        )
+        #expect(QuickstartView.lowMemoryRecoveryChoice(for: selfWarning) == nil)
+
+        let unknown = ModelSizing.MemoryWarning(
+            alias: QuickstartCoordinator.defaultChoice.alias, hfPath: nil,
+            isAutoRespawn: false, severity: .unsafe,
+            footprintGB: 3.4, freeGB: 6, totalGB: 0
+        )
+        #expect(QuickstartView.lowMemoryRecoveryChoice(for: unknown) == nil)
     }
 
     /// The deadlock scenario itself: a serve we handed off has parked on the
@@ -648,6 +698,17 @@ struct QuickstartViewSourceGrepTests {
         #expect(QuickstartCoordinator.defaultChoice.hfRepo == "mlx-community/LFM2.5-1.2B-Instruct-4bit")
         #expect(QuickstartCoordinator.defaultChoice.hfRepo?.contains("4B") != true)
     }
+
+    @Test("Onboarding keeps one explicit, honestly-labelled sub-1B escape hatch")
+    func lowMemoryChoiceIsExplicitAndHonest() {
+        let choice = QuickstartCoordinator.lowMemoryChoice
+        #expect(choice.alias == "qwen3-0.6b-4bit")
+        #expect(choice.tier == .lowMemory)
+        #expect(choice.blurb.localizedCaseInsensitiveContains("lowest memory"))
+        #expect(choice.blurb.localizedCaseInsensitiveContains("less accurate"))
+        #expect(choice.blurb.localizedCaseInsensitiveContains("not recommended for tools"))
+        #expect(QuickstartCoordinator.onboardingChoices.filter(\.isLowMemory) == [choice])
+    }
 }
 
 /// #1503 render-wiring source guard.
@@ -714,6 +775,14 @@ struct QuickstartMemoryWiringSourceGuardTests {
         #expect(
             src.contains("coordinator.returnToChooser()"),
             "Cancel no longer calls returnToChooser — the coordinator stays in .starting and the sheet never releases (#1503)."
+        )
+        #expect(
+            src.contains("Quickstart.Memory.SwitchToLowMemory"),
+            "The in-sheet warning no longer exposes the verified low-memory recovery action."
+        )
+        #expect(
+            src.contains("coordinator.select(fallback)"),
+            "The recovery action no longer retargets Quickstart to the verified fallback."
         )
     }
 

--- a/apps/rapid-mac/docs/gui-golden-flows.md
+++ b/apps/rapid-mac/docs/gui-golden-flows.md
@@ -10,14 +10,17 @@ Rapid-MLX Desktop app without loading a real model.
 3. basic chat, persisted conversation row, and restored transcript;
 4. a deliberately slow stream and semantic **Stop generating** action;
 5. model start, a one-shot sidecar crash, automatic respawn, and ready state.
+6. a memory-constrained user can see and select an honestly labelled sub-1B
+   fallback instead of being sent back to a chooser whose smallest visible
+   model is the one that just failed the live-memory guard.
 
 **Invariants** — properties that must hold, not paths a user walks. These were
 added after a release where every escaped defect landed on a surface no journey
 covered, and each one names the defect it would have caught:
 
-6. `update-state` — Settings → App must name the version the app actually is.
-7. `no-dead-controls` — every Settings panel must expose controls of its own.
-8. `catalog-integrity` — a model that cannot chat must never be offered as one.
+7. `update-state` — Settings → App must name the version the app actually is.
+8. `no-dead-controls` — every Settings panel must expose controls of its own.
+9. `catalog-integrity` — a model that cannot chat must never be offered as one.
 
 The distinction matters. A journey answers *"can someone do this?"*; an
 invariant answers *"is this still true everywhere?"*. The three defects below
@@ -63,6 +66,31 @@ Every journey gets a unique bundle identifier and throwaway `HOME` through
 lifecycle evidence, so the suite does not download a model or put meaningful
 pressure on unified memory.
 
+### Low-memory recovery
+
+The normal model picker intentionally hides sub-1B models: they fall below the
+default quality and tool-use floor, and presenting them beside normal choices
+without context makes a faster but worse answer look like a product failure.
+That policy cannot govern a recovery path. If the live memory guard says the
+starter is unsafe and tells the user to “pick a smaller model,” onboarding must
+actually contain one.
+
+`low-memory-choice` pins the visible half of that contract through AX:
+
+1. open fresh onboarding and advance to **Choose your first model**;
+2. find `Quickstart.Choice.qwen3-0.6b-4bit` under **LOWEST MEMORY**;
+3. assert that the card says **less accurate** and **not recommended for
+   tools**, so lower memory is not presented as equivalent quality;
+4. select it through AX and retain the before/after trees as evidence.
+
+The warning-to-switch half is deterministic Swift coverage rather than a host-
+RAM-dependent GUI trick. `QuickstartView.lowMemoryRecoveryChoice(for:)` replays
+the original live-memory snapshot against the fallback footprint and exposes
+`Quickstart.Memory.SwitchToLowMemory` only when the replacement falls below the
+85% danger line. Under heavier pressure the button is absent, avoiding a false
+promise or a warning loop; **Cancel** still returns to the chooser where the
+low-memory category remains visible.
+
 ## Run
 
 Build the current checkout, then run all flows:
@@ -77,6 +105,7 @@ Run one journey or retain its isolated persona for diagnosis:
 
 ```bash
 ./scripts/gui-golden-flows.sh --flow slow-stream-stop
+./scripts/gui-golden-flows.sh --flow low-memory-choice
 ./scripts/gui-golden-flows.sh --flow chat-restore --keep
 ./scripts/gui-golden-flows.sh --flow no-dead-controls
 ```

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -25,7 +25,7 @@ usage() {
 Usage: gui-golden-flows.sh [--flow NAME] [--keep]
 
 Flows: fresh-install, settings-persistence, chat-restore, slow-stream-stop,
-       model-crash-recovery, update-state, no-dead-controls,
+       model-crash-recovery, low-memory-choice, update-state, no-dead-controls,
        catalog-integrity, all
 
 Environment:
@@ -266,7 +266,7 @@ assert_tree_text() {
 }
 
 flow_fresh_install() {
-    log "1/5 fresh install and onboarding"
+    log "1/6 fresh install and onboarding"
     start_persona fresh-install
     see_main "$OUT/consent-visible.json"
     jq -e '.data.ui_elements[]? | select(.identifier == "TelemetryConsent.DontShare")' "$OUT/consent-visible.json" >/dev/null \
@@ -281,7 +281,7 @@ flow_fresh_install() {
 }
 
 flow_settings_persistence() {
-    log "2/5 settings and persistence"
+    log "2/6 settings and persistence"
     start_persona settings-persistence
     dismiss_first_run
     open_settings
@@ -316,7 +316,7 @@ flow_settings_persistence() {
 }
 
 flow_chat_restore() {
-    log "3/5 basic chat and session restore"
+    log "3/6 basic chat and session restore"
     start_persona chat-restore
     dismiss_first_run
     start_model
@@ -343,7 +343,7 @@ flow_chat_restore() {
 }
 
 flow_slow_stream_stop() {
-    log "4/5 controlled slow stream and Stop"
+    log "4/6 controlled slow stream and Stop"
     start_persona slow-stream-stop FAKE_INTER_TOKEN_SLEEP_S=0.01 FAKE_CONTENT_REPEAT=20000
     dismiss_first_run
     start_model
@@ -378,7 +378,7 @@ flow_slow_stream_stop() {
 }
 
 flow_model_crash_recovery() {
-    log "5/5 model lifecycle and crash recovery"
+    log "5/6 model lifecycle and crash recovery"
     start_persona model-crash-recovery FAKE_DIE_AFTER_CHUNKS=2 \
         FAKE_DIE_ONCE_STATE="$OUT_ROOT/model-crash-recovery/died-once"
     dismiss_first_run
@@ -405,6 +405,47 @@ flow_model_crash_recovery() {
     jq -n --argjson starts "$(grep -c '"event": "server_started"' "$OUT/fake-events.jsonl")" \
         '{success: true, assertion: "sidecar crashed once, respawned, and returned to ready", server_starts: $starts}' \
         > "$OUT/recovery-assertion.json"
+    cleanup_persona
+}
+
+flow_low_memory_choice() {
+    log "6/6 low-memory onboarding escape"
+    start_persona low-memory-choice
+
+    local tree="$OUT/onboarding.json"
+    see_main "$tree"
+    if jq -e '.data.ui_elements[]? | select(.identifier == "TelemetryConsent.DontShare")' "$tree" >/dev/null; then
+        press "$tree" TelemetryConsent.DontShare "$OUT/consent.json"
+    fi
+    wait_identifier Quickstart.GetStarted "$OUT/welcome.json"
+    press "$OUT/welcome.json" Quickstart.GetStarted "$OUT/get-started.json"
+    wait_identifier Quickstart.Choice.qwen3-0.6b-4bit "$OUT/model-choices.json"
+
+    local fallback_label
+    fallback_label="$(element_field "$OUT/model-choices.json" Quickstart.Choice.qwen3-0.6b-4bit description)"
+    [[ "$fallback_label" == *"Lowest memory"* ]] \
+        || die "low-memory choice is missing its spoken category label"
+    [[ "$fallback_label" == *"less accurate"* ]] \
+        || die "low-memory choice hides its quality trade-off"
+    [[ "$fallback_label" == *"not recommended for tools"* ]] \
+        || die "low-memory choice hides its tool-use limitation"
+    press "$OUT/model-choices.json" Quickstart.Choice.qwen3-0.6b-4bit "$OUT/select-low-memory.json"
+    see_main "$OUT/low-memory-selected.json"
+    jq -e '.data.ui_elements[]? | select(.identifier == "Quickstart.Choice.qwen3-0.6b-4bit")' \
+        "$OUT/low-memory-selected.json" >/dev/null \
+        || die "selecting the low-memory choice dismissed or replaced the chooser"
+    jq -e '.data.ui_elements[]? | select(.identifier == "Quickstart.Footer.Primary")' \
+        "$OUT/low-memory-selected.json" >/dev/null \
+        || die "selecting the low-memory choice left no Download & start action"
+    local sheet_region
+    sheet_region="$(jq -r '.data.ui_elements[] | select(.role == "AXSheet") | [.bounds.x, .bounds.y, .bounds.width, .bounds.height] | map(round) | @csv' "$OUT/low-memory-selected.json" | head -1)"
+    [[ -n "$sheet_region" ]] || die "Quickstart sheet bounds are absent from AX"
+    pb app switch --to "PID:$APP_PID" --verify --json > "$OUT/focus-before-image.json"
+    pb image --mode area --region "$sheet_region" --path "$OUT/low-memory-selected.png" --json \
+        > "$OUT/low-memory-selected-image.json"
+
+    jq -n '{success: true, assertion: "onboarding exposes and selects an honestly labelled sub-1B low-memory fallback"}' \
+        > "$OUT/low-memory-assertion.json"
     cleanup_persona
 }
 
@@ -508,6 +549,7 @@ case "$FLOW" in
     chat-restore) flow_chat_restore ;;
     slow-stream-stop) flow_slow_stream_stop ;;
     model-crash-recovery) flow_model_crash_recovery ;;
+    low-memory-choice) flow_low_memory_choice ;;
     update-state) flow_update_state ;;
     no-dead-controls) flow_no_dead_controls ;;
     catalog-integrity) flow_catalog_integrity ;;
@@ -517,6 +559,7 @@ case "$FLOW" in
         flow_chat_restore
         flow_slow_stream_stop
         flow_model_crash_recovery
+        flow_low_memory_choice
         flow_update_state
         flow_no_dead_controls
         flow_catalog_integrity


### PR DESCRIPTION
## What changed

- add an explicit Qwen 3 0.6B lowest-memory choice to Quickstart
- make the capability tradeoff visible instead of presenting it as equivalent to the recommended starter
- offer a direct warning recovery action only when the current memory snapshot says the smaller model clears the safety threshold
- add AX-driven golden-flow coverage and document the release journey

## Why

When memory pressure blocks the starter model, Cancel returned users to a chooser with no smaller option. That made the warning actionable in wording but not in product flow.

## Validation

- foreground AX golden flow passed with real app screenshot
- Swift RapidTests target builds successfully
- release Rapid.app build passed
- shell syntax and diff checks passed
- Codex review found no actionable correctness regressions

Full swift test remains unavailable on this host because the Command Line Tools environment cannot import XCTest in RapidUXTests; this is pre-existing and unrelated to the change.
