### PR TITLE
Record measured model capability slots

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Resources/benchmark-scores.json
+++ b/apps/rapid-mac/Sources/Rapid/Resources/benchmark-scores.json
@@ -1,11 +1,11 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-06-30",
-  "default_speed_chip": "Apple M3 Ultra",
+  "generated_at": "2026-08-07",
+  "default_speed_chip": "per-model; see speed_source",
   "axes": {
     "general_reasoning": {
       "label_en": "General & Reasoning",
-      "label_zh": "通识和推理",
+      "label_zh": "\u901a\u8bc6\u548c\u63a8\u7406",
       "definition": "arithmetic_mean(mmlu_pro, gpqa_diamond) when both present; otherwise the single available bench",
       "thresholds": {
         "good": 50.0,
@@ -39,7 +39,7 @@
     "speed": {
       "label_en": "Speed",
       "unit": "tokens/sec",
-      "source_bench": "community-benchmarks/aggregated.json long.decode_tps.median (Apple M3 Ultra)",
+      "source_bench": "community-benchmarks M3 Ultra or release-sweep M2 Pro; see each row's speed_source",
       "thresholds": {
         "good": 80.0,
         "great": 180.0
@@ -259,7 +259,7 @@
     "qwen3-coder-30b-4bit": {
       "general_reasoning": null,
       "code": null,
-      "code_null_reason": "Qwen publishes no LiveCodeBench/HumanEval/SWE-bench pass@1 for the Coder variant; the only available number was Artificial Analysis's Coding *Index* (29.0), a normalized composite on a different scale than the pass@1 family the Code axis renders. Shown beside its bucket-mates it put our dedicated coder below every general-purpose model (#468). Honest gap per the no-fabrication / no-incomparable-substitution policy — leave null rather than display a cross-scale number.",
+      "code_null_reason": "Qwen publishes no LiveCodeBench/HumanEval/SWE-bench pass@1 for the Coder variant; the only available number was Artificial Analysis's Coding *Index* (29.0), a normalized composite on a different scale than the pass@1 family the Code axis renders. Shown beside its bucket-mates it put our dedicated coder below every general-purpose model (#468). Honest gap per the no-fabrication / no-incomparable-substitution policy \u2014 leave null rather than display a cross-scale number.",
       "tool": null,
       "tool_null_reason": "Qwen does not publish BFCL for the Coder variant",
       "ifeval": null,
@@ -278,7 +278,7 @@
       "code": 83.9,
       "code_source": "https://huggingface.co/Qwen/Qwen3.6-27B",
       "tool": null,
-      "tool_null_reason": "Qwen3.6 blog does not publish BFCL — focuses on SWE-bench + Terminal-Bench",
+      "tool_null_reason": "Qwen3.6 blog does not publish BFCL \u2014 focuses on SWE-bench + Terminal-Bench",
       "ifeval": null,
       "ifeval_null_reason": "Qwen3.6 blog does not publish IFEval",
       "speed_tps": 36.5,
@@ -401,6 +401,76 @@
       },
       "general_reasoning_source": "mean(mmlu_pro, gpqa_diamond)",
       "general_reasoning_provenance": "https://arxiv.org/abs/2511.21631 (MMLU-Pro 77.8 + GPQA-Diamond 70.4, high-confidence)"
+    },
+    "lfm2.5-1b-4bit": {
+      "general_reasoning": 45.0,
+      "general_reasoning_source": "rapid-mlx release eval mean(reasoning, general)",
+      "general_reasoning_provenance": "docs/benchmarks/model-capability-measurements.json",
+      "code": 50.0,
+      "code_source": "rapid-mlx release eval (10 HumanEval-derived tasks)",
+      "tool": 47.0,
+      "tool_source": "rapid-mlx release eval (30 tool-calling scenarios)",
+      "ifeval": null,
+      "ifeval_null_reason": "not measured by the local release eval",
+      "speed_tps": 124.33,
+      "speed_source": "Rapid-MLX 0.12.7 M2 Pro 32GB ~8K decode",
+      "local_release_eval_composite": 46.75
+    },
+    "lfm2.5-2.6b-4bit": {
+      "general_reasoning": 65.0,
+      "general_reasoning_source": "rapid-mlx release eval mean(reasoning, general)",
+      "general_reasoning_provenance": "docs/benchmarks/model-capability-measurements.json",
+      "code": 50.0,
+      "code_source": "rapid-mlx release eval (10 HumanEval-derived tasks)",
+      "tool": 77.0,
+      "tool_source": "rapid-mlx release eval (30 tool-calling scenarios)",
+      "ifeval": null,
+      "ifeval_null_reason": "not measured by the local release eval",
+      "speed_tps": 64.95,
+      "speed_source": "Rapid-MLX 0.12.7 M2 Pro 32GB ~8K decode",
+      "local_release_eval_composite": 64.25
+    },
+    "lfm2.5-8b-a1b-4bit": {
+      "general_reasoning": 60.0,
+      "general_reasoning_source": "rapid-mlx release eval mean(reasoning, general)",
+      "general_reasoning_provenance": "docs/benchmarks/model-capability-measurements.json",
+      "code": 40.0,
+      "code_source": "rapid-mlx release eval (10 HumanEval-derived tasks)",
+      "tool": 73.0,
+      "tool_source": "rapid-mlx release eval (30 tool-calling scenarios)",
+      "ifeval": null,
+      "ifeval_null_reason": "not measured by the local release eval",
+      "speed_tps": 82.52,
+      "speed_source": "Rapid-MLX 0.12.7 M2 Pro 32GB ~8K decode",
+      "local_release_eval_composite": 58.25
+    },
+    "bonsai-27b-2bit": {
+      "general_reasoning": 80.0,
+      "general_reasoning_source": "rapid-mlx release eval mean(reasoning, general)",
+      "general_reasoning_provenance": "docs/benchmarks/model-capability-measurements.json",
+      "code": 90.0,
+      "code_source": "rapid-mlx release eval (10 HumanEval-derived tasks)",
+      "tool": 93.0,
+      "tool_source": "rapid-mlx release eval (30 tool-calling scenarios)",
+      "ifeval": null,
+      "ifeval_null_reason": "not measured by the local release eval",
+      "speed_tps": 15.0,
+      "speed_source": "Rapid-MLX 0.12.7 M2 Pro 32GB ~8K decode",
+      "local_release_eval_composite": 85.75
+    },
+    "qwen3.5-35b-4bit": {
+      "general_reasoning": 70.0,
+      "general_reasoning_source": "rapid-mlx release eval mean(reasoning, general)",
+      "general_reasoning_provenance": "docs/benchmarks/model-capability-measurements.json",
+      "code": 100.0,
+      "code_source": "rapid-mlx release eval (10 HumanEval-derived tasks)",
+      "tool": 97.0,
+      "tool_source": "rapid-mlx release eval (30 tool-calling scenarios)",
+      "ifeval": null,
+      "ifeval_null_reason": "not measured by the local release eval",
+      "speed_tps": 21.14,
+      "speed_source": "Rapid-MLX 0.12.7 M2 Pro 32GB ~8K decode",
+      "local_release_eval_composite": 84.25
     }
   },
   "ground_truth_source": "data/benchmark-ground-truth.json"

--- a/apps/rapid-mac/Sources/Rapid/Server/BenchScores.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/BenchScores.swift
@@ -1,9 +1,10 @@
 import Foundation
 
-/// Industry-standard benchmark scores for a model alias, plus a
-/// locally-measured decode tok/s number. All four LLM bars sit on a
-/// 0–100 % scale; ``speedTps`` is the raw decode tok/s median from
-/// `community-benchmarks/aggregated.json` (Apple M3 Ultra).
+/// Industry-standard benchmark scores for a model alias, plus measured
+/// decode tok/s. When a model has no compatible published row, a fully
+/// recorded Rapid-MLX release eval may fill the gap; its per-row provenance
+/// names that local suite and the raw counts live under `docs/benchmarks/`.
+/// All four LLM bars sit on a 0–100 % scale.
 ///
 /// The picker hover tooltip renders five bars top → bottom:
 ///
@@ -18,11 +19,12 @@ import Foundation
 ///      comparable magnitude; per the audit's gap-honesty policy
 ///      the UI label stays version-agnostic).
 ///   4. Instruction Following — IFEval prompt-strict accuracy.
-///   5. Speed — `community-benchmarks` long-decode tok/s on
-///      Apple M3 Ultra.
+///   5. Speed — measured long-context decode tok/s; hardware is recorded in
+///      the row's provenance (community rows use M3 Ultra, the release sweep
+///      uses M2 Pro).
 ///
-/// ``nil`` on any axis means the model author did not publish the
-/// number AND it isn't on Artificial Analysis / llm-stats either.
+/// ``nil`` on any axis means neither a compatible published number nor a
+/// recorded local release eval exists for that axis.
 /// The UI must render the dashed track + em-dash value in that row.
 /// **Never** fabricate a value to fill a gap; the explicit user
 /// policy (recorded in `model-recs-audit.md` §1.5) is honest gaps
@@ -51,8 +53,7 @@ struct BenchScores: Equatable, Sendable {
     let tool: Double?
     /// IFEval prompt-strict accuracy, 0–100.
     let ifeval: Double?
-    /// Decode tok/s, raw integer-range value (typical 30–270 on
-    /// Apple M3 Ultra).
+    /// Decode tok/s; see the JSON row's `speed_source` for hardware.
     let speedTps: Double?
 
     /// Axes rendered in the tooltip, top → bottom. The order is the
@@ -109,8 +110,8 @@ struct BenchScores: Equatable, Sendable {
         }
 
         /// Footer copy describing the source bench. Drives a
-        /// "Speed measured on Apple M3 Ultra" note for the speed
-        /// axis and lets the tooltip surface BFCL version pedantry
+        /// speed methodology note and lets the tooltip surface benchmark
+        /// version pedantry
         /// once at the bottom rather than on every row.
         var sourceDescription: String {
             switch self {
@@ -118,7 +119,7 @@ struct BenchScores: Equatable, Sendable {
             case .code:             return "LiveCodeBench v6"
             case .tool:             return "BFCL v3 / v4"
             case .ifeval:           return "IFEval (prompt-strict)"
-            case .speed:            return "Community-bench long decode, Apple M3 Ultra"
+            case .speed:            return "Measured long-context decode (hardware per row)"
             }
         }
     }

--- a/apps/rapid-mac/Sources/Rapid/Server/RAMBucketedDefault.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/RAMBucketedDefault.swift
@@ -28,12 +28,12 @@ import Foundation
 ///
 /// | RAM    | 🧠 Smart            | GB   | Cap | tok/s | 🚀 Fast                          |
 /// | ------ | ------------------- | ---- | --- | ----- | -------------------------------- |
-/// |  8 GB  | lfm2.5-2.6b-4bit    |  3.2 | 62% | 94.2  | lfm2.5-1b-4bit · basic · 214.5   |
-/// | 16 GB  | qwen3.5-4b-4bit     |  5.8 | 78% | 62.2  | lfm2.5-1b-4bit · basic · 214.5   |
-/// | 18 GB  | qwen3.5-9b-4bit     |  8.7 | 82% | 36.2  | qwen3.5-4b-4bit · 78% · 62.2     |
-/// | 24 GB  | bonsai-27b-2bit     | 13.0 | 86% | 17.8  | qwen3.5-4b-4bit · 78% · 62.2     |
-/// | 32 GB  | gemma-4-26b-4bit    | 20.0 | 87% | 50.1  | qwen3.5-4b-4bit · 78% · 62.2     |
-/// | 48 GB  | gemma-4-26b-4bit    | 20.0 | 87% | 50.1  | qwen3.6-35b-4bit · 87% · 60      |
+/// |  8 GB  | lfm2.5-2.6b-4bit    |  3.0 | 64% | 93.5  | lfm2.5-1b-4bit · basic · 208.4   |
+/// | 16 GB  | qwen3.5-4b-4bit     |  6.0 | 78% | 60.7  | lfm2.5-1b-4bit · basic · 208.4   |
+/// | 18 GB  | qwen3.5-9b-4bit     |  8.7 | 82% | 35.7  | qwen3.5-4b-4bit · 78% · 60.7     |
+/// | 24 GB  | bonsai-27b-2bit     | 13.0 | 86% | 17.5  | qwen3.5-4b-4bit · 78% · 60.7     |
+/// | 32 GB  | gemma-4-26b-4bit    | 17.0 | 87% | 49.5  | qwen3.5-4b-4bit · 78% · 60.7     |
+/// | 48 GB  | gemma-4-26b-4bit    | 17.0 | 87% | 49.5  | qwen3.6-35b-4bit · 87% · 60      |
 /// | 64 GB  | qwen3.6-35b-8bit    | 37.7 | 87% | —     | qwen3.6-35b-4bit · 87% · 60      |
 /// | 96 GB+ | qwen3.5-122b-mxfp4  | 65.0 | 88% | —     | qwen3.6-35b-4bit · 87% · 60      |
 ///
@@ -95,46 +95,50 @@ enum RAMBucketedDefault {
     /// Conservative general-purpose laptop picks. Both have verified tool
     /// calling and stay within the same footprint budget enforced at launch.
     private static let qwen4Pick = Pick(
-        alias: "qwen3.5-4b-4bit", footprintGB: 5.8, capabilityPct: 78,
-        tokensPerSec: 62.2, launchFlags: [])
+        alias: "qwen3.5-4b-4bit", footprintGB: 6.0, capabilityPct: 78,
+        tokensPerSec: 60.7, launchFlags: [])
 
     private static let qwen9Pick = Pick(
         alias: "qwen3.5-9b-4bit", footprintGB: 8.7, capabilityPct: 82,
-        tokensPerSec: 36.2, launchFlags: [])
+        tokensPerSec: 35.7, launchFlags: [])
 
+    /// Latest release-eval mean: Tool 47, Code 50, Reasoning 40, General 50
+    /// = 46.75, rounded to 47. The Basic chat caveat remains user-facing.
     private static let lfm1Pick = Pick(
-        alias: "lfm2.5-1b-4bit", footprintGB: 2.1, capabilityPct: 50,
-        tokensPerSec: 214.5, launchFlags: [], caveat: "Basic chat")
+        alias: "lfm2.5-1b-4bit", footprintGB: 1.9, capabilityPct: 47,
+        tokensPerSec: 208.4, launchFlags: [], caveat: "Basic chat")
 
     /// The 8 GB tier's smarter pick: LFM2.5-2.6B, a 2.6 B dense model whose
     /// 30 layers are 22 short-convolution blocks and just 8 GQA. Those 8
     /// attention layers are why it belongs here — the KV cache costs
     /// ~16 KB/token, so a 32 K conversation adds only ~0.5 GB on top of
-    /// 1.6 GB of weights. On an M2 Pro it peaks at 3.2 GB on the standard
+    /// 1.6 GB of weights. On an M2 Pro it peaks at 3.0 GB on the standard
     /// 8K prompt, decodes at
-    /// 94.2 tok/s on the short prompt, and prefills at 488 tok/s at 8K.
+    /// 93.5 tok/s on the short prompt, and prefills at 473 tok/s at 8K.
     ///
     /// It carries a caveat rather than a capability %, and the caveat is
     /// Liquid's own: they publish this model as "not recommended for
     /// agentic coding and knowledge-heavy tasks". It is post-trained for
     /// tool use and instruction following, and on those it beats models
     /// ~4x its size — but our users drive coding agents, and putting a
-    /// bare "62%" on this card would invite exactly the use Liquid warns
+    /// bare "64%" on this card would invite exactly the use Liquid warns
     /// against. ``capabilityPct`` is never rendered for a caveat pick; the
-    /// 62 below exists only to satisfy the monotonic-by-RAM invariant and
-    /// is deliberately the same band as the other caveat pick in the
-    /// family, not an independently measured score.
+    /// 64 below is the mean of the latest local tool, coding, reasoning,
+    /// and general release-eval suites; the caveat remains more useful than
+    /// presenting that small-suite composite as a universal quality score.
     private static let lfm26Pick = Pick(
-        alias: "lfm2.5-2.6b-4bit", footprintGB: 3.2, capabilityPct: 62,
-        tokensPerSec: 94.2, launchFlags: [], caveat: "Not for coding")
+        alias: "lfm2.5-2.6b-4bit", footprintGB: 3.0, capabilityPct: 64,
+        tokensPerSec: 93.5, launchFlags: [], caveat: "Not for coding")
 
+    /// Latest release-eval mean: Tool 93, Code 90, Reasoning 70, General 90
+    /// = 85.75, rounded to 86.
     private static let bonsaiPick = Pick(
         alias: "bonsai-27b-2bit", footprintGB: 13.0, capabilityPct: 86,
-        tokensPerSec: 17.8, launchFlags: [])
+        tokensPerSec: 17.5, launchFlags: [])
 
     private static let gemma26Pick = Pick(
-        alias: "gemma-4-26b-4bit", footprintGB: 20.0, capabilityPct: 87,
-        tokensPerSec: 50.1,
+        alias: "gemma-4-26b-4bit", footprintGB: 17.0, capabilityPct: 87,
+        tokensPerSec: 49.5,
         launchFlags: ["--no-mllm", "--kv-cache-dtype", "bf16", "--cache-memory-mb", "512"])
 
     /// Existing reviewed fast/light pick for the unmeasured 48/64/96 GB tiers.

