### PR TITLE
Fail closed after attached harness timeout

### DIFF
--- a/tests/test_bench_tier_harness.py
+++ b/tests/test_bench_tier_harness.py
@@ -545,6 +545,58 @@ def test_harness_timeout_forces_server_restart_isolation(capsys):
     )
 
 
+def test_attached_harness_timeout_stops_before_next_profile(capsys):
+    """An attached server cannot isolate an orphan, so fail closed."""
+    import threading
+
+    invocations: list[str] = []
+
+    def _runner_factory(profile, base_url, model_id=None, **kwargs):
+        invocations.append(profile.name)
+        runner = MagicMock()
+        if profile.name == "codex":
+            runner.run.side_effect = lambda: threading.Event().wait()
+        else:
+            runner.run.return_value = _make_fake_report()
+        return runner
+
+    def _fake_get_profile(name):
+        profile = MagicMock()
+        profile.name = name
+        profile.display_name = name.title()
+        return profile
+
+    class _FakeResp:
+        status = 200
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return None
+
+    with (
+        patch("urllib.request.urlopen", return_value=_FakeResp()),
+        patch("vllm_mlx.agents.get_profile", _fake_get_profile),
+        patch("vllm_mlx.agents.testing.AgentTestRunner", side_effect=_runner_factory),
+        patch("vllm_mlx.bench.tier_runner._health_check", return_value=True),
+        patch("vllm_mlx.bench.tier_runner.HARNESS_PROFILE_TIMEOUT_S", 1),
+    ):
+        rc = run_tier(
+            model="qwen3.5-4b-4bit",
+            tier="harness",
+            base_url="http://127.0.0.1:8000/v1",
+        )
+
+    assert invocations == ["codex"]
+    assert rc == 1
+    output = capsys.readouterr().out
+    assert "server isolation FAILED" in output
+    assert "not run: prior profile timed out" in output
+    for profile_name in HARNESS_PROFILES[1:]:
+        assert f"FAIL {profile_name}" in output
+
+
 def test_harness_restart_tears_down_old_server_before_booting_new(capsys):
     """Reboot must kill the current server BEFORE spawning the replacement.
 

--- a/vllm_mlx/bench/tier_runner.py
+++ b/vllm_mlx/bench/tier_runner.py
@@ -653,18 +653,16 @@ class _HarnessServerSession:
         race against the new profile's measurements / failure modes.
         Force a fresh server so the next profile starts on a clean slate.
 
-        No-op (returns ``(True, None)``) when we don't own the server —
-        we can't restart what the user is hosting, so the next profile
-        will simply contend with whatever ghost requests the orphan
-        emits. Surface a clear note in that case so the gauntlet
-        operator knows the next profile's numbers are suspect.
+        Returns ``False`` when we don't own the server. We cannot restart
+        what the user is hosting, so clean isolation cannot be restored;
+        the caller must stop the sweep instead of reporting subsequent
+        profiles whose measurements may be contaminated by the orphan.
         """
         if not self._owns:
             return (
-                True,
+                False,
                 "profile timed out and --base-url is attached — "
-                "subsequent profile measurements may be polluted by the "
-                "orphaned worker",
+                "cannot isolate subsequent profiles from the orphaned worker",
             )
         return self._restart()
 
@@ -944,7 +942,7 @@ def _run_harness(
     # profiles not in the active sweep. G12 (random-coverage) uses this
     # to scope to e.g. 2 of the 5 harnesses per (model × round) pick.
     profiles_to_run = HARNESS_PROFILES_FILTER or HARNESS_PROFILES
-    for profile_name in profiles_to_run:
+    for profile_index, profile_name in enumerate(profiles_to_run):
         profile = get_profile(profile_name)
         if profile is None:
             per_harness.append(
@@ -1018,6 +1016,21 @@ def _run_harness(
                         dur,
                         f"{base_detail} | server isolation FAILED: {suffix}",
                     )
+                # Do not manufacture results from a contaminated server.
+                # This is especially important in --base-url attach mode,
+                # where we cannot kill the timed-out profile's in-flight
+                # requests. Mark the untouched profiles explicitly and stop.
+                for remaining_name in profiles_to_run[profile_index + 1 :]:
+                    per_harness.append(
+                        (
+                            remaining_name,
+                            False,
+                            0.0,
+                            "not run: prior profile timed out and clean "
+                            "server isolation could not be restored",
+                        )
+                    )
+                break
 
     elapsed = time.perf_counter() - t0
     all_passed = all(ok for _, ok, _, _ in per_harness)


### PR DESCRIPTION
## Why

An attached harness profile can time out while its daemon worker keeps issuing requests to the externally managed server. Because bench cannot restart a server supplied through `--base-url`, continuing the sweep produces contaminated results for later profiles.

## What

- Treat inability to restart an attached server as an isolation failure.
- Stop the sweep immediately when clean isolation cannot be restored.
- Report every untouched profile explicitly as not run instead of presenting polluted measurements.
- Add a deterministic attached-server timeout regression test.

## Validation

- `ruff format` / `ruff check`
- 20/20 harness lifecycle tests
- 40/40 related harness/all/submit-combo tests

Closes #1679