### PR TITLE
Add image attachments to Chat

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatMessage.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatMessage.swift
@@ -320,6 +320,7 @@ struct ChatMessage: Identifiable, Codable, Equatable, Hashable {
         try c.encode(id, forKey: .id)
         try c.encode(role, forKey: .role)
         try c.encode(content, forKey: .content)
+        try c.encode(imageAttachments, forKey: .imageAttachments)
         try c.encode(reasoning, forKey: .reasoning)
         try c.encode(status, forKey: .status)
         try c.encodeIfPresent(errorMessage, forKey: .errorMessage)

--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatMessage.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatMessage.swift
@@ -1,4 +1,56 @@
 import Foundation
+import ImageIO
+import UniformTypeIdentifiers
+
+struct ChatImageAttachment: Codable, Equatable, Hashable, Identifiable, Sendable {
+    static let maxBytes = 20 * 1024 * 1024
+
+    let id: UUID
+    let filename: String
+    let mimeType: String
+    let data: Data
+
+    init(id: UUID = UUID(), filename: String, mimeType: String, data: Data) throws {
+        guard data.count <= Self.maxBytes else { throw ValidationError.tooLarge }
+        guard ["image/png", "image/jpeg", "image/gif"].contains(mimeType) else {
+            throw ValidationError.unsupportedType
+        }
+        if mimeType == "image/gif",
+           let source = CGImageSourceCreateWithData(data as CFData, nil),
+           CGImageSourceGetCount(source) > 1 {
+            throw ValidationError.animatedGIF
+        }
+        self.id = id
+        self.filename = filename
+        self.mimeType = mimeType
+        self.data = data
+    }
+
+    init(contentsOf url: URL) throws {
+        let values = try url.resourceValues(forKeys: [.fileSizeKey, .contentTypeKey])
+        guard (values.fileSize ?? 0) <= Self.maxBytes else { throw ValidationError.tooLarge }
+        let type = values.contentType
+        let mime: String
+        if type?.conforms(to: .png) == true { mime = "image/png" }
+        else if type?.conforms(to: .jpeg) == true { mime = "image/jpeg" }
+        else if type?.conforms(to: .gif) == true { mime = "image/gif" }
+        else { throw ValidationError.unsupportedType }
+        try self.init(filename: url.lastPathComponent, mimeType: mime, data: Data(contentsOf: url))
+    }
+
+    var dataURL: String { "data:\(mimeType);base64,\(data.base64EncodedString())" }
+
+    enum ValidationError: LocalizedError {
+        case tooLarge, unsupportedType, animatedGIF
+        var errorDescription: String? {
+            switch self {
+            case .tooLarge: return "Images must be 20 MB or smaller."
+            case .unsupportedType: return "Choose a PNG, JPEG, or non-animated GIF."
+            case .animatedGIF: return "Animated GIFs aren't supported."
+            }
+        }
+    }
+}
 
 /// One chat message. Mirrors the OpenAI chat-completions schema closely
 /// enough that the stream client can serialise an array of these directly
@@ -73,6 +125,7 @@ struct ChatMessage: Identifiable, Codable, Equatable, Hashable {
     /// the model produced — that goes into ``reasoning`` so the UI can
     /// render it in a collapsed disclosure block.
     var content: String
+    var imageAttachments: [ChatImageAttachment]
     /// Hybrid-thinking trace (mlx-lm ``reasoning_content`` field). Only
     /// populated for assistant messages from hybrid models; empty string
     /// is treated as "no trace" by the UI.
@@ -195,6 +248,7 @@ struct ChatMessage: Identifiable, Codable, Equatable, Hashable {
         id: UUID = UUID(),
         role: Role,
         content: String = "",
+        imageAttachments: [ChatImageAttachment] = [],
         reasoning: String = "",
         status: Status = .complete,
         errorMessage: String? = nil,
@@ -211,6 +265,7 @@ struct ChatMessage: Identifiable, Codable, Equatable, Hashable {
         self.id = id
         self.role = role
         self.content = content
+        self.imageAttachments = imageAttachments
         self.reasoning = reasoning
         self.status = status
         self.errorMessage = errorMessage
@@ -232,7 +287,7 @@ struct ChatMessage: Identifiable, Codable, Equatable, Hashable {
     /// for that one key and defers all other fields to the standard
     /// container shape.
     enum CodingKeys: String, CodingKey {
-        case id, role, content, reasoning, status
+        case id, role, content, imageAttachments, reasoning, status
         case errorMessage, failureKind, toolCalls, toolCallID
         case stats, reasoningTruncated, contentTruncated
         case toolNotCalledFlagged
@@ -285,6 +340,7 @@ struct ChatMessage: Identifiable, Codable, Equatable, Hashable {
         self.id = try c.decode(UUID.self, forKey: .id)
         self.role = try c.decode(Role.self, forKey: .role)
         self.content = try c.decode(String.self, forKey: .content)
+        self.imageAttachments = try c.decodeIfPresent([ChatImageAttachment].self, forKey: .imageAttachments) ?? []
         self.reasoning = try c.decode(String.self, forKey: .reasoning)
         self.status = try c.decode(Status.self, forKey: .status)
         self.errorMessage = try c.decodeIfPresent(String.self, forKey: .errorMessage)

--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatStreamClient.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatStreamClient.swift
@@ -159,7 +159,10 @@ struct ChatStreamClient {
             forcedTool: String? = nil
         ) {
             self.alias = alias
-            self.messages = messages.map { Wire.Message(from: $0) }
+            let includeImages = ModelBrandStyle.supportsImageInput(forAlias: alias)
+            self.messages = messages.map {
+                Wire.Message(from: $0, includeImages: includeImages)
+            }
             self.temperature = temperature
             self.topP = topP
             self.maxTokens = maxTokens
@@ -834,12 +837,20 @@ enum Wire {
         let tool_calls: [ToolCall]?
         let tool_call_id: String?
 
-        init(from message: ChatMessage) {
+        init(from message: ChatMessage, includeImages: Bool = true) {
             self.role = message.role.rawValue
-            // The minimal menu-bar app is text-only: no image / file
-            // attachments, so the wire content is always the plain
-            // prose body.
-            self.content = .text(message.content)
+            if message.imageAttachments.isEmpty || !includeImages {
+                self.content = .text(message.content)
+            } else {
+                var parts: [ContentPart] = []
+                if !message.content.isEmpty {
+                    parts.append(.init(type: "text", text: message.content, image_url: nil))
+                }
+                parts.append(contentsOf: message.imageAttachments.map {
+                    .init(type: "image_url", text: nil, image_url: .init(url: $0.dataURL))
+                })
+                self.content = .parts(parts)
+            }
             self.tool_calls = (message.toolCalls?.isEmpty == false) ? message.toolCalls : nil
             self.tool_call_id = message.toolCallID
         }

--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
@@ -389,10 +389,11 @@ final class ChatViewModel {
     /// the caller's side.
     func send(
         _ text: String,
-        alias: String
+        alias: String,
+        imageAttachments: [ChatImageAttachment] = []
     ) {
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return }
+        guard !trimmed.isEmpty || !imageAttachments.isEmpty else { return }
         guard !isStreaming else { return }
 
         // Small local models are unreliable at the first step of tool use:
@@ -413,6 +414,7 @@ final class ChatViewModel {
         let user = ChatMessage(
             role: .user,
             content: trimmed,
+            imageAttachments: imageAttachments,
             status: .complete
         )
         _ = appendMessage(user)
@@ -1099,11 +1101,12 @@ final class ChatViewModel {
         alias: String
     ) -> Bool {
         guard !isStreaming else { return false }
-        let trimmed = newContent.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return false }
         guard let idx = messages.firstIndex(where: { $0.id == id && $0.role == .user }) else { return false }
+        let attachments = messages[idx].imageAttachments
+        let trimmed = newContent.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty || !attachments.isEmpty else { return false }
         messages = Array(messages.prefix(idx))
-        send(trimmed, alias: alias)
+        send(trimmed, alias: alias, imageAttachments: attachments)
         return true
     }
 
@@ -1113,9 +1116,13 @@ final class ChatViewModel {
     func regenerateLast(alias: String) {
         guard !isStreaming else { return }
         guard let lastUserIndex = messages.lastIndex(where: { $0.role == .user }) else { return }
-        let userText = messages[lastUserIndex].content
+        let userMessage = messages[lastUserIndex]
         messages = Array(messages.prefix(lastUserIndex))
-        send(userText, alias: alias)
+        send(
+            userMessage.content,
+            alias: alias,
+            imageAttachments: userMessage.imageAttachments
+        )
     }
 
     /// Retry the turn that produced a specific assistant message. This is
@@ -1132,14 +1139,19 @@ final class ChatViewModel {
             $0.role == .user
         }) else { return false }
 
-        let userText = messages[userIndex].content
-        guard !userText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+        let userMessage = messages[userIndex]
+        guard !userMessage.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                || !userMessage.imageAttachments.isEmpty else {
             return false
         }
         // In place, on the SAME conversation id — see ``editUserMessage``
         // for why the old fork-into-a-branch behaviour was removed.
         messages = Array(messages.prefix(userIndex))
-        send(userText, alias: alias)
+        send(
+            userMessage.content,
+            alias: alias,
+            imageAttachments: userMessage.imageAttachments
+        )
         return true
     }
 

--- a/apps/rapid-mac/Sources/Rapid/Server/ModelBrandStyle.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ModelBrandStyle.swift
@@ -102,9 +102,16 @@ enum ModelBrandStyle {
     /// name (`qwen3-vl-*`), so this is a reliable name-only signal.
     static func modelType(forAlias alias: String) -> ModelType {
         let a = alias.lowercased()
+        if a == "qwen3.5-4b-4bit" || a.contains("gemma3-1b") { return .chat }
         if a.contains("-vl-") || a.hasSuffix("-vl") || a.contains("vl-")
-            || a.contains("-vision") { return .vision }
+            || a.contains("-vision") || a.contains("qwen3.5-")
+            || a.contains("gemma3-") || a.contains("gemma-3n-")
+            || a.contains("gemma-4-") { return .vision }
         return .chat
+    }
+
+    static func supportsImageInput(forAlias alias: String) -> Bool {
+        modelType(forAlias: alias) == .vision
     }
 
     /// A human-readable family name for the row's meta line. Prefers

--- a/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
@@ -201,6 +201,9 @@ struct ChatView: View {
     @Environment(QuickstartCoordinator.self) private var quickstart
 
     @State private var draft: String = ""
+    @State private var imageAttachments: [ChatImageAttachment] = []
+    @State private var attachmentNotice: String?
+    @State private var isImageDropTarget = false
     @State private var composeFocusToken: Int = 0
     @State private var showConnectTools = false
     @State private var showBenchmark = false
@@ -480,6 +483,10 @@ struct ChatView: View {
                 InlineNotice(message: error, tone: .error)
                     .frame(maxWidth: contentMaxWidth)
                     .frame(maxWidth: .infinity)
+            } else if let attachmentNotice {
+                InlineNotice(message: attachmentNotice, tone: .error)
+                    .frame(maxWidth: contentMaxWidth)
+                    .frame(maxWidth: .infinity)
             }
             // One input, not a pill containing a second pill.
             //
@@ -491,6 +498,9 @@ struct ChatView: View {
             // tall and read as a card that happened to contain a text
             // area; this reads as a text field with controls in it.
             VStack(spacing: RapidTheme.Space.sm - 2) {
+                if !imageAttachments.isEmpty {
+                    attachmentStrip
+                }
                 // The field stays live in every state — a user may draft
                 // while the model downloads, and that draft survives the
                 // transition to ready untouched. Only the send ACTION is
@@ -503,6 +513,7 @@ struct ChatView: View {
                     placeholder: readiness.composerPlaceholder,
                     onSubmit: send,
                     onCancel: { viewModel.stop() },
+                    onPasteImages: pasteImagesFromClipboard,
                     onRecallLastUser: {
                         messages.last(where: { $0.role == .user })?.content
                     }
@@ -517,8 +528,21 @@ struct ChatView: View {
             )
             .overlay(
                 RoundedRectangle(cornerRadius: RapidTheme.Radius.input, style: .continuous)
-                    .strokeBorder(RapidTheme.hairlineStrong, lineWidth: 1)
+                    .strokeBorder(
+                        isImageDropTarget ? RapidTheme.brandPrimary : RapidTheme.hairlineStrong,
+                        lineWidth: isImageDropTarget ? 2 : 1
+                    )
             )
+            .dropDestination(for: URL.self) { urls, _ in
+                guard supportsImageInput else {
+                    rejectImageInputForCurrentModel()
+                    return false
+                }
+                addImageURLs(urls)
+                return true
+            } isTargeted: { targeted in
+                isImageDropTarget = targeted && supportsImageInput
+            }
             .frame(maxWidth: contentMaxWidth)
             .frame(maxWidth: .infinity)
         }
@@ -531,6 +555,19 @@ struct ChatView: View {
     /// right, then the send/stop button — Ollama's `model ▾  ⬆` cluster.
     private var composerControls: some View {
         HStack(spacing: RapidTheme.Space.sm) {
+            Button(action: chooseImages) {
+                Image(systemName: "plus")
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(supportsImageInput ? Color.primary : Color.secondary)
+                    .frame(width: 28, height: 28)
+                    .background(Circle().fill(Color.primary.opacity(supportsImageInput ? 0.06 : 0.02)))
+            }
+            .buttonStyle(.plain)
+            .disabled(!supportsImageInput || viewModel.isStreaming)
+            .help(supportsImageInput ? "Add photos" : "This model doesn't support images")
+            .accessibilityLabel("Add photos")
+            .accessibilityHint(supportsImageInput ? "" : "This model doesn't support images")
+            .accessibilityIdentifier("ChatView.AddPhotos")
             Spacer(minLength: 0)
             ModelPickerBar(
                 server: server,
@@ -600,19 +637,25 @@ struct ChatView: View {
     /// replaces the old behaviour where pressing Send on a cold model
     /// silently kicked off a multi-gigabyte download behind a spinner.
     private var sendEnabled: Bool {
-        hasDraft && readiness.sendAllowed
+        hasDraft && readiness.sendAllowed && (imageAttachments.isEmpty || supportsImageInput)
     }
 
     private var hasDraft: Bool {
         !draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            || !imageAttachments.isEmpty
     }
 
     // MARK: - Actions
 
     private func send() {
         let text = draft
-        guard !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+        guard !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                || !imageAttachments.isEmpty else { return }
         guard !viewModel.isStreaming else { return }
+        guard imageAttachments.isEmpty || supportsImageInput else {
+            rejectImageInputForCurrentModel()
+            return
+        }
         // Return reaches here even when the Send button is disabled —
         // AppKit routes the key through ``ComposeTextEditor`` regardless
         // of SwiftUI's button state. Previously that landed on a silent
@@ -625,8 +668,106 @@ struct ChatView: View {
         // tooltip carries.
         guard acknowledgeIfNotReady() else { return }
         draft = ""
+        let images = imageAttachments
+        imageAttachments = []
+        attachmentNotice = nil
         composeFocusToken &+= 1
-        viewModel.send(text, alias: alias)
+        viewModel.send(text, alias: alias, imageAttachments: images)
+    }
+
+    private var supportsImageInput: Bool {
+        ModelBrandStyle.supportsImageInput(forAlias: alias)
+    }
+
+    private var attachmentStrip: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: RapidTheme.Space.sm) {
+                ForEach(imageAttachments) { attachment in
+                    ZStack(alignment: .topTrailing) {
+                        if let image = NSImage(data: attachment.data) {
+                            Image(nsImage: image)
+                                .resizable()
+                                .scaledToFill()
+                                .frame(width: 64, height: 64)
+                                .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+                        }
+                        Button {
+                            imageAttachments.removeAll { $0.id == attachment.id }
+                        } label: {
+                            Image(systemName: "xmark.circle.fill")
+                                .symbolRenderingMode(.palette)
+                                .foregroundStyle(.white, .black.opacity(0.7))
+                        }
+                        .buttonStyle(.plain)
+                        .offset(x: 5, y: -5)
+                        .accessibilityLabel("Remove \(attachment.filename)")
+                        .accessibilityIdentifier(
+                            "ChatView.Attachment.Remove.\(attachment.filename)"
+                        )
+                    }
+                }
+            }
+            .padding(.top, 5)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func chooseImages() {
+        guard supportsImageInput else {
+            rejectImageInputForCurrentModel()
+            return
+        }
+        let panel = NSOpenPanel()
+        panel.allowedContentTypes = [.png, .jpeg, .gif]
+        panel.allowsMultipleSelection = true
+        panel.canChooseDirectories = false
+        panel.canChooseFiles = true
+        guard panel.runModal() == .OK else { return }
+        addImageURLs(panel.urls)
+    }
+
+    private func addImageURLs(_ urls: [URL]) {
+        var accepted: [ChatImageAttachment] = []
+        var rejection: String?
+        for url in urls {
+            do { accepted.append(try ChatImageAttachment(contentsOf: url)) }
+            catch { rejection = error.localizedDescription }
+        }
+        imageAttachments.append(contentsOf: accepted)
+        attachmentNotice = rejection
+    }
+
+    private func pasteImagesFromClipboard() -> Bool {
+        let pasteboard = NSPasteboard.general
+        let urls = (pasteboard.readObjects(
+            forClasses: [NSURL.self],
+            options: [.urlReadingFileURLsOnly: true]
+        ) as? [URL] ?? []).filter { UTType(filenameExtension: $0.pathExtension)?.conforms(to: .image) == true }
+        let pastedImage = NSImage(pasteboard: pasteboard)
+        guard !urls.isEmpty || pastedImage != nil else { return false }
+        guard supportsImageInput else {
+            rejectImageInputForCurrentModel()
+            return true
+        }
+        if !urls.isEmpty {
+            addImageURLs(urls)
+        } else if let image = pastedImage,
+                  let tiff = image.tiffRepresentation,
+                  let rep = NSBitmapImageRep(data: tiff),
+                  let png = rep.representation(using: .png, properties: [:]) {
+            do {
+                imageAttachments.append(try ChatImageAttachment(
+                    filename: "Pasted image.png", mimeType: "image/png", data: png
+                ))
+                attachmentNotice = nil
+            } catch { attachmentNotice = error.localizedDescription }
+        }
+        return true
+    }
+
+    private func rejectImageInputForCurrentModel() {
+        attachmentNotice = "\(alias) doesn't support image input. Choose a vision model to add photos."
+        VoiceOverAnnouncer.announce(attachmentNotice ?? "This model doesn't support images.")
     }
 
     /// The shared lifecycle gate for every path that would start a turn:
@@ -698,9 +839,30 @@ private struct MessageRow: View {
                 if isEditing {
                     userEditor
                 } else {
-                    Text(message.content)
-                        .textSelection(.enabled)
-                        .foregroundStyle(RapidTheme.userBubbleText)
+                    VStack(alignment: .leading, spacing: RapidTheme.Space.sm) {
+                        if !message.imageAttachments.isEmpty {
+                            LazyVGrid(
+                                columns: [GridItem(.adaptive(minimum: 120, maximum: 220))],
+                                spacing: RapidTheme.Space.sm
+                            ) {
+                                ForEach(message.imageAttachments) { attachment in
+                                    if let image = NSImage(data: attachment.data) {
+                                        Image(nsImage: image)
+                                            .resizable()
+                                            .scaledToFit()
+                                            .frame(maxHeight: 240)
+                                            .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+                                            .accessibilityLabel(attachment.filename)
+                                    }
+                                }
+                            }
+                        }
+                        if !message.content.isEmpty {
+                            Text(message.content)
+                                .textSelection(.enabled)
+                                .foregroundStyle(RapidTheme.userBubbleText)
+                        }
+                    }
                         .padding(.horizontal, 14)
                         .padding(.vertical, 10)
                         .background(
@@ -1266,6 +1428,7 @@ struct ComposeField: View {
     /// No-op (returns control to AppKit's default Esc handling)
     /// when nothing is streaming.
     var onCancel: () -> Void
+    var onPasteImages: () -> Bool = { false }
     /// Resolves the text of the last user message in the active
     /// session, or ``nil`` when there's nothing to recall. Bound to
     /// the Up-arrow-in-empty-compose recall affordance (Claude /
@@ -1303,6 +1466,7 @@ struct ComposeField: View {
                 isStreaming: isStreaming,
                 onSubmit: onSubmit,
                 onCancel: onCancel,
+                onPasteImages: onPasteImages,
                 onRecallLastUser: onRecallLastUser,
                 onMeasuredHeight: { measured in
                     let clamped = min(max(measured, minHeight), maxHeight)
@@ -1410,6 +1574,7 @@ struct ComposeTextEditor: NSViewRepresentable {
     var isStreaming: Bool
     var onSubmit: () -> Void
     var onCancel: () -> Void
+    var onPasteImages: () -> Bool
     var onRecallLastUser: () -> String?
     /// Reports the editor's laid-out content height so ``ComposeField``
     /// can size the field to the draft.
@@ -1478,6 +1643,7 @@ struct ComposeTextEditor: NSViewRepresentable {
         view.onMeasuredHeight = onMeasuredHeight
         context.coordinator.onSubmit = onSubmit
         context.coordinator.onCancel = onCancel
+        context.coordinator.onPasteImages = onPasteImages
         context.coordinator.isStreaming = isStreaming
         context.coordinator.onRecallLastUser = onRecallLastUser
         // Cmd+L (or any other external focus request) bumps the
@@ -1498,6 +1664,7 @@ struct ComposeTextEditor: NSViewRepresentable {
             text: $text,
             onSubmit: onSubmit,
             onCancel: onCancel,
+            onPasteImages: onPasteImages,
             isStreaming: isStreaming,
             onRecallLastUser: onRecallLastUser
         )
@@ -1508,6 +1675,7 @@ struct ComposeTextEditor: NSViewRepresentable {
         var text: Binding<String>
         var onSubmit: () -> Void
         var onCancel: () -> Void
+        var onPasteImages: () -> Bool
         var isStreaming: Bool
         /// Resolves text of the last user message for Up-arrow recall;
         /// nil = nothing to recall, fall through to AppKit default.
@@ -1520,12 +1688,14 @@ struct ComposeTextEditor: NSViewRepresentable {
             text: Binding<String>,
             onSubmit: @escaping () -> Void,
             onCancel: @escaping () -> Void,
+            onPasteImages: @escaping () -> Bool,
             isStreaming: Bool,
             onRecallLastUser: @escaping () -> String?
         ) {
             self.text = text
             self.onSubmit = onSubmit
             self.onCancel = onCancel
+            self.onPasteImages = onPasteImages
             self.isStreaming = isStreaming
             self.onRecallLastUser = onRecallLastUser
         }
@@ -1536,6 +1706,9 @@ struct ComposeTextEditor: NSViewRepresentable {
         }
 
         func textView(_ textView: NSTextView, doCommandBy commandSelector: Selector) -> Bool {
+            if commandSelector == #selector(NSText.paste(_:)), onPasteImages() {
+                return true
+            }
             if commandSelector == #selector(NSResponder.insertNewline(_:)) {
                 // Shift held → real newline. Otherwise → submit. Probing
                 // ``NSApp.currentEvent`` is the documented way to read

--- a/apps/rapid-mac/Tests/RapidTests/ChatImageAttachmentTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ChatImageAttachmentTests.swift
@@ -1,0 +1,86 @@
+import Foundation
+import Testing
+@testable import Rapid
+
+@Suite("Chat image attachments")
+struct ChatImageAttachmentTests {
+    @Test("multimodal user message encodes text followed by image_url data URI")
+    func wireEncoding() throws {
+        let attachment = try ChatImageAttachment(
+            filename: "photo.png",
+            mimeType: "image/png",
+            data: Data([0x89, 0x50, 0x4e, 0x47])
+        )
+        let message = ChatMessage(
+            role: .user,
+            content: "What is this?",
+            imageAttachments: [attachment]
+        )
+        let encoded = try JSONEncoder().encode(Wire.Message(from: message))
+        let json = try #require(JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+        let parts = try #require(json["content"] as? [[String: Any]])
+        #expect(parts.count == 2)
+        #expect(parts[0]["type"] as? String == "text")
+        #expect(parts[0]["text"] as? String == "What is this?")
+        #expect(parts[1]["type"] as? String == "image_url")
+        let imageURL = try #require(parts[1]["image_url"] as? [String: Any])
+        #expect((imageURL["url"] as? String)?.hasPrefix("data:image/png;base64,") == true)
+    }
+
+    @Test("text-only aliases omit images from existing conversation history")
+    func textOnlyAliasOmitsHistoricalImages() throws {
+        let attachment = try ChatImageAttachment(
+            filename: "photo.png",
+            mimeType: "image/png",
+            data: Data([0x89, 0x50, 0x4e, 0x47])
+        )
+        let request = ChatStreamClient.Request(
+            alias: "qwen3.5-4b-4bit",
+            messages: [
+                ChatMessage(
+                    role: .user,
+                    content: "What is this?",
+                    imageAttachments: [attachment]
+                )
+            ]
+        )
+
+        let encoded = try JSONEncoder().encode(request.messages[0])
+        let json = try #require(JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+        #expect(json["content"] as? String == "What is this?")
+        #expect(String(data: encoded, encoding: .utf8)?.contains("data:image/") == false)
+    }
+
+    @Test("attachments survive conversation persistence and old messages default empty")
+    func codableCompatibility() throws {
+        let attachment = try ChatImageAttachment(
+            filename: "photo.jpg", mimeType: "image/jpeg", data: Data([1, 2, 3])
+        )
+        let original = ChatMessage(role: .user, content: "look", imageAttachments: [attachment])
+        let restored = try JSONDecoder().decode(
+            ChatMessage.self, from: JSONEncoder().encode(original)
+        )
+        #expect(restored.imageAttachments == [attachment])
+
+        var object = try #require(
+            JSONSerialization.jsonObject(with: JSONEncoder().encode(original)) as? [String: Any]
+        )
+        object.removeValue(forKey: "imageAttachments")
+        let legacyData = try JSONSerialization.data(withJSONObject: object)
+        #expect(try JSONDecoder().decode(ChatMessage.self, from: legacyData).imageAttachments.isEmpty)
+    }
+
+    @Test("20 MB cap and accepted MIME types are enforced")
+    func validation() throws {
+        #expect(throws: ChatImageAttachment.ValidationError.self) {
+            try ChatImageAttachment(
+                filename: "huge.png",
+                mimeType: "image/png",
+                data: Data(count: ChatImageAttachment.maxBytes + 1)
+            )
+        }
+        #expect(throws: ChatImageAttachment.ValidationError.self) {
+            try ChatImageAttachment(filename: "x.webp", mimeType: "image/webp", data: Data())
+        }
+    }
+}

--- a/apps/rapid-mac/Tests/RapidTests/ModelSurfaceRedesignTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ModelSurfaceRedesignTests.swift
@@ -68,10 +68,15 @@ struct ModelSurfaceRedesignTests {
 
     // MARK: - ModelBrandStyle.modelType
 
-    @Test("modelType: -vl aliases are vision, the rest are chat")
+    @Test("modelType: visual alias families are vision; explicit text-only variants stay chat")
     func modelTypeVision() {
         #expect(ModelBrandStyle.modelType(forAlias: "qwen3-vl-30b-4bit") == .vision)
         #expect(ModelBrandStyle.modelType(forAlias: "some-model-vl") == .vision)
+        #expect(ModelBrandStyle.modelType(forAlias: "gemma3-12b-4bit") == .vision)
+        #expect(ModelBrandStyle.modelType(forAlias: "gemma-4-26b-4bit") == .vision)
+        #expect(ModelBrandStyle.modelType(forAlias: "qwen3.5-9b-4bit") == .vision)
+        #expect(ModelBrandStyle.modelType(forAlias: "qwen3.5-4b-4bit") == .chat)
+        #expect(ModelBrandStyle.modelType(forAlias: "gemma3-1b-4bit") == .chat)
         #expect(ModelBrandStyle.modelType(forAlias: "qwen3.6-35b-4bit") == .chat)
         #expect(ModelBrandStyle.modelType(forAlias: "gpt-oss-20b-4bit") == .chat)
     }

--- a/apps/rapid-mac/docs/gui-golden-flows.md
+++ b/apps/rapid-mac/docs/gui-golden-flows.md
@@ -38,6 +38,10 @@ covered, and each one names the defect it would have caught:
     instruction-**edit** path exists in code but is parked as a slow, batch-only
     lane on current hardware (~20 min/edit at q4); the interactive golden flow is
     text→image generation.
+13. `chat-image-attachment` — a vision-language model accepts a PNG through
+    the Chat composer, renders it in the user turn, and sends typed
+    `text` + `image_url` content; the same composer keeps its attachment
+    control visible but disabled for a text-only alias and rejects paste/drop.
 
 The distinction matters. A journey answers *"can someone do this?"*; an
 invariant answers *"is this still true everywhere?"*. The three defects below
@@ -182,6 +186,44 @@ The flow also waits for `Benchmark.LoadedModelResult`, proving the number made
 it back through the real sheet. This would have caught the old implementation,
 which rejected an 8B speed test for lack of memory precisely because it tried
 to load an unnecessary second 8B copy.
+
+### Chat image attachment
+
+`chat-image-attachment` covers image input inside the normal Chat tab. This is
+separate from `image-generation`: the former asks a VLM to understand an image;
+the latter asks a diffusion model to create one.
+
+The deterministic lane should use a fake VLM alias and a small fixture PNG, and
+walk both halves of the capability boundary:
+
+1. select the fake VLM alias and assert `ChatView.AddPhotos` is present and
+   enabled;
+2. add the fixture through the standard open panel, then assert the thumbnail's
+   `ChatView.Attachment.Remove.<filename>` control is present;
+3. enter a caption question, send, and assert the user bubble contains the
+   attachment while the fake sidecar records an `image_url` data URI alongside
+   the typed text part;
+4. retry or regenerate the turn and assert the replay request still contains
+   the attachment;
+5. switch to a text-only alias and assert `ChatView.AddPhotos` remains visible
+   but disabled with the “This model doesn't support images” help text;
+6. attempt image paste and drop, assert no thumbnail appears and no image bytes
+   reach the fake sidecar. Historical image turns must also be reduced to text
+   before a text-only request is encoded.
+
+The standard file picker itself remains outside the structural AX baseline, as
+with the Images-tab save panel. The flow drives it only to supply the fixture;
+the product assertions begin at the composer thumbnail and end at the recorded
+wire request.
+
+Real-weight dogfood on 2026-08-09 used the locally built
+`rapid_mlx-0.12.7` wheel with its `[vision]` extra and
+`gemma-4-e2b-4bit`. The GUI accepted `cheetah-logo-96.png`, displayed it in
+the user bubble, and the model described the spotted feline in the fixture at
+5.8 tok/s. The paired `qwen3.5-4b-4bit` text-only run kept the add button
+visible and disabled and accepted no pasted attachment. A base-wheel-only run
+is not valid evidence for this flow: without `[vision]` / `mlx-vlm`, the engine
+intentionally rejects or text-degrades VLM serving.
 
 ## Image generation
 


### PR DESCRIPTION
## What changed

- add PNG, JPEG, and static GIF attachments to the Chat composer through file selection, drag-and-drop, and paste
- encode VLM turns as typed `text` + `image_url` content while keeping text-only aliases attachment-free
- render and persist image attachments, including retry, regenerate, and edit/replay paths
- keep the attachment button visible but disabled for text-only models
- document the new `chat-image-attachment` GUI golden flow and add stable AX identifiers

## Why

Image understanding was already supported by the engine and streaming client shape, but the desktop Chat composer had no attachment surface. This closes that product gap while preventing unsupported image requests from reaching text-only models.

## Validation

- `swift build --target RapidTests`
- `python3 scripts/check_rapid_mac_ax_identifiers.py`
- `git diff --check`
- three Codex review/fix passes before publication
- real GUI dogfood on Mac mini using a locally built `rapid_mlx-0.12.7[vision]` wheel and `gemma-4-e2b-4bit`: selected `cheetah-logo-96.png`, rendered it in the user turn, and received an image-grounded response at 5.8 tok/s
- text-only `qwen3.5-4b-4bit`: attachment control remained visible/disabled and image paste produced no attachment

Full `swift test` remains blocked by the repository's existing `RapidUXTests` `no such module XCTest` environment issue; the `RapidTests` target builds successfully.