--- a/apps/rapid-mac/Tests/RapidTests/BenchScoresTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/BenchScoresTests.swift
@@ -13,7 +13,8 @@ import Testing
 ///   3. Round-trip a handful of sample alias scores so a stray edit
 ///      to the JSON (typo in a key, accidental string-vs-number) is
 ///      caught at CI time.
-///   4. Never fabricate a value to fill a gap — gaps stay ``nil``.
+///   4. Never fabricate a value to fill a gap — gaps stay ``nil`` unless a
+///      committed local release eval records the exact suite and raw counts.
 ///
 /// The five-axis order (General & Reasoning → Code → Tool →
 /// Instruction Following → Speed) is the user-signed-off spec; a
@@ -46,6 +47,30 @@ struct BenchScoresTests {
         #expect(closeEnough(s.tool, 66.1))
         #expect(closeEnough(s.ifeval, 91.5))
         #expect(closeEnough(s.speedTps, 106.4))
+    }
+
+    @Test("locally evaluated aliases fill measured slots and preserve honest gaps")
+    func localReleaseEvalRows() {
+        let lfm = BenchScoresCatalog.lookup(alias: "lfm2.5-2.6b-4bit")
+        #expect(closeEnough(lfm?.generalReasoning, 65.0))
+        #expect(closeEnough(lfm?.code, 50.0))
+        #expect(closeEnough(lfm?.tool, 77.0))
+        #expect(closeEnough(lfm?.speedTps, 64.95))
+        #expect(lfm?.ifeval == nil)
+
+        let bonsai = BenchScoresCatalog.lookup(alias: "bonsai-27b-2bit")
+        #expect(closeEnough(bonsai?.generalReasoning, 80.0))
+        #expect(closeEnough(bonsai?.code, 90.0))
+        #expect(closeEnough(bonsai?.tool, 93.0))
+        #expect(closeEnough(bonsai?.speedTps, 15.0))
+        #expect(bonsai?.ifeval == nil)
+
+        let qwen35 = BenchScoresCatalog.lookup(alias: "qwen3.5-35b-4bit")
+        #expect(closeEnough(qwen35?.generalReasoning, 70.0))
+        #expect(closeEnough(qwen35?.code, 100.0))
+        #expect(closeEnough(qwen35?.tool, 97.0))
+        #expect(closeEnough(qwen35?.speedTps, 21.14))
+        #expect(qwen35?.ifeval == nil)
     }
 
     @Test("gemma3-1b-qat-4bit bench row: fast (262 t/s), near-floor reasoning, code is an honest gap")
