### PR TITLE
fix flaky GUI and telemetry regressions

### DIFF
--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-restore.answered.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-restore.answered.txt
@@ -9,7 +9,7 @@ AXApplication title="Rapid-MLX"
           AXScrollArea
             AXHeading desc="<relative-day>" enabled=true
             AXButton id="Sidebar.Conversation.Pin.<uuid>" desc="Pin conversation" help="Pin conversation" enabled=true
-            AXMenuButton id="Sidebar.Conversation.Menu.<uuid>" desc="Conversation actions" enabled=true
+            AXPopUpButton id="Sidebar.Conversation.Menu.<uuid>" desc="Conversation actions" enabled=true
             AXButton id="Sidebar.Conversation.<uuid>" desc="golden restore marker" enabled=true
         AXSplitter value=number enabled=false
         AXGroup subrole=AXHostingView
@@ -26,7 +26,7 @@ AXApplication title="Rapid-MLX"
           AXStaticText value=text enabled=true
           AXScrollArea
             AXTextArea id="rapid.chat.compose" desc="Message compose field" value=empty
-          AXMenuButton id="ModelPickerBar.ModelMenu" desc="Model" help="Choose which model to run" value=text enabled=true
+          AXPopUpButton id="ModelPickerBar.ModelMenu" desc="Model" help="Choose which model to run" value=text enabled=true
           AXButton id="ChatView.SendOrStopButton" desc="Send message" enabled=false
     AXToolbar
       AXButton desc="Hide Sidebar" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-restore.transcript-restored.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-restore.transcript-restored.txt
@@ -9,7 +9,7 @@ AXApplication title="Rapid-MLX"
           AXScrollArea
             AXHeading desc="<relative-day>" enabled=true
             AXButton id="Sidebar.Conversation.Pin.<uuid>" desc="Pin conversation" help="Pin conversation" enabled=true
-            AXMenuButton id="Sidebar.Conversation.Menu.<uuid>" desc="Conversation actions" enabled=true
+            AXPopUpButton id="Sidebar.Conversation.Menu.<uuid>" desc="Conversation actions" enabled=true
             AXButton id="Sidebar.Conversation.<uuid>" desc="golden restore marker" enabled=true
         AXSplitter value=number enabled=false
         AXGroup subrole=AXHostingView
@@ -26,7 +26,7 @@ AXApplication title="Rapid-MLX"
           AXStaticText value=text enabled=true
           AXScrollArea
             AXTextArea id="rapid.chat.compose" desc="Message compose field" value=empty
-          AXMenuButton id="ModelPickerBar.ModelMenu" desc="Model" help="Choose which model to run" value=text enabled=true
+          AXPopUpButton id="ModelPickerBar.ModelMenu" desc="Model" help="Choose which model to run" value=text enabled=true
           AXButton id="ChatView.SendOrStopButton" desc="Send message" enabled=false
     AXToolbar
       AXButton desc="Hide Sidebar" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/fresh-install.consent.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/fresh-install.consent.txt
@@ -19,7 +19,7 @@ AXApplication title="Rapid-MLX"
           AXStaticText value=text enabled=true
           AXScrollArea
             AXTextArea id="rapid.chat.compose" desc="Message compose field" value=empty
-          AXMenuButton id="ModelPickerBar.ModelMenu" desc="Model" help="Choose which model to run" value=text enabled=true
+          AXPopUpButton id="ModelPickerBar.ModelMenu" desc="Model" help="Choose which model to run" value=text enabled=true
           AXButton id="ChatView.SendOrStopButton" desc="Send message" help="Start <model> before sending." enabled=false
     AXToolbar
       AXButton desc="Hide Sidebar" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/fresh-install.steady.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/fresh-install.steady.txt
@@ -19,7 +19,7 @@ AXApplication title="Rapid-MLX"
           AXStaticText value=text enabled=true
           AXScrollArea
             AXTextArea id="rapid.chat.compose" desc="Message compose field" value=empty
