### PR TITLE
fix(release): isolate agent configs in gauntlet

### DIFF
--- a/scripts/release_check_m3.sh
+++ b/scripts/release_check_m3.sh
@@ -196,8 +196,25 @@ cleanup() {
   if [ -n "${CLUSTER_WORK:-}" ]; then
     rm -rf "$CLUSTER_WORK"
   fi
+  if [ -n "${RELEASE_AGENT_HOME_ROOT:-}" ]; then
+    rm -rf "$RELEASE_AGENT_HOME_ROOT"
+  fi
 }
 trap cleanup EXIT INT TERM
+
+# G7b and G12 drive real agent CLIs. Their config is part of the test fixture,
+# not operator state: inheriting ~/.codex or ~/.hermes also inherits personal
+# plugins, MCP servers, skills, and stale model settings. On #1683 that turned
+# Codex's normal 13-tool / 5.5K-token request into 134 tools / 33K tokens; each
+# prefill took ~110s and a healthy file-read loop false-timed out at 120s.
+# Redirect both config homes for a deterministic gate and protect the user's
+# real agent config from setup writes. This allocation deliberately comes
+# AFTER the EXIT trap is installed, and after early preflight refusals, so
+# subsequent failures clean it up. cleanup's inline pre-G12 call clears it;
+# setup recreates it for the independent random sweep.
+RELEASE_AGENT_HOME_ROOT="$(mktemp -d)"
+export CODEX_HOME="$RELEASE_AGENT_HOME_ROOT/codex"
+export HERMES_HOME="$RELEASE_AGENT_HOME_ROOT/hermes"
 
 # Fail before downloading/booting models if a benchmark candidate has no
 # committed comparison point. Staleness is surfaced as a warning; refreshing a

--- a/tests/release/test_release_check_m3_cleanup.sh
+++ b/tests/release/test_release_check_m3_cleanup.sh
@@ -47,6 +47,7 @@ if bash -c '
       set -euo pipefail
       PIDFILE="'"$TMP"'/no-such-pidfile"
       CLUSTER_WORK=""
+      RELEASE_AGENT_HOME_ROOT=""
       . "'"$TMP"'/cleanup.sh"
       cleanup
       exit 0
@@ -61,6 +62,7 @@ if bash -c '
       set -euo pipefail
       PIDFILE="'"$TMP"'/no-such-pidfile"
       unset CLUSTER_WORK
+      unset RELEASE_AGENT_HOME_ROOT
       . "'"$TMP"'/cleanup.sh"
       cleanup
       exit 0
@@ -78,6 +80,7 @@ if bash -c '
       set -euo pipefail
       PIDFILE="'"$TMP"'/no-such-pidfile"
       CLUSTER_WORK="'"$WORK"'"
+      RELEASE_AGENT_HOME_ROOT=""
       . "'"$TMP"'/cleanup.sh"
       cleanup
       exit 0
@@ -95,6 +98,7 @@ if bash -c '
       set -euo pipefail
       PIDFILE="'"$PIDFILE_STALE"'"
       CLUSTER_WORK=""
+      RELEASE_AGENT_HOME_ROOT=""
       . "'"$TMP"'/cleanup.sh"
       cleanup
       exit 0
@@ -102,6 +106,41 @@ if bash -c '
   ok "tolerates a pidfile whose process is already gone, and removes it"
 else
   bad "a stale pidfile made cleanup fail, or left the file behind"
+fi
+
+# Agent homes are temporary fixtures. This both prevents the release gate from
+# loading an operator's plugins/MCPs and makes the pre-G12 cleanup a clean
+# boundary before the random sweep recreates its own configs.
+AGENT_ROOT="$TMP/agent-homes"
+mkdir -p "$AGENT_ROOT/codex" "$AGENT_ROOT/hermes"
+touch "$AGENT_ROOT/codex/config.toml" "$AGENT_ROOT/hermes/config.yaml"
+if bash -c '
+      set -euo pipefail
+      PIDFILE="'"$TMP"'/no-such-pidfile"
+      CLUSTER_WORK=""
+      RELEASE_AGENT_HOME_ROOT="'"$AGENT_ROOT"'"
+      . "'"$TMP"'/cleanup.sh"
+      cleanup
+      exit 0
+    ' 2>/dev/null && [ ! -e "$AGENT_ROOT" ]; then
+  ok "removes isolated Codex/Hermes config homes"
+else
+  bad "left isolated agent config behind, or cleanup returned non-zero"
+fi
+
+if grep -q 'export CODEX_HOME="$RELEASE_AGENT_HOME_ROOT/codex"' "$SCRIPT" \
+   && grep -q 'export HERMES_HOME="$RELEASE_AGENT_HOME_ROOT/hermes"' "$SCRIPT"; then
+  ok "release gate redirects Codex and Hermes into isolated config homes"
+else
+  bad "release gate can inherit or overwrite an operator agent config"
+fi
+
+trap_line=$(grep -n '^trap cleanup EXIT INT TERM$' "$SCRIPT" | cut -d: -f1)
+home_line=$(grep -n '^RELEASE_AGENT_HOME_ROOT="$(mktemp -d)"$' "$SCRIPT" | cut -d: -f1)
+if [ -n "$trap_line" ] && [ -n "$home_line" ] && [ "$trap_line" -lt "$home_line" ]; then
+  ok "installs cleanup trap before allocating the temporary agent home"
+else
+  bad "temporary agent home can leak when an early preflight exits"
 fi
 
 echo "── G12 call site"


### PR DESCRIPTION
Fixes #1683.

The release gauntlet now runs Codex and Hermes with temporary config homes, preventing operator plugins, MCP servers, skills, and stale settings from contaminating G7b/G12.

Measured on the release mini with qwen3.5-9b-4bit: Codex dropped from 134 tools / ~33K prompt tokens to 13 tools / ~5.5K, and the real E2E harness passed 12/12 in 93.3s without increasing the 120s query timeout.

Validation:
- mini real harness: 12 passed, 0 skipped, 93.3s
- cleanup integration: 22 passed
- related Python tests: 33 passed
- Codex review: no findings