### PR TITLE
fix responses streaming reasoning sanitization

### DIFF
--- a/tests/test_r12_reasoning_sanitizer_required.py
+++ b/tests/test_r12_reasoning_sanitizer_required.py
@@ -61,6 +61,7 @@ from vllm_mlx.api.models import (
     ChatCompletionChunkDelta,
 )
 from vllm_mlx.api.utils import (
+    StreamingReasoningSanitizer,
     sanitize_output,
     sanitize_reasoning_content,
     sanitize_reasoning_for_stream,
@@ -93,6 +94,79 @@ class TestSanitizeReasoningHelpers:
     single source of truth — pin their contract here so the field
     validators can rely on it without re-asserting per-call-site.
     """
+
+    def test_streaming_sanitizer_removes_cascading_cross_destination_marker(self):
+        sanitizer = StreamingReasoningSanitizer()
+        parts = sanitizer.process("<</tool_call>", "reasoning")
+        parts += sanitizer.process("/tool_call>", "content")
+        parts += sanitizer.flush()
+        assert parts == []
+
+    @pytest.mark.parametrize("marker", _LEAK_MARKERS)
+    def test_streaming_sanitizer_carries_every_canonical_marker(self, marker):
+        for split_at in range(1, len(marker)):
+            sanitizer = StreamingReasoningSanitizer()
+            parts = sanitizer.process(marker[:split_at], "reasoning")
+            parts += sanitizer.transition_to_content(marker[split_at:])
+            parts += sanitizer.flush()
+            assert parts == [], (marker, split_at, parts)
+
+    def test_streaming_sanitizer_does_not_buffer_ordinary_brackets(self):
+        sanitizer = StreamingReasoningSanitizer()
+        assert sanitizer.process("items [1, 2]", "reasoning") == [
+            ("reasoning", "items [1, 2]")
+        ]
+        assert sanitizer.flush() == []
+
+    def test_streaming_sanitizer_carries_across_multiple_content_chunks(self):
+        sanitizer = StreamingReasoningSanitizer()
+        parts = sanitizer.process("</tool_", "reasoning")
+        parts += sanitizer.transition_to_content("ca")
+        parts += sanitizer.transition_to_content("ll>answer")
+        parts += sanitizer.flush()
+        assert parts == [("content", "answer")]
+
+    def test_streaming_sanitizer_carries_calling_tool_payload(self):
+        sanitizer = StreamingReasoningSanitizer()
+        parts = sanitizer.process("plan [Calling tool foo", "reasoning")
+        parts += sanitizer.process("] next", "reasoning")
+        parts += sanitizer.flush()
+        assert parts == [("reasoning", "plan "), ("reasoning", " next")]
+
+    def test_streaming_sanitizer_bounds_unterminated_calling_tool_payload(self):
+        sanitizer = StreamingReasoningSanitizer()
+        parts = sanitizer.process("[Calling tool " + "x" * 200, "reasoning")
+        parts += sanitizer.flush()
+        assert parts == []
+
+    def test_streaming_sanitizer_does_not_consume_content_after_calling_prefix(self):
+        sanitizer = StreamingReasoningSanitizer()
+        parts = sanitizer.process("[Calling tool ", "reasoning")
+        parts += sanitizer.transition_to_content("legitimate answer")
+        parts += sanitizer.flush()
+        assert parts == [("content", "legitimate answer")]
+
+    def test_streaming_sanitizer_tracks_overflow_reasoning_origin(self):
+        sanitizer = StreamingReasoningSanitizer()
+        parts = sanitizer.process("</tool_", "reasoning_overflow")
+        parts += sanitizer.transition_to_content("call>answer")
+        parts += sanitizer.flush()
+        assert parts == [("content", "answer")]
+
+    def test_streaming_sanitizer_preserves_terminal_marker_prefix(self):
+        sanitizer = StreamingReasoningSanitizer()
+        assert sanitizer.process("answer</tool_", "reasoning") == [
+            ("reasoning", "answer")
+        ]
+        assert sanitizer.flush() == [("reasoning", "</tool_")]
+
+    @pytest.mark.parametrize("suffix", ["<", "["])
+    def test_streaming_sanitizer_preserves_terminal_literal_punctuation(self, suffix):
+        sanitizer = StreamingReasoningSanitizer()
+        assert sanitizer.process("compare " + suffix, "reasoning") == [
+            ("reasoning", "compare ")
+        ]
+        assert sanitizer.flush() == [("reasoning", suffix)]
 
     @pytest.mark.parametrize("marker", _LEAK_MARKERS)
     def test_sanitize_reasoning_content_strips_marker(self, marker):

--- a/tests/test_responses_engine_failure_envelope.py
+++ b/tests/test_responses_engine_failure_envelope.py
@@ -18,6 +18,7 @@ trips a CI failure rather than waiting for another dogfood report.
 """
 
 import asyncio
+import importlib.util
 import json
 import sys
 import types
@@ -28,6 +29,11 @@ from typing import Any
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+
+_REQUIRES_MLX = pytest.mark.skipif(
+    importlib.util.find_spec("mlx") is None,
+    reason="full Responses route imports require Apple MLX",
+)
 
 
 @pytest.mark.asyncio
@@ -333,6 +339,124 @@ class _ReasoningOnlyStopEngine:
                 finished=i == len(chunks) - 1,
                 channel="reasoning",
             )
