### PR TITLE
fix(agents): preserve literal tool markup without request tools

### DIFF
--- a/tests/test_chat_streaming_spec.py
+++ b/tests/test_chat_streaming_spec.py
@@ -659,6 +659,15 @@ def test_terminal_finish_snapshot_does_not_replay_streamed_content(
             "stream": True,
             "max_tokens": 16,
             "messages": [{"role": "user", "content": "say hello world"}],
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "dummy",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                }
+            ],
         },
     )
     assert resp.status_code == 200, resp.text
@@ -752,6 +761,15 @@ def test_terminal_replay_guard_suppresses_snapshot_split_across_fields(monkeypat
             "stream": True,
             "max_tokens": 16,
             "messages": [{"role": "user", "content": "say hello world"}],
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "dummy",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                }
+            ],
         },
     )
     assert resp.status_code == 200, resp.text

--- a/tests/test_postprocessor.py
+++ b/tests/test_postprocessor.py
@@ -1969,6 +1969,55 @@ class TestToolParserInit:
         assert pp.tool_parser is not singleton
         assert pp.tool_parser is not None
 
+    def test_configured_parser_is_disabled_without_request_tools(self):
+        """A server parser setting must not reinterpret ordinary prose.
+
+        ``tool_call_parser`` is configured once for the served model, but a
+        request with no ``tools`` has no callable namespace.  Before this
+        guard, Hermes held a literal ``<tool_call>`` opener as an in-flight
+        call and silently dropped it (and the following text) at EOF.
+        """
+        cfg = _make_cfg(
+            enable_auto_tool_choice=True,
+            tool_call_parser="hermes",
+            tool_parser_instance=None,
+        )
+        pp = StreamingPostProcessor(cfg, tools_requested=False)
+        pp.reset()
+
+        assert pp.tool_parser is None
+        events = pp.process_chunk(
+            _make_output("Explain the literal <tool_call> tag.", finished=True)
+        )
+        assert len(events) == 1
+        assert events[0].type == "finish"
+        assert events[0].content == "Explain the literal <tool_call> tag."
+
+    def test_omitted_capability_fails_closed_without_request(self):
+        cfg = _make_cfg(
+            enable_auto_tool_choice=True,
+            tool_call_parser="hermes",
+            tool_parser_instance=None,
+        )
+
+        pp = StreamingPostProcessor(cfg)
+
+        assert pp.tool_parser is None
+
+    def test_omitted_capability_is_inferred_from_request_tools(self):
+        cfg = _make_cfg(
+            enable_auto_tool_choice=True,
+            tool_call_parser="hermes",
+            tool_parser_instance=None,
+        )
+
+        pp = StreamingPostProcessor(
+            cfg,
+            request={"tools": [{"type": "function", "function": {"name": "x"}}]},
+        )
+
+        assert pp.tool_parser is not None
+
     def test_init_parser_failure_returns_none(self):
         """Failed tool parser init returns None gracefully."""
         cfg = _make_cfg(

--- a/tests/test_tool_call_streaming_parity.py
+++ b/tests/test_tool_call_streaming_parity.py
@@ -123,7 +123,9 @@ def _extract_stream(parser_name: str, text: str) -> list:
     surface PR #426 fixed.
     """
     cfg = _make_cfg_for_parser(parser_name)
-    pp = StreamingPostProcessor(cfg)
+    # This helper intentionally exercises a configured parser without a full
+    # request object, so declare the capability explicitly.
+    pp = StreamingPostProcessor(cfg, tools_requested=True)
     pp.reset()
     pp.tool_accumulated_text = text
     events = pp.finalize()

--- a/vllm_mlx/service/postprocessor.py
+++ b/vllm_mlx/service/postprocessor.py
@@ -207,7 +207,7 @@ class StreamingPostProcessor:
     def __init__(
         self,
         cfg: ServerConfig,
-        tools_requested: bool = False,
+        tools_requested: bool | None = None,
         enable_thinking: bool | None = None,
         json_mode: bool = False,
         request: dict | None = None,
@@ -215,6 +215,17 @@ class StreamingPostProcessor:
         line1_gate_engaged: bool = False,
     ):
         self.cfg = cfg
+        if tools_requested is None:
+            # Backward-compatible inference for direct/internal callers that
+            # already pass the request payload but predate this constructor
+            # argument. Fail closed when capability is absent or ambiguous.
+            if isinstance(request, dict):
+                tools_requested = bool(request.get("tools"))
+            else:
+                request_tools = getattr(request, "tools", None)
+                tools_requested = isinstance(request_tools, (list, tuple)) and bool(
+                    request_tools
+                )
         self.tools_requested = tools_requested
         self.json_mode = json_mode
         # LINE① (#558, codex r4 #4): when the reasoning-gated forced tool grammar is
@@ -1436,8 +1447,17 @@ class StreamingPostProcessor:
         if cfg.engine is not None and hasattr(cfg.engine, "_tokenizer"):
             tokenizer = cfg.engine._tokenizer
 
-        # Primary: explicit tool parser configured
-        if cfg.enable_auto_tool_choice and cfg.tool_call_parser:
+        # Primary: explicit tool parser configured for a request that can
+        # actually call a tool.  Parser selection is a server-level setting,
+        # while ``tools_requested`` is the per-request capability boundary.
+        # Instantiating the parser without that boundary makes ordinary prose
+        # containing a wire opener (for example documentation that mentions
+        # ``<tool_call>``) enter the streaming suppression state even though
+        # there is no declared tool the response could invoke.  In that case
+        # the only correct interpretation is content. Direct callers that
+        # omit the flag have it inferred from ``request.tools`` above; an
+        # absent or ambiguous capability fails closed.
+        if tools_requested and cfg.enable_auto_tool_choice and cfg.tool_call_parser:
             try:
                 parser_cls = ToolParserManager.get_tool_parser(cfg.tool_call_parser)
                 return parser_cls(tokenizer)


### PR DESCRIPTION
## What changed

- gate the configured streaming tool parser on the request actually declaring tools
- preserve literal tool-call markup as ordinary content when there is no callable namespace
- keep the #1709 terminal replay tests on the real parser path by declaring a dummy tool

## Why

A model-level tool parser is configured once at server startup. Before this change it was also instantiated for requests with no tools. Hermes then interpreted a literal opening tool_call tag in documentation or code as an in-flight call, held it, and silently dropped the tag and following text at EOF.

The reported tokenizer diagnosis is not correct on current main: the real Qwen tokenizers preserve the literals even with skip_special_tokens enabled. The remaining loss is a request-capability/parser-boundary bug. The previously reported closing-tag content loss and tool-argument truncation were already fixed by PRs #1511 and #1730.

## Safety

Requests that declare tools retain the existing parser and structural leak protections unchanged. Requests without tools cannot legally emit a structured tool call, so treating markup as content is the only valid interpretation. No tokenizer or global sanitizer behavior changes.

## Validation

- real cached Qwen3.5 35B, Qwen3.6 27B, Qwen3.5 9B, and Qwen3 tokenizer encode/decode probes
- 723 passed, 28 skipped across postprocessor, chat streaming, Qwen parser, suppression, content-integrity, and argument-fidelity suites
- ruff check and format check
- git diff --check

## AI assistance disclosure

Codex reproduced the current-main behavior, isolated the parser boundary, implemented the focused gate and regressions, and validated the affected matrices.