### PR TITLE
fix(mac): Browse all models opens the catalogue instead of closing the wizard

### DIFF
--- a/apps/rapid-mac/CHANGELOG.md
+++ b/apps/rapid-mac/CHANGELOG.md
@@ -13,6 +13,14 @@ can actually understand.
 
 ## [Unreleased]
 
+### Fixed
+
+- **"Browse all models" in the setup wizard opens the model catalogue.** It used
+  to close the wizard instead — your chosen model was discarded and you landed
+  on the chat surface pinned to a model you never picked. It now opens
+  Settings → Models with the wizard still behind it, so closing Settings puts
+  you back on your selection.
+
 ## [0.12.7] — 2026-08-07
 
 The privacy switch does what it looks like it does, and the models Rapid

--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -460,8 +460,15 @@ struct ContentView: View {
             get: { quickstartVisible },
             set: { presented in
                 // A swipe-down / Esc means "let me look around first" — the
-                // same intent as the card's own "Browse all models", so route
-                // it to the same session flag rather than dropping it.
+                // same intent as the card's own "Skip for now", so route it to
+                // the same session flag rather than dropping it.
+                //
+                // NOT the same intent as "Browse all models", which used to
+                // land here too: that one asks to see the catalogue, and
+                // answering it by closing the wizard discarded the user's
+                // selection and left them on the alphabetical fallback
+                // (#1653). It opens Settings → Models now and leaves the
+                // wizard standing.
                 if !presented { quickstartDismissedThisSession = true }
             }
         )
@@ -473,7 +480,7 @@ struct ContentView: View {
             coordinator: quickstart,
             downloads: downloads,
             server: server,
-            onBrowseAll: { quickstartDismissedThisSession = true },
+            onSkip: { quickstartDismissedThisSession = true },
             onSeedWelcome: { true }
         )
         // QuickstartView was written for the detail column and its comments

