### PR TITLE
feat(mac): add budgeted multi-model residency for Chat and Images

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
@@ -441,7 +441,12 @@ final class ChatViewModel {
             // `ensureServing` short-circuits when we are already serving
             // this alias, so the warm path pays only a state read.
             if let server {
-                let ready = await server.ensureServing(alias: alias, hfPath: startupHFPath)
+                let ready = await server.ensureServing(
+                    alias: alias,
+                    hfPath: startupHFPath,
+                    estimatedMemoryGB: nil,
+                    replacementGroup: .assistant
+                )
                 // A user Stop during the (possibly cold, multi-second)
                 // bring-up cancels THIS task. That is a deliberate
                 // cancel, not a start failure — route it through the
@@ -1164,7 +1169,12 @@ final class ChatViewModel {
         let trimmed = newAlias.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
         if let server {
-            let ok = await server.ensureServing(alias: trimmed)
+            let ok = await server.ensureServing(
+                alias: trimmed,
+                hfPath: nil,
+                estimatedMemoryGB: nil,
+                replacementGroup: .assistant
+            )
             guard ok else {
                 lastFailureKind = .modelLoadFailed
                 lastError = FailureDiagnoser.diagnosis(
@@ -1273,12 +1283,10 @@ final class ChatViewModel {
             // Issue #477: drop any forward-incompatible ``.unknown``-role rows
             // so a serialised ``{"role":"unknown"}`` never 400s the send.
             history = ChatViewModel.filterUnknownRolesForWire(history)
-            // v0.5.1: outgoing ``model:`` is the alias the server is ACTUALLY
-            // serving right now, falling back to the caller-supplied alias
-            // until the server reports ``.ready``. Resolved BEFORE the tool
-            // definitions so the broken-tool-caller strip runs against the
-            // model that will actually answer this round.
-            let wireAlias = server?.servingAlias ?? alias
+            // Multi-model servers route each request by this selected alias.
+            // ``servingAlias`` is the protected startup/default engine and is
+            // no longer authoritative once secondary models are resident.
+            let wireAlias = alias
             let definitions = isFinalSynthesisRound ? [] : ChatViewModel.wireDefinitions(
                 forAlias: wireAlias,
                 enabled: enabledDefinitions

--- a/apps/rapid-mac/Sources/Rapid/Images/ImageClient.swift
+++ b/apps/rapid-mac/Sources/Rapid/Images/ImageClient.swift
@@ -220,8 +220,13 @@ struct ImageClient {
 
     /// ``GET /v1/images/progress`` — polled during a render. Returns nil on any
     /// transport hiccup so the caller simply keeps its last known state.
-    func fetchProgress(port: Int, bearer: String?) async -> ImageProgress? {
-        let url = Self.loopbackURL(port: port).appendingPathComponent("v1/images/progress")
+    func fetchProgress(model: String, port: Int, bearer: String?) async -> ImageProgress? {
+        var components = URLComponents(
+            url: Self.loopbackURL(port: port).appendingPathComponent("v1/images/progress"),
+            resolvingAgainstBaseURL: false
+        )!
+        components.queryItems = [URLQueryItem(name: "model", value: model)]
+        let url = components.url!
         var req = URLRequest(url: url)
         req.timeoutInterval = 5
         req.setValue("application/json", forHTTPHeaderField: "Accept")
@@ -236,8 +241,13 @@ struct ImageClient {
 
     /// ``POST /v1/images/cancel`` — best-effort; the render stops at its next
     /// denoise step and its in-flight ``generate`` returns the finished images.
-    func cancel(port: Int, bearer: String?) async {
-        let url = Self.loopbackURL(port: port).appendingPathComponent("v1/images/cancel")
+    func cancel(model: String, port: Int, bearer: String?) async {
+        var components = URLComponents(
+            url: Self.loopbackURL(port: port).appendingPathComponent("v1/images/cancel"),
+            resolvingAgainstBaseURL: false
+        )!
+        components.queryItems = [URLQueryItem(name: "model", value: model)]
+        let url = components.url!
         var req = URLRequest(url: url)
         req.httpMethod = "POST"
         req.timeoutInterval = 5

--- a/apps/rapid-mac/Sources/Rapid/Images/ImageGenViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Images/ImageGenViewModel.swift
@@ -166,20 +166,30 @@ final class ImageGenViewModel {
         cancelling = true
         let port = server.activePort
         let bearer = server.activeBearer
-        cancelTask = Task { await client.cancel(port: port, bearer: bearer) }
+        let model = selectedAlias
+        cancelTask = Task { await client.cancel(model: model, port: port, bearer: bearer) }
     }
 
     private func runGenerate() async {
         let trimmed = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty, !selectedAlias.isEmpty else { return }
         await withRequest {
-            let hf = self.imageModels.first { $0.alias == self.selectedAlias }?.hfRepo
-            guard await self.server.ensureServing(alias: self.selectedAlias, hfPath: hf) else {
+            let selected = self.imageModels.first { $0.alias == self.selectedAlias }
+            let hf = selected?.hfRepo
+            let estimatedGB = ModelSizing.residentEstimateGB(
+                alias: self.selectedAlias,
+                sizeText: selected?.sizeOnDisk
+            )
+            guard await self.server.ensureServing(
+                alias: self.selectedAlias,
+                hfPath: hf,
+                estimatedMemoryGB: estimatedGB
+            ) else {
                 throw ImageClientError.notReady
             }
             let port = self.server.activePort
             let bearer = self.server.activeBearer
-            let poll = self.startPolling(port: port, bearer: bearer)
+            let poll = self.startPolling(model: self.selectedAlias, port: port, bearer: bearer)
             defer { poll.cancel() }
             let images = try await self.client.generate(
                 prompt: trimmed, model: self.selectedAlias, size: self.aspect.size,
@@ -200,13 +210,22 @@ final class ImageGenViewModel {
         let trimmed = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty, !selectedAlias.isEmpty else { return }
         await withRequest {
-            let hf = self.imageModels.first { $0.alias == self.selectedAlias }?.hfRepo
-            guard await self.server.ensureServing(alias: self.selectedAlias, hfPath: hf) else {
+            let selected = self.imageModels.first { $0.alias == self.selectedAlias }
+            let hf = selected?.hfRepo
+            let estimatedGB = ModelSizing.residentEstimateGB(
+                alias: self.selectedAlias,
+                sizeText: selected?.sizeOnDisk
+            )
+            guard await self.server.ensureServing(
+                alias: self.selectedAlias,
+                hfPath: hf,
+                estimatedMemoryGB: estimatedGB
+            ) else {
                 throw ImageClientError.notReady
             }
             let port = self.server.activePort
             let bearer = self.server.activeBearer
-            let poll = self.startPolling(port: port, bearer: bearer)
+            let poll = self.startPolling(model: self.selectedAlias, port: port, bearer: bearer)
             defer { poll.cancel() }
             let images = try await self.client.edit(
                 imagePNG: source.pngData, prompt: trimmed, model: self.selectedAlias,
@@ -224,10 +243,14 @@ final class ImageGenViewModel {
 
     /// Poll the server's live denoise progress ~3×/second and mirror it into
     /// ``progress`` / ``phase`` so the stage shows a true step bar and ETA.
-    private func startPolling(port: Int, bearer: String?) -> Task<Void, Never> {
+    private func startPolling(model: String, port: Int, bearer: String?) -> Task<Void, Never> {
         Task { [weak self] in
             while !Task.isCancelled {
-                if let snap = await self?.client.fetchProgress(port: port, bearer: bearer) {
+                if let snap = await self?.client.fetchProgress(
+                    model: model,
+                    port: port,
+                    bearer: bearer
+                ) {
                     self?.progress = snap
                     self?.phase = snap.running ? .denoising : .preparing
                     if snap.running, self?.denoiseStartedAt == nil {

--- a/apps/rapid-mac/Sources/Rapid/RapidApp.swift
+++ b/apps/rapid-mac/Sources/Rapid/RapidApp.swift
@@ -30,8 +30,8 @@ struct RapidApp: App {
     /// keeping a process-wide instance is fine.
     @State private var chatViewModel: ChatViewModel
     /// Images-tab controller — text→image / image-edit against an image-gen
-    /// alias (rapid serves one model per process, so this is decoupled from
-    /// chat and reloads the server when switching to an image model).
+    /// alias. It keeps its own UI state while sharing the resident-model
+    /// sidecar with Chat.
     @State private var imageGen: ImageGenViewModel
     /// Self-update poller. GETs a public static manifest on R2 at
     /// `https://dl.rapidmlx.com/latest.json`. See ``UpdateChecker``.

--- a/apps/rapid-mac/Sources/Rapid/Server/ModelSizing.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ModelSizing.swift
@@ -103,6 +103,24 @@ enum ModelSizing {
         )
     }
 
+    /// Default budget for all engines held by the desktop sidecar. Reuses the
+    /// same 80%-of-physical usable pool as picker classification so startup
+    /// warnings and runtime eviction do not disagree about available memory.
+    static func residentMemoryCeilingGB(on hardware: MacHardware) -> Double {
+        max(4, floor(hardware.usableRAMGB))
+    }
+
+    /// Residency charge sent to the server. Downloaded bytes are better
+    /// evidence for image aliases whose names carry no parameter count; add a
+    /// modest runtime margin and keep the ordinary model estimate as a floor.
+    static func residentEstimateGB(alias: String, sizeText: String? = nil) -> Double {
+        let heuristic = estimate(alias: alias).totalGB
+        guard let bytes = ModelCacheActions.parseSizeBytes(sizeText), bytes > 0
+        else { return heuristic }
+        let diskGiB = Double(bytes) / Double(UInt64(1) << 30)
+        return max(heuristic, diskGiB * 1.25 + 0.5)
+    }
+
     /// Pick a KV-reserve target proportional to model size — bigger
     /// models have bigger per-token cache cost. The picker is mostly
     /// concerned with order-of-magnitude, not precision.

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -49,6 +49,13 @@ final class ServerManager {
     /// Current lifecycle phase. Drives all UI state controls.
     private(set) var state: ServerState
 
+    /// Models currently held by the one sidecar process, plus total process
+    /// memory against its configured ceiling.
+    private(set) var residency: ModelResidencySnapshot = .empty
+
+    @ObservationIgnored
+    private var residencyClient = ServerResidencyClient()
+
     /// Set when ``start`` declines a load because the model's footprint
     /// on top of live memory use would risk exhausting RAM (#324). A
     /// top-level view binds a confirmation alert to this; the user
@@ -93,6 +100,29 @@ final class ServerManager {
     var servingAlias: String? {
         if case .ready(let alias) = state { return alias }
         return nil
+    }
+
+    func isModelResident(_ alias: String) -> Bool {
+        guard case .ready = state else { return false }
+        return residency.contains(alias) || servingAlias == alias
+    }
+
+    /// Feed the existing readiness resolver an alias-specific view of a
+    /// process that may now hold several ready engines.
+    func readinessState(for alias: String) -> ServerState {
+        isModelResident(alias) ? .ready(alias: alias) : state
+    }
+
+    func refreshResidency() async {
+        guard case .ready = state else {
+            residency = .empty
+            return
+        }
+        guard let snapshot = await residencyClient.fetch(
+            port: activePort,
+            bearer: activeBearer
+        ) else { return }
+        residency = snapshot
     }
 
     /// Alias of the child that currently owns the runtime — for BOTH
@@ -468,9 +498,14 @@ final class ServerManager {
     /// disk. Not part of any production code path; the underscore
     /// prefix mirrors the Swift Standard Library convention for
     /// "API kept around for testing only."
-    internal init(testingState: ServerState, binaryPath: URL? = nil) {
+    internal init(
+        testingState: ServerState,
+        binaryPath: URL? = nil,
+        residency: ModelResidencySnapshot = .empty
+    ) {
         self.state = testingState
         self.binaryPath = binaryPath
+        self.residency = residency
         self.binaryResolution = binaryPath.map {
             ServerLocator.Resolution(binary: $0, source: .unknown, version: nil)
         }
@@ -620,10 +655,66 @@ final class ServerManager {
     ///   installs the bytes-on-disk progress monitor; without it the
     ///   user watches a featureless spinner for the whole download.
     func ensureServing(alias: String, hfPath: String? = nil) async -> Bool {
+        await ensureServing(
+            alias: alias,
+            hfPath: hfPath,
+            estimatedMemoryGB: nil,
+            replacementGroup: nil
+        )
+    }
+
+    func ensureServing(
+        alias: String,
+        hfPath: String?,
+        estimatedMemoryGB: Double?,
+        replacementGroup: ResidentModelReplacementGroup? = nil
+    ) async -> Bool {
         let trimmed = alias.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return false }
-        if case .ready(let current) = state, current == trimmed {
+        if replacementGroup == nil,
+           case .ready(let current) = state, current == trimmed {
             return true
+        }
+        if replacementGroup == nil, isModelResident(trimmed) { return true }
+
+        // A healthy sidecar can admit another engine without replacing the
+        // process. Only a 404/405 from an older bundled server falls back to
+        // the legacy stop/start path; capacity and load failures stay failures
+        // so we never hide a rejected ceiling by unloading the primary model.
+        if case .ready = state, child != nil {
+            let estimate = estimatedMemoryGB ?? ModelSizing.estimate(alias: trimmed).totalGB
+            let result = await residencyClient.load(
+                alias: trimmed,
+                hfPath: hfPath,
+                estimatedSizeGB: estimate,
+                replaceGroup: replacementGroup,
+                port: activePort,
+                bearer: activeBearer
+            )
+            switch result {
+            case .loaded(let status):
+                if !residency.contains(status.id) {
+                    residency = ModelResidencySnapshot(
+                        memoryLimitBytes: residency.memoryLimitBytes,
+                        memoryUsedBytes: residency.memoryUsedBytes,
+                        memoryAvailableBytes: residency.memoryAvailableBytes,
+                        idleTTLSeconds: residency.idleTTLSeconds,
+                        loadsTotal: residency.loadsTotal + 1,
+                        evictionsTotal: residency.evictionsTotal,
+                        models: residency.models + [status]
+                    )
+                }
+                await refreshResidency()
+                if replacementGroup != nil {
+                    state = .ready(alias: trimmed)
+                }
+                return true
+            case .unsupported:
+                break
+            case .rejected(let message):
+                appendLogLines(["Resident model load declined: \(message)"])
+                return false
+            }
         }
         // Someone else — the picker's Start CTA, auto-start on launch,
         // Quickstart — may already be bringing up the very alias we
@@ -1105,18 +1196,24 @@ final class ServerManager {
         // passed as a plain ``--port <int>`` so the child binds via
         // the standard ``uvicorn`` shape.
         // Per-recommendation launch flags, derived HERE so every start
-        // path funnels through one place — the composer's `ensureServing`,
-        // ContentView's switch/reload, and auto-respawn all reach `start`
+        // path funnels through one place — the composer's cold-start path,
+        // explicit crash recovery, and auto-respawn all reach `start`
         // but none of them thread flags, so computing at the call sites
         // (as an earlier revision did) silently dropped them. RAM-gated:
         // `launchFlags` returns the flags only when this alias is the pick
         // for this Mac's RAM tier (e.g. the --no-mllm + kv-cache trio for
         // the 24 GB gemma-4-26b), so a hand-picked model that isn't the
         // recommendation gets none.
-        let extraFlags = RAMBucketedDefault.launchFlags(
+        let hardware = MacHardware.detect()
+        var extraFlags = RAMBucketedDefault.launchFlags(
             forAlias: trimmedAlias,
-            physicalRAMGB: MacHardware.detect().physicalRAMGB
+            physicalRAMGB: hardware.physicalRAMGB
         )
+        extraFlags.append(contentsOf: [
+            "--resident-memory-limit-gb",
+            String(format: "%.0f", ModelSizing.residentMemoryCeilingGB(on: hardware)),
+            "--resident-model-idle-ttl", "1800",
+        ])
         let arguments = Self.serveArguments(
             alias: trimmedAlias,
             host: host,
@@ -1379,6 +1476,7 @@ final class ServerManager {
                 // crashed launch attempt doesn't strand the resume
                 // logic on a model the user can't actually load.
                 UserDefaults.standard.set(trimmedAlias, forKey: Self.lastServedAliasKey)
+                await refreshResidency()
                 // v0.6 audit P1 (silent-crash detection): now that
                 // the child is ready, start the runtime health
                 // monitor so a subsequent silent crash surfaces

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerResidency.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerResidency.swift
@@ -1,0 +1,177 @@
+import Foundation
+
+struct ResidentModelStatus: Codable, Sendable, Equatable, Identifiable {
+    let id: String
+    let modelPath: String
+    let aliases: [String]
+    let modality: String
+    let state: String
+    let pinned: Bool
+    let primary: Bool
+    let activeRequests: Int
+    let estimatedBytes: UInt64
+    let measuredBytes: UInt64?
+    let idleSeconds: Double
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case modelPath = "model_path"
+        case aliases
+        case modality
+        case state
+        case pinned
+        case primary
+        case activeRequests = "active_requests"
+        case estimatedBytes = "estimated_bytes"
+        case measuredBytes = "measured_bytes"
+        case idleSeconds = "idle_seconds"
+    }
+
+    func matches(_ alias: String) -> Bool {
+        id == alias || modelPath == alias || aliases.contains(alias)
+    }
+
+    func displayName(preferredAlias: String? = nil) -> String {
+        if let preferredAlias, matches(preferredAlias) {
+            return preferredAlias
+        }
+        // Startup entries use the resolved HF repo as their canonical id and
+        // retain the catalog alias separately. Prefer that short, recognizable
+        // name in the sidebar so it matches the chat/image picker.
+        return aliases.min { lhs, rhs in
+            if lhs.count != rhs.count { return lhs.count < rhs.count }
+            return lhs.localizedCaseInsensitiveCompare(rhs) == .orderedAscending
+        } ?? id
+    }
+
+    /// A lazy engine's load-time process delta may cover only metadata while
+    /// its first request materializes the weights. Never present that partial
+    /// delta as smaller than the admission reservation.
+    var displayBytes: UInt64 { max(estimatedBytes, measuredBytes ?? 0) }
+}
+
+struct ModelResidencySnapshot: Codable, Sendable, Equatable {
+    let memoryLimitBytes: UInt64
+    let memoryUsedBytes: UInt64
+    let memoryAvailableBytes: UInt64?
+    let idleTTLSeconds: Double
+    let loadsTotal: Int
+    let evictionsTotal: Int
+    let models: [ResidentModelStatus]
+
+    enum CodingKeys: String, CodingKey {
+        case memoryLimitBytes = "memory_limit_bytes"
+        case memoryUsedBytes = "memory_used_bytes"
+        case memoryAvailableBytes = "memory_available_bytes"
+        case idleTTLSeconds = "idle_ttl_seconds"
+        case loadsTotal = "loads_total"
+        case evictionsTotal = "evictions_total"
+        case models
+    }
+
+    static let empty = ModelResidencySnapshot(
+        memoryLimitBytes: 0,
+        memoryUsedBytes: 0,
+        memoryAvailableBytes: nil,
+        idleTTLSeconds: 0,
+        loadsTotal: 0,
+        evictionsTotal: 0,
+        models: []
+    )
+
+    func contains(_ alias: String) -> Bool {
+        models.contains { $0.matches(alias) && $0.state != "evicting" }
+    }
+}
+
+enum ResidentModelLoadResult: Sendable, Equatable {
+    case loaded(ResidentModelStatus)
+    case unsupported
+    case rejected(String)
+}
+
+enum ResidentModelReplacementGroup: String, Sendable {
+    case assistant
+}
+
+struct ServerResidencyClient {
+    private struct LoadBody: Encodable {
+        let model: String
+        let model_path: String?
+        let estimated_size_gb: Double
+        let pin: Bool
+        let replace_group: String?
+    }
+
+    private struct ErrorEnvelope: Decodable {
+        let detail: String?
+    }
+
+    var session: URLSession = {
+        let config = URLSessionConfiguration.ephemeral
+        config.timeoutIntervalForRequest = 30 * 60
+        config.timeoutIntervalForResource = 30 * 60
+        return URLSession(configuration: config)
+    }()
+
+    private func request(path: String, port: Int, bearer: String?) -> URLRequest {
+        var request = URLRequest(
+            url: URL(string: "http://127.0.0.1:\(port)\(path)")!
+        )
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        if let bearer, !bearer.isEmpty {
+            request.setValue("Bearer \(bearer)", forHTTPHeaderField: "Authorization")
+        }
+        return request
+    }
+
+    func fetch(port: Int, bearer: String?) async -> ModelResidencySnapshot? {
+        let request = request(path: "/v1/models/residency", port: port, bearer: bearer)
+        guard let (data, response) = try? await session.data(for: request),
+              let http = response as? HTTPURLResponse,
+              (200...299).contains(http.statusCode)
+        else { return nil }
+        return try? JSONDecoder().decode(ModelResidencySnapshot.self, from: data)
+    }
+
+    func load(
+        alias: String,
+        hfPath: String?,
+        estimatedSizeGB: Double,
+        replaceGroup: ResidentModelReplacementGroup? = nil,
+        port: Int,
+        bearer: String?
+    ) async -> ResidentModelLoadResult {
+        var request = request(path: "/v1/models/load", port: port, bearer: bearer)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try? JSONEncoder().encode(
+            LoadBody(
+                model: alias,
+                model_path: hfPath,
+                estimated_size_gb: estimatedSizeGB,
+                pin: false,
+                replace_group: replaceGroup?.rawValue
+            )
+        )
+        do {
+            let (data, response) = try await session.data(for: request)
+            guard let http = response as? HTTPURLResponse else {
+                return .rejected("The model server returned an invalid response.")
+            }
+            if (200...299).contains(http.statusCode) {
+                guard let status = try? JSONDecoder().decode(ResidentModelStatus.self, from: data) else {
+                    return .rejected("The model server returned invalid residency data.")
+                }
+                return .loaded(status)
+            }
+            if http.statusCode == 404 || http.statusCode == 405 {
+                return .unsupported
+            }
+            let detail = (try? JSONDecoder().decode(ErrorEnvelope.self, from: data))?.detail
+            return .rejected(detail ?? "The model could not be kept resident (HTTP \(http.statusCode)).")
+        } catch {
+            return .rejected("The model server could not load another resident model.")
+        }
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
@@ -189,7 +189,7 @@ struct ChatView: View {
     var readiness: ModelReadiness
     /// Explicit picker gesture signal used by launch auto-start arbitration.
     /// Catalog-driven default selection intentionally does not call this.
-    var onUserModelSelection: () -> Void = {}
+    var onUserModelSelection: (String) -> Void = { _ in }
     /// Perform the readiness banner's next-step action (start, download
     /// & start, retry). Owned by ``ContentView`` because starting a model
     /// is a window-level concern, not a chat-surface one.

--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -32,16 +32,6 @@ struct ContentView: View {
     /// An absent telemetry preference is an undecided first run, not
     /// implicit consent.
     @State private var telemetryConsentPending = TelemetryConsent.needsDecision()
-    /// Set when the user picks a different alias while a server is
-    /// already serving a different one — drives the reload confirm.
-    @State private var pendingReloadAlias: String?
-    /// Set by "Switch and reload" so the implicit dismiss doesn't roll
-    /// ``alias`` back to the old model.
-    @State private var switchConfirmed: Bool = false
-    /// Alias the user confirmed via "Switch and reload" whose footprint
-    /// classifies ``.tooBig`` — drives a follow-up OOM confirm alert.
-    @State private var pendingTooBigSwitch: String?
-    @State private var switchAlertHardware: MacHardware = MacHardware.detect()
     @SceneStorage("Rapid.showLogs") private var showLogs: Bool = false
     /// Per-session "browse all models" dismissal of the Quickstart card.
     @State private var quickstartDismissedThisSession: Bool = false
@@ -79,7 +69,8 @@ struct ContentView: View {
                 onSelectConversation: { id in
                     chat.selectConversation(id)
                     section = .chat
-                }
+                },
+                server: server
             )
             // v1.0: the rail paints an explicit warm surface rather than
             // inheriting the system sidebar material. The material is a
@@ -115,102 +106,12 @@ struct ContentView: View {
                 }
             }
         }
-        .onChange(of: alias) { _, newValue in
-            // Auto-reload affordance: picking a new model while another
-            // is running surfaces a confirm rather than stranding the
-            // user in a manual Stop → Start dance.
-            guard !newValue.isEmpty else { return }
-            if server.servingAlias == newValue { return }
-            if let running = runningAlias, running != newValue {
-                pendingReloadAlias = newValue
-            }
-        }
         .onChange(of: server.state) { _, newState in
             // Sync the picker breadcrumb when the server lands in
             // ``.ready(<alias>)`` against a different alias than shown.
             if case .ready(let serving) = newState, !serving.isEmpty, serving != alias {
                 alias = serving
             }
-        }
-        .confirmationDialog(
-            "Switch to \(pendingReloadAlias ?? "")?",
-            isPresented: Binding(
-                get: { pendingReloadAlias != nil },
-                set: { presented in
-                    if !presented {
-                        if !switchConfirmed, let running = runningAlias {
-                            alias = running
-                        }
-                        switchConfirmed = false
-                        pendingReloadAlias = nil
-                    }
-                }
-            ),
-            titleVisibility: .visible,
-            presenting: pendingReloadAlias
-        ) { newAlias in
-            Button("Switch and reload") {
-                switchConfirmed = true
-                alias = newAlias
-                let fit = ModelSizing.classify(
-                    ModelSizing.estimate(alias: newAlias),
-                    on: switchAlertHardware
-                )
-                // A recommended pick trusts the curated table's measured
-                // footprint over ModelSizing's estimate (which over-states
-                // low-bit / MoE models), so switching to it skips the
-                // .tooBig gate — mirrors ModelPickerBar.handleStartTap.
-                let isRecommended = RAMBucketedDefault.isRecommendedPick(
-                    alias: newAlias, physicalRAMGB: switchAlertHardware.physicalRAMGB)
-                if fit == .tooBig && !isRecommended {
-                    pendingReloadAlias = nil
-                    pendingTooBigSwitch = newAlias
-                    return
-                }
-                Task {
-                    await server.stop()
-                    await server.start(alias: newAlias)
-                    pendingReloadAlias = nil
-                }
-            }
-            Button("Cancel", role: .cancel) {
-                if let running = runningAlias { alias = running }
-                pendingReloadAlias = nil
-            }
-        } message: { newAlias in
-            Text("Stops the current model and loads \(newAlias). Chat history stays put.")
-        }
-        .alert(
-            ModelPickerBar.tooBigAlertTitle(
-                alias: pendingTooBigSwitch ?? "",
-                physicalRAMGB: switchAlertHardware.physicalRAMGB
-            ),
-            isPresented: Binding(
-                get: { pendingTooBigSwitch != nil },
-                set: { if !$0 { pendingTooBigSwitch = nil } }
-            ),
-            presenting: pendingTooBigSwitch
-        ) { aliasToStart in
-            Button("Cancel", role: .cancel) {
-                if let running = runningAlias { alias = running }
-                pendingTooBigSwitch = nil
-            }
-            Button("Start anyway", role: .destructive) {
-                let confirmed = aliasToStart
-                pendingTooBigSwitch = nil
-                Task {
-                    await server.stop()
-                    await server.start(alias: confirmed)
-                }
-            }
-        } message: { aliasToStart in
-            Text(
-                ModelPickerBar.tooBigAlertMessage(
-                    alias: aliasToStart,
-                    footprint: ModelSizing.estimate(alias: aliasToStart),
-                    hardware: switchAlertHardware
-                )
-            )
         }
         .alert(
             server.pendingMemoryWarning?.title ?? "",
@@ -285,6 +186,12 @@ struct ContentView: View {
         )) {
             await refreshCatalogSnapshot()
         }
+        .task {
+            while !Task.isCancelled {
+                await server.refreshResidency()
+                try? await Task.sleep(for: .seconds(5))
+            }
+        }
     }
 
     // MARK: - Readiness (the one shared lifecycle value)
@@ -297,7 +204,7 @@ struct ContentView: View {
     /// rules and the copy contract.
     private var readiness: ModelReadiness {
         ModelReadiness.resolve(
-            serverState: server.state,
+            serverState: server.readinessState(for: alias),
             alias: alias,
             cacheState: cacheState(for: alias),
             sizeText: sizeText(for: alias),
@@ -428,7 +335,43 @@ struct ContentView: View {
         // ``ensureServing`` via the shared helper, NOT ``server.start``: start is
         // cold-start only and no-ops while a different model (e.g. an Images
         // checkpoint) is resident, silently dropping the switch (#1739).
-        Task { await ReadinessModelStart.perform(server, alias: target, hfPath: hfPath) }
+        Task {
+            _ = await server.ensureServing(
+                alias: target,
+                hfPath: hfPath,
+                estimatedMemoryGB: nil,
+                replacementGroup: .assistant
+            )
+        }
+    }
+
+    private func selectChatModel(_ target: String) {
+        userSelectionRevision &+= 1
+        // Selecting an on-disk model is an activation request: load it and
+        // release the previous assistant immediately. An uncached selection
+        // still waits for the explicit Download & start action, so browsing
+        // the catalog never starts a multi-GB network transfer by itself.
+        let entry = catalogEntries.first(where: { $0.alias == target })
+        guard Self.activatesChatModelOnSelection(
+            isResident: server.isModelResident(target),
+            isCached: entry?.cached == true
+        ) else { return }
+        let hfPath = entry?.hfRepo
+        Task {
+            _ = await server.ensureServing(
+                alias: target,
+                hfPath: hfPath,
+                estimatedMemoryGB: nil,
+                replacementGroup: .assistant
+            )
+        }
+    }
+
+    static func activatesChatModelOnSelection(
+        isResident: Bool,
+        isCached: Bool
+    ) -> Bool {
+        isResident || isCached
     }
 
     private func restartModel(_ target: String) {
@@ -471,7 +414,7 @@ struct ContentView: View {
                 server: server,
                 alias: $alias,
                 readiness: readiness,
-                onUserModelSelection: { userSelectionRevision &+= 1 },
+                onUserModelSelection: selectChatModel,
                 onReadinessAction: performReadinessAction
             )
         case .missing:

--- a/apps/rapid-mac/Sources/Rapid/UI/ImagesView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ImagesView.swift
@@ -108,13 +108,12 @@ struct ImagesView: View {
 
     // MARK: - Readiness (mirrors ChatView: same "load the model first" flow)
 
-    /// Readiness for the selected image model. Because rapid serves one model
-    /// per process, this reports "isn't running" whenever the server is
-    /// serving something else (e.g. a chat model) — exactly the "load FLUX
-    /// first" guidance chat gives, produced by the same resolver.
+    /// Readiness for the selected image model. A healthy sidecar may keep this
+    /// engine resident beside the chat engine; otherwise the shared resolver
+    /// presents the same on-demand load guidance used by Chat.
     private var readiness: ModelReadiness {
         ModelReadiness.resolve(
-            serverState: server.state,
+            serverState: server.readinessState(for: viewModel.selectedAlias),
             alias: viewModel.selectedAlias,
             cacheState: imageCacheState,
             sizeText: viewModel.imageModels
@@ -144,8 +143,8 @@ struct ImagesView: View {
         )
     }
 
-    /// The banner's next-step action: start (or download-and-start) the
-    /// selected image model, switching the single server process to it.
+    /// The banner's next-step action: start the sidecar or load the selected
+    /// image engine into the already-running process.
     private func handleReadinessAction(_ action: ModelReadiness.Action) {
         switch action {
         case .chooseModel:

--- a/apps/rapid-mac/Sources/Rapid/UI/ModelPickerBar.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ModelPickerBar.swift
@@ -79,7 +79,7 @@ struct ModelPickerBar: View {
     var composerStyle: Bool = false
     /// Called only for explicit model-row gestures, never when catalog
     /// initialization fills an empty selection.
-    var onUserSelection: () -> Void = {}
+    var onUserSelection: (String) -> Void = { _ in }
 
     /// The alias the Quickstart flow is currently aimed at — the wizard's
     /// live selection (#1524) while a coordinator is attached, else the
@@ -776,7 +776,7 @@ struct ModelPickerBar: View {
     /// ``entryLabel`` comment for the same trap).
     private func quickstartRow(entry: ModelEntry) -> some View {
         return Button {
-            onUserSelection()
+            onUserSelection(entry.alias)
             alias = entry.alias
         } label: {
             Label(
@@ -1018,7 +1018,7 @@ struct ModelPickerBar: View {
         // inside a ``Menu`` is silently dropped once the dropdown becomes
         // an NSMenu — and doubles as the row's accessibility label.
         return Button {
-            onUserSelection()
+            onUserSelection(entry.alias)
             alias = entry.alias
         } label: {
             // The image slot carries download state, uniformly with
@@ -1136,7 +1136,7 @@ struct ModelPickerBar: View {
         let bucket = ModelPickerVisibility.qualityBucket(for: entry.alias)
         let footprint = ModelSizing.estimate(alias: entry.alias)
         return Button {
-            onUserSelection()
+            onUserSelection(entry.alias)
             alias = entry.alias
         } label: {
             Label(
@@ -1806,7 +1806,7 @@ struct ModelPickerBar: View {
     private func commitCustomAlias() {
         let trimmed = customDraft.trimmingCharacters(in: .whitespacesAndNewlines)
         if !trimmed.isEmpty {
-            onUserSelection()
+            onUserSelection(trimmed)
             alias = trimmed
         }
         showCustom = false

--- a/apps/rapid-mac/Sources/Rapid/UI/SidebarView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SidebarView.swift
@@ -37,6 +37,9 @@ struct SidebarView: View {
     var onNewChat: () -> Void
     /// Open a saved conversation (switches the detail pane back to chat).
     var onSelectConversation: (UUID) -> Void
+    /// Optional in isolated snapshot fixtures; the shipping ContentView passes
+    /// it so residency and the enforced memory ceiling remain visible globally.
+    var server: ServerManager? = nil
 
     /// The "now" the date buckets are computed against. Rolled forward by
     /// ``dayBoundaryTicker`` at each midnight so an open, untouched sidebar
@@ -141,6 +144,13 @@ struct SidebarView: View {
             }
 
             Spacer(minLength: 0)
+
+            if let server, !server.residency.models.isEmpty {
+                residencyFooter(
+                    server.residency,
+                    preferredAlias: server.servingAlias
+                )
+            }
         }
         .padding(.horizontal, RapidTheme.Space.sm)
         .padding(.vertical, RapidTheme.Space.md)
@@ -177,6 +187,66 @@ struct SidebarView: View {
         } message: { _ in
             Text("This permanently deletes the conversation. It can't be undone.")
         }
+    }
+
+    private func residencyFooter(
+        _ snapshot: ModelResidencySnapshot,
+        preferredAlias: String?
+    ) -> some View {
+        VStack(alignment: .leading, spacing: RapidTheme.Space.xs) {
+            HStack(spacing: RapidTheme.Space.xs) {
+                Image(systemName: "memorychip")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(.secondary)
+                Text("Resident")
+                    .font(RapidFont.caption)
+                    .foregroundStyle(.secondary)
+                Spacer(minLength: 4)
+                Text(memorySummary(snapshot))
+                    .font(.system(size: 10, weight: .medium, design: .monospaced))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+
+            if snapshot.memoryLimitBytes > 0 {
+                ProgressView(
+                    value: min(1, Double(snapshot.memoryUsedBytes) / Double(snapshot.memoryLimitBytes))
+                )
+                .controlSize(.mini)
+                .tint(RapidTheme.brandAmber)
+            }
+
+            ForEach(snapshot.models.prefix(4)) { model in
+                HStack(spacing: RapidTheme.Space.xs) {
+                    Image(systemName: model.pinned ? "lock.fill" : "circle.fill")
+                        .font(.system(size: model.pinned ? 9 : 6, weight: .semibold))
+                        .foregroundStyle(model.pinned ? RapidTheme.brandAmber : .secondary)
+                        .frame(width: 12)
+                    Text(model.displayName(preferredAlias: preferredAlias))
+                        .font(RapidFont.caption)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                    Spacer(minLength: 4)
+                    Text(Self.formatBytes(model.displayBytes))
+                        .font(.system(size: 10, design: .monospaced))
+                        .foregroundStyle(.secondary)
+                }
+                .accessibilityIdentifier("Sidebar.ResidentModel.\(model.id)")
+            }
+        }
+        .padding(.horizontal, RapidTheme.Space.sm)
+        .padding(.vertical, RapidTheme.Space.sm)
+        .accessibilityIdentifier("Sidebar.Residency")
+    }
+
+    private func memorySummary(_ snapshot: ModelResidencySnapshot) -> String {
+        let used = Self.formatBytes(snapshot.memoryUsedBytes)
+        guard snapshot.memoryLimitBytes > 0 else { return used }
+        return "\(used) / \(Self.formatBytes(snapshot.memoryLimitBytes))"
+    }
+
+    nonisolated private static func formatBytes(_ bytes: UInt64) -> String {
+        ByteCountFormatter.string(fromByteCount: Int64(clamping: bytes), countStyle: .memory)
     }
 
     // MARK: - Accessibility identifiers

--- a/apps/rapid-mac/Tests/RapidTests/ModelResidencyTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ModelResidencyTests.swift
@@ -1,0 +1,167 @@
+import Foundation
+import Testing
+@testable import Rapid
+
+@MainActor
+@Suite("Multi-model residency")
+struct ModelResidencyTests {
+    @Test("Residency status decodes the server wire format")
+    func decodesSnapshot() throws {
+        let data = Data(
+            #"""
+            {
+              "memory_limit_bytes": 34359738368,
+              "memory_used_bytes": 10737418240,
+              "memory_available_bytes": 23622320128,
+              "idle_ttl_seconds": 1800,
+              "loads_total": 2,
+              "evictions_total": 1,
+              "models": [{
+                "id": "flux2-klein-4b",
+                "model_path": "Runware/FLUX.2-klein-4B",
+                "aliases": ["flux-klein"],
+                "modality": "image-gen",
+                "state": "resident",
+                "pinned": false,
+                "primary": false,
+                "active_requests": 0,
+                "estimated_bytes": 6335076761,
+                "measured_bytes": 5905580032,
+                "idle_seconds": 12.5
+              }]
+            }
+            """#.utf8
+        )
+
+        let snapshot = try JSONDecoder().decode(ModelResidencySnapshot.self, from: data)
+
+        #expect(snapshot.memoryLimitBytes == 34_359_738_368)
+        #expect(snapshot.memoryUsedBytes == 10_737_418_240)
+        #expect(snapshot.loadsTotal == 2)
+        #expect(snapshot.evictionsTotal == 1)
+        #expect(snapshot.models.first?.modality == "image-gen")
+        #expect(snapshot.models.first?.displayBytes == 6_335_076_761)
+        #expect(snapshot.contains("flux2-klein-4b"))
+        #expect(snapshot.contains("flux-klein"))
+        #expect(snapshot.contains("Runware/FLUX.2-klein-4B"))
+    }
+
+    @Test("Resident rows prefer the catalog alias over the HF path")
+    func residentDisplayName() {
+        let status = ResidentModelStatus(
+            id: "mlx-community/Qwen3.5-4B-MLX-4bit",
+            modelPath: "mlx-community/Qwen3.5-4B-MLX-4bit",
+            aliases: ["qwen3.5-4b-4bit"],
+            modality: "text",
+            state: "resident",
+            pinned: true,
+            primary: true,
+            activeRequests: 0,
+            estimatedBytes: 1,
+            measuredBytes: nil,
+            idleSeconds: 0
+        )
+
+        #expect(status.displayName() == "qwen3.5-4b-4bit")
+        #expect(status.displayName(preferredAlias: "qwen3.5-4b-4bit") == "qwen3.5-4b-4bit")
+    }
+
+    @Test("Server readiness is resolved for every resident alias")
+    func aliasSpecificReadiness() {
+        let image = ResidentModelStatus(
+            id: "flux2-klein-4b",
+            modelPath: "Runware/FLUX.2-klein-4B",
+            aliases: ["flux-klein"],
+            modality: "image-gen",
+            state: "resident",
+            pinned: false,
+            primary: false,
+            activeRequests: 0,
+            estimatedBytes: 6_335_076_761,
+            measuredBytes: nil,
+            idleSeconds: 0
+        )
+        let snapshot = ModelResidencySnapshot(
+            memoryLimitBytes: 25 * 1_073_741_824,
+            memoryUsedBytes: 10 * 1_073_741_824,
+            memoryAvailableBytes: 15 * 1_073_741_824,
+            idleTTLSeconds: 1800,
+            loadsTotal: 1,
+            evictionsTotal: 0,
+            models: [image]
+        )
+        let server = ServerManager(
+            testingState: .ready(alias: "qwen3.5-4b-4bit"),
+            residency: snapshot
+        )
+
+        #expect(server.isModelResident("qwen3.5-4b-4bit"))
+        #expect(server.isModelResident("flux2-klein-4b"))
+        #expect(server.isModelResident("flux-klein"))
+        #expect(!server.isModelResident("z-image-turbo"))
+
+        guard case .ready(let alias) = server.readinessState(for: "flux-klein") else {
+            Issue.record("Expected resident image alias to be ready")
+            return
+        }
+        #expect(alias == "flux-klein")
+    }
+
+    @Test("Resident ceiling reuses the Mac usable-RAM bucket")
+    func residentMemoryCeiling() {
+        #expect(ModelSizing.residentMemoryCeilingGB(on: mockMac(ramGB: 32)) == 25)
+        #expect(ModelSizing.residentMemoryCeilingGB(on: mockMac(ramGB: 8)) == 6)
+        #expect(ModelSizing.residentMemoryCeilingGB(on: mockMac(ramGB: 4)) == 4)
+    }
+
+    @Test("Image residency estimate uses catalog bytes plus runtime margin")
+    func imageEstimateUsesDownloadSize() {
+        let estimate = ModelSizing.residentEstimateGB(
+            alias: "z-image-turbo",
+            sizeText: "5.5 GiB"
+        )
+        #expect(abs(estimate - 7.375) < 0.001)
+        #expect(estimate > ModelSizing.residentEstimateGB(alias: "z-image-turbo"))
+    }
+
+    @Test("Selecting a chat model does not retain the legacy server restart flow")
+    func selectionDoesNotRestartServer() throws {
+        let rapidMacRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let sourceURL = rapidMacRoot
+            .appendingPathComponent("Sources/Rapid/UI/ContentView.swift")
+        let source = try String(contentsOf: sourceURL, encoding: .utf8)
+
+        #expect(!source.contains("pendingReloadAlias"))
+        #expect(!source.contains("Switch and reload"))
+        #expect(!source.contains("Stops the current model and loads"))
+    }
+
+    @Test("Selecting a cached chat model activates it immediately")
+    func cachedChatSelectionActivates() {
+        #expect(ContentView.activatesChatModelOnSelection(
+            isResident: false,
+            isCached: true
+        ))
+        #expect(ContentView.activatesChatModelOnSelection(
+            isResident: true,
+            isCached: false
+        ))
+        #expect(!ContentView.activatesChatModelOnSelection(
+            isResident: false,
+            isCached: false
+        ))
+    }
+
+    private func mockMac(ramGB: Int) -> MacHardware {
+        MacHardware(
+            brandString: "Apple M3 Pro",
+            family: .m3,
+            tier: .pro,
+            physicalRAMBytes: UInt64(ramGB) * UInt64(1 << 30),
+            memoryBandwidthGBs: 150
+        )
+    }
+}

--- a/tests/test_cli_models.py
+++ b/tests/test_cli_models.py
@@ -371,6 +371,23 @@ def test_cached_view_marks_known_partial_repo_incomplete(tmp_path, monkeypatch, 
     assert alias not in out
 
 
+def test_cached_view_renders_complete_mflux_alias(monkeypatch, capsys):
+    """A complete mflux cache must map back to its image alias in ``ls``."""
+    repo = "Runpod/FLUX.2-klein-4B-mflux-4bit"
+    monkeypatch.setattr(
+        cli,
+        "_scan_hf_cache_models",
+        lambda: [(repo, 4 * 1024**3, 0.0)],
+    )
+    monkeypatch.setattr(cli, "_cache_entry_is_runnable", lambda _repo: True)
+
+    cli._print_cached_models()
+
+    out = capsys.readouterr().out
+    assert "flux2-klein-4b" in out
+    assert "(incomplete)" not in out
+
+
 def test_format_bytes_unit_selection():
     """``_format_bytes`` picks the largest unit where value >= 1.
 

--- a/tests/test_download_gate.py
+++ b/tests/test_download_gate.py
@@ -1107,6 +1107,48 @@ def test_is_weightless_stub_false_for_video_component_weights(tmp_path, monkeypa
     assert gate.is_weightless_stub("dgrauet/CogVideoX-Fun-V1.5-5b-InP-mlx-q4") is False
 
 
+def _seed_mflux_snapshot(repo_root, sha: str, *, omit: tuple[str, str] | None = None):
+    snap = repo_root / "snapshots" / sha
+    (snap / "tokenizer").mkdir(parents=True)
+    (snap / "tokenizer" / "tokenizer.json").write_text("{}")
+    for component in ("transformer", "text_encoder", "vae"):
+        component_dir = snap / component
+        component_dir.mkdir()
+        (component_dir / "model.safetensors.index.json").write_text(
+            '{"weight_map": {"a": "0.safetensors", "b": "1.safetensors"}}'
+        )
+        for shard in ("0.safetensors", "1.safetensors"):
+            if omit != (component, shard):
+                (component_dir / shard).write_bytes(b"weights")
+    _seed_refs_main(repo_root, sha)
+
+
+def test_complete_mflux_snapshot_is_runnable(tmp_path, monkeypatch):
+    """A complete image-gen component layout is a cached runnable model."""
+    cache_root = tmp_path / "hf-cache"
+    repo = "Runpod/FLUX.2-klein-4B-mflux-4bit"
+    repo_root = cache_root / "models--Runpod--FLUX.2-klein-4B-mflux-4bit"
+    _seed_mflux_snapshot(repo_root, "a" * 40)
+
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+
+    assert gate.is_repo_cached(repo) is False
+    assert gate._snapshot_is_complete_mflux_model(repo) is True
+    assert gate.is_weightless_stub(repo) is False
+
+
+def test_partial_mflux_snapshot_is_not_runnable(tmp_path, monkeypatch):
+    """Every shard from every required mflux component must be present."""
+    cache_root = tmp_path / "hf-cache"
+    repo = "Runpod/FLUX.2-klein-4B-mflux-4bit"
+    repo_root = cache_root / "models--Runpod--FLUX.2-klein-4B-mflux-4bit"
+    _seed_mflux_snapshot(repo_root, "b" * 40, omit=("transformer", "1.safetensors"))
+
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+
+    assert gate._snapshot_is_complete_mflux_model(repo) is False
+
+
 def test_is_weightless_stub_true_for_partial_split_model_components(
     tmp_path, monkeypatch
 ):

--- a/tests/test_image_lane.py
+++ b/tests/test_image_lane.py
@@ -403,6 +403,31 @@ def test_route_happy_path_returns_b64(client, monkeypatch):
     assert raw.startswith(_PNG_MAGIC)
 
 
+def test_route_selects_resident_image_engine_by_model(client, monkeypatch):
+    from vllm_mlx.runtime.model_registry import ModelEntry, ModelRegistry
+
+    chat = types.SimpleNamespace(is_image_gen=False)
+    image = _FakeImageEngine()
+    registry = ModelRegistry()
+    registry.add(ModelEntry(chat, "chat", "repo/chat"), is_default=True)
+    registry.add(ModelEntry(image, "image", "repo/image"))
+    monkeypatch.setattr(
+        "vllm_mlx.config.get_config",
+        lambda: types.SimpleNamespace(
+            engine=chat,
+            model_registry=registry,
+            residency_manager=None,
+        ),
+    )
+
+    resp = client.post(
+        "/v1/images/generations",
+        json={"model": "image", "prompt": "a resident fox", "seed": 7},
+    )
+    assert resp.status_code == 200
+    assert image.seeds == [7]
+
+
 def test_route_multi_image_offsets_seed(client, monkeypatch):
     engine = _FakeImageEngine()
     _patch_engine(monkeypatch, engine)

--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -6,6 +6,7 @@ from fastapi.testclient import TestClient
 
 from vllm_mlx.runtime.model_registry import ModelEntry, ModelRegistry
 from vllm_mlx.runtime.resident_models import (
+    ResidentModelBusyError,
     ResidentModelCapacityError,
     ResidentModelManager,
 )
@@ -200,6 +201,24 @@ async def test_replacing_assistant_promotes_target_and_keeps_image_resident():
         "chat-new",
         "image",
     }
+
+
+@pytest.mark.asyncio
+async def test_failed_assistant_replacement_rolls_back_newly_loaded_model():
+    manager, registry, loaded, _ = manager_fixture(limit_gib=20)
+    registry.get_engine("chat").running = 1
+
+    with pytest.raises(ResidentModelBusyError, match="active request"):
+        await manager.load(
+            "chat-new",
+            estimated_bytes=4 * GIB,
+            replace_group="assistant",
+        )
+
+    assert "chat" in registry
+    assert "chat-new" not in registry
+    assert loaded["chat-new"].stopped is True
+    assert {item["id"] for item in manager.snapshot()["models"]} == {"chat"}
 
 
 @pytest.mark.asyncio

--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -1,0 +1,258 @@
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from vllm_mlx.runtime.model_registry import ModelEntry, ModelRegistry
+from vllm_mlx.runtime.resident_models import (
+    ResidentModelCapacityError,
+    ResidentModelManager,
+)
+
+GIB = 1024**3
+
+
+class FakeEngine:
+    is_mllm = False
+
+    def __init__(self) -> None:
+        self.stopped = False
+        self.running = 0
+
+    def get_stats(self):
+        return {"num_running": self.running, "num_waiting": 0}
+
+    async def stop(self) -> None:
+        self.stopped = True
+
+
+class FakeImageEngine(FakeEngine):
+    is_image_gen = True
+
+
+class Clock:
+    def __init__(self) -> None:
+        self.now = 0.0
+
+    def __call__(self) -> float:
+        return self.now
+
+
+def entry(name: str, engine: FakeEngine | None = None) -> ModelEntry:
+    return ModelEntry(
+        engine=engine or FakeEngine(),
+        model_name=name,
+        model_path=f"repo/{name}",
+    )
+
+
+def manager_fixture(*, limit_gib=10, ttl=0):
+    registry = ModelRegistry()
+    primary = entry("chat")
+    registry.add(primary, is_default=True)
+    loaded: dict[str, FakeEngine] = {}
+
+    async def loader(name: str, path: str | None):
+        engine = FakeEngine()
+        loaded[name] = engine
+        return ModelEntry(
+            engine=engine,
+            model_name=name,
+            model_path=path or f"repo/{name}",
+        )
+
+    clock = Clock()
+    manager = ResidentModelManager(
+        registry,
+        loader,
+        memory_limit_bytes=limit_gib * GIB,
+        idle_ttl_seconds=ttl,
+        clock=clock,
+        memory_reader=lambda: 0,
+    )
+    manager.register_primary(primary, estimated_bytes=4 * GIB)
+    return manager, registry, loaded, clock
+
+
+@pytest.mark.asyncio
+async def test_accounting_reserves_lazy_model_estimates_and_tracks_larger_actual_usage():
+    registry = ModelRegistry()
+    primary = entry("chat")
+    registry.add(primary, is_default=True)
+    process_usage = [1 * GIB]
+
+    async def loader(name: str, path: str | None):
+        return entry(name)
+
+    manager = ResidentModelManager(
+        registry,
+        loader,
+        memory_limit_bytes=20 * GIB,
+        memory_reader=lambda: process_usage[0],
+    )
+    manager.register_primary(primary, estimated_bytes=4 * GIB)
+    await manager.load("image", estimated_bytes=3 * GIB)
+
+    # A lazy engine may add almost nothing to phys_footprint at load time;
+    # admission still reserves its full estimate.
+    assert manager.snapshot()["memory_used_bytes"] == 7 * GIB
+
+    process_usage[0] = 9 * GIB
+    assert manager.snapshot()["memory_used_bytes"] == 9 * GIB
+
+
+@pytest.mark.asyncio
+async def test_load_evicts_least_recently_used_unpinned_model():
+    manager, registry, loaded, clock = manager_fixture()
+    clock.now = 1
+    await manager.load("image-a", estimated_bytes=3 * GIB)
+    clock.now = 2
+    await manager.load("image-b", estimated_bytes=3 * GIB)
+
+    # A becomes most recently used, leaving B as the eviction candidate.
+    clock.now = 3
+    registry.get_engine("image-a")
+    await manager.load("image-c", estimated_bytes=3 * GIB)
+
+    assert "image-a" in registry
+    assert "image-b" not in registry
+    assert "image-c" in registry
+    assert loaded["image-b"].stopped is True
+    assert manager.snapshot()["evictions_total"] == 1
+
+
+@pytest.mark.asyncio
+async def test_pin_and_active_lease_are_never_evicted():
+    manager, registry, loaded, clock = manager_fixture(limit_gib=9)
+    clock.now = 1
+    await manager.load("pinned", estimated_bytes=2 * GIB, pin=True)
+    clock.now = 2
+    await manager.load("working", estimated_bytes=2 * GIB)
+
+    async with manager.lease("working"):
+        with pytest.raises(ResidentModelCapacityError, match="no idle unpinned"):
+            await manager.load("incoming", estimated_bytes=2 * GIB)
+
+    assert "pinned" in registry
+    assert "working" in registry
+    assert not loaded["pinned"].stopped
+    assert not loaded["working"].stopped
+
+
+@pytest.mark.asyncio
+async def test_idle_ttl_reclaims_only_unpinned_secondary_models():
+    manager, registry, loaded, clock = manager_fixture(limit_gib=20, ttl=60)
+    await manager.load("old", estimated_bytes=2 * GIB)
+    await manager.load("kept", estimated_bytes=2 * GIB, pin=True)
+    clock.now = 61
+
+    assert await manager.evict_expired() == ["old"]
+    assert "old" not in registry
+    assert "kept" in registry
+    assert loaded["old"].stopped
+    assert not loaded["kept"].stopped
+
+
+@pytest.mark.asyncio
+async def test_replacing_assistant_promotes_target_and_keeps_image_resident():
+    registry = ModelRegistry()
+    primary = entry("chat-old")
+    registry.add(primary, is_default=True)
+    loaded: dict[str, FakeEngine] = {}
+    promoted: list[str] = []
+
+    async def loader(name: str, path: str | None):
+        engine = FakeImageEngine() if name == "image" else FakeEngine()
+        loaded[name] = engine
+        return ModelEntry(
+            engine=engine,
+            model_name=name,
+            model_path=path or f"repo/{name}",
+        )
+
+    manager = ResidentModelManager(
+        registry,
+        loader,
+        memory_limit_bytes=20 * GIB,
+        memory_reader=lambda: 0,
+        on_primary_changed=lambda value: promoted.append(value.model_name),
+    )
+    manager.register_primary(primary, estimated_bytes=4 * GIB)
+    await manager.load("image", estimated_bytes=3 * GIB)
+    await manager.load("chat-new", estimated_bytes=4 * GIB)
+
+    # The desktop may select a chat model that is already resident. Reissuing
+    # the load with a replacement group must still perform the handoff.
+    replacement = await manager.load("chat-new", replace_group="assistant")
+
+    assert replacement.primary is True
+    assert replacement.pinned is True
+    assert registry.default_name == "chat-new"
+    assert promoted == ["chat-new"]
+    assert primary.engine.stopped is True
+    assert loaded["chat-new"].stopped is False
+    assert loaded["image"].stopped is False
+    assert "chat-old" not in registry
+    assert "chat-new" in registry
+    assert "image" in registry
+    assert {item["id"] for item in manager.snapshot()["models"]} == {
+        "chat-new",
+        "image",
+    }
+
+
+@pytest.mark.asyncio
+async def test_soak_load_evict_cycles_stay_inside_ceiling():
+    manager, registry, loaded, clock = manager_fixture(limit_gib=8)
+
+    for index in range(40):
+        clock.now = float(index + 1)
+        await manager.load(f"image-{index}", estimated_bytes=4 * GIB)
+        snapshot = manager.snapshot()
+        accounted = sum(model["estimated_bytes"] for model in snapshot["models"])
+        assert accounted <= snapshot["memory_limit_bytes"]
+        assert len(snapshot["models"]) == 2  # protected chat + latest image
+
+    assert manager.snapshot()["evictions_total"] == 39
+    assert sum(engine.stopped for engine in loaded.values()) == 39
+    assert len(registry.list_entries()) == 2
+
+
+def test_residency_control_plane_load_pin_status_and_unload(monkeypatch):
+    from types import SimpleNamespace
+
+    from vllm_mlx.routes.residency import router
+
+    manager, registry, _, _ = manager_fixture(limit_gib=12)
+    monkeypatch.setattr(
+        "vllm_mlx.routes.residency.get_config",
+        lambda: SimpleNamespace(residency_manager=manager),
+    )
+    app = FastAPI()
+    app.include_router(router)
+
+    with TestClient(app) as client:
+        loaded = client.post(
+            "/v1/models/load",
+            json={"model": "image", "estimated_size_gb": 3},
+        )
+        assert loaded.status_code == 200
+        assert loaded.json()["id"] == "image"
+
+        status = client.get("/v1/models/residency")
+        assert status.status_code == 200
+        assert status.json()["memory_limit_bytes"] == 12 * GIB
+        assert {item["id"] for item in status.json()["models"]} == {"chat", "image"}
+
+        pinned = client.put("/v1/models/image/pin", json={"pinned": True})
+        assert pinned.status_code == 200
+        assert pinned.json()["pinned"] is True
+        assert client.delete("/v1/models/image").status_code == 409
+
+        assert (
+            client.put("/v1/models/image/pin", json={"pinned": False}).status_code
+            == 200
+        )
+        assert client.delete("/v1/models/image").status_code == 204
+        assert "image" not in registry

--- a/vllm_mlx/_download_gate.py
+++ b/vllm_mlx/_download_gate.py
@@ -580,6 +580,85 @@ def _snapshot_is_complete_split_model(repo_id: str) -> bool:
         return False
 
 
+def _snapshot_is_complete_mflux_model(repo_id: str) -> bool:
+    """True when a registered image-gen repo has every mflux weight shard.
+
+    mflux checkpoints keep independent sharded indexes below ``transformer/``,
+    ``text_encoder/``, and ``vae/``. They therefore satisfy neither the text
+    ``model*.safetensors`` probe nor mlx-video's ``split_model.json`` probe.
+    Anchor this layout to an explicit image-gen alias, then validate every
+    shard named by each required component index.
+    """
+    try:
+        from huggingface_hub.constants import HF_HUB_CACHE
+
+        from vllm_mlx.model_aliases import resolve_profile
+
+        profile = resolve_profile(repo_id)
+        if profile is None or profile.modality != "image-gen":
+            return False
+
+        repo_root = os.path.join(
+            HF_HUB_CACHE,
+            f"models--{repo_id.replace('/', '--')}",
+        )
+        resolved_sha = _resolved_snapshot_sha(repo_root)
+        if resolved_sha is None:
+            return False
+        snap_dir = os.path.join(repo_root, "snapshots", resolved_sha)
+        if not os.path.isdir(snap_dir):
+            return False
+
+        repo_root_real = os.path.realpath(repo_root)
+
+        def _is_nonempty_repo_file(path: str) -> bool:
+            if not os.path.isfile(path):
+                return False
+            real = os.path.realpath(path)
+            if real != repo_root_real and not real.startswith(repo_root_real + os.sep):
+                return False
+            try:
+                return os.path.getsize(path) > 0
+            except OSError:
+                return False
+
+        # All currently supported mflux families use these three components
+        # and a local tokenizer. Requiring the full set prevents an interrupted
+        # pull with only one component index from looking runnable.
+        tokenizer = os.path.join(snap_dir, "tokenizer", "tokenizer.json")
+        if not _is_nonempty_repo_file(tokenizer):
+            return False
+
+        import json
+
+        for component in ("transformer", "text_encoder", "vae"):
+            component_dir = os.path.join(snap_dir, component)
+            index_path = os.path.join(component_dir, "model.safetensors.index.json")
+            if not _is_nonempty_repo_file(index_path):
+                return False
+            try:
+                with open(index_path) as fh:
+                    index = json.load(fh)
+            except (OSError, json.JSONDecodeError):
+                return False
+            weight_map = index.get("weight_map") if isinstance(index, dict) else None
+            if not isinstance(weight_map, dict) or not weight_map:
+                return False
+            for shard in set(weight_map.values()):
+                if (
+                    not isinstance(shard, str)
+                    or not shard.endswith(".safetensors")
+                    or os.path.basename(shard) != shard
+                    or shard in (".", "..")
+                ):
+                    return False
+                if not _is_nonempty_repo_file(os.path.join(component_dir, shard)):
+                    return False
+        return True
+    except Exception:
+        return False
+
+
 def is_weightless_stub(repo_id: str) -> bool:
     """True if ``repo_id``'s config is cached but its weight shards are NOT.
 
@@ -627,7 +706,9 @@ def is_weightless_stub(repo_id: str) -> bool:
         # manifest lists components and EVERY one is cached, the weights are
         # present — not a stub. Check this BEFORE the text-glob probe so a
         # fully-cached video model doesn't mis-fire the notice.
-        if _snapshot_is_complete_split_model(repo_id):
+        if _snapshot_is_complete_split_model(
+            repo_id
+        ) or _snapshot_is_complete_mflux_model(repo_id):
             return False
         # Config is on disk; the stub is exactly "config present but the
         # loader's weight glob (model*.safetensors) is not satisfied".

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -3186,8 +3186,8 @@ def parse_image_size(value: str) -> tuple[int, int]:
 class ImageGenerationRequest(BaseModel):
     """Request for text-to-image (OpenAI ``/v1/images/generations`` compatible).
 
-    Rapid-MLX serves one image model per process (like the audio/video lanes),
-    so ``model`` is advisory — the loaded alias decides the family. ``size`` is
+    Rapid-MLX routes ``model`` to an exact resident image engine. It may be
+    omitted only when exactly one image model is resident. ``size`` is
     parsed and bounds-checked here so a malformed or oversized request surfaces
     a 400 ``invalid_request_error`` BEFORE mflux loads multi-gigabyte weights.
 

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -2674,6 +2674,12 @@ def serve_command(args):
             "Error: --gpu-memory-utilization must be between 0.0 (exclusive) and 1.0 (inclusive)"
         )
         sys.exit(1)
+    if getattr(args, "resident_memory_limit_gb", 0.0) < 0:
+        print("Error: --resident-memory-limit-gb must be >= 0")
+        sys.exit(1)
+    if getattr(args, "resident_model_idle_ttl", 0.0) < 0:
+        print("Error: --resident-model-idle-ttl must be >= 0")
+        sys.exit(1)
 
     # Validate PFlash config and reject unsupported model combinations
     # at startup. Done here (not lazily in the scheduler) so a typo in
@@ -3766,6 +3772,11 @@ def serve_command(args):
             file=sys.stderr,
         )
         sys.exit(2)
+    server.configure_model_residency(
+        memory_limit_gb=getattr(args, "resident_memory_limit_gb", 0.0),
+        idle_ttl_seconds=getattr(args, "resident_model_idle_ttl", 0.0),
+        gpu_memory_utilization=args.gpu_memory_utilization,
+    )
     try:
         load_model(
             args.model,
@@ -4911,11 +4922,16 @@ def _cache_entry_is_runnable(repo: str) -> bool:
     """
     try:
         from vllm_mlx._download_gate import (
+            _snapshot_is_complete_mflux_model,
             _snapshot_is_complete_split_model,
             is_repo_cached,
         )
 
-        return is_repo_cached(repo) or _snapshot_is_complete_split_model(repo)
+        return (
+            is_repo_cached(repo)
+            or _snapshot_is_complete_split_model(repo)
+            or _snapshot_is_complete_mflux_model(repo)
+        )
     except Exception:
         return False
 
@@ -8219,6 +8235,25 @@ Examples:
         help="Fraction of device memory for Metal allocation limit and emergency "
         "cache clear threshold (0.0-1.0, default: 0.90). Increase to 0.95 for "
         "large models (200GB+) that need more memory headroom.",
+    )
+    serve_parser.add_argument(
+        "--resident-memory-limit-gb",
+        type=float,
+        default=0.0,
+        help=(
+            "Process-wide resident model ceiling in GiB. Loading another model "
+            "evicts the least-recently-used idle unpinned model first. 0 disables "
+            "the ceiling (default: 0)."
+        ),
+    )
+    serve_parser.add_argument(
+        "--resident-model-idle-ttl",
+        type=float,
+        default=0.0,
+        help=(
+            "Evict idle unpinned secondary models after this many seconds. "
+            "0 disables idle eviction (default: 0)."
+        ),
     )
     # Paged cache options (experimental)
     serve_parser.add_argument(

--- a/vllm_mlx/config/server_config.py
+++ b/vllm_mlx/config/server_config.py
@@ -41,6 +41,10 @@ class ServerConfig:
     model_name: str | None = None
     model_alias: str | None = None
     model_path: str | None = None
+    # Runtime owner for additional engines loaded into this process. The
+    # legacy ``engine`` fields remain the protected startup/default model;
+    # request routes consult this manager for residency, eviction, and status.
+    residency_manager: Any = None
     # True only after lifespan has finished engine.start(), warmup,
     # prefix-cache load_from_disk, and MCP init. Used by /health/ready
     # so callers (e.g. validation pipelines) can wait for a real

--- a/vllm_mlx/routes/images.py
+++ b/vllm_mlx/routes/images.py
@@ -134,11 +134,41 @@ def install_image_body_limit_middleware(app) -> None:
 _DEFAULT_EDIT_STEPS = 20
 
 
-def _image_engine():
-    """Return the loaded image engine or raise a 409 if this isn't an image server."""
+def _image_engine(model_name: str = ""):
+    """Resolve an image engine exactly by request model, with single-model fallback."""
     from ..config import get_config
 
-    img_engine = get_config().engine
+    cfg = get_config()
+    registry = getattr(cfg, "model_registry", None)
+    img_engine = None
+
+    if model_name and registry:
+        try:
+            registry.validate_model_name(model_name)
+            img_engine = registry.get_engine(model_name)
+        except KeyError:
+            img_engine = None
+    elif model_name:
+        accepted = {
+            getattr(cfg, "model_name", None),
+            getattr(cfg, "model_alias", None),
+            getattr(cfg, "model_path", None),
+        }
+        if model_name in accepted:
+            img_engine = getattr(cfg, "engine", None)
+    elif registry:
+        image_entries = [
+            entry
+            for entry in registry.list_entries()
+            if getattr(entry.engine, "is_image_gen", False)
+        ]
+        # Backward compatibility for clients that omit model: it remains
+        # unambiguous when exactly one image model is resident.
+        if len(image_entries) == 1:
+            img_engine = image_entries[0].engine
+    else:
+        img_engine = getattr(cfg, "engine", None)
+
     if img_engine is None or not getattr(img_engine, "is_image_gen", False):
         raise HTTPException(
             status_code=409,
@@ -154,6 +184,9 @@ def _image_engine():
                 }
             },
         )
+    manager = getattr(cfg, "residency_manager", None)
+    if manager is not None:
+        manager.touch(model_name or getattr(img_engine, "model_name", None))
     return img_engine
 
 
@@ -189,11 +222,11 @@ async def create_image(request: ImageGenerationRequest = Body(...)):
     """
     from ..image.engine import ImageRuntimeError
 
-    img_engine = _image_engine()
+    img_engine = _image_engine(request.model)
 
-    # A single server hosts exactly one image model. When that model is the
-    # instruction-edit family, text-to-image generation is the wrong endpoint —
-    # 409 toward /v1/images/edits instead of silently ignoring the mismatch.
+    # When the selected resident engine is an instruction-edit model,
+    # text-to-image generation is the wrong endpoint. Point the caller to
+    # /v1/images/edits instead of silently ignoring the mismatch.
     if getattr(img_engine, "is_edit", False):
         raise HTTPException(
             status_code=409,
@@ -262,7 +295,7 @@ async def create_image(request: ImageGenerationRequest = Body(...)):
 
 
 @router.get("/v1/images/progress")
-async def image_progress():
+async def image_progress(model: str = ""):
     """Live denoise progress for the single in-flight render.
 
     Diffusion has a fixed step count, so this is a *true* ``step / total``
@@ -270,12 +303,12 @@ async def image_progress():
     streaming parser, and honest on slow hardware (the bar can't outrun the
     real steps). Single-flight: the server renders one image at a time.
     """
-    img_engine = _image_engine()
+    img_engine = _image_engine(model)
     return img_engine.progress_snapshot()
 
 
 @router.post("/v1/images/cancel")
-async def image_cancel():
+async def image_cancel(model: str = ""):
     """Ask the in-flight render to stop at the next denoise step.
 
     By design the image lane is **single-flight**: the engine's process lock
@@ -284,7 +317,7 @@ async def image_cancel():
     single-user server (the desktop app issues one generation at a time), so
     there is deliberately no per-request generation id to thread through.
     """
-    img_engine = _image_engine()
+    img_engine = _image_engine(model)
     img_engine.request_cancel()
     return {"ok": True}
 
@@ -346,7 +379,7 @@ async def edit_image(
     """
     from ..image.engine import ImageGenerationCancelled, ImageRuntimeError
 
-    img_engine = _image_engine()
+    img_engine = _image_engine(model)
 
     # /v1/images/edits requires the edit family; a txt2img server points the
     # caller at /v1/images/generations instead of silently ignoring the image.

--- a/vllm_mlx/routes/residency.py
+++ b/vllm_mlx/routes/residency.py
@@ -1,0 +1,107 @@
+"""Authenticated control plane for loading and evicting resident models."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Response
+from pydantic import BaseModel, Field
+
+from ..config import get_config
+from ..middleware.auth import verify_api_key
+from ..runtime.resident_models import (
+    ResidentModelBusyError,
+    ResidentModelCapacityError,
+    ResidentModelError,
+)
+
+router = APIRouter(dependencies=[Depends(verify_api_key)])
+
+
+class ModelLoadRequest(BaseModel):
+    model: str = Field(..., min_length=1)
+    model_path: str | None = None
+    estimated_size_gb: float | None = Field(default=None, gt=0, le=1024)
+    pin: bool = False
+    replace_group: str | None = Field(default=None, pattern="^(assistant)$")
+
+
+class ModelPinRequest(BaseModel):
+    pinned: bool = True
+
+
+def _manager():
+    manager = get_config().residency_manager
+    if manager is None:
+        raise HTTPException(
+            status_code=503,
+            detail="Resident model management is not initialized",
+        )
+    return manager
+
+
+def _record_payload(record) -> dict:
+    return next(
+        item
+        for item in _manager().snapshot()["models"]
+        if item["id"] == record.model_id
+    )
+
+
+@router.get("/v1/models/residency")
+async def model_residency():
+    """Return resident models and actual process usage against the ceiling."""
+
+    return _manager().snapshot()
+
+
+@router.post("/v1/models/load")
+async def load_resident_model(request: ModelLoadRequest):
+    """Load a model into the current process, evicting idle LRU entries first."""
+
+    manager = _manager()
+    estimated_bytes = (
+        int(request.estimated_size_gb * 1024**3)
+        if request.estimated_size_gb is not None
+        else None
+    )
+    try:
+        record = await manager.load(
+            request.model,
+            model_path=request.model_path,
+            estimated_bytes=estimated_bytes,
+            pin=request.pin,
+            replace_group=request.replace_group,
+        )
+    except ResidentModelCapacityError as exc:
+        raise HTTPException(status_code=507, detail=str(exc)) from exc
+    except ResidentModelError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except Exception as exc:
+        raise HTTPException(
+            status_code=500,
+            detail=f"Failed to load resident model: {type(exc).__name__}",
+        ) from exc
+    return _record_payload(record)
+
+
+@router.put("/v1/models/{model_id:path}/pin")
+async def pin_resident_model(model_id: str, request: ModelPinRequest):
+    try:
+        record = await _manager().set_pinned(model_id, request.pinned)
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail="Model is not resident") from exc
+    except ResidentModelError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    return _record_payload(record)
+
+
+@router.delete("/v1/models/{model_id:path}", status_code=204)
+async def unload_resident_model(model_id: str):
+    try:
+        await _manager().unload(model_id)
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail="Model is not resident") from exc
+    except ResidentModelBusyError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except ResidentModelError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    return Response(status_code=204)

--- a/vllm_mlx/runtime/image_lane.py
+++ b/vllm_mlx/runtime/image_lane.py
@@ -62,6 +62,15 @@ class ImageEngine:
         self.model_name = model_name
         self._engine = ImageGenerationEngine(model_name)
 
+    @property
+    def is_resident(self) -> bool:
+        """Whether mflux weights, rather than only the adapter, are loaded."""
+        return self._engine._model is not None  # noqa: SLF001
+
+    def ensure_resident(self) -> None:
+        """Eagerly materialize lazy mflux weights for budgeted residency."""
+        self._engine._ensure_loaded()  # noqa: SLF001
+
     def get_stats(self) -> dict:
         """Route-facing engine surface (mirrors ``BaseEngine.get_stats``).
 

--- a/vllm_mlx/runtime/model_registry.py
+++ b/vllm_mlx/runtime/model_registry.py
@@ -56,6 +56,9 @@ class ModelRegistry:
         self._default: str | None = None
         # Lookup index: any name/alias -> canonical_name
         self._index: dict[str, str] = {}
+        # Optional residency hook. Kept callback-shaped so this import-light
+        # name registry does not depend on the lifecycle manager.
+        self.on_engine_access = None
 
     def add(self, entry: ModelEntry, is_default: bool = False):
         """Register a model. First model added is default unless specified."""
@@ -115,17 +118,26 @@ class ModelRegistry:
         # None, empty, or "default" → default engine
         if not model_name or model_name == "default":
             if self._default and self._default in self._entries:
-                return self._entries[self._default].engine
+                engine = self._entries[self._default].engine
+                if self.on_engine_access is not None:
+                    self.on_engine_access(self._default)
+                return engine
             raise KeyError("No default model set")
 
         # Exact lookup via index
         canonical = self._index.get(model_name)
         if canonical and canonical in self._entries:
-            return self._entries[canonical].engine
+            engine = self._entries[canonical].engine
+            if self.on_engine_access is not None:
+                self.on_engine_access(canonical)
+            return engine
 
         # Fallback: default
         if self._default and self._default in self._entries:
-            return self._entries[self._default].engine
+            engine = self._entries[self._default].engine
+            if self.on_engine_access is not None:
+                self.on_engine_access(self._default)
+            return engine
 
         raise KeyError(f"Model '{model_name}' not found")
 
@@ -183,6 +195,16 @@ class ModelRegistry:
         if self._default:
             return self._entries.get(self._default)
         return None
+
+    def set_default(self, name: str) -> ModelEntry:
+        """Promote an already-registered model to the default engine."""
+
+        canonical = self._index.get(name)
+        if canonical is None or canonical not in self._entries:
+            raise KeyError(name)
+        self._default = canonical
+        logger.info("Promoted model %r to registry default", canonical)
+        return self._entries[canonical]
 
     def __len__(self) -> int:
         return len(self._entries)

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -381,7 +381,10 @@ class ResidentModelManager:
                 await self._evict_for_locked(0, exclude={record.model_id})
                 if replace_group is not None:
                     await self._replace_group_locked(record, replace_group)
-            except ResidentModelCapacityError:
+            except BaseException:
+                # Once the loader returns, this manager owns the engine.  A
+                # later admission/replacement failure must not leave a model
+                # resident even though the control-plane request was rejected.
                 await self._evict_locked(record, reason="load_rollback", count=False)
                 raise
             return record

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -1,0 +1,532 @@
+"""Budgeted lifecycle management for models resident in one server process."""
+
+from __future__ import annotations
+
+import asyncio
+import gc
+import logging
+import re
+import time
+from collections.abc import Awaitable, Callable
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+
+from .model_registry import ModelEntry, ModelRegistry
+from .process_memory import get_phys_footprint
+
+logger = logging.getLogger(__name__)
+
+_GIB = 1024**3
+_PARAM_RE = re.compile(r"(?<![a-z0-9])(\d+(?:\.\d+)?)b(?![a-z])", re.IGNORECASE)
+_QUANT_RE = re.compile(r"(?<!\d)(2|3|4|6|8|16)[-]?bit", re.IGNORECASE)
+
+
+class ResidentModelError(RuntimeError):
+    """Base class for resident-model control-plane failures."""
+
+
+class ResidentModelCapacityError(ResidentModelError):
+    """The configured ceiling cannot admit a model after eligible eviction."""
+
+
+class ResidentModelBusyError(ResidentModelError):
+    """A model cannot be removed while it owns active work."""
+
+
+@dataclass
+class ResidencyRecord:
+    """Mutable lifecycle metadata kept outside the route-facing registry entry."""
+
+    entry: ModelEntry
+    estimated_bytes: int
+    loaded_at: float
+    last_used_at: float
+    pinned: bool = False
+    primary: bool = False
+    active_requests: int = 0
+    state: str = "resident"
+    measured_bytes: int = 0
+
+    @property
+    def model_id(self) -> str:
+        return self.entry.model_name
+
+
+Loader = Callable[[str, str | None], Awaitable[ModelEntry]]
+PrimaryChanged = Callable[[ModelEntry], None]
+
+
+def _modality(entry: ModelEntry) -> str:
+    engine = entry.engine
+    if getattr(engine, "is_image_gen", False):
+        return "image-gen"
+    if getattr(engine, "is_video_gen", False):
+        return "video-gen"
+    if getattr(engine, "is_mllm", False):
+        return "mllm"
+    return "text"
+
+
+def _replacement_group(entry: ModelEntry) -> str:
+    """Map request-facing modalities to lifecycle replacement groups."""
+
+    modality = _modality(entry)
+    return "assistant" if modality in {"text", "mllm"} else modality
+
+
+def estimate_model_bytes(model_name: str) -> int:
+    """Conservative fallback charge when the caller has no catalog estimate.
+
+    This mirrors the desktop's weight + runtime + KV shape closely enough for
+    admission, without pretending it is an allocator measurement. Callers that
+    know the downloaded size should pass ``estimated_bytes`` to ``load``.
+    """
+
+    folded = model_name.casefold()
+    known_image_gib = {
+        "flux2-klein-4b": 5.9,
+        "z-image-turbo": 5.9,
+    }
+    for token, gib in known_image_gib.items():
+        if token in folded:
+            return int(gib * _GIB)
+
+    params = [float(value) for value in _PARAM_RE.findall(folded)]
+    if not params:
+        return 4 * _GIB
+    bits_match = _QUANT_RE.search(folded)
+    bits = int(bits_match.group(1)) if bits_match else 4
+    bytes_per_param = {
+        2: 0.28,
+        3: 0.42,
+        4: 0.55,
+        6: 0.80,
+        8: 1.05,
+        16: 2.0,
+    }.get(bits, 0.55)
+    largest = max(params)
+    kv_gib = (
+        1.5 if largest < 4 else 2.5 if largest < 10 else 4.0 if largest < 25 else 6.0
+    )
+    return int((largest * bytes_per_param + 1.2 + kv_gib) * _GIB)
+
+
+def _engine_is_idle(engine: object) -> bool:
+    """Best-effort idle check shared by explicit, LRU, and TTL eviction."""
+
+    progress = getattr(engine, "progress_snapshot", None)
+    if callable(progress):
+        try:
+            if bool(progress().get("running", False)):
+                return False
+        except Exception:
+            return False
+
+    get_stats = getattr(engine, "get_stats", None)
+    if callable(get_stats):
+        try:
+            stats = get_stats() or {}
+            if int(stats.get("num_running", 0) or 0) > 0:
+                return False
+            if int(stats.get("num_waiting", 0) or 0) > 0:
+                return False
+        except Exception:
+            return False
+    return True
+
+
+def _release_allocator_cache() -> None:
+    """Return dead model buffers to MLX/Metal after dropping Python refs."""
+
+    gc.collect()
+    try:
+        import mlx.core as mx
+
+        mx.clear_cache()
+    except Exception:
+        # Non-MLX unit-test hosts and older MLX builds are valid here.
+        pass
+
+
+class ResidentModelManager:
+    """Own dynamic engines and enforce a process-wide residency ceiling.
+
+    Loads and evictions are serialized under one asyncio lock. The primary
+    startup model is registered as pinned because legacy health/cache routes
+    still expose it through ``ServerConfig.engine``; dynamic engines are fully
+    owned by this manager and may be evicted.
+    """
+
+    def __init__(
+        self,
+        registry: ModelRegistry,
+        loader: Loader,
+        *,
+        memory_limit_bytes: int = 0,
+        idle_ttl_seconds: float = 0,
+        clock: Callable[[], float] = time.monotonic,
+        memory_reader: Callable[[], int] = get_phys_footprint,
+        on_primary_changed: PrimaryChanged | None = None,
+    ) -> None:
+        self.registry = registry
+        self.loader = loader
+        self.memory_limit_bytes = max(0, int(memory_limit_bytes))
+        self.idle_ttl_seconds = max(0.0, float(idle_ttl_seconds))
+        self._clock = clock
+        self._memory_reader = memory_reader
+        self._on_primary_changed = on_primary_changed
+        self._records: dict[str, ResidencyRecord] = {}
+        self._index: dict[str, str] = {}
+        self._lock = asyncio.Lock()
+        self._ttl_task: asyncio.Task | None = None
+        self.evictions_total = 0
+        self.loads_total = 0
+        self.registry.on_engine_access = self.touch
+
+    def _canonical(self, name: str | None) -> str | None:
+        if not name or name == "default":
+            return self.registry.default_name
+        return self._index.get(name, name if name in self._records else None)
+
+    def _index_record(self, record: ResidencyRecord) -> None:
+        canonical = record.model_id
+        self._records[canonical] = record
+        self._index[canonical] = canonical
+        self._index[record.entry.model_path] = canonical
+        for alias in record.entry.aliases:
+            self._index[alias] = canonical
+
+    def _drop_record(self, canonical: str) -> ResidencyRecord | None:
+        record = self._records.pop(canonical, None)
+        if record is None:
+            return None
+        for key in [key for key, value in self._index.items() if value == canonical]:
+            self._index.pop(key, None)
+        return record
+
+    def register_primary(
+        self, entry: ModelEntry, *, estimated_bytes: int | None = None
+    ) -> ResidencyRecord:
+        """Register the already-started legacy engine as protected primary."""
+
+        now = self._clock()
+        record = ResidencyRecord(
+            entry=entry,
+            estimated_bytes=max(
+                1, estimated_bytes or estimate_model_bytes(entry.model_name)
+            ),
+            # Process footprint is exposed separately as the authoritative
+            # total. Charging it to the primary row would make that one model
+            # appear to own Python, uvicorn, Metal caches, and every secondary.
+            measured_bytes=0,
+            loaded_at=now,
+            last_used_at=now,
+            pinned=True,
+            primary=True,
+        )
+        self._index_record(record)
+        return record
+
+    def _read_memory(self) -> int:
+        try:
+            return max(0, int(self._memory_reader()))
+        except Exception:
+            return 0
+
+    def _accounted_usage(self) -> int:
+        measured = self._read_memory()
+        reserved = sum(
+            max(record.estimated_bytes, record.measured_bytes)
+            for record in self._records.values()
+            if record.state == "resident"
+        )
+        # Some engines (notably mflux) construct lazy MLX arrays without
+        # faulting all weight pages into the process. The footprint delta at
+        # load time can therefore be much smaller than the memory the first
+        # request will materialize. Keep the catalog/heuristic reservation in
+        # force until the actual process footprint grows past it.
+        return max(measured, reserved)
+
+    def contains(self, model_name: str) -> bool:
+        return self._canonical(model_name) is not None
+
+    def touch(self, model_name: str | None) -> None:
+        canonical = self._canonical(model_name)
+        if canonical and canonical in self._records:
+            self._records[canonical].last_used_at = self._clock()
+
+    async def start(self) -> None:
+        if self.idle_ttl_seconds <= 0 or self._ttl_task is not None:
+            return
+        self._ttl_task = asyncio.create_task(self._ttl_loop())
+
+    async def shutdown(self) -> None:
+        task = self._ttl_task
+        self._ttl_task = None
+        if task is not None:
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+        async with self._lock:
+            dynamic = [
+                record for record in self._records.values() if not record.primary
+            ]
+            for record in dynamic:
+                await self._evict_locked(record, reason="shutdown", count=False)
+
+    async def _ttl_loop(self) -> None:
+        interval = min(60.0, max(1.0, self.idle_ttl_seconds / 4.0))
+        while True:
+            await asyncio.sleep(interval)
+            await self.evict_expired()
+
+    async def evict_expired(self) -> list[str]:
+        if self.idle_ttl_seconds <= 0:
+            return []
+        async with self._lock:
+            now = self._clock()
+            expired = sorted(
+                (
+                    record
+                    for record in self._records.values()
+                    if not record.pinned
+                    and not record.primary
+                    and record.active_requests == 0
+                    and now - record.last_used_at >= self.idle_ttl_seconds
+                    and _engine_is_idle(record.entry.engine)
+                ),
+                key=lambda record: record.last_used_at,
+            )
+            evicted = []
+            for record in expired:
+                evicted.append(record.model_id)
+                await self._evict_locked(record, reason="idle_ttl")
+            return evicted
+
+    async def _evict_for_locked(self, incoming_bytes: int, exclude: set[str]) -> None:
+        if self.memory_limit_bytes <= 0:
+            return
+        while self._accounted_usage() + incoming_bytes > self.memory_limit_bytes:
+            candidates = sorted(
+                (
+                    record
+                    for record in self._records.values()
+                    if record.model_id not in exclude
+                    and not record.pinned
+                    and not record.primary
+                    and record.active_requests == 0
+                    and record.state == "resident"
+                    and _engine_is_idle(record.entry.engine)
+                ),
+                key=lambda record: record.last_used_at,
+            )
+            if not candidates:
+                usage = self._accounted_usage()
+                raise ResidentModelCapacityError(
+                    "resident model memory ceiling exceeded: "
+                    f"usage={usage / _GIB:.2f} GiB, "
+                    f"incoming={incoming_bytes / _GIB:.2f} GiB, "
+                    f"limit={self.memory_limit_bytes / _GIB:.2f} GiB; "
+                    "no idle unpinned model is eligible for eviction"
+                )
+            await self._evict_locked(candidates[0], reason="memory_pressure")
+
+    async def load(
+        self,
+        model_name: str,
+        *,
+        model_path: str | None = None,
+        estimated_bytes: int | None = None,
+        pin: bool = False,
+        replace_group: str | None = None,
+    ) -> ResidencyRecord:
+        model_name = model_name.strip()
+        if not model_name:
+            raise ResidentModelError("model must not be empty")
+        estimate = max(1, estimated_bytes or estimate_model_bytes(model_name))
+
+        async with self._lock:
+            canonical = self._canonical(model_name)
+            if canonical is not None:
+                record = self._records[canonical]
+                record.last_used_at = self._clock()
+                if pin:
+                    record.pinned = True
+                if replace_group is not None:
+                    await self._replace_group_locked(record, replace_group)
+                return record
+
+            await self._evict_for_locked(estimate, exclude={model_name})
+            before = self._read_memory()
+            entry = await self.loader(model_name, model_path)
+            now = self._clock()
+            after = self._read_memory()
+            delta = max(0, after - before) if before and after else 0
+            record = ResidencyRecord(
+                entry=entry,
+                estimated_bytes=estimate,
+                measured_bytes=delta,
+                loaded_at=now,
+                last_used_at=now,
+                pinned=pin,
+            )
+            self.registry.add(entry)
+            self._index_record(record)
+            self.loads_total += 1
+
+            try:
+                await self._evict_for_locked(0, exclude={record.model_id})
+                if replace_group is not None:
+                    await self._replace_group_locked(record, replace_group)
+            except ResidentModelCapacityError:
+                await self._evict_locked(record, reason="load_rollback", count=False)
+                raise
+            return record
+
+    async def _replace_group_locked(
+        self, target: ResidencyRecord, group: str
+    ) -> None:
+        """Make ``target`` the sole unpinned model in a lifecycle group.
+
+        The desktop uses the ``assistant`` group for its chat picker: changing
+        chat models replaces the previous text/VLM engine while independent
+        image engines remain resident. A protected startup assistant hands its
+        primary role to the replacement before the old engine is stopped, so
+        legacy health/cache routes never retain a reference to unloaded weights.
+        """
+
+        if group != _replacement_group(target.entry):
+            raise ResidentModelError(
+                f"model {target.model_id!r} does not belong to replacement group {group!r}"
+            )
+
+        candidates = [
+            record
+            for record in self._records.values()
+            if record.model_id != target.model_id
+            and _replacement_group(record.entry) == group
+        ]
+        for record in candidates:
+            if record.active_requests or not _engine_is_idle(record.entry.engine):
+                raise ResidentModelBusyError("model is serving an active request")
+            if record.pinned and not record.primary:
+                raise ResidentModelError(
+                    f"pinned model {record.model_id!r} cannot be replaced"
+                )
+
+        old_primary = next((record for record in candidates if record.primary), None)
+        if old_primary is not None:
+            old_primary.primary = False
+            old_primary.pinned = False
+            target.primary = True
+            target.pinned = True
+            self.registry.set_default(target.model_id)
+            if self._on_primary_changed is not None:
+                self._on_primary_changed(target.entry)
+
+        for record in candidates:
+            await self._evict_locked(record, reason=f"replace_{group}")
+
+    async def set_pinned(self, model_name: str, pinned: bool) -> ResidencyRecord:
+        async with self._lock:
+            canonical = self._canonical(model_name)
+            if canonical is None:
+                raise KeyError(model_name)
+            record = self._records[canonical]
+            if record.primary and not pinned:
+                raise ResidentModelError("the primary startup model cannot be unpinned")
+            record.pinned = pinned
+            record.last_used_at = self._clock()
+            return record
+
+    async def unload(self, model_name: str) -> None:
+        async with self._lock:
+            canonical = self._canonical(model_name)
+            if canonical is None:
+                raise KeyError(model_name)
+            record = self._records[canonical]
+            if record.pinned or record.primary:
+                raise ResidentModelError("pinned models cannot be unloaded")
+            if record.active_requests or not _engine_is_idle(record.entry.engine):
+                raise ResidentModelBusyError("model is serving an active request")
+            await self._evict_locked(record, reason="explicit")
+
+    async def _evict_locked(
+        self, record: ResidencyRecord, *, reason: str, count: bool = True
+    ) -> None:
+        if record.active_requests:
+            raise ResidentModelBusyError("model is serving an active request")
+        record.state = "evicting"
+        self.registry.remove(record.model_id)
+        self._drop_record(record.model_id)
+        stop = getattr(record.entry.engine, "stop", None)
+        if callable(stop):
+            result = stop()
+            if asyncio.iscoroutine(result):
+                await result
+        _release_allocator_cache()
+        if count:
+            self.evictions_total += 1
+        logger.info("Evicted resident model %r (%s)", record.model_id, reason)
+
+    @asynccontextmanager
+    async def lease(self, model_name: str):
+        async with self._lock:
+            canonical = self._canonical(model_name)
+            if canonical is None:
+                raise KeyError(model_name)
+            record = self._records[canonical]
+            if record.state != "resident":
+                raise ResidentModelBusyError("model is being evicted")
+            record.active_requests += 1
+            record.last_used_at = self._clock()
+            engine = record.entry.engine
+        try:
+            yield engine
+        finally:
+            async with self._lock:
+                current = self._records.get(canonical)
+                if current is not None:
+                    current.active_requests = max(0, current.active_requests - 1)
+                    current.last_used_at = self._clock()
+
+    def snapshot(self) -> dict:
+        now = self._clock()
+        models = []
+        for record in sorted(self._records.values(), key=lambda item: item.loaded_at):
+            engine = record.entry.engine
+            resident = not hasattr(engine, "is_resident") or bool(engine.is_resident)
+            models.append(
+                {
+                    "id": record.model_id,
+                    "model_path": record.entry.model_path,
+                    "aliases": sorted(record.entry.aliases),
+                    "modality": (
+                        _modality(record.entry)
+                    ),
+                    "state": record.state if resident else "registered",
+                    "pinned": record.pinned,
+                    "primary": record.primary,
+                    "active_requests": record.active_requests,
+                    "estimated_bytes": record.estimated_bytes,
+                    "measured_bytes": record.measured_bytes or None,
+                    "idle_seconds": max(0.0, now - record.last_used_at),
+                }
+            )
+        usage = self._accounted_usage()
+        return {
+            "memory_limit_bytes": self.memory_limit_bytes,
+            "memory_used_bytes": usage,
+            "memory_available_bytes": (
+                max(0, self.memory_limit_bytes - usage)
+                if self.memory_limit_bytes > 0
+                else None
+            ),
+            "idle_ttl_seconds": self.idle_ttl_seconds,
+            "loads_total": self.loads_total,
+            "evictions_total": self.evictions_total,
+            "models": models,
+        }

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -125,6 +125,7 @@ from .engine import (
     BatchedEngine,
 )
 from .runtime.model_registry import ModelEntry, ModelRegistry
+from .runtime.resident_models import ResidentModelManager, estimate_model_bytes
 from .service.helpers import (  # noqa: F401 — re-export for backward compat
     _FALLBACK_TEMPERATURE,
     _FALLBACK_TOP_P,
@@ -188,6 +189,10 @@ def configure_logging(log_level: str) -> str:
 # When populated, get_engine() routes by request model name.
 # Backward-compatible: single-model mode still uses _engine global as before.
 _model_registry = ModelRegistry()
+_residency_manager: ResidentModelManager | None = None
+_resident_memory_limit_bytes: int = 0
+_resident_idle_ttl_seconds: float = 0.0
+_resident_gpu_memory_utilization: float = 0.90
 
 # Global engine instance (single-model legacy path, also primary model in multi-model)
 _engine: BaseEngine | None = None
@@ -627,6 +632,37 @@ async def lifespan(app: FastAPI):
         _warmup_secs = _time.monotonic() - _warmup_start
         logger.info(f"Warmup complete ({_warmup_secs:.1f}s)")
 
+    # Publish the startup engine into the resident-model lifecycle after it is
+    # fully started. Legacy routes still expose this engine through cfg.engine,
+    # so it is the protected primary; additional engines are manager-owned and
+    # eligible for LRU/TTL eviction.
+    global _residency_manager
+    if _residency_manager is None:
+        _residency_manager = configure_model_residency(
+            memory_limit_gb=_resident_memory_limit_bytes / 1024**3,
+            idle_ttl_seconds=_resident_idle_ttl_seconds,
+            gpu_memory_utilization=_resident_gpu_memory_utilization,
+        )
+    if _engine is not None:
+        _primary_entry = next(
+            (
+                entry
+                for entry in _model_registry.list_entries()
+                if entry.engine is _engine
+            ),
+            None,
+        )
+        if _primary_entry is not None and not _residency_manager.contains(
+            _primary_entry.model_name
+        ):
+            _residency_manager.register_primary(
+                _primary_entry,
+                estimated_bytes=estimate_model_bytes(
+                    _model_alias or _primary_entry.model_name
+                ),
+            )
+    await _residency_manager.start()
+
     # Tool-grammar warmup (#558): the FIRST grammar-constrained tool call
     # otherwise pays a one-time ~1s llguidance ``LLTokenizer`` build on the
     # request path (measured on gpt-oss-20b: ~1.7s cold first tool-call vs
@@ -787,6 +823,8 @@ async def lifespan(app: FastAPI):
         if _mcp_manager is not None:
             await _mcp_manager.stop()
             logger.info("MCP manager stopped")
+        if _residency_manager is not None:
+            await _residency_manager.shutdown()
         if _engine is not None:
             await _engine.stop()
             logger.info("Engine stopped")
@@ -2049,6 +2087,129 @@ def load_model(
     register_audio_routes_if_enabled()
 
 
+async def _load_dynamic_resident_model(
+    model_name: str, model_path: str | None
+) -> ModelEntry:
+    """Construct and start one non-primary engine for the residency manager."""
+
+    from .model_aliases import resolve_profile
+
+    profile = resolve_profile(model_name) or (
+        resolve_profile(model_path) if model_path else None
+    )
+    resolved_path = model_path or (
+        profile.hf_path if profile is not None else model_name
+    )
+    modality = profile.modality if profile is not None else "text"
+
+    if modality == "image-gen":
+        from .runtime.image_lane import ImageEngine
+
+        engine = ImageEngine(model_name=resolved_path)
+        # Dynamic loads are explicit operator/app requests. Materialize the
+        # lazy mflux weights before returning so "resident" and budget usage
+        # have their literal meanings on the control-plane response.
+        await asyncio.to_thread(engine.ensure_resident)
+    elif modality == "text-diffusion":
+        from .runtime.diffusion_lane import DiffusionEngine
+
+        engine = DiffusionEngine(
+            model_name=resolved_path,
+            max_tokens=_default_max_tokens,
+        )
+        engine._load_blocking()  # noqa: SLF001
+        if hasattr(engine, "_loaded") and not engine._loaded:
+            await engine.start()
+        engine.generate_warmup()
+    elif modality in ("video-gen", "audio"):
+        raise RuntimeError(
+            f"runtime residency loading is not available for modality {modality!r}"
+        )
+    else:
+        engine = BatchedEngine(
+            model_name=resolved_path,
+            force_text=bool(profile is not None and profile.is_text_only),
+            gpu_memory_utilization=_resident_gpu_memory_utilization,
+        )
+        await engine.start()
+        try:
+            engine.generate_warmup()
+        except Exception as exc:  # noqa: BLE001 - warmup is an optimization
+            logger.debug("Dynamic model warmup failed (non-fatal): %s", exc)
+
+    return ModelEntry(
+        engine=engine,
+        model_name=model_name,
+        model_path=resolved_path,
+        aliases=set(),
+        tool_call_parser=(profile.tool_call_parser if profile is not None else None),
+        reasoning_parser=(profile.reasoning_parser if profile is not None else None),
+        is_mllm=getattr(engine, "is_mllm", False),
+        max_tokens=_default_max_tokens,
+    )
+
+
+def configure_model_residency(
+    *,
+    memory_limit_gb: float = 0,
+    idle_ttl_seconds: float = 0,
+    gpu_memory_utilization: float = 0.90,
+) -> ResidentModelManager:
+    """Configure the process-wide resident-model manager before startup."""
+
+    global _residency_manager
+    global _resident_memory_limit_bytes
+    global _resident_idle_ttl_seconds
+    global _resident_gpu_memory_utilization
+
+    _resident_memory_limit_bytes = max(0, int(float(memory_limit_gb) * 1024**3))
+    _resident_idle_ttl_seconds = max(0.0, float(idle_ttl_seconds))
+    _resident_gpu_memory_utilization = float(gpu_memory_utilization)
+    _residency_manager = ResidentModelManager(
+        _model_registry,
+        _load_dynamic_resident_model,
+        memory_limit_bytes=_resident_memory_limit_bytes,
+        idle_ttl_seconds=_resident_idle_ttl_seconds,
+        on_primary_changed=_set_resident_primary,
+    )
+    get_config().residency_manager = _residency_manager
+    return _residency_manager
+
+
+def _set_resident_primary(entry: ModelEntry) -> None:
+    """Publish a replacement assistant as the legacy/default engine."""
+
+    global _engine, _model_name, _model_alias, _model_path
+    global _enable_auto_tool_choice, _tool_call_parser, _tool_parser_instance
+    global _reasoning_parser, _reasoning_parser_name
+
+    _engine = entry.engine
+    _model_name = entry.model_name
+    _model_alias = entry.model_name
+    _model_path = entry.model_path
+    _tool_call_parser = entry.tool_call_parser
+    _tool_parser_instance = None
+    _enable_auto_tool_choice = entry.tool_call_parser is not None
+    _reasoning_parser_name = entry.reasoning_parser
+    if entry.reasoning_parser is not None:
+        from .reasoning import get_parser
+
+        _reasoning_parser = get_parser(entry.reasoning_parser)()
+    else:
+        _reasoning_parser = None
+
+    cfg = get_config()
+    cfg.engine = entry.engine
+    cfg.model_name = entry.model_name
+    cfg.model_alias = entry.model_name
+    cfg.model_path = entry.model_path
+    cfg.enable_auto_tool_choice = _enable_auto_tool_choice
+    cfg.tool_call_parser = entry.tool_call_parser
+    cfg.tool_parser_instance = None
+    cfg.reasoning_parser = _reasoning_parser
+    cfg.reasoning_parser_name = entry.reasoning_parser
+
+
 def _sync_config() -> None:
     """Copy server globals into the ServerConfig singleton.
 
@@ -2100,6 +2261,7 @@ def _sync_config() -> None:
     cfg.pinned_system_prompt_hash = _pinned_system_prompt_hash
     cfg.mcp_executor = _mcp_executor
     cfg.model_registry = _model_registry
+    cfg.residency_manager = _residency_manager
     cfg.enable_audio_lane = _enable_audio_lane
 
 
@@ -2175,6 +2337,7 @@ from .routes.images import router as _images_router
 from .routes.mcp_routes import router as _mcp_router
 from .routes.metrics import router as _metrics_router
 from .routes.models import router as _models_router
+from .routes.residency import router as _residency_router
 from .routes.responses import router as _responses_router
 from .routes.video import router as _video_router
 
@@ -2184,6 +2347,9 @@ app.include_router(_health_router)
 # ``X-Rapid-MLX-Internal: true`` gate ALSO applies when ``--api-key`` is unset.
 app.include_router(_health_admin_router)
 app.include_router(_metrics_router)
+# Keep literal residency paths ahead of ``/v1/models/{model_id:path}`` so the
+# latter cannot consume ``residency`` as an ordinary model id.
+app.include_router(_residency_router)
 app.include_router(_models_router)
 app.include_router(_chat_router)
 app.include_router(_completions_router)


### PR DESCRIPTION
## What does this PR do?

  Adds budgeted multi-model residency to the server and desktop app.

  - Allows one server process to host multiple models and route requests using the request's `model` field.
  - Keeps Chat and Images models resident at the same time when memory permits.
  - Adds a configurable process-wide memory ceiling.
  - Evicts the least-recently-used idle, unpinned model before admitting a model that would exceed the ceiling.
  - Supports pinned models and idle-TTL eviction.
  - Treats chat and VLM models as an `assistant` replacement group: selecting a new text model unloads the previous assistant while leaving image models resident.
  - Exposes resident models and memory usage in the desktop sidebar.
  - Stops replace-starting the sidecar when switching between Chat and Images.
  - Recognizes complete mflux image-model caches correctly in Model Management, while partial downloads remain marked incomplete.

  ## Why is this needed?

  Fixes #1713: **Chat and Images cannot be resident together: switching tabs replace-starts the server.**

  Previously, the server hosted exactly one model. Selecting an image model unloaded the chat model, and returning to Chat unloaded the image model and reloaded the chat model. Every tab round trip therefore paid a full model-load cost, even on machines with enough unified memory for both models.

  This also made the desktop UI misleading because Chat and Images are presented as peer workflows, but using one interrupted the other. It prevented workflows involving multiple modalities from sharing one running server.

  The new residency manager enforces an explicit memory ceiling rather than relying on host swapping or failing an admission request. Desktop defaults reuse the existing RAM and model-sizing logic.