### PR TITLE
feat(image): local image-generation lane + rapid-mac Images tab

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/DevSnapshot.swift
+++ b/apps/rapid-mac/Sources/Rapid/DevSnapshot.swift
@@ -43,6 +43,10 @@ enum DevSnapshot {
         // throwaway instance is right here: the snapshot never approves
         // anything, it only needs the object to exist.
         let browseApproval = BrowseApprovalStore()
+        // ``ContentView`` also reads ``ImageGenViewModel`` from the
+        // environment (the Images tab). Same rule as ``browseApproval``: a
+        // throwaway instance so the view can be evaluated without trapping.
+        let imageGen = ImageGenViewModel(server: server)
 
         // Erase to AnyView so the long environment chain stays cheap to
         // type-check and the render call is monomorphic.
@@ -61,6 +65,18 @@ enum DevSnapshot {
                     .environment(quickstart)
                     .environment(dockPromptStore)
                     .environment(browseApproval)
+                    .environment(imageGen)
+                    .frame(width: width, height: height)
+            )
+        }
+
+        // The Images tab, rendered standalone — ``ContentView`` owns its
+        // ``SidebarSection`` privately, so (like ``launchView``) the detail
+        // surface is captured directly rather than by driving navigation.
+        func imagesView(width: CGFloat, height: CGFloat) -> AnyView {
+            AnyView(
+                ImagesView(viewModel: imageGen, server: server)
+                    .tint(RapidTheme.brandAmber)
                     .frame(width: width, height: height)
             )
         }
