### PR TITLE
ci(mac): run the GUI golden flows on every rapid-mac PR

### DIFF
--- a/.github/workflows/rapid-mac-ci.yml
+++ b/.github/workflows/rapid-mac-ci.yml
@@ -277,23 +277,25 @@ jobs:
       # than "golden flows failed". Each needs its own output directory: the
       # harness refuses to start on a non-empty one.
       #
-      # These four are exactly the flows that drive the app through `rapid-ax`
-      # alone (see `flow_requires_peekaboo` in the harness). The rest shell out
-      # to peekaboo — a third-party install whose bridge socket comes from the
-      # Peekaboo app rather than its CLI, with its own permission surface.
-      # Between them these four own 6 of the 12 committed baselines; the way to
-      # extend the set is to make the remaining flows peekaboo-free (the menu
-      # click in `open_settings` is the main holdout), not to add peekaboo to
-      # this job.
+      # These three drive the app through `rapid-ax` alone (see
+      # `flow_requires_peekaboo` in the harness). Most other flows shell out to
+      # peekaboo — a third-party install whose bridge socket comes from the
+      # Peekaboo app rather than its CLI, with its own permission surface. The
+      # way to extend the set is to make those flows peekaboo-free (the menu
+      # click in `open_settings` is the main holdout), not to add peekaboo here.
+      #
+      # `chat-depth` is peekaboo-free but deliberately NOT run here. It asserts
+      # that all five turns are present in the accessibility tree at once, and
+      # the transcript is a virtualized scroll view: on this runner's 1024x681
+      # window the first user bubble is scrolled out and unrealized by turn 4,
+      # so the tree honestly reports 3 user + 4 model with a COMPLETE walk. That
+      # is the app working as designed, not a regression, and it cannot be fixed
+      # by a bigger window on a 1024x768 screen. Its assertions are only valid
+      # where the whole transcript fits, so it stays a local flow.
       - name: 'Golden flow: chat-restore'
         run: ./scripts/gui-golden-flows.sh --flow chat-restore
         env:
           RAPID_GUI_GOLDEN_OUT: ${{ runner.temp }}/golden/chat-restore
-
-      - name: 'Golden flow: chat-depth'
-        run: ./scripts/gui-golden-flows.sh --flow chat-depth
-        env:
-          RAPID_GUI_GOLDEN_OUT: ${{ runner.temp }}/golden/chat-depth
 
       - name: 'Golden flow: slow-stream-stop'
         run: ./scripts/gui-golden-flows.sh --flow slow-stream-stop
