### PR TITLE
fix(rapid-mac): benchmark the loaded model

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Server/BenchmarkRunner.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/BenchmarkRunner.swift
@@ -1,26 +1,22 @@
 import Foundation
 
-/// Runs the bundled `rapid-mlx bench` for the in-app "Speed on this Mac"
-/// card, and drives the community-leaderboard submission.
+/// Measures the already-loaded desktop server for the in-app "Speed on this
+/// Mac" card, and drives the community-leaderboard submission.
 ///
-/// Two paths, both delegating to the proven CLI so the app never
-/// reimplements the benchmark or the submission wire format:
-///   * ``run`` → `rapid-mlx bench <alias>` (freeform), parses the
-///     `Throughput: N tok/s` summary line for display.
+/// Two deliberately different paths:
+///   * ``run`` sends a warm-up plus one measured OpenAI-compatible request to
+///     the server the user is already chatting with. It never starts another
+///     process or loads a second copy of the model.
 ///   * ``submit`` → `rapid-mlx bench <alias> --submit` (the
 ///     standardized B=1 community runner that POSTs to
 ///     rapidmlx.com/api/benchmarks). The CLI asks for a y/N consent on
 ///     stdin; the app shows its OWN consent first, then pipes "y" so the
 ///     user only answers once.
 ///
