### PR TITLE
fix(audio): omitted-model TTS requests follow the served model, not Kokoro

### DIFF
--- a/tests/test_audio_served_tts_default.py
+++ b/tests/test_audio_served_tts_default.py
@@ -1,0 +1,139 @@
+# SPDX-License-Identifier: Apache-2.0
+"""An omitted-``model`` TTS request must follow the SERVED model, not Kokoro.
+
+Dogfood finding: ``rapid-mlx serve qwen3-tts-voicedesign`` answered a bare
+``/v1/audio/voices`` with Kokoro's voices, and a bare ``/v1/audio/speech`` tried
+to LOAD Kokoro — both contradicting the ``Audio mode: qwen3-tts-voicedesign``
+banner the server printed at boot. The routes hard-coded ``DEFAULT_TTS_ALIAS``
+for the omitted-model case instead of consulting the served model.
+
+These pin :func:`_served_tts_default` and the default branch of
+:func:`_resolve_tts_model`, which is the shared resolution both routes go
+through. Hermetic: ``get_config`` is stubbed, so no server and no ``mlx_audio``.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from vllm_mlx.api.models import AudioSpeechRequest
+from vllm_mlx.routes import audio
+
+
+def _serve(monkeypatch, *, alias=None, name=None):
+    """Stub the process config as if ``serve`` stamped these onto it."""
+    monkeypatch.setattr(
+        "vllm_mlx.config.get_config",
+        lambda: SimpleNamespace(model_alias=alias, model_name=name),
+    )
+
+
+@pytest.fixture
+def _audio_probes_ok(monkeypatch):
+    """No-op the mlx_audio / Kokoro runtime probes so the route bodies run."""
+    monkeypatch.setattr("vllm_mlx.audio.probe.require_mlx_audio_tts", lambda: None)
+    monkeypatch.setattr(
+        "vllm_mlx.audio.probe.require_kokoro_runtime", lambda *a, **k: None
+    )
+
+
+def test_no_served_model_falls_back_to_kokoro(monkeypatch):
+    """The API-only / text-only config: nothing served → unchanged default."""
+    _serve(monkeypatch, alias=None, name=None)
+    assert audio._served_tts_default() is None
+    for placeholder in (None, "", "default"):
+        assert "kokoro" in audio._resolve_tts_model(placeholder).lower()
+
+
+def test_served_tts_alias_becomes_the_default(monkeypatch):
+    """serve <tts-alias> → a bare request resolves to THAT model, not Kokoro."""
+    _serve(monkeypatch, alias="qwen3-tts-voicedesign")
+    assert audio._served_tts_default() == "qwen3-tts-voicedesign"
+    resolved = audio._resolve_tts_model(None)
+    assert resolved == audio._resolve_tts_model("qwen3-tts-voicedesign")
+    assert "kokoro" not in resolved.lower()
+
+
+def test_served_tts_by_hf_id_is_recognised(monkeypatch):
+    """No alias hop (a full HF id was passed to serve): reverse lookup finds it."""
+    hf = "mlx-community/Qwen3-TTS-12Hz-1.7B-VoiceDesign-bf16"
+    _serve(monkeypatch, name=hf)
+    assert audio._served_tts_default() == hf
+    assert audio._resolve_tts_model(None) == audio._resolve_tts_model(hf)
+    assert "kokoro" not in audio._resolve_tts_model(None).lower()
+
+
+def test_served_stt_model_does_not_hijack_the_tts_default(monkeypatch):
+    """A served STT model is audio but not TTS — the TTS default stays Kokoro."""
+    _serve(monkeypatch, alias="whisper-large-v3")
+    assert audio._served_tts_default() is None
+    assert "kokoro" in audio._resolve_tts_model(None).lower()
+
+
+def test_enable_audio_on_a_chat_model_falls_back_to_kokoro(monkeypatch):
+    """--enable-audio on a text model: the served alias isn't audio at all."""
+    _serve(monkeypatch, alias="qwen3.5-4b-4bit")
+    assert audio._served_tts_default() is None
+    assert "kokoro" in audio._resolve_tts_model(None).lower()
+
+
+def test_served_by_custom_name_still_finds_the_tts_model(monkeypatch):
+    """``--served-model-name`` case: the alias is an opaque gateway name that
+    resolves to nothing, but ``model_name`` carries a real TTS HF id. The
+    default must check both, not short-circuit on the truthy alias."""
+    hf = "mlx-community/Qwen3-TTS-12Hz-1.7B-VoiceDesign-bf16"
+    _serve(monkeypatch, alias="my-gateway-name", name=hf)
+    assert audio._served_tts_default() == hf
+    assert "kokoro" not in audio._resolve_tts_model(None).lower()
+
+
+def test_explicit_model_is_never_overridden_by_the_served_default(monkeypatch):
+    """An explicit request model always wins over the served-model default."""
+    _serve(monkeypatch, alias="qwen3-tts-voicedesign")
+    # Client explicitly asks for Kokoro on a VoiceDesign server → honoured.
+    kokoro_id = audio.TTS_MODEL_ALIASES["kokoro"]
+    assert audio._resolve_tts_model("kokoro") == kokoro_id
+    assert "voicedesign" not in kokoro_id.lower()
+
+
+# --- Route-level: the actual regression paths, not just the helpers ----------
+
+
+@pytest.mark.asyncio
+async def test_voices_route_omitted_model_uses_served(monkeypatch, _audio_probes_ok):
+    """GET /v1/audio/voices with no ?model passes the SERVED model — not the
+    literal "kokoro" — to the voice resolver; an explicit ?model is honoured."""
+    _serve(monkeypatch, alias="qwen3-tts-voicedesign")
+    seen: list[str] = []
+    monkeypatch.setattr(audio, "_allowed_voices_for", lambda m: seen.append(m) or ["x"])
+    await audio.list_voices(model=None)  # omitted → served
+    await audio.list_voices(model="default")  # OpenAI placeholder → served too
+    await audio.list_voices(model="kokoro")  # explicit → honoured
+    assert seen == ["qwen3-tts-voicedesign", "qwen3-tts-voicedesign", "kokoro"]
+
+
+@pytest.mark.asyncio
+async def test_speech_route_omitted_model_resolves_to_served(
+    monkeypatch, _audio_probes_ok
+):
+    """POST /v1/audio/speech with no ``model`` synthesises with the served
+    model's HF id (via model_fields_set → None → served default), and an
+    explicit ``model`` is honoured verbatim. Spies the blocking synth so no
+    real engine loads; its first arg is the fully resolved model_name."""
+    _serve(monkeypatch, alias="qwen3-tts-voicedesign")
+    captured: list[str] = []
+    monkeypatch.setattr(
+        audio,
+        "_generate_speech_blocking",
+        lambda model_name, *a, **k: captured.append(model_name) or (b"RIFF0", 24000, 1),
+    )
+
+    await audio.create_speech(AudioSpeechRequest(input="hi"))
+    assert captured[-1] == audio._resolve_tts_model("qwen3-tts-voicedesign")
+    assert "voicedesign" in captured[-1].lower()
+
+    await audio.create_speech(
+        AudioSpeechRequest(model="kokoro", input="hi", voice="af_heart")
+    )
+    assert captured[-1] == audio.TTS_MODEL_ALIASES["kokoro"]
+    assert "voicedesign" not in captured[-1].lower()

