### PR TITLE
fix: honor tool_choice="none" across all parsers and stream modes

### DIFF
--- a/tests/test_tool_choice_none_suppression.py
+++ b/tests/test_tool_choice_none_suppression.py
@@ -1,0 +1,282 @@
+# SPDX-License-Identifier: Apache-2.0
+"""``tool_choice="none"`` must surface ZERO tool calls, on every parser
+and on both the streaming and non-streaming paths.
+
+Reported bug (deterministic 5/5 on ``lfm2.5-2.6b-4bit``): a request that
+explicitly sets ``tool_choice="none"`` still came back with a tool call —
+and one whose name/arguments were never declared (``GetWeather`` /
+``location`` against a declared ``get_weather`` / ``city, unit``). An
+OpenAI-SDK client that has explicitly turned tools OFF for a turn received
+a phantom call it cannot execute.
+
+Root cause: ``"none"`` only had a best-effort *prompt-level* lever
+(dropping ``request.tools`` before rendering in ``routes/chat.py``). A
+tool-trained model still echoes ``[name({...})]``-style markup it was
+never shown, and the text parser promoted it — the declared-name / choice
+enforcement ran ONLY for the ``qwen3_coder_xml`` parser, and the
+post-parse ``routes/chat.py`` enforcement short-circuited on the very
+``request.tools = None`` the prompt-level lever had just set.
+
+Fix (``tool_choice_is_none`` gate, parser-agnostic): the parser still
+RUNS under ``none`` — that is what strips the wire markup out of content
+(the R12 sanitizer invariant) — but the resolved call is DROPPED at the
+emission points rather than forwarded as a phantom:
+  * non-streaming ``_parse_tool_calls_with_parser`` wraps ``_run_tool_parser``
+    and drops the calls (text parsers AND the structured harmony/gemma4
+    channel), keeping the cleaned content;
+  * streaming ``_detect_tool_calls`` drops the resolved call and surfaces
+    only co-emitted prose, leaving ``tool_calls_detected`` False;
+  * the streaming channel-routed path suppresses the whole ``tool_call``
+    channel and normalizes the terminal ``finish_reason`` to ``"stop"``.
+In every case the wire markup is stripped from content, never leaked.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+import vllm_mlx.service.helpers as helpers
+from vllm_mlx.config import get_config
+from vllm_mlx.service.helpers import tool_choice_is_none
+from vllm_mlx.service.postprocessor import StreamingPostProcessor
+
+# The exact wire markup the weak model emitted despite the prompt-level
+# ``tools`` drop — an undeclared name/param, the reported reproduction.
+LFM_WIRE = '[GetWeather({"location": "Rome"})]'
+
+DECLARED_TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "city": {"type": "string"},
+                    "unit": {"type": "string"},
+                },
+                "required": ["city"],
+            },
+        },
+    }
+]
+
+
+def _request(tool_choice):
+    """A minimal chat request exposing ``model_dump`` + ``tool_choice``."""
+    return SimpleNamespace(
+        tool_choice=tool_choice,
+        tools=DECLARED_TOOLS,
+        model_dump=lambda: {"tool_choice": tool_choice, "tools": DECLARED_TOOLS},
+    )
+
+
+# =====================================================================
+# The parser-agnostic predicate
+# =====================================================================
+
+
+class TestToolChoiceIsNonePredicate:
+    def test_string_none_object(self):
+        assert tool_choice_is_none(SimpleNamespace(tool_choice="none")) is True
+
+    def test_string_none_dict(self):
+        assert tool_choice_is_none({"tool_choice": "none"}) is True
+
+    @pytest.mark.parametrize("choice", ["auto", "required", None])
+    def test_other_string_modes_are_not_none(self, choice):
+        assert tool_choice_is_none({"tool_choice": choice}) is False
+
+    def test_named_function_choice_is_not_none(self):
+        # ``{"type":"function",...}`` is a FORCED call, the opposite of none.
+        assert (
+            tool_choice_is_none(
+                {"tool_choice": {"type": "function", "function": {"name": "x"}}}
+            )
+            is False
+        )
+
+    def test_none_request_object(self):
+        assert tool_choice_is_none(None) is False
+
+    def test_request_without_tool_choice_attr(self):
+        assert tool_choice_is_none(SimpleNamespace()) is False
+
+
+# =====================================================================
+# Non-streaming path — _parse_tool_calls_with_parser
+# =====================================================================
+
+
+class TestNonStreamingSuppression:
+    def _run(self, parser, request, *, structured=None):
+        cfg = get_config()
+        saved = (cfg.enable_auto_tool_choice, cfg.tool_call_parser)
+        cfg.enable_auto_tool_choice = True
+        cfg.tool_call_parser = parser
+        try:
+            return helpers._parse_tool_calls_with_parser(
+                LFM_WIRE if structured is None else "plain answer",
+                request,
+                structured_tool_calls=structured,
+            )
+        finally:
+            cfg.enable_auto_tool_choice, cfg.tool_call_parser = saved
+
+    def test_none_suppresses_text_parser_call(self):
+        # The reported reproduction: lfm markup under ``none`` must NOT
+        # surface a call. The parser still runs, so the wire markup is
+        # STRIPPED from content (R12 sanitizer invariant) rather than leaked.
+        content, calls = self._run("lfm", _request("none"))
+        assert calls is None
+        assert "GetWeather" not in content  # markup did not leak into content
+
+    def test_none_suppresses_structured_channel_call(self):
+        # Harmony/gemma4 surface calls via ``structured_tool_calls``; the
+        # none drop runs after parsing, so the call is dropped and the
+        # already-clean channel content is preserved.
+        content, calls = self._run(
+            "harmony",
+            _request("none"),
+            structured=[{"name": "GetWeather", "arguments": '{"location":"Rome"}'}],
+        )
+        assert calls is None
+        assert content == "plain answer"
+
+    def test_auto_still_parses_the_same_markup(self):
+        # Guard against over-suppression: the identical markup under
+        # ``auto`` MUST still yield the call.
+        _content, calls = self._run("lfm", _request("auto"))
+        assert calls and calls[0].function.name == "GetWeather"
+
+    def test_unset_tool_choice_still_parses(self):
+        _content, calls = self._run("lfm", _request(None))
+        assert calls and calls[0].function.name == "GetWeather"
+
+
+# =====================================================================
+# Streaming path — StreamingPostProcessor
+# =====================================================================
+
+
+def _cfg(parser="lfm"):
+    cfg = MagicMock()
+    cfg.engine = None
+    cfg.reasoning_parser = None
+    cfg.reasoning_parser_name = None
+    cfg.enable_auto_tool_choice = True
+    cfg.tool_call_parser = parser
+    cfg.tool_parser_instance = None
+    return cfg
+
+
+def _output(text, finished, *, channel=None, tool_calls=None):
+    out = MagicMock()
+    out.new_text = text
+    out.finished = finished
+    out.channel = channel
+    out.finish_reason = ("tool_calls" if tool_calls else "stop") if finished else None
+    out.prompt_tokens = 10
+    out.completion_tokens = 5
+    out.tokens = []
+    out.logprobs = None
+    out.tool_calls = tool_calls
+    return out
+
+
+def _drive(pp, outputs):
+    events = []
+    for out in outputs:
+        events.extend(pp.process_chunk(out))
+    tool_calls = [
+        tc
+        for e in events
+        if e.type == "tool_call" and e.tool_calls
+        for tc in e.tool_calls
+    ]
+    content = "".join(
+        (getattr(e, "content", "") or "")
+        for e in events
+        if e.type in ("content", "finish")
+    )
+    finish_reasons = [
+        e.finish_reason for e in events if e.type == "finish" and e.finish_reason
+    ]
+    return tool_calls, content, finish_reasons
+
+
+def _make_pp(tool_choice, parser="lfm"):
+    request = {"tool_choice": tool_choice, "tools": DECLARED_TOOLS}
+    pp = StreamingPostProcessor(
+        _cfg(parser), tools_requested=True, enable_thinking=False, request=request
+    )
+    pp.reset()
+    return pp
+
+
+class TestStreamingTextParserSuppression:
+    def test_none_suppresses_text_parser_stream(self):
+        pp = _make_pp("none")
+        calls, content, finish = _drive(pp, [_output(LFM_WIRE, finished=True)])
+        assert calls == []
+        # Parser consumed the block, so the markup did not leak into content.
+        assert "GetWeather" not in content
+        # No call reached the wire → the terminal must not claim tool_calls.
+        assert "tool_calls" not in finish
+
+    def test_auto_still_emits_the_same_stream(self):
+        pp = _make_pp("auto")
+        calls, _content, _finish = _drive(pp, [_output(LFM_WIRE, finished=True)])
+        assert [c["function"]["name"] for c in calls] == ["GetWeather"]
+
+
+class TestStreamingChannelRoutedSuppression:
+    """Harmony/gemma4 surface structured calls on a dedicated channel that
+    bypasses the text ``tool_parser`` — it needs its own none gate."""
+
+    def _channel_output(self):
+        return _output(
+            "tool",
+            finished=True,
+            channel="tool_call",
+            tool_calls=[
+                {
+                    "name": "GetWeather",
+                    "arguments": '{"location":"Rome"}',
+                    "id": "call_x",
+                }
+            ],
+        )
+
+    def test_none_suppresses_channel_routed_call(self):
+        pp = _make_pp("none", parser="harmony")
+        calls, content, finish = _drive(pp, [self._channel_output()])
+        assert calls == []
+        # The raw tool-call-channel delta must not leak into content either.
+        assert "tool" not in content
+        # R11-A: zero calls on the wire ⇒ the terminal is normalized to stop,
+        # never a phantom finish_reason="tool_calls" (codex #1761 BLOCKING).
+        assert finish == ["stop"]
+
+    def test_none_suppresses_partial_then_separate_finish(self):
+        # codex #1761: a partial ``tool_call`` channel chunk (no structured
+        # call yet) must not leak as content, and a SEPARATE finish-only
+        # chunk that still carries ``finish_reason="tool_calls"`` must be
+        # normalized to ``"stop"`` — the suppression can't be gated on this
+        # chunk carrying ``engine_tool_calls``.
+        pp = _make_pp("none", parser="harmony")
+        partial = _output("<call>get_", finished=False, channel="tool_call")
+        finish = _output("", finished=True, channel="tool_call")
+        finish.finish_reason = "tool_calls"  # engine's terminal, no calls set
+        calls, content, finish_reasons = _drive(pp, [partial, finish])
+        assert calls == []
+        assert "get_" not in content  # partial channel markup did not leak
+        assert finish_reasons == ["stop"]
+
+    def test_auto_still_emits_channel_routed_call(self):
+        pp = _make_pp("auto", parser="harmony")
+        calls, _content, _finish = _drive(pp, [self._channel_output()])
+        assert [c["function"]["name"] for c in calls] == ["GetWeather"]

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -2814,6 +2814,32 @@ def _validate_model_name(request_model: str) -> None:
 # ── Tool call parsing ──────────────────────────────────────────────
 
 
+def tool_choice_is_none(request) -> bool:
+    """True when the request set OpenAI ``tool_choice="none"``.
+
+    Parser-agnostic: ``"none"`` is a hard contract that the model will NOT
+    emit a tool call this turn, so the server must surface ZERO
+    ``tool_calls`` regardless of what wire markup a non-compliant model
+    produced. The prompt-level lever (dropping ``tools`` before rendering,
+    ``routes/chat.py``) is best-effort only — a tool-trained model can
+    still echo ``[name({...})]``-style markup it was never shown, and the
+    text parser would otherwise promote it. This gate is the reliable,
+    parser-independent enforcement of the ``"none"`` mode; it fires on
+    both the streaming and non-streaming paths.
+
+    ``request`` may be a pydantic request model (non-streaming) or the
+    plain dict the postprocessor holds (streaming), so both shapes are
+    accepted — mirroring ``_forced_tool_choice_name``.
+    """
+    if request is None:
+        return False
+    if isinstance(request, dict):
+        tc = request.get("tool_choice")
+    else:
+        tc = getattr(request, "tool_choice", None)
+    return isinstance(tc, str) and tc == "none"
+
+
 def _request_declared_tool_names(request_dict: dict | None) -> set[str]:
     """Executable function names after applying tool_choice=none."""
     if not isinstance(request_dict, dict) or request_dict.get("tool_choice") == "none":
@@ -2838,6 +2864,32 @@ def _request_declared_tool_names(request_dict: dict | None) -> set[str]:
 
 
 def _parse_tool_calls_with_parser(
+    output_text: str,
+    request=None,
+    *,
+    structured_tool_calls: list[dict] | None = None,
+) -> tuple[str, list | None]:
+    """Parse tool calls, then honor ``tool_choice="none"`` by dropping them.
+
+    The parser still RUNS under ``"none"`` — that is what strips the wire
+    markup out of ``content`` (the R12 sanitizer invariant: raw
+    ``<tool_call>…</tool_call>`` / ``[name({…})]`` must never leak to the
+    client). What ``"none"`` forbids is *surfacing a call*: the OpenAI
+    contract says the model will not call a tool this turn, so any call it
+    emitted anyway is DROPPED rather than forwarded as a phantom the client
+    cannot execute. Parser-agnostic — covers the text parsers AND the
+    structured harmony/gemma4 channel. The cleaned content (markup removed)
+    is preserved unchanged.
+    """
+    content, tool_calls = _run_tool_parser(
+        output_text, request, structured_tool_calls=structured_tool_calls
+    )
+    if tool_choice_is_none(request):
+        return content, None
+    return content, tool_calls
+
+
+def _run_tool_parser(
     output_text: str,
     request=None,
     *,

--- a/vllm_mlx/service/postprocessor.py
+++ b/vllm_mlx/service/postprocessor.py
@@ -385,6 +385,19 @@ class StreamingPostProcessor:
             if callable(reset_parser):
                 reset_parser()
 
+        # ``tool_choice="none"`` forbids tool calls this turn (OpenAI
+        # contract). The tool parser still RUNS — that is what strips wire
+        # markup out of ``content`` (the R12 sanitizer invariant) — but any
+        # call it resolves is DROPPED at the emission points rather than
+        # forwarded as a phantom the client cannot execute. This flag is
+        # read by ``_detect_tool_calls`` (text-parser incremental /
+        # finalize paths) and ``_process_channel_routed`` (harmony/gemma4
+        # structured channel), mirroring the non-streaming
+        # ``_parse_tool_calls_with_parser`` drop.
+        from .helpers import tool_choice_is_none
+
+        self._suppress_tool_calls = tool_choice_is_none(request)
+
         # State
         self.accumulated_text = ""
         self.tool_accumulated_text = ""
@@ -2646,6 +2659,21 @@ class StreamingPostProcessor:
         # round-14 BLOCKING — tool calls whose JSON args contain
         # literal harmony sentinels were corrupted by sentinel-
         # anchored regex parsing).
+        # ``tool_choice="none"`` forbids tool calls this turn (OpenAI
+        # contract). The channel-routed structured path bypasses the text
+        # ``self.tool_parser``, so it needs its own suppression. Drop the
+        # ENTIRE ``tool_call`` channel — completed structured calls AND
+        # partial in-flight deltas — so no call reaches the wire and the raw
+        # channel markup never falls through to ``content`` below. The
+        # engine stamps ``finish_reason="tool_calls"`` when it fires a call;
+        # that is normalized to ``"stop"`` centrally in
+        # ``_compute_finish_reason`` (R11-A: zero calls on the wire must not
+        # terminate as ``tool_calls``), which also covers a separate
+        # finish-only chunk that carries no structured call of its own.
+        if self._suppress_tool_calls and output.channel == "tool_call":
+            if output.finished:
+                return [self._make_finish_event(output)]
+            return []
         engine_tool_calls = getattr(output, "tool_calls", None) or []
         # F-200: when ``tool_choice`` forces a named function, route
         # the channel-routed structured calls through the SHARED
@@ -3995,6 +4023,14 @@ class StreamingPostProcessor:
         self._tool_suppressed_buffer = ""
 
         if "tool_calls" in tool_result:
+            if self._suppress_tool_calls:
+                # ``tool_choice="none"``: the parser has already consumed the
+                # wire markup (so it does NOT leak into content), but the
+                # resolved call must be dropped. Surface only any prose the
+                # same delta carried, and leave ``tool_calls_detected`` False
+                # so ``_compute_finish_reason`` stays honest (no phantom
+                # ``finish_reason="tool_calls"`` with zero calls on the wire).
+                return {"content": tool_result.get("content", "")}
             self.tool_calls_detected = True
             return tool_result
 
@@ -4019,6 +4055,14 @@ class StreamingPostProcessor:
         # only fires UP from ``output.finish_reason``, never DOWN.
         if self._tool_calls_emitted_to_wire > 0:
             return "tool_calls"
+        # ``tool_choice="none"``: no call can ever reach the wire this turn,
+        # so a channel-routed engine's ``finish_reason="tool_calls"`` (stamped
+        # when it fired a structured call the none-gate then dropped) would be
+        # a lie. Normalize it here — the single terminal chokepoint — so it
+        # holds even for a separate finish-only chunk that carried no
+        # structured call of its own (codex #1761).
+        if self._suppress_tool_calls and output.finish_reason == "tool_calls":
+            return "stop"
         return output.finish_reason
 
     def _make_finish_event(self, output: GenerationOutput) -> StreamEvent:


### PR DESCRIPTION
## Why

OpenAI's `tool_choice="none"` contract forbids tool calls for the turn. The server only enforced it **best-effort at the prompt level** (`routes/chat.py` drops `request.tools` before rendering). A tool-trained model still echoes `[name({...})]`-style markup it was never shown, and the text parser promoted it — because:

1. the declared-name / choice whitelist ran **only** for the `qwen3_coder_xml` parser (`helpers._parse_tool_calls_with_parser`);
2. the post-parse enforcement at `routes/chat.py:5451` is gated `if request.tool_choice is not None and request.tools:` — and `request.tools` was already set to `None` by the prompt-level lever, so the block is skipped.

**Deterministically reproducible on `lfm2.5-2.6b-4bit` (5/5):** an explicit `tool_choice="none"` came back with a phantom call `GetWeather({"location":"Rome"})` — a name and parameter never declared (declared tool was `get_weather(city, unit)`). An OpenAI-SDK client that turned tools OFF for a turn receives a call it cannot execute. The same leak exists on the streaming path and on the channel-routed harmony/gemma4 path.

## What

A parser-agnostic predicate `tool_choice_is_none(request)` (accepts pydantic request OR dict, mirroring `_forced_tool_choice_name`). The key design point: **the parser still RUNS under `none`** — that is what strips the wire markup out of `content` (the R12 sanitizer invariant: raw `<tool_call>…</tool_call>` must never leak). What `none` forbids is *surfacing a call*, so the resolved call is **dropped**:

- **Non-streaming** `_parse_tool_calls_with_parser`: now a thin wrapper over `_run_tool_parser` that drops the calls under `none` while keeping the cleaned content. Covers the text parsers AND the structured harmony/gemma4 `structured_tool_calls` channel.
- **Streaming text parsers** (`_detect_tool_calls`): drop the resolved call, surface only co-emitted prose, and leave `tool_calls_detected` False so `_compute_finish_reason` stays honest.
- **Streaming channel-routed** (`_process_channel_routed`): drop the engine-surfaced calls, suppress the raw channel delta (so it doesn't leak as content), and normalize `finish_reason` to `"stop"` — R11-A forbids a `tool_calls` terminal with zero calls on the wire.

## Tests

New `tests/test_tool_choice_none_suppression.py` (16 cases, hermetic — no model, no network):
- predicate unit tests (string/dict/object; `auto`/`required`/named-function/`None` all correctly NOT-none);
- non-streaming: `none` + lfm markup → no call, **markup stripped from content** (not leaked); `none` + structured harmony channel → no call, clean content; **`auto` + the identical markup still parses** (over-suppression guard); unset choice still parses;
- streaming: `none` + lfm stream → no `tool_call` event, markup not leaked, no `tool_calls` terminal; `auto` still emits; channel-routed harmony `none` → suppressed, no content leak, `finish_reason == "stop"`; channel-routed `auto` still emits.

Regression (691 passed, 4 skipped): `test_tool_parser_content_passthrough`, `test_447_stream_tool_choice_auto`, `test_lfm_tool_parser`, `test_tool_choice_enforcement`, `test_chat_route_tool_choice_enforcement`, `test_openai_tool_choice_validation`, `test_postprocessor`, `test_tool_call_streaming_parity`, `test_r12_reasoning_sanitizer_required`, `test_stream_forced_tool_reasoning`, `test_chat_route_forced_tool_prefix_wiring`. `ruff check` + `ruff format --check` clean.

## Notes

One PR, one change; no version bump. `auto` / `required` / named-function paths are untouched — the gate fires only on the string `"none"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)