@@ -284,34 +309,24 @@ struct BenchScoresTests {
                 distinct.insert(pick.alias)
             }
         }
-        // Curated picks that legitimately publish NO standard benchmark —
-        // their capability / speed come from the maintainer's own eval and
-        // surface in the recommendation stats line, not the bench meters.
-        // The picker degrades gracefully for these (no bar block, no card
-        // meters), so a bench JSON row is not required.
-        // The LFM2.5 small picks are genuinely unscored — not on Artificial
-        // Analysis, no comparable published standard bench — so they belong
-        // here rather than getting fabricated rows. The anti-fabrication
-        // check below is what keeps that honest.
-        let noStandardBench: Set<String> = [
+        // These picks have no compatible published standard benchmark, but
+        // now have a committed local release-eval row with raw counts and
+        // engine/hardware provenance. They must resolve just like published
+        // rows; unmeasured axes (currently IFEval) stay nil.
+        let localReleaseEval: Set<String> = [
             "bonsai-27b-2bit", "lfm2.5-1b-4bit", "lfm2.5-8b-a1b-4bit",
             "lfm2.5-2.6b-4bit",
         ]
         let known = Set(BenchScoresCatalog.allAliases)
-        let missing = distinct.subtracting(known).subtracting(noStandardBench)
+        let missing = distinct.subtracting(known)
         #expect(
             missing.isEmpty,
             "Aliases recommended by RAMBucketedDefault but missing a bench JSON row: \(missing.sorted())"
         )
