### PR TITLE
fix(release): extend readiness while boot progresses

### DIFF
--- a/scripts/coherence_sweep.sh
+++ b/scripts/coherence_sweep.sh
@@ -39,6 +39,18 @@ set -euo pipefail
 PY="${PY:-python3.12}"
 PORT="${PORT:-8402}"
 FLEET_SCOPE="${FLEET_SCOPE:-auto}"
+# Server readiness has two bounds. Cold-cache mirror/download work may take
+# longer than the old fixed 180s while still making deterministic progress
+# (#1686), so only 180s with no new log output counts as stalled. The hard cap
+# remains absolute even when a noisy process keeps writing forever.
+BOOT_STALL_S="${COHERENCE_BOOT_STALL_S:-180}"
+BOOT_HARD_S="${COHERENCE_BOOT_HARD_S:-1800}"
+case "$BOOT_STALL_S:$BOOT_HARD_S" in
+  *[!0-9:]*|0:*|*:0)
+    echo "ERROR: COHERENCE_BOOT_STALL_S and COHERENCE_BOOT_HARD_S must be positive integers." >&2
+    exit 2
+    ;;
+esac
 if [ "$#" -gt 0 ]; then
   MODELS="$*"
 elif [ -n "${MODELS:-}" ]; then
@@ -134,14 +146,32 @@ for MODEL in $MODELS; do
   echo "$CURRENT_PID" > "$PIDFILE"
 
   up=0
-  for _ in $(seq 1 180); do
+  boot_failure="hard timeout (${BOOT_HARD_S}s)"
+  boot_started=$SECONDS
+  last_progress=$SECONDS
+  last_log_size=0
+  while [ "$((SECONDS - boot_started))" -lt "$BOOT_HARD_S" ]; do
     if curl -sf "http://127.0.0.1:$PORT/v1/models" >/dev/null 2>&1; then up=1; break; fi
     # Bail early if the server process died during load.
-    if ! kill -0 "$CURRENT_PID" 2>/dev/null; then break; fi
+    if ! kill -0 "$CURRENT_PID" 2>/dev/null; then
+      boot_failure="server process exited"
+      break
+    fi
+
+    # `wc -c` is portable to macOS bash 3.2 and observes both ordinary logs
+    # and carriage-return progress updates redirected into the log file.
+    log_size=$(wc -c < "$LOG" | tr -d ' ')
+    if [ "$log_size" -gt "$last_log_size" ]; then
+      last_log_size=$log_size
+      last_progress=$SECONDS
+    elif [ "$((SECONDS - last_progress))" -ge "$BOOT_STALL_S" ]; then
+      boot_failure="no startup progress for ${BOOT_STALL_S}s"
+      break
+    fi
     sleep 1
   done
   if [ "$up" != 1 ]; then
-    echo "ERROR: $MODEL server did not come up. Last log lines:" >&2
+    echo "ERROR: $MODEL server did not come up: $boot_failure. Last log lines:" >&2
     tail -20 "$LOG" >&2
     infra_failed="$infra_failed $MODEL(boot)"
   else

--- a/tests/test_release_fleet.py
+++ b/tests/test_release_fleet.py
@@ -306,3 +306,13 @@ def test_coherence_sweep_pins_text_only_lane():
     script = (REPO_ROOT / "scripts" / "coherence_sweep.sh").read_text()
     assert 'scripts/release_fleet.py forces-text-lane "$MODEL"' in script
     assert "SERVE_ARGS+=(--no-mllm)" in script
+
+
+def test_coherence_sweep_boot_wait_is_progress_aware_and_hard_bounded():
+    script = (REPO_ROOT / "scripts" / "coherence_sweep.sh").read_text()
+    assert 'BOOT_STALL_S="${COHERENCE_BOOT_STALL_S:-180}"' in script
+    assert 'BOOT_HARD_S="${COHERENCE_BOOT_HARD_S:-1800}"' in script
+    assert 'log_size=$(wc -c < "$LOG"' in script
+    assert "SECONDS - last_progress" in script
+    assert "SECONDS - boot_started" in script
+    assert "for _ in $(seq 1 180)" not in script


### PR DESCRIPTION
Fixes #1686.

G0a readiness now separates a stalled boot from an actively progressing cold-cache mirror:

- fail after 180s without new server-log output
- continue while download/mirror progress is being emitted
- always fail at an absolute 1800s hard cap
- fail immediately when the server process exits
- both bounds are environment-overridable positive integers

The issue reproduction already captures flushed `[bytes] current/total` progress in this same redirected server log, so log growth directly covers the reported path.

Validation:
- release fleet tests: 23 passed
- shell syntax, ruff, diff check: passed
- Codex review: no applicable correctness regression on the observed progress path