### PR TITLE
fix(rapid-mac): keep laptop recommendations conservative

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ or Homebrew — prebuilt bottle straight from homebrew-core:
 brew install rapid-mlx
 ```
 
-Both land the same `rapid-mlx` CLI. The curl installer additionally installs Python 3.10+ if missing, creates an isolated venv at `~/.rapid-mlx/`, symlinks the `rapid-mlx` CLI into `~/.local/bin/`, and prints a serve command sized to your Mac (8–15 GB → `lfm2.5-2.6b-4bit`; 16–23 GB → `bonsai-27b-2bit`; 24–31 GB → `gemma-4-26b-4bit`; 32–63 GB → `qwen3.6-35b-4bit`; 64–95 GB → `qwen3.6-35b-8bit`; 96 GB+ → `qwen3.5-122b-mxfp4`).
+Both land the same `rapid-mlx` CLI. The curl installer additionally installs Python 3.10+ if missing, creates an isolated venv at `~/.rapid-mlx/`, symlinks the `rapid-mlx` CLI into `~/.local/bin/`, and prints a serve command sized to your Mac (8–15 GB → `lfm2.5-2.6b-4bit`; 16–17 GB → `qwen3.5-4b-4bit`; 18–23 GB → `qwen3.5-9b-4bit`; 24–31 GB → `gemma-4-26b-4bit`; 32–63 GB → `qwen3.6-35b-4bit`; 64–95 GB → `qwen3.6-35b-8bit`; 96 GB+ → `qwen3.5-122b-mxfp4`).
 
 > **Install security.** `install.sh` is served over HTTPS (HSTS-preload) from `rapidmlx.com` and is a byte-identical mirror of [`install.sh`](install.sh) at the release commit — read it before running if you like. If you want a cryptographically verified installer rather than trusting the website pipe, don't `curl | bash` the URL above: instead download the release's `install.sh` asset, verify it against the cosign-signed `SHA256SUMS.txt` shipped alongside it, and run that verified copy — full recipe in [SECURITY.md](SECURITY.md). PyPI artifacts additionally carry Sigstore attestations (PEP 740). Two more low-trust paths:
 > - **Pin to a commit hash** — `curl -fsSL https://raw.githubusercontent.com/raullenchai/Rapid-MLX/<commit>/install.sh -o install.sh && shasum -a 256 install.sh && bash install.sh`
