### PR TITLE
Fix DeepSeek R1 distill reasoning leakage

### DIFF
--- a/tests/test_model_auto_config.py
+++ b/tests/test_model_auto_config.py
@@ -504,7 +504,7 @@ class TestDetectModelConfig:
             "Qwen2/Llama2-arch SFT and cannot emit the V3 fenced-JSON "
             "envelope. See Sven r12 dogfood HIGH-1 verdict (R12-S1)."
         )
-        assert config.reasoning_parser == "deepseek_r1"
+        assert config.reasoning_parser == "deepseek_r1_distill"
 
     # DeepSeek V2.5 (and older non-R1) → legacy ``deepseek`` parser.
     # R12-5: V3 vanilla checkpoints now route to ``deepseek_v3`` (the

--- a/tests/test_postprocessor.py
+++ b/tests/test_postprocessor.py
@@ -240,7 +240,11 @@ class TestStreamingPostProcessorReasoning:
     def test_1570_distill_parser_stays_active_when_thinking_flag_is_false(self):
         """The distill template ignores the off flag and still primes think."""
         parser = DeepSeekR1DistillReasoningParser()
-        cfg = _make_cfg(reasoning_parser=parser)
+        engine = MagicMock()
+        engine.tokenizer.chat_template = (
+            "{% if add_generation_prompt %}<think>{% endif %}"
+        )
+        cfg = _make_cfg(reasoning_parser=parser, engine=engine)
         pp = StreamingPostProcessor(cfg, enable_thinking=False)
         pp.reset()
 

--- a/tests/test_postprocessor.py
+++ b/tests/test_postprocessor.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from vllm_mlx.reasoning.deepseek_r1_parser import DeepSeekR1DistillReasoningParser
 from vllm_mlx.service.postprocessor import StreamingPostProcessor
 from vllm_mlx.tool_parsers.llama_tool_parser import LlamaToolParser
 
@@ -235,6 +236,20 @@ class TestStreamingPostProcessorReasoning:
         assert len(content_events) == 1
         assert content_events[0].content == "The capital of France is Paris."
         assert not reasoning_events
+
+    def test_1570_distill_parser_stays_active_when_thinking_flag_is_false(self):
+        """The distill template ignores the off flag and still primes think."""
+        parser = DeepSeekR1DistillReasoningParser()
+        cfg = _make_cfg(reasoning_parser=parser)
+        pp = StreamingPostProcessor(cfg, enable_thinking=False)
+        pp.reset()
+
+        trace = "Okay, so I need to figure out unified memory. " * 3
+        events = pp.process_chunk(_make_output(trace))
+
+        assert not [event for event in events if event.type == "content"]
+        reasoning = [event.reasoning for event in events if event.type == "reasoning"]
+        assert reasoning == [trace]
 
     def test_enable_thinking_none_uses_reasoning_parser(self):
         """Default (None) preserves the existing reasoning-parser path."""

--- a/tests/test_reasoning_content_null_rescue.py
+++ b/tests/test_reasoning_content_null_rescue.py
@@ -1142,7 +1142,10 @@ class TestRescueSilentDropFromReasoning:
             finish_reason="stop",
             raw_text="Okay, so I need to figure out unified memory.",
             reasoning_is_case4=True,
-            prompt_thinking_active=True,
+            # R1-Distill's shipped template ignores enable_thinking=False
+            # and still primes <think>; the parser capability is therefore
+            # sufficient even when the generic template probe says False.
+            prompt_thinking_active=False,
             implicit_reasoning_until_close=True,
         )
         assert content is None

--- a/tests/test_reasoning_content_null_rescue.py
+++ b/tests/test_reasoning_content_null_rescue.py
@@ -1142,13 +1142,25 @@ class TestRescueSilentDropFromReasoning:
             finish_reason="stop",
             raw_text="Okay, so I need to figure out unified memory.",
             reasoning_is_case4=True,
-            # R1-Distill's shipped template ignores enable_thinking=False
-            # and still primes <think>; the parser capability is therefore
-            # sufficient even when the generic template probe says False.
-            prompt_thinking_active=False,
+            # The shared template probe recognizes that R1-Distill's shipped
+            # template ignores enable_thinking=False and still primes <think>.
+            prompt_thinking_active=True,
             implicit_reasoning_until_close=True,
         )
         assert content is None
+
+    def test_1570_custom_non_priming_template_rescues_short_answer(self):
+        content = _rescue_silent_drop_from_reasoning(
+            final_content=None,
+            reasoning_text="Unified memory is shared by the CPU and GPU.",
+            tool_calls=None,
+            finish_reason="stop",
+            raw_text="Unified memory is shared by the CPU and GPU.",
+            reasoning_is_case4=True,
+            prompt_thinking_active=False,
+            implicit_reasoning_until_close=True,
+        )
+        assert content == "Unified memory is shared by the CPU and GPU."
 
     def test_case4_length_without_prompt_thinking_rescues_content(self):
         """A non-thinking answer truncated by max_tokens must not be

--- a/tests/test_reasoning_content_null_rescue.py
+++ b/tests/test_reasoning_content_null_rescue.py
@@ -1133,6 +1133,20 @@ class TestGemma4HarmonyEngineRouted:
 
 
 class TestRescueSilentDropFromReasoning:
+    def test_1570_natural_eos_from_prompt_primed_reasoning_stays_suppressed(self):
+        """Natural EOS does not turn an unclosed implicit thought into content."""
+        content = _rescue_silent_drop_from_reasoning(
+            final_content=None,
+            reasoning_text="Okay, so I need to figure out unified memory.",
+            tool_calls=None,
+            finish_reason="stop",
+            raw_text="Okay, so I need to figure out unified memory.",
+            reasoning_is_case4=True,
+            prompt_thinking_active=True,
+            implicit_reasoning_until_close=True,
+        )
+        assert content is None
+
     def test_case4_length_without_prompt_thinking_rescues_content(self):
         """A non-thinking answer truncated by max_tokens must not be
         silently dropped just because a Case-4 parser put it in reasoning."""

--- a/tests/test_reasoning_parsers.py
+++ b/tests/test_reasoning_parsers.py
@@ -430,8 +430,7 @@ class TestDeepSeekR1Distill:
         )
         assert reasoning == "I should inspect the file."
         assert content == (
-            '<tool_call>{"name":"read_file","arguments":{"path":"a.py"}}'
-            "</tool_call>"
+            '<tool_call>{"name":"read_file","arguments":{"path":"a.py"}}</tool_call>'
         )
 
     def test_1570_prompt_primed_stream_keeps_untagged_trace_in_reasoning(self):

--- a/tests/test_reasoning_parsers.py
+++ b/tests/test_reasoning_parsers.py
@@ -4,7 +4,10 @@
 import pytest
 
 from vllm_mlx.reasoning.base import DeltaMessage, ReasoningParser
-from vllm_mlx.reasoning.deepseek_r1_parser import DeepSeekR1ReasoningParser
+from vllm_mlx.reasoning.deepseek_r1_parser import (
+    DeepSeekR1DistillReasoningParser,
+    DeepSeekR1ReasoningParser,
+)
 from vllm_mlx.reasoning.gemma4_parser import Gemma4ReasoningParser
 from vllm_mlx.reasoning.gpt_oss_parser import (
     _CHANNEL_RE,
@@ -404,6 +407,25 @@ class TestDeepSeekR1:
         self.parser.reset_state()
         result = self.parser.finalize_streaming("")
         assert result is None
+
+
+class TestDeepSeekR1Distill:
+    def setup_method(self):
+        self.parser = DeepSeekR1DistillReasoningParser()
+
+    def test_1570_no_tag_complete_output_is_reasoning(self):
+        trace = "Okay, so I need to figure out unified memory."
+        reasoning, content = self.parser.extract_reasoning(trace, enable_thinking=False)
+        assert reasoning == trace
+        assert content is None
+
+    def test_1570_prompt_primed_stream_keeps_untagged_trace_in_reasoning(self):
+        self.parser.configure_request(enable_thinking=False)
+        trace = "Okay, so I need to figure out unified memory. " * 3
+        result = self.parser.extract_reasoning_streaming("", trace, trace)
+        assert result is not None
+        assert result.reasoning == trace
+        assert result.content is None
 
 
 class TestThinkParserSSEBoundary:

--- a/tests/test_reasoning_parsers.py
+++ b/tests/test_reasoning_parsers.py
@@ -419,6 +419,21 @@ class TestDeepSeekR1Distill:
         assert reasoning == trace
         assert content is None
 
+    def test_1570_no_tag_complete_output_promotes_tool_call(self):
+        output = (
+            "I should inspect the file.\n"
+            '<tool_call>{"name":"read_file","arguments":{"path":"a.py"}}'
+            "</tool_call>"
+        )
+        reasoning, content = self.parser.extract_reasoning(
+            output, enable_thinking=False
+        )
+        assert reasoning == "I should inspect the file."
+        assert content == (
+            '<tool_call>{"name":"read_file","arguments":{"path":"a.py"}}'
+            "</tool_call>"
+        )
+
     def test_1570_prompt_primed_stream_keeps_untagged_trace_in_reasoning(self):
         self.parser.configure_request(enable_thinking=False)
         trace = "Okay, so I need to figure out unified memory. " * 3

--- a/tests/test_reasoning_parsers.py
+++ b/tests/test_reasoning_parsers.py
@@ -415,7 +415,9 @@ class TestDeepSeekR1Distill:
 
     def test_1570_no_tag_complete_output_is_reasoning(self):
         trace = "Okay, so I need to figure out unified memory."
-        reasoning, content = self.parser.extract_reasoning(trace, enable_thinking=False)
+        reasoning, content = self.parser.extract_reasoning(
+            trace, enable_thinking=False, prompt_thinking_active=True
+        )
         assert reasoning == trace
         assert content is None
 
@@ -426,7 +428,7 @@ class TestDeepSeekR1Distill:
             "</tool_call>"
         )
         reasoning, content = self.parser.extract_reasoning(
-            output, enable_thinking=False
+            output, enable_thinking=False, prompt_thinking_active=True
         )
         assert reasoning == "I should inspect the file."
         assert content == (
@@ -434,7 +436,9 @@ class TestDeepSeekR1Distill:
         )
 
     def test_1570_prompt_primed_stream_keeps_untagged_trace_in_reasoning(self):
-        self.parser.configure_request(enable_thinking=False)
+        self.parser.configure_request(
+            enable_thinking=False, prompt_thinking_active=True
+        )
         trace = "Okay, so I need to figure out unified memory. " * 3
         result = self.parser.extract_reasoning_streaming("", trace, trace)
         assert result is not None
@@ -448,7 +452,9 @@ class TestDeepSeekR1Distill:
         self.parser._in_tool_call = True
         self.parser._tool_call_buffer = "<tool_call>{"
 
-        self.parser.configure_request(enable_thinking=False)
+        self.parser.configure_request(
+            enable_thinking=False, prompt_thinking_active=True
+        )
 
         assert self.parser._saw_any_tag is False
         assert self.parser._streaming_phase is None
@@ -460,6 +466,16 @@ class TestDeepSeekR1Distill:
         assert result is not None
         assert result.reasoning == trace
         assert result.content is None
+
+    def test_1570_custom_non_priming_template_preserves_content(self):
+        answer = "Unified memory is shared by the CPU and GPU."
+        reasoning, content = self.parser.extract_reasoning(
+            answer,
+            enable_thinking=False,
+            prompt_thinking_active=False,
+        )
+        assert reasoning is None
+        assert content == answer
 
 
 class TestThinkParserSSEBoundary:

--- a/tests/test_reasoning_parsers.py
+++ b/tests/test_reasoning_parsers.py
@@ -427,6 +427,26 @@ class TestDeepSeekR1Distill:
         assert result.reasoning == trace
         assert result.content is None
 
+    def test_1570_configure_request_clears_prior_stream_state(self):
+        self.parser._saw_any_tag = True
+        self.parser._streaming_phase = "content"
+        self.parser._reasoning_carry = "<th"
+        self.parser._in_tool_call = True
+        self.parser._tool_call_buffer = "<tool_call>{"
+
+        self.parser.configure_request(enable_thinking=False)
+
+        assert self.parser._saw_any_tag is False
+        assert self.parser._streaming_phase is None
+        assert self.parser._reasoning_carry == ""
+        assert self.parser._in_tool_call is False
+        assert self.parser._tool_call_buffer == ""
+        trace = "Okay, I need to reason about the next request."
+        result = self.parser.extract_reasoning_streaming("", trace, trace)
+        assert result is not None
+        assert result.reasoning == trace
+        assert result.content is None
+
 
 class TestThinkParserSSEBoundary:
     """SSE-boundary withhold for split ``<think>`` / ``</think>`` tags

