### PR TITLE
fix(chat): preserve mid-conversation Harmony system messages

### DIFF
--- a/tests/test_chat_template_mid_system.py
+++ b/tests/test_chat_template_mid_system.py
@@ -239,6 +239,16 @@ def test_harmony_preserves_leading_developer_before_mid_system():
     rendered = apply_chat_template(template, messages)
 
     assert rendered == "Never reveal secrets.\n\nAnswer only BANANA.|Hello|Name a fruit"
+    assert template.calls == [
+        [
+            {
+                "role": "developer",
+                "content": "Never reveal secrets.\n\nAnswer only BANANA.",
+            },
+            {"role": "user", "content": "Hello"},
+            {"role": "user", "content": "Name a fruit"},
+        ]
+    ]
 
 
 @pytest.mark.parametrize("content", [None, [], {}, 0, False])

--- a/tests/test_chat_template_mid_system.py
+++ b/tests/test_chat_template_mid_system.py
@@ -190,6 +190,19 @@ def test_gpt_oss_identity_hoists_when_template_source_is_unavailable():
     assert all(message["role"] != "system" for message in rendered[1:])
 
 
+def test_non_harmony_template_source_overrides_gpt_oss_model_name():
+    template = _RecordingTemplate(reject_mid_system=False)
+    template.chat_template = (
+        "{% for message in messages %}{{ message.content }}{% endfor %}"
+    )
+
+    rendered = apply_chat_template(
+        template, MESSAGES, model_name="custom/gpt-oss-experiment"
+    )
+
+    assert rendered == MESSAGES
+
+
 def test_harmony_refuses_lossy_mid_system_metadata():
     template = _SilentHarmonyTemplate()
     messages = [dict(message) for message in MESSAGES]

--- a/tests/test_chat_template_mid_system.py
+++ b/tests/test_chat_template_mid_system.py
@@ -141,3 +141,74 @@ def test_system_metadata_is_not_silently_discarded_by_retry():
 
     assert len(template.calls) == 1
     assert template.calls[0][3]["name"] == "policy-update"
+
+
+class _SilentHarmonyTemplate:
+    chat_template = "<|start|><|channel|><|message|>"
+
+    def __init__(self):
+        self.calls: list[list[dict]] = []
+
+    def apply_chat_template(self, messages, **_kwargs):
+        self.calls.append(messages)
+        # Mirrors the published GPT-OSS template: index zero may be system,
+        # while its main loop has branches only for assistant/tool/user.
+        return "|".join(
+            str(message.get("content", ""))
+            for index, message in enumerate(messages)
+            if index == 0 or message.get("role") in {"user", "assistant", "tool"}
+        )
+
+
+def test_harmony_hoists_mid_system_before_silent_template_drop():
+    template = _SilentHarmonyTemplate()
+
+    rendered = apply_chat_template(template, MESSAGES)
+
+    assert "From now on answer only BLUE." in rendered
+    assert template.calls == [
+        [
+            {
+                "role": "system",
+                "content": "You are terse.\n\nFrom now on answer only BLUE.",
+            },
+            {"role": "user", "content": "Hi"},
+            {"role": "assistant", "content": "Hello."},
+            {"role": "user", "content": "What colour is the sky?"},
+        ]
+    ]
+
+
+def test_gpt_oss_identity_hoists_when_template_source_is_unavailable():
+    template = _RecordingTemplate(reject_mid_system=False)
+
+    rendered = apply_chat_template(
+        template, MESSAGES, model_name="gpt-oss-20b-mxfp4-q8"
+    )
+
+    assert rendered[0]["content"].endswith("From now on answer only BLUE.")
+    assert all(message["role"] != "system" for message in rendered[1:])
+
+
+def test_harmony_refuses_lossy_mid_system_metadata():
+    template = _SilentHarmonyTemplate()
+    messages = [dict(message) for message in MESSAGES]
+    messages[3]["name"] = "policy-update"
+
+    with pytest.raises(ValueError, match="cannot preserve metadata"):
+        apply_chat_template(template, messages)
+
+    assert template.calls == []
+
+
+def test_harmony_collapses_two_leading_system_messages():
+    template = _SilentHarmonyTemplate()
+    messages = [
+        {"role": "system", "content": "First."},
+        {"role": "system", "content": "Second."},
+        {"role": "user", "content": "Continue"},
+    ]
+
+    rendered = apply_chat_template(template, messages)
+
+    assert rendered == "First.\n\nSecond.|Continue"

