### PR TITLE
fix(mac): harden model catalog and safe defaults

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Server/ModelCatalog.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ModelCatalog.swift
@@ -427,9 +427,16 @@ enum ModelCatalog {
             // the word) keeps a genuine alias that merely starts with
             // those letters safe.
             if isBannerLine(line) { continue }
-            // First whitespace-delimited token is the alias.
-            let token = line.split(maxSplits: 1, whereSeparator: { $0.isWhitespace }).first
-            guard let alias = token.map(String.init), !alias.isEmpty else { continue }
+            // Catalog rows are column-aligned with runs of 2+ spaces.
+            // Requiring a second column keeps prose footers out of the
+            // catalog. In particular, current engines end with
+            // "Size is an approximate download footprint ..."; taking the
+            // first whitespace token alone promoted a phantom model named
+            // "Size" into Settings and the picker.
+            let columns = splitOnMultiSpace(line)
+            guard columns.count >= 2 else { continue }
+            let alias = columns[0]
+            guard !alias.isEmpty else { continue }
             guard isSafeAlias(alias) else { continue }
             entries.append((alias, nil))
         }

--- a/apps/rapid-mac/Sources/Rapid/Server/RAMBucketedDefault.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/RAMBucketedDefault.swift
@@ -433,12 +433,20 @@ enum SafeDefaultFallback {
 /// once and threads the snapshot in. Tested directly in
 /// ``CacheAwareDefaultTests``.
 enum CacheAwareDefault {
+    /// Models that remain manually selectable but must never be chosen by an
+    /// automatic default policy. Bonsai 1.7B was retired after repeatedly
+    /// degenerating in ordinary plain chat; cached weights are not a reason to
+    /// resurrect it on relaunch when auto-start is disabled.
+    static let retiredAutomaticAliases: Set<String> = ["bonsai-1.7b-2bit"]
+
     static func pick(
         catalog: [ModelEntry],
         hardware: MacHardware,
-        bucketedDefault: String
+        bucketedDefault: String,
+        excludedAliases: Set<String> = retiredAutomaticAliases
     ) -> String? {
-        let bucketedEntry = catalog.first(where: { $0.alias == bucketedDefault })
+        let eligibleCatalog = catalog.filter { !excludedAliases.contains($0.alias) }
+        let bucketedEntry = eligibleCatalog.first(where: { $0.alias == bucketedDefault })
         // The RAM-tier primary is trusted to fit even when ModelSizing's
         // heuristic over-states it (it scores the real-7.6 GB
         // bonsai-27b-2bit as ~14.8 GB → .tooBig on 16 GB). Without this
@@ -472,7 +480,7 @@ enum CacheAwareDefault {
         // out unparseable-params aliases so a cached coder/flash
         // quant doesn't phantom-classify as small and land us in an
         // OOM (codex r3 on #165).
-        let cachedCandidates = catalog
+        let cachedCandidates = eligibleCatalog
             .filter { $0.cached }
             .filter { ModelSizing.estimate(alias: $0.alias).paramsBillions != nil }
             .filter { isSafe($0, on: hardware) }
@@ -489,7 +497,7 @@ enum CacheAwareDefault {
         // Step 4: bucketed is .tooBig OR missing — hand off to the
         // existing hardware-floor escape so we never silently
         // promote a .tooBig cached alias above a safe one.
-        return SafeDefaultFallback.pick(catalog: catalog, hardware: hardware)
+        return SafeDefaultFallback.pick(catalog: eligibleCatalog, hardware: hardware)
     }
 
     private static func isSafe(_ entry: ModelEntry, on hardware: MacHardware) -> Bool {

--- a/apps/rapid-mac/Sources/Rapid/UI/ModelPickerBar.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ModelPickerBar.swift
@@ -197,6 +197,41 @@ struct ModelPickerBar: View {
            catalog.contains(where: { $0.alias == quickstartTargetAlias }) {
             return quickstartTargetAlias
         }
+        // A user who dismisses the Quickstart sheet has declined the guided
+        // download flow, not the starter itself.  Keep the picker aimed at the
+        // current coherent starter while that user remains Quickstart-eligible
+        // (brand-new install, or the retired Bonsai cohort we are rescuing).
+        //
+        // Without this gate the cache-aware fallback below can immediately
+        // resurrect ``bonsai-1.7b-2bit`` merely because its old weights are on
+        // disk.  That makes the sheet recommend LFM2.5 while the chat composer
+        // behind it says Bonsai — and Skip drops the user directly onto the
+        // model retired for degenerating in ordinary plain chat.
+        if let quickstart,
+           let starter = ModelPickerBar.quickstartEligibleDefault(
+               catalog: catalog,
+               eligible: QuickstartCoordinator.isEligible(
+               done: quickstart.done,
+               legacyDone: quickstart.legacyDone,
+               lastServedAlias: ServerManager.lastServedAlias(),
+               serverState: server.state
+               ),
+               targetAlias: quickstartTargetAlias
+           ) {
+            return starter
+        }
+        // Returning users expect the picker to remember the model they last
+        // ran even when they deliberately disable launch-time auto-start.
+        // ``ContentView.alias`` is view state, not AppStorage; without this
+        // branch a relaunch silently jumps to the first alphabetical cached
+        // model. Never restore a retired automatic alias — the stranded
+        // Quickstart branch above migrates that cohort to the current starter.
+        if let previous = ModelPickerBar.lastServedDefault(
+            catalog: catalog,
+            lastServedAlias: ServerManager.lastServedAlias()
+        ) {
+            return previous
+        }
         // v0.7.1 #229: on a fresh install the bundled lfm2.5-1b-4bit
         // is on disk and the user has never picked anything else.
         // Prefer it so the picker matches what the ContentView ``.task``
@@ -740,6 +775,37 @@ struct ModelPickerBar: View {
     /// promise depends on link speed — calling out "smallest /
     /// fastest" is honest regardless of the user's bandwidth.
     static let quickstartSubtitle: String = "Smallest model — fastest first install"
+
+    /// Resolve the safe picker default while the current user is still
+    /// eligible for Quickstart. Kept pure so the retired-starter regression
+    /// can be pinned without mounting the SwiftUI menu or touching defaults.
+    ///
+    /// A cached retired model must not outrank the coherent starter merely
+    /// because the user chose "Skip for now" in the onboarding sheet.
+    static func quickstartEligibleDefault(
+        catalog: [ModelEntry],
+        eligible: Bool,
+        targetAlias: String = QuickstartCoordinator.defaultChoice.alias
+    ) -> String? {
+        guard eligible, catalog.contains(where: { $0.alias == targetAlias }) else {
+            return nil
+        }
+        return targetAlias
+    }
+
+    /// Restore a returning user's last runnable choice without allowing a
+    /// retired starter to re-enter any automatic default path.
+    static func lastServedDefault(
+        catalog: [ModelEntry],
+        lastServedAlias: String?,
+        excludedAliases: Set<String> = CacheAwareDefault.retiredAutomaticAliases
+    ) -> String? {
+        guard let alias = lastServedAlias,
+              !excludedAliases.contains(alias),
+              catalog.contains(where: { $0.alias == alias && $0.cached })
+        else { return nil }
+        return alias
+    }
 
     /// Pure helper so the row title (which has to ride inside the
     /// single Text NSMenuItem honors) is unit-testable without a

--- a/apps/rapid-mac/Tests/RapidTests/DownloadCatalogHardeningTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/DownloadCatalogHardeningTests.swift
@@ -193,6 +193,23 @@ struct DownloadCatalogHardeningTests {
         #expect(!ModelCatalog.hasNonChatKindTag("odd [image:gen] org/repo"))
     }
 
+    @Test("parseAvailable drops the human-readable size footer")
+    func catalogParserDropsSizeFooter() {
+        let available = ModelCatalog.parseAvailable(
+            """
+              Available models (1 aliases)
+              ────────────────────────────────────────
+              Alias                 Size       Tools
+              lfm2.5-1b-4bit        563 MiB    —
+              ────────────────────────────────────────
+              Size is an approximate download footprint (weight+tokenizer); “—” = unknown. The exact size is confirmed at pull time.
+            """
+        )
+
+        #expect(available.map { $0.0 } == ["lfm2.5-1b-4bit"])
+        #expect(!available.contains(where: { $0.0 == "Size" }))
+    }
+
     @Test("ModelInfoCatalog sanitizes repo ids before UI link construction")
     func modelInfoSanitizesHuggingFaceRepo() {
         let safe = ModelInfoCatalog.info(for: "qwen3-8b", hfRepo: "mlx-community/Qwen3-8B-4bit")

--- a/apps/rapid-mac/Tests/RapidTests/ModelPickerBarSectionOrderTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ModelPickerBarSectionOrderTests.swift
@@ -71,6 +71,88 @@ struct ModelPickerBarSectionOrderTests {
         ]
     }
 
+    @Test("Quickstart-eligible user keeps coherent LFM starter even when retired Bonsai is cached")
+    func eligibleDefaultNeverResurrectsRetiredBonsai() {
+        let catalog = [
+            entry("bonsai-1.7b-2bit", hfRepo: "prism-ml/Ternary-Bonsai-1.7B-mlx-2bit", cached: true),
+            entry(QuickstartCoordinator.defaultChoice.alias,
+                  hfRepo: "mlx-community/LFM2.5-1.2B-Instruct-4bit",
+                  cached: false),
+            entry("bonsai-27b-2bit", hfRepo: "prism-ml/Ternary-Bonsai-27B-mlx-2bit", cached: false),
+        ]
+
+        let pick = ModelPickerBar.quickstartEligibleDefault(
+            catalog: catalog,
+            eligible: true
+        )
+
+        #expect(pick == "lfm2.5-1b-4bit")
+        #expect(pick != "bonsai-1.7b-2bit")
+    }
+
+    @Test("Completed or ineligible user is left to normal cache/RAM default policy")
+    func ineligibleDefaultDoesNotOverrideNormalPolicy() {
+        let catalog = [
+            entry("bonsai-1.7b-2bit", hfRepo: "prism-ml/Ternary-Bonsai-1.7B-mlx-2bit", cached: true),
+            entry(QuickstartCoordinator.defaultChoice.alias,
+                  hfRepo: "mlx-community/LFM2.5-1.2B-Instruct-4bit",
+                  cached: false),
+        ]
+
+        #expect(ModelPickerBar.quickstartEligibleDefault(
+            catalog: catalog,
+            eligible: false
+        ) == nil)
+    }
+
+    @Test("Auto-start off relaunch restores the last served non-retired model")
+    func lastServedModelIsRestored() {
+        let catalog = [
+            entry("bonsai-1.7b-2bit", hfRepo: "prism-ml/Ternary-Bonsai-1.7B-mlx-2bit", cached: true),
+            entry("qwen3-1.7b", hfRepo: "mlx-community/Qwen3-1.7B-4bit", cached: true),
+        ]
+
+        #expect(ModelPickerBar.lastServedDefault(
+            catalog: catalog,
+            lastServedAlias: "qwen3-1.7b"
+        ) == "qwen3-1.7b")
+    }
+
+    @Test("Last served retired Bonsai is never restored automatically")
+    func retiredLastServedModelIsRejected() {
+        let catalog = [
+            entry("bonsai-1.7b-2bit", hfRepo: "prism-ml/Ternary-Bonsai-1.7B-mlx-2bit", cached: true),
+            entry(QuickstartCoordinator.defaultChoice.alias,
+                  hfRepo: "mlx-community/LFM2.5-1.2B-Instruct-4bit",
+                  cached: true),
+        ]
+
+        #expect(ModelPickerBar.lastServedDefault(
+            catalog: catalog,
+            lastServedAlias: "bonsai-1.7b-2bit"
+        ) == nil)
+    }
+
+    @Test("Quickstart and automatic defaults agree on retired aliases")
+    func retiredAliasPoliciesStayInSync() {
+        #expect(QuickstartCoordinator.retiredStarters == CacheAwareDefault.retiredAutomaticAliases)
+    }
+
+    @Test("Deleted last-served model is not restored as a runnable default")
+    func uncachedLastServedModelIsRejected() {
+        let catalog = [
+            entry("qwen3-1.7b", hfRepo: "mlx-community/Qwen3-1.7B-4bit", cached: false),
+            entry(QuickstartCoordinator.defaultChoice.alias,
+                  hfRepo: "mlx-community/LFM2.5-1.2B-Instruct-4bit",
+                  cached: true),
+        ]
+
+        #expect(ModelPickerBar.lastServedDefault(
+            catalog: catalog,
+            lastServedAlias: "qwen3-1.7b"
+        ) == nil)
+    }
+
     @Test("Section order: Quickstart → Recommended → All (pinned by view-builder call order)")
     func sectionOrderPinned() throws {
         // The view-builder call order in ``ModelPickerBar.modelPicker``

--- a/apps/rapid-mac/Tests/RapidTests/RAMBucketedDefaultTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/RAMBucketedDefaultTests.swift
@@ -364,10 +364,11 @@ struct CacheAwareDefaultTests {
 
     // MARK: - Headline case (issue #436 repro)
 
-    @Test("256 GB Mac with Quickstart cached — picker defaults to cached bonsai-1.7b-2bit, not the bucketed pick")
-    func two56GBWithQuickstartCachedPrefersCached() {
+    @Test("256 GB Mac with retired Bonsai cached — picker chooses coherent cached LFM")
+    func retiredBonsaiNeverWinsCachedFallback() {
         let catalog = [
             entry("bonsai-1.7b-2bit", cached: true),
+            entry("lfm2.5-1b-4bit", cached: true),
             entry("qwen3.5-122b-mxfp4", cached: false),
         ]
         let pick = CacheAwareDefault.pick(
@@ -375,7 +376,7 @@ struct CacheAwareDefaultTests {
             hardware: host(gb: 256),
             bucketedDefault: "qwen3.5-122b-mxfp4"
         )
-        #expect(pick == "bonsai-1.7b-2bit")
+        #expect(pick == "lfm2.5-1b-4bit")
     }
 
     // MARK: - Step 1: bucketed is cached + fits → use it
@@ -417,13 +418,14 @@ struct CacheAwareDefaultTests {
     func bucketedMissingCachedWins() {
         let catalog = [
             entry("bonsai-1.7b-2bit", cached: true),
+            entry("lfm2.5-1b-4bit", cached: true),
         ]
         let pick = CacheAwareDefault.pick(
             catalog: catalog,
             hardware: host(gb: 256),
             bucketedDefault: "future-alias-not-yet-shipped"
         )
-        #expect(pick == "bonsai-1.7b-2bit")
+        #expect(pick == "lfm2.5-1b-4bit")
     }
 
     @Test("Step 2: cached candidate must FIT — .tooBig cached alias gets skipped, falls to bucketed")
@@ -506,10 +508,11 @@ struct CacheAwareDefaultTests {
 
     // MARK: - Slim-DMG real-world case
 
-    @Test("Slim DMG fresh install (Quickstart only) — picker defaults to cached bonsai-1.7b-2bit")
+    @Test("Slim DMG with retired cache — picker defaults to current coherent starter")
     func slimDMGFreshInstallPrefersQuickstart() {
         let catalog = [
             entry("bonsai-1.7b-2bit", cached: true),
+            entry("lfm2.5-1b-4bit", cached: true),
             entry("qwen3.5-4b-4bit", cached: false),
             entry("qwen3.5-9b-4bit", cached: false),
             entry("qwen3.6-35b-4bit", cached: false),
@@ -519,6 +522,6 @@ struct CacheAwareDefaultTests {
             hardware: host(gb: 256),
             bucketedDefault: "qwen3.5-122b-mxfp4"
         )
-        #expect(pick == "bonsai-1.7b-2bit")
+        #expect(pick == "lfm2.5-1b-4bit")
     }
 }

--- a/tests/test_cli_models.py
+++ b/tests/test_cli_models.py
@@ -287,6 +287,7 @@ def test_cached_view_renders_alias_for_known_repo(tmp_path, monkeypatch, capsys)
     monkeypatch.setattr(
         cli, "_scan_hf_cache_models", lambda: [(hf_path, 1024 * 1024 * 100, 0.0)]
     )
+    monkeypatch.setattr(cli, "_cache_entry_is_runnable", lambda _repo: True)
     cli._print_cached_models()
     out = capsys.readouterr().out
     assert alias in out, f"expected alias {alias!r} in cached view"
@@ -304,6 +305,34 @@ def test_cached_view_renders_unmapped_for_unknown_repo(monkeypatch, capsys):
     out = capsys.readouterr().out
     assert "(unmapped)" in out
     assert "totally-unmapped-repo" in out
+
+
+def test_cached_view_marks_known_partial_repo_incomplete(tmp_path, monkeypatch, capsys):
+    """Metadata-only cache directories must not advertise an alias as ready."""
+    from vllm_mlx.model_aliases import list_profiles
+
+    alias, profile = next(iter(list_profiles().items()))
+    cache_root = tmp_path / "hf-cache"
+    repo_root = cache_root / f"models--{profile.hf_path.replace('/', '--')}"
+    snapshot = repo_root / "snapshots" / "deadbeef"
+    snapshot.mkdir(parents=True)
+    (snapshot / "config.json").write_text("{}")
+    (snapshot / "tokenizer.json").write_text("{}")
+    refs = repo_root / "refs"
+    refs.mkdir()
+    (refs / "main").write_text("deadbeef")
+
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+    monkeypatch.setattr(
+        cli,
+        "_scan_hf_cache_models",
+        lambda: [(profile.hf_path, 61 * 1024 * 1024, 0.0)],
+    )
+
+    cli._print_cached_models()
+    out = capsys.readouterr().out
+    assert "(incomplete)" in out
+    assert alias not in out
 
 
 def test_format_bytes_unit_selection():

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -4872,6 +4872,26 @@ def _scan_hf_cache_models() -> list[tuple[str, int, float]]:
     return out
 
 
+def _cache_entry_is_runnable(repo: str) -> bool:
+    """Whether a cache directory contains a complete runnable snapshot.
+
+    A Hugging Face repo directory appears as soon as metadata starts
+    downloading.  Treating directory presence as "cached" made interrupted
+    downloads (config/tokenizer only, no weights) look ready in ``ls`` and in
+    the desktop model picker. Reuse the serve download gate's authoritative
+    completeness checks for both text and component-split video layouts.
+    """
+    try:
+        from vllm_mlx._download_gate import (
+            _snapshot_is_complete_split_model,
+            is_repo_cached,
+        )
+
+        return is_repo_cached(repo) or _snapshot_is_complete_split_model(repo)
+    except Exception:
+        return False
+
+
 def _print_cached_models() -> None:
     """Render the ``--cached`` view: locally-downloaded HF cache entries
     cross-referenced against the alias registry.
@@ -4923,6 +4943,12 @@ def _print_cached_models() -> None:
     for repo, size, mtime in sorted(rows, key=lambda r: -r[1]):
         total_bytes += size
         alias = hf_to_alias.get(repo, "(unmapped)")
+        # Keep partial directories visible for disk cleanup, but never label
+        # a known alias as downloaded/runnable. The desktop parser deliberately
+        # rejects parenthesized status rows, so this also prevents a 61 MiB
+        # metadata stub for a 26B model from receiving a green checkmark.
+        if alias != "(unmapped)" and not _cache_entry_is_runnable(repo):
+            alias = "(incomplete)"
         # Render modified as a human delta: "2 days ago" beats raw epoch.
         if mtime <= 0:
             mod = "?"


### PR DESCRIPTION
## Necessity

Without this PR, interrupted metadata-only downloads are presented as runnable, the human-readable `Size is ...` footer can become a selectable phantom model, and relaunch/default selection can resurrect the retired Bonsai starter or a deleted last-served model.

## What changed

- require real column-aligned rows when parsing `rapid-mlx models`, preventing prose footers such as `Size is ...` from becoming phantom models
- classify known Hugging Face cache directories without complete runnable snapshots as incomplete instead of downloaded
- retire `bonsai-1.7b-2bit` from every automatic default path while keeping it manually selectable
- keep Quickstart-eligible users on the current LFM starter after dismissing onboarding
- restore a returning user's last served model only when it is cached, runnable, and non-retired

## Root cause and impact

A Hugging Face repo directory exists before its weights finish downloading, while `rapid-mlx ls` previously equated directory presence with readiness. The desktop parser also accepted the first token of any safe-looking prose line. Finally, the cached/default policy had no shared exclusion for retired automatic aliases and did not validate that the persisted last-served choice remained cached.

Together these made the desktop advertise models that were not runnable or automatically return users to a model retired for incoherent plain chat.

## Validation

- `pr_validate 1692 --verbose --skip-steps stress_e2e_bench,diff_coverage` — **MERGE-SAFE**
  - Codex review: PASS, no blocking issues
  - targeted tests: 480 passed across 21 files
  - full unit: 16,407 passed; 123 skipped; 18 deselected; 6 xfailed; 1 xpassed
  - supply-chain, lint, format, description, and environment checks: PASS
- `swift build` in `apps/rapid-mac`
- targeted cache/default suites: 131 passed
- `git diff --check`

`stress_e2e_bench` was skipped because this PR does not touch inference/generation paths and this machine currently reports 0 GB usable benchmark RAM. `diff_coverage` is advisory and never gates. Local `swift test` is unavailable because this machine has not accepted the Xcode license; macOS CI is authoritative for that suite.

### Mutation evidence

Temporary mutation: `_cache_entry_is_runnable` was changed to return `True` before consulting the download gate. `test_cached_view_marks_known_partial_repo_incomplete` then failed because `(incomplete)` disappeared from the rendered output. Restoring the implementation made the test pass. The test constructs a real `refs/main` → metadata-only snapshot and does not mock the helper.

## Review findings addressed

- Require the persisted last-served model to remain cached before restoring it automatically; added an uncached/deleted-model regression test.
- Exercise the real cache-completeness helper with a synthetic metadata-only HF snapshot instead of mocking its result.
- Preserve the explicit Quickstart retired-starter literal required by the independent release contract, with a Swift equality test keeping it aligned with automatic-default exclusions.

## AI assistance disclosure

Codex implemented and reviewed all eight changed files. Human verification consisted of the complete `pr_validate` run, Swift application build, targeted tests, mutation check, diff inspection, and review of every Codex finding. I can explain every changed line on demand.
