### PR TITLE
fix: account for cached bytes in disk preflight

### DIFF
--- a/tests/test_disk_space_check.py
+++ b/tests/test_disk_space_check.py
@@ -9,7 +9,7 @@ and respect HF_HOME via huggingface_hub.constants.HF_HUB_CACHE.
 from __future__ import annotations
 
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -18,7 +18,10 @@ from vllm_mlx.cli import _check_disk_space
 
 def _make_info(file_sizes_bytes: list[int]) -> SimpleNamespace:
     """Build a fake huggingface_hub.ModelInfo with sibling file sizes."""
-    siblings = [SimpleNamespace(size=sz) for sz in file_sizes_bytes]
+    siblings = [
+        SimpleNamespace(size=sz, rfilename=f"file-{index}.safetensors")
+        for index, sz in enumerate(file_sizes_bytes)
+    ]
     return SimpleNamespace(siblings=siblings, safetensors=None)
 
 
@@ -92,16 +95,123 @@ class TestDiskSpaceCheck:
         _check_disk_space(str(local))
 
     def test_skips_already_cached(self):
-        """If config.json is in the cache, skip the size check entirely."""
+        """If every remote file is cached, skip the size check entirely."""
+        info = _make_info([int(5 * 1024**3)])
+        disk_probe = Mock(return_value=_fake_statvfs(100 * 1024**3))
         with (
             patch(
                 "huggingface_hub.try_to_load_from_cache",
-                return_value="/fake/path/config.json",
+                return_value="/fake/path/file-0.safetensors",
             ),
-            patch("os.path.exists", return_value=True),
+            patch("huggingface_hub.model_info", return_value=info),
+            patch(
+                "os.path.exists",
+                side_effect=lambda path: str(path).startswith("/fake/path/"),
+            ),
+            patch("os.statvfs", disk_probe),
         ):
-            # Should not raise even without mocking model_info.
             _check_disk_space("mlx-community/Some-Model")
