### PR TITLE
Refresh M2 Pro recommendation measurements

### DIFF
--- a/docs/benchmarks/model-recommendation-measurements.json
+++ b/docs/benchmarks/model-recommendation-measurements.json
@@ -1,45 +1,175 @@
 {
   "schema_version": 1,
   "environment": {
-    "timestamp_utc": "2026-08-07T20:28:07Z",
-    "hostname": "Raullens-Mini",
-    "machine": "Mac mini",
-    "chip": "Apple M2 Pro (10-core)",
+    "timestamp_utc": "2026-08-07T22:27:20Z",
+    "hostname": "Raullens-Mini.attlocal.net",
     "chip_model": "Mac14,12",
     "physical_ram_gb": 32,
     "macos": "26.5.2",
-    "rapid_mlx": "0.12.5",
-    "git_sha": "aba2fdd11da4636b6372415f7903fc90f45ff3e8",
+    "rapid_mlx": "0.12.7",
     "mlx": "0.31.2",
     "mlx_lm": "0.31.3",
-    "mlx_vlm": "0.6.3",
-    "python": "3.12.13"
+    "git_sha": "850f62135f9c0c718aa493aea47d266443795cc9",
+    "python": "3.12.13",
+    "machine": "Mac mini",
+    "chip": "Apple M2 Pro (10-core)"
   },
   "method": {
     "serve_path": "python -m vllm_mlx.cli serve --disable-prefix-cache",
     "output_tokens": 96,
-    "long_prompt_tokens": 8110,
+    "long_prompt_tokens": 8112,
     "models_are_sequential": true,
     "max_recommended_ram_fraction": 0.75,
     "min_decode_tps": 10.0,
     "min_8k_prefill_tps": 100.0,
     "max_new_swap_mb": 0.0,
     "local_cache": "/Users/raullenmini/.cache/huggingface/hub",
-    "cold_cache": "/Volumes/mac-storage/hf-cache (Jetson over USB-C SMB; load time is not locally comparable)"
+    "cold_cache": "/Volumes/mac-storage/hf-cache (Jetson over USB-C SMB; load time is not locally comparable)",
+    "per_model_serve_args": {
+      "gemma-4-12b-4bit": [
+        "--no-mllm"
+      ],
+      "gemma-4-26b-4bit": [
+        "--no-mllm",
+        "--kv-cache-dtype",
+        "bf16",
+        "--cache-memory-mb",
+        "512"
+      ]
+    }
   },
   "measurements": [
-    {"model":"lfm2.5-1b-4bit","cache":"local","load_s":3.05,"idle_gb":0.783,"peak_8k_gb":1.872,"prefill_8k_tps":1123.22,"decode_short_tps":212.68,"decode_8k_tps":127.23,"swap_delta_mb":0.0},
-    {"model":"lfm2.5-2.6b-4bit","cache":"local","load_s":3.05,"idle_gb":1.729,"peak_8k_gb":3.029,"prefill_8k_tps":488.48,"decode_short_tps":94.46,"decode_8k_tps":65.36,"swap_delta_mb":0.0},
-    {"model":"qwen3-1.7b-4bit","cache":"jetson_smb","load_s":11.10,"idle_gb":1.307,"peak_8k_gb":5.002,"prefill_8k_tps":616.64,"decode_short_tps":133.40,"decode_8k_tps":21.23,"swap_delta_mb":0.0},
-    {"model":"lfm2.5-8b-a1b-4bit","cache":"local","load_s":5.07,"idle_gb":4.692,"peak_8k_gb":5.893,"prefill_8k_tps":634.00,"decode_short_tps":119.82,"decode_8k_tps":83.98,"swap_delta_mb":0.0},
-    {"model":"qwen3.5-4b-4bit","cache":"local","load_s":6.07,"idle_gb":2.789,"peak_8k_gb":5.856,"prefill_8k_tps":313.70,"decode_short_tps":61.78,"decode_8k_tps":41.60,"swap_delta_mb":0.0},
-    {"model":"qwen3.5-9b-4bit","cache":"local","load_s":7.08,"idle_gb":5.403,"peak_8k_gb":8.718,"prefill_8k_tps":172.69,"decode_short_tps":36.13,"decode_8k_tps":31.76,"swap_delta_mb":0.0},
-    {"model":"qwen3.5-9b-8bit","cache":"jetson_smb","load_s":75.51,"idle_gb":9.489,"peak_8k_gb":13.0,"prefill_8k_tps":173.89,"decode_short_tps":21.08,"decode_8k_tps":19.41,"swap_delta_mb":0.0},
-    {"model":"gemma-4-12b-4bit","cache":"local","load_s":6.06,"idle_gb":6.995,"peak_8k_gb":11.0,"prefill_8k_tps":52.42,"decode_short_tps":23.45,"decode_8k_tps":22.16,"swap_delta_mb":0.0},
-    {"model":"deepseek-coder-v2-lite-16b-4bit","cache":"jetson_smb","load_s":67.43,"idle_gb":8.531,"peak_8k_gb":15.0,"prefill_8k_tps":465.56,"decode_short_tps":84.33,"decode_8k_tps":11.29,"swap_delta_mb":0.0},
-    {"model":"bonsai-27b-2bit","cache":"local","load_s":8.09,"idle_gb":7.678,"peak_8k_gb":13.0,"prefill_8k_tps":169.13,"decode_short_tps":17.68,"decode_8k_tps":15.31,"swap_delta_mb":0.0},
-    {"model":"gemma-4-26b-4bit","cache":"local","serve_args":["--no-mllm","--kv-cache-dtype","bf16","--cache-memory-mb","512"],"load_s":12.11,"idle_gb":14.0,"peak_8k_gb":17.0,"prefill_8k_tps":276.77,"decode_short_tps":50.81,"decode_8k_tps":39.62,"swap_delta_mb":0.0},
-    {"model":"qwen3.5-35b-4bit","cache":"local","status":"aborted_after_short_prompt","load_s":14.13,"idle_gb":19.0,"peak_short_gb":19.0,"decode_short_tps":58.49,"swap_delta_mb":1119.8},
-    {"model":"qwen3.6-27b-4bit","cache":"local","load_s":12.13,"idle_gb":15.0,"peak_8k_gb":20.0,"prefill_8k_tps":48.90,"decode_short_tps":11.43,"decode_8k_tps":10.59,"swap_delta_mb":0.0}
+    {
+      "model": "lfm2.5-1b-4bit",
+      "cache": "local",
+      "status": "ok",
+      "load_s": 3.05,
+      "idle_gb": 0.777,
+      "peak_8k_gb": 1.866,
+      "prefill_8k_tps": 1084.13,
+      "decode_short_tps": 208.41,
+      "decode_8k_tps": 124.33,
+      "swap_delta_mb": 0.0
+    },
+    {
+      "model": "lfm2.5-2.6b-4bit",
+      "cache": "jetson_smb",
+      "status": "ok",
+      "load_s": 19.12,
+      "idle_gb": 1.73,
+      "peak_8k_gb": 3.014,
+      "prefill_8k_tps": 472.71,
+      "decode_short_tps": 93.45,
+      "decode_8k_tps": 64.95,
+      "swap_delta_mb": 0.0
+    },
+    {
+      "model": "lfm2.5-8b-a1b-4bit",
+      "cache": "jetson_smb",
+      "status": "ok",
+      "load_s": 39.19,
+      "idle_gb": 4.697,
+      "peak_8k_gb": 5.897,
+      "prefill_8k_tps": 618.31,
+      "decode_short_tps": 117.88,
+      "decode_8k_tps": 82.52,
+      "swap_delta_mb": 0.0
+    },
+    {
+      "model": "qwen3.5-4b-4bit",
+      "cache": "local",
+      "status": "ok",
+      "load_s": 6.06,
+      "idle_gb": 2.911,
+      "peak_8k_gb": 5.977,
+      "prefill_8k_tps": 303.05,
+      "decode_short_tps": 60.68,
+      "decode_8k_tps": 39.94,
+      "swap_delta_mb": 0.0
+    },
+    {
+      "model": "qwen3.5-9b-4bit",
+      "cache": "jetson_smb",
+      "status": "ok",
+      "load_s": 43.2,
+      "idle_gb": 5.403,
+      "peak_8k_gb": 8.718,
+      "prefill_8k_tps": 166.49,
+      "decode_short_tps": 35.74,
+      "decode_8k_tps": 30.51,
+      "swap_delta_mb": 0.0
+    },
+    {
+      "model": "gemma-4-12b-4bit",
+      "cache": "jetson_smb",
+      "status": "ok",
+      "load_s": 56.34,
+      "idle_gb": 7.017,
+      "peak_8k_gb": 11.0,
+      "prefill_8k_tps": 104.75,
+      "decode_short_tps": 22.27,
+      "decode_8k_tps": 19.01,
+      "swap_delta_mb": 0.0
+    },
+    {
+      "model": "bonsai-27b-2bit",
+      "cache": "jetson_smb",
+      "status": "ok",
+      "load_s": 63.28,
+      "idle_gb": 7.685,
+      "peak_8k_gb": 13.0,
+      "prefill_8k_tps": 163.87,
+      "decode_short_tps": 17.47,
+      "decode_8k_tps": 15.0,
+      "swap_delta_mb": 0.0
+    },
+    {
+      "model": "gemma-4-26b-4bit",
+      "cache": "local",
+      "status": "ok",
+      "load_s": 11.2,
+      "idle_gb": 14.0,
+      "peak_8k_gb": 17.0,
+      "prefill_8k_tps": 268.64,
+      "decode_short_tps": 49.5,
+      "decode_8k_tps": 36.9,
+      "swap_delta_mb": 0.0
+    },
+    {
+      "model": "qwen3.5-35b-4bit",
+      "cache": "local",
+      "status": "ok",
+      "load_s": 14.1,
+      "idle_gb": 19.0,
+      "peak_8k_gb": 22.0,
+      "prefill_8k_tps": 287.09,
+      "decode_short_tps": 58.53,
+      "decode_8k_tps": 21.14,
+      "swap_delta_mb": 4.4
+    },
+    {
+      "model": "qwen3.6-27b-4bit",
+      "cache": "jetson_smb",
+      "status": "ok",
+      "load_s": 119.76,
+      "idle_gb": 15.0,
+      "peak_8k_gb": 21.0,
+      "prefill_8k_tps": 46.7,
+      "decode_short_tps": 10.95,
+      "decode_8k_tps": 10.12,
+      "swap_delta_mb": 0.0
+    },
+    {
+      "model": "qwen3.6-35b-4bit",
+      "cache": "jetson_smb",
+      "status": "aborted_swap",
+      "load_s": 155.0,
+      "idle_gb": 19.0,
+      "peak_8k_gb": null,
+      "prefill_8k_tps": null,
+      "decode_short_tps": 59.86,
+      "decode_8k_tps": null,
+      "swap_delta_mb": 648.4
+    }
   ]
 }

