### PR TITLE
Fix remaining Qwen tool-call admission edge cases

### DIFF
--- a/tests/test_tool_parser_content_passthrough.py
+++ b/tests/test_tool_parser_content_passthrough.py
@@ -480,6 +480,7 @@ class TestTruncatedCallsStillRecover:
         result = _qwen3coder().extract_tool_calls(wire, {"tools": DECLARED_TOOLS})
         assert result.tools_called is True
         assert result.tool_calls[0]["name"] == "write_file"
+        assert result.content is None
 
     def test_wrapped_zero_arg_call_truncated_after_header_recovers(self):
         request = {
@@ -498,6 +499,7 @@ class TestTruncatedCallsStillRecover:
         )
         assert result.tools_called is True
         assert result.tool_calls[0]["name"] == "ping"
+        assert result.content is None
 
         # Without canonical framing, a zero-argument span is indistinguishable
         # from prose documenting the protocol and remains non-executable.

--- a/tests/test_tool_parser_content_passthrough.py
+++ b/tests/test_tool_parser_content_passthrough.py
@@ -324,6 +324,22 @@ class TestOnlyDeclaredToolsBecomeCalls:
         assert [call["name"] for call in result.tool_calls] == ["write_file"]
         assert result.content == ("Docs: <function=read_file></function> then call: ")
 
+    def test_shared_wrapper_is_preserved_for_a_rejected_sibling(self):
+        text = (
+            "<tool_call><function=read_file></function>"
+            "<function=write_file>"
+            "<parameter=path>a.md</parameter>"
+            "<parameter=content>hi</parameter>"
+            "</function></tool_call>"
+        )
+        result = _qwen3coder().extract_tool_calls(text, {"tools": DECLARED_TOOLS})
+
+        assert result.tools_called is True
+        assert [call["name"] for call in result.tool_calls] == ["write_file"]
+        assert result.content == (
+            "<tool_call><function=read_file></function></tool_call>"
+        )
+
     @pytest.mark.parametrize(
         "request_payload",
         [

--- a/tests/test_tool_parser_content_passthrough.py
+++ b/tests/test_tool_parser_content_passthrough.py
@@ -510,6 +510,18 @@ class TestTruncatedCallsStillRecover:
         )
         assert unrelated_wrapper.tools_called is False
 
+    def test_call_truncated_after_function_close_removes_open_wrapper(self):
+        wire = (
+            "<tool_call><function=write_file>"
+            "<parameter=path>a.md</parameter>"
+            "<parameter=content>hi</parameter>"
+            "</function>"
+        )
+        result = _qwen3coder().extract_tool_calls(wire, {"tools": DECLARED_TOOLS})
+
+        assert result.tools_called is True
+        assert result.content is None
+
     def test_complete_call_is_unaffected(self):
         wire = (
             "<tool_call>\n<function=write_file>\n"

--- a/tests/test_tool_parser_content_passthrough.py
+++ b/tests/test_tool_parser_content_passthrough.py
@@ -340,6 +340,23 @@ class TestOnlyDeclaredToolsBecomeCalls:
             "<tool_call><function=read_file></function></tool_call>"
         )
 
+    def test_shared_wrapper_admits_a_later_zero_argument_call(self):
+        ping = {
+            "type": "function",
+            "function": {"name": "ping", "parameters": {}},
+        }
+        text = (
+            "<tool_call><function=read_file></function>"
+            "<function=ping></function></tool_call>"
+        )
+        result = _qwen3coder().extract_tool_calls(text, {"tools": [ping]})
+
+        assert result.tools_called is True
+        assert [call["name"] for call in result.tool_calls] == ["ping"]
+        assert result.content == (
+            "<tool_call><function=read_file></function></tool_call>"
+        )
+
     @pytest.mark.parametrize(
         "request_payload",
         [

--- a/tests/test_tool_parser_content_passthrough.py
+++ b/tests/test_tool_parser_content_passthrough.py
@@ -28,6 +28,7 @@ not be able to lose text to the tool layer.
 
 import pytest
 
+from vllm_mlx.api.models import ToolDefinition
 from vllm_mlx.config import get_config
 from vllm_mlx.service import helpers
 from vllm_mlx.tool_parsers.abstract_tool_parser import ToolParserManager
@@ -281,6 +282,47 @@ class TestOnlyDeclaredToolsBecomeCalls:
         )
         assert result.tools_called is True
         assert result.tool_calls[0]["name"] == "write_file"
+
+    def test_pydantic_tool_definition_is_executable(self):
+        tool = ToolDefinition.model_validate(DECLARED_TOOLS[0])
+        wire = (
+            "<tool_call><function=write_file>"
+            "<parameter=path>a.md</parameter>"
+            "<parameter=content>hi</parameter>"
+            "</function></tool_call>"
+        )
+        result = _qwen3coder().extract_tool_calls(wire, {"tools": [tool]})
+
+        assert result.tools_called is True
+        assert result.tool_calls[0]["name"] == "write_file"
+        assert result.tool_calls[0]["arguments"] == (
+            '{"path": "a.md", "content": "hi"}'
+        )
+
+        streaming = _qwen3coder().extract_tool_calls_streaming(
+            "", wire, wire, request={"tools": [tool]}
+        )
+        assert streaming is not None
+        assert streaming["tool_calls"][0]["function"] == {
+            "name": "write_file",
+            "arguments": '{"path": "a.md", "content": "hi"}',
+        }
+
+    def test_rejected_prose_does_not_hide_a_later_declared_call(self):
+        text = (
+            "Docs: <function=read_file></function> then call: "
+            "<tool_call><function=write_file>"
+            "<parameter=path>a.md</parameter>"
+            "<parameter=content>hi</parameter>"
+            "</function></tool_call>"
+        )
+        result = _qwen3coder().extract_tool_calls(
+            text, {"tools": DECLARED_TOOLS, "tool_choice": "auto"}
+        )
+
+        assert result.tools_called is True
+        assert [call["name"] for call in result.tool_calls] == ["write_file"]
+        assert result.content == ("Docs: <function=read_file></function> then call: ")
 
     @pytest.mark.parametrize(
         "request_payload",

--- a/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
+++ b/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
@@ -428,9 +428,11 @@ class Qwen3CoderToolParser(ToolParser):
                 if function_close >= 0
                 else span_end
             )
-            if function_close < 0 and model_output[span_start:].startswith(
+            owns_wrapper = model_output[span_start:].startswith(
                 self.tool_call_start_token
-            ):
+            )
+            wrapper_close = model_output.find(self.tool_call_end_token, function_end)
+            if owns_wrapper and (function_close < 0 or wrapper_close < 0):
                 function_start = span_start
             ranges.append((function_start, function_end))
 

--- a/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
+++ b/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
@@ -364,13 +364,13 @@ class Qwen3CoderToolParser(ToolParser):
         }
 
     def _get_function_calls(self, model_output: str) -> list[str]:
-        return [body for body, _, _ in self._function_call_candidates(model_output)]
+        return [body for body, _, _, _ in self._function_call_candidates(model_output)]
 
     def _function_call_candidates(
         self, model_output: str
-    ) -> list[tuple[str, int, int]]:
+    ) -> list[tuple[str, int, int, bool]]:
         """Return function bodies and the exact framing span each occupies."""