+
+
+class _ReasoningMarkerThenContentEngine:
+    """Reasoning-channel parser residue followed by a normal final answer."""
+
+    preserve_native_tool_format = False
+
+    def __init__(self):
+        self.tokenizer = _Tokenizer()
+
+    async def stream_chat(self, messages, **kwargs):
+        yield _GenerationOutput(
+            text="plan </tool_",
+            new_text="plan </tool_",
+            prompt_tokens=7,
+            completion_tokens=2,
+            finish_reason=None,
+            finished=False,
+            channel="reasoning",
+        )
+        yield _GenerationOutput(
+            text="plan </tool_call> next ",
+            new_text="call> next ",
+            completion_tokens=4,
+            finish_reason=None,
+            finished=False,
+            channel="reasoning",
+        )
+        yield _GenerationOutput(
+            text="answer",
+            new_text="answer",
+            completion_tokens=5,
+            finish_reason="stop",
+            finished=True,
+            channel="content",
+        )
+
+
+class _ReasoningMarkerAcrossCapEngine:
+    """The reasoning cap divides a closer between kept and overflow bytes."""
+
+    preserve_native_tool_format = False
+
+    def __init__(self):
+        self.tokenizer = _Tokenizer()
+
+    async def stream_chat(self, messages, **kwargs):
+        yield _GenerationOutput(
+            text="abc</tool_call>answer",
+            new_text="abc</tool_call>answer",
+            prompt_tokens=7,
+            completion_tokens=5,
+            finish_reason="stop",
+            finished=True,
+            channel="reasoning",
+        )
+
+
+class _ReasoningMarkerAcrossChannelEngine:
+    preserve_native_tool_format = False
+
+    def __init__(self):
+        self.tokenizer = _Tokenizer()
+
+    async def stream_chat(self, messages, **kwargs):
+        yield _GenerationOutput(
+            text="plan </tool_",
+            new_text="plan </tool_",
+            prompt_tokens=7,
+            completion_tokens=2,
+            finish_reason=None,
+            finished=False,
+            channel="reasoning",
+        )
+        yield _GenerationOutput(
+            text="call>answer",
+            new_text="call>answer",
+            completion_tokens=4,
+            finish_reason="stop",
+            finished=True,
+            channel="content",
+        )
+
+
+class _ReasoningFalsePrefixAcrossCapEngine:
+    preserve_native_tool_format = False
+
+    def __init__(self):
+        self.tokenizer = _Tokenizer()
+
+    async def stream_chat(self, messages, **kwargs):
+        yield _GenerationOutput(
+            text="abc<answer",
+            new_text="abc<answer",
+            prompt_tokens=7,
+            completion_tokens=3,
+            finish_reason="stop",
+            finished=True,
+            channel="reasoning",
+        )
+
+
+class _ReasoningOverflowPartialPrefixEngine:
+    preserve_native_tool_format = False
+
+    def __init__(self):
+        self.tokenizer = _Tokenizer()
+
+    async def stream_chat(self, messages, **kwargs):
+        yield _GenerationOutput(
+            text="abcdanswer<",
+            new_text="abcdanswer<",
+            prompt_tokens=7,
+            completion_tokens=3,
+            finish_reason="stop",
+            finished=True,
+            channel="reasoning",
+        )
 
 
 class _ReasoningThenWhitespaceStopEngine:
