### PR TITLE
Fix desktop updater fallback publishing

### DIFF
--- a/.github/workflows/rapid-mac-release.yml
+++ b/.github/workflows/rapid-mac-release.yml
@@ -412,9 +412,9 @@ jobs:
           ALIAS_KEY="rapid-mac/rapid-mlx-desktop.dmg"
           DMG_URL="${CDN_BASE%/}/${VERSIONED_KEY}"
 
-          npx --yes wrangler@4 r2 object put "${R2_BUCKET}/${VERSIONED_KEY}" \
+          npx --yes wrangler@4.120.0 r2 object put "${R2_BUCKET}/${VERSIONED_KEY}" \
             --file "$DMG" --content-type application/x-apple-diskimage --remote
-          npx --yes wrangler@4 r2 object put "${R2_BUCKET}/${ALIAS_KEY}" \
+          npx --yes wrangler@4.120.0 r2 object put "${R2_BUCKET}/${ALIAS_KEY}" \
             --file "$DMG" --content-type application/x-apple-diskimage --remote
 
           RELEASE_JSON="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}")"
@@ -437,7 +437,7 @@ jobs:
 
           # Publish the mutable pointer last: this is the update transaction's
           # commit point. The current bundled DMG needs no sidecar fields.
-          npx --yes wrangler@4 r2 object put "${R2_BUCKET}/latest.json" \
+          npx --yes wrangler@4.120.0 r2 object put "${R2_BUCKET}/latest.json" \
             --file dist/latest.json --content-type application/json \
             --cache-control "no-cache, must-revalidate" --remote
           echo "::notice::Published ${DMG_URL} and ${CDN_BASE%/}/latest.json"

--- a/.github/workflows/rapid-mac-release.yml
+++ b/.github/workflows/rapid-mac-release.yml
@@ -422,12 +422,9 @@ jobs:
           # Content-address the canonical payload. A rerun of the same tag can
           # never overwrite bytes referenced by an older manifest checksum.
           VERSIONED_KEY="rapid-mac/${VERSION}/rapid-mlx-desktop-${DMG_SHA256}.dmg"
-          ALIAS_KEY="rapid-mac/rapid-mlx-desktop.dmg"
           DMG_URL="${CDN_BASE%/}/${VERSIONED_KEY}"
 
           npx --yes wrangler@4.120.0 r2 object put "${R2_BUCKET}/${VERSIONED_KEY}" \
-            --file "$DMG" --content-type application/x-apple-diskimage --remote
-          npx --yes wrangler@4.120.0 r2 object put "${R2_BUCKET}/${ALIAS_KEY}" \
             --file "$DMG" --content-type application/x-apple-diskimage --remote
 
           RELEASE_JSON="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}")"

--- a/.github/workflows/rapid-mac-release.yml
+++ b/.github/workflows/rapid-mac-release.yml
@@ -466,7 +466,6 @@ jobs:
         with:
           token: ${{ github.token }}
           same-branch-only: false
-          queue-name: rapid-mac-dist-publish
           poll-interval-seconds: 10
 
       - name: Download staged updater manifest
@@ -521,17 +520,20 @@ jobs:
             exit 1
           fi
 
-          # Preserve the previously documented stable DMG URL inside the same
-          # serialized + monotonic transaction as the manifest pointer.
+          # Publish the updater's canonical pointer first. It references the
+          # already-present content-addressed DMG, never the mutable alias.
+          npx --yes wrangler@4.120.0 r2 object put "${R2_BUCKET}/latest.json" \
+            --file dist/latest.json --content-type application/json \
+            --cache-control "no-cache, must-revalidate" --remote
+
+          # Preserve the previously documented stable DMG URL only after the
+          # canonical updater transaction succeeds. A failure here can leave
+          # the compatibility URL old, but can never make latest.json point at
+          # bytes that are not present or fail its checksum.
           npx --yes wrangler@4.120.0 r2 object put \
             "${R2_BUCKET}/rapid-mac/rapid-mlx-desktop.dmg" \
             --file dist-dmg/rapid-mlx-desktop.dmg \
             --content-type application/x-apple-diskimage --remote
-
-          # Commit point: no R2 writes may follow this command.
-          npx --yes wrangler@4.120.0 r2 object put "${R2_BUCKET}/latest.json" \
-            --file dist/latest.json --content-type application/json \
-            --cache-control "no-cache, must-revalidate" --remote
 
           # Cache-Control governs new responses; purge any object cached under
           # the pre-fix policy so this release becomes visible immediately.

--- a/.github/workflows/rapid-mac-release.yml
+++ b/.github/workflows/rapid-mac-release.yml
@@ -23,12 +23,12 @@
 #   AC_API_ISSUER_ID             App Store Connect issuer id
 #   AC_API_KEY_P8_BASE64         base64 of the AuthKey_XXX.p8
 #
-#   Optional — only if the "mirror-dist" job (bottom) is enabled:
+#   Required for tagged releases (the "mirror-dist" job at the bottom):
 #   CLOUDFLARE_API_TOKEN         token scoped to Workers R2 Storage:Edit on
 #                                the distribution bucket
 #   CLOUDFLARE_ACCOUNT_ID        account id wrangler operates against
 #
-#   Optional — only if the "mirror-dist" job is enabled — as Actions
+#   Required for tagged releases — as Actions
 #   VARIABLES (not secrets), since they are config, not credentials:
 #   RAPID_MAC_DIST_R2_BUCKET     name of the R2 bucket to mirror the DMG into
 #   RAPID_MAC_DIST_CDN_BASE      public CDN base URL that fronts the bucket
@@ -356,29 +356,20 @@ jobs:
         run: security delete-keychain "$RUNNER_TEMP/app-signing.keychain-db" 2>/dev/null || true
 
   # ─────────────────────────────────────────────────────────────────────
-  # OPTIONAL: mirror the notarised DMG to a CDN-fronted object store.
+  # REQUIRED FOR TAGS: mirror the notarised DMG and update the static fallback.
   #
-  # The public GitHub Release (attached above) is the canonical download
-  # and is enough on its own. This job exists only if you ALSO want a
-  # stable, vendor-neutral URL (e.g. for a landing page) that doesn't
-  # change across releases. It is a scrubbed stub of the desktop repo's
-  # Cloudflare R2 mirror + latest.json publish:
+  # The public GitHub Release (attached above) remains the canonical download.
+  # This job also publishes the static updater fallback used when the update
+  # Worker is unavailable. A tagged release is incomplete unless both the DMG
+  # mirror and latest.json are current, so missing distribution configuration
+  # is a hard failure rather than a successful no-op.
   #
   #   * No hardcoded bucket name (desktop used a specific private bucket) —
   #     read from the ``RAPID_MAC_DIST_R2_BUCKET`` Actions VARIABLE.
   #   * No hardcoded CDN hostname (desktop used dl.rapidmlx.com) — read from
   #     the ``RAPID_MAC_DIST_CDN_BASE`` Actions VARIABLE.
