### PR TITLE
fix(cli): account for cached mflux component files

### DIFF
--- a/tests/test_disk_space_check.py
+++ b/tests/test_disk_space_check.py
@@ -9,7 +9,7 @@ and respect HF_HOME via huggingface_hub.constants.HF_HUB_CACHE.
 from __future__ import annotations
 
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -18,8 +18,11 @@ from vllm_mlx.cli import _check_disk_space
 
 def _make_info(file_sizes_bytes: list[int]) -> SimpleNamespace:
     """Build a fake huggingface_hub.ModelInfo with sibling file sizes."""
-    siblings = [SimpleNamespace(size=sz) for sz in file_sizes_bytes]
-    return SimpleNamespace(siblings=siblings, safetensors=None)
+    siblings = [
+        SimpleNamespace(rfilename=f"file-{index}.safetensors", size=size)
+        for index, size in enumerate(file_sizes_bytes)
+    ]
+    return SimpleNamespace(siblings=siblings, safetensors=None, sha="current-sha")
 
 
 def _fake_statvfs(free_bytes: int):
@@ -91,17 +94,105 @@ class TestDiskSpaceCheck:
         # Should not raise even without mocking model_info — must short-circuit.
         _check_disk_space(str(local))
 
-    def test_skips_already_cached(self):
-        """If config.json is in the cache, skip the size check entirely."""
+    def test_skips_already_cached(self, tmp_path):
+        """A cached root config keeps the selective-loader fast path."""
+        cached_file = tmp_path / "cached"
+        cached_file.write_bytes(b"present")
+        model_info = MagicMock()
+        statvfs = MagicMock()
         with (
             patch(
                 "huggingface_hub.try_to_load_from_cache",
-                return_value="/fake/path/config.json",
+                return_value=str(cached_file),
             ),
-            patch("os.path.exists", return_value=True),
+            patch("huggingface_hub.model_info", model_info),
+            patch("os.statvfs", statvfs),
         ):
-            # Should not raise even without mocking model_info.
             _check_disk_space("mlx-community/Some-Model")
