### PR TITLE
fix(release): cut app + engine in one event, and stop failing silently

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -303,3 +303,46 @@ jobs:
           # Extracted to scripts/create_release.sh so the TOCTOU and recovery
           # paths are testable offline against a mock ``gh``.
           bash scripts/create_release.sh
+
+      # The engine and the desktop app are ONE version, enforced by
+      # scripts/check_version_sync.py — so a release is one event, not two.
+      # Cutting them separately is what produced the 0.12.5-vs-0.12.6 split
+      # that reached users: the engine shipped, the app tag was a manual step
+      # somebody had to remember, and for four releases nobody did.
+      #
+      # Pushing ``rapid-mac-v$VERSION`` here hands off to
+      # .github/workflows/rapid-mac-release.yml, which builds, signs, notarises
+      # and attaches the DMG. It runs only after the engine release succeeded,
+      # so a failed gate never ships a half-release.
+      - name: Tag the desktop app at the same version
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
+          VERSION: ${{ needs.detect.outputs.version }}
+          RELEASE_SHA: ${{ steps.changelog.outputs.release_sha }}
+        run: |
+          set -euo pipefail
+          APP_TAG="rapid-mac-v${VERSION}"
+
+          # The app release needs its own CHANGELOG section; rapid-mac-release.yml
+          # extracts ``## [VERSION]`` from apps/rapid-mac/CHANGELOG.md for the
+          # release body. Missing it yields an empty release rather than a loud
+          # failure, so check here where it can still be fixed cheaply.
+          if ! grep -qE "^## \[${VERSION//./\\.}\]" apps/rapid-mac/CHANGELOG.md; then
+            echo "::error::apps/rapid-mac/CHANGELOG.md has no '## [${VERSION}]' section — the app release would ship empty notes."
+            exit 1
+          fi
+
+          # Idempotent: a re-run must not fail on a tag that already exists, and
+          # must not silently move it to a different commit.
+          if EXISTING="$(git ls-remote --tags origin "refs/tags/${APP_TAG}" | awk '{print $1}')" && [[ -n "$EXISTING" ]]; then
+            if [[ "$EXISTING" == "$RELEASE_SHA" ]]; then
+              echo "${APP_TAG} already points at ${RELEASE_SHA} — nothing to do."
+              exit 0
+            fi
+            echo "::error::${APP_TAG} already exists at ${EXISTING}, but this release is ${RELEASE_SHA}. Refusing to move a published tag."
+            exit 1
+          fi
+
+          git tag "$APP_TAG" "$RELEASE_SHA"
+          git push origin "refs/tags/${APP_TAG}"
+          echo "pushed ${APP_TAG} at ${RELEASE_SHA} → rapid-mac-release.yml"

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -242,6 +242,23 @@ jobs:
           # the previous tag, not only the version-bump commit.
           fetch-depth: 0
 
+      # FIRST, because everything after it is irreversible. rapid-mac-release.yml
+      # extracts ``## [VERSION]`` from apps/rapid-mac/CHANGELOG.md for the app
+      # release body, and a missing section yields an EMPTY release rather than a
+      # loud failure. Checked after the engine had already published, this would
+      # produce exactly the half-release — engine out, app not — that tagging both
+      # from one job exists to prevent.
+      - name: Pre-check the desktop app CHANGELOG
+        env:
+          VERSION: ${{ needs.detect.outputs.version }}
+        run: |
+          set -euo pipefail
+          if ! grep -qE "^## \[${VERSION//./\\.}\]" apps/rapid-mac/CHANGELOG.md; then
+            echo "::error::apps/rapid-mac/CHANGELOG.md has no '## [${VERSION}]' section — the app release would ship empty notes. Add it and re-run; nothing has been published yet."
+            exit 1
+          fi
+          echo "apps/rapid-mac/CHANGELOG.md has a [${VERSION}] section."
+
       - name: Build release notes
         id: changelog
         env:
@@ -310,39 +327,25 @@ jobs:
       # that reached users: the engine shipped, the app tag was a manual step
       # somebody had to remember, and for four releases nobody did.
       #
-      # Pushing ``rapid-mac-v$VERSION`` here hands off to
+      # Creating ``refs/tags/rapid-mac-v$VERSION`` hands off to
       # .github/workflows/rapid-mac-release.yml, which builds, signs, notarises
       # and attaches the DMG. It runs only after the engine release succeeded,
       # so a failed gate never ships a half-release.
+      #
+      # RELEASE_PAT for the same reason as the step above: the tag is created
+      # through the API under a real user, because a ref written with the
+      # default GITHUB_TOKEN fires no ``push`` event and would leave this step
+      # green with no app build at all. Falls back to GITHUB_TOKEN so forks
+      # don't break — there the tag lands but the DMG must be cut by hand.
       - name: Tag the desktop app at the same version
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
           VERSION: ${{ needs.detect.outputs.version }}
+          # Resolved once by "Build release notes". The app is built from the
+          # same tree the engine released, so the tag must land on that commit.
           RELEASE_SHA: ${{ steps.changelog.outputs.release_sha }}
         run: |
           set -euo pipefail
-          APP_TAG="rapid-mac-v${VERSION}"
-
-          # The app release needs its own CHANGELOG section; rapid-mac-release.yml
-          # extracts ``## [VERSION]`` from apps/rapid-mac/CHANGELOG.md for the
-          # release body. Missing it yields an empty release rather than a loud
-          # failure, so check here where it can still be fixed cheaply.
-          if ! grep -qE "^## \[${VERSION//./\\.}\]" apps/rapid-mac/CHANGELOG.md; then
-            echo "::error::apps/rapid-mac/CHANGELOG.md has no '## [${VERSION}]' section — the app release would ship empty notes."
-            exit 1
-          fi
-
-          # Idempotent: a re-run must not fail on a tag that already exists, and
-          # must not silently move it to a different commit.
-          if EXISTING="$(git ls-remote --tags origin "refs/tags/${APP_TAG}" | awk '{print $1}')" && [[ -n "$EXISTING" ]]; then
-            if [[ "$EXISTING" == "$RELEASE_SHA" ]]; then
-              echo "${APP_TAG} already points at ${RELEASE_SHA} — nothing to do."
-              exit 0
-            fi
-            echo "::error::${APP_TAG} already exists at ${EXISTING}, but this release is ${RELEASE_SHA}. Refusing to move a published tag."
-            exit 1
-          fi
-
-          git tag "$APP_TAG" "$RELEASE_SHA"
-          git push origin "refs/tags/${APP_TAG}"
-          echo "pushed ${APP_TAG} at ${RELEASE_SHA} → rapid-mac-release.yml"
+          # Atomic tag claim + annotated-tag-aware recovery, extracted so both
+          # paths are testable offline against a mock ``gh``.
+          bash scripts/tag_desktop_app.sh

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -265,6 +265,17 @@ jobs:
             exit 1
           fi
           echo "apps/rapid-mac/CHANGELOG.md has a [${VERSION}] section."
+
+          # Fail HERE, before anything is published, because there is no good
+          # answer later. Skipping the app tag would leave a green run with only
+          # the engine released, and a re-run then sees the published engine
+          # Release, sets should_release=false and never reaches the app step —
+          # the version would be permanently engine-only. Failing now costs
+          # nothing: set the secret and re-run, and the whole release proceeds.
+          if [ "$HAVE_PAT" != "true" ]; then
+            echo "::error::RELEASE_PAT is not set. The app tag has to be created by a real user — a ref written with the default GITHUB_TOKEN triggers no workflow, so no DMG would ever be built for ${VERSION}. Nothing has been published yet: add the RELEASE_PAT secret and re-run this workflow."
+            exit 1
+          fi
           echo "have_pat=${HAVE_PAT}" >> "$GITHUB_OUTPUT"
 
       - name: Build release notes
