### PR TITLE
fix(qwen3): preserve literal think tags in non-streaming content

### DIFF
--- a/tests/test_reasoning_parsers.py
+++ b/tests/test_reasoning_parsers.py
@@ -1806,6 +1806,16 @@ class TestQwen3:
         assert reasoning == "analysis"
         assert content == "answer"
 
+    def test_1778_implicit_close_before_literal_opener_keeps_reasoning(self):
+        """A real implicit close before answer prose stays authoritative."""
+        reasoning, content = self.parser.extract_reasoning(
+            "reasoning</think>answer <think>literal</think>",
+            enable_thinking=True,
+            prompt_thinking_active=True,
+        )
+        assert reasoning == "reasoning"
+        assert content == "answer <think>literal</think>"
+
     # ---- #575 fast-path coverage (Qwen3 override branch) ----------------
 
     def test_575_qwen3_fast_path_no_tags_enable_thinking_true(self):

--- a/tests/test_reasoning_parsers.py
+++ b/tests/test_reasoning_parsers.py
@@ -1744,6 +1744,68 @@ class TestQwen3:
         assert reasoning is None
         assert content == "content"
 
+    @pytest.mark.parametrize(
+        "text,expected_content",
+        [
+            ("BEGIN <think> AFTER END", "BEGIN <think> AFTER END"),
+            (
+                "BEGIN <think>inner</think> AFTER END",
+                "BEGIN inner AFTER END",
+            ),
+            ("BEGIN `<think>` AFTER END", "BEGIN `<think>` AFTER END"),
+        ],
+    )
+    def test_1778_mid_answer_think_literal_stays_content(self, text, expected_content):
+        """A generated opener after visible prose is literal Qwen output.
+
+        Non-streaming used to partition at the opener regardless of its
+        position, truncating Markdown explanations and moving either side
+        of a balanced pair into ``reasoning_content``.  Thinking is enabled
+        here to match the served aliases from the issue report.
+        """
+        from vllm_mlx.service.helpers import _finalize_content_and_reasoning
+
+        content, reasoning = _finalize_content_and_reasoning(
+            raw_text=text,
+            cleaned_text=text,
+            tool_calls=[],
+            reasoning_parser=self.parser,
+            enable_thinking=True,
+            prompt_thinking_active=True,
+        )
+        assert reasoning is None
+        assert content == expected_content
+
+    def test_1778_leading_opener_remains_structural(self):
+        """The literal guard must not disable ordinary Qwen reasoning."""
+        reasoning, content = self.parser.extract_reasoning(
+            "  <think>analysis</think>answer",
+            enable_thinking=True,
+            prompt_thinking_active=True,
+        )
+        assert reasoning == "analysis"
+        assert content == "answer"
+
+    def test_1778_lone_closer_remains_implicit_reasoning(self):
+        """Prompt-primed Qwen output still closes reasoning normally."""
+        reasoning, content = self.parser.extract_reasoning(
+            "implicit reasoning</think>answer",
+            enable_thinking=True,
+            prompt_thinking_active=True,
+        )
+        assert reasoning == "implicit reasoning"
+        assert content == "answer"
+
+    def test_1778_mid_output_opener_without_prompt_prime_stays_structural(self):
+        """Autonomous explicit reasoning still supports a short preamble."""
+        reasoning, content = self.parser.extract_reasoning(
+            "preamble <think>analysis</think>answer",
+            enable_thinking=True,
+            prompt_thinking_active=False,
+        )
+        assert reasoning == "analysis"
+        assert content == "answer"
+
     # ---- #575 fast-path coverage (Qwen3 override branch) ----------------
 
     def test_575_qwen3_fast_path_no_tags_enable_thinking_true(self):

--- a/vllm_mlx/reasoning/qwen3_parser.py
+++ b/vllm_mlx/reasoning/qwen3_parser.py
@@ -158,6 +158,7 @@ class Qwen3ReasoningParser(BaseThinkingReasoningParser):
         self,
         model_output: str,
         enable_thinking: bool | None = None,
+        prompt_thinking_active: bool = False,
     ) -> tuple[str | None, str | None]:
         """
         Extract reasoning from Qwen3 output.
@@ -175,10 +176,45 @@ class Qwen3ReasoningParser(BaseThinkingReasoningParser):
                 the entire thought trace leaked to ``content``). When
                 None / False the no-tag case is treated as plain
                 content as before.
+            prompt_thinking_active: Whether the rendered prompt already
+                opened the reasoning channel. This is the evidence that a
+                later generated opener is an echoed literal rather than
+                the structural opener for this turn.
 
         Returns:
             (reasoning, content) tuple.
         """
