### PR TITLE
fix(metrics): keep the prefix-cache family all-or-nothing on the MLLM lane

### DIFF
--- a/tests/test_metrics_route.py
+++ b/tests/test_metrics_route.py
@@ -288,13 +288,22 @@ def test_metrics_omits_cache_series_when_no_cache_active(metrics_client):
     assert "rapid_mlx_requests_processed_total 0" in body
 
 
-def test_metrics_exposes_mllm_prefix_cache_zero_counters(metrics_client):
-    """An enabled MLLM prefix cache must not disappear at zero traffic.
+def test_metrics_prefix_cache_family_is_all_or_nothing_on_mllm_lane(metrics_client):
+    """The ``rapid_mlx_prefix_cache_*`` family is exposed together or not at all.
 
-    ``BatchedEngine.get_stats()`` keeps the MLLM scheduler snapshot nested,
-    including the enabled ``MLLMPrefixCacheManager`` under ``vision_cache``.
-    Prometheus must distinguish that active cache with zero lookups from a
-    deployment where prefix caching is disabled and the series is absent.
+    Regression for #1777. The MLLM lane runs an ``MLLMScheduler`` with **no**
+    ``AsyncEngineCore`` (``BatchedEngine.start`` returns after ``_start_mllm``),
+    so it has no prompt prefix cache: ``get_stats()`` carries no top-level
+    ``prefix_cache``/``paged_cache``/``memory_aware_cache`` key. The real image
+    cache lives under ``mllm_scheduler.vision_embedding_cache`` and is *not* a
+    prefix cache.
+
+    Before the fix, ``metrics.py`` looked up a never-populated
+    ``mllm_scheduler.vision_cache`` manager (so hits/misses/evictions/
+    tokens_saved were absent) while ``pressure_evictions`` rendered
+    unconditionally at 0 — a lone survivor that made the dashboard read as
+    "prefix caching is off but somehow evicting". The whole family must be
+    absent together on this lane.
     """
     stats = {
         "num_waiting": 0,
@@ -305,12 +314,13 @@ def test_metrics_exposes_mllm_prefix_cache_zero_counters(metrics_client):
         "steps_executed": 0,
         "uptime_seconds": 0,
         "is_mllm": True,
+        # The only real MLLM-lane cache — an image embedding cache, published
+        # under its own key. It is deliberately NOT wired to the prefix-cache
+        # metric family (that would misname vision hits as prefix-cache hits).
         "mllm_scheduler": {
-            "vision_cache": {
-                "hits": 0,
-                "misses": 0,
-                "evictions": 0,
-                "tokens_saved": 0,
+            "vision_embedding_cache": {
+                "pixel_cache_hits": 3,
+                "pixel_cache_misses": 1,
             }
         },
     }
@@ -318,10 +328,57 @@ def test_metrics_exposes_mllm_prefix_cache_zero_counters(metrics_client):
 
     body = metrics_client.client.get("/metrics").text
 
-    assert "rapid_mlx_prefix_cache_hits_total 0" in body
-    assert "rapid_mlx_prefix_cache_misses_total 0" in body
-    assert "rapid_mlx_prefix_cache_evictions_total 0" in body
-    assert "rapid_mlx_prefix_cache_tokens_saved_total 0" in body
+    prefix_family = (
+        "rapid_mlx_prefix_cache_hits_total",
+        "rapid_mlx_prefix_cache_misses_total",
+        "rapid_mlx_prefix_cache_evictions_total",
+        "rapid_mlx_prefix_cache_tokens_saved_total",
+        # The former lone survivor — must vanish with the rest of the family.
+        "rapid_mlx_prefix_cache_pressure_evictions_total",
+    )
+    # Match on the ``# TYPE`` declaration, not a bare substring: several HELP
+    # strings cross-reference sibling metric names in prose (e.g. the pressure
+    # counter's help mentions ``rapid_mlx_prefix_cache_evictions_total``), and
+    # only a declared series carries a ``# TYPE`` line.
+    for name in prefix_family:
+        assert f"# TYPE {name} " not in body, (
+            f"{name} leaked without the rest of the family"
+        )
+    # Sanity: non-cache series are unaffected.
+    assert "rapid_mlx_requests_processed_total 0" in body
+
+
+def test_metrics_pressure_evictions_travels_with_the_prefix_cache_family(
+    metrics_client,
+):
+    """On a lane that HAS a prefix cache, ``pressure_evictions`` is exposed too.
+
+    The all-or-nothing invariant cuts both ways: when the family is present
+    (text lane with an active prefix cache), the pressure-eviction counter
+    renders alongside it — defaulting to 0 when the scheduler never recorded
+    a pressure-driven eviction.
+    """
+    stats = {
+        "num_waiting": 0,
+        "num_running": 0,
+        "num_requests_processed": 0,
+        "total_prompt_tokens": 0,
+        "total_completion_tokens": 0,
+        "steps_executed": 0,
+        "uptime_seconds": 0,
+        "prefix_cache": {
+            "hits": 5,
+            "misses": 2,
+            "evictions": 0,
+            "tokens_saved": 40,
+        },
+    }
+    metrics_client.cfg.engine = _fake_engine(stats)
+
+    body = metrics_client.client.get("/metrics").text
+
+    assert "rapid_mlx_prefix_cache_hits_total 5" in body
+    assert "rapid_mlx_prefix_cache_pressure_evictions_total 0" in body
 
 
 def test_metrics_exposes_r7_m1_prefix_cache_cap_and_current_bytes(metrics_client):

--- a/vllm_mlx/routes/metrics.py
+++ b/vllm_mlx/routes/metrics.py
@@ -1269,18 +1269,18 @@ def _render_prometheus(cfg: Any) -> str:
             cache_stats = candidate
             break
 
-    # The MLLM lane keeps its enabled ``MLLMPrefixCacheManager`` snapshot
-    # below ``mllm_scheduler.vision_cache`` instead of promoting it to one
-    # of the canonical text-lane keys above.  Treat that specific nested
-    # snapshot as the same prefix-cache counter source.  Do not synthesize
-    # an empty dict when the key is absent: absence still means the cache is
-    # disabled, and its Prometheus series should remain absent accordingly.
-    if cache_stats is None:
-        mllm_stats = stats.get("mllm_scheduler")
-        if isinstance(mllm_stats, dict):
-            mllm_cache_stats = mllm_stats.get("vision_cache")
-            if isinstance(mllm_cache_stats, dict):
-                cache_stats = mllm_cache_stats
+    # The MLLM lane runs an ``MLLMScheduler`` with no ``AsyncEngineCore``
+    # (``BatchedEngine.start`` returns after ``_start_mllm``), so it has no
+    # prompt prefix cache and exposes none of the canonical keys above. It
+    # deliberately does NOT feed this family: ``mllm_scheduler.vision_cache``
+    # is a vestigial, never-populated ``MLLMPrefixCacheManager`` (nothing
+    # inserts into it), and the live image cache under
+    # ``mllm_scheduler.vision_embedding_cache`` is an embedding cache, not a
+    # prefix cache — surfacing it here would misname vision hits as
+    # prefix-cache hits. So on that lane ``cache_stats`` stays ``None`` and
+    # the whole ``rapid_mlx_prefix_cache_*`` family is absent together (see
+    # the pressure-eviction counter below, which is gated on the same
+    # condition so it can never survive alone — #1777).
 
     if cache_stats is not None:
         # The raw cache counters are reset by ``cache.clear()``; pipe each
@@ -1662,20 +1662,29 @@ def _render_prometheus(cfg: Any) -> str:
             int(_coerce_number(stats.get("num_metal_cap_violations"))),
         )
     )
-    lines.extend(
-        _fmt_metric(
-            "rapid_mlx_prefix_cache_pressure_evictions_total",
-            "counter",
-            (
-                "Prefix-cache entries evicted by the Metal-pressure "
-                "trigger (D-METAL-PFX). Disjoint from "
-                "rapid_mlx_prefix_cache_evictions_total which counts "
-                "LRU-on-capacity evictions performed by the cache "
-                "itself."
-            ),
-            int(_coerce_number(stats.get("num_prefix_cache_pressure_evictions"))),
+    # #1777: this counter belongs to the ``rapid_mlx_prefix_cache_*`` family,
+    # so it is emitted on the same all-or-nothing condition as the hit/miss/
+    # eviction series above — never alone. Pressure eviction is only possible
+    # when a prefix cache exists to evict from, so ``cache_stats is None``
+    # (no cache on this lane, e.g. the MLLM scheduler) correctly suppresses
+    # the whole family together instead of leaving this one flat-lining at 0.
+    # ``num_metal_cap_violations`` above is a separate D-METAL-CAP admission
+    # counter, independent of prefix caching, and stays unconditional.
+    if cache_stats is not None:
+        lines.extend(
+            _fmt_metric(
+                "rapid_mlx_prefix_cache_pressure_evictions_total",
+                "counter",
+                (
+                    "Prefix-cache entries evicted by the Metal-pressure "
+                    "trigger (D-METAL-PFX). Disjoint from "
+                    "rapid_mlx_prefix_cache_evictions_total which counts "
+                    "LRU-on-capacity evictions performed by the cache "
+                    "itself."
+                ),
+                int(_coerce_number(stats.get("num_prefix_cache_pressure_evictions"))),
+            )
         )
-    )
 
     # ---- R15-P1 disk-backed KV checkpoints (task #296) -----------------
     # Counters are process-monotonic by construction (the module-level


### PR DESCRIPTION
## Why
Closes #1777. On the MLLM lane, `/metrics` exposed `rapid_mlx_prefix_cache_pressure_evictions_total` at a flat `0` while the rest of the `rapid_mlx_prefix_cache_*` family (hits/misses/evictions/tokens_saved) was absent. On a dashboard that reads as "prefix caching is off but somehow evicting" — the asymmetry is the original complaint.

Root cause is two compounding defects:
1. **The #1771 lookup can never fire.** It read `stats["mllm_scheduler"]["vision_cache"]`, but that object (`mllm_scheduler.py:242`, an `MLLMPrefixCacheManager`) is **never inserted into** anywhere in the tree — only `init` / `get_stats` / `clear` reference it. It is also guarded by a truthiness test (`if self.vision_cache:`) on an object whose `__len__` is always `0`, so the `vision_cache` key never even enters the snapshot. The real image cache (`vision_embedding_cache`) is a different key, and an embedding cache — not a prefix cache.
2. **The MLLM lane has no prompt prefix cache at all.** `BatchedEngine.start()` returns after `_start_mllm()` (which builds only an `MLLMScheduler`) and never constructs the `AsyncEngineCore` that owns the prefix cache. So the family *should* be absent on this lane — the only bug is the lone-survivor pressure counter.

## What
- Remove the never-firing `vision_cache` lookup in `_render_prometheus`. The family stays absent on lanes with no prefix cache (surfacing `vision_embedding_cache` here would misname vision hits as prefix-cache hits).
- Gate `rapid_mlx_prefix_cache_pressure_evictions_total` on the same `cache_stats is not None` condition as the rest of the family, so it is emitted together or not at all. `num_metal_cap_violations` stays unconditional — it is a separate D-METAL-CAP admission counter, not part of this family.

## Tests
- Replaced the #1771 unit test (which asserted on a `vision_cache` stats shape that never occurs at runtime — the reporter called this out) with two invariant tests in `tests/test_metrics_route.py`:
  - `test_metrics_prefix_cache_family_is_all_or_nothing_on_mllm_lane` — on an MLLM-shaped snapshot (has `vision_embedding_cache`, no top-level prefix cache), **none** of the family appears, including the pressure counter. Fails on `main`, passes with this change.
  - `test_metrics_pressure_evictions_travels_with_the_prefix_cache_family` — on a text snapshot with an active prefix cache, the pressure counter renders (at `0`) alongside the family.
- Full `tests/test_metrics_route.py` green (21 passed); `ruff` clean.

## Notes
Not addressed here (deliberately out of scope, one change per PR): exposing the live `VisionEmbeddingCache` under a correctly-named `rapid_mlx_vision_cache_*` family for image-cache observability. That is a feature add, not part of restoring the prefix-cache family's consistency.

🤖 Written by Claude (Opus 4.8, 1M context) at the direction of the repository owner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)