--- a/tests/test_streaming_pipeline_integration.py
+++ b/tests/test_streaming_pipeline_integration.py
@@ -92,11 +92,11 @@ class TestAnthropicThinkingStartDecision(unittest.TestCase):
             _should_start_in_thinking(conditional, False, unconditional=True) is False
         )
 
-    def test_1570_conditional_distill_template_is_inactive_when_unspecified(self):
+    def test_1570_conditional_distill_template_uses_enabled_default(self):
         conditional = (
             "{% if add_generation_prompt and enable_thinking %}<think>{% endif %}"
         )
-        assert _should_start_in_thinking(conditional, None, unconditional=True) is False
+        assert _should_start_in_thinking(conditional, None, unconditional=True) is True
 
     def test_1570_nested_conditional_distill_template_respects_disabled_flag(self):
         conditional = (

--- a/tests/test_streaming_pipeline_integration.py
+++ b/tests/test_streaming_pipeline_integration.py
@@ -123,6 +123,24 @@ class TestAnthropicThinkingStartDecision(unittest.TestCase):
         templates = {"default": self.THINKING_TEMPLATE, "tool_use": "plain"}
         assert _should_start_in_thinking(templates, None) is True
 
+    def test_1570_named_tool_template_is_selected_when_tools_requested(self):
+        templates = {"default": self.THINKING_TEMPLATE, "tool_use": "plain"}
+        assert (
+            _should_start_in_thinking(
+                templates, None, unconditional=True, tools_requested=True
+            )
+            is False
+        )
+
+    def test_1570_named_tool_template_can_enable_implicit_thinking(self):
+        templates = {"default": "plain", "tool_use": self.THINKING_TEMPLATE}
+        assert (
+            _should_start_in_thinking(
+                templates, None, unconditional=True, tools_requested=True
+            )
+            is True
+        )
+
     def test_plain_template_never_starts_in_thinking(self):
         """Templates without an implicit think marker should start as text."""
         assert _should_start_in_thinking("{{ add_generation_prompt }}", None) is False

--- a/tests/test_streaming_pipeline_integration.py
+++ b/tests/test_streaming_pipeline_integration.py
@@ -102,6 +102,16 @@ class TestAnthropicThinkingStartDecision(unittest.TestCase):
             _should_start_in_thinking(conditional, False, unconditional=True) is False
         )
 
+    def test_1570_whitespace_control_condition_respects_disabled_flag(self):
+        conditional = (
+            "{%- if enable_thinking %}"
+            "{%- if add_generation_prompt %}<think>{%- endif %}"
+            "{%- endif %}"
+        )
+        assert (
+            _should_start_in_thinking(conditional, False, unconditional=True) is False
+        )
+
     def test_1570_unrelated_enable_variable_does_not_hide_unconditional_marker(self):
         template = (
             "{% set enable_thinking = false %}"

--- a/tests/test_streaming_pipeline_integration.py
+++ b/tests/test_streaming_pipeline_integration.py
@@ -176,6 +176,9 @@ class TestAnthropicThinkingStartDecision(unittest.TestCase):
         )
         assert _should_start_in_thinking(template, False, unconditional=True) is False
 
+    def test_1570_rendered_marker_does_not_require_generation_variable(self):
+        assert _should_start_in_thinking("prefix<think>", False, unconditional=True)
+
     def test_1570_unrelated_enable_variable_does_not_hide_unconditional_marker(self):
         template = (
             "{% set enable_thinking = false %}"

--- a/tests/test_streaming_pipeline_integration.py
+++ b/tests/test_streaming_pipeline_integration.py
@@ -126,6 +126,14 @@ class TestAnthropicThinkingStartDecision(unittest.TestCase):
         )
         assert _should_start_in_thinking(conditional, False, unconditional=True) is True
 
+    def test_1570_inactive_false_branch_does_not_prime_when_enabled(self):
+        conditional = (
+            "{% if enable_thinking %}plain{% else %}"
+            "{% if add_generation_prompt %}<think>{% endif %}"
+            "{% endif %}"
+        )
+        assert _should_start_in_thinking(conditional, True, unconditional=True) is False
+
     def test_1570_inactive_elif_marker_does_not_prime_thinking(self):
         conditional = (
             "{% if not enable_thinking %}plain"

--- a/tests/test_streaming_pipeline_integration.py
+++ b/tests/test_streaming_pipeline_integration.py
@@ -92,6 +92,17 @@ class TestAnthropicThinkingStartDecision(unittest.TestCase):
             _should_start_in_thinking(conditional, False, unconditional=True) is False
         )
 
+    def test_1570_unrelated_enable_variable_does_not_hide_unconditional_marker(self):
+        template = (
+            "{% set enable_thinking = false %}"
+            "{% if add_generation_prompt %}<think>{% endif %}"
+        )
+        assert _should_start_in_thinking(template, False, unconditional=True) is True
+
+    def test_1570_named_default_template_is_resolved(self):
+        templates = {"default": self.THINKING_TEMPLATE, "tool_use": "plain"}
+        assert _should_start_in_thinking(templates, None) is True
+
     def test_plain_template_never_starts_in_thinking(self):
         """Templates without an implicit think marker should start as text."""
         assert _should_start_in_thinking("{{ add_generation_prompt }}", None) is False

--- a/tests/test_streaming_pipeline_integration.py
+++ b/tests/test_streaming_pipeline_integration.py
@@ -144,6 +144,38 @@ class TestAnthropicThinkingStartDecision(unittest.TestCase):
             _should_start_in_thinking(conditional, False, unconditional=True) is False
         )
 