--- a/vllm_mlx/routes/audio.py
+++ b/vllm_mlx/routes/audio.py
@@ -2211,13 +2211,51 @@ def _decode_tts_ref_audio(value: str) -> bytes:
     return decoded
 
 
+def _served_tts_default() -> str | None:
+    """The served TTS model's name, or ``None`` when no TTS model is served.
+
+    ``rapid-mlx serve qwen3-tts-voicedesign`` stamps the served alias onto
+    ``ServerConfig.model_alias`` and its HF id onto ``model_name`` (see the
+    audio branch of ``cli.serve_command``). Without consulting it, the TTS
+    routes fall back to :data:`DEFAULT_TTS_ALIAS` for an omitted ``model``, so a
+    server started on one TTS model answers a bare ``/v1/audio/voices`` with
+    Kokoro's voices — and a bare ``/v1/audio/speech`` tries to LOAD Kokoro —
+    contradicting the ``Audio mode: <alias>`` banner it printed at boot.
+
+    Returns ``None`` (caller falls back to :data:`DEFAULT_TTS_ALIAS`) whenever
+    nothing served resolves to a TTS registry entry: a text model running with
+    ``--enable-audio``, a served STT-only model, or the API-only test config
+    whose ``model_alias`` / ``model_name`` are both unset.
+    """
+    from ..audio.registry import resolve_audio_alias
+    from ..config import get_config
+
+    cfg = get_config()
+    # Check the alias AND the HF id independently, not ``alias or name``: under
+    # ``--served-model-name foo`` the alias is the operator's opaque gateway
+    # name (which resolves to nothing) while the real TTS model lives on
+    # ``model_name``. Short-circuiting on the truthy-but-unrecognised alias
+    # would wrongly fall back to Kokoro. First TTS hit wins.
+    for served in (getattr(cfg, "model_alias", None), getattr(cfg, "model_name", None)):
+        if not served:
+            continue
+        entry = resolve_audio_alias(served)
+        if entry is not None and entry.type == "tts":
+            return served
+    return None
+
+
 def _resolve_tts_model(model: str | None) -> str:
     """Map a TTS request-time alias to its HF repo id.
 
     Recognises:
 
-    * ``None`` / ``""`` / ``"default"`` → :data:`DEFAULT_TTS_ALIAS`'s
-      mapped HF id (R-03 OpenAI-canonical placeholder).
+    * ``None`` / ``""`` / ``"default"`` → the served TTS model when this
+      process was started to serve one (:func:`_served_tts_default`), else
+      :data:`DEFAULT_TTS_ALIAS`'s mapped HF id (R-03 OpenAI-canonical
+      placeholder). Honouring the served model first is what makes
+      ``rapid-mlx serve qwen3-tts-voicedesign`` answer a bare request with
+      that model instead of silently loading Kokoro.
     * A short alias listed in :data:`TTS_MODEL_ALIASES` → its mapped
       HF id.
     * Anything else → pass through verbatim (a HuggingFace repo id
@@ -2233,6 +2271,11 @@ def _resolve_tts_model(model: str | None) -> str:
     short alias table, never for passthrough.
     """
     if not model or model == "default":
