### PR TITLE
fix(mac): re-synthesize once when a grounded answer denies real-time access

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
@@ -1687,23 +1687,40 @@ final class ChatViewModel {
         return history[start...].contains { $0.role == .tool }
     }
 
-    /// Like ``carriesToolResultForThisTurn`` but requires a SUCCESSFUL tool
-    /// result — a ``.tool`` row for this turn that did not fail. The grounding
+    /// Like ``carriesToolResultForThisTurn`` but requires usable current data
+    /// from one of the built-in live-data tools. The grounding
     /// correction (BUG C) asserts "the tool result above was fetched just now
     /// and IS the current data", so it must not fire when the only tool result
     /// this turn is a failed/empty one (e.g. a search that errored): there the
     /// model's "I can't get current data" answer is correct, not a
-    /// confabulation. All three built-in tools (web_search, browse, weather)
-    /// are live-data sources, so a non-failed result from any of them is
-    /// real-time evidence.
+    /// confabulation. Tool rows are joined back to their calls by ID so a
+    /// successful calculator or MCP result cannot accidentally arm this
+    /// live-data-specific retry.
     static func carriesSuccessfulToolResultForThisTurn(_ history: [ChatMessage]) -> Bool {
         let start =
             history.lastIndex { $0.role == .user }
             .map { history.index(after: $0) } ?? history.startIndex
-        return history[start...].contains {
-            $0.role == .tool
-                && $0.status == .complete
-                && !$0.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        let turn = history[start...]
+        let liveToolNames: Set<String> = ["web_search", "browse", "weather"]
+        var liveCallIDs: Set<String> = []
+        for message in turn where message.role == .assistant {
+            for call in message.toolCalls ?? []
+            where liveToolNames.contains(call.function.name) {
+                liveCallIDs.insert(call.id)
+            }
+        }
+        return turn.contains { message in
+            guard message.role == .tool,
+                message.status == .complete,
+                let toolCallID = message.toolCallID,
+                liveCallIDs.contains(toolCallID)
+            else { return false }
+            let content = message.content.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !content.isEmpty else { return false }
+            // A successful transport can still produce no evidence. In that
+            // case a refusal may be accurate, and the correction preamble must
+            // not claim that current data exists.
+            return !content.lowercased().contains("no results found")
         }
     }
 

--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
@@ -1223,6 +1223,16 @@ final class ChatViewModel {
         var toolExecutionsLeft = maxToolExecutions
         var appGroundingSources: [GroundingSource] = []
         var isFinalSynthesisRound = false
+        // dogfood-0810 BUG C: one-shot grounding-correction retry. Set when a
+        // grounded synthesis answer denies real-time access; forces a single
+        // tools-disabled correction round carrying ``groundingCorrectionPreamble``.
+        var groundingCorrectionUsed = false
+        var forceGroundingCorrection = false
+        // The confabulated draft we are replacing, kept until the correction
+        // round produces a usable answer. Restored if the retry stream fails,
+        // is cancelled, or comes back empty — a wrong-but-present answer beats
+        // a blank message.
+        var draftBeforeCorrection: String?
 
         // `tool_choice:function` is advisory in several local chat templates:
         // the shipped 1.2B starter can ignore it and answer "I can search".
@@ -1339,6 +1349,12 @@ final class ChatViewModel {
             if isFinalSynthesisRound {
                 history = ChatViewModel.addingToolBudgetSynthesisPreamble(to: history)
             }
+            // BUG C: on the forced correction round, name the exact failure so
+            // the retry has a stronger steer than the preamble that already
+            // rode on the draft it is correcting.
+            if forceGroundingCorrection {
+                history = ChatViewModel.addingGroundingCorrectionPreamble(to: history)
+            }
             let request: ChatStreamClient.Request
             if let s = sampling {
                 let resolved = s.resolved(toolsEnabled: !definitions.isEmpty)
@@ -1367,6 +1383,78 @@ final class ChatViewModel {
             )
             switch outcome {
             case .terminal:
+                // BUG C: if this .terminal ends a grounding-correction round
+                // that failed to produce a usable answer (transport error,
+                // cancellation, or an empty stream), restore the original draft
+                // — a wrong-but-present answer is better than a blank message.
+                // A successful, non-empty correction is kept as-is.
+                if let original = draftBeforeCorrection {
+                    draftBeforeCorrection = nil
+                    guard epoch == conversationEpoch else { return }
+                    let corrected = currentMessage(index: currentPlaceholder)
+                    let correctedText =
+                        (corrected?.content ?? "")
+                        .trimmingCharacters(in: .whitespacesAndNewlines)
+                    // Keep the correction only if it produced a usable, non-
+                    // failed answer of its own. Restore the original draft on
+                    // failure, an empty stream, OR cancellation — a cancelled
+                    // retry must never leave the blanked placeholder empty.
+                    let correctionUsable =
+                        !Task.isCancelled
+                        && !correctedText.isEmpty
+                        && corrected?.status != .failed
+                    if !correctionUsable,
+                        var restore = currentMessage(index: currentPlaceholder)
+                    {
+                        restore.content = original
+                        restore.status = .complete
+                        restore.errorMessage = nil
+                        restore.failureKind = nil
+                        updateMessage(at: currentPlaceholder, with: restore)
+                    }
+                    appendGroundingSources(
+                        appGroundingSources,
+                        to: currentPlaceholder,
+                        epoch: epoch
+                    )
+                    return
+                }
+                // The model finished in prose, but if it denied having
+                // real-time/current data while a SUCCESSFUL tool result for
+                // THIS turn is on the wire, that answer confabulates a refusal
+                // over live evidence. Force exactly one tools-disabled
+                // correction round. Guarded so it fires at most once, only with
+                // a successful tool result present, and never on a cancelled/
+                // superseded turn. The ``!answerReliesOnEvidence`` clause spares
+                // the caveat case ("I can't browse directly, but the results
+                // show X"): a disclaimer in front of a grounded answer is not a
+                // refusal.
+                if !groundingCorrectionUsed,
+                    epoch == conversationEpoch,
+                    !Task.isCancelled,
+                    ChatViewModel.carriesSuccessfulToolResultForThisTurn(
+                        Array(messages.prefix(currentPlaceholder))
+                    ),
+                    let produced = currentMessage(index: currentPlaceholder)?.content,
+                    ChatViewModel.looksLikeUngroundedRefusal(produced),
+                    !ChatViewModel.answerReliesOnEvidence(produced)
+                {
+                    groundingCorrectionUsed = true
+                    forceGroundingCorrection = true
+                    isFinalSynthesisRound = true
+                    // Stash the draft and reset the placeholder so the
+                    // correction streams fresh instead of appending onto the
+                    // refusal text. The stash is restored above if the retry
+                    // does not produce a usable answer.
+                    draftBeforeCorrection = produced
+                    if var staged = currentMessage(index: currentPlaceholder) {
+                        staged.content = ""
+                        staged.toolCalls = nil
+                        staged.status = .streaming
+                        updateMessage(at: currentPlaceholder, with: staged)
+                    }
+                    continue
+                }
                 appendGroundingSources(
                     appGroundingSources,
                     to: currentPlaceholder,
@@ -1599,6 +1687,26 @@ final class ChatViewModel {
         return history[start...].contains { $0.role == .tool }
     }
 
+    /// Like ``carriesToolResultForThisTurn`` but requires a SUCCESSFUL tool
+    /// result — a ``.tool`` row for this turn that did not fail. The grounding
+    /// correction (BUG C) asserts "the tool result above was fetched just now
+    /// and IS the current data", so it must not fire when the only tool result
+    /// this turn is a failed/empty one (e.g. a search that errored): there the
+    /// model's "I can't get current data" answer is correct, not a
+    /// confabulation. All three built-in tools (web_search, browse, weather)
+    /// are live-data sources, so a non-failed result from any of them is
+    /// real-time evidence.
+    static func carriesSuccessfulToolResultForThisTurn(_ history: [ChatMessage]) -> Bool {
+        let start =
+            history.lastIndex { $0.role == .user }
+            .map { history.index(after: $0) } ?? history.startIndex
+        return history[start...].contains {
+            $0.role == .tool
+                && $0.status == .complete
+                && !$0.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }
+    }
+
     static func ambientSystemMessages(
         historyOpensWithSystem: Bool,
         toolsAdvertised: Bool,
@@ -1629,6 +1737,113 @@ You have access to tools that fetch real-time information. When you use one of t
 
 These rules apply to every tool, not just web search.
 """
+
+    /// Failure-specific instruction for the one correction round the tool loop
+    /// forces when a grounded synthesis still denies having current data
+    /// (dogfood-0810 BUG C). The anti-confabulation preamble already rode on
+    /// the draft that failed, so a plain retry would likely repeat it; this
+    /// names the exact mistake so the retry has a different, stronger steer.
+    nonisolated static let groundingCorrectionPreamble: String = """
+Your previous draft refused the question by claiming you lack real-time access or that your knowledge has a cutoff. That is FALSE for this turn: the tool result above was fetched just now and IS the current, real-time data. Answer the user's question again using ONLY the tool result. Do NOT mention a knowledge cutoff, a training date, or any inability to access real-time / current information. If the tool result genuinely does not contain the answer, say specifically what it is missing — do not fall back to a blanket refusal.
+"""
+
+    /// Prepend/merge the grounding-correction instruction onto the wire body of
+    /// the forced correction round. Mirrors ``addingToolBudgetSynthesisPreamble``
+    /// so both can stack on a single leading system row.
+    nonisolated static func addingGroundingCorrectionPreamble(
+        to messages: [ChatMessage]
+    ) -> [ChatMessage] {
+        var result = messages
+        if result.first?.role == .system {
+            result[0].content += "\n\n" + groundingCorrectionPreamble
+        } else {
+            result.insert(
+                ChatMessage(
+                    role: .system,
+                    content: groundingCorrectionPreamble,
+                    status: .complete
+                ),
+                at: 0
+            )
+        }
+        return result
+    }
+
+    /// True when an assistant answer is a FIRST-PERSON temporal-denial refusal
+    /// — "I can't access real-time information", "my knowledge is only up to
+    /// 2024", etc. Every phrase carries its own first-person subject (``i ``,
+    /// ``my ``, ``as of my ``, or the Chinese ``我``) so a grounded answer that
+    /// reports a cutoff about a third party ("the model's knowledge cutoff is
+    /// 2023") or quotes a tool result ("users were 'unable to browse'") is not
+    /// flagged. Typographic apostrophes are normalized first so a curly
+    /// ``can't`` matches too. Used ONLY with ``carriesToolResultForThisTurn``
+    /// so the signal is "denied despite having evidence", never "no data".
+    nonisolated static func looksLikeUngroundedRefusal(_ text: String) -> Bool {
+        let value =
+            text
+            .lowercased()
+            .replacingOccurrences(of: "\u{2019}", with: "'")  // ’ right single quote
+            .replacingOccurrences(of: "\u{2018}", with: "'")  // ‘ left single quote
+            .replacingOccurrences(of: "\u{02BC}", with: "'")  // ʼ modifier apostrophe
+        guard !value.isEmpty else { return false }
+        let firstPersonDenials = [
+            "i can't access real-time", "i cannot access real-time",
+            "i can't access current", "i cannot access current",
+            "i can't access the internet", "i cannot access the internet",
+            "i can't provide real-time", "i cannot provide real-time",
+            "i can't provide current", "i cannot provide current",
+            "i can't give you real-time", "i cannot give you real-time",
+            "i don't have access to real-time", "i do not have access to real-time",
+            "i don't have real-time", "i do not have real-time",
+            "i don't have access to current", "i do not have access to current",
+            "i don't have internet access", "i do not have internet access",
+            "i have no access to real-time", "i have no access to current",
+            "i'm unable to access real-time", "i am unable to access real-time",
+            "i'm unable to access current", "i am unable to access current",
+            "i'm unable to provide real-time", "i am unable to provide real-time",
+            "i can't browse the internet", "i cannot browse the internet",
+            "i can't browse", "i cannot browse",
+            "i'm not able to browse", "i am not able to browse",
+            "i don't have browsing", "i do not have browsing",
+            "my knowledge is only up to", "my knowledge only goes up to",
+            "my knowledge cutoff", "my knowledge is current up to",
+            "my knowledge only extends to", "my knowledge ends in",
+            "as of my last update", "as of my last training",
+            "as of my knowledge cutoff", "my training data only goes",
+            "my training only goes", "i was last trained", "my last training",
+            // Chinese equivalents (the app ships a zh UI), anchored on the
+            // first-person 我 so a third-party report does not match.
+            "我无法访问实时", "我无法获取实时", "我无法提供实时",
+            "我无法访问最新", "我无法获取最新", "我没有实时",
+            "我不能访问实时", "我无法联网", "我无法上网", "我不能联网",
+            "我的知识截止", "我的知识只到", "我的训练数据截止"
+        ]
+        return firstPersonDenials.contains(where: value.contains)
+    }
+
+    /// True when an answer visibly draws on the tool result — a citation link,
+    /// or a CONCRETE reference to the fetched results. Used to spare the caveat
+    /// case ("I can't browse directly, BUT the tool results show X"): the model
+    /// prefaced a grounded answer with a disclaimer, so it did NOT confabulate.
+    ///
+    /// Deliberately concrete: only a link or an explicit reference to the
+    /// fetched *results* counts. Vague connectors like "according to" or "the
+    /// source" are excluded because they attach just as readily to a refusal
+    /// ("According to my knowledge cutoff, I cannot provide current data") and
+    /// would let a confabulation slip through the correction.
+    nonisolated static func answerReliesOnEvidence(_ text: String) -> Bool {
+        let value = text.lowercased()
+        guard !value.isEmpty else { return false }
+        let groundingSignals = [
+            "](",  // a Markdown-linked source inside a formatted answer
+            "the results", "the result show", "the result indicate",
+            "search result", "the tool result", "the tool output",
+            "the search returned", "the fetched",
+            // Chinese concrete-result references.
+            "搜索结果", "结果显示", "工具结果", "抓取"
+        ]
+        return groundingSignals.contains(where: value.contains)
+    }
 
     // MARK: - Single-stream driver
 

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -671,8 +671,12 @@ final class ServerManager {
     ) async -> Bool {
         let trimmed = alias.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return false }
-        if replacementGroup == nil,
-           case .ready(let current) = state, current == trimmed {
+        // Replacement policy matters only when loading a different model.
+        // The requested alias is already the active assistant, so asking the
+        // residency endpoint to replace it is redundant and breaks legacy
+        // sidecars: their 404 fallback stops and restarts the model on every
+        // chat send before the request can leave the app.
+        if case .ready(let current) = state, current == trimmed {
             return true
         }
         if replacementGroup == nil, isModelResident(trimmed) { return true }

--- a/apps/rapid-mac/Tests/RapidTests/AutoRestartAndRegenRaceTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/AutoRestartAndRegenRaceTests.swift
@@ -64,6 +64,24 @@ struct AutoRestartAndRegenRaceTests {
         }
     }
 
+    @Test("replacement group is also a noop for the already-serving alias")
+    func replacementGroupDoesNotReloadCurrentAlias() async {
+        let server = ServerManager(testingState: .ready(alias: "qwen3.6-27b-4bit"))
+        let ok = await server.ensureServing(
+            alias: "qwen3.6-27b-4bit",
+            hfPath: nil,
+            estimatedMemoryGB: nil,
+            replacementGroup: .assistant
+        )
+
+        #expect(ok == true)
+        guard case .ready(let alias) = server.state else {
+            Issue.record("Expected the current model to remain ready")
+            return
+        }
+        #expect(alias == "qwen3.6-27b-4bit")
+    }
+
     @Test("ensureServing returns false when the binary is missing")
     func ensureServingFailsWithoutBinary() async {
         // The ``.missing`` test seam simulates rapid-mlx not being

--- a/apps/rapid-mac/Tests/RapidTests/GroundingConfabulationRetryTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/GroundingConfabulationRetryTests.swift
@@ -295,6 +295,55 @@ struct SuccessfulToolResultScopingTests {
         #expect(ChatViewModel.carriesToolResultForThisTurn(h))
         #expect(!ChatViewModel.carriesSuccessfulToolResultForThisTurn(h))
     }
+
+    @Test("A successful non-live tool result does not arm the current-data correction")
+    func nonLiveResultIsNotCurrentData() {
+        let h = [
+            ChatMessage(role: .user, content: "Calculate 17 times 23."),
+            ChatMessage(
+                role: .assistant,
+                toolCalls: [ToolCall(id: "c1", name: "calculator", arguments: "{}")]
+            ),
+            ChatMessage(role: .tool, content: "391", status: .complete, toolCallID: "c1")
+        ]
+        #expect(!ChatViewModel.carriesSuccessfulToolResultForThisTurn(h))
+    }
+
+    @Test("A successful search with no results does not claim current data exists")
+    func noResultsIsNotCurrentData() {
+        let h = [
+            ChatMessage(role: .user, content: "Find the latest frobnicator news."),
+            ChatMessage(
+                role: .assistant,
+                toolCalls: [ToolCall(id: "s1", name: "web_search", arguments: "{}")]
+            ),
+            ChatMessage(
+                role: .tool,
+                content: "web_search: no results found for frobnicator",
+                status: .complete,
+                toolCallID: "s1"
+            )
+        ]
+        #expect(!ChatViewModel.carriesSuccessfulToolResultForThisTurn(h))
+    }
+
+    @Test("A live result must match the originating live tool call ID")
+    func resultMustMatchLiveCallID() {
+        let h = [
+            ChatMessage(role: .user, content: "What's the weather?"),
+            ChatMessage(
+                role: .assistant,
+                toolCalls: [ToolCall(id: "w1", name: "weather", arguments: "{}")]
+            ),
+            ChatMessage(
+                role: .tool,
+                content: "72 F and sunny",
+                status: .complete,
+                toolCallID: "other"
+            )
+        ]
+        #expect(!ChatViewModel.carriesSuccessfulToolResultForThisTurn(h))
+    }
 }
 
 @MainActor

--- a/apps/rapid-mac/Tests/RapidTests/GroundingConfabulationRetryTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/GroundingConfabulationRetryTests.swift
@@ -1,0 +1,391 @@
+import Foundation
+import Testing
+@testable import Rapid
+
+// File-scope (nonisolated) so the URLProtocol stub can read them without
+// crossing the @MainActor boundary of the test suite.
+private let kGroundedAnswer =
+    "According to the results, the biggest story is the Lumen-Nexus merger."
+private let kConfabAnswer =
+    "I can't access real-time information, and my knowledge is only up to 2024."
+
+/// Grounded-answer confabulation guard (dogfood-0810 BUG C): when a tool
+/// result for THIS turn is on the wire but the model's synthesis still denies
+/// having real-time / current data ("my knowledge is only up to 2024"), the
+/// loop forces exactly one tools-disabled correction round instead of shipping
+/// the confabulated refusal.
+@MainActor
+@Suite("Grounding confabulation retry", .serialized)
+struct GroundingConfabulationRetryTests {
+    static let caveat =
+        "I can't browse directly, but the search result shows the Lumen-Nexus merger closed."
+
+    @Test("A tool-grounded answer that denies real-time access is re-synthesized once")
+    func confabulatedDenialTriggersOneCorrection() async throws {
+        ConfabRetryProtocol.reset(firstAnswer: kConfabAnswer)
+        let registry = WebSearchStubRegistry()
+        let model = ChatViewModel(
+            client: ChatStreamClient(
+                baseURL: URL(string: "fake://confab")!,
+                session: ConfabRetryProtocol.session()
+            ),
+            tools: registry,
+            persistsConversations: false
+        )
+
+        model.send("What's a major news story from the last week?", alias: "test-model")
+        for _ in 0..<300 where model.isStreaming {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+
+        #expect(!model.isStreaming)
+        // The final answer is the grounded retry, not the confabulated draft.
+        #expect(model.messages.last?.content == kGroundedAnswer)
+        #expect(model.messages.last?.status == .complete)
+        // Exactly two synthesis requests: the confabulated one, then one
+        // correction. (The forced web_search itself is dispatched app-side and
+        // is not an HTTP request.)
+        #expect(ConfabRetryProtocol.requestBodies.count == 2)
+        // The correction round is tools-disabled and carries a failure-specific
+        // system instruction.
+        let correction = try #require(ConfabRetryProtocol.requestBodies.last)
+        let json = try #require(
+            JSONSerialization.jsonObject(with: correction) as? [String: Any]
+        )
+        #expect(json["tools"] == nil)
+        let messages = try #require(json["messages"] as? [[String: Any]])
+        let systemBlob = messages
+            .filter { ($0["role"] as? String) == "system" }
+            .compactMap { $0["content"] as? String }
+            .joined(separator: "\n")
+            .lowercased()
+        // Assert a distinctive clause from ``groundingCorrectionPreamble`` so
+        // this cannot pass on an unrelated pre-existing system prompt.
+        #expect(systemBlob.contains("that is false for this turn"))
+    }
+
+    @Test("A grounded answer with no denial is shipped as-is, never retried")
+    func groundedAnswerIsNotRetried() async throws {
+        ConfabRetryProtocol.reset(firstAnswer: kGroundedAnswer)
+        let registry = WebSearchStubRegistry()
+        let model = ChatViewModel(
+            client: ChatStreamClient(
+                baseURL: URL(string: "fake://confab")!,
+                session: ConfabRetryProtocol.session()
+            ),
+            tools: registry,
+            persistsConversations: false
+        )
+
+        model.send("What's a major news story from the last week?", alias: "test-model")
+        for _ in 0..<300 where model.isStreaming {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+
+        #expect(!model.isStreaming)
+        #expect(model.messages.last?.content == kGroundedAnswer)
+        // A clean grounded answer must not spend a second synthesis round.
+        #expect(ConfabRetryProtocol.requestBodies.count == 1)
+    }
+
+    @Test("A failed/empty correction round restores the original draft, not a blank")
+    func failedCorrectionRestoresOriginalDraft() async throws {
+        // Request 1 confabulates → correction is forced; request 2 (the
+        // correction) comes back empty → the loop must restore the original
+        // answer rather than leave the blanked placeholder empty.
+        ConfabRetryProtocol.reset(firstAnswer: kConfabAnswer)
+        ConfabRetryProtocol.emptySecondResponse = true
+        defer { ConfabRetryProtocol.emptySecondResponse = false }
+        let registry = WebSearchStubRegistry()
+        let model = ChatViewModel(
+            client: ChatStreamClient(
+                baseURL: URL(string: "fake://confab")!,
+                session: ConfabRetryProtocol.session()
+            ),
+            tools: registry,
+            persistsConversations: false
+        )
+
+        model.send("What's a major news story from the last week?", alias: "test-model")
+        for _ in 0..<300 where model.isStreaming {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+
+        #expect(!model.isStreaming)
+        // The correction was attempted (two requests) but produced nothing…
+        #expect(ConfabRetryProtocol.requestBodies.count == 2)
+        // …so the original draft is preserved, and the message is not blank.
+        #expect(model.messages.last?.content == kConfabAnswer)
+        #expect(model.messages.last?.status == .complete)
+    }
+
+    @Test("A disclaimer in front of a grounded answer is preserved end-to-end")
+    func caveatedGroundedAnswerIsPreservedThroughTheLoop() async throws {
+        ConfabRetryProtocol.reset(firstAnswer: Self.caveat)
+        let registry = WebSearchStubRegistry()
+        let model = ChatViewModel(
+            client: ChatStreamClient(
+                baseURL: URL(string: "fake://confab")!,
+                session: ConfabRetryProtocol.session()
+            ),
+            tools: registry,
+            persistsConversations: false
+        )
+
+        model.send("What's a major news story from the last week?", alias: "test-model")
+        for _ in 0..<300 where model.isStreaming {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+
+        #expect(!model.isStreaming)
+        // The caveat carries a refusal phrase ("I can't browse") but also draws
+        // on the evidence ("the search result shows …"), so the combined guard
+        // must NOT retry it — the answer is preserved verbatim.
+        #expect(model.messages.last?.content == Self.caveat)
+        #expect(ConfabRetryProtocol.requestBodies.count == 1)
+    }
+}
+
+@Suite("Ungrounded-refusal detection")
+struct UngroundedRefusalDetectionTests {
+    @Test(
+        "First-person temporal-denial refusals are detected",
+        arguments: [
+            "I can't access real-time information.",
+            // Typographic (curly) apostrophe — normalized before matching.
+            "I can\u{2019}t access real-time information.",
+            "I cannot provide current data, my knowledge is only up to 2024.",
+            "As of my last update, I don't have real-time access.",
+            "My knowledge cutoff is 2024, so I can't help with this week's news.",
+            "Sorry, I'm not able to browse the internet.",
+            "I don't have access to current events.",
+            "抱歉，我无法访问实时信息。",
+            "我的知识截止到2024年。"
+        ]
+    )
+    func detectsDenials(_ text: String) {
+        #expect(ChatViewModel.looksLikeUngroundedRefusal(text))
+    }
+
+    @Test(
+        "Grounded answers, including third-party cutoff reports and quotes, are not flagged",
+        arguments: [
+            "According to the results, the biggest story is the Lumen-Nexus merger.",
+            "The article reports real-time traffic data updated this morning.",
+            "Revenue grew steadily up to 2024 before the merger closed.",
+            "The live scoreboard shows the current score is 2-1.",
+            "Here are the latest headlines from the search results, with sources.",
+            // Third-party cutoff report — must NOT trigger (no first-person).
+            "The article explains that the model's knowledge cutoff is 2023.",
+            "The vendor says its assistant is unable to browse the web.",
+            // Quoted tool-result text — must NOT trigger.
+            "The outage report notes users were 'unable to browse' the site.",
+            "根据搜索结果，本周最大的新闻是这次合并。",
+            "文章说该模型无法联网，只能用训练数据。"
+        ]
+    )
+    func ignoresGroundedAnswers(_ text: String) {
+        #expect(!ChatViewModel.looksLikeUngroundedRefusal(text))
+    }
+
+    @Test("Empty text is not a refusal")
+    func emptyIsNotRefusal() {
+        #expect(!ChatViewModel.looksLikeUngroundedRefusal(""))
+    }
+
+    @Test(
+        "Answers that draw on the tool result are recognized as evidence-backed",
+        arguments: [
+            "According to the results, the merger closed on Aug 7.",
+            "Based on the search result, the score is 2-1.",
+            "The full story is here: [report](https://example.com/story)",
+            "The article says the deal is done. [source](https://x.com)",
+            "根据搜索结果，本周最大的新闻是这次合并。"
+        ]
+    )
+    func recognizesEvidenceBackedAnswers(_ text: String) {
+        #expect(ChatViewModel.answerReliesOnEvidence(text))
+    }
+
+    @Test("A bare link is not, by itself, proof the model answered from the tool")
+    func bareLinkAloneIsNotEvidence() {
+        // A refusal that tacks on a raw URL must still be corrected — a bare
+        // link is not a substantive, result-referencing answer.
+        let text = "I can't access current data; see https://example.com"
+        #expect(ChatViewModel.looksLikeUngroundedRefusal(text))
+        #expect(!ChatViewModel.answerReliesOnEvidence(text))
+    }
+
+    @Test(
+        "A disclaimer in front of a grounded answer is NOT treated as a refusal",
+        arguments: [
+            "I can't browse directly, but the tool results show the merger closed Aug 7.",
+            "I don't have real-time data myself, but the search result says it is 2-1.",
+            "我无法联网，但根据搜索结果，合并已完成。"
+        ]
+    )
+    func caveatBeforeGroundedAnswerIsSpared(_ text: String) {
+        // The refusal phrase is present, but the answer visibly relies on the
+        // evidence — so the loop's combined guard must NOT force a correction.
+        #expect(ChatViewModel.looksLikeUngroundedRefusal(text))
+        #expect(ChatViewModel.answerReliesOnEvidence(text))
+    }
+
+    @Test(
+        "A refusal wrapped in a vague connector is still corrected, not spared",
+        arguments: [
+            "According to my knowledge cutoff, I cannot provide current data.",
+            "Based on my training, I don't have access to real-time information.",
+            "Per the usual disclaimer, I can't access current events."
+        ]
+    )
+    func vagueConnectorRefusalIsNotEvidence(_ text: String) {
+        // "according to" / "based on" / "per the" attach to a refusal just as
+        // readily as to a citation, so they must NOT count as grounding — the
+        // combined guard must still force a correction here.
+        #expect(ChatViewModel.looksLikeUngroundedRefusal(text))
+        #expect(!ChatViewModel.answerReliesOnEvidence(text))
+    }
+}
+
+@MainActor
+@Suite("Successful-tool-result scoping")
+struct SuccessfulToolResultScopingTests {
+    private func history(toolStatus: ChatMessage.Status) -> [ChatMessage] {
+        [
+            ChatMessage(role: .user, content: "What's the latest news?"),
+            ChatMessage(
+                role: .assistant,
+                toolCalls: [ToolCall(id: "s1", name: "web_search", arguments: "{}")]
+            ),
+            ChatMessage(
+                role: .tool,
+                content: "web search results: ...",
+                status: toolStatus,
+                toolCallID: "s1"
+            )
+        ]
+    }
+
+    @Test("A failed tool result this turn does not count as a successful one")
+    func failedResultIsNotSuccessful() {
+        let h = history(toolStatus: .failed)
+        // A tool row IS present…
+        #expect(ChatViewModel.carriesToolResultForThisTurn(h))
+        // …but it failed, so the correction must not treat it as fetched data.
+        #expect(!ChatViewModel.carriesSuccessfulToolResultForThisTurn(h))
+    }
+
+    @Test("A completed tool result this turn counts as successful")
+    func completedResultIsSuccessful() {
+        let h = history(toolStatus: .complete)
+        #expect(ChatViewModel.carriesSuccessfulToolResultForThisTurn(h))
+    }
+
+    @Test("A completed-but-empty tool result does not count as successful")
+    func completedButEmptyResultIsNotSuccessful() {
+        let h = [
+            ChatMessage(role: .user, content: "What's the latest news?"),
+            ChatMessage(
+                role: .assistant,
+                toolCalls: [ToolCall(id: "s1", name: "web_search", arguments: "{}")]
+            ),
+            ChatMessage(role: .tool, content: "   ", status: .complete, toolCallID: "s1")
+        ]
+        #expect(ChatViewModel.carriesToolResultForThisTurn(h))
+        #expect(!ChatViewModel.carriesSuccessfulToolResultForThisTurn(h))
+    }
+}
+
+@MainActor
+private final class WebSearchStubRegistry: ToolRegistry {
+    let definitions = [
+        ToolDefinition(
+            name: "web_search",
+            description: "Search the web",
+            parameters: .object(["type": .string("object")])
+        )
+    ]
+
+    func run(_ call: ToolCall) async -> ToolCallResult {
+        ToolCallResult(
+            toolCallID: call.id,
+            content: "Web search results: the Lumen-Nexus merger closed on Aug 7, 2026."
+        )
+    }
+}
+
+private final class ConfabRetryProtocol: URLProtocol, @unchecked Sendable {
+    nonisolated(unsafe) static var requestBodies: [Data] = []
+    nonisolated(unsafe) static var firstAnswer = ""
+    nonisolated(unsafe) static var emptySecondResponse = false
+
+    static func reset(firstAnswer: String) {
+        requestBodies = []
+        self.firstAnswer = firstAnswer
+        emptySecondResponse = false
+    }
+
+    static func session() -> URLSession {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [ConfabRetryProtocol.self]
+        return URLSession(configuration: config)
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        Self.requestBodies.append(readBody(from: request))
+        let requestNumber = Self.requestBodies.count
+        let response = HTTPURLResponse(
+            url: request.url!,
+            statusCode: 200,
+            httpVersion: "HTTP/1.1",
+            headerFields: ["Content-Type": "text/event-stream"]
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+
+        let answer =
+            requestNumber == 1
+            ? Self.firstAnswer
+            : (Self.emptySecondResponse ? "" : kGroundedAnswer)
+        let stream = """
+        data: {"choices":[{"delta":{"content":\(Self.jsonString(answer))},"finish_reason":"stop"}]}
+
+        data: [DONE]
+
+        """
+        client?.urlProtocol(self, didLoad: Data(stream.utf8))
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+
+    private static func jsonString(_ value: String) -> String {
+        let data = try? JSONSerialization.data(
+            withJSONObject: [value],
+            options: [.withoutEscapingSlashes]
+        )
+        // Serialize as a 1-element array then strip the brackets to get a
+        // correctly-escaped JSON string literal.
+        guard let data, let array = String(data: data, encoding: .utf8) else {
+            return "\"\""
+        }
+        return String(array.dropFirst().dropLast())
+    }
+
+    private func readBody(from request: URLRequest) -> Data {
+        guard let input = request.httpBodyStream else { return request.httpBody ?? Data() }
+        input.open()
+        defer { input.close() }
+        var data = Data()
+        var buffer = [UInt8](repeating: 0, count: 4096)
+        while input.hasBytesAvailable {
+            let count = input.read(&buffer, maxLength: buffer.count)
+            guard count > 0 else { break }
+            data.append(buffer, count: count)
+        }
+        return data
+    }
+}

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -389,9 +389,7 @@ class ResidentModelManager:
                 raise
             return record
 
-    async def _replace_group_locked(
-        self, target: ResidencyRecord, group: str
-    ) -> None:
+    async def _replace_group_locked(self, target: ResidencyRecord, group: str) -> None:
         """Make ``target`` the sole unpinned model in a lifecycle group.
 
         The desktop uses the ``assistant`` group for its chat picker: changing
@@ -507,9 +505,7 @@ class ResidentModelManager:
                     "id": record.model_id,
                     "model_path": record.entry.model_path,
                     "aliases": sorted(record.entry.aliases),
-                    "modality": (
-                        _modality(record.entry)
-                    ),
+                    "modality": (_modality(record.entry)),
                     "state": record.state if resident else "registered",
                     "pinned": record.pinned,
                     "primary": record.primary,


### PR DESCRIPTION
## Why
Dogfood report (BUG C): with the built-in web tools, the model sometimes fetches real current data (web_search/browse returning live results) and then still answers *"I can't access real-time information, my knowledge is only up to 2024,"* discarding its own successful fetch. The anti-confabulation preamble (#1556) rides on that turn and mitigates it, but a small local model (e.g. Qwen3.5-4B) can still ignore the instruction. That preamble is the only line of defence today, and it is probabilistic.

## What
A deterministic second layer in `runToolLoop`. After a synthesis turn finishes in prose (`.terminal`), if **a tool result for THIS turn is on the wire** (`carriesToolResultForThisTurn`) **AND** the answer is a first-person temporal-denial refusal (`looksLikeUngroundedRefusal`), the loop forces **exactly one** tools-disabled correction round carrying a failure-specific preamble (`groundingCorrectionPreamble`) that names the mistake: *"the tool result above was fetched just now and IS the current data — answer from it, do not mention a knowledge cutoff."*

Safety properties:
- **One-shot** (`groundingCorrectionUsed`) — cannot loop.
- **Evidence-gated** — only fires when a real tool result is present this turn, so a legitimate "I can't access X" with no tool data is never touched.
- **Epoch + cancellation guarded** — never fires on a superseded/cancelled turn.
- The detector matches only first-person capability denials, so a grounded answer that merely quotes "real-time" or a year *from the tool result* is not flagged.

`num_metal_cap_violations`-style always-on counters and the existing preamble paths are untouched; this is purely additive.

## Tests
`apps/rapid-mac/Tests/RapidTests/GroundingConfabulationRetryTests.swift`:
- A confabulated denial over a live `web_search` result triggers exactly one tools-disabled correction round, and the grounded retry becomes the final answer.
- A clean grounded answer is shipped as-is (no second round).
- Both **fail on the pre-fix loop** — verified by stashing the source change (final answer == the confabulation, `requestBodies.count == 1`).

`UngroundedRefusalDetectionTests`: parameterized positive/negative/empty coverage of `looksLikeUngroundedRefusal`, including grounded answers that mention time words but do not refuse (EN + ZH).

Full `rapid-mac` suite: **1838 tests pass**, no regression.

## Notes
Scoped to the deterministic layer; it does not (and cannot) eliminate all model confabulation, but it converts the most jarring, user-visible failure ("fetched the news, then denied having it") into a single automatic correction. The other dogfood items in the same report (web_search/weather in existing threads, denied-browse re-ask) were verified already fixed on main by #1694/#1696/#1556 and are pinned by existing tests.

🤖 Written by Claude (Opus 4.8, 1M context) at the direction of the repository owner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)