### PR TITLE
docs: bring the unreleased release notes up to date

### DIFF
--- a/apps/rapid-mac/CHANGELOG.md
+++ b/apps/rapid-mac/CHANGELOG.md
@@ -45,9 +45,14 @@ can actually understand.
   things a new user saw. Tools still live in Settings → Tools; the speed test
   is gone for the reason above.
 
-- **The model menu lists models.** "Refresh catalog", "Type a model name" and
-  the "N small models hidden" footer are gone; what remains is the quickstart
-  picks, the recommendations, and the full alphabetical list.
+- **The model menu focuses on models.** The "N small models hidden" footer is
+  gone, and "Refresh catalog" / "Type a model name…" now appear only when
+  there is nothing to pick — while the catalogue is still loading, or when it
+  came back empty — instead of sitting at the bottom of a working menu. A
+  normal menu is the quickstart picks, the recommendations, and the model
+  list, with models you have downloaded first. Models under 1B and
+  known-broken aliases stay hidden; the small ones can be shown from
+  Settings → Models.
 
 ### Fixed
 

--- a/apps/rapid-mac/CHANGELOG.md
+++ b/apps/rapid-mac/CHANGELOG.md
@@ -50,8 +50,9 @@ can actually understand.
   "Type a model name…" — those are now offered only when there is nothing to
   choose yet. What you get is the quickstart picks, the recommendations, and
   the model list, with the ones you have downloaded first in each group.
-  Models under 1B stay hidden unless you turn them on in Settings → Models,
-  except for the one you are currently using, which always shows.
+  Models under 1B stay hidden unless you turn them on in
+  Settings → Model Management, except for the one you are currently using,
+  which always shows.
 
 ### Fixed
 
@@ -68,8 +69,8 @@ can actually understand.
 - **"Browse all models" in the setup wizard opens the model catalogue.** It used
   to close the wizard instead — your chosen model was discarded and you landed
   on the chat surface pinned to a model you never picked. It now opens
-  Settings → Models with the wizard still behind it, so closing Settings puts
-  you back on your selection.
+  Settings → Model Management with the wizard still behind it, so closing
+  Settings puts you back on your selection.
 
 ## [0.12.7] — 2026-08-07
 

--- a/apps/rapid-mac/CHANGELOG.md
+++ b/apps/rapid-mac/CHANGELOG.md
@@ -46,13 +46,12 @@ can actually understand.
   is gone for the reason above.
 
 - **The model menu focuses on models.** The "N small models hidden" footer is
-  gone, and "Refresh catalog" / "Type a model name…" now appear only when
-  there is nothing to pick — while the catalogue is still loading, or when it
-  came back empty — instead of sitting at the bottom of a working menu. A
-  normal menu is the quickstart picks, the recommendations, and the model
-  list, with models you have downloaded first. Models under 1B and
-  known-broken aliases stay hidden; the small ones can be shown from
-  Settings → Models.
+  gone, and a menu with models in it no longer ends with "Refresh catalog" and
+  "Type a model name…" — those are now offered only when there is nothing to
+  choose yet. What you get is the quickstart picks, the recommendations, and
+  the model list, with the ones you have downloaded first in each group.
+  Models under 1B stay hidden unless you turn them on in Settings → Models,
+  except for the one you are currently using, which always shows.
 
 ### Fixed
 

--- a/apps/rapid-mac/CHANGELOG.md
+++ b/apps/rapid-mac/CHANGELOG.md
@@ -15,6 +15,17 @@ can actually understand.
 
 ### Added
 
+- **A new Images tab generates pictures on your Mac.** Choose an image model,
+  load it the same way you load a chat model, type a prompt and generate. Each
+  render joins a filmstrip below the picture; selecting an earlier one brings
+  its prompt back so you can adjust and re-run. Aspect ratio is 1:1, 3:4 or
+  4:3, and the save button writes a PNG wherever you choose.
+
+- **Chat accepts image attachments.** With a model that can read images, attach
+  one to a message and ask about it. Models that cannot read images show the
+  attach button disabled with "This model doesn't support images", rather than
+  letting you attach one and failing later.
+
 - **Web-page approvals now include “Always allow.”** Choose it once to let the
   model read future public web pages without interrupting you for every URL.
   Private and local addresses remain blocked, and the permission can be turned

