### PR TITLE
fix(mac): expose Images-tab tooltips to AX on macOS 26 via accessibilityHint

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/UI/ImagesView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ImagesView.swift
@@ -82,6 +82,7 @@ struct ImagesView: View {
             .buttonStyle(.plain)
             .padding(10)
             .help("Save image")
+            .accessibilityHint("Save image")
             .accessibilityIdentifier("Images.Result.Save")
         }
     }
@@ -216,6 +217,7 @@ struct ImagesView: View {
                         .buttonStyle(.plain)
                         .disabled(viewModel.cancelling)
                         .help("Cancel")
+                        .accessibilityHint("Cancel")
                         .accessibilityIdentifier("Images.Cancel")
                     }
 
@@ -522,6 +524,11 @@ struct ImagesView: View {
         .fixedSize()
         .onHover { pickerHovering = $0 }
         .help(viewModel.selectedAlias.isEmpty ? "Choose a model" : "Model: \(viewModel.selectedAlias)")
+        // Mirror the tooltip into an accessibility hint: SwiftUI's `.help(_)`
+        // reaches AXHelp on macOS 15 but not on macOS 26 for a `Menu` styled as
+        // a button, so without this the model the picker resolved to is
+        // invisible to VoiceOver and to the golden-flow harness on 26.
+        .accessibilityHint(viewModel.selectedAlias.isEmpty ? "Choose a model" : "Model: \(viewModel.selectedAlias)")
         .accessibilityIdentifier("Images.ModelPicker")
     }
 
@@ -547,6 +554,7 @@ struct ImagesView: View {
             .buttonStyle(.plain)
             .disabled(viewModel.cancelling)
             .help("Cancel")
+            .accessibilityHint("Cancel")
             .accessibilityIdentifier("Images.Generate")
         } else {
             Button(action: runSubmit) {
@@ -563,6 +571,12 @@ struct ImagesView: View {
             .buttonStyle(.plain)
             .disabled(!sendEnabled)
             .help(readiness.isReady ? "Generate" : "Load the model first")
+            // `.help(_)` does not reach AXHelp on macOS 26 for this button
+            // (it publishes an identifier but no accessibilityLabel), so mirror
+            // the readiness tooltip into a hint — the only signal that
+            // distinguishes "ready" from "load the model first" while the
+            // button is disabled for an empty prompt on both.
+            .accessibilityHint(readiness.isReady ? "Generate" : "Load the model first")
             .accessibilityIdentifier("Images.Generate")
         }
     }


### PR DESCRIPTION
## Why

Found dogfooding the GUI golden flows on **macOS 26.5.2**. `gui-golden-flows.sh --flow image-generation` reds with `Images.ModelPicker never resolved to fake-image-alias`, even though the picker *did* resolve.

Root cause: **SwiftUI's `.help(_)` tooltip reaches AXHelp on macOS 15 but not on macOS 26** for some control shapes — the Images tab's `Menu` styled as a button (`Images.ModelPicker`) and its label-less icon buttons (`Images.Generate`, save, cancel). Chat's `ModelPickerBar` survives because it carries an explicit `.accessibilityHint(_)`, which *does* reach AXHelp on both. So on macOS 26 those Images controls publish **no AXHelp**: VoiceOver loses the tooltip, and the flow's liveness poll (which reads AXHelp) hangs, while the committed baselines pin a `help="..."` the runner never emits.

## What

Mirror each Images-tab `.help(_)` into an `.accessibilityHint(_)` of the **same content**, matching the `ModelPickerBar` pattern. `.accessibilityHint` reaches AXHelp on both OSes, so AXHelp is now published on macOS 26 with the exact value the macOS-15 baselines already pin.

Five controls: `Images.ModelPicker`, `Images.Generate` (ready + cancel states), `Images.Result.Save`, `Images.Cancel`. **Product-only change** — no normalizer, baseline, or flow-assertion edits.

## Tests

- macOS 26.5.2, before: `--flow image-generation` → **FAIL** (`Images.ModelPicker never resolved`).
- macOS 26.5.2, after: **PASS** — against the **unchanged** committed baselines and the original AXHelp-based liveness polls.
- `swift build --build-tests` clean. The macOS-15 CI golden-flow job stays green because the AXHelp *value* is unchanged there (the hint mirrors the help).

## Notes

This supersedes the earlier version of this PR, which absorbed AXHelp in the baseline normalizer instead. A reviewer rightly flagged that dropping every AXHelp-beside-a-description also discards **stable** accessibility hints (the picker's, Settings' explanations), so the golden tests could no longer detect one going missing. Fixing the product to publish AXHelp consistently keeps that coverage and needs no harness change. Sibling PR #1752 (already merged) fixes the other macOS-26 golden-flow gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)