### PR TITLE
Fix balanced JSON parsing in AutoToolParser

### DIFF
--- a/tests/test_tool_parsers.py
+++ b/tests/test_tool_parsers.py
@@ -678,6 +678,53 @@ class TestAutoToolParser:
         assert result.tools_called
         assert result.tool_calls[0]["name"] == "add"
 
+    def test_qwen_bracket_closer_inside_string_is_not_truncated(self, parser):
+        text = '[Calling tool: f({"x": "literal })] text"})]'
+
+        result = parser.extract_tool_calls(text)
+
+        assert result.tools_called
+        assert len(result.tool_calls) == 1
+        assert result.tool_calls[0]["name"] == "f"
+        assert json.loads(result.tool_calls[0]["arguments"]) == {
+            "x": "literal })] text"
+        }
+        assert result.content is None
+
+    def test_qwen_bracket_rejects_invalid_json_without_dispatching_nested_call(
+        self, parser
+    ):
+        text = '[Calling tool: f({"x": "[Calling tool: g({})]"} trailing)]'
+
+        result = parser.extract_tool_calls(text)
+
+        assert not result.tools_called
+        assert result.tool_calls == []
+        assert result.content == text
+
+    def test_qwen_bracket_invalid_json_remains_content(self, parser):
+        text = '[Calling tool: f({"x": invalid})]'
+
+        result = parser.extract_tool_calls(text)
+
+        assert not result.tools_called
+        assert result.tool_calls == []
+        assert result.content == text
+
+    def test_qwen_bracket_streaming_waits_for_real_outer_closer(self, parser):
+        partial = '[Calling tool: f({"x": "literal })] text"}'
+        complete = partial + ")]"
+
+        first = parser.extract_tool_calls_streaming("", partial, partial)
+        second = parser.extract_tool_calls_streaming(partial, complete, ")]")
+
+        assert first is None
+        assert second is not None
+        assert len(second["tool_calls"]) == 1
+        function = second["tool_calls"][0]["function"]
+        assert function["name"] == "f"
+        assert json.loads(function["arguments"]) == {"x": "literal })] text"}
+
     def test_detects_llama(self, parser):
         """Test auto detection of Llama format."""
         text = '<function=multiply>{"x": 2}</function>'

--- a/tests/test_tool_parsers.py
+++ b/tests/test_tool_parsers.py
@@ -711,6 +711,15 @@ class TestAutoToolParser:
         assert result.tool_calls == []
         assert result.content == text
 
+    def test_qwen_bracket_unterminated_outer_call_masks_nested_marker(self, parser):
+        text = '[Calling tool: f({"x": "[Calling tool: g({})]"'
+
+        result = parser.extract_tool_calls(text)
+
+        assert not result.tools_called
+        assert result.tool_calls == []
+        assert result.content == text
+
     def test_qwen_bracket_streaming_waits_for_real_outer_closer(self, parser):
         partial = '[Calling tool: f({"x": "literal })] text"}'
         complete = partial + ")]"

