### PR TITLE
fix(mac): the reasoning tools token floor never lifted anyone

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Chat/SamplingConfig.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/SamplingConfig.swift
@@ -95,13 +95,63 @@ final class SamplingConfig {
     /// non-reasoning floor lowering can't silently downshift a
     /// reasoning alias below 2,048.
     ///
-    /// Tools floor ``4096`` — a multi-tool prompt on the same
-    /// reasoning alias routinely emits 3-4k completion tokens
-    /// before the *second* tool_call fires (cycle-2 repro at
-    /// 4,096 used 3,407 completion tokens for the single-tool
-    /// 27+45 case). Tools-on auto-scales to this floor instead
-    /// of the chat one so a reasoning-finetune with a heavy
-    /// preamble doesn't blow the budget mid-tool-call.
+    /// Tools floor ``16384`` — a multi-tool prompt on a reasoning
+    /// alias routinely emits 3-4k completion tokens before the
+    /// *second* tool_call fires (cycle-2 repro at 4,096 used 3,407
+    /// for the single-tool 27+45 case). Tools-on auto-scales to
+    /// this floor instead of the chat one so a reasoning-finetune
+    /// with a heavy preamble doesn't blow the budget mid-tool-call.
+    ///
+    /// This floor sat at ``4_096`` — identical to
+    /// ``maxTokensDefault`` — from the day it was introduced, so
+    /// ``max(maxTokens, effectiveToolsFloor)`` resolved to 4,096 on
+    /// every default install. **It never lifted anyone by a single
+    /// token.** The intent was recorded; the effect was not.
+    ///
+    /// What that cost, measured on 2026-08-09 through the shipped
+    /// GUI against `qwen3.5-4b-4bit` — the 16 GB tier's own
+    /// recommendation — asking one live web-research question five
+    /// times:
+    ///
+    /// | outcome | runs |
+    /// |---|---|
+    /// | tool budget exhausted, no answer | 2 |
+    /// | hit max_tokens with EMPTY content | 2 |
+    /// | answered | 1 |
+    ///
+    /// and the one that answered opened with "I can't access
+    /// real-time news or browse live pages" before contradicting
+    /// itself from the search results it had just been handed.
+    ///
+    /// Sizing this by measured consumption would be the wrong
+    /// instrument. ``max_tokens`` is a safety ceiling, not a budget
+    /// allocation: its job is to be high enough that legitimate work
+    /// never reaches it and low enough that a runaway is cut off in
+    /// tolerable time. Fitting it to a p95 of observed usage kills
+    /// the other 5% by construction, and would need re-deriving for
+    /// every new tool, model and quantisation.
+    ///
+    /// So it is set from the two real costs instead:
+    ///
+    ///   * **Memory: none.** The KV cache grows with tokens actually
+    ///     produced. The one place ``max_tokens`` could reserve
+    ///     capacity up front is
+    ///     ``SchedulerConfig.metal_cap_kv_bytes_per_token``, which
+    ///     defaults to ``0`` (disabled) and which the desktop never
+    ///     sets. Worst case for this model is 32 KB/token over its 8
+    ///     full-attention layers — 512 MB if a turn genuinely runs to
+    ///     16,384, against 2.9 GB of weights. Nothing is spent until
+    ///     the tokens are.
+    ///   * **Time: real.** At ~60 tok/s this is ~4.5 min of decode
+    ///     before the ceiling fires, and the tool loop allows up to
+    ///     four rounds. That is the price, and it is the right one to
+    ///     pay: a turn that runs long and then answers beats a turn
+    ///     that stops early and delivers nothing.
+    ///
+    /// A model that genuinely needs different numbers gets them
+    /// per-alias from the engine via
+    /// ``ServerModelProfile.reasoningToolsFloor`` rather than by
+    /// moving this global.
     ///
     /// Both floors are observed only via ``applyServerProfile``
     /// + ``effectiveMaxTokens(toolsEnabled:)``, so a user who
@@ -109,7 +159,7 @@ final class SamplingConfig {
     /// below) takes immediate priority — auto-scale never fights
     /// an explicit user choice.
     static let reasoningChatFloor: Int = 2_048
-    static let reasoningToolsFloor: Int = 4_096
+    static let reasoningToolsFloor: Int = 16_384
     /// FU-3 (post-v0.7.19) canonical names. ``reasoningChatFloor``
     /// and ``reasoningToolsFloor`` are the GLOBAL fallbacks the
     /// per-alias override (``ServerModelProfile.reasoningChatFloor``

--- a/apps/rapid-mac/Tests/RapidTests/SamplingConfigPerAliasFloorTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SamplingConfigPerAliasFloorTests.swift
@@ -64,7 +64,7 @@ final class SamplingConfigPerAliasFloorTests {
         #expect(s.effectiveChatFloor == SamplingConfig.defaultReasoningChatFloor)
         #expect(s.effectiveToolsFloor == SamplingConfig.defaultReasoningToolsFloor)
         #expect(s.effectiveChatFloor == 2_048)
-        #expect(s.effectiveToolsFloor == 4_096)
+        #expect(s.effectiveToolsFloor == 16_384)
     }
 
     /// Pin the canonical default-alias names alias the legacy

--- a/apps/rapid-mac/Tests/RapidTests/ServerModelProfileTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ServerModelProfileTests.swift
@@ -222,9 +222,16 @@ final class ServerModelProfileTests {
     @Test("Cycle-3: reasoning floor constants exist + are non-decreasing (chat ≤ tools)")
     func reasoningFloorConstantsAreConsistent() {
         #expect(SamplingConfig.reasoningChatFloor == 2_048)
-        #expect(SamplingConfig.reasoningToolsFloor == 4_096)
+        #expect(SamplingConfig.reasoningToolsFloor == 16_384)
         #expect(SamplingConfig.reasoningChatFloor <= SamplingConfig.reasoningToolsFloor,
                 "tools floor must be at least the chat floor — tools-heavy prompts emit more reasoning tokens before the first call")
+        // The floor spent its whole life equal to maxTokensDefault, which
+        // made `max(maxTokens, effectiveToolsFloor)` a no-op and lifted
+        // nobody. A floor at or below the baseline is not a floor.
+        #expect(SamplingConfig.reasoningToolsFloor > SamplingConfig.maxTokensDefault,
+                "a tools floor that does not exceed the default budget can never raise it — see the 5-run repro in SamplingConfig")
+        #expect(SamplingConfig.reasoningToolsFloor <= SamplingConfig.maxTokensRange.upperBound,
+                "the floor must be reachable through the same range an explicit user choice obeys")
     }
 
     /// Non-reasoning alias path — the existing 4,096 default must NOT