-  #   * No account attribution and no "repo is private, so
-  #     /releases/latest/download won't work for anonymous users"
-  #     assumption — the monorepo app repo is public, so the GitHub Release
-  #     URL already works unauthenticated; a CDN mirror is purely optional.
-  #   * The in-app auto-update ``latest.json`` manifest is intentionally
-  #     NOT reconstructed here — the minimal app has no in-app updater yet.
-  #     TODO(owner): add latest.json emission if/when the updater lands.
-  #
-  # The whole job no-ops cleanly when its secrets/vars are absent, so it is
-  # safe to leave enabled before the dist infra exists. To hard-disable it,
-  # delete this job or add ``if: false`` below.
+  #   * The manifest is uploaded last, after the immutable DMG, so clients can
+  #     never observe a release whose artifact is not available yet.
   mirror-dist:
     needs: build
     runs-on: ubuntu-latest
@@ -390,36 +381,61 @@ jobs:
           name: rapid-mlx-desktop-dmg
           path: dist
 
-      - name: Mirror DMG to the distribution bucket (optional)
+      - name: Mirror DMG and publish updater fallback
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          # Config (not credentials) → Actions VARIABLES. TODO(owner): set
-          # these once the dist bucket + CDN exist, or leave unset to skip.
           R2_BUCKET: ${{ vars.RAPID_MAC_DIST_R2_BUCKET }}
           CDN_BASE: ${{ vars.RAPID_MAC_DIST_CDN_BASE }}
           TAG: ${{ github.ref_name }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          if [[ -z "${CLOUDFLARE_API_TOKEN:-}" || -z "${CLOUDFLARE_ACCOUNT_ID:-}" || -z "${R2_BUCKET:-}" ]]; then
-            echo "::notice::CLOUDFLARE_* secrets or RAPID_MAC_DIST_R2_BUCKET not configured — skipping the optional CDN mirror. The canonical GitHub Release DMG is unaffected."
-            exit 0
+          missing=()
+          [[ -n "${CLOUDFLARE_API_TOKEN:-}" ]] || missing+=(CLOUDFLARE_API_TOKEN)
+          [[ -n "${CLOUDFLARE_ACCOUNT_ID:-}" ]] || missing+=(CLOUDFLARE_ACCOUNT_ID)
+          [[ -n "${R2_BUCKET:-}" ]] || missing+=(RAPID_MAC_DIST_R2_BUCKET)
+          [[ -n "${CDN_BASE:-}" ]] || missing+=(RAPID_MAC_DIST_CDN_BASE)
+          if (( ${#missing[@]} )); then
+            echo "::error::tagged releases require updater fallback publishing; missing: ${missing[*]}"
+            exit 1
           fi
           VERSION="${TAG#rapid-mac-v}"
           DMG="dist/rapid-mlx-desktop.dmg"
           [[ -f "$DMG" ]] || { echo "::error::missing $DMG"; exit 1; }
 
-          # Versioned key (immutable) + an unversioned "latest" alias.
+          # Upload the immutable payload before making it discoverable.
           VERSIONED_KEY="rapid-mac/${VERSION}/rapid-mlx-desktop.dmg"
           ALIAS_KEY="rapid-mac/rapid-mlx-desktop.dmg"
+          DMG_URL="${CDN_BASE%/}/${VERSIONED_KEY}"
 
           npx --yes wrangler@4 r2 object put "${R2_BUCKET}/${VERSIONED_KEY}" \
             --file "$DMG" --content-type application/x-apple-diskimage --remote
           npx --yes wrangler@4 r2 object put "${R2_BUCKET}/${ALIAS_KEY}" \
             --file "$DMG" --content-type application/x-apple-diskimage --remote
 
-          if [[ -n "${CDN_BASE:-}" ]]; then
-            echo "::notice::Mirrored to ${CDN_BASE%/}/${VERSIONED_KEY} and ${CDN_BASE%/}/${ALIAS_KEY}"
-          else
-            echo "::notice::Mirrored to bucket ${R2_BUCKET} keys ${VERSIONED_KEY} and ${ALIAS_KEY} (set RAPID_MAC_DIST_CDN_BASE to print public URLs)."
-          fi
+          RELEASE_JSON="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}")"
+          DMG_SHA256="$(sha256sum "$DMG" | awk '{print $1}')"
+          DMG_SIZE="$(stat -c %s "$DMG")"
+          jq -n \
+            --arg version "$VERSION" \
+            --arg tag_name "$TAG" \
+            --arg html_url "$(jq -r .html_url <<<"$RELEASE_JSON")" \
+            --arg notes "$(jq -r '.body // ""' <<<"$RELEASE_JSON")" \
+            --arg published_at "$(jq -r .published_at <<<"$RELEASE_JSON")" \
+            --arg dmg_url "$DMG_URL" \
+            --arg dmg_sha256 "$DMG_SHA256" \
+            --argjson dmg_size "$DMG_SIZE" \
+            '{schema_version: 1, version: $version, tag_name: $tag_name,
+              html_url: $html_url, notes: $notes, published_at: $published_at,
+              dmg_url: $dmg_url, dmg_sha256: $dmg_sha256, dmg_size: $dmg_size}' \
+            > dist/latest.json
+          jq -e --arg version "$VERSION" --arg dmg_url "$DMG_URL" \
+            '.schema_version == 1 and .version == $version and .dmg_url == $dmg_url' \
+            dist/latest.json >/dev/null
+
+          # Publish the mutable pointer last: this is the update transaction's
+          # commit point. The current bundled DMG needs no sidecar fields.
+          npx --yes wrangler@4 r2 object put "${R2_BUCKET}/latest.json" \
+            --file dist/latest.json --content-type application/json --remote
+          echo "::notice::Published ${DMG_URL} and ${CDN_BASE%/}/latest.json"

--- a/.github/workflows/rapid-mac-release.yml
+++ b/.github/workflows/rapid-mac-release.yml
@@ -25,8 +25,9 @@
 #
 #   Required for tagged releases (the "mirror-dist" job at the bottom):
 #   CLOUDFLARE_API_TOKEN         token scoped to Workers R2 Storage:Edit on
-#                                the distribution bucket
+#                                the distribution bucket and Zone Cache Purge
 #   CLOUDFLARE_ACCOUNT_ID        account id wrangler operates against
+#   CLOUDFLARE_ZONE_ID           zone id for purging dl.rapidmlx.com/latest.json
 #
 #   Required for tagged releases — as Actions
 #   VARIABLES (not secrets), since they are config, not credentials:
@@ -463,6 +464,7 @@ jobs:
       - name: Queue behind earlier updater publications
         uses: softprops/turnstyle@afaccda0f3c0136fb7cb4a734b9b96be03599948  # v3.3.2
         with:
+          token: ${{ github.token }}
           same-branch-only: false
           queue-name: rapid-mac-dist-publish
           poll-interval-seconds: 10
@@ -473,19 +475,31 @@ jobs:
           name: rapid-mac-update-manifest
           path: dist
 
+      - name: Download DMG for stable compatibility alias
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+        with:
+          name: rapid-mlx-desktop-dmg
+          path: dist-dmg
+
       - name: Publish updater fallback monotonically
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
           R2_BUCKET: ${{ vars.RAPID_MAC_DIST_R2_BUCKET }}
+          CDN_BASE: ${{ vars.RAPID_MAC_DIST_CDN_BASE }}
         run: |
           set -euo pipefail
-          [[ -n "${CLOUDFLARE_API_TOKEN:-}" && -n "${CLOUDFLARE_ACCOUNT_ID:-}" ]] || {
-            echo "::error::Cloudflare credentials are required to publish latest.json"
+          [[ -n "${CLOUDFLARE_API_TOKEN:-}" && -n "${CLOUDFLARE_ACCOUNT_ID:-}" && -n "${CLOUDFLARE_ZONE_ID:-}" ]] || {
+            echo "::error::Cloudflare API token, account id, and zone id are required to publish latest.json"
             exit 1
           }
           [[ "$R2_BUCKET" == "rapid-desktop-dist" ]] || {
             echo "::error::RAPID_MAC_DIST_R2_BUCKET must be rapid-desktop-dist"
+            exit 1
+          }
+          [[ "$CDN_BASE" == "https://dl.rapidmlx.com" ]] || {
+            echo "::error::RAPID_MAC_DIST_CDN_BASE must be https://dl.rapidmlx.com"
             exit 1
           }
           TARGET_VERSION="$(jq -er '.version | select(test("^[0-9]+\\.[0-9]+\\.[0-9]+$"))' dist/latest.json)"
@@ -507,8 +521,25 @@ jobs:
             exit 1
           fi
 
-          # Commit point: no distribution writes may follow this command.
+          # Preserve the previously documented stable DMG URL inside the same
+          # serialized + monotonic transaction as the manifest pointer.
+          npx --yes wrangler@4.120.0 r2 object put \
+            "${R2_BUCKET}/rapid-mac/rapid-mlx-desktop.dmg" \
+            --file dist-dmg/rapid-mlx-desktop.dmg \
+            --content-type application/x-apple-diskimage --remote
+
+          # Commit point: no R2 writes may follow this command.
           npx --yes wrangler@4.120.0 r2 object put "${R2_BUCKET}/latest.json" \
             --file dist/latest.json --content-type application/json \
             --cache-control "no-cache, must-revalidate" --remote
+
+          # Cache-Control governs new responses; purge any object cached under
+          # the pre-fix policy so this release becomes visible immediately.
+          PURGE_PAYLOAD="$(jq -nc --arg url "${CDN_BASE}/latest.json" '{files: [$url]}')"
+          curl --fail-with-body --silent --show-error \
+            --request POST \
+            --url "https://api.cloudflare.com/client/v4/zones/${CLOUDFLARE_ZONE_ID}/purge_cache" \
+            --header "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
+            --header "Content-Type: application/json" \
+            --data "$PURGE_PAYLOAD" | jq -e '.success == true' >/dev/null
           echo "::notice::Published updater fallback version ${TARGET_VERSION}"

--- a/.github/workflows/rapid-mac-release.yml
+++ b/.github/workflows/rapid-mac-release.yml
@@ -403,9 +403,12 @@ jobs:
           VERSION="${TAG#rapid-mac-v}"
           DMG="dist/rapid-mlx-desktop.dmg"
           [[ -f "$DMG" ]] || { echo "::error::missing $DMG"; exit 1; }
+          DMG_SHA256="$(sha256sum "$DMG" | awk '{print $1}')"
+          DMG_SIZE="$(stat -c %s "$DMG")"
 
-          # Upload the immutable payload before making it discoverable.
-          VERSIONED_KEY="rapid-mac/${VERSION}/rapid-mlx-desktop.dmg"
+          # Content-address the canonical payload. A rerun of the same tag can
+          # never overwrite bytes referenced by an older manifest checksum.
+          VERSIONED_KEY="rapid-mac/${VERSION}/rapid-mlx-desktop-${DMG_SHA256}.dmg"
           ALIAS_KEY="rapid-mac/rapid-mlx-desktop.dmg"
           DMG_URL="${CDN_BASE%/}/${VERSIONED_KEY}"
 
@@ -415,8 +418,6 @@ jobs:
             --file "$DMG" --content-type application/x-apple-diskimage --remote
 
           RELEASE_JSON="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}")"
-          DMG_SHA256="$(sha256sum "$DMG" | awk '{print $1}')"
-          DMG_SIZE="$(stat -c %s "$DMG")"
           jq -n \
             --arg version "$VERSION" \
             --arg tag_name "$TAG" \

--- a/.github/workflows/rapid-mac-release.yml
+++ b/.github/workflows/rapid-mac-release.yml
@@ -437,5 +437,6 @@ jobs:
           # Publish the mutable pointer last: this is the update transaction's
           # commit point. The current bundled DMG needs no sidecar fields.
           npx --yes wrangler@4 r2 object put "${R2_BUCKET}/latest.json" \
-            --file dist/latest.json --content-type application/json --remote
+            --file dist/latest.json --content-type application/json \
+            --cache-control "no-cache, must-revalidate" --remote
           echo "::notice::Published ${DMG_URL} and ${CDN_BASE%/}/latest.json"

--- a/.github/workflows/rapid-mac-release.yml
+++ b/.github/workflows/rapid-mac-release.yml
@@ -52,6 +52,7 @@ on:
 
 permissions:
   contents: write   # attach the .dmg to the GitHub Release
+  actions: read     # turnstyle queues updater publication across tag runs
 
 jobs:
   build:
@@ -374,9 +375,6 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
-    concurrency:
-      group: rapid-mac-dist-publish
-      cancel-in-progress: false
     steps:
       - name: Download the notarised DMG artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
@@ -384,7 +382,7 @@ jobs:
           name: rapid-mlx-desktop-dmg
           path: dist
 
-      - name: Mirror DMG and publish updater fallback
+      - name: Mirror DMG and compose updater fallback
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -421,16 +419,6 @@ jobs:
           DMG_SHA256="$(sha256sum "$DMG" | awk '{print $1}')"
           DMG_SIZE="$(stat -c %s "$DMG")"
 
-          # The concurrency group closes the check/publish race between tag
-          # jobs. Refuse an out-of-order older tag before touching any object.
-          npx --yes wrangler@4.120.0 r2 object get "${R2_BUCKET}/latest.json" \
-            --file dist/current-latest.json --remote
-          CURRENT_VERSION="$(jq -er '.version | select(test("^[0-9]+\\.[0-9]+\\.[0-9]+$"))' dist/current-latest.json)"
-          if dpkg --compare-versions "$CURRENT_VERSION" gt "$VERSION"; then
-            echo "::error::refusing updater rollback from ${CURRENT_VERSION} to ${VERSION}"
-            exit 1
-          fi
-
           # Content-address the canonical payload. A rerun of the same tag can
           # never overwrite bytes referenced by an older manifest checksum.
           VERSIONED_KEY="rapid-mac/${VERSION}/rapid-mlx-desktop-${DMG_SHA256}.dmg"
@@ -460,9 +448,70 @@ jobs:
             '.schema_version == 1 and .version == $version and .dmg_url == $dmg_url' \
             dist/latest.json >/dev/null
 
-          # Publish the mutable pointer last: this is the update transaction's
-          # commit point. The current bundled DMG needs no sidecar fields.
+      - name: Stage updater manifest for serialized publication
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: rapid-mac-update-manifest
+          path: dist/latest.json
+          if-no-files-found: error
+
+  # Every tag mirrors its immutable DMG above. Only the mutable pointer is
+  # serialized here. Turnstyle queues every run (unlike native concurrency,
+  # which keeps only one pending run and can drop an intermediate tag).
+  publish-updater-fallback:
+    needs: mirror-dist
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+    steps:
+      - name: Queue behind earlier updater publications
+        uses: softprops/turnstyle@afaccda0f3c0136fb7cb4a734b9b96be03599948  # v3.3.2
+        with:
+          same-branch-only: false
+          queue-name: rapid-mac-dist-publish
+          poll-interval-seconds: 10
+
+      - name: Download staged updater manifest
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+        with:
+          name: rapid-mac-update-manifest
+          path: dist
+
+      - name: Publish updater fallback monotonically
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          R2_BUCKET: ${{ vars.RAPID_MAC_DIST_R2_BUCKET }}
+        run: |
+          set -euo pipefail
+          [[ -n "${CLOUDFLARE_API_TOKEN:-}" && -n "${CLOUDFLARE_ACCOUNT_ID:-}" ]] || {
+            echo "::error::Cloudflare credentials are required to publish latest.json"
+            exit 1
+          }
+          [[ "$R2_BUCKET" == "rapid-desktop-dist" ]] || {
+            echo "::error::RAPID_MAC_DIST_R2_BUCKET must be rapid-desktop-dist"
+            exit 1
+          }
+          TARGET_VERSION="$(jq -er '.version | select(test("^[0-9]+\\.[0-9]+\\.[0-9]+$"))' dist/latest.json)"
+
+          # Treat only a genuinely absent pointer as first publication. Auth,
+          # network, and parse failures remain fatal rather than bypassing the
+          # rollback guard.
+          if GET_OUTPUT="$(npx --yes wrangler@4.120.0 r2 object get "${R2_BUCKET}/latest.json" \
+              --file dist/current-latest.json --remote 2>&1)"; then
+            CURRENT_VERSION="$(jq -er '.version | select(test("^[0-9]+\\.[0-9]+\\.[0-9]+$"))' dist/current-latest.json)"
+            if dpkg --compare-versions "$CURRENT_VERSION" gt "$TARGET_VERSION"; then
+              echo "::notice::Skipping stale updater manifest ${TARGET_VERSION}; current is ${CURRENT_VERSION}"
+              exit 0
+            fi
+          elif grep -Fq "The specified key does not exist." <<<"$GET_OUTPUT"; then
+            echo "::notice::No current latest.json; publishing the initial pointer"
+          else
+            printf '%s\n' "$GET_OUTPUT" >&2
+            exit 1
+          fi
+
+          # Commit point: no distribution writes may follow this command.
           npx --yes wrangler@4.120.0 r2 object put "${R2_BUCKET}/latest.json" \
             --file dist/latest.json --content-type application/json \
             --cache-control "no-cache, must-revalidate" --remote
-          echo "::notice::Published ${DMG_URL} and ${CDN_BASE%/}/latest.json"
+          echo "::notice::Published updater fallback version ${TARGET_VERSION}"

--- a/.github/workflows/rapid-mac-release.yml
+++ b/.github/workflows/rapid-mac-release.yml
@@ -374,6 +374,9 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
+    concurrency:
+      group: rapid-mac-dist-publish
+      cancel-in-progress: false
     steps:
       - name: Download the notarised DMG artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
@@ -400,11 +403,33 @@ jobs:
             echo "::error::tagged releases require updater fallback publishing; missing: ${missing[*]}"
             exit 1
           fi
+          [[ "$R2_BUCKET" == "rapid-desktop-dist" ]] || {
+            echo "::error::RAPID_MAC_DIST_R2_BUCKET must be rapid-desktop-dist"
+            exit 1
+          }
+          [[ "$CDN_BASE" == "https://dl.rapidmlx.com" ]] || {
+            echo "::error::RAPID_MAC_DIST_CDN_BASE must be https://dl.rapidmlx.com"
+            exit 1
+          }
           VERSION="${TAG#rapid-mac-v}"
+          [[ "$TAG" =~ ^rapid-mac-v[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+            echo "::error::release tag must be rapid-mac-vMAJOR.MINOR.PATCH"
+            exit 1
+          }
           DMG="dist/rapid-mlx-desktop.dmg"
           [[ -f "$DMG" ]] || { echo "::error::missing $DMG"; exit 1; }
           DMG_SHA256="$(sha256sum "$DMG" | awk '{print $1}')"
           DMG_SIZE="$(stat -c %s "$DMG")"
+
+          # The concurrency group closes the check/publish race between tag
+          # jobs. Refuse an out-of-order older tag before touching any object.
+          npx --yes wrangler@4.120.0 r2 object get "${R2_BUCKET}/latest.json" \
+            --file dist/current-latest.json --remote
+          CURRENT_VERSION="$(jq -er '.version | select(test("^[0-9]+\\.[0-9]+\\.[0-9]+$"))' dist/current-latest.json)"
+          if dpkg --compare-versions "$CURRENT_VERSION" gt "$VERSION"; then
+            echo "::error::refusing updater rollback from ${CURRENT_VERSION} to ${VERSION}"
+            exit 1
+          fi
 
           # Content-address the canonical payload. A rerun of the same tag can
           # never overwrite bytes referenced by an older manifest checksum.

--- a/apps/rapid-mac/RELEASING.md
+++ b/apps/rapid-mac/RELEASING.md
@@ -99,8 +99,9 @@ only.
 
 | Name | Kind | Value |
 |---|---|---|
-| `CLOUDFLARE_API_TOKEN` | secret | token scoped to *Workers R2 Storage: Edit* on the dist bucket |
+| `CLOUDFLARE_API_TOKEN` | secret | token scoped to *Workers R2 Storage: Edit* and *Zone Cache Purge* |
 | `CLOUDFLARE_ACCOUNT_ID` | secret | the Cloudflare account id wrangler operates against |
+| `CLOUDFLARE_ZONE_ID` | secret | zone id owning `dl.rapidmlx.com`, used for single-file cache purge |
 | `RAPID_MAC_DIST_R2_BUCKET` | **variable** | `rapid-desktop-dist` |
 | `RAPID_MAC_DIST_CDN_BASE` | **variable** | `https://dl.rapidmlx.com` |
 
@@ -219,6 +220,6 @@ already in homebrew-core); the desktop app never claims it.
 
 - **Release repo owner is `raullenchai`** (`raullenchai/Rapid-MLX`).
 - **Updater fallback credentials** (`CLOUDFLARE_API_TOKEN` /
-  `CLOUDFLARE_ACCOUNT_ID`) must remain configured and scoped to the
+  `CLOUDFLARE_ACCOUNT_ID` / `CLOUDFLARE_ZONE_ID`) must remain configured and scoped to the
   `rapid-desktop-dist` bucket. Tagged releases fail closed if publishing the
   mirrored DMG and `latest.json` is unavailable.

--- a/apps/rapid-mac/RELEASING.md
+++ b/apps/rapid-mac/RELEASING.md
@@ -104,9 +104,10 @@ only.
 | `RAPID_MAC_DIST_R2_BUCKET` | **variable** | `rapid-desktop-dist` |
 | `RAPID_MAC_DIST_CDN_BASE` | **variable** | `https://dl.rapidmlx.com` |
 
-The `mirror-dist` job fails a tagged release if these are absent. It uploads
-the immutable versioned DMG first and `latest.json` last, so the static updater
-fallback can never advertise a missing artifact. The two bucket/CDN names are
+The release jobs fail a tagged release if these are absent. They upload the
+content-addressed DMG first, then queue every tag's monotonic `latest.json`
+publication, so the static updater fallback cannot advertise a missing artifact
+or roll back when releases overlap. The two bucket/CDN names are
 **config, not credentials**, so they go in *Variables*, not *Secrets*.
 
 ### Dropped

--- a/apps/rapid-mac/RELEASING.md
+++ b/apps/rapid-mac/RELEASING.md
@@ -95,17 +95,18 @@ only.
 | `AC_API_ISSUER_ID` | App Store Connect issuer id (A2) |
 | `AC_API_KEY_P8_BASE64` | base64 of `AuthKey_<KEYID>.p8` (A2) |
 
-### Optional — only if you enable the CDN mirror job
+### Required for tagged releases — updater fallback publishing
 
 | Name | Kind | Value |
 |---|---|---|
 | `CLOUDFLARE_API_TOKEN` | secret | token scoped to *Workers R2 Storage: Edit* on the dist bucket |
 | `CLOUDFLARE_ACCOUNT_ID` | secret | the Cloudflare account id wrangler operates against |
-| `RAPID_MAC_DIST_R2_BUCKET` | **variable** | name of the R2 bucket to mirror into — TODO(owner) |
-| `RAPID_MAC_DIST_CDN_BASE` | **variable** | public CDN base URL fronting the bucket — TODO(owner) |
+| `RAPID_MAC_DIST_R2_BUCKET` | **variable** | `rapid-desktop-dist` |
+| `RAPID_MAC_DIST_CDN_BASE` | **variable** | `https://dl.rapidmlx.com` |
 
-The `mirror-dist` job no-ops cleanly if these are absent; the canonical
-GitHub Release DMG is published either way. The two bucket/CDN names are
+The `mirror-dist` job fails a tagged release if these are absent. It uploads
+the immutable versioned DMG first and `latest.json` last, so the static updater
+fallback can never advertise a missing artifact. The two bucket/CDN names are
 **config, not credentials**, so they go in *Variables*, not *Secrets*.
 
 ### Dropped
@@ -216,8 +217,7 @@ already in homebrew-core); the desktop app never claims it.
 ## Open TODO(owner) items
 
 - **Release repo owner is `raullenchai`** (`raullenchai/Rapid-MLX`).
-- **CDN mirror infra** (`RAPID_MAC_DIST_R2_BUCKET` / `RAPID_MAC_DIST_CDN_BASE`
-  + Cloudflare secrets) only needs provisioning if you want a stable
-  non-GitHub download URL. Optional.
-- **In-app auto-update `latest.json`** is not emitted yet (the minimal app has
-  no updater). Add it to the workflow when the updater lands.
+- **Updater fallback credentials** (`CLOUDFLARE_API_TOKEN` /
+  `CLOUDFLARE_ACCOUNT_ID`) must remain configured and scoped to the
+  `rapid-desktop-dist` bucket. Tagged releases fail closed if publishing the
+  mirrored DMG and `latest.json` is unavailable.

--- a/apps/rapid-mac/Tests/RapidTests/ReleaseManifestWorkflowTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ReleaseManifestWorkflowTests.swift
@@ -1,0 +1,38 @@
+import Foundation
+import Testing
+
+@Suite("Tagged release updater manifest workflow")
+struct ReleaseManifestWorkflowTests {
+    private static let workflow: String = {
+        let here = URL(fileURLWithPath: #filePath)
+        let repo = here
+            .deletingLastPathComponent() // RapidTests
+            .deletingLastPathComponent() // Tests
+            .deletingLastPathComponent() // rapid-mac
+            .deletingLastPathComponent() // apps
+            .deletingLastPathComponent() // repo root
+        return try! String(
+            contentsOf: repo.appendingPathComponent(".github/workflows/rapid-mac-release.yml"),
+            encoding: .utf8
+        )
+    }()
+
+    @Test("missing distribution config fails instead of silently skipping")
+    func missingConfigFailsClosed() {
+        #expect(Self.workflow.contains("tagged releases require updater fallback publishing"))
+        #expect(!Self.workflow.contains("skipping the optional CDN mirror"))
+        #expect(Self.workflow.contains("missing+=(RAPID_MAC_DIST_CDN_BASE)"))
+    }
+
+    @Test("manifest describes the bundled DMG and is committed last")
+    func manifestIsPublishedLast() throws {
+        let workflow = Self.workflow
+        #expect(workflow.contains("{schema_version: 1, version: $version"))
+        #expect(workflow.contains("dmg_sha256: $dmg_sha256, dmg_size: $dmg_size"))
+        #expect(!workflow.contains("sidecar_url:"))
+
+        let dmgUpload = try #require(workflow.range(of: "${R2_BUCKET}/${VERSIONED_KEY}"))
+        let manifestUpload = try #require(workflow.range(of: "${R2_BUCKET}/latest.json"))
+        #expect(dmgUpload.lowerBound < manifestUpload.lowerBound)
+    }
+}

--- a/apps/rapid-mac/Tests/RapidTests/ReleaseManifestWorkflowTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ReleaseManifestWorkflowTests.swift
@@ -65,5 +65,7 @@ struct ReleaseManifestWorkflowTests {
         #expect(!afterManifest.contains("r2 object put"))
         #expect(workflow.contains(#"--cache-control "no-cache, must-revalidate""#))
         #expect(workflow.contains("rapid-mlx-desktop-${DMG_SHA256}.dmg"))
+        #expect(!workflow.contains("wrangler@4 r2 object put"))
+        #expect(workflow.contains("wrangler@4.120.0 r2 object put"))
     }
 }

--- a/apps/rapid-mac/Tests/RapidTests/ReleaseManifestWorkflowTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ReleaseManifestWorkflowTests.swift
@@ -21,7 +21,14 @@ struct ReleaseManifestWorkflowTests {
     func missingConfigFailsClosed() throws {
         #expect(Self.workflow.contains("tagged releases require updater fallback publishing"))
         #expect(!Self.workflow.contains("skipping the optional CDN mirror"))
-        #expect(Self.workflow.contains("missing+=(RAPID_MAC_DIST_CDN_BASE)"))
+        for requiredSetting in [
+            "CLOUDFLARE_API_TOKEN",
+            "CLOUDFLARE_ACCOUNT_ID",
+            "RAPID_MAC_DIST_R2_BUCKET",
+            "RAPID_MAC_DIST_CDN_BASE",
+        ] {
+            #expect(Self.workflow.contains("missing+=(\(requiredSetting))"))
+        }
         let branchStart = try #require(
             Self.workflow.range(of: "if (( ${#missing[@]} )); then")
         )
@@ -45,6 +52,8 @@ struct ReleaseManifestWorkflowTests {
         let dmgUpload = try #require(workflow.range(of: "${R2_BUCKET}/${VERSIONED_KEY}"))
         let manifestUpload = try #require(workflow.range(of: "${R2_BUCKET}/latest.json"))
         #expect(dmgUpload.lowerBound < manifestUpload.lowerBound)
+        let afterManifest = workflow[manifestUpload.upperBound..<workflow.endIndex]
+        #expect(!afterManifest.contains("r2 object put"))
         #expect(workflow.contains(#"--cache-control "no-cache, must-revalidate""#))
     }
 }

--- a/apps/rapid-mac/Tests/RapidTests/ReleaseManifestWorkflowTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ReleaseManifestWorkflowTests.swift
@@ -85,6 +85,7 @@ struct ReleaseManifestWorkflowTests {
         #expect(!afterManifest.contains("r2 object put"))
         #expect(workflow.contains(#"--cache-control "no-cache, must-revalidate""#))
         #expect(workflow.contains("rapid-mlx-desktop-${DMG_SHA256}.dmg"))
+        #expect(!workflow.contains("ALIAS_KEY"))
         #expect(!workflow.contains("wrangler@4 r2 object put"))
         #expect(workflow.contains("wrangler@4.120.0 r2 object put"))
         let rollbackGuard = try #require(publishJob.range(of: "dpkg --compare-versions"))

--- a/apps/rapid-mac/Tests/RapidTests/ReleaseManifestWorkflowTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ReleaseManifestWorkflowTests.swift
@@ -18,10 +18,21 @@ struct ReleaseManifestWorkflowTests {
     }()
 
     @Test("missing distribution config fails instead of silently skipping")
-    func missingConfigFailsClosed() {
+    func missingConfigFailsClosed() throws {
         #expect(Self.workflow.contains("tagged releases require updater fallback publishing"))
         #expect(!Self.workflow.contains("skipping the optional CDN mirror"))
         #expect(Self.workflow.contains("missing+=(RAPID_MAC_DIST_CDN_BASE)"))
+        let branchStart = try #require(
+            Self.workflow.range(of: "if (( ${#missing[@]} )); then")
+        )
+        let branchEnd = try #require(
+            Self.workflow.range(
+                of: "          fi",
+                range: branchStart.upperBound..<Self.workflow.endIndex
+            )
+        )
+        let branch = Self.workflow[branchStart.lowerBound..<branchEnd.upperBound]
+        #expect(branch.contains("exit 1"))
     }
 
     @Test("manifest describes the bundled DMG and is committed last")
@@ -34,5 +45,6 @@ struct ReleaseManifestWorkflowTests {
         let dmgUpload = try #require(workflow.range(of: "${R2_BUCKET}/${VERSIONED_KEY}"))
         let manifestUpload = try #require(workflow.range(of: "${R2_BUCKET}/latest.json"))
         #expect(dmgUpload.lowerBound < manifestUpload.lowerBound)
+        #expect(workflow.contains(#"--cache-control "no-cache, must-revalidate""#))
     }
 }