+        served = _served_tts_default()
+        if served is not None:
+            # ``served`` is a concrete alias / HF id, never a placeholder, so
+            # this reuses the exact mapping rule below without recursing again.
+            return _resolve_tts_model(served)
         return TTS_MODEL_ALIASES[DEFAULT_TTS_ALIAS]
     return TTS_MODEL_ALIASES.get(model.lower(), model)
 
@@ -2546,7 +2589,15 @@ async def create_speech(request: AudioSpeechRequest = Body(...)):
 
     # Pydantic already validated min_length / non-blank — past this
     # point the input is safe to forward.
-    model = request.model
+    #
+    # An OMITTED ``model`` follows the served model, not the Pydantic
+    # placeholder default ("kokoro"): serving qwen3-tts-voicedesign and posting
+    # a bare request should render with THAT model, not silently load Kokoro.
+    # Detected via ``model_fields_set`` — the same mechanism the voice default
+    # below uses — so an EXPLICIT ``"model": "kokoro"`` on a non-Kokoro server
+    # is still honoured, while the omitted case flows through
+    # ``_resolve_tts_model(None)`` to :func:`_served_tts_default`.
+    model = request.model if "model" in request.model_fields_set else None
     input_text = request.input
     voice = request.voice
     speed = request.speed
@@ -3210,8 +3261,15 @@ async def create_music(request: AudioMusicRequest = Body(...)):
 
 
 @router.get("/v1/audio/voices", dependencies=[Depends(verify_api_key)])
