### PR TITLE
fix(mac): bound the chat repaint rate so a long answer stops melting the app

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatStreamClient.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatStreamClient.swift
@@ -1008,8 +1008,10 @@ enum Wire {
 ///     (usage, tool_calls, finish_reason, [DONE]) AND before
 ///     throwing on cancellation or transport error. The send()
 ///     scope guarantees the latter via a `defer` block.
-///   * The 16 ms window is opportunistic (checked on each
-///     append), not timed: if a delta burst stops mid-window,
+///   * The window is opportunistic (checked on each append), not
+///     timed, and its length is adaptive — 16 ms until the message
+///     passes ``adaptiveThresholdChars``, then proportional to the
+///     text so far up to ``maxWindowNs`` (#1743): if a delta burst stops mid-window,
 ///     the trailing text is held until the next event of any
 ///     kind or until send()'s defer flush. Real backends emit
 ///     a continuous stream of deltas terminated by
@@ -1036,8 +1038,8 @@ final class SSEDeltaCoalescer: @unchecked Sendable {
 
     /// Ceiling on the widened window. At 250 ms a very long message
     /// still repaints four times a second, which reads as "streaming"
-    /// rather than "frozen", while costing a twentieth of what a 16 ms
-    /// cadence costs.
+    /// rather than "frozen", at about a sixteenth of the callback rate a
+    /// flat 16 ms cadence costs (250 / 16).
     private static let maxWindowNs: UInt64 = 250_000_000
 
     /// Total characters handed to the UI so far this turn.
@@ -1067,9 +1069,19 @@ final class SSEDeltaCoalescer: @unchecked Sendable {
         guard flushedCharacters > Self.adaptiveThresholdChars else {
             return Self.coalesceWindowNs
         }
-        let scale = UInt64(flushedCharacters / Self.adaptiveThresholdChars)
-        let widened = Self.coalesceWindowNs &* max(1, scale)
-        return min(widened, Self.maxWindowNs)
+        // Multiply BEFORE dividing so the growth is actually linear. Dividing
+        // first floors the ratio to an integer, which makes the window a
+        // staircase — flat from 2 000 to 3 999 characters and then jumping
+        // straight from 16 ms to 32 ms — rather than the smooth ramp the
+        // comment above promises.
+        //
+        // `characters` is clamped to the value that already yields the cap, so
+        // the multiplication cannot overflow no matter how long the message
+        // gets, and no masking operators are needed.
+        let capCharacters = Int(Self.maxWindowNs / Self.coalesceWindowNs) * Self.adaptiveThresholdChars
+        let characters = UInt64(min(flushedCharacters, capCharacters))
+        let widened = Self.coalesceWindowNs * characters / UInt64(Self.adaptiveThresholdChars)
+        return min(max(widened, Self.coalesceWindowNs), Self.maxWindowNs)
     }
 
     /// Codex r2 BLOCKING (unbounded queue): force-flush when the
@@ -1153,18 +1165,36 @@ final class SSEDeltaCoalescer: @unchecked Sendable {
         // Count `toEmit`, NOT `pending` — `pending` was just emptied, so
         // counting it leaves the total at zero forever and the adaptive
         // window silently never widens.
-        flushedCharacters &+= toEmit.reduce(0) { $0 + $1.text.count }
+        // Saturating, not wrapping: a wrapped total would silently drop the
+        // window back to its 16 ms floor, which is the bug this bounds.
+        let batch = toEmit.reduce(0) { $0 + $1.text.count }
+        flushedCharacters = (flushedCharacters > Int.max - batch)
+            ? Int.max
+            : flushedCharacters + batch
         lastFlushNs = nowNs()
         for segment in toEmit {
             switch segment.kind {
-            case .content:
-                contentEverFlushed = true
-                let s = segment.text
-                await MainActor.run { onEvent(.content(s)) }
-            case .reasoning:
-                reasoningEverFlushed = true
-                let s = segment.text
-                await MainActor.run { onEvent(.reasoning(s)) }
+            case .content: contentEverFlushed = true
+            case .reasoning: reasoningEverFlushed = true
+            }
+        }
+        // ONE hop for the whole batch, in wire order.
+        //
+        // Hopping per segment defeats the point of coalescing on an
+        // alternating content/reasoning stream: the `overCap` force-flush
+        // fires at 33 segments regardless of the adaptive window, and if each
+        // segment then gets its own MainActor mutation the view rebuilds —
+        // and re-parses the whole message — about once per delta again, which
+        // is exactly the #1743 failure the window is meant to bound. Applying
+        // them in a single hop keeps the queue bound AND the repaint bound,
+        // and order is preserved because the closure runs the array in
+        // sequence.
+        await MainActor.run {
+            for segment in toEmit {
+                switch segment.kind {
+                case .content: onEvent(.content(segment.text))
+                case .reasoning: onEvent(.reasoning(segment.text))
+                }
             }
         }
     }

--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatStreamClient.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatStreamClient.swift
@@ -986,9 +986,14 @@ enum Wire {
 /// Per-token MainActor hops on a fast stream (M3 Ultra rapid-mlx
 /// at 200+ tok/s) burned a hop per emitted delta. This coalescer
 /// accumulates ``content`` and ``reasoning_content`` deltas inside
-/// a 16 ms window (one display frame at 60 Hz) and emits ONE
-/// MainActor callback per window — collapsing a 500-token stream
-/// from ~500 hops to ~30.
+/// a coalescing window and emits ONE MainActor callback per window
+/// — collapsing a 500-token stream from ~500 hops to ~30.
+///
+/// The window starts at 16 ms (one display frame at 60 Hz) and, past
+/// ``adaptiveThresholdChars``, widens in proportion to the text already
+/// flushed, up to ``maxWindowNs``. A fixed window would leave the turn
+/// quadratic: each repaint re-parses the whole message, so an O(length)
+/// parse at a fixed rate costs O(length²) over the turn (#1743).
 ///
 /// Held as a reference type so the captured mutable state survives
 /// the ``await`` boundary the SSE loop crosses on every line
@@ -999,8 +1004,9 @@ enum Wire {
 ///     SINGLE ordered queue keyed by kind, merging into the
 ///     trailing entry when the kind matches. The first call of
 ///     each kind surfaces IMMEDIATELY (first-token visibility —
-///     the typing indicator must not wait 16 ms). Subsequent calls
-///     flush when the 16 ms coalesce window has elapsed.
+///     the typing indicator must not wait a frame). Subsequent
+///     calls flush once the current window (see
+///     ``currentWindowNs()``) has elapsed.
 ///   * ``flush`` emits the pending queue IN ORDER, so a
 ///     content→reasoning interleave preserves the server's wire
 ///     order — there is no cross-kind reordering.
@@ -1078,7 +1084,17 @@ final class SSEDeltaCoalescer: @unchecked Sendable {
         // `characters` is clamped to the value that already yields the cap, so
         // the multiplication cannot overflow no matter how long the message
         // gets, and no masking operators are needed.
-        let capCharacters = Int(Self.maxWindowNs / Self.coalesceWindowNs) * Self.adaptiveThresholdChars
+        //
+        // Derive that clamp by solving for it, not by scaling the window
+        // ratio: `maxWindowNs / coalesceWindowNs` is 250/16, which floors to
+        // 15, capping at 30 000 characters and a 240 ms window — so
+        // `maxWindowNs` would never actually be reached and the ceiling the
+        // rest of this file talks about would not exist. The exact answer is
+        // 31 250. (250e6 * 2000 fits in UInt64 with ~7 orders of magnitude to
+        // spare, so the numerator here is safe.)
+        let capCharacters = Int(
+            Self.maxWindowNs * UInt64(Self.adaptiveThresholdChars) / Self.coalesceWindowNs
+        )
         let characters = UInt64(min(flushedCharacters, capCharacters))
         let widened = Self.coalesceWindowNs * characters / UInt64(Self.adaptiveThresholdChars)
         return min(max(widened, Self.coalesceWindowNs), Self.maxWindowNs)
@@ -1094,6 +1110,16 @@ final class SSEDeltaCoalescer: @unchecked Sendable {
     /// into one flush, but tight enough that a runaway stream gets
     /// drained promptly.
     private static let maxPendingSegments: Int = 32
+
+    /// How many times ``flush`` has applied a batch on the main actor — one
+    /// per flush, by construction.
+    ///
+    /// Exposed because the emitted event stream cannot distinguish one hop
+    /// carrying N segments from N hops carrying one each, and that difference
+    /// is the whole point: it is what decides whether the view rebuilds once
+    /// or N times per flush. A test asserting only on events would pass just
+    /// as happily against the per-segment version this replaced.
+    private(set) var mainActorApplications: Int = 0
 
     enum Kind { case content, reasoning }
 
@@ -1178,6 +1204,7 @@ final class SSEDeltaCoalescer: @unchecked Sendable {
             case .reasoning: reasoningEverFlushed = true
             }
         }
+        mainActorApplications += 1
         // ONE hop for the whole batch, in wire order.
         //
         // Hopping per segment defeats the point of coalescing on an

--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatStreamClient.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatStreamClient.swift
@@ -1024,7 +1024,53 @@ final class SSEDeltaCoalescer: @unchecked Sendable {
     /// 16 ms = 1 frame at 60 Hz. Tight enough that the user
     /// perceives a smooth typing effect; loose enough to amortise
     /// MainActor hop cost.
+    ///
+    /// This is the FLOOR, not the whole story — see ``currentWindowNs``.
     private static let coalesceWindowNs: UInt64 = 16_000_000
+
+    /// Above this many flushed characters the window starts to widen.
+    /// Chosen so an ordinary reply never changes behaviour at all: the
+    /// median chat answer is a few hundred characters and the long tail
+    /// of "write me a function" answers still lands under 2 000.
+    private static let adaptiveThresholdChars: Int = 2_000
+
+    /// Ceiling on the widened window. At 250 ms a very long message
+    /// still repaints four times a second, which reads as "streaming"
+    /// rather than "frozen", while costing a twentieth of what a 16 ms
+    /// cadence costs.
+    private static let maxWindowNs: UInt64 = 250_000_000
+
+    /// Total characters handed to the UI so far this turn.
+    private var flushedCharacters: Int = 0
+
+    /// How long to coalesce before the next flush, given how much text
+    /// the message already holds.
+    ///
+    /// Every flush makes the chat view rebuild its body, and
+    /// ``LaTeXMarkdownView`` re-parses the ENTIRE accumulated message
+    /// through MarkdownUI on each rebuild — parsing is O(length), and a
+    /// fixed 16 ms cadence therefore costs O(length²) across a turn. On a
+    /// long answer that saturates the main thread: measured on a fake
+    /// stream, main-thread CPU climbed 47 % → 68 % → 94 % → 100 % as the
+    /// message grew, and a real 9-minute answer left the app pinned at
+    /// 100 % with the window gone and RSS climbing ~11 MB/s until it was
+    /// force-killed (#1743).
+    ///
+    /// Widening the window in proportion to the text bounds the repaint
+    /// RATE, which is the term that makes the cost quadratic. Below the
+    /// threshold the arithmetic is a no-op and short replies stream
+    /// exactly as they did before.
+    ///
+    /// This does not make a single parse cheaper — that is #1624, and it
+    /// is the real fix. This stops the app melting while that is done.
+    private func currentWindowNs() -> UInt64 {
+        guard flushedCharacters > Self.adaptiveThresholdChars else {
+            return Self.coalesceWindowNs
+        }
+        let scale = UInt64(flushedCharacters / Self.adaptiveThresholdChars)
+        let widened = Self.coalesceWindowNs &* max(1, scale)
+        return min(widened, Self.maxWindowNs)
+    }
 
     /// Codex r2 BLOCKING (unbounded queue): force-flush when the
     /// pending queue would exceed this many segments. An adversarial
@@ -1080,7 +1126,7 @@ final class SSEDeltaCoalescer: @unchecked Sendable {
         // Codex r2 BLOCKING: cap pending segments to bound queue
         // growth on adversarial alternating-kind streams.
         let overCap = pending.count > Self.maxPendingSegments
-        if !contentEverFlushed || elapsed >= Self.coalesceWindowNs || overCap {
+        if !contentEverFlushed || elapsed >= currentWindowNs() || overCap {
             await flush(onEvent: onEvent)
         }
     }
@@ -1093,7 +1139,7 @@ final class SSEDeltaCoalescer: @unchecked Sendable {
         appendSegment(kind: .reasoning, text: r)
         let elapsed = nowNs() &- lastFlushNs
         let overCap = pending.count > Self.maxPendingSegments
-        if !reasoningEverFlushed || elapsed >= Self.coalesceWindowNs || overCap {
+        if !reasoningEverFlushed || elapsed >= currentWindowNs() || overCap {
             await flush(onEvent: onEvent)
         }
     }
@@ -1104,6 +1150,10 @@ final class SSEDeltaCoalescer: @unchecked Sendable {
         guard !pending.isEmpty else { return }
         let toEmit = pending
         pending.removeAll(keepingCapacity: true)
+        // Count `toEmit`, NOT `pending` — `pending` was just emptied, so
+        // counting it leaves the total at zero forever and the adaptive
+        // window silently never widens.
+        flushedCharacters &+= toEmit.reduce(0) { $0 + $1.text.count }
         lastFlushNs = nowNs()
         for segment in toEmit {
             switch segment.kind {

--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatStreamClient.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatStreamClient.swift
@@ -475,11 +475,15 @@ struct ChatStreamClient {
         // Audit P1 — SSE delta coalescing. Per-delta MainActor.run on
         // a fast stream (M3 Ultra rapid-mlx can decode 200+ tok/s)
         // burned a main-actor hop per token. Coalesce content/reasoning
-        // deltas into a single hop per ~16 ms window (one display
-        // frame at 60 Hz) so a 500-token response that previously cost
-        // ~500 hops collapses to ~30 — while the first delta of each
-        // type still surfaces immediately so the typing indicator
-        // appears without perceptible delay.
+        // deltas into a single hop per window so a 500-token response
+        // that previously cost ~500 hops collapses to ~30 — while the
+        // first delta of each type still surfaces immediately so the
+        // typing indicator appears without perceptible delay.
+        //
+        // The window is 16 ms (one display frame at 60 Hz) and widens
+        // with the length already sent, to 250 ms — see
+        // ``SSEDeltaCoalescer/currentWindowNs()`` for why a fixed
+        // window leaves the turn quadratic (#1743).
         //
         // Invariants the coalescer preserves:
         //   * First content/reasoning delta flushes BEFORE any
@@ -1204,7 +1208,6 @@ final class SSEDeltaCoalescer: @unchecked Sendable {
             case .reasoning: reasoningEverFlushed = true
             }
         }
-        mainActorApplications += 1
         // ONE hop for the whole batch, in wire order.
         //
         // Hopping per segment defeats the point of coalescing on an
@@ -1217,6 +1220,12 @@ final class SSEDeltaCoalescer: @unchecked Sendable {
         // and order is preserved because the closure runs the array in
         // sequence.
         await MainActor.run {
+            // Counted INSIDE the hop, not beside it. Incrementing once per
+            // flush would measure flushes, and the thing worth measuring is
+            // main-actor applications: restore the per-segment version and a
+            // flush-side counter still reports 1, so the test that watches it
+            // would stay green through the exact regression it exists for.
+            self.mainActorApplications += 1
             for segment in toEmit {
                 switch segment.kind {
                 case .content: onEvent(.content(segment.text))

--- a/apps/rapid-mac/Tests/RapidTests/SSEDeltaCoalescerTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SSEDeltaCoalescerTests.swift
@@ -224,34 +224,49 @@ struct SSEDeltaCoalescerTests {
         }
         await coalescer.flush { recorder.capture($0) }
 
-        // Wire order preserved across kinds.
-        let kinds = recorder.events.compactMap { event -> String? in
+        // (1) The batching itself. Asserting on the events cannot show this —
+        // one hop carrying N segments and N hops carrying one each produce an
+        // identical event list — so ask the coalescer how many times it
+        // actually touched the main actor. 82 deltas went in; the per-segment
+        // version this replaced would report ~82 applications, one repaint
+        // each, which is #1743 all over again.
+        let hops = coalescer.mainActorApplications
+        #expect(
+            hops < 12,
+            "\(hops) main-actor applications for 82 deltas — flush is hopping per segment again, so the view rebuilds (and re-parses the whole message) about once per delta"
+        )
+
+        // (2) Wire order across kinds, as the sequence it actually is, not as
+        // two payloads checked separately: concatenating per kind would pass
+        // even if every reasoning delta arrived after every content delta.
+        let arrived = recorder.events.compactMap { event -> String? in
             switch event {
-            case .content: return "c"
-            case .reasoning: return "r"
+            case .content(let t): return "c:\(t)"
+            case .reasoning(let t): return "r:\(t)"
             default: return nil
             }
         }
-        #expect(kinds.first == "c", "first event should be the first content delta")
-        // Every c\(i) must precede its r\(i): concatenating the payloads in
-        // arrival order must reproduce the order they were appended in.
-        var content = ""
-        var reasoning = ""
-        for event in recorder.events {
-            switch event {
-            case .content(let t): content += t
-            case .reasoning(let t): reasoning += t
-            default: break
+        var expected = ["c:c0", "r:r0"]
+        for i in 0..<40 {
+            expected.append("c:c\(i)")
+            expected.append("r:r\(i)")
+        }
+        // Adjacent same-kind deltas merge into one segment, so compare the
+        // merged form: fold neighbours of equal kind together on both sides.
+        func merged(_ items: [String]) -> [String] {
+            items.reduce(into: [String]()) { acc, item in
+                let kind = item.prefix(2)
+                if let last = acc.last, last.hasPrefix(kind) {
+                    acc[acc.count - 1] = last + item.dropFirst(2)
+                } else {
+                    acc.append(item)
+                }
             }
         }
-        var expectedContent = "c0"
-        var expectedReasoning = "r0"
-        for i in 0..<40 {
-            expectedContent += "c\(i)"
-            expectedReasoning += "r\(i)"
-        }
-        #expect(content == expectedContent, "content text was reordered or dropped by the batched flush")
-        #expect(reasoning == expectedReasoning, "reasoning text was reordered or dropped by the batched flush")
+        #expect(
+            merged(arrived) == merged(expected),
+            "the batched flush reordered, dropped, or cross-mixed the stream"
+        )
     }
 
     @Test("flush on empty buffers is a no-op")

--- a/apps/rapid-mac/Tests/RapidTests/SSEDeltaCoalescerTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SSEDeltaCoalescerTests.swift
@@ -143,6 +143,61 @@ struct SSEDeltaCoalescerTests {
         #expect(collapsed == ["C", "R", "C"], "kind order leaked: got \(kindOrder)")
     }
 
+    /// #1743: the repaint RATE has to fall as the message grows.
+    ///
+    /// Every flush makes the chat view rebuild, and that rebuild re-parses
+    /// the WHOLE accumulated message through MarkdownUI. Parsing is
+    /// O(length), so a fixed 16 ms cadence costs O(length²) over a turn.
+    /// Measured on a fake stream before the fix, main-thread CPU climbed
+    /// 47 % → 68 % → 94 % → 100 % as the answer grew and stayed pinned;
+    /// a real 9-minute answer left the app at 100 % with its window gone
+    /// and RSS climbing ~11 MB/s until it was force-killed.
+    ///
+    /// This pins the two halves of the contract that matter:
+    ///
+    ///   1. a SHORT message is untouched — 16 ms still flushes, so the
+    ///      overwhelming majority of replies stream exactly as before;
+    ///   2. a LONG message does not, because the window has widened.
+    ///
+    /// Both directions are asserted deliberately. A "fix" that simply
+    /// slowed everything down would pass (2) and fail (1), and would be
+    /// a visible regression on every ordinary answer.
+    @Test("#1743: the coalescing window widens once the message is long")
+    @MainActor
+    func window_widens_with_accumulated_length() async {
+        // (1) Short message: 16 ms is still enough to flush.
+        let short = SSEDeltaCoalescer()
+        let shortRec = EventRecorder()
+        await short.appendContent("seed") { shortRec.capture($0) }   // first flush
+        let afterSeed = shortRec.events.count
+        try? await Task.sleep(for: .milliseconds(40))
+        await short.appendContent("more") { shortRec.capture($0) }
+        #expect(
+            shortRec.events.count > afterSeed,
+            "a short message must still flush on the 16 ms cadence — widening it unconditionally would slow every normal reply"
+        )
+
+        // (2) Long message: the same 40 ms pause is no longer enough.
+        let long = SSEDeltaCoalescer()
+        let longRec = EventRecorder()
+        await long.appendContent("seed") { longRec.capture($0) }
+        // Push well past the adaptive threshold. Each append is separated
+        // by enough real time to be flushed on the old cadence, so by the
+        // end the coalescer has genuinely emitted this much text.
+        let chunk = String(repeating: "x", count: 4_000)
+        for _ in 0..<6 {
+            try? await Task.sleep(for: .milliseconds(40))
+            await long.appendContent(chunk) { longRec.capture($0) }
+        }
+        let afterBulk = longRec.events.count
+        try? await Task.sleep(for: .milliseconds(40))
+        await long.appendContent("tail") { longRec.capture($0) }
+        #expect(
+            longRec.events.count == afterBulk,
+            "after ~24k characters a 40 ms gap still flushed — the window did not widen, so the repaint rate is still O(length²) (#1743)"
+        )
+    }
+
     @Test("flush on empty buffers is a no-op")
     @MainActor
     func empty_flush_emits_nothing() async {

--- a/apps/rapid-mac/Tests/RapidTests/SSEDeltaCoalescerTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SSEDeltaCoalescerTests.swift
@@ -178,24 +178,80 @@ struct SSEDeltaCoalescerTests {
         )
 
         // (2) Long message: the same 40 ms pause is no longer enough.
+        //
+        // Seed past the point where the window has reached its 250 ms
+        // ceiling in ONE flush, rather than creeping up to it over several.
+        // Creeping leaves the assertion comparing ~120 ms of sleeps against a
+        // ~128 ms window — 8 ms of slack, which a loaded CI runner eats, and
+        // the test then fails against correct code. From the ceiling the
+        // margin is 250 ms against 40 ms.
         let long = SSEDeltaCoalescer()
         let longRec = EventRecorder()
-        await long.appendContent("seed") { longRec.capture($0) }
-        // Push well past the adaptive threshold. Each append is separated
-        // by enough real time to be flushed on the old cadence, so by the
-        // end the coalescer has genuinely emitted this much text.
-        let chunk = String(repeating: "x", count: 4_000)
-        for _ in 0..<6 {
-            try? await Task.sleep(for: .milliseconds(40))
-            await long.appendContent(chunk) { longRec.capture($0) }
-        }
+        await long.appendContent(String(repeating: "x", count: 64_000)) { longRec.capture($0) }
         let afterBulk = longRec.events.count
+        #expect(afterBulk > 0, "the first delta must flush immediately regardless of size")
         try? await Task.sleep(for: .milliseconds(40))
         await long.appendContent("tail") { longRec.capture($0) }
         #expect(
             longRec.events.count == afterBulk,
-            "after ~24k characters a 40 ms gap still flushed — the window did not widen, so the repaint rate is still O(length²) (#1743)"
+            "a 40 ms gap still flushed after 64k characters — the window did not widen, so the repaint rate is still O(length²) (#1743)"
         )
+    }
+
+    /// The `overCap` force-flush path, which exists to bound the QUEUE, must
+    /// not also un-bound the repaint rate.
+    ///
+    /// It fires at 33 pending segments regardless of the window, so an
+    /// alternating content/reasoning stream reaches it constantly. If that
+    /// flush then hopped to the main actor once per segment, the view would
+    /// rebuild — and re-parse the whole message — about once per delta again,
+    /// which is the #1743 failure with extra steps. One flush must produce one
+    /// batch of events delivered together, in wire order.
+    @Test("#1743: an alternating stream still flushes as batches, in order")
+    @MainActor
+    func alternating_stream_flushes_in_ordered_batches() async {
+        let coalescer = SSEDeltaCoalescer()
+        let recorder = EventRecorder()
+        // Get both kinds past their first-delta immediate flush.
+        await coalescer.appendContent("c0") { recorder.capture($0) }
+        await coalescer.appendReasoning("r0") { recorder.capture($0) }
+        // Now alternate hard enough to trip the 32-segment cap, with no
+        // sleeps, so the window never expires and `overCap` is the only
+        // thing that can flush.
+        for i in 0..<40 {
+            await coalescer.appendContent("c\(i)") { recorder.capture($0) }
+            await coalescer.appendReasoning("r\(i)") { recorder.capture($0) }
+        }
+        await coalescer.flush { recorder.capture($0) }
+
+        // Wire order preserved across kinds.
+        let kinds = recorder.events.compactMap { event -> String? in
+            switch event {
+            case .content: return "c"
+            case .reasoning: return "r"
+            default: return nil
+            }
+        }
+        #expect(kinds.first == "c", "first event should be the first content delta")
+        // Every c\(i) must precede its r\(i): concatenating the payloads in
+        // arrival order must reproduce the order they were appended in.
+        var content = ""
+        var reasoning = ""
+        for event in recorder.events {
+            switch event {
+            case .content(let t): content += t
+            case .reasoning(let t): reasoning += t
+            default: break
+            }
+        }
+        var expectedContent = "c0"
+        var expectedReasoning = "r0"
+        for i in 0..<40 {
+            expectedContent += "c\(i)"
+            expectedReasoning += "r\(i)"
+        }
+        #expect(content == expectedContent, "content text was reordered or dropped by the batched flush")
+        #expect(reasoning == expectedReasoning, "reasoning text was reordered or dropped by the batched flush")
     }
 
     @Test("flush on empty buffers is a no-op")


### PR DESCRIPTION
## Why

Closes #1743, found in the 0.12.8 release dogfood and called a blocker.

A long streaming answer left the app **pinned at 100 % CPU with its window
gone** and RSS climbing ~11 MB/s past 10 GB until it had to be `SIGKILL`ed
(`SIGTERM` was ignored). The bundled engine stayed healthy the whole time
(`/health` reported ready, model loaded), so this is entirely the SwiftUI side.

## Root cause

Every coalescer flush rebuilds the chat view, and `LaTeXMarkdownView`
re-parses the **entire accumulated message** through MarkdownUI on each
rebuild. Parsing is O(length), so a fixed 16 ms cadence costs O(length²)
across a turn.

`sample` of the hung app put **1379 of 1621** main-thread samples in
`GraphHost.runTransaction`, with `Markdown.init(_:baseURL:imageBaseURL:)` and
`LaTeXMarkdownView.body` on the hot path, plus `AppKitPlatformViewHost`
layout invalidation re-entering the transaction that scheduled it.

## What changed

`SSEDeltaCoalescer`'s flush window now widens in proportion to the text
already flushed: **unchanged below 2 000 characters**, then linear, capped at
250 ms. That bounds the repaint RATE, which is the term that makes the cost
quadratic.

This does not make a single parse cheaper — that is #1624, and it is still the
real fix. This stops the app becoming unusable while that is done.

## Measured, same fake stream, before and after

| build | main-thread CPU over the turn | RSS |
| --- | --- | --- |
| `main` | 47 % → 55 % → 68 % → 88 % → 94 % → **100 % pegged** | unbounded (10 GB in the live case) |
| this PR | 9 % → 14 % → 13 % → 14 % → 32 % → 21 % → **~16 % steady** | 271 MB |

## How I checked the mechanism rather than assuming it

My first attempt at this fix changed nothing at all. Rather than conclude the
hypothesis was wrong, I forced the window to a flat 2 s as a probe — CPU fell
from 100 % to ~8 %, proving the coalescer really was the driver. That sent me
back to the diff, where the bug was mine: I counted `pending` **after**
`pending.removeAll()`, so the running total stayed 0 and the window never
widened. The numbers alone would have read as "wrong theory".

## Tests

`window_widens_with_accumulated_length` asserts **both** directions:

1. a short message still flushes on the 16 ms cadence — so ordinary replies
   are untouched;
2. a long one does not, because the window has widened.

Only asserting (2) would also pass for a change that simply slowed every reply
down, which would be a visible regression on every normal answer.

`swift test` cannot run on this machine (#1638), so CI is the authority for the
unit test.

## Verification

Six streaming-heavy golden flows pass on the fixed build: `chat-restore`,
`slow-stream-stop`, `chat-depth`, `tool-loop-budget`, `restored-tools`,
`model-crash-recovery`.