### PR TITLE
fix(tools): make small-model tool loops release-safe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -271,25 +271,20 @@ jobs:
     # the expensive Studio gate: garbage-from-first-token (#1234 doubled-norm
     # class, via the #1247 GOLDEN gate) and tool-call parser regressions.
     #
-    # Matrix over two SMALL models from DIFFERENT families so the tool-call
-    # FORMAT check exercises two distinct parser paths — Qwen -> hermes and
-    # Llama -> the `<function=name>` LlamaToolParser — catching family-specific
-    # chat-template / parser breakage that a single-family smoke would miss.
+    # Two GOLDEN models run coherence + the engine contract. The remaining 4B
+    # aliases run contract-only: forcing a zero-argument call factors model
+    # competence out while still covering multi-turn replay, streaming channel
+    # routing, and native-marker leaks (#1677).
     # Each model runs on its own runner (parallel), so ~7GB RAM holds one ~2GB
     # model comfortably. A 3-4B model is fine for a coherence/parser gate — it
     # is not a chat-quality eval, which stays on the 35B L2 tier.
     #
-    # Why only these two families (not Gemma / Mistral too): their small
-    # checkpoints are multimodal. The broken Ministral-3 alias was retired after
-    # its default VLM route repeatedly hung (#1367). Gemma e2b now passes the
-    # coherence gate on M2/M3, but its historical macos-14/M1 0/6 result still
-    # needs a same-runner rerun before it becomes an always-on CI leg. The smoke
-    # script forces ``--no-mllm``, so adding a validated multimodal model later
-    # needs no install change.
+    # Gemma3 is multimodal but this contract is text/tool-only, so the smoke
+    # script forces ``--no-mllm`` and exercises its LM backbone without pulling
+    # the vision extra. Ministral remains out after its text lane hung (#1367).
     #
-    # Kept a standalone check (NOT folded into the required ``tests`` aggregate)
-    # so it can prove itself green on real PRs before a maintainer marks it a
-    # required check in branch protection — prove before enforce.
+    # The aggregate ``tests`` job requires this matrix, so a contract failure is
+    # release-blocking rather than an informational red check.
     runs-on: macos-14
     timeout-minutes: 20
     strategy:
@@ -297,9 +292,17 @@ jobs:
       # which families regressed, not just the first failure.
       fail-fast: false
       matrix:
-        model:
-          - qwen3.5-4b-4bit  # hermes tool-call parser
-          - llama3-3b-4bit  # llama `<function=name>` tool-call parser
+        include:
+          - model: qwen3.5-4b-4bit  # hermes parser + GOLDEN coherence
+            contract_only: "0"
+          - model: llama3-3b-4bit  # llama parser + GOLDEN coherence
+            contract_only: "0"
+          - model: gemma3-4b-qat-4bit  # #1677 excluded G12 4B tier
+            contract_only: "1"
+          - model: qwen3-4b-instruct-2507-4bit
+            contract_only: "1"
+          - model: qwen3-4b-thinking-2507-4bit
+            contract_only: "1"
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
@@ -332,13 +335,14 @@ jobs:
         # disk before the serve boot; no actions/cache needed.
         run: rapid-mlx pull "${{ matrix.model }}"
 
-      - name: L1 smoke (coherence + tool-call format)
+      - name: L1 smoke (coherence + tool-loop contract)
         env:
           RAPID_MLX_PORT: "8123"
+          L1_CONTRACT_ONLY: ${{ matrix.contract_only }}
         run: bash scripts/l1_smoke.sh "${{ matrix.model }}"
 
   tests:
-    needs: [test-matrix, test-apple-silicon]
+    needs: [test-matrix, test-apple-silicon, l1-smoke]
     runs-on: ubuntu-latest
     if: always()
     steps:
@@ -350,5 +354,9 @@ jobs:
           fi
           if [ "${{ needs.test-apple-silicon.result }}" != "success" ]; then
             echo "Apple Silicon tests failed"
+            exit 1
+          fi
+          if [ "${{ needs.l1-smoke.result }}" != "success" ]; then
+            echo "Small-model tool-loop contract failed"
             exit 1
           fi

--- a/docs/release-notes/unreleased.md
+++ b/docs/release-notes/unreleased.md
@@ -2,3 +2,10 @@
      version-bump PR, `git mv` this to vX.Y.Z.md and recreate this file empty.
      Whole-line HTML comments like this one are stripped before publishing.
      See README.md in this directory for what good notes look like. -->
