### PR TITLE
feat: ground model recommendations in measured performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ or Homebrew — prebuilt bottle straight from homebrew-core:
 brew install rapid-mlx
 ```
 
-Both land the same `rapid-mlx` CLI. The curl installer additionally installs Python 3.10+ if missing, creates an isolated venv at `~/.rapid-mlx/`, symlinks the `rapid-mlx` CLI into `~/.local/bin/`, and prints a serve command sized to your Mac (8–15 GB → `lfm2.5-2.6b-4bit`; 16–17 GB → `qwen3.5-4b-4bit`; 18–23 GB → `qwen3.5-9b-4bit`; 24–31 GB → `gemma-4-26b-4bit`; 32–63 GB → `qwen3.6-35b-4bit`; 64–95 GB → `qwen3.6-35b-8bit`; 96 GB+ → `qwen3.5-122b-mxfp4`).
+Both land the same `rapid-mlx` CLI. The curl installer additionally installs Python 3.10+ if missing, creates an isolated venv at `~/.rapid-mlx/`, symlinks the `rapid-mlx` CLI into `~/.local/bin/`, and prints a serve command sized to your Mac (8–15 GB → `lfm2.5-2.6b-4bit`; 16–17 GB → `qwen3.5-4b-4bit`; 18–23 GB → `qwen3.5-9b-4bit`; 24–31 GB → `bonsai-27b-2bit`; 32–63 GB → `gemma-4-26b-4bit`; 64–95 GB → `qwen3.6-35b-8bit`; 96 GB+ → `qwen3.5-122b-mxfp4`).
 
 > **Install security.** `install.sh` is served over HTTPS (HSTS-preload) from `rapidmlx.com` and is a byte-identical mirror of [`install.sh`](install.sh) at the release commit — read it before running if you like. If you want a cryptographically verified installer rather than trusting the website pipe, don't `curl | bash` the URL above: instead download the release's `install.sh` asset, verify it against the cosign-signed `SHA256SUMS.txt` shipped alongside it, and run that verified copy — full recipe in [SECURITY.md](SECURITY.md). PyPI artifacts additionally carry Sigstore attestations (PEP 740). Two more low-trust paths:
 > - **Pin to a commit hash** — `curl -fsSL https://raw.githubusercontent.com/raullenchai/Rapid-MLX/<commit>/install.sh -o install.sh && shasum -a 256 install.sh && bash install.sh`
@@ -237,21 +237,20 @@ The installer's RAM detector picks a sensible default. If you want to shop the f
 
 This table is the same one the desktop app's picker reads, and the installer
 prints the matching line for your Mac — a CI test parses both files and fails
-if they drift apart. Peak RSS is measured through `rapid-mlx serve` on an
-M3 Ultra (the engine quantizes the KV cache to int4 by default, so a bare
-`mlx_lm` probe will read higher).
+if they drift apart. Measured rows use the standard ~8K prompt peak of the
+complete `rapid-mlx serve` process tree on an M2 Pro 32 GB Mac mini.
 
 | RAM | Recommended | Peak RSS | One-shot |
 |---|---|---:|---|
-| **8–15 GB** MacBook Air / base Mini | `lfm2.5-2.6b-4bit` | 2.0 GB | `rapid-mlx serve lfm2.5-2.6b-4bit` |
-| **16–17 GB** MacBook Air / Pro | `qwen3.5-4b-4bit` | 5.9 GB | `rapid-mlx serve qwen3.5-4b-4bit` |
+| **8–15 GB** MacBook Air / base Mini | `lfm2.5-2.6b-4bit` | 3.2 GB | `rapid-mlx serve lfm2.5-2.6b-4bit` |
+| **16–17 GB** MacBook Air / Pro | `qwen3.5-4b-4bit` | 5.8 GB | `rapid-mlx serve qwen3.5-4b-4bit` |
 | **18–23 GB** MacBook Pro | `qwen3.5-9b-4bit` | 8.7 GB | `rapid-mlx serve qwen3.5-9b-4bit` |
-| **24–31 GB** Mac Mini / MacBook Pro | `gemma-4-26b-4bit` | 15.6 GB | `rapid-mlx serve gemma-4-26b-4bit --no-mllm --kv-cache-dtype bf16 --cache-memory-mb 512` |
-| **32–63 GB** Mac Studio / high-spec Mini | `qwen3.6-35b-4bit` | 20.4 GB | `rapid-mlx serve qwen3.6-35b-4bit` |
+| **24–31 GB** Mac Mini / MacBook Pro | `bonsai-27b-2bit` | 13.0 GB | `rapid-mlx serve bonsai-27b-2bit` |
+| **32–63 GB** Mac Studio / high-spec Mini | `gemma-4-26b-4bit` | 20.0 GB | `rapid-mlx serve gemma-4-26b-4bit --no-mllm --kv-cache-dtype bf16 --cache-memory-mb 512` |
 | **64–95 GB** Mac Studio | `qwen3.6-35b-8bit` | 37.7 GB | `rapid-mlx serve qwen3.6-35b-8bit` |
 | **96 GB+** Mac Studio / Pro | `qwen3.5-122b-mxfp4` | — | `rapid-mlx serve qwen3.5-122b-mxfp4` |
 
-The 24–31 GB flags are not optional: Gemma 4 26B ships a vision tower that tier
+The 32–63 GB flags are not optional: Gemma 4 26B ships a vision tower that tier
 has no memory for, and an uncapped KV budget claims the headroom the rest of
 your Mac needs.
 

--- a/apps/rapid-mac/Sources/Rapid/Server/RAMBucketedDefault.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/RAMBucketedDefault.swift
@@ -3,8 +3,7 @@ import Foundation
 /// Pure RAM tier → curated model recommendation for "what should this
 /// Mac run". Replaces the old 6-bucket × 5-role matrix (Default / Speed /
 /// Quality / Coding / Vision) with a much simpler table: per RAM tier, a
-/// **smart** pick (the most capable model that fits) and, when a genuinely
-/// faster/lighter model is worth surfacing, a **fast** alternative — plus
+/// **smart** pick (the most capable model that fits) and a **fast** alternative — plus
 /// the exact launch flags each pick needs.
 ///
 /// ## Why the roles went away
@@ -24,42 +23,31 @@ import Foundation
 /// pick (which would be borderline). Sub-8 GB Macs clamp to the 8 GB
 /// tier; the app's per-row fit warning still flags anything too big.
 ///
-/// A tier only carries a **fast** alt when it beats the smart pick on
-/// speed by a margin worth a second card. The 24 & 32 GB smart picks are
-/// already MoE-fast (42 / 60 tok/s), so they stand alone — a slower or
-/// much weaker "fast" option there would only mislead.
+/// Every tier carries exactly two choices. This keeps the decision stable:
+/// choose responsiveness, or trade some responsiveness for capability.
 ///
 /// | RAM    | 🧠 Smart            | GB   | Cap | tok/s | 🚀 Fast                          |
 /// | ------ | ------------------- | ---- | --- | ----- | -------------------------------- |
-/// |  8 GB  | lfm2.5-2.6b-4bit    |  2.0 |  —  | 97.8  | — (only model that fits)         |
-/// | 16 GB  | qwen3.5-4b-4bit     |  5.9 | 78% | 157.6 | —                                |
-/// | 18 GB  | qwen3.5-9b-4bit     |  8.7 | 82% | 106.4 | qwen3.5-4b-4bit · 78% · 157.6    |
-/// | 24 GB  | gemma-4-26b-4bit    | 14.6 | 87% | 41.7  | — (smart pick already fast)      |
-/// | 32 GB  | qwen3.6-35b-4bit    | 20.0 | 87% | 60.0  | — (smart pick already fast)      |
+/// |  8 GB  | lfm2.5-2.6b-4bit    |  3.2 | 62% | 94.2  | lfm2.5-1b-4bit · basic · 214.5   |
+/// | 16 GB  | qwen3.5-4b-4bit     |  5.8 | 78% | 62.2  | lfm2.5-1b-4bit · basic · 214.5   |
+/// | 18 GB  | qwen3.5-9b-4bit     |  8.7 | 82% | 36.2  | qwen3.5-4b-4bit · 78% · 62.2     |
+/// | 24 GB  | bonsai-27b-2bit     | 13.0 | 86% | 17.8  | qwen3.5-4b-4bit · 78% · 62.2     |
+/// | 32 GB  | gemma-4-26b-4bit    | 20.0 | 87% | 50.1  | qwen3.5-4b-4bit · 78% · 62.2     |
+/// | 48 GB  | gemma-4-26b-4bit    | 20.0 | 87% | 50.1  | qwen3.6-35b-4bit · 87% · 60      |
 /// | 64 GB  | qwen3.6-35b-8bit    | 37.7 | 87% | —     | qwen3.6-35b-4bit · 87% · 60      |
 /// | 96 GB+ | qwen3.5-122b-mxfp4  | 65.0 | 88% | —     | qwen3.6-35b-4bit · 87% · 60      |
 ///
