### PR TITLE
Fix GUI benchmark and catalog round trip

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -43,6 +43,7 @@ struct ContentView: View {
     @SceneStorage("Rapid.showLogs") private var showLogs: Bool = false
     /// Per-session "browse all models" dismissal of the Quickstart card.
     @State private var quickstartDismissedThisSession: Bool = false
+    @Environment(SettingsRouter.self) private var settingsRouter
     /// #223: launch-time auto-start "needs download" state — the empty
     /// state names the pending pull when non-nil.
     @State private var autoStartPendingDownload: (alias: String, sizeText: String?)?
@@ -255,6 +256,9 @@ struct ContentView: View {
         // setup first".
         .sheet(isPresented: quickstartSheetPresented) {
             quickstartSheet
+        }
+        .onChange(of: settingsRouter.quickstartReturnGeneration) { _, _ in
+            quickstartDismissedThisSession = false
         }
         // Per-fetch approval for the ``browse`` tool. Skipped entirely when
         // the user has turned on auto-approve in Settings (resolved before a
@@ -481,6 +485,7 @@ struct ContentView: View {
             downloads: downloads,
             server: server,
             onSkip: { quickstartDismissedThisSession = true },
+            onBrowseAll: { quickstartDismissedThisSession = true },
             onSeedWelcome: { true }
         )
         // QuickstartView was written for the detail column and its comments

--- a/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
@@ -759,6 +759,8 @@ Open the picker any time to switch models.
 /// ``QuickstartCoordinator`` reports the surface should show.
 struct QuickstartView: View {
     @Environment(SettingsRouter.self) private var settingsRouter
+    @Environment(\.dismiss) private var dismiss
+
     /// The ONLY mechanism that opens this app's Settings. It declares a real
     /// ``Window("Settings", id: "settings")`` and no SwiftUI ``Settings``
     /// scene, so ``@Environment(\.openSettings)`` — which this view used to
@@ -785,6 +787,9 @@ struct QuickstartView: View {
     /// on the alphabetical fallback (#1653). Browsing is handled in this view
     /// now, by ``browseAllModels()``.
     var onSkip: () -> Void
+
+    /// Temporarily lower the wizard while its Settings catalogue is open.
+    var onBrowseAll: () -> Void
 
     /// Callback the parent supplies for seeding the welcome message
     /// into the active session. Closing over ``SessionStore`` /
@@ -1383,21 +1388,28 @@ struct QuickstartView: View {
         .buttonStyle(.borderless)
     }
 
-    /// Open Settings on the model catalogue, leaving Quickstart standing.
+    /// Open Settings on the model catalogue and restore Quickstart on return.
     ///
-    /// The wizard deliberately stays up behind the Settings window. "Browse all
-    /// models" is a request to see the other options, not to abandon setup, so
-    /// closing Settings has to put the user back where they were with the pick
-    /// they had already made. Dismissing instead is what made the link a dead
-    /// end (#1653): the wizard vanished, the selection was discarded, and the
-    /// user landed on whatever the alphabetical fallback chose — a 7.6 GB
-    /// download they never asked for.
+    /// The sheet's modal session must end before the separate Settings window
+    /// opens. The router restores the wizard when Settings closes, preserving
+    /// the user's existing pick. Without that handoff, browsing became a dead
+    /// end and fell back to an unrelated model (#1653).
     ///
     /// Routed through ``SettingsRouter`` for its ordering rule (stage the tab,
     /// THEN open), and through ``openWindow(id: "settings")`` rather than
     /// ``openSettings()`` — see the ``openWindow`` property above.
     private func browseAllModels() {
-        settingsRouter.route(to: .modelManagement) { openWindow(id: "settings") }
+        settingsRouter.beginQuickstartCatalogRoundTrip()
+        onBrowseAll()
+        dismiss()
+        // End the sheet's AppKit modal session before opening another window.
+        // Opening synchronously leaves Settings visible to AX but unable to
+        // accept real foreground input until the stale modal session unwinds.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            settingsRouter.route(to: .modelManagement) {
+                openWindow(id: "settings")
+            }
+        }
     }
 
     private func handleQuickstartFailureAction(_ action: FailureDiagnosis.Action) {

--- a/apps/rapid-mac/Sources/Rapid/UI/SettingsRouter.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SettingsRouter.swift
@@ -48,6 +48,22 @@ final class SettingsRouter {
     /// land on the user's last selected tab."
     var requestedCategory: SettingsView.Category?
 
+    /// One-shot handoff used by Quickstart's Browse all round trip. The
+    /// onboarding sheet must be lowered before opening a separate Settings
+    /// window, otherwise AppKit's modal session traps that window.
+    private(set) var quickstartReturnGeneration = 0
+    private(set) var quickstartCatalogReturnPending = false
+
+    func beginQuickstartCatalogRoundTrip() {
+        quickstartCatalogReturnPending = true
+    }
+
+    func completeQuickstartCatalogRoundTrip() {
+        guard quickstartCatalogReturnPending else { return }
+        quickstartCatalogReturnPending = false
+        quickstartReturnGeneration &+= 1
+    }
+
     /// Which Settings tab a failure-recovery action deep-links to, or `nil`
     /// when the action is carried out in place (retry, restart, switch
     /// download source) and must NOT open Settings at all.

--- a/apps/rapid-mac/Sources/Rapid/UI/SettingsView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SettingsView.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Carbon.HIToolbox
 import SwiftUI
 import UniformTypeIdentifiers
@@ -38,6 +39,7 @@ struct SettingsView: View {
     /// "Failed: …" inline when the dedicated update window is
     /// closed.
     @Environment(Installer.self) private var appInstaller
+    @Environment(\.dismissWindow) private var dismissWindow
     /// #260: persisted "hide Dock icon on close" choice. Settings →
     /// App surfaces a toggle so the user can change their mind
     /// without re-triggering the one-time prompt, plus a "Reset
@@ -278,20 +280,45 @@ struct SettingsView: View {
             }
         }
         .frame(minWidth: 720, minHeight: 480)
+        .safeAreaInset(edge: .top, spacing: 0) {
+            if router.quickstartCatalogReturnPending {
+                VStack(spacing: 0) {
+                    HStack {
+                        QuickstartBackButton { window in
+                            dismissWindow(id: "settings")
+                            window.close()
+                            DispatchQueue.main.async {
+                                router.completeQuickstartCatalogRoundTrip()
+                            }
+                        }
+                        .frame(width: 130, height: 28)
+                        Spacer()
+                    }
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 10)
+                    Divider()
+                }
+            }
+        }
         .onAppear {
-            // v0.4.37: consume any pending deep-link request. Fires
-            // when the Settings scene is created (typical for the
-            // FIRST open this app session) — covers the case where
-            // a deep-link click set ``requestedCategory`` before
-            // ever opening Settings, so the window opens already on
-            // the target tab instead of the default Tools tab. The
-            // ``.onChange`` below handles the SECOND case (Settings
-            // already open and being re-focused by another deep-link
-            // click).
+            // v0.4.37: consume any pending deep-link request. Fires when the
+            // Settings scene is created (typical for the first open this app
+            // session). The onChange below handles an already-open window.
             consumeRouterRequest()
         }
         .onChange(of: router.requestedCategory) { _, _ in
             consumeRouterRequest()
+        }
+        .onDisappear {
+            // onDisappear fires while AppKit is still closing the window.
+            // Restoring the onboarding sheet synchronously would start a new
+            // modal session and trap the Settings window mid-close.
+            Task { @MainActor in
+                try? await Task.sleep(nanoseconds: 200_000_000)
+                if router.quickstartCatalogReturnPending {
+                    router.completeQuickstartCatalogRoundTrip()
+                }
+            }
         }
     }
 
@@ -950,5 +977,43 @@ struct SettingsView: View {
         case "current_datetime": return "clock"
         default: return "wrench.and.screwdriver"
         }
+    }
+}
+
+/// AppKit-backed because AXPress on a SwiftUI button in a secondary Window can
+/// report success without invoking its closure while another app window remains
+/// main. NSButton's target/action contract is deterministic for both people and
+/// Accessibility-first automation.
+private struct QuickstartBackButton: NSViewRepresentable {
+    let action: (NSWindow) -> Void
+
+    final class Coordinator: NSObject {
+        var action: (NSWindow) -> Void
+
+        init(action: @escaping (NSWindow) -> Void) {
+            self.action = action
+        }
+
+        @MainActor @objc func invoke(_ sender: NSButton) {
+            guard let window = sender.window else { return }
+            action(window)
+        }
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(action: action)
+    }
+
+    func makeNSView(context: Context) -> NSButton {
+        let button = NSButton(title: "Back to setup", target: context.coordinator, action: #selector(Coordinator.invoke(_:)))
+        button.bezelStyle = .rounded
+        button.image = NSImage(systemSymbolName: "chevron.left", accessibilityDescription: nil)
+        button.imagePosition = .imageLeading
+        button.setAccessibilityIdentifier("Settings.BackToQuickstart")
+        return button
+    }
+
+    func updateNSView(_ button: NSButton, context: Context) {
+        context.coordinator.action = action
     }
 }

--- a/apps/rapid-mac/Tests/RapidTests/LoadedModelBenchmarkTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/LoadedModelBenchmarkTests.swift
@@ -75,6 +75,19 @@ struct LoadedModelBenchmarkTests {
         #expect(body["stream"] as? Bool == false)
     }
 
+    @Test("Speed test adds the OpenAI version path to the desktop server root")
+    func desktopServerRootRequest() throws {
+        let request = try BenchmarkRunner.loadedBenchmarkRequest(
+            baseURL: URL(string: "http://127.0.0.1:8123")!,
+            bearer: "",
+            alias: "fake-alias",
+            maxTokens: 8,
+            prompt: "warm up"
+        )
+
+        #expect(request.url?.absoluteString == "http://127.0.0.1:8123/v1/chat/completions")
+    }
+
     @Test("Displayed speed uses completion tokens over measured wall time")
     func completionSpeed() {
         let measurement = BenchmarkRunner.LoadedMeasurement(

--- a/apps/rapid-mac/Tests/RapidTests/QuickstartBrowseAllDestinationTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/QuickstartBrowseAllDestinationTests.swift
@@ -76,21 +76,31 @@ struct QuickstartBrowseAllDestinationTests {
         )
     }
 
-    @Test("browseAllModels() stages the models tab, then opens Settings")
+    @Test("browseAllModels() ends the sheet, then stages the models tab and opens Settings")
     func browseAllModelsRoutesToModelManagement() throws {
         let source = try Self.quickstartSource
-        #expect(
-            source.contains(
-                "settingsRouter.route(to: .modelManagement) { openWindow(id: \"settings\") }"
-            ),
-            """
-            browseAllModels() must route through SettingsRouter to the \
-            modelManagement tab. Opening Settings on the user's last-used tab \
-            is a different bug wearing the same green check, and \
-            openSettings() targets a scene this app does not declare — see \
-            OpenSettingsActionAbsenceTests.
-            """
-        )
+        let requiredInOrder = [
+            "settingsRouter.beginQuickstartCatalogRoundTrip()",
+            "onBrowseAll()",
+            "dismiss()",
+            "settingsRouter.route(to: .modelManagement)",
+            "openWindow(id: \"settings\")",
+        ]
+        var cursor = source.startIndex
+        for needle in requiredInOrder {
+            guard let range = source.range(of: needle, range: cursor..<source.endIndex) else {
+                Issue.record(
+                    """
+                    browseAllModels() is missing `\(needle)`. The flow must lower \
+                    Quickstart's modal sheet, preserve the selection through the \
+                    one-shot router handoff, and open Model Management rather than \
+                    the user's last-used Settings tab.
+                    """
+                )
+                return
+            }
+            cursor = range.upperBound
+        }
     }
 
     @Test("Dismissing the wizard is reachable from exactly one control")

--- a/apps/rapid-mac/Tests/RapidTests/SettingsRouterTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SettingsRouterTests.swift
@@ -54,4 +54,23 @@ struct SettingsRouterTests {
         r.requestedCategory = .app
         #expect(r.requestedCategory == .app)
     }
+
+    @Test("Quickstart catalogue return is one-shot")
+    func quickstartCatalogueReturn() {
+        let r = SettingsRouter()
+        #expect(r.quickstartReturnGeneration == 0)
+        #expect(!r.quickstartCatalogReturnPending)
+
+        r.completeQuickstartCatalogRoundTrip()
+        #expect(r.quickstartReturnGeneration == 0)
+
+        r.beginQuickstartCatalogRoundTrip()
+        #expect(r.quickstartCatalogReturnPending)
+        r.completeQuickstartCatalogRoundTrip()
+        #expect(!r.quickstartCatalogReturnPending)
+        #expect(r.quickstartReturnGeneration == 1)
+
+        r.completeQuickstartCatalogRoundTrip()
+        #expect(r.quickstartReturnGeneration == 1)
+    }
 }