@@ -344,12 +355,12 @@ jobs:
       # through the API under a real user, because a ref written with the
       # default GITHUB_TOKEN fires no ``push`` event.
       #
-      # Without the PAT this step does NOT fall back to creating the tag anyway.
-      # A GITHUB_TOKEN-authored tag is the worst of both worlds: the ref exists,
-      # so a later re-run (with the PAT restored) finds it already correct and
-      # exits green — while no build, signing, notarisation or DMG ever
-      # happened, and now never can. Refusing to create it keeps the release
-      # recoverable: fix the secret, re-run, and the tag is created for real.
+      # Its absence is already fatal in the pre-flight step above, before
+      # anything is published — a GITHUB_TOKEN-authored tag is the worst of both
+      # worlds: the ref exists, so a later re-run finds it already correct and
+      # exits green, while no build, signing, notarisation or DMG ever happened
+      # and now never can. The script re-checks anyway, so a hand-run cannot
+      # walk into it either.
       - name: Tag the desktop app at the same version
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -316,14 +316,55 @@ jobs:
           echo "--- release notes ---"
           cat "$NOTES_FILE"
 
+      # The engine and the desktop app are ONE version, enforced by
+      # scripts/check_version_sync.py — so a release is one event, not two.
+      # Cutting them separately is what produced the 0.12.5-vs-0.12.6 split that
+      # reached users: the engine shipped, the app tag was a manual step somebody
+      # had to remember, and for four releases nobody did.
+      #
+      # Creating ``refs/tags/rapid-mac-v$VERSION`` hands off to
+      # .github/workflows/rapid-mac-release.yml, which builds, signs, notarises
+      # and attaches the DMG from this same tree (its sidecar is built from repo
+      # source at the tag, so it does not wait on the engine Release or PyPI).
+      #
+      # BEFORE the engine Release, deliberately. Publishing the engine is the
+      # irreversible step: once it exists, ``detect`` sets should_release=false
+      # and no re-run can ever reach this step again. So anything that can refuse
+      # the app tag — it already exists at another commit, a ruleset rejects the
+      # namespace, a transient API failure — has to refuse while the release can
+      # still be re-run from the top. Claiming the tag first inverts the failure:
+      # the worst case is an app tag whose engine Release lands seconds later on
+      # the re-run, instead of a version that is engine-only forever.
+      #
+      # RELEASE_PAT because the tag is created through the API under a real user:
+      # a ref written with the default GITHUB_TOKEN fires no ``push`` event. Its
+      # absence is already fatal in the pre-flight step above; the script
+      # re-checks anyway, so a hand-run cannot walk into it either.
+      - name: Tag the desktop app at the same version
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
+          HAVE_PAT: ${{ steps.appcheck.outputs.have_pat }}
+          VERSION: ${{ needs.detect.outputs.version }}
+          # Resolved once by "Build release notes". The app is built from the
+          # same tree the engine releases, so the tag must land on that commit.
+          RELEASE_SHA: ${{ steps.changelog.outputs.release_sha }}
+        run: |
+          set -euo pipefail
+          # Atomic tag claim + annotated-tag-aware recovery, extracted so both
+          # paths are testable offline against a mock ``gh``.
+          bash scripts/tag_desktop_app.sh
+
       - name: Create tag and release
         env:
           # Use a user PAT (RELEASE_PAT) so the resulting ``release: published``
           # event fires downstream workflows. Releases created with the default
           # ``GITHUB_TOKEN`` are suppressed by GitHub's anti-loop guard, leaving
           # ``publish.yml`` un-triggered and the version stranded between tag and
-          # PyPI/Homebrew. Falls back to ``GITHUB_TOKEN`` if the secret is absent
-          # so forks don't break — the release just won't auto-publish.
+          # PyPI/Homebrew. The ``|| GITHUB_TOKEN`` fallback is now unreachable in
+          # practice: the pre-flight step fails the job when RELEASE_PAT is
+          # absent, because the app tag cannot be created without it and a
+          # half-released version is not recoverable. It stays as the expression
+          # default rather than as a working fork path.
           GH_TOKEN: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
           TAG: v${{ needs.detect.outputs.version }}
           # Resolved once by the step above. The notes describe exactly this
@@ -339,38 +380,3 @@ jobs:
           # Extracted to scripts/create_release.sh so the TOCTOU and recovery
           # paths are testable offline against a mock ``gh``.
           bash scripts/create_release.sh
-
-      # The engine and the desktop app are ONE version, enforced by
-      # scripts/check_version_sync.py — so a release is one event, not two.
-      # Cutting them separately is what produced the 0.12.5-vs-0.12.6 split
-      # that reached users: the engine shipped, the app tag was a manual step
-      # somebody had to remember, and for four releases nobody did.
-      #
-      # Creating ``refs/tags/rapid-mac-v$VERSION`` hands off to
-      # .github/workflows/rapid-mac-release.yml, which builds, signs, notarises
-      # and attaches the DMG. It runs only after the engine release succeeded,
-      # so a failed gate never ships a half-release.
-      #
-      # RELEASE_PAT for the same reason as the step above: the tag is created
-      # through the API under a real user, because a ref written with the
-      # default GITHUB_TOKEN fires no ``push`` event.
-      #
-      # Its absence is already fatal in the pre-flight step above, before
-      # anything is published — a GITHUB_TOKEN-authored tag is the worst of both
-      # worlds: the ref exists, so a later re-run finds it already correct and
-      # exits green, while no build, signing, notarisation or DMG ever happened
-      # and now never can. The script re-checks anyway, so a hand-run cannot
-      # walk into it either.
-      - name: Tag the desktop app at the same version
-        env:
-          GH_TOKEN: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
-          HAVE_PAT: ${{ steps.appcheck.outputs.have_pat }}
-          VERSION: ${{ needs.detect.outputs.version }}
-          # Resolved once by "Build release notes". The app is built from the
-          # same tree the engine released, so the tag must land on that commit.
-          RELEASE_SHA: ${{ steps.changelog.outputs.release_sha }}
-        run: |
-          set -euo pipefail
-          # Atomic tag claim + annotated-tag-aware recovery, extracted so both
-          # paths are testable offline against a mock ``gh``.
-          bash scripts/tag_desktop_app.sh

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -249,8 +249,15 @@ jobs:
       # produce exactly the half-release — engine out, app not — that tagging both
       # from one job exists to prevent.
       - name: Pre-check the desktop app CHANGELOG
+        id: appcheck
         env:
           VERSION: ${{ needs.detect.outputs.version }}
+          # Presence only — the value never enters the log. The app tag has to
+          # be created by a real user or the DMG workflow never fires (see the
+          # tag step below), so whether we hold a PAT decides whether this run
+          # can cut the app half at all. Deciding it HERE, before anything is
+          # published, is what makes the skip recoverable.
+          HAVE_PAT: ${{ secrets.RELEASE_PAT != '' }}
         run: |
           set -euo pipefail
           if ! grep -qE "^## \[${VERSION//./\\.}\]" apps/rapid-mac/CHANGELOG.md; then
@@ -258,6 +265,7 @@ jobs:
             exit 1
           fi
           echo "apps/rapid-mac/CHANGELOG.md has a [${VERSION}] section."
+          echo "have_pat=${HAVE_PAT}" >> "$GITHUB_OUTPUT"
 
       - name: Build release notes
         id: changelog
@@ -334,12 +342,18 @@ jobs:
       #
       # RELEASE_PAT for the same reason as the step above: the tag is created
       # through the API under a real user, because a ref written with the
