### PR TITLE
fix(mac): show untested metrics and make recommendation benchmarks reproducible

### DIFF
--- a/apps/rapid-mac/CHANGELOG.md
+++ b/apps/rapid-mac/CHANGELOG.md
@@ -13,6 +13,12 @@ can actually understand.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Models without a compatible benchmark now say “Untested”.** Empty dashed
+  capability and speed tracks looked like zero scores. The model list now
+  distinguishes missing measurements from poor results explicitly.
+
 ## [0.12.6] — 2026-08-07
 
 Rapid can now look things up. The headline is a set of built-in tools —

--- a/apps/rapid-mac/Sources/Rapid/Server/ModelMeter.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ModelMeter.swift
@@ -23,7 +23,7 @@ enum MeterLevel: String, Equatable, Sendable {
 /// One resolved meter: which axis it represents, the label to show, the
 /// number of filled segments (0…5), the rating, and the formatted value.
 /// ``value``/``level`` are ``nil`` when the model author didn't publish
-/// the axis — the view renders a dashed empty track + em-dash (never a
+/// the axis — the view renders an explicit "Untested" state (never a
 /// fabricated number, per the standing benchmark-honesty policy).
 struct ResolvedMeter: Equatable, Sendable {
     let axis: BenchScores.Axis
@@ -95,7 +95,7 @@ enum ModelMeter {
     }
 
     /// Resolve the quality meter for an alias. Returns a meter whose
-    /// `value`/`level` are `nil` (dashed) when no quality axis is
+    /// `value`/`level` are `nil` when no quality axis is
     /// published, so the caller always has a labelled row to render.
     static func qualityMeter(for alias: String) -> ResolvedMeter {
         guard let scores = BenchScoresCatalog.lookup(alias: alias),
@@ -108,7 +108,7 @@ enum ModelMeter {
                 label: shortLabel(for: .generalReasoning),
                 filledSegments: 0,
                 level: nil,
-                formattedValue: "—"
+                formattedValue: "Untested"
             )
         }
         return ResolvedMeter(
@@ -129,7 +129,7 @@ enum ModelMeter {
         )
     }
 
-    /// Resolve the speed meter for an alias. `nil`-dashed when the
+    /// Resolve the speed meter for an alias. `nil` / "Untested" when the
     /// alias has no measured decode tok/s (many vision + newest models).
     static func speedMeter(for alias: String) -> ResolvedMeter {
         guard let scores = BenchScoresCatalog.lookup(alias: alias),
@@ -139,7 +139,7 @@ enum ModelMeter {
                 label: shortLabel(for: .speed),
                 filledSegments: 0,
                 level: nil,
-                formattedValue: "—"
+                formattedValue: "Untested"
             )
         }
         return ResolvedMeter(

--- a/apps/rapid-mac/Sources/Rapid/UI/SegmentedBenchMeter.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SegmentedBenchMeter.swift
@@ -6,8 +6,7 @@ import SwiftUI
 /// painted in the rating colour, and a right-aligned numeric readout.
 ///
 /// A meter with `level == nil` (the author published no score for the
-/// axis) draws a single dashed empty track + an em-dash value — never a
-/// fabricated fill.
+/// axis) says "Untested" — never a blank-looking track or fabricated fill.
 ///
 /// Segmented blocks (not a continuous bar) are the deliberate style
 /// choice from the #507 design review: five discrete blocks read faster
@@ -40,16 +39,15 @@ struct SegmentedBenchMeter: View {
                 .frame(width: labelWidth, alignment: .trailing)
 
             if meter.level == nil {
-                dashedTrack
+                untestedLabel
             } else {
                 segments
-            }
-
-            if showValue {
-                Text(meter.formattedValue)
-                    .font(.system(size: valueSize, weight: .medium).monospacedDigit())
-                    .foregroundStyle(meter.level == nil ? .tertiary : .secondary)
-                    .frame(width: 30, alignment: .trailing)
+                if showValue {
+                    Text(meter.formattedValue)
+                        .font(.system(size: valueSize, weight: .medium).monospacedDigit())
+                        .foregroundStyle(.secondary)
+                        .frame(width: 30, alignment: .trailing)
+                }
             }
         }
         .accessibilityElement(children: .ignore)
@@ -66,11 +64,11 @@ struct SegmentedBenchMeter: View {
         }
     }
 
-    private var dashedTrack: some View {
-        RoundedRectangle(cornerRadius: 3, style: .continuous)
-            .strokeBorder(style: StrokeStyle(lineWidth: 1, dash: [3, 3]))
-            .foregroundStyle(Color.secondary.opacity(0.4))
-            .frame(height: segmentHeight + 2)
+    private var untestedLabel: some View {
+        Text("Untested")
+            .font(.system(size: valueSize, weight: .medium))
+            .foregroundStyle(.tertiary)
+            .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     private var fillColor: Color {
@@ -88,7 +86,7 @@ struct SegmentedBenchMeter: View {
     /// sighted users read off the blocks. Pure + static for testability.
     static func accessibilityLabel(for meter: ResolvedMeter) -> String {
         guard let level = meter.level else {
-            return "\(meter.label): not published"
+            return "\(meter.label): untested"
         }
         let rating: String
         switch level {

--- a/apps/rapid-mac/Sources/Rapid/UI/SettingsModelManagementPanel.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SettingsModelManagementPanel.swift
@@ -658,7 +658,7 @@ struct SettingsModelManagementPanel: View {
         }
     }
 
-    /// One-line meaning of the two meters + the em-dash. Rendered inside
+    /// One-line meaning of the two meters + the explicit unknown state. Rendered inside
     /// the "All models" section, immediately above the only rows that
     /// carry the Quality · Speed bars. (It used to sit at the panel top,
     /// but the recommendation cards no longer show meters — they show the
@@ -666,7 +666,7 @@ struct SettingsModelManagementPanel: View {
     /// misattributed those curated numbers as published benchmarks.)
     @ViewBuilder
     private var meterLegend: some View {
-        Text("Quality = the author's published benchmark, labelled per row (Accuracy / Code / Tool / Instructions) · Speed = tokens/sec on this class of Mac · “—” = the author hasn't published that score.")
+        Text("Quality = published benchmark, labelled per row (Accuracy / Code / Tool / Instructions) · Speed = measured tokens/sec on this class of Mac · Untested = no compatible result recorded yet.")
             .scaledSystemFont(10)
             .foregroundStyle(.tertiary)
             .fixedSize(horizontal: false, vertical: true)

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-after-relaunch.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-after-relaunch.txt
@@ -88,8 +88,8 @@ AXApplication title="Rapid-MLX"
           AXButton id="Settings.ModelManagement.Favorite.<model>" desc="Pin <model>" enabled=true
           AXStaticText value=text enabled=true
           AXStaticText value=text enabled=true
-          AXUnknown desc="Accuracy: not published" enabled=true
-          AXUnknown desc="Speed: not published" enabled=true
+          AXUnknown desc="Accuracy: untested" enabled=true
+          AXUnknown desc="Speed: untested" enabled=true
           AXStaticText help="Measured size on disk. Deleting frees this much." value=text enabled=true
           AXButton id="Settings.ModelManagement.Delete.<model>" desc="Delete <model> from disk" enabled=true
         AXStaticText id="Settings.ModelManagement.Footer" value=text enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-idle.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-idle.txt
@@ -88,8 +88,8 @@ AXApplication title="Rapid-MLX"
           AXButton id="Settings.ModelManagement.Favorite.<model>" desc="Pin <model>" enabled=true
           AXStaticText value=text enabled=true
           AXStaticText value=text enabled=true
-          AXUnknown desc="Accuracy: not published" enabled=true
-          AXUnknown desc="Speed: not published" enabled=true
+          AXUnknown desc="Accuracy: untested" enabled=true
+          AXUnknown desc="Speed: untested" enabled=true
           AXStaticText help="Measured size on disk. Deleting frees this much." value=text enabled=true
           AXButton id="Settings.ModelManagement.Delete.<model>" desc="Delete <model> from disk" enabled=true
         AXStaticText id="Settings.ModelManagement.Footer" value=text enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-toggled.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-toggled.txt
@@ -88,8 +88,8 @@ AXApplication title="Rapid-MLX"
           AXButton id="Settings.ModelManagement.Favorite.<model>" desc="Pin <model>" enabled=true
           AXStaticText value=text enabled=true
           AXStaticText value=text enabled=true
-          AXUnknown desc="Accuracy: not published" enabled=true
-          AXUnknown desc="Speed: not published" enabled=true
+          AXUnknown desc="Accuracy: untested" enabled=true
+          AXUnknown desc="Speed: untested" enabled=true
           AXStaticText help="Measured size on disk. Deleting frees this much." value=text enabled=true
           AXButton id="Settings.ModelManagement.Delete.<model>" desc="Delete <model> from disk" enabled=true
         AXStaticText id="Settings.ModelManagement.Footer" value=text enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.settings-root.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.settings-root.txt
@@ -88,8 +88,8 @@ AXApplication title="Rapid-MLX"
           AXButton id="Settings.ModelManagement.Favorite.<model>" desc="Pin <model>" enabled=true
           AXStaticText value=text enabled=true
           AXStaticText value=text enabled=true
-          AXUnknown desc="Accuracy: not published" enabled=true
-          AXUnknown desc="Speed: not published" enabled=true
+          AXUnknown desc="Accuracy: untested" enabled=true
+          AXUnknown desc="Speed: untested" enabled=true
           AXStaticText help="Measured size on disk. Deleting frees this much." value=text enabled=true
           AXButton id="Settings.ModelManagement.Delete.<model>" desc="Delete <model> from disk" enabled=true
         AXStaticText id="Settings.ModelManagement.Footer" value=text enabled=true

--- a/apps/rapid-mac/Tests/RapidTests/ModelSurfaceRedesignTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ModelSurfaceRedesignTests.swift
@@ -171,22 +171,22 @@ struct ModelSurfaceRedesignTests {
 
     // MARK: - ModelMeter resolved meters (catalog integration)
 
-    @Test("qualityMeter: an unscored alias yields a dashed, em-dash meter")
+    @Test("qualityMeter: an unscored alias is explicitly untested")
     func qualityMeterUnscored() {
         let meter = ModelMeter.qualityMeter(for: "definitely-not-a-real-alias-xyz")
         #expect(meter.level == nil)
         #expect(meter.filledSegments == 0)
-        #expect(meter.formattedValue == "—")
+        #expect(meter.formattedValue == "Untested")
         // Still labelled so the row renders a quality track, not a blank.
         #expect(meter.label == "Accuracy")
     }
 
-    @Test("speedMeter: an unscored alias yields a dashed, em-dash meter")
+    @Test("speedMeter: an unscored alias is explicitly untested")
     func speedMeterUnscored() {
         let meter = ModelMeter.speedMeter(for: "definitely-not-a-real-alias-xyz")
         #expect(meter.level == nil)
         #expect(meter.filledSegments == 0)
-        #expect(meter.formattedValue == "—")
+        #expect(meter.formattedValue == "Untested")
         #expect(meter.label == "Speed")
     }
 

--- a/docs/benchmarks/model-recommendation-measurements.json
+++ b/docs/benchmarks/model-recommendation-measurements.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "environment": {
-    "timestamp_utc": "2026-08-07T19:40:00Z",
+    "timestamp_utc": "2026-08-07T20:28:07Z",
     "hostname": "Raullens-Mini",
     "machine": "Mac mini",
     "chip": "Apple M2 Pro (10-core)",
@@ -9,32 +9,37 @@
     "physical_ram_gb": 32,
     "macos": "26.5.2",
     "rapid_mlx": "0.12.5",
-    "git_sha": "1bc6244be3d7e49c7f91a195175e5167244a0e1f",
+    "git_sha": "aba2fdd11da4636b6372415f7903fc90f45ff3e8",
     "mlx": "0.31.2",
     "mlx_lm": "0.31.3",
     "mlx_vlm": "0.6.3",
-    "python": "3.13.2"
+    "python": "3.12.13"
   },
   "method": {
-    "serve_path": "python -m vllm_mlx.cli serve",
+    "serve_path": "python -m vllm_mlx.cli serve --disable-prefix-cache",
     "output_tokens": 96,
     "long_prompt_tokens": 8110,
     "models_are_sequential": true,
     "max_recommended_ram_fraction": 0.75,
     "min_decode_tps": 10.0,
     "min_8k_prefill_tps": 100.0,
-    "max_new_swap_mb": 0.0
+    "max_new_swap_mb": 0.0,
+    "local_cache": "/Users/raullenmini/.cache/huggingface/hub",
+    "cold_cache": "/Volumes/mac-storage/hf-cache (Jetson over USB-C SMB; load time is not locally comparable)"
   },
   "measurements": [
-    {"model":"lfm2.5-1b-4bit","load_s":5.07,"idle_gb":0.965,"peak_8k_gb":2.054,"prefill_8k_tps":1121.96,"decode_short_tps":214.45,"decode_8k_tps":127.25,"swap_delta_mb":0.0},
-    {"model":"lfm2.5-2.6b-4bit","load_s":4.06,"idle_gb":1.908,"peak_8k_gb":3.207,"prefill_8k_tps":488.09,"decode_short_tps":94.15,"decode_8k_tps":51.97,"swap_delta_mb":0.0},
-    {"model":"lfm2.5-8b-a1b-4bit","load_s":7.10,"idle_gb":4.868,"peak_8k_gb":6.067,"prefill_8k_tps":631.63,"decode_short_tps":120.12,"decode_8k_tps":83.50,"swap_delta_mb":0.0},
-    {"model":"qwen3.5-4b-4bit","load_s":5.05,"idle_gb":2.761,"peak_8k_gb":5.818,"prefill_8k_tps":313.18,"decode_short_tps":62.17,"decode_8k_tps":39.09,"swap_delta_mb":0.0},
-    {"model":"qwen3.5-9b-4bit","load_s":6.07,"idle_gb":5.262,"peak_8k_gb":8.680,"prefill_8k_tps":172.50,"decode_short_tps":36.19,"decode_8k_tps":31.80,"swap_delta_mb":0.0},
-    {"model":"gemma-4-12b-4bit","load_s":14.11,"idle_gb":7.322,"peak_8k_gb":11.0,"prefill_8k_tps":52.27,"decode_short_tps":23.39,"decode_8k_tps":22.04,"swap_delta_mb":0.0},
-    {"model":"bonsai-27b-2bit","load_s":8.07,"idle_gb":7.813,"peak_8k_gb":13.0,"prefill_8k_tps":169.52,"decode_short_tps":17.78,"decode_8k_tps":15.82,"swap_delta_mb":0.0},
-    {"model":"gemma-4-26b-4bit","serve_args":["--no-mllm","--kv-cache-dtype","bf16","--cache-memory-mb","512"],"load_s":12.12,"idle_gb":14.0,"peak_8k_gb":20.0,"prefill_8k_tps":226.94,"decode_short_tps":50.06,"decode_8k_tps":23.61,"swap_delta_mb":0.0},
-    {"model":"qwen3.5-35b-4bit","load_s":17.14,"idle_gb":19.0,"peak_8k_gb":22.0,"prefill_8k_tps":335.90,"decode_short_tps":60.26,"decode_8k_tps":50.30,"swap_delta_mb":988.8},
-    {"model":"qwen3.6-27b-4bit","load_s":13.51,"idle_gb":15.0,"peak_8k_gb":21.0,"prefill_8k_tps":48.88,"decode_short_tps":11.30,"decode_8k_tps":10.72,"swap_delta_mb":0.0}
+    {"model":"lfm2.5-1b-4bit","cache":"local","load_s":3.05,"idle_gb":0.783,"peak_8k_gb":1.872,"prefill_8k_tps":1123.22,"decode_short_tps":212.68,"decode_8k_tps":127.23,"swap_delta_mb":0.0},
+    {"model":"lfm2.5-2.6b-4bit","cache":"local","load_s":3.05,"idle_gb":1.729,"peak_8k_gb":3.029,"prefill_8k_tps":488.48,"decode_short_tps":94.46,"decode_8k_tps":65.36,"swap_delta_mb":0.0},
+    {"model":"qwen3-1.7b-4bit","cache":"jetson_smb","load_s":11.10,"idle_gb":1.307,"peak_8k_gb":5.002,"prefill_8k_tps":616.64,"decode_short_tps":133.40,"decode_8k_tps":21.23,"swap_delta_mb":0.0},
+    {"model":"lfm2.5-8b-a1b-4bit","cache":"local","load_s":5.07,"idle_gb":4.692,"peak_8k_gb":5.893,"prefill_8k_tps":634.00,"decode_short_tps":119.82,"decode_8k_tps":83.98,"swap_delta_mb":0.0},
+    {"model":"qwen3.5-4b-4bit","cache":"local","load_s":6.07,"idle_gb":2.789,"peak_8k_gb":5.856,"prefill_8k_tps":313.70,"decode_short_tps":61.78,"decode_8k_tps":41.60,"swap_delta_mb":0.0},
+    {"model":"qwen3.5-9b-4bit","cache":"local","load_s":7.08,"idle_gb":5.403,"peak_8k_gb":8.718,"prefill_8k_tps":172.69,"decode_short_tps":36.13,"decode_8k_tps":31.76,"swap_delta_mb":0.0},
+    {"model":"qwen3.5-9b-8bit","cache":"jetson_smb","load_s":75.51,"idle_gb":9.489,"peak_8k_gb":13.0,"prefill_8k_tps":173.89,"decode_short_tps":21.08,"decode_8k_tps":19.41,"swap_delta_mb":0.0},
+    {"model":"gemma-4-12b-4bit","cache":"local","load_s":6.06,"idle_gb":6.995,"peak_8k_gb":11.0,"prefill_8k_tps":52.42,"decode_short_tps":23.45,"decode_8k_tps":22.16,"swap_delta_mb":0.0},
+    {"model":"deepseek-coder-v2-lite-16b-4bit","cache":"jetson_smb","load_s":67.43,"idle_gb":8.531,"peak_8k_gb":15.0,"prefill_8k_tps":465.56,"decode_short_tps":84.33,"decode_8k_tps":11.29,"swap_delta_mb":0.0},
+    {"model":"bonsai-27b-2bit","cache":"local","load_s":8.09,"idle_gb":7.678,"peak_8k_gb":13.0,"prefill_8k_tps":169.13,"decode_short_tps":17.68,"decode_8k_tps":15.31,"swap_delta_mb":0.0},
+    {"model":"gemma-4-26b-4bit","cache":"local","serve_args":["--no-mllm","--kv-cache-dtype","bf16","--cache-memory-mb","512"],"load_s":12.11,"idle_gb":14.0,"peak_8k_gb":17.0,"prefill_8k_tps":276.77,"decode_short_tps":50.81,"decode_8k_tps":39.62,"swap_delta_mb":0.0},
+    {"model":"qwen3.5-35b-4bit","cache":"local","status":"aborted_after_short_prompt","load_s":14.13,"idle_gb":19.0,"peak_short_gb":19.0,"decode_short_tps":58.49,"swap_delta_mb":1119.8},
+    {"model":"qwen3.6-27b-4bit","cache":"local","load_s":12.13,"idle_gb":15.0,"peak_8k_gb":20.0,"prefill_8k_tps":48.90,"decode_short_tps":11.43,"decode_8k_tps":10.59,"swap_delta_mb":0.0}
   ]
 }

--- a/docs/benchmarks/model-recommendations.md
+++ b/docs/benchmarks/model-recommendations.md
@@ -17,7 +17,22 @@ python scripts/benchmark_model_recommendations.py \
   --output /tmp/model-recommendations.json
 ```
 
-It starts one cached model at a time through `rapid-mlx serve`, uses macOS
+Weights may live on a mounted model store when the test Mac is short on local
+disk. Pass the concrete Hugging Face Hub cache directory (the directory that
+contains `models--…`, not its parent):
+
+```bash
+python scripts/benchmark_model_recommendations.py qwen3-1.7b-4bit \
+  --hf-cache /Volumes/mac-storage/hf-cache \
+  --output /tmp/model-recommendations-jetson-cache.json
+```
+
+The cache path is recorded in the raw result. Network storage can affect load
+time, so only steady-state prefill/decode and post-load memory are comparable
+with local-cache runs.
+
+It starts one cached model at a time through `rapid-mlx serve`, disables the
+persisted prefix cache so a rerun cannot reuse the benchmark prompt, uses macOS
 `footprint` so Metal unified memory is counted, runs short and ~8K-token
 prompts, records `/v1/status` throughput, and stops between models. Raw reviewed
 rows live in [`model-recommendation-measurements.json`](model-recommendation-measurements.json).
@@ -25,26 +40,33 @@ rows live in [`model-recommendation-measurements.json`](model-recommendation-mea
 ## Table 1 — chip × RAM × model × engine
 
 First release sweep: Mac mini Mac14,12, Apple M2 Pro (10-core), 32 GB, macOS
-26.5.2; Rapid-MLX 0.12.5 at `1bc6244b`; MLX 0.31.2; mlx-lm 0.31.3. `Peak` is
+26.5.2; Rapid-MLX 0.12.5 at `aba2fdd1`; MLX 0.31.2; mlx-lm 0.31.3. `Peak` is
 the process-lifetime `phys_footprint_peak`. Throughput columns show short / 8K.
 
 | Model | Load | Idle | 8K peak | Prefill tok/s | Decode tok/s | New swap | Decision |
 |---|---:|---:|---:|---:|---:|---:|---|
-| `lfm2.5-1b-4bit` | 5.1s | 0.97 GB | 2.05 GB | 1,122 | 214 / 127 | 0 MB | Very fast; basic chat only |
-| `lfm2.5-2.6b-4bit` | 4.1s | 1.91 GB | 3.21 GB | 488 | 94.2 / 52.0 | 0 MB | Smarter small-model option; not for coding |
-| `lfm2.5-8b-a1b-4bit` | 7.1s | 4.87 GB | 6.07 GB | 632 | 120 / 83.5 | 0 MB | Fast chat specialist |
-| `qwen3.5-4b-4bit` | 5.1s | 2.76 GB | 5.82 GB | 313 | 62.2 / 39.1 | 0 MB | Fast general-purpose |
-| `qwen3.5-9b-4bit` | 6.1s | 5.26 GB | 8.68 GB | 172 | 36.2 / 31.8 | 0 MB | Strong laptop default |
-| `gemma-4-12b-4bit` | 14.1s | 7.32 GB | 11.0 GB | 52 | 23.4 / 22.0 | 0 MB | Fails 8K prefill gate |
-| `bonsai-27b-2bit` | 8.1s | 7.81 GB | 13.0 GB | 170 | 17.8 / 15.8 | 0 MB | Smart 24 GB candidate |
-| `gemma-4-26b-4bit`¹ | 12.1s | 14.0 GB | 20.0 GB | 227 | 50.1 / 23.6 | 0 MB | Floor at 32 GB, not 24 GB |
-| `qwen3.5-35b-4bit` | 17.1s | 19.0 GB | 22.0 GB | 336 | 60.3 / 50.3 | **989 MB** | Floor above 32 GB |
-| `qwen3.6-27b-4bit` | 13.5s | 15.0 GB | 21.0 GB | 48.9 | 11.3 / 10.7 | 0 MB | Fails 8K prefill gate |
+| `lfm2.5-1b-4bit` | 3.1s | 0.78 GB | 1.87 GB | 1,123 | 213 / 127 | 0 MB | Very fast; basic chat only |
+| `lfm2.5-2.6b-4bit` | 3.1s | 1.73 GB | 3.03 GB | 488 | 94.5 / 65.4 | 0 MB | Smarter small-model option; not for coding |
+| `qwen3-1.7b-4bit`² | 11.1s | 1.31 GB | 5.00 GB | 617 | 133 / 21.2 | 0 MB | Runs well; quality remains untested |
+| `lfm2.5-8b-a1b-4bit` | 5.1s | 4.69 GB | 5.89 GB | 634 | 120 / 84.0 | 0 MB | Fast chat specialist |
+| `qwen3.5-4b-4bit` | 6.1s | 2.79 GB | 5.86 GB | 314 | 61.8 / 41.6 | 0 MB | Fast general-purpose |
+| `qwen3.5-9b-4bit` | 7.1s | 5.40 GB | 8.72 GB | 173 | 36.1 / 31.8 | 0 MB | Strong laptop default |
+| `qwen3.5-9b-8bit`² | 75.5s | 9.49 GB | 13.0 GB | 174 | 21.1 / 19.4 | 0 MB | Fits 18 GB narrowly; slow remote load |
+| `gemma-4-12b-4bit` | 6.1s | 7.00 GB | 11.0 GB | 52 | 23.5 / 22.2 | 0 MB | Fails 8K prefill gate |
+| `deepseek-coder-v2-lite-16b-4bit`² | 67.4s | 8.53 GB | 15.0 GB | 466 | 84.3 / 11.3 | 0 MB | Coding specialist; 32 GB floor |
+| `bonsai-27b-2bit` | 8.1s | 7.68 GB | 13.0 GB | 169 | 17.7 / 15.3 | 0 MB | Smart 24 GB candidate |
+| `gemma-4-26b-4bit`¹ | 12.1s | 14.0 GB | 17.0 GB | 277 | 50.8 / 39.6 | 0 MB | Floor at 32 GB, not 24 GB |
+| `qwen3.5-35b-4bit` | 14.1s | 19.0 GB | — | — | 58.5 / — | **1,120 MB** | Aborted after short prompt; floor above 32 GB |
+| `qwen3.6-27b-4bit` | 12.1s | 15.0 GB | 20.0 GB | 48.9 | 11.4 / 10.6 | 0 MB | Fails 8K prefill gate |
 
 ¹ Text-only launch flags: `--no-mllm --kv-cache-dtype bf16 --cache-memory-mb 512`.
 
+² Weights were read directly from the Jetson-backed SMB cache. Load time is
+not comparable to local-cache rows; steady-state throughput and memory are.
+
 The 32 GB Qwen 35B swap regression is tracked in #1634. The unsafe 24 GB
-Gemma 26B floor is tracked in #1636.
+Gemma 26B floor is tracked in #1636. Prefix-cache contamination of rerun
+measurements is tracked in #1641 and prevented by the harness now.
 
 ## Table 2 — two choices per RAM tier
 

--- a/scripts/benchmark_model_recommendations.py
+++ b/scripts/benchmark_model_recommendations.py
@@ -99,12 +99,26 @@ def physical_ram_gb() -> int:
     return round(int(command("sysctl", "-n", "hw.memsize")) / GIB)
 
 
-def cached_repo_for(alias: str) -> bool:
+def huggingface_cache_dir(override: str | None = None) -> Path:
+    """Return the concrete HF Hub cache directory.
+
+    ``HF_HUB_CACHE`` is the direct cache path; ``HF_HOME`` contains a
+    ``hub`` child.  Keeping both forms straight matters when the cache is a
+    mounted NAS/Jetson volume rather than the default local disk.
+    """
+    if override:
+        return Path(override).expanduser()
+    if os.environ.get("HF_HUB_CACHE"):
+        return Path(os.environ["HF_HUB_CACHE"]).expanduser()
+    return Path(os.environ.get("HF_HOME", Path.home() / ".cache/huggingface")) / "hub"
+
+
+def cached_repo_for(alias: str, cache_dir: Path | None = None) -> bool:
     # Resolve through Rapid-MLX so aliases and HF cache directory names cannot drift.
     from vllm_mlx.model_aliases import resolve_model
 
     repo = resolve_model(alias)
-    root = Path(os.environ.get("HF_HOME", Path.home() / ".cache/huggingface")) / "hub"
+    root = cache_dir or huggingface_cache_dir()
     return (root / ("models--" + repo.replace("/", "--"))).is_dir()
 
 
@@ -160,7 +174,8 @@ def stop(proc: subprocess.Popen[str]) -> None:
 
 
 def measure(alias: str, args: argparse.Namespace, environment: dict) -> dict:
-    if not args.allow_download and not cached_repo_for(alias):
+    cache_dir = huggingface_cache_dir(args.hf_cache)
+    if not args.allow_download and not cached_repo_for(alias, cache_dir):
         return {"model": alias, "status": "skipped_not_cached"}
 
     log_path = Path(args.log_dir) / f"{alias}.log"
@@ -168,6 +183,8 @@ def measure(alias: str, args: argparse.Namespace, environment: dict) -> dict:
     swap_before = swap_used_mb()
     started = time.monotonic()
     with log_path.open("w") as log:
+        process_environment = os.environ.copy()
+        process_environment["HF_HUB_CACHE"] = str(cache_dir)
         proc = subprocess.Popen(
             [
                 sys.executable,
@@ -182,12 +199,16 @@ def measure(alias: str, args: argparse.Namespace, environment: dict) -> dict:
                 "127.0.0.1",
                 "--port",
                 str(args.port),
+                # A benchmark rerun must measure prefill, not a persisted
+                # prefix-cache hit from an earlier run of the same prompt.
+                "--disable-prefix-cache",
                 *MODEL_SERVE_ARGS.get(alias, []),
                 *args.serve_arg,
             ],
             stdout=log,
             stderr=subprocess.STDOUT,
             text=True,
+            env=process_environment,
         )
         try:
             wait_ready(proc, args.port, args.load_timeout)
@@ -274,6 +295,10 @@ def main() -> int:
     parser.add_argument("--abort-swap-mb", type=float, default=256)
     parser.add_argument("--allow-download", action="store_true")
     parser.add_argument(
+        "--hf-cache",
+        help="HF Hub cache directory (for example a mounted Jetson/NAS cache)",
+    )
+    parser.add_argument(
         "--serve-arg",
         action="append",
         default=[],
@@ -302,12 +327,14 @@ def main() -> int:
         "environment": environment,
         "method": {
             "serve_path": "python -m vllm_mlx.cli serve",
+            "prefix_cache": "disabled to prevent cross-run contamination",
             "output_tokens": args.output_tokens,
             "long_prompt": "~8K tokens (900 repeated neutral sentences)",
             "abort_ram_fraction": args.abort_ram_fraction,
             "abort_swap_mb": args.abort_swap_mb,
             "extra_serve_args": args.serve_arg,
             "per_model_serve_args": MODEL_SERVE_ARGS,
+            "hf_cache": str(huggingface_cache_dir(args.hf_cache)),
             "models_are_sequential": True,
         },
         "measurements": [],

--- a/scripts/benchmark_model_recommendations.py
+++ b/scripts/benchmark_model_recommendations.py
@@ -326,7 +326,7 @@ def main() -> int:
         "schema_version": 1,
         "environment": environment,
         "method": {
-            "serve_path": "python -m vllm_mlx.cli serve",
+            "serve_path": "python -m vllm_mlx.cli serve --disable-prefix-cache",
             "prefix_cache": "disabled to prevent cross-run contamination",
             "output_tokens": args.output_tokens,
             "long_prompt": "~8K tokens (900 repeated neutral sentences)",

--- a/tests/test_benchmark_model_recommendations.py
+++ b/tests/test_benchmark_model_recommendations.py
@@ -6,9 +6,7 @@ from scripts.benchmark_model_recommendations import huggingface_cache_dir
 def test_huggingface_cache_dir_prefers_explicit_override(monkeypatch):
     monkeypatch.setenv("HF_HUB_CACHE", "/ignored/direct")
     monkeypatch.setenv("HF_HOME", "/ignored/home")
-    assert huggingface_cache_dir("/Volumes/model-cache") == Path(
-        "/Volumes/model-cache"
-    )
+    assert huggingface_cache_dir("/Volumes/model-cache") == Path("/Volumes/model-cache")
 
 
 def test_huggingface_cache_dir_understands_direct_hub_cache(monkeypatch):

--- a/tests/test_benchmark_model_recommendations.py
+++ b/tests/test_benchmark_model_recommendations.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+
+from scripts.benchmark_model_recommendations import huggingface_cache_dir
+
+
+def test_huggingface_cache_dir_prefers_explicit_override(monkeypatch):
+    monkeypatch.setenv("HF_HUB_CACHE", "/ignored/direct")
+    monkeypatch.setenv("HF_HOME", "/ignored/home")
+    assert huggingface_cache_dir("/Volumes/model-cache") == Path(
+        "/Volumes/model-cache"
+    )
+
+
+def test_huggingface_cache_dir_understands_direct_hub_cache(monkeypatch):
+    monkeypatch.setenv("HF_HUB_CACHE", "/Volumes/jetson/hf-cache")
+    monkeypatch.setenv("HF_HOME", "/ignored/home")
+    assert huggingface_cache_dir() == Path("/Volumes/jetson/hf-cache")
+
+
+def test_huggingface_cache_dir_appends_hub_to_hf_home(monkeypatch):
+    monkeypatch.delenv("HF_HUB_CACHE", raising=False)
+    monkeypatch.setenv("HF_HOME", "/Volumes/jetson/hf-home")
+    assert huggingface_cache_dir() == Path("/Volumes/jetson/hf-home/hub")

--- a/tests/test_benchmark_model_recommendations.py
+++ b/tests/test_benchmark_model_recommendations.py
@@ -1,5 +1,7 @@
 from pathlib import Path
+from types import SimpleNamespace
 
+from scripts import benchmark_model_recommendations as benchmark
 from scripts.benchmark_model_recommendations import huggingface_cache_dir
 
 
@@ -19,3 +21,52 @@ def test_huggingface_cache_dir_appends_hub_to_hf_home(monkeypatch):
     monkeypatch.delenv("HF_HUB_CACHE", raising=False)
     monkeypatch.setenv("HF_HOME", "/Volumes/jetson/hf-home")
     assert huggingface_cache_dir() == Path("/Volumes/jetson/hf-home/hub")
+
+
+def test_measure_disables_prefix_cache_and_passes_selected_hf_cache(
+    monkeypatch, tmp_path
+):
+    launched = {}
+
+    class FakeProcess:
+        pid = 123
+
+        def poll(self):
+            return 0
+
+    def fake_popen(argv, **kwargs):
+        launched["argv"] = argv
+        launched["env"] = kwargs["env"]
+        return FakeProcess()
+
+    monkeypatch.setattr(benchmark, "cached_repo_for", lambda *_: True)
+    monkeypatch.setattr(benchmark.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(benchmark, "wait_ready", lambda *_: None)
+    monkeypatch.setattr(benchmark, "footprint", lambda *_: (1.0, 1.0))
+    monkeypatch.setattr(benchmark, "swap_used_mb", lambda: 0.0)
+    monkeypatch.setattr(
+        benchmark,
+        "run_prompt",
+        lambda *_: {
+            "server_prompt_tps": 100.0,
+            "server_generation_tps": 20.0,
+        },
+    )
+
+    args = SimpleNamespace(
+        allow_download=False,
+        hf_cache="/Volumes/jetson/hf-cache",
+        log_dir=str(tmp_path),
+        port=8010,
+        load_timeout=10,
+        abort_ram_fraction=0.8,
+        abort_swap_mb=256,
+        output_tokens=4,
+        serve_arg=[],
+        cooldown=0,
+    )
+    result = benchmark.measure("qwen3-1.7b-4bit", args, {"physical_ram_gb": 32})
+
+    assert result["status"] == "ok"
+    assert "--disable-prefix-cache" in launched["argv"]
+    assert launched["env"]["HF_HUB_CACHE"] == "/Volumes/jetson/hf-cache"


### PR DESCRIPTION
## What changed

- replace blank-looking dashed model meters with an explicit `Untested` state
- clarify that quality is published benchmark data while speed is compatible hardware measurement
- disable persisted prefix cache in the recommendation benchmark so reruns measure real prefill
- add `--hf-cache` for mounted Jetson/NAS model stores
- rerun the M2 Pro 32 GB matrix on latest main and add three Jetson-backed common models

## Why

Users read an empty meter as a zero score. Missing evidence must be visibly different from a poor result. During the requested rerun, deterministic prompts also exposed that persisted prefix-cache entries could inflate 8K prefill from ~313 tok/s to ~20,701 tok/s, making the release gate non-reproducible.

## Validation

- 24 targeted Python tests pass
- full suite: 16,293 pass; the sole failure reproduces unchanged on clean main and is filed as #1644
- production Swift build passes
- complete app bundle builds and ad-hoc signing succeeds
- clean-cache-disabled Mac mini sweep completed sequentially with no concurrent models
- AX GUI validation observed `Accuracy: untested` and `Speed: untested` in settings root, idle, and toggled states
- full settings-persistence flow then hit the unrelated post-relaunch AX failure filed as #1642

Fixes #1641.