--- a/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
@@ -771,13 +771,20 @@ struct QuickstartView: View {
     @Bindable var downloads: DownloadManager
     @Bindable var server: ServerManager
 
-    /// Callback the parent supplies for the "or browse all models →"
-    /// link. The parent dismisses the Quickstart surface for the
-    /// current session (without flipping the persisted flag) so the
-    /// existing picker becomes visible. Lifted out as a closure so
-    /// this view can stay agnostic of how the parent toggles its own
-    /// state.
-    var onBrowseAll: () -> Void
+    /// Callback the parent supplies for "Skip for now". The parent
+    /// dismisses the Quickstart surface for the current session (without
+    /// flipping the persisted flag) so the existing picker becomes visible.
+    /// Lifted out as a closure so this view can stay agnostic of how the
+    /// parent toggles its own state.
+    ///
+    /// This is ONLY the skip path. "Browse all models" used to share it, on
+    /// the theory that both mean "let me look around first" — but they differ
+    /// in exactly the thing that matters: skipping accepts whatever the app
+    /// picks, browsing is a request to choose. Sharing the closure made the
+    /// link a dismiss button that dropped the user's selection and left them
+    /// on the alphabetical fallback (#1653). Browsing is handled in this view
+    /// now, by ``browseAllModels()``.
+    var onSkip: () -> Void
 
     /// Callback the parent supplies for seeding the welcome message
     /// into the active session. Closing over ``SessionStore`` /
@@ -981,12 +988,16 @@ struct QuickstartView: View {
             // #549 (§16 wayfinding): the hero must answer "how do I get
             // out?" — before this the only exit was the "Browse all
             // models" link on step 2, trapping a first-run user sitting
-            // on step 1. A low-emphasis Skip drops straight into the app
-            // (same `onBrowseAll` dismiss path the chooser uses), and
-            // `.cancelAction` makes Esc leave onboarding — mirroring the
-            // Skip control OnboardingTour already ships.
+            // on step 1. A low-emphasis Skip drops straight into the app,
+            // and `.cancelAction` makes Esc leave onboarding — mirroring
+            // the Skip control OnboardingTour already ships.
+            //
+            // This is the app's one genuine "dismiss onboarding" control.
+            // "Browse all models" on step 2 shared it until #1653; it does
+            // not any more, because a user asking to see the catalogue has
+            // not asked to leave setup.
             Button("Skip for now") {
-                onBrowseAll()
+                onSkip()
             }
             .buttonStyle(.plain)
             .scaledSystemFont(12, weight: .medium)
@@ -1060,7 +1071,7 @@ struct QuickstartView: View {
                     }
 
                     Button {
-                        onBrowseAll()
+                        browseAllModels()
                     } label: {
                         Text("Browse all models →")
                             .scaledSystemFont(12, weight: .medium)
@@ -1364,12 +1375,29 @@ struct QuickstartView: View {
         )
 
         Button {
-            onBrowseAll()
+            browseAllModels()
         } label: {
             Text("or browse all models →")
                 .font(.callout)
         }
         .buttonStyle(.borderless)
+    }
+
+    /// Open Settings on the model catalogue, leaving Quickstart standing.
+    ///
+    /// The wizard deliberately stays up behind the Settings window. "Browse all
+    /// models" is a request to see the other options, not to abandon setup, so
+    /// closing Settings has to put the user back where they were with the pick
+    /// they had already made. Dismissing instead is what made the link a dead
+    /// end (#1653): the wizard vanished, the selection was discarded, and the
+    /// user landed on whatever the alphabetical fallback chose — a 7.6 GB
+    /// download they never asked for.
+    ///
+    /// Routed through ``SettingsRouter`` for its ordering rule (stage the tab,
+    /// THEN open), and through ``openWindow(id: "settings")`` rather than
+    /// ``openSettings()`` — see the ``openWindow`` property above.
+    private func browseAllModels() {
+        settingsRouter.route(to: .modelManagement) { openWindow(id: "settings") }
     }
 
     private func handleQuickstartFailureAction(_ action: FailureDiagnosis.Action) {

--- a/apps/rapid-mac/Tests/RapidTests/QuickstartBrowseAllDestinationTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/QuickstartBrowseAllDestinationTests.swift
@@ -1,0 +1,139 @@
+import Foundation
+import Testing
+
+@testable import Rapid
+
+/// "Browse all models →" must have a destination (#1653).
+///
+/// The bug this pins was not a wrong destination — it was no destination. The
+/// whole implementation was one line that set a session dismiss flag, so
+/// clicking the link closed the wizard, discarded the model the user had
+/// chosen, and dropped them onto the chat surface pinned to whatever the
+/// alphabetical fallback picked (a 7.6 GB download nobody asked for).
+///
+/// It survived every check we had. The control was present, enabled, correctly
+/// labelled and carried `Quickstart.BrowseAll`, so the AX structural baselines
+/// recorded a perfectly healthy button. A tree dump cannot tell a working
+/// button from a decorative one; only pressing it can. So this suite pins the
+/// wiring in source, and `gui-golden-flows.sh browse-all-destination` presses
+/// the real control and asserts where the user lands.
+///
+/// Source-level rather than a rendered-view assertion because the failure is a
+/// missing call, and the value of catching it is highest at the point where
+/// somebody edits that call site — SwiftUI gives no seam to observe "this
+/// button's action did nothing".
+@MainActor
+@Suite("Quickstart — Browse all models opens the catalogue")
+struct QuickstartBrowseAllDestinationTests {
+    private static var quickstartSource: String {
+        get throws {
+            let url = URL(fileURLWithPath: #filePath)
+                .deletingLastPathComponent()  // RapidTests
+                .deletingLastPathComponent()  // Tests
+                .deletingLastPathComponent()  // rapid-mac
+                .appendingPathComponent("Sources/Rapid/UI/QuickstartView.swift")
+            return try String(contentsOf: url, encoding: .utf8)
+        }
+    }
+
+    @Test("The link's action calls browseAllModels(), not a dismiss flag")
+    func browseAllIsWiredToTheCatalogue() throws {
+        let source = try Self.quickstartSource
+        #expect(
+            source.contains(
+                """
+                                    Button {
+                                        browseAllModels()
+                                    } label: {
+                                        Text("Browse all models →")
+                """
+            ),
+            """
+            The "Browse all models →" button no longer calls browseAllModels(). \
+            If it is back to a dismiss closure, that is #1653 returning: the \
+            wizard vanishes and the user's selection is discarded.
+            """
+        )
+    }
+
+    @Test("The failure card's 'or browse all models' goes to the same place")
+    func failureCardLinkIsWiredToo() throws {
+        let source = try Self.quickstartSource
+        #expect(
+            source.contains(
+                """
+                        Button {
+                            browseAllModels()
+                        } label: {
+                            Text("or browse all models →")
+                """
+            ),
+            """
+            The failure card's browse link must reach the catalogue as well — \
+            it is offered precisely when the user's chosen model failed, which \
+            is the moment they most need to pick a different one.
+            """
+        )
+    }
+
+    @Test("browseAllModels() stages the models tab, then opens Settings")
+    func browseAllModelsRoutesToModelManagement() throws {
+        let source = try Self.quickstartSource
+        #expect(
+            source.contains(
+                "settingsRouter.route(to: .modelManagement) { openWindow(id: \"settings\") }"
+            ),
+            """
+            browseAllModels() must route through SettingsRouter to the \
+            modelManagement tab. Opening Settings on the user's last-used tab \
+            is a different bug wearing the same green check, and \
+            openSettings() targets a scene this app does not declare — see \
+            OpenSettingsActionAbsenceTests.
+            """
+        )
+    }
+
+    @Test("Dismissing the wizard is reachable from exactly one control")
+    func onlySkipDismissesTheWizard() throws {
+        let source = try Self.quickstartSource
+        let dismissCalls = source.components(separatedBy: "onSkip()").count - 1
+        #expect(
+            dismissCalls == 1,
+            """
+            onSkip() is the app's one genuine "leave onboarding" action and is \
+            called \(dismissCalls) time(s). "Browse all models" shared it \
+            until #1653 on the theory that both mean "let me look around \
+            first" — they differ in exactly the thing that matters, whether \
+            the user gets to choose.
+            """
+        )
+        #expect(
+            source.contains(
+                """
+                            Button("Skip for now") {
+                                onSkip()
+                            }
+                """
+            ),
+            "The one onSkip() call must be Skip for now."
+        )
+    }
+
+    /// The routing contract the button depends on, exercised rather than read.
+    ///
+    /// `SettingsRouter.route(to:open:)` takes the open as a closure so the tab
+    /// cannot be staged *after* the window opens — `SettingsView` reads the
+    /// router from `.onAppear`, so the wrong order lands the user on their
+    /// last-used tab. Pinned here because "Browse all models" is a first-run
+    /// surface: the person clicking it has never seen Settings before and has
+    /// no last-used tab worth landing on.
+    @Test("The tab is staged before the window opens, never after")
+    func routerStagesTheTabBeforeOpening() {
+        let router = SettingsRouter()
+        var categoryWhenOpened: SettingsView.Category??
+        router.route(to: .modelManagement) {
+            categoryWhenOpened = router.requestedCategory
+        }
+        #expect(categoryWhenOpened == .modelManagement)
+    }
+}

