### PR TITLE
test: refresh stale timing fixture blocking pr_validate (fixes #1630)

### DIFF
--- a/tests/test_memory_stability.py
+++ b/tests/test_memory_stability.py
@@ -8,6 +8,7 @@ Verifies that:
 3. Metal memory stats are reported in get_stats()
 """
 
+import time
 from unittest.mock import MagicMock, patch
 
 from vllm_mlx.request import SamplingParams
@@ -228,6 +229,20 @@ class TestIncrementalCacheEval:
         mock_request.output_token_ids = [100]
         mock_request.num_output_tokens = 1
         mock_request.num_prompt_tokens = 3
+        # Real floats for the timing fields _process_batch_responses reads:
+        # it computes prefill_s / generation_s and gates each on ``> 0``,
+        # which a bare auto-created MagicMock cannot satisfy (MagicMock
+        # supports arithmetic magic methods but not comparison ones, so
+        # ``MagicMock() > 0`` raises TypeError). Leaving these as mocks is
+        # what made this test go stale; the subject under test — no eager
+        # mx.eval in the extraction path — is unaffected by the values.
+        # Offsets follow the real request lifecycle (arrival → prefill
+        # start → first token, all in the past) so both the prefill and
+        # generation durations come out positive.
+        now = time.time()
+        mock_request.arrival_time = now - 2.0
+        mock_request._prefill_started_at = now - 1.5
+        mock_request.first_token_time = now - 1.0
         scheduler.running["req-1"] = mock_request
         scheduler.uid_to_request_id[42] = "req-1"
 


### PR DESCRIPTION
## Why

`tests/test_memory_stability.py::TestIncrementalCacheEval::test_no_eager_eval_in_extraction_path`
fails on a **clean `main`, deterministically — 3/3 runs** (reproduced), and
is a `pr_validate` blocker on *every* PR, including ones that touch no Python
at all (it red-flagged #1619, a `apps/rapid-mac/**`-only change). That is the
corrosive kind of red — it trains everyone to skim past a `full_unit` failure
as "probably unrelated", which is exactly how a real regression slips through.

Root cause: the test builds a `MagicMock` request whose timing attributes are
left as auto-created mocks. `_process_batch_responses` has since grown numeric
gates on them:

```python
generation_s = time.time() - request.first_token_time   # float - MagicMock → MagicMock
if generation_s > 0:                                     # MagicMock > int → TypeError
```

`MagicMock` implements arithmetic magic methods but **not** comparison ones, so
`MagicMock() > 0` raises `TypeError`. The fixture went stale, not the product.

## What

Give the mock request real `float` values for the three timing fields the
scheduler now reads (`first_token_time`, `arrival_time`, `_prefill_started_at`),
so both the prefill and generation `> 0` gates evaluate. No production change —
the issue's fix sketch explicitly prefers fixing the fixture over relaxing the
assertion in `scheduler.py`. The test's actual subject (no eager `mx.eval` in
the extraction path) is untouched.

## Tests

- Target test now passes 3/3 (was 3/3 red).
- Full `tests/test_memory_stability.py` — 15/15 pass.
- `ruff check` + `ruff format --check` clean.

## Notes

Fixes #1630. Test-only change; no engine/product code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)