+    def test_1570_jinja_assignment_can_activate_marker(self):
+        template = (
+            "{% set prime = true %}"
+            "{% if prime and add_generation_prompt %}<think>{% endif %}"
+        )
+        assert _should_start_in_thinking(template, False, unconditional=True) is True
+
+    def test_1570_marker_in_empty_loop_is_inactive(self):
+        template = (
+            "{% for item in [] %}<think>{% endfor %}"
+            "{% if add_generation_prompt %}plain{% endif %}"
+        )
+        assert _should_start_in_thinking(template, False, unconditional=True) is False
+
+    def test_1570_marker_in_unused_macro_is_inactive(self):
+        template = (
+            "{% macro prime() %}<think>{% endmacro %}"
+            "{% if add_generation_prompt %}plain{% endif %}"
+        )
+        assert _should_start_in_thinking(template, False, unconditional=True) is False
+
+    def test_1570_marker_in_jinja_comment_is_inactive(self):
+        template = "{# <think> #}{% if add_generation_prompt %}plain{% endif %}"
+        assert _should_start_in_thinking(template, False, unconditional=True) is False
+
+    def test_1570_unrenderable_template_does_not_suppress_content(self):
+        template = (
+            "{% if missing_global() %}<think>{% endif %}"
+            "{% if add_generation_prompt %}plain{% endif %}"
+        )
+        assert _should_start_in_thinking(template, False, unconditional=True) is False
+
     def test_1570_unrelated_enable_variable_does_not_hide_unconditional_marker(self):
         template = (
             "{% set enable_thinking = false %}"

--- a/tests/test_streaming_pipeline_integration.py
+++ b/tests/test_streaming_pipeline_integration.py
@@ -78,6 +78,20 @@ class TestAnthropicThinkingStartDecision(unittest.TestCase):
         """No-thinking mode must emit direct answer tokens as text, not thinking."""
         assert _should_start_in_thinking(self.THINKING_TEMPLATE, False) is False
 
+    def test_1570_unconditional_distill_template_ignores_disabled_flag(self):
+        assert (
+            _should_start_in_thinking(self.THINKING_TEMPLATE, False, unconditional=True)
+            is True
+        )
+
+    def test_1570_conditional_distill_template_respects_disabled_flag(self):
+        conditional = (
+            "{% if add_generation_prompt and enable_thinking %}<think>{% endif %}"
+        )
+        assert (
+            _should_start_in_thinking(conditional, False, unconditional=True) is False
+        )
+
     def test_plain_template_never_starts_in_thinking(self):
         """Templates without an implicit think marker should start as text."""
         assert _should_start_in_thinking("{{ add_generation_prompt }}", None) is False

--- a/tests/test_streaming_pipeline_integration.py
+++ b/tests/test_streaming_pipeline_integration.py
@@ -92,6 +92,16 @@ class TestAnthropicThinkingStartDecision(unittest.TestCase):
             _should_start_in_thinking(conditional, False, unconditional=True) is False
         )
 
