### PR TITLE
fix(cache): reuse first-turn prefix on turn two

### DIFF
--- a/tests/test_prefix_boundary_path_parity.py
+++ b/tests/test_prefix_boundary_path_parity.py
@@ -266,6 +266,34 @@ def test_prefix_boundary_prefers_latest_stable_message_boundary(monkeypatch):
     assert engine._compute_prefix_boundary(messages) == len(stable) - 8
 
 
+def test_first_turn_saves_stable_boundary_before_generation_suffix(monkeypatch):
+    """Turn one must seed the cache boundary that turn two actually shares.
+
+    Returning zero merely because the first user is at index zero falls back
+    to the scheduler's generic N-1 snapshot. For templates whose generation
+    suffix is several tokens long, that entry extends past the next turn's
+    shared prefix and a non-trimmable cache cannot reuse it (#1611).
+    """
+    engine, _ = _build_engine(monkeypatch)
+    engine._compute_prefix_boundary = BatchedEngine._compute_prefix_boundary.__get__(
+        engine, BatchedEngine
+    )
+    engine._tokenizer = _CharacterTokenizer()
+
+    def render(messages, tools=None, *, add_generation_prompt=True, **kwargs):
+        body = "|".join(str(message.get("content", "")) for message in messages)
+        return body + ("|ASSISTANT_GENERATION" if add_generation_prompt else "")
+
+    monkeypatch.setattr(engine, "_apply_chat_template", render)
+    messages = [{"role": "user", "content": "first turn"}]
+    stable = render(messages, add_generation_prompt=False)
+
+    boundary = engine._compute_prefix_boundary(messages)
+
+    assert boundary == len(stable) - 8
+    assert 0 < boundary < len(render(messages, add_generation_prompt=True)) - 1
+
+
 def test_prefix_boundary_stops_before_transient_server_priming(monkeypatch):
     """A server-only reminder is absent from the client's next request."""
     engine, _ = _build_engine(monkeypatch)

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -2261,7 +2261,7 @@ class BatchedEngine(BaseEngine):
             if messages[i].get("role") == "user":
                 last_user_idx = i
                 break
-        if last_user_idx is None or last_user_idx == 0:
+        if last_user_idx is None:
             return 0
         try:
             template_tools = convert_tools_for_template(tools) if tools else None


### PR DESCRIPTION
## What does this PR do?

Allows the first user turn to compute the same conservative stable prefix boundary used by later turns, so non-trimmable hybrid caches can reuse it on turn two.

## Why is this needed?

Fixes #1611. The previous `last_user_idx == 0` guard skipped the stable boundary on turn one and fell back to an N-1 snapshot. For chat templates with a multi-token assistant-generation suffix, that snapshot extended three tokens past the next request shared prefix, forcing a full turn-two cache miss.

## AI assistance disclosure

Codex reproduced the issue, wrote the one-line production fix and regression test in `vllm_mlx/engine/batched.py` and `tests/test_prefix_boundary_path_parity.py`, independently reviewed the committed diff twice, and verified it with focused and broad cache suites plus a live Qwen3.5-4B three-turn run. The maintainer can explain the intent, risk, and behavior of every change.

> By submitting this PR I confirm I can explain the intent, risk, and behavior of every non-generated change in this PR. For any generated / boilerplate / scaffolded sections, I have identified them above and can describe how I verified them.

## Test plan

- [x] Exact negative control: restoring `last_user_idx == 0` makes `test_first_turn_saves_stable_boundary_before_generation_suffix` fail with `boundary 0 != 2`; restoring the fix passes
- [x] Cache regression selection: 275 passed
- [x] Full unit: 16,600 passed, 123 skipped, 18 deselected, 6 xfailed, 1 xpassed
- [x] Ruff lint and format checks pass
- [x] Live Qwen3.5-4B: turn two changed from 5.210s MISS to 0.458s HIT (`cached_tokens=3008`)
- [x] Codex review converged twice with zero blocking findings
- [x] Local `pr_validate 1732`: MERGE-SAFE; stress explicitly skipped because the 18GB host cannot meet the registry's 26GB minimum including OS headroom
- [x] GitHub CI and all five live L1 smoke checks pass

## Checklist

- [x] Tests pass locally
- [x] Lint passes
- [x] Self-validated with `python -m scripts.pr_validate 1732`
- [x] Critical-path negative control reproduced locally
- [x] No dependency or supply-chain files changed
- [x] No breaking API changes

## Validation note

A full four-family stress run was attempted on the 256GB Mac Studio. Qwen3.5 and Qwen3.6 advanced before the SSH connection was reset while entering DiffusionGemma; the host then became unreachable. This is recorded as an incomplete infrastructure attempt, not as a passing gate. The issue-specific live Qwen3.5 reproduction and GitHub's five live model smokes are green.