-      # default GITHUB_TOKEN fires no ``push`` event and would leave this step
-      # green with no app build at all. Falls back to GITHUB_TOKEN so forks
-      # don't break — there the tag lands but the DMG must be cut by hand.
+      # default GITHUB_TOKEN fires no ``push`` event.
+      #
+      # Without the PAT this step does NOT fall back to creating the tag anyway.
+      # A GITHUB_TOKEN-authored tag is the worst of both worlds: the ref exists,
+      # so a later re-run (with the PAT restored) finds it already correct and
+      # exits green — while no build, signing, notarisation or DMG ever
+      # happened, and now never can. Refusing to create it keeps the release
+      # recoverable: fix the secret, re-run, and the tag is created for real.
       - name: Tag the desktop app at the same version
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
+          HAVE_PAT: ${{ steps.appcheck.outputs.have_pat }}
           VERSION: ${{ needs.detect.outputs.version }}
           # Resolved once by "Build release notes". The app is built from the
           # same tree the engine released, so the tag must land on that commit.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,19 @@ jobs:
       - name: Workflow expression sanity
         run: python scripts/check_workflow_expressions.py
 
+      # The release scripts cannot be exercised without cutting a release, so
+      # their tag-claim, recovery and refuse-to-move paths are covered offline
+      # against a mock ``gh``. These existed but nothing ran them, which is how
+      # a release-path regression stays invisible until release day. Pure bash,
+      # no network/gh/git.
+      - name: Release-script offline tests
+        run: |
+          set -euo pipefail
+          for t in tests/release/test_*.sh; do
+            echo "── $t"
+            bash "$t"
+          done
+
       # Parser microbench — catches >10x regressions in tool-call
       # extraction. Pure Python (parsers don't import mlx); thresholds
       # are intentionally generous (3-5x measured M3 numbers) to

--- a/apps/rapid-mac/scripts/release-local.sh
+++ b/apps/rapid-mac/scripts/release-local.sh
@@ -188,7 +188,30 @@ if [[ "$MODE" == "publish" ]]; then
     [[ "$PLIST_VERSION" == "$VERSION" ]] \
         || fail "tag $TAG (=$VERSION) != Resources/Info.plist CFBundleShortVersionString ($PLIST_VERSION). Bump the plist first."
 
-    git fetch "$RELEASE_REMOTE" --tags --quiet
+    # NOT --quiet, and NOT bare: `git fetch --tags` exits non-zero when ANY tag
+    # would clobber a local one, and `set -e` then killed this script with no
+    # output at all — the operator saw a release that simply did not happen and
+    # no reason why. That is the worst way for a release tool to fail: the
+    # natural next step is to cut the release by hand, which bypasses every
+    # check below.
+    #
+    # Here it was five legacy tags (v0.6.53/62/72/76, v0.7.2) that point at
+    # different commits in this fork than in the upstream this clone also has a
+    # remote for. They have nothing to do with the release being cut, so they
+    # must not silently block it — but they must not be force-overwritten
+    # either, because which lineage is authoritative is the operator's call.
+    if ! FETCH_ERR="$(git fetch "$RELEASE_REMOTE" --tags 2>&1)"; then
+        printf '%s\n' "$FETCH_ERR" >&2
+        CLOBBER="$(printf '%s\n' "$FETCH_ERR" | awk '/would clobber existing tag/ {print $3}' | tr '\n' ' ')"
+        if [[ -n "$CLOBBER" ]]; then
+            fail "cannot fetch tags from $RELEASE_REMOTE: these local tags disagree with it — ${CLOBBER}
+       They are unrelated to $TAG, but the fetch cannot complete while they differ.
+       Inspect one with:   git rev-parse <tag>   vs   git ls-remote $RELEASE_REMOTE refs/tags/<tag>
+       If $RELEASE_REMOTE is authoritative, drop the local copies and retry:
+           git tag -d ${CLOBBER}&& git fetch $RELEASE_REMOTE --tags"
+        fi
+        fail "cannot fetch tags from $RELEASE_REMOTE (see the git output above) — refusing to publish against a stale tag list."
+    fi
     [[ "$(git rev-parse --abbrev-ref HEAD)" == "main" ]] || fail "publish from main."
 
     # HEAD must be exactly the release remote's main — reject BOTH unpushed local commits

--- a/apps/rapid-mac/scripts/release-local.sh
+++ b/apps/rapid-mac/scripts/release-local.sh
@@ -200,7 +200,13 @@ if [[ "$MODE" == "publish" ]]; then
     # remote for. They have nothing to do with the release being cut, so they
     # must not silently block it — but they must not be force-overwritten
     # either, because which lineage is authoritative is the operator's call.
-    if ! FETCH_ERR="$(git fetch "$RELEASE_REMOTE" --tags 2>&1)"; then
+    #
+    # LC_ALL=C because the tag list below is scraped out of git's human-facing
+    # error text. Under a localised git the awk match silently finds nothing,
+    # and the operator gets the generic failure instead of the named tags and
+    # the exact command that fixes them — which is the whole point of this
+    # block.
+    if ! FETCH_ERR="$(LC_ALL=C git fetch "$RELEASE_REMOTE" --tags 2>&1)"; then
         printf '%s\n' "$FETCH_ERR" >&2
         CLOBBER="$(printf '%s\n' "$FETCH_ERR" | awk '/would clobber existing tag/ {print $3}' | tr '\n' ' ')"
         if [[ -n "$CLOBBER" ]]; then

--- a/scripts/create_release.sh
+++ b/scripts/create_release.sh
@@ -57,7 +57,11 @@ resolve_tag_commit() {
       --jq '.object | [.type, .sha] | @tsv' 2>/dev/null
   ) || return 1
   IFS=$'\t' read -r object_type object_sha <<<"$object_line"
-  for _ in 1 2 3 4 5; do
+  # Bounds the number of FOLLOWS, not the number of iterations: a bound on
+  # iterations rejects a chain whose last hop lands on a commit, having had the
+  # answer in hand. Same fix as scripts/tag_desktop_app.sh.
+  local depth=0
+  while true; do
     case "$object_type" in
       commit)
         [ -n "$object_sha" ] || return 1
@@ -65,6 +69,8 @@ resolve_tag_commit() {
         return 0
         ;;
       tag)
