### PR TITLE
Fix readiness actions for non-retriable failures

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -20,6 +20,7 @@ struct ContentView: View {
     @Environment(UpdateChecker.self) private var updater
     @Environment(QuickstartCoordinator.self) private var quickstart
     @Environment(BrowseApprovalStore.self) private var browseApproval
+    @Environment(\.openWindow) private var openWindow
 
     @State private var alias: String = ""
     /// Monotonic signal from picker row taps. Catalog initialization also
@@ -412,12 +413,27 @@ struct ContentView: View {
             // the user would read "Couldn't start X" while X is starting.
             chat.clearStaleErrorBanner()
             startModel(target)
+        case .restart(let target):
+            chat.clearStaleErrorBanner()
+            restartModel(target)
+        case .openModelManagement:
+            settingsRouter.route(.openModelManagement) {
+                openWindow(id: "settings")
+            }
         }
     }
 
     private func startModel(_ target: String) {
         let hfPath = catalogEntries.first(where: { $0.alias == target })?.hfRepo
         Task { await server.start(alias: target, hfPath: hfPath) }
+    }
+
+    private func restartModel(_ target: String) {
+        let hfPath = catalogEntries.first(where: { $0.alias == target })?.hfRepo
+        Task {
+            await server.stop()
+            _ = await server.ensureServing(alias: target, hfPath: hfPath)
+        }
     }
 
     // MARK: - Detail routing

--- a/apps/rapid-mac/Sources/Rapid/UI/ImagesView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ImagesView.swift
@@ -8,6 +8,8 @@ import SwiftUI
 struct ImagesView: View {
     @Bindable var viewModel: ImageGenViewModel
     @Bindable var server: ServerManager
+    @Environment(\.openWindow) private var openWindow
+    @Environment(SettingsRouter.self) private var settingsRouter
 
     private let contentMaxWidth: CGFloat = RapidTheme.Layout.contentMaxWidth
 
@@ -156,6 +158,16 @@ struct ImagesView: View {
             // serving — so it would silently do nothing here; ``ensureServing``
             // stops the current model and brings the target up.
             Task { _ = await server.ensureServing(alias: target, hfPath: hf) }
+        case .restart(let target):
+            let hf = viewModel.imageModels.first { $0.alias == target }?.hfRepo
+            Task {
+                await server.stop()
+                _ = await server.ensureServing(alias: target, hfPath: hf)
+            }
+        case .openModelManagement:
+            settingsRouter.route(.openModelManagement) {
+                openWindow(id: "settings")
+            }
         }
     }
 

--- a/apps/rapid-mac/Sources/Rapid/UI/ModelReadiness.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ModelReadiness.swift
@@ -93,6 +93,8 @@ enum ModelReadiness: Equatable {
         case downloadAndStart(alias: String)
         case start(alias: String)
         case retry(alias: String)
+        case restart(alias: String)
+        case openModelManagement
 
         var title: String {
             switch self {
@@ -100,6 +102,8 @@ enum ModelReadiness: Equatable {
             case .downloadAndStart: return "Download & start"
             case .start:            return "Start"
             case .retry:            return "Retry"
+            case .restart:          return "Restart"
+            case .openModelManagement: return "Open Model Management"
             }
         }
 
@@ -109,6 +113,8 @@ enum ModelReadiness: Equatable {
             case .downloadAndStart: return "icloud.and.arrow.down"
             case .start:            return "play.fill"
             case .retry:            return "arrow.clockwise"
+            case .restart:          return "arrow.clockwise"
+            case .openModelManagement: return "square.stack.3d.up"
             }
         }
 
@@ -122,9 +128,9 @@ enum ModelReadiness: Equatable {
         /// The alias this action operates on, when it has one.
         var alias: String? {
             switch self {
-            case .chooseModel:
+            case .chooseModel, .openModelManagement:
                 return nil
-            case .downloadAndStart(let a), .start(let a), .retry(let a):
+            case .downloadAndStart(let a), .start(let a), .retry(let a), .restart(let a):
                 return a
             }
         }
@@ -308,7 +314,7 @@ enum ModelReadiness: Equatable {
                 return .failed(
                     alias: name,
                     message: failureMessage(failure),
-                    action: name.map { ModelReadiness.Action.retry(alias: $0) }
+                    action: failureAction(kind: failure.kind, alias: name)
                 )
             }
         }
@@ -322,6 +328,27 @@ enum ModelReadiness: Equatable {
             return .unknownModel(alias: name)
         case .onDisk, .catalogPending:
             return .needsStart(alias: name)
+        }
+    }
+
+    /// Preserve the recovery policy already defined by `FailureDiagnoser`
+    /// instead of flattening every readiness failure into Retry.
+    private static func failureAction(
+        kind: FailureDiagnosis.Kind?,
+        alias: String?
+    ) -> Action? {
+        guard let kind else { return alias.map(Action.retry) }
+        switch FailureDiagnoser.diagnosis(for: kind, modelAlias: alias).action {
+        case .openModelManagement:
+            return .openModelManagement
+        case .restart:
+            return alias.map(Action.restart)
+        case .retry:
+            return alias.map(Action.retry)
+        case .switchDownloadSource, .openWebSearchSettings, .none:
+            // These actions belong to their originating surfaces, not the
+            // readiness banner. Preserve its legacy Retry contract.
+            return alias.map(Action.retry)
         }
     }
 

