### PR TITLE
fix: make doctor compare against engine release tags

### DIFF
--- a/tests/test_version_check.py
+++ b/tests/test_version_check.py
@@ -105,7 +105,7 @@ def test_fetch_latest_pins_nonidentifying_user_agent(monkeypatch):
     def fake_urlopen(req, timeout=None):
         # urllib normalizes header keys to ``User-agent``.
         captured["ua"] = req.get_header("User-agent")
-        return _FakeResp(json.dumps({"tag_name": "0.6.70"}).encode())
+        return _FakeResp(json.dumps({"tag_name": "v0.6.70"}).encode())
 
     monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
 
@@ -126,7 +126,7 @@ def test_fetch_latest_url_encodes_version(monkeypatch):
 
     def fake_urlopen(req, timeout=None):
         captured["url"] = req.full_url
-        return _FakeResp(json.dumps({"tag_name": "0.6.70"}).encode())
+        return _FakeResp(json.dumps({"tag_name": "v0.6.70"}).encode())
 
     monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
 
@@ -143,7 +143,7 @@ def test_fetch_latest_sends_empty_version_when_uninstalled(monkeypatch):
 
     def fake_urlopen(req, timeout=None):
         captured["url"] = req.full_url
-        return _FakeResp(json.dumps({"tag_name": "0.6.70"}).encode())
+        return _FakeResp(json.dumps({"tag_name": "v0.6.70"}).encode())
 
     monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
 
@@ -180,11 +180,90 @@ def test_fetch_latest_returns_none_when_tag_missing(monkeypatch):
     """Passthrough JSON without ``tag_name`` → None (unchanged parse)."""
     monkeypatch.setattr(vc, "_installed_version", lambda: "0.6.61")
 
+    responses = iter(
+        [
+            _FakeResp(json.dumps({"other": "field"}).encode()),
+            _FakeResp(json.dumps([]).encode()),
+        ]
+    )
+
     def fake_urlopen(req, timeout=None):
-        return _FakeResp(json.dumps({"other": "field"}).encode())
+        return next(responses)
 
     monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
     assert vc._fetch_latest() is None
+
+
+@pytest.mark.parametrize("worker_body", [[], "valid-json", 42])
+def test_fetch_latest_fails_open_on_non_object_worker_json(monkeypatch, worker_body):
+    monkeypatch.setattr(vc, "_installed_version", lambda: "0.12.7")
+    responses = iter(
+        [
+            _FakeResp(json.dumps(worker_body).encode()),
+            _FakeResp(json.dumps([]).encode()),
+        ]
+    )
+    monkeypatch.setattr("urllib.request.urlopen", lambda *a, **kw: next(responses))
+    assert vc._fetch_latest() is None
+
+
+def test_fetch_latest_ignores_desktop_release_and_selects_engine_tag(monkeypatch):
+    monkeypatch.setattr(vc, "_installed_version", lambda: "0.12.7")
+    urls = []
+    responses = iter(
+        [
+            _FakeResp(json.dumps({"tag_name": "rapid-mac-v0.12.5"}).encode()),
+            _FakeResp(
+                json.dumps(
+                    [
+                        {"tag_name": "rapid-mac-v0.12.5"},
+                        {"tag_name": "v0.12.7"},
+                        {"tag_name": "v0.12.6"},
+                        {"tag_name": "99.0.0"},
+                        {"tag_name": 999},
+                        {"tag_name": f"v{'9' * 5000}.0.0"},
+                    ]
+                ).encode()
+            ),
+        ]
+    )
+
+    def fake_urlopen(req, timeout=None):
+        urls.append(req.full_url)
+        return next(responses)
+
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+
+    assert vc._fetch_latest() == "0.12.7"
+    assert urls == [
+        "https://rapidmlx.com/api/cli-update?v=0.12.7",
+        f"{vc.GITHUB_RELEASES_ENDPOINT}&page=1",
+    ]
+
+
+def test_desktop_fallback_paginates_until_engine_release(monkeypatch):
+    monkeypatch.setattr(vc, "_installed_version", lambda: "0.12.7")
+    desktop_page = [{"tag_name": f"rapid-mac-v0.11.{index}"} for index in range(100)]
+    responses = iter(
+        [
+            _FakeResp(json.dumps({"tag_name": "rapid-mac-v0.12.5"}).encode()),
+            _FakeResp(json.dumps(desktop_page).encode()),
+            _FakeResp(json.dumps([{"tag_name": "v0.12.7"}]).encode()),
+        ]
+    )
+    urls = []
+
+    def fake_urlopen(req, timeout=None):
+        urls.append(req.full_url)
+        return next(responses)
+
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+
+    assert vc._fetch_latest() == "0.12.7"
+    assert urls[-2:] == [
+        f"{vc.GITHUB_RELEASES_ENDPOINT}&page=1",
+        f"{vc.GITHUB_RELEASES_ENDPOINT}&page=2",
+    ]
 
 
 def test_disabled_short_circuits_before_any_fetch(monkeypatch):