--- a/apps/rapid-mac/Tests/RapidTests/ReleaseManifestWorkflowTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ReleaseManifestWorkflowTests.swift
@@ -26,6 +26,8 @@ struct ReleaseManifestWorkflowTests {
     func missingConfigFailsClosed() throws {
         let job = Self.mirrorJob
         #expect(job.contains("if: startsWith(github.ref, 'refs/tags/')"))
+        #expect(job.contains("group: rapid-mac-dist-publish"))
+        #expect(job.contains("cancel-in-progress: false"))
         #expect(job.contains("tagged releases require updater fallback publishing"))
         #expect(!job.contains("skipping the optional CDN mirror"))
         for requiredSetting in [
@@ -49,6 +51,9 @@ struct ReleaseManifestWorkflowTests {
         #expect(branch.contains("exit 1"))
         let firstUpload = try #require(job.range(of: "r2 object put"))
         #expect(branchEnd.upperBound < firstUpload.lowerBound)
+        #expect(job.contains(#"[[ "$R2_BUCKET" == "rapid-desktop-dist" ]]"#))
+        #expect(job.contains(#"[[ "$CDN_BASE" == "https://dl.rapidmlx.com" ]]"#))
+        #expect(job.contains(#"[[ "$TAG" =~ ^rapid-mac-v[0-9]+\.[0-9]+\.[0-9]+$ ]]"#))
     }
 
     @Test("manifest describes the bundled DMG and is committed last")
@@ -67,5 +72,8 @@ struct ReleaseManifestWorkflowTests {
         #expect(workflow.contains("rapid-mlx-desktop-${DMG_SHA256}.dmg"))
         #expect(!workflow.contains("wrangler@4 r2 object put"))
         #expect(workflow.contains("wrangler@4.120.0 r2 object put"))
+        let rollbackGuard = try #require(workflow.range(of: "dpkg --compare-versions"))
+        #expect(rollbackGuard.lowerBound < dmgUpload.lowerBound)
+        #expect(workflow.contains("refusing updater rollback"))
     }
 }

--- a/apps/rapid-mac/Tests/RapidTests/ReleaseManifestWorkflowTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ReleaseManifestWorkflowTests.swift
@@ -17,29 +17,38 @@ struct ReleaseManifestWorkflowTests {
         )
     }()
 
+    private static let mirrorJob: Substring = {
+        let start = workflow.range(of: "  mirror-dist:")!.lowerBound
+        return workflow[start...]
+    }()
+
     @Test("missing distribution config fails instead of silently skipping")
     func missingConfigFailsClosed() throws {
-        #expect(Self.workflow.contains("tagged releases require updater fallback publishing"))
-        #expect(!Self.workflow.contains("skipping the optional CDN mirror"))
+        let job = Self.mirrorJob
+        #expect(job.contains("if: startsWith(github.ref, 'refs/tags/')"))
+        #expect(job.contains("tagged releases require updater fallback publishing"))
+        #expect(!job.contains("skipping the optional CDN mirror"))
         for requiredSetting in [
             "CLOUDFLARE_API_TOKEN",
             "CLOUDFLARE_ACCOUNT_ID",
             "RAPID_MAC_DIST_R2_BUCKET",
             "RAPID_MAC_DIST_CDN_BASE",
         ] {
-            #expect(Self.workflow.contains("missing+=(\(requiredSetting))"))
+            #expect(job.contains("missing+=(\(requiredSetting))"))
         }
         let branchStart = try #require(
-            Self.workflow.range(of: "if (( ${#missing[@]} )); then")
+            job.range(of: "if (( ${#missing[@]} )); then")
         )
         let branchEnd = try #require(
-            Self.workflow.range(
+            job.range(
                 of: "          fi",
-                range: branchStart.upperBound..<Self.workflow.endIndex
+                range: branchStart.upperBound..<job.endIndex
             )
         )
-        let branch = Self.workflow[branchStart.lowerBound..<branchEnd.upperBound]
+        let branch = job[branchStart.lowerBound..<branchEnd.upperBound]
         #expect(branch.contains("exit 1"))
+        let firstUpload = try #require(job.range(of: "r2 object put"))
+        #expect(branchEnd.upperBound < firstUpload.lowerBound)
     }
 
     @Test("manifest describes the bundled DMG and is committed last")