-          AXMenuButton id="ModelPickerBar.ModelMenu" desc="Model" help="Choose which model to run" value=text enabled=true
+          AXPopUpButton id="ModelPickerBar.ModelMenu" desc="Model" help="Choose which model to run" value=text enabled=true
           AXButton id="ChatView.SendOrStopButton" desc="Send message" help="Start <model> before sending." enabled=false
     AXToolbar
       AXButton desc="Hide Sidebar" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/model-crash-recovery.recovered.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/model-crash-recovery.recovered.txt
@@ -9,7 +9,7 @@ AXApplication title="Rapid-MLX"
           AXScrollArea
             AXHeading desc="<relative-day>" enabled=true
             AXButton id="Sidebar.Conversation.Pin.<uuid>" desc="Pin conversation" help="Pin conversation" enabled=true
-            AXMenuButton id="Sidebar.Conversation.Menu.<uuid>" desc="Conversation actions" enabled=true
+            AXPopUpButton id="Sidebar.Conversation.Menu.<uuid>" desc="Conversation actions" enabled=true
             AXButton id="Sidebar.Conversation.<uuid>" desc="golden crash marker" enabled=true
         AXSplitter value=number enabled=false
         AXGroup subrole=AXHostingView
@@ -26,7 +26,7 @@ AXApplication title="Rapid-MLX"
           AXStaticText value=text enabled=true
           AXScrollArea
             AXTextArea id="rapid.chat.compose" desc="Message compose field" value=empty
-          AXMenuButton id="ModelPickerBar.ModelMenu" desc="Model" help="Choose which model to run" value=text enabled=true
+          AXPopUpButton id="ModelPickerBar.ModelMenu" desc="Model" help="Choose which model to run" value=text enabled=true
           AXButton id="ChatView.SendOrStopButton" desc="Send message" enabled=false
     AXToolbar
       AXButton desc="Hide Sidebar" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-after-relaunch.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-after-relaunch.txt
@@ -19,7 +19,7 @@ AXApplication title="Rapid-MLX"
           AXStaticText value=text enabled=true
           AXScrollArea
             AXTextArea id="rapid.chat.compose" desc="Message compose field" value=empty
-          AXMenuButton id="ModelPickerBar.ModelMenu" desc="Model" help="Choose which model to run" value=text enabled=true
+          AXPopUpButton id="ModelPickerBar.ModelMenu" desc="Model" help="Choose which model to run" value=text enabled=true
           AXButton id="ChatView.SendOrStopButton" desc="Send message" help="Start <model> before sending." enabled=false
     AXToolbar
       AXButton desc="Hide Sidebar" enabled=true
@@ -63,7 +63,7 @@ AXApplication title="Rapid-MLX"
         AXStaticText value=text enabled=true
         AXCheckBox subrole=AXSwitch id="Settings.Models.AutoStartOnLaunchToggle" desc="Auto-start model on launch" help="When off, opening Rapid-MLX will not load a model until you start one manually from the picker." value=bool:true enabled=true
         AXTextField id="Settings.ModelManagement.Search" value=empty enabled=true
-        AXMenuButton id="Settings.ModelManagement.SortMenu" title="Sort" enabled=true
+        AXPopUpButton id="Settings.ModelManagement.SortMenu" title="Sort" enabled=true
         AXRadioGroup id="Settings.ModelManagement.Filter" desc="Filter" enabled=true
           AXRadioButton subrole=AXSegment desc="All" value=bool:true enabled=true
           AXRadioButton subrole=AXSegment desc="Cached" value=bool:false enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-idle.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-idle.txt
@@ -19,7 +19,7 @@ AXApplication title="Rapid-MLX"
           AXStaticText value=text enabled=true
           AXScrollArea
             AXTextArea id="rapid.chat.compose" desc="Message compose field" value=empty
