### PR TITLE
fix(mac): a Chat readiness action must switch models, not cold-start (#1739)

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -425,7 +425,10 @@ struct ContentView: View {
 
     private func startModel(_ target: String) {
         let hfPath = catalogEntries.first(where: { $0.alias == target })?.hfRepo
-        Task { await server.start(alias: target, hfPath: hfPath) }
+        // ``ensureServing`` via the shared helper, NOT ``server.start``: start is
+        // cold-start only and no-ops while a different model (e.g. an Images
+        // checkpoint) is resident, silently dropping the switch (#1739).
+        Task { await ReadinessModelStart.perform(server, alias: target, hfPath: hfPath) }
     }
 
     private func restartModel(_ target: String) {

--- a/apps/rapid-mac/Sources/Rapid/UI/ImagesView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ImagesView.swift
@@ -152,12 +152,11 @@ struct ImagesView: View {
             break  // the composer's model picker owns this step
         case .downloadAndStart(let target), .start(let target), .retry(let target):
             let hf = viewModel.imageModels.first { $0.alias == target }?.hfRepo
-            // ``ensureServing`` (not ``start``): the user is almost always
-            // switching FROM a running chat model TO the image model. Plain
-            // ``start`` is cold-start only — it no-ops when a child is already
-            // serving — so it would silently do nothing here; ``ensureServing``
-            // stops the current model and brings the target up.
-            Task { _ = await server.ensureServing(alias: target, hfPath: hf) }
+            // Same shared helper as Chat: ``ensureServing`` (not ``start``),
+            // because the user is almost always switching FROM a running chat
+            // model TO the image model, and cold-start ``start`` would no-op
+            // while that model is resident. See ``ReadinessModelStart``.
+            Task { await ReadinessModelStart.perform(server, alias: target, hfPath: hf) }
         case .restart(let target):
             let hf = viewModel.imageModels.first { $0.alias == target }?.hfRepo
             Task {

--- a/apps/rapid-mac/Sources/Rapid/UI/ReadinessModelStart.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ReadinessModelStart.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+/// The one server capability a readiness action needs: bring `alias` up,
+/// switching away from whatever is currently resident. Narrowed to a single
+/// method so a test can supply a spy without depending on the whole `final`
+/// `ServerManager` (which spawns real child processes).
+@MainActor
+protocol ReadinessServing {
+    func ensureServing(alias: String, hfPath: String?) async -> Bool
+}
+
+extension ServerManager: ReadinessServing {}
+
+/// Where a readiness action ("Load model", "Retry", "Download and start")
+/// turns into a server call.
+///
+/// It goes through ``ServerManager/ensureServing(alias:hfPath:)`` — NEVER
+/// ``start`` — because `start` is cold-start only: it no-ops when a DIFFERENT
+/// model is already resident. A Chat readiness action fired while an Images
+/// checkpoint is loaded would then silently do nothing (#1739). The Chat and
+/// Images readiness handlers were separate copies of this call and drifted —
+/// Chat regressed to `start` twice — so the rule now lives in one place they
+/// both route through, with a behavioural test.
+enum ReadinessModelStart {
+    @MainActor
+    static func perform(_ server: ReadinessServing, alias: String, hfPath: String?) async {
+        _ = await server.ensureServing(alias: alias, hfPath: hfPath)
+    }
+}

--- a/apps/rapid-mac/Tests/RapidTests/ReadinessModelStartTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ReadinessModelStartTests.swift
@@ -1,0 +1,45 @@
+import Testing
+
+@testable import Rapid
+
+@Suite("Readiness model start")
+struct ReadinessModelStartTests {
+    /// A stand-in for ``ServerManager`` that records how it was asked to bring a
+    /// model up. Conforming to ``ReadinessServing`` — not subclassing the
+    /// `final` ``ServerManager`` — is why that protocol exists.
+    @MainActor
+    final class SpyServing: ReadinessServing {
+        private(set) var calls: [(alias: String, hfPath: String?)] = []
+
+        func ensureServing(alias: String, hfPath: String?) async -> Bool {
+            calls.append((alias, hfPath))
+            return true
+        }
+    }
+
+    @Test("a readiness action starts its target through ensureServing")
+    @MainActor
+    func routesThroughEnsureServing() async {
+        let spy = SpyServing()
+
+        await ReadinessModelStart.perform(
+            spy, alias: "qwen3.5-9b-4bit", hfPath: "mlx-community/Qwen3.5-9B-4bit"
+        )
+
+        // ensureServing switches away from a DIFFERENT resident model (e.g. an
+        // Images checkpoint). `start` is cold-start only and would silently
+        // no-op there — the #1739 regression this pins.
+        #expect(spy.calls.count == 1)
+        #expect(spy.calls.first?.alias == "qwen3.5-9b-4bit")
+        #expect(spy.calls.first?.hfPath == "mlx-community/Qwen3.5-9B-4bit")
+    }
+
+    @Test("a nil hfPath (uncached alias) is forwarded unchanged")
+    @MainActor
+    func forwardsNilHFPath() async {
+        let spy = SpyServing()
+        await ReadinessModelStart.perform(spy, alias: "local-alias", hfPath: nil)
+        #expect(spy.calls.count == 1)
+        #expect(spy.calls.first?.hfPath == nil)
+    }
+}


### PR DESCRIPTION
## Why

You spotted this: **#1754 reverted #1745**, and the #1739 production bug came back. `ContentView.startModel` is `Task { await server.start(alias: target, hfPath: hfPath) }` again.

`ServerManager.start` is cold-start only — it returns early on `guard child == nil else { return }`. So pressing **Load model** in the Chat readiness banner while a *different* model (an Images checkpoint) is resident **silently does nothing**: no switch, no error. `ensureServing` is the one that tears the resident model down first, then starts the target.

It regressed twice: #1745 fixed it and was reverted by #1754 (because #1745 had merged with a red macOS build), taking its **only test** with it — so CI stayed green over the reintroduced bug.

## What

Root cause is **duplication** — the Chat and Images readiness handlers each held their own copy of the "start the target" call, and only Chat's ever went un-corrected. So this doesn't just re-flip the line; it removes the fork:

- New `ReadinessModelStart.perform(_:alias:hfPath:)` — the single place a readiness action becomes a server call, documented to use `ensureServing`, never `start`.
- `ContentView.startModel` **and** `ImagesView.handleReadinessAction` both route through it.
- Behavioural test: a spy conforming to the new `ReadinessServing` protocol (needed because `ServerManager` is `final` and spawns real child processes) asserts `perform` calls `ensureServing`. **No source scraping** — so it can't rot the way #1745's brace-matched source check did (the exact fragility that made #1745 merge red in the first place).

## Tests

- `swift test --filter ReadinessModelStartTests` → 2 passed (routes through ensureServing; nil hfPath forwarded).
- `swift build` / `swift build --build-tests` clean.

## Notes

Audited every other `server.start` site — all correct and unchanged: ContentView's alias-switch and too-big-confirm paths `stop()` first (an explicit switch), auto-start and the picker's idle **Start** CTA are genuine cold starts, and the picker's model *switch* already routes through `ensureServing`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)