### PR TITLE
Fix the readiness source gate that made rapid-mac build red on main

### DIFF
--- a/apps/rapid-mac/Tests/RapidTests/ContentViewReadinessActionTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ContentViewReadinessActionTests.swift
@@ -115,6 +115,12 @@ struct ContentViewReadinessActionTests {
                 }
                 continue
             }
+            // Extended regex literal (`#/…/#`). Its contents can hold `//`,
+            // braces, and call-shaped text, so it is skipped like a literal.
+            if c == "#", let end = Self.endOfExtendedRegex(in: swift, at: i) {
+                i = end
+                continue
+            }
             // String literal, including raw (`#"…"#`) and multiline (`"""`).
             if c == "\"" || c == "#" {
                 if let end = Self.endOfStringLiteral(in: swift, at: i) {
@@ -145,15 +151,25 @@ struct ContentViewReadinessActionTests {
         }
         guard cursor < source.endIndex, source[cursor] == "\"" else { return nil }
 
-        // A run of three or more opening quotes is a multiline literal; `""`
-        // on its own is just an empty one.
+        // `"""` opens a multiline literal only when a newline follows it —
+        // that is the grammar, and it is what separates it from a raw
+        // single-line literal whose contents happen to start with quotes.
+        // `#"""foo"#` is the latter: three quotes, no newline, value `""foo`.
+        // Treating it as multiline pairs its close with a LATER literal's
+        // open and erases the executable source in between.
         var quoteRun = 0
         var probe = cursor
         while probe < source.endIndex, source[probe] == "\"" {
             quoteRun += 1
             probe = source.index(after: probe)
         }
-        let delimiter = quoteRun >= 3 ? 3 : 1
+        var delimiter = 1
+        if quoteRun >= 3 {
+            let afterOpener = source.index(cursor, offsetBy: 3)
+            if afterOpener < source.endIndex, source[afterOpener].isNewline {
+                delimiter = 3
+            }
+        }
 
         var scan = source.index(cursor, offsetBy: delimiter)
         while scan < source.endIndex {
@@ -193,6 +209,47 @@ struct ContentViewReadinessActionTests {
             scan = source.index(after: scan)
         }
         return nil  // Unterminated: treat as "not a literal" and keep scanning.
+    }
+
+    /// The index just past the closing delimiter of the extended regex
+    /// literal starting at `start` (`#/…/#`, with any number of hashes), or
+    /// nil if no such literal starts there.
+    ///
+    /// Bare `/…/` regex literals are deliberately NOT recognised: telling one
+    /// from division needs real parsing, and guessing wrong would mangle
+    /// ordinary arithmetic. `ContentView.swift` contains none, and the shape
+    /// this gate defends against — a cold-start call reintroduced by a
+    /// refactor — does not arrive hidden inside a regex.
+    private static func endOfExtendedRegex(
+        in source: String,
+        at start: String.Index
+    ) -> String.Index? {
+        var cursor = start
+        var hashes = 0
+        while cursor < source.endIndex, source[cursor] == "#" {
+            hashes += 1
+            cursor = source.index(after: cursor)
+        }
+        guard hashes > 0, cursor < source.endIndex, source[cursor] == "/" else { return nil }
+
+        var scan = source.index(after: cursor)
+        while scan < source.endIndex {
+            if source[scan] == "\\" {
+                scan = source.index(scan, offsetBy: 2, limitedBy: source.endIndex) ?? source.endIndex
+                continue
+            }
+            if source[scan] == "/" {
+                var probe = source.index(after: scan)
+                var seen = 0
+                while seen < hashes, probe < source.endIndex, source[probe] == "#" {
+                    seen += 1
+                    probe = source.index(after: probe)
+                }
+                if seen == hashes { return probe }
+            }
+            scan = source.index(after: scan)
+        }
+        return nil
     }
 
     /// The source text of the block whose opening `{` is at `start`, up to

--- a/apps/rapid-mac/Tests/RapidTests/ContentViewReadinessActionTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ContentViewReadinessActionTests.swift
@@ -33,13 +33,40 @@ struct ContentViewReadinessActionTests {
             return
         }
 
+        // Brace counting is fooled by a `{` or `}` inside a string literal, so
+        // the slice can end early (or, if a literal swallows a real brace,
+        // late). Neither is allowed to hide a regression, so each check below
+        // is arranged to fail rather than pass when the slice is wrong.
+
+        // A slice that ended early cannot contain the call, so this goes red —
+        // loudly, which is the safe direction.
         #expect(
             function.contains("server.ensureServing(alias:target,hfPath:hfPath)"),
             "The Chat readiness button must switch away from a resident Images model."
         )
+
+        // Deliberately checked against the WHOLE file, not the slice. Scoping
+        // it to the slice is what makes a mis-slice dangerous: put
+        // `let marker = "}"` after the ensureServing call and before a
+        // cold-start call, and the extraction stops at the literal's brace —
+        // the positive check above still passes, and the forbidden call sits
+        // just outside the slice, unseen. Against the whole file there is
+        // nowhere outside the slice to hide.
+        //
+        // ContentView does call `server.start` elsewhere (resume, confirmed,
+        // newAlias), but never with this argument shape, so the exact stripped
+        // form below is specific to startModel's signature.
         #expect(
-            !function.contains("server.start(alias:target,hfPath:hfPath)"),
+            !source.contains("server.start(alias:target,hfPath:hfPath)"),
             "ServerManager.start is cold-start only and silently no-ops while Images is resident."
+        )
+
+        // The remaining risk is a slice that ran LONG — then the positive check
+        // could be satisfied by some other function's call. A second
+        // declaration inside the body is the cheap tell.
+        #expect(
+            !function.dropFirst().contains("privatefunc"),
+            "the extracted body ran past startModel into the next declaration, so the check above is no longer about startModel"
         )
     }
 