-/// Laptop tiers deliberately use the same conservative footprint model as
-/// the launch-time memory guard. A low-bit large model must not be labelled
-/// "Recommended" using a short-prompt RSS measurement only to be rejected
-/// later by the guard's KV/runtime budget. Capability % and tok/s are the
-/// maintainer's measured scores (M2/M3); the 64/96 GB smart rows have no
-/// local tok/s measurement yet (rendered without a speed figure).
+/// The measured rows use the standard ~8K prompt peak of the complete
+/// ``rapid-mlx serve`` process tree on an M2 Pro 32 GB Mac mini, not weight
+/// size or an idle/short-prompt RSS. Recommendations require zero new swap,
+/// peak below 75% of the tier floor, 8K prefill >=100 tok/s, and decode
+/// >=10 tok/s. The 64/96 GB rows predate this run and remain explicitly
+/// unmeasured until matching hardware is available.
 ///
-/// The GB column is peak resident memory of the whole ``rapid-mlx serve``
-/// process tree, measured on an M3 Ultra. It must be measured THROUGH
-/// serve: the engine quantizes the KV cache to int4 by default, and a
-/// bare ``mlx_lm`` probe without that default reads about two gigabytes
-/// higher on a 27B. bonsai briefly shipped 10.7 GB here from exactly that
-/// mistake — an M2 Pro probe with an unquantized cache, reported via
-/// MLX's device high-water mark rather than RSS. Served, it is 8.4 GB on
-/// a short prompt and 8.5 GB on a 2 K-token one, so the figure is not
-/// especially workload-sensitive either.
-///
-/// The column had also drifted into meaning *weights on disk* for bonsai
-/// (7.6 GB) while the field is documented as active memory. tok/s are
-/// M2 Pro measurements. The column is display-only (``pickStatsLine``),
-/// so this corrects what users read, not what the app allows them to run.
+/// These figures must be measured THROUGH serve: a bare ``mlx_lm`` probe
+/// does not exercise the product's cache configuration or full process
+/// tree. The column is display-only (``pickStatsLine``); safety gates still
+/// apply independently at launch.
 ///
 /// The capability column is monotonic non-decreasing by RAM, with ONE
 /// deliberate tie documented at the tier: the 64 GB smart 8-bit is floored