+        depth=$((depth + 1))
+        [ "$depth" -le 10 ] || return 1
         object_line=$(
           "$GH_BIN" api "repos/$GITHUB_REPOSITORY/git/tags/$object_sha" \
             --jq '.object | [.type, .sha] | @tsv' 2>/dev/null
@@ -74,7 +80,6 @@ resolve_tag_commit() {
       *) return 1 ;;
     esac
   done
-  return 1
 }
 
 verify_existing_release() {

--- a/scripts/tag_desktop_app.sh
+++ b/scripts/tag_desktop_app.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+#
+# Tag the desktop app at the version the engine just released.
+#
+# The engine and the app ship ONE version number (enforced on every PR by
+# scripts/check_version_sync.py), so a release is one event, not two.
+# Cutting them separately is what produced the 0.12.5-vs-0.12.6 split that
+# reached users: the engine shipped from auto-release.yml, the
+# ``rapid-mac-vX.Y.Z`` tag was a manual step somebody had to remember, and
+# for four releases nobody did.
+#
+# Creating ``refs/tags/rapid-mac-v$VERSION`` hands off to
+# .github/workflows/rapid-mac-release.yml, which builds, signs, notarises
+# and attaches the DMG.
+#
+# WHY THE API AND NOT ``git push``
+# --------------------------------
+# actions/checkout persists the default ``GITHUB_TOKEN`` as the credential
+# for ``origin``, and GitHub suppresses workflow runs caused by pushes
+# authenticated with ``GITHUB_TOKEN`` (its anti-loop guard). A ``git push``
+# of this tag would therefore succeed, the step would go green, and NO app
+# build, signing, notarisation or DMG would ever happen — the silent
+# half-release this whole change exists to prevent. Going through
+# ``gh api`` uses ``GH_TOKEN``, which the workflow sets to the RELEASE_PAT
+# user; a ref created by a real user does fire ``push``. This is the same
+# reason create_release.sh runs under the PAT.
+#
+# Idempotency is a POST, not a pre-check: ``POST /git/refs`` fails 422 when
+# the ref already exists, so the claim is atomic. Only on that failure do we
+# read the tag back — peeling annotated tag objects, because
+# ``/git/ref/tags/X`` returns the *tag object's* SHA for an annotated tag
+# and comparing that raw value to a commit SHA would report "points
+# somewhere else" for a tag that is in fact correct (four of this repo's
+# rapid-mac tags are annotated). Same tree → done. Different tree → refuse:
+# moving a published tag would ship one version's notes against another's
+# build.
+#
+# Required environment:
+#   VERSION            X.Y.Z — the version the engine just released
+#   RELEASE_SHA        the commit the engine release was cut from
+#   GITHUB_REPOSITORY  owner/repo
+#   GH_TOKEN           consumed by ``gh`` (RELEASE_PAT in the workflow)
+# Optional:
+#   GH                 path to the gh binary (tests point this at a mock)
+#
+# Exit status: 0 tag created or already correct, 1 anything else.
+
+set -euo pipefail
+
+: "${VERSION:?tag_desktop_app.sh: VERSION is required}"
+: "${RELEASE_SHA:?tag_desktop_app.sh: RELEASE_SHA is required}"
+: "${GITHUB_REPOSITORY:?tag_desktop_app.sh: GITHUB_REPOSITORY is required}"
+GH_BIN="${GH:-gh}"
+
+# The tag is built from this string, so a value the tag namespace cannot
+# carry has to fail here rather than produce ``rapid-mac-v0.12.7\n``.
+case "$VERSION" in
+  *[!0-9.]* | *..* | .* | *. | "")
+    echo "❌ VERSION is '$VERSION', which is not X.Y.Z" >&2
+    exit 1
+    ;;
+esac
+if [ "$(printf '%s' "$VERSION" | tr -cd '.' | wc -c | tr -d ' ')" != "2" ]; then
+  echo "❌ VERSION is '$VERSION', which is not X.Y.Z" >&2
+  exit 1
+fi
+
+APP_TAG="rapid-mac-v${VERSION}"
+
+resolve_tag_commit() {
+  # Start from the explicit tag namespace so a same-named branch can never
+  # satisfy verification, then peel annotated tag objects to a commit.
+  local object_line object_type object_sha
+  object_line=$(
+    "$GH_BIN" api "repos/$GITHUB_REPOSITORY/git/ref/tags/$APP_TAG" \
+      --jq '.object | [.type, .sha] | @tsv' 2>/dev/null
+  ) || return 1
+  IFS=$'\t' read -r object_type object_sha <<<"$object_line"
+  for _ in 1 2 3 4 5; do
+    case "$object_type" in
+      commit)
+        [ -n "$object_sha" ] || return 1
+        printf '%s\n' "$object_sha"
+        return 0
+        ;;
+      tag)
+        object_line=$(
+          "$GH_BIN" api "repos/$GITHUB_REPOSITORY/git/tags/$object_sha" \
+            --jq '.object | [.type, .sha] | @tsv' 2>/dev/null
+        ) || return 1
+        IFS=$'\t' read -r object_type object_sha <<<"$object_line"
+        ;;
+      *) return 1 ;;
+    esac
+  done
+  return 1
+}
+
+if "$GH_BIN" api -X POST "repos/$GITHUB_REPOSITORY/git/refs" \
+    -f "ref=refs/tags/$APP_TAG" -f "sha=$RELEASE_SHA" >/dev/null 2>&1; then
+  echo "Created $APP_TAG at $RELEASE_SHA → rapid-mac-release.yml"
+  exit 0
+fi
+
+EXISTING=$(resolve_tag_commit || true)
+if [ -z "$EXISTING" ]; then
+  echo "❌ could not create refs/tags/$APP_TAG and could not read it back — refusing to guess." >&2
+  echo "   Check the token's contents:write scope, then re-run this workflow." >&2
+  exit 1
+fi
+if [ "$EXISTING" != "$RELEASE_SHA" ]; then
+  echo "❌ $APP_TAG already exists at $EXISTING, but this release is $RELEASE_SHA." >&2
+  echo "   Refusing to move a published tag: the DMG built from $EXISTING would" >&2
+  echo "   ship under $RELEASE_SHA's release notes." >&2
+  echo "   Fix by hand: delete the stale tag, or bump to a fresh version." >&2
+  exit 1
+fi
+echo "$APP_TAG already points at $RELEASE_SHA — nothing to do."

--- a/scripts/tag_desktop_app.sh
+++ b/scripts/tag_desktop_app.sh
@@ -35,15 +35,29 @@
 # moving a published tag would ship one version's notes against another's
 # build.
 #
+# WHY A MISSING PAT SKIPS RATHER THAN FALLS BACK
+# ----------------------------------------------
+# Creating the tag under GITHUB_TOKEN would be worse than not creating it. The
+# ref would exist and this step would go green, but the run it should have
+# triggered is suppressed — and the recovery (restore the secret, re-run) then
+# finds a tag that already points at the right commit and exits 0 without
+# emitting any event. The app could never be built for that version again
+# without hand-deleting a published tag. So: no PAT, no tag, loud warning, and
+# a release that is still recoverable by re-running.
+#
 # Required environment:
 #   VERSION            X.Y.Z — the version the engine just released
 #   RELEASE_SHA        the commit the engine release was cut from
 #   GITHUB_REPOSITORY  owner/repo
 #   GH_TOKEN           consumed by ``gh`` (RELEASE_PAT in the workflow)
 # Optional:
+#   HAVE_PAT           "true" when GH_TOKEN is the RELEASE_PAT. Anything else
+#                      skips tag creation (see above). Unset = assume true, so
+#                      a hand-run of this script behaves like it reads.
 #   GH                 path to the gh binary (tests point this at a mock)
 #
-# Exit status: 0 tag created or already correct, 1 anything else.
+# Exit status: 0 tag created, already correct, or deliberately skipped;
+#              1 anything else.
 
 set -euo pipefail
 
@@ -51,6 +65,7 @@ set -euo pipefail
 : "${RELEASE_SHA:?tag_desktop_app.sh: RELEASE_SHA is required}"
 : "${GITHUB_REPOSITORY:?tag_desktop_app.sh: GITHUB_REPOSITORY is required}"
 GH_BIN="${GH:-gh}"
+HAVE_PAT="${HAVE_PAT:-true}"
 
 # The tag is built from this string, so a value the tag namespace cannot
 # carry has to fail here rather than produce ``rapid-mac-v0.12.7\n``.
@@ -67,16 +82,32 @@ fi
 
 APP_TAG="rapid-mac-v${VERSION}"
 
+if [ "$HAVE_PAT" != "true" ]; then
+  echo "::warning::RELEASE_PAT is not set, so ${APP_TAG} was NOT created — a tag written with the default GITHUB_TOKEN triggers no workflow, and its existence would then block every retry. The engine released; the app did not."
+  echo "To finish this release: set the RELEASE_PAT secret and re-run this workflow," >&2
+  echo "or cut the app half by hand from a clean checkout of ${RELEASE_SHA}:" >&2
+  echo "    apps/rapid-mac/scripts/release-local.sh --publish ${APP_TAG}" >&2
+  exit 0
+fi
+
+# Follows at most this many annotated tag objects before giving up. Ordinary
+# tags peel in one hop; the bound only exists so a malformed chain cannot spin.
+MAX_TAG_PEEL_DEPTH=10
+
 resolve_tag_commit() {
   # Start from the explicit tag namespace so a same-named branch can never
   # satisfy verification, then peel annotated tag objects to a commit.
-  local object_line object_type object_sha
+  #
+  # The loop checks the type BEFORE following, and the counter bounds the
+  # number of FOLLOWS. Bounding iterations instead would reject a chain whose
+  # last hop lands on a commit — the answer was in hand and thrown away.
+  local object_line object_type object_sha depth=0
   object_line=$(
     "$GH_BIN" api "repos/$GITHUB_REPOSITORY/git/ref/tags/$APP_TAG" \
       --jq '.object | [.type, .sha] | @tsv' 2>/dev/null
   ) || return 1
   IFS=$'\t' read -r object_type object_sha <<<"$object_line"
-  for _ in 1 2 3 4 5; do
+  while true; do
     case "$object_type" in
       commit)
         [ -n "$object_sha" ] || return 1