@@ -54,10 +81,15 @@ struct ContentViewReadinessActionTests {
     /// no matter how the function is written, which leaves the gate
     /// permanently red instead of protecting anything.
     ///
-    /// Brace counting is fooled by a `{` or `}` inside a string literal.
-    /// `startModel` has none, and if one ever appears the count goes wrong in
-    /// the direction that fails this test loudly rather than passing it
-    /// silently.
+    /// This counts braces without lexing string literals. That is deliberate:
+    /// a half-correct Swift lexer in a test is its own hazard, and the caller
+    /// is arranged so that a wrong slice fails the suite instead of passing
+    /// it. See the comments at each expectation.
+    ///
+    /// The cost of that choice is a false failure, not a false pass: add a
+    /// literal `"{"` or `"}"` to `startModel` and this suite goes red on
+    /// correct code. That is the point at which to teach this helper about
+    /// string literals — the test will have told you.
     private static func balancedBody(
         of source: String,
         openingBraceAt start: String.Index

--- a/apps/rapid-mac/Tests/RapidTests/ContentViewReadinessActionTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ContentViewReadinessActionTests.swift
@@ -15,9 +15,7 @@ struct ContentViewReadinessActionTests {
     func readinessUsesEnsureServing() throws {
         let url = Self.packageRoot
             .appendingPathComponent("Sources/Rapid/UI/ContentView.swift")
-        let body = try String(contentsOf: url, encoding: .utf8)
-        let source = CapabilityChipRenderGateSourceGuardTests
-            .stripCommentsAndWhitespace(body)
+        let source = Self.canonicalSource(try String(contentsOf: url, encoding: .utf8))
 
         guard let signature = source.range(
             of: "privatefuncstartModel(_target:String){"
@@ -33,41 +31,168 @@ struct ContentViewReadinessActionTests {
             return
         }
 
-        // Brace counting is fooled by a `{` or `}` inside a string literal, so
-        // the slice can end early (or, if a literal swallows a real brace,
-        // late). Neither is allowed to hide a regression, so each check below
-        // is arranged to fail rather than pass when the slice is wrong.
-
-        // A slice that ended early cannot contain the call, so this goes red —
-        // loudly, which is the safe direction.
         #expect(
             function.contains("server.ensureServing(alias:target,hfPath:hfPath)"),
             "The Chat readiness button must switch away from a resident Images model."
         )
 
-        // Deliberately checked against the WHOLE file, not the slice. Scoping
-        // it to the slice is what makes a mis-slice dangerous: put
-        // `let marker = "}"` after the ensureServing call and before a
-        // cold-start call, and the extraction stops at the literal's brace —
-        // the positive check above still passes, and the forbidden call sits
-        // just outside the slice, unseen. Against the whole file there is
-        // nowhere outside the slice to hide.
-        //
-        // ContentView does call `server.start` elsewhere (resume, confirmed,
-        // newAlias), but never with this argument shape, so the exact stripped
-        // form below is specific to startModel's signature.
+        // Checked against the whole file rather than the slice. ContentView
+        // does call `server.start` elsewhere — resume, confirmed, newAlias —
+        // but never with this argument shape, so the form below is specific to
+        // startModel's signature, and checking it file-wide means a slice that
+        // ends early cannot leave a forbidden call sitting just outside it.
         #expect(
             !source.contains("server.start(alias:target,hfPath:hfPath)"),
             "ServerManager.start is cold-start only and silently no-ops while Images is resident."
         )
 
-        // The remaining risk is a slice that ran LONG — then the positive check
-        // could be satisfied by some other function's call. A second
-        // declaration inside the body is the cheap tell.
-        #expect(
-            !function.dropFirst().contains("privatefunc"),
-            "the extracted body ran past startModel into the next declaration, so the check above is no longer about startModel"
-        )
+        // Tripwire, not a proof: if the extraction ever runs past startModel,
+        // the check above could be satisfied by a different function's call.
+        // These are the two declaration forms that follow it today.
+        for declaration in ["privatefunc", "privatevar"] {
+            #expect(
+                !function.dropFirst().contains(declaration),
+                "the extracted body ran past startModel into a following \(declaration) declaration"
+            )
+        }
+    }
+
+    // MARK: - Source canonicalisation
+
+    /// `swift` with comments and whitespace removed, and every string literal
+    /// reduced to an empty one.
+    ///
+    /// Erasing literal *contents* is what makes the plain text matching in
+    /// this suite sound. Two bypasses fall out of it, both of which were live
+    /// before this existed:
+    ///
+    /// - a `"}"` literal ends the brace scan early, so a forbidden call placed
+    ///   after it sits outside the extracted body;
+    /// - a `"//"` literal makes a comment stripper eat the rest of the line,
+    ///   deleting real executable code from the text being asserted on.
+    ///
+    /// Both need the scanner to know where literals begin and end. Once it
+    /// does, the cheapest thing to do with the contents is drop them: no
+    /// literal can then contribute a brace, a slash, or a call.
+    ///
+    /// Not handled: a call written inside a string interpolation, whose
+    /// contents are erased along with the rest of the literal. That is not a
+    /// shape this gate is about, and it fails safe for the positive check.
+    static func canonicalSource(_ swift: String) -> String {
+        var out = ""
+        out.reserveCapacity(swift.count)
+        var i = swift.startIndex
+
+        func peek(_ offset: Int, from index: String.Index) -> Character? {
+            guard let j = swift.index(index, offsetBy: offset, limitedBy: swift.endIndex),
+                j < swift.endIndex
+            else { return nil }
+            return swift[j]
+        }
+
+        while i < swift.endIndex {
+            let c = swift[i]
+
+            // Line comment.
+            if c == "/", peek(1, from: i) == "/" {
+                while i < swift.endIndex, swift[i] != "\n" { i = swift.index(after: i) }
+                continue
+            }
+            // Block comment. Swift nests them.
+            if c == "/", peek(1, from: i) == "*" {
+                var depth = 0
+                while i < swift.endIndex {
+                    if swift[i] == "/", peek(1, from: i) == "*" {
+                        depth += 1
+                        i = swift.index(i, offsetBy: 2)
+                    } else if swift[i] == "*", peek(1, from: i) == "/" {
+                        depth -= 1
+                        i = swift.index(i, offsetBy: 2)
+                        if depth == 0 { break }
+                    } else {
+                        i = swift.index(after: i)
+                    }
+                }
+                continue
+            }
+            // String literal, including raw (`#"…"#`) and multiline (`"""`).
+            if c == "\"" || c == "#" {
+                if let end = Self.endOfStringLiteral(in: swift, at: i) {
+                    out += "\"\""
+                    i = end
+                    continue
+                }
+                // A `#` that does not open a raw literal (`#available`,
+                // `#filePath`) is ordinary source.
+            }
+            if !c.isWhitespace { out.append(c) }
+            i = swift.index(after: i)
+        }
+        return out
+    }
+
+    /// The index just past the closing delimiter of the string literal
+    /// starting at `start`, or nil if no literal starts there.
+    private static func endOfStringLiteral(
+        in source: String,
+        at start: String.Index
+    ) -> String.Index? {
+        var cursor = start
+        var hashes = 0
+        while cursor < source.endIndex, source[cursor] == "#" {
+            hashes += 1
+            cursor = source.index(after: cursor)
+        }
+        guard cursor < source.endIndex, source[cursor] == "\"" else { return nil }
+
+        // A run of three or more opening quotes is a multiline literal; `""`
+        // on its own is just an empty one.
+        var quoteRun = 0
+        var probe = cursor
+        while probe < source.endIndex, source[probe] == "\"" {
+            quoteRun += 1
+            probe = source.index(after: probe)
+        }
+        let delimiter = quoteRun >= 3 ? 3 : 1
+
+        var scan = source.index(cursor, offsetBy: delimiter)
+        while scan < source.endIndex {
+            // An escape is `\` in a normal literal and `\###…` in a raw one
+            // with that many hashes; anything else is a literal backslash.
+            if source[scan] == "\\" {
+                var probe = source.index(after: scan)
+                var seen = 0
+                while seen < hashes, probe < source.endIndex, source[probe] == "#" {
+                    seen += 1
+                    probe = source.index(after: probe)
+                }
+                if seen == hashes {
+                    scan = probe < source.endIndex ? source.index(after: probe) : probe
+                    continue
+                }
+            }
+            if source[scan] == "\"" {
+                // `delimiter` quotes followed by `hashes` hashes closes it.
+                var probe = scan
+                var quotes = 0
+                while quotes < delimiter, probe < source.endIndex, source[probe] == "\"" {
+                    quotes += 1
+                    probe = source.index(after: probe)
+                }
+                if quotes == delimiter {
+                    var seen = 0
+                    while seen < hashes, probe < source.endIndex, source[probe] == "#" {
+                        seen += 1
+                        probe = source.index(after: probe)
+                    }
+                    if seen == hashes { return probe }
+                }
+                scan = probe
+                continue
+            }
+            scan = source.index(after: scan)
+        }
+        return nil  // Unterminated: treat as "not a literal" and keep scanning.
     }
 
     /// The source text of the block whose opening `{` is at `start`, up to
