### PR TITLE
Propagate auth to attached agent harnesses

### DIFF
--- a/tests/integrations/test_hermes.py
+++ b/tests/integrations/test_hermes.py
@@ -26,10 +26,13 @@ import uuid
 
 import httpx
 
+from vllm_mlx.http_auth import rapid_mlx_auth_headers
+
 BASE_URL = os.environ.get("RAPID_MLX_BASE_URL", "http://localhost:8000/v1")
+AUTH_HEADERS = rapid_mlx_auth_headers()
 # Auto-detect model from server
 try:
-    resp = httpx.get(f"{BASE_URL}/models", timeout=5)
+    resp = httpx.get(f"{BASE_URL}/models", headers=AUTH_HEADERS, timeout=5)
     MODEL_ID = resp.json()["data"][0]["id"]
 except Exception:
     MODEL_ID = "default"
@@ -59,6 +62,7 @@ def api_call(messages, tools=None, stream=False, max_tokens=300, temperature=0.3
     resp = httpx.post(
         f"{BASE_URL}/chat/completions",
         json=payload,
+        headers=AUTH_HEADERS,
         timeout=120,
     )
     resp.raise_for_status()
@@ -68,7 +72,7 @@ def api_call(messages, tools=None, stream=False, max_tokens=300, temperature=0.3
 def _detect_context_window() -> int:
     """Fetch context_window for MODEL_ID from the running server, default 32768."""
     try:
-        resp = httpx.get(f"{BASE_URL}/models", timeout=5)
+        resp = httpx.get(f"{BASE_URL}/models", headers=AUTH_HEADERS, timeout=5)
         models = resp.json().get("data", [])
         # Exact match by MODEL_ID first
         for m in models:
@@ -104,6 +108,19 @@ def ensure_hermes_config():
         f.write(config)
 
 
+def _hermes_subprocess_env():
+    """Pass local-server auth to Hermes without persisting the secret."""
+    env = os.environ.copy()
+    api_key = os.environ.get("RAPID_MLX_API_KEY")
+    if api_key:
+        # Hermes custom providers fall back to these variables. Override them
+        # only for this child process so an unrelated user key cannot be sent
+        # to the Rapid-MLX endpoint and the parent environment stays untouched.
+        env["OPENAI_API_KEY"] = api_key
+        env["CUSTOM_API_KEY"] = api_key
+    return env
+
+
 def hermes_query(query, timeout_sec=120):
     """Run a single Hermes query in non-interactive mode.
 
@@ -123,6 +140,7 @@ def hermes_query(query, timeout_sec=120):
             text=True,
             timeout=timeout_sec,
             cwd=os.getcwd(),
+            env=_hermes_subprocess_env(),
         )
         output = proc.stdout + proc.stderr
         # Detect Hermes-level errors
@@ -392,7 +410,11 @@ def test_api_streaming_tool_call():
         "stream": True,
     }
     with httpx.stream(
-        "POST", f"{BASE_URL}/chat/completions", json=payload, timeout=60
+        "POST",
+        f"{BASE_URL}/chat/completions",
+        json=payload,
+        headers=AUTH_HEADERS,
+        timeout=60,
     ) as resp:
         tool_call_chunks = []
         content_chunks = []

--- a/tests/integrations/test_langchain.py
+++ b/tests/integrations/test_langchain.py
@@ -6,6 +6,8 @@ from collections.abc import Mapping
 
 import httpx as _httpx
 
+from vllm_mlx.http_auth import rapid_mlx_auth_headers
+
 # ``results`` is read by the ``rapid-mlx bench --tier harness`` path
 # (``vllm_mlx/agents/testing.py::_run_specific_tests`` does
 # ``getattr(mod, "results", {})`` after ``spec.loader.exec_module``).
@@ -46,15 +48,18 @@ def _run_tests() -> None:
     from pydantic import BaseModel, Field
 
     base_url = os.environ.get("RAPID_MLX_BASE_URL", "http://localhost:8000/v1")
+    auth_headers = rapid_mlx_auth_headers()
     try:
-        model_id = _httpx.get(f"{base_url}/models", timeout=5).json()["data"][0]["id"]
+        model_id = _httpx.get(
+            f"{base_url}/models", headers=auth_headers, timeout=5
+        ).json()["data"][0]["id"]
     except Exception:
         model_id = "default"
 
     llm = ChatOpenAI(
         model=model_id,
         base_url=base_url,
-        api_key="not-needed",
+        api_key=os.environ.get("RAPID_MLX_API_KEY") or "not-needed",
         temperature=0.0,
     )
 

--- a/tests/test_hermes_harness_contract.py
+++ b/tests/test_hermes_harness_contract.py
@@ -41,10 +41,19 @@ def test_test_hermes_populates_results_under_exec_module(monkeypatch):
     # on a real server. The point of this test is the harness invocation
     # contract — not the integration tests' substance.
     class _FailHTTPX:
+        def __init__(self):
+            self.calls = []
+
         def get(self, *a, **kw):
+            self.calls.append(("get", a, kw))
             raise RuntimeError("mocked: no server")
 
         def post(self, *a, **kw):
+            self.calls.append(("post", a, kw))
+            raise RuntimeError("mocked: no server")
+
+        def stream(self, *a, **kw):
+            self.calls.append(("stream", a, kw))
             raise RuntimeError("mocked: no server")
 
     import httpx
@@ -52,6 +61,7 @@ def test_test_hermes_populates_results_under_exec_module(monkeypatch):
     fake = _FailHTTPX()
     monkeypatch.setattr(httpx, "get", fake.get)
     monkeypatch.setattr(httpx, "post", fake.post)
+    monkeypatch.setattr(httpx, "stream", fake.stream)
 
     # Force HERMES_BIN to a path that cannot exist so the E2E branch
     # (which would write ~/.hermes/config.yaml and invoke real hermes
@@ -60,6 +70,7 @@ def test_test_hermes_populates_results_under_exec_module(monkeypatch):
     # block would be a side effect, not part of the contract.
     monkeypatch.setenv("HERMES_BIN", "/nonexistent/hermes-binary-for-contract-test")
     monkeypatch.setenv("RAPID_MLX_BASE_URL", "http://localhost:0/v1")
+    monkeypatch.setenv("RAPID_MLX_API_KEY", "harness-secret")
 
     # Mirror vllm_mlx/agents/testing.py:_run_specific_tests exactly.
     spec = importlib.util.spec_from_file_location(
@@ -92,3 +103,9 @@ def test_test_hermes_populates_results_under_exec_module(monkeypatch):
     # Every entry should carry a status string (PASS / FAIL / ERROR).
     for name, status in results.items():
         assert isinstance(status, str), f"non-str status for {name!r}: {status!r}"
+
+    assert fake.calls, "Hermes integration module must exercise its HTTP client"
+    for method, _args, kwargs in fake.calls:
+        assert kwargs.get("headers") == {"Authorization": "Bearer harness-secret"}, (
+            f"Hermes {method} did not propagate RAPID_MLX_API_KEY: {kwargs}"
+        )

--- a/tests/test_http_auth.py
+++ b/tests/test_http_auth.py
@@ -1,10 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for env-only authentication of local HTTP clients."""
 
+from pathlib import Path
 from unittest.mock import Mock, patch
 
 from vllm_mlx.agents.testing import AgentTestRunner
 from vllm_mlx.http_auth import rapid_mlx_auth_headers
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
 
 
 def test_auth_headers_are_empty_without_api_key(monkeypatch):
@@ -33,3 +36,28 @@ def test_harness_model_discovery_uses_same_bearer(monkeypatch):
         headers={"Authorization": "Bearer harness-secret"},
         timeout=5,
     )
+
+
+def test_langchain_integration_propagates_bearer_to_discovery_and_client():
+    """Keep both LangChain HTTP paths on the shared env-only auth contract."""
+    source = (
+        REPO_ROOT / "vllm_mlx" / "_integration_tests" / "test_langchain.py"
+    ).read_text()
+
+    assert "headers=auth_headers" in source
+    assert 'os.environ.get("RAPID_MLX_API_KEY") or "not-needed"' in source
+
+
+def test_hermes_cli_receives_process_scoped_auth_without_persisting_it():
+    """Keep the external Hermes CLI on the env-only auth contract."""
+    source = (
+        REPO_ROOT / "vllm_mlx" / "_integration_tests" / "test_hermes.py"
+    ).read_text()
+
+    assert 'env["OPENAI_API_KEY"] = api_key' in source
+    assert 'env["CUSTOM_API_KEY"] = api_key' in source
+    assert "env=_hermes_subprocess_env()" in source
+    config_block = source.split("def ensure_hermes_config", 1)[1].split(
+        "def _hermes_subprocess_env", 1
+    )[0]
+    assert "api_key" not in config_block


### PR DESCRIPTION
## What changed

- pass the shared `rapid_mlx_auth_headers()` bearer to every Hermes integration GET, POST, and stream request
- use the same bearer for LangChain model discovery and `ChatOpenAI`
- extend harness contract tests to pin authenticated requests

## Why

Attached harness runs failed because Hermes and LangChain ignored `RAPID_MLX_API_KEY`, even though the runner and other profiles supported authenticated Rapid-MLX servers. This produced profile-dependent false 401 failures.

Closes #1680.

## Validation

- `ruff format` and `ruff check` on all changed files
- `pytest -q tests/test_http_auth.py tests/test_hermes_harness_contract.py` — 5 passed
- Mini live authenticated Hermes smoke: no 401, 6/10 passed on LFM2.5 1B; remaining failures were model capability
- Mini live authenticated LangChain smoke: no 401, 5/6 passed on LFM2.5 1B; remaining failure was model capability