@@ -73,7 +61,7 @@ enum RAMBucketedDefault {
     /// tier's RAM (e.g. ``--no-mllm`` to drop the vision tower).
     struct Pick: Sendable, Equatable {
         let alias: String
-        /// Active-memory footprint in GB (what the model actually uses).
+        /// Standard ~8K prompt peak footprint in GB for measured picks.
         let footprintGB: Double
         /// Blended capability score 0–100 (tool / coding / reasoning /
         /// general) — the single number that ranks picks.
@@ -94,8 +82,7 @@ enum RAMBucketedDefault {
     }
 
     /// A RAM tier: the ``floorGB`` it applies from (up to the next tier),
-    /// its ``primary`` (smart) pick, and an optional ``alt`` (fast/light)
-    /// pick — present only when a faster model is worth a second card.
+    /// its ``primary`` (smart) pick, and its ``alt`` (fast/light) pick.
     struct Tier: Sendable, Equatable {
         let floorGB: Double
         let primary: Pick
@@ -108,19 +95,24 @@ enum RAMBucketedDefault {
     /// Conservative general-purpose laptop picks. Both have verified tool
     /// calling and stay within the same footprint budget enforced at launch.
     private static let qwen4Pick = Pick(
-        alias: "qwen3.5-4b-4bit", footprintGB: 5.9, capabilityPct: 78,
-        tokensPerSec: 157.6, launchFlags: [])
+        alias: "qwen3.5-4b-4bit", footprintGB: 5.8, capabilityPct: 78,
+        tokensPerSec: 62.2, launchFlags: [])
 
     private static let qwen9Pick = Pick(
         alias: "qwen3.5-9b-4bit", footprintGB: 8.7, capabilityPct: 82,
-        tokensPerSec: 106.4, launchFlags: [])
+        tokensPerSec: 36.2, launchFlags: [])
 
-    /// The 8 GB tier's only pick: LFM2.5-2.6B, a 2.6 B dense model whose
+    private static let lfm1Pick = Pick(
+        alias: "lfm2.5-1b-4bit", footprintGB: 2.1, capabilityPct: 50,
+        tokensPerSec: 214.5, launchFlags: [], caveat: "Basic chat")
+
+    /// The 8 GB tier's smarter pick: LFM2.5-2.6B, a 2.6 B dense model whose
     /// 30 layers are 22 short-convolution blocks and just 8 GQA. Those 8
     /// attention layers are why it belongs here — the KV cache costs
     /// ~16 KB/token, so a 32 K conversation adds only ~0.5 GB on top of
-    /// 1.6 GB of weights. Served on an M3 Ultra it peaks at 2.0 GB; on an
-    /// M2 Pro it decodes at 97.8 tok/s and prefills at 503 tok/s.
+    /// 1.6 GB of weights. On an M2 Pro it peaks at 3.2 GB on the standard
+    /// 8K prompt, decodes at
+    /// 94.2 tok/s on the short prompt, and prefills at 488 tok/s at 8K.
     ///
     /// It carries a caveat rather than a capability %, and the caveat is
     /// Liquid's own: they publish this model as "not recommended for
@@ -133,12 +125,19 @@ enum RAMBucketedDefault {
     /// is deliberately the same band as the other caveat pick in the
     /// family, not an independently measured score.
     private static let lfm26Pick = Pick(
-        alias: "lfm2.5-2.6b-4bit", footprintGB: 2.0, capabilityPct: 62,
-        tokensPerSec: 97.8, launchFlags: [], caveat: "Not for coding")
+        alias: "lfm2.5-2.6b-4bit", footprintGB: 3.2, capabilityPct: 62,
+        tokensPerSec: 94.2, launchFlags: [], caveat: "Not for coding")
 
-    /// The fast/light pick for the big-MoE tiers: the 4-bit Qwen3.6-35B
-    /// (same weights as the 32 GB smart pick) — near-equal capability to
-    /// the tier's smart model but much faster than an 8-bit / 122B load.
+    private static let bonsaiPick = Pick(
+        alias: "bonsai-27b-2bit", footprintGB: 13.0, capabilityPct: 86,
+        tokensPerSec: 17.8, launchFlags: [])
+
+    private static let gemma26Pick = Pick(
+        alias: "gemma-4-26b-4bit", footprintGB: 20.0, capabilityPct: 87,
+        tokensPerSec: 50.1,
+        launchFlags: ["--no-mllm", "--kv-cache-dtype", "bf16", "--cache-memory-mb", "512"])
+
+    /// Existing reviewed fast/light pick for the unmeasured 48/64/96 GB tiers.
     private static let qwen35bFastPick = Pick(
         alias: "qwen3.6-35b-4bit", footprintGB: 20.0, capabilityPct: 87,
         tokensPerSec: 60.0, launchFlags: [])
@@ -154,38 +153,36 @@ enum RAMBucketedDefault {
         // rejected the only thing it was offered and fell through to
         // ``SafeDefaultFallback``. The user's first run was a model the app
         // had just told them not to run. Nothing in the catalog fit until
-        // LFM2.5-2.6B: 2.70 GB peak leaves room for macOS on an 8 GB
-        // machine, where the 16 GB tier's 5.3 GB "fast" alt did not.
-        Tier(floorGB: 8, primary: lfm26Pick, alt: nil),
+        // LFM2.5-2.6B: 3.21 GB standard-8K peak leaves room for macOS on
+        // an 8 GB machine; LFM 1B supplies the even lighter fast choice.
+        Tier(floorGB: 8, primary: lfm26Pick, alt: lfm1Pick),
         Tier(
             floorGB: 16,
             primary: qwen4Pick,
-            alt: nil
+            alt: lfm1Pick
         ),
         // 18 GB gets the verified 9B general-purpose model plus the 4B fast
-        // option. Do not promote bonsai-27b-2bit here: its measured 8.4 GB
-        // short-prompt RSS conflicts with the launch guard's conservative
-        // ~15 GB budget, producing a recommendation followed by a crash
-        // warning after the user has downloaded it.
+        // option. Do not promote bonsai-27b-2bit here: its 13 GB standard
+        // 8K peak leaves too little headroom at the 18 GB tier floor.
         Tier(
             floorGB: 18,
             primary: qwen9Pick,
             alt: qwen4Pick
         ),
-        // 24 & 32 GB: the smart pick is already MoE-fast (42 / 60 tok/s),
-        // so it stands alone — a slower or much-weaker "fast" card here
-        // would only mislead.
         Tier(
             floorGB: 24,
-            primary: Pick(
-                alias: "gemma-4-26b-4bit", footprintGB: 14.6, capabilityPct: 87, tokensPerSec: 41.7,
-                launchFlags: ["--no-mllm", "--kv-cache-dtype", "bf16", "--cache-memory-mb", "512"]),
-            alt: nil
+            primary: bonsaiPick,
+            alt: qwen4Pick
         ),
         Tier(
             floorGB: 32,
-            primary: Pick(alias: "qwen3.6-35b-4bit", footprintGB: 20.0, capabilityPct: 87, tokensPerSec: 60.0, launchFlags: []),
-            alt: nil
+            primary: gemma26Pick,
+            alt: qwen4Pick
+        ),
+        Tier(
+            floorGB: 48,
+            primary: gemma26Pick,
+            alt: qwen35bFastPick
         ),
         // 64 GB smart pick is the 8-bit of the same Qwen3.6-35B whose 4-bit
         // is the fast alt. Its capability is floored at the 4-bit's measured
@@ -233,7 +230,7 @@ enum RAMBucketedDefault {
     /// Launch flags to apply when starting ``alias`` AS the recommended
     /// model for a Mac at ``physicalRAMGB`` — empty unless the alias is
     /// this Mac's primary or alt pick. This is why a 64 GB Mac that hand-
-    /// picks ``gemma-4-26b-4bit`` (the 24 GB tier's pick, not its own)
+    /// picks ``gemma-4-26b-4bit`` (a 32/48 GB tier pick, not its own)
     /// keeps vision: the flags (``--no-mllm`` …) only ride along with the
     /// recommendation on the tier they were curated for.
     static func launchFlags(forAlias alias: String, physicalRAMGB: Double) -> [String] {

--- a/apps/rapid-mac/Tests/RapidTests/BenchScoresTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/BenchScoresTests.swift
@@ -289,13 +289,13 @@ struct BenchScoresTests {
         // surface in the recommendation stats line, not the bench meters.
         // The picker degrades gracefully for these (no bar block, no card
         // meters), so a bench JSON row is not required.
-        // lfm2.5-2.6b-4bit joined 2026-08-04 as the 8-15 GB pick. It is
-        // genuinely unscored — not on Artificial Analysis, no published
-        // standard bench — so it belongs here rather than getting a
-        // fabricated row. The anti-fabrication check below is what keeps
-        // that honest.
+        // The LFM2.5 small picks are genuinely unscored — not on Artificial
+        // Analysis, no comparable published standard bench — so they belong
+        // here rather than getting fabricated rows. The anti-fabrication
+        // check below is what keeps that honest.
         let noStandardBench: Set<String> = [
-            "bonsai-27b-2bit", "lfm2.5-8b-a1b-4bit", "lfm2.5-2.6b-4bit",
+            "bonsai-27b-2bit", "lfm2.5-1b-4bit", "lfm2.5-8b-a1b-4bit",
+            "lfm2.5-2.6b-4bit",
         ]
         let known = Set(BenchScoresCatalog.allAliases)
         let missing = distinct.subtracting(known).subtracting(noStandardBench)

--- a/apps/rapid-mac/Tests/RapidTests/RAMBucketedDefaultTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/RAMBucketedDefaultTests.swift
@@ -2,19 +2,20 @@ import Testing
 @testable import Rapid
 
 /// Pin the RAM tier → recommended-pick table. v0.13 replaced the old
-/// 6-bucket × 5-role matrix with one primary pick per RAM tier (plus an
-/// optional faster alt on the smallest tier) and per-pick launch flags.
+/// 6-bucket × 5-role matrix with exactly two choices per RAM tier: a smart
+/// primary and a faster/lighter alternative.
 ///
 /// The tiers are keyed by machine RAM and a Mac rounds DOWN to the
 /// nearest floor: a 20 GB Mac gets the 18 GB pick (which fits), not the
 /// 24 GB pick. Table (see ``RAMBucketedDefault`` docstring for the full
 /// numbers):
 ///
-///    8 GB  → lfm2.5-2.6b-4bit  (· Not for coding — only model that fits)
-///   16 GB  → qwen3.5-4b-4bit
+///    8 GB  → lfm2.5-2.6b-4bit  (+ fast lfm2.5-1b-4bit)
+///   16 GB  → qwen3.5-4b-4bit   (+ fast lfm2.5-1b-4bit)
 ///   18 GB  → qwen3.5-9b-4bit   (+ fast qwen3.5-4b-4bit)
-///   24 GB  → gemma-4-26b-4bit  (--no-mllm --kv-cache-dtype bf16 --cache-memory-mb 512)
-///   32 GB  → qwen3.6-35b-4bit
+///   24 GB  → bonsai-27b-2bit   (+ fast qwen3.5-4b-4bit)
+///   32 GB  → gemma-4-26b-4bit  (+ fast qwen3.5-4b-4bit)
+///   48 GB  → gemma-4-26b-4bit  (+ fast qwen3.6-35b-4bit)
 ///   64 GB  → qwen3.6-35b-8bit  (+ fast qwen3.6-35b-4bit)
 ///   96 GB+ → qwen3.5-122b-mxfp4 (+ fast qwen3.6-35b-4bit)
 ///
@@ -34,9 +35,9 @@ struct RAMBucketedDefaultTests {
         #expect(RAMBucketedDefault.alias(forPhysicalRAMGB: 16) == "qwen3.5-4b-4bit")
         #expect(RAMBucketedDefault.alias(forPhysicalRAMGB: 17) == "qwen3.5-4b-4bit")
         #expect(RAMBucketedDefault.alias(forPhysicalRAMGB: 18) == "qwen3.5-9b-4bit")
-        #expect(RAMBucketedDefault.alias(forPhysicalRAMGB: 24) == "gemma-4-26b-4bit")
-        #expect(RAMBucketedDefault.alias(forPhysicalRAMGB: 32) == "qwen3.6-35b-4bit")
-        #expect(RAMBucketedDefault.alias(forPhysicalRAMGB: 48) == "qwen3.6-35b-4bit")   // 32 tier
+        #expect(RAMBucketedDefault.alias(forPhysicalRAMGB: 24) == "bonsai-27b-2bit")
+        #expect(RAMBucketedDefault.alias(forPhysicalRAMGB: 32) == "gemma-4-26b-4bit")
+        #expect(RAMBucketedDefault.alias(forPhysicalRAMGB: 48) == "gemma-4-26b-4bit")
         #expect(RAMBucketedDefault.alias(forPhysicalRAMGB: 64) == "qwen3.6-35b-8bit")
         #expect(RAMBucketedDefault.alias(forPhysicalRAMGB: 96) == "qwen3.5-122b-mxfp4")
         #expect(RAMBucketedDefault.alias(forPhysicalRAMGB: 256) == "qwen3.5-122b-mxfp4") // 96 tier
@@ -45,7 +46,7 @@ struct RAMBucketedDefaultTests {
     @Test("A 20 GB Mac rounds DOWN to the 18 GB pick (fits), not up to 24 GB")
     func roundsDownNotUp() {
         #expect(RAMBucketedDefault.alias(forPhysicalRAMGB: 20) == "qwen3.5-9b-4bit")
-        #expect(RAMBucketedDefault.alias(forPhysicalRAMGB: 30) == "gemma-4-26b-4bit")
+        #expect(RAMBucketedDefault.alias(forPhysicalRAMGB: 30) == "bonsai-27b-2bit")
     }
 
     @Test("Pathological zero / negative RAM clamps to the smallest tier, no crash")
@@ -58,24 +59,27 @@ struct RAMBucketedDefaultTests {
 
     @Test("Each tier surfaces a smart pick + a fast alt where speed warrants it")
     func smartAndFastPicks() {
-        // 8 GB: one pick, and it carries the publisher's own caveat rather
-        // than a capability % — nothing else in the catalog fits.
+        // Every tier deliberately exposes the same two-choice decision.
         let smallest = RAMBucketedDefault.picks(forPhysicalRAMGB: 8)
-        #expect(smallest.count == 1)
+        #expect(smallest.count == 2)
         #expect(smallest[0].alias == "lfm2.5-2.6b-4bit")
         #expect(smallest[0].caveat == "Not for coding")
-        // 16 GB: conservative general-purpose default, no duplicate alt.
+        #expect(smallest[1].alias == "lfm2.5-1b-4bit")
         let tier16 = RAMBucketedDefault.picks(forPhysicalRAMGB: 16)
-        #expect(tier16.count == 1)
+        #expect(tier16.count == 2)
         #expect(tier16[0].alias == "qwen3.5-4b-4bit")
+        #expect(tier16[1].alias == "lfm2.5-1b-4bit")
         // 18 GB: 9B smart + 4B fast, both verified for tools.
         let tier18 = RAMBucketedDefault.picks(forPhysicalRAMGB: 18)
         #expect(tier18.count == 2)
         #expect(tier18[0].alias == "qwen3.5-9b-4bit")
         #expect(tier18[1].alias == "qwen3.5-4b-4bit")
-        // 24/32 GB: smart pick is already MoE-fast → stands alone.
-        #expect(RAMBucketedDefault.picks(forPhysicalRAMGB: 24).count == 1)
-        #expect(RAMBucketedDefault.picks(forPhysicalRAMGB: 32).count == 1)
+        #expect(RAMBucketedDefault.picks(forPhysicalRAMGB: 24).map(\.alias)
+            == ["bonsai-27b-2bit", "qwen3.5-4b-4bit"])
+        #expect(RAMBucketedDefault.picks(forPhysicalRAMGB: 32).map(\.alias)
+            == ["gemma-4-26b-4bit", "qwen3.5-4b-4bit"])
+        #expect(RAMBucketedDefault.picks(forPhysicalRAMGB: 48).map(\.alias)
+            == ["gemma-4-26b-4bit", "qwen3.6-35b-4bit"])
         // 64/96 GB: fast alt is the lighter 4-bit Qwen3.6-35B (no caveat).
         let tier64 = RAMBucketedDefault.picks(forPhysicalRAMGB: 64)
         #expect(tier64.count == 2)
@@ -91,9 +95,9 @@ struct RAMBucketedDefaultTests {
     @Test("Flags apply only when the alias IS the pick for that Mac's RAM")
     func launchFlagsAreRAMGated() {
         #expect(RAMBucketedDefault.launchFlags(forAlias: "qwen3.5-9b-4bit", physicalRAMGB: 18).isEmpty)
-        #expect(RAMBucketedDefault.launchFlags(forAlias: "gemma-4-26b-4bit", physicalRAMGB: 24)
+        #expect(RAMBucketedDefault.launchFlags(forAlias: "gemma-4-26b-4bit", physicalRAMGB: 32)
             == ["--no-mllm", "--kv-cache-dtype", "bf16", "--cache-memory-mb", "512"])
-        #expect(RAMBucketedDefault.launchFlags(forAlias: "qwen3.6-35b-4bit", physicalRAMGB: 32).isEmpty)
+        #expect(RAMBucketedDefault.launchFlags(forAlias: "qwen3.6-35b-4bit", physicalRAMGB: 48).isEmpty)
         // Hand-picking gemma-26b on a 64 GB Mac (where it is NOT the pick)
         // → no forced flags, so it keeps vision.
         #expect(RAMBucketedDefault.launchFlags(forAlias: "gemma-4-26b-4bit", physicalRAMGB: 64).isEmpty)
@@ -157,6 +161,13 @@ struct RAMBucketedDefaultTests {
                 #expect(pick.capabilityPct > 0 && pick.capabilityPct <= 100,
                         "\(pick.alias) capability \(pick.capabilityPct) out of range")
             }
+        }
+    }
+
+    @Test("Every RAM tier exposes exactly smart and fast choices")
+    func exactlyTwoChoices() {
+        for tier in RAMBucketedDefault.tiers {
+            #expect(tier.picks.count == 2, "Tier \(tier.floorGB) GB must have exactly two picks")
         }
     }
 }

--- a/apps/rapid-mac/scripts/verify-recommendation-tiers.swift
+++ b/apps/rapid-mac/scripts/verify-recommendation-tiers.swift
@@ -33,25 +33,28 @@ struct Tier: Equatable {
     let alt: Pick?
     var picks: [Pick] { alt.map { [primary, $0] } ?? [primary] }
 }
-let qwen4Pick = Pick(alias: "qwen3.5-4b-4bit", footprintGB: 5.9, capabilityPct: 78,
-                     tokensPerSec: 157.6, launchFlags: [])
+let qwen4Pick = Pick(alias: "qwen3.5-4b-4bit", footprintGB: 5.8, capabilityPct: 78,
+                     tokensPerSec: 62.2, launchFlags: [])
 let qwen9Pick = Pick(alias: "qwen3.5-9b-4bit", footprintGB: 8.7, capabilityPct: 82,
-                     tokensPerSec: 106.4, launchFlags: [])
-let lfm26Pick = Pick(alias: "lfm2.5-2.6b-4bit", footprintGB: 2.0, capabilityPct: 62,
-                     tokensPerSec: 97.8, launchFlags: [], caveat: "Not for coding")
+                     tokensPerSec: 36.2, launchFlags: [])
+let lfm1Pick = Pick(alias: "lfm2.5-1b-4bit", footprintGB: 2.1, capabilityPct: 50,
+                    tokensPerSec: 214.5, launchFlags: [], caveat: "Basic chat")
+let lfm26Pick = Pick(alias: "lfm2.5-2.6b-4bit", footprintGB: 3.2, capabilityPct: 62,
+                     tokensPerSec: 94.2, launchFlags: [], caveat: "Not for coding")
+let bonsaiPick = Pick(alias: "bonsai-27b-2bit", footprintGB: 13.0, capabilityPct: 86,
+                      tokensPerSec: 17.8, launchFlags: [])
+let gemma26Pick = Pick(alias: "gemma-4-26b-4bit", footprintGB: 20.0, capabilityPct: 87,
+                       tokensPerSec: 50.1,
+                       launchFlags: ["--no-mllm", "--kv-cache-dtype", "bf16", "--cache-memory-mb", "512"])
 let qwen35bFastPick = Pick(alias: "qwen3.6-35b-4bit", footprintGB: 20.0, capabilityPct: 87,
                            tokensPerSec: 60.0, launchFlags: [])
 let tiers: [Tier] = [
-    Tier(floorGB: 8, primary: lfm26Pick, alt: nil),
-    Tier(floorGB: 16, primary: qwen4Pick, alt: nil),
+    Tier(floorGB: 8, primary: lfm26Pick, alt: lfm1Pick),
+    Tier(floorGB: 16, primary: qwen4Pick, alt: lfm1Pick),
     Tier(floorGB: 18, primary: qwen9Pick, alt: qwen4Pick),
-    Tier(floorGB: 24,
-         primary: Pick(alias: "gemma-4-26b-4bit", footprintGB: 14.6, capabilityPct: 87, tokensPerSec: 41.7,
-                       launchFlags: ["--no-mllm", "--kv-cache-dtype", "bf16", "--cache-memory-mb", "512"]),
-         alt: nil),
-    Tier(floorGB: 32,
-         primary: Pick(alias: "qwen3.6-35b-4bit", footprintGB: 20.0, capabilityPct: 87, tokensPerSec: 60.0, launchFlags: []),
-         alt: nil),
+    Tier(floorGB: 24, primary: bonsaiPick, alt: qwen4Pick),
+    Tier(floorGB: 32, primary: gemma26Pick, alt: qwen4Pick),
+    Tier(floorGB: 48, primary: gemma26Pick, alt: qwen35bFastPick),
     Tier(floorGB: 64,
          primary: Pick(alias: "qwen3.6-35b-8bit", footprintGB: 37.7, capabilityPct: 87, tokensPerSec: nil, launchFlags: []),
          alt: qwen35bFastPick),
@@ -109,21 +112,23 @@ check(alias(forPhysicalRAMGB: 16) == "qwen3.5-4b-4bit",     "16GB → qwen3.5-4b
 check(alias(forPhysicalRAMGB: 17) == "qwen3.5-4b-4bit",     "17GB → still 16 tier")
 check(alias(forPhysicalRAMGB: 18) == "qwen3.5-9b-4bit",     "18GB → qwen3.5-9b")
 check(alias(forPhysicalRAMGB: 20) == "qwen3.5-9b-4bit",     "20GB rounds DOWN to 18 (qwen9), not 24")
-check(alias(forPhysicalRAMGB: 24) == "gemma-4-26b-4bit",    "24GB → gemma-4-26b")
-check(alias(forPhysicalRAMGB: 30) == "gemma-4-26b-4bit",    "30GB → 24 tier")
-check(alias(forPhysicalRAMGB: 32) == "qwen3.6-35b-4bit",    "32GB → qwen3.6-35b-4bit")
-check(alias(forPhysicalRAMGB: 48) == "qwen3.6-35b-4bit",    "48GB → 32 tier")
+check(alias(forPhysicalRAMGB: 24) == "bonsai-27b-2bit",     "24GB → bonsai-27b")
+check(alias(forPhysicalRAMGB: 30) == "bonsai-27b-2bit",     "30GB → 24 tier")
+check(alias(forPhysicalRAMGB: 32) == "gemma-4-26b-4bit",    "32GB → gemma-4-26b")
+check(alias(forPhysicalRAMGB: 48) == "gemma-4-26b-4bit",    "48GB → gemma-4-26b")
 check(alias(forPhysicalRAMGB: 64) == "qwen3.6-35b-8bit",    "64GB → qwen3.6-35b-8bit")
 check(alias(forPhysicalRAMGB: 96) == "qwen3.5-122b-mxfp4",  "96GB → 122b-mxfp4")
 check(alias(forPhysicalRAMGB: 256) == "qwen3.5-122b-mxfp4", "256GB → 96 tier (122b-mxfp4)")
 
-print("Smart + fast picks per tier (fast alt only where it beats the smart pick on speed):")
-check(picks(forPhysicalRAMGB: 16).count == 1, "16GB conservative pick stands alone")
+print("Smart + fast picks per tier:")
+for floor in [8.0, 16.0, 18.0, 24.0, 32.0, 48.0, 64.0, 96.0] {
+    check(picks(forPhysicalRAMGB: floor).count == 2, "\(Int(floor))GB has exactly two choices")
+}
 check(picks(forPhysicalRAMGB: 18).count == 2, "18GB has smart + fast")
 check(picks(forPhysicalRAMGB: 18)[1].alias == "qwen3.5-4b-4bit", "18GB fast is qwen3.5-4b")
-// 24/32 GB → smart pick is already MoE-fast, so it stands alone.
-check(picks(forPhysicalRAMGB: 24).count == 1, "24GB smart pick stands alone (already fast)")
-check(picks(forPhysicalRAMGB: 32).count == 1, "32GB smart pick stands alone (already fast)")
+check(picks(forPhysicalRAMGB: 24)[0].alias == "bonsai-27b-2bit", "24GB smart is bonsai")
+check(picks(forPhysicalRAMGB: 32)[0].alias == "gemma-4-26b-4bit", "32GB smart is gemma")
+check(picks(forPhysicalRAMGB: 48)[1].alias == "qwen3.6-35b-4bit", "48GB retains reviewed Qwen3.6 fast pick")
 // 64/96 GB → fast alt is the lighter 4-bit Qwen3.6-35B.
 check(picks(forPhysicalRAMGB: 64).count == 2, "64GB has smart + fast")
 check(picks(forPhysicalRAMGB: 64)[1].alias == "qwen3.6-35b-4bit", "64GB fast is qwen3.6-35b-4bit")
@@ -135,7 +140,7 @@ print("Capability column: a smart pick never DISPLAYS weaker than its own fast a
 // 64 GB: the 8-bit smart pick is floored at its 4-bit alt's 87 % — an 8-bit
 // quant can't read weaker than its own 4-bit (that made "Best pick" look
 // worse than "Faster"). Pin smart >= alt for every tier that carries an alt.
-for ram in [16.0, 18.0, 64.0, 96.0] {
+for ram in [8.0, 16.0, 18.0, 24.0, 32.0, 48.0, 64.0, 96.0] {
     let ps = picks(forPhysicalRAMGB: ram)
     if ps.count == 2, ps[1].caveat == nil {
         // Only compare when the alt shows a %; a caveat alt (lfm2.5) opts out.
@@ -146,7 +151,7 @@ for ram in [16.0, 18.0, 64.0, 96.0] {
 check(picks(forPhysicalRAMGB: 64)[0].capabilityPct == 87, "64GB 8-bit floored at its 4-bit's 87%")
 
 print("Smart-pick capability is monotonic non-decreasing by RAM (no 'more RAM, worse pick' dip):")
-let floors = [8.0, 16.0, 18.0, 24.0, 32.0, 64.0, 96.0]
+let floors = [8.0, 16.0, 18.0, 24.0, 32.0, 48.0, 64.0, 96.0]
 for (a, b) in zip(floors, floors.dropFirst()) {
     let ca = picks(forPhysicalRAMGB: a)[0].capabilityPct
     let cb = picks(forPhysicalRAMGB: b)[0].capabilityPct
@@ -161,23 +166,23 @@ print("Smallest tier shows an honest capability caveat:")
 // Liquid publishes 2.6B as "not recommended for agentic coding" — our users
 // drive coding agents, so the card must say so instead of showing a bare %.
 let smart8 = picks(forPhysicalRAMGB: 8)[0]
-check(picks(forPhysicalRAMGB: 8).count == 1, "8GB has a single pick (nothing else fits)")
+check(picks(forPhysicalRAMGB: 8).count == 2, "8GB has smart + fast")
 check(smart8.caveat == "Not for coding", "8GB pick carries the coding caveat")
-check(pickStatsLine(smart8) == "2.0 GB · ~98 tok/s · Not for coding", "8GB stats line drops the % for the caveat")
+check(pickStatsLine(smart8) == "3.2 GB · ~94 tok/s · Not for coding", "8GB stats line drops the % for the caveat")
 check(smart8.footprintGB < 4.0, "8GB pick must leave room for macOS on an 8GB machine")
 let fast96 = picks(forPhysicalRAMGB: 96)[1]
 check(fast96.caveat == nil, "96GB fast (qwen3.6-35b-4bit) is general-purpose — no caveat")
 check(pickStatsLine(fast96) == "20.0 GB · 87% capability · ~60 tok/s", "general-purpose fast pick keeps its capability %")
 let smart16 = picks(forPhysicalRAMGB: 16)[0]
-check(pickStatsLine(smart16) == "5.9 GB · 78% capability · ~158 tok/s", "16GB qwen4 renders conservative footprint")
+check(pickStatsLine(smart16) == "5.8 GB · 78% capability · ~62 tok/s", "16GB qwen4 renders measured 8K peak")
 let smart96 = picks(forPhysicalRAMGB: 96)[0]
 check(pickStatsLine(smart96) == "65.0 GB · 88% capability", "no-tok/s smart pick omits the speed figure")
 
 print("Launch flags travel with the recommendation, gated by RAM:")
 check(launchFlags(forAlias: "lfm2.5-2.6b-4bit", physicalRAMGB: 8).isEmpty, "8GB lfm2.5-2.6b → no flags")
 check(launchFlags(forAlias: "qwen3.5-9b-4bit", physicalRAMGB: 18).isEmpty, "18GB qwen9 → no flags")
-check(launchFlags(forAlias: "gemma-4-26b-4bit", physicalRAMGB: 24) == ["--no-mllm", "--kv-cache-dtype", "bf16", "--cache-memory-mb", "512"], "24GB gemma-26b → kv trio")
-check(launchFlags(forAlias: "qwen3.6-35b-4bit", physicalRAMGB: 32).isEmpty, "35b-4bit → no flags")
+check(launchFlags(forAlias: "gemma-4-26b-4bit", physicalRAMGB: 32) == ["--no-mllm", "--kv-cache-dtype", "bf16", "--cache-memory-mb", "512"], "32GB gemma-26b → kv trio")
+check(launchFlags(forAlias: "qwen3.6-35b-4bit", physicalRAMGB: 48).isEmpty, "48GB reviewed 35b-4bit → no flags")
 // Key: hand-picking gemma-26b on a big Mac (where it is NOT the pick) → no forced flags.
 check(launchFlags(forAlias: "gemma-4-26b-4bit", physicalRAMGB: 64).isEmpty, "gemma-26b on 64GB (not its tier) keeps vision")
 check(launchFlags(forAlias: "some-random", physicalRAMGB: 32).isEmpty, "unknown alias → no flags")
@@ -188,9 +193,10 @@ check(isRecommendedPick(alias: "lfm2.5-2.6b-4bit", physicalRAMGB: 8), "lfm2.5-2.
 check(!isRecommendedPick(alias: "bonsai-27b-2bit", physicalRAMGB: 8), "bonsai still NOT recommended on 8GB (not in the 8 tier)")
 check(!isRecommendedPick(alias: "lfm2.5-2.6b-4bit", physicalRAMGB: 4), "sub-floor 4GB Mac gets NO exemption even from its own tier pick")
 check(isRecommendedPick(alias: "qwen3.5-9b-4bit", physicalRAMGB: 18), "qwen9 recommended on 18GB")
-check(!isRecommendedPick(alias: "bonsai-27b-2bit", physicalRAMGB: 18), "bonsai is never recommended on laptop tiers")
+check(!isRecommendedPick(alias: "bonsai-27b-2bit", physicalRAMGB: 18), "bonsai is not recommended below 24GB")
 check(!isRecommendedPick(alias: "gemma-4-12b-4bit", physicalRAMGB: 18), "gemma-12b NOT recommended anywhere (dropped from picks)")
-check(isRecommendedPick(alias: "gemma-4-26b-4bit", physicalRAMGB: 24), "gemma-26b recommended on 24GB")
+check(isRecommendedPick(alias: "bonsai-27b-2bit", physicalRAMGB: 24), "bonsai recommended on 24GB")
+check(isRecommendedPick(alias: "gemma-4-26b-4bit", physicalRAMGB: 32), "gemma-26b recommended on 32GB")
 check(isRecommendedPick(alias: "qwen3.5-122b-mxfp4", physicalRAMGB: 96), "122b-mxfp4 recommended on 96GB")
 check(!isRecommendedPick(alias: "qwen3.5-122b-mxfp4", physicalRAMGB: 64), "122b-mxfp4 NOT recommended on 64GB")
 // The fast alt is a recommended pick on its tiers too (skips the .tooBig gate).

--- a/docs/benchmarks/model-recommendation-measurements.json
+++ b/docs/benchmarks/model-recommendation-measurements.json
@@ -1,0 +1,40 @@
+{
+  "schema_version": 1,
+  "environment": {
+    "timestamp_utc": "2026-08-07T19:40:00Z",
+    "hostname": "Raullens-Mini",
+    "machine": "Mac mini",
+    "chip": "Apple M2 Pro (10-core)",
+    "chip_model": "Mac14,12",
+    "physical_ram_gb": 32,
+    "macos": "26.5.2",
+    "rapid_mlx": "0.12.5",
+    "git_sha": "1bc6244be3d7e49c7f91a195175e5167244a0e1f",
+    "mlx": "0.31.2",
+    "mlx_lm": "0.31.3",
+    "mlx_vlm": "0.6.3",
+    "python": "3.13.2"
+  },
+  "method": {
+    "serve_path": "python -m vllm_mlx.cli serve",
+    "output_tokens": 96,
+    "long_prompt_tokens": 8110,
+    "models_are_sequential": true,
+    "max_recommended_ram_fraction": 0.75,
+    "min_decode_tps": 10.0,
+    "min_8k_prefill_tps": 100.0,
+    "max_new_swap_mb": 0.0
+  },
+  "measurements": [
+    {"model":"lfm2.5-1b-4bit","load_s":5.07,"idle_gb":0.965,"peak_8k_gb":2.054,"prefill_8k_tps":1121.96,"decode_short_tps":214.45,"decode_8k_tps":127.25,"swap_delta_mb":0.0},
+    {"model":"lfm2.5-2.6b-4bit","load_s":4.06,"idle_gb":1.908,"peak_8k_gb":3.207,"prefill_8k_tps":488.09,"decode_short_tps":94.15,"decode_8k_tps":51.97,"swap_delta_mb":0.0},
+    {"model":"lfm2.5-8b-a1b-4bit","load_s":7.10,"idle_gb":4.868,"peak_8k_gb":6.067,"prefill_8k_tps":631.63,"decode_short_tps":120.12,"decode_8k_tps":83.50,"swap_delta_mb":0.0},
+    {"model":"qwen3.5-4b-4bit","load_s":5.05,"idle_gb":2.761,"peak_8k_gb":5.818,"prefill_8k_tps":313.18,"decode_short_tps":62.17,"decode_8k_tps":39.09,"swap_delta_mb":0.0},
+    {"model":"qwen3.5-9b-4bit","load_s":6.07,"idle_gb":5.262,"peak_8k_gb":8.680,"prefill_8k_tps":172.50,"decode_short_tps":36.19,"decode_8k_tps":31.80,"swap_delta_mb":0.0},
+    {"model":"gemma-4-12b-4bit","load_s":14.11,"idle_gb":7.322,"peak_8k_gb":11.0,"prefill_8k_tps":52.27,"decode_short_tps":23.39,"decode_8k_tps":22.04,"swap_delta_mb":0.0},
+    {"model":"bonsai-27b-2bit","load_s":8.07,"idle_gb":7.813,"peak_8k_gb":13.0,"prefill_8k_tps":169.52,"decode_short_tps":17.78,"decode_8k_tps":15.82,"swap_delta_mb":0.0},
+    {"model":"gemma-4-26b-4bit","serve_args":["--no-mllm","--kv-cache-dtype","bf16","--cache-memory-mb","512"],"load_s":12.12,"idle_gb":14.0,"peak_8k_gb":20.0,"prefill_8k_tps":226.94,"decode_short_tps":50.06,"decode_8k_tps":23.61,"swap_delta_mb":0.0},
+    {"model":"qwen3.5-35b-4bit","load_s":17.14,"idle_gb":19.0,"peak_8k_gb":22.0,"prefill_8k_tps":335.90,"decode_short_tps":60.26,"decode_8k_tps":50.30,"swap_delta_mb":988.8},
+    {"model":"qwen3.6-27b-4bit","load_s":13.51,"idle_gb":15.0,"peak_8k_gb":21.0,"prefill_8k_tps":48.88,"decode_short_tps":11.30,"decode_8k_tps":10.72,"swap_delta_mb":0.0}
+  ]
+}

--- a/docs/benchmarks/model-recommendations.md
+++ b/docs/benchmarks/model-recommendations.md
@@ -1,0 +1,69 @@
+# Measured model recommendations
+
+Release recommendations use two slots per RAM tier:
+
+- **Faster:** the fastest model that remains useful for its stated scope.
+- **Smarter:** the highest-capability model that clears the interaction and safety gates.
+
+A recommendation must decode at **10 tok/s or faster**, complete the standard
+8K prefill at **100 prompt tok/s or faster**, stay below **75% of physical RAM**
+at the tier floor, and add **no swap**. A model that misses a gate may remain in
+the catalog, but belongs under “Runs, but slow or tight”, not Recommended.
+
+The benchmark is reproducible with:
+
+```bash
+python scripts/benchmark_model_recommendations.py \
+  --output /tmp/model-recommendations.json
+```
+
+It starts one cached model at a time through `rapid-mlx serve`, uses macOS
+`footprint` so Metal unified memory is counted, runs short and ~8K-token
+prompts, records `/v1/status` throughput, and stops between models. Raw reviewed
+rows live in [`model-recommendation-measurements.json`](model-recommendation-measurements.json).
+
+## Table 1 — chip × RAM × model × engine
+
+First release sweep: Mac mini Mac14,12, Apple M2 Pro (10-core), 32 GB, macOS
+26.5.2; Rapid-MLX 0.12.5 at `1bc6244b`; MLX 0.31.2; mlx-lm 0.31.3. `Peak` is
+the process-lifetime `phys_footprint_peak`. Throughput columns show short / 8K.
+
+| Model | Load | Idle | 8K peak | Prefill tok/s | Decode tok/s | New swap | Decision |
+|---|---:|---:|---:|---:|---:|---:|---|
+| `lfm2.5-1b-4bit` | 5.1s | 0.97 GB | 2.05 GB | 1,122 | 214 / 127 | 0 MB | Very fast; basic chat only |
+| `lfm2.5-2.6b-4bit` | 4.1s | 1.91 GB | 3.21 GB | 488 | 94.2 / 52.0 | 0 MB | Smarter small-model option; not for coding |
+| `lfm2.5-8b-a1b-4bit` | 7.1s | 4.87 GB | 6.07 GB | 632 | 120 / 83.5 | 0 MB | Fast chat specialist |
+| `qwen3.5-4b-4bit` | 5.1s | 2.76 GB | 5.82 GB | 313 | 62.2 / 39.1 | 0 MB | Fast general-purpose |
+| `qwen3.5-9b-4bit` | 6.1s | 5.26 GB | 8.68 GB | 172 | 36.2 / 31.8 | 0 MB | Strong laptop default |
+| `gemma-4-12b-4bit` | 14.1s | 7.32 GB | 11.0 GB | 52 | 23.4 / 22.0 | 0 MB | Fails 8K prefill gate |
+| `bonsai-27b-2bit` | 8.1s | 7.81 GB | 13.0 GB | 170 | 17.8 / 15.8 | 0 MB | Smart 24 GB candidate |
+| `gemma-4-26b-4bit`¹ | 12.1s | 14.0 GB | 20.0 GB | 227 | 50.1 / 23.6 | 0 MB | Floor at 32 GB, not 24 GB |
+| `qwen3.5-35b-4bit` | 17.1s | 19.0 GB | 22.0 GB | 336 | 60.3 / 50.3 | **989 MB** | Floor above 32 GB |
+| `qwen3.6-27b-4bit` | 13.5s | 15.0 GB | 21.0 GB | 48.9 | 11.3 / 10.7 | 0 MB | Fails 8K prefill gate |
+
+¹ Text-only launch flags: `--no-mllm --kv-cache-dtype bf16 --cache-memory-mb 512`.
+
+The 32 GB Qwen 35B swap regression is tracked in #1634. The unsafe 24 GB
+Gemma 26B floor is tracked in #1636.
+
+## Table 2 — two choices per RAM tier
+
+“Smarter” is the primary pick. “Faster” deliberately trades capability for
+latency. Rows above the measured 32 GB host retain the existing reviewed
+large-memory picks and must gain host-specific measurements before their next
+release change.
+
+| Physical RAM | Faster | Smarter | Rationale |
+|---|---|---|---|
+| 8–15 GB | `lfm2.5-1b-4bit` | `lfm2.5-2.6b-4bit` | Smallest safe pair; neither is for serious coding |
+| 16–17 GB | `lfm2.5-1b-4bit` | `qwen3.5-4b-4bit` | Instant basic chat vs reliable general use |
+| 18–23 GB | `qwen3.5-4b-4bit` | `qwen3.5-9b-4bit` | Both tool-capable and comfortably above 10 tok/s |
+| 24–31 GB | `qwen3.5-4b-4bit` | `bonsai-27b-2bit` | 13 GB measured peak; Gemma 26B is too large at 24 GB |
+| 32–47 GB | `qwen3.5-4b-4bit` | `gemma-4-26b-4bit` | 20 GB 8K peak with no new swap on the 32 GB floor |
+| 48–63 GB | `qwen3.6-35b-4bit` | `gemma-4-26b-4bit` | Retains the existing reviewed fast pick pending a 48 GB host measurement |
+| 64–95 GB | `qwen3.6-35b-4bit` | `qwen3.6-35b-8bit` | Same family: speed vs quantization fidelity |
+| 96 GB+ | `qwen3.6-35b-4bit` | `qwen3.5-122b-mxfp4` | Workhorse speed vs maximum local capability |
+
+Recommendation data is hardware-specific. A result from one chip/RAM pair must
+not be silently copied to another; missing rows are estimates and should be
+replaced by measurements before changing a tier.

--- a/install.sh
+++ b/install.sh
@@ -99,16 +99,16 @@ fi
 # single command, so it takes the app's PRIMARY (smart) pick only.
 #
 # RECOMMENDED_FLAGS carries the tier's launch flags. It is not cosmetic:
-# ``gemma-4-26b-4bit`` at 24 GB needs its vision tower dropped and its KV
-# budget capped, and printing the bare ``serve`` line would hand a 24 GB
+# ``gemma-4-26b-4bit`` at 32–63 GB needs its vision tower dropped and its KV
+# budget capped, and printing the bare ``serve`` line would hand that Mac
 # Mac a command that does not fit in it.
 RAM_GB=$(sysctl -n hw.memsize 2>/dev/null | awk '{printf "%d", $1/1073741824}')
 RECOMMENDED_FLAGS=""
 if   [ "$RAM_GB" -ge 96 ]; then RECOMMENDED_MODEL="qwen3.5-122b-mxfp4";  RAM_TIER="96+ GB"
 elif [ "$RAM_GB" -ge 64 ]; then RECOMMENDED_MODEL="qwen3.6-35b-8bit";    RAM_TIER="64-95 GB"
-elif [ "$RAM_GB" -ge 32 ]; then RECOMMENDED_MODEL="qwen3.6-35b-4bit";    RAM_TIER="32-63 GB"
-elif [ "$RAM_GB" -ge 24 ]; then RECOMMENDED_MODEL="gemma-4-26b-4bit";    RAM_TIER="24-31 GB"
+elif [ "$RAM_GB" -ge 32 ]; then RECOMMENDED_MODEL="gemma-4-26b-4bit";    RAM_TIER="32-63 GB"
                                 RECOMMENDED_FLAGS=" --no-mllm --kv-cache-dtype bf16 --cache-memory-mb 512"
+elif [ "$RAM_GB" -ge 24 ]; then RECOMMENDED_MODEL="bonsai-27b-2bit";     RAM_TIER="24-31 GB"
 elif [ "$RAM_GB" -ge 18 ]; then RECOMMENDED_MODEL="qwen3.5-9b-4bit";     RAM_TIER="18-23 GB"
 elif [ "$RAM_GB" -ge 16 ]; then RECOMMENDED_MODEL="qwen3.5-4b-4bit";     RAM_TIER="16-17 GB"
 else                            RECOMMENDED_MODEL="lfm2.5-2.6b-4bit";    RAM_TIER="8-15 GB"

--- a/scripts/benchmark_model_recommendations.py
+++ b/scripts/benchmark_model_recommendations.py
@@ -1,0 +1,326 @@
+#!/usr/bin/env python3
+"""Measure the memory and interactive speed used by model recommendations.
+
+Runs one cached model at a time through the real ``rapid-mlx serve`` path.
+The output is append-friendly JSON; maintainers commit reviewed rows to
+``docs/benchmarks/model-recommendation-measurements.json``.
+
+macOS only: the harness uses ``footprint`` so Metal/unified memory is counted.
+It never downloads weights unless ``--allow-download`` is explicitly passed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import platform
+import re
+import signal
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+
+GIB = 1 << 30
+DEFAULT_MODELS = [
+    "lfm2.5-1b-4bit",
+    "lfm2.5-2.6b-4bit",
+    "lfm2.5-8b-a1b-4bit",
+    "qwen3.5-4b-4bit",
+    "qwen3.5-9b-4bit",
+    "gemma-4-12b-4bit",
+    "bonsai-27b-2bit",
+    "gemma-4-26b-4bit",
+    "qwen3.5-35b-4bit",
+    "qwen3.6-27b-4bit",
+    "qwen3.6-35b-4bit",
+]
+MODEL_SERVE_ARGS = {
+    "gemma-4-26b-4bit": [
+        "--no-mllm",
+        "--kv-cache-dtype",
+        "bf16",
+        "--cache-memory-mb",
+        "512",
+    ]
+}
+
+
+def command(*args: str, timeout: float = 15) -> str:
+    return subprocess.run(
+        args, check=True, capture_output=True, text=True, timeout=timeout
+    ).stdout.strip()
+
+
+def package_version(name: str) -> str:
+    try:
+        return version(name)
+    except PackageNotFoundError:
+        return "unknown"
+
+
+def json_request(url: str, payload: dict | None = None, timeout: float = 600) -> dict:
+    data = None if payload is None else json.dumps(payload).encode()
+    request = urllib.request.Request(url, data=data)
+    if data is not None:
+        request.add_header("Content-Type", "application/json")
+    with urllib.request.urlopen(request, timeout=timeout) as response:
+        return json.load(response)
+
+
+def footprint(pid: int) -> tuple[float, float]:
+    text = command("footprint", "-p", str(pid), timeout=30)
+    current = re.search(r"Footprint:\s+([0-9.]+)\s+(MB|GB)", text)
+    peak = re.search(r"phys_footprint_peak:\s+([0-9.]+)\s+(MB|GB)", text)
+    if not current or not peak:
+        raise RuntimeError("could not parse macOS footprint output")
+
+    def gb(match: re.Match[str]) -> float:
+        value = float(match.group(1))
+        return value if match.group(2) == "GB" else value / 1024
+
+    return round(gb(current), 3), round(gb(peak), 3)
+
+
+def swap_used_mb() -> float:
+    text = command("sysctl", "-n", "vm.swapusage")
+    match = re.search(r"used = ([0-9.]+)([MG])", text)
+    if not match:
+        return 0.0
+    value = float(match.group(1))
+    return value * 1024 if match.group(2) == "G" else value
+
+
+def physical_ram_gb() -> int:
+    return round(int(command("sysctl", "-n", "hw.memsize")) / GIB)
+
+
+def cached_repo_for(alias: str) -> bool:
+    # Resolve through Rapid-MLX so aliases and HF cache directory names cannot drift.
+    from vllm_mlx.model_aliases import resolve_model
+
+    repo = resolve_model(alias)
+    root = Path(os.environ.get("HF_HOME", Path.home() / ".cache/huggingface")) / "hub"
+    return (root / ("models--" + repo.replace("/", "--"))).is_dir()
+
+
+def wait_ready(proc: subprocess.Popen[str], port: int, timeout: float) -> None:
+    deadline = time.monotonic() + timeout
+    url = f"http://127.0.0.1:{port}/v1/models"
+    while time.monotonic() < deadline:
+        if proc.poll() is not None:
+            raise RuntimeError(f"server exited with status {proc.returncode}")
+        try:
+            json_request(url, timeout=2)
+            return
+        except (OSError, urllib.error.URLError, json.JSONDecodeError):
+            time.sleep(1)
+    raise TimeoutError(f"server was not ready after {timeout:.0f}s")
+
+
+def run_prompt(port: int, alias: str, content: str, max_tokens: int) -> dict:
+    started = time.monotonic()
+    response = json_request(
+        f"http://127.0.0.1:{port}/v1/chat/completions",
+        {
+            "model": alias,
+            "messages": [{"role": "user", "content": content}],
+            "temperature": 0,
+            "max_tokens": max_tokens,
+        },
+    )
+    elapsed = time.monotonic() - started
+    usage = response.get("usage") or {}
+    status = json_request(f"http://127.0.0.1:{port}/v1/status")
+    completion = int(usage.get("completion_tokens") or 0)
+    return {
+        "elapsed_s": round(elapsed, 3),
+        "prompt_tokens": int(usage.get("prompt_tokens") or 0),
+        "completion_tokens": completion,
+        "wall_decode_tps": round(completion / elapsed, 2) if elapsed else 0.0,
+        "server_prompt_tps": float(status.get("prompt_tps") or 0),
+        "server_generation_tps": float(status.get("generation_tps") or 0),
+        "metal": status.get("metal") or {},
+    }
+
+
+def stop(proc: subprocess.Popen[str]) -> None:
+    if proc.poll() is not None:
+        return
+    proc.send_signal(signal.SIGTERM)
+    try:
+        proc.wait(timeout=30)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait(timeout=10)
+
+
+def measure(alias: str, args: argparse.Namespace, environment: dict) -> dict:
+    if not args.allow_download and not cached_repo_for(alias):
+        return {"model": alias, "status": "skipped_not_cached"}
+
+    log_path = Path(args.log_dir) / f"{alias}.log"
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    swap_before = swap_used_mb()
+    started = time.monotonic()
+    with log_path.open("w") as log:
+        proc = subprocess.Popen(
+            [
+                sys.executable,
+                "-P",
+                "-u",
+                "-s",
+                "-m",
+                "vllm_mlx.cli",
+                "serve",
+                alias,
+                "--host",
+                "127.0.0.1",
+                "--port",
+                str(args.port),
+                *MODEL_SERVE_ARGS.get(alias, []),
+                *args.serve_arg,
+            ],
+            stdout=log,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+        try:
+            wait_ready(proc, args.port, args.load_timeout)
+            load_s = time.monotonic() - started
+            idle_gb, load_peak_gb = footprint(proc.pid)
+            if load_peak_gb > environment["physical_ram_gb"] * args.abort_ram_fraction:
+                raise RuntimeError(
+                    f"load peak {load_peak_gb} GB exceeded safety limit "
+                    f"{environment['physical_ram_gb'] * args.abort_ram_fraction:.1f} GB"
+                )
+
+            short = run_prompt(
+                args.port,
+                alias,
+                "Explain in one concise paragraph why local inference is useful.",
+                args.output_tokens,
+            )
+            short_gb, short_peak_gb = footprint(proc.pid)
+            swap_after_short = max(0.0, swap_used_mb() - swap_before)
+            if swap_after_short > args.abort_swap_mb:
+                return {
+                    "model": alias,
+                    "status": "aborted_swap",
+                    "load_s": round(load_s, 2),
+                    "idle_footprint_gb": idle_gb,
+                    "load_peak_gb": load_peak_gb,
+                    "short_footprint_gb": short_gb,
+                    "short_peak_gb": short_peak_gb,
+                    "short": short,
+                    "swap_delta_mb": round(swap_after_short, 1),
+                    "reason": f"new swap exceeded {args.abort_swap_mb:.0f} MB safety limit",
+                }
+
+            # Repeated neutral text gives every tokenizer a comparable ~8K context.
+            long_text = (
+                "Local models keep data private and available offline. " * 900
+            ).strip()
+            long = run_prompt(args.port, alias, long_text, args.output_tokens)
+            long_gb, long_peak_gb = footprint(proc.pid)
+            swap_after_long = max(0.0, swap_used_mb() - swap_before)
+
+            row = {
+                "model": alias,
+                "status": (
+                    "aborted_swap" if swap_after_long > args.abort_swap_mb else "ok"
+                ),
+                "load_s": round(load_s, 2),
+                "idle_footprint_gb": idle_gb,
+                "load_peak_gb": load_peak_gb,
+                "short_footprint_gb": short_gb,
+                "short_peak_gb": short_peak_gb,
+                "long_footprint_gb": long_gb,
+                "long_peak_gb": long_peak_gb,
+                "short": short,
+                "long": long,
+                "swap_delta_mb": round(swap_after_long, 1),
+            }
+            if swap_after_long > args.abort_swap_mb:
+                row["reason"] = (
+                    f"new swap exceeded {args.abort_swap_mb:.0f} MB safety limit"
+                )
+            return row
+        except Exception as exc:
+            return {
+                "model": alias,
+                "status": "error",
+                "error": str(exc),
+                "log": str(log_path),
+            }
+        finally:
+            stop(proc)
+            time.sleep(args.cooldown)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("models", nargs="*", default=DEFAULT_MODELS)
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--port", type=int, default=8010)
+    parser.add_argument("--output-tokens", type=int, default=96)
+    parser.add_argument("--load-timeout", type=float, default=300)
+    parser.add_argument("--cooldown", type=float, default=10)
+    parser.add_argument("--abort-ram-fraction", type=float, default=0.80)
+    parser.add_argument("--abort-swap-mb", type=float, default=256)
+    parser.add_argument("--allow-download", action="store_true")
+    parser.add_argument(
+        "--serve-arg",
+        action="append",
+        default=[],
+        help="extra serve argv; repeat and use --serve-arg=--flag for flags",
+    )
+    parser.add_argument("--log-dir", default="/tmp/rapid-model-recommendations")
+    args = parser.parse_args()
+
+    if platform.system() != "Darwin":
+        parser.error("this benchmark requires macOS footprint")
+
+    environment = {
+        "timestamp_utc": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "hostname": platform.node(),
+        "chip_model": command("sysctl", "-n", "hw.model"),
+        "physical_ram_gb": physical_ram_gb(),
+        "macos": platform.mac_ver()[0],
+        "rapid_mlx": package_version("rapid-mlx"),
+        "mlx": package_version("mlx"),
+        "mlx_lm": package_version("mlx-lm"),
+        "git_sha": command("git", "rev-parse", "HEAD"),
+        "python": platform.python_version(),
+    }
+    result = {
+        "schema_version": 1,
+        "environment": environment,
+        "method": {
+            "serve_path": "python -m vllm_mlx.cli serve",
+            "output_tokens": args.output_tokens,
+            "long_prompt": "~8K tokens (900 repeated neutral sentences)",
+            "abort_ram_fraction": args.abort_ram_fraction,
+            "abort_swap_mb": args.abort_swap_mb,
+            "extra_serve_args": args.serve_arg,
+            "per_model_serve_args": MODEL_SERVE_ARGS,
+            "models_are_sequential": True,
+        },
+        "measurements": [],
+    }
+    output = Path(args.output)
+    for alias in args.models:
+        print(f"Measuring {alias}...", flush=True)
+        row = measure(alias, args, environment)
+        result["measurements"].append(row)
+        output.write_text(json.dumps(result, indent=2) + "\n")
+        print(json.dumps(row, indent=2), flush=True)
+    return 1 if any(r["status"] == "error" for r in result["measurements"]) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_ram_tier_recommendations_agree.py
+++ b/tests/test_ram_tier_recommendations_agree.py
@@ -183,10 +183,10 @@ def _render_banner(ram_gb: int) -> str:
 
 
 def test_the_banner_actually_prints_the_launch_flags():
-    """gemma-4-26b-4bit at 24 GB needs its vision tower dropped and its KV
+    """gemma-4-26b-4bit at 32 GB needs its vision tower dropped and its KV
     budget capped. That is not advice — without the flags the command does
     not fit on the Mac it is being handed to."""
-    printed = _render_banner(24)
+    printed = _render_banner(32)
     assert "gemma-4-26b-4bit" in printed, printed
     for flag in ("--no-mllm", "--kv-cache-dtype", "bf16", "--cache-memory-mb", "512"):
         assert flag in printed, (
@@ -196,7 +196,7 @@ def test_the_banner_actually_prints_the_launch_flags():
 
 def test_the_banner_prints_a_bare_command_where_no_flags_are_needed():
     """Control: the flags must not leak onto tiers that do not want them."""
-    for ram in (8, 16, 32, 64):
+    for ram in (8, 16, 24, 64):
         printed = _render_banner(ram)
         assert "rapid-mlx serve" in printed
         assert "--no-mllm" not in printed, f"{ram} GB banner: {printed}"


### PR DESCRIPTION
## Summary

- benchmark common models sequentially on the M2 Pro 32 GB Mac mini using current main and commit chip/RAM/model/engine measurements
- make every RAM tier expose exactly two choices: faster and smarter
- move Bonsai 27B to the 24 GB smart slot and Gemma 26B to 32 GB+, with measured ~8K peak memory and throughput
- add a reusable macOS benchmark harness with cache-only default, RAM/swap abort guards, and exact per-model launch flags
- keep installer, README, desktop picker, and standalone contract verification synchronized

## Validation

- `python3 -m ruff check scripts/benchmark_model_recommendations.py`
- `python3 -m py_compile scripts/benchmark_model_recommendations.py`
- `python3 -m json.tool docs/benchmarks/model-recommendation-measurements.json`
- `swift apps/rapid-mac/scripts/verify-recommendation-tiers.swift`
- `python3 -m pytest tests/test_ram_tier_recommendations_agree.py -q` (21 passed)
- `swift build --target RapidTests`
- `SKIP_SIDECAR=1 BUNDLE_MODEL=0 ./scripts/build.sh` (release app build)
- two Codex reviews; all actionable findings addressed

## Follow-ups found during validation

- #1638 tracks the existing `swift test` / RapidUXTests XCTest configuration blocker

Closes #1634
Closes #1636
Closes #1639