--- a/vllm_mlx/_version_check.py
+++ b/vllm_mlx/_version_check.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import sys
 import time
 import urllib.error
@@ -55,6 +56,9 @@ from pathlib import Path
 # already had — the only change is the recipient is now our own endpoint.
 # Never sent: client id, os/arch, flag values, prompt or generated content.
 CLI_UPDATE_ENDPOINT = "https://rapidmlx.com/api/cli-update"
+GITHUB_RELEASES_ENDPOINT = (
+    "https://api.github.com/repos/raullenchai/Rapid-MLX/releases?per_page=100"
+)
 # Fixed, non-identifying User-Agent so the poll carries no data beyond the
 # ``v`` param + unavoidable IP. Overrides urllib's ``Python-urllib/x.y.z``.
 USER_AGENT = "rapid-mlx-cli"
@@ -64,6 +68,8 @@ NETWORK_TIMEOUT_SECONDS = 2  # tight — staleness check is best-effort
 # enough that a one-version lag is normal noise; 2+ means a feature
 # release was missed.
 MIN_LAG_PATCH = 2
+_REMOTE_ENGINE_TAG_RE = re.compile(r"^v(\d{1,6})\.(\d{1,6})\.(\d{1,6})$")
+_CACHED_VERSION_RE = re.compile(r"^\d{1,6}\.\d{1,6}\.\d{1,6}$")
 
 
 def _cache_path() -> Path:
@@ -113,7 +119,11 @@ def _read_cache() -> dict | None:
             return None
         with p.open("r") as f:
             data = json.load(f)
-        if isinstance(data, dict) and "latest" in data:
+        if (
+            isinstance(data, dict)
+            and isinstance(data.get("latest"), str)
+            and _CACHED_VERSION_RE.fullmatch(data["latest"])
+        ):
             return data
         return None
     except (OSError, json.JSONDecodeError):
@@ -163,10 +173,46 @@ def _fetch_latest() -> str | None:
         )
         with urllib.request.urlopen(req, timeout=NETWORK_TIMEOUT_SECONDS) as resp:
             data = json.loads(resp.read())
-        tag = data.get("tag_name")
-        if not isinstance(tag, str):
-            return None
-        return tag.lstrip("v")
+        tag = data.get("tag_name") if isinstance(data, dict) else None
+        if isinstance(tag, str) and _REMOTE_ENGINE_TAG_RE.fullmatch(tag):
+            return tag.lstrip("v")
+
+        # GitHub's "latest release" can be a desktop release tagged
+        # ``rapid-mac-vX.Y.Z``. That is a different product/version stream,
+        # so fall back to the repository tag inventory and select only exact
+        # engine tags. This path is exceptional; normal polls remain countable
+        # through the landing worker above.
+        page = 1
+        versions: list[tuple[int, int, int]] = []
+        while True:
+            separator = "&" if "?" in GITHUB_RELEASES_ENDPOINT else "?"
+            fallback = urllib.request.Request(
+                f"{GITHUB_RELEASES_ENDPOINT}{separator}page={page}",
+                headers={
+                    "Accept": "application/vnd.github+json",
+                    "User-Agent": USER_AGENT,
+                },
+            )
+            with urllib.request.urlopen(
+                fallback, timeout=NETWORK_TIMEOUT_SECONDS
+            ) as fallback_resp:
+                releases = json.loads(fallback_resp.read())
+            if not isinstance(releases, list):
+                return None
+            # GitHub returns releases newest-first. The first exact engine tag
+            # is therefore authoritative; desktop releases are simply skipped.
+            for item in releases:
+                candidate = item.get("tag_name") if isinstance(item, dict) else None
+                match = (
+                    _REMOTE_ENGINE_TAG_RE.fullmatch(candidate)
+                    if isinstance(candidate, str)
+                    else None
+                )
+                if match:
+                    versions.append(tuple(map(int, match.groups())))
+            if len(releases) < 100:
+                return ".".join(map(str, max(versions))) if versions else None
+            page += 1
     except (urllib.error.URLError, TimeoutError, json.JSONDecodeError, OSError):
         return None
 


### PR DESCRIPTION
## Summary
- accept only exact `vX.Y.Z` engine tags from the countable update endpoint/cache
- when GitHub latest points at a `rapid-mac-vX.Y.Z` desktop release, fall back to the tag inventory and select the highest engine semver
- retain tight timeouts, fixed user agent, and fail-open behavior

## Validation
- `python -m pytest tests/test_version_check.py tests/test_doctor_env_health.py -q` (99 passed)
- live endpoint smoke returned engine `0.12.7`
- ruff check/format

Closes #1655