### PR TITLE
fix(release): G12 has not run for eleven releases, and would false-fail if it did

### DIFF
--- a/scripts/release_check_m3.sh
+++ b/scripts/release_check_m3.sh
@@ -78,6 +78,43 @@ echo "  base_url: $RAPID_MLX_BASE_URL"
 echo "  log:      $LOG"
 line
 
+# `lsof` decides, here and at the G12 handoff, whether a port is free —
+# and "free" is the one answer that must never be guessed. A PATH without
+# /usr/sbin makes every check silently answer "free": the `if` below swallows
+# the 127, the whole gauntlet runs, and only the last gate notices. Refuse now.
+command -v lsof >/dev/null 2>&1 \
+  || { echo "ERROR: lsof is required (port checks would silently pass)." >&2; exit 2; }
+
+# `lsof` with a per-invocation watchdog.
+#   0 = something is listening   1 = nothing is   2 = could not find out
+# A stuck `lsof` would otherwise stretch any "wait N seconds" loop that calls
+# it into as long as it likes, because the deadline is only read between calls.
+# `-nP` also removes the name/port resolution stalls that cause most of them.
+# Callers must treat 2 as "not free": an unverifiable port is not a free one.
+port_busy() {
+  local port="$1" limit="${2:-10}" pid n=0
+  lsof -nP -i ":$port" >/dev/null 2>&1 &
+  pid=$!
+  while kill -0 "$pid" 2>/dev/null && [ "$n" -lt "$((limit * 10))" ]; do
+    sleep 0.1
+    n=$((n + 1))
+  done
+  if kill -0 "$pid" 2>/dev/null; then
+    kill -9 "$pid" 2>/dev/null || true
+    wait "$pid" 2>/dev/null || true
+    echo "  ! lsof did not return within ${limit}s for port $port" >&2
+    return 2
+  fi
+  local rc=0
+  wait "$pid" || rc=$?
+  # lsof exits 1 for "nothing matched" and anything else for "I failed".
+  case "$rc" in
+    0) return 0 ;;
+    1) return 1 ;;
+    *) return 2 ;;
+  esac
+}
+
 # Pre-flight: refuse if port is busy so we don't accidentally murder
 # someone's debug server.
 if lsof -i ":$PORT" >/dev/null 2>&1; then
@@ -651,11 +688,6 @@ else
   # ``cleanup`` is the trap-installed teardown defined at the top of
   # this script — calling it manually here releases the PID file too, so
   # read the PID before calling it.
-  # `lsof` decides below whether the port is free. Without it every check
-  # silently answers "free", which is the one answer that must never be
-  # guessed — so require it rather than degrade.
-  command -v lsof >/dev/null 2>&1 \
-    || { echo "  ✗ lsof is required to verify the port handoff to G12" >&2; exit 1; }
   OLD_SERVER_PID="$(cat "$PIDFILE" 2>/dev/null || true)"
   # `kill -0` succeeds on a ZOMBIE — a child that has exited but whose status
   # the shell has not collected still owns a pid, and it owns no GPU. Waiting
@@ -690,7 +722,12 @@ else
       sleep 1
       continue
     fi
-    if lsof -i ":$PORT" >/dev/null 2>&1; then
+    # 0 = still listening, 2 = could not find out. Only an explicit 1 — a
+    # check that ran and said nothing is there — releases the handoff; an
+    # unverifiable port is not a free one.
+    port_state=0
+    port_busy "$PORT" 5 || port_state=$?
+    if [ "$port_state" != 1 ]; then
       sleep 1
       continue
     fi

--- a/scripts/release_check_m3.sh
+++ b/scripts/release_check_m3.sh
@@ -803,8 +803,10 @@ else
     --port "$PORT" \
     --models "${G12_MODELS:-2}" \
     --harnesses "${G12_HARNESSES:-2}" \
-    --rounds "${G12_ROUNDS:-3}" \
-    --report /tmp/release-check-m3-random.log
+    --rounds "${G12_ROUNDS:-3}"
+  # No --report: the script defaults it into its own 0700 run directory and
+  # prints the path. A fixed /tmp name is a symlink the next local process can
+  # aim wherever it likes.
 fi
 
 #-------------------- Done ----------------------------------------

--- a/scripts/release_check_m3.sh
+++ b/scripts/release_check_m3.sh
@@ -725,6 +725,12 @@ else
     # exact overlap this two-condition handoff exists to prevent.
     local state
     state="$(ps -o stat= -p "$OLD_SERVER_PID" 2>/dev/null)"
+    # Trim. `ps -o stat=` right-aligns into a column whose width comes from the
+    # widest state on the machine, so a zombie can arrive as " Z+" rather than
+    # "Z+". Matching `Z*` against the padded string fails, the zombie reads as
+    # ALIVE, and the handoff burns its whole 60 s and fails — which is the
+    # false failure this helper was written to remove.
+    state="${state#"${state%%[![:space:]]*}"}"
     case "$state" in
       Z*) return 1 ;;
       *)  return 0 ;;

--- a/scripts/release_check_m3.sh
+++ b/scripts/release_check_m3.sh
@@ -651,6 +651,11 @@ else
   # ``cleanup`` is the trap-installed teardown defined at the top of
   # this script — calling it manually here releases the PID file too, so
   # read the PID before calling it.
+  # `lsof` decides below whether the port is free. Without it every check
+  # silently answers "free", which is the one answer that must never be
+  # guessed — so require it rather than degrade.
+  command -v lsof >/dev/null 2>&1 \
+    || { echo "  ✗ lsof is required to verify the port handoff to G12" >&2; exit 1; }
   OLD_SERVER_PID="$(cat "$PIDFILE" 2>/dev/null || true)"
   cleanup
   sleep 2
@@ -661,8 +666,12 @@ else
   # model next; overlapping that with a process still holding weights is how
   # a gauntlet earns a metal::malloc "Resource limit" that reads like a code
   # bug. Both conditions, then, and neither on its own.
+  #
+  # Wall-clock bounded, not iteration-bounded: a slow or stuck `lsof` would
+  # otherwise stretch "60s" into as long as it likes.
   server_gone=0
-  for _ in $(seq 1 60); do
+  handoff_deadline=$((SECONDS + 60))
+  while [ "$SECONDS" -lt "$handoff_deadline" ]; do
     if [ -n "$OLD_SERVER_PID" ] && kill -0 "$OLD_SERVER_PID" 2>/dev/null; then
       sleep 1
       continue
@@ -685,6 +694,15 @@ else
     echo "    refusing to hand the port and the GPU to G12" >&2
     [ -n "$OLD_SERVER_PID" ] && ps -p "$OLD_SERVER_PID" >&2 || true
     lsof -i ":$PORT" >&2 || true
+    # `cleanup` already TERM'd it and deleted the pidfile, so the EXIT trap
+    # can no longer reach it: exiting here would leave the process alive with
+    # the GPU allocated, poisoning the retry this failure is telling us to
+    # run. Kill it for real before giving up.
+    if [ -n "$OLD_SERVER_PID" ] && kill -0 "$OLD_SERVER_PID" 2>/dev/null; then
+      echo "    SIGKILLing $OLD_SERVER_PID so the retry starts on a free GPU" >&2
+      kill -9 "$OLD_SERVER_PID" 2>/dev/null || true
+      wait "$OLD_SERVER_PID" 2>/dev/null || true
+    fi
     exit 1
   fi
   "$PY" scripts/release_check_m3_random.py \

--- a/scripts/release_check_m3.sh
+++ b/scripts/release_check_m3.sh
@@ -657,6 +657,20 @@ else
   command -v lsof >/dev/null 2>&1 \
     || { echo "  ✗ lsof is required to verify the port handoff to G12" >&2; exit 1; }
   OLD_SERVER_PID="$(cat "$PIDFILE" 2>/dev/null || true)"
+  # `kill -0` succeeds on a ZOMBIE — a child that has exited but whose status
+  # the shell has not collected still owns a pid, and it owns no GPU. Waiting
+  # for one to "go away" burns the whole deadline and then SIGKILLs a corpse,
+  # turning a clean shutdown into a gate failure. Read the state instead.
+  # Non-blocking on purpose: a plain `wait` would hang forever on the shutdown
+  # this deadline exists to catch.
+  old_server_alive() {
+    [ -n "$OLD_SERVER_PID" ] || return 1
+    kill -0 "$OLD_SERVER_PID" 2>/dev/null || return 1
+    case "$(ps -o stat= -p "$OLD_SERVER_PID" 2>/dev/null)" in
+      Z*|"") return 1 ;;
+      *)    return 0 ;;
+    esac
+  }
   cleanup
   sleep 2
   # Wait for the old server to be GONE, not merely for the port to look
@@ -672,7 +686,7 @@ else
   server_gone=0
   handoff_deadline=$((SECONDS + 60))
   while [ "$SECONDS" -lt "$handoff_deadline" ]; do
-    if [ -n "$OLD_SERVER_PID" ] && kill -0 "$OLD_SERVER_PID" 2>/dev/null; then
+    if old_server_alive; then
       sleep 1
       continue
     fi
@@ -698,9 +712,11 @@ else
     # can no longer reach it: exiting here would leave the process alive with
     # the GPU allocated, poisoning the retry this failure is telling us to
     # run. Kill it for real before giving up.
-    if [ -n "$OLD_SERVER_PID" ] && kill -0 "$OLD_SERVER_PID" 2>/dev/null; then
+    if old_server_alive; then
       echo "    SIGKILLing $OLD_SERVER_PID so the retry starts on a free GPU" >&2
       kill -9 "$OLD_SERVER_PID" 2>/dev/null || true
+      # It IS a child of this shell (started with `&` above), so this reaps it
+      # rather than returning 127; SIGKILL cannot be caught, so it cannot hang.
       wait "$OLD_SERVER_PID" 2>/dev/null || true
     fi
     exit 1

--- a/scripts/release_check_m3.sh
+++ b/scripts/release_check_m3.sh
@@ -100,6 +100,10 @@ port_busy() {
     n=$((n + 1))
   done
   if kill -0 "$pid" 2>/dev/null; then
+    # Kills the pid we spawned. If `lsof` were a wrapper script that forked a
+    # helper, the helper would outlive this — real `/usr/sbin/lsof` is a single
+    # process, so that only matters if someone shadows it, and a shadowed lsof
+    # is already the scenario the `command -v` pre-flight cannot defend.
     kill -9 "$pid" 2>/dev/null || true
     wait "$pid" 2>/dev/null || true
     echo "  ! lsof did not return within ${limit}s for port $port" >&2
@@ -117,8 +121,23 @@ port_busy() {
 
 # Pre-flight: refuse if port is busy so we don't accidentally murder
 # someone's debug server.
-if lsof -i ":$PORT" >/dev/null 2>&1; then
-  echo "ERROR: port $PORT already in use — kill the existing server first." >&2
+#
+# Through `port_busy`, not a bare `lsof`: an executable `lsof` that hangs or
+# exits non-zero satisfies the `command -v` check above and then reads as
+# "port free" to a bare `if`. The gauntlet would boot its own server, fail to
+# bind, and run every gate against whatever was already there — which is the
+# contamination this check exists to prevent, arriving through the check
+# itself. Only an explicit 1 (ran, found nothing) is free.
+port_state=0
+port_busy "$PORT" 10 || port_state=$?
+if [ "$port_state" != 1 ]; then
+  if [ "$port_state" = 0 ]; then
+    echo "ERROR: port $PORT already in use — kill the existing server first." >&2
+    lsof -nP -i ":$PORT" >&2 || true
+  else
+    echo "ERROR: could not determine whether port $PORT is free — refusing to" >&2
+    echo "  start rather than run every gate against someone else's server." >&2
+  fi
   exit 2
 fi
 
@@ -698,9 +717,17 @@ else
   old_server_alive() {
     [ -n "$OLD_SERVER_PID" ] || return 1
     kill -0 "$OLD_SERVER_PID" 2>/dev/null || return 1
-    case "$(ps -o stat= -p "$OLD_SERVER_PID" 2>/dev/null)" in
-      Z*|"") return 1 ;;
-      *)    return 0 ;;
+    # `kill -0` succeeded, so SOMETHING is there. Only a zombie is safely gone:
+    # it has exited and released the GPU, it just has not been reaped. Every
+    # other answer — a live state, or a `ps` that failed or printed nothing —
+    # has to count as ALIVE. Reading "I could not tell" as "gone" hands the GPU
+    # to G12 while the old server may still be flushing weights, which is the
+    # exact overlap this two-condition handoff exists to prevent.
+    local state
+    state="$(ps -o stat= -p "$OLD_SERVER_PID" 2>/dev/null)"
+    case "$state" in
+      Z*) return 1 ;;
+      *)  return 0 ;;
     esac
   }
   cleanup
@@ -714,7 +741,10 @@ else
   # bug. Both conditions, then, and neither on its own.
   #
   # Wall-clock bounded, not iteration-bounded: a slow or stuck `lsof` would
-  # otherwise stretch "60s" into as long as it likes.
+  # otherwise stretch this into as long as it likes. The bound is not exact —
+  # the deadline is read BETWEEN operations, so a check starting just under it
+  # can still run its own 5s watchdog out, and the 2s settle above is on top.
+  # Roughly a minute, never unbounded, which is the property that matters.
   server_gone=0
   handoff_deadline=$((SECONDS + 60))
   while [ "$SECONDS" -lt "$handoff_deadline" ]; do
@@ -741,7 +771,7 @@ else
   # this would be caught — but failing here says WHY, instead of timing out
   # while looking healthy.
   if [ "$server_gone" != 1 ]; then
-    echo "  ✗ the gauntlet's server did not exit and free port $PORT within 60s" >&2
+    echo "  ✗ the gauntlet's server did not exit and free port $PORT in ~60s" >&2
     echo "    refusing to hand the port and the GPU to G12" >&2
     [ -n "$OLD_SERVER_PID" ] && ps -p "$OLD_SERVER_PID" >&2 || true
     lsof -i ":$PORT" >&2 || true
@@ -749,7 +779,12 @@ else
     # can no longer reach it: exiting here would leave the process alive with
     # the GPU allocated, poisoning the retry this failure is telling us to
     # run. Kill it for real before giving up.
-    if old_server_alive; then
+    # Only if it is still OUR child. The pid came from `$!`, but a cleanly
+    # exited and reaped server frees that number, and SIGKILLing whatever
+    # inherited it would be a destructive answer to a problem we no longer
+    # have. `ps -o ppid=` is the cheap identity check available here.
+    old_ppid="$(ps -o ppid= -p "$OLD_SERVER_PID" 2>/dev/null | tr -d ' ' || true)"
+    if old_server_alive && [ "$old_ppid" = "$$" ]; then
       echo "    SIGKILLing $OLD_SERVER_PID so the retry starts on a free GPU" >&2
       kill -9 "$OLD_SERVER_PID" 2>/dev/null || true
       # It IS a child of this shell (started with `&` above), so this reaps it

--- a/scripts/release_check_m3.sh
+++ b/scripts/release_check_m3.sh
@@ -131,7 +131,15 @@ cleanup() {
   fi
   # The concurrent correctness cluster stages per-gate logs/rc under a
   # mktemp dir; remove it too so an abort mid-cluster doesn't leak /tmp.
-  [ -n "${CLUSTER_WORK:-}" ] && rm -rf "$CLUSTER_WORK"
+  #
+  # `if`, not `[ … ] && rm`: this function is ALSO called inline before G12,
+  # where its return status is load-bearing under `set -e`. As an `&&` list it
+  # returns 1 whenever CLUSTER_WORK is empty — which it always is by then, the
+  # cluster having cleared it — and the gauntlet died there instead of running
+  # the gate.
+  if [ -n "${CLUSTER_WORK:-}" ]; then
+    rm -rf "$CLUSTER_WORK"
+  fi
 }
 trap cleanup EXIT INT TERM
 

--- a/scripts/release_check_m3.sh
+++ b/scripts/release_check_m3.sh
@@ -649,17 +649,44 @@ else
   line
   # Free the gauntlet's main server so G12 owns the port + GPU.
   # ``cleanup`` is the trap-installed teardown defined at the top of
-  # this script — calling it manually here releases the PID file too.
+  # this script — calling it manually here releases the PID file too, so
+  # read the PID before calling it.
+  OLD_SERVER_PID="$(cat "$PIDFILE" 2>/dev/null || true)"
   cleanup
   sleep 2