@@ -84,6 +115,8 @@ resolve_tag_commit() {
         return 0
         ;;
       tag)
+        depth=$((depth + 1))
+        [ "$depth" -le "$MAX_TAG_PEEL_DEPTH" ] || return 1
         object_line=$(
           "$GH_BIN" api "repos/$GITHUB_REPOSITORY/git/tags/$object_sha" \
             --jq '.object | [.type, .sha] | @tsv' 2>/dev/null
@@ -93,7 +126,6 @@ resolve_tag_commit() {
       *) return 1 ;;
     esac
   done
-  return 1
 }
 
 if "$GH_BIN" api -X POST "repos/$GITHUB_REPOSITORY/git/refs" \

--- a/scripts/tag_desktop_app.sh
+++ b/scripts/tag_desktop_app.sh
@@ -35,15 +35,20 @@
 # moving a published tag would ship one version's notes against another's
 # build.
 #
-# WHY A MISSING PAT SKIPS RATHER THAN FALLS BACK
-# ----------------------------------------------
+# WHY A MISSING PAT IS FATAL RATHER THAN A FALLBACK
+# -------------------------------------------------
 # Creating the tag under GITHUB_TOKEN would be worse than not creating it. The
 # ref would exist and this step would go green, but the run it should have
 # triggered is suppressed — and the recovery (restore the secret, re-run) then
 # finds a tag that already points at the right commit and exits 0 without
 # emitting any event. The app could never be built for that version again
-# without hand-deleting a published tag. So: no PAT, no tag, loud warning, and
-# a release that is still recoverable by re-running.
+# without hand-deleting a published tag.
+#
+# Skipping quietly is no better: the run ends green with only the engine
+# released, and a re-run sees the published engine Release, decides there is
+# nothing to release, and never reaches this step again. So this refuses to
+# run at all. In the workflow the same condition is checked BEFORE anything is
+# published, which is what makes "set the secret and re-run" an actual fix.
 #
 # Required environment:
 #   VERSION            X.Y.Z — the version the engine just released
@@ -51,13 +56,14 @@
 #   GITHUB_REPOSITORY  owner/repo
 #   GH_TOKEN           consumed by ``gh`` (RELEASE_PAT in the workflow)
 # Optional:
-#   HAVE_PAT           "true" when GH_TOKEN is the RELEASE_PAT. Anything else
-#                      skips tag creation (see above). Unset = assume true, so
-#                      a hand-run of this script behaves like it reads.
+#   HAVE_PAT           "true" when GH_TOKEN is the RELEASE_PAT. Anything else,
+#                      INCLUDING the empty string, refuses to tag (see above).
+#                      Only a genuinely unset value defaults to true, for a
+#                      hand-run — an empty one means a workflow expression
+#                      evaluated to nothing, which must not read as consent.
 #   GH                 path to the gh binary (tests point this at a mock)
 #
-# Exit status: 0 tag created, already correct, or deliberately skipped;
-#              1 anything else.
+# Exit status: 0 tag created or already correct, 1 anything else.
 
 set -euo pipefail
 
@@ -65,7 +71,7 @@ set -euo pipefail
 : "${RELEASE_SHA:?tag_desktop_app.sh: RELEASE_SHA is required}"
 : "${GITHUB_REPOSITORY:?tag_desktop_app.sh: GITHUB_REPOSITORY is required}"
 GH_BIN="${GH:-gh}"
-HAVE_PAT="${HAVE_PAT:-true}"
+HAVE_PAT="${HAVE_PAT-true}"
 
 # The tag is built from this string, so a value the tag namespace cannot
 # carry has to fail here rather than produce ``rapid-mac-v0.12.7\n``.
@@ -83,11 +89,9 @@ fi
 APP_TAG="rapid-mac-v${VERSION}"
 
 if [ "$HAVE_PAT" != "true" ]; then
-  echo "::warning::RELEASE_PAT is not set, so ${APP_TAG} was NOT created — a tag written with the default GITHUB_TOKEN triggers no workflow, and its existence would then block every retry. The engine released; the app did not."
-  echo "To finish this release: set the RELEASE_PAT secret and re-run this workflow," >&2
-  echo "or cut the app half by hand from a clean checkout of ${RELEASE_SHA}:" >&2
-  echo "    apps/rapid-mac/scripts/release-local.sh --publish ${APP_TAG}" >&2
-  exit 0
+  echo "::error::refusing to create ${APP_TAG}: RELEASE_PAT is not available, and a tag written with the default GITHUB_TOKEN triggers no workflow — no DMG would ever be built, and the tag's existence would then block every retry." >&2
+  echo "   Set the RELEASE_PAT secret and run again." >&2
+  exit 1
 fi
 
 # Follows at most this many annotated tag objects before giving up. Ordinary

--- a/tests/release/test_tag_desktop_app.sh
+++ b/tests/release/test_tag_desktop_app.sh
@@ -217,16 +217,24 @@ contains "$PREFLIGHT" 'echo "have_pat=${HAVE_PAT}" >> "$GITHUB_OUTPUT"' \
 contains "$PREFLIGHT" 'if [ "$HAVE_PAT" != "true" ]; then' \
   "pre-flight refuses before anything is published"
 
-# The CHANGELOG check has to precede the irreversible engine publication, or a
-# missing section ships the engine and then fails — the half-release this whole
-# change exists to prevent.
-CHANGELOG_LINE=$(grep -n "Pre-check the desktop app CHANGELOG" "$WORKFLOW" | head -1 | cut -d: -f1)
+# Everything that can refuse the app half has to happen BEFORE the engine
+# Release is published. Publishing is the irreversible step: once the Release
+# exists, `detect` sets should_release=false and no re-run reaches these steps
+# again, so a failure after it strands the version as engine-only forever.
 CREATE_LINE=$(grep -n "name: Create tag and release" "$WORKFLOW" | head -1 | cut -d: -f1)
-if [ -n "$CHANGELOG_LINE" ] && [ -n "$CREATE_LINE" ] && [ "$CHANGELOG_LINE" -lt "$CREATE_LINE" ]; then
-  ok "app CHANGELOG is checked before the engine release is created"
-else
-  bad "app CHANGELOG is checked before the engine release is created (changelog=$CHANGELOG_LINE create=$CREATE_LINE)"
-fi
+before_publish() {  # before_publish <step name> <label>
+  local line
+  line=$(grep -n "$1" "$WORKFLOW" | head -1 | cut -d: -f1)
+  if [ -n "$line" ] && [ -n "$CREATE_LINE" ] && [ "$line" -lt "$CREATE_LINE" ]; then
+    ok "$2"
+  else
+    bad "$2 (step=$line publish=$CREATE_LINE)"
+  fi
+}
+before_publish "Pre-check the desktop app CHANGELOG" \
+  "app CHANGELOG is checked before the engine release is published"
+before_publish "name: Tag the desktop app at the same version" \
+  "app tag is claimed before the engine release is published"
 
 echo
 echo "passed: $PASS  failed: $FAIL"