-          AXMenuButton id="ModelPickerBar.ModelMenu" desc="Model" help="Choose which model to run" value=text enabled=true
+          AXPopUpButton id="ModelPickerBar.ModelMenu" desc="Model" help="Choose which model to run" value=text enabled=true
           AXButton id="ChatView.SendOrStopButton" desc="Send message" help="Start <model> before sending." enabled=false
     AXToolbar
       AXButton desc="Hide Sidebar" enabled=true
@@ -63,7 +63,7 @@ AXApplication title="Rapid-MLX"
         AXStaticText value=text enabled=true
         AXCheckBox subrole=AXSwitch id="Settings.Models.AutoStartOnLaunchToggle" desc="Auto-start model on launch" help="When off, opening Rapid-MLX will not load a model until you start one manually from the picker." value=bool:true enabled=true
         AXTextField id="Settings.ModelManagement.Search" value=empty enabled=true
-        AXMenuButton id="Settings.ModelManagement.SortMenu" title="Sort" enabled=true
+        AXPopUpButton id="Settings.ModelManagement.SortMenu" title="Sort" enabled=true
         AXRadioGroup id="Settings.ModelManagement.Filter" desc="Filter" enabled=true
           AXRadioButton subrole=AXSegment desc="All" value=bool:true enabled=true
           AXRadioButton subrole=AXSegment desc="Cached" value=bool:false enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-toggled.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-toggled.txt
@@ -19,7 +19,7 @@ AXApplication title="Rapid-MLX"
           AXStaticText value=text enabled=true
           AXScrollArea
             AXTextArea id="rapid.chat.compose" desc="Message compose field" value=empty
-          AXMenuButton id="ModelPickerBar.ModelMenu" desc="Model" help="Choose which model to run" value=text enabled=true
+          AXPopUpButton id="ModelPickerBar.ModelMenu" desc="Model" help="Choose which model to run" value=text enabled=true
           AXButton id="ChatView.SendOrStopButton" desc="Send message" help="Start <model> before sending." enabled=false
     AXToolbar
       AXButton desc="Hide Sidebar" enabled=true
@@ -63,7 +63,7 @@ AXApplication title="Rapid-MLX"
         AXStaticText value=text enabled=true
         AXCheckBox subrole=AXSwitch id="Settings.Models.AutoStartOnLaunchToggle" desc="Auto-start model on launch" help="When off, opening Rapid-MLX will not load a model until you start one manually from the picker." value=bool:true enabled=true
         AXTextField id="Settings.ModelManagement.Search" value=empty enabled=true
-        AXMenuButton id="Settings.ModelManagement.SortMenu" title="Sort" enabled=true
+        AXPopUpButton id="Settings.ModelManagement.SortMenu" title="Sort" enabled=true
         AXRadioGroup id="Settings.ModelManagement.Filter" desc="Filter" enabled=true
           AXRadioButton subrole=AXSegment desc="All" value=bool:true enabled=true
           AXRadioButton subrole=AXSegment desc="Cached" value=bool:false enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.settings-root.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.settings-root.txt
@@ -19,7 +19,7 @@ AXApplication title="Rapid-MLX"
           AXStaticText value=text enabled=true
           AXScrollArea
             AXTextArea id="rapid.chat.compose" desc="Message compose field" value=empty
-          AXMenuButton id="ModelPickerBar.ModelMenu" desc="Model" help="Choose which model to run" value=text enabled=true
+          AXPopUpButton id="ModelPickerBar.ModelMenu" desc="Model" help="Choose which model to run" value=text enabled=true
           AXButton id="ChatView.SendOrStopButton" desc="Send message" help="Start <model> before sending." enabled=false
     AXToolbar
       AXButton desc="Hide Sidebar" enabled=true
