### PR TITLE
fix: expose MLLM status metrics

### DIFF
--- a/tests/test_mllm_stats.py
+++ b/tests/test_mllm_stats.py
@@ -82,6 +82,37 @@ def test_batched_engine_promotes_mllm_stats_to_common_top_level():
     assert stats["uptime_seconds"] >= 2.0
 
 
+def test_batched_engine_mllm_stats_cannot_overwrite_engine_identity():
+    """A scheduler snapshot must not replace BatchedEngine-owned fields."""
+
+    class FakeScheduler:
+        _step_count = 0
+
+        def get_stats(self) -> dict[str, object]:
+            return {
+                "engine_type": "scheduler-controlled",
+                "model_name": "wrong-model",
+                "loaded": False,
+                "total_prompt_tokens": 5,
+            }
+
+    engine = BatchedEngine.__new__(BatchedEngine)
+    engine._model_name = "real-model"
+    engine._is_mllm = True
+    engine._loaded = True
+    engine._stream_interval = 1
+    engine._mllm_scheduler = FakeScheduler()
+    engine._engine = None
+
+    stats = engine.get_stats()
+
+    assert stats["engine_type"] == "batched"
+    assert stats["model_name"] == "real-model"
+    assert stats["loaded"] is True
+    assert stats["total_prompt_tokens"] == 5
+    assert stats["uptime_seconds"] == 0.0
+
+
 def test_mllm_completed_request_adds_prompt_and_completion_tokens():
     """Completed MLLM requests must contribute both token counters."""
     scheduler = _bare_scheduler()