-        candidates: list[tuple[str, int, int]] = []
+        candidates: list[tuple[str, int, int, bool]] = []
         for start in self._function_start_positions(model_output):
             close = self._top_level_function_close(model_output, start)
             body_start = start + len(self.tool_call_prefix)
@@ -396,6 +396,10 @@ class Qwen3CoderToolParser(ToolParser):
 
             span_start = start
             wrapper_start = model_output.rfind(self.tool_call_start_token, 0, start)
+            wrapper_close_before = model_output.rfind(
+                self.tool_call_end_token, 0, start
+            )
+            is_wrapped = wrapper_start > wrapper_close_before
             if (
                 wrapper_start >= 0
                 and not model_output[
@@ -408,7 +412,7 @@ class Qwen3CoderToolParser(ToolParser):
             wrapper_end = model_output.find(self.tool_call_end_token, function_end)
             if wrapper_end >= 0 and not model_output[function_end:wrapper_end].strip():
                 span_end = wrapper_end + len(self.tool_call_end_token)
-            candidates.append((body, span_start, span_end))
+            candidates.append((body, span_start, span_end, is_wrapped))
         return candidates
 
     def _content_without_admitted_calls(
@@ -546,12 +550,10 @@ class Qwen3CoderToolParser(ToolParser):
 
             tool_calls = []
             accepted_spans: list[tuple[int, int]] = []
-            for fc_str, span_start, span_end in candidates:
+            for fc_str, span_start, span_end, is_wrapped in candidates:
                 candidate_name = fc_str.split(">", 1)[0]
                 if (
-                    not model_output[span_start:span_end].startswith(
-                        self.tool_call_start_token
-                    )
+                    not is_wrapped
                     and self.parameter_prefix not in fc_str
                     and candidate_name != selected
                 ):

--- a/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
+++ b/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
@@ -46,16 +46,21 @@ def _generate_tool_id() -> str:
     return f"call_{uuid.uuid4().hex[:8]}"
 
 
-def _get_arguments_config(func_name: str, tools: list[dict] | None) -> dict:
+def _field(value: Any, name: str, default: Any = None) -> Any:
+    """Read a request field from either its wire dict or Pydantic model."""
+    if isinstance(value, dict):
+        return value.get(name, default)
+    return getattr(value, name, default)
+
+
+def _get_arguments_config(func_name: str, tools: list[Any] | None) -> dict:
     """Extract argument config from tools list for type conversion."""
     if tools is None:
         return {}
     for tool in tools:
-        if not isinstance(tool, dict):
-            continue
-        func = tool.get("function", {})
-        if func.get("name") == func_name:
-            params = func.get("parameters", {})
+        func = _field(tool, "function", {})
+        if _field(func, "name") == func_name:
+            params = _field(func, "parameters", {})
             if isinstance(params, dict) and "properties" in params:
                 return params["properties"]
             return {}
@@ -311,7 +316,7 @@ class Qwen3CoderToolParser(ToolParser):
         return f'{inner}"'
 
     def _parse_xml_function_call(
-        self, function_call_str: str, tools: list[dict] | None
+        self, function_call_str: str, tools: list[Any] | None
     ) -> dict | None:
         """Parse a single function call from XML and return a tool call dict."""
         try:
@@ -359,45 +364,61 @@ class Qwen3CoderToolParser(ToolParser):
         }
 
     def _get_function_calls(self, model_output: str) -> list[str]:
-        calls = []
+        return [body for body, _, _ in self._function_call_candidates(model_output)]
+
+    def _function_call_candidates(
+        self, model_output: str
+    ) -> list[tuple[str, int, int]]:
+        """Return function bodies and the exact framing span each occupies."""
+        candidates: list[tuple[str, int, int]] = []
         for start in self._function_start_positions(model_output):
-            end = self._top_level_function_close(model_output, start)
+            close = self._top_level_function_close(model_output, start)
             body_start = start + len(self.tool_call_prefix)
-            if end == -1:
-                # Preserve the established max-token recovery contract: a
-                # function whose parameter blocks are complete is executable
-                # even when generation stopped before ``</function>``.  Do not
-                # recover a partially emitted parameter value.
-                candidate = model_output[body_start:]
-                complete_params = self.parameter_prefix in candidate and (
-                    candidate.rstrip().endswith(self.parameter_end_token)
+            if close == -1:
+                body = model_output[body_start:]
+                complete_params = (
+                    self.parameter_prefix in body
+                    and body.rstrip().endswith(self.parameter_end_token)
                 )
-                header_end = candidate.find(">")
                 wrapper_start = model_output.rfind(self.tool_call_start_token, 0, start)
                 wrapper_close = model_output.rfind(self.tool_call_end_token, 0, start)
                 wrapped_zero_arg = (
                     wrapper_start > wrapper_close
-                    and header_end >= 0
-                    and not candidate[header_end + 1 :].strip()
+                    and body.find(">") >= 0
+                    and not body[body.find(">") + 1 :].strip()
                 )
-                if complete_params or wrapped_zero_arg:
-                    calls.append(candidate)
-                continue
-            calls.append(model_output[body_start:end])
-        return calls
+                if not (complete_params or wrapped_zero_arg):
+                    continue
+                function_end = len(model_output)
+            else:
+                body = model_output[body_start:close]
+                function_end = close + len(self.function_end_token)
+
+            span_start = start
+            wrapper_start = model_output.rfind(self.tool_call_start_token, 0, start)
+            if (
+                wrapper_start >= 0
+                and not model_output[
+                    wrapper_start + len(self.tool_call_start_token) : start
+                ].strip()
+            ):
+                span_start = wrapper_start
+
+            span_end = function_end
+            wrapper_end = model_output.find(self.tool_call_end_token, function_end)
+            if wrapper_end >= 0 and not model_output[function_end:wrapper_end].strip():
+                span_end = wrapper_end + len(self.tool_call_end_token)
+            candidates.append((body, span_start, span_end))
+        return candidates
 
     @staticmethod
     def _named_tool_choice(request: dict[str, Any] | None) -> str | None:
         if not isinstance(request, dict):
             return None
         choice = request.get("tool_choice")
-        if isinstance(choice, dict):
-            function = choice.get("function")
-            selected = (
-                function.get("name")
-                if isinstance(function, dict)
-                else choice.get("name")
-            )
+        if isinstance(choice, dict) or choice is not None:
+            function = _field(choice, "function")
+            selected = _field(function, "name") or _field(choice, "name")
             if isinstance(selected, str) and selected:
                 return selected
         return None
@@ -409,14 +430,8 @@ class Qwen3CoderToolParser(ToolParser):
             return set()
         names: set[str] = set()
         for tool in request.get("tools") or []:
-            if not isinstance(tool, dict):
-                continue
-            function = tool.get("function")
-            if isinstance(function, dict):
-                name = function.get("name")
-            else:
-                # Responses-native tools are flat: {type, name, parameters}.
-                name = tool.get("name")
+            function = _field(tool, "function")
+            name = _field(function, "name") or _field(tool, "name")
             if isinstance(name, str) and name:
                 names.add(name)
         selected = cls._named_tool_choice(request)
@@ -433,8 +448,8 @@ class Qwen3CoderToolParser(ToolParser):
             )
 
         try:
-            function_calls = self._get_function_calls(model_output)
-            if not function_calls:
+            candidates = self._function_call_candidates(model_output)
+            if not candidates:
                 return ExtractedToolCallInformation(
                     tools_called=False, tool_calls=[], content=model_output
                 )
@@ -444,10 +459,13 @@ class Qwen3CoderToolParser(ToolParser):
             selected = self._named_tool_choice(request)
 
             tool_calls = []
-            for fc_str in function_calls:
+            accepted_spans: list[tuple[int, int]] = []
+            for fc_str, span_start, span_end in candidates:
                 candidate_name = fc_str.split(">", 1)[0]
                 if (
-                    self.tool_call_start_token not in model_output
+                    not model_output[span_start:span_end].startswith(
+                        self.tool_call_start_token
+                    )
                     and self.parameter_prefix not in fc_str
                     and candidate_name != selected
                 ):
@@ -456,9 +474,7 @@ class Qwen3CoderToolParser(ToolParser):
                     # documenting the wire format. Require either canonical
                     # framing or parameter structure before model text can
                     # become executable data.
-                    return ExtractedToolCallInformation(
-                        tools_called=False, tool_calls=[], content=model_output
-                    )
+                    continue
                 tc = self._parse_xml_function_call(fc_str, tools)
                 if not tc:
                     continue
@@ -466,22 +482,24 @@ class Qwen3CoderToolParser(ToolParser):
                     # Framing alone cannot distinguish executable wire from
                     # prose documenting that wire. A name the caller did not
                     # offer (including every name under tool_choice=none) is
-                    # never executable, so preserve the entire answer as text.
-                    return ExtractedToolCallInformation(
-                        tools_called=False, tool_calls=[], content=model_output
-                    )
+                    # never executable. Preserve that span as text while still
+                    # admitting independent, later candidates.
+                    continue
                 tool_calls.append(tc)
+                accepted_spans.append((span_start, span_end))
 
             if not tool_calls:
                 return ExtractedToolCallInformation(
                     tools_called=False, tool_calls=[], content=model_output
                 )
 
-            # Extract content before tool calls
-            content_index = model_output.find(self.tool_call_start_token)
-            idx = model_output.find(self.tool_call_prefix)
-            content_index = content_index if content_index >= 0 else idx
-            content = model_output[:content_index]
+            content_parts = []
+            cursor = 0
+            for span_start, span_end in accepted_spans:
+                content_parts.append(model_output[cursor:span_start])
+                cursor = span_end
+            content_parts.append(model_output[cursor:])
+            content = "".join(content_parts)
 
             return ExtractedToolCallInformation(
                 tools_called=len(tool_calls) > 0,

--- a/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
+++ b/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
@@ -474,14 +474,11 @@ class Qwen3CoderToolParser(ToolParser):
             if not residual and model_output[cursor:wrapper_close].strip():
                 residual = True
             if not residual:
-                wrapper_ranges.extend(
-                    [
-                        (wrapper_start, inner_start),
-                        (
-                            wrapper_close,
-                            wrapper_close + len(self.tool_call_end_token),
-                        ),
-                    ]
+                wrapper_ranges.append(
+                    (
+                        wrapper_start,
+                        wrapper_close + len(self.tool_call_end_token),
+                    )
                 )
             search_from = wrapper_close + len(self.tool_call_end_token)
 

--- a/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
+++ b/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
@@ -430,10 +430,24 @@ class Qwen3CoderToolParser(ToolParser):
             )
             ranges.append((function_start, function_end))
 
+        ranges.sort()
+        merged_ranges: list[tuple[int, int]] = []
+        for start, end in ranges:
+            if merged_ranges and start <= merged_ranges[-1][1]:
+                merged_ranges[-1] = (
+                    merged_ranges[-1][0],
+                    max(end, merged_ranges[-1][1]),
+                )
+            else:
+                merged_ranges.append((start, end))
+        ranges = merged_ranges
+
         # A wrapper may frame more than one function. Strip its delimiters only
         # when every non-whitespace byte inside it is already being removed;
         # otherwise both delimiters belong to the rejected content sibling.
         search_from = 0
+        range_index = 0
+        wrapper_ranges: list[tuple[int, int]] = []
         while True:
             wrapper_start = model_output.find(self.tool_call_start_token, search_from)
             if wrapper_start < 0:
@@ -442,16 +456,25 @@ class Qwen3CoderToolParser(ToolParser):
             wrapper_close = model_output.find(self.tool_call_end_token, inner_start)
             if wrapper_close < 0:
                 break
-            residual_parts = []
+            while range_index < len(ranges) and ranges[range_index][1] <= inner_start:
+                range_index += 1
             cursor = inner_start
-            for start, end in ranges:
-                if end <= inner_start or start >= wrapper_close:
-                    continue
-                residual_parts.append(model_output[cursor : max(cursor, start)])
+            residual = False
+            candidate_index = range_index
+            while (
+                candidate_index < len(ranges)
+                and ranges[candidate_index][0] < wrapper_close
+            ):
+                start, end = ranges[candidate_index]
+                if model_output[cursor : max(cursor, start)].strip():
+                    residual = True
+                    break
                 cursor = max(cursor, min(end, wrapper_close))
-            residual_parts.append(model_output[cursor:wrapper_close])
-            if not "".join(residual_parts).strip():
-                ranges.extend(
+                candidate_index += 1
+            if not residual and model_output[cursor:wrapper_close].strip():
+                residual = True
+            if not residual:
+                wrapper_ranges.extend(
                     [
                         (wrapper_start, inner_start),
                         (
@@ -464,7 +487,7 @@ class Qwen3CoderToolParser(ToolParser):
 
         content_parts = []
         cursor = 0
-        for start, end in sorted(ranges):
+        for start, end in sorted([*ranges, *wrapper_ranges]):
             if start > cursor:
                 content_parts.append(model_output[cursor:start])
             cursor = max(cursor, end)

--- a/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
+++ b/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
@@ -428,6 +428,10 @@ class Qwen3CoderToolParser(ToolParser):
                 if function_close >= 0
                 else span_end
             )
+            if function_close < 0 and model_output[span_start:].startswith(
+                self.tool_call_start_token
+            ):
+                function_start = span_start
             ranges.append((function_start, function_end))
 
         ranges.sort()

--- a/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
+++ b/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
@@ -411,6 +411,66 @@ class Qwen3CoderToolParser(ToolParser):
             candidates.append((body, span_start, span_end))
         return candidates
 
+    def _content_without_admitted_calls(
+        self, model_output: str, admitted_spans: list[tuple[int, int]]
+    ) -> str:
+        """Remove admitted functions without leaving half of a shared wrapper."""
+        ranges: list[tuple[int, int]] = []
+        for span_start, span_end in admitted_spans:
+            function_start = model_output.find(
+                self.tool_call_prefix, span_start, span_end
+            )
+            function_close = self._top_level_function_close(
+                model_output, function_start
+            )
+            function_end = (
+                function_close + len(self.function_end_token)
+                if function_close >= 0
+                else span_end
+            )
+            ranges.append((function_start, function_end))
+
+        # A wrapper may frame more than one function. Strip its delimiters only
+        # when every non-whitespace byte inside it is already being removed;
+        # otherwise both delimiters belong to the rejected content sibling.
+        search_from = 0
+        while True:
+            wrapper_start = model_output.find(self.tool_call_start_token, search_from)
+            if wrapper_start < 0:
+                break
+            inner_start = wrapper_start + len(self.tool_call_start_token)
+            wrapper_close = model_output.find(self.tool_call_end_token, inner_start)
+            if wrapper_close < 0:
+                break
+            residual_parts = []
+            cursor = inner_start
+            for start, end in ranges:
+                if end <= inner_start or start >= wrapper_close:
+                    continue
+                residual_parts.append(model_output[cursor : max(cursor, start)])
+                cursor = max(cursor, min(end, wrapper_close))
+            residual_parts.append(model_output[cursor:wrapper_close])
+            if not "".join(residual_parts).strip():
+                ranges.extend(
+                    [
+                        (wrapper_start, inner_start),
+                        (
+                            wrapper_close,
+                            wrapper_close + len(self.tool_call_end_token),
+                        ),
+                    ]
+                )
+            search_from = wrapper_close + len(self.tool_call_end_token)
+
+        content_parts = []
+        cursor = 0
+        for start, end in sorted(ranges):
+            if start > cursor:
+                content_parts.append(model_output[cursor:start])
+            cursor = max(cursor, end)
+        content_parts.append(model_output[cursor:])
+        return "".join(content_parts)
+
     @staticmethod
     def _named_tool_choice(request: dict[str, Any] | None) -> str | None:
         if not isinstance(request, dict):
@@ -493,13 +553,7 @@ class Qwen3CoderToolParser(ToolParser):
                     tools_called=False, tool_calls=[], content=model_output
                 )
 
-            content_parts = []
-            cursor = 0
-            for span_start, span_end in accepted_spans:
-                content_parts.append(model_output[cursor:span_start])
-                cursor = span_end
-            content_parts.append(model_output[cursor:])
-            content = "".join(content_parts)
+            content = self._content_without_admitted_calls(model_output, accepted_spans)
 
             return ExtractedToolCallInformation(
                 tools_called=len(tool_calls) > 0,


### PR DESCRIPTION
Closes #1513

## What does this PR do?

- accepts Pydantic `ToolDefinition` instances as well as wire dictionaries when resolving declared tools and argument schemas
- evaluates Qwen XML function candidates independently, preserving rejected prose spans without suppressing later declared calls
- removes admitted calls without corrupting shared, complete, or truncated `<tool_call>` wrappers
- keeps cleanup linear after sorting ranges, avoiding model-controlled quadratic work
- adds regressions for model objects, streaming parity, mixed admission, shared wrappers, zero-argument siblings, and truncated framing

## Why is this needed?

Issue #1513 remained partially reproducible after the earlier broad fix. The parser only inspected dictionary-shaped tool definitions and returned immediately when any candidate was rejected. Internal callers passing model objects therefore produced false negatives, while an undeclared documentation example could hide a later valid call in the same response.

## AI assistance disclosure

Codex wrote and iteratively reviewed both touched files: `vllm_mlx/tool_parsers/qwen3coder_tool_parser.py` and `tests/test_tool_parser_content_passthrough.py`. Each reported blocking edge case was reproduced with a regression test and re-reviewed. I verified the final behavior with focused parser suites, upstream regression tests, the repository PR-validation pipeline, and the full unit suite.

> By submitting this PR I confirm I can explain the intent, risk, and behavior of every non-generated change in this PR. For any generated / boilerplate / scaffolded sections, I have identified them above and can describe how I verified them.

## Test plan

- `ruff check vllm_mlx/tool_parsers/qwen3coder_tool_parser.py tests/test_tool_parser_content_passthrough.py`
- focused Qwen parser, streaming, parallel-call, value-fidelity, closer-integrity, and wire-format suites: 763 passed, 28 skipped before the later focused regressions
- final targeted PR validation: 256 passed, 2 skipped
- final full unit suite: 16,656 passed, 60 skipped, 18 deselected, 6 xfailed, 1 xpassed
- Codex adversarial review: no blocking issues
- `git diff --check`

## Checklist

- [x] Tests pass locally (`python3 -m pytest tests/ -x`)
- [x] Lint passes (`ruff check && ruff format --check`)
- [x] Self-validated with `python3 -m scripts.pr_validate.pr_validate 1727`
- [x] Critical parser regressions were confirmed failing before the production fix
- [x] README/docs update not applicable
- [x] No breaking changes to existing API