@@ -327,7 +329,7 @@ jobs:
           set -uo pipefail
           mkdir -p "$SCRATCH/snapshots"
           cp Tests/GUIGoldenFlows/__Snapshots__/*.txt "$SCRATCH/snapshots/"
-          for flow in chat-restore chat-depth slow-stream-stop model-crash-recovery; do
+          for flow in chat-restore slow-stream-stop model-crash-recovery; do
             RAPID_GUI_BASELINE_DIR="$SCRATCH/snapshots" \
             RAPID_GUI_GOLDEN_OUT="$SCRATCH/run/$flow" \
               ./scripts/gui-golden-flows.sh --flow "$flow" --update-baselines || true

--- a/.github/workflows/rapid-mac-ci.yml
+++ b/.github/workflows/rapid-mac-ci.yml
@@ -16,6 +16,12 @@
 # silently losing coverage. It fails a PR that ADDS an interactive control with
 # no `.accessibilityIdentifier(...)` — see the script's module docstring for the
 # rationale, the escape hatch, and the shapes it deliberately does not detect.
+#
+# Third gate: `gui-golden-flows` actually RUNS that harness. The identifier gate
+# only ensures new controls are reachable; nothing was checking that the
+# journeys still pass or that the committed AX baselines still describe the app.
+# They did not — #1705 shipped a new sidebar button and left all 12 baselines
+# stale. See the job's own comment for why a hosted runner can drive it.
 name: rapid-mac CI
 
 on:
@@ -157,3 +163,115 @@ jobs:
       # an actionable, retryable failure instead of a multi-minute hang.
       - name: verify chat timeout contract
         run: swift scripts/verify-chat-timeout.swift
+
+  # Drives the REAL .app through real user journeys and diffs the resulting
+  # accessibility tree against committed structural baselines.
+  #
+  # Why this job exists: apps/rapid-mac/scripts/gui-golden-flows.sh and the 12
+  # baselines under Tests/GUIGoldenFlows/__Snapshots__ ran in NO workflow at
+  # all. A regression net that only fires when a human remembers to run it is
+  # not a net, and it had already failed: #1705 added the Images sidebar button
+  # and left every one of the 12 baselines stale, with every check green.
+  #
+  # A NOTE ON WHY THIS IS POSSIBLE AT ALL. Reading another process's AX tree
+  # needs the caller to hold TCC Accessibility, which is normally interactive
+  # and lives in the SIP-protected system TCC database. GitHub bakes the grant
+  # into the runner image instead: images/macos/scripts/build/configure-tccdb-
+  # macos.sh in actions/runner-images inserts kTCCServiceAccessibility with
+  # auth_value 2 (allowed) for /bin/bash and for the agent that parents the
+  # runner, and configure-autologin.sh gives the VM a real logged-in Aqua
+  # session so an .app can actually open a window. Both are image properties,
+  # not promises — which is what the preflight step below is for.
+  gui-golden-flows:
+    # macos-15 for the same reason as the build job: Package.swift is
+    # swift-tools-version 6.0, and macos-14 still defaults to Swift 5.x.
+    runs-on: macos-15
+    # Build is ~the same cost as the build job; the four flows are seconds
+    # each (6-11 s on an M3 Ultra). 30 leaves room for a cold package resolve
+    # without letting a wedged app sit on the 6-hour default.
+    timeout-minutes: 30
+    defaults:
+      run:
+        working-directory: apps/rapid-mac
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      # BEFORE the build, because it is the cheap question and the one most
+      # likely to be answered "no" by a future runner-image change. If the
+      # image ever drops the Accessibility grant, every AX read returns
+      # nothing, `dump` yields a tree containing only the application root,
+      # and the flows would die on "main window did not appear" — blaming the
+      # app for a permission problem. This step makes that failure say what it
+      # actually is, in 30 s, instead of after a five-minute build.
+      #
+      # It is deliberately fail-closed: no Dock means no GUI session, which
+      # means the app could not have opened a window either.
+      - name: Accessibility + GUI session preflight
+        run: |
+          set -euo pipefail
+          swiftc scripts/rapid-ax.swift -o "$RUNNER_TEMP/rapid-ax"
+          dock_pid="$(pgrep -x Dock | head -1 || true)"
+          if [[ -z "$dock_pid" ]]; then
+            echo "::error::No Dock process: this runner has no logged-in GUI (Aqua) session, so the app cannot open a window."
+            exit 1
+          fi
+          echo "Dock pid: $dock_pid"
+          "$RUNNER_TEMP/rapid-ax" trust "$dock_pid"
+
+      # SKIP_SIDECAR=1 drops the 5-10 min pip install of the bundled Python
+      # engine. The golden flows never touch it: every flow points RAPID_BIN
+      # at scripts/fake-rapid-mlx.sh, so there is no model download, no GPU
+      # work and no network in the run at all.
+      #
+      # Debug rather than release for the same reason — the accessibility tree
+      # is identical and the compile is much cheaper. This gate is about
+      # structure, not optimised codegen.
+      - name: Build Rapid-MLX Desktop.app
+        env:
+          SKIP_SIDECAR: "1"
+          RAPID_BUILD_CONFIG: debug
+        run: ./scripts/build.sh
+
+      # One step per flow so a red check names the journey that broke rather
+      # than "golden flows failed". Each needs its own output directory: the
+      # harness refuses to start on a non-empty one.
+      #
+      # These four are exactly the flows that drive the app through `rapid-ax`
+      # alone (see `flow_requires_peekaboo` in the harness). The rest shell out
+      # to peekaboo — a third-party install whose bridge socket comes from the
+      # Peekaboo app rather than its CLI, with its own permission surface.
+      # Between them these four own 6 of the 12 committed baselines; the way to
+      # extend the set is to make the remaining flows peekaboo-free (the menu
+      # click in `open_settings` is the main holdout), not to add peekaboo to
+      # this job.
+      - name: 'Golden flow: chat-restore'
+        run: ./scripts/gui-golden-flows.sh --flow chat-restore
+        env:
+          RAPID_GUI_GOLDEN_OUT: ${{ runner.temp }}/golden/chat-restore
+
+      - name: 'Golden flow: chat-depth'
+        run: ./scripts/gui-golden-flows.sh --flow chat-depth
+        env:
+          RAPID_GUI_GOLDEN_OUT: ${{ runner.temp }}/golden/chat-depth
+
+      - name: 'Golden flow: slow-stream-stop'
+        run: ./scripts/gui-golden-flows.sh --flow slow-stream-stop
+        env:
+          RAPID_GUI_GOLDEN_OUT: ${{ runner.temp }}/golden/slow-stream-stop
+
+      - name: 'Golden flow: model-crash-recovery'
+        run: ./scripts/gui-golden-flows.sh --flow model-crash-recovery
+        env:
+          RAPID_GUI_GOLDEN_OUT: ${{ runner.temp }}/golden/model-crash-recovery
+
+      # A structural mismatch is only actionable with the observed tree beside
+      # the committed one. The harness writes `<name>.observed.txt` next to the
+      # raw AX dump it came from, which is what someone re-generating a
+      # baseline needs to review the diff.
+      - name: Upload AX evidence
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: gui-golden-flow-evidence
+          path: ${{ runner.temp }}/golden
+          retention-days: 7

--- a/.github/workflows/rapid-mac-ci.yml
+++ b/.github/workflows/rapid-mac-ci.yml
@@ -35,6 +35,12 @@ on:
       # ...and its regression suite, which is the only thing that runs when a
       # PR touches the detector but no Swift at all.
       - "tests/test_rapid_mac_ax_identifiers.py"
+      # Same reasoning for the harness contract suites and the captured
+      # cross-OS dumps they assert against: a PR that edits only those must
+      # still run them.
+      - "tests/test_ax_baseline_os_variance.py"
+      - "tests/test_gui_preflight_contract.py"
+      - "tests/fixtures/ax_baseline/**"
 
 permissions:
   contents: read
@@ -109,6 +115,41 @@ jobs:
       # pinned cases at once, and seeing all of them is the point.
       - name: Gate regression suite
         run: pytest tests/test_rapid_mac_ax_identifiers.py -q
+
+  # Text-only contracts protecting the golden-flow harness itself. Ubuntu is
+  # deliberate: both suites read captured dumps and script sources, so they
+  # cost seconds, need no GPU or GUI, and — for the OS-independence suite
+  # especially — must not themselves depend on a macOS version.
+  #
+  # These guard the two ways this gate can rot into uselessness:
+  #
+  #   * a baseline that only one macOS can produce. Developers here are on
+  #     macOS 26 and the runner is macOS 15, so any OS-variable attribute that
+  #     reaches a baseline means whoever runs --update-baselines turns CI red
+  #     for everyone, and regenerating on the other side turns it red locally.
+  #   * a deleted preflight. Removing it breaks nothing on a healthy machine;
+  #     it only restores the misdiagnosis on an unhealthy one, where a missing
+  #     permission or a locked screen again reads as "the app is broken".
+  gui-harness-contracts:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+        with:
+          python-version: "3.12"
+
+      - name: Install pytest
+        run: pip install pytest
+
+      # Separate steps so a red names which contract broke.
+      - name: Baselines are OS-independent
+        run: pytest tests/test_ax_baseline_os_variance.py -q
+
+      - name: GUI preflight contract
+        run: pytest tests/test_gui_preflight_contract.py -q
 
   build:
     # macos-15 → default Xcode 16 → Swift 6.0, matching Package.swift's
@@ -264,6 +305,37 @@ jobs:
         env:
           RAPID_GUI_GOLDEN_OUT: ${{ runner.temp }}/golden/model-crash-recovery
 
+      # The harness stops at the FIRST mismatched baseline and the job stops at
+      # the first failing flow, so one red run reveals exactly one line. With 6
+      # baselines across 4 flows that is up to 6 push-and-wait cycles to see a
+      # difference that was fully visible on the runner the first time — which
+      # is precisely what the OS-variance round trip on PR #1721 cost.
+      #
+      # So on failure, regenerate the whole set against a throwaway baseline
+      # directory and diff it against the committed one. The result is "here is
+      # everything this runner actually sees", in one artifact.
+      #
+      # `|| true` is on a DIAGNOSTIC, never on a check: this step only runs when
+      # the job has already failed, and `if: failure()` steps cannot turn a red
+      # job green. Swallowing errors here keeps a flow that dies for a
+      # non-baseline reason from hiding the diff for the ones that did not.
+      - name: Regenerate baselines on this runner (diagnostic)
+        if: failure()
+        env:
+          SCRATCH: ${{ runner.temp }}/os-baselines
+        run: |
+          set -uo pipefail
+          mkdir -p "$SCRATCH/snapshots"
+          cp Tests/GUIGoldenFlows/__Snapshots__/*.txt "$SCRATCH/snapshots/"
+          for flow in chat-restore chat-depth slow-stream-stop model-crash-recovery; do
+            RAPID_GUI_BASELINE_DIR="$SCRATCH/snapshots" \
+            RAPID_GUI_GOLDEN_OUT="$SCRATCH/run/$flow" \
+              ./scripts/gui-golden-flows.sh --flow "$flow" --update-baselines || true
+          done
+          echo "=== committed (left) vs this runner (right) ==="
+          diff -ru Tests/GUIGoldenFlows/__Snapshots__ "$SCRATCH/snapshots" \
+            | tee "$SCRATCH/runner-vs-committed.diff" || true
+
       # A structural mismatch is only actionable with the observed tree beside
       # the committed one. The harness writes `<name>.observed.txt` next to the
       # raw AX dump it came from, which is what someone re-generating a
@@ -273,5 +345,9 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: gui-golden-flow-evidence
-          path: ${{ runner.temp }}/golden
+          # Both halves: the failing flow's own dumps, and the full
+          # runner-vs-committed regeneration from the diagnostic step above.
+          path: |
+            ${{ runner.temp }}/golden
+            ${{ runner.temp }}/os-baselines
           retention-days: 7

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-depth.five-turns.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-depth.five-turns.txt
@@ -5,6 +5,7 @@ AXApplication title="Rapid-MLX"
       AXSplitGroup id="main, SidebarNavigationSplitView"
         AXGroup subrole=AXHostingView
           AXButton id="Sidebar.NewChat" desc="New Chat" enabled=true
+          AXButton id="Sidebar.Images" desc="Images" enabled=true
           AXButton id="Sidebar.Launch" desc="Launch" enabled=true
           AXScrollArea
             AXHeading desc="<relative-day>" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-depth.five-turns.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-depth.five-turns.txt
@@ -82,6 +82,7 @@ AXApplication title="Rapid-MLX"
           AXStaticText value=text enabled=true
           AXScrollArea
             AXTextArea id="rapid.chat.compose" desc="Message compose field" value=empty
+          AXButton id="ChatView.AddPhotos" desc="Add photos" help="This model doesn't support images" enabled=false
           AXPopUpButton id="ModelPickerBar.ModelMenu" desc="Model" help="Choose which model to run" value=text enabled=true
           AXButton id="ChatView.SendOrStopButton" desc="Send message" enabled=false
     AXToolbar

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-depth.restored.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-depth.restored.txt
@@ -5,6 +5,7 @@ AXApplication title="Rapid-MLX"
       AXSplitGroup id="main, SidebarNavigationSplitView"
         AXGroup subrole=AXHostingView
           AXButton id="Sidebar.NewChat" desc="New Chat" enabled=true
+          AXButton id="Sidebar.Images" desc="Images" enabled=true
           AXButton id="Sidebar.Launch" desc="Launch" enabled=true
           AXScrollArea
             AXHeading desc="<relative-day>" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-depth.restored.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-depth.restored.txt
@@ -82,6 +82,7 @@ AXApplication title="Rapid-MLX"
           AXStaticText value=text enabled=true
           AXScrollArea
             AXTextArea id="rapid.chat.compose" desc="Message compose field" value=empty
+          AXButton id="ChatView.AddPhotos" desc="Add photos" help="This model doesn't support images" enabled=false
           AXPopUpButton id="ModelPickerBar.ModelMenu" desc="Model" help="Choose which model to run" value=text enabled=true
           AXButton id="ChatView.SendOrStopButton" desc="Send message" enabled=false
     AXToolbar

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-restore.answered.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-restore.answered.txt
@@ -27,6 +27,7 @@ AXApplication title="Rapid-MLX"
           AXStaticText value=text enabled=true
           AXScrollArea
             AXTextArea id="rapid.chat.compose" desc="Message compose field" value=empty
+          AXButton id="ChatView.AddPhotos" desc="Add photos" help="This model doesn't support images" enabled=false
           AXPopUpButton id="ModelPickerBar.ModelMenu" desc="Model" help="Choose which model to run" value=text enabled=true
           AXButton id="ChatView.SendOrStopButton" desc="Send message" enabled=false
     AXToolbar

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-restore.answered.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-restore.answered.txt
@@ -5,6 +5,7 @@ AXApplication title="Rapid-MLX"
       AXSplitGroup id="main, SidebarNavigationSplitView"
         AXGroup subrole=AXHostingView
           AXButton id="Sidebar.NewChat" desc="New Chat" enabled=true
+          AXButton id="Sidebar.Images" desc="Images" enabled=true
           AXButton id="Sidebar.Launch" desc="Launch" enabled=true
           AXScrollArea
             AXHeading desc="<relative-day>" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-restore.transcript-restored.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-restore.transcript-restored.txt
@@ -27,6 +27,7 @@ AXApplication title="Rapid-MLX"
           AXStaticText value=text enabled=true
           AXScrollArea
             AXTextArea id="rapid.chat.compose" desc="Message compose field" value=empty
+          AXButton id="ChatView.AddPhotos" desc="Add photos" help="This model doesn't support images" enabled=false
           AXPopUpButton id="ModelPickerBar.ModelMenu" desc="Model" help="Choose which model to run" value=text enabled=true
           AXButton id="ChatView.SendOrStopButton" desc="Send message" enabled=false
     AXToolbar

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-restore.transcript-restored.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-restore.transcript-restored.txt
@@ -5,6 +5,7 @@ AXApplication title="Rapid-MLX"
       AXSplitGroup id="main, SidebarNavigationSplitView"
         AXGroup subrole=AXHostingView
           AXButton id="Sidebar.NewChat" desc="New Chat" enabled=true
+          AXButton id="Sidebar.Images" desc="Images" enabled=true
           AXButton id="Sidebar.Launch" desc="Launch" enabled=true
           AXScrollArea
             AXHeading desc="<relative-day>" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/model-crash-recovery.recovered.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/model-crash-recovery.recovered.txt
@@ -27,6 +27,7 @@ AXApplication title="Rapid-MLX"
           AXStaticText value=text enabled=true
           AXScrollArea
             AXTextArea id="rapid.chat.compose" desc="Message compose field" value=empty
+          AXButton id="ChatView.AddPhotos" desc="Add photos" help="This model doesn't support images" enabled=false
           AXPopUpButton id="ModelPickerBar.ModelMenu" desc="Model" help="Choose which model to run" value=text enabled=true
           AXButton id="ChatView.SendOrStopButton" desc="Send message" enabled=false
     AXToolbar

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/model-crash-recovery.recovered.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/model-crash-recovery.recovered.txt
@@ -5,6 +5,7 @@ AXApplication title="Rapid-MLX"
       AXSplitGroup id="main, SidebarNavigationSplitView"
         AXGroup subrole=AXHostingView
           AXButton id="Sidebar.NewChat" desc="New Chat" enabled=true
+          AXButton id="Sidebar.Images" desc="Images" enabled=true
           AXButton id="Sidebar.Launch" desc="Launch" enabled=true
           AXScrollArea
             AXHeading desc="<relative-day>" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/slow-stream-stop.stopped.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/slow-stream-stop.stopped.txt
@@ -27,6 +27,7 @@ AXApplication title="Rapid-MLX"
           AXStaticText value=text enabled=true
           AXScrollArea
             AXTextArea id="rapid.chat.compose" desc="Message compose field" value=empty
+          AXButton id="ChatView.AddPhotos" desc="Add photos" help="This model doesn't support images" enabled=false
           AXPopUpButton id="ModelPickerBar.ModelMenu" desc="Model" help="Choose which model to run" value=text enabled=true
           AXButton id="ChatView.SendOrStopButton" desc="Send message" enabled=false
     AXToolbar

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/slow-stream-stop.stopped.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/slow-stream-stop.stopped.txt
@@ -5,6 +5,7 @@ AXApplication title="Rapid-MLX"
       AXSplitGroup id="main, SidebarNavigationSplitView"
         AXGroup subrole=AXHostingView
           AXButton id="Sidebar.NewChat" desc="New Chat" enabled=true
+          AXButton id="Sidebar.Images" desc="Images" enabled=true
           AXButton id="Sidebar.Launch" desc="Launch" enabled=true
           AXScrollArea
             AXHeading desc="<relative-day>" enabled=true

--- a/apps/rapid-mac/scripts/ax-baseline.py
+++ b/apps/rapid-mac/scripts/ax-baseline.py
@@ -17,7 +17,8 @@ What the normalizer keeps
   * nesting depth and parent/child relationships (rendered as indentation)
   * ``AXRole`` and ``AXSubrole``
   * ``accessibilityIdentifier``
-  * ``AXTitle`` / ``AXDescription`` / ``AXHelp`` (scrubbed, see below)
+  * ``AXDescription`` / ``AXHelp``, and ``AXTitle`` only when the element
+    publishes no ``AXDescription`` (scrubbed, see below)
   * ``AXEnabled``
   * the *kind* of ``AXValue`` — ``bool:true`` / ``bool:false`` for toggles,
     ``number`` / ``text`` / ``empty`` for everything else
@@ -38,6 +39,12 @@ What it drops or rewrites, and why
     conversation row identifier legitimately carries a fresh UUID.
   * caller-supplied tokens (``--scrub``) — the golden flows pass the fake
     model alias so a rename of the fixture is not a baseline change.
+  * ``AXTitle`` on an element that also publishes ``AXDescription`` — the
+    description is the label the app authored, the title is AppKit's own
+    synthesis from how the control is drawn, and that synthesis differs
+    between macOS releases (see ``render_node``). A baseline that pins it
+    cannot be regenerated on one macOS and used on another, in either
+    direction.
   * ``AXSelected`` — dumped by ``rapid-ax.swift`` (a flow has to be able to ask
     which model card the user chose, see #1653) but deliberately NOT rendered
     here. Which of several equal-looking cards is highlighted is state, not
@@ -242,9 +249,15 @@ def build_tree(records: list[dict]) -> Node | None:
 
 def window_sort_key(node: Node) -> tuple[str, str, str, str]:
     record = node.record
+    # Sort on exactly what gets RENDERED, including the title rule in
+    # `render_node`. Ordering windows by an attribute the baseline then hides
+    # would let two machines emit identical lines in a different order — the
+    # same un-regenerable baseline this normalizer exists to prevent, only
+    # harder to read.
+    title = "" if record.get("description") else (record.get("title", "") or "")
     return (
         record.get("identifier", "") or "",
-        record.get("title", "") or "",
+        title,
         record.get("subrole", "") or "",
         record.get("role", "") or "",
     )
@@ -266,7 +279,36 @@ def render_node(node: Node, extra_tokens: tuple[str, ...]) -> str:
         normalized = normalize_identifier(identifier, extra_tokens)
         if normalized:
             parts.append(f"id={quote(normalized)}")
+    # AXTitle is dropped whenever AXDescription is published on the same
+    # element.
+    #
+    # SwiftUI's accessibilityLabel lands in AXDescription: that is the label
+    # the APP authored. AppKit may additionally synthesise an AXTitle for the
+    # same control out of how it happens to be drawn, and that synthesis is
+    # not stable across macOS releases. Measured on one commit, two machines:
+    # the conversation "..." menu publishes
+    #     AXPopUpButton id="Sidebar.Conversation.Menu.<uuid>"
+    #         title="More" desc="Conversation actions"
+    # on macOS 15 (hosted runner) and the same line WITHOUT the title on
+    # macOS 26 (dev machine). Pinning that makes a baseline un-regenerable in
+    # both directions — whoever writes it turns the other OS red, and
+    # `--update-baselines` becomes a trap rather than a tool.
+    #
+    # Deliberately narrow. A title with NO description beside it is the only
+    # label the element has and is kept, which preserves every title the
+    # committed baselines actually rely on: AXApplication and AXWindow
+    # titles, and controls such as `Settings.ModelManagement.SortMenu`
+    # (title="Sort", no description) that are otherwise indistinguishable
+    # from a neighbouring popup.
+    #
+    # What this gives up, stated plainly: a change to a control's VISIBLE text
+    # while its accessibility label stays put. That was never this file's job
+    # — see the scope note at the top of the module; visible text belongs to
+    # the PNG snapshots in Tests/RapidTests.
+    description = record.get("description")
     for key, label in (("title", "title"), ("description", "desc"), ("help", "help")):
+        if key == "title" and description:
+            continue
         text = record.get(key)
         if text:
             parts.append(f"{label}={quote(scrub(text, extra_tokens))}")

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -153,26 +153,29 @@ trap finish EXIT
 trap 'cleanup_persona; exit 130' INT
 trap 'cleanup_persona; exit 143' TERM
 
-# The one permission every flow depends on and none of them can observe.
+# The preconditions every flow depends on and none of them can observe:
+# permission to read another process's AX tree, and a session that can actually
+# put a window on screen.
 #
-# Checked BEFORE the first app launch. Without it a machine that lacks the
-# Accessibility grant spends 20 s per flow inside `wait_for_window` and then
-# dies on "main window did not appear" — a message that accuses the app of
-# never opening a window when the truth is that we were never allowed to look.
-# On an unattended runner that is the difference between a diagnosable red and
-# a fortnight of blaming the product.
+# Checked BEFORE the first app launch. Both failures otherwise look identical
+# and identically wrong: the flow spends 20 s inside `wait_for_window` and dies
+# on "main window did not appear", accusing the app of never opening a window
+# when the truth is either that we were not allowed to look or that nothing can
+# be shown at all. Both were observed for real while building this — a missing
+# grant, and a Mac that locked its screen mid-run.
 #
 # Aimed at the Dock when one is running, because the grant has to work against
 # ANOTHER process and `AXIsProcessTrusted()` alone is only the system's opinion
-# about us until a real cross-process read backs it up. With no Dock at all —
-# no GUI session — the trust bit is still checked and the flows then fail on
-# their own window wait, which is the honest outcome for a session that cannot
-# show a window in the first place.
+# about us until a real cross-process read backs it up. rapid-ax adds the lock
+# check, which that read cannot supply: the Dock reads perfectly behind a lock
+# screen.
 require_ax_trust() {
     local dock_pid
     dock_pid="$(pgrep -x Dock | head -1 || true)"
+    # rapid-ax prints the specific reason to stderr; do not restate it here and
+    # risk naming the wrong one of the two.
     "$AX_DRIVER" trust ${dock_pid:+"$dock_pid"} > "$OUT_ROOT/ax-trust.json" \
-        || die "Accessibility is not usable by this process (see $OUT_ROOT/ax-trust.json)"
+        || die "GUI preconditions not met — see the rapid-ax line above and $OUT_ROOT/ax-trust.json"
 }
 
 require_tools() {

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -1106,6 +1106,29 @@ flow_slow_stream_stop() {
     done
     [[ "$(element_field "$OUT/slow-streaming.json" ChatView.SendOrStopButton description)" == "Stop generating" ]] \
         || die "send button never transitioned to Stop generating"
+    # Stop a stream that is actually streaming CONTENT.
+    #
+    # The button flips to "Stop generating" on the first delta, and that delta
+    # is a REASONING token — the answer itself has not started. Pressing there
+    # leaves a bubble with no content node; pressing a moment later leaves one
+    # with. Both are legitimate app states, and the structural baseline can
+    # only pin one of them.
+    #
+    # Measured, same commit: this dev machine always had the content by then
+    # and the hosted runner never did, so whichever machine wrote the baseline
+    # made it un-enforceable on the other — three local runs were stable, which
+    # is exactly what makes this kind of race so easy to commit by accident.
+    #
+    # Waiting for the first content token removes the race and sharpens what
+    # the flow claims to test: cancelling a response that is being produced,
+    # not one that has yet to start.
+    for _ in {1..80}; do
+        see_main "$OUT/slow-streaming.json"
+        if jq -e '(.data.ui_elements | tostring) | contains("Hello")' \
+            "$OUT/slow-streaming.json" >/dev/null; then break; fi
+        sleep 0.1
+    done
+    assert_tree_text "$OUT/slow-streaming.json" "Hello"
     press "$OUT/slow-streaming.json" ChatView.SendOrStopButton "$OUT/slow-stop.json"
     for _ in {1..40}; do
         see_main "$OUT/slow-stopped.json"

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -662,13 +662,25 @@ transcript_counts() {
            | "\(.user) \(.model)"' "$tree"
 }
 
+# Counts every turn in the tree — which is only a valid completeness check
+# while the WHOLE transcript is realized.
+#
+# The transcript is a virtualized scroll view: a message scrolled far enough out
+# of view is removed from the accessibility tree, and the dump says so honestly
+# with `walk.complete == true`. Measured on a 1024x681 window, `chat-depth` at
+# turn 4 reported 3 user + 4 model with a complete walk, the first user bubble
+# sitting at y=-429. Nothing was broken; it had simply scrolled away.
+#
+# So a shortfall here means one of two things, and they are not distinguishable
+# from the counts alone: a dropped turn, or a window too short to hold them.
+# Check the window height before reading it as a product bug.
 assert_transcript_turns() {
     local tree="$1" expected="$2" counts user model
     counts="$(transcript_counts "$tree")"
     user="${counts% *}"
     model="${counts#* }"
     [[ "$user" == "$expected" && "$model" == "$expected" ]] \
-        || die "expected $expected user + $expected model message(s), tree shows ${user} + ${model}"
+        || die "expected $expected user + $expected model message(s), tree shows ${user} + ${model} (a virtualized transcript drops off-screen turns — check the window is tall enough before reading this as a dropped message)"
 }
 
 # Do these strings appear in the transcript IN THIS ORDER?

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -37,6 +37,12 @@ Flows: fresh-install, settings-persistence, chat-restore, restored-tools, tool-l
        update-state, no-dead-controls, catalog-integrity,
        browse-all-destination, all
 
+chat-restore, chat-depth, slow-stream-stop, model-crash-recovery,
+restored-tools and tool-loop-budget drive the app through the accessibility
+API alone. They need no peekaboo and no Screen Recording, which is what lets
+them run unattended in CI (see the gui-golden-flows job in
+.github/workflows/rapid-mac-ci.yml). Every other flow needs peekaboo.
+
 Options:
   --update-baselines  rewrite the committed AX structural baselines instead of
                       comparing against them. Intended UI changes land as a
@@ -67,6 +73,30 @@ flow_requires_screen_recording() {
     case "$FLOW" in
         all|fresh-install|low-memory-choice|browse-all-destination) return 0 ;;
         *) return 1 ;;
+    esac
+}
+# Which flows shell out to `peekaboo`, and therefore need it installed and
+# permitted. Named flows drive the app through `rapid-ax` alone; everything
+# else — including `all` — is assumed to need peekaboo.
+#
+# Default-deny is the load-bearing part. A NEW flow is treated as needing
+# peekaboo until someone says otherwise, so it cannot quietly join the
+# unattended subset and then fail somewhere unrelated on a machine that has no
+# peekaboo. Getting this backwards would be silent; getting it wrong this way
+# round is a one-line fix.
+#
+# Why it matters at all: `rapid-ax` needs only the Accessibility grant, which a
+# GitHub-hosted macOS runner already carries in its image TCC database, and it
+# is built from a source file in this repo. Peekaboo is a third-party install
+# that additionally reaches its bridge socket (`--bridge-socket`, provided by
+# the Peekaboo app rather than the `brew` CLI) and has its own permission
+# surface. The peekaboo-free flows are therefore the set that can run
+# unattended without taking on any of that.
+flow_requires_peekaboo() {
+    case "$FLOW" in
+        chat-restore|restored-tools|tool-loop-budget|chat-depth) return 1 ;;
+        slow-stream-stop|model-crash-recovery) return 1 ;;
+        *) return 0 ;;
     esac
 }
 pb_click_coords() {
@@ -123,14 +153,39 @@ trap finish EXIT
 trap 'cleanup_persona; exit 130' INT
 trap 'cleanup_persona; exit 143' TERM
 
+# The one permission every flow depends on and none of them can observe.
+#
+# Checked BEFORE the first app launch. Without it a machine that lacks the
+# Accessibility grant spends 20 s per flow inside `wait_for_window` and then
+# dies on "main window did not appear" — a message that accuses the app of
+# never opening a window when the truth is that we were never allowed to look.
+# On an unattended runner that is the difference between a diagnosable red and
+# a fortnight of blaming the product.
+#
+# Aimed at the Dock when one is running, because the grant has to work against
+# ANOTHER process and `AXIsProcessTrusted()` alone is only the system's opinion
+# about us until a real cross-process read backs it up. With no Dock at all —
+# no GUI session — the trust bit is still checked and the flows then fail on
+# their own window wait, which is the honest outcome for a session that cannot
+# show a window in the first place.
+require_ax_trust() {
+    local dock_pid
+    dock_pid="$(pgrep -x Dock | head -1 || true)"
+    "$AX_DRIVER" trust ${dock_pid:+"$dock_pid"} > "$OUT_ROOT/ax-trust.json" \
+        || die "Accessibility is not usable by this process (see $OUT_ROOT/ax-trust.json)"
+}
+
 require_tools() {
     [[ -d "$APP_SOURCE" ]] || die "built app not found: $APP_SOURCE"
-    for tool in peekaboo jq python3; do
+    for tool in jq python3; do
         command -v "$tool" >/dev/null || die "$tool is required"
     done
     [[ -f "$BASELINE_TOOL" ]] || die "AX baseline normalizer not found: $BASELINE_TOOL"
     AX_DRIVER="$OUT_ROOT/rapid-ax"
     swiftc "$ROOT/scripts/rapid-ax.swift" -o "$AX_DRIVER"
+    require_ax_trust
+    flow_requires_peekaboo || return 0
+    command -v peekaboo >/dev/null || die "peekaboo is required for flow: $FLOW"
     pb permissions status --json > "$OUT_ROOT/permissions.json"
     jq -e '.success and any(.data.permissions[]?; .name == "Accessibility" and .isGranted == true)' \
         "$OUT_ROOT/permissions.json" >/dev/null || die "Peekaboo needs Accessibility permission"
@@ -669,6 +724,12 @@ dismiss_first_run() {
     see_main "$tree"
     if jq -e '.data.ui_elements[]? | select(.identifier == "TelemetryConsent.DontShare")' "$tree" >/dev/null; then
         if ! press "$tree" TelemetryConsent.DontShare "$OUT/consent.json" 2>/dev/null; then
+            # The coordinate fallback is peekaboo's. A flow that declared
+            # itself peekaboo-free has no fallback left, and reaching for one
+            # anyway would surface as a bare "peekaboo: command not found"
+            # attached to whichever assertion happened to run next.
+            command -v peekaboo >/dev/null \
+                || die "AXPress on TelemetryConsent.DontShare failed and $FLOW has no peekaboo fallback"
             read -r x y < <(jq -r '.data.ui_elements[] | select(.identifier == "TelemetryConsent.DontShare") | [(.bounds.x + .bounds.width / 2), (.bounds.y + .bounds.height / 2)] | @tsv' "$tree")
             pb_click_coords "$x,$y" --app "PID:$APP_PID" --json > "$OUT/consent-coordinate-fallback.json"
         fi

--- a/apps/rapid-mac/scripts/rapid-ax.swift
+++ b/apps/rapid-mac/scripts/rapid-ax.swift
@@ -9,9 +9,75 @@ func fail(_ message: String) -> Never {
     exit(1)
 }
 
+// `trust` answers the question every other command silently depends on: is
+// THIS process allowed to read another process's accessibility tree?
+//
+// Without it, a missing Accessibility grant is indistinguishable from a
+// product bug. `AXUIElementCopyAttributeValue` just fails, `dump` returns a
+// tree containing nothing but the application root, and the caller times out
+// on "main window did not appear" — which accuses the app of never opening a
+// window when the truth is that we were never allowed to look. That is the
+// same trap the window-list comment below describes, and it is the single
+// most likely way an unattended (CI) run of the golden flows would misreport
+// itself.
+//
+// `AXIsProcessTrusted()` is the gate the AX APIs actually consult, but on its
+// own it is only the system's opinion about us. When a target pid is supplied
+// the check also performs a real cross-process read, so a grant that exists on
+// paper yet does not work in practice still fails HERE, naming the permission,
+// instead of surfacing minutes later as a phantom UI regression.
+if CommandLine.arguments.count >= 2, CommandLine.arguments[1] == "trust" {
+    let trusted = AXIsProcessTrusted()
+    var payload: [String: Any] = ["trusted": trusted]
+    var readSucceeded = true
+
+    if CommandLine.arguments.count >= 3 {
+        guard let target = pid_t(CommandLine.arguments[2]) else {
+            fail("trust: target must be a pid")
+        }
+        var value: CFTypeRef?
+        let result = AXUIElementCopyAttributeValue(
+            AXUIElementCreateApplication(target),
+            kAXChildrenAttribute as CFString,
+            &value
+        )
+        // `.noValue` / `.attributeUnsupported` mean the read itself WORKED and
+        // the target simply publishes no children. Only an outright failure is
+        // evidence that we were refused.
+        readSucceeded =
+            result == .success || result == .noValue || result == .attributeUnsupported
+        payload["target_pid"] = Int(target)
+        payload["target_read"] = readSucceeded
+        payload["target_read_error"] = Int(result.rawValue)
+    }
+
+    payload["success"] = trusted && readSucceeded
+    let data = try! JSONSerialization.data(
+        withJSONObject: payload, options: [.prettyPrinted, .sortedKeys])
+    FileHandle.standardOutput.write(data)
+    FileHandle.standardOutput.write(Data("\n".utf8))
+
+    if !trusted {
+        fail(
+            "this process is NOT trusted for Accessibility "
+            + "(AXIsProcessTrusted() == false). Every AX read will fail, and the "
+            + "golden flows would report a missing window instead of a missing "
+            + "permission. Grant Accessibility to the controlling process "
+            + "(System Settings > Privacy & Security > Accessibility)."
+        )
+    }
+    if !readSucceeded {
+        fail(
+            "Accessibility is granted but reading another process's AX tree "
+            + "still failed. The grant is not effective for this process tree."
+        )
+    }
+    exit(0)
+}
+
 guard CommandLine.arguments.count >= 3,
       let pid = pid_t(CommandLine.arguments[2]) else {
-    fail("usage: rapid-ax <dump|press|set-value> <pid> [identifier] [value]")
+    fail("usage: rapid-ax <dump|press|set-value|trust> <pid> [identifier] [value]")
 }
 
 let command = CommandLine.arguments[1]

--- a/apps/rapid-mac/scripts/rapid-ax.swift
+++ b/apps/rapid-mac/scripts/rapid-ax.swift
@@ -31,6 +31,29 @@ if CommandLine.arguments.count >= 2, CommandLine.arguments[1] == "trust" {
     var payload: [String: Any] = ["trusted": trusted]
     var readSucceeded = true
 
+    // A LOCKED screen produces the exact symptom this command exists to
+    // prevent being misread. Measured while writing this: with the screen
+    // locked, Accessibility is still granted and the Dock's AX tree still
+    // reads fine, but no application can present a window, so every golden
+    // flow dies on "main window did not appear" — indistinguishable from the
+    // app being broken. The permission check alone does NOT see it.
+    //
+    // Complementary signals, deliberately: reading another process's tree is
+    // positive evidence that a GUI session exists at all; the lock bit is the
+    // one negative signal that evidence cannot carry, because the Dock is
+    // perfectly readable behind a lock screen.
+    //
+    // Only an explicit `true` fails. An unreadable session dictionary is
+    // recorded and left to the cross-process read above to adjudicate, rather
+    // than inventing a verdict from a failed read.
+    let session = CGSessionCopyCurrentDictionary() as? [String: Any]
+    let screenLocked = (session?["CGSSessionScreenIsLocked"] as? NSNumber)?.boolValue
+    payload["session_readable"] = session != nil
+    payload["screen_locked"] = screenLocked ?? false
+    if let onConsole = (session?["kCGSSessionOnConsoleKey"] as? NSNumber)?.boolValue {
+        payload["on_console"] = onConsole
+    }
+
     if CommandLine.arguments.count >= 3 {
         guard let target = pid_t(CommandLine.arguments[2]) else {
             fail("trust: target must be a pid")
@@ -51,12 +74,21 @@ if CommandLine.arguments.count >= 2, CommandLine.arguments[1] == "trust" {
         payload["target_read_error"] = Int(result.rawValue)
     }
 
-    payload["success"] = trusted && readSucceeded
+    payload["success"] = trusted && readSucceeded && !(screenLocked ?? false)
     let data = try! JSONSerialization.data(
         withJSONObject: payload, options: [.prettyPrinted, .sortedKeys])
     FileHandle.standardOutput.write(data)
     FileHandle.standardOutput.write(Data("\n".utf8))
 
+    if screenLocked == true {
+        fail(
+            "the screen is locked (CGSSessionScreenIsLocked). Accessibility is "
+            + "fine and other processes' trees still read, but no app can "
+            + "present a window while locked, so every flow would fail with "
+            + "\"main window did not appear\" and look like an app regression. "
+            + "Unlock the screen and re-run."
+        )
+    }
     if !trusted {
         fail(
             "this process is NOT trusted for Accessibility "

--- a/tests/fixtures/ax_baseline/chat-settled.macos15.json
+++ b/tests/fixtures/ax_baseline/chat-settled.macos15.json
@@ -1,0 +1,491 @@
+{
+  "data" : {
+    "pid" : 32668,
+    "ui_elements" : [
+      {
+        "depth" : 0,
+        "role" : "AXApplication",
+        "title" : "Rapid-MLX"
+      },
+      {
+        "bounds" : {
+          "height" : 681,
+          "width" : 1024,
+          "x" : 0,
+          "y" : 25
+        },
+        "depth" : 1,
+        "identifier" : "main",
+        "role" : "AXWindow",
+        "subrole" : "AXStandardWindow",
+        "title" : "Rapid-MLX"
+      },
+      {
+        "bounds" : {
+          "height" : 681,
+          "width" : 1024,
+          "x" : 0,
+          "y" : 25
+        },
+        "depth" : 2,
+        "role" : "AXGroup",
+        "subrole" : "AXHostingView"
+      },
+      {
+        "bounds" : {
+          "height" : 681,
+          "width" : 1024,
+          "x" : 0,
+          "y" : 25
+        },
+        "depth" : 3,
+        "identifier" : "main, SidebarNavigationSplitView",
+        "role" : "AXSplitGroup"
+      },
+      {
+        "bounds" : {
+          "height" : 681,
+          "width" : 200,
+          "x" : 0,
+          "y" : 25
+        },
+        "depth" : 4,
+        "role" : "AXGroup",
+        "subrole" : "AXHostingView"
+      },
+      {
+        "bounds" : {
+          "height" : 30,
+          "width" : 184,
+          "x" : 8,
+          "y" : 89
+        },
+        "depth" : 5,
+        "description" : "New Chat",
+        "enabled" : true,
+        "identifier" : "Sidebar.NewChat",
+        "role" : "AXButton"
+      },
+      {
+        "bounds" : {
+          "height" : 30,
+          "width" : 184,
+          "x" : 8,
+          "y" : 120
+        },
+        "depth" : 5,
+        "description" : "Images",
+        "enabled" : true,
+        "identifier" : "Sidebar.Images",
+        "role" : "AXButton"
+      },
+      {
+        "bounds" : {
+          "height" : 30,
+          "width" : 184,
+          "x" : 8,
+          "y" : 151
+        },
+        "depth" : 5,
+        "description" : "Launch",
+        "enabled" : true,
+        "identifier" : "Sidebar.Launch",
+        "role" : "AXButton"
+      },
+      {
+        "bounds" : {
+          "height" : 511,
+          "width" : 184,
+          "x" : 8,
+          "y" : 182
+        },
+        "depth" : 5,
+        "role" : "AXScrollArea"
+      },
+      {
+        "bounds" : {
+          "height" : 14,
+          "width" : 33,
+          "x" : 16,
+          "y" : 198
+        },
+        "depth" : 6,
+        "description" : "Today",
+        "enabled" : true,
+        "role" : "AXHeading"
+      },
+      {
+        "bounds" : {
+          "height" : 24,
+          "width" : 24,
+          "x" : 144,
+          "y" : 220
+        },
+        "depth" : 6,
+        "description" : "Pin conversation",
+        "enabled" : true,
+        "help" : "Pin conversation",
+        "identifier" : "Sidebar.Conversation.Pin.13D1622D-E725-4A05-BC63-B23F9E672FF4",
+        "role" : "AXButton"
+      },
+      {
+        "bounds" : {
+          "height" : 14,
+          "width" : 20,
+          "x" : 168,
+          "y" : 225
+        },
+        "depth" : 6,
+        "description" : "Conversation actions",
+        "enabled" : true,
+        "identifier" : "Sidebar.Conversation.Menu.13D1622D-E725-4A05-BC63-B23F9E672FF4",
+        "role" : "AXPopUpButton",
+        "title" : "More"
+      },
+      {
+        "bounds" : {
+          "height" : 30,
+          "width" : 184,
+          "x" : 8,
+          "y" : 217
+        },
+        "depth" : 6,
+        "description" : "golden restore marker",
+        "enabled" : true,
+        "identifier" : "Sidebar.Conversation.13D1622D-E725-4A05-BC63-B23F9E672FF4",
+        "role" : "AXButton",
+        "selected" : true
+      },
+      {
+        "bounds" : {
+          "height" : 629,
+          "width" : 1,
+          "x" : 200,
+          "y" : 77
+        },
+        "depth" : 4,
+        "enabled" : false,
+        "role" : "AXSplitter",
+        "selected" : false,
+        "value" : 200
+      },
+      {
+        "bounds" : {
+          "height" : 681,
+          "width" : 823,
+          "x" : 201,
+          "y" : 25
+        },
+        "depth" : 4,
+        "role" : "AXGroup",
+        "subrole" : "AXHostingView"
+      },
+      {
+        "bounds" : {
+          "height" : 520,
+          "width" : 823,
+          "x" : 201,
+          "y" : 77
+        },
+        "depth" : 5,
+        "role" : "AXScrollArea"
+      },
+      {
+        "bounds" : {
+          "height" : 196,
+          "width" : 743,
+          "x" : 230,
+          "y" : 111
+        },
+        "depth" : 6,
+        "enabled" : true,
+        "role" : "AXOpaqueProviderGroup",
+        "subrole" : "AXOpaqueProviderList"
+      },
+      {
+        "bounds" : {
+          "height" : 16,
+          "width" : 134,
+          "x" : 825,
+          "y" : 111
+        },
+        "depth" : 7,
+        "enabled" : true,
+        "role" : "AXStaticText",
+        "value" : "golden restore marker"
+      },
+      {
+        "bounds" : {
+          "height" : 24,
+          "width" : 24,
+          "x" : 923,
+          "y" : 141
+        },
+        "depth" : 7,
+        "description" : "Copy message",
+        "enabled" : true,
+        "help" : "Copy message",
+        "identifier" : "ChatView.Message.Copy.8677EA2F-CCAA-4F4A-B338-BED3BC4CDFB2",
+        "role" : "AXButton"
+      },
+      {
+        "bounds" : {
+          "height" : 24,
+          "width" : 24,
+          "x" : 949,
+          "y" : 141
+        },
+        "depth" : 7,
+        "description" : "Edit message",
+        "enabled" : true,
+        "help" : "Edit message",
+        "identifier" : "ChatView.Message.Edit.8677EA2F-CCAA-4F4A-B338-BED3BC4CDFB2",
+        "role" : "AXButton"
+      },
+      {
+        "bounds" : {
+          "height" : 13.02294921875,
+          "width" : 110,
+          "x" : 230,
+          "y" : 186
+        },
+        "depth" : 7,
+        "description" : "Reasoning",
+        "enabled" : true,
+        "role" : "AXDisclosureTriangle",
+        "value" : false
+      },
+      {
+        "bounds" : {
+          "height" : 43,
+          "width" : 700,
+          "x" : 253,
+          "y" : 211
+        },
+        "depth" : 7,
+        "enabled" : true,
+        "role" : "AXStaticText",
+        "value" : "Hello from the fake rapid-mlx mock. I return deterministic content so the smoke test has something to assert on."
+      },
+      {
+        "bounds" : {
+          "height" : 13,
+          "width" : 77,
+          "x" : 252.5,
+          "y" : 262.02294921875
+        },
+        "depth" : 7,
+        "enabled" : true,
+        "role" : "AXStaticText",
+        "value" : "~20 tok\/s · 1.4 s"
+      },
+      {
+        "bounds" : {
+          "height" : 24,
+          "width" : 24,
+          "x" : 253,
+          "y" : 283
+        },
+        "depth" : 7,
+        "description" : "Copy response",
+        "enabled" : true,
+        "help" : "Copy response",
+        "identifier" : "ChatView.Message.Copy.0ED6D9D1-1401-41D2-815A-00E44978C77C",
+        "role" : "AXButton"
+      },
+      {
+        "bounds" : {
+          "height" : 24,
+          "width" : 24,
+          "x" : 279,
+          "y" : 283
+        },
+        "depth" : 7,
+        "description" : "Retry response",
+        "enabled" : true,
+        "identifier" : "ChatView.Message.Retry.0ED6D9D1-1401-41D2-815A-00E44978C77C",
+        "role" : "AXButton"
+      },
+      {
+        "bounds" : {
+          "height" : 19,
+          "width" : 125,
+          "x" : 272.5,
+          "y" : 623.5
+        },
+        "depth" : 5,
+        "enabled" : true,
+        "role" : "AXStaticText",
+        "value" : "Send a message…"
+      },
+      {
+        "bounds" : {
+          "height" : 31,
+          "width" : 700,
+          "x" : 263,
+          "y" : 618
+        },
+        "depth" : 5,
+        "role" : "AXScrollArea"
+      },
+      {
+        "bounds" : {
+          "height" : 31,
+          "width" : 700,
+          "x" : 263,
+          "y" : 618
+        },
+        "depth" : 6,
+        "description" : "Message compose field",
+        "identifier" : "rapid.chat.compose",
+        "role" : "AXTextArea",
+        "value" : ""
+      },
+      {
+        "bounds" : {
+          "height" : 28,
+          "width" : 118,
+          "x" : 809,
+          "y" : 654
+        },
+        "depth" : 5,
+        "description" : "Model",
+        "enabled" : true,
+        "help" : "Choose which model to run",
+        "identifier" : "ModelPickerBar.ModelMenu",
+        "role" : "AXMenuButton",
+        "value" : "fake-alias"
+      },
+      {
+        "bounds" : {
+          "height" : 28,
+          "width" : 28,
+          "x" : 935,
+          "y" : 654
+        },
+        "depth" : 5,
+        "description" : "Send message",
+        "enabled" : false,
+        "identifier" : "ChatView.SendOrStopButton",
+        "role" : "AXButton"
+      },
+      {
+        "bounds" : {
+          "height" : 52,
+          "width" : 1024,
+          "x" : 0,
+          "y" : 25
+        },
+        "depth" : 2,
+        "role" : "AXToolbar"
+      },
+      {
+        "bounds" : {
+          "height" : 52,
+          "width" : 42,
+          "x" : 87,
+          "y" : 25
+        },
+        "depth" : 3,
+        "description" : "Hide Sidebar",
+        "enabled" : true,
+        "identifier" : "",
+        "role" : "AXButton",
+        "selected" : false
+      },
+      {
+        "bounds" : {
+          "height" : 28,
+          "width" : 34,
+          "x" : 91,
+          "y" : 37
+        },
+        "depth" : 4,
+        "description" : "Hide Sidebar",
+        "enabled" : true,
+        "help" : "Hide Sidebar",
+        "role" : "AXButton"
+      },
+      {
+        "bounds" : {
+          "height" : 16,
+          "width" : 16,
+          "x" : 18,
+          "y" : 43
+        },
+        "depth" : 2,
+        "enabled" : true,
+        "role" : "AXButton",
+        "subrole" : "AXCloseButton"
+      },
+      {
+        "bounds" : {
+          "height" : 16,
+          "width" : 16,
+          "x" : 58,
+          "y" : 43
+        },
+        "depth" : 2,
+        "enabled" : true,
+        "help" : "this button also has an action to zoom the window",
+        "role" : "AXButton",
+        "subrole" : "AXFullScreenButton"
+      },
+      {
+        "bounds" : {
+          "height" : 16,
+          "width" : 14,
+          "x" : 59,
+          "y" : 43
+        },
+        "depth" : 3,
+        "role" : "AXGroup"
+      },
+      {
+        "bounds" : {
+          "height" : 16,
+          "width" : 14,
+          "x" : 59,
+          "y" : 43
+        },
+        "depth" : 4,
+        "role" : "AXGroup"
+      },
+      {
+        "bounds" : {
+          "height" : 16,
+          "width" : 16,
+          "x" : 38,
+          "y" : 43
+        },
+        "depth" : 2,
+        "enabled" : true,
+        "role" : "AXButton",
+        "subrole" : "AXMinimizeButton"
+      },
+      {
+        "bounds" : {
+          "height" : 52,
+          "width" : 807,
+          "x" : 209,
+          "y" : 25
+        },
+        "depth" : 2,
+        "enabled" : true,
+        "role" : "AXStaticText",
+        "value" : "Rapid-MLX"
+      }
+    ],
+    "walk" : {
+      "complete" : true,
+      "record_count" : 39
+    },
+    "windows" : {
+      "complete" : true,
+      "titles" : [
+        "Rapid-MLX"
+      ]
+    }
+  },
+  "success" : true
+}

--- a/tests/fixtures/ax_baseline/chat-settled.macos26.json
+++ b/tests/fixtures/ax_baseline/chat-settled.macos26.json
@@ -1,0 +1,477 @@
+{
+  "data" : {
+    "pid" : 88326,
+    "ui_elements" : [
+      {
+        "depth" : 0,
+        "role" : "AXApplication",
+        "title" : "Rapid-MLX"
+      },
+      {
+        "bounds" : {
+          "height" : 820,
+          "width" : 1200,
+          "x" : 725,
+          "y" : 145
+        },
+        "depth" : 1,
+        "identifier" : "main",
+        "role" : "AXWindow",
+        "subrole" : "AXStandardWindow",
+        "title" : "Rapid-MLX"
+      },
+      {
+        "bounds" : {
+          "height" : 820,
+          "width" : 1200,
+          "x" : 725,
+          "y" : 145
+        },
+        "depth" : 2,
+        "role" : "AXGroup",
+        "subrole" : "AXHostingView"
+      },
+      {
+        "bounds" : {
+          "height" : 820,
+          "width" : 1200,
+          "x" : 725,
+          "y" : 145
+        },
+        "depth" : 3,
+        "identifier" : "main, SidebarNavigationSplitView",
+        "role" : "AXSplitGroup"
+      },
+      {
+        "bounds" : {
+          "height" : 804,
+          "width" : 200,
+          "x" : 733,
+          "y" : 153
+        },
+        "depth" : 4,
+        "role" : "AXGroup",
+        "subrole" : "AXHostingView"
+      },
+      {
+        "bounds" : {
+          "height" : 30,
+          "width" : 184,
+          "x" : 741,
+          "y" : 209
+        },
+        "depth" : 5,
+        "description" : "New Chat",
+        "enabled" : true,
+        "identifier" : "Sidebar.NewChat",
+        "role" : "AXButton"
+      },
+      {
+        "bounds" : {
+          "height" : 30,
+          "width" : 184,
+          "x" : 741,
+          "y" : 240
+        },
+        "depth" : 5,
+        "description" : "Images",
+        "enabled" : true,
+        "identifier" : "Sidebar.Images",
+        "role" : "AXButton"
+      },
+      {
+        "bounds" : {
+          "height" : 30,
+          "width" : 184,
+          "x" : 741,
+          "y" : 271
+        },
+        "depth" : 5,
+        "description" : "Launch",
+        "enabled" : true,
+        "identifier" : "Sidebar.Launch",
+        "role" : "AXButton"
+      },
+      {
+        "bounds" : {
+          "height" : 642,
+          "width" : 184,
+          "x" : 741,
+          "y" : 302
+        },
+        "depth" : 5,
+        "role" : "AXScrollArea"
+      },
+      {
+        "bounds" : {
+          "height" : 14,
+          "width" : 33,
+          "x" : 749,
+          "y" : 318
+        },
+        "depth" : 6,
+        "description" : "Today",
+        "enabled" : true,
+        "role" : "AXHeading"
+      },
+      {
+        "bounds" : {
+          "height" : 24,
+          "width" : 24,
+          "x" : 877,
+          "y" : 340
+        },
+        "depth" : 6,
+        "description" : "Pin conversation",
+        "enabled" : true,
+        "help" : "Pin conversation",
+        "identifier" : "Sidebar.Conversation.Pin.DEE0E540-1032-47E8-900C-26396E845A5B",
+        "role" : "AXButton"
+      },
+      {
+        "bounds" : {
+          "height" : 14,
+          "width" : 20,
+          "x" : 901,
+          "y" : 345
+        },
+        "depth" : 6,
+        "description" : "Conversation actions",
+        "enabled" : true,
+        "identifier" : "Sidebar.Conversation.Menu.DEE0E540-1032-47E8-900C-26396E845A5B",
+        "role" : "AXMenuButton"
+      },
+      {
+        "bounds" : {
+          "height" : 30,
+          "width" : 184,
+          "x" : 741,
+          "y" : 337
+        },
+        "depth" : 6,
+        "description" : "golden restore marker",
+        "enabled" : true,
+        "identifier" : "Sidebar.Conversation.DEE0E540-1032-47E8-900C-26396E845A5B",
+        "role" : "AXButton",
+        "selected" : true
+      },
+      {
+        "bounds" : {
+          "height" : 768,
+          "width" : 0,
+          "x" : 933,
+          "y" : 197
+        },
+        "depth" : 4,
+        "enabled" : false,
+        "role" : "AXSplitter",
+        "selected" : false,
+        "value" : 208
+      },
+      {
+        "bounds" : {
+          "height" : 820,
+          "width" : 1200,
+          "x" : 725,
+          "y" : 145
+        },
+        "depth" : 4,
+        "role" : "AXGroup",
+        "subrole" : "AXHostingView"
+      },
+      {
+        "bounds" : {
+          "height" : 659,
+          "width" : 992,
+          "x" : 933,
+          "y" : 197
+        },
+        "depth" : 5,
+        "role" : "AXScrollArea"
+      },
+      {
+        "bounds" : {
+          "height" : 196,
+          "width" : 742,
+          "x" : 1047,
+          "y" : 231
+        },
+        "depth" : 6,
+        "enabled" : true,
+        "role" : "AXOpaqueProviderGroup",
+        "subrole" : "AXOpaqueProviderList"
+      },
+      {
+        "bounds" : {
+          "height" : 16,
+          "width" : 134,
+          "x" : 1641,
+          "y" : 231
+        },
+        "depth" : 7,
+        "enabled" : true,
+        "role" : "AXStaticText",
+        "value" : "golden restore marker"
+      },
+      {
+        "bounds" : {
+          "height" : 24,
+          "width" : 24,
+          "x" : 1739,
+          "y" : 261
+        },
+        "depth" : 7,
+        "description" : "Copy message",
+        "enabled" : true,
+        "help" : "Copy message",
+        "identifier" : "ChatView.Message.Copy.44CB1487-9FD1-4EED-90DE-555119D732B2",
+        "role" : "AXButton"
+      },
+      {
+        "bounds" : {
+          "height" : 24,
+          "width" : 24,
+          "x" : 1765,
+          "y" : 261
+        },
+        "depth" : 7,
+        "description" : "Edit message",
+        "enabled" : true,
+        "help" : "Edit message",
+        "identifier" : "ChatView.Message.Edit.44CB1487-9FD1-4EED-90DE-555119D732B2",
+        "role" : "AXButton"
+      },
+      {
+        "bounds" : {
+          "height" : 13.02294921875,
+          "width" : 109.5,
+          "x" : 1047,
+          "y" : 306
+        },
+        "depth" : 7,
+        "description" : "Reasoning",
+        "enabled" : true,
+        "role" : "AXDisclosureTriangle",
+        "value" : false
+      },
+      {
+        "bounds" : {
+          "height" : 43,
+          "width" : 700,
+          "x" : 1069,
+          "y" : 331
+        },
+        "depth" : 7,
+        "enabled" : true,
+        "role" : "AXStaticText",
+        "value" : "Hello from the fake rapid-mlx mock. I return deterministic content so the smoke test has something to assert on."
+      },
+      {
+        "bounds" : {
+          "height" : 13,
+          "width" : 91,
+          "x" : 1069,
+          "y" : 382.02294921875
+        },
+        "depth" : 7,
+        "enabled" : true,
+        "role" : "AXStaticText",
+        "value" : "~77 tok\/s · 365 ms"
+      },
+      {
+        "bounds" : {
+          "height" : 24,
+          "width" : 24,
+          "x" : 1069,
+          "y" : 403
+        },
+        "depth" : 7,
+        "description" : "Copy response",
+        "enabled" : true,
+        "help" : "Copy response",
+        "identifier" : "ChatView.Message.Copy.4F48ED27-F31F-478E-8949-B7AC5E6A5799",
+        "role" : "AXButton"
+      },
+      {
+        "bounds" : {
+          "height" : 24,
+          "width" : 24,
+          "x" : 1095,
+          "y" : 403
+        },
+        "depth" : 7,
+        "description" : "Retry response",
+        "enabled" : true,
+        "identifier" : "ChatView.Message.Retry.4F48ED27-F31F-478E-8949-B7AC5E6A5799",
+        "role" : "AXButton"
+      },
+      {
+        "bounds" : {
+          "height" : 19,
+          "width" : 125,
+          "x" : 1089,
+          "y" : 882.5
+        },
+        "depth" : 5,
+        "enabled" : true,
+        "role" : "AXStaticText",
+        "value" : "Send a message…"
+      },
+      {
+        "bounds" : {
+          "height" : 31,
+          "width" : 700,
+          "x" : 1079,
+          "y" : 877
+        },
+        "depth" : 5,
+        "role" : "AXScrollArea"
+      },
+      {
+        "bounds" : {
+          "height" : 31,
+          "width" : 700,
+          "x" : 1079,
+          "y" : 877
+        },
+        "depth" : 6,
+        "description" : "Message compose field",
+        "identifier" : "rapid.chat.compose",
+        "role" : "AXTextArea",
+        "value" : ""
+      },
+      {
+        "bounds" : {
+          "height" : 28,
+          "width" : 118,
+          "x" : 1625,
+          "y" : 913
+        },
+        "depth" : 5,
+        "description" : "Model",
+        "enabled" : true,
+        "help" : "Choose which model to run",
+        "identifier" : "ModelPickerBar.ModelMenu",
+        "role" : "AXMenuButton",
+        "value" : "fake-alias"
+      },
+      {
+        "bounds" : {
+          "height" : 28,
+          "width" : 28,
+          "x" : 1751,
+          "y" : 913
+        },
+        "depth" : 5,
+        "description" : "Send message",
+        "enabled" : false,
+        "identifier" : "ChatView.SendOrStopButton",
+        "role" : "AXButton"
+      },
+      {
+        "bounds" : {
+          "height" : 52,
+          "width" : 1200,
+          "x" : 725,
+          "y" : 145
+        },
+        "depth" : 2,
+        "role" : "AXToolbar"
+      },
+      {
+        "bounds" : {
+          "height" : 52,
+          "width" : 47,
+          "x" : 886,
+          "y" : 145
+        },
+        "depth" : 3,
+        "description" : "Hide Sidebar",
+        "enabled" : true,
+        "identifier" : "",
+        "role" : "AXButton",
+        "selected" : false
+      },
+      {
+        "bounds" : {
+          "height" : 16,
+          "width" : 16,
+          "x" : 743,
+          "y" : 163
+        },
+        "depth" : 2,
+        "enabled" : true,
+        "role" : "AXButton",
+        "subrole" : "AXCloseButton"
+      },
+      {
+        "bounds" : {
+          "height" : 16,
+          "width" : 16,
+          "x" : 789,
+          "y" : 163
+        },
+        "depth" : 2,
+        "enabled" : true,
+        "help" : "this button also has an action to zoom the window",
+        "role" : "AXButton",
+        "subrole" : "AXFullScreenButton"
+      },
+      {
+        "bounds" : {
+          "height" : 14,
+          "width" : 14,
+          "x" : 790,
+          "y" : 164
+        },
+        "depth" : 3,
+        "role" : "AXGroup"
+      },
+      {
+        "bounds" : {
+          "height" : 14,
+          "width" : 14,
+          "x" : 790,
+          "y" : 164
+        },
+        "depth" : 4,
+        "role" : "AXGroup"
+      },
+      {
+        "bounds" : {
+          "height" : 16,
+          "width" : 16,
+          "x" : 766,
+          "y" : 163
+        },
+        "depth" : 2,
+        "enabled" : true,
+        "role" : "AXButton",
+        "subrole" : "AXMinimizeButton"
+      },
+      {
+        "bounds" : {
+          "height" : 52,
+          "width" : 984,
+          "x" : 937,
+          "y" : 145
+        },
+        "depth" : 2,
+        "enabled" : true,
+        "role" : "AXStaticText",
+        "value" : "Rapid-MLX"
+      }
+    ],
+    "walk" : {
+      "complete" : true,
+      "record_count" : 38
+    },
+    "windows" : {
+      "complete" : true,
+      "titles" : [
+        "Rapid-MLX"
+      ]
+    }
+  },
+  "success" : true
+}

--- a/tests/test_ax_baseline_os_variance.py
+++ b/tests/test_ax_baseline_os_variance.py
@@ -1,0 +1,168 @@
+# SPDX-License-Identifier: Apache-2.0
+"""AX structural baselines must not depend on the macOS version.
+
+A golden-flow baseline is generated on whatever machine a developer happens to
+have and then enforced on a GitHub-hosted runner. If any part of the normalized
+tree varies with the OS, the two can never agree: whoever regenerates the
+baseline turns the other side red, and ``--update-baselines`` stops being a
+tool and becomes a trap.
+
+That is not hypothetical. PR #1721 built one commit on both, and the runner's
+accessibility tree reported an ``AXTitle`` that the dev machine did not:
+
+    AXPopUpButton id="Sidebar.Conversation.Menu.<uuid>"
+        title="More" desc="Conversation actions"      # macOS 15, hosted runner
+    AXPopUpButton id="Sidebar.Conversation.Menu.<uuid>"
+        desc="Conversation actions"                   # macOS 26, dev machine
+
+The fixtures beside this file are the REAL dumps from those two runs, not
+hand-written approximations, so this suite fails if the normalizer ever stops
+absorbing that difference.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+BASELINE_TOOL = ROOT / "apps/rapid-mac/scripts/ax-baseline.py"
+FIXTURES = Path(__file__).resolve().parent / "fixtures/ax_baseline"
+SNAPSHOTS = ROOT / "apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__"
+# The token the golden flows pass, so fixture normalization matches production.
+SCRUB = ("fake-alias",)
+
+
+def _load_tool():
+    """Import ax-baseline.py, whose filename is not a valid module name."""
+    spec = importlib.util.spec_from_file_location("ax_baseline", BASELINE_TOOL)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+ax_baseline = _load_tool()
+
+
+def _normalize(path: Path) -> list[str]:
+    return ax_baseline.normalize_dump(path, SCRUB)
+
+
+def test_fixtures_actually_differ_before_normalization():
+    """Guard against a vacuous cross-OS test.
+
+    If someone regenerates both fixtures on one machine they become identical,
+    and the equality test below would pass while checking nothing at all. Pin
+    the difference these fixtures exist to carry.
+    """
+    macos15 = json.loads((FIXTURES / "chat-settled.macos15.json").read_text())
+    macos26 = json.loads((FIXTURES / "chat-settled.macos26.json").read_text())
+
+    def titled_menus(payload: dict) -> list[str]:
+        return [
+            element.get("title", "")
+            for element in payload["data"]["ui_elements"]
+            if str(element.get("identifier", "")).startswith(
+                "Sidebar.Conversation.Menu."
+            )
+        ]
+
+    assert titled_menus(macos15) == ["More"], (
+        "the macOS 15 fixture no longer carries the AppKit-synthesised title; "
+        "it is no longer evidence of cross-OS variance"
+    )
+    assert titled_menus(macos26) == [""], (
+        "the macOS 26 fixture unexpectedly carries a title; regenerate it on "
+        "macOS 26 or this suite proves nothing"
+    )
+
+
+def test_real_cross_os_dumps_normalize_identically():
+    """The whole point: same commit, two macOS versions, one baseline."""
+    macos15 = _normalize(FIXTURES / "chat-settled.macos15.json")
+    macos26 = _normalize(FIXTURES / "chat-settled.macos26.json")
+    assert macos15 == macos26, (
+        "the normalizer lets a macOS difference through — a baseline generated "
+        "on one macOS cannot be enforced on the other"
+    )
+
+
+def test_committed_baseline_accepts_the_other_os_dump():
+    """End to end, against the baseline the golden flows actually enforce.
+
+    Equality between the two fixtures is necessary but not sufficient: both
+    could normalize to something the committed file does not match.
+    """
+    observed = _normalize(FIXTURES / "chat-settled.macos15.json")
+    committed = (SNAPSHOTS / "chat-restore.answered.txt").read_text().splitlines()
+    assert observed == committed
+
+
+def _render(record: dict) -> str:
+    node = ax_baseline.Node(record)
+    return ax_baseline.render_node(node, SCRUB)
+
+
+def test_title_is_dropped_when_a_description_is_present():
+    rendered = _render(
+        {
+            "role": "AXPopUpButton",
+            "identifier": "Sidebar.Conversation.Menu.x",
+            "title": "More",
+            "description": "Conversation actions",
+        }
+    )
+    assert "More" not in rendered
+    assert 'desc="Conversation actions"' in rendered
+
+
+def test_title_is_kept_when_it_is_the_only_label():
+    """The rule has to stay narrow or it destroys real signal.
+
+    `Settings.ModelManagement.SortMenu` publishes a title and no description;
+    without it that popup is indistinguishable from its neighbour.
+    """
+    rendered = _render(
+        {
+            "role": "AXPopUpButton",
+            "identifier": "Settings.ModelManagement.SortMenu",
+            "title": "Sort",
+        }
+    )
+    assert 'title="Sort"' in rendered
+
+
+@pytest.mark.parametrize(
+    "baseline", sorted(SNAPSHOTS.glob("*.txt")), ids=lambda p: p.name
+)
+def test_no_committed_baseline_pins_a_title_beside_a_description(baseline: Path):
+    """Corpus invariant, enforced on every committed baseline.
+
+    Covers the files this change did not regenerate, and catches a baseline
+    written by an older copy of the normalizer.
+    """
+    offenders = [
+        line.strip()
+        for line in baseline.read_text().splitlines()
+        if " title=" in f" {line.strip()}" and " desc=" in line
+    ]
+    assert not offenders, (
+        f"{baseline.name} pins an AppKit-synthesised title next to the app's "
+        f"own description: {offenders}"
+    )
+
+
+def test_window_ordering_ignores_a_title_the_baseline_hides():
+    """Sorting must use what is rendered, or two OSes order windows differently
+    while rendering identical lines."""
+    with_title = ax_baseline.Node(
+        {"role": "AXWindow", "title": "More", "description": "Main"}
+    )
+    without_title = ax_baseline.Node({"role": "AXWindow", "description": "Main"})
+    assert ax_baseline.window_sort_key(with_title) == ax_baseline.window_sort_key(
+        without_title
+    )

--- a/tests/test_ax_baseline_os_variance.py
+++ b/tests/test_ax_baseline_os_variance.py
@@ -18,6 +18,14 @@ accessibility tree reported an ``AXTitle`` that the dev machine did not:
 The fixtures beside this file are the REAL dumps from those two runs, not
 hand-written approximations, so this suite fails if the normalizer ever stops
 absorbing that difference.
+
+They are a FROZEN corpus for the normalizer, deliberately not tied to the app's
+current UI. Do not add a test asserting that a fixture normalizes to a
+committed baseline: the two drift apart the first time anyone changes the
+chat view, and the churn teaches people to refresh fixtures reflexively — the
+exact habit that let three separate UI changes ship with stale baselines. That
+the committed baselines match a LIVE app is the macOS golden-flow job's
+assertion, made on both operating systems, every PR.
 """
 
 from __future__ import annotations
@@ -110,17 +118,6 @@ def test_real_cross_os_dumps_normalize_identically():
         "the normalizer lets a macOS difference through — a baseline generated "
         "on one macOS cannot be enforced on the other"
     )
-
-
-def test_committed_baseline_accepts_the_other_os_dump():
-    """End to end, against the baseline the golden flows actually enforce.
-
-    Equality between the two fixtures is necessary but not sufficient: both
-    could normalize to something the committed file does not match.
-    """
-    observed = _normalize(FIXTURES / "chat-settled.macos15.json")
-    committed = (SNAPSHOTS / "chat-restore.answered.txt").read_text().splitlines()
-    assert observed == committed
 
 
 def _render(record: dict) -> str:

--- a/tests/test_ax_baseline_os_variance.py
+++ b/tests/test_ax_baseline_os_variance.py
@@ -52,33 +52,54 @@ def _normalize(path: Path) -> list[str]:
     return ax_baseline.normalize_dump(path, SCRUB)
 
 
-def test_fixtures_actually_differ_before_normalization():
+def test_fixtures_carry_all_three_known_os_differences():
     """Guard against a vacuous cross-OS test.
 
-    If someone regenerates both fixtures on one machine they become identical,
-    and the equality test below would pass while checking nothing at all. Pin
-    the difference these fixtures exist to carry.
-    """
-    macos15 = json.loads((FIXTURES / "chat-settled.macos15.json").read_text())
-    macos26 = json.loads((FIXTURES / "chat-settled.macos26.json").read_text())
+    Regenerate both fixtures on one machine and they become identical, and the
+    equality test below passes while checking nothing at all. So pin what these
+    two dumps exist to carry. The same UI, from the same commit, differs in
+    THREE independent ways between the two releases:
 
-    def titled_menus(payload: dict) -> list[str]:
-        return [
-            element.get("title", "")
-            for element in payload["data"]["ui_elements"]
+      1. the conversation menu's role spelling — AXMenuButton on macOS 26,
+         AXPopUpButton on macOS 15 (absorbed by ``_ROLE_EQUIVALENTS``);
+      2. an extra lazily-realized AXButton child under the "Hide Sidebar"
+         control on macOS 15 (absorbed by ``is_window_control``);
+      3. an AppKit-synthesised AXTitle="More" on the conversation menu on
+         macOS 15 (absorbed by the title rule in ``render_node``).
+
+    Any of the three regressing makes ``--update-baselines`` machine-specific
+    again, so the corpus has to keep covering all three.
+    """
+    macos15 = json.loads((FIXTURES / "chat-settled.macos15.json").read_text())["data"][
+        "ui_elements"
+    ]
+    macos26 = json.loads((FIXTURES / "chat-settled.macos26.json").read_text())["data"][
+        "ui_elements"
+    ]
+
+    def menu(elements: list[dict]) -> dict:
+        return next(
+            element
+            for element in elements
             if str(element.get("identifier", "")).startswith(
                 "Sidebar.Conversation.Menu."
             )
-        ]
+        )
 
-    assert titled_menus(macos15) == ["More"], (
-        "the macOS 15 fixture no longer carries the AppKit-synthesised title; "
-        "it is no longer evidence of cross-OS variance"
-    )
-    assert titled_menus(macos26) == [""], (
-        "the macOS 26 fixture unexpectedly carries a title; regenerate it on "
-        "macOS 26 or this suite proves nothing"
-    )
+    # 1. role spelling
+    assert menu(macos15)["role"] == "AXPopUpButton"
+    assert menu(macos26)["role"] == "AXMenuButton"
+
+    # 2. the extra OS-owned sidebar child
+    def hide_sidebar_nodes(elements: list[dict]) -> int:
+        return sum(1 for e in elements if e.get("description") == "Hide Sidebar")
+
+    assert hide_sidebar_nodes(macos15) == 2
+    assert hide_sidebar_nodes(macos26) == 1
+
+    # 3. the synthesised title
+    assert menu(macos15).get("title") == "More"
+    assert "title" not in menu(macos26)
 
 
 def test_real_cross_os_dumps_normalize_identically():

--- a/tests/test_gui_preflight_contract.py
+++ b/tests/test_gui_preflight_contract.py
@@ -1,0 +1,103 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Static contract for the golden-flow GUI preflight.
+
+Two different environment faults make the golden flows fail in exactly the same
+misleading way — the flow waits 20 s and dies on "main window did not appear",
+which reads as "the app is broken":
+
+  * the controlling process does not hold TCC Accessibility, so every AX read
+    fails and the dump contains nothing but the application root;
+  * the screen is locked, so Accessibility is fine and other processes' trees
+    read perfectly, but no application can present a window.
+
+Both were hit for real while this gate was being built. The preflight turns
+each into a one-line, correctly-named failure before anything launches. These
+tests exist because deleting it would not break a single flow on a healthy
+machine — it would only quietly restore the misdiagnosis on an unhealthy one.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+DRIVER = ROOT / "apps/rapid-mac/scripts/rapid-ax.swift"
+HARNESS = ROOT / "apps/rapid-mac/scripts/gui-golden-flows.sh"
+
+
+def test_trust_command_checks_permission_reach_and_lock():
+    source = DRIVER.read_text()
+    trust = source.split('CommandLine.arguments[1] == "trust"', 1)[1]
+    trust = trust.split("guard CommandLine.arguments.count >= 3", 1)[0]
+
+    # The system's opinion about us...
+    assert "AXIsProcessTrusted()" in trust
+    # ...a real cross-process read, because that opinion is not proof...
+    assert "AXUIElementCopyAttributeValue(" in trust
+    # ...and the one signal neither of those can carry.
+    assert "CGSessionCopyCurrentDictionary()" in trust
+    assert "CGSSessionScreenIsLocked" in trust
+
+
+def test_trust_success_requires_all_three_signals():
+    """`success` must not be satisfiable by a subset.
+
+    A locked screen still reports trusted == true and a successful read, so an
+    AND that forgets the lock bit is green in exactly the case that matters.
+    """
+    source = DRIVER.read_text()
+    line = next(line for line in source.splitlines() if 'payload["success"]' in line)
+    assert "trusted" in line
+    assert "readSucceeded" in line
+    assert "screenLocked" in line
+
+
+def test_each_fault_fails_with_its_own_message():
+    source = DRIVER.read_text()
+    assert source.count("fail(") >= 4
+    # Naming the fault is the entire point; a shared message would rebuild the
+    # ambiguity this preflight exists to remove.
+    assert "the screen is locked" in source
+    assert "NOT trusted for Accessibility" in source
+
+
+def test_preflight_runs_before_any_persona_starts():
+    source = HARNESS.read_text()
+    require_tools = source.split("require_tools() {", 1)[1].split("\n}", 1)[0]
+    assert "require_ax_trust" in require_tools
+    # Before the peekaboo branch, so the cheap universal check is not skipped
+    # for the flows that return early.
+    assert require_tools.index("require_ax_trust") < require_tools.index(
+        "flow_requires_peekaboo"
+    )
+    # And require_tools itself runs before the dispatcher picks a flow.
+    assert source.index("require_tools\n") < source.index(
+        'case "$FLOW" in\n    fresh-install)'
+    )
+
+
+def test_peekaboo_requirement_is_default_deny():
+    """A new flow must be assumed to need peekaboo until stated otherwise.
+
+    The inverse — listing the flows that DO need it — is silent when someone
+    adds a flow and forgets, and the failure lands on a runner as an unrelated
+    "command not found".
+    """
+    source = HARNESS.read_text()
+    body = source.split("flow_requires_peekaboo() {", 1)[1].split("\n}", 1)[0]
+    assert "*) return 0 ;;" in body, "the catch-all must REQUIRE peekaboo"
+    peekaboo_free = {
+        "chat-restore",
+        "restored-tools",
+        "tool-loop-budget",
+        "chat-depth",
+        "slow-stream-stop",
+        "model-crash-recovery",
+    }
+    named = {
+        flow
+        for line in body.splitlines()
+        if "return 1" in line
+        for flow in line.split(")", 1)[0].strip().split("|")
+    }
+    assert named == peekaboo_free


### PR DESCRIPTION
## Why

`apps/rapid-mac/scripts/gui-golden-flows.sh` defines 15 flows and `Tests/GUIGoldenFlows/__Snapshots__/` holds 12 committed AX structural baselines. **None of them ran in any workflow.** They ran when a human remembered, which is not a regression net.

The cost is not hypothetical — there are two live instances right now:

1. `286b735f` (#1705, **current HEAD of main**) added the `Sidebar.Images` button and left all 12 baselines stale. Every selected flow fails on main today with `+ AXButton id="Sidebar.Images"`.
2. A branch in flight removes two chat empty-state buttons; 4 baselines still pin them.

Neither was reported by anything.

## What runs

A `gui-golden-flows` job on `macos-15`, added to the existing `rapid-mac-ci.yml` rather than a new workflow file, so it inherits that file's `paths:` filters by construction instead of via a copy that drifts. Engine-only PRs do not trigger it.

Four flows, chosen because they need neither `peekaboo` nor a model:

* `fresh-install` · `chat-restore` · `restored-tools` · `tool-loop-budget`

They drive `scripts/fake-rapid-mlx.sh`, so: no model download, no GPU, no network. `SKIP_SIDECAR=1` skips the 5–10 min Python sidecar staging. Locally each flow is 6–11 s.

## Why this works on a hosted runner

The obvious objection is TCC: `AXUIElementCopyAttributeValue` needs the controlling process to hold Accessibility, and a workflow cannot grant that at runtime under SIP (runner-images #3286, #1567).

It does not need to. The **image** already granted it, at build time, before SIP is in the way — `actions/runner-images` → `images/macos/scripts/build/configure-tccdb-macos.sh` writes into the system TCC.db:

```
'kTCCServiceAccessibility','/bin/bash',1,2,...
```

`client_type=1` (path), `auth_value=2` (allowed), and the same for `/opt/hca/hosted-compute-agent` and `/usr/local/opt/runner/provisioner/provisioner` — the processes that parent every `run:` step and therefore own TCC responsibility for what those steps spawn. `kTCCServiceScreenCapture` and `kTCCServicePostEvent` are granted the same way. The same packer templates run `configure-autologin.sh` right after, so there is a real logged-in Aqua session and an `.app` can open a window.

## Fail-closed preflight

New `rapid-ax trust` subcommand, run before any flow. It reports `AXIsProcessTrusted()` **and** performs a real cross-process AX read, exiting non-zero on either.

Without it, a missing grant and a product bug are indistinguishable: every AX read fails, `dump` returns only the app root, and the flow dies on `"main window did not appear"` — accusing the app of something we were never permitted to observe. If the runner image ever drops the grant, this job goes red naming the permission instead of inventing a regression.

`flow_requires_peekaboo()` is **default-deny**: a new flow is assumed to need peekaboo unless it says otherwise, so one cannot silently join the CI subset and then fail there.

## Proof the gate can fail

Three, staged deliberately:

**1. Baseline pins a control the app does not render**
```
  disappeared at baseline line 10:
    -           AXButton desc="Connect your agents" ... enabled=true
[gui-golden] FAIL: AX structural baseline mismatch: chat-restore.answered
```

**2. A real source change** — deleted `.accessibilityIdentifier("Sidebar.Images")` from `SidebarView.swift` and rebuilt:
```
  changed at baseline line 8:
    -           AXButton id="Sidebar.Images" desc="Images" enabled=true
    +           AXButton desc="Images" enabled=true
[gui-golden] FAIL: AX structural baseline mismatch: chat-restore.answered
```

**3. The Accessibility preflight**, staged with `sandbox-exec` denying `com.apple.tccd` — the actual CI failure mode:
```
rapid-ax: this process is NOT trusted for Accessibility (AXIsProcessTrusted() == false).
Every AX read will fail, and the golden flows would report a missing window
instead of a missing permission.
EXIT=1
```

Source restored, rebuilt, all four flows green.

## Baselines

6 regenerated (one added line each, the `Sidebar.Images` button from #1705). `fresh-install.*` and `settings-persistence.*` are **deliberately left stale** — a branch in flight owns those and needs the same one-line addition; regenerating them here would collide.

## Known limits

* **Not verified on a real runner.** Locally proven end-to-end and evidence-based on the runner-image sources, but this PR's own CI run is the first in-situ execution. The preflight exists so that a wrong assumption surfaces as a named failure rather than a hollow pass.
* **Coverage is 6 of 12 baselines.** The subset excludes `fresh-install` and `settings-persistence`, so it would **not** have caught the two-button removal mentioned above. The single blocker is `pb menu click --item 'Settings…'` inside `open_settings`; making that AX-native unlocks `settings-persistence` and 4 more baselines. Highest-value follow-up.
* **`Sources/` is untouched.** shellcheck clean; `tests/test_gui_walk_completeness.py` and `tests/test_rapid_mac_ax_identifiers.py` pass (72).

## Also found

Running the harness locally kills a developer's own `rapid-mlx` on :8000 — the app's launch-time `PortSweep` matches on command *shape*, not per-instance ownership (#1618). Every local invocation here used `RAPID_DESKTOP_NO_PORT_SWEEP=1`; irrelevant on a clean runner, a real footgun when dogfooding.

Closes nothing on its own; makes #1719 (XCUITest) the next question rather than the only one.