--- a/docs/benchmarks/model-recommendations.md
+++ b/docs/benchmarks/model-recommendations.md
@@ -39,34 +39,36 @@ rows live in [`model-recommendation-measurements.json`](model-recommendation-mea
 
 ## Table 1 — chip × RAM × model × engine
 
-First release sweep: Mac mini Mac14,12, Apple M2 Pro (10-core), 32 GB, macOS
-26.5.2; Rapid-MLX 0.12.5 at `aba2fdd1`; MLX 0.31.2; mlx-lm 0.31.3. `Peak` is
+Release refresh: Mac mini Mac14,12, Apple M2 Pro (10-core), 32 GB, macOS
+26.5.2; Rapid-MLX 0.12.7 at `850f6213`; MLX 0.31.2; mlx-lm 0.31.3. `Peak` is
 the process-lifetime `phys_footprint_peak`. Throughput columns show short / 8K.
 
 | Model | Load | Idle | 8K peak | Prefill tok/s | Decode tok/s | New swap | Decision |
 |---|---:|---:|---:|---:|---:|---:|---|
-| `lfm2.5-1b-4bit` | 3.1s | 0.78 GB | 1.87 GB | 1,123 | 213 / 127 | 0 MB | Very fast; basic chat only |
-| `lfm2.5-2.6b-4bit` | 3.1s | 1.73 GB | 3.03 GB | 488 | 94.5 / 65.4 | 0 MB | Smarter small-model option; not for coding |
-| `qwen3-1.7b-4bit`² | 11.1s | 1.31 GB | 5.00 GB | 617 | 133 / 21.2 | 0 MB | Runs well; quality remains untested |
-| `lfm2.5-8b-a1b-4bit` | 5.1s | 4.69 GB | 5.89 GB | 634 | 120 / 84.0 | 0 MB | Fast chat specialist |
-| `qwen3.5-4b-4bit` | 6.1s | 2.79 GB | 5.86 GB | 314 | 61.8 / 41.6 | 0 MB | Fast general-purpose |
-| `qwen3.5-9b-4bit` | 7.1s | 5.40 GB | 8.72 GB | 173 | 36.1 / 31.8 | 0 MB | Strong laptop default |
-| `qwen3.5-9b-8bit`² | 75.5s | 9.49 GB | 13.0 GB | 174 | 21.1 / 19.4 | 0 MB | Fits 18 GB narrowly; slow remote load |
-| `gemma-4-12b-4bit` | 6.1s | 7.00 GB | 11.0 GB | 52 | 23.5 / 22.2 | 0 MB | Fails 8K prefill gate |
-| `deepseek-coder-v2-lite-16b-4bit`² | 67.4s | 8.53 GB | 15.0 GB | 466 | 84.3 / 11.3 | 0 MB | Coding specialist; 32 GB floor |
-| `bonsai-27b-2bit` | 8.1s | 7.68 GB | 13.0 GB | 169 | 17.7 / 15.3 | 0 MB | Smart 24 GB candidate |
-| `gemma-4-26b-4bit`¹ | 12.1s | 14.0 GB | 17.0 GB | 277 | 50.8 / 39.6 | 0 MB | Floor at 32 GB, not 24 GB |
-| `qwen3.5-35b-4bit` | 14.1s | 19.0 GB | — | — | 58.5 / — | **1,120 MB** | Aborted after short prompt; floor above 32 GB |
-| `qwen3.6-27b-4bit` | 12.1s | 15.0 GB | 20.0 GB | 48.9 | 11.4 / 10.6 | 0 MB | Fails 8K prefill gate |
+| `lfm2.5-1b-4bit` | 3.1s | 0.78 GB | 1.87 GB | 1,084 | 208 / 124 | 0 MB | Very fast; basic chat only |
+| `lfm2.5-2.6b-4bit`² | 19.1s | 1.73 GB | 3.01 GB | 473 | 93.5 / 65.0 | 0 MB | Smarter small-model option; not for coding |
+| `lfm2.5-8b-a1b-4bit`² | 39.2s | 4.70 GB | 5.90 GB | 618 | 118 / 82.5 | 0 MB | Fast chat specialist |
+| `qwen3.5-4b-4bit` | 6.1s | 2.91 GB | 5.98 GB | 303 | 60.7 / 39.9 | 0 MB | Fast general-purpose |
+| `qwen3.5-9b-4bit`² | 43.2s | 5.40 GB | 8.72 GB | 166 | 35.7 / 30.5 | 0 MB | Strong laptop default |
+| `gemma-4-12b-4bit`¹² | 56.3s | 7.02 GB | 11.0 GB | 105 | 22.3 / 19.0 | 0 MB | Barely clears prefill gate; 24 GB floor |
+| `bonsai-27b-2bit`² | 63.3s | 7.69 GB | 13.0 GB | 164 | 17.5 / 15.0 | 0 MB | Smart 24 GB candidate |
+| `gemma-4-26b-4bit`¹ | 11.2s | 14.0 GB | 17.0 GB | 269 | 49.5 / 36.9 | 0 MB | Floor at 32 GB, not 24 GB |
+| `qwen3.5-35b-4bit` | 14.1s | 19.0 GB | 22.0 GB | 287 | 58.5 / 21.1 | 4.4 MB | Runs at 32 GB; fails strict zero-new-swap gate |
+| `qwen3.6-27b-4bit`² | 119.8s | 15.0 GB | 21.0 GB | 46.7 | 11.0 / 10.1 | 0 MB | Fails 8K prefill gate |
+| `qwen3.6-35b-4bit`² | 155.0s | 19.0 GB | — | — | 59.9 / — | **648 MB** | Aborted after short prompt; floor above 32 GB |
 
-¹ Text-only launch flags: `--no-mllm --kv-cache-dtype bf16 --cache-memory-mb 512`.
+¹ Text-only launch flags: Gemma 12B uses `--no-mllm`; Gemma 26B uses
+`--no-mllm --kv-cache-dtype bf16 --cache-memory-mb 512`.
 
 ² Weights were read directly from the Jetson-backed SMB cache. Load time is
 not comparable to local-cache rows; steady-state throughput and memory are.
 
-The 32 GB Qwen 35B swap regression is tracked in #1634. The unsafe 24 GB
-Gemma 26B floor is tracked in #1636. Prefix-cache contamination of rerun
-measurements is tracked in #1641 and prevented by the harness now.
+The earlier Qwen 3.5 35B swap regression (#1634) is fixed on this HEAD; the
+different Qwen 3.6 35B alias still crosses the abort threshold on 32 GB
+(#1650). The unsafe 24 GB Gemma 26B floor (#1636) remains excluded. Prefix-cache
+contamination (#1641) is prevented by the harness. The Gemma 12B base-install
+launch omission found by this sweep is tracked in #1648 and covered by a
+regression test in this change.
 
 ## Table 2 — two choices per RAM tier
 
@@ -81,7 +83,7 @@ release change.
 | 16–17 GB | `lfm2.5-1b-4bit` | `qwen3.5-4b-4bit` | Instant basic chat vs reliable general use |
 | 18–23 GB | `qwen3.5-4b-4bit` | `qwen3.5-9b-4bit` | Both tool-capable and comfortably above 10 tok/s |
 | 24–31 GB | `qwen3.5-4b-4bit` | `bonsai-27b-2bit` | 13 GB measured peak; Gemma 26B is too large at 24 GB |
-| 32–47 GB | `qwen3.5-4b-4bit` | `gemma-4-26b-4bit` | 20 GB 8K peak with no new swap on the 32 GB floor |
+| 32–47 GB | `qwen3.5-4b-4bit` | `gemma-4-26b-4bit` | 17 GB 8K peak with no new swap on the 32 GB floor |
 | 48–63 GB | `qwen3.6-35b-4bit` | `gemma-4-26b-4bit` | Retains the existing reviewed fast pick pending a 48 GB host measurement |
 | 64–95 GB | `qwen3.6-35b-4bit` | `qwen3.6-35b-8bit` | Same family: speed vs quantization fidelity |
 | 96 GB+ | `qwen3.6-35b-4bit` | `qwen3.5-122b-mxfp4` | Workhorse speed vs maximum local capability |

--- a/scripts/benchmark_model_recommendations.py
+++ b/scripts/benchmark_model_recommendations.py
@@ -40,13 +40,14 @@ DEFAULT_MODELS = [
     "qwen3.6-35b-4bit",
 ]
 MODEL_SERVE_ARGS = {
+    "gemma-4-12b-4bit": ["--no-mllm"],
     "gemma-4-26b-4bit": [
         "--no-mllm",
         "--kv-cache-dtype",
         "bf16",
         "--cache-memory-mb",
         "512",
-    ]
+    ],
 }
 
 

--- a/tests/test_benchmark_model_recommendations.py
+++ b/tests/test_benchmark_model_recommendations.py
@@ -65,8 +65,9 @@ def test_measure_disables_prefix_cache_and_passes_selected_hf_cache(
         serve_arg=[],
         cooldown=0,
     )
-    result = benchmark.measure("qwen3-1.7b-4bit", args, {"physical_ram_gb": 32})
+    result = benchmark.measure("gemma-4-12b-4bit", args, {"physical_ram_gb": 32})
 
     assert result["status"] == "ok"
     assert "--disable-prefix-cache" in launched["argv"]
+    assert "--no-mllm" in launched["argv"]
     assert launched["env"]["HF_HUB_CACHE"] == "/Volumes/jetson/hf-cache"


### PR DESCRIPTION
## What changed

- refresh the release recommendation measurement table on the 32 GB M2 Pro Mac mini using Rapid-MLX 0.12.7 at `850f621`
- record eleven current candidate models, including successful full 8K runs for Qwen 3.5 35B and Gemma 12B and the Qwen 3.6 35B swap abort
- make the default Gemma 12B benchmark use the text-only loader (`--no-mllm`)
- add a regression test for the default Gemma 12B launch arguments

## Why

The prior table used Rapid-MLX 0.12.5 and incorrectly treated the fixed Qwen 3.5 35B result as still aborted. The current default harness also could not start Gemma 12B from a base install because it implicitly selected the optional multimodal loader.

Jetson-backed SMB storage was used for weights not present on the mini's internal disk. Those rows explicitly mark remote-cache load times as non-comparable; steady-state memory and throughput are measured after load through the real server path.

## Validation

- `python -m pytest -q tests/test_benchmark_model_recommendations.py` — 5 passed
- `python -m json.tool docs/benchmarks/model-recommendation-measurements.json`
- `python scripts/benchmark_model_recommendations.py --help`
- full short + ~8K server benchmark sweep on Mac mini M2 Pro 32 GB
- Gemma 12B retry after fix: 11.0 GB peak, 104.75 prompt tok/s, 19.01 decode tok/s, 0 MB new swap

Tracks #1648. The newly isolated Qwen 3.6 35B swap behavior is filed as #1650.