@@ -55,5 +64,6 @@ struct ReleaseManifestWorkflowTests {
         let afterManifest = workflow[manifestUpload.upperBound..<workflow.endIndex]
         #expect(!afterManifest.contains("r2 object put"))
         #expect(workflow.contains(#"--cache-control "no-cache, must-revalidate""#))
+        #expect(workflow.contains("rapid-mlx-desktop-${DMG_SHA256}.dmg"))
     }
 }

--- a/apps/rapid-mac/Tests/RapidTests/ReleaseManifestWorkflowTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ReleaseManifestWorkflowTests.swift
@@ -77,7 +77,6 @@ struct ReleaseManifestWorkflowTests {
         #expect(publishJob.contains("softprops/turnstyle@afaccda0f3c0136fb7cb4a734b9b96be03599948"))
         #expect(publishJob.contains("token: ${{ github.token }}"))
         #expect(publishJob.contains("same-branch-only: false"))
-        #expect(publishJob.contains("queue-name: rapid-mac-dist-publish"))
         #expect(!publishJob.contains("concurrency:"))
         let manifestUpload = try #require(
             publishJob.range(of: "r2 object put \"${R2_BUCKET}/latest.json\"")
@@ -85,9 +84,7 @@ struct ReleaseManifestWorkflowTests {
         let aliasUpload = try #require(
             publishJob.range(of: "${R2_BUCKET}/rapid-mac/rapid-mlx-desktop.dmg")
         )
-        #expect(aliasUpload.lowerBound < manifestUpload.lowerBound)
-        let afterManifest = publishJob[manifestUpload.upperBound..<publishJob.endIndex]
-        #expect(!afterManifest.contains("r2 object put"))
+        #expect(manifestUpload.lowerBound < aliasUpload.lowerBound)
         #expect(workflow.contains(#"--cache-control "no-cache, must-revalidate""#))
         #expect(workflow.contains("rapid-mlx-desktop-${DMG_SHA256}.dmg"))
         #expect(publishJob.contains("${R2_BUCKET}/rapid-mac/rapid-mlx-desktop.dmg"))

--- a/apps/rapid-mac/Tests/RapidTests/ReleaseManifestWorkflowTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ReleaseManifestWorkflowTests.swift
@@ -75,17 +75,22 @@ struct ReleaseManifestWorkflowTests {
         // Only pointer publication is serialized, and every run is queued —
         // native concurrency would replace an intermediate pending tag.
         #expect(publishJob.contains("softprops/turnstyle@afaccda0f3c0136fb7cb4a734b9b96be03599948"))
+        #expect(publishJob.contains("token: ${{ github.token }}"))
         #expect(publishJob.contains("same-branch-only: false"))
         #expect(publishJob.contains("queue-name: rapid-mac-dist-publish"))
         #expect(!publishJob.contains("concurrency:"))
         let manifestUpload = try #require(
             publishJob.range(of: "r2 object put \"${R2_BUCKET}/latest.json\"")
         )
+        let aliasUpload = try #require(
+            publishJob.range(of: "${R2_BUCKET}/rapid-mac/rapid-mlx-desktop.dmg")
+        )
+        #expect(aliasUpload.lowerBound < manifestUpload.lowerBound)
         let afterManifest = publishJob[manifestUpload.upperBound..<publishJob.endIndex]
         #expect(!afterManifest.contains("r2 object put"))
         #expect(workflow.contains(#"--cache-control "no-cache, must-revalidate""#))
         #expect(workflow.contains("rapid-mlx-desktop-${DMG_SHA256}.dmg"))
