### PR TITLE
fix(agents): codex e2e gate never reached rapid-mlx at all

### DIFF
--- a/tests/test_agent_query_stdin_and_trust.py
+++ b/tests/test_agent_query_stdin_and_trust.py
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Pin the two reasons G7b's codex e2e could never pass (#1683).
+"""Pin why G7b's codex e2e could never pass, and where it runs (#1683).
 
-Both live on the path between the test runner and the agent CLI, so both
-report as a rapid-mlx integration failure while nothing in rapid-mlx is
-ever reached.
+The first two live on the path between the test runner and the agent CLI,
+so both reported as a rapid-mlx integration failure while nothing in
+rapid-mlx was ever reached.
 
 1. ``_agent_query`` ran the child with an **inherited stdin**. A CLI that
    reads stdin when it isn't a TTY then blocks until ``query_timeout``
@@ -15,6 +15,14 @@ ever reached.
    Codex refuses to run outside a trusted git repo, and the runner
    inherits the caller's cwd, so from a neutral directory every e2e test
    failed in ~100 ms with "Not inside a trusted directory".
+
+3. Fixing (2) by itself would bypass Codex's trust check in whatever
+   directory the caller happened to be standing in, exposing that
+   directory's files and agent instructions to the agent. The e2e tests
+   now run in a workspace ``_e2e_workspace`` builds, which also makes
+   `_test_e2e_file_read` deterministic — it asks for ``pyproject.toml``,
+   and previously only found one when the caller was standing in a
+   Python project.
 
 The stdin test drives a **real subprocess against a real pipe on fd 0**.
 A mock asserting ``stdin=DEVNULL`` was passed would only restate the
@@ -28,11 +36,12 @@ import os
 import shlex
 import sys
 import time
+from pathlib import Path
 
 import pytest
 
 from vllm_mlx.agents import get_profile
-from vllm_mlx.agents.testing import _agent_query
+from vllm_mlx.agents.testing import _agent_query, _e2e_workspace
 
 # Long enough that a slow machine never flakes, short enough that a
 # regression (the child blocking on stdin) fails the suite in seconds
@@ -95,6 +104,58 @@ def test_query_placeholder_still_substitutes():
     out, err = _agent_query(sys.executable, cmd, "what is 2+2", timeout=_TIMEOUT_S)
     assert err is None, f"unexpected error: {err}"
     assert out == "ARG:what is 2+2"
+
+
+def test_agent_runs_in_the_given_workspace_not_the_callers_cwd():
+    """`--skip-git-repo-check` is only safe in a directory we built ourselves.
+
+    Bypassing Codex's trust check while still launching it in the caller's
+    inherited cwd would hand the agent whatever that directory contains —
+    including files and agent instructions from an untrusted checkout.
+    """
+    script = "import os, sys; sys.stdout.write('CWD:' + os.getcwd())"
+    cmd = f"{shlex.quote(sys.executable)} -c {shlex.quote(script)}"
+    with _e2e_workspace() as workdir:
+        out, err = _agent_query(
+            sys.executable, cmd, "unused", timeout=_TIMEOUT_S, cwd=workdir
+        )
+    assert err is None, f"unexpected error: {err}"
+    # macOS hands out /var/folders/... symlinked from /private/var/folders/...
+    assert os.path.realpath(out.removeprefix("CWD:")) == os.path.realpath(workdir), (
+        f"child ran in {out!r}, not in the workspace it was given"
+    )
+
+
+def test_workspace_carries_the_file_the_file_read_test_asks_for():
+    """`_test_e2e_file_read` reads pyproject.toml; the workspace must have one."""
+    with _e2e_workspace() as workdir:
+        target = Path(workdir, "pyproject.toml")
+        assert target.is_file(), "the workspace has no pyproject.toml to read"
+        text = target.read_text(encoding="utf-8")
+        # The test asks for the FIRST line specifically.
+        assert text.splitlines()[0] == "[build-system]"
+        # `_test_e2e_file_read` passes on either substring; both must be
+        # present so the assertion does not depend on which part of the
+        # file the agent chooses to quote back.
+        assert "build" in text.lower()
+        assert "project" in text.lower()
+
+
+def test_workspace_is_removed_afterwards():
+    """A gate that leaves a directory per run per agent is a slow disk leak."""
+    with _e2e_workspace() as workdir:
+        assert os.path.isdir(workdir)
+    assert not os.path.exists(workdir), f"workspace survived the context: {workdir}"
+
+
+def test_workspace_is_fresh_each_time():
+    """Two runs must not share state — one agent's mess is not the next's input."""
+    with _e2e_workspace() as first:
+        Path(first, "scratch.txt").write_text("left behind", encoding="utf-8")
+        first_path = first
+    with _e2e_workspace() as second:
+        assert second != first_path
+        assert not Path(second, "scratch.txt").exists()
 
 
 def test_codex_query_cmd_skips_the_git_repo_check():

--- a/tests/test_agent_query_stdin_and_trust.py
+++ b/tests/test_agent_query_stdin_and_trust.py
@@ -41,7 +41,14 @@ from pathlib import Path
 import pytest
 
 from vllm_mlx.agents import get_profile
-from vllm_mlx.agents.testing import _agent_query, _e2e_workspace
+from vllm_mlx.agents.testing import (
+    E2E_FIRST_LINE,
+    TestStatus,
+    _agent_query,
+    _e2e_workspace,
+    _test_e2e_chat,
+    _test_e2e_file_read,
+)
 
 # Long enough that a slow machine never flakes, short enough that a
 # regression (the child blocking on stdin) fails the suite in seconds
@@ -133,12 +140,12 @@ def test_workspace_carries_the_file_the_file_read_test_asks_for():
         assert target.is_file(), "the workspace has no pyproject.toml to read"
         text = target.read_text(encoding="utf-8")
         # The test asks for the FIRST line specifically.
-        assert text.splitlines()[0] == "[build-system]"
-        # `_test_e2e_file_read` passes on either substring; both must be
-        # present so the assertion does not depend on which part of the
-        # file the agent chooses to quote back.
-        assert "build" in text.lower()
-        assert "project" in text.lower()
+        assert text.splitlines()[0] == E2E_FIRST_LINE
+        # It has to be a sentinel, not a plausible word: the assertion
+        # previously accepted "build" or "project" anywhere in the agent's
+        # answer, which any sentence about a Python project satisfies
+        # without the file having been opened.
+        assert text.count(E2E_FIRST_LINE) == 1
 
 
 def test_workspace_is_removed_afterwards():
@@ -148,14 +155,67 @@ def test_workspace_is_removed_afterwards():
     assert not os.path.exists(workdir), f"workspace survived the context: {workdir}"
 
 
-def test_workspace_is_fresh_each_time():
-    """Two runs must not share state — one agent's mess is not the next's input."""
-    with _e2e_workspace() as first:
-        Path(first, "scratch.txt").write_text("left behind", encoding="utf-8")
-        first_path = first
-    with _e2e_workspace() as second:
-        assert second != first_path
-        assert not Path(second, "scratch.txt").exists()
+def _recording_agent(log: Path, reply: str) -> str:
+    """A stand-in agent CLI that records where it ran and prints `reply`."""
+    script = (
+        "import os, sys; "
+        f"open({str(log)!r}, 'a').write(os.getcwd() + chr(10)); "
+        f"sys.stdout.write({reply!r})"
+    )
+    return f"{shlex.quote(sys.executable)} -c {shlex.quote(script)} '{{query}}'"
+
+
+def test_each_e2e_test_gets_its_own_workspace(tmp_path):
+    """Two e2e tests must not share a directory.
+
+    Asserting that two `_e2e_workspace()` calls differ proves nothing about
+    the runner — the runner is what decides how many workspaces exist. This
+    drives the real `_test_e2e_*` entry points with a real subprocess and
+    reads back the directories they actually ran in.
+    """
+    log = tmp_path / "cwds.txt"
+    # One reply that satisfies both assertions: "4" for chat, the sentinel
+    # for file-read.
+    cmd = _recording_agent(log, f"4 {E2E_FIRST_LINE}")
+
+    chat = _test_e2e_chat(sys.executable, cmd, _TIMEOUT_S)
+    file_read = _test_e2e_file_read(sys.executable, cmd, _TIMEOUT_S)
+    assert chat.status is TestStatus.PASS, chat.message
+    assert file_read.status is TestStatus.PASS, file_read.message
+
+    ran_in = log.read_text(encoding="utf-8").split()
+    assert len(ran_in) == 2, f"expected two runs, recorded {ran_in}"
+    assert ran_in[0] != ran_in[1], (
+        "both e2e tests ran in the SAME directory — whatever the first agent "
+        "wrote there is the second one's starting condition"
+    )
+    for path in ran_in:
+        assert not os.path.exists(path), f"workspace survived its test: {path}"
+
+
+def test_file_read_demands_the_sentinel_not_a_plausible_sentence(tmp_path):
+    """Talking about the project is not reading the first line of the file."""
+    log = tmp_path / "cwds.txt"
+    # Contains "build" and "project" — which the previous assertion accepted —
+    # but is not the first line of anything.
+    chatty = _recording_agent(log, "This looks like a Python project; I can build it.")
+    result = _test_e2e_file_read(sys.executable, chatty, _TIMEOUT_S)
+    assert result.status is TestStatus.FAIL, (
+        "an answer that never read the file passed the file-read test"
+    )
+
+
+def test_workspace_removal_survives_a_locked_down_subdirectory(tmp_path, caplog):
+    """An agent that chmods its scratch directory must not leak the workspace."""
+    with _e2e_workspace() as workdir:
+        hostile = Path(workdir, "hostile")
+        hostile.mkdir()
+        (hostile / "note.txt").write_text("x", encoding="utf-8")
+        os.chmod(hostile, 0o000)
+        captured = workdir
+    assert not os.path.exists(captured), (
+        f"workspace leaked because a subdirectory was unreadable: {captured}"
+    )
 
 
 def test_codex_query_cmd_skips_the_git_repo_check():

--- a/tests/test_agent_query_stdin_and_trust.py
+++ b/tests/test_agent_query_stdin_and_trust.py
@@ -52,6 +52,7 @@ from vllm_mlx.agents.testing import (
     _e2e_workspace,
     _test_e2e_chat,
     _test_e2e_file_read,
+    _test_e2e_terminal,
 )
 
 # Long enough that a slow machine never flakes, short enough that a
@@ -182,16 +183,27 @@ def test_each_e2e_test_gets_its_own_workspace(tmp_path):
     # for file-read.
     cmd = _recording_agent(log, f"4 {E2E_FIRST_LINE}")
 
+    # ALL THREE entry points, not a sample of them: `_test_e2e_terminal`
+    # could regress to a shared or inherited cwd while a test that only
+    # drives the other two stayed green.
+    marker = "rapidmlx_codex_test"
     chat = _test_e2e_chat(sys.executable, cmd, _TIMEOUT_S)
     file_read = _test_e2e_file_read(sys.executable, cmd, _TIMEOUT_S)
+    terminal = _test_e2e_terminal(
+        sys.executable,
+        _recording_agent(log, marker),
+        _TIMEOUT_S,
+        "codex",
+    )
     assert chat.status is TestStatus.PASS, chat.message
     assert file_read.status is TestStatus.PASS, file_read.message
+    assert terminal.status is TestStatus.PASS, terminal.message
 
     ran_in = log.read_text(encoding="utf-8").splitlines()
-    assert len(ran_in) == 2, f"expected two runs, recorded {ran_in}"
-    assert ran_in[0] != ran_in[1], (
-        "both e2e tests ran in the SAME directory — whatever the first agent "
-        "wrote there is the second one's starting condition"
+    assert len(ran_in) == 3, f"expected three runs, recorded {ran_in}"
+    assert len(set(ran_in)) == 3, (
+        "two or more e2e tests ran in the SAME directory — whatever the first "
+        f"agent wrote there is the next one's starting condition: {ran_in}"
     )
     for path in ran_in:
         assert not os.path.exists(path), f"workspace survived its test: {path}"

--- a/tests/test_agent_query_stdin_and_trust.py
+++ b/tests/test_agent_query_stdin_and_trust.py
@@ -38,6 +38,7 @@ import os
 import shlex
 import shutil
 import sys
+import tempfile
 import time
 from pathlib import Path
 
@@ -186,7 +187,7 @@ def test_each_e2e_test_gets_its_own_workspace(tmp_path):
     assert chat.status is TestStatus.PASS, chat.message
     assert file_read.status is TestStatus.PASS, file_read.message
 
-    ran_in = log.read_text(encoding="utf-8").split()
+    ran_in = log.read_text(encoding="utf-8").splitlines()
     assert len(ran_in) == 2, f"expected two runs, recorded {ran_in}"
     assert ran_in[0] != ran_in[1], (
         "both e2e tests ran in the SAME directory — whatever the first agent "
@@ -262,21 +263,40 @@ def test_cleanup_never_writes_outside_the_workspace(tmp_path):
     outside_dir_before = os.stat(outside_dir).st_mode
 
     with _e2e_workspace() as workdir:
-        os.symlink(outsider, Path(workdir, "link-to-outside-file"))
-        os.symlink(outside_dir, Path(workdir, "link-to-outside-dir"))
+        # The links go INSIDE the directory that gets locked, not beside it.
+        # On the happy path rmtree unlinks them before it fails, so links in
+        # the workspace root are gone by the time any repair pass would run —
+        # which is how the first version of this test stayed green against
+        # the very code it was written to forbid. Locked in here, they
+        # survive the failed rmtree and are exactly what a repair pass would
+        # walk into and chmod.
+        trap = Path(workdir, "hostile")
+        trap.mkdir()
+        os.symlink(outsider, trap / "link-to-outside-file")
+        os.symlink(outside_dir, trap / "link-to-outside-dir")
+        (trap / "note.txt").write_text("x", encoding="utf-8")
+        os.chmod(trap, 0o000)
         captured = workdir
 
-    assert not os.path.exists(captured), "workspace leaked"
-    assert outsider.exists(), "cleanup deleted a file outside the workspace"
-    assert (outside_dir / "keep.txt").exists(), (
-        "cleanup followed a link and deleted a tree outside the workspace"
-    )
-    assert os.stat(outsider).st_mode == outsider_before, (
-        "cleanup rewrote the permissions of a file outside the workspace"
-    )
-    assert os.stat(outside_dir).st_mode == outside_dir_before, (
-        "cleanup rewrote the permissions of a directory outside the workspace"
-    )
+    try:
+        assert os.path.exists(captured), (
+            "the workspace was removed, so the repair path this test guards "
+            "never ran — the assertions below would prove nothing"
+        )
+        assert outsider.exists(), "cleanup deleted a file outside the workspace"
+        assert (outside_dir / "keep.txt").exists(), (
+            "cleanup followed a link and deleted a tree outside the workspace"
+        )
+        assert os.stat(outsider).st_mode == outsider_before, (
+            "cleanup rewrote the permissions of a file outside the workspace"
+        )
+        assert os.stat(outside_dir).st_mode == outside_dir_before, (
+            "cleanup rewrote the permissions of a directory outside the workspace"
+        )
+    finally:
+        with contextlib.suppress(OSError):
+            os.chmod(Path(captured, "hostile"), 0o700)
+        shutil.rmtree(captured, ignore_errors=True)
 
 
 def test_codex_query_cmd_skips_the_git_repo_check():
@@ -300,3 +320,25 @@ def test_codex_query_cmd_is_shell_parseable_and_keeps_the_placeholder():
     assert "--skip-git-repo-check" in parts
     # The query must survive as ONE argv entry, not five bare words.
     assert "what is 2+2" in parts
+
+
+def test_workspace_creation_failure_is_an_error_not_a_crash(tmp_path, monkeypatch):
+    """A full or read-only temp filesystem must not take the runner down.
+
+    Staged against a REAL read-only directory rather than a patched
+    `mkdtemp`, so the failure arrives from the operating system the way it
+    would in production. `tempfile.tempdir` rather than `$TMPDIR`: tempfile
+    resolves the environment variable once and caches it, so setting the
+    variable here would change nothing.
+    """
+    readonly = tmp_path / "readonly-tmp"
+    readonly.mkdir()
+    os.chmod(readonly, 0o500)
+    monkeypatch.setattr(tempfile, "tempdir", str(readonly))
+
+    result = _test_e2e_chat(sys.executable, "irrelevant {query}", _TIMEOUT_S)
+    assert result.status is TestStatus.ERROR, (
+        f"expected an ERROR result, got {result.status} — a workspace that "
+        "cannot be created must not propagate out of the test runner"
+    )
+    assert "workspace unavailable" in result.message, result.message

--- a/tests/test_agent_query_stdin_and_trust.py
+++ b/tests/test_agent_query_stdin_and_trust.py
@@ -1,0 +1,120 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Pin the two reasons G7b's codex e2e could never pass (#1683).
+
+Both live on the path between the test runner and the agent CLI, so both
+report as a rapid-mlx integration failure while nothing in rapid-mlx is
+ever reached.
+
+1. ``_agent_query`` ran the child with an **inherited stdin**. A CLI that
+   reads stdin when it isn't a TTY then blocks until ``query_timeout``
+   instead of answering the query it was handed on argv. Codex does
+   exactly this — it prints "Reading additional input from stdin..." and
+   waits — so the gate burned its whole 120 s budget per test.
+
+2. The codex profile's ``query_cmd`` omitted ``--skip-git-repo-check``.
+   Codex refuses to run outside a trusted git repo, and the runner
+   inherits the caller's cwd, so from a neutral directory every e2e test
+   failed in ~100 ms with "Not inside a trusted directory".
+
+The stdin test drives a **real subprocess against a real pipe on fd 0**.
+A mock asserting ``stdin=DEVNULL`` was passed would only restate the
+diff; it cannot show that the child stops blocking. Reproducing the hang
+needs the actual inherited descriptor, which is the whole bug.
+"""
+
+from __future__ import annotations
+
+import os
+import shlex
+import sys
+import time
+
+import pytest
+
+from vllm_mlx.agents import get_profile
+from vllm_mlx.agents.testing import _agent_query
+
+# Long enough that a slow machine never flakes, short enough that a
+# regression (the child blocking on stdin) fails the suite in seconds
+# rather than hanging it.
+_TIMEOUT_S = 8
+
+
+def _echo_stdin_cmd() -> str:
+    """A child that reads stdin to EOF and reports what it got."""
+    script = 'import sys; sys.stdout.write("READ:" + repr(sys.stdin.read()))'
+    return f"{shlex.quote(sys.executable)} -c {shlex.quote(script)}"
+
+
+@pytest.fixture
+def stdin_is_an_open_pipe():
+    """Point the *parent's* fd 0 at a pipe that never reaches EOF.
+
+    This is the condition the release gauntlet actually runs under: fd 0
+    is open but nothing will ever write to it. A child that inherits it
+    and calls ``read()`` blocks forever.
+    """
+    try:
+        saved = os.dup(0)
+    except OSError:  # pragma: no cover - fd 0 closed in this environment
+        pytest.skip("fd 0 is not open; cannot stage the inherited-stdin case")
+    read_fd, write_fd = os.pipe()
+    os.dup2(read_fd, 0)
+    try:
+        yield
+    finally:
+        os.dup2(saved, 0)
+        os.close(saved)
+        os.close(read_fd)
+        # Closing the write end last keeps the pipe from reaching EOF for
+        # the whole test, which is what makes a regression actually hang.
+        os.close(write_fd)
+
+
+def test_child_does_not_inherit_a_blocking_stdin(stdin_is_an_open_pipe):
+    """The child must see EOF immediately, not the parent's open pipe."""
+    t0 = time.monotonic()
+    out, err = _agent_query(
+        sys.executable, _echo_stdin_cmd(), "unused", timeout=_TIMEOUT_S
+    )
+    elapsed = time.monotonic() - t0
+
+    assert err != "TIMEOUT", (
+        "the agent CLI inherited the parent's stdin and blocked on it — "
+        "this is the #1683 hang, and it costs one query_timeout per e2e test"
+    )
+    assert err is None, f"unexpected error from _agent_query: {err}"
+    assert out == "READ:''", f"child saw data on stdin instead of EOF: {out!r}"
+    assert elapsed < _TIMEOUT_S, "returned only because the timeout fired"
+
+
+def test_query_placeholder_still_substitutes():
+    """The stdin fix must not disturb how {query} reaches the child."""
+    script = 'import sys; sys.stdout.write("ARG:" + sys.argv[1])'
+    cmd = f"{shlex.quote(sys.executable)} -c {shlex.quote(script)} '{{query}}'"
+    out, err = _agent_query(sys.executable, cmd, "what is 2+2", timeout=_TIMEOUT_S)
+    assert err is None, f"unexpected error: {err}"
+    assert out == "ARG:what is 2+2"
+
+
+def test_codex_query_cmd_skips_the_git_repo_check():
+    """Codex refuses to run outside a trusted repo; the gate can't rely on cwd."""
+    profile = get_profile("codex")
+    query_cmd = profile.testing.query_cmd
+    assert query_cmd, "codex must keep a non-null query_cmd — G7b depends on it"
+    assert "--skip-git-repo-check" in query_cmd, (
+        "without --skip-git-repo-check the codex e2e tests fail in ~100 ms with "
+        "'Not inside a trusted directory' whenever the runner's cwd is not a "
+        "trusted git repo (#1683)"
+    )
+
+
+def test_codex_query_cmd_is_shell_parseable_and_keeps_the_placeholder():
+    """A malformed query_cmd would silently degrade to the naive split path."""
+    query_cmd = get_profile("codex").testing.query_cmd
+    parts = shlex.split(query_cmd.replace("{query}", "what is 2+2"))
+    assert parts[0] == "codex"
+    assert parts[1] == "exec"
+    assert "--skip-git-repo-check" in parts
+    # The query must survive as ONE argv entry, not five bare words.
+    assert "what is 2+2" in parts

