### PR TITLE
fix(mac): the speed test was posting to a path the engine does not serve

### DIFF
--- a/apps/rapid-mac/CHANGELOG.md
+++ b/apps/rapid-mac/CHANGELOG.md
@@ -15,6 +15,10 @@ can actually understand.
 
 ### Fixed
 
+- **"Speed on this Mac" actually measures something.** It was posting to the
+  wrong path on the local server, so every run 404'd and reported "The
+  benchmark didn't finish. Try again." without ever having measured anything.
+
 - **"Browse all models" in the setup wizard opens the model catalogue.** It used
   to close the wizard instead — your chosen model was discarded and you landed
   on the chat surface pinned to a model you never picked. It now opens

--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatStreamClient.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatStreamClient.swift
@@ -222,6 +222,19 @@ struct ChatStreamClient {
         URL(string: "http://127.0.0.1:\(port)")!
     }
 
+    /// The chat-completions endpoint for a port-only base URL.
+    ///
+    /// Written exactly once, for the same reason `loopbackURL` is: the base
+    /// URL every caller holds is `http://127.0.0.1:<port>` with NO path, so
+    /// each one has to remember to add `v1/`. The benchmark forgot, POSTed to
+    /// `/chat/completions`, got a 404 from the engine and reported "The
+    /// benchmark didn't finish" — a shipped feature that could never once have
+    /// worked (#1668). Anything that talks to the local engine's chat endpoint
+    /// goes through here.
+    static func chatCompletionsURL(base: URL) -> URL {
+        base.appendingPathComponent("v1/chat/completions")
+    }
+
     /// Default startup-time base URL — pulled from
     /// `PortSweep.defaultPort` (the single source of truth) so the
     /// literal port doesn't live in two places. ChatViewModel
