### PR TITLE
fix: let SIGHUP terminate supervised servers

### DIFF
--- a/tests/test_signal_observability.py
+++ b/tests/test_signal_observability.py
@@ -394,31 +394,12 @@ def test_subprocess_sigterm_emits_warning_and_stack_dump():
     assert "Thread" in stderr or "Current thread" in stderr, stderr
 
 
-def test_subprocess_sighup_default_disposition_dumps_and_stays_alive():
-    """R7-C1 (dogfood-088 Talia r1/r2): SIGHUP is now a *diagnostic
-    probe* — the observability hook dumps the stack to stderr and
-    KEEPS THE PROCESS ALIVE. The 0.8.5/0.8.7 lineage (PR #820) had
-    the SIG_DFL chain terminate on SIGHUP via ``raise_signal``; the
-    0.8.7 dogfood (Hiro r6) confirmed dump-and-stay-alive as the
-    intended shape, and the 0.8.8 regression Talia caught was that
-    the SIG_DFL re-raise still terminated the process. Per the C-04
-    PR commentary, operators reach for SIGHUP precisely to inspect a
-    LIVE process without taking it down — SIGTERM/SIGINT are the
-    right signals for graceful shutdown.
+def test_subprocess_sighup_default_disposition_dumps_and_terminates():
+    """SIGHUP keeps its default termination after the diagnostic dump.
 
-    The test:
-      1. Asserts SIGHUP starts from SIG_DFL (the production baseline:
-         uvicorn captures SIGINT/SIGTERM only).
-      2. Sends SIGHUP after the install.
-      3. Verifies stderr contains the WARNING marker + stack frames.
-      4. Verifies the process REACHES the post-sleep ``os._exit(0)``
-         (stays alive end-to-end).
-
-    A previous round of this test installed a callable
-    ``_exit_handler`` BEFORE calling ``install_signal_observability``,
-    which bypassed the SIG_DFL chain entirely. This version
-    deliberately does NOT install a prior so we exercise the real
-    default-disposition path that production sees.
+    This is the production baseline under uvicorn, which does not install a
+    SIGHUP handler. Swallowing it strands servers when tmux or another
+    supervisor closes the controlling session.
     """
     program = textwrap.dedent(
         """
@@ -431,9 +412,7 @@ def test_subprocess_sighup_default_disposition_dumps_and_stays_alive():
         from vllm_mlx._signal_observability import install_signal_observability
         assert install_signal_observability() is True
         sys.stdout.write("READY\\n"); sys.stdout.flush()
-        # If the chain DOES terminate (the regression), we never
-        # reach the os._exit(0) below and the test detects the
-        # subprocess died via a non-zero returncode.
+        # Reaching this exit means the observability hook swallowed SIGHUP.
         for _ in range(20):
             time.sleep(0.1)
         sys.stdout.write("ALIVE\\n"); sys.stdout.flush()
@@ -457,24 +436,15 @@ def test_subprocess_sighup_default_disposition_dumps_and_stays_alive():
             proc.kill()
             proc.communicate()
 
-    # WARNING marker must land before the process continues running.
+    # WARNING marker and stacks land before default termination.
     assert "received signal SIGHUP" in stderr, stderr
     # faulthandler.dump_traceback shape — verifies stack-dump fired.
     assert "Thread" in stderr or "Current thread" in stderr, stderr
