### PR TITLE
fix(mac): a golden flow may only claim absence from a walk it can vouch for

### DIFF
--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-depth.five-turns.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-depth.five-turns.txt
@@ -1,0 +1,91 @@
+# rapid-mac AX structural baseline v1
+AXApplication title="Rapid-MLX"
+  AXWindow subrole=AXStandardWindow id="main" title="Rapid-MLX"
+    AXGroup subrole=AXHostingView
+      AXSplitGroup id="main, SidebarNavigationSplitView"
+        AXGroup subrole=AXHostingView
+          AXButton id="Sidebar.NewChat" desc="New Chat" enabled=true
+          AXButton id="Sidebar.Launch" desc="Launch" enabled=true
+          AXScrollArea
+            AXHeading desc="<relative-day>" enabled=true
+            AXButton id="Sidebar.Conversation.Pin.<uuid>" desc="Pin conversation" help="Pin conversation" enabled=true
+            AXPopUpButton id="Sidebar.Conversation.Menu.<uuid>" desc="Conversation actions" enabled=true
+            AXButton id="Sidebar.Conversation.<uuid>" desc="shape:prose write the opening of a story a…" enabled=true
+        AXSplitter value=number enabled=false
+        AXGroup subrole=AXHostingView
+          AXScrollArea
+            AXOpaqueProviderGroup subrole=AXOpaqueProviderList enabled=true
+              AXStaticText value=text enabled=true
+              AXButton id="ChatView.Message.Copy.<uuid>" desc="Copy message" help="Copy message" enabled=true
+              AXButton id="ChatView.Message.Edit.<uuid>" desc="Edit message" help="Edit message" enabled=true
+              AXDisclosureTriangle desc="Reasoning" value=bool:false enabled=true
+              AXStaticText value=text enabled=true
+              AXStaticText value=text enabled=true
+              AXButton id="ChatView.Message.Copy.<uuid>" desc="Copy response" help="Copy response" enabled=true
+              AXButton id="ChatView.Message.Retry.<uuid>" desc="Retry response" enabled=true
+              AXStaticText value=text enabled=true
+              AXButton id="ChatView.Message.Copy.<uuid>" desc="Copy message" help="Copy message" enabled=true
+              AXButton id="ChatView.Message.Edit.<uuid>" desc="Edit message" help="Edit message" enabled=true
+              AXDisclosureTriangle desc="Reasoning" value=bool:false enabled=true
+              AXStaticText value=text enabled=true
+              AXScrollArea
+                AXStaticText value=text enabled=true
+              AXStaticText value=text enabled=true
+              AXStaticText value=text enabled=true
+              AXButton id="ChatView.Message.Copy.<uuid>" desc="Copy response" help="Copy response" enabled=true
+              AXButton id="ChatView.Message.Retry.<uuid>" desc="Retry response" enabled=true
+              AXStaticText value=text enabled=true
+              AXButton id="ChatView.Message.Copy.<uuid>" desc="Copy message" help="Copy message" enabled=true
+              AXButton id="ChatView.Message.Edit.<uuid>" desc="Edit message" help="Edit message" enabled=true
+              AXDisclosureTriangle desc="Reasoning" value=bool:false enabled=true
+              AXStaticText value=text enabled=true
+              AXStaticText value=text enabled=true
+              AXStaticText value=text enabled=true
+              AXStaticText value=text enabled=true
+              AXStaticText value=text enabled=true
+              AXStaticText value=text enabled=true
+              AXStaticText value=text enabled=true
+              AXStaticText value=text enabled=true
+              AXStaticText value=text enabled=true
+              AXStaticText value=text enabled=true
+              AXStaticText value=text enabled=true
+              AXButton id="ChatView.Message.Copy.<uuid>" desc="Copy response" help="Copy response" enabled=true
+              AXButton id="ChatView.Message.Retry.<uuid>" desc="Retry response" enabled=true
+              AXStaticText value=text enabled=true
+              AXButton id="ChatView.Message.Copy.<uuid>" desc="Copy message" help="Copy message" enabled=true
+              AXButton id="ChatView.Message.Edit.<uuid>" desc="Edit message" help="Edit message" enabled=true
+              AXDisclosureTriangle desc="Reasoning" value=bool:false enabled=true
+              AXStaticText value=text enabled=true
+              AXStaticText value=text enabled=true
+              AXStaticText value=text enabled=true
+              AXStaticText value=text enabled=true
+              AXStaticText value=text enabled=true
+              AXStaticText value=text enabled=true
+              AXStaticText value=text enabled=true
+              AXButton id="ChatView.Message.Copy.<uuid>" desc="Copy response" help="Copy response" enabled=true
+              AXButton id="ChatView.Message.Retry.<uuid>" desc="Retry response" enabled=true
+              AXStaticText value=text enabled=true
+              AXButton id="ChatView.Message.Copy.<uuid>" desc="Copy message" help="Copy message" enabled=true
+              AXButton id="ChatView.Message.Edit.<uuid>" desc="Edit message" help="Edit message" enabled=true
+              AXDisclosureTriangle desc="Reasoning" value=bool:false enabled=true
+              AXStaticText value=text enabled=true
+              AXStaticText value=text enabled=true
+              AXButton id="ChatView.Message.Copy.<uuid>" desc="Copy response" help="Copy response" enabled=true
+              AXButton id="ChatView.Message.Retry.<uuid>" desc="Retry response" enabled=true
+            AXScrollBar value=number enabled=true
+              AXValueIndicator value=number
+              AXButton subrole=AXIncrementArrow
+              AXButton subrole=AXDecrementArrow
+              AXButton subrole=AXIncrementPage
+              AXButton subrole=AXDecrementPage
+          AXStaticText value=text enabled=true
+          AXScrollArea
+            AXTextArea id="rapid.chat.compose" desc="Message compose field" value=empty
+          AXPopUpButton id="ModelPickerBar.ModelMenu" desc="Model" help="Choose which model to run" value=text enabled=true
+          AXButton id="ChatView.SendOrStopButton" desc="Send message" enabled=false
+    AXToolbar
+      AXButton desc="Hide Sidebar" enabled=true
+    AXButton subrole=AXCloseButton enabled=true
+    AXButton subrole=AXFullScreenButton help="this button also has an action to zoom the window" enabled=true
+    AXButton subrole=AXMinimizeButton enabled=true
+    AXStaticText value=text enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-depth.restored.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-depth.restored.txt
@@ -1,0 +1,91 @@
+# rapid-mac AX structural baseline v1
+AXApplication title="Rapid-MLX"
+  AXWindow subrole=AXStandardWindow id="main" title="Rapid-MLX"
+    AXGroup subrole=AXHostingView
+      AXSplitGroup id="main, SidebarNavigationSplitView"
+        AXGroup subrole=AXHostingView
+          AXButton id="Sidebar.NewChat" desc="New Chat" enabled=true
+          AXButton id="Sidebar.Launch" desc="Launch" enabled=true
+          AXScrollArea
+            AXHeading desc="<relative-day>" enabled=true
+            AXButton id="Sidebar.Conversation.Pin.<uuid>" desc="Pin conversation" help="Pin conversation" enabled=true
+            AXPopUpButton id="Sidebar.Conversation.Menu.<uuid>" desc="Conversation actions" enabled=true
+            AXButton id="Sidebar.Conversation.<uuid>" desc="shape:prose write the opening of a story a…" enabled=true
+        AXSplitter value=number enabled=false
+        AXGroup subrole=AXHostingView
+          AXScrollArea
+            AXOpaqueProviderGroup subrole=AXOpaqueProviderList enabled=true
+              AXStaticText value=text enabled=true
+              AXButton id="ChatView.Message.Copy.<uuid>" desc="Copy message" help="Copy message" enabled=true
+              AXButton id="ChatView.Message.Edit.<uuid>" desc="Edit message" help="Edit message" enabled=true
+              AXDisclosureTriangle desc="Reasoning" value=bool:false enabled=true
+              AXStaticText value=text enabled=true
+              AXStaticText value=text enabled=true
+              AXButton id="ChatView.Message.Copy.<uuid>" desc="Copy response" help="Copy response" enabled=true
+              AXButton id="ChatView.Message.Retry.<uuid>" desc="Retry response" enabled=true
+              AXStaticText value=text enabled=true
+              AXButton id="ChatView.Message.Copy.<uuid>" desc="Copy message" help="Copy message" enabled=true
+              AXButton id="ChatView.Message.Edit.<uuid>" desc="Edit message" help="Edit message" enabled=true
+              AXDisclosureTriangle desc="Reasoning" value=bool:false enabled=true
+              AXStaticText value=text enabled=true
+              AXScrollArea
+                AXStaticText value=text enabled=true
+              AXStaticText value=text enabled=true
+              AXStaticText value=text enabled=true
+              AXButton id="ChatView.Message.Copy.<uuid>" desc="Copy response" help="Copy response" enabled=true
+              AXButton id="ChatView.Message.Retry.<uuid>" desc="Retry response" enabled=true
+              AXStaticText value=text enabled=true
+              AXButton id="ChatView.Message.Copy.<uuid>" desc="Copy message" help="Copy message" enabled=true
+              AXButton id="ChatView.Message.Edit.<uuid>" desc="Edit message" help="Edit message" enabled=true
+              AXDisclosureTriangle desc="Reasoning" value=bool:false enabled=true
+              AXStaticText value=text enabled=true
+              AXStaticText value=text enabled=true
+              AXStaticText value=text enabled=true
+              AXStaticText value=text enabled=true
+              AXStaticText value=text enabled=true
+              AXStaticText value=text enabled=true
+              AXStaticText value=text enabled=true
+              AXStaticText value=text enabled=true
+              AXStaticText value=text enabled=true
+              AXStaticText value=text enabled=true
+              AXStaticText value=text enabled=true
+              AXButton id="ChatView.Message.Copy.<uuid>" desc="Copy response" help="Copy response" enabled=true
+              AXButton id="ChatView.Message.Retry.<uuid>" desc="Retry response" enabled=true
+              AXStaticText value=text enabled=true
+              AXButton id="ChatView.Message.Copy.<uuid>" desc="Copy message" help="Copy message" enabled=true
+              AXButton id="ChatView.Message.Edit.<uuid>" desc="Edit message" help="Edit message" enabled=true
+              AXDisclosureTriangle desc="Reasoning" value=bool:false enabled=true
+              AXStaticText value=text enabled=true
+              AXStaticText value=text enabled=true
+              AXStaticText value=text enabled=true
+              AXStaticText value=text enabled=true
+              AXStaticText value=text enabled=true
+              AXStaticText value=text enabled=true
+              AXStaticText value=text enabled=true
+              AXButton id="ChatView.Message.Copy.<uuid>" desc="Copy response" help="Copy response" enabled=true
+              AXButton id="ChatView.Message.Retry.<uuid>" desc="Retry response" enabled=true
+              AXStaticText value=text enabled=true
+              AXButton id="ChatView.Message.Copy.<uuid>" desc="Copy message" help="Copy message" enabled=true
+              AXButton id="ChatView.Message.Edit.<uuid>" desc="Edit message" help="Edit message" enabled=true
+              AXDisclosureTriangle desc="Reasoning" value=bool:false enabled=true
+              AXStaticText value=text enabled=true
+              AXStaticText value=text enabled=true
+              AXButton id="ChatView.Message.Copy.<uuid>" desc="Copy response" help="Copy response" enabled=true
+              AXButton id="ChatView.Message.Retry.<uuid>" desc="Retry response" enabled=true
+            AXScrollBar value=number enabled=true
+              AXValueIndicator value=number
+              AXButton subrole=AXIncrementArrow
+              AXButton subrole=AXDecrementArrow
+              AXButton subrole=AXIncrementPage
+              AXButton subrole=AXDecrementPage
+          AXStaticText value=text enabled=true
+          AXScrollArea
+            AXTextArea id="rapid.chat.compose" desc="Message compose field" value=empty
+          AXPopUpButton id="ModelPickerBar.ModelMenu" desc="Model" help="Choose which model to run" value=text enabled=true
+          AXButton id="ChatView.SendOrStopButton" desc="Send message" enabled=false
+    AXToolbar
+      AXButton desc="Hide Sidebar" enabled=true
+    AXButton subrole=AXCloseButton enabled=true
+    AXButton subrole=AXFullScreenButton help="this button also has an action to zoom the window" enabled=true
+    AXButton subrole=AXMinimizeButton enabled=true
+    AXStaticText value=text enabled=true