@@ -319,7 +332,7 @@ struct ChatStreamClient {
         bearerToken: String? = nil,
         onEvent: @escaping @MainActor (Event) -> Void
     ) async throws {
-        let url = baseURL.appendingPathComponent("v1/chat/completions")
+        let url = Self.chatCompletionsURL(base: baseURL)
         var req = URLRequest(url: url)
         req.httpMethod = "POST"
         req.setValue("application/json", forHTTPHeaderField: "Content-Type")

--- a/apps/rapid-mac/Sources/Rapid/Server/BenchmarkRunner.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/BenchmarkRunner.swift
@@ -322,7 +322,11 @@ final class BenchmarkRunner {
         baseURL: URL, bearer: String, alias: String,
         maxTokens: Int, prompt: String
     ) throws -> URLRequest {
-        let url = baseURL.appendingPathComponent("chat/completions")
+        // NOT ``baseURL.appendingPathComponent("chat/completions")``. The
+        // base URL is ``http://127.0.0.1:<port>`` with no path, so that built
+        // ``/chat/completions``, which the engine does not serve — every run
+        // 404'd and reported "The benchmark didn't finish" (#1668).
+        let url = ChatStreamClient.chatCompletionsURL(base: baseURL)
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.timeoutInterval = 180

--- a/apps/rapid-mac/Tests/RapidTests/LoadedModelBenchmarkTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/LoadedModelBenchmarkTests.swift
@@ -12,12 +12,34 @@ struct LoadedModelBenchmarkTests {
     /// "looked right" in isolation, and only chat was ever exercised against a
     /// real server. Pinning the equality — rather than either literal — is
     /// what makes the next divergence a test failure.
-    @Test("The speed test and chat resolve to the same endpoint")
-    func benchmarkAndChatAgreeOnTheEndpoint() throws {
+    /// ``.serialized`` because the recorder below keeps its captured URL in
+    /// process-wide ``URLProtocol`` state, exactly like the bearer-auth suite.
+    @Test("The speed test and chat resolve to the same endpoint", .serialized)
+    @MainActor
+    func benchmarkAndChatAgreeOnTheEndpoint() async throws {
         let base = ChatStreamClient.loopbackURL(port: 8123)
+
         let benchmark = try BenchmarkRunner.loadedBenchmarkRequest(
             baseURL: base, bearer: "", alias: "a", maxTokens: 8, prompt: "p")
-        #expect(benchmark.url == ChatStreamClient.chatCompletionsURL(base: base))
+
+        // Chat's URL is captured from a real ``send`` through the URLProtocol
+        // seam, NOT recomputed from the same helper the benchmark calls.
+        // Comparing two callers of one helper only proves the helper is
+        // deterministic; it would stay green if ``send`` went back to building
+        // its own path, which is precisely how the two drifted in the first
+        // place.
+        BenchmarkURLRecorderProtocol.reset()
+        let cfg = URLSessionConfiguration.ephemeral
+        cfg.protocolClasses = [BenchmarkURLRecorderProtocol.self] + (cfg.protocolClasses ?? [])
+        let client = ChatStreamClient(baseURL: base, session: URLSession(configuration: cfg))
+        _ = try? await client.send(
+            ChatStreamClient.Request(
+                alias: "a", messages: [ChatMessage(role: .user, content: "hi")])
+        ) { _ in }
+        let chatURL = BenchmarkURLRecorderProtocol.lastURL
+
+        #expect(chatURL != nil, "the recorder saw no chat request at all")
+        #expect(benchmark.url == chatURL, "the speed test and chat must hit one endpoint")
         #expect(
             benchmark.url?.absoluteString == "http://127.0.0.1:8123/v1/chat/completions",
             "the engine serves /v1/chat/completions; anything else 404s")
@@ -70,4 +92,29 @@ struct LoadedModelBenchmarkTests {
             _ = try BenchmarkRunner.loadedCompletionTokens(from: data)
         }
     }
+}
+
+
+/// Captures the URL a real ``ChatStreamClient.send`` puts on the wire, and
+/// answers with a terminating SSE frame so the client returns instead of
+/// hanging on a bodyless 200.
+final class BenchmarkURLRecorderProtocol: URLProtocol, @unchecked Sendable {
+    nonisolated(unsafe) static var lastURL: URL?
+
+    static func reset() { lastURL = nil }
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        Self.lastURL = request.url
+        let response = HTTPURLResponse(
+            url: request.url!, statusCode: 200, httpVersion: "HTTP/1.1",
+            headerFields: ["Content-Type": "text/event-stream"])!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: Data("data: [DONE]\n\n".utf8))
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
 }

--- a/apps/rapid-mac/Tests/RapidTests/LoadedModelBenchmarkTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/LoadedModelBenchmarkTests.swift
@@ -12,9 +12,12 @@ struct LoadedModelBenchmarkTests {
     /// "looked right" in isolation, and only chat was ever exercised against a
     /// real server. Pinning the equality — rather than either literal — is
     /// what makes the next divergence a test failure.
-    /// ``.serialized`` because the recorder below keeps its captured URL in
-    /// process-wide ``URLProtocol`` state, exactly like the bearer-auth suite.
-    @Test("The speed test and chat resolve to the same endpoint", .serialized)
+    ///
+    /// The recorder below holds its captured URL in static state, which is safe
+    /// only because this is its one and only writer. Give it a second test and
+    /// it needs its own instance state, not a `.serialized` trait — that trait
+    /// orders the cases of a parameterized test and does nothing here.
+    @Test("The speed test and chat resolve to the same endpoint")
     @MainActor
     func benchmarkAndChatAgreeOnTheEndpoint() async throws {
         let base = ChatStreamClient.loopbackURL(port: 8123)

--- a/apps/rapid-mac/Tests/RapidTests/LoadedModelBenchmarkTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/LoadedModelBenchmarkTests.swift
@@ -4,10 +4,35 @@ import Testing
 
 @Suite("Loaded-model speed test")
 struct LoadedModelBenchmarkTests {
+    /// The speed test and chat must reach the SAME endpoint.
+    ///
+    /// They are two callers of one local server, each of which used to build
+    /// the path itself from a base URL that carries none. Chat appended
+    /// `v1/chat/completions`; the benchmark appended `chat/completions`. Both
+    /// "looked right" in isolation, and only chat was ever exercised against a
+    /// real server. Pinning the equality — rather than either literal — is
+    /// what makes the next divergence a test failure.
+    @Test("The speed test and chat resolve to the same endpoint")
+    func benchmarkAndChatAgreeOnTheEndpoint() throws {
+        let base = ChatStreamClient.loopbackURL(port: 8123)
+        let benchmark = try BenchmarkRunner.loadedBenchmarkRequest(
+            baseURL: base, bearer: "", alias: "a", maxTokens: 8, prompt: "p")
+        #expect(benchmark.url == ChatStreamClient.chatCompletionsURL(base: base))
+        #expect(
+            benchmark.url?.absoluteString == "http://127.0.0.1:8123/v1/chat/completions",
+            "the engine serves /v1/chat/completions; anything else 404s")
+    }
+
     @Test("Speed test targets the current authenticated server without a model-loader command")
     func currentServerRequest() throws {
+        // The base URL PRODUCTION passes — `ChatStreamClient.loopbackURL`,
+        // which is host:port with NO path. This test used to hand in
+        // ".../v1" instead, a value no call site ever produces, so it went
+        // green while the shipped build POSTed to /chat/completions and got
+        // a 404 on every run (#1668). A test that invents its own input
+        // cannot fail when the caller is wrong.
         let request = try BenchmarkRunner.loadedBenchmarkRequest(
-            baseURL: URL(string: "http://127.0.0.1:8123/v1")!,
+            baseURL: ChatStreamClient.loopbackURL(port: 8123),
             bearer: "test-secret",
             alias: "lfm2.5-8b-a1b-4bit",
             maxTokens: 128,


### PR DESCRIPTION
Closes #1668.

"Speed on this Mac" → Benchmark this Mac has never worked. Every run reported
"The benchmark didn't finish. Try again." because the request 404'd:

    ChatStreamClient   baseURL.appendingPathComponent("v1/chat/completions")
    BenchmarkRunner    baseURL.appendingPathComponent("chat/completions")

The base URL both hold is `ChatStreamClient.loopbackURL(port:)` —
`http://127.0.0.1:<port>` with no path — so each caller has to remember to add
`v1/`. Chat did. The benchmark did not, and posted to `/chat/completions`,
which the engine does not serve.

That is also why the failure looked like nothing happened at all: the fake
sidecar answers 404 for any path that is not `/v1/chat/completions` and returns
BEFORE recording an event, so the run left `server_started` as the only line in
the event log — no request, no error, just the generic failure copy.

(My first hypothesis on the issue — the sheet's `.onDisappear` cancelling the
task via `cancelActive()` — was wrong. The task ran fine; the server said 404.)

Both callers now go through one `ChatStreamClient.chatCompletionsURL(base:)`,
so the path is written once and they cannot drift again.

## Why the test suite did not catch it

`LoadedModelBenchmarkTests` passed `URL(string: "http://127.0.0.1:8123/v1")`
— a base URL no call site produces — and asserted the result was
`.../v1/chat/completions`. Green test, broken product: a test that invents its
own input cannot fail when the caller is wrong. It now uses
`ChatStreamClient.loopbackURL(port:)`, exactly what `ChatView` passes, plus a
new case pinning that the speed test and chat resolve to the SAME endpoint —
the equality, not either literal, is what makes the next divergence fail.

## Verification

`gui-golden-flows.sh --flow loaded-model-benchmark` against a build of this
commit: PASS, 3 runs. The fake sidecar's event log goes from

    1 server_started                      (before — no request ever sent)

to

    1 server_started, 2 chat_request, 2 benchmark_request   (warm-up + measured)

which is what the flow asserts. `chat-restore` and `slow-stream-stop` also pass,
since this touches the URL builder chat itself uses.