--- a/apps/rapid-mac/docs/gui-golden-flows.md
+++ b/apps/rapid-mac/docs/gui-golden-flows.md
@@ -17,13 +17,17 @@ Rapid-MLX Desktop app without loading a real model.
    server: one server start, then one warm-up plus one measured request, with
    no second model process and no duplicate weight load.
 
+8. “Browse all models” lowers the onboarding sheet, opens Model Management in
+   Settings, accepts a foreground interaction, and returns to the wizard with
+   the user's original model selection intact. A final full-screen capture
+   records the state a person actually sees.
 **Invariants** — properties that must hold, not paths a user walks. These were
 added after a release where every escaped defect landed on a surface no journey
 covered, and each one names the defect it would have caught:
 
-8. `update-state` — Settings → App must name the version the app actually is.
-9. `no-dead-controls` — every Settings panel must expose controls of its own.
-10. `catalog-integrity` — a model that cannot chat must never be offered as one.
+9. `update-state` — Settings → App must name the version the app actually is.
+10. `no-dead-controls` — every Settings panel must expose controls of its own.
+11. `catalog-integrity` — a model that cannot chat must never be offered as one.
 
 The distinction matters. A journey answers *"can someone do this?"*; an
 invariant answers *"is this still true everywhere?"*. The three defects below
