### PR TITLE
fix(mac): cap desktop prefix-cache memory

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -2520,22 +2520,18 @@ final class ServerManager {
     /// Desktop-specific prefix-cache budget: the smallest of 8% physical RAM,
     /// 20% currently available RAM, and 4 GiB. The available-RAM clamp keeps
     /// this override from raising the engine's ordinary 20%-of-available
-    /// budget on a machine that is already under pressure. A missing
-    /// available-memory probe retains the physical-RAM policy; a zero physical
-    /// probe omits the override instead of manufacturing an invalid zero-byte
-    /// cache. Kept pure so the spawn contract is deterministic in tests.
+    /// budget on a machine that is already under pressure. If either probe
+    /// fails, omit the override and retain the engine's live available-memory
+    /// fallback instead of manufacturing an unsafe fixed ceiling. Kept pure so
+    /// the spawn contract is deterministic in tests.
     nonisolated internal static func desktopPrefixCacheMaxBytes(
         physicalRAMBytes: UInt64,
         availableRAMBytes: UInt64 = 0
     ) -> UInt64? {
-        guard physicalRAMBytes > 0 else { return nil }
+        guard physicalRAMBytes > 0, availableRAMBytes > 0 else { return nil }
         let fourGiB = UInt64(4) << 30
         let eightPercent = (physicalRAMBytes / 100) * 8
-        var ceiling = min(eightPercent, fourGiB)
-        if availableRAMBytes > 0 {
-            ceiling = min(ceiling, availableRAMBytes / 5)
-        }
-        return ceiling
+        return min(min(eightPercent, availableRAMBytes / 5), fourGiB)
     }
 }
 

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -1196,6 +1196,12 @@ final class ServerManager {
                 environmentAdditions: Self.serveEnvironmentAdditions(
                     bearer: bearer,
                     ambient: ProcessInfo.processInfo.environment,
+                    // Issue #1412: the engine's server-oriented default may
+                    // retain up to 20% of RAM in prefix-cache entries. The
+                    // desktop shares unified memory with foreground apps, so
+                    // give its sidecar a smaller, hardware-scaled ceiling.
+                    physicalRAMBytes: MacHardware.detect().physicalRAMBytes,
+                    availableRAMBytes: MemoryProbe.snapshot()?.freeBytes ?? 0,
                     // Issue #449: stamp the launcher's PID so the
                     // bundled rapid-mlx (>=PR #942) self-terminates
                     // when this process dies under SIGKILL. The
@@ -2392,6 +2398,8 @@ final class ServerManager {
     nonisolated internal static func serveEnvironmentAdditions(
         bearer: String,
         ambient: [String: String],
+        physicalRAMBytes: UInt64 = 0,
+        availableRAMBytes: UInt64 = 0,
         supervisorPID: Int32 = -1,
         modelsFolderOverride: String? = nil
     ) -> [String: String] {
@@ -2412,6 +2420,20 @@ final class ServerManager {
         // Layer 2: desktop-injected, always.
         if !bearer.isEmpty {
             env["RAPID_MLX_API_KEY"] = bearer
+        }
+        // Issue #1412: rapid-mlx defaults the prefix cache to 20% of
+        // available RAM, which is appropriate for a dedicated server but
+        // can push a 16/32 GB desktop Mac into swap while the user is also
+        // running a browser or IDE. Reserve at most 8% of physical RAM for the
+        // desktop sidecar, never exceed 20% of currently available RAM, and
+        // cap large machines at 4 GiB. This is a direct Layer-2 write: an
+        // ambient shell export must not defeat the app's memory-pressure
+        // policy for the child it owns.
+        if let prefixCacheMaxBytes = desktopPrefixCacheMaxBytes(
+            physicalRAMBytes: physicalRAMBytes,
+            availableRAMBytes: availableRAMBytes
+        ) {
+            env["RAPID_MLX_PREFIX_CACHE_MAX_BYTES"] = String(prefixCacheMaxBytes)
         }
         // Issue #449: stamp the launcher's PID into
         // ``RAPID_MLX_WATCHDOG_PPID`` so the sidecar's parent-PID
@@ -2493,6 +2515,27 @@ final class ServerManager {
         env["HF_HUB_DOWNLOAD_TIMEOUT"] = ambient["HF_HUB_DOWNLOAD_TIMEOUT"] ?? "300"
 
         return env
+    }
+
+    /// Desktop-specific prefix-cache budget: the smallest of 8% physical RAM,
+    /// 20% currently available RAM, and 4 GiB. The available-RAM clamp keeps
+    /// this override from raising the engine's ordinary 20%-of-available
+    /// budget on a machine that is already under pressure. A missing
+    /// available-memory probe retains the physical-RAM policy; a zero physical
+    /// probe omits the override instead of manufacturing an invalid zero-byte
+    /// cache. Kept pure so the spawn contract is deterministic in tests.
+    nonisolated internal static func desktopPrefixCacheMaxBytes(
+        physicalRAMBytes: UInt64,
+        availableRAMBytes: UInt64 = 0
+    ) -> UInt64? {
+        guard physicalRAMBytes > 0 else { return nil }
+        let fourGiB = UInt64(4) << 30
+        let eightPercent = (physicalRAMBytes / 100) * 8
+        var ceiling = min(eightPercent, fourGiB)
+        if availableRAMBytes > 0 {
+            ceiling = min(ceiling, availableRAMBytes / 5)
+        }
+        return ceiling
     }
 }
 

--- a/apps/rapid-mac/Tests/RapidTests/SpawnEnvAllowlistTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SpawnEnvAllowlistTests.swift
@@ -153,6 +153,61 @@ struct SpawnEnvAllowlistTests {
         #expect(env["PATH"] == "/usr/bin")
     }
 
+    // MARK: - desktop prefix-cache ceiling (issue #1412)
+
+    @Test("Desktop sidecar caps prefix cache at 8 percent of physical RAM")
+    func desktopPrefixCacheUsesPhysicalRAMFraction() {
+        let sixteenGiB = UInt64(16) << 30
+        let env = ServerManager.serveEnvironmentAdditions(
+            bearer: "b",
+            ambient: ["RAPID_MLX_PREFIX_CACHE_MAX_BYTES": "999999999999"],
+            physicalRAMBytes: sixteenGiB
+        )
+
+        let expected = (sixteenGiB / 100) * 8
+        #expect(env["RAPID_MLX_PREFIX_CACHE_MAX_BYTES"] == String(expected))
+    }
+
+    @Test("Desktop prefix-cache ceiling tops out at 4 GiB")
+    func desktopPrefixCacheHasAbsoluteCeiling() {
+        let env = ServerManager.serveEnvironmentAdditions(
+            bearer: "b",
+            ambient: [:],
+            physicalRAMBytes: UInt64(256) << 30
+        )
+
+        #expect(
+            env["RAPID_MLX_PREFIX_CACHE_MAX_BYTES"]
+                == String(UInt64(4) << 30)
+        )
+    }
+
+    @Test("Memory pressure cannot raise engine's available-RAM default")
+    func desktopPrefixCacheClampsToAvailableRAM() {
+        let env = ServerManager.serveEnvironmentAdditions(
+            bearer: "b",
+            ambient: [:],
+            physicalRAMBytes: UInt64(32) << 30,
+            availableRAMBytes: UInt64(8) << 30
+        )
+
+        #expect(
+            env["RAPID_MLX_PREFIX_CACHE_MAX_BYTES"]
+                == String((UInt64(8) << 30) / 5)
+        )
+    }
+
+    @Test("Unavailable RAM probe omits prefix-cache override")
+    func unavailableRAMProbeKeepsEngineFallback() {
+        let env = ServerManager.serveEnvironmentAdditions(
+            bearer: "b",
+            ambient: [:],
+            physicalRAMBytes: 0
+        )
+
+        #expect(env["RAPID_MLX_PREFIX_CACHE_MAX_BYTES"] == nil)
+    }
+
     // MARK: - empty ambient
 
     @Test("Empty ambient yields only the desktop-injected layer")

--- a/apps/rapid-mac/Tests/RapidTests/SpawnEnvAllowlistTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SpawnEnvAllowlistTests.swift
@@ -203,7 +203,7 @@ struct SpawnEnvAllowlistTests {
     func unavailablePhysicalRAMProbeKeepsEngineFallback() {
         let env = ServerManager.serveEnvironmentAdditions(
             bearer: "b",
-            ambient: [:],
+            ambient: ["RAPID_MLX_PREFIX_CACHE_MAX_BYTES": "999999999999"],
             physicalRAMBytes: 0,
             availableRAMBytes: UInt64(8) << 30
         )
@@ -215,7 +215,7 @@ struct SpawnEnvAllowlistTests {
     func unavailableFreeRAMProbeKeepsEngineFallback() {
         let env = ServerManager.serveEnvironmentAdditions(
             bearer: "b",
-            ambient: [:],
+            ambient: ["RAPID_MLX_PREFIX_CACHE_MAX_BYTES": "999999999999"],
             physicalRAMBytes: UInt64(32) << 30,
             availableRAMBytes: 0
         )

--- a/apps/rapid-mac/Tests/RapidTests/SpawnEnvAllowlistTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SpawnEnvAllowlistTests.swift
@@ -161,7 +161,8 @@ struct SpawnEnvAllowlistTests {
         let env = ServerManager.serveEnvironmentAdditions(
             bearer: "b",
             ambient: ["RAPID_MLX_PREFIX_CACHE_MAX_BYTES": "999999999999"],
-            physicalRAMBytes: sixteenGiB
+            physicalRAMBytes: sixteenGiB,
+            availableRAMBytes: sixteenGiB
         )
 
         let expected = (sixteenGiB / 100) * 8
@@ -173,7 +174,8 @@ struct SpawnEnvAllowlistTests {
         let env = ServerManager.serveEnvironmentAdditions(
             bearer: "b",
             ambient: [:],
-            physicalRAMBytes: UInt64(256) << 30
+            physicalRAMBytes: UInt64(256) << 30,
+            availableRAMBytes: UInt64(256) << 30
         )
 
         #expect(
@@ -197,12 +199,25 @@ struct SpawnEnvAllowlistTests {
         )
     }
 
-    @Test("Unavailable RAM probe omits prefix-cache override")
-    func unavailableRAMProbeKeepsEngineFallback() {
+    @Test("Unavailable physical RAM probe preserves engine fallback")
+    func unavailablePhysicalRAMProbeKeepsEngineFallback() {
         let env = ServerManager.serveEnvironmentAdditions(
             bearer: "b",
             ambient: [:],
-            physicalRAMBytes: 0
+            physicalRAMBytes: 0,
+            availableRAMBytes: UInt64(8) << 30
+        )
+
+        #expect(env["RAPID_MLX_PREFIX_CACHE_MAX_BYTES"] == nil)
+    }
+
+    @Test("Unavailable free RAM probe preserves engine fallback")
+    func unavailableFreeRAMProbeKeepsEngineFallback() {
+        let env = ServerManager.serveEnvironmentAdditions(
+            bearer: "b",
+            ambient: [:],
+            physicalRAMBytes: UInt64(32) << 30,
+            availableRAMBytes: 0
         )
 
         #expect(env["RAPID_MLX_PREFIX_CACHE_MAX_BYTES"] == nil)


### PR DESCRIPTION
## What does this PR do?

Injects a hardware-aware `RAPID_MLX_PREFIX_CACHE_MAX_BYTES` ceiling into every Rapid Desktop sidecar spawn. The ceiling is the minimum of 8% physical RAM, 20% currently available RAM, and 4 GiB.

## Why is this needed?

Fixes #1412. The engine default is server-oriented and permits prefix-cache growth up to 20% of available memory. In the desktop app that cache competes with the foreground browser, IDE, and the model itself in unified memory; dogfood measured 8.7 GiB and growing.

## AI assistance disclosure

Codex reproduced the missing spawn variable, implemented the Swift production wiring and four regression tests, and ran two adversarial review rounds. The first review found that a physical-RAM-only limit could exceed the engine default under pressure; the implementation was corrected to clamp against current available RAM. The maintainer can explain every change.

> By submitting this PR I confirm I can explain the intent, risk, and behavior of every non-generated change in this PR. For generated sections, I have identified them above and can describe how I verified them.

## Test plan

- [x] `swift build`
- [x] `swift build --target RapidTests` (new tests and full RapidTests module compile)
- [x] 16 GiB maps to 8% physical RAM
- [x] 256 GiB clamps to 4 GiB
- [x] 32 GiB host with 8 GiB available clamps to 20% available
- [x] failed physical-memory probe preserves engine fallback
- [x] Codex review round 2: zero findings

## Checklist

- [x] Tests compile locally
- [x] Full app builds locally
- [x] No dependency changes
- [x] No breaking API changes

Local `swift test` is blocked by existing #1638 because SwiftPM builds the unrelated RapidUXTests/XCTest target first; GitHub rapid-mac CI has the full Xcode test environment.