@@ -363,8 +370,9 @@ final class ServerModelProfileTests {
     /// so a "Reset" press behaves like a clean v0.4.12 install. Without
     /// this clear, a user who resets while a reasoning alias is loaded
     /// would still see ``effectiveMaxTokens(toolsEnabled: true) ==
-    /// reasoningToolsFloor`` (which is OK at 4,096 == default today, but
-    /// would diverge the moment the floor is raised).
+    /// reasoningToolsFloor``. That used to be harmless because the floor
+    /// equalled the default; now that it is 16,384 the two genuinely
+    /// diverge, so this assertion carries real weight.
     @Test("Cycle-3: resetToDefaults clears activeReasoningParser + the auto-scale bookkeeping")
     func resetClearsReasoningBookkeeping() {
         let s = SamplingConfig(defaults: freshDefaults())


### PR DESCRIPTION
## The bug

```swift
static let maxTokensDefault:    Int = 4096
static let reasoningToolsFloor: Int = 4_096
```

`effectiveMaxTokens(toolsEnabled:)` resolves `max(maxTokens, effectiveToolsFloor)`. On every default install that is `max(4096, 4096)`.

**The floor has been inert since the day it was added.** Its docstring describes lifting a tools-carrying turn on a reasoning alias above the baseline "so a reasoning-finetune with a heavy preamble doesn't blow the budget mid-tool-call". It never lifted anyone by a single token. A test comment had already noticed the arithmetic without following it through — *"which is OK at 4,096 == default today"*.

## What it cost

Measured through the shipped GUI (AX-driven, five identical turns, `qwen3.5-4b-4bit` — the **16 GB tier's own recommended model** — asking one live web-research question):

| outcome | runs |
|---|---|
| tool budget exhausted, no answer | 2 |
| hit `max_tokens` with **empty** content | 2 |
| answered | 1 |

Four in five delivered nothing. And the one that answered opened with:

> "I can't access real-time news or browse live pages. However, based on the search results…"

— contradicting itself inside one sentence, using evidence it had just been handed. That is the same shape as an external report we received against 0.12.7.

For contrast, `qwen3.6-35b-4bit` answers this cleanly in 41 s with three cited sources. Smaller models are *more* token-hungry on reasoning, not less, so the tier that most needs headroom is the one running with none.

## Why 16,384 and not a measured number

`max_tokens` is a **safety ceiling, not a budget allocation**. Its job is to be high enough that legitimate work never reaches it, and low enough that a runaway is cut off in tolerable time.

Sizing it to observed consumption inverts that: fitting a p95 kills the remaining 5% by construction, and the number would need re-deriving for every new tool, model and quantisation — a matrix nobody can maintain. So it is set from the two costs that are actually real:

**Memory: none.** The KV cache grows with tokens actually produced. The one place `max_tokens` could reserve capacity up front is `SchedulerConfig.metal_cap_kv_bytes_per_token`, which defaults to `0` (disabled) and which the desktop never passes. Worst case for this model is 32 KB/token across its 8 full-attention layers (32 layers, but the rest are linear-attention with fixed state) — 512 MB *only if a turn genuinely runs to 16,384*, against 2.9 GB of weights. Nothing is spent until the tokens are.

**Time: real.** ~4.5 min of decode at ~60 tok/s before the ceiling fires, and the tool loop allows up to four rounds.

That trade is taken deliberately: **a turn that runs long and then answers beats a turn that stops early and delivers nothing.**

## Scope

One constant. Only `reasoning_parser != null` aliases with tools advertised are affected — the failing case. Plain chat is untouched (`reasoningChatFloor` stays 2,048, below the baseline, still inert there and fine: plain chat is not failing). A user who has dragged the Settings → Sampling slider at all keeps their value; `maxTokensIsAutoScaled` already guarantees auto-scale never fights an explicit choice.

Per-alias overrides via `ServerModelProfile.reasoningToolsFloor` remain the escape hatch for a model that genuinely needs different numbers, so onboarding a special case does not mean moving this global.

## Guarding the class, not the value

Two assertions added:

```swift
#expect(SamplingConfig.reasoningToolsFloor > SamplingConfig.maxTokensDefault,
        "a tools floor that does not exceed the default budget can never raise it")
#expect(SamplingConfig.reasoningToolsFloor <= SamplingConfig.maxTokensRange.upperBound,
        "the floor must be reachable through the same range an explicit user choice obeys")
```

The first is the one that matters: it fails on the *original* code, and it fails on any future edit that quietly re-flattens the floor against the baseline. The existing `== 4_096` pin would have happily survived the bug forever, because it pinned the value rather than the property.

## Verification status — read this before merging

`swift build` is clean. **The test assertions in this PR have not been executed**: this machine has no full Xcode, so neither `XCTest` nor swift-testing resolves (#1638) and `swift test` cannot run at all. Every assertion here was checked by reading, and I traced each of the ~29 floor-sensitive assertions in `ServerModelProfileTests` / `SamplingConfigPerAliasFloorTests` to confirm which follow the constant (most), which pin explicit user choices (`512`, `2_048` — unaffected), and which pin per-alias overrides (`8_192` — unaffected). CI is the first real execution.

The runtime behaviour change *was* measured, on the real app, as above.