@@ -142,6 +158,11 @@ enum DevSnapshot {
         // whether HF_HUB_CACHE points at a populated cache).
         render(contentView(width: 900, height: 640), to: "\(dir)/content-idle.png")
         render(contentView(width: 640, height: 560), to: "\(dir)/content-min.png")
+        // Images tab (empty state — no results, catalog not yet resolved).
+        render(imagesView(width: 700, height: 640), to: "\(dir)/images-empty.png")
+        renderHosted(imagesView(width: 700, height: 640),
+                     size: CGSize(width: 700, height: 640),
+                     appearance: .darkAqua, to: "\(dir)/images-dark.png")
 
         // Scenario 1b (v1.0 visual foundation): the Light/Dark × surface
         // matrix the Phase-1 review runs on. Chat and Launch are the two

--- a/apps/rapid-mac/Sources/Rapid/Images/ImageClient.swift
+++ b/apps/rapid-mac/Sources/Rapid/Images/ImageClient.swift
@@ -1,0 +1,217 @@
+import Foundation
+
+/// One generated (or edited) image plus the seed that produced it, so the
+/// gallery can label results and an edit can re-target a specific image.
+struct GeneratedImage: Identifiable, Hashable, Sendable {
+    let id = UUID()
+    /// Decoded PNG bytes (from the API's ``b64_json``).
+    let pngData: Data
+    /// The prompt that produced this image — shown as the gallery caption.
+    let prompt: String
+    /// True when this came from ``/v1/images/edits`` (vs. generations).
+    let isEdit: Bool
+}
+
+/// Errors surfaced to the Images tab. Mirrors ``ChatStreamError`` in shape:
+/// a small, user-actionable enum rather than raw ``URLError``/decode noise.
+enum ImageClientError: Error, LocalizedError {
+    case notReady
+    case http(status: Int, message: String?)
+    case emptyResponse
+    case transport(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .notReady:
+            return "The image model isn't running yet."
+        case let .http(status, message):
+            return message ?? "Image request failed (HTTP \(status))."
+        case .emptyResponse:
+            return "The server returned no image."
+        case let .transport(detail):
+            return detail
+        }
+    }
+}
+
+/// HTTP client for the OpenAI-compatible image endpoints. Non-streaming
+/// (unlike ``ChatStreamClient``): a single request/response per image batch,
+/// so it uses ``session.data(for:)`` like ``ServerProfileFetcher`` rather
+/// than the SSE byte loop.
+///
+/// Port and bearer are passed per call — the caller reads
+/// ``ServerManager.activePort`` / ``activeBearer`` at request time (they can
+/// change across a stop/start reload), never caching them.
+struct ImageClient {
+    /// Generous timeout: a cold diffusion run on a large model can take tens
+    /// of seconds, and the first call also pays a lazy model load.
+    static let requestTimeout: TimeInterval = 300
+
+    static let sharedSession: URLSession = {
+        let config = URLSessionConfiguration.ephemeral
+        config.timeoutIntervalForRequest = requestTimeout
+        config.timeoutIntervalForResource = requestTimeout
+        return URLSession(configuration: config)
+    }()
+
+    var session: URLSession = ImageClient.sharedSession
+
+    static func loopbackURL(port: Int) -> URL {
+        URL(string: "http://127.0.0.1:\(port)")!
+    }
+
+    // MARK: - Wire types
+
+    private struct GenerationBody: Encodable {
+        let model: String
+        let prompt: String
+        let n: Int
+        let size: String
+        let response_format = "b64_json"
+        let seed: Int?
+    }
+
+    private struct ImageResponse: Decodable {
+        struct Item: Decodable { let b64_json: String? }
+        let data: [Item]
+    }
+
+    private struct ErrorEnvelope: Decodable {
+        struct Inner: Decodable { let message: String? }
+        let error: Inner?
+    }
+
+    // MARK: - Generations
+
+    /// ``POST /v1/images/generations`` — text→image.
+    func generate(
+        prompt: String,
+        model: String,
+        size: String,
+        count: Int,
+        seed: Int?,
+        port: Int,
+        bearer: String?
+    ) async throws -> [GeneratedImage] {
+        let url = Self.loopbackURL(port: port).appendingPathComponent("v1/images/generations")
+        var req = URLRequest(url: url)
+        req.httpMethod = "POST"
+        req.timeoutInterval = Self.requestTimeout
+        req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        req.setValue("application/json", forHTTPHeaderField: "Accept")
+        applyBearer(&req, bearer)
+        req.httpBody = try JSONEncoder().encode(
+            GenerationBody(model: model, prompt: prompt, n: count, size: size, seed: seed)
+        )
+        let images = try await sendAndDecode(req)
+        return images.map { GeneratedImage(pngData: $0, prompt: prompt, isEdit: false) }
+    }
+
+    // MARK: - Edits
+
+    /// ``POST /v1/images/edits`` — image + instruction → image. Multipart,
+    /// built by hand (there is no shared multipart helper in the app).
+    func edit(
+        imagePNG: Data,
+        prompt: String,
+        model: String,
+        size: String,
+        count: Int,
+        seed: Int?,
+        port: Int,
+        bearer: String?
+    ) async throws -> [GeneratedImage] {
+        let url = Self.loopbackURL(port: port).appendingPathComponent("v1/images/edits")
+        var req = URLRequest(url: url)
+        req.httpMethod = "POST"
+        req.timeoutInterval = Self.requestTimeout
+        req.setValue("application/json", forHTTPHeaderField: "Accept")
+        applyBearer(&req, bearer)
+
+        let boundary = "rapid-\(UUID().uuidString)"
+        req.setValue(
+            "multipart/form-data; boundary=\(boundary)",
+            forHTTPHeaderField: "Content-Type"
+        )
+        var fields: [(String, String)] = [
+            ("prompt", prompt),
+            ("model", model),
+            ("size", size),
+            ("n", String(count)),
+            ("response_format", "b64_json"),
+        ]
+        if let seed { fields.append(("seed", String(seed))) }
+        req.httpBody = Self.multipartBody(
+            boundary: boundary, fields: fields,
+            fileField: "image", fileName: "input.png",
+            fileMime: "image/png", fileData: imagePNG
+        )
+        let images = try await sendAndDecode(req)
+        return images.map { GeneratedImage(pngData: $0, prompt: prompt, isEdit: true) }
+    }
+
+    // MARK: - Shared
+
+    private func applyBearer(_ req: inout URLRequest, _ bearer: String?) {
+        if let bearer, !bearer.isEmpty {
+            req.setValue("Bearer \(bearer)", forHTTPHeaderField: "Authorization")
+        }
+    }
+
+    /// Send, validate status, decode the ``{data:[{b64_json}]}`` envelope
+    /// into raw PNG byte blobs.
+    private func sendAndDecode(_ req: URLRequest) async throws -> [Data] {
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await session.data(for: req)
+        } catch {
+            throw ImageClientError.transport(error.localizedDescription)
+        }
+        guard let http = response as? HTTPURLResponse else {
+            throw ImageClientError.transport("Malformed server response.")
+        }
+        guard (200...299).contains(http.statusCode) else {
+            let message = (try? JSONDecoder().decode(ErrorEnvelope.self, from: data))?
+                .error?.message
+            throw ImageClientError.http(status: http.statusCode, message: message)
+        }
+        guard let decoded = try? JSONDecoder().decode(ImageResponse.self, from: data),
+              !decoded.data.isEmpty else {
+            throw ImageClientError.emptyResponse
+        }
+        let blobs = decoded.data.compactMap { item -> Data? in
+            guard let b64 = item.b64_json else { return nil }
+            return Data(base64Encoded: b64)
+        }
+        guard !blobs.isEmpty else { throw ImageClientError.emptyResponse }
+        return blobs
+    }
+
+    /// Assemble a multipart/form-data body from text fields + one file part.
+    static func multipartBody(
+        boundary: String,
+        fields: [(String, String)],
+        fileField: String,
+        fileName: String,
+        fileMime: String,
+        fileData: Data
+    ) -> Data {
+        var body = Data()
+        let dashes = "--\(boundary)\r\n"
+        for (name, value) in fields {
+            body.append(Data(dashes.utf8))
+            body.append(Data("Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n".utf8))
+            body.append(Data("\(value)\r\n".utf8))
+        }
+        body.append(Data(dashes.utf8))
+        body.append(Data(
+            "Content-Disposition: form-data; name=\"\(fileField)\"; filename=\"\(fileName)\"\r\n".utf8
+        ))
+        body.append(Data("Content-Type: \(fileMime)\r\n\r\n".utf8))
+        body.append(fileData)
+        body.append(Data("\r\n".utf8))
+        body.append(Data("--\(boundary)--\r\n".utf8))
+        return body
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/Images/ImageClient.swift
+++ b/apps/rapid-mac/Sources/Rapid/Images/ImageClient.swift
@@ -186,11 +186,16 @@ struct ImageClient {
             if decoded.cancelled == true { return [] }
             throw ImageClientError.emptyResponse
         }
-        let blobs = decoded.data.compactMap { item -> Data? in
-            guard let b64 = item.b64_json else { return nil }
-            return Data(base64Encoded: b64)
+        // Fail on any malformed item rather than silently dropping it — a
+        // "successful" batch that quietly returns fewer images than requested
+        // would hide server corruption behind a partial gallery.
+        var blobs: [Data] = []
+        for item in decoded.data {
+            guard let b64 = item.b64_json, let data = Data(base64Encoded: b64) else {
+                throw ImageClientError.emptyResponse
+            }
+            blobs.append(data)
         }
-        guard !blobs.isEmpty else { throw ImageClientError.emptyResponse }
         return blobs
     }
 

--- a/apps/rapid-mac/Sources/Rapid/Images/ImageClient.swift
+++ b/apps/rapid-mac/Sources/Rapid/Images/ImageClient.swift
@@ -74,6 +74,7 @@ struct ImageClient {
     private struct ImageResponse: Decodable {
         struct Item: Decodable { let b64_json: String? }
         let data: [Item]
+        let cancelled: Bool?
     }
 
     private struct ErrorEnvelope: Decodable {
@@ -176,8 +177,13 @@ struct ImageClient {
                 .error?.message
             throw ImageClientError.http(status: http.statusCode, message: message)
         }
-        guard let decoded = try? JSONDecoder().decode(ImageResponse.self, from: data),
-              !decoded.data.isEmpty else {
+        guard let decoded = try? JSONDecoder().decode(ImageResponse.self, from: data) else {
+            throw ImageClientError.emptyResponse
+        }
+        // A cancel that lands before the first image finishes returns an empty,
+        // non-error batch — surface it as "no images" rather than a failure.
+        if decoded.data.isEmpty {
+            if decoded.cancelled == true { return [] }
             throw ImageClientError.emptyResponse
         }
         let blobs = decoded.data.compactMap { item -> Data? in
@@ -186,6 +192,52 @@ struct ImageClient {
         }
         guard !blobs.isEmpty else { throw ImageClientError.emptyResponse }
         return blobs
+    }
+
+    // MARK: - Progress & cancel
+
+    /// A live snapshot of the single in-flight render. `running` is false
+    /// during the cold model-load phase (before the denoise loop starts) and
+    /// after it finishes; `step`/`total` drive a determinate progress bar.
+    struct ImageProgress: Decodable, Sendable {
+        let running: Bool
+        let step: Int
+        let total: Int
+        let elapsedMs: Int
+        enum CodingKeys: String, CodingKey {
+            case running, step, total, elapsedMs = "elapsed_ms"
+        }
+        /// Fraction complete in [0, 1], or nil when the step total is unknown.
+        var fraction: Double? {
+            total > 0 ? min(1, Double(step) / Double(total)) : nil
+        }
+    }
+
+    /// ``GET /v1/images/progress`` — polled during a render. Returns nil on any
+    /// transport hiccup so the caller simply keeps its last known state.
+    func fetchProgress(port: Int, bearer: String?) async -> ImageProgress? {
+        let url = Self.loopbackURL(port: port).appendingPathComponent("v1/images/progress")
+        var req = URLRequest(url: url)
+        req.timeoutInterval = 5
+        req.setValue("application/json", forHTTPHeaderField: "Accept")
+        applyBearer(&req, bearer)
+        guard let (data, response) = try? await session.data(for: req),
+              let http = response as? HTTPURLResponse,
+              (200...299).contains(http.statusCode),
+              let progress = try? JSONDecoder().decode(ImageProgress.self, from: data)
+        else { return nil }
+        return progress
+    }
+
+    /// ``POST /v1/images/cancel`` — best-effort; the render stops at its next
+    /// denoise step and its in-flight ``generate`` returns the finished images.
+    func cancel(port: Int, bearer: String?) async {
+        let url = Self.loopbackURL(port: port).appendingPathComponent("v1/images/cancel")
+        var req = URLRequest(url: url)
+        req.httpMethod = "POST"
+        req.timeoutInterval = 5
+        applyBearer(&req, bearer)
+        _ = try? await session.data(for: req)
     }
 
     /// Assemble a multipart/form-data body from text fields + one file part.

--- a/apps/rapid-mac/Sources/Rapid/Images/ImageGenViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Images/ImageGenViewModel.swift
@@ -8,24 +8,89 @@ import Observation
 @MainActor
 @Observable
 final class ImageGenViewModel {
-    /// The prompt the user is composing.
+    /// Speed-vs-quality is the user's real choice; the checkpoint name is
+    /// subtext. ``match`` picks the alias out of the catalog.
+    enum Quality: String, CaseIterable, Identifiable {
+        case fast, best
+        var id: String { rawValue }
+        var title: String { self == .fast ? "Fast" : "Best" }
+        var symbol: String { self == .fast ? "bolt.fill" : "sparkles" }
+        var subtitle: String { self == .fast ? "FLUX.2 Klein" : "Z-Image Turbo" }
+        var etaHint: String { self == .fast ? "~10s" : "~33s" }
+        /// Substring that identifies this tier's alias in the catalog.
+        var match: String { self == .fast ? "klein" : "z-image" }
+        /// Steps used to seed the progress bar before the server reports one.
+        var seedSteps: Int { self == .fast ? 4 : 8 }
+    }
+
+    /// Aspect ratio as three friendly buttons rather than a "512×512" string.
+    enum Aspect: String, CaseIterable, Identifiable {
+        case square, portrait, landscape
+        var id: String { rawValue }
+        var label: String {
+            switch self {
+            case .square: return "1:1"
+            case .portrait: return "3:4"
+            case .landscape: return "4:3"
+            }
+        }
+        var size: String {
+            switch self {
+            case .square: return "1024x1024"
+            case .portrait: return "768x1024"
+            case .landscape: return "1024x768"
+            }
+        }
+    }
+
+    /// The two phases of a render, shown very differently: a reassuring
+    /// (indeterminate) cold-load, then a determinate denoise.
+    enum Phase: Equatable { case preparing, denoising }
+
+    /// A few one-tap prompt starters to beat the blank page.
+    static let starters: [String] = [
+        "A cozy ramen shop at night in the rain, neon, steam, 35mm",
+        "Studio portrait of an elderly fisherman, dramatic side light",
+        "A minimalist product shot of a ceramic mug on linen",
+        "A whale drifting through clouds above a city at dusk",
+    ]
+
+    // MARK: - Composed input
     var prompt: String = ""
-    /// The selected image-gen alias (e.g. ``flux-schnell-4bit``).
-    var selectedAlias: String = ""
-    /// Output size, ``WIDTHxHEIGHT``. Kept to a small curated set in the UI.
-    var size: String = "1024x1024"
-    /// Newest-first gallery of results this session.
-    var results: [GeneratedImage] = []
-    /// True while a generate/edit request is in flight — gates the button.
-    var isGenerating: Bool = false
-    /// User-facing error from the last request, or nil.
-    var errorMessage: String?
-    /// Image-gen aliases discovered from the catalog (``[image:gen]`` rows).
+    var quality: Quality = .fast
+    var aspect: Aspect = .square
+
+    // MARK: - Catalog
+    /// The alias each quality tier resolves to (from the ``[image:gen]`` rows).
     var imageModels: [ModelEntry] = []
-    /// False until the first catalog refresh completes.
     var catalogLoaded: Bool = false
-    /// When set, the next run is an EDIT of this image rather than a fresh
-    /// generation — the compose box shows an "editing" affordance.
+    private(set) var selectedAlias: String = ""
+
+    // MARK: - Results
+    /// Newest-first session gallery (the filmstrip).
+    var results: [GeneratedImage] = []
+    /// The focal image the stage shows; nil ⇒ newest, or empty state.
+    var activeID: GeneratedImage.ID?
+    var activeImage: GeneratedImage? {
+        if let activeID, let hit = results.first(where: { $0.id == activeID }) { return hit }
+        return results.first
+    }
+
+    // MARK: - Run state
+    var isGenerating: Bool = false
+    var phase: Phase = .preparing
+    var progress: ImageClient.ImageProgress?
+    var errorMessage: String?
+    /// True only for the window between "Cancel pressed" and the run ending.
+    private(set) var cancelling: Bool = false
+    /// When the current run started — drives a live elapsed clock in the HUD
+    /// that keeps moving even during the cold model-load phase.
+    private(set) var genStartedAt: Date?
+
+    /// Steps the bar should assume before the server reports a live total.
+    var estimatedSteps: Int { progress?.total ?? quality.seedSteps }
+
+    // MARK: - Edit (parked lane, kept for later)
     var editSource: GeneratedImage?
 
     private let client = ImageClient()
@@ -35,39 +100,62 @@ final class ImageGenViewModel {
         self.server = server
     }
 
-    /// True when the selected alias is an instruction-edit model (its alias
-    /// carries ``image-edit``). Editing requires such a model to be loaded.
-    var selectedIsEditModel: Bool {
-        selectedAlias.localizedCaseInsensitiveContains("image-edit")
-    }
-
-    /// Whether Generate/Edit can fire: a prompt, a model, and no request in
-    /// flight. (Editing additionally needs an ``editSource``.)
     var canSubmit: Bool {
         !isGenerating
             && !prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
             && !selectedAlias.isEmpty
     }
 
+    /// Does a model for the chosen quality exist in the catalog?
+    func hasModel(for quality: Quality) -> Bool {
+        imageModels.contains { $0.alias.localizedCaseInsensitiveContains(quality.match) }
+    }
+
+    func setQuality(_ q: Quality) {
+        quality = q
+        resolveAlias()
+    }
+
+    func use(starter: String) {
+        prompt = starter
+    }
+
+    func select(_ image: GeneratedImage) {
+        activeID = image.id
+        prompt = image.prompt
+    }
+
     /// Load the image-gen alias catalog (safe to call repeatedly).
     func refreshCatalog() async {
         guard let binary = server.binaryPath else { return }
-        let entries = await ModelCatalog.imageEntries(binary: binary)
-        imageModels = entries
+        imageModels = await ModelCatalog.imageEntries(binary: binary)
         catalogLoaded = true
-        if selectedAlias.isEmpty {
-            // Prefer a cached model so the first run doesn't force a pull.
-            selectedAlias = (entries.first { $0.cached } ?? entries.first)?.alias ?? ""
-        }
+        resolveAlias()
     }
 
-    /// Generate (or edit, when ``editSource`` is set) from the current prompt.
+    /// Point ``selectedAlias`` at the current quality tier, falling back to the
+    /// other tier (then any image model) so Generate is never dead.
+    private func resolveAlias() {
+        let byTier = imageModels.first { $0.alias.localizedCaseInsensitiveContains(quality.match) }
+        selectedAlias = (byTier ?? imageModels.first)?.alias ?? ""
+    }
+
+    // MARK: - Generate
+
     func submit() async {
         if let source = editSource {
             await runEdit(source: source)
         } else {
             await runGenerate()
         }
+    }
+
+    func cancel() {
+        guard isGenerating, !cancelling else { return }
+        cancelling = true
+        let port = server.activePort
+        let bearer = server.activeBearer
+        Task { await client.cancel(port: port, bearer: bearer) }
     }
 
     private func runGenerate() async {
@@ -78,16 +166,19 @@ final class ImageGenViewModel {
             guard await self.server.ensureServing(alias: self.selectedAlias, hfPath: hf) else {
                 throw ImageClientError.notReady
             }
+            let port = self.server.activePort
+            let bearer = self.server.activeBearer
+            let poll = self.startPolling(port: port, bearer: bearer)
+            defer { poll.cancel() }
             let images = try await self.client.generate(
-                prompt: trimmed,
-                model: self.selectedAlias,
-                size: self.size,
-                count: 1,
-                seed: nil,
-                port: self.server.activePort,
-                bearer: self.server.activeBearer
+                prompt: trimmed, model: self.selectedAlias, size: self.aspect.size,
+                count: 1, seed: nil, port: port, bearer: bearer
             )
-            self.results.insert(contentsOf: images, at: 0)
+            if let first = images.first {
+                self.results.insert(contentsOf: images, at: 0)
+                self.activeID = first.id
+            }
+            // Empty (cancelled before the first image) leaves the gallery as-is.
         }
     }
 
@@ -99,39 +190,58 @@ final class ImageGenViewModel {
             guard await self.server.ensureServing(alias: self.selectedAlias, hfPath: hf) else {
                 throw ImageClientError.notReady
             }
+            let port = self.server.activePort
+            let bearer = self.server.activeBearer
+            let poll = self.startPolling(port: port, bearer: bearer)
+            defer { poll.cancel() }
             let images = try await self.client.edit(
-                imagePNG: source.pngData,
-                prompt: trimmed,
-                model: self.selectedAlias,
-                size: self.size,
-                count: 1,
-                seed: nil,
-                port: self.server.activePort,
-                bearer: self.server.activeBearer
+                imagePNG: source.pngData, prompt: trimmed, model: self.selectedAlias,
+                size: self.aspect.size, count: 1, seed: nil, port: port, bearer: bearer
             )
-            self.results.insert(contentsOf: images, at: 0)
+            if let first = images.first {
+                self.results.insert(contentsOf: images, at: 0)
+                self.activeID = first.id
+            }
         }
     }
 
-    /// Begin editing a specific result: stage it as the edit source and clear
-    /// the prompt for the instruction.
+    /// Poll the server's live denoise progress ~3×/second and mirror it into
+    /// ``progress`` / ``phase`` so the stage shows a true step bar and ETA.
+    private func startPolling(port: Int, bearer: String?) -> Task<Void, Never> {
+        Task { [weak self] in
+            while !Task.isCancelled {
+                if let snap = await self?.client.fetchProgress(port: port, bearer: bearer) {
+                    self?.progress = snap
+                    self?.phase = snap.running ? .denoising : .preparing
+                }
+                try? await Task.sleep(for: .milliseconds(300))
+            }
+        }
+    }
+
     func beginEdit(_ image: GeneratedImage) {
         editSource = image
         prompt = ""
         errorMessage = nil
     }
 
-    /// Cancel an in-progress edit intent, returning to fresh generation.
-    func cancelEdit() {
-        editSource = nil
-    }
+    func cancelEdit() { editSource = nil }
 
-    /// Shared request wrapper: flips ``isGenerating``, clears ``editSource``
-    /// on success, and funnels every failure into ``errorMessage``.
+    /// Shared request wrapper: flips run state, resets progress, and funnels
+    /// every failure into ``errorMessage``.
     private func withRequest(_ body: @escaping () async throws -> Void) async {
         isGenerating = true
+        cancelling = false
+        phase = .preparing
+        progress = nil
+        genStartedAt = Date()
         errorMessage = nil
-        defer { isGenerating = false }
+        defer {
+            isGenerating = false
+            cancelling = false
+            progress = nil
+            genStartedAt = nil
+        }
         do {
             try await body()
             editSource = nil

--- a/apps/rapid-mac/Sources/Rapid/Images/ImageGenViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Images/ImageGenViewModel.swift
@@ -147,12 +147,17 @@ final class ImageGenViewModel {
         }
     }
 
+    /// The in-flight cancel POST, tracked so the next render can wait for it to
+    /// land — otherwise a delayed cancel could arrive after this generation
+    /// ended and stop the *following* one.
+    private var cancelTask: Task<Void, Never>?
+
     func cancel() {
         guard isGenerating, !cancelling else { return }
         cancelling = true
         let port = server.activePort
         let bearer = server.activeBearer
-        Task { await client.cancel(port: port, bearer: bearer) }
+        cancelTask = Task { await client.cancel(port: port, bearer: bearer) }
     }
 
     private func runGenerate() async {
@@ -233,6 +238,10 @@ final class ImageGenViewModel {
     /// Shared request wrapper: flips run state, resets progress, and funnels
     /// every failure into ``errorMessage``.
     private func withRequest(_ body: @escaping () async throws -> Void) async {
+        // Wait for any prior cancel POST to land before starting, so a delayed
+        // cancel can never stop this fresh render.
+        await cancelTask?.value
+        cancelTask = nil
         isGenerating = true
         cancelling = false
         phase = .preparing

--- a/apps/rapid-mac/Sources/Rapid/Images/ImageGenViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Images/ImageGenViewModel.swift
@@ -8,21 +8,6 @@ import Observation
 @MainActor
 @Observable
 final class ImageGenViewModel {
-    /// Speed-vs-quality is the user's real choice; the checkpoint name is
-    /// subtext. ``match`` picks the alias out of the catalog.
-    enum Quality: String, CaseIterable, Identifiable {
-        case fast, best
-        var id: String { rawValue }
-        var title: String { self == .fast ? "Fast" : "Best" }
-        var symbol: String { self == .fast ? "bolt.fill" : "sparkles" }
-        var subtitle: String { self == .fast ? "FLUX.2 Klein" : "Z-Image Turbo" }
-        var etaHint: String { self == .fast ? "~10s" : "~33s" }
-        /// Substring that identifies this tier's alias in the catalog.
-        var match: String { self == .fast ? "klein" : "z-image" }
-        /// Steps used to seed the progress bar before the server reports one.
-        var seedSteps: Int { self == .fast ? 4 : 8 }
-    }
-
     /// Aspect ratio as three friendly buttons rather than a "512×512" string.
     enum Aspect: String, CaseIterable, Identifiable {
         case square, portrait, landscape
@@ -57,14 +42,16 @@ final class ImageGenViewModel {
 
     // MARK: - Composed input
     var prompt: String = ""
-    var quality: Quality = .fast
     var aspect: Aspect = .square
 
     // MARK: - Catalog
-    /// The alias each quality tier resolves to (from the ``[image:gen]`` rows).
+    /// Every installed/available image model (the ``[image:gen]`` rows). The
+    /// picker lists these directly — one dropdown that scales to N models,
+    /// same shape as the chat picker, rather than a fixed set of boxes.
     var imageModels: [ModelEntry] = []
     var catalogLoaded: Bool = false
-    private(set) var selectedAlias: String = ""
+    /// The alias the picker points at. Settable directly by the dropdown.
+    var selectedAlias: String = ""
 
     // MARK: - Results
     /// Newest-first session gallery (the filmstrip).
@@ -88,7 +75,20 @@ final class ImageGenViewModel {
     private(set) var genStartedAt: Date?
 
     /// Steps the bar should assume before the server reports a live total.
-    var estimatedSteps: Int { progress?.total ?? quality.seedSteps }
+    /// Derived from the selected model family (turbo Z-Image wants ~8, the
+    /// distilled Klein/schnell 4) so the bar is sensibly scaled from step one.
+    var estimatedSteps: Int {
+        progress?.total ?? Self.seedSteps(for: selectedAlias)
+    }
+
+    static func seedSteps(for alias: String) -> Int {
+        alias.localizedCaseInsensitiveContains("z-image") ? 8 : 4
+    }
+
+    /// A readable name for the selected model, shown in the cold-load HUD.
+    var selectedDisplayName: String {
+        selectedAlias.isEmpty ? "the model" : selectedAlias
+    }
 
     // MARK: - Edit (parked lane, kept for later)
     var editSource: GeneratedImage?
@@ -104,16 +104,6 @@ final class ImageGenViewModel {
         !isGenerating
             && !prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
             && !selectedAlias.isEmpty
-    }
-
-    /// Does a model for the chosen quality exist in the catalog?
-    func hasModel(for quality: Quality) -> Bool {
-        imageModels.contains { $0.alias.localizedCaseInsensitiveContains(quality.match) }
-    }
-
-    func setQuality(_ q: Quality) {
-        quality = q
-        resolveAlias()
     }
 
     func use(starter: String) {
@@ -133,11 +123,14 @@ final class ImageGenViewModel {
         resolveAlias()
     }
 
-    /// Point ``selectedAlias`` at the current quality tier, falling back to the
-    /// other tier (then any image model) so Generate is never dead.
+    /// Keep ``selectedAlias`` valid: default to a cached model (so the first
+    /// run doesn't force a pull), else the first image model. Only overrides
+    /// when the current selection is empty or no longer in the catalog, so a
+    /// user's explicit pick survives a refresh.
     private func resolveAlias() {
-        let byTier = imageModels.first { $0.alias.localizedCaseInsensitiveContains(quality.match) }
-        selectedAlias = (byTier ?? imageModels.first)?.alias ?? ""
+        let stillValid = imageModels.contains { $0.alias == selectedAlias }
+        guard selectedAlias.isEmpty || !stillValid else { return }
+        selectedAlias = (imageModels.first { $0.cached } ?? imageModels.first)?.alias ?? ""
     }
 
     // MARK: - Generate

--- a/apps/rapid-mac/Sources/Rapid/Images/ImageGenViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Images/ImageGenViewModel.swift
@@ -77,6 +77,10 @@ final class ImageGenViewModel {
     /// When the current run started — drives a live elapsed clock in the HUD
     /// that keeps moving even during the cold model-load phase.
     private(set) var genStartedAt: Date?
+    /// When denoising actually began (first `running` step). ETA is computed
+    /// from THIS, not ``genStartedAt`` — otherwise minutes of cold model load
+    /// inflate the per-step estimate.
+    private(set) var denoiseStartedAt: Date?
 
     /// Steps the bar should assume before the server reports a live total.
     /// Derived from the selected model family (turbo Z-Image wants ~8, the
@@ -140,6 +144,11 @@ final class ImageGenViewModel {
     // MARK: - Generate
 
     func submit() async {
+        // Claim the run synchronously (on the MainActor, before any await) so
+        // two rapid submits can't both slip past the gate and launch concurrent
+        // renders. ``withRequest`` clears it when the run ends.
+        guard !isGenerating else { return }
+        isGenerating = true
         if let source = editSource {
             await runEdit(source: source)
         } else {
@@ -221,6 +230,9 @@ final class ImageGenViewModel {
                 if let snap = await self?.client.fetchProgress(port: port, bearer: bearer) {
                     self?.progress = snap
                     self?.phase = snap.running ? .denoising : .preparing
+                    if snap.running, self?.denoiseStartedAt == nil {
+                        self?.denoiseStartedAt = Date()
+                    }
                 }
                 try? await Task.sleep(for: .milliseconds(300))
             }
@@ -247,12 +259,14 @@ final class ImageGenViewModel {
         phase = .preparing
         progress = nil
         genStartedAt = Date()
+        denoiseStartedAt = nil
         errorMessage = nil
         defer {
             isGenerating = false
             cancelling = false
             progress = nil
             genStartedAt = nil
+            denoiseStartedAt = nil
         }
         do {
             try await body()

--- a/apps/rapid-mac/Sources/Rapid/Images/ImageGenViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Images/ImageGenViewModel.swift
@@ -1,0 +1,145 @@
+import Foundation
+import Observation
+
+/// State + orchestration for the Images tab. Mirrors ``ChatViewModel``:
+/// an ``@Observable`` store the view binds to, owning the image client and
+/// the results, and reading ``ServerManager.activePort`` / ``activeBearer``
+/// at request time (never caching — they change across a reload).
+@MainActor
+@Observable
+final class ImageGenViewModel {
+    /// The prompt the user is composing.
+    var prompt: String = ""
+    /// The selected image-gen alias (e.g. ``flux-schnell-4bit``).
+    var selectedAlias: String = ""
+    /// Output size, ``WIDTHxHEIGHT``. Kept to a small curated set in the UI.
+    var size: String = "1024x1024"
+    /// Newest-first gallery of results this session.
+    var results: [GeneratedImage] = []
+    /// True while a generate/edit request is in flight — gates the button.
+    var isGenerating: Bool = false
+    /// User-facing error from the last request, or nil.
+    var errorMessage: String?
+    /// Image-gen aliases discovered from the catalog (``[image:gen]`` rows).
+    var imageModels: [ModelEntry] = []
+    /// False until the first catalog refresh completes.
+    var catalogLoaded: Bool = false
+    /// When set, the next run is an EDIT of this image rather than a fresh
+    /// generation — the compose box shows an "editing" affordance.
+    var editSource: GeneratedImage?
+
+    private let client = ImageClient()
+    private let server: ServerManager
+
+    init(server: ServerManager) {
+        self.server = server
+    }
+
+    /// True when the selected alias is an instruction-edit model (its alias
+    /// carries ``image-edit``). Editing requires such a model to be loaded.
+    var selectedIsEditModel: Bool {
+        selectedAlias.localizedCaseInsensitiveContains("image-edit")
+    }
+
+    /// Whether Generate/Edit can fire: a prompt, a model, and no request in
+    /// flight. (Editing additionally needs an ``editSource``.)
+    var canSubmit: Bool {
+        !isGenerating
+            && !prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && !selectedAlias.isEmpty
+    }
+
+    /// Load the image-gen alias catalog (safe to call repeatedly).
+    func refreshCatalog() async {
+        guard let binary = server.binaryPath else { return }
+        let entries = await ModelCatalog.imageEntries(binary: binary)
+        imageModels = entries
+        catalogLoaded = true
+        if selectedAlias.isEmpty {
+            // Prefer a cached model so the first run doesn't force a pull.
+            selectedAlias = (entries.first { $0.cached } ?? entries.first)?.alias ?? ""
+        }
+    }
+
+    /// Generate (or edit, when ``editSource`` is set) from the current prompt.
+    func submit() async {
+        if let source = editSource {
+            await runEdit(source: source)
+        } else {
+            await runGenerate()
+        }
+    }
+
+    private func runGenerate() async {
+        let trimmed = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, !selectedAlias.isEmpty else { return }
+        await withRequest {
+            let hf = self.imageModels.first { $0.alias == self.selectedAlias }?.hfRepo
+            guard await self.server.ensureServing(alias: self.selectedAlias, hfPath: hf) else {
+                throw ImageClientError.notReady
+            }
+            let images = try await self.client.generate(
+                prompt: trimmed,
+                model: self.selectedAlias,
+                size: self.size,
+                count: 1,
+                seed: nil,
+                port: self.server.activePort,
+                bearer: self.server.activeBearer
+            )
+            self.results.insert(contentsOf: images, at: 0)
+        }
+    }
+
+    private func runEdit(source: GeneratedImage) async {
+        let trimmed = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, !selectedAlias.isEmpty else { return }
+        await withRequest {
+            let hf = self.imageModels.first { $0.alias == self.selectedAlias }?.hfRepo
+            guard await self.server.ensureServing(alias: self.selectedAlias, hfPath: hf) else {
+                throw ImageClientError.notReady
+            }
+            let images = try await self.client.edit(
+                imagePNG: source.pngData,
+                prompt: trimmed,
+                model: self.selectedAlias,
+                size: self.size,
+                count: 1,
+                seed: nil,
+                port: self.server.activePort,
+                bearer: self.server.activeBearer
+            )
+            self.results.insert(contentsOf: images, at: 0)
+        }
+    }
+
+    /// Begin editing a specific result: stage it as the edit source and clear
+    /// the prompt for the instruction.
+    func beginEdit(_ image: GeneratedImage) {
+        editSource = image
+        prompt = ""
+        errorMessage = nil
+    }
+
+    /// Cancel an in-progress edit intent, returning to fresh generation.
+    func cancelEdit() {
+        editSource = nil
+    }
+
+    /// Shared request wrapper: flips ``isGenerating``, clears ``editSource``
+    /// on success, and funnels every failure into ``errorMessage``.
+    private func withRequest(_ body: @escaping () async throws -> Void) async {
+        isGenerating = true
+        errorMessage = nil
+        defer { isGenerating = false }
+        do {
+            try await body()
+            editSource = nil
+            prompt = ""
+        } catch let error as ImageClientError {
+            errorMessage = error.errorDescription
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/Images/ImageGenViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Images/ImageGenViewModel.swift
@@ -54,6 +54,10 @@ final class ImageGenViewModel {
     var selectedAlias: String = ""
 
     // MARK: - Results
+    /// Cap on the in-memory session gallery. Each result holds a full-resolution
+    /// PNG (multiple MB), so an unbounded list would grow app memory without
+    /// limit across a long session; older results roll off the end.
+    static let maxResults = 30
     /// Newest-first session gallery (the filmstrip).
     var results: [GeneratedImage] = []
     /// The focal image the stage shows; nil ⇒ newest, or empty state.
@@ -169,6 +173,9 @@ final class ImageGenViewModel {
             )
             if let first = images.first {
                 self.results.insert(contentsOf: images, at: 0)
+                if self.results.count > Self.maxResults {
+                    self.results.removeLast(self.results.count - Self.maxResults)
+                }
                 self.activeID = first.id
             }
             // Empty (cancelled before the first image) leaves the gallery as-is.
@@ -193,6 +200,9 @@ final class ImageGenViewModel {
             )
             if let first = images.first {
                 self.results.insert(contentsOf: images, at: 0)
+                if self.results.count > Self.maxResults {
+                    self.results.removeLast(self.results.count - Self.maxResults)
+                }
                 self.activeID = first.id
             }
         }

--- a/apps/rapid-mac/Sources/Rapid/RapidApp.swift
+++ b/apps/rapid-mac/Sources/Rapid/RapidApp.swift
@@ -29,6 +29,10 @@ struct RapidApp: App {
     /// Per-window-but-shared chat controller — single window for now, so
     /// keeping a process-wide instance is fine.
     @State private var chatViewModel: ChatViewModel
+    /// Images-tab controller — text→image / image-edit against an image-gen
+    /// alias (rapid serves one model per process, so this is decoupled from
+    /// chat and reloads the server when switching to an image model).
+    @State private var imageGen: ImageGenViewModel
     /// Self-update poller. GETs a public static manifest on R2 at
     /// `https://dl.rapidmlx.com/latest.json`. See ``UpdateChecker``.
     @State private var updater: UpdateChecker
@@ -127,6 +131,7 @@ struct RapidApp: App {
         _dockPromptStore = State(initialValue: dockPrompt)
         AppDelegate.shared.dockPromptStore = dockPrompt
         _chatViewModel = State(initialValue: chat)
+        _imageGen = State(initialValue: ImageGenViewModel(server: manager))
         _updater = State(initialValue: updateChecker)
         _installer = State(initialValue: installerInstance)
         _sampling = State(initialValue: samplingConfig)
@@ -153,6 +158,7 @@ struct RapidApp: App {
                 .environment(server)
                 .environment(downloads)
                 .environment(chatViewModel)
+                .environment(imageGen)
                 .environment(updater)
                 .environment(sampling)
                 .environment(appearance)

--- a/apps/rapid-mac/Sources/Rapid/Server/ModelCatalog.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ModelCatalog.swift
@@ -303,6 +303,52 @@ enum ModelCatalog {
         return (parseAvailable(output), parseExcludedAliases(output))
     }
 
+    /// Image-generation aliases (``[image:gen]`` rows) for the Images tab's
+    /// model picker. Parsed from the same ``rapid-mlx models`` output the
+    /// chat catalog reads, but keeping ONLY the image rows the chat catalog
+    /// deliberately excludes. ``cached`` is resolved by cross-referencing
+    /// ``rapid-mlx ls`` on HF repo id, so the picker can show which image
+    /// models boot instantly vs. which trigger a multi-GB pull.
+    static func imageEntries(
+        binary: URL,
+        hubCacheOverride: URL? = ModelsFolderPreference.validatedOverrideURL()
+    ) async -> [ModelEntry] {
+        async let modelsOut = runRapidMlx(binary: binary, args: ["models"])
+        async let cachedTask: [(String, String?, String?)] = listCached(
+            binary: binary,
+            hubCacheOverride: hubCacheOverride
+        )
+        let rows = parseImageRows(await modelsOut)
+        let cachedRepos = Set((await cachedTask).compactMap { $0.1 })
+        return rows.map { row in
+            ModelEntry(
+                alias: row.alias,
+                hfRepo: row.hfRepo,
+                sizeOnDisk: row.size,
+                cached: row.hfRepo.map { cachedRepos.contains($0) } ?? false
+            )
+        }
+    }
+
+    /// Parse ``[image:gen]``-tagged rows into ``(alias, hfRepo, size)``.
+    /// Row shape (see cli.py image section):
+    /// ``flux-schnell-4bit    8.9 GiB    [image:gen] dhairyashil/FLUX...``.
+    static func parseImageRows(
+        _ output: String
+    ) -> [(alias: String, hfRepo: String?, size: String?)] {
+        var rows: [(String, String?, String?)] = []
+        for rawLine in output.split(separator: "\n", omittingEmptySubsequences: true) {
+            let line = String(rawLine).trimmingCharacters(in: .whitespaces)
+            let fields = line.split(whereSeparator: { $0.isWhitespace }).map(String.init)
+            guard let alias = fields.first, isSafeAlias(alias),
+                  let tagIdx = fields.firstIndex(of: "[image:gen]") else { continue }
+            let hfRepo = tagIdx + 1 < fields.count ? fields[tagIdx + 1] : nil
+            let size = tagIdx > 1 ? fields[1..<tagIdx].joined(separator: " ") : nil
+            rows.append((alias, hfRepo, size))
+        }
+        return rows
+    }
+
     /// True when the line carries a non-chat Kind tag in its own column.
     ///
     /// Matching the bare substring ``"[audio:"`` would let any row whose
@@ -319,7 +365,7 @@ enum ModelCatalog {
             guard let colon = body.firstIndex(of: ":") else { continue }
             let kind = body[body.startIndex..<colon]
             let subtype = body[body.index(after: colon)...]
-            guard kind == "audio" || kind == "video" else { continue }
+            guard kind == "audio" || kind == "video" || kind == "image" else { continue }
             guard !subtype.isEmpty, subtype.allSatisfy({ $0.isLetter || $0 == "-" }) else {
                 continue
             }

--- a/apps/rapid-mac/Sources/Rapid/Server/ModelCatalog.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ModelCatalog.swift
@@ -1,5 +1,22 @@
 import Foundation
 
+/// What a model is *for*. Drives the capability tabs in Model Management —
+/// chat models and image models are managed side by side but never mixed in
+/// one list (and are picked in different tabs). Video is reserved for when
+/// the video lane surfaces manageable aliases.
+enum ModelKind: String, Sendable, Hashable, CaseIterable, Identifiable {
+    case chat, image, video
+    var id: String { rawValue }
+    /// Tab label in Model Management.
+    var tabLabel: String {
+        switch self {
+        case .chat: return "Chat"
+        case .image: return "Image"
+        case .video: return "Video"
+        }
+    }
+}
+
 /// One model in the rapid-mlx catalog. The picker UI groups cached vs.
 /// uncached so the user knows which aliases boot instantly vs. which
 /// trigger an HF download on first ``serve``.
@@ -17,6 +34,10 @@ struct ModelEntry: Identifiable, Hashable, Sendable {
     /// Drives a green dot in the picker so the user can tell at a glance
     /// which models start in seconds vs. which trigger a 5-80 GB pull.
     let cached: Bool
+
+    /// What the model is for. Defaults to ``.chat`` so every existing
+    /// construction site keeps working; the image catalog tags ``.image``.
+    var kind: ModelKind = .chat
 
     var id: String { alias }
 }
@@ -325,7 +346,8 @@ enum ModelCatalog {
                 alias: row.alias,
                 hfRepo: row.hfRepo,
                 sizeOnDisk: row.size,
-                cached: row.hfRepo.map { cachedRepos.contains($0) } ?? false
+                cached: row.hfRepo.map { cachedRepos.contains($0) } ?? false,
+                kind: .image
             )
         }
     }

--- a/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
@@ -1207,7 +1207,10 @@ private struct ToolCallChip: View {
     }
 }
 
-private struct ComposeField: View {
+/// The chat/image compose text editor: an autosizing NSTextView with a
+/// placeholder, ⏎-to-submit and Esc-to-cancel. Shared by ChatView and
+/// ImagesView so both tabs get an identical input field.
+struct ComposeField: View {
     @Binding var text: String
     /// Counter the parent bumps when it wants the editor to grab
     /// keyboard focus. See ``ChatView.composeFocusToken``.
@@ -1365,7 +1368,7 @@ final class AutosizingTextView: NSTextView {
 /// Smart-substitutions are explicitly off — chat with an LLM is
 /// code-heavy enough that auto-quoting / dash substitution corrupts
 /// snippets the user pastes.
-private struct ComposeTextEditor: NSViewRepresentable {
+struct ComposeTextEditor: NSViewRepresentable {
     @Binding var text: String
     var focusToken: Int
     var isStreaming: Bool

--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -15,6 +15,7 @@ struct ContentView: View {
     @Environment(ServerManager.self) private var server
     @Environment(DownloadManager.self) private var downloads
     @Environment(ChatViewModel.self) private var chat
+    @Environment(ImageGenViewModel.self) private var imageGen
     @Environment(SamplingConfig.self) private var sampling
     @Environment(UpdateChecker.self) private var updater
     @Environment(QuickstartCoordinator.self) private var quickstart
@@ -424,6 +425,8 @@ struct ContentView: View {
         switch section {
         case .chat:
             mainArea
+        case .images:
+            ImagesView(viewModel: imageGen, server: server)
         case .launch:
             LaunchView(
                 server: server,

--- a/apps/rapid-mac/Sources/Rapid/UI/ImagesView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ImagesView.swift
@@ -1,132 +1,296 @@
 import AppKit
 import SwiftUI
 
-/// The Images tab — a dedicated text→image / image-edit surface, decoupled
-/// from chat (rapid-mlx serves one model per process, so image generation
-/// runs against an image-gen alias rather than the chat model). Layout
-/// mirrors ``ChatView``: a results area on top, a compose bar on the bottom.
+/// The Images tab — a local text→image surface designed around three jobs:
+/// get a good image with the least friction, riff on it, and never feel stuck
+/// during a 10–40 s render. Layout: a Fast/Best quality bar, a big focal stage
+/// that shows the render's live step progress, a session filmstrip, and a
+/// prompt composer with one-tap starters.
 struct ImagesView: View {
     @Bindable var viewModel: ImageGenViewModel
     @Bindable var server: ServerManager
 
-    /// Curated output sizes. Kept small (all multiples of 16, within the
-    /// engine's 256–2048 bounds) so the picker can't produce a 400.
-    private let sizeOptions = ["512x512", "768x768", "1024x1024", "1024x768", "768x1024"]
-
     var body: some View {
         VStack(spacing: 0) {
-            gallery
+            qualityBar
             Divider()
-            composeBar
+            stageAndHistory
+            Divider()
+            composer
         }
         .background(RapidTheme.surfaceCanvas)
         .task { await viewModel.refreshCatalog() }
     }
 
-    // MARK: - Gallery
+    // MARK: - Quality bar
 
-    @ViewBuilder
-    private var gallery: some View {
-        if viewModel.results.isEmpty {
-            EmptyState(
-                symbol: "photo.on.rectangle.angled",
-                title: "Generate an image",
-                message: "Describe what you want to see, pick an image model, and press Generate.",
-                hint: viewModel.imageModels.isEmpty && viewModel.catalogLoaded
-                    ? "No image models found — install one from the model list."
-                    : nil
-            )
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .accessibilityIdentifier("Images.EmptyState")
-        } else {
-            ScrollView {
-                LazyVGrid(
-                    columns: [GridItem(.adaptive(minimum: 220), spacing: 16)],
-                    spacing: 16
-                ) {
-                    ForEach(viewModel.results) { image in
-                        resultCard(image)
-                    }
-                }
-                .padding(16)
+    private var qualityBar: some View {
+        HStack(spacing: 12) {
+            ForEach(ImageGenViewModel.Quality.allCases) { q in
+                qualityChip(q)
             }
-            .accessibilityIdentifier("Images.Gallery")
+            Spacer()
+            if let active = viewModel.activeImage, !viewModel.isGenerating {
+                Button {
+                    save(active)
+                } label: {
+                    Label("Save", systemImage: "square.and.arrow.down")
+                }
+                .buttonStyle(.rapidSecondary)
+                .accessibilityIdentifier("Images.Result.Save")
+            }
         }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+        .background(RapidTheme.surfaceSidebar)
     }
 
-    private func resultCard(_ image: GeneratedImage) -> some View {
-        VStack(alignment: .leading, spacing: 8) {
-            if let nsImage = NSImage(data: image.pngData) {
+    private func qualityChip(_ q: ImageGenViewModel.Quality) -> some View {
+        let selected = viewModel.quality == q
+        return Button {
+            viewModel.setQuality(q)
+        } label: {
+            HStack(spacing: 8) {
+                Image(systemName: q.symbol)
+                    .font(.system(size: 12, weight: .semibold))
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(q.title).font(.system(size: 13, weight: .semibold))
+                    Text("\(q.subtitle) · \(q.etaHint)")
+                        .font(.system(size: 10))
+                        .foregroundStyle(selected ? Color.black.opacity(0.65) : .secondary)
+                }
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 7)
+            .background(selected ? RapidTheme.brandAmber : RapidTheme.card)
+            .foregroundStyle(selected ? Color.black : Color.primary)
+            .clipShape(RoundedRectangle(cornerRadius: 10))
+            .overlay(
+                RoundedRectangle(cornerRadius: 10)
+                    .stroke(RapidTheme.hairline, lineWidth: selected ? 0 : 1)
+            )
+            .opacity(viewModel.catalogLoaded && !viewModel.hasModel(for: q) ? 0.45 : 1)
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier("Images.Quality.\(q.title)")
+    }
+
+    // MARK: - Stage + history
+
+    private var stageAndHistory: some View {
+        VStack(spacing: 12) {
+            stage
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            if !viewModel.results.isEmpty {
+                filmstrip
+            }
+        }
+        .padding(16)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    @ViewBuilder
+    private var stage: some View {
+        ZStack {
+            if let active = viewModel.activeImage, let nsImage = NSImage(data: active.pngData) {
                 Image(nsImage: nsImage)
                     .resizable()
                     .aspectRatio(contentMode: .fit)
-                    .frame(maxWidth: .infinity)
-                    .clipShape(RoundedRectangle(cornerRadius: 10))
+                    .clipShape(RoundedRectangle(cornerRadius: 14))
                     .overlay(
-                        RoundedRectangle(cornerRadius: 10)
-                            .stroke(RapidTheme.hairline, lineWidth: 1)
+                        RoundedRectangle(cornerRadius: 14).stroke(RapidTheme.hairline, lineWidth: 1)
                     )
+                    .accessibilityIdentifier("Images.Stage")
+            } else if !viewModel.isGenerating {
+                emptyStage
             }
-            Text(image.prompt)
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .lineLimit(2)
-            HStack(spacing: 8) {
-                Button("Edit") { viewModel.beginEdit(image) }
-                    .buttonStyle(.rapidSecondary)
-                    .accessibilityIdentifier("Images.Result.Edit")
-                Button("Save") { save(image) }
-                    .buttonStyle(.rapidSecondary)
-                    .accessibilityIdentifier("Images.Result.Save")
-                Spacer()
-                if image.isEdit {
-                    Text("edited")
-                        .font(.caption2)
-                        .foregroundStyle(RapidTheme.brandAmber)
-                }
+
+            if viewModel.isGenerating {
+                progressHUD
+                    .transition(.opacity)
             }
         }
-        .padding(10)
-        .background(RapidTheme.card)
-        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
-    // MARK: - Compose bar
+    private var emptyStage: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "photo.on.rectangle.angled")
+                .font(.system(size: 36, weight: .light))
+                .foregroundStyle(.tertiary)
+            Text("Type a thought below and press Generate.")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+            Text(noModelHint ?? "Runs entirely on this Mac — private, offline, unlimited.")
+                .font(.caption)
+                .foregroundStyle(.tertiary)
+        }
+        .multilineTextAlignment(.center)
+        .padding(24)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .accessibilityIdentifier("Images.EmptyState")
+    }
 
-    private var composeBar: some View {
-        VStack(spacing: 8) {
-            if viewModel.editSource != nil {
-                editingBanner
+    private var noModelHint: String? {
+        guard viewModel.catalogLoaded, viewModel.imageModels.isEmpty else { return nil }
+        return "No image models found — install one from the model list."
+    }
+
+    // MARK: - Progress HUD (the wait, designed)
+
+    private var progressHUD: some View {
+        // A live clock that keeps moving even during the cold model-load phase.
+        TimelineView(.periodic(from: .now, by: 0.1)) { context in
+            let elapsed = viewModel.genStartedAt.map { context.date.timeIntervalSince($0) } ?? 0
+            VStack {
+                Spacer()
+                VStack(alignment: .leading, spacing: 10) {
+                    if viewModel.phase == .denoising, let p = viewModel.progress {
+                        denoiseBody(p, elapsed: elapsed)
+                    } else {
+                        preparingBody(elapsed: elapsed)
+                    }
+                }
+                .padding(16)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(.ultraThinMaterial)
+                .clipShape(RoundedRectangle(cornerRadius: 14))
             }
+            .padding(2)
+        }
+    }
+
+    private func preparingBody(elapsed: TimeInterval) -> some View {
+        HStack(spacing: 12) {
+            ProgressView().controlSize(.small)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(viewModel.cancelling ? "Stopping…" : "Warming up \(viewModel.quality.subtitle)…")
+                    .font(.system(size: 13, weight: .semibold))
+                Text("First run loads the model — this only happens once.")
+                    .font(.caption).foregroundStyle(.secondary)
+            }
+            Spacer()
+            clock(elapsed)
+            cancelButton
+        }
+    }
+
+    private func denoiseBody(_ p: ImageClient.ImageProgress, elapsed: TimeInterval) -> some View {
+        let total = max(p.total, viewModel.estimatedSteps)
+        let fraction = total > 0 ? min(1, Double(p.step) / Double(total)) : 0
+        return VStack(alignment: .leading, spacing: 9) {
+            HStack {
+                Text(viewModel.cancelling
+                     ? "Stopping…"
+                     : "Step \(max(1, p.step)) / \(total) · denoising")
+                    .font(.system(size: 13, weight: .semibold))
+                Spacer()
+                clock(elapsed)
+                cancelButton
+            }
+            ProgressBar(fraction: fraction)
+                .frame(height: 6)
+            if let eta = etaText(step: p.step, total: total, elapsed: elapsed) {
+                Text(eta).font(.caption).foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private func clock(_ elapsed: TimeInterval) -> some View {
+        Text(String(format: "%.1fs", max(0, elapsed)))
+            .font(.system(size: 12, weight: .semibold, design: .monospaced))
+            .foregroundStyle(.secondary)
+    }
+
+    private var cancelButton: some View {
+        Button {
+            viewModel.cancel()
+        } label: {
+            Image(systemName: "xmark")
+                .font(.system(size: 11, weight: .bold))
+                .frame(width: 22, height: 22)
+        }
+        .buttonStyle(.plain)
+        .background(Color.primary.opacity(0.08))
+        .clipShape(Circle())
+        .disabled(viewModel.cancelling)
+        .help("Cancel")
+        .accessibilityIdentifier("Images.Cancel")
+    }
+
+    /// ETA from uniform step time; nil until there's a step to extrapolate from.
+    private func etaText(step: Int, total: Int, elapsed: TimeInterval) -> String? {
+        guard step > 0, total > step, elapsed > 0 else { return nil }
+        let perStep = elapsed / Double(step)
+        let remaining = perStep * Double(total - step)
+        return "~\(Int(remaining.rounded()))s left"
+    }
+
+    // MARK: - Filmstrip
+
+    private var filmstrip: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 8) {
+                ForEach(viewModel.results) { image in
+                    filmstripThumb(image)
+                }
+            }
+            .padding(.vertical, 2)
+        }
+        .frame(height: 64)
+        .accessibilityIdentifier("Images.Gallery")
+    }
+
+    private func filmstripThumb(_ image: GeneratedImage) -> some View {
+        let selected = viewModel.activeImage?.id == image.id
+        return Button {
+            viewModel.select(image)
+        } label: {
+            Group {
+                if let nsImage = NSImage(data: image.pngData) {
+                    Image(nsImage: nsImage).resizable().aspectRatio(contentMode: .fill)
+                } else {
+                    Rectangle().fill(RapidTheme.card)
+                }
+            }
+            .frame(width: 56, height: 56)
+            .clipShape(RoundedRectangle(cornerRadius: 9))
+            .overlay(
+                RoundedRectangle(cornerRadius: 9)
+                    .stroke(selected ? RapidTheme.brandAmber : RapidTheme.hairline,
+                            lineWidth: selected ? 2 : 1)
+            )
+        }
+        .buttonStyle(.plain)
+    }
+
+    // MARK: - Composer
+
+    private var composer: some View {
+        VStack(spacing: 10) {
             if let error = viewModel.errorMessage {
                 InlineNotice(message: error, tone: .error)
             }
-            HStack(spacing: 12) {
-                modelPicker
-                sizePicker
-                Spacer()
+            if viewModel.prompt.isEmpty {
+                starters
             }
-            HStack(spacing: 10) {
-                TextField(
-                    viewModel.editSource != nil
-                        ? "Describe the change…"
-                        : "Describe the image…",
-                    text: $viewModel.prompt,
-                    axis: .vertical
-                )
-                .textFieldStyle(.plain)
-                .lineLimit(1...4)
-                .padding(10)
-                .background(RapidTheme.composePill)
-                .clipShape(RoundedRectangle(cornerRadius: 10))
-                .accessibilityIdentifier("Images.Prompt")
-                .onSubmit { runSubmit() }
+            HStack(alignment: .bottom, spacing: 10) {
+                TextField("Describe the image you want…", text: $viewModel.prompt, axis: .vertical)
+                    .textFieldStyle(.plain)
+                    .lineLimit(1...4)
+                    .padding(10)
+                    .background(RapidTheme.composePill)
+                    .clipShape(RoundedRectangle(cornerRadius: 10))
+                    .accessibilityIdentifier("Images.Prompt")
+                    .onSubmit(runSubmit)
+
+                aspectPicker
 
                 Button(action: runSubmit) {
                     if viewModel.isGenerating {
                         ProgressView().controlSize(.small)
                     } else {
-                        Text(viewModel.editSource != nil ? "Edit" : "Generate")
+                        Text("Generate")
                     }
                 }
                 .buttonStyle(.rapidPrimary)
@@ -138,39 +302,51 @@ struct ImagesView: View {
         .background(RapidTheme.surfaceSidebar)
     }
 
-    private var editingBanner: some View {
-        HStack(spacing: 8) {
-            Image(systemName: "wand.and.stars")
-                .foregroundStyle(RapidTheme.brandAmber)
-            Text("Editing an image")
-                .font(.callout)
-            Spacer()
-            Button("Cancel") { viewModel.cancelEdit() }
-                .buttonStyle(.rapidSecondary)
-                .accessibilityIdentifier("Images.CancelEdit")
-        }
-        .padding(.horizontal, 4)
-    }
-
-    private var modelPicker: some View {
-        Picker("Model", selection: $viewModel.selectedAlias) {
-            ForEach(viewModel.imageModels) { entry in
-                Text(entry.cached ? "\(entry.alias) ✓" : entry.alias)
-                    .tag(entry.alias)
+    private var starters: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 7) {
+                ForEach(ImageGenViewModel.starters, id: \.self) { starter in
+                    Button {
+                        viewModel.use(starter: starter)
+                    } label: {
+                        Text(starter)
+                            .font(.caption)
+                            .lineLimit(1)
+                            .padding(.horizontal, 11)
+                            .padding(.vertical, 6)
+                            .background(RapidTheme.card)
+                            .clipShape(Capsule())
+                            .overlay(Capsule().stroke(RapidTheme.hairline, lineWidth: 1))
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityIdentifier("Images.Starter")
+                }
             }
         }
-        .labelsHidden()
-        .frame(maxWidth: 260)
-        .accessibilityIdentifier("Images.ModelPicker")
     }
 
-    private var sizePicker: some View {
-        Picker("Size", selection: $viewModel.size) {
-            ForEach(sizeOptions, id: \.self) { Text($0).tag($0) }
+    private var aspectPicker: some View {
+        HStack(spacing: 4) {
+            ForEach(ImageGenViewModel.Aspect.allCases) { ar in
+                let on = viewModel.aspect == ar
+                Button {
+                    viewModel.aspect = ar
+                } label: {
+                    Text(ar.label)
+                        .font(.system(size: 11, weight: .medium))
+                        .padding(.horizontal, 9)
+                        .padding(.vertical, 7)
+                        .background(on ? RapidTheme.card : Color.clear)
+                        .foregroundStyle(on ? Color.primary : Color.secondary)
+                        .clipShape(RoundedRectangle(cornerRadius: 6))
+                }
+                .buttonStyle(.plain)
+            }
         }
-        .labelsHidden()
-        .frame(maxWidth: 120)
-        .accessibilityIdentifier("Images.SizePicker")
+        .padding(3)
+        .background(RapidTheme.composePill)
+        .clipShape(RoundedRectangle(cornerRadius: 9))
+        .accessibilityIdentifier("Images.Aspect")
     }
 
     // MARK: - Actions
@@ -180,7 +356,6 @@ struct ImagesView: View {
         Task { await viewModel.submit() }
     }
 
-    /// Write the PNG to a user-chosen location via the standard save panel.
     private func save(_ image: GeneratedImage) {
         let panel = NSSavePanel()
         panel.allowedContentTypes = [.png]
@@ -188,5 +363,24 @@ struct ImagesView: View {
         panel.canCreateDirectories = true
         guard panel.runModal() == .OK, let url = panel.url else { return }
         try? image.pngData.write(to: url)
+    }
+}
+
+/// A determinate capsule progress bar with the brand fill. Kept tiny and
+/// local — the only progress bar in the app that shows a true diffusion
+/// step fraction.
+private struct ProgressBar: View {
+    let fraction: Double
+
+    var body: some View {
+        GeometryReader { geo in
+            ZStack(alignment: .leading) {
+                Capsule().fill(Color.primary.opacity(0.15))
+                Capsule()
+                    .fill(RapidTheme.brandAmber)
+                    .frame(width: max(0, min(1, fraction)) * geo.size.width)
+                    .animation(.easeOut(duration: 0.3), value: fraction)
+            }
+        }
     }
 }

--- a/apps/rapid-mac/Sources/Rapid/UI/ImagesView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ImagesView.swift
@@ -1,0 +1,192 @@
+import AppKit
+import SwiftUI
+
+/// The Images tab — a dedicated text→image / image-edit surface, decoupled
+/// from chat (rapid-mlx serves one model per process, so image generation
+/// runs against an image-gen alias rather than the chat model). Layout
+/// mirrors ``ChatView``: a results area on top, a compose bar on the bottom.
+struct ImagesView: View {
+    @Bindable var viewModel: ImageGenViewModel
+    @Bindable var server: ServerManager
+
+    /// Curated output sizes. Kept small (all multiples of 16, within the
+    /// engine's 256–2048 bounds) so the picker can't produce a 400.
+    private let sizeOptions = ["512x512", "768x768", "1024x1024", "1024x768", "768x1024"]
+
+    var body: some View {
+        VStack(spacing: 0) {
+            gallery
+            Divider()
+            composeBar
+        }
+        .background(RapidTheme.surfaceCanvas)
+        .task { await viewModel.refreshCatalog() }
+    }
+
+    // MARK: - Gallery
+
+    @ViewBuilder
+    private var gallery: some View {
+        if viewModel.results.isEmpty {
+            EmptyState(
+                symbol: "photo.on.rectangle.angled",
+                title: "Generate an image",
+                message: "Describe what you want to see, pick an image model, and press Generate.",
+                hint: viewModel.imageModels.isEmpty && viewModel.catalogLoaded
+                    ? "No image models found — install one from the model list."
+                    : nil
+            )
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .accessibilityIdentifier("Images.EmptyState")
+        } else {
+            ScrollView {
+                LazyVGrid(
+                    columns: [GridItem(.adaptive(minimum: 220), spacing: 16)],
+                    spacing: 16
+                ) {
+                    ForEach(viewModel.results) { image in
+                        resultCard(image)
+                    }
+                }
+                .padding(16)
+            }
+            .accessibilityIdentifier("Images.Gallery")
+        }
+    }
+
+    private func resultCard(_ image: GeneratedImage) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            if let nsImage = NSImage(data: image.pngData) {
+                Image(nsImage: nsImage)
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(maxWidth: .infinity)
+                    .clipShape(RoundedRectangle(cornerRadius: 10))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 10)
+                            .stroke(RapidTheme.hairline, lineWidth: 1)
+                    )
+            }
+            Text(image.prompt)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(2)
+            HStack(spacing: 8) {
+                Button("Edit") { viewModel.beginEdit(image) }
+                    .buttonStyle(.rapidSecondary)
+                    .accessibilityIdentifier("Images.Result.Edit")
+                Button("Save") { save(image) }
+                    .buttonStyle(.rapidSecondary)
+                    .accessibilityIdentifier("Images.Result.Save")
+                Spacer()
+                if image.isEdit {
+                    Text("edited")
+                        .font(.caption2)
+                        .foregroundStyle(RapidTheme.brandAmber)
+                }
+            }
+        }
+        .padding(10)
+        .background(RapidTheme.card)
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+
+    // MARK: - Compose bar
+
+    private var composeBar: some View {
+        VStack(spacing: 8) {
+            if viewModel.editSource != nil {
+                editingBanner
+            }
+            if let error = viewModel.errorMessage {
+                InlineNotice(message: error, tone: .error)
+            }
+            HStack(spacing: 12) {
+                modelPicker
+                sizePicker
+                Spacer()
+            }
+            HStack(spacing: 10) {
+                TextField(
+                    viewModel.editSource != nil
+                        ? "Describe the change…"
+                        : "Describe the image…",
+                    text: $viewModel.prompt,
+                    axis: .vertical
+                )
+                .textFieldStyle(.plain)
+                .lineLimit(1...4)
+                .padding(10)
+                .background(RapidTheme.composePill)
+                .clipShape(RoundedRectangle(cornerRadius: 10))
+                .accessibilityIdentifier("Images.Prompt")
+                .onSubmit { runSubmit() }
+
+                Button(action: runSubmit) {
+                    if viewModel.isGenerating {
+                        ProgressView().controlSize(.small)
+                    } else {
+                        Text(viewModel.editSource != nil ? "Edit" : "Generate")
+                    }
+                }
+                .buttonStyle(.rapidPrimary)
+                .disabled(!viewModel.canSubmit)
+                .accessibilityIdentifier("Images.Generate")
+            }
+        }
+        .padding(12)
+        .background(RapidTheme.surfaceSidebar)
+    }
+
+    private var editingBanner: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "wand.and.stars")
+                .foregroundStyle(RapidTheme.brandAmber)
+            Text("Editing an image")
+                .font(.callout)
+            Spacer()
+            Button("Cancel") { viewModel.cancelEdit() }
+                .buttonStyle(.rapidSecondary)
+                .accessibilityIdentifier("Images.CancelEdit")
+        }
+        .padding(.horizontal, 4)
+    }
+
+    private var modelPicker: some View {
+        Picker("Model", selection: $viewModel.selectedAlias) {
+            ForEach(viewModel.imageModels) { entry in
+                Text(entry.cached ? "\(entry.alias) ✓" : entry.alias)
+                    .tag(entry.alias)
+            }
+        }
+        .labelsHidden()
+        .frame(maxWidth: 260)
+        .accessibilityIdentifier("Images.ModelPicker")
+    }
+
+    private var sizePicker: some View {
+        Picker("Size", selection: $viewModel.size) {
+            ForEach(sizeOptions, id: \.self) { Text($0).tag($0) }
+        }
+        .labelsHidden()
+        .frame(maxWidth: 120)
+        .accessibilityIdentifier("Images.SizePicker")
+    }
+
+    // MARK: - Actions
+
+    private func runSubmit() {
+        guard viewModel.canSubmit else { return }
+        Task { await viewModel.submit() }
+    }
+
+    /// Write the PNG to a user-chosen location via the standard save panel.
+    private func save(_ image: GeneratedImage) {
+        let panel = NSSavePanel()
+        panel.allowedContentTypes = [.png]
+        panel.nameFieldStringValue = "rapid-image.png"
+        panel.canCreateDirectories = true
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+        try? image.pngData.write(to: url)
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/UI/ImagesView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ImagesView.swift
@@ -1,111 +1,26 @@
 import AppKit
 import SwiftUI
 
-/// The Images tab — a local text→image surface designed around three jobs:
-/// get a good image with the least friction, riff on it, and never feel stuck
-/// during a 10–40 s render. Layout: a Fast/Best quality bar, a big focal stage
-/// that shows the render's live step progress, a session filmstrip, and a
-/// prompt composer with one-tap starters.
+/// The Images tab. Deliberately mirrors ``ChatView``: a scrollable results
+/// area on top and, at the bottom, the *same* compose box — a `surfaceRaised`
+/// rounded field with the model picker + submit button clustered at its
+/// bottom-right — so model selection and input feel identical across tabs.
 struct ImagesView: View {
     @Bindable var viewModel: ImageGenViewModel
     @Bindable var server: ServerManager
 
+    private let contentMaxWidth: CGFloat = RapidTheme.Layout.contentMaxWidth
+
+    @State private var composeFocusToken = 0
+    @State private var pickerHovering = false
+
     var body: some View {
         VStack(spacing: 0) {
-            topBar
-            Divider()
             stageAndHistory
-            Divider()
             composer
         }
         .background(RapidTheme.surfaceCanvas)
         .task { await viewModel.refreshCatalog() }
-    }
-
-    // MARK: - Top bar (model picker + Save)
-
-    private var topBar: some View {
-        HStack(spacing: 10) {
-            Text("Model").font(.caption).foregroundStyle(.secondary)
-            modelPicker
-                .frame(minWidth: 220, maxWidth: 320)
-            Spacer()
-            if let active = viewModel.activeImage, !viewModel.isGenerating {
-                Button {
-                    save(active)
-                } label: {
-                    Label("Save", systemImage: "square.and.arrow.down")
-                }
-                .buttonStyle(.rapidSecondary)
-                .accessibilityIdentifier("Images.Result.Save")
-            }
-        }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 10)
-        .background(RapidTheme.surfaceSidebar)
-    }
-
-    /// A dropdown listing every image model — the same shape as the chat
-    /// picker (one Menu, a cache glyph per row) so it scales to any number of
-    /// models instead of the fixed Fast/Best boxes. Manage/download/delete
-    /// live in Settings → Model Management (Image tab).
-    private var modelPicker: some View {
-        Menu {
-            if viewModel.imageModels.isEmpty {
-                Text(viewModel.catalogLoaded ? "No image models available" : "Loading…")
-            } else {
-                ForEach(viewModel.imageModels) { entry in
-                    Button {
-                        viewModel.selectedAlias = entry.alias
-                    } label: {
-                        Label(
-                            modelRowTitle(entry),
-                            systemImage: ModelPickerBar.cacheGlyph(cached: entry.cached)
-                        )
-                    }
-                }
-            }
-        } label: {
-            HStack(spacing: 6) {
-                Image(systemName: "photo")
-                    .foregroundStyle(.secondary)
-                    .accessibilityHidden(true)
-                Text(viewModel.selectedAlias.isEmpty ? "Choose a model" : viewModel.selectedAlias)
-                    .lineLimit(1)
-                    .truncationMode(.middle)
-                    .foregroundStyle(viewModel.selectedAlias.isEmpty ? .secondary : .primary)
-                Spacer(minLength: 4)
-                Image(systemName: "chevron.up.chevron.down")
-                    .font(.system(size: 10, weight: .medium))
-                    .foregroundStyle(.secondary)
-                    .accessibilityHidden(true)
-            }
-            .padding(.horizontal, 10)
-            .frame(height: 30)
-            .background(
-                RoundedRectangle(cornerRadius: 8, style: .continuous)
-                    .fill(Color.secondary.opacity(0.06))
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: 8, style: .continuous)
-                    .stroke(RapidTheme.hairline, lineWidth: 1)
-            )
-            .contentShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
-        }
-        .menuStyle(.button)
-        .buttonStyle(.plain)
-        .menuIndicator(.hidden)
-        .accessibilityIdentifier("Images.ModelPicker")
-    }
-
-    /// "flux2-klein-4b · 4.3 GiB" — alias plus size when known. The green
-    /// check / download glyph (from ``ModelPickerBar.cacheGlyph``) carries
-    /// installed state, exactly as in the chat picker.
-    private func modelRowTitle(_ entry: ModelEntry) -> String {
-        if let size = entry.sizeOnDisk, !size.isEmpty {
-            return "\(entry.alias) · \(size)"
-        }
-        return entry.alias
     }
 
     // MARK: - Stage + history
@@ -133,17 +48,35 @@ struct ImagesView: View {
                     .overlay(
                         RoundedRectangle(cornerRadius: 14).stroke(RapidTheme.hairline, lineWidth: 1)
                     )
+                    .overlay(alignment: .topTrailing) { saveOverlay(active) }
                     .accessibilityIdentifier("Images.Stage")
             } else if !viewModel.isGenerating {
                 emptyStage
             }
 
             if viewModel.isGenerating {
-                progressHUD
-                    .transition(.opacity)
+                progressHUD.transition(.opacity)
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    @ViewBuilder
+    private func saveOverlay(_ image: GeneratedImage) -> some View {
+        if !viewModel.isGenerating {
+            Button {
+                save(image)
+            } label: {
+                Image(systemName: "square.and.arrow.down")
+                    .font(.system(size: 12, weight: .semibold))
+                    .frame(width: 28, height: 28)
+                    .background(.ultraThinMaterial, in: Circle())
+            }
+            .buttonStyle(.plain)
+            .padding(10)
+            .help("Save image")
+            .accessibilityIdentifier("Images.Result.Save")
+        }
     }
 
     private var emptyStage: some View {
@@ -166,13 +99,12 @@ struct ImagesView: View {
 
     private var noModelHint: String? {
         guard viewModel.catalogLoaded, viewModel.imageModels.isEmpty else { return nil }
-        return "No image models found — install one from the model list."
+        return "No image models found — install one from Settings → Model Management."
     }
 
     // MARK: - Progress HUD (the wait, designed)
 
     private var progressHUD: some View {
-        // A live clock that keeps moving even during the cold model-load phase.
         TimelineView(.periodic(from: .now, by: 0.1)) { context in
             let elapsed = viewModel.genStartedAt.map { context.date.timeIntervalSince($0) } ?? 0
             VStack {
@@ -221,8 +153,7 @@ struct ImagesView: View {
                 clock(elapsed)
                 cancelButton
             }
-            ProgressBar(fraction: fraction)
-                .frame(height: 6)
+            ProgressBar(fraction: fraction).frame(height: 6)
             if let eta = etaText(step: p.step, total: total, elapsed: elapsed) {
                 Text(eta).font(.caption).foregroundStyle(.secondary)
             }
@@ -251,12 +182,10 @@ struct ImagesView: View {
         .accessibilityIdentifier("Images.Cancel")
     }
 
-    /// ETA from uniform step time; nil until there's a step to extrapolate from.
     private func etaText(step: Int, total: Int, elapsed: TimeInterval) -> String? {
         guard step > 0, total > step, elapsed > 0 else { return nil }
         let perStep = elapsed / Double(step)
-        let remaining = perStep * Double(total - step)
-        return "~\(Int(remaining.rounded()))s left"
+        return "~\(Int((perStep * Double(total - step)).rounded()))s left"
     }
 
     // MARK: - Filmstrip
@@ -297,42 +226,60 @@ struct ImagesView: View {
         .buttonStyle(.plain)
     }
 
-    // MARK: - Composer
+    // MARK: - Composer (mirrors ChatView's compose box)
 
     private var composer: some View {
-        VStack(spacing: 10) {
+        VStack(spacing: RapidTheme.Space.sm) {
             if let error = viewModel.errorMessage {
                 InlineNotice(message: error, tone: .error)
+                    .frame(maxWidth: contentMaxWidth)
+                    .frame(maxWidth: .infinity)
             }
             if viewModel.prompt.isEmpty {
                 starters
+                    .frame(maxWidth: contentMaxWidth)
+                    .frame(maxWidth: .infinity)
             }
-            HStack(alignment: .bottom, spacing: 10) {
-                TextField("Describe the image you want…", text: $viewModel.prompt, axis: .vertical)
-                    .textFieldStyle(.plain)
-                    .lineLimit(1...4)
-                    .padding(10)
-                    .background(RapidTheme.composePill)
-                    .clipShape(RoundedRectangle(cornerRadius: 10))
-                    .accessibilityIdentifier("Images.Prompt")
-                    .onSubmit(runSubmit)
-
-                aspectPicker
-
-                Button(action: runSubmit) {
-                    if viewModel.isGenerating {
-                        ProgressView().controlSize(.small)
-                    } else {
-                        Text("Generate")
-                    }
-                }
-                .buttonStyle(.rapidPrimary)
-                .disabled(!viewModel.canSubmit)
-                .accessibilityIdentifier("Images.Generate")
+            VStack(spacing: RapidTheme.Space.sm - 2) {
+                ComposeField(
+                    text: $viewModel.prompt,
+                    focusToken: composeFocusToken,
+                    isStreaming: viewModel.isGenerating,
+                    placeholder: "Describe the image you want…",
+                    onSubmit: runSubmit,
+                    onCancel: { viewModel.cancel() }
+                )
+                .accessibilityIdentifier("Images.Prompt")
+                composerControls
             }
+            .padding(.horizontal, RapidTheme.Space.md - 2)
+            .padding(.vertical, RapidTheme.Space.sm)
+            .background(
+                RoundedRectangle(cornerRadius: RapidTheme.Radius.input, style: .continuous)
+                    .fill(RapidTheme.surfaceRaised)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: RapidTheme.Radius.input, style: .continuous)
+                    .strokeBorder(RapidTheme.hairlineStrong, lineWidth: 1)
+            )
+            .frame(maxWidth: contentMaxWidth)
+            .frame(maxWidth: .infinity)
         }
-        .padding(12)
-        .background(RapidTheme.surfaceSidebar)
+        .padding(.horizontal, RapidTheme.Space.xl)
+        .padding(.top, RapidTheme.Space.md)
+        .padding(.bottom, RapidTheme.Space.lg)
+    }
+
+    /// Bottom row of the compose box: aspect on the left, then the inline
+    /// model picker + submit clustered on the right — the same
+    /// `model ▾  ⬆` grouping ChatView uses.
+    private var composerControls: some View {
+        HStack(spacing: RapidTheme.Space.sm) {
+            aspectPicker
+            Spacer(minLength: 0)
+            modelPicker
+            sendOrStopButton
+        }
     }
 
     private var starters: some View {
@@ -367,19 +314,113 @@ struct ImagesView: View {
                 } label: {
                     Text(ar.label)
                         .font(.system(size: 11, weight: .medium))
-                        .padding(.horizontal, 9)
-                        .padding(.vertical, 7)
-                        .background(on ? RapidTheme.card : Color.clear)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 5)
+                        .background(on ? RapidTheme.hoverFill : Color.clear)
                         .foregroundStyle(on ? Color.primary : Color.secondary)
                         .clipShape(RoundedRectangle(cornerRadius: 6))
                 }
                 .buttonStyle(.plain)
             }
         }
-        .padding(3)
-        .background(RapidTheme.composePill)
-        .clipShape(RoundedRectangle(cornerRadius: 9))
         .accessibilityIdentifier("Images.Aspect")
+    }
+
+    /// The inline model picker — same composer-embedded chip as chat
+    /// (``ModelPickerBar`` in `composerStyle`): borderless, a fill on hover,
+    /// a cache glyph per row, scaling to any number of image models.
+    private var modelPicker: some View {
+        Menu {
+            if viewModel.imageModels.isEmpty {
+                Text(viewModel.catalogLoaded ? "No image models available" : "Loading…")
+            } else {
+                ForEach(viewModel.imageModels) { entry in
+                    Button {
+                        viewModel.selectedAlias = entry.alias
+                    } label: {
+                        Label(
+                            modelRowTitle(entry),
+                            systemImage: ModelPickerBar.cacheGlyph(cached: entry.cached)
+                        )
+                    }
+                }
+            }
+        } label: {
+            HStack(spacing: 6) {
+                Image(systemName: "photo")
+                    .foregroundStyle(.secondary)
+                    .accessibilityHidden(true)
+                Text(viewModel.selectedAlias.isEmpty ? "Choose a model" : viewModel.selectedAlias)
+                    .font(RapidFont.secondary)
+                    .foregroundStyle(viewModel.selectedAlias.isEmpty ? .secondary : .primary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                Image(systemName: "chevron.up.chevron.down")
+                    .font(.system(size: 10, weight: .medium))
+                    .foregroundStyle(pickerHovering ? .primary : .secondary)
+                    .accessibilityHidden(true)
+            }
+            .padding(.horizontal, RapidTheme.Space.sm)
+            .frame(height: RapidTheme.ControlHeight.small)
+            .background(
+                RoundedRectangle(cornerRadius: RapidTheme.Radius.row, style: .continuous)
+                    .fill(pickerHovering ? RapidTheme.hoverFill : .clear)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: RapidTheme.Radius.row, style: .continuous)
+                    .strokeBorder(pickerHovering ? RapidTheme.hairlineStrong : .clear, lineWidth: 1)
+            )
+            .contentShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+        }
+        .menuStyle(.button)
+        .buttonStyle(.plain)
+        .menuIndicator(.hidden)
+        .fixedSize()
+        .onHover { pickerHovering = $0 }
+        .help(viewModel.selectedAlias.isEmpty ? "Choose a model" : "Model: \(viewModel.selectedAlias)")
+        .accessibilityIdentifier("Images.ModelPicker")
+    }
+
+    private func modelRowTitle(_ entry: ModelEntry) -> String {
+        if let size = entry.sizeOnDisk, !size.isEmpty {
+            return "\(entry.alias) · \(size)"
+        }
+        return entry.alias
+    }
+
+    /// Submit / stop, styled exactly like ChatView's send button: an amber
+    /// disc when there's something to run, a stop disc while generating.
+    @ViewBuilder
+    private var sendOrStopButton: some View {
+        if viewModel.isGenerating {
+            Button { viewModel.cancel() } label: {
+                Image(systemName: "stop.fill")
+                    .font(.system(size: 12, weight: .bold))
+                    .foregroundStyle(RapidTheme.sendButtonIcon)
+                    .frame(width: 28, height: 28)
+                    .background(Circle().fill(RapidTheme.sendButton))
+            }
+            .buttonStyle(.plain)
+            .disabled(viewModel.cancelling)
+            .help("Cancel")
+            .accessibilityIdentifier("Images.Generate")
+        } else {
+            Button(action: runSubmit) {
+                Image(systemName: "arrow.up")
+                    .font(.system(size: 12, weight: .bold))
+                    .foregroundStyle(viewModel.canSubmit ? RapidTheme.onBrandPrimary : Color.secondary)
+                    .frame(width: 28, height: 28)
+                    .background(Circle().fill(viewModel.canSubmit ? RapidTheme.brandPrimary : Color.clear))
+                    .overlay(
+                        Circle().strokeBorder(
+                            viewModel.canSubmit ? .clear : RapidTheme.hairlineStrong, lineWidth: 1)
+                    )
+            }
+            .buttonStyle(.plain)
+            .disabled(!viewModel.canSubmit)
+            .help("Generate")
+            .accessibilityIdentifier("Images.Generate")
+        }
     }
 
     // MARK: - Actions
@@ -399,9 +440,8 @@ struct ImagesView: View {
     }
 }
 
-/// A determinate capsule progress bar with the brand fill. Kept tiny and
-/// local — the only progress bar in the app that shows a true diffusion
-/// step fraction.
+/// A determinate capsule progress bar with the brand fill — the only bar in
+/// the app that shows a true diffusion step fraction.
 private struct ProgressBar: View {
     let fraction: Double
 

--- a/apps/rapid-mac/Sources/Rapid/UI/ImagesView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ImagesView.swift
@@ -228,8 +228,12 @@ struct ImagesView: View {
                             .foregroundStyle(.secondary)
                             .monospacedDigit()
                         Spacer()
+                        // ETA from the denoise-phase clock, not total elapsed —
+                        // otherwise cold-load time inflates the per-step estimate.
+                        let denoiseElapsed = viewModel.denoiseStartedAt
+                            .map { context.date.timeIntervalSince($0) } ?? elapsed
                         Text(denoising
-                             ? (etaText(step: step, total: total, elapsed: elapsed) ?? "finishing…")
+                             ? (etaText(step: step, total: total, elapsed: denoiseElapsed) ?? "finishing…")
                              : "First run — only happens once")
                             .font(.system(size: 11))
                             .foregroundStyle(.secondary)

--- a/apps/rapid-mac/Sources/Rapid/UI/ImagesView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ImagesView.swift
@@ -165,81 +165,87 @@ struct ImagesView: View {
     // MARK: - Progress HUD (the wait, designed)
 
     private var progressHUD: some View {
-        TimelineView(.periodic(from: .now, by: 0.1)) { context in
+        TimelineView(.periodic(from: .now, by: 0.08)) { context in
             let elapsed = viewModel.genStartedAt.map { context.date.timeIntervalSince($0) } ?? 0
-            VStack {
-                Spacer()
-                VStack(alignment: .leading, spacing: 10) {
-                    if viewModel.phase == .denoising, let p = viewModel.progress {
-                        denoiseBody(p, elapsed: elapsed)
-                    } else {
-                        preparingBody(elapsed: elapsed)
+            // A 0→1 loop driving the shimmer sweep + status-dot pulse, derived
+            // from the frame's date so it animates without stored state.
+            let phase = (context.date.timeIntervalSinceReferenceDate
+                .truncatingRemainder(dividingBy: 1.6)) / 1.6
+            let denoising = viewModel.phase == .denoising && viewModel.progress != nil
+            let total = max(viewModel.progress?.total ?? 0, viewModel.estimatedSteps)
+            let step = max(1, viewModel.progress?.step ?? 0)
+            let fraction = (denoising && total > 0) ? min(1, Double(step) / Double(total)) : 0
+
+            ZStack {
+                // Soft scrim so the card reads cleanly over any prior image.
+                LinearGradient(colors: [.black.opacity(0.06), .black.opacity(0.34)],
+                               startPoint: .top, endPoint: .bottom)
+                    .allowsHitTesting(false)
+
+                VStack(spacing: 14) {
+                    HStack(spacing: 10) {
+                        if denoising {
+                            Circle()
+                                .fill(RapidTheme.brandAmber)
+                                .frame(width: 9, height: 9)
+                                .shadow(color: RapidTheme.brandAmber.opacity(0.9), radius: 5)
+                                .scaleEffect(0.65 + 0.35 * (0.5 + 0.5 * sin(phase * .pi * 2)))
+                            Text(viewModel.cancelling ? "Stopping…" : "Generating")
+                                .font(.system(size: 14, weight: .semibold))
+                        } else {
+                            ProgressView().controlSize(.small)
+                            Text(viewModel.cancelling
+                                 ? "Stopping…"
+                                 : "Warming up \(viewModel.selectedDisplayName)")
+                                .font(.system(size: 14, weight: .semibold))
+                                .lineLimit(1).truncationMode(.middle)
+                        }
+                        Spacer(minLength: 8)
+                        if denoising {
+                            Text("\(step) / \(total)")
+                                .font(.system(size: 12, weight: .semibold, design: .monospaced))
+                                .foregroundStyle(.secondary)
+                                .monospacedDigit()
+                        }
+                        Button { viewModel.cancel() } label: {
+                            Image(systemName: "xmark")
+                                .font(.system(size: 10, weight: .bold))
+                                .frame(width: 22, height: 22)
+                                .background(Color.primary.opacity(0.08), in: Circle())
+                        }
+                        .buttonStyle(.plain)
+                        .disabled(viewModel.cancelling)
+                        .help("Cancel")
+                        .accessibilityIdentifier("Images.Cancel")
+                    }
+
+                    ShimmerProgressBar(fraction: fraction, indeterminate: !denoising, phase: phase)
+                        .frame(height: 10)
+
+                    HStack {
+                        Text(String(format: "%.1fs", max(0, elapsed)))
+                            .font(.system(size: 11, weight: .medium, design: .monospaced))
+                            .foregroundStyle(.secondary)
+                            .monospacedDigit()
+                        Spacer()
+                        Text(denoising
+                             ? (etaText(step: step, total: total, elapsed: elapsed) ?? "finishing…")
+                             : "First run — only happens once")
+                            .font(.system(size: 11))
+                            .foregroundStyle(.secondary)
                     }
                 }
-                .padding(16)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .background(.ultraThinMaterial)
-                .clipShape(RoundedRectangle(cornerRadius: 14))
-            }
-            .padding(2)
-        }
-    }
-
-    private func preparingBody(elapsed: TimeInterval) -> some View {
-        HStack(spacing: 12) {
-            ProgressView().controlSize(.small)
-            VStack(alignment: .leading, spacing: 2) {
-                Text(viewModel.cancelling ? "Stopping…" : "Warming up \(viewModel.selectedDisplayName)…")
-                    .font(.system(size: 13, weight: .semibold))
-                Text("First run loads the model — this only happens once.")
-                    .font(.caption).foregroundStyle(.secondary)
-            }
-            Spacer()
-            clock(elapsed)
-            cancelButton
-        }
-    }
-
-    private func denoiseBody(_ p: ImageClient.ImageProgress, elapsed: TimeInterval) -> some View {
-        let total = max(p.total, viewModel.estimatedSteps)
-        let fraction = total > 0 ? min(1, Double(p.step) / Double(total)) : 0
-        return VStack(alignment: .leading, spacing: 9) {
-            HStack {
-                Text(viewModel.cancelling
-                     ? "Stopping…"
-                     : "Step \(max(1, p.step)) / \(total) · denoising")
-                    .font(.system(size: 13, weight: .semibold))
-                Spacer()
-                clock(elapsed)
-                cancelButton
-            }
-            ProgressBar(fraction: fraction).frame(height: 6)
-            if let eta = etaText(step: p.step, total: total, elapsed: elapsed) {
-                Text(eta).font(.caption).foregroundStyle(.secondary)
+                .padding(18)
+                .frame(width: 340)
+                .background(.ultraThinMaterial,
+                            in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 18, style: .continuous)
+                        .strokeBorder(.white.opacity(0.12), lineWidth: 1)
+                )
+                .shadow(color: .black.opacity(0.28), radius: 22, y: 10)
             }
         }
-    }
-
-    private func clock(_ elapsed: TimeInterval) -> some View {
-        Text(String(format: "%.1fs", max(0, elapsed)))
-            .font(.system(size: 12, weight: .semibold, design: .monospaced))
-            .foregroundStyle(.secondary)
-    }
-
-    private var cancelButton: some View {
-        Button {
-            viewModel.cancel()
-        } label: {
-            Image(systemName: "xmark")
-                .font(.system(size: 11, weight: .bold))
-                .frame(width: 22, height: 22)
-        }
-        .buttonStyle(.plain)
-        .background(Color.primary.opacity(0.08))
-        .clipShape(Circle())
-        .disabled(viewModel.cancelling)
-        .help("Cancel")
-        .accessibilityIdentifier("Images.Cancel")
     }
 
     private func etaText(step: Int, total: Int, elapsed: TimeInterval) -> String? {
@@ -515,19 +521,44 @@ struct ImagesView: View {
     }
 }
 
-/// A determinate capsule progress bar with the brand fill — the only bar in
-/// the app that shows a true diffusion step fraction.
-private struct ProgressBar: View {
-    let fraction: Double
+/// The diffusion progress bar: a rounded amber→gold gradient fill with a soft
+/// glow and a sheen that sweeps across it, over a faint track. Determinate
+/// (true step fraction) while denoising; a sliding segment while the model
+/// warms up. The only bar in the app that shows a real diffusion step count.
+private struct ShimmerProgressBar: View {
+    var fraction: Double
+    var indeterminate: Bool
+    var phase: Double  // 0→1, loops to drive the sheen
+
+    private var fillGradient: LinearGradient {
+        LinearGradient(
+            colors: [RapidTheme.brandAmber, Color(red: 1.0, green: 0.85, blue: 0.47)],
+            startPoint: .leading, endPoint: .trailing)
+    }
 
     var body: some View {
         GeometryReader { geo in
+            let w = geo.size.width
+            let fillW = indeterminate ? max(1, w * 0.34)
+                                      : max(10, w * min(1, max(0, fraction)))
+            let slideX = indeterminate ? (w + fillW) * phase - fillW : 0
             ZStack(alignment: .leading) {
-                Capsule().fill(Color.primary.opacity(0.15))
-                Capsule()
-                    .fill(RapidTheme.brandAmber)
-                    .frame(width: max(0, min(1, fraction)) * geo.size.width)
-                    .animation(.easeOut(duration: 0.3), value: fraction)
+                Capsule().fill(Color.primary.opacity(0.12))
+                ZStack(alignment: .leading) {
+                    Capsule().fill(fillGradient)
+                    // A narrow highlight sweeping the filled portion.
+                    Capsule()
+                        .fill(LinearGradient(
+                            colors: [.clear, .white.opacity(0.55), .clear],
+                            startPoint: .leading, endPoint: .trailing))
+                        .frame(width: 64)
+                        .offset(x: (fillW + 64) * phase - 64)
+                }
+                .frame(width: fillW)
+                .clipShape(Capsule())
+                .shadow(color: RapidTheme.brandAmber.opacity(0.55), radius: 6)
+                .offset(x: slideX)
+                .animation(indeterminate ? nil : .easeOut(duration: 0.3), value: fraction)
             }
         }
     }

--- a/apps/rapid-mac/Sources/Rapid/UI/ImagesView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ImagesView.swift
@@ -12,7 +12,7 @@ struct ImagesView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            qualityBar
+            topBar
             Divider()
             stageAndHistory
             Divider()
@@ -22,13 +22,13 @@ struct ImagesView: View {
         .task { await viewModel.refreshCatalog() }
     }
 
-    // MARK: - Quality bar
+    // MARK: - Top bar (model picker + Save)
 
-    private var qualityBar: some View {
-        HStack(spacing: 12) {
-            ForEach(ImageGenViewModel.Quality.allCases) { q in
-                qualityChip(q)
-            }
+    private var topBar: some View {
+        HStack(spacing: 10) {
+            Text("Model").font(.caption).foregroundStyle(.secondary)
+            modelPicker
+                .frame(minWidth: 220, maxWidth: 320)
             Spacer()
             if let active = viewModel.activeImage, !viewModel.isGenerating {
                 Button {
@@ -45,34 +45,67 @@ struct ImagesView: View {
         .background(RapidTheme.surfaceSidebar)
     }
 
-    private func qualityChip(_ q: ImageGenViewModel.Quality) -> some View {
-        let selected = viewModel.quality == q
-        return Button {
-            viewModel.setQuality(q)
-        } label: {
-            HStack(spacing: 8) {
-                Image(systemName: q.symbol)
-                    .font(.system(size: 12, weight: .semibold))
-                VStack(alignment: .leading, spacing: 1) {
-                    Text(q.title).font(.system(size: 13, weight: .semibold))
-                    Text("\(q.subtitle) · \(q.etaHint)")
-                        .font(.system(size: 10))
-                        .foregroundStyle(selected ? Color.black.opacity(0.65) : .secondary)
+    /// A dropdown listing every image model — the same shape as the chat
+    /// picker (one Menu, a cache glyph per row) so it scales to any number of
+    /// models instead of the fixed Fast/Best boxes. Manage/download/delete
+    /// live in Settings → Model Management (Image tab).
+    private var modelPicker: some View {
+        Menu {
+            if viewModel.imageModels.isEmpty {
+                Text(viewModel.catalogLoaded ? "No image models available" : "Loading…")
+            } else {
+                ForEach(viewModel.imageModels) { entry in
+                    Button {
+                        viewModel.selectedAlias = entry.alias
+                    } label: {
+                        Label(
+                            modelRowTitle(entry),
+                            systemImage: ModelPickerBar.cacheGlyph(cached: entry.cached)
+                        )
+                    }
                 }
             }
-            .padding(.horizontal, 12)
-            .padding(.vertical, 7)
-            .background(selected ? RapidTheme.brandAmber : RapidTheme.card)
-            .foregroundStyle(selected ? Color.black : Color.primary)
-            .clipShape(RoundedRectangle(cornerRadius: 10))
-            .overlay(
-                RoundedRectangle(cornerRadius: 10)
-                    .stroke(RapidTheme.hairline, lineWidth: selected ? 0 : 1)
+        } label: {
+            HStack(spacing: 6) {
+                Image(systemName: "photo")
+                    .foregroundStyle(.secondary)
+                    .accessibilityHidden(true)
+                Text(viewModel.selectedAlias.isEmpty ? "Choose a model" : viewModel.selectedAlias)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                    .foregroundStyle(viewModel.selectedAlias.isEmpty ? .secondary : .primary)
+                Spacer(minLength: 4)
+                Image(systemName: "chevron.up.chevron.down")
+                    .font(.system(size: 10, weight: .medium))
+                    .foregroundStyle(.secondary)
+                    .accessibilityHidden(true)
+            }
+            .padding(.horizontal, 10)
+            .frame(height: 30)
+            .background(
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .fill(Color.secondary.opacity(0.06))
             )
-            .opacity(viewModel.catalogLoaded && !viewModel.hasModel(for: q) ? 0.45 : 1)
+            .overlay(
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .stroke(RapidTheme.hairline, lineWidth: 1)
+            )
+            .contentShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
         }
+        .menuStyle(.button)
         .buttonStyle(.plain)
-        .accessibilityIdentifier("Images.Quality.\(q.title)")
+        .menuIndicator(.hidden)
+        .accessibilityIdentifier("Images.ModelPicker")
+    }
+
+    /// "flux2-klein-4b · 4.3 GiB" — alias plus size when known. The green
+    /// check / download glyph (from ``ModelPickerBar.cacheGlyph``) carries
+    /// installed state, exactly as in the chat picker.
+    private func modelRowTitle(_ entry: ModelEntry) -> String {
+        if let size = entry.sizeOnDisk, !size.isEmpty {
+            return "\(entry.alias) · \(size)"
+        }
+        return entry.alias
     }
 
     // MARK: - Stage + history
@@ -164,7 +197,7 @@ struct ImagesView: View {
         HStack(spacing: 12) {
             ProgressView().controlSize(.small)
             VStack(alignment: .leading, spacing: 2) {
-                Text(viewModel.cancelling ? "Stopping…" : "Warming up \(viewModel.quality.subtitle)…")
+                Text(viewModel.cancelling ? "Stopping…" : "Warming up \(viewModel.selectedDisplayName)…")
                     .font(.system(size: 13, weight: .semibold))
                 Text("First run loads the model — this only happens once.")
                     .font(.caption).foregroundStyle(.secondary)

--- a/apps/rapid-mac/Sources/Rapid/UI/ImagesView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ImagesView.swift
@@ -517,7 +517,12 @@ struct ImagesView: View {
         panel.nameFieldStringValue = "rapid-image.png"
         panel.canCreateDirectories = true
         guard panel.runModal() == .OK, let url = panel.url else { return }
-        try? image.pngData.write(to: url)
+        do {
+            try image.pngData.write(to: url)
+        } catch {
+            // Don't let a disk-full / permission failure look like a success.
+            viewModel.errorMessage = "Couldn't save the image: \(error.localizedDescription)"
+        }
     }
 }
 

--- a/apps/rapid-mac/Sources/Rapid/UI/ImagesView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ImagesView.swift
@@ -13,6 +13,9 @@ struct ImagesView: View {
 
     @State private var composeFocusToken = 0
     @State private var pickerHovering = false
+    /// Bumped when the user tries to submit while gated, so the readiness
+    /// banner flashes for attention (same signal ChatView uses).
+    @State private var blockedSendAttempts = 0
 
     var body: some View {
         VStack(spacing: 0) {
@@ -79,27 +82,75 @@ struct ImagesView: View {
         }
     }
 
+    /// The empty hero — the same shape as ChatView's, with the cheetah mark
+    /// and readiness-driven copy. Just "Draw anything" instead of "Ask
+    /// anything", and no Connect-tools / Speed actions.
     private var emptyStage: some View {
-        VStack(spacing: 12) {
-            Image(systemName: "photo.on.rectangle.angled")
-                .font(.system(size: 36, weight: .light))
-                .foregroundStyle(.tertiary)
-            Text("Type a thought below and press Generate.")
-                .font(.callout)
-                .foregroundStyle(.secondary)
-            Text(noModelHint ?? "Runs entirely on this Mac — private, offline, unlimited.")
-                .font(.caption)
-                .foregroundStyle(.tertiary)
-        }
-        .multilineTextAlignment(.center)
-        .padding(24)
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        EmptyState(
+            title: "Draw anything",
+            message: readiness.isReady
+                ? "Describe what you want to see, then press Generate."
+                : readiness.emptyStateSubtitle,
+            hint: readiness.isReady ? nil : readiness.emptyStateHint,
+            markDiameter: 92,
+            mark: { CheetahLogo(size: 68) },
+            actions: { EmptyView() }
+        )
         .accessibilityIdentifier("Images.EmptyState")
     }
 
-    private var noModelHint: String? {
-        guard viewModel.catalogLoaded, viewModel.imageModels.isEmpty else { return nil }
-        return "No image models found — install one from Settings → Model Management."
+    // MARK: - Readiness (mirrors ChatView: same "load the model first" flow)
+
+    /// Readiness for the selected image model. Because rapid serves one model
+    /// per process, this reports "isn't running" whenever the server is
+    /// serving something else (e.g. a chat model) — exactly the "load FLUX
+    /// first" guidance chat gives, produced by the same resolver.
+    private var readiness: ModelReadiness {
+        ModelReadiness.resolve(
+            serverState: server.state,
+            alias: viewModel.selectedAlias,
+            cacheState: imageCacheState,
+            sizeText: viewModel.imageModels
+                .first { $0.alias == viewModel.selectedAlias }?.sizeOnDisk,
+            progress: startupProgress,
+            failure: nil
+        )
+    }
+
+    private var imageCacheState: ModelReadiness.CacheState {
+        guard !viewModel.selectedAlias.isEmpty, viewModel.catalogLoaded else {
+            return .catalogPending
+        }
+        guard let entry = viewModel.imageModels
+            .first(where: { $0.alias == viewModel.selectedAlias }) else {
+            return .notInCatalog
+        }
+        return entry.cached ? .onDisk : .notOnDisk
+    }
+
+    private var startupProgress: ModelReadiness.ProgressSnapshot? {
+        guard case .starting = server.state else { return nil }
+        return ModelReadiness.ProgressSnapshot(
+            activity: server.downloadProgress.startupActivity,
+            subtitle: server.downloadProgress.progressSubtitle,
+            fraction: server.downloadProgress.progressFraction
+        )
+    }
+
+    /// The banner's next-step action: start (or download-and-start) the
+    /// selected image model, switching the single server process to it.
+    private func handleReadinessAction(_ action: ModelReadiness.Action) {
+        switch action {
+        case .chooseModel:
+            break  // the composer's model picker owns this step
+        case .downloadAndStart(let target), .start(let target), .retry(let target):
+            let hf = viewModel.imageModels.first { $0.alias == target }?.hfRepo
+            Task { await server.start(alias: target, hfPath: hf) }
+        }
+    }
+
+    private var sendEnabled: Bool {
+        viewModel.canSubmit && readiness.sendAllowed
     }
 
     // MARK: - Progress HUD (the wait, designed)
@@ -230,7 +281,15 @@ struct ImagesView: View {
 
     private var composer: some View {
         VStack(spacing: RapidTheme.Space.sm) {
-            if let error = viewModel.errorMessage {
+            if !readiness.isReady {
+                ReadinessBanner(
+                    readiness: readiness,
+                    attentionToken: blockedSendAttempts,
+                    onAction: handleReadinessAction
+                )
+                .frame(maxWidth: contentMaxWidth)
+                .frame(maxWidth: .infinity)
+            } else if let error = viewModel.errorMessage {
                 InlineNotice(message: error, tone: .error)
                     .frame(maxWidth: contentMaxWidth)
                     .frame(maxWidth: .infinity)
@@ -245,7 +304,9 @@ struct ImagesView: View {
                     text: $viewModel.prompt,
                     focusToken: composeFocusToken,
                     isStreaming: viewModel.isGenerating,
-                    placeholder: "Describe the image you want…",
+                    placeholder: readiness.isReady
+                        ? "Describe the image you want…"
+                        : readiness.composerPlaceholder,
                     onSubmit: runSubmit,
                     onCancel: { viewModel.cancel() }
                 )
@@ -408,17 +469,17 @@ struct ImagesView: View {
             Button(action: runSubmit) {
                 Image(systemName: "arrow.up")
                     .font(.system(size: 12, weight: .bold))
-                    .foregroundStyle(viewModel.canSubmit ? RapidTheme.onBrandPrimary : Color.secondary)
+                    .foregroundStyle(sendEnabled ? RapidTheme.onBrandPrimary : Color.secondary)
                     .frame(width: 28, height: 28)
-                    .background(Circle().fill(viewModel.canSubmit ? RapidTheme.brandPrimary : Color.clear))
+                    .background(Circle().fill(sendEnabled ? RapidTheme.brandPrimary : Color.clear))
                     .overlay(
                         Circle().strokeBorder(
-                            viewModel.canSubmit ? .clear : RapidTheme.hairlineStrong, lineWidth: 1)
+                            sendEnabled ? .clear : RapidTheme.hairlineStrong, lineWidth: 1)
                     )
             }
             .buttonStyle(.plain)
-            .disabled(!viewModel.canSubmit)
-            .help("Generate")
+            .disabled(!sendEnabled)
+            .help(readiness.isReady ? "Generate" : "Load the model first")
             .accessibilityIdentifier("Images.Generate")
         }
     }
@@ -426,7 +487,12 @@ struct ImagesView: View {
     // MARK: - Actions
 
     private func runSubmit() {
-        guard viewModel.canSubmit else { return }
+        guard sendEnabled else {
+            // Not ready (or empty prompt): flash the readiness banner instead
+            // of silently doing nothing, so the blocking step is visible.
+            if !readiness.sendAllowed { blockedSendAttempts += 1 }
+            return
+        }
         Task { await viewModel.submit() }
     }
 

--- a/apps/rapid-mac/Sources/Rapid/UI/ImagesView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ImagesView.swift
@@ -33,7 +33,11 @@ struct ImagesView: View {
             stage
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
             if !viewModel.results.isEmpty {
+                // Centered on the same column as the composer so the strip
+                // reads as part of the layout rather than floating far-left.
                 filmstrip
+                    .frame(maxWidth: contentMaxWidth)
+                    .frame(maxWidth: .infinity)
             }
         }
         .padding(16)
@@ -145,7 +149,12 @@ struct ImagesView: View {
             break  // the composer's model picker owns this step
         case .downloadAndStart(let target), .start(let target), .retry(let target):
             let hf = viewModel.imageModels.first { $0.alias == target }?.hfRepo
-            Task { await server.start(alias: target, hfPath: hf) }
+            // ``ensureServing`` (not ``start``): the user is almost always
+            // switching FROM a running chat model TO the image model. Plain
+            // ``start`` is cold-start only — it no-ops when a child is already
+            // serving — so it would silently do nothing here; ``ensureServing``
+            // stops the current model and brings the target up.
+            Task { _ = await server.ensureServing(alias: target, hfPath: hf) }
         }
     }
 

--- a/apps/rapid-mac/Sources/Rapid/UI/SettingsModelManagementPanel.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SettingsModelManagementPanel.swift
@@ -46,6 +46,9 @@ struct SettingsModelManagementPanel: View {
     @State private var lastFreed: String?
 
     @State private var query: String = ""
+    /// Which capability tab is showing (Chat vs Image vs future Video). Model
+    /// Management manages every kind, but never mixes them in one list.
+    @State private var capability: ModelKind = .chat
     @State private var filterMode: ModelCacheActions.FilterMode = .all
     @State private var sortOrder: ModelCacheActions.SortOrder = .familyThenSize
 
@@ -117,9 +120,12 @@ struct SettingsModelManagementPanel: View {
             header
             modelsFolderSection
             preferencesSection
-            controlsRow
-            if showRecommendedSection {
-                recommendedSection
+            capabilityTabs
+            if capability == .chat {
+                controlsRow
+                if showRecommendedSection {
+                    recommendedSection
+                }
             }
             if loading && catalog.isEmpty {
                 loadingState
@@ -387,6 +393,23 @@ struct SettingsModelManagementPanel: View {
         Task { await refreshCatalog() }
     }
 
+    /// Capability tabs — Chat / Image (/ Video, once it has aliases). Only
+    /// shown when there's more than one kind installed, so a chat-only setup
+    /// looks exactly as it did before image models existed.
+    @ViewBuilder
+    private var capabilityTabs: some View {
+        if availableKinds.count > 1 {
+            Picker("Model type", selection: $capability) {
+                ForEach(availableKinds) { kind in
+                    Text("\(kind.tabLabel) models").tag(kind)
+                }
+            }
+            .pickerStyle(.segmented)
+            .labelsHidden()
+            .accessibilityIdentifier("Settings.ModelManagement.CapabilityTabs")
+        }
+    }
+
     @ViewBuilder
     private var controlsRow: some View {
         VStack(spacing: 10) {
@@ -631,23 +654,25 @@ struct SettingsModelManagementPanel: View {
         // the number in the heading and the rows under it can never
         // describe different sets.
         let entries = visibleEntries
+        let kindEntries = catalog.filter { $0.kind == capability }
         let heading = ModelCacheActions.listHeading(
             filter: filterMode,
             query: query,
             visibleCount: entries.count,
-            totalCount: catalog.count
+            totalCount: kindEntries.count
         )
         VStack(alignment: .leading, spacing: 9) {
             ModelsTableHeading(heading: heading)
-            // The meter legend belongs HERE — these are the only rows that
-            // render the Quality · Speed bars. The recommendation cards
-            // above show the curated capability / speed stats instead, so a
-            // top-of-panel legend misattributed them.
-            meterLegend
-            columnHeader
+            // The meter legend + Quality·Speed column belong to CHAT rows only
+            // — image models have no tok/s benchmark, so their tab shows a
+            // leaner row (name · repo · size · download).
+            if capability == .chat {
+                meterLegend
+                columnHeader
+            }
             listSection(entries)
             if let footer = ModelCacheActions.diskUsageFooter(
-                ModelCacheActions.aggregateOnDiskBytes(catalog)
+                ModelCacheActions.aggregateOnDiskBytes(kindEntries)
             ) {
                 Text(footer)
                     .font(.caption)
@@ -924,9 +949,16 @@ struct SettingsModelManagementPanel: View {
     // MARK: - List
 
     private var visibleEntries: [ModelEntry] {
-        let filtered = ModelCacheActions.filter(catalog, by: filterMode, query: query)
+        let byCapability = catalog.filter { $0.kind == capability }
+        let filtered = ModelCacheActions.filter(byCapability, by: filterMode, query: query)
         let sorted = ModelCacheActions.sorted(filtered, order: sortOrder)
         return ModelFavorites.favoritesFirst(sorted, favorites: favorites)
+    }
+
+    /// Kinds that actually have models to manage — the tab bar only offers
+    /// these (Video stays hidden until the video lane surfaces aliases).
+    private var availableKinds: [ModelKind] {
+        ModelKind.allCases.filter { kind in catalog.contains { $0.kind == kind } }
     }
 
     @ViewBuilder
@@ -939,7 +971,11 @@ struct SettingsModelManagementPanel: View {
         } else {
             VStack(alignment: .leading, spacing: 0) {
                 ForEach(Array(entries.enumerated()), id: \.element.alias) { idx, entry in
-                    row(for: entry)
+                    if entry.kind == .image {
+                        imageRow(for: entry)
+                    } else {
+                        row(for: entry)
+                    }
                     if idx < entries.count - 1 {
                         Divider().opacity(0.5)
                     }
@@ -999,6 +1035,40 @@ struct SettingsModelManagementPanel: View {
             .frame(maxWidth: .infinity, alignment: .leading)
             metersView(alias: entry.alias)
                 .frame(width: 158)
+            sizeAction(entry: entry, badge: badge)
+                .frame(width: ModelTableLayout.sizeColumnWidth, alignment: .trailing)
+        }
+        .padding(.vertical, 8)
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("Settings.ModelManagement.Row.\(entry.alias)")
+    }
+
+    /// A leaner row for image models: no tok/s meters (a diffusion model has
+    /// no token throughput), just name · repo · size and the same
+    /// download/delete control the chat rows use.
+    @ViewBuilder
+    private func imageRow(for entry: ModelEntry) -> some View {
+        let badge = ModelCacheActions.statusBadge(
+            for: entry,
+            downloadJob: downloads.jobs[entry.alias],
+            servingAlias: server.servingAlias
+        )
+        HStack(spacing: 10) {
+            BrandIcon(alias: entry.alias)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(entry.alias)
+                    .font(.body.weight(.medium))
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                if let repo = entry.hfRepo {
+                    Text(repo)
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
             sizeAction(entry: entry, badge: badge)
                 .frame(width: ModelTableLayout.sizeColumnWidth, alignment: .trailing)
         }
@@ -1252,15 +1322,20 @@ struct SettingsModelManagementPanel: View {
         if let hit = await ModelCatalogCache.shared.cached(
             binary: binary, generation: generation
         ) {
-            catalog = hit
+            catalog = hit + (await ModelCatalog.imageEntries(binary: binary))
             loading = false
             return
         }
         loading = true
         defer { loading = false }
-        catalog = await ModelCatalogCache.shared.entries(
+        // Chat catalog + image-gen aliases, managed side by side. The image
+        // rows carry ``kind == .image`` so the capability tabs keep them out of
+        // the chat list (and vice-versa).
+        let chat = await ModelCatalogCache.shared.entries(
             binary: binary, generation: generation
         )
+        let image = await ModelCatalog.imageEntries(binary: binary)
+        catalog = chat + image
     }
 
     private func deleteAlias(_ entry: ModelEntry) async {

--- a/apps/rapid-mac/Sources/Rapid/UI/SettingsModelManagementPanel.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SettingsModelManagementPanel.swift
@@ -1323,6 +1323,7 @@ struct SettingsModelManagementPanel: View {
             binary: binary, generation: generation
         ) {
             catalog = hit + (await ModelCatalog.imageEntries(binary: binary))
+            reconcileCapability()
             loading = false
             return
         }
@@ -1336,6 +1337,19 @@ struct SettingsModelManagementPanel: View {
         )
         let image = await ModelCatalog.imageEntries(binary: binary)
         catalog = chat + image
+        reconcileCapability()
+    }
+
+    /// Keep the selected capability tab valid after the catalog changes.
+    /// Deleting the last image model while the Image tab is active (the tab bar
+    /// then collapses because only one kind remains) would otherwise strand the
+    /// panel on an empty, un-switchable ``.image`` view even though chat models
+    /// exist — so fall back to an available kind.
+    private func reconcileCapability() {
+        let kinds = availableKinds
+        if !kinds.isEmpty, !kinds.contains(capability) {
+            capability = kinds.first ?? .chat
+        }
     }
 
     private func deleteAlias(_ entry: ModelEntry) async {

--- a/apps/rapid-mac/Sources/Rapid/UI/SidebarView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SidebarView.swift
@@ -5,6 +5,7 @@ import SwiftUI
 /// ("Older" list) is a later milestone.
 enum SidebarSection: Hashable {
     case chat
+    case images
     case launch
 }
 
@@ -103,6 +104,13 @@ struct SidebarView: View {
                 action: onNewChat
             )
             .accessibilityIdentifier("Sidebar.NewChat")
+            row(
+                title: "Images",
+                systemImage: "photo",
+                isSelected: selection == .images,
+                action: { selection = .images }
+            )
+            .accessibilityIdentifier("Sidebar.Images")
             row(
                 title: "Launch",
                 systemImage: "paperplane",

--- a/apps/rapid-mac/Tests/RapidTests/ImageCatalogTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ImageCatalogTests.swift
@@ -27,8 +27,8 @@ struct ImageCatalogTests {
       ────────────────────────────
       Alias                 Size       Kind        HF id
       ────────────────────────────
-      flux-schnell-4bit     8.9 GiB    [image:gen] dhairyashil/FLUX.1-schnell-mflux-4bit
-      qwen-image-edit-4bit  25.4 GiB   [image:gen] OsaurusAI/Qwen-Image-Edit-mflux-q4
+      flux2-klein-4b        4.3 GiB    [image:gen] Runpod/FLUX.2-klein-4B-mflux-4bit
+      z-image-turbo         5.5 GiB    [image:gen] filipstrand/Z-Image-Turbo-mflux-4bit
     """
 
     @Test("parseImageRows extracts only the [image:gen] rows")
@@ -37,22 +37,22 @@ struct ImageCatalogTests {
         #expect(rows.count == 2)
 
         let aliases = rows.map(\.alias)
-        #expect(aliases.contains("flux-schnell-4bit"))
-        #expect(aliases.contains("qwen-image-edit-4bit"))
+        #expect(aliases.contains("flux2-klein-4b"))
+        #expect(aliases.contains("z-image-turbo"))
         // No chat / video alias leaks in.
         #expect(!aliases.contains("qwen3.6-27b-4bit"))
         #expect(!aliases.contains("ltx-2.3-mlx-q4"))
 
-        let flux = rows.first { $0.alias == "flux-schnell-4bit" }
-        #expect(flux?.hfRepo == "dhairyashil/FLUX.1-schnell-mflux-4bit")
-        #expect(flux?.size == "8.9 GiB")
+        let klein = rows.first { $0.alias == "flux2-klein-4b" }
+        #expect(klein?.hfRepo == "Runpod/FLUX.2-klein-4B-mflux-4bit")
+        #expect(klein?.size == "4.3 GiB")
     }
 
     @Test("[image:gen] rows are excluded from the chat catalog")
     func imageRowsExcludedFromChat() {
         // hasNonChatKindTag now drops image alongside audio/video.
         #expect(ModelCatalog.hasNonChatKindTag(
-            "flux-schnell-4bit  8.9 GiB  [image:gen] dhairyashil/FLUX.1-schnell-mflux-4bit"))
+            "flux2-klein-4b  4.3 GiB  [image:gen] Runpod/FLUX.2-klein-4B-mflux-4bit"))
         #expect(ModelCatalog.hasNonChatKindTag(
             "ltx-2.3-mlx-q4  24.0 GiB  [video:gen] repo/ltx"))
         // A plain chat row is not dropped.
@@ -61,7 +61,7 @@ struct ImageCatalogTests {
 
         // The chat parser drops the image alias entirely.
         let excluded = ModelCatalog.parseExcludedAliases(Self.sample)
-        #expect(excluded.contains("flux-schnell-4bit"))
-        #expect(excluded.contains("qwen-image-edit-4bit"))
+        #expect(excluded.contains("flux2-klein-4b"))
+        #expect(excluded.contains("z-image-turbo"))
     }
 }

--- a/apps/rapid-mac/Tests/RapidTests/ImageCatalogTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ImageCatalogTests.swift
@@ -1,0 +1,67 @@
+import Foundation
+import Testing
+@testable import Rapid
+
+/// Coverage for the image-gen catalog split: `[image:gen]` rows must be
+/// parsed for the Images tab AND excluded from the chat catalog, so an image
+/// checkpoint can never surface in the chat picker (catalog-integrity, #1603).
+@Suite("Image catalog")
+struct ImageCatalogTests {
+    /// A faithful slice of `rapid-mlx models` output: a chat row, the video
+    /// section, and the image section the CLI now emits.
+    static let sample = """
+      Available models (2 aliases)
+      ────────────────────────────
+      Alias                 Size       Tools      HF id
+      ────────────────────────────
+      qwen3.6-27b-4bit      15.0 GiB   hermes     mlx-community/Qwen3.6-27B-4bit
+      bonsai-1.7b-2bit      0.9 GiB    —          prism-ml/Bonsai
+
+      Video models (1 aliases)
+      ────────────────────────────
+      Alias                 Size       Kind        HF id
+      ────────────────────────────
+      ltx-2.3-mlx-q4        24.0 GiB   [video:gen] notapalindrome/ltx23-mlx-av-q4
+
+      Image models (2 aliases)
+      ────────────────────────────
+      Alias                 Size       Kind        HF id
+      ────────────────────────────
+      flux-schnell-4bit     8.9 GiB    [image:gen] dhairyashil/FLUX.1-schnell-mflux-4bit
+      qwen-image-edit-4bit  15.8 GiB   [image:gen] ovedrive/Qwen-Image-Edit-2511-4bit
+    """
+
+    @Test("parseImageRows extracts only the [image:gen] rows")
+    func parsesImageRows() {
+        let rows = ModelCatalog.parseImageRows(Self.sample)
+        #expect(rows.count == 2)
+
+        let aliases = rows.map(\.alias)
+        #expect(aliases.contains("flux-schnell-4bit"))
+        #expect(aliases.contains("qwen-image-edit-4bit"))
+        // No chat / video alias leaks in.
+        #expect(!aliases.contains("qwen3.6-27b-4bit"))
+        #expect(!aliases.contains("ltx-2.3-mlx-q4"))
+
+        let flux = rows.first { $0.alias == "flux-schnell-4bit" }
+        #expect(flux?.hfRepo == "dhairyashil/FLUX.1-schnell-mflux-4bit")
+        #expect(flux?.size == "8.9 GiB")
+    }
+
+    @Test("[image:gen] rows are excluded from the chat catalog")
+    func imageRowsExcludedFromChat() {
+        // hasNonChatKindTag now drops image alongside audio/video.
+        #expect(ModelCatalog.hasNonChatKindTag(
+            "flux-schnell-4bit  8.9 GiB  [image:gen] dhairyashil/FLUX.1-schnell-mflux-4bit"))
+        #expect(ModelCatalog.hasNonChatKindTag(
+            "ltx-2.3-mlx-q4  24.0 GiB  [video:gen] repo/ltx"))
+        // A plain chat row is not dropped.
+        #expect(!ModelCatalog.hasNonChatKindTag(
+            "qwen3.6-27b-4bit  15.0 GiB  hermes  mlx-community/Qwen3.6-27B-4bit"))
+
+        // The chat parser drops the image alias entirely.
+        let excluded = ModelCatalog.parseExcludedAliases(Self.sample)
+        #expect(excluded.contains("flux-schnell-4bit"))
+        #expect(excluded.contains("qwen-image-edit-4bit"))
+    }
+}

--- a/apps/rapid-mac/Tests/RapidTests/ImageCatalogTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ImageCatalogTests.swift
@@ -28,7 +28,7 @@ struct ImageCatalogTests {
       Alias                 Size       Kind        HF id
       ────────────────────────────
       flux-schnell-4bit     8.9 GiB    [image:gen] dhairyashil/FLUX.1-schnell-mflux-4bit
-      qwen-image-edit-4bit  15.8 GiB   [image:gen] ovedrive/Qwen-Image-Edit-2511-4bit
+      qwen-image-edit-4bit  25.4 GiB   [image:gen] OsaurusAI/Qwen-Image-Edit-mflux-q4
     """
 
     @Test("parseImageRows extracts only the [image:gen] rows")

--- a/apps/rapid-mac/docs/gui-golden-flows.md
+++ b/apps/rapid-mac/docs/gui-golden-flows.md
@@ -197,31 +197,36 @@ seconds, refine by re-prompting. `image-generation` walks that through AX
 identifiers, no real diffusion weights required (the fake sidecar answers
 `/v1/images/*` with a 1×1 PNG). Demonstrated live with real weights below.
 
-1. open the Images tab via `Sidebar.Images`; assert `Images.EmptyState` is
-   present (no results yet) and its copy invites a prompt + model;
-2. pick an image model in `Images.ModelPicker` (the list is the `[image:gen]`
-   rows from `rapid-mlx models`, never a chat alias — see `catalog-integrity`);
-   optionally set `Images.SizePicker`;
-3. **Generate.** Type into `Images.Prompt`, press `Images.Generate`; assert the
-   button shows the in-flight state while the request is open, then that a
-   result card appears under `Images.Gallery` (and `Images.EmptyState` is gone);
-4. **Refine by re-prompting.** Adjust the prompt and press `Images.Generate`
-   again; each render lands as its own card under `Images.Gallery`, so the user
-   iterates a look by editing words rather than waiting on a slow image-edit.
-5. `Images.Result.Save` opens the standard save panel on any card (not asserted
-   through the panel itself — a modal `NSSavePanel` is out of AX scope, like
-   every other file-picker in the app).
+1. open the Images tab via `Sidebar.Images`; assert the `Images.EmptyState`
+   hero (the cheetah mark + "Draw anything") is present;
+2. the composer's `Images.ModelPicker` lists the `[image:gen]` rows from
+   `rapid-mlx models`, never a chat alias (see `catalog-integrity`); set the
+   aspect ratio with `Images.Aspect` (1:1 / 3:4 / 4:3);
+3. **Load the model.** rapid-mlx serves one model per process, so when the
+   server is on a different (e.g. chat) model the tab shows a readiness banner
+   ("<model> isn't running"); press `Readiness.Action` to switch the server to
+   the image model. `Images.Generate` stays disabled until it is ready — the
+   same `ModelReadiness` gate chat uses;
+4. **Generate.** Type into `Images.Prompt`, press `Images.Generate`; assert the
+   in-flight progress card appears (a true `step / total` bar, elapsed, ETA, and
+   an `Images.Cancel` control), then a result appears in `Images.Stage` with a
+   thumbnail under `Images.Gallery` (and `Images.EmptyState` is gone);
+5. **Refine by re-prompting.** Adjust the prompt and press `Images.Generate`
+   again; each render lands as its own thumbnail in the `Images.Gallery`
+   filmstrip, clickable to revisit its prompt;
+6. `Images.Result.Save` (a hover control on the focal image) opens the standard
+   save panel — not asserted through the modal `NSSavePanel`, out of AX scope
+   like every other file-picker in the app.
 
-### Instruction edit — parked (slow, batch-only)
+### Instruction edit — endpoint-only, parked
 
-The tab also ships an instruction-**edit** path (`Images.Result.Edit` on a card
-re-stages its output as the next `image_paths`, driving `/v1/images/edits`). It
-is **correct but deliberately not the interactive flow**: on current Apple
-Silicon a q4 Qwen-Image-Edit render is ~20 min (see realities below), so it reads
-as a batch action, not a conversation. The endpoint, `ImageGenViewModel.runEdit`
-/ `beginEdit`, and their hermetic tests stay in the tree for when a distilled
-edit model or faster hardware makes it interactive; until then the product story
-is generation.
+The `/v1/images/edits` endpoint and `ImageGenViewModel.runEdit` / `beginEdit`
+exist and are hermetically tested, but the current Images tab wires **no UI
+control** to them — there is no in-app edit action. The path is parked because
+on current Apple Silicon a q4 Qwen-Image-Edit render is ~20 min (see realities
+below): a batch action, not a conversation. It stays in the tree, reachable only
+via the HTTP API, for when a distilled edit model or faster hardware makes it
+interactive; until then the product story is generation.
 
 ### Model realities the UX has to design around
 
@@ -246,12 +251,12 @@ Verified on an M2 Pro 32 GB with the 4-bit mflux checkpoints:
   `-q8`), which costs proportionally more RAM/disk. Raising `steps` past ~20 on
   q4 only burns wall-clock.
 
-The **model-vs-endpoint contract** is the load-bearing invariant here and is
-covered by pure Swift coverage rather than a live flow: a text-to-image alias
-must drive `/v1/images/generations` and an `*-image-edit` alias
-`/v1/images/edits`; the server answers the wrong pairing with a 409 rather than
-a silent wrong result (`ImageGenViewModel.selectedIsEditModel` gates which one
-the compose bar offers, and the routes enforce it server-side).
+The **model-vs-endpoint contract** is enforced server-side and covered by
+hermetic tests rather than a live flow: a text-to-image server answers
+`/v1/images/edits` with a 409, and an edit server answers
+`/v1/images/generations` with a 409, so a mis-routed request fails loud instead
+of returning a silent wrong result. The Images tab itself only drives
+`/v1/images/generations`.
 
 > Status: the AX identifiers and states above are **defined and shipped** in
 > product code; the runnable `gui-golden-flows.sh --flow image-generation`

--- a/apps/rapid-mac/docs/gui-golden-flows.md
+++ b/apps/rapid-mac/docs/gui-golden-flows.md
@@ -187,7 +187,7 @@ to load an unnecessary second 8B copy.
 
 The Images tab is a dedicated text→image / image-edit surface, reached from
 `Sidebar.Images`. It is decoupled from chat on purpose: rapid-mlx serves **one
-model per process**, so an image-gen alias (e.g. `flux-schnell-4bit`) cannot be
+model per process**, so an image-gen alias (e.g. `flux2-klein-4b`) cannot be
 loaded alongside the chat LLM — selecting one reloads the sidecar, exactly the
 stop/start path a chat model-switch already takes.
 
@@ -232,10 +232,11 @@ interactive; until then the product story is generation.
 
 Verified on an M2 Pro 32 GB with the 4-bit mflux checkpoints:
 
-* **Generate is fast, edit is not.** `flux-schnell-4bit` is step-distilled — a
-  512² image lands in ~27 s at 4 steps. `qwen-image-edit-4bit` is a large,
-  non-distilled 20B model and mflux fixes the edit canvas to a ~1024²-area
-  render, so each denoise step is ~1 min and a default 20-step edit is
+* **Generate is fast, edit is not.** The exposed generators are step-distilled
+  (`flux2-klein-4b` lands a 512² image in ~3 s / a 1024² in ~10 s on an M3
+  Ultra). `qwen-image-edit-4bit` is a large, non-distilled 20B model and mflux
+  fixes the edit canvas to a ~1024²-area render, so each denoise step is ~1 min
+  and a default 20-step edit is
   **~20 minutes**. The edit round is a *batch* action on this hardware, not the
   sub-second turnaround ChatGPT has; the compose bar must show a clearly
   long-running, cancellable in-flight state and never imply instant results.

--- a/apps/rapid-mac/docs/gui-golden-flows.md
+++ b/apps/rapid-mac/docs/gui-golden-flows.md
@@ -202,6 +202,29 @@ The switch between a text-to-image model (round 0) and an image-edit model
 (rounds 1+) reloads the sidecar — one model per process — so the flow also
 exercises the stop/start path, exactly as a chat model-switch does.
 
+### Model realities the UX has to design around
+
+Verified on an M2 Pro 32 GB with the 4-bit mflux checkpoints:
+
+* **Generate is fast, edit is not.** `flux-schnell-4bit` is step-distilled — a
+  512² image lands in ~27 s at 4 steps. `qwen-image-edit-4bit` is a large,
+  non-distilled 20B model and mflux fixes the edit canvas to a ~1024²-area
+  render, so each denoise step is ~1 min and a default 20-step edit is
+  **~20 minutes**. The edit round is a *batch* action on this hardware, not the
+  sub-second turnaround ChatGPT has; the compose bar must show a clearly
+  long-running, cancellable in-flight state and never imply instant results.
+* **Do not send a `size` on edits.** mflux derives the edit output canvas from
+  the input image (its VAE conditioning latents are pinned to a 1024²-area
+  grid). Forcing a mismatched `width`/`height` desyncs the RoPE position ids and
+  the model returns a valid-looking PNG of **pure noise**. The engine passes
+  `None` for edit dimensions and the route accepts `size` only for OpenAI-API
+  shape, then discards it. Round 1+ therefore inherits the round-0 framing.
+* **Edit quality is checkpoint-bound, not step-bound.** The q4 edit checkpoint
+  carries a persistent VAE speckle (40 steps looks the same as 20); a clean
+  edit needs a higher-precision repo (`OsaurusAI/Qwen-Image-Edit-mflux-q6` /
+  `-q8`), which costs proportionally more RAM/disk. Raising `steps` past ~20 on
+  q4 only burns wall-clock.
+
 The **model-vs-endpoint contract** is the load-bearing invariant here and is
 covered by pure Swift coverage rather than a live flow: a text-to-image alias
 must drive `/v1/images/generations` and an `*-image-edit` alias

--- a/apps/rapid-mac/docs/gui-golden-flows.md
+++ b/apps/rapid-mac/docs/gui-golden-flows.md
@@ -21,6 +21,14 @@ covered, and each one names the defect it would have caught:
 7. `update-state` — Settings → App must name the version the app actually is.
 8. `no-dead-controls` — every Settings panel must expose controls of its own.
 9. `catalog-integrity` — a model that cannot chat must never be offered as one.
+   Now covers **image-gen** aliases too: `rapid-mlx models` tags them
+   `[image:gen]` in their own section (mirroring `[video:gen]`), and the
+   chat catalog's `hasNonChatKindTag` drops `image` alongside `audio`/`video`,
+   so a 24 GB FLUX/Qwen-Image checkpoint can never surface in the chat picker.
+
+10. `image-conversation` — the Images tab holds a multi-round image chat:
+    generate, then edit the result, then edit *that* result (see **Image
+    generation** below).
 
 The distinction matters. A journey answers *"can someone do this?"*; an
 invariant answers *"is this still true everywhere?"*. The three defects below
@@ -149,6 +157,62 @@ the original live-memory snapshot against the fallback footprint and exposes
 85% danger line. Under heavier pressure the button is absent, avoiding a false
 promise or a warning loop; **Cancel** still returns to the chooser where the
 low-memory category remains visible.
+
+## Image generation
+
+The Images tab is a dedicated text→image / image-edit surface, reached from
+`Sidebar.Images`. It is decoupled from chat on purpose: rapid-mlx serves **one
+model per process**, so an image-gen alias (e.g. `flux-schnell-4bit`) cannot be
+loaded alongside the chat LLM — selecting one reloads the sidecar, exactly the
+stop/start path a chat model-switch already takes.
+
+**The golden flow is the multi-round conversation, not a single generate.**
+The product this tab imitates is ChatGPT's image loop: make a picture, then
+*keep talking to it* — "put a hat on the dog", "now change the background",
+"make it night" — each turn editing the **previous turn's output**, not the
+original. `image-conversation` walks that N-round chain through AX identifiers,
+no real diffusion weights required (the fake sidecar answers `/v1/images/*`
+with a 1×1 PNG). Demonstrated live with real weights below.
+
+1. open the Images tab via `Sidebar.Images`; assert `Images.EmptyState` is
+   present (no results yet) and its copy invites a prompt + model;
+2. pick an image model in `Images.ModelPicker` (the list is the `[image:gen]`
+   rows from `rapid-mlx models`, never a chat alias — see `catalog-integrity`);
+   optionally set `Images.SizePicker`;
+3. **Round 0 — generate.** Type into `Images.Prompt`, press `Images.Generate`;
+   assert the button shows the in-flight state while the request is open, then
+   that a result card appears under `Images.Gallery` (and `Images.EmptyState`
+   is gone);
+4. **Round 1 — edit that result.** Press `Images.Result.Edit` on the card;
+   assert the compose bar enters edit mode (`Images.CancelEdit` present, the
+   button relabels to **Edit**). Type an instruction, press `Images.Generate`,
+   assert a second card appears tagged **edited**;
+5. **Round 2+ — keep editing the newest result.** Press `Images.Result.Edit`
+   on the *edited* card and run another instruction. This is the load-bearing
+   assertion: the edit source is the previous **output**, so each round
+   compounds on the last (`ImageGenViewModel.beginEdit` re-stages whichever
+   card the user points at, `runEdit` feeds its bytes back as the next
+   `image_paths`). The chain has no fixed length — the test asserts three
+   distinct cards, each derived from the one before.
+6. `Images.Result.Save` opens the standard save panel on any card (not
+   asserted through the panel itself — a modal `NSSavePanel` is out of AX
+   scope, like every other file-picker in the app).
+
+The switch between a text-to-image model (round 0) and an image-edit model
+(rounds 1+) reloads the sidecar — one model per process — so the flow also
+exercises the stop/start path, exactly as a chat model-switch does.
+
+The **model-vs-endpoint contract** is the load-bearing invariant here and is
+covered by pure Swift coverage rather than a live flow: a text-to-image alias
+must drive `/v1/images/generations` and an `*-image-edit` alias
+`/v1/images/edits`; the server answers the wrong pairing with a 409 rather than
+a silent wrong result (`ImageGenViewModel.selectedIsEditModel` gates which one
+the compose bar offers, and the routes enforce it server-side).
+
+> Status: the AX identifiers and states above are **defined and shipped** in
+> product code; the runnable `gui-golden-flows.sh --flow image-conversation`
+> journey and its structural baseline are the next increment (added the same way
+> every other flow was — identifiers first, then the scripted journey).
 
 ## Run
 

--- a/apps/rapid-mac/docs/gui-golden-flows.md
+++ b/apps/rapid-mac/docs/gui-golden-flows.md
@@ -26,9 +26,11 @@ covered, and each one names the defect it would have caught:
    chat catalog's `hasNonChatKindTag` drops `image` alongside `audio`/`video`,
    so a 24 GB FLUX/Qwen-Image checkpoint can never surface in the chat picker.
 
-10. `image-conversation` — the Images tab holds a multi-round image chat:
-    generate, then edit the result, then edit *that* result (see **Image
-    generation** below).
+10. `image-generation` — the Images tab turns a text prompt into a picture and
+    lets the user iterate by re-prompting (see **Image generation** below). The
+    instruction-**edit** path exists in code but is parked as a slow, batch-only
+    lane on current hardware (~20 min/edit at q4); the interactive golden flow is
+    text→image generation.
 
 The distinction matters. A journey answers *"can someone do this?"*; an
 invariant answers *"is this still true everywhere?"*. The three defects below
@@ -166,41 +168,37 @@ model per process**, so an image-gen alias (e.g. `flux-schnell-4bit`) cannot be
 loaded alongside the chat LLM — selecting one reloads the sidecar, exactly the
 stop/start path a chat model-switch already takes.
 
-**The golden flow is the multi-round conversation, not a single generate.**
-The product this tab imitates is ChatGPT's image loop: make a picture, then
-*keep talking to it* — "put a hat on the dog", "now change the background",
-"make it night" — each turn editing the **previous turn's output**, not the
-original. `image-conversation` walks that N-round chain through AX identifiers,
-no real diffusion weights required (the fake sidecar answers `/v1/images/*`
-with a 1×1 PNG). Demonstrated live with real weights below.
+**The interactive golden flow is text→image generation.** The tab imitates the
+fast half of ChatGPT's image experience: type a prompt, get a picture in
+seconds, refine by re-prompting. `image-generation` walks that through AX
+identifiers, no real diffusion weights required (the fake sidecar answers
+`/v1/images/*` with a 1×1 PNG). Demonstrated live with real weights below.
 
 1. open the Images tab via `Sidebar.Images`; assert `Images.EmptyState` is
    present (no results yet) and its copy invites a prompt + model;
 2. pick an image model in `Images.ModelPicker` (the list is the `[image:gen]`
    rows from `rapid-mlx models`, never a chat alias — see `catalog-integrity`);
    optionally set `Images.SizePicker`;
-3. **Round 0 — generate.** Type into `Images.Prompt`, press `Images.Generate`;
-   assert the button shows the in-flight state while the request is open, then
-   that a result card appears under `Images.Gallery` (and `Images.EmptyState`
-   is gone);
-4. **Round 1 — edit that result.** Press `Images.Result.Edit` on the card;
-   assert the compose bar enters edit mode (`Images.CancelEdit` present, the
-   button relabels to **Edit**). Type an instruction, press `Images.Generate`,
-   assert a second card appears tagged **edited**;
-5. **Round 2+ — keep editing the newest result.** Press `Images.Result.Edit`
-   on the *edited* card and run another instruction. This is the load-bearing
-   assertion: the edit source is the previous **output**, so each round
-   compounds on the last (`ImageGenViewModel.beginEdit` re-stages whichever
-   card the user points at, `runEdit` feeds its bytes back as the next
-   `image_paths`). The chain has no fixed length — the test asserts three
-   distinct cards, each derived from the one before.
-6. `Images.Result.Save` opens the standard save panel on any card (not
-   asserted through the panel itself — a modal `NSSavePanel` is out of AX
-   scope, like every other file-picker in the app).
+3. **Generate.** Type into `Images.Prompt`, press `Images.Generate`; assert the
+   button shows the in-flight state while the request is open, then that a
+   result card appears under `Images.Gallery` (and `Images.EmptyState` is gone);
+4. **Refine by re-prompting.** Adjust the prompt and press `Images.Generate`
+   again; each render lands as its own card under `Images.Gallery`, so the user
+   iterates a look by editing words rather than waiting on a slow image-edit.
+5. `Images.Result.Save` opens the standard save panel on any card (not asserted
+   through the panel itself — a modal `NSSavePanel` is out of AX scope, like
+   every other file-picker in the app).
 
-The switch between a text-to-image model (round 0) and an image-edit model
-(rounds 1+) reloads the sidecar — one model per process — so the flow also
-exercises the stop/start path, exactly as a chat model-switch does.
+### Instruction edit — parked (slow, batch-only)
+
+The tab also ships an instruction-**edit** path (`Images.Result.Edit` on a card
+re-stages its output as the next `image_paths`, driving `/v1/images/edits`). It
+is **correct but deliberately not the interactive flow**: on current Apple
+Silicon a q4 Qwen-Image-Edit render is ~20 min (see realities below), so it reads
+as a batch action, not a conversation. The endpoint, `ImageGenViewModel.runEdit`
+/ `beginEdit`, and their hermetic tests stay in the tree for when a distilled
+edit model or faster hardware makes it interactive; until then the product story
+is generation.
 
 ### Model realities the UX has to design around
 
@@ -233,7 +231,7 @@ a silent wrong result (`ImageGenViewModel.selectedIsEditModel` gates which one
 the compose bar offers, and the routes enforce it server-side).
 
 > Status: the AX identifiers and states above are **defined and shipped** in
-> product code; the runnable `gui-golden-flows.sh --flow image-conversation`
+> product code; the runnable `gui-golden-flows.sh --flow image-generation`
 > journey and its structural baseline are the next increment (added the same way
 > every other flow was — identifiers first, then the scripted journey).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -430,6 +430,14 @@ video = [
     "pillow>=10.0.0; platform_system == 'Darwin' and python_version >= '3.11'",
     "sentencepiece>=0.2.0; platform_system == 'Darwin' and python_version >= '3.11'",
 ]
+image = [
+    # MLX-native text-to-image / image-edit (FLUX.1-schnell, Qwen-Image,
+    # Qwen-Image-Edit) via mflux. mflux pins ``mlx<0.32`` — the same ceiling
+    # Rapid-MLX core already tracks — and requires Python >=3.11 (Rapid-MLX
+    # core still supports 3.10, so the image lane preflight gives 3.10 users an
+    # explicit upgrade diagnostic). Only Apache-2.0 model families are wired.
+    "mflux>=0.18.0; platform_system == 'Darwin' and python_version >= '3.11'",
+]
 
 [project.urls]
 Homepage = "https://github.com/raullenchai/Rapid-MLX"

--- a/tests/test_cli_models.py
+++ b/tests/test_cli_models.py
@@ -60,9 +60,8 @@ def test_models_command_lists_all_aliases():
 
     text_profiles, video_profiles, image_profiles = _split_by_modality()
     assert f"({len(text_profiles)} aliases)" in out
-    assert (
-        len(text_profiles) + len(video_profiles) + len(image_profiles)
-        == len(profiles)
+    assert len(text_profiles) + len(video_profiles) + len(image_profiles) == len(
+        profiles
     )
 
 

--- a/tests/test_cli_models.py
+++ b/tests/test_cli_models.py
@@ -27,14 +27,20 @@ def _capture_models_output() -> str:
 
 
 def _split_by_modality() -> tuple[dict, dict]:
-    """``(text_profiles, video_profiles)`` — the split the listing renders."""
+    """``(text, video, image)`` profiles — the split the listing renders."""
     profiles = list_profiles()
     video = {
         a: p
         for a, p in profiles.items()
         if getattr(p, "modality", "text") == "video-gen"
     }
-    return {a: p for a, p in profiles.items() if a not in video}, video
+    image = {
+        a: p
+        for a, p in profiles.items()
+        if getattr(p, "modality", "text") == "image-gen"
+    }
+    text = {a: p for a, p in profiles.items() if a not in video and a not in image}
+    return text, video, image
 
 
 def test_models_command_lists_all_aliases():
@@ -52,9 +58,12 @@ def test_models_command_lists_all_aliases():
     for alias in profiles:
         assert alias in out, f"alias {alias!r} missing from `rapid-mlx models` output"
 
-    text_profiles, video_profiles = _split_by_modality()
+    text_profiles, video_profiles, image_profiles = _split_by_modality()
     assert f"({len(text_profiles)} aliases)" in out
-    assert len(text_profiles) + len(video_profiles) == len(profiles)
+    assert (
+        len(text_profiles) + len(video_profiles) + len(image_profiles)
+        == len(profiles)
+    )
 
 
 def test_models_command_sections_video_aliases_out_of_the_text_table():
@@ -67,7 +76,7 @@ def test_models_command_sections_video_aliases_out_of_the_text_table():
     (#1603). The section header and the ``[video:gen]`` tag are the
     contract it filters on — mirroring ``[audio:tts]`` / ``[audio:stt]``.
     """
-    _, video_profiles = _split_by_modality()
+    _, video_profiles, _ = _split_by_modality()
     if not video_profiles:
         pytest.skip("no video-gen aliases in the registry")
 
@@ -85,6 +94,34 @@ def test_models_command_sections_video_aliases_out_of_the_text_table():
     # Every video row carries the Kind tag the desktop filters on.
     tagged = [ln for ln in video_section.splitlines() if "[video:gen]" in ln]
     assert len(tagged) == len(video_profiles)
+
+
+def test_models_command_sections_image_aliases_out_of_the_text_table():
+    """Image-gen aliases must not sit in the chat table, and must carry a Kind tag.
+
+    An ``image-gen`` model (mflux FLUX / Qwen-Image) has no ``stream_chat``,
+    so it can never answer ``/v1/chat/completions``. Same catalog-integrity
+    contract as video (#1603): the ``[image:gen]`` tag + section header are
+    what the desktop catalog filters on so it never offers a multi-GB image
+    checkpoint as a chat model.
+    """
+    _, _, image_profiles = _split_by_modality()
+    if not image_profiles:
+        pytest.skip("no image-gen aliases in the registry")
+
+    out = _capture_models_output()
+    head, _, image_section = out.partition("Image models (")
+    assert image_section, "expected an 'Image models (N aliases)' section"
+    assert f"{len(image_profiles)} aliases)" in image_section.split("\n", 1)[0]
+
+    for alias in image_profiles:
+        assert alias not in head, (
+            f"image alias {alias!r} leaked into the chat table — a catalog "
+            "consumer would offer it as a chat model"
+        )
+        assert alias in image_section
+    tagged = [ln for ln in image_section.splitlines() if "[image:gen]" in ln]
+    assert len(tagged) == len(image_profiles)
 
 
 def test_models_command_shows_capability_columns():

--- a/tests/test_image_lane.py
+++ b/tests/test_image_lane.py
@@ -193,6 +193,7 @@ def test_progress_reporter_tracks_step_then_cancels():
 
     engine = ImageGenerationEngine("Runpod/FLUX.2-klein-4B-mflux-4bit")
     engine._progress.update(total=4)
+    engine._active_seq = 1  # simulate an in-flight run (set under the lock)
 
     class _Cfg:
         num_inference_steps = 4
@@ -203,7 +204,7 @@ def test_progress_reporter_tracks_step_then_cancels():
     assert engine._progress["step"] == 1
     assert engine._progress["total"] == 4
 
-    # Once cancel is armed, the next step aborts the loop by raising.
+    # A cancel targets the active run's seq; the next step then aborts by raising.
     engine.request_cancel()
     with pytest.raises(ImageGenerationCancelled):
         engine._reporter.call_in_loop(
@@ -221,8 +222,25 @@ def test_progress_snapshot_shape():
 
 def test_generate_resets_progress_and_registers_reporter():
     engine = ImageGenerationEngine("Runpod/FLUX.2-klein-4B-mflux-4bit")
-    engine._model = _FakeModel()  # no ``.callbacks`` — registration is skipped
+
+    class _FakeRegistry:
+        def __init__(self):
+            self.registered = []
+
+        def register(self, callback):
+            self.registered.append(callback)
+
+    class _ModelWithCallbacks(_FakeModel):
+        def __init__(self):
+            super().__init__()
+            self.callbacks = _FakeRegistry()
+
+    built = _ModelWithCallbacks()
+    engine._build_model = lambda: built  # type: ignore[assignment]
     engine.generate(prompt="a fox", num_inference_steps=4, seed=1)
+    # The progress/cancel reporter was registered on the model's mflux registry —
+    # without this, live progress and cancellation would silently never fire.
+    assert engine._reporter in built.callbacks.registered
     # After a clean run the snapshot is idle but carries the step total.
     assert engine._progress["running"] is False
     assert engine._progress["total"] == 4
@@ -609,7 +627,7 @@ def test_generate_honors_cancel_after_cold_load():
     built = _FakeModel()
 
     def _load_then_cancel():
-        engine._cancel = True  # simulate Cancel pressed during the load
+        engine.request_cancel()  # simulate Cancel pressed during the load
         return built
 
     engine._build_model = _load_then_cancel  # type: ignore[assignment]

--- a/tests/test_image_lane.py
+++ b/tests/test_image_lane.py
@@ -221,6 +221,34 @@ def test_generate_resets_progress_and_registers_reporter():
     assert engine._progress["total"] == 4
 
 
+def test_klein_drops_unsupported_negative_prompt():
+    # Regression: FLUX.2 Klein's generate_image has no negative_prompt param,
+    # so the engine must NOT forward it (passing it raises a TypeError).
+    engine = ImageGenerationEngine("Runpod/FLUX.2-klein-4B-mflux-4bit")
+    fake = _FakeModel()
+    engine._model = fake
+    engine.generate(prompt="a fox", negative_prompt="blurry, low quality", seed=1)
+    assert "negative_prompt" not in fake.calls[0]
+
+
+def test_supporting_family_keeps_negative_prompt():
+    engine = ImageGenerationEngine("filipstrand/Z-Image-Turbo-mflux-4bit")
+    fake = _FakeModel()
+    engine._model = fake
+    engine.generate(prompt="a fox", negative_prompt="blurry", seed=1)
+    assert fake.calls[0]["negative_prompt"] == "blurry"
+
+
+def test_guidance_omitted_when_unset():
+    # Unset guidance is dropped so a guidance-distilled model uses its own
+    # trained default rather than a forced value.
+    engine = ImageGenerationEngine("Runpod/FLUX.2-klein-4B-mflux-4bit")
+    fake = _FakeModel()
+    engine._model = fake
+    engine.generate(prompt="a fox", seed=1)
+    assert "guidance" not in fake.calls[0]
+
+
 def test_backend_failure_becomes_runtime_error():
     engine = ImageGenerationEngine("Qwen/Qwen-Image")
 

--- a/tests/test_image_lane.py
+++ b/tests/test_image_lane.py
@@ -170,12 +170,21 @@ class _FakeImageEngine:
     def __init__(self, is_edit=False):
         self.is_edit = is_edit
         self.seeds = []
+        self.image_paths_seen = []
 
-    def generate(self, *, prompt, width, height, num_inference_steps, seed, guidance, negative_prompt):
+    def generate(self, *, prompt, width, height, num_inference_steps, seed,
+                 guidance, negative_prompt, image_paths=None):
         self.seeds.append(seed)
+        self.image_paths_seen.append(image_paths)
         buffer = io.BytesIO()
         Image.new("RGB", (4, 4), (10, 20, 30)).save(buffer, format="PNG")
         return buffer.getvalue()
+
+
+def _png_upload_bytes():
+    buffer = io.BytesIO()
+    Image.new("RGB", (16, 16), (90, 90, 90)).save(buffer, format="PNG")
+    return buffer.getvalue()
 
 
 def _patch_engine(monkeypatch, engine):
@@ -254,3 +263,88 @@ def test_request_model_rejects_nonfinite_guidance(bad_guidance):
     # NaN/inf fail the ge=0 / le=20 comparisons, so the bounds reject them.
     with pytest.raises(ValueError):
         ImageGenerationRequest(prompt="x", guidance=bad_guidance)
+
+
+# --------------------------------------------------------------------------- #
+# Route: /v1/images/edits
+# --------------------------------------------------------------------------- #
+def test_edit_409_when_no_image_model(client, monkeypatch):
+    _patch_engine(monkeypatch, None)
+    resp = client.post(
+        "/v1/images/edits",
+        files={"image": ("in.png", _png_upload_bytes(), "image/png")},
+        data={"prompt": "add a hat"},
+    )
+    assert resp.status_code == 409
+    assert resp.json()["error"]["code"] == "image_model_not_loaded"
+
+
+def test_edit_409_when_txt2img_model_loaded(client, monkeypatch):
+    _patch_engine(monkeypatch, _FakeImageEngine(is_edit=False))
+    resp = client.post(
+        "/v1/images/edits",
+        files={"image": ("in.png", _png_upload_bytes(), "image/png")},
+        data={"prompt": "add a hat"},
+    )
+    assert resp.status_code == 409
+    assert resp.json()["error"]["code"] == "wrong_image_endpoint"
+
+
+def test_edit_happy_path_returns_b64_and_passes_image(client, monkeypatch):
+    engine = _FakeImageEngine(is_edit=True)
+    _patch_engine(monkeypatch, engine)
+    resp = client.post(
+        "/v1/images/edits",
+        files={"image": ("in.png", _png_upload_bytes(), "image/png")},
+        data={"prompt": "make the sky blue", "size": "512x512", "seed": "5"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body["data"]) == 1
+    assert base64.b64decode(body["data"][0]["b64_json"]).startswith(_PNG_MAGIC)
+    # The uploaded image was written to a temp file and passed to the engine.
+    assert engine.image_paths_seen[0] is not None
+    assert len(engine.image_paths_seen[0]) == 1
+
+
+def test_edit_multi_offsets_seed(client, monkeypatch):
+    engine = _FakeImageEngine(is_edit=True)
+    _patch_engine(monkeypatch, engine)
+    resp = client.post(
+        "/v1/images/edits",
+        files={"image": ("in.png", _png_upload_bytes(), "image/png")},
+        data={"prompt": "x", "n": "2", "seed": "50"},
+    )
+    assert resp.status_code == 200
+    assert len(resp.json()["data"]) == 2
+    assert engine.seeds == [50, 51]
+
+
+def test_edit_400_empty_prompt(client, monkeypatch):
+    _patch_engine(monkeypatch, _FakeImageEngine(is_edit=True))
+    resp = client.post(
+        "/v1/images/edits",
+        files={"image": ("in.png", _png_upload_bytes(), "image/png")},
+        data={"prompt": "   "},
+    )
+    assert resp.status_code == 400
+
+
+def test_edit_400_bad_size(client, monkeypatch):
+    _patch_engine(monkeypatch, _FakeImageEngine(is_edit=True))
+    resp = client.post(
+        "/v1/images/edits",
+        files={"image": ("in.png", _png_upload_bytes(), "image/png")},
+        data={"prompt": "x", "size": "100x100"},
+    )
+    assert resp.status_code == 400
+
+
+def test_edit_400_empty_image(client, monkeypatch):
+    _patch_engine(monkeypatch, _FakeImageEngine(is_edit=True))
+    resp = client.post(
+        "/v1/images/edits",
+        files={"image": ("in.png", b"", "image/png")},
+        data={"prompt": "x"},
+    )
+    assert resp.status_code == 400

--- a/tests/test_image_lane.py
+++ b/tests/test_image_lane.py
@@ -1,0 +1,256 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Hermetic tests for the mflux image-generation lane.
+
+No network, no disk, no real weights: the mflux model is replaced by a fake
+that returns a tiny in-memory PIL image, so these exercise Rapid-MLX's own
+validation / dispatch / transport contract rather than the diffusion pipeline.
+"""
+
+import base64
+import io
+import types
+
+import pytest
+from fastapi.testclient import TestClient
+from PIL import Image
+
+from vllm_mlx.api.models import ImageGenerationRequest
+from vllm_mlx.image.engine import ImageGenerationEngine, ImageRuntimeError
+from vllm_mlx.runtime.image_lane import ImageEngine
+
+_PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
+
+
+class _FakeGeneratedImage:
+    def __init__(self, image):
+        self.image = image
+
+
+class _FakeModel:
+    """Stand-in for an mflux Flux1 / QwenImage model."""
+
+    def __init__(self):
+        self.calls = []
+
+    def generate_image(self, **kwargs):
+        self.calls.append(kwargs)
+        return _FakeGeneratedImage(Image.new("RGB", (8, 8), (200, 40, 40)))
+
+
+# --------------------------------------------------------------------------- #
+# Family detection
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    "hf_path,expected_family,is_edit",
+    [
+        ("black-forest-labs/FLUX.1-schnell", "flux-schnell", False),
+        ("Qwen/Qwen-Image", "qwen-image", False),
+        ("Qwen/Qwen-Image-Edit-2509", "qwen-image-edit", True),
+    ],
+)
+def test_detect_family(hf_path, expected_family, is_edit):
+    engine = ImageGenerationEngine(hf_path)
+    assert engine.family == expected_family
+    assert engine.is_edit is is_edit
+
+
+def test_unknown_family_raises():
+    with pytest.raises(ImageRuntimeError, match="Unsupported image model"):
+        ImageGenerationEngine("stabilityai/some-unwired-model")
+
+
+@pytest.mark.parametrize(
+    "hf_path,family",
+    [
+        # ``<n>bit`` convention — the repos the -4bit aliases point at
+        ("dhairyashil/FLUX.1-schnell-mflux-4bit", "flux-schnell"),
+        ("mlx-community/Qwen-Image-2512-4bit", "qwen-image"),
+        ("ovedrive/Qwen-Image-Edit-2511-4bit", "qwen-image-edit"),
+        ("filipstrand/Qwen-Image-mflux-6bit", "qwen-image"),
+        # ``q<n>`` convention
+        ("someorg/Qwen-Image-Edit-mflux-q4", "qwen-image-edit"),
+    ],
+)
+def test_prequantized_repo_disables_onload_quantize(hf_path, family):
+    engine = ImageGenerationEngine(hf_path)
+    assert engine._prequantized is True
+    assert engine._quantize is None  # never re-quantize an already-quantized repo
+    assert engine.family == family
+
+
+@pytest.mark.parametrize(
+    "hf_path",
+    [
+        # Base repos carry no quant tag — the leading "q" of "Qwen" must not be
+        # mistaken for a "q<n>" tag, so on-load quantization stays enabled.
+        "black-forest-labs/FLUX.1-schnell",
+        "Qwen/Qwen-Image",
+        "Qwen/Qwen-Image-Edit-2509",
+    ],
+)
+def test_canonical_repo_keeps_onload_quantize(hf_path):
+    engine = ImageGenerationEngine(hf_path)
+    assert engine._prequantized is False
+    assert engine._quantize == 4
+
+
+# --------------------------------------------------------------------------- #
+# ImageGenerationEngine.generate
+# --------------------------------------------------------------------------- #
+def test_generate_returns_png_bytes():
+    engine = ImageGenerationEngine("black-forest-labs/FLUX.1-schnell")
+    engine._model = _FakeModel()  # bypass lazy load / real weights
+    png = engine.generate(prompt="a red fox", width=512, height=512, seed=7)
+    assert png.startswith(_PNG_MAGIC)
+    # It round-trips as a real PNG.
+    assert Image.open(io.BytesIO(png)).size == (8, 8)
+
+
+def test_generate_is_lazy(monkeypatch):
+    engine = ImageGenerationEngine("black-forest-labs/FLUX.1-schnell")
+    built = _FakeModel()
+    monkeypatch.setattr(engine, "_build_model", lambda: built)
+    assert engine._model is None  # not loaded at construction
+    engine.generate(prompt="x", seed=1)
+    assert engine._model is built  # loaded on first generate
+    assert built.calls[0]["prompt"] == "x"
+
+
+def test_edit_family_requires_image_paths():
+    engine = ImageGenerationEngine("Qwen/Qwen-Image-Edit-2509")
+    engine._model = _FakeModel()
+    with pytest.raises(ImageRuntimeError, match="requires at least one input image"):
+        engine.generate(prompt="make it blue", image_paths=None)
+
+
+def test_txt2img_family_rejects_image_paths():
+    engine = ImageGenerationEngine("Qwen/Qwen-Image")
+    engine._model = _FakeModel()
+    with pytest.raises(ImageRuntimeError, match="text-to-image only"):
+        engine.generate(prompt="a cat", image_paths=["/tmp/x.png"])
+
+
+def test_edit_family_passes_image_paths_through():
+    engine = ImageGenerationEngine("Qwen/Qwen-Image-Edit-2509")
+    fake = _FakeModel()
+    engine._model = fake
+    engine.generate(prompt="add a hat", image_paths=["/tmp/in.png"], seed=3)
+    assert fake.calls[0]["image_paths"] == ["/tmp/in.png"]
+
+
+def test_backend_failure_becomes_runtime_error():
+    engine = ImageGenerationEngine("Qwen/Qwen-Image")
+
+    class _Boom:
+        def generate_image(self, **kwargs):
+            raise ValueError("metal exploded")
+
+    engine._model = _Boom()
+    with pytest.raises(ImageRuntimeError, match="Image generation failed"):
+        engine.generate(prompt="x")
+
+
+# --------------------------------------------------------------------------- #
+# ImageEngine adapter
+# --------------------------------------------------------------------------- #
+def test_image_engine_adapter_is_duck_typed():
+    engine = ImageEngine("black-forest-labs/FLUX.1-schnell")
+    assert engine.is_image_gen is True
+    assert engine._loaded is True
+    assert engine.family == "flux-schnell"
+    assert engine.is_edit is False
+
+
+# --------------------------------------------------------------------------- #
+# Route: /v1/images/generations
+# --------------------------------------------------------------------------- #
+class _FakeImageEngine:
+    is_image_gen = True
+
+    def __init__(self, is_edit=False):
+        self.is_edit = is_edit
+        self.seeds = []
+
+    def generate(self, *, prompt, width, height, num_inference_steps, seed, guidance, negative_prompt):
+        self.seeds.append(seed)
+        buffer = io.BytesIO()
+        Image.new("RGB", (4, 4), (10, 20, 30)).save(buffer, format="PNG")
+        return buffer.getvalue()
+
+
+def _patch_engine(monkeypatch, engine):
+    monkeypatch.setattr(
+        "vllm_mlx.config.get_config", lambda: types.SimpleNamespace(engine=engine)
+    )
+
+
+@pytest.fixture
+def client():
+    from vllm_mlx.server import app
+
+    return TestClient(app)
+
+
+def test_route_409_when_no_image_model(client, monkeypatch):
+    _patch_engine(monkeypatch, None)
+    resp = client.post("/v1/images/generations", json={"prompt": "a fox"})
+    assert resp.status_code == 409
+    assert resp.json()["error"]["code"] == "image_model_not_loaded"
+
+
+def test_route_409_when_edit_model_loaded(client, monkeypatch):
+    _patch_engine(monkeypatch, _FakeImageEngine(is_edit=True))
+    resp = client.post("/v1/images/generations", json={"prompt": "a fox"})
+    assert resp.status_code == 409
+    assert resp.json()["error"]["code"] == "wrong_image_endpoint"
+
+
+def test_route_400_url_response_format(client, monkeypatch):
+    _patch_engine(monkeypatch, _FakeImageEngine())
+    resp = client.post(
+        "/v1/images/generations",
+        json={"prompt": "a fox", "response_format": "url"},
+    )
+    assert resp.status_code == 400
+    assert resp.json()["error"]["code"] == "unsupported_response_format"
+
+
+def test_route_happy_path_returns_b64(client, monkeypatch):
+    _patch_engine(monkeypatch, _FakeImageEngine())
+    resp = client.post(
+        "/v1/images/generations",
+        json={"prompt": "a red fox", "size": "512x512", "seed": 42},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "created" in body and len(body["data"]) == 1
+    raw = base64.b64decode(body["data"][0]["b64_json"])
+    assert raw.startswith(_PNG_MAGIC)
+
+
+def test_route_multi_image_offsets_seed(client, monkeypatch):
+    engine = _FakeImageEngine()
+    _patch_engine(monkeypatch, engine)
+    resp = client.post(
+        "/v1/images/generations",
+        json={"prompt": "a fox", "n": 3, "seed": 100},
+    )
+    assert resp.status_code == 200
+    assert len(resp.json()["data"]) == 3
+    assert engine.seeds == [100, 101, 102]  # per-index seed offset
+
+
+@pytest.mark.parametrize("bad_size", ["1023x1024", "100x100", "3000x512", "oops"])
+def test_route_rejects_bad_size(client, monkeypatch, bad_size):
+    _patch_engine(monkeypatch, _FakeImageEngine())
+    resp = client.post(
+        "/v1/images/generations", json={"prompt": "x", "size": bad_size}
+    )
+    assert resp.status_code in (400, 422)
+
+
+@pytest.mark.parametrize("bad_guidance", [float("nan"), float("inf"), float("-inf")])
+def test_request_model_rejects_nonfinite_guidance(bad_guidance):
+    # NaN/inf fail the ge=0 / le=20 comparisons, so the bounds reject them.
+    with pytest.raises(ValueError):
+        ImageGenerationRequest(prompt="x", guidance=bad_guidance)

--- a/tests/test_image_lane.py
+++ b/tests/test_image_lane.py
@@ -181,6 +181,46 @@ def test_txt2img_family_honors_requested_dimensions():
     assert fake.calls[0]["height"] == 512
 
 
+def test_progress_reporter_tracks_step_then_cancels():
+    from vllm_mlx.image.engine import ImageGenerationCancelled
+
+    engine = ImageGenerationEngine("Runpod/FLUX.2-klein-4B-mflux-4bit")
+    engine._progress.update(total=4)
+
+    class _Cfg:
+        num_inference_steps = 4
+
+    engine._reporter.call_in_loop(
+        t=0, seed=1, prompt="x", latents=None, config=_Cfg(), time_steps=None
+    )
+    assert engine._progress["step"] == 1
+    assert engine._progress["total"] == 4
+
+    # Once cancel is armed, the next step aborts the loop by raising.
+    engine.request_cancel()
+    with pytest.raises(ImageGenerationCancelled):
+        engine._reporter.call_in_loop(
+            t=1, seed=1, prompt="x", latents=None, config=_Cfg(), time_steps=None
+        )
+
+
+def test_progress_snapshot_shape():
+    engine = ImageGenerationEngine("Runpod/FLUX.2-klein-4B-mflux-4bit")
+    snap = engine.progress_snapshot()
+    assert set(snap) >= {"running", "step", "total", "elapsed_ms", "family"}
+    assert snap["running"] is False  # nothing running yet
+    assert snap["family"] == "flux2-klein"
+
+
+def test_generate_resets_progress_and_registers_reporter():
+    engine = ImageGenerationEngine("Runpod/FLUX.2-klein-4B-mflux-4bit")
+    engine._model = _FakeModel()  # no ``.callbacks`` — registration is skipped
+    engine.generate(prompt="a fox", num_inference_steps=4, seed=1)
+    # After a clean run the snapshot is idle but carries the step total.
+    assert engine._progress["running"] is False
+    assert engine._progress["total"] == 4
+
+
 def test_backend_failure_becomes_runtime_error():
     engine = ImageGenerationEngine("Qwen/Qwen-Image")
 
@@ -216,6 +256,14 @@ class _FakeImageEngine:
         self.image_paths_seen = []
         self.dims_seen = []
         self.steps_seen = []
+        self.cancelled = False
+
+    def progress_snapshot(self):
+        return {"running": True, "step": 2, "total": 4, "elapsed_ms": 1200,
+                "family": "flux2-klein"}
+
+    def request_cancel(self):
+        self.cancelled = True
 
     def generate(self, *, prompt, num_inference_steps, seed, guidance,
                  negative_prompt, width=None, height=None, image_paths=None):
@@ -296,6 +344,28 @@ def test_route_multi_image_offsets_seed(client, monkeypatch):
     assert resp.status_code == 200
     assert len(resp.json()["data"]) == 3
     assert engine.seeds == [100, 101, 102]  # per-index seed offset
+
+
+def test_progress_endpoint_returns_snapshot(client, monkeypatch):
+    _patch_engine(monkeypatch, _FakeImageEngine())
+    resp = client.get("/v1/images/progress")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["step"] == 2 and body["total"] == 4
+    assert body["family"] == "flux2-klein"
+
+
+def test_progress_endpoint_409_without_image_model(client, monkeypatch):
+    _patch_engine(monkeypatch, None)
+    assert client.get("/v1/images/progress").status_code == 409
+
+
+def test_cancel_endpoint_signals_engine(client, monkeypatch):
+    engine = _FakeImageEngine()
+    _patch_engine(monkeypatch, engine)
+    resp = client.post("/v1/images/cancel")
+    assert resp.status_code == 200 and resp.json()["ok"] is True
+    assert engine.cancelled is True
 
 
 @pytest.mark.parametrize("bad_size", ["1023x1024", "100x100", "3000x512", "oops"])

--- a/tests/test_image_lane.py
+++ b/tests/test_image_lane.py
@@ -303,8 +303,9 @@ def test_image_engine_adapter_is_duck_typed():
 class _FakeImageEngine:
     is_image_gen = True
 
-    def __init__(self, is_edit=False):
+    def __init__(self, is_edit=False, default_steps=4):
         self.is_edit = is_edit
+        self.default_steps = default_steps
         self.seeds = []
         self.image_paths_seen = []
         self.dims_seen = []
@@ -648,3 +649,14 @@ def test_edit_rejects_non_b64_response_format(client, monkeypatch, fmt):
         data={"prompt": "x", "response_format": fmt},
     )
     assert resp.status_code == 400
+
+
+@pytest.mark.parametrize("default_steps", [4, 8, 20])
+def test_generations_uses_engine_default_steps(client, monkeypatch, default_steps):
+    # A request without an explicit `steps` must inherit the engine's
+    # family-specific default (Klein 4, Z-Image 8, Qwen 20), not a hardcoded 4.
+    engine = _FakeImageEngine(default_steps=default_steps)
+    _patch_engine(monkeypatch, engine)
+    resp = client.post("/v1/images/generations", json={"prompt": "a fox"})
+    assert resp.status_code == 200
+    assert engine.steps_seen == [default_steps]

--- a/tests/test_image_lane.py
+++ b/tests/test_image_lane.py
@@ -64,11 +64,10 @@ def test_unknown_family_raises():
     [
         # ``<n>bit`` convention — the repos the -4bit aliases point at
         ("dhairyashil/FLUX.1-schnell-mflux-4bit", "flux-schnell"),
-        ("mlx-community/Qwen-Image-2512-4bit", "qwen-image"),
-        ("ovedrive/Qwen-Image-Edit-2511-4bit", "qwen-image-edit"),
+        ("OsaurusAI/Qwen-Image-mflux-4bit", "qwen-image"),
         ("filipstrand/Qwen-Image-mflux-6bit", "qwen-image"),
-        # ``q<n>`` convention
-        ("someorg/Qwen-Image-Edit-mflux-q4", "qwen-image-edit"),
+        # ``q<n>`` convention — the repo the qwen-image-edit-4bit alias points at
+        ("OsaurusAI/Qwen-Image-Edit-mflux-q4", "qwen-image-edit"),
     ],
 )
 def test_prequantized_repo_disables_onload_quantize(hf_path, family):
@@ -138,6 +137,32 @@ def test_edit_family_passes_image_paths_through():
     assert fake.calls[0]["image_paths"] == ["/tmp/in.png"]
 
 
+def test_edit_forces_none_dimensions_even_when_size_requested():
+    # Regression: mflux edit fixes the conditioning latents to a 1024²-area
+    # canvas of the input; forcing a mismatched width/height (e.g. 512×512)
+    # desyncs the RoPE ids and yields pure noise. The engine must hand mflux
+    # None so it sizes the target to match the conditioning.
+    engine = ImageGenerationEngine("Qwen/Qwen-Image-Edit-2509")
+    fake = _FakeModel()
+    engine._model = fake
+    engine.generate(
+        prompt="add a hat", image_paths=["/tmp/in.png"],
+        width=512, height=512, seed=3,
+    )
+    assert fake.calls[0]["width"] is None
+    assert fake.calls[0]["height"] is None
+
+
+def test_txt2img_family_honors_requested_dimensions():
+    # The noise trap is edit-only: text-to-image must still respect width/height.
+    engine = ImageGenerationEngine("Qwen/Qwen-Image")
+    fake = _FakeModel()
+    engine._model = fake
+    engine.generate(prompt="a cat", width=768, height=512, seed=3)
+    assert fake.calls[0]["width"] == 768
+    assert fake.calls[0]["height"] == 512
+
+
 def test_backend_failure_becomes_runtime_error():
     engine = ImageGenerationEngine("Qwen/Qwen-Image")
 
@@ -171,11 +196,17 @@ class _FakeImageEngine:
         self.is_edit = is_edit
         self.seeds = []
         self.image_paths_seen = []
+        self.dims_seen = []
+        self.steps_seen = []
 
-    def generate(self, *, prompt, width, height, num_inference_steps, seed,
-                 guidance, negative_prompt, image_paths=None):
+    def generate(self, *, prompt, num_inference_steps, seed, guidance,
+                 negative_prompt, width=None, height=None, image_paths=None):
+        # The edit route omits width/height (the engine derives them from the
+        # input image); the generations route always supplies them.
         self.seeds.append(seed)
         self.image_paths_seen.append(image_paths)
+        self.dims_seen.append((width, height))
+        self.steps_seen.append(num_inference_steps)
         buffer = io.BytesIO()
         Image.new("RGB", (4, 4), (10, 20, 30)).save(buffer, format="PNG")
         return buffer.getvalue()
@@ -305,6 +336,36 @@ def test_edit_happy_path_returns_b64_and_passes_image(client, monkeypatch):
     # The uploaded image was written to a temp file and passed to the engine.
     assert engine.image_paths_seen[0] is not None
     assert len(engine.image_paths_seen[0]) == 1
+    # Even though the request carried size=512x512, the edit route does NOT
+    # thread dimensions — the engine derives them from the input image.
+    assert engine.dims_seen[0] == (None, None)
+
+
+def test_edit_defaults_to_20_steps_when_unspecified(client, monkeypatch):
+    # FLUX.1-schnell generation defaults to 4 distilled steps, but a
+    # non-distilled edit needs ~20 to resolve structure; the edit route must
+    # not inherit the 4-step generation default.
+    engine = _FakeImageEngine(is_edit=True)
+    _patch_engine(monkeypatch, engine)
+    resp = client.post(
+        "/v1/images/edits",
+        files={"image": ("in.png", _png_upload_bytes(), "image/png")},
+        data={"prompt": "add a hat"},
+    )
+    assert resp.status_code == 200
+    assert engine.steps_seen == [20]
+
+
+def test_edit_honors_explicit_steps(client, monkeypatch):
+    engine = _FakeImageEngine(is_edit=True)
+    _patch_engine(monkeypatch, engine)
+    resp = client.post(
+        "/v1/images/edits",
+        files={"image": ("in.png", _png_upload_bytes(), "image/png")},
+        data={"prompt": "add a hat", "steps": "8"},
+    )
+    assert resp.status_code == 200
+    assert engine.steps_seen == [8]
 
 
 def test_edit_multi_offsets_seed(client, monkeypatch):

--- a/tests/test_image_lane.py
+++ b/tests/test_image_lane.py
@@ -43,6 +43,10 @@ class _FakeModel:
 @pytest.mark.parametrize(
     "hf_path,expected_family,is_edit",
     [
+        # Fast tab defaults — the "klein" / "z-image" tokens must win even
+        # though the Klein repo id also contains "flux".
+        ("Runpod/FLUX.2-klein-4B-mflux-4bit", "flux2-klein", False),
+        ("filipstrand/Z-Image-Turbo-mflux-4bit", "z-image", False),
         ("black-forest-labs/FLUX.1-schnell", "flux-schnell", False),
         ("Qwen/Qwen-Image", "qwen-image", False),
         ("Qwen/Qwen-Image-Edit-2509", "qwen-image-edit", True),
@@ -54,6 +58,19 @@ def test_detect_family(hf_path, expected_family, is_edit):
     assert engine.is_edit is is_edit
 
 
+@pytest.mark.parametrize(
+    "hf_path,expected_default_steps",
+    [
+        ("Runpod/FLUX.2-klein-4B-mflux-4bit", 4),   # distilled turbo
+        ("filipstrand/Z-Image-Turbo-mflux-4bit", 8),  # turbo, 8-step sweet spot
+        ("black-forest-labs/FLUX.1-schnell", 4),
+        ("Qwen/Qwen-Image", 20),                    # non-distilled
+    ],
+)
+def test_default_steps_is_family_aware(hf_path, expected_default_steps):
+    assert ImageGenerationEngine(hf_path).default_steps == expected_default_steps
+
+
 def test_unknown_family_raises():
     with pytest.raises(ImageRuntimeError, match="Unsupported image model"):
         ImageGenerationEngine("stabilityai/some-unwired-model")
@@ -62,10 +79,11 @@ def test_unknown_family_raises():
 @pytest.mark.parametrize(
     "hf_path,family",
     [
-        # ``<n>bit`` convention — the repos the -4bit aliases point at
+        # ``<n>bit`` convention — the repos the fast-tab aliases point at
+        ("Runpod/FLUX.2-klein-4B-mflux-4bit", "flux2-klein"),
+        ("filipstrand/Z-Image-Turbo-mflux-4bit", "z-image"),
         ("dhairyashil/FLUX.1-schnell-mflux-4bit", "flux-schnell"),
         ("OsaurusAI/Qwen-Image-mflux-4bit", "qwen-image"),
-        ("filipstrand/Qwen-Image-mflux-6bit", "qwen-image"),
         # ``q<n>`` convention — the repo the qwen-image-edit-4bit alias points at
         ("OsaurusAI/Qwen-Image-Edit-mflux-q4", "qwen-image-edit"),
     ],

--- a/tests/test_image_lane.py
+++ b/tests/test_image_lane.py
@@ -635,3 +635,16 @@ def test_generate_honors_cancel_after_cold_load():
         engine.generate(prompt="x", seed=1)
     # Nothing was generated (aborted before the denoise call).
     assert built.calls == []
+
+
+@pytest.mark.parametrize("fmt", ["url", "webp", "png"])
+def test_edit_rejects_non_b64_response_format(client, monkeypatch, fmt):
+    # The edit endpoint must reject any response_format other than b64_json
+    # (the local lane has no object store for URLs), matching generations.
+    _patch_engine(monkeypatch, _FakeImageEngine(is_edit=True))
+    resp = client.post(
+        "/v1/images/edits",
+        files={"image": ("in.png", _png_upload_bytes(), "image/png")},
+        data={"prompt": "x", "response_format": fmt},
+    )
+    assert resp.status_code == 400

--- a/tests/test_image_lane.py
+++ b/tests/test_image_lane.py
@@ -15,7 +15,11 @@ from fastapi.testclient import TestClient
 from PIL import Image
 
 from vllm_mlx.api.models import ImageGenerationRequest
-from vllm_mlx.image.engine import ImageGenerationEngine, ImageRuntimeError
+from vllm_mlx.image.engine import (
+    ImageGenerationCancelled,
+    ImageGenerationEngine,
+    ImageRuntimeError,
+)
 from vllm_mlx.runtime.image_lane import ImageEngine
 
 _PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
@@ -61,10 +65,10 @@ def test_detect_family(hf_path, expected_family, is_edit):
 @pytest.mark.parametrize(
     "hf_path,expected_default_steps",
     [
-        ("Runpod/FLUX.2-klein-4B-mflux-4bit", 4),   # distilled turbo
+        ("Runpod/FLUX.2-klein-4B-mflux-4bit", 4),  # distilled turbo
         ("filipstrand/Z-Image-Turbo-mflux-4bit", 8),  # turbo, 8-step sweet spot
         ("black-forest-labs/FLUX.1-schnell", 4),
-        ("Qwen/Qwen-Image", 20),                    # non-distilled
+        ("Qwen/Qwen-Image", 20),  # non-distilled
     ],
 )
 def test_default_steps_is_family_aware(hf_path, expected_default_steps):
@@ -164,8 +168,11 @@ def test_edit_forces_none_dimensions_even_when_size_requested():
     fake = _FakeModel()
     engine._model = fake
     engine.generate(
-        prompt="add a hat", image_paths=["/tmp/in.png"],
-        width=512, height=512, seed=3,
+        prompt="add a hat",
+        image_paths=["/tmp/in.png"],
+        width=512,
+        height=512,
+        seed=3,
     )
     assert fake.calls[0]["width"] is None
     assert fake.calls[0]["height"] is None
@@ -287,14 +294,29 @@ class _FakeImageEngine:
         self.cancelled = False
 
     def progress_snapshot(self):
-        return {"running": True, "step": 2, "total": 4, "elapsed_ms": 1200,
-                "family": "flux2-klein"}
+        return {
+            "running": True,
+            "step": 2,
+            "total": 4,
+            "elapsed_ms": 1200,
+            "family": "flux2-klein",
+        }
 
     def request_cancel(self):
         self.cancelled = True
 
-    def generate(self, *, prompt, num_inference_steps, seed, guidance,
-                 negative_prompt, width=None, height=None, image_paths=None):
+    def generate(
+        self,
+        *,
+        prompt,
+        num_inference_steps,
+        seed,
+        guidance,
+        negative_prompt,
+        width=None,
+        height=None,
+        image_paths=None,
+    ):
         # The edit route omits width/height (the engine derives them from the
         # input image); the generations route always supplies them.
         self.seeds.append(seed)
@@ -399,9 +421,7 @@ def test_cancel_endpoint_signals_engine(client, monkeypatch):
 @pytest.mark.parametrize("bad_size", ["1023x1024", "100x100", "3000x512", "oops"])
 def test_route_rejects_bad_size(client, monkeypatch, bad_size):
     _patch_engine(monkeypatch, _FakeImageEngine())
-    resp = client.post(
-        "/v1/images/generations", json={"prompt": "x", "size": bad_size}
-    )
+    resp = client.post("/v1/images/generations", json={"prompt": "x", "size": bad_size})
     assert resp.status_code in (400, 422)
 
 
@@ -525,3 +545,75 @@ def test_edit_400_empty_image(client, monkeypatch):
         data={"prompt": "x"},
     )
     assert resp.status_code == 400
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("steps", "0"),
+        ("steps", "500"),
+        ("guidance", "nan"),
+        ("guidance", "999"),
+        ("seed", "-1"),
+    ],
+)
+def test_edit_rejects_out_of_bounds_params(client, monkeypatch, field, value):
+    # A raw multipart form must not smuggle a negative seed / non-finite
+    # guidance / absurd step count past the validated bounds.
+    _patch_engine(monkeypatch, _FakeImageEngine(is_edit=True))
+    resp = client.post(
+        "/v1/images/edits",
+        files={"image": ("in.png", _png_upload_bytes(), "image/png")},
+        data={"prompt": "x", field: value},
+    )
+    assert resp.status_code in (400, 422)
+
+
+def test_edit_rejects_oversized_image(client, monkeypatch):
+    _patch_engine(monkeypatch, _FakeImageEngine(is_edit=True))
+    oversized = b"\x89PNG\r\n\x1a\n" + b"0" * (26 * 1024 * 1024)  # > 25 MB cap
+    resp = client.post(
+        "/v1/images/edits",
+        files={"image": ("in.png", oversized, "image/png")},
+        data={"prompt": "x"},
+    )
+    assert resp.status_code == 413
+
+
+def test_edit_cancel_returns_cancelled_envelope(client, monkeypatch):
+    from vllm_mlx.image.engine import ImageGenerationCancelled
+
+    class _CancelEngine:
+        is_image_gen = True
+        is_edit = True
+
+        def generate(self, **kwargs):
+            raise ImageGenerationCancelled("cancelled")
+
+    _patch_engine(monkeypatch, _CancelEngine())
+    resp = client.post(
+        "/v1/images/edits",
+        files={"image": ("in.png", _png_upload_bytes(), "image/png")},
+        data={"prompt": "x"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["cancelled"] is True
+    assert body["data"] == []
+
+
+def test_generate_honors_cancel_after_cold_load():
+    # A cancel that lands during the warm-up load must abort before denoising,
+    # not be reset away once the model finishes loading.
+    engine = ImageGenerationEngine("Runpod/FLUX.2-klein-4B-mflux-4bit")
+    built = _FakeModel()
+
+    def _load_then_cancel():
+        engine._cancel = True  # simulate Cancel pressed during the load
+        return built
+
+    engine._build_model = _load_then_cancel  # type: ignore[assignment]
+    with pytest.raises(ImageGenerationCancelled):
+        engine.generate(prompt="x", seed=1)
+    # Nothing was generated (aborted before the denoise call).
+    assert built.calls == []

--- a/tests/test_modality_field.py
+++ b/tests/test_modality_field.py
@@ -83,8 +83,12 @@ class TestModalityValidation:
         # ``load_model``. If you add a value here you MUST also
         # update the Literal in model_aliases.py AND the dispatch
         # tables in cli.py / routes/models.py. Failing this assertion
-        # is the trigger to do that work.
-        assert frozenset({"text", "text-diffusion", "video-gen"}) == _VALID_MODALITIES
+        # is the trigger to do that work. ``image-gen`` joined when the
+        # mflux image lane (runtime/image_lane.py) landed.
+        assert (
+            frozenset({"text", "text-diffusion", "video-gen", "image-gen"})
+            == _VALID_MODALITIES
+        )
 
     def test_reserved_modality_set_pinned(self) -> None:
         # Reserved lanes — declared in the type alias so routing
@@ -93,12 +97,12 @@ class TestModalityValidation:
         # (pr_validate codex r13 NIT). When you implement one of
         # these, move it from _RESERVED_MODALITIES into
         # _VALID_MODALITIES and update this test.
-        assert frozenset({"vision", "image-gen"}) == _RESERVED_MODALITIES
+        assert frozenset({"vision"}) == _RESERVED_MODALITIES
 
     def test_reserved_modality_rejected_at_load(self) -> None:
         # Loading an alias whose modality is reserved-but-not-routed
         # must fail with a clear "not yet implemented" message.
-        for reserved in ("vision", "image-gen"):
+        for reserved in ("vision",):
             with pytest.raises(ValueError, match="not yet implemented"):
                 _coerce(
                     "bad",
@@ -109,6 +113,20 @@ class TestModalityValidation:
                         "supports_dflash": False,
                     },
                 )
+
+    def test_image_gen_accepted(self) -> None:
+        # ``image-gen`` is now a routed lane (mflux) — it must coerce
+        # cleanly like any other implemented modality.
+        profile = _coerce(
+            "flux-schnell",
+            {
+                "hf_path": "black-forest-labs/FLUX.1-schnell",
+                "modality": "image-gen",
+                "supports_spec_decode": False,
+                "supports_dflash": False,
+            },
+        )
+        assert profile.modality == "image-gen"
 
 
 class TestNonTextLaneRejectsARGates:

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -1635,7 +1635,7 @@
     "min_memory_gb": 12
   },
   "qwen-image-4bit": {
-    "hf_path": "mlx-community/Qwen-Image-2512-4bit",
+    "hf_path": "OsaurusAI/Qwen-Image-mflux-4bit",
     "modality": "image-gen",
     "tool_call_parser": null,
     "reasoning_parser": null,
@@ -1647,7 +1647,7 @@
     "min_memory_gb": 32
   },
   "qwen-image-edit-4bit": {
-    "hf_path": "ovedrive/Qwen-Image-Edit-2511-4bit",
+    "hf_path": "OsaurusAI/Qwen-Image-Edit-mflux-q4",
     "modality": "image-gen",
     "tool_call_parser": null,
     "reasoning_parser": null,

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -1586,44 +1586,8 @@
     "suffix_decoding_tier": "unknown",
     "min_memory_gb": 24
   },
-  "flux-schnell": {
-    "hf_path": "black-forest-labs/FLUX.1-schnell",
-    "modality": "image-gen",
-    "tool_call_parser": null,
-    "reasoning_parser": null,
-    "is_hybrid": false,
-    "is_moe": false,
-    "supports_spec_decode": false,
-    "supports_dflash": false,
-    "suffix_decoding_tier": "unknown",
-    "min_memory_gb": 16
-  },
-  "qwen-image": {
-    "hf_path": "Qwen/Qwen-Image",
-    "modality": "image-gen",
-    "tool_call_parser": null,
-    "reasoning_parser": null,
-    "is_hybrid": false,
-    "is_moe": false,
-    "supports_spec_decode": false,
-    "supports_dflash": false,
-    "suffix_decoding_tier": "unknown",
-    "min_memory_gb": 24
-  },
-  "qwen-image-edit": {
-    "hf_path": "Qwen/Qwen-Image-Edit-2509",
-    "modality": "image-gen",
-    "tool_call_parser": null,
-    "reasoning_parser": null,
-    "is_hybrid": false,
-    "is_moe": false,
-    "supports_spec_decode": false,
-    "supports_dflash": false,
-    "suffix_decoding_tier": "unknown",
-    "min_memory_gb": 24
-  },
-  "flux-schnell-4bit": {
-    "hf_path": "dhairyashil/FLUX.1-schnell-mflux-4bit",
+  "flux2-klein-4b": {
+    "hf_path": "Runpod/FLUX.2-klein-4B-mflux-4bit",
     "modality": "image-gen",
     "tool_call_parser": null,
     "reasoning_parser": null,
@@ -1634,8 +1598,8 @@
     "suffix_decoding_tier": "unknown",
     "min_memory_gb": 12
   },
-  "qwen-image-4bit": {
-    "hf_path": "OsaurusAI/Qwen-Image-mflux-4bit",
+  "z-image-turbo": {
+    "hf_path": "filipstrand/Z-Image-Turbo-mflux-4bit",
     "modality": "image-gen",
     "tool_call_parser": null,
     "reasoning_parser": null,
@@ -1644,19 +1608,7 @@
     "supports_spec_decode": false,
     "supports_dflash": false,
     "suffix_decoding_tier": "unknown",
-    "min_memory_gb": 32
-  },
-  "qwen-image-edit-4bit": {
-    "hf_path": "OsaurusAI/Qwen-Image-Edit-mflux-q4",
-    "modality": "image-gen",
-    "tool_call_parser": null,
-    "reasoning_parser": null,
-    "is_hybrid": false,
-    "is_moe": false,
-    "supports_spec_decode": false,
-    "supports_dflash": false,
-    "suffix_decoding_tier": "unknown",
-    "min_memory_gb": 24
+    "min_memory_gb": 16
   },
   "embeddinggemma-300m-6bit": {
     "hf_path": "mlx-community/embeddinggemma-300m-6bit",

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -1586,6 +1586,78 @@
     "suffix_decoding_tier": "unknown",
     "min_memory_gb": 24
   },
+  "flux-schnell": {
+    "hf_path": "black-forest-labs/FLUX.1-schnell",
+    "modality": "image-gen",
+    "tool_call_parser": null,
+    "reasoning_parser": null,
+    "is_hybrid": false,
+    "is_moe": false,
+    "supports_spec_decode": false,
+    "supports_dflash": false,
+    "suffix_decoding_tier": "unknown",
+    "min_memory_gb": 16
+  },
+  "qwen-image": {
+    "hf_path": "Qwen/Qwen-Image",
+    "modality": "image-gen",
+    "tool_call_parser": null,
+    "reasoning_parser": null,
+    "is_hybrid": false,
+    "is_moe": false,
+    "supports_spec_decode": false,
+    "supports_dflash": false,
+    "suffix_decoding_tier": "unknown",
+    "min_memory_gb": 24
+  },
+  "qwen-image-edit": {
+    "hf_path": "Qwen/Qwen-Image-Edit-2509",
+    "modality": "image-gen",
+    "tool_call_parser": null,
+    "reasoning_parser": null,
+    "is_hybrid": false,
+    "is_moe": false,
+    "supports_spec_decode": false,
+    "supports_dflash": false,
+    "suffix_decoding_tier": "unknown",
+    "min_memory_gb": 24
+  },
+  "flux-schnell-4bit": {
+    "hf_path": "dhairyashil/FLUX.1-schnell-mflux-4bit",
+    "modality": "image-gen",
+    "tool_call_parser": null,
+    "reasoning_parser": null,
+    "is_hybrid": false,
+    "is_moe": false,
+    "supports_spec_decode": false,
+    "supports_dflash": false,
+    "suffix_decoding_tier": "unknown",
+    "min_memory_gb": 12
+  },
+  "qwen-image-4bit": {
+    "hf_path": "mlx-community/Qwen-Image-2512-4bit",
+    "modality": "image-gen",
+    "tool_call_parser": null,
+    "reasoning_parser": null,
+    "is_hybrid": false,
+    "is_moe": false,
+    "supports_spec_decode": false,
+    "supports_dflash": false,
+    "suffix_decoding_tier": "unknown",
+    "min_memory_gb": 32
+  },
+  "qwen-image-edit-4bit": {
+    "hf_path": "ovedrive/Qwen-Image-Edit-2511-4bit",
+    "modality": "image-gen",
+    "tool_call_parser": null,
+    "reasoning_parser": null,
+    "is_hybrid": false,
+    "is_moe": false,
+    "supports_spec_decode": false,
+    "supports_dflash": false,
+    "suffix_decoding_tier": "unknown",
+    "min_memory_gb": 24
+  },
   "embeddinggemma-300m-6bit": {
     "hf_path": "mlx-community/embeddinggemma-300m-6bit",
     "tool_call_parser": null,

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -3158,6 +3158,31 @@ _IMAGE_DIM_MULTIPLE = 16
 _IMAGE_SIZE_RE = re.compile(r"^\s*(\d{2,4})\s*[x×]\s*(\d{2,4})\s*$")
 
 
+def parse_image_size(value: str) -> tuple[int, int]:
+    """Parse+validate a ``WIDTHxHEIGHT`` string into a bounded ``(w, h)`` pair.
+
+    Shared by :class:`ImageGenerationRequest` (JSON body) and the multipart
+    ``/v1/images/edits`` form so both surfaces enforce the identical contract.
+    Raises ``ValueError`` on a malformed / out-of-range / non-multiple size.
+    """
+    match = _IMAGE_SIZE_RE.match(value or "")
+    if not match:
+        raise ValueError(
+            f"size must be 'WIDTHxHEIGHT' (e.g. '1024x1024'), got {value!r}"
+        )
+    width, height = int(match.group(1)), int(match.group(2))
+    for dim, side in ((width, "width"), (height, "height")):
+        if dim < _IMAGE_MIN_DIM or dim > _IMAGE_MAX_DIM:
+            raise ValueError(
+                f"{side} must be between {_IMAGE_MIN_DIM} and {_IMAGE_MAX_DIM}, got {dim}"
+            )
+        if dim % _IMAGE_DIM_MULTIPLE != 0:
+            raise ValueError(
+                f"{side} must be a multiple of {_IMAGE_DIM_MULTIPLE}, got {dim}"
+            )
+    return width, height
+
+
 class ImageGenerationRequest(BaseModel):
     """Request for text-to-image (OpenAI ``/v1/images/generations`` compatible).
 
@@ -3188,22 +3213,7 @@ class ImageGenerationRequest(BaseModel):
     @field_validator("size")
     @classmethod
     def _validate_size(cls, value: str) -> str:
-        match = _IMAGE_SIZE_RE.match(value or "")
-        if not match:
-            raise ValueError(
-                f"size must be 'WIDTHxHEIGHT' (e.g. '1024x1024'), got {value!r}"
-            )
-        width, height = int(match.group(1)), int(match.group(2))
-        for dim, side in ((width, "width"), (height, "height")):
-            if dim < _IMAGE_MIN_DIM or dim > _IMAGE_MAX_DIM:
-                raise ValueError(
-                    f"{side} must be between {_IMAGE_MIN_DIM} and {_IMAGE_MAX_DIM}, "
-                    f"got {dim}"
-                )
-            if dim % _IMAGE_DIM_MULTIPLE != 0:
-                raise ValueError(
-                    f"{side} must be a multiple of {_IMAGE_DIM_MULTIPLE}, got {dim}"
-                )
+        width, height = parse_image_size(value)
         return f"{width}x{height}"
 
     # NOTE: ``guidance`` needs no explicit finite check — it carries ``ge=0``

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -3145,3 +3145,73 @@ class ChatCompletionChunk(BaseModel):
     model: str
     choices: list[ChatCompletionChunkChoice]
     usage: Usage | None = None  # Included when stream_options.include_usage=true
+
+
+# Supported output dimensions: a bounded range keeps a single request from
+# pinning the whole GPU (a 2048² FLUX latent is ~4x the 1024² working set) and
+# every side is forced to a multiple of 16 because the FLUX / Qwen-Image VAE
+# down/up-samples by 8 twice — an odd dimension crashes deep inside the mflux
+# pipeline with an opaque reshape error instead of a clean 400 here.
+_IMAGE_MIN_DIM = 256
+_IMAGE_MAX_DIM = 2048
+_IMAGE_DIM_MULTIPLE = 16
+_IMAGE_SIZE_RE = re.compile(r"^\s*(\d{2,4})\s*[x×]\s*(\d{2,4})\s*$")
+
+
+class ImageGenerationRequest(BaseModel):
+    """Request for text-to-image (OpenAI ``/v1/images/generations`` compatible).
+
+    Rapid-MLX serves one image model per process (like the audio/video lanes),
+    so ``model`` is advisory — the loaded alias decides the family. ``size`` is
+    parsed and bounds-checked here so a malformed or oversized request surfaces
+    a 400 ``invalid_request_error`` BEFORE mflux loads multi-gigabyte weights.
+
+    ``steps`` / ``guidance`` / ``seed`` / ``negative_prompt`` are Rapid-MLX
+    extensions (not in the stock OpenAI schema) exposing the diffusion knobs;
+    OpenAI clients that omit them get the family's fast defaults.
+    """
+
+    model: str = ""
+    prompt: str = Field(..., min_length=1)
+    # Cap ``n`` so one call can't serialize an unbounded number of full renders
+    # behind the process generation lock.
+    n: int = Field(default=1, ge=1, le=4)
+    size: str = "1024x1024"
+    response_format: Literal["b64_json", "url"] = "b64_json"
+    seed: int | None = Field(default=None, ge=0)
+    negative_prompt: str | None = None
+    # Diffusion-step count. schnell/Qwen-Image are distilled for 2-8 steps; the
+    # ceiling keeps a single request from monopolizing the GPU for minutes.
+    steps: int | None = Field(default=None, ge=1, le=50)
+    guidance: float | None = Field(default=None, ge=0.0, le=20.0)
+
+    @field_validator("size")
+    @classmethod
+    def _validate_size(cls, value: str) -> str:
+        match = _IMAGE_SIZE_RE.match(value or "")
+        if not match:
+            raise ValueError(
+                f"size must be 'WIDTHxHEIGHT' (e.g. '1024x1024'), got {value!r}"
+            )
+        width, height = int(match.group(1)), int(match.group(2))
+        for dim, side in ((width, "width"), (height, "height")):
+            if dim < _IMAGE_MIN_DIM or dim > _IMAGE_MAX_DIM:
+                raise ValueError(
+                    f"{side} must be between {_IMAGE_MIN_DIM} and {_IMAGE_MAX_DIM}, "
+                    f"got {dim}"
+                )
+            if dim % _IMAGE_DIM_MULTIPLE != 0:
+                raise ValueError(
+                    f"{side} must be a multiple of {_IMAGE_DIM_MULTIPLE}, got {dim}"
+                )
+        return f"{width}x{height}"
+
+    # NOTE: ``guidance`` needs no explicit finite check — it carries ``ge=0``
+    # AND ``le=20``, and NaN/inf fail every comparison, so a non-finite value
+    # is already rejected by the bounds. The repo-wide ``math.isfinite`` guard
+    # only matters for UNBOUNDED float fields, which this model has none of.
+
+    def dimensions(self) -> tuple[int, int]:
+        """Return the validated ``(width, height)`` pair."""
+        width, height = self.size.split("x")
+        return int(width), int(height)

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -3203,7 +3203,9 @@ class ImageGenerationRequest(BaseModel):
     n: int = Field(default=1, ge=1, le=4)
     size: str = "1024x1024"
     response_format: Literal["b64_json", "url"] = "b64_json"
-    seed: int | None = Field(default=None, ge=0)
+    # Upper bound so an arbitrarily large Python int can't reach the native
+    # MLX/mflux backend and overflow into a 500.
+    seed: int | None = Field(default=None, ge=0, le=2_147_483_647)
     negative_prompt: str | None = None
     # Diffusion-step count. schnell/Qwen-Image are distilled for 2-8 steps; the
     # ceiling keeps a single request from monopolizing the GPU for minutes.

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -4982,7 +4982,22 @@ def models_command(args):
         for alias, p in all_profiles.items()
         if getattr(p, "modality", "text") == "video-gen"
     }
-    profiles = {a: p for a, p in all_profiles.items() if a not in video_profiles}
+    # Image-generation aliases (mflux FLUX / Qwen-Image) are likewise not chat
+    # models — ``/v1/chat/completions`` on one is unrouted. Split them into
+    # their own ``[image:gen]``-tagged section for the same catalog-integrity
+    # reason as video (#1603): a GUI consumer must be able to tell an image
+    # model from a chat model without hardcoding alias names, or it will offer
+    # a multi-GB image checkpoint as a chat model that dead-ends on first send.
+    image_profiles = {
+        alias: p
+        for alias, p in all_profiles.items()
+        if getattr(p, "modality", "text") == "image-gen"
+    }
+    profiles = {
+        a: p
+        for a, p in all_profiles.items()
+        if a not in video_profiles and a not in image_profiles
+    }
     print()
     print(f"  Available models ({len(profiles)} aliases)")
 
@@ -5108,6 +5123,30 @@ def models_command(args):
                 f"{p.hf_path:<40}"
             )
         print(video_sep)
+
+    # Image-generation aliases, tagged ``[image:gen]`` — same rationale as the
+    # video section above (#1603): a chat-catalog consumer must be able to
+    # exclude them by Kind tag rather than by hardcoded name.
+    if image_profiles:
+        image_alias_width = max(
+            24, max((len(a) for a in image_profiles), default=0) + 2
+        )
+        print()
+        print(f"  Image models ({len(image_profiles)} aliases)")
+        image_sep = "  " + "─" * width
+        print(image_sep)
+        print(
+            f"  {'Alias':<{image_alias_width}} {'Size':<10} {'Kind':<11} {'HF id':<40}"
+        )
+        print(image_sep)
+        for alias in sorted(image_profiles):
+            p = image_profiles[alias]
+            print(
+                f"  {alias:<{image_alias_width}} "
+                f"{format_size(p.hf_path):<10} {'[image:gen]':<11} "
+                f"{p.hf_path:<40}"
+            )
+        print(image_sep)
 
     print()
     print(

--- a/vllm_mlx/image/__init__.py
+++ b/vllm_mlx/image/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+"""MLX-native text-to-image / image-edit generation backends (mflux)."""

--- a/vllm_mlx/image/engine.py
+++ b/vllm_mlx/image/engine.py
@@ -81,7 +81,7 @@ class _ProgressReporter:
         )
         engine._progress["step"] = int(t) + 1
         engine._progress["total"] = int(total)
-        if engine._cancel:
+        if engine._is_cancelled():
             raise ImageGenerationCancelled("Generation cancelled.")
 
 
@@ -171,8 +171,19 @@ class ImageGenerationEngine:
             "total": 0,
             "started_at": 0.0,
         }
-        self._cancel = False
+        # Cancellation is scoped by a monotonic run sequence rather than a bare
+        # boolean, so a cancel is tied to a specific render and can never be
+        # clobbered by the next request arming itself. ``_active_seq`` is the
+        # in-flight run (0 = none); ``_cancel_seq`` is the highest run a cancel
+        # was requested for. A run is cancelled iff ``_cancel_seq >= its seq``.
+        self._run_seq = 0
+        self._active_seq = 0
+        self._cancel_seq = 0
         self._reporter = _ProgressReporter(self)
+
+    def _is_cancelled(self) -> bool:
+        """True when the in-flight run has an outstanding cancel request."""
+        return self._active_seq > 0 and self._cancel_seq >= self._active_seq
 
     def _build_model(self):
         """Instantiate the backing mflux model (import-lazy)."""
@@ -237,8 +248,13 @@ class ImageGenerationEngine:
         return self._model
 
     def request_cancel(self) -> None:
-        """Ask an in-flight generation to stop at the next denoise step."""
-        self._cancel = True
+        """Ask the in-flight generation to stop at the next denoise step.
+
+        Targets the currently-active run; a cancel with no render in flight is a
+        no-op (``_active_seq == 0``), and one armed while a render is starting is
+        preserved because the seq is only advanced under the lock.
+        """
+        self._cancel_seq = max(self._cancel_seq, self._active_seq)
 
     def progress_snapshot(self) -> dict:
         """A JSON-safe view of the current denoise progress (single-flight)."""
@@ -282,11 +298,12 @@ class ImageGenerationEngine:
             )
 
         with self._lock:
-            # Arm cancellation + progress BEFORE loading, so a Cancel pressed
-            # during the (possibly multi-gigabyte) cold model load is honored
-            # instead of being reset away once the load finishes. The lock
-            # guarantees no other generation is mutating the snapshot.
-            self._cancel = False
+            # Claim a run sequence and arm progress BEFORE loading, so a Cancel
+            # pressed during the (possibly multi-gigabyte) cold model load is
+            # honored — its seq already matches this run — instead of being lost.
+            # The lock guarantees single-flight, so one snapshot is unambiguous.
+            self._run_seq += 1
+            self._active_seq = self._run_seq
             self._progress.update(
                 running=True,
                 step=0,
@@ -297,7 +314,7 @@ class ImageGenerationEngine:
                 model = self._ensure_loaded()
                 # Honor a cancel that landed during the warm-up load before we
                 # commit to the denoise loop.
-                if self._cancel:
+                if self._is_cancelled():
                     raise ImageGenerationCancelled("Generation cancelled.")
                 if self.is_edit:
                     # Edit derives its output canvas from the input image and
@@ -332,6 +349,7 @@ class ImageGenerationEngine:
                 raise ImageRuntimeError(f"Image generation failed: {exc}") from exc
             finally:
                 self._progress["running"] = False
+                self._active_seq = 0
 
         return self._encode_png(result)
 

--- a/vllm_mlx/image/engine.py
+++ b/vllm_mlx/image/engine.py
@@ -105,6 +105,11 @@ def _detect_family(model_name: str) -> str:
     )
 
 
+# Families whose ``generate_image`` takes NO ``negative_prompt`` parameter.
+# FLUX.2 Klein omits it (Flux1 / Qwen-Image / Z-Image all accept it), and
+# passing an unknown kwarg raises — so the engine drops it for these.
+_NO_NEGATIVE_PROMPT_FAMILIES = frozenset({"flux2-klein"})
+
 # Per-family default denoise steps when the request pins none. Distilled/turbo
 # models converge in a handful of steps; a non-distilled model needs many more.
 _DEFAULT_STEPS_BY_FAMILY = {
@@ -144,6 +149,7 @@ class ImageGenerationEngine:
         self.family = _detect_family(model_name)
         self.is_edit = self.family == "qwen-image-edit"
         self.default_steps = _DEFAULT_STEPS_BY_FAMILY.get(self.family, 4)
+        self.supports_negative_prompt = self.family not in _NO_NEGATIVE_PROMPT_FAMILIES
         self._prequantized = _looks_like_prequantized(model_name)
         # ``None`` when the repo is already quantized — passing a quantize width
         # for a pre-quantized checkpoint makes mflux re-quantize and error.
@@ -240,7 +246,7 @@ class ImageGenerationEngine:
         height: int = 1024,
         num_inference_steps: int = 4,
         seed: int = 0,
-        guidance: float = 4.0,
+        guidance: float | None = None,
         negative_prompt: str | None = None,
         image_paths: list[str] | None = None,
     ) -> bytes:
@@ -282,24 +288,15 @@ class ImageGenerationEngine:
                     # Passing ``None`` lets mflux size the target to match the
                     # conditioning, exactly like its edit CLI.
                     result = model.generate_image(
-                        seed=seed,
-                        prompt=prompt,
-                        image_paths=image_paths,
-                        num_inference_steps=num_inference_steps,
-                        height=None,
-                        width=None,
-                        guidance=guidance,
-                        negative_prompt=negative_prompt,
+                        image_paths=image_paths, height=None, width=None,
+                        **self._gen_kwargs(seed, prompt, num_inference_steps,
+                                           guidance, negative_prompt),
                     )
                 else:
                     result = model.generate_image(
-                        seed=seed,
-                        prompt=prompt,
-                        num_inference_steps=num_inference_steps,
-                        height=height,
-                        width=width,
-                        guidance=guidance,
-                        negative_prompt=negative_prompt,
+                        height=height, width=width,
+                        **self._gen_kwargs(seed, prompt, num_inference_steps,
+                                           guidance, negative_prompt),
                     )
             except ImageRuntimeError:
                 raise  # cancellation + already-clean errors pass straight through
@@ -309,6 +306,25 @@ class ImageGenerationEngine:
                 self._progress["running"] = False
 
         return self._encode_png(result)
+
+    def _gen_kwargs(self, seed, prompt, num_inference_steps, guidance, negative_prompt) -> dict:
+        """Build ``generate_image`` kwargs, omitting params a family rejects.
+
+        FLUX.2 Klein has no ``negative_prompt`` parameter (passing it raises),
+        and a guidance-distilled model degrades when forced to a fixed guidance
+        — so ``guidance`` is passed only when the caller set one, otherwise each
+        model uses its own trained default.
+        """
+        kwargs = {
+            "seed": seed,
+            "prompt": prompt,
+            "num_inference_steps": num_inference_steps,
+        }
+        if guidance is not None:
+            kwargs["guidance"] = guidance
+        if negative_prompt is not None and self.supports_negative_prompt:
+            kwargs["negative_prompt"] = negative_prompt
+        return kwargs
 
     @staticmethod
     def _encode_png(result) -> bytes:

--- a/vllm_mlx/image/engine.py
+++ b/vllm_mlx/image/engine.py
@@ -163,13 +163,23 @@ class ImageGenerationEngine:
             model = self._ensure_loaded()
             try:
                 if self.is_edit:
+                    # Edit derives its output canvas from the input image and
+                    # must NOT be given an explicit width/height. mflux fixes the
+                    # VAE conditioning latents to a 1024²-area canvas of the input
+                    # aspect ratio (``_compute_dimensions``), while the denoised
+                    # latents use ``config.width/height``. Any mismatch between
+                    # the two — e.g. forcing 512×512 against 1024²-derived
+                    # conditioning — desyncs the RoPE position ids and the model
+                    # emits pure noise (a valid, correctly-sized PNG of static).
+                    # Passing ``None`` lets mflux size the target to match the
+                    # conditioning, exactly like its edit CLI.
                     result = model.generate_image(
                         seed=seed,
                         prompt=prompt,
                         image_paths=image_paths,
                         num_inference_steps=num_inference_steps,
-                        height=height,
-                        width=width,
+                        height=None,
+                        width=None,
                         guidance=guidance,
                         negative_prompt=negative_prompt,
                     )

--- a/vllm_mlx/image/engine.py
+++ b/vllm_mlx/image/engine.py
@@ -362,6 +362,9 @@ class ImageGenerationEngine:
                 raise ImageRuntimeError(f"Image generation failed: {exc}") from exc
             finally:
                 self._progress["running"] = False
+                # Clear the start time so a completed run's snapshot doesn't keep
+                # reporting an ever-growing ``elapsed_ms`` while idle.
+                self._progress["started_at"] = 0.0
                 with self._state_lock:
                     self._active_seq = 0
 

--- a/vllm_mlx/image/engine.py
+++ b/vllm_mlx/image/engine.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 import io
 import re
 import threading
+import time
 from pathlib import Path
 
 # A pre-quantized mflux repo carries a quant tag in its id — either the
@@ -52,6 +53,32 @@ _DEFAULT_QUANTIZE = 4
 
 class ImageRuntimeError(RuntimeError):
     """Safe, actionable generation error suitable for the public API."""
+
+
+class ImageGenerationCancelled(ImageRuntimeError):  # noqa: N818 — a cancel, not an error condition
+    """Raised when the user cancels an in-flight generation mid-denoise."""
+
+
+class _ProgressReporter:
+    """mflux in-loop callback that mirrors denoise progress onto the engine.
+
+    Diffusion has a fixed, known step count, so this yields a *true*
+    ``step / total`` signal (unlike an LLM token stream). Registered once per
+    loaded model; it also enforces cooperative cancellation by raising out of
+    the loop when the engine's cancel flag is set — the abort lands within one
+    step (a second or two), not after the whole render.
+    """
+
+    def __init__(self, engine: ImageGenerationEngine) -> None:
+        self._engine = engine
+
+    def call_in_loop(self, t, seed, prompt, latents, config, time_steps) -> None:  # noqa: ANN001
+        engine = self._engine
+        total = getattr(config, "num_inference_steps", 0) or engine._progress.get("total", 0)
+        engine._progress["step"] = int(t) + 1
+        engine._progress["total"] = int(total)
+        if engine._cancel:
+            raise ImageGenerationCancelled("Generation cancelled.")
 
 
 def _detect_family(model_name: str) -> str:
@@ -123,6 +150,14 @@ class ImageGenerationEngine:
         self._quantize = None if self._prequantized else quantize
         self._model = None
         self._lock = _PROCESS_GENERATION_LOCK
+        # Live denoise progress (single-flight under ``_lock``, so one snapshot
+        # is unambiguous). ``request_cancel`` flips ``_cancel``; the reporter
+        # reads it each step. ``_reporter`` is registered once per loaded model.
+        self._progress: dict[str, float | int | bool] = {
+            "running": False, "step": 0, "total": 0, "started_at": 0.0,
+        }
+        self._cancel = False
+        self._reporter = _ProgressReporter(self)
 
     def _build_model(self):
         """Instantiate the backing mflux model (import-lazy)."""
@@ -173,7 +208,29 @@ class ImageGenerationEngine:
                 raise ImageRuntimeError(
                     f"Failed to load image model '{self.model_name}': {exc}"
                 ) from exc
+            # Register the progress/cancel reporter on the model's mflux
+            # callback registry (present on every txt2img/edit variant).
+            registry = getattr(self._model, "callbacks", None)
+            if registry is not None and hasattr(registry, "register"):
+                registry.register(self._reporter)
         return self._model
+
+    def request_cancel(self) -> None:
+        """Ask an in-flight generation to stop at the next denoise step."""
+        self._cancel = True
+
+    def progress_snapshot(self) -> dict:
+        """A JSON-safe view of the current denoise progress (single-flight)."""
+        p = self._progress
+        started = float(p.get("started_at") or 0.0)
+        elapsed_ms = int((time.time() - started) * 1000) if started else 0
+        return {
+            "running": bool(p.get("running", False)),
+            "step": int(p.get("step", 0)),
+            "total": int(p.get("total", 0)),
+            "elapsed_ms": elapsed_ms,
+            "family": self.family,
+        }
 
     def generate(
         self,
@@ -205,6 +262,13 @@ class ImageGenerationEngine:
 
         with self._lock:
             model = self._ensure_loaded()
+            # Arm progress for this single-flight render (the lock guarantees no
+            # other generation is mutating the snapshot concurrently).
+            self._cancel = False
+            self._progress.update(
+                running=True, step=0, total=int(num_inference_steps),
+                started_at=time.time(),
+            )
             try:
                 if self.is_edit:
                     # Edit derives its output canvas from the input image and
@@ -238,9 +302,11 @@ class ImageGenerationEngine:
                         negative_prompt=negative_prompt,
                     )
             except ImageRuntimeError:
-                raise
+                raise  # cancellation + already-clean errors pass straight through
             except Exception as exc:  # noqa: BLE001 — surface a clean API error
                 raise ImageRuntimeError(f"Image generation failed: {exc}") from exc
+            finally:
+                self._progress["running"] = False
 
         return self._encode_png(result)
 

--- a/vllm_mlx/image/engine.py
+++ b/vllm_mlx/image/engine.py
@@ -10,9 +10,17 @@ the diffusion pipeline and weight loading.
 Only Apache-2.0-licensed families are wired here so the whole surface stays
 commercially clean:
 
-* ``flux-schnell``     — text→image (``black-forest-labs/FLUX.1-schnell``)
+* ``flux2-klein``      — text→image (``FLUX.2-klein-4B``), 4B/4-step, the fast
+  default: ~3 s @ 512² / ~10 s @ 1024² on an M3 Ultra, ~4 GB at 4-bit
+* ``z-image``          — text→image (``Z-Image-Turbo``), 6B/8-step, the quality
+  option (SOTA open-source photorealism), ~5.5 GB at 4-bit
+* ``flux-schnell``     — text→image (``black-forest-labs/FLUX.1-schnell``), 12B
 * ``qwen-image``       — text→image (``Qwen/Qwen-Image``), strongest text-in-image
 * ``qwen-image-edit``  — instruction edit (``Qwen/Qwen-Image-Edit-2509``)
+
+``flux2-klein`` and ``z-image`` supersede the older/larger families for the
+interactive tab: Klein is ~3× faster than schnell/z-image at the same
+resolution while staying smaller, and Qwen-Image (20B) is too slow to feature.
 
 The mflux model is loaded lazily on the first ``generate`` call: the canonical
 repos ship full-precision weights that mflux quantizes at load, so pulling them
@@ -49,6 +57,13 @@ class ImageRuntimeError(RuntimeError):
 def _detect_family(model_name: str) -> str:
     """Map an alias hf_path (or local dir) to a supported mflux family."""
     name = (model_name or "").casefold()
+    # Klein first — its repos ("FLUX.2-klein-4B-mflux-4bit") also contain
+    # "flux", so the distinctive "klein" / "flux2" token must win before the
+    # generic FLUX.1 checks below.
+    if "klein" in name or "flux2" in name or "flux.2" in name:
+        return "flux2-klein"
+    if "z-image" in name or "z_image" in name or "zimage" in name:
+        return "z-image"
     if "qwen-image-edit" in name or "qwen_image_edit" in name:
         return "qwen-image-edit"
     if "qwen-image" in name or "qwen_image" in name:
@@ -59,8 +74,20 @@ def _detect_family(model_name: str) -> str:
         return "flux-dev"
     raise ImageRuntimeError(
         f"Unsupported image model '{model_name}'. Supported families: "
-        "flux-schnell, qwen-image, qwen-image-edit."
+        "flux2-klein, z-image, flux-schnell, qwen-image, qwen-image-edit."
     )
+
+
+# Per-family default denoise steps when the request pins none. Distilled/turbo
+# models converge in a handful of steps; a non-distilled model needs many more.
+_DEFAULT_STEPS_BY_FAMILY = {
+    "flux2-klein": 4,   # distilled turbo
+    "z-image": 8,       # turbo, but 8 is the sweet spot for its quality
+    "flux-schnell": 4,  # distilled
+    "flux-dev": 20,     # non-distilled
+    "qwen-image": 20,   # non-distilled 20B
+    "qwen-image-edit": 20,
+}
 
 
 def _looks_like_prequantized(model_name: str) -> bool:
@@ -89,6 +116,7 @@ class ImageGenerationEngine:
         self.model_name = model_name
         self.family = _detect_family(model_name)
         self.is_edit = self.family == "qwen-image-edit"
+        self.default_steps = _DEFAULT_STEPS_BY_FAMILY.get(self.family, 4)
         self._prequantized = _looks_like_prequantized(model_name)
         # ``None`` when the repo is already quantized — passing a quantize width
         # for a pre-quantized checkpoint makes mflux re-quantize and error.
@@ -105,6 +133,22 @@ class ImageGenerationEngine:
         # so mflux downloads the official weights and quantizes on load.
         model_path = self.model_name if self._prequantized else None
 
+        if self.family == "flux2-klein":
+            from mflux.models.flux2.variants.txt2img.flux2_klein import Flux2Klein
+
+            return Flux2Klein(
+                quantize=self._quantize,
+                model_path=model_path,
+                model_config=ModelConfig.flux2_klein_4b(),
+            )
+        if self.family == "z-image":
+            from mflux.models.z_image.variants.z_image import ZImage
+
+            return ZImage(
+                quantize=self._quantize,
+                model_path=model_path,
+                model_config=ModelConfig.z_image_turbo(),
+            )
         if self.family == "qwen-image-edit":
             from mflux.models.qwen.variants.edit.qwen_image_edit import QwenImageEdit
 

--- a/vllm_mlx/image/engine.py
+++ b/vllm_mlx/image/engine.py
@@ -79,6 +79,10 @@ class _ProgressReporter:
         total = getattr(config, "num_inference_steps", 0) or engine._progress.get(
             "total", 0
         )
+        # ``running`` flips true only once the denoise loop actually fires, so
+        # the client shows "warming up" during the cold load and "denoising"
+        # (with a real step count) only while stepping — not step 1 mid-download.
+        engine._progress["running"] = True
         engine._progress["step"] = int(t) + 1
         engine._progress["total"] = int(total)
         if engine._is_cancelled():
@@ -304,8 +308,11 @@ class ImageGenerationEngine:
             # The lock guarantees single-flight, so one snapshot is unambiguous.
             self._run_seq += 1
             self._active_seq = self._run_seq
+            # ``running`` stays False through the cold load — the reporter flips
+            # it true on the first denoise step — so the client renders the
+            # "warming up" phase during load, not a bogus "denoising step 1".
             self._progress.update(
-                running=True,
+                running=False,
                 step=0,
                 total=int(num_inference_steps),
                 started_at=time.time(),

--- a/vllm_mlx/image/engine.py
+++ b/vllm_mlx/image/engine.py
@@ -40,7 +40,9 @@ from pathlib import Path
 # ``q<n>`` convention (``Qwen-Image-Edit-mflux-q4``). Anchored to a separator
 # so a base repo like ``Qwen/Qwen-Image`` (no tag) is never misread — the
 # leading ``q`` of "Qwen" is not followed by a quant digit.
-_QUANT_TAG_RE = re.compile(r"(?:^|[-_./])(?:q[2-8]|[2-8]-?bit)(?:[-_./]|$)", re.IGNORECASE)
+_QUANT_TAG_RE = re.compile(
+    r"(?:^|[-_./])(?:q[2-8]|[2-8]-?bit)(?:[-_./]|$)", re.IGNORECASE
+)
 
 # mflux/Metal graphs are not re-entrant — a single process-wide lock serializes
 # every generation exactly like the video lane's ``_PROCESS_GENERATION_LOCK``.
@@ -74,7 +76,9 @@ class _ProgressReporter:
 
     def call_in_loop(self, t, seed, prompt, latents, config, time_steps) -> None:  # noqa: ANN001
         engine = self._engine
-        total = getattr(config, "num_inference_steps", 0) or engine._progress.get("total", 0)
+        total = getattr(config, "num_inference_steps", 0) or engine._progress.get(
+            "total", 0
+        )
         engine._progress["step"] = int(t) + 1
         engine._progress["total"] = int(total)
         if engine._cancel:
@@ -113,11 +117,11 @@ _NO_NEGATIVE_PROMPT_FAMILIES = frozenset({"flux2-klein"})
 # Per-family default denoise steps when the request pins none. Distilled/turbo
 # models converge in a handful of steps; a non-distilled model needs many more.
 _DEFAULT_STEPS_BY_FAMILY = {
-    "flux2-klein": 4,   # distilled turbo
-    "z-image": 8,       # turbo, but 8 is the sweet spot for its quality
+    "flux2-klein": 4,  # distilled turbo
+    "z-image": 8,  # turbo, but 8 is the sweet spot for its quality
     "flux-schnell": 4,  # distilled
-    "flux-dev": 20,     # non-distilled
-    "qwen-image": 20,   # non-distilled 20B
+    "flux-dev": 20,  # non-distilled
+    "qwen-image": 20,  # non-distilled 20B
     "qwen-image-edit": 20,
 }
 
@@ -144,7 +148,9 @@ class ImageGenerationEngine:
     the transport never has to touch the filesystem.
     """
 
-    def __init__(self, model_name: str, *, quantize: int | None = _DEFAULT_QUANTIZE) -> None:
+    def __init__(
+        self, model_name: str, *, quantize: int | None = _DEFAULT_QUANTIZE
+    ) -> None:
         self.model_name = model_name
         self.family = _detect_family(model_name)
         self.is_edit = self.family == "qwen-image-edit"
@@ -160,7 +166,10 @@ class ImageGenerationEngine:
         # is unambiguous). ``request_cancel`` flips ``_cancel``; the reporter
         # reads it each step. ``_reporter`` is registered once per loaded model.
         self._progress: dict[str, float | int | bool] = {
-            "running": False, "step": 0, "total": 0, "started_at": 0.0,
+            "running": False,
+            "step": 0,
+            "total": 0,
+            "started_at": 0.0,
         }
         self._cancel = False
         self._reporter = _ProgressReporter(self)
@@ -201,8 +210,14 @@ class ImageGenerationEngine:
 
         from mflux.models.flux.variants.txt2img.flux import Flux1
 
-        config = ModelConfig.schnell() if self.family == "flux-schnell" else ModelConfig.dev()
-        return Flux1(quantize=self._quantize, model_path=model_path, model_config=config)
+        config = (
+            ModelConfig.schnell()
+            if self.family == "flux-schnell"
+            else ModelConfig.dev()
+        )
+        return Flux1(
+            quantize=self._quantize, model_path=model_path, model_config=config
+        )
 
     def _ensure_loaded(self):
         if self._model is None:
@@ -267,15 +282,23 @@ class ImageGenerationEngine:
             )
 
         with self._lock:
-            model = self._ensure_loaded()
-            # Arm progress for this single-flight render (the lock guarantees no
-            # other generation is mutating the snapshot concurrently).
+            # Arm cancellation + progress BEFORE loading, so a Cancel pressed
+            # during the (possibly multi-gigabyte) cold model load is honored
+            # instead of being reset away once the load finishes. The lock
+            # guarantees no other generation is mutating the snapshot.
             self._cancel = False
             self._progress.update(
-                running=True, step=0, total=int(num_inference_steps),
+                running=True,
+                step=0,
+                total=int(num_inference_steps),
                 started_at=time.time(),
             )
             try:
+                model = self._ensure_loaded()
+                # Honor a cancel that landed during the warm-up load before we
+                # commit to the denoise loop.
+                if self._cancel:
+                    raise ImageGenerationCancelled("Generation cancelled.")
                 if self.is_edit:
                     # Edit derives its output canvas from the input image and
                     # must NOT be given an explicit width/height. mflux fixes the
@@ -288,15 +311,20 @@ class ImageGenerationEngine:
                     # Passing ``None`` lets mflux size the target to match the
                     # conditioning, exactly like its edit CLI.
                     result = model.generate_image(
-                        image_paths=image_paths, height=None, width=None,
-                        **self._gen_kwargs(seed, prompt, num_inference_steps,
-                                           guidance, negative_prompt),
+                        image_paths=image_paths,
+                        height=None,
+                        width=None,
+                        **self._gen_kwargs(
+                            seed, prompt, num_inference_steps, guidance, negative_prompt
+                        ),
                     )
                 else:
                     result = model.generate_image(
-                        height=height, width=width,
-                        **self._gen_kwargs(seed, prompt, num_inference_steps,
-                                           guidance, negative_prompt),
+                        height=height,
+                        width=width,
+                        **self._gen_kwargs(
+                            seed, prompt, num_inference_steps, guidance, negative_prompt
+                        ),
                     )
             except ImageRuntimeError:
                 raise  # cancellation + already-clean errors pass straight through
@@ -307,7 +335,9 @@ class ImageGenerationEngine:
 
         return self._encode_png(result)
 
-    def _gen_kwargs(self, seed, prompt, num_inference_steps, guidance, negative_prompt) -> dict:
+    def _gen_kwargs(
+        self, seed, prompt, num_inference_steps, guidance, negative_prompt
+    ) -> dict:
         """Build ``generate_image`` kwargs, omitting params a family rejects.
 
         FLUX.2 Klein has no ``negative_prompt`` parameter (passing it raises),

--- a/vllm_mlx/image/engine.py
+++ b/vllm_mlx/image/engine.py
@@ -1,0 +1,201 @@
+# SPDX-License-Identifier: Apache-2.0
+"""mflux-backed image generation engine.
+
+Thin wrapper over `mflux <https://github.com/filipstrand/mflux>`_ — an
+MLX-native, line-by-line port of the FLUX / Qwen-Image model families with
+built-in 4/8-bit quantization. Rapid-MLX owns request validation, the lazy
+load / process-lock lifecycle and the OpenAI-compatible transport; mflux owns
+the diffusion pipeline and weight loading.
+
+Only Apache-2.0-licensed families are wired here so the whole surface stays
+commercially clean:
+
+* ``flux-schnell``     — text→image (``black-forest-labs/FLUX.1-schnell``)
+* ``qwen-image``       — text→image (``Qwen/Qwen-Image``), strongest text-in-image
+* ``qwen-image-edit``  — instruction edit (``Qwen/Qwen-Image-Edit-2509``)
+
+The mflux model is loaded lazily on the first ``generate`` call: the canonical
+repos ship full-precision weights that mflux quantizes at load, so pulling them
+at server boot would stall startup on a multi-gigabyte download.
+"""
+
+from __future__ import annotations
+
+import io
+import re
+import threading
+from pathlib import Path
+
+# A pre-quantized mflux repo carries a quant tag in its id — either the
+# ``<n>bit`` / ``<n>-bit`` convention (``FLUX.1-schnell-mflux-4bit``) or the
+# ``q<n>`` convention (``Qwen-Image-Edit-mflux-q4``). Anchored to a separator
+# so a base repo like ``Qwen/Qwen-Image`` (no tag) is never misread — the
+# leading ``q`` of "Qwen" is not followed by a quant digit.
+_QUANT_TAG_RE = re.compile(r"(?:^|[-_./])(?:q[2-8]|[2-8]-?bit)(?:[-_./]|$)", re.IGNORECASE)
+
+# mflux/Metal graphs are not re-entrant — a single process-wide lock serializes
+# every generation exactly like the video lane's ``_PROCESS_GENERATION_LOCK``.
+_PROCESS_GENERATION_LOCK = threading.Lock()
+
+# Default quantization for the on-load quantize path. 4-bit is the 32GB sweet
+# spot (FLUX.1-schnell ~9GB, Qwen-Image ~12GB resident at q4).
+_DEFAULT_QUANTIZE = 4
+
+
+class ImageRuntimeError(RuntimeError):
+    """Safe, actionable generation error suitable for the public API."""
+
+
+def _detect_family(model_name: str) -> str:
+    """Map an alias hf_path (or local dir) to a supported mflux family."""
+    name = (model_name or "").casefold()
+    if "qwen-image-edit" in name or "qwen_image_edit" in name:
+        return "qwen-image-edit"
+    if "qwen-image" in name or "qwen_image" in name:
+        return "qwen-image"
+    if "schnell" in name:
+        return "flux-schnell"
+    if "flux.1-dev" in name or "flux1-dev" in name:
+        return "flux-dev"
+    raise ImageRuntimeError(
+        f"Unsupported image model '{model_name}'. Supported families: "
+        "flux-schnell, qwen-image, qwen-image-edit."
+    )
+
+
+def _looks_like_prequantized(model_name: str) -> bool:
+    """A pre-quantized mflux repo / local dir is loaded via ``model_path``.
+
+    The canonical BFL / Qwen repos ship full weights that mflux quantizes on
+    load (a ~57 GB download). Community mflux repos ship already-quantized
+    weights (~9-27 GB) whose id carries a quant tag; those are passed straight
+    through as ``model_path`` with ``quantize=None`` — re-quantizing an
+    already-quantized checkpoint makes mflux error.
+    """
+    if model_name and Path(model_name).expanduser().is_dir():
+        return True
+    return bool(_QUANT_TAG_RE.search(model_name or ""))
+
+
+class ImageGenerationEngine:
+    """Adapter over a single mflux model family.
+
+    One instance owns one lazily-loaded mflux model. ``generate`` is blocking
+    (the caller runs it off the event loop) and returns encoded PNG bytes so
+    the transport never has to touch the filesystem.
+    """
+
+    def __init__(self, model_name: str, *, quantize: int | None = _DEFAULT_QUANTIZE) -> None:
+        self.model_name = model_name
+        self.family = _detect_family(model_name)
+        self.is_edit = self.family == "qwen-image-edit"
+        self._prequantized = _looks_like_prequantized(model_name)
+        # ``None`` when the repo is already quantized — passing a quantize width
+        # for a pre-quantized checkpoint makes mflux re-quantize and error.
+        self._quantize = None if self._prequantized else quantize
+        self._model = None
+        self._lock = _PROCESS_GENERATION_LOCK
+
+    def _build_model(self):
+        """Instantiate the backing mflux model (import-lazy)."""
+        from mflux.models.common.config.model_config import ModelConfig
+
+        # A pre-quantized repo / local dir is handed to mflux verbatim as
+        # ``model_path``; a canonical repo is selected through ``ModelConfig``
+        # so mflux downloads the official weights and quantizes on load.
+        model_path = self.model_name if self._prequantized else None
+
+        if self.family == "qwen-image-edit":
+            from mflux.models.qwen.variants.edit.qwen_image_edit import QwenImageEdit
+
+            return QwenImageEdit(quantize=self._quantize, model_path=model_path)
+        if self.family == "qwen-image":
+            from mflux.models.qwen.variants.txt2img.qwen_image import QwenImage
+
+            return QwenImage(quantize=self._quantize, model_path=model_path)
+
+        from mflux.models.flux.variants.txt2img.flux import Flux1
+
+        config = ModelConfig.schnell() if self.family == "flux-schnell" else ModelConfig.dev()
+        return Flux1(quantize=self._quantize, model_path=model_path, model_config=config)
+
+    def _ensure_loaded(self):
+        if self._model is None:
+            try:
+                self._model = self._build_model()
+            except ImageRuntimeError:
+                raise
+            except Exception as exc:  # noqa: BLE001 — surface a clean API error
+                raise ImageRuntimeError(
+                    f"Failed to load image model '{self.model_name}': {exc}"
+                ) from exc
+        return self._model
+
+    def generate(
+        self,
+        *,
+        prompt: str,
+        width: int = 1024,
+        height: int = 1024,
+        num_inference_steps: int = 4,
+        seed: int = 0,
+        guidance: float = 4.0,
+        negative_prompt: str | None = None,
+        image_paths: list[str] | None = None,
+    ) -> bytes:
+        """Generate one image and return it as PNG bytes.
+
+        ``image_paths`` is required for the edit family and rejected for the
+        text-to-image families so a mis-routed request fails loud instead of
+        silently ignoring the conditioning image.
+        """
+        if self.is_edit and not image_paths:
+            raise ImageRuntimeError(
+                "qwen-image-edit requires at least one input image (image_paths)."
+            )
+        if not self.is_edit and image_paths:
+            raise ImageRuntimeError(
+                f"{self.family} is text-to-image only and does not accept input images; "
+                "use the qwen-image-edit model for image editing."
+            )
+
+        with self._lock:
+            model = self._ensure_loaded()
+            try:
+                if self.is_edit:
+                    result = model.generate_image(
+                        seed=seed,
+                        prompt=prompt,
+                        image_paths=image_paths,
+                        num_inference_steps=num_inference_steps,
+                        height=height,
+                        width=width,
+                        guidance=guidance,
+                        negative_prompt=negative_prompt,
+                    )
+                else:
+                    result = model.generate_image(
+                        seed=seed,
+                        prompt=prompt,
+                        num_inference_steps=num_inference_steps,
+                        height=height,
+                        width=width,
+                        guidance=guidance,
+                        negative_prompt=negative_prompt,
+                    )
+            except ImageRuntimeError:
+                raise
+            except Exception as exc:  # noqa: BLE001 — surface a clean API error
+                raise ImageRuntimeError(f"Image generation failed: {exc}") from exc
+
+        return self._encode_png(result)
+
+    @staticmethod
+    def _encode_png(result) -> bytes:
+        """Encode an mflux ``GeneratedImage`` to PNG bytes without touching disk."""
+        pil_image = getattr(result, "image", None)
+        if pil_image is None:
+            raise ImageRuntimeError("Image backend returned no image data.")
+        buffer = io.BytesIO()
+        pil_image.save(buffer, format="PNG")
+        return buffer.getvalue()

--- a/vllm_mlx/image/engine.py
+++ b/vllm_mlx/image/engine.py
@@ -183,11 +183,15 @@ class ImageGenerationEngine:
         self._run_seq = 0
         self._active_seq = 0
         self._cancel_seq = 0
+        # Guards the three seq counters, which are touched from both the request
+        # thread (``request_cancel``) and the generation worker thread.
+        self._state_lock = threading.Lock()
         self._reporter = _ProgressReporter(self)
 
     def _is_cancelled(self) -> bool:
         """True when the in-flight run has an outstanding cancel request."""
-        return self._active_seq > 0 and self._cancel_seq >= self._active_seq
+        with self._state_lock:
+            return self._active_seq > 0 and self._cancel_seq >= self._active_seq
 
     def _build_model(self):
         """Instantiate the backing mflux model (import-lazy)."""
@@ -258,7 +262,8 @@ class ImageGenerationEngine:
         no-op (``_active_seq == 0``), and one armed while a render is starting is
         preserved because the seq is only advanced under the lock.
         """
-        self._cancel_seq = max(self._cancel_seq, self._active_seq)
+        with self._state_lock:
+            self._cancel_seq = max(self._cancel_seq, self._active_seq)
 
     def progress_snapshot(self) -> dict:
         """A JSON-safe view of the current denoise progress (single-flight)."""
@@ -306,8 +311,9 @@ class ImageGenerationEngine:
             # pressed during the (possibly multi-gigabyte) cold model load is
             # honored — its seq already matches this run — instead of being lost.
             # The lock guarantees single-flight, so one snapshot is unambiguous.
-            self._run_seq += 1
-            self._active_seq = self._run_seq
+            with self._state_lock:
+                self._run_seq += 1
+                self._active_seq = self._run_seq
             # ``running`` stays False through the cold load — the reporter flips
             # it true on the first denoise step — so the client renders the
             # "warming up" phase during load, not a bogus "denoising step 1".
@@ -356,7 +362,8 @@ class ImageGenerationEngine:
                 raise ImageRuntimeError(f"Image generation failed: {exc}") from exc
             finally:
                 self._progress["running"] = False
-                self._active_seq = 0
+                with self._state_lock:
+                    self._active_seq = 0
 
         return self._encode_png(result)
 

--- a/vllm_mlx/middleware/body_size.py
+++ b/vllm_mlx/middleware/body_size.py
@@ -113,6 +113,10 @@ _EXCLUDED_PATHS = frozenset(
         # Multipart video uploads have a dedicated 20 MiB file / 21 MiB
         # request cap plus pre-parse authentication in routes.video.
         "/v1/videos",
+        # Multipart image-edit uploads have a dedicated 25 MB cap enforced
+        # pre-parse by ``routes.images.ImageBodyLimitMiddleware``; the generic
+        # 8 MiB JSON cap would otherwise reject a legitimate large init image.
+        "/v1/images/edits",
     }
 )
 

--- a/vllm_mlx/model_aliases.py
+++ b/vllm_mlx/model_aliases.py
@@ -24,13 +24,15 @@ from .model_profile import Modality, ModelProfile
 # sites keep resolving. See ``model_profile`` for why the class lives
 # there (import-light + avoids the model_auto_config↔model_aliases cycle).
 # Implemented lanes — what ``load_model`` can actually dispatch to today.
-# ``vision`` and ``image-gen`` are RESERVED in the type alias so that
-# routing code can pattern-match on them once their dispatch paths land,
-# but loading an alias that declares one MUST fail loud right now —
-# otherwise an aliases.json typo would pass schema validation and crash
-# at request time with an unrouted lane (pr_validate codex r13 NIT).
-_VALID_MODALITIES: frozenset[str] = frozenset({"text", "text-diffusion", "video-gen"})
-_RESERVED_MODALITIES: frozenset[str] = frozenset({"vision", "image-gen"})
+# ``image-gen`` routes to the mflux image lane (runtime/image_lane.py).
+# ``vision`` stays RESERVED in the type alias so routing code can pattern-match
+# on it once its dispatch path lands, but loading a ``vision`` alias MUST fail
+# loud right now — otherwise an aliases.json typo would pass schema validation
+# and crash at request time with an unrouted lane (pr_validate codex r13 NIT).
+_VALID_MODALITIES: frozenset[str] = frozenset(
+    {"text", "text-diffusion", "video-gen", "image-gen"}
+)
+_RESERVED_MODALITIES: frozenset[str] = frozenset({"vision"})
 
 # Canonical enum for ``suffix_decoding_tier``. Kept here so the contract
 # test (tests/test_aliases_contract.py) and any future loader / CLI

--- a/vllm_mlx/model_profile.py
+++ b/vllm_mlx/model_profile.py
@@ -45,9 +45,10 @@ from typing import Literal
 # (and every external JSON snippet that pre-dates this field) keeps the
 # auto-regressive LLM lane untouched. New modalities branch the runtime
 # at startup — see ``runtime/diffusion_lane.py`` for the discrete
-# text-diffusion path used by DiffusionGemma. ``"vision"`` and
-# ``"image-gen"`` are reserved for forthcoming VLM / image-gen
-# integrations. (A vision-config checkpoint we serve text-only — e.g.
+# text-diffusion path used by DiffusionGemma; ``"image-gen"`` routes to
+# the mflux image lane (``runtime/image_lane.py``). ``"vision"`` is
+# reserved for a forthcoming VLM integration. (A vision-config checkpoint
+# we serve text-only — e.g.
 # Ternary-Bonsai-27B — stays ``modality="text"`` and sets
 # ``is_text_only=True`` instead; it is not a ``"vision"`` alias because
 # we do not serve its vision tower.)
@@ -190,8 +191,10 @@ class ModelProfile:
     # alias and keeps the auto-regressive scheduler/runtime path
     # unchanged. Non-text modalities branch into dedicated lanes:
     # ``"text-diffusion"`` → ``runtime/diffusion_lane.py`` (block
-    # denoising, no spec-decode, no DFlash); ``"vision"`` /
-    # ``"image-gen"`` reserved for upcoming integrations.
+    # denoising, no spec-decode, no DFlash); ``"image-gen"`` →
+    # ``runtime/image_lane.py`` (mflux FLUX / Qwen-Image); ``"video-gen"``
+    # → ``runtime/video_lane.py``; ``"vision"`` reserved for an upcoming
+    # VLM integration.
     modality: Modality = "text"
     # PFlash long-prompt compression eligibility (#287). Default
     # ``"unknown"`` keeps the engine's PFlash mode at ``"off"`` so a

--- a/vllm_mlx/model_sizes.json
+++ b/vllm_mlx/model_sizes.json
@@ -200,7 +200,7 @@
     "Qwen/Qwen-Image": 57704572586,
     "Qwen/Qwen-Image-Edit-2509": 57720451254,
     "dhairyashil/FLUX.1-schnell-mflux-4bit": 9609155321,
-    "mlx-community/Qwen-Image-2512-4bit": 25907120736,
-    "ovedrive/Qwen-Image-Edit-2511-4bit": 16952630925
+    "OsaurusAI/Qwen-Image-mflux-4bit": 25907137020,
+    "OsaurusAI/Qwen-Image-Edit-mflux-q4": 27260308022
   }
 }

--- a/vllm_mlx/model_sizes.json
+++ b/vllm_mlx/model_sizes.json
@@ -196,11 +196,7 @@
     "unsloth/Qwen3.6-27B-UD-MLX-4bit": 26210992727,
     "unsloth/Qwen3.6-27B-UD-MLX-6bit": 30522606211,
     "unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit": 21655301364,
-    "black-forest-labs/FLUX.1-schnell": 57843734078,
-    "Qwen/Qwen-Image": 57704572586,
-    "Qwen/Qwen-Image-Edit-2509": 57720451254,
-    "dhairyashil/FLUX.1-schnell-mflux-4bit": 9609155321,
-    "OsaurusAI/Qwen-Image-mflux-4bit": 25907137020,
-    "OsaurusAI/Qwen-Image-Edit-mflux-q4": 27260308022
+    "Runpod/FLUX.2-klein-4B-mflux-4bit": 4617089843,
+    "filipstrand/Z-Image-Turbo-mflux-4bit": 5905580032
   }
 }

--- a/vllm_mlx/model_sizes.json
+++ b/vllm_mlx/model_sizes.json
@@ -195,6 +195,12 @@
     "unsloth/Qwen3.6-27B-UD-MLX-3bit": 24071897617,
     "unsloth/Qwen3.6-27B-UD-MLX-4bit": 26210992727,
     "unsloth/Qwen3.6-27B-UD-MLX-6bit": 30522606211,
-    "unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit": 21655301364
+    "unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit": 21655301364,
+    "black-forest-labs/FLUX.1-schnell": 57843734078,
+    "Qwen/Qwen-Image": 57704572586,
+    "Qwen/Qwen-Image-Edit-2509": 57720451254,
+    "dhairyashil/FLUX.1-schnell-mflux-4bit": 9609155321,
+    "mlx-community/Qwen-Image-2512-4bit": 25907120736,
+    "ovedrive/Qwen-Image-Edit-2511-4bit": 16952630925
   }
 }

--- a/vllm_mlx/routes/images.py
+++ b/vllm_mlx/routes/images.py
@@ -368,12 +368,14 @@ async def edit_image(
         )
     raw = bytes(raw)
 
-    suffix = os.path.splitext(image.filename or "")[1] or ".png"
+    # A fixed suffix — never the attacker-controlled upload filename, whose
+    # length/bytes could otherwise raise an uncaught OSError from the temp-file
+    # layer. mflux/PIL sniff the real format from content, not the extension.
     base_seed = seed if seed is not None else int(time.time()) & 0x7FFFFFFF
     data = []
     # One temp file for the whole request; the process lock in the engine keeps
     # generations serial, so a shared init image is safe across the n renders.
-    with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as tmp:
+    with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as tmp:
         tmp.write(raw)
         tmp_path = tmp.name
     cancelled = False

--- a/vllm_mlx/routes/images.py
+++ b/vllm_mlx/routes/images.py
@@ -3,6 +3,7 @@
 
 import base64
 import logging
+import math
 import os
 import tempfile
 import time
@@ -63,7 +64,9 @@ def _generate_one(engine, request: ImageGenerationRequest, seed: int) -> bytes:
         prompt=request.prompt,
         width=width,
         height=height,
-        num_inference_steps=request.steps if request.steps is not None else default_steps,
+        num_inference_steps=request.steps
+        if request.steps is not None
+        else default_steps,
         seed=seed,
         # None → each model uses its own trained default guidance (Klein is
         # guidance-distilled; forcing 4.0 washes it out).
@@ -121,7 +124,9 @@ async def create_image(request: ImageGenerationRequest = Body(...)):
 
     # When no seed is pinned, derive one from wall-clock so successive calls
     # vary; multi-image (``n``) requests offset per index off that base.
-    base_seed = request.seed if request.seed is not None else int(time.time()) & 0x7FFFFFFF
+    base_seed = (
+        request.seed if request.seed is not None else int(time.time()) & 0x7FFFFFFF
+    )
 
     from ..image.engine import ImageGenerationCancelled
 
@@ -176,8 +181,24 @@ async def image_cancel():
     return {"ok": True}
 
 
-def _generate_edit_one(engine, prompt, steps, seed, guidance,
-                       negative_prompt, image_path) -> bytes:
+def _reject(condition: bool, message: str, param: str) -> None:
+    """Raise a 400 invalid_request_error when ``condition`` holds."""
+    if condition:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "error": {
+                    "message": message,
+                    "type": "invalid_request_error",
+                    "param": param,
+                }
+            },
+        )
+
+
+def _generate_edit_one(
+    engine, prompt, steps, seed, guidance, negative_prompt, image_path
+) -> bytes:
     """Blocking single instruction-edit render — runs off the event loop.
 
     No width/height is threaded: the edit family sizes its output canvas from
@@ -215,7 +236,7 @@ async def edit_image(
     prompt drive a global instruction edit (no mask). Returns the same
     ``{created, data:[{b64_json}]}`` envelope as generations.
     """
-    from ..image.engine import ImageRuntimeError
+    from ..image.engine import ImageGenerationCancelled, ImageRuntimeError
 
     engine = _image_engine()
 
@@ -241,23 +262,37 @@ async def edit_image(
     if not prompt or not prompt.strip():
         raise HTTPException(
             status_code=400,
-            detail={"error": {"message": "prompt must not be empty",
-                              "type": "invalid_request_error", "param": "prompt"}},
+            detail={
+                "error": {
+                    "message": "prompt must not be empty",
+                    "type": "invalid_request_error",
+                    "param": "prompt",
+                }
+            },
         )
     if response_format == "url":
         raise HTTPException(
             status_code=400,
-            detail={"error": {"message": "The local image lane only returns base64 "
-                              "data; request response_format='b64_json'.",
-                              "type": "invalid_request_error",
-                              "code": "unsupported_response_format",
-                              "param": "response_format"}},
+            detail={
+                "error": {
+                    "message": "The local image lane only returns base64 "
+                    "data; request response_format='b64_json'.",
+                    "type": "invalid_request_error",
+                    "code": "unsupported_response_format",
+                    "param": "response_format",
+                }
+            },
         )
     if not 1 <= n <= 4:
         raise HTTPException(
             status_code=400,
-            detail={"error": {"message": "n must be between 1 and 4",
-                              "type": "invalid_request_error", "param": "n"}},
+            detail={
+                "error": {
+                    "message": "n must be between 1 and 4",
+                    "type": "invalid_request_error",
+                    "param": "n",
+                }
+            },
         )
     # ``size`` is accepted for OpenAI-API compatibility but the edit family
     # derives its output canvas from the input image; a mismatched target size
@@ -269,24 +304,69 @@ async def edit_image(
     except ValueError as exc:
         raise HTTPException(
             status_code=400,
-            detail={"error": {"message": str(exc),
-                              "type": "invalid_request_error", "param": "size"}},
+            detail={
+                "error": {
+                    "message": str(exc),
+                    "type": "invalid_request_error",
+                    "param": "size",
+                }
+            },
         ) from exc
 
-    raw = await image.read()
+    # A raw multipart form bypasses the validated bounds ``ImageGenerationRequest``
+    # enforces on the JSON path, so a negative seed, non-finite guidance, or an
+    # enormous step count could otherwise reach — and monopolize/crash — the
+    # inference server. Validate the numeric knobs to the same bounds here.
+    _reject(
+        steps is not None and not (1 <= steps <= 100),
+        "steps must be between 1 and 100",
+        "steps",
+    )
+    _reject(
+        guidance is not None
+        and not (math.isfinite(guidance) and 0.0 <= guidance <= 20.0),
+        "guidance must be a finite number between 0 and 20",
+        "guidance",
+    )
+    _reject(
+        seed is not None and not (0 <= seed <= 0x7FFFFFFF),
+        "seed must be between 0 and 2147483647",
+        "seed",
+    )
+
+    # Bounded, streaming read: abort as soon as the cumulative size exceeds the
+    # cap rather than materializing the whole (possibly huge) upload first —
+    # otherwise an unauthenticated oversized multipart request exhausts memory.
+    raw = bytearray()
+    while True:
+        chunk = await image.read(1024 * 1024)
+        if not chunk:
+            break
+        raw.extend(chunk)
+        if len(raw) > _MAX_EDIT_IMAGE_BYTES:
+            raise HTTPException(
+                status_code=413,
+                detail={
+                    "error": {
+                        "message": f"image exceeds "
+                        f"{_MAX_EDIT_IMAGE_BYTES // (1024 * 1024)} MB limit",
+                        "type": "invalid_request_error",
+                        "param": "image",
+                    }
+                },
+            )
     if not raw:
         raise HTTPException(
             status_code=400,
-            detail={"error": {"message": "image file is empty",
-                              "type": "invalid_request_error", "param": "image"}},
+            detail={
+                "error": {
+                    "message": "image file is empty",
+                    "type": "invalid_request_error",
+                    "param": "image",
+                }
+            },
         )
-    if len(raw) > _MAX_EDIT_IMAGE_BYTES:
-        raise HTTPException(
-            status_code=413,
-            detail={"error": {"message": f"image exceeds "
-                              f"{_MAX_EDIT_IMAGE_BYTES // (1024 * 1024)} MB limit",
-                              "type": "invalid_request_error", "param": "image"}},
-        )
+    raw = bytes(raw)
 
     suffix = os.path.splitext(image.filename or "")[1] or ".png"
     base_seed = seed if seed is not None else int(time.time()) & 0x7FFFFFFF
@@ -296,19 +376,35 @@ async def edit_image(
     with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as tmp:
         tmp.write(raw)
         tmp_path = tmp.name
+    cancelled = False
     try:
         for index in range(n):
             try:
                 png_bytes = await run_to_completion(
-                    _generate_edit_one, engine, prompt, steps,
-                    base_seed + index, guidance, negative_prompt, tmp_path,
+                    _generate_edit_one,
+                    engine,
+                    prompt,
+                    steps,
+                    base_seed + index,
+                    guidance,
+                    negative_prompt,
+                    tmp_path,
                 )
+            except ImageGenerationCancelled:
+                # A mid-render cancel is a success, not a 500: return whatever
+                # finished (matching the generations envelope), never an error.
+                cancelled = True
+                break
             except ImageRuntimeError as exc:
                 raise HTTPException(
                     status_code=500,
-                    detail={"error": {"message": str(exc),
-                                      "type": "image_generation_error",
-                                      "code": "image_generation_failed"}},
+                    detail={
+                        "error": {
+                            "message": str(exc),
+                            "type": "image_generation_error",
+                            "code": "image_generation_failed",
+                        }
+                    },
                 ) from exc
             data.append({"b64_json": base64.b64encode(png_bytes).decode("ascii")})
     finally:
@@ -317,4 +413,4 @@ async def edit_image(
         except OSError:
             pass
 
-    return {"created": int(time.time()), "data": data}
+    return {"created": int(time.time()), "data": data, "cancelled": cancelled}

--- a/vllm_mlx/routes/images.py
+++ b/vllm_mlx/routes/images.py
@@ -5,6 +5,7 @@ import base64
 import logging
 import math
 import os
+import secrets
 import tempfile
 import time
 
@@ -34,8 +35,8 @@ def _image_engine():
     """Return the loaded image engine or raise a 409 if this isn't an image server."""
     from ..config import get_config
 
-    engine = get_config().engine
-    if engine is None or not getattr(engine, "is_image_gen", False):
+    img_engine = get_config().engine
+    if img_engine is None or not getattr(img_engine, "is_image_gen", False):
         raise HTTPException(
             status_code=409,
             detail={
@@ -50,17 +51,17 @@ def _image_engine():
                 }
             },
         )
-    return engine
+    return img_engine
 
 
-def _generate_one(engine, request: ImageGenerationRequest, seed: int) -> bytes:
+def _generate_one(img_engine, request: ImageGenerationRequest, seed: int) -> bytes:
     """Blocking single-image render — runs off the event loop."""
     width, height = request.dimensions()
     # Step count is family-aware: a distilled model (Klein/schnell, 4 steps)
     # would waste wall-clock at 20 and a non-distilled one (Qwen, 20) would be
     # noise at 4. The engine advertises the right default per family.
-    default_steps = getattr(engine, "default_steps", 4)
-    return engine.generate(
+    default_steps = getattr(img_engine, "default_steps", 4)
+    return img_engine.generate(
         prompt=request.prompt,
         width=width,
         height=height,
@@ -85,12 +86,12 @@ async def create_image(request: ImageGenerationRequest = Body(...)):
     """
     from ..image.engine import ImageRuntimeError
 
-    engine = _image_engine()
+    img_engine = _image_engine()
 
     # A single server hosts exactly one image model. When that model is the
     # instruction-edit family, text-to-image generation is the wrong endpoint —
     # 409 toward /v1/images/edits instead of silently ignoring the mismatch.
-    if getattr(engine, "is_edit", False):
+    if getattr(img_engine, "is_edit", False):
         raise HTTPException(
             status_code=409,
             detail={
@@ -122,11 +123,10 @@ async def create_image(request: ImageGenerationRequest = Body(...)):
             },
         )
 
-    # When no seed is pinned, derive one from wall-clock so successive calls
-    # vary; multi-image (``n``) requests offset per index off that base.
-    base_seed = (
-        request.seed if request.seed is not None else int(time.time()) & 0x7FFFFFFF
-    )
+    # When no seed is pinned, draw a random one so successive calls vary — even
+    # two unseeded requests within the same wall-clock second. Multi-image
+    # (``n``) requests offset per index off that base.
+    base_seed = request.seed if request.seed is not None else secrets.randbelow(2**31)
 
     from ..image.engine import ImageGenerationCancelled
 
@@ -135,7 +135,7 @@ async def create_image(request: ImageGenerationRequest = Body(...)):
     for index in range(request.n):
         try:
             png_bytes = await run_to_completion(
-                _generate_one, engine, request, base_seed + index
+                _generate_one, img_engine, request, base_seed + index
             )
         except ImageGenerationCancelled:
             # User stopped mid-render: return whatever finished rather than an
@@ -167,17 +167,22 @@ async def image_progress():
     streaming parser, and honest on slow hardware (the bar can't outrun the
     real steps). Single-flight: the server renders one image at a time.
     """
-    engine = _image_engine()
-    snap = engine.progress_snapshot() if hasattr(engine, "progress_snapshot") else {}
-    return snap
+    img_engine = _image_engine()
+    return img_engine.progress_snapshot()
 
 
 @router.post("/v1/images/cancel")
 async def image_cancel():
-    """Ask the in-flight render to stop at the next denoise step."""
-    engine = _image_engine()
-    if hasattr(engine, "request_cancel"):
-        engine.request_cancel()
+    """Ask the in-flight render to stop at the next denoise step.
+
+    By design the image lane is **single-flight**: the engine's process lock
+    serialises one render at a time, so progress and cancel are intentionally
+    process-global — they refer to the one active render. This is a local,
+    single-user server (the desktop app issues one generation at a time), so
+    there is deliberately no per-request generation id to thread through.
+    """
+    img_engine = _image_engine()
+    img_engine.request_cancel()
     return {"ok": True}
 
 
@@ -197,16 +202,16 @@ def _reject(condition: bool, message: str, param: str) -> None:
 
 
 def _generate_edit_one(
-    engine, prompt, steps, seed, guidance, negative_prompt, image_path
+    img_engine, prompt, steps, seed, guidance, negative_prompt, image_path
 ) -> bytes:
     """Blocking single instruction-edit render — runs off the event loop.
 
     No width/height is threaded: the edit family sizes its output canvas from
-    the input image (the engine passes ``None`` to mflux). Forcing a mismatched
+    the input image (the img_engine passes ``None`` to mflux). Forcing a mismatched
     size desyncs the conditioning latents and yields pure noise, so the request
     ``size`` is accepted for OpenAI-API shape but deliberately not honored.
     """
-    return engine.generate(
+    return img_engine.generate(
         prompt=prompt,
         num_inference_steps=steps if steps is not None else _DEFAULT_EDIT_STEPS,
         seed=seed,
@@ -238,11 +243,11 @@ async def edit_image(
     """
     from ..image.engine import ImageGenerationCancelled, ImageRuntimeError
 
-    engine = _image_engine()
+    img_engine = _image_engine()
 
     # /v1/images/edits requires the edit family; a txt2img server points the
     # caller at /v1/images/generations instead of silently ignoring the image.
-    if not getattr(engine, "is_edit", False):
+    if not getattr(img_engine, "is_edit", False):
         raise HTTPException(
             status_code=409,
             detail={
@@ -270,7 +275,9 @@ async def edit_image(
                 }
             },
         )
-    if response_format == "url":
+    if response_format != "b64_json":
+        # Reject any non-b64_json value (not just "url"), matching the validated
+        # generations contract — the local lane has no object store for URLs.
         raise HTTPException(
             status_code=400,
             detail={
@@ -298,7 +305,7 @@ async def edit_image(
     # derives its output canvas from the input image; a mismatched target size
     # desyncs mflux's conditioning latents into pure noise. We still validate
     # the value so a malformed ``size`` fails loud rather than being silently
-    # dropped, then discard it — the engine sizes the render from the image.
+    # dropped, then discard it — the img_engine sizes the render from the image.
     try:
         parse_image_size(size)
     except ValueError as exc:
@@ -373,10 +380,10 @@ async def edit_image(
     # A fixed suffix — never the attacker-controlled upload filename, whose
     # length/bytes could otherwise raise an uncaught OSError from the temp-file
     # layer. mflux/PIL sniff the real format from content, not the extension.
-    base_seed = seed if seed is not None else int(time.time()) & 0x7FFFFFFF
+    base_seed = seed if seed is not None else secrets.randbelow(2**31)
     data = []
     cancelled = False
-    # One temp file for the whole request; the process lock in the engine keeps
+    # One temp file for the whole request; the process lock in the img_engine keeps
     # generations serial, so a shared init image is safe across the n renders.
     # Creation + write live inside the try so a partial-write / close failure
     # can't leak the file — ``tmp_path`` is captured before the write, and the
@@ -390,7 +397,7 @@ async def edit_image(
             try:
                 png_bytes = await run_to_completion(
                     _generate_edit_one,
-                    engine,
+                    img_engine,
                     prompt,
                     steps,
                     base_seed + index,

--- a/vllm_mlx/routes/images.py
+++ b/vllm_mlx/routes/images.py
@@ -65,7 +65,9 @@ def _generate_one(engine, request: ImageGenerationRequest, seed: int) -> bytes:
         height=height,
         num_inference_steps=request.steps if request.steps is not None else default_steps,
         seed=seed,
-        guidance=request.guidance if request.guidance is not None else 4.0,
+        # None → each model uses its own trained default guidance (Klein is
+        # guidance-distilled; forcing 4.0 washes it out).
+        guidance=request.guidance,
         negative_prompt=request.negative_prompt,
     )
 

--- a/vllm_mlx/routes/images.py
+++ b/vllm_mlx/routes/images.py
@@ -121,12 +121,20 @@ async def create_image(request: ImageGenerationRequest = Body(...)):
     # vary; multi-image (``n``) requests offset per index off that base.
     base_seed = request.seed if request.seed is not None else int(time.time()) & 0x7FFFFFFF
 
+    from ..image.engine import ImageGenerationCancelled
+
     data = []
+    cancelled = False
     for index in range(request.n):
         try:
             png_bytes = await run_to_completion(
                 _generate_one, engine, request, base_seed + index
             )
+        except ImageGenerationCancelled:
+            # User stopped mid-render: return whatever finished rather than an
+            # error, so a cancelled multi-image batch keeps its earlier images.
+            cancelled = True
+            break
         except ImageRuntimeError as exc:
             raise HTTPException(
                 status_code=500,
@@ -140,7 +148,30 @@ async def create_image(request: ImageGenerationRequest = Body(...)):
             ) from exc
         data.append({"b64_json": base64.b64encode(png_bytes).decode("ascii")})
 
-    return {"created": int(time.time()), "data": data}
+    return {"created": int(time.time()), "data": data, "cancelled": cancelled}
+
+
+@router.get("/v1/images/progress")
+async def image_progress():
+    """Live denoise progress for the single in-flight render.
+
+    Diffusion has a fixed step count, so this is a *true* ``step / total``
+    signal the client polls to drive a determinate progress bar and ETA — no
+    streaming parser, and honest on slow hardware (the bar can't outrun the
+    real steps). Single-flight: the server renders one image at a time.
+    """
+    engine = _image_engine()
+    snap = engine.progress_snapshot() if hasattr(engine, "progress_snapshot") else {}
+    return snap
+
+
+@router.post("/v1/images/cancel")
+async def image_cancel():
+    """Ask the in-flight render to stop at the next denoise step."""
+    engine = _image_engine()
+    if hasattr(engine, "request_cancel"):
+        engine.request_cancel()
+    return {"ok": True}
 
 
 def _generate_edit_one(engine, prompt, steps, seed, guidance,

--- a/vllm_mlx/routes/images.py
+++ b/vllm_mlx/routes/images.py
@@ -55,11 +55,15 @@ def _image_engine():
 def _generate_one(engine, request: ImageGenerationRequest, seed: int) -> bytes:
     """Blocking single-image render — runs off the event loop."""
     width, height = request.dimensions()
+    # Step count is family-aware: a distilled model (Klein/schnell, 4 steps)
+    # would waste wall-clock at 20 and a non-distilled one (Qwen, 20) would be
+    # noise at 4. The engine advertises the right default per family.
+    default_steps = getattr(engine, "default_steps", 4)
     return engine.generate(
         prompt=request.prompt,
         width=width,
         height=height,
-        num_inference_steps=request.steps if request.steps is not None else 4,
+        num_inference_steps=request.steps if request.steps is not None else default_steps,
         seed=seed,
         guidance=request.guidance if request.guidance is not None else 4.0,
         negative_prompt=request.negative_prompt,

--- a/vllm_mlx/routes/images.py
+++ b/vllm_mlx/routes/images.py
@@ -10,6 +10,7 @@ import tempfile
 import time
 
 from fastapi import APIRouter, Body, File, Form, HTTPException, UploadFile
+from starlette.responses import JSONResponse
 
 from ..api.models import ImageGenerationRequest, parse_image_size
 from ._async_utils import run_to_completion
@@ -21,6 +22,108 @@ router = APIRouter()
 # Cap the uploaded init image so a single edit request can't buffer an
 # unbounded body into memory before the size validators run.
 _MAX_EDIT_IMAGE_BYTES = 25 * 1024 * 1024
+# Whole-request cap for the middleware (init image + a little multipart framing
+# slack), enforced BEFORE FastAPI spools the body to disk.
+_IMAGE_EDIT_REQUEST_BYTES = _MAX_EDIT_IMAGE_BYTES + 1024 * 1024
+_OVERSIZE_DETAIL = "image edit request body exceeds the 25 MB limit"
+
+
+class _ImageBodyTooLargeError(Exception):
+    """Signals the bounded receive tripped the body cap mid-stream."""
+
+
+class ImageBodyLimitMiddleware:
+    """Cap /v1/images/edits multipart bodies before FastAPI spools them.
+
+    FastAPI resolves the ``UploadFile``/``Form`` params by parsing (and
+    spooling) the whole multipart body before the endpoint runs, so an
+    in-handler size check is too late to stop an oversized upload from
+    consuming disk. This ASGI middleware rejects on the advertised
+    Content-Length and, absent that, caps the streamed bytes — mirroring the
+    video lane's ``VideoBodyLimitMiddleware``.
+    """
+
+    def __init__(self, app) -> None:
+        self.app = app
+
+    async def __call__(self, scope, receive, send):
+        if (
+            scope.get("type") != "http"
+            or scope.get("method") != "POST"
+            or scope.get("path") != "/v1/images/edits"
+        ):
+            return await self.app(scope, receive, send)
+
+        headers = {name.lower(): value for name, value in scope.get("headers", ())}
+        advertised = headers.get(b"content-length")
+        if advertised is not None:
+            try:
+                advertised_bytes = int(advertised.decode("ascii"))
+            except (UnicodeDecodeError, ValueError):
+                advertised_bytes = None
+            if (
+                advertised_bytes is not None
+                and advertised_bytes > _IMAGE_EDIT_REQUEST_BYTES
+            ):
+                response = JSONResponse(
+                    status_code=413, content={"detail": _OVERSIZE_DETAIL}
+                )
+                return await response(scope, receive, send)
+
+        total = 0
+        limit_tripped = False
+        replacement_sent = False
+        downstream_started = False
+        downstream_completed = False
+
+        async def bounded_receive():
+            nonlocal total, limit_tripped
+            message = await receive()
+            if message.get("type") == "http.request":
+                total += len(message.get("body", b"") or b"")
+                if total > _IMAGE_EDIT_REQUEST_BYTES:
+                    limit_tripped = True
+                    raise _ImageBodyTooLargeError
+            return message
+
+        async def guarded_send(message):
+            nonlocal replacement_sent, downstream_started, downstream_completed
+            if limit_tripped:
+                if not downstream_started and not replacement_sent:
+                    response = JSONResponse(
+                        status_code=413, content={"detail": _OVERSIZE_DETAIL}
+                    )
+                    await response(scope, receive, send)
+                    replacement_sent = True
+                return
+            message_type = message.get("type")
+            if message_type == "http.response.start":
+                downstream_started = True
+            elif message_type == "http.response.body" and not message.get(
+                "more_body", False
+            ):
+                downstream_completed = True
+            await send(message)
+
+        try:
+            await self.app(scope, bounded_receive, guarded_send)
+        except _ImageBodyTooLargeError:
+            if replacement_sent or downstream_completed:
+                return
+            if downstream_started:
+                await send(
+                    {"type": "http.response.body", "body": b"", "more_body": False}
+                )
+                return
+            response = JSONResponse(
+                status_code=413, content={"detail": _OVERSIZE_DETAIL}
+            )
+            await response(scope, receive, send)
+
+
+def install_image_body_limit_middleware(app) -> None:
+    app.add_middleware(ImageBodyLimitMiddleware)
+
 
 # Default denoise steps for an instruction edit. Qwen-Image-Edit is a large,
 # non-distilled model (unlike the 4-step FLUX.1-schnell generator): its edit

--- a/vllm_mlx/routes/images.py
+++ b/vllm_mlx/routes/images.py
@@ -1,0 +1,125 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Image generation endpoints (OpenAI ``/v1/images/*`` compatible)."""
+
+import base64
+import logging
+import time
+
+from fastapi import APIRouter, Body, HTTPException
+
+from ..api.models import ImageGenerationRequest
+from ._async_utils import run_to_completion
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+def _image_engine():
+    """Return the loaded image engine or raise a 409 if this isn't an image server."""
+    from ..config import get_config
+
+    engine = get_config().engine
+    if engine is None or not getattr(engine, "is_image_gen", False):
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "error": {
+                    "message": (
+                        "This server is not running an image model. Start it with "
+                        "`rapid-mlx serve flux-schnell` (or another image alias)."
+                    ),
+                    "type": "invalid_request_error",
+                    "code": "image_model_not_loaded",
+                    "param": "model",
+                }
+            },
+        )
+    return engine
+
+
+def _generate_one(engine, request: ImageGenerationRequest, seed: int) -> bytes:
+    """Blocking single-image render — runs off the event loop."""
+    width, height = request.dimensions()
+    return engine.generate(
+        prompt=request.prompt,
+        width=width,
+        height=height,
+        num_inference_steps=request.steps if request.steps is not None else 4,
+        seed=seed,
+        guidance=request.guidance if request.guidance is not None else 4.0,
+        negative_prompt=request.negative_prompt,
+    )
+
+
+@router.post("/v1/images/generations")
+async def create_image(request: ImageGenerationRequest = Body(...)):
+    """Generate one or more images from a text prompt.
+
+    Returns the OpenAI ``{created, data:[{b64_json}]}`` envelope. ``url``
+    responses are not offered by the local lane (there is no object store to
+    host the bytes) — callers must request ``b64_json``.
+    """
+    from ..image.engine import ImageRuntimeError
+
+    engine = _image_engine()
+
+    # A single server hosts exactly one image model. When that model is the
+    # instruction-edit family, text-to-image generation is the wrong endpoint —
+    # 409 toward /v1/images/edits instead of silently ignoring the mismatch.
+    if getattr(engine, "is_edit", False):
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "error": {
+                    "message": (
+                        "This server is running an image-edit model; use "
+                        "/v1/images/edits with an input image."
+                    ),
+                    "type": "invalid_request_error",
+                    "code": "wrong_image_endpoint",
+                    "param": "model",
+                }
+            },
+        )
+
+    if request.response_format == "url":
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "error": {
+                    "message": (
+                        "The local image lane only returns base64 data; request "
+                        "response_format='b64_json'."
+                    ),
+                    "type": "invalid_request_error",
+                    "code": "unsupported_response_format",
+                    "param": "response_format",
+                }
+            },
+        )
+
+    # When no seed is pinned, derive one from wall-clock so successive calls
+    # vary; multi-image (``n``) requests offset per index off that base.
+    base_seed = request.seed if request.seed is not None else int(time.time()) & 0x7FFFFFFF
+
+    data = []
+    for index in range(request.n):
+        try:
+            png_bytes = await run_to_completion(
+                _generate_one, engine, request, base_seed + index
+            )
+        except ImageRuntimeError as exc:
+            raise HTTPException(
+                status_code=500,
+                detail={
+                    "error": {
+                        "message": str(exc),
+                        "type": "image_generation_error",
+                        "code": "image_generation_failed",
+                    }
+                },
+            ) from exc
+        data.append({"b64_json": base64.b64encode(png_bytes).decode("ascii")})
+
+    return {"created": int(time.time()), "data": data}

--- a/vllm_mlx/routes/images.py
+++ b/vllm_mlx/routes/images.py
@@ -135,7 +135,7 @@ async def create_image(request: ImageGenerationRequest = Body(...)):
     for index in range(request.n):
         try:
             png_bytes = await run_to_completion(
-                _generate_one, img_engine, request, base_seed + index
+                _generate_one, img_engine, request, (base_seed + index) & 0x7FFFFFFF
             )
         except ImageGenerationCancelled:
             # User stopped mid-render: return whatever finished rather than an
@@ -400,7 +400,7 @@ async def edit_image(
                     img_engine,
                     prompt,
                     steps,
-                    base_seed + index,
+                    (base_seed + index) & 0x7FFFFFFF,
                     guidance,
                     negative_prompt,
                     tmp_path,
@@ -426,7 +426,14 @@ async def edit_image(
         if tmp_path is not None:
             try:
                 os.unlink(tmp_path)
-            except OSError:
-                pass
+            except OSError as exc:
+                # Don't fail the response on cleanup, but don't swallow it
+                # silently either — a leaked upload in the temp dir is worth a
+                # log line (the basename only, not the full path).
+                logger.warning(
+                    "failed to remove temp edit image %s: %s",
+                    os.path.basename(tmp_path),
+                    exc,
+                )
 
     return {"created": int(time.time()), "data": data, "cancelled": cancelled}

--- a/vllm_mlx/routes/images.py
+++ b/vllm_mlx/routes/images.py
@@ -317,9 +317,11 @@ async def edit_image(
     # enforces on the JSON path, so a negative seed, non-finite guidance, or an
     # enormous step count could otherwise reach — and monopolize/crash — the
     # inference server. Validate the numeric knobs to the same bounds here.
+    # 1..50 matches the JSON generations contract (ImageGenerationRequest:
+    # ge=1, le=50) so an edit can't run for twice the documented maximum.
     _reject(
-        steps is not None and not (1 <= steps <= 100),
-        "steps must be between 1 and 100",
+        steps is not None and not (1 <= steps <= 50),
+        "steps must be between 1 and 50",
         "steps",
     )
     _reject(
@@ -373,13 +375,17 @@ async def edit_image(
     # layer. mflux/PIL sniff the real format from content, not the extension.
     base_seed = seed if seed is not None else int(time.time()) & 0x7FFFFFFF
     data = []
+    cancelled = False
     # One temp file for the whole request; the process lock in the engine keeps
     # generations serial, so a shared init image is safe across the n renders.
-    with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as tmp:
-        tmp.write(raw)
-        tmp_path = tmp.name
-    cancelled = False
+    # Creation + write live inside the try so a partial-write / close failure
+    # can't leak the file — ``tmp_path`` is captured before the write, and the
+    # finally unlinks whatever path was created on every exit.
+    tmp_path: str | None = None
     try:
+        with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as tmp:
+            tmp_path = tmp.name
+            tmp.write(raw)
         for index in range(n):
             try:
                 png_bytes = await run_to_completion(
@@ -410,9 +416,10 @@ async def edit_image(
                 ) from exc
             data.append({"b64_json": base64.b64encode(png_bytes).decode("ascii")})
     finally:
-        try:
-            os.unlink(tmp_path)
-        except OSError:
-            pass
+        if tmp_path is not None:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
 
     return {"created": int(time.time()), "data": data, "cancelled": cancelled}

--- a/vllm_mlx/routes/images.py
+++ b/vllm_mlx/routes/images.py
@@ -20,6 +20,14 @@ router = APIRouter()
 # unbounded body into memory before the size validators run.
 _MAX_EDIT_IMAGE_BYTES = 25 * 1024 * 1024
 
+# Default denoise steps for an instruction edit. Qwen-Image-Edit is a large,
+# non-distilled model (unlike the 4-step FLUX.1-schnell generator): its edit
+# structure needs ~20 steps to resolve, and — because output quality on the
+# 4-bit checkpoints is bounded by the quantized VAE rather than by step count —
+# pushing past this only costs wall-clock (≈1 min/step at the derived 1024²
+# canvas) without a visible gain. Callers can override via ``steps``.
+_DEFAULT_EDIT_STEPS = 20
+
 
 def _image_engine():
     """Return the loaded image engine or raise a 409 if this isn't an image server."""
@@ -131,14 +139,18 @@ async def create_image(request: ImageGenerationRequest = Body(...)):
     return {"created": int(time.time()), "data": data}
 
 
-def _generate_edit_one(engine, prompt, width, height, steps, seed, guidance,
+def _generate_edit_one(engine, prompt, steps, seed, guidance,
                        negative_prompt, image_path) -> bytes:
-    """Blocking single instruction-edit render — runs off the event loop."""
+    """Blocking single instruction-edit render — runs off the event loop.
+
+    No width/height is threaded: the edit family sizes its output canvas from
+    the input image (the engine passes ``None`` to mflux). Forcing a mismatched
+    size desyncs the conditioning latents and yields pure noise, so the request
+    ``size`` is accepted for OpenAI-API shape but deliberately not honored.
+    """
     return engine.generate(
         prompt=prompt,
-        width=width,
-        height=height,
-        num_inference_steps=steps if steps is not None else 4,
+        num_inference_steps=steps if steps is not None else _DEFAULT_EDIT_STEPS,
         seed=seed,
         guidance=guidance if guidance is not None else 4.0,
         negative_prompt=negative_prompt,
@@ -210,8 +222,13 @@ async def edit_image(
             detail={"error": {"message": "n must be between 1 and 4",
                               "type": "invalid_request_error", "param": "n"}},
         )
+    # ``size`` is accepted for OpenAI-API compatibility but the edit family
+    # derives its output canvas from the input image; a mismatched target size
+    # desyncs mflux's conditioning latents into pure noise. We still validate
+    # the value so a malformed ``size`` fails loud rather than being silently
+    # dropped, then discard it — the engine sizes the render from the image.
     try:
-        width, height = parse_image_size(size)
+        parse_image_size(size)
     except ValueError as exc:
         raise HTTPException(
             status_code=400,
@@ -246,7 +263,7 @@ async def edit_image(
         for index in range(n):
             try:
                 png_bytes = await run_to_completion(
-                    _generate_edit_one, engine, prompt, width, height, steps,
+                    _generate_edit_one, engine, prompt, steps,
                     base_seed + index, guidance, negative_prompt, tmp_path,
                 )
             except ImageRuntimeError as exc:

--- a/vllm_mlx/routes/images.py
+++ b/vllm_mlx/routes/images.py
@@ -3,16 +3,22 @@
 
 import base64
 import logging
+import os
+import tempfile
 import time
 
-from fastapi import APIRouter, Body, HTTPException
+from fastapi import APIRouter, Body, File, Form, HTTPException, UploadFile
 
-from ..api.models import ImageGenerationRequest
+from ..api.models import ImageGenerationRequest, parse_image_size
 from ._async_utils import run_to_completion
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+
+# Cap the uploaded init image so a single edit request can't buffer an
+# unbounded body into memory before the size validators run.
+_MAX_EDIT_IMAGE_BYTES = 25 * 1024 * 1024
 
 
 def _image_engine():
@@ -121,5 +127,140 @@ async def create_image(request: ImageGenerationRequest = Body(...)):
                 },
             ) from exc
         data.append({"b64_json": base64.b64encode(png_bytes).decode("ascii")})
+
+    return {"created": int(time.time()), "data": data}
+
+
+def _generate_edit_one(engine, prompt, width, height, steps, seed, guidance,
+                       negative_prompt, image_path) -> bytes:
+    """Blocking single instruction-edit render — runs off the event loop."""
+    return engine.generate(
+        prompt=prompt,
+        width=width,
+        height=height,
+        num_inference_steps=steps if steps is not None else 4,
+        seed=seed,
+        guidance=guidance if guidance is not None else 4.0,
+        negative_prompt=negative_prompt,
+        image_paths=[image_path],
+    )
+
+
+@router.post("/v1/images/edits")
+async def edit_image(
+    image: UploadFile = File(...),
+    prompt: str = Form(...),
+    model: str = Form(""),
+    n: int = Form(1),
+    size: str = Form("1024x1024"),
+    response_format: str = Form("b64_json"),
+    seed: int | None = Form(None),
+    steps: int | None = Form(None),
+    guidance: float | None = Form(None),
+    negative_prompt: str | None = Form(None),
+):
+    """Instruction-edit an input image (OpenAI ``/v1/images/edits`` compatible).
+
+    Requires a server running an image-**edit** model (e.g.
+    ``rapid-mlx serve qwen-image-edit-4bit``); the uploaded image plus the
+    prompt drive a global instruction edit (no mask). Returns the same
+    ``{created, data:[{b64_json}]}`` envelope as generations.
+    """
+    from ..image.engine import ImageRuntimeError
+
+    engine = _image_engine()
+
+    # /v1/images/edits requires the edit family; a txt2img server points the
+    # caller at /v1/images/generations instead of silently ignoring the image.
+    if not getattr(engine, "is_edit", False):
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "error": {
+                    "message": (
+                        "This server is running a text-to-image model; use "
+                        "/v1/images/generations, or start an image-edit model "
+                        "(e.g. `rapid-mlx serve qwen-image-edit-4bit`)."
+                    ),
+                    "type": "invalid_request_error",
+                    "code": "wrong_image_endpoint",
+                    "param": "model",
+                }
+            },
+        )
+
+    if not prompt or not prompt.strip():
+        raise HTTPException(
+            status_code=400,
+            detail={"error": {"message": "prompt must not be empty",
+                              "type": "invalid_request_error", "param": "prompt"}},
+        )
+    if response_format == "url":
+        raise HTTPException(
+            status_code=400,
+            detail={"error": {"message": "The local image lane only returns base64 "
+                              "data; request response_format='b64_json'.",
+                              "type": "invalid_request_error",
+                              "code": "unsupported_response_format",
+                              "param": "response_format"}},
+        )
+    if not 1 <= n <= 4:
+        raise HTTPException(
+            status_code=400,
+            detail={"error": {"message": "n must be between 1 and 4",
+                              "type": "invalid_request_error", "param": "n"}},
+        )
+    try:
+        width, height = parse_image_size(size)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=400,
+            detail={"error": {"message": str(exc),
+                              "type": "invalid_request_error", "param": "size"}},
+        ) from exc
+
+    raw = await image.read()
+    if not raw:
+        raise HTTPException(
+            status_code=400,
+            detail={"error": {"message": "image file is empty",
+                              "type": "invalid_request_error", "param": "image"}},
+        )
+    if len(raw) > _MAX_EDIT_IMAGE_BYTES:
+        raise HTTPException(
+            status_code=413,
+            detail={"error": {"message": f"image exceeds "
+                              f"{_MAX_EDIT_IMAGE_BYTES // (1024 * 1024)} MB limit",
+                              "type": "invalid_request_error", "param": "image"}},
+        )
+
+    suffix = os.path.splitext(image.filename or "")[1] or ".png"
+    base_seed = seed if seed is not None else int(time.time()) & 0x7FFFFFFF
+    data = []
+    # One temp file for the whole request; the process lock in the engine keeps
+    # generations serial, so a shared init image is safe across the n renders.
+    with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as tmp:
+        tmp.write(raw)
+        tmp_path = tmp.name
+    try:
+        for index in range(n):
+            try:
+                png_bytes = await run_to_completion(
+                    _generate_edit_one, engine, prompt, width, height, steps,
+                    base_seed + index, guidance, negative_prompt, tmp_path,
+                )
+            except ImageRuntimeError as exc:
+                raise HTTPException(
+                    status_code=500,
+                    detail={"error": {"message": str(exc),
+                                      "type": "image_generation_error",
+                                      "code": "image_generation_failed"}},
+                ) from exc
+            data.append({"b64_json": base64.b64encode(png_bytes).decode("ascii")})
+    finally:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
 
     return {"created": int(time.time()), "data": data}

--- a/vllm_mlx/routes/models.py
+++ b/vllm_mlx/routes/models.py
@@ -410,6 +410,9 @@ def _detect_capabilities(
     if profile_modality == "video-gen":
         return ["video.generation"]
 
+    if profile_modality == "image-gen":
+        return ["image.generation"]
+
     caps: list[str] = ["text"]
     if _is_vlm(model_id, profile_modality, is_text_only):
         caps.append("vision")

--- a/vllm_mlx/runtime/image_lane.py
+++ b/vllm_mlx/runtime/image_lane.py
@@ -60,6 +60,11 @@ class ImageEngine:
     def family(self) -> str:
         return self._engine.family
 
+    @property
+    def default_steps(self) -> int:
+        """Per-family default denoise steps when the request pins none."""
+        return self._engine.default_steps
+
     def generate(
         self,
         *,

--- a/vllm_mlx/runtime/image_lane.py
+++ b/vllm_mlx/runtime/image_lane.py
@@ -90,7 +90,7 @@ class ImageEngine:
         height: int = 1024,
         num_inference_steps: int = 4,
         seed: int = 0,
-        guidance: float = 4.0,
+        guidance: float | None = None,
         negative_prompt: str | None = None,
         image_paths: list[str] | None = None,
     ) -> bytes:

--- a/vllm_mlx/runtime/image_lane.py
+++ b/vllm_mlx/runtime/image_lane.py
@@ -1,0 +1,92 @@
+# SPDX-License-Identifier: Apache-2.0
+"""MLX-native text-to-image / image-edit generation lane (mflux backend).
+
+Mirrors the video lane's split: this module is the thin, duck-typed engine
+adapter that ``server.load_model`` dispatches to for ``modality=image-gen``
+aliases; ``vllm_mlx/image/engine.py`` owns the mflux pipeline and the
+``vllm_mlx/routes/images.py`` router owns the OpenAI-compatible transport.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+
+from ..image.engine import ImageGenerationEngine, ImageRuntimeError
+
+__all__ = ["ImageEngine", "ImageRuntimeError", "require_image_runtime_or_exit"]
+
+
+def require_image_runtime_or_exit(model_name: str | None = None) -> None:
+    """Fail before model download when the optional image stack is absent."""
+    if sys.version_info < (3, 11):
+        print(
+            "\n  Error: image generation requires Python 3.11 or newer "
+            f"(current: {sys.version_info.major}.{sys.version_info.minor}). "
+            "Rapid-MLX core still supports Python 3.10, but the mflux runtime "
+            "does not.\n",
+            file=sys.stderr,
+        )
+        raise SystemExit(2)
+    if importlib.util.find_spec("mflux") is None:
+        print(
+            "\n  Error: image generation requires the `rapid-mlx[image]` "
+            "Python extra (`pip install 'rapid-mlx[image]'`).\n",
+            file=sys.stderr,
+        )
+        raise SystemExit(2)
+
+
+class ImageEngine:
+    """Thin adapter over the mflux image backend.
+
+    Duck-typed like ``VideoEngine`` (``is_image_gen`` / ``_loaded``) so the
+    router and ``/v1/models`` probes can recognise the lane. The underlying
+    mflux model loads lazily on the first ``generate`` call.
+    """
+
+    is_image_gen = True
+    _loaded = True
+
+    def __init__(self, model_name: str) -> None:
+        self.model_name = model_name
+        self._engine = ImageGenerationEngine(model_name)
+
+    @property
+    def is_edit(self) -> bool:
+        return self._engine.is_edit
+
+    @property
+    def family(self) -> str:
+        return self._engine.family
+
+    def generate(
+        self,
+        *,
+        prompt: str,
+        width: int = 1024,
+        height: int = 1024,
+        num_inference_steps: int = 4,
+        seed: int = 0,
+        guidance: float = 4.0,
+        negative_prompt: str | None = None,
+        image_paths: list[str] | None = None,
+    ) -> bytes:
+        """Generate one image; returns PNG bytes. Raises ``ImageRuntimeError``."""
+        return self._engine.generate(
+            prompt=prompt,
+            width=width,
+            height=height,
+            num_inference_steps=num_inference_steps,
+            seed=seed,
+            guidance=guidance,
+            negative_prompt=negative_prompt,
+            image_paths=image_paths,
+        )
+
+    def generate_warmup(self) -> None:
+        """Image weights load lazily; startup must not trigger a multi-GB pull."""
+
+    async def stop(self) -> None:
+        """Release the backing model reference (mflux holds no async resources)."""
+        self._engine._model = None  # noqa: SLF001 — internal drop for restart hygiene

--- a/vllm_mlx/runtime/image_lane.py
+++ b/vllm_mlx/runtime/image_lane.py
@@ -12,9 +12,18 @@ from __future__ import annotations
 import importlib.util
 import sys
 
-from ..image.engine import ImageGenerationEngine, ImageRuntimeError
+from ..image.engine import (
+    ImageGenerationCancelled,
+    ImageGenerationEngine,
+    ImageRuntimeError,
+)
 
-__all__ = ["ImageEngine", "ImageRuntimeError", "require_image_runtime_or_exit"]
+__all__ = [
+    "ImageEngine",
+    "ImageGenerationCancelled",
+    "ImageRuntimeError",
+    "require_image_runtime_or_exit",
+]
 
 
 def require_image_runtime_or_exit(model_name: str | None = None) -> None:
@@ -64,6 +73,14 @@ class ImageEngine:
     def default_steps(self) -> int:
         """Per-family default denoise steps when the request pins none."""
         return self._engine.default_steps
+
+    def request_cancel(self) -> None:
+        """Ask the in-flight generation to stop at the next denoise step."""
+        self._engine.request_cancel()
+
+    def progress_snapshot(self) -> dict:
+        """Live denoise progress for the single in-flight render."""
+        return self._engine.progress_snapshot()
 
     def generate(
         self,

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -837,6 +837,10 @@ from .routes.video import install_video_body_limit_middleware  # noqa: E402
 
 install_video_body_limit_middleware(app)
 
+from .routes.images import install_image_body_limit_middleware  # noqa: E402
+
+install_image_body_limit_middleware(app)
+
 # SECURITY: blanket request-body size cap across all /v1/* routes.
 # Defends against the DoS pattern documented in rapid-desktop#273 / #463
 # where a 10–100 MB JSON body silently runs full prefill (~60–90 s on a

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -1846,9 +1846,13 @@ def load_model(
         _engine = VideoEngine(model_name=_video_hf_path)
         logger.info(f"Video model ready for lazy generation: {model_name}")
     elif _profile_modality == "image-gen":
-        from .runtime.image_lane import ImageEngine
+        from .runtime.image_lane import ImageEngine, require_image_runtime_or_exit
 
         _image_hf_path = _profile.hf_path if _profile is not None else model_name
+        # Preflight the optional image stack (Python ≥3.11 + mflux) BEFORE
+        # advertising a ready server, so a missing runtime fails at startup with
+        # an actionable diagnostic instead of a generic HTTP 500 on first request.
+        require_image_runtime_or_exit(_image_hf_path)
         logger.info(
             f"Loading model with ImageEngine (modality=image-gen): {_image_hf_path}"
         )

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -1845,6 +1845,15 @@ def load_model(
         )
         _engine = VideoEngine(model_name=_video_hf_path)
         logger.info(f"Video model ready for lazy generation: {model_name}")
+    elif _profile_modality == "image-gen":
+        from .runtime.image_lane import ImageEngine
+
+        _image_hf_path = _profile.hf_path if _profile is not None else model_name
+        logger.info(
+            f"Loading model with ImageEngine (modality=image-gen): {_image_hf_path}"
+        )
+        _engine = ImageEngine(model_name=_image_hf_path)
+        logger.info(f"Image model ready for lazy generation: {model_name}")
     elif _profile_modality == "text-diffusion":
         from .runtime.diffusion_lane import DiffusionEngine
 
@@ -2138,6 +2147,7 @@ from .routes.embeddings import router as _embeddings_router
 from .routes.health import admin_router as _health_admin_router
 from .routes.health import probe_router as _probe_router
 from .routes.health import router as _health_router
+from .routes.images import router as _images_router
 from .routes.mcp_routes import router as _mcp_router
 from .routes.metrics import router as _metrics_router
 from .routes.models import router as _models_router
@@ -2156,6 +2166,10 @@ app.include_router(_completions_router)
 app.include_router(_anthropic_router)
 app.include_router(_responses_router)
 app.include_router(_video_router)
+# Image lane is registered unconditionally like video: a text-only server
+# answers /v1/images/generations with the 409 "image_model_not_loaded"
+# envelope (the router's own gate), never a stray 404.
+app.include_router(_images_router)
 app.include_router(_embeddings_router)
 app.include_router(_mcp_router)
 # Task #292: ``_audio_router`` is registered LAZILY (after model load) by


### PR DESCRIPTION
## Why
Bring a ChatGPT-style **local** image-generation experience to Rapid-MLX: type a prompt, watch it render on-device, iterate — private, offline, unlimited. This adds the engine lane and a rapid-mac Images tab built to feel identical to the chat surface.

## What
**Engine (`vllm_mlx`)**
- New `image-gen` modality lane on the mflux backend (`image/engine.py`, `runtime/image_lane.py`, `routes/images.py`), mirroring the video lane's two-file split.
- `POST /v1/images/generations` + `POST /v1/images/edits` (OpenAI-compatible, b64_json).
- **True step progress + cancel**: `GET /v1/images/progress` (single-flight, real diffusion step/total via an mflux in-loop callback) and `POST /v1/images/cancel` (cooperative, stops at the next step).
- Family-aware behavior: per-family default steps, and `generate_image` kwargs are built per family (FLUX.2 Klein has no `negative_prompt`; guidance is omitted when unset so guidance-distilled models use their trained default).
- Models: **FLUX.2 Klein 4B** (default, ~10 s @ 1024² on M3 Ultra, 4.3 GB) and **Z-Image Turbo 6B** (quality, SOTA open-source, 5.5 GB) — both Apache-2.0, mflux-native 4-bit. Replaces the slower flux-schnell/Qwen-Image aliases. The instruction-**edit** path stays in the tree but is parked (slow/batch on current hardware).

**rapid-mac**
- Images tab built as a clone of chat: `CheetahLogo` + "Draw anything" empty state, the shared `ComposeField` compose box, an inline model-picker chip bottom-right, and the same `ModelReadiness` "load the model first" flow.
- Premium generation progress card (gradient/glow/shimmer bar, step count, elapsed + ETA, cancel).
- Model Management gains **capability tabs** (Chat / Image; Video reserved) so image models are downloaded/deleted alongside chat models; the chat picker still excludes non-chat aliases (`catalog-integrity`).

## Tests
- Hermetic: `tests/test_image_lane.py` (57), `test_cli_models.py`, `test_modality_field.py`, `test_aliases_contract.py` — all green after merging current `main`.
- `swift build` clean; `ImageCatalogTests` pass.
- Verified end-to-end via the AX harness on a Mac Studio (M3 Ultra): Start switches the server chat→image model; generate shows live 1/4→4/4 progress; multi-image filmstrip; mid-denoise Cancel stops at the next step and recovers cleanly. Direct-API generate returns a real 1024² PNG for both models.

## Notes
- The public model mirror (`models.rapidmlx.com`) does not host the two new image repos yet; client downloads fall back to HuggingFace (verified working), so this is not a blocker. Seeding the mirror is a follow-up (`scripts/mirror_to_r2.py <repo>`).
- No version bump.
- Written with assistance from Claude Code (Opus 4.8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)