--- a/tests/release/test_tag_desktop_app.sh
+++ b/tests/release/test_tag_desktop_app.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+#
+# Offline tests for scripts/tag_desktop_app.sh.
+#
+# The real path cannot be exercised without cutting a release, so the tag
+# claim, the annotated-tag peel and the refuse-to-move branch run here
+# against a mock ``gh`` that records the exact API calls made.
+#
+#   ./tests/release/test_tag_desktop_app.sh
+#
+# Requires: bash. No network/gh/git required.
+
+set -euo pipefail
+
+REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+SCRIPT="$REPO_ROOT/scripts/tag_desktop_app.sh"
+WORKFLOW="$REPO_ROOT/.github/workflows/auto-release.yml"
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+PASS=0
+FAIL=0
+ok()  { PASS=$((PASS + 1)); printf '  \033[32mPASS\033[0m %s\n' "$1"; }
+bad() { FAIL=$((FAIL + 1)); printf '  \033[31mFAIL\033[0m %s\n' "$1"; }
+contains() { if grep -qF -- "$2" <<<"$1"; then ok "$3"; else bad "$3"; printf '        want substring: %s\n        got:            %s\n' "$2" "$1"; fi; }
+lacks()    { if grep -qF -- "$2" <<<"$1"; then bad "$3"; else ok "$3"; fi; }
+
+SHA_GOOD="1111111111111111111111111111111111111111"
+SHA_BAD="2222222222222222222222222222222222222222"
+TAG_OBJ="3333333333333333333333333333333333333333"
+
+# ``$MODE`` selects the remote state the mock simulates; every invocation is
+# appended to $TMP/calls so the test can assert on what was actually asked.
+make_mock_gh() {
+  cat > "$TMP/gh" <<'MOCK'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$CALLS"
+case "$1 $2" in
+  "api -X")  # POST repos/<r>/git/refs
+    case "$MODE" in
+      free) exit 0 ;;
+      *)    echo "HTTP 422: Reference already exists" >&2; exit 1 ;;
+    esac
+    ;;
+esac
+# read-back paths
+case "$*" in
+  *"git/ref/tags/"*)
+    case "$MODE" in
+      taken_light)      printf 'commit\t%s\n' "$READ_SHA" ;;
+      taken_annotated)  printf 'tag\t%s\n' "$TAG_OBJ" ;;
+      unreadable)       exit 1 ;;
+      *)                exit 1 ;;
+    esac
+    ;;
+  *"git/tags/"*)
+    printf 'commit\t%s\n' "$READ_SHA"
+    ;;
+esac
+MOCK
+  chmod +x "$TMP/gh"
+}
+make_mock_gh
+
+# ``${3-…}``, not ``${3:-…}``: an EMPTY VERSION is a case under test, and
+# ``:-`` would silently substitute the default for it. (No comments inside the
+# assignment chain below — a comment line ends the ``\`` continuation, which
+# silently drops every later assignment.)
+run() {  # run <MODE> <READ_SHA> [VERSION]
+  : > "$TMP/calls"
+  MODE="$1" READ_SHA="$2" TAG_OBJ="$TAG_OBJ" CALLS="$TMP/calls" \
+  GH="$TMP/gh" GITHUB_REPOSITORY="raullenchai/Rapid-MLX" \
+  VERSION="${3-0.12.8}" RELEASE_SHA="$SHA_GOOD" \
+    bash "$SCRIPT" 2>&1
+}
+
+# ==========================================================================
+echo "== 1. free tag: claimed with one atomic POST =="
+# ==========================================================================
+OUT=$(run free "" ) && RC=0 || RC=$?
+[ "${RC:-0}" -eq 0 ] && ok "exit 0 when the tag is free" || bad "exit 0 when the tag is free (got $RC)"
+contains "$OUT" "Created rapid-mac-v0.12.8 at $SHA_GOOD" "reports the tag it created"
+CALLS=$(cat "$TMP/calls")
+contains "$CALLS" "ref=refs/tags/rapid-mac-v0.12.8" "POSTs the rapid-mac-v-prefixed ref"
+contains "$CALLS" "sha=$SHA_GOOD" "POSTs the release commit"
+lacks "$CALLS" "git/ref/tags/" "does not pre-check — the POST itself is the claim"
+
+# ==========================================================================
+echo "== 2. re-run over an ANNOTATED tag at the same commit is a no-op =="
+# ==========================================================================
+# The regression this guards: /git/ref/tags/X returns the TAG OBJECT's sha for
+# an annotated tag. Comparing that raw value to the release commit reports
+# "already exists somewhere else" for a tag that is in fact correct — and four
+# of this repo's rapid-mac-v tags are annotated, so the very first re-run of
+# the release job would have failed.
+OUT=$(run taken_annotated "$SHA_GOOD") && RC=0 || RC=$?
+[ "${RC:-0}" -eq 0 ] && ok "exit 0 when an annotated tag already points at the release commit" \
+                     || bad "exit 0 when an annotated tag already points at the release commit (got $RC)"
+contains "$OUT" "already points at $SHA_GOOD" "says it is a no-op"
+contains "$(cat "$TMP/calls")" "git/tags/$TAG_OBJ" "peels the annotated tag object"
+
+# ==========================================================================
+echo "== 3. re-run over a LIGHTWEIGHT tag at the same commit is a no-op =="
+# ==========================================================================
+OUT=$(run taken_light "$SHA_GOOD") && RC=0 || RC=$?
+[ "${RC:-0}" -eq 0 ] && ok "exit 0 for a lightweight tag at the release commit" \
+                     || bad "exit 0 for a lightweight tag at the release commit (got $RC)"
+
+# ==========================================================================
+echo "== 4. a tag at a DIFFERENT commit is refused, never moved =="
+# ==========================================================================
+OUT=$(run taken_annotated "$SHA_BAD") && RC=0 || RC=$?
+[ "${RC:-0}" -ne 0 ] && ok "non-zero when the tag points elsewhere" || bad "non-zero when the tag points elsewhere"
+contains "$OUT" "already exists at $SHA_BAD" "names the commit the tag actually holds"
+lacks "$(cat "$TMP/calls")" "--force" "never force-moves a published tag"
+
+# ==========================================================================
+echo "== 5. unreadable after a failed claim fails closed =="
+# ==========================================================================
+OUT=$(run unreadable "") && RC=0 || RC=$?
+[ "${RC:-0}" -ne 0 ] && ok "non-zero when the tag can be neither created nor read" \
+                     || bad "non-zero when the tag can be neither created nor read"
+contains "$OUT" "refusing to guess" "says why it stopped"
+
+# ==========================================================================
+echo "== 6. a version the tag namespace cannot carry is rejected =="
+# ==========================================================================
+for BADV in "0.12" "0.12.8-rc1" "v0.12.8" ""; do
+  OUT=$(run free "" "$BADV") && RC=0 || RC=$?
+  [ "${RC:-0}" -ne 0 ] && ok "rejects VERSION='$BADV'" || bad "rejects VERSION='$BADV'"
+done
+
+# ==========================================================================
+echo "== 7. workflow wiring =="
+# ==========================================================================
+# The app tag MUST be created through the API under the PAT. A ``git push``
+# uses the credential actions/checkout persisted (GITHUB_TOKEN), and GitHub
+# suppresses workflow runs caused by GITHUB_TOKEN pushes — the step would go
+# green with no app build, signing, notarisation or DMG.
+APP_STEP=$(sed -n '/Tag the desktop app at the same version/,/^      - name:/p' "$WORKFLOW")
+contains "$APP_STEP" "secrets.RELEASE_PAT" "app tag step runs under the PAT"
+contains "$APP_STEP" "scripts/tag_desktop_app.sh" "app tag step calls the tested script"
+lacks "$APP_STEP" "git push" "app tag step does not git push the tag"
+
+# The CHANGELOG check has to precede the irreversible engine publication, or a
+# missing section ships the engine and then fails — the half-release this whole
+# change exists to prevent.
+CHANGELOG_LINE=$(grep -n "Pre-check the desktop app CHANGELOG" "$WORKFLOW" | head -1 | cut -d: -f1)
+CREATE_LINE=$(grep -n "name: Create tag and release" "$WORKFLOW" | head -1 | cut -d: -f1)
+if [ -n "$CHANGELOG_LINE" ] && [ -n "$CREATE_LINE" ] && [ "$CHANGELOG_LINE" -lt "$CREATE_LINE" ]; then
+  ok "app CHANGELOG is checked before the engine release is created"
+else
+  bad "app CHANGELOG is checked before the engine release is created (changelog=$CHANGELOG_LINE create=$CREATE_LINE)"
+fi
+
+echo
+echo "passed: $PASS  failed: $FAIL"
+[ "$FAIL" -eq 0 ]