--- a/apps/rapid-mac/scripts/ax-baseline.py
+++ b/apps/rapid-mac/scripts/ax-baseline.py
@@ -308,7 +308,22 @@ def render(root: Node, extra_tokens: tuple[str, ...]) -> list[str]:
 
 def normalize_dump(path: Path, extra_tokens: tuple[str, ...]) -> list[str]:
     payload = json.loads(path.read_text(encoding="utf-8"))
-    records = payload.get("data", {}).get("ui_elements", [])
+    data = payload.get("data", {})
+    # A structural baseline is a claim about the whole tree, including that
+    # nothing is there that the committed snapshot does not list — the same
+    # claim `assert_ax_absent` makes, at a larger scale. A dump the driver
+    # cannot vouch for cannot support it: comparison would pass on a clipped
+    # tree whose recorded prefix happens to match, and `--update` would commit
+    # the clipped tree as the new truth.
+    walk = data.get("walk")
+    if not isinstance(walk, dict) or walk.get("complete") is not True:
+        reasons = "; ".join(walk.get("reasons", [])) if isinstance(walk, dict) else ""
+        raise SystemExit(
+            f"ax-baseline: {path} is not a complete observation"
+            + (f" ({reasons})" if reasons else " (no walk.complete signal)")
+            + " — a baseline taken from it would claim absence it did not see"
+        )
+    records = data.get("ui_elements", [])
     if not records:
         raise SystemExit(f"ax-baseline: no ui_elements in {path}")
     root = build_tree(records)

--- a/apps/rapid-mac/scripts/fake-rapid-mlx.sh
+++ b/apps/rapid-mac/scripts/fake-rapid-mlx.sh
@@ -82,6 +82,95 @@ CONTENT_CHUNKS = [
     " I", " return", " deterministic", " content", " so", " the",
     " smoke", " test", " has", " something", " to", " assert", " on.",
 ]
+
+# Answer SHAPES, chosen by a marker in the user's message.
+#
+# The fake has no model, so it cannot vary answer QUALITY — a golden flow
+# asserting that a poem is good would be theatre. What it can vary, and what
+# the app genuinely does different work for, is the shape of what has to be
+# rendered: a fenced code block gets highlighting and its own copy button, a
+# table has to become a table rather than pipes, LaTeX has to typeset, CJK and
+# emoji have to measure correctly, and a long answer has to scroll without
+# losing the turns above it. Judging what a model actually SAYS to a literary
+# or coding prompt belongs to the eval suites, against a real model.
+#
+# Chunked deliberately mid-token in places: a renderer that only works when a
+# fence or a table row arrives whole is a renderer that breaks on a real
+# stream.
+RESPONSE_SHAPES = {
+    "shape:code": [
+        "Here is the function you asked for:\n\n",
+        "```", "python", "\n",
+        "def fib(n):\n", "    a, b = 0, 1\n",
+        "    for _ in range(n):\n", "        a, b = b, a + b\n",
+        "    return a\n",
+        "```", "\n\n",
+        "It runs in O(n) time and constant space.",
+    ],
+    "shape:table": [
+        "| model | size | speed |\n",
+        "| --- | --- | ---", " |\n",
+        "| qwen3.5-9b | 5.2 GB | 74 tok/s |\n",
+        "| llama-3.1-8b | 4.5 GB | 68 tok/s |\n",
+        "\nBoth fit comfortably in 16 GB.",
+    ],
+    "shape:math": [
+        "The Gaussian integral is\n\n",
+        "$$\\int_{-\\infty}^{\\infty} e^{-x^2}\\,dx = \\sqrt{\\pi}$$",
+        "\n\nand inline it reads $e^{i\\pi} + 1 = 0$.",
+    ],
+    "shape:list": [
+        "Three things, in order:\n\n",
+        "1. First, ", "read the prompt.\n",
+        "2. Second, ", "plan the answer.\n",
+        "   - a nested point\n", "   - another one\n",
+        "3. Third, ", "write it down.\n",
+    ],
+    "shape:unicode": [
+        "中文排版测试:", "这是一段中文回答,", "用来检查换行和字宽。",
+        " Emoji: ", "🎯", "🚀", "。",
+        " Right-to-left: ", "مرحبا", ".",
+    ],
+    "shape:prose": [
+        "The lighthouse keeper ", "kept two logbooks. ",
+        "One recorded the weather, ", "the ships, ", "the hours of the lamp. ",
+        "The other recorded ", "what he thought about ", "while he watched. ",
+        "Only the first was ever read ", "by anyone else.",
+    ],
+}
+
+# Long output is the same default text repeated, so the scroll/perf case does
+# not need its own vocabulary to assert on.
+RESPONSE_SHAPES["shape:long"] = CONTENT_CHUNKS * 30
+
+
+def _shape_for(body):
+    """The chunk list this request should stream.
+
+    Reads the LAST user message, so a multi-turn conversation gets a different
+    shape per turn rather than whatever the first turn asked for.
+    """
+    messages = body.get("messages")
+    if not isinstance(messages, list):
+        return CONTENT_CHUNKS * CONTENT_REPEAT
+    text = ""
+    for message in reversed(messages):
+        if isinstance(message, dict) and message.get("role") == "user":
+            content = message.get("content")
+            if isinstance(content, str):
+                text = content
+            elif isinstance(content, list):
+                # OpenAI content-parts form.
+                text = " ".join(
+                    part.get("text", "")
+                    for part in content
+                    if isinstance(part, dict)
+                )
+            break
+    for marker, chunks in RESPONSE_SHAPES.items():
+        if marker in text:
+            return chunks
+    return CONTENT_CHUNKS * CONTENT_REPEAT
 REASONING_CHUNKS = [
     "Let", " me", " think", " about", " the", " prompt", "."
 ]
@@ -213,7 +302,7 @@ class Handler(BaseHTTPRequestHandler):
                 self.wfile.write(_sse(_delta(reasoning=r)))
                 self.wfile.flush()
                 time.sleep(INTER_TOKEN_SLEEP_S)
-            for c in CONTENT_CHUNKS * CONTENT_REPEAT:
+            for c in _shape_for(body):
                 self.wfile.write(_sse(_delta(content=c)))
                 self.wfile.flush()
                 content_emitted += 1

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -253,6 +253,78 @@ ax_window_present() {
     esac
 }
 