--- a/apps/rapid-mac/docs/gui-golden-flows.md
+++ b/apps/rapid-mac/docs/gui-golden-flows.md
@@ -264,8 +264,14 @@ The checked-in `rapid-ax.swift` helper talks directly to macOS Accessibility.
 It finds controls by stable `AXIdentifier`, performs `AXPress`, sets native text
 values, and serializes roles/descriptions/values for assertions. Peekaboo is
 kept for permission checks, window discovery, menu interaction, and screenshots.
-The only coordinate fallback is the documented first-run SwiftUI consent-sheet
-fallback, derived from AX bounds, for older accessibility stacks.
+Coordinates are used in exactly two places, both deliberate and both derived
+from AX bounds. One is the first-run SwiftUI consent-sheet fallback, for older
+accessibility stacks. The other is `browse-all-destination`, where a coordinate
+click is the *point*: `AXPress` reaches a window trapped behind a modal sheet
+just as well as a usable one, and so does Peekaboo's default background click,
+so proving that a person could use the Settings window the wizard opened takes
+a real `--foreground` mouse event at a real position. Bounds are re-read after
+focusing, since focusing can raise or move the window.
 
 This makes normal actions independent of window position, resolution, theme,
 and most layout changes. It also avoids Peekaboo snapshot publication failures

