### PR TITLE
fix(mac): make recent web search reliably grounded

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
@@ -1363,7 +1363,7 @@ You have access to tools that fetch real-time information. When you use one of t
 
 5. When the user's question is ambiguous about which subject the tool result covers, ask a clarifying question before answering.
 
-6. If you find yourself wanting to write a long enumerated list, STOP. The tool result likely doesn't contain that list. Issue another tool call with a more specific query instead.
+6. If the search result only contains site homepages, section pages, or snippets that do not support an answer, do not stop at "insufficient information." Call web_search again with a more specific subject/date query, or call browse on the most relevant concrete article URL. If you find yourself wanting to write a long enumerated list, STOP and retrieve the missing evidence first.
 
 These rules apply to every tool, not just web search.
 """

--- a/apps/rapid-mac/Sources/Rapid/Tools/WebSearchTool.swift
+++ b/apps/rapid-mac/Sources/Rapid/Tools/WebSearchTool.swift
@@ -101,7 +101,7 @@ enum WebSearchTool {
     static func preparedQuery(
         _ query: String,
         now: Date = Date(),
-        calendar inputCalendar: Calendar = Calendar(identifier: .gregorian)
+        calendar inputCalendar: Calendar = .autoupdatingCurrent
     ) -> String {
         let folded = query.folding(options: [.caseInsensitive, .diacriticInsensitive], locale: Locale(identifier: "en_US_POSIX"))
         let asksForEnglishLastWeek = folded.range(
@@ -115,12 +115,11 @@ enum WebSearchTool {
         let asksForLastWeek = asksForEnglishLastWeek || asksForChineseLastWeek
         guard asksForLastWeek else { return query }
 
-        var calendar = inputCalendar
-        calendar.timeZone = inputCalendar.timeZone
-        let end = calendar.startOfDay(for: now)
-        // Both endpoints are inclusive, so today plus the preceding six days
-        // is exactly seven calendar dates.
-        guard let start = calendar.date(byAdding: .day, value: -6, to: end) else {
+        let calendar = inputCalendar
+        let today = calendar.startOfDay(for: now)
+        guard let currentWeek = calendar.dateInterval(of: .weekOfYear, for: today),
+              let start = calendar.date(byAdding: .weekOfYear, value: -1, to: currentWeek.start),
+              let end = calendar.date(byAdding: .day, value: -1, to: currentWeek.start) else {
             return query
         }
         let formatter = DateFormatter()

--- a/apps/rapid-mac/Sources/Rapid/Tools/WebSearchTool.swift
+++ b/apps/rapid-mac/Sources/Rapid/Tools/WebSearchTool.swift
@@ -104,10 +104,15 @@ enum WebSearchTool {
         calendar inputCalendar: Calendar = Calendar(identifier: .gregorian)
     ) -> String {
         let folded = query.folding(options: [.caseInsensitive, .diacriticInsensitive], locale: Locale(identifier: "en_US_POSIX"))
-        let asksForLastWeek = folded.range(
+        let asksForEnglishLastWeek = folded.range(
             of: #"\blast week\b"#,
             options: .regularExpression
-        ) != nil || query.contains("上周") || query.contains("上一周")
+        ) != nil
+        let asksForChineseLastWeek =
+            (query.contains("上周") || query.contains("上一周"))
+            && !query.contains("上周末")
+            && !query.contains("上一周末")
+        let asksForLastWeek = asksForEnglishLastWeek || asksForChineseLastWeek
         guard asksForLastWeek else { return query }
 
         var calendar = inputCalendar

--- a/apps/rapid-mac/Sources/Rapid/Tools/WebSearchTool.swift
+++ b/apps/rapid-mac/Sources/Rapid/Tools/WebSearchTool.swift
@@ -108,10 +108,10 @@ enum WebSearchTool {
             of: #"\blast week\b"#,
             options: .regularExpression
         ) != nil
-        let asksForChineseLastWeek =
-            (query.contains("上周") || query.contains("上一周"))
-            && !query.contains("上周末")
-            && !query.contains("上一周末")
+        let asksForChineseLastWeek = query.range(
+            of: #"(?:上周|上一周)(?!末)"#,
+            options: .regularExpression
+        ) != nil
         let asksForLastWeek = asksForEnglishLastWeek || asksForChineseLastWeek
         guard asksForLastWeek else { return query }
 
@@ -123,7 +123,9 @@ enum WebSearchTool {
             return query
         }
         let formatter = DateFormatter()
-        formatter.calendar = calendar
+        var formattingCalendar = Calendar(identifier: .gregorian)
+        formattingCalendar.timeZone = calendar.timeZone
+        formatter.calendar = formattingCalendar
         formatter.locale = Locale(identifier: "en_US_POSIX")
         formatter.timeZone = calendar.timeZone
         formatter.dateFormat = "yyyy-MM-dd"

--- a/apps/rapid-mac/Sources/Rapid/Tools/WebSearchTool.swift
+++ b/apps/rapid-mac/Sources/Rapid/Tools/WebSearchTool.swift
@@ -104,13 +104,18 @@ enum WebSearchTool {
         calendar inputCalendar: Calendar = Calendar(identifier: .gregorian)
     ) -> String {
         let folded = query.folding(options: [.caseInsensitive, .diacriticInsensitive], locale: Locale(identifier: "en_US_POSIX"))
-        let asksForLastWeek = folded.contains("last week") || query.contains("上周") || query.contains("上一周")
+        let asksForLastWeek = folded.range(
+            of: #"\blast week\b"#,
+            options: .regularExpression
+        ) != nil || query.contains("上周") || query.contains("上一周")
         guard asksForLastWeek else { return query }
 
         var calendar = inputCalendar
         calendar.timeZone = inputCalendar.timeZone
         let end = calendar.startOfDay(for: now)
-        guard let start = calendar.date(byAdding: .day, value: -7, to: end) else {
+        // Both endpoints are inclusive, so today plus the preceding six days
+        // is exactly seven calendar dates.
+        guard let start = calendar.date(byAdding: .day, value: -6, to: end) else {
             return query
         }
         let formatter = DateFormatter()

--- a/apps/rapid-mac/Sources/Rapid/Tools/WebSearchTool.swift
+++ b/apps/rapid-mac/Sources/Rapid/Tools/WebSearchTool.swift
@@ -65,10 +65,16 @@ enum WebSearchTool {
               let args = try? JSONDecoder().decode(Args.self, from: data) else {
             return ToolCallResult(toolCallID: "", content: "\(toolName) error: could not parse arguments JSON", isError: true)
         }
-        let q = args.query.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !q.isEmpty else {
+        let rawQuery = args.query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !rawQuery.isEmpty else {
             return ToolCallResult(toolCallID: "", content: "\(toolName) error: empty query", isError: true)
         }
+        // Small local models commonly pass relative dates through verbatim
+        // ("last week", "上周"). Search engines then tend to return evergreen
+        // section homepages instead of an article from the requested window.
+        // Resolve the date on the application side so search quality does not
+        // depend on the model knowing today's date or deciding to retry.
+        let q = preparedQuery(rawQuery)
         var effectiveProvider = provider
         var fallbackNote: String? = nil
         if provider.requiresKey, apiKey == nil {
@@ -83,6 +89,36 @@ enum WebSearchTool {
         case .tavily:
             return await runTavily(query: q, apiKey: apiKey ?? "")
         }
+    }
+
+    /// Expand relative-time language into an explicit, stable date window.
+    ///
+    /// This deliberately keeps the user's original words and appends dates:
+    /// providers still see the semantic intent, while the date range prevents
+    /// generic news homepages from dominating queries such as "major news
+    /// story last week". ``now`` and ``calendar`` are injectable so the
+    /// boundary behavior is deterministic in tests.
+    static func preparedQuery(
+        _ query: String,
+        now: Date = Date(),
+        calendar inputCalendar: Calendar = Calendar(identifier: .gregorian)
+    ) -> String {
+        let folded = query.folding(options: [.caseInsensitive, .diacriticInsensitive], locale: Locale(identifier: "en_US_POSIX"))
+        let asksForLastWeek = folded.contains("last week") || query.contains("上周") || query.contains("上一周")
+        guard asksForLastWeek else { return query }
+
+        var calendar = inputCalendar
+        calendar.timeZone = inputCalendar.timeZone
+        let end = calendar.startOfDay(for: now)
+        guard let start = calendar.date(byAdding: .day, value: -7, to: end) else {
+            return query
+        }
+        let formatter = DateFormatter()
+        formatter.calendar = calendar
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = calendar.timeZone
+        formatter.dateFormat = "yyyy-MM-dd"
+        return "\(query) (date range: \(formatter.string(from: start)) through \(formatter.string(from: end)))"
     }
 
     /// Shared formatting: takes a list of provider-agnostic

--- a/apps/rapid-mac/Sources/Rapid/Tools/WebSearchTool.swift
+++ b/apps/rapid-mac/Sources/Rapid/Tools/WebSearchTool.swift
@@ -105,11 +105,11 @@ enum WebSearchTool {
     ) -> String {
         let folded = query.folding(options: [.caseInsensitive, .diacriticInsensitive], locale: Locale(identifier: "en_US_POSIX"))
         let asksForEnglishLastWeek = folded.range(
-            of: #"\blast week\b"#,
+            of: #"\blast week\b(?!\s+of\b)"#,
             options: .regularExpression
         ) != nil
         let asksForChineseLastWeek = query.range(
-            of: #"(?:上周|上一周)(?!末)"#,
+            of: #"(?<!上)(?:上周|上一周)(?!末)"#,
             options: .regularExpression
         ) != nil
         let asksForLastWeek = asksForEnglishLastWeek || asksForChineseLastWeek

--- a/apps/rapid-mac/Tests/RapidTests/ModelSwitchHistoryTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ModelSwitchHistoryTests.swift
@@ -30,6 +30,37 @@ import Testing
 @Suite("v0.4.35 model-switch silent-failure defense")
 struct ModelSwitchHistoryTests {
 
+    @Test("Restored tool exchange preserves call IDs and remains wire-valid")
+    func restoredToolExchangePreservesLinkage() throws {
+        let call = ToolCall(
+            id: "call_search_1",
+            name: "web_search",
+            arguments: #"{"query":"major news last week"}"#
+        )
+        let original: [ChatMessage] = [
+            ChatMessage(role: .user, content: "What happened last week?"),
+            ChatMessage(role: .assistant, content: "", status: .complete, toolCalls: [call]),
+            ChatMessage(
+                role: .tool,
+                content: "1. Example article\n   https://example.com/story",
+                status: .complete,
+                toolCallID: call.id
+            ),
+            ChatMessage(role: .assistant, content: "Here is what happened.", status: .complete),
+        ]
+
+        let restored = try JSONDecoder().decode(
+            [ChatMessage].self,
+            from: JSONEncoder().encode(original)
+        )
+        let wire = ChatViewModel.filterEmptyAssistantsForWire(restored)
+
+        #expect(wire.count == 4)
+        #expect(wire[1].toolCalls?.first?.id == "call_search_1")
+        #expect(wire[2].toolCallID == "call_search_1")
+        #expect(ChatViewModel.carriesToolResultForThisTurn(wire))
+    }
+
     // MARK: - filterEmptyAssistantsForWire
 
     @Test("Empty-prose assistant turn is stripped from wire history")

--- a/apps/rapid-mac/Tests/RapidTests/ModelSwitchHistoryTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ModelSwitchHistoryTests.swift
@@ -59,6 +59,20 @@ struct ModelSwitchHistoryTests {
         #expect(wire[1].toolCalls?.first?.id == "call_search_1")
         #expect(wire[2].toolCallID == "call_search_1")
         #expect(ChatViewModel.carriesToolResultForThisTurn(wire))
+
+        let wireData = try JSONEncoder().encode(
+            wire.map { Wire.Message(from: $0) }
+        )
+        let payload = try #require(
+            JSONSerialization.jsonObject(with: wireData) as? [[String: Any]]
+        )
+        let assistantCalls = try #require(payload[1]["tool_calls"] as? [[String: Any]])
+        let encodedCallID = assistantCalls.first?["id"] as? String
+        let encodedResultID = payload[2]["tool_call_id"] as? String
+        #expect(encodedCallID == "call_search_1")
+        #expect(encodedResultID == "call_search_1")
+        #expect(payload[2]["toolCalls"] == nil)
+        #expect(payload[2]["toolCallID"] == nil)
     }
 
     // MARK: - filterEmptyAssistantsForWire

--- a/apps/rapid-mac/Tests/RapidTests/WebToolsHardeningTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/WebToolsHardeningTests.swift
@@ -23,7 +23,7 @@ struct WebToolsHardeningTests {
             calendar: calendar
         )
 
-        #expect(prepared.contains("2026-08-01 through 2026-08-08"))
+        #expect(prepared.contains("2026-08-02 through 2026-08-08"))
         #expect(prepared.hasPrefix("What's a major news story from the last week?"))
     }
 
@@ -40,7 +40,13 @@ struct WebToolsHardeningTests {
             now: now,
             calendar: calendar
         )
-        #expect(prepared.contains("2026-08-01 through 2026-08-08"))
+        #expect(prepared.contains("2026-08-02 through 2026-08-08"))
+    }
+
+    @Test("Last weekend is not broadened into a week-long query")
+    func lastWeekendIsNotRewritten() {
+        let query = "What happened last weekend?"
+        #expect(WebSearchTool.preparedQuery(query) == query)
     }
 
     @Test("Timeless query is not rewritten")

--- a/apps/rapid-mac/Tests/RapidTests/WebToolsHardeningTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/WebToolsHardeningTests.swift
@@ -49,9 +49,21 @@ struct WebToolsHardeningTests {
         #expect(WebSearchTool.preparedQuery(query) == query)
     }
 
+    @Test("A historical last-week-of phrase is not treated as relative")
+    func historicalLastWeekOfIsNotRewritten() {
+        let query = "What happened in the last week of July 2020?"
+        #expect(WebSearchTool.preparedQuery(query) == query)
+    }
+
     @Test("Chinese last weekend is not broadened into a week-long query")
     func chineseLastWeekendIsNotRewritten() {
         let query = "上周末有什么活动？"
+        #expect(WebSearchTool.preparedQuery(query) == query)
+    }
+
+    @Test("The Chinese week-before-last phrase is not shifted forward")
+    func chineseWeekBeforeLastIsNotRewritten() {
+        let query = "上上周有什么新闻？"
         #expect(WebSearchTool.preparedQuery(query) == query)
     }
 

--- a/apps/rapid-mac/Tests/RapidTests/WebToolsHardeningTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/WebToolsHardeningTests.swift
@@ -49,6 +49,12 @@ struct WebToolsHardeningTests {
         #expect(WebSearchTool.preparedQuery(query) == query)
     }
 
+    @Test("Chinese last weekend is not broadened into a week-long query")
+    func chineseLastWeekendIsNotRewritten() {
+        let query = "上周末有什么活动？"
+        #expect(WebSearchTool.preparedQuery(query) == query)
+    }
+
     @Test("Timeless query is not rewritten")
     func timelessQueryPassesThrough() {
         let query = "Swift concurrency actor isolation"

--- a/apps/rapid-mac/Tests/RapidTests/WebToolsHardeningTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/WebToolsHardeningTests.swift
@@ -55,6 +55,35 @@ struct WebToolsHardeningTests {
         #expect(WebSearchTool.preparedQuery(query) == query)
     }
 
+    @Test("A standalone Chinese last-week phrase still matches beside last-weekend")
+    func standaloneChineseLastWeekStillMatches() throws {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = try #require(TimeZone(secondsFromGMT: 0))
+        let now = try #require(calendar.date(from: DateComponents(
+            year: 2026, month: 8, day: 8
+        )))
+        let prepared = WebSearchTool.preparedQuery(
+            "总结上周新闻，不包括上周末",
+            now: now,
+            calendar: calendar
+        )
+        #expect(prepared.contains("2026-07-26 through 2026-08-01"))
+    }
+
+    @Test("Date constraint stays Gregorian for a non-Gregorian user calendar")
+    func dateConstraintUsesGregorianYear() throws {
+        var calendar = Calendar(identifier: .buddhist)
+        calendar.timeZone = try #require(TimeZone(secondsFromGMT: 0))
+        let now = try #require(ISO8601DateFormatter().date(from: "2026-08-08T12:00:00Z"))
+        let prepared = WebSearchTool.preparedQuery(
+            "major news last week",
+            now: now,
+            calendar: calendar
+        )
+        #expect(prepared.contains("2026-"))
+        #expect(!prepared.contains("2569-"))
+    }
+
     @Test("Timeless query is not rewritten")
     func timelessQueryPassesThrough() {
         let query = "Swift concurrency actor isolation"

--- a/apps/rapid-mac/Tests/RapidTests/WebToolsHardeningTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/WebToolsHardeningTests.swift
@@ -7,6 +7,48 @@ import Testing
 /// logic that previously had no direct unit tests.
 @Suite("Web tools hardening")
 struct WebToolsHardeningTests {
+    // MARK: - Relative-date query grounding
+
+    @Test("Last-week news query gets an explicit seven-day date window")
+    func lastWeekQueryGetsConcreteDates() throws {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = try #require(TimeZone(secondsFromGMT: 0))
+        let now = try #require(calendar.date(from: DateComponents(
+            year: 2026, month: 8, day: 8, hour: 19
+        )))
+
+        let prepared = WebSearchTool.preparedQuery(
+            "What's a major news story from the last week?",
+            now: now,
+            calendar: calendar
+        )
+
+        #expect(prepared.contains("2026-08-01 through 2026-08-08"))
+        #expect(prepared.hasPrefix("What's a major news story from the last week?"))
+    }
+
+    @Test("Chinese last-week query gets the same explicit date window")
+    func chineseLastWeekQueryGetsConcreteDates() throws {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = try #require(TimeZone(secondsFromGMT: 0))
+        let now = try #require(calendar.date(from: DateComponents(
+            year: 2026, month: 8, day: 8
+        )))
+
+        let prepared = WebSearchTool.preparedQuery(
+            "上周有什么重大新闻？",
+            now: now,
+            calendar: calendar
+        )
+        #expect(prepared.contains("2026-08-01 through 2026-08-08"))
+    }
+
+    @Test("Timeless query is not rewritten")
+    func timelessQueryPassesThrough() {
+        let query = "Swift concurrency actor isolation"
+        #expect(WebSearchTool.preparedQuery(query) == query)
+    }
+
     // MARK: - #4 DuckDuckGo query encoding
 
     @Test("A query with & and # is one opaque q value, not injected parameters")

--- a/apps/rapid-mac/Tests/RapidTests/WebToolsHardeningTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/WebToolsHardeningTests.swift
@@ -9,7 +9,7 @@ import Testing
 struct WebToolsHardeningTests {
     // MARK: - Relative-date query grounding
 
-    @Test("Last-week news query gets an explicit seven-day date window")
+    @Test("Last-week news query gets the previous complete calendar week")
     func lastWeekQueryGetsConcreteDates() throws {
         var calendar = Calendar(identifier: .gregorian)
         calendar.timeZone = try #require(TimeZone(secondsFromGMT: 0))
@@ -23,7 +23,7 @@ struct WebToolsHardeningTests {
             calendar: calendar
         )
 
-        #expect(prepared.contains("2026-08-02 through 2026-08-08"))
+        #expect(prepared.contains("2026-07-26 through 2026-08-01"))
         #expect(prepared.hasPrefix("What's a major news story from the last week?"))
     }
 
@@ -40,7 +40,7 @@ struct WebToolsHardeningTests {
             now: now,
             calendar: calendar
         )
-        #expect(prepared.contains("2026-08-02 through 2026-08-08"))
+        #expect(prepared.contains("2026-07-26 through 2026-08-01"))
     }
 
     @Test("Last weekend is not broadened into a week-long query")

--- a/apps/rapid-mac/docs/gui-golden-flows.md
+++ b/apps/rapid-mac/docs/gui-golden-flows.md
@@ -8,16 +8,19 @@ Rapid-MLX Desktop app without loading a real model.
 1. fresh install, consent, onboarding, and steady-state shell;
 2. Settings mutation and persistence across an app relaunch;
 3. basic chat, persisted conversation row, and restored transcript;
-4. a deliberately slow stream and semantic **Stop generating** action;
-5. model start, a one-shot sidecar crash, automatic respawn, and ready state.
-6. a memory-constrained user can see and select an honestly labelled sub-1B
+4. restored-thread tool availability: after relaunching and reopening a saved
+   conversation, the next real request must retain the prior user turn and
+   advertise both `web_search` and `browse`;
+5. a deliberately slow stream and semantic **Stop generating** action;
+6. model start, a one-shot sidecar crash, automatic respawn, and ready state;
+7. a memory-constrained user can see and select an honestly labelled sub-1B
    fallback instead of being sent back to a chooser whose smallest visible
-   model is the one that just failed the live-memory guard.
-7. “Speed on this Mac” benchmarks the model already resident in the desktop
+   model is the one that just failed the live-memory guard;
+8. “Speed on this Mac” benchmarks the model already resident in the desktop
    server: one server start, then one warm-up plus one measured request, with
-   no second model process and no duplicate weight load.
+   no second model process and no duplicate weight load;
 
-8. “Browse all models” lowers the onboarding sheet, opens Model Management in
+9. “Browse all models” lowers the onboarding sheet, opens Model Management in
    Settings, accepts a foreground interaction, and returns to the wizard with
    the user's original model selection intact. A final full-screen capture
    records the state a person actually sees.
@@ -25,9 +28,9 @@ Rapid-MLX Desktop app without loading a real model.
 added after a release where every escaped defect landed on a surface no journey
 covered, and each one names the defect it would have caught:
 
-9. `update-state` — Settings → App must name the version the app actually is.
-10. `no-dead-controls` — every Settings panel must expose controls of its own.
-11. `catalog-integrity` — a model that cannot chat must never be offered as one.
+10. `update-state` — Settings → App must name the version the app actually is.
+11. `no-dead-controls` — every Settings panel must expose controls of its own.
+12. `catalog-integrity` — a model that cannot chat must never be offered as one.
 
 The distinction matters. A journey answers *"can someone do this?"*; an
 invariant answers *"is this still true everywhere?"*. The three defects below
@@ -132,6 +135,23 @@ Every journey gets a unique bundle identifier and throwaway `HOME` through
 lifecycle evidence, so the suite does not download a model or put meaningful
 pressure on unified memory.
 
+### How GUI integration is tested
+
+`restored-tools` deliberately uses two independent witnesses. Accessibility
+drives the same controls a person uses: send a first turn, terminate and
+relaunch the app, reopen the saved conversation, and send a second turn. The
+fake OpenAI-compatible sidecar then records the request that actually crossed
+the process boundary. The flow fails unless that post-restore request contains
+the first user turn plus the `web_search` and `browse` schemas.
+
+This division avoids two common false greens: an AX-only test can be satisfied
+by canned text that never left the composer, while a request-only unit test
+does not prove that selecting a restored conversation wired the right state
+into Send. The flow covers both without a real model or public web dependency.
+Its contract is semantic rather than visual, so it retains raw AX/request
+artifacts but does not add another structural snapshot: `chat-depth.restored`
+already fingerprints the restored transcript hierarchy.
+
 ### Low-memory recovery
 
 The normal model picker intentionally hides sub-1B models: they fall below the
@@ -190,6 +210,7 @@ Run one journey or retain its isolated persona for diagnosis:
 ./scripts/gui-golden-flows.sh --flow low-memory-choice
 ./scripts/gui-golden-flows.sh --flow loaded-model-benchmark
 ./scripts/gui-golden-flows.sh --flow chat-restore --keep
+./scripts/gui-golden-flows.sh --flow restored-tools
 ./scripts/gui-golden-flows.sh --flow browse-all-destination
 ./scripts/gui-golden-flows.sh --flow no-dead-controls
 ```

--- a/apps/rapid-mac/scripts/fake-rapid-mlx.sh
+++ b/apps/rapid-mac/scripts/fake-rapid-mlx.sh
@@ -248,7 +248,27 @@ class Handler(BaseHTTPRequestHandler):
                 body = json.loads(self.rfile.read(length))
             except (json.JSONDecodeError, UnicodeDecodeError):
                 body = {}
-        _event("chat_request")
+        messages = body.get("messages") if isinstance(body.get("messages"), list) else []
+        tool_names = []
+        for tool in body.get("tools") or []:
+            if not isinstance(tool, dict):
+                continue
+            function = tool.get("function")
+            if isinstance(function, dict) and isinstance(function.get("name"), str):
+                tool_names.append(function["name"])
+        user_texts = []
+        for message in messages:
+            if not isinstance(message, dict) or message.get("role") != "user":
+                continue
+            content = message.get("content")
+            if isinstance(content, str):
+                user_texts.append(content)
+        _event(
+            "chat_request",
+            roles=[message.get("role") for message in messages if isinstance(message, dict)],
+            tools=tool_names,
+            user_texts=user_texts,
+        )
 
         if body.get("stream") is False:
             max_tokens = int(body.get("max_tokens", 8) or 8)

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -30,7 +30,7 @@ usage() {
     cat <<'EOF'
 Usage: gui-golden-flows.sh [--flow NAME] [--keep] [--update-baselines]
 
-Flows: fresh-install, settings-persistence, chat-restore, chat-depth,
+Flows: fresh-install, settings-persistence, chat-restore, restored-tools, chat-depth,
        slow-stream-stop,
        model-crash-recovery, low-memory-choice, loaded-model-benchmark,
        update-state, no-dead-controls, catalog-integrity,
@@ -916,6 +916,47 @@ flow_chat_restore() {
     cleanup_persona
 }
 
+flow_restored_tools() {
+    # A restored transcript is only useful if the next request is built with
+    # BOTH its old context and the current tool definitions. This is the GUI
+    # integration boundary for the reported "web search only works in a new
+    # chat" failure: the fake sidecar records the actual OpenAI request, so an
+    # on-screen canned answer cannot make the flow pass by itself.
+    start_persona restored-tools
+    dismiss_first_run
+    start_model
+    send_prompt "golden pre-restore context marker" tools-before
+    wait_send_idle "$OUT/tools-before-settled.json"
+
+    relaunch_persona
+    dismiss_first_run
+    wait_identifier Sidebar.NewChat "$OUT/tools-restored.json"
+    local conversation_id
+    conversation_id="$(jq -r '.data.ui_elements[] | (.identifier // "")
+        | select(test("^Sidebar\\.Conversation\\.[0-9A-Fa-f-]{36}$"))' \
+        "$OUT/tools-restored.json" | head -1)"
+    [[ -n "$conversation_id" ]] || die "restored tools conversation row was not exposed to AX"
+    press "$OUT/tools-restored.json" "$conversation_id" "$OUT/tools-open-restored.json"
+    wait_send_idle "$OUT/tools-restored-transcript.json"
+
+    send_prompt "golden existing-thread tools marker" tools-after
+    wait_send_idle "$OUT/tools-after-settled.json"
+    assert_transcript_turns "$OUT/tools-after-settled.json" 2
+    assert_tree_text "$OUT/tools-after-settled.json" "golden pre-restore context marker"
+    assert_tree_text "$OUT/tools-after-settled.json" "golden existing-thread tools marker"
+
+    jq -e '
+        select(.event == "chat_request")
+        | select(.user_texts[-1] == "golden existing-thread tools marker")
+        | select(.user_texts | index("golden pre-restore context marker"))
+        | select(.tools | index("web_search"))
+        | select(.tools | index("browse"))
+    ' "$OUT/fake-events.jsonl" >/dev/null \
+        || die "restored-thread request lost prior context or web tool definitions"
+    log "  restored conversation sent prior context plus web_search and browse definitions"
+    cleanup_persona
+}
+
 flow_slow_stream_stop() {
     log "4/6 controlled slow stream and Stop"
     start_persona slow-stream-stop FAKE_INTER_TOKEN_SLEEP_S=0.01 FAKE_CONTENT_REPEAT=20000
@@ -1475,6 +1516,7 @@ case "$FLOW" in
     fresh-install) flow_fresh_install ;;
     settings-persistence) flow_settings_persistence ;;
     chat-restore) flow_chat_restore ;;
+    restored-tools) flow_restored_tools ;;
     chat-depth) flow_chat_depth ;;
     slow-stream-stop) flow_slow_stream_stop ;;
     model-crash-recovery) flow_model_crash_recovery ;;
@@ -1488,6 +1530,7 @@ case "$FLOW" in
         flow_fresh_install
         flow_settings_persistence
         flow_chat_restore
+        flow_restored_tools
         flow_chat_depth
         flow_slow_stream_stop
         flow_model_crash_recovery


### PR DESCRIPTION
## What does this PR do?

- Resolves “last week” / “上周” into the previous complete calendar week in the user’s local calendar before dispatching web search.
- Tells weak local models to refine search or browse a concrete article when snippets are insufficient.
- Adds unit coverage for relative-date boundaries and exact restored tool-call wire fields.
- Adds a `restored-tools` GUI golden flow: AX sends before and after an app relaunch, while the fake OpenAI sidecar proves the restored request retained old context and advertised `web_search` + `browse`.

## Why is this needed?

A reported fresh-chat query for a major story from the last week successfully called `web_search`, but broad DuckDuckGo results contained only publisher homepages. The starter model then returned “insufficient information.” A separate report said web search only worked in new chats.

This PR moves relative-date grounding into the application, supplies a deterministic recovery instruction, pins the restored wire contract, and guards the real GUI restore/send boundary without a real model or public web dependency.

## AI assistance disclosure

Codex wrote and iteratively reviewed all touched Swift, shell, Python-embedded fake-server, test, and documentation edits. Adversarial review rounds corrected date-range, phrase-boundary, locale/calendar, and wire-assertion issues. The maintainer requested and supervised the product and integration-test direction.

> By submitting this PR I confirm I can explain the intent, risk, and behavior of every non-generated change in this PR. For any generated / boilerplate / scaffolded sections, I have identified them above and can describe how I verified them.

## Test plan

- `swift build --target RapidTests`
- `bash -n scripts/fake-rapid-mlx.sh scripts/gui-golden-flows.sh`
- launch fake sidecar, POST a restored multi-turn request, assert JSONL contains both user turns plus `web_search` and `browse`
- `git diff --check`
- PR validation pipeline and rapid-mac CI
- `restored-tools` GUI flow was attempted twice locally; this host only exposed the dynamic app bundle’s `AXApplication` root and timed out before `rapid.chat.compose`. Run the committed flow from the release GUI login session with valid AX/TCC grants.

## Checklist

- [x] Swift production and `RapidTests` targets compile locally
- [x] Shell syntax, fake-sidecar integration evidence, and `git diff --check` pass
- [x] Self-validation executed; local Python-only gates lack `mlx_vlm` / `mlx_audio`; GitHub PR validation runs on a clean runner
- [x] New tests do not touch parser / scheduler / security critical paths
- [x] GUI golden-flow architecture documented
- [x] No breaking changes to existing API