-    # R7-C1 invariant: the process MUST reach the post-sleep
-    # ``os._exit(0)`` (returncode=0, "ALIVE" line printed). If
-    # returncode is negative (signal-terminated) or 99 (a different
-    # bailout), the regression is back.
-    assert proc.returncode == 0, (
-        f"SIGHUP terminated the process — R7-C1 regression: the"
-        f" SIG_DFL chain re-raised instead of staying alive."
-        f" returncode={proc.returncode} stdout={stdout!r}"
-        f" stderr={stderr!r}"
+    assert proc.returncode == -signal.SIGHUP, (
+        f"SIGHUP was swallowed: returncode={proc.returncode} "
+        f"stdout={stdout!r} stderr={stderr!r}"
     )
-    assert "ALIVE" in stdout, (
-        f"SIGHUP did not allow the subprocess to continue past the"
-        f" 2-second sleep window; stdout={stdout!r} stderr={stderr!r}"
-    )
+    assert "ALIVE" not in stdout
 
 
 def test_subprocess_sigterm_default_disposition_still_terminates():

--- a/vllm_mlx/_signal_observability.py
+++ b/vllm_mlx/_signal_observability.py
@@ -149,35 +149,11 @@ def _on_signal(signum: int, frame) -> None:  # noqa: ARG001 — frame unused
     except Exception:  # pragma: no cover — defensive
         pass
 
-    # R7-C1 (dogfood-088 Talia r1/r2): SIGHUP is special-cased to a
-    # *diagnostic dump* — restore the default disposition for
-    # termination-class signals OTHER than SIGHUP, but treat SIGHUP as
-    # "dump and stay alive". Historically SIGHUP was used by daemons as
-    # a "reload config / rotate logs" signal: terminating the process on
-    # it (the POSIX SIG_DFL default) is hostile in a long-running
-    # inference server where operators reach for SIGHUP to *probe* a
-    # live process without taking it down. The 0.8.7 dogfood (Hiro r6)
-    # explicitly verified the dump-and-stay-alive shape on SIGHUP; the
-    # 0.8.8 regression Talia caught (PR-#820 chain still terminating
-    # because the SIG_DFL ``raise_signal`` path fires unconditionally)
-    # is fixed here by gating that path behind a "not SIGHUP" check.
-    #
-    # SIGTERM is unchanged — uvicorn registers a callable handler for
-    # SIGTERM (its ``handle_exit``), so the ``callable(prior)`` branch
-    # below runs the graceful drain. Even on the corner case where
-    # SIGTERM's prior is SIG_DFL (no uvicorn installed yet, e.g. unit
-    # tests that mount the lifespan without binding the socket),
-    # SIGTERM still terminates via the SIG_DFL chain — only SIGHUP
-    # short-circuits.
-    #
     # Chain to whatever was registered before us so the original
     # disposition is preserved end-to-end:
     #   * callable prior (uvicorn's ``handle_exit`` etc.) → call it so
     #     graceful shutdown still runs;
-    #   * SIG_DFL on SIGHUP → return (stay alive); the WARNING + stack
-    #     dump above is the entire intended behaviour for SIGHUP as a
-    #     diagnostic probe;
-    #   * SIG_DFL on any other signal → restore default + ``raise_signal``
+    #   * SIG_DFL → restore default + ``raise_signal``
     #     so the kernel-level terminate-by-default fires (we've already
     #     added the observability via the WARNING + stack dump above);
     #   * SIG_IGN → return; ignore-by-default IS the original behaviour.
@@ -188,10 +164,10 @@ def _on_signal(signum: int, frame) -> None:  # noqa: ARG001 — frame unused
     # uvicorn does not capture SIGHUP) was never observed in production
     # — exactly the silent-death shape C-04 was trying to fix. Always
     # install, and make the SIG_DFL branch preserve termination via
-    # ``raise_signal`` after restoring the default handler (except for
-    # SIGHUP per R7-C1 above).
+    # ``raise_signal`` after restoring the default handler. Preserving
+    # SIGHUP's default termination is important: terminal/supervisor
+    # hangup must not orphan a model server that keeps its port and RAM.
     prior = _prior_handlers.get(signum)
-    is_sighup = getattr(signal, "SIGHUP", None) is not None and signum == signal.SIGHUP
     if callable(prior):
         # Codex r8 BLOCKING #2: do NOT swallow exceptions from the prior
         # handler — uvicorn raises ``KeyboardInterrupt`` from its own
@@ -207,15 +183,6 @@ def _on_signal(signum: int, frame) -> None:  # noqa: ARG001 — frame unused
                 "prior signal handler for %s raised during chain", name, exc_info=True
             )
             raise
-    elif prior == signal.SIG_DFL and is_sighup:
-        # R7-C1: SIGHUP-as-diagnostic-probe path. The WARNING + stack
-        # dump above is the full intended behaviour — return without
-        # restoring SIG_DFL + raising, so the process stays alive. Do
-        # NOT chain to terminate semantics here; that's the regression
-        # Talia's r1/r2 caught. Operators reach for SIGHUP precisely
-        # because they want a live-process snapshot WITHOUT taking the
-        # server down (a SIGTERM/SIGINT is the right signal for that).
-        return
     elif prior == signal.SIG_DFL:
         # Restore the default disposition and re-deliver the signal so
         # the kernel-level terminate behaviour fires. ``signal.signal``


### PR DESCRIPTION
## Summary
- retain the diagnostic warning and faulthandler stack dump on SIGHUP
- chain the prior/default disposition instead of swallowing SIGHUP
- prevent tmux or supervisor hangup from orphaning a model server that keeps RAM and its port
- replace the stay-alive subprocess contract with an end-to-end termination assertion

## Validation
- `python -m pytest tests/test_signal_observability.py -q` (10 passed)
- ruff check/format

Closes #1659