@@ -81,15 +206,8 @@ struct ContentViewReadinessActionTests {
     /// no matter how the function is written, which leaves the gate
     /// permanently red instead of protecting anything.
     ///
-    /// This counts braces without lexing string literals. That is deliberate:
-    /// a half-correct Swift lexer in a test is its own hazard, and the caller
-    /// is arranged so that a wrong slice fails the suite instead of passing
-    /// it. See the comments at each expectation.
-    ///
-    /// The cost of that choice is a false failure, not a false pass: add a
-    /// literal `"{"` or `"}"` to `startModel` and this suite goes red on
-    /// correct code. That is the point at which to teach this helper about
-    /// string literals — the test will have told you.
+    /// Counting braces is only sound because ``canonicalSource(_:)`` has
+    /// already emptied every string literal, so no brace here is inside one.
     private static func balancedBody(
         of source: String,
         openingBraceAt start: String.Index

--- a/apps/rapid-mac/Tests/RapidTests/ContentViewReadinessActionTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ContentViewReadinessActionTests.swift
@@ -19,18 +19,19 @@ struct ContentViewReadinessActionTests {
         let source = CapabilityChipRenderGateSourceGuardTests
             .stripCommentsAndWhitespace(body)
 
-        guard let functionStart = source.range(
+        guard let signature = source.range(
             of: "privatefuncstartModel(_target:String){"
-        )?.lowerBound else {
+        ) else {
             Issue.record("ContentView.startModel could not be found")
             return
         }
-        let suffix = source[functionStart...]
-        guard let functionEnd = suffix.firstIndex(of: "}") else {
+        guard let function = Self.balancedBody(
+            of: source,
+            openingBraceAt: source.index(before: signature.upperBound)
+        ) else {
             Issue.record("ContentView.startModel has no closing brace")
             return
         }
-        let function = String(suffix[...functionEnd])
 
         #expect(
             function.contains("server.ensureServing(alias:target,hfPath:hfPath)"),
@@ -40,5 +41,41 @@ struct ContentViewReadinessActionTests {
             !function.contains("server.start(alias:target,hfPath:hfPath)"),
             "ServerManager.start is cold-start only and silently no-ops while Images is resident."
         )
+    }
+
+    /// The source text of the block whose opening `{` is at `start`, up to
+    /// and including its matching `}`.
+    ///
+    /// Slicing to the FIRST `}` instead does not work here, and that is not a
+    /// stylistic point: `startModel` opens a closure — `first(where: { … })` —
+    /// before it reaches the call this suite is about, so the first closing
+    /// brace belongs to that closure. A first-brace slice therefore ends at
+    /// `…first(where:{$0.alias==target}` and cannot contain `ensureServing`
+    /// no matter how the function is written, which leaves the gate
+    /// permanently red instead of protecting anything.
+    ///
+    /// Brace counting is fooled by a `{` or `}` inside a string literal.
+    /// `startModel` has none, and if one ever appears the count goes wrong in
+    /// the direction that fails this test loudly rather than passing it
+    /// silently.
+    private static func balancedBody(
+        of source: String,
+        openingBraceAt start: String.Index
+    ) -> String? {
+        var depth = 0
+        var index = start
+        while index < source.endIndex {
+            switch source[index] {
+            case "{":
+                depth += 1
+            case "}":
+                depth -= 1
+                if depth == 0 { return String(source[start...index]) }
+            default:
+                break
+            }
+            index = source.index(after: index)
+        }
+        return nil
     }
 }


### PR DESCRIPTION
## Why

`main` is red. The `build` job (`swift test --no-parallel`) fails, so **every**
rapid-mac PR inherits a failing check and none can be verified green — #1746 is
blocked on it right now.

The cause is a source-scraping gate added in #1745. It finds
`ContentView.startModel` in the stripped source, then slices the body with
`firstIndex(of: "}")`. But `startModel` opens a closure before the call the test
is about:

```swift
private func startModel(_ target: String) {
    let hfPath = catalogEntries.first(where: { $0.alias == target })?.hfRepo
    Task { _ = await server.ensureServing(alias: target, hfPath: hfPath) }
}
```

The first `}` is the closure's, so the slice is

```
privatefuncstartModel(_target:String){lethfPath=catalogEntries.first(where:{$0.alias==target}
```

which cannot contain `server.ensureServing(...)` for **any** implementation. The
gate never protected anything; it was red the moment it was written, and #1745
was merged with the check already failing
([run](https://github.com/raullenchai/Rapid-MLX/actions/runs/31338998032/job/93309538384)).

## What

Balance braces from the opening `{` so the whole function body is scanned.
Test-only change; no production source is touched.

## Verification

`swift test` needs a full Xcode toolchain, which this machine does not have
(`xcrun --find swift` → CommandLineTools, so `import XCTest` fails locally). So
rather than assert the fix works, I compiled the two functions the gate actually
runs — `stripCommentsAndWhitespace` (extracted verbatim from
`CapabilityChipRenderGateSourceGuardTests.swift`) and the new `balancedBody` —
into a standalone binary and ran the suite's exact assertion logic against the
real file and two mutants:

| input | `ensureServing` | `server.start` | verdict |
| --- | --- | --- | --- |
| real `ContentView.swift` | true | false | **PASS** |
| `ensureServing` → `server.start` | false | true | **FAIL** |
| the call deleted entirely | false | false | **FAIL** |

The gate now passes on correct code *and* still goes red on the regression it
was written to catch — the old version could do neither.

Closes #1748