--- a/tests/test_mllm_stats.py
+++ b/tests/test_mllm_stats.py
@@ -1,0 +1,130 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for MLLM status and metrics statistics."""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections import deque
+from types import SimpleNamespace
+
+from vllm_mlx.engine.batched import BatchedEngine
+from vllm_mlx.mllm_scheduler import MLLMRequest, MLLMScheduler
+from vllm_mlx.request import RequestStatus
+
+
+class _FakeDetokenizer:
+    """Small streaming-detokenizer stub for scheduler accounting tests."""
+
+    last_segment = "x"
+    text = "x"
+
+    def reset(self) -> None:
+        pass
+
+    def add_token(self, _token: int) -> None:
+        pass
+
+    def finalize(self) -> None:
+        pass
+
+
+class _FakeTokenizer:
+    def __init__(self) -> None:
+        self.detokenizer = _FakeDetokenizer()
+
+
+def _bare_scheduler() -> MLLMScheduler:
+    """Build an MLLM scheduler without loading MLX model components."""
+    scheduler = MLLMScheduler.__new__(MLLMScheduler)
+    scheduler.processor = SimpleNamespace(tokenizer=_FakeTokenizer())
+    scheduler.uid_to_request_id = {}
+    scheduler.running = {}
+    scheduler._detokenizer_pool = {}
+    scheduler.total_prompt_tokens = 0
+    scheduler.total_completion_tokens = 0
+    scheduler.num_requests_processed = 0
+    return scheduler
+
+
+def test_batched_engine_promotes_mllm_stats_to_common_top_level():
+    """Status and metrics consumers must see MLLM counters at top level."""
+
+    class FakeScheduler:
+        def get_stats(self) -> dict[str, object]:
+            return {
+                "num_running": 1,
+                "num_waiting": 2,
+                "num_requests_processed": 3,
+                "total_prompt_tokens": 40,
+                "total_completion_tokens": 7,
+            }
+
+    engine = BatchedEngine.__new__(BatchedEngine)
+    engine._model_name = "gemma-test"
+    engine._is_mllm = True
+    engine._loaded = True
+    engine._stream_interval = 1
+    engine._mllm_scheduler = FakeScheduler()
+    engine._engine = None
+    engine._start_time = time.monotonic() - 2.0
+    engine._mllm_scheduler._step_count = 12
+
+    stats = engine.get_stats()
+
+    assert stats["mllm_scheduler"]["num_running"] == 1
+    assert stats["num_running"] == 1
+    assert stats["num_waiting"] == 2
+    assert stats["num_requests_processed"] == 3
+    assert stats["total_prompt_tokens"] == 40
+    assert stats["total_completion_tokens"] == 7
+    assert stats["steps_executed"] == 12
+    assert stats["uptime_seconds"] >= 2.0
+
+
+def test_mllm_completed_request_adds_prompt_and_completion_tokens():
+    """Completed MLLM requests must contribute both token counters."""
+    scheduler = _bare_scheduler()
+    request = MLLMRequest(request_id="req-1", prompt="hello")
+    scheduler.uid_to_request_id[7] = request.request_id
+    scheduler.running[request.request_id] = request
+
+    response = SimpleNamespace(
+        uid=7,
+        token=11,
+        prompt_tokens=19,
+        finish_reason="stop",
+        token_is_stop_token=False,
+        logprobs=None,
+    )
+
+    outputs, finished_ids = scheduler._process_batch_responses([response])
+
+    assert finished_ids == {request.request_id}
+    assert outputs[0].finished is True
+    assert scheduler.total_prompt_tokens == 19
+    assert scheduler.total_completion_tokens == 1
+    assert scheduler.num_requests_processed == 1
+
+
+def test_mllm_aborted_request_adds_prompt_tokens_without_completion_tokens():
+    """Aborted requests still account for their already-prefilled prompt."""
+    scheduler = _bare_scheduler()
+    request = MLLMRequest(request_id="req-2", prompt="hello")
+    request.status = RequestStatus.RUNNING
+    request.num_prompt_tokens = 23
+    scheduler.requests = {request.request_id: request}
+    scheduler.waiting = deque()
+    scheduler.request_id_to_uid = {}
+    scheduler.uid_to_request_id = {}
+    scheduler.running = {request.request_id: request}
+    scheduler.batch_generator = None
+    scheduler.finished_req_ids = set()
+    scheduler._cancel_counter_lock = threading.Lock()
+    scheduler._aborted_queue_ids = set()
+
+    scheduler._do_abort_request(request.request_id)
+
+    assert scheduler.total_prompt_tokens == 23
+    assert scheduler.total_completion_tokens == 0
+    assert request.status is RequestStatus.FINISHED_ABORTED

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -2858,11 +2858,29 @@ class BatchedEngine(BaseEngine):
             # counters permanently at zero while generation was successful.
             # Keep the detailed nested snapshot and promote the same fields
             # that the text engine exposes at the top level.
-            stats.update(mllm_stats)
+            for key in (
+                "num_waiting",
+                "num_running",
+                "num_finished",
+                "num_requests_processed",
+                "total_prompt_tokens",
+                "total_completion_tokens",
+                "num_requests_cancelled",
+                "num_requests_cancelled_via_disconnect",
+                "metal_active_memory_gb",
+                "metal_peak_memory_gb",
+                "metal_cache_memory_gb",
+                "batch_generator",
+                "vision_embedding_cache",
+                "vision_cache",
+            ):
+                if key in mllm_stats:
+                    stats[key] = mllm_stats[key]
             stats["steps_executed"] = getattr(self._mllm_scheduler, "_step_count", 0)
+            start_time = getattr(self, "_start_time", None)
             stats["uptime_seconds"] = (
-                max(0.0, time.monotonic() - self._start_time)
-                if self._start_time is not None
+                max(0.0, time.monotonic() - start_time)
+                if start_time is not None
                 else 0.0
             )
         elif self._engine:

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -15,6 +15,7 @@ import functools
 import json
 import logging
 import threading
+import time
 from collections.abc import AsyncIterator
 from dataclasses import replace
 from typing import Any
@@ -836,6 +837,7 @@ class BatchedEngine(BaseEngine):
         self._mllm_instance = None  # MLXMultimodalLM instance
         self._loaded = False
         self._engine_started = False  # Track if engine loop is running
+        self._start_time: float | None = None
 
         # Atomic admission counter. Tracks in-flight requests admitted
         # via ``check_admission``; released by
@@ -1012,6 +1014,7 @@ class BatchedEngine(BaseEngine):
             await self._start_llm()
 
         self._loaded = True
+        self._start_time = time.monotonic()
         logger.info(f"BatchedEngine loaded: {self._model_name} (mllm={self._is_mllm})")
 
     async def _start_mllm(self) -> None:
@@ -1354,6 +1357,7 @@ class BatchedEngine(BaseEngine):
         # (handed off in start()). Drop our reference so __del__ doesn't
         # double-shutdown.
         self._model_load_executor = None
+        self._start_time = None
 
         self._model = None
         self._tokenizer = None
@@ -2848,18 +2852,19 @@ class BatchedEngine(BaseEngine):
         if self._mllm_scheduler:
             mllm_stats = self._mllm_scheduler.get_stats()
             stats["mllm_scheduler"] = mllm_stats
-            # Promote Metal memory stats + batch_generator throughput to
-            # top-level for /v1/status. Without "batch_generator" forwarded,
-            # generation_tps/prompt_tps stay invisible to monitoring even
-            # though the underlying counters are populated.
-            for key in (
-                "metal_active_memory_gb",
-                "metal_peak_memory_gb",
-                "metal_cache_memory_gb",
-                "batch_generator",
-            ):
-                if key in mllm_stats:
-                    stats[key] = mllm_stats[key]
+            # The health and Prometheus routes consume the common top-level
+            # stats contract. MLLM scheduler values used to remain nested
+            # under ``mllm_scheduler``, leaving Gemma's activity and token
+            # counters permanently at zero while generation was successful.
+            # Keep the detailed nested snapshot and promote the same fields
+            # that the text engine exposes at the top level.
+            stats.update(mllm_stats)
+            stats["steps_executed"] = getattr(self._mllm_scheduler, "_step_count", 0)
+            stats["uptime_seconds"] = (
+                max(0.0, time.monotonic() - self._start_time)
+                if self._start_time is not None
+                else 0.0
+            )
         elif self._engine:
             stats.update(self._engine.get_stats())
 

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -655,9 +655,10 @@ class MLLMScheduler:
         # Same ``request is not None`` guard as below — late/duplicate
         # aborts arrive after self.requests.pop() and would otherwise
         # raise AttributeError on the dereference.
-        if request is not None and request.num_output_tokens > 0:
-            self.total_completion_tokens += request.num_output_tokens
+        if request is not None:
             self.total_prompt_tokens += request.num_prompt_tokens
+            if request.num_output_tokens > 0:
+                self.total_completion_tokens += request.num_output_tokens
 
         # Mark as aborted
         if request is not None:
@@ -1018,6 +1019,7 @@ class MLLMScheduler:
                 request.finish_reason = finish_reason
                 self._detokenizer_pool.pop(request_id, None)
 
+                self.total_prompt_tokens += request.num_prompt_tokens
                 self.total_completion_tokens += request.num_output_tokens
                 self.num_requests_processed += 1
 


### PR DESCRIPTION
## What does this PR do?

Fixes MLLM/Gemma observability by exposing scheduler statistics through the common top-level engine stats consumed by `/v1/status` and `/metrics`.

Also fixes aggregate prompt-token accounting for completed and aborted MLLM requests.

## Why is this needed?

Successful Gemma requests were returning usage data, but Rapid-MLX reported zero activity in `/v1/status` and Prometheus metrics.

The MLLM scheduler stored request and token counters under `mllm_scheduler`, while the health and metrics routes read the top-level stats contract.

Observed before this change:

- Successful request usage: `prompt_tokens=20`, `completion_tokens=2`
- `total_requests_processed=0`
- `total_prompt_tokens=0`
- `total_completion_tokens=0`
- `uptime_seconds=0`

This made active vision-model traffic appear idle or invisible to dashboards.

## AI assistance disclosure

Codex authored the implementation and regression tests in:

- `vllm_mlx/engine/batched.py`
- `vllm_mlx/mllm_scheduler.py`
- `tests/test_mllm_stats.py`

The changes were reviewed against the existing text-engine stats contract and verified with focused tests, Ruff, and a live Rapid-MLX 0.12.7 Gemma request.

## Test plan

- [x] `python3 -m pytest tests/test_mllm_stats.py -q` — 3 passed
- [x] Ruff check on changed files
- [x] Ruff format check on changed files
- [x] `python3 -m py_compile` on changed Python files
- [x] Live Gemma request verified status and metrics counters

- Full pytest collection requires optional packages including `anthropic` and `hypothesis`, which are not installed in the validation environment.
- Full Ruff reports unrelated existing issues outside this change, including 3 lint errors and 14 unformatted files.

## Checklist

- [x] Focused regression tests pass
- [x] Changed files pass lint and formatting
- [x] No API-breaking changes
- [x] No version bump