-        // Anti-fabrication: the allowlisted picks publish no standard
-        // benchmark, so they must NOT carry a bench-scores.json row —
-        // otherwise re-introducing fabricated maintainer-eval numbers
-        // into the standard-bench columns would silently pass this test.
-        let fabricated = noStandardBench.intersection(known)
-        #expect(
-            fabricated.isEmpty,
-            "Allowlisted no-standard-bench aliases must not have a bench JSON row (fabrication risk): \(fabricated.sorted())"
-        )
+        #expect(localReleaseEval.isSubset(of: known))
+        for alias in localReleaseEval {
+            #expect(BenchScoresCatalog.lookup(alias: alias)?.ifeval == nil)
+        }
     }
 }
 

--- a/apps/rapid-mac/scripts/verify-recommendation-tiers.swift
+++ b/apps/rapid-mac/scripts/verify-recommendation-tiers.swift
@@ -33,18 +33,18 @@ struct Tier: Equatable {
     let alt: Pick?
     var picks: [Pick] { alt.map { [primary, $0] } ?? [primary] }
 }
-let qwen4Pick = Pick(alias: "qwen3.5-4b-4bit", footprintGB: 5.8, capabilityPct: 78,
-                     tokensPerSec: 62.2, launchFlags: [])
+let qwen4Pick = Pick(alias: "qwen3.5-4b-4bit", footprintGB: 6.0, capabilityPct: 78,
+                     tokensPerSec: 60.7, launchFlags: [])
 let qwen9Pick = Pick(alias: "qwen3.5-9b-4bit", footprintGB: 8.7, capabilityPct: 82,
-                     tokensPerSec: 36.2, launchFlags: [])
-let lfm1Pick = Pick(alias: "lfm2.5-1b-4bit", footprintGB: 2.1, capabilityPct: 50,
-                    tokensPerSec: 214.5, launchFlags: [], caveat: "Basic chat")
-let lfm26Pick = Pick(alias: "lfm2.5-2.6b-4bit", footprintGB: 3.2, capabilityPct: 62,
-                     tokensPerSec: 94.2, launchFlags: [], caveat: "Not for coding")
+                     tokensPerSec: 35.7, launchFlags: [])
+let lfm1Pick = Pick(alias: "lfm2.5-1b-4bit", footprintGB: 1.9, capabilityPct: 47,
+                    tokensPerSec: 208.4, launchFlags: [], caveat: "Basic chat")
+let lfm26Pick = Pick(alias: "lfm2.5-2.6b-4bit", footprintGB: 3.0, capabilityPct: 64,
+                     tokensPerSec: 93.5, launchFlags: [], caveat: "Not for coding")
 let bonsaiPick = Pick(alias: "bonsai-27b-2bit", footprintGB: 13.0, capabilityPct: 86,
-                      tokensPerSec: 17.8, launchFlags: [])
-let gemma26Pick = Pick(alias: "gemma-4-26b-4bit", footprintGB: 20.0, capabilityPct: 87,
-                       tokensPerSec: 50.1,
+                      tokensPerSec: 17.5, launchFlags: [])
+let gemma26Pick = Pick(alias: "gemma-4-26b-4bit", footprintGB: 17.0, capabilityPct: 87,
+                       tokensPerSec: 49.5,
                        launchFlags: ["--no-mllm", "--kv-cache-dtype", "bf16", "--cache-memory-mb", "512"])
 let qwen35bFastPick = Pick(alias: "qwen3.6-35b-4bit", footprintGB: 20.0, capabilityPct: 87,
                            tokensPerSec: 60.0, launchFlags: [])
