### PR TITLE
fix(mac): balance braces when reading startModel — unblock the build gate

### DIFF
--- a/apps/rapid-mac/Tests/RapidTests/ContentViewReadinessActionTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ContentViewReadinessActionTests.swift
@@ -19,18 +19,38 @@ struct ContentViewReadinessActionTests {
         let source = CapabilityChipRenderGateSourceGuardTests
             .stripCommentsAndWhitespace(body)
 
-        guard let functionStart = source.range(
+        guard let signature = source.range(
             of: "privatefuncstartModel(_target:String){"
-        )?.lowerBound else {
+        ) else {
             Issue.record("ContentView.startModel could not be found")
             return
         }
-        let suffix = source[functionStart...]
-        guard let functionEnd = suffix.firstIndex(of: "}") else {
+        // Balance braces from the function's opening ``{`` — a plain
+        // ``firstIndex(of: "}")`` stops at the ``}`` of the
+        // ``catalogEntries.first(where: { $0.alias == target })`` closure,
+        // truncating the body before the ``ensureServing`` call and failing
+        // the assertion on correct code.
+        var depth = 1
+        var index = signature.upperBound
+        var functionEnd: String.Index?
+        while index < source.endIndex {
+            switch source[index] {
+            case "{": depth += 1
+            case "}":
+                depth -= 1
+                if depth == 0 {
+                    functionEnd = index
+                }
+            default: break
+            }
+            if functionEnd != nil { break }
+            index = source.index(after: index)
+        }
+        guard let functionEnd else {
             Issue.record("ContentView.startModel has no closing brace")
             return
         }
-        let function = String(suffix[...functionEnd])
+        let function = String(source[signature.lowerBound...functionEnd])
 
         #expect(
             function.contains("server.ensureServing(alias:target,hfPath:hfPath)"),


### PR DESCRIPTION
## Why

`main`'s `build` gate is red, and has been since **#1745** — every rapid-mac PR inherits the failure:

```
✘ Test "Chat readiness replaces a different resident model"
  ContentViewReadinessActionTests.swift:35 — Expectation failed:
  (function → "privatefuncstartModel(_target:String){lethfPath=catalogEntries.first(where:{$0.alias==target}")
      .contains("server.ensureServing(alias:target,hfPath:hfPath)")
```

`ContentViewReadinessActionTests` (added in #1745) reads `ContentView.startModel`'s source, whitespace-strips it, and takes everything up to the **first `}`**. But `startModel` resolves its target through a closure:

```swift
private func startModel(_ target: String) {
    let hfPath = catalogEntries.first(where: { $0.alias == target })?.hfRepo   // ← first `}` is HERE
    Task { _ = await server.ensureServing(alias: target, hfPath: hfPath) }      // ← never reached
}
```

So the extracted "body" truncates at `$0.alias==target}` — before the `ensureServing` call it is meant to assert on — and the test fails on **correct** code. #1745 was merged red because of this self-inflicted harness bug, not a product regression.

## What

The production code is right (`startModel` already calls `ensureServing`, exactly what the test wants). Fix the harness: scan from the function's opening `{` and balance `{`/`}` depth to find its true closing brace, so the extracted body spans the whole function regardless of closures inside it.

## Tests

- `swift test --filter ContentViewReadinessActionTests` → **fails on `main`**, **passes** with this change (the extracted body now contains `server.ensureServing(alias:target,hfPath:hfPath)`, and the negative assertion — no `server.start(...)` — still holds).

## Notes

This unblocks the `build` gate for the two open macOS-26 golden-flow PRs (#1752, #1755) and every future rapid-mac PR. Pure test-harness fix; no product code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)