@@ -748,6 +872,41 @@ def immediate_stop_client(monkeypatch):
 @pytest.fixture
 def reasoning_only_stop_client(monkeypatch):
     holder = _build_client(monkeypatch, _ReasoningOnlyStopEngine)
+    yield holder
+    holder.cleanup()
+
+
+@pytest.fixture
+def reasoning_marker_then_content_client(monkeypatch):
+    holder = _build_client(monkeypatch, _ReasoningMarkerThenContentEngine)
+    yield holder
+    holder.cleanup()
+
+
+@pytest.fixture
+def reasoning_marker_across_cap_client(monkeypatch):
+    holder = _build_client(monkeypatch, _ReasoningMarkerAcrossCapEngine)
+    yield holder
+    holder.cleanup()
+
+
+@pytest.fixture
+def reasoning_marker_across_channel_client(monkeypatch):
+    holder = _build_client(monkeypatch, _ReasoningMarkerAcrossChannelEngine)
+    yield holder
+    holder.cleanup()
+
+
+@pytest.fixture
+def reasoning_false_prefix_across_cap_client(monkeypatch):
+    holder = _build_client(monkeypatch, _ReasoningFalsePrefixAcrossCapEngine)
+    yield holder
+    holder.cleanup()
+
+
+@pytest.fixture
+def reasoning_overflow_partial_prefix_client(monkeypatch):
+    holder = _build_client(monkeypatch, _ReasoningOverflowPartialPrefixEngine)
     yield holder
     holder.cleanup()
 
@@ -1243,6 +1402,130 @@ class TestResponsesStreamFailureEnvelope:
             and d.get("item", {}).get("type") == "reasoning"
         ]
         assert reasoning_done, "reasoning item should still be closed for diagnostics"
