### PR TITLE
Bound GUI tool loops and synthesize an answer

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
@@ -12,7 +12,7 @@ import Observation
 /// (in parallel via ``TaskGroup``), append the ``role: "tool"`` results
 /// to the transcript, open a fresh assistant placeholder, and start
 /// another stream. The loop terminates on any non-tool finish reason
-/// or when ``maxToolRounds`` is hit.
+/// or after a tools-disabled synthesis round when ``maxToolExecutions`` is hit.
 @MainActor
 @Observable
 final class ChatViewModel {
@@ -51,9 +51,15 @@ final class ChatViewModel {
     /// content), which is what unit tests and the no-tools build get.
     let tools: any ToolRegistry
 
-    /// Hard cap on tool-call rounds within a single user turn — stops a
-    /// runaway model that just keeps asking for the same tool.
-    private let maxToolRounds: Int = 10
+    /// Hard cap on tool executions within a single user turn. Three leaves
+    /// room for the useful search → open page → refine pattern without making
+    /// a user wait through a long local-model loop. After the budget is spent
+    /// we give the model one tools-disabled round to synthesize what it has.
+    private let maxToolExecutions: Int = 3
+
+    nonisolated private static let toolBudgetSynthesisPreamble = """
+    The tool-use budget for this turn is exhausted. Do not request or describe any more tool calls. Answer the user's question now using the evidence already present in the conversation. If that evidence is insufficient, say what remains uncertain.
+    """
 
     /// Per-tool on/off flags, persisted in ``UserDefaults`` under keys of the
     /// form ``rapid.tools.enabled.<name>``. Reads fall through to ``true``
@@ -1169,8 +1175,8 @@ final class ChatViewModel {
     /// ``finish_reason: "tool_calls"`` we run the referenced tools, append the
     /// results as ``role: "tool"`` rows, open a fresh assistant placeholder,
     /// and loop. Any other finish reason (or a transport failure, or Stop)
-    /// ends the turn. Bounded by ``maxToolRounds`` so a misbehaving model
-    /// can't pin the loop forever.
+    /// ends the turn. Bounded by ``maxToolExecutions`` plus one tools-disabled
+    /// synthesis round so a misbehaving model can't pin the loop forever.
     ///
     /// The KEEP-path wire hygiene is preserved on every round: empty-prose
     /// and forward-incompatible ``.unknown`` rows are stripped from the wire
@@ -1192,8 +1198,9 @@ final class ChatViewModel {
             }
         }
         var currentPlaceholder = initialPlaceholder
-        var roundsLeft = maxToolRounds
+        var toolExecutionsLeft = maxToolExecutions
         var appGroundingSources: [GroundingSource] = []
+        var isFinalSynthesisRound = false
 
         // `tool_choice:function` is advisory in several local chat templates:
         // the shipped 1.2B starter can ignore it and answer "I can search".
@@ -1202,7 +1209,7 @@ final class ChatViewModel {
         // tool(result) transcript it would have produced itself. The model's
         // job is then only evidence synthesis, which is much more reliable.
         if let query = forcedWebSearchQuery,
-           roundsLeft > 1,
+           toolExecutionsLeft > 0,
            !query.isEmpty
         {
             let call = ToolCall(
@@ -1235,11 +1242,10 @@ final class ChatViewModel {
                 toolCallID: result.toolCallID
             ))
             currentPlaceholder = appendMessage(ChatMessage(role: .assistant, status: .streaming))
-            roundsLeft -= 1
+            toolExecutionsLeft -= 1
         }
 
-        while roundsLeft > 0 {
-            roundsLeft -= 1
+        while toolExecutionsLeft > 0 || isFinalSynthesisRound {
             // History for this request: everything BEFORE the streaming
             // placeholder. The placeholder itself is excluded because the
             // assistant hasn't said anything yet.
@@ -1261,7 +1267,7 @@ final class ChatViewModel {
             // definitions so the broken-tool-caller strip runs against the
             // model that will actually answer this round.
             let wireAlias = server?.servingAlias ?? alias
-            let definitions = ChatViewModel.wireDefinitions(
+            let definitions = isFinalSynthesisRound ? [] : ChatViewModel.wireDefinitions(
                 forAlias: wireAlias,
                 enabled: enabledDefinitions
             )
@@ -1308,6 +1314,11 @@ final class ChatViewModel {
             {
                 history.removeFirst()
             }
+            // Add this after the ambient/evidence consistency check above so
+            // combining the two system instructions cannot defeat that guard.
+            if isFinalSynthesisRound {
+                history = ChatViewModel.addingToolBudgetSynthesisPreamble(to: history)
+            }
             let request: ChatStreamClient.Request
             if let s = sampling {
                 let resolved = s.resolved(toolsEnabled: !definitions.isEmpty)
@@ -1353,10 +1364,10 @@ final class ChatViewModel {
                     finaliseCancelledPlaceholder(at: currentPlaceholder, epoch: epoch)
                     return
                 }
-                // On the last allowed round, executing the requested tools is
-                // wasted work — there is no follow-up round left to consume
-                // the results. Bail before the side-effects fire.
-                if roundsLeft == 0 {
+                // A tools-disabled synthesis request should never produce a
+                // structured call. Keep a defensive failure for malformed
+                // model output rather than looping forever.
+                if isFinalSynthesisRound {
                     failWithToolRoundCap(at: currentPlaceholder, epoch: epoch)
                     return
                 }
@@ -1370,6 +1381,20 @@ final class ChatViewModel {
                         finaliseCancelledPlaceholder(at: currentPlaceholder, epoch: epoch)
                         return
                     }
+                    // A model may batch many calls into one assistant turn.
+                    // Enforce the budget per requested call, and still emit a
+                    // matching result for every skipped call so the transcript
+                    // remains a valid assistant(tool_calls) → tool sequence.
+                    guard toolExecutionsLeft > 0 else {
+                        results.append(ToolCallResult(
+                            toolCallID: call.id,
+                            content: "Tool budget exhausted. Answer using the results already available.",
+                            isError: true,
+                            failureKind: .toolFailed
+                        ))
+                        continue
+                    }
+                    toolExecutionsLeft -= 1
                     // Refuse rather than dispatch when the tool was not
                     // advertised this round — a malformed model can emit a
                     // tool_call for a tool we never offered, and ``tools.run``
@@ -1419,6 +1444,9 @@ final class ChatViewModel {
                 }
                 // Open the next assistant placeholder and loop.
                 currentPlaceholder = appendMessage(ChatMessage(role: .assistant, status: .streaming))
+                if toolExecutionsLeft == 0 {
+                    isFinalSynthesisRound = true
+                }
             }
         }
     }
@@ -1432,12 +1460,11 @@ final class ChatViewModel {
         updateMessage(at: index, with: stale)
     }
 
-    /// The model kept asking for tools until ``maxToolRounds`` ran out. Surface
-    /// it as a failed row + banner rather than leaving the user staring at a
-    /// half-finished transcript.
+    /// Defensive fallback when a model emits a structured call even though
+    /// the final synthesis request advertised no tools.
     private func failWithToolRoundCap(at index: Int, epoch: Int) {
         guard epoch == conversationEpoch else { return }
-        let message = ChatViewModel.toolRoundCapMessage(cap: maxToolRounds)
+        let message = ChatViewModel.toolRoundCapMessage(cap: maxToolExecutions)
         if var capped = currentMessage(index: index) {
             capped.status = .failed
             capped.failureKind = .toolFailed
@@ -1452,7 +1479,24 @@ final class ChatViewModel {
     /// Copy for the round-cap failure. Static so a test can pin it without
     /// driving a full loop.
     static func toolRoundCapMessage(cap: Int) -> String {
-        "The model kept calling tools without answering (\(cap) rounds). Try rephrasing, or turn a tool off."
+        "The model could not finish after \(cap) tool calls. Try rephrasing, or turn a tool off."
+    }
+
+    /// Add the tools-disabled final-round instruction without introducing a
+    /// second system row, which several local chat templates reject.
+    nonisolated static func addingToolBudgetSynthesisPreamble(
+        to messages: [ChatMessage]
+    ) -> [ChatMessage] {
+        var result = messages
+        if result.first?.role == .system {
+            result[0].content += "\n\n" + toolBudgetSynthesisPreamble
+        } else {
+            result.insert(
+                ChatMessage(role: .system, content: toolBudgetSynthesisPreamble, status: .complete),
+                at: 0
+            )
+        }
+        return result
     }
 
     /// Wire-side filter — what actually ends up in the request body's ``tools``

--- a/apps/rapid-mac/Tests/RapidTests/ToolLoopBudgetIntegrationTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ToolLoopBudgetIntegrationTests.swift
@@ -1,0 +1,168 @@
+import Foundation
+import Testing
+@testable import Rapid
+
+@MainActor
+@Suite("Tool-loop budget integration", .serialized)
+struct ToolLoopBudgetIntegrationTests {
+    @Test("three tool rounds end in a tools-disabled synthesis answer")
+    func cappedLoopSynthesizesInsteadOfFailing() async throws {
+        ToolLoopBudgetProtocol.reset()
+        let registry = CountingToolRegistry()
+        let client = ChatStreamClient(
+            baseURL: URL(string: "fake://tool-loop")!,
+            session: ToolLoopBudgetProtocol.session()
+        )
+        let model = ChatViewModel(
+            client: client,
+            tools: registry,
+            persistsConversations: false
+        )
+
+        model.send("Research this topic thoroughly", alias: "test-model")
+        for _ in 0..<200 where model.isStreaming {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+
+        #expect(!model.isStreaming)
+        #expect(registry.runCount == 3)
+        #expect(ToolLoopBudgetProtocol.requestBodies.count == 4)
+        #expect(model.messages.last?.content == "Here is the answer from the evidence.")
+        #expect(model.messages.last?.status == .complete)
+        #expect(model.lastError == nil)
+
+        let finalBody = try #require(ToolLoopBudgetProtocol.requestBodies.last)
+        let json = try #require(
+            JSONSerialization.jsonObject(with: finalBody) as? [String: Any]
+        )
+        #expect(json["tools"] == nil)
+        let messages = try #require(json["messages"] as? [[String: Any]])
+        let system = try #require(messages.first)
+        #expect((system["content"] as? String)?.contains("tool-use budget") == true)
+    }
+
+    @Test("a batched response cannot execute past the three-call budget")
+    func batchedCallsAreCappedIndividually() async throws {
+        ToolLoopBudgetProtocol.reset(batched: true)
+        let registry = CountingToolRegistry()
+        let model = ChatViewModel(
+            client: ChatStreamClient(
+                baseURL: URL(string: "fake://tool-loop")!,
+                session: ToolLoopBudgetProtocol.session()
+            ),
+            tools: registry,
+            persistsConversations: false
+        )
+
+        model.send("Research several sources", alias: "test-model")
+        for _ in 0..<200 where model.isStreaming {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+
+        #expect(!model.isStreaming)
+        #expect(registry.runCount == 3)
+        #expect(ToolLoopBudgetProtocol.requestBodies.count == 2)
+        #expect(model.messages.last?.content == "Here is the answer from the evidence.")
+        let toolRows = model.messages.filter { $0.role == .tool }
+        #expect(toolRows.count == 5)
+        #expect(toolRows.filter { $0.content.contains("budget exhausted") }.count == 2)
+    }
+}
+
+@MainActor
+private final class CountingToolRegistry: ToolRegistry {
+    private(set) var runCount = 0
+
+    let definitions = [
+        ToolDefinition(
+            name: "lookup",
+            description: "Look up evidence",
+            parameters: .object(["type": .string("object")])
+        )
+    ]
+
+    func run(_ call: ToolCall) async -> ToolCallResult {
+        runCount += 1
+        return ToolCallResult(
+            toolCallID: call.id,
+            content: "Evidence item \(runCount)"
+        )
+    }
+}
+
+private final class ToolLoopBudgetProtocol: URLProtocol, @unchecked Sendable {
+    nonisolated(unsafe) static var requestBodies: [Data] = []
+    nonisolated(unsafe) static var sendsBatchedCalls = false
+
+    static func reset(batched: Bool = false) {
+        requestBodies = []
+        sendsBatchedCalls = batched
+    }
+
+    static func session() -> URLSession {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [ToolLoopBudgetProtocol.self]
+        return URLSession(configuration: config)
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        let body = readBody(from: request)
+        Self.requestBodies.append(body)
+        let requestNumber = Self.requestBodies.count
+        let response = HTTPURLResponse(
+            url: request.url!,
+            statusCode: 200,
+            httpVersion: "HTTP/1.1",
+            headerFields: ["Content-Type": "text/event-stream"]
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+
+        let stream: String
+        if Self.sendsBatchedCalls, requestNumber == 1 {
+            let calls = (1...5).map { index in
+                "{\"index\":\(index - 1),\"id\":\"call_\(index)\",\"type\":\"function\",\"function\":{\"name\":\"lookup\",\"arguments\":\"{}\"}}"
+            }.joined(separator: ",")
+            stream = """
+            data: {"choices":[{"delta":{"tool_calls":[\(calls)]},"finish_reason":"tool_calls"}]}
+
+            data: [DONE]
+
+            """
+        } else if !Self.sendsBatchedCalls, requestNumber <= 3 {
+            stream = """
+            data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_\(requestNumber)","type":"function","function":{"name":"lookup","arguments":"{}"}}]},"finish_reason":"tool_calls"}]}
+
+            data: [DONE]
+
+            """
+        } else {
+            stream = """
+            data: {"choices":[{"delta":{"content":"Here is the answer from the evidence."},"finish_reason":"stop"}]}
+
+            data: [DONE]
+
+            """
+        }
+        client?.urlProtocol(self, didLoad: Data(stream.utf8))
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+
+    private func readBody(from request: URLRequest) -> Data {
+        guard let input = request.httpBodyStream else { return request.httpBody ?? Data() }
+        input.open()
+        defer { input.close() }
+        var data = Data()
+        var buffer = [UInt8](repeating: 0, count: 4096)
+        while input.hasBytesAvailable {
+            let count = input.read(&buffer, maxLength: buffer.count)
+            guard count > 0 else { break }
+            data.append(buffer, count: count)
+        }
+        return data
+    }
+}

--- a/apps/rapid-mac/scripts/fake-rapid-mlx.sh
+++ b/apps/rapid-mac/scripts/fake-rapid-mlx.sh
@@ -208,6 +208,21 @@ def _delta(content=None, reasoning=None, finish=None):
     return {"choices": [choice]}
 
 
+def _tool_call_delta(call_id):
+    return {"choices": [{
+        "delta": {"tool_calls": [{
+            "index": 0,
+            "id": call_id,
+            "type": "function",
+            "function": {
+                "name": "web_search",
+                "arguments": json.dumps({"query": "golden tool loop evidence"}),
+            },
+        }]},
+        "finish_reason": "tool_calls",
+    }]}
+
+
 class Handler(BaseHTTPRequestHandler):
     """Minimal OpenAI-shaped surface that's enough to satisfy
     ChatStreamClient + ServerManager's /healthz poll.
@@ -289,6 +304,32 @@ class Handler(BaseHTTPRequestHandler):
         self.send_header("Cache-Control", "no-store")
         self.send_header("Connection", "keep-alive")
         self.end_headers()
+
+        # Deterministic runaway-model fixture. The app must execute only its
+        # bounded budget and then issue one final request with no tools; that
+        # request gets a useful synthesis rather than another tool call.
+        last_user = next((
+            m.get("content", "") for m in reversed(messages)
+            if isinstance(m, dict) and m.get("role") == "user"
+        ), "")
+        if "shape:tool-loop" in last_user:
+            tool_results = sum(
+                1 for m in messages
+                if isinstance(m, dict) and m.get("role") == "tool"
+            )
+            if definitions:
+                call_id = f"golden_loop_{tool_results + 1}"
+                self.wfile.write(_sse(_tool_call_delta(call_id)))
+                self.wfile.write(b"data: [DONE]\n\n")
+                self.wfile.flush()
+                _event("tool_loop_call", call_id=call_id)
+                return
+            synthesis = "Golden tool-loop synthesis from existing evidence."
+            self.wfile.write(_sse(_delta(content=synthesis, finish="stop")))
+            self.wfile.write(b"data: [DONE]\n\n")
+            self.wfile.flush()
+            _event("tool_loop_synthesis", tool_results=tool_results)
+            return
 
         # #896 crash-recovery harness: when FAKE_DIE_AFTER_CHUNKS
         # is set to a positive integer N, we abruptly os._exit(1)

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -31,7 +31,7 @@ usage() {
     cat <<'EOF'
 Usage: gui-golden-flows.sh [--flow NAME] [--keep] [--update-baselines]
 
-Flows: fresh-install, settings-persistence, chat-restore, restored-tools, chat-depth,
+Flows: fresh-install, settings-persistence, chat-restore, restored-tools, tool-loop-budget, chat-depth,
        slow-stream-stop,
        model-crash-recovery, low-memory-choice, loaded-model-benchmark,
        update-state, no-dead-controls, catalog-integrity,
@@ -951,6 +951,27 @@ flow_restored_tools() {
     cleanup_persona
 }
 
+flow_tool_loop_budget() {
+    log "runaway tool use ends with a bounded synthesis answer"
+    start_persona tool-loop-budget RAPID_GUI_WEB_SEARCH_FIXTURE=1
+    dismiss_first_run
+    start_model
+    send_prompt "shape:tool-loop research this topic thoroughly" tool-loop-budget
+    wait_send_idle "$OUT/settled.json"
+    assert_tree_text "$OUT/settled.json" "Golden tool-loop synthesis"
+
+    jq -s -e '[.[] | select(.event == "tool_loop_call")] | length == 3' \
+        "$OUT/fake-events.jsonl" >/dev/null \
+        || die "the app did not stop after exactly three tool executions"
+    jq -s -e '[.[] | select(.event == "tool_loop_synthesis" and .tool_results == 3)] | length == 1' \
+        "$OUT/fake-events.jsonl" >/dev/null \
+        || die "the capped loop did not finish with one synthesis request"
+    jq -s -e '[.[] | select(.event == "chat_request")][-1].tools == []' \
+        "$OUT/fake-events.jsonl" >/dev/null \
+        || die "the final synthesis request still advertised tools"
+    cleanup_persona
+}
+
 flow_slow_stream_stop() {
     log "4/6 controlled slow stream and Stop"
     start_persona slow-stream-stop FAKE_INTER_TOKEN_SLEEP_S=0.01 FAKE_CONTENT_REPEAT=20000
@@ -1511,6 +1532,7 @@ case "$FLOW" in
     settings-persistence) flow_settings_persistence ;;
     chat-restore) flow_chat_restore ;;
     restored-tools) flow_restored_tools ;;
+    tool-loop-budget) flow_tool_loop_budget ;;
     chat-depth) flow_chat_depth ;;
     slow-stream-stop) flow_slow_stream_stop ;;
     model-crash-recovery) flow_model_crash_recovery ;;
@@ -1525,6 +1547,7 @@ case "$FLOW" in
         flow_settings_persistence
         flow_chat_restore
         flow_restored_tools
+        flow_tool_loop_budget
         flow_chat_depth
         flow_slow_stream_stop
         flow_model_crash_recovery


### PR DESCRIPTION
## What changed

- Cap each user turn at three requested tool calls, including batched calls.
- After the budget is spent, run one final synthesis request with tools disabled instead of showing a tool-loop failure.
- Return matching refusal results for overflow calls so the OpenAI tool transcript remains valid.
- Add real ChatViewModel/SSE integration coverage and an AX-driven GUI golden flow.

## Why

Small local models can repeatedly search or browse instead of answering. The previous ten-round cap made users wait through long loops and then ended with an error rather than a useful response.

## Validation

- `swift build --package-path apps/rapid-mac`
- `swift test --package-path apps/rapid-mac --filter ToolLoopBudgetIntegrationTests` (2 passed; local CommandLineTools workaround only excluded the unrelated XCTest-based RapidUXTests target)
- `apps/rapid-mac/scripts/gui-golden-flows.sh --flow tool-loop-budget` (PASS)
- `bash -n apps/rapid-mac/scripts/fake-rapid-mlx.sh apps/rapid-mac/scripts/gui-golden-flows.sh`
- `codex review --uncommitted` (no actionable correctness issues)