+# Does the element dump contain anything matching `filter`?
+#
+# Same three outcomes as ax_window_present, for the same reason: 0 = matched,
+# 1 = the dump is a complete observation and holds no match, 2 = could not
+# observe. A caller looking for something PRESENT can ignore the distinction —
+# a match proves itself. A caller proving something ABSENT cannot: the walk has
+# three silent ways to fall short of a full inventory (an AXChildren read that
+# failed, the depth cap, the record cap), and every one of them leaves
+# `success: true` with the subtree missing. `data.walk.complete` is the driver
+# saying whether it can vouch for `ui_elements` at all.
+ax_elements_match() {
+    local dump="$1" filter="$2" status
+    # `ui_elements` must be an array as well as vouched-for: `[]?` inside the
+    # filters below swallows a structural failure, so without this a malformed
+    # dump would read as a confident "absent".
+    jq -e '.success == true and .data.walk.complete == true
+           and (.data.ui_elements | type) == "array"' "$dump" >/dev/null 2>&1 || return 2
+    status=0
+    jq -e "$filter" "$dump" >/dev/null 2>&1 || status=$?
+    # jq exits 1 only for a well-formed query whose answer was false or empty;
+    # anything else (2 usage, 3 compile, 5 runtime error) is a broken query, not
+    # an answer, and must not be reported as "absent".
+    case "$status" in
+        0) return 0 ;;
+        1) return 1 ;;
+        *) return 2 ;;
+    esac
+}
+
+# Prove that nothing in the app's accessibility tree matches `filter`, and
+# refuse to conclude anything from a dump that cannot support the claim.
+#
+# `[…] | length == 0` on its own is satisfied by never having looked, which is
+# how the guard against #1603 — eight video-generation aliases reaching the
+# picker and dead-ending after a 64 GB download — could go green without
+# observing the catalogue at all. An incomplete dump is usually a lost race, so
+# re-dump a few times before giving up; then fail loudly rather than issue a
+# clean bill of health that was not earned.
+assert_ax_absent() {
+    local dump="$1" filter="$2" present_message="$3" status=0 i
+    for ((i=0; i<20; i++)); do
+        if (( i > 0 )); then
+            sleep 0.25
+            # Stage the retry: a driver that cannot run must not truncate the
+            # evidence the caller already captured, which is also the only place
+            # the reason for giving up is written down.
+            if "$AX_DRIVER" dump "$APP_PID" > "$dump.retry" 2>/dev/null; then
+                mv "$dump.retry" "$dump"
+            fi
+            rm -f "$dump.retry"
+        fi
+        status=0
+        ax_elements_match "$dump" "$filter" || status=$?
+        if [[ "$status" != 2 ]]; then break; fi
+    done
+    case "$status" in
+        1) return 0 ;;
+        0) die "$present_message" ;;
+        *) die "no complete AX dump in 5s ($dump: $(walk_reasons "$dump")) — cannot rule out: $present_message" ;;
+    esac
+}
+
+# Why a dump cannot be trusted as an inventory, in the driver's own words —
+# never empty, because "it failed and I will not say why" is how a flake becomes
+# unfixable.
+walk_reasons() {
+    local reasons
+    reasons="$(jq -r '(.data.walk.reasons // []) | join("; ")' "$1" 2>/dev/null || true)"
+    [[ -n "$reasons" ]] || reasons="the dump could not be read at all"
+    printf '%s' "$reasons"
+}
+
 element_field() {
     local tree="$1" identifier="$2" field="$3"
     jq -r --arg id "$identifier" --arg field "$field" \
@@ -960,9 +1032,9 @@ flow_browse_all_destination() {
     fi
 
     wait_identifier Quickstart.BrowseAll "$OUT/ba-after.json"
-    jq -e '[.data.ui_elements[]? | select(.identifier == "Settings.BackToQuickstart")] | length == 0' \
-        "$OUT/ba-after.json" >/dev/null \
-        || die "Settings remained interactive after returning to setup"
+    assert_ax_absent "$OUT/ba-after.json" \
+        '[.data.ui_elements[]? | select(.identifier == "Settings.BackToQuickstart")] | length > 0' \
+        "Settings remained interactive after returning to setup"
     pb image --mode screen --screen-index 0 --path "$OUT/ba-after.png" --json \
         > "$OUT/ba-after-image.json"
     jq -e --arg id "$chosen" '.data.ui_elements[]? | select(.identifier == $id) | select(.selected == true)' \
@@ -980,22 +1052,26 @@ flow_catalog_integrity() {
     # again" forever, reachable AFTER downloading up to 64 GB (#1603). The
     # fake sidecar emits a `[video:gen]`-tagged row so this proves the FILTER,
     # not today's registry contents.
+    # Any surface at all: the alias could show up as a row identifier, a picker
+    # label, a menu title or an accessibility description, and all four are the
+    # bug.
+    local VIDEO_ALIAS_FILTER='[.data.ui_elements[]?
+        | select([(.identifier // ""), (.value // ""), (.title // ""), (.description // "")]
+                 | map(tostring) | join(" ") | test("fake-video-alias"))] | length > 0'
     start_persona catalog-integrity
     dismiss_first_run
     see_main "$OUT/catalog-main.json"
 
-    jq -e '[.data.ui_elements[]? | select([(.identifier // ""), (.value // ""), (.title // ""), (.description // "")] | map(tostring) | join(" ") | test("fake-video-alias"))] | length == 0' \
-        "$OUT/catalog-main.json" >/dev/null \
-        || die "a video-gen alias reached the chat surface"
+    assert_ax_absent "$OUT/catalog-main.json" "$VIDEO_ALIAS_FILTER" \
+        "a video-gen alias reached the chat surface"
 
     open_settings
     see_main "$OUT/catalog-settings.json"
     press "$OUT/catalog-settings.json" Settings.Category.modelManagement \
         "$OUT/catalog-open-mm.json"
     see_main "$OUT/catalog-model-management.json"
-    jq -e '[.data.ui_elements[]? | select([(.identifier // ""), (.value // ""), (.title // ""), (.description // "")] | map(tostring) | join(" ") | test("fake-video-alias"))] | length == 0' \
-        "$OUT/catalog-model-management.json" >/dev/null \
-        || die "a video-gen alias reached Model Management"
+    assert_ax_absent "$OUT/catalog-model-management.json" "$VIDEO_ALIAS_FILTER" \
+        "a video-gen alias reached Model Management"
     log "  no video-gen alias on either catalog surface"
     cleanup_persona
 }

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -30,7 +30,8 @@ usage() {
     cat <<'EOF'
 Usage: gui-golden-flows.sh [--flow NAME] [--keep] [--update-baselines]
 
-Flows: fresh-install, settings-persistence, chat-restore, slow-stream-stop,
+Flows: fresh-install, settings-persistence, chat-restore, chat-depth,
+       slow-stream-stop,
        model-crash-recovery, low-memory-choice, loaded-model-benchmark,
        update-state, no-dead-controls, catalog-integrity,
        browse-all-destination, all
@@ -365,6 +366,102 @@ walk_reasons() {
     reasons="$(jq -r '(.data.walk.reasons // []) | join("; ")' "$1" 2>/dev/null || true)"
     [[ -n "$reasons" ]] || reasons="the dump could not be read at all"
     printf '%s' "$reasons"
+}
+
+# Markdown reached the renderer as markdown, not as source text.
+#
+# The cheapest regression here is the loudest one for a user: the renderer
+# falls back to plain text and the answer arrives full of ``` fences and | pipe
+# rows. Every "does the text appear" assertion in this file passes on that,
+# because the text does appear — wearing its syntax.
+assert_markdown_rendered() {
+    local tree="$1"
+    jq -e '[.data.ui_elements[]? | ((.value // "") | tostring)
+            | select(contains("```"))] | length == 0' "$tree" >/dev/null \
+        || die "a code fence reached the screen verbatim — markdown was printed, not rendered"
+    jq -e '[.data.ui_elements[]? | ((.value // "") | tostring)
+            | select(test("\\| *-{2,} *\\|"))] | length == 0' "$tree" >/dev/null \
+        || die "a table separator row reached the screen verbatim — the table was not rendered"
+}
+
+# A fenced block is its own view, not a paragraph that happens to contain code.
+#
+# Measured: the surrounding prose sits at one depth and the code block one
+# level deeper, with its newlines and indentation intact. If a refactor
+# flattens that, the code still "appears" — as a wrapped, unindented,
+# uncopyable smear.
+assert_code_block_is_its_own_view() {
+    local tree="$1" prose="$2" code="$3"
+    python3 - "$tree" "$prose" "$code" <<'PYEOF'
+import json, sys
+tree, prose, code = sys.argv[1], sys.argv[2], sys.argv[3]
+elements = json.load(open(tree))["data"]["ui_elements"]
+def find(needle):
+    return next((e for e in elements if needle in str(e.get("value", ""))), None)
+prose_el, code_el = find(prose), find(code)
+if prose_el is None:
+    sys.exit(f"prose not found: {prose}")
+if code_el is None:
+    sys.exit(f"code not found: {code}")
+if code_el["depth"] <= prose_el["depth"]:
+    sys.exit(
+        f"code block is not nested below its paragraph "
+        f"(code depth {code_el['depth']} <= prose depth {prose_el['depth']})"
+    )
+if "\n" not in str(code_el.get("value", "")):
+    sys.exit("code block lost its line breaks")
+PYEOF
+}
+
+# How many messages of each side the transcript is showing.
+#
+# User turns carry an Edit button, assistant turns carry a Retry button — the
+# app's own distinction, not one this harness invents. Counting them is how a
+# multi-turn flow proves nothing was dropped, merged or duplicated; asserting
+# only that the LAST answer is on screen cannot tell a five-turn conversation
+# from a one-turn one.
+transcript_counts() {
+    local tree="$1"
+    jq -r '[.data.ui_elements[]? | (.identifier // "")]
+           | { user:  [ .[] | select(startswith("ChatView.Message.Edit."))  ] | length,
+               model: [ .[] | select(startswith("ChatView.Message.Retry.")) ] | length }
+           | "\(.user) \(.model)"' "$tree"
+}
+
+assert_transcript_turns() {
+    local tree="$1" expected="$2" counts user model
+    counts="$(transcript_counts "$tree")"
+    user="${counts% *}"
+    model="${counts#* }"
+    [[ "$user" == "$expected" && "$model" == "$expected" ]] \
+        || die "expected $expected user + $expected model message(s), tree shows ${user} + ${model}"
+}
+
+# Do these strings appear in the transcript IN THIS ORDER?
+#
+# A conversation that shows every turn but in the wrong order is still broken,
+# and every "does the text appear" assertion in this file would pass on it.
+# `ui_elements` is emitted in tree order, so position in that array is reading
+# order.
+assert_text_order() {
+    local tree="$1"
+    shift
+    local needles=("$@")
+    python3 - "$tree" "${needles[@]}" <<'PYEOF'
+import json, sys
+tree, needles = sys.argv[1], sys.argv[2:]
+elements = json.load(open(tree))["data"]["ui_elements"]
+haystack = [str(e.get("value", "")) + " " + str(e.get("title", "")) for e in elements]
+positions = []
+for needle in needles:
+    hit = next((i for i, text in enumerate(haystack) if needle in text), None)
+    if hit is None:
+        sys.exit(f"transcript never shows: {needle}")
+    positions.append(hit)
+if positions != sorted(positions):
+    order = ", ".join(f"{n}@{p}" for n, p in zip(needles, positions))
+    sys.exit(f"transcript is out of order: {order}")
+PYEOF
 }
 
 element_field() {
@@ -1086,6 +1183,86 @@ flow_browse_all_destination() {
     cleanup_persona
 }
 
+flow_chat_depth() {
+    # One message is not a conversation.
+    #
+    # `chat-restore` sends a single prompt and checks it comes back after a
+    # relaunch — that covers persistence and almost nothing about chatting. It
+    # cannot see a second turn landing above the first, a turn being dropped
+    # when the next one starts, or a restore that brings back only the last
+    # exchange. And every answer it has ever rendered was the same paragraph of
+    # plain text, so the code block, the table, the list and the CJK line have
+    # never once been through the renderer in this suite.
+    #
+    # Each turn here asks the fake for a different SHAPE of answer. The fake has
+    # no model, so this is not about whether an answer is any good — judging
+    # that belongs to the eval suites against a real model. It is about the work
+    # the APP does differently per shape, which is exactly what a GUI gate can
+    # hold.
+    start_persona chat-depth
+    dismiss_first_run
+    start_model
+
+    # marker | what the user would be asking | a distinctive string the answer must contain
+    local -a turns=(
+        "shape:prose|write the opening of a story about a lighthouse|lighthouse keeper"
+        "shape:code|show me fibonacci in python|def fib(n)"
+        "shape:table|compare those two models for me|qwen3.5-9b"
+        "shape:list|give me three steps|nested point"
+        "shape:unicode|用中文回答并带上 emoji|中文排版测试"
+    )
+
+    local -a prompts=()
+    local index=0 spec marker prompt expect
+    for spec in "${turns[@]}"; do
+        index=$((index + 1))
+        marker="${spec%%|*}"
+        prompt="${spec#*|}"; prompt="${prompt%%|*}"
+        expect="${spec##*|}"
+        # The marker travels in the prompt so the fake can pick the shape, and
+        # it doubles as the per-turn needle for the ordering assertion below.
+        prompts+=("$marker")
+        send_prompt "$marker $prompt" "turn$index"
+        wait_send_idle "$OUT/turn$index-settled.json"
+        assert_tree_text "$OUT/turn$index-settled.json" "$expect"
+        # After turn N there must be exactly N of each, every time — not just
+        # at the end, so a turn that vanishes is attributed to the turn that
+        # dropped it.
+        assert_transcript_turns "$OUT/turn$index-settled.json" "$index"
+        log "  turn $index ($marker) rendered and both sides counted"
+    done
+
+    assert_text_order "$OUT/turn5-settled.json" "${prompts[@]}"
+    log "  all 5 turns present, in the order they were sent"
+
+    # The shapes are only worth sending if something asserts on what the
+    # renderer did with them.
+    assert_markdown_rendered "$OUT/turn5-settled.json"
+    assert_code_block_is_its_own_view "$OUT/turn5-settled.json" \
+        "Here is the function you asked for" "def fib(n)"
+    log "  markdown rendered: no raw fences or pipe rows, code block nested and intact"
+    baseline chat-depth.five-turns "$OUT/turn5-settled.json"
+
+    # Restore has to bring back the WHOLE conversation. `chat-restore` only
+    # ever proved that one message survived, which a store that keeps the last
+    # exchange would also pass.
+    relaunch_persona
+    dismiss_first_run
+    wait_identifier Sidebar.NewChat "$OUT/depth-restored.json"
+    local conversation_id
+    conversation_id="$(jq -r '.data.ui_elements[] | (.identifier // "")
+        | select(test("^Sidebar\\.Conversation\\.[0-9A-Fa-f-]{36}$"))' \
+        "$OUT/depth-restored.json" | head -1)"
+    [[ -n "$conversation_id" ]] || die "restored conversation row was not exposed to AX"
+    press "$OUT/depth-restored.json" "$conversation_id" "$OUT/depth-open-restored.json"
+    wait_send_idle "$OUT/depth-restored-transcript.json"
+    assert_transcript_turns "$OUT/depth-restored-transcript.json" 5
+    assert_text_order "$OUT/depth-restored-transcript.json" "${prompts[@]}"
+    log "  all 5 turns restored, still in order"
+    baseline chat-depth.restored "$OUT/depth-restored-transcript.json"
+    cleanup_persona
+}
+
 flow_catalog_integrity() {
     # A model that cannot chat must never be offered as one.
     #
@@ -1139,6 +1316,7 @@ case "$FLOW" in
     fresh-install) flow_fresh_install ;;
     settings-persistence) flow_settings_persistence ;;
     chat-restore) flow_chat_restore ;;
+    chat-depth) flow_chat_depth ;;
     slow-stream-stop) flow_slow_stream_stop ;;
     model-crash-recovery) flow_model_crash_recovery ;;
     low-memory-choice) flow_low_memory_choice ;;
