### PR TITLE
fix(image): the Images tab could never generate a picture

### DIFF
--- a/apps/rapid-mac/Tests/RapidTests/SidecarBuildScriptTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SidecarBuildScriptTests.swift
@@ -10,8 +10,23 @@ struct SidecarBuildScriptTests {
 
         #expect(!script.contains("require python3.12"),
                 "The script downloads pinned Python 3.12 itself and must not require a host copy.")
-        #expect(script.components(separatedBy: embeddedPip).count - 1 == 2,
-                "Both dependency installs must use the pinned interpreter extracted into the bundle.")
+        // Pin the EQUALITY, not a count. The invariant is "every build-time
+        // install runs on the pinned interpreter", and a hard-coded total
+        // re-breaks the moment a dependency is added (bundling mflux for the
+        // Images tab made this 2 -> 3) while saying nothing about whether the
+        // NEW install honours the rule. Comparing the two tallies fails only
+        // when an install actually escapes the pinned interpreter.
+        let anyPip = "-m pip install"
+        let embeddedInstalls = script.components(separatedBy: embeddedPip).count - 1
+        let allInstalls = script.components(separatedBy: anyPip).count - 1
+        #expect(embeddedInstalls >= 2,
+                "The engine and vision-stack installs must both still be here.")
+        #expect(embeddedInstalls == allInstalls,
+                """
+                Every build-time pip install must use the pinned interpreter \
+                extracted into the bundle; \(allInstalls - embeddedInstalls) \
+                of \(allInstalls) do not.
+                """)
         #expect(!script.contains("\npython3.12 -m pip install"),
                 "A host Python can resolve wheels for the wrong ABI and make the bundle unloadable.")
     }
@@ -51,6 +66,27 @@ struct SidecarBuildScriptTests {
         #expect(script.contains("from packaging.requirements import Requirement"))
         #expect(script.contains("actual not in req.specifier"),
                 "Post-install validation must reject incompatible installed dependency versions.")