@@ -244,7 +244,8 @@ M3 Ultra (the engine quantizes the KV cache to int4 by default, so a bare
 | RAM | Recommended | Peak RSS | One-shot |
 |---|---|---:|---|
 | **8–15 GB** MacBook Air / base Mini | `lfm2.5-2.6b-4bit` | 2.0 GB | `rapid-mlx serve lfm2.5-2.6b-4bit` |
-| **16–23 GB** MacBook Air / Pro | `bonsai-27b-2bit` | 8.4 GB | `rapid-mlx serve bonsai-27b-2bit` |
+| **16–17 GB** MacBook Air / Pro | `qwen3.5-4b-4bit` | 5.9 GB | `rapid-mlx serve qwen3.5-4b-4bit` |
+| **18–23 GB** MacBook Pro | `qwen3.5-9b-4bit` | 8.7 GB | `rapid-mlx serve qwen3.5-9b-4bit` |
 | **24–31 GB** Mac Mini / MacBook Pro | `gemma-4-26b-4bit` | 15.6 GB | `rapid-mlx serve gemma-4-26b-4bit --no-mllm --kv-cache-dtype bf16 --cache-memory-mb 512` |
 | **32–63 GB** Mac Studio / high-spec Mini | `qwen3.6-35b-4bit` | 20.4 GB | `rapid-mlx serve qwen3.6-35b-4bit` |
 | **64–95 GB** Mac Studio | `qwen3.6-35b-8bit` | 37.7 GB | `rapid-mlx serve qwen3.6-35b-8bit` |

--- a/apps/rapid-mac/Sources/Rapid/Server/RAMBucketedDefault.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/RAMBucketedDefault.swift
@@ -32,17 +32,17 @@ import Foundation
 /// | RAM    | 🧠 Smart            | GB   | Cap | tok/s | 🚀 Fast                          |
 /// | ------ | ------------------- | ---- | --- | ----- | -------------------------------- |
 /// |  8 GB  | lfm2.5-2.6b-4bit    |  2.0 |  —  | 97.8  | — (only model that fits)         |
-/// | 16 GB  | bonsai-27b-2bit     |  8.4 | 86% | 17.8  | lfm2.5-8b-a1b-4bit · 121 · chat  |
-/// | 18 GB  | bonsai-27b-2bit     |  8.4 | 86% | 17.8  | lfm2.5-8b-a1b-4bit · 121 · chat  |
+/// | 16 GB  | qwen3.5-4b-4bit     |  5.9 | 78% | 157.6 | —                                |
+/// | 18 GB  | qwen3.5-9b-4bit     |  8.7 | 82% | 106.4 | qwen3.5-4b-4bit · 78% · 157.6    |
 /// | 24 GB  | gemma-4-26b-4bit    | 14.6 | 87% | 41.7  | — (smart pick already fast)      |
 /// | 32 GB  | qwen3.6-35b-4bit    | 20.0 | 87% | 60.0  | — (smart pick already fast)      |
 /// | 64 GB  | qwen3.6-35b-8bit    | 37.7 | 87% | —     | qwen3.6-35b-4bit · 87% · 60      |
 /// | 96 GB+ | qwen3.5-122b-mxfp4  | 65.0 | 88% | —     | qwen3.6-35b-4bit · 87% · 60      |
 ///
-/// 18 GB deliberately mirrors 16 GB (see the tier comment). The 16/18 GB
-/// fast pick is ``lfm2.5-8b-a1b-4bit`` — a chat specialist, so it shows
-/// "Chat only" instead of its blended 62 % (which understates conversation
-/// and overstates tools/coding). Capability % and tok/s are the
+/// Laptop tiers deliberately use the same conservative footprint model as
+/// the launch-time memory guard. A low-bit large model must not be labelled
+/// "Recommended" using a short-prompt RSS measurement only to be rejected
+/// later by the guard's KV/runtime budget. Capability % and tok/s are the
 /// maintainer's measured scores (M2/M3); the 64/96 GB smart rows have no
 /// local tok/s measurement yet (rendered without a speed figure).
 ///
@@ -105,12 +105,15 @@ enum RAMBucketedDefault {
         var picks: [Pick] { alt.map { [primary, $0] } ?? [primary] }
     }
 
-    /// The fast/light pick shared by every tier whose smart pick is slow:
-    /// an 8B-A1B MoE at ~121 tok/s. A chat specialist, so it carries a
-    /// "Chat only" caveat instead of its (misleadingly low) blended score.
-    private static let lfm2FastPick = Pick(
-        alias: "lfm2.5-8b-a1b-4bit", footprintGB: 5.3, capabilityPct: 62,
-        tokensPerSec: 121.2, launchFlags: [], caveat: "Chat only")
+    /// Conservative general-purpose laptop picks. Both have verified tool
+    /// calling and stay within the same footprint budget enforced at launch.
+    private static let qwen4Pick = Pick(
+        alias: "qwen3.5-4b-4bit", footprintGB: 5.9, capabilityPct: 78,
+        tokensPerSec: 157.6, launchFlags: [])
+
+    private static let qwen9Pick = Pick(
+        alias: "qwen3.5-9b-4bit", footprintGB: 8.7, capabilityPct: 82,
+        tokensPerSec: 106.4, launchFlags: [])
 
     /// The 8 GB tier's only pick: LFM2.5-2.6B, a 2.6 B dense model whose
     /// 30 layers are 22 short-convolution blocks and just 8 GQA. Those 8
@@ -156,21 +159,18 @@ enum RAMBucketedDefault {
         Tier(floorGB: 8, primary: lfm26Pick, alt: nil),
         Tier(
             floorGB: 16,
-            primary: Pick(alias: "bonsai-27b-2bit", footprintGB: 8.4, capabilityPct: 86, tokensPerSec: 17.8, launchFlags: []),
-            alt: lfm2FastPick
+            primary: qwen4Pick,
+            alt: nil
         ),
-        // 18 GB intentionally MIRRORS the 16 GB tier (bonsai smart + lfm2.5
-        // fast). An 18 GB Mac has no headroom for a meaningfully stronger
-        // model than bonsai-27b-2bit that we'd trust, and the gemma-4-12b
-        // that used to sit here read WEAKER (72 %) than 16 GB's bonsai
-        // (86 %) — a "more RAM, worse pick" dip. Rather than ship that
-        // inversion we keep bonsai here too; the tier stays explicit (not
-        // folded into 16 GB) so a future 18 GB-specific pick is a one-line
-        // edit. gemma-4-12b remains available in the full "All models" list.
+        // 18 GB gets the verified 9B general-purpose model plus the 4B fast
+        // option. Do not promote bonsai-27b-2bit here: its measured 8.4 GB
+        // short-prompt RSS conflicts with the launch guard's conservative
+        // ~15 GB budget, producing a recommendation followed by a crash
+        // warning after the user has downloaded it.
         Tier(
             floorGB: 18,
-            primary: Pick(alias: "bonsai-27b-2bit", footprintGB: 8.4, capabilityPct: 86, tokensPerSec: 17.8, launchFlags: []),
-            alt: lfm2FastPick
+            primary: qwen9Pick,
+            alt: qwen4Pick
         ),
         // 24 & 32 GB: the smart pick is already MoE-fast (42 / 60 tok/s),
         // so it stands alone — a slower or much-weaker "fast" card here

--- a/apps/rapid-mac/Sources/Rapid/UI/ModelPickerBar.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ModelPickerBar.swift
@@ -13,9 +13,9 @@ import SwiftUI
 ///   │  lfm2.5-1b-4bit · Smallest model — fastest   │ ← RAM-blind, F-LWT-1
 ///   │  first install                                │
 ///   ├── Recommended for your 18 GB Mac ─────────────┤
-///   │  Best pick   bonsai-27b-2bit   [amber row     │ ← the RAM tier's
+///   │  Recommended qwen3.5-9b-4bit   [amber row     │ ← the RAM tier's
 ///   │              when selected]                   │   smart pick
-///   │  Faster      lfm2.5-8b-a1b-4bit               │ ← optional fast/light alt
+///   │  Faster      qwen3.5-4b-4bit                  │ ← optional fast/light alt
 ///   ├── All models (alphabetical) ──────────────────┤
 ///   │  bonsai-1.7b-unpacked                         │
 ///   │  deepseek-coder-v2-lite-16b-4bit            ● │ ← green dot = cached
@@ -838,7 +838,9 @@ struct ModelPickerBar: View {
             filtered: filtered,
             quickstartRowRendered: quickstartEntry() != nil
         )
-        let sorted = ModelPickerBar.orderedAllModels(deduped)
+        let partition = ModelPickerBar.partitionByFit(deduped, hardware: hardware)
+        let sorted = ModelPickerBar.orderedAllModels(partition.fits)
+        let notFit = ModelPickerBar.orderedAllModels(partition.notFit)
         let hiddenCount = ModelPickerVisibility.hiddenCount(
             catalog,
             selectedAlias: alias,
@@ -877,6 +879,33 @@ struct ModelPickerBar: View {
                 }
             }
         }
+        if !notFit.isEmpty {
+            Section("Not fit for this Mac") {
+                ForEach(notFit) { entry in
+                    aliasButton(entry, notFit: true)
+                }
+            }
+        }
+    }
+
+    /// Keep oversized aliases discoverable without presenting them beside
+    /// models this Mac can actually run. Download remains available; the
+    /// launch-time live-memory guard is still the final safety boundary.
+    static func partitionByFit(
+        _ entries: [ModelEntry],
+        hardware: MacHardware
+    ) -> (fits: [ModelEntry], notFit: [ModelEntry]) {
+        var fits: [ModelEntry] = []
+        var notFit: [ModelEntry] = []
+        for entry in entries {
+            let fit = ModelSizing.classify(ModelSizing.estimate(alias: entry.alias), on: hardware)
+            if fit == .tooBig {
+                notFit.append(entry)
+            } else {
+                fits.append(entry)
+            }
+        }
+        return (fits, notFit)
     }
 
     /// One row inside the "Recommended for your N GB Mac" section.
