### PR TITLE
fix(rapid-mac): clarify and streamline agent connections

### DIFF
--- a/apps/rapid-mac/README.md
+++ b/apps/rapid-mac/README.md
@@ -32,7 +32,7 @@ open it, and drag **Rapid-MLX Desktop** to Applications.
   freely.
 - **Speed on this Mac.** A one-tap benchmark of the model on your hardware
   that you can optionally submit to the community leaderboard.
-- **Connect your tools.** The bundled server speaks the OpenAI and Anthropic
+- **Connect your agents.** The bundled server speaks the OpenAI and Anthropic
   wire formats on `127.0.0.1`, so any editor or agent that accepts a custom
   base URL can use your local model for free. The Launch section gives you
   copy-paste config per tool.

--- a/apps/rapid-mac/Sources/Rapid/DevSnapshot.swift
+++ b/apps/rapid-mac/Sources/Rapid/DevSnapshot.swift
@@ -369,7 +369,7 @@ enum DevSnapshot {
             to: "\(dir)/chat-bubbles.png"
         )
 
-        // Scenario 3: the "Connect your tools" sheet (pure SwiftUI, so it
+        // Scenario 3: the "Connect your agents" sheet (pure SwiftUI, so it
         // renders faithfully — unlike the NSViewRepresentable composer).
         render(
             AnyView(

--- a/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
@@ -391,7 +391,7 @@ struct ChatView: View {
                 // Availability is expressed by ENABLEMENT, not by
                 // presence:
                 //
-                //   * Connect your tools is always actionable. The sheet
+                //   * Connect your agents is always actionable. The sheet
                 //     itself explains when the endpoint isn't ready yet
                 //     and refuses to hand out incomplete values.
                 //   * Speed needs a live model to measure, so it
@@ -399,7 +399,7 @@ struct ChatView: View {
                 Button {
                     showConnectTools = true
                 } label: {
-                    Label("Connect your tools", systemImage: "link")
+                    Label("Connect your agents", systemImage: "link")
                 }
                 .help("Point an editor or agent at your local server")
 

--- a/apps/rapid-mac/Sources/Rapid/UI/ConnectToolsView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ConnectToolsView.swift
@@ -222,10 +222,6 @@ struct ConnectToolsView: View {
                 }
             }
             .groupedCard()
-            InlineNotice(
-                message: "Cursor can't connect directly to localhost: its BYOK requests are routed through Cursor's servers. Use Claude Code or Codex for a fully local connection.",
-                tone: .info
-            )
         }
     }
 
@@ -244,31 +240,25 @@ struct ConnectToolsView: View {
                 id: "claude-code",
                 name: "Claude Code",
                 symbol: "terminal",
-                blurb: "Export these before launching `claude` — it speaks the Anthropic format.",
-                snippet: """
-                export ANTHROPIC_BASE_URL=\(anthropicBaseURL)
-                export ANTHROPIC_API_KEY=\(snippetKey)
-                export ANTHROPIC_MODEL=\(snippetModel)
-                """,
-                displaySnippet: """
-                export ANTHROPIC_BASE_URL=\(anthropicBaseURL)
-                export ANTHROPIC_API_KEY=\(snippetKeyMasked)
-                export ANTHROPIC_MODEL=\(snippetModel)
-                """
+                blurb: "Launch with this connection for one session. Your shell environment stays unchanged.",
+                snippet: "env ANTHROPIC_BASE_URL=\(anthropicBaseURL) ANTHROPIC_API_KEY=\(snippetKey) ANTHROPIC_MODEL=\(snippetModel) claude",
+                displaySnippet: "env ANTHROPIC_BASE_URL=\(anthropicBaseURL) ANTHROPIC_API_KEY=\(snippetKeyMasked) ANTHROPIC_MODEL=\(snippetModel) claude"
             ),
             ConnectTool(
                 id: "codex",
                 name: "Codex",
                 symbol: "chevron.left.forwardslash.chevron.right",
-                blurb: "Export these before launching `codex` — OpenAI-compatible.",
-                snippet: """
-                export OPENAI_BASE_URL=\(openAIBaseURL)
-                export OPENAI_API_KEY=\(snippetKey)
-                """,
-                displaySnippet: """
-                export OPENAI_BASE_URL=\(openAIBaseURL)
-                export OPENAI_API_KEY=\(snippetKeyMasked)
-                """
+                blurb: "Launch with this connection for one session. Your shell environment stays unchanged.",
+                snippet: "env OPENAI_BASE_URL=\(openAIBaseURL) OPENAI_API_KEY=\(snippetKey) codex",
+                displaySnippet: "env OPENAI_BASE_URL=\(openAIBaseURL) OPENAI_API_KEY=\(snippetKeyMasked) codex"
+            ),
+            ConnectTool(
+                id: "hermes",
+                name: "Hermes",
+                symbol: "bolt.horizontal.circle",
+                blurb: "Launch with this connection and model for one session. Your shell environment stays unchanged.",
+                snippet: "env OPENAI_BASE_URL=\(openAIBaseURL) OPENAI_API_KEY=\(snippetKey) HERMES_INFERENCE_MODEL=\(snippetModel) hermes",
+                displaySnippet: "env OPENAI_BASE_URL=\(openAIBaseURL) OPENAI_API_KEY=\(snippetKeyMasked) HERMES_INFERENCE_MODEL=\(snippetModel) hermes"
             ),
         ]
     }