-async def list_voices(model: str = "kokoro"):
+async def list_voices(model: str | None = None):
     """List available voices for a TTS model.
+
+    When ``model`` is omitted the listing follows the model this server is
+    actually serving (:func:`_served_tts_default`), falling back to
+    :data:`DEFAULT_TTS_ALIAS` only when no TTS model is served. Pre-fix the
+    query defaulted to the literal ``"kokoro"``, so a server started on a
+    different TTS model advertised Kokoro's voices here and then 400'd with
+    ``invalid_voice`` when the caller sent one to ``/v1/audio/speech``.
 
     F-D05: gates on the same :func:`require_mlx_audio` probe that
     ``/v1/audio/speech`` uses so callers can't get a 200 with a
@@ -3242,4 +3300,11 @@ async def list_voices(model: str = "kokoro"):
     # via the registry and falls back to the per-family static list
     # when the snapshot isn't cached locally — same contract as the
     # speech route.
+    # ``None`` / ``""`` / ``"default"`` are all the omitted-model case — the
+    # same placeholder set ``_resolve_tts_model`` collapses — so an explicit
+    # ``?model=default`` selects the served model here exactly as it does on
+    # /v1/audio/speech, rather than being handed to ``_allowed_voices_for``
+    # verbatim.
+    if not model or model == "default":
+        model = _served_tts_default() or DEFAULT_TTS_ALIAS
     return {"voices": _allowed_voices_for(model)}


### PR DESCRIPTION
## Why

Found while dogfooding the audio lane for the next release. `rapid-mlx serve qwen3-tts-voicedesign` prints `Audio mode: qwen3-tts-voicedesign` and stamps the served alias onto `ServerConfig`, but the TTS routes ignored it whenever a request **omitted** `model`:

- `GET /v1/audio/voices` (no `?model`) returned **Kokoro's** voices (`af_heart`, …) even though VoiceDesign was the only model that could serve. A caller who used one of those then got `400 invalid_voice` from `/v1/audio/speech`.
- `POST /v1/audio/speech` with no `model` tried to **load Kokoro** (503 on a host without espeak-ng), silently ignoring the served model — contradicting the boot banner.

Root cause: both paths defaulted the omitted-model case to `DEFAULT_TTS_ALIAS` (`"kokoro"`) instead of the served model. The voices default was a hardcoded query default; the speech default was masked because `AudioSpeechRequest.model` carries the Pydantic placeholder `"kokoro"`, so the route could not tell "omitted" from "explicitly kokoro".

## What

- New `_served_tts_default()`: returns the served model (`ServerConfig.model_alias`/`model_name`) when it resolves to a **TTS** registry entry, else `None`.
- `_resolve_tts_model(None/""/"default")` and `GET /v1/audio/voices` consult it first, falling back to `DEFAULT_TTS_ALIAS`.
- The speech route detects an omitted `model` via `request.model_fields_set` — the **same mechanism it already uses for an omitted `voice`** — and routes it through the shared helper. No schema-default change, so existing request-model contracts are untouched.
- An **explicit** model (including `"kokoro"` on a non-Kokoro server) is always honoured. A `--enable-audio` text install or a served **STT** model falls back to Kokoro unchanged, so the API-only test config is byte-for-byte identical (`_served_tts_default()` → `None`).

## Tests

- New `tests/test_audio_served_tts_default.py` (6 cases, hermetic — `get_config` stubbed, no server/`mlx_audio`): no-serve→Kokoro; served TTS alias→that model; served TTS by HF id (reverse lookup); served STT does not hijack the TTS default; `--enable-audio` chat model→Kokoro; explicit model never overridden.
- Existing audio suites green (598 passed / 14 skipped across `-k 'audio or tts or voice'`); `test_api_models.py::test_speech_request_defaults` (asserts the schema default stays `"kokoro"`) still passes because the schema is unchanged.
- Live-verified on `rapid-mlx serve qwen3-tts-voicedesign`: bare `/v1/audio/voices`→`["describe"]`; bare `/v1/audio/speech` (with and without `voice`)→200; explicit `?model=kokoro`/`model:"kokoro"` still routed to Kokoro.

## Notes

Scope is the TTS lane (speech + voices); STT and music defaults are separate modalities and unchanged. A sibling non-bug surfaced in the same dogfood — `/v1/audio/music` "ignoring duration" was operator error (the field is `seconds`, not `duration_seconds`) — so it is intentionally not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)