### PR TITLE
fix(release): run Gemma coherence on text lane

### DIFF
--- a/scripts/coherence_sweep.sh
+++ b/scripts/coherence_sweep.sh
@@ -8,7 +8,7 @@
 # aliases it affects — one representative per family, plus any alias the change
 # touches.
 #
-# Each alias is booted on a dedicated port with --no-thinking, run through
+# Each alias is booted on a dedicated port in its manifest-selected lane, run through
 # evals/coherence_gate.py (blocking golden answers), then torn down before the
 # next. Any alias that fails its blocking golden gate fails the whole sweep.
 #
@@ -109,6 +109,18 @@ for MODEL in $MODELS; do
     fi
   fi
   SERVE_ARGS=(--port "$PORT")
+  if "$PY" scripts/release_fleet.py forces-text-lane "$MODEL"; then
+    # Gemma 4's checkpoint also carries a vision tower, but this gate scores
+    # its text path. Auto-routing would require the optional mlx-vlm extra and
+    # fail a valid base-wheel release before the first golden prompt (#1685).
+    SERVE_ARGS+=(--no-mllm)
+  else
+    classifier_status=$?
+    if [ "$classifier_status" -ne 1 ]; then
+      echo "ERROR: could not classify serving lane for $MODEL" >&2
+      exit 2
+    fi
+  fi
   if [ "$DISTILL" = "1" ]; then
     # The serve CLI exposes the reasoning profile as ``--reasoning``;
     # ``--thinking`` has never been a valid serve flag. The stale flag made

--- a/scripts/release_fleet.json
+++ b/scripts/release_fleet.json
@@ -25,6 +25,7 @@
       "coherence_model": "gemma-4-12b-4bit",
       "coverage_class": "multimodal",
       "scopes": ["release", "toolchain"],