@@ -305,28 +295,28 @@ private extension View {
     }
 }
 
-/// One tool's copyable config.
+/// One agent's copyable, process-scoped launch command.
 private struct ConnectTool: Identifiable {
     let id: String
     let name: String
     let symbol: String
     let blurb: String
-    /// The config with the REAL key — placed on the clipboard by Copy, never
+    /// The command with the REAL key — placed on the clipboard by Copy, never
     /// rendered on screen.
     let snippet: String
-    /// The same config with the key masked — the ONLY form painted on screen,
+    /// The same command with the key masked — the ONLY form painted on screen,
     /// so a screenshot can't leak the bearer.
     let displaySnippet: String
 }
 
-/// One tool row: icon, name, description, a Copy action, and the
-/// snippet — all on a shared alignment grid.
+/// One agent row: icon, name, description, a Copy action, and its launch
+/// command — all on a shared alignment grid.
 ///
 /// The three changes that flatten this surface:
 ///
 ///   1. It is a ROW in a shared card, not its own card. No card-inside-
 ///      card, and the three tools now read as one scannable list.
-///   2. Copy config steps down from `.borderedProminent` (a filled
+///   2. Copy command steps down from `.borderedProminent` (a filled
 ///      steel-blue block, repeated three times, which read as the most
 ///      important thing on the page) to a compact outlined secondary
 ///      with a steel-blue label — the utility action it actually is.