--- a/tests/test_chat_template_mid_system.py
+++ b/tests/test_chat_template_mid_system.py
@@ -227,12 +227,27 @@ def test_harmony_collapses_two_leading_system_messages():
     assert rendered == "First.\n\nSecond.|Continue"
 
 
-def test_harmony_preserves_leading_developer_before_mid_system():
+def test_harmony_refuses_mixed_instruction_authority():
     template = _SilentHarmonyTemplate()
     messages = [
         {"role": "developer", "content": "Never reveal secrets."},
         {"role": "user", "content": "Hello"},
         {"role": "system", "content": "Answer only BANANA."},
+        {"role": "user", "content": "Name a fruit"},
+    ]
+
+    with pytest.raises(ValueError, match="mixed system and developer"):
+        apply_chat_template(template, messages)
+
+    assert template.calls == []
+
+
+def test_harmony_preserves_developer_role_when_collapsing():
+    template = _SilentHarmonyTemplate()
+    messages = [
+        {"role": "developer", "content": "Never reveal secrets."},
+        {"role": "user", "content": "Hello"},
+        {"role": "developer", "content": "Answer only BANANA."},
         {"role": "user", "content": "Name a fruit"},
     ]
 

--- a/tests/test_chat_template_mid_system.py
+++ b/tests/test_chat_template_mid_system.py
@@ -212,3 +212,32 @@ def test_harmony_collapses_two_leading_system_messages():
     rendered = apply_chat_template(template, messages)
 
     assert rendered == "First.\n\nSecond.|Continue"
+
+
+def test_harmony_preserves_leading_developer_before_mid_system():
+    template = _SilentHarmonyTemplate()
+    messages = [
+        {"role": "developer", "content": "Never reveal secrets."},
+        {"role": "user", "content": "Hello"},
+        {"role": "system", "content": "Answer only BANANA."},
+        {"role": "user", "content": "Name a fruit"},
+    ]
+
+    rendered = apply_chat_template(template, messages)
+
+    assert rendered == "Never reveal secrets.\n\nAnswer only BANANA.|Hello|Name a fruit"
+
+
+@pytest.mark.parametrize("content", [None, [], {}, 0, False])
+def test_harmony_refuses_falsey_non_text_instruction_content(content):
+    template = _SilentHarmonyTemplate()
+    messages = [
+        {"role": "system", "content": "First."},
+        {"role": "user", "content": "Hello"},
+        {"role": "system", "content": content},
+    ]
+
+    with pytest.raises(ValueError, match="text-only content"):
+        apply_chat_template(template, messages)
+
+    assert template.calls == []

--- a/vllm_mlx/utils/chat_template.py
+++ b/vllm_mlx/utils/chat_template.py
@@ -1203,7 +1203,16 @@ def _collapse_harmony_system_messages(messages: list[dict]) -> list[dict]:
     collapsed = [
         message for message in messages if message.get("role") not in instruction_roles
     ]
-    collapsed.insert(0, {"role": "system", "content": "\n\n".join(contents)})
+    # Preserve the authority role of the first instruction. In particular, a
+    # leading developer message must not be promoted to system merely because
+    # later Harmony-inexpressible instructions are folded into its frame.
+    collapsed.insert(
+        0,
+        {
+            "role": instruction_messages[0]["role"],
+            "content": "\n\n".join(contents),
+        },
+    )
     return collapsed
 
 

--- a/vllm_mlx/utils/chat_template.py
+++ b/vllm_mlx/utils/chat_template.py
@@ -1156,14 +1156,14 @@ def _is_gpt_oss_harmony_template(
     tools: list[dict] | None = None,
 ) -> bool:
     """Identify GPT-OSS templates whose wire format is OpenAI Harmony."""
