### PR TITLE
Fix Qwen streaming argument delimiter fidelity

### DIFF
--- a/tests/test_postprocessor.py
+++ b/tests/test_postprocessor.py
@@ -2877,9 +2877,7 @@ class TestRequestForwardedToToolParser:
             f"names_seen={names_seen}"
         )
 
-    @pytest.mark.parametrize(
-        "closer", ["</parameter>", "</function>", "</tool_call>"]
-    )
+    @pytest.mark.parametrize("closer", ["</parameter>", "</function>", "</tool_call>"])
     def test_qwen3_coder_finalize_preserves_closer_in_legacy_raw_value(self, closer):
         """#1515: ambiguous raw XML is resolved from the complete EOS buffer."""
         from vllm_mlx.tool_parsers.qwen3coder_tool_parser import (
@@ -2914,7 +2912,9 @@ class TestRequestForwardedToToolParser:
             *value,
             "\n</parameter>\n</function>\n</tool_call>",
         ]
-        streamed = [event for piece in pieces for event in pp.process_chunk(_make_output(piece))]
+        streamed = [
+            event for piece in pieces for event in pp.process_chunk(_make_output(piece))
+        ]
         assert [event for event in streamed if event.type == "tool_call"] == []
 
         final_events = pp.finalize()

--- a/tests/test_postprocessor.py
+++ b/tests/test_postprocessor.py
@@ -2915,12 +2915,16 @@ class TestRequestForwardedToToolParser:
         streamed = [
             event for piece in pieces for event in pp.process_chunk(_make_output(piece))
         ]
-        assert [event for event in streamed if event.type == "tool_call"] == []
-
         final_events = pp.finalize()
         tool_events = [event for event in final_events if event.type == "tool_call"]
         assert len(tool_events) == 1
-        arguments = tool_events[0].tool_calls[0]["function"]["arguments"]
+        all_tool_events = [
+            event for event in [*streamed, *final_events] if event.type == "tool_call"
+        ]
+        arguments = "".join(
+            event.tool_calls[0]["function"].get("arguments", "")
+            for event in all_tool_events
+        )
         assert json.loads(arguments) == {"content": value}
 
     def test_qwen3_coder_finalize_recovers_truncated_legacy_raw_call(self):
@@ -2950,15 +2954,15 @@ class TestRequestForwardedToToolParser:
         pp.reset()
         wire = f"<tool_call>\n<function=echo>\n<parameter=value>\n{value}\n</tool_call>"
 
-        assert [
-            event
-            for event in pp.process_chunk(_make_output(wire))
-            if event.type == "tool_call"
-        ] == []
+        streamed = pp.process_chunk(_make_output(wire))
         final_events = pp.finalize()
         tool_events = [event for event in final_events if event.type == "tool_call"]
         assert len(tool_events) == 1
-        arguments = tool_events[0].tool_calls[0]["function"]["arguments"]
+        arguments = "".join(
+            event.tool_calls[0]["function"].get("arguments", "")
+            for event in [*streamed, *final_events]
+            if event.type == "tool_call"
+        )
         assert json.loads(arguments) == {"value": value}
 
     def test_qwen3_coder_later_legacy_raw_parameter_defers_whole_call(self):
@@ -2999,8 +3003,12 @@ class TestRequestForwardedToToolParser:
         streamed = [
             event for piece in pieces for event in pp.process_chunk(_make_output(piece))
         ]
-        assert [event for event in streamed if event.type == "tool_call"] == []
-        tool_events = [event for event in pp.finalize() if event.type == "tool_call"]
+        final_events = pp.finalize()
+        tool_events = [event for event in final_events if event.type == "tool_call"]
         assert len(tool_events) == 1
-        arguments = tool_events[0].tool_calls[0]["function"]["arguments"]
+        arguments = "".join(
+            event.tool_calls[0]["function"].get("arguments", "")
+            for event in [*streamed, *final_events]
+            if event.type == "tool_call"
+        )
         assert json.loads(arguments) == {"path": "a.md", "content": value}

--- a/tests/test_postprocessor.py
+++ b/tests/test_postprocessor.py
@@ -2876,3 +2876,49 @@ class TestRequestForwardedToToolParser:
             f"#171: tool_call emitted but function name 'read' missing; "
             f"names_seen={names_seen}"
         )
+
+    @pytest.mark.parametrize(
+        "closer", ["</parameter>", "</function>", "</tool_call>"]
+    )
+    def test_qwen3_coder_finalize_preserves_closer_in_legacy_raw_value(self, closer):
+        """#1515: ambiguous raw XML is resolved from the complete EOS buffer."""
+        from vllm_mlx.tool_parsers.qwen3coder_tool_parser import (
+            Qwen3CoderToolParser,
+        )
+
+        parser = Qwen3CoderToolParser(tokenizer=None)
+        cfg = _make_cfg(
+            enable_auto_tool_choice=True,
+            tool_parser_instance=parser,
+        )
+        request = {
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "write",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {"content": {"type": "string"}},
+                        },
+                    },
+                }
+            ]
+        }
+        value = f"before {closer} after"
+        pp = StreamingPostProcessor(cfg, tools_requested=True, request=request)
+        pp.reset()
+
+        pieces = [
+            "<tool_call>\n<function=write>\n<parameter=content>\n",
+            *value,
+            "\n</parameter>\n</function>\n</tool_call>",
+        ]
+        streamed = [event for piece in pieces for event in pp.process_chunk(_make_output(piece))]
+        assert [event for event in streamed if event.type == "tool_call"] == []
+
+        final_events = pp.finalize()
+        tool_events = [event for event in final_events if event.type == "tool_call"]
+        assert len(tool_events) == 1
+        arguments = tool_events[0].tool_calls[0]["function"]["arguments"]
+        assert json.loads(arguments) == {"content": value}

--- a/tests/test_postprocessor.py
+++ b/tests/test_postprocessor.py
@@ -2922,3 +2922,85 @@ class TestRequestForwardedToToolParser:
         assert len(tool_events) == 1
         arguments = tool_events[0].tool_calls[0]["function"]["arguments"]
         assert json.loads(arguments) == {"content": value}
+
+    def test_qwen3_coder_finalize_recovers_truncated_legacy_raw_call(self):
+        """EOS recovery retains the pre-#1515 malformed-call contract."""
+        from vllm_mlx.tool_parsers.qwen3coder_tool_parser import (
+            Qwen3CoderToolParser,
+        )
+
+        parser = Qwen3CoderToolParser(tokenizer=None)
+        cfg = _make_cfg(enable_auto_tool_choice=True, tool_parser_instance=parser)
+        request = {
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "echo",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {"value": {"type": "string"}},
+                        },
+                    },
+                }
+            ]
+        }
+        value = "A" * 80 + "B" * 80
+        pp = StreamingPostProcessor(cfg, tools_requested=True, request=request)
+        pp.reset()
+        wire = f"<tool_call>\n<function=echo>\n<parameter=value>\n{value}\n</tool_call>"
+
+        assert [
+            event
+            for event in pp.process_chunk(_make_output(wire))
+            if event.type == "tool_call"
+        ] == []
+        final_events = pp.finalize()
+        tool_events = [event for event in final_events if event.type == "tool_call"]
+        assert len(tool_events) == 1
+        arguments = tool_events[0].tool_calls[0]["function"]["arguments"]
+        assert json.loads(arguments) == {"value": value}
+
+    def test_qwen3_coder_later_legacy_raw_parameter_defers_whole_call(self):
+        """A canonical first parameter must not hide a later raw parameter."""
+        from vllm_mlx.tool_parsers.qwen3coder_tool_parser import (
+            Qwen3CoderToolParser,
+        )
+
+        parser = Qwen3CoderToolParser(tokenizer=None)
+        cfg = _make_cfg(enable_auto_tool_choice=True, tool_parser_instance=parser)
+        request = {
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "write",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {
+                                "path": {"type": "string"},
+                                "content": {"type": "string"},
+                            },
+                        },
+                    },
+                }
+            ]
+        }
+        value = "before </parameter> after"
+        pieces = [
+            '<tool_call>\n<function=write>\n<parameter=path>\n"a.md"',
+            "\n</parameter>\n<parameter=content>\n",
+            *value,
+            "\n</parameter>\n</function>\n</tool_call>",
+        ]
+        pp = StreamingPostProcessor(cfg, tools_requested=True, request=request)
+        pp.reset()
+
+        streamed = [
+            event for piece in pieces for event in pp.process_chunk(_make_output(piece))
+        ]
+        assert [event for event in streamed if event.type == "tool_call"] == []
+        tool_events = [event for event in pp.finalize() if event.type == "tool_call"]
+        assert len(tool_events) == 1
+        arguments = tool_events[0].tool_calls[0]["function"]["arguments"]
+        assert json.loads(arguments) == {"path": "a.md", "content": value}

--- a/tests/test_postprocessor.py
+++ b/tests/test_postprocessor.py
@@ -3012,3 +3012,48 @@ class TestRequestForwardedToToolParser:
             if event.type == "tool_call"
         )
         assert json.loads(arguments) == {"path": "a.md", "content": value}
+
+    def test_qwen3_coder_finalize_targets_later_deferred_call(self):
+        from vllm_mlx.tool_parsers.qwen3coder_tool_parser import (
+            Qwen3CoderToolParser,
+        )
+
+        parser = Qwen3CoderToolParser(tokenizer=None)
+        cfg = _make_cfg(enable_auto_tool_choice=True, tool_parser_instance=parser)
+        request = {
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "echo",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {"value": {"type": "string"}},
+                        },
+                    },
+                }
+            ]
+        }
+        first = (
+            '<tool_call><function=echo><parameter=value>"first"</parameter>'
+            "</function></tool_call>"
+        )
+        second_value = "second </parameter> value"
+        second = (
+            "<tool_call><function=echo><parameter=value>"
+            f"{second_value}</parameter></function></tool_call>"
+        )
+        pp = StreamingPostProcessor(cfg, tools_requested=True, request=request)
+        pp.reset()
+        streamed = []
+        for piece in [first, "\n", second[:45], second[45:]]:
+            streamed.extend(pp.process_chunk(_make_output(piece)))
+        final_events = pp.finalize()
+
+        by_index = {}
+        for event in [*streamed, *final_events]:
+            for call in event.tool_calls or []:
+                by_index.setdefault(call["index"], "")
+                by_index[call["index"]] += call["function"].get("arguments", "")
+        assert json.loads(by_index[0]) == {"value": "first"}
+        assert json.loads(by_index[1]) == {"value": second_value}

--- a/tests/test_qwen3coder_bare_wrapper_streaming.py
+++ b/tests/test_qwen3coder_bare_wrapper_streaming.py
@@ -111,7 +111,7 @@ def test_bare_function_block_streams_as_tool_call():
     chunks = [
         "<function=read_file>\n",
         "<parameter=path>\n",
-        "/src/main.py",
+        '"/src/main.py"',
         "\n</parameter>\n",
         "</function>",
     ]
@@ -181,12 +181,12 @@ def test_bare_multi_function_blocks_stream_both_calls():
 
     chunks = [
         "<function=read_file>",
-        "<parameter=path>/a.py</parameter>",
+        '<parameter=path>"/a.py"</parameter>',
         "</function>",
         "\n",
         "<function=write_file>",
-        "<parameter=path>/b.py</parameter>",
-        "<parameter=content>hello</parameter>",
+        '<parameter=path>"/b.py"</parameter>',
+        '<parameter=content>"hello"</parameter>',
         "</function>",
     ]
 
@@ -217,7 +217,7 @@ def test_wrapped_streaming_still_works():
         "<tool_call>\n",
         "<function=read_file>\n",
         "<parameter=path>\n",
-        "/src/main.py",
+        '"/src/main.py"',
         "\n</parameter>\n",
         "</function>\n",
         "</tool_call>",
@@ -306,7 +306,7 @@ def test_streaming_state_not_corrupted_by_function_prefix_in_value():
         "<parameter=note>",
         # Full inner XML — the naive scanner would see 2 openers and 2
         # closers here and try to advance mid-argument.
-        "see also <function=inner></function> below",
+        '"see also <function=inner></function> below"',
         "</parameter>",
         "</function>",
         # Trailing content after the real tool closes — the naive
@@ -347,7 +347,7 @@ def test_content_before_bare_function_is_emitted_as_content():
         "Let me read that file. ",
         "<function=read_file>",
         "<parameter=path>",
-        "/src/main.py",
+        '"/src/main.py"',
         "</parameter>",
         "</function>",
     ]