@@ -1151,6 +1329,7 @@ case "$FLOW" in
         flow_fresh_install
         flow_settings_persistence
         flow_chat_restore
+        flow_chat_depth
         flow_slow_stream_stop
         flow_model_crash_recovery
         flow_low_memory_choice

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -265,14 +265,24 @@ ax_window_present() {
 # saying whether it can vouch for `ui_elements` at all.
 ax_elements_match() {
     local dump="$1" filter="$2" status
-    # `ui_elements` must be an array as well as vouched-for: `[]?` inside the
-    # filters below swallows a structural failure, so without this a malformed
-    # dump would read as a confident "absent".
+    # `ui_elements` must be a NON-EMPTY array as well as vouched-for. `[]?`
+    # inside the filters below swallows a structural failure, so without the
+    # type check a malformed dump would read as a confident "absent" — and a
+    # complete dump always holds at least the application record, so an empty
+    # array is not an empty app, it is a dump that is not one of ours.
     jq -e '.success == true and .data.walk.complete == true
-           and (.data.ui_elements | type) == "array"' "$dump" >/dev/null 2>&1 || return 2
+           and (.data.ui_elements | type) == "array"
+           and (.data.ui_elements | length) > 0' "$dump" >/dev/null 2>&1 || return 2
     status=0
-    jq -e "$filter" "$dump" >/dev/null 2>&1 || status=$?
-    # jq exits 1 only for a well-formed query whose answer was false or empty;
+    # Wrapped, not run bare: `jq -e` reports the LAST value a filter emits, so a
+    # streaming filter that yields `true, false` exits 1 and reads as "absent"
+    # having just matched. Require exactly one boolean and make anything else an
+    # error, which lands in the third outcome where it belongs.
+    jq -e "[ $filter ] | if length == 1 and (.[0] | type) == \"boolean\"
+                         then .[0]
+                         else error(\"filter must emit exactly one boolean\") end" \
+        "$dump" >/dev/null 2>&1 || status=$?
+    # jq exits 1 only for a well-formed query whose answer was false or null;
     # anything else (2 usage, 3 compile, 5 runtime error) is a broken query, not
     # an answer, and must not be reported as "absent".
     case "$status" in
@@ -280,6 +290,44 @@ ax_elements_match() {
         1) return 1 ;;
         *) return 2 ;;
     esac
+}
+
+# Refresh a dump in place without destroying it on failure.
+#
+# The file a caller passes in is both the evidence a human debugs from and the
+# only place the driver's reason for giving up is written down, so a driver that
+# cannot produce a usable dump must leave the previous one alone. Exit status is
+# not enough on its own — a driver that exits 0 having written nothing would
+# still clobber it.
+redump_evidence() {
+    local dump="$1"
+    if "$AX_DRIVER" dump "$APP_PID" > "$dump.retry" 2>/dev/null \
+       && jq -e 'type == "object"' "$dump.retry" >/dev/null 2>&1; then
+        mv "$dump.retry" "$dump"
+    fi
+    rm -f "$dump.retry"
+}
+
+# Wait until the tree positively contains a match, and die if it never does.
+#
+# A positive match proves itself and needs no completeness gate. What this is
+# for is the assertion that comes AFTER it: "no video-gen alias in the
+# catalogue" observed while the catalogue is still a spinner is not an
+# observation of the filter under test, it is an observation of a spinner, and
+# it passes. Proving the fixture's ordinary alias has arrived first is what
+# makes the absence claim about the catalogue at all.
+wait_ax_match() {
+    local dump="$1" filter="$2" what="$3" attempts="${4:-80}" status i
+    for ((i=0; i<attempts; i++)); do
+        if (( i > 0 )); then
+            sleep 0.25
+            redump_evidence "$dump"
+        fi
+        status=0
+        ax_elements_match "$dump" "$filter" || status=$?
+        if [[ "$status" == 0 ]]; then return 0; fi
+    done
+    die "timed out waiting for $what ($dump: $(walk_reasons "$dump"))"
 }
 
 # Prove that nothing in the app's accessibility tree matches `filter`, and
@@ -296,13 +344,7 @@ assert_ax_absent() {
     for ((i=0; i<20; i++)); do
         if (( i > 0 )); then
             sleep 0.25
-            # Stage the retry: a driver that cannot run must not truncate the
-            # evidence the caller already captured, which is also the only place
-            # the reason for giving up is written down.
-            if "$AX_DRIVER" dump "$APP_PID" > "$dump.retry" 2>/dev/null; then
-                mv "$dump.retry" "$dump"
-            fi
-            rm -f "$dump.retry"
+            redump_evidence "$dump"
         fi
         status=0
         ax_elements_match "$dump" "$filter" || status=$?
@@ -1058,10 +1100,19 @@ flow_catalog_integrity() {
     local VIDEO_ALIAS_FILTER='[.data.ui_elements[]?
         | select([(.identifier // ""), (.value // ""), (.title // ""), (.description // "")]
                  | map(tostring) | join(" ") | test("fake-video-alias"))] | length > 0'
+    # The same search for the fixture's ORDINARY alias. Asserting this first is
+    # what makes the assertion after it mean something: a surface still
+    # fetching its model list contains neither alias, and would pass the
+    # absence check without the filter under test having been exercised once.
+    local PLAIN_ALIAS_FILTER='[.data.ui_elements[]?
+        | select([(.identifier // ""), (.value // ""), (.title // ""), (.description // "")]
+                 | map(tostring) | join(" ") | test("fake-alias"))] | length > 0'
     start_persona catalog-integrity
     dismiss_first_run
     see_main "$OUT/catalog-main.json"
 
+    wait_ax_match "$OUT/catalog-main.json" "$PLAIN_ALIAS_FILTER" \
+        "the chat surface to offer the fixture's chat-capable alias — until it does, it is not offering anything and proves nothing about the filter"
     assert_ax_absent "$OUT/catalog-main.json" "$VIDEO_ALIAS_FILTER" \
         "a video-gen alias reached the chat surface"
 
@@ -1070,9 +1121,11 @@ flow_catalog_integrity() {
     press "$OUT/catalog-settings.json" Settings.Category.modelManagement \
         "$OUT/catalog-open-mm.json"
     see_main "$OUT/catalog-model-management.json"
+    wait_ax_match "$OUT/catalog-model-management.json" "$PLAIN_ALIAS_FILTER" \
+        "Model Management to finish listing models — an empty or still-loading list contains no alias of any kind"
     assert_ax_absent "$OUT/catalog-model-management.json" "$VIDEO_ALIAS_FILTER" \
         "a video-gen alias reached Model Management"
-    log "  no video-gen alias on either catalog surface"
+    log "  both catalog surfaces listed models, and neither offered a video-gen alias"
     cleanup_persona
 }
 

--- a/apps/rapid-mac/scripts/rapid-ax.swift
+++ b/apps/rapid-mac/scripts/rapid-ax.swift
@@ -54,6 +54,7 @@ var walkComplete = true
 var walkUnreadableChildren = 0
 var walkLastChildrenError: AXError?
 var walkUnreadableFields = 0
+var walkUnobservableElements = 0
 var walkLastFieldError: AXError?
 var walkHitDepthCap = false
 var walkHitRecordCap = false
@@ -163,16 +164,18 @@ func searchable(_ element: AXUIElement, _ name: CFString) -> SearchableRead {
     }
 }
 
-/// Read a searchable attribute, and stop vouching for the dump if the read
-/// failed. `nil` means "nothing to record" — never "the read failed".
-func searchableText(_ element: AXUIElement, _ name: CFString) -> String? {
+/// Read a searchable attribute, noting the label when the read FAILED (as
+/// opposed to the element simply not publishing one). `nil` means "nothing to
+/// record" in either case; the caller decides what a failure costs.
+func searchableText(
+    _ element: AXUIElement, _ name: CFString, _ label: String, failed: inout [String]
+) -> String? {
     switch searchable(element, name) {
     case .text(let text): return text
     case .absent, .number: return nil
     case .unreadable(let error):
-        walkUnreadableFields += 1
+        failed.append(label)
         walkLastFieldError = error
-        walkComplete = false
         return nil
     }
 }
@@ -200,7 +203,12 @@ func walk(_ element: AXUIElement, depth: Int) {
     }
     guard visit(element) else { return }
 
-    let identifier = searchableText(element, kAXIdentifierAttribute as CFString)
+    // Which of the SEARCHED attributes failed to read on this element, as
+    // opposed to simply not being published. Collected per element because the
+    // cost depends on what else the element carries.
+    var failedFields = [String]()
+    let identifier = searchableText(
+        element, kAXIdentifierAttribute as CFString, "identifier", failed: &failedFields)
     var record: [String: Any] = ["depth": depth]
     if let identifier { record["identifier"] = identifier }
     if let role = string(element, kAXRoleAttribute as CFString) { record["role"] = role }
@@ -222,10 +230,16 @@ func walk(_ element: AXUIElement, depth: Int) {
     if let selected = attribute(element, kAXSelectedAttribute as CFString) as? NSNumber {
         record["selected"] = selected.boolValue
     }
-    if let title = searchableText(element, kAXTitleAttribute as CFString), !title.isEmpty {
+    if let title = searchableText(
+        element, kAXTitleAttribute as CFString, "title", failed: &failedFields),
+        !title.isEmpty
+    {
         record["title"] = title
     }
-    if let description = searchableText(element, kAXDescriptionAttribute as CFString), !description.isEmpty {
+    if let description = searchableText(
+        element, kAXDescriptionAttribute as CFString, "description", failed: &failedFields),
+        !description.isEmpty
+    {
         record["description"] = description
     }
     // `help` is not one of the searched fields, so a failed read here costs
@@ -236,9 +250,26 @@ func walk(_ element: AXUIElement, depth: Int) {
     case .number(let number): record["value"] = number
     case .absent: break
     case .unreadable(let error):
-        walkUnreadableFields += 1
+        failedFields.append("value")
         walkLastFieldError = error
-        walkComplete = false
+    }
+
+    // A failed read costs the dump its completeness only when it leaves the
+    // element with NOTHING searchable — that is the element that could be
+    // hiding the string an assertion is looking for. One whose title would not
+    // read but whose identifier did is still found by every filter that tests
+    // identifiers, and condemning the whole dump for it makes the signal
+    // unsatisfiable: measured on this app, five of seventy-seven dumps carry
+    // one such read failure, in the same panels every run.
+    if !failedFields.isEmpty {
+        record["unreadable"] = failedFields
+        walkUnreadableFields += 1
+        let searchableTextPresent = ["identifier", "title", "description", "value"]
+            .contains { record[$0] != nil }
+        if !searchableTextPresent {
+            walkUnobservableElements += 1
+            walkComplete = false
+        }
     }
     if let origin = point(element, kAXPositionAttribute as CFString),
        let extent = size(element, kAXSizeAttribute as CFString) {
@@ -324,11 +355,12 @@ if walkUnreadableChildren > 0 {
     walkReasons.append(
         "AXChildren was unreadable on \(walkUnreadableChildren) element(s) (last AXError \(code))")
 }
-if walkUnreadableFields > 0 {
+if walkUnobservableElements > 0 {
     let code = walkLastFieldError.map { String($0.rawValue) } ?? "unknown"
     walkReasons.append(
-        "a searched attribute (identifier/value/title/description) was unreadable on "
-            + "\(walkUnreadableFields) element(s) (last AXError \(code))")
+        "\(walkUnobservableElements) element(s) carry no searchable text because every "
+            + "attribute that could have held it failed to read (last AXError \(code)) — "
+            + "each could be hiding anything")
 }
 if walkHitDepthCap { walkReasons.append("the depth cap of \(maxDepth) was reached") }
 if walkHitRecordCap { walkReasons.append("the record cap of \(recordCap) was reached") }
@@ -348,7 +380,12 @@ if command == "dump" {
             "walk": [
                 "complete": walkComplete,
                 "scope": "window-forest",
-                "reasons": walkReasons
+                "reasons": walkReasons,
+                // Informational: elements where a searched attribute would not
+                // read but something else identified them anyway. Not a gap —
+                // recorded so the artifact can say which, since `reasons` only
+                // ever explains why `complete` is false.
+                "elements_with_unreadable_fields": walkUnreadableFields
             ],
             // The authority for "is window X open?" — see the note above. Callers
             // must treat `complete: false` as "could not observe", never as an

--- a/apps/rapid-mac/scripts/rapid-ax.swift
+++ b/apps/rapid-mac/scripts/rapid-ax.swift
@@ -18,7 +18,11 @@ let command = CommandLine.arguments[1]
 let application = AXUIElementCreateApplication(pid)
 let maxDepth = 40
 let recordCap = 12_000
-var visited = Set<CFHashCode>()
+// Hash-bucketed, but membership is decided by CFEqual. A bare hash set treats
+// two distinct elements that happen to collide as the same object and drops the
+// second one's whole subtree — silently, and with `complete: true`, which is the
+// exact failure this dump is supposed to have stopped being able to report.
+var visited = [CFHashCode: [AXUIElement]]()
 var records = [[String: Any]]()
 var match: AXUIElement?
 // The same contract as `windows.complete`, for the element array. A caller that
@@ -28,9 +32,20 @@ var match: AXUIElement?
 // `success: true`, so `length == 0` is satisfied by never having looked. Say so
 // instead. `complete: false` is not an error; it means "this dump cannot answer
 // a question about absence".
+//
+// The scope is the app's WINDOW forest, deliberately: the walk starts from the
+// root's window children and never enters the global menu bar, which would drag
+// unrelated macOS Recent Items into every artifact. `complete` therefore means
+// "every window and descendant was observed", not "every AX element the process
+// owns" — a menu-bar item is out of scope, not missing. It also cannot be an
+// atomic snapshot: a window opened after its parent's AXChildren was read is
+// simply not in this dump. Callers proving absence must have settled the UI
+// first; completeness is a floor, not a substitute for waiting.
 var walkComplete = true
 var walkUnreadableChildren = 0
 var walkLastChildrenError: AXError?
+var walkUnreadableFields = 0
+var walkLastFieldError: AXError?
 var walkHitDepthCap = false
 var walkHitRecordCap = false
 var walkRootReasons = [String]()
@@ -107,6 +122,62 @@ func children(_ element: AXUIElement) -> ChildrenRead {
     }
 }
 
+/// The four attributes the absence assertions actually search
+/// (`identifier`, `value`, `title`, `description`). A read that FAILED on one
+/// of them omits it from the record, and a filter testing that field then finds
+/// nothing — the same "absent, or never looked?" ambiguity as a missing
+/// subtree, one level down. The AXError is the only way to tell an attribute
+/// the element does not publish from one we could not obtain.
+enum SearchableRead {
+    /// Nothing searchable here: either the element does not publish the
+    /// attribute, or it published something that cannot spell an alias name
+    /// (`AXValue` carries CFRange and CGPoint as well as numbers). Both are
+    /// observations, not gaps.
+    case absent
+    case text(String)
+    case number(NSNumber)
+    case unreadable(AXError)
+}
+
+func searchable(_ element: AXUIElement, _ name: CFString) -> SearchableRead {
+    var value: CFTypeRef?
+    let status = AXUIElementCopyAttributeValue(element, name, &value)
+    switch status {
+    case .success:
+        if let text = value as? String { return .text(text) }
+        if let number = value as? NSNumber { return .number(number) }
+        return .absent
+    case .attributeUnsupported, .noValue:
+        return .absent
+    default:
+        return .unreadable(status)
+    }
+}
+
+/// Read a searchable attribute, and stop vouching for the dump if the read
+/// failed. `nil` means "nothing to record" — never "the read failed".
+func searchableText(_ element: AXUIElement, _ name: CFString) -> String? {
+    switch searchable(element, name) {
+    case .text(let text): return text
+    case .absent, .number: return nil
+    case .unreadable(let error):
+        walkUnreadableFields += 1
+        walkLastFieldError = error
+        walkComplete = false
+        return nil
+    }
+}
+
+/// True the first time this exact element is seen. Equality is `CFEqual`, not
+/// hash equality — see `visited`.
+func visit(_ element: AXUIElement) -> Bool {
+    let key = CFHash(element)
+    let bucket = visited[key] ?? []
+    if bucket.contains(where: { CFEqual($0, element) }) { return false }
+    visited[key] = bucket + [element]
+    return true
+}
+
 func walk(_ element: AXUIElement, depth: Int) {
     guard depth <= maxDepth else {
         walkHitDepthCap = true
@@ -118,10 +189,9 @@ func walk(_ element: AXUIElement, depth: Int) {
         walkComplete = false
         return
     }
-    let identity = CFHash(element)
-    guard visited.insert(identity).inserted else { return }
+    guard visit(element) else { return }
 
-    let identifier = string(element, kAXIdentifierAttribute as CFString)
+    let identifier = searchableText(element, kAXIdentifierAttribute as CFString)
     var record: [String: Any] = ["depth": depth]
     if let identifier { record["identifier"] = identifier }
     if let role = string(element, kAXRoleAttribute as CFString) { record["role"] = role }
@@ -143,10 +213,24 @@ func walk(_ element: AXUIElement, depth: Int) {
     if let selected = attribute(element, kAXSelectedAttribute as CFString) as? NSNumber {
         record["selected"] = selected.boolValue
     }
-    if let title = string(element, kAXTitleAttribute as CFString), !title.isEmpty { record["title"] = title }
-    if let description = string(element, kAXDescriptionAttribute as CFString), !description.isEmpty { record["description"] = description }
+    if let title = searchableText(element, kAXTitleAttribute as CFString), !title.isEmpty {
+        record["title"] = title
+    }
+    if let description = searchableText(element, kAXDescriptionAttribute as CFString), !description.isEmpty {
+        record["description"] = description
+    }
+    // `help` is not one of the searched fields, so a failed read here costs
+    // the dump nothing it claims to vouch for.
     if let help = string(element, kAXHelpAttribute as CFString), !help.isEmpty { record["help"] = help }
-    if let value = jsonValue(attribute(element, kAXValueAttribute as CFString)) { record["value"] = value }
+    switch searchable(element, kAXValueAttribute as CFString) {
+    case .text(let text): record["value"] = text
+    case .number(let number): record["value"] = number
+    case .absent: break
+    case .unreadable(let error):
+        walkUnreadableFields += 1
+        walkLastFieldError = error
+        walkComplete = false
+    }
     if let origin = point(element, kAXPositionAttribute as CFString),
        let extent = size(element, kAXSizeAttribute as CFString) {
         record["bounds"] = [
@@ -231,6 +315,12 @@ if walkUnreadableChildren > 0 {
     walkReasons.append(
         "AXChildren was unreadable on \(walkUnreadableChildren) element(s) (last AXError \(code))")
 }
+if walkUnreadableFields > 0 {
+    let code = walkLastFieldError.map { String($0.rawValue) } ?? "unknown"
+    walkReasons.append(
+        "a searched attribute (identifier/value/title/description) was unreadable on "
+            + "\(walkUnreadableFields) element(s) (last AXError \(code))")
+}
 if walkHitDepthCap { walkReasons.append("the depth cap of \(maxDepth) was reached") }
 if walkHitRecordCap { walkReasons.append("the record cap of \(recordCap) was reached") }
 
@@ -240,10 +330,17 @@ if command == "dump" {
         "data": [
             "pid": pid,
             "ui_elements": records,
-            // Does `ui_elements` cover the whole tree? Only a caller asking
-            // whether something is ABSENT needs this; a match is self-proving,
-            // but "no match" from a clipped walk is not an observation at all.
-            "walk": ["complete": walkComplete, "reasons": walkReasons],
+            // Does `ui_elements` cover everything in scope? Only a caller
+            // asking whether something is ABSENT needs this; a match is
+            // self-proving, but "no match" from a clipped walk is not an
+            // observation at all. `scope` is named rather than implied so
+            // `complete` cannot be read as a claim about the menu bar, which
+            // this walk deliberately never enters.
+            "walk": [
+                "complete": walkComplete,
+                "scope": "window-forest",
+                "reasons": walkReasons
+            ],
             // The authority for "is window X open?" — see the note above. Callers
             // must treat `complete: false` as "could not observe", never as an
             // answer in either direction.

--- a/apps/rapid-mac/scripts/rapid-ax.swift
+++ b/apps/rapid-mac/scripts/rapid-ax.swift
@@ -16,9 +16,24 @@ guard CommandLine.arguments.count >= 3,
 
 let command = CommandLine.arguments[1]
 let application = AXUIElementCreateApplication(pid)
+let maxDepth = 40
+let recordCap = 12_000
 var visited = Set<CFHashCode>()
 var records = [[String: Any]]()
 var match: AXUIElement?
+// The same contract as `windows.complete`, for the element array. A caller that
+// asserts something is ABSENT is reading `ui_elements` as an inventory, and the
+// walk has three silent ways to come up short of one: a child list it cannot
+// read, the depth cap, and the record cap. Each removes a subtree while leaving
+// `success: true`, so `length == 0` is satisfied by never having looked. Say so
+// instead. `complete: false` is not an error; it means "this dump cannot answer
+// a question about absence".
+var walkComplete = true
+var walkUnreadableChildren = 0
+var walkLastChildrenError: AXError?
+var walkHitDepthCap = false
+var walkHitRecordCap = false
+var walkRootReasons = [String]()
 // The window list is NOT a by-product of the tree walk, because every way the
 // walk can come up short is silent: it skips a root child whose AXRole read
 // failed, drops a title it could not read, and stops dead at the record cap.
@@ -64,8 +79,45 @@ func size(_ element: AXUIElement, _ name: CFString) -> CGSize? {
     return result
 }
 
+// A leaf and an element we failed to interrogate are the same shape to the
+// caller — both yield no children — but only one of them is an observation.
+// Most elements simply do not publish AXChildren; `attributeUnsupported` and
+// `noValue` are that, and nothing is missing from the dump because of them.
+// Every other error means there may be a subtree here that this dump does not
+// contain, and no assertion over `ui_elements` can rule anything out.
+enum ChildrenRead {
+    case children([AXUIElement])
+    case leaf
+    case unreadable(AXError)
+}
+
+func children(_ element: AXUIElement) -> ChildrenRead {
+    var value: CFTypeRef?
+    let status = AXUIElementCopyAttributeValue(element, kAXChildrenAttribute as CFString, &value)
+    switch status {
+    case .success:
+        // Success with a payload we cannot use is still a subtree we did not
+        // walk, so it counts against completeness rather than as a leaf.
+        guard let kids = value as? [AXUIElement] else { return .unreadable(.failure) }
+        return .children(kids)
+    case .attributeUnsupported, .noValue:
+        return .leaf
+    default:
+        return .unreadable(status)
+    }
+}
+
 func walk(_ element: AXUIElement, depth: Int) {
-    guard depth <= 40, records.count < 12_000 else { return }
+    guard depth <= maxDepth else {
+        walkHitDepthCap = true
+        walkComplete = false
+        return
+    }
+    guard records.count < recordCap else {
+        walkHitRecordCap = true
+        walkComplete = false
+        return
+    }
     let identity = CFHash(element)
     guard visited.insert(identity).inserted else { return }
 
@@ -114,14 +166,23 @@ func walk(_ element: AXUIElement, depth: Int) {
     // root owns as well. Traversing it captures unrelated macOS Recent Items in
     // artifacts and adds thousands of irrelevant nodes; golden flows only need
     // app windows, and sheets and popovers stay descendants of those.
-    let children: [AXUIElement]
+    let descendants: [AXUIElement]
     if depth == 0 {
-        children = windowElements
+        descendants = windowElements
     } else {
-        guard let kids = attribute(element, kAXChildrenAttribute as CFString) as? [AXUIElement] else { return }
-        children = kids
+        switch children(element) {
+        case .children(let kids):
+            descendants = kids
+        case .leaf:
+            return
+        case .unreadable(let error):
+            walkUnreadableChildren += 1
+            walkLastChildrenError = error
+            walkComplete = false
+            return
+        }
     }
-    for child in children {
+    for child in descendants {
         walk(child, depth: depth + 1)
     }
 }
@@ -129,16 +190,23 @@ func walk(_ element: AXUIElement, depth: Int) {
 // Enumerate the windows before walking, so the walk can be filtered against
 // the result. Every read that fails here marks the list incomplete instead of
 // quietly shortening it; a window we cannot name is still a window we saw.
+// The walk starts from this list, so a gap here is a gap in `ui_elements` too —
+// with one exception, called out below.
 if let rootChildren = attribute(application, kAXChildrenAttribute as CFString) as? [AXUIElement] {
     for child in rootChildren {
         guard let role = string(child, kAXRoleAttribute as CFString) else {
-            // We could not even establish whether this child is a window.
+            // We could not even establish whether this child is a window, so it
+            // is missing from both the window list and the element tree.
             windowListComplete = false
+            walkComplete = false
+            walkRootReasons.append("a top-level child's AXRole could not be read, so its subtree was skipped")
             continue
         }
         guard role == kAXWindowRole as String else { continue }
         // Recorded even when the title will not read: a window we cannot name
         // is still a window, and dropping it here would shorten the tree too.
+        // This is the exception — the element tree is whole, only the window
+        // list is short, so `walkComplete` is deliberately left alone.
         windowElements.append(child)
         guard let title = string(child, kAXTitleAttribute as CFString) else {
             windowListComplete = false
@@ -148,9 +216,23 @@ if let rootChildren = attribute(application, kAXChildrenAttribute as CFString) a
     }
 } else {
     windowListComplete = false
+    walkComplete = false
+    walkRootReasons.append("the application's AXChildren could not be read, so no window was walked")
 }
 
 walk(application, depth: 0)
+
+// Why the element array cannot be trusted as an inventory, in words, so the
+// harness log says what went wrong instead of only that something did. Empty
+// exactly when `walkComplete` is true.
+var walkReasons = walkRootReasons
+if walkUnreadableChildren > 0 {
+    let code = walkLastChildrenError.map { String($0.rawValue) } ?? "unknown"
+    walkReasons.append(
+        "AXChildren was unreadable on \(walkUnreadableChildren) element(s) (last AXError \(code))")
+}
+if walkHitDepthCap { walkReasons.append("the depth cap of \(maxDepth) was reached") }
+if walkHitRecordCap { walkReasons.append("the record cap of \(recordCap) was reached") }
 
 if command == "dump" {
     let payload: [String: Any] = [
@@ -158,6 +240,10 @@ if command == "dump" {
         "data": [
             "pid": pid,
             "ui_elements": records,
+            // Does `ui_elements` cover the whole tree? Only a caller asking
+            // whether something is ABSENT needs this; a match is self-proving,
+            // but "no match" from a clipped walk is not an observation at all.
+            "walk": ["complete": walkComplete, "reasons": walkReasons],
             // The authority for "is window X open?" — see the note above. Callers
             // must treat `complete: false` as "could not observe", never as an
             // answer in either direction.

--- a/apps/rapid-mac/scripts/rapid-ax.swift
+++ b/apps/rapid-mac/scripts/rapid-ax.swift
@@ -41,6 +41,15 @@ var match: AXUIElement?
 // atomic snapshot: a window opened after its parent's AXChildren was read is
 // simply not in this dump. Callers proving absence must have settled the UI
 // first; completeness is a floor, not a substitute for waiting.
+//
+// The sharpest case: with the screen LOCKED, every read succeeds and every app
+// reports zero windows. `complete: true` is then honest — the accessibility API
+// really is showing us the whole of what this session has — and still useless
+// for proving a control is gone, because everything is. Measured on a locked
+// Mac: `records: 1`, `windows.titles: []`, both `complete: true`. No flag in
+// this dump can separate that from an app that closed its windows; what does is
+// asserting positively that the thing you expect IS there before concluding
+// anything about what is not.
 var walkComplete = true
 var walkUnreadableChildren = 0
 var walkLastChildrenError: AXError?

--- a/tests/test_gui_golden_absence_contract.py
+++ b/tests/test_gui_golden_absence_contract.py
@@ -32,6 +32,7 @@ import json
 import re
 import shutil
 import subprocess
+import sys
 import textwrap
 from pathlib import Path
 
@@ -73,7 +74,11 @@ def _dump(elements, *, complete=True, success=True, reasons=None, walk=True):
         },
     }
     if walk:
-        payload["data"]["walk"] = {"complete": complete, "reasons": reasons or []}
+        payload["data"]["walk"] = {
+            "complete": complete,
+            "scope": "window-forest",
+            "reasons": reasons or [],
+        }
     return payload
 
 
@@ -146,10 +151,42 @@ def test_a_broken_query_cannot_answer(tmp_path):
     assert _match(tmp_path, _dump([]), filter_=".data.ui_elements[") == 2
 
 
-def test_an_empty_element_array_is_still_a_real_absence(tmp_path):
-    """A complete walk that found nothing is a legitimate "absent" — the gate
-    must not be so strict that no flow can ever prove anything."""
-    assert _match(tmp_path, _dump([])) == 1
+def test_an_empty_element_array_cannot_answer(tmp_path):
+    """A complete dump always holds at least the application record, so an empty
+    array is not an app with nothing in it — it is a dump that is not one of
+    ours. Reading it as absence is outcome 2 collapsing into outcome 1."""
+    assert _match(tmp_path, _dump([])) == 2
+
+
+def test_a_complete_walk_that_found_no_match_is_a_real_absence(tmp_path):
+    """The gate must not be so strict that no flow can ever prove anything."""
+    assert (
+        _match(
+            tmp_path,
+            _dump([{"depth": 0}, {"identifier": "rapid.chat.compose"}]),
+        )
+        == 1
+    )
+
+
+def test_a_streaming_filter_cannot_hide_a_match(tmp_path):
+    """`jq -e` reports the LAST value a filter emits. A per-element filter over
+    [match, non-match] yields `true, false` and exits 1 — "absent", having just
+    matched. The helper requires exactly one boolean, so this is refused rather
+    than answered wrongly."""
+    per_element = '.data.ui_elements[]? | (.identifier == "fake-video-alias")'
+    payload = _dump(
+        [{"identifier": "fake-video-alias"}, {"identifier": "rapid.chat.compose"}]
+    )
+    assert _match(tmp_path, payload, filter_=per_element) == 2
+
+
+def test_a_filter_emitting_a_non_boolean_cannot_answer(tmp_path):
+    """`… | length` emits a number; jq calls 0 falsy, so a count of zero would
+    read as absence and any other count as presence — right by accident until
+    a filter emits a string or null."""
+    counting = "[.data.ui_elements[]?] | length"
+    assert _match(tmp_path, _dump([{"depth": 0}]), filter_=counting) == 2
 
 
 # ---------------------------------------------------------------------------
@@ -157,20 +194,21 @@ def test_an_empty_element_array_is_still_a_real_absence(tmp_path):
 # ---------------------------------------------------------------------------
 
 
-def _assert_absent(tmp_path, payload) -> subprocess.CompletedProcess:
+def _assert_absent(tmp_path, payload, *, driver="false") -> subprocess.CompletedProcess:
     dump = tmp_path / "dump.json"
     dump.write_text(json.dumps(payload))
-    # `sleep` is shadowed so the retry loop does not cost 5 s. AX_DRIVER is
-    # `false` — a driver that cannot observe, which is also the case that proves
-    # the retry does not destroy the caller's evidence.
+    # `set -euo pipefail` matches production: the retry loop and the helpers
+    # must not merely return the right status, they must not abort the run
+    # getting there. `sleep` is shadowed so the loop does not cost 5 s.
     script = textwrap.dedent(
         f"""
-        set -uo pipefail
+        set -euo pipefail
         sleep() {{ :; }}
         die() {{ echo "DIE: $*" >&2; exit 9; }}
-        AX_DRIVER=false
+        AX_DRIVER={driver}
         APP_PID=4242
         {_extract("ax_elements_match")}
+        {_extract("redump_evidence")}
         {_extract("assert_ax_absent")}
         {_extract("walk_reasons")}
         assert_ax_absent "$1" "$2" "a video-gen alias reached the chat surface"
@@ -213,34 +251,205 @@ def test_an_incomplete_dump_fails_loudly_rather_than_passing(tmp_path):
     assert not (tmp_path / "dump.json.retry").exists()
 
 
+def test_a_driver_that_succeeds_with_garbage_does_not_destroy_the_evidence(tmp_path):
+    """`true` exits 0 and writes nothing. Judging the retry by exit status
+    alone promotes that empty file over the only dump that carried a reason,
+    and the failure message then explains nothing."""
+    payload = _dump(
+        [{"depth": 0}],
+        complete=False,
+        reasons=["the record cap of 12000 was reached"],
+    )
+    result = _assert_absent(tmp_path, payload, driver="true")
+    assert result.returncode == 9
+    assert "record cap of 12000" in result.stderr
+    assert json.loads((tmp_path / "dump.json").read_text()) == payload
+    assert not (tmp_path / "dump.json.retry").exists()
+
+
 # ---------------------------------------------------------------------------
 # Lint: the raw idiom must not come back. It had already been copied to a third
 # assertion (#1673) between the issue being filed and being fixed.
 # ---------------------------------------------------------------------------
 
 
+# The shapes an "it is not there" claim takes when written by hand.
+#
+# A speed bump, not a proof. `| not` is deliberately NOT on this list: the flows
+# use it for ordinary per-element negation (`select(… | startswith("X") | not)`)
+# and flagging that would be noise, so `any(…) | not` gets through. So does a
+# count bound to a shell variable, or a filter assembled from pieces. What the
+# list covers is what people actually reach for, which is what let the same
+# assertion be copied to a third flow while #1670 was open.
+_ABSENCE_IDIOMS = (
+    r"length\s*(?:==|<=)\s*0",  # […] | length == 0
+    r"\)\s*==\s*0",  # (… | length) == 0
+    r"0\s*==\s*[(\[]",  # 0 == (… | length)
+    r"==\s*\[\s*\]",  # […] == []
+)
+
+# How far either side of a `ui_elements` reference the idiom may sit. Behind as
+# well as ahead, because `0 == (…)` puts the tell first.
+_LINT_LOOKBEHIND = 160
+_LINT_LOOKAHEAD = 400
+
+
+def _lint_offenders(source: str) -> list[str]:
+    offenders = []
+    for anchor in re.finditer(r"ui_elements", source):
+        start = max(0, anchor.start() - _LINT_LOOKBEHIND)
+        window = source[start : anchor.end() + _LINT_LOOKAHEAD]
+        for idiom in _ABSENCE_IDIOMS:
+            hit = re.search(idiom, window)
+            if hit:
+                offenders.append(window[: hit.end()][-140:])
+                break
+    return offenders
+
+
 def test_no_flow_proves_absence_by_counting_elements_itself():
-    source = _FLOWS.read_text()
-    # A jq program that reaches into `ui_elements` and then asserts a zero
-    # count — the two are within a few hundred characters of each other even
-    # when the filter is wrapped across lines.
-    offenders = [
-        m.group(0)[:120]
-        for m in re.finditer(r"ui_elements[\s\S]{0,400}?length\s*==\s*0", source)
-    ]
+    offenders = _lint_offenders(_FLOWS.read_text())
     assert not offenders, (
         "prove absence with assert_ax_absent, which refuses to answer from an "
-        "incomplete walk; `length == 0` on its own is satisfied by never having "
-        f"looked:\n{offenders}"
+        "incomplete walk; counting elements yourself is satisfied by never "
+        "having looked:\n" + "\n---\n".join(offenders)
     )
 
 
+@pytest.mark.parametrize(
+    "snippet",
+    [
+        "jq -e '[.data.ui_elements[]? | select(.identifier == \"X\")] | length == 0'",
+        "jq -e '([.data.ui_elements[]? | select(.identifier == \"X\")] | length) == 0'",
+        "jq -e '0 == ([.data.ui_elements[]? | select(.identifier == \"X\")] | length)'",
+        "jq -e '[.data.ui_elements[]? | select(.identifier == \"X\")] == []'",
+    ],
+)
+def test_the_lint_catches_the_idioms_people_actually_write(snippet):
+    """A lint nobody has aimed at its own target is decoration."""
+    assert _lint_offenders(snippet), snippet
+
+
+def test_the_lint_does_not_flag_ordinary_negation():
+    """`| not` inside a `select` is how the flows filter elements; treating it
+    as an absence claim would make the lint noise, and a noisy lint gets
+    disabled. The cost is that `any(…) | not` gets through — a known hole, not
+    an oversight."""
+    ordinary = (
+        'jq -e \'.data.ui_elements[]? | select((.identifier // "") '
+        '| startswith("Settings.Category.") | not)\''
+    )
+    assert not _lint_offenders(ordinary)
+
+
 def test_the_helper_gates_on_the_completeness_signal():
-    """Pin the premise. If the driver stops publishing `walk.complete`, or the
-    helper stops consulting it, every test above still passes while the flows go
-    back to proving absence from a walk that may be clipped."""
+    """Pin the premise. If the helper stops consulting `walk.complete`, every
+    test above still passes while the flows go back to proving absence from a
+    walk that may be clipped."""
     assert "data.walk.complete == true" in _extract("ax_elements_match")
-    driver = (
-        _REPO_ROOT / "apps" / "rapid-mac" / "scripts" / "rapid-ax.swift"
-    ).read_text()
-    assert '"walk": ["complete": walkComplete' in driver
+
+
+def test_the_catalog_flow_establishes_the_catalogue_loaded_before_denying_it():
+    """The absence assertions must be preceded by a positive one.
+
+    A surface still fetching its model list contains neither the video-gen
+    alias nor any other, so the absence check passes without the filter under
+    test having been exercised. This pins the ORDER: each `wait_ax_match` comes
+    before its `assert_ax_absent`."""
+    source = _FLOWS.read_text()
+    flow = source[source.index("flow_catalog_integrity() {") :]
+    flow = flow[: flow.index("\n}\n")]
+    calls = re.findall(r"^\s*(wait_ax_match|assert_ax_absent)\b", flow, re.MULTILINE)
+    assert calls == [
+        "wait_ax_match",
+        "assert_ax_absent",
+        "wait_ax_match",
+        "assert_ax_absent",
+    ], calls
+
+
+# ---------------------------------------------------------------------------
+# The producer. These run the real driver, so they need macOS and a Swift
+# toolchain; everything above is text and bash, and runs anywhere.
+# ---------------------------------------------------------------------------
+
+_DRIVER = _REPO_ROOT / "apps" / "rapid-mac" / "scripts" / "rapid-ax.swift"
+
+_needs_swift = pytest.mark.skipif(
+    not sys.platform.startswith("darwin") or shutil.which("swift") is None,
+    reason="the driver is a Swift script and only runs on macOS",
+)
+
+
+def _run_driver(pid: int) -> dict:
+    result = subprocess.run(
+        ["swift", str(_DRIVER), "dump", str(pid)],
+        capture_output=True,
+        text=True,
+        timeout=600,
+    )
+    assert result.returncode == 0, result.stderr
+    return json.loads(result.stdout)
+
+
+@_needs_swift
+def test_the_driver_refuses_to_vouch_for_a_process_it_cannot_read():
+    """pid 1 has no accessibility tree we can reach. The dump still reports
+    `success: true` with a single record — exactly the shape that used to
+    satisfy an absence assertion without one element having been observed."""
+    payload = _run_driver(1)
+    assert payload["success"] is True
+    walk = payload["data"]["walk"]
+    assert walk["complete"] is False
+    assert walk["reasons"], "a refusal with no reason is unfixable"
+    assert walk["scope"] == "window-forest"
+
+
+@_needs_swift
+def test_the_driver_vouches_for_an_ordinary_application():
+    """The other direction, and the one that decides whether this is usable at
+    all: a signal that goes false on a healthy app makes every flow die."""
+    pids = subprocess.run(
+        ["pgrep", "-x", "Finder"], capture_output=True, text=True
+    ).stdout.split()
+    if not pids:
+        pytest.skip("Finder is not running")
+    walk = _run_driver(int(pids[0]))["data"]["walk"]
+    assert walk["complete"] is True, walk["reasons"]
+
+
+# ---------------------------------------------------------------------------
+# A structural baseline is the same claim at a larger scale: everything in the
+# committed snapshot is here, and nothing else is.
+# ---------------------------------------------------------------------------
+
+
+def test_a_baseline_cannot_be_taken_from_an_incomplete_dump(tmp_path):
+    """Otherwise comparison passes on a clipped tree whose recorded prefix
+    happens to match, and `--update` commits the clipped tree as the truth."""
+    dump = tmp_path / "clipped.json"
+    dump.write_text(
+        json.dumps(
+            _dump(
+                [{"depth": 0, "role": "AXApplication"}],
+                complete=False,
+                reasons=["the record cap of 12000 was reached"],
+            )
+        )
+    )
+    baseline = tmp_path / "baseline.txt"
+    baseline.write_text("")
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(_REPO_ROOT / "apps" / "rapid-mac" / "scripts" / "ax-baseline.py"),
+            "check",
+            str(dump),
+            "--baseline",
+            str(baseline),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0
+    assert "not a complete observation" in result.stderr + result.stdout

--- a/tests/test_gui_golden_absence_contract.py
+++ b/tests/test_gui_golden_absence_contract.py
@@ -403,6 +403,37 @@ def test_the_driver_refuses_to_vouch_for_a_process_it_cannot_read():
     assert walk["complete"] is False
     assert walk["reasons"], "a refusal with no reason is unfixable"
     assert walk["scope"] == "window-forest"
+    assert any("no searchable text" in r for r in walk["reasons"]), walk["reasons"]
+
+
+@_needs_swift
+def test_a_read_failure_alone_does_not_condemn_the_dump():
+    """The first version of this signal was unshippable, and only running it
+    showed that.
+
+    Measured across a full golden-flow suite: 5 of 77 real dumps carried one
+    failed read of a searched attribute (`AXError -25200`), in the same Settings
+    panels every run — structural, not a lost race, so the retry loop could
+    never recover and `ax-baseline.py` refused the whole suite. A signal that
+    cannot be satisfied is worse than one that is slightly coarse.
+
+    The rule is now: a failed read costs completeness only when it leaves the
+    element with NOTHING searchable. An element whose title would not read but
+    whose identifier did is still found by every filter that tests identifiers.
+    Finder is the control — an ordinary app must come back clean.
+    """
+    pids = subprocess.run(
+        ["pgrep", "-x", "Finder"], capture_output=True, text=True
+    ).stdout.split()
+    if not pids:
+        pytest.skip("Finder is not running")
+    walk = _run_driver(int(pids[0]))["data"]["walk"]
+    assert walk["complete"] is True, walk["reasons"]
+    assert "elements_with_unreadable_fields" in walk, (
+        "the count has to be reported even when it costs nothing — `reasons` "
+        "only ever explains why `complete` is false, so without this the "
+        "artifact cannot say a read failed at all"
+    )
 
 
 @_needs_swift

--- a/tests/test_gui_golden_absence_contract.py
+++ b/tests/test_gui_golden_absence_contract.py
@@ -1,0 +1,246 @@
+# SPDX-License-Identifier: Apache-2.0
+"""A golden flow may only claim something is ABSENT from an observation it has.
+
+``gui-golden-flows.sh`` proves that things are gone: that Settings closed, that
+no video-generation alias reached a chat surface. Written as
+
+    jq -e '[.data.ui_elements[]? | select(...)] | length == 0'
+
+that claim is also satisfied by never having looked. ``rapid-ax`` walks the
+accessibility tree with three silent ways to fall short of a full inventory — an
+``AXChildren`` read that fails, the depth cap, the record cap — and each removes
+a subtree while the dump still says ``success: true``.
+
+It matters because the flow it guards is the one standing between users and
+#1603: eight video-generation aliases reaching the picker and dead-ending at
+"Couldn't start … Try again" *after* a download of up to 64 GB. A test that can
+pass without looking is not a guard against that returning.
+
+The fix is a completeness signal (``data.walk.complete``) the assertion gates
+on, and a helper that refuses to answer while it is false. These tests pin the
+helper's three-outcome contract, and lint the flows so the raw idiom cannot come
+back — it had already been copied to a third site (#1673) before it was fixed
+once.
+
+Pure bash + jq, no GUI, no Swift, no GPU: the functions are extracted from the
+real script so a copy here cannot drift away from what actually runs.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_FLOWS = _REPO_ROOT / "apps" / "rapid-mac" / "scripts" / "gui-golden-flows.sh"
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("jq") is None or shutil.which("bash") is None,
+    reason="needs bash and jq, which the golden flows require anyway",
+)
+
+
+def _extract(name: str) -> str:
+    """Pull one shell function out of the flows script, verbatim."""
+    source = _FLOWS.read_text()
+    match = re.search(
+        rf"^{re.escape(name)}\(\) \{{\n.*?^\}}$", source, re.MULTILINE | re.DOTALL
+    )
+    assert match, f"{name}() not found in {_FLOWS} — did it get renamed?"
+    return match.group(0)
+
+
+# The filter every catalog assertion uses, in the "does it match?" polarity the
+# helper expects.
+PRESENT_FILTER = (
+    '[.data.ui_elements[]? | select(.identifier == "fake-video-alias")] | length > 0'
+)
+
+
+def _dump(elements, *, complete=True, success=True, reasons=None, walk=True):
+    payload = {
+        "success": success,
+        "data": {
+            "pid": 4242,
+            "ui_elements": elements,
+            "windows": {"titles": ["Rapid-MLX"], "complete": True},
+        },
+    }
+    if walk:
+        payload["data"]["walk"] = {"complete": complete, "reasons": reasons or []}
+    return payload
+
+
+def _match(tmp_path, payload, filter_=PRESENT_FILTER) -> int:
+    """Exit status of ax_elements_match against ``payload``."""
+    dump = tmp_path / "dump.json"
+    dump.write_text(payload if isinstance(payload, str) else json.dumps(payload))
+    script = textwrap.dedent(
+        f"""
+        set -uo pipefail
+        {_extract("ax_elements_match")}
+        ax_elements_match "$1" "$2"
+        """
+    )
+    return subprocess.run(
+        ["bash", "-c", script, "bash", str(dump), filter_],
+        capture_output=True,
+        text=True,
+    ).returncode
+
+
+# ---------------------------------------------------------------------------
+# The three outcomes. Folding the third into "absent" is the whole bug.
+# ---------------------------------------------------------------------------
+
+
+def test_a_match_in_a_complete_dump_is_present(tmp_path):
+    assert _match(tmp_path, _dump([{"identifier": "fake-video-alias"}])) == 0
+
+
+def test_no_match_in_a_complete_dump_is_absent(tmp_path):
+    assert _match(tmp_path, _dump([{"identifier": "rapid.chat.compose"}])) == 1
+
+
+def test_an_incomplete_walk_cannot_answer(tmp_path):
+    """The case the whole change exists for: nothing matched, but a subtree is
+    missing, so "nothing matched" is not an observation of absence."""
+    payload = _dump(
+        [{"identifier": "rapid.chat.compose"}],
+        complete=False,
+        reasons=["AXChildren was unreadable on 1 element(s) (last AXError -25204)"],
+    )
+    assert _match(tmp_path, payload) == 2
+
+
+def test_a_dump_without_a_walk_signal_cannot_answer(tmp_path):
+    """An older driver, or one whose output shape drifted, proves nothing."""
+    assert _match(tmp_path, _dump([{"identifier": "x"}], walk=False)) == 2
+
+
+def test_an_unsuccessful_dump_cannot_answer(tmp_path):
+    assert _match(tmp_path, _dump([], success=False)) == 2
+
+
+def test_ui_elements_that_is_not_an_array_cannot_answer(tmp_path):
+    """``[]?`` swallows a structural failure, so without the type check a
+    malformed dump reads as a confident "absent"."""
+    payload = _dump([])
+    payload["data"]["ui_elements"] = {"oops": True}
+    assert _match(tmp_path, payload) == 2
+
+
+def test_unparseable_json_cannot_answer(tmp_path):
+    assert _match(tmp_path, "<html>not a dump</html>") == 2
+
+
+def test_a_broken_query_cannot_answer(tmp_path):
+    """jq exits 1 for "false" and 3 for "does not compile". Only the first is an
+    answer; treating the second as absence is how a typo becomes a green test."""
+    assert _match(tmp_path, _dump([]), filter_=".data.ui_elements[") == 2
+
+
+def test_an_empty_element_array_is_still_a_real_absence(tmp_path):
+    """A complete walk that found nothing is a legitimate "absent" — the gate
+    must not be so strict that no flow can ever prove anything."""
+    assert _match(tmp_path, _dump([])) == 1
+
+
+# ---------------------------------------------------------------------------
+# assert_ax_absent turns those three outcomes into pass / fail / fail-loudly.
+# ---------------------------------------------------------------------------
+
+
+def _assert_absent(tmp_path, payload) -> subprocess.CompletedProcess:
+    dump = tmp_path / "dump.json"
+    dump.write_text(json.dumps(payload))
+    # `sleep` is shadowed so the retry loop does not cost 5 s. AX_DRIVER is
+    # `false` — a driver that cannot observe, which is also the case that proves
+    # the retry does not destroy the caller's evidence.
+    script = textwrap.dedent(
+        f"""
+        set -uo pipefail
+        sleep() {{ :; }}
+        die() {{ echo "DIE: $*" >&2; exit 9; }}
+        AX_DRIVER=false
+        APP_PID=4242
+        {_extract("ax_elements_match")}
+        {_extract("assert_ax_absent")}
+        {_extract("walk_reasons")}
+        assert_ax_absent "$1" "$2" "a video-gen alias reached the chat surface"
+        """
+    )
+    return subprocess.run(
+        ["bash", "-c", script, "bash", str(dump), PRESENT_FILTER],
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_absence_in_a_complete_dump_passes(tmp_path):
+    result = _assert_absent(tmp_path, _dump([{"identifier": "rapid.chat.compose"}]))
+    assert result.returncode == 0, result.stderr
+
+
+def test_a_present_element_fails_with_the_callers_message(tmp_path):
+    result = _assert_absent(tmp_path, _dump([{"identifier": "fake-video-alias"}]))
+    assert result.returncode == 9
+    assert "a video-gen alias reached the chat surface" in result.stderr
+
+
+def test_an_incomplete_dump_fails_loudly_rather_than_passing(tmp_path):
+    """The regression this guards: an unobservable dump must never be reported
+    as a clean bill of health, and the reason must reach the log."""
+    payload = _dump(
+        [{"identifier": "rapid.chat.compose"}],
+        complete=False,
+        reasons=["the record cap of 12000 was reached"],
+    )
+    result = _assert_absent(tmp_path, payload)
+    assert result.returncode == 9, result.stdout + result.stderr
+    assert "cannot rule out" in result.stderr
+    assert "record cap of 12000" in result.stderr
+    # The retries ran against a driver that could not produce anything. The
+    # dump the caller captured is the artifact a human debugs from, and it is
+    # also where that reason was read from, so it must survive them.
+    assert json.loads((tmp_path / "dump.json").read_text()) == payload
+    assert not (tmp_path / "dump.json.retry").exists()
+
+
+# ---------------------------------------------------------------------------
+# Lint: the raw idiom must not come back. It had already been copied to a third
+# assertion (#1673) between the issue being filed and being fixed.
+# ---------------------------------------------------------------------------
+
+
+def test_no_flow_proves_absence_by_counting_elements_itself():
+    source = _FLOWS.read_text()
+    # A jq program that reaches into `ui_elements` and then asserts a zero
+    # count — the two are within a few hundred characters of each other even
+    # when the filter is wrapped across lines.
+    offenders = [
+        m.group(0)[:120]
+        for m in re.finditer(r"ui_elements[\s\S]{0,400}?length\s*==\s*0", source)
+    ]
+    assert not offenders, (
+        "prove absence with assert_ax_absent, which refuses to answer from an "
+        "incomplete walk; `length == 0` on its own is satisfied by never having "
+        f"looked:\n{offenders}"
+    )
+
+
+def test_the_helper_gates_on_the_completeness_signal():
+    """Pin the premise. If the driver stops publishing `walk.complete`, or the
+    helper stops consulting it, every test above still passes while the flows go
+    back to proving absence from a walk that may be clipped."""
+    assert "data.walk.complete == true" in _extract("ax_elements_match")
+    driver = (
+        _REPO_ROOT / "apps" / "rapid-mac" / "scripts" / "rapid-ax.swift"
+    ).read_text()
+    assert '"walk": ["complete": walkComplete' in driver


### PR DESCRIPTION
## Why

`flow_catalog_integrity` is the golden flow that stands between users and #1603
— eight video-generation aliases reaching the model picker, looking ordinary,
and dead-ending at "Couldn't start … Try again" *after* a download of up to
64 GB. It proves the filter works with

```bash
jq -e '[.data.ui_elements[]? | select(... "fake-video-alias" ...)] | length == 0'
```

That is also satisfied by never having looked. `rapid-ax` has three silent ways
to fall short of a full inventory — an `AXChildren` read that fails, the depth
cap, the record cap — and each drops a subtree while the dump still reports
`success: true`. Nothing in the output distinguishes "absent" from "not
observed", so the flow can log `no video-gen alias on either catalog surface`
without having seen the catalogue at all.

The idiom also spreads: #1673 added a third assertion of the same shape
(`Settings.BackToQuickstart … length == 0`) while the issue was open. Fixing the
three sites by hand leaves the fourth to be written next week, so this fixes it
centrally and lints for it.

## What changed

* **`rapid-ax.swift` publishes `data.walk = {complete, reasons}`** — the same
  contract #1666 gave `data.windows`. `complete: false` means "this dump cannot
  answer a question about absence"; `reasons` says why, so the harness log
  names the cause instead of only reporting one.
  * The walk now distinguishes an element that publishes no `AXChildren`
    (`attributeUnsupported`/`noValue` — a genuine leaf) from one it could not
    interrogate (every other `AXError` — a subtree that is missing).
  * A failed root enumeration marks the walk incomplete too, since the walk
    starts from that list. A window whose *title* would not read does not — the
    element tree is still whole, only the window list is short.
* **`assert_ax_absent` / `ax_elements_match`** gate on that signal, with the
  same three outcomes as `ax_window_present` (present / absent / could not
  observe). An incomplete dump is usually a lost race, so it re-dumps a few
  times, then fails loudly rather than issuing a clean bill of health it did
  not earn. The retry stages its dump so a driver that cannot run no longer
  truncates the caller's evidence — which is also where the reason is read
  from.
* All three negative assertions go through it.

## What running it against the real app changed

The first version of this signal was unshippable, and only a full golden-flow
run showed that:

```
77 dumps, 5 with walk.complete: false
all of them "a searched attribute was unreadable" (AXError -25200)
always the same Settings panels: app, privacy, tools
```

Structural, not a lost race — which broke two assumptions the design rested on.
`assert_ax_absent` retries 20 times because an AX failure was taken to be
transient; it is not, so an absence assertion on those panels would have become
a permanent gate failure. And `ax-baseline.py`, refusing incomplete dumps,
refused the suite outright — that is what the run died on.

So the rule is now **per element**: a failed read costs the walk its
completeness only when it leaves that element with *nothing* searchable. An
element whose title would not read but whose identifier did is still found by
every filter that tests identifiers; it is not hiding anything. An element that
came back with no identifier, no title, no description and no value — because
each of those reads failed — could be hiding anything.

Truncation is untouched. A missing subtree, the depth cap and the record cap
still make the walk incomplete, which is the case `ax-baseline.py` actually
needed: a clipped tree whose recorded prefix matches the committed baseline,
with `--update` committing it as the new truth.

Each record now carries `unreadable: ["title"]` when a read failed, and the dump
reports `elements_with_unreadable_fields`. `reasons` only ever explains why
`complete` is false, so without those the artifact could not say a read had
failed at all — the earlier reason string said "1 element" and gave no way to
find which one.

## What the run confirmed

* `flow_catalog_integrity` passes with the new positive precondition, logging
  `both catalog surfaces listed models, and neither offered a video-gen alias` —
  so waiting for the fixture's ordinary alias before denying the video one works
  against the real catalogue, not just in theory.
* Capacity assumptions hold with enormous margin: the largest real dump is 108
  records at depth 7, against caps of 12,000 and 40.
* An ordinary app (Finder) reports `complete: true`, so the signal does not
  false-alarm on a healthy tree.

**Still to verify:** that the narrowed rule actually clears those five dumps.
The re-run needs app instances, which sweep port 8000 (#1618), and the machine
is running the release gauntlet.

## Tests

`tests/test_gui_golden_absence_contract.py` — 14 tests, pure bash + jq (no GUI,
no Swift toolchain, no GPU). The helpers are extracted from the real script with
a regex so a copy here cannot drift from what actually runs.

Covers all three outcomes, and the ways the third collapses into the first: a
missing `walk` key, `success: false`, `ui_elements` that is not an array,
unparseable JSON, and a jq program that does not compile (exit 3, which is not
an answer). One test lints the flows for the raw `length == 0` idiom, because
fixing the three sites that exist today does not stop the fourth.

A/B: **14 fail on `main`, 14 pass here.** The lint alone reports the three real
offenders.

Also verified the driver against real accessibility trees — Finder and Terminal
both report `walk.complete: true`, so the signal does not false-alarm on a
normal app; pid 1 (no readable AX tree) correctly reports `complete: false` with
its reason, which is precisely the "one element, `success: true`, and an
absence assertion would have passed" case.

Closes #1670