-  # Wait for the port to actually free (cleanup sends TERM; the server
-  # then runs PR #667's deadline-aware prefix-cache flush on shutdown).
-  for _ in $(seq 1 10); do
-    if ! lsof -i ":$PORT" >/dev/null 2>&1; then
-      break
+  # Wait for the old server to be GONE, not merely for the port to look
+  # free. uvicorn closes its listening socket before lifespan shutdown
+  # completes — and shutdown is where PR #667's deadline-aware prefix-cache
+  # flush runs — so a free port is not yet an idle GPU. G12 loads its own
+  # model next; overlapping that with a process still holding weights is how
+  # a gauntlet earns a metal::malloc "Resource limit" that reads like a code
+  # bug. Both conditions, then, and neither on its own.
+  server_gone=0
+  for _ in $(seq 1 60); do
+    if [ -n "$OLD_SERVER_PID" ] && kill -0 "$OLD_SERVER_PID" 2>/dev/null; then
+      sleep 1
+      continue
     fi
-    sleep 1
+    if lsof -i ":$PORT" >/dev/null 2>&1; then
+      sleep 1
+      continue
+    fi
+    server_gone=1
+    break
   done
+  # Handing over an occupied port is worse than stopping here. G12 boots its
+  # own server and waits for :$PORT to answer; whatever is still sitting
+  # there answers first, and the sweep would benchmark a stranger under the
+  # sampled alias's name. G12 checks that the listener is its own child, so
+  # this would be caught — but failing here says WHY, instead of timing out
+  # while looking healthy.
+  if [ "$server_gone" != 1 ]; then
+    echo "  ✗ the gauntlet's server did not exit and free port $PORT within 60s" >&2
+    echo "    refusing to hand the port and the GPU to G12" >&2
+    [ -n "$OLD_SERVER_PID" ] && ps -p "$OLD_SERVER_PID" >&2 || true
+    lsof -i ":$PORT" >&2 || true
+    exit 1
+  fi
   "$PY" scripts/release_check_m3_random.py \
     --port "$PORT" \
     --models "${G12_MODELS:-2}" \

--- a/scripts/release_check_m3_random.py
+++ b/scripts/release_check_m3_random.py
@@ -428,6 +428,11 @@ def _parent_pid(pid: int) -> int | None:
         )
     except (OSError, subprocess.SubprocessError):
         return None
+    # Same rule as `_listening_pids`: a non-zero exit discards the output. A
+    # `ps` that failed after printing something stale would otherwise hand back
+    # a parent that makes a stranger look like our descendant.
+    if out.returncode != 0:
+        return None
     text = out.stdout.strip()
     return int(text) if text.isdigit() else None
 
@@ -517,7 +522,7 @@ def _still_ours(proc: subprocess.Popen, port: int) -> str:
 
 def _wait_for_server(
     proc: subprocess.Popen, port: int, deadline_s: float, log_path: Path
-) -> bool:
+) -> tuple[bool, bool]:
     """Poll ``/v1/models`` until our own server responds 200, the child
     exits, or the deadline expires. Returns True on success, False
     otherwise.
@@ -532,10 +537,17 @@ def _wait_for_server(
     loading weights it is very much alive, so a stranger already on the
     port answers first and the sweep would report that stranger's numbers
     under the sampled alias's name. Hence ``_owns_port``.
+
+    Returns ``(ready, saw_stranger)``. The second value is the difference
+    between "this model would not boot" — one model's problem, move on — and
+    "somebody else has the port", which is the environment's problem and makes
+    every later model's numbers meaningless too. Collapsing both into ``False``
+    is how the sweep used to carry on into a contaminated machine.
     """
     url = f"http://127.0.0.1:{port}/v1/models"
     start = time.monotonic()
     warned_stranger = False
+    saw_stranger = False
     while time.monotonic() - start < deadline_s:
         rc = proc.poll()
         if rc is not None:
