### PR TITLE
Fix Chat readiness model switching

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -393,10 +393,10 @@ struct ContentView: View {
     ///
     /// Lives here rather than in ``ChatView`` because starting a model is
     /// a window-level concern — the Launch page raises the same actions.
-    /// Start routes through ``ServerManager.start``, which is the one
-    /// choke point that applies the launch flags and the live
-    /// free-memory guard (#1435), so this path inherits the same OOM
-    /// protection the implicit send-start path already had.
+    /// Start routes through ``ServerManager.ensureServing`` so the action also
+    /// replaces a different resident model (for example after using Images).
+    /// ``ensureServing`` delegates its cold-start leg to ``start``, preserving
+    /// the launch flags and live free-memory guard (#1435).
     private func performReadinessAction(_ action: ModelReadiness.Action) {
         switch action {
         case .chooseModel:
@@ -417,7 +417,7 @@ struct ContentView: View {
 
     private func startModel(_ target: String) {
         let hfPath = catalogEntries.first(where: { $0.alias == target })?.hfRepo
-        Task { await server.start(alias: target, hfPath: hfPath) }
+        Task { _ = await server.ensureServing(alias: target, hfPath: hfPath) }
     }
 
     // MARK: - Detail routing

--- a/apps/rapid-mac/Tests/RapidTests/ContentViewReadinessActionTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ContentViewReadinessActionTests.swift
@@ -1,0 +1,44 @@
+import Foundation
+import Testing
+@testable import Rapid
+
+@Suite("ContentView readiness action wiring")
+struct ContentViewReadinessActionTests {
+    private static var packageRoot: URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()  // RapidTests
+            .deletingLastPathComponent()  // Tests
+            .deletingLastPathComponent()  // package root
+    }
+
+    @Test("Chat readiness replaces a different resident model")
+    func readinessUsesEnsureServing() throws {
+        let url = Self.packageRoot
+            .appendingPathComponent("Sources/Rapid/UI/ContentView.swift")
+        let body = try String(contentsOf: url, encoding: .utf8)
+        let source = CapabilityChipRenderGateSourceGuardTests
+            .stripCommentsAndWhitespace(body)
+
+        guard let functionStart = source.range(
+            of: "privatefuncstartModel(_target:String){"
+        )?.lowerBound else {
+            Issue.record("ContentView.startModel could not be found")
+            return
+        }
+        let suffix = source[functionStart...]
+        guard let functionEnd = suffix.firstIndex(of: "}") else {
+            Issue.record("ContentView.startModel has no closing brace")
+            return
+        }
+        let function = String(suffix[...functionEnd])
+
+        #expect(
+            function.contains("server.ensureServing(alias:target,hfPath:hfPath)"),
+            "The Chat readiness button must switch away from a resident Images model."
+        )
+        #expect(
+            !function.contains("server.start(alias:target,hfPath:hfPath)"),
+            "ServerManager.start is cold-start only and silently no-ops while Images is resident."
+        )
+    }
+}

--- a/docs/release-notes/unreleased.md
+++ b/docs/release-notes/unreleased.md
@@ -69,6 +69,9 @@ to always-allow rather than prompting every time (#1695).
   system message by combining system instructions at the front, matching the
   compatibility already provided by the Responses and Anthropic surfaces
   (#1543). Templates that accept the original ordering remain untouched.
+- Returning to Chat after loading an Images model no longer leaves the
+  readiness banner's load button inert; the action now switches the resident
+  server back to the selected chat model (#1739).
 
 ## Release engineering
 


### PR DESCRIPTION
## Summary
- route the Chat readiness action through `ServerManager.ensureServing`
- preserve cold-start and memory-guard behavior through `ensureServing`'s existing delegation to `start`
- add a wiring regression guard for the readiness action

## Why
After loading an Images model, Chat's readiness button called cold-start-only `start`, which silently returns while any child is resident. Sending a message recovered through `ensureServing`, but the explicit load button was dead.

## Test plan
- [x] Reproduce the early-return chain from ContentView to ServerManager.start
- [x] Build the Rapid application target successfully
- [x] Build the RapidTests target, including the new regression guard
- [x] Run an independent source wiring assertion and `git diff --check`

Note: executing `swift test` locally still hits existing #1638 (`RapidUXTests` imports unavailable XCTest); GitHub Apple Silicon CI owns the complete suite.

Closes #1739