@@ -186,11 +190,18 @@ Run one journey or retain its isolated persona for diagnosis:
 ./scripts/gui-golden-flows.sh --flow low-memory-choice
 ./scripts/gui-golden-flows.sh --flow loaded-model-benchmark
 ./scripts/gui-golden-flows.sh --flow chat-restore --keep
+./scripts/gui-golden-flows.sh --flow browse-all-destination
 ./scripts/gui-golden-flows.sh --flow no-dead-controls
 ```
 
-The suite needs a **local login session** — not SSH or tmux. It also needs the
-screen to stay awake: when the session goes idle, `CGSSessionScreenIsLocked`
+The suite needs an active **GUI login session**. A command launched directly by
+`sshd` or tmux does not inherit Terminal's Screen Recording and Accessibility
+grants. Remote runs are supported by asking the logged-in Terminal app to run
+the command (for example with `osascript ... do script ...`); the test process
+then has the same TCC identity as that Terminal session.
+
+The screen must also stay awake: when the session goes idle,
+`CGSSessionScreenIsLocked`
 flips to `Yes`, every app reports zero windows through AX, and `screencapture`
 returns wallpaper. That looks exactly like a broken app. Hold the session with
 `caffeinate -dimsu -t <seconds>` for the length of the run — `-u` is the

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -61,6 +61,17 @@ done
 log() { printf '[gui-golden] %s\n' "$*"; }
 die() { printf '[gui-golden] FAIL: %s\n' "$*" >&2; exit 1; }
 pb() { peekaboo "$@" --bridge-socket "$BRIDGE"; }
+pb_click_coords() {
+    local coords="$1"
+    shift
+    # Peekaboo 3.0 uses screen coordinates by default and auto-focuses the
+    # target window. Newer releases make those semantics explicit.
+    if peekaboo click --help 2>&1 | grep -q -- --global-coords; then
+        pb click --coords "$coords" --global-coords --foreground "$@"
+    else
+        pb click --coords "$coords" "$@"
+    fi
+}
 
 cleanup_persona() {
     if [[ -n "$APP_PID" ]] && kill -0 "$APP_PID" 2>/dev/null; then
@@ -263,7 +274,7 @@ dismiss_first_run() {
     if jq -e '.data.ui_elements[]? | select(.identifier == "TelemetryConsent.DontShare")' "$tree" >/dev/null; then
         if ! press "$tree" TelemetryConsent.DontShare "$OUT/consent.json" 2>/dev/null; then
             read -r x y < <(jq -r '.data.ui_elements[] | select(.identifier == "TelemetryConsent.DontShare") | [(.bounds.x + .bounds.width / 2), (.bounds.y + .bounds.height / 2)] | @tsv' "$tree")
-            pb click --coords "$x,$y" --global-coords --app "PID:$APP_PID" --json > "$OUT/consent-coordinate-fallback.json"
+            pb_click_coords "$x,$y" --app "PID:$APP_PID" --json > "$OUT/consent-coordinate-fallback.json"
         fi
         sleep 0.5
         see_main "$tree"
@@ -648,7 +659,11 @@ flow_low_memory_choice() {
     sheet_region="$(jq -r '.data.ui_elements[] | select(.role == "AXSheet") | [.bounds.x, .bounds.y, .bounds.width, .bounds.height] | map(round) | @csv' "$OUT/low-memory-selected.json" | head -1)"
     [[ -n "$sheet_region" ]] || die "Quickstart sheet bounds are absent from AX"
     pb app switch --to "PID:$APP_PID" --verify --json > "$OUT/focus-before-image.json"
-    pb image --mode area --region "$sheet_region" --path "$OUT/low-memory-selected.png" --json \
+    # Capture the containing window instead of relying on Peekaboo's newer
+    # area/region flags. The AX assertion above still proves that the sheet is
+    # present, while a window capture works with both v3.0 beta and current
+    # Peekaboo releases used across our dogfood Macs.
+    pb image --window-id "$MAIN_WINDOW_ID" --path "$OUT/low-memory-selected.png" --json \
         > "$OUT/low-memory-selected-image.json"
 
     jq -n '{success: true, assertion: "onboarding exposes and selects an honestly labelled sub-1B low-memory fallback"}' \
@@ -887,7 +902,7 @@ flow_browse_all_destination() {
     #    AXUIElementPerformAction reaches it there too — so neither the tree
     #    nor an AXPress can tell a usable window from a trapped one. Focus it,
     #    click it the way a person would, and require the panel to change.
-    pb window focus --window-id "$SETTINGS_WINDOW_ID" --json > "$OUT/ba-focus.json" \
+    pb window focus --app "PID:$APP_PID" --window-id "$SETTINGS_WINDOW_ID" --json > "$OUT/ba-focus.json" \
         || die "could not focus the Settings window the button opened"
     # Coordinates re-read AFTER the focus, because focusing can raise or move
     # the window and a stale point would click whatever now sits there.
@@ -904,8 +919,9 @@ flow_browse_all_destination() {
     # "trapped behind a modal sheet" as the AXPress this replaced.
     # ``--window-id`` also pins the click to the Settings window rather than
     # whatever else the app has on screen at that point.
-    pb click --coords "$cx,$cy" --global-coords --foreground \
-        --window-id "$SETTINGS_WINDOW_ID" --json > "$OUT/ba-click.json" \
+    pb_click_coords "$cx,$cy" \
+        --app "PID:$APP_PID" --window-id "$SETTINGS_WINDOW_ID" \
+        --json > "$OUT/ba-click.json" \
         || die "the Settings window did not accept a real click — it is behind the wizard sheet"
     # A real click that changed nothing is the same failure as no click at all,
     # so require the panel's own control to appear, not merely that the press
@@ -916,12 +932,12 @@ flow_browse_all_destination() {
     # 4. Close it, the way the user would, and land back on the wizard with
     #    the same pick. This is the half the bug actually broke.
     #
-    #    Scoped to the window, not the app: ``menu click --app`` routes Close
-    #    to whichever window is key, which on a bad day is the main one — and
-    #    then every assertion below runs against a wizard that was never
-    #    actually returned to.
-    pb menu click --window-id "$SETTINGS_WINDOW_ID" --item 'Close' --json > "$OUT/ba-close.json" \
-        || die "could not close the Settings window"
+    press "$OUT/ba-privacy.json" Settings.BackToQuickstart "$OUT/ba-close.json" \
+        || die "could not activate Back to setup"
+
+    # The SwiftUI scene may retain an internal window object after dismissal,
+    # so ask AX whether a user-visible Settings window remains. Do not accept a
+    # failed dump as evidence that closing succeeded.
     local closed=0
     probe=2
     for ((i=0; i<40; i++)); do
@@ -944,6 +960,11 @@ flow_browse_all_destination() {
     fi
 
     wait_identifier Quickstart.BrowseAll "$OUT/ba-after.json"
+    jq -e '[.data.ui_elements[]? | select(.identifier == "Settings.BackToQuickstart")] | length == 0' \
+        "$OUT/ba-after.json" >/dev/null \
+        || die "Settings remained interactive after returning to setup"
+    pb image --mode screen --screen-index 0 --path "$OUT/ba-after.png" --json \
+        > "$OUT/ba-after-image.json"
     jq -e --arg id "$chosen" '.data.ui_elements[]? | select(.identifier == $id) | select(.selected == true)' \
         "$OUT/ba-after.json" >/dev/null \
         || die "the wizard came back without the user's selection — browsing must not discard it (#1653)"


### PR DESCRIPTION
## Summary
- make Quickstart → Browse all models → Back to setup a deterministic round trip that preserves the selected model
- retain main’s shared `/v1/chat/completions` benchmark endpoint fix and extend its regression coverage
- harden the Accessibility-first GUI golden-flow runner across Peekaboo versions and record the new release flow

## Root causes
- opening a secondary Settings window while the onboarding sheet modal session was active left an AX-visible but non-interactive window
- closing onboarding for catalog browsing lost the user’s selection and had no explicit return affordance
- GUI assertions could confuse retained/hidden SwiftUI window objects with user-visible state

## Validation
- targeted Swift suites: loaded benchmark 6/6; Settings router 5/5; Quickstart catalog destination 5/5
- full local Swift suite passed; repository-path group separately passed 4/4 from a complete-repo local-SSD copy
- full Accessibility-first GUI golden suite: PASS — all
- post-review window-scoped GUI round trip: PASS
- `git diff --check` and shell syntax check passed
- final `codex review --base origin/main`: no actionable correctness defects
- GitHub CI / PR validation: all required checks passed

GUI artifacts on the Mini:
- `/Volumes/mac-storage/gui-golden-rebase-full-20260808T0640Z`
- `/Volumes/mac-storage/gui-golden-window-scoped-20260808T0642Z`