### PR TITLE
Accept mid-conversation system messages in chat

### DIFF
--- a/docs/release-notes/unreleased.md
+++ b/docs/release-notes/unreleased.md
@@ -65,6 +65,10 @@ to always-allow rather than prompting every time (#1695).
 - Multi-turn tool history now stays in each model family's trained wire format
   for Qwen, Gemma 4, MiniMax, Nemotron and xLAM instead of being rewritten into
   the generic `[Calling tool: ...]` transcript (#1593).
+- `/v1/chat/completions` now retries templates that reject a mid-conversation
+  system message by combining system instructions at the front, matching the
+  compatibility already provided by the Responses and Anthropic surfaces
+  (#1543). Templates that accept the original ordering remain untouched.
 
 ## Release engineering
 

--- a/tests/test_chat_template_mid_system.py
+++ b/tests/test_chat_template_mid_system.py
@@ -57,6 +57,41 @@ def test_does_not_coerce_template_that_accepts_original_order():
     assert rendered == MESSAGES
 
 
+def test_retry_preserves_structured_system_content_parts():
+    template = _RecordingTemplate(reject_mid_system=True)
+    structured = [
+        {
+            "role": "system",
+            "content": [
+                {"type": "text", "text": "Inspect this."},
+                {"type": "image", "image": "first.png"},
+            ],
+        },
+        {"role": "user", "content": "Hi"},
+        {
+            "role": "system",
+            "content": [
+                {"type": "text", "text": "Compare it."},
+                {"type": "image", "image": "second.png"},
+            ],
+        },
+        {"role": "user", "content": "Continue"},
+    ]
+
+    rendered = apply_chat_template(template, structured)
+
+    assert rendered[0] == {
+        "role": "system",
+        "content": [
+            {"type": "text", "text": "Inspect this."},
+            {"type": "image", "image": "first.png"},
+            {"type": "text", "text": "\n\n"},
+            {"type": "text", "text": "Compare it."},
+            {"type": "image", "image": "second.png"},
+        ],
+    }
+
+
 def test_unrelated_template_error_is_not_retried():
     class _BrokenTemplate:
         calls = 0

--- a/tests/test_chat_template_mid_system.py
+++ b/tests/test_chat_template_mid_system.py
@@ -129,3 +129,15 @@ def test_no_mid_system_does_not_retry_matching_error():
     with pytest.raises(RuntimeError, match="System message must be at the beginning"):
         apply_chat_template(template, leading_only)
     assert template.calls == 1
+
+
+def test_system_metadata_is_not_silently_discarded_by_retry():
+    template = _RecordingTemplate(reject_mid_system=True)
+    named_system = [dict(message) for message in MESSAGES]
+    named_system[3]["name"] = "policy-update"
+
+    with pytest.raises(RuntimeError, match="System message must be at the beginning"):
+        apply_chat_template(template, named_system)
+
+    assert len(template.calls) == 1
+    assert template.calls[0][3]["name"] == "policy-update"

--- a/tests/test_chat_template_mid_system.py
+++ b/tests/test_chat_template_mid_system.py
@@ -1,0 +1,96 @@
+"""Compatibility coverage for mid-conversation system messages (#1543)."""
+
+import pytest
+
+from vllm_mlx.utils.chat_template import apply_chat_template
+
+MESSAGES = [
+    {"role": "system", "content": "You are terse."},
+    {"role": "user", "content": "Hi"},
+    {"role": "assistant", "content": "Hello."},
+    {"role": "system", "content": "From now on answer only BLUE."},
+    {"role": "user", "content": "What colour is the sky?"},
+]
+
+
+class _RecordingTemplate:
+    def __init__(
+        self, *, reject_mid_system: bool, retry_error: Exception | None = None
+    ):
+        self.reject_mid_system = reject_mid_system
+        self.retry_error = retry_error
+        self.calls: list[list[dict]] = []
+
+    def apply_chat_template(self, messages, **_kwargs):
+        self.calls.append(messages)
+        has_mid_system = any(message["role"] == "system" for message in messages[1:])
+        if self.reject_mid_system and has_mid_system:
+            raise RuntimeError("System message must be at the beginning.")
+        if len(self.calls) > 1 and self.retry_error is not None:
+            raise self.retry_error
+        return messages
+
+
+def test_retries_rejecting_template_with_one_leading_system_message():
+    template = _RecordingTemplate(reject_mid_system=True)
+
+    rendered = apply_chat_template(template, MESSAGES)
+
+    assert len(template.calls) == 2
+    assert rendered == [
+        {
+            "role": "system",
+            "content": "You are terse.\n\nFrom now on answer only BLUE.",
+        },
+        {"role": "user", "content": "Hi"},
+        {"role": "assistant", "content": "Hello."},
+        {"role": "user", "content": "What colour is the sky?"},
+    ]
+
+
+def test_does_not_coerce_template_that_accepts_original_order():
+    template = _RecordingTemplate(reject_mid_system=False)
+
+    rendered = apply_chat_template(template, MESSAGES)
+
+    assert len(template.calls) == 1
+    assert rendered == MESSAGES
+
+
+def test_unrelated_template_error_is_not_retried():
+    class _BrokenTemplate:
+        calls = 0
+
+        def apply_chat_template(self, _messages, **_kwargs):
+            self.calls += 1
+            raise RuntimeError("unknown template failure")
+
+    template = _BrokenTemplate()
+    with pytest.raises(RuntimeError, match="unknown template failure"):
+        apply_chat_template(template, MESSAGES)
+    assert template.calls == 1
+
+
+def test_retry_failure_surfaces_original_template_error():
+    template = _RecordingTemplate(
+        reject_mid_system=True,
+        retry_error=RuntimeError("retry-only failure"),
+    )
+
+    with pytest.raises(RuntimeError, match="System message must be at the beginning"):
+        apply_chat_template(template, MESSAGES)
+
+
+def test_no_mid_system_does_not_retry_matching_error():
+    class _RejectsForAnotherReason:
+        calls = 0
+
+        def apply_chat_template(self, _messages, **_kwargs):
+            self.calls += 1
+            raise RuntimeError("System message must be at the beginning.")
+
+    template = _RejectsForAnotherReason()
+    leading_only = MESSAGES[:3]
+    with pytest.raises(RuntimeError, match="System message must be at the beginning"):
+        apply_chat_template(template, leading_only)
+    assert template.calls == 1

--- a/vllm_mlx/utils/chat_template.py
+++ b/vllm_mlx/utils/chat_template.py
@@ -1352,8 +1352,61 @@ def apply_chat_template(
                 flattened, **alternating_kwargs
             )
 
+    def _apply_with_mid_system_fallback(
+        candidate_messages: list[dict], candidate_kwargs: dict
+    ) -> str:
+        """Retry templates that explicitly reject a non-leading system role.
+
+        Render the client's message order first so templates that accept
+        mid-conversation system messages keep their native semantics.  Only
+        the well-known Qwen/Llama/Gemma guard opts into the compatibility
+        retry; unrelated template failures must remain unchanged.
+        """
+        try:
+            return _apply_with_alternating_fallback(
+                candidate_messages, candidate_kwargs
+            )
+        except Exception as original:
+            if "System message must be at the beginning." not in str(original):
+                raise
+
+            first_body = next(
+                (
+                    index
+                    for index, message in enumerate(candidate_messages)
+                    if message.get("role") != "system"
+                ),
+                len(candidate_messages),
+            )
+            has_mid_system = any(
+                message.get("role") == "system"
+                for message in candidate_messages[first_body:]
+            )
+            if not has_mid_system:
+                raise
+
+            system_text = "\n\n".join(
+                message.get("content", "")
+                for message in candidate_messages
+                if message.get("role") == "system" and message.get("content")
+            )
+            collapsed = [
+                message
+                for message in candidate_messages
+                if message.get("role") != "system"
+            ]
+            if system_text:
+                collapsed.insert(0, {"role": "system", "content": system_text})
+
+            try:
+                return _apply_with_alternating_fallback(collapsed, candidate_kwargs)
+            except Exception:
+                # Preserve the first diagnostic: it describes the client input
+                # that triggered compatibility handling, not our retry shape.
+                raise original
+
     try:
-        return _apply_with_alternating_fallback(messages, template_kwargs)
+        return _apply_with_mid_system_fallback(messages, template_kwargs)
     except TypeError as e:
         retry_messages = messages
         # DeepSeek-R1's published template concatenates historical tool-call
@@ -1368,7 +1421,7 @@ def apply_chat_template(
             if string_argument_messages is not messages:
                 retry_messages = string_argument_messages
                 try:
-                    return _apply_with_alternating_fallback(
+                    return _apply_with_mid_system_fallback(
                         string_argument_messages, template_kwargs
                     )
                 except TypeError:
@@ -1385,7 +1438,7 @@ def apply_chat_template(
         logger.debug("Chat template TypeError, retrying without enable_thinking: %s", e)
         template_kwargs.pop("enable_thinking", None)
         try:
-            return _apply_with_alternating_fallback(retry_messages, template_kwargs)
+            return _apply_with_mid_system_fallback(retry_messages, template_kwargs)
         except TypeError as e2:
             # Second failure. Only drop ``reasoning_effort`` when the error
             # actually names it (codex R8 BLOCKING: unconditionally popping it
@@ -1436,10 +1489,10 @@ def apply_chat_template(
             )
             injected = _inject_tools_into_messages(retry_messages, tools)
             try:
-                return _apply_with_alternating_fallback(injected, template_kwargs)
+                return _apply_with_mid_system_fallback(injected, template_kwargs)
             except TypeError:
                 # enable_thinking also unsupported after all — drop it
                 template_kwargs.pop("enable_thinking", None)
-                return _apply_with_alternating_fallback(injected, template_kwargs)
+                return _apply_with_mid_system_fallback(injected, template_kwargs)
 
-        return _apply_with_alternating_fallback(retry_messages, template_kwargs)
+        return _apply_with_mid_system_fallback(retry_messages, template_kwargs)

--- a/vllm_mlx/utils/chat_template.py
+++ b/vllm_mlx/utils/chat_template.py
@@ -1385,10 +1385,21 @@ def apply_chat_template(
             if not has_mid_system:
                 raise
 
+            system_messages = [
+                message
+                for message in candidate_messages
+                if message.get("role") == "system"
+            ]
+            # Collapsing multiple system messages cannot faithfully preserve
+            # per-message metadata such as ``name``. Refuse that lossy retry
+            # and surface the template's original diagnostic instead.
+            if any(set(message) - {"role", "content"} for message in system_messages):
+                raise
+
             system_contents = [
                 message.get("content")
-                for message in candidate_messages
-                if message.get("role") == "system" and message.get("content")
+                for message in system_messages
+                if message.get("content")
             ]
             if all(isinstance(content, str) for content in system_contents):
                 merged_system_content: str | list = "\n\n".join(system_contents)

--- a/vllm_mlx/utils/chat_template.py
+++ b/vllm_mlx/utils/chat_template.py
@@ -1385,18 +1385,38 @@ def apply_chat_template(
             if not has_mid_system:
                 raise
 
-            system_text = "\n\n".join(
-                message.get("content", "")
+            system_contents = [
+                message.get("content")
                 for message in candidate_messages
                 if message.get("role") == "system" and message.get("content")
-            )
+            ]
+            if all(isinstance(content, str) for content in system_contents):
+                merged_system_content: str | list = "\n\n".join(system_contents)
+            else:
+                # Multimodal templates may carry structured content arrays.
+                # Preserve those parts instead of stringifying them; inject a
+                # text separator between instructions so their boundaries do
+                # not disappear when two system messages are combined.
+                merged_parts: list = []
+                for content in system_contents:
+                    if merged_parts:
+                        merged_parts.append({"type": "text", "text": "\n\n"})
+                    if isinstance(content, list):
+                        merged_parts.extend(content)
+                    elif isinstance(content, dict):
+                        merged_parts.append(content)
+                    else:
+                        merged_parts.append({"type": "text", "text": str(content)})
+                merged_system_content = merged_parts
             collapsed = [
                 message
                 for message in candidate_messages
                 if message.get("role") != "system"
             ]
-            if system_text:
-                collapsed.insert(0, {"role": "system", "content": system_text})
+            if merged_system_content:
+                collapsed.insert(
+                    0, {"role": "system", "content": merged_system_content}
+                )
 
             try:
                 return _apply_with_alternating_fallback(collapsed, candidate_kwargs)


### PR DESCRIPTION
## Summary
- render chat messages in their original order first
- retry only the known Qwen/Llama/Gemma non-leading-system template failure with one combined leading system message
- preserve the original diagnostic if the compatibility retry also fails

## Why
`/v1/chat/completions` returned HTTP 400 for mid-conversation system messages even though the Responses and Anthropic surfaces already support them. Common agent frameworks use these messages to steer a running conversation, and flagship templates reject them unless they are hoisted.

## Test plan
- [x] Reproduce the pre-fix template failure with the issue message sequence
- [x] Render the fixed sequence through the real cached Qwen3.5 tokenizer
- [x] Run 160 adjacent chat-template, tool, reasoning-budget, and DeepSeek tests
- [x] Run Ruff lint/format and `git diff --check`

Closes #1543