@@ -63,7 +63,7 @@ AXApplication title="Rapid-MLX"
         AXStaticText value=text enabled=true
         AXCheckBox subrole=AXSwitch id="Settings.Models.AutoStartOnLaunchToggle" desc="Auto-start model on launch" help="When off, opening Rapid-MLX will not load a model until you start one manually from the picker." value=bool:true enabled=true
         AXTextField id="Settings.ModelManagement.Search" value=empty enabled=true
-        AXMenuButton id="Settings.ModelManagement.SortMenu" title="Sort" enabled=true
+        AXPopUpButton id="Settings.ModelManagement.SortMenu" title="Sort" enabled=true
         AXRadioGroup id="Settings.ModelManagement.Filter" desc="Filter" enabled=true
           AXRadioButton subrole=AXSegment desc="All" value=bool:true enabled=true
           AXRadioButton subrole=AXSegment desc="Cached" value=bool:false enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/slow-stream-stop.stopped.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/slow-stream-stop.stopped.txt
@@ -9,7 +9,7 @@ AXApplication title="Rapid-MLX"
           AXScrollArea
             AXHeading desc="<relative-day>" enabled=true
             AXButton id="Sidebar.Conversation.Pin.<uuid>" desc="Pin conversation" help="Pin conversation" enabled=true
-            AXMenuButton id="Sidebar.Conversation.Menu.<uuid>" desc="Conversation actions" enabled=true
+            AXPopUpButton id="Sidebar.Conversation.Menu.<uuid>" desc="Conversation actions" enabled=true
             AXButton id="Sidebar.Conversation.<uuid>" desc="golden stop marker" enabled=true
         AXSplitter value=number enabled=false
         AXGroup subrole=AXHostingView
@@ -26,7 +26,7 @@ AXApplication title="Rapid-MLX"
           AXStaticText value=text enabled=true
           AXScrollArea
             AXTextArea id="rapid.chat.compose" desc="Message compose field" value=empty
-          AXMenuButton id="ModelPickerBar.ModelMenu" desc="Model" help="Choose which model to run" value=text enabled=true
+          AXPopUpButton id="ModelPickerBar.ModelMenu" desc="Model" help="Choose which model to run" value=text enabled=true
           AXButton id="ChatView.SendOrStopButton" desc="Send message" enabled=false
     AXToolbar
       AXButton desc="Hide Sidebar" enabled=true

--- a/apps/rapid-mac/scripts/ax-baseline.py
+++ b/apps/rapid-mac/scripts/ax-baseline.py
@@ -136,10 +136,25 @@ _WINDOW_CONTROL_SUBROLES = frozenset(
     }
 )
 
+# AppKit exposes the same SwiftUI ``Picker`` as either role depending on the
+# macOS release. Both are the same semantic popup control, so fingerprints
+# use one stable spelling instead of treating an OS upgrade as a product diff.
+_ROLE_EQUIVALENTS = {
+    "AXMenuButton": "AXPopUpButton",
+}
+
 
 def is_window_control(record: dict) -> bool:
     """True for a traffic-light / toolbar button whose subtree is AppKit's."""
-    return record.get("subrole") in _WINDOW_CONTROL_SUBROLES
+    if record.get("subrole") in _WINDOW_CONTROL_SUBROLES:
+        return True
+    # On macOS 15.6 the system sidebar item gained a second, lazily-realized
+    # AXButton child. Keep the public button but ignore its OS-owned internals,
+    # just as we already do for traffic-light controls.
+    return record.get("role") == "AXButton" and record.get("description") in {
+        "Hide Sidebar",
+        "Show Sidebar",
+    }
 
 
 class Node:
@@ -236,7 +251,8 @@ def quote(text: str) -> str:
 
 def render_node(node: Node, extra_tokens: tuple[str, ...]) -> str:
     record = node.record
-    parts = [record.get("role", "AXUnknown")]
+    raw_role = record.get("role", "AXUnknown")
+    parts = [_ROLE_EQUIVALENTS.get(raw_role, raw_role)]
     subrole = record.get("subrole")
     if subrole:
         parts.append(f"subrole={subrole}")

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -253,6 +253,48 @@ see_settings() {
     "$AX_DRIVER" dump "$APP_PID" > "$1"
 }
 