--- a/tests/release/test_tag_desktop_app.sh
+++ b/tests/release/test_tag_desktop_app.sh
@@ -35,25 +35,43 @@ make_mock_gh() {
   cat > "$TMP/gh" <<'MOCK'
 #!/usr/bin/env bash
 printf '%s\n' "$*" >> "$CALLS"
-case "$1 $2" in
-  "api -X")  # POST repos/<r>/git/refs
-    case "$MODE" in
-      free) exit 0 ;;
-      *)    echo "HTTP 422: Reference already exists" >&2; exit 1 ;;
-    esac
-    ;;
-esac
+# The claim is asserted precisely — verb AND endpoint — so a rewrite that
+# POSTs somewhere else, or GETs where it should POST, fails here instead of
+# passing against a mock that accepts anything.
+if [ "$1 $2 $3" = "api -X POST" ]; then
+  [ "$4" = "repos/$GITHUB_REPOSITORY/git/refs" ] || {
+    echo "mock: claim POSTed to '$4', expected repos/$GITHUB_REPOSITORY/git/refs" >&2
+    exit 64
+  }
+  case "$MODE" in
+    free) exit 0 ;;
+    *)    echo "HTTP 422: Reference already exists" >&2; exit 1 ;;
+  esac
+fi
 # read-back paths
 case "$*" in
   *"git/ref/tags/"*)
     case "$MODE" in
       taken_light)      printf 'commit\t%s\n' "$READ_SHA" ;;
       taken_annotated)  printf 'tag\t%s\n' "$TAG_OBJ" ;;
+      # A chain of nested tag objects: each /git/tags/<sha> hop below returns
+      # another tag until the hop count runs out.
+      taken_chain)      printf 'tag\t%s\n' "$TAG_OBJ" ;;
       unreadable)       exit 1 ;;
       *)                exit 1 ;;
     esac
     ;;
   *"git/tags/"*)
+    if [ "$MODE" = "taken_chain" ]; then
+      HOPS=$(( $(cat "$TMP_HOPS" 2>/dev/null || echo 0) + 1 ))
+      printf '%s' "$HOPS" > "$TMP_HOPS"
+      if [ "$HOPS" -lt "$CHAIN_LEN" ]; then
+        printf 'tag\t%s\n' "$TAG_OBJ"
+      else
+        printf 'commit\t%s\n' "$READ_SHA"
+      fi
+      exit 0
+    fi
     printf 'commit\t%s\n' "$READ_SHA"
     ;;
 esac