+        disk_probe.assert_not_called()
+
+    def test_fully_cached_nested_mflux_layout_needs_no_free_space(self):
+        """#1772: mflux has no root config, but all nested files are cached."""
+        repo = "filipstrand/Z-Image-Turbo-mflux-4bit"
+        siblings = [
+            SimpleNamespace(
+                size=int(4 * 1024**3),
+                rfilename="transformer/model-00001-of-00002.safetensors",
+            ),
+            SimpleNamespace(
+                size=int(1.5 * 1024**3),
+                rfilename="text_encoder/model.safetensors",
+            ),
+            SimpleNamespace(size=4096, rfilename="vae/config.json"),
+        ]
+        info = SimpleNamespace(siblings=siblings, safetensors=None)
+        disk_probe = Mock(return_value=_fake_statvfs(100 * 1024**3))
+
+        cached_files = {sibling.rfilename for sibling in siblings}
+
+        def cached(_repo, filename):
+            if filename in cached_files:
+                return f"/fake/snapshot/{filename}"
+            return None
+
+        with (
+            patch("huggingface_hub.try_to_load_from_cache", side_effect=cached),
+            patch("huggingface_hub.model_info", return_value=info),
+            patch(
+                "os.path.exists",
+                side_effect=lambda path: str(path).startswith("/fake/snapshot/"),
+            ),
+            patch("os.statvfs", disk_probe),
+        ):
+            _check_disk_space(repo)
+        disk_probe.assert_not_called()
+
+    def test_partial_nested_cache_checks_only_missing_bytes(self, capsys):
+        """A partial mflux cache must retain the gate for uncached payload."""
+        repo = "filipstrand/Z-Image-Turbo-mflux-4bit"
+        gib = 1024**3
+        info = SimpleNamespace(
+            siblings=[
+                SimpleNamespace(
+                    size=int(4 * gib),
+                    rfilename="transformer/model.safetensors",
+                ),
+                SimpleNamespace(
+                    size=int(1.5 * gib),
+                    rfilename="text_encoder/model.safetensors",
+                ),
+            ],
+            safetensors=None,
+        )
+
+        def cached(_repo, filename):
+            if filename.startswith("transformer/"):
+                return f"/fake/snapshot/{filename}"
+            return None
+
+        with (
+            patch("huggingface_hub.try_to_load_from_cache", side_effect=cached),
+            patch("huggingface_hub.model_info", return_value=info),
+            patch(
+                "os.path.exists",
+                side_effect=lambda path: str(path).startswith("/fake/snapshot/"),
+            ),
+            patch("os.statvfs", return_value=_fake_statvfs(int(1.0 * gib))),
+        ):
+            with pytest.raises(SystemExit) as exc:
+                _check_disk_space(repo)
+            assert exc.value.code == 1
+        assert "Download size:     1.5 GB" in capsys.readouterr().out
+
+    def test_config_only_text_cache_does_not_bypass_missing_weights(self):
+        """A cached config is metadata, not proof that model weights exist."""
+        gib = 1024**3
+        info = SimpleNamespace(
+            siblings=[
+                SimpleNamespace(size=4096, rfilename="config.json"),
+                SimpleNamespace(size=int(5 * gib), rfilename="model.safetensors"),
+            ],
+            safetensors=None,
+        )
+
+        def cached(_repo, filename):
+            return "/fake/snapshot/config.json" if filename == "config.json" else None
+
+        with (
+            patch("huggingface_hub.try_to_load_from_cache", side_effect=cached),
+            patch("huggingface_hub.model_info", return_value=info),
+            patch(
+                "os.path.exists",
+                side_effect=lambda path: str(path) == "/fake/snapshot/config.json",
+            ),
+            patch("os.statvfs", return_value=_fake_statvfs(int(1.0 * gib))),
+        ):
+            with pytest.raises(SystemExit) as exc:
+                _check_disk_space("mlx-community/Partial-Model")
+            assert exc.value.code == 1
 
     def test_uses_hf_hub_cache_for_statvfs(self):
         """The probe must use HF_HUB_CACHE (respects HF_HOME), not the

--- a/tests/test_disk_space_check.py
+++ b/tests/test_disk_space_check.py
@@ -22,7 +22,7 @@ def _make_info(file_sizes_bytes: list[int]) -> SimpleNamespace:
         SimpleNamespace(size=sz, rfilename=f"file-{index}.safetensors")
         for index, sz in enumerate(file_sizes_bytes)
     ]
-    return SimpleNamespace(siblings=siblings, safetensors=None)
+    return SimpleNamespace(siblings=siblings, safetensors=None, sha="current-sha")
 
 
 def _fake_statvfs(free_bytes: int):
@@ -127,12 +127,17 @@ class TestDiskSpaceCheck:
             ),
             SimpleNamespace(size=4096, rfilename="vae/config.json"),
         ]
-        info = SimpleNamespace(siblings=siblings, safetensors=None)
+        info = SimpleNamespace(
+            siblings=siblings,
+            safetensors=None,
+            sha="current-mflux-sha",
+        )
         disk_probe = Mock(return_value=_fake_statvfs(100 * 1024**3))
 
         cached_files = {sibling.rfilename for sibling in siblings}
 
-        def cached(_repo, filename):
+        def cached(_repo, filename, *, revision=None):
+            assert revision == "current-mflux-sha"
             if filename in cached_files:
                 return f"/fake/snapshot/{filename}"
             return None
@@ -165,9 +170,11 @@ class TestDiskSpaceCheck:
                 ),
             ],
             safetensors=None,
+            sha="current-mflux-sha",
         )
 
-        def cached(_repo, filename):
+        def cached(_repo, filename, *, revision=None):
+            assert revision == "current-mflux-sha"
             if filename.startswith("transformer/"):
                 return f"/fake/snapshot/{filename}"
             return None
@@ -195,9 +202,11 @@ class TestDiskSpaceCheck:
                 SimpleNamespace(size=int(5 * gib), rfilename="model.safetensors"),
             ],
             safetensors=None,
+            sha="current-text-sha",
         )
 
-        def cached(_repo, filename):
+        def cached(_repo, filename, *, revision=None):
+            assert revision == "current-text-sha"
             return "/fake/snapshot/config.json" if filename == "config.json" else None
 
         with (
@@ -212,6 +221,35 @@ class TestDiskSpaceCheck:
             with pytest.raises(SystemExit) as exc:
                 _check_disk_space("mlx-community/Partial-Model")
             assert exc.value.code == 1
+
+    def test_stale_default_ref_does_not_credit_old_revision_bytes(self):
+        """Cache hits must belong to the exact remote SHA being measured."""
+        gib = 1024**3
+        info = SimpleNamespace(
+            siblings=[
+                SimpleNamespace(size=int(5 * gib), rfilename="model.safetensors")
+            ],
+            safetensors=None,
+            sha="new-remote-sha",
+        )
+        seen_revisions = []
+
+        def cached(_repo, _filename, *, revision=None):
+            seen_revisions.append(revision)
+            # The unpinned default ref still resolves an old same-named file;
+            # the current remote revision has not been downloaded.
+            return "/fake/old/model.safetensors" if revision is None else None
+
+        with (
+            patch("huggingface_hub.try_to_load_from_cache", side_effect=cached),
+            patch("huggingface_hub.model_info", return_value=info),
+            patch("os.path.exists", return_value=False),
+            patch("os.statvfs", return_value=_fake_statvfs(int(1.0 * gib))),
+        ):
+            with pytest.raises(SystemExit) as exc:
+                _check_disk_space("mlx-community/Updated-Model")
+            assert exc.value.code == 1
+        assert seen_revisions == ["new-remote-sha"]
 
     def test_uses_hf_hub_cache_for_statvfs(self):
         """The probe must use HF_HUB_CACHE (respects HF_HOME), not the

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -917,7 +917,7 @@ def _check_disk_space(model_name: str, force: bool = False) -> None:
     Behaviour:
 
     - Model is already a local path → return.