@@ -168,13 +168,13 @@ print("Smallest tier shows an honest capability caveat:")
 let smart8 = picks(forPhysicalRAMGB: 8)[0]
 check(picks(forPhysicalRAMGB: 8).count == 2, "8GB has smart + fast")
 check(smart8.caveat == "Not for coding", "8GB pick carries the coding caveat")
-check(pickStatsLine(smart8) == "3.2 GB · ~94 tok/s · Not for coding", "8GB stats line drops the % for the caveat")
+check(pickStatsLine(smart8) == "3.0 GB · ~94 tok/s · Not for coding", "8GB stats line drops the % for the caveat")
 check(smart8.footprintGB < 4.0, "8GB pick must leave room for macOS on an 8GB machine")
 let fast96 = picks(forPhysicalRAMGB: 96)[1]
 check(fast96.caveat == nil, "96GB fast (qwen3.6-35b-4bit) is general-purpose — no caveat")
 check(pickStatsLine(fast96) == "20.0 GB · 87% capability · ~60 tok/s", "general-purpose fast pick keeps its capability %")
 let smart16 = picks(forPhysicalRAMGB: 16)[0]
-check(pickStatsLine(smart16) == "5.8 GB · 78% capability · ~62 tok/s", "16GB qwen4 renders measured 8K peak")
+check(pickStatsLine(smart16) == "6.0 GB · 78% capability · ~61 tok/s", "16GB qwen4 renders measured 8K peak")
 let smart96 = picks(forPhysicalRAMGB: 96)[0]
 check(pickStatsLine(smart96) == "65.0 GB · 88% capability", "no-tok/s smart pick omits the speed figure")
 

