### PR TITLE
fix(rapid-mac): clarify active agent work

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Services/FailureDiagnosis.swift
+++ b/apps/rapid-mac/Sources/Rapid/Services/FailureDiagnosis.swift
@@ -20,6 +20,9 @@ struct FailureDiagnosis: Equatable, Sendable {
         /// Settings is misconfigured, so "check its settings" sends the user to
         /// a dead end. The only real fix is a different backend.
         case webSearchRateLimited
+        /// A browse fetch crossed the bounded response cap. The agent can
+        /// normally recover by searching or choosing a narrower page.
+        case browsePageTooLarge
         case commandPermissionDenied
         case commandFailed
         case fileNotFound
@@ -58,6 +61,8 @@ struct FailureDiagnosis: Equatable, Sendable {
             // copy it always showed for a throttled search.
             case .webSearchRateLimited:
                 return .webSearchUnavailable
+            case .browsePageTooLarge:
+                return .toolFailed
             case .modelOutOfMemory, .modelLoadFailed, .engineNotRunning,
                  .webSearchOffline, .webSearchUnavailable,
                  .commandPermissionDenied, .commandFailed,
@@ -194,6 +199,7 @@ extension FailureDiagnosis.Kind {
         // copy and deep-link do the recovering.
         case .modelOutOfMemory, .modelLoadFailed, .engineNotRunning,
              .webSearchOffline, .webSearchUnavailable, .webSearchRateLimited,
+             .browsePageTooLarge,
              .commandPermissionDenied, .commandFailed,
              .fileNotFound, .filePermissionDenied, .toolFailed,
              .downloadFailed, .downloadSourceUnavailable, .requestFailed:
@@ -243,6 +249,9 @@ enum FailureDiagnoser {
             // remedy so it still reads inside the tool card.
             message = "DuckDuckGo is rate-limiting web searches from this Mac. Switch to Brave Search or Tavily in Settings → Tools and add a free key."
             action = .openWebSearchSettings
+        case .browsePageTooLarge:
+            message = "This page is too large for Rapid to read at once. Search it or open a smaller page instead."
+            action = nil
         case .commandPermissionDenied:
             // No action, and no "allow that folder, then try again" — this app
             // ships no shell tool and no place to grant a folder, so the old
@@ -322,6 +331,12 @@ enum FailureDiagnoser {
         }
 
         guard isError else { return nil }
+
+        if toolName == "browse",
+           raw.contains("page exceeded"),
+           raw.contains("mb cap") {
+            return .browsePageTooLarge
+        }
 
         if toolName == "web_search" {
             // ``WebSearchTool`` stamps ``.webSearchRateLimited`` on the result

--- a/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
@@ -961,16 +961,43 @@ private struct MessageRow: View {
                 .textSelection(.enabled)
                 .frame(maxWidth: .infinity, alignment: .leading)
         } label: {
-            Label(message.reasoningTruncated ? "Thinking trace (cut off)" : "Reasoning",
-                  systemImage: "brain")
+            HStack(spacing: RapidTheme.Space.xs) {
+                Label(message.reasoningTruncated ? "Thinking trace (cut off)" : reasoningTitle,
+                      systemImage: "brain")
+                if reasoningInProgress {
+                    ProgressView()
+                        .controlSize(.mini)
+                        .accessibilityHidden(true)
+                }
+            }
                 .font(.caption.weight(.medium))
                 .foregroundStyle(.secondary)
+                .accessibilityElement(children: .combine)
+                .accessibilityLabel(reasoningAccessibilityLabel)
         }
         .onAppear {
             // Auto-expand a truncated reasoning-only turn so the user
             // sees the partial trace instead of an empty bubble.
             if message.reasoningTruncated { reasoningExpanded = true }
         }
+    }
+
+    /// A reasoning trace can begin well before answer tokens arrive. Keeping
+    /// its disclosure label static during that interval made a healthy stream
+    /// look frozen. Key this to the ROW's status (not the view model's global
+    /// streaming flag) so completed history never keeps animating while a
+    /// later turn is running.
+    private var reasoningInProgress: Bool {
+        message.status == .streaming && !message.reasoningTruncated
+    }
+
+    private var reasoningTitle: String {
+        reasoningInProgress ? "Reasoning…" : "Reasoning"
+    }
+
+    private var reasoningAccessibilityLabel: String {
+        if message.reasoningTruncated { return "Thinking trace, cut off" }
+        return reasoningInProgress ? "Reasoning in progress" : "Reasoning"
     }
 
     private var showTypingIndicator: Bool {
@@ -1121,13 +1148,17 @@ private struct ToolCallChip: View {
     private var statusIcon: String {
         guard result != nil else { return "ellipsis.circle" }
         guard let failureDiagnosis else { return "checkmark.circle.fill" }
-        return failureDiagnosis.severity == .notice ? "hand.raised" : "exclamationmark.octagon.fill"
+        if failureDiagnosis.severity == .notice { return "hand.raised" }
+        if failureDiagnosis.kind == .browsePageTooLarge { return "exclamationmark.triangle.fill" }
+        return "exclamationmark.octagon.fill"
     }
 
     private var statusColor: Color {
         guard result != nil else { return .secondary }
         guard let failureDiagnosis else { return .green }
-        return failureDiagnosis.severity == .notice ? .secondary : RapidTheme.statusError
+        if failureDiagnosis.severity == .notice { return .secondary }
+        if failureDiagnosis.kind == .browsePageTooLarge { return .orange }
+        return RapidTheme.statusError
     }
 
     /// Red is reserved for something that actually went wrong. A decline reads
@@ -1135,7 +1166,9 @@ private struct ToolCallChip: View {
     /// "this ended early, and that's fine" footers (e.g. "Stopped.").
     private var resultBodyColor: Color {
         guard let failureDiagnosis else { return .secondary }
-        return failureDiagnosis.severity == .notice ? .secondary : RapidTheme.statusError
+        if failureDiagnosis.severity == .notice { return .secondary }
+        if failureDiagnosis.kind == .browsePageTooLarge { return .orange }
+        return RapidTheme.statusError
     }
 
     var body: some View {

--- a/apps/rapid-mac/Sources/Rapid/UI/ConnectToolsView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ConnectToolsView.swift
@@ -248,17 +248,17 @@ struct ConnectToolsView: View {
                 id: "codex",
                 name: "Codex",
                 symbol: "chevron.left.forwardslash.chevron.right",
-                blurb: "Launch with this connection for one session. Your shell environment stays unchanged.",
-                snippet: "env OPENAI_BASE_URL=\(openAIBaseURL) OPENAI_API_KEY=\(snippetKey) codex",
-                displaySnippet: "env OPENAI_BASE_URL=\(openAIBaseURL) OPENAI_API_KEY=\(snippetKeyMasked) codex"
+                blurb: "Launch with an isolated Rapid provider for one session. Your existing Codex provider and shell environment stay unchanged.",
+                snippet: "env OPENAI_API_KEY=\(snippetKey) codex --ignore-user-config -m \(snippetModel) -c 'model_provider=\"rapid-mlx\"' -c 'model_providers.rapid-mlx={name=\"Rapid-MLX\",base_url=\"\(openAIBaseURL)\",env_key=\"OPENAI_API_KEY\",wire_api=\"responses\"}'",
+                displaySnippet: "env OPENAI_API_KEY=\(snippetKeyMasked) codex --ignore-user-config -m \(snippetModel) -c 'model_provider=\"rapid-mlx\"' -c 'model_providers.rapid-mlx={name=\"Rapid-MLX\",base_url=\"\(openAIBaseURL)\",env_key=\"OPENAI_API_KEY\",wire_api=\"responses\"}'"
             ),
             ConnectTool(
                 id: "hermes",
                 name: "Hermes",
                 symbol: "bolt.horizontal.circle",
                 blurb: "Launch with this connection and model for one session. Your shell environment stays unchanged.",
-                snippet: "env OPENAI_BASE_URL=\(openAIBaseURL) OPENAI_API_KEY=\(snippetKey) HERMES_INFERENCE_MODEL=\(snippetModel) hermes",
-                displaySnippet: "env OPENAI_BASE_URL=\(openAIBaseURL) OPENAI_API_KEY=\(snippetKeyMasked) HERMES_INFERENCE_MODEL=\(snippetModel) hermes"
+                snippet: "env OPENAI_BASE_URL=\(openAIBaseURL) OPENAI_API_KEY=\(snippetKey) HERMES_INFERENCE_MODEL=\(snippetModel) hermes --provider openai-api --ignore-user-config",
+                displaySnippet: "env OPENAI_BASE_URL=\(openAIBaseURL) OPENAI_API_KEY=\(snippetKeyMasked) HERMES_INFERENCE_MODEL=\(snippetModel) hermes --provider openai-api --ignore-user-config"
             ),
         ]
     }

--- a/apps/rapid-mac/Sources/Rapid/UI/FailureDiagnosisView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/FailureDiagnosisView.swift
@@ -85,6 +85,7 @@ struct FailureDiagnosisView: View {
         case .engineNotRunning, .modelLoadFailed: return "bolt.slash"
         case .webSearchOffline, .webSearchUnavailable: return "wifi.exclamationmark"
         case .webSearchRateLimited: return "hourglass"
+        case .browsePageTooLarge: return "doc.text.magnifyingglass"
         case .commandPermissionDenied, .filePermissionDenied: return "hand.raised.fill"
         // Unfilled, and tinted secondary above: the user turned this down on
         // purpose, so it reads as a note rather than a stop sign.

--- a/apps/rapid-mac/Tests/RapidTests/DeclinedToolDiagnosisTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/DeclinedToolDiagnosisTests.swift
@@ -211,6 +211,20 @@ final class DeclinedToolDiagnosisTests {
         #expect(result.failureKind?.severity == .error)
     }
 
+    @Test("An oversized browse page gets specific recovery copy")
+    func oversizedBrowsePageIsSpecific() throws {
+        let kind = FailureDiagnoser.toolFailureKind(
+            toolName: "browse",
+            content: "browse error: page exceeded 2 MB cap",
+            isError: true
+        )
+        #expect(kind == .browsePageTooLarge)
+        let diagnosis = FailureDiagnoser.diagnosis(for: try #require(kind))
+        #expect(diagnosis.message ==
+                "This page is too large for Rapid to read at once. Search it or open a smaller page instead.")
+        #expect(diagnosis.action == nil)
+    }
+
     @Test("Text that merely LOOKS like a decline is not promoted to one")
     func declineIsNeverInferredFromWording() {
         // The marker is carried by the approval gate, so a page (or a future
@@ -327,6 +341,7 @@ final class DeclinedToolDiagnosisTests {
         // The condition this kind describes used to land on webSearchUnavailable,
         // so that is what an older build should keep showing for it.
         #expect(FailureDiagnosis.Kind.webSearchRateLimited.legacyPersistedKind == .webSearchUnavailable)
+        #expect(FailureDiagnosis.Kind.browsePageTooLarge.legacyPersistedKind == .toolFailed)
     }
 
     @Test("A rate-limited row is downgrade-safe and reopens as itself")


### PR DESCRIPTION
## Summary

- show a native progress indicator while a reasoning row is still streaming
- present oversized browse attempts as a specific recoverable warning instead of a generic red turn failure
- make Codex and Hermes launch commands self-contained so existing user provider configuration cannot redirect them

## Dogfood (Mac mini)

- Claude Code reached Rapid via Anthropic `/v1/messages`
- Codex reached Rapid via `/v1/responses` with the isolated inline provider
- Hermes reached Rapid via `/v1/chat/completions` using `openai-api`
- all commands were process-scoped; no persistent shell or agent config was changed

## Validation

- `swift test` (1758 tests)
- `SKIP_SIDECAR=1 BUNDLE_MODEL=0 ./scripts/build.sh`
- targeted oversized-browse diagnosis regression test
