### PR TITLE
fix(mac): the Images tab's three selectable controls carry no AX identifier

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/UI/ImagesView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ImagesView.swift
@@ -294,6 +294,13 @@ struct ImagesView: View {
             )
         }
         .buttonStyle(.plain)
+        // Per-item id, mirroring `Sidebar.Conversation.<uuid>`. The
+        // enclosing `Images.Gallery` identifies the strip, not the
+        // thumbnails inside it — without this the only selectable item in
+        // the filmstrip is unreachable by identifier, so a harness can
+        // neither pick a specific image nor assert which one is active.
+        .accessibilityIdentifier("Images.Thumb.\(image.id)")
+        .accessibilityLabel(selected ? "Generated image, selected" : "Generated image")
     }
 
     // MARK: - Composer (mirrors ChatView's compose box)
@@ -401,6 +408,12 @@ struct ImagesView: View {
                         .clipShape(RoundedRectangle(cornerRadius: 6))
                 }
                 .buttonStyle(.plain)
+                // ``Aspect.rawValue`` (square / portrait / landscape), NOT
+                // ``label`` — the label is display copy ("1:1", "3:4") and a
+                // future copy change would silently rename the hook.
+                .accessibilityIdentifier("Images.Aspect.\(ar.rawValue)")
+                .accessibilityLabel(ar.label)
+                .accessibilityAddTraits(on ? .isSelected : [])
             }
         }
         .accessibilityIdentifier("Images.Aspect")
@@ -423,6 +436,10 @@ struct ImagesView: View {
                             systemImage: ModelPickerBar.cacheGlyph(cached: entry.cached)
                         )
                     }
+                    // Keyed on the alias, which is what selecting the row
+                    // actually writes — so the hook and the effect cannot
+                    // drift apart the way a positional index would.
+                    .accessibilityIdentifier("Images.Model.\(entry.alias)")
                 }
             }
         } label: {


### PR DESCRIPTION
## Why

`accessibility-identifiers` FAILED on #1705 and the PR merged anyway, so
`ImagesView.swift` shipped with every one of its per-item controls
unreachable by identifier:

    ImagesView.swift:278  filmstrip thumbnail
    ImagesView.swift:392  aspect-ratio button
    ImagesView.swift:418  model row

Refs #1705.

The enclosing containers do carry ids — `Images.Gallery`, `Images.Aspect`
— which is presumably why they were skipped. But the container is not the
control: a harness can find the filmstrip and still be unable to select an
image, or to assert which one is active. Every interactive control in the
tab was in that state.

## The ids

Per-item, keyed on what selecting the row actually writes, mirroring the
existing `Sidebar.Conversation.<uuid>` convention:

    Images.Thumb.<image.id>
    Images.Aspect.<square|portrait|landscape>
    Images.Model.<alias>

The aspect id uses `Aspect.rawValue`, not `label`. The label is display
copy ("1:1", "3:4"); keying on it would let a copy change silently rename
an automation hook. The model id uses the alias for the same reason — it
is the value the button assigns, so hook and effect cannot drift.

VoiceOver labels and an `.isSelected` trait come along with them: the
thumbnail renders as a bare image with no text, so without a label a
screen-reader user hears nothing selectable at all.

## On proving this

The gate cannot fail on this PR either way, and that is worth stating
rather than dressing up: it only inspects controls a PR *adds*, and these
three are already on main. It ran, it reported PASS, and it examined
`ImagesView.swift` — that is the positive assertion available here.

The gate was never the thing that broke. It caught these three on #1705
and said so. What failed was that a red gate did not stop the merge.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>