### PR TITLE
Fix isolated Codex launch command

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/UI/ConnectToolsView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ConnectToolsView.swift
@@ -241,26 +241,63 @@ struct ConnectToolsView: View {
                 name: "Claude Code",
                 symbol: "terminal",
                 blurb: "Launch with this connection for one session. Your shell environment stays unchanged.",
-                snippet: "env ANTHROPIC_BASE_URL=\(anthropicBaseURL) ANTHROPIC_API_KEY=\(snippetKey) ANTHROPIC_MODEL=\(snippetModel) claude",
-                displaySnippet: "env ANTHROPIC_BASE_URL=\(anthropicBaseURL) ANTHROPIC_API_KEY=\(snippetKeyMasked) ANTHROPIC_MODEL=\(snippetModel) claude"
+                snippet: AgentLaunchCommand.claude(
+                    baseURL: anthropicBaseURL, key: snippetKey, model: snippetModel
+                ),
+                displaySnippet: AgentLaunchCommand.claude(
+                    baseURL: anthropicBaseURL, key: snippetKeyMasked, model: snippetModel
+                )
             ),
             ConnectTool(
                 id: "codex",
                 name: "Codex",
                 symbol: "chevron.left.forwardslash.chevron.right",
                 blurb: "Launch with an isolated Rapid provider for one session. Your existing Codex provider and shell environment stay unchanged.",
-                snippet: "env OPENAI_API_KEY=\(snippetKey) codex --ignore-user-config -m \(snippetModel) -c 'model_provider=\"rapid-mlx\"' -c 'model_providers.rapid-mlx={name=\"Rapid-MLX\",base_url=\"\(openAIBaseURL)\",env_key=\"OPENAI_API_KEY\",wire_api=\"responses\"}'",
-                displaySnippet: "env OPENAI_API_KEY=\(snippetKeyMasked) codex --ignore-user-config -m \(snippetModel) -c 'model_provider=\"rapid-mlx\"' -c 'model_providers.rapid-mlx={name=\"Rapid-MLX\",base_url=\"\(openAIBaseURL)\",env_key=\"OPENAI_API_KEY\",wire_api=\"responses\"}'"
+                snippet: AgentLaunchCommand.codex(
+                    baseURL: openAIBaseURL, key: snippetKey, model: snippetModel
+                ),
+                displaySnippet: AgentLaunchCommand.codex(
+                    baseURL: openAIBaseURL, key: snippetKeyMasked, model: snippetModel
+                )
             ),
             ConnectTool(
                 id: "hermes",
                 name: "Hermes",
                 symbol: "bolt.horizontal.circle",
                 blurb: "Launch with this connection and model for one session. Your shell environment stays unchanged.",
-                snippet: "env OPENAI_BASE_URL=\(openAIBaseURL) OPENAI_API_KEY=\(snippetKey) HERMES_INFERENCE_MODEL=\(snippetModel) hermes --provider openai-api --ignore-user-config",
-                displaySnippet: "env OPENAI_BASE_URL=\(openAIBaseURL) OPENAI_API_KEY=\(snippetKeyMasked) HERMES_INFERENCE_MODEL=\(snippetModel) hermes --provider openai-api --ignore-user-config"
+                snippet: AgentLaunchCommand.hermes(
+                    baseURL: openAIBaseURL, key: snippetKey, model: snippetModel
+                ),
+                displaySnippet: AgentLaunchCommand.hermes(
+                    baseURL: openAIBaseURL, key: snippetKeyMasked, model: snippetModel
+                )
             ),
         ]