+        model_info.assert_not_called()
+        statvfs.assert_not_called()
+
+    def test_complete_mflux_cache_without_root_config_skips_gate(self, tmp_path):
+        """A component-layout mflux repo has no root config.json.
+
+        Completeness is determined from every file at the current revision,
+        so a fully cached 5.5 GB Z-Image snapshot must not be rejected merely
+        because only 3.5 GB remains free.
+        """
+        names_and_sizes = [
+            ("transformer/0.safetensors", int(3.2 * 1024**3)),
+            ("text_encoder/0.safetensors", int(2.1 * 1024**3)),
+            ("vae/0.safetensors", int(0.2 * 1024**3)),
+            ("tokenizer/tokenizer.json", 10_000),
+        ]
+        info = SimpleNamespace(
+            siblings=[
+                SimpleNamespace(rfilename=name, size=size)
+                for name, size in names_and_sizes
+            ],
+            sha="z-image-sha",
+        )
+        cached_paths = {}
+        for index, (name, _size) in enumerate(names_and_sizes):
+            path = tmp_path / str(index)
+            path.write_bytes(b"present")
+            cached_paths[name] = str(path)
+
+        def cache_lookup(repo_id, filename, revision=None):
+            assert repo_id == "filipstrand/Z-Image-Turbo-mflux-4bit"
+            if revision is None:
+                assert filename == "config.json"
+                return None
+            assert revision == "z-image-sha"
+            return cached_paths[filename]
+
+        statvfs = MagicMock()
+        with (
+            patch("huggingface_hub.model_info", return_value=info),
+            patch(
+                "huggingface_hub.try_to_load_from_cache",
+                side_effect=cache_lookup,
+            ),
+            patch("os.statvfs", statvfs),
+        ):
+            _check_disk_space("filipstrand/Z-Image-Turbo-mflux-4bit")
+        statvfs.assert_not_called()
+
+    def test_partial_mflux_cache_counts_only_missing_files(self, tmp_path):
+        """A partial component cache still gates on the missing weights."""
+        cached_transformer = tmp_path / "transformer.safetensors"
+        cached_transformer.write_bytes(b"present")
+        info = SimpleNamespace(
+            siblings=[
+                SimpleNamespace(
+                    rfilename="transformer/0.safetensors", size=int(3 * 1024**3)
+                ),
+                SimpleNamespace(
+                    rfilename="text_encoder/0.safetensors",
+                    size=int(2.5 * 1024**3),
+                ),
+            ],
+            sha="z-image-sha",
+        )
+
+        def cache_lookup(_repo_id, filename, revision=None):
+            if revision is None:
+                return None
+            assert revision == "z-image-sha"
+            if filename == "transformer/0.safetensors":
+                return str(cached_transformer)
+            return None
+
+        with (
+            patch("huggingface_hub.model_info", return_value=info),
+            patch(
+                "huggingface_hub.try_to_load_from_cache",
+                side_effect=cache_lookup,
+            ),
+            patch("os.statvfs", return_value=_fake_statvfs(int(2 * 1024**3))),
+            pytest.raises(SystemExit),
+        ):
+            _check_disk_space("filipstrand/Z-Image-Turbo-mflux-4bit")
 
     def test_uses_hf_hub_cache_for_statvfs(self):
         """The probe must use HF_HUB_CACHE (respects HF_HOME), not the

--- a/tests/test_disk_space_check.py
+++ b/tests/test_disk_space_check.py
@@ -159,7 +159,7 @@ class TestDiskSpaceCheck:
         statvfs.assert_not_called()
 
     def test_partial_mflux_cache_counts_only_missing_files(self, tmp_path):
-        """A partial component cache still gates on the missing weights."""
+        """A partial component cache requires space only for missing weights."""
         cached_transformer = tmp_path / "transformer.safetensors"
         cached_transformer.write_bytes(b"present")
         info = SimpleNamespace(
@@ -189,8 +189,10 @@ class TestDiskSpaceCheck:
                 "huggingface_hub.try_to_load_from_cache",
                 side_effect=cache_lookup,
             ),
-            patch("os.statvfs", return_value=_fake_statvfs(int(2 * 1024**3))),
-            pytest.raises(SystemExit),
+            # 3 GB fits the missing 2.5 GB shard plus headroom, but not the
+            # full 5.5 GB repository. Counting the cached transformer would
+            # therefore make this call raise SystemExit.
+            patch("os.statvfs", return_value=_fake_statvfs(int(3 * 1024**3))),
         ):
             _check_disk_space("filipstrand/Z-Image-Turbo-mflux-4bit")
 

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -917,7 +917,8 @@ def _check_disk_space(model_name: str, force: bool = False) -> None:
     Behaviour:
 
     - Model is already a local path → return.
-    - ``config.json`` is in the cache → assume already downloaded → return.
+    - Files already cached for the current Hub revision are excluded from the
+      required download size.
     - HF API call fails (offline, gated repo, etc.) → return silently. The
       loader's 404/auth handlers will surface the real error if there is one.
     - Determined size and disk is insufficient → print actionable error
@@ -941,31 +942,58 @@ def _check_disk_space(model_name: str, force: bool = False) -> None:
 
     _prefix = checkpoint_prefix(model_name)
 
-    # Skip if model is already in the HF cache.
+    # Keep the historical fast path for ordinary text-model repositories.
+    # Their loaders may intentionally fetch only one of several weight formats,
+    # so treating every uncached sibling as an impending download would count
+    # optional artifacts that the selected loader never requests.
     try:
         from huggingface_hub import try_to_load_from_cache
 
-        cached = try_to_load_from_cache(model_name, f"{_prefix}config.json")
-        if isinstance(cached, str) and os.path.exists(cached):
+        cached_config = try_to_load_from_cache(
+            model_name,
+            f"{_prefix}config.json",
+        )
+        if isinstance(cached_config, str) and os.path.exists(cached_config):
             return
     except Exception:
         pass
 
-    # Query HF for repo size + free space on the actual HF cache filesystem.
+    # Query HF for the current revision and repo size + free space on the
+    # actual HF cache filesystem. Component-layout repositories such as mflux
+    # have no root config.json, so exclude each file already cached at the
+    # current revision instead of assuming the entire snapshot is missing.
     # Only this alias's checkpoint counts — a subfolder-per-quant repo would
     # otherwise demand disk for seven quantizations nobody asked for.
     try:
-        from huggingface_hub import model_info
+        from huggingface_hub import model_info, try_to_load_from_cache
         from huggingface_hub.constants import HF_HUB_CACHE
 
         info = model_info(model_name, files_metadata=True)
-        model_size_bytes = sum(
-            (s.size or 0)
-            for s in (getattr(info, "siblings", None) or [])
-            if hasattr(s, "size") and (not _prefix or s.rfilename.startswith(_prefix))
-        )
+        revision = getattr(info, "sha", None)
+        siblings = [
+            sibling
+            for sibling in (getattr(info, "siblings", None) or [])
+            if hasattr(sibling, "size")
+            and hasattr(sibling, "rfilename")
+            and (not _prefix or sibling.rfilename.startswith(_prefix))
+        ]
+        model_size_bytes = 0
+        for sibling in siblings:
+            try:
+                cached = try_to_load_from_cache(
+                    model_name,
+                    sibling.rfilename,
+                    revision=revision,
+                )
+                is_cached = isinstance(cached, str) and os.path.exists(cached)
+            except Exception:
+                # A cache lookup is only an optimization. If it is unreadable,
+                # retain the file in the conservative download estimate.
+                is_cached = False
+            if not is_cached:
+                model_size_bytes += sibling.size or 0
         if model_size_bytes == 0:
-            return  # Can't determine size — skip rather than guess.
+            return  # Nothing left to download (or size unavailable).
 
         # statvfs needs an existing path; HF_HUB_CACHE may not exist yet on
         # a fresh install. Walk up to the first ancestor that does.
@@ -994,7 +1022,7 @@ def _check_disk_space(model_name: str, force: bool = False) -> None:
 
         print()
         print("  Error: Insufficient disk space for download.")
-        print(f"    Model size:    {model_size_gb:>7.1f} GB")
+        print(f"    Download size: {model_size_gb:>7.1f} GB")
         print(f"    Free space:    {available_gb:>7.1f} GB  ({probe})")
         print(f"    Need to free:  {need_to_free_gb:>7.1f} GB")
         print()


### PR DESCRIPTION
## What does this PR do?

Updates the serve disk-space gate to subtract files already cached for the current Hugging Face revision when a repository has no root config marker. The error now reports the actual remaining download size.

The existing root-config fast path remains intact for selective text-model loaders, so optional alternate weight formats are not newly counted.

## Why is this needed?

A fully downloaded `filipstrand/Z-Image-Turbo-mflux-4bit` snapshot has no root `config.json`. The old cache probe therefore missed it and aborted startup when free space was below the full 5.5 GB repository size, even though there was nothing left to download.

Without this fix, users with a complete Z-Image cache can be unable to serve the model until they bypass the disk gate or free unnecessary space.

## AI assistance disclosure

Codex wrote and reviewed `vllm_mlx/cli.py` and `tests/test_disk_space_check.py`. The changes were verified with targeted and broad unit tests, Ruff, adversarial review, current Hugging Face repository metadata, and contract mutation tests.

> By submitting this PR I confirm I can explain the intent, risk, and behavior of every non-generated change in this PR. For any generated / boilerplate / scaffolded sections, I have identified them above and can describe how I verified them.

## Test plan

- `python3 -m pytest tests/test_disk_space_check.py tests/test_alias_subfolder.py -q --no-header` — 64 passed
- `pr_validate` targeted tests — 491 passed
- `pr_validate` full unit — 16,765 passed, 123 skipped, 18 deselected, 6 xfailed, 1 xpassed
- Patch coverage — 100% (16/16 changed production lines)
- `ruff check vllm_mlx/cli.py tests/test_disk_space_check.py`
- `ruff format --check vllm_mlx/cli.py tests/test_disk_space_check.py`
- Codex standalone review converged after retaining the selective-loader root-config fast path
- Mutation evidence: counting cached mflux files makes the complete-cache test call `statvfs`; counting the cached 3 GB transformer makes the partial-cache test fail because 3 GB only fits the missing 2.5 GB shard plus headroom

## Checklist

- [x] Tests pass locally (`python3 -m pytest tests/ -x` equivalent SOP suite)
- [x] Lint passes (`ruff check && ruff format --check`)
- [x] Self-validated with `python3 -m scripts.pr_validate.pr_validate 1773` (first run identified and led to strengthening a regression assertion; final rerun follows on current head)
- [x] Critical-path mutation check not required; behavior contract mutations were still verified
- [x] README/docs not applicable
- [x] No breaking changes to existing API