@@ -1040,13 +1069,18 @@ struct ModelPickerBar: View {
     /// Rows are no longer disabled by ``.tooBig``: a user can pick
     /// any alias from the picker, and the Start CTA wires the actual
     /// guardrail via the confirmation alert.
-    private func aliasButton(_ entry: ModelEntry) -> some View {
+    private func aliasButton(_ entry: ModelEntry, notFit: Bool = false) -> some View {
         let bucket = ModelPickerVisibility.qualityBucket(for: entry.alias)
+        let footprint = ModelSizing.estimate(alias: entry.alias)
         return Button {
             onUserSelection()
             alias = entry.alias
         } label: {
-            entryLabel(entry, bucket: bucket)
+            Label(
+                ModelPickerBar.aliasButtonTitle(alias: entry.alias, bucket: bucket)
+                    + (notFit ? " · needs ~\(Int(footprint.totalGB.rounded())) GB" : ""),
+                systemImage: ModelPickerBar.cacheGlyph(cached: entry.cached)
+            )
         }
         .disabled(deleting == entry.alias)
         // cycle-10: rows in the .tiny (< 1B) and .small (>= 1B,
@@ -1055,8 +1089,9 @@ struct ModelPickerBar: View {
         // the cache-state cue. Combined into one string via
         // ``qualityRowHelpText`` so the help() modifier stays a single
         // value and tests can pin the multi-line copy.
-        .help(
-            ModelPickerBar.aliasRowHelpText(
+        .help(notFit
+            ? "Estimated to need about \(Int(footprint.totalGB.rounded())) GB; this Mac has \(Int(hardware.usableRAMGB.rounded())) GB available for models. You can download it, but starting it may fail or destabilize the Mac."
+            : ModelPickerBar.aliasRowHelpText(
                 alias: entry.alias,
                 bucket: bucket,
                 cached: entry.cached
@@ -1074,7 +1109,7 @@ struct ModelPickerBar: View {
                 alias: entry.alias,
                 cached: entry.cached,
                 bucket: bucket
-            )
+            ) + (notFit ? ". Not fit for this Mac. Needs about \(Int(footprint.totalGB.rounded())) gigabytes" : "")
         )
         // v0.5.2: right-click → "Delete from disk". Cached rows
         // only — uncached models would just trigger "alias not

--- a/apps/rapid-mac/Tests/RapidTests/ModelPickerBarSectionOrderTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ModelPickerBarSectionOrderTests.swift
@@ -2,7 +2,7 @@ import Foundation
 import Testing
 @testable import Rapid
 
-/// F-LWT-1 contract — the picker dropdown surfaces THREE sections in
+/// F-LWT-1 contract — the picker dropdown surfaces four sections in
 /// a pinned order:
 ///
 ///   ┌── Quickstart ──────────────────────────────────────┐
@@ -11,6 +11,8 @@ import Testing
 ///   │  Default | Speed | Quality | Coding | Vision       │ ← RAM-aware, role-anchored
 ///   ├── All models (alphabetical) ───────────────────────┤
 ///   │  alpha … omega                                     │ ← dedup: Quickstart alias excluded
+///   ├── Not fit for this Mac ────────────────────────────┤
+///   │  oversized aliases remain downloadable            │
 ///   └────────────────────────────────────────────────────┘
 ///
 /// The Quickstart section is a NEW row landed in F-LWT-1 (the 0.6B
@@ -25,8 +27,9 @@ import Testing
 ///     matching the Quickstart card's promise.
 ///   * Recommended goes SECOND because it's RAM-aware (different
 ///     advice on a 16 GB Mac vs a 64 GB Mac).
-///   * All models goes LAST because it's the long-tail browse
-///     surface for power users.
+///   * All models contains runnable long-tail choices.
+///   * Not fit for this Mac stays last: oversized choices remain
+///     downloadable, but cannot masquerade as normal recommendations.
 ///
 /// Dedup invariant: the Quickstart alias must NEVER appear in BOTH
 /// the Quickstart section AND the All models section — otherwise
@@ -36,6 +39,22 @@ import Testing
 @MainActor
 @Suite("ModelPickerBar section order — F-LWT-1 Quickstart section")
 struct ModelPickerBarSectionOrderTests {
+
+    @Test("Oversized aliases are separated from runnable All models")
+    func partitionsByConservativeFit() {
+        let hardware = MacHardware(
+            brandString: "Apple M3 Pro", family: .m3, tier: .pro,
+            physicalRAMBytes: 18 * 1024 * 1024 * 1024,
+            memoryBandwidthGBs: 150
+        )
+        let entries = [
+            entry("qwen3.5-4b-4bit", hfRepo: "stub/qwen4", cached: false),
+            entry("gemma-4-26b-4bit", hfRepo: "stub/gemma26", cached: false),
+        ]
+        let result = ModelPickerBar.partitionByFit(entries, hardware: hardware)
+        #expect(result.fits.map(\.alias) == ["qwen3.5-4b-4bit"])
+        #expect(result.notFit.map(\.alias) == ["gemma-4-26b-4bit"])
+    }
 
     /// Synthetic catalog covering all three sections: one Quickstart
     /// alias, three Recommended-bucket aliases, four miscellaneous

--- a/apps/rapid-mac/Tests/RapidTests/RAMBucketedDefaultTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/RAMBucketedDefaultTests.swift
@@ -11,8 +11,8 @@ import Testing
 /// numbers):
 ///
 ///    8 GB  → lfm2.5-2.6b-4bit  (· Not for coding — only model that fits)
-///   16 GB  → bonsai-27b-2bit   (+ fast lfm2.5-8b-a1b-4bit · Chat only)
-///   18 GB  → bonsai-27b-2bit   (mirrors 16 GB) (+ fast lfm2.5-8b-a1b-4bit)
+///   16 GB  → qwen3.5-4b-4bit
+///   18 GB  → qwen3.5-9b-4bit   (+ fast qwen3.5-4b-4bit)
 ///   24 GB  → gemma-4-26b-4bit  (--no-mllm --kv-cache-dtype bf16 --cache-memory-mb 512)
 ///   32 GB  → qwen3.6-35b-4bit
 ///   64 GB  → qwen3.6-35b-8bit  (+ fast qwen3.6-35b-4bit)
@@ -31,9 +31,9 @@ struct RAMBucketedDefaultTests {
     @Test("Each RAM lands on the tier whose floor is the largest ≤ its RAM")
     func aliasPerRAM() {
         #expect(RAMBucketedDefault.alias(forPhysicalRAMGB: 8) == "lfm2.5-2.6b-4bit")   // 8 GB is its own tier now
-        #expect(RAMBucketedDefault.alias(forPhysicalRAMGB: 16) == "bonsai-27b-2bit")
-        #expect(RAMBucketedDefault.alias(forPhysicalRAMGB: 17) == "bonsai-27b-2bit")
-        #expect(RAMBucketedDefault.alias(forPhysicalRAMGB: 18) == "bonsai-27b-2bit")   // 18 mirrors 16
+        #expect(RAMBucketedDefault.alias(forPhysicalRAMGB: 16) == "qwen3.5-4b-4bit")
+        #expect(RAMBucketedDefault.alias(forPhysicalRAMGB: 17) == "qwen3.5-4b-4bit")
+        #expect(RAMBucketedDefault.alias(forPhysicalRAMGB: 18) == "qwen3.5-9b-4bit")
         #expect(RAMBucketedDefault.alias(forPhysicalRAMGB: 24) == "gemma-4-26b-4bit")
         #expect(RAMBucketedDefault.alias(forPhysicalRAMGB: 32) == "qwen3.6-35b-4bit")
         #expect(RAMBucketedDefault.alias(forPhysicalRAMGB: 48) == "qwen3.6-35b-4bit")   // 32 tier
@@ -44,7 +44,7 @@ struct RAMBucketedDefaultTests {
 
     @Test("A 20 GB Mac rounds DOWN to the 18 GB pick (fits), not up to 24 GB")
     func roundsDownNotUp() {
-        #expect(RAMBucketedDefault.alias(forPhysicalRAMGB: 20) == "bonsai-27b-2bit")   // 18 tier (mirrors 16)
+        #expect(RAMBucketedDefault.alias(forPhysicalRAMGB: 20) == "qwen3.5-9b-4bit")
         #expect(RAMBucketedDefault.alias(forPhysicalRAMGB: 30) == "gemma-4-26b-4bit")
     }
 
@@ -64,17 +64,15 @@ struct RAMBucketedDefaultTests {
         #expect(smallest.count == 1)
         #expect(smallest[0].alias == "lfm2.5-2.6b-4bit")
         #expect(smallest[0].caveat == "Not for coding")
-        // 16/18 GB: slow smart pick → a fast lfm2.5 alt (chat specialist).
+        // 16 GB: conservative general-purpose default, no duplicate alt.
         let tier16 = RAMBucketedDefault.picks(forPhysicalRAMGB: 16)
-        #expect(tier16.count == 2)
-        #expect(tier16[0].alias == "bonsai-27b-2bit")
-        #expect(tier16[1].alias == "lfm2.5-8b-a1b-4bit")
-        #expect(tier16[1].caveat == "Chat only")
-        // 18 GB mirrors 16 GB (bonsai smart + lfm2.5 fast).
+        #expect(tier16.count == 1)
+        #expect(tier16[0].alias == "qwen3.5-4b-4bit")
+        // 18 GB: 9B smart + 4B fast, both verified for tools.
         let tier18 = RAMBucketedDefault.picks(forPhysicalRAMGB: 18)
         #expect(tier18.count == 2)
-        #expect(tier18[0].alias == "bonsai-27b-2bit")
-        #expect(tier18[1].alias == "lfm2.5-8b-a1b-4bit")
+        #expect(tier18[0].alias == "qwen3.5-9b-4bit")
+        #expect(tier18[1].alias == "qwen3.5-4b-4bit")
         // 24/32 GB: smart pick is already MoE-fast → stands alone.
         #expect(RAMBucketedDefault.picks(forPhysicalRAMGB: 24).count == 1)
         #expect(RAMBucketedDefault.picks(forPhysicalRAMGB: 32).count == 1)
@@ -92,7 +90,7 @@ struct RAMBucketedDefaultTests {
 
     @Test("Flags apply only when the alias IS the pick for that Mac's RAM")
     func launchFlagsAreRAMGated() {
-        #expect(RAMBucketedDefault.launchFlags(forAlias: "bonsai-27b-2bit", physicalRAMGB: 18).isEmpty)
+        #expect(RAMBucketedDefault.launchFlags(forAlias: "qwen3.5-9b-4bit", physicalRAMGB: 18).isEmpty)
         #expect(RAMBucketedDefault.launchFlags(forAlias: "gemma-4-26b-4bit", physicalRAMGB: 24)
             == ["--no-mllm", "--kv-cache-dtype", "bf16", "--cache-memory-mb", "512"])
         #expect(RAMBucketedDefault.launchFlags(forAlias: "qwen3.6-35b-4bit", physicalRAMGB: 32).isEmpty)
@@ -104,9 +102,10 @@ struct RAMBucketedDefaultTests {
 
     @Test("isRecommendedPick is true only for this Mac's primary or alt, and is floor-gated")
     func isRecommendedPickContract() {
-        #expect(RAMBucketedDefault.isRecommendedPick(alias: "bonsai-27b-2bit", physicalRAMGB: 16))
-        #expect(RAMBucketedDefault.isRecommendedPick(alias: "lfm2.5-8b-a1b-4bit", physicalRAMGB: 16))
-        #expect(RAMBucketedDefault.isRecommendedPick(alias: "bonsai-27b-2bit", physicalRAMGB: 18))   // 18 mirrors 16
+        #expect(RAMBucketedDefault.isRecommendedPick(alias: "qwen3.5-4b-4bit", physicalRAMGB: 16))
+        #expect(RAMBucketedDefault.isRecommendedPick(alias: "qwen3.5-9b-4bit", physicalRAMGB: 18))
+        #expect(RAMBucketedDefault.isRecommendedPick(alias: "qwen3.5-4b-4bit", physicalRAMGB: 18))
+        #expect(!RAMBucketedDefault.isRecommendedPick(alias: "bonsai-27b-2bit", physicalRAMGB: 18))
         #expect(!RAMBucketedDefault.isRecommendedPick(alias: "gemma-4-12b-4bit", physicalRAMGB: 18)) // dropped from picks
         // An 8 GB Mac now SITS IN a tier, so its own pick is exempt from the
         // .tooBig gate — that exemption is the whole point of the tier, since
@@ -115,13 +114,30 @@ struct RAMBucketedDefaultTests {
         // The bigger models are still NOT exempt there: they are not this
         // tier's picks, so the OOM hole stays closed.
         #expect(!RAMBucketedDefault.isRecommendedPick(alias: "bonsai-27b-2bit", physicalRAMGB: 8))
-        #expect(!RAMBucketedDefault.isRecommendedPick(alias: "lfm2.5-8b-a1b-4bit", physicalRAMGB: 8))
+        #expect(!RAMBucketedDefault.isRecommendedPick(alias: "qwen3.5-4b-4bit", physicalRAMGB: 8))
         // Below the lowest floor there is still no exemption for anything.
         #expect(!RAMBucketedDefault.isRecommendedPick(alias: "lfm2.5-2.6b-4bit", physicalRAMGB: 4))
         // The fast alt is a recommended pick on its own tiers (64/96 GB),
         // so it also skips the .tooBig gate there.
         #expect(RAMBucketedDefault.isRecommendedPick(alias: "qwen3.6-35b-4bit", physicalRAMGB: 64))
         #expect(RAMBucketedDefault.isRecommendedPick(alias: "qwen3.6-35b-4bit", physicalRAMGB: 96))
+    }
+
+    @Test("Laptop recommendations agree with the conservative launch sizing guard")
+    func laptopRecommendationsDoNotRequireSizingBypass() {
+        for ram in [16.0, 18.0] {
+            let hardware = MacHardware(
+                brandString: "Apple Silicon", family: .m3, tier: .base,
+                physicalRAMBytes: UInt64(ram * Double(1 << 30)),
+                memoryBandwidthGBs: 100
+            )
+            for pick in RAMBucketedDefault.picks(forPhysicalRAMGB: ram) {
+                #expect(
+                    ModelSizing.classify(ModelSizing.estimate(alias: pick.alias), on: hardware) != .tooBig,
+                    "\(pick.alias) must not be recommended and then rejected by the launch budget"
+                )
+            }
+        }
     }
 
     // MARK: - Table invariants

--- a/apps/rapid-mac/scripts/verify-recommendation-tiers.swift
+++ b/apps/rapid-mac/scripts/verify-recommendation-tiers.swift
@@ -33,20 +33,18 @@ struct Tier: Equatable {
     let alt: Pick?
     var picks: [Pick] { alt.map { [primary, $0] } ?? [primary] }
 }
-let lfm2FastPick = Pick(alias: "lfm2.5-8b-a1b-4bit", footprintGB: 5.3, capabilityPct: 62,
-                        tokensPerSec: 121.2, launchFlags: [], caveat: "Chat only")
+let qwen4Pick = Pick(alias: "qwen3.5-4b-4bit", footprintGB: 5.9, capabilityPct: 78,
+                     tokensPerSec: 157.6, launchFlags: [])
+let qwen9Pick = Pick(alias: "qwen3.5-9b-4bit", footprintGB: 8.7, capabilityPct: 82,
+                     tokensPerSec: 106.4, launchFlags: [])
 let lfm26Pick = Pick(alias: "lfm2.5-2.6b-4bit", footprintGB: 2.0, capabilityPct: 62,
                      tokensPerSec: 97.8, launchFlags: [], caveat: "Not for coding")
 let qwen35bFastPick = Pick(alias: "qwen3.6-35b-4bit", footprintGB: 20.0, capabilityPct: 87,
                            tokensPerSec: 60.0, launchFlags: [])
 let tiers: [Tier] = [
     Tier(floorGB: 8, primary: lfm26Pick, alt: nil),
-    Tier(floorGB: 16,
-         primary: Pick(alias: "bonsai-27b-2bit", footprintGB: 8.4, capabilityPct: 86, tokensPerSec: 17.8, launchFlags: []),
-         alt: lfm2FastPick),
-    Tier(floorGB: 18,  // mirrors 16 GB (bonsai + lfm2.5) — no "more RAM, worse pick" dip
-         primary: Pick(alias: "bonsai-27b-2bit", footprintGB: 8.4, capabilityPct: 86, tokensPerSec: 17.8, launchFlags: []),
-         alt: lfm2FastPick),
+    Tier(floorGB: 16, primary: qwen4Pick, alt: nil),
+    Tier(floorGB: 18, primary: qwen9Pick, alt: qwen4Pick),
     Tier(floorGB: 24,
          primary: Pick(alias: "gemma-4-26b-4bit", footprintGB: 14.6, capabilityPct: 87, tokensPerSec: 41.7,
                        launchFlags: ["--no-mllm", "--kv-cache-dtype", "bf16", "--cache-memory-mb", "512"]),
@@ -107,10 +105,10 @@ check(alias(forPhysicalRAMGB: 4)  == "lfm2.5-2.6b-4bit",    "sub-8GB clamps DOWN
 check(alias(forPhysicalRAMGB: 0)  == "lfm2.5-2.6b-4bit",    "0GB clamps to the smallest tier")
 check(alias(forPhysicalRAMGB: -1) == "lfm2.5-2.6b-4bit",    "negative RAM clamps to the smallest tier")
 check(alias(forPhysicalRAMGB: 15) == "lfm2.5-2.6b-4bit",    "15GB rounds DOWN to 8, not up to 16")
-check(alias(forPhysicalRAMGB: 16) == "bonsai-27b-2bit",     "16GB → bonsai-27b-2bit")
-check(alias(forPhysicalRAMGB: 17) == "bonsai-27b-2bit",     "17GB → still 16 tier")
-check(alias(forPhysicalRAMGB: 18) == "bonsai-27b-2bit",     "18GB → bonsai (mirrors 16 tier)")
-check(alias(forPhysicalRAMGB: 20) == "bonsai-27b-2bit",     "20GB rounds DOWN to 18 (bonsai), not 24")
+check(alias(forPhysicalRAMGB: 16) == "qwen3.5-4b-4bit",     "16GB → qwen3.5-4b")
+check(alias(forPhysicalRAMGB: 17) == "qwen3.5-4b-4bit",     "17GB → still 16 tier")
+check(alias(forPhysicalRAMGB: 18) == "qwen3.5-9b-4bit",     "18GB → qwen3.5-9b")
+check(alias(forPhysicalRAMGB: 20) == "qwen3.5-9b-4bit",     "20GB rounds DOWN to 18 (qwen9), not 24")
 check(alias(forPhysicalRAMGB: 24) == "gemma-4-26b-4bit",    "24GB → gemma-4-26b")
 check(alias(forPhysicalRAMGB: 30) == "gemma-4-26b-4bit",    "30GB → 24 tier")
 check(alias(forPhysicalRAMGB: 32) == "qwen3.6-35b-4bit",    "32GB → qwen3.6-35b-4bit")
@@ -120,11 +118,9 @@ check(alias(forPhysicalRAMGB: 96) == "qwen3.5-122b-mxfp4",  "96GB → 122b-mxfp4
 check(alias(forPhysicalRAMGB: 256) == "qwen3.5-122b-mxfp4", "256GB → 96 tier (122b-mxfp4)")
 
 print("Smart + fast picks per tier (fast alt only where it beats the smart pick on speed):")
-// 16/18 GB → slow smart pick, so a fast lfm2.5 alt.
-check(picks(forPhysicalRAMGB: 16).count == 2, "16GB has smart + fast")
-check(picks(forPhysicalRAMGB: 16)[1].alias == "lfm2.5-8b-a1b-4bit", "16GB fast is lfm2.5")
+check(picks(forPhysicalRAMGB: 16).count == 1, "16GB conservative pick stands alone")
 check(picks(forPhysicalRAMGB: 18).count == 2, "18GB has smart + fast")
-check(picks(forPhysicalRAMGB: 18)[1].alias == "lfm2.5-8b-a1b-4bit", "18GB fast is lfm2.5")
+check(picks(forPhysicalRAMGB: 18)[1].alias == "qwen3.5-4b-4bit", "18GB fast is qwen3.5-4b")
 // 24/32 GB → smart pick is already MoE-fast, so it stands alone.
 check(picks(forPhysicalRAMGB: 24).count == 1, "24GB smart pick stands alone (already fast)")
 check(picks(forPhysicalRAMGB: 32).count == 1, "32GB smart pick stands alone (already fast)")
@@ -158,13 +154,10 @@ for (a, b) in zip(floors, floors.dropFirst()) {
 }
 // 18 GB mirrors 16 GB (bonsai smart + lfm2.5 fast) — the old gemma-4-12b that
 // read 72 % (below 16 GB's 86 %) was dropped from the tier picks.
-check(picks(forPhysicalRAMGB: 18)[0].alias == "bonsai-27b-2bit" && picks(forPhysicalRAMGB: 18)[0].capabilityPct == 86, "18GB smart = bonsai 86% (mirrors 16GB)")
+check(picks(forPhysicalRAMGB: 18)[0].alias == "qwen3.5-9b-4bit" && picks(forPhysicalRAMGB: 18)[0].capabilityPct == 82, "18GB smart = qwen9 82%")
 check(!tiers.flatMap(\.picks).contains { $0.alias == "gemma-4-12b-4bit" }, "gemma-4-12b is no longer a tier pick")
 
-print("Fast chat-specialist shows a 'Chat only' caveat instead of a misleading capability %:")
-let fast16 = picks(forPhysicalRAMGB: 16)[1]
-check(fast16.caveat == "Chat only", "16GB fast (lfm2.5) carries the Chat only caveat")
-check(pickStatsLine(fast16) == "5.3 GB · ~121 tok/s · Chat only", "lfm2.5 stats line drops the % for the caveat")
+print("Smallest tier shows an honest capability caveat:")
 // Liquid publishes 2.6B as "not recommended for agentic coding" — our users
 // drive coding agents, so the card must say so instead of showing a bare %.
 let smart8 = picks(forPhysicalRAMGB: 8)[0]
@@ -176,13 +169,13 @@ let fast96 = picks(forPhysicalRAMGB: 96)[1]
 check(fast96.caveat == nil, "96GB fast (qwen3.6-35b-4bit) is general-purpose — no caveat")
 check(pickStatsLine(fast96) == "20.0 GB · 87% capability · ~60 tok/s", "general-purpose fast pick keeps its capability %")
 let smart16 = picks(forPhysicalRAMGB: 16)[0]
-check(pickStatsLine(smart16) == "8.4 GB · 86% capability · ~18 tok/s", "bonsai renders its served PEAK, not its weight bytes")
+check(pickStatsLine(smart16) == "5.9 GB · 78% capability · ~158 tok/s", "16GB qwen4 renders conservative footprint")
 let smart96 = picks(forPhysicalRAMGB: 96)[0]
 check(pickStatsLine(smart96) == "65.0 GB · 88% capability", "no-tok/s smart pick omits the speed figure")
 
 print("Launch flags travel with the recommendation, gated by RAM:")
 check(launchFlags(forAlias: "lfm2.5-2.6b-4bit", physicalRAMGB: 8).isEmpty, "8GB lfm2.5-2.6b → no flags")
-check(launchFlags(forAlias: "bonsai-27b-2bit", physicalRAMGB: 18).isEmpty, "18GB bonsai → no flags")
+check(launchFlags(forAlias: "qwen3.5-9b-4bit", physicalRAMGB: 18).isEmpty, "18GB qwen9 → no flags")
 check(launchFlags(forAlias: "gemma-4-26b-4bit", physicalRAMGB: 24) == ["--no-mllm", "--kv-cache-dtype", "bf16", "--cache-memory-mb", "512"], "24GB gemma-26b → kv trio")
 check(launchFlags(forAlias: "qwen3.6-35b-4bit", physicalRAMGB: 32).isEmpty, "35b-4bit → no flags")
 // Key: hand-picking gemma-26b on a big Mac (where it is NOT the pick) → no forced flags.
@@ -190,12 +183,12 @@ check(launchFlags(forAlias: "gemma-4-26b-4bit", physicalRAMGB: 64).isEmpty, "gem
 check(launchFlags(forAlias: "some-random", physicalRAMGB: 32).isEmpty, "unknown alias → no flags")
 
 print("isRecommendedPick is floor-gated (the floor is now 8 GB, not 16):")
-check(isRecommendedPick(alias: "bonsai-27b-2bit", physicalRAMGB: 16), "bonsai IS recommended on 16GB (in tier)")
-check(isRecommendedPick(alias: "lfm2.5-8b-a1b-4bit", physicalRAMGB: 16), "lfm2.5 alt IS recommended on 16GB")
+check(isRecommendedPick(alias: "qwen3.5-4b-4bit", physicalRAMGB: 16), "qwen4 IS recommended on 16GB")
 check(isRecommendedPick(alias: "lfm2.5-2.6b-4bit", physicalRAMGB: 8), "lfm2.5-2.6b IS recommended on 8GB (its own tier)")
 check(!isRecommendedPick(alias: "bonsai-27b-2bit", physicalRAMGB: 8), "bonsai still NOT recommended on 8GB (not in the 8 tier)")
 check(!isRecommendedPick(alias: "lfm2.5-2.6b-4bit", physicalRAMGB: 4), "sub-floor 4GB Mac gets NO exemption even from its own tier pick")
-check(isRecommendedPick(alias: "bonsai-27b-2bit", physicalRAMGB: 18), "bonsai recommended on 18GB (mirrors 16 tier)")
+check(isRecommendedPick(alias: "qwen3.5-9b-4bit", physicalRAMGB: 18), "qwen9 recommended on 18GB")
+check(!isRecommendedPick(alias: "bonsai-27b-2bit", physicalRAMGB: 18), "bonsai is never recommended on laptop tiers")
 check(!isRecommendedPick(alias: "gemma-4-12b-4bit", physicalRAMGB: 18), "gemma-12b NOT recommended anywhere (dropped from picks)")
 check(isRecommendedPick(alias: "gemma-4-26b-4bit", physicalRAMGB: 24), "gemma-26b recommended on 24GB")
 check(isRecommendedPick(alias: "qwen3.5-122b-mxfp4", physicalRAMGB: 96), "122b-mxfp4 recommended on 96GB")
@@ -216,11 +209,8 @@ func rejectsForAutoStart(alias a: String, modelSizingSaysTooBig tooBig: Bool, ph
 }
 
 print("Launch auto-start never rejects the curated recommendation (codex r6 MAJOR):")
-// bonsai-27b-2bit is really 7.6GB but ModelSizing over-estimates it as
-// ~14.8GB → .tooBig on a 16GB Mac. It IS the 16-tier pick, so auto-start
-// must keep it (not fall through to .noResolvableAlias / an unrelated model).
-check(!rejectsForAutoStart(alias: "bonsai-27b-2bit", modelSizingSaysTooBig: true, physicalRAMGB: 16),
-      "16GB: recommended bonsai NOT rejected despite ModelSizing .tooBig")
+check(rejectsForAutoStart(alias: "bonsai-27b-2bit", modelSizingSaysTooBig: true, physicalRAMGB: 16),
+      "16GB: bonsai is no longer exempt from ModelSizing .tooBig")
 check(rejectsForAutoStart(alias: "bonsai-27b-2bit", modelSizingSaysTooBig: true, physicalRAMGB: 8),
       "8GB: bonsai is not this tier's pick → auto-start still rejects .tooBig")
 // The hole this tier closes: before it, EVERY pick offered to an 8 GB Mac was

--- a/install.sh
+++ b/install.sh
@@ -109,7 +109,8 @@ elif [ "$RAM_GB" -ge 64 ]; then RECOMMENDED_MODEL="qwen3.6-35b-8bit";    RAM_TIE
 elif [ "$RAM_GB" -ge 32 ]; then RECOMMENDED_MODEL="qwen3.6-35b-4bit";    RAM_TIER="32-63 GB"
 elif [ "$RAM_GB" -ge 24 ]; then RECOMMENDED_MODEL="gemma-4-26b-4bit";    RAM_TIER="24-31 GB"
                                 RECOMMENDED_FLAGS=" --no-mllm --kv-cache-dtype bf16 --cache-memory-mb 512"
-elif [ "$RAM_GB" -ge 16 ]; then RECOMMENDED_MODEL="bonsai-27b-2bit";     RAM_TIER="16-23 GB"
+elif [ "$RAM_GB" -ge 18 ]; then RECOMMENDED_MODEL="qwen3.5-9b-4bit";     RAM_TIER="18-23 GB"
+elif [ "$RAM_GB" -ge 16 ]; then RECOMMENDED_MODEL="qwen3.5-4b-4bit";     RAM_TIER="16-17 GB"
 else                            RECOMMENDED_MODEL="lfm2.5-2.6b-4bit";    RAM_TIER="8-15 GB"
 fi
 

--- a/tests/test_ram_tier_recommendations_agree.py
+++ b/tests/test_ram_tier_recommendations_agree.py
@@ -115,8 +115,7 @@ def test_both_tables_parse():
 def test_same_alias_at_every_ram_size():
     """The comparison that matters: for a real Mac's RAM, both front doors
     name the same model. Compared by RAM size rather than by row so the
-    app's 18 GB tier (which deliberately mirrors 16) doesn't register as a
-    mismatch against install.sh's single 16-23 branch."""
+    app's explicit laptop tiers are checked at both sides of each boundary."""
     sh = sorted(_parse_install_sh(), key=lambda t: t[0], reverse=True)
     app = sorted(_parse_app_tiers(), key=lambda t: t[0], reverse=True)
 
@@ -230,10 +229,15 @@ def test_every_recommended_alias_exists():
 
 
 @pytest.mark.parametrize(
-    "ram,expected", [(8, "lfm2.5-2.6b-4bit"), (16, "bonsai-27b-2bit")]
+    "ram,expected",
+    [
+        (8, "lfm2.5-2.6b-4bit"),
+        (16, "qwen3.5-4b-4bit"),
+        (18, "qwen3.5-9b-4bit"),
+    ],
 )
 def test_small_macs_get_something_that_fits(ram, expected):
-    """Pinned literally: these two tiers are the ones that changed, and a
+    """Pinned literally: these laptop tiers are the ones that changed, and a
     regression here is the difference between an 8 GB Mac running a model
     and being told nothing fits."""
     sh = sorted(_parse_install_sh(), key=lambda t: t[0], reverse=True)
@@ -298,7 +302,8 @@ def test_readme_table_matches_the_app_tier_for_tier():
     boundary moved, while still reporting that the tables agree.
     """
     app = [(f, a) for f, a, _ in sorted(_parse_app_tiers())]
-    # The app splits 16 and 18; the README covers both with one 16-23 row.
+    # Collapse only genuinely identical adjacent picks, if a future table
+    # expresses the same recommendation at two consecutive floors.
     app_collapsed = []
     for floor, alias in app:
         if app_collapsed and app_collapsed[-1][1] == alias:


### PR DESCRIPTION
## What changed

- replace the 16 GB Bonsai 27B recommendation with Qwen 3.5 4B
- replace the 18–23 GB Bonsai 27B recommendation with Qwen 3.5 9B plus a faster 4B option
- split oversized aliases into a `Not fit for this Mac` menu section
- keep oversized models selectable and downloadable, while showing their estimated memory need before download/start
- add regression coverage requiring laptop recommendations to agree with the conservative sizing guard

## Why

This change is needed because the recommendation table trusted Bonsai's measured short-prompt RSS (8.4 GB), while the launch guard used a conservative runtime + KV budget (about 15 GB). An 18 GB user could therefore be told to download a recommended model and then immediately receive a crash warning when only 7 GB was free.

The curl installer and README now mirror the same 16 GB and 18 GB boundaries as the app, preventing different entry points from recommending different models.

## Validation

- recommendation-tier standalone contract: all pass
- RapidTests target build: pass
- full release Rapid.app build: pass
- diff check: pass
- isolated AX control inspection: pass
- Codex review: no actionable correctness findings