+    }
+}
+
+/// Process-scoped launch commands shown by the Connect agents surface.
+///
+/// These deliberately use inline `env` assignments rather than `export`, so
+/// copying a command cannot alter the user's shell after the agent exits.
+/// Codex additionally receives a throwaway home because its interactive CLI
+/// has no top-level `--ignore-user-config` flag (that flag belongs only to the
+/// non-interactive `exec` subcommand in Codex 0.146). The temporary home keeps
+/// the Rapid provider isolated without rewriting `~/.codex/config.toml`.
+enum AgentLaunchCommand {
+    static func claude(baseURL: String, key: String, model: String) -> String {
+        "env ANTHROPIC_BASE_URL=\(baseURL) ANTHROPIC_API_KEY=\(key) ANTHROPIC_MODEL=\(model) claude"
+    }
+
+    static func codex(baseURL: String, key: String, model: String) -> String {
+        "env CODEX_HOME=\"$(mktemp -d)\" OPENAI_API_KEY=\(key) codex -m \(model) "
+            + "-c 'model_provider=\"rapid-mlx\"' "
+            + "-c 'model_providers.rapid-mlx={name=\"Rapid-MLX\",base_url=\"\(baseURL)\",env_key=\"OPENAI_API_KEY\",wire_api=\"responses\"}'"
+    }
+
+    static func hermes(baseURL: String, key: String, model: String) -> String {
+        "env OPENAI_BASE_URL=\(baseURL) OPENAI_API_KEY=\(key) HERMES_INFERENCE_MODEL=\(model) "
+            + "hermes --provider openai-api --ignore-user-config"
     }
 }
 

--- a/apps/rapid-mac/Tests/RapidTests/AgentLaunchCommandTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/AgentLaunchCommandTests.swift
@@ -1,0 +1,49 @@
+import Testing
+@testable import Rapid
+
+@Suite("Connect agents — process-scoped launch commands")
+struct AgentLaunchCommandTests {
+    private let base = "http://127.0.0.1:8000/v1"
+    private let key = "local-key"
+    private let model = "qwen-test"
+
+    @Test("Every command is one process-scoped line, never an export")
+    func commandsDoNotMutateTheShellEnvironment() {
+        let commands = [
+            AgentLaunchCommand.claude(baseURL: base, key: key, model: model),
+            AgentLaunchCommand.codex(baseURL: base, key: key, model: model),
+            AgentLaunchCommand.hermes(baseURL: base, key: key, model: model),
+        ]
+
+        for command in commands {
+            #expect(command.hasPrefix("env "))
+            #expect(!command.contains("export "))
+            #expect(!command.contains("\n"))
+            #expect(command.contains(key))
+            #expect(command.contains(model))
+        }
+    }
+
+    @Test("Interactive Codex uses an isolated temporary home")
+    func codexInteractiveCommandUsesSupportedIsolation() {
+        let command = AgentLaunchCommand.codex(baseURL: base, key: key, model: model)
+
+        #expect(command.contains(#"CODEX_HOME="$(mktemp -d)""#))
+        #expect(command.contains(" codex -m qwen-test "))
+        #expect(!command.contains("codex --ignore-user-config"))
+        #expect(command.contains(#"wire_api="responses""#))
+    }
+
+    @Test("Claude and Hermes retain their native provider variables")
+    func providerSpecificVariablesRemainComplete() {
+        let claude = AgentLaunchCommand.claude(baseURL: base, key: key, model: model)
+        #expect(claude.contains("ANTHROPIC_BASE_URL=\(base)"))
+        #expect(claude.contains("ANTHROPIC_API_KEY=\(key)"))
+        #expect(claude.hasSuffix("ANTHROPIC_MODEL=\(model) claude"))
+
+        let hermes = AgentLaunchCommand.hermes(baseURL: base, key: key, model: model)
+        #expect(hermes.contains("OPENAI_BASE_URL=\(base)"))
+        #expect(hermes.contains("HERMES_INFERENCE_MODEL=\(model)"))
+        #expect(hermes.hasSuffix("hermes --provider openai-api --ignore-user-config"))
+    }
+}


### PR DESCRIPTION
## What changed

- replace the unsupported interactive `codex --ignore-user-config` command with a one-session temporary `CODEX_HOME`
- centralize Claude Code, Codex, and Hermes launch command construction
- add regression tests ensuring all commands remain one-line, process-scoped, and provider-complete

## Why

The copied Codex command failed because Codex 0.146 exposes `--ignore-user-config` on the noninteractive `exec` subcommand, not on the interactive top-level command.

## User impact

The copied Codex command now launches against Rapid-MLX without changing shell environment variables or the user’s existing `~/.codex` configuration.

## Validation

- Mini: live Claude Code, Codex, and Hermes connection dogfood against the latest Rapid-MLX server
- Mini: release app build and Connect agents GUI snapshot
- `swift test --package-path apps/rapid-mac` — 1773 passed
- `git diff --check`