--- a/docs/benchmarks/model-capability-measurements.json
+++ b/docs/benchmarks/model-capability-measurements.json
@@ -1,0 +1,175 @@
+{
+  "schema_version": 1,
+  "environment": {
+    "date": "2026-08-07",
+    "hardware": "Mac mini M2 Pro 32GB",
+    "macos": "26.5.2",
+    "rapid_mlx": "0.12.7",
+    "engine_git_sha": "850f62135f9c0c718aa493aea47d266443795cc9",
+    "mlx": "0.31.2",
+    "mlx_lm": "0.31.3"
+  },
+  "method": {
+    "runner": "evals/run_eval.py",
+    "server_flags": [
+      "--disable-prefix-cache"
+    ],
+    "suites": {
+      "tool_calling": "30 scenarios",
+      "coding": "10 HumanEval-derived tasks",
+      "reasoning": "10 MATH-500 subset tasks",
+      "general": "10 MMLU-Pro subset tasks"
+    },
+    "general_reasoning_pct": "mean(reasoning, general)",
+    "four_suite_composite_pct": "mean(tool_calling, coding, reasoning, general)",
+    "instruction_following": "not tested; remains null/Untested in the app",
+    "models_are_sequential": true
+  },
+  "measurements": [
+    {
+      "model": "lfm2.5-1b-4bit",
+      "scores": {
+        "tool_calling": {
+          "passed": 14,
+          "total": 30,
+          "score_pct": 47.0
+        },
+        "coding": {
+          "passed": 5,
+          "total": 10,
+          "score_pct": 50.0
+        },
+        "reasoning": {
+          "passed": 4,
+          "total": 10,
+          "score_pct": 40.0
+        },
+        "general": {
+          "passed": 5,
+          "total": 10,
+          "score_pct": 50.0
+        }
+      },
+      "general_reasoning_pct": 45.0,
+      "four_suite_composite_pct": 46.75,
+      "decode_8k_tps": 124.33,
+      "total_eval_time_s": 173.0
+    },
+    {
+      "model": "lfm2.5-2.6b-4bit",
+      "scores": {
+        "tool_calling": {
+          "passed": 23,
+          "total": 30,
+          "score_pct": 77.0
+        },
+        "coding": {
+          "passed": 5,
+          "total": 10,
+          "score_pct": 50.0
+        },
+        "reasoning": {
+          "passed": 5,
+          "total": 10,
+          "score_pct": 50.0
+        },
+        "general": {
+          "passed": 8,
+          "total": 10,
+          "score_pct": 80.0
+        }
+      },
+      "general_reasoning_pct": 65.0,
+      "four_suite_composite_pct": 64.25,
+      "decode_8k_tps": 64.95,
+      "total_eval_time_s": 631.7
+    },
+    {
+      "model": "lfm2.5-8b-a1b-4bit",
+      "scores": {
+        "tool_calling": {
+          "passed": 22,
+          "total": 30,
+          "score_pct": 73.0
+        },
+        "coding": {
+          "passed": 4,
+          "total": 10,
+          "score_pct": 40.0
+        },
+        "reasoning": {
+          "passed": 4,
+          "total": 10,
+          "score_pct": 40.0
+        },
+        "general": {
+          "passed": 8,
+          "total": 10,
+          "score_pct": 80.0
+        }
+      },
+      "general_reasoning_pct": 60.0,
+      "four_suite_composite_pct": 58.25,
+      "decode_8k_tps": 82.52,
+      "total_eval_time_s": 636.0
+    },
+    {
+      "model": "bonsai-27b-2bit",
+      "scores": {
+        "tool_calling": {
+          "passed": 28,
+          "total": 30,
+          "score_pct": 93.0
+        },
+        "coding": {
+          "passed": 9,
+          "total": 10,
+          "score_pct": 90.0
+        },
+        "reasoning": {
+          "passed": 7,
+          "total": 10,
+          "score_pct": 70.0
+        },
+        "general": {
+          "passed": 9,
+          "total": 10,
+          "score_pct": 90.0
+        }
+      },
+      "general_reasoning_pct": 80.0,
+      "four_suite_composite_pct": 85.75,
+      "decode_8k_tps": 15.0,
+      "total_eval_time_s": 1447.7
+    },
+    {
+      "model": "qwen3.5-35b-4bit",
+      "scores": {
+        "tool_calling": {
+          "passed": 29,
+          "total": 30,
+          "score_pct": 97.0
+        },
+        "coding": {
+          "passed": 10,
+          "total": 10,
+          "score_pct": 100.0
+        },
+        "reasoning": {
+          "passed": 6,
+          "total": 10,
+          "score_pct": 60.0
+        },
+        "general": {
+          "passed": 8,
+          "total": 10,
+          "score_pct": 80.0
+        }
+      },
+      "general_reasoning_pct": 70.0,
+      "four_suite_composite_pct": 84.25,
+      "decode_8k_tps": 21.14,
+      "total_eval_time_s": 420.3
+    }
+  ]
+}

