### PR TITLE
fix(bench): authenticate attached tier requests

### DIFF
--- a/tests/test_bench_tier_smoke.py
+++ b/tests/test_bench_tier_smoke.py
@@ -21,6 +21,7 @@ from vllm_mlx.bench.tier_runner import (
     _find_free_port_in_range,
     _normalize_openai_base,
     _resolve_base_url,
+    _run_smoke,
     run_tier,
 )
 
@@ -125,6 +126,33 @@ def test_smoke_happy_path_returns_zero(patch_smoke_environment, capsys):
     captured = capsys.readouterr()
     assert "[PASS] tier=smoke" in captured.out
     assert "OK: 1/1 tiers passed" in captured.out
+
+
+def test_attached_smoke_uses_api_key_from_environment(monkeypatch):
+    """An attached secured server receives the env-only bearer secret."""
+    stream_lines = [
+        'data: {"choices":[{"delta":{"content":"4"}}]}',
+        "data: [DONE]",
+    ]
+    models_payload = {"data": [{"id": "secured-model"}]}
+    observed: dict[str, str] = {}
+
+    def _client_factory(*args, **kwargs):
+        observed.update(kwargs.get("headers", {}))
+        return _FakeClient(
+            models_payload=models_payload,
+            stream_lines=stream_lines,
+        )
+
+    monkeypatch.setenv("RAPID_MLX_API_KEY", "bench-secret")
+    with patch("httpx.Client", _client_factory):
+        result = _run_smoke(
+            "secured-model",
+            "http://127.0.0.1:8000/v1",
+        )
+
+    assert result.passed is True
+    assert observed == {"Authorization": "Bearer bench-secret"}
 
 
 def test_smoke_fail_when_no_four_in_response(capsys):

