### PR TITLE
fix(cache): enable LFM2.5-2.6B bounded prefix reuse

### DIFF
--- a/tests/test_hybrid_prefix_cache_auto_default.py
+++ b/tests/test_hybrid_prefix_cache_auto_default.py
@@ -247,6 +247,25 @@ class TestNeedsBoundedTrimFreeReuseRealAliases:
 
         assert _needs_bounded_trim_free_reuse("qwen3.6-27b-4bit") is True
 
+    def test_lfm25_26b_hybrid_alias_needs_bounded_reuse(self):
+        """LFM2.5's declared ArraysCache routing must retain cache entries."""
+        from vllm_mlx.cli import _needs_bounded_trim_free_reuse
+        from vllm_mlx.model_aliases import resolve_profile
+
+        profile = resolve_profile("lfm2.5-2.6b-4bit")
+        assert profile is not None
+        assert profile.is_hybrid is True
+        assert _needs_bounded_trim_free_reuse("lfm2.5-2.6b-4bit") is True
+        assert (
+            _resolve_hybrid_cache_entries(
+                enable_prefix_cache=True,
+                explicit_value=0,
+                user_set_explicit=False,
+                model_name="lfm2.5-2.6b-4bit",
+            )
+            == _DEFAULT_HYBRID_CACHE_ENTRIES
+        )
+
     def test_moe_hybrid_still_needs_bounded_reuse(self):
         from vllm_mlx.cli import _needs_bounded_trim_free_reuse
 

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -1815,7 +1815,7 @@
     "subfolder": "4bit",
     "tool_call_parser": "lfm",
     "reasoning_parser": "qwen3",
-    "is_hybrid": false,
+    "is_hybrid": true,
     "supports_spec_decode": false
   },
   "lfm2.5-8b-a1b-4bit": {


### PR DESCRIPTION
## What does this PR do?

Corrects the `lfm2.5-2.6b-4bit` alias to declare its runtime-observed hybrid `ArraysCache` architecture before scheduler construction. This makes the existing prefix-cache resolver auto-configure eight bounded non-trimmable entries instead of dropping every entry.

Fixes #1762.

## Why is this needed?

The alias said `is_hybrid=false`, so `_resolve_hybrid_cache_entries` returned zero before weights loaded. The later runtime `ArraysCache` probe promoted the model to hybrid, but the already-built cache retained a zero non-trimmable-entry bound. Consequently every store returned `stored=False`, `cache_entries` stayed zero, and repeated prefixes never hit.

Declaring `is_hybrid=true` aligns metadata with the existing runtime decision. It does not newly enable speculative decoding (`supports_spec_decode` remains false) and does not change the post-load routing observed in the report.

## Test plan

- [x] Mutation proof: with the alias restored to `is_hybrid=false`, `test_lfm25_26b_hybrid_alias_needs_bounded_reuse` fails at `assert profile.is_hybrid is True` (actual `False`)
- [x] Alias/cache/model-config neighborhood: 424 passed
- [x] Full local unit: 16,591 passed, 123 skipped, 9 deselected, 6 xfailed, 1 xpassed
- [x] First `pr_validate` code gates: targeted 18 passed; full unit 16,721 passed; Codex, supply-chain, lint all passed. The run correctly returned DO NOT MERGE solely because this body still had pending checkboxes; rerun follows with the metadata corrected.
- [x] Ruff check and format check pass
- [x] Codex adversarial review: zero actionable findings

GitHub CI will be checked from a fresh final snapshot immediately before merge; pending or red checks block landing.

## AI assistance disclosure

Codex reproduced the resolver/configuration mismatch, authored the two-line behavior change plus regression coverage, reviewed the routing-risk tradeoff, and ran focused and full validation. The maintainer can explain the intent, risk, and behavior of every changed line.

> By submitting this PR I confirm I can explain the intent, risk, and behavior of every non-generated change in this PR.