### PR TITLE
fix(mac): keep the disabled Add-photos button in the AX tree on macOS 26

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
@@ -493,8 +493,15 @@ struct ChatView: View {
             .disabled(!supportsImageInput || viewModel.isStreaming)
             .help(supportsImageInput ? "Add photos" : "This model doesn't support images")
             .accessibilityLabel("Add photos")
-            .accessibilityHint(supportsImageInput ? "" : "This model doesn't support images")
+            // Identifier BEFORE hint, matching ChatView.SendOrStopButton. On
+            // macOS 26 a disabled .buttonStyle(.plain) button whose hint is
+            // applied after the identifier drops out of the AX tree entirely
+            // (the enabled Send button, ordered the other way, survives) — so
+            // the "Add photos" control became unreachable to VoiceOver and
+            // invisible to the golden-flow harness whenever the model is
+            // text-only. Ordering identifier first keeps it addressable.
             .accessibilityIdentifier("ChatView.AddPhotos")
+            .accessibilityHint(supportsImageInput ? "" : "This model doesn't support images")
             Spacer(minLength: 0)
             ModelPickerBar(
                 server: server,


### PR DESCRIPTION
## Why

Found dogfooding the GUI golden flows on **macOS 26.5.2**. The chat composer's **Add photos** button vanished from the accessibility tree whenever the loaded model is text-only — the button is `.disabled` there — so `chat-restore` reds with `ChatView.AddPhotos ... disappeared at baseline line 30`.

It is a real macOS-26 SwiftUI/AppKit behaviour, not a fake artifact: the analogous, **also-disabled** `ChatView.SendOrStopButton` stays in the tree, and the two buttons differ in exactly one way —

| Button | order | macOS 26 |
| --- | --- | --- |
| `ChatView.AddPhotos` | `label` → **hint** → **identifier** | **dropped** |
| `ChatView.SendOrStopButton` | `label` → **identifier** → **hint** | present |

On macOS 26 a disabled `.buttonStyle(.plain)` button whose `.accessibilityHint` is applied *after* `.accessibilityIdentifier` drops out of the AX hierarchy entirely. VoiceOver then can't reach the "Add photos" control, and the golden-flow harness sees the composer without it.

## What

Order `.accessibilityIdentifier` before `.accessibilityHint`, matching `SendOrStopButton`. Two-line reorder + a comment recording why the order is load-bearing.

## Tests

- macOS 26.5.2, before: `gui-golden-flows.sh --flow chat-restore` → **FAIL** (AddPhotos absent).
- macOS 26.5.2, after: **PASS** — the button reappears as `AXButton id="ChatView.AddPhotos" desc="Add photos" help="This model doesn't support images" enabled=false`, **byte-identical to the committed macOS-15 baseline**, so the macOS-15 CI run is unaffected (no baseline change).
- `swift build --build-tests` clean.

## Notes

CI runs the golden flows on macOS 15 only, where the button was already present, so CI can't regression-guard the macOS-26 behaviour — the code comment is the guard against re-reordering. A sibling PR addresses the other macOS-26 golden-flow gap (`.help()` not reaching AXHelp on macOS 26).

🤖 Generated with [Claude Code](https://claude.com/claude-code)