### PR TITLE
fix(metrics): expose MLLM prefix cache counters

### DIFF
--- a/tests/test_metrics_route.py
+++ b/tests/test_metrics_route.py
@@ -288,6 +288,42 @@ def test_metrics_omits_cache_series_when_no_cache_active(metrics_client):
     assert "rapid_mlx_requests_processed_total 0" in body
 
 
+def test_metrics_exposes_mllm_prefix_cache_zero_counters(metrics_client):
+    """An enabled MLLM prefix cache must not disappear at zero traffic.
+
+    ``BatchedEngine.get_stats()`` keeps the MLLM scheduler snapshot nested,
+    including the enabled ``MLLMPrefixCacheManager`` under ``vision_cache``.
+    Prometheus must distinguish that active cache with zero lookups from a
+    deployment where prefix caching is disabled and the series is absent.
+    """
+    stats = {
+        "num_waiting": 0,
+        "num_running": 0,
+        "num_requests_processed": 0,
+        "total_prompt_tokens": 0,
+        "total_completion_tokens": 0,
+        "steps_executed": 0,
+        "uptime_seconds": 0,
+        "is_mllm": True,
+        "mllm_scheduler": {
+            "vision_cache": {
+                "hits": 0,
+                "misses": 0,
+                "evictions": 0,
+                "tokens_saved": 0,
+            }
+        },
+    }
+    metrics_client.cfg.engine = _fake_engine(stats)
+
+    body = metrics_client.client.get("/metrics").text
+
+    assert "rapid_mlx_prefix_cache_hits_total 0" in body
+    assert "rapid_mlx_prefix_cache_misses_total 0" in body
+    assert "rapid_mlx_prefix_cache_evictions_total 0" in body
+    assert "rapid_mlx_prefix_cache_tokens_saved_total 0" in body
+
+
 def test_metrics_exposes_r7_m1_prefix_cache_cap_and_current_bytes(metrics_client):
     """R7-M1 (dogfood-088 Talia r2): ``rapid_mlx_prefix_cache_cap_bytes``
     and ``rapid_mlx_prefix_cache_current_bytes`` gauges must appear in

--- a/vllm_mlx/routes/metrics.py
+++ b/vllm_mlx/routes/metrics.py
@@ -1269,6 +1269,19 @@ def _render_prometheus(cfg: Any) -> str:
             cache_stats = candidate
             break
 
+    # The MLLM lane keeps its enabled ``MLLMPrefixCacheManager`` snapshot
+    # below ``mllm_scheduler.vision_cache`` instead of promoting it to one
+    # of the canonical text-lane keys above.  Treat that specific nested
+    # snapshot as the same prefix-cache counter source.  Do not synthesize
+    # an empty dict when the key is absent: absence still means the cache is
+    # disabled, and its Prometheus series should remain absent accordingly.
+    if cache_stats is None:
+        mllm_stats = stats.get("mllm_scheduler")
+        if isinstance(mllm_stats, dict):
+            mllm_cache_stats = mllm_stats.get("vision_cache")
+            if isinstance(mllm_cache_stats, dict):
+                cache_stats = mllm_cache_stats
+
     if cache_stats is not None:
         # The raw cache counters are reset by ``cache.clear()``; pipe each
         # one through the sticky accumulator so the exposed value never


### PR DESCRIPTION
## What changed

- teach `/metrics` to use the enabled MLLM prefix-cache snapshot nested at `mllm_scheduler.vision_cache`
- keep cache metrics absent when the MLLM cache is disabled or unavailable
- add a regression covering the zero-traffic MLLM series

## Root cause

The MLLM scheduler exposes `MLLMPrefixCacheManager` counters under a nested `vision_cache` key, while the Prometheus renderer only searched the three top-level text-lane cache keys. The pressure-eviction metric is unconditional, so MLLM scrapes showed that series but omitted prefix-cache hits and misses entirely.

## Impact

An enabled MLLM prefix cache now reports explicit zero-valued hit/miss/eviction/token-saved counters before its first lookup. Prometheus dashboards can distinguish an idle cache from a disabled cache.

## Validation

- reproduced on `main`: zero-traffic MLLM cache regression failed because the series were absent
- `python3.12 -m ruff check vllm_mlx/routes/metrics.py tests/test_metrics_route.py`
- `python3.12 -m pytest tests/test_metrics_route.py tests/test_mllm_cache.py -q` (54 passed)
