### PR TITLE
fix: make Codex review auth reliable and fail closed

### DIFF
--- a/scripts/pr_validate/README.md
+++ b/scripts/pr_validate/README.md
@@ -238,17 +238,18 @@ embedded as the `PROMPT_TEMPLATE` string constant in
 tiering on every finding (see "Code Review Philosophy" above). Only
 `[BLOCKING]` findings fail the gate; `[NIT]`s surface in the
 scorecard. Skips if `PR_VALIDATE_NO_CODEX=1` or the `codex` binary is
-missing. For non-zero codex exits, stderr is matched against a
-transient-backend marker list (network, auth, rate-limit, 5xx) — a
-match skips (flaky LLM mustn't block PRs), anything else fails (a
-malicious diff shouldn't be able to bypass review by inducing a
-crash). See "Failure-mode classification" below for the full table.
+missing. Once Codex is invoked, a timeout, auth/backend error, unusable
+binary, or any other unsuccessful exit fails closed: an unavailable
+review cannot produce a MERGE-SAFE verdict.
 
 Authentication: codex uses its own ChatGPT login at
 `~/.codex/auth.json`. No auth/API-key env var is read here; the repo is
 public and we explicitly do not want a fallback key in source. (The
 `PR_VALIDATE_CODEX_MODEL` env var documented below only selects the
-model — it carries no credentials.)
+model — it carries no credentials.) The invocation uses
+`--ignore-user-config` so a normal-use local `model_provider` override
+does not redirect review traffic, while preserving the ChatGPT-login
+auth path instead of preferring an ambient API key.
 
 Model is pinned to `gpt-5.6-sol` via the `--model` flag so a change to
 the caller's `~/.codex/config.toml` default cannot silently swap the
@@ -261,11 +262,10 @@ a newer generation ships or for local experimentation.
 deprecation notice) so CI/local workflows that pre-date the codex
 swap don't unexpectedly re-enable the paid LLM review.
 
-**Failure-mode classification.** A non-zero `codex exec` exit is
-discriminated: stderr matching transient-backend patterns (network,
-auth, rate-limit, 5xx) → `skip`; anything else → `fail`. This stops
-a malicious PR from bypassing the review gate by inducing a content-
-side codex crash.
+**Failure-mode classification.** Missing binary or explicit opt-out →
+`skip`; every attempted but incomplete review → `fail`. This stops both
+a malicious content-side crash and a persistent auth/backend outage
+from silently bypassing the only adversarial review gate.
 
 **Sandbox-read residual risk.** Codex's `--sandbox read-only` is the
 strictest mode the CLI exposes; absolute-path reads (e.g.

--- a/scripts/pr_validate/steps/codex_review.py
+++ b/scripts/pr_validate/steps/codex_review.py
@@ -12,8 +12,8 @@ each, which is the failure mode that note warns about.
 Codex authentication is the user's own ChatGPT login (``~/.codex/
 auth.json``) — no API key is read from the environment. The repo is
 public; we do not want a fallback key in source. If ``codex`` is
-missing or not logged in, the step skips (a temporarily-broken codex
-must not block every PR).
+missing, the step skips. Once the CLI is invoked, every unsuccessful
+run fails closed so an unavailable review cannot produce MERGE-SAFE.
 
 Failure policy mirrors the previous step:
 * Reply containing "No blocking issues found." → ``pass``.
@@ -404,19 +404,14 @@ class CodexReviewStep(Step):
                         # README + step description promise gpt-5.6-sol.
                         "--model",
                         CODEX_MODEL,
-                        # Force the OpenAI cloud provider for the review
-                        # call. The user's config.toml may set
-                        # ``model_provider = "rapid-mlx"`` for normal
-                        # codex use (so codex routes to local server),
-                        # but pr_validate wants the gpt-5.6-sol cloud model
-                        # talking through OpenAI, not the local mlx
-                        # server. Without this override, codex tries to
-                        # refresh /models against the rapid-mlx server
-                        # and exits 1 because rapid-mlx's OpenAI-shaped
-                        # ``{"data": [...]}`` response lacks the
-                        # ``models`` field codex 0.136+ expects.
-                        "-c",
-                        'model_provider="openai"',
+                        # Ignore the caller's provider override while keeping
+                        # Codex's ChatGPT-login auth path. Pinning
+                        # ``model_provider=openai`` instead makes Codex prefer
+                        # an ambient API key; a key without Responses scopes
+                        # then 401s every review. This flag gives the review a
+                        # clean cloud configuration without inheriting a
+                        # normal-use ``rapid-mlx`` local provider.
+                        "--ignore-user-config",
                         # Skip the "is this a git repo?" check — we
                         # deliberately run codex outside the repo (in
                         # an empty tempdir, see ``cwd=`` below).
@@ -463,38 +458,23 @@ class CodexReviewStep(Step):
             # instead of skipping the gate cleanly.
             return StepResult(
                 name=self.name,
-                status="skip",
+                status="fail",
                 summary=(
                     f"codex exec failed ({type(exc).__name__}: {exc}) — "
-                    "binary present but unusable; treating as skip"
+                    "review was not completed"
                 ),
             )
 
         if proc.returncode != 0:
-            # Discriminate "backend transiently broken" (skip — don't
-            # block PRs on a flaky LLM) from "codex crashed in a way
-            # the PR diff plausibly caused" (fail — a malicious diff
-            # mustn't be able to bypass the review gate by inducing a
-            # crash). Codex round-4 BLOCKER on PR #505.
             stderr_blob = (proc.stderr or "").strip()
-            stdout_had_agent_msg = bool(_parse_codex_jsonl(proc.stdout)[0].strip())
             short_err = stderr_blob.splitlines()
             tail = "\n".join(short_err[-5:]) if short_err else "(no stderr)"
-            if _is_transient_codex_failure(stderr_blob) and not stdout_had_agent_msg:
-                return StepResult(
-                    name=self.name,
-                    status="skip",
-                    summary=f"codex exec exited {proc.returncode} (transient backend)",
-                    details=f"```\n{tail}\n```",
-                )
-            # Non-transient: treat as a hard fail so a content-induced
-            # crash cannot let an unreviewed PR slip past the gate.
             return StepResult(
                 name=self.name,
                 status="fail",
                 summary=(
-                    f"codex exec exited {proc.returncode} — non-transient failure; "
-                    "may indicate the diff triggered a model-side crash"
+                    f"codex exec exited {proc.returncode} — review was not completed; "
+                    "re-run pr_validate after resolving auth/backend failures"
                 ),
                 details=f"```\n{tail}\n```",
             )

--- a/tests/test_pr_validate_codex.py
+++ b/tests/test_pr_validate_codex.py
@@ -428,6 +428,8 @@ class TestModelPinning:
         assert cmd[idx + 1] == CODEX_MODEL, (
             f"expected --model {CODEX_MODEL}, got {cmd[idx + 1]}"
         )
+        assert "--ignore-user-config" in cmd
+        assert 'model_provider="openai"' not in cmd
 
 
 class TestBackwardsCompatOptOut:
@@ -711,15 +713,15 @@ class TestNonZeroExitDiscrimination:
     def test_discriminator(self, stderr, expected):
         assert _is_transient_codex_failure(stderr) is expected
 
-    def test_codex_skip_on_transient_backend(self, monkeypatch, tmp_path):
-        """Network-down stderr → skip (don't block PRs on flaky API)."""
+    def test_codex_fails_closed_on_transient_backend(self, monkeypatch, tmp_path):
+        """Network-down stderr must not let an unreviewed PR report safe."""
 
         class _FakeProc:
             returncode = 1
             stderr = "error: could not resolve host: api.openai.com"
             stdout = ""
 
-        self._drive_and_assert(monkeypatch, tmp_path, _FakeProc(), expected="skip")
+        self._drive_and_assert(monkeypatch, tmp_path, _FakeProc(), expected="fail")
 
     def test_codex_fail_on_content_induced_crash(self, monkeypatch, tmp_path):
         """Non-transient stderr → fail (a malicious diff might be the cause)."""
@@ -1839,25 +1841,25 @@ class TestRound15BrokenCodexBinaryDoesNotCrashPipeline:
 
         return CodexReviewStep().run(ctx)
 
-    def test_permission_error_yields_skip_not_crash(self, monkeypatch, tmp_path):
+    def test_permission_error_yields_fail_not_crash(self, monkeypatch, tmp_path):
         result = self._drive(
             monkeypatch, tmp_path, PermissionError(13, "Permission denied")
         )
-        assert result.status == "skip"
+        assert result.status == "fail"
         assert "PermissionError" in result.summary
 
-    def test_oserror_yields_skip_not_crash(self, monkeypatch, tmp_path):
+    def test_oserror_yields_fail_not_crash(self, monkeypatch, tmp_path):
         """Generic OSError — e.g. ENOEXEC (bad binary format), ETXTBSY
         (executable being written), or any other kernel-level exec
-        rejection — must also degrade to skip."""
+        rejection — must also fail closed."""
         result = self._drive(monkeypatch, tmp_path, OSError(8, "Exec format error"))
-        assert result.status == "skip"
+        assert result.status == "fail"
         assert "OSError" in result.summary
 
-    def test_filenotfounderror_still_yields_skip(self, monkeypatch, tmp_path):
-        """The original case (binary disappeared mid-run) still skips
+    def test_filenotfounderror_yields_fail(self, monkeypatch, tmp_path):
+        """A binary disappearing after resolution is an incomplete review
         — same handler, but the exception name in the summary is now
         explicit rather than hardcoded."""
         result = self._drive(monkeypatch, tmp_path, FileNotFoundError(2, "No such"))
-        assert result.status == "skip"
+        assert result.status == "fail"
         assert "FileNotFoundError" in result.summary


### PR DESCRIPTION
## Summary
- invoke Codex with `--ignore-user-config` so ChatGPT auth is preserved without inheriting a local Rapid-MLX provider
- fail closed after any attempted but incomplete review, preventing an unavailable adversarial review from reporting MERGE-SAFE
- update the validation contract and regression coverage

## Validation
- `python -m pytest tests/test_pr_validate_codex.py -q` (109 passed)
- `ruff check scripts/pr_validate/steps/codex_review.py tests/test_pr_validate_codex.py`
- `ruff format --check scripts/pr_validate/steps/codex_review.py tests/test_pr_validate_codex.py`
- real isolated `codex exec --ignore-user-config ...` authentication smoke passed

Closes #1684