+
+- Fixed DeepSeek-R1 tool-result replays returning HTTP 500 when its official
+  chat template expected JSON-string arguments, and removed native tool-wire
+  residue from forced-call content channels. The 4B release lane now validates
+  a deterministic forced call, streaming channel hygiene, and stream/non-stream
+  tool-result replay without treating small-model knowledge errors as engine
+  release failures (#1676, #1677).

--- a/scripts/l1_smoke.sh
+++ b/scripts/l1_smoke.sh
@@ -10,7 +10,7 @@
 # expensive Studio gate:
 #   * garbage-from-first-token (#1234 doubled-norm class) via the #1247 GOLDEN
 #     coherence gate, and
-#   * tool-call parser regressions via a forced-``tool_choice`` format assertion.
+#   * tool-loop parser/template regressions via a forced call and result replay.
 # Neither can run on the pure-CPU Linux CI (no Metal, no weights).
 #
 # Boots ``rapid-mlx serve <model>``, runs both checks, then tears down ONLY the
@@ -28,6 +28,8 @@
 #   PYTHON           python for the gate scripts (default: ``python3``)
 #   RAPID_MLX_PORT   serve port (default: 8123 — deliberately not :8000)
 #   L1_MODEL         model alias (overridden by the positional arg)
+#   L1_CONTRACT_ONLY  1 skips the model-quality coherence eval and runs only
+#                     the engine-owned tool-loop contract (default: 0)
 #
 # Exit code: 0 iff BOTH checks pass; non-zero blocks the PR.
 set -uo pipefail
@@ -36,6 +38,7 @@ RMLX="${RAPID_MLX:-rapid-mlx}"
 PY="${PYTHON:-python3}"
 ALIAS="${1:-${L1_MODEL:-qwen3.5-4b-4bit}}"
 PORT="${RAPID_MLX_PORT:-8123}"
+CONTRACT_ONLY="${L1_CONTRACT_ONLY:-0}"
 B="http://127.0.0.1:$PORT"
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 LOG="$(mktemp -t l1-serve.XXXXXX)"
@@ -84,15 +87,26 @@ for i in $(seq 1 60); do
   [ "$i" = 60 ] && { tail -30 "$LOG"; fail "serve not ready in 180s"; }
 done
 
-# ---- check 1/2: output coherence (#1247 GOLDEN, blocking) ----------------
-echo "== [1/2] coherence gate (#1247) =="
-RAPID_MLX_BASE_URL="$B/v1" "$PY" "$REPO_ROOT/evals/coherence_gate.py" \
-  --base-url "$B/v1" --timeout 90 \
-  || fail "coherence gate failed — served model gave a wrong/incoherent golden answer"
+if [ "$CONTRACT_ONLY" = "1" ]; then
+  echo "== [1/2] coherence gate [SKIPPED: engine-contract-only alias] =="
+else
+  # Model-quality coherence remains useful on the two validated GOLDEN aliases,
+  # but it is deliberately separate from #1677's engine contract: a Hermes3
+  # answering one arithmetic prompt incorrectly must not masquerade as an
+  # engine release regression.
+  echo "== [1/2] coherence gate (#1247) =="
+  RAPID_MLX_BASE_URL="$B/v1" "$PY" "$REPO_ROOT/evals/coherence_gate.py" \
+    --base-url "$B/v1" --timeout 90 \
+    || fail "coherence gate failed — served model gave a wrong/incoherent golden answer"
+fi
 
-# ---- check 2/2: tool-call format under forced tool_choice (blocking) -----
-echo "== [2/2] tool-call format =="
+# ---- check 2/2: forced tool-call + result replay contract (blocking) -----
+echo "== [2/2] small-model tool-loop contract =="
 "$PY" "$REPO_ROOT/scripts/l1_toolcall_check.py" --base-url "$B/v1" --timeout 90 \
-  || fail "tool-call format check failed — forced tool_choice did not yield a well-formed call"
+  || fail "tool-loop contract failed — forced call or tool-result replay broke"
 
-echo "L1-SMOKE PASS ($ALIAS): coherence + tool-call format OK"
+if [ "$CONTRACT_ONLY" = "1" ]; then
+  echo "L1-SMOKE PASS ($ALIAS): tool-loop engine contract OK"
+else
+  echo "L1-SMOKE PASS ($ALIAS): coherence + tool-loop contract OK"
+fi

--- a/scripts/l1_smoke.sh
+++ b/scripts/l1_smoke.sh
@@ -66,8 +66,10 @@ if curl -s -m 3 "$B/v1/models" >/dev/null 2>&1; then
 fi
 
 # ---- boot serve ----------------------------------------------------------
-# --no-thinking: the coherence gate measures answer coherence, not think-mode
-# behavior (its no-think-leak case still asserts no raw <think> tag leaks).
+# Keep the reasoning parser enabled at the server. The coherence requests set
+# ``enable_thinking=false`` themselves, while reasoning-distill models can
+# still emit ``<think>`` despite that preference; their parser must remain
+# available so raw wrappers/CoT never leak into the OpenAI content channel.
 #
 # --no-mllm: force the text-only mlx-lm lane. This gate only exercises the
 # TEXT coherence + tool-call parser paths, never vision, so the LM backbone is
@@ -78,7 +80,7 @@ fi
 # Ministral-3 alias hung there; Gemma e2b now passes on M2/M3 but its historical
 # M1 runner failure remains tracked in #1367. ``resolve_serving_lane`` maps
 # ``--no-mllm`` -> ``force_text`` -> the text lane, matching engine semantics.
-nohup "$RMLX" serve "$ALIAS" --port "$PORT" --no-thinking --no-mllm > "$LOG" 2>&1 &
+nohup "$RMLX" serve "$ALIAS" --port "$PORT" --no-mllm > "$LOG" 2>&1 &
 SERVE_PID=$!
 for i in $(seq 1 60); do
   curl -s -m 3 "$B/v1/models" 2>/dev/null | grep -q '"id"' && { echo "serve READY (~$((i * 3))s)"; break; }

--- a/scripts/l1_toolcall_check.py
+++ b/scripts/l1_toolcall_check.py
@@ -34,11 +34,11 @@ _TOOL = {
     "function": {
         "name": "release_probe",
         "description": "Return a fixed release-gate marker.",
-        "parameters": {
-            "type": "object",
-            "properties": {},
-            "additionalProperties": False,
-        },
+        # No required arguments: the gate measures structured transport and
+        # replay, not whether a small model follows an optional-argument hint.
+        # This is deliberately non-strict; ordinary OpenAI tool schemas do not
+        # decoder-constrain model output unless strict=true is requested.
+        "parameters": {"type": "object"},
     },
 }
 
@@ -113,8 +113,11 @@ def _validate_forced_stream(lines: list[str]) -> None:
     if name != "release_probe":
         raise ValueError(f"forced stream tool name is invalid: {name!r}")
     raw_arguments = "".join(streamed_calls[0]["arguments"])
-    if json.loads(raw_arguments) != {}:
-        raise ValueError(f"forced stream arguments are not {{}}: {raw_arguments!r}")
+    parsed_arguments = json.loads(raw_arguments)
+    if not isinstance(parsed_arguments, dict):
+        raise ValueError(
+            f"forced stream arguments are not a JSON object: {raw_arguments!r}"
+        )
     leaked = _visible_wire_marker("".join(visible_chunks))
     if leaked:
         raise ValueError(f"native wire marker leaked into stream: {leaked!r}")
@@ -151,9 +154,10 @@ def main() -> int:
         "model": "default",
         "messages": [{"role": "user", "content": "Call release_probe now."}],
         "tools": [_TOOL],
-        # A named zero-argument call factors model competence out completely:
+        # A named call with no required arguments factors model competence out:
         # the engine need not invent a required value before it can prove the
-        # parser/template contract.
+        # parser/template contract. Optional model-generated fields are fine;
+        # the exact assistant call is replayed below.
         "tool_choice": {
             "type": "function",
             "function": {"name": "release_probe"},

--- a/scripts/l1_toolcall_check.py
+++ b/scripts/l1_toolcall_check.py
@@ -1,23 +1,24 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0
-"""L1 tool-call FORMAT check — assert a forced ``tool_choice`` yields a
-well-formed tool call.
+"""L1 small-model tool-loop contract check.
 
 This guards the tool-call *plumbing*, not the small model's discretion to call
-a tool. ``tool_choice="required"`` with a single tool forces the call via a
-grammar-constrained forced-function prefix (see ``vllm_mlx/routes/chat.py``), so
+a tool. A named ``tool_choice`` forces the call via a grammar-constrained
+forced-function prefix (see ``vllm_mlx/routes/chat.py``), so
 the result is deterministic at temperature 0 — the check measures whether the
-server emits a structurally valid ``tool_calls`` entry (function name present,
-arguments parseable as a JSON object), the class of regression where a model
-emits a call but the parser mangles it into free text or breaks the JSON args.
+server emits a structurally valid ``tool_calls`` entry and can render that call
+plus its ``role=tool`` result on the next turn in both non-streaming and
+streaming modes.  The replay catches chat-template shape regressions that only
+appear after a successful call (for example #1676's DeepSeek-R1 ``str + dict``
+500), while deliberately making no assertion about the small model's answer.
 
 Companion to ``evals/coherence_gate.py``; both are driven by
 ``scripts/l1_smoke.sh`` on the free macos-14 L1 runner. Requires a
 ``rapid-mlx serve`` already listening — it does not boot one.
 
 Exit codes:
-    0 — a well-formed forced tool call came back
-    1 — no/malformed tool call, or the server was unreachable
+    0 — forced call plus streaming/non-streaming tool-result replay succeeded
+    1 — malformed call, replay failure, or the server was unreachable
 """
 
 from __future__ import annotations
@@ -31,17 +32,35 @@ import httpx
 _TOOL = {
     "type": "function",
     "function": {
-        "name": "get_weather",
-        "description": "Get the current weather for a city.",
+        "name": "release_probe",
+        "description": "Return a fixed release-gate marker.",
         "parameters": {
             "type": "object",
-            "properties": {
-                "location": {"type": "string", "description": "City name, e.g. Paris"}
-            },
-            "required": ["location"],
+            "properties": {},
+            "additionalProperties": False,
         },
     },
 }
+
+_WIRE_MARKERS = (
+    "<tool_call",
+    "<toolcall",
+    "<｜tool▁call",
+    "<｜tool▁sep｜>",
+    "[TOOL_CALLS]",
+    "<think>",
+    "</think>",
+)
+
+
+def _visible_wire_marker(text: str) -> str | None:
+    return next((marker for marker in _WIRE_MARKERS if marker in text), None)
+
+
+def _error_detail(exc: Exception) -> str:
+    if isinstance(exc, httpx.HTTPStatusError):
+        return f"; body={exc.response.text[:500]}"
+    return ""
 
 
 def main() -> int:
@@ -52,13 +71,15 @@ def main() -> int:
 
     body = {
         "model": "default",
-        "messages": [
-            {"role": "user", "content": "What is the weather in Paris? Use the tool."}
-        ],
+        "messages": [{"role": "user", "content": "Call release_probe now."}],
         "tools": [_TOOL],
-        # Single tool + "required" => forced call, grammar-constrained. Makes the
-        # FORMAT deterministic regardless of a small model's tool-calling mood.
-        "tool_choice": "required",
+        # A named zero-argument call factors model competence out completely:
+        # the engine need not invent a required value before it can prove the
+        # parser/template contract.
+        "tool_choice": {
+            "type": "function",
+            "function": {"name": "release_probe"},
+        },
         "max_tokens": 128,
         "temperature": 0.0,
         "stream": False,
@@ -97,8 +118,8 @@ def main() -> int:
 
     fn = (calls[0] or {}).get("function") or {}
     name = fn.get("name")
-    if name != "get_weather":
-        print(f"FAIL: tool name {name!r} != 'get_weather'", file=sys.stderr)
+    if name != "release_probe":
+        print(f"FAIL: tool name {name!r} != 'release_probe'", file=sys.stderr)
         return 1
 
     raw_args = fn.get("arguments")
@@ -129,7 +150,101 @@ def main() -> int:
         )
         return 1
 
-    print(f"PASS: well-formed forced tool_call get_weather(arguments={parsed})")
+    visible = f"{msg.get('content') or ''}\n{msg.get('reasoning_content') or ''}"
+    leaked = _visible_wire_marker(visible)
+    if leaked:
+        print(
+            f"FAIL: native wire marker leaked into non-stream content: {leaked!r}",
+            file=sys.stderr,
+        )
+        return 1
+
+    endpoint = f"{args.base_url.rstrip('/')}/chat/completions"
+    try:
+        with httpx.stream(
+            "POST", endpoint, json={**body, "stream": True}, timeout=args.timeout
+        ) as forced_stream:
+            forced_stream.raise_for_status()
+            forced_lines = [
+                line for line in forced_stream.iter_lines() if line.startswith("data:")
+            ]
+        forced_wire = "\n".join(forced_lines)
+        if '"tool_calls"' not in forced_wire:
+            raise ValueError("forced stream returned no tool_calls delta")
+        if not forced_lines or forced_lines[-1].strip() != "data: [DONE]":
+            raise ValueError("forced stream did not terminate with data: [DONE]")
+        leaked = _visible_wire_marker(forced_wire)
+        if leaked:
+            raise ValueError(f"native wire marker leaked into stream: {leaked!r}")
+    except Exception as exc:
+        print(
+            f"FAIL: streaming forced-call error: {exc}{_error_detail(exc)}",
+            file=sys.stderr,
+        )
+        return 1
+
+    # Replay the exact OpenAI-wire assistant message returned by the server.
+    # This is the important second half of the contract: templates differ on
+    # whether historical arguments must be a mapping or JSON text, and the
+    # first turn cannot expose that mismatch.
+    call_id = (calls[0] or {}).get("id")
+    if not isinstance(call_id, str) or not call_id:
+        print(f"FAIL: tool call has no string id: {calls[0]!r}", file=sys.stderr)
+        return 1
+    replay_messages = [
+        body["messages"][0],
+        msg,
+        {
+            "role": "tool",
+            "tool_call_id": call_id,
+            "name": "release_probe",
+            "content": "RELEASE_PROBE_OK",
+        },
+        {"role": "user", "content": "Acknowledge the completed probe."},
+    ]
+
+    replay = {
+        "model": "default",
+        "messages": replay_messages,
+        "tools": [_TOOL],
+        "tool_choice": "auto",
+        "max_tokens": 32,
+        "temperature": 0.0,
+    }
+    try:
+        nonstream = httpx.post(
+            endpoint, json={**replay, "stream": False}, timeout=args.timeout
+        )
+        nonstream.raise_for_status()
+        nonstream_data = nonstream.json()
+        if not (nonstream_data.get("choices") or []):
+            raise ValueError("non-stream replay returned no choices")
+
+        with httpx.stream(
+            "POST",
+            endpoint,
+            json={**replay, "stream": True},
+            timeout=args.timeout,
+        ) as stream_response:
+            stream_response.raise_for_status()
+            stream_lines = [
+                line
+                for line in stream_response.iter_lines()
+                if line.startswith("data:")
+            ]
+        if not stream_lines or stream_lines[-1].strip() != "data: [DONE]":
+            raise ValueError("stream replay did not terminate with data: [DONE]")
+    except Exception as exc:
+        print(
+            f"FAIL: tool-result replay error: {exc}{_error_detail(exc)}",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        "PASS: forced release_probe tool_call + tool-result replay "
+        "(non-stream + stream)"
+    )
     return 0
 
 

--- a/scripts/l1_toolcall_check.py
+++ b/scripts/l1_toolcall_check.py
@@ -63,6 +63,74 @@ def _error_detail(exc: Exception) -> str:
     return ""
 
 
+def _sse_payloads(lines: list[str]) -> list[dict]:
+    payloads = []
+    for line in lines:
+        if not line.startswith("data:"):
+            continue
+        raw = line.removeprefix("data:").strip()
+        if raw == "[DONE]":
+            continue
+        payload = json.loads(raw)
+        if not isinstance(payload, dict):
+            raise ValueError("SSE payload is not a JSON object")
+        payloads.append(payload)
+    return payloads
+
+
+def _validate_forced_stream(lines: list[str]) -> None:
+    if not lines or lines[-1].strip() != "data: [DONE]":
+        raise ValueError("forced stream did not terminate with data: [DONE]")
+    names: list[str] = []
+    argument_chunks: list[str] = []
+    saw_tool_delta = False
+    visible_chunks: list[str] = []
+    for payload in _sse_payloads(lines):
+        for choice in payload.get("choices") or []:
+            delta = choice.get("delta") or {}
+            visible_chunks.extend(
+                str(delta.get(key) or "") for key in ("content", "reasoning_content")
+            )
+            for tool_call in delta.get("tool_calls") or []:
+                saw_tool_delta = True
+                function = tool_call.get("function") or {}
+                if function.get("name"):
+                    names.append(function["name"])
+                if function.get("arguments") is not None:
+                    argument_chunks.append(str(function["arguments"]))
+    if not saw_tool_delta:
+        raise ValueError("forced stream returned no structured tool_calls delta")
+    if names != ["release_probe"]:
+        raise ValueError(f"forced stream tool name is invalid: {names!r}")
+    raw_arguments = "".join(argument_chunks)
+    if json.loads(raw_arguments) != {}:
+        raise ValueError(f"forced stream arguments are not {{}}: {raw_arguments!r}")
+    leaked = _visible_wire_marker("".join(visible_chunks))
+    if leaked:
+        raise ValueError(f"native wire marker leaked into stream: {leaked!r}")
+
+
+def _validate_replay_stream(lines: list[str]) -> None:
+    if not lines or lines[-1].strip() != "data: [DONE]":
+        raise ValueError("stream replay did not terminate with data: [DONE]")
+    saw_choice_delta = False
+    visible_chunks: list[str] = []
+    for payload in _sse_payloads(lines):
+        for choice in payload.get("choices") or []:
+            delta = choice.get("delta")
+            if not isinstance(delta, dict):
+                continue
+            saw_choice_delta = True
+            visible_chunks.extend(
+                str(delta.get(key) or "") for key in ("content", "reasoning_content")
+            )
+    if not saw_choice_delta:
+        raise ValueError("stream replay returned no choice delta")
+    leaked = _visible_wire_marker("".join(visible_chunks))
+    if leaked:
+        raise ValueError(f"native wire marker leaked into replay stream: {leaked!r}")
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--base-url", default="http://127.0.0.1:8123/v1")
@@ -168,14 +236,7 @@ def main() -> int:
             forced_lines = [
                 line for line in forced_stream.iter_lines() if line.startswith("data:")
             ]
-        forced_wire = "\n".join(forced_lines)
-        if '"tool_calls"' not in forced_wire:
-            raise ValueError("forced stream returned no tool_calls delta")
-        if not forced_lines or forced_lines[-1].strip() != "data: [DONE]":
-            raise ValueError("forced stream did not terminate with data: [DONE]")
-        leaked = _visible_wire_marker(forced_wire)
-        if leaked:
-            raise ValueError(f"native wire marker leaked into stream: {leaked!r}")
+        _validate_forced_stream(forced_lines)
     except Exception as exc:
         print(
             f"FAIL: streaming forced-call error: {exc}{_error_detail(exc)}",
@@ -232,8 +293,7 @@ def main() -> int:
                 for line in stream_response.iter_lines()
                 if line.startswith("data:")
             ]
-        if not stream_lines or stream_lines[-1].strip() != "data: [DONE]":
-            raise ValueError("stream replay did not terminate with data: [DONE]")
+        _validate_replay_stream(stream_lines)
     except Exception as exc:
         print(
             f"FAIL: tool-result replay error: {exc}{_error_detail(exc)}",

--- a/scripts/l1_toolcall_check.py
+++ b/scripts/l1_toolcall_check.py
@@ -81,8 +81,7 @@ def _sse_payloads(lines: list[str]) -> list[dict]:
 def _validate_forced_stream(lines: list[str]) -> None:
     if not lines or lines[-1].strip() != "data: [DONE]":
         raise ValueError("forced stream did not terminate with data: [DONE]")
-    names: list[str] = []
-    argument_chunks: list[str] = []
+    streamed_calls: dict[int, dict[str, list[str]]] = {}
     saw_tool_delta = False
     visible_chunks: list[str] = []
     for payload in _sse_payloads(lines):
@@ -93,16 +92,27 @@ def _validate_forced_stream(lines: list[str]) -> None:
             )
             for tool_call in delta.get("tool_calls") or []:
                 saw_tool_delta = True
+                index = tool_call.get("index", 0)
+                if not isinstance(index, int):
+                    raise ValueError(f"streamed tool-call index is invalid: {index!r}")
+                fragments = streamed_calls.setdefault(
+                    index, {"name": [], "arguments": []}
+                )
                 function = tool_call.get("function") or {}
-                if function.get("name"):
-                    names.append(function["name"])
+                if function.get("name") is not None:
+                    fragments["name"].append(str(function["name"]))
                 if function.get("arguments") is not None:
-                    argument_chunks.append(str(function["arguments"]))
+                    fragments["arguments"].append(str(function["arguments"]))
     if not saw_tool_delta:
         raise ValueError("forced stream returned no structured tool_calls delta")
-    if names != ["release_probe"]:
-        raise ValueError(f"forced stream tool name is invalid: {names!r}")
-    raw_arguments = "".join(argument_chunks)
+    if set(streamed_calls) != {0}:
+        raise ValueError(
+            f"forced stream tool-call indexes are invalid: {streamed_calls!r}"
+        )
+    name = "".join(streamed_calls[0]["name"])
+    if name != "release_probe":
+        raise ValueError(f"forced stream tool name is invalid: {name!r}")
+    raw_arguments = "".join(streamed_calls[0]["arguments"])
     if json.loads(raw_arguments) != {}:
         raise ValueError(f"forced stream arguments are not {{}}: {raw_arguments!r}")
     leaked = _visible_wire_marker("".join(visible_chunks))
@@ -278,8 +288,21 @@ def main() -> int:
         )
         nonstream.raise_for_status()
         nonstream_data = nonstream.json()
-        if not (nonstream_data.get("choices") or []):
+        nonstream_choices = nonstream_data.get("choices") or []
+        if not nonstream_choices:
             raise ValueError("non-stream replay returned no choices")
+        replay_message = nonstream_choices[0].get("message")
+        if not isinstance(replay_message, dict):
+            raise ValueError("non-stream replay returned no message object")
+        replay_visible = "\n".join(
+            str(replay_message.get(key) or "")
+            for key in ("content", "reasoning_content")
+        )
+        leaked = _visible_wire_marker(replay_visible)
+        if leaked:
+            raise ValueError(
+                f"native wire marker leaked into non-stream replay: {leaked!r}"
+            )
 
         with httpx.stream(
             "POST",

--- a/tests/test_chat_template_tool_call_arguments.py
+++ b/tests/test_chat_template_tool_call_arguments.py
@@ -39,6 +39,12 @@ from unittest.mock import MagicMock
 
 import pytest
 
+# The minimal PR-validation environment intentionally omits optional template
+# dependencies. These tests exercise real Jinja rendering, so absence of Jinja
+# means the environment cannot execute the contract (rather than a product
+# failure). Full unit/L1 CI installs it and executes this module normally.
+pytest.importorskip("jinja2")
+
 from vllm_mlx.utils.chat_template import (
     _normalize_assistant_tool_call_arguments,
     apply_chat_template,
@@ -730,6 +736,37 @@ def test_gemma_alternating_template_replays_openai_tool_history():
     assert "Tool result call_1: sunny, 22C in Paris" in prompt
     assert "and tomorrow?" in prompt
     assert "tool:" not in prompt
+
+
+def test_alternating_fallback_after_unsupported_template_kwarg():
+    """A keyword retry must not bypass the strict-role compatibility path."""
+    tokenizer = _fake_tokenizer_with_template(ALTERNATING_ONLY_TEMPLATE)
+    render = tokenizer.apply_chat_template.side_effect
+
+    def reject_enable_thinking(messages, **kwargs):
+        if "enable_thinking" in kwargs:
+            raise TypeError(
+                "apply_chat_template() got an unexpected keyword argument "
+                "'enable_thinking'"
+            )
+        return render(messages, **kwargs)
+
+    tokenizer.apply_chat_template.side_effect = reject_enable_thinking
+    prompt = apply_chat_template(
+        tokenizer,
+        _messages_with_assistant_tool_call('{"city":"Paris"}'),
+        tools=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "parameters": {"type": "object"},
+                },
+            }
+        ],
+    )
+    assert 'Tool call get_weather: {"city":"Paris"}' in prompt
+    assert "Tool result call_1: sunny, 22C in Paris" in prompt
 
 
 def test_unrelated_template_error_is_not_hidden():

--- a/tests/test_chat_template_tool_call_arguments.py
+++ b/tests/test_chat_template_tool_call_arguments.py
@@ -39,12 +39,6 @@ from unittest.mock import MagicMock
 
 import pytest
 
-# The minimal PR-validation environment intentionally omits optional template
-# dependencies. These tests exercise real Jinja rendering, so absence of Jinja
-# means the environment cannot execute the contract (rather than a product
-# failure). Full unit/L1 CI installs it and executes this module normally.
-pytest.importorskip("jinja2")
-
 from vllm_mlx.utils.chat_template import (
     _normalize_assistant_tool_call_arguments,
     apply_chat_template,
@@ -294,7 +288,10 @@ def _fake_tokenizer_with_template(chat_template_str: str) -> MagicMock:
     lists), so the sanitisation layer and the tool-call normalisation layer
     both run end-to-end.
     """
-    import jinja2
+    # The minimal PR-validation environment intentionally omits optional
+    # template dependencies. Helper-level normalisation tests above remain
+    # runnable there; only real rendering cases skip when Jinja is unavailable.
+    jinja2 = pytest.importorskip("jinja2")
 
     env = jinja2.Environment(  # noqa: S701 - test scaffolding
         keep_trailing_newline=True,
@@ -704,6 +701,29 @@ def test_deepseek_r1_retry_accepts_internal_dict_arguments():
         tokenizer, _messages_with_assistant_tool_call({"city": "東京"})
     )
     assert '{"city":"東京"}' in prompt
+
+
+def test_deepseek_serialized_retry_survives_unsupported_kwarg():
+    """The serialized candidate must survive later kwarg compatibility retries."""
+    tokenizer = _fake_tokenizer_with_template(DEEPSEEK_R1_LIKE_TEMPLATE)
+    render = tokenizer.apply_chat_template.side_effect
+    calls = 0
+
+    def concat_then_reject_kwarg(messages, **kwargs):
+        nonlocal calls
+        calls += 1
+        if calls > 1 and "enable_thinking" in kwargs:
+            raise TypeError(
+                "apply_chat_template() got an unexpected keyword argument "
+                "'enable_thinking'"
+            )
+        return render(messages, **kwargs)
+
+    tokenizer.apply_chat_template.side_effect = concat_then_reject_kwarg
+    prompt = apply_chat_template(
+        tokenizer, _messages_with_assistant_tool_call('{"city":"Paris"}')
+    )
+    assert 'get_weather\n```json\n{"city":"Paris"}\n```' in prompt
 
 
 ALTERNATING_ONLY_TEMPLATE = r"""

--- a/tests/test_chat_template_tool_call_arguments.py
+++ b/tests/test_chat_template_tool_call_arguments.py
@@ -34,6 +34,7 @@ mlx-lm model weights, so this suite runs in unit CI.
 
 from __future__ import annotations
 
+import copy
 from unittest.mock import MagicMock
 
 import pytest
@@ -293,6 +294,9 @@ def _fake_tokenizer_with_template(chat_template_str: str) -> MagicMock:
         keep_trailing_newline=True,
         trim_blocks=True,
         lstrip_blocks=True,
+    )
+    env.globals["raise_exception"] = lambda message: (_ for _ in ()).throw(
+        jinja2.TemplateError(message)
     )
     template = env.from_string(chat_template_str)
 
@@ -656,3 +660,81 @@ def test_pydantic_ai_style_retry_message_list_does_not_crash():
     prompt = apply_chat_template(tokenizer, messages)
     assert "name=Alice" in prompt
     assert "age=30" in prompt
+
+
+DEEPSEEK_R1_LIKE_TEMPLATE = r"""
+{%- for message in messages %}
+  {%- if message.role == 'assistant' and message.tool_calls is defined %}
+    {%- for tool in message.tool_calls %}
+      {{ tool.function.name + '\n```json\n' + tool.function.arguments + '\n```' }}
+    {%- endfor %}
+  {%- elif message.content is defined %}{{ message.content }}
+  {%- endif %}
+{%- endfor %}
+"""
+
+
+def test_deepseek_r1_string_concat_template_replays_tool_result():
+    """#1676: DeepSeek-R1's official template requires JSON strings.
+
+    The shared normaliser first converts OpenAI-wire strings to mappings for
+    Qwen/Hermes-style templates.  The exact string-concatenation TypeError must
+    trigger the compatibility retry rather than escape as an HTTP 500 on the
+    tool-result turn.
+    """
+    tokenizer = _fake_tokenizer_with_template(DEEPSEEK_R1_LIKE_TEMPLATE)
+    messages = _messages_with_assistant_tool_call('{"city": "Paris"}')
+    original = copy.deepcopy(messages)
+
+    prompt = apply_chat_template(tokenizer, messages)
+
+    assert 'get_weather\n```json\n{"city":"Paris"}\n```' in prompt
+    assert messages == original
+
+
+def test_deepseek_r1_retry_accepts_internal_dict_arguments():
+    tokenizer = _fake_tokenizer_with_template(DEEPSEEK_R1_LIKE_TEMPLATE)
+    prompt = apply_chat_template(
+        tokenizer, _messages_with_assistant_tool_call({"city": "東京"})
+    )
+    assert '{"city":"東京"}' in prompt
+
+
+ALTERNATING_ONLY_TEMPLATE = r"""
+{%- set loop_messages = messages[1:] if messages and messages[0].role == 'system' else messages -%}
+{%- for message in loop_messages %}
+  {%- if (message.role == 'user') != (loop.index0 % 2 == 0) -%}
+    {{ raise_exception('Conversation roles must alternate user/assistant/user/assistant/...') }}
+  {%- endif -%}
+  {{ message.role + ': ' + message.get('content', '') + '\n' }}
+{%- endfor %}
+"""
+
+
+def test_gemma_alternating_template_replays_openai_tool_history():
+    tokenizer = _fake_tokenizer_with_template(ALTERNATING_ONLY_TEMPLATE)
+    prompt = apply_chat_template(
+        tokenizer,
+        _messages_with_assistant_tool_call('{"city":"Paris"}'),
+        tools=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "parameters": {"type": "object"},
+                },
+            }
+        ],
+    )
+    assert 'Tool call get_weather: {"city":"Paris"}' in prompt
+    assert "Tool result call_1: sunny, 22C in Paris" in prompt
+    assert "and tomorrow?" in prompt
+    assert "tool:" not in prompt
+
+
+def test_unrelated_template_error_is_not_hidden():
+    tokenizer = _fake_tokenizer_with_template(
+        "{{ raise_exception('different template failure') }}"
+    )
+    with pytest.raises(Exception, match="different template failure"):
+        apply_chat_template(tokenizer, _messages_with_assistant_tool_call("{}"))

--- a/tests/test_l1_toolcall_check.py
+++ b/tests/test_l1_toolcall_check.py
@@ -61,8 +61,8 @@ def test_gate_replays_tool_result_in_both_modes(monkeypatch):
         [
             _Response(
                 lines=[
-                    'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"name":"release_","arguments":"{"}}]}}]}',
-                    'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"name":"probe","arguments":"}"}}]}}]}',
+                    'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"name":"release_","arguments":"{\\"prompt\\":"}}]}}]}',
+                    'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"name":"probe","arguments":"\\"inspect\\"}"}}]}}]}',
                     "data: [DONE]",
                 ]
             ),

--- a/tests/test_l1_toolcall_check.py
+++ b/tests/test_l1_toolcall_check.py
@@ -51,12 +51,18 @@ def _forced_payload():
 
 def test_gate_replays_tool_result_in_both_modes(monkeypatch):
     requests = []
-    posts = iter([_Response(_forced_payload()), _Response({"choices": [{}]})])
+    posts = iter(
+        [
+            _Response(_forced_payload()),
+            _Response({"choices": [{"message": {"content": "ack"}}]}),
+        ]
+    )
     streams = iter(
         [
             _Response(
                 lines=[
-                    'data: {"choices":[{"delta":{"tool_calls":[{"function":{"name":"release_probe","arguments":"{}"}}]}}]}',
+                    'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"name":"release_","arguments":"{"}}]}}]}',
+                    'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"name":"probe","arguments":"}"}}]}}]}',
                     "data: [DONE]",
                 ]
             ),
@@ -104,7 +110,12 @@ def test_gate_replays_tool_result_in_both_modes(monkeypatch):
 
 
 def test_gate_fails_closed_when_stream_replay_has_no_done(monkeypatch):
-    posts = iter([_Response(_forced_payload()), _Response({"choices": [{}]})])
+    posts = iter(
+        [
+            _Response(_forced_payload()),
+            _Response({"choices": [{"message": {"content": "ack"}}]}),
+        ]
+    )
     streams = iter(
         [
             _Response(
@@ -114,6 +125,25 @@ def test_gate_fails_closed_when_stream_replay_has_no_done(monkeypatch):
                 ]
             ),
             _Response(lines=["data: {}"]),
+        ]
+    )
+    monkeypatch.setattr(gate.httpx, "post", lambda *args, **kwargs: next(posts))
+    monkeypatch.setattr(gate.httpx, "stream", lambda *args, **kwargs: next(streams))
+    monkeypatch.setattr(sys, "argv", ["l1_toolcall_check.py"])
+
+    assert gate.main() == 1
+
+
+def test_gate_fails_closed_when_nonstream_replay_has_no_message(monkeypatch):
+    posts = iter([_Response(_forced_payload()), _Response({"choices": [{}]})])
+    streams = iter(
+        [
+            _Response(
+                lines=[
+                    'data: {"choices":[{"delta":{"tool_calls":[{"function":{"name":"release_probe","arguments":"{}"}}]}}]}',
+                    "data: [DONE]",
+                ]
+            )
         ]
     )
     monkeypatch.setattr(gate.httpx, "post", lambda *args, **kwargs: next(posts))

--- a/tests/test_l1_toolcall_check.py
+++ b/tests/test_l1_toolcall_check.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import sys
+
+from scripts import l1_toolcall_check as gate
+
+
+class _Response:
+    def __init__(self, payload=None, lines=None):
+        self._payload = payload
+        self._lines = lines or []
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self._payload
+
+    def iter_lines(self):
+        return iter(self._lines)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+
+def _forced_payload():
+    return {
+        "choices": [
+            {
+                "message": {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "call_probe",
+                            "type": "function",
+                            "function": {
+                                "name": "release_probe",
+                                "arguments": "{}",
+                            },
+                        }
+                    ],
+                }
+            }
+        ]
+    }
+
+
+def test_gate_replays_tool_result_in_both_modes(monkeypatch):
+    posts = iter([_Response(_forced_payload()), _Response({"choices": [{}]})])
+    streams = iter(
+        [
+            _Response(
+                lines=[
+                    'data: {"choices":[{"delta":{"tool_calls":[{}]}}]}',
+                    "data: [DONE]",
+                ]
+            ),
+            _Response(lines=["data: {}", "data: [DONE]"]),
+        ]
+    )
+    monkeypatch.setattr(gate.httpx, "post", lambda *args, **kwargs: next(posts))
+    monkeypatch.setattr(gate.httpx, "stream", lambda *args, **kwargs: next(streams))
+    monkeypatch.setattr(sys, "argv", ["l1_toolcall_check.py"])
+
+    assert gate.main() == 0
+
+
+def test_gate_fails_closed_when_stream_replay_has_no_done(monkeypatch):
+    posts = iter([_Response(_forced_payload()), _Response({"choices": [{}]})])
+    streams = iter(
+        [
+            _Response(
+                lines=[
+                    'data: {"choices":[{"delta":{"tool_calls":[{}]}}]}',
+                    "data: [DONE]",
+                ]
+            ),
+            _Response(lines=["data: {}"]),
+        ]
+    )
+    monkeypatch.setattr(gate.httpx, "post", lambda *args, **kwargs: next(posts))
+    monkeypatch.setattr(gate.httpx, "stream", lambda *args, **kwargs: next(streams))
+    monkeypatch.setattr(sys, "argv", ["l1_toolcall_check.py"])
+
+    assert gate.main() == 1

--- a/tests/test_l1_toolcall_check.py
+++ b/tests/test_l1_toolcall_check.py
@@ -50,23 +50,57 @@ def _forced_payload():
 
 
 def test_gate_replays_tool_result_in_both_modes(monkeypatch):
+    requests = []
     posts = iter([_Response(_forced_payload()), _Response({"choices": [{}]})])
     streams = iter(
         [
             _Response(
                 lines=[
-                    'data: {"choices":[{"delta":{"tool_calls":[{}]}}]}',
+                    'data: {"choices":[{"delta":{"tool_calls":[{"function":{"name":"release_probe","arguments":"{}"}}]}}]}',
                     "data: [DONE]",
                 ]
             ),
-            _Response(lines=["data: {}", "data: [DONE]"]),
+            _Response(
+                lines=[
+                    'data: {"choices":[{"delta":{"content":"ack"}}]}',
+                    "data: [DONE]",
+                ]
+            ),
         ]
     )
-    monkeypatch.setattr(gate.httpx, "post", lambda *args, **kwargs: next(posts))
-    monkeypatch.setattr(gate.httpx, "stream", lambda *args, **kwargs: next(streams))
+
+    def fake_post(*args, **kwargs):
+        requests.append(("post", kwargs["json"]))
+        return next(posts)
+
+    def fake_stream(*args, **kwargs):
+        requests.append(("stream", kwargs["json"]))
+        return next(streams)
+
+    monkeypatch.setattr(gate.httpx, "post", fake_post)
+    monkeypatch.setattr(gate.httpx, "stream", fake_stream)
     monkeypatch.setattr(sys, "argv", ["l1_toolcall_check.py"])
 
     assert gate.main() == 0
+    assert [request[1]["stream"] for request in requests] == [False, True, False, True]
+    for _, replay in requests[2:]:
+        messages = replay["messages"]
+        assistant = messages[1]
+        result = messages[2]
+        assert (
+            assistant["tool_calls"]
+            == _forced_payload()["choices"][0]["message"]["tool_calls"]
+        )
+        assert result == {
+            "role": "tool",
+            "tool_call_id": "call_probe",
+            "name": "release_probe",
+            "content": "RELEASE_PROBE_OK",
+        }
+        assert messages[3] == {
+            "role": "user",
+            "content": "Acknowledge the completed probe.",
+        }
 
 
 def test_gate_fails_closed_when_stream_replay_has_no_done(monkeypatch):
@@ -75,7 +109,7 @@ def test_gate_fails_closed_when_stream_replay_has_no_done(monkeypatch):
         [
             _Response(
                 lines=[
-                    'data: {"choices":[{"delta":{"tool_calls":[{}]}}]}',
+                    'data: {"choices":[{"delta":{"tool_calls":[{"function":{"name":"release_probe","arguments":"{}"}}]}}]}',
                     "data: [DONE]",
                 ]
             ),

--- a/tests/test_tool_choice_enforcement.py
+++ b/tests/test_tool_choice_enforcement.py
@@ -59,6 +59,7 @@ from vllm_mlx.routes.chat import (
     _recover_partial_tool_args,
     _scrub_tool_wire_literals,
     _scrub_visible_tool_wire_leaks,
+    _strip_forced_tool_section,
     _synthesize_forced_tool_call,
 )
 from vllm_mlx.routes.chat import router as chat_router
@@ -1414,6 +1415,25 @@ def test_codex_r13_visible_scrub_skips_broken_deepseek_begin_then_scrubs_payload
     assert "get_weather" not in out
     assert '"arguments"' not in out
     assert "suffix" in out
+
+
+def test_1676_forced_deepseek_section_is_removed_from_visible_channels():
+    fullwidth = (
+        "narration\n<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>"
+        "function<｜tool▁sep｜>release_probe\n```json\n{}\n```"
+    )
+    compact = (
+        "<toolcallsbegin>\n<toolcallbegin>function<toolsep>release_probe"
+        "</function>\n<argument>now</argument>"
+    )
+    assert _strip_forced_tool_section(fullwidth) == "narration"
+    assert _strip_forced_tool_section(compact) == ""
+    assert _strip_forced_tool_section("<think>") == ""
+
+
+def test_1676_literal_deepseek_marker_mention_is_preserved():
+    prose = "Explain the literal <｜tool▁calls▁begin｜> marker to me."
+    assert _strip_forced_tool_section(prose) == prose
 
 
 def test_codex_r11_broad_scrub_does_not_cross_family_strip_marker_prose():

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -2680,6 +2680,39 @@ def _scrub_visible_tool_wire_leaks(text: str | None) -> str:
     return re.sub(r"\s+", " ", result).strip()
 
 
+_FORCED_TOOL_SECTION_RE = re.compile(
+    r"(?:"
+    r"<｜tool▁calls▁begin｜>\s*<｜tool▁call▁begin｜>"
+    r"|<toolcallsbegin>\s*<toolcallbegin>"
+    r")",
+    re.DOTALL,
+)
+
+
+def _strip_forced_tool_section(text: str | None) -> str:
+    """Remove a structurally unmistakable native tool section.
+
+    DeepSeek-R1 distills can emit one valid call followed by a malformed,
+    truncated duplicate.  The parser correctly recovers the valid structured
+    call but intentionally returns the raw text for diagnostics, which leaks
+    the native section into ``content`` and — after reasoning extraction — into
+    ``reasoning_content``.  A paired section+call opener is stronger evidence
+    than a literal marker mention in prose, so truncate only at that sequence
+    and preserve any narration before it.  The compact spelling is produced by
+    Qwen-tokenizer decoding of the same fullwidth DeepSeek markers.
+    """
+    if not text:
+        return text or ""
+    match = _FORCED_TOOL_SECTION_RE.search(text)
+    result = text if match is None else text[: match.start()].rstrip()
+    # A truncated DeepSeek forced call can leave only the reasoning opener in
+    # content after the native section was recovered.  It carries no user
+    # information and belongs in neither OpenAI visible channel.
+    if result.strip() in {"<think>", "</think>"}:
+        return ""
+    return result
+
+
 def _scrub_tool_wire_literals(text: str | None) -> str:
     """Strip every known parser-wire opener/closer marker from
     ``text`` in three phases. Returns a whitespace-collapsed result
@@ -5675,6 +5708,13 @@ async def _create_chat_completion_impl(
         cleaned_text = _scrub_visible_tool_wire_leaks(cleaned_text)
     if _should_scrub_visible_wire(reasoning_text) and reasoning_text:
         reasoning_text = _scrub_visible_tool_wire_leaks(reasoning_text)
+    if _is_forced_choice and tool_calls:
+        # #1676/#1677: a recovered valid DeepSeek call may be followed by a
+        # malformed duplicate.  Never expose that native section through the
+        # OpenAI content channels; the structured ``tool_calls`` field is the
+        # authoritative representation.
+        cleaned_text = _strip_forced_tool_section(cleaned_text)
+        reasoning_text = _strip_forced_tool_section(reasoning_text)
 
     # Process response_format if specified (after reasoning parser cleaned the text)
     if response_format and not tool_calls:

--- a/vllm_mlx/utils/chat_template.py
+++ b/vllm_mlx/utils/chat_template.py
@@ -1355,6 +1355,7 @@ def apply_chat_template(
     try:
         return _apply_with_alternating_fallback(messages, template_kwargs)
     except TypeError as e:
+        retry_messages = messages
         # DeepSeek-R1's published template concatenates historical tool-call
         # arguments as text, while the majority of HF templates iterate them as
         # mappings.  The shared boundary normalises to the majority mapping
@@ -1365,6 +1366,7 @@ def apply_chat_template(
                 messages
             )
             if string_argument_messages is not messages:
+                retry_messages = string_argument_messages
                 try:
                     return _apply_with_alternating_fallback(
                         string_argument_messages, template_kwargs
@@ -1383,7 +1385,7 @@ def apply_chat_template(
         logger.debug("Chat template TypeError, retrying without enable_thinking: %s", e)
         template_kwargs.pop("enable_thinking", None)
         try:
-            return _apply_with_alternating_fallback(messages, template_kwargs)
+            return _apply_with_alternating_fallback(retry_messages, template_kwargs)
         except TypeError as e2:
             # Second failure. Only drop ``reasoning_effort`` when the error
             # actually names it (codex R8 BLOCKING: unconditionally popping it
@@ -1432,7 +1434,7 @@ def apply_chat_template(
                 "injecting %d tool definitions into system prompt",
                 len(tools),
             )
-            injected = _inject_tools_into_messages(messages, tools)
+            injected = _inject_tools_into_messages(retry_messages, tools)
             try:
                 return _apply_with_alternating_fallback(injected, template_kwargs)
             except TypeError:
@@ -1440,4 +1442,4 @@ def apply_chat_template(
                 template_kwargs.pop("enable_thinking", None)
                 return _apply_with_alternating_fallback(injected, template_kwargs)
 
-        return _apply_with_alternating_fallback(messages, template_kwargs)
+        return _apply_with_alternating_fallback(retry_messages, template_kwargs)

--- a/vllm_mlx/utils/chat_template.py
+++ b/vllm_mlx/utils/chat_template.py
@@ -620,6 +620,146 @@ def _normalize_assistant_tool_call_arguments(messages: list) -> list:
     return normalized
 
 
+def _serialize_assistant_tool_call_arguments(messages: list) -> list:
+    """Return a copy with mapping-form tool arguments encoded as JSON.
+
+    Most Hugging Face templates iterate over ``arguments`` and therefore need
+    the internal mapping form produced by
+    :func:`_normalize_assistant_tool_call_arguments`.  DeepSeek-R1's shipped
+    template is a notable inverse: it concatenates ``arguments`` directly into
+    a JSON code block and raises ``TypeError: can only concatenate str (not
+    \"dict\") to str`` for a standards-compliant replayed tool call.
+
+    This helper is intentionally used only as a compatibility retry after that
+    exact render failure.  It is copy-on-write so neither the OpenAI request nor
+    the normalised representation used by other templates is mutated.
+    """
+    if not isinstance(messages, list):
+        return messages
+
+    result = messages
+    for index, message in enumerate(messages):
+        if not isinstance(message, dict) or message.get("role") != "assistant":
+            continue
+        tool_calls = message.get("tool_calls")
+        if not isinstance(tool_calls, list):
+            continue
+
+        new_calls = tool_calls
+        message_changed = False
+        for call_index, tool_call in enumerate(tool_calls):
+            if not isinstance(tool_call, dict):
+                continue
+            new_call = tool_call
+            call_changed = False
+
+            function = tool_call.get("function")
+            if isinstance(function, dict) and isinstance(
+                function.get("arguments"), dict
+            ):
+                new_function = dict(function)
+                new_function["arguments"] = json.dumps(
+                    function["arguments"], ensure_ascii=False, separators=(",", ":")
+                )
+                new_call = dict(new_call)
+                new_call["function"] = new_function
+                call_changed = True
+
+            if isinstance(tool_call.get("arguments"), dict):
+                if not call_changed:
+                    new_call = dict(new_call)
+                new_call["arguments"] = json.dumps(
+                    tool_call["arguments"],
+                    ensure_ascii=False,
+                    separators=(",", ":"),
+                )
+                call_changed = True
+
+            if call_changed:
+                if not message_changed:
+                    new_calls = list(tool_calls)
+                new_calls[call_index] = new_call
+                message_changed = True
+
+        if message_changed:
+            if result is messages:
+                result = list(messages)
+            new_message = dict(message)
+            new_message["tool_calls"] = new_calls
+            result[index] = new_message
+
+    return result
+
+
+def _flatten_tool_history_for_alternating_template(messages: list) -> list:
+    """Encode OpenAI tool history for templates limited to user/assistant.
+
+    Gemma 3's official template rejects every ``role="tool"`` message and
+    requires strict user/assistant alternation.  Preserve the conversation by
+    rendering structured assistant calls as text, converting tool results to a
+    user turn, and merging the immediately following user follow-up into that
+    turn.  Called only after the template explicitly reports its alternation
+    constraint, so native tool-aware templates retain their native shape.
+    """
+    flattened: list = []
+    for message in messages:
+        if not isinstance(message, dict):
+            flattened.append(message)
+            continue
+        role = message.get("role")
+        if role == "assistant" and isinstance(message.get("tool_calls"), list):
+            parts: list[str] = []
+            content = message.get("content")
+            if isinstance(content, str) and content.strip():
+                parts.append(content.strip())
+            for tool_call in message["tool_calls"]:
+                if not isinstance(tool_call, dict):
+                    continue
+                function = tool_call.get("function")
+                if not isinstance(function, dict):
+                    continue
+                name = function.get("name") or "unknown"
+                arguments = function.get("arguments", {})
+                if not isinstance(arguments, str):
+                    arguments = json.dumps(
+                        arguments, ensure_ascii=False, separators=(",", ":")
+                    )
+                parts.append(f"Tool call {name}: {arguments}")
+            new_message = dict(message)
+            new_message.pop("tool_calls", None)
+            new_message["content"] = "\n".join(parts)
+            flattened.append(new_message)
+            continue
+        if role == "tool":
+            name = message.get("name") or message.get("tool_call_id") or "unknown"
+            content = message.get("content")
+            result_text = content if isinstance(content, str) else json.dumps(content)
+            text = f"Tool result {name}: {result_text}"
+            if (
+                flattened
+                and isinstance(flattened[-1], dict)
+                and flattened[-1].get("role") == "user"
+            ):
+                prior = flattened[-1].get("content") or ""
+                flattened[-1] = {**flattened[-1], "content": f"{prior}\n{text}"}
+            else:
+                flattened.append({"role": "user", "content": text})
+            continue
+        if role == "user" and flattened and isinstance(flattened[-1], dict):
+            previous = flattened[-1]
+            if previous.get("role") == "user" and str(
+                previous.get("content", "")
+            ).startswith("Tool result "):
+                content = message.get("content") or ""
+                flattened[-1] = {
+                    **previous,
+                    "content": f"{previous.get('content', '')}\n\n{content}",
+                }
+                continue
+        flattened.append(message)
+    return flattened
+
+
 def _baseline_sanitize_messages(messages):
     """Fail-closed fallback for ``_sanitize_messages_for_template``.
 
@@ -1189,6 +1329,24 @@ def apply_chat_template(
     try:
         return template_applicator.apply_chat_template(messages, **template_kwargs)
     except TypeError as e:
+        # DeepSeek-R1's published template concatenates historical tool-call
+        # arguments as text, while the majority of HF templates iterate them as
+        # mappings.  The shared boundary normalises to the majority mapping
+        # form above; retry the exact inverse incompatibility with JSON strings
+        # before treating the TypeError as an unsupported template kwarg.
+        if 'can only concatenate str (not "dict") to str' in str(e):
+            string_argument_messages = _serialize_assistant_tool_call_arguments(
+                messages
+            )
+            if string_argument_messages is not messages:
+                try:
+                    return template_applicator.apply_chat_template(
+                        string_argument_messages, **template_kwargs
+                    )
+                except TypeError:
+                    # It was not the known argument-shape incompatibility; keep
+                    # the existing generic kwarg/tools fallback behaviour.
+                    pass
         # Step 1: retry without enable_thinking (many templates don't support it).
         # Codex round-1 NIT fix (PR #1070 finding #4): keep
         # ``reasoning_effort`` on this first retry so a Hy3 checkpoint
@@ -1261,3 +1419,19 @@ def apply_chat_template(
                 )
 
         return template_applicator.apply_chat_template(messages, **template_kwargs)
+    except Exception as e:
+        # Gemma 3 and a few minimal instruction templates have no native tool
+        # role and fail a standards-compliant replay with this exact Jinja
+        # diagnostic.  Retry only that declared limitation; unrelated template
+        # errors remain visible to the caller.
+        if "Conversation roles must alternate user/assistant" not in str(e) or not any(
+            isinstance(message, dict) and message.get("role") == "tool"
+            for message in messages
+        ):
+            raise
+        flattened = _flatten_tool_history_for_alternating_template(messages)
+        if tools:
+            flattened = _inject_tools_into_messages(flattened, tools)
+        alternating_kwargs = dict(template_kwargs)
+        alternating_kwargs.pop("tools", None)
+        return template_applicator.apply_chat_template(flattened, **alternating_kwargs)

--- a/vllm_mlx/utils/chat_template.py
+++ b/vllm_mlx/utils/chat_template.py
@@ -1326,8 +1326,34 @@ def apply_chat_template(
     if _looks_like_hy3(model_name) and enable_thinking is not False:
         template_kwargs.setdefault("reasoning_effort", "low")
 
+    def _apply_with_alternating_fallback(
+        candidate_messages: list[dict], candidate_kwargs: dict
+    ) -> str:
+        try:
+            return template_applicator.apply_chat_template(
+                candidate_messages, **candidate_kwargs
+            )
+        except Exception as exc:
+            if "Conversation roles must alternate user/assistant" not in str(
+                exc
+            ) or not any(
+                isinstance(message, dict) and message.get("role") == "tool"
+                for message in candidate_messages
+            ):
+                raise
+            flattened = _flatten_tool_history_for_alternating_template(
+                candidate_messages
+            )
+            alternating_kwargs = dict(candidate_kwargs)
+            fallback_tools = alternating_kwargs.pop("tools", None)
+            if fallback_tools:
+                flattened = _inject_tools_into_messages(flattened, fallback_tools)
+            return template_applicator.apply_chat_template(
+                flattened, **alternating_kwargs
+            )
+
     try:
-        return template_applicator.apply_chat_template(messages, **template_kwargs)
+        return _apply_with_alternating_fallback(messages, template_kwargs)
     except TypeError as e:
         # DeepSeek-R1's published template concatenates historical tool-call
         # arguments as text, while the majority of HF templates iterate them as
@@ -1340,8 +1366,8 @@ def apply_chat_template(
             )
             if string_argument_messages is not messages:
                 try:
-                    return template_applicator.apply_chat_template(
-                        string_argument_messages, **template_kwargs
+                    return _apply_with_alternating_fallback(
+                        string_argument_messages, template_kwargs
                     )
                 except TypeError:
                     # It was not the known argument-shape incompatibility; keep
@@ -1357,7 +1383,7 @@ def apply_chat_template(
         logger.debug("Chat template TypeError, retrying without enable_thinking: %s", e)
         template_kwargs.pop("enable_thinking", None)
         try:
-            return template_applicator.apply_chat_template(messages, **template_kwargs)
+            return _apply_with_alternating_fallback(messages, template_kwargs)
         except TypeError as e2:
             # Second failure. Only drop ``reasoning_effort`` when the error
             # actually names it (codex R8 BLOCKING: unconditionally popping it
@@ -1408,30 +1434,10 @@ def apply_chat_template(
             )
             injected = _inject_tools_into_messages(messages, tools)
             try:
-                return template_applicator.apply_chat_template(
-                    injected, **template_kwargs
-                )
+                return _apply_with_alternating_fallback(injected, template_kwargs)
             except TypeError:
                 # enable_thinking also unsupported after all — drop it
                 template_kwargs.pop("enable_thinking", None)
-                return template_applicator.apply_chat_template(
-                    injected, **template_kwargs
-                )
+                return _apply_with_alternating_fallback(injected, template_kwargs)
 
-        return template_applicator.apply_chat_template(messages, **template_kwargs)
-    except Exception as e:
-        # Gemma 3 and a few minimal instruction templates have no native tool
-        # role and fail a standards-compliant replay with this exact Jinja
-        # diagnostic.  Retry only that declared limitation; unrelated template
-        # errors remain visible to the caller.
-        if "Conversation roles must alternate user/assistant" not in str(e) or not any(
-            isinstance(message, dict) and message.get("role") == "tool"
-            for message in messages
-        ):
-            raise
-        flattened = _flatten_tool_history_for_alternating_template(messages)
-        if tools:
-            flattened = _inject_tools_into_messages(flattened, tools)
-        alternating_kwargs = dict(template_kwargs)
-        alternating_kwargs.pop("tools", None)
-        return template_applicator.apply_chat_template(flattened, **alternating_kwargs)
+        return _apply_with_alternating_fallback(messages, template_kwargs)


### PR DESCRIPTION
## What does this PR do?

- fixes DeepSeek-R1 replay of a standards-compliant assistant `tool_calls` message followed by `role: tool`; its official template concatenates JSON strings while the shared template boundary normalizes arguments to mappings, previously causing deterministic HTTP 500 on turn two
- removes recovered DeepSeek native tool-section / lone `<think>` residue from visible OpenAI content channels
- adds a narrow fallback for Gemma 3 templates that explicitly reject `role: tool` and require strict user/assistant alternation, preserving the call/result/follow-up as text turns
- upgrades the L1 format probe into a deterministic engine contract: named zero-arg call, non-stream + stream channel hygiene, and non-stream + stream tool-result replay
- runs that contract for every 4B alias removed from G12 and makes the matrix part of the required aggregate

## Why is this needed?

Fixes #1676. Fixes #1677.

The honest G12 run failed DeepSeek because the 8B model did not voluntarily call a tool and failed Hermes3 because one exact 2+2 prompt returns `2`. Six controls showed those are model-competence quirks, not engine regressions. A forced zero-argument call factors that competence out. It immediately exposed two real engine bugs instead: DeepSeek tool-result replay returned 500 (`str + dict`), and Gemma 3 tool-result replay returned 400 because its official template rejects tool roles.

## AI assistance disclosure

Codex reproduced the failures on a Mac mini, wrote the implementation and regression tests across the listed files, and reviewed the complete diff. Validation used six real model boots plus unit, lint, and PR-validation gates.

## Test plan

- `382 passed` across tool-choice, chat-template, API model/utils, L1 gate, and G12 filter suites
- `ruff check` and `ruff format --check` on all changed Python files
- real Mini contract PASS: `deepseek-r1-8b-4bit`, `hermes3-8b-4bit`, `qwen3.5-4b-4bit`, `gemma3-4b-qat-4bit`, `qwen3-4b-instruct-2507-4bit`, `qwen3-4b-thinking-2507-4bit`
- full Qwen3.5-4B L1 mode: coherence 6/6 + tool-loop contract PASS
- pending final `pr_validate` scorecard on this PR

## Checklist

- [x] Targeted and adjacent tests pass locally
- [x] Lint passes (`ruff check && ruff format --check`)
- [x] Self-validated with `python3.12 -m scripts.pr_validate <PR#> --verbose`
- [x] Critical regressions fail pre-fix and pass post-fix on real models
- [x] Updated release notes
- [x] No breaking changes to existing API