### PR TITLE
fix(mac): the golden flows must ask the AX tree whether a window is gone

### DIFF
--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/fresh-install.consent.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/fresh-install.consent.txt
@@ -11,7 +11,7 @@ AXApplication title="Rapid-MLX"
           AXStaticText value=text enabled=true
           AXStaticText value=text enabled=true
           AXButton desc="Connect your agents" help="Point an editor or agent at your local server" enabled=true
-          AXButton desc="Speed on this Mac" help="Start a model to run a speed test." enabled=false
+          AXButton id="ChatView.SpeedOnThisMac" desc="Speed on this Mac" help="Start a model to run a speed test." enabled=false
           AXGroup desc="<model> isn't running, It's already downloaded — starting takes a few seconds." enabled=true
             AXStaticText value=text enabled=true
             AXStaticText value=text enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/fresh-install.steady.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/fresh-install.steady.txt
@@ -11,7 +11,7 @@ AXApplication title="Rapid-MLX"
           AXStaticText value=text enabled=true
           AXStaticText value=text enabled=true
           AXButton desc="Connect your agents" help="Point an editor or agent at your local server" enabled=true
-          AXButton desc="Speed on this Mac" help="Start a model to run a speed test." enabled=false
+          AXButton id="ChatView.SpeedOnThisMac" desc="Speed on this Mac" help="Start a model to run a speed test." enabled=false
           AXGroup desc="<model> isn't running, It's already downloaded — starting takes a few seconds." enabled=true
             AXStaticText value=text enabled=true
             AXStaticText value=text enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-after-relaunch.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-after-relaunch.txt
@@ -11,7 +11,7 @@ AXApplication title="Rapid-MLX"
           AXStaticText value=text enabled=true
           AXStaticText value=text enabled=true
           AXButton desc="Connect your agents" help="Point an editor or agent at your local server" enabled=true
-          AXButton desc="Speed on this Mac" help="Start a model to run a speed test." enabled=false
+          AXButton id="ChatView.SpeedOnThisMac" desc="Speed on this Mac" help="Start a model to run a speed test." enabled=false
           AXGroup desc="<model> isn't running, It's already downloaded — starting takes a few seconds." enabled=true
             AXStaticText value=text enabled=true
             AXStaticText value=text enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-idle.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-idle.txt
@@ -11,7 +11,7 @@ AXApplication title="Rapid-MLX"
           AXStaticText value=text enabled=true
           AXStaticText value=text enabled=true
           AXButton desc="Connect your agents" help="Point an editor or agent at your local server" enabled=true
-          AXButton desc="Speed on this Mac" help="Start a model to run a speed test." enabled=false
+          AXButton id="ChatView.SpeedOnThisMac" desc="Speed on this Mac" help="Start a model to run a speed test." enabled=false
           AXGroup desc="<model> isn't running, It's already downloaded — starting takes a few seconds." enabled=true
             AXStaticText value=text enabled=true
             AXStaticText value=text enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-toggled.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-toggled.txt
@@ -11,7 +11,7 @@ AXApplication title="Rapid-MLX"
           AXStaticText value=text enabled=true
           AXStaticText value=text enabled=true
           AXButton desc="Connect your agents" help="Point an editor or agent at your local server" enabled=true
-          AXButton desc="Speed on this Mac" help="Start a model to run a speed test." enabled=false
+          AXButton id="ChatView.SpeedOnThisMac" desc="Speed on this Mac" help="Start a model to run a speed test." enabled=false
           AXGroup desc="<model> isn't running, It's already downloaded — starting takes a few seconds." enabled=true
             AXStaticText value=text enabled=true
             AXStaticText value=text enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.settings-root.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.settings-root.txt
@@ -11,7 +11,7 @@ AXApplication title="Rapid-MLX"
           AXStaticText value=text enabled=true
           AXStaticText value=text enabled=true
           AXButton desc="Connect your agents" help="Point an editor or agent at your local server" enabled=true