+        # #1778: Qwen chat templates prime the structural ``<think>`` in
+        # the prompt, so an opener generated after ordinary answer text is
+        # an echoed literal, not a new reasoning boundary.  The streaming
+        # parser already keeps that leading text on the content lane; the
+        # old full-output parser instead partitioned at any opener and
+        # silently moved either the prefix or suffix into reasoning.
+        #
+        # Preserve an unmatched mid-answer opener verbatim (important for
+        # Markdown such as ``` `<think>` ```).  For a balanced literal pair,
+        # remove only the tag wrappers so the downstream content sanitizer
+        # cannot mistake the pair for a structural block and erase its body.
+        # A leading opener (allowing whitespace) remains structural, and a
+        # lone closer retains the implicit-reasoning contract.
+        start_index = model_output.find(self.start_token)
+        if (
+            prompt_thinking_active
+            and start_index > 0
+            and model_output[:start_index].strip()
+        ):
+            end_index = model_output.find(
+                self.end_token, start_index + len(self.start_token)
+            )
+            if end_index == -1:
+                return None, model_output
+            content = (
+                model_output[:start_index]
+                + model_output[start_index + len(self.start_token) : end_index]
+                + model_output[end_index + len(self.end_token) :]
+            )
+            return None, content
+
         # If no end token at all:
         if self.end_token not in model_output:
             # If start token is present, model started thinking but never finished

--- a/vllm_mlx/reasoning/qwen3_parser.py
+++ b/vllm_mlx/reasoning/qwen3_parser.py
@@ -198,20 +198,26 @@ class Qwen3ReasoningParser(BaseThinkingReasoningParser):
         # A leading opener (allowing whitespace) remains structural, and a
         # lone closer retains the implicit-reasoning contract.
         start_index = model_output.find(self.start_token)
+        end_index = model_output.find(self.end_token)
+        if end_index != -1 and (start_index == -1 or end_index < start_index):
+            reasoning = model_output[:end_index].strip() or None
+            content = model_output[end_index + len(self.end_token) :].strip() or None
+            return self._promote_tool_calls(reasoning, content)
         if (
             prompt_thinking_active
             and start_index > 0
             and model_output[:start_index].strip()
+            and self.end_token not in model_output[:start_index]
         ):
-            end_index = model_output.find(
+            literal_end_index = model_output.find(
                 self.end_token, start_index + len(self.start_token)
             )
-            if end_index == -1:
+            if literal_end_index == -1:
                 return None, model_output
             content = (
                 model_output[:start_index]
-                + model_output[start_index + len(self.start_token) : end_index]
-                + model_output[end_index + len(self.end_token) :]
+                + model_output[start_index + len(self.start_token) : literal_end_index]
+                + model_output[literal_end_index + len(self.end_token) :]
             )
             return None, content
 


### PR DESCRIPTION
## Necessity

Fixes #1778. Qwen-family non-streaming responses silently truncated ordinary prose containing a literal `<think>` opener, including Markdown code spans, while the streaming surface kept the answer text.

## What changed

- Thread the existing `prompt_thinking_active` signal into `Qwen3ReasoningParser.extract_reasoning`.
- When the prompt already primed reasoning and the generated output first emits ordinary prose before `<think>`, classify that opener as an echoed literal rather than a new reasoning boundary.
- Preserve unmatched literal openers verbatim; for balanced literal pairs, remove only the wrappers so the body remains visible and matches streaming content behavior.
- Preserve leading structural openers, implicit `</think>` closing, and autonomous explicit reasoning when the prompt was not primed.

## Validation

- `270 passed`: reasoning parser, truncation-finalize, and chat tool-tag regression suites.
- Full local unit suite passed on this branch before the final signal-narrowing/test-only refinement.
- `ruff check` and `ruff format --check` pass for changed files.
- Mutation evidence: changing the new literal guard to `False` made all three issue reproductions fail: unmatched opener, balanced pair, and backtick-wrapped opener.

- GitHub CI: all checks passed, including Apple Silicon and five L1 smoke jobs.
- M3 release sweep: qwen3.5-4b passed 6/6 coherence; two larger-model runs returned infrastructure 503s before assertions, so the sweep was stopped after the repeated infrastructure failure.
## AI assistance

Codex authored and reviewed the changes in `vllm_mlx/reasoning/qwen3_parser.py` and `tests/test_reasoning_parsers.py`. The maintainer verified the behavior with targeted tests, a deliberate contract mutation, lint/format checks, the broader unit suite, and the repository PR validation workflow. I can explain every changed line on demand.