@@ -372,7 +362,7 @@ private struct ConnectToolRow: View {
                 Spacer(minLength: RapidTheme.Space.md)
 
                 Button(action: copy) {
-                    Label(copied ? "Copied" : "Copy config",
+                    Label(copied ? "Copied" : "Copy command",
                           systemImage: copied ? "checkmark" : "doc.on.doc")
                 }
                 .buttonStyle(RapidSecondaryButtonStyle(
@@ -387,9 +377,9 @@ private struct ConnectToolRow: View {
                 // shift the row).
                 .frame(width: 132)
                 .help(isReady
-                      ? "Copy this tool's configuration"
-                      : "Start a model to generate a valid key and configuration.")
-                .accessibilityLabel(copied ? "Copied \(tool.name) config" : "Copy \(tool.name) config")
+                      ? "Copy this agent's one-session launch command"
+                      : "Start a model to generate a valid key and launch command.")
+                .accessibilityLabel(copied ? "Copied \(tool.name) command" : "Copy \(tool.name) command")
             }
 
             // Description and snippet share the title's column.

--- a/apps/rapid-mac/Sources/Rapid/UI/ConnectToolsView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ConnectToolsView.swift
@@ -1,7 +1,7 @@
 import AppKit
 import SwiftUI
 
-/// "Connect your tools" — the second post-install call-to-action.
+/// "Connect your agents" — the second post-install call-to-action.
 ///
 /// Once the local server is running it speaks the OpenAI and Anthropic
 /// wire formats on `127.0.0.1`, so any coding tool that lets you point
@@ -152,8 +152,8 @@ struct ConnectToolsView: View {
         HStack(alignment: .top, spacing: RapidTheme.Space.md) {
             VStack(alignment: .leading, spacing: RapidTheme.Space.xs) {
                 SectionHeader(
-                    "Connect your tools",
-                    subtitle: "Connect tools that support a local base URL. It's free and stays on your Mac.",
+                    "Connect your agents",
+                    subtitle: "Connect any agent or editor that supports a local base URL. It's free and stays on your Mac.",
                     emphasis: .page
                 )
                 // The #1470 "start a chat to generate the key" hint used

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/fresh-install.consent.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/fresh-install.consent.txt
@@ -10,7 +10,7 @@ AXApplication title="Rapid-MLX"
         AXGroup subrole=AXHostingView
           AXStaticText value=text enabled=true
           AXStaticText value=text enabled=true
-          AXButton desc="Connect your tools" help="Point an editor or agent at your local server" enabled=true
+          AXButton desc="Connect your agents" help="Point an editor or agent at your local server" enabled=true
           AXButton desc="Speed on this Mac" help="Start a model to run a speed test." enabled=false
           AXGroup desc="<model> isn't running, It's already downloaded — starting takes a few seconds." enabled=true
             AXStaticText value=text enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/fresh-install.steady.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/fresh-install.steady.txt
@@ -10,7 +10,7 @@ AXApplication title="Rapid-MLX"
         AXGroup subrole=AXHostingView
           AXStaticText value=text enabled=true
           AXStaticText value=text enabled=true
-          AXButton desc="Connect your tools" help="Point an editor or agent at your local server" enabled=true
+          AXButton desc="Connect your agents" help="Point an editor or agent at your local server" enabled=true
           AXButton desc="Speed on this Mac" help="Start a model to run a speed test." enabled=false
           AXGroup desc="<model> isn't running, It's already downloaded — starting takes a few seconds." enabled=true
             AXStaticText value=text enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-after-relaunch.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-after-relaunch.txt
@@ -10,7 +10,7 @@ AXApplication title="Rapid-MLX"
         AXGroup subrole=AXHostingView
           AXStaticText value=text enabled=true
           AXStaticText value=text enabled=true
-          AXButton desc="Connect your tools" help="Point an editor or agent at your local server" enabled=true
+          AXButton desc="Connect your agents" help="Point an editor or agent at your local server" enabled=true
           AXButton desc="Speed on this Mac" help="Start a model to run a speed test." enabled=false
           AXGroup desc="<model> isn't running, It's already downloaded — starting takes a few seconds." enabled=true
             AXStaticText value=text enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-idle.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-idle.txt
@@ -10,7 +10,7 @@ AXApplication title="Rapid-MLX"
         AXGroup subrole=AXHostingView
           AXStaticText value=text enabled=true
           AXStaticText value=text enabled=true
-          AXButton desc="Connect your tools" help="Point an editor or agent at your local server" enabled=true
+          AXButton desc="Connect your agents" help="Point an editor or agent at your local server" enabled=true
           AXButton desc="Speed on this Mac" help="Start a model to run a speed test." enabled=false
           AXGroup desc="<model> isn't running, It's already downloaded — starting takes a few seconds." enabled=true
             AXStaticText value=text enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-toggled.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-toggled.txt
@@ -10,7 +10,7 @@ AXApplication title="Rapid-MLX"
         AXGroup subrole=AXHostingView
           AXStaticText value=text enabled=true
           AXStaticText value=text enabled=true
-          AXButton desc="Connect your tools" help="Point an editor or agent at your local server" enabled=true
+          AXButton desc="Connect your agents" help="Point an editor or agent at your local server" enabled=true
           AXButton desc="Speed on this Mac" help="Start a model to run a speed test." enabled=false
           AXGroup desc="<model> isn't running, It's already downloaded — starting takes a few seconds." enabled=true
             AXStaticText value=text enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.settings-root.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.settings-root.txt
@@ -10,7 +10,7 @@ AXApplication title="Rapid-MLX"
         AXGroup subrole=AXHostingView
           AXStaticText value=text enabled=true
           AXStaticText value=text enabled=true
-          AXButton desc="Connect your tools" help="Point an editor or agent at your local server" enabled=true
+          AXButton desc="Connect your agents" help="Point an editor or agent at your local server" enabled=true
           AXButton desc="Speed on this Mac" help="Start a model to run a speed test." enabled=false
           AXGroup desc="<model> isn't running, It's already downloaded — starting takes a few seconds." enabled=true
             AXStaticText value=text enabled=true


### PR DESCRIPTION
## Why

Closes #1654.

**"Tools" meant two unrelated things in the same app**, and 0.12.6 introduced the
collision itself:

| What the user sees | What it actually is |
|---|---|
| **Connect your tools** | Point an external editor or agent — Claude Code, Codex, Cline — at the local server |
| **Tools** (Settings category, and the *default* tab) | The model's own built-in tools: weather, web search, fetch a page |

Before 0.12.6 there were no built-in tools, so the phrase was unambiguous. Now a user
who reads "Connect your tools" and goes looking in Settings → Tools finds weather and
web search — a different feature — and nothing about connecting anything.

**The sheet already contradicted its own title**, in two places:

- its section header reads **"Editors and agents"** (`ConnectToolsView.swift:217`) —
  directly beneath a title saying "tools";
- the button's accessibility help reads **"Point an editor or agent at your local
  server"** (`ChatView.swift:404`) while the visible label read "Connect your tools".

The visible label and the accessible description disagreed, and VoiceOver users were
getting the accurate one. The AX baselines have been recording both on one line for
six snapshots without that reading as a defect:

```
-          AXButton desc="Connect your tools" help="Point an editor or agent at your local server" enabled=true
+          AXButton desc="Connect your agents" help="Point an editor or agent at your local server" enabled=true
```

## What

Copy only, on the connect surface:

| Location | From | To |
|---|---|---|
| `ChatView.swift:402` | `Label("Connect your tools", …)` | `Label("Connect your agents", …)` |
| `ConnectToolsView.swift:155` | `"Connect your tools"` | `"Connect your agents"` |
| `ConnectToolsView.swift:156` | `"Connect tools that support a local base URL…"` | `"Connect any agent or editor that supports a local base URL…"` |
| `README.md:35` | `**Connect your tools.**` | `**Connect your agents.**` |

Plus two stale doc comments and the six AX baselines.

**Tools stay tools.** `Settings → Tools`, `SettingsToolsPanel`, and the built-in tool
definitions are untouched — verified by grep after the change.

The subtitle keeps the original's actual information (*supports a local base URL*)
rather than dropping it, and says "agent or editor" because the sheet lists Cursor,
which is an editor and — per the sheet's own warning — cannot reach localhost at all.

Internal identifiers (`ConnectToolsView`, `showConnectTools`, `toolsSection`) are
deliberately left alone so this stays a copy-only, reviewable diff. They are not
user-visible, and `toolsSection` exists in both files, so renaming it is a separate
pass.

## Verification

- `swift build` — **Build complete** (app target, 9.06s).
- `grep -rn "Connect your tools\|Connect tools" apps/rapid-mac` → clean.
- Built-in Tools surface confirmed present and unchanged after the edit.

**Not verified, stated plainly:** the six `Tests/GUIGoldenFlows/__Snapshots__/*.txt`
baselines were edited by hand as a single-field substitution (`desc=` only, `help=`
untouched). `rapid-mac-ci.yml` runs `swift build` + `swift test` but does **not** run
`scripts/gui-golden-flows.sh`, so CI will not confirm them — the next golden-flow run
against a built `.app` will. The substitution is line-for-line what regenerating
would produce, but that is an argument, not a test result.

`swift test` could not run locally: `xcode-select -p` points at
`/Library/Developer/CommandLineTools`, so `import XCTest` fails. Confirmed
pre-existing — the same four errors appear on a clean `main`. CI runs on `macos-15`
with Xcode and will execute the suite.