@@ -68,7 +86,9 @@ make_mock_gh
 # silently drops every later assignment.)
 run() {  # run <MODE> <READ_SHA> [VERSION]
   : > "$TMP/calls"
+  : > "$TMP/hops"
   MODE="$1" READ_SHA="$2" TAG_OBJ="$TAG_OBJ" CALLS="$TMP/calls" \
+  TMP_HOPS="$TMP/hops" CHAIN_LEN="${CHAIN_LEN:-1}" HAVE_PAT="${HAVE_PAT:-true}" \
   GH="$TMP/gh" GITHUB_REPOSITORY="raullenchai/Rapid-MLX" \
   VERSION="${3-0.12.8}" RELEASE_SHA="$SHA_GOOD" \
     bash "$SCRIPT" 2>&1
@@ -131,6 +151,34 @@ for BADV in "0.12" "0.12.8-rc1" "v0.12.8" ""; do
 done
 
 # ==========================================================================
+echo "== 6b. a deep annotated-tag chain still peels to its commit =="
+# ==========================================================================
+# The bound is on FOLLOWS, not iterations. A loop bounded by iterations
+# rejects a chain whose last hop lands on a commit — it had the answer and
+# threw it away, reporting "unreadable" AFTER the engine has published.
+CHAIN_LEN=6 OUT=$(CHAIN_LEN=6 run taken_chain "$SHA_GOOD") && RC=0 || RC=$?
+[ "${RC:-0}" -eq 0 ] && ok "peels a 6-deep annotated chain to the release commit" \
+                     || bad "peels a 6-deep annotated chain to the release commit (got $RC)"
+contains "$OUT" "already points at $SHA_GOOD" "6-deep chain reads as a no-op"
+
+# ...and a chain past the bound is still refused rather than looping forever.
+OUT=$(CHAIN_LEN=99 run taken_chain "$SHA_GOOD") && RC=0 || RC=$?
+[ "${RC:-0}" -ne 0 ] && ok "refuses a chain deeper than the peel bound" \
+                     || bad "refuses a chain deeper than the peel bound"
+
+# ==========================================================================
+echo "== 6c. no PAT: refuse to create the tag at all =="
+# ==========================================================================
+# A tag written with GITHUB_TOKEN fires no workflow AND blocks every retry:
+# the re-run finds it already at the right commit and exits green, so the DMG
+# can never be built for that version without hand-deleting a published tag.
+OUT=$(HAVE_PAT=false run free "") && RC=0 || RC=$?
+[ "${RC:-0}" -eq 0 ] && ok "exit 0 — the engine release stands" || bad "exit 0 — the engine release stands (got $RC)"
+lacks "$(cat "$TMP/calls")" "git/refs" "creates NO tag when the token cannot trigger the build"
+contains "$OUT" "::warning::" "warns in the job log"
+contains "$OUT" "release-local.sh --publish rapid-mac-v0.12.8" "gives the manual command to finish the release"
+
+# ==========================================================================
 echo "== 7. workflow wiring =="
 # ==========================================================================
 # The app tag MUST be created through the API under the PAT. A ``git push``
@@ -141,6 +189,14 @@ APP_STEP=$(sed -n '/Tag the desktop app at the same version/,/^      - name:/p' 
 contains "$APP_STEP" "secrets.RELEASE_PAT" "app tag step runs under the PAT"
 contains "$APP_STEP" "scripts/tag_desktop_app.sh" "app tag step calls the tested script"
 lacks "$APP_STEP" "git push" "app tag step does not git push the tag"
+# Finding RELEASE_PAT in the env is not enough — the step falls back to
+# GITHUB_TOKEN, so it must also be TOLD whether the token it got can trigger a
+# workflow. Without this wiring the script's own guard defaults to "true" and
+# the fallback silently creates a dead tag.
+contains "$APP_STEP" "HAVE_PAT: \${{ steps.appcheck.outputs.have_pat }}" \
+  "app tag step is told whether the PAT is actually present"
+contains "$(sed -n '/Pre-check the desktop app CHANGELOG/,/Build release notes/p' "$WORKFLOW")" \
+  "have_pat=" "the pre-flight step publishes have_pat, before anything is released"
 
 # The CHANGELOG check has to precede the irreversible engine publication, or a
 # missing section ships the engine and then fails — the half-release this whole

--- a/tests/release/test_tag_desktop_app.sh
+++ b/tests/release/test_tag_desktop_app.sh
@@ -88,7 +88,7 @@ run() {  # run <MODE> <READ_SHA> [VERSION]
   : > "$TMP/calls"
   : > "$TMP/hops"
   MODE="$1" READ_SHA="$2" TAG_OBJ="$TAG_OBJ" CALLS="$TMP/calls" \
-  TMP_HOPS="$TMP/hops" CHAIN_LEN="${CHAIN_LEN:-1}" HAVE_PAT="${HAVE_PAT:-true}" \
+  TMP_HOPS="$TMP/hops" CHAIN_LEN="${CHAIN_LEN:-1}" HAVE_PAT="${HAVE_PAT-true}" \
   GH="$TMP/gh" GITHUB_REPOSITORY="raullenchai/Rapid-MLX" \
   VERSION="${3-0.12.8}" RELEASE_SHA="$SHA_GOOD" \
     bash "$SCRIPT" 2>&1
@@ -167,16 +167,25 @@ OUT=$(CHAIN_LEN=99 run taken_chain "$SHA_GOOD") && RC=0 || RC=$?
                      || bad "refuses a chain deeper than the peel bound"
 
 # ==========================================================================
-echo "== 6c. no PAT: refuse to create the tag at all =="
+echo "== 6c. no PAT: refuse to run at all =="
 # ==========================================================================
-# A tag written with GITHUB_TOKEN fires no workflow AND blocks every retry:
-# the re-run finds it already at the right commit and exits green, so the DMG
-# can never be built for that version without hand-deleting a published tag.
-OUT=$(HAVE_PAT=false run free "") && RC=0 || RC=$?
-[ "${RC:-0}" -eq 0 ] && ok "exit 0 — the engine release stands" || bad "exit 0 — the engine release stands (got $RC)"
-lacks "$(cat "$TMP/calls")" "git/refs" "creates NO tag when the token cannot trigger the build"
-contains "$OUT" "::warning::" "warns in the job log"
-contains "$OUT" "release-local.sh --publish rapid-mac-v0.12.8" "gives the manual command to finish the release"
+# A tag written with GITHUB_TOKEN fires no workflow AND blocks every retry: the
+# re-run finds it already at the right commit and exits green, so the DMG can
+# never be built for that version without hand-deleting a published tag.
+# Skipping quietly is no better — the run would end green with only the engine
+# released, and the next re-run sees the published engine Release and decides
+# there is nothing left to release. So this fails, and the workflow asks the
+# same question before anything irreversible happens.
+#
+# The EMPTY case is the one that bites in production: a workflow expression
+# that evaluates to nothing would otherwise hit the "unset means a human is
+# running this" default and recreate the dead-tag failure.
+for BAD_PAT in false ""; do
+  OUT=$(HAVE_PAT="$BAD_PAT" run free "") && RC=0 || RC=$?
+  [ "${RC:-0}" -ne 0 ] && ok "non-zero with HAVE_PAT='$BAD_PAT'" || bad "non-zero with HAVE_PAT='$BAD_PAT'"
+  lacks "$(cat "$TMP/calls")" "git/refs" "creates NO tag with HAVE_PAT='$BAD_PAT'"
+  contains "$OUT" "RELEASE_PAT is not available" "says which secret is missing (HAVE_PAT='$BAD_PAT')"
+done
 
 # ==========================================================================
 echo "== 7. workflow wiring =="
@@ -195,8 +204,18 @@ lacks "$APP_STEP" "git push" "app tag step does not git push the tag"
 # the fallback silently creates a dead tag.
 contains "$APP_STEP" "HAVE_PAT: \${{ steps.appcheck.outputs.have_pat }}" \
   "app tag step is told whether the PAT is actually present"
-contains "$(sed -n '/Pre-check the desktop app CHANGELOG/,/Build release notes/p' "$WORKFLOW")" \
-  "have_pat=" "the pre-flight step publishes have_pat, before anything is released"
+# Assert the EXACT expression and the EXACT guard. A bare "have_pat=" check
+# passed even when the published value was empty — which the script's
+# "unset means a human" default then read as consent, recreating the very
+# dead-tag failure this wiring exists to prevent. Pin what is written, not
+# that something is.
+PREFLIGHT=$(sed -n '/Pre-check the desktop app CHANGELOG/,/Build release notes/p' "$WORKFLOW")
+contains "$PREFLIGHT" "HAVE_PAT: \${{ secrets.RELEASE_PAT != '' }}" \
+  "pre-flight derives have_pat from the secret's presence"
+contains "$PREFLIGHT" 'echo "have_pat=${HAVE_PAT}" >> "$GITHUB_OUTPUT"' \
+  "pre-flight publishes that value verbatim, not a literal"
+contains "$PREFLIGHT" 'if [ "$HAVE_PAT" != "true" ]; then' \
+  "pre-flight refuses before anything is published"
 
 # The CHANGELOG check has to precede the irreversible engine publication, or a
 # missing section ships the engine and then fails — the half-release this whole


### PR DESCRIPTION
Both found while cutting 0.12.7 **by the documented path**, which is the only way they
surface.

## 1. `release-local.sh --publish` failed with no output at all

```
$ ./scripts/release-local.sh --publish rapid-mac-v0.12.7
$ echo $?
1
# ...and zero bytes on stdout AND stderr
```

`git fetch --tags --quiet` exits non-zero when **any** tag would clobber a local one.
Under `set -e` that killed the script silently.

That is the worst way for a release tool to fail. The operator sees a release that simply
did not happen and no reason why — and the natural next step is to cut it by hand, which
bypasses every check the script exists to enforce.

The actual cause here was five legacy tags — `v0.6.53`, `v0.6.62`, `v0.6.72`, `v0.6.76`,
`v0.7.2` — pointing at different commits in this fork than in the upstream this clone
also has a remote for. **Nothing to do with the release being cut.**

Now:

```
release-local: cannot fetch tags from raullenchai: these local tags disagree with it — v0.6.53
       They are unrelated to rapid-mac-v0.12.7, but the fetch cannot complete while they differ.
       Inspect one with:   git rev-parse <tag>   vs   git ls-remote raullenchai refs/tags/<tag>
       If raullenchai is authoritative, drop the local copies and retry:
           git tag -d v0.6.53 && git fetch raullenchai --tags
```

It deliberately does **not** force-overwrite them. Which lineage is authoritative is the
operator's call, not the release script's.

## 2. The app tag was a manual step somebody had to remember

The engine and the app are one version now, enforced by `scripts/check_version_sync.py`.
A release should therefore be **one event**.

Cutting them separately is precisely what produced the split that reached users: the
engine shipped automatically, the app tag was manual, and for four releases nobody did
it — leaving GitHub showing `rapid-mac-v0.12.6` while the install command said `0.12.5`,
both correct, with no single answer to "which version are you running?".

`auto-release.yml` now pushes `rapid-mac-v$VERSION` after the engine release succeeds,
handing off to `rapid-mac-release.yml` (build → sign → notarise → attach DMG).

Safety properties, because this runs unattended on a token with `contents: write`:

- **Ordered.** Runs only after the Tier-1 gate and the engine release passed, so a failed
  gate never ships half a release.
- **Idempotent.** An existing tag at the same commit is a no-op. One at a *different*
  commit is a hard error — it will not move a published tag.
- **Fails early on missing notes.** `rapid-mac-release.yml` builds the release body from
  `## [VERSION]` in `apps/rapid-mac/CHANGELOG.md`; a missing section yields an *empty
  release* rather than a failure, so this checks first, where it is still cheap to fix.

## Verification

- The new fetch failure names the offending tag, why it blocks, and the fix — verified by
  planting a conflicting tag and running it. The old path printed nothing.
- Workflow YAML parses; the `release` job's checkout already uses `fetch-depth: 0`, so
  tagging an explicit SHA resolves.
- `bash -n` clean on `release-local.sh`.

Note on what is *not* claimed: I have not exercised the new workflow step end to end — it
only runs on a real release. Its logic is guarded as above so the failure modes are loud,
but the first real proof will be the next version bump.