--- a/vllm_mlx/tool_parsers/auto_tool_parser.py
+++ b/vllm_mlx/tool_parsers/auto_tool_parser.py
@@ -49,6 +49,9 @@ def _parse_qwen_bracket_calls(
         start = match.start()
         end = _balanced_block_end(text, start)
         if end == -1:
+            # Do not search inside an unfinished outer envelope. A complete
+            # marker later in the bytes may only be string data belonging to
+            # this call, and dispatching it cannot be undone by streaming.
             break
 
         calls = _parse_text_format_block(text[start:end])

--- a/vllm_mlx/tool_parsers/auto_tool_parser.py
+++ b/vllm_mlx/tool_parsers/auto_tool_parser.py
@@ -16,12 +16,57 @@ from .abstract_tool_parser import (
     ToolParser,
     ToolParserManager,
 )
-from .lfm_tool_parser import LFM_CALL_START, parse_lfm_tool_calls
+from .lfm_tool_parser import (
+    LFM_CALL_START,
+    TEXT_CALL_START,
+    _balanced_block_end,
+    _parse_text_format_block,
+    parse_lfm_tool_calls,
+)
 
 
 def generate_tool_id() -> str:
     """Generate a unique tool call ID."""
     return f"call_{uuid.uuid4().hex[:8]}"
+
+
+def _parse_qwen_bracket_calls(
+    text: str,
+) -> tuple[list[dict[str, Any]], str]:
+    """Extract balanced ``[Calling tool: name({json})]`` blocks.
+
+    A regex cannot distinguish an envelope-closing ``})]`` from the same
+    bytes inside a JSON string. Walk the whole bracket block with the
+    quote/escape-aware LFM scanner, then accept it only when its payload is
+    a JSON object. Rejected blocks remain content, and scanning resumes after
+    their closing bracket so markup inside an argument is never dispatched.
+    """
+    tool_calls: list[dict[str, Any]] = []
+    accepted_spans: list[tuple[int, int]] = []
+    search_from = 0
+
+    while match := TEXT_CALL_START.search(text, search_from):
+        start = match.start()
+        end = _balanced_block_end(text, start)
+        if end == -1:
+            break
+
+        calls = _parse_text_format_block(text[start:end])
+        if calls:
+            tool_calls.extend(calls)
+            accepted_spans.append((start, end))
+        search_from = end
+
+    if not accepted_spans:
+        return tool_calls, text
+
+    pieces: list[str] = []
+    cursor = 0
+    for start, end in accepted_spans:
+        pieces.append(text[cursor:start])
+        cursor = end
+    pieces.append(text[cursor:])
+    return tool_calls, "".join(pieces).strip()
 
 
 @ToolParserManager.register_module(["auto", "generic"])
@@ -44,9 +89,6 @@ class AutoToolParser(ToolParser):
     # Patterns for different formats
     MISTRAL_TOKEN = "[TOOL_CALLS]"
 
-    QWEN_BRACKET_PATTERN = re.compile(
-        r"\[Calling tool:\s*(\w+)\((\{.*?\})\)\]", re.DOTALL
-    )
     QWEN_XML_PATTERN = re.compile(r"<tool_call>\s*(\{.*?\})\s*</tool_call>", re.DOTALL)
     LLAMA_PATTERN = re.compile(r"<function=([^>]+)>(\{.*?\})</function>", re.DOTALL)
     NEMOTRON_PATTERN = re.compile(
@@ -138,33 +180,9 @@ class AutoToolParser(ToolParser):
                     content=content if content else None,
                 )
 
-        # 2. Try Qwen bracket pattern
-        bracket_matches = self.QWEN_BRACKET_PATTERN.findall(model_output)
-        for name, args_str in bracket_matches:
-            try:
-                arguments = json.loads(args_str)
-                tool_calls.append(
-                    {
-                        "id": generate_tool_id(),
-                        "name": name.strip(),
-                        "arguments": (
-                            json.dumps(arguments, ensure_ascii=False)
-                            if isinstance(arguments, dict)
-                            else str(arguments)
-                        ),
-                    }
-                )
-            except json.JSONDecodeError:
-                tool_calls.append(
-                    {
-                        "id": generate_tool_id(),
-                        "name": name.strip(),
-                        "arguments": args_str,
-                    }
-                )
-
-        if bracket_matches:
-            cleaned_text = self.QWEN_BRACKET_PATTERN.sub("", cleaned_text).strip()
+        # 2. Try Qwen bracket format with balanced, JSON-aware scanning.
+        bracket_calls, cleaned_text = _parse_qwen_bracket_calls(cleaned_text)
+        tool_calls.extend(bracket_calls)
 
         # 3. Try Nemotron pattern (before Qwen XML as it's more specific)
         nemotron_matches = self.NEMOTRON_PATTERN.findall(cleaned_text)


### PR DESCRIPTION
## What changed

- replace `AutoToolParser`'s non-greedy Qwen bracket regex with the quote- and escape-aware balanced-block scanner already used by the LFM parser
- accept `[Calling tool: name({json})]` only when its payload decodes to a JSON object
- leave malformed envelopes in assistant content instead of shipping truncated, invalid tool arguments
- skip over rejected outer blocks so nested tool-like text inside arguments is never dispatched
- add static and streaming regressions for embedded `})]`, malformed JSON, and nested envelopes

## Root cause

`QWEN_BRACKET_PATTERN` matched `\{.*?\}` and stopped at the first `})]`, including when those bytes appeared inside a JSON string. Its decode-failure branch then emitted that truncated substring as `arguments`. In streaming mode the first inner `]` triggered extraction, putting an invalid call on the wire before the real envelope completed.

## Impact

Models using the default `--tool-call-parser auto` now preserve complete JSON string values and fail safely when a bracket envelope is malformed.

Fixes #1591.

## Validation

- `pytest -q tests/test_lfm_tool_parser.py tests/test_tool_parsers.py` — 216 passed
- full suite excluding three unavailable optional-SDK collection files — 16,611 passed, 218 skipped, 6 xfailed; two unrelated event-loop integration tests require a server on `127.0.0.1:8000`
- `ruff check vllm_mlx/tool_parsers/auto_tool_parser.py tests/test_tool_parsers.py`
- `ruff format --check vllm_mlx/tool_parsers/auto_tool_parser.py tests/test_tool_parsers.py`
