### PR TITLE
feat(mac): add audio transcription, speech, and voice previews

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Audio/AudioClient.swift
+++ b/apps/rapid-mac/Sources/Rapid/Audio/AudioClient.swift
@@ -1,0 +1,395 @@
+import Foundation
+import AVFoundation
+
+struct AudioTranscriptionResult: Equatable, Sendable {
+    let text: String
+    let language: String?
+    let duration: Double?
+}
+
+struct SynthesizedAudio: Equatable, Sendable {
+    let data: Data
+    let contentType: String
+
+    var fileExtension: String {
+        switch contentType.lowercased() {
+        case let type where type.contains("mpeg"): return "mp3"
+        case let type where type.contains("flac"): return "flac"
+        case let type where type.contains("ogg"): return "ogg"
+        default: return "wav"
+        }
+    }
+}
+
+enum AudioClientError: Error, LocalizedError, Equatable {
+    case fileTooLarge(maxBytes: Int)
+    case unreadableFile(String)
+    case http(status: Int, message: String?)
+    case invalidResponse
+    case emptyAudio
+    case transport(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .fileTooLarge(let maxBytes):
+            return "That file is larger than \(maxBytes / 1024 / 1024) MB. Choose a shorter recording."
+        case .unreadableFile(let detail):
+            return "The audio file couldn't be read: \(detail)"
+        case .http(let status, let message):
+            return message ?? "Audio request failed (HTTP \(status))."
+        case .invalidResponse:
+            return "The audio server returned an unreadable response."
+        case .emptyAudio:
+            return "The audio server returned no sound."
+        case .transport(let detail):
+            return detail
+        }
+    }
+}
+
+/// Native loopback client for the OpenAI-compatible audio routes. Port and
+/// bearer are supplied per request because both rotate when ServerManager
+/// replaces the single resident model.
+struct AudioClient {
+    static let maxUploadBytes = 25 * 1024 * 1024
+    static let requestTimeout: TimeInterval = 30 * 60
+
+    static let sharedSession: URLSession = {
+        let config = URLSessionConfiguration.ephemeral
+        config.timeoutIntervalForRequest = requestTimeout
+        config.timeoutIntervalForResource = requestTimeout
+        return URLSession(configuration: config)
+    }()
+
+    var session: URLSession = AudioClient.sharedSession
+
+    private struct TranscriptionWire: Decodable {
+        let text: String
+        let language: String?
+        let duration: Double?
+    }
+
+    private struct VoicesWire: Decodable { let voices: [String] }
+
+    private struct SpeechBody: Encodable {
+        let model: String
+        let input: String
+        let voice: String
+        let speed: Double
+        let response_format = "wav"
+    }
+
+    func transcribe(
+        fileURL: URL,
+        model: String,
+        port: Int,
+        bearer: String?
+    ) async throws -> AudioTranscriptionResult {
+        let upload: AudioUpload
+        do {
+            upload = try await Task.detached(priority: .userInitiated) {
+                let values = try fileURL.resourceValues(forKeys: [.fileSizeKey])
+                if let size = values.fileSize, size > Self.maxUploadBytes {
+                    throw AudioClientError.fileTooLarge(maxBytes: Self.maxUploadBytes)
+                }
+                let data = try Data(contentsOf: fileURL, options: [.mappedIfSafe])
+                guard data.count <= Self.maxUploadBytes else {
+                    throw AudioClientError.fileTooLarge(maxBytes: Self.maxUploadBytes)
+                }
+                let ext = Self.safeExtension(fileURL.pathExtension)
+                if AudioUploadTranscoder.requiresWAV(ext) {
+                    let wav = try AudioUploadTranscoder.wavData(
+                        from: fileURL,
+                        maxBytes: Self.maxUploadBytes
+                    )
+                    return AudioUpload(data: wav, fileExtension: "wav", mimeType: "audio/wav")
+                }
+                return AudioUpload(
+                    data: data,
+                    fileExtension: ext,
+                    mimeType: Self.mimeType(forExtension: ext)
+                )
+            }.value
+        } catch let error as AudioClientError {
+            throw error
+        } catch {
+            throw AudioClientError.unreadableFile(error.localizedDescription)
+        }
+
+        let boundary = "rapid-audio-\(UUID().uuidString)"
+        var request = URLRequest(
+            url: Self.loopbackURL(port: port)
+                .appendingPathComponent("v1/audio/transcriptions")
+        )
+        request.httpMethod = "POST"
+        request.timeoutInterval = Self.requestTimeout
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue(
+            "multipart/form-data; boundary=\(boundary)",
+            forHTTPHeaderField: "Content-Type"
+        )
+        applyBearer(&request, bearer)
+        request.httpBody = ImageClient.multipartBody(
+            boundary: boundary,
+            fields: [("model", model), ("response_format", "json")],
+            fileField: "file",
+            fileName: "input.\(upload.fileExtension)",
+            fileMime: upload.mimeType,
+            fileData: upload.data
+        )
+
+        let (data, response) = try await send(request)
+        try validate(response: response, data: data)
+        guard let decoded = try? JSONDecoder().decode(TranscriptionWire.self, from: data) else {
+            throw AudioClientError.invalidResponse
+        }
+        return AudioTranscriptionResult(
+            text: decoded.text,
+            language: decoded.language,
+            duration: decoded.duration
+        )
+    }
+
+    func voices(
+        model: String,
+        port: Int,
+        bearer: String?
+    ) async throws -> [String] {
+        var components = URLComponents(
+            url: Self.loopbackURL(port: port).appendingPathComponent("v1/audio/voices"),
+            resolvingAgainstBaseURL: false
+        )!
+        components.queryItems = [URLQueryItem(name: "model", value: model)]
+        var request = URLRequest(url: components.url!)
+        request.timeoutInterval = Self.requestTimeout
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        applyBearer(&request, bearer)
+        let (data, response) = try await send(request)
+        try validate(response: response, data: data)
+        guard let decoded = try? JSONDecoder().decode(VoicesWire.self, from: data) else {
+            throw AudioClientError.invalidResponse
+        }
+        return decoded.voices
+    }
+
+    func synthesize(
+        text: String,
+        model: String,
+        voice: String,
+        speed: Double,
+        port: Int,
+        bearer: String?
+    ) async throws -> SynthesizedAudio {
+        var request = URLRequest(
+            url: Self.loopbackURL(port: port).appendingPathComponent("v1/audio/speech")
+        )
+        request.httpMethod = "POST"
+        request.timeoutInterval = Self.requestTimeout
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("audio/wav", forHTTPHeaderField: "Accept")
+        applyBearer(&request, bearer)
+        request.httpBody = try JSONEncoder().encode(
+            SpeechBody(model: model, input: text, voice: voice, speed: speed)
+        )
+        let (data, response) = try await send(request)
+        try validate(response: response, data: data)
+        guard !data.isEmpty else { throw AudioClientError.emptyAudio }
+        let contentType = (response as? HTTPURLResponse)?
+            .value(forHTTPHeaderField: "Content-Type") ?? "audio/wav"
+        return SynthesizedAudio(data: data, contentType: contentType)
+    }
+
+    private static func loopbackURL(port: Int) -> URL {
+        URL(string: "http://127.0.0.1:\(port)")!
+    }
+
+    private func applyBearer(_ request: inout URLRequest, _ bearer: String?) {
+        if let bearer, !bearer.isEmpty {
+            request.setValue("Bearer \(bearer)", forHTTPHeaderField: "Authorization")
+        }
+    }
+
+    private func send(_ request: URLRequest) async throws -> (Data, URLResponse) {
+        do {
+            return try await session.data(for: request)
+        } catch let error as AudioClientError {
+            throw error
+        } catch {
+            throw AudioClientError.transport(error.localizedDescription)
+        }
+    }
+
+    private func validate(response: URLResponse, data: Data) throws {
+        guard let http = response as? HTTPURLResponse else {
+            throw AudioClientError.invalidResponse
+        }
+        guard (200...299).contains(http.statusCode) else {
+            throw AudioClientError.http(
+                status: http.statusCode,
+                message: Self.errorMessage(from: data)
+            )
+        }
+    }
+
+    static func errorMessage(from data: Data) -> String? {
+        guard let root = try? JSONSerialization.jsonObject(with: data) else { return nil }
+        return findMessage(root)
+    }
+
+    private static func findMessage(_ value: Any) -> String? {
+        if let string = value as? String, !string.isEmpty { return string }
+        if let dict = value as? [String: Any] {
+            if let message = dict["message"] as? String, !message.isEmpty { return message }
+            for key in ["error", "detail"] {
+                if let nested = dict[key], let message = findMessage(nested) { return message }
+            }
+        }
+        return nil
+    }
+
+    private static func safeExtension(_ raw: String) -> String {
+        let lower = raw.lowercased()
+        let allowed = Set(["wav", "mp3", "m4a", "aac", "flac", "ogg", "opus", "webm", "mp4"])
+        return allowed.contains(lower) ? lower : "audio"
+    }
+
+    private static func mimeType(forExtension ext: String) -> String {
+        switch ext {
+        case "wav": return "audio/wav"
+        case "mp3": return "audio/mpeg"
+        case "m4a", "mp4": return "audio/mp4"
+        case "aac": return "audio/aac"
+        case "flac": return "audio/flac"
+        case "ogg", "opus": return "audio/ogg"
+        case "webm": return "audio/webm"
+        default: return "application/octet-stream"
+        }
+    }
+}
+
+private struct AudioUpload: Sendable {
+    let data: Data
+    let fileExtension: String
+    let mimeType: String
+}
+
+enum AudioUploadTranscoder {
+    static let wavSampleRate = 16_000.0
+    private static let wavChannels: AVAudioChannelCount = 1
+    private static let bytesPerFrame = 2
+
+    static func requiresWAV(_ fileExtension: String) -> Bool {
+        ["m4a", "mp4", "aac"].contains(fileExtension.lowercased())
+    }
+
+    /// Decode Apple-native compressed containers and normalize them to the
+    /// format Whisper expects. AVAudioFile exposes decoded PCM through
+    /// ``processingFormat``, so the converter never has to understand AAC.
+    static func wavData(from sourceURL: URL, maxBytes: Int) throws -> Data {
+        let source = try AVAudioFile(forReading: sourceURL)
+        let sourceFormat = source.processingFormat
+        guard source.length > 0,
+              source.length <= AVAudioFramePosition(UInt32.max),
+              let input = AVAudioPCMBuffer(
+                  pcmFormat: sourceFormat,
+                  frameCapacity: AVAudioFrameCount(source.length)
+              ) else {
+            throw AudioClientError.unreadableFile("The recording contains no decodable audio frames.")
+        }
+        try source.read(into: input)
+        guard input.frameLength > 0 else {
+            throw AudioClientError.unreadableFile("The recording contains no decodable audio frames.")
+        }
+
+        guard let outputFormat = AVAudioFormat(
+            commonFormat: .pcmFormatInt16,
+            sampleRate: wavSampleRate,
+            channels: wavChannels,
+            interleaved: false
+        ), let converter = AVAudioConverter(from: sourceFormat, to: outputFormat) else {
+            throw AudioClientError.unreadableFile("macOS couldn't create an audio converter for this recording.")
+        }
+
+        let ratio = wavSampleRate / sourceFormat.sampleRate
+        let outputFrames = Int(ceil(Double(input.frameLength) * ratio)) + 32
+        let estimatedBytes = outputFrames * bytesPerFrame + 44
+        guard estimatedBytes <= maxBytes else {
+            throw AudioClientError.fileTooLarge(maxBytes: maxBytes)
+        }
+        guard outputFrames <= Int(UInt32.max),
+              let output = AVAudioPCMBuffer(
+                  pcmFormat: outputFormat,
+                  frameCapacity: AVAudioFrameCount(outputFrames)
+              ) else {
+            throw AudioClientError.unreadableFile("The decoded recording is too long.")
+        }
+
+        let inputState = AudioConverterInput(buffer: input)
+        var conversionError: NSError?
+        let status = converter.convert(to: output, error: &conversionError) { _, inputStatus in
+            inputState.next(status: inputStatus)
+        }
+        guard status != .error, conversionError == nil,
+              output.frameLength > 0,
+              let samples = output.int16ChannelData?[0] else {
+            throw AudioClientError.unreadableFile(
+                conversionError?.localizedDescription ?? "macOS couldn't decode this audio file."
+            )
+        }
+
+        let pcmByteCount = Int(output.frameLength) * bytesPerFrame
+        guard pcmByteCount + 44 <= maxBytes else {
+            throw AudioClientError.fileTooLarge(maxBytes: maxBytes)
+        }
+        return makeWAV(samples: samples, byteCount: pcmByteCount)
+    }
+
+    private static func makeWAV(samples: UnsafePointer<Int16>, byteCount: Int) -> Data {
+        var data = Data()
+        data.reserveCapacity(44 + byteCount)
+        data.append(contentsOf: "RIFF".utf8)
+        appendLittleEndian(UInt32(36 + byteCount), to: &data)
+        data.append(contentsOf: "WAVE".utf8)
+        data.append(contentsOf: "fmt ".utf8)
+        appendLittleEndian(UInt32(16), to: &data)
+        appendLittleEndian(UInt16(1), to: &data)
+        appendLittleEndian(UInt16(wavChannels), to: &data)
+        appendLittleEndian(UInt32(wavSampleRate), to: &data)
+        appendLittleEndian(UInt32(Int(wavSampleRate) * bytesPerFrame), to: &data)
+        appendLittleEndian(UInt16(bytesPerFrame), to: &data)
+        appendLittleEndian(UInt16(16), to: &data)
+        data.append(contentsOf: "data".utf8)
+        appendLittleEndian(UInt32(byteCount), to: &data)
+        data.append(UnsafeRawPointer(samples).assumingMemoryBound(to: UInt8.self), count: byteCount)
+        return data
+    }
+
+    private static func appendLittleEndian<T: FixedWidthInteger>(_ value: T, to data: inout Data) {
+        var littleEndian = value.littleEndian
+        Swift.withUnsafeBytes(of: &littleEndian) { data.append(contentsOf: $0) }
+    }
+}
+
+private final class AudioConverterInput: @unchecked Sendable {
+    private let buffer: AVAudioPCMBuffer
+    private let lock = NSLock()
+    private var supplied = false
+
+    init(buffer: AVAudioPCMBuffer) {
+        self.buffer = buffer
+    }
+
+    func next(
+        status: UnsafeMutablePointer<AVAudioConverterInputStatus>
+    ) -> AVAudioBuffer? {
+        lock.lock()
+        defer { lock.unlock() }
+        guard !supplied else {
+            status.pointee = .endOfStream
+            return nil
+        }
+        supplied = true
+        status.pointee = .haveData
+        return buffer
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/Audio/AudioViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Audio/AudioViewModel.swift
@@ -1,0 +1,279 @@
+import Foundation
+import Observation
+
+@MainActor
+@Observable
+final class AudioViewModel {
+    enum Mode: String, CaseIterable, Identifiable {
+        case speech
+        case transcription
+
+        var id: String { rawValue }
+        var label: String {
+            switch self {
+            case .transcription: return "Transcription"
+            case .speech: return "Speech"
+            }
+        }
+    }
+
+    var mode: Mode = .speech
+    var audioModels: [ModelEntry] = []
+    var catalogLoaded = false
+    var selectedTranscriptionAlias = ""
+    var selectedSpeechAlias = ""
+
+    var selectedFileURL: URL?
+    var transcription: AudioTranscriptionResult?
+    var speechText = ""
+    var voices: [String] = []
+    var selectedVoice = ""
+    var speed = 1.0
+    var synthesizedAudio: SynthesizedAudio?
+
+    var isTranscribing = false
+    var isLoadingVoices = false
+    var isSynthesizing = false
+    var previewingVoice: String?
+    var errorMessage: String?
+
+    private let server: ServerManager
+    private let client: AudioClient
+
+    init(server: ServerManager, client: AudioClient = AudioClient()) {
+        self.server = server
+        self.client = client
+    }
+
+    var transcriptionModels: [ModelEntry] {
+        audioModels.filter {
+            $0.audioCapability?.supportsTranscription == true
+                && ModelCatalog.isDesktopAudioAliasVisible($0.alias)
+        }
+    }
+
+    var speechModels: [ModelEntry] {
+        // The signed desktop sidecar intentionally bundles the compact MLX
+        // audio core, not Kokoro's spaCy/espeak language stack or F5 cloning.
+        // Qwen3 CustomVoice is reference-free, has real named speakers, and
+        // runs entirely on dependencies in the desktop audio extra.
+        audioModels.filter {
+            $0.audioCapability?.supportsPresetSpeech == true
+                && $0.audioFamily == "qwen3_tts"
+        }
+    }
+
+    var isBusy: Bool {
+        isTranscribing || isLoadingVoices || isSynthesizing || previewingVoice != nil
+    }
+
+    func refreshCatalog() async {
+        guard let binary = server.binaryPath else {
+            audioModels = []
+            catalogLoaded = true
+            return
+        }
+        audioModels = await ModelCatalog.audioEntries(binary: binary)
+        catalogLoaded = true
+        resolveSelections()
+    }
+
+    func selectFile(_ url: URL) {
+        selectedFileURL = url
+        transcription = nil
+        errorMessage = nil
+    }
+
+    func selectSpeechModel(_ alias: String) {
+        guard alias != selectedSpeechAlias else { return }
+        selectedSpeechAlias = alias
+        voices = []
+        selectedVoice = ""
+        synthesizedAudio = nil
+        errorMessage = nil
+    }
+
+    func transcribe() async {
+        guard !isBusy,
+              let fileURL = selectedFileURL,
+              let entry = transcriptionModels.first(where: {
+                  $0.alias == selectedTranscriptionAlias
+              }) else { return }
+        isTranscribing = true
+        errorMessage = nil
+        transcription = nil
+        defer { isTranscribing = false }
+        guard await server.ensureServing(alias: entry.alias, hfPath: entry.hfRepo) else {
+            errorMessage = "The audio model couldn't start. Audio support may be unavailable in this app build."
+            return
+        }
+        do {
+            transcription = try await client.transcribe(
+                fileURL: fileURL,
+                model: entry.alias,
+                port: server.activePort,
+                bearer: server.activeBearer
+            )
+        } catch {
+            errorMessage = Self.message(for: error)
+        }
+    }
+
+    func loadVoices() async -> Bool {
+        guard !isBusy,
+              let entry = speechModels.first(where: { $0.alias == selectedSpeechAlias }) else {
+            return false
+        }
+        isLoadingVoices = true
+        errorMessage = nil
+        defer { isLoadingVoices = false }
+        guard await server.ensureServing(alias: entry.alias, hfPath: entry.hfRepo) else {
+            errorMessage = "The speech model couldn't start. Audio support may be unavailable in this app build."
+            return false
+        }
+        do {
+            let loaded = try await client.voices(
+                model: entry.alias,
+                port: server.activePort,
+                bearer: server.activeBearer
+            )
+            guard !loaded.isEmpty else {
+                errorMessage = "This model did not report any available voices."
+                return false
+            }
+            voices = loaded
+            if !loaded.contains(selectedVoice) { selectedVoice = loaded[0] }
+            return true
+        } catch {
+            errorMessage = Self.message(for: error)
+            return false
+        }
+    }
+
+    func synthesize() async {
+        let trimmed = speechText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !isBusy, !trimmed.isEmpty,
+              let entry = speechModels.first(where: { $0.alias == selectedSpeechAlias }) else {
+            return
+        }
+        if voices.isEmpty {
+            guard await loadVoices() else { return }
+        }
+        guard !selectedVoice.isEmpty else { return }
+
+        isSynthesizing = true
+        errorMessage = nil
+        synthesizedAudio = nil
+        defer { isSynthesizing = false }
+        guard await server.ensureServing(alias: entry.alias, hfPath: entry.hfRepo) else {
+            errorMessage = "The speech model is no longer running. Load its voices and try again."
+            return
+        }
+        do {
+            synthesizedAudio = try await client.synthesize(
+                text: trimmed,
+                model: entry.alias,
+                voice: selectedVoice,
+                speed: speed,
+                port: server.activePort,
+                bearer: server.activeBearer
+            )
+        } catch {
+            errorMessage = Self.message(for: error)
+        }
+    }
+
+    func previewVoice(_ voice: String) async -> SynthesizedAudio? {
+        guard !isBusy, voices.contains(voice),
+              let entry = speechModels.first(where: { $0.alias == selectedSpeechAlias }) else {
+            return nil
+        }
+
+        previewingVoice = voice
+        errorMessage = nil
+        defer { previewingVoice = nil }
+
+        guard await server.ensureServing(alias: entry.alias, hfPath: entry.hfRepo),
+              !Task.isCancelled else {
+            if !Task.isCancelled {
+                errorMessage = "The speech model is no longer running. Load its voices and try again."
+            }
+            return nil
+        }
+
+        do {
+            return try await client.synthesize(
+                text: Self.previewText(for: voice),
+                model: entry.alias,
+                voice: voice,
+                speed: speed,
+                port: server.activePort,
+                bearer: server.activeBearer
+            )
+        } catch {
+            if !Task.isCancelled {
+                errorMessage = Self.message(for: error)
+            }
+            return nil
+        }
+    }
+
+    static func voiceDetails(for voice: String) -> String {
+        switch voice.lowercased() {
+        case "vivian", "serena": return "Chinese · Female"
+        case "uncle_fu": return "Chinese · Male"
+        case "dylan": return "Chinese · Beijing · Male"
+        case "eric": return "Chinese · Sichuan · Male"
+        case "ryan", "aiden": return "English · Male"
+        case "ono_anna": return "Japanese · Female"
+        case "sohee": return "Korean · Female"
+        default: return "Multilingual"
+        }
+    }
+
+    static func previewText(for voice: String) -> String {
+        switch voice.lowercased() {
+        case "vivian", "serena", "uncle_fu", "dylan", "eric":
+            return "你好，这是我的声音，很高兴认识你。"
+        case "ono_anna":
+            return "こんにちは、私の声を聞いてください。"
+        case "sohee":
+            return "안녕하세요, 제 목소리를 들어 보세요."
+        default:
+            return "Hello, this is a preview of my voice."
+        }
+    }
+
+    func wouldReplaceServingModel(alias: String) -> String? {
+        guard let serving = server.servingAlias, serving != alias else { return nil }
+        return serving
+    }
+
+    private func resolveSelections() {
+        if !transcriptionModels.contains(where: { $0.alias == selectedTranscriptionAlias }) {
+            selectedTranscriptionAlias = preferredAlias(
+                from: transcriptionModels,
+                preferred: ["whisper-small", "whisper-large-v3-turbo", "whisper-large-v3"]
+            )
+        }
+        if !speechModels.contains(where: { $0.alias == selectedSpeechAlias }) {
+            selectedSpeechAlias = preferredAlias(
+                from: speechModels,
+                preferred: ["qwen3-tts-4bit", "qwen3-tts-6bit", "qwen3-tts"]
+            )
+        }
+    }
+
+    private func preferredAlias(from entries: [ModelEntry], preferred: [String]) -> String {
+        if let cached = entries.first(where: { $0.cached }) { return cached.alias }
+        for alias in preferred where entries.contains(where: { $0.alias == alias }) { return alias }
+        return entries.first?.alias ?? ""
+    }
+
+    private static func message(for error: Error) -> String {
+        if let localized = error as? LocalizedError, let message = localized.errorDescription {
+            return message
+        }
+        return error.localizedDescription
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/Audio/AudioViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Audio/AudioViewModel.swift
@@ -103,7 +103,11 @@ final class AudioViewModel {
         errorMessage = nil
         transcription = nil
         defer { isTranscribing = false }
-        guard await server.ensureServing(alias: entry.alias, hfPath: entry.hfRepo) else {
+        guard await server.ensureServing(
+            alias: entry.alias,
+            hfPath: entry.hfRepo,
+            residencyEligible: false
+        ) else {
             errorMessage = "The audio model couldn't start. Audio support may be unavailable in this app build."
             return
         }
@@ -127,7 +131,11 @@ final class AudioViewModel {
         isLoadingVoices = true
         errorMessage = nil
         defer { isLoadingVoices = false }
-        guard await server.ensureServing(alias: entry.alias, hfPath: entry.hfRepo) else {
+        guard await server.ensureServing(
+            alias: entry.alias,
+            hfPath: entry.hfRepo,
+            residencyEligible: false
+        ) else {
             errorMessage = "The speech model couldn't start. Audio support may be unavailable in this app build."
             return false
         }
@@ -165,7 +173,11 @@ final class AudioViewModel {
         errorMessage = nil
         synthesizedAudio = nil
         defer { isSynthesizing = false }
-        guard await server.ensureServing(alias: entry.alias, hfPath: entry.hfRepo) else {
+        guard await server.ensureServing(
+            alias: entry.alias,
+            hfPath: entry.hfRepo,
+            residencyEligible: false
+        ) else {
             errorMessage = "The speech model is no longer running. Load its voices and try again."
             return
         }
@@ -193,7 +205,11 @@ final class AudioViewModel {
         errorMessage = nil
         defer { previewingVoice = nil }
 
-        guard await server.ensureServing(alias: entry.alias, hfPath: entry.hfRepo),
+        guard await server.ensureServing(
+                  alias: entry.alias,
+                  hfPath: entry.hfRepo,
+                  residencyEligible: false
+              ),
               !Task.isCancelled else {
             if !Task.isCancelled {
                 errorMessage = "The speech model is no longer running. Load its voices and try again."

--- a/apps/rapid-mac/Sources/Rapid/DevSnapshot.swift
+++ b/apps/rapid-mac/Sources/Rapid/DevSnapshot.swift
@@ -47,6 +47,7 @@ enum DevSnapshot {
         // environment (the Images tab). Same rule as ``browseApproval``: a
         // throwaway instance so the view can be evaluated without trapping.
         let imageGen = ImageGenViewModel(server: server)
+        let audio = AudioViewModel(server: server)
 
         // Erase to AnyView so the long environment chain stays cheap to
         // type-check and the render call is monomorphic.
@@ -66,6 +67,7 @@ enum DevSnapshot {
                     .environment(dockPromptStore)
                     .environment(browseApproval)
                     .environment(imageGen)
+                    .environment(audio)
                     .frame(width: width, height: height)
             )
         }

--- a/apps/rapid-mac/Sources/Rapid/RapidApp.swift
+++ b/apps/rapid-mac/Sources/Rapid/RapidApp.swift
@@ -33,6 +33,9 @@ struct RapidApp: App {
     /// alias. It keeps its own UI state while sharing the resident-model
     /// sidecar with Chat.
     @State private var imageGen: ImageGenViewModel
+    /// Local speech-to-text and text-to-speech workflows. Like Images, this
+    /// shares the one embedded server and swaps models only on explicit work.
+    @State private var audio: AudioViewModel
     /// Self-update poller. GETs a public static manifest on R2 at
     /// `https://dl.rapidmlx.com/latest.json`. See ``UpdateChecker``.
     @State private var updater: UpdateChecker
@@ -201,6 +204,7 @@ struct RapidApp: App {
         AppDelegate.shared.dockPromptStore = dockPrompt
         _chatViewModel = State(initialValue: chat)
         _imageGen = State(initialValue: ImageGenViewModel(server: manager))
+        _audio = State(initialValue: AudioViewModel(server: manager))
         _updater = State(initialValue: updateChecker)
         _installer = State(initialValue: installerInstance)
         _sampling = State(initialValue: samplingConfig)
@@ -228,6 +232,7 @@ struct RapidApp: App {
                 .environment(downloads)
                 .environment(chatViewModel)
                 .environment(imageGen)
+                .environment(audio)
                 .environment(updater)
                 .environment(sampling)
                 .environment(appearance)

--- a/apps/rapid-mac/Sources/Rapid/Server/ModelCatalog.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ModelCatalog.swift
@@ -1,20 +1,37 @@
 import Foundation
 
 /// What a model is *for*. Drives the capability tabs in Model Management —
-/// chat models and image models are managed side by side but never mixed in
-/// one list (and are picked in different tabs). Video is reserved for when
-/// the video lane surfaces manageable aliases.
+/// chat, image, and audio models are managed side by side but never mixed in
+/// one list (and are picked in different surfaces). Video is reserved for
+/// when the video lane surfaces manageable aliases.
 enum ModelKind: String, Sendable, Hashable, CaseIterable, Identifiable {
-    case chat, image, video
+    case chat, image, audio, video
     var id: String { rawValue }
     /// Tab label in Model Management.
     var tabLabel: String {
         switch self {
         case .chat: return "Chat"
         case .image: return "Image"
+        case .audio: return "Audio"
         case .video: return "Video"
         }
     }
+}
+
+/// The user-facing operation an audio checkpoint can actually perform.
+/// The engine's registry intentionally groups forced alignment under `stt`
+/// and several reference-driven models under `tts`; the desktop needs the
+/// finer distinction so its simple transcription and preset-voice pickers do
+/// not offer models that require inputs those flows do not collect.
+enum AudioModelCapability: String, Sendable, Hashable {
+    case transcription
+    case alignment
+    case speech
+    case voiceCloning
+    case voiceDesign
+
+    var supportsTranscription: Bool { self == .transcription }
+    var supportsPresetSpeech: Bool { self == .speech }
 }
 
 /// One model in the rapid-mlx catalog. The picker UI groups cached vs.
@@ -48,6 +65,11 @@ struct ModelEntry: Identifiable, Hashable, Sendable {
     /// construction site keeps working; the image catalog tags ``.image``.
     var kind: ModelKind = .chat
 
+    /// Audio-only metadata parsed from the engine registry table. `nil` for
+    /// chat/image/video rows.
+    var audioCapability: AudioModelCapability? = nil
+    var audioFamily: String? = nil
+
     var id: String { alias }
 }
 
@@ -67,6 +89,10 @@ enum ModelCatalog {
     static let maxAliasBytes = 128
     static let maxHuggingFaceRepoBytes = 192
     static let maxSubprocessStdoutBytes = 1_048_576
+    /// Tiny Whisper is fast, but its transcription accuracy is below the
+    /// desktop workflow's quality floor. Keep the engine alias available to
+    /// CLI users while omitting it from the GUI catalog.
+    private static let hiddenDesktopAudioAliases: Set<String> = ["whisper-tiny"]
     private static let maxSubprocessStderrBytes = 256 * 1024
     private static let pipeReadChunkBytes = 16 * 1024
 
@@ -466,6 +492,95 @@ enum ModelCatalog {
         }
     }
 
+    /// Audio aliases for Settings and the dedicated Audio surface. Cached
+    /// state is matched by HF repo because `rapid-mlx ls` currently reports
+    /// audio snapshots as `(unmapped)` rather than reverse-mapping the audio
+    /// registry's alias.
+    static func audioEntries(
+        binary: URL,
+        hubCacheOverride: URL? = ModelsFolderPreference.validatedOverrideURL()
+    ) async -> [ModelEntry] {
+        async let modelsOut = runRapidMlx(binary: binary, args: ["models"])
+        async let cachedTask: [(String, String?, String?)] = listCached(
+            binary: binary,
+            hubCacheOverride: hubCacheOverride
+        )
+        let rows = parseAudioRows(await modelsOut).filter {
+            isDesktopAudioAliasVisible($0.alias)
+        }
+        let cachedByRepo = Dictionary(
+            (await cachedTask).compactMap { alias, repo, size -> (String, String?)? in
+                guard let repo else { return nil }
+                return (repo, size)
+            },
+            uniquingKeysWith: { first, _ in first }
+        )
+        return rows.map { row in
+            ModelEntry(
+                alias: row.alias,
+                hfRepo: row.hfRepo,
+                sizeOnDisk: row.hfRepo.flatMap { cachedByRepo[$0] } ?? row.size,
+                cached: row.hfRepo.map { cachedByRepo[$0] != nil } ?? false,
+                kind: .audio,
+                audioCapability: audioCapability(
+                    alias: row.alias,
+                    subtype: row.subtype,
+                    family: row.family
+                ),
+                audioFamily: row.family
+            )
+        }
+    }
+
+    static func isDesktopAudioAliasVisible(_ alias: String) -> Bool {
+        !hiddenDesktopAudioAliases.contains(alias)
+    }
+
+    /// Parse rows shaped as:
+    /// `kokoro  338.9 MiB  [audio:tts]  kokoro  mlx-community/Kokoro...`.
+    /// The family column is retained because the registry's broad `stt`/`tts`
+    /// type does not distinguish aligners and reference-driven speech models.
+    static func parseAudioRows(
+        _ output: String
+    ) -> [(alias: String, hfRepo: String?, size: String?, subtype: String, family: String?)] {
+        var rows: [(String, String?, String?, String, String?)] = []
+        for rawLine in output.split(separator: "\n", omittingEmptySubsequences: true) {
+            let line = String(rawLine).trimmingCharacters(in: .whitespaces)
+            let fields = line.split(whereSeparator: { $0.isWhitespace }).map(String.init)
+            guard let alias = fields.first, isSafeAlias(alias),
+                  let tagIdx = fields.firstIndex(where: {
+                      $0.hasPrefix("[audio:") && $0.hasSuffix("]")
+                  }) else { continue }
+            let tag = fields[tagIdx]
+            let subtype = String(tag.dropFirst("[audio:".count).dropLast())
+            guard subtype == "tts" || subtype == "stt" else { continue }
+            let family = tagIdx + 1 < fields.count ? fields[tagIdx + 1] : nil
+            let hfRepo = tagIdx + 2 < fields.count
+                ? sanitizedHuggingFaceRepo(fields[tagIdx + 2])
+                : nil
+            let size = tagIdx > 1 ? fields[1..<tagIdx].joined(separator: " ") : nil
+            rows.append((alias, hfRepo, size, subtype, family))
+        }
+        return rows
+    }
+
+    /// Refine the registry's broad audio type into the operations the desktop
+    /// currently exposes. Kept pure so capability filtering is regression
+    /// tested without starting an audio engine.
+    static func audioCapability(
+        alias: String,
+        subtype: String,
+        family: String?
+    ) -> AudioModelCapability {
+        if subtype == "stt" {
+            return family == "qwen3_aligner" ? .alignment : .transcription
+        }
+        let lower = alias.lowercased()
+        if lower.contains("voicedesign") { return .voiceDesign }
+        if family == "indextts" || lower == "qwen3-tts-clone" { return .voiceCloning }
+        return .speech
+    }
+
     /// Parse ``[image:gen]``-tagged rows into ``(alias, hfRepo, size)``.
     /// Row shape (see cli.py image section):
     /// ``flux-schnell-4bit    8.9 GiB    [image:gen] dhairyashil/FLUX...``.
@@ -561,26 +676,14 @@ enum ModelCatalog {
             if line.hasPrefix("Available models") { continue }
             if line.hasPrefix("Alias") { continue }
             if line.allSatisfy({ $0 == "─" || $0 == "-" || $0.isWhitespace }) { continue }
-            // Drop audio-only aliases (TTS/STT: kokoro, whisper, parakeet,
-            // dia, chatterbox, vibevoice, voxcpm — 26 aliases). The desktop
-            // has no audio-input UI, and the shipped sidecar is built without
-            // the `mlx-audio` dependency, so selecting one and pressing Start
-            // fails the server ("model 'X' is an audio alias and requires the
-            // optional `mlx-audio` dependency … pip install 'rapid-mlx[audio]'")
-            // — an un-actionable dead-end for a desktop user with no terminal
-            // into the bundled engine. `rapid-mlx models` lists them under an
-            // "Audio models (N aliases)" section and tags every row with an
-            // `[audio:tts]` / `[audio:stt]` Kind column. Skip the section
-            // header — which would otherwise leak a phantom "Audio" alias
-            // (its first token passes ``isSafeAlias``) — and skip every tagged
-            // row (matching on the `[audio:` tag is robust to section
-            // ordering and to audio rows ever appearing inline). If the
-            // desktop ever grows a dictation/transcription surface, that is a
-            // separate feature that would re-admit these deliberately; until
-            // then they must not be promoted in any catalog consumer (picker,
-            // Model Management, auto-start).
+            // Audio-only aliases belong to the dedicated Audio surface and
+            // Model Management tab, never the chat picker or chat auto-start.
+            // Skip the section header — whose first token would otherwise
+            // pass ``isSafeAlias`` as a phantom "Audio" model. Tagged rows are
+            // rejected by ``hasNonChatKindTag`` below using a complete Kind
+            // token, so an HF id that merely contains "[audio:" cannot hide an
+            // unrelated chat row.
             if line.hasPrefix("Audio models") { continue }
-            if line.contains("[audio:") { continue }
             // Video-generation aliases, same reasoning and same shape.
             // A ``video-gen`` model has no tokenizer and no
             // ``stream_chat``, so it can never answer a chat request; the
@@ -667,12 +770,14 @@ enum ModelCatalog {
             // Same banner guard as ``parseAvailable`` — `ls` shares the
             // engine's stdout too.
             if isBannerLine(line) { continue }
-            // Multi-space splitting: each column is separated by 2+
-            // spaces.  ``components(separatedBy: doubleSpaces)`` would
-            // need a custom CharacterSet; cheaper to regex.
-            let parts = splitOnMultiSpace(line)
-            guard parts.count >= 2 else { continue }
-            let alias = parts[0]
+            // Alias and HF repo IDs cannot contain whitespace, so parse
+            // those fields as tokens rather than by visual column spacing.
+            // Rich leaves only one space after a repo that fills the column
+            // width (for example Qwen3-TTS CustomVoice). A 2+-space split
+            // would merge that repo with "2.2 GiB" and reject it as invalid.
+            let fields = line.split(whereSeparator: { $0.isWhitespace }).map(String.init)
+            guard fields.count >= 2 else { continue }
+            let alias = fields[0]
             // ``(unmapped)`` and ``(external)`` are the two status values the
             // engine may put in the alias column that still carry a real
             // repo. Every other parenthesized value — ``(incomplete)`` — is
@@ -684,8 +789,15 @@ enum ModelCatalog {
             guard alias == "(unmapped)" || alias == "(external)" || isSafeAlias(alias) else {
                 continue
             }
-            let hf = parts.count >= 2 ? sanitizedHuggingFaceRepo(parts[1]) : nil
-            let size = parts.count >= 3 ? parts[2] : nil
+            let hf = sanitizedHuggingFaceRepo(fields[1])
+            // Size is a two-token cell ("2.2 GiB"); anything shorter means the
+            // row carried no measured size.
+            let size: String?
+            if fields.count >= 4 {
+                size = "\(fields[2]) \(fields[3])"
+            } else {
+                size = fields.count == 3 ? fields[2] : nil
+            }
             entries.append((alias, hf, size))
         }
         return entries

--- a/apps/rapid-mac/Sources/Rapid/Server/ModelDeletion.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ModelDeletion.swift
@@ -38,6 +38,7 @@ enum ModelDeletion {
     nonisolated static func deleteCachedModel(
         binaryPath: URL?,
         alias: String,
+        knownRepo: String? = nil,
         hubCacheRoot: URL? = nil
     ) async -> Outcome {
         let trimmedAlias = alias.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -50,7 +51,13 @@ enum ModelDeletion {
             return .failed(message: "Rapid isn't fully set up. Please restart Rapid-MLX.")
         }
 
-        guard let repo = await cachedRepo(for: trimmedAlias, binary: tool) else {
+        let repo: String?
+        if let known = ModelCatalog.sanitizedHuggingFaceRepo(knownRepo) {
+            repo = known
+        } else {
+            repo = await cachedRepo(for: trimmedAlias, binary: tool)
+        }
+        guard let repo else {
             return .failed(message: "Cached model path could not be verified.")
         }
         // Issue #503: when the caller didn't pin an explicit root, prefer

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -676,11 +676,24 @@ final class ServerManager {
     ///   installs the bytes-on-disk progress monitor; without it the
     ///   user watches a featureless spinner for the whole download.
     func ensureServing(alias: String, hfPath: String? = nil) async -> Bool {
+        await ensureServing(alias: alias, hfPath: hfPath, residencyEligible: true)
+    }
+
+    /// Residency-aware convenience. ``residencyEligible`` is non-defaulted so
+    /// this never shadows the two-argument form that ``ReadinessServing``
+    /// requires; audio/video-gen callers pass ``false`` to force a process
+    /// swap instead of the in-process ``/v1/models/load`` path.
+    func ensureServing(
+        alias: String,
+        hfPath: String?,
+        residencyEligible: Bool
+    ) async -> Bool {
         await ensureServing(
             alias: alias,
             hfPath: hfPath,
             estimatedMemoryGB: nil,
-            replacementGroup: nil
+            replacementGroup: nil,
+            residencyEligible: residencyEligible
         )
     }
 
@@ -688,7 +701,8 @@ final class ServerManager {
         alias: String,
         hfPath: String?,
         estimatedMemoryGB: Double?,
-        replacementGroup: ResidentModelReplacementGroup? = nil
+        replacementGroup: ResidentModelReplacementGroup? = nil,
+        residencyEligible: Bool = true
     ) async -> Bool {
         let trimmed = alias.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return false }
@@ -706,7 +720,14 @@ final class ServerManager {
         // process. Only a 404/405 from an older bundled server falls back to
         // the legacy stop/start path; capacity and load failures stay failures
         // so we never hide a rejected ceiling by unloading the primary model.
-        if case .ready = state, child != nil {
+        //
+        // Audio (and video-gen) aliases opt out via ``residencyEligible: false``:
+        // the engine's residency loader rejects those modalities with a 500,
+        // not a 404/405, so an in-process ``/v1/models/load`` attempt would
+        // surface as a hard failure instead of the process swap they actually
+        // need — audio runs as its own ``serve <alias>`` (audio-mode) process.
+        let readyWithChild: Bool = { if case .ready = state, child != nil { return true }; return false }()
+        if Self.residencyLoadApplies(residencyEligible: residencyEligible, readyWithChild: readyWithChild) {
             let estimate = estimatedMemoryGB ?? ModelSizing.estimate(alias: trimmed).totalGB
             let result = await residencyClient.load(
                 alias: trimmed,
@@ -1901,6 +1922,22 @@ final class ServerManager {
         preservingLastServedAlias: Bool
     ) -> Bool {
         expectedStop && !preservingLastServedAlias
+    }
+
+    /// Pure gate for the in-process residency-load attempt in
+    /// ``ensureServing``, extracted so its regression test can run without a
+    /// live sidecar. The residency ``/v1/models/load`` path only works for
+    /// modalities the engine can admit as a non-primary resident (chat/VLM,
+    /// image-gen, text-diffusion). Audio and video-gen aliases raise a 500
+    /// there — which does NOT trigger ``ensureServing``'s 404/405 stop/start
+    /// fallback — so their callers pass ``residencyEligible: false`` and this
+    /// returns ``false`` even when a model is already resident, sending them
+    /// straight to the process-replacement path.
+    nonisolated static func residencyLoadApplies(
+        residencyEligible: Bool,
+        readyWithChild: Bool
+    ) -> Bool {
+        residencyEligible && readyWithChild
     }
 
     /// Pure decision helper for the auto-respawn budget reset gate in

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -379,6 +379,13 @@ final class ServerManager {
 
     private var expectedStop: Bool = false
 
+    /// ``stop()`` normally represents an explicit user request and clears
+    /// the resume alias. Internal model replacement is also an expected
+    /// process exit, but it must preserve that alias while the next model is
+    /// starting; otherwise first-run eligibility briefly becomes true and
+    /// can present Quickstart in the middle of another workflow.
+    private var preservingLastServedAliasDuringStop: Bool = false
+
     /// Issue #270: the current spawn cycle observed at least one
     /// ``.ready`` transition. Drives the auto-respawn decision in
     /// ``handleChildExit`` — a child that crashed BEFORE it ever
@@ -748,7 +755,7 @@ final class ServerManager {
         // the idle/stopped/missing cases just fall through to
         // ``start(alias:)``.
         if child != nil {
-            await stop()
+            await stop(preservingLastServedAlias: true)
         }
         await start(alias: trimmed, hfPath: hfPath)
         // ``start`` also returns without spawning when the pre-load
@@ -1549,6 +1556,13 @@ final class ServerManager {
     /// SIGKILL if still alive. State transitions to `.stopped` on
     /// success.
     func stop() async {
+        await stop(preservingLastServedAlias: false)
+    }
+
+    /// Shared expected-stop path. Model replacement keeps the previous
+    /// known-good alias until the replacement reaches ``.ready`` and writes
+    /// its own alias; a user-facing Stop continues to clear it immediately.
+    private func stop(preservingLastServedAlias: Bool) async {
         // Issue #270: the user clicked Stop. A pending auto-respawn
         // racing them would defeat the click — cancel it AND reset
         // the retry budget so a subsequent user-driven Start gets a
@@ -1560,6 +1574,7 @@ final class ServerManager {
         guard child != nil else { return }
         isOperating = true
         defer { isOperating = false }
+        preservingLastServedAliasDuringStop = preservingLastServedAlias
         await terminateChild(reason: nil)
     }
 
@@ -1786,7 +1801,9 @@ final class ServerManager {
             cancelRuntimeHealthMonitor()
         }
         let wasExpected = expectedStop
+        let preservedLastServedAlias = preservingLastServedAliasDuringStop
         expectedStop = false
+        preservingLastServedAliasDuringStop = false
         child = nil
         // #17: the child owns the secret; the secret is meaningless
         // (and a leak vector) once the child is gone.
@@ -1823,7 +1840,12 @@ final class ServerManager {
             // below) and INTENTIONALLY keep the persisted value so
             // the user can hit Restart against the last-known-good
             // alias without picker re-selection.
-            UserDefaults.standard.removeObject(forKey: Self.lastServedAliasKey)
+            if Self.shouldClearLastServedAlias(
+                expectedStop: wasExpected,
+                preservingLastServedAlias: preservedLastServedAlias
+            ) {
+                UserDefaults.standard.removeObject(forKey: Self.lastServedAliasKey)
+            }
             return
         }
         if process.isProcessGroupAlive {
@@ -1871,6 +1893,14 @@ final class ServerManager {
         ) {
             scheduleAutoRespawn(alias: alias)
         }
+    }
+
+    /// Pure policy used by the child-exit path and its regression tests.
+    nonisolated static func shouldClearLastServedAlias(
+        expectedStop: Bool,
+        preservingLastServedAlias: Bool
+    ) -> Bool {
+        expectedStop && !preservingLastServedAlias
     }
 
     /// Pure decision helper for the auto-respawn budget reset gate in

--- a/apps/rapid-mac/Sources/Rapid/Services/ModelCacheActions.swift
+++ b/apps/rapid-mac/Sources/Rapid/Services/ModelCacheActions.swift
@@ -56,8 +56,8 @@ enum ModelCacheActions {
         /// Alias is on disk, not currently being served.
         case cached
         /// Alias is on disk AND is the active serving alias.
-        /// rapid-mlx has the weights mmap'd; the panel renders
-        /// an "In use" pill (not deletable mid-serve).
+        /// rapid-mlx has the weights mmap'd; deletion must stop the server
+        /// before removing the cache directory.
         case inUse
         /// Alias is not on disk and no download is in flight.
         case notCached
@@ -160,7 +160,10 @@ enum ModelCacheActions {
         let message: String
     }
 
-    static func deletionConfirmation(for entry: ModelEntry) -> DeletionConfirmation {
+    static func deletionConfirmation(
+        for entry: ModelEntry,
+        isServing: Bool = false
+    ) -> DeletionConfirmation {
         let title: String
         if let size = entry.sizeOnDisk {
             title = "Delete \"\(entry.alias)\"? This frees \(size)."
@@ -168,7 +171,8 @@ enum ModelCacheActions {
             title = "Delete \"\(entry.alias)\"?"
         }
         let suffix = entry.sizeOnDisk.map { " Frees \($0)." } ?? ""
-        let message = "Removes this model from your Mac. You can download it again later by selecting it.\(suffix)"
+        let stopPrefix = isServing ? "Stops the currently serving model first. " : ""
+        let message = "\(stopPrefix)Removes this model from your Mac. You can download it again later by selecting it.\(suffix)"
         return DeletionConfirmation(title: title, message: message)
     }
 
@@ -219,8 +223,8 @@ enum ModelCacheActions {
     static func runDeletion(
         for entry: ModelEntry,
         binaryPath: URL?,
-        delete: (URL?, String) async -> ModelDeletion.Outcome = {
-            await ModelDeletion.deleteCachedModel(binaryPath: $0, alias: $1)
+        delete: (URL?, String, String?) async -> ModelDeletion.Outcome = {
+            await ModelDeletion.deleteCachedModel(binaryPath: $0, alias: $1, knownRepo: $2)
         }
     ) async -> RunDeleteOutcome {
         // Defence in depth for #1718. The Settings panel already omits the
@@ -236,7 +240,11 @@ enum ModelCacheActions {
                     + "Rapid can't remove it — delete it where it was installed."
             )
         }
-        let outcome = await delete(binaryPath, entry.alias)
+        // Audio (and image) snapshots list as `(unmapped)`, so pass the
+        // catalog's known repo for non-chat rows; `deleteCachedModel` reverse
+        // maps chat aliases itself when the repo is nil.
+        let knownRepo = entry.kind == .chat ? nil : entry.hfRepo
+        let outcome = await delete(binaryPath, entry.alias, knownRepo)
         switch outcome {
         case .freed(let bytes, _):
             let msg = successMessage(

--- a/apps/rapid-mac/Sources/Rapid/UI/AudioView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/AudioView.swift
@@ -95,6 +95,7 @@ struct AudioView: View {
             Button("Open Model Management", systemImage: "square.stack.3d.up") {
                 openModelManagement()
             }
+            .accessibilityIdentifier("Audio.EmptyState.OpenModelManagement")
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .accessibilityIdentifier("Audio.EmptyState")
@@ -356,6 +357,7 @@ struct AudioView: View {
                 controlLabel("Speed")
                 HStack(spacing: RapidTheme.Space.md) {
                     Slider(value: $viewModel.speed, in: 0.5...2, step: 0.05)
+                        .accessibilityIdentifier("Audio.Speech.Speed")
                     Text(viewModel.speed.formatted(.number.precision(.fractionLength(2))) + "x")
                         .font(.system(size: 12, weight: .medium, design: .monospaced))
                         .monospacedDigit()
@@ -446,6 +448,7 @@ struct AudioView: View {
                         Text(modelTitle(entry))
                     }
                 }
+                .accessibilityIdentifier("\(identifier).\(entry.alias)")
             }
         } label: {
             popupControlLabel(

--- a/apps/rapid-mac/Sources/Rapid/UI/AudioView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/AudioView.swift
@@ -1,0 +1,774 @@
+import AppKit
+import AVFoundation
+import Observation
+import SwiftUI
+import UniformTypeIdentifiers
+
+/// Audio workflows backed by the local OpenAI-compatible routes. The page
+/// deliberately starts no model on appearance: with today's single-model
+/// runtime, a model is swapped only when the user transcribes, loads voices,
+/// or synthesizes speech.
+struct AudioView: View {
+    @Bindable var viewModel: AudioViewModel
+    @Bindable var server: ServerManager
+    @Environment(\.openWindow) private var openWindow
+    @Environment(SettingsRouter.self) private var settingsRouter
+    @Environment(DownloadManager.self) private var downloads
+
+    @State private var copied = false
+    @State private var playback = AudioPlaybackController()
+    @State private var showVoicePicker = false
+    @State private var playingPreviewVoice: String?
+    @State private var voicePreviewTask: Task<Void, Never>?
+    @State private var voicePreviewRequestID: UUID?
+
+    private let contentMaxWidth = RapidTheme.Layout.contentMaxWidth
+    private let controlLabelWidth: CGFloat = 80
+    private let controlFieldWidth: CGFloat = 320
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider().overlay(RapidTheme.hairline)
+            content
+        }
+        .background(RapidTheme.surfaceCanvas)
+        // Settings is a separate window, so this view can remain mounted
+        // while an audio pull finishes. Refresh on the shared disk-cache
+        // generation instead of keeping the pre-download catalog snapshot.
+        .task(id: downloads.cacheGeneration) {
+            await viewModel.refreshCatalog()
+        }
+        .onChange(of: viewModel.mode) { _, _ in cancelVoicePreview() }
+        .onDisappear { cancelVoicePreview() }
+    }
+
+    private var header: some View {
+        HStack(spacing: RapidTheme.Space.lg) {
+            Spacer(minLength: 0)
+            Picker("Mode", selection: $viewModel.mode) {
+                ForEach(AudioViewModel.Mode.allCases) { mode in
+                    Text(mode.label).tag(mode)
+                }
+            }
+            .pickerStyle(.segmented)
+            .labelsHidden()
+            .frame(width: 250)
+            .accessibilityLabel("Audio mode")
+            .accessibilityIdentifier("Audio.Mode")
+        }
+        .padding(.horizontal, RapidTheme.Space.xl)
+        .padding(.vertical, RapidTheme.Space.lg)
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if !viewModel.catalogLoaded {
+            ProgressView("Loading audio models...")
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else {
+            switch viewModel.mode {
+            case .transcription:
+                if viewModel.transcriptionModels.isEmpty {
+                    unavailableState(operation: "transcription")
+                } else {
+                    transcriptionSurface
+                }
+            case .speech:
+                if viewModel.speechModels.isEmpty {
+                    unavailableState(operation: "speech")
+                } else {
+                    speechSurface
+                }
+            }
+        }
+    }
+
+    private func unavailableState(operation: String) -> some View {
+        EmptyState(
+            symbol: "waveform",
+            title: "Audio unavailable",
+            message: server.binaryPath == nil
+                ? "The bundled engine could not be found. The rest of Rapid-MLX remains available."
+                : "No model in this build supports \(operation). Audio models can be managed in Settings."
+        ) {
+            Button("Open Model Management", systemImage: "square.stack.3d.up") {
+                openModelManagement()
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .accessibilityIdentifier("Audio.EmptyState")
+    }
+
+    private var transcriptionSurface: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: RapidTheme.Space.xl) {
+                SectionHeader(
+                    "Transcription",
+                    subtitle: "Turn a local recording into text without uploading it."
+                )
+                filePicker
+                modelPicker(
+                    title: "Model",
+                    selection: $viewModel.selectedTranscriptionAlias,
+                    entries: viewModel.transcriptionModels,
+                    identifier: "Audio.Transcription.ModelPicker"
+                )
+                swapNotice(alias: viewModel.selectedTranscriptionAlias)
+                operationNotice
+                HStack(spacing: RapidTheme.Space.md) {
+                    if viewModel.isTranscribing {
+                        ProgressView()
+                            .controlSize(.small)
+                        Text("Loading model and transcribing...")
+                            .font(RapidFont.secondary)
+                            .foregroundStyle(.secondary)
+                    }
+                    Spacer(minLength: RapidTheme.Space.md)
+                    Button("Transcribe", systemImage: "text.badge.checkmark") {
+                        playback.stop()
+                        Task { await viewModel.transcribe() }
+                    }
+                    .buttonStyle(.rapidPrimary)
+                    .disabled(
+                        viewModel.selectedFileURL == nil
+                            || viewModel.selectedTranscriptionAlias.isEmpty
+                            || viewModel.isBusy
+                    )
+                    .accessibilityIdentifier("Audio.Transcription.Run")
+                }
+
+                if let result = viewModel.transcription {
+                    transcriptionResult(result)
+                }
+            }
+            .frame(maxWidth: contentMaxWidth, alignment: .leading)
+            .frame(maxWidth: .infinity)
+            .padding(RapidTheme.Space.xl)
+        }
+    }
+
+    private var filePicker: some View {
+        VStack(alignment: .leading, spacing: RapidTheme.Space.sm) {
+            HStack(spacing: RapidTheme.Space.md) {
+                Image(systemName: "waveform")
+                    .font(.system(size: 22, weight: .medium))
+                    .foregroundStyle(RapidTheme.brandPrimaryDeep)
+                    .frame(width: 34)
+                    .accessibilityHidden(true)
+
+                VStack(alignment: .leading, spacing: RapidTheme.Space.xs) {
+                    Text(viewModel.selectedFileURL?.lastPathComponent ?? "Audio file")
+                        .font(RapidFont.body)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                    Text(fileCaption)
+                        .font(RapidFont.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer(minLength: RapidTheme.Space.md)
+                Button("Choose File", systemImage: "folder") { chooseAudioFile() }
+                    .buttonStyle(.rapidSecondaryCompactUtility)
+                    .accessibilityIdentifier("Audio.Transcription.FilePicker")
+            }
+            .padding(RapidTheme.Space.lg)
+            .frame(maxWidth: .infinity, minHeight: 84)
+            .background(
+                RoundedRectangle(cornerRadius: RapidTheme.Radius.card, style: .continuous)
+                    .fill(RapidTheme.surfaceRaised)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: RapidTheme.Radius.card, style: .continuous)
+                    .strokeBorder(RapidTheme.hairlineStrong, style: StrokeStyle(lineWidth: 1, dash: [5]))
+            )
+            .contentShape(Rectangle())
+            .dropDestination(for: URL.self) { urls, _ in
+                guard let url = urls.first(where: isAudioFile) else { return false }
+                viewModel.selectFile(url)
+                return true
+            }
+        }
+    }
+
+    private var fileCaption: String {
+        guard let url = viewModel.selectedFileURL else {
+            return "WAV, MP3, M4A, AAC, FLAC, or MP4 - up to 25 MB"
+        }
+        if let bytes = try? url.resourceValues(forKeys: [.fileSizeKey]).fileSize {
+            return ByteCountFormatter.string(fromByteCount: Int64(bytes), countStyle: .file)
+        }
+        return url.pathExtension.uppercased()
+    }
+
+    private func transcriptionResult(_ result: AudioTranscriptionResult) -> some View {
+        VStack(alignment: .leading, spacing: RapidTheme.Space.sm) {
+            SectionHeader("Result") {
+                HStack(spacing: RapidTheme.Space.xs) {
+                    QuietIconButton(
+                        symbol: copied ? "checkmark" : "doc.on.doc",
+                        label: copied ? "Copied" : "Copy transcription",
+                        tint: copied ? RapidTheme.statusReady : nil
+                    ) {
+                        NSPasteboard.general.clearContents()
+                        NSPasteboard.general.setString(result.text, forType: .string)
+                        copied = true
+                        Task {
+                            try? await Task.sleep(for: .seconds(1.5))
+                            copied = false
+                        }
+                    }
+                    .accessibilityIdentifier("Audio.Transcription.Copy")
+                    QuietIconButton(
+                        symbol: "square.and.arrow.down",
+                        label: "Save transcription"
+                    ) { saveTranscription(result.text) }
+                    .accessibilityIdentifier("Audio.Transcription.Save")
+                }
+            }
+
+            ScrollView {
+                Text(result.text)
+                    .font(RapidFont.body)
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(RapidTheme.Space.lg)
+            }
+            .frame(minHeight: 130, maxHeight: 300)
+            .background(
+                RoundedRectangle(cornerRadius: RapidTheme.Radius.card, style: .continuous)
+                    .fill(RapidTheme.surfaceRaised)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: RapidTheme.Radius.card, style: .continuous)
+                    .strokeBorder(RapidTheme.hairline, lineWidth: 1)
+            )
+            .accessibilityIdentifier("Audio.Transcription.Result")
+
+            if result.language != nil || result.duration != nil {
+                Text(resultMetadata(result))
+                    .font(RapidFont.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private var speechSurface: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: RapidTheme.Space.xl) {
+                SectionHeader(
+                    "Speech",
+                    subtitle: "Create spoken audio with a model and one of its built-in voices."
+                )
+
+                VStack(alignment: .leading, spacing: RapidTheme.Space.sm) {
+                    SectionHeader("Text")
+                    TextEditor(text: $viewModel.speechText)
+                        .font(RapidFont.body)
+                        .scrollContentBackground(.hidden)
+                        .padding(RapidTheme.Space.sm)
+                        .frame(minHeight: 150)
+                        .background(
+                            RoundedRectangle(cornerRadius: RapidTheme.Radius.input, style: .continuous)
+                                .fill(RapidTheme.surfaceRaised)
+                        )
+                        .overlay(
+                            RoundedRectangle(cornerRadius: RapidTheme.Radius.input, style: .continuous)
+                                .strokeBorder(RapidTheme.hairlineStrong, lineWidth: 1)
+                        )
+                        .accessibilityLabel("Text to speak")
+                        .accessibilityIdentifier("Audio.Speech.Text")
+                }
+
+                speechControls
+                swapNotice(alias: viewModel.selectedSpeechAlias)
+                operationNotice
+
+                HStack(spacing: RapidTheme.Space.md) {
+                    if viewModel.isSynthesizing {
+                        ProgressView().controlSize(.small)
+                        Text("Generating audio...")
+                            .font(RapidFont.secondary)
+                            .foregroundStyle(.secondary)
+                    }
+                    Spacer(minLength: RapidTheme.Space.md)
+                    Button("Generate Speech", systemImage: "waveform.badge.plus") {
+                        playback.stop()
+                        Task { await viewModel.synthesize() }
+                    }
+                    .buttonStyle(.rapidPrimary)
+                    .disabled(
+                        viewModel.speechText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                            || viewModel.selectedSpeechAlias.isEmpty
+                            || viewModel.isBusy
+                    )
+                    .accessibilityIdentifier("Audio.Speech.Generate")
+                }
+
+                if let audio = viewModel.synthesizedAudio {
+                    speechResult(audio)
+                }
+            }
+            .frame(maxWidth: contentMaxWidth, alignment: .leading)
+            .frame(maxWidth: .infinity)
+            .padding(RapidTheme.Space.xl)
+        }
+    }
+
+    private var speechModelSelection: Binding<String> {
+        Binding(
+            get: { viewModel.selectedSpeechAlias },
+            set: { viewModel.selectSpeechModel($0) }
+        )
+    }
+
+    private var speechControls: some View {
+        VStack(alignment: .leading, spacing: RapidTheme.Space.md) {
+            HStack(spacing: RapidTheme.Space.md) {
+                controlLabel("Model")
+                modelPickerControl(
+                    title: "Model",
+                    selection: speechModelSelection,
+                    entries: viewModel.speechModels,
+                    identifier: "Audio.Speech.ModelPicker"
+                )
+                Spacer(minLength: RapidTheme.Space.md)
+            }
+
+            HStack(spacing: RapidTheme.Space.md) {
+                controlLabel("Voice")
+                voicePickerControl
+                HStack(spacing: RapidTheme.Space.sm) {
+                    Button("Load Voices", systemImage: "arrow.clockwise") {
+                        playback.stop()
+                        Task { _ = await viewModel.loadVoices() }
+                    }
+                    .buttonStyle(.rapidSecondaryCompactUtility)
+                    .disabled(viewModel.selectedSpeechAlias.isEmpty || viewModel.isBusy)
+                    .accessibilityIdentifier("Audio.Speech.LoadVoices")
+                    if viewModel.isLoadingVoices {
+                        ProgressView().controlSize(.small)
+                    }
+                }
+                Spacer(minLength: RapidTheme.Space.md)
+            }
+
+            HStack(spacing: RapidTheme.Space.md) {
+                controlLabel("Speed")
+                HStack(spacing: RapidTheme.Space.md) {
+                    Slider(value: $viewModel.speed, in: 0.5...2, step: 0.05)
+                    Text(viewModel.speed.formatted(.number.precision(.fractionLength(2))) + "x")
+                        .font(.system(size: 12, weight: .medium, design: .monospaced))
+                        .monospacedDigit()
+                        .frame(width: 48, alignment: .trailing)
+                }
+                .frame(width: controlFieldWidth)
+                .accessibilityElement(children: .contain)
+                Spacer(minLength: RapidTheme.Space.md)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func speechResult(_ audio: SynthesizedAudio) -> some View {
+        HStack(spacing: RapidTheme.Space.md) {
+            Image(systemName: "waveform.circle.fill")
+                .font(.system(size: 28))
+                .foregroundStyle(RapidTheme.brandPrimaryDeep)
+                .accessibilityHidden(true)
+            VStack(alignment: .leading, spacing: RapidTheme.Space.xs) {
+                Text("Speech ready")
+                    .font(RapidFont.body)
+                Text(ByteCountFormatter.string(fromByteCount: Int64(audio.data.count), countStyle: .file))
+                    .font(RapidFont.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer(minLength: RapidTheme.Space.md)
+            QuietIconButton(
+                symbol: playback.isPlaying ? "stop.fill" : "play.fill",
+                label: playback.isPlaying ? "Stop playback" : "Play speech"
+            ) {
+                do {
+                    try playback.toggle(audio.data)
+                } catch {
+                    viewModel.errorMessage = "Couldn't play the audio: \(error.localizedDescription)"
+                }
+            }
+            .accessibilityIdentifier("Audio.Speech.Play")
+            QuietIconButton(
+                symbol: "square.and.arrow.down",
+                label: "Save speech"
+            ) { saveSpeech(audio) }
+            .accessibilityIdentifier("Audio.Speech.Save")
+        }
+        .padding(RapidTheme.Space.lg)
+        .background(
+            RoundedRectangle(cornerRadius: RapidTheme.Radius.card, style: .continuous)
+                .fill(RapidTheme.surfaceRaised)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: RapidTheme.Radius.card, style: .continuous)
+                .strokeBorder(RapidTheme.hairline, lineWidth: 1)
+        )
+    }
+
+    private func modelPicker(
+        title: String,
+        selection: Binding<String>,
+        entries: [ModelEntry],
+        identifier: String
+    ) -> some View {
+        HStack(spacing: RapidTheme.Space.md) {
+            controlLabel(title)
+            modelPickerControl(
+                title: title,
+                selection: selection,
+                entries: entries,
+                identifier: identifier
+            )
+            Spacer(minLength: 0)
+        }
+    }
+
+    private func modelPickerControl(
+        title: String,
+        selection: Binding<String>,
+        entries: [ModelEntry],
+        identifier: String
+    ) -> some View {
+        Menu {
+            ForEach(entries) { entry in
+                Button {
+                    selection.wrappedValue = entry.alias
+                } label: {
+                    if selection.wrappedValue == entry.alias {
+                        Label(modelTitle(entry), systemImage: "checkmark")
+                    } else {
+                        Text(modelTitle(entry))
+                    }
+                }
+            }
+        } label: {
+            popupControlLabel(
+                entries.first(where: { $0.alias == selection.wrappedValue })
+                    .map(modelTitle) ?? "Choose a model"
+            )
+        }
+        .menuStyle(.button)
+        .buttonStyle(.plain)
+        .menuIndicator(.hidden)
+        .disabled(viewModel.isBusy)
+        .accessibilityLabel(title)
+        .accessibilityValue(selection.wrappedValue)
+        .accessibilityIdentifier(identifier)
+    }
+
+    private var voicePickerControl: some View {
+        Button {
+            showVoicePicker.toggle()
+        } label: {
+            popupControlLabel(
+                viewModel.selectedVoice.isEmpty ? "No voices loaded" : viewModel.selectedVoice
+            )
+        }
+        .buttonStyle(.plain)
+        .disabled(
+            viewModel.voices.isEmpty
+                || (viewModel.isBusy && viewModel.previewingVoice == nil)
+        )
+        .accessibilityLabel("Voice")
+        .accessibilityValue(viewModel.selectedVoice)
+        .accessibilityIdentifier("Audio.Speech.VoicePicker")
+        .popover(isPresented: $showVoicePicker, arrowEdge: .top) {
+            ScrollView {
+                LazyVStack(spacing: RapidTheme.Space.xs) {
+                    ForEach(viewModel.voices, id: \.self) { voice in
+                        VoiceOptionRow(
+                            voice: voice,
+                            details: AudioViewModel.voiceDetails(for: voice),
+                            isSelected: viewModel.selectedVoice == voice,
+                            isPreviewing: viewModel.previewingVoice == voice,
+                            isPlaying: playback.isPlaying && playingPreviewVoice == voice,
+                            isEnabled: !viewModel.isBusy,
+                            select: {
+                                cancelVoicePreview()
+                                viewModel.selectedVoice = voice
+                                showVoicePicker = false
+                            },
+                            preview: { toggleVoicePreview(voice) }
+                        )
+                    }
+                }
+                .padding(RapidTheme.Space.xs)
+            }
+            .frame(width: controlFieldWidth, height: voicePopoverHeight)
+        }
+    }
+
+    private var voicePopoverHeight: CGFloat {
+        min(max(CGFloat(viewModel.voices.count) * 34 + RapidTheme.Space.sm, 42), 320)
+    }
+
+    private func popupControlLabel(_ value: String) -> some View {
+        HStack(spacing: RapidTheme.Space.sm) {
+            Text(value)
+                .font(RapidFont.body)
+                .lineLimit(1)
+                .truncationMode(.middle)
+            Spacer(minLength: RapidTheme.Space.sm)
+            Image(systemName: "chevron.up.chevron.down")
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundStyle(.secondary)
+                .accessibilityHidden(true)
+        }
+        .padding(.horizontal, RapidTheme.Space.md)
+        .frame(width: controlFieldWidth, height: RapidTheme.ControlHeight.small)
+        .background(
+            RoundedRectangle(cornerRadius: RapidTheme.Radius.row, style: .continuous)
+                .fill(RapidTheme.surfaceCode)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: RapidTheme.Radius.row, style: .continuous)
+                .strokeBorder(RapidTheme.hairlineStrong, lineWidth: 1)
+        )
+        .contentShape(RoundedRectangle(cornerRadius: RapidTheme.Radius.row, style: .continuous))
+    }
+
+    private func controlLabel(_ title: String) -> some View {
+        Text(title)
+            .font(RapidFont.secondary)
+            .frame(width: controlLabelWidth, alignment: .leading)
+    }
+
+    private func modelTitle(_ entry: ModelEntry) -> String {
+        let status = entry.cached ? "Downloaded" : "Not downloaded"
+        return "\(entry.alias) - \(status)"
+    }
+
+    @ViewBuilder
+    private func swapNotice(alias: String) -> some View {
+        if let running = viewModel.wouldReplaceServingModel(alias: alias) {
+            InlineNotice(
+                message: "Starting \(alias) will stop \(running). This version runs one model at a time.",
+                tone: .info
+            )
+        }
+    }
+
+    @ViewBuilder
+    private var operationNotice: some View {
+        if let message = viewModel.errorMessage {
+            InlineNotice(message: message, tone: .error)
+        }
+    }
+
+    private func chooseAudioFile() {
+        let panel = NSOpenPanel()
+        panel.allowedContentTypes = [.audio]
+        panel.allowsMultipleSelection = false
+        panel.canChooseDirectories = false
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+        viewModel.selectFile(url)
+    }
+
+    private func isAudioFile(_ url: URL) -> Bool {
+        UTType(filenameExtension: url.pathExtension)?.conforms(to: .audio) == true
+    }
+
+    private func saveTranscription(_ text: String) {
+        let panel = NSSavePanel()
+        panel.allowedContentTypes = [.plainText]
+        panel.nameFieldStringValue = "transcription.txt"
+        panel.canCreateDirectories = true
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+        do {
+            try text.write(to: url, atomically: true, encoding: .utf8)
+        } catch {
+            viewModel.errorMessage = "Couldn't save the transcription: \(error.localizedDescription)"
+        }
+    }
+
+    private func saveSpeech(_ audio: SynthesizedAudio) {
+        let panel = NSSavePanel()
+        if let type = UTType(filenameExtension: audio.fileExtension) {
+            panel.allowedContentTypes = [type]
+        }
+        panel.nameFieldStringValue = "rapid-speech.\(audio.fileExtension)"
+        panel.canCreateDirectories = true
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+        do {
+            try audio.data.write(to: url, options: .atomic)
+        } catch {
+            viewModel.errorMessage = "Couldn't save the audio: \(error.localizedDescription)"
+        }
+    }
+
+    private func resultMetadata(_ result: AudioTranscriptionResult) -> String {
+        var parts: [String] = []
+        if let language = result.language, !language.isEmpty {
+            parts.append("Language: \(language)")
+        }
+        if let duration = result.duration {
+            parts.append("Duration: \(duration.formatted(.number.precision(.fractionLength(1)))) s")
+        }
+        return parts.joined(separator: "  |  ")
+    }
+
+    private func openModelManagement() {
+        settingsRouter.route(.openModelManagement) { openWindow(id: "settings") }
+    }
+
+    private func toggleVoicePreview(_ voice: String) {
+        if playback.isPlaying, playingPreviewVoice == voice {
+            playback.stop()
+            playingPreviewVoice = nil
+            return
+        }
+
+        voicePreviewTask?.cancel()
+        playback.stop()
+        playingPreviewVoice = nil
+
+        let requestID = UUID()
+        voicePreviewRequestID = requestID
+        voicePreviewTask = Task {
+            defer {
+                if voicePreviewRequestID == requestID {
+                    voicePreviewTask = nil
+                    voicePreviewRequestID = nil
+                }
+            }
+            guard let audio = await viewModel.previewVoice(voice),
+                  !Task.isCancelled,
+                  voicePreviewRequestID == requestID else { return }
+            do {
+                try playback.play(audio.data)
+                playingPreviewVoice = voice
+            } catch {
+                viewModel.errorMessage = "Couldn't play the voice preview: \(error.localizedDescription)"
+            }
+        }
+    }
+
+    private func cancelVoicePreview() {
+        voicePreviewTask?.cancel()
+        voicePreviewTask = nil
+        voicePreviewRequestID = nil
+        playback.stop()
+        playingPreviewVoice = nil
+    }
+}
+
+private struct VoiceOptionRow: View {
+    let voice: String
+    let details: String
+    let isSelected: Bool
+    let isPreviewing: Bool
+    let isPlaying: Bool
+    let isEnabled: Bool
+    let select: () -> Void
+    let preview: () -> Void
+
+    @State private var hovering = false
+
+    var body: some View {
+        HStack(spacing: RapidTheme.Space.xs) {
+            Button(action: select) {
+                HStack(spacing: RapidTheme.Space.sm) {
+                    Image(systemName: "checkmark")
+                        .font(.system(size: 10, weight: .semibold))
+                        .opacity(isSelected ? 1 : 0)
+                        .frame(width: 14)
+                    Text(voice)
+                        .font(RapidFont.body)
+                        .lineLimit(1)
+                    Text(details)
+                        .font(RapidFont.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                    Spacer(minLength: RapidTheme.Space.sm)
+                }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .disabled(!isEnabled)
+            .accessibilityLabel("Select \(voice), \(details)")
+            .accessibilityIdentifier("Audio.Speech.VoiceOption.\(voice)")
+
+            if isPreviewing {
+                ProgressView()
+                    .controlSize(.small)
+                    .frame(
+                        width: RapidTheme.ControlHeight.small,
+                        height: RapidTheme.ControlHeight.small
+                    )
+                    .accessibilityLabel("Generating \(voice) preview")
+            } else {
+                QuietIconButton(
+                    symbol: isPlaying ? "stop.circle.fill" : "play.circle.fill",
+                    label: isPlaying ? "Stop \(voice) preview" : "Preview \(voice)",
+                    symbolSize: 16,
+                    action: preview
+                )
+                .disabled(!isEnabled && !isPlaying)
+                .accessibilityIdentifier("Audio.Speech.PreviewVoice.\(voice)")
+            }
+        }
+        .padding(.leading, RapidTheme.Space.sm)
+        .padding(.trailing, RapidTheme.Space.xs)
+        .frame(height: 30)
+        .background(
+            RoundedRectangle(cornerRadius: RapidTheme.Radius.row, style: .continuous)
+                .fill(isSelected || hovering ? RapidTheme.hoverFill : .clear)
+        )
+        .contentShape(RoundedRectangle(cornerRadius: RapidTheme.Radius.row, style: .continuous))
+        .onHover { hovering = $0 }
+        .rapidAnimation(RapidMotion.quick, value: hovering)
+    }
+}
+
+@MainActor
+@Observable
+private final class AudioPlaybackController {
+    private var player: AVAudioPlayer?
+    private var monitor: Task<Void, Never>?
+    private(set) var isPlaying = false
+
+    func toggle(_ data: Data) throws {
+        if isPlaying {
+            stop()
+            return
+        }
+        try play(data)
+    }
+
+    func play(_ data: Data) throws {
+        stop()
+        let player = try AVAudioPlayer(data: data)
+        guard player.prepareToPlay(), player.play() else {
+            throw AudioPlaybackError.couldNotStart
+        }
+        self.player = player
+        isPlaying = true
+        monitor = Task { [weak self, weak player] in
+            while !Task.isCancelled, player?.isPlaying == true {
+                try? await Task.sleep(for: .milliseconds(100))
+            }
+            guard !Task.isCancelled else { return }
+            self?.isPlaying = false
+        }
+    }
+
+    func stop() {
+        monitor?.cancel()
+        monitor = nil
+        player?.stop()
+        player = nil
+        isPlaying = false
+    }
+}
+
+private enum AudioPlaybackError: LocalizedError {
+    case couldNotStart
+
+    var errorDescription: String? { "Playback could not start." }
+}

--- a/apps/rapid-mac/Sources/Rapid/UI/Components/QuietIconButton.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/Components/QuietIconButton.swift
@@ -21,6 +21,7 @@ struct QuietIconButton: View {
     /// Overrides the resting colour — for transient success states.
     var tint: Color? = nil
     var size: CGFloat = RapidTheme.ControlHeight.small
+    var symbolSize: CGFloat = 11
     var action: () -> Void
 
     @Environment(\.isEnabled) private var isEnabled
@@ -42,7 +43,7 @@ struct QuietIconButton: View {
     var body: some View {
         Button(action: action) {
             Image(systemName: symbol)
-                .font(.system(size: 11, weight: .medium))
+                .font(.system(size: symbolSize, weight: .medium))
                 .foregroundStyle(foreground)
                 .frame(width: size, height: size)
                 .background(

--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -16,6 +16,7 @@ struct ContentView: View {
     @Environment(DownloadManager.self) private var downloads
     @Environment(ChatViewModel.self) private var chat
     @Environment(ImageGenViewModel.self) private var imageGen
+    @Environment(AudioViewModel.self) private var audio
     @Environment(SamplingConfig.self) private var sampling
     @Environment(UpdateChecker.self) private var updater
     @Environment(QuickstartCoordinator.self) private var quickstart
@@ -419,6 +420,8 @@ struct ContentView: View {
             mainArea
         case .images:
             ImagesView(viewModel: imageGen, server: server)
+        case .audio:
+            AudioView(viewModel: audio, server: server)
         case .launch:
             LaunchView(
                 server: server,
@@ -493,6 +496,10 @@ struct ContentView: View {
     /// different alias. Eligibility keys on app-owned state only (see
     /// ``QuickstartCoordinator.isEligible``), never the shared HF cache.
     private var quickstartVisible: Bool {
+        // Quickstart is a Chat onboarding surface. Server/model transitions
+        // inside Audio or Images must never interrupt those workflows with a
+        // global onboarding sheet.
+        guard ContentView.quickstartCanPresent(in: section) else { return false }
         guard !quickstartDismissedThisSession else { return false }
         // Telemetry consent comes first. Both surfaces used to be able to fire
         // together (nothing referenced the other's condition) — tolerable when
@@ -522,6 +529,10 @@ struct ContentView: View {
         case .idle, .ready:
             return false
         }
+    }
+
+    static func quickstartCanPresent(in section: SidebarSection) -> Bool {
+        section == .chat
     }
 
     /// True when the Quickstart sheet is up AND owns the pending

--- a/apps/rapid-mac/Sources/Rapid/UI/SettingsModelManagementPanel.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SettingsModelManagementPanel.swift
@@ -189,6 +189,7 @@ struct SettingsModelManagementPanel: View {
                 Task { await deleteAlias(entry) }
                 pendingDeletion = nil
             }
+            .accessibilityIdentifier("Settings.ModelManagement.ConfirmDelete")
             Button("Keep on disk", role: .cancel) {
                 pendingDeletion = nil
             }

--- a/apps/rapid-mac/Sources/Rapid/UI/SettingsModelManagementPanel.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SettingsModelManagementPanel.swift
@@ -46,7 +46,7 @@ struct SettingsModelManagementPanel: View {
     @State private var lastFreed: String?
 
     @State private var query: String = ""
-    /// Which capability tab is showing (Chat vs Image vs future Video). Model
+    /// Which capability tab is showing (Chat vs Image vs Audio vs future Video). Model
     /// Management manages every kind, but never mixes them in one list.
     @State private var capability: ModelKind = .chat
     @State private var filterMode: ModelCacheActions.FilterMode = .all
@@ -121,8 +121,8 @@ struct SettingsModelManagementPanel: View {
             modelsFolderSection
             preferencesSection
             capabilityTabs
+            controlsRow
             if capability == .chat {
-                controlsRow
                 if showRecommendedSection {
                     recommendedSection
                 }
@@ -172,7 +172,8 @@ struct SettingsModelManagementPanel: View {
         // the wording matches.
         .confirmationDialog(
             ModelCacheActions.deletionConfirmation(
-                for: pendingDeletion ?? ModelEntry(alias: "", hfRepo: nil, sizeOnDisk: nil, cached: false)
+                for: pendingDeletion ?? ModelEntry(alias: "", hfRepo: nil, sizeOnDisk: nil, cached: false),
+                isServing: pendingDeletion?.alias == server.servingAlias
             ).title,
             isPresented: Binding(
                 get: { pendingDeletion != nil },
@@ -181,7 +182,10 @@ struct SettingsModelManagementPanel: View {
             titleVisibility: .visible,
             presenting: pendingDeletion
         ) { entry in
-            Button("Delete from disk", role: .destructive) {
+            Button(
+                entry.alias == server.servingAlias ? "Stop and delete" : "Delete from disk",
+                role: .destructive
+            ) {
                 Task { await deleteAlias(entry) }
                 pendingDeletion = nil
             }
@@ -189,7 +193,10 @@ struct SettingsModelManagementPanel: View {
                 pendingDeletion = nil
             }
         } message: { entry in
-            Text(ModelCacheActions.deletionConfirmation(for: entry).message)
+            Text(ModelCacheActions.deletionConfirmation(
+                for: entry,
+                isServing: entry.alias == server.servingAlias
+            ).message)
         }
     }
 
@@ -393,7 +400,7 @@ struct SettingsModelManagementPanel: View {
         Task { await refreshCatalog() }
     }
 
-    /// Capability tabs — Chat / Image (/ Video, once it has aliases). Only
+    /// Capability tabs — Chat / Image / Audio (/ Video, once it has aliases). Only
     /// shown when there's more than one kind installed, so a chat-only setup
     /// looks exactly as it did before image models existed.
     @ViewBuilder
@@ -897,8 +904,8 @@ struct SettingsModelManagementPanel: View {
             // answer as any other cached row: how much disk it is using.
             // Showing only "Serving" left the one model the user is most
             // likely to be weighing as the single row with no size.
-            // There is still no delete here — the weights are mmap'd
-            // mid-serve — which is what "Serving" says.
+            // Deletion remains available, but its confirmed action stops the
+            // server before touching weights that are currently mmap'd.
             HStack(spacing: ModelTableLayout.cellSpacing) {
                 if let size = Self.onDiskSizeLabel(entry) {
                     Text(size)
@@ -914,6 +921,16 @@ struct SettingsModelManagementPanel: View {
                     .foregroundStyle(.secondary)
                     .lineLimit(1)
                     .minimumScaleFactor(ModelTableLayout.cellMinimumScaleFactor)
+                Button(role: .destructive) {
+                    pendingDeletion = entry
+                } label: {
+                    Image(systemName: "trash").font(.system(size: 11))
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(.secondary)
+                .help("Stop serving and delete this model from disk.")
+                .accessibilityLabel("Stop serving and delete \(entry.alias) from disk")
+                .accessibilityIdentifier("Settings.ModelManagement.Delete.\(entry.alias)")
             }
         case .notCached:
             HStack(spacing: 8) {
@@ -985,10 +1002,10 @@ struct SettingsModelManagementPanel: View {
         } else {
             VStack(alignment: .leading, spacing: 0) {
                 ForEach(Array(entries.enumerated()), id: \.element.alias) { idx, entry in
-                    if entry.kind == .image {
-                        imageRow(for: entry)
-                    } else {
+                    if entry.kind == .chat {
                         row(for: entry)
+                    } else {
+                        capabilityRow(for: entry)
                     }
                     if idx < entries.count - 1 {
                         Divider().opacity(0.5)
@@ -1057,11 +1074,10 @@ struct SettingsModelManagementPanel: View {
         .accessibilityIdentifier("Settings.ModelManagement.Row.\(entry.alias)")
     }
 
-    /// A leaner row for image models: no tok/s meters (a diffusion model has
-    /// no token throughput), just name · repo · size and the same
-    /// download/delete control the chat rows use.
+    /// A leaner row for image/audio models: no chat tok/s meters, just
+    /// name · capability/repo · size and the same download/delete control.
     @ViewBuilder
-    private func imageRow(for entry: ModelEntry) -> some View {
+    private func capabilityRow(for entry: ModelEntry) -> some View {
         let badge = ModelCacheActions.statusBadge(
             for: entry,
             downloadJob: downloads.jobs[entry.alias],
@@ -1074,6 +1090,11 @@ struct SettingsModelManagementPanel: View {
                     .font(.body.weight(.medium))
                     .lineLimit(1)
                     .truncationMode(.middle)
+                if entry.kind == .audio, let audioCapability = entry.audioCapability {
+                    Text(audioCapabilityLabel(audioCapability))
+                        .font(.caption2.weight(.medium))
+                        .foregroundStyle(.secondary)
+                }
                 if let repo = entry.hfRepo {
                     Text(repo)
                         .font(.caption2)
@@ -1089,6 +1110,16 @@ struct SettingsModelManagementPanel: View {
         .padding(.vertical, 8)
         .accessibilityElement(children: .contain)
         .accessibilityIdentifier("Settings.ModelManagement.Row.\(entry.alias)")
+    }
+
+    private func audioCapabilityLabel(_ capability: AudioModelCapability) -> String {
+        switch capability {
+        case .transcription: return "Speech to text"
+        case .alignment: return "Forced alignment"
+        case .speech: return "Text to speech"
+        case .voiceCloning: return "Voice cloning"
+        case .voiceDesign: return "Voice design"
+        }
     }
 
     @ViewBuilder
@@ -1350,7 +1381,9 @@ struct SettingsModelManagementPanel: View {
         if let hit = await ModelCatalogCache.shared.cached(
             binary: binary, generation: generation
         ) {
-            catalog = hit + (await ModelCatalog.imageEntries(binary: binary))
+            async let image = ModelCatalog.imageEntries(binary: binary)
+            async let audio = ModelCatalog.audioEntries(binary: binary)
+            catalog = hit + (await image) + (await audio)
             reconcileCapability()
             loading = false
             return
@@ -1363,8 +1396,9 @@ struct SettingsModelManagementPanel: View {
         let chat = await ModelCatalogCache.shared.entries(
             binary: binary, generation: generation
         )
-        let image = await ModelCatalog.imageEntries(binary: binary)
-        catalog = chat + image
+        async let image = ModelCatalog.imageEntries(binary: binary)
+        async let audio = ModelCatalog.audioEntries(binary: binary)
+        catalog = chat + (await image) + (await audio)
         reconcileCapability()
     }
 
@@ -1383,6 +1417,13 @@ struct SettingsModelManagementPanel: View {
     private func deleteAlias(_ entry: ModelEntry) async {
         lastError = nil
         lastFreed = nil
+        if server.servingAlias == entry.alias {
+            await server.stop()
+            guard server.servingAlias != entry.alias else {
+                lastError = "Couldn't stop \(entry.alias), so it was not deleted."
+                return
+            }
+        }
         let outcome = await ModelCacheActions.runDeletion(
             for: entry,
             binaryPath: server.binaryPath
@@ -1503,12 +1544,11 @@ enum RecommendedCardLayout {
 /// cell rather than the narrowest.
 ///
 /// It was 84pt, sized when a cached cell held two glyphs and nothing
-/// between them. Now that it also carries the measured size, the biggest
-/// caches on a large Mac ("123.4 GiB") need ~88pt, so the column moves to
-/// 100 and the flexible model-name column gives up 16.
+/// between them. Serving rows now carry measured size, status, and a delete
+/// control, so the column is wide enough for all three without truncation.
 enum ModelTableLayout {
     /// Shared width of the Size column.
-    static let sizeColumnWidth: CGFloat = 100
+    static let sizeColumnWidth: CGFloat = 124
 
     /// Spacing between the glyph, the figure and the button in a cell.
     static let cellSpacing: CGFloat = 6
@@ -1556,11 +1596,12 @@ enum ModelTableLayout {
         RecommendedCardLayout.captionWidth("~" + size) + 8 + glyphWidth
     }
 
-    /// Width a serving cell needs: measured size + the "Serving" label
-    /// that stands in for the (deliberately absent) delete button.
+    /// Width a serving cell needs: measured size + status + stop-and-delete.
     static func inUseCellWidth(size: String) -> CGFloat {
         RecommendedCardLayout.captionWidth(size)
             + cellSpacing
             + RecommendedCardLayout.captionMediumWidth("Serving")
+            + cellSpacing
+            + glyphWidth
     }
 }

--- a/apps/rapid-mac/Sources/Rapid/UI/SidebarView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SidebarView.swift
@@ -6,6 +6,7 @@ import SwiftUI
 enum SidebarSection: Hashable {
     case chat
     case images
+    case audio
     case launch
 }
 
@@ -114,6 +115,13 @@ struct SidebarView: View {
                 action: { selection = .images }
             )
             .accessibilityIdentifier("Sidebar.Images")
+            row(
+                title: "Audio",
+                systemImage: "waveform",
+                isSelected: selection == .audio,
+                action: { selection = .audio }
+            )
+            .accessibilityIdentifier("Sidebar.Audio")
             row(
                 title: "Launch",
                 systemImage: "paperplane",

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-depth.five-turns.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-depth.five-turns.txt
@@ -6,6 +6,7 @@ AXApplication title="Rapid-MLX"
         AXGroup subrole=AXHostingView
           AXButton id="Sidebar.NewChat" desc="New Chat" enabled=true
           AXButton id="Sidebar.Images" desc="Images" enabled=true
+          AXButton id="Sidebar.Audio" desc="Audio" enabled=true
           AXButton id="Sidebar.Launch" desc="Launch" enabled=true
           AXScrollArea
             AXHeading desc="<relative-day>" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-depth.restored.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-depth.restored.txt
@@ -6,6 +6,7 @@ AXApplication title="Rapid-MLX"
         AXGroup subrole=AXHostingView
           AXButton id="Sidebar.NewChat" desc="New Chat" enabled=true
           AXButton id="Sidebar.Images" desc="Images" enabled=true
+          AXButton id="Sidebar.Audio" desc="Audio" enabled=true
           AXButton id="Sidebar.Launch" desc="Launch" enabled=true
           AXScrollArea
             AXHeading desc="<relative-day>" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-restore.answered.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-restore.answered.txt
@@ -6,6 +6,7 @@ AXApplication title="Rapid-MLX"
         AXGroup subrole=AXHostingView
           AXButton id="Sidebar.NewChat" desc="New Chat" enabled=true
           AXButton id="Sidebar.Images" desc="Images" enabled=true
+          AXButton id="Sidebar.Audio" desc="Audio" enabled=true
           AXButton id="Sidebar.Launch" desc="Launch" enabled=true
           AXScrollArea
             AXHeading desc="<relative-day>" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-restore.transcript-restored.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-restore.transcript-restored.txt
@@ -6,6 +6,7 @@ AXApplication title="Rapid-MLX"
         AXGroup subrole=AXHostingView
           AXButton id="Sidebar.NewChat" desc="New Chat" enabled=true
           AXButton id="Sidebar.Images" desc="Images" enabled=true
+          AXButton id="Sidebar.Audio" desc="Audio" enabled=true
           AXButton id="Sidebar.Launch" desc="Launch" enabled=true
           AXScrollArea
             AXHeading desc="<relative-day>" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/fresh-install.consent.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/fresh-install.consent.txt
@@ -6,6 +6,7 @@ AXApplication title="Rapid-MLX"
         AXGroup subrole=AXHostingView
           AXButton id="Sidebar.NewChat" desc="New Chat" enabled=true
           AXButton id="Sidebar.Images" desc="Images" enabled=true
+          AXButton id="Sidebar.Audio" desc="Audio" enabled=true
           AXButton id="Sidebar.Launch" desc="Launch" enabled=true
         AXSplitter value=number enabled=false
         AXGroup subrole=AXHostingView

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/fresh-install.steady.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/fresh-install.steady.txt
@@ -6,6 +6,7 @@ AXApplication title="Rapid-MLX"
         AXGroup subrole=AXHostingView
           AXButton id="Sidebar.NewChat" desc="New Chat" enabled=true
           AXButton id="Sidebar.Images" desc="Images" enabled=true
+          AXButton id="Sidebar.Audio" desc="Audio" enabled=true
           AXButton id="Sidebar.Launch" desc="Launch" enabled=true
         AXSplitter value=number enabled=false
         AXGroup subrole=AXHostingView

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/image-generation.generated.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/image-generation.generated.txt
@@ -6,6 +6,7 @@ AXApplication title="Rapid-MLX"
         AXGroup subrole=AXHostingView
           AXButton id="Sidebar.NewChat" desc="New Chat" enabled=true
           AXButton id="Sidebar.Images" desc="Images" enabled=true
+          AXButton id="Sidebar.Audio" desc="Audio" enabled=true
           AXButton id="Sidebar.Launch" desc="Launch" enabled=true
         AXSplitter value=number enabled=false
         AXGroup subrole=AXHostingView

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/model-crash-recovery.recovered.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/model-crash-recovery.recovered.txt
@@ -6,6 +6,7 @@ AXApplication title="Rapid-MLX"
         AXGroup subrole=AXHostingView
           AXButton id="Sidebar.NewChat" desc="New Chat" enabled=true
           AXButton id="Sidebar.Images" desc="Images" enabled=true
+          AXButton id="Sidebar.Audio" desc="Audio" enabled=true
           AXButton id="Sidebar.Launch" desc="Launch" enabled=true
           AXScrollArea
             AXHeading desc="<relative-day>" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-after-relaunch.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-after-relaunch.txt
@@ -6,6 +6,7 @@ AXApplication title="Rapid-MLX"
         AXGroup subrole=AXHostingView
           AXButton id="Sidebar.NewChat" desc="New Chat" enabled=true
           AXButton id="Sidebar.Images" desc="Images" enabled=true
+          AXButton id="Sidebar.Audio" desc="Audio" enabled=true
           AXButton id="Sidebar.Launch" desc="Launch" enabled=true
         AXSplitter value=number enabled=false
         AXGroup subrole=AXHostingView

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-idle.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-idle.txt
@@ -6,6 +6,7 @@ AXApplication title="Rapid-MLX"
         AXGroup subrole=AXHostingView
           AXButton id="Sidebar.NewChat" desc="New Chat" enabled=true
           AXButton id="Sidebar.Images" desc="Images" enabled=true
+          AXButton id="Sidebar.Audio" desc="Audio" enabled=true
           AXButton id="Sidebar.Launch" desc="Launch" enabled=true
         AXSplitter value=number enabled=false
         AXGroup subrole=AXHostingView

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-toggled.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-toggled.txt
@@ -6,6 +6,7 @@ AXApplication title="Rapid-MLX"
         AXGroup subrole=AXHostingView
           AXButton id="Sidebar.NewChat" desc="New Chat" enabled=true
           AXButton id="Sidebar.Images" desc="Images" enabled=true
+          AXButton id="Sidebar.Audio" desc="Audio" enabled=true
           AXButton id="Sidebar.Launch" desc="Launch" enabled=true
         AXSplitter value=number enabled=false
         AXGroup subrole=AXHostingView

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.settings-root.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.settings-root.txt
@@ -6,6 +6,7 @@ AXApplication title="Rapid-MLX"
         AXGroup subrole=AXHostingView
           AXButton id="Sidebar.NewChat" desc="New Chat" enabled=true
           AXButton id="Sidebar.Images" desc="Images" enabled=true
+          AXButton id="Sidebar.Audio" desc="Audio" enabled=true
           AXButton id="Sidebar.Launch" desc="Launch" enabled=true
         AXSplitter value=number enabled=false
         AXGroup subrole=AXHostingView

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/slow-stream-stop.stopped.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/slow-stream-stop.stopped.txt
@@ -6,6 +6,7 @@ AXApplication title="Rapid-MLX"
         AXGroup subrole=AXHostingView
           AXButton id="Sidebar.NewChat" desc="New Chat" enabled=true
           AXButton id="Sidebar.Images" desc="Images" enabled=true
+          AXButton id="Sidebar.Audio" desc="Audio" enabled=true
           AXButton id="Sidebar.Launch" desc="Launch" enabled=true
           AXScrollArea
             AXHeading desc="<relative-day>" enabled=true

--- a/apps/rapid-mac/Tests/RapidTests/AudioCatalogTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/AudioCatalogTests.swift
@@ -1,0 +1,178 @@
+import Foundation
+import Testing
+@testable import Rapid
+
+@Suite("Audio model catalog")
+struct AudioCatalogTests {
+    static let sample = """
+      Available models (1 aliases)
+      Alias                 Size       Tools
+      qwen3.6-27b-4bit      15.0 GiB   hermes
+
+      Audio models (6 aliases)
+      Alias                        Size       Kind       Family        HF id
+      kokoro                       338.9 MiB  [audio:tts] kokoro        mlx-community/Kokoro-82M-bf16
+      whisper-tiny                 71.0 MiB   [audio:stt] whisper       mlx-community/whisper-tiny-mlx
+      qwen3-aligner                1.2 GiB    [audio:stt] qwen3_aligner mlx-community/Qwen3-ForcedAligner-0.6B-8bit
+      qwen3-tts-clone              4.2 GiB    [audio:tts] qwen3_tts     mlx-community/Qwen3-TTS-12Hz-1.7B-Base-bf16
+      qwen3-tts-4bit               1.1 GiB    [audio:tts] qwen3_tts     mlx-community/Qwen3-TTS-12Hz-0.6B-CustomVoice-4bit
+      qwen3-tts-voicedesign-4bit   2.2 GiB    [audio:tts] qwen3_tts     mlx-community/Qwen3-TTS-12Hz-1.7B-VoiceDesign-4bit
+
+      Image models (1 aliases)
+      flux2-klein-4b               4.3 GiB    [image:gen] Runpod/FLUX.2-klein-4B-mflux-4bit
+    """
+
+    @Test("audio mode control places Speech before Transcription")
+    @MainActor
+    func modeOrder() {
+        #expect(AudioViewModel.Mode.allCases == [.speech, .transcription])
+        let viewModel = AudioViewModel(server: ServerManager(testingState: .idle))
+        #expect(viewModel.mode == .speech)
+    }
+
+    @Test("Qwen voice labels and previews follow each speaker's primary language")
+    @MainActor
+    func voiceLanguageProfiles() {
+        #expect(AudioViewModel.voiceDetails(for: "Vivian") == "Chinese · Female")
+        #expect(AudioViewModel.voiceDetails(for: "Uncle_Fu") == "Chinese · Male")
+        #expect(AudioViewModel.voiceDetails(for: "Dylan") == "Chinese · Beijing · Male")
+        #expect(AudioViewModel.voiceDetails(for: "Eric") == "Chinese · Sichuan · Male")
+        #expect(AudioViewModel.voiceDetails(for: "Ryan") == "English · Male")
+        #expect(AudioViewModel.voiceDetails(for: "Ono_Anna") == "Japanese · Female")
+        #expect(AudioViewModel.voiceDetails(for: "Sohee") == "Korean · Female")
+        #expect(AudioViewModel.previewText(for: "Ryan").hasPrefix("Hello"))
+        #expect(AudioViewModel.previewText(for: "Ono_Anna").hasPrefix("こんにちは"))
+        #expect(AudioViewModel.previewText(for: "Sohee").hasPrefix("안녕하세요"))
+    }
+
+    @Test("parser extracts audio rows and preserves subtype, family, size, and repo")
+    func parsesRows() {
+        let rows = ModelCatalog.parseAudioRows(Self.sample)
+        #expect(rows.count == 6)
+        let kokoro = rows.first { $0.alias == "kokoro" }
+        #expect(kokoro?.subtype == "tts")
+        #expect(kokoro?.family == "kokoro")
+        #expect(kokoro?.size == "338.9 MiB")
+        #expect(kokoro?.hfRepo == "mlx-community/Kokoro-82M-bf16")
+        #expect(!rows.contains { $0.alias == "qwen3.6-27b-4bit" })
+        #expect(!rows.contains { $0.alias == "flux2-klein-4b" })
+    }
+
+    @Test("operation classification keeps unsupported audio shapes out of basic pickers")
+    func classifiesOperations() {
+        #expect(ModelCatalog.audioCapability(
+            alias: "whisper-tiny", subtype: "stt", family: "whisper"
+        ) == .transcription)
+        #expect(ModelCatalog.audioCapability(
+            alias: "qwen3-aligner", subtype: "stt", family: "qwen3_aligner"
+        ) == .alignment)
+        #expect(ModelCatalog.audioCapability(
+            alias: "kokoro", subtype: "tts", family: "kokoro"
+        ) == .speech)
+        #expect(ModelCatalog.audioCapability(
+            alias: "qwen3-tts-clone", subtype: "tts", family: "qwen3_tts"
+        ) == .voiceCloning)
+        #expect(ModelCatalog.audioCapability(
+            alias: "qwen3-tts-voicedesign-4bit", subtype: "tts", family: "qwen3_tts"
+        ) == .voiceDesign)
+    }
+
+    @Test("audio rows remain excluded from the chat catalog")
+    func staysOutOfChat() {
+        let available = ModelCatalog.parseAvailable(Self.sample).map(\.0)
+        #expect(available.contains("qwen3.6-27b-4bit"))
+        #expect(!available.contains("kokoro"))
+        #expect(!available.contains("whisper-tiny"))
+        let excluded = ModelCatalog.parseExcludedAliases(Self.sample)
+        #expect(excluded.contains("kokoro"))
+        #expect(excluded.contains("whisper-tiny"))
+    }
+
+    @Test("speech picker exposes only Qwen3 preset-voice models")
+    @MainActor
+    func filtersSpeechPickerModels() {
+        let viewModel = AudioViewModel(server: ServerManager(testingState: .idle))
+        viewModel.audioModels = [
+            audioEntry(alias: "qwen3-tts-4bit", capability: .speech, family: "qwen3_tts"),
+            audioEntry(alias: "qwen3-tts-clone", capability: .voiceCloning, family: "qwen3_tts"),
+            audioEntry(alias: "qwen3-tts-voicedesign-4bit", capability: .voiceDesign, family: "qwen3_tts"),
+            audioEntry(alias: "kokoro", capability: .speech, family: "kokoro"),
+            audioEntry(alias: "whisper-tiny", capability: .transcription, family: "whisper"),
+            audioEntry(alias: "whisper-small", capability: .transcription, family: "whisper"),
+        ]
+
+        #expect(viewModel.speechModels.map(\.alias) == ["qwen3-tts-4bit"])
+        #expect(viewModel.transcriptionModels.map(\.alias) == ["whisper-small"])
+        #expect(!ModelCatalog.isDesktopAudioAliasVisible("whisper-tiny"))
+        #expect(ModelCatalog.isDesktopAudioAliasVisible("whisper-small"))
+    }
+
+    @Test("audio surface refreshes after a background model download")
+    func refreshesOnCacheGeneration() throws {
+        let source = try String(contentsOf: Self.audioViewURL, encoding: .utf8)
+
+        #expect(source.contains("@Environment(DownloadManager.self) private var downloads"))
+        #expect(source.contains(".task(id: downloads.cacheGeneration)"),
+                "The Audio view may stay mounted while Settings downloads a model.")
+        #expect(source.contains("WAV, MP3, M4A, AAC, FLAC, or MP4 - up to 25 MB"))
+        #expect(!source.contains("OGG, Opus, WebM"),
+                "The desktop sidecar does not bundle ffmpeg for these formats.")
+    }
+
+    @Test("unmapped audio cache rows match their Hugging Face repo")
+    func matchesUnmappedAudioCacheByRepo() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("rapid-audio-catalog-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let binary = directory.appendingPathComponent("rapid-mlx")
+        let script = """
+        #!/bin/sh
+        if [ "$1" = "models" ]; then
+          cat <<'EOF'
+          Audio models (1 aliases)
+          Alias               Size       Kind        Family      HF id
+          qwen3-tts-4bit      2.2 GiB    [audio:tts] qwen3_tts   mlx-community/Qwen3-TTS-12Hz-1.7B-CustomVoice-4bit
+        EOF
+        else
+          cat <<'EOF'
+          Cached models (1 on disk)
+          Alias        HF repo                                              Size
+          (unmapped)             mlx-community/Qwen3-TTS-12Hz-1.7B-CustomVoice-4bit 2.2 GiB   29m ago
+        EOF
+        fi
+        """
+        try script.write(to: binary, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: binary.path)
+
+        let entries = await ModelCatalog.audioEntries(binary: binary, hubCacheOverride: nil)
+        let qwen = try #require(entries.first { $0.alias == "qwen3-tts-4bit" })
+
+        #expect(qwen.cached)
+        #expect(qwen.sizeOnDisk == "2.2 GiB")
+    }
+
+    private func audioEntry(
+        alias: String,
+        capability: AudioModelCapability,
+        family: String
+    ) -> ModelEntry {
+        ModelEntry(
+            alias: alias,
+            hfRepo: "mlx-community/\(alias)",
+            sizeOnDisk: nil,
+            cached: false,
+            kind: .audio,
+            audioCapability: capability,
+            audioFamily: family
+        )
+    }
+
+    private static var audioViewURL: URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent() // RapidTests
+            .deletingLastPathComponent() // Tests
+            .deletingLastPathComponent() // rapid-mac
+            .appendingPathComponent("Sources/Rapid/UI/AudioView.swift")
+    }
+}

--- a/apps/rapid-mac/Tests/RapidTests/AudioClientTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/AudioClientTests.swift
@@ -1,0 +1,295 @@
+import Foundation
+import AVFoundation
+import Testing
+@testable import Rapid
+
+@Suite("AudioClient wire contract", .serialized)
+struct AudioClientTests {
+    private func makeClient() -> AudioClient {
+        AudioStubProtocol.reset()
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [AudioStubProtocol.self]
+        return AudioClient(session: URLSession(configuration: config))
+    }
+
+    @Test("Transcription uploads multipart audio with model and bearer")
+    @MainActor
+    func transcriptionRequest() async throws {
+        let client = makeClient()
+        AudioStubProtocol.response = (
+            200,
+            ["Content-Type": "application/json"],
+            Data(#"{"text":"hello world","language":"en","duration":1.25}"#.utf8)
+        )
+        let file = temporaryFile(name: "sample.wav", data: Data("RIFFrapid-audio".utf8))
+        defer { try? FileManager.default.removeItem(at: file.deletingLastPathComponent()) }
+
+        let result = try await client.transcribe(
+            fileURL: file,
+            model: "whisper-tiny",
+            port: 8123,
+            bearer: "secret"
+        )
+
+        #expect(result == AudioTranscriptionResult(text: "hello world", language: "en", duration: 1.25))
+        let request = try #require(AudioStubProtocol.requests.first)
+        #expect(request.url?.absoluteString == "http://127.0.0.1:8123/v1/audio/transcriptions")
+        #expect(request.httpMethod == "POST")
+        #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer secret")
+        #expect(request.value(forHTTPHeaderField: "Content-Type")?.hasPrefix("multipart/form-data; boundary=") == true)
+
+        let body = String(decoding: try #require(AudioStubProtocol.bodies.first), as: UTF8.self)
+        #expect(body.contains("name=\"model\"\r\n\r\nwhisper-tiny"))
+        #expect(body.contains("name=\"response_format\"\r\n\r\njson"))
+        #expect(body.contains("name=\"file\"; filename=\"input.wav\""))
+        #expect(body.contains("Content-Type: audio/wav"))
+        #expect(body.contains("RIFFrapid-audio"))
+    }
+
+    @Test("M4A transcription is normalized to a 16 kHz WAV upload")
+    @MainActor
+    func m4aTranscriptionRequest() async throws {
+        let client = makeClient()
+        AudioStubProtocol.response = (
+            200,
+            ["Content-Type": "application/json"],
+            Data(#"{"text":"local m4a","language":"en","duration":0.1}"#.utf8)
+        )
+        let file = try temporaryM4A()
+        defer { try? FileManager.default.removeItem(at: file.deletingLastPathComponent()) }
+
+        _ = try await client.transcribe(
+            fileURL: file,
+            model: "whisper-medium",
+            port: 8124,
+            bearer: nil
+        )
+
+        let bodyData = try #require(AudioStubProtocol.bodies.first)
+        let body = String(decoding: bodyData, as: UTF8.self)
+        #expect(body.contains("name=\"file\"; filename=\"input.wav\""))
+        #expect(body.contains("Content-Type: audio/wav"))
+        #expect(bodyData.range(of: Data("RIFF".utf8)) != nil)
+        #expect(bodyData.range(of: Data("WAVEfmt ".utf8)) != nil)
+    }
+
+    @Test("Voices sends model query and omits an empty bearer")
+    @MainActor
+    func voicesRequest() async throws {
+        let client = makeClient()
+        AudioStubProtocol.response = (
+            200,
+            ["Content-Type": "application/json"],
+            Data(#"{"voices":["af_heart","bf_emma"]}"#.utf8)
+        )
+
+        let voices = try await client.voices(model: "kokoro", port: 8222, bearer: "")
+
+        #expect(voices == ["af_heart", "bf_emma"])
+        let request = try #require(AudioStubProtocol.requests.first)
+        #expect(request.url?.path == "/v1/audio/voices")
+        #expect(URLComponents(url: try #require(request.url), resolvingAgainstBaseURL: false)?
+            .queryItems == [URLQueryItem(name: "model", value: "kokoro")])
+        #expect(request.value(forHTTPHeaderField: "Authorization") == nil)
+    }
+
+    @Test("Speech sends the OpenAI JSON shape and preserves WAV bytes")
+    @MainActor
+    func speechRequest() async throws {
+        let client = makeClient()
+        let wav = Data([0x52, 0x49, 0x46, 0x46, 0x01, 0x02])
+        AudioStubProtocol.response = (200, ["Content-Type": "audio/wav"], wav)
+
+        let result = try await client.synthesize(
+            text: "Hello locally",
+            model: "kokoro-4bit",
+            voice: "af_heart",
+            speed: 1.15,
+            port: 8333,
+            bearer: "token"
+        )
+
+        #expect(result == SynthesizedAudio(data: wav, contentType: "audio/wav"))
+        let request = try #require(AudioStubProtocol.requests.first)
+        #expect(request.url?.path == "/v1/audio/speech")
+        #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer token")
+        #expect(request.value(forHTTPHeaderField: "Accept") == "audio/wav")
+        let body = try JSONSerialization.jsonObject(
+            with: try #require(AudioStubProtocol.bodies.first)
+        ) as? [String: Any]
+        #expect(body?["model"] as? String == "kokoro-4bit")
+        #expect(body?["input"] as? String == "Hello locally")
+        #expect(body?["voice"] as? String == "af_heart")
+        #expect(body?["speed"] as? Double == 1.15)
+        #expect(body?["response_format"] as? String == "wav")
+    }
+
+    @Test("Voice preview uses the requested voice without changing the selection")
+    @MainActor
+    func voicePreview() async throws {
+        let client = makeClient()
+        let wav = Data([0x52, 0x49, 0x46, 0x46, 0x03, 0x04])
+        AudioStubProtocol.response = (200, ["Content-Type": "audio/wav"], wav)
+        let server = ServerManager(testingState: .ready(alias: "qwen3-tts-4bit"))
+        let viewModel = AudioViewModel(server: server, client: client)
+        viewModel.audioModels = [
+            ModelEntry(
+                alias: "qwen3-tts-4bit",
+                hfRepo: "mlx-community/Qwen3-TTS-12Hz-0.6B-CustomVoice-4bit",
+                sizeOnDisk: "1.1 GiB",
+                cached: true,
+                kind: .audio,
+                audioCapability: .speech,
+                audioFamily: "qwen3_tts"
+            )
+        ]
+        viewModel.selectedSpeechAlias = "qwen3-tts-4bit"
+        viewModel.voices = ["Vivian", "Serena"]
+        viewModel.selectedVoice = "Vivian"
+
+        let result = await viewModel.previewVoice("Serena")
+
+        #expect(result == SynthesizedAudio(data: wav, contentType: "audio/wav"))
+        #expect(viewModel.selectedVoice == "Vivian")
+        #expect(viewModel.previewingVoice == nil)
+        let body = try JSONSerialization.jsonObject(
+            with: try #require(AudioStubProtocol.bodies.first)
+        ) as? [String: Any]
+        #expect(body?["model"] as? String == "qwen3-tts-4bit")
+        #expect(body?["input"] as? String == "你好，这是我的声音，很高兴认识你。")
+        #expect(body?["voice"] as? String == "Serena")
+    }
+
+    @Test("Nested server detail is exposed as the user-facing failure")
+    @MainActor
+    func nestedServerError() async throws {
+        let client = makeClient()
+        AudioStubProtocol.response = (
+            500,
+            ["Content-Type": "application/json"],
+            Data(#"{"detail":{"error":{"message":"audio runtime is unavailable"}}}"#.utf8)
+        )
+
+        do {
+            _ = try await client.voices(model: "kokoro", port: 8444, bearer: nil)
+            Issue.record("Expected the HTTP error")
+        } catch let error as AudioClientError {
+            #expect(error == .http(status: 500, message: "audio runtime is unavailable"))
+            #expect(error.errorDescription == "audio runtime is unavailable")
+        }
+    }
+
+    @Test("Files larger than 25 MB are rejected before transport")
+    @MainActor
+    func oversizedFile() async throws {
+        let client = makeClient()
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("rapid-audio-test-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let file = directory.appendingPathComponent("large.wav")
+        FileManager.default.createFile(atPath: file.path, contents: nil)
+        let handle = try FileHandle(forWritingTo: file)
+        try handle.truncate(atOffset: UInt64(AudioClient.maxUploadBytes + 1))
+        try handle.close()
+
+        do {
+            _ = try await client.transcribe(
+                fileURL: file,
+                model: "whisper-tiny",
+                port: 8555,
+                bearer: nil
+            )
+            Issue.record("Expected the file-size error")
+        } catch let error as AudioClientError {
+            #expect(error == .fileTooLarge(maxBytes: AudioClient.maxUploadBytes))
+        }
+        #expect(AudioStubProtocol.requests.isEmpty)
+    }
+
+    private func temporaryFile(name: String, data: Data) -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("rapid-audio-test-\(UUID().uuidString)", isDirectory: true)
+        try! FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let file = directory.appendingPathComponent(name)
+        try! data.write(to: file)
+        return file
+    }
+
+    private func temporaryM4A() throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("rapid-audio-test-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let file = directory.appendingPathComponent("sample.m4a")
+        let sampleRate = 44_100.0
+        let format = try #require(AVAudioFormat(
+            standardFormatWithSampleRate: sampleRate,
+            channels: 1
+        ))
+        let frames: AVAudioFrameCount = 4_410
+        let buffer = try #require(AVAudioPCMBuffer(pcmFormat: format, frameCapacity: frames))
+        buffer.frameLength = frames
+        let samples = try #require(buffer.floatChannelData?[0])
+        for index in 0..<Int(frames) {
+            samples[index] = Float(sin(2.0 * .pi * 440.0 * Double(index) / sampleRate) * 0.2)
+        }
+        let output = try AVAudioFile(
+            forWriting: file,
+            settings: [
+                AVFormatIDKey: kAudioFormatMPEG4AAC,
+                AVSampleRateKey: sampleRate,
+                AVNumberOfChannelsKey: 1,
+                AVEncoderBitRateKey: 64_000,
+            ]
+        )
+        try output.write(from: buffer)
+        return file
+    }
+}
+
+private final class AudioStubProtocol: URLProtocol, @unchecked Sendable {
+    nonisolated(unsafe) static var requests: [URLRequest] = []
+    nonisolated(unsafe) static var bodies: [Data] = []
+    nonisolated(unsafe) static var response: (Int, [String: String], Data) = (200, [:], Data())
+
+    static func reset() {
+        requests = []
+        bodies = []
+        response = (200, [:], Data())
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        Self.requests.append(request)
+        Self.bodies.append(Self.readBody(from: request))
+        let (status, headers, data) = Self.response
+        let response = HTTPURLResponse(
+            url: request.url!,
+            statusCode: status,
+            httpVersion: "HTTP/1.1",
+            headerFields: headers
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: data)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+
+    private static func readBody(from request: URLRequest) -> Data {
+        if let body = request.httpBody { return body }
+        guard let stream = request.httpBodyStream else { return Data() }
+        stream.open()
+        defer { stream.close() }
+        var data = Data()
+        var buffer = [UInt8](repeating: 0, count: 4096)
+        while true {
+            let count = stream.read(&buffer, maxLength: buffer.count)
+            if count <= 0 { break }
+            data.append(buffer, count: count)
+        }
+        return data
+    }
+}

--- a/apps/rapid-mac/Tests/RapidTests/AutoRestartAndRegenRaceTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/AutoRestartAndRegenRaceTests.swift
@@ -113,4 +113,29 @@ struct AutoRestartAndRegenRaceTests {
         ))
     }
 
+    @Test("audio aliases skip the in-process residency load and use stop/start")
+    func audioBypassesResidencyLoad() {
+        // The engine's residency loader raises a 500 for the audio (and
+        // video-gen) modality, which is NOT the 404/405 that triggers
+        // ensureServing's stop/start fallback. Audio callers therefore pass
+        // residencyEligible: false and must skip the residency path even when
+        // a non-audio model is already resident (ready + child present).
+        #expect(!ServerManager.residencyLoadApplies(
+            residencyEligible: false,
+            readyWithChild: true
+        ))
+        // Residency-eligible modalities (chat/VLM, image-gen, text-diffusion)
+        // still admit a second engine in-process when one is already running.
+        #expect(ServerManager.residencyLoadApplies(
+            residencyEligible: true,
+            readyWithChild: true
+        ))
+        // No resident process yet: even an eligible model has nothing to load
+        // into, so ensureServing goes straight to start().
+        #expect(!ServerManager.residencyLoadApplies(
+            residencyEligible: true,
+            readyWithChild: false
+        ))
+    }
+
 }

--- a/apps/rapid-mac/Tests/RapidTests/AutoRestartAndRegenRaceTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/AutoRestartAndRegenRaceTests.swift
@@ -101,4 +101,16 @@ struct AutoRestartAndRegenRaceTests {
         #expect(await server.ensureServing(alias: "   ") == false)
     }
 
+    @Test("internal model replacement preserves the resume alias")
+    func modelReplacementPreservesLastServedAlias() {
+        #expect(!ServerManager.shouldClearLastServedAlias(
+            expectedStop: true,
+            preservingLastServedAlias: true
+        ))
+        #expect(ServerManager.shouldClearLastServedAlias(
+            expectedStop: true,
+            preservingLastServedAlias: false
+        ))
+    }
+
 }

--- a/apps/rapid-mac/Tests/RapidTests/ExternalModelCatalogTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ExternalModelCatalogTests.swift
@@ -163,7 +163,7 @@ struct ExternalModelCatalogTests {
         let outcome = await ModelCacheActions.runDeletion(
             for: entry,
             binaryPath: URL(fileURLWithPath: "/nonexistent-binary"),
-            delete: { _, alias in
+            delete: { _, alias, _ in
                 await probe.record(alias)
                 return .freed(bytes: 1024, raw: "Freed 1.0 KiB")
             }

--- a/apps/rapid-mac/Tests/RapidTests/ExternalModelCatalogTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ExternalModelCatalogTests.swift
@@ -136,7 +136,7 @@ struct ExternalModelCatalogTests {
         let outcome = await ModelCacheActions.runDeletion(
             for: entry,
             binaryPath: URL(fileURLWithPath: "/bin/echo"),
-            delete: { _, alias in
+            delete: { _, alias, _ in
                 await probe.record(alias)
                 return .freed(bytes: 1, raw: "should not run")
             }

--- a/apps/rapid-mac/Tests/RapidTests/LaunchOnboardingOrderingTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/LaunchOnboardingOrderingTests.swift
@@ -39,6 +39,14 @@ import Testing
 @Suite("#1589 — launch auto-start must not outrace first-run onboarding")
 struct LaunchOnboardingOrderingTests {
 
+    @Test("Quickstart cannot interrupt Audio, Images, or Launch")
+    func quickstartOnlyPresentsOnChat() {
+        #expect(ContentView.quickstartCanPresent(in: .chat))
+        #expect(!ContentView.quickstartCanPresent(in: .audio))
+        #expect(!ContentView.quickstartCanPresent(in: .images))
+        #expect(!ContentView.quickstartCanPresent(in: .launch))
+    }
+
     /// Convenience: the launch gate exactly as ``ContentView`` calls it,
     /// for a user sitting at the pre-auto-start ``.idle`` state.
     private func launchDecision(

--- a/apps/rapid-mac/Tests/RapidTests/ModelCacheActionsTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ModelCacheActionsTests.swift
@@ -112,6 +112,13 @@ struct ModelCacheActionsTests {
         #expect(!copy.message.contains("Frees "))
     }
 
+    @Test("deletionConfirmation: serving model explains stop-before-delete")
+    func deletionConfirmationServing() {
+        let e = entry("qwen3-tts-4bit", cached: true, size: "2.2 GiB")
+        let copy = ModelCacheActions.deletionConfirmation(for: e, isServing: true)
+        #expect(copy.message.hasPrefix("Stops the currently serving model first."))
+    }
+
     @Test("deletionConfirmation: matches ModelPickerBar.deletionTitle shape")
     func deletionConfirmationParityWithPicker() {
         // Issue #210 is explicit that the two surfaces present the

--- a/apps/rapid-mac/Tests/RapidTests/ModelDeletionTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ModelDeletionTests.swift
@@ -286,6 +286,32 @@ struct ModelDeletionBoundaryTests {
         #expect(outcome == .failed(message: "That model name isn't valid."))
     }
 
+    @Test("Known non-chat repo can be deleted without re-entering the chat-only catalog")
+    func knownRepoDeletesAudioSnapshot() async throws {
+        let tmp = try makeTmpDir()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        let hub = tmp.appendingPathComponent("hub", isDirectory: true)
+        try FileManager.default.createDirectory(at: hub, withIntermediateDirectories: true)
+
+        let repo = "mlx-community/Kokoro-82M-bf16"
+        let dirName = try #require(ModelDeletion._testingCacheDirectoryName(forRepo: repo))
+        let target = hub.appendingPathComponent(dirName, isDirectory: true)
+        try FileManager.default.createDirectory(at: target, withIntermediateDirectories: true)
+        try Data("audio weights".utf8).write(to: target.appendingPathComponent("weights.npz"))
+
+        let outcome = await ModelDeletion.deleteCachedModel(
+            binaryPath: URL(fileURLWithPath: "/bin/echo"),
+            alias: "kokoro",
+            knownRepo: repo,
+            hubCacheRoot: hub
+        )
+        guard case .freed = outcome else {
+            Issue.record("Expected successful audio delete, got \(outcome)")
+            return
+        }
+        #expect(!FileManager.default.fileExists(atPath: target.path))
+    }
+
     private func makeTmpDir() throws -> URL {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("rapid-model-deletion-\(UUID().uuidString)", isDirectory: true)

--- a/apps/rapid-mac/Tests/RapidTests/ModelSurfaceRedesignTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ModelSurfaceRedesignTests.swift
@@ -546,9 +546,9 @@ struct ModelSurfaceRedesignTests {
     }
 
     /// The serving row is a cached row too — it owes the same size, and
-    /// the "Serving" label it carries instead of a delete button is wider
-    /// than that button, so it needs its own width check.
-    @Test("size column: a serving cell fits its size next to \"Serving\"")
+    /// the "Serving" label and stop-and-delete button need their own width
+    /// check.
+    @Test("size column: a serving cell fits its size, status, and delete button")
     func inUseCellFitsTheSizeColumn() {
         for size in ["7.9 GiB", "35.2 GiB", "123.4 GiB"] {
             let needed = ModelTableLayout.inUseCellWidth(size: size)

--- a/apps/rapid-mac/Tests/RapidTests/SidecarBuildScriptTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SidecarBuildScriptTests.swift
@@ -89,6 +89,39 @@ struct SidecarBuildScriptTests {
                 "A post-patch import probe must prove the image lane needs no torch.")
     }
 
+    @Test("Desktop sidecar bundles and smokes both audio lanes")
+    func audioRuntimeIsBundled() throws {
+        let script = try String(contentsOf: Self.scriptURL, encoding: .utf8)
+        let pyproject = try String(contentsOf: Self.pyprojectURL, encoding: .utf8)
+
+        #expect(pyproject.contains("\naudio-desktop = ["),
+                "The bounded desktop audio dependency group must remain separately installable.")
+        #expect(pyproject.contains(#""mlx-audio>=0.2.9,<0.4.4""#))
+        #expect(pyproject.contains(#""soundfile>=0.12.0""#))
+        #expect(script.contains(#""${RAPID_MLX_SOURCE}[audio-desktop]""#),
+                "The desktop sidecar must install the bounded desktop audio dependency set.")
+        #expect(script.contains("from mlx_audio.stt.utils import load_model"),
+                "The build smoke must import the transcription loader, not only mlx_audio's package root.")
+        #expect(script.contains("from transformers.models.whisper.feature_extraction_whisper import WhisperFeatureExtractor"),
+                "The build smoke must prove the processor implementation survives trimming.")
+        #expect(script.contains(#"-not -path "*/transformers/models/whisper/feature_extraction_whisper.py""#),
+                "Whisper's processor fallback cannot work when its feature extractor is trimmed.")
+        #expect(script.contains("from mlx_audio.tts.generate import load_model"),
+                "The build smoke must import the speech loader.")
+        #expect(script.contains("from mlx_audio.tts.models.qwen3_tts import Model"),
+                "The smoke must cover the preset-voice family exposed by the desktop picker.")
+        #expect(script.contains("from scipy import signal"),
+                "The smoke must cover the resampler after SciPy trimming.")
+        #expect(script.contains("TTSEngine.__new__(TTSEngine).to_bytes"),
+                "The smoke must encode a WAV after scipy.io has been trimmed.")
+        #expect(script.contains(#"-not -name qwen3_tts -not -name __pycache__"#),
+                "Only model-family directories outside Qwen3 TTS may be removed.")
+        #expect(!script.contains(#"rm -rf "$STAGE/site-packages/mlx_audio/tts/models""#),
+                "The trim must never remove the complete TTS model directory.")
+        #expect(script.contains(#"MACHO_BASELINE_COUNT="${MACHO_BASELINE_COUNT:-174}""#),
+                "The signing baseline must match the measured post-audio bundle.")
+    }
+
     private static var scriptURL: URL {
         URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()
@@ -99,5 +132,14 @@ struct SidecarBuildScriptTests {
 
     private static var appBuildScriptURL: URL {
         scriptURL.deletingLastPathComponent().appendingPathComponent("build.sh")
+    }
+
+    private static var pyprojectURL: URL {
+        scriptURL
+            .deletingLastPathComponent() // scripts
+            .deletingLastPathComponent() // rapid-mac
+            .deletingLastPathComponent() // apps
+            .deletingLastPathComponent() // repository root
+            .appendingPathComponent("pyproject.toml")
     }
 }

--- a/apps/rapid-mac/scripts/build-sidecar.sh
+++ b/apps/rapid-mac/scripts/build-sidecar.sh
@@ -86,7 +86,14 @@ COMPILEALL_JOBS="${COMPILEALL_JOBS:-0}"
 # dead weight). No signing-safety implication: we are REMOVING Mach-Os we
 # used to sign, not adding new ones. The embedded-pip and numpy-tests
 # trims in the same pass are pure-Python and Mach-O-neutral.
-MACHO_BASELINE_COUNT="${MACHO_BASELINE_COUNT:-70}"
+#
+# Re-locked at 174 on 2026-08-10 after adding the bounded desktop Audio
+# runtime (mlx-audio, SciPy's signal import closure, and libsndfile). This is
+# the measured post-trim count from the pinned Python 3.12 bundle with both
+# STT and Qwen3-TTS smoke imports passing. The non-Qwen TTS implementations
+# and SciPy subpackages outside the signal closure have already been removed
+# before this count is taken.
+MACHO_BASELINE_COUNT="${MACHO_BASELINE_COUNT:-174}"
 # Allow modest drift without blocking — wheel updates sometimes shift
 # 1-2 .so files. Bigger drift means a new dependency, needs review.
 # Kept at 5 across the 51 → 77 baseline rebase to give Pillow and
@@ -246,7 +253,7 @@ fi
     --no-warn-script-location \
     --no-compile \
     --upgrade \
-    "$RAPID_MLX_SOURCE" \
+    "${RAPID_MLX_SOURCE}[audio-desktop]" \
     'transformers>=5.5.0,<5.13'
 
 # ----- step 2.5: bundle mlx-vlm --no-deps + Pillow ---------------------
@@ -495,6 +502,13 @@ find "$STAGE" -type d -name __pycache__ -prune -exec rm -rf {} +
 #     transformers/models/* via `-not -path "*/transformers/models/*"`,
 #     so the preserved .py files stay in source form and the
 #     transformers lazy import_structure registry still finds them.
+#
+# The desktop STT lane also needs WhisperFeatureExtractor. mlx-community's
+# MLX Whisper checkpoints intentionally contain weights/config only, so
+# STTEngine attaches a WhisperProcessor from the matching openai/whisper-*
+# repo. Deleting feature_extraction_whisper.py makes that processor fail even
+# when all of its config/tokenizer files are available. Preserve this single
+# audio implementation without retaining every transformers audio family.
 
 echo "==> building multimodal trim allowlist from mlx-vlm bundled models"
 VLM_DIRS=()
@@ -532,17 +546,56 @@ find "$STAGE/site-packages/transformers/models" \
 find "$STAGE/site-packages/transformers/models" \
     "${PRUNE_ARGS[@]}" -o \
     \( -name "image_processing_*.py" -o -name "feature_extraction_*.py" \) \
+    -not -path "*/transformers/models/whisper/feature_extraction_whisper.py" \
     -print -delete
 
 echo "==> trimming numpy dev/test detritus"
 rm -rf \
-    "$STAGE/site-packages/numpy/random/_examples" \
-    "$STAGE/site-packages/numpy/testing/_private/extbuild.py" 2>/dev/null || true
+    "$STAGE/site-packages/numpy/random/_examples" 2>/dev/null || true
 # Sweep every numpy `tests/` package (~9 MB across _core, lib, ma,
 # random, linalg, polynomial, matrixlib, fft, testing, typing, f2py,
 # distutils). numpy never imports its own test suites at runtime, and
 # they carry no Mach-Os (verified: pure .py + data fixtures).
 find "$STAGE/site-packages/numpy" -type d -name tests -prune -exec rm -rf {} + 2>/dev/null || true
+
+# Audio adds SciPy and mlx-audio, whose wheels include ~23 MB of their own
+# unit suites. Runtime never imports those suites. Keep
+# numpy.testing._private.extbuild above, however: SciPy 1.18's Array API
+# compatibility bootstrap clones NumPy's public attributes and imports
+# numpy.testing while `from scipy import signal` initializes.
+find "$STAGE/site-packages/scipy" -type d -name tests -prune -exec rm -rf {} + 2>/dev/null || true
+find "$STAGE/site-packages/mlx_audio" -type d -name tests -prune -exec rm -rf {} + 2>/dev/null || true
+
+# The desktop Audio surface uses scipy.signal for input resampling. Speech WAV
+# output uses the standard-library `wave` writer, so scipy.io is not required.
+# SciPy's
+# signal import closure covers _lib/_external plus constants, fft, integrate,
+# interpolate, linalg, ndimage, optimize, sparse, spatial, special, and stats;
+# the subpackages below remain outside that closure (verified in the bundled
+# interpreter) and are not referenced anywhere in mlx_audio. Removing them
+# saves several MB and their native extensions while keeping the resampler
+# under the build smoke below.
+rm -rf \
+    "$STAGE/site-packages/scipy/cluster" \
+    "$STAGE/site-packages/scipy/datasets" \
+    "$STAGE/site-packages/scipy/differentiate" \
+    "$STAGE/site-packages/scipy/fftpack" \
+    "$STAGE/site-packages/scipy/io" \
+    "$STAGE/site-packages/scipy/misc" \
+    "$STAGE/site-packages/scipy/odr"
+
+# mlx-audio ships implementations for dozens of TTS families. The desktop
+# picker deliberately exposes only Qwen3 CustomVoice: it offers real named
+# preset speakers without the large Kokoro G2P or F5 cloning dependency
+# stacks. Drop the other family implementations so the release stays below
+# the app's 500 MiB envelope; shared TTS utilities and Qwen3's codec modules
+# remain intact.
+if [ -d "$STAGE/site-packages/mlx_audio/tts/models" ]; then
+    find "$STAGE/site-packages/mlx_audio/tts/models" \
+        -mindepth 1 -maxdepth 1 -type d \
+        -not -name qwen3_tts -not -name __pycache__ \
+        -prune -exec rm -rf {} +
+fi
 
 # Pre-compile every .py in the bundled stdlib + site-packages BEFORE
 # we codesign. Otherwise CPython's import machinery writes .pyc files
@@ -807,6 +860,23 @@ else
         exit 3
     }
     echo "    mlx_vlm import: $VLM_OUT"
+
+    # Audio surface smoke. Import both engine lanes and the Qwen3 preset-voice
+    # implementation without loading model weights. A base-only sidecar can
+    # register the routes but exits when an audio alias boots; checking the
+    # actual loader modules here prevents the desktop from shipping controls
+    # that can never complete a request.
+    AUDIO_OUT="$(env -i HOME="$SMOKE_HOME" PATH=/usr/bin:/bin \
+        PYTHONHOME="$STAGE/python" \
+        PYTHONPATH="$STAGE/site-packages" \
+        PYTHONNOUSERSITE=1 \
+        "$STAGE/python/bin/python3.12" -s -c \
+        'from importlib.metadata import version; import numpy as np; import mlx_audio; from mlx_audio.stt.utils import load_model as load_stt_model; from transformers.models.whisper.feature_extraction_whisper import WhisperFeatureExtractor; from mlx_audio.tts.generate import load_model as load_tts_model; from mlx_audio.tts.models.qwen3_tts import Model as Qwen3TTSModel; from scipy import signal; import soundfile; from vllm_mlx.audio.tts import AudioOutput, TTSEngine; payload = TTSEngine.__new__(TTSEngine).to_bytes(AudioOutput(audio=np.zeros(8, dtype=np.float32), sample_rate=24000, duration=8/24000), format="wav"); assert payload.startswith(b"RIFF"); print("mlx_audio", version("mlx-audio"))' 2>&1)" || {
+        echo "ERR: bundled audio runtime import failed — desktop Audio would be unusable:" >&2
+        echo "$AUDIO_OUT" >&2
+        exit 3
+    }
+    echo "    audio import: $AUDIO_OUT"
 
     # codex r3 B1: capture inside an `if` instead of separate
     # `X=$(...); RC=$?` lines — under `set -e`, a command-substitution

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -416,6 +416,17 @@ audio = [
     # Additional multilingual dependencies
     "cn2an>=0.5.0",          # Chinese number conversion
 ]
+# Audio dependencies shipped inside the macOS desktop sidecar. The desktop
+# exposes transcription plus Qwen3 preset-voice speech; it does not expose
+# F5 cloning, Kokoro's language-specific G2P stack, or voice design. Keeping
+# those families in the full [audio] extra avoids making the public engine
+# less capable while preventing the signed app from absorbing llvmlite,
+# spaCy, espeak, and language dictionaries it cannot drive from its UI.
+audio-desktop = [
+    "mlx-audio>=0.2.9,<0.4.4",
+    # vllm_mlx.audio.tts encodes the in-memory result with libsndfile.
+    "soundfile>=0.12.0",
+]
 video = [
     # MLX-native LTX-2.3 T2V/I2V with synchronized audio. 0.1.36 is the
     # first verified release with the split-format LTX-2.3 VAE fixes. The

--- a/tests/test_audio_desktop_extra.py
+++ b/tests/test_audio_desktop_extra.py
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Lock in the bounded audio dependency group used by the macOS sidecar."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+try:
+    import tomllib  # type: ignore[import-not-found]
+except ModuleNotFoundError:  # pragma: no cover - Python 3.10 fallback
+    import tomli as tomllib  # type: ignore[import-not-found,no-redef]
+
+
+PYPROJECT_PATH = Path(__file__).resolve().parents[1] / "pyproject.toml"
+
+
+def _extras() -> dict[str, list[str]]:
+    with PYPROJECT_PATH.open("rb") as handle:
+        return tomllib.load(handle)["project"]["optional-dependencies"]
+
+
+def _dependency_name(spec: str) -> str:
+    return re.split(r"[<>=!~\[;@\s]", spec, maxsplit=1)[0].lower()
+
+
+def test_audio_desktop_extra_stays_bounded() -> None:
+    specs = _extras()["audio-desktop"]
+    names = {_dependency_name(spec) for spec in specs}
+
+    assert names == {"mlx-audio", "soundfile"}
+    assert "mlx-audio>=0.2.9,<0.4.4" in specs
+    assert "soundfile>=0.12.0" in specs
+
+
+def test_full_audio_extra_remains_independent_and_complete() -> None:
+    extras = _extras()
+    desktop_names = {_dependency_name(spec) for spec in extras["audio-desktop"]}
+    full_names = {_dependency_name(spec) for spec in extras["audio"]}
+
+    assert desktop_names <= full_names
+    assert {"f5-tts-mlx", "misaki", "spacy", "phonemizer-fork"} <= full_names

--- a/tests/test_audio_output_format.py
+++ b/tests/test_audio_output_format.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import builtins
 import io
 import wave
 
@@ -9,6 +10,7 @@ from pydantic import ValidationError
 
 from vllm_mlx.api.models import AudioMusicRequest, AudioSpeechRequest
 from vllm_mlx.audio.output_format import convert_audio_output
+from vllm_mlx.audio.tts import AudioOutput, TTSEngine
 from vllm_mlx.routes.audio import _convert_music_wav
 
 
@@ -20,6 +22,30 @@ def _wav_bytes(audio: np.ndarray, sample_rate: int) -> bytes:
         output.setframerate(sample_rate)
         output.writeframes(audio.astype("<i2").tobytes())
     return payload.getvalue()
+
+
+def test_tts_wav_encoding_does_not_require_scipy_io(monkeypatch) -> None:
+    real_import = builtins.__import__
+
+    def reject_scipy_io(name, *args, **kwargs):
+        if name.startswith("scipy.io"):
+            raise ModuleNotFoundError("No module named 'scipy.io'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", reject_scipy_io)
+    audio = AudioOutput(
+        audio=np.array([0.0, 0.5, -0.5], dtype=np.float32),
+        sample_rate=24_000,
+        duration=3 / 24_000,
+    )
+
+    payload = TTSEngine.__new__(TTSEngine).to_bytes(audio, format="wav")
+
+    with wave.open(io.BytesIO(payload), "rb") as result:
+        assert result.getframerate() == 24_000
+        assert result.getnchannels() == 1
+        assert result.getsampwidth() == 2
+        assert result.getnframes() == 3
 
 
 def test_tts_mono_can_be_resampled_and_expanded_to_stereo() -> None:

--- a/vllm_mlx/audio/tts.py
+++ b/vllm_mlx/audio/tts.py
@@ -15,6 +15,7 @@ import io
 import json
 import logging
 import threading
+import wave
 from collections.abc import Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
@@ -967,7 +968,9 @@ class TTSEngine:
         non-wav format. The handler now branches on ``format`` and
         encodes via the appropriate codec:
 
-        * ``wav`` → scipy (always available with the audio extra).
+        * ``wav`` → Python's standard-library ``wave`` writer. Keeping this
+          path independent of SciPy IO lets bounded clients retain only the
+          ``scipy.signal`` resampling closure.
         * ``flac`` / ``ogg`` / ``opus`` → ``soundfile`` (libsndfile
           ≥1.0). Always shipped via ``rapid-mlx[audio]``.
         * ``mp3`` → ``soundfile`` when libsndfile ≥1.1 (the version
@@ -992,10 +995,13 @@ class TTSEngine:
         audio_int16 = (np.clip(audio.audio, -1.0, 1.0) * 32767).astype(np.int16)
 
         if fmt == "wav":
-            import scipy.io.wavfile as wav
-
             buffer = io.BytesIO()
-            wav.write(buffer, audio.sample_rate, audio_int16)
+            channels = 1 if audio_int16.ndim == 1 else audio_int16.shape[1]
+            with wave.open(buffer, "wb") as output:
+                output.setnchannels(channels)
+                output.setsampwidth(2)
+                output.setframerate(audio.sample_rate)
+                output.writeframes(audio_int16.astype("<i2", copy=False).tobytes())
             return buffer.getvalue()
 
         if fmt == "pcm":


### PR DESCRIPTION
## What does this PR do?

  Adds a native Audio surface to the macOS desktop app with two local workflows:

  - Speech synthesis with model selection, voice loading, playback, saving, and per-voice previews.
  - Local audio transcription with file picking or drag-and-drop, progress, copy, and save actions.
  - Voice metadata showing each Qwen speaker's native language, dialect, and gender.
  - Native-language preview phrases for Chinese, English, Japanese, and Korean speakers.
  - Audio model discovery, download, status, and deletion in Settings.
  - Local conversion of M4A, AAC, and MP4 audio to 16 kHz mono WAV before transcription.
  - Clear model replacement messaging for the current single-model residency behavior.
  - Explanatory empty states when the audio runtime or a compatible model is unavailable.

  Audio models remain excluded from the Chat model picker.

  ## Why is this needed?

  Fixes #1714: **Audio is engine-complete and unreachable from the app: the picker filters audio models out and nothing else offers them.**

  The engine already provides speech synthesis, transcription, translation, voice listing, and music routes behind `serve --enable-audio`. The desktop app intentionally filters audio models out of Chat, but
  previously provided no alternative UI for discovering or using them.

  As a result, users could download an audio model that appeared in `rapid-mlx ls` but remained invisible and unusable in the GUI. This PR makes the two primary desktop audio workflows available without
  requiring the CLI, while keeping all files and inference local.