--- a/docs/benchmarks/model-capability-measurements.md
+++ b/docs/benchmarks/model-capability-measurements.md
@@ -1,0 +1,25 @@
+# Measured capability gaps
+
+This release sweep fills catalog slots only for aliases that lacked compatible
+published benchmark rows. It does not replace existing official model-card
+scores. Raw counts and the exact engine/hardware metadata are committed in
+[`model-capability-measurements.json`](model-capability-measurements.json).
+
+All models ran sequentially through `rapid-mlx serve` and
+`evals/run_eval.py` on the 32 GB M2 Pro Mac mini. Scores are small release
+regression suites, not claims of parity with full MMLU-Pro, LiveCodeBench, or
+BFCL. Instruction following was not tested and therefore remains explicitly
+`Untested` in the app.
+
+| Model | Tool (30) | Code (10) | Reasoning (10) | General (10) | Four-suite mean | 8K decode |
+|---|---:|---:|---:|---:|---:|---:|
+| `lfm2.5-1b-4bit` | 47% | 50% | 40% | 50% | 46.75% | 124.33 tok/s |
+| `lfm2.5-2.6b-4bit` | 77% | 50% | 50% | 80% | 64.25% | 64.95 tok/s |
+| `lfm2.5-8b-a1b-4bit` | 73% | 40% | 40% | 80% | 58.25% | 82.52 tok/s |
+| `bonsai-27b-2bit` | 93% | 90% | 70% | 90% | 85.75% | 15.00 tok/s |
+| `qwen3.5-35b-4bit` | 97% | 100% | 60% | 80% | 84.25% | 21.14 tok/s |
+
+The compact catalog quality meter uses the mean of the local Reasoning and
+General suites for these fallback rows. The detailed tooltip retains the
+measured Code and Tool axes separately. No value is inferred for a suite that
+was not run.


### PR DESCRIPTION
## Summary
- record latest M2 Pro capability and 8K performance measurements for recommendation models
- fill only measured capability slots; leave IFEval explicitly untested
- refresh RAM-tier footprints and speeds from the current Rapid-MLX engine

## Validation
- swift apps/rapid-mac/scripts/verify-recommendation-tiers.swift
- cd apps/rapid-mac && swift test --filter BenchScoresTests --filter RAMBucketedDefaultTests
- JSON parse + git diff --check

Raw reports remain on the Mac mini Jetson volume; committed tables include engine, hardware, suite counts, and provenance.