### PR TITLE
fix: make GUI catalog absence checks evidence-based

### DIFF
--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -1505,6 +1505,11 @@ flow_catalog_integrity() {
     dismiss_first_run
     see_main "$OUT/catalog-main.json"
 
+    jq -e '.data.walk.complete == true' "$OUT/catalog-main.json" >/dev/null \
+        || die "could not completely observe the chat catalog"
+    jq -e '.data.ui_elements[]? | select(.identifier == "ModelPickerBar.ModelMenu" and .value == "fake-alias")' \
+        "$OUT/catalog-main.json" >/dev/null \
+        || die "chat catalog inventory was not observed"
     jq -e '[.data.ui_elements[]? | select([(.identifier // ""), (.value // ""), (.title // ""), (.description // "")] | map(tostring) | join(" ") | test("fake-video-alias"))] | length == 0' \
         "$OUT/catalog-main.json" >/dev/null \
         || die "a video-gen alias reached the chat surface"
@@ -1514,6 +1519,11 @@ flow_catalog_integrity() {
     press "$OUT/catalog-settings.json" Settings.Category.modelManagement \
         "$OUT/catalog-open-mm.json"
     see_main "$OUT/catalog-model-management.json"
+    jq -e '.data.walk.complete == true' "$OUT/catalog-model-management.json" >/dev/null \
+        || die "could not completely observe Model Management"
+    jq -e '.data.ui_elements[]? | select(.identifier == "Settings.ModelManagement.Row.fake-alias")' \
+        "$OUT/catalog-model-management.json" >/dev/null \
+        || die "Model Management inventory was not observed"
     jq -e '[.data.ui_elements[]? | select([(.identifier // ""), (.value // ""), (.title // ""), (.description // "")] | map(tostring) | join(" ") | test("fake-video-alias"))] | length == 0' \
         "$OUT/catalog-model-management.json" >/dev/null \
         || die "a video-gen alias reached Model Management"

--- a/apps/rapid-mac/scripts/rapid-ax.swift
+++ b/apps/rapid-mac/scripts/rapid-ax.swift
@@ -16,9 +16,13 @@ guard CommandLine.arguments.count >= 3,
 
 let command = CommandLine.arguments[1]
 let application = AXUIElementCreateApplication(pid)
-var visited = Set<CFHashCode>()
+var visited = Set<AXUIElement>()
 var records = [[String: Any]]()
 var match: AXUIElement?
+// A negative assertion over ui_elements is valid only if the descendant walk
+// reached every child. Caps and AX read failures are observations of
+// "unknown", not proof that an element is absent.
+var elementWalkComplete = true
 // The window list is NOT a by-product of the tree walk, because every way the
 // walk can come up short is silent: it skips a root child whose AXRole read
 // failed, drops a title it could not read, and stops dead at the record cap.
@@ -65,9 +69,11 @@ func size(_ element: AXUIElement, _ name: CFString) -> CGSize? {
 }
 
 func walk(_ element: AXUIElement, depth: Int) {
-    guard depth <= 40, records.count < 12_000 else { return }
-    let identity = CFHash(element)
-    guard visited.insert(identity).inserted else { return }
+    guard depth <= 40, records.count < 12_000 else {
+        elementWalkComplete = false
+        return
+    }
+    guard visited.insert(element).inserted else { return }
 
     let identifier = string(element, kAXIdentifierAttribute as CFString)
     var record: [String: Any] = ["depth": depth]
@@ -118,8 +124,17 @@ func walk(_ element: AXUIElement, depth: Int) {
     if depth == 0 {
         children = windowElements
     } else {
-        guard let kids = attribute(element, kAXChildrenAttribute as CFString) as? [AXUIElement] else { return }
-        children = kids
+        var value: CFTypeRef?
+        let result = AXUIElementCopyAttributeValue(
+            element, kAXChildrenAttribute as CFString, &value)
+        if result == .attributeUnsupported || result == .noValue {
+            children = []
+        } else if result == .success, let kids = value as? [AXUIElement] {
+            children = kids
+        } else {
+            elementWalkComplete = false
+            return
+        }
     }
     for child in children {
         walk(child, depth: depth + 1)
@@ -151,6 +166,7 @@ if let rootChildren = attribute(application, kAXChildrenAttribute as CFString) a
 }
 
 walk(application, depth: 0)
+elementWalkComplete = elementWalkComplete && windowListComplete
 
 if command == "dump" {
     let payload: [String: Any] = [
@@ -158,6 +174,10 @@ if command == "dump" {
         "data": [
             "pid": pid,
             "ui_elements": records,
+            "walk": [
+                "complete": elementWalkComplete,
+                "record_count": records.count
+            ],
             // The authority for "is window X open?" — see the note above. Callers
             // must treat `complete: false` as "could not observe", never as an
             // answer in either direction.

--- a/tests/test_gui_walk_completeness.py
+++ b/tests/test_gui_walk_completeness.py
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Static contract for completeness-gated GUI absence assertions."""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def test_rapid_ax_reports_descendant_walk_completeness():
+    source = (ROOT / "apps/rapid-mac/scripts/rapid-ax.swift").read_text()
+    assert '"walk": [' in source
+    assert '"complete": elementWalkComplete' in source
+    assert source.count("elementWalkComplete = false") >= 2
+    assert "Set<AXUIElement>()" in source
+    assert "elementWalkComplete && windowListComplete" in source
+
+
+def test_catalog_absence_checks_require_complete_walks():
+    source = (ROOT / "apps/rapid-mac/scripts/gui-golden-flows.sh").read_text()
+    flow = source.split("flow_catalog_integrity() {", 1)[1].split("\n}", 1)[0]
+    assert flow.count(".data.walk.complete == true") == 2
+    assert flow.count('test("fake-video-alias")') == 2
+    assert 'ModelPickerBar.ModelMenu" and .value == "fake-alias' in flow
+    assert "Settings.ModelManagement.Row.fake-alias" in flow
+    complete_offsets = [
+        index
+        for index in range(len(flow))
+        if flow.startswith(".data.walk.complete == true", index)
+    ]
+    absence_offsets = [
+        index
+        for index in range(len(flow))
+        if flow.startswith('test("fake-video-alias")', index)
+    ]
+    assert all(
+        complete < absence
+        for complete, absence in zip(complete_offsets, absence_offsets, strict=True)
+    )


### PR DESCRIPTION
## Summary
- expose descendant-walk completeness and record count in `rapid-ax` dumps
- distinguish leaf nodes from actual AX child-read failures and flag depth/record truncation
- require complete walks plus positive observation of the fake chat inventory before asserting the video alias is absent
- guard the contract with release tests

## Validation
- `swiftc -typecheck apps/rapid-mac/scripts/rapid-ax.swift`
- `bash -n apps/rapid-mac/scripts/gui-golden-flows.sh`
- `python -m pytest tests/test_gui_walk_completeness.py -q`
- ruff check/format

Closes #1670