-          AXButton desc="Speed on this Mac" help="Start a model to run a speed test." enabled=false
+          AXButton id="ChatView.SpeedOnThisMac" desc="Speed on this Mac" help="Start a model to run a speed test." enabled=false
           AXGroup desc="<model> isn't running, It's already downloaded — starting takes a few seconds." enabled=true
             AXStaticText value=text enabled=true
             AXStaticText value=text enabled=true

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -219,12 +219,15 @@ wait_identifier() {
 ax_window_present() {
     local title="$1" destination="$2" status
     "$AX_DRIVER" dump "$APP_PID" > "$destination" 2>/dev/null || return 2
-    # A dump the driver refused to vouch for says nothing either way.
-    jq -e '.success == true and (.data.ui_elements | type) == "array"' \
+    # `data.windows`, NOT `ui_elements`: the driver enumerates the root's
+    # children once and vouches for that list with `complete`. The element
+    # array cannot answer this, because every way it comes up short — a role
+    # read that failed, a title that would not read, the record cap — removes a
+    # window from it silently and is indistinguishable from the window closing.
+    jq -e '.success == true and .data.windows.complete == true' \
         "$destination" >/dev/null 2>&1 || return 2
     status=0
-    jq -e --arg t "$title" \
-        '[.data.ui_elements[]? | select(.role == "AXWindow" and .title == $t)] | length > 0' \
+    jq -e --arg t "$title" '[.data.windows.titles[]? | select(. == $t)] | length > 0' \
         "$destination" >/dev/null 2>&1 || status=$?
     # jq exits 1 only for a well-formed query whose answer was false; anything
     # else (2 usage, 3 compile, 4 no output) is a broken observation.
@@ -859,8 +862,11 @@ flow_browse_all_destination() {
     SETTINGS_WINDOW_ID=""
     for ((i=0; i<40; i++)); do
         pb list windows --app "PID:$APP_PID" --json > "$OUT/ba-windows.json" 2>/dev/null || true
+        # `|| true` on the whole pipeline: a failed `pb` leaves empty or partial
+        # JSON, jq then exits non-zero, and under `set -euo pipefail` that would
+        # abort the very loop written to survive it.
         SETTINGS_WINDOW_ID="$(jq -r '.data.windows[]? | select(.title == "Settings") | .window_id' \
-            "$OUT/ba-windows.json" 2>/dev/null | head -1)"
+            "$OUT/ba-windows.json" 2>/dev/null | head -1 || true)"
         if [[ -n "$SETTINGS_WINDOW_ID" ]]; then break; fi
         sleep 0.25
     done

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -211,12 +211,28 @@ wait_identifier() {
 # one that polls for a title to APPEAR can be satisfied by a window a previous
 # persona in the same run opened. The app's own AX tree is authoritative for
 # both directions.
+#
+# Three outcomes, not two: 0 = present, 1 = absent, 2 = could not observe.
+# Folding the third into "absent" recreates the very bug above in a new place —
+# one failed dump, one unparseable file, and a caller waiting for a window to
+# close concludes that it closed. Callers must branch on all three.
 ax_window_present() {
-    local title="$1" destination="$2"
-    "$AX_DRIVER" dump "$APP_PID" > "$destination" 2>/dev/null || return 1
+    local title="$1" destination="$2" status
+    "$AX_DRIVER" dump "$APP_PID" > "$destination" 2>/dev/null || return 2
+    # A dump the driver refused to vouch for says nothing either way.
+    jq -e '.success == true and (.data.ui_elements | type) == "array"' \
+        "$destination" >/dev/null 2>&1 || return 2
+    status=0
     jq -e --arg t "$title" \
         '[.data.ui_elements[]? | select(.role == "AXWindow" and .title == $t)] | length > 0' \
-        "$destination" >/dev/null
+        "$destination" >/dev/null 2>&1 || status=$?
+    # jq exits 1 only for a well-formed query whose answer was false; anything
+    # else (2 usage, 3 compile, 4 no output) is a broken observation.
+    case "$status" in
+        0) return 0 ;;
+        1) return 1 ;;
+        *) return 2 ;;
+    esac
 }
 
 element_field() {
@@ -778,12 +794,36 @@ flow_browse_all_destination() {
     # Choose a card that is NOT the default. The bug discarded the user's
     # selection; asserting the survival of a pick nobody made proves nothing,
     # so make one, and make it a different one.
-    local chosen
-    chosen="$(jq -r '[.data.ui_elements[]?
-                      | select((.identifier // "") | startswith("Quickstart.Choice."))
-                      | select(.selected != true)][0].identifier // empty' \
-              "$OUT/ba-chooser.json")"
-    [[ -n "$chosen" ]] || die "the chooser offers no unselected model card to pick"
+    #
+    # Find the default POSITIVELY and exclude it by identifier — never pick by
+    # `.selected != true`. Measured: SwiftUI publishes AXSelected only on the
+    # card that IS selected; the other three omit the attribute entirely, and
+    # rapid-ax also omits an attribute whose read failed. Absence therefore
+    # means "not selected OR we failed to look", and the two are
+    # indistinguishable by construction, not merely on a bad day. A `!= true`
+    # pick can thus hand back the default itself, after which the round trip at
+    # the end asserts only that the default is still the default — which stays
+    # true when the wizard throws the user's choice away, i.e. the bug walks
+    # straight through the flow written to catch it (#1653).
+    #
+    # Requiring exactly one card to claim selection is what keeps this honest:
+    # if that read is the one that failed, the count is 0 and we retry rather
+    # than quietly promoting some other card to "the default".
+    local i chosen=""
+    for ((i=0; i<40; i++)); do
+        see_main "$OUT/ba-chooser.json"
+        chosen="$(jq -r '[.data.ui_elements[]?
+                          | select((.identifier // "") | startswith("Quickstart.Choice."))]
+                         | (map(select(.selected == true))) as $default
+                         | if ($default | length) != 1 then empty
+                           else (map(select(.identifier != $default[0].identifier))[0].identifier // empty)
+                           end' \
+                  "$OUT/ba-chooser.json")"
+        if [[ -n "$chosen" ]]; then break; fi
+        sleep 0.25
+    done
+    [[ -n "$chosen" ]] \
+        || die "the chooser never showed exactly one selected card with another to pick — AXSelected did not read cleanly"
     press "$OUT/ba-chooser.json" "$chosen" "$OUT/ba-choose.json" \
         || die "$chosen is not pressable"
     sleep 0.5
@@ -798,16 +838,32 @@ flow_browse_all_destination() {
 
     # 1. It opened the catalogue. `open_settings` drives the menu, so assert
     #    the window the BUTTON opened rather than opening one ourselves.
-    local i opened=0
+    local opened=0 probe=2
     for ((i=0; i<40; i++)); do
-        if ax_window_present Settings "$OUT/ba-settings-window.json"; then opened=1; break; fi
+        probe=0; ax_window_present Settings "$OUT/ba-settings-window.json" || probe=$?
+        if [[ "$probe" == 0 ]]; then opened=1; break; fi
+        # probe == 2 is "we never got to look" — keep looking, and if the
+        # budget runs out still un-observed, blame the driver, not the button.
         sleep 0.25
     done
-    [[ "$opened" == 1 ]] \
-        || die "Browse all models did not open anything — it is a dismiss button again (#1653)"
+    if [[ "$opened" != 1 ]]; then
+        if [[ "$probe" == 2 ]]; then
+            die "could not read the app's window list for 10s — the AX driver failed, so the button is untested"
+        fi
+        die "Browse all models did not open anything — it is a dismiss button again (#1653)"
+    fi
     # Only NOW ask peekaboo for the id, purely to target focus/click/menu at it.
-    pb list windows --app "PID:$APP_PID" --json > "$OUT/ba-windows.json"
-    SETTINGS_WINDOW_ID="$(jq -r '.data.windows[]? | select(.title == "Settings") | .window_id' "$OUT/ba-windows.json" | head -1)"
+    # A poll rather than one read: AX publishes a new window before CGWindow
+    # hands out a targetable id, and a one-shot here fails the flow for a race
+    # that has nothing to do with the button under test.
+    SETTINGS_WINDOW_ID=""
+    for ((i=0; i<40; i++)); do
+        pb list windows --app "PID:$APP_PID" --json > "$OUT/ba-windows.json" 2>/dev/null || true
+        SETTINGS_WINDOW_ID="$(jq -r '.data.windows[]? | select(.title == "Settings") | .window_id' \
+            "$OUT/ba-windows.json" 2>/dev/null | head -1)"
+        if [[ -n "$SETTINGS_WINDOW_ID" ]]; then break; fi
+        sleep 0.25
+    done
     [[ -n "$SETTINGS_WINDOW_ID" ]] || die "Settings is in the AX tree but peekaboo will not name its window"
 
     # 2. On the models tab, not merely "Settings somewhere". The wizard's own
@@ -857,14 +913,25 @@ flow_browse_all_destination() {
     pb menu click --window-id "$SETTINGS_WINDOW_ID" --item 'Close' --json > "$OUT/ba-close.json" \
         || die "could not close the Settings window"
     local closed=0
+    probe=2
     for ((i=0; i<40; i++)); do
-        if ! ax_window_present Settings "$OUT/ba-windows-after.json"; then closed=1; break; fi
+        probe=0; ax_window_present Settings "$OUT/ba-windows-after.json" || probe=$?
+        # ONLY an explicit 1 — a dump we actually read that does not contain
+        # the window. Accepting 2 here would let one failed dump stand in for
+        # the close, which is exactly the mistake this helper exists to make
+        # impossible to write.
+        if [[ "$probe" == 1 ]]; then closed=1; break; fi
         sleep 0.25
     done
     # Not a cosmetic check: with Settings still open, the app-wide AX dump
     # below carries the wizard AND the Settings tree, so the round-trip
     # assertion would pass without any round trip having happened.
-    [[ "$closed" == 1 ]] || die "the Settings window did not close — the round trip below would be vacuous"
+    if [[ "$closed" != 1 ]]; then
+        if [[ "$probe" == 2 ]]; then
+            die "could not read the app's window list for 10s — whether Settings closed is unknown, so the round trip below is untrustworthy"
+        fi
+        die "the Settings window did not close — the round trip below would be vacuous"
+    fi
 
     wait_identifier Quickstart.BrowseAll "$OUT/ba-after.json"
     jq -e --arg id "$chosen" '.data.ui_elements[]? | select(.identifier == $id) | select(.selected == true)' \

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -201,6 +201,24 @@ wait_identifier() {
     die "timed out waiting for AX identifier $identifier"
 }
 
+# Is a window with this title in the app's OWN accessibility tree?
+#
+# ``peekaboo list windows`` is NOT an oracle for this. It reports a window that
+# has already been destroyed — measured: immediately after Settings closes,
+# ``pb list windows`` still lists it while the AX tree does not, and it never
+# catches up. A flow that polls the window list for a title to DISAPPEAR
+# therefore waits forever and then reports a product bug that is not there;
+# one that polls for a title to APPEAR can be satisfied by a window a previous
+# persona in the same run opened. The app's own AX tree is authoritative for
+# both directions.
+ax_window_present() {
+    local title="$1" destination="$2"
+    "$AX_DRIVER" dump "$APP_PID" > "$destination" 2>/dev/null || return 1
+    jq -e --arg t "$title" \
+        '[.data.ui_elements[]? | select(.role == "AXWindow" and .title == $t)] | length > 0' \
+        "$destination" >/dev/null
+}
+
 element_field() {
     local tree="$1" identifier="$2" field="$3"
     jq -r --arg id "$identifier" --arg field "$field" \
@@ -780,15 +798,17 @@ flow_browse_all_destination() {
 
     # 1. It opened the catalogue. `open_settings` drives the menu, so assert
     #    the window the BUTTON opened rather than opening one ourselves.
-    local i
+    local i opened=0
     for ((i=0; i<40; i++)); do
-        pb list windows --app "PID:$APP_PID" --json > "$OUT/ba-windows.json"
-        SETTINGS_WINDOW_ID="$(jq -r '.data.windows[]? | select(.title == "Settings") | .window_id' "$OUT/ba-windows.json" | head -1)"
-        [[ -n "$SETTINGS_WINDOW_ID" ]] && break
+        if ax_window_present Settings "$OUT/ba-settings-window.json"; then opened=1; break; fi
         sleep 0.25
     done
-    [[ -n "$SETTINGS_WINDOW_ID" ]] \
+    [[ "$opened" == 1 ]] \
         || die "Browse all models did not open anything — it is a dismiss button again (#1653)"
+    # Only NOW ask peekaboo for the id, purely to target focus/click/menu at it.
+    pb list windows --app "PID:$APP_PID" --json > "$OUT/ba-windows.json"
+    SETTINGS_WINDOW_ID="$(jq -r '.data.windows[]? | select(.title == "Settings") | .window_id' "$OUT/ba-windows.json" | head -1)"
+    [[ -n "$SETTINGS_WINDOW_ID" ]] || die "Settings is in the AX tree but peekaboo will not name its window"
 
     # 2. On the models tab, not merely "Settings somewhere". The wizard's own
     #    copy promises the catalogue; landing on the user's last-used tab is a
@@ -838,9 +858,7 @@ flow_browse_all_destination() {
         || die "could not close the Settings window"
     local closed=0
     for ((i=0; i<40; i++)); do
-        pb list windows --app "PID:$APP_PID" --json > "$OUT/ba-windows-after.json"
-        if jq -e '[.data.windows[]? | select(.title == "Settings")] | length == 0' \
-            "$OUT/ba-windows-after.json" >/dev/null; then closed=1; break; fi
+        if ! ax_window_present Settings "$OUT/ba-windows-after.json"; then closed=1; break; fi
         sleep 0.25
     done
     # Not a cosmetic check: with Settings still open, the app-wide AX dump

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -224,7 +224,11 @@ ax_window_present() {
     # array cannot answer this, because every way it comes up short — a role
     # read that failed, a title that would not read, the record cap — removes a
     # window from it silently and is indistinguishable from the window closing.
-    jq -e '.success == true and .data.windows.complete == true' \
+    # `titles` must be an array as well as complete: `titles[]?` below swallows
+    # a structural failure, so without this a malformed list would read as a
+    # confident "absent" — the third outcome collapsing back into the first.
+    jq -e '.success == true and .data.windows.complete == true
+           and (.data.windows.titles | type) == "array"' \
         "$destination" >/dev/null 2>&1 || return 2
     status=0
     jq -e --arg t "$title" '[.data.windows.titles[]? | select(. == $t)] | length > 0' \

--- a/apps/rapid-mac/scripts/rapid-ax.swift
+++ b/apps/rapid-mac/scripts/rapid-ax.swift
@@ -19,13 +19,17 @@ let application = AXUIElementCreateApplication(pid)
 var visited = Set<CFHashCode>()
 var records = [[String: Any]]()
 var match: AXUIElement?
-// The application root's children ARE the window list, so a failed read there
-// is not "the app has no windows", it is "we never got to look" — and emitting
-// the two as the same successful, window-less dump is how a caller waiting for
-// a window to DISAPPEAR takes a transient AX failure as proof that it closed.
-// Nothing deeper needs this: the depth and record guards can clip a subtree
-// without hiding a window, because windows only ever sit at depth 1.
-var rootChildrenRead = false
+// The window list is NOT a by-product of the tree walk, because every way the
+// walk can come up short is silent: it skips a root child whose AXRole read
+// failed, drops a title it could not read, and stops dead at the record cap.
+// Each shortens the list, and no caller can tell a shortened list from a
+// window that closed — which is exactly how a golden flow waiting for a window
+// to DISAPPEAR takes a transient AX failure as proof that it did. So enumerate
+// the root's children once, up front, and say plainly whether that enumeration
+// can be trusted. `complete: false` is not an error; it means "ask again".
+var windowTitles = [String]()
+var windowListComplete = true
+var windowHashes = Set<CFHashCode>()
 let wanted = CommandLine.arguments.count > 3 ? CommandLine.arguments[3] : nil
 
 func attribute(_ element: AXUIElement, _ name: CFString) -> AnyObject? {
@@ -102,29 +106,55 @@ func walk(_ element: AXUIElement, depth: Int) {
 
     if match == nil, identifier == wanted { match = element }
     guard let children = attribute(element, kAXChildrenAttribute as CFString) as? [AXUIElement] else { return }
-    if depth == 0 { rootChildrenRead = true }
     for child in children {
         // The application root also owns the global menu bar. Traversing it
         // captures unrelated macOS Recent Items in test artifacts and adds
         // thousands of irrelevant nodes. Golden flows only need app windows;
         // sheets and popovers remain descendants of those windows.
-        if depth == 0, string(child, kAXRoleAttribute as CFString) != kAXWindowRole as String {
-            continue
-        }
+        //
+        // Filtered against the window list enumerated above rather than by
+        // re-reading AXRole here, so the tree and that list cannot disagree
+        // about which windows exist.
+        if depth == 0, !windowHashes.contains(CFHash(child)) { continue }
         walk(child, depth: depth + 1)
     }
+}
+
+// Enumerate the windows before walking, so the walk can be filtered against
+// the result. Every read that fails here marks the list incomplete instead of
+// quietly shortening it; a window we cannot name is still a window we saw.
+if let rootChildren = attribute(application, kAXChildrenAttribute as CFString) as? [AXUIElement] {
+    for child in rootChildren {
+        guard let role = string(child, kAXRoleAttribute as CFString) else {
+            // We could not even establish whether this child is a window.
+            windowListComplete = false
+            continue
+        }
+        guard role == kAXWindowRole as String else { continue }
+        windowHashes.insert(CFHash(child))
+        guard let title = string(child, kAXTitleAttribute as CFString) else {
+            windowListComplete = false
+            continue
+        }
+        windowTitles.append(title)
+    }
+} else {
+    windowListComplete = false
 }
 
 walk(application, depth: 0)
 
 if command == "dump" {
-    // Fail loudly rather than hand back a plausible, empty tree.
-    guard rootChildrenRead else {
-        fail("could not read the application's window list (AXChildren on the root)")
-    }
     let payload: [String: Any] = [
         "success": true,
-        "data": ["pid": pid, "ui_elements": records]
+        "data": [
+            "pid": pid,
+            "ui_elements": records,
+            // The authority for "is window X open?" — see the note above. Callers
+            // must treat `complete: false` as "could not observe", never as an
+            // answer in either direction.
+            "windows": ["titles": windowTitles, "complete": windowListComplete]
+        ]
     ]
     let data = try! JSONSerialization.data(withJSONObject: payload, options: [.prettyPrinted, .sortedKeys])
     FileHandle.standardOutput.write(data)

--- a/apps/rapid-mac/scripts/rapid-ax.swift
+++ b/apps/rapid-mac/scripts/rapid-ax.swift
@@ -29,7 +29,7 @@ var match: AXUIElement?
 // can be trusted. `complete: false` is not an error; it means "ask again".
 var windowTitles = [String]()
 var windowListComplete = true
-var windowHashes = Set<CFHashCode>()
+var windowElements = [AXUIElement]()
 let wanted = CommandLine.arguments.count > 3 ? CommandLine.arguments[3] : nil
 
 func attribute(_ element: AXUIElement, _ name: CFString) -> AnyObject? {
@@ -105,17 +105,23 @@ func walk(_ element: AXUIElement, depth: Int) {
     records.append(record)
 
     if match == nil, identifier == wanted { match = element }
-    guard let children = attribute(element, kAXChildrenAttribute as CFString) as? [AXUIElement] else { return }
+    // At depth 0 the children ARE the windows enumerated below, reused rather
+    // than read again: a second AXChildren read can return a different set, and
+    // then `ui_elements` and the `windows` list this dump vouches for would
+    // disagree about which windows exist.
+    //
+    // That enumeration also drops the global menu bar, which the application
+    // root owns as well. Traversing it captures unrelated macOS Recent Items in
+    // artifacts and adds thousands of irrelevant nodes; golden flows only need
+    // app windows, and sheets and popovers stay descendants of those.
+    let children: [AXUIElement]
+    if depth == 0 {
+        children = windowElements
+    } else {
+        guard let kids = attribute(element, kAXChildrenAttribute as CFString) as? [AXUIElement] else { return }
+        children = kids
+    }
     for child in children {
-        // The application root also owns the global menu bar. Traversing it
-        // captures unrelated macOS Recent Items in test artifacts and adds
-        // thousands of irrelevant nodes. Golden flows only need app windows;
-        // sheets and popovers remain descendants of those windows.
-        //
-        // Filtered against the window list enumerated above rather than by
-        // re-reading AXRole here, so the tree and that list cannot disagree
-        // about which windows exist.
-        if depth == 0, !windowHashes.contains(CFHash(child)) { continue }
         walk(child, depth: depth + 1)
     }
 }
@@ -131,7 +137,9 @@ if let rootChildren = attribute(application, kAXChildrenAttribute as CFString) a
             continue
         }
         guard role == kAXWindowRole as String else { continue }
-        windowHashes.insert(CFHash(child))
+        // Recorded even when the title will not read: a window we cannot name
+        // is still a window, and dropping it here would shorten the tree too.
+        windowElements.append(child)
         guard let title = string(child, kAXTitleAttribute as CFString) else {
             windowListComplete = false
             continue

--- a/apps/rapid-mac/scripts/rapid-ax.swift
+++ b/apps/rapid-mac/scripts/rapid-ax.swift
@@ -19,6 +19,13 @@ let application = AXUIElementCreateApplication(pid)
 var visited = Set<CFHashCode>()
 var records = [[String: Any]]()
 var match: AXUIElement?
+// The application root's children ARE the window list, so a failed read there
+// is not "the app has no windows", it is "we never got to look" — and emitting
+// the two as the same successful, window-less dump is how a caller waiting for
+// a window to DISAPPEAR takes a transient AX failure as proof that it closed.
+// Nothing deeper needs this: the depth and record guards can clip a subtree
+// without hiding a window, because windows only ever sit at depth 1.
+var rootChildrenRead = false
 let wanted = CommandLine.arguments.count > 3 ? CommandLine.arguments[3] : nil
 
 func attribute(_ element: AXUIElement, _ name: CFString) -> AnyObject? {
@@ -95,6 +102,7 @@ func walk(_ element: AXUIElement, depth: Int) {
 
     if match == nil, identifier == wanted { match = element }
     guard let children = attribute(element, kAXChildrenAttribute as CFString) as? [AXUIElement] else { return }
+    if depth == 0 { rootChildrenRead = true }
     for child in children {
         // The application root also owns the global menu bar. Traversing it
         // captures unrelated macOS Recent Items in test artifacts and adds
@@ -110,6 +118,10 @@ func walk(_ element: AXUIElement, depth: Int) {
 walk(application, depth: 0)
 
 if command == "dump" {
+    // Fail loudly rather than hand back a plausible, empty tree.
+    guard rootChildrenRead else {
+        fail("could not read the application's window list (AXChildren on the root)")
+    }
     let payload: [String: Any] = [
         "success": true,
         "data": ["pid": pid, "ui_elements": records]


### PR DESCRIPTION
## Why

Because the golden-flow suite is red on `main` for two independent reasons,
and one of them makes an assertion that cannot fail — which is worse than a
red suite.

Found by running `browse-all-destination` against a real build for the first
time. It failed at "the Settings window did not close", and the failure was in
the harness, not the app.

## 1. `peekaboo list windows` is not an oracle for window lifetime

It keeps reporting a window that has already been destroyed. Measured, with
both oracles side by side immediately after Settings closes:

```
probe: pb=1 ax=1     <- closing
probe: pb=1 ax=0     <- closed; peekaboo still lists it, and never stops
```

So the disappearance poll could never succeed. Six different ways of closing
the window — the File menu scoped to the window, the File menu scoped to the
app, `peekaboo window close`, ⌘W, and a real foreground click on the red
traffic light — all "failed" against that oracle. Every one of them actually
worked; a control flow with no wizard involved reproduced it, which is what
ruled the app out.

The appearance check had the mirror of the same problem, and it is the worse
one: a stale list can name a Settings window a PREVIOUS persona opened, so
"Browse all models opened the catalogue" — the assertion that catches #1653
coming back — could pass without anything having opened.

Both directions now ask the app's own AX tree, which is authoritative for
both. peekaboo is still asked for the window id, but only after the AX tree
has confirmed the window exists, and only to aim focus/click/menu at it.

## 2. Six AX baselines left stale by #1663

```
-  AXButton desc="Speed on this Mac" …
+  AXButton id="ChatView.SpeedOnThisMac" desc="Speed on this Mac" …
```

#1663 gave that button an accessibility identifier — strictly an improvement,
and exactly what the new gate asks for — but did not re-record the six
baselines that fingerprint it. That one line is the ONLY difference in all
six; nothing else in any tree moved.

Worth noting because the identifier gate cannot catch this: it reports a
control that has NO identifier, so ADDING one is invisible to it, and the
structural baselines are the only thing that notices.

## Verification

Against a build of this commit:

| flow | result |
| --- | --- |
| fresh-install | PASS |
| settings-persistence | PASS |
| chat-restore | PASS |
| slow-stream-stop | PASS |
| model-crash-recovery | PASS |
| low-memory-choice | PASS |
| update-state | PASS |
| no-dead-controls | PASS |
| catalog-integrity | PASS |
| browse-all-destination | PASS |
| loaded-model-benchmark | FAIL — #1668, a real product bug, not addressed here |

`browse-all-destination` now exercises the half that never ran before: a
non-default model card is chosen, Browse opens Model Management, Settings
takes a real foreground click, Settings closes, and the wizard comes back with
that same card still selected.