-    - ``config.json`` is in the cache → assume already downloaded → return.
+    - Every remote file is in the cache → no download remains → return.
     - HF API call fails (offline, gated repo, etc.) → return silently. The
       loader's 404/auth handlers will surface the real error if there is one.
     - Determined size and disk is insufficient → print actionable error
@@ -941,30 +941,41 @@ def _check_disk_space(model_name: str, force: bool = False) -> None:
 
     _prefix = checkpoint_prefix(model_name)
 
-    # Skip if model is already in the HF cache.
-    try:
-        from huggingface_hub import try_to_load_from_cache
-
-        cached = try_to_load_from_cache(model_name, f"{_prefix}config.json")
-        if isinstance(cached, str) and os.path.exists(cached):
-            return
-    except Exception:
-        pass
-
     # Query HF for repo size + free space on the actual HF cache filesystem.
-    # Only this alias's checkpoint counts — a subfolder-per-quant repo would
-    # otherwise demand disk for seven quantizations nobody asked for.
+    # Only bytes that are NOT already cached count. This is layout-agnostic:
+    # text checkpoints keep weights at the root, while mflux image checkpoints
+    # keep them under transformer/ / text_encoder/ / vae/ and often have no
+    # root config.json at all (#1772). A root-config shortcut therefore both
+    # missed complete mflux caches and falsely blessed config-only text stubs.
+    # Asking HF's cache for every declared file gives the disk gate the exact
+    # remaining transfer without weakening partial-cache protection.
+    #
+    # For a subfolder-per-quant repo, only the selected alias prefix counts —
+    # otherwise one quantization would demand room for every sibling variant.
     try:
-        from huggingface_hub import model_info
+        from huggingface_hub import model_info, try_to_load_from_cache
         from huggingface_hub.constants import HF_HUB_CACHE
 
+        from vllm_mlx._download_gate import _sibling_size
+
         info = model_info(model_name, files_metadata=True)
