### PR TITLE
fix(rapid-mac): repair Brave API key link

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Tools/WebSearchProvider.swift
+++ b/apps/rapid-mac/Sources/Rapid/Tools/WebSearchProvider.swift
@@ -75,12 +75,14 @@ enum WebSearchProvider: String, CaseIterable, Codable, Identifiable, Sendable {
     ///
     /// For Tavily this resolves to the same /home page as
     /// ``keyConsoleURL`` (the dashboard IS the home view). Brave
-    /// splits: ``keyConsoleURL`` points at the public api docs
-    /// landing, ``keyDashboardURL`` jumps straight to /app/keys.
+    /// splits: ``keyConsoleURL`` points at the public API landing,
+    /// while ``keyDashboardURL`` uses the dedicated dashboard host
+    /// and jumps straight to /app/keys. The API-serving host returns
+    /// HTTP 403 for that UI route.
     var keyDashboardURL: URL? {
         switch self {
         case .duckduckgo: return nil
-        case .brave:      return URL(string: "https://api.search.brave.com/app/keys")
+        case .brave:      return URL(string: "https://api-dashboard.search.brave.com/app/keys")
         case .tavily:     return URL(string: "https://app.tavily.com/home")
         }
     }

--- a/apps/rapid-mac/Tests/RapidTests/WebSearchThrottleTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/WebSearchThrottleTests.swift
@@ -264,4 +264,17 @@ struct WebSearchThrottleTests {
         #expect(WebSearchProvider.brave.subtitle.contains("Brave Search API key"))
         #expect(WebSearchProvider.tavily.subtitle.contains("Tavily API key"))
     }
+
+    @Test("Key links use each provider's live dashboard host")
+    func keyDashboardLinksAreCurrent() {
+        #expect(
+            WebSearchProvider.brave.keyDashboardURL?.absoluteString
+                == "https://api-dashboard.search.brave.com/app/keys"
+        )
+        #expect(
+            WebSearchProvider.tavily.keyDashboardURL?.absoluteString
+                == "https://app.tavily.com/home"
+        )
+        #expect(WebSearchProvider.duckduckgo.keyDashboardURL == nil)
+    }
 }


### PR DESCRIPTION
## What changed

- point the Brave Search key link at the dedicated API dashboard host
- keep Tavily on its verified live dashboard URL
- add regression coverage for every provider's key-dashboard destination

## Why

The Settings link used the Brave API-serving host for a dashboard UI route. That host returns HTTP 403, while the same `/app/keys` route on `api-dashboard.search.brave.com` redirects unauthenticated users to login and returns HTTP 200.

## User impact

“Get a Brave Search key” now opens a working login/key-management flow. Tavily remains unchanged because its current dashboard URL still returns HTTP 200 and matches the official key signup path.

## Validation

- live redirect/status probe: old Brave 403, new Brave 200, Tavily 200
- `swift build --target RapidTests`
- `git diff --check`
- Codex review: no actionable defects
