### PR TITLE
test(mac): [image:gen] is a non-chat kind, and the test still said otherwise

### DIFF
--- a/apps/rapid-mac/Tests/RapidTests/DownloadCatalogHardeningTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/DownloadCatalogHardeningTests.swift
@@ -184,13 +184,22 @@ struct DownloadCatalogHardeningTests {
     func nonChatKindTagIsColumnScoped() {
         #expect(ModelCatalog.hasNonChatKindTag("kokoro [audio:tts] kokoro mlx/Kokoro"))
         #expect(ModelCatalog.hasNonChatKindTag("cog 13.3 GiB [video:gen] org/repo"))
+        // Image generation joined audio and video as a non-chat kind in
+        // #1705, which is what keeps `flux2-klein-4b` and `z-image-turbo`
+        // out of the chat picker while the Images tab serves them. This
+        // assertion asserted the opposite until that landed.
+        #expect(ModelCatalog.hasNonChatKindTag("flux 4.3 GiB [image:gen] Runpod/FLUX.2-klein-4B-mflux-4bit"))
+        #expect(ModelCatalog.hasNonChatKindTag("odd [image:gen] org/repo"))
         // A model whose repo or description merely contains the
         // characters must not vanish from the catalog.
         #expect(!ModelCatalog.hasNonChatKindTag("weird-model hermes org/repo[audio:tts]x"))
         #expect(!ModelCatalog.hasNonChatKindTag("weird-model hermes org/audio:tts"))
         #expect(!ModelCatalog.hasNonChatKindTag("qwen3.6-27b hermes qwen3 ✓ avoid — —"))
         #expect(!ModelCatalog.hasNonChatKindTag("odd [audio:] org/repo"))
-        #expect(!ModelCatalog.hasNonChatKindTag("odd [image:gen] org/repo"))
+        #expect(!ModelCatalog.hasNonChatKindTag("odd [image:] org/repo"))
+        // The column-scoping property the test is named for still holds
+        // for the new kind: a bare substring must not disqualify a row.
+        #expect(!ModelCatalog.hasNonChatKindTag("weird-model hermes org/repo[image:gen]x"))
     }
 
     @Test("parseAvailable drops the human-readable size footer")


### PR DESCRIPTION
## Why

`main` is red and has been since #1705 merged, because that PR changed
`ModelCatalog.hasNonChatKindTag` to treat `image` as a non-chat kind but left the
test asserting the opposite. Every rapid-mac PR opened since inherits the failure.

Refs #1705.

## The failure

```
✘ Test "Kind-tag matching requires a real column token, not a substring"
  recorded an issue at DownloadCatalogHardeningTests.swift:193:9:
  Expectation failed: !(ModelCatalog.hasNonChatKindTag("odd [image:gen] org/repo") → true)
✘ Test run with 1795 tests failed after 9.669 seconds with 1 issue.
```

#1705 added `kind == "image"` correctly — that is what keeps `flux2-klein-4b` and
`z-image-turbo` out of the chat picker while the new Images tab serves them. It
simply did not update the assertion that says the opposite.

`git log` on the test file confirms #1705 never touched it (last two edits are
`0fbee824` and `69fd0ba1`, both earlier), and the assertion is present on clean
`286b735f`.

**#1705 merged with `build: FAILURE` and `accessibility-identifiers: fail` already
showing**, which is how it reached main at all. That is the root cause worth
fixing separately — a red gate that does not block a merge is not a gate.

## The fix

Flip the assertion, and add the row shape the engine actually prints rather than
only the synthetic one:

```swift
#expect(ModelCatalog.hasNonChatKindTag("flux 4.3 GiB [image:gen] Runpod/FLUX.2-klein-4B-mflux-4bit"))
```

(taken verbatim from real `rapid-mlx models` output).

## Two negatives added

The test is named for a *property* — "a real column token, not a substring" — and
that property is what deserves pinning, not the specific kinds:

```swift
#expect(!ModelCatalog.hasNonChatKindTag("odd [image:] org/repo"))                    // empty subtype
#expect(!ModelCatalog.hasNonChatKindTag("weird-model hermes org/repo[image:gen]x"))  // bare substring
```

Without those, "image is non-chat" could be satisfied by a naive `contains("[image:")`
that would also swallow an innocent row whose HF path happens to contain the
characters — which is the exact failure the audio/video versions of this test were
written to prevent.

## Verification

`swift build` clean. `swift test` **not run locally** because this machine has no full
Xcode, so neither XCTest nor swift-testing resolves (#1638). The assertions were derived
by reading `hasNonChatKindTag` against real `rapid-mlx models` row shapes; CI is the
first execution.

Merging this unblocks #1721, #1722 and the chat-tab branch, all of which currently fail
on this one inherited assertion.