### PR TITLE
fix: let empty GUI personas run on macOS Bash 3

### DIFF
--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -147,7 +147,10 @@ start_persona() {
     local config="$PERSONA/home/.rapid-golden-fake.json"
     jq -n --arg event_log "$OUT/fake-events.jsonl" '{FAKE_EVENT_LOG: $event_log}' > "$config"
     local assignment key value updated
-    for assignment in "${PERSONA_ENV[@]}"; do
+    # macOS ships Bash 3.2, where expanding a declared-but-empty array under
+    # `set -u` raises "unbound variable". The `+` form expands to nothing
+    # when the array has no elements and preserves argv boundaries otherwise.
+    for assignment in "${PERSONA_ENV[@]+"${PERSONA_ENV[@]}"}"; do
         key="${assignment%%=*}"
         value="${assignment#*=}"
         updated="$config.next"
@@ -155,7 +158,8 @@ start_persona() {
         mv "$updated" "$config"
     done
     env RAPID_BIN="$ROOT/scripts/fake-rapid-mlx.sh" \
-        FAKE_EVENT_LOG="$OUT/fake-events.jsonl" "${PERSONA_ENV[@]}" \
+        FAKE_EVENT_LOG="$OUT/fake-events.jsonl" \
+        "${PERSONA_ENV[@]+"${PERSONA_ENV[@]}"}" \
         "$PERSONA/launch.sh" > "$OUT/app.log" 2>&1 &
     APP_PID=$!
     wait_for_window
@@ -165,7 +169,7 @@ relaunch_persona() {
     stop_app
     env RAPID_BIN="$ROOT/scripts/fake-rapid-mlx.sh" \
         FAKE_EVENT_LOG="$OUT/fake-events.jsonl" \
-        "${PERSONA_ENV[@]}" \
+        "${PERSONA_ENV[@]+"${PERSONA_ENV[@]}"}" \
         "$PERSONA/launch.sh" >> "$OUT/app.log" 2>&1 &
     APP_PID=$!
     wait_for_window

--- a/tests/test_gui_walk_completeness.py
+++ b/tests/test_gui_walk_completeness.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Static contract for completeness-gated GUI absence assertions."""
 
+import subprocess
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -36,3 +37,25 @@ def test_catalog_absence_checks_require_complete_walks():
         complete < absence
         for complete, absence in zip(complete_offsets, absence_offsets, strict=True)
     )
+
+
+def test_empty_persona_environment_is_safe_on_macos_bash3():
+    source = (ROOT / "apps/rapid-mac/scripts/gui-golden-flows.sh").read_text()
+    safe = '${PERSONA_ENV[@]+"${PERSONA_ENV[@]}"}'
+    assert source.count(safe) == 3
+
+    program = r"""
+set -u
+PERSONA_ENV=()
+empty=0
+for value in "${PERSONA_ENV[@]+"${PERSONA_ENV[@]}"}"; do empty=$((empty + 1)); done
+PERSONA_ENV=("ONE=two words" "THREE=four")
+printf '%s\n' "$empty" "${PERSONA_ENV[@]+"${PERSONA_ENV[@]}"}"
+"""
+    result = subprocess.run(
+        ["/bin/bash", "-c", program],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert result.stdout.splitlines() == ["0", "ONE=two words", "THREE=four"]


### PR DESCRIPTION
## Summary
- guard empty `PERSONA_ENV` array expansion under `set -u`
- preserve argument boundaries for non-empty persona overrides
- add a static contract and verify the exact expansion on macOS system Bash 3.2

## Validation
- `bash -n apps/rapid-mac/scripts/gui-golden-flows.sh`
- `python -m pytest tests/test_gui_walk_completeness.py -q`
- real `/bin/bash 3.2.57` empty and spaced-value expansion smoke on the mini

Found during release wheel + GUI dogfood.