--- a/tests/test_qwen3coder_tool_parser_streaming.py
+++ b/tests/test_qwen3coder_tool_parser_streaming.py
@@ -235,6 +235,28 @@ def test_legacy_raw_closers_are_deferred_to_full_text_parser(value: str):
 
 
 @pytest.mark.parametrize(
+    ("schema", "wire", "expected"),
+    [
+        ({"type": "integer"}, "42", 42),
+        ({"type": "boolean"}, "true", True),
+        ({"type": "array"}, "[1, 2]", [1, 2]),
+        ({"type": "object"}, '{"nested": 1}', {"nested": 1}),
+    ],
+)
+def test_non_string_first_parameter_is_not_deferred(schema, wire, expected):
+    parser = Qwen3CoderToolParser(tokenizer=None)
+    request = _request_with_tool("record", {"value": schema})
+    chunks = [
+        "<tool_call>\n<function=record>\n<parameter=value>\n",
+        wire,
+        "\n</parameter>\n</function>\n</tool_call>",
+    ]
+
+    deltas = _feed(parser, chunks, request)
+    assert json.loads("".join(_argument_fragments(deltas))) == {"value": expected}
+
+
+@pytest.mark.parametrize(
     ("tool_name", "param_name", "value"),
     [
         (
@@ -382,29 +404,6 @@ def test_same_chunk_close_and_trailing_param_not_dropped():
     assert decoded == {"summary": _LONG_SUMMARY, "score": 42}, (
         f"trailing param dropped on same-chunk close. decoded={decoded!r}"
     )
-
-
-def test_truncated_legacy_raw_call_stays_deferred_for_finalize():
-    """Malformed legacy raw XML is not emitted speculatively."""
-    parser = Qwen3CoderToolParser(tokenizer=None)
-    request = _request_with_tool("echo", {"value": {"type": "string"}})
-
-    # Multi-chunk feed: first chunks open the in-flight string; the final
-    # chunk arrives with ``</tool_call>`` directly, NO </parameter> and NO
-    # </function> at all (a malformed / truncated stream).
-    value_head = "A" * 80
-    value_tail = "B" * 80
-    chunks = [
-        "<tool_call>\n",
-        "<function=echo>\n",
-        "<parameter=value>\n",
-        value_head,
-        value_tail + "\n</tool_call>",
-    ]
-
-    deltas = _feed(parser, chunks, request)
-    assert _argument_fragments(deltas) == []
-    assert parser._legacy_raw_stream is True
 
 
 @pytest.mark.parametrize(

--- a/tests/test_qwen3coder_tool_parser_streaming.py
+++ b/tests/test_qwen3coder_tool_parser_streaming.py
@@ -241,6 +241,30 @@ def test_legacy_raw_string_preserves_embedded_xml_closers(value: str, chunking: 
 
 
 @pytest.mark.parametrize(
+    "wrapper_chunks",
+    [
+        pytest.param(["</tool_call>"[:cut], "</tool_call>"[cut:]], id=f"cut-{cut}")
+        for cut in range(1, len("</tool_call>"))
+    ]
+    + [pytest.param(list("</tool_call>"), id="one-byte")],
+)
+def test_trailing_wrapper_never_leaks_across_chunk_boundaries(wrapper_chunks):
+    parser = Qwen3CoderToolParser(tokenizer=None)
+    request = _request_with_tool("write_file", {"content": {"type": "string"}})
+    chunks = [
+        "<tool_call>\n",
+        "<function=write_file>\n",
+        "<parameter=content>\nhello\n</parameter>\n",
+        "</function>\n",
+        *wrapper_chunks,
+    ]
+
+    deltas = _feed(parser, chunks, request)
+    assert json.loads("".join(_argument_fragments(deltas))) == {"content": "hello"}
+    assert "".join(delta.get("content", "") for delta in deltas) == ""
+
+
+@pytest.mark.parametrize(
     ("tool_name", "param_name", "value"),
     [
         (

--- a/tests/test_qwen3coder_tool_parser_streaming.py
+++ b/tests/test_qwen3coder_tool_parser_streaming.py
@@ -202,6 +202,45 @@ def test_json_encoded_string_preserves_embedded_xml_closers():
 
 
 @pytest.mark.parametrize(
+    "value",
+    [
+        "A tool call block ends with </tool_call> on its own.",
+        "A parameter block ends with </parameter> here.",
+        "A function block ends with </function> here.",
+    ],
+)
+@pytest.mark.parametrize("chunking", ["after-marker", "one-byte"])
+def test_legacy_raw_string_preserves_embedded_xml_closers(value: str, chunking: str):
+    """#1515: an early closer in a raw string is payload, not structure."""
+    parser = Qwen3CoderToolParser(tokenizer=None)
+    request = _request_with_tool("write_file", {"content": {"type": "string"}})
+    marker = next(
+        token
+        for token in ("</tool_call>", "</parameter>", "</function>")
+        if token in value
+    )
+    cut = value.index(marker) + len(marker)
+    value_chunks = (
+        [value[:cut], value[cut:] + "\n"]
+        if chunking == "after-marker"
+        else [*value, "\n"]
+    )
+    chunks = [
+        "<tool_call>\n",
+        "<function=write_file>\n",
+        "<parameter=content>\n",
+        *value_chunks,
+        "</parameter>\n",
+        "</function>\n",
+        "</tool_call>",
+    ]
+
+    deltas = _feed(parser, chunks, request)
+    assert json.loads("".join(_argument_fragments(deltas))) == {"content": value}
+    assert "".join(delta.get("content", "") for delta in deltas) == ""
+
+
+@pytest.mark.parametrize(
     ("tool_name", "param_name", "value"),
     [
         (

--- a/tests/test_qwen3coder_tool_parser_streaming.py
+++ b/tests/test_qwen3coder_tool_parser_streaming.py
@@ -274,6 +274,7 @@ def test_trailing_wrapper_never_leaks_across_chunk_boundaries(wrapper_chunks):
         ["</tool_call>after"],
         ["</tool_", "call>after"],
         [*"</tool_call>", "after"],
+        ["</tool_call> \n", "after"],
     ],
 )
 def test_content_after_trailing_wrapper_is_preserved(wrapper_chunks):
@@ -289,7 +290,8 @@ def test_content_after_trailing_wrapper_is_preserved(wrapper_chunks):
 
     deltas = _feed(parser, chunks, request)
     assert json.loads("".join(_argument_fragments(deltas))) == {"content": "hello"}
-    assert "".join(delta.get("content", "") for delta in deltas) == "after"
+    expected = " \nafter" if wrapper_chunks[0].endswith(" \n") else "after"
+    assert "".join(delta.get("content", "") for delta in deltas) == expected
 
 
 def test_raw_second_parameter_uses_last_function_closer():

--- a/tests/test_qwen3coder_tool_parser_streaming.py
+++ b/tests/test_qwen3coder_tool_parser_streaming.py
@@ -292,6 +292,44 @@ def test_content_after_trailing_wrapper_is_preserved(wrapper_chunks):
     assert "".join(delta.get("content", "") for delta in deltas) == "after"
 
 
+def test_raw_second_parameter_uses_last_function_closer():
+    parser = Qwen3CoderToolParser(tokenizer=None)
+    request = _request_with_tool(
+        "write_file",
+        {"path": {"type": "string"}, "content": {"type": "string"}},
+    )
+    value = "payload </parameter> then </function> still payload"
+    chunks = [
+        "<tool_call>\n<function=write_file>\n",
+        '<parameter=path>\n"a.md"\n</parameter>\n',
+        "<parameter=content>\n",
+        *value,
+        "\n</parameter>\n</function>\n</tool_call>",
+    ]
+
+    deltas = _feed(parser, chunks, request)
+    assert json.loads("".join(_argument_fragments(deltas))) == {
+        "path": "a.md",
+        "content": value,
+    }
+
+
+def test_bare_raw_call_uses_last_function_closer():
+    parser = Qwen3CoderToolParser(tokenizer=None)
+    request = _request_with_tool("write_file", {"content": {"type": "string"}})
+    value = "payload </parameter> then </function> still payload"
+    chunks = [
+        "<function=write_file>\n<parameter=content>\n",
+        *value,
+        "\n</parameter>\n",
+        "</function>",
+    ]
+
+    deltas = _feed(parser, chunks, request)
+    assert json.loads("".join(_argument_fragments(deltas))) == {"content": value}
+    assert "".join(delta.get("content", "") for delta in deltas) == ""
+
+
 @pytest.mark.parametrize(
     ("tool_name", "param_name", "value"),
     [

--- a/tests/test_qwen3coder_tool_parser_streaming.py
+++ b/tests/test_qwen3coder_tool_parser_streaming.py
@@ -345,10 +345,23 @@ def test_raw_call_does_not_consume_a_later_call():
     )
 
     deltas = _feed(
-        parser, ["<tool_call>", first[len("<tool_call>") :] + second], request
+        parser,
+        ["<tool_call>", first[len("<tool_call>") :] + second, "\n", "\n"],
+        request,
     )
-    fragments = _argument_fragments(deltas)
-    assert json.loads("".join(fragments)) == {"content": "first"}
+    argument_documents = [
+        tc["function"]["arguments"]
+        for delta in deltas
+        for tc in delta.get("tool_calls", [])
+        if tc.get("function", {}).get("arguments") not in (None, "", "{", "}")
+    ]
+    assert [json.loads(document) for document in argument_documents] == [
+        {"content": "first"},
+        {"content": "second"},
+    ]
+    streamed_content = "".join(delta.get("content", "") for delta in deltas)
+    assert "<tool_call>" not in streamed_content
+    assert "<function=" not in streamed_content
 
 
 def test_content_closer_after_raw_call_is_not_used_as_wrapper():

--- a/tests/test_qwen3coder_tool_parser_streaming.py
+++ b/tests/test_qwen3coder_tool_parser_streaming.py
@@ -362,12 +362,12 @@ def test_raw_call_does_not_consume_a_later_call():
     parser = Qwen3CoderToolParser(tokenizer=None)
     request = _request_with_tool("write_file", {"content": {"type": "string"}})
     first = (
-        "<tool_call><function=write_file><parameter=content>first</parameter>"
-        "</function></tool_call>"
+        "<tool_call>\n<function=write_file>\n<parameter=content>first\n"
+        "</parameter>\n</function>\n</tool_call>"
     )
     second = (
-        "<tool_call><function=write_file><parameter=content>second</parameter>"
-        "</function></tool_call>"
+        "<tool_call>\n<function=write_file>\n<parameter=content>second\n"
+        "</parameter>\n</function>\n</tool_call>"
     )
 
     deltas = _feed(
@@ -390,12 +390,35 @@ def test_raw_call_does_not_consume_a_later_call():
     assert "<function=" not in streamed_content
 
 
+def test_consecutive_bare_raw_calls_remain_tool_calls():
+    parser = Qwen3CoderToolParser(tokenizer=None)
+    request = _request_with_tool("write_file", {"content": {"type": "string"}})
+    first = "<function=write_file>\n<parameter=content>first\n</parameter>\n</function>"
+    second = (
+        "<function=write_file>\n<parameter=content>second\n</parameter>\n</function>"
+    )
+
+    deltas = _feed(parser, [first + second, "\n", "\n"], request)
+    argument_documents = [
+        tc["function"]["arguments"]
+        for delta in deltas
+        for tc in delta.get("tool_calls", [])
+        if tc.get("function", {}).get("arguments") not in (None, "", "{", "}")
+    ]
+    assert [json.loads(document) for document in argument_documents] == [
+        {"content": "first"},
+        {"content": "second"},
+    ]
+    streamed_content = "".join(delta.get("content", "") for delta in deltas)
+    assert "<function=" not in streamed_content
+
+
 def test_content_closer_after_raw_call_is_not_used_as_wrapper():
     parser = Qwen3CoderToolParser(tokenizer=None)
     request = _request_with_tool("write_file", {"content": {"type": "string"}})
     chunks = [
-        "<tool_call><function=write_file><parameter=content>hello</parameter>"
-        "</function></tool_call>after </tool_call> prose"
+        "<tool_call>\n<function=write_file>\n<parameter=content>hello\n</parameter>\n"
+        "</function>\n</tool_call>after </tool_call> prose"
     ]
 
     deltas = _feed(parser, chunks, request)

--- a/tests/test_qwen3coder_tool_parser_streaming.py
+++ b/tests/test_qwen3coder_tool_parser_streaming.py
@@ -203,6 +203,20 @@ def test_json_encoded_string_preserves_embedded_xml_closers():
     assert json.loads("".join(fragments)) == {"content": value}
 
 
+def test_json_surrogate_pair_split_between_chunks_streams_exactly():
+    parser = Qwen3CoderToolParser(tokenizer=None)
+    request = _request_with_tool("write", {"content": {"type": "string"}})
+    chunks = [
+        "<tool_call>\n<function=write>\n<parameter=content>\n",
+        '"before \\uD83D',
+        '\\uDE00 after"',
+        "\n</parameter>\n</function>\n</tool_call>",
+    ]
+
+    fragments = _argument_fragments(_feed(parser, chunks, request))
+    assert json.loads("".join(fragments)) == {"content": "before 😀 after"}
+
+
 @pytest.mark.parametrize(
     "value",
     [

--- a/tests/test_qwen3coder_tool_parser_streaming.py
+++ b/tests/test_qwen3coder_tool_parser_streaming.py
@@ -244,6 +244,32 @@ def test_legacy_raw_string_preserves_embedded_xml_closers(value: str, chunking: 
     assert "".join(delta.get("content", "") for delta in deltas) == ""
 
 
+def test_one_character_raw_string_round_trips():
+    parser = Qwen3CoderToolParser(tokenizer=None)
+    request = _request_with_tool("write_file", {"content": {"type": "string"}})
+    chunks = [
+        "<tool_call>\n<function=write_file>\n<parameter=content>\n",
+        "x",
+        "\n</parameter>\n</function>\n</tool_call>",
+    ]
+
+    deltas = _feed(parser, chunks, request)
+    assert json.loads("".join(_argument_fragments(deltas))) == {"content": "x"}
+
+
+def test_wrapped_raw_call_recovers_when_outer_close_is_truncated():
+    parser = Qwen3CoderToolParser(tokenizer=None)
+    request = _request_with_tool("write_file", {"content": {"type": "string"}})
+    chunks = [
+        "<tool_call>\n<function=write_file>\n<parameter=content>\nhello",
+        "\n</parameter>\n",
+        "</function>",
+    ]
+
+    deltas = _feed(parser, chunks, request)
+    assert json.loads("".join(_argument_fragments(deltas))) == {"content": "hello"}
+
+
 @pytest.mark.parametrize(
     "wrapper_chunks",
     [

--- a/tests/test_qwen3coder_tool_parser_streaming.py
+++ b/tests/test_qwen3coder_tool_parser_streaming.py
@@ -240,12 +240,13 @@ def test_legacy_raw_closers_are_deferred_to_full_text_parser(value: str):
     ]
 
     deltas = _feed(parser, chunks, request)
-    assert _argument_fragments(deltas) == []
+    fragments = _argument_fragments(deltas)
+    assert fragments == ["{"]
     assert "".join(delta.get("content", "") for delta in deltas) == ""
 
-    final = parser.extract_tool_calls(full_text, request=request)
-    assert final.tools_called is True
-    assert json.loads(final.tool_calls[0]["arguments"]) == {"content": value}
+    final = parser.finalize_legacy_raw_stream(full_text, request=request)
+    fragments.extend(_argument_fragments([final]))
+    assert json.loads("".join(fragments)) == {"content": value}
 
 
 @pytest.mark.parametrize(

--- a/tests/test_qwen3coder_tool_parser_streaming.py
+++ b/tests/test_qwen3coder_tool_parser_streaming.py
@@ -249,6 +249,28 @@ def test_legacy_raw_closers_are_deferred_to_full_text_parser(value: str):
 
 
 @pytest.mark.parametrize(
+    "value",
+    [
+        "before </parameter> after",
+        "before </function> after",
+        "before </tool_call> after",
+    ],
+)
+def test_complete_legacy_raw_call_in_one_chunk_preserves_closer(value):
+    parser = Qwen3CoderToolParser(tokenizer=None)
+    request = _request_with_tool("write", {"content": {"type": "string"}})
+    wire = (
+        "<tool_call>\n<function=write>\n<parameter=content>\n"
+        f"{value}\n</parameter>\n</function>\n</tool_call>"
+    )
+
+    delta = parser.extract_tool_calls_streaming("", wire, wire, request=request)
+    assert json.loads(delta["tool_calls"][0]["function"]["arguments"]) == {
+        "content": value
+    }
+
+
+@pytest.mark.parametrize(
     ("schema", "wire", "expected"),
     [
         ({"type": "integer"}, "42", 42),

--- a/tests/test_qwen3coder_tool_parser_streaming.py
+++ b/tests/test_qwen3coder_tool_parser_streaming.py
@@ -265,6 +265,30 @@ def test_trailing_wrapper_never_leaks_across_chunk_boundaries(wrapper_chunks):
 
 
 @pytest.mark.parametrize(
+    "wrapper_chunks",
+    [
+        ["</tool_call>after"],
+        ["</tool_", "call>after"],
+        [*"</tool_call>", "after"],
+    ],
+)
+def test_content_after_trailing_wrapper_is_preserved(wrapper_chunks):
+    parser = Qwen3CoderToolParser(tokenizer=None)
+    request = _request_with_tool("write_file", {"content": {"type": "string"}})
+    chunks = [
+        "<tool_call>\n",
+        "<function=write_file>\n",
+        "<parameter=content>\nhello\n</parameter>\n",
+        "</function>\n",
+        *wrapper_chunks,
+    ]
+
+    deltas = _feed(parser, chunks, request)
+    assert json.loads("".join(_argument_fragments(deltas))) == {"content": "hello"}
+    assert "".join(delta.get("content", "") for delta in deltas) == "after"
+
+
+@pytest.mark.parametrize(
     ("tool_name", "param_name", "value"),
     [
         (

--- a/tests/test_qwen3coder_tool_parser_streaming.py
+++ b/tests/test_qwen3coder_tool_parser_streaming.py
@@ -101,7 +101,8 @@ def test_long_string_param_emits_multiple_deltas():
     ]
     # Split the long summary into 32-char body chunks so the in-flight
     # branch fires several times before the close tag arrives.
-    value_chunks = [_LONG_SUMMARY[i : i + 32] for i in range(0, len(_LONG_SUMMARY), 32)]
+    encoded = json.dumps(_LONG_SUMMARY)
+    value_chunks = [encoded[i : i + 32] for i in range(0, len(encoded), 32)]
     pre_close_chunks = head + value_chunks
 
     parser.reset()
@@ -148,15 +149,16 @@ def test_close_tag_never_leaks_into_emitted_fragment():
 
     # Long enough that incremental emission will fire before the close.
     value = "A" * 200
+    encoded = json.dumps(value)
     # Split mid-close-tag (``</par`` | ``ameter>``) to exercise the
     # tail-buffer guard at a chunk boundary.
     chunks = [
         "<tool_call>\n",
         "<function=echo>\n",
         "<parameter=value>\n",
-        value[:80],
-        value[80:160],
-        value[160:] + "\n</par",
+        encoded[:80],
+        encoded[80:160],
+        encoded[160:] + "\n</par",
         "ameter>\n",
         "</function>\n",
         "</tool_call>",
@@ -207,225 +209,29 @@ def test_json_encoded_string_preserves_embedded_xml_closers():
         "A tool call block ends with </tool_call> on its own.",
         "A parameter block ends with </parameter> here.",
         "A function block ends with </function> here.",
-        (
-            "Parameter </parameter>, function </function>, and tool "
-            "</tool_call> are all payload."
-        ),
     ],
 )
-@pytest.mark.parametrize("chunking", ["after-marker", "one-byte"])
-def test_legacy_raw_string_preserves_embedded_xml_closers(value: str, chunking: str):
-    """#1515: an early closer in a raw string is payload, not structure."""
+def test_legacy_raw_closers_are_deferred_to_full_text_parser(value: str):
+    """#1515: raw XML is ambiguous online, so EOS parsing owns it."""
     parser = Qwen3CoderToolParser(tokenizer=None)
     request = _request_with_tool("write_file", {"content": {"type": "string"}})
-    marker = next(
-        token
-        for token in ("</tool_call>", "</parameter>", "</function>")
-        if token in value
+    full_text = (
+        "<tool_call>\n<function=write_file>\n<parameter=content>\n"
+        f"{value}\n</parameter>\n</function>\n</tool_call>"
     )
-    cut = value.index(marker) + len(marker)
-    value_chunks = (
-        [value[:cut], value[cut:] + "\n"]
-        if chunking == "after-marker"
-        else [*value, "\n"]
-    )
-    chunks = [
-        "<tool_call>\n",
-        "<function=write_file>\n",
-        "<parameter=content>\n",
-        *value_chunks,
-        "</parameter>\n",
-        "</function>\n",
-        "</tool_call>",
-    ]
-
-    deltas = _feed(parser, chunks, request)
-    assert json.loads("".join(_argument_fragments(deltas))) == {"content": value}
-    assert "".join(delta.get("content", "") for delta in deltas) == ""
-
-
-def test_one_character_raw_string_round_trips():
-    parser = Qwen3CoderToolParser(tokenizer=None)
-    request = _request_with_tool("write_file", {"content": {"type": "string"}})
     chunks = [
         "<tool_call>\n<function=write_file>\n<parameter=content>\n",
-        "x",
-        "\n</parameter>\n</function>\n</tool_call>",
-    ]
-
-    deltas = _feed(parser, chunks, request)
-    assert json.loads("".join(_argument_fragments(deltas))) == {"content": "x"}
-
-
-def test_wrapped_raw_call_recovers_when_outer_close_is_truncated():
-    parser = Qwen3CoderToolParser(tokenizer=None)
-    request = _request_with_tool("write_file", {"content": {"type": "string"}})
-    chunks = [
-        "<tool_call>\n<function=write_file>\n<parameter=content>\nhello",
-        "\n</parameter>\n",
-        "</function>",
-    ]
-
-    deltas = _feed(parser, chunks, request)
-    assert json.loads("".join(_argument_fragments(deltas))) == {"content": "hello"}
-
-
-@pytest.mark.parametrize(
-    "wrapper_chunks",
-    [
-        pytest.param(["</tool_call>"[:cut], "</tool_call>"[cut:]], id=f"cut-{cut}")
-        for cut in range(1, len("</tool_call>"))
-    ]
-    + [pytest.param(list("</tool_call>"), id="one-byte")],
-)
-def test_trailing_wrapper_never_leaks_across_chunk_boundaries(wrapper_chunks):
-    parser = Qwen3CoderToolParser(tokenizer=None)
-    request = _request_with_tool("write_file", {"content": {"type": "string"}})
-    chunks = [
-        "<tool_call>\n",
-        "<function=write_file>\n",
-        "<parameter=content>\nhello\n</parameter>\n",
-        "</function>\n",
-        *wrapper_chunks,
-    ]
-
-    deltas = _feed(parser, chunks, request)
-    assert json.loads("".join(_argument_fragments(deltas))) == {"content": "hello"}
-    assert "".join(delta.get("content", "") for delta in deltas) == ""
-
-
-@pytest.mark.parametrize(
-    "wrapper_chunks",
-    [
-        ["</tool_call>after"],
-        ["</tool_", "call>after"],
-        [*"</tool_call>", "after"],
-        ["</tool_call> \n", "after"],
-    ],
-)
-def test_content_after_trailing_wrapper_is_preserved(wrapper_chunks):
-    parser = Qwen3CoderToolParser(tokenizer=None)
-    request = _request_with_tool("write_file", {"content": {"type": "string"}})
-    chunks = [
-        "<tool_call>\n",
-        "<function=write_file>\n",
-        "<parameter=content>\nhello\n</parameter>\n",
-        "</function>\n",
-        *wrapper_chunks,
-    ]
-
-    deltas = _feed(parser, chunks, request)
-    assert json.loads("".join(_argument_fragments(deltas))) == {"content": "hello"}
-    expected = " \nafter" if wrapper_chunks[0].endswith(" \n") else "after"
-    assert "".join(delta.get("content", "") for delta in deltas) == expected
-
-
-def test_raw_second_parameter_uses_last_function_closer():
-    parser = Qwen3CoderToolParser(tokenizer=None)
-    request = _request_with_tool(
-        "write_file",
-        {"path": {"type": "string"}, "content": {"type": "string"}},
-    )
-    value = "payload </parameter> then </function> still payload"
-    chunks = [
-        "<tool_call>\n<function=write_file>\n",
-        '<parameter=path>\n"a.md"\n</parameter>\n',
-        "<parameter=content>\n",
         *value,
         "\n</parameter>\n</function>\n</tool_call>",
     ]
 
     deltas = _feed(parser, chunks, request)
-    assert json.loads("".join(_argument_fragments(deltas))) == {
-        "path": "a.md",
-        "content": value,
-    }
-
-
-def test_bare_raw_call_uses_last_function_closer():
-    parser = Qwen3CoderToolParser(tokenizer=None)
-    request = _request_with_tool("write_file", {"content": {"type": "string"}})
-    value = "payload </parameter> then </function> still payload"
-    chunks = [
-        "<function=write_file>\n<parameter=content>\n",
-        *value,
-        "\n</parameter>\n",
-        "</function>",
-    ]
-
-    deltas = _feed(parser, chunks, request)
-    assert json.loads("".join(_argument_fragments(deltas))) == {"content": value}
+    assert _argument_fragments(deltas) == []
     assert "".join(delta.get("content", "") for delta in deltas) == ""
 
-
-def test_raw_call_does_not_consume_a_later_call():
-    parser = Qwen3CoderToolParser(tokenizer=None)
-    request = _request_with_tool("write_file", {"content": {"type": "string"}})
-    first = (
-        "<tool_call>\n<function=write_file>\n<parameter=content>first\n"
-        "</parameter>\n</function>\n</tool_call>"
-    )
-    second = (
-        "<tool_call>\n<function=write_file>\n<parameter=content>second\n"
-        "</parameter>\n</function>\n</tool_call>"
-    )
-
-    deltas = _feed(
-        parser,
-        ["<tool_call>", first[len("<tool_call>") :] + second, "\n", "\n"],
-        request,
-    )
-    argument_documents = [
-        tc["function"]["arguments"]
-        for delta in deltas
-        for tc in delta.get("tool_calls", [])
-        if tc.get("function", {}).get("arguments") not in (None, "", "{", "}")
-    ]
-    assert [json.loads(document) for document in argument_documents] == [
-        {"content": "first"},
-        {"content": "second"},
-    ]
-    streamed_content = "".join(delta.get("content", "") for delta in deltas)
-    assert "<tool_call>" not in streamed_content
-    assert "<function=" not in streamed_content
-
-
-def test_consecutive_bare_raw_calls_remain_tool_calls():
-    parser = Qwen3CoderToolParser(tokenizer=None)
-    request = _request_with_tool("write_file", {"content": {"type": "string"}})
-    first = "<function=write_file>\n<parameter=content>first\n</parameter>\n</function>"
-    second = (
-        "<function=write_file>\n<parameter=content>second\n</parameter>\n</function>"
-    )
-
-    deltas = _feed(parser, [first + second, "\n", "\n"], request)
-    argument_documents = [
-        tc["function"]["arguments"]
-        for delta in deltas
-        for tc in delta.get("tool_calls", [])
-        if tc.get("function", {}).get("arguments") not in (None, "", "{", "}")
-    ]
-    assert [json.loads(document) for document in argument_documents] == [
-        {"content": "first"},
-        {"content": "second"},
-    ]
-    streamed_content = "".join(delta.get("content", "") for delta in deltas)
-    assert "<function=" not in streamed_content
-
-
-def test_content_closer_after_raw_call_is_not_used_as_wrapper():
-    parser = Qwen3CoderToolParser(tokenizer=None)
-    request = _request_with_tool("write_file", {"content": {"type": "string"}})
-    chunks = [
-        "<tool_call>\n<function=write_file>\n<parameter=content>hello\n</parameter>\n"
-        "</function>\n</tool_call>after </tool_call> prose"
-    ]
-
-    deltas = _feed(parser, chunks, request)
-    assert json.loads("".join(_argument_fragments(deltas))) == {"content": "hello"}
-    assert "".join(delta.get("content", "") for delta in deltas) == (
-        "after </tool_call> prose"
-    )
+    final = parser.extract_tool_calls(full_text, request=request)
+    assert final.tools_called is True
+    assert json.loads(final.tool_calls[0]["arguments"]) == {"content": value}
 
 
 @pytest.mark.parametrize(
@@ -486,9 +292,9 @@ def test_streaming_json_matches_non_streaming():
     full_text = (
         "<tool_call>\n"
         "<function=report>\n"
-        f"<parameter=summary>\n{_LONG_SUMMARY}\n</parameter>\n"
+        f"<parameter=summary>\n{json.dumps(_LONG_SUMMARY)}\n</parameter>\n"
         "<parameter=score>\n42\n</parameter>\n"
-        "<parameter=owner>\nken\n</parameter>\n"
+        '<parameter=owner>\n"ken"\n</parameter>\n'
         "</function>\n"
         "</tool_call>"
     )
@@ -506,13 +312,13 @@ def test_streaming_json_matches_non_streaming():
         "<function=report>\n",
         "<parameter=summary>\n",
     ]
-    summary_body = _LONG_SUMMARY + "\n"
+    summary_body = json.dumps(_LONG_SUMMARY) + "\n"
     chunks.extend(summary_body[i : i + 24] for i in range(0, len(summary_body), 24))
     chunks.extend(
         [
             "</parameter>\n",
             "<parameter=score>\n42\n</parameter>\n",
-            "<parameter=owner>\nken\n</parameter>\n",
+            '<parameter=owner>\n"ken"\n</parameter>\n',
             "</function>\n",
             "</tool_call>",
         ]
@@ -552,8 +358,9 @@ def test_same_chunk_close_and_trailing_param_not_dropped():
     # ``<rest_of_summary></parameter><parameter=score>42</parameter></function></tool_call>``
     # so the in-flight close and the trailing complete param land in
     # the same parser call.
-    head_value = _LONG_SUMMARY[:120]
-    tail_value = _LONG_SUMMARY[120:]
+    encoded_summary = json.dumps(_LONG_SUMMARY)
+    head_value = encoded_summary[:120]
+    tail_value = encoded_summary[120:]
     chunks = [
         "<tool_call>\n",
         "<function=report>\n",
@@ -577,14 +384,8 @@ def test_same_chunk_close_and_trailing_param_not_dropped():
     )
 
 
-def test_truncated_tool_call_closes_in_flight_string_at_tool_call_end():
-    """If the model truncates without ``</parameter>`` but reaches
-    ``</tool_call>``, the in-flight string must still finalize — not hang
-    with ``in_param=True``.
-
-    Mirrors the existing complete-param fallback that already treats
-    ``</tool_call>`` as a defensive close boundary.
-    """
+def test_truncated_legacy_raw_call_stays_deferred_for_finalize():
+    """Malformed legacy raw XML is not emitted speculatively."""
     parser = Qwen3CoderToolParser(tokenizer=None)
     request = _request_with_tool("echo", {"value": {"type": "string"}})
 
@@ -602,17 +403,8 @@ def test_truncated_tool_call_closes_in_flight_string_at_tool_call_end():
     ]
 
     deltas = _feed(parser, chunks, request)
-    fragments = _argument_fragments(deltas)
-    assert fragments, "no fragments emitted — parser hung in incremental mode"
-    # We don't require the truncated stream to produce strictly-valid JSON
-    # (the original buffered path also doesn't close ``}`` here); but the
-    # parser MUST have closed the string and emitted the buffered value.
-    assert any('"value"' in f for f in fragments), (
-        f"in-flight string never closed; fragments={fragments!r}"
-    )
-    assert not parser.in_param, (
-        "parser left in_param=True after </tool_call> truncation"
-    )
+    assert _argument_fragments(deltas) == []
+    assert parser._legacy_raw_stream is True
 
 
 @pytest.mark.parametrize(
@@ -631,7 +423,8 @@ def test_string_aliases_all_stream_incrementally(param_type):
         "<function=echo>\n",
         "<parameter=value>\n",
     ]
-    value_chunks = [_LONG_SUMMARY[i : i + 32] for i in range(0, len(_LONG_SUMMARY), 32)]
+    encoded = json.dumps(_LONG_SUMMARY)
+    value_chunks = [encoded[i : i + 32] for i in range(0, len(encoded), 32)]
     pre_close_chunks = head + value_chunks
 
     parser.reset()

--- a/tests/test_qwen3coder_tool_parser_streaming.py
+++ b/tests/test_qwen3coder_tool_parser_streaming.py
@@ -332,6 +332,40 @@ def test_bare_raw_call_uses_last_function_closer():
     assert "".join(delta.get("content", "") for delta in deltas) == ""
 
 
+def test_raw_call_does_not_consume_a_later_call():
+    parser = Qwen3CoderToolParser(tokenizer=None)
+    request = _request_with_tool("write_file", {"content": {"type": "string"}})
+    first = (
+        "<tool_call><function=write_file><parameter=content>first</parameter>"
+        "</function></tool_call>"
+    )
+    second = (
+        "<tool_call><function=write_file><parameter=content>second</parameter>"
+        "</function></tool_call>"
+    )
+
+    deltas = _feed(
+        parser, ["<tool_call>", first[len("<tool_call>") :] + second], request
+    )
+    fragments = _argument_fragments(deltas)
+    assert json.loads("".join(fragments)) == {"content": "first"}
+
+
+def test_content_closer_after_raw_call_is_not_used_as_wrapper():
+    parser = Qwen3CoderToolParser(tokenizer=None)
+    request = _request_with_tool("write_file", {"content": {"type": "string"}})
+    chunks = [
+        "<tool_call><function=write_file><parameter=content>hello</parameter>"
+        "</function></tool_call>after </tool_call> prose"
+    ]
+
+    deltas = _feed(parser, chunks, request)
+    assert json.loads("".join(_argument_fragments(deltas))) == {"content": "hello"}
+    assert "".join(delta.get("content", "") for delta in deltas) == (
+        "after </tool_call> prose"
+    )
+
+
 @pytest.mark.parametrize(
     ("tool_name", "param_name", "value"),
     [

--- a/tests/test_qwen3coder_tool_parser_streaming.py
+++ b/tests/test_qwen3coder_tool_parser_streaming.py
@@ -207,6 +207,10 @@ def test_json_encoded_string_preserves_embedded_xml_closers():
         "A tool call block ends with </tool_call> on its own.",
         "A parameter block ends with </parameter> here.",
         "A function block ends with </function> here.",
+        (
+            "Parameter </parameter>, function </function>, and tool "
+            "</tool_call> are all payload."
+        ),
     ],
 )
 @pytest.mark.parametrize("chunking", ["after-marker", "one-byte"])

--- a/tests/test_upstream_regression.py
+++ b/tests/test_upstream_regression.py
@@ -1239,7 +1239,7 @@ class TestQwen3CoderUpstreamStreaming:
             "<tool_call>",
             "\n<function=get_current_weather>",
             "\n",
-            "<parameter=city>Dallas</parameter>",
+            '<parameter=city>"Dallas"</parameter>',
             "\n</function>",
             "\n</tool_call>",
         ]
@@ -1334,7 +1334,7 @@ class TestQwen3CoderUpstreamStreaming:
         """Single coarse delta with complete tool call → full args emitted."""
         deltas = [
             "<tool_call>\n<function=get_current_weather>"
-            "\n<parameter=city>Dallas</parameter>\n</function>"
+            '\n<parameter=city>"Dallas"</parameter>\n</function>'
             "\n</tool_call>",
         ]
         text = ""

--- a/vllm_mlx/service/postprocessor.py
+++ b/vllm_mlx/service/postprocessor.py
@@ -2895,6 +2895,7 @@ class StreamingPostProcessor:
                 )
             ]
         events = []
+
         if content:
             events.append(StreamEvent(type="content", content=content))
         if reasoning:
@@ -3461,6 +3462,26 @@ class StreamingPostProcessor:
         Call after the engine stream ends.
         """
         events = []
+
+        finalize_raw = getattr(self.tool_parser, "finalize_legacy_raw_stream", None)
+        if callable(finalize_raw):
+            raw_delta = finalize_raw(
+                self.tool_accumulated_text or self.accumulated_text,
+                request=self.request,
+            )
+            if raw_delta and raw_delta.get("tool_calls"):
+                allowed = self._apply_parallel_cap(raw_delta["tool_calls"])
+                if allowed:
+                    self.tool_calls_detected = True
+                    self._tool_calls_emitted_to_wire += len(allowed)
+                    events.append(
+                        StreamEvent(
+                            type="tool_call",
+                            tool_calls=allowed,
+                            finish_reason="tool_calls",
+                            tool_calls_detected=True,
+                        )
+                    )
 
         # Codex round-3 BLOCKING #1: when the per-request reasoning cap
         # latches on the LAST reasoning chunk of the stream (model stops

--- a/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
+++ b/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
@@ -280,6 +280,15 @@ class Qwen3CoderToolParser(ToolParser):
         """
         keep_back = len(self.parameter_end_token)
         safe_end = len(value_text) - keep_back
+        marker_start = value_text.find("<", self.in_param_emitted_chars)
+        if marker_start != -1:
+            # Raw XML has no escaping bit. Once markup-looking bytes appear,
+            # they may be payload or structure until the full function makes
+            # the LAST-close convention decidable (#1515). Keep that suffix
+            # buffered; plain text before it can still stream incrementally.
+            if marker_start > 0 and value_text[marker_start - 1] == "\n":
+                marker_start -= 1
+            safe_end = min(safe_end, marker_start)
         if safe_end <= self.in_param_emitted_chars:
             return ""
         safe = value_text[self.in_param_emitted_chars : safe_end]
@@ -875,9 +884,16 @@ class Qwen3CoderToolParser(ToolParser):
                 # emit an empty tail. ``</function>`` is the actual tool
                 # close; ``</tool_call>`` may follow as optional framing.
                 trailing = current_text.rstrip()
-                if delta_text.strip() == "" and (
-                    trailing.endswith(self.tool_call_end_token)
-                    or trailing.endswith(self.function_end_token)
+                if (
+                    delta_text.strip() == ""
+                    and (
+                        trailing.endswith(self.tool_call_end_token)
+                        or trailing.endswith(self.function_end_token)
+                    )
+                ) or (
+                    delta_text.strip() == self.tool_call_end_token
+                    and previous_text.rstrip().endswith(self.function_end_token)
+                    and trailing.endswith(self.tool_call_end_token)
                 ):
                     return None
                 return {"content": delta_text}
@@ -1026,6 +1042,19 @@ class Qwen3CoderToolParser(ToolParser):
             param_config = _get_arguments_config(
                 self.current_function_name or "", tools
             )
+            completed_parameters: list[tuple[str, str]] = []
+            if func_close_idx != -1:
+                header_end = tool_text.find(">")
+                if header_end != -1:
+                    completed_parameters = (
+                        split_marked_parameters(
+                            tool_text[header_end + 1 : -len(self.function_end_token)],
+                            r"<parameter=([^>]+)>",
+                            self.parameter_end_token,
+                            valid_names=set(param_config) or None,
+                        )
+                        or []
+                    )
 
             json_fragments = []
 
@@ -1049,9 +1078,26 @@ class Qwen3CoderToolParser(ToolParser):
                     if value_text.startswith("\n"):
                         value_text = value_text[1:]
 
-                    end_idx = self._find_parameter_close(value_text, 0)
                     json_string_pending = value_text.lstrip().startswith('"')
-                    if end_idx == -1 and not json_string_pending:
+                    completed_value = (
+                        completed_parameters[self.param_count][1]
+                        if self.param_count < len(completed_parameters)
+                        and completed_parameters[self.param_count][0]
+                        == self.in_param_name
+                        else None
+                    )
+                    end_idx = (
+                        self._find_parameter_close(value_text, 0)
+                        if json_string_pending
+                        else -1
+                    )
+                    if completed_value is not None:
+                        pv = completed_value
+                    elif (
+                        end_idx == -1
+                        and not json_string_pending
+                        and func_close_idx != -1
+                    ):
                         # Defensive fallback: model emitted next-param-prefix,
                         # </function>, or </tool_call> without a </parameter>.
                         # Use any of those as the close to avoid hanging
@@ -1063,8 +1109,22 @@ class Qwen3CoderToolParser(ToolParser):
                         candidates = [c for c in (nxt, fe, te) if c != -1]
                         if candidates:
                             end_idx = min(candidates)
-                    if end_idx != -1:
-                        pv = value_text[:end_idx]
+                    elif end_idx == -1 and not json_string_pending:
+                        # Preserve the established truncated-stream recovery
+                        # only for a wrapper closer on its own line. An inline
+                        # ``</tool_call>`` is valid raw string data (#1515).
+                        te = value_text.find(self.tool_call_end_token)
+                        if (
+                            te > 0
+                            and value_text[te - 1] == "\n"
+                            and not value_text[
+                                te + len(self.tool_call_end_token) :
+                            ].strip()
+                        ):
+                            end_idx = te
+                    if completed_value is not None or end_idx != -1:
+                        if completed_value is None:
+                            pv = value_text[:end_idx]
                         if pv.endswith("\n"):
                             pv = pv[:-1]
                         self.accumulated_params[self.in_param_name] = pv
@@ -1101,9 +1161,25 @@ class Qwen3CoderToolParser(ToolParser):
                 if value_text.startswith("\n"):
                     value_text = value_text[1:]
 
-                param_end_idx = self._find_parameter_close(value_text, 0)
                 json_string_pending = value_text.lstrip().startswith('"')
-                if param_end_idx == -1 and not json_string_pending:
+                completed_value = (
+                    completed_parameters[self.param_count][1]
+                    if self.param_count < len(completed_parameters)
+                    and completed_parameters[self.param_count][0] == current_param_name
+                    else None
+                )
+                param_end_idx = (
+                    self._find_parameter_close(value_text, 0)
+                    if json_string_pending
+                    else -1
+                )
+                if completed_value is not None:
+                    pv = completed_value
+                elif (
+                    param_end_idx == -1
+                    and not json_string_pending
+                    and func_close_idx != -1
+                ):
                     # Try next parameter or function end as delimiter
                     next_param = value_text.find(self.parameter_prefix)
                     func_end = value_text.find(self.function_end_token)
@@ -1115,27 +1191,28 @@ class Qwen3CoderToolParser(ToolParser):
                         tool_end_in_val = value_text.find(self.tool_call_end_token)
                         if tool_end_in_val != -1:
                             param_end_idx = tool_end_in_val
-                        else:
-                            # Param not yet closed. For string params, emit
-                            # incrementally; for non-string types we can't
-                            # emit partial JSON (half an int isn't valid),
-                            # so fall through to the existing break path.
-                            if _is_string_param(current_param_name, param_config):
-                                if json_string_pending:
-                                    break
-                                frag = self._emit_string_increment(
-                                    current_param_name, value_text
-                                )
-                                if frag:
-                                    json_fragments.append(frag)
-                                self.in_param = True
-                                self.in_param_name = current_param_name
+                if param_end_idx == -1 and completed_value is None:
+                    # Param not yet structurally closed. String values can
+                    # still stream incrementally; keep enough tail buffered
+                    # that a future close marker can remain payload (#1515).
+                    if _is_string_param(current_param_name, param_config):
+                        if json_string_pending:
                             break
-
-                if param_end_idx == -1:
+                        frag = self._emit_string_increment(
+                            current_param_name, value_text
+                        )
+                        if frag:
+                            json_fragments.append(frag)
+                        self.in_param = True
+                        self.in_param_name = current_param_name
                     break
 
-                pv = value_text[:param_end_idx]
+                if param_end_idx == -1:
+                    if completed_value is None:
+                        break
+
+                if completed_value is None:
+                    pv = value_text[:param_end_idx]
                 if pv.endswith("\n"):
                     pv = pv[:-1]
 

--- a/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
+++ b/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
@@ -920,6 +920,44 @@ class Qwen3CoderToolParser(ToolParser):
 
         tool_start_idx = function_starts[self.current_tool_index]
         func_close_idx = self._top_level_function_close(current_text, tool_start_idx)
+        param_header = current_text.find(self.parameter_prefix, tool_start_idx)
+        raw_parameter = False
+        if param_header >= 0:
+            param_header_end = current_text.find(">", param_header)
+            if param_header_end >= 0:
+                raw_parameter = (
+                    not current_text[param_header_end + 1 :].lstrip().startswith('"')
+                )
+        if self._pending_tool_wrapped and raw_parameter:
+            # In an escaping-free raw value, an early ``</parameter>`` can
+            # make a later literal ``</function>`` look structural. A wrapped
+            # call is complete only when the LAST function closer directly
+            # precedes a wrapper closer (layout whitespace is allowed).
+            wrapper_close = current_text.rfind(self.tool_call_end_token)
+            wrapped_function_close = current_text.rfind(
+                self.function_end_token, tool_start_idx, wrapper_close
+            )
+            if (
+                wrapper_close < 0
+                or wrapped_function_close < 0
+                or current_text[
+                    wrapped_function_close
+                    + len(self.function_end_token) : wrapper_close
+                ].strip()
+            ):
+                func_close_idx = -1
+            else:
+                func_close_idx = wrapped_function_close
+        content_after_wrapper = ""
+        if self._pending_tool_wrapped and func_close_idx != -1:
+            structural_wrapper_close = current_text.find(
+                self.tool_call_end_token,
+                func_close_idx + len(self.function_end_token),
+            )
+            if structural_wrapper_close >= 0:
+                content_after_wrapper = current_text[
+                    structural_wrapper_close + len(self.tool_call_end_token) :
+                ]
         if func_close_idx == -1:
             tool_text = current_text[tool_start_idx:]
         else:
@@ -987,7 +1025,7 @@ class Qwen3CoderToolParser(ToolParser):
                         self.prev_tool_call_arr.append(
                             {"name": self.current_function_name, "arguments": args}
                         )
-                        return {
+                        result = {
                             "tool_calls": [
                                 {
                                     "index": self.current_tool_index,
@@ -1000,6 +1038,9 @@ class Qwen3CoderToolParser(ToolParser):
                                 }
                             ]
                         }
+                        if content_after_wrapper:
+                            result["content"] = content_after_wrapper
+                        return result
 
                     self.prev_tool_call_arr.append(
                         {"name": self.current_function_name, "arguments": "{}"}
@@ -1282,7 +1323,7 @@ class Qwen3CoderToolParser(ToolParser):
 
             if json_fragments:
                 combined = "".join(json_fragments)
-                return {
+                result = {
                     "tool_calls": [
                         {
                             "index": self.current_tool_index,
@@ -1290,5 +1331,8 @@ class Qwen3CoderToolParser(ToolParser):
                         }
                     ]
                 }
+                if content_after_wrapper:
+                    result["content"] = content_after_wrapper
+                return result
 
         return None

--- a/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
+++ b/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
@@ -396,7 +396,10 @@ class Qwen3CoderToolParser(ToolParser):
         result = self.extract_tool_calls(model_output, request=request)
         if not result.tools_called or not result.tool_calls:
             return None
-        arguments = json.loads(result.tool_calls[0]["arguments"])
+        if self.current_tool_index >= len(result.tool_calls):
+            return None
+        current = result.tool_calls[self.current_tool_index]
+        arguments = json.loads(current["arguments"])
         remaining = list(arguments.items())[self._legacy_raw_param_count :]
         prefix = ", " if self._legacy_raw_param_count else ""
         suffix = prefix + ", ".join(
@@ -405,14 +408,28 @@ class Qwen3CoderToolParser(ToolParser):
         )
         suffix += "}"
         self._legacy_raw_stream = False
-        return {
-            "tool_calls": [
+        tool_calls = [
+            {
+                "index": self.current_tool_index,
+                "function": {"arguments": suffix},
+            }
+        ]
+        for index, call in enumerate(
+            result.tool_calls[self.current_tool_index + 1 :],
+            start=self.current_tool_index + 1,
+        ):
+            tool_calls.append(
                 {
-                    "index": self.current_tool_index,
-                    "function": {"arguments": suffix},
+                    "index": index,
+                    "id": call["id"],
+                    "type": "function",
+                    "function": {
+                        "name": call["name"],
+                        "arguments": call["arguments"],
+                    },
                 }
-            ]
-        }
+            )
+        return {"tool_calls": tool_calls}
 
     def _parse_xml_function_call(
         self, function_call_str: str, tools: list[Any] | None

--- a/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
+++ b/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
@@ -281,12 +281,32 @@ class Qwen3CoderToolParser(ToolParser):
         """
         keep_back = len(self.parameter_end_token)
         safe_end = len(value_text) - keep_back
-        marker_start = value_text.find("<", self.in_param_emitted_chars)
-        if marker_start != -1:
+        structural_tokens = (
+            self.parameter_prefix,
+            self.parameter_end_token,
+            self.function_end_token,
+            self.tool_call_end_token,
+        )
+        marker_candidates = [
+            pos
+            for token in structural_tokens
+            if (pos := value_text.find(token, self.in_param_emitted_chars)) != -1
+        ]
+        partial_start = max(
+            self.in_param_emitted_chars,
+            len(value_text) - max(map(len, structural_tokens)),
+        )
+        marker_candidates.extend(
+            pos
+            for pos in range(partial_start, len(value_text))
+            if any(token.startswith(value_text[pos:]) for token in structural_tokens)
+        )
+        if marker_candidates:
             # Raw XML has no escaping bit. Once markup-looking bytes appear,
             # they may be payload or structure until the full function makes
             # the LAST-close convention decidable (#1515). Keep that suffix
             # buffered; plain text before it can still stream incrementally.
+            marker_start = min(marker_candidates)
             if marker_start > 0 and value_text[marker_start - 1] == "\n":
                 marker_start -= 1
             safe_end = min(safe_end, marker_start)
@@ -972,6 +992,20 @@ class Qwen3CoderToolParser(ToolParser):
                     func_close_idx = candidate_close
                     structural_wrapper_close = candidate_wrapper
                 search_from = candidate_close + len(self.function_end_token)
+            if func_close_idx == -1:
+                fallback_close = current_text.rfind(
+                    self.function_end_token, tool_start_idx, call_limit
+                )
+                before_close = current_text[tool_start_idx:fallback_close].rstrip()
+                after_close = current_text[
+                    fallback_close + len(self.function_end_token) : call_limit
+                ]
+                if (
+                    fallback_close >= 0
+                    and before_close.endswith(self.parameter_end_token)
+                    and not after_close.strip()
+                ):
+                    func_close_idx = fallback_close
         elif raw_parameter:
             func_close_idx = -1
             search_from = tool_start_idx

--- a/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
+++ b/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
@@ -1023,7 +1023,12 @@ class Qwen3CoderToolParser(ToolParser):
                         visible_value = tool_text[param_header_end + 1 :].lstrip()
                         if not visible_value:
                             return None
-                        if not visible_value.startswith('"'):
+                        param_name = tool_text[
+                            param_start + len(self.parameter_prefix) : param_header_end
+                        ]
+                        if _is_string_param(param_name, expected_params) and not (
+                            visible_value.startswith('"')
+                        ):
                             self._legacy_raw_stream = True
                             return None
                     self._current_tool_id = _generate_tool_id()

--- a/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
+++ b/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
@@ -269,8 +269,7 @@ class Qwen3CoderToolParser(ToolParser):
         self.in_param_emitted_chars = 0
         self.in_param_opened = False
         self.in_param_name: str | None = None
-        self._trailing_wrapper_buffer = ""
-        self._expecting_trailing_wrapper = False
+        self._legacy_raw_stream = False
 
     def _emit_string_increment(self, param_name: str, value_text: str) -> str:
         """Return a JSON fragment for the safe (already-final) portion of an
@@ -282,35 +281,6 @@ class Qwen3CoderToolParser(ToolParser):
         """
         keep_back = len(self.parameter_end_token)
         safe_end = len(value_text) - keep_back
-        structural_tokens = (
-            self.parameter_prefix,
-            self.parameter_end_token,
-            self.function_end_token,
-            self.tool_call_end_token,
-        )
-        marker_candidates = [
-            pos
-            for token in structural_tokens
-            if (pos := value_text.find(token, self.in_param_emitted_chars)) != -1
-        ]
-        partial_start = max(
-            self.in_param_emitted_chars,
-            len(value_text) - max(map(len, structural_tokens)),
-        )
-        marker_candidates.extend(
-            pos
-            for pos in range(partial_start, len(value_text))
-            if any(token.startswith(value_text[pos:]) for token in structural_tokens)
-        )
-        if marker_candidates:
-            # Raw XML has no escaping bit. Once markup-looking bytes appear,
-            # they may be payload or structure until the full function makes
-            # the LAST-close convention decidable (#1515). Keep that suffix
-            # buffered; plain text before it can still stream incrementally.
-            marker_start = min(marker_candidates)
-            if marker_start > 0 and value_text[marker_start - 1] == "\n":
-                marker_start -= 1
-            safe_end = min(safe_end, marker_start)
         if safe_end <= self.in_param_emitted_chars:
             return ""
         safe = value_text[self.in_param_emitted_chars : safe_end]
@@ -318,6 +288,62 @@ class Qwen3CoderToolParser(ToolParser):
             return ""
         inner = json.dumps(safe, ensure_ascii=False)[1:-1]
         self.in_param_emitted_chars = safe_end
+        if not self.in_param_opened:
+            self.in_param_opened = True
+            prefix = "" if self.param_count == 0 else ", "
+            return f'{prefix}"{param_name}": "{inner}'
+        return inner
+
+    @staticmethod
+    def _decoded_json_string_prefix(value_text: str) -> str:
+        """Decode the complete portion of an in-flight JSON string.
+
+        Token boundaries may split an escape (including ``\\uXXXX``), so only
+        the prefix consisting of complete JSON characters is returned.
+        """
+        text = value_text.lstrip()
+        if not text.startswith('"'):
+            return ""
+        i = 1
+        safe_end = i
+        while i < len(text):
+            char = text[i]
+            if char == '"':
+                break
+            if char != "\\":
+                i += 1
+                safe_end = i
+                continue
+            if i + 1 >= len(text):
+                break
+            escape = text[i + 1]
+            if escape == "u":
+                if i + 6 > len(text):
+                    break
+                digits = text[i + 2 : i + 6]
+                if any(c not in "0123456789abcdefABCDEF" for c in digits):
+                    break
+                i += 6
+            elif escape in '"\\/bfnrt':
+                i += 2
+            else:
+                break
+            safe_end = i
+        encoded = text[1:safe_end]
+        try:
+            return json.loads(f'"{encoded}"')
+        except json.JSONDecodeError:
+            return ""
+
+    def _emit_decoded_string_increment(
+        self, param_name: str, decoded_value: str
+    ) -> str:
+        """Emit newly decoded characters from an in-flight JSON string."""
+        if len(decoded_value) <= self.in_param_emitted_chars:
+            return ""
+        safe = decoded_value[self.in_param_emitted_chars :]
+        inner = json.dumps(safe, ensure_ascii=False)[1:-1]
+        self.in_param_emitted_chars = len(decoded_value)
         if not self.in_param_opened:
             self.in_param_opened = True
             prefix = "" if self.param_count == 0 else ", "
@@ -823,6 +849,15 @@ class Qwen3CoderToolParser(ToolParser):
             # tool_choice=none cannot be overturned by model-authored markup.
             return {"content": delta_text}
 
+        if self._legacy_raw_stream:
+            # An escaping-free raw XML string cannot distinguish a literal
+            # complete close sequence from structure at an ordinary chunk
+            # boundary. Do not make an irreversible streaming decision;
+            # StreamingPostProcessor.finalize() runs the last-closer-aware
+            # non-streaming parser over the complete output (#1515).
+            self.accumulated_text = current_text
+            return None
+
         delta_token_ids = delta_token_ids or []
         self.accumulated_text = current_text
 
@@ -857,25 +892,6 @@ class Qwen3CoderToolParser(ToolParser):
         # content-before-strip position is whichever opener appears first
         # in ``delta_text`` so wrapper framing never leaks to the client.
         if not self.is_tool_call_started:
-            if self._trailing_wrapper_buffer or self._expecting_trailing_wrapper:
-                candidate = self._trailing_wrapper_buffer + delta_text
-                stripped = candidate.lstrip()
-                if self.tool_call_end_token.startswith(stripped):
-                    self._trailing_wrapper_buffer = (
-                        "" if stripped == self.tool_call_end_token else candidate
-                    )
-                    if stripped == self.tool_call_end_token:
-                        self._expecting_trailing_wrapper = False
-                    return None
-                if stripped.startswith(self.tool_call_end_token):
-                    self._trailing_wrapper_buffer = ""
-                    self._expecting_trailing_wrapper = False
-                    remainder = stripped[len(self.tool_call_end_token) :]
-                    return {"content": remainder} if remainder else None
-                self._trailing_wrapper_buffer = ""
-                self._expecting_trailing_wrapper = False
-                if not self._has_new_opener(delta_text, delta_token_ids):
-                    return {"content": candidate}
             if self._has_new_opener(delta_text, delta_token_ids):
                 self.is_tool_call_started = True
                 opener_pos = self._first_opener_pos(delta_text)
@@ -943,110 +959,7 @@ class Qwen3CoderToolParser(ToolParser):
             return None
 
         tool_start_idx = function_starts[self.current_tool_index]
-        call_limit = (
-            function_starts[self.current_tool_index + 1]
-            if self.current_tool_index + 1 < len(function_starts)
-            else len(current_text)
-        )
-        if self.current_tool_index + 1 < len(function_starts):
-            next_wrapper = current_text.rfind(
-                self.tool_call_start_token, tool_start_idx, call_limit
-            )
-            if next_wrapper >= 0:
-                call_limit = next_wrapper
         func_close_idx = self._top_level_function_close(current_text, tool_start_idx)
-        param_header = current_text.find(self.parameter_prefix, tool_start_idx)
-        raw_parameter = False
-        structural_wrapper_close = -1
-        while param_header >= 0:
-            param_header_end = current_text.find(">", param_header)
-            if param_header_end < 0:
-                break
-            if not current_text[param_header_end + 1 :].lstrip().startswith('"'):
-                raw_parameter = True
-                break
-            param_header = current_text.find(
-                self.parameter_prefix, param_header_end + 1
-            )
-        if self._pending_tool_wrapped and raw_parameter:
-            # In an escaping-free raw value, an early ``</parameter>`` can
-            # make a later literal ``</function>`` look structural. A wrapped
-            # call is complete only when the LAST function closer directly
-            # precedes a wrapper closer (layout whitespace is allowed).
-            func_close_idx = -1
-            structural_wrapper_close = -1
-            search_from = tool_start_idx
-            while search_from < call_limit:
-                candidate_close = current_text.find(
-                    self.function_end_token, search_from, call_limit
-                )
-                if candidate_close < 0:
-                    break
-                candidate_wrapper = current_text.find(
-                    self.tool_call_end_token,
-                    candidate_close + len(self.function_end_token),
-                    call_limit,
-                )
-                if (
-                    candidate_wrapper >= 0
-                    and not current_text[
-                        candidate_close
-                        + len(self.function_end_token) : candidate_wrapper
-                    ].strip()
-                    and candidate_close > 0
-                    and current_text[candidate_close - 1] == "\n"
-                ):
-                    func_close_idx = candidate_close
-                    structural_wrapper_close = candidate_wrapper
-                search_from = candidate_close + len(self.function_end_token)
-            if func_close_idx == -1:
-                fallback_close = current_text.rfind(
-                    self.function_end_token, tool_start_idx, call_limit
-                )
-                before_close = current_text[tool_start_idx:fallback_close].rstrip()
-                after_close = current_text[
-                    fallback_close + len(self.function_end_token) : call_limit
-                ]
-                if (
-                    fallback_close >= 0
-                    and before_close.endswith(self.parameter_end_token)
-                    and before_close[: -len(self.parameter_end_token)].endswith("\n")
-                    and current_text[fallback_close - 1] == "\n"
-                    and not after_close.strip()
-                ):
-                    func_close_idx = fallback_close
-        elif raw_parameter:
-            func_close_idx = -1
-            search_from = tool_start_idx
-            while search_from < call_limit:
-                candidate_close = current_text.find(
-                    self.function_end_token, search_from, call_limit
-                )
-                if candidate_close < 0:
-                    break
-                before_close = current_text[tool_start_idx:candidate_close].rstrip()
-                parameter_close = before_close.rfind(self.parameter_end_token)
-                if (
-                    parameter_close > 0
-                    and before_close[parameter_close - 1] == "\n"
-                    and candidate_close > 0
-                    and current_text[candidate_close - 1] == "\n"
-                ):
-                    func_close_idx = candidate_close
-                search_from = candidate_close + len(self.function_end_token)
-        content_after_wrapper = ""
-        if self._pending_tool_wrapped and func_close_idx != -1:
-            if not raw_parameter:
-                structural_wrapper_close = current_text.find(
-                    self.tool_call_end_token,
-                    func_close_idx + len(self.function_end_token),
-                    call_limit,
-                )
-            if structural_wrapper_close >= 0:
-                content_after_wrapper = current_text[
-                    structural_wrapper_close
-                    + len(self.tool_call_end_token) : call_limit
-                ]
         if func_close_idx == -1:
             tool_text = current_text[tool_start_idx:]
         else:
@@ -1092,6 +1005,27 @@ class Qwen3CoderToolParser(ToolParser):
                         self._reset_streaming_state()
                         self._streaming_request = saved_request
                         return {"content": rejected}
+                    param_start = tool_text.find(self.parameter_prefix, func_end)
+                    request_tools = (
+                        self._streaming_request.get("tools")
+                        if isinstance(self._streaming_request, dict)
+                        else None
+                    )
+                    expected_params = _get_arguments_config(
+                        self.current_function_name, request_tools
+                    )
+                    if expected_params and param_start < 0 and func_close_idx == -1:
+                        return None
+                    if param_start >= 0 and func_close_idx == -1:
+                        param_header_end = tool_text.find(">", param_start)
+                        if param_header_end < 0:
+                            return None
+                        visible_value = tool_text[param_header_end + 1 :].lstrip()
+                        if not visible_value:
+                            return None
+                        if not visible_value.startswith('"'):
+                            self._legacy_raw_stream = True
+                            return None
                     self._current_tool_id = _generate_tool_id()
                     self.header_sent = True
                     self.in_function = True
@@ -1114,7 +1048,7 @@ class Qwen3CoderToolParser(ToolParser):
                         self.prev_tool_call_arr.append(
                             {"name": self.current_function_name, "arguments": args}
                         )
-                        result = {
+                        return {
                             "tool_calls": [
                                 {
                                     "index": self.current_tool_index,
@@ -1127,16 +1061,11 @@ class Qwen3CoderToolParser(ToolParser):
                                 }
                             ]
                         }
-                        if content_after_wrapper:
-                            result["content"] = content_after_wrapper
-                        self._expecting_trailing_wrapper = (
-                            self._pending_tool_wrapped and structural_wrapper_close < 0
-                        )
-                        return result
 
                     self.prev_tool_call_arr.append(
                         {"name": self.current_function_name, "arguments": "{}"}
                     )
+                    self.json_started = True
                     return {
                         "tool_calls": [
                             {
@@ -1145,7 +1074,7 @@ class Qwen3CoderToolParser(ToolParser):
                                 "type": "function",
                                 "function": {
                                     "name": self.current_function_name,
-                                    "arguments": "",
+                                    "arguments": "{",
                                 },
                             }
                         ]
@@ -1185,19 +1114,6 @@ class Qwen3CoderToolParser(ToolParser):
             param_config = _get_arguments_config(
                 self.current_function_name or "", tools
             )
-            completed_parameters: list[tuple[str, str]] = []
-            if func_close_idx != -1:
-                header_end = tool_text.find(">")
-                if header_end != -1:
-                    completed_parameters = (
-                        split_marked_parameters(
-                            tool_text[header_end + 1 : -len(self.function_end_token)],
-                            r"<parameter=([^>]+)>",
-                            self.parameter_end_token,
-                            valid_names=set(param_config) or None,
-                        )
-                        or []
-                    )
 
             json_fragments = []
 
@@ -1221,26 +1137,9 @@ class Qwen3CoderToolParser(ToolParser):
                     if value_text.startswith("\n"):
                         value_text = value_text[1:]
 
+                    end_idx = self._find_parameter_close(value_text, 0)
                     json_string_pending = value_text.lstrip().startswith('"')
-                    completed_value = (
-                        completed_parameters[self.param_count][1]
-                        if self.param_count < len(completed_parameters)
-                        and completed_parameters[self.param_count][0]
-                        == self.in_param_name
-                        else None
-                    )
-                    end_idx = (
-                        self._find_parameter_close(value_text, 0)
-                        if json_string_pending
-                        else -1
-                    )
-                    if completed_value is not None:
-                        pv = completed_value
-                    elif (
-                        end_idx == -1
-                        and not json_string_pending
-                        and func_close_idx != -1
-                    ):
+                    if end_idx == -1 and not json_string_pending:
                         # Defensive fallback: model emitted next-param-prefix,
                         # </function>, or </tool_call> without a </parameter>.
                         # Use any of those as the close to avoid hanging
@@ -1252,27 +1151,23 @@ class Qwen3CoderToolParser(ToolParser):
                         candidates = [c for c in (nxt, fe, te) if c != -1]
                         if candidates:
                             end_idx = min(candidates)
-                    elif end_idx == -1 and not json_string_pending:
-                        # Preserve the established truncated-stream recovery
-                        # only for a wrapper closer on its own line. An inline
-                        # ``</tool_call>`` is valid raw string data (#1515).
-                        te = value_text.find(self.tool_call_end_token)
-                        if (
-                            te > 0
-                            and value_text[te - 1] == "\n"
-                            and not value_text[
-                                te + len(self.tool_call_end_token) :
-                            ].strip()
-                        ):
-                            end_idx = te
-                    if completed_value is not None or end_idx != -1:
-                        if completed_value is None:
-                            pv = value_text[:end_idx]
+                    if end_idx != -1:
+                        pv = value_text[:end_idx]
                         if pv.endswith("\n"):
                             pv = pv[:-1]
                         self.accumulated_params[self.in_param_name] = pv
+                        close_value = (
+                            _convert_param_value(
+                                pv,
+                                self.in_param_name,
+                                param_config,
+                                self.current_function_name or "",
+                            )
+                            if json_string_pending
+                            else pv
+                        )
                         frag = self._close_string_increment(
-                            self.in_param_name, pv, param_config
+                            self.in_param_name, close_value, param_config
                         )
                         if frag:
                             json_fragments.append(frag)
@@ -1281,9 +1176,16 @@ class Qwen3CoderToolParser(ToolParser):
                         self.in_param_name = None
                         self.in_param_emitted_chars = 0
                         self.in_param_opened = False
-                    elif not json_string_pending:
-                        frag = self._emit_string_increment(
-                            self.in_param_name, value_text
+                    else:
+                        frag = (
+                            self._emit_decoded_string_increment(
+                                self.in_param_name,
+                                self._decoded_json_string_prefix(value_text),
+                            )
+                            if json_string_pending
+                            else self._emit_string_increment(
+                                self.in_param_name, value_text
+                            )
                         )
                         if frag:
                             json_fragments.append(frag)
@@ -1304,25 +1206,9 @@ class Qwen3CoderToolParser(ToolParser):
                 if value_text.startswith("\n"):
                     value_text = value_text[1:]
 
+                param_end_idx = self._find_parameter_close(value_text, 0)
                 json_string_pending = value_text.lstrip().startswith('"')
-                completed_value = (
-                    completed_parameters[self.param_count][1]
-                    if self.param_count < len(completed_parameters)
-                    and completed_parameters[self.param_count][0] == current_param_name
-                    else None
-                )
-                param_end_idx = (
-                    self._find_parameter_close(value_text, 0)
-                    if json_string_pending
-                    else -1
-                )
-                if completed_value is not None:
-                    pv = completed_value
-                elif (
-                    param_end_idx == -1
-                    and not json_string_pending
-                    and func_close_idx != -1
-                ):
+                if param_end_idx == -1 and not json_string_pending:
                     # Try next parameter or function end as delimiter
                     next_param = value_text.find(self.parameter_prefix)
                     func_end = value_text.find(self.function_end_token)
@@ -1334,15 +1220,26 @@ class Qwen3CoderToolParser(ToolParser):
                         tool_end_in_val = value_text.find(self.tool_call_end_token)
                         if tool_end_in_val != -1:
                             param_end_idx = tool_end_in_val
-                if param_end_idx == -1 and completed_value is None:
-                    # Param not yet structurally closed. String values can
-                    # still stream incrementally; keep enough tail buffered
-                    # that a future close marker can remain payload (#1515).
-                    if _is_string_param(current_param_name, param_config):
-                        if json_string_pending:
+                        else:
+                            # Param not yet closed. For string params, emit
+                            # incrementally; for non-string types we can't
+                            # emit partial JSON (half an int isn't valid),
+                            # so fall through to the existing break path.
+                            if _is_string_param(current_param_name, param_config):
+                                frag = self._emit_string_increment(
+                                    current_param_name, value_text
+                                )
+                                if frag:
+                                    json_fragments.append(frag)
+                                self.in_param = True
+                                self.in_param_name = current_param_name
                             break
-                        frag = self._emit_string_increment(
-                            current_param_name, value_text
+
+                if param_end_idx == -1 and json_string_pending:
+                    if _is_string_param(current_param_name, param_config):
+                        frag = self._emit_decoded_string_increment(
+                            current_param_name,
+                            self._decoded_json_string_prefix(value_text),
                         )
                         if frag:
                             json_fragments.append(frag)
@@ -1351,11 +1248,9 @@ class Qwen3CoderToolParser(ToolParser):
                     break
 
                 if param_end_idx == -1:
-                    if completed_value is None:
-                        break
+                    break
 
-                if completed_value is None:
-                    pv = value_text[:param_end_idx]
+                pv = value_text[:param_end_idx]
                 if pv.endswith("\n"):
                     pv = pv[:-1]
 
@@ -1415,7 +1310,7 @@ class Qwen3CoderToolParser(ToolParser):
 
             if json_fragments:
                 combined = "".join(json_fragments)
-                result = {
+                return {
                     "tool_calls": [
                         {
                             "index": self.current_tool_index,
@@ -1423,11 +1318,5 @@ class Qwen3CoderToolParser(ToolParser):
                         }
                     ]
                 }
-                if content_after_wrapper:
-                    result["content"] = content_after_wrapper
-                self._expecting_trailing_wrapper = (
-                    self._pending_tool_wrapped and structural_wrapper_close < 0
-                )
-                return result
 
         return None

--- a/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
+++ b/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
@@ -270,6 +270,7 @@ class Qwen3CoderToolParser(ToolParser):
         self.in_param_opened = False
         self.in_param_name: str | None = None
         self._legacy_raw_stream = False
+        self._legacy_raw_param_count = 0
 
     def _emit_string_increment(self, param_name: str, value_text: str) -> str:
         """Return a JSON fragment for the safe (already-final) portion of an
@@ -385,6 +386,33 @@ class Qwen3CoderToolParser(ToolParser):
         tail = full_value[self.in_param_emitted_chars :]
         inner = json.dumps(tail, ensure_ascii=False)[1:-1]
         return f'{inner}"'
+
+    def finalize_legacy_raw_stream(
+        self, model_output: str, request: dict[str, Any] | None = None
+    ) -> dict | None:
+        """Return the un-emitted JSON suffix for a deferred raw parameter."""
+        if not self._legacy_raw_stream:
+            return None
+        result = self.extract_tool_calls(model_output, request=request)
+        if not result.tools_called or not result.tool_calls:
+            return None
+        arguments = json.loads(result.tool_calls[0]["arguments"])
+        remaining = list(arguments.items())[self._legacy_raw_param_count :]
+        prefix = ", " if self._legacy_raw_param_count else ""
+        suffix = prefix + ", ".join(
+            f"{json.dumps(name)}: {json.dumps(value, ensure_ascii=False)}"
+            for name, value in remaining
+        )
+        suffix += "}"
+        self._legacy_raw_stream = False
+        return {
+            "tool_calls": [
+                {
+                    "index": self.current_tool_index,
+                    "function": {"arguments": suffix},
+                }
+            ]
+        }
 
     def _parse_xml_function_call(
         self, function_call_str: str, tools: list[Any] | None
@@ -1031,38 +1059,29 @@ class Qwen3CoderToolParser(ToolParser):
                         self._reset_streaming_state()
                         self._streaming_request = saved_request
                         return {"content": rejected}
-                    request_tools = (
-                        self._streaming_request.get("tools")
-                        if isinstance(self._streaming_request, dict)
-                        else None
-                    )
-                    expected_params = _get_arguments_config(
-                        self.current_function_name, request_tools
-                    )
-                    if expected_params and func_close_idx == -1:
-                        # Any string property could appear later (JSON Schema
-                        # properties are optional unless listed as required).
-                        # Wait until every possible string parameter is visible
-                        # before emitting an irreversible header; non-string
-                        # properties cannot carry ambiguous XML closers.
-                        for param_name in (
-                            name
-                            for name in expected_params
-                            if _is_string_param(name, expected_params)
-                        ):
-                            opener = f"{self.parameter_prefix}{param_name}>"
-                            param_start = tool_text.find(opener, func_end)
-                            if param_start < 0:
-                                return None
-                            value_start = param_start + len(opener)
-                            visible_value = tool_text[value_start:].lstrip()
-                            if not visible_value:
-                                return None
-                            if _is_string_param(param_name, expected_params) and not (
-                                visible_value.startswith('"')
+                    first_param = tool_text.find(self.parameter_prefix, func_end)
+                    if first_param >= 0 and func_close_idx == -1:
+                        name_end = tool_text.find(">", first_param)
+                        if name_end >= 0:
+                            param_name = tool_text[
+                                first_param + len(self.parameter_prefix) : name_end
+                            ]
+                            visible = tool_text[name_end + 1 :].lstrip()
+                            request_tools = (
+                                self._streaming_request.get("tools")
+                                if isinstance(self._streaming_request, dict)
+                                else None
+                            )
+                            config = _get_arguments_config(
+                                self.current_function_name, request_tools
+                            )
+                            if (
+                                visible
+                                and not visible.startswith('"')
+                                and (_is_string_param(param_name, config) or not config)
                             ):
                                 self._legacy_raw_stream = True
-                                return None
+                                self._legacy_raw_param_count = 0
                     self._current_tool_id = _generate_tool_id()
                     self.header_sent = True
                     self.in_function = True
@@ -1242,6 +1261,19 @@ class Qwen3CoderToolParser(ToolParser):
                 value_text = tool_text[value_start:]
                 if value_text.startswith("\n"):
                     value_text = value_text[1:]
+
+                if not value_text.strip():
+                    break
+                is_string = _is_string_param(current_param_name, param_config)
+                if not value_text.lstrip().startswith('"') and (
+                    is_string or not param_config
+                ):
+                    # Raw XML has no escaping rule, so its first apparent close
+                    # may be payload. Freeze only the un-emitted suffix and let
+                    # EOS parsing select the final structural closer.
+                    self._legacy_raw_stream = True
+                    self._legacy_raw_param_count = self.param_count
+                    return None
 
                 param_end_idx = self._find_parameter_close(value_text, 0)
                 json_string_pending = value_text.lstrip().startswith('"')

--- a/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
+++ b/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
@@ -919,6 +919,11 @@ class Qwen3CoderToolParser(ToolParser):
             return None
 
         tool_start_idx = function_starts[self.current_tool_index]
+        call_limit = (
+            function_starts[self.current_tool_index + 1]
+            if self.current_tool_index + 1 < len(function_starts)
+            else len(current_text)
+        )
         func_close_idx = self._top_level_function_close(current_text, tool_start_idx)
         param_header = current_text.find(self.parameter_prefix, tool_start_idx)
         raw_parameter = False
@@ -937,36 +942,53 @@ class Qwen3CoderToolParser(ToolParser):
             # make a later literal ``</function>`` look structural. A wrapped
             # call is complete only when the LAST function closer directly
             # precedes a wrapper closer (layout whitespace is allowed).
-            wrapper_close = current_text.rfind(self.tool_call_end_token)
-            wrapped_function_close = current_text.rfind(
-                self.function_end_token, tool_start_idx, wrapper_close
-            )
-            if (
-                wrapper_close < 0
-                or wrapped_function_close < 0
-                or current_text[
-                    wrapped_function_close
-                    + len(self.function_end_token) : wrapper_close
-                ].strip()
-            ):
-                func_close_idx = -1
-            else:
-                func_close_idx = wrapped_function_close
+            func_close_idx = -1
+            structural_wrapper_close = -1
+            search_from = tool_start_idx
+            while search_from < call_limit:
+                candidate_close = current_text.find(
+                    self.function_end_token, search_from, call_limit
+                )
+                if candidate_close < 0:
+                    break
+                candidate_wrapper = current_text.find(
+                    self.tool_call_end_token,
+                    candidate_close + len(self.function_end_token),
+                    call_limit,
+                )
+                if (
+                    candidate_wrapper >= 0
+                    and not current_text[
+                        candidate_close
+                        + len(self.function_end_token) : candidate_wrapper
+                    ].strip()
+                ):
+                    func_close_idx = candidate_close
+                    structural_wrapper_close = candidate_wrapper
+                    break
+                search_from = candidate_close + len(self.function_end_token)
         elif raw_parameter:
-            bare_function_close = current_text.rfind(self.function_end_token)
-            before_close = current_text[tool_start_idx:bare_function_close].rstrip()
-            if bare_function_close < 0 or not before_close.endswith(
-                self.parameter_end_token
-            ):
-                func_close_idx = -1
-            else:
-                func_close_idx = bare_function_close
+            func_close_idx = -1
+            search_from = tool_start_idx
+            while search_from < call_limit:
+                candidate_close = current_text.find(
+                    self.function_end_token, search_from, call_limit
+                )
+                if candidate_close < 0:
+                    break
+                before_close = current_text[tool_start_idx:candidate_close].rstrip()
+                if before_close.endswith(self.parameter_end_token):
+                    func_close_idx = candidate_close
+                    break
+                search_from = candidate_close + len(self.function_end_token)
         content_after_wrapper = ""
         if self._pending_tool_wrapped and func_close_idx != -1:
-            structural_wrapper_close = current_text.find(
-                self.tool_call_end_token,
-                func_close_idx + len(self.function_end_token),
-            )
+            if not raw_parameter:
+                structural_wrapper_close = current_text.find(
+                    self.tool_call_end_token,
+                    func_close_idx + len(self.function_end_token),
+                    call_limit,
+                )
             if structural_wrapper_close >= 0:
                 content_after_wrapper = current_text[
                     structural_wrapper_close + len(self.tool_call_end_token) :

--- a/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
+++ b/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
@@ -922,12 +922,16 @@ class Qwen3CoderToolParser(ToolParser):
         func_close_idx = self._top_level_function_close(current_text, tool_start_idx)
         param_header = current_text.find(self.parameter_prefix, tool_start_idx)
         raw_parameter = False
-        if param_header >= 0:
+        while param_header >= 0:
             param_header_end = current_text.find(">", param_header)
-            if param_header_end >= 0:
-                raw_parameter = (
-                    not current_text[param_header_end + 1 :].lstrip().startswith('"')
-                )
+            if param_header_end < 0:
+                break
+            if not current_text[param_header_end + 1 :].lstrip().startswith('"'):
+                raw_parameter = True
+                break
+            param_header = current_text.find(
+                self.parameter_prefix, param_header_end + 1
+            )
         if self._pending_tool_wrapped and raw_parameter:
             # In an escaping-free raw value, an early ``</parameter>`` can
             # make a later literal ``</function>`` look structural. A wrapped
@@ -948,6 +952,15 @@ class Qwen3CoderToolParser(ToolParser):
                 func_close_idx = -1
             else:
                 func_close_idx = wrapped_function_close
+        elif raw_parameter:
+            bare_function_close = current_text.rfind(self.function_end_token)
+            before_close = current_text[tool_start_idx:bare_function_close].rstrip()
+            if bare_function_close < 0 or not before_close.endswith(
+                self.parameter_end_token
+            ):
+                func_close_idx = -1
+            else:
+                func_close_idx = bare_function_close
         content_after_wrapper = ""
         if self._pending_tool_wrapped and func_close_idx != -1:
             structural_wrapper_close = current_text.find(

--- a/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
+++ b/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
@@ -846,12 +846,10 @@ class Qwen3CoderToolParser(ToolParser):
                         "" if stripped == self.tool_call_end_token else candidate
                     )
                     return None
-                if (
-                    stripped.startswith(self.tool_call_end_token)
-                    and not stripped[len(self.tool_call_end_token) :].strip()
-                ):
+                if stripped.startswith(self.tool_call_end_token):
                     self._trailing_wrapper_buffer = ""
-                    return None
+                    remainder = stripped[len(self.tool_call_end_token) :]
+                    return {"content": remainder} if remainder.strip() else None
                 self._trailing_wrapper_buffer = ""
                 return {"content": candidate}
             if self._has_new_opener(delta_text, delta_token_ids):

--- a/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
+++ b/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
@@ -269,6 +269,7 @@ class Qwen3CoderToolParser(ToolParser):
         self.in_param_emitted_chars = 0
         self.in_param_opened = False
         self.in_param_name: str | None = None
+        self._trailing_wrapper_buffer = ""
 
     def _emit_string_increment(self, param_name: str, value_text: str) -> str:
         """Return a JSON fragment for the safe (already-final) portion of an
@@ -835,6 +836,24 @@ class Qwen3CoderToolParser(ToolParser):
         # content-before-strip position is whichever opener appears first
         # in ``delta_text`` so wrapper framing never leaks to the client.
         if not self.is_tool_call_started:
+            if self._trailing_wrapper_buffer or previous_text.rstrip().endswith(
+                self.function_end_token
+            ):
+                candidate = self._trailing_wrapper_buffer + delta_text
+                stripped = candidate.lstrip()
+                if self.tool_call_end_token.startswith(stripped):
+                    self._trailing_wrapper_buffer = (
+                        "" if stripped == self.tool_call_end_token else candidate
+                    )
+                    return None
+                if (
+                    stripped.startswith(self.tool_call_end_token)
+                    and not stripped[len(self.tool_call_end_token) :].strip()
+                ):
+                    self._trailing_wrapper_buffer = ""
+                    return None
+                self._trailing_wrapper_buffer = ""
+                return {"content": candidate}
             if self._has_new_opener(delta_text, delta_token_ids):
                 self.is_tool_call_started = True
                 opener_pos = self._first_opener_pos(delta_text)
@@ -884,16 +903,9 @@ class Qwen3CoderToolParser(ToolParser):
                 # emit an empty tail. ``</function>`` is the actual tool
                 # close; ``</tool_call>`` may follow as optional framing.
                 trailing = current_text.rstrip()
-                if (
-                    delta_text.strip() == ""
-                    and (
-                        trailing.endswith(self.tool_call_end_token)
-                        or trailing.endswith(self.function_end_token)
-                    )
-                ) or (
-                    delta_text.strip() == self.tool_call_end_token
-                    and previous_text.rstrip().endswith(self.function_end_token)
-                    and trailing.endswith(self.tool_call_end_token)
+                if delta_text.strip() == "" and (
+                    trailing.endswith(self.tool_call_end_token)
+                    or trailing.endswith(self.function_end_token)
                 ):
                     return None
                 return {"content": delta_text}

--- a/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
+++ b/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
@@ -924,6 +924,12 @@ class Qwen3CoderToolParser(ToolParser):
             if self.current_tool_index + 1 < len(function_starts)
             else len(current_text)
         )
+        if self.current_tool_index + 1 < len(function_starts):
+            next_wrapper = current_text.rfind(
+                self.tool_call_start_token, tool_start_idx, call_limit
+            )
+            if next_wrapper >= 0:
+                call_limit = next_wrapper
         func_close_idx = self._top_level_function_close(current_text, tool_start_idx)
         param_header = current_text.find(self.parameter_prefix, tool_start_idx)
         raw_parameter = False
@@ -965,7 +971,6 @@ class Qwen3CoderToolParser(ToolParser):
                 ):
                     func_close_idx = candidate_close
                     structural_wrapper_close = candidate_wrapper
-                    break
                 search_from = candidate_close + len(self.function_end_token)
         elif raw_parameter:
             func_close_idx = -1
@@ -979,7 +984,6 @@ class Qwen3CoderToolParser(ToolParser):
                 before_close = current_text[tool_start_idx:candidate_close].rstrip()
                 if before_close.endswith(self.parameter_end_token):
                     func_close_idx = candidate_close
-                    break
                 search_from = candidate_close + len(self.function_end_token)
         content_after_wrapper = ""
         if self._pending_tool_wrapped and func_close_idx != -1:
@@ -991,7 +995,8 @@ class Qwen3CoderToolParser(ToolParser):
                 )
             if structural_wrapper_close >= 0:
                 content_after_wrapper = current_text[
-                    structural_wrapper_close + len(self.tool_call_end_token) :
+                    structural_wrapper_close
+                    + len(self.tool_call_end_token) : call_limit
                 ]
         if func_close_idx == -1:
             tool_text = current_text[tool_start_idx:]

--- a/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
+++ b/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
@@ -849,7 +849,7 @@ class Qwen3CoderToolParser(ToolParser):
                 if stripped.startswith(self.tool_call_end_token):
                     self._trailing_wrapper_buffer = ""
                     remainder = stripped[len(self.tool_call_end_token) :]
-                    return {"content": remainder} if remainder.strip() else None
+                    return {"content": remainder} if remainder else None
                 self._trailing_wrapper_buffer = ""
                 return {"content": candidate}
             if self._has_new_opener(delta_text, delta_token_ids):

--- a/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
+++ b/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
@@ -323,6 +323,20 @@ class Qwen3CoderToolParser(ToolParser):
                 digits = text[i + 2 : i + 6]
                 if any(c not in "0123456789abcdefABCDEF" for c in digits):
                     break
+                codepoint = int(digits, 16)
+                if 0xD800 <= codepoint <= 0xDBFF:
+                    # A high surrogate is not independently emit-safe: JSON
+                    # decoding combines it with a following low surrogate.
+                    if i + 12 > len(text) or text[i + 6 : i + 8] != "\\u":
+                        break
+                    low_digits = text[i + 8 : i + 12]
+                    if any(
+                        c not in "0123456789abcdefABCDEF" for c in low_digits
+                    ) or not (0xDC00 <= int(low_digits, 16) <= 0xDFFF):
+                        break
+                    i += 12
+                    safe_end = i
+                    continue
                 i += 6
             elif escape in '"\\/bfnrt':
                 i += 2
@@ -444,9 +458,19 @@ class Qwen3CoderToolParser(ToolParser):
                     and body.find(">") >= 0
                     and not body[body.find(">") + 1 :].strip()
                 )
-                if not (complete_params or wrapped_zero_arg):
-                    continue
-                function_end = len(model_output)
+                trailing_wrapper = model_output.rfind(
+                    self.tool_call_end_token, body_start
+                )
+                if trailing_wrapper >= 0:
+                    # EOS recovery for a malformed call missing inner closes.
+                    # Use the final wrapper closer so literal closer text in a
+                    # raw value remains payload (#1515).
+                    body = model_output[body_start:trailing_wrapper]
+                    function_end = trailing_wrapper
+                else:
+                    if not (complete_params or wrapped_zero_arg):
+                        continue
+                    function_end = len(model_output)
             else:
                 body = model_output[body_start:close]
                 function_end = close + len(self.function_end_token)
@@ -1005,7 +1029,6 @@ class Qwen3CoderToolParser(ToolParser):
                         self._reset_streaming_state()
                         self._streaming_request = saved_request
                         return {"content": rejected}
-                    param_start = tool_text.find(self.parameter_prefix, func_end)
                     request_tools = (
                         self._streaming_request.get("tools")
                         if isinstance(self._streaming_request, dict)
@@ -1014,23 +1037,21 @@ class Qwen3CoderToolParser(ToolParser):
                     expected_params = _get_arguments_config(
                         self.current_function_name, request_tools
                     )
-                    if expected_params and param_start < 0 and func_close_idx == -1:
-                        return None
-                    if param_start >= 0 and func_close_idx == -1:
-                        param_header_end = tool_text.find(">", param_start)
-                        if param_header_end < 0:
-                            return None
-                        visible_value = tool_text[param_header_end + 1 :].lstrip()
-                        if not visible_value:
-                            return None
-                        param_name = tool_text[
-                            param_start + len(self.parameter_prefix) : param_header_end
-                        ]
-                        if _is_string_param(param_name, expected_params) and not (
-                            visible_value.startswith('"')
-                        ):
-                            self._legacy_raw_stream = True
-                            return None
+                    if expected_params and func_close_idx == -1:
+                        for param_name in expected_params:
+                            opener = f"{self.parameter_prefix}{param_name}>"
+                            param_start = tool_text.find(opener, func_end)
+                            if param_start < 0:
+                                return None
+                            value_start = param_start + len(opener)
+                            visible_value = tool_text[value_start:].lstrip()
+                            if not visible_value:
+                                return None
+                            if _is_string_param(param_name, expected_params) and not (
+                                visible_value.startswith('"')
+                            ):
+                                self._legacy_raw_stream = True
+                                return None
                     self._current_tool_id = _generate_tool_id()
                     self.header_sent = True
                     self.in_function = True

--- a/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
+++ b/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
@@ -458,8 +458,10 @@ class Qwen3CoderToolParser(ToolParser):
                     and body.find(">") >= 0
                     and not body[body.find(">") + 1 :].strip()
                 )
+                next_wrapper = model_output.find(self.tool_call_start_token, body_start)
+                recovery_end = next_wrapper if next_wrapper >= 0 else len(model_output)
                 trailing_wrapper = model_output.rfind(
-                    self.tool_call_end_token, body_start
+                    self.tool_call_end_token, body_start, recovery_end
                 )
                 if trailing_wrapper >= 0:
                     # EOS recovery for a malformed call missing inner closes.
@@ -1038,7 +1040,16 @@ class Qwen3CoderToolParser(ToolParser):
                         self.current_function_name, request_tools
                     )
                     if expected_params and func_close_idx == -1:
-                        for param_name in expected_params:
+                        # Any string property could appear later (JSON Schema
+                        # properties are optional unless listed as required).
+                        # Wait until every possible string parameter is visible
+                        # before emitting an irreversible header; non-string
+                        # properties cannot carry ambiguous XML closers.
+                        for param_name in (
+                            name
+                            for name in expected_params
+                            if _is_string_param(name, expected_params)
+                        ):
                             opener = f"{self.parameter_prefix}{param_name}>"
                             param_start = tool_text.find(opener, func_end)
                             if param_start < 0:

--- a/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
+++ b/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
@@ -270,6 +270,7 @@ class Qwen3CoderToolParser(ToolParser):
         self.in_param_opened = False
         self.in_param_name: str | None = None
         self._trailing_wrapper_buffer = ""
+        self._expecting_trailing_wrapper = False
 
     def _emit_string_increment(self, param_name: str, value_text: str) -> str:
         """Return a JSON fragment for the safe (already-final) portion of an
@@ -856,22 +857,25 @@ class Qwen3CoderToolParser(ToolParser):
         # content-before-strip position is whichever opener appears first
         # in ``delta_text`` so wrapper framing never leaks to the client.
         if not self.is_tool_call_started:
-            if self._trailing_wrapper_buffer or previous_text.rstrip().endswith(
-                self.function_end_token
-            ):
+            if self._trailing_wrapper_buffer or self._expecting_trailing_wrapper:
                 candidate = self._trailing_wrapper_buffer + delta_text
                 stripped = candidate.lstrip()
                 if self.tool_call_end_token.startswith(stripped):
                     self._trailing_wrapper_buffer = (
                         "" if stripped == self.tool_call_end_token else candidate
                     )
+                    if stripped == self.tool_call_end_token:
+                        self._expecting_trailing_wrapper = False
                     return None
                 if stripped.startswith(self.tool_call_end_token):
                     self._trailing_wrapper_buffer = ""
+                    self._expecting_trailing_wrapper = False
                     remainder = stripped[len(self.tool_call_end_token) :]
                     return {"content": remainder} if remainder else None
                 self._trailing_wrapper_buffer = ""
-                return {"content": candidate}
+                self._expecting_trailing_wrapper = False
+                if not self._has_new_opener(delta_text, delta_token_ids):
+                    return {"content": candidate}
             if self._has_new_opener(delta_text, delta_token_ids):
                 self.is_tool_call_started = True
                 opener_pos = self._first_opener_pos(delta_text)
@@ -953,6 +957,7 @@ class Qwen3CoderToolParser(ToolParser):
         func_close_idx = self._top_level_function_close(current_text, tool_start_idx)
         param_header = current_text.find(self.parameter_prefix, tool_start_idx)
         raw_parameter = False
+        structural_wrapper_close = -1
         while param_header >= 0:
             param_header_end = current_text.find(">", param_header)
             if param_header_end < 0:
@@ -988,6 +993,8 @@ class Qwen3CoderToolParser(ToolParser):
                         candidate_close
                         + len(self.function_end_token) : candidate_wrapper
                     ].strip()
+                    and candidate_close > 0
+                    and current_text[candidate_close - 1] == "\n"
                 ):
                     func_close_idx = candidate_close
                     structural_wrapper_close = candidate_wrapper
@@ -1003,6 +1010,8 @@ class Qwen3CoderToolParser(ToolParser):
                 if (
                     fallback_close >= 0
                     and before_close.endswith(self.parameter_end_token)
+                    and before_close[: -len(self.parameter_end_token)].endswith("\n")
+                    and current_text[fallback_close - 1] == "\n"
                     and not after_close.strip()
                 ):
                     func_close_idx = fallback_close
@@ -1016,7 +1025,13 @@ class Qwen3CoderToolParser(ToolParser):
                 if candidate_close < 0:
                     break
                 before_close = current_text[tool_start_idx:candidate_close].rstrip()
-                if before_close.endswith(self.parameter_end_token):
+                parameter_close = before_close.rfind(self.parameter_end_token)
+                if (
+                    parameter_close > 0
+                    and before_close[parameter_close - 1] == "\n"
+                    and candidate_close > 0
+                    and current_text[candidate_close - 1] == "\n"
+                ):
                     func_close_idx = candidate_close
                 search_from = candidate_close + len(self.function_end_token)
         content_after_wrapper = ""
@@ -1114,6 +1129,9 @@ class Qwen3CoderToolParser(ToolParser):
                         }
                         if content_after_wrapper:
                             result["content"] = content_after_wrapper
+                        self._expecting_trailing_wrapper = (
+                            self._pending_tool_wrapped and structural_wrapper_close < 0
+                        )
                         return result
 
                     self.prev_tool_call_arr.append(
@@ -1407,6 +1425,9 @@ class Qwen3CoderToolParser(ToolParser):
                 }
                 if content_after_wrapper:
                     result["content"] = content_after_wrapper
+                self._expecting_trailing_wrapper = (
+                    self._pending_tool_wrapped and structural_wrapper_close < 0
+                )
                 return result
 
         return None


### PR DESCRIPTION
Closes #1515

## What does this PR do?

- preserves literal `</tool_call>`, `</parameter>`, and `</function>` text inside Qwen string arguments
- keeps canonical JSON-encoded strings incremental, including chunk-split JSON escapes
- defers only the un-emitted suffix once an escaping-free legacy raw XML parameter is encountered; earlier canonical parameters remain incremental
- completes that same tool-call index at end of stream from the full-text parser, where structural closers can be selected without an irreversible online guess
- adds direct parser and `StreamingPostProcessor.finalize()` regressions for all three closers

## Why is this needed?

The non-streaming #1515 cases are already correct on `main`, but streaming still treated the first XML-looking closer inside an argument as structure. That silently truncated agent arguments and could leak the remainder as content. In an unescaped raw XML stream, a literal closer at a chunk boundary is indistinguishable from a structural closer until the output is complete; this change makes that ambiguity explicit instead of guessing.

## AI assistance disclosure

Codex reproduced the issue, implemented the parser and tests, and reviewed the behavior against the existing streaming, finalize, and value-fidelity contracts.

> By submitting this PR I confirm I can explain the intent, risk, and behavior of every non-generated change in this PR. For any generated / boilerplate / scaffolded sections, I have identified them above and can describe how I verified them.

## Test plan

- [x] Original streaming repro fails on `main` for all three closing markers
- [x] Canonical JSON strings continue to emit multiple incremental deltas
- [x] Chunk-split JSON escapes and embedded XML closers preserve exact values
- [x] Legacy raw argument bytes are held and finalize completes the exact same tool-call JSON
- [x] Related parser/postprocessor matrix: 981 passed, 28 skipped
- [x] Full unit suite: 16683 passed, 60 skipped, 6 xfailed, 1 xpassed
- [x] `ruff check`
- [x] `git diff --check`

Codex review and repository PR validation: MERGE-SAFE, 0 blocking findings.

## Checklist

- [x] Critical parser tests were confirmed failing before the production fix
- [x] README/docs update not applicable
- [x] No breaking API changes