+# AX can expose a newly opened/refocused Settings window before AppKit has
+# finished realizing every window subtree. A single immediate dump therefore
+# sometimes loses the main-window children or the category rail entirely.
+# Require the semantic anchors we care about and two identical normalized
+# trees before snapshotting or pressing from the tree.
+wait_settings_stable() {
+    local destination="$1"
+    shift
+    local candidate="$destination.candidate" previous="$destination.previous.txt"
+    local normalized="$destination.normalized.txt" stable=0
+    rm -f "$previous"
+    for _ in {1..80}; do
+        see_settings "$candidate"
+        local complete=1 identifier
+        for identifier in rapid.chat.compose Settings.Category.modelManagement "$@"; do
+            jq -e --arg id "$identifier" \
+                '.data.ui_elements[]? | select(.identifier == $id)' \
+                "$candidate" >/dev/null || { complete=0; break; }
+        done
+        if [[ "$complete" == 1 ]]; then
+            python3 "$BASELINE_TOOL" normalize "$candidate" --scrub "$FAKE_ALIAS" \
+                --output "$normalized"
+            if [[ -f "$previous" ]] && cmp -s "$previous" "$normalized"; then
+                stable=$((stable + 1))
+                if [[ "$stable" -ge 1 ]]; then
+                    mv "$candidate" "$destination"
+                    rm -f "$previous" "$normalized"
+                    return
+                fi
+            else
+                stable=0
+            fi
+            cp "$normalized" "$previous"
+        else
+            stable=0
+            rm -f "$previous"
+        fi
+        sleep 0.25
+    done
+    die "Settings AX tree did not settle with required identifiers: $*"
+}
+
 start_model() {
     wait_identifier Readiness.Action "$OUT/readiness-start.json"
     press "$OUT/readiness-start.json" Readiness.Action "$OUT/start-model.json"
@@ -388,11 +430,10 @@ flow_settings_persistence() {
     start_persona settings-persistence
     dismiss_first_run
     open_settings
-    see_settings "$OUT/settings-root.json"
+    wait_settings_stable "$OUT/settings-root.json"
     baseline settings-persistence.settings-root "$OUT/settings-root.json"
     press "$OUT/settings-root.json" Settings.Category.modelManagement "$OUT/settings-models-open.json"
-    sleep 0.3
-    see_settings "$OUT/models-before.json"
+    wait_settings_stable "$OUT/models-before.json" Settings.Models.ShowAllModelsToggle
     baseline settings-persistence.models-idle "$OUT/models-before.json"
     local preference_key="rapid.picker.show_all_models.v1"
     press "$OUT/models-before.json" Settings.Models.ShowAllModelsToggle "$OUT/models-toggle.json"
@@ -402,15 +443,14 @@ flow_settings_persistence() {
     done
     [[ "$(defaults read "$BUNDLE_ID" "$preference_key" 2>/dev/null || true)" == 1 ]] \
         || die "GUI toggle did not persist true to isolated preferences"
-    see_settings "$OUT/models-after.json"
+    wait_settings_stable "$OUT/models-after.json" Settings.Models.ShowAllModelsToggle
     baseline settings-persistence.models-toggled "$OUT/models-after.json"
     relaunch_persona
     dismiss_first_run
     open_settings
-    see_settings "$OUT/settings-relaunch.json"
+    wait_settings_stable "$OUT/settings-relaunch.json"
     press "$OUT/settings-relaunch.json" Settings.Category.modelManagement "$OUT/settings-models-reopen.json"
-    sleep 0.3
-    see_settings "$OUT/models-persisted.json"
+    wait_settings_stable "$OUT/models-persisted.json" Settings.Models.ShowAllModelsToggle
     baseline settings-persistence.models-after-relaunch "$OUT/models-persisted.json"
     press "$OUT/models-persisted.json" Settings.Models.ShowAllModelsToggle "$OUT/models-toggle-after-relaunch.json"
     for _ in {1..20}; do

--- a/tests/test_ax_baseline.py
+++ b/tests/test_ax_baseline.py
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for the macOS AX golden-flow normalizer."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "apps" / "rapid-mac" / "scripts" / "ax-baseline.py"
+
+
+@pytest.fixture(scope="module")
+def ax_baseline():
+    spec = importlib.util.spec_from_file_location("rapid_ax_baseline", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_popup_roles_are_stable_across_macos_versions(ax_baseline):
+    menu = ax_baseline.Node({"role": "AXMenuButton", "identifier": "sort"})
+    popup = ax_baseline.Node({"role": "AXPopUpButton", "identifier": "sort"})
+
+    assert ax_baseline.render_node(menu, ()) == ax_baseline.render_node(popup, ())
+    assert ax_baseline.render_node(menu, ()).startswith("AXPopUpButton ")
+
+
+@pytest.mark.parametrize("description", ["Hide Sidebar", "Show Sidebar"])
+def test_system_sidebar_button_subtree_is_ignored(ax_baseline, description):
+    button = ax_baseline.Node(
+        {"role": "AXButton", "description": description, "enabled": True}
+    )
+    button.children.append(
+        ax_baseline.Node(
+            {
+                "role": "AXButton",
+                "description": description,
+                "help": description,
+                "enabled": True,
+            }
+        )
+    )
+
+    assert ax_baseline.render(button, ()) == [
+        f'AXButton desc="{description}" enabled=true'
+    ]

--- a/tests/test_telemetry_request_wiring.py
+++ b/tests/test_telemetry_request_wiring.py
@@ -86,10 +86,15 @@ def _request(model="test-model"):
 @pytest.mark.asyncio
 async def test_nonstreaming_completion_emits_request_event(monkeypatch):
     from vllm_mlx.routes import chat
+    from vllm_mlx.telemetry import emit
 
     calls: list[dict] = []
     engine = _FakeChatEngine()
     _patch_route(monkeypatch, engine, calls)
+    # Pin the consent state this test documents. Developer machines may have
+    # telemetry opted in already, and the route intentionally computes a
+    # concrete False degeneracy signal in that state (covered below).
+    monkeypatch.setattr(emit, "is_enabled", lambda *a, **k: False)
 
     await chat._create_chat_completion_impl(
         _request(),


### PR DESCRIPTION
Closes #1642.
Closes #1644.

## What changed

- wait for two complete, identical normalized Settings AX trees before snapshotting or acting after open/relaunch
- normalize AppKit's macOS-dependent `AXMenuButton` / `AXPopUpButton` spelling and ignore only the private subtree of the OS sidebar toolbar button
- add focused normalizer regression tests and migrate committed AX snapshots to the canonical popup role
- explicitly pin telemetry-disabled state in the non-stream request wiring test

## Root cause

The GUI flow captured the application-level AX tree immediately after window transitions. AppKit can publish the window first and realize the category rail or the other window subtree later, producing deterministic-looking structural failures from an incomplete dump. macOS 15.6 also exposes the same picker and sidebar toolbar item with a different role/private subtree than the committed baseline.

The telemetry test relied on the developer machine's persisted consent default. On opted-in machines the route correctly evaluates a coherent completion as `output_degenerate=False`, while the test expected the telemetry-disabled sentinel `None`.

## Validation

- settings-persistence GUI golden flow: PASS twice against a local release build from current main
- focused Python tests: 7 passed
- full non-integration unit suite: 16,299 passed, 122 skipped, 6 xfailed; two pre-existing live-server tests failed because no server was listening on 127.0.0.1:8000
- Ruff and `git diff --check`: PASS