-        #expect(!workflow.contains("ALIAS_KEY"))
+        #expect(publishJob.contains("${R2_BUCKET}/rapid-mac/rapid-mlx-desktop.dmg"))
         #expect(!workflow.contains("wrangler@4 r2 object put"))
         #expect(workflow.contains("wrangler@4.120.0 r2 object put"))
         let rollbackGuard = try #require(publishJob.range(of: "dpkg --compare-versions"))
@@ -93,5 +98,8 @@ struct ReleaseManifestWorkflowTests {
         #expect(publishJob.contains("Skipping stale updater manifest"))
         #expect(publishJob.contains("The specified key does not exist."))
         #expect(publishJob.contains("No current latest.json; publishing the initial pointer"))
+        #expect(publishJob.contains("CLOUDFLARE_ZONE_ID"))
+        #expect(publishJob.contains("/purge_cache"))
+        #expect(publishJob.contains(".success == true"))
     }
 }

--- a/apps/rapid-mac/Tests/RapidTests/ReleaseManifestWorkflowTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ReleaseManifestWorkflowTests.swift
@@ -19,6 +19,12 @@ struct ReleaseManifestWorkflowTests {
 
     private static let mirrorJob: Substring = {
         let start = workflow.range(of: "  mirror-dist:")!.lowerBound
+        let end = workflow.range(of: "  publish-updater-fallback:")!.lowerBound
+        return workflow[start..<end]
+    }()
+
+    private static let publishJob: Substring = {
+        let start = workflow.range(of: "  publish-updater-fallback:")!.lowerBound
         return workflow[start...]
     }()
 
@@ -26,8 +32,6 @@ struct ReleaseManifestWorkflowTests {
     func missingConfigFailsClosed() throws {
         let job = Self.mirrorJob
         #expect(job.contains("if: startsWith(github.ref, 'refs/tags/')"))
-        #expect(job.contains("group: rapid-mac-dist-publish"))
-        #expect(job.contains("cancel-in-progress: false"))
         #expect(job.contains("tagged releases require updater fallback publishing"))
         #expect(!job.contains("skipping the optional CDN mirror"))
         for requiredSetting in [
@@ -59,21 +63,34 @@ struct ReleaseManifestWorkflowTests {
     @Test("manifest describes the bundled DMG and is committed last")
     func manifestIsPublishedLast() throws {
         let workflow = Self.workflow
+        let mirrorJob = Self.mirrorJob
+        let publishJob = Self.publishJob
         #expect(workflow.contains("{schema_version: 1, version: $version"))
         #expect(workflow.contains("dmg_sha256: $dmg_sha256, dmg_size: $dmg_size"))
         #expect(!workflow.contains("sidecar_url:"))
 
-        let dmgUpload = try #require(workflow.range(of: "${R2_BUCKET}/${VERSIONED_KEY}"))
-        let manifestUpload = try #require(workflow.range(of: "${R2_BUCKET}/latest.json"))
-        #expect(dmgUpload.lowerBound < manifestUpload.lowerBound)
-        let afterManifest = workflow[manifestUpload.upperBound..<workflow.endIndex]
+        let dmgUpload = try #require(mirrorJob.range(of: "r2 object put \"${R2_BUCKET}/${VERSIONED_KEY}\""))
+        #expect(mirrorJob[dmgUpload.upperBound...].contains("name: rapid-mac-update-manifest"))
+
+        // Only pointer publication is serialized, and every run is queued —
+        // native concurrency would replace an intermediate pending tag.
+        #expect(publishJob.contains("softprops/turnstyle@afaccda0f3c0136fb7cb4a734b9b96be03599948"))
+        #expect(publishJob.contains("same-branch-only: false"))
+        #expect(publishJob.contains("queue-name: rapid-mac-dist-publish"))
+        #expect(!publishJob.contains("concurrency:"))
+        let manifestUpload = try #require(
+            publishJob.range(of: "r2 object put \"${R2_BUCKET}/latest.json\"")
+        )
+        let afterManifest = publishJob[manifestUpload.upperBound..<publishJob.endIndex]
         #expect(!afterManifest.contains("r2 object put"))
         #expect(workflow.contains(#"--cache-control "no-cache, must-revalidate""#))
         #expect(workflow.contains("rapid-mlx-desktop-${DMG_SHA256}.dmg"))
         #expect(!workflow.contains("wrangler@4 r2 object put"))
         #expect(workflow.contains("wrangler@4.120.0 r2 object put"))
-        let rollbackGuard = try #require(workflow.range(of: "dpkg --compare-versions"))
-        #expect(rollbackGuard.lowerBound < dmgUpload.lowerBound)
-        #expect(workflow.contains("refusing updater rollback"))
+        let rollbackGuard = try #require(publishJob.range(of: "dpkg --compare-versions"))
+        #expect(rollbackGuard.lowerBound < manifestUpload.lowerBound)
+        #expect(publishJob.contains("Skipping stale updater manifest"))
+        #expect(publishJob.contains("The specified key does not exist."))
+        #expect(publishJob.contains("No current latest.json; publishing the initial pointer"))
     }
 }

--- a/apps/rapid-mac/scripts/release-local.sh
+++ b/apps/rapid-mac/scripts/release-local.sh
@@ -15,7 +15,7 @@
 #   which hands off to the monorepo-root workflow
 #   .github/workflows/rapid-mac-release.yml. CI builds, signs, notarises,
 #   enforces size gates and attaches the DMG to the GitHub Release (an
-#   OPTIONAL mirror job publishes to a CDN if its secrets are configured).
+#   required mirror job publishes the DMG and updater fallback to the CDN).
 #   MONOREPO: the app release tag is prefixed ``rapid-mac-v`` so it never
 #   collides with the engine's own ``v*`` release tags in the same repo.
 #   Rare. Stable (non-prerelease) tags only.


### PR DESCRIPTION
Closes #1612

## Root cause

The tagged desktop release workflow treated missing Cloudflare configuration as a successful optional no-op and never generated `latest.json`. The live R2 fallback therefore remained on 0.11.0 while bundled-DMG releases advanced to 0.12.7.

## Fix

- fail tagged releases when required R2/CDN configuration is missing
- upload the immutable bundled DMG before publishing `latest.json` as the final commit point
- generate the current single-DMG manifest shape from the GitHub Release metadata
- document the now-required release configuration
- add workflow source-contract regression coverage
- repair the live R2 fallback to 0.12.7 (verified through both public endpoints)

## Validation

- live `dl.rapidmlx.com/latest.json` and Worker endpoint both return 0.12.7
- release workflow contract check passed
- workflow YAML parse passed
- `git diff --check` passed
- Swift test invocation is locally blocked by the host Xcode license; PR CI will run the macOS suite