### PR TITLE
Fix source guards and streaming test upload hangs

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -394,10 +394,10 @@ struct ContentView: View {
     ///
     /// Lives here rather than in ``ChatView`` because starting a model is
     /// a window-level concern — the Launch page raises the same actions.
-    /// Start routes through ``ServerManager.start``, which is the one
-    /// choke point that applies the launch flags and the live
-    /// free-memory guard (#1435), so this path inherits the same OOM
-    /// protection the implicit send-start path already had.
+    /// Start routes through ``ServerManager.ensureServing`` so the action also
+    /// replaces a different resident model (for example after using Images).
+    /// ``ensureServing`` delegates its cold-start leg to ``start``, preserving
+    /// the launch flags and live free-memory guard (#1435).
     private func performReadinessAction(_ action: ModelReadiness.Action) {
         switch action {
         case .chooseModel:

--- a/apps/rapid-mac/Tests/RapidTests/CapabilityChipRenderGateSourceGuardTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/CapabilityChipRenderGateSourceGuardTests.swift
@@ -494,51 +494,9 @@ struct CapabilityChipRenderGateSourceGuardTests {
 
     // MARK: - Strip helper (mirrors ChatViewAssistantContentBidiTests)
 
-    /// Strip ``//`` line comments, ``/*…*/`` block comments, and all
-    /// whitespace so the source-grep tests can pin against a
-    /// canonical form. The same shape ``ChatViewAssistantContentBidiTests``
-    /// uses (PR #329 carryover) — we keep it private so the two
-    /// suites can't drift on the strip rules.
+    /// Strip comments and whitespace without mistaking comment markers inside
+    /// string or extended-regex literals for comments.
     static func stripCommentsAndWhitespace(_ source: String) -> String {
-        var out = ""
-        out.reserveCapacity(source.count)
-        var i = source.startIndex
-        while i < source.endIndex {
-            let c = source[i]
-            // Block comment
-            if c == "/", source.index(after: i) < source.endIndex,
-               source[source.index(after: i)] == "*" {
-                var j = source.index(i, offsetBy: 2)
-                while j < source.endIndex {
-                    if source[j] == "*",
-                       source.index(after: j) < source.endIndex,
-                       source[source.index(after: j)] == "/" {
-                        j = source.index(j, offsetBy: 2)
-                        break
-                    }
-                    j = source.index(after: j)
-                }
-                i = j
-                continue
-            }
-            // Line comment
-            if c == "/", source.index(after: i) < source.endIndex,
-               source[source.index(after: i)] == "/" {
-                var j = source.index(after: i)
-                while j < source.endIndex, source[j] != "\n" {
-                    j = source.index(after: j)
-                }
-                i = j
-                continue
-            }
-            // Strip whitespace
-            if c.isWhitespace {
-                i = source.index(after: i)
-                continue
-            }
-            out.append(c)
-            i = source.index(after: i)
-        }
-        return out
+        SourceGuardSupport.canonicalSource(source, literals: .preserve)
     }
 }

--- a/apps/rapid-mac/Tests/RapidTests/ChatStreamRequestBodyTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ChatStreamRequestBodyTests.swift
@@ -502,6 +502,10 @@ final class NoUsageProtocol: URLProtocol, @unchecked Sendable {
     override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
 
     override func startLoading() {
+        // ``ChatStreamClient`` uploads through an HTTP body stream. Drain it
+        // before replying: Foundation can otherwise wait forever for the
+        // upload to finish on CI even though this stub ignores the payload.
+        _ = requestBodyData(from: request)
         let response = HTTPURLResponse(
             url: request.url!,
             statusCode: 200,
@@ -541,6 +545,7 @@ final class UsageEmittingProtocol: URLProtocol, @unchecked Sendable {
     override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
 
     override func startLoading() {
+        _ = requestBodyData(from: request)
         let response = HTTPURLResponse(
             url: request.url!,
             statusCode: 200,
@@ -586,23 +591,7 @@ final class FakeChatProtocol: URLProtocol, @unchecked Sendable {
     override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
 
     override func startLoading() {
-        if let stream = request.httpBodyStream {
-            stream.open()
-            var data = Data()
-            let bufSize = 4096
-            var buf = [UInt8](repeating: 0, count: bufSize)
-            while stream.hasBytesAvailable {
-                let n = buf.withUnsafeMutableBufferPointer { ptr in
-                    stream.read(ptr.baseAddress!, maxLength: bufSize)
-                }
-                if n > 0 { data.append(buf, count: n) }
-                if n <= 0 { break }
-            }
-            stream.close()
-            FakeChatProtocol.lastRequestBody = data
-        } else {
-            FakeChatProtocol.lastRequestBody = request.httpBody
-        }
+        FakeChatProtocol.lastRequestBody = requestBodyData(from: request)
         let response = HTTPURLResponse(
             url: request.url!,
             statusCode: 200,
@@ -622,6 +611,22 @@ final class FakeChatProtocol: URLProtocol, @unchecked Sendable {
     }
 
     override func stopLoading() {}
+}
+
+private func requestBodyData(from request: URLRequest) -> Data? {
+    guard let stream = request.httpBodyStream else { return request.httpBody }
+    stream.open()
+    defer { stream.close() }
+    var data = Data()
+    var buffer = [UInt8](repeating: 0, count: 4096)
+    while true {
+        let count = buffer.withUnsafeMutableBufferPointer { pointer in
+            stream.read(pointer.baseAddress!, maxLength: pointer.count)
+        }
+        if count > 0 { data.append(buffer, count: count) }
+        if count == 0 { return data }
+        if count < 0 { return nil }
+    }
 }
 
 /// #896: rapid-mlx that crashes mid-response closes the TCP socket

--- a/apps/rapid-mac/Tests/RapidTests/SourceGuardSupport.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SourceGuardSupport.swift
@@ -1,0 +1,439 @@
+import Foundation
+
+/// Literal-aware canonicalisation for tests that assert on Swift source text.
+enum SourceGuardSupport {
+    enum LiteralPolicy: Equatable { case preserve, erase }
+
+    static func canonicalSource(_ source: String, literals policy: LiteralPolicy) -> String {
+        var output = ""
+        output.reserveCapacity(source.count)
+        var index = source.startIndex
+        while index < source.endIndex {
+            if hasPrefix("//", in: source, at: index) {
+                while index < source.endIndex, source[index] != "\n" { index = source.index(after: index) }
+                continue
+            }
+            if hasPrefix("/*", in: source, at: index) {
+                index = endOfBlockComment(in: source, at: index)
+                continue
+            }
+            if canStartBareRegex(in: source, at: index),
+               let literal = canonicalizedBareRegex(
+                   in: source, at: index, policy: policy
+               ) {
+                // Keep one slash as a fail-closed marker. Text gates can
+                // still inspect executable source after the regex, while a
+                // brace-balancing caller refuses to guess whether remaining
+                // slash syntax is regex or division.
+                output += policy == .erase ? "/" + literal.text : literal.text
+                index = literal.end
+                continue
+            }
+            if let literal = canonicalizedExtendedRegex(
+                in: source, at: index, policy: policy
+            ) {
+                output += literal.text
+                index = literal.end
+                continue
+            }
+            if let literal = canonicalizedStringLiteral(
+                in: source, at: index, policy: policy
+            ) {
+                output += literal.text
+                index = literal.end
+                continue
+            }
+            if !source[index].isWhitespace { output.append(source[index]) }
+            index = source.index(after: index)
+        }
+        return output
+    }
+
+    static func balancedBlock(in source: String, openingBraceAt start: String.Index) -> String? {
+        guard start < source.endIndex, source[start] == "{" else { return nil }
+        var depth = 0
+        var index = start
+        while index < source.endIndex {
+            // Bare regex literals and division share `/` syntax. Guessing
+            // which one this is can let a brace inside `/[}]/` terminate the
+            // scan. Extended regexes have already been erased, so fail closed
+            // on every unresolved slash and make the caller choose a parser
+            // before balancing slash-bearing source.
+            if source[index] == "/" { return nil }
+            if source[index] == "{" { depth += 1 }
+            if source[index] == "}" {
+                depth -= 1
+                if depth == 0 { return String(source[start...index]) }
+            }
+            index = source.index(after: index)
+        }
+        return nil
+    }
+
+    private static func hasPrefix(_ prefix: String, in source: String, at index: String.Index) -> Bool {
+        source[index...].hasPrefix(prefix)
+    }
+
+    private static func canonicalizedStringLiteral(
+        in source: String,
+        at start: String.Index,
+        policy: LiteralPolicy
+    ) -> (text: String, end: String.Index)? {
+        var quote = start
+        var hashes = 0
+        while quote < source.endIndex, source[quote] == "#" {
+            hashes += 1
+            quote = source.index(after: quote)
+        }
+        guard quote < source.endIndex, source[quote] == "\"" else { return nil }
+
+        var quoteCount = 1
+        if hasPrefix("\"\"\"", in: source, at: quote) {
+            let afterTripleQuote = source.index(quote, offsetBy: 3)
+            if afterTripleQuote < source.endIndex, source[afterTripleQuote].isNewline {
+                quoteCount = 3
+            }
+        }
+        guard let end = endOfStringLiteral(in: source, at: start) else { return nil }
+        let contentStart = source.index(quote, offsetBy: quoteCount)
+        let contentEnd = source.index(end, offsetBy: -(quoteCount + hashes))
+        return (
+            canonicalizedLiteral(
+                in: source,
+                opening: start..<contentStart,
+                content: contentStart..<contentEnd,
+                closing: contentEnd..<end,
+                hashCount: hashes,
+                policy: policy
+            ),
+            end
+        )
+    }
+
+    private static func canonicalizedExtendedRegex(
+        in source: String,
+        at start: String.Index,
+        policy: LiteralPolicy
+    ) -> (text: String, end: String.Index)? {
+        var slash = start
+        var hashes = 0
+        while slash < source.endIndex, source[slash] == "#" {
+            hashes += 1
+            slash = source.index(after: slash)
+        }
+        guard hashes > 0, slash < source.endIndex, source[slash] == "/",
+              let end = endOfExtendedRegex(in: source, at: start)
+        else { return nil }
+
+        let contentStart = source.index(after: slash)
+        let contentEnd = source.index(end, offsetBy: -(hashes + 1))
+        return (
+            canonicalizedLiteral(
+                in: source,
+                opening: start..<contentStart,
+                content: contentStart..<contentEnd,
+                closing: contentEnd..<end,
+                hashCount: hashes,
+                policy: policy
+            ),
+            end
+        )
+    }
+
+    private static func canonicalizedBareRegex(
+        in source: String,
+        at start: String.Index,
+        policy: LiteralPolicy
+    ) -> (text: String, end: String.Index)? {
+        guard start < source.endIndex, source[start] == "/",
+              !hasPrefix("//", in: source, at: start),
+              !hasPrefix("/*", in: source, at: start),
+              let end = endOfBareRegex(in: source, at: start)
+        else { return nil }
+
+        let contentStart = source.index(after: start)
+        let contentEnd = source.index(before: end)
+        return (
+            canonicalizedLiteral(
+                in: source,
+                opening: start..<contentStart,
+                content: contentStart..<contentEnd,
+                closing: contentEnd..<end,
+                hashCount: 0,
+                policy: policy
+            ),
+            end
+        )
+    }
+
+    private static func canStartBareRegex(
+        in source: String,
+        at slash: String.Index
+    ) -> Bool {
+        var cursor = slash
+        while cursor > source.startIndex {
+            let previous = source.index(before: cursor)
+            if source[previous].isWhitespace {
+                cursor = previous
+                continue
+            }
+            if "=([{,:;!?&|+-*%^~<>".contains(source[previous]) { return true }
+            guard source[previous].isLetter else { return false }
+
+            var wordStart = previous
+            while wordStart > source.startIndex {
+                let candidate = source.index(before: wordStart)
+                guard source[candidate].isLetter else { break }
+                wordStart = candidate
+            }
+            let word = source[wordStart...previous]
+            return ["return", "throw", "case", "in", "where", "try", "await"]
+                .contains(String(word))
+        }
+        return true
+    }
+
+    private static func canonicalizedLiteral(
+        in source: String,
+        opening: Range<String.Index>,
+        content: Range<String.Index>,
+        closing: Range<String.Index>,
+        hashCount: Int,
+        policy: LiteralPolicy
+    ) -> String {
+        var output = policy == .preserve
+            ? String(source[opening].filter { !$0.isWhitespace })
+            : "\"\""
+        var index = content.lowerBound
+        while index < content.upperBound {
+            if let expressionStart = interpolationExpressionStart(
+                in: source, at: index, hashCount: hashCount
+            ), let expressionEnd = endOfInterpolation(in: source, at: expressionStart),
+               expressionEnd < content.upperBound {
+                if policy == .preserve {
+                    output.append(
+                        contentsOf: source[index..<expressionStart].filter { !$0.isWhitespace }
+                    )
+                } else {
+                    output.append("(")
+                }
+                output += canonicalSource(
+                    String(source[expressionStart..<expressionEnd]),
+                    literals: policy
+                )
+                output.append(")")
+                index = source.index(after: expressionEnd)
+                continue
+            }
+            if policy == .preserve, !source[index].isWhitespace {
+                output.append(source[index])
+            }
+            index = source.index(after: index)
+        }
+        if policy == .preserve {
+            output.append(contentsOf: source[closing].filter { !$0.isWhitespace })
+        }
+        return output
+    }
+
+    private static func interpolationExpressionStart(
+        in source: String,
+        at slash: String.Index,
+        hashCount: Int
+    ) -> String.Index? {
+        guard slash < source.endIndex, source[slash] == "\\" else { return nil }
+        var index = source.index(after: slash)
+        for _ in 0..<hashCount {
+            guard index < source.endIndex, source[index] == "#" else { return nil }
+            index = source.index(after: index)
+        }
+        guard index < source.endIndex, source[index] == "(" else { return nil }
+        return source.index(after: index)
+    }
+
+    private static func endOfInterpolation(
+        in source: String,
+        at expressionStart: String.Index
+    ) -> String.Index? {
+        var depth = 1
+        var index = expressionStart
+        while index < source.endIndex {
+            if hasPrefix("//", in: source, at: index) {
+                while index < source.endIndex, source[index] != "\n" {
+                    index = source.index(after: index)
+                }
+                continue
+            }
+            if hasPrefix("/*", in: source, at: index) {
+                index = endOfBlockComment(in: source, at: index)
+                continue
+            }
+            if canStartBareRegex(in: source, at: index),
+               let end = endOfBareRegex(in: source, at: index) {
+                index = end
+                continue
+            }
+            if let end = endOfExtendedRegex(in: source, at: index) {
+                index = end
+                continue
+            }
+            if let end = endOfStringLiteral(in: source, at: index) {
+                index = end
+                continue
+            }
+            if source[index] == "(" { depth += 1 }
+            if source[index] == ")" {
+                depth -= 1
+                if depth == 0 { return index }
+            }
+            index = source.index(after: index)
+        }
+        return nil
+    }
+
+    private static func endOfBlockComment(in source: String, at start: String.Index) -> String.Index {
+        var depth = 0
+        var index = start
+        while index < source.endIndex {
+            if hasPrefix("/*", in: source, at: index) {
+                depth += 1
+                index = source.index(index, offsetBy: 2)
+            } else if hasPrefix("*/", in: source, at: index) {
+                depth -= 1
+                index = source.index(index, offsetBy: 2)
+                if depth == 0 { return index }
+            } else { index = source.index(after: index) }
+        }
+        return index
+    }
+
+    private static func endOfStringLiteral(in source: String, at start: String.Index) -> String.Index? {
+        var quote = start
+        var hashes = 0
+        while quote < source.endIndex, source[quote] == "#" {
+            hashes += 1
+            quote = source.index(after: quote)
+        }
+        guard quote < source.endIndex, source[quote] == "\"" else { return nil }
+        var quoteCount = 1
+        if hasPrefix("\"\"\"", in: source, at: quote) {
+            let afterTripleQuote = source.index(quote, offsetBy: 3)
+            if afterTripleQuote < source.endIndex, source[afterTripleQuote].isNewline {
+                quoteCount = 3
+            }
+        }
+        var index = source.index(quote, offsetBy: quoteCount)
+        while index < source.endIndex {
+            if let expressionStart = interpolationExpressionStart(
+                in: source, at: index, hashCount: hashes
+            ), let expressionEnd = endOfInterpolation(in: source, at: expressionStart) {
+                index = source.index(after: expressionEnd)
+                continue
+            }
+            if source[index] == "\\", escapeUses(hashCount: hashes, in: source, at: index) {
+                index = indexAfterEscape(hashCount: hashes, in: source, at: index)
+                continue
+            }
+            if let end = closingDelimiter(quoteCount: quoteCount, hashCount: hashes, in: source, at: index) {
+                return end
+            }
+            index = source.index(after: index)
+        }
+        return nil
+    }
+
+    private static func endOfExtendedRegex(in source: String, at start: String.Index) -> String.Index? {
+        var slash = start
+        var hashes = 0
+        while slash < source.endIndex, source[slash] == "#" {
+            hashes += 1
+            slash = source.index(after: slash)
+        }
+        guard hashes > 0, slash < source.endIndex, source[slash] == "/" else { return nil }
+        var index = source.index(after: slash)
+        while index < source.endIndex {
+            if let expressionStart = interpolationExpressionStart(
+                in: source, at: index, hashCount: hashes
+            ), let expressionEnd = endOfInterpolation(in: source, at: expressionStart) {
+                index = source.index(after: expressionEnd)
+                continue
+            }
+            if source[index] == "\\" {
+                index = source.index(index, offsetBy: 2, limitedBy: source.endIndex) ?? source.endIndex
+                continue
+            }
+            if source[index] == "/" {
+                var end = source.index(after: index)
+                var seen = 0
+                while seen < hashes, end < source.endIndex, source[end] == "#" {
+                    seen += 1
+                    end = source.index(after: end)
+                }
+                if seen == hashes { return end }
+            }
+            index = source.index(after: index)
+        }
+        return nil
+    }
+
+    private static func endOfBareRegex(
+        in source: String,
+        at start: String.Index
+    ) -> String.Index? {
+        guard start < source.endIndex, source[start] == "/",
+              !hasPrefix("//", in: source, at: start),
+              !hasPrefix("/*", in: source, at: start)
+        else { return nil }
+        var index = source.index(after: start)
+        var insideCharacterClass = false
+        while index < source.endIndex {
+            if source[index].isNewline { return nil }
+            if let expressionStart = interpolationExpressionStart(
+                in: source, at: index, hashCount: 0
+            ), let expressionEnd = endOfInterpolation(in: source, at: expressionStart) {
+                index = source.index(after: expressionEnd)
+                continue
+            }
+            if source[index] == "\\" {
+                index = source.index(index, offsetBy: 2, limitedBy: source.endIndex)
+                    ?? source.endIndex
+                continue
+            }
+            if source[index] == "[" { insideCharacterClass = true }
+            if source[index] == "]" { insideCharacterClass = false }
+            if source[index] == "/", !insideCharacterClass {
+                return source.index(after: index)
+            }
+            index = source.index(after: index)
+        }
+        return nil
+    }
+
+    private static func closingDelimiter(quoteCount: Int, hashCount: Int, in source: String, at start: String.Index) -> String.Index? {
+        var index = start
+        for _ in 0..<quoteCount {
+            guard index < source.endIndex, source[index] == "\"" else { return nil }
+            index = source.index(after: index)
+        }
+        for _ in 0..<hashCount {
+            guard index < source.endIndex, source[index] == "#" else { return nil }
+            index = source.index(after: index)
+        }
+        return index
+    }
+
+    private static func escapeUses(hashCount: Int, in source: String, at slash: String.Index) -> Bool {
+        var index = source.index(after: slash)
+        for _ in 0..<hashCount {
+            guard index < source.endIndex, source[index] == "#" else { return false }
+            index = source.index(after: index)
+        }
+        return true
+    }
+
+    private static func indexAfterEscape(hashCount: Int, in source: String, at slash: String.Index) -> String.Index {
+        var index = source.index(after: slash)
+        for _ in 0..<hashCount where index < source.endIndex { index = source.index(after: index) }
+        return index < source.endIndex ? source.index(after: index) : index
+    }
+}

--- a/apps/rapid-mac/Tests/RapidTests/SourceGuardSupportTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SourceGuardSupportTests.swift
@@ -1,0 +1,109 @@
+import Testing
+@testable import Rapid
+
+@Suite("Literal-aware source guard support")
+struct SourceGuardSupportTests {
+    @Test("comment markers in strings cannot hide executable code")
+    func stringCommentMarkersDoNotHideCode() {
+        let source = #"let line = "//"; forbiddenLine(); let block = "/*"; forbiddenBlock()"#
+        let canonical = SourceGuardSupport.canonicalSource(source, literals: .preserve)
+        #expect(canonical.contains("forbiddenLine()"))
+        #expect(canonical.contains("forbiddenBlock()"))
+        #expect(canonical.contains(#""//""#))
+        #expect(canonical.contains(#""/*""#))
+    }
+
+    @Test("actual comments and nested block comments are removed")
+    func removesComments() {
+        let source = "kept() // removed()\n/* outer /* nested */ still outer */ keptToo()"
+        #expect(SourceGuardSupport.canonicalSource(source, literals: .preserve) == "kept()keptToo()")
+    }
+
+    @Test("literal braces cannot terminate a balanced source block")
+    func literalBracesDoNotAffectBalance() {
+        let source = #"func f() { let close = "}"; nested { work() }; forbidden() } after()"#
+        let canonical = SourceGuardSupport.canonicalSource(source, literals: .erase)
+        let block = SourceGuardSupport.balancedBlock(in: canonical, openingBraceAt: canonical.firstIndex(of: "{")!)
+        #expect(block?.contains("forbidden()") == true)
+        #expect(block?.contains("after()") == false)
+    }
+
+    @Test("raw, multiline, and extended-regex contents cannot mimic source")
+    func extendedLiteralContentsAreErased() {
+        let source = ##"""
+        let raw = #"// }"#; rawCode()
+        let multiline = """
+        /* } */
+        """; multilineCode()
+        let regex = #/\/\* } \/\//#; regexCode()
+        """##
+        let canonical = SourceGuardSupport.canonicalSource(source, literals: .erase)
+
+        #expect(canonical.contains("rawCode()"))
+        #expect(canonical.contains("multilineCode()"))
+        #expect(canonical.contains("regexCode()"))
+        #expect(!canonical.contains("/*"))
+    }
+
+    @Test("interpolation expressions remain executable source")
+    func interpolationCodeIsCanonicalizedRecursively() {
+        let source = ##"""
+        func f() {
+            let text = "\(outer({ closureCall() }, "value \(nestedCall())"))"
+            let raw = #"\#(rawCall())"#
+            tailCall()
+        }
+        afterFunction()
+        """##
+        let erased = SourceGuardSupport.canonicalSource(source, literals: .erase)
+        let preserved = SourceGuardSupport.canonicalSource(source, literals: .preserve)
+        let opening = erased.firstIndex(of: "{")!
+        let function = SourceGuardSupport.balancedBlock(
+            in: erased,
+            openingBraceAt: opening
+        )
+
+        for call in ["outer(", "closureCall()", "nestedCall()", "rawCall()"] {
+            #expect(erased.contains(call), "erased literals hid \(call)")
+            #expect(preserved.contains(call), "preserved literals hid \(call)")
+        }
+        #expect(function?.contains("tailCall()") == true)
+        #expect(function?.contains("afterFunction()") == false)
+    }
+
+    @Test("balanced blocks fail closed on ambiguous ordinary regex syntax")
+    func ordinaryRegexRequiresAParser() {
+        let source = #"func f() { let pattern = /https?:\/\/[}]/; hiddenAfterBrace() }"#
+        let canonical = SourceGuardSupport.canonicalSource(source, literals: .erase)
+        let opening = canonical.firstIndex(of: "{")!
+
+        #expect(canonical.contains("hiddenAfterBrace()"))
+        #expect(
+            SourceGuardSupport.balancedBlock(
+                in: canonical,
+                openingBraceAt: opening
+            ) == nil
+        )
+    }
+
+    @Test("preserved ordinary regex keeps exactly one opening slash")
+    func preservedOrdinaryRegexDelimiterIsNotDuplicated() {
+        let source = "let pattern = /foo/; followingCall()"
+        let canonical = SourceGuardSupport.canonicalSource(source, literals: .preserve)
+
+        #expect(canonical == "letpattern=/foo/;followingCall()")
+    }
+
+    @Test("bare-regex parentheses cannot end a string interpolation")
+    func regexParenthesesInsideInterpolationAreSkipped() {
+        let source = ##"""
+        let text = "\(use(/[(]/, /[)]/))"; followingCall()
+        outsideCall()
+        """##
+        let canonical = SourceGuardSupport.canonicalSource(source, literals: .erase)
+
+        #expect(canonical.contains("use("))
+        #expect(canonical.contains("followingCall()"))
+        #expect(canonical.contains("outsideCall()"))
+    }
+}

--- a/docs/release-notes/unreleased.md
+++ b/docs/release-notes/unreleased.md
@@ -69,6 +69,9 @@ to always-allow rather than prompting every time (#1695).
   system message by combining system instructions at the front, matching the
   compatibility already provided by the Responses and Anthropic surfaces
   (#1543). Templates that accept the original ordering remain untouched.
+- Returning to Chat after loading an Images model no longer leaves the
+  readiness banner's load button inert; the action now switches the resident
+  server back to the selected chat model (#1739).
 
 ## Release engineering
 


### PR DESCRIPTION
## Summary
- replace string-unaware source stripping in capability text gates with shared literal/interpolation/regex-aware support
- preserve executable interpolation expressions while ignoring literal/comment contents, and fail closed on ambiguous bare-regex balancing
- drain URLProtocol request body streams in Chat streaming tests, preventing the full macOS suite from hanging before later tests run
- retain the #1739 release note and correct the now-stale ContentView readiness documentation after #1758 landed the production fix

## Reproduction and root cause
`CapabilityChipRenderGateSourceGuardTests.stripCommentsAndWhitespace` treated comment markers inside Swift strings as real comments, so a `"//"` literal could delete following executable source from the text a gate asserted on (#1751). The shared scanner now understands Swift literals and recursively retains interpolation expressions.

During final CI, rapid-mac `swift test --no-parallel` twice stalled at the existing `ChatStreamClientUsageTests` before this PRs new source-guard tests ran. Those URLProtocol stubs did not consume `request.httpBodyStream`, unlike the stable sibling stub in the same file; Foundation can wait indefinitely for that upload on the CI runner. Both stubs now use the shared body-drain helper.

#1739 itself is already fixed and closed by #1758; this PR intentionally drops its duplicate production/test implementation after rebasing onto main.

## Verification
- Mac mini full `swift test --package-path apps/rapid-mac --no-parallel`: 1820 passed in 18.522s after the body-stream fix
- Mac mini `SourceGuardSupportTests`: 7/7 passed
- first CI attempt timed out at the pre-existing usage test; logs showed this PRs later tests had not started
- isolated Mac mini `ChatStreamClientUsageTests`: 2/2 passed in 0.009s
- `git diff --check`

Closes #1751