### PR TITLE
fix(mac): make live web research deterministic

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
@@ -389,6 +389,21 @@ final class ChatViewModel {
         guard !trimmed.isEmpty else { return }
         guard !isStreaming else { return }
 
+        // Small local models are unreliable at the first step of tool use:
+        // deciding that an explicitly live/dated question needs the web. Do
+        // that narrow piece of routing in the app, while leaving query wording
+        // and answer synthesis to the model. Follow-ups inherit the intent of
+        // the preceding user turn ("What about technology?") so restoring a
+        // conversation cannot silently turn search back into plain chat.
+        let forcedTool = Self.forcedToolForUserTurn(
+            trimmed,
+            priorMessages: messages,
+            enabledToolNames: Set(enabledDefinitions.map { $0.function.name })
+        )
+        let forcedWebSearchQuery = forcedTool == "web_search"
+            ? Self.webSearchQuery(for: trimmed, priorMessages: messages)
+            : nil
+
         let user = ChatMessage(
             role: .user,
             content: trimmed,
@@ -457,9 +472,131 @@ final class ChatViewModel {
             await self.runToolLoop(
                 alias: alias,
                 initialPlaceholder: placeholderIndex,
-                epoch: epoch
+                epoch: epoch,
+                forcedWebSearchQuery: forcedWebSearchQuery
             )
         }
+    }
+
+    /// Deterministic routing for prompts whose answer is explicitly time
+    /// sensitive. This is intentionally narrower than a general semantic
+    /// classifier: a false negative falls back to normal `tool_choice:auto`,
+    /// while a false positive performs an unnecessary network search.
+    nonisolated static func forcedToolForUserTurn(
+        _ prompt: String,
+        priorMessages: [ChatMessage],
+        enabledToolNames: Set<String>
+    ) -> String? {
+        guard enabledToolNames.contains("web_search") else { return nil }
+        if promptRequiresFreshWebEvidence(prompt) { return "web_search" }
+
+        // A short follow-up often omits the live-time words carried by the
+        // previous turn. Inherit across the immediately preceding user turn;
+        // this also covers a restored thread where the first broad search ran
+        // but the user now asks for a narrower, fresh query.
+        let tail = priorMessages.suffix(8)
+        guard let previous = tail.last(where: { $0.role == .user }),
+              promptLooksLikeFollowUp(prompt),
+              promptRequiresFreshWebEvidence(previous.content)
+        else { return nil }
+        return "web_search"
+    }
+
+    nonisolated static func promptRequiresFreshWebEvidence(_ prompt: String) -> Bool {
+        let value = prompt.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !value.isEmpty else { return false }
+        let phrases = [
+            "latest", "recent", "today", "yesterday", "this week", "last week",
+            "this month", "this year", "current", "right now", "breaking news",
+            "news story", "news about", "world cup 2026", "2026 world cup",
+            "最新", "最近", "今天", "昨天", "本周", "上周", "这个月", "本月",
+            "今年", "当前", "现在", "刚刚", "新闻", "今年世界杯"
+        ]
+        return phrases.contains(where: value.contains)
+    }
+
+    nonisolated static func promptLooksLikeFollowUp(_ prompt: String) -> Bool {
+        let value = prompt.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !value.isEmpty, value.count <= 240 else { return false }
+        let markers = [
+            "what about", "how about", "and ", "also", "instead", "one concrete",
+            "tell me more", "why", "summarize it", "that story", "those results",
+            "那", "那么", "这个", "这件事", "为什么", "再", "具体", "总结"
+        ]
+        return markers.contains(where: value.contains)
+    }
+
+    nonisolated static func webSearchArguments(query: String) -> String {
+        let data = try? JSONSerialization.data(
+            withJSONObject: ["query": query],
+            options: [.sortedKeys]
+        )
+        return data.flatMap { String(data: $0, encoding: .utf8) }
+            ?? #"{"query":""}"#
+    }
+
+    /// Preserve the live-time scope when a follow-up is elliptical. Searching
+    /// only "What about technology?" loses the preceding "last week" filter
+    /// and lets stale or fictional high-ranking pages dominate the results.
+    nonisolated static func webSearchQuery(
+        for prompt: String,
+        priorMessages: [ChatMessage]
+    ) -> String {
+        if promptRequiresFreshWebEvidence(prompt) { return prompt }
+        if let previous = priorMessages.suffix(8).last(where: {
+            $0.role == .user && promptRequiresFreshWebEvidence($0.content)
+        }) {
+            return "\(previous.content)\nFollow-up focus: \(prompt)"
+        }
+        return prompt
+    }
+
+    struct GroundingSource: Equatable, Sendable {
+        let title: String
+        let url: String
+    }
+
+    nonisolated static func groundingSources(from toolResult: String) -> [GroundingSource] {
+        let lines = toolResult.split(separator: "\n", omittingEmptySubsequences: false)
+        var sources: [GroundingSource] = []
+        for index in lines.indices where sources.count < 3 {
+            let titleLine = lines[index].trimmingCharacters(in: .whitespaces)
+            guard titleLine.range(of: #"^\d+\.\s+"#, options: .regularExpression) != nil,
+                  lines.indices.contains(index + 1)
+            else { continue }
+            let url = lines[index + 1].trimmingCharacters(in: .whitespaces)
+            guard url.hasPrefix("https://") || url.hasPrefix("http://") else { continue }
+            let title = titleLine.replacingOccurrences(
+                of: #"^\d+\.\s+"#,
+                with: "",
+                options: .regularExpression
+            )
+            sources.append(GroundingSource(title: title, url: url))
+        }
+        return sources
+    }
+
+    private func appendGroundingSources(
+        _ sources: [GroundingSource],
+        to index: Int,
+        epoch: Int
+    ) {
+        guard epoch == conversationEpoch,
+              !sources.isEmpty,
+              var message = currentMessage(index: index),
+              message.status == .complete,
+              !message.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        else { return }
+        let missing = sources.filter { !message.content.contains($0.url) }
+        guard !missing.isEmpty else { return }
+        let rows = missing.map { source in
+            let safeTitle = source.title
+                .replacingOccurrences(of: "[", with: "\\[")
+                .replacingOccurrences(of: "]", with: "\\]")
+            return "- [\(safeTitle)](\(source.url))"
+        }
+        message.content += "\n\nSources:\n" + rows.joined(separator: "\n")
+        updateMessage(at: index, with: message)
     }
 
     /// HF repo for the alias the next Send will start, supplied by the
@@ -1034,7 +1171,8 @@ final class ChatViewModel {
     private func runToolLoop(
         alias: String,
         initialPlaceholder: Int,
-        epoch: Int
+        epoch: Int,
+        forcedWebSearchQuery: String? = nil
     ) async {
         defer {
             // A stream that outlived a conversation switch must not reset
@@ -1047,6 +1185,51 @@ final class ChatViewModel {
         }
         var currentPlaceholder = initialPlaceholder
         var roundsLeft = maxToolRounds
+        var appGroundingSources: [GroundingSource] = []
+
+        // `tool_choice:function` is advisory in several local chat templates:
+        // the shipped 1.2B starter can ignore it and answer "I can search".
+        // For an unambiguous fresh-information prompt, dispatch the harmless
+        // search directly and give the model the same assistant(tool_calls) +
+        // tool(result) transcript it would have produced itself. The model's
+        // job is then only evidence synthesis, which is much more reliable.
+        if let query = forcedWebSearchQuery,
+           roundsLeft > 1,
+           !query.isEmpty
+        {
+            let call = ToolCall(
+                id: "app_search_\(UUID().uuidString)",
+                name: "web_search",
+                arguments: Self.webSearchArguments(query: query)
+            )
+            if var staged = currentMessage(index: currentPlaceholder) {
+                staged.toolCalls = [call]
+                staged.status = .complete
+                updateMessage(at: currentPlaceholder, with: staged)
+            }
+            let result = await tools.run(call)
+            appGroundingSources = Self.groundingSources(from: result.content)
+            guard epoch == conversationEpoch, !Task.isCancelled else {
+                finaliseCancelledPlaceholder(at: currentPlaceholder, epoch: epoch)
+                return
+            }
+            let failureKind = result.failureKind ?? FailureDiagnoser.toolFailureKind(
+                toolName: "web_search",
+                content: result.content,
+                isError: result.isError
+            )
+            _ = appendMessage(ChatMessage(
+                role: .tool,
+                content: result.content,
+                status: (result.isError || failureKind != nil) ? .failed : .complete,
+                errorMessage: failureKind.map { FailureDiagnoser.diagnosis(for: $0).message },
+                failureKind: failureKind,
+                toolCallID: result.toolCallID
+            ))
+            currentPlaceholder = appendMessage(ChatMessage(role: .assistant, status: .streaming))
+            roundsLeft -= 1
+        }
+
         while roundsLeft > 0 {
             roundsLeft -= 1
             // History for this request: everything BEFORE the streaming
@@ -1145,6 +1328,11 @@ final class ChatViewModel {
             )
             switch outcome {
             case .terminal:
+                appendGroundingSources(
+                    appGroundingSources,
+                    to: currentPlaceholder,
+                    epoch: epoch
+                )
                 return
             case .toolCallsPending(let calls):
                 // The user can press Stop in the gap between the stream
@@ -1363,7 +1551,9 @@ You have access to tools that fetch real-time information. When you use one of t
 
 5. When the user's question is ambiguous about which subject the tool result covers, ask a clarifying question before answering.
 
-6. If you find yourself wanting to write a long enumerated list, STOP. The tool result likely doesn't contain that list. Issue another tool call with a more specific query instead.
+6. For web results, cite the supporting source inline as a Markdown link using its exact title and URL. Never give a current-events answer without at least one clickable source.
+
+7. If the search result only contains homepages or snippets that do not support a concrete answer, call web_search again with a more specific subject/date query. Do not merely offer to search and do not ask permission to use a tool that is already available.
 
 These rules apply to every tool, not just web search.
 """

--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
@@ -494,8 +494,7 @@ final class ChatViewModel {
         // previous turn. Inherit across the immediately preceding user turn;
         // this also covers a restored thread where the first broad search ran
         // but the user now asks for a narrower, fresh query.
-        let tail = priorMessages.suffix(8)
-        guard let previous = tail.last(where: { $0.role == .user }),
+        guard let previous = priorMessages.last(where: { $0.role == .user }),
               promptLooksLikeFollowUp(prompt),
               promptRequiresFreshWebEvidence(previous.content)
         else { return nil }
@@ -507,8 +506,10 @@ final class ChatViewModel {
         guard !value.isEmpty else { return false }
         let phrases = [
             "latest", "recent", "today", "yesterday", "this week", "last week",
-            "this month", "this year", "current", "right now", "breaking news",
+            "this month", "this year", "right now", "breaking news",
             "news story", "news about", "world cup 2026", "2026 world cup",
+            "current price", "current weather", "current version", "current president",
+            "current status", "current score", "current exchange rate",
             "最新", "最近", "今天", "昨天", "本周", "上周", "这个月", "本月",
             "今年", "当前", "现在", "刚刚", "新闻", "今年世界杯"
         ]
@@ -543,7 +544,7 @@ final class ChatViewModel {
         priorMessages: [ChatMessage]
     ) -> String {
         if promptRequiresFreshWebEvidence(prompt) { return prompt }
-        if let previous = priorMessages.suffix(8).last(where: {
+        if let previous = priorMessages.last(where: {
             $0.role == .user && promptRequiresFreshWebEvidence($0.content)
         }) {
             return "\(previous.content)\nFollow-up focus: \(prompt)"

--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
@@ -519,12 +519,19 @@ final class ChatViewModel {
     nonisolated static func promptLooksLikeFollowUp(_ prompt: String) -> Bool {
         let value = prompt.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         guard !value.isEmpty, value.count <= 240 else { return false }
-        let markers = [
-            "what about", "how about", "and ", "also", "instead", "one concrete",
-            "tell me more", "why", "summarize it", "that story", "those results",
-            "那", "那么", "这个", "这件事", "为什么", "再", "具体", "总结"
+        let referentialPhrases = [
+            "what about", "how about", "tell me more", "summarize it",
+            "that story", "those results", "the same topic", "one concrete story",
+            "那这个呢", "那件事", "这件事", "这些结果", "继续说", "总结一下这个"
         ]
-        return markers.contains(where: value.contains)
+        if referentialPhrases.contains(where: value.contains) { return true }
+        // Bare elliptical replies are referential precisely because they have
+        // no independent subject. Do not broaden this to arbitrary questions
+        // containing "why" (e.g. "Why is the sky blue?").
+        let bareFollowUps: Set<String> = [
+            "why?", "why", "more", "and?", "还有呢？", "为什么？", "然后呢？"
+        ]
+        return bareFollowUps.contains(value)
     }
 
     nonisolated static func webSearchArguments(query: String) -> String {

--- a/apps/rapid-mac/Sources/Rapid/Tools/WebSearchTool.swift
+++ b/apps/rapid-mac/Sources/Rapid/Tools/WebSearchTool.swift
@@ -135,9 +135,8 @@ enum WebSearchTool {
         // An explicit year makes "last week" historical, not relative to
         // today. Likewise, "last week in/of July" supplies its own calendar
         // anchor even when the year is omitted.
-        if folded.range(of: #"\b(?:19|20)\d{2}\b"#, options: .regularExpression) != nil
-            || folded.range(
-                of: #"\blast week\s+(?:in|of)\s+(?:january|february|march|april|may|june|july|august|september|october|november|december)\b"#,
+        if folded.range(
+                of: #"\blast week\s+(?:in|of)\s+(?:(?:january|february|march|april|may|june|july|august|september|october|november|december)(?:\s+(?:19|20)\d{2})?|(?:19|20)\d{2})\b"#,
                 options: .regularExpression
             ) != nil
         {

--- a/apps/rapid-mac/Sources/Rapid/Tools/WebSearchTool.swift
+++ b/apps/rapid-mac/Sources/Rapid/Tools/WebSearchTool.swift
@@ -65,9 +65,22 @@ enum WebSearchTool {
               let args = try? JSONDecoder().decode(Args.self, from: data) else {
             return ToolCallResult(toolCallID: "", content: "\(toolName) error: could not parse arguments JSON", isError: true)
         }
-        let q = args.query.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !q.isEmpty else {
+        let rawQuery = args.query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !rawQuery.isEmpty else {
             return ToolCallResult(toolCallID: "", content: "\(toolName) error: empty query", isError: true)
+        }
+        let q = preparedQuery(rawQuery)
+        // Deterministic GUI integration fixture. This is deliberately an
+        // explicit test-only environment switch (the golden-flow launcher
+        // already replaces RAPID_BIN); normal app launches never set it.
+        if ProcessInfo.processInfo.environment["RAPID_GUI_WEB_SEARCH_FIXTURE"] == "1" {
+            return formatOutput(query: q, provider: .duckduckgo, results: [
+                Result(
+                    title: "Golden technology story",
+                    url: "https://example.com/golden-tech",
+                    snippet: "A concrete dated technology result used by the restored-thread GUI integration test."
+                )
+            ])
         }
         var effectiveProvider = provider
         var fallbackNote: String? = nil
@@ -83,6 +96,64 @@ enum WebSearchTool {
         case .tavily:
             return await runTavily(query: q, apiKey: apiKey ?? "")
         }
+    }
+
+    /// Turn relative "last week" language into the previous complete
+    /// calendar week's concrete dates. Search backends otherwise tend to rank
+    /// evergreen news homepages (or stale popular stories) above articles in
+    /// the period the user actually requested.
+    static func preparedQuery(
+        _ query: String,
+        now: Date = Date(),
+        calendar inputCalendar: Calendar = .autoupdatingCurrent
+    ) -> String {
+        let currentYear = inputCalendar.component(.year, from: now)
+        // Search engines frequently rank local-language pre-tournament
+        // predictions above the completed event. Add neutral English entities
+        // and outcome terms when the user asks in Chinese about this year's
+        // World Cup; this is query expansion, not an assumed answer.
+        if query.contains("今年世界杯") {
+            var expansion = "\(currentYear) FIFA World Cup completed final result"
+            if query.localizedCaseInsensitiveContains("spain") || query.contains("西班牙") {
+                expansion += " Spain"
+            }
+            if query.contains("夺冠") || query.contains("冠军") {
+                expansion += " winner champion"
+            }
+            if query.contains("为什么") || query.contains("为何") {
+                expansion += " why tactical analysis"
+            }
+            return "\(query) (\(expansion))"
+        }
+        let folded = query.folding(
+            options: [.caseInsensitive, .diacriticInsensitive],
+            locale: Locale(identifier: "en_US_POSIX")
+        )
+        let english = folded.range(
+            of: #"\blast week\b(?!\s+of\b)"#,
+            options: .regularExpression
+        ) != nil
+        let chinese = query.range(
+            of: #"(?<!上)(?:上周|上一周)(?!末)"#,
+            options: .regularExpression
+        ) != nil
+        guard english || chinese else { return query }
+
+        let calendar = inputCalendar
+        let today = calendar.startOfDay(for: now)
+        guard let currentWeek = calendar.dateInterval(of: .weekOfYear, for: today),
+              let start = calendar.date(byAdding: .weekOfYear, value: -1, to: currentWeek.start),
+              let end = calendar.date(byAdding: .day, value: -1, to: currentWeek.start)
+        else { return query }
+
+        let formatter = DateFormatter()
+        var gregorian = Calendar(identifier: .gregorian)
+        gregorian.timeZone = calendar.timeZone
+        formatter.calendar = gregorian
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = calendar.timeZone
+        formatter.dateFormat = "yyyy-MM-dd"
+        return "\(query) (date range: \(formatter.string(from: start)) through \(formatter.string(from: end)))"
     }
 
     /// Shared formatting: takes a list of provider-agnostic

--- a/apps/rapid-mac/Sources/Rapid/Tools/WebSearchTool.swift
+++ b/apps/rapid-mac/Sources/Rapid/Tools/WebSearchTool.swift
@@ -113,12 +113,15 @@ enum WebSearchTool {
         // and outcome terms when the user asks in Chinese about this year's
         // World Cup; this is query expansion, not an assumed answer.
         if query.contains("今年世界杯") {
-            var expansion = "\(currentYear) FIFA World Cup completed final result"
+            var expansion = "\(currentYear) FIFA World Cup"
             if query.localizedCaseInsensitiveContains("spain") || query.contains("西班牙") {
                 expansion += " Spain"
             }
-            if query.contains("夺冠") || query.contains("冠军") {
-                expansion += " winner champion"
+            let assertsCompletedOutcome = query.contains("夺冠了")
+                || query.contains("获得了冠军")
+                || query.localizedCaseInsensitiveContains(" won ")
+            if assertsCompletedOutcome {
+                expansion += " completed final result winner champion"
             }
             if query.contains("为什么") || query.contains("为何") {
                 expansion += " why tactical analysis"
@@ -129,8 +132,19 @@ enum WebSearchTool {
             options: [.caseInsensitive, .diacriticInsensitive],
             locale: Locale(identifier: "en_US_POSIX")
         )
+        // An explicit year makes "last week" historical, not relative to
+        // today. Likewise, "last week in/of July" supplies its own calendar
+        // anchor even when the year is omitted.
+        if folded.range(of: #"\b(?:19|20)\d{2}\b"#, options: .regularExpression) != nil
+            || folded.range(
+                of: #"\blast week\s+(?:in|of)\s+(?:january|february|march|april|may|june|july|august|september|october|november|december)\b"#,
+                options: .regularExpression
+            ) != nil
+        {
+            return query
+        }
         let english = folded.range(
-            of: #"\blast week\b(?!\s+of\b)"#,
+            of: #"\blast week\b(?!\s+(?:of|in)\b)"#,
             options: .regularExpression
         ) != nil
         let chinese = query.range(

--- a/apps/rapid-mac/Tests/RapidTests/FreshWebRoutingTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/FreshWebRoutingTests.swift
@@ -142,6 +142,7 @@ struct FreshWebRoutingTests {
         #expect(WebSearchTool.preparedQuery("the last week of July 2020") == "the last week of July 2020")
         #expect(WebSearchTool.preparedQuery("the last week in July") == "the last week in July")
         #expect(WebSearchTool.preparedQuery("what happened last week in 2020?") == "what happened last week in 2020?")
+        #expect(WebSearchTool.preparedQuery("what happened last week compared with 2025?").contains("date range:"))
         #expect(WebSearchTool.preparedQuery("what happened last weekend?") == "what happened last weekend?")
         #expect(WebSearchTool.preparedQuery("上周末有什么活动？") == "上周末有什么活动？")
     }

--- a/apps/rapid-mac/Tests/RapidTests/FreshWebRoutingTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/FreshWebRoutingTests.swift
@@ -121,13 +121,22 @@ struct FreshWebRoutingTests {
             now: now,
             calendar: calendar
         )
-        #expect(query.contains("2026 FIFA World Cup completed final result"))
-        #expect(query.contains("Spain winner champion why tactical analysis"))
+        #expect(query.contains("2026 FIFA World Cup Spain completed final result"))
+        #expect(query.contains("winner champion why tactical analysis"))
+        let prediction = WebSearchTool.preparedQuery(
+            "今年世界杯谁会夺冠？",
+            now: now,
+            calendar: calendar
+        )
+        #expect(prediction.contains("2026 FIFA World Cup"))
+        #expect(!prediction.contains("completed final result"))
     }
 
     @Test("Historical and weekend phrases are not rewritten")
     func relativeDateFalsePositives() {
         #expect(WebSearchTool.preparedQuery("the last week of July 2020") == "the last week of July 2020")
+        #expect(WebSearchTool.preparedQuery("the last week in July") == "the last week in July")
+        #expect(WebSearchTool.preparedQuery("what happened last week in 2020?") == "what happened last week in 2020?")
         #expect(WebSearchTool.preparedQuery("what happened last weekend?") == "what happened last weekend?")
         #expect(WebSearchTool.preparedQuery("上周末有什么活动？") == "上周末有什么活动？")
     }

--- a/apps/rapid-mac/Tests/RapidTests/FreshWebRoutingTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/FreshWebRoutingTests.swift
@@ -1,0 +1,124 @@
+import Foundation
+import Testing
+@testable import Rapid
+
+@Suite("Fresh web routing")
+struct FreshWebRoutingTests {
+    private let enabled: Set<String> = ["web_search", "browse", "weather"]
+
+    @Test("Explicit recent-news prompt forces web search")
+    func explicitRecentNews() {
+        #expect(ChatViewModel.forcedToolForUserTurn(
+            "What's a major news story from the last week?",
+            priorMessages: [],
+            enabledToolNames: enabled
+        ) == "web_search")
+    }
+
+    @Test("Current World Cup research prompt forces web search in Chinese")
+    func chineseCurrentWorldCup() {
+        #expect(ChatViewModel.forcedToolForUserTurn(
+            "Codex，你研究下今年世界杯为什么 Spain 夺冠了",
+            priorMessages: [],
+            enabledToolNames: enabled
+        ) == "web_search")
+    }
+
+    @Test("Restored-thread follow-up inherits fresh evidence intent")
+    func restoredFollowUp() {
+        let history = [
+            ChatMessage(role: .user, content: "What's a major news story from the last week?"),
+            ChatMessage(role: .assistant, content: "I found several sources."),
+            ChatMessage(role: .tool, content: "Web search via DuckDuckGo: results")
+        ]
+        #expect(ChatViewModel.forcedToolForUserTurn(
+            "What about technology? Find one concrete story and summarize it.",
+            priorMessages: history,
+            enabledToolNames: enabled
+        ) == "web_search")
+        #expect(ChatViewModel.webSearchQuery(
+            for: "What about technology? Find one concrete story and summarize it.",
+            priorMessages: history
+        ).contains("last week"))
+    }
+
+    @Test("Evergreen and casual prompts remain automatic")
+    func evergreenPrompts() {
+        #expect(ChatViewModel.forcedToolForUserTurn(
+            "What is the capital of France?",
+            priorMessages: [],
+            enabledToolNames: enabled
+        ) == nil)
+        #expect(ChatViewModel.forcedToolForUserTurn(
+            "Tell me a joke",
+            priorMessages: [],
+            enabledToolNames: enabled
+        ) == nil)
+    }
+
+    @Test("Disabled web search is never forced")
+    func disabledSearch() {
+        #expect(ChatViewModel.forcedToolForUserTurn(
+            "latest technology news",
+            priorMessages: [],
+            enabledToolNames: ["weather"]
+        ) == nil)
+    }
+
+    @Test("Last-week query uses the previous complete calendar week")
+    func concreteLastWeekDates() throws {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = try #require(TimeZone(secondsFromGMT: 0))
+        let now = try #require(calendar.date(from: DateComponents(
+            year: 2026, month: 8, day: 8, hour: 19
+        )))
+        let query = WebSearchTool.preparedQuery(
+            "What's a major news story from the last week?",
+            now: now,
+            calendar: calendar
+        )
+        #expect(query.contains("2026-07-26 through 2026-08-01"))
+    }
+
+    @Test("Chinese current World Cup query is expanded to completed-event terms")
+    func currentWorldCupQueryExpansion() throws {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = try #require(TimeZone(secondsFromGMT: 0))
+        let now = try #require(calendar.date(from: DateComponents(
+            year: 2026, month: 8, day: 8
+        )))
+        let query = WebSearchTool.preparedQuery(
+            "今年世界杯为什么 Spain 夺冠了",
+            now: now,
+            calendar: calendar
+        )
+        #expect(query.contains("2026 FIFA World Cup completed final result"))
+        #expect(query.contains("Spain winner champion why tactical analysis"))
+    }
+
+    @Test("Historical and weekend phrases are not rewritten")
+    func relativeDateFalsePositives() {
+        #expect(WebSearchTool.preparedQuery("the last week of July 2020") == "the last week of July 2020")
+        #expect(WebSearchTool.preparedQuery("what happened last weekend?") == "what happened last weekend?")
+        #expect(WebSearchTool.preparedQuery("上周末有什么活动？") == "上周末有什么活动？")
+    }
+
+    @Test("Grounding sources are extracted from formatted search output")
+    func sourceExtraction() {
+        let output = """
+        Web search via DuckDuckGo: query — 2 results
+
+        1. First [story]
+           https://example.com/one
+           Snippet one
+
+        2. Second story
+           https://example.com/two
+           Snippet two
+        """
+        #expect(ChatViewModel.groundingSources(from: output) == [
+            .init(title: "First [story]", url: "https://example.com/one"),
+            .init(title: "Second story", url: "https://example.com/two")
+        ])
+    }
+}

--- a/apps/rapid-mac/Tests/RapidTests/FreshWebRoutingTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/FreshWebRoutingTests.swift
@@ -54,6 +54,35 @@ struct FreshWebRoutingTests {
             priorMessages: [],
             enabledToolNames: enabled
         ) == nil)
+        #expect(ChatViewModel.forcedToolForUserTurn(
+            "Explain electric current and a current account",
+            priorMessages: [],
+            enabledToolNames: enabled
+        ) == nil)
+    }
+
+    @Test("Follow-up survives a long multi-tool preceding turn")
+    func longToolTurnFollowUp() {
+        var history = [ChatMessage(
+            role: .user,
+            content: "What happened in the news last week?"
+        )]
+        for index in 0..<6 {
+            history.append(ChatMessage(
+                role: .assistant,
+                toolCalls: [ToolCall(id: "c\(index)", name: "web_search", arguments: "{}")]
+            ))
+            history.append(ChatMessage(
+                role: .tool,
+                content: "result \(index)",
+                toolCallID: "c\(index)"
+            ))
+        }
+        #expect(ChatViewModel.forcedToolForUserTurn(
+            "What about technology?",
+            priorMessages: history,
+            enabledToolNames: enabled
+        ) == "web_search")
     }
 
     @Test("Disabled web search is never forced")

--- a/apps/rapid-mac/Tests/RapidTests/FreshWebRoutingTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/FreshWebRoutingTests.swift
@@ -40,6 +40,11 @@ struct FreshWebRoutingTests {
             for: "What about technology? Find one concrete story and summarize it.",
             priorMessages: history
         ).contains("last week"))
+        #expect(ChatViewModel.forcedToolForUserTurn(
+            "Why is the sky blue?",
+            priorMessages: history,
+            enabledToolNames: enabled
+        ) == nil)
     }
 
     @Test("Evergreen and casual prompts remain automatic")

--- a/apps/rapid-mac/scripts/fake-rapid-mlx.sh
+++ b/apps/rapid-mac/scripts/fake-rapid-mlx.sh
@@ -248,7 +248,21 @@ class Handler(BaseHTTPRequestHandler):
                 body = json.loads(self.rfile.read(length))
             except (json.JSONDecodeError, UnicodeDecodeError):
                 body = {}
-        _event("chat_request")
+        messages = body.get("messages") if isinstance(body.get("messages"), list) else []
+        definitions = body.get("tools") if isinstance(body.get("tools"), list) else []
+        _event(
+            "chat_request",
+            roles=[m.get("role") for m in messages if isinstance(m, dict)],
+            tools=[
+                d.get("function", {}).get("name")
+                for d in definitions
+                if isinstance(d, dict) and isinstance(d.get("function"), dict)
+            ],
+            user_texts=[
+                m.get("content") for m in messages
+                if isinstance(m, dict) and m.get("role") == "user" and isinstance(m.get("content"), str)
+            ],
+        )
 
         if body.get("stream") is False:
             max_tokens = int(body.get("max_tokens", 8) or 8)

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -25,12 +25,13 @@ MAIN_WINDOW_ID=""
 BUNDLE_ID=""
 AX_DRIVER=""
 RESULT_WRITTEN=0
+PERSONA_ENV=()
 
 usage() {
     cat <<'EOF'
 Usage: gui-golden-flows.sh [--flow NAME] [--keep] [--update-baselines]
 
-Flows: fresh-install, settings-persistence, chat-restore, chat-depth,
+Flows: fresh-install, settings-persistence, chat-restore, restored-tools, chat-depth,
        slow-stream-stop,
        model-crash-recovery, low-memory-choice, loaded-model-benchmark,
        update-state, no-dead-controls, catalog-integrity,
@@ -98,6 +99,7 @@ cleanup_persona() {
     fi
     PERSONA=""
     BUNDLE_ID=""
+    PERSONA_ENV=()
 }
 
 finish() {
@@ -134,6 +136,7 @@ start_persona() {
     shift
     cleanup_persona
     OUT="$OUT_ROOT/$name"
+    PERSONA_ENV=("$@")
     PERSONA="$(mktemp -d "/tmp/rapid-golden-${name}.XXXXXX")"
     mkdir -p "$OUT"
     "$ROOT/scripts/dogfood-isolate.sh" "$APP_SOURCE" "$PERSONA" \
@@ -144,7 +147,7 @@ start_persona() {
     local config="$PERSONA/home/.rapid-golden-fake.json"
     jq -n --arg event_log "$OUT/fake-events.jsonl" '{FAKE_EVENT_LOG: $event_log}' > "$config"
     local assignment key value updated
-    for assignment in "$@"; do
+    for assignment in "${PERSONA_ENV[@]}"; do
         key="${assignment%%=*}"
         value="${assignment#*=}"
         updated="$config.next"
@@ -152,7 +155,7 @@ start_persona() {
         mv "$updated" "$config"
     done
     env RAPID_BIN="$ROOT/scripts/fake-rapid-mlx.sh" \
-        FAKE_EVENT_LOG="$OUT/fake-events.jsonl" "$@" \
+        FAKE_EVENT_LOG="$OUT/fake-events.jsonl" "${PERSONA_ENV[@]}" \
         "$PERSONA/launch.sh" > "$OUT/app.log" 2>&1 &
     APP_PID=$!
     wait_for_window
@@ -162,6 +165,7 @@ relaunch_persona() {
     stop_app
     env RAPID_BIN="$ROOT/scripts/fake-rapid-mlx.sh" \
         FAKE_EVENT_LOG="$OUT/fake-events.jsonl" \
+        "${PERSONA_ENV[@]}" \
         "$PERSONA/launch.sh" >> "$OUT/app.log" 2>&1 &
     APP_PID=$!
     wait_for_window
@@ -916,6 +920,37 @@ flow_chat_restore() {
     cleanup_persona
 }
 
+flow_restored_tools() {
+    log "restored conversation keeps deterministic web research"
+    start_persona restored-tools RAPID_GUI_WEB_SEARCH_FIXTURE=1
+    dismiss_first_run
+    start_model
+    send_prompt "What's a major news story from the last week?" restored-tools-first
+    wait_send_idle "$OUT/first-settled.json"
+    assert_tree_text "$OUT/first-settled.json" "Tool call web_search"
+    assert_tree_text "$OUT/first-settled.json" "Golden technology story"
+
+    relaunch_persona
+    dismiss_first_run
+    wait_identifier Sidebar.NewChat "$OUT/restored.json"
+    local conversation_id
+    conversation_id="$(jq -r '.data.ui_elements[] | (.identifier // "")
+        | select(test("^Sidebar\\.Conversation\\.[0-9A-Fa-f-]{36}$"))' \
+        "$OUT/restored.json" | head -1)"
+    [[ -n "$conversation_id" ]] || die "restored tool conversation row missing"
+    press "$OUT/restored.json" "$conversation_id" "$OUT/opened.json"
+    send_prompt "What about technology? Find one concrete story and summarize it." restored-tools-followup
+    wait_send_idle "$OUT/followup-settled.json"
+    assert_tree_text "$OUT/followup-settled.json" "Golden technology story"
+
+    jq -s -e '[.[] | select(.event == "chat_request")
+        | select((.roles | index("tool")) != null)
+        | select((.tools | index("web_search")) != null)] | length == 2' \
+        "$OUT/fake-events.jsonl" >/dev/null \
+        || die "fresh/restored synthesis requests did not both carry web evidence and tools"
+    cleanup_persona
+}
+
 flow_slow_stream_stop() {
     log "4/6 controlled slow stream and Stop"
     start_persona slow-stream-stop FAKE_INTER_TOKEN_SLEEP_S=0.01 FAKE_CONTENT_REPEAT=20000
@@ -1475,6 +1510,7 @@ case "$FLOW" in
     fresh-install) flow_fresh_install ;;
     settings-persistence) flow_settings_persistence ;;
     chat-restore) flow_chat_restore ;;
+    restored-tools) flow_restored_tools ;;
     chat-depth) flow_chat_depth ;;
     slow-stream-stop) flow_slow_stream_stop ;;
     model-crash-recovery) flow_model_crash_recovery ;;
@@ -1488,6 +1524,7 @@ case "$FLOW" in
         flow_fresh_install
         flow_settings_persistence
         flow_chat_restore
+        flow_restored_tools
         flow_chat_depth
         flow_slow_stream_stop
         flow_model_crash_recovery


### PR DESCRIPTION
## What changed

- route explicit live/dated questions to `web_search` in the app instead of relying on small models to elect a tool
- preserve the original time scope for elliptical follow-ups after restoring a conversation
- ground relative “last week” searches with concrete dates and expand current World Cup queries with completed-event terms
- append up to three clickable grounding sources when a small model omits citations
- add unit coverage and a deterministic GUI golden flow covering fresh search, relaunch, restored-thread follow-up, evidence injection, and source rendering

## Why

The shipped LFM2.5 1.2B starter frequently ignored `tool_choice`, said it could search without doing so, or lost the live-time constraint in a restored-thread follow-up. Request-shape-only tests therefore passed while the real GUI still failed.

## Validation

- `swift build`
- `swift build -c release`
- `./scripts/gui-golden-flows.sh --flow restored-tools`
- real isolated GUI with LFM2.5 1.2B + DuckDuckGo:
  - fresh “last week” prompt produced a concrete answer and search card
  - restored-thread technology follow-up produced a second search card
  - Chinese 2026 World Cup research prompt produced a grounded Spain–Argentina final summary with three clickable sources

Note: local `swift test` is blocked by the host CommandLineTools installation lacking the XCTest module required by the existing `RapidUXTests` target; GitHub macOS CI remains the authoritative full test run.
