### PR TITLE
fix(mac): surface the resolved engine override

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/AboutPanel.swift
+++ b/apps/rapid-mac/Sources/Rapid/AboutPanel.swift
@@ -10,6 +10,21 @@ import SwiftUI
 /// the About window can stay a simple, on-brand credit: mark, version,
 /// one-line what-it-is, and the public links.
 enum AboutPanel {
+    struct EngineIdentity: Equatable, Sendable {
+        let version: String?
+        let source: ServerLocator.ResolvedSource
+        let path: String
+
+        var summary: String {
+            let versionLabel = version.map { "Engine \($0)" } ?? "Engine version unknown"
+            return "\(versionLabel) · \(source.displayLabel)"
+        }
+
+        var isOverride: Bool {
+            source == .runtimeOverride || source == .rapidBin
+        }
+    }
+
     private static let website = "https://rapidmlx.com"
     private static let repoURL = "https://github.com/raullenchai/Rapid-MLX"
     /// The policy in the repository, not `rapidmlx.com/privacy` — that page
@@ -36,6 +51,7 @@ enum AboutPanel {
         let view = AboutView(
             version: bundleShortVersion(),
             build: bundleBuildNumber(),
+            engine: engineIdentity(binaryPath: server.binaryPath),
             website: website,
             repoURL: repoURL,
             privacyURL: privacyURL
@@ -83,12 +99,54 @@ enum AboutPanel {
     static func bundleBuildNumber() -> String? {
         Bundle.main.infoDictionary?["CFBundleVersion"] as? String
     }
+
+    /// Describe the binary the server will actually spawn, rather than the
+    /// sidecar merely shipped inside this app bundle. A runtime override can
+    /// legitimately win version selection; surfacing that fact prevents a
+    /// dogfood session from silently attributing its behaviour to the wrong
+    /// engine (#1712).
+    static func engineIdentity(
+        binaryPath: URL?,
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        bundleResourceURL: URL? = Bundle.main.resourceURL,
+        applicationSupportURL: URL? = nil
+    ) -> EngineIdentity? {
+        guard let binaryPath else { return nil }
+        let supportURL = applicationSupportURL ??
+            ApplicationSupportLocator.applicationSupportRoot(environment: environment)
+        let source = ServerLocator.classify(
+            resolved: binaryPath,
+            environment: environment,
+            bundleResourceURL: bundleResourceURL,
+            applicationSupportURL: supportURL
+        )
+        // Managed launchers may be symlinks. `find()` resolves the executable
+        // target, but VERSION belongs to the slot root, not necessarily the
+        // target checkout; read the same metadata path version selection used.
+        let versionBinary: URL
+        switch source {
+        case .runtimeOverride:
+            versionBinary = supportURL
+                .appendingPathComponent("runtime-override/rapid-mlx/bin/rapid-mlx")
+        case .bundled:
+            versionBinary = bundleResourceURL?
+                .appendingPathComponent("rapid-mlx/bin/rapid-mlx") ?? binaryPath
+        case .rapidBin, .unknown:
+            versionBinary = binaryPath
+        }
+        return EngineIdentity(
+            version: ServerLocator.sidecarVersion(forBinary: versionBinary),
+            source: source,
+            path: binaryPath.path
+        )
+    }
 }
 
 /// The branded About content.
 private struct AboutView: View {
     let version: String
     let build: String?
+    let engine: AboutPanel.EngineIdentity?
     let website: String
     let repoURL: String
     let privacyURL: String
@@ -119,6 +177,21 @@ private struct AboutView: View {
                 .font(.callout)
                 .foregroundStyle(.secondary)
                 .textSelection(.enabled)
+
+            if let engine {
+                HStack(spacing: 5) {
+                    if engine.isOverride {
+                        Image(systemName: "exclamationmark.triangle.fill")
+                            .foregroundStyle(.orange)
+                    }
+                    Text(engine.summary)
+                }
+                .font(.caption.weight(engine.isOverride ? .semibold : .regular))
+                .foregroundStyle(engine.isOverride ? .primary : .secondary)
+                .help(engine.path)
+                .accessibilityLabel("\(engine.summary). Path: \(engine.path)")
+                .textSelection(.enabled)
+            }
 
             Text("Fast, private AI that runs on your Mac.")
                 .font(.callout)

--- a/apps/rapid-mac/Sources/Rapid/AboutPanel.swift
+++ b/apps/rapid-mac/Sources/Rapid/AboutPanel.swift
@@ -51,7 +51,7 @@ enum AboutPanel {
         let view = AboutView(
             version: bundleShortVersion(),
             build: bundleBuildNumber(),
-            engine: engineIdentity(binaryPath: server.binaryPath),
+            engine: engineIdentity(resolution: server.binaryResolution),
             website: website,
             repoURL: repoURL,
             privacyURL: privacyURL
@@ -106,38 +106,13 @@ enum AboutPanel {
     /// dogfood session from silently attributing its behaviour to the wrong
     /// engine (#1712).
     static func engineIdentity(
-        binaryPath: URL?,
-        environment: [String: String] = ProcessInfo.processInfo.environment,
-        bundleResourceURL: URL? = Bundle.main.resourceURL,
-        applicationSupportURL: URL? = nil
+        resolution: ServerLocator.Resolution?
     ) -> EngineIdentity? {
-        guard let binaryPath else { return nil }
-        let supportURL = applicationSupportURL ??
-            ApplicationSupportLocator.applicationSupportRoot(environment: environment)
-        let source = ServerLocator.classify(
-            resolved: binaryPath,
-            environment: environment,
-            bundleResourceURL: bundleResourceURL,
-            applicationSupportURL: supportURL
-        )
-        // Managed launchers may be symlinks. `find()` resolves the executable
-        // target, but VERSION belongs to the slot root, not necessarily the
-        // target checkout; read the same metadata path version selection used.
-        let versionBinary: URL
-        switch source {
-        case .runtimeOverride:
-            versionBinary = supportURL
-                .appendingPathComponent("runtime-override/rapid-mlx/bin/rapid-mlx")
-        case .bundled:
-            versionBinary = bundleResourceURL?
-                .appendingPathComponent("rapid-mlx/bin/rapid-mlx") ?? binaryPath
-        case .rapidBin, .unknown:
-            versionBinary = binaryPath
-        }
+        guard let resolution else { return nil }
         return EngineIdentity(
-            version: ServerLocator.sidecarVersion(forBinary: versionBinary),
-            source: source,
-            path: binaryPath.path
+            version: resolution.version,
+            source: resolution.source,
+            path: resolution.binary.path
         )
     }
 }

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerLocator.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerLocator.swift
@@ -287,21 +287,35 @@ enum ServerLocator {
                 return .rapidBin
             }
         }
+        let runtimeMatches: Bool
         if let overrideURL = applicationSupportURL?
             .appendingPathComponent("runtime-override/rapid-mlx/bin/rapid-mlx") {
             let override = overrideURL.standardizedFileURL.path
             let resolvedOverride = overrideURL.resolvingSymlinksInPath().standardizedFileURL.path
-            if override == path || resolvedOverride == path {
-                return .runtimeOverride
-            }
+            runtimeMatches = override == path || resolvedOverride == path
+        } else {
+            runtimeMatches = false
         }
+        let bundledMatches: Bool
         if let bundledURL = bundleResourceURL?
             .appendingPathComponent("rapid-mlx/bin/rapid-mlx") {
             let bundled = bundledURL.standardizedFileURL.path
             let resolvedBundled = bundledURL.resolvingSymlinksInPath().standardizedFileURL.path
-            if bundled == path || resolvedBundled == path {
-                return .bundled
-            }
+            bundledMatches = bundled == path || resolvedBundled == path
+        } else {
+            bundledMatches = false
+        }
+        switch (runtimeMatches, bundledMatches) {
+        case (true, false): return .runtimeOverride
+        case (false, true): return .bundled
+        case (true, true):
+            // Both managed launchers can point at the same checkout. Once
+            // `find()` has resolved the symlink target, path inspection cannot
+            // recover which slot won VERSION selection. Unknown is honest;
+            // choosing either source here would display the wrong slot's
+            // VERSION for one of the two possible outcomes.
+            return .unknown
+        case (false, false): break
         }
         // No PATH / brew / pipx / uv slots to match: ``find()`` stopped
         // surfacing them in the v0.8.10 cutover, and a real ``RAPID_BIN``

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerLocator.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerLocator.swift
@@ -53,18 +53,36 @@ import Foundation
 /// the bootstrapper) rather than silently fall back to a sibling
 /// install of a different version.
 enum ServerLocator {
-    /// Returns the absolute path to `rapid-mlx`, or `nil` if no candidate
-    /// resolves to a regular executable file.
-    static func find() -> URL? {
-        find(environment: ProcessInfo.processInfo.environment)
+    struct Resolution: Equatable, Sendable {
+        let binary: URL
+        let source: ResolvedSource
+        let version: String?
     }
 
-    static func find(environment: [String: String]) -> URL? {
-        find(
+    /// Resolve the executable together with the provenance decided by the
+    /// same priority/version comparison. Callers that surface diagnostics
+    /// must use this instead of trying to reconstruct a winning slot from a
+    /// symlink-resolved path (#1712).
+    static func locate() -> Resolution? {
+        locate(environment: ProcessInfo.processInfo.environment)
+    }
+
+    static func locate(environment: [String: String]) -> Resolution? {
+        locate(
             environment: environment,
             bundleResourceURL: Self.defaultBundleResourceURL,
             applicationSupportURL: Self.defaultApplicationSupportURL(environment: environment)
         )
+    }
+
+    /// Returns the absolute path to `rapid-mlx`, or `nil` if no candidate
+    /// resolves to a regular executable file.
+    static func find() -> URL? {
+        locate()?.binary
+    }
+
+    static func find(environment: [String: String]) -> URL? {
+        locate(environment: environment)?.binary
     }
 
     /// Test seam: `bundleResourceURL` and `applicationSupportURL` are
@@ -75,6 +93,18 @@ enum ServerLocator {
         bundleResourceURL: URL?,
         applicationSupportURL: URL?
     ) -> URL? {
+        locate(
+            environment: environment,
+            bundleResourceURL: bundleResourceURL,
+            applicationSupportURL: applicationSupportURL
+        )?.binary
+    }
+
+    static func locate(
+        environment: [String: String],
+        bundleResourceURL: URL?,
+        applicationSupportURL: URL?
+    ) -> Resolution? {
         // 1. ``RAPID_BIN`` — test/dev override. TestDriver chat smoke
         // uses this to swap in ``scripts/fake-rapid-mlx.sh`` so the
         // lifecycle test runs in <2 s. Power users running their own
@@ -82,7 +112,11 @@ enum ServerLocator {
         if let override = environment["RAPID_BIN"],
            !override.isEmpty,
            let resolved = executableURL(path: override, allowRelative: true) {
-            return resolved
+            return Resolution(
+                binary: resolved,
+                source: .rapidBin,
+                version: sidecarVersion(forBinary: resolved)
+            )
         }
 
         // Managed sidecars. Resolve both executable slots before choosing:
@@ -128,22 +162,34 @@ enum ServerLocator {
 
         // There is intentionally no PATH / Homebrew / pipx / uv fallback:
         // if both managed slots miss, callers re-run the supported bootstrap.
+        // Read metadata from the managed slots rather than the resolved
+        // executable targets. This also preserves the correct VERSION when a
+        // launcher is a symlink into a checkout.
+        let runtimeVersion = runtimeOverride.flatMap { sidecarVersion(forBinary: $0) }
+        let bundledVersion = bundled.flatMap { sidecarVersion(forBinary: $0) }
+
         switch (resolvedRuntimeOverride, resolvedBundled) {
         case let (runtime?, resolvedBundle?):
-            // Read metadata from the managed slot rather than the resolved
-            // executable target. That keeps VERSION discovery correct if a
-            // slot uses a symlinked launcher.
-            let runtimeVersion = runtimeOverride.flatMap { sidecarVersion(forBinary: $0) }
-            let bundledVersion = bundled.flatMap { sidecarVersion(forBinary: $0) }
-            return shouldPreferBundled(
+            if shouldPreferBundled(
                 runtimeOverrideVersion: runtimeVersion,
                 bundledVersion: bundledVersion
-            ) ? resolvedBundle : runtime
+            ) {
+                return Resolution(binary: resolvedBundle, source: .bundled, version: bundledVersion)
+            }
+            return Resolution(binary: runtime, source: .runtimeOverride, version: runtimeVersion)
         case let (runtime?, nil):
             // Slim DMG: bootstrap owns the only populated sidecar slot.
-            return runtime
+            return Resolution(
+                binary: runtime,
+                source: .runtimeOverride,
+                version: runtimeVersion
+            )
         case let (nil, bundled?):
-            return bundled
+            return Resolution(
+                binary: bundled,
+                source: .bundled,
+                version: bundledVersion
+            )
         case (nil, nil):
             return nil
         }
@@ -167,7 +213,7 @@ enum ServerLocator {
     }
 
     /// Read `<sidecar-root>/VERSION` for a `.../bin/rapid-mlx` candidate.
-    static func sidecarVersion(forBinary binary: URL) -> String? {
+    private static func sidecarVersion(forBinary binary: URL) -> String? {
         let versionFile = binary
             .deletingLastPathComponent() // bin/
             .deletingLastPathComponent() // rapid-mlx/
@@ -287,35 +333,17 @@ enum ServerLocator {
                 return .rapidBin
             }
         }
-        let runtimeMatches: Bool
-        if let overrideURL = applicationSupportURL?
-            .appendingPathComponent("runtime-override/rapid-mlx/bin/rapid-mlx") {
-            let override = overrideURL.standardizedFileURL.path
-            let resolvedOverride = overrideURL.resolvingSymlinksInPath().standardizedFileURL.path
-            runtimeMatches = override == path || resolvedOverride == path
-        } else {
-            runtimeMatches = false
+        if let override = applicationSupportURL?
+            .appendingPathComponent("runtime-override/rapid-mlx/bin/rapid-mlx")
+            .standardizedFileURL.path,
+           override == path {
+            return .runtimeOverride
         }
-        let bundledMatches: Bool
-        if let bundledURL = bundleResourceURL?
-            .appendingPathComponent("rapid-mlx/bin/rapid-mlx") {
-            let bundled = bundledURL.standardizedFileURL.path
-            let resolvedBundled = bundledURL.resolvingSymlinksInPath().standardizedFileURL.path
-            bundledMatches = bundled == path || resolvedBundled == path
-        } else {
-            bundledMatches = false
-        }
-        switch (runtimeMatches, bundledMatches) {
-        case (true, false): return .runtimeOverride
-        case (false, true): return .bundled
-        case (true, true):
-            // Both managed launchers can point at the same checkout. Once
-            // `find()` has resolved the symlink target, path inspection cannot
-            // recover which slot won VERSION selection. Unknown is honest;
-            // choosing either source here would display the wrong slot's
-            // VERSION for one of the two possible outcomes.
-            return .unknown
-        case (false, false): break
+        if let bundled = bundleResourceURL?
+            .appendingPathComponent("rapid-mlx/bin/rapid-mlx")
+            .standardizedFileURL.path,
+           bundled == path {
+            return .bundled
         }
         // No PATH / brew / pipx / uv slots to match: ``find()`` stopped
         // surfacing them in the v0.8.10 cutover, and a real ``RAPID_BIN``

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerLocator.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerLocator.swift
@@ -167,7 +167,7 @@ enum ServerLocator {
     }
 
     /// Read `<sidecar-root>/VERSION` for a `.../bin/rapid-mlx` candidate.
-    private static func sidecarVersion(forBinary binary: URL) -> String? {
+    static func sidecarVersion(forBinary binary: URL) -> String? {
         let versionFile = binary
             .deletingLastPathComponent() // bin/
             .deletingLastPathComponent() // rapid-mlx/
@@ -287,17 +287,21 @@ enum ServerLocator {
                 return .rapidBin
             }
         }
-        if let override = applicationSupportURL?
-            .appendingPathComponent("runtime-override/rapid-mlx/bin/rapid-mlx")
-            .standardizedFileURL.path,
-           override == path {
-            return .runtimeOverride
+        if let overrideURL = applicationSupportURL?
+            .appendingPathComponent("runtime-override/rapid-mlx/bin/rapid-mlx") {
+            let override = overrideURL.standardizedFileURL.path
+            let resolvedOverride = overrideURL.resolvingSymlinksInPath().standardizedFileURL.path
+            if override == path || resolvedOverride == path {
+                return .runtimeOverride
+            }
         }
-        if let bundled = bundleResourceURL?
-            .appendingPathComponent("rapid-mlx/bin/rapid-mlx")
-            .standardizedFileURL.path,
-           bundled == path {
-            return .bundled
+        if let bundledURL = bundleResourceURL?
+            .appendingPathComponent("rapid-mlx/bin/rapid-mlx") {
+            let bundled = bundledURL.standardizedFileURL.path
+            let resolvedBundled = bundledURL.resolvingSymlinksInPath().standardizedFileURL.path
+            if bundled == path || resolvedBundled == path {
+                return .bundled
+            }
         }
         // No PATH / brew / pipx / uv slots to match: ``find()`` stopped
         // surfacing them in the v0.8.10 cutover, and a real ``RAPID_BIN``

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -113,6 +113,11 @@ final class ServerManager {
     /// `.missing` so the user knows what we looked for.
     private(set) var binaryPath: URL?
 
+    /// Provenance captured by the same decision that selected `binaryPath`.
+    /// A resolved path alone is insufficient when two managed launchers point
+    /// at the same target; About uses this to report the actual winning slot.
+    private(set) var binaryResolution: ServerLocator.Resolution?
+
     /// Tail of stdout/stderr lines from the live child, oldest first.
     /// Bounded to `logBufferCapacity` entries.
     private(set) var logLines: [String] = []
@@ -442,9 +447,10 @@ final class ServerManager {
     // MARK: - Construction
 
     init() {
-        let located = ServerLocator.find()
-        self.binaryPath = located
-        self.state = (located == nil) ? .missing : .idle
+        let resolution = ServerLocator.locate()
+        self.binaryResolution = resolution
+        self.binaryPath = resolution?.binary
+        self.state = (resolution == nil) ? .missing : .idle
     }
 
     /// Wire the app's ``DownloadManager`` so ``start(alias:)`` can
@@ -465,6 +471,9 @@ final class ServerManager {
     internal init(testingState: ServerState, binaryPath: URL? = nil) {
         self.state = testingState
         self.binaryPath = binaryPath
+        self.binaryResolution = binaryPath.map {
+            ServerLocator.Resolution(binary: $0, source: .unknown, version: nil)
+        }
     }
 
     /// codex r1 BLOCKING #3 test seam — install a stub
@@ -727,9 +736,10 @@ final class ServerManager {
     /// the correct initial state even if the user installed rapid-mlx
     /// just before launching Rapid.
     func refreshBinary() {
-        let path = ServerLocator.find()
-        self.binaryPath = path
-        if path == nil {
+        let resolution = ServerLocator.locate()
+        self.binaryResolution = resolution
+        self.binaryPath = resolution?.binary
+        if resolution == nil {
             state = .missing
         } else if case .missing = state {
             state = .idle

--- a/apps/rapid-mac/Tests/RapidTests/AboutPanelEngineIdentityTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/AboutPanelEngineIdentityTests.swift
@@ -1,0 +1,123 @@
+import Foundation
+import Testing
+
+@testable import Rapid
+
+@Suite("About panel engine identity — #1712")
+struct AboutPanelEngineIdentityTests {
+    @Test("A winning runtime override is visible with its own version and path")
+    func runtimeOverrideIdentity() throws {
+        let fixture = try Fixture()
+        defer { fixture.remove() }
+
+        let identity = AboutPanel.engineIdentity(
+            binaryPath: fixture.runtimeBinary,
+            environment: [:],
+            bundleResourceURL: fixture.bundleResources,
+            applicationSupportURL: fixture.applicationSupport
+        )
+
+        #expect(identity?.source == .runtimeOverride)
+        #expect(identity?.version == "99.0.0")
+        #expect(identity?.summary == "Engine 99.0.0 · App-managed override")
+        #expect(identity?.isOverride == true)
+        #expect(identity?.path == fixture.runtimeBinary.path)
+    }
+
+    @Test("A bundled engine is labelled without an override warning")
+    func bundledIdentity() throws {
+        let fixture = try Fixture()
+        defer { fixture.remove() }
+
+        let identity = AboutPanel.engineIdentity(
+            binaryPath: fixture.bundledBinary,
+            environment: [:],
+            bundleResourceURL: fixture.bundleResources,
+            applicationSupportURL: fixture.applicationSupport
+        )
+
+        #expect(identity?.source == .bundled)
+        #expect(identity?.version == "0.12.7")
+        #expect(identity?.summary == "Engine 0.12.7 · Bundled with app")
+        #expect(identity?.isOverride == false)
+    }
+
+    @Test("A symlinked override keeps the managed slot's identity and version")
+    func symlinkedRuntimeIdentity() throws {
+        let fixture = try Fixture(symlinkRuntime: true)
+        defer { fixture.remove() }
+
+        let resolved = fixture.runtimeBinary.resolvingSymlinksInPath()
+        let identity = AboutPanel.engineIdentity(
+            binaryPath: resolved,
+            environment: [:],
+            bundleResourceURL: fixture.bundleResources,
+            applicationSupportURL: fixture.applicationSupport
+        )
+
+        #expect(identity?.source == .runtimeOverride)
+        #expect(identity?.version == "99.0.0")
+        #expect(identity?.path == resolved.path)
+    }
+
+    @Test("No resolved binary produces no misleading engine identity")
+    func missingIdentity() {
+        #expect(AboutPanel.engineIdentity(binaryPath: nil) == nil)
+    }
+}
+
+private struct Fixture {
+    let root: URL
+    let applicationSupport: URL
+    let bundleResources: URL
+    let runtimeBinary: URL
+    let bundledBinary: URL
+
+    init(symlinkRuntime: Bool = false) throws {
+        let fm = FileManager.default
+        root = fm.temporaryDirectory
+            .appendingPathComponent("rapid-about-engine-\(UUID().uuidString)", isDirectory: true)
+        applicationSupport = root.appendingPathComponent("support", isDirectory: true)
+        bundleResources = root.appendingPathComponent("resources", isDirectory: true)
+        runtimeBinary = applicationSupport
+            .appendingPathComponent("runtime-override/rapid-mlx/bin/rapid-mlx")
+        bundledBinary = bundleResources
+            .appendingPathComponent("rapid-mlx/bin/rapid-mlx")
+        if symlinkRuntime {
+            let target = root.appendingPathComponent("checkout/bin/rapid-mlx")
+            try Self.writeSidecar(binary: target, version: "0.1.0")
+            try fm.createDirectory(
+                at: runtimeBinary.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try fm.createSymbolicLink(at: runtimeBinary, withDestinationURL: target)
+            let runtimeRoot = runtimeBinary.deletingLastPathComponent().deletingLastPathComponent()
+            try Data("99.0.0\n".utf8).write(
+                to: runtimeRoot.appendingPathComponent("VERSION"),
+                options: .atomic
+            )
+        } else {
+            try Self.writeSidecar(binary: runtimeBinary, version: "99.0.0")
+        }
+        try Self.writeSidecar(binary: bundledBinary, version: "0.12.7")
+    }
+
+    func remove() {
+        try? FileManager.default.removeItem(at: root)
+    }
+
+    private static func writeSidecar(binary: URL, version: String) throws {
+        let fm = FileManager.default
+        try fm.createDirectory(
+            at: binary.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try Data("#!/bin/sh\nexit 0\n".utf8).write(to: binary, options: .atomic)
+        try fm.setAttributes([.posixPermissions: 0o755], ofItemAtPath: binary.path)
+        let root = binary.deletingLastPathComponent().deletingLastPathComponent()
+        try Data("\(version)\n".utf8).write(
+            to: root.appendingPathComponent("VERSION"),
+            options: .atomic
+        )
+    }
+}

--- a/apps/rapid-mac/Tests/RapidTests/AboutPanelEngineIdentityTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/AboutPanelEngineIdentityTests.swift
@@ -64,6 +64,23 @@ struct AboutPanelEngineIdentityTests {
     func missingIdentity() {
         #expect(AboutPanel.engineIdentity(binaryPath: nil) == nil)
     }
+
+    @Test("Shared symlink targets do not invent managed-slot provenance")
+    func ambiguousManagedTarget() throws {
+        let fixture = try Fixture(sharedManagedTarget: true)
+        defer { fixture.remove() }
+
+        let identity = AboutPanel.engineIdentity(
+            binaryPath: fixture.runtimeBinary.resolvingSymlinksInPath(),
+            environment: [:],
+            bundleResourceURL: fixture.bundleResources,
+            applicationSupportURL: fixture.applicationSupport
+        )
+
+        #expect(identity?.source == .unknown)
+        #expect(identity?.summary == "Engine 0.1.0 · Unknown origin")
+        #expect(identity?.isOverride == false)
+    }
 }
 
 private struct Fixture {
@@ -73,7 +90,7 @@ private struct Fixture {
     let runtimeBinary: URL
     let bundledBinary: URL
 
-    init(symlinkRuntime: Bool = false) throws {
+    init(symlinkRuntime: Bool = false, sharedManagedTarget: Bool = false) throws {
         let fm = FileManager.default
         root = fm.temporaryDirectory
             .appendingPathComponent("rapid-about-engine-\(UUID().uuidString)", isDirectory: true)
@@ -83,7 +100,17 @@ private struct Fixture {
             .appendingPathComponent("runtime-override/rapid-mlx/bin/rapid-mlx")
         bundledBinary = bundleResources
             .appendingPathComponent("rapid-mlx/bin/rapid-mlx")
-        if symlinkRuntime {
+        if sharedManagedTarget {
+            let target = root.appendingPathComponent("checkout/bin/rapid-mlx")
+            try Self.writeSidecar(binary: target, version: "0.1.0")
+            for binary in [runtimeBinary, bundledBinary] {
+                try fm.createDirectory(
+                    at: binary.deletingLastPathComponent(),
+                    withIntermediateDirectories: true
+                )
+                try fm.createSymbolicLink(at: binary, withDestinationURL: target)
+            }
+        } else if symlinkRuntime {
             let target = root.appendingPathComponent("checkout/bin/rapid-mlx")
             try Self.writeSidecar(binary: target, version: "0.1.0")
             try fm.createDirectory(
@@ -99,7 +126,9 @@ private struct Fixture {
         } else {
             try Self.writeSidecar(binary: runtimeBinary, version: "99.0.0")
         }
-        try Self.writeSidecar(binary: bundledBinary, version: "0.12.7")
+        if !sharedManagedTarget {
+            try Self.writeSidecar(binary: bundledBinary, version: "0.12.7")
+        }
     }
 
     func remove() {

--- a/apps/rapid-mac/Tests/RapidTests/AboutPanelEngineIdentityTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/AboutPanelEngineIdentityTests.swift
@@ -10,12 +10,12 @@ struct AboutPanelEngineIdentityTests {
         let fixture = try Fixture()
         defer { fixture.remove() }
 
-        let identity = AboutPanel.engineIdentity(
-            binaryPath: fixture.runtimeBinary,
+        let resolution = ServerLocator.locate(
             environment: [:],
             bundleResourceURL: fixture.bundleResources,
             applicationSupportURL: fixture.applicationSupport
         )
+        let identity = AboutPanel.engineIdentity(resolution: resolution)
 
         #expect(identity?.source == .runtimeOverride)
         #expect(identity?.version == "99.0.0")
@@ -26,15 +26,15 @@ struct AboutPanelEngineIdentityTests {
 
     @Test("A bundled engine is labelled without an override warning")
     func bundledIdentity() throws {
-        let fixture = try Fixture()
+        let fixture = try Fixture(runtimeVersion: "0.11.0")
         defer { fixture.remove() }
 
-        let identity = AboutPanel.engineIdentity(
-            binaryPath: fixture.bundledBinary,
+        let resolution = ServerLocator.locate(
             environment: [:],
             bundleResourceURL: fixture.bundleResources,
             applicationSupportURL: fixture.applicationSupport
         )
+        let identity = AboutPanel.engineIdentity(resolution: resolution)
 
         #expect(identity?.source == .bundled)
         #expect(identity?.version == "0.12.7")
@@ -47,13 +47,13 @@ struct AboutPanelEngineIdentityTests {
         let fixture = try Fixture(symlinkRuntime: true)
         defer { fixture.remove() }
 
-        let resolved = fixture.runtimeBinary.resolvingSymlinksInPath()
-        let identity = AboutPanel.engineIdentity(
-            binaryPath: resolved,
+        let resolution = ServerLocator.locate(
             environment: [:],
             bundleResourceURL: fixture.bundleResources,
             applicationSupportURL: fixture.applicationSupport
         )
+        let identity = AboutPanel.engineIdentity(resolution: resolution)
+        let resolved = fixture.runtimeBinary.resolvingSymlinksInPath()
 
         #expect(identity?.source == .runtimeOverride)
         #expect(identity?.version == "99.0.0")
@@ -62,24 +62,25 @@ struct AboutPanelEngineIdentityTests {
 
     @Test("No resolved binary produces no misleading engine identity")
     func missingIdentity() {
-        #expect(AboutPanel.engineIdentity(binaryPath: nil) == nil)
+        #expect(AboutPanel.engineIdentity(resolution: nil) == nil)
     }
 
-    @Test("Shared symlink targets do not invent managed-slot provenance")
-    func ambiguousManagedTarget() throws {
+    @Test("Shared symlink targets preserve the slot that won version selection")
+    func sharedManagedTarget() throws {
         let fixture = try Fixture(sharedManagedTarget: true)
         defer { fixture.remove() }
 
-        let identity = AboutPanel.engineIdentity(
-            binaryPath: fixture.runtimeBinary.resolvingSymlinksInPath(),
+        let resolution = ServerLocator.locate(
             environment: [:],
             bundleResourceURL: fixture.bundleResources,
             applicationSupportURL: fixture.applicationSupport
         )
+        let identity = AboutPanel.engineIdentity(resolution: resolution)
 
-        #expect(identity?.source == .unknown)
-        #expect(identity?.summary == "Engine 0.1.0 · Unknown origin")
-        #expect(identity?.isOverride == false)
+        #expect(identity?.source == .runtimeOverride)
+        #expect(identity?.version == "99.0.0")
+        #expect(identity?.summary == "Engine 99.0.0 · App-managed override")
+        #expect(identity?.isOverride == true)
     }
 }
 
@@ -90,7 +91,11 @@ private struct Fixture {
     let runtimeBinary: URL
     let bundledBinary: URL
 
-    init(symlinkRuntime: Bool = false, sharedManagedTarget: Bool = false) throws {
+    init(
+        runtimeVersion: String = "99.0.0",
+        symlinkRuntime: Bool = false,
+        sharedManagedTarget: Bool = false
+    ) throws {
         let fm = FileManager.default
         root = fm.temporaryDirectory
             .appendingPathComponent("rapid-about-engine-\(UUID().uuidString)", isDirectory: true)
@@ -110,6 +115,8 @@ private struct Fixture {
                 )
                 try fm.createSymbolicLink(at: binary, withDestinationURL: target)
             }
+            try Self.writeVersion(runtimeVersion, forBinary: runtimeBinary)
+            try Self.writeVersion("0.12.7", forBinary: bundledBinary)
         } else if symlinkRuntime {
             let target = root.appendingPathComponent("checkout/bin/rapid-mlx")
             try Self.writeSidecar(binary: target, version: "0.1.0")
@@ -119,12 +126,10 @@ private struct Fixture {
             )
             try fm.createSymbolicLink(at: runtimeBinary, withDestinationURL: target)
             let runtimeRoot = runtimeBinary.deletingLastPathComponent().deletingLastPathComponent()
-            try Data("99.0.0\n".utf8).write(
-                to: runtimeRoot.appendingPathComponent("VERSION"),
-                options: .atomic
-            )
+            try Data("\(runtimeVersion)\n".utf8).write(
+                to: runtimeRoot.appendingPathComponent("VERSION"), options: .atomic)
         } else {
-            try Self.writeSidecar(binary: runtimeBinary, version: "99.0.0")
+            try Self.writeSidecar(binary: runtimeBinary, version: runtimeVersion)
         }
         if !sharedManagedTarget {
             try Self.writeSidecar(binary: bundledBinary, version: "0.12.7")
@@ -143,10 +148,12 @@ private struct Fixture {
         )
         try Data("#!/bin/sh\nexit 0\n".utf8).write(to: binary, options: .atomic)
         try fm.setAttributes([.posixPermissions: 0o755], ofItemAtPath: binary.path)
+        try writeVersion(version, forBinary: binary)
+    }
+
+    private static func writeVersion(_ version: String, forBinary binary: URL) throws {
         let root = binary.deletingLastPathComponent().deletingLastPathComponent()
         try Data("\(version)\n".utf8).write(
-            to: root.appendingPathComponent("VERSION"),
-            options: .atomic
-        )
+            to: root.appendingPathComponent("VERSION"), options: .atomic)
     }
 }


### PR DESCRIPTION
## Why

A managed runtime override can win engine selection forever with a fabricated high `VERSION`, while the app gives no indication that the bundled engine lost. That makes dogfood results silently attributable to the wrong engine.

The underlying source classifier already existed and was documented as feeding the About panel, but `AboutPanel` never consumed it. In addition, managed-slot classification did not follow symlinks even though `ServerLocator.find()` returns symlink-resolved paths.

## What

- Show the actual resolved engine version and source in About.
- Mark runtime and `RAPID_BIN` overrides with a warning icon; expose the resolved path through the tooltip and accessibility label.
- Classify symlinked runtime/bundled launchers against their managed slot.
- Read `VERSION` from the managed slot root, not a symlink target checkout.
- Add regressions for the reported `99.0.0` override, bundled engines, symlinked overrides, and missing binaries.

## Validation

- `swift build` — PASS.
- `git diff --check` — PASS.
- Local Swift tests are blocked before execution by the repository/toolchain issue tracked in #1638 (`Testing` / `XCTest` unavailable); the GitHub Apple runner will execute the new suite.

Fixes #1712
