### PR TITLE
fix(mac): update-state must accept the ahead-of-manifest state

### DIFF
--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -627,16 +627,45 @@ flow_update_state() {
     open_settings
     see_main "$OUT/update-settings.json"
     press "$OUT/update-settings.json" Settings.Category.app "$OUT/update-open-app.json"
-    wait_identifier Settings.App.UpToDate "$OUT/update-app-panel.json"
 
-    local shown expected
-    shown="$(element_field "$OUT/update-app-panel.json" Settings.App.UpToDate value)"
+    # TWO identifiers satisfy this invariant, and which one appears depends on
+    # something outside the app: whether a release for this version has been
+    # published yet.
+    #
+    #   Settings.App.UpToDate        — the build matches the newest published release
+    #   Settings.App.AheadOfManifest — the build is NEWER than anything published
+    #
+    # The second is not an edge case, it is the state every release passes
+    # through: the version is bumped and the app is built before its release is
+    # tagged. Waiting only for UpToDate made this flow fail during exactly the
+    # window it is meant to protect — cutting 0.12.7, with the app correctly
+    # reporting "Up to date — v0.12.7." under the other identifier.
+    #
+    # The invariant is unchanged: whichever state the panel is in, it must name
+    # the version the app actually IS.
+    local state shown expected
+    state=""
+    for _ in {1..80}; do
+        see_settings "$OUT/update-app-panel.json"
+        for candidate in Settings.App.UpToDate Settings.App.AheadOfManifest; do
+            if jq -e --arg id "$candidate" '.data.ui_elements[]? | select(.identifier == $id)' \
+                "$OUT/update-app-panel.json" >/dev/null 2>&1; then
+                state="$candidate"
+                break 2
+            fi
+        done
+        sleep 0.25
+    done
+    [[ -n "$state" ]] \
+        || die "Settings > App reported neither Settings.App.UpToDate nor Settings.App.AheadOfManifest"
+
+    shown="$(element_field "$OUT/update-app-panel.json" "$state" value)"
     expected="$(/usr/libexec/PlistBuddy -c 'Print CFBundleShortVersionString' \
         "$APP_SOURCE/Contents/Info.plist" 2>/dev/null)"
     [[ -n "$expected" ]] || die "could not read CFBundleShortVersionString"
     [[ "$shown" == *"$expected"* ]] \
-        || die "update panel says '$shown' but the app is $expected"
-    log "  update state names the running version ($expected)"
+        || die "update panel ($state) says '$shown' but the app is $expected"
+    log "  update state names the running version ($expected, via ${state##*.})"
     cleanup_persona
 }
 


### PR DESCRIPTION
Found by running the golden-flow suite during an actual release — the only time this
state occurs.

## The failure

Cutting 0.12.7, `update-state` failed:

```
[gui-golden] FAIL: timed out waiting for AX identifier Settings.App.UpToDate
```

The app was fine. Settings → App read exactly what it should:

```
Settings.App.AheadOfManifest   value="Up to date — v0.12.7."
```

## Why

The panel reports being current under **two** identifiers, and which one appears depends
on something outside the app — whether a release for this version has been published yet:

| identifier | meaning |
| --- | --- |
| `Settings.App.UpToDate` | the build matches the newest published release |
| `Settings.App.AheadOfManifest` | the build is **newer** than anything published |

The second is not an edge case. It is the state **every release passes through**: the
version is bumped and the app is built before its release is tagged. So the flow failed
during precisely the window it exists to protect, and it would have failed on every
future release the same way.

The product was right and the test was wrong.

## Fix

Accept either identifier and assert the invariant against whichever one is present. The
invariant is unchanged and just as strong: **whatever state the panel is in, the version
it names must equal `CFBundleShortVersionString`.** That is still what catches the
original bug this flow was written for — [#1612](https://github.com/raullenchai/Rapid-MLX/issues/1612),
where a stale manifest reported a version that disagreed with the bundle.

The log now names the matched state, so a future failure says whether the app believed it
was current or ahead:

```
update state names the running version (0.12.7, via AheadOfManifest)
```

## Verification

On a real 0.12.7 build against `main`, with no `rapid-mac-v0.12.7` release published:

```
[gui-golden]   update state names the running version (0.12.7, via AheadOfManifest)
[gui-golden] PASS — all
```

Full suite green (6 journeys + 3 invariants), zero baseline drift.

Worth noting what this says about the flow's value: it is the one invariant aimed at
version coherence, and it caught a genuine hole in itself on the first release where the
version actually moved. It just needed the assertion widened to the real contract rather
than the one state I happened to observe when writing it.