+    }
+
+    @Test("Desktop image stack is pinned and its torch-free proof fails closed")
+    func imageStackIsPinnedAndProvenTorchFree() throws {
+        let script = try String(contentsOf: Self.scriptURL, encoding: .utf8)
+
+        #expect(script.contains("'mflux==0.18.1'"),
+                "The no-deps sidecar install must never float within a range.")
+        // The Images tab is only shippable because mflux's module-level
+        // `import torch` is deferred into the three torch-only loading modes —
+        // bundling torch itself would be +363 MB against a 500 MB cap. Both
+        // halves of that argument have to fail closed, or a future mflux bump
+        // ships an Images tab that dies on every generation: the patch must
+        // refuse to guess when weight_loader.py has been reshaped, and the
+        // import probe must prove the result needs no torch.
+        #expect(script.contains("no longer has the eager import"),
+                "The torch-deferral patch must abort on an unrecognised weight_loader.py.")
+        #expect(script.contains("has no single-line def for"),
+                "The torch-deferral patch must abort when a target function moves.")
+        #expect(script.contains("mflux still pulls torch at import time"),
+                "A post-patch import probe must prove the image lane needs no torch.")
     }
 
     private static var scriptURL: URL {

--- a/apps/rapid-mac/scripts/build-sidecar.sh
+++ b/apps/rapid-mac/scripts/build-sidecar.sh
@@ -8,7 +8,7 @@
 #
 # Lives in **rapid-desktop**, not vllm-mlx. Sidecar packaging is a
 # rapid-desktop concern — tunables like MACHO_BASELINE_COUNT, extras
-# (mlx-vlm, Pillow), trim rules, and size gates all gate a
+# (mlx-vlm, Pillow, mflux), trim rules, and size gates all gate a
 # rapid-desktop artifact, so they live next to it. Submodule
 # indirection used to put this script in the rapid-mlx repo (v0.6.6 →
 # v0.7.7), and the v0.7.4 slim mechanism notes flagged that as a
@@ -281,6 +281,105 @@ echo "==> bundling mlx-vlm --no-deps + Pillow (gemma-4 + DiffusionGemma loader p
     --no-deps \
     'mlx-vlm==0.6.3' \
     'Pillow>=10.0'
+
+# ----- step 2.6: bundle mflux --no-deps (Images tab image-gen lane) ----
+#
+# The Images tab offers the ``[image:gen]`` aliases — flux2-klein-4b and
+# z-image-turbo — and ``ImageGenViewModel.runGenerate`` starts the sidecar
+# on whichever one the user picked. Without mflux the sidecar prints
+# "image generation requires the `rapid-mlx[image]` Python extra" and
+# exits before binding a port, so the app can only say "Couldn't start X.
+# Try again" — advice that fails identically forever, after a 4-6 GB
+# download. That is precisely the dead end #1603 closed for the video
+# aliases, and it shipped unnoticed because the Images golden flow drives
+# a stub server and so cannot observe a missing engine dependency.
+#
+# mflux declares torch (363 MB installed), opencv-python and matplotlib.
+# Bundling torch alone would blow BUNDLE_SIZE_CAP_MB (500) on its own, and
+# none of the three is reachable from the two families we wire:
+#   * every component of Flux2KleinWeightDefinition / ZImageWeightDefinition
+#     takes ComponentDefinition's default ``loading_mode="mlx_native"``,
+#     which loads through ``mx.load``;
+#   * torch is only touched by the "torch_checkpoint" / "torch_convert" /
+#     "torch_bfloat16" modes, which belong to families we do not wire
+#     (fibo, fibo_vlm, depth_pro);
+#   * cv2 lives in flux/variants/controlnet and matplotlib in
+#     flux/variants/concept_attention — neither on our path.
+# The only thing in the way is a module-level ``import torch`` in
+# weight_loader.py that runs on EVERY load; the patch below defers it into
+# the three functions that actually use it. Verified end to end on a
+# bundle with no torch: ``serve flux2-klein-4b`` binds, and
+# /v1/images/generations returns a real 512x512 PNG in ~3 s on an M3 Ultra.
+#
+# Of mflux's other declared deps only three are both missing here and
+# actually imported: platformdirs (cli/defaults/defaults.py, reached from
+# weight_loader), piexif (utils/image_util.py) and toml
+# (utils/version_util.py) — ~620 KB together. filelock is already bundled
+# by rapid-mlx's own install; hf-transfer is declared but never imported.
+# Pin exactly, for the same reason as mlx-vlm above: with --no-deps a range
+# would let the desktop float onto an mflux release whose loader wants a
+# dependency this bundle does not carry.
+echo "==> bundling mflux --no-deps + platformdirs/piexif/toml (Images tab image-gen lane)"
+"$STAGE/python/bin/python3.12" -m pip install \
+    --target "$STAGE/site-packages" \
+    --no-warn-script-location \
+    --no-compile \
+    --no-deps \
+    'mflux==0.18.1' \
+    'platformdirs>=4.0,<5.0' \
+    'piexif>=1.1.3,<2.0' \
+    'toml>=0.10.2,<1.0'
+
+# Defer mflux's module-level torch imports into the three functions that
+# use them. Fails the build when the expected lines are gone: an mflux bump
+# that reshapes weight_loader.py must be re-verified by a human rather than
+# silently shipping an Images tab that dies on every generation.
+"$STAGE/python/bin/python3.12" - "$STAGE/site-packages" <<'PY'
+import pathlib
+import re
+import sys
+
+target = pathlib.Path(sys.argv[1]) / "mflux/models/common/weights/loading/weight_loader.py"
+src = target.read_text()
+
+for eager in ("import torch\n", "from safetensors.torch import load_file as torch_load_file\n"):
+    if eager not in src:
+        raise SystemExit(
+            f"ERR: mflux weight_loader.py no longer has the eager import "
+            f"{eager.strip()!r}. Re-verify the torch-free image path before "
+            f"bumping the mflux pin."
+        )
+    src = src.replace(eager, "", 1)
+
+lazy = (
+    "        import torch\n"
+    "        from safetensors.torch import load_file as torch_load_file\n"
+)
+for fn in ("_load_torch_checkpoint", "_load_torch_convert", "_load_torch_bfloat16"):
+    match = re.search(rf"^    def {fn}\(.*\n", src, re.M)
+    if match is None or not match.group(0).rstrip().endswith(":"):
+        raise SystemExit(
+            f"ERR: mflux weight_loader.py has no single-line def for {fn}(). "
+            f"Re-verify the torch-free image path before bumping the mflux pin."
+        )
+    src = src[: match.end()] + lazy + src[match.end() :]
+
+target.write_text(src)
+print("==> mflux torch imports deferred into the 3 torch-only loading modes")
+PY
+
+# Fail closed: with no torch in the stage, importing mflux's weight loader
+# is itself the proof that the image lane no longer needs a 363 MB
+# dependency. A regression here means every Images-tab generation 500s.
+PYTHONPATH="$STAGE/site-packages" PYTHONNOUSERSITE=1 "$STAGE/python/bin/python3.12" -s - <<'PY'
+import importlib
+import sys
+
+importlib.import_module("mflux.models.common.weights.loading.weight_loader")
+if "torch" in sys.modules:
+    raise SystemExit("ERR: mflux still pulls torch at import time")
+print("==> mflux image lane imports without torch: OK")
+PY
 
 # ``--no-deps`` is intentional for bundle size, but it must not hide version
 # conflicts among distributions that ARE present. Missing optional heavy deps

--- a/tests/test_image_lane.py
+++ b/tests/test_image_lane.py
@@ -660,3 +660,58 @@ def test_generations_uses_engine_default_steps(client, monkeypatch, default_step
     resp = client.post("/v1/images/generations", json={"prompt": "a fox"})
     assert resp.status_code == 200
     assert engine.steps_seen == [default_steps]
+
+
+def test_image_alias_skips_the_mllm_routing_preflight(monkeypatch):
+    """An image-gen alias must not run the MLLM-vs-text routing preflight.
+
+    ``_ensure_routing_config`` materializes a checkpoint ``config.json`` so
+    ``resolve_serving_lane`` can tell a hybrid VLM from a text model, and
+    fails fast when it cannot. mflux-layout checkpoints keep every weight and
+    config under ``transformer/`` / ``text_encoder/`` / ``vae/`` and ship no
+    ``config.json`` at the checkpoint root, so that preflight can never
+    succeed for them — which is how ``serve z-image-turbo`` refused a
+    fully-cached 5.5 GB model with an error about hybrid-VLM misrouting, a
+    hazard a diffusion model does not have. A diffusion alias branches
+    straight to ImageEngine and never asks the question, so the preflight
+    must be skipped rather than merely tolerated.
+    """
+    from vllm_mlx import server
+    from vllm_mlx.runtime import image_lane
+
+    def _unmaterializable(name):
+        raise RuntimeError(
+            f"Could not materialize the checkpoint config for {name!r} "
+            "before selecting the serving lane."
+        )
+
+    built: dict[str, object] = {}
+
+    class _LazyImageEngine:
+        def __init__(self, model_name):
+            built["model_name"] = model_name
+
+    monkeypatch.setattr(server, "_ensure_routing_config", _unmaterializable)
+    monkeypatch.setattr(image_lane, "ImageEngine", _LazyImageEngine)
+    monkeypatch.setattr(
+        image_lane, "require_image_runtime_or_exit", lambda *_a, **_kw: None
+    )
+    monkeypatch.setattr(
+        "vllm_mlx.utils.generation_config.load_generation_config_sampling",
+        lambda *_a, **_kw: {},
+    )
+
+    # ``load_model`` publishes module globals; keep them off sibling tests.
+    saved = {
+        attr: getattr(server, attr, None)
+        for attr in ("_engine", "_model_name", "_model_alias")
+    }
+    try:
+        server.load_model("z-image-turbo")
+        assert built.get("model_name") == "filipstrand/Z-Image-Turbo-mflux-4bit", (
+            "the image alias never reached ImageEngine — the MLLM routing "
+            "preflight ran and killed a lane that has no MLLM question"
+        )
+    finally:
+        for attr, value in saved.items():
+            setattr(server, attr, value)

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -1759,8 +1759,24 @@ def load_model(
     # auto mode: an explicit ``--mllm`` (force_mllm) is respected so the
     # operator who insists on the multimodal path gets the engine's own #352
     # error rather than a silent override. #352 dogfood P1-② (0.10.16).
+    #
+    # The generative-media lanes are exempt. An ``image-gen`` / ``video-gen``
+    # alias never reaches ``resolve_serving_lane``'s question at all — it
+    # branches to ImageEngine / VideoEngine below — so the MLLM-vs-text
+    # preflight has nothing to decide for it. Running it anyway is not merely
+    # wasted work: mflux-layout checkpoints keep their weights and configs in
+    # ``transformer/`` / ``text_encoder/`` / ``vae/`` subdirectories and ship
+    # no ``config.json`` at the checkpoint root, so ``_ensure_routing_config``
+    # cannot materialize one and raises. That is how the Images tab's
+    # ``z-image-turbo`` alias could never start: a fully-cached 5.5 GB
+    # checkpoint refused with an error about hybrid-VLM misrouting, a hazard
+    # that does not exist for a diffusion model.
     _auto_text_fallback = False
-    if not force_text and not force_mllm:
+    _is_generative_media = _profile is not None and _profile.modality in (
+        "image-gen",
+        "video-gen",
+    )
+    if not force_text and not force_mllm and not _is_generative_media:
         _ensure_routing_config(model_name)
         _lane_is_mllm, _auto_text_fallback = resolve_serving_lane(
             model_name, force_mllm=force_mllm, force_text=force_text
@@ -2663,6 +2679,7 @@ Examples:
     # was silently dropped — same bug class as #400. The unified rapid-mlx
     # CLI builds a richer SchedulerConfig in cli.py; the standalone path only
     # exposes a small subset of flags, so we plumb just those.
+    from .model_aliases import resolve_profile as _srv_resolve_profile
     from .pflash import resolve_pflash_config as _server_pflash_resolve_config
     from .pflash import validate_model_support as _server_pflash_validate
     from .scheduler import SchedulerConfig
@@ -2684,9 +2701,18 @@ Examples:
     # ``_ensure_routing_config`` fail-fast would DENY the very ``--no-mllm``
     # escape hatch its own error message advertises when the config cannot be
     # fetched. Mirror ``load_model()``'s flag-first skip (codex BLOCKING #1178).
+    # Same generative-media exemption as ``load_model`` above: an image-gen /
+    # video-gen alias branches to its own engine and never asks the
+    # MLLM-vs-text question, while an mflux-layout checkpoint has no
+    # root-level config.json for the preflight to materialize.
+    _srv_profile = _srv_resolve_profile(args.model)
+    _srv_generative_media = _srv_profile is not None and _srv_profile.modality in (
+        "image-gen",
+        "video-gen",
+    )
     _srv_force_mllm = getattr(args, "mllm", False)
     _srv_force_text = getattr(args, "no_mllm", False)
-    if not _srv_force_mllm and not _srv_force_text:
+    if not _srv_force_mllm and not _srv_force_text and not _srv_generative_media:
         _ensure_routing_config(args.model)
     _srv_is_mllm, _ = resolve_serving_lane(
         args.model,


### PR DESCRIPTION
Closes #1767

## Why

The Images tab offers the two `[image:gen]` aliases and starts the sidecar on whichever one the user picks. Neither could work in a shipped build:

1. **The sidecar has no `mflux`.** `build-sidecar.sh` installs the engine with no extras, so either alias printed `image generation requires the 'rapid-mlx[image]' Python extra` and exited before binding a port — leaving the app to say "Couldn't start X. Try again", advice that fails identically forever, after a 4–6 GB download. Same dead end #1603 closed for the video aliases, except here the tab *is* the user-facing surface.
2. **`z-image-turbo` also died in `_ensure_routing_config`.** That preflight materializes a checkpoint `config.json` so `resolve_serving_lane` can tell a hybrid VLM from a text model, and fails fast when it cannot. mflux-layout checkpoints keep every weight and config under `transformer/` / `text_encoder/` / `vae/` and ship no root `config.json`, so it could never succeed — a fully-cached 5.5 GB model refused with an error about a hazard a diffusion model does not have.

The Images golden flow drives a stub server, so it is structurally unable to observe a missing engine dependency. That is why this shipped unnoticed, and why the gate added here is a build-time import probe rather than another flow assertion.

## What changed

**`apps/rapid-mac/scripts/build-sidecar.sh`** — bundle `mflux==0.18.1 --no-deps` plus the only three declared deps that are both missing and actually imported (`platformdirs`, `piexif`, `toml`; `filelock` is already bundled, `hf-transfer` is declared but never imported).

Bundling mflux normally means bundling **torch (363 MB installed)**, which would blow `BUNDLE_SIZE_CAP_MB` on its own. None of mflux's heavy declared deps is reachable from the two families we wire:

* every component of `Flux2KleinWeightDefinition` / `ZImageWeightDefinition` takes `ComponentDefinition`'s default `loading_mode="mlx_native"`, which loads through `mx.load`;
* torch is only touched by the `torch_checkpoint` / `torch_convert` / `torch_bfloat16` modes, which belong to families we do not wire (fibo, fibo_vlm, depth_pro);
* `cv2` lives in `flux/variants/controlnet` and `matplotlib` in `flux/variants/concept_attention` — neither on our path.

The one obstacle was a module-level `import torch` in `weight_loader.py` that runs on every load, so the build defers it into the three functions that use it. Both the patch and the follow-up import probe **fail closed**: an mflux bump that reshapes that file stops the build instead of silently shipping an Images tab that dies on every generation.

**`vllm_mlx/server.py`** — skip the MLLM-vs-text routing preflight for the `image-gen` / `video-gen` modalities at both call sites. A diffusion alias branches straight to ImageEngine and never asks the question.

**`tests/test_image_lane.py`** — regression test for the routing exemption. Verified it fails without the fix, with the real error (`RuntimeError: Could not materialize the checkpoint config for 'z-image-turbo'`).

## Verification

Against the **built bundle**, not a dev checkout — this is a packaging bug, so a dev checkout could not have seen it:

| | before | after |
|---|---|---|
| `serve flux2-klein-4b` | exits, no port | binds; 512×512 PNG in ~2.9 s |
| `serve z-image-turbo` | exits, no port | binds; 512×512 PNG in ~7.3 s |
| `torch` in bundle | — | absent |
| app size | 425 MB | 438 MB (cap 500) |

Images inspected, not just byte-counted. `tests/test_image_lane.py tests/test_no_mllm_flag.py tests/test_fake_sidecar_image_catalog.py` — 122 passed. `ruff check` + `ruff format --check` clean. Codex review: 0 BLOCKING, 0 MAJOR.

**Not verified:** the end-to-end GUI path (launch app → Images tab → Generate). The screen was locked for this session, and a locked screen reports zero windows for every app, so no AX assertion would have meant anything. The app-side call is `ensureServing(alias:)` + `POST /v1/images/generations`, both exercised directly against the shipped sidecar binary above.

## Not changed

No CHANGELOG entry: the Images tab is itself still under `[Unreleased]`, so a "fixed" line for a feature no user has seen would only confuse a release-day reader. The fix folds into the existing Added entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)