+      "coherence_force_text_lane": true,
       "artifact_matrix": {
         "model": "gemma-4-12b-4bit",
         "server_args": ["--no-thinking"],

--- a/scripts/release_fleet.py
+++ b/scripts/release_fleet.py
@@ -51,6 +51,7 @@ class FleetFamily:
     artifact_matrix: dict[str, Any] | None
     coherence_enabled: bool = True
     reasoning_distill: bool = False
+    coherence_force_text_lane: bool = False
 
 
 def load_fleet(path: Path = DEFAULT_MANIFEST) -> tuple[FleetFamily, ...]:
@@ -74,6 +75,7 @@ def load_fleet(path: Path = DEFAULT_MANIFEST) -> tuple[FleetFamily, ...]:
         artifact = raw.get("artifact_matrix")
         coherence_enabled = raw.get("coherence", True)
         reasoning_distill = raw.get("reasoning_distill", False)
+        coherence_force_text_lane = raw.get("coherence_force_text_lane", False)
         if (
             not isinstance(model, str)
             or not model
@@ -104,6 +106,8 @@ def load_fleet(path: Path = DEFAULT_MANIFEST) -> tuple[FleetFamily, ...]:
             raise ValueError(f"{name}: coherence must be a boolean")
         if not isinstance(reasoning_distill, bool):
             raise ValueError(f"{name}: reasoning_distill must be a boolean")
+        if not isinstance(coherence_force_text_lane, bool):
+            raise ValueError(f"{name}: coherence_force_text_lane must be a boolean")
         families.append(
             FleetFamily(
                 name=name,
@@ -113,6 +117,7 @@ def load_fleet(path: Path = DEFAULT_MANIFEST) -> tuple[FleetFamily, ...]:
                 artifact_matrix=artifact,
                 coherence_enabled=coherence_enabled,
                 reasoning_distill=reasoning_distill,
+                coherence_force_text_lane=coherence_force_text_lane,
             )
         )
     release_classes = {
@@ -154,6 +159,26 @@ def is_reasoning_distill_model(model: str, *, path: Path = DEFAULT_MANIFEST) -> 
         return True
 
     # Import lazily so ordinary fleet parsing stays dependency-light.
+    from vllm_mlx.model_aliases import resolve_profile
+
+    profile = resolve_profile(model)
+    if profile is None:
+        return False
+    return any(
+        (candidate := resolve_profile(family.coherence_model)) is not None
+        and candidate.hf_path == profile.hf_path
+        for family in families
+    )
+
+
+def coherence_forces_text_lane(model: str, *, path: Path = DEFAULT_MANIFEST) -> bool:
+    """Return whether G0a must use the base-wheel-compatible text lane."""
+    families = tuple(
+        family for family in load_fleet(path) if family.coherence_force_text_lane
+    )
+    if any(model == family.coherence_model for family in families):
+        return True
+
     from vllm_mlx.model_aliases import resolve_profile
 
     profile = resolve_profile(model)
@@ -279,6 +304,11 @@ def _build_parser() -> argparse.ArgumentParser:
         help="exit 0 iff the given coherence model is a reasoning-distill family",
     )
     distill.add_argument("model", help="coherence_model alias to test")
+    text_lane = subparsers.add_parser(
+        "forces-text-lane",
+        help="exit 0 iff G0a should force this coherence model onto the text lane",
+    )
+    text_lane.add_argument("model", help="coherence_model alias to test")
     return parser
 
 
@@ -287,6 +317,12 @@ def main() -> int:
     if args.command == "is-reasoning-distill":
         try:
             return 0 if is_reasoning_distill_model(args.model) else 1
+        except (OSError, ValueError) as exc:
+            print(f"release fleet classification failed: {exc}", file=sys.stderr)
+            return 2
+    if args.command == "forces-text-lane":
+        try:
+            return 0 if coherence_forces_text_lane(args.model) else 1
         except (OSError, ValueError) as exc:
             print(f"release fleet classification failed: {exc}", file=sys.stderr)
             return 2

--- a/tests/test_release_fleet.py
+++ b/tests/test_release_fleet.py
@@ -144,6 +144,28 @@ def test_reasoning_distill_classifier_resolves_alias_and_hf_path(fleet):
     assert not fleet.is_reasoning_distill_model("qwen3.5-4b-4bit")
 
 
+def test_force_text_lane_classifier_is_explicit_and_resolves_hf_path(fleet):
+    gemma = next(f for f in fleet.load_fleet() if f.name == "gemma4")
+    assert gemma.coherence_force_text_lane is True
+    assert fleet.coherence_forces_text_lane("gemma-4-12b-4bit")
+    assert fleet.coherence_forces_text_lane("mlx-community/gemma-4-12B-it-4bit")
+    assert not fleet.coherence_forces_text_lane("qwen3.5-4b-4bit")
+
+
+def test_force_text_lane_flag_defaults_false_and_rejects_non_bool(fleet, tmp_path):
+    data = json.loads(fleet.DEFAULT_MANIFEST.read_text())
+    del data["families"]["gemma4"]["coherence_force_text_lane"]
+    defaulted = tmp_path / "defaulted.json"
+    defaulted.write_text(json.dumps(data))
+    assert all(not f.coherence_force_text_lane for f in fleet.load_fleet(defaulted))
+
+    data["families"]["gemma4"]["coherence_force_text_lane"] = "yes"
+    invalid = tmp_path / "invalid.json"
+    invalid.write_text(json.dumps(data))
+    with pytest.raises(ValueError, match="coherence_force_text_lane must be a boolean"):
+        fleet.load_fleet(invalid)
+
+
 def test_reasoning_distill_classifier_reports_infrastructure_failure(
     fleet, monkeypatch, capsys
 ):
@@ -277,3 +299,10 @@ def test_reasoning_distill_sweep_uses_supported_serve_flag():
     script = (REPO_ROOT / "scripts" / "coherence_sweep.sh").read_text()
     assert "SERVE_ARGS+=(--reasoning)" in script
     assert "SERVE_ARGS+=(--thinking)" not in script
+
+
+def test_coherence_sweep_pins_text_only_lane():
+    """G0a scores text and must not require the optional vision dependency."""
+    script = (REPO_ROOT / "scripts" / "coherence_sweep.sh").read_text()
+    assert 'scripts/release_fleet.py forces-text-lane "$MODEL"' in script
+    assert "SERVE_ARGS+=(--no-mllm)" in script


### PR DESCRIPTION
Fixes #1685.

G0a now uses explicit release-fleet metadata to force Gemma 4 onto the text-only lane for its text coherence contract. Other and future multimodal models retain their normal manifest-selected serving lane. This keeps the base-wheel release gate independent of the optional vision extra without globally forcing every model through text routing.

Validation:
- release fleet tests: 22 passed
- shell syntax and ruff: passed
- Codex review round 1 P2 addressed with explicit per-family metadata
- Codex review round 2: no findings