### PR TITLE
fix(scheduler): reap orphaned disconnect slots

### DIFF
--- a/tests/test_batching.py
+++ b/tests/test_batching.py
@@ -315,6 +315,46 @@ class TestSchedulerBasic:
         assert scheduler.abort_request("known-1") is True
         assert scheduler.abort_request("known-1") is True
 
+    def test_step_reaps_disconnect_orphan_before_next(
+        self, mock_model, mock_tokenizer
+    ):
+        """#1759: engine cleanup without a surviving abort must not leak a slot.
+
+        This is the deterministic form of the production race: the streaming
+        consumer is gone (``requests`` was popped), but the scheduler's running
+        map, uid maps and mlx-lm batch slot remain while the deferred-abort set
+        is empty.  Before the reconciliation guard, ``step()`` called
+        ``BatchGenerator.next()`` forever and ``num_running`` stayed pinned.
+        """
+        scheduler = Scheduler(model=mock_model, tokenizer=mock_tokenizer)
+        request = Request(
+            request_id="disconnect-orphan",
+            prompt="Hello",
+            sampling_params=SamplingParams(max_tokens=512),
+        )
+        request.status = RequestStatus.RUNNING
+        uid = 73
+
+        # Deliberately do not populate scheduler.requests: this models
+        # EngineCore._cleanup_request having already released the consumer.
+        scheduler.running[request.request_id] = request
+        scheduler.request_id_to_uid[request.request_id] = uid
+        scheduler.uid_to_request_id[uid] = request.request_id
+        scheduler._pending_abort_ids.clear()
+
+        batch = MagicMock()
+        batch.next.side_effect = AssertionError("ghost slot was decoded")
+        scheduler.batch_generator = batch
+
+        scheduler.step()
+
+        batch.remove.assert_called_once_with([uid])
+        batch.next.assert_not_called()
+        assert request.request_id not in scheduler.running
+        assert request.request_id not in scheduler.request_id_to_uid
+        assert uid not in scheduler.uid_to_request_id
+        assert scheduler.get_num_running() == 0
+
     def test_get_stats(self, mock_model, mock_tokenizer):
         """Test getting scheduler stats."""
         scheduler = Scheduler(

--- a/tests/test_batching.py
+++ b/tests/test_batching.py
@@ -315,9 +315,7 @@ class TestSchedulerBasic:
         assert scheduler.abort_request("known-1") is True
         assert scheduler.abort_request("known-1") is True
 
-    def test_step_reaps_disconnect_orphan_before_next(
-        self, mock_model, mock_tokenizer
-    ):
+    def test_step_reaps_disconnect_orphan_before_next(self, mock_model, mock_tokenizer):
         """#1759: engine cleanup without a surviving abort must not leak a slot.
 
         This is the deterministic form of the production race: the streaming
@@ -335,12 +333,16 @@ class TestSchedulerBasic:
         request.status = RequestStatus.RUNNING
         uid = 73
 
-        # Deliberately do not populate scheduler.requests: this models
-        # EngineCore._cleanup_request having already released the consumer.
+        scheduler.requests[request.request_id] = request
         scheduler.running[request.request_id] = request
         scheduler.request_id_to_uid[request.request_id] = uid
         scheduler.uid_to_request_id[uid] = request.request_id
         scheduler._pending_abort_ids.clear()
+
+        # The engine releases its canonical tracking entry while the running
+        # slot is still live.  This is the production cleanup edge that arms
+        # the targeted reconciliation fallback.
+        scheduler.remove_finished_request(request.request_id)
 
         batch = MagicMock()
         batch.next.side_effect = AssertionError("ghost slot was decoded")

--- a/tests/test_batching.py
+++ b/tests/test_batching.py
@@ -357,6 +357,48 @@ class TestSchedulerBasic:
         assert uid not in scheduler.uid_to_request_id
         assert scheduler.get_num_running() == 0
 
+    def test_orphan_candidate_cannot_abort_reused_request_id(
+        self, mock_model, mock_tokenizer
+    ):
+        """A stale cleanup candidate is scoped to one Request identity."""
+        scheduler = Scheduler(model=mock_model, tokenizer=mock_tokenizer)
+        old = Request("reused-id", "old", SamplingParams())
+        old.status = RequestStatus.RUNNING
+        scheduler.requests[old.request_id] = old
+        scheduler.running[old.request_id] = old
+        scheduler.remove_finished_request(old.request_id)
+
+        new = Request("reused-id", "new", SamplingParams())
+        new.status = RequestStatus.RUNNING
+        scheduler.requests[new.request_id] = new
+        scheduler.running[new.request_id] = new
+        scheduler.batch_generator = MagicMock()
+
+        assert scheduler._reconcile_orphaned_running_requests() == []
+        assert scheduler.running[new.request_id] is new
+        scheduler.batch_generator.remove.assert_not_called()
+
+    def test_reset_removes_running_orphan_missing_from_requests(
+        self, mock_model, mock_tokenizer
+    ):
+        """Reset must tear down ghost slots, not only canonical requests."""
+        scheduler = Scheduler(model=mock_model, tokenizer=mock_tokenizer)
+        orphan = Request("reset-orphan", "old", SamplingParams())
+        orphan.status = RequestStatus.RUNNING
+        uid = 91
+        scheduler.running[orphan.request_id] = orphan
+        scheduler.request_id_to_uid[orphan.request_id] = uid
+        scheduler.uid_to_request_id[uid] = orphan.request_id
+        batch = MagicMock()
+        scheduler.batch_generator = batch
+
+        scheduler.reset()
+
+        batch.remove.assert_called_once_with([uid])
+        assert not scheduler.running
+        assert not scheduler.request_id_to_uid
+        assert not scheduler.uid_to_request_id
+
     def test_get_stats(self, mock_model, mock_tokenizer):
         """Test getting scheduler stats."""
         scheduler = Scheduler(

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -6150,21 +6150,36 @@ class Scheduler:
         with self._cancel_counter_lock:
             candidates = self._orphaned_running_candidates
             self._orphaned_running_candidates = {}
-            orphaned = [
-                rid
-                for rid, request in candidates.items()
-                if self.running.get(rid) is request and rid not in self.requests
-            ]
-
-        for request_id in orphaned:
-            logger.warning(
-                "[abort_reconcile] reaping orphaned running request %s",
-                request_id[:12],
-            )
-            self._do_abort_request(request_id)
+        orphaned = []
+        for request_id, request in candidates.items():
+            if self._do_abort_request(request_id, expected_orphan=request):
+                orphaned.append(request_id)
+                logger.warning(
+                    "[abort_reconcile] reaped orphaned running request %s",
+                    request_id[:12],
+                )
         return orphaned
 
-    def _do_abort_request(self, request_id: str) -> bool:
+    def _do_abort_request(
+        self, request_id: str, *, expected_orphan: Request | None = None
+    ) -> bool:
+        """Serialize abort cleanup and optionally bind it to one lifetime.
+
+        The orphan reconciler crosses from engine cleanup back onto the
+        scheduler thread.  An ID alone is insufficient because callers may
+        reuse one after cleanup.  Validate the exact ``Request`` identity and
+        perform the ID-based teardown while holding the same lock used by the
+        admission commit, closing the check-to-abort window.
+        """
+        with self._cancel_counter_lock:
+            if expected_orphan is not None and not (
+                self.running.get(request_id) is expected_orphan
+                and request_id not in self.requests
+            ):
+                return False
+            return self._do_abort_request_impl(request_id)
+
+    def _do_abort_request_impl(self, request_id: str) -> bool:
         """
         Actually abort a request. Must be called from the executor thread.
 

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -3063,7 +3063,7 @@ class Scheduler:
         # ``remove_finished_request`` adds an id only when its running slot is
         # still live; normal completions remove ``running`` first.  This avoids
         # an O(batch) reconciliation scan on every decode tick.
-        self._orphaned_running_candidates: set[str] = set()
+        self._orphaned_running_candidates: dict[str, Request] = {}
         # M-01 codex r2 BLOCKING #1: lifetime de-dup set for the
         # cancellation counter. ``_pending_abort_ids`` is the wrong
         # ledger to dedupe against — it's a DEFERRED-ABORT QUEUE that
@@ -5770,7 +5770,7 @@ class Scheduler:
         with self._cancel_counter_lock:
             self._cancelled_request_ids.discard(request.request_id)
             self._disconnect_abort_ids.discard(request.request_id)
-            self._orphaned_running_candidates.discard(request.request_id)
+            self._orphaned_running_candidates.pop(request.request_id, None)
             self.requests[request.request_id] = request
         self.waiting.append(request)
 
@@ -6149,11 +6149,11 @@ class Scheduler:
         """
         with self._cancel_counter_lock:
             candidates = self._orphaned_running_candidates
-            self._orphaned_running_candidates = set()
+            self._orphaned_running_candidates = {}
             orphaned = [
                 rid
-                for rid in candidates
-                if rid in self.running and rid not in self.requests
+                for rid, request in candidates.items()
+                if self.running.get(rid) is request and rid not in self.requests
             ]
 
         for request_id in orphaned:
@@ -7647,8 +7647,8 @@ class Scheduler:
         # False per F-151). The ledgers stay populated indefinitely.
         with self._cancel_counter_lock:
             popped = self.requests.pop(request_id, None)
-            if popped is not None and request_id in self.running:
-                self._orphaned_running_candidates.add(request_id)
+            if popped is not None and self.running.get(request_id) is popped:
+                self._orphaned_running_candidates[request_id] = popped
         return popped
 
     def get_running_requests_info(self) -> list[dict[str, Any]]:
@@ -7843,12 +7843,17 @@ class Scheduler:
         started (correct) or sees the cleared state and no-ops
         (correct: the request is gone, attribution is meaningless).
         """
-        # Drain any pending deferred aborts
-        self._pending_abort_ids.clear()
-        self._orphaned_running_candidates.clear()
+        # Drain both cross-thread cleanup edges under their shared lock.
+        # Snapshot the union before teardown: a disconnect orphan has already
+        # left ``requests`` and would otherwise survive a reset that iterated
+        # only the canonical map.
+        with self._cancel_counter_lock:
+            self._pending_abort_ids.clear()
+            self._orphaned_running_candidates.clear()
+            teardown_ids = list(dict.fromkeys((*self.requests, *self.running)))
 
         # Abort all requests directly (reset is synchronous)
-        for request_id in list(self.requests.keys()):
+        for request_id in teardown_ids:
             self._do_abort_request(request_id)
 
         self.waiting.clear()

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -3059,6 +3059,11 @@ class Scheduler:
         # Thread-safe set for deferred aborts (main thread → executor thread)
         # CPython GIL guarantees set.add() and `x in set` are atomic.
         self._pending_abort_ids: set[str] = set()
+        # #1759: targeted second edge from engine cleanup to the executor.
+        # ``remove_finished_request`` adds an id only when its running slot is
+        # still live; normal completions remove ``running`` first.  This avoids
+        # an O(batch) reconciliation scan on every decode tick.
+        self._orphaned_running_candidates: set[str] = set()
         # M-01 codex r2 BLOCKING #1: lifetime de-dup set for the
         # cancellation counter. ``_pending_abort_ids`` is the wrong
         # ledger to dedupe against — it's a DEFERRED-ABORT QUEUE that
@@ -5765,6 +5770,7 @@ class Scheduler:
         with self._cancel_counter_lock:
             self._cancelled_request_ids.discard(request.request_id)
             self._disconnect_abort_ids.discard(request.request_id)
+            self._orphaned_running_candidates.discard(request.request_id)
             self.requests[request.request_id] = request
         self.waiting.append(request)
 
@@ -6142,7 +6148,13 @@ class Scheduler:
         through the same BatchGenerator-aware abort implementation.
         """
         with self._cancel_counter_lock:
-            orphaned = [rid for rid in self.running if rid not in self.requests]
+            candidates = self._orphaned_running_candidates
+            self._orphaned_running_candidates = set()
+            orphaned = [
+                rid
+                for rid in candidates
+                if rid in self.running and rid not in self.requests
+            ]
 
         for request_id in orphaned:
             logger.warning(
@@ -7635,6 +7647,8 @@ class Scheduler:
         # False per F-151). The ledgers stay populated indefinitely.
         with self._cancel_counter_lock:
             popped = self.requests.pop(request_id, None)
+            if popped is not None and request_id in self.running:
+                self._orphaned_running_candidates.add(request_id)
         return popped
 
     def get_running_requests_info(self) -> list[dict[str, Any]]:
@@ -7831,6 +7845,7 @@ class Scheduler:
         """
         # Drain any pending deferred aborts
         self._pending_abort_ids.clear()
+        self._orphaned_running_candidates.clear()
 
         # Abort all requests directly (reset is synchronous)
         for request_id in list(self.requests.keys()):

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -6122,6 +6122,36 @@ class Scheduler:
             request_id = self._pending_abort_ids.pop()
             self._do_abort_request(request_id)
 
+    def _reconcile_orphaned_running_requests(self) -> list[str]:
+        """Reap running slots whose engine-side request was already released.
+
+        ``EngineCore._cleanup_request`` removes the canonical ``requests``
+        entry when a streaming consumer disconnects.  The scheduler normally
+        consumes the corresponding deferred abort at the start of the next
+        step.  Production issue #1759 demonstrated that relying on that single
+        edge is not sufficient: after a rare disconnect race, the abort edge
+        can be gone while ``running`` and the BatchGenerator uid remain.  The
+        empty consumer can then be decoded forever and permanently occupies a
+        ``max_num_seqs`` slot.
+
+        After pending aborts have been drained, a running id missing from
+        ``requests`` is impossible for a live request: normal completions are
+        removed from ``running`` on the executor thread *before* engine cleanup,
+        while disconnect cleanup deliberately removes ``requests`` first.  Use
+        that invariant as a narrow executor-thread safety net and route cleanup
+        through the same BatchGenerator-aware abort implementation.
+        """
+        with self._cancel_counter_lock:
+            orphaned = [rid for rid in self.running if rid not in self.requests]
+
+        for request_id in orphaned:
+            logger.warning(
+                "[abort_reconcile] reaping orphaned running request %s",
+                request_id[:12],
+            )
+            self._do_abort_request(request_id)
+        return orphaned
+
     def _do_abort_request(self, request_id: str) -> bool:
         """
         Actually abort a request. Must be called from the executor thread.
@@ -7366,6 +7396,11 @@ class Scheduler:
 
         # Process pending aborts FIRST (in executor thread, safe for MLX)
         self._process_pending_aborts()
+        # #1759: the engine has no consumer for a running request once its
+        # canonical tracking entry is gone.  Reconcile that invariant before
+        # invoking BatchGenerator.next(), otherwise a lost disconnect-abort can
+        # spend this and every later tick decoding a ghost slot.
+        self._reconcile_orphaned_running_requests()
 
         for attempt in range(max_retries + 1):
             try:


### PR DESCRIPTION
## Summary

- reconcile scheduler `running` entries after deferred abort processing
- treat a running request missing from canonical `requests` tracking as a disconnected orphan
- remove the orphan through the existing BatchGenerator-aware abort path before the next decode tick
- add a deterministic regression that recreates the production ghost-slot state

Closes #1759

## Reproduction

The deterministic regression constructs the state observed in production:

- the streaming consumer has unwound and `EngineCore._cleanup_request` has removed `scheduler.requests[request_id]`
- `scheduler.running`, both uid maps, and the BatchGenerator slot still retain the request
- `_pending_abort_ids` no longer contains the abort edge

Before this change, `Scheduler.step()` calls `BatchGenerator.next()` and the ghost continues consuming a `max_num_seqs` slot. The regression makes `next()` fail if reached.

I also exercised main HEAD on the reporter's exact cached model (`mlx-community/Qwen3.6-35B-A3B-8bit`) with `--max-num-seqs 4`, `--hybrid-cache-entries 8`, long tool-bearing prompts, and streaming disconnects:

- 160 TCP-RST attempts: final `running=0`, `waiting=0`
- 200 disconnects after receiving SSE chunks: final `running=0`, `waiting=0`; all 200 were attributed via the disconnect counter

The low-rate production race did not trigger in that finite run, but the deterministic lifecycle state reproduces the permanent-slot failure and pins the recovery invariant.

## Safety invariant

After pending aborts are drained, a live running request must still exist in `scheduler.requests`. Normal completion removes `running` on the scheduler executor thread before engine cleanup. Disconnect cleanup is the only path that removes the canonical request first. Reconciliation therefore cannot reap a normal live request and runs on the executor thread before `BatchGenerator.next()`.

## Validation

- `python3.12 -m pytest -q tests/test_batching.py tests/test_cancelled_requests_metric.py tests/test_disconnect_counter_prod_shape.py tests/test_disconnect_guard_aborts_scheduler.py tests/test_rst_mid_sse_zombie_kv.py` — 86 passed, 2 deselected
- `python3.12 -m ruff check vllm_mlx/scheduler.py tests/test_batching.py` — clean
- `git diff --check` — clean

`tests/test_event_loop.py` was also invoked but is an external-server manual harness and its two network cases failed only because no server was listening on its hard-coded port 8000.