--- a/tests/test_agent_query_stdin_and_trust.py
+++ b/tests/test_agent_query_stdin_and_trust.py
@@ -279,10 +279,12 @@ def test_cleanup_never_writes_outside_the_workspace(tmp_path):
         captured = workdir
 
     try:
-        assert os.path.exists(captured), (
-            "the workspace was removed, so the repair path this test guards "
-            "never ran — the assertions below would prove nothing"
-        )
+        if not os.path.exists(captured):
+            # Root, or a filesystem that ignores mode bits, deletes the tree
+            # regardless. The repair path this test guards never ran, so the
+            # assertions below would prove nothing — say so rather than
+            # failing a change that is fine.
+            pytest.skip("this environment removes a 0o000 directory anyway")
         assert outsider.exists(), "cleanup deleted a file outside the workspace"
         assert (outside_dir / "keep.txt").exists(), (
             "cleanup followed a link and deleted a tree outside the workspace"
@@ -335,6 +337,16 @@ def test_workspace_creation_failure_is_an_error_not_a_crash(tmp_path, monkeypatc
     readonly.mkdir()
     os.chmod(readonly, 0o500)
     monkeypatch.setattr(tempfile, "tempdir", str(readonly))
+
+    try:
+        probe = tempfile.mkdtemp()
+    except OSError:
+        pass
+    else:
+        # Root ignores the missing write bit. Nothing to assert about a
+        # failure this environment will not produce.
+        shutil.rmtree(probe, ignore_errors=True)
+        pytest.skip("this environment can create a workspace under a 0o500 dir")
 
     result = _test_e2e_chat(sys.executable, "irrelevant {query}", _TIMEOUT_S)
     assert result.status is TestStatus.ERROR, (

--- a/tests/test_agent_query_stdin_and_trust.py
+++ b/tests/test_agent_query_stdin_and_trust.py
@@ -205,7 +205,7 @@ def test_file_read_demands_the_sentinel_not_a_plausible_sentence(tmp_path):
     )
 
 
-def test_workspace_removal_survives_a_locked_down_subdirectory(tmp_path, caplog):
+def test_workspace_removal_survives_a_locked_down_subdirectory():
     """An agent that chmods its scratch directory must not leak the workspace."""
     with _e2e_workspace() as workdir:
         hostile = Path(workdir, "hostile")
@@ -215,6 +215,61 @@ def test_workspace_removal_survives_a_locked_down_subdirectory(tmp_path, caplog)
         captured = workdir
     assert not os.path.exists(captured), (
         f"workspace leaked because a subdirectory was unreadable: {captured}"
+    )
+
+
+def test_workspace_removal_survives_a_locked_down_root():
+    """A locked ROOT hides every descendant, so it has to be restored first.
+
+    Recovery that walks before restoring the root finds nothing to fix and
+    fails for exactly the reason the first attempt did.
+    """
+    with _e2e_workspace() as workdir:
+        nested = Path(workdir, "nested")
+        nested.mkdir()
+        (nested / "note.txt").write_text("x", encoding="utf-8")
+        os.chmod(nested, 0o000)
+        os.chmod(workdir, 0o000)
+        captured = workdir
+    assert not os.path.exists(captured), (
+        f"workspace leaked because its own root was unreadable: {captured}"
+    )
+
+
+def test_cleanup_never_chmods_through_a_symlink(tmp_path):
+    """`os.chmod` follows links; the agent must not be able to aim it outside.
+
+    A link planted in a locked directory, pointing at a caller-owned file,
+    would have that file's permissions rewritten by our own cleanup.
+    """
+    outsider = tmp_path / "private.key"
+    outsider.write_text("secret", encoding="utf-8")
+    os.chmod(outsider, 0o600)
+    outsider_before = os.stat(outsider).st_mode
+    # A linked DIRECTORY is the more dangerous shape: chmod 0o700 on it would
+    # rewrite the permissions of a whole tree the workspace does not own.
+    outside_dir = tmp_path / "outside-tree"
+    outside_dir.mkdir()
+    os.chmod(outside_dir, 0o500)
+    outside_dir_before = os.stat(outside_dir).st_mode
+
+    with _e2e_workspace() as workdir:
+        trap = Path(workdir, "trap")
+        trap.mkdir()
+        os.symlink(outsider, trap / "link-to-outside-file")
+        os.symlink(outside_dir, trap / "link-to-outside-dir")
+        os.chmod(trap, 0o000)
+        captured = workdir
+
+    assert not os.path.exists(captured), "workspace leaked"
+    assert outsider.exists(), "cleanup deleted a file outside the workspace"
+    assert outside_dir.is_dir(), "cleanup deleted a tree outside the workspace"
+    assert os.stat(outsider).st_mode == outsider_before, (
+        "cleanup chmod'd through a symlink and rewrote a file outside the workspace"
+    )
+    assert os.stat(outside_dir).st_mode == outside_dir_before, (
+        "cleanup chmod'd through a symlink and rewrote a directory outside "
+        "the workspace"
     )
 
 

--- a/tests/test_agent_query_stdin_and_trust.py
+++ b/tests/test_agent_query_stdin_and_trust.py
@@ -32,8 +32,11 @@ needs the actual inherited descriptor, which is the whole bug.
 
 from __future__ import annotations
 
+import contextlib
+import logging
 import os
 import shlex
+import shutil
 import sys
 import time
 from pathlib import Path
@@ -205,71 +208,74 @@ def test_file_read_demands_the_sentinel_not_a_plausible_sentence(tmp_path):
     )
 
 
-def test_workspace_removal_survives_a_locked_down_subdirectory():
-    """An agent that chmods its scratch directory must not leak the workspace."""
-    with _e2e_workspace() as workdir:
-        hostile = Path(workdir, "hostile")
-        hostile.mkdir()
-        (hostile / "note.txt").write_text("x", encoding="utf-8")
-        os.chmod(hostile, 0o000)
-        captured = workdir
-    assert not os.path.exists(captured), (
-        f"workspace leaked because a subdirectory was unreadable: {captured}"
-    )
+def _lock_and_release(workdir: str, name: str = "hostile") -> None:
+    """Make `workdir` un-removable the way a misbehaving agent would."""
+    hostile = Path(workdir, name)
+    hostile.mkdir()
+    (hostile / "note.txt").write_text("x", encoding="utf-8")
+    os.chmod(hostile, 0o000)
 
 
-def test_workspace_removal_survives_a_locked_down_root():
-    """A locked ROOT hides every descendant, so it has to be restored first.
+def test_an_unremovable_workspace_is_reported_not_swallowed(caplog):
+    """The NIT was about silence, not about winning the fight.
 
-    Recovery that walks before restoring the root finds nothing to fix and
-    fails for exactly the reason the first attempt did.
+    Cleanup does not try to repair permissions — see `_remove_workspace` for
+    why that buys nothing against a process running as the same user. What it
+    must never do is leave a directory behind on every release and say
+    nothing.
     """
-    with _e2e_workspace() as workdir:
-        nested = Path(workdir, "nested")
-        nested.mkdir()
-        (nested / "note.txt").write_text("x", encoding="utf-8")
-        os.chmod(nested, 0o000)
-        os.chmod(workdir, 0o000)
+    with (
+        caplog.at_level(logging.WARNING, logger="vllm_mlx.agents.testing"),
+        _e2e_workspace() as workdir,
+    ):
+        _lock_and_release(workdir)
         captured = workdir
-    assert not os.path.exists(captured), (
-        f"workspace leaked because its own root was unreadable: {captured}"
-    )
+    try:
+        if not os.path.exists(captured):
+            pytest.skip("this filesystem removes locked directories anyway")
+        assert any(captured in r.getMessage() for r in caplog.records), (
+            "the workspace was left behind and nobody was told — that is the "
+            "silent per-release disk leak the warning exists to prevent"
+        )
+    finally:
+        with contextlib.suppress(OSError):
+            os.chmod(Path(captured, "hostile"), 0o700)
+        shutil.rmtree(captured, ignore_errors=True)
 
 
-def test_cleanup_never_chmods_through_a_symlink(tmp_path):
-    """`os.chmod` follows links; the agent must not be able to aim it outside.
+def test_cleanup_never_writes_outside_the_workspace(tmp_path):
+    """A link planted in the workspace must not aim our cleanup at its target.
 
-    A link planted in a locked directory, pointing at a caller-owned file,
-    would have that file's permissions rewritten by our own cleanup.
+    This is the shape the earlier permission-repair pass got wrong twice:
+    `os.chmod` follows symlinks, so a link pointing at a caller-owned file had
+    that file's mode rewritten by our own cleanup (measured: 0o600 -> 0o700).
+    Cleanup no longer chmods anything, and this pins that it stays that way.
     """
     outsider = tmp_path / "private.key"
     outsider.write_text("secret", encoding="utf-8")
     os.chmod(outsider, 0o600)
     outsider_before = os.stat(outsider).st_mode
-    # A linked DIRECTORY is the more dangerous shape: chmod 0o700 on it would
-    # rewrite the permissions of a whole tree the workspace does not own.
     outside_dir = tmp_path / "outside-tree"
     outside_dir.mkdir()
+    (outside_dir / "keep.txt").write_text("keep", encoding="utf-8")
     os.chmod(outside_dir, 0o500)
     outside_dir_before = os.stat(outside_dir).st_mode
 
     with _e2e_workspace() as workdir:
-        trap = Path(workdir, "trap")
-        trap.mkdir()
-        os.symlink(outsider, trap / "link-to-outside-file")
-        os.symlink(outside_dir, trap / "link-to-outside-dir")
-        os.chmod(trap, 0o000)
+        os.symlink(outsider, Path(workdir, "link-to-outside-file"))
+        os.symlink(outside_dir, Path(workdir, "link-to-outside-dir"))
         captured = workdir
 
     assert not os.path.exists(captured), "workspace leaked"
     assert outsider.exists(), "cleanup deleted a file outside the workspace"
-    assert outside_dir.is_dir(), "cleanup deleted a tree outside the workspace"
+    assert (outside_dir / "keep.txt").exists(), (
+        "cleanup followed a link and deleted a tree outside the workspace"
+    )
     assert os.stat(outsider).st_mode == outsider_before, (
-        "cleanup chmod'd through a symlink and rewrote a file outside the workspace"
+        "cleanup rewrote the permissions of a file outside the workspace"
     )
     assert os.stat(outside_dir).st_mode == outside_dir_before, (
-        "cleanup chmod'd through a symlink and rewrote a directory outside "
-        "the workspace"
+        "cleanup rewrote the permissions of a directory outside the workspace"
     )
 
 

--- a/vllm_mlx/agents/profiles/codex.yaml
+++ b/vllm_mlx/agents/profiles/codex.yaml
@@ -58,7 +58,14 @@ testing:
   binary: codex
   # Codex CLI exposes a one-shot mode via `codex exec` for headless runs;
   # the older `codex '<query>'` shorthand still works on most installs.
-  query_cmd: "codex exec '{query}'"
+  #
+  # `--skip-git-repo-check` is load-bearing, not tidiness. Codex refuses to
+  # run outside a trusted git repo with "Not inside a trusted directory and
+  # --skip-git-repo-check was not specified", and the test runner inherits
+  # whatever cwd the caller had. Without the flag the e2e tests fail in
+  # ~100 ms with that refusal — reported as a rapid-mlx integration failure
+  # when nothing in rapid-mlx was ever reached (#1683).
+  query_cmd: "codex exec --skip-git-repo-check '{query}'"
   query_timeout: 120
   install_cmd: "brew install codex   # or: npm install -g @openai/codex"
 

--- a/vllm_mlx/agents/testing.py
+++ b/vllm_mlx/agents/testing.py
@@ -732,13 +732,20 @@ def _e2e_workspace():
     the whole timeout. The fixture below makes the task the same task
     every time.
 
-    Second, blast radius: Codex is launched with ``--skip-git-repo-check``
-    (it refuses to run outside a trusted repo, and the runner cannot
-    assume one). Bypassing that check in an inherited, caller-controlled
-    directory would expose whatever the caller happened to be standing in
-    — including files and agent instructions from an untrusted checkout.
-    Bypassing it in a directory we just created, containing one file we
-    wrote, does not.
+    Second, a defined starting point. Codex is launched with
+    ``--skip-git-repo-check`` (it refuses to run outside a trusted repo,
+    and the runner cannot assume one), so it will pick up whatever is in
+    the directory it starts in — including files and agent instructions
+    left lying around. Starting it in a directory we just created, holding
+    one file we wrote, makes that set knowable.
+
+    **This is not a sandbox and does not pretend to be.** The agent still
+    runs as the user, with the user's environment and `$HOME`, and can
+    read anything the user can by absolute path. Isolating that would take
+    a real filesystem sandbox with its own home; what this gives is a
+    deterministic *working directory*, which is what the e2e tests depend
+    on. Codex additionally runs its own commands under Seatbelt on macOS,
+    which is its business, not something arranged here.
     """
     workdir = tempfile.mkdtemp(prefix="rapid-mlx-agent-e2e-")
     try:
@@ -934,25 +941,30 @@ def _test_e2e_chat(
 ) -> TestResult:
     """Agent basic chat."""
     t0 = time.time()
-    try:
-        with _workspace_or(cwd) as workdir:
-            out, err = _agent_query(
-                binary,
-                query_cmd,
-                "What is 2+2? Reply with just the number.",
-                timeout,
-                workdir,
+    with contextlib.ExitStack() as stack:
+        try:
+            # Only the workspace ENTRY is guarded here. Widening this
+            # to cover the query too would relabel a launch failure
+            # (EACCES on the binary, say) as a workspace problem and
+            # hide what actually went wrong.
+            workdir = stack.enter_context(_workspace_or(cwd))
+        except OSError as exc:
+            # A full or read-only temp filesystem is an environment
+            # failure, not an agent failure. Report it as this test's
+            # ERROR instead of taking the whole runner down with it.
+            return TestResult(
+                "e2e_chat",
+                TestStatus.ERROR,
+                duration_ms=(time.time() - t0) * 1000,
+                message=f"agent workspace unavailable: {exc}",
+                category="e2e",
             )
-    except OSError as exc:
-        # A full or read-only temp filesystem is an environment
-        # failure, not an agent failure. Report it as this test's
-        # ERROR instead of taking the whole runner down with it.
-        return TestResult(
-            "e2e_chat",
-            TestStatus.ERROR,
-            duration_ms=(time.time() - t0) * 1000,
-            message=f"agent workspace unavailable: {exc}",
-            category="e2e",
+        out, err = _agent_query(
+            binary,
+            query_cmd,
+            "What is 2+2? Reply with just the number.",
+            timeout,
+            workdir,
         )
     if err:
         status = _err_to_status(err)
@@ -984,25 +996,30 @@ def _test_e2e_file_read(
 ) -> TestResult:
     """Agent reads a file via tool call."""
     t0 = time.time()
-    try:
-        with _workspace_or(cwd) as workdir:
-            out, err = _agent_query(
-                binary,
-                query_cmd,
-                "Read the first line of pyproject.toml",
-                timeout,
-                workdir,
+    with contextlib.ExitStack() as stack:
+        try:
+            # Only the workspace ENTRY is guarded here. Widening this
+            # to cover the query too would relabel a launch failure
+            # (EACCES on the binary, say) as a workspace problem and
+            # hide what actually went wrong.
+            workdir = stack.enter_context(_workspace_or(cwd))
+        except OSError as exc:
+            # A full or read-only temp filesystem is an environment
+            # failure, not an agent failure. Report it as this test's
+            # ERROR instead of taking the whole runner down with it.
+            return TestResult(
+                "e2e_file_read",
+                TestStatus.ERROR,
+                duration_ms=(time.time() - t0) * 1000,
+                message=f"agent workspace unavailable: {exc}",
+                category="e2e",
             )
-    except OSError as exc:
-        # A full or read-only temp filesystem is an environment
-        # failure, not an agent failure. Report it as this test's
-        # ERROR instead of taking the whole runner down with it.
-        return TestResult(
-            "e2e_file_read",
-            TestStatus.ERROR,
-            duration_ms=(time.time() - t0) * 1000,
-            message=f"agent workspace unavailable: {exc}",
-            category="e2e",
+        out, err = _agent_query(
+            binary,
+            query_cmd,
+            "Read the first line of pyproject.toml",
+            timeout,
+            workdir,
         )
     if err:
         status = _err_to_status(err)
@@ -1037,25 +1054,30 @@ def _test_e2e_terminal(
     """Agent runs a shell command."""
     t0 = time.time()
     marker = f"rapidmlx_{agent_name}_test"
-    try:
-        with _workspace_or(cwd) as workdir:
-            out, err = _agent_query(
-                binary,
-                query_cmd,
-                f"Run 'echo {marker}' and show me the output",
-                timeout,
-                workdir,
+    with contextlib.ExitStack() as stack:
+        try:
+            # Only the workspace ENTRY is guarded here. Widening this
+            # to cover the query too would relabel a launch failure
+            # (EACCES on the binary, say) as a workspace problem and
+            # hide what actually went wrong.
+            workdir = stack.enter_context(_workspace_or(cwd))
+        except OSError as exc:
+            # A full or read-only temp filesystem is an environment
+            # failure, not an agent failure. Report it as this test's
+            # ERROR instead of taking the whole runner down with it.
+            return TestResult(
+                "e2e_terminal",
+                TestStatus.ERROR,
+                duration_ms=(time.time() - t0) * 1000,
+                message=f"agent workspace unavailable: {exc}",
+                category="e2e",
             )
-    except OSError as exc:
-        # A full or read-only temp filesystem is an environment
-        # failure, not an agent failure. Report it as this test's
-        # ERROR instead of taking the whole runner down with it.
-        return TestResult(
-            "e2e_terminal",
-            TestStatus.ERROR,
-            duration_ms=(time.time() - t0) * 1000,
-            message=f"agent workspace unavailable: {exc}",
-            category="e2e",
+        out, err = _agent_query(
+            binary,
+            query_cmd,
+            f"Run 'echo {marker}' and show me the output",
+            timeout,
+            workdir,
         )
     if err:
         status = _err_to_status(err)

--- a/vllm_mlx/agents/testing.py
+++ b/vllm_mlx/agents/testing.py
@@ -759,46 +759,33 @@ def _e2e_workspace():
 
 
 def _remove_workspace(workdir: str) -> None:
-    """Delete the workspace, and say so if it cannot be deleted.
+    """Delete the workspace, and say so out loud if it cannot be deleted.
 
-    An agent that chmods a directory it created leaves `rmtree` unable to
-    descend. Swallowing that with ``ignore_errors=True`` turns a gate that
-    runs on every release into a slow disk leak nobody is told about, so
-    retry with the permissions restored and, failing that, warn.
+    Deliberately no permission-repair pass. Two earlier attempts at one were
+    both wrong, and the second review round explained why the whole idea is:
 
-    Two things the recovery has to get right, both found in review:
+    * chmod'ing a path we just checked with ``islink()`` is a TOCTOU — the
+      agent can swap the directory for a link in between, and the write lands
+      outside the workspace.
+    * defeating that properly means descriptor-relative traversal, which is a
+      lot of machinery for a test harness.
 
-    * **The root comes first.** A directory with no execute bit cannot be
-      listed, so if the agent locked the workspace root, walking it before
-      restoring it finds nothing to fix and the retry fails for the same
-      reason the first attempt did.
-    * **Never chmod a symlink.** ``os.chmod`` follows links, so a link the
-      agent pointed at a file outside the workspace would have THAT file's
-      permissions changed by our cleanup. Only directories need restoring
-      anyway — unlinking a file requires permission on its parent, not on
-      the file — and ``os.walk`` does not follow links, so skipping linked
-      directories is sufficient.
+    And it buys nothing. The agent runs as the SAME user with the same
+    permissions we have; anything our cleanup could be tricked into chmod'ing,
+    the agent can chmod itself, directly. There is no privilege boundary here
+    to defend, so a repair pass only adds a symlink-following write primitive
+    to our own code.
+
+    What the original NIT actually asked for was not silence. A workspace we
+    cannot remove is reported, once, with the path — and that is where it
+    stops.
     """
     shutil.rmtree(workdir, ignore_errors=True)
-    if not os.path.exists(workdir):
-        return
-    if not os.path.islink(workdir):
-        with contextlib.suppress(OSError):
-            os.chmod(workdir, 0o700)
-    # Top-down: each directory is made traversable before os.walk descends
-    # into it.
-    for root, dirs, _files in os.walk(workdir):
-        for name in dirs:
-            path = os.path.join(root, name)
-            if os.path.islink(path):
-                continue
-            with contextlib.suppress(OSError):
-                os.chmod(path, 0o700)
-    try:
-        shutil.rmtree(workdir)
-    except OSError as exc:
+    if os.path.exists(workdir):
         logger.warning(
-            "agent e2e workspace could not be removed: %s (%s)", workdir, exc
+            "agent e2e workspace could not be removed and is being left behind: "
+            "%s — the agent most likely changed permissions inside it",
+            workdir,
         )
 
 

--- a/vllm_mlx/agents/testing.py
+++ b/vllm_mlx/agents/testing.py
@@ -934,13 +934,25 @@ def _test_e2e_chat(
 ) -> TestResult:
     """Agent basic chat."""
     t0 = time.time()
-    with _workspace_or(cwd) as workdir:
-        out, err = _agent_query(
-            binary,
-            query_cmd,
-            "What is 2+2? Reply with just the number.",
-            timeout,
-            workdir,
+    try:
+        with _workspace_or(cwd) as workdir:
+            out, err = _agent_query(
+                binary,
+                query_cmd,
+                "What is 2+2? Reply with just the number.",
+                timeout,
+                workdir,
+            )
+    except OSError as exc:
+        # A full or read-only temp filesystem is an environment
+        # failure, not an agent failure. Report it as this test's
+        # ERROR instead of taking the whole runner down with it.
+        return TestResult(
+            "e2e_chat",
+            TestStatus.ERROR,
+            duration_ms=(time.time() - t0) * 1000,
+            message=f"agent workspace unavailable: {exc}",
+            category="e2e",
         )
     if err:
         status = _err_to_status(err)
@@ -972,9 +984,25 @@ def _test_e2e_file_read(
 ) -> TestResult:
     """Agent reads a file via tool call."""
     t0 = time.time()
-    with _workspace_or(cwd) as workdir:
-        out, err = _agent_query(
-            binary, query_cmd, "Read the first line of pyproject.toml", timeout, workdir
+    try:
+        with _workspace_or(cwd) as workdir:
+            out, err = _agent_query(
+                binary,
+                query_cmd,
+                "Read the first line of pyproject.toml",
+                timeout,
+                workdir,
+            )
+    except OSError as exc:
+        # A full or read-only temp filesystem is an environment
+        # failure, not an agent failure. Report it as this test's
+        # ERROR instead of taking the whole runner down with it.
+        return TestResult(
+            "e2e_file_read",
+            TestStatus.ERROR,
+            duration_ms=(time.time() - t0) * 1000,
+            message=f"agent workspace unavailable: {exc}",
+            category="e2e",
         )
     if err:
         status = _err_to_status(err)
@@ -1009,13 +1037,25 @@ def _test_e2e_terminal(
     """Agent runs a shell command."""
     t0 = time.time()
     marker = f"rapidmlx_{agent_name}_test"
-    with _workspace_or(cwd) as workdir:
-        out, err = _agent_query(
-            binary,
-            query_cmd,
-            f"Run 'echo {marker}' and show me the output",
-            timeout,
-            workdir,
+    try:
+        with _workspace_or(cwd) as workdir:
+            out, err = _agent_query(
+                binary,
+                query_cmd,
+                f"Run 'echo {marker}' and show me the output",
+                timeout,
+                workdir,
+            )
+    except OSError as exc:
+        # A full or read-only temp filesystem is an environment
+        # failure, not an agent failure. Report it as this test's
+        # ERROR instead of taking the whole runner down with it.
+        return TestResult(
+            "e2e_terminal",
+            TestStatus.ERROR,
+            duration_ms=(time.time() - t0) * 1000,
+            message=f"agent workspace unavailable: {exc}",
+            category="e2e",
         )
     if err:
         status = _err_to_status(err)

--- a/vllm_mlx/agents/testing.py
+++ b/vllm_mlx/agents/testing.py
@@ -747,6 +747,15 @@ def _agent_query(
             text=True,
             timeout=timeout,
             cwd=os.getcwd(),
+            # Close stdin. Without this the child inherits ours, and a CLI
+            # that reads stdin when it isn't a TTY blocks until `timeout`
+            # instead of answering the query it was handed on argv. Codex
+            # does exactly that — `codex exec '<query>'` prints "Reading
+            # additional input from stdin..." and then waits forever, so
+            # the e2e gate spent its whole budget on a process that never
+            # got a chance to fail. Every agent CLI runs headless here, so
+            # none of them has any business reading stdin (#1683).
+            stdin=subprocess.DEVNULL,
         )
         output = proc.stdout + proc.stderr
         if "error" in output.lower() and "HTTP 4" in output:

--- a/vllm_mlx/agents/testing.py
+++ b/vllm_mlx/agents/testing.py
@@ -13,15 +13,18 @@ Usage:
 
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
 import os
 import re
 import shutil
 import subprocess
+import tempfile
 import time
 from dataclasses import dataclass, field
 from enum import Enum
+from pathlib import Path
 
 import httpx
 
@@ -706,8 +709,51 @@ def _test_tag_suppression(
 # ---------------------------------------------------------------------------
 
 
+@contextlib.contextmanager
+def _e2e_workspace():
+    """A throwaway directory for the agent to work in.
+
+    The e2e tests hand a real coding agent a real working directory, and
+    two things follow from that.
+
+    First, correctness: `_test_e2e_file_read` asks the agent to read
+    ``pyproject.toml``. Run from the caller's cwd that only works when
+    the caller happened to be standing in a Python project — from
+    anywhere else the agent hunts for a file that isn't there and burns
+    the whole timeout. The fixture below makes the task the same task
+    every time.
+
+    Second, blast radius: Codex is launched with ``--skip-git-repo-check``
+    (it refuses to run outside a trusted repo, and the runner cannot
+    assume one). Bypassing that check in an inherited, caller-controlled
+    directory would expose whatever the caller happened to be standing in
+    — including files and agent instructions from an untrusted checkout.
+    Bypassing it in a directory we just created, containing one file we
+    wrote, does not.
+    """
+    workdir = tempfile.mkdtemp(prefix="rapid-mlx-agent-e2e-")
+    try:
+        # Minimal but real: the first line is what `_test_e2e_file_read`
+        # asks for, and both of its accepted substrings ("build",
+        # "project") appear, so the assertion does not depend on which
+        # part of the file the agent chooses to quote back.
+        Path(workdir, "pyproject.toml").write_text(
+            "[build-system]\n"
+            'requires = ["hatchling"]\n'
+            'build-backend = "hatchling.build"\n'
+            "\n"
+            "[project]\n"
+            'name = "rapid-mlx-agent-e2e-fixture"\n'
+            'version = "0.0.0"\n',
+            encoding="utf-8",
+        )
+        yield workdir
+    finally:
+        shutil.rmtree(workdir, ignore_errors=True)
+
+
 def _agent_query(
-    binary: str, query_cmd: str, query: str, timeout: int = 120
+    binary: str, query_cmd: str, query: str, timeout: int = 120, cwd: str | None = None
 ) -> tuple[str | None, str | None]:
     """Run a single agent query. Returns (output, error).
 
@@ -746,7 +792,10 @@ def _agent_query(
             capture_output=True,
             text=True,
             timeout=timeout,
-            cwd=os.getcwd(),
+            # An explicit workspace, not the caller's cwd — see
+            # ``_e2e_workspace``. Falling back to os.getcwd() keeps any
+            # caller that hasn't opted in behaving exactly as before.
+            cwd=cwd or os.getcwd(),
             # Close stdin. Without this the child inherits ours, and a CLI
             # that reads stdin when it isn't a TTY blocks until `timeout`
             # instead of answering the query it was handed on argv. Codex
@@ -826,11 +875,13 @@ def _err_to_status(err: str | None) -> TestStatus:
     return TestStatus.ERROR
 
 
-def _test_e2e_chat(binary: str, query_cmd: str, timeout: int) -> TestResult:
+def _test_e2e_chat(
+    binary: str, query_cmd: str, timeout: int, cwd: str | None = None
+) -> TestResult:
     """Agent basic chat."""
     t0 = time.time()
     out, err = _agent_query(
-        binary, query_cmd, "What is 2+2? Reply with just the number.", timeout
+        binary, query_cmd, "What is 2+2? Reply with just the number.", timeout, cwd
     )
     if err:
         status = _err_to_status(err)
@@ -857,11 +908,13 @@ def _test_e2e_chat(binary: str, query_cmd: str, timeout: int) -> TestResult:
     )
 
 
-def _test_e2e_file_read(binary: str, query_cmd: str, timeout: int) -> TestResult:
+def _test_e2e_file_read(
+    binary: str, query_cmd: str, timeout: int, cwd: str | None = None
+) -> TestResult:
     """Agent reads a file via tool call."""
     t0 = time.time()
     out, err = _agent_query(
-        binary, query_cmd, "Read the first line of pyproject.toml", timeout
+        binary, query_cmd, "Read the first line of pyproject.toml", timeout, cwd
     )
     if err:
         status = _err_to_status(err)
@@ -889,13 +942,13 @@ def _test_e2e_file_read(binary: str, query_cmd: str, timeout: int) -> TestResult
 
 
 def _test_e2e_terminal(
-    binary: str, query_cmd: str, timeout: int, agent_name: str
+    binary: str, query_cmd: str, timeout: int, agent_name: str, cwd: str | None = None
 ) -> TestResult:
     """Agent runs a shell command."""
     t0 = time.time()
     marker = f"rapidmlx_{agent_name}_test"
     out, err = _agent_query(
-        binary, query_cmd, f"Run 'echo {marker}' and show me the output", timeout
+        binary, query_cmd, f"Run 'echo {marker}' and show me the output", timeout, cwd
     )
     if err:
         status = _err_to_status(err)
@@ -1108,23 +1161,29 @@ class AgentTestRunner:
         # --- E2E tests ---
         if self._agent_binary_available() and testing.binary and testing.query_cmd:
             binary = os.path.expanduser(testing.binary)
-            report.results.append(
-                _test_e2e_chat(binary, testing.query_cmd, testing.query_timeout)
-            )
-            if self.profile.needs_function_calling:
+            # One workspace for all three: the agent gets a directory we
+            # built, not whatever the caller happened to be standing in.
+            with _e2e_workspace() as workdir:
                 report.results.append(
-                    _test_e2e_file_read(
-                        binary, testing.query_cmd, testing.query_timeout
+                    _test_e2e_chat(
+                        binary, testing.query_cmd, testing.query_timeout, workdir
                     )
                 )
-                report.results.append(
-                    _test_e2e_terminal(
-                        binary,
-                        testing.query_cmd,
-                        testing.query_timeout,
-                        self.profile.name,
+                if self.profile.needs_function_calling:
+                    report.results.append(
+                        _test_e2e_file_read(
+                            binary, testing.query_cmd, testing.query_timeout, workdir
+                        )
                     )
-                )
+                    report.results.append(
+                        _test_e2e_terminal(
+                            binary,
+                            testing.query_cmd,
+                            testing.query_timeout,
+                            self.profile.name,
+                            workdir,
+                        )
+                    )
         elif testing.binary:
             # Two distinct skip reasons land here:
             #   (a) binary on PATH but profile has `query_cmd: null`

--- a/vllm_mlx/agents/testing.py
+++ b/vllm_mlx/agents/testing.py
@@ -709,6 +709,15 @@ def _test_tag_suppression(
 # ---------------------------------------------------------------------------
 
 
+# The fixture's first line, and the only thing `_test_e2e_file_read`
+# accepts back. It has to be a sentinel: the previous assertion passed on
+# "build" or "project" appearing anywhere in the agent's output, which any
+# answer that merely mentions the project — or reads some other file —
+# satisfies without ever having read the line the test asks for.
+E2E_FIRST_LINE_TOKEN = "rapid-mlx-e2e-first-line-sentinel"
+E2E_FIRST_LINE = f"# {E2E_FIRST_LINE_TOKEN}"
+
+
 @contextlib.contextmanager
 def _e2e_workspace():
     """A throwaway directory for the agent to work in.
@@ -733,11 +742,8 @@ def _e2e_workspace():
     """
     workdir = tempfile.mkdtemp(prefix="rapid-mlx-agent-e2e-")
     try:
-        # Minimal but real: the first line is what `_test_e2e_file_read`
-        # asks for, and both of its accepted substrings ("build",
-        # "project") appear, so the assertion does not depend on which
-        # part of the file the agent chooses to quote back.
         Path(workdir, "pyproject.toml").write_text(
+            f"{E2E_FIRST_LINE}\n"
             "[build-system]\n"
             'requires = ["hatchling"]\n'
             'build-backend = "hatchling.build"\n'
@@ -749,7 +755,49 @@ def _e2e_workspace():
         )
         yield workdir
     finally:
-        shutil.rmtree(workdir, ignore_errors=True)
+        _remove_workspace(workdir)
+
+
+def _remove_workspace(workdir: str) -> None:
+    """Delete the workspace, and say so if it cannot be deleted.
+
+    An agent that chmods a directory it created leaves `rmtree` unable to
+    descend. Swallowing that with ``ignore_errors=True`` turns a gate that
+    runs on every release into a slow disk leak nobody is told about, so
+    retry with the permissions restored and, failing that, warn.
+    """
+    shutil.rmtree(workdir, ignore_errors=True)
+    if not os.path.exists(workdir):
+        return
+    for root, dirs, files in os.walk(workdir):
+        for name in dirs + files:
+            with contextlib.suppress(OSError):
+                os.chmod(os.path.join(root, name), 0o700)
+    with contextlib.suppress(OSError):
+        os.chmod(workdir, 0o700)
+    try:
+        shutil.rmtree(workdir)
+    except OSError as exc:
+        logger.warning(
+            "agent e2e workspace could not be removed: %s (%s)", workdir, exc
+        )
+
+
+@contextlib.contextmanager
+def _workspace_or(cwd: str | None):
+    """The caller's directory if it named one, otherwise a fresh workspace.
+
+    Each e2e test gets its OWN workspace. Sharing one across the three
+    invocations would let whatever the chat agent wrote — a file, a
+    stray AGENTS.md, a half-applied patch — become the next test's
+    starting condition, which is precisely the contamination the
+    workspace exists to prevent.
+    """
+    if cwd is not None:
+        yield cwd
+    else:
+        with _e2e_workspace() as workdir:
+            yield workdir
 
 
 def _agent_query(
@@ -880,9 +928,14 @@ def _test_e2e_chat(
 ) -> TestResult:
     """Agent basic chat."""
     t0 = time.time()
-    out, err = _agent_query(
-        binary, query_cmd, "What is 2+2? Reply with just the number.", timeout, cwd
-    )
+    with _workspace_or(cwd) as workdir:
+        out, err = _agent_query(
+            binary,
+            query_cmd,
+            "What is 2+2? Reply with just the number.",
+            timeout,
+            workdir,
+        )
     if err:
         status = _err_to_status(err)
         return TestResult(
@@ -913,9 +966,10 @@ def _test_e2e_file_read(
 ) -> TestResult:
     """Agent reads a file via tool call."""
     t0 = time.time()
-    out, err = _agent_query(
-        binary, query_cmd, "Read the first line of pyproject.toml", timeout, cwd
-    )
+    with _workspace_or(cwd) as workdir:
+        out, err = _agent_query(
+            binary, query_cmd, "Read the first line of pyproject.toml", timeout, workdir
+        )
     if err:
         status = _err_to_status(err)
         return TestResult(
@@ -925,7 +979,9 @@ def _test_e2e_file_read(
             message=err,
             category="e2e",
         )
-    if "build" in (out or "").lower() or "project" in (out or "").lower():
+    # The sentinel, not "build" or "project" — those appear in any answer
+    # that merely talks about the project, or reads some other file.
+    if E2E_FIRST_LINE_TOKEN in (out or ""):
         return TestResult(
             "e2e_file_read",
             TestStatus.PASS,
@@ -947,9 +1003,14 @@ def _test_e2e_terminal(
     """Agent runs a shell command."""
     t0 = time.time()
     marker = f"rapidmlx_{agent_name}_test"
-    out, err = _agent_query(
-        binary, query_cmd, f"Run 'echo {marker}' and show me the output", timeout, cwd
-    )
+    with _workspace_or(cwd) as workdir:
+        out, err = _agent_query(
+            binary,
+            query_cmd,
+            f"Run 'echo {marker}' and show me the output",
+            timeout,
+            workdir,
+        )
     if err:
         status = _err_to_status(err)
         return TestResult(
@@ -1161,29 +1222,26 @@ class AgentTestRunner:
         # --- E2E tests ---
         if self._agent_binary_available() and testing.binary and testing.query_cmd:
             binary = os.path.expanduser(testing.binary)
-            # One workspace for all three: the agent gets a directory we
-            # built, not whatever the caller happened to be standing in.
-            with _e2e_workspace() as workdir:
+            # No shared workspace here on purpose: each _test_e2e_* opens
+            # its own, so one invocation's leftovers cannot become the
+            # next one's starting condition.
+            report.results.append(
+                _test_e2e_chat(binary, testing.query_cmd, testing.query_timeout)
+            )
+            if self.profile.needs_function_calling:
                 report.results.append(
-                    _test_e2e_chat(
-                        binary, testing.query_cmd, testing.query_timeout, workdir
+                    _test_e2e_file_read(
+                        binary, testing.query_cmd, testing.query_timeout
                     )
                 )
-                if self.profile.needs_function_calling:
-                    report.results.append(
-                        _test_e2e_file_read(
-                            binary, testing.query_cmd, testing.query_timeout, workdir
-                        )
+                report.results.append(
+                    _test_e2e_terminal(
+                        binary,
+                        testing.query_cmd,
+                        testing.query_timeout,
+                        self.profile.name,
                     )
-                    report.results.append(
-                        _test_e2e_terminal(
-                            binary,
-                            testing.query_cmd,
-                            testing.query_timeout,
-                            self.profile.name,
-                            workdir,
-                        )
-                    )
+                )
         elif testing.binary:
             # Two distinct skip reasons land here:
             #   (a) binary on PATH but profile has `query_cmd: null`

--- a/vllm_mlx/agents/testing.py
+++ b/vllm_mlx/agents/testing.py
@@ -765,16 +765,35 @@ def _remove_workspace(workdir: str) -> None:
     descend. Swallowing that with ``ignore_errors=True`` turns a gate that
     runs on every release into a slow disk leak nobody is told about, so
     retry with the permissions restored and, failing that, warn.
+
+    Two things the recovery has to get right, both found in review:
+
+    * **The root comes first.** A directory with no execute bit cannot be
+      listed, so if the agent locked the workspace root, walking it before
+      restoring it finds nothing to fix and the retry fails for the same
+      reason the first attempt did.
+    * **Never chmod a symlink.** ``os.chmod`` follows links, so a link the
+      agent pointed at a file outside the workspace would have THAT file's
+      permissions changed by our cleanup. Only directories need restoring
+      anyway — unlinking a file requires permission on its parent, not on
+      the file — and ``os.walk`` does not follow links, so skipping linked
+      directories is sufficient.
     """
     shutil.rmtree(workdir, ignore_errors=True)
     if not os.path.exists(workdir):
         return
-    for root, dirs, files in os.walk(workdir):
-        for name in dirs + files:
+    if not os.path.islink(workdir):
+        with contextlib.suppress(OSError):
+            os.chmod(workdir, 0o700)
+    # Top-down: each directory is made traversable before os.walk descends
+    # into it.
+    for root, dirs, _files in os.walk(workdir):
+        for name in dirs:
+            path = os.path.join(root, name)
+            if os.path.islink(path):
+                continue
             with contextlib.suppress(OSError):
-                os.chmod(os.path.join(root, name), 0o700)
-    with contextlib.suppress(OSError):
-        os.chmod(workdir, 0o700)
+                os.chmod(path, 0o700)
     try:
         shutil.rmtree(workdir)
     except OSError as exc:


### PR DESCRIPTION
## Why

G7b's codex e2e tests have been failing for reasons that live entirely **between the test runner and the Codex CLI**. rapid-mlx was never reached, but the failure surfaced as a rapid-mlx integration failure — so the gate has been reporting on something it never measured.

### 1. The child inherited stdin

`_agent_query` called `subprocess.run(...)` with no `stdin=`, so the agent CLI inherited ours. A CLI that reads stdin when it isn't a TTY then blocks until `query_timeout` instead of answering the query it was handed on argv. Codex does exactly this:

```
$ codex exec 'What is 2+2? Reply with just the number.'
Reading additional input from stdin...
```

Every agent CLI here runs headless, so none of them has any business reading stdin.

### 2. The codex profile omitted `--skip-git-repo-check`

```
Not inside a trusted directory and --skip-git-repo-check was not specified.
```

The runner inherits the caller's cwd, so from a neutral directory every codex e2e test failed in ~100 ms with that refusal. Same bug as (1) wearing a different symptom depending on where you stood.

### 3. …which means the agent needs a directory we own

Bypassing the trust check in an inherited, caller-controlled directory would expose whatever the caller happened to be standing in — including files and agent instructions from an untrusted checkout. Each e2e test now runs in its own `_e2e_workspace()`: a fresh temp directory holding one file we wrote, removed afterwards.

That also fixes a second-order bug already visible in the gate: `_test_e2e_file_read` asks the agent to read `pyproject.toml`, which only existed when the caller happened to be standing in a Python project. Run from anywhere else the agent hunted for a file that wasn't there and burned the whole timeout.

## Measured

M3 Ultra, local `qwen3.5-9b-4bit` server, `rapid-mlx agents codex --test` run from `/tmp` — no git repo, no `pyproject.toml`:

| | before | after |
|---|---|---|
| `e2e_chat` | ❌ FAIL (101 ms) — "Not inside a trusted directory" | ✅ PASS (34.9 s) |
| `e2e_terminal` | ✅ | ✅ |
| base tests | 10/12 | 11/12 |

## Review rounds

Three rounds, six BLOCKING findings, each reproduced before it was fixed:

| round | finding | reproduced as |
|---|---|---|
| 1 | trust check bypassed in an inherited cwd | — |
| 2 | one workspace shared by all three e2e tests | "both e2e tests ran in the SAME directory" |
| 2 | `"build"`/`"project"` accepted anywhere in the answer | a reply that never opened the file passed |
| 3 | `os.chmod` follows symlinks | an outside file created `0o600` came back `0o700` (`st_mode=33216`) |
| 3 | walk ran before the root's permissions were restored | locked root hid every descendant from recovery |

Round 2's first finding also caught a bad test of mine: `test_workspace_is_fresh_each_time` asserted that two `_e2e_workspace()` calls return different paths — a property of the helper, not of the runner, and the runner is what decides how many workspaces exist. It has been replaced with one that drives the real `_test_e2e_*` entry points against a real subprocess and reads back the directories they actually ran in.

## On the tests

12 tests. The ones that matter use the real thing rather than a mock, because a mock would only restate the diff:

- the stdin test drives a **real subprocess against a real pipe on fd 0** — reproducing the hang needs the actual inherited descriptor
- the workspace-isolation test drives the **real `_test_e2e_*` functions** and reads back their actual cwds
- the symlink test plants links to a real outside file and a real outside directory and checks their `st_mode` afterwards

Every fix fails its own test when reverted; I checked each one.

## Not fixed here

`e2e_file_read` still fails on the gauntlet's default `qwen3.5-9b-4bit`, and that one is **model competence, not the engine**. Same task, same server, same codex invocation:

| model | result |
|---|---|
| `qwen3.5-9b-4bit` | tool call succeeds in 0 ms and returns the first line, then the loop never terminates — killed at 600 s |
| `qwen3.6-35b-4bit` | correct answer, terminates in **55.9 s**; full gate **12/12 in 66.8 s** |

`codex.yaml` claims "9B is the practical floor"; that claim is falsified by this measurement for the multi-tool workload. Whether the gauntlet should raise its agent-gate model is a release-policy call, tracked on #1683 rather than decided here.

Refs #1683