### PR TITLE
docs: standardize PR closure records

### DIFF
--- a/docs/development/pr_merge_sop.md
+++ b/docs/development/pr_merge_sop.md
@@ -246,14 +246,16 @@ Before merge, the PR description must accurately reflect actual current state:
 
 Every landed issue/PR must end with a compact, evidence-backed closure record.
 Use the same eight rows, in this order, so a maintainer can audit the whole
-journey without reconstructing it from terminal logs:
+journey without reconstructing it from terminal logs. For docs, dependency,
+release, and maintenance PRs, an inapplicable row may say `n/a`, but must give
+the concrete reason it does not apply.
 
 | Item | Required evidence |
 |---|---|
-| Reproduction | The failing user-visible behavior, including the exact model/input/path and measured failure where applicable. |
+| Reproduction | The failing user-visible behavior, including the exact model/input/path and measured failure where applicable; maintenance PRs state the concrete toil or broken workflow instead. |
 | Root cause | The specific faulty branch or invariant and why adjacent paths are unaffected. |
 | Fix | The behavioral change, including preserved compatibility and fallback behavior. |
-| Wiring | The production entry point that supplies/consumes the new behavior; write `n/a` only when the fix is already on the live path. |
+| Wiring | The production entry point that supplies/consumes the new behavior; if it was already on the live path, name that path. Reserve `n/a` for changes with no runtime wiring and explain why. |
 | Tests | New regression cases, affected-suite totals, builds/lint, and any live-model result. |
 | `pr_validate` | Final verdict, full-unit count, Codex review rounds and blocking-finding count. Do not report this row green before an actual PR-number run. |
 | Land | PR number, merge method, resulting `main` SHA, and linked-issue terminal state. |

--- a/docs/development/pr_merge_sop.md
+++ b/docs/development/pr_merge_sop.md
@@ -242,6 +242,44 @@ Before merge, the PR description must accurately reflect actual current state:
 - If the squash subject contains `(#NN)` GitHub auto-suffix on a `chore: bump version to X.Y.Z` commit, override with `--subject` — the regex in `auto-release.yml` is strict.
 - After merge, verify `git log raullenchai/main --oneline -1` shows your squash commit.
 
+## Required closure record
+
+Every landed issue/PR must end with a compact, evidence-backed closure record.
+Use the same eight rows, in this order, so a maintainer can audit the whole
+journey without reconstructing it from terminal logs:
+
+| Item | Required evidence |
+|---|---|
+| Reproduction | The failing user-visible behavior, including the exact model/input/path and measured failure where applicable. |
+| Root cause | The specific faulty branch or invariant and why adjacent paths are unaffected. |
+| Fix | The behavioral change, including preserved compatibility and fallback behavior. |
+| Wiring | The production entry point that supplies/consumes the new behavior; write `n/a` only when the fix is already on the live path. |
+| Tests | New regression cases, affected-suite totals, builds/lint, and any live-model result. |
+| `pr_validate` | Final verdict, full-unit count, Codex review rounds and blocking-finding count. Do not report this row green before an actual PR-number run. |
+| Land | PR number, merge method, resulting `main` SHA, and linked-issue terminal state. |
+| Elapsed | Wall-clock time from reproduction start through verified land (for example, `Worked for 14m 15s`). |
+
+The narrative should also classify the path. A focused change with one root
+cause, a small diff, and a first-round zero-blocking Codex review is a
+“straight-through” path. If review or validation required iteration, name the
+finding and the corrective round instead of presenting it as straight-through.
+
+Example closure shape from issue #1706 / PR #1729:
+
+| Item | Result |
+|---|---|
+| Reproduction | Unit-level reproduction showed `AutoStartDecision.decide` returning `.promptDownload` for both a non-catalog alias and an over-memory alias. |
+| Root cause | The stored-alias return bypassed both catalog membership and the OOM guard already used by cached-scan resolution. |
+| Fix | `storedAliasIsServable` requires catalog membership and the OOM guard when a catalog snapshot is supplied, while preserving the legacy `nil` contract and valid not-yet-downloaded aliases. |
+| Wiring | `ContentView.runLaunchAutoStart` passes the aliases from `ModelCatalogCache.entries`; unmapped aliases now fall through to the picker. |
+| Tests | Six new regressions; the 31-test suite, adjacent 18-test launch suite, and `swift build` passed. |
+| `pr_validate` | `MERGE-SAFE`; supply chain and full unit (16,633 passed) green; Codex round 1 had zero blocking findings. |
+| Land | PR #1729 squash-merged to `main` at `bb497477`; issue #1706 auto-closed as completed. |
+| Elapsed | `Worked for 14m 15s`. |
+
+This record is the final handoff, not a substitute for the detailed PR body or
+the `pr_validate` scorecard.
+
 ## CI coverage of these steps
 
 The full `pr_validate` pipeline runs on every PR via `.github/workflows/pr-validate.yml` — the scorecard is posted as a PR comment so you can see verdicts without leaving the PR page. The table below maps each SOP step to its CI status:


### PR DESCRIPTION
## What does this PR do?

Adds a required eight-row closure record to the PR Merge SOP: reproduction, root cause, fix, wiring, tests, pr_validate, land, and elapsed time. It also records #1706 / #1729 as the canonical straight-through example.

## Why is this needed?

A green PR currently leaves its evidence scattered across terminal logs, PR comments, and merge state. A fixed closure shape makes every landed issue auditable and prevents incomplete validation attempts from being summarized as passes.

## AI assistance disclosure

Codex drafted `docs/development/pr_merge_sop.md` from the maintainer-provided #1706 closure example. The maintainer specified the workflow and example; Codex kept it as a docs-only change and verified the diff.

> By submitting this PR I confirm I can explain the intent, risk, and behavior of every non-generated change in this PR. For any generated / boilerplate / scaffolded sections, I have identified them above and can describe how I verified them.

## Test plan

- [x] `git diff --check`
- [x] Docs-only diff reviewed against the supplied #1706 / #1729 example
- [x] No runtime behavior changed

## Checklist

- [x] Documentation updated
- [x] No breaking API changes
- [x] No dependencies or workflows changed