-/// Both paths are multi-minute for a large model — a cold model load
-/// plus (for submit) a full standardized short+long workload. The CLI
-/// emits little incremental output, so a plain spinner reads as "hung".
-/// We stream the child's stdout to advance a coarse stage label, run a
-/// one-second ticker for a live elapsed clock, and show a size-derived
-/// ETA so the user knows roughly how long to wait. The elapsed clock is
-/// the source of truth; the ETA is an estimate that gracefully degrades
-/// to "almost there…" once a slow Mac blows past it.
+/// The loaded-model measurement is normally seconds; leaderboard submission
+/// can still take minutes because it intentionally runs the standardized
+/// workload. Both keep a live elapsed clock, while submission also streams the
+/// child's stdout to advance its stage label.
 @MainActor
 @Observable
 final class BenchmarkRunner {
@@ -140,9 +136,8 @@ final class BenchmarkRunner {
 
     private var ticker: Task<Void, Never>?
     /// The in-flight run/submit. Owned here (not by the view's button) so
-    /// closing the sheet or starting another run can cancel it — which
-    /// terminates the underlying `rapid-mlx bench` child so a closed card
-    /// can't leave a GPU-bound benchmark running or overlap two runs.
+    /// closing the sheet or starting another run can cancel either the live
+    /// HTTP request or the submission child, preventing overlapping work.
     private var inFlight: Task<Void, Never>?
 
     /// Public leaderboard the submission lands on.
@@ -159,13 +154,13 @@ final class BenchmarkRunner {
     // MARK: - Lifecycle / cancellation
 
     /// Start a benchmark, owning the task so the view can cancel it.
-    /// Supersedes any in-flight run (which terminates its child process).
+    /// Supersedes any in-flight request or submission process.
     /// The generation is allocated *synchronously here* (not inside the
     /// task body): a task cancelled before it starts still runs its body,
     /// so binding "who is current" at launch time — not execution time —
     /// is what lets the stale task's top guard reject it before it mutates
     /// any state (codex round-3 MAJOR).
-    func launchRun(binary: URL, alias: String, chip: String) {
+    func launchRun(baseURL: URL, bearer: String, alias: String, chip: String) {
         inFlight?.cancel()
         // Clear a superseded submit's transient phase so it can't linger
         // as a stale "Submitting…" behind the new run (UI-gated today, but
@@ -174,7 +169,9 @@ final class BenchmarkRunner {
         runGeneration &+= 1
         let gen = runGeneration
         inFlight = Task { [weak self] in
-            await self?.run(binary: binary, alias: alias, chip: chip, generation: gen)
+            await self?.run(
+                baseURL: baseURL, bearer: bearer, alias: alias,
+                chip: chip, generation: gen)
         }
     }
 
@@ -189,11 +186,10 @@ final class BenchmarkRunner {
         }
     }
 
-    /// Cancel the in-flight run/submit — terminates the `rapid-mlx bench`
-    /// child. Call from the view's `.onDisappear` so a closed card never
-    /// leaves a benchmark burning the GPU in the background. Bumping the
-    /// generation also neutralizes any task that hasn't run its top guard
-    /// yet.
+    /// Cancel the in-flight HTTP measurement or submission child. Call from
+    /// the view's `.onDisappear` so a closed card never leaves GPU work in the
+    /// background. Bumping the generation also neutralizes any task that has
+    /// not run its top guard yet.
     func cancelActive() {
         inFlight?.cancel()
         inFlight = nil
@@ -213,7 +209,10 @@ final class BenchmarkRunner {
 
     // MARK: - Benchmark (display)
 
-    func run(binary: URL, alias: String, chip: String, generation gen: UInt64) async {
+    func run(
+        baseURL: URL, bearer: String, alias: String, chip: String,
+        generation gen: UInt64
+    ) async {
         // Superseded/cancelled before we even started, or another run has
         // already advanced past us: do nothing, touch no state.
         guard !Task.isCancelled, runGeneration == gen else { return }
@@ -221,53 +220,136 @@ final class BenchmarkRunner {
             phase = .failed("Choose a model first.")
             return
         }
-        // Pre-load memory guard (#324). `rapid-mlx bench` spawns its own
-        // process that loads the full model — a *second* resident copy
-        // if the app's sidecar already has this alias loaded. Projecting
-        // the footprint onto live `usedBytes` (which already includes the
-        // first copy) catches that 2× case, so we refuse to spawn a bench
-        // that would push unified memory past the kernel-panic line.
-        if let snapshot = MemoryProbe.snapshot(),
-           ModelSizing.memorySafety(
-               footprint: ModelSizing.estimate(alias: alias),
-               usedBytes: snapshot.usedBytes,
-               totalBytes: snapshot.totalBytes
-           ) == .unsafe {
-            phase = .failed(
-                "Not enough free memory to benchmark \(alias) right now — it loads a second copy of the model on top of what's already running. Close some apps or restart the model, then try again.")
-            return
-        }
         phase = .running
         beginProgress(gen, kind: .benchmark, alias: alias)
         defer { endProgress(gen) }
 
-        let output = await runStreaming(
-            binary: binary, args: ["bench", alias], stdinLine: nil, generation: gen)
+        progress?.observe("Running benchmark against the loaded model")
+        let output = await Self.measureLoadedModel(
+            baseURL: baseURL, bearer: bearer, alias: alias)
         // Cancelled (sheet closed) or superseded (another run bumped the
-        // generation): the child was terminated and the output is a
+        // generation): the request was cancelled and the output is a
         // spurious failure — leave the UI state untouched rather than
         // flashing an error on a dead card or clobbering the newer run.
         guard !Task.isCancelled, runGeneration == gen else { return }
         switch output {
         case .failure(let msg):
             phase = .failed(msg)
-        case .success(let text):
-            guard let result = Self.parse(text, alias: alias, chip: chip) else {
-                phase = .failed("Couldn't read the benchmark result.")
-                return
-            }
-            // A zero/garbage throughput means the run produced no tokens
-            // (e.g. the model errored mid-generation but the summary line
-            // still printed "0.00 tok/s" and the process exited cleanly).
-            // Never surface a confident "0 tokens / second" — and never
-            // let a zero reach the community leaderboard.
-            guard result.throughputTPS > 0 else {
+        case .success(let measurement):
+            guard measurement.tokensPerSecond > 0 else {
                 phase = .failed(
                     "The benchmark didn't produce a usable number — the model generated no tokens. Try again, or restart the model.")
                 return
             }
-            phase = .done(result)
+            phase = .done(BenchmarkResult(
+                alias: alias,
+                chip: chip,
+                throughputTPS: measurement.tokensPerSecond,
+                tokensPerSecond: measurement.tokensPerSecond
+            ))
         }
+    }
+
+    struct LoadedMeasurement: Equatable, Sendable {
+        let completionTokens: Int
+        let elapsedSeconds: TimeInterval
+
+        var tokensPerSecond: Double {
+            guard completionTokens > 0, elapsedSeconds > 0 else { return 0 }
+            return Double(completionTokens) / elapsedSeconds
+        }
+    }
+
+    private enum LoadedRunOutput: Sendable {
+        case success(LoadedMeasurement)
+        case failure(String)
+    }
+
+    /// Benchmark the model already resident in the desktop sidecar. A short
+    /// warm-up avoids charging one-time Metal compilation to the displayed
+    /// decode speed; the measured request is intentionally single-user (B=1),
+    /// matching what somebody experiences in Chat.
+    private nonisolated static func measureLoadedModel(
+        baseURL: URL, bearer: String, alias: String
+    ) async -> LoadedRunOutput {
+        let config = URLSessionConfiguration.ephemeral
+        config.timeoutIntervalForRequest = 180
+        config.timeoutIntervalForResource = 180
+        let session = URLSession(configuration: config)
+
+        do {
+            _ = try await completion(
+                session: session, baseURL: baseURL, bearer: bearer,
+                alias: alias, maxTokens: 8,
+                prompt: "Reply with exactly eight short words.")
+            let start = ContinuousClock.now
+            let tokens = try await completion(
+                session: session, baseURL: baseURL, bearer: bearer,
+                alias: alias, maxTokens: 128,
+                prompt: "Write exactly 128 words describing a calm walk through a forest. Do not use headings or lists.")
+            let elapsed = start.duration(to: .now)
+            let seconds = Double(elapsed.components.seconds)
+                + Double(elapsed.components.attoseconds) / 1e18
+            return .success(LoadedMeasurement(
+                completionTokens: tokens, elapsedSeconds: seconds))
+        } catch is CancellationError {
+            return .failure("The benchmark was cancelled.")
+        } catch {
+            return .failure(
+                "The running model couldn't complete the speed test. Make sure it is still running, then try again. (\(error.localizedDescription))")
+        }
+    }
+
+    private nonisolated static func completion(
+        session: URLSession, baseURL: URL, bearer: String, alias: String,
+        maxTokens: Int, prompt: String
+    ) async throws -> Int {
+        let request = try loadedBenchmarkRequest(
+            baseURL: baseURL, bearer: bearer, alias: alias,
+            maxTokens: maxTokens, prompt: prompt)
+        let (data, response) = try await session.data(for: request)
+        guard let http = response as? HTTPURLResponse,
+              (200..<300).contains(http.statusCode) else {
+            let status = (response as? HTTPURLResponse)?.statusCode ?? 0
+            throw NSError(
+                domain: "RapidBenchmark", code: status,
+                userInfo: [NSLocalizedDescriptionKey: "Local server returned HTTP \(status)."])
+        }
+        return try loadedCompletionTokens(from: data)
+    }
+
+    nonisolated static func loadedBenchmarkRequest(
+        baseURL: URL, bearer: String, alias: String,
+        maxTokens: Int, prompt: String
+    ) throws -> URLRequest {
+        let url = baseURL.appendingPathComponent("chat/completions")
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.timeoutInterval = 180
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        if !bearer.isEmpty {
+            request.setValue("Bearer \(bearer)", forHTTPHeaderField: "Authorization")
+        }
+        request.httpBody = try JSONSerialization.data(withJSONObject: [
+            "model": alias,
+            "messages": [["role": "user", "content": prompt]],
+            "max_tokens": maxTokens,
+            "temperature": 0,
+            "stream": false,
+        ])
+        return request
+    }
+
+    nonisolated static func loadedCompletionTokens(from data: Data) throws -> Int {
+        guard let root = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let usage = root["usage"] as? [String: Any],
+              let completionTokens = usage["completion_tokens"] as? Int,
+              completionTokens > 0 else {
+            throw NSError(
+                domain: "RapidBenchmark", code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "The local server returned no completion-token count."])
+        }
+        return completionTokens
     }
 
     // MARK: - Submit (community leaderboard)
@@ -363,49 +445,16 @@ final class BenchmarkRunner {
         progress = nil
     }
 
-    /// Coarse total-duration estimate. Load time is dominated by the
-    /// weight bytes (disk read + Metal upload) and generation is a fixed
-    /// token budget, so both scale roughly with parameter count. These
-    /// constants are a UX ballpark calibrated against the bundled models
-    /// on Apple Silicon (~4B ≈ 1 min, ~12B ≈ 2 min, ~30B ≈ 4–5 min); the
-    /// live elapsed clock, not this number, is the source of truth. The
-    /// submit path re-runs the full standardized short+long workload, so
-    /// it takes ~1.6× the freeform pass. Returns ``nil`` for a custom
-    /// alias with no parseable size.
+    /// Coarse total-duration estimate. The loaded-model path has no weight
+    /// load and a fixed 128-token ceiling, so a small constant is more honest
+    /// than parameter-scaled cold-start time. Submission still loads and runs
+    /// the standardized workload, so it scales with model size.
     nonisolated static func etaSeconds(alias: String, kind: Progress.Kind) -> Int? {
+        if kind == .benchmark { return 30 }
         let footprint = ModelSizing.estimate(alias: alias)
         guard let params = footprint.paramsBillions else { return nil }
         let base = 20.0 + params * 8.0
-        let mult = kind == .submit ? 1.6 : 1.0
-        return Int((base * mult).rounded())
-    }
-
-    // MARK: - Parsing
-
-    /// Pulls the throughput + tokens/second out of the freeform bench
-    /// summary. Format (rapid-mlx bench):
-    ///     Tokens/second: 781.55
-    ///     Throughput: 836.26 tok/s
-    static func parse(_ text: String, alias: String, chip: String) -> BenchmarkResult? {
-        let throughput = firstDouble(in: text, pattern: #"Throughput:\s*([\d.]+)\s*tok"#)
-        let tokensPerSec = firstDouble(in: text, pattern: #"Tokens/second:\s*([\d.]+)"#)
-        // Prefer throughput (end-to-end); fall back to tokens/second.
-        guard let primary = throughput ?? tokensPerSec else { return nil }
-        return BenchmarkResult(
-            alias: alias,
-            chip: chip,
-            throughputTPS: primary,
-            tokensPerSecond: tokensPerSec ?? primary
-        )
-    }
-
-    private static func firstDouble(in text: String, pattern: String) -> Double? {
-        guard let re = try? NSRegularExpression(pattern: pattern) else { return nil }
-        let range = NSRange(text.startIndex..., in: text)
-        guard let m = re.firstMatch(in: text, range: range),
-              m.numberOfRanges > 1,
-              let r = Range(m.range(at: 1), in: text) else { return nil }
-        return Double(text[r])
+        return Int((base * 1.6).rounded())
     }
 
     private static func firstErrorLine(_ text: String) -> String? {

--- a/apps/rapid-mac/Sources/Rapid/UI/BenchmarkView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/BenchmarkView.swift
@@ -16,15 +16,20 @@ struct BenchmarkView: View {
     @State private var showFailureDetails = false
 
     let binary: URL?
+    let baseURL: URL
+    let bearer: String
     let alias: String
     let hardware: MacHardware
     var onClose: () -> Void
 
     init(
-        binary: URL?, alias: String, hardware: MacHardware,
+        binary: URL?, baseURL: URL = ChatStreamClient.defaultBaseURL,
+        bearer: String = "", alias: String, hardware: MacHardware,
         onClose: @escaping () -> Void, runner: BenchmarkRunner = BenchmarkRunner()
     ) {
         self.binary = binary
+        self.baseURL = baseURL
+        self.bearer = bearer
         self.alias = alias
         self.hardware = hardware
         self.onClose = onClose
@@ -83,13 +88,15 @@ struct BenchmarkView: View {
                 .font(.system(size: 40))
                 .foregroundStyle(RapidTheme.brandAmber)
                 .padding(.top, 24)
-            Text("Run a quick benchmark to see \(displayAlias)'s tokens per second on your \(hardware.brandString).")
+            Text("Test the \(displayAlias) model already running on your \(hardware.brandString) — no second copy is loaded.")
                 .font(.callout)
                 .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)
                 .fixedSize(horizontal: false, vertical: true)
             Button {
-                runner.launchRun(binary: binary ?? URL(fileURLWithPath: "/"), alias: alias, chip: hardware.brandString)
+                runner.launchRun(
+                    baseURL: baseURL, bearer: bearer,
+                    alias: alias, chip: hardware.brandString)
             } label: {
                 Label("Benchmark this Mac", systemImage: "play.fill")
                     .frame(maxWidth: .infinity)
@@ -97,7 +104,8 @@ struct BenchmarkView: View {
             .controlSize(.large)
             .buttonStyle(.borderedProminent)
             .tint(RapidTheme.amber)
-            .disabled(binary == nil || alias.isEmpty)
+            .disabled(alias.isEmpty)
+            .accessibilityIdentifier("Benchmark.RunLoadedModel")
         }
         .frame(maxWidth: .infinity)
     }
@@ -118,7 +126,7 @@ struct BenchmarkView: View {
         .frame(maxWidth: .infinity)
     }
 
-    /// Live progress used by both the freeform benchmark and the submit
+    /// Live progress used by both the loaded-model benchmark and the submit
     /// re-bench: a determinate bar toward the ETA (indeterminate when the
     /// model size is unknown), the current stage, and an elapsed + ETA
     /// caption so a multi-minute run never reads as frozen.
@@ -163,6 +171,8 @@ struct BenchmarkView: View {
                 Text("tokens / second")
                     .font(.callout).foregroundStyle(.secondary)
             }
+            .accessibilityElement(children: .combine)
+            .accessibilityIdentifier("Benchmark.LoadedModelResult")
             .padding(.top, 12)
             .frame(maxWidth: .infinity)
 
@@ -195,7 +205,9 @@ struct BenchmarkView: View {
                 .buttonStyle(.borderedProminent)
                 .tint(RapidTheme.brand)
                 Button("Run again") {
-                    runner.launchRun(binary: binary ?? URL(fileURLWithPath: "/"), alias: alias, chip: hardware.brandString)
+                    runner.launchRun(
+                        baseURL: baseURL, bearer: bearer,
+                        alias: alias, chip: hardware.brandString)
                 }
                 .buttonStyle(.plain)
                 .font(.callout)
@@ -258,12 +270,10 @@ struct BenchmarkView: View {
 
     /// Failure state.
     ///
-    /// ``BenchmarkRunner`` returns the last four lines of the child's
-    /// combined stdout+stderr on a non-zero exit, which for a Python
-    /// sidecar is a raw traceback tail. Rendering that as the primary
-    /// message told the user nothing actionable and looked like a
-    /// crash. The raw text is still preserved — it just moves behind a
-    /// collapsed disclosure, and a classified sentence takes the front.
+    /// Runner details can be a local HTTP error or (for leaderboard publish)
+    /// a child-process traceback tail. Rendering either as the primary message
+    /// tells the user little, so raw text stays behind a disclosure and a
+    /// classified sentence takes the front.
     private func failedState(_ msg: String) -> some View {
         let diagnosis = BenchmarkView.classifyFailure(msg)
         return VStack(spacing: RapidTheme.Space.md) {
@@ -281,7 +291,8 @@ struct BenchmarkView: View {
 
             Button("Try again") {
                 runner.launchRun(
-                    binary: binary ?? URL(fileURLWithPath: "/"),
+                    baseURL: baseURL,
+                    bearer: bearer,
                     alias: alias,
                     chip: hardware.brandString
                 )
@@ -321,8 +332,8 @@ struct BenchmarkView: View {
     /// in one place rather than a new branch in the view.
     ///
     /// ``showsDetails`` is false for messages we authored ourselves
-    /// (they are already the explanation) and true for anything that
-    /// came out of the child process.
+    /// (they are already the explanation) and true for raw transport/process
+    /// details.
     static func classifyFailure(_ raw: String) -> (headline: String, showsDetails: Bool) {
         let lowered = raw.lowercased()
 

--- a/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
@@ -237,14 +237,16 @@ struct ChatView: View {
                 host: "127.0.0.1",
                 port: server.activePort,
                 bearer: server.activeBearer ?? "",
-                alias: alias,
+                alias: server.servingAlias ?? alias,
                 onClose: { showConnectTools = false }
             )
         }
         .sheet(isPresented: $showBenchmark) {
             BenchmarkView(
                 binary: server.binaryPath,
-                alias: alias,
+                baseURL: ChatStreamClient.loopbackURL(port: server.activePort),
+                bearer: server.activeBearer ?? "",
+                alias: server.servingAlias ?? alias,
                 hardware: MacHardware.detect(),
                 onClose: { showBenchmark = false }
             )
@@ -408,6 +410,7 @@ struct ChatView: View {
                 } label: {
                     Label("Speed on this Mac", systemImage: "gauge.with.dots.needle.67percent")
                 }
+                .accessibilityIdentifier("ChatView.SpeedOnThisMac")
                 // Enablement is derived from live server state, so the
                 // button flips to enabled on its own the moment the
                 // model reaches .ready — no user action, no re-render

--- a/apps/rapid-mac/Tests/RapidTests/BenchmarkProgressTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/BenchmarkProgressTests.swift
@@ -60,21 +60,22 @@ struct BenchmarkProgressTests {
 
     // MARK: - ETA estimate
 
-    @Test("ETA scales with model size and is larger for submit")
+    @Test("Loaded-model ETA is fixed; submit still scales with size")
     func etaScalesWithSize() {
         let small = BenchmarkRunner.etaSeconds(alias: "qwen3.5-4b", kind: .benchmark)
         let big = BenchmarkRunner.etaSeconds(alias: "qwen3.6-27b-8bit", kind: .benchmark)
-        #expect(small != nil && big != nil)
-        #expect((big ?? 0) > (small ?? 0), "a 27B should take longer than a 4B")
+        #expect(small == 30)
+        #expect(big == 30)
 
         let free = BenchmarkRunner.etaSeconds(alias: "gemma-4-12b", kind: .benchmark)!
         let submit = BenchmarkRunner.etaSeconds(alias: "gemma-4-12b", kind: .submit)!
         #expect(submit > free, "submit re-runs the full standardized workload")
     }
 
-    @Test("ETA is nil for a custom alias with no parseable size")
+    @Test("Only submit needs a parseable model size for ETA")
     func etaNilForUnknown() {
-        #expect(BenchmarkRunner.etaSeconds(alias: "my-custom-model", kind: .benchmark) == nil)
+        #expect(BenchmarkRunner.etaSeconds(alias: "my-custom-model", kind: .benchmark) == 30)
+        #expect(BenchmarkRunner.etaSeconds(alias: "my-custom-model", kind: .submit) == nil)
     }
 
     // MARK: - Caption + bar fraction

--- a/apps/rapid-mac/Tests/RapidTests/LoadedModelBenchmarkTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/LoadedModelBenchmarkTests.swift
@@ -1,0 +1,48 @@
+import Foundation
+import Testing
+@testable import Rapid
+
+@Suite("Loaded-model speed test")
+struct LoadedModelBenchmarkTests {
+    @Test("Speed test targets the current authenticated server without a model-loader command")
+    func currentServerRequest() throws {
+        let request = try BenchmarkRunner.loadedBenchmarkRequest(
+            baseURL: URL(string: "http://127.0.0.1:8123/v1")!,
+            bearer: "test-secret",
+            alias: "lfm2.5-8b-a1b-4bit",
+            maxTokens: 128,
+            prompt: "measure me"
+        )
+
+        #expect(request.url?.absoluteString == "http://127.0.0.1:8123/v1/chat/completions")
+        #expect(request.httpMethod == "POST")
+        #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer test-secret")
+        let bodyData = try #require(request.httpBody)
+        let body = try #require(
+            JSONSerialization.jsonObject(with: bodyData) as? [String: Any])
+        #expect(body["model"] as? String == "lfm2.5-8b-a1b-4bit")
+        #expect(body["max_tokens"] as? Int == 128)
+        #expect(body["stream"] as? Bool == false)
+    }
+
+    @Test("Displayed speed uses completion tokens over measured wall time")
+    func completionSpeed() {
+        let measurement = BenchmarkRunner.LoadedMeasurement(
+            completionTokens: 120, elapsedSeconds: 4)
+        #expect(measurement.tokensPerSecond == 30)
+    }
+
+    @Test("OpenAI usage supplies the measured completion count")
+    func usageParsing() throws {
+        let data = Data(#"{"usage":{"prompt_tokens":12,"completion_tokens":96,"total_tokens":108}}"#.utf8)
+        #expect(try BenchmarkRunner.loadedCompletionTokens(from: data) == 96)
+    }
+
+    @Test("Missing completion usage is rejected instead of showing zero")
+    func missingUsageRejected() {
+        let data = Data(#"{"choices":[]}"#.utf8)
+        #expect(throws: Error.self) {
+            _ = try BenchmarkRunner.loadedCompletionTokens(from: data)
+        }
+    }
+}

--- a/apps/rapid-mac/docs/gui-golden-flows.md
+++ b/apps/rapid-mac/docs/gui-golden-flows.md
@@ -13,14 +13,17 @@ Rapid-MLX Desktop app without loading a real model.
 6. a memory-constrained user can see and select an honestly labelled sub-1B
    fallback instead of being sent back to a chooser whose smallest visible
    model is the one that just failed the live-memory guard.
+7. “Speed on this Mac” benchmarks the model already resident in the desktop
+   server: one server start, then one warm-up plus one measured request, with
+   no second model process and no duplicate weight load.
 
 **Invariants** — properties that must hold, not paths a user walks. These were
 added after a release where every escaped defect landed on a surface no journey
 covered, and each one names the defect it would have caught:
 
-7. `update-state` — Settings → App must name the version the app actually is.
-8. `no-dead-controls` — every Settings panel must expose controls of its own.
-9. `catalog-integrity` — a model that cannot chat must never be offered as one.
+8. `update-state` — Settings → App must name the version the app actually is.
+9. `no-dead-controls` — every Settings panel must expose controls of its own.
+10. `catalog-integrity` — a model that cannot chat must never be offered as one.
 
 The distinction matters. A journey answers *"can someone do this?"*; an
 invariant answers *"is this still true everywhere?"*. The three defects below
@@ -150,6 +153,22 @@ the original live-memory snapshot against the fallback footprint and exposes
 promise or a warning loop; **Cancel** still returns to the chooser where the
 low-memory category remains visible.
 
+### Loaded-model speed test
+
+`loaded-model-benchmark` pins the resource contract behind **Speed on this
+Mac**. The action is only available after the selected model is ready. It then
+reuses that server's live loopback port and bearer, sends a short warm-up and an
+up-to-128-token measured request, and calculates completion tokens per wall
+second. It must not invoke `rapid-mlx bench`, start another server, or load a
+second copy of the weights.
+
+The deterministic fake sidecar records the evidence the UI alone cannot show:
+exactly one `server_started` event and exactly two `benchmark_request` events.
+The flow also waits for `Benchmark.LoadedModelResult`, proving the number made
+it back through the real sheet. This would have caught the old implementation,
+which rejected an 8B speed test for lack of memory precisely because it tried
+to load an unnecessary second 8B copy.
+
 ## Run
 
 Build the current checkout, then run all flows:
@@ -165,6 +184,7 @@ Run one journey or retain its isolated persona for diagnosis:
 ```bash
 ./scripts/gui-golden-flows.sh --flow slow-stream-stop
 ./scripts/gui-golden-flows.sh --flow low-memory-choice
+./scripts/gui-golden-flows.sh --flow loaded-model-benchmark
 ./scripts/gui-golden-flows.sh --flow chat-restore --keep
 ./scripts/gui-golden-flows.sh --flow no-dead-controls
 ```

--- a/apps/rapid-mac/scripts/fake-rapid-mlx.sh
+++ b/apps/rapid-mac/scripts/fake-rapid-mlx.sh
@@ -150,13 +150,36 @@ class Handler(BaseHTTPRequestHandler):
         if self.path != "/v1/chat/completions":
             self._json(404, {"error": "not_found"})
             return
-        # Drain (and ignore) the request body — we don't echo the
-        # prompt; the fake's output is deterministic so test
-        # assertions can pin specific strings.
+        # Decode only enough of the request to support both normal SSE chat
+        # and the in-app loaded-model speed test (`stream: false`).
         length = int(self.headers.get("content-length", "0") or "0")
+        body = {}
         if length:
-            self.rfile.read(length)
+            try:
+                body = json.loads(self.rfile.read(length))
+            except (json.JSONDecodeError, UnicodeDecodeError):
+                body = {}
         _event("chat_request")
+
+        if body.get("stream") is False:
+            max_tokens = int(body.get("max_tokens", 8) or 8)
+            completion_tokens = min(max_tokens, 128)
+            _event("benchmark_request", max_tokens=max_tokens)
+            self._json(200, {
+                "id": "fake-benchmark",
+                "object": "chat.completion",
+                "choices": [{
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "measured output"},
+                    "finish_reason": "stop",
+                }],
+                "usage": {
+                    "prompt_tokens": 12,
+                    "completion_tokens": completion_tokens,
+                    "total_tokens": 12 + completion_tokens,
+                },
+            })
+            return
 
         self.send_response(200)
         self.send_header("Content-Type", "text/event-stream")

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -31,7 +31,8 @@ usage() {
 Usage: gui-golden-flows.sh [--flow NAME] [--keep] [--update-baselines]
 
 Flows: fresh-install, settings-persistence, chat-restore, slow-stream-stop,
-       model-crash-recovery, low-memory-choice, update-state, no-dead-controls,
+       model-crash-recovery, low-memory-choice, loaded-model-benchmark,
+       update-state, no-dead-controls,
        catalog-integrity, all
 
 Options:
@@ -614,6 +615,32 @@ flow_low_memory_choice() {
     cleanup_persona
 }
 
+flow_loaded_model_benchmark() {
+    log "7/7 benchmark the model that is already loaded"
+    start_persona loaded-model-benchmark
+    pb app switch --to "PID:$APP_PID" --verify --json > "$OUT/focus.json"
+    dismiss_first_run
+    start_model
+
+    wait_identifier ChatView.SpeedOnThisMac "$OUT/chat-ready.json"
+    press "$OUT/chat-ready.json" ChatView.SpeedOnThisMac "$OUT/open-benchmark.json"
+    wait_identifier Benchmark.RunLoadedModel "$OUT/benchmark-idle.json"
+    press "$OUT/benchmark-idle.json" Benchmark.RunLoadedModel "$OUT/run-benchmark.json"
+    wait_identifier Benchmark.LoadedModelResult "$OUT/benchmark-result.json"
+
+    local starts requests
+    starts="$(grep -c '"event": "server_started"' "$OUT/fake-events.jsonl" 2>/dev/null || true)"
+    requests="$(grep -c '"event": "benchmark_request"' "$OUT/fake-events.jsonl" 2>/dev/null || true)"
+    [[ "$starts" == 1 ]] \
+        || die "speed test started a second server/model process ($starts starts)"
+    [[ "$requests" == 2 ]] \
+        || die "speed test did not send warm-up + measured requests to the loaded server ($requests requests)"
+    jq -n --argjson starts "$starts" --argjson requests "$requests" \
+        '{success: true, assertion: "speed test reused the loaded model", server_starts: $starts, benchmark_requests: $requests}' \
+        > "$OUT/loaded-model-benchmark-assertion.json"
+    cleanup_persona
+}
+
 flow_update_state() {
     # Settings > App must name the version the app actually IS.
     #
@@ -744,6 +771,7 @@ case "$FLOW" in
     slow-stream-stop) flow_slow_stream_stop ;;
     model-crash-recovery) flow_model_crash_recovery ;;
     low-memory-choice) flow_low_memory_choice ;;
+    loaded-model-benchmark) flow_loaded_model_benchmark ;;
     update-state) flow_update_state ;;
     no-dead-controls) flow_no_dead_controls ;;
     catalog-integrity) flow_catalog_integrity ;;
@@ -754,6 +782,7 @@ case "$FLOW" in
         flow_slow_stream_stop
         flow_model_crash_recovery
         flow_low_memory_choice
+        flow_loaded_model_benchmark
         flow_update_state
         flow_no_dead_controls
         flow_catalog_integrity


### PR DESCRIPTION
## Why

“Speed on this Mac” claimed to measure the running model but spawned `rapid-mlx bench`, loading a second copy of the same weights. On an 18 GB Mac with the 8B model already running, the memory guard correctly rejected that unnecessary duplicate load.

## What changed

- reuse the ready desktop server, active port, bearer, and serving alias
- send one 8-token warm-up followed by one up-to-128-token measured request
- display completion tokens / measured wall time
- never spawn a second process for the normal speed card
- clarify this contract in the UI
- add request/usage/speed regression tests
- add a `loaded-model-benchmark` AX golden flow requiring one server start and exactly two benchmark requests
- update `docs/gui-golden-flows.md`

Leaderboard publication remains a separate, explicit standardized submission workload.

## Validation

- release app build passed (`SKIP_SIDECAR=1 BUNDLE_MODEL=0`)
- `swift build --target RapidTests` passed (all Swift Testing sources compiled)
- shell syntax checks passed
- fake sidecar non-stream OpenAI response validated
- real already-running `lfm2.5-8b-a1b-4bit` on this M3 Pro: warm-up 8/8 tokens, then measured 128/128 tokens at 98.1 tok/s; server PID stayed unchanged and no second model process appeared
- full local `swift test` is blocked by this Mac’s unaccepted Xcode license; CI will run the complete matrix
- AX golden execution is implemented; this login session currently reports `loginwindow` as frontmost, so the runner correctly refused to claim a GUI pass