### PR TITLE
Stop advertising tools for DeepSeek R1 distills

### DIFF
--- a/docs/agents/matrix.md
+++ b/docs/agents/matrix.md
@@ -45,7 +45,7 @@ truthfully from the authoritative test suite in
 |---|---|---|---|
 | Qwen 3.6 | `qwen3.6-*` (matrix reps via `qwen3.5-4b-4bit`, shares parsers) | `qwen3_coder_xml` (3.6) / `hermes` (3.5 rep) | `qwen3` |
 | Gemma 4 | `gemma-4-12b-4bit` | `gemma4` | `gemma4` |
-| DeepSeek | `deepseek-r1-32b-4bit` | `deepseek` | `deepseek_r1` |
+| DeepSeek | `deepseek-r1-32b-4bit` | none — checkpoint cannot emit calls (#1569) | `deepseek_r1_distill` |
 | gpt-oss | `gpt-oss-20b` | `harmony` | `harmony` |
 | Hy3 | `hy3-preview-4bit` (Ultra-only) | `hy_v3` | `hy_v3` |
 

--- a/tests/integrations/README.md
+++ b/tests/integrations/README.md
@@ -171,7 +171,7 @@ Family choice per matrix run:
 |---|---|---|
 | Qwen 3.6 | `qwen3.5-4b-4bit` | 3.6 has no <27B SKU; 3.5-4B shares `hermes` / `qwen3` parsers |
 | Gemma 4 | `gemma-4-12b-4bit` | Smallest text-only alias; ~7 GB at 4-bit |
-| DeepSeek | `deepseek-r1-32b-4bit` | 0.10.2 PR-2 pilot swapped from `deepseek-v4-flash-8bit` (~155 GB weights, single-node-infeasible on 256 GB M3 Ultra + G11 100 GB floor). R1-Distill-Qwen-32B-4bit at ~16 GB stays above the "no cheap-alias" bar and exercises the same `deepseek` tool-call + `deepseek_r1` reasoning parsers V4-Flash would have. **Full DeepSeek V4 Flash Tier-1 slot tracked in follow-up issue #1041** (hardware plan needed) |
+| DeepSeek | `deepseek-r1-32b-4bit` | 0.10.2 PR-2 pilot swapped from `deepseek-v4-flash-8bit` (~155 GB weights, single-node-infeasible on 256 GB M3 Ultra + G11 100 GB floor). R1-Distill-Qwen-32B-4bit at ~16 GB stays above the "no cheap-alias" bar and exercises DeepSeek reasoning, but deliberately does not advertise tools because the checkpoint cannot emit calls (#1569). **Full DeepSeek V4 Flash Tier-1 tool-parser slot tracked in follow-up issue #1041** (hardware plan needed). |
 | gpt-oss | `gpt-oss-20b-mxfp4-q8` | Smallest gpt-oss; ~11 GB |
 | Hy3 (Hunyuan 3) | `hy3-preview-4bit` | **Ultra-only** — 295B/21B-active MoE, 166 GB weights / ~156 GB peak (`min_memory_gb: 192`). No cheap alias exists; single-node-infeasible under G11 like DeepSeek V4-Flash. All 14 Hy3 cells `xfail(strict=True)`; real inference is weekly-Golden-Path-only; always-on CI coverage is the offline `test_hy3_offline.py` (parser wire, no model boot) |
 

--- a/tests/integrations/conftest.py
+++ b/tests/integrations/conftest.py
@@ -112,15 +112,15 @@ _FAMILY_ALIASES: dict[str, FamilyAlias] = {
         # from the PR body.
         #
         # R1-Distill-Qwen-32B-4bit stays above the "no cheap-alias"
-        # bar (32B params is comfortably Tier-1) and exercises the
-        # same ``deepseek`` tool-call parser + ``deepseek_r1``
-        # reasoning parser V4-Flash would have (per
-        # ``vllm_mlx/aliases.json``). No parser-coverage loss.
+        # bar (32B params is comfortably Tier-1) and exercises DeepSeek
+        # reasoning. It deliberately does not advertise tool calls: the
+        # strict-xfail block below records the checkpoint's architectural
+        # tool-emission gap (#1569). V4 tool-parser coverage remains #1041.
         alias="deepseek-r1-32b-4bit",
         reason=(
             "V4-Flash-8bit is 155 GB single-node-infeasible; "
-            "R1-Distill-Qwen-32B-4bit exercises the same tool_call + "
-            "reasoning parsers at ~16 GB"
+            "R1-Distill-Qwen-32B-4bit exercises reasoning at ~16 GB; "
+            "V4 tool-parser coverage remains tracked by #1041"
         ),
     ),
     "gptoss": FamilyAlias(

--- a/tests/test_aliases_contract.py
+++ b/tests/test_aliases_contract.py
@@ -1077,6 +1077,7 @@ def test_gemma_3n_multimodal_aliases_share_family_sampling() -> None:
         "phi-3.5-mini-4bit",
         "gemma-3n-e2b-4bit",
         "gemma-3n-e4b-4bit",
+        "deepseek-r1-32b-4bit",
     ],
 )
 def test_no_tool_call_support_aliases_have_null_tool_call_parser(
@@ -1093,6 +1094,8 @@ def test_no_tool_call_support_aliases_have_null_tool_call_parser(
     * ``phi-3.5-mini-4bit`` (Microsoft Phi-3.5) — chat template only
       defines ``<|user|>`` / ``<|assistant|>`` / ``<|end|>``; no
       ``<tool_call>`` special tokens. Tool-call attempts get ignored.
+    * ``deepseek-r1-32b-4bit`` (DeepSeek R1 Distill Qwen 32B) — live
+      forced/auto tool prompts emit plausible prose instead of a call (#1569).
     * ``gemma-3n-e2b-4bit`` / ``gemma-3n-e4b-4bit`` (Google Gemma 3n
       multimodal) — chat template injects no tool-call markers; model
       replies with plain prose when asked to use a tool.
@@ -1114,14 +1117,14 @@ def test_no_tool_call_support_aliases_have_null_tool_call_parser(
     Pinned here so a future PR can't silently re-wire ``hermes``
     on the strength of "but the family default is hermes" — the
     family default is correct for the chat-format families that
-    ship tool tokens, and wrong for these three that don't.
+    ship tool tokens, and wrong for these checkpoints that don't.
     """
     profiles = list_profiles()
     assert alias in profiles, f"{alias} missing from aliases.json"
     assert profiles[alias].tool_call_parser is None, (
-        f"{alias}: tool_call_parser must be None — the model's chat "
-        f"template can't emit hermes-style tool grammar (PR #715 fuzz "
-        f"finding D). Got {profiles[alias].tool_call_parser!r}."
+        f"{alias}: tool_call_parser must be None — the checkpoint cannot "
+        f"reliably emit its configured tool grammar. "
+        f"Got {profiles[alias].tool_call_parser!r}."
     )
 
 

--- a/tests/test_capabilities_field.py
+++ b/tests/test_capabilities_field.py
@@ -270,6 +270,21 @@ class TestToolsCapability:
             f"Qwen3 alias should advertise 'tools' (hermes parser), got {caps}"
         )
 
+    def test_1569_r1_distill_does_not_advertise_tools(self, monkeypatch):
+        """A parser must not stand in for empirical checkpoint capability."""
+        model_id = "mlx-community/DeepSeek-R1-Distill-Qwen-32B-4bit"
+        client, restore = _mount_models_app(
+            monkeypatch,
+            model_name=model_id,
+            model_alias="deepseek-r1-32b-4bit",
+            tool_call_parser=None,
+        )
+        try:
+            entry = _fetch_entry(client, model_id)
+        finally:
+            restore()
+        assert entry["capabilities"] == ["text"]
+
     def test_server_tool_parser_enables_tag_for_unregistered_id(self, monkeypatch):
         """Operator-supplied custom HF path + ``--tool-call-parser``
         flag → ``"tools"`` capability appears even without an alias

--- a/tests/test_model_auto_config.py
+++ b/tests/test_model_auto_config.py
@@ -1629,6 +1629,14 @@ class TestWarnMisboundDeepseekV3Parser:
         assert "do not reliably emit tool calls" in msg
         assert "Remove the explicit" in msg
 
+    def test_distill_parent_directory_does_not_disable_checkpoint_tools(self):
+        msg = warn_misbound_deepseek_v3_parser(
+            "/models/DeepSeek-R1-Distill/qwen-model", "deepseek_v3"
+        )
+        assert msg is not None
+        assert "do not reliably emit tool calls" not in msg
+        assert "hermes" in msg.lower()
+
     # Codex r5 follow-up nit: even when auto-detect's pick is a
     # DIFFERENT V3-family parser than the one bound (so the suggestion
     # would have fired under the r5 same-parser-only gate), suppress

--- a/tests/test_model_auto_config.py
+++ b/tests/test_model_auto_config.py
@@ -502,6 +502,11 @@ class TestDetectModelConfig:
         assert config.tool_call_parser is None
         assert config.reasoning_parser == "deepseek_r1_distill"
 
+    def test_distill_parent_directory_does_not_disable_child_tools(self):
+        config = detect_model_config("/models/DeepSeek-R1-Distill/qwen-model")
+        assert config is not None
+        assert config.tool_call_parser is not None
+
     # DeepSeek V2.5 (and older non-R1) → legacy ``deepseek`` parser.
     # R12-5: V3 vanilla checkpoints now route to ``deepseek_v3`` (the
     # dedicated parser) — see ``test_deepseek_v3_vanilla_routes_to_v3_parser``.

--- a/tests/test_model_auto_config.py
+++ b/tests/test_model_auto_config.py
@@ -493,17 +493,13 @@ class TestDetectModelConfig:
             "deepseek-ai/DeepSeek-R1-Distill-Llama-8B",
         ],
     )
-    def test_deepseek_r1_distill_routes_to_legacy_parser(self, model_path):
+    def test_deepseek_r1_distill_does_not_advertise_tool_calls(self, model_path):
         config = detect_model_config(model_path)
         assert config is not None
-        # MUST be the legacy ``deepseek`` parser, NOT ``deepseek_v3`` —
-        # the distills cannot emit the V3 wire shape.
-        assert config.tool_call_parser == "deepseek", (
-            f"{model_path}: tool_call_parser must be 'deepseek' (legacy), "
-            f"got {config.tool_call_parser!r}. R1-Distill family is "
-            "Qwen2/Llama2-arch SFT and cannot emit the V3 fenced-JSON "
-            "envelope. See Sven r12 dogfood HIGH-1 verdict (R12-S1)."
-        )
+        # The distills cannot reliably emit either the legacy or V3 wire
+        # shape. A parser binding advertises tool capability and causes agent
+        # clients to trust plausible fabricated prose (#1569).
+        assert config.tool_call_parser is None
         assert config.reasoning_parser == "deepseek_r1_distill"
 
     # DeepSeek V2.5 (and older non-R1) → legacy ``deepseek`` parser.
@@ -1316,8 +1312,8 @@ class TestGetProfile:
 class TestWarnMisboundDeepseekV3Parser:
     """R12-S1: cover the misbind-warning helper added in response to
     Sven r12 dogfood HIGH-1. The auto-detect path already routes the
-    R1-distill family to the legacy ``deepseek`` parser (covered by
-    ``test_deepseek_r1_distill_routes_to_legacy_parser`` above); this
+    R1-distill family deliberately leaves tool parsing unset (covered by
+    ``test_deepseek_r1_distill_does_not_advertise_tool_calls`` above); this
     helper exists so an EXPLICIT override (``--tool-call-parser
     deepseek_v3``) on a non-V3 model surfaces a loud startup warning
     instead of silently shipping ``arguments="{}"`` tool calls.
@@ -1453,12 +1449,11 @@ class TestWarnMisboundDeepseekV3Parser:
         # locate the misconfiguration without grepping the source.
         assert parser in msg
         assert model_path in msg
-        # Must point at the auto-detected suggestion (``deepseek`` for
-        # the R1-distill family) so the fix is one flag-flip away.
-        assert "deepseek" in msg
-        # Must mention the actionable remediation — drop the flag or
-        # switch to hermes for Qwen/Llama-arch SFTs.
-        assert "auto-detect" in msg.lower() or "hermes" in msg.lower()
+        # #1569: the family has no supported tool-emission contract, so the
+        # warning must not recommend swapping to another parser.
+        assert "do not reliably emit tool calls" in msg
+        assert "Remove the explicit" in msg
+        assert "hermes" not in msg.lower()
 
     # Also warn on V2.x and bare Qwen/Llama paths that someone might
     # explicitly try to coerce to the V3 parser.
@@ -1625,16 +1620,14 @@ class TestWarnMisboundDeepseekV3Parser:
         assert "Drop the explicit" not in msg
         assert "hermes" in msg
 
-    # Sanity check that the suggestion path still fires for the common
-    # case (non-V3-named parent, R1-Distill family, auto suggests the
-    # legacy ``deepseek`` parser).
-    def test_suggestion_still_fires_when_auto_picks_non_v3(self):
+    def test_r1_distill_override_warns_that_tools_are_unsupported(self):
         msg = warn_misbound_deepseek_v3_parser(
             "mlx-community/DeepSeek-R1-Distill-Qwen-1.5B-4bit", "deepseek_v3"
         )
         assert msg is not None
-        assert "Auto-detect would pick 'deepseek'" in msg
-        assert "Drop the explicit" in msg
+        assert "Auto-detect would pick" not in msg
+        assert "do not reliably emit tool calls" in msg
+        assert "Remove the explicit" in msg
 
     # Codex r5 follow-up nit: even when auto-detect's pick is a
     # DIFFERENT V3-family parser than the one bound (so the suggestion
@@ -2120,7 +2113,7 @@ class TestMistralFamilyToolParser:
     @pytest.mark.parametrize(
         "model_path,expected_tool",
         [
-            ("org/DeepSeek-R1-Distill-Mistral-7B", "deepseek"),
+            ("org/DeepSeek-R1-Distill-Mistral-7B", None),
             ("org/DeepSeek-V3-Mistral-Merge", "deepseek_v3"),
             ("some/Qwen3-Mistral-Merge-8B", "hermes"),
         ],

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -1130,7 +1130,7 @@
   },
   "deepseek-r1-32b-4bit": {
     "hf_path": "mlx-community/DeepSeek-R1-Distill-Qwen-32B-4bit",
-    "tool_call_parser": "deepseek",
+    "tool_call_parser": null,
     "reasoning_parser": "deepseek_r1_distill",
     "is_hybrid": false,
     "supports_spec_decode": true,

--- a/vllm_mlx/model_auto_config.py
+++ b/vllm_mlx/model_auto_config.py
@@ -125,7 +125,12 @@ _MODEL_PATTERNS: list[tuple[re.Pattern, ModelConfig]] = [
     (
         re.compile(r"deepseek.*r1.*distill", re.IGNORECASE),
         ModelConfig(
-            tool_call_parser="deepseek",
+            # R1-Distill checkpoints do not reliably emit either supported
+            # DeepSeek tool wire format. Binding a parser advertises tools to
+            # agents, which then accept plausible fabricated prose as a tool
+            # result (#1569). Keep reasoning support, but make tool capability
+            # explicitly absent for both aliases and raw HF paths.
+            tool_call_parser=None,
             reasoning_parser="deepseek_r1_distill",
         ),
     ),
@@ -1622,15 +1627,20 @@ def warn_misbound_deepseek_v3_parser(
     #      full-path regex even though the checkpoint name itself is
     #      non-V3. "Drop the flag" is actively bad advice — pin to
     #      ``hermes`` directly.
-    #   2. ``auto_parser is None`` (codex r6 PR-validate NIT): unknown
-    #      model, no regex match. "Drop the flag" leaves the user with
-    #      no tool parser at all, which is worse than the current
-    #      misbind. Pin explicitly to ``hermes`` for the typical
-    #      Qwen/Llama-arch case.
-    #   3. ``auto_parser`` is a non-V3 family parser: the auto-detect
-    #      knows the right answer (e.g. ``deepseek`` for R1-Distill).
-    #      Dropping the flag is the right call.
-    if auto_parser in _DEEPSEEK_V3_FAMILY_PARSERS:
+    #   2. R1-Distill: auto-detect intentionally has no parser because the
+    #      checkpoint cannot reliably emit calls (#1569). Tell the user to
+    #      remove the override, not to swap parser families.
+    #   3. ``auto_parser is None`` for an unknown model: pin explicitly to
+    #      ``hermes`` for the typical Qwen/Llama-arch case.
+    #   4. ``auto_parser`` is a non-V3 family parser: auto-detect knows the
+    #      right answer, so dropping the flag is the right call.
+    is_r1_distill = bool(re.search(r"deepseek.*r1.*distill", model_path, re.I))
+    if is_r1_distill:
+        remediation = (
+            "Remove the explicit --tool-call-parser flag; R1-Distill "
+            "checkpoints do not reliably emit tool calls (#1569)."
+        )
+    elif auto_parser in _DEEPSEEK_V3_FAMILY_PARSERS:
         remediation = "Pass --tool-call-parser hermes for this Qwen/Llama-arch model."
     elif auto_parser is None:
         remediation = (

--- a/vllm_mlx/model_auto_config.py
+++ b/vllm_mlx/model_auto_config.py
@@ -70,6 +70,7 @@ ModelConfig = ModelProfile
 # still happens on the model-name SEGMENT rather than the full path (so a
 # family-named parent dir / org does not steal an unrelated model).
 _MISTRAL_FAMILY_SENTINEL = ModelConfig()
+_R1_DISTILL_FAMILY_SENTINEL = ModelConfig()
 
 # Model family patterns → optimal config.
 # Order matters: first match wins. More specific patterns go first.
@@ -124,15 +125,7 @@ _MODEL_PATTERNS: list[tuple[re.Pattern, ModelConfig]] = [
     # DeepSeek R1 (non-0528) — has reasoning
     (
         re.compile(r"deepseek.*r1.*distill", re.IGNORECASE),
-        ModelConfig(
-            # R1-Distill checkpoints do not reliably emit either supported
-            # DeepSeek tool wire format. Binding a parser advertises tools to
-            # agents, which then accept plausible fabricated prose as a tool
-            # result (#1569). Keep reasoning support, but make tool capability
-            # explicitly absent for both aliases and raw HF paths.
-            tool_call_parser=None,
-            reasoning_parser="deepseek_r1_distill",
-        ),
+        _R1_DISTILL_FAMILY_SENTINEL,
     ),
     (
         re.compile(r"deepseek.*r1", re.IGNORECASE),
@@ -1225,6 +1218,24 @@ def detect_model_config(model_path: str) -> ModelConfig | None:
     for pattern, config in _MODEL_PATTERNS:
         if not pattern.search(model_path):
             continue
+        if config is _R1_DISTILL_FAMILY_SENTINEL:
+            if not re.search(r"deepseek.*r1.*distill", name_segment, re.I):
+                continue
+            cfg = ModelConfig(
+                # R1-Distill checkpoints do not reliably emit either
+                # supported DeepSeek tool wire format. Binding a parser
+                # advertises tools to agents, which then accept plausible
+                # fabricated prose as a tool result (#1569).
+                tool_call_parser=None,
+                reasoning_parser="deepseek_r1_distill",
+            )
+            _log_resolution_once(
+                model_path,
+                f"Auto-detected R1-Distill family for '{model_path}' → "
+                "tool_call_parser=None, "
+                "reasoning_parser=deepseek_r1_distill",
+            )
+            return cfg
         # #1071: the Mistral-family entry is a full-path pre-filter that
         # delegates to a MODEL-NAME-SEGMENT-scoped resolver. This keeps the
         # family at its original precedence (so a compound name like

--- a/vllm_mlx/model_auto_config.py
+++ b/vllm_mlx/model_auto_config.py
@@ -1634,7 +1634,16 @@ def warn_misbound_deepseek_v3_parser(
     #      ``hermes`` for the typical Qwen/Llama-arch case.
     #   4. ``auto_parser`` is a non-V3 family parser: auto-detect knows the
     #      right answer, so dropping the flag is the right call.
-    is_r1_distill = bool(re.search(r"deepseek.*r1.*distill", model_path, re.I))
+    distill_name = _extract_model_name_segment(model_path).lower()
+    is_r1_distill = bool(re.search(r"deepseek.*r1.*distill", distill_name))
+    if not is_r1_distill:
+        try:
+            profile = resolve_profile(model_path)
+        except Exception:  # noqa: BLE001
+            profile = None
+        if profile is not None:
+            canonical_name = _extract_model_name_segment(profile.hf_path).lower()
+            is_r1_distill = bool(re.search(r"deepseek.*r1.*distill", canonical_name))
     if is_r1_distill:
         remediation = (
             "Remove the explicit --tool-call-parser flag; R1-Distill "


### PR DESCRIPTION
Closes #1569

## What changed

- remove the tool-call parser binding from the `deepseek-r1-32b-4bit` alias
- classify every raw `DeepSeek-R1-Distill-*` path as reasoning-capable but not tool-capable
- make explicit DeepSeek V3 parser misbind warnings tell R1-Distill users to remove the override instead of recommending another parser
- update the integration-matrix documentation to reflect the checkpoint's known tool-emission gap

## Root cause

Capability discovery treated the presence of a parser as proof that the checkpoint could emit that parser's wire format. R1-Distill Qwen/Llama checkpoints do not reliably emit either supported DeepSeek tool-call format, so `/v1/models` advertised `tools` while a tool-directed request returned plausible fabricated prose with `tool_calls=null`.

## Validation

- red-first: 9 config/alias regressions failed on main HEAD
- real 32B repro before fix: `capabilities=["text","tools"]`; Osaka weather request returned fabricated prose, `finish_reason=stop`, `tool_calls=null`, reasoning length 941
- focused config/capability/profile suite: 3,119 passed
- real 32B smoke after fix: CLI enabled only `deepseek_r1_distill`; `/v1/models` returned `capabilities=["text"]`
- ruff check/format and `git diff --check` passed