+
+    @_REQUIRES_MLX
+    def test_streaming_reasoning_sanitizes_tool_call_closer(
+        self, reasoning_marker_then_content_client
+    ):
+        """Raw decode residue must not reach any public reasoning SSE field."""
+        with reasoning_marker_then_content_client.client.stream(
+            "POST",
+            "/v1/responses",
+            json={**PAYLOAD, "stream": True},
+            headers=HEADERS,
+        ) as resp:
+            body = "".join(resp.iter_text())
+        assert resp.status_code == 200, body
+        events = _parse_sse(body)
+
+        public_reasoning = []
+        for name, data in events:
+            if name == "response.reasoning_summary_text.delta":
+                public_reasoning.append(data["delta"])
+            elif name == "response.reasoning_summary_text.done":
+                public_reasoning.append(data["text"])
+            elif name == "response.reasoning_summary_part.done":
+                public_reasoning.append(data["part"]["text"])
+            elif (
+                name == "response.output_item.done"
+                and data.get("item", {}).get("type") == "reasoning"
+            ):
+                public_reasoning.extend(
+                    part["text"] for part in data["item"].get("summary", [])
+                )
+
+        assert public_reasoning
+        assert all("</tool_call>" not in text for text in public_reasoning)
+        assert "plan  next " in public_reasoning
+
+    @_REQUIRES_MLX
+    def test_streaming_reasoning_sanitizes_closer_across_budget_boundary(
+        self, reasoning_marker_across_cap_client
+    ):
+        """The kept/overflow split must not defeat marker recognition."""
+        with reasoning_marker_across_cap_client.client.stream(
+            "POST",
+            "/v1/responses",
+            json={**PAYLOAD, "stream": True, "reasoning_max_tokens": 1},
+            headers=HEADERS,
+        ) as resp:
+            body = "".join(resp.iter_text())
+        assert resp.status_code == 200, body
+        assert "</tool_call>" not in body
+        events = _parse_sse(body)
+        reasoning = "".join(
+            data["delta"]
+            for name, data in events
+            if name == "response.reasoning_summary_text.delta"
+        )
+        content = "".join(
+            data["delta"]
+            for name, data in events
+            if name == "response.output_text.delta"
+        )
+        assert reasoning == "abc"
+        assert content == "answer"
+
+    @_REQUIRES_MLX
+    def test_streaming_reasoning_sanitizes_closer_across_channel_boundary(
+        self, reasoning_marker_across_channel_client
+    ):
+        with reasoning_marker_across_channel_client.client.stream(
+            "POST",
+            "/v1/responses",
+            json={**PAYLOAD, "stream": True},
+            headers=HEADERS,
+        ) as resp:
+            body = "".join(resp.iter_text())
+        assert resp.status_code == 200, body
+        assert "</tool_call>" not in body
+        events = _parse_sse(body)
+        reasoning = "".join(
+            data["delta"]
+            for name, data in events
+            if name == "response.reasoning_summary_text.delta"
+        )
+        content = "".join(
+            data["delta"]
+            for name, data in events
+            if name == "response.output_text.delta"
+        )
+        assert reasoning == "plan "
+        assert content == "answer"
+
+    @_REQUIRES_MLX
+    @pytest.mark.parametrize(
+        ("client_fixture", "expected_reasoning", "expected_content"),
+        [
+            ("reasoning_false_prefix_across_cap_client", "abc<", "answer"),
+            ("reasoning_overflow_partial_prefix_client", "abcd", "answer<"),
+        ],
+    )
+    def test_streaming_reasoning_preserves_false_prefix_destination(
+        self, request, client_fixture, expected_reasoning, expected_content
+    ):
+        holder = request.getfixturevalue(client_fixture)
+        with holder.client.stream(
+            "POST",
+            "/v1/responses",
+            json={**PAYLOAD, "stream": True, "reasoning_max_tokens": 1},
+            headers=HEADERS,
+        ) as resp:
+            body = "".join(resp.iter_text())
+        assert resp.status_code == 200, body
+        events = _parse_sse(body)
+        reasoning = "".join(
+            data["delta"]
+            for name, data in events
+            if name == "response.reasoning_summary_text.delta"
+        )
+        content = "".join(
+            data["delta"]
+            for name, data in events
+            if name == "response.output_text.delta"
+        )
+        assert reasoning == expected_reasoning
+        assert content == expected_content
 
     def test_reasoning_only_failure_closes_summary_events_before_failed(
         self, reasoning_only_stop_client

--- a/vllm_mlx/api/utils.py
+++ b/vllm_mlx/api/utils.py
@@ -298,6 +298,171 @@ def sanitize_reasoning_for_stream(text: str | None) -> str:
     return _sanitize_for_stream(text, _REASONING_FINAL_SANITIZER)
 
 
+class StreamingReasoningSanitizer:
+    """Preserve canonical wire-marker carry across reasoning fragments.
+
+    ``sanitize_reasoning_for_stream`` is intentionally stateless.  Routes
+    that enforce the reasoning sanitizer must additionally retain suffixes
+    that can begin canonical wire markers; otherwise a token split can bypass
+    the per-fragment regex.  The finite set below is the literal-token portion
+    of :data:`_REASONING_FINAL_SANITIZER`; payload-shaped regex matches remain
+    handled by the stateless sanitizer once their complete fragment arrives.
+    """
+
+    _MARKERS = (
+        "</tool_call>",
+        "</think>",
+        "<|im_start|>",
+        "<|im_end|>",
+        "<|endoftext|>",
+        "<|channel|>",
+        "<|message|>",
+        "<|channel>",
+        "<|constrain|>",
+        "<|tool_call>",
+        "<tool_call|>",
+    )
+
+    def __init__(self) -> None:
+        self._pending: list[tuple[str, str]] = []
+
+    def process(self, text: str | None, destination: str) -> list[tuple[str, str]]:
+        items = self._pending + [(destination, ch) for ch in (text or "")]
+        self._pending = []
+        if not items:
+            return []
+
+        deferred_payload: list[tuple[str, str]] = []
+        raw_combined = "".join(ch for _, ch in items)
+        calling_at = raw_combined.rfind("[Calling")
+        calling_candidate = raw_combined[calling_at:] if calling_at >= 0 else ""
+        if (
+            calling_at >= 0
+            and len(calling_candidate) <= 128
+            and re.fullmatch(r"\[Calling\s+tool[^\]]*", calling_candidate)
+        ):
+            deferred_payload = items[calling_at:]
+            items = items[:calling_at]
+        items = self._remove_regex_matches(items)
+        kept: list[tuple[str, str]] = []
+        for item in items:
+            kept.append(item)
+            for marker in self._MARKERS:
+                marker_size = len(marker)
+                if len(kept) >= marker_size and all(
+                    kept[-marker_size + offset][1] == marker_char
+                    for offset, marker_char in enumerate(marker)
+                ):
+                    del kept[-marker_size:]
+                    break
+
+        kept_text = "".join(ch for _, ch in kept)
+        pending_at = self._pending_suffix_start(kept_text)
+        if pending_at >= 0:
+            self._pending = kept[pending_at:]
+            kept = kept[:pending_at]
+        if deferred_payload:
+            self._pending.extend(deferred_payload)
+        return self._group_and_sanitize(kept)
+
+    @classmethod
+    def _pending_suffix_start(cls, text: str) -> int:
+        max_carry = min(len(text), 128)
+        calling_prefix = "[Calling tool"
+        for size in range(max_carry, 0, -1):
+            suffix = text[-size:]
+            if any(marker.startswith(suffix) for marker in cls._MARKERS):
+                return len(text) - size
+            if calling_prefix.startswith(suffix):
+                return len(text) - size
+            if re.fullmatch(r"\[Calling\s+tool[^\]]*", suffix):
+                return len(text) - size
+        return -1
+
+    def flush(self) -> list[tuple[str, str]]:
+        pending = self._pending
+        self._pending = []
+        return self._group_and_sanitize(pending)
+
+    def transition_to_content(self, text: str | None) -> list[tuple[str, str]]:
+        """Resolve a reasoning-side prefix without sanitizing content prose."""
+        content = text or ""
+        if not self._pending:
+            return [("content", content)] if content else []
+        pending_text = "".join(ch for _, ch in self._pending)
+        if pending_text.startswith("[Calling"):
+            pending = self._pending
+            self._pending = []
+            parts = self._group_and_sanitize(pending)
+            if content:
+                parts.append(("content", content))
+            return parts
+        items = self._pending + [("content", ch) for ch in content]
+        self._pending = []
+        items = self._remove_regex_matches(
+            items,
+            require_reasoning_origin=True,
+        )
+        combined = "".join(ch for _, ch in items)
+        pending_at = self._pending_suffix_start(combined)
+        if pending_at >= 0 and any(
+            destination != "content" for destination, _ in items[pending_at:]
+        ):
+            self._pending = items[pending_at:]
+            items = items[:pending_at]
+        return self._group_and_sanitize(items, sanitize_content=False)
+
+    @staticmethod
+    def _remove_regex_matches(
+        items: list[tuple[str, str]],
+        *,
+        require_reasoning_origin: bool = False,
+    ) -> list[tuple[str, str]]:
+        while items:
+            combined = "".join(ch for _, ch in items)
+            spans = []
+            for match in _REASONING_FINAL_SANITIZER.finditer(combined):
+                if require_reasoning_origin and not any(
+                    destination != "content"
+                    for destination, _ in items[match.start() : match.end()]
+                ):
+                    continue
+                spans.append((match.start(), match.end()))
+            if not spans:
+                return items
+            removed = [False] * len(items)
+            for start, end in spans:
+                removed[start:end] = [True] * (end - start)
+            items = [item for index, item in enumerate(items) if not removed[index]]
+        return items
+
+    @staticmethod
+    def _group_and_sanitize(
+        items: list[tuple[str, str]], *, sanitize_content: bool = True
+    ) -> list[tuple[str, str]]:
+        grouped: list[tuple[str, str]] = []
+        current_destination: str | None = None
+        current_chars: list[str] = []
+        for destination, char in items:
+            if current_destination is not None and destination != current_destination:
+                grouped.append((current_destination, "".join(current_chars)))
+                current_chars = []
+            current_destination = destination
+            current_chars.append(char)
+        if current_destination is not None:
+            grouped.append((current_destination, "".join(current_chars)))
+        result = []
+        for destination, text in grouped:
+            cleaned = (
+                sanitize_reasoning_for_stream(text)
+                if sanitize_content or destination != "content"
+                else text
+            )
+            if cleaned:
+                result.append((destination, cleaned))
+        return result
+
+
 def sanitize_content_for_stream(text: str | None) -> str:
     """Streaming variant of :func:`sanitize_output` for ``content``.
 

--- a/vllm_mlx/routes/responses.py
+++ b/vllm_mlx/routes/responses.py
@@ -65,6 +65,7 @@ from ..api.tool_calling import (
     validate_output_against_schema,
 )
 from ..api.utils import (
+    StreamingReasoningSanitizer,
     StreamingThinkRouter,
     StreamingToolCallFilter,
     clean_output_text,
@@ -2874,6 +2875,42 @@ async def _stream_responses(
         # accumulator + the post-loop emitter below close the cross-path
         # parity gap.
         accumulated_reasoning_text = ""
+        reasoning_sanitizer = StreamingReasoningSanitizer()
+        reasoning_stream_seen = False
+
+        def _route_sanitized_reasoning(
+            parts: list[tuple[str, str]],
+        ) -> str:
+            nonlocal accumulated_reasoning_text
+            content_parts: list[str] = []
+            for destination, text in parts:
+                if destination == "reasoning":
+                    accumulated_reasoning_text += text
+                else:
+                    content_parts.append(text)
+            return "".join(content_parts)
+
+        def _append_reasoning(text: str | None) -> str:
+            nonlocal reasoning_stream_seen
+            if text:
+                reasoning_stream_seen = True
+            return _route_sanitized_reasoning(
+                reasoning_sanitizer.process(text, "reasoning")
+            )
+
+        def _sanitize_reasoning_overflow(text: str | None) -> str:
+            return _route_sanitized_reasoning(
+                reasoning_sanitizer.process(text, "reasoning_overflow")
+            )
+
+        def _transition_reasoning_to_content(text: str | None) -> str:
+            return _route_sanitized_reasoning(
+                reasoning_sanitizer.transition_to_content(text)
+            )
+
+        def _flush_reasoning_sanitizer() -> str:
+            return _route_sanitized_reasoning(reasoning_sanitizer.flush())
+
         terminal_reasoning_sidecar_seen = False
 
         # R11-B codex r7 BLOCKING: track an explicit "reasoning closed"
@@ -3246,6 +3283,18 @@ async def _stream_responses(
                 },
             )
 
+        async def _emit_reasoning_fragment(text: str | None) -> AsyncIterator[str]:
+            released_content = _append_reasoning(text)
+            if not released_content:
+                return
+            content = strip_special_tokens(released_content)
+            if not content:
+                return
+            filtered = tool_filter.process(content)
+            if filtered:
+                async for ev in _emit_text_delta(filtered):
+                    yield ev
+
         async def _flush_deferred_text_if_no_synthesis(
             will_synthesise: bool,
         ) -> AsyncIterator[str]:
@@ -3360,7 +3409,9 @@ async def _stream_responses(
                     # reasoning overflow reclassified via
                     # _account_for_reasoning below).
                     reasoning_block_closed = True
-                    content = strip_special_tokens(delta_text)
+                    content = strip_special_tokens(
+                        _transition_reasoning_to_content(delta_text)
+                    )
                     if content:
                         filtered = tool_filter.process(content)
                         if filtered:
@@ -3397,7 +3448,8 @@ async def _stream_responses(
                     # as ``content`` per the original contract).
                     kept_reasoning, overflow, _ = _account_for_reasoning(delta_text)
                     if kept_reasoning:
-                        accumulated_reasoning_text += kept_reasoning
+                        async for ev in _emit_reasoning_fragment(kept_reasoning):
+                            yield ev
                     # Reasoning-cap reclassification: once the per-request
                     # cap fires, route the overflow portion of this and
                     # every subsequent reasoning chunk to ``content`` so
@@ -3405,7 +3457,9 @@ async def _stream_responses(
                     # unending silent reasoning stream. Without the cap
                     # the chunk drops as before (v1 Responses contract).
                     if overflow:
-                        content = strip_special_tokens(overflow)
+                        content = strip_special_tokens(
+                            _sanitize_reasoning_overflow(overflow)
+                        )
                         if content:
                             filtered = tool_filter.process(content)
                             if filtered:
@@ -3470,6 +3524,7 @@ async def _stream_responses(
                     _reasoning_close_injected = True
                 if delta_msg is None:
                     continue
+                raw_overflow_content = ""
                 # R11-B codex r7 BLOCKING: latch the close signal from
                 # the PARSER'S OWN content output (i.e. ``delta_msg.content``
                 # populated by ``extract_reasoning_streaming`` BEFORE any
@@ -3506,7 +3561,8 @@ async def _stream_responses(
                     # has something to ship when the engine cuts off
                     # mid-think under ``max_output_tokens``.
                     if kept_reasoning:
-                        accumulated_reasoning_text += kept_reasoning
+                        async for ev in _emit_reasoning_fragment(kept_reasoning):
+                            yield ev
                     flip_succeeded = _reasoning_close_injected
                     if overflow and not _reasoning_close_injected:
                         # Codex round-10 BLOCKING #2: flip the latch
@@ -3571,9 +3627,21 @@ async def _stream_responses(
                         # (``_reasoning_close_injected`` was already
                         # True on entry, captured in ``flip_succeeded``
                         # via the initial assignment above).
-                        delta_msg.content = (delta_msg.content or "") + overflow
+                        raw_overflow_content = overflow
                 if delta_msg.content:
-                    content = strip_special_tokens(delta_msg.content)
+                    content = strip_special_tokens(
+                        _transition_reasoning_to_content(delta_msg.content)
+                    )
+                    if content:
+                        filtered = tool_filter.process(content)
+                        if filtered:
+                            async for ev in _emit_text_delta(filtered):
+                                yield ev
+                if raw_overflow_content:
+                    sanitized_overflow_content = _sanitize_reasoning_overflow(
+                        raw_overflow_content
+                    )
+                    content = strip_special_tokens(sanitized_overflow_content)
                     if content:
                         filtered = tool_filter.process(content)
                         if filtered:
@@ -3602,6 +3670,7 @@ async def _stream_responses(
                     # post-``</think>`` bytes to the "text" block —
                     # that's the close signal for this path.
                     reasoning_block_closed = True
+                    piece = _transition_reasoning_to_content(piece)
                     async for ev in _emit_text_delta(piece):
                         yield ev
                 elif block_type == "thinking" and piece:
@@ -3609,12 +3678,14 @@ async def _stream_responses(
                     # reasoning-item emitter has bytes to ship under
                     # ``max_output_tokens`` cutoffs. Same rationale as
                     # the reasoning_parser path above.
-                    accumulated_reasoning_text += piece
+                    async for ev in _emit_reasoning_fragment(piece):
+                        yield ev
 
         # Flush filters
         remaining = tool_filter.flush()
         if remaining:
             if reasoning_parser:
+                remaining = _transition_reasoning_to_content(remaining)
                 async for ev in _emit_text_delta(remaining):
                     yield ev
             else:
@@ -3622,25 +3693,29 @@ async def _stream_responses(
                     if block_type == "text" and piece:
                         # R11-B codex r7 BLOCKING: see in-loop branch.
                         reasoning_block_closed = True
+                        piece = _transition_reasoning_to_content(piece)
                         async for ev in _emit_text_delta(piece):
                             yield ev
                     elif block_type == "thinking" and piece:
                         # R11-B: same rationale as the in-loop think_router
                         # branch above — preserve mid-think bytes for the
                         # terminal reasoning output item.
-                        accumulated_reasoning_text += piece
+                        async for ev in _emit_reasoning_fragment(piece):
+                            yield ev
 
         if not reasoning_parser:
             for block_type, piece in think_router.flush():
                 if block_type == "text" and piece:
                     # R11-B codex r7 BLOCKING: see in-loop branch.
                     reasoning_block_closed = True
+                    piece = _transition_reasoning_to_content(piece)
                     async for ev in _emit_text_delta(piece):
                         yield ev
                 elif block_type == "thinking" and piece:
                     # R11-B: same rationale as the in-loop think_router
                     # branch above.
-                    accumulated_reasoning_text += piece
+                    async for ev in _emit_reasoning_fragment(piece):
+                        yield ev
 
         # Codex round-3 BLOCKING #3: if the reasoning cap latched on the
         # last engine chunk of the stream (terminal exact-boundary case
@@ -3699,7 +3774,9 @@ async def _stream_responses(
                 )
                 final_inject = None
             if final_inject is not None and getattr(final_inject, "content", None):
-                content = strip_special_tokens(final_inject.content)
+                content = strip_special_tokens(
+                    _transition_reasoning_to_content(final_inject.content)
+                )
                 if content:
                     filtered = tool_filter.process(content)
                     if filtered:
@@ -3750,7 +3827,9 @@ async def _stream_responses(
                 else None
             )
             if final_msg and final_msg.content:
-                content = strip_special_tokens(final_msg.content)
+                content = strip_special_tokens(
+                    _transition_reasoning_to_content(final_msg.content)
+                )
                 if content:
                     async for ev in _emit_text_delta(content):
                         yield ev
@@ -3769,7 +3848,23 @@ async def _stream_responses(
                 and getattr(final_msg, "reasoning", None)
                 and not accumulated_reasoning_text
             ):
-                accumulated_reasoning_text += final_msg.reasoning
+                if reasoning_stream_seen:
+                    reasoning_sanitizer = StreamingReasoningSanitizer()
+                async for ev in _emit_reasoning_fragment(final_msg.reasoning):
+                    yield ev
+
+        sanitized_overflow_tail = _flush_reasoning_sanitizer()
+        if sanitized_overflow_tail:
+            content = strip_special_tokens(sanitized_overflow_tail)
+            if content:
+                filtered = tool_filter.process(content)
+                if filtered:
+                    async for ev in _emit_text_delta(filtered):
+                        yield ev
+        remaining = tool_filter.flush()
+        if remaining:
+            async for ev in _emit_text_delta(remaining):
+                yield ev
 
         # Parse tool_calls FIRST so the forced-choice deferred-text
         # resolution (Yuki F6 codex r1 BLOCKING #2) can decide whether


### PR DESCRIPTION
## Summary

- sanitize every `/v1/responses` streaming reasoning source before it reaches public summary events
- preserve raw reasoning-budget and parser transition boundaries while sanitizing both retained and overflow output
- add an end-to-end SSE regression covering summary delta/done, part done, and the terminal reasoning item

## Root cause

Non-streaming reasoning uses `sanitize_reasoning_content`, and Anthropic streaming was repaired by #1517. The Responses streaming adapter still accumulated explicit reasoning-channel, reasoning-parser, and think-router text verbatim. The shared accumulator was then serialized into every public reasoning summary field, allowing `</tool_call>` parser residue to leak to agent clients.

## Validation

- reproduced on `main@6b976ac3` with the new SSE regression (failed before the production change)
- `ruff check vllm_mlx/routes/responses.py tests/test_responses_engine_failure_envelope.py`
- `ruff format --check vllm_mlx/routes/responses.py tests/test_responses_engine_failure_envelope.py`
- 165 sanitizer/closer/route tests passed, 2 skipped
- 115 Responses and Anthropic adjacent streaming tests passed

Closes #1516