--- a/tests/test_http_auth.py
+++ b/tests/test_http_auth.py
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for env-only authentication of local HTTP clients."""
+
+from unittest.mock import Mock, patch
+
+from vllm_mlx.agents.testing import AgentTestRunner
+from vllm_mlx.http_auth import rapid_mlx_auth_headers
+
+
+def test_auth_headers_are_empty_without_api_key(monkeypatch):
+    monkeypatch.delenv("RAPID_MLX_API_KEY", raising=False)
+    assert rapid_mlx_auth_headers() == {}
+
+
+def test_auth_headers_use_bearer_without_exposing_key_in_argv(monkeypatch):
+    monkeypatch.setenv("RAPID_MLX_API_KEY", "local-secret")
+    assert rapid_mlx_auth_headers() == {
+        "Authorization": "Bearer local-secret",
+    }
+
+
+def test_harness_model_discovery_uses_same_bearer(monkeypatch):
+    monkeypatch.setenv("RAPID_MLX_API_KEY", "harness-secret")
+    response = Mock()
+    response.json.return_value = {"data": [{"id": "secured-model"}]}
+
+    with patch("httpx.get", return_value=response) as get:
+        runner = AgentTestRunner(Mock(), base_url="http://127.0.0.1:8000/v1")
+
+    assert runner.model_id == "secured-model"
+    get.assert_called_once_with(
+        "http://127.0.0.1:8000/v1/models",
+        headers={"Authorization": "Bearer harness-secret"},
+        timeout=5,
+    )

--- a/vllm_mlx/agents/testing.py
+++ b/vllm_mlx/agents/testing.py
@@ -25,6 +25,7 @@ from enum import Enum
 
 import httpx
 
+from ..http_auth import rapid_mlx_auth_headers
 from .base import AgentProfile
 
 logger = logging.getLogger(__name__)
@@ -199,6 +200,7 @@ def _api_call(
     resp = httpx.post(
         f"{base_url}/chat/completions",
         json=payload,
+        headers=rapid_mlx_auth_headers(),
         timeout=timeout,
     )
     resp.raise_for_status()
@@ -480,7 +482,11 @@ def _test_streaming_tool_call(base_url: str, model_id: str) -> TestResult:
             "stream": True,
         }
         with httpx.stream(
-            "POST", f"{base_url}/chat/completions", json=payload, timeout=60
+            "POST",
+            f"{base_url}/chat/completions",
+            json=payload,
+            headers=rapid_mlx_auth_headers(),
+            timeout=60,
         ) as resp:
             tool_chunks = []
             finish_reason = None
@@ -606,7 +612,11 @@ def _test_streaming_basic(base_url: str, model_id: str) -> TestResult:
         chunks = 0
         content = ""
         with httpx.stream(
-            "POST", f"{base_url}/chat/completions", json=payload, timeout=30
+            "POST",
+            f"{base_url}/chat/completions",
+            json=payload,
+            headers=rapid_mlx_auth_headers(),
+            timeout=30,
         ) as resp:
             for line in resp.iter_lines():
                 if not line.startswith("data: "):
@@ -927,7 +937,11 @@ class AgentTestRunner:
             self.model_id = model_id
         else:
             try:
-                resp = httpx.get(f"{base_url}/models", timeout=5)
+                resp = httpx.get(
+                    f"{base_url}/models",
+                    headers=rapid_mlx_auth_headers(),
+                    timeout=5,
+                )
                 self.model_id = resp.json()["data"][0]["id"]
             except Exception:
                 self.model_id = "default"

--- a/vllm_mlx/bench/tier_runner.py
+++ b/vllm_mlx/bench/tier_runner.py
@@ -29,6 +29,8 @@ import urllib.error
 import urllib.request
 from dataclasses import dataclass
 
+from ..http_auth import rapid_mlx_auth_headers
+
 # The 5 first-class harnesses in the documented order. Used by both
 # ``--tier harness`` and the release_check_m3.sh G7b gate. Keep this
 # list in lock-step with the G7b shell loop in scripts/release_check_m3.sh
@@ -295,7 +297,7 @@ def _run_smoke(
     try:
         # Resolve model_id from the server so we don't have to guess
         # the canonical name post-alias-resolution.
-        with httpx.Client(timeout=30) as client:
+        with httpx.Client(timeout=30, headers=rapid_mlx_auth_headers()) as client:
             models_resp = client.get(f"{base_url}/models")
             models_resp.raise_for_status()
             model_id = models_resp.json()["data"][0]["id"]
@@ -462,7 +464,7 @@ def _run_speed(model: str, base_url: str, sampled: bool = False) -> TierResult:
         # booted server, which is explicitly PR #3 scope. For PR #2 we
         # surface the metric we can measure cleanly through HTTP: a
         # 5-prompt decode/prefill probe to flag gross perf regressions.
-        with httpx.Client(timeout=180) as client:
+        with httpx.Client(timeout=180, headers=rapid_mlx_auth_headers()) as client:
             models_resp = client.get(f"{base_url}/models")
             models_resp.raise_for_status()
             model_id = models_resp.json()["data"][0]["id"]

--- a/vllm_mlx/http_auth.py
+++ b/vllm_mlx/http_auth.py
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Authentication helpers for local OpenAI-compatible HTTP clients."""
+
+from __future__ import annotations
+
+import os
+
+
+def rapid_mlx_auth_headers() -> dict[str, str]:
+    """Return the bearer header configured for the local Rapid-MLX server.
+
+    Keeping the key in ``RAPID_MLX_API_KEY`` avoids exposing it in argv or
+    command output. An unset or empty value means the server is unsecured.
+    """
+    api_key = os.environ.get("RAPID_MLX_API_KEY")
+    if not api_key:
+        return {}
+    return {"Authorization": f"Bearer {api_key}"}


### PR DESCRIPTION
## Summary

- read the secured-server bearer from `RAPID_MLX_API_KEY` without exposing it in argv
- apply it to smoke/speed HTTP clients and agent-harness model/API/stream requests
- keep the helper lightweight so importing bench/harness code does not import MLX

Fixes #1656

## Reproduction

On Mac mini, main `715b5d73` against an authenticated `qwen3-0.6b-4bit` server:

```
[FAIL] HTTPStatusError: 401 Unauthorized ... /v1/models
```

## Validation

- Mac mini authenticated attach with `qwen3.5-4b-4bit`: smoke PASS, TTFT 328 ms
- Mac mini: `33 passed` (`test_http_auth`, tier smoke, tier harness)
- Mac mini: ruff check + format check PASS
- import probe: `mlx_loaded=False`, `mlx_lm_loaded=False`
- Codex review round 1 found eager MLX import; helper moved out of `utils`
- Codex review round 2: no actionable findings