-        model_size_bytes = sum(
-            (s.size or 0)
-            for s in (getattr(info, "siblings", None) or [])
-            if hasattr(s, "size") and (not _prefix or s.rfilename.startswith(_prefix))
-        )
-        if model_size_bytes == 0:
+        download_size_bytes = 0
+        for sibling in getattr(info, "siblings", None) or []:
+            filename = getattr(sibling, "rfilename", "") or ""
+            if _prefix and not filename.startswith(_prefix):
+                continue
+            size = _sibling_size(sibling)
+            if size <= 0:
+                continue
+            try:
+                cached = try_to_load_from_cache(model_name, filename)
+            except Exception:
+                cached = None
+            if isinstance(cached, str) and os.path.exists(cached):
+                continue
+            download_size_bytes += size
+
+        if download_size_bytes == 0:
             return  # Can't determine size — skip rather than guess.
 
         # statvfs needs an existing path; HF_HUB_CACHE may not exist yet on
@@ -984,17 +995,17 @@ def _check_disk_space(model_name: str, force: bool = False) -> None:
         available_bytes = stat.f_bavail * stat.f_frsize
 
         # ~10% headroom for temp files during xet_get / move-into-place.
-        required_bytes = int(model_size_bytes * 1.1)
+        required_bytes = int(download_size_bytes * 1.1)
         if available_bytes >= required_bytes:
             return
 
-        model_size_gb = model_size_bytes / (1024**3)
+        download_size_gb = download_size_bytes / (1024**3)
         available_gb = available_bytes / (1024**3)
         need_to_free_gb = (required_bytes - available_bytes) / (1024**3)
 
         print()
         print("  Error: Insufficient disk space for download.")
-        print(f"    Model size:    {model_size_gb:>7.1f} GB")
+        print(f"    Download size: {download_size_gb:>7.1f} GB")
         print(f"    Free space:    {available_gb:>7.1f} GB  ({probe})")
         print(f"    Need to free:  {need_to_free_gb:>7.1f} GB")
         print()

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -959,6 +959,7 @@ def _check_disk_space(model_name: str, force: bool = False) -> None:
         from vllm_mlx._download_gate import _sibling_size
 
         info = model_info(model_name, files_metadata=True)
+        remote_revision = getattr(info, "sha", None)
         download_size_bytes = 0
         for sibling in getattr(info, "siblings", None) or []:
             filename = getattr(sibling, "rfilename", "") or ""
@@ -968,7 +969,11 @@ def _check_disk_space(model_name: str, force: bool = False) -> None:
             if size <= 0:
                 continue
             try:
-                cached = try_to_load_from_cache(model_name, filename)
+                cached = try_to_load_from_cache(
+                    model_name,
+                    filename,
+                    revision=remote_revision,
+                )
             except Exception:
                 cached = None
             if isinstance(cached, str) and os.path.exists(cached):


### PR DESCRIPTION
## Summary

- compute disk preflight requirements from remote bytes that are not already present at the exact remote revision in the Hugging Face cache
- support complete nested checkpoint layouts such as mflux without weakening partial-cache protection
- remove the unsafe root `config.json` shortcut that treated config-only text caches as complete

## Root cause

The disk preflight used a root-level `config.json` as its only cache hit signal. mflux checkpoints keep configs and weights under component directories, so a fully cached Z-Image snapshot missed that probe and was charged for the entire repository again. Conversely, a partial text cache containing only `config.json` skipped the gate entirely.

## User impact

`rapid-mlx serve z-image-turbo` can start from a complete cache even when free disk is below the full model size. Partial downloads and stale local refs remain protected, but the gate now checks only the bytes that still need to be transferred for the current remote revision.

Closes #1772

## Validation

- `python3.12 -m pytest -q tests/test_disk_space_check.py tests/test_download_gate.py tests/test_alias_subfolder.py tests/test_cli_chat.py tests/test_image_lane.py` — 307 passed
- `python3.12 -m ruff check vllm_mlx/cli.py tests/test_disk_space_check.py`
- `python3.12 -m ruff format --check vllm_mlx/cli.py tests/test_disk_space_check.py`
- real `filipstrand/Z-Image-Turbo-mflux-4bit` cache: 21/21 sized files cached, 0 missing bytes, disk gate passes