--- a/apps/rapid-mac/scripts/ax-baseline.py
+++ b/apps/rapid-mac/scripts/ax-baseline.py
@@ -38,6 +38,11 @@ What it drops or rewrites, and why
     conversation row identifier legitimately carries a fresh UUID.
   * caller-supplied tokens (``--scrub``) — the golden flows pass the fake
     model alias so a rename of the fixture is not a baseline change.
+  * ``AXSelected`` — dumped by ``rapid-ax.swift`` (a flow has to be able to ask
+    which model card the user chose, see #1653) but deliberately NOT rendered
+    here. Which of several equal-looking cards is highlighted is state, not
+    structure, and it legitimately differs between a fresh persona and a
+    relaunched one. Flows assert it against the raw dump instead.
 """
 
 from __future__ import annotations

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -32,8 +32,8 @@ Usage: gui-golden-flows.sh [--flow NAME] [--keep] [--update-baselines]
 
 Flows: fresh-install, settings-persistence, chat-restore, slow-stream-stop,
        model-crash-recovery, low-memory-choice, loaded-model-benchmark,
-       update-state, no-dead-controls,
-       catalog-integrity, all
+       update-state, no-dead-controls, catalog-integrity,
+       browse-all-destination, all
 
 Options:
   --update-baselines  rewrite the committed AX structural baselines instead of

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -803,14 +803,24 @@ flow_browse_all_destination() {
     #    click it the way a person would, and require the panel to change.
     pb window focus --window-id "$SETTINGS_WINDOW_ID" --json > "$OUT/ba-focus.json" \
         || die "could not focus the Settings window the button opened"
+    # Coordinates re-read AFTER the focus, because focusing can raise or move
+    # the window and a stale point would click whatever now sits there.
+    see_settings "$OUT/ba-focused.json"
     local cx cy
     read -r cx cy < <(jq -r '.data.ui_elements[]
                              | select(.identifier == "Settings.Category.privacy")
                              | [(.bounds.x + .bounds.width / 2), (.bounds.y + .bounds.height / 2)]
-                             | @tsv' "$OUT/ba-settings.json")
+                             | @tsv' "$OUT/ba-focused.json")
     [[ -n "$cx" && -n "$cy" ]] || die "Settings.Category.privacy has no bounds to click"
-    pb click --coords "$cx,$cy" --global-coords --app "PID:$APP_PID" --json > "$OUT/ba-click.json" \
-        || die "the Settings window did not accept a click — it is behind the wizard sheet"
+    # ``--foreground`` is the whole point. Peekaboo's default is background
+    # delivery — a coordinate hit-test followed by an accessibility action,
+    # which reaches UI a person cannot, and is therefore exactly as blind to
+    # "trapped behind a modal sheet" as the AXPress this replaced.
+    # ``--window-id`` also pins the click to the Settings window rather than
+    # whatever else the app has on screen at that point.
+    pb click --coords "$cx,$cy" --global-coords --foreground \
+        --window-id "$SETTINGS_WINDOW_ID" --json > "$OUT/ba-click.json" \
+        || die "the Settings window did not accept a real click — it is behind the wizard sheet"
     # A real click that changed nothing is the same failure as no click at all,
     # so require the panel's own control to appear, not merely that the press
     # returned success.

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -730,6 +730,63 @@ flow_no_dead_controls() {
     cleanup_persona
 }
 
+flow_browse_all_destination() {
+    # An advertised destination must actually be one.
+    #
+    # "Browse all models →" on Quickstart step 2 was implemented as one line
+    # that set a dismiss flag (#1653). It was present, enabled, correctly
+    # labelled and carried an AXIdentifier, so every structural check passed —
+    # the wizard simply vanished, the user's pick was discarded, and they
+    # landed on whatever the alphabetical fallback chose (a 7.6 GB download
+    # nobody asked for). Nothing here can be asserted from a tree dump alone:
+    # this flow PRESSES the control and asserts where the user ends up.
+    start_persona browse-all-destination
+
+    # Only the consent sheet — the wizard has to stay up, it is the subject.
+    local tree="$OUT/ba-first-run.json"
+    see_main "$tree"
+    if jq -e '.data.ui_elements[]? | select(.identifier == "TelemetryConsent.DontShare")' "$tree" >/dev/null; then
+        press "$tree" TelemetryConsent.DontShare "$OUT/ba-consent.json" \
+            || die "could not answer the telemetry consent sheet"
+        sleep 0.5
+    fi
+
+    wait_identifier Quickstart.GetStarted "$OUT/ba-welcome.json"
+    press "$OUT/ba-welcome.json" Quickstart.GetStarted "$OUT/ba-get-started.json" \
+        || die "Quickstart.GetStarted is not pressable"
+    wait_identifier Quickstart.BrowseAll "$OUT/ba-chooser.json"
+
+    press "$OUT/ba-chooser.json" Quickstart.BrowseAll "$OUT/ba-press.json" \
+        || die "Quickstart.BrowseAll is not pressable"
+
+    # 1. It opened the catalogue. `open_settings` drives the menu, so assert
+    #    the window the BUTTON opened rather than opening one ourselves.
+    local i
+    for ((i=0; i<40; i++)); do
+        pb list windows --app "PID:$APP_PID" --json > "$OUT/ba-windows.json"
+        SETTINGS_WINDOW_ID="$(jq -r '.data.windows[]? | select(.title == "Settings") | .window_id' "$OUT/ba-windows.json" | head -1)"
+        [[ -n "$SETTINGS_WINDOW_ID" ]] && break
+        sleep 0.25
+    done
+    [[ -n "$SETTINGS_WINDOW_ID" ]] \
+        || die "Browse all models did not open anything — it is a dismiss button again (#1653)"
+
+    # 2. On the models tab, not merely "Settings somewhere". The wizard's own
+    #    copy promises the catalogue; landing on the user's last-used tab is a
+    #    different bug wearing the same green check.
+    wait_settings_stable "$OUT/ba-settings.json" Settings.Models.ShowAllModelsToggle
+    log "  landed on Model Management"
+
+    # 3. The wizard is still standing. "Show me the options" is not "I give
+    #    up": closing Settings has to put the user back on their pick.
+    see_main "$OUT/ba-after.json"
+    jq -e '.data.ui_elements[]? | select(.identifier == "Quickstart.BrowseAll")' \
+        "$OUT/ba-after.json" >/dev/null \
+        || die "the wizard was dismissed — browsing must not discard the user's selection (#1653)"
+    log "  wizard still up behind Settings"
+    cleanup_persona
+}
+
 flow_catalog_integrity() {
     # A model that cannot chat must never be offered as one.
     #
@@ -775,6 +832,7 @@ case "$FLOW" in
     update-state) flow_update_state ;;
     no-dead-controls) flow_no_dead_controls ;;
     catalog-integrity) flow_catalog_integrity ;;
+    browse-all-destination) flow_browse_all_destination ;;
     all)
         flow_fresh_install
         flow_settings_persistence
@@ -786,6 +844,7 @@ case "$FLOW" in
         flow_update_state
         flow_no_dead_controls
         flow_catalog_integrity
+        flow_browse_all_destination
         ;;
     *) die "unknown flow: $FLOW" ;;
 esac

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -797,23 +797,46 @@ flow_browse_all_destination() {
     log "  landed on Model Management"
 
     # 3. Settings is actually USABLE, not merely present. A window opened
-    #    behind a modal sheet still publishes its whole subtree to AX, so
-    #    every assertion above would pass on a window the user cannot touch.
-    #    Only driving one of its controls tells them apart.
-    press "$OUT/ba-settings.json" Settings.Category.appearance "$OUT/ba-settings-drive.json" \
-        || die "the Settings window opened but does not accept input — it is behind the wizard sheet"
-    log "  Settings accepts input"
+    #    behind a modal sheet still publishes its whole subtree to AX, and
+    #    AXUIElementPerformAction reaches it there too — so neither the tree
+    #    nor an AXPress can tell a usable window from a trapped one. Focus it,
+    #    click it the way a person would, and require the panel to change.
+    pb window focus --window-id "$SETTINGS_WINDOW_ID" --json > "$OUT/ba-focus.json" \
+        || die "could not focus the Settings window the button opened"
+    local cx cy
+    read -r cx cy < <(jq -r '.data.ui_elements[]
+                             | select(.identifier == "Settings.Category.privacy")
+                             | [(.bounds.x + .bounds.width / 2), (.bounds.y + .bounds.height / 2)]
+                             | @tsv' "$OUT/ba-settings.json")
+    [[ -n "$cx" && -n "$cy" ]] || die "Settings.Category.privacy has no bounds to click"
+    pb click --coords "$cx,$cy" --global-coords --app "PID:$APP_PID" --json > "$OUT/ba-click.json" \
+        || die "the Settings window did not accept a click — it is behind the wizard sheet"
+    # A real click that changed nothing is the same failure as no click at all,
+    # so require the panel's own control to appear, not merely that the press
+    # returned success.
+    wait_settings_stable "$OUT/ba-privacy.json" Settings.Privacy.TelemetryToggle
+    log "  Settings is focused and responds to a real click"
 
     # 4. Close it, the way the user would, and land back on the wizard with
     #    the same pick. This is the half the bug actually broke.
-    pb menu click --app "PID:$APP_PID" --item 'Close' --json > "$OUT/ba-close.json" \
+    #
+    #    Scoped to the window, not the app: ``menu click --app`` routes Close
+    #    to whichever window is key, which on a bad day is the main one — and
+    #    then every assertion below runs against a wizard that was never
+    #    actually returned to.
+    pb menu click --window-id "$SETTINGS_WINDOW_ID" --item 'Close' --json > "$OUT/ba-close.json" \
         || die "could not close the Settings window"
+    local closed=0
     for ((i=0; i<40; i++)); do
         pb list windows --app "PID:$APP_PID" --json > "$OUT/ba-windows-after.json"
-        jq -e '[.data.windows[]? | select(.title == "Settings")] | length == 0' \
-            "$OUT/ba-windows-after.json" >/dev/null && break
+        if jq -e '[.data.windows[]? | select(.title == "Settings")] | length == 0' \
+            "$OUT/ba-windows-after.json" >/dev/null; then closed=1; break; fi
         sleep 0.25
     done
+    # Not a cosmetic check: with Settings still open, the app-wide AX dump
+    # below carries the wizard AND the Settings tree, so the round-trip
+    # assertion would pass without any round trip having happened.
+    [[ "$closed" == 1 ]] || die "the Settings window did not close — the round trip below would be vacuous"
 
     wait_identifier Quickstart.BrowseAll "$OUT/ba-after.json"
     jq -e --arg id "$chosen" '.data.ui_elements[]? | select(.identifier == $id) | select(.selected == true)' \

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -731,15 +731,16 @@ flow_no_dead_controls() {
 }
 
 flow_browse_all_destination() {
-    # An advertised destination must actually be one.
+    # An advertised destination must actually be one, and must not cost the
+    # user what they already chose.
     #
     # "Browse all models →" on Quickstart step 2 was implemented as one line
     # that set a dismiss flag (#1653). It was present, enabled, correctly
     # labelled and carried an AXIdentifier, so every structural check passed —
     # the wizard simply vanished, the user's pick was discarded, and they
     # landed on whatever the alphabetical fallback chose (a 7.6 GB download
-    # nobody asked for). Nothing here can be asserted from a tree dump alone:
-    # this flow PRESSES the control and asserts where the user ends up.
+    # nobody asked for). None of that is visible in a tree dump. This flow
+    # presses the control and drives the whole round trip.
     start_persona browse-all-destination
 
     # Only the consent sheet — the wizard has to stay up, it is the subject.
@@ -756,7 +757,25 @@ flow_browse_all_destination() {
         || die "Quickstart.GetStarted is not pressable"
     wait_identifier Quickstart.BrowseAll "$OUT/ba-chooser.json"
 
-    press "$OUT/ba-chooser.json" Quickstart.BrowseAll "$OUT/ba-press.json" \
+    # Choose a card that is NOT the default. The bug discarded the user's
+    # selection; asserting the survival of a pick nobody made proves nothing,
+    # so make one, and make it a different one.
+    local chosen
+    chosen="$(jq -r '[.data.ui_elements[]?
+                      | select((.identifier // "") | startswith("Quickstart.Choice."))
+                      | select(.selected != true)][0].identifier // empty' \
+              "$OUT/ba-chooser.json")"
+    [[ -n "$chosen" ]] || die "the chooser offers no unselected model card to pick"
+    press "$OUT/ba-chooser.json" "$chosen" "$OUT/ba-choose.json" \
+        || die "$chosen is not pressable"
+    sleep 0.5
+    see_main "$OUT/ba-chosen.json"
+    jq -e --arg id "$chosen" '.data.ui_elements[]? | select(.identifier == $id) | select(.selected == true)' \
+        "$OUT/ba-chosen.json" >/dev/null \
+        || die "pressing $chosen did not select it — the chooser cannot record a choice"
+    log "  chose $chosen"
+
+    press "$OUT/ba-chosen.json" Quickstart.BrowseAll "$OUT/ba-press.json" \
         || die "Quickstart.BrowseAll is not pressable"
 
     # 1. It opened the catalogue. `open_settings` drives the menu, so assert
@@ -777,13 +796,30 @@ flow_browse_all_destination() {
     wait_settings_stable "$OUT/ba-settings.json" Settings.Models.ShowAllModelsToggle
     log "  landed on Model Management"
 
-    # 3. The wizard is still standing. "Show me the options" is not "I give
-    #    up": closing Settings has to put the user back on their pick.
-    see_main "$OUT/ba-after.json"
-    jq -e '.data.ui_elements[]? | select(.identifier == "Quickstart.BrowseAll")' \
+    # 3. Settings is actually USABLE, not merely present. A window opened
+    #    behind a modal sheet still publishes its whole subtree to AX, so
+    #    every assertion above would pass on a window the user cannot touch.
+    #    Only driving one of its controls tells them apart.
+    press "$OUT/ba-settings.json" Settings.Category.appearance "$OUT/ba-settings-drive.json" \
+        || die "the Settings window opened but does not accept input — it is behind the wizard sheet"
+    log "  Settings accepts input"
+
+    # 4. Close it, the way the user would, and land back on the wizard with
+    #    the same pick. This is the half the bug actually broke.
+    pb menu click --app "PID:$APP_PID" --item 'Close' --json > "$OUT/ba-close.json" \
+        || die "could not close the Settings window"
+    for ((i=0; i<40; i++)); do
+        pb list windows --app "PID:$APP_PID" --json > "$OUT/ba-windows-after.json"
+        jq -e '[.data.windows[]? | select(.title == "Settings")] | length == 0' \
+            "$OUT/ba-windows-after.json" >/dev/null && break
+        sleep 0.25
+    done
+
+    wait_identifier Quickstart.BrowseAll "$OUT/ba-after.json"
+    jq -e --arg id "$chosen" '.data.ui_elements[]? | select(.identifier == $id) | select(.selected == true)' \
         "$OUT/ba-after.json" >/dev/null \
-        || die "the wizard was dismissed — browsing must not discard the user's selection (#1653)"
-    log "  wizard still up behind Settings"
+        || die "the wizard came back without the user's selection — browsing must not discard it (#1653)"
+    log "  back on the wizard, $chosen still selected"
     cleanup_persona
 }
 

--- a/apps/rapid-mac/scripts/rapid-ax.swift
+++ b/apps/rapid-mac/scripts/rapid-ax.swift
@@ -72,6 +72,14 @@ func walk(_ element: AXUIElement, depth: Int) {
     if let enabled = attribute(element, kAXEnabledAttribute as CFString) as? NSNumber {
         record["enabled"] = enabled.boolValue
     }
+    // Which of several equal-looking things is the CHOSEN one. Without it a
+    // flow can see that the model cards exist and are enabled but not which
+    // one the user picked, so "the wizard silently discarded your selection"
+    // is invisible to every assertion the harness can make (#1653). Same rule
+    // as AXEnabled: absent on most elements, recorded only when published.
+    if let selected = attribute(element, kAXSelectedAttribute as CFString) as? NSNumber {
+        record["selected"] = selected.boolValue
+    }
     if let title = string(element, kAXTitleAttribute as CFString), !title.isEmpty { record["title"] = title }
     if let description = string(element, kAXDescriptionAttribute as CFString), !description.isEmpty { record["description"] = description }
     if let help = string(element, kAXHelpAttribute as CFString), !help.isEmpty { record["help"] = help }


### PR DESCRIPTION
Closes #1653.

The whole implementation of "Browse all models →" was one line that set a
session dismiss flag. Nothing navigated, presented a sheet, or opened Settings
— the link had no destination at all. Clicking it made the wizard vanish, and
because the selection lived in the wizard, the user's pick (LFM2.5 · 1.2B,
563 MB) went with it: they landed on the chat surface pinned to whatever the
alphabetical fallback chose, staring at a 7.6 GB download they never asked for.

The closure was shared with the Esc / swipe-down path, with a comment recording
the intent: both mean "let me look around first". That is the defect. Skipping
accepts whatever the app picks; browsing is a request to choose. They differ in
exactly the thing that matters.

So the two intents are separated. The dismiss closure is now named `onSkip` and
has exactly one caller — "Skip for now" on step 1, the app's one genuine leave-
onboarding control. Browsing routes through `SettingsRouter` to Model
Management, using the deep-link path the failure card already used, and leaves
the wizard standing behind the Settings window: closing Settings puts the user
back where they were, with the model they had already chosen.

The failure card's "or browse all models →" shared the same dead closure and is
fixed with it — it is offered precisely when the user's chosen model failed,
which is the moment they most need to pick a different one.

## Tests

The issue's sharpest point is that this passed everything we run: the button was
present, enabled, correctly labelled and carried `Quickstart.BrowseAll`, so the
AX structural baselines recorded a perfectly healthy control. A tree dump cannot
tell a working button from a decorative one.

- `gui-golden-flows.sh browse-all-destination` — a new flow that PRESSES the
  real control on the real wizard and asserts where the user ends up: a Settings
  window opened, it is on Model Management (not merely "Settings somewhere"),
  and the wizard is still up. Each assertion names the bug it would catch.
- `QuickstartBrowseAllDestinationTests` — pins the wiring in source, where the
  next person edits that call site, plus the router's stage-then-open ordering
  that a first-run user (who has no last-used tab) depends on.