@@ -548,7 +560,8 @@ def _wait_for_server(
             with urllib.request.urlopen(url, timeout=3) as resp:
                 if resp.status == 200:
                     if _owns_port(proc, port):
-                        return True
+                        return True, saw_stranger
+                    saw_stranger = True
                     if not warned_stranger:
                         warned_stranger = True
                         print(
@@ -567,7 +580,7 @@ def _wait_for_server(
         print("  server log (last 30 lines):", file=sys.stderr)
         for line in log_path.read_text(errors="replace").splitlines()[-30:]:
             print(f"    {line}", file=sys.stderr)
-    return False
+    return False, saw_stranger
 
 
 def _port_free(port: int) -> bool:
@@ -845,8 +858,23 @@ def main() -> int:
                 cwd=REPO_ROOT,
             )
         try:
-            if not _wait_for_server(proc, args.port, SERVE_READY_TIMEOUT_S, log_path):
-                msg = f"{alias}: server did not respond within {SERVE_READY_TIMEOUT_S}s"
+            ready, saw_stranger = _wait_for_server(
+                proc, args.port, SERVE_READY_TIMEOUT_S, log_path
+            )
+            if not ready:
+                if saw_stranger:
+                    # Not this model's failure. Something else holds the port,
+                    # and it will still hold it for the next model.
+                    msg = (
+                        f"{alias}: port {args.port} was answered by another "
+                        f"process while this model was booting"
+                    )
+                    drifted = True
+                else:
+                    msg = (
+                        f"{alias}: server did not respond within "
+                        f"{SERVE_READY_TIMEOUT_S}s"
+                    )
                 print(f"  FAIL  {msg}", file=sys.stderr)
                 with report_path.open("a") as fh:
                     fh.write(f"FAIL  {msg}\n")

--- a/scripts/release_check_m3_random.py
+++ b/scripts/release_check_m3_random.py
@@ -118,9 +118,16 @@ ROUND_TIMEOUT_S = 1080
 # share the 4B ceiling, this constant moves again — that is how the gemma-4 and
 # hybrid excludes got here.
 #
-# Excluding the 4B tier does not leave it unobserved: ``qwen3.5-4b-4bit`` is a
-# release-fleet coherence model, so G0a boots it every gauntlet. What it loses
-# is agentic coverage, which is the coverage it cannot provide.
+# What this costs, stated plainly rather than waved away: the 4B tier keeps
+# only the coverage it already had, and that is thin. ``qwen3.5-4b-4bit`` is a
+# release-fleet coherence model, so G0a boots it every gauntlet — but
+# ``evals/coherence_gate.py`` sends short, single-turn, tool-free prompts at
+# temperature 0. CI's ``l1-smoke`` adds one forced tool-call format check on the
+# same alias, and is not a required check. Neither covers multi-turn contexts,
+# streaming tool calls, parser stress under repeated agent traffic, or the other
+# three 4B aliases at all. Buying that back needs a small-model tier that is
+# sized for what small models can finish, not a sweep that hands them the same
+# agentic profiles as a 12B — tracked separately.
 _MIN_PARAMS_B = 6.0
 # Ceiling: larger models bust the disk budget on M3 16/32 GB systems.
 _MAX_PARAMS_B = 12.0
@@ -254,6 +261,15 @@ def _hf_cache_dir(hf_repo_path: str) -> Path:
     return _hf_cache_root() / f"models--{hf_repo_path.replace('/', '--')}"
 
 
+def _as_text(payload: str | bytes | None) -> str:
+    """``TimeoutExpired`` carries bytes even when the run asked for text."""
+    if payload is None:
+        return ""
+    if isinstance(payload, bytes):
+        return payload.decode("utf-8", errors="replace")
+    return payload
+
+
 def _serve_log_path(alias: str) -> Path:
     """Where the sampled server's own stdout goes."""
     return Path(f"/tmp/release-check-m3-random-{alias}.log")
@@ -289,7 +305,14 @@ def _parent_pid(pid: int) -> int | None:
 
 def _listening_pids(port: int) -> list[int]:
     """PIDs with a LISTEN socket on ``port``; ``[]`` if that cannot be
-    established (``lsof`` missing, permission denied, timeout)."""
+    established (``lsof`` missing, permission denied, timeout, partial run).
+
+    A non-zero exit discards the output rather than trusting it. ``lsof`` can
+    print some rows and then fail on a socket it may not inspect, and half a
+    listener list is worse than none here: the caller reads "all of these are
+    ours" as ownership, so the one row that was not printed is exactly the
+    stranger it was asked about.
+    """
     try:
         out = subprocess.run(
             ["lsof", "-nP", f"-iTCP:{port}", "-sTCP:LISTEN", "-t"],
@@ -298,6 +321,8 @@ def _listening_pids(port: int) -> list[int]:
             timeout=10,
         )
     except (OSError, subprocess.SubprocessError):
+        return []
+    if out.returncode != 0:
         return []
     return [int(tok) for tok in out.stdout.split() if tok.isdigit()]
 
@@ -333,6 +358,25 @@ def _owns_port(proc: subprocess.Popen, port: int, max_depth: int = 8) -> bool:
         else:
             return False
     return True
+
+
+def _still_ours(proc: subprocess.Popen, port: int) -> str:
+    """``""`` while the server we started still owns the port, else why not.
+
+    Readiness establishes ownership once, at the start of a sweep that then
+    runs for tens of minutes. Everything measured after a takeover belongs to
+    whoever took over, so this is asked around every round rather than trusted
+    from the beginning.
+    """
+    rc = proc.poll()
+    if rc is not None:
+        return f"the server exited (rc={rc})"
+    if not _owns_port(proc, port):
+        return (
+            f"port {port} is no longer served by our process (pid {proc.pid}); "
+            f"listeners={_listening_pids(port) or '<could not determine>'}"
+        )
+    return ""
 
 
 def _wait_for_server(
@@ -461,8 +505,19 @@ def _run_harness_round(
             capture_output=True,
             text=True,
         )
-    except subprocess.TimeoutExpired:
+    except subprocess.TimeoutExpired as expired:
         dur = time.monotonic() - t0
+        # Whatever bench managed to say before the clock stopped it is the only
+        # evidence there will be about WHERE it got stuck. Returning without
+        # writing it leaves the one failure class that most needs a transcript
+        # with none at all.
+        with bench_log.open("a") as fh:
+            fh.write(f"\n=== {alias}/{harness} (TIMED OUT after {dur:.1f}s) ===\n")
+            fh.write(_as_text(expired.stdout))
+            stderr_text = _as_text(expired.stderr)
+            if stderr_text:
+                fh.write("\n--- stderr ---\n")
+                fh.write(stderr_text)
         return False, dur, f"round timed out after {ROUND_TIMEOUT_S}s"
     dur = time.monotonic() - t0
     # Append the subprocess output to the bench log so a failure has
@@ -662,14 +717,45 @@ def main() -> int:
                 continue
             print(f"     server up ({alias}); harnesses={harnesses}")
             base_url = f"http://127.0.0.1:{args.port}"
+            drifted = False
             for harness in harnesses:
+                if drifted:
+                    break
                 for r in range(1, args.rounds + 1):
+                    # Ownership is not a one-time fact. Readiness proved the
+                    # port was ours when the sweep started; a takeover after
+                    # that (#1618 again) hands every later round to a stranger,
+                    # and the numbers come back attributed to the sampled
+                    # alias. Ask before AND after — before, so we do not
+                    # measure someone else; after, so a takeover mid-round
+                    # cannot be reported as a result.
+                    drift = _still_ours(proc, args.port)
+                    if drift:
+                        msg = f"{alias}/{harness} round {r}: {drift} before the round"
+                        print(f"     FAIL  {msg}", file=sys.stderr)
+                        with report_path.open("a") as fh:
+                            fh.write(f"FAIL  {msg}\n")
+                        failures.append(msg)
+                        drifted = True
+                        break
                     ok, dur, excerpt = _run_harness_round(
                         alias=alias,
                         harness=harness,
                         base_url=base_url,
                         bench_log=bench_log,
                     )
+                    drift = _still_ours(proc, args.port)
+                    if drift:
+                        msg = (
+                            f"{alias}/{harness} round {r}: {drift} during the round"
+                            " — its result cannot be attributed to this model"
+                        )
+                        print(f"     FAIL  {msg}", file=sys.stderr)
+                        with report_path.open("a") as fh:
+                            fh.write(f"FAIL  {msg}\n")
+                        failures.append(msg)
+                        drifted = True
+                        break
                     marker = "PASS" if ok else "FAIL"
                     line = (
                         f"     {marker} {alias}/{harness} "

--- a/scripts/release_check_m3_random.py
+++ b/scripts/release_check_m3_random.py
@@ -254,10 +254,91 @@ def _hf_cache_dir(hf_repo_path: str) -> Path:
     return _hf_cache_root() / f"models--{hf_repo_path.replace('/', '--')}"
 
 
+def _serve_log_path(alias: str) -> Path:
+    """Where the sampled server's own stdout goes."""
+    return Path(f"/tmp/release-check-m3-random-{alias}.log")
+
+
+def _bench_log_path(alias: str) -> Path:
+    """Where each round's bench transcript goes.
+
+    Deliberately NOT the serve log. The server writes through a descriptor it
+    opened ``"w"``, tracking its own byte offset; appending to the same path
+    from here moves the end of the file without moving that offset, and the
+    server's next line lands on top of the transcript. Two writers, one of
+    them offset-based, corrupts the artifact on exactly the runs someone
+    needs to read.
+    """
+    return Path(f"/tmp/release-check-m3-random-{alias}.bench.log")
+
+
+def _parent_pid(pid: int) -> int | None:
+    """PPID of ``pid``, or None when it cannot be read."""
+    try:
+        out = subprocess.run(
+            ["ps", "-o", "ppid=", "-p", str(pid)],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    text = out.stdout.strip()
+    return int(text) if text.isdigit() else None
+
+
+def _listening_pids(port: int) -> list[int]:
+    """PIDs with a LISTEN socket on ``port``; ``[]`` if that cannot be
+    established (``lsof`` missing, permission denied, timeout)."""
+    try:
+        out = subprocess.run(
+            ["lsof", "-nP", f"-iTCP:{port}", "-sTCP:LISTEN", "-t"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return []
+    return [int(tok) for tok in out.stdout.split() if tok.isdigit()]
+
+
+def _owns_port(proc: subprocess.Popen, port: int, max_depth: int = 8) -> bool:
+    """True when every listener on ``port`` is ``proc`` or a descendant.
+
+    A 200 on the port proves something is there, not that it is ours, and
+    identity is not ownership either: asking ``/v1/models`` what it serves
+    accepts a leftover sidecar or an older engine that happens to hold the
+    same weights. This walks the process tree instead, so the only thing
+    that satisfies it is the child we started.
+
+    Not hypothetical. While a gauntlet was running, a desktop app on this
+    machine swept port 8000, SIGTERM'd the gauntlet's server and bound its
+    own sidecar (#1618); every later request went there. It went unnoticed
+    because the replacement answered perfectly well.
+
+    Fails CLOSED: an empty listener list while the port demonstrably answers
+    means ``lsof`` could not tell us, and an unverifiable port is refused.
+    """
+    listeners = _listening_pids(port)
+    if not listeners:
+        return False
+    for pid in listeners:
+        cur: int | None = pid
+        for _ in range(max_depth):
+            if cur == proc.pid:
+                break
+            if cur is None or cur <= 1:
+                return False
+            cur = _parent_pid(cur)
+        else:
+            return False
+    return True
+
+
 def _wait_for_server(
     proc: subprocess.Popen, port: int, deadline_s: float, log_path: Path
 ) -> bool:
-    """Poll ``/v1/models`` until the server responds 200, the child
+    """Poll ``/v1/models`` until our own server responds 200, the child
     exits, or the deadline expires. Returns True on success, False
     otherwise.
 
@@ -266,9 +347,15 @@ def _wait_for_server(
     pre-flight, mlx-lm import error on a clean venv), there is no port
     that will ever come up. Without this check we'd burn the full 600 s
     deadline polling a dead child.
+
+    It is not sufficient on its own, though: while our child is still
+    loading weights it is very much alive, so a stranger already on the
+    port answers first and the sweep would report that stranger's numbers
+    under the sampled alias's name. Hence ``_owns_port``.
     """
     url = f"http://127.0.0.1:{port}/v1/models"
     start = time.monotonic()
+    warned_stranger = False
     while time.monotonic() - start < deadline_s:
         rc = proc.poll()
         if rc is not None:
@@ -280,7 +367,17 @@ def _wait_for_server(
         try:
             with urllib.request.urlopen(url, timeout=3) as resp:
                 if resp.status == 200:
-                    return True
+                    if _owns_port(proc, port):
+                        return True
+                    if not warned_stranger:
+                        warned_stranger = True
+                        print(
+                            f"  port {port} answers, but the listener is not our "
+                            f"server (pid {proc.pid}); listeners="
+                            f"{_listening_pids(port) or '<could not determine>'} "
+                            f"— still waiting",
+                            file=sys.stderr,
+                        )
         except (urllib.error.URLError, urllib.error.HTTPError, OSError):
             pass
         time.sleep(2)
@@ -323,10 +420,19 @@ def _run_harness_round(
     alias: str,
     harness: str,
     base_url: str,
-    log_path: Path,
+    bench_log: Path,
 ) -> tuple[bool, float, str]:
     """Run one ``bench --tier harness`` invocation scoped to one
-    harness. Returns ``(ok, wall_clock_s, error_excerpt)``."""
+    harness. Returns ``(ok, wall_clock_s, error_excerpt)``.
+
+    ``bench_log`` is a DIFFERENT file from the server log on purpose. The
+    server holds its own descriptor on that file, opened ``"w"`` — no
+    ``O_APPEND``, so it writes at a position it tracks itself. Appending
+    bench output to the same path moves the end of the file without moving
+    that position, and the server's next line lands on top of what we just
+    wrote. Two writers, one of them offset-based, is a corrupted artifact on
+    exactly the runs anyone needs to read.
+    """
     env = {**os.environ, "RAPID_MLX_HARNESS_PROFILES_FILTER": harness}
     # Right-size the inner per-profile cap for standalone runs. Via
     # release_check_m3.sh the gauntlet exports HARNESS_PROFILE_TIMEOUT_S
@@ -359,10 +465,10 @@ def _run_harness_round(
         dur = time.monotonic() - t0
         return False, dur, f"round timed out after {ROUND_TIMEOUT_S}s"
     dur = time.monotonic() - t0
-    # Append the subprocess output to our log so a failure has
+    # Append the subprocess output to the bench log so a failure has
     # a debuggable trail. ``"a"`` mode is single-write-atomic enough for
     # our single-threaded sweep loop.
-    with log_path.open("a") as fh:
+    with bench_log.open("a") as fh:
         fh.write(
             f"\n=== {alias}/{harness} (exit={result.returncode}, {dur:.1f}s) ===\n"
         )
@@ -378,7 +484,7 @@ def _run_harness_round(
                 excerpt = line.strip()[:200]
                 break
         if not excerpt:
-            excerpt = f"exit {result.returncode}; see {log_path}"
+            excerpt = f"exit {result.returncode}; see {bench_log}"
         return False, dur, excerpt
     return True, dur, ""
 
@@ -526,8 +632,10 @@ def main() -> int:
     for alias, hf_path, harnesses in sampled:
         print()
         print(f"  >> Booting {alias} on port {args.port}…")
-        log_path = Path(f"/tmp/release-check-m3-random-{alias}.log")
+        log_path = _serve_log_path(alias)
+        bench_log = _bench_log_path(alias)
         log_path.write_text("")
+        bench_log.write_text("")
         with log_path.open("w") as logfh:
             proc = subprocess.Popen(
                 [
@@ -560,7 +668,7 @@ def main() -> int:
                         alias=alias,
                         harness=harness,
                         base_url=base_url,
-                        log_path=log_path,
+                        bench_log=bench_log,
                     )
                     marker = "PASS" if ok else "FAIL"
                     line = (

--- a/scripts/release_check_m3_random.py
+++ b/scripts/release_check_m3_random.py
@@ -37,9 +37,11 @@ allocate ~14 GB, but cleanup runs after each model so peak working set
 is one model at a time + 5 GB headroom).
 
 Eligibility filter (sample pool):
-  * 4 ≤ size_B ≤ 12  (smaller models can't actually solve harness tasks
-                       → false-fail spam; larger models bust the disk
-                       budget on M3 16/32 GB systems)
+  * 6 ≤ size_B ≤ 12  (smaller models can't actually solve harness tasks
+                       → they burn the whole per-profile clock retrying
+                       and the gauntlet goes red on a working engine, see
+                       #1672; larger models bust the disk budget on M3
+                       16/32 GB systems)
   * 4-bit quant only  (8-bit is 2x download cost for the same coverage)
   * no kimi-*         (deliberately heavy class, explicit user exclude)
   * no -vl- variants  (vision; harness tasks are text-only)
@@ -90,6 +92,38 @@ SERVE_READY_TIMEOUT_S = 600  # 10 minutes
 # (HARNESS_PROFILE_TIMEOUT_S, 1200s in the gauntlet) so in the gauntlet
 # the outer subprocess timeout — not the inner cap — bounds a hung round.
 ROUND_TIMEOUT_S = 1080
+
+# Sample-pool size window, in billions of parameters.
+#
+# Every profile in HARNESS_PROFILES drives a multi-step tool-calling loop, and
+# a model that cannot hold one does not fail fast: it emits malformed calls and
+# retries until the per-profile clock runs out. G12 can only report that as a
+# red gauntlet, so the pool has to exclude models that cannot do the work —
+# the same rule the hybrid, gemma-4 and low-active-param excludes below apply.
+#
+# The floor sits at 6 because that is the conservative cut between the two
+# sizes actually measured on this hardware:
+#
+#   * 4B fails — ``qwen3-4b-instruct-2507-4bit`` × ``hermes`` burned the whole
+#     1020 s cap while the engine answered without a single 5xx, and v0.12.7
+#     does exactly the same, so it is the model's ceiling, not a regression
+#     (#1672). The other three 4B aliases are excluded with it rather than
+#     waiting to be drawn and measured one by one: a coverage sweep that cries
+#     wolf on a random calendar day stops being read at all.
+#   * 9B passes — a dense 9B completes hermes in ~740-800 s (see
+#     ROUND_TIMEOUT_S above), which is where that budget came from.
+#
+# 7B and 8B are in between and unmeasured; they stay in the pool because that
+# band is where most of the sweep's coverage lives. If one of them turns out to
+# share the 4B ceiling, this constant moves again — that is how the gemma-4 and
+# hybrid excludes got here.
+#
+# Excluding the 4B tier does not leave it unobserved: ``qwen3.5-4b-4bit`` is a
+# release-fleet coherence model, so G0a boots it every gauntlet. What it loses
+# is agentic coverage, which is the coverage it cannot provide.
+_MIN_PARAMS_B = 6.0
+# Ceiling: larger models bust the disk budget on M3 16/32 GB systems.
+_MAX_PARAMS_B = 12.0
 
 
 # Match a parameter-count token bounded by name separators (``-``,
@@ -154,14 +188,14 @@ def _eligible_aliases(aliases_path: Path) -> list[tuple[str, str]]:
             # oversized model into the sweep.
             continue
         size_b = float(match.group(1))
-        if not (4.0 <= size_b <= 12.0):
+        if not (_MIN_PARAMS_B <= size_b <= _MAX_PARAMS_B):
             continue
         # Effective-capacity floor for MoEs: e.g. ``LFM2.5-8B-A1B`` is 8B
-        # total but ~1B ACTIVE/token — too weak to solve agentic harness
-        # tasks (emits malformed tool calls → false-fail spam), the same
-        # rationale as the 4B total-size floor but applied to active params.
+        # total but ~1B ACTIVE/token. The same floor, applied to the params
+        # that actually do the work — a model's ability to hold an agentic
+        # loop follows its active parameters, not its total.
         active_m = _ACTIVE_TOKEN_RE.search(repo_name)
-        if active_m and float(active_m.group(1)) < 4.0:
+        if active_m and float(active_m.group(1)) < _MIN_PARAMS_B:
             continue
         out.append((size_b, name, hf_path))
     out.sort()

--- a/scripts/release_check_m3_random.py
+++ b/scripts/release_check_m3_random.py
@@ -344,6 +344,13 @@ def _owns_port(proc: subprocess.Popen, port: int, max_depth: int = 8) -> bool:
     Fails CLOSED: an empty listener list while the port demonstrably answers
     means ``lsof`` could not tell us, and an unverifiable port is refused.
     """
+    # Every process is a descendant of init, so "the listener descends from
+    # pid 1" is true of every listener and proves nothing. Measured, not
+    # theorised: with a real listener on a real port, this returned True for
+    # pid 1 until the guard existed — and the unit tests could not see it,
+    # because they stub the parent walk.
+    if proc.pid <= 1:
+        return False
     listeners = _listening_pids(port)
     if not listeners:
         return False

--- a/scripts/release_check_m3_random.py
+++ b/scripts/release_check_m3_random.py
@@ -803,6 +803,17 @@ def main() -> int:
         return 2
 
     # ===== Pre-flight =====
+    # Ownership is established from the listener process tree. Without lsof,
+    # an answering server is indistinguishable from a stranger and the ready
+    # loop would burn its full ten-minute deadline before saying so. The shell
+    # wrapper checks this too, but this script is also a supported standalone
+    # entry point.
+    if shutil.which("lsof") is None:
+        print(
+            "  Error: lsof is required to verify G12 server ownership.",
+            file=sys.stderr,
+        )
+        return 2
     if not _port_free(args.port):
         print(
             f"  Error: port {args.port} already in use — kill the existing "
@@ -967,11 +978,11 @@ def main() -> int:
         print(f"  G12: {len(failures)} failure(s)")
         for f in failures:
             print(f"    - {f}")
-        print(f"  Full log: {args.report}")
+        print(f"  Full log: {report_path}")
         print("=" * 60)
         return 1
     print("  G12: ALL rounds passed")
-    print(f"  Full log: {args.report}")
+    print(f"  Full log: {report_path}")
     print("=" * 60)
     return 0
 

--- a/scripts/release_check_m3_random.py
+++ b/scripts/release_check_m3_random.py
@@ -44,7 +44,9 @@ Eligibility filter (sample pool):
                        16/32 GB systems)
   * 4-bit quant only  (8-bit is 2x download cost for the same coverage)
   * no kimi-*         (deliberately heavy class, explicit user exclude)
-  * no -vl- variants  (vision; harness tasks are text-only)
+  * no multimodal     (vision; harness tasks are text-only — matched with
+                       the engine's own MLLM_PATTERNS, not a name guess:
+                       UI-TARS and Gemma 3 carry no ``VL`` marker)
   * no gemma-4-*      (known model-side hang on tool-use prompts; see
                        issue #686 + huggingface/google/gemma-4-12B-it
                        discussion #41 — would burn 156s+ per round on
@@ -73,6 +75,57 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 # here so this script doesn't need to import the package (which would
 # pull mlx_lm at module-load and fail in a clean-venv sanity run).
 HARNESS_PROFILES = ("codex", "opencode", "hermes", "aider", "langchain")
+
+# Mirror of ``vllm_mlx.api.utils.MLLM_PATTERNS``, for the same reason as
+# HARNESS_PROFILES: importing the package pulls mlx_lm at module load.
+#
+# Hand-rolling this was a bug. The filter used to exclude vision models by
+# looking for ``-vl-`` in the alias name, which is precisely the test the engine
+# documents as insufficient: UI-TARS is a Qwen2.5-VL-based GUI agent whose
+# public name carries no ``VL``, and Gemma 3 is multimodal with no marker at
+# all. Both were in the sample pool. Booting one through a text-only agentic
+# harness is not thin coverage, it is a crash on an install without the vision
+# extra — and something worse than a crash on one with it.
+#
+# ``tests/test_release_check_random.py`` parses the real list out of
+# ``vllm_mlx/api/utils.py`` and fails if this mirror stops covering it, so a
+# family added upstream cannot silently reappear here.
+MLLM_NAME_PATTERNS = (
+    "-vl-",
+    "-vl/",
+    "vl-",
+    "llava",
+    "idefics",
+    "paligemma",
+    "gemma-3",
+    "gemma3",
+    "medgemma",
+    "pixtral",
+    "molmo",
+    "phi3-vision",
+    "phi-3-vision",
+    "cogvlm",
+    "internvl",
+    "deepseek-vl",
+    "ui-tars",
+    "ui_tars",
+)
+
+
+def _is_multimodal(*names: str) -> bool:
+    """True when any of ``names`` looks like a multimodal model.
+
+    Same case-folded substring rule as ``vllm_mlx.api.utils.is_mllm_model``.
+    Both the alias and the HF path are checked: the alias is what a human
+    recognises, the repo name is where the family marker usually survives.
+    """
+    return any(
+        pattern in name.lower()
+        for name in names
+        if name
+        for pattern in MLLM_NAME_PATTERNS
+    )
+
 
 # Disk safety floor — refuse to start if the cache disk has less than
 # this. Sized for one 12B-4bit model + 5 GB headroom.
@@ -114,7 +167,9 @@ ROUND_TIMEOUT_S = 1080
 #     ROUND_TIMEOUT_S above), which is where that budget came from.
 #
 # 7B and 8B are in between and unmeasured; they stay in the pool because that
-# band is where most of the sweep's coverage lives. If one of them turns out to
+# band is where most of the sweep's coverage lives (what is left of it: the
+# multimodal filter above takes the three UI-TARS aliases as well, and the pool
+# is down to five). If one of them turns out to
 # share the 4B ceiling, this constant moves again — that is how the gemma-4 and
 # hybrid excludes got here.
 #
@@ -169,8 +224,6 @@ def _eligible_aliases(aliases_path: Path) -> list[tuple[str, str]]:
             continue
         if "kimi" in name.lower():
             continue
-        if "-vl-" in name.lower():
-            continue
         if name.lower().startswith("gemma-4-"):
             # Known-bad: model-side ``thought\n…`` loop on agent prompts.
             # See issue #686 + HF discussion google/gemma-4-12B-it#41.
@@ -186,6 +239,13 @@ def _eligible_aliases(aliases_path: Path) -> list[tuple[str, str]]:
         # should silently skip the entry, not crash the gauntlet.
         hf_path = entry.get("hf_path") if isinstance(entry, dict) else None
         if not hf_path:
+            continue
+        # Multimodal models, checked against the engine's own rule rather than
+        # a hand-rolled name test — the harness profiles are text-only, so a
+        # VLM here is a crash on a base install and a meaningless result on a
+        # vision-enabled one. The HF path matters as much as the alias: the
+        # family marker survives there when the alias has dropped it.
+        if _is_multimodal(name, hf_path):
             continue
         repo_name = hf_path.split("/")[-1]
         match = _SIZE_TOKEN_RE.search(repo_name)
@@ -259,6 +319,75 @@ def _hf_cache_root() -> Path:
 def _hf_cache_dir(hf_repo_path: str) -> Path:
     """Path of the HuggingFace cache entry for ``hf_repo_path``."""
     return _hf_cache_root() / f"models--{hf_repo_path.replace('/', '--')}"
+
+
+def _run_model_rounds(
+    *,
+    proc: subprocess.Popen,
+    port: int,
+    alias: str,
+    harnesses: list[str],
+    rounds: int,
+    bench_log: Path,
+    report_path: Path,
+) -> tuple[list[str], bool]:
+    """Run every (harness × round) for one booted model.
+
+    Returns ``(failures, drifted)``. ``drifted`` means the port stopped being
+    ours partway through — an infrastructure failure rather than a result, and
+    the caller's cue to stop the whole sweep rather than boot the next model
+    into whatever took it.
+
+    Extracted from ``main`` so the control flow can be tested: that ownership
+    is asked before AND after each round, that a round whose ownership changed
+    is not reported as a result, and that the remaining harnesses are skipped.
+    Reading the source to check a call site is present does not establish any
+    of those.
+    """
+    failures: list[str] = []
+    base_url = f"http://127.0.0.1:{port}"
+
+    def _record(msg: str) -> None:
+        print(f"     FAIL  {msg}", file=sys.stderr)
+        with report_path.open("a") as fh:
+            fh.write(f"FAIL  {msg}\n")
+        failures.append(msg)
+
+    for harness in harnesses:
+        for r in range(1, rounds + 1):
+            # Ownership is not a one-time fact. Readiness proved the port was
+            # ours when the sweep started; a takeover after that (#1618 again)
+            # hands every later round to a stranger and the numbers come back
+            # attributed to the sampled alias. Ask before AND after — before,
+            # so we do not measure someone else; after, so a takeover mid-round
+            # cannot be reported as a result.
+            drift = _still_ours(proc, port)
+            if drift:
+                _record(f"{alias}/{harness} round {r}: {drift} before the round")
+                return failures, True
+            ok, dur, excerpt = _run_harness_round(
+                alias=alias,
+                harness=harness,
+                base_url=base_url,
+                bench_log=bench_log,
+            )
+            drift = _still_ours(proc, port)
+            if drift:
+                _record(
+                    f"{alias}/{harness} round {r}: {drift} during the round"
+                    " — its result cannot be attributed to this model"
+                )
+                return failures, True
+            marker = "PASS" if ok else "FAIL"
+            line = f"     {marker} {alias}/{harness} round {r}/{rounds} ({dur:.1f}s)"
+            if excerpt:
+                line += f"  — {excerpt}"
+            print(line)
+            with report_path.open("a") as fh:
+                fh.write(line + "\n")
+            if not ok:
+                failures.append(f"{alias}/{harness} round {r}: {excerpt}")
+    return failures, False
 
 
 def _as_text(payload: str | bytes | None) -> str:
@@ -691,6 +820,7 @@ def main() -> int:
 
     # ===== Sweep =====
     failures: list[str] = []
+    drifted = False
     for alias, hf_path, harnesses in sampled:
         print()
         print(f"  >> Booting {alias} on port {args.port}…")
@@ -723,58 +853,16 @@ def main() -> int:
                 failures.append(msg)
                 continue
             print(f"     server up ({alias}); harnesses={harnesses}")
-            base_url = f"http://127.0.0.1:{args.port}"
-            drifted = False
-            for harness in harnesses:
-                if drifted:
-                    break
-                for r in range(1, args.rounds + 1):
-                    # Ownership is not a one-time fact. Readiness proved the
-                    # port was ours when the sweep started; a takeover after
-                    # that (#1618 again) hands every later round to a stranger,
-                    # and the numbers come back attributed to the sampled
-                    # alias. Ask before AND after — before, so we do not
-                    # measure someone else; after, so a takeover mid-round
-                    # cannot be reported as a result.
-                    drift = _still_ours(proc, args.port)
-                    if drift:
-                        msg = f"{alias}/{harness} round {r}: {drift} before the round"
-                        print(f"     FAIL  {msg}", file=sys.stderr)
-                        with report_path.open("a") as fh:
-                            fh.write(f"FAIL  {msg}\n")
-                        failures.append(msg)
-                        drifted = True
-                        break
-                    ok, dur, excerpt = _run_harness_round(
-                        alias=alias,
-                        harness=harness,
-                        base_url=base_url,
-                        bench_log=bench_log,
-                    )
-                    drift = _still_ours(proc, args.port)
-                    if drift:
-                        msg = (
-                            f"{alias}/{harness} round {r}: {drift} during the round"
-                            " — its result cannot be attributed to this model"
-                        )
-                        print(f"     FAIL  {msg}", file=sys.stderr)
-                        with report_path.open("a") as fh:
-                            fh.write(f"FAIL  {msg}\n")
-                        failures.append(msg)
-                        drifted = True
-                        break
-                    marker = "PASS" if ok else "FAIL"
-                    line = (
-                        f"     {marker} {alias}/{harness} "
-                        f"round {r}/{args.rounds} ({dur:.1f}s)"
-                    )
-                    if excerpt:
-                        line += f"  — {excerpt}"
-                    print(line)
-                    with report_path.open("a") as fh:
-                        fh.write(line + "\n")
-                    if not ok:
-                        failures.append(f"{alias}/{harness} round {r}: {excerpt}")
+            round_failures, drifted = _run_model_rounds(
+                proc=proc,
+                port=args.port,
+                alias=alias,
+                harnesses=harnesses,
+                rounds=args.rounds,
+                bench_log=bench_log,
+                report_path=report_path,
+            )
+            failures.extend(round_failures)
         finally:
             print(f"  << Stopping {alias}…")
             _stop_server(proc, args.port)
@@ -783,6 +871,21 @@ def main() -> int:
                 if cache_dir.exists():
                     print(f"     rm -rf {cache_dir}")
                     shutil.rmtree(cache_dir, ignore_errors=True)
+        if drifted:
+            # Ownership drift is an infrastructure failure, not this model's
+            # result. The environment that took the port is still out there;
+            # booting the next model into it produces numbers nobody can
+            # attribute, and can overlap its GPU allocation with whatever is
+            # tearing down. Stop, with our own server already reaped by the
+            # `finally` above.
+            print(
+                "  !! aborting the sweep — the port was taken from us; "
+                "remaining models were not run",
+                file=sys.stderr,
+            )
+            with report_path.open("a") as fh:
+                fh.write("ABORT ownership drift — remaining models not run\n")
+            break
 
     # ===== Verdict =====
     print()

--- a/scripts/release_check_m3_random.py
+++ b/scripts/release_check_m3_random.py
@@ -879,18 +879,24 @@ def main() -> int:
                 with report_path.open("a") as fh:
                     fh.write(f"FAIL  {msg}\n")
                 failures.append(msg)
-                continue
-            print(f"     server up ({alias}); harnesses={harnesses}")
-            round_failures, drifted = _run_model_rounds(
-                proc=proc,
-                port=args.port,
-                alias=alias,
-                harnesses=harnesses,
-                rounds=args.rounds,
-                bench_log=bench_log,
-                report_path=report_path,
-            )
-            failures.extend(round_failures)
+                # Deliberately NOT `continue`. A `continue` here runs the
+                # `finally` and then starts the next model, stepping straight
+                # over the `if drifted: break` below — so a stranger detected
+                # during boot recorded the failure and then carried on
+                # benchmarking into the same contaminated port, which is the
+                # exact outcome the drift check exists to prevent.
+            else:
+                print(f"     server up ({alias}); harnesses={harnesses}")
+                round_failures, drifted = _run_model_rounds(
+                    proc=proc,
+                    port=args.port,
+                    alias=alias,
+                    harnesses=harnesses,
+                    rounds=args.rounds,
+                    bench_log=bench_log,
+                    report_path=report_path,
+                )
+                failures.extend(round_failures)
         finally:
             print(f"  << Stopping {alias}…")
             _stop_server(proc, args.port)

--- a/scripts/release_check_m3_random.py
+++ b/scripts/release_check_m3_random.py
@@ -64,6 +64,7 @@ import shutil
 import socket
 import subprocess
 import sys
+import tempfile
 import time
 import urllib.error
 import urllib.request
@@ -399,9 +400,31 @@ def _as_text(payload: str | bytes | None) -> str:
     return payload
 
 
+# One private directory per run, created 0700, holding every per-alias log.
+#
+# The paths used to be `/tmp/release-check-m3-random-<alias>.log`, which is
+# predictable and sits in a world-writable directory: any other local process
+# can pre-create that name as a symlink, and this script's `write_text("")`
+# follows it and truncates whatever it points at. Owning the directory removes
+# the name-guessing step entirely — nobody else can create entries in it.
+_LOG_DIR: Path | None = None
+
+
+def _log_dir() -> Path:
+    """The per-run log directory, created on first use."""
+    global _LOG_DIR
+    if _LOG_DIR is None:
+        _LOG_DIR = Path(tempfile.mkdtemp(prefix="release-check-m3-random-"))
+        # mkdtemp is already 0700; make that a stated requirement rather than
+        # an implementation detail we inherited.
+        _LOG_DIR.chmod(0o700)
+        print(f"  logs:     {_LOG_DIR}")
+    return _LOG_DIR
+
+
 def _serve_log_path(alias: str) -> Path:
     """Where the sampled server's own stdout goes."""
-    return Path(f"/tmp/release-check-m3-random-{alias}.log")
+    return _log_dir() / f"{alias}.log"
 
 
 def _bench_log_path(alias: str) -> Path:
@@ -414,7 +437,7 @@ def _bench_log_path(alias: str) -> Path:
     them offset-based, corrupts the artifact on exactly the runs someone
     needs to read.
     """
-    return Path(f"/tmp/release-check-m3-random-{alias}.bench.log")
+    return _log_dir() / f"{alias}.bench.log"
 
 
 def _parent_pid(pid: int) -> int | None:

--- a/scripts/release_check_m3_random.py
+++ b/scripts/release_check_m3_random.py
@@ -513,7 +513,13 @@ def _owns_port(proc: subprocess.Popen, port: int, max_depth: int = 8) -> bool:
         return False
     for pid in listeners:
         cur: int | None = pid
-        for _ in range(max_depth):
+        # `max_depth` is a number of ancestry EDGES, so the walk needs
+        # max_depth + 1 identity checks: the listener itself, then one after
+        # each hop. Checking only `max_depth` times tested every generation
+        # except the last one it walked to — so a listener exactly max_depth
+        # edges below our process was reported as a stranger and aborted the
+        # release as ownership drift.
+        for _ in range(max_depth + 1):
             if cur == proc.pid:
                 break
             if cur is None or cur <= 1:
@@ -749,8 +755,14 @@ def main() -> int:
     )
     parser.add_argument(
         "--report",
-        default="/tmp/release-check-m3-random.log",
-        help="Path to write the human-readable summary report to.",
+        default=None,
+        help=(
+            "Path to write the human-readable summary report to. Defaults to "
+            "a file inside this run's private log directory — the previous "
+            "default was a fixed name in world-writable /tmp, which any other "
+            "local process could pre-create as a symlink for this script to "
+            "truncate."
+        ),
     )
     parser.add_argument(
         "--aliases-json",
@@ -834,13 +846,18 @@ def main() -> int:
         hs = per_model_rng.sample(list(HARNESS_PROFILES), args.harnesses)
         sampled.append((alias, hf_path, hs))
 
+    # Resolved before the banner because the banner prints it, and inside
+    # `_log_dir()` so an unspecified report shares the run's private
+    # directory rather than a fixed name in world-writable /tmp.
+    report_path = Path(args.report) if args.report else _log_dir() / "report.log"
+
     print("=" * 60)
     print("  G12 — random-coverage release gate")
     print(f"  seed:     {args.seed}")
     print(f"  models:   {args.models} (of {len(eligible)} eligible)")
     print(f"  harnesses:{args.harnesses} (of {len(HARNESS_PROFILES)})")
     print(f"  rounds:   {args.rounds}")
-    print(f"  report:   {args.report}")
+    print(f"  report:   {report_path}")
     print(f"  free GB:  {free_gb:.1f}")
     print("=" * 60)
     print("  Sampled matrix:")
@@ -849,7 +866,6 @@ def main() -> int:
     print("=" * 60)
 
     # Reset the report log.
-    report_path = Path(args.report)
     report_path.write_text(
         f"G12 random-coverage report (seed={args.seed})\n" + "=" * 60 + "\n"
     )

--- a/tests/release/test_release_check_m3_cleanup.sh
+++ b/tests/release/test_release_check_m3_cleanup.sh
@@ -159,6 +159,27 @@ else
   ok "a zombie reads as gone (kill -0 succeeds on one; ps says Z)"
 fi
 
+# `ps -o stat=` right-aligns into a column sized by the widest state on the
+# machine, so the very same zombie arrives as " Z+" on a box that has, say, an
+# "SNs+" process running. Matching Z* against the padded string fails, the
+# zombie reads as ALIVE, and the handoff burns its full 60s and then SIGKILLs
+# a corpse — the exact failure the Z check was added to remove, reappearing
+# only on machines with a wide stat column.
+for padded in " Z" " Z+" "  Z+ "; do
+  if alive_with "$padded" 0; then
+    bad "a zombie printed as '$padded' read as alive — ps pads its stat column"
+  else
+    ok "a zombie printed as '$padded' still reads as gone"
+  fi
+done
+
+# The padding must not swallow a genuinely live state either.
+if alive_with "  S+ " 0; then
+  ok "a padded running state still reads as alive"
+else
+  bad "a padded running state read as gone — the handoff would proceed onto a busy GPU"
+fi
+
 # The direction that matters. `kill -0` already succeeded, so SOMETHING is
 # there; `ps` failing to describe it is not evidence that it left. Reading
 # "I could not tell" as "gone" hands the GPU over while the old server may
@@ -196,17 +217,41 @@ fi
 # shellcheck source=/dev/null
 . "$TMP/port_busy.sh"
 
-st=0; port_busy 59999 5 || st=$?
+# Ephemeral ports, not fixed ones. A hard-coded 59997-59999 turns any
+# unrelated local or CI listener into a failure of THIS gate — the free-port
+# assertion sees a stranger, or the fixture cannot bind at all. Ask the kernel
+# for ports nobody is using and hand those to each check.
+#
+# `free_port` closes the socket before returning, so the number is
+# "unused a moment ago" rather than "reserved". That is exactly the property
+# the free-port case wants, and the occupied case binds its own listener
+# immediately afterwards.
+free_port() {
+  python3 -c 'import socket
+s = socket.socket()
+s.bind(("127.0.0.1", 0))
+print(s.getsockname()[1])
+s.close()'
+}
+PORT_FREE="$(free_port)"
+PORT_BUSY="$(free_port)"
+PORT_HUNG="$(free_port)"
+
+st=0; port_busy "$PORT_FREE" 5 || st=$?
 if [ "$st" = 1 ]; then
   ok "a free port reports 1 (nothing listening)"
 else
   bad "a free port reported $st — the handoff would never release"
 fi
 
-python3 -c 'import socket,time; s=socket.socket(); s.bind(("127.0.0.1",59998)); s.listen(1); time.sleep(8)' &
+python3 -c 'import socket,sys,time
+s = socket.socket()
+s.bind(("127.0.0.1", int(sys.argv[1])))
+s.listen(1)
+time.sleep(8)' "$PORT_BUSY" &
 LISTENER=$!
 sleep 1
-st=0; port_busy 59998 5 || st=$?
+st=0; port_busy "$PORT_BUSY" 5 || st=$?
 if [ "$st" = 0 ]; then
   ok "an occupied port reports 0"
 else
@@ -221,7 +266,7 @@ mkdir -p "$TMP/fakebin"
 printf '#!/bin/sh\nsleep 300\n' > "$TMP/fakebin/lsof"
 chmod +x "$TMP/fakebin/lsof"
 STARTED=$SECONDS
-st=0; PATH="$TMP/fakebin:$PATH" port_busy 59997 2 || st=$?
+st=0; PATH="$TMP/fakebin:$PATH" port_busy "$PORT_HUNG" 2 || st=$?
 ELAPSED=$((SECONDS - STARTED))
 if [ "$st" = 2 ] && [ "$ELAPSED" -le 6 ]; then
   ok "a hung lsof is killed and reported as unknown (${ELAPSED}s)"
@@ -230,7 +275,7 @@ else
 fi
 
 printf '#!/bin/sh\nexit 9\n' > "$TMP/fakebin/lsof"
-st=0; st_out=$(PATH="$TMP/fakebin:$PATH"; port_busy 59997 2 || echo $?)
+st=0; st_out=$(PATH="$TMP/fakebin:$PATH"; port_busy "$PORT_HUNG" 2 || echo $?)
 if [ "$st_out" = 2 ]; then
   ok "an lsof that fails is unknown, not 'free'"
 else

--- a/tests/release/test_release_check_m3_cleanup.sh
+++ b/tests/release/test_release_check_m3_cleanup.sh
@@ -122,5 +122,65 @@ else
   bad "G12 no longer calls cleanup inline — re-read this test's premise"
 fi
 
+echo "── old_server_alive() (the G12 port/GPU handoff)"
+
+# Extract the nested helper — it lives inside the G12 `else` branch, indented.
+sed -n '/^  old_server_alive() {/,/^  }/p' "$SCRIPT" | sed 's/^  //' > "$TMP/alive.sh"
+if [ ! -s "$TMP/alive.sh" ]; then
+  printf '  \033[31mFAIL\033[0m could not extract old_server_alive() from %s\n' "$SCRIPT"
+  exit 1
+fi
+
+# `kill` and `ps` are shadowed so each process state can be posed exactly.
+# A zombie is the case that matters: `kill -0` succeeds on one, because a child
+# that has exited but has not been reaped still owns a pid — and owns no GPU.
+# Reading that as "still running" burns the whole 60s deadline and then SIGKILLs
+# a corpse, turning a clean shutdown into a gate failure.
+alive_with() {  # $1 = ps stat output, $2 = kill -0 status
+  bash -c '
+      set -uo pipefail
+      OLD_SERVER_PID=4242
+      kill() { return '"$2"'; }
+      ps() { printf "%s" "'"$1"'"; }
+      . "'"$TMP"'/alive.sh"
+      old_server_alive
+    ' 2>/dev/null
+}
+
+if alive_with "S+" 0; then
+  ok "a running process reads as alive"
+else
+  bad "a running process read as gone — the handoff would proceed onto a busy GPU"
+fi
+
+if alive_with "Z" 0; then
+  bad "a ZOMBIE read as alive — the deadline would expire and SIGKILL a corpse"
+else
+  ok "a zombie reads as gone (kill -0 succeeds on one; ps says Z)"
+fi
+
+if alive_with "" 0; then
+  bad "an unreadable process state read as alive"
+else
+  ok "a process ps cannot describe reads as gone"
+fi
+
+if alive_with "S+" 1; then
+  bad "kill -0 failing still read as alive"
+else
+  ok "a pid that no longer exists reads as gone"
+fi
+
+if bash -c '
+      set -uo pipefail
+      OLD_SERVER_PID=""
+      . "'"$TMP"'/alive.sh"
+      old_server_alive
+    ' 2>/dev/null; then
+  bad "an empty pid read as alive — nothing to wait for"
+else
+  ok "an empty pid reads as gone"
+fi
+
 printf '\n  %d passed, %d failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/tests/release/test_release_check_m3_cleanup.sh
+++ b/tests/release/test_release_check_m3_cleanup.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+#
+# Offline tests for the ``cleanup`` function in scripts/release_check_m3.sh.
+#
+# The gauntlet installs ``cleanup`` as an EXIT trap, where its return status is
+# discarded — but it ALSO calls it inline, just before G12, to hand the port and
+# the GPU to the random-coverage sweep. There, under ``set -euo pipefail``, the
+# status is load-bearing: a non-zero return kills the gauntlet on the spot.
+#
+# Written as `[ -n "$CLUSTER_WORK" ] && rm -rf …`, the function returned 1
+# whenever CLUSTER_WORK was empty — which it always is by G12, the correctness
+# cluster having cleared it a few hundred lines earlier. The observable symptom
+# was the G12 banner followed immediately by ``make: *** Error 1`` and not one
+# line of gate output, because the sweep never started. G12 had been dead for as
+# long as the two lines coexisted.
+#
+#   ./tests/release/test_release_check_m3_cleanup.sh
+#
+# Requires: bash. No network/git/GPU required — the function is extracted from
+# the script and exercised on its own.
+
+set -euo pipefail
+
+REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+SCRIPT="$REPO_ROOT/scripts/release_check_m3.sh"
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+PASS=0
+FAIL=0
+ok()  { PASS=$((PASS + 1)); printf '  \033[32mPASS\033[0m %s\n' "$1"; }
+bad() { FAIL=$((FAIL + 1)); printf '  \033[31mFAIL\033[0m %s\n' "$1"; }
+
+# Extract `cleanup() { … }` from the gauntlet so the test exercises the real
+# text rather than a copy that can drift away from it.
+sed -n '/^cleanup() {/,/^}/p' "$SCRIPT" > "$TMP/cleanup.sh"
+if [ ! -s "$TMP/cleanup.sh" ]; then
+  printf '  \033[31mFAIL\033[0m could not extract cleanup() from %s\n' "$SCRIPT"
+  exit 1
+fi
+
+echo "── cleanup() return status"
+
+# 1. The regression itself: empty CLUSTER_WORK, no pidfile — the state the
+#    gauntlet is in at the inline call site.
+if bash -c '
+      set -euo pipefail
+      PIDFILE="'"$TMP"'/no-such-pidfile"
+      CLUSTER_WORK=""
+      . "'"$TMP"'/cleanup.sh"
+      cleanup
+      exit 0
+    ' 2>/dev/null; then
+  ok "returns 0 with CLUSTER_WORK empty (the state G12 calls it in)"
+else
+  bad "returns non-zero with CLUSTER_WORK empty — under set -e this kills G12"
+fi
+
+# 2. Unset, not merely empty — the trap can fire before the cluster runs at all.
+if bash -c '
+      set -euo pipefail
+      PIDFILE="'"$TMP"'/no-such-pidfile"
+      unset CLUSTER_WORK
+      . "'"$TMP"'/cleanup.sh"
+      cleanup
+      exit 0
+    ' 2>/dev/null; then
+  ok "returns 0 with CLUSTER_WORK unset"
+else
+  bad "returns non-zero with CLUSTER_WORK unset"
+fi
+
+# 3. It must still do its job: a populated CLUSTER_WORK is removed.
+WORK="$TMP/cluster"
+mkdir -p "$WORK"
+touch "$WORK/g6.rc"
+if bash -c '
+      set -euo pipefail
+      PIDFILE="'"$TMP"'/no-such-pidfile"
+      CLUSTER_WORK="'"$WORK"'"
+      . "'"$TMP"'/cleanup.sh"
+      cleanup
+      exit 0
+    ' 2>/dev/null && [ ! -d "$WORK" ]; then
+  ok "removes a populated CLUSTER_WORK and still returns 0"
+else
+  bad "did not remove CLUSTER_WORK, or returned non-zero"
+fi
+
+# 4. A stale pidfile naming a dead process must not fail either — `kill` on a
+#    reaped pid is the normal case at teardown.
+PIDFILE_STALE="$TMP/stale.pid"
+echo 99999999 > "$PIDFILE_STALE"
+if bash -c '
+      set -euo pipefail
+      PIDFILE="'"$PIDFILE_STALE"'"
+      CLUSTER_WORK=""
+      . "'"$TMP"'/cleanup.sh"
+      cleanup
+      exit 0
+    ' 2>/dev/null && [ ! -f "$PIDFILE_STALE" ]; then
+  ok "tolerates a pidfile whose process is already gone, and removes it"
+else
+  bad "a stale pidfile made cleanup fail, or left the file behind"
+fi
+
+echo "── G12 call site"
+
+# 5. Pin the reason this matters: the gauntlet really does call cleanup inline,
+#    and really does run under `set -e`. If either stops being true this test is
+#    guarding nothing, and should be re-read rather than silently kept green.
+if grep -qE '^set -euo pipefail' "$SCRIPT"; then
+  ok "gauntlet still runs under set -euo pipefail"
+else
+  bad "gauntlet no longer sets -euo pipefail — re-read this test's premise"
+fi
+
+if awk '/G12 — random-coverage \(sampled/,/release_check_m3_random\.py/' "$SCRIPT" \
+     | grep -qE '^[[:space:]]*cleanup[[:space:]]*$'; then
+  ok "G12 still calls cleanup inline before handing over the port"
+else
+  bad "G12 no longer calls cleanup inline — re-read this test's premise"
+fi
+
+printf '\n  %d passed, %d failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/tests/release/test_release_check_m3_cleanup.sh
+++ b/tests/release/test_release_check_m3_cleanup.sh
@@ -182,5 +182,56 @@ else
   ok "an empty pid reads as gone"
 fi
 
+echo "── port_busy() (the watchdog around lsof)"
+
+sed -n '/^port_busy() {/,/^}/p' "$SCRIPT" > "$TMP/port_busy.sh"
+if [ ! -s "$TMP/port_busy.sh" ]; then
+  printf '  \033[31mFAIL\033[0m could not extract port_busy() from %s\n' "$SCRIPT"
+  exit 1
+fi
+# shellcheck source=/dev/null
+. "$TMP/port_busy.sh"
+
+st=0; port_busy 59999 5 || st=$?
+if [ "$st" = 1 ]; then
+  ok "a free port reports 1 (nothing listening)"
+else
+  bad "a free port reported $st — the handoff would never release"
+fi
+
+python3 -c 'import socket,time; s=socket.socket(); s.bind(("127.0.0.1",59998)); s.listen(1); time.sleep(8)' &
+LISTENER=$!
+sleep 1
+st=0; port_busy 59998 5 || st=$?
+if [ "$st" = 0 ]; then
+  ok "an occupied port reports 0"
+else
+  bad "an occupied port reported $st — the GPU would be handed over while busy"
+fi
+kill "$LISTENER" 2>/dev/null || true
+wait "$LISTENER" 2>/dev/null || true
+
+# The whole point of the watchdog. `SECONDS` is only read BETWEEN calls, so an
+# lsof that never returns makes any "wait N seconds" loop wait forever.
+mkdir -p "$TMP/fakebin"
+printf '#!/bin/sh\nsleep 300\n' > "$TMP/fakebin/lsof"
+chmod +x "$TMP/fakebin/lsof"
+STARTED=$SECONDS
+st=0; PATH="$TMP/fakebin:$PATH" port_busy 59997 2 || st=$?
+ELAPSED=$((SECONDS - STARTED))
+if [ "$st" = 2 ] && [ "$ELAPSED" -le 6 ]; then
+  ok "a hung lsof is killed and reported as unknown (${ELAPSED}s)"
+else
+  bad "a hung lsof gave $st after ${ELAPSED}s — expected 2 within a few seconds"
+fi
+
+printf '#!/bin/sh\nexit 9\n' > "$TMP/fakebin/lsof"
+st=0; st_out=$(PATH="$TMP/fakebin:$PATH"; port_busy 59997 2 || echo $?)
+if [ "$st_out" = 2 ]; then
+  ok "an lsof that fails is unknown, not 'free'"
+else
+  bad "a broken lsof reported $st_out — an unverifiable port must never read as free"
+fi
+
 printf '\n  %d passed, %d failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/tests/release/test_release_check_m3_cleanup.sh
+++ b/tests/release/test_release_check_m3_cleanup.sh
@@ -159,10 +159,14 @@ else
   ok "a zombie reads as gone (kill -0 succeeds on one; ps says Z)"
 fi
 
+# The direction that matters. `kill -0` already succeeded, so SOMETHING is
+# there; `ps` failing to describe it is not evidence that it left. Reading
+# "I could not tell" as "gone" hands the GPU over while the old server may
+# still be flushing weights — the overlap this handoff exists to prevent.
 if alive_with "" 0; then
-  bad "an unreadable process state read as alive"
+  ok "a process ps cannot describe reads as ALIVE, not gone"
 else
-  ok "a process ps cannot describe reads as gone"
+  bad "an unreadable process state read as gone — the GPU would be handed over on a guess"
 fi
 
 if alive_with "S+" 1; then

--- a/tests/test_release_check_random.py
+++ b/tests/test_release_check_random.py
@@ -12,6 +12,7 @@ import os
 import re
 import shutil
 import socket
+import stat
 import subprocess
 import sys
 import time
@@ -789,3 +790,33 @@ def test_ownership_against_a_real_listener(g12):
         time.sleep(0.1)
     assert not g12._listening_pids(port)
     assert not g12._owns_port(proc, port), "a freed port belongs to nobody"
+
+
+def test_logs_live_in_a_private_directory_not_a_guessable_tmp_path(g12):
+    """A predictable name in a world-writable directory is a truncation gadget.
+
+    The per-alias logs used to be `/tmp/release-check-m3-random-<alias>.log`.
+    Any other local process can pre-create that exact name as a symlink, and
+    this script opens the path with `write_text("")` — which follows the link
+    and truncates whatever it points at, as the user running the gauntlet.
+    Owning the directory removes the guess: nobody else can create entries in
+    it.
+    """
+    serve = g12._serve_log_path("qwen3-8b-4bit")
+    bench = g12._bench_log_path("qwen3-8b-4bit")
+
+    assert serve.parent == bench.parent, "both logs belong to the same run"
+    parent = serve.parent
+    assert parent != Path("/tmp"), (
+        f"logs are written straight into a world-writable directory: {serve}"
+    )
+    assert parent.is_dir()
+    mode = stat.S_IMODE(parent.stat().st_mode)
+    assert mode == 0o700, (
+        f"log directory is {mode:o}, not 0700 — another user can plant "
+        f"symlinks in it: {parent}"
+    )
+    # Same run, same directory: a second call must not mint a new one, or the
+    # per-alias logs of one sweep end up scattered.
+    assert g12._serve_log_path("another-alias").parent == parent
+    assert serve != bench, "the serve and bench logs must not share a path"

--- a/tests/test_release_check_random.py
+++ b/tests/test_release_check_random.py
@@ -175,19 +175,25 @@ def test_the_measured_agentic_failure_is_out_of_the_pool(g12):
 
 
 def test_the_floor_applies_to_active_params_not_total(g12, tmp_path):
-    """A MoE's ability to hold an agentic loop follows its ACTIVE parameters.
-    ``LFM2.5-8B-A1B`` is in-band on total size and hopeless on the work."""
+    """A MoE's ability to hold an agentic loop follows its ACTIVE parameters,
+    so the SAME floor applies to them.
+
+    The cases straddle the new floor rather than the old one: A4 and A5 were
+    admitted before this change and are not now, A6 is the boundary and stays.
+    Picking A1-vs-A8 would pass either way and prove nothing about the move.
+    """
     p = tmp_path / "aliases.json"
     p.write_text(
         json.dumps(
             {
-                "lfm-8b-a1b-4bit": {"hf_path": "mlx-community/LFM2.5-8B-A1B-4bit"},
-                "big-moe-9b-a8b-4bit": {"hf_path": "fake/Big-9B-A8B-4bit"},
+                "moe-12b-a4b-4bit": {"hf_path": "fake/MoE-12B-A4B-4bit"},
+                "moe-12b-a5b-4bit": {"hf_path": "fake/MoE-12B-A5B-4bit"},
+                "moe-12b-a6b-4bit": {"hf_path": "fake/MoE-12B-A6B-4bit"},
             }
         )
     )
     names = {name for name, _ in g12._eligible_aliases(p)}
-    assert names == {"big-moe-9b-a8b-4bit"}
+    assert names == {"moe-12b-a6b-4bit"}
 
 
 def test_real_aliases_json_yields_nonzero_pool(g12):
@@ -364,3 +370,124 @@ def test_a_round_appends_its_transcript_to_the_bench_log(g12, tmp_path, monkeypa
     )
     assert ok
     assert "harness ok" in bench_log.read_text()
+
+
+# ---------------------------------------------------------------------------
+# The ownership check has to be WIRED IN, and it has to keep being asked.
+#
+# Testing `_owns_port` alone proves nothing: delete its call site and every
+# test above stays green while the sweep goes back to benchmarking strangers.
+# ---------------------------------------------------------------------------
+
+
+class _FakeResponse:
+    status = 200
+
+    def read(self):
+        return b'{"object":"list","data":[{"id":"x"}]}'
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+class _AliveProc:
+    """A child that never exits — readiness must be decided by the port."""
+
+    def __init__(self, pid: int = 900) -> None:
+        self.pid = pid
+
+    def poll(self):
+        return None
+
+
+def test_readiness_refuses_a_port_answering_from_someone_elses_process(
+    g12, monkeypatch, tmp_path
+):
+    """A 200 is not ownership. Our child is alive the whole time it loads
+    weights, so a stranger already on the port answers first (#1618)."""
+    monkeypatch.setattr(g12.urllib.request, "urlopen", lambda *a, **k: _FakeResponse())
+    monkeypatch.setattr(g12, "_owns_port", lambda proc, port: False)
+    monkeypatch.setattr(g12.time, "sleep", lambda *_: None)
+    assert not g12._wait_for_server(_AliveProc(), 8000, 0.3, tmp_path / "serve.log")
+
+
+def test_readiness_accepts_the_port_once_it_is_ours(g12, monkeypatch, tmp_path):
+    monkeypatch.setattr(g12.urllib.request, "urlopen", lambda *a, **k: _FakeResponse())
+    monkeypatch.setattr(g12, "_owns_port", lambda proc, port: True)
+    monkeypatch.setattr(g12.time, "sleep", lambda *_: None)
+    assert g12._wait_for_server(_AliveProc(), 8000, 5, tmp_path / "serve.log")
+
+
+def test_a_takeover_is_noticed_and_named(g12, monkeypatch):
+    """`_still_ours` is what the round loop asks before and after every round.
+    Its answer has to be a reason, not a bare False — a sweep that says "round
+    3 failed" without saying the port changed hands sends someone hunting a
+    regression that is not there."""
+    monkeypatch.setattr(g12, "_owns_port", lambda proc, port: False)
+    monkeypatch.setattr(g12, "_listening_pids", lambda port: [555])
+    reason = g12._still_ours(_AliveProc(), 8000)
+    assert "no longer served by our process" in reason
+    assert "555" in reason
+
+
+def test_a_dead_server_is_noticed_by_the_same_check(g12, monkeypatch):
+    class _Dead(_AliveProc):
+        def poll(self):
+            return 137
+
+    monkeypatch.setattr(g12, "_owns_port", lambda proc, port: True)
+    assert "exited (rc=137)" in g12._still_ours(_Dead(), 8000)
+
+
+def test_ownership_is_asked_around_every_round_not_once():
+    """Pin the wiring. `_wait_for_server` returns permanently after the first
+    owned 200, so without these calls a takeover during round 1 of 6 is
+    invisible and every later round is attributed to the sampled alias."""
+    source = SCRIPT_PATH.read_text()
+    loop = source[source.index("for harness in harnesses:") :]
+    loop = loop[: loop.index("finally:")]
+    before, _, after = loop.partition("_run_harness_round(")
+    assert "_still_ours(" in before, "nothing checks ownership before the round"
+    assert "_still_ours(" in after, (
+        "nothing checks ownership after the round — a takeover DURING one is "
+        "then reported as that model's result"
+    )
+
+
+def test_a_partial_lsof_run_is_not_read_as_a_listener_list(g12, monkeypatch):
+    """lsof can print some rows and then fail. Half a listener list reads as
+    "all of these are ours", so the row it did not print is exactly the
+    stranger the caller asked about."""
+
+    class _Partial:
+        returncode = 1
+        stdout = "900\n"
+
+    monkeypatch.setattr(g12.subprocess, "run", lambda *a, **k: _Partial())
+    assert g12._listening_pids(8000) == []
+
+
+def test_a_timed_out_round_still_leaves_a_transcript(g12, tmp_path, monkeypatch):
+    """The failure class that most needs evidence produced none: the timeout
+    path returned before anything was written."""
+    bench_log = tmp_path / "bench.log"
+    bench_log.write_text("")
+
+    def _boom(*a, **k):
+        raise g12.subprocess.TimeoutExpired(
+            cmd="bench", timeout=1, output=b"got as far as tier=harness\n", stderr=b""
+        )
+
+    monkeypatch.setattr(g12.subprocess, "run", _boom)
+    ok, _, excerpt = g12._run_harness_round(
+        alias="qwen3-8b-4bit",
+        harness="hermes",
+        base_url="http://127.0.0.1:8000",
+        bench_log=bench_log,
+    )
+    assert not ok
+    assert "timed out" in excerpt
+    assert "got as far as tier=harness" in bench_log.read_text()

--- a/tests/test_release_check_random.py
+++ b/tests/test_release_check_random.py
@@ -921,7 +921,9 @@ def test_the_bench_transcript_is_wired_to_the_bench_log_not_the_server_log(
         )
 
 
-def test_the_report_defaults_into_the_private_directory(g12, monkeypatch, tmp_path):
+def test_the_report_defaults_into_the_private_directory(
+    g12, monkeypatch, tmp_path, capsys
+):
     """An unspecified --report must not land on a fixed name in /tmp."""
     aliases = tmp_path / "aliases.json"
     aliases.write_text(json.dumps(_fake_aliases()))
@@ -953,3 +955,18 @@ def test_the_report_defaults_into_the_private_directory(g12, monkeypatch, tmp_pa
     written = g12._log_dir() / "report.log"
     assert written.is_file(), f"no report written into {g12._log_dir()}"
     assert written.parent != Path("/tmp")
+    assert f"Full log: {written}" in capsys.readouterr().out
+
+
+def test_main_fails_fast_when_lsof_is_unavailable(g12, monkeypatch, capsys):
+    """Standalone G12 must not spend ten minutes misdiagnosing missing lsof."""
+    monkeypatch.setattr(g12.shutil, "which", lambda name: None)
+    monkeypatch.setattr(
+        g12,
+        "_port_free",
+        lambda port: pytest.fail("port probing must happen after the lsof preflight"),
+    )
+    monkeypatch.setattr(sys, "argv", ["release_check_m3_random.py"])
+
+    assert g12.main() == 2
+    assert "lsof is required" in capsys.readouterr().err

--- a/tests/test_release_check_random.py
+++ b/tests/test_release_check_random.py
@@ -464,18 +464,63 @@ def test_readiness_refuses_a_port_answering_from_someone_elses_process(
     g12, monkeypatch, tmp_path
 ):
     """A 200 is not ownership. Our child is alive the whole time it loads
-    weights, so a stranger already on the port answers first (#1618)."""
+    weights, so a stranger already on the port answers first (#1618).
+
+    The second return value is the part that matters downstream: this is not
+    "the model would not boot", it is "somebody else has the port", and that
+    stays true for every model after this one.
+    """
     monkeypatch.setattr(g12.urllib.request, "urlopen", lambda *a, **k: _FakeResponse())
     monkeypatch.setattr(g12, "_owns_port", lambda proc, port: False)
     monkeypatch.setattr(g12.time, "sleep", lambda *_: None)
-    assert not g12._wait_for_server(_AliveProc(), 8000, 0.3, tmp_path / "serve.log")
+    ready, saw_stranger = g12._wait_for_server(
+        _AliveProc(), 8000, 0.3, tmp_path / "serve.log"
+    )
+    assert not ready
+    assert saw_stranger
 
 
 def test_readiness_accepts_the_port_once_it_is_ours(g12, monkeypatch, tmp_path):
     monkeypatch.setattr(g12.urllib.request, "urlopen", lambda *a, **k: _FakeResponse())
     monkeypatch.setattr(g12, "_owns_port", lambda proc, port: True)
     monkeypatch.setattr(g12.time, "sleep", lambda *_: None)
-    assert g12._wait_for_server(_AliveProc(), 8000, 5, tmp_path / "serve.log")
+    ready, saw_stranger = g12._wait_for_server(
+        _AliveProc(), 8000, 5, tmp_path / "serve.log"
+    )
+    assert ready
+    assert not saw_stranger
+
+
+def test_a_model_that_simply_will_not_boot_is_not_reported_as_a_takeover(
+    g12, monkeypatch, tmp_path
+):
+    """The other direction. One model failing to load is that model's problem;
+    treating it as environment contamination would abort a sweep that could
+    still have covered the rest."""
+
+    def _refused(*a, **k):
+        raise OSError("connection refused")
+
+    monkeypatch.setattr(g12.urllib.request, "urlopen", _refused)
+    monkeypatch.setattr(g12.time, "sleep", lambda *_: None)
+    ready, saw_stranger = g12._wait_for_server(
+        _AliveProc(), 8000, 0.3, tmp_path / "serve.log"
+    )
+    assert not ready
+    assert not saw_stranger
+
+
+def test_a_stolen_port_during_boot_aborts_the_sweep():
+    """Pin the caller's half: `main` must set `drifted` on that second value,
+    or the next model boots into the same contaminated machine — the failure
+    the round-loop abort already prevents, arriving one step earlier."""
+    source = SCRIPT_PATH.read_text()
+    sweep = source[source.index("    # ===== Sweep =====") :]
+    sweep = sweep[: sweep.index("    # ===== Verdict =====")]
+    boot = sweep[
+        sweep.index("ready, saw_stranger") : sweep.index('print(f"     server up')
+    ]
+    assert "if saw_stranger:" in boot and "drifted = True" in boot, boot
 
 
 def test_a_takeover_is_noticed_and_named(g12, monkeypatch):

--- a/tests/test_release_check_random.py
+++ b/tests/test_release_check_random.py
@@ -7,7 +7,13 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import os
 import re
+import shutil
+import socket
+import subprocess
+import sys
+import time
 from pathlib import Path
 
 import pytest
@@ -491,3 +497,62 @@ def test_a_timed_out_round_still_leaves_a_transcript(g12, tmp_path, monkeypatch)
     assert not ok
     assert "timed out" in excerpt
     assert "got as far as tier=harness" in bench_log.read_text()
+
+
+# ---------------------------------------------------------------------------
+# The same question asked of the real machine.
+#
+# Every ownership test above stubs `_listening_pids` and `_parent_pid`, so none
+# of them exercises the `lsof`/`ps` invocations or the actual process tree — and
+# that blind spot hid a live bug: `_owns_port` returned True for pid 1, because
+# every process descends from init and nothing rejected that. Measured here, not
+# reasoned about.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    shutil.which("lsof") is None or shutil.which("ps") is None,
+    reason="ownership is established with lsof + ps",
+)
+def test_ownership_against_a_real_listener(g12):
+    sock = socket.socket()
+    sock.bind(("127.0.0.1", 0))
+    port = sock.getsockname()[1]
+    sock.close()
+
+    class _Pid:
+        def __init__(self, pid: int) -> None:
+            self.pid = pid
+
+        def poll(self):
+            return None
+
+    proc = subprocess.Popen(
+        [sys.executable, "-m", "http.server", str(port), "--bind", "127.0.0.1"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    try:
+        deadline = time.monotonic() + 15
+        while time.monotonic() < deadline and not g12._listening_pids(port):
+            time.sleep(0.1)
+        assert g12._listening_pids(port), "the child never bound the port"
+
+        assert g12._owns_port(proc, port), "our own child must count as ours"
+        # We are the listener's parent, so we own it too — the walk has to
+        # cross at least one edge for a `serve` that binds from a subprocess.
+        assert g12._owns_port(_Pid(os.getpid()), port)
+        # init is an ancestor of everything, which is exactly why it must not
+        # satisfy ownership.
+        assert not g12._owns_port(_Pid(1), port)
+        assert "no longer served by our process" in g12._still_ours(_Pid(1), port)
+        assert g12._still_ours(proc, port) == ""
+    finally:
+        proc.terminate()
+        proc.wait(timeout=10)
+
+    deadline = time.monotonic() + 10
+    while time.monotonic() < deadline and g12._listening_pids(port):
+        time.sleep(0.1)
+    assert not g12._listening_pids(port)
+    assert not g12._owns_port(proc, port), "a freed port belongs to nobody"

--- a/tests/test_release_check_random.py
+++ b/tests/test_release_check_random.py
@@ -11,7 +11,6 @@ import json
 import os
 import re
 import shutil
-import socket
 import stat
 import subprocess
 import sys
@@ -744,16 +743,27 @@ def test_a_timed_out_round_still_leaves_a_transcript(g12, tmp_path, monkeypatch)
 # ---------------------------------------------------------------------------
 
 
+# The child binds its own port and reports it, rather than the parent asking
+# the kernel for a free one and handing over the number. Closing the probe
+# socket before the child binds leaves a window in which any other process on
+# the machine can take that port — a flake that would show up as this gate
+# failing for reasons nobody can reproduce.
+_PORT_HOLDER = """
+import socket, sys, time
+s = socket.socket()
+s.bind(("127.0.0.1", 0))
+s.listen(1)
+sys.stdout.write(str(s.getsockname()[1]) + chr(10))
+sys.stdout.flush()
+time.sleep(60)
+"""
+
+
 @pytest.mark.skipif(
     shutil.which("lsof") is None or shutil.which("ps") is None,
     reason="ownership is established with lsof + ps",
 )
 def test_ownership_against_a_real_listener(g12):
-    sock = socket.socket()
-    sock.bind(("127.0.0.1", 0))
-    port = sock.getsockname()[1]
-    sock.close()
-
     class _Pid:
         def __init__(self, pid: int) -> None:
             self.pid = pid
@@ -762,11 +772,15 @@ def test_ownership_against_a_real_listener(g12):
             return None
 
     proc = subprocess.Popen(
-        [sys.executable, "-m", "http.server", str(port), "--bind", "127.0.0.1"],
-        stdout=subprocess.DEVNULL,
+        [sys.executable, "-c", _PORT_HOLDER],
+        stdout=subprocess.PIPE,
         stderr=subprocess.DEVNULL,
+        text=True,
     )
     try:
+        line = proc.stdout.readline().strip()
+        assert line.isdigit(), f"the listener did not report a port: {line!r}"
+        port = int(line)
         deadline = time.monotonic() + 15
         while time.monotonic() < deadline and not g12._listening_pids(port):
             time.sleep(0.1)
@@ -820,3 +834,122 @@ def test_logs_live_in_a_private_directory_not_a_guessable_tmp_path(g12):
     # per-alias logs of one sweep end up scattered.
     assert g12._serve_log_path("another-alias").parent == parent
     assert serve != bench, "the serve and bench logs must not share a path"
+
+
+def test_a_listener_exactly_max_depth_below_us_is_ours(g12, monkeypatch):
+    """`max_depth` counts ancestry EDGES, so the walk needs max_depth + 1 checks.
+
+    Checking only `max_depth` times tested every generation except the last
+    one it walked to, so a legitimate listener exactly `max_depth` edges below
+    the server we started was reported as a stranger — and a stranger aborts
+    the release as ownership drift.
+    """
+    chain = {900: 800, 800: 700, 700: 600, 600: 500, 500: 4242, 4242: 1}
+    monkeypatch.setattr(g12, "_listening_pids", lambda port: [900])
+    monkeypatch.setattr(g12, "_parent_pid", lambda pid: chain.get(pid))
+    # 900 -> 800 -> 700 -> 600 -> 500 -> 4242 is five edges. _AliveProc
+    # defaults to pid 900, which IS the listener — pass the server pid
+    # explicitly or the walk matches at depth 0 and proves nothing.
+    assert g12._owns_port(_AliveProc(4242), 8000, max_depth=5) is True
+    # One edge short of reaching us is correctly a stranger.
+    assert g12._owns_port(_AliveProc(4242), 8000, max_depth=4) is False
+
+
+def test_the_bench_transcript_is_wired_to_the_bench_log_not_the_server_log(
+    g12, monkeypatch, tmp_path
+):
+    """Drive `main()`: the round runner must receive the BENCH log.
+
+    Asserting that the two helper functions return different names says
+    nothing about which one `main()` actually hands down. If it passed the
+    serve log, two writers would share one file — the server tracking its own
+    byte offset — and corrupt the artifact someone needs on exactly the runs
+    that failed.
+    """
+    seen: list[Path] = []
+
+    class _Proc:
+        pid = 4242
+
+        def poll(self):
+            return None
+
+    aliases = tmp_path / "aliases.json"
+    aliases.write_text(json.dumps(_fake_aliases()))
+
+    monkeypatch.setattr(g12.subprocess, "Popen", lambda cmd, **kw: _Proc())
+    monkeypatch.setattr(g12, "_free_disk_gb", lambda path: 10_000.0)
+    monkeypatch.setattr(
+        g12, "_wait_for_server", lambda proc, port, timeout, log: (True, False)
+    )
+    monkeypatch.setattr(g12, "_still_ours", lambda proc, port: "")
+    monkeypatch.setattr(g12, "_stop_server", lambda proc, port: None)
+    monkeypatch.setattr(g12, "_hf_cache_dir", lambda hf_path: tmp_path / "nonexistent")
+
+    def _round(*, alias, harness, base_url, bench_log):
+        seen.append(Path(bench_log))
+        return True, 1.0, ""
+
+    monkeypatch.setattr(g12, "_run_harness_round", _round)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "release_check_m3_random.py",
+            "--models",
+            "1",
+            "--harnesses",
+            "1",
+            "--rounds",
+            "1",
+            "--seed",
+            "7",
+            "--aliases-json",
+            str(aliases),
+        ],
+    )
+
+    g12.main()
+
+    assert seen, "no harness round ran, so nothing was verified"
+    for bench_log in seen:
+        assert bench_log.name.endswith(".bench.log"), (
+            f"the round runner was handed {bench_log}, which is not a bench log"
+        )
+        assert bench_log != g12._serve_log_path(bench_log.name.split(".")[0]), (
+            "the round transcript would be appended to the server's own log"
+        )
+
+
+def test_the_report_defaults_into_the_private_directory(g12, monkeypatch, tmp_path):
+    """An unspecified --report must not land on a fixed name in /tmp."""
+    aliases = tmp_path / "aliases.json"
+    aliases.write_text(json.dumps(_fake_aliases()))
+    monkeypatch.setattr(g12, "_free_disk_gb", lambda path: 10_000.0)
+    monkeypatch.setattr(
+        g12, "_wait_for_server", lambda proc, port, timeout, log: (False, False)
+    )
+    monkeypatch.setattr(g12.subprocess, "Popen", lambda cmd, **kw: _AliveProc())
+    monkeypatch.setattr(g12, "_stop_server", lambda proc, port: None)
+    monkeypatch.setattr(g12, "_hf_cache_dir", lambda hf_path: tmp_path / "nonexistent")
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "release_check_m3_random.py",
+            "--models",
+            "1",
+            "--harnesses",
+            "1",
+            "--rounds",
+            "1",
+            "--seed",
+            "7",
+            "--aliases-json",
+            str(aliases),
+        ],
+    )
+    g12.main()
+    written = g12._log_dir() / "report.log"
+    assert written.is_file(), f"no report written into {g12._log_dir()}"
+    assert written.parent != Path("/tmp")

--- a/tests/test_release_check_random.py
+++ b/tests/test_release_check_random.py
@@ -510,17 +510,78 @@ def test_a_model_that_simply_will_not_boot_is_not_reported_as_a_takeover(
     assert not saw_stranger
 
 
-def test_a_stolen_port_during_boot_aborts_the_sweep():
-    """Pin the caller's half: `main` must set `drifted` on that second value,
-    or the next model boots into the same contaminated machine — the failure
-    the round-loop abort already prevents, arriving one step earlier."""
-    source = SCRIPT_PATH.read_text()
-    sweep = source[source.index("    # ===== Sweep =====") :]
-    sweep = sweep[: sweep.index("    # ===== Verdict =====")]
-    boot = sweep[
-        sweep.index("ready, saw_stranger") : sweep.index('print(f"     server up')
-    ]
-    assert "if saw_stranger:" in boot and "drifted = True" in boot, boot
+def test_a_stolen_port_during_boot_aborts_the_sweep(g12, monkeypatch, tmp_path):
+    """A stranger on the port during boot must stop the sweep, not just log it.
+
+    Driven through `main()` on purpose. The previous version of this test read
+    the source and asserted that `drifted = True` appears near `if
+    saw_stranger:` — which it did, while a `continue` on the same path ran the
+    `finally` and jumped straight over the `if drifted: break` underneath it.
+    The text was right and the behaviour was wrong, so the test could not tell.
+    Counting how many models actually get booted can.
+    """
+    booted: list[str] = []
+    ran_rounds: list[str] = []
+
+    class _Proc:
+        pid = 4242
+
+        def poll(self):
+            return None
+
+    def _popen(cmd, **kwargs):
+        # `serve <alias>` — the alias is the argument after "serve".
+        booted.append(cmd[cmd.index("serve") + 1])
+        return _Proc()
+
+    aliases = tmp_path / "aliases.json"
+    aliases.write_text(json.dumps(_fake_aliases()))
+    report = tmp_path / "report.log"
+
+    monkeypatch.setattr(g12.subprocess, "Popen", _popen)
+    monkeypatch.setattr(g12, "_free_disk_gb", lambda path: 10_000.0)
+    # The stranger arrives while the FIRST model is booting.
+    monkeypatch.setattr(
+        g12, "_wait_for_server", lambda proc, port, timeout, log: (False, True)
+    )
+    monkeypatch.setattr(
+        g12,
+        "_run_model_rounds",
+        lambda **kw: ran_rounds.append(kw["alias"]) or ([], False),
+    )
+    monkeypatch.setattr(g12, "_stop_server", lambda proc, port: None)
+    monkeypatch.setattr(g12, "_hf_cache_dir", lambda hf_path: tmp_path / "nonexistent")
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "release_check_m3_random.py",
+            "--models",
+            "3",
+            "--harnesses",
+            "1",
+            "--rounds",
+            "1",
+            "--seed",
+            "7",
+            "--aliases-json",
+            str(aliases),
+            "--report",
+            str(report),
+        ],
+    )
+
+    rc = g12.main()
+
+    assert len(booted) == 1, (
+        f"the sweep booted {len(booted)} models after detecting a stranger on "
+        f"the port during the first one's boot: {booted} — every model after "
+        "the first is measured against a machine we know is contaminated"
+    )
+    assert ran_rounds == [], (
+        f"benchmark rounds ran against the contaminated port: {ran_rounds}"
+    )
+    assert rc != 0, "a drifted sweep must not report success"
 
 
 def test_a_takeover_is_noticed_and_named(g12, monkeypatch):

--- a/tests/test_release_check_random.py
+++ b/tests/test_release_check_random.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import re
 from pathlib import Path
 
 import pytest
@@ -33,17 +34,25 @@ def _fake_aliases() -> dict[str, dict]:
     marker, 8bit vs 4bit, missing hf_path, fail-closed name-without-
     size token)."""
     return {
-        # In-band (4-12 B, 4-bit, no special excludes)
+        # In-band (6-12 B, 4-bit, no special excludes)
         "qwen3.5-9b-4bit": {"hf_path": "mlx-community/Qwen3.5-9B-4bit"},
         "qwen3-8b-4bit": {"hf_path": "mlx-community/Qwen3-8B-4bit"},
         "hermes3-8b-4bit": {"hf_path": "mlx-community/Hermes-3-Llama-3.1-8B-4bit"},
+        # Excluded: the 4 B tier cannot hold an agentic loop. It does not
+        # fail fast either — it retries malformed tool calls until the
+        # per-profile clock runs out, so the gauntlet goes red on a healthy
+        # engine (#1672).
+        "qwen3-4b-instruct-2507-4bit": {
+            "hf_path": "mlx-community/Qwen3-4B-Instruct-2507-4bit"
+        },
+        "qwen3.5-4b-4bit": {"hf_path": "mlx-community/Qwen3.5-4B-MLX-4bit"},
         # Fail-closed: the repo name carries no parameter-count token
         # (``Air`` is a variant name, ``4.5`` is the version). The old
         # parser regex extracted ``4`` from ``-4bit`` and admitted this
         # entry as a 4 B model — codex PR #693 review caught it. The
         # post-fix parser refuses to guess and skips the entry.
         "glm4.5-air-4bit": {"hf_path": "mlx-community/GLM-4.5-Air-4bit"},
-        # Out-of-band: too small (< 4 B) — harnesses would false-fail.
+        # Out-of-band: far below the floor — harnesses would false-fail.
         "qwen3-0.6b-4bit": {"hf_path": "mlx-community/Qwen3-0.6B-4bit"},
         "llama3-1b-4bit": {"hf_path": "mlx-community/Llama-3.2-1B-Instruct-4bit"},
         "smollm3-3b-4bit": {"hf_path": "mlx-community/SmolLM3-3B-4bit"},
@@ -138,6 +147,47 @@ def test_eligible_aliases_sorted_for_reproducible_sampling(g12, tmp_path):
     assert eligible_a == eligible_c, (
         "eligibility must be order-stable across source-file dict orderings"
     )
+
+
+def test_the_measured_agentic_failure_is_out_of_the_pool(g12):
+    """#1672, at the source rather than at the verdict.
+
+    ``qwen3-4b-instruct-2507-4bit`` × ``hermes`` burns the entire 1020 s
+    per-profile cap while the engine answers without a single 5xx, and v0.12.7
+    behaves identically — the model's ceiling, not a regression. G12 is a
+    coverage sweep, so the answer is to stop drawing a model that cannot do
+    the work, NOT to teach the gate to forgive a red round: from the log of a
+    failed round, "weak model" and "wedged scheduler" are the same evidence,
+    and any rule lenient enough to pass the first ships the second.
+
+    All four 4 B aliases go, not just the measured one. Waiting for each to be
+    drawn and measured means a red gauntlet on a random calendar day, which is
+    how a gate stops being read.
+    """
+    real = Path(__file__).resolve().parent.parent / "vllm_mlx" / "aliases.json"
+    names = {name for name, _ in g12._eligible_aliases(real)}
+    four_b = {n for n in names if re.search(r"(?:^|[-_.])4b(?=[-_.]|$)", n)}
+    assert not four_b, f"the 4 B tier cannot run agentic profiles (#1672): {four_b}"
+    assert "qwen3.5-9b-4bit" in names, (
+        "the 9 B tier completes hermes in ~740-800 s and is where the floor's "
+        "upper measurement comes from — it must stay in the pool"
+    )
+
+
+def test_the_floor_applies_to_active_params_not_total(g12, tmp_path):
+    """A MoE's ability to hold an agentic loop follows its ACTIVE parameters.
+    ``LFM2.5-8B-A1B`` is in-band on total size and hopeless on the work."""
+    p = tmp_path / "aliases.json"
+    p.write_text(
+        json.dumps(
+            {
+                "lfm-8b-a1b-4bit": {"hf_path": "mlx-community/LFM2.5-8B-A1B-4bit"},
+                "big-moe-9b-a8b-4bit": {"hf_path": "fake/Big-9B-A8B-4bit"},
+            }
+        )
+    )
+    names = {name for name, _ in g12._eligible_aliases(p)}
+    assert names == {"big-moe-9b-a8b-4bit"}
 
 
 def test_real_aliases_json_yields_nonzero_pool(g12):

--- a/tests/test_release_check_random.py
+++ b/tests/test_release_check_random.py
@@ -5,6 +5,7 @@ random-coverage gate. The orchestrator script lives outside the
 
 from __future__ import annotations
 
+import ast
 import importlib.util
 import json
 import os
@@ -180,6 +181,52 @@ def test_the_measured_agentic_failure_is_out_of_the_pool(g12):
     )
 
 
+def test_multimodal_models_are_out_of_the_pool(g12):
+    """The harness profiles are text-only, and this filter has always said so —
+    but it said it by looking for ``-vl-`` in the alias, which is exactly the
+    test the engine documents as insufficient.
+
+    UI-TARS is a Qwen2.5-VL-based GUI agent whose public name carries no
+    ``VL``; Gemma 3 is multimodal with no marker at all. Four of the nine
+    eligible aliases were vision models, and the default seed sampled one. On
+    an install without the vision extra that is a crash; with it, a text-only
+    agentic harness measures nothing about a model whose whole contract is
+    screenshots.
+    """
+    real = SCRIPT_PATH.parent.parent / "vllm_mlx" / "aliases.json"
+    names = {name for name, _ in g12._eligible_aliases(real)}
+    offenders = {n for n in names if "ui-tars" in n or "gemma3" in n or "-vl-" in n}
+    assert not offenders, f"multimodal aliases in a text-only sweep: {offenders}"
+
+
+def test_the_multimodal_mirror_still_covers_the_engines_own_list():
+    """``MLLM_NAME_PATTERNS`` is a copy — the script cannot import the package
+    without pulling mlx_lm at module load. Parsed, not imported, so this runs on
+    a machine with no MLX at all: a family added upstream must not be able to
+    reappear in the sweep silently."""
+    tree = ast.parse(
+        (SCRIPT_PATH.parent.parent / "vllm_mlx" / "api" / "utils.py").read_text()
+    )
+    upstream = None
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign) and any(
+            getattr(t, "id", "") == "MLLM_PATTERNS" for t in node.targets
+        ):
+            upstream = [e.value for e in node.value.elts]
+    assert upstream, "MLLM_PATTERNS not found in vllm_mlx/api/utils.py"
+    mirrored = {p.lower() for p in g12_module_patterns()}
+    missing = {p.lower() for p in upstream} - mirrored
+    assert not missing, f"engine patterns absent from the G12 mirror: {missing}"
+
+
+def g12_module_patterns():
+    """Load just the mirror, without importing anything heavyweight."""
+    spec = importlib.util.spec_from_file_location("g12_mirror", SCRIPT_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod.MLLM_NAME_PATTERNS
+
+
 def test_the_floor_applies_to_active_params_not_total(g12, tmp_path):
     """A MoE's ability to hold an agentic loop follows its ACTIVE parameters,
     so the SAME floor applies to them.
@@ -203,10 +250,14 @@ def test_the_floor_applies_to_active_params_not_total(g12, tmp_path):
 
 
 def test_real_aliases_json_yields_nonzero_pool(g12):
-    """Sanity check against the in-tree aliases.json: at least 5
-    eligible models must exist or the gauntlet has nothing to sample.
-    If this trips after a future aliases prune, raise the floor or
-    adjust the filter to admit a wider band."""
+    """Sanity check against the in-tree aliases.json: at least 5 eligible
+    models must exist or the gauntlet has nothing to sample.
+
+    The pool sits at EXACTLY 5 as of #1671 — the 6B floor took the four 4B
+    aliases and the multimodal filter took three UI-TARS plus Gemma 3. There is
+    no headroom left: the next exclusion, or an aliases prune, trips this, and
+    the answer then is a gate sized for the models being excluded (#1677), not
+    a lower bar here."""
     real = Path(__file__).resolve().parent.parent / "vllm_mlx" / "aliases.json"
     eligible = g12._eligible_aliases(real)
     assert len(eligible) >= 5, (
@@ -448,18 +499,94 @@ def test_a_dead_server_is_noticed_by_the_same_check(g12, monkeypatch):
     assert "exited (rc=137)" in g12._still_ours(_Dead(), 8000)
 
 
-def test_ownership_is_asked_around_every_round_not_once():
-    """Pin the wiring. `_wait_for_server` returns permanently after the first
-    owned 200, so without these calls a takeover during round 1 of 6 is
-    invisible and every later round is attributed to the sampled alias."""
+def _drive_rounds(g12, monkeypatch, tmp_path, *, ownership, rounds=2, harnesses=None):
+    """Run `_run_model_rounds` with ownership answers fed in order."""
+    answers = list(ownership)
+    asked: list[str] = []
+    ran: list[tuple[str, int]] = []
+
+    def _ours(proc, port):
+        reply = answers.pop(0) if answers else ""
+        asked.append(reply)
+        return reply
+
+    def _round(*, alias, harness, base_url, bench_log):
+        ran.append((harness, len(ran)))
+        return True, 1.0, ""
+
+    monkeypatch.setattr(g12, "_still_ours", _ours)
+    monkeypatch.setattr(g12, "_run_harness_round", _round)
+    report = tmp_path / "report.log"
+    report.write_text("")
+    failures, drifted = g12._run_model_rounds(
+        proc=_AliveProc(),
+        port=8000,
+        alias="qwen3-8b-4bit",
+        harnesses=list(harnesses or ["hermes", "aider"]),
+        rounds=rounds,
+        bench_log=tmp_path / "bench.log",
+        report_path=report,
+    )
+    return failures, drifted, asked, ran, report.read_text()
+
+
+def test_ownership_is_asked_twice_per_round(g12, monkeypatch, tmp_path):
+    """Once before and once after. Before alone cannot catch a takeover that
+    happens DURING a round, and after alone measures a stranger first."""
+    failures, drifted, asked, ran, _ = _drive_rounds(
+        g12, monkeypatch, tmp_path, ownership=[""] * 8
+    )
+    assert not failures and not drifted
+    assert len(ran) == 4, "2 harnesses x 2 rounds"
+    assert len(asked) == 8, "one check before and one after each round"
+
+
+def test_a_takeover_during_a_round_discards_that_round(g12, monkeypatch, tmp_path):
+    """The dangerous direction: the round finished, so there IS a result — it
+    just belongs to whoever took the port. It must not be reported as this
+    model's."""
+    failures, drifted, _, ran, report = _drive_rounds(
+        g12, monkeypatch, tmp_path, ownership=["", "taken"]
+    )
+    assert drifted
+    assert len(ran) == 1, "the round ran, and is the one being discarded"
+    assert "PASS" not in report, "a round whose port changed hands is not a PASS"
+    assert len(failures) == 1
+    assert "during the round" in failures[0]
+
+
+def test_a_takeover_before_a_round_does_not_run_it(g12, monkeypatch, tmp_path):
+    failures, drifted, _, ran, _ = _drive_rounds(
+        g12, monkeypatch, tmp_path, ownership=["taken"]
+    )
+    assert drifted and not ran
+    assert "before the round" in failures[0]
+
+
+def test_drift_skips_the_remaining_harnesses(g12, monkeypatch, tmp_path):
+    """Continuing after a takeover measures the stranger under this alias's
+    name for every remaining round."""
+    _, drifted, _, ran, _ = _drive_rounds(
+        g12,
+        monkeypatch,
+        tmp_path,
+        ownership=["", "", "", "taken"],
+        harnesses=["hermes", "aider", "codex"],
+    )
+    assert drifted
+    assert len(ran) == 2, "stopped inside the first harness, not after it"
+
+
+def test_the_sweep_aborts_rather_than_booting_the_next_model_into_a_stranger():
+    """Pin the caller's half. `_run_model_rounds` reporting drift is useless if
+    `main` shrugs and boots the next model into the environment that took the
+    port — which can also overlap its GPU allocation with whatever is tearing
+    down."""
     source = SCRIPT_PATH.read_text()
-    loop = source[source.index("for harness in harnesses:") :]
-    loop = loop[: loop.index("finally:")]
-    before, _, after = loop.partition("_run_harness_round(")
-    assert "_still_ours(" in before, "nothing checks ownership before the round"
-    assert "_still_ours(" in after, (
-        "nothing checks ownership after the round — a takeover DURING one is "
-        "then reported as that model's result"
+    sweep = source[source.index("    # ===== Sweep =====") :]
+    sweep = sweep[: sweep.index("    # ===== Verdict =====")]
+    assert "if drifted:" in sweep and "break" in sweep, (
+        "the model loop must stop on ownership drift, not continue"
     )
 
 

--- a/tests/test_release_check_random.py
+++ b/tests/test_release_check_random.py
@@ -267,3 +267,100 @@ def test_hf_cache_root_honors_env_vars(g12, tmp_path, monkeypatch):
 
     # Default
     assert g12._hf_cache_root() == Path.home() / ".cache" / "huggingface" / "hub"
+
+
+# ---------------------------------------------------------------------------
+# The port G12 benchmarks must belong to the server G12 started.
+#
+# Not hypothetical: while a gauntlet was running, a desktop app on this machine
+# swept port 8000, SIGTERM'd the gauntlet's server and bound its own sidecar
+# (#1618). Every later request went there, and nothing noticed, because the
+# replacement answered perfectly well.
+# ---------------------------------------------------------------------------
+
+
+class _FakeProc:
+    def __init__(self, pid: int) -> None:
+        self.pid = pid
+
+
+def _stub_tree(g12, monkeypatch, *, listeners, parents):
+    monkeypatch.setattr(g12, "_listening_pids", lambda port: list(listeners))
+    monkeypatch.setattr(g12, "_parent_pid", lambda pid: parents.get(pid))
+
+
+def test_our_own_process_owns_the_port(g12, monkeypatch):
+    _stub_tree(g12, monkeypatch, listeners=[900], parents={})
+    assert g12._owns_port(_FakeProc(900), 8000)
+
+
+def test_a_descendant_of_ours_owns_the_port(g12, monkeypatch):
+    """`rapid-mlx serve` may bind from a child of the process we spawned."""
+    _stub_tree(g12, monkeypatch, listeners=[903], parents={903: 902, 902: 900})
+    assert g12._owns_port(_FakeProc(900), 8000)
+
+
+def test_a_stranger_does_not_own_the_port(g12, monkeypatch):
+    """The #1618 shape: something else is listening and answering 200."""
+    _stub_tree(g12, monkeypatch, listeners=[555], parents={555: 1})
+    assert not g12._owns_port(_FakeProc(900), 8000)
+
+
+def test_a_port_shared_with_a_stranger_is_refused(g12, monkeypatch):
+    """One of ours plus one of theirs is not ownership — requests can land on
+    either, so the numbers cannot be attributed to the sampled alias."""
+    _stub_tree(g12, monkeypatch, listeners=[900, 555], parents={555: 1})
+    assert not g12._owns_port(_FakeProc(900), 8000)
+
+
+def test_an_unverifiable_port_is_refused(g12, monkeypatch):
+    """Fails CLOSED. The caller only asks after a 200, so an empty listener
+    list means `lsof` could not tell us — not that nothing is there. Reading
+    "cannot tell" as "it's ours" reinstates exactly the bug."""
+    _stub_tree(g12, monkeypatch, listeners=[], parents={})
+    assert not g12._owns_port(_FakeProc(900), 8000)
+
+
+def test_an_unreadable_parent_is_refused(g12, monkeypatch):
+    """`ps` failing mid-walk proves nothing about the rest of the chain."""
+    _stub_tree(g12, monkeypatch, listeners=[903], parents={903: None})
+    assert not g12._owns_port(_FakeProc(900), 8000)
+
+
+def test_the_ancestor_walk_is_bounded(g12, monkeypatch):
+    """A pid whose parent chain loops must not spin forever."""
+    _stub_tree(g12, monkeypatch, listeners=[10], parents={10: 11, 11: 10})
+    assert not g12._owns_port(_FakeProc(900), 8000)
+
+
+# ---------------------------------------------------------------------------
+# Two writers, one of them offset-based, corrupts the artifact.
+# ---------------------------------------------------------------------------
+
+
+def test_the_bench_transcript_is_not_written_to_the_servers_log(g12):
+    """The server holds its log open ``"w"`` — no O_APPEND — so it writes at
+    an offset it tracks itself. Appending a bench transcript to that same path
+    moves the end of the file without moving that offset, and the server's
+    next line overwrites what we wrote."""
+    assert g12._serve_log_path("qwen3-8b-4bit") != g12._bench_log_path("qwen3-8b-4bit")
+
+
+def test_a_round_appends_its_transcript_to_the_bench_log(g12, tmp_path, monkeypatch):
+    bench_log = tmp_path / "bench.log"
+    bench_log.write_text("")
+
+    class _Result:
+        returncode = 0
+        stdout = "harness ok\n"
+        stderr = ""
+
+    monkeypatch.setattr(g12.subprocess, "run", lambda *a, **k: _Result())
+    ok, _, _ = g12._run_harness_round(
+        alias="qwen3-8b-4bit",
+        harness="hermes",
+        base_url="http://127.0.0.1:8000",
+        bench_log=bench_log,
+    )
+    assert ok
+    assert "harness ok" in bench_log.read_text()


### PR DESCRIPTION
## Why

**G12 has not run for eleven releases.** Not "ran and passed" — never
executed, from v0.11.4 through v0.12.7. It is the gauntlet's last gate and the
only one that boots anything other than `qwen3.5-9b-4bit`, so each of those
releases shipped without the other ~28 registered aliases being started once.

`cleanup()` was written as `[ -n "$CLUSTER_WORK" ] && rm -rf "$CLUSTER_WORK"`.
As an EXIT trap its return status is discarded, but G12 *also* calls it inline,
to hand the port and the GPU to the sweep. There, under `set -euo pipefail`, the
status is load-bearing: by then `CLUSTER_WORK` is always empty — the correctness
cluster cleared it a few hundred lines earlier — so the `&&` list returns 1 and
the gauntlet dies on the spot. The signature is the G12 banner, then
`make: *** Error 1`, and not one line of gate output.

The window is precise, and it is not "since G12 was added": at #693 `cleanup`
was the pidfile block alone and returned 0. The `&&` arrived together with
`CLUSTER_WORK` in #1354 (`a4520b2a`, 2026-07-30), and G12 has been dead from
that commit onward.

It is fail-closed, so nothing shipped that a green G12 would have caught. What
was lost is the coverage.

## What un-skipping it found

The first real run went red on `qwen3-4b-instruct-2507-4bit` × `hermes`: the
profile burned the entire 1020 s per-profile cap while the engine answered
58×200 / 36×404 (the harness probing `GET /version`, which the server does not
expose) and zero 5xx. Replayed on v0.12.7 the run is byte-identical, so it is
the model's ceiling and not a regression (#1672).

The tempting fix — teach the gate to forgive that round — cannot be made sound,
and the first draft of this PR tried it. From the log of a failed round, "weak
model" and "wedged scheduler" produce the same evidence. Liveness plus a 2xx
does not separate them either: bench issues `GET /health` and `GET /v1/models`
itself before the profile starts, so a 2xx is automatic and says nothing about
inference. Any rule lenient enough to pass a 4B model that ran out of clock also
passes a scheduler that deadlocked after the first request, a stall between
streaming headers and the first token, and a decode regression that put every
request past the cap.

So it is fixed where the fact lives — the sample pool.

## The three commits

1. **`cleanup` returns 0.** `if`, not `&&`, plus an explicit `return 0`, with a
   comment saying why the status matters at one of its two call sites.

2. **G12 stops drawing models that cannot do agentic work.** Every profile in
   `HARNESS_PROFILES` drives a multi-step tool-calling loop; a model that cannot
   hold one does not fail fast, it retries malformed calls until the clock runs
   out. Excluding models that cannot do the work is what this filter already
   does for hybrids, for gemma-4 (#686), and for MoEs with too few active
   params — this adds the tier the gauntlet measured.

   The floor moves 4 → 6 B, the conservative cut between the two sizes measured
   on this hardware: 4B fails hermes; 9B completes it in ~740–800 s, which is
   where `ROUND_TIMEOUT_S` came from. 7B and 8B are unmeasured and stay, because
   that band is most of the sweep's coverage; if one shares the ceiling, the
   constant moves again. All four 4B aliases go, not only the drawn one —
   waiting for each to be sampled and measured means a red gauntlet on a random
   calendar day, which is how a gate stops being read. Pool: 13 → 9.

   **What this costs, without the gloss.** The 4B tier keeps only the coverage
   it already had, and that is thin: `qwen3.5-4b-4bit` is a release-fleet
   coherence model so G0a boots it every gauntlet, but `evals/coherence_gate.py`
   sends short, single-turn, tool-free prompts at temperature 0, and CI's
   `l1-smoke` adds one forced tool-call format check on that same alias and is
   not a required check. Neither covers multi-turn contexts, streaming tool
   calls, parser stress under repeated agent traffic, or the other three 4B
   aliases at all. Buying that back needs a tier sized for what small models can
   finish rather than a sweep that hands them a 12B's profiles — filed
   separately (#1677). The alternative — keeping the 4B aliases in the pool and accepting the occasional red day — would mean narrowing the exclusion to the agentic harnesses only, rather than dropping the tier from sampling.**

3. **G12 must own the port it benchmarks, and the GPU.**
   * Ownership was checked once. `_wait_for_server` returns permanently on the
     first owned 200, and the round loop never asked again — so a takeover after
     readiness hands every later round to a stranger, and a model can even PASS
     that way. `_still_ours` is now asked before AND after every round: before,
     so we do not measure someone else; after, because a takeover during a round
     would otherwise be reported as that round's result.
   * `_wait_for_server` accepted any 200. Our child stays alive for minutes
     while it loads weights, so anything already bound answers first and every
     round after that measures it — which happened during this work: a desktop
     app swept port 8000, SIGTERM'd the gauntlet's server and bound its own
     sidecar (#1618), and nothing noticed because the replacement answered
     perfectly well. Asking `/v1/models` what it serves is not enough (identity
     is not ownership; a leftover engine holding the same weights passes), so
     `_owns_port` walks the process tree: every listener must be our child or a
     descendant. Fails closed.
   * The handoff waited for the port, not for the process. uvicorn closes its
     listening socket before lifespan shutdown finishes — and shutdown is where
     #667's deadline-aware prefix-cache flush runs — so a free port is not an
     idle GPU. Overlapping G12's model load with a process still holding weights
     is how a run earns a `metal::malloc` "Resource limit" that reads like a
     code bug. Now: capture the PID before `cleanup` deletes the pidfile, then
     require both the process gone and the port free, or refuse.
   * Each round appended its bench transcript to the server's log file. The
     server holds that file open `"w"` — no `O_APPEND` — so it writes at an
     offset it tracks itself: our append moves the end of the file, its next
     line lands on top of what we wrote. Transcripts get their own file.

## Tests

* `tests/release/test_release_check_m3_cleanup.sh` — extracts the real
  `cleanup` with `sed` so a copy cannot drift, and pins the premise (the script
  still runs under `set -euo pipefail`; G12 still calls `cleanup` inline). 3 of
  6 assertions fail on `main`. Runs in CI via the existing
  `tests/release/test_*.sh` loop.
* `tests/test_release_check_random.py` — 7 → 25 tests: the 4B tier is out of
  the pool and 9B is still in; the floor applies to a MoE's active params, with
  cases straddling the NEW floor (A4/A5 out, A6 in) so the test is not vacuous;
  the ownership walk (ours, a descendant, a stranger, a shared port, an
  unverifiable port, an unreadable parent, a looping parent chain); that
  readiness actually consults ownership rather than merely defining it; that the
  round loop asks before *and* after each round, by parsing the loop, so
  deleting a call site fails; a partial `lsof` run; and a timed-out round
  leaving a transcript. **19 fail against this branch's base.**

All offline — no GPU, no network, no server.

4. **G12 was sampling vision models into a text-only harness.** The filter
   excluded multimodal models by looking for `-vl-` in the alias — precisely
   the test `vllm_mlx/api/utils.py` documents as insufficient, because UI-TARS
   is a Qwen2.5-VL-based GUI agent whose public name carries no `VL` and
   Gemma 3 is multimodal with no marker at all. Four of the nine eligible
   aliases were vision models and the default seed `20260808` sampled
   `ui-tars-7b-dpo-4bit`: a hard exit at boot without the vision extra, and a
   meaningless measurement with it. Now mirrored from `MLLM_PATTERNS`, matched
   against the alias and the HF path, with a test that parses the engine's list
   out of the source (the script must stay importable without MLX) and fails if
   the mirror falls behind.

   **Pool: 13 → 5**, exactly the documented minimum. The sanity test now says
   so — the next exclusion trips it, and the answer then is a gate sized for
   what is being excluded (#1677), not a lower bar here. `deepseek-r1-8b-4bit`
   is one of the five and is a suspected #1672 (#1676); today's seed draws it.

5. **Ownership drift aborts the sweep**, rather than booting the next model
   into whatever took the port. `_run_model_rounds` came out of `main` so the
   control flow is testable: the earlier test read the source for a call site,
   which a rename breaks and which never proved that a drifted round is
   discarded or that the remaining harnesses are skipped.

6. **`lsof` is bounded and required up front.** The 60s handoff deadline read
   `SECONDS` only between calls, so an `lsof` that never returned made it
   unbounded. `port_busy` runs it under a watchdog and reports
   listening / free / could-not-tell, with an unverifiable port never counting
   as free. The `command -v lsof` check moved to the top-level pre-flight,
   because the gauntlet's first act is an `lsof` port check whose 127 the `if`
   swallows — a PATH without `/usr/sbin` used to run the whole gauntlet before
   G12 noticed.

## Two bugs I found by measuring instead of reasoning

Both were invisible to the unit tests, because the unit tests stub the thing
that was broken.

* **`_owns_port` returned True for pid 1.** The ancestor walk climbs until it
  meets `proc.pid`, and every chain reaches init, so "the listener descends
  from pid 1" is true of every listener on the machine. Found by pointing the
  check at a real listener on a real port. There is now a test that does that —
  bind a port from a real child, assert the child is ours, our own pid is ours
  (the walk has to cross an edge, which is what a `serve` binding from a
  subprocess needs), pid 1 is not, and a freed port belongs to nobody.
* **`kill -0` succeeds on a zombie.** Between `cleanup` sending TERM and the
  shell collecting the status, the server still owns a pid — and owns no GPU.
  The wait loop read that as "still running", would burn the whole 60s deadline
  and then SIGKILL a corpse, turning a clean shutdown into a gate failure that
  blames the thing that worked.

## Review rounds

Two so far. Round 1 killed the original approach outright: I had G12 classify a
failed round as WARN when the engine looked healthy, and the review showed the
downgrade is unsound — `bench` issues `GET /health` and `GET /v1/models` itself,
so the "positive evidence" I required was free. That code is gone; commit 2 is
what replaced it. Round 2 produced the ownership blocker, the leaked-process
path, the `lsof` handling, and the correction to the release history above (I
had said "since #693"; it is #1354). Round 3 produced the multimodal blocker,
the abort-on-drift major, and the bounded/early `lsof` — and confirmed the
round-2 fixes.

## Run on real hardware

**A full `make release-check-m3` cannot go green on this machine, and that is
not this branch.** The gauntlet died at **G7b**, four gates before G12:

```
FAIL codex (163.1s) 11p 0f 1e 0s | e2e_file_read: TIMEOUT
```

Replayed scoped to that profile it fails again with a *different* subtest
(`e2e_chat`), and replayed on **`v0.12.7`** it fails identically to the gauntlet
run. Not a regression, not caused by a branch that changes four files and no
engine code. Filed as **#1683** — and note what it implies: G7b is not sampled,
so the local gauntlet has not been able to reach G12 at all.

So the gate this PR fixes was exercised directly instead:

```
python3.12 scripts/release_check_m3_random.py --models 2 --harnesses 1 --rounds 1
```

**The G12 machinery works end to end on real hardware.** Boot → ownership
verified against the real process tree → round → clean teardown → next model →
verdict. No spurious ownership drift, no leaked server, `:8000` released
afterwards. The earlier full-gauntlet run also proved the `cleanup` fix in
situ: it failed at G7b and exited cleanly, leaving no server behind.

And on its first honest run the gate immediately found two per-model defects,
which is exactly what it exists for:

```
FAIL hermes3-8b-4bit/aider        (0.3s)  1p 1f | plain_chat: Expected '4', got: 2
FAIL deepseek-r1-8b-4bit/opencode (40.4s) 5p 5f | single_tool_call: No tool_calls in response
```

Both are model-side. `hermes3-8b-4bit` answering `2` to "What is 2+2? Reply with
just the number" is deterministic at temperature 0.0 and 0.3, while the same
model answers `What is 2+2?`, `2+2=`, the capital of Japan, an exact-echo
instruction, and — with the identical "reply with just the number" phrasing —
`17 times 23` → `391`, all correctly. So it is neither the engine nor the chat
template.

Which is the honest caveat on this PR: **G12's pass criterion is model
competence, so it will keep going red without an engine regression in sight.**
Three red gates today, zero product bugs. That is the argument for #1677, and
the reason the pool cannot simply keep shrinking — it is at five now, the
documented minimum, and #1676 wants a sixth exclusion.

### Suggested merge criterion

This branch makes a dead gate run, verified on hardware. Blocking it on a green
`release-check-m3` blocks it on #1683, which is someone else's bug and older
than this branch.

Refs #1672, #1618

