### PR TITLE
fix(desktop): validate the stored last-served alias before restoring it (#1706)

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Server/AutoStartDecision.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/AutoStartDecision.swift
@@ -239,7 +239,11 @@ enum AutoStartDecision: Equatable {
     /// 1. ``lastServedAlias`` — the user already picked something on
     ///    a prior launch; honour it even if it isn't cached (we'll
     ///    return ``.promptDownload``, the user's intent stays
-    ///    represented).
+    ///    represented). Gated by ``storedAliasIsServable`` when a
+    ///    ``catalogAliases`` snapshot is supplied: a stored alias that
+    ///    is not a catalog member, or that ``rejectsAlias`` refuses,
+    ///    falls through to the tiers below rather than being restored
+    ///    into a guaranteed serve failure (#1706).
     /// 2. ``bundledFallbackAlias`` — the BUNDLE_MODEL=1 dev build
     ///    instant-on path.
     /// 3. First entry in ``cachedAliases`` sorted alphabetically —
@@ -258,6 +262,7 @@ enum AutoStartDecision: Equatable {
         binaryReachable: Bool,
         cachedAliases: Set<String>,
         serverState: ServerState,
+        catalogAliases: Set<String>? = nil,
         rejectsAlias: (String) -> Bool = { _ in false },
         userOptedIn: Bool = true,
         firstRunDecisionPending: Bool = false,
@@ -324,18 +329,22 @@ enum AutoStartDecision: Equatable {
         }
 
         // Alias resolution — strict precedence per the doc comment.
-        // ``rejectsAlias`` is only applied to the CACHED-FALLBACK tier
-        // (codex r1 MAJOR): lastServed represents an explicit prior
-        // user choice we don't second-guess, bundled is hand-picked
-        // by us, but the alphabetically-first cached entry is a
+        // ``rejectsAlias`` always guards the CACHED-FALLBACK tier
+        // (codex r1 MAJOR): the alphabetically-first cached entry is a
         // best-effort heuristic that must respect the same
-        // ``ModelSizing.tooBig`` guard the picker's Start CTA
-        // enforces (otherwise a cleared-defaults user with one large
-        // cached model on disk gets auto-OOM'd on launch).
+        // ``ModelSizing.tooBig`` guard the picker's Start CTA enforces
+        // (otherwise a cleared-defaults user with one large cached
+        // model on disk gets auto-OOM'd on launch). Since #1706 it also
+        // guards the STORED lastServed tier — together with a catalog-
+        // membership check — whenever ``catalogAliases`` is supplied, so
+        // a stale/oversized/renamed stored alias declines to the picker
+        // instead of being restored into a failed serve. bundled stays
+        // product-curated and unconditionally honoured.
         let resolved = resolveAlias(
             lastServedAlias: lastServedAlias,
             bundledFallbackAlias: bundledFallbackAlias,
             cachedAliases: cachedAliases,
+            catalogAliases: catalogAliases,
             rejectsAlias: rejectsAlias
         )
         guard let alias = resolved else {
@@ -386,17 +395,22 @@ enum AutoStartDecision: Equatable {
     /// Pure resolver — extracted so the precedence rules can be
     /// pinned without standing up the wider ``decide`` machinery.
     ///
-    /// ``rejectsAlias`` is consulted ONLY for the cached-fallback
-    /// tier. The lastServed and bundled tiers carry user-level or
-    /// product-level intent we don't override — see ``decide``'s
-    /// doc comment for the codex r1 MAJOR rationale.
+    /// ``rejectsAlias`` is always consulted for the cached-fallback
+    /// tier, and — when ``catalogAliases`` is supplied — for the
+    /// stored ``lastServedAlias`` tier as well (see
+    /// ``storedAliasIsServable`` and #1706). The bundled tier is
+    /// product-curated and unconditionally honoured.
     private static func resolveAlias(
         lastServedAlias: String?,
         bundledFallbackAlias: String?,
         cachedAliases: Set<String>,
+        catalogAliases: Set<String>?,
         rejectsAlias: (String) -> Bool
     ) -> String? {
-        if let stored = trimmed(lastServedAlias) {
+        if let stored = trimmed(lastServedAlias),
+           storedAliasIsServable(
+               stored, catalogAliases: catalogAliases, rejectsAlias: rejectsAlias
+           ) {
             return stored
         }
         if let bundled = trimmed(bundledFallbackAlias) {
@@ -428,6 +442,58 @@ enum AutoStartDecision: Equatable {
             }
         }
         return nil
+    }
+
+    /// Whether a stored ``lastServedAlias`` may be resumed as-is.
+    ///
+    /// ## Why (issue #1706)
+    ///
+    /// Before this gate the stored alias was returned unconditionally.
+    /// That let the desktop try to restore an alias the bundled engine
+    /// cannot serve *now* — the reported case was an image-generation
+    /// alias (``flux2-klein-4b``) left in ``rapid.serve.lastAlias`` by a
+    /// different checkout's build, which is absent from the chat catalog
+    /// entirely. The stored alias also stops being servable when it is
+    /// renamed/dropped across engine versions, when the engine is
+    /// downgraded, or when free memory has shrunk since the last run
+    /// (the ``.tooBig`` classification is a per-launch fact, not a
+    /// last-time guarantee). In every case the old path spent a model
+    /// load on a request it could have known would fail, and greeted the
+    /// returning user with a failure banner instead of the picker.
+    ///
+    /// Two membership-scoped checks, mirroring how ``CacheAwareDefault``
+    /// validates the RAM-bucketed default:
+    ///
+    /// 1. **Catalog membership.** The alias must appear in the catalog
+    ///    the sidecar can serve. A member that simply is not downloaded
+    ///    yet still qualifies here — cached-vs-uncached is a separate
+    ///    axis that ``decide`` uses to choose ``.start`` vs
+    ///    ``.promptDownload``, so honouring an uncached-but-real alias
+    ///    (the user's prior intent) is preserved.
+    /// 2. **OOM guard.** The alias must pass ``rejectsAlias`` — the same
+    ///    ``ModelSizing.classify(...) == .tooBig`` predicate the
+    ///    cached-fallback tier and the picker's Start CTA enforce, so a
+    ///    "worked last time" alias that no longer fits this Mac's free
+    ///    memory declines to the picker rather than auto-OOM-ing.
+    ///
+    /// When either fails, ``resolveAlias`` falls through to the bundled
+    /// / cached-scan ladder — "restore what I was using" stays the
+    /// dominant behaviour and only yields when the alias genuinely
+    /// cannot be served now.
+    ///
+    /// ``catalogAliases == nil`` means the caller did not supply an
+    /// authoritative catalog snapshot (legacy call sites / unit tests
+    /// that predate #1706). There we keep the historical unconditional-
+    /// honour contract so those callers are unaffected; the production
+    /// launch hook in ``ContentView`` always supplies the real set.
+    private static func storedAliasIsServable(
+        _ alias: String,
+        catalogAliases: Set<String>?,
+        rejectsAlias: (String) -> Bool
+    ) -> Bool {
+        guard let catalogAliases else { return true }
+        guard catalogAliases.contains(alias) else { return false }
+        return !rejectsAlias(alias)
     }
 
     private static func trimmed(_ s: String?) -> String? {

--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -711,12 +711,21 @@ struct ContentView: View {
         let aliasAtEntry = alias
         let userSelectionRevisionAtEntry = userSelectionRevision
         var cachedAliases: Set<String> = []
+        // #1706: the full catalog membership snapshot (cached AND
+        // uncached entries the sidecar can serve), used to validate the
+        // stored last-served alias before we resume it. `nil` would ask
+        // ``decide`` to skip the membership check; we always pass a
+        // concrete set when the binary is reachable so a stored alias
+        // the engine can't serve (renamed/dropped/wrong-modality) falls
+        // through to the picker instead of a failed serve.
+        var catalogAliases: Set<String>? = nil
         if let binary = server.binaryPath {
             let entries = await ModelCatalogCache.shared.entries(
                 binary: binary,
                 generation: downloads.cacheGeneration
             )
             cachedAliases = Set(entries.filter { $0.cached }.map(\.alias))
+            catalogAliases = Set(entries.map(\.alias))
         }
         guard case .idle = server.state else {
             autoStartPendingDownload = nil
@@ -749,6 +758,7 @@ struct ContentView: View {
             binaryReachable: server.binaryPath != nil,
             cachedAliases: cachedAliases,
             serverState: server.state,
+            catalogAliases: catalogAliases,
             rejectsAlias: rejectsAlias,
             userOptedIn: autoStartOnLaunch,
             // #1589: the two first-run surfaces get the launch before

--- a/apps/rapid-mac/Tests/RapidTests/AutoStartDecisionTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/AutoStartDecisionTests.swift
@@ -327,7 +327,7 @@ struct AutoStartDecisionTests {
         #expect(decision == .start(alias: "qwen3.5-4b-4bit"))
     }
 
-    @Test("Codex r1 MAJOR: rejectsAlias does NOT filter lastServed (explicit prior intent honoured)")
+    @Test("Codex r1 MAJOR: rejectsAlias does NOT filter lastServed when no catalog snapshot is supplied (legacy contract)")
     func rejectsAliasDoesNotFilterLastServed() {
         let decision = AutoStartDecision.decide(
             lastServedAlias: "qwen3.5-122b-8bit",
@@ -335,8 +335,12 @@ struct AutoStartDecisionTests {
             binaryReachable: true,
             cachedAliases: ["qwen3.5-122b-8bit"],
             serverState: .idle,
-            // Reject everything — proves the predicate is only
-            // consulted for the cached-fallback tier.
+            // ``catalogAliases`` defaults to nil here (legacy call
+            // shape). Reject everything — with no catalog snapshot the
+            // stored tier keeps its unconditional-honour contract and
+            // the predicate is consulted only for the cached-fallback
+            // tier. The #1706 tests below cover the supplied-catalog
+            // case where the stored tier IS filtered.
             rejectsAlias: { _ in true }
         )
         #expect(decision == .start(alias: "qwen3.5-122b-8bit"))
@@ -387,6 +391,115 @@ struct AutoStartDecisionTests {
         )
         #expect(decision == .skip(reason: .noResolvableAlias))
         #expect(invoked == false)
+    }
+
+    // MARK: - #1706: stored last-served alias must be servable now
+
+    /// The reporter's exact case: ``rapid.serve.lastAlias`` held an
+    /// image-generation alias (``flux2-klein-4b``) written by another
+    /// checkout's build; it is absent from the chat catalog entirely.
+    /// With a catalog snapshot supplied, the stored non-member must NOT
+    /// be restored — resolution falls through to the real cached model.
+    @Test("#1706: stored alias absent from the catalog falls through to the cached model")
+    func storedNonMemberFallsThroughToCached() {
+        let decision = AutoStartDecision.decide(
+            lastServedAlias: "flux2-klein-4b",
+            bundledFallbackAlias: nil,
+            binaryReachable: true,
+            cachedAliases: ["qwen3.5-4b-4bit"],
+            serverState: .idle,
+            catalogAliases: ["qwen3.5-4b-4bit"]
+        )
+        #expect(decision == .start(alias: "qwen3.5-4b-4bit"))
+    }
+
+    /// Stored non-member with nothing else to fall back to → the picker
+    /// (``noResolvableAlias``), NOT a ``promptDownload`` of an alias the
+    /// engine cannot serve. This is the exact repro from the issue
+    /// ("the picker shows does-not-exist-9b" is what we must avoid).
+    @Test("#1706: stored non-member with no fallback → picker, never promptDownload of an unservable alias")
+    func storedNonMemberNoFallbackShowsPicker() {
+        let decision = AutoStartDecision.decide(
+            lastServedAlias: "does-not-exist-9b",
+            bundledFallbackAlias: nil,
+            binaryReachable: true,
+            cachedAliases: [],
+            serverState: .idle,
+            catalogAliases: ["qwen3.5-4b-4bit"]
+        )
+        #expect(decision == .skip(reason: .noResolvableAlias))
+    }
+
+    /// A stored alias that IS a catalog member but that ``rejectsAlias``
+    /// refuses (``ModelSizing.classify == .tooBig`` — free memory shrank
+    /// since it last served) must decline to a servable alternative
+    /// rather than auto-OOM. "Worked last time" is not a RAM guarantee.
+    @Test("#1706: stored member the OOM guard rejects falls through to a fitting cached model")
+    func storedMemberRejectedByGuardFallsThrough() {
+        let decision = AutoStartDecision.decide(
+            lastServedAlias: "qwen3.5-122b-8bit",
+            bundledFallbackAlias: nil,
+            binaryReachable: true,
+            cachedAliases: ["qwen3.5-122b-8bit", "qwen3.5-4b-4bit"],
+            serverState: .idle,
+            catalogAliases: ["qwen3.5-122b-8bit", "qwen3.5-4b-4bit"],
+            // Only the oversized alias is refused; the small one fits.
+            rejectsAlias: { $0 == "qwen3.5-122b-8bit" }
+        )
+        #expect(decision == .start(alias: "qwen3.5-4b-4bit"))
+    }
+
+    /// The dominant behaviour is preserved: a stored alias that IS a
+    /// catalog member, merely not downloaded yet and not oversized, is
+    /// still honoured as the user's intent → ``.promptDownload``.
+    /// Catalog membership is orthogonal to cached-ness — the fix must
+    /// not collapse "not downloaded" into "not servable".
+    @Test("#1706: stored member that is uncached-but-servable is still honoured → promptDownload")
+    func storedUncachedMemberStillPromptsDownload() {
+        let decision = AutoStartDecision.decide(
+            lastServedAlias: "qwen3.5-122b-8bit",
+            bundledFallbackAlias: nil,
+            binaryReachable: true,
+            cachedAliases: ["qwen3.5-4b-4bit"],
+            serverState: .idle,
+            catalogAliases: ["qwen3.5-122b-8bit", "qwen3.5-4b-4bit"],
+            rejectsAlias: { _ in false }
+        )
+        #expect(decision == .promptDownload(alias: "qwen3.5-122b-8bit"))
+    }
+
+    /// Back-compat: with ``catalogAliases`` left nil (every legacy call
+    /// site and the 50+ existing tests), the stored tier keeps its
+    /// unconditional-honour contract — no membership check, so a
+    /// non-member stored alias is still returned. Guards against the fix
+    /// silently changing callers that cannot supply a catalog snapshot.
+    @Test("#1706: nil catalog snapshot preserves the legacy unconditional-honour contract")
+    func nilCatalogPreservesLegacyHonour() {
+        let decision = AutoStartDecision.decide(
+            lastServedAlias: "flux2-klein-4b",
+            bundledFallbackAlias: nil,
+            binaryReachable: true,
+            cachedAliases: ["qwen3.5-4b-4bit"],
+            serverState: .idle
+            // catalogAliases omitted → nil → legacy path.
+        )
+        #expect(decision == .promptDownload(alias: "flux2-klein-4b"))
+    }
+
+    /// When the stored alias is unservable, the fall-through respects
+    /// the full precedence ladder: a product-curated bundled alias is
+    /// preferred over the alphabetical cached scan.
+    @Test("#1706: unservable stored alias falls through to the bundled tier before the cached scan")
+    func storedNonMemberFallsThroughToBundled() {
+        let decision = AutoStartDecision.decide(
+            lastServedAlias: "flux2-klein-4b",
+            bundledFallbackAlias: "bonsai-1.7b-2bit",
+            binaryReachable: true,
+            cachedAliases: ["bonsai-1.7b-2bit", "qwen3.5-4b-4bit"],
+            serverState: .idle,
+            catalogAliases: ["bonsai-1.7b-2bit", "qwen3.5-4b-4bit"]
+        )
+        #expect(decision == .start(alias: "bonsai-1.7b-2bit"))
     }
 
     // MARK: - FU-1 (v0.7.19 audit): user opt-out for launch-time auto-start


### PR DESCRIPTION
## Why

`AutoStartDecision.resolveAlias` returned the persisted `lastServedAlias` **unconditionally**, so the desktop would try to restore an alias the bundled engine cannot serve *now*. Closes #1706.

The reported case: `rapid.serve.lastAlias` held an image-generation alias (`flux2-klein-4b`) written by a different checkout's build — it is absent from the chat catalog entirely (`rapid-mlx ls` lists the FLUX weights as `(unmapped)`, which `ModelCatalog.load` skips). Every other default-resolution path is catalog-scoped (`CacheAwareDefault.pick` falls through to `SafeDefaultFallback` when the RAM table names an alias the bundled engine doesn't ship); the stored-alias path had no equivalent, and it also bypassed the `rejectsAlias` `.tooBig` OOM guard that the cached-scan tier below it enforces.

It matters beyond the reporter's dual-checkout setup: a stored alias stops being servable when it is renamed/dropped across engine versions, when the engine is downgraded, or when free memory has shrunk since the last successful run (`.tooBig` is a per-launch fact, not a "it worked last time" guarantee). In each case the old path spent a model load on a request it could have known would fail, and greeted the returning user with a failure banner instead of the picker.

## What

- `AutoStartDecision.decide`/`resolveAlias` take a new optional `catalogAliases: Set<String>?`. New `storedAliasIsServable` helper gates the stored tier: when a catalog snapshot is supplied, the stored alias must **(1)** be a catalog member and **(2)** pass `rejectsAlias`. On either failure, `resolveAlias` falls through to the existing bundled / cached-scan ladder — "restore what I was using" stays the dominant behaviour and only yields when the alias genuinely cannot be served now.
- Catalog membership is orthogonal to cached-ness: an uncached-but-real alias (the user's prior intent) is still honoured as `.promptDownload`. The fix does not collapse "not downloaded" into "not servable".
- `catalogAliases == nil` preserves the historical unconditional-honour contract for legacy call sites and the existing test suite. The production launch hook (`ContentView.runLaunchAutoStart`) always supplies the real set — `Set(entries.map(\.alias))`, the full mapped catalog (cached + uncached), computed from the same `ModelCatalogCache.entries` probe that already feeds `cachedAliases`.
- The bundled tier stays product-curated and unconditionally honoured (unchanged).

## Tests

- Reproduced first: with the current signature, a stored non-member alias (`does-not-exist-9b`) and a too-big stored alias are both handed back as `.promptDownload` of an unservable alias.
- 6 new regression tests in `AutoStartDecisionTests` (31 total in the suite, green):
  - stored non-member falls through to the cached model;
  - stored non-member with no fallback → picker (`noResolvableAlias`), never `.promptDownload` of an unservable alias (the exact issue repro);
  - stored member the OOM guard rejects falls through to a fitting cached model;
  - stored uncached-but-servable member still honoured → `.promptDownload` (intent preserved);
  - nil catalog snapshot preserves the legacy unconditional-honour contract;
  - unservable stored alias falls through to the bundled tier before the cached scan.
- `swift build` clean; adjacent suites green (`LaunchOnboardingOrderingTests`, `HideAlwaysOrthogonalToAutoStartTests` — 18 tests). Python `pr_validate` full_unit does not cover Swift; this is a Swift-only change with zero Python risk.

## Notes

This reverses the earlier codex r1 MAJOR "do not filter lastServed" stance **only** for callers that supply an authoritative catalog snapshot — the reporter (repo owner) explicitly asked for both the membership check and the `rejectsAlias` guard on the stored tier. The legacy nil-catalog contract is retained and pinned by a dedicated test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)