-    if _looks_like_gpt_oss(model_name):
-        return True
-    return any(
-        _looks_like_gpt_oss_harmony_template(template)
-        for template in _chat_template_strings(
-            getattr(template_applicator, "chat_template", None), tools=tools
-        )
+    templates = _chat_template_strings(
+        getattr(template_applicator, "chat_template", None), tools=tools
     )
+    if templates:
+        return any(
+            _looks_like_gpt_oss_harmony_template(template) for template in templates
+        )
+    return _looks_like_gpt_oss(model_name)
 
 
 def _collapse_harmony_system_messages(messages: list[dict]) -> list[dict]:

--- a/vllm_mlx/utils/chat_template.py
+++ b/vllm_mlx/utils/chat_template.py
@@ -1149,6 +1149,61 @@ def _template_uses_reasoning_effort_without_enable_thinking(
     )
 
 
+def _is_gpt_oss_harmony_template(
+    template_applicator,
+    *,
+    model_name: str = "",
+    tools: list[dict] | None = None,
+) -> bool:
+    """Identify GPT-OSS templates whose wire format is OpenAI Harmony."""
+    if _looks_like_gpt_oss(model_name):
+        return True
+    return any(
+        _looks_like_gpt_oss_harmony_template(template)
+        for template in _chat_template_strings(
+            getattr(template_applicator, "chat_template", None), tools=tools
+        )
+    )
+
+
+def _collapse_harmony_system_messages(messages: list[dict]) -> list[dict]:
+    """Make every system instruction visible to leading-only Harmony templates.
+
+    GPT-OSS' published template consumes a system/developer role only at index
+    zero and silently skips later system roles.  Harmony has no mid-conversation
+    system frame, so preserve authority by joining all system instructions into
+    the single leading developer frame the template does support.
+    """
+    # Harmony consumes at most the first message as an instruction. This also
+    # catches two consecutive leading system messages: the second is otherwise
+    # just as invisible as one placed after a user turn.
+    if not any(
+        index > 0 and message.get("role") == "system"
+        for index, message in enumerate(messages)
+    ):
+        return messages
+
+    system_messages = [m for m in messages if m.get("role") == "system"]
+    if any(set(message) - {"role", "content"} for message in system_messages):
+        raise ValueError(
+            "GPT-OSS/Harmony cannot preserve metadata on a mid-conversation "
+            "system message"
+        )
+
+    contents = [
+        message.get("content") for message in system_messages if message.get("content")
+    ]
+    if not all(isinstance(content, str) for content in contents):
+        raise ValueError(
+            "GPT-OSS/Harmony system messages must contain text-only content"
+        )
+
+    collapsed = [message for message in messages if message.get("role") != "system"]
+    if contents:
+        collapsed.insert(0, {"role": "system", "content": "\n\n".join(contents)})
+    return collapsed
+
+
 def apply_chat_template(
     template_applicator,
     messages: list[dict],
@@ -1256,6 +1311,16 @@ def apply_chat_template(
             e,
         )
         tools = _baseline_sanitize_tools(tools)
+
+    # The published GPT-OSS template accepts a mid-conversation system role but
+    # has no loop branch for it, so rendering succeeds while deleting the
+    # instruction.  Error-driven compatibility fallback (#1543) cannot catch a
+    # successful lossy render.  Normalize only the Harmony family, whose wire
+    # protocol has a single leading developer instruction frame.
+    if _is_gpt_oss_harmony_template(
+        template_applicator, model_name=model_name, tools=tools
+    ):
+        messages = _collapse_harmony_system_messages(messages)
 
     # DeepSeek-V4-Flash-0731 intentionally ships a Python encoder instead of
     # a Jinja template.  Route by model identity before the generic tokenizer

--- a/vllm_mlx/utils/chat_template.py
+++ b/vllm_mlx/utils/chat_template.py
@@ -1177,30 +1177,33 @@ def _collapse_harmony_system_messages(messages: list[dict]) -> list[dict]:
     # Harmony consumes at most the first message as an instruction. This also
     # catches two consecutive leading system messages: the second is otherwise
     # just as invisible as one placed after a user turn.
+    instruction_roles = {"system", "developer"}
     if not any(
-        index > 0 and message.get("role") == "system"
+        index > 0 and message.get("role") in instruction_roles
         for index, message in enumerate(messages)
     ):
         return messages
 
-    system_messages = [m for m in messages if m.get("role") == "system"]
-    if any(set(message) - {"role", "content"} for message in system_messages):
+    instruction_messages = [
+        message for message in messages if message.get("role") in instruction_roles
+    ]
+    if any(set(message) - {"role", "content"} for message in instruction_messages):
         raise ValueError(
-            "GPT-OSS/Harmony cannot preserve metadata on a mid-conversation "
-            "system message"
+            "GPT-OSS/Harmony cannot preserve metadata on a conversation "
+            "instruction message"
         )
 
-    contents = [
-        message.get("content") for message in system_messages if message.get("content")
-    ]
+    contents = [message.get("content") for message in instruction_messages]
     if not all(isinstance(content, str) for content in contents):
         raise ValueError(
-            "GPT-OSS/Harmony system messages must contain text-only content"
+            "GPT-OSS/Harmony system and developer messages must contain "
+            "text-only content"
         )
 
-    collapsed = [message for message in messages if message.get("role") != "system"]
-    if contents:
-        collapsed.insert(0, {"role": "system", "content": "\n\n".join(contents)})
+    collapsed = [
+        message for message in messages if message.get("role") not in instruction_roles
+    ]
+    collapsed.insert(0, {"role": "system", "content": "\n\n".join(contents)})
     return collapsed
 
 

--- a/vllm_mlx/utils/chat_template.py
+++ b/vllm_mlx/utils/chat_template.py
@@ -1200,16 +1200,23 @@ def _collapse_harmony_system_messages(messages: list[dict]) -> list[dict]:
             "text-only content"
         )
 
+    instruction_role = instruction_messages[0]["role"]
+    if any(message["role"] != instruction_role for message in instruction_messages):
+        raise ValueError(
+            "GPT-OSS/Harmony cannot preserve mixed system and developer "
+            "instruction roles"
+        )
+
     collapsed = [
         message for message in messages if message.get("role") not in instruction_roles
     ]
-    # Preserve the authority role of the first instruction. In particular, a
-    # leading developer message must not be promoted to system merely because
-    # later Harmony-inexpressible instructions are folded into its frame.
+    # All instructions have the same authority role here, so folding them into
+    # the single leading frame supported by Harmony is lossless with respect to
+    # role authority.
     collapsed.insert(
         0,
         {
-            "role": instruction_messages[0]["role"],
+            "role": instruction_role,
             "content": "\n\n".join(contents),
         },
     )


### PR DESCRIPTION
## What does this PR do?

Normalizes GPT-OSS/Harmony conversations before template rendering so later instruction messages are not silently dropped. Same-role system or developer instructions are folded into the single leading frame Harmony supports while preserving that role. Mixed system/developer authority, lossy metadata, and non-text instruction content fail explicitly instead of being silently rewritten or discarded. Detection prefers actual Harmony template markers, with GPT-OSS model identity used only when template source is unavailable.

## Why is this needed?

Fixes #1765. The published GPT-OSS template reads only the first system/developer message, then loops over assistant/tool/user roles. A system message later in the conversation matches no branch, so rendering succeeds while deleting the instruction. The existing #1543 fallback only activates when a template raises and therefore cannot catch this successful-but-lossy render.

## AI assistance disclosure

Codex reproduced the issue, implemented and reviewed both touched files, ran adversarial local Codex review, and iterated on its authority-boundary findings. The final change was verified by targeted tests, Ruff, PR validation, the Python matrix, Apple Silicon CI, and model smoke tests.

## Test plan

- Published tokenizer A/B: baseline omitted the mid-system instruction; fixed rendering preserves it in the leading same-role instruction frame.
- pytest -q tests/test_chat_template_mid_system.py (19 passed)
- Adjacent template suites (26 passed, 3 skipped)
- Ruff check and format checks pass.
- Local pr_validate: MERGE-SAFE; Codex found no blocking issues.
- Remote PR validation, Python 3.10/3.11/3.12, Apple Silicon, and five model smoke jobs pass.

## Compatibility

No API shape changes. Non-Harmony templates are untouched. Harmony conversations whose instruction roles cannot be represented faithfully now return an explicit error instead of silently changing authority or losing content.