### PR TITLE
Preserve native tool history across parser families

### DIFF
--- a/docs/release-notes/unreleased.md
+++ b/docs/release-notes/unreleased.md
@@ -62,6 +62,9 @@ to always-allow rather than prompting every time (#1695).
   a deterministic forced call, streaming channel hygiene, and stream/non-stream
   tool-result replay without treating small-model knowledge errors as engine
   release failures (#1676, #1677).
+- Multi-turn tool history now stays in each model family's trained wire format
+  for Qwen, Gemma 4, MiniMax, Nemotron and xLAM instead of being rewritten into
+  the generic `[Calling tool: ...]` transcript (#1593).
 
 ## Release engineering
 

--- a/tests/test_native_tool_format.py
+++ b/tests/test_native_tool_format.py
@@ -15,6 +15,7 @@ from vllm_mlx.tool_parsers import (
     AutoToolParser,
     DeepSeekToolParser,
     FunctionaryToolParser,
+    Gemma4ToolParser,
     Glm47ToolParser,
     GraniteToolParser,
     HarmonyToolParser,
@@ -22,6 +23,7 @@ from vllm_mlx.tool_parsers import (
     KimiToolParser,
     LfmToolParser,
     LlamaToolParser,
+    MiniMaxToolParser,
     MistralToolParser,
     NemotronToolParser,
     QwenToolParser,
@@ -45,6 +47,11 @@ class TestNativeToolFormatCapability:
             HermesToolParser,
             HarmonyToolParser,
             Glm47ToolParser,
+            QwenToolParser,
+            Gemma4ToolParser,
+            MiniMaxToolParser,
+            NemotronToolParser,
+            xLAMToolParser,
         ]
         for parser_cls in native_parsers:
             assert parser_cls.SUPPORTS_NATIVE_TOOL_FORMAT is True, (
@@ -57,9 +64,6 @@ class TestNativeToolFormatCapability:
     def test_parsers_without_native_support(self):
         """Parsers that don't support native tool format should return False."""
         non_native_parsers = [
-            QwenToolParser,
-            NemotronToolParser,
-            xLAMToolParser,
             AutoToolParser,
             LfmToolParser,
         ]
@@ -85,6 +89,11 @@ class TestNativeToolFormatCapability:
             "harmony",
             "glm47",
             "glm4",
+            "qwen",
+            "gemma4",
+            "minimax",
+            "nemotron",
+            "xlam",
         ]:
             parser_cls = ToolParserManager.get_tool_parser(name)
             assert parser_cls.supports_native_format() is True, (
@@ -92,11 +101,26 @@ class TestNativeToolFormatCapability:
             )
 
         # No native support
-        for name in ["qwen", "nemotron", "xlam", "auto", "lfm", "liquid"]:
+        for name in ["auto", "lfm", "liquid"]:
             parser_cls = ToolParserManager.get_tool_parser(name)
             assert parser_cls.supports_native_format() is False, (
                 f"Parser '{name}' should not support native format"
             )
+
+    def test_every_registered_parser_makes_native_support_explicit(self):
+        """Concrete parsers must not silently inherit the base default."""
+        parser_classes = set(ToolParserManager.tool_parsers.values())
+
+        missing = sorted(
+            parser_cls.__name__
+            for parser_cls in parser_classes
+            if "SUPPORTS_NATIVE_TOOL_FORMAT" not in parser_cls.__dict__
+        )
+
+        assert not missing, (
+            "Every registered parser must explicitly declare "
+            f"SUPPORTS_NATIVE_TOOL_FORMAT; missing: {missing}"
+        )
 
 
 class TestExtractMultimodalContentNativeFormat:

--- a/vllm_mlx/tool_parsers/auto_tool_parser.py
+++ b/vllm_mlx/tool_parsers/auto_tool_parser.py
@@ -89,6 +89,10 @@ class AutoToolParser(ToolParser):
     This is the default parser when no specific parser is selected.
     """
 
+    # Deliberately conservative: output-shape auto-detection cannot prove the
+    # unknown model's input chat template accepts structured tool history.
+    SUPPORTS_NATIVE_TOOL_FORMAT = False
+
     # Patterns for different formats
     MISTRAL_TOKEN = "[TOOL_CALLS]"
 

--- a/vllm_mlx/tool_parsers/gemma4_tool_parser.py
+++ b/vllm_mlx/tool_parsers/gemma4_tool_parser.py
@@ -688,6 +688,10 @@ class Gemma4ToolParser(ToolParser):
 
     EXPECTED_WIRE_FORMATS = ("gemma4_native", "calling_tool_text")
 
+    # Gemma 4's template owns both tool-call and tool-response channel tokens;
+    # preserving structured history lets it reconstruct its trained transcript.
+    SUPPORTS_NATIVE_TOOL_FORMAT = True
+
     # Grammar-CAPABLE (#558 E4): overrides ``structure_info`` below to emit the
     # gemma4 native arg body (``arg_style="gemma4"``). The three wire markers are
     # single special tokens on the target tokenizer (verified on

--- a/vllm_mlx/tool_parsers/minimax_tool_parser.py
+++ b/vllm_mlx/tool_parsers/minimax_tool_parser.py
@@ -44,6 +44,10 @@ class MiniMaxToolParser(ToolParser):
 
     EXPECTED_WIRE_FORMATS = ("minimax_native",)
 
+    # MiniMax-M2 templates consume assistant ``tool_calls`` plus ``tool``
+    # messages and render the matching minimax tool-call/result envelopes.
+    SUPPORTS_NATIVE_TOOL_FORMAT = True
+
     TOOL_CALL_BLOCK = re.compile(
         r"<minimax:tool_call>(.*?)</minimax:tool_call>", re.DOTALL
     )

--- a/vllm_mlx/tool_parsers/nemotron_tool_parser.py
+++ b/vllm_mlx/tool_parsers/nemotron_tool_parser.py
@@ -53,6 +53,10 @@ class NemotronToolParser(ToolParser):
 
     EXPECTED_WIRE_FORMATS = ("tool_call_xml_body",)
 
+    # Nemotron's tool template accepts structured assistant calls and tool
+    # results, rendering its native function/parameter XML transcript.
+    SUPPORTS_NATIVE_TOOL_FORMAT = True
+
     # How much of ``current_text`` this turn has already been accounted for on
     # the wire — forwarded as prose, consumed into an emitted call, or released
     # after a refusal. The refusal release below sends only what lies past it.

--- a/vllm_mlx/tool_parsers/qwen_tool_parser.py
+++ b/vllm_mlx/tool_parsers/qwen_tool_parser.py
@@ -47,6 +47,10 @@ class QwenToolParser(ToolParser):
 
     EXPECTED_WIRE_FORMATS = ("tool_call_json", "calling_tool_text")
 
+    # Qwen chat templates render assistant ``tool_calls`` and ``role="tool"``
+    # history into the family's native <tool_call>/<tool_response> transcript.
+    SUPPORTS_NATIVE_TOOL_FORMAT = True
+
     # Pattern for XML-style: <tool_call>{"json"}</tool_call>
     XML_PATTERN = re.compile(r"<tool_call>\s*(\{.*?\})\s*</tool_call>", re.DOTALL)
 

--- a/vllm_mlx/tool_parsers/xlam_tool_parser.py
+++ b/vllm_mlx/tool_parsers/xlam_tool_parser.py
@@ -41,6 +41,10 @@ class xLAMToolParser(ToolParser):
 
     EXPECTED_WIRE_FORMATS = ("raw_json",)
 
+    # xLAM's chat template consumes OpenAI-shaped ``tool_calls`` and
+    # ``role="tool"`` messages when rebuilding multi-turn agent history.
+    SUPPORTS_NATIVE_TOOL_FORMAT = True
+
     # Patterns for extracting JSON
     CODE_BLOCK_PATTERN = re.compile(r"```(?:json)?\s*([\s\S]*?)```")
     THINKING_PATTERN = re.compile(r"</think>\s*([\s\S]*)")


### PR DESCRIPTION
## Summary
- declare native tool-history support explicitly on every previously implicit parser
- preserve structured tool calls/results for Qwen, Gemma 4, MiniMax, Nemotron, and xLAM; keep auto conservative
- add a structural regression gate so registered parsers cannot inherit the base default silently

## Why
Before this change, `QwenToolParser.supports_native_format()` and four other native-template families returned `False` solely through inheritance. The engine therefore rewrote assistant calls and tool results into an invented `[Calling tool: ...]` / `[Tool Result ...]` transcript instead of letting each model chat template render its trained format.

## Test plan
- [x] Run native-format, parser, upstream-regression, Gemma grammar, and Qwen grammar suites (384 passed, 39 skipped)
- [x] Run Ruff lint and formatting checks on changed Python files
- [x] Run `git diff --check`

Closes #1593