--- a/apps/rapid-mac/Tests/RapidTests/ReadinessRecoveryActionWiringTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ReadinessRecoveryActionWiringTests.swift
@@ -1,0 +1,59 @@
+import Foundation
+import Testing
+@testable import Rapid
+
+@Suite("Readiness recovery action wiring")
+struct ReadinessRecoveryActionWiringTests {
+    private static var contentViewSource: String {
+        get throws {
+            let packageRoot = URL(fileURLWithPath: #filePath)
+                .deletingLastPathComponent()
+                .deletingLastPathComponent()
+                .deletingLastPathComponent()
+            let url = packageRoot
+                .appendingPathComponent("Sources/Rapid/UI/ContentView.swift")
+            let body = try String(contentsOf: url, encoding: .utf8)
+            return CapabilityChipRenderGateSourceGuardTests
+                .stripCommentsAndWhitespace(body)
+        }
+    }
+
+    @Test("Restart tears down the engine before serving")
+    func restartStopsBeforeEnsuringServing() throws {
+        let source = try Self.contentViewSource
+        #expect(
+            source.contains("case.restart(lettarget):chat.clearStaleErrorBanner()restartModel(target)"),
+            "The Restart CTA must use the explicit restart path rather than Retry."
+        )
+
+        guard let signature = source.range(
+            of: "privatefuncrestartModel(_target:String){"
+        ) else {
+            Issue.record("ContentView.restartModel could not be found")
+            return
+        }
+        var depth = 1
+        var index = signature.upperBound
+        var functionEnd: String.Index?
+        while index < source.endIndex {
+            switch source[index] {
+            case "{": depth += 1
+            case "}":
+                depth -= 1
+                if depth == 0 { functionEnd = index }
+            default: break
+            }
+            if functionEnd != nil { break }
+            index = source.index(after: index)
+        }
+        guard let functionEnd else {
+            Issue.record("ContentView.restartModel has no closing brace")
+            return
+        }
+        let function = String(source[signature.lowerBound...functionEnd])
+        #expect(
+            function.contains("awaitserver.stop()_=awaitserver.ensureServing(alias:target,hfPath:hfPath)"),
+            "Restart must stop the failed engine before bringing the selected model back."
+        )
+    }
+}

--- a/apps/rapid-mac/Tests/RapidUXTests/ModelReadinessTests.swift
+++ b/apps/rapid-mac/Tests/RapidUXTests/ModelReadinessTests.swift
@@ -255,7 +255,7 @@ final class ModelReadinessTests: XCTestCase {
             message,
             FailureDiagnoser.diagnosis(for: .engineNotRunning, modelAlias: alias).message
         )
-        XCTAssertEqual(action, .retry(alias: alias))
+        XCTAssertEqual(action, .restart(alias: alias))
     }
 
     /// With no structured kind, the raw message is the fallback rather
@@ -345,7 +345,54 @@ final class ModelReadinessTests: XCTestCase {
             return XCTFail("expected .failed, got \(state)")
         }
         XCTAssertEqual(name, alias)
-        XCTAssertEqual(action, .retry(alias: alias))
+        XCTAssertEqual(action, .openModelManagement)
+    }
+
+    /// Regression for #1514: model-load failures are not retryable in place.
+    /// The shared diagnosis contract sends the user to Model Management, but
+    /// readiness used to overwrite that decision with an unconditional Retry.
+    func testModelLoadFailureOffersModelManagementInsteadOfRetry() {
+        let state = resolve(
+            .idle,
+            alias: alias,
+            cached: true,
+            failure: .init(message: "load failed", kind: .modelLoadFailed, alias: alias)
+        )
+
+        XCTAssertEqual(state.action, .openModelManagement)
+    }
+
+    func testOutOfMemoryFailureOffersModelManagementInsteadOfRetry() {
+        let state = resolve(
+            .idle,
+            alias: alias,
+            cached: true,
+            failure: .init(message: "out of memory", kind: .modelOutOfMemory, alias: alias)
+        )
+
+        XCTAssertEqual(state.action, .openModelManagement)
+    }
+
+    func testEngineNotRunningFailureOffersRestartInsteadOfRetry() {
+        let state = resolve(
+            .idle,
+            alias: alias,
+            cached: true,
+            failure: .init(message: "engine stopped", kind: .engineNotRunning, alias: alias)
+        )
+
+        XCTAssertEqual(state.action, .restart(alias: alias))
+    }
+
+    func testOtherDiagnosedFailureKeepsLegacyRetry() {
+        let state = resolve(
+            .idle,
+            alias: alias,
+            cached: true,
+            failure: .init(message: "request failed", kind: .requestFailed, alias: alias)
+        )
+
+        XCTAssertEqual(state.action, .retry(alias: alias))
     }
 
     /// An unattributable failure must not be pinned on the user's fresh


### PR DESCRIPTION
Fixes #1514.

## What changed

- derive readiness recovery actions from the existing `FailureDiagnoser` policy
- route model OOM/load failures to Settings → Model Management
- expose Restart for engine-not-running failures
- preserve Retry for other and unclassified readiness failures
- add regression coverage for all three paths

## Root cause

`ModelReadiness.resolve` retained the structured failure kind for copy generation, but discarded it when choosing the CTA and unconditionally returned `.retry(alias:)`.

## Validation

- Reproduced against `origin/main`: `.modelLoadFailed` resolves to Retry despite `FailureDiagnoser` prescribing Model Management
- `swift build` passes
- `git diff --check` passes
- Local `swift test` is blocked before test execution by the existing #1638 toolchain issue (`no such module XCTest`); CI/pr_validation will run the suite in the supported environment