--- a/apps/rapid-mac/CHANGELOG.md
+++ b/apps/rapid-mac/CHANGELOG.md
@@ -16,7 +16,7 @@ can actually understand.
 ### Added
 
 - **A new Images tab generates pictures on your Mac.** Choose an image model,
-  load it the same way you load a chat model, type a prompt and generate. Each
+  follow the readiness prompt to load it, type a prompt and generate. Each
   render joins a filmstrip below the picture; selecting an earlier one brings
   its prompt back so you can adjust and re-run. Aspect ratio is 1:1, 3:4 or
   4:3, and the save button writes a PNG wherever you choose.

--- a/docs/release-notes/unreleased.md
+++ b/docs/release-notes/unreleased.md
@@ -3,9 +3,58 @@
      Whole-line HTML comments like this one are stripped before publishing.
      See README.md in this directory for what good notes look like. -->
 
+## Highlights
+
+**The desktop app generates images.** A new Images tab renders locally through
+the same one-model-per-process server the chat tab uses: pick an image model,
+load it through the usual readiness gate, prompt, and refine. Renders land in a
+filmstrip you can step back through, and selecting an older one restores the
+prompt that produced it (#1705). Chat gained the other direction at the same
+time — you can attach images to a message and ask about them (#1723).
+
+**Tool calls on Qwen models stopped losing their arguments.** A long series of
+fixes to the Qwen streaming parser: arguments split across chunks, wrapper
+closers that arrive in pieces, truncated calls, and content that follows a
+wrapper close were each mis-framed in ways that produced a call with the wrong
+arguments rather than a visible failure. `AutoToolParser`'s balanced-JSON scan
+was fixed alongside them (#1726), and a replayed terminal chunk under
+`tool_choice: auto` no longer duplicates content into the answer (#1711).
+
+**Tool-using turns are no longer cut off mid-thought.** The desktop's floor for
+reasoning-plus-tools turns was set to exactly the default token budget, so the
+`max()` that was supposed to lift it never lifted anyone. It is now 16384
+(#1722). Short budgets do not fail loudly — they deliver a truncated answer, so
+this showed up as models that "could not do it" rather than as an error.
+
+**A second turn now reuses the first turn's prefix cache** (#1732), and the
+scheduler reclaims paged full-KV and free-block memory instead of wedging on a
+`D-METAL-CAP` 503 under sustained load (#1646).
+
+**Claude Code has an agent profile** (#1720), and browsing approvals can be set
+to always-allow rather than prompting every time (#1695).
+
+## Fixes worth calling out
+
+- The model picker's "Browse all models" opened the catalogue instead of
+  closing the wizard (#1662).
+- A stored last-served alias is validated before the app tries to restore it,
+  so a stale or removed model no longer produces a failed start on launch
+  (#1729).
+- `SIGHUP` termination semantics are preserved (#1703), and desktop tags no
+  longer leak into the engine's update check (#1704).
 - Fixed DeepSeek-R1 tool-result replays returning HTTP 500 when its official
   chat template expected JSON-string arguments, and removed native tool-wire
   residue from forced-call content channels. The 4B release lane now validates
   a deterministic forced call, streaming channel hygiene, and stream/non-stream
   tool-result replay without treating small-model knowledge errors as engine
   release failures (#1676, #1677).
+
+## Release engineering
+
+Mostly invisible, but it is why the above is trustworthy: the app and engine
+are now cut in one event instead of two that could drift (#1649); a release
+gate that had not run for eleven releases was found dead and repaired (#1671);
+the Codex review step fails closed when the reviewer is unavailable rather than
+passing silently (#1700); and the GUI golden flows run on every desktop PR
+(#1721), driving the app through the accessibility API with no screen recording
+(#1708) so they work unattended in CI.

--- a/docs/release-notes/unreleased.md
+++ b/docs/release-notes/unreleased.md
@@ -26,9 +26,14 @@ reasoning-plus-tools turns was set to exactly the default token budget, so the
 (#1722). Short budgets do not fail loudly — they deliver a truncated answer, so
 this showed up as models that "could not do it" rather than as an error.
 
-**A second turn now reuses the first turn's prefix cache** (#1732), and the
-scheduler reclaims paged full-KV and free-block memory instead of wedging on a
-`D-METAL-CAP` 503 under sustained load (#1646).
+**The scheduler reclaims paged full-KV and free-block memory** instead of
+wedging on a `D-METAL-CAP` 503 under sustained load (#1646). A prefix-cache
+boundary fix also landed (#1732) — but note that on hybrid models (Qwen3.5 and
+Qwen3.6, which includes the recommended chat picks) a follow-up turn still
+re-prefills the whole conversation rather than reusing the previous turn's
+cache. Measured after #1732: an extension turn on `qwen3.6-27b-4bit` prefills
+all 9940 tokens where a dense model prefills 24. That is tracked in #1737 and
+is NOT fixed in this release.
 
 **Claude Code has an agent profile** (#1720), and browsing approvals can be set
 to always-allow rather than prompting every time (#1695).

--- a/docs/release-notes/unreleased.md
+++ b/docs/release-notes/unreleased.md
@@ -34,7 +34,7 @@ loudly: it returns a cut-off answer, which reads as a model that "could not do
 it".
 
 **The first follow-up message no longer re-reads the opening context.** The
-opening turn never saved a reuseable cache boundary, so the second message paid
+opening turn never saved a reusable cache boundary, so the second message paid
 to re-read everything; from the third message on, reuse already worked. #1732
 closes that one gap. Measured on `qwen3.6-27b-4bit` with a ~9.9K-token
 document: the opening turn prefills 9922 tokens (32.4 s to first token), and
@@ -49,7 +49,7 @@ to always-allow rather than prompting every time (#1695).
 
 ## Fixes worth calling out
 
-- The model picker's "Browse all models" opened the catalogue instead of
+- The model picker's "Browse all models" now opens the catalogue instead of
   closing the wizard (#1662).
 - A stored last-served alias is validated before the app tries to restore it,
   so a stale or removed model no longer produces a failed start on launch

--- a/docs/release-notes/unreleased.md
+++ b/docs/release-notes/unreleased.md
@@ -12,19 +12,25 @@ filmstrip you can step back through, and selecting an older one restores the
 prompt that produced it (#1705). Chat gained the other direction at the same
 time — you can attach images to a message and ask about them (#1723).
 
-**Tool calls on Qwen models stopped losing their arguments.** A long series of
-fixes to the Qwen streaming parser: arguments split across chunks, wrapper
-closers that arrive in pieces, truncated calls, and content that follows a
-wrapper close were each mis-framed in ways that produced a call with the wrong
-arguments rather than a visible failure. `AutoToolParser`'s balanced-JSON scan
-was fixed alongside them (#1726), and a replayed terminal chunk under
-`tool_choice: auto` no longer duplicates content into the answer (#1711).
+**The Qwen tool-call parser handles awkward arguments correctly.** A long
+series of fixes to `qwen3_coder_xml` (#1730), most of them around legacy raw
+string arguments whose own content contains XML-like closing tags — the case
+where the parser cannot tell an argument's text from the wrapper around it.
+Different fixes in the series address different symptoms: some produced wrong
+arguments, others leaked wrapper framing into the answer or dropped the text
+that followed a call. `AutoToolParser`'s balanced-JSON scan was fixed alongside
+them (#1726), and a replayed terminal chunk under `tool_choice: auto` no longer
+duplicates content into the answer (#1711).
 
-**Tool-using turns are no longer cut off mid-thought.** The desktop's floor for
-reasoning-plus-tools turns was set to exactly the default token budget, so the
-`max()` that was supposed to lift it never lifted anyone. It is now 16384
-(#1722). Short budgets do not fail loudly — they deliver a truncated answer, so
-this showed up as models that "could not do it" rather than as an error.
+**Reasoning-plus-tools turns get a much larger default token budget.** The
+desktop's floor for those turns was set to exactly the default budget, so the
+`max()` meant to lift it never lifted anyone; it is now 16384 (#1722). This
+applies to turns with a reasoning model and tools enabled, and only while the
+Max Tokens slider is still at its default — an explicit setting is respected.
+16384 is a ceiling too, so this makes a truncated answer much less likely
+rather than impossible. Worth knowing because a short budget does not fail
+loudly: it returns a cut-off answer, which reads as a model that "could not do
+it".
 
 **The scheduler reclaims paged full-KV and free-block memory** instead of
 wedging on a `D-METAL-CAP` 503 under sustained load (#1646). A prefix-cache
@@ -59,7 +65,10 @@ to always-allow rather than prompting every time (#1695).
 Mostly invisible, but it is why the above is trustworthy: the app and engine
 are now cut in one event instead of two that could drift (#1649); a release
 gate that had not run for eleven releases was found dead and repaired (#1671);
-the Codex review step fails closed when the reviewer is unavailable rather than
-passing silently (#1700); and the GUI golden flows run on every desktop PR
-(#1721), driving the app through the accessibility API with no screen recording
-(#1708) so they work unattended in CI.
+a Codex review that is actually invoked now fails closed on backend, auth,
+timeout or execution failure rather than passing silently (#1700) — a missing
+Codex binary is still reported as a skip; and three AX-only GUI golden flows
+(`chat-restore`, `slow-stream-stop`, `model-crash-recovery`) run on every
+desktop PR (#1721), driving the app through the accessibility API with no
+screen recording (#1708) so they work unattended in CI. The remaining flows
+still need Peekaboo locally and are not part of the CI set.

--- a/docs/release-notes/unreleased.md
+++ b/docs/release-notes/unreleased.md
@@ -13,9 +13,9 @@ prompt that produced it (#1705). Chat gained the other direction at the same
 time — you can attach images to a message and ask about them (#1723).
 
 **The Qwen tool-call parser handles awkward arguments correctly.** A series
-of fixes to `qwen3_coder_xml` (#1730), most of them around legacy raw
-string arguments whose own content contains XML-like closing tags — the case
-where the parser cannot tell an argument's text from the wrapper around it.
+of fixes to `qwen3_coder_xml` (#1730) addresses legacy raw string arguments
+whose own content contains XML-like closing tags — the case where the parser
+cannot tell an argument's text from the wrapper around it.
 Different fixes in the series address different symptoms: some produced wrong
 arguments, others leaked wrapper framing into the answer or dropped the text
 that followed a call. `AutoToolParser`'s balanced-JSON scan was fixed alongside
@@ -33,12 +33,13 @@ impossible. Worth knowing because a short budget does not fail
 loudly: it returns a cut-off answer, which reads as a model that "could not do
 it".
 
-**A follow-up message no longer re-reads the whole conversation.** #1732 fixes
-the cache boundary for the first turn, which is what the second turn needs in
-order to reuse it. Measured on `qwen3.6-27b-4bit` with a ~9.9K-token document:
-the opening turn prefills 9922 tokens (32.4 s to first token), and the next
-turn prefills **34** instead of 9941 — 1.45 s, about 22x faster. It grows with
-the conversation, so the longer the chat the more it saves.
+**The first follow-up message no longer re-reads the opening context.** The
+opening turn never saved a reuseable cache boundary, so the second message paid
+to re-read everything; from the third message on, reuse already worked. #1732
+closes that one gap. Measured on `qwen3.6-27b-4bit` with a ~9.9K-token
+document: the opening turn prefills 9922 tokens (32.4 s to first token), and
+the follow-up prefills **34** instead of 9941 — 1.45 s, about 22x faster. The
+longer the opening context, the more that first follow-up saves.
 
 **The scheduler reclaims paged full-KV and free-block memory** instead of
 wedging on a `D-METAL-CAP` 503 under sustained load (#1646).

--- a/docs/release-notes/unreleased.md
+++ b/docs/release-notes/unreleased.md
@@ -12,8 +12,8 @@ filmstrip you can step back through, and selecting an older one restores the
 prompt that produced it (#1705). Chat gained the other direction at the same
 time — you can attach images to a message and ask about them (#1723).
 
-**The Qwen tool-call parser handles awkward arguments correctly.** A long
-series of fixes to `qwen3_coder_xml` (#1730), most of them around legacy raw
+**The Qwen tool-call parser handles awkward arguments correctly.** A series
+of fixes to `qwen3_coder_xml` (#1730), most of them around legacy raw
 string arguments whose own content contains XML-like closing tags — the case
 where the parser cannot tell an argument's text from the wrapper around it.
 Different fixes in the series address different symptoms: some produced wrong
@@ -25,10 +25,11 @@ duplicates content into the answer (#1711).
 **Reasoning-plus-tools turns get a much larger default token budget.** The
 desktop's floor for those turns was set to exactly the default budget, so the
 `max()` meant to lift it never lifted anyone; it is now 16384 (#1722). This
-applies to turns with a reasoning model and tools enabled, and only while the
-Max Tokens slider is still at its default — an explicit setting is respected.
-16384 is a ceiling too, so this makes a truncated answer much less likely
-rather than impossible. Worth knowing because a short budget does not fail
+applies to turns with a reasoning model and tools enabled, and only while Max
+Tokens is still at its default. A non-default setting is respected; 4096 is
+read as "untouched" even if you picked it deliberately. 16384 is a ceiling
+too, so this makes a truncated answer much less likely rather than
+impossible. Worth knowing because a short budget does not fail
 loudly: it returns a cut-off answer, which reads as a model that "could not do
 it".
 
@@ -68,8 +69,9 @@ are now cut in one event instead of two that could drift (#1649); a release
 gate that had not run for eleven releases was found dead and repaired (#1671);
 a Codex review that is actually invoked now fails closed on backend, auth,
 timeout or execution failure rather than passing silently (#1700) — a missing
-Codex binary is still reported as a skip; and three AX-only GUI golden flows
-(`chat-restore`, `slow-stream-stop`, `model-crash-recovery`) run on every
-desktop PR (#1721), driving the app through the accessibility API with no
-screen recording (#1708) so they work unattended in CI. The remaining flows
-still need Peekaboo locally and are not part of the CI set.
+Codex binary is still reported as a skip; and four AX-only GUI golden flows run on every
+desktop PR — `chat-restore`, `slow-stream-stop` and `model-crash-recovery`
+(#1721), plus `image-generation` (#1731) — driving the app through the
+accessibility API with no screen recording (#1708) so they work unattended in
+CI. Three more flows (`restored-tools`, `tool-loop-budget`, `chat-depth`) are
+also Peekaboo-free but stay local-only; the rest still need Peekaboo.

--- a/docs/release-notes/unreleased.md
+++ b/docs/release-notes/unreleased.md
@@ -70,8 +70,8 @@ are now cut in one event instead of two that could drift (#1649); a release
 gate that had not run for eleven releases was found dead and repaired (#1671);
 a Codex review that is actually invoked now fails closed on backend, auth,
 timeout or execution failure rather than passing silently (#1700) — a missing
-Codex binary is still reported as a skip; and four AX-only GUI golden flows run on every
-desktop PR — `chat-restore`, `slow-stream-stop` and `model-crash-recovery`
+Codex binary is still reported as a skip; and four AX-only GUI golden flows run
+on every desktop PR — `chat-restore`, `slow-stream-stop` and `model-crash-recovery`
 (#1721), plus `image-generation` (#1731) — driving the app through the
 accessibility API with no screen recording (#1708) so they work unattended in
 CI. Three more flows (`restored-tools`, `tool-loop-budget`, `chat-depth`) are

--- a/docs/release-notes/unreleased.md
+++ b/docs/release-notes/unreleased.md
@@ -32,14 +32,15 @@ rather than impossible. Worth knowing because a short budget does not fail
 loudly: it returns a cut-off answer, which reads as a model that "could not do
 it".
 
+**A follow-up message no longer re-reads the whole conversation.** #1732 fixes
+the cache boundary for the first turn, which is what the second turn needs in
+order to reuse it. Measured on `qwen3.6-27b-4bit` with a ~9.9K-token document:
+the opening turn prefills 9922 tokens (32.4 s to first token), and the next
+turn prefills **34** instead of 9941 — 1.45 s, about 22x faster. It grows with
+the conversation, so the longer the chat the more it saves.
+
 **The scheduler reclaims paged full-KV and free-block memory** instead of
-wedging on a `D-METAL-CAP` 503 under sustained load (#1646). A prefix-cache
-boundary fix also landed (#1732) — but note that on hybrid models (Qwen3.5 and
-Qwen3.6, which includes the recommended chat picks) a follow-up turn still
-re-prefills the whole conversation rather than reusing the previous turn's
-cache. Measured after #1732: an extension turn on `qwen3.6-27b-4bit` prefills
-all 9940 tokens where a dense model prefills 24. That is tracked in #1737 and
-is NOT fixed in this release.
+wedging on a `D-METAL-CAP` 503 under sustained load (#1646).
 
 **Claude Code has an agent profile** (#1720), and browsing approvals can be set
 to always-allow rather than prompting every time (#1695).

--- a/docs/release-notes/unreleased.md
+++ b/docs/release-notes/unreleased.md
@@ -70,9 +70,10 @@ are now cut in one event instead of two that could drift (#1649); a release
 gate that had not run for eleven releases was found dead and repaired (#1671);
 a Codex review that is actually invoked now fails closed on backend, auth,
 timeout or execution failure rather than passing silently (#1700) — a missing
-Codex binary is still reported as a skip; and four AX-only GUI golden flows run
-on every desktop PR — `chat-restore`, `slow-stream-stop` and `model-crash-recovery`
-(#1721), plus `image-generation` (#1731) — driving the app through the
-accessibility API with no screen recording (#1708) so they work unattended in
-CI. Three more flows (`restored-tools`, `tool-loop-budget`, `chat-depth`) are
-also Peekaboo-free but stay local-only; the rest still need Peekaboo.
+Codex binary is still reported as a skip; and four AX-only GUI golden flows
+run on every desktop PR — `chat-restore`, `slow-stream-stop` and
+`model-crash-recovery` (#1721), plus `image-generation` (#1731) — driving the
+app through the accessibility API with no screen recording (#1708) so they
+work unattended in CI. Three more flows (`restored-tools`, `tool-loop-budget`,
+`chat-depth`) are also Peekaboo-free but stay local-only; the rest still need
+Peekaboo.


### PR DESCRIPTION
## Why

`docs/release-notes/unreleased.md` had a single bullet while 75 commits had
landed since `v0.12.7`. `RELEASE.md` asks for the prose to be captured as the
work lands, precisely so the version-bump PR only has to `git mv` the file —
otherwise the notes get reconstructed from a commit list at cut time, which is
the thing `docs/release-notes/README.md` exists to prevent ("a `git log` dump
is a record, not release notes").

This is prose only. No code, no version bump — the bump PR is separate and is
not opened here.

## What

Grouped by what a user would notice rather than one entry per PR:

- the Images tab and chat image attachments (#1705, #1723)
- the Qwen streaming tool-argument series, plus #1726 and #1711
- the reasoning-tools token floor that never lifted anyone (#1722) — worth
  calling out because a short budget delivers a truncated answer rather than an
  error, so it presented as "the model can't do it"
- turn-two prefix cache reuse (#1732) and the scheduler's memory reclaim (#1646)
- a "Fixes worth calling out" list, and a release-engineering section

Existing content on `unreleased.md` (#1676, #1677) is kept.

Closes nothing; this is release prep.