+    def test_1570_nested_conditional_distill_template_respects_disabled_flag(self):
+        conditional = (
+            "{% if enable_thinking %}"
+            "{% if add_generation_prompt %}<think>{% endif %}"
+            "{% endif %}"
+        )
+        assert (
+            _should_start_in_thinking(conditional, False, unconditional=True) is False
+        )
+
     def test_1570_unrelated_enable_variable_does_not_hide_unconditional_marker(self):
         template = (
             "{% set enable_thinking = false %}"

--- a/tests/test_streaming_pipeline_integration.py
+++ b/tests/test_streaming_pipeline_integration.py
@@ -179,6 +179,10 @@ class TestAnthropicThinkingStartDecision(unittest.TestCase):
     def test_1570_rendered_marker_does_not_require_generation_variable(self):
         assert _should_start_in_thinking("prefix<think>", False, unconditional=True)
 
+    def test_1570_closed_rendered_block_does_not_prime_generation(self):
+        template = "prefix<think>private</think>answer-prefix"
+        assert _should_start_in_thinking(template, False, unconditional=True) is False
+
     def test_1570_unrelated_enable_variable_does_not_hide_unconditional_marker(self):
         template = (
             "{% set enable_thinking = false %}"

--- a/tests/test_streaming_pipeline_integration.py
+++ b/tests/test_streaming_pipeline_integration.py
@@ -112,6 +112,24 @@ class TestAnthropicThinkingStartDecision(unittest.TestCase):
             _should_start_in_thinking(conditional, False, unconditional=True) is False
         )
 
+    def test_1570_false_branch_can_still_prime_implicit_thinking(self):
+        conditional = (
+            "{% if enable_thinking %}plain{% else %}"
+            "{% if add_generation_prompt %}<think>{% endif %}"
+            "{% endif %}"
+        )
+        assert _should_start_in_thinking(conditional, False, unconditional=True) is True
+
+    def test_1570_inactive_elif_marker_does_not_prime_thinking(self):
+        conditional = (
+            "{% if not enable_thinking %}plain"
+            "{% elif add_generation_prompt %}<think>"
+            "{% endif %}"
+        )
+        assert (
+            _should_start_in_thinking(conditional, False, unconditional=True) is False
+        )
+
     def test_1570_unrelated_enable_variable_does_not_hide_unconditional_marker(self):
         template = (
             "{% set enable_thinking = false %}"

--- a/tests/test_streaming_pipeline_integration.py
+++ b/tests/test_streaming_pipeline_integration.py
@@ -92,6 +92,12 @@ class TestAnthropicThinkingStartDecision(unittest.TestCase):
             _should_start_in_thinking(conditional, False, unconditional=True) is False
         )
 
+    def test_1570_conditional_distill_template_is_inactive_when_unspecified(self):
+        conditional = (
+            "{% if add_generation_prompt and enable_thinking %}<think>{% endif %}"
+        )
+        assert _should_start_in_thinking(conditional, None, unconditional=True) is False
+
     def test_1570_nested_conditional_distill_template_respects_disabled_flag(self):
         conditional = (
             "{% if enable_thinking %}"

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -1131,7 +1131,7 @@
   "deepseek-r1-32b-4bit": {
     "hf_path": "mlx-community/DeepSeek-R1-Distill-Qwen-32B-4bit",
     "tool_call_parser": "deepseek",
-    "reasoning_parser": "deepseek_r1",
+    "reasoning_parser": "deepseek_r1_distill",
     "is_hybrid": false,
     "supports_spec_decode": true,
     "suffix_decoding_tier": "neutral",

--- a/vllm_mlx/model_auto_config.py
+++ b/vllm_mlx/model_auto_config.py
@@ -123,6 +123,13 @@ _MODEL_PATTERNS: list[tuple[re.Pattern, ModelConfig]] = [
     ),
     # DeepSeek R1 (non-0528) — has reasoning
     (
+        re.compile(r"deepseek.*r1.*distill", re.IGNORECASE),
+        ModelConfig(
+            tool_call_parser="deepseek",
+            reasoning_parser="deepseek_r1_distill",
+        ),
+    ),
+    (
         re.compile(r"deepseek.*r1", re.IGNORECASE),
         ModelConfig(
             tool_call_parser="deepseek",

--- a/vllm_mlx/reasoning/__init__.py
+++ b/vllm_mlx/reasoning/__init__.py
@@ -81,6 +81,7 @@ def list_parsers() -> list[str]:
 def _register_builtin_parsers():
     """Register built-in parsers."""
     from .deepseek_r1_parser import (
+        DeepSeekR1DistillReasoningParser,
         DeepSeekR1ReasoningParser,
         VibeThinkerReasoningParser,
     )
@@ -101,6 +102,7 @@ def _register_builtin_parsers():
     register_parser("hy_v3", Hy3ReasoningParser)
     register_parser("hy3", Hy3ReasoningParser)
     register_parser("deepseek_r1", DeepSeekR1ReasoningParser)
+    register_parser("deepseek_r1_distill", DeepSeekR1DistillReasoningParser)
     register_parser("deepseek_v4", DeepSeekV4ReasoningParser)
     # ``vibethinker`` — DeepSeek-R1 variant with a 1024-char no-tag
     # threshold (vs. 64) to accommodate VibeThinker's preamble-before-

--- a/vllm_mlx/reasoning/deepseek_r1_parser.py
+++ b/vllm_mlx/reasoning/deepseek_r1_parser.py
@@ -315,5 +315,5 @@ class DeepSeekR1DistillReasoningParser(DeepSeekR1ReasoningParser):
         enable_thinking: bool | None = None,
     ) -> tuple[str | None, str | None]:
         if self.start_token not in model_output and self.end_token not in model_output:
-            return model_output.strip() or None, None
+            return self._promote_tool_calls(model_output.strip() or None, None)
         return super().extract_reasoning(model_output, enable_thinking=enable_thinking)

--- a/vllm_mlx/reasoning/deepseek_r1_parser.py
+++ b/vllm_mlx/reasoning/deepseek_r1_parser.py
@@ -306,6 +306,7 @@ class DeepSeekR1DistillReasoningParser(DeepSeekR1ReasoningParser):
 
     def configure_request(self, *, enable_thinking: bool | None = None) -> None:
         del enable_thinking
+        self.reset_state()
         self._prompt_primed_thinking = True
 
     def extract_reasoning(

--- a/vllm_mlx/reasoning/deepseek_r1_parser.py
+++ b/vllm_mlx/reasoning/deepseek_r1_parser.py
@@ -302,6 +302,7 @@ class DeepSeekR1DistillReasoningParser(DeepSeekR1ReasoningParser):
     """
 
     implicit_reasoning_until_close = True
+    sanitize_when_thinking_disabled = True
 
     def configure_request(self, *, enable_thinking: bool | None = None) -> None:
         del enable_thinking

--- a/vllm_mlx/reasoning/deepseek_r1_parser.py
+++ b/vllm_mlx/reasoning/deepseek_r1_parser.py
@@ -129,6 +129,12 @@ class DeepSeekR1ReasoningParser(BaseThinkingReasoningParser):
         # threshold-crossing content delta so no buffered bytes
         # are stranded and a split opener reassembles correctly.
         if not has_tags and not self._saw_any_tag:
+            if getattr(self, "_prompt_primed_thinking", False):
+                return self._apply_tool_call_promotion(
+                    super()._extract_reasoning_streaming_inner(
+                        previous_text, current_text, delta_text
+                    )
+                )
             if len(current_text) >= self.NO_TAG_CONTENT_THRESHOLD:
                 prefix_parts: list[str] = []
                 if self._reasoning_carry:
@@ -230,6 +236,8 @@ class DeepSeekR1ReasoningParser(BaseThinkingReasoningParser):
             DeltaMessage correction, or None if no correction needed.
         """
         if not self._saw_any_tag and accumulated_text:
+            if getattr(self, "_prompt_primed_thinking", False):
+                return None
             if finish_reason == "length" and prompt_thinking_active:
                 # Prompt-injected mid-think + max_tokens cut — route to
                 # reasoning to suppress D-STOP-THINK duplication. This
@@ -282,3 +290,28 @@ class VibeThinkerReasoningParser(DeepSeekR1ReasoningParser):
     """
 
     NO_TAG_CONTENT_THRESHOLD = 1024
+
+
+class DeepSeekR1DistillReasoningParser(DeepSeekR1ReasoningParser):
+    """Parser for R1-Distill templates that unconditionally prime thinking.
+
+    The released Qwen/Llama distill templates append ``<think>`` to the
+    assistant prompt but do not consult ``enable_thinking``.  Generated text
+    therefore starts *inside* reasoning, and only ``</think>`` can transition
+    it to public content.
+    """
+
+    implicit_reasoning_until_close = True
+
+    def configure_request(self, *, enable_thinking: bool | None = None) -> None:
+        del enable_thinking
+        self._prompt_primed_thinking = True
+
+    def extract_reasoning(
+        self,
+        model_output: str,
+        enable_thinking: bool | None = None,
+    ) -> tuple[str | None, str | None]:
+        if self.start_token not in model_output and self.end_token not in model_output:
+            return model_output.strip() or None, None
+        return super().extract_reasoning(model_output, enable_thinking=enable_thinking)

--- a/vllm_mlx/reasoning/deepseek_r1_parser.py
+++ b/vllm_mlx/reasoning/deepseek_r1_parser.py
@@ -304,16 +304,24 @@ class DeepSeekR1DistillReasoningParser(DeepSeekR1ReasoningParser):
     implicit_reasoning_until_close = True
     sanitize_when_thinking_disabled = True
 
-    def configure_request(self, *, enable_thinking: bool | None = None) -> None:
+    def configure_request(
+        self,
+        *,
+        enable_thinking: bool | None = None,
+        prompt_thinking_active: bool | None = None,
+    ) -> None:
         del enable_thinking
         self.reset_state()
-        self._prompt_primed_thinking = True
+        self._prompt_primed_thinking = prompt_thinking_active is True
 
     def extract_reasoning(
         self,
         model_output: str,
         enable_thinking: bool | None = None,
+        prompt_thinking_active: bool | None = None,
     ) -> tuple[str | None, str | None]:
         if self.start_token not in model_output and self.end_token not in model_output:
-            return self._promote_tool_calls(model_output.strip() or None, None)
+            if prompt_thinking_active is True:
+                return self._promote_tool_calls(model_output.strip() or None, None)
+            return None, model_output
         return super().extract_reasoning(model_output, enable_thinking=enable_thinking)

--- a/vllm_mlx/routes/anthropic.py
+++ b/vllm_mlx/routes/anthropic.py
@@ -104,7 +104,12 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
-def _should_start_in_thinking(chat_template: str, enable_thinking: bool | None) -> bool:
+def _should_start_in_thinking(
+    chat_template: str,
+    enable_thinking: bool | None,
+    *,
+    unconditional: bool = False,
+) -> bool:
     """Thin wrapper over the shared
     ``service.helpers._should_start_in_thinking`` predicate.
 
@@ -117,7 +122,7 @@ def _should_start_in_thinking(chat_template: str, enable_thinking: bool | None) 
     """
     from ..service.helpers import _should_start_in_thinking as _shared
 
-    return _shared(chat_template, enable_thinking)
+    return _shared(chat_template, enable_thinking, unconditional=unconditional)
 
 
 def _named_tool_choice_target(tool_choice) -> str | None:
@@ -976,6 +981,11 @@ async def create_anthropic_message(
             prompt_thinking_active=_should_start_in_thinking(
                 getattr(getattr(engine, "tokenizer", None), "chat_template", "") or "",
                 resolved_thinking,
+                unconditional=bool(
+                    getattr(
+                        cfg.reasoning_parser, "implicit_reasoning_until_close", False
+                    )
+                ),
             ),
             # Per-request reasoning cap (upstream vLLM PR #20859 / #42396
             # backport). The adapter translated ``output_config.effort``
@@ -1026,7 +1036,11 @@ async def create_anthropic_message(
         if _tok_ns and hasattr(_tok_ns, "chat_template"):
             _chat_template_ns = _tok_ns.chat_template or ""
         prompt_thinking_active_ns = _should_start_in_thinking(
-            _chat_template_ns, resolved_thinking
+            _chat_template_ns,
+            resolved_thinking,
+            unconditional=bool(
+                getattr(cfg.reasoning_parser, "implicit_reasoning_until_close", False)
+            ),
         )
         final_content = _rescue_silent_drop_from_reasoning(
             final_content,
@@ -1874,7 +1888,9 @@ async def _stream_anthropic_messages(
     if _tokenizer and hasattr(_tokenizer, "chat_template"):
         _chat_template = _tokenizer.chat_template or ""
     _starts_thinking = _should_start_in_thinking(
-        _chat_template, chat_kwargs.get("enable_thinking")
+        _chat_template,
+        chat_kwargs.get("enable_thinking"),
+        unconditional=cfg.reasoning_parser_name == "deepseek_r1_distill",
     )
     think_router = StreamingThinkRouter(start_in_thinking=_starts_thinking)
     # D-ANTHRO-TOOL-USAGE F5: seed the running counter with the
@@ -2011,6 +2027,7 @@ async def _stream_anthropic_messages(
                     getattr(getattr(engine, "tokenizer", None), "chat_template", "")
                     or "",
                     chat_kwargs.get("enable_thinking"),
+                    unconditional=True,
                 )
             configure_request(**configure_kwargs)
         else:

--- a/vllm_mlx/routes/anthropic.py
+++ b/vllm_mlx/routes/anthropic.py
@@ -2005,7 +2005,14 @@ async def _stream_anthropic_messages(
     if reasoning_parser:
         configure_request = getattr(reasoning_parser, "configure_request", None)
         if callable(configure_request):
-            configure_request(enable_thinking=chat_kwargs.get("enable_thinking"))
+            configure_kwargs = {"enable_thinking": chat_kwargs.get("enable_thinking")}
+            if getattr(reasoning_parser, "implicit_reasoning_until_close", False):
+                configure_kwargs["prompt_thinking_active"] = _should_start_in_thinking(
+                    getattr(getattr(engine, "tokenizer", None), "chat_template", "")
+                    or "",
+                    chat_kwargs.get("enable_thinking"),
+                )
+            configure_request(**configure_kwargs)
         else:
             reasoning_parser.reset_state()
 

--- a/vllm_mlx/routes/anthropic.py
+++ b/vllm_mlx/routes/anthropic.py
@@ -1033,6 +1033,13 @@ async def create_anthropic_message(
             reasoning_is_case4=reasoning_is_case4,
             matched_stop=getattr(output, "matched_stop", None),
             prompt_thinking_active=prompt_thinking_active_ns,
+            implicit_reasoning_until_close=bool(
+                getattr(
+                    cfg.reasoning_parser,
+                    "implicit_reasoning_until_close",
+                    False,
+                )
+            ),
         )
         # Issue #858: Anthropic-side mirror of the chat-route cutoff
         # sentinel. Default-on (PR #802 / H-01 semantics restored) — the

--- a/vllm_mlx/routes/anthropic.py
+++ b/vllm_mlx/routes/anthropic.py
@@ -109,6 +109,7 @@ def _should_start_in_thinking(
     enable_thinking: bool | None,
     *,
     unconditional: bool = False,
+    tools_requested: bool = False,
 ) -> bool:
     """Thin wrapper over the shared
     ``service.helpers._should_start_in_thinking`` predicate.
@@ -122,7 +123,12 @@ def _should_start_in_thinking(
     """
     from ..service.helpers import _should_start_in_thinking as _shared
 
-    return _shared(chat_template, enable_thinking, unconditional=unconditional)
+    return _shared(
+        chat_template,
+        enable_thinking,
+        unconditional=unconditional,
+        tools_requested=tools_requested,
+    )
 
 
 def _named_tool_choice_target(tool_choice) -> str | None:
@@ -986,6 +992,7 @@ async def create_anthropic_message(
                         cfg.reasoning_parser, "implicit_reasoning_until_close", False
                     )
                 ),
+                tools_requested=bool(openai_request.tools),
             ),
             # Per-request reasoning cap (upstream vLLM PR #20859 / #42396
             # backport). The adapter translated ``output_config.effort``
@@ -1041,6 +1048,7 @@ async def create_anthropic_message(
             unconditional=bool(
                 getattr(cfg.reasoning_parser, "implicit_reasoning_until_close", False)
             ),
+            tools_requested=bool(openai_request.tools),
         )
         final_content = _rescue_silent_drop_from_reasoning(
             final_content,
@@ -1891,6 +1899,7 @@ async def _stream_anthropic_messages(
         _chat_template,
         chat_kwargs.get("enable_thinking"),
         unconditional=cfg.reasoning_parser_name == "deepseek_r1_distill",
+        tools_requested=bool(chat_kwargs.get("tools")),
     )
     think_router = StreamingThinkRouter(start_in_thinking=_starts_thinking)
     # D-ANTHRO-TOOL-USAGE F5: seed the running counter with the
@@ -2028,6 +2037,7 @@ async def _stream_anthropic_messages(
                     or "",
                     chat_kwargs.get("enable_thinking"),
                     unconditional=True,
+                    tools_requested=bool(chat_kwargs.get("tools")),
                 )
             configure_request(**configure_kwargs)
         else:

--- a/vllm_mlx/routes/anthropic.py
+++ b/vllm_mlx/routes/anthropic.py
@@ -973,6 +973,10 @@ async def create_anthropic_message(
             enable_thinking=_effective_enable_thinking(
                 resolved_thinking, cfg.model_path or cfg.model_name
             ),
+            prompt_thinking_active=_should_start_in_thinking(
+                getattr(getattr(engine, "tokenizer", None), "chat_template", "") or "",
+                resolved_thinking,
+            ),
             # Per-request reasoning cap (upstream vLLM PR #20859 / #42396
             # backport). The adapter translated ``output_config.effort``
             # or legacy ``thinking.budget_tokens`` into this field on

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -5696,6 +5696,9 @@ async def _create_chat_completion_impl(
         prompt_thinking_active=_should_start_in_thinking(
             getattr(getattr(engine, "tokenizer", None), "chat_template", "") or "",
             resolved_thinking,
+            unconditional=bool(
+                getattr(cfg.reasoning_parser, "implicit_reasoning_until_close", False)
+            ),
         ),
         # Per-request reasoning cap (upstream vLLM PR #20859 backport).
         # None → back-compat no-op. Suppressed when the generation-time
@@ -5813,7 +5816,11 @@ async def _create_chat_completion_impl(
         if _tok and hasattr(_tok, "chat_template"):
             _chat_template_str = _tok.chat_template or ""
         prompt_thinking_active = _should_start_in_thinking(
-            _chat_template_str, resolved_thinking
+            _chat_template_str,
+            resolved_thinking,
+            unconditional=bool(
+                getattr(cfg.reasoning_parser, "implicit_reasoning_until_close", False)
+            ),
         )
         deepseek_v4_mid_think = bool(
             _uses_deepseek_v4_reasoning(cfg)
@@ -6919,7 +6926,11 @@ async def stream_chat_completion(
                 if _tok_stream and hasattr(_tok_stream, "chat_template"):
                     _chat_template_str_stream = _tok_stream.chat_template or ""
                 prompt_thinking_active_stream = _should_start_in_thinking(
-                    _chat_template_str_stream, _stream_resolved_thinking
+                    _chat_template_str_stream,
+                    _stream_resolved_thinking,
+                    unconditional=bool(
+                        getattr(rp, "implicit_reasoning_until_close", False)
+                    ),
                 )
                 # D-STOP-THINK codex round-6 BLOCKING (PR #799):
                 # prefer the per-chunk accumulator over

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -5693,6 +5693,10 @@ async def _create_chat_completion_impl(
         enable_thinking=_effective_enable_thinking(
             resolved_thinking, cfg.model_path or cfg.model_name
         ),
+        prompt_thinking_active=_should_start_in_thinking(
+            getattr(getattr(engine, "tokenizer", None), "chat_template", "") or "",
+            resolved_thinking,
+        ),
         # Per-request reasoning cap (upstream vLLM PR #20859 backport).
         # None → back-compat no-op. Suppressed when the generation-time
         # thinking-budget processor owns this request (#558 single mechanism).

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -5827,6 +5827,13 @@ async def _create_chat_completion_impl(
                 reasoning_is_case4=reasoning_is_case4,
                 matched_stop=getattr(output, "matched_stop", None),
                 prompt_thinking_active=prompt_thinking_active,
+                implicit_reasoning_until_close=bool(
+                    getattr(
+                        cfg.reasoning_parser,
+                        "implicit_reasoning_until_close",
+                        False,
+                    )
+                ),
             )
         # Issue #858: cutoff sentinel is ON by default — restores PR #802
         # (H-01) semantics after the R-01 (#815) opt-in flip produced
@@ -6938,6 +6945,13 @@ async def stream_chat_completion(
                         reasoning_is_case4=reasoning_is_case4_stream,
                         matched_stop=_effective_matched_stop,
                         prompt_thinking_active=prompt_thinking_active_stream,
+                        implicit_reasoning_until_close=bool(
+                            getattr(
+                                processor.reasoning_parser,
+                                "implicit_reasoning_until_close",
+                                False,
+                            )
+                        ),
                     )
                 # The helper returns the rescued reasoning ONLY when
                 # all four predicates pass (empty/whitespace content,

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -5699,6 +5699,7 @@ async def _create_chat_completion_impl(
             unconditional=bool(
                 getattr(cfg.reasoning_parser, "implicit_reasoning_until_close", False)
             ),
+            tools_requested=bool(request.tools),
         ),
         # Per-request reasoning cap (upstream vLLM PR #20859 backport).
         # None → back-compat no-op. Suppressed when the generation-time
@@ -5821,6 +5822,7 @@ async def _create_chat_completion_impl(
             unconditional=bool(
                 getattr(cfg.reasoning_parser, "implicit_reasoning_until_close", False)
             ),
+            tools_requested=bool(request.tools),
         )
         deepseek_v4_mid_think = bool(
             _uses_deepseek_v4_reasoning(cfg)
@@ -6931,6 +6933,7 @@ async def stream_chat_completion(
                     unconditional=bool(
                         getattr(rp, "implicit_reasoning_until_close", False)
                     ),
+                    tools_requested=bool(request.tools),
                 )
                 # D-STOP-THINK codex round-6 BLOCKING (PR #799):
                 # prefer the per-chunk accumulator over

--- a/vllm_mlx/routes/responses.py
+++ b/vllm_mlx/routes/responses.py
@@ -669,7 +669,12 @@ def _attach_deepseek_codex_reasoning_budget(
     )
 
 
-def _should_start_in_thinking(chat_template: str, enable_thinking: bool | None) -> bool:
+def _should_start_in_thinking(
+    chat_template: str,
+    enable_thinking: bool | None,
+    *,
+    unconditional: bool = False,
+) -> bool:
     """Thin wrapper over the shared
     ``service.helpers._should_start_in_thinking`` predicate.
 
@@ -681,7 +686,7 @@ def _should_start_in_thinking(chat_template: str, enable_thinking: bool | None) 
     """
     from ..service.helpers import _should_start_in_thinking as _shared
 
-    return _shared(chat_template, enable_thinking)
+    return _shared(chat_template, enable_thinking, unconditional=unconditional)
 
 
 def _enforce_responses_tool_choice(
@@ -2120,6 +2125,9 @@ async def _non_stream(
         prompt_thinking_active=_should_start_in_thinking(
             getattr(getattr(engine, "tokenizer", None), "chat_template", "") or "",
             resolved_thinking,
+            unconditional=bool(
+                getattr(cfg.reasoning_parser, "implicit_reasoning_until_close", False)
+            ),
         ),
         # Per-request reasoning cap (upstream vLLM PR #20859 backport).
         # Forwarded from ``ResponsesRequest.reasoning_max_tokens`` via
@@ -2858,7 +2866,9 @@ async def _stream_responses(
         if _tokenizer and hasattr(_tokenizer, "chat_template"):
             _chat_template = _tokenizer.chat_template or ""
         _starts_thinking = _should_start_in_thinking(
-            _chat_template, chat_kwargs.get("enable_thinking")
+            _chat_template,
+            chat_kwargs.get("enable_thinking"),
+            unconditional=cfg.reasoning_parser_name == "deepseek_r1_distill",
         )
         think_router = StreamingThinkRouter(start_in_thinking=_starts_thinking)
 
@@ -3005,6 +3015,7 @@ async def _stream_responses(
                             )
                             or "",
                             chat_kwargs.get("enable_thinking"),
+                            unconditional=True,
                         )
                     )
                 configure_request(**configure_kwargs)

--- a/vllm_mlx/routes/responses.py
+++ b/vllm_mlx/routes/responses.py
@@ -674,6 +674,7 @@ def _should_start_in_thinking(
     enable_thinking: bool | None,
     *,
     unconditional: bool = False,
+    tools_requested: bool = False,
 ) -> bool:
     """Thin wrapper over the shared
     ``service.helpers._should_start_in_thinking`` predicate.
@@ -686,7 +687,12 @@ def _should_start_in_thinking(
     """
     from ..service.helpers import _should_start_in_thinking as _shared
 
-    return _shared(chat_template, enable_thinking, unconditional=unconditional)
+    return _shared(
+        chat_template,
+        enable_thinking,
+        unconditional=unconditional,
+        tools_requested=tools_requested,
+    )
 
 
 def _enforce_responses_tool_choice(
@@ -2128,6 +2134,7 @@ async def _non_stream(
             unconditional=bool(
                 getattr(cfg.reasoning_parser, "implicit_reasoning_until_close", False)
             ),
+            tools_requested=bool(openai_request.tools),
         ),
         # Per-request reasoning cap (upstream vLLM PR #20859 backport).
         # Forwarded from ``ResponsesRequest.reasoning_max_tokens`` via
@@ -2869,6 +2876,7 @@ async def _stream_responses(
             _chat_template,
             chat_kwargs.get("enable_thinking"),
             unconditional=cfg.reasoning_parser_name == "deepseek_r1_distill",
+            tools_requested=bool(chat_kwargs.get("tools")),
         )
         think_router = StreamingThinkRouter(start_in_thinking=_starts_thinking)
 
@@ -3016,6 +3024,7 @@ async def _stream_responses(
                             or "",
                             chat_kwargs.get("enable_thinking"),
                             unconditional=True,
+                            tools_requested=bool(chat_kwargs.get("tools")),
                         )
                     )
                 configure_request(**configure_kwargs)

--- a/vllm_mlx/routes/responses.py
+++ b/vllm_mlx/routes/responses.py
@@ -2117,6 +2117,10 @@ async def _non_stream(
         enable_thinking=_effective_enable_thinking(
             resolved_thinking, cfg.model_path or cfg.model_name
         ),
+        prompt_thinking_active=_should_start_in_thinking(
+            getattr(getattr(engine, "tokenizer", None), "chat_template", "") or "",
+            resolved_thinking,
+        ),
         # Per-request reasoning cap (upstream vLLM PR #20859 backport).
         # Forwarded from ``ResponsesRequest.reasoning_max_tokens`` via
         # the Responses → OpenAI adapter. None → no cap (back-compat).

--- a/vllm_mlx/routes/responses.py
+++ b/vllm_mlx/routes/responses.py
@@ -2994,7 +2994,20 @@ async def _stream_responses(
         if reasoning_parser:
             configure_request = getattr(reasoning_parser, "configure_request", None)
             if callable(configure_request):
-                configure_request(enable_thinking=chat_kwargs.get("enable_thinking"))
+                configure_kwargs = {
+                    "enable_thinking": chat_kwargs.get("enable_thinking")
+                }
+                if getattr(reasoning_parser, "implicit_reasoning_until_close", False):
+                    configure_kwargs["prompt_thinking_active"] = (
+                        _should_start_in_thinking(
+                            getattr(
+                                getattr(engine, "tokenizer", None), "chat_template", ""
+                            )
+                            or "",
+                            chat_kwargs.get("enable_thinking"),
+                        )
+                    )
+                configure_request(**configure_kwargs)
             else:
                 reasoning_parser.reset_state()
 

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -831,6 +831,7 @@ def _should_start_in_thinking(
             return False
         if "<think>" not in rendered:
             return False
+        return True
     return "<think>" in chat_template and "add_generation_prompt" in chat_template
 
 

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -14,7 +14,6 @@ import inspect
 import json
 import logging
 import os
-import re
 import threading
 import uuid
 from collections.abc import AsyncIterator
@@ -791,77 +790,40 @@ def _should_start_in_thinking(
     if enable_thinking is False and not unconditional:
         return False
     if unconditional:
-        # Distill parsers need the rendered branch for every flag value. A
-        # marker can live exclusively in either the truthy or falsey branch;
-        # searching the template source would classify the inactive branch.
         if "<think>" not in chat_template:
             return False
-        # Follow the active Jinja branch instead of treating every enclosing
-        # reference to ``enable_thinking`` as an opt-out.  In particular,
-        # ``{% if enable_thinking %}...{% else %}<think>{% endif %}`` primes
-        # reasoning when the flag is false.  Evaluating only control
-        # expressions avoids rendering the full model template (which needs
-        # messages, tokenizer-specific globals, and filters).
-        from jinja2 import Environment
+        # Use the same sandboxed Jinja compiler as Hugging Face tokenizers.
+        # Rendering, unlike source scanning, honors assignments, macros,
+        # loops, comments, and the active if/elif/else branch.
+        try:
+            from transformers.utils.chat_template_utils import (
+                _compile_jinja_template,
+            )
 
-        environment = Environment(autoescape=False)
-        context = {
-            "enable_thinking": enable_thinking,
-            "add_generation_prompt": True,
-            "tools": [{}] if tools_requested else None,
-        }
-
-        def _condition_is_true(expression: str) -> bool:
-            try:
-                return bool(environment.compile_expression(expression)(**context))
-            except Exception:
-                # For an unfamiliar tokenizer-specific condition, preserve the
-                # no-leak invariant.  A false negative would expose scratch
-                # reasoning; a false positive only keeps it on the private lane.
-                return True
-
-        # parent-active, any-prior-branch-taken, current-branch-active
-        branch_stack: list[tuple[bool, bool, bool]] = []
-        active = True
-        token_re = re.compile(
-            r"<think>|{%-?\s*(if\b.*?|elif\b.*?|else|endif)\s*-?%}", re.DOTALL
-        )
-        active_marker = False
-        for match in token_re.finditer(chat_template):
-            token = match.group(0)
-            if token == "<think>":
-                if active:
-                    active_marker = True
-                    break
-                continue
-            clause = (match.group(1) or "").strip()
-            if clause.startswith("if "):
-                parent_active = active
-                selected = parent_active and _condition_is_true(clause[3:].strip())
-                branch_stack.append((parent_active, selected, selected))
-                active = selected
-            elif clause.startswith("elif ") and branch_stack:
-                parent_active, branch_taken, _ = branch_stack[-1]
-                selected = (
-                    parent_active
-                    and not branch_taken
-                    and _condition_is_true(clause[5:].strip())
-                )
-                branch_stack[-1] = (
-                    parent_active,
-                    branch_taken or selected,
-                    selected,
-                )
-                active = selected
-            elif clause == "else" and branch_stack:
-                parent_active, branch_taken, _ = branch_stack[-1]
-                selected = parent_active and not branch_taken
-                branch_stack[-1] = (parent_active, True, selected)
-                active = selected
-            elif clause == "endif" and branch_stack:
-                parent_active, _, _ = branch_stack.pop()
-                active = parent_active
-        if not active_marker:
+            tool_probe = {
+                "type": "function",
+                "function": {
+                    "name": "probe",
+                    "description": "probe",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+            rendered = _compile_jinja_template(chat_template).render(
+                messages=[{"role": "user", "content": "probe"}],
+                tools=[tool_probe] if tools_requested else None,
+                add_generation_prompt=True,
+                enable_thinking=enable_thinking,
+                bos_token="",
+                eos_token="",
+                pad_token="",
+                unk_token="",
+            )
+        except Exception:
+            # An unrenderable custom template is indeterminate. Do not claim it
+            # primed thinking: a false positive would silently discard a valid
+            # public answer. The shipped distill templates render above.
+            return False
+        if "<think>" not in rendered:
             return False
     return "<think>" in chat_template and "add_generation_prompt" in chat_template
 

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -773,8 +773,9 @@ def _should_start_in_thinking(
     route uses the same predicate and the contract has a single
     source of truth.
     """
-    if enable_thinking is False and not unconditional:
-        return False
+    if enable_thinking is False:
+        if not unconditional or "enable_thinking" in chat_template:
+            return False
     return "<think>" in chat_template and "add_generation_prompt" in chat_template
 
 

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -808,11 +808,17 @@ def _should_start_in_thinking(
                     "parameters": {"type": "object", "properties": {}},
                 },
             }
+            # The generation path resolves an omitted flag to enabled for
+            # non-coder models. ``deepseek_r1_distill`` is such a family, so
+            # its unconditional probe must use that same effective value.
+            effective_enable_thinking = (
+                True if enable_thinking is None else enable_thinking
+            )
             rendered = _compile_jinja_template(chat_template).render(
                 messages=[{"role": "user", "content": "probe"}],
                 tools=[tool_probe] if tools_requested else None,
                 add_generation_prompt=True,
-                enable_thinking=enable_thinking,
+                enable_thinking=effective_enable_thinking,
                 bos_token="",
                 eos_token="",
                 pad_token="",

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -782,6 +782,7 @@ def _rescue_silent_drop_from_reasoning(
     reasoning_is_case4: bool = False,
     matched_stop: str | None = None,
     prompt_thinking_active: bool = False,
+    implicit_reasoning_until_close: bool = False,
 ) -> str | None:
     """Issue #569: never silently drop an assistant turn.
 
@@ -940,6 +941,8 @@ def _rescue_silent_drop_from_reasoning(
             and prompt_thinking_active
         )
     )
+    if implicit_reasoning_until_close and reasoning_is_case4 and prompt_thinking_active:
+        return final_content
     if truncated_mid_think:
         return final_content
     # r5-D (F-DGF-V080-B-7, 2026-06-21): gemma4 channel-token analog

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -829,7 +829,9 @@ def _should_start_in_thinking(
             # primed thinking: a false positive would silently discard a valid
             # public answer. The shipped distill templates render above.
             return False
-        if "<think>" not in rendered:
+        # Priming means the rendered prompt ends *inside* a think block, not
+        # merely that it contains a historical closed block.
+        if rendered.rfind("<think>") <= rendered.rfind("</think>"):
             return False
         return True
     return "<think>" in chat_template and "add_generation_prompt" in chat_template

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -184,6 +184,7 @@ def _finalize_content_and_reasoning(
     reasoning_parser,
     engine_reasoning_text: str = "",
     enable_thinking: bool | None = None,
+    prompt_thinking_active: bool | None = None,
     reasoning_max_tokens: int | None = None,
     finish_reason: str | None = None,
 ) -> tuple[str, str | None]:
@@ -360,12 +361,12 @@ def _finalize_content_and_reasoning(
     # R1 NIT: an ``extract("")`` probe could hide a real ``TypeError``
     # raised inside the parser body OR trigger third-party parser
     # side effects on the empty-string input).
-    if _parser_accepts_enable_thinking(reasoning_parser):
-        extract = lambda text: reasoning_parser.extract_reasoning(
-            text, enable_thinking=enable_thinking
-        )
-    else:
-        extract = lambda text: reasoning_parser.extract_reasoning(text)
+    extract_kwargs = {}
+    if _parser_accepts_parameter(reasoning_parser, "enable_thinking"):
+        extract_kwargs["enable_thinking"] = enable_thinking
+    if _parser_accepts_parameter(reasoning_parser, "prompt_thinking_active"):
+        extract_kwargs["prompt_thinking_active"] = prompt_thinking_active
+    extract = lambda text: reasoning_parser.extract_reasoning(text, **extract_kwargs)
     if tool_calls:
         reasoning_text, _ = extract(raw_text)
     else:
@@ -767,7 +768,7 @@ def _should_start_in_thinking(chat_template: str, enable_thinking: bool | None) 
     route uses the same predicate and the contract has a single
     source of truth.
     """
-    if enable_thinking is False:
+    if enable_thinking is False and "enable_thinking" in chat_template:
         return False
     return "<think>" in chat_template and "add_generation_prompt" in chat_template
 
@@ -1450,7 +1451,7 @@ def _is_structured_output_requested(response_format) -> bool:
     return rf_type in ("json_object", "json_schema")
 
 
-def _parser_accepts_enable_thinking(reasoning_parser) -> bool:
+def _parser_accepts_parameter(reasoning_parser, name: str) -> bool:
     """Return True iff ``reasoning_parser.extract_reasoning`` declares
     an ``enable_thinking`` parameter (or ``**kwargs`` catch-all).
 
@@ -1472,9 +1473,13 @@ def _parser_accepts_enable_thinking(reasoning_parser) -> bool:
         # fall back to the 1-arg call so we don't blow up here.
         return False
     params = sig.parameters
-    if "enable_thinking" in params:
+    if name in params:
         return True
     return any(p.kind is inspect.Parameter.VAR_KEYWORD for p in params.values())
+
+
+def _parser_accepts_enable_thinking(reasoning_parser) -> bool:
+    return _parser_accepts_parameter(reasoning_parser, "enable_thinking")
 
 
 def _cascade(cli_value, alias_key: str, gen_key: str | None = None):

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -942,7 +942,7 @@ def _rescue_silent_drop_from_reasoning(
             and prompt_thinking_active
         )
     )
-    if implicit_reasoning_until_close and reasoning_is_case4:
+    if implicit_reasoning_until_close and reasoning_is_case4 and prompt_thinking_active:
         return final_content
     if truncated_mid_think:
         return final_content

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -788,8 +788,14 @@ def _should_start_in_thinking(
             chat_template = ""
     if not isinstance(chat_template, str):
         return False
-    if enable_thinking is False:
-        if not unconditional:
+    if enable_thinking is False and not unconditional:
+        return False
+    if unconditional and enable_thinking is not True:
+        # Distill parsers need the rendered branch for both an explicit false
+        # flag and the ordinary unspecified (None) request. Jinja treats None
+        # as falsey, so a marker living only in ``{% if enable_thinking %}``
+        # is not part of the actual prompt.
+        if "<think>" not in chat_template:
             return False
         # Follow the active Jinja branch instead of treating every enclosing
         # reference to ``enable_thinking`` as an opt-out.  In particular,
@@ -801,7 +807,7 @@ def _should_start_in_thinking(
 
         environment = Environment(autoescape=False)
         context = {
-            "enable_thinking": False,
+            "enable_thinking": enable_thinking,
             "add_generation_prompt": True,
             "tools": [{}] if tools_requested else None,
         }

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -14,6 +14,7 @@ import inspect
 import json
 import logging
 import os
+import re
 import threading
 import uuid
 from collections.abc import AsyncIterator

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -747,6 +747,7 @@ def _should_start_in_thinking(
     enable_thinking: bool | None,
     *,
     unconditional: bool = False,
+    tools_requested: bool = False,
 ) -> bool:
     """Shared predicate: does this chat template start the assistant
     response inside an implicit ``<think>`` block?
@@ -775,7 +776,11 @@ def _should_start_in_thinking(
     source of truth.
     """
     if isinstance(chat_template, dict):
-        if "default" in chat_template:
+        if tools_requested and "tool_use" in chat_template:
+            chat_template = chat_template["tool_use"]
+        elif tools_requested and "tools" in chat_template:
+            chat_template = chat_template["tools"]
+        elif "default" in chat_template:
             chat_template = chat_template["default"]
         elif len(chat_template) == 1:
             chat_template = next(iter(chat_template.values()))

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -742,7 +742,7 @@ def _apply_reasoning_cap(
 
 
 def _should_start_in_thinking(
-    chat_template: str,
+    chat_template,
     enable_thinking: bool | None,
     *,
     unconditional: bool = False,
@@ -773,8 +773,24 @@ def _should_start_in_thinking(
     route uses the same predicate and the contract has a single
     source of truth.
     """
+    if isinstance(chat_template, dict):
+        if "default" in chat_template:
+            chat_template = chat_template["default"]
+        elif len(chat_template) == 1:
+            chat_template = next(iter(chat_template.values()))
+        else:
+            chat_template = ""
+    if not isinstance(chat_template, str):
+        return False
     if enable_thinking is False:
-        if not unconditional or "enable_thinking" in chat_template:
+        marker_index = chat_template.find("<think>")
+        prefix = chat_template[:marker_index] if marker_index >= 0 else ""
+        active_if = prefix.rfind("{% if")
+        active_endif = prefix.rfind("{% endif")
+        marker_depends_on_enable = (
+            active_if > active_endif and "enable_thinking" in prefix[active_if:]
+        )
+        if not unconditional or marker_depends_on_enable:
             return False
     return "<think>" in chat_template and "add_generation_prompt" in chat_template
 

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -790,11 +790,10 @@ def _should_start_in_thinking(
         return False
     if enable_thinking is False and not unconditional:
         return False
-    if unconditional and enable_thinking is not True:
-        # Distill parsers need the rendered branch for both an explicit false
-        # flag and the ordinary unspecified (None) request. Jinja treats None
-        # as falsey, so a marker living only in ``{% if enable_thinking %}``
-        # is not part of the actual prompt.
+    if unconditional:
+        # Distill parsers need the rendered branch for every flag value. A
+        # marker can live exclusively in either the truthy or falsey branch;
+        # searching the template source would classify the inactive branch.
         if "<think>" not in chat_template:
             return False
         # Follow the active Jinja branch instead of treating every enclosing

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -785,10 +785,19 @@ def _should_start_in_thinking(
     if enable_thinking is False:
         marker_index = chat_template.find("<think>")
         prefix = chat_template[:marker_index] if marker_index >= 0 else ""
-        active_if = prefix.rfind("{% if")
-        active_endif = prefix.rfind("{% endif")
-        marker_depends_on_enable = (
-            active_if > active_endif and "enable_thinking" in prefix[active_if:]
+        condition_stack: list[str] = []
+        for match in re.finditer(
+            r"{%\s*(if\b.*?|elif\b.*?|else|endif)\s*%}", prefix, re.DOTALL
+        ):
+            clause = match.group(1).strip()
+            if clause.startswith("if "):
+                condition_stack.append(clause)
+            elif clause.startswith("elif ") and condition_stack:
+                condition_stack[-1] += " " + clause
+            elif clause == "endif" and condition_stack:
+                condition_stack.pop()
+        marker_depends_on_enable = any(
+            "enable_thinking" in clause for clause in condition_stack
         )
         if not unconditional or marker_depends_on_enable:
             return False

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -788,7 +788,7 @@ def _should_start_in_thinking(
         prefix = chat_template[:marker_index] if marker_index >= 0 else ""
         condition_stack: list[str] = []
         for match in re.finditer(
-            r"{%\s*(if\b.*?|elif\b.*?|else|endif)\s*%}", prefix, re.DOTALL
+            r"{%-?\s*(if\b.*?|elif\b.*?|else|endif)\s*-?%}", prefix, re.DOTALL
         ):
             clause = match.group(1).strip()
             if clause.startswith("if "):

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -789,23 +789,74 @@ def _should_start_in_thinking(
     if not isinstance(chat_template, str):
         return False
     if enable_thinking is False:
-        marker_index = chat_template.find("<think>")
-        prefix = chat_template[:marker_index] if marker_index >= 0 else ""
-        condition_stack: list[str] = []
-        for match in re.finditer(
-            r"{%-?\s*(if\b.*?|elif\b.*?|else|endif)\s*-?%}", prefix, re.DOTALL
-        ):
-            clause = match.group(1).strip()
-            if clause.startswith("if "):
-                condition_stack.append(clause)
-            elif clause.startswith("elif ") and condition_stack:
-                condition_stack[-1] += " " + clause
-            elif clause == "endif" and condition_stack:
-                condition_stack.pop()
-        marker_depends_on_enable = any(
-            "enable_thinking" in clause for clause in condition_stack
+        if not unconditional:
+            return False
+        # Follow the active Jinja branch instead of treating every enclosing
+        # reference to ``enable_thinking`` as an opt-out.  In particular,
+        # ``{% if enable_thinking %}...{% else %}<think>{% endif %}`` primes
+        # reasoning when the flag is false.  Evaluating only control
+        # expressions avoids rendering the full model template (which needs
+        # messages, tokenizer-specific globals, and filters).
+        from jinja2 import Environment
+
+        environment = Environment(autoescape=False)
+        context = {
+            "enable_thinking": False,
+            "add_generation_prompt": True,
+            "tools": [{}] if tools_requested else None,
+        }
+
+        def _condition_is_true(expression: str) -> bool:
+            try:
+                return bool(environment.compile_expression(expression)(**context))
+            except Exception:
+                # For an unfamiliar tokenizer-specific condition, preserve the
+                # no-leak invariant.  A false negative would expose scratch
+                # reasoning; a false positive only keeps it on the private lane.
+                return True
+
+        # parent-active, any-prior-branch-taken, current-branch-active
+        branch_stack: list[tuple[bool, bool, bool]] = []
+        active = True
+        token_re = re.compile(
+            r"<think>|{%-?\s*(if\b.*?|elif\b.*?|else|endif)\s*-?%}", re.DOTALL
         )
-        if not unconditional or marker_depends_on_enable:
+        active_marker = False
+        for match in token_re.finditer(chat_template):
+            token = match.group(0)
+            if token == "<think>":
+                if active:
+                    active_marker = True
+                    break
+                continue
+            clause = (match.group(1) or "").strip()
+            if clause.startswith("if "):
+                parent_active = active
+                selected = parent_active and _condition_is_true(clause[3:].strip())
+                branch_stack.append((parent_active, selected, selected))
+                active = selected
+            elif clause.startswith("elif ") and branch_stack:
+                parent_active, branch_taken, _ = branch_stack[-1]
+                selected = (
+                    parent_active
+                    and not branch_taken
+                    and _condition_is_true(clause[5:].strip())
+                )
+                branch_stack[-1] = (
+                    parent_active,
+                    branch_taken or selected,
+                    selected,
+                )
+                active = selected
+            elif clause == "else" and branch_stack:
+                parent_active, branch_taken, _ = branch_stack[-1]
+                selected = parent_active and not branch_taken
+                branch_stack[-1] = (parent_active, True, selected)
+                active = selected
+            elif clause == "endif" and branch_stack:
+                parent_active, _, _ = branch_stack.pop()
+                active = parent_active
+        if not active_marker:
             return False
     return "<think>" in chat_template and "add_generation_prompt" in chat_template
 

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -741,7 +741,12 @@ def _apply_reasoning_cap(
     return cleaned_text, truncated
 
 
-def _should_start_in_thinking(chat_template: str, enable_thinking: bool | None) -> bool:
+def _should_start_in_thinking(
+    chat_template: str,
+    enable_thinking: bool | None,
+    *,
+    unconditional: bool = False,
+) -> bool:
     """Shared predicate: does this chat template start the assistant
     response inside an implicit ``<think>`` block?
 
@@ -768,7 +773,7 @@ def _should_start_in_thinking(chat_template: str, enable_thinking: bool | None) 
     route uses the same predicate and the contract has a single
     source of truth.
     """
-    if enable_thinking is False and "enable_thinking" in chat_template:
+    if enable_thinking is False and not unconditional:
         return False
     return "<think>" in chat_template and "add_generation_prompt" in chat_template
 

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -941,7 +941,7 @@ def _rescue_silent_drop_from_reasoning(
             and prompt_thinking_active
         )
     )
-    if implicit_reasoning_until_close and reasoning_is_case4 and prompt_thinking_active:
+    if implicit_reasoning_until_close and reasoning_is_case4:
         return final_content
     if truncated_mid_think:
         return final_content

--- a/vllm_mlx/service/postprocessor.py
+++ b/vllm_mlx/service/postprocessor.py
@@ -331,13 +331,27 @@ class StreamingPostProcessor:
                 # continuing after failure can route implicit scratch text to
                 # content using the parser's constructor defaults.
                 configure_kwargs = {"enable_thinking": enable_thinking}
-                if "prompt_thinking_active" in inspect.signature(_configure).parameters:
+                try:
+                    configure_parameters = inspect.signature(_configure).parameters
+                except (TypeError, ValueError):
+                    configure_parameters = {}
+                if "prompt_thinking_active" in configure_parameters:
                     from .helpers import _should_start_in_thinking
 
                     tokenizer = getattr(cfg.engine, "tokenizer", None)
                     template = getattr(tokenizer, "chat_template", "") or ""
                     configure_kwargs["prompt_thinking_active"] = (
-                        _should_start_in_thinking(template, enable_thinking)
+                        _should_start_in_thinking(
+                            template,
+                            enable_thinking,
+                            unconditional=bool(
+                                getattr(
+                                    self.reasoning_parser,
+                                    "implicit_reasoning_until_close",
+                                    False,
+                                )
+                            ),
+                        )
                     )
                 _configure(**configure_kwargs)
             _set = getattr(self.reasoning_parser, "set_enable_thinking", None)
@@ -2406,13 +2420,27 @@ class StreamingPostProcessor:
             _configure = getattr(self.reasoning_parser, "configure_request", None)
             if callable(_configure):
                 configure_kwargs = {"enable_thinking": self.enable_thinking}
-                if "prompt_thinking_active" in inspect.signature(_configure).parameters:
+                try:
+                    configure_parameters = inspect.signature(_configure).parameters
+                except (TypeError, ValueError):
+                    configure_parameters = {}
+                if "prompt_thinking_active" in configure_parameters:
                     from .helpers import _should_start_in_thinking
 
                     tokenizer = getattr(self.cfg.engine, "tokenizer", None)
                     template = getattr(tokenizer, "chat_template", "") or ""
                     configure_kwargs["prompt_thinking_active"] = (
-                        _should_start_in_thinking(template, self.enable_thinking)
+                        _should_start_in_thinking(
+                            template,
+                            self.enable_thinking,
+                            unconditional=bool(
+                                getattr(
+                                    self.reasoning_parser,
+                                    "implicit_reasoning_until_close",
+                                    False,
+                                )
+                            ),
+                        )
                     )
                 _configure(**configure_kwargs)
             else:

--- a/vllm_mlx/service/postprocessor.py
+++ b/vllm_mlx/service/postprocessor.py
@@ -9,6 +9,7 @@ one cohesive orchestrator, because reasoning/tool/sanitize are tightly coupled.
 from __future__ import annotations
 
 import copy
+import inspect
 import json
 import logging
 import os
@@ -329,7 +330,16 @@ class StreamingPostProcessor:
                 # Request-aware parser configuration is a safety boundary:
                 # continuing after failure can route implicit scratch text to
                 # content using the parser's constructor defaults.
-                _configure(enable_thinking=enable_thinking)
+                configure_kwargs = {"enable_thinking": enable_thinking}
+                if "prompt_thinking_active" in inspect.signature(_configure).parameters:
+                    from .helpers import _should_start_in_thinking
+
+                    tokenizer = getattr(cfg.engine, "tokenizer", None)
+                    template = getattr(tokenizer, "chat_template", "") or ""
+                    configure_kwargs["prompt_thinking_active"] = (
+                        _should_start_in_thinking(template, enable_thinking)
+                    )
+                _configure(**configure_kwargs)
             _set = getattr(self.reasoning_parser, "set_enable_thinking", None)
             if callable(_set):
                 try:
@@ -2395,7 +2405,16 @@ class StreamingPostProcessor:
         if self.reasoning_parser:
             _configure = getattr(self.reasoning_parser, "configure_request", None)
             if callable(_configure):
-                _configure(enable_thinking=self.enable_thinking)
+                configure_kwargs = {"enable_thinking": self.enable_thinking}
+                if "prompt_thinking_active" in inspect.signature(_configure).parameters:
+                    from .helpers import _should_start_in_thinking
+
+                    tokenizer = getattr(self.cfg.engine, "tokenizer", None)
+                    template = getattr(tokenizer, "chat_template", "") or ""
+                    configure_kwargs["prompt_thinking_active"] = (
+                        _should_start_in_thinking(template, self.enable_thinking)
+                    )
+                _configure(**configure_kwargs)
             else:
                 self.reasoning_parser.reset_state()
             # R10-M1: ``reset_state`` clears the parser's per-request

--- a/vllm_mlx/service/postprocessor.py
+++ b/vllm_mlx/service/postprocessor.py
@@ -351,6 +351,7 @@ class StreamingPostProcessor:
                                     False,
                                 )
                             ),
+                            tools_requested=self.tools_requested,
                         )
                     )
                 _configure(**configure_kwargs)
@@ -2440,6 +2441,7 @@ class StreamingPostProcessor:
                                     False,
                                 )
                             ),
+                            tools_requested=self.tools_requested,
                         )
                     )
                 _configure(**configure_kwargs)


### PR DESCRIPTION
Closes #1570

## What changed

- add a dedicated `deepseek_r1_distill` reasoning profile for R1-Distill Qwen/Llama templates
- keep generated bytes in reasoning until the template-primed `</think>` transition appears, including streaming output beyond the old 64-character ambiguity window
- prevent the generic empty-content rescue from copying an unclosed implicit thought back into OpenAI or Anthropic content
- keep the existing `deepseek_r1` contract unchanged for models whose templates do not unconditionally prime thinking

## Root cause

The R1-Distill tokenizer template appends `<think>` to the assistant prompt, so the generated stream begins inside reasoning. When the model reached EOS without emitting `</think>`, the generic parser threshold switched long streams to content and the non-streaming silent-drop rescue copied Case-4 reasoning back into content. The template also ignores `enable_thinking`, so request-level casual-chat auto-disable could not establish a content boundary.

## Validation

- red/green regressions for non-streaming natural EOS and streaming threshold crossing
- 345 reasoning/rescue/Anthropic adjacent tests passed
- 3,300 model-config, alias, parser, and rescue tests passed
- 369 parser/route/tool-grammar/structured-output tests passed
- ruff check and format checks passed
- real `mlx-community/DeepSeek-R1-Distill-Qwen-32B-4bit` serve smoke: 200 response, clean final content, 2,297-character reasoning channel, 502 generated tokens at 31.8 tok/s