### PR TITLE
feat(models): Muse Glimmer support — ATEM tool parser, recipient-channel reasoning, aliases

### DIFF
--- a/tests/test_muse_parsers.py
+++ b/tests/test_muse_parsers.py
@@ -203,13 +203,52 @@ def test_fake_opener_inside_value_filtered_by_schema():
     assert json.loads(result.tool_calls[0]["arguments"]) == {"text": value}
 
 
-def test_null_for_nullable_non_string():
+def test_null_only_when_schema_allows_it():
+    # Codex r4 #1: null -> None ONLY for nullable schemas; against a
+    # non-nullable type the raw string survives so strict validation
+    # rejects it visibly instead of receiving a forged None.
     parser = _tool_parser()
-    text = _block(_invoke("f", {"limit": "null"}))
+    text = _block(_invoke("f", {"limit": "null", "count": "null"}))
     result = parser.extract_tool_calls(
-        text, request=_request("f", {"limit": {"type": "integer"}})
+        text,
+        request=_request(
+            "f",
+            {
+                "limit": {"type": ["integer", "null"]},
+                "count": {"type": "integer"},
+            },
+        ),
     )
-    assert json.loads(result.tool_calls[0]["arguments"]) == {"limit": None}
+    assert json.loads(result.tool_calls[0]["arguments"]) == {
+        "limit": None,
+        "count": "null",
+    }
+
+
+def test_duplicate_name_fake_opener_cannot_overwrite_value():
+    # Codex r4 #2: a fake opener REUSING the declared name must not
+    # become a second parameter that overwrites the real value.
+    parser = _tool_parser()
+    value = 'real start <atem:parameter name="text">evil</atem:parameter> real end'
+    text = _block(_invoke("echo", {"text": value}))
+    result = parser.extract_tool_calls(
+        text, request=_request("echo", {"text": {"type": "string"}})
+    )
+    assert json.loads(result.tool_calls[0]["arguments"]) == {"text": value}
+
+
+def test_literal_invoke_closer_inside_value_does_not_truncate():
+    # Codex r4 #3: a literal </atem:invoke> inside a parameter value
+    # leaves the parameter structure unbalanced at that point, so the
+    # invoke scan extends to the real closer.
+    parser = _tool_parser()
+    value = "docs mention </atem:invoke> literally"
+    text = _block(_invoke("echo", {"text": value}))
+    result = parser.extract_tool_calls(
+        text, request=_request("echo", {"text": {"type": "string"}})
+    )
+    assert result.tools_called
+    assert json.loads(result.tool_calls[0]["arguments"]) == {"text": value}
 
 
 @BOTH_MODES
@@ -354,8 +393,7 @@ def test_malformed_completed_block_bytes_survive(streaming):
     # Codex r3 #2: a completed block with no parseable invoke is model
     # output the client must see — in BOTH modes.
     text = (
-        "Before <atem:function_calls>\ngarbage, no invoke\n"
-        "</atem:function_calls> after"
+        "Before <atem:function_calls>\ngarbage, no invoke\n</atem:function_calls> after"
     )
     content, calls = run_tool_extraction(
         _tool_parser(), _chars(text), streaming=streaming
@@ -457,6 +495,18 @@ def test_tool_segment_passes_through_as_content(streaming):
     )
     assert reasoning == "Need the weather."
     assert content is not None and block in content
+
+
+@BOTH_MODES
+def test_plain_text_before_explicit_header_is_content(streaming):
+    # Codex r4 #4: with no implicit header, text before the first
+    # explicit header is model output, not discardable plumbing.
+    text = "Hello<|start|>assistant to=user<|message|>Hi<|eot|>"
+    reasoning, content = run_reasoning_extraction(
+        _reasoning_parser(), _chars(text), streaming=streaming
+    )
+    assert reasoning is None
+    assert content == "HelloHi"
 
 
 def test_streaming_never_leaks_header_or_terminator_bytes():

--- a/tests/test_muse_parsers.py
+++ b/tests/test_muse_parsers.py
@@ -509,6 +509,37 @@ def test_reasoning_trailing_partial_sentinel_parity(streaming):
     assert content == "answer <|eo"
 
 
+@BOTH_MODES
+def test_literal_terminator_mid_prose_survives(streaming):
+    # Codex r7 #3/#4: only STRUCTURAL terminators (segment boundary /
+    # end) are plumbing; a literal one mid-prose is model output.
+    text = " to=user<|message|>the <|eot|> token ends a turn<|eot|>"
+    reasoning, content = run_reasoning_extraction(
+        _reasoning_parser(), _chars(text), streaming=streaming
+    )
+    assert reasoning is None
+    assert content == "the <|eot|> token ends a turn"
+
+
+def test_same_delta_content_and_call_keep_wire_order():
+    # Codex r7 #2: content arriving in the same delta as the block
+    # close rides in the SAME response as the calls.
+    parser = _tool_parser()
+    block = _block(_invoke("f", {"a": "1"}))
+    deltas = ["Hi", " there\n" + block]
+    prev = ""
+    outs = []
+    for d in deltas:
+        curr = prev + d
+        out = parser.extract_tool_calls_streaming(prev, curr, d)
+        if out:
+            outs.append(out)
+        prev = curr
+    last = outs[-1]
+    assert last.get("tool_calls") and len(last["tool_calls"]) == 1
+    assert last.get("content") == " there\n"
+
+
 def test_truncated_block_keeps_bytes_as_content():
     # An opener with no parseable invoke must not vanish silently.
     parser = _tool_parser()

--- a/tests/test_muse_parsers.py
+++ b/tests/test_muse_parsers.py
@@ -483,6 +483,32 @@ def test_non_finite_number_stays_raw():
     assert args == {"a": "NaN", "b": "1e309", "c": 2.5}
 
 
+@BOTH_MODES
+def test_quoted_opener_in_prose_does_not_swallow_later_call(streaming):
+    # Codex r6 #2: a definitively malformed (quoted-in-prose) opener
+    # must not stop the scan — a real call later in the response fires.
+    text = "The wire wraps calls in <atem:function_calls> as you know.\n" + _block(
+        _invoke("get_weather", {"city": "Oslo"})
+    )
+    content, calls = run_tool_extraction(
+        _tool_parser(), _chars(text), streaming=streaming
+    )
+    assert [c.name for c in calls] == ["get_weather"]
+    assert "as you know." in (content or "")
+
+
+@BOTH_MODES
+def test_reasoning_trailing_partial_sentinel_parity(streaming):
+    # Codex r6 #3: output ending in a partial sentinel must not lose
+    # those bytes in streaming — finalize releases the hold.
+    text = " to=user<|message|>answer <|eo"
+    reasoning, content = run_reasoning_extraction(
+        _reasoning_parser(), _chars(text), streaming=streaming
+    )
+    assert reasoning is None
+    assert content == "answer <|eo"
+
+
 def test_truncated_block_keeps_bytes_as_content():
     # An opener with no parseable invoke must not vanish silently.
     parser = _tool_parser()

--- a/tests/test_muse_parsers.py
+++ b/tests/test_muse_parsers.py
@@ -240,6 +240,53 @@ def test_channel_wrapped_call_extracts_and_strips_plumbing(streaming):
     assert not (content or "").strip()
 
 
+@BOTH_MODES
+def test_content_after_block_survives(streaming):
+    # Codex r1 BLOCKING #1: streaming used to swallow everything after
+    # the first opener; content between/after blocks must reach the wire.
+    text = (
+        "Checking.\n"
+        + _block(_invoke("get_weather", {"city": "Oslo"}))
+        + "\nDone checking."
+    )
+    content, calls = run_tool_extraction(
+        _tool_parser(), _chars(text), streaming=streaming
+    )
+    assert len(calls) == 1
+    combined = content or ""
+    assert "Checking." in combined
+    assert "Done checking." in combined
+
+
+def test_invoke_outside_block_is_literal_content():
+    # Codex r1 BLOCKING #2: invoke-shaped text OUTSIDE a completed block
+    # (the model quoting an example) must never become an executable call.
+    quoted = _invoke("rm_rf", {"path": "/"})
+    text = (
+        "For example you would write:\n"
+        + quoted
+        + "\n"
+        + _block(_invoke("get_weather", {"city": "Oslo"}))
+    )
+    parser = _tool_parser()
+    result = parser.extract_tool_calls(text)
+    assert [c["name"] for c in result.tool_calls] == ["get_weather"]
+    assert "rm_rf" in (result.content or "")
+
+
+@BOTH_MODES
+def test_reasoning_whitespace_parity(streaming):
+    # Codex r1 BLOCKING #3: non-stream used to strip() segment bodies
+    # while streaming preserved them — same input must give the same
+    # output in both modes, whitespace included.
+    text = " to=self<|message|>  padded thought \n<|eom|><|start|>assistant to=user<|message|> spaced answer <|eot|>"
+    reasoning, content = run_reasoning_extraction(
+        _reasoning_parser(), _chars(text), streaming=streaming
+    )
+    assert reasoning == "  padded thought \n"
+    assert content == " spaced answer "
+
+
 def test_truncated_block_keeps_bytes_as_content():
     # An opener with no parseable invoke must not vanish silently.
     parser = _tool_parser()

--- a/tests/test_muse_parsers.py
+++ b/tests/test_muse_parsers.py
@@ -335,6 +335,54 @@ def test_valid_call_then_literal_opener_released_at_flush():
     assert nonstream.content == "\nsee <atem:function_calls> docs"
 
 
+def test_literal_block_closer_inside_value_does_not_truncate_call():
+    # Codex r3 #1: a value containing the literal BLOCK closer leaves the
+    # invoke structure unbalanced at that point, so the block scan must
+    # extend to the next closer instead of truncating the real call.
+    parser = _tool_parser()
+    value = "docs mention </atem:function_calls> literally"
+    text = _block(_invoke("echo", {"text": value}))
+    result = parser.extract_tool_calls(
+        text, request=_request("echo", {"text": {"type": "string"}})
+    )
+    assert result.tools_called
+    assert json.loads(result.tool_calls[0]["arguments"]) == {"text": value}
+
+
+@BOTH_MODES
+def test_malformed_completed_block_bytes_survive(streaming):
+    # Codex r3 #2: a completed block with no parseable invoke is model
+    # output the client must see — in BOTH modes.
+    text = (
+        "Before <atem:function_calls>\ngarbage, no invoke\n"
+        "</atem:function_calls> after"
+    )
+    content, calls = run_tool_extraction(
+        _tool_parser(), _chars(text), streaming=streaming
+    )
+    assert calls == []
+    combined = content or ""
+    assert "garbage, no invoke" in combined
+    assert "Before " in combined and " after" in combined
+
+
+def test_nullable_list_type_schema_coerces():
+    # Codex r3 #3: {"type": ["integer", "null"]} must behave as integer.
+    parser = _tool_parser()
+    text = _block(_invoke("f", {"n": "5", "m": "null"}))
+    result = parser.extract_tool_calls(
+        text,
+        request=_request(
+            "f",
+            {
+                "n": {"type": ["integer", "null"]},
+                "m": {"anyOf": [{"type": "number"}, {"type": "null"}]},
+            },
+        ),
+    )
+    assert json.loads(result.tool_calls[0]["arguments"]) == {"n": 5, "m": None}
+
+
 def test_truncated_block_keeps_bytes_as_content():
     # An opener with no parseable invoke must not vanish silently.
     parser = _tool_parser()

--- a/tests/test_muse_parsers.py
+++ b/tests/test_muse_parsers.py
@@ -287,6 +287,54 @@ def test_reasoning_whitespace_parity(streaming):
     assert content == " spaced answer "
 
 
+def test_close_and_trailing_text_in_one_delta():
+    # Codex r2 #1: a single delta that completes the block AND carries
+    # trailing text must not lose that text — the tool_calls return wins
+    # the delta, and the cursor picks the text up on the next call.
+    parser = _tool_parser()
+    block = _block(_invoke("f", {"a": "1"}))
+    deltas = ["Hi ", block[:-5], block[-5:] + " tail", " end"]
+    contents: list[str] = []
+    calls = 0
+    prev = ""
+    for d in deltas:
+        curr = prev + d
+        out = parser.extract_tool_calls_streaming(prev, curr, d)
+        if out:
+            if out.get("content"):
+                contents.append(out["content"])
+            calls += len(out.get("tool_calls") or [])
+        prev = curr
+    contents.append(parser.flush_held_content(prev))
+    assert calls == 1
+    assert "".join(contents) == "Hi  tail end"
+
+
+def test_valid_call_then_literal_opener_released_at_flush():
+    # Codex r2 #3: after a real call, a trailing literal/truncated opener
+    # can never complete — its bytes are content and must be released at
+    # end of stream, matching the non-streaming path (#1766 principle).
+    parser = _tool_parser()
+    text = _block(_invoke("f", {"a": "1"})) + "\nsee <atem:function_calls> docs"
+    emitted: list[str] = []
+    calls = 0
+    prev = ""
+    for ch in text:
+        curr = prev + ch
+        out = parser.extract_tool_calls_streaming(prev, curr, ch)
+        if out:
+            if out.get("content"):
+                emitted.append(out["content"])
+            calls += len(out.get("tool_calls") or [])
+        prev = curr
+    emitted.append(parser.flush_held_content(prev))
+    assert calls == 1
+    assert "".join(emitted) == "\nsee <atem:function_calls> docs"
+    # And non-stream agrees byte-for-byte.
+    nonstream = _tool_parser().extract_tool_calls(text)
+    assert nonstream.content == "\nsee <atem:function_calls> docs"
+
+
 def test_truncated_block_keeps_bytes_as_content():
     # An opener with no parseable invoke must not vanish silently.
     parser = _tool_parser()

--- a/tests/test_muse_parsers.py
+++ b/tests/test_muse_parsers.py
@@ -421,6 +421,68 @@ def test_nullable_list_type_schema_coerces():
     assert json.loads(result.tool_calls[0]["arguments"]) == {"n": 5, "m": None}
 
 
+def test_unmatched_literal_invoke_opener_in_value_still_parses():
+    # Codex r5 #2: an UNMATCHED literal "<atem:invoke" inside a value
+    # must not stop the real block from completing — inside a value the
+    # scanner examines nothing until a boundary-valid closer.
+    parser = _tool_parser()
+    value = "the wire uses <atem:invoke tags for calls"
+    text = _block(_invoke("echo", {"text": value}))
+    result = parser.extract_tool_calls(
+        text, request=_request("echo", {"text": {"type": "string"}})
+    )
+    assert result.tools_called
+    assert json.loads(result.tool_calls[0]["arguments"]) == {"text": value}
+
+
+def test_unmatched_fake_param_opener_in_value_still_parses():
+    # Codex r5 #3: an unmatched fake parameter opener inside a value
+    # must not make a valid call read as malformed.
+    parser = _tool_parser()
+    value = 'see <atem:parameter name="x"> for details'
+    text = _block(_invoke("echo", {"text": value}))
+    result = parser.extract_tool_calls(
+        text, request=_request("echo", {"text": {"type": "string"}})
+    )
+    assert result.tools_called
+    assert json.loads(result.tool_calls[0]["arguments"]) == {"text": value}
+
+
+def test_param_without_closer_never_becomes_a_call():
+    # Codex r5 #1: a parameter that never closes must not execute with
+    # a truncated value — the whole structure is unparseable content.
+    parser = _tool_parser()
+    text = (
+        "<atem:function_calls>\n"
+        '<atem:invoke name="rm">\n'
+        '<atem:parameter name="path">/tmp/x\n'
+        "</atem:invoke>\n</atem:function_calls>"
+    )
+    result = parser.extract_tool_calls(text)
+    assert not result.tools_called
+    assert "/tmp/x" in (result.content or "")
+
+
+def test_non_finite_number_stays_raw():
+    # Codex r5 #4: NaN/Infinity/1e309 would make json.dumps emit tokens
+    # that are not valid JSON — keep the raw string for the validator.
+    parser = _tool_parser()
+    text = _block(_invoke("f", {"a": "NaN", "b": "1e309", "c": "2.5"}))
+    result = parser.extract_tool_calls(
+        text,
+        request=_request(
+            "f",
+            {
+                "a": {"type": "number"},
+                "b": {"type": "number"},
+                "c": {"type": "number"},
+            },
+        ),
+    )
+    args = json.loads(result.tool_calls[0]["arguments"])
+    assert args == {"a": "NaN", "b": "1e309", "c": 2.5}
+
+
 def test_truncated_block_keeps_bytes_as_content():
     # An opener with no parseable invoke must not vanish silently.
     parser = _tool_parser()

--- a/tests/test_muse_parsers.py
+++ b/tests/test_muse_parsers.py
@@ -1,0 +1,339 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Muse Glimmer ATEM tool parser + recipient-channel reasoning parser.
+
+Wire shapes are pinned against ``chat_template.jinja`` on
+``meta-models/Muse-Glimmer-30B`` (2026-08-10): tool calls are
+Anthropic-style ``<atem:...>`` XML blocks, reasoning rides a
+``to=self`` channel, and the template itself warns the output "is not
+expected to be valid XML and is parsed with regular expressions" — so
+the delimiter-ambiguity cases here (#1730's bug class) are not
+paranoia, they are the documented contract.
+
+Streaming cases run per-character where it matters: every sentinel in
+this format spans many deltas at char granularity, which is exactly
+where prefix-leak bugs (#444/#480) live.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from vllm_mlx.reasoning import get_parser
+from vllm_mlx.tool_parsers import ToolParserManager
+
+from .parsers.dispatch import run_reasoning_extraction, run_tool_extraction
+
+BOTH_MODES = pytest.mark.parametrize(
+    "streaming", [False, True], ids=["nonstream", "stream"]
+)
+
+
+def _tool_parser():
+    parser = ToolParserManager.get_tool_parser("muse")(None)
+    parser.reset()
+    return parser
+
+
+def _reasoning_parser():
+    return get_parser("muse")()
+
+
+def _chars(text: str) -> list[str]:
+    return list(text)
+
+
+def _block(*invokes: str) -> str:
+    return "<atem:function_calls>\n" + "\n".join(invokes) + "\n</atem:function_calls>"
+
+
+def _invoke(name: str, params: dict[str, str]) -> str:
+    lines = [f'<atem:invoke name="{name}">']
+    for k, v in params.items():
+        lines.append(f'<atem:parameter name="{k}">{v}</atem:parameter>')
+    lines.append("</atem:invoke>")
+    return "\n".join(lines)
+
+
+def _request(name: str, properties: dict) -> dict:
+    return {
+        "tools": [
+            {
+                "type": "function",
+                "function": {
+                    "name": name,
+                    "parameters": {"type": "object", "properties": properties},
+                },
+            }
+        ]
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tool parser — extraction
+# ---------------------------------------------------------------------------
+
+
+@BOTH_MODES
+def test_single_call_bare_string_value(streaming):
+    text = _block(_invoke("get_weather", {"city": "Paris"}))
+    content, calls = run_tool_extraction(
+        _tool_parser(), _chars(text), streaming=streaming
+    )
+    assert [(c.name, json.loads(c.arguments)) for c in calls] == [
+        ("get_weather", {"city": "Paris"})
+    ]
+    assert not (content or "").strip()
+
+
+@BOTH_MODES
+def test_multiple_invokes_in_one_block(streaming):
+    text = _block(
+        _invoke("read_file", {"path": "/a"}),
+        _invoke("read_file", {"path": "/b"}),
+    )
+    # Both calls close with the same ``</atem:function_calls>`` delta, so
+    # the stream finalizes them together — the documented parallel-tool
+    # finalization shape.
+    _, calls = run_tool_extraction(
+        _tool_parser(),
+        _chars(text),
+        streaming=streaming,
+        assert_one_tool_per_delta=False,
+    )
+    assert [json.loads(c.arguments)["path"] for c in calls] == ["/a", "/b"]
+
+
+@BOTH_MODES
+def test_content_before_block_survives(streaming):
+    text = "Let me check.\n" + _block(_invoke("get_weather", {"city": "Oslo"}))
+    content, calls = run_tool_extraction(
+        _tool_parser(), _chars(text), streaming=streaming
+    )
+    assert len(calls) == 1
+    assert (content or "").strip() == "Let me check."
+
+
+def test_string_whitespace_is_preserved():
+    # The template: "spaces for string values are not stripped."
+    parser = _tool_parser()
+    text = _block(_invoke("echo", {"text": "  padded  "}))
+    result = parser.extract_tool_calls(
+        text, request=_request("echo", {"text": {"type": "string"}})
+    )
+    assert json.loads(result.tool_calls[0]["arguments"]) == {"text": "  padded  "}
+
+
+def test_multiline_string_value_kept_verbatim():
+    value = 'line one\ncan span\n"multiple" lines\n'
+    parser = _tool_parser()
+    text = _block(_invoke("echo", {"text": value}))
+    result = parser.extract_tool_calls(
+        text, request=_request("echo", {"text": {"type": "string"}})
+    )
+    assert json.loads(result.tool_calls[0]["arguments"]) == {"text": value}
+
+
+def test_schema_typing_scalars_and_containers():
+    parser = _tool_parser()
+    props = {
+        "count": {"type": "integer"},
+        "ratio": {"type": "number"},
+        "flag": {"type": "boolean"},
+        "items": {"type": "array"},
+        "meta": {"type": "object"},
+        "note": {"type": "string"},
+    }
+    text = _block(
+        _invoke(
+            "configure",
+            {
+                "count": "5",
+                "ratio": "0.5",
+                "flag": "true",
+                "items": '["a", "b"]',
+                "meta": '{"k": 1}',
+                "note": "true",
+            },
+        )
+    )
+    result = parser.extract_tool_calls(text, request=_request("configure", props))
+    args = json.loads(result.tool_calls[0]["arguments"])
+    assert args == {
+        "count": 5,
+        "ratio": 0.5,
+        "flag": True,
+        "items": ["a", "b"],
+        "meta": {"k": 1},
+        # A declared string stays a string even when it spells a boolean.
+        "note": "true",
+    }
+
+
+def test_undeclared_param_stays_string_unless_container():
+    # No schema: bare scalars must stay strings ("5" could be a real
+    # string), containers self-identify as JSON per the template.
+    parser = _tool_parser()
+    text = _block(_invoke("f", {"a": "5", "b": '{"x": 1}'}))
+    result = parser.extract_tool_calls(text, request=None)
+    assert json.loads(result.tool_calls[0]["arguments"]) == {"a": "5", "b": {"x": 1}}
+
+
+def test_literal_closer_inside_string_value():
+    # #1730's bug class: a value containing a literal closer must not be
+    # truncated at the first one — the value runs to the LAST closer.
+    parser = _tool_parser()
+    value = "before </atem:parameter> after"
+    text = _block(_invoke("echo", {"text": value}))
+    result = parser.extract_tool_calls(
+        text, request=_request("echo", {"text": {"type": "string"}})
+    )
+    assert json.loads(result.tool_calls[0]["arguments"]) == {"text": value}
+
+
+def test_fake_opener_inside_value_filtered_by_schema():
+    # An opener whose name the schema does not declare is value text.
+    parser = _tool_parser()
+    value = 'x <atem:parameter name="fake">y</atem:parameter> z'
+    text = _block(_invoke("echo", {"text": value}))
+    result = parser.extract_tool_calls(
+        text, request=_request("echo", {"text": {"type": "string"}})
+    )
+    assert json.loads(result.tool_calls[0]["arguments"]) == {"text": value}
+
+
+def test_null_for_nullable_non_string():
+    parser = _tool_parser()
+    text = _block(_invoke("f", {"limit": "null"}))
+    result = parser.extract_tool_calls(
+        text, request=_request("f", {"limit": {"type": "integer"}})
+    )
+    assert json.loads(result.tool_calls[0]["arguments"]) == {"limit": None}
+
+
+@BOTH_MODES
+def test_no_tools_plain_text_passthrough(streaming):
+    content, calls = run_tool_extraction(
+        _tool_parser(), _chars("Just an answer."), streaming=streaming
+    )
+    assert calls == []
+    assert content == "Just an answer."
+
+
+@BOTH_MODES
+def test_channel_wrapped_call_extracts_and_strips_plumbing(streaming):
+    # Standalone use (no reasoning parser): raw channel output.
+    text = (
+        " to=self<|message|>Consider the request.<|eom|>"
+        "<|start|>assistant to=get_weather<|message|>"
+        + _block(_invoke("get_weather", {"city": "Lima"}))
+        + "<|eot|>"
+    )
+    content, calls = run_tool_extraction(
+        _tool_parser(), _chars(text), streaming=streaming
+    )
+    assert [(c.name,) for c in calls] == [("get_weather",)]
+    # Neither plumbing nor the to=self reasoning may leak into content —
+    # exact comparison, because a substring check let a 2-byte " to"
+    # header fragment through during development.
+    assert not (content or "").strip()
+
+
+def test_truncated_block_keeps_bytes_as_content():
+    # An opener with no parseable invoke must not vanish silently.
+    parser = _tool_parser()
+    text = '<atem:function_calls>\n<atem:invoke name="get_w'
+    result = parser.extract_tool_calls(text)
+    assert not result.tools_called
+    assert "atem:invoke" in (result.content or "")
+
+
+def test_streaming_emits_no_partial_sentinel_bytes():
+    parser = _tool_parser()
+    text = "Hello " + _block(_invoke("f", {"a": "1"}))
+    emitted: list[str] = []
+    prev = ""
+    for ch in text:
+        curr = prev + ch
+        delta = parser.extract_tool_calls_streaming(prev, curr, ch)
+        if delta and delta.get("content"):
+            emitted.append(delta["content"])
+        prev = curr
+    assert "".join(emitted) == "Hello "
+
+
+# ---------------------------------------------------------------------------
+# Reasoning parser
+# ---------------------------------------------------------------------------
+
+
+@BOTH_MODES
+def test_reasoning_then_answer(streaming):
+    text = (
+        " to=self<|message|>Two plus two is four.<|eom|>"
+        "<|start|>assistant to=user<|message|>4<|eot|>"
+    )
+    reasoning, content = run_reasoning_extraction(
+        _reasoning_parser(), _chars(text), streaming=streaming
+    )
+    assert reasoning == "Two plus two is four."
+    assert content == "4"
+
+
+@BOTH_MODES
+def test_bare_message_header_is_user_content(streaming):
+    text = "<|message|>Plain answer.<|eot|>"
+    reasoning, content = run_reasoning_extraction(
+        _reasoning_parser(), _chars(text), streaming=streaming
+    )
+    assert reasoning is None
+    assert content == "Plain answer."
+
+
+@BOTH_MODES
+def test_no_channel_markers_degrades_to_content(streaming):
+    reasoning, content = run_reasoning_extraction(
+        _reasoning_parser(), _chars("No plumbing at all."), streaming=streaming
+    )
+    assert reasoning is None
+    assert content == "No plumbing at all."
+
+
+@BOTH_MODES
+def test_tool_segment_passes_through_as_content(streaming):
+    # The ATEM block must SURVIVE the reasoning split — the tool parser
+    # downstream consumes it from the content channel (harmony division).
+    block = _block(_invoke("get_weather", {"city": "Rome"}))
+    text = (
+        " to=self<|message|>Need the weather.<|eom|>"
+        "<|start|>assistant to=get_weather<|message|>" + block + "<|eot|>"
+    )
+    reasoning, content = run_reasoning_extraction(
+        _reasoning_parser(), _chars(text), streaming=streaming
+    )
+    assert reasoning == "Need the weather."
+    assert content is not None and block in content
+
+
+def test_streaming_never_leaks_header_or_terminator_bytes():
+    text = (
+        " to=self<|message|>thinking<|eom|>"
+        "<|start|>assistant to=user<|message|>answer<|eot|>"
+    )
+    parser = _reasoning_parser()
+    parser.reset_state()
+    reasoning_parts: list[str] = []
+    content_parts: list[str] = []
+    prev = ""
+    for ch in text:
+        curr = prev + ch
+        msg = parser.extract_reasoning_streaming(prev, curr, ch)
+        if msg is not None:
+            if msg.reasoning:
+                reasoning_parts.append(msg.reasoning)
+            if msg.content:
+                content_parts.append(msg.content)
+        prev = curr
+    assert "".join(reasoning_parts) == "thinking"
+    assert "".join(content_parts) == "answer"

--- a/tests/test_tool_call_streaming_parity.py
+++ b/tests/test_tool_call_streaming_parity.py
@@ -153,6 +153,19 @@ PARITY_FIXTURES: list = [
         '<function name="read_file"><param name="path">/etc/hostname</param></function>',
         [("read_file", {"path": "/etc/hostname"})],
     ),
+    # Muse Glimmer — ATEM function-calls block (Anthropic-style XML on
+    # recipient-routed channels). Value is a bare string per the chat
+    # template ("String and scalar parameters should be specified as is").
+    (
+        "muse",
+        "muse_atem",
+        (
+            '<atem:function_calls>\n<atem:invoke name="read_file">\n'
+            '<atem:parameter name="path">/etc/hostname</atem:parameter>\n'
+            "</atem:invoke>\n</atem:function_calls>"
+        ),
+        [("read_file", {"path": "/etc/hostname"})],
+    ),
     # hermes — JSON body inside <tool_call>...</tool_call>
     (
         "hermes",

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -1833,22 +1833,6 @@
     "is_hybrid": false,
     "supports_spec_decode": false
   },
-  "muse-glimmer-30b-4bit": {
-    "hf_path": "mlx-community/Muse-Glimmer-30B-4bit",
-    "tool_call_parser": "muse",
-    "reasoning_parser": "muse",
-    "is_hybrid": false,
-    "is_moe": false,
-    "supports_spec_decode": false
-  },
-  "muse-glimmer-30b-8bit": {
-    "hf_path": "mlx-community/Muse-Glimmer-30B-8bit",
-    "tool_call_parser": "muse",
-    "reasoning_parser": "muse",
-    "is_hybrid": false,
-    "is_moe": false,
-    "supports_spec_decode": false
-  },
   "minicpm5-1b-4bit": {
     "hf_path": "openbmb/MiniCPM5-1B-MLX",
     "tool_call_parser": "minicpm",

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -1833,6 +1833,22 @@
     "is_hybrid": false,
     "supports_spec_decode": false
   },
+  "muse-glimmer-30b-4bit": {
+    "hf_path": "mlx-community/Muse-Glimmer-30B-4bit",
+    "tool_call_parser": "muse",
+    "reasoning_parser": "muse",
+    "is_hybrid": false,
+    "is_moe": false,
+    "supports_spec_decode": false
+  },
+  "muse-glimmer-30b-8bit": {
+    "hf_path": "mlx-community/Muse-Glimmer-30B-8bit",
+    "tool_call_parser": "muse",
+    "reasoning_parser": "muse",
+    "is_hybrid": false,
+    "is_moe": false,
+    "supports_spec_decode": false
+  },
   "minicpm5-1b-4bit": {
     "hf_path": "openbmb/MiniCPM5-1B-MLX",
     "tool_call_parser": "minicpm",

--- a/vllm_mlx/model_auto_config.py
+++ b/vllm_mlx/model_auto_config.py
@@ -396,6 +396,15 @@ _MODEL_PATTERNS: list[tuple[re.Pattern, ModelConfig]] = [
         re.compile(r"ministral|mistral|devstral|magistral", re.IGNORECASE),
         _MISTRAL_FAMILY_SENTINEL,
     ),
+    # Meta Muse Glimmer — ATEM function-calls blocks on recipient-routed
+    # channels; reasoning on the ``to=self`` channel.
+    (
+        re.compile(r"muse[-_]?glimmer", re.IGNORECASE),
+        ModelConfig(
+            tool_call_parser="muse",
+            reasoning_parser="muse",
+        ),
+    ),
     # Gemma 4 (native tool format)
     (
         re.compile(r"gemma[-_]?4", re.IGNORECASE),

--- a/vllm_mlx/reasoning/__init__.py
+++ b/vllm_mlx/reasoning/__init__.py
@@ -92,6 +92,7 @@ def _register_builtin_parsers():
     from .harmony_parser import HarmonyReasoningParser
     from .hy3_parser import Hy3ReasoningParser
     from .minimax_parser import MiniMaxReasoningParser
+    from .muse_parser import MuseReasoningParser
     from .qwen3_parser import Qwen3ReasoningParser
     from .ui_tars_parser import UiTarsReasoningParser
 
@@ -113,6 +114,9 @@ def _register_builtin_parsers():
     register_parser("gpt_oss", GptOssReasoningParser)
     register_parser("harmony", HarmonyReasoningParser)
     register_parser("minimax", MiniMaxReasoningParser)
+    # ``muse`` — Meta Muse Glimmer recipient-routed channels
+    # (``to=self`` -> reasoning). Pairs with the ``muse`` tool parser.
+    register_parser("muse", MuseReasoningParser)
     # ``ui_tars`` — UI-TARS Thought:/Reflection: preamble splitter (no
     # ``<think>`` tags; labels are literal). Auto-wired by the ``ui-tars*``
     # regex in ``model_auto_config`` and by the alias entries in

--- a/vllm_mlx/reasoning/muse_parser.py
+++ b/vllm_mlx/reasoning/muse_parser.py
@@ -92,14 +92,18 @@ class MuseReasoningParser(ReasoningParser):
         content_parts: list[str] = []
         for recipient, body in _segments(model_output):
             if recipient == "self":
-                reasoning_parts.append(body.strip())
+                reasoning_parts.append(body)
             else:
                 # Tool-addressed segments pass through as content so the
                 # tool parser can extract the ATEM block.
-                content_parts.append(body.strip())
+                content_parts.append(body)
 
-        reasoning = "\n\n".join(p for p in reasoning_parts if p) or None
-        content = "\n\n".join(p for p in content_parts if p) or None
+        # Plain concatenation, no per-segment strip — the streaming path
+        # emits body bytes verbatim, and the two modes must produce the
+        # same API output (codex r1 BLOCKING #3). Only protocol tokens
+        # are removed; the model's own whitespace is content.
+        reasoning = "".join(reasoning_parts) or None
+        content = "".join(content_parts) or None
         return reasoning, content
 
     # ------------------------------------------------------------------

--- a/vllm_mlx/reasoning/muse_parser.py
+++ b/vllm_mlx/reasoning/muse_parser.py
@@ -34,7 +34,6 @@ _HEADER_RE = re.compile(r"<\|start\|>assistant(?:\s+to=(?P<to>\S+?))?\s*<\|messa
 # Implicit first-segment header (prompt ends with ``<|start|>assistant``).
 _IMPLICIT_RE = re.compile(r"^\s?(?:to=(?P<to>\S+?))?\s*<\|message\|>")
 _TERMINATORS = ("<|eot|>", "<|eom|>")
-_CONTROL_TOKENS = ("<|start|>", "<|message|>", "<|eot|>", "<|eom|>")
 
 # Partial-prefix hold set for streaming (bug class #444/#480: per-char
 # streaming must not leak ``<``, ``<|``, ``<|eo``… as visible content).
@@ -72,8 +71,16 @@ def _segments(text: str) -> list[tuple[str, str]]:
 
     cleaned: list[tuple[str, str]] = []
     for recipient, body in segs:
-        for term in _TERMINATORS:
-            body = body.replace(term, "")
+        # Trim terminators only at the segment BOUNDARY (the body end) —
+        # a literal ``<|eot|>`` mid-prose is model output and survives,
+        # per the #1766/#1779 literal-markup principle (codex r7 #3).
+        trimmed = True
+        while trimmed:
+            trimmed = False
+            for term in _TERMINATORS:
+                if body.endswith(term):
+                    body = body[: -len(term)]
+                    trimmed = True
         cleaned.append((recipient, body))
     return cleaned
 
@@ -198,8 +205,19 @@ class MuseReasoningParser(ReasoningParser):
         for i, (recipient, body) in enumerate(segs):
             if hold and i == len(segs) - 1:
                 body = cls._hold_partial_sentinel(body)
-            for token in _CONTROL_TOKENS:
-                body = body.replace(token, "")
+                # A COMPLETE trailing terminator is undecidable while
+                # the stream runs: followed by a header (or stream end)
+                # it is structural and ``_segments`` trims it; followed
+                # by prose it is literal output. Hold until decided —
+                # ``_hold_partial_sentinel`` can re-expose one by
+                # trimming a partial ``<`` that arrived after it.
+                trailing = re.search(r"(?:<\|eot\|>|<\|eom\|>)+$", body)
+                if trailing:
+                    body = body[: trailing.start()]
+            # No blanket control-token deletion here: ``_segments``
+            # already trims boundary terminators, headers never reach a
+            # body, and a literal token mid-prose must survive exactly
+            # as it does on the non-streaming path (codex r7 #3).
             if recipient == "self":
                 reasoning.append(body)
             else:

--- a/vllm_mlx/reasoning/muse_parser.py
+++ b/vllm_mlx/reasoning/muse_parser.py
@@ -133,8 +133,34 @@ class MuseReasoningParser(ReasoningParser):
             content=new_content or None,
         )
 
+    def finalize_streaming(
+        self,
+        accumulated_text: str,
+        *,
+        matched_stop: str | None = None,
+        prompt_thinking_active: bool = False,
+        finish_reason: str | None = None,
+    ) -> DeltaMessage | None:
+        """Release bytes the in-flight holds withheld (codex r6 #3).
+
+        At end of stream a partial sentinel (``<``, ``<|eo``…) or a
+        never-completed header can no longer grow into plumbing — the
+        non-streaming path keeps those bytes, so the stream must too.
+        The parser is stateless, so what was emitted is exactly the
+        held view of the accumulated text; the correction is the
+        unheld view's suffix beyond it.
+        """
+        del matched_stop, prompt_thinking_active, finish_reason
+        emitted_r, emitted_c = self._visible(accumulated_text)
+        final_r, final_c = self._visible(accumulated_text, hold=False)
+        extra_r = final_r[len(emitted_r) :]
+        extra_c = final_c[len(emitted_c) :]
+        if not extra_r and not extra_c:
+            return None
+        return DeltaMessage(reasoning=extra_r or None, content=extra_c or None)
+
     @classmethod
-    def _visible(cls, text: str) -> tuple[str, str]:
+    def _visible(cls, text: str, *, hold: bool = True) -> tuple[str, str]:
         """(reasoning_bytes, content_bytes) safely emittable for ``text``.
 
         Recomputed per delta from the full accumulated text — O(n) per
@@ -149,9 +175,13 @@ class MuseReasoningParser(ReasoningParser):
         # recipient decides reasoning vs content), so hold it. Without
         # this, the tail of ``…<|eom|><|start|>assistant to=u`` would
         # survive token-stripping as literal "assistant to=u" bytes.
-        pending = text.rfind("<|start|>")
-        if pending >= 0 and "<|message|>" not in text[pending:]:
-            text = text[:pending]
+        # ``hold=False`` (finalize): the stream is over, a header that
+        # never completed is model bytes — keep them, matching the
+        # non-streaming path.
+        if hold:
+            pending = text.rfind("<|start|>")
+            if pending >= 0 and "<|message|>" not in text[pending:]:
+                text = text[:pending]
         segs = _segments(text)
         # Header-in-progress: the tail may be a partial header for a
         # segment we cannot classify yet. ``_segments`` only recognises
@@ -163,10 +193,10 @@ class MuseReasoningParser(ReasoningParser):
         # AFTER the region ``_segments`` assigned, and since each
         # segment runs to the next header (or end), only the no-marker
         # fallback can misfire; guard it separately.
-        if segs and segs == [("user", text)] and cls._could_be_header(text):
+        if hold and segs == [("user", text)] and cls._could_be_header(text):
             return "", ""
         for i, (recipient, body) in enumerate(segs):
-            if i == len(segs) - 1:
+            if hold and i == len(segs) - 1:
                 body = cls._hold_partial_sentinel(body)
             for token in _CONTROL_TOKENS:
                 body = body.replace(token, "")

--- a/vllm_mlx/reasoning/muse_parser.py
+++ b/vllm_mlx/reasoning/muse_parser.py
@@ -1,0 +1,198 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Reasoning parser for Meta Muse Glimmer's recipient-routed channels.
+
+Muse Glimmer thinks on a ``to=self`` channel instead of ``<think>`` tags::
+
+    <|start|>assistant to=self<|message|>[reasoning]<|eom|>
+    <|start|>assistant to=user<|message|>[answer]<|eot|>
+
+The generation prompt ends with ``<|start|>assistant``, so the FIRST
+segment of model output has an implicit header — it begins directly
+with `` to=self<|message|>`` / `` to=user<|message|>`` (or a bare
+``<|message|>``, which the template's ``or 'user'`` default makes
+equivalent to ``to=user``).
+
+Segments addressed to a tool (``to=<tool_name>``) carry the ATEM
+function-calls block. Those are CONTENT here, not reasoning — they pass
+through so the downstream ``MuseToolParser`` (which the postprocessor
+feeds with this parser's content channel) can extract the calls; its
+prefix-hold machinery keeps the markup off the wire. Mirrors the
+harmony split, where the reasoning parser owns analysis/final and the
+tool parser owns commentary.
+"""
+
+from __future__ import annotations
+
+import re
+
+from .base import DeltaMessage, ReasoningParser
+
+# Explicit segment header. The recipient is optional (history renders
+# ``to=user`` explicitly, but a bare ``<|start|>assistant<|message|>``
+# is representable and means user).
+_HEADER_RE = re.compile(r"<\|start\|>assistant(?:\s+to=(?P<to>\S+?))?\s*<\|message\|>")
+# Implicit first-segment header (prompt ends with ``<|start|>assistant``).
+_IMPLICIT_RE = re.compile(r"^\s?(?:to=(?P<to>\S+?))?\s*<\|message\|>")
+_TERMINATORS = ("<|eot|>", "<|eom|>")
+_CONTROL_TOKENS = ("<|start|>", "<|message|>", "<|eot|>", "<|eom|>")
+
+# Partial-prefix hold set for streaming (bug class #444/#480: per-char
+# streaming must not leak ``<``, ``<|``, ``<|eo``… as visible content).
+_SENTINELS: tuple[str, ...] = ("<|start|>", "<|message|>", "<|eot|>", "<|eom|>")
+
+
+def _segments(text: str) -> list[tuple[str, str]]:
+    """Split model output into ``(recipient, body)`` segments.
+
+    The first segment may use the implicit header; later segments use
+    the explicit ``<|start|>assistant`` form. Text with no channel
+    markers at all yields a single ``("user", text)`` segment so a
+    model that skips the plumbing degrades to plain content.
+    """
+    segs: list[tuple[str, str]] = []
+    first = _IMPLICIT_RE.match(text)
+    matches = list(_HEADER_RE.finditer(text))
+    if first is None and not matches:
+        return [("user", text)] if text else []
+
+    # Region before the first explicit header belongs to the implicit
+    # segment (when present).
+    if first is not None:
+        start = first.end()
+        end = matches[0].start() if matches else len(text)
+        segs.append((first.group("to") or "user", text[start:end]))
+    for i, m in enumerate(matches):
+        start = m.end()
+        end = matches[i + 1].start() if i + 1 < len(matches) else len(text)
+        segs.append((m.group("to") or "user", text[start:end]))
+
+    cleaned: list[tuple[str, str]] = []
+    for recipient, body in segs:
+        for term in _TERMINATORS:
+            body = body.replace(term, "")
+        cleaned.append((recipient, body))
+    return cleaned
+
+
+class MuseReasoningParser(ReasoningParser):
+    """Routes ``to=self`` segments to reasoning, the rest to content."""
+
+    def extract_reasoning(
+        self,
+        model_output: str,
+        enable_thinking: bool | None = None,
+    ) -> tuple[str | None, str | None]:
+        # Channel routing is unambiguous — the flag is informational
+        # (same signature-parity rationale as GptOssReasoningParser).
+        del enable_thinking
+        if not model_output:
+            return None, None
+
+        reasoning_parts: list[str] = []
+        content_parts: list[str] = []
+        for recipient, body in _segments(model_output):
+            if recipient == "self":
+                reasoning_parts.append(body.strip())
+            else:
+                # Tool-addressed segments pass through as content so the
+                # tool parser can extract the ATEM block.
+                content_parts.append(body.strip())
+
+        reasoning = "\n\n".join(p for p in reasoning_parts if p) or None
+        content = "\n\n".join(p for p in content_parts if p) or None
+        return reasoning, content
+
+    # ------------------------------------------------------------------
+    # Streaming — stateless phase detection from accumulated text, the
+    # GptOssReasoningParser pattern.
+    # ------------------------------------------------------------------
+
+    def extract_reasoning_streaming(
+        self,
+        previous_text: str,
+        current_text: str,
+        delta_text: str,
+    ) -> DeltaMessage | None:
+        prev_reasoning, prev_content = self._visible(previous_text)
+        curr_reasoning, curr_content = self._visible(current_text)
+
+        new_reasoning = curr_reasoning[len(prev_reasoning) :]
+        new_content = curr_content[len(prev_content) :]
+        if not new_reasoning and not new_content:
+            return None
+        return DeltaMessage(
+            reasoning=new_reasoning or None,
+            content=new_content or None,
+        )
+
+    @classmethod
+    def _visible(cls, text: str) -> tuple[str, str]:
+        """(reasoning_bytes, content_bytes) safely emittable for ``text``.
+
+        Recomputed per delta from the full accumulated text — O(n) per
+        chunk, same order as the other stateless streaming parsers here.
+        The last segment's tail is truncated by the longest partial
+        sentinel so a half-arrived ``<|eom|>`` never leaks (#444/#480).
+        """
+        reasoning: list[str] = []
+        content: list[str] = []
+        # A ``<|start|>`` not yet followed by ``<|message|>`` is a header
+        # still arriving — everything from it on is unclassifiable (the
+        # recipient decides reasoning vs content), so hold it. Without
+        # this, the tail of ``…<|eom|><|start|>assistant to=u`` would
+        # survive token-stripping as literal "assistant to=u" bytes.
+        pending = text.rfind("<|start|>")
+        if pending >= 0 and "<|message|>" not in text[pending:]:
+            text = text[:pending]
+        segs = _segments(text)
+        # Header-in-progress: the tail may be a partial header for a
+        # segment we cannot classify yet. ``_segments`` only recognises
+        # COMPLETE headers (through ``<|message|>``), so bytes belonging
+        # to a partial header at the tail must not be emitted. Detect:
+        # anything after the last complete segment's start that has not
+        # passed ``<|message|>`` yet is either terminator plumbing or a
+        # growing header — both unemittable. That is exactly the text
+        # AFTER the region ``_segments`` assigned, and since each
+        # segment runs to the next header (or end), only the no-marker
+        # fallback can misfire; guard it separately.
+        if segs and segs == [("user", text)] and cls._could_be_header(text):
+            return "", ""
+        for i, (recipient, body) in enumerate(segs):
+            if i == len(segs) - 1:
+                body = cls._hold_partial_sentinel(body)
+            for token in _CONTROL_TOKENS:
+                body = body.replace(token, "")
+            if recipient == "self":
+                reasoning.append(body)
+            else:
+                content.append(body)
+        return "".join(reasoning), "".join(content)
+
+    @staticmethod
+    def _could_be_header(text: str) -> bool:
+        """True while ``text`` could still grow into an implicit header.
+
+        The implicit header is `` to=recipient<|message|>``. Until a
+        ``<|message|>`` arrives, output like `` to=se`` is unclassifiable;
+        emitting it as content would leak plumbing bytes that belong to
+        the header. Bounded: headers are short, so only inspect a text
+        that is still plausibly all-header (no whitespace beyond the
+        leading one, or an incomplete ``<|message|>`` tail).
+        """
+        candidate = text[1:] if text.startswith(" ") else text
+        if "<|message|>" in candidate:
+            return False
+        # Includes the prefixes of ``to=`` itself — at char granularity
+        # the very first deltas are `` t``, `` to`` and are just as
+        # unclassifiable as `` to=se``.
+        return bool(re.fullmatch(r"|t|to|to=\S*", candidate))
+
+    @staticmethod
+    def _hold_partial_sentinel(body: str) -> str:
+        max_hold = 0
+        for sentinel in _SENTINELS:
+            for length in range(min(len(body), len(sentinel) - 1), 0, -1):
+                if body.endswith(sentinel[:length]):
+                    max_hold = max(max_hold, length)
+                    break
+        return body if max_hold == 0 else body[: len(body) - max_hold]

--- a/vllm_mlx/reasoning/muse_parser.py
+++ b/vllm_mlx/reasoning/muse_parser.py
@@ -56,11 +56,15 @@ def _segments(text: str) -> list[tuple[str, str]]:
         return [("user", text)] if text else []
 
     # Region before the first explicit header belongs to the implicit
-    # segment (when present).
+    # segment (when present). Without an implicit header, plain text
+    # before the first explicit header is still model output — it is
+    # user-facing content, not discardable plumbing (codex r4 #4).
     if first is not None:
         start = first.end()
         end = matches[0].start() if matches else len(text)
         segs.append((first.group("to") or "user", text[start:end]))
+    elif matches and matches[0].start() > 0:
+        segs.append(("user", text[: matches[0].start()]))
     for i, m in enumerate(matches):
         start = m.end()
         end = matches[i + 1].start() if i + 1 < len(matches) else len(text)

--- a/vllm_mlx/tool_parsers/__init__.py
+++ b/vllm_mlx/tool_parsers/__init__.py
@@ -22,6 +22,8 @@ Available parsers:
 - functionary/meetkai: MeetKai Functionary models
 - glm47/glm4: GLM-4.7 and GLM-4.7-Flash models
 - harmony/gpt-oss: GPT-OSS models (Harmony format with channels)
+- muse: Meta Muse Glimmer (ATEM function-calls blocks on
+  recipient-routed channels)
 - seed_oss/seed/gpt_oss: Seed-OSS / GPT-OSS models (XML format)
 - deepseek_v31: DeepSeek V3.1 thinking-channel wire shape only
 - qwen/qwen3/qwen3_xml: Qwen models (<tool_call>JSON</tool_call> and [Calling tool:] formats)
@@ -69,6 +71,7 @@ from .llama_tool_parser import LlamaToolParser
 from .minicpm_tool_parser import MiniCPMToolParser
 from .minimax_tool_parser import MiniMaxToolParser
 from .mistral_tool_parser import MistralToolParser
+from .muse_tool_parser import MuseToolParser
 from .nemotron_tool_parser import NemotronToolParser
 from .qwen3coder_tool_parser import Qwen3CoderToolParser
 from .qwen_tool_parser import QwenToolParser
@@ -100,6 +103,7 @@ __all__ = [
     "HyV3ToolParser",
     "MiniCPMToolParser",
     "MiniMaxToolParser",
+    "MuseToolParser",
     "SeedOssToolParser",
     "DeepSeekV3ToolParser",
     "DeepSeekV40731ToolParser",

--- a/vllm_mlx/tool_parsers/abstract_tool_parser.py
+++ b/vllm_mlx/tool_parsers/abstract_tool_parser.py
@@ -126,6 +126,10 @@ class ExtractedToolCallInformation:
 #                           preview checkpoint.
 #   minicpm_native        — <function name="NAME"><param name="KEY">VALUE
 #                           </param></function>  (MiniCPM5 XML tool contract)
+#   muse_atem             — <atem:function_calls><atem:invoke name="NAME">
+#                           <atem:parameter name="K">V</atem:parameter>
+#                           </atem:invoke></atem:function_calls> on
+#                           recipient-routed channels (Meta Muse Glimmer)
 WIRE_FORMAT_LABELS: frozenset[str] = frozenset(
     {
         "tool_call_json",
@@ -152,6 +156,7 @@ WIRE_FORMAT_LABELS: frozenset[str] = frozenset(
         "ui_tars_action",
         "hy3_native",
         "minicpm_native",
+        "muse_atem",
     }
 )
 

--- a/vllm_mlx/tool_parsers/muse_tool_parser.py
+++ b/vllm_mlx/tool_parsers/muse_tool_parser.py
@@ -57,10 +57,6 @@ _BLOCK_OPEN = "<atem:function_calls>"
 _BLOCK_CLOSE = "</atem:function_calls>"
 _PARAM_CLOSE = "</atem:parameter>"
 
-_BLOCK_RE = re.compile(
-    re.escape(_BLOCK_OPEN) + r"(?P<body>.*?)" + re.escape(_BLOCK_CLOSE),
-    re.DOTALL,
-)
 _INVOKE_RE = re.compile(
     r'<atem:invoke\s+name="(?P<name>[^"]+)">(?P<body>.*?)</atem:invoke>',
     re.DOTALL,
@@ -97,6 +93,77 @@ def _generate_tool_id() -> str:
     return f"call_{uuid.uuid4().hex[:8]}"
 
 
+def _completed_blocks(text: str) -> list[tuple[int, int, str]]:
+    """``(start, end, body)`` for each completed ATEM block, in order.
+
+    A block's close is the first ``</atem:function_calls>`` at which the
+    body's invoke structure is BALANCED (opens <= closes). A literal
+    block closer inside a parameter value sits between an
+    ``<atem:invoke`` and its ``</atem:invoke>``, leaves the count
+    unbalanced, and is skipped over instead of truncating the real call
+    (codex r3 #1 — the block-level twin of the parameter scan's
+    last-closer rule).
+
+    Prefix-stable: whether a block is complete, and where it closes,
+    depends only on text up to that close — so as a stream grows,
+    already-completed blocks never change. The streaming path's
+    ``_stream_blocks_emitted`` cursor relies on this.
+    """
+    blocks: list[tuple[int, int, str]] = []
+    pos = 0
+    while True:
+        open_idx = text.find(_BLOCK_OPEN, pos)
+        if open_idx < 0:
+            break
+        body_start = open_idx + len(_BLOCK_OPEN)
+        search = body_start
+        close_idx = -1
+        while True:
+            candidate = text.find(_BLOCK_CLOSE, search)
+            if candidate < 0:
+                break
+            body = text[body_start:candidate]
+            if body.count("<atem:invoke") <= body.count("</atem:invoke>"):
+                close_idx = candidate
+                break
+            search = candidate + len(_BLOCK_CLOSE)
+        if close_idx < 0:
+            break
+        end = close_idx + len(_BLOCK_CLOSE)
+        blocks.append((open_idx, end, text[body_start:close_idx]))
+        pos = end
+    return blocks
+
+
+def _declared_type(cfg: Any) -> str | None:
+    """Normalize a property schema to one simple type name, or None.
+
+    Handles the shapes real tool schemas use for nullability (codex r3
+    #3): ``{"type": ["integer", "null"]}`` and single-non-null
+    ``anyOf``/``oneOf`` unions both normalize to the non-null type.
+    Ambiguous unions return None (value falls to the as-is rules).
+    """
+    if not isinstance(cfg, dict):
+        return None
+    declared = cfg.get("type")
+    if isinstance(declared, str):
+        return declared
+    if isinstance(declared, list):
+        non_null = [t for t in declared if t != "null"]
+        if len(non_null) == 1 and isinstance(non_null[0], str):
+            return non_null[0]
+        return None
+    for key in ("anyOf", "oneOf"):
+        subs = cfg.get(key)
+        if isinstance(subs, list):
+            types = {_declared_type(sub) for sub in subs}
+            types.discard(None)
+            types.discard("null")
+            if len(types) == 1:
+                return next(iter(types))
+    return None
+
+
 def _schema_properties(tool_name: str, request: dict[str, Any] | None) -> dict:
     """The declared JSON-schema ``properties`` for ``tool_name``, or {}."""
     if not isinstance(request, dict):
@@ -128,9 +195,7 @@ def _convert_param_value(raw: str, param_name: str, props: dict) -> Any:
       stays a string — guessing would corrupt legitimate string values.
     """
     cfg = props.get(param_name)
-    declared = None
-    if isinstance(cfg, dict):
-        declared = cfg.get("type")
+    declared = _declared_type(cfg)
     if declared == "string":
         return raw
     if raw == "null" and declared is not None:
@@ -258,33 +323,17 @@ class MuseToolParser(ToolParser):
     def extract_tool_calls(
         self, model_output: str, request: dict[str, Any] | None = None
     ) -> ExtractedToolCallInformation:
-        blocks = list(_BLOCK_RE.finditer(model_output))
-        if not blocks:
-            # No COMPLETED block. A truncated opener stays visible as
-            # content rather than silently dropping bytes.
-            return ExtractedToolCallInformation(
-                False, [], _strip_channel_plumbing(model_output) or None
-            )
-
         calls = [
             call
-            for block in blocks
-            for call in self._parse_block(block.group("body"), request)
+            for _, _, body in _completed_blocks(model_output)
+            for call in self._parse_block(body, request)
         ]
-
-        # Content = whatever sits outside the completed ATEM blocks,
-        # channel-clean. No ``.strip()`` — the streaming path emits these
-        # bytes verbatim and the two modes must agree (codex r2 #2).
-        outside = _BLOCK_RE.sub("", model_output)
-        content = _strip_channel_plumbing(outside) or None
-
-        if not calls:
-            # Completed block(s) with no parseable invoke (malformed):
-            # keep the raw text as content rather than dropping bytes.
-            return ExtractedToolCallInformation(
-                False, [], _strip_channel_plumbing(model_output) or None
-            )
-        return ExtractedToolCallInformation(True, calls, content)
+        # One content rule for BOTH modes (codex r2 #2, r3 #2): the
+        # ``hold_tail=False`` visible view — parseable blocks removed,
+        # malformed blocks and truncated openers kept as literal bytes,
+        # channel plumbing stripped, no ``.strip()``.
+        content = self._visible_content(model_output, hold_tail=False) or None
+        return ExtractedToolCallInformation(bool(calls), calls, content)
 
     # ------------------------------------------------------------------
     # Streaming
@@ -301,38 +350,57 @@ class MuseToolParser(ToolParser):
         and after blocks therefore streams normally instead of being
         swallowed once the first opener appears (codex r1 BLOCKING #1).
 
-        Monotonic in ``text`` by construction (each transform only
-        appends to or truncates the tail), which is what lets callers
-        emit ``curr[len(prev):]`` diffs.
+        Monotonic in ``text`` by construction: completed blocks are
+        prefix-stable (see ``_completed_blocks``), a parseable block's
+        removal never exposes earlier bytes, and a malformed block's
+        bytes appear in one piece at its close. That is what lets
+        callers emit from an absolute cursor.
         """
-        work = _BLOCK_RE.sub("", text)
-        first_open = work.find(_BLOCK_OPEN)
+        blocks = _completed_blocks(text)
+        pieces: list[str] = []
+        pos = 0
+        for start, end, body in blocks:
+            pieces.append(text[pos:start])
+            if _INVOKE_RE.search(body) is None:
+                # Completed but malformed — no parseable invoke, so the
+                # bytes are model output the client must see (codex r3
+                # #2; non-stream applies the identical rule above).
+                pieces.append(text[start:end])
+            pos = end
+        tail = text[pos:]
+        first_open = tail.find(_BLOCK_OPEN)
         if first_open >= 0:
             if hold_tail:
-                work = work[:first_open]
+                tail = tail[:first_open]
             # hold_tail=False (end of stream): the opener can no longer
             # complete, so its literal bytes are content — matching the
-            # non-streaming path, which keeps unmatched-opener text
-            # (codex r2 #3; the #1766 literal-markup-survives principle).
+            # non-streaming path (codex r2 #3; the #1766 principle).
         elif hold_tail:
+            # In-flight holds apply to the TAIL only — bytes before a
+            # completed block are already-visible history and truncating
+            # them would break monotonicity.
+            #
             # A ``<|start|>`` whose ``<|message|>`` has not arrived is a
             # channel header still in flight — hold from it so its
             # plain-word bytes ("assistant to=x") cannot leak once
             # tokens are stripped.
-            pending = work.rfind("<|start|>")
-            if pending >= 0 and "<|message|>" not in work[pending:]:
-                work = work[:pending]
-            # Same for the IMPLICIT first-segment header: while the
-            # entire output is still a growing `` to=recipient`` (no
-            # ``<|message|>`` yet), classification is impossible.
-            # Includes the prefixes of ``to=`` itself (`` t``, `` to``).
-            elif "<|message|>" not in work and re.fullmatch(
-                r"\s?(?:t|to|to=\S*)?", work
+            pending = tail.rfind("<|start|>")
+            if pending >= 0 and "<|message|>" not in tail[pending:]:
+                tail = tail[:pending]
+            # The IMPLICIT first-segment header: while the ENTIRE output
+            # is still a growing `` to=recipient`` (no ``<|message|>``
+            # yet), classification is impossible. Includes the prefixes
+            # of ``to=`` itself (`` t``, `` to``). Only possible at the
+            # very start of the generation — i.e. before any block.
+            elif (
+                not blocks
+                and "<|message|>" not in tail
+                and re.fullmatch(r"\s?(?:t|to|to=\S*)?", tail)
             ):
-                work = ""
+                tail = ""
             else:
-                work = cls._hold_partial_sentinel(work)
-        return _strip_channel_plumbing(work)
+                tail = cls._hold_partial_sentinel(tail)
+        return _strip_channel_plumbing("".join(pieces) + tail)
 
     @classmethod
     def _hold_partial_sentinel(cls, text: str) -> str:
@@ -345,7 +413,9 @@ class MuseToolParser(ToolParser):
         return text if max_hold == 0 else text[: len(text) - max_hold]
 
     def has_pending_tool_call(self, text: str) -> bool:
-        return _BLOCK_OPEN in _BLOCK_RE.sub("", text)
+        blocks = _completed_blocks(text)
+        after = blocks[-1][1] if blocks else 0
+        return _BLOCK_OPEN in text[after:]
 
     def flush_held_content(self, full_text: str) -> str:
         """Release held-but-safe bytes at end of stream.
@@ -374,17 +444,18 @@ class MuseToolParser(ToolParser):
 
         # A block close just completed — parse ONLY the newly completed
         # blocks (already-emitted blocks keep their ids and are never
-        # re-scanned; codex r1 #4).
+        # re-scanned; codex r1 #4). ``_completed_blocks`` is
+        # prefix-stable, so the cursor into its result is safe.
         prev_closes = previous_text.count(_BLOCK_CLOSE)
         curr_closes = current_text.count(_BLOCK_CLOSE)
         if curr_closes > prev_closes:
-            blocks = list(_BLOCK_RE.finditer(current_text))
+            blocks = _completed_blocks(current_text)
             new_blocks = blocks[self._stream_blocks_emitted :]
             self._stream_blocks_emitted = len(blocks)
             fresh = [
                 call
-                for block in new_blocks
-                for call in self._parse_block(block.group("body"), request)
+                for _, _, body in new_blocks
+                for call in self._parse_block(body, request)
             ]
             if fresh:
                 offset = self._stream_calls_emitted

--- a/vllm_mlx/tool_parsers/muse_tool_parser.py
+++ b/vllm_mlx/tool_parsers/muse_tool_parser.py
@@ -68,9 +68,35 @@ _BLOCK_CLOSE = "</atem:function_calls>"
 _PARAM_CLOSE = "</atem:parameter>"
 _INVOKE_CLOSE = "</atem:invoke>"
 
-_INVOKE_OPEN_RE = re.compile(r'<atem:invoke\s+name="(?P<name>[^"]+)">')
-_PARAM_OPEN_RE = re.compile(r'<atem:parameter\s+name="(?P<name>[^"]+)">')
+# CANONICAL opener forms only — exactly what the chat template renders
+# (single space, double quotes). Deliberately no ``\s+`` tolerance: the
+# in-flight partial-prefix classifiers below must agree byte-for-byte
+# with these, or a structure could flip between "malformed" and
+# "parsed" as a stream grows (prefix-stability). A model emitting a
+# non-canonical variant degrades to visible content, never a call.
+_INVOKE_OPEN_RE = re.compile(r'<atem:invoke name="(?P<name>[^"]+)">')
+_PARAM_OPEN_RE = re.compile(r'<atem:parameter name="(?P<name>[^"]+)">')
+_INVOKE_OPEN_LITERAL = '<atem:invoke name="'
+_PARAM_OPEN_LITERAL = '<atem:parameter name="'
 _WS_RE = re.compile(r"[ \t\r\n]*")
+
+# Scan-state sentinels (see ``_walk_invoke`` / ``_scan_text``).
+_INCOMPLETE = "incomplete"
+_MALFORMED = "malformed"
+
+
+def _tail_could_grow_into_opener(tail: str, literal: str) -> bool:
+    """Whether ``tail`` (which runs to end of input) could still become
+    the canonical opener ``literal<name>">`` with more bytes."""
+    if literal.startswith(tail):
+        return True
+    if not tail.startswith(literal):
+        return False
+    rest = tail[len(literal) :]
+    # Inside the name: any bytes without a closing quote yet, or the
+    # quote with the ``>`` still to come.
+    return re.fullmatch(r'[^"]*(?:">?)?', rest) is not None and not rest.endswith('">')
+
 
 # Muse channel plumbing (Harmony-flavored, but a distinct token set:
 # <|eot|>/<|eom|> terminators instead of <|end|>/<|return|>/<|call|>,
@@ -108,8 +134,13 @@ def _generate_tool_id() -> str:
 
 def _walk_invoke(
     text: str, opener: re.Match[str]
-) -> tuple[str, list[tuple[str, str]], int] | None:
-    """Walk one invoke starting at ``opener``; None if malformed/incomplete.
+) -> tuple[str, list[tuple[str, str]], int] | str:
+    """Walk one invoke starting at ``opener``.
+
+    Returns ``(name, params, end)`` on success, ``_INCOMPLETE`` when
+    more bytes could still legally complete the structure (a stream in
+    flight), or ``_MALFORMED`` when no continuation can (bytes present
+    that diverge from every legal token).
 
     Positional grammar walk: after the invoke opener, the only legal
     tokens (whitespace-separated) are parameter openers and the invoke
@@ -125,6 +156,8 @@ def _walk_invoke(
     cursor = opener.end()
     while True:
         j = _WS_RE.match(text, cursor).end()
+        if j >= len(text):
+            return _INCOMPLETE
         pm = _PARAM_OPEN_RE.match(text, j)
         if pm is not None:
             value_start = pm.end()
@@ -133,7 +166,8 @@ def _walk_invoke(
             while True:
                 idx = text.find(_PARAM_CLOSE, pos)
                 if idx < 0:
-                    break
+                    # No boundary-valid closer yet; one may still arrive.
+                    return _INCOMPLETE
                 after = idx + len(_PARAM_CLOSE)
                 k = _WS_RE.match(text, after).end()
                 if (
@@ -147,42 +181,52 @@ def _walk_invoke(
                     break
                 pos = after
             if not closed:
-                return None
+                return _INCOMPLETE
             continue
         if text.startswith(_INVOKE_CLOSE, j):
             return (opener.group("name"), params, j + len(_INVOKE_CLOSE))
-        # Unexpected bytes (or end of input) inside the invoke.
-        return None
+        tail = text[j:]
+        if _INVOKE_CLOSE.startswith(tail) or _tail_could_grow_into_opener(
+            tail, _PARAM_OPEN_LITERAL
+        ):
+            return _INCOMPLETE
+        return _MALFORMED
 
 
-def _completed_blocks(text: str) -> list[_Block]:
-    """Every completed, structurally valid ATEM block in ``text``.
+def _scan_text(text: str) -> tuple[list[_Block], int | None]:
+    """``(completed_blocks, pending_open_idx)`` for ``text``.
 
-    Prefix-stable: a completed block's geometry depends only on the
-    bytes up to its close (every lookahead that validated a closer is
-    internal to the block once the block close itself validates), so as
-    a stream grows, already-completed blocks never change. The
+    ``pending_open_idx`` is the offset of an opener whose block is
+    still legally completable (more bytes may arrive) — the streaming
+    hold point — or None. A DEFINITIVELY malformed opener (bytes
+    present that no continuation can repair) is skipped and its bytes
+    stay visible content, so a quoted/broken opener earlier in the
+    response cannot swallow a real call after it (codex r6 #2).
+
+    Prefix-stable both ways: a completed block's geometry depends only
+    on bytes up to its close, and a malformed verdict is only reached
+    on diverging bytes that later input cannot un-diverge. The
     streaming path's ``_stream_blocks_emitted`` cursor relies on this.
-
-    A block whose interior fails the walk is treated as in-flight /
-    malformed: scanning stops at its opener, and the bytes surface as
-    visible content instead of calls.
     """
     blocks: list[_Block] = []
     pos = 0
     while True:
         open_idx = text.find(_BLOCK_OPEN, pos)
         if open_idx < 0:
-            break
+            return blocks, None
         invokes: list[tuple[str, list[tuple[str, str]]]] = []
         cursor = open_idx + len(_BLOCK_OPEN)
-        completed = False
+        verdict: str | None = None
         while True:
             j = _WS_RE.match(text, cursor).end()
+            if j >= len(text):
+                verdict = _INCOMPLETE
+                break
             im = _INVOKE_OPEN_RE.match(text, j)
             if im is not None:
                 walked = _walk_invoke(text, im)
-                if walked is None:
+                if isinstance(walked, str):
+                    verdict = walked
                     break
                 name, params, end = walked
                 invokes.append((name, params))
@@ -191,12 +235,21 @@ def _completed_blocks(text: str) -> list[_Block]:
             if text.startswith(_BLOCK_CLOSE, j):
                 blocks.append((open_idx, j + len(_BLOCK_CLOSE), invokes))
                 pos = j + len(_BLOCK_CLOSE)
-                completed = True
+                verdict = None
                 break
+            tail = text[j:]
+            if _BLOCK_CLOSE.startswith(tail) or _tail_could_grow_into_opener(
+                tail, _INVOKE_OPEN_LITERAL
+            ):
+                verdict = _INCOMPLETE
+                break
+            verdict = _MALFORMED
             break
-        if not completed:
-            break
-    return blocks
+        if verdict == _INCOMPLETE:
+            return blocks, open_idx
+        if verdict == _MALFORMED:
+            # Resume AFTER the opener token; its bytes remain content.
+            pos = open_idx + len(_BLOCK_OPEN)
 
 
 def _allows_null(cfg: Any) -> bool:
@@ -387,7 +440,7 @@ class MuseToolParser(ToolParser):
     ) -> ExtractedToolCallInformation:
         calls = [
             call
-            for _, _, invokes in _completed_blocks(model_output)
+            for _, _, invokes in _scan_text(model_output)[0]
             for call in self._convert_invokes(invokes, request)
         ]
         # One content rule for BOTH modes (codex r2 #2, r3 #2): the
@@ -414,12 +467,12 @@ class MuseToolParser(ToolParser):
         blocks therefore streams normally (codex r1 #1).
 
         Monotonic in ``text`` by construction: completed blocks are
-        prefix-stable (see ``_completed_blocks``), a parseable block's
+        prefix-stable (see ``_scan_text``), a parseable block's
         removal never exposes earlier bytes, and an empty block's bytes
         appear in one piece at its close. That is what lets callers
         emit from an absolute cursor.
         """
-        blocks = _completed_blocks(text)
+        blocks, pending = _scan_text(text)
         pieces: list[str] = []
         pos = 0
         for start, end, invokes in blocks:
@@ -428,13 +481,12 @@ class MuseToolParser(ToolParser):
                 pieces.append(text[start:end])
             pos = end
         tail = text[pos:]
-        first_open = tail.find(_BLOCK_OPEN)
-        if first_open >= 0:
+        if pending is not None:
             if hold_tail:
-                tail = tail[:first_open]
-            # hold_tail=False (end of stream): the opener can no longer
-            # complete, so its literal bytes are content — matching the
-            # non-streaming path (codex r2 #3; the #1766 principle).
+                tail = text[pos:pending]
+            # hold_tail=False (end of stream): the pending opener can no
+            # longer complete, so its literal bytes are content — matching
+            # the non-streaming path (codex r2 #3; the #1766 principle).
         elif hold_tail:
             # In-flight holds apply to the TAIL only — bytes before a
             # completed block are already-visible history and truncating
@@ -473,9 +525,7 @@ class MuseToolParser(ToolParser):
         return text if max_hold == 0 else text[: len(text) - max_hold]
 
     def has_pending_tool_call(self, text: str) -> bool:
-        blocks = _completed_blocks(text)
-        after = blocks[-1][1] if blocks else 0
-        return _BLOCK_OPEN in text[after:]
+        return _scan_text(text)[1] is not None
 
     def flush_held_content(self, full_text: str) -> str:
         """Release held-but-safe bytes at end of stream.
@@ -504,12 +554,12 @@ class MuseToolParser(ToolParser):
 
         # A block close just completed — parse ONLY the newly completed
         # blocks (already-emitted blocks keep their ids and are never
-        # re-scanned; codex r1 #4). ``_completed_blocks`` is
-        # prefix-stable, so the cursor into its result is safe.
+        # re-scanned; codex r1 #4). ``_scan_text`` is prefix-stable,
+        # so the cursor into its result is safe.
         prev_closes = previous_text.count(_BLOCK_CLOSE)
         curr_closes = current_text.count(_BLOCK_CLOSE)
         if curr_closes > prev_closes:
-            blocks = _completed_blocks(current_text)
+            blocks, _ = _scan_text(current_text)
             new_blocks = blocks[self._stream_blocks_emitted :]
             self._stream_blocks_emitted = len(blocks)
             fresh = [

--- a/vllm_mlx/tool_parsers/muse_tool_parser.py
+++ b/vllm_mlx/tool_parsers/muse_tool_parser.py
@@ -57,10 +57,8 @@ _BLOCK_OPEN = "<atem:function_calls>"
 _BLOCK_CLOSE = "</atem:function_calls>"
 _PARAM_CLOSE = "</atem:parameter>"
 
-_INVOKE_RE = re.compile(
-    r'<atem:invoke\s+name="(?P<name>[^"]+)">(?P<body>.*?)</atem:invoke>',
-    re.DOTALL,
-)
+_INVOKE_OPEN_RE = re.compile(r'<atem:invoke\s+name="(?P<name>[^"]+)">')
+_INVOKE_CLOSE = "</atem:invoke>"
 _PARAM_OPEN_RE = re.compile(r'<atem:parameter\s+name="(?P<name>[^"]+)">')
 
 # Muse channel plumbing (Harmony-flavored, but a distinct token set:
@@ -135,6 +133,58 @@ def _completed_blocks(text: str) -> list[tuple[int, int, str]]:
     return blocks
 
 
+def _scan_invokes(body: str) -> list[tuple[str, str]]:
+    """``(name, inner)`` for each invoke in a block body.
+
+    An invoke's close is the first ``</atem:invoke>`` at which the
+    inner PARAMETER structure is balanced — a literal invoke closer
+    inside a parameter value sits between that parameter's opener and
+    closer, leaves the count unbalanced, and is skipped (codex r4 #3;
+    same rule one level down from ``_completed_blocks``). The rule errs
+    toward "unparseable stays content": a truly unbalanced body yields
+    no invoke rather than a wrong call.
+    """
+    out: list[tuple[str, str]] = []
+    pos = 0
+    while True:
+        opener = _INVOKE_OPEN_RE.search(body, pos)
+        if opener is None:
+            break
+        inner_start = opener.end()
+        search = inner_start
+        close_idx = -1
+        while True:
+            candidate = body.find(_INVOKE_CLOSE, search)
+            if candidate < 0:
+                break
+            inner = body[inner_start:candidate]
+            if inner.count("<atem:parameter") <= inner.count("</atem:parameter>"):
+                close_idx = candidate
+                break
+            search = candidate + len(_INVOKE_CLOSE)
+        if close_idx < 0:
+            break
+        out.append((opener.group("name"), body[inner_start:close_idx]))
+        pos = close_idx + len(_INVOKE_CLOSE)
+    return out
+
+
+def _allows_null(cfg: Any) -> bool:
+    """Whether the property schema explicitly permits ``null``."""
+    if not isinstance(cfg, dict):
+        return False
+    declared = cfg.get("type")
+    if declared == "null":
+        return True
+    if isinstance(declared, list) and "null" in declared:
+        return True
+    return any(
+        any(_allows_null(sub) for sub in cfg[key])
+        for key in ("anyOf", "oneOf")
+        if isinstance(cfg.get(key), list)
+    )
+
+
 def _declared_type(cfg: Any) -> str | None:
     """Normalize a property schema to one simple type name, or None.
 
@@ -198,7 +248,11 @@ def _convert_param_value(raw: str, param_name: str, props: dict) -> Any:
     declared = _declared_type(cfg)
     if declared == "string":
         return raw
-    if raw == "null" and declared is not None:
+    if raw == "null" and _allows_null(cfg):
+        # Only when the schema PERMITS null (codex r4 #1): a bare
+        # ``null`` against a non-nullable type stays the raw string so
+        # downstream strict validation rejects it visibly instead of
+        # receiving a silently-forged None.
         return None
     if declared == "boolean":
         if raw in ("true", "false"):
@@ -239,11 +293,21 @@ def _scan_parameters(body: str, declared: set[str] | None) -> list[tuple[str, st
     ambiguous there (the template says regex, not XML), and the schema
     is the only disambiguator, exactly as in the qwen scanner.
     """
-    openers = [
-        m
-        for m in _PARAM_OPEN_RE.finditer(body)
-        if declared is None or m.group("name") in declared
-    ]
+    openers: list[re.Match[str]] = []
+    seen: set[str] = set()
+    for m in _PARAM_OPEN_RE.finditer(body):
+        name = m.group("name")
+        if declared is not None and name not in declared:
+            continue
+        if name in seen:
+            # The template emits each parameter at most once, so a
+            # SECOND opener with the same name is value text — without
+            # this, a fake opener reusing a declared name would
+            # overwrite the real value (codex r4 #2). Its bytes stay in
+            # the current segment and the last-closer rule keeps them.
+            continue
+        seen.add(name)
+        openers.append(m)
     params: list[tuple[str, str]] = []
     for i, m in enumerate(openers):
         seg_end = openers[i + 1].start() if i + 1 < len(openers) else len(body)
@@ -299,13 +363,12 @@ class MuseToolParser(ToolParser):
         (codex r1 BLOCKING #2; the #44 injection-surface concern).
         """
         calls: list[dict[str, str]] = []
-        for match in _INVOKE_RE.finditer(body):
-            name = match.group("name")
+        for name, inner in _scan_invokes(body):
             props = _schema_properties(name, request)
             declared = declared_parameter_names(name, request)
             arguments = {
                 pname: _convert_param_value(raw, pname, props)
-                for pname, raw in _scan_parameters(match.group("body"), declared)
+                for pname, raw in _scan_parameters(inner, declared)
             }
             calls.append(
                 {
@@ -361,7 +424,7 @@ class MuseToolParser(ToolParser):
         pos = 0
         for start, end, body in blocks:
             pieces.append(text[pos:start])
-            if _INVOKE_RE.search(body) is None:
+            if not _scan_invokes(body):
                 # Completed but malformed — no parseable invoke, so the
                 # bytes are model output the client must see (codex r3
                 # #2; non-stream applies the identical rule above).

--- a/vllm_mlx/tool_parsers/muse_tool_parser.py
+++ b/vllm_mlx/tool_parsers/muse_tool_parser.py
@@ -110,7 +110,6 @@ _SELF_SEGMENT_RE = re.compile(
     r"(?:<\|start\|>assistant\s+|^\s?)to=self<\|message\|>.*?(?:<\|eom\|>|<\|eot\|>|$)",
     re.DOTALL,
 )
-_CONTROL_TOKENS = ("<|start|>", "<|message|>", "<|eot|>", "<|eom|>")
 
 # Sentinels whose partial prefixes must be held back from streamed
 # content so per-char streaming doesn't leak ``<``, ``<a``, ``<atem:``…
@@ -366,13 +365,19 @@ def _convert_param_value(raw: str, param_name: str, props: dict) -> Any:
 
 
 def _strip_channel_plumbing(text: str) -> str:
-    """Remove Muse channel tokens and ``to=self`` reasoning segments."""
-    # Reasoning segments first (they carry their own header/terminator).
+    """Remove Muse channel plumbing and ``to=self`` reasoning segments.
+
+    Only STRUCTURAL occurrences are removed: complete headers, and
+    terminators sitting at a segment boundary (directly before the next
+    header, or at end of input). A literal ``<|eot|>`` mid-prose is
+    model output and survives — the #1766/#1779 literal-markup
+    principle (codex r7 #3/#4). Terminator stripping runs BEFORE header
+    removal so the before-a-header lookahead can still see the header.
+    """
     result = _SELF_SEGMENT_RE.sub("", text)
+    result = re.sub(r"(?:<\|eot\|>|<\|eom\|>)+(?=<\|start\|>|\Z)", "", result)
     result = _CHANNEL_HEADER_RE.sub("", result)
     result = _IMPLICIT_HEADER_RE.sub("", result)
-    for token in _CONTROL_TOKENS:
-        result = result.replace(token, "")
     return result
 
 
@@ -512,6 +517,15 @@ class MuseToolParser(ToolParser):
                 tail = ""
             else:
                 tail = cls._hold_partial_sentinel(tail)
+                # A COMPLETE trailing terminator is undecidable while
+                # the stream runs: followed by a header (or end) it is
+                # structural plumbing; followed by prose it is literal
+                # model output. Hold it until the next bytes decide —
+                # emitting now and un-emitting later would break
+                # monotonicity.
+                trailing_term = re.search(r"(?:<\|eot\|>|<\|eom\|>)+$", tail)
+                if trailing_term:
+                    tail = tail[: trailing_term.start()]
         return _strip_channel_plumbing("".join(pieces) + tail)
 
     @classmethod
@@ -558,6 +572,7 @@ class MuseToolParser(ToolParser):
         # so the cursor into its result is safe.
         prev_closes = previous_text.count(_BLOCK_CLOSE)
         curr_closes = current_text.count(_BLOCK_CLOSE)
+        fresh: list[dict[str, str]] = []
         if curr_closes > prev_closes:
             blocks, _ = _scan_text(current_text)
             new_blocks = blocks[self._stream_blocks_emitted :]
@@ -567,32 +582,37 @@ class MuseToolParser(ToolParser):
                 for _, _, invokes in new_blocks
                 for call in self._convert_invokes(invokes, request)
             ]
-            if fresh:
-                offset = self._stream_calls_emitted
-                self._stream_calls_emitted += len(fresh)
-                return {
-                    "tool_calls": [
-                        {
-                            "index": offset + i,
-                            "id": call["id"],
-                            "type": "function",
-                            "function": {
-                                "name": call["name"],
-                                "arguments": call["arguments"],
-                            },
-                        }
-                        for i, call in enumerate(fresh)
-                    ]
-                }
-            return None
 
         # Content channel: everything outside completed blocks, held at
         # any in-flight opener/header/sentinel. Emitted from an absolute
         # cursor, not a prev/curr diff, so bytes that arrived in the same
-        # delta as a block close are not skipped (codex r2 #1).
+        # delta as a block close are not skipped (codex r2 #1) — and
+        # content preceding a close in the SAME delta rides in the same
+        # response as the calls, preserving wire order (codex r7 #2).
+        new_content = None
         visible = self._visible_content(current_text)
         if len(visible) > self._content_emitted:
             new_content = visible[self._content_emitted :]
             self._content_emitted = len(visible)
-            return {"content": new_content}
-        return None
+
+        if not fresh and new_content is None:
+            return None
+        out: dict[str, Any] = {}
+        if new_content:
+            out["content"] = new_content
+        if fresh:
+            offset = self._stream_calls_emitted
+            self._stream_calls_emitted += len(fresh)
+            out["tool_calls"] = [
+                {
+                    "index": offset + i,
+                    "id": call["id"],
+                    "type": "function",
+                    "function": {
+                        "name": call["name"],
+                        "arguments": call["arguments"],
+                    },
+                }
+                for i, call in enumerate(fresh)
+            ]
+        return out or None

--- a/vllm_mlx/tool_parsers/muse_tool_parser.py
+++ b/vllm_mlx/tool_parsers/muse_tool_parser.py
@@ -216,6 +216,12 @@ class MuseToolParser(ToolParser):
         super().reset()
         self._stream_calls_emitted = 0
         self._stream_blocks_emitted = 0
+        # Chars of the visible-content view already sent to the client.
+        # An absolute cursor (not a prev-vs-curr diff): a delta that both
+        # completes a block AND carries trailing text returns tool_calls
+        # for that call, and the trailing text is picked up on the next
+        # call because the cursor did not advance past it (codex r2 #1).
+        self._content_emitted = 0
 
     @staticmethod
     def _parse_block(body: str, request: dict[str, Any] | None) -> list[dict[str, str]]:
@@ -267,9 +273,10 @@ class MuseToolParser(ToolParser):
         ]
 
         # Content = whatever sits outside the completed ATEM blocks,
-        # channel-clean.
+        # channel-clean. No ``.strip()`` — the streaming path emits these
+        # bytes verbatim and the two modes must agree (codex r2 #2).
         outside = _BLOCK_RE.sub("", model_output)
-        content = _strip_channel_plumbing(outside).strip() or None
+        content = _strip_channel_plumbing(outside) or None
 
         if not calls:
             # Completed block(s) with no parseable invoke (malformed):
@@ -301,7 +308,12 @@ class MuseToolParser(ToolParser):
         work = _BLOCK_RE.sub("", text)
         first_open = work.find(_BLOCK_OPEN)
         if first_open >= 0:
-            work = work[:first_open]
+            if hold_tail:
+                work = work[:first_open]
+            # hold_tail=False (end of stream): the opener can no longer
+            # complete, so its literal bytes are content — matching the
+            # non-streaming path, which keeps unmatched-opener text
+            # (codex r2 #3; the #1766 literal-markup-survives principle).
         elif hold_tail:
             # A ``<|start|>`` whose ``<|message|>`` has not arrived is a
             # channel header still in flight — hold from it so its
@@ -338,15 +350,14 @@ class MuseToolParser(ToolParser):
     def flush_held_content(self, full_text: str) -> str:
         """Release held-but-safe bytes at end of stream.
 
-        The difference between the unheld view (partial sentinels
+        The unheld view (partial sentinels and unmatched-opener text
         released — the stream is over, they can no longer grow into
-        markup) and what the per-delta path already emitted. An
-        UNMATCHED opener's markup stays dropped here; the finalize
-        fallback re-parses the full text if no call ever fired.
+        markup) minus what the per-delta path already emitted, tracked
+        by the ``_content_emitted`` cursor.
         """
-        emitted = self._visible_content(full_text)
         final = self._visible_content(full_text, hold_tail=False)
-        return final[len(emitted) :]
+        cursor = getattr(self, "_content_emitted", 0)
+        return final[cursor:]
 
     def extract_tool_calls_streaming(
         self,
@@ -395,9 +406,12 @@ class MuseToolParser(ToolParser):
             return None
 
         # Content channel: everything outside completed blocks, held at
-        # any in-flight opener/header/sentinel.
-        prev_safe = self._visible_content(previous_text)
-        curr_safe = self._visible_content(current_text)
-        if len(curr_safe) > len(prev_safe):
-            return {"content": curr_safe[len(prev_safe) :]}
+        # any in-flight opener/header/sentinel. Emitted from an absolute
+        # cursor, not a prev/curr diff, so bytes that arrived in the same
+        # delta as a block close are not skipped (codex r2 #1).
+        visible = self._visible_content(current_text)
+        if len(visible) > self._content_emitted:
+            new_content = visible[self._content_emitted :]
+            self._content_emitted = len(visible)
+            return {"content": new_content}
         return None

--- a/vllm_mlx/tool_parsers/muse_tool_parser.py
+++ b/vllm_mlx/tool_parsers/muse_tool_parser.py
@@ -57,6 +57,10 @@ _BLOCK_OPEN = "<atem:function_calls>"
 _BLOCK_CLOSE = "</atem:function_calls>"
 _PARAM_CLOSE = "</atem:parameter>"
 
+_BLOCK_RE = re.compile(
+    re.escape(_BLOCK_OPEN) + r"(?P<body>.*?)" + re.escape(_BLOCK_CLOSE),
+    re.DOTALL,
+)
 _INVOKE_RE = re.compile(
     r'<atem:invoke\s+name="(?P<name>[^"]+)">(?P<body>.*?)</atem:invoke>',
     re.DOTALL,
@@ -211,21 +215,20 @@ class MuseToolParser(ToolParser):
     def reset(self) -> None:
         super().reset()
         self._stream_calls_emitted = 0
+        self._stream_blocks_emitted = 0
 
-    # ------------------------------------------------------------------
-    # Non-streaming
-    # ------------------------------------------------------------------
+    @staticmethod
+    def _parse_block(body: str, request: dict[str, Any] | None) -> list[dict[str, str]]:
+        """Parse the invokes of ONE completed block body.
 
-    def extract_tool_calls(
-        self, model_output: str, request: dict[str, Any] | None = None
-    ) -> ExtractedToolCallInformation:
-        if _BLOCK_OPEN not in model_output:
-            return ExtractedToolCallInformation(
-                False, [], _strip_channel_plumbing(model_output) or None
-            )
-
+        Scoping the invoke scan to completed block bodies (rather than the
+        whole response) is load-bearing: invoke-shaped text OUTSIDE a
+        block — the model quoting an example, documentation in prose —
+        must stay literal content, never become an executable call
+        (codex r1 BLOCKING #2; the #44 injection-surface concern).
+        """
         calls: list[dict[str, str]] = []
-        for match in _INVOKE_RE.finditer(model_output):
+        for match in _INVOKE_RE.finditer(body):
             name = match.group("name")
             props = _schema_properties(name, request)
             declared = declared_parameter_names(name, request)
@@ -240,18 +243,36 @@ class MuseToolParser(ToolParser):
                     "arguments": json.dumps(arguments, ensure_ascii=False),
                 }
             )
+        return calls
 
-        # Content = whatever sits outside the ATEM blocks, channel-clean.
-        outside = re.sub(
-            re.escape(_BLOCK_OPEN) + r".*?" + re.escape(_BLOCK_CLOSE),
-            "",
-            model_output,
-            flags=re.DOTALL,
-        )
+    # ------------------------------------------------------------------
+    # Non-streaming
+    # ------------------------------------------------------------------
+
+    def extract_tool_calls(
+        self, model_output: str, request: dict[str, Any] | None = None
+    ) -> ExtractedToolCallInformation:
+        blocks = list(_BLOCK_RE.finditer(model_output))
+        if not blocks:
+            # No COMPLETED block. A truncated opener stays visible as
+            # content rather than silently dropping bytes.
+            return ExtractedToolCallInformation(
+                False, [], _strip_channel_plumbing(model_output) or None
+            )
+
+        calls = [
+            call
+            for block in blocks
+            for call in self._parse_block(block.group("body"), request)
+        ]
+
+        # Content = whatever sits outside the completed ATEM blocks,
+        # channel-clean.
+        outside = _BLOCK_RE.sub("", model_output)
         content = _strip_channel_plumbing(outside).strip() or None
 
         if not calls:
-            # An opener with no parseable invoke (malformed / truncated):
+            # Completed block(s) with no parseable invoke (malformed):
             # keep the raw text as content rather than dropping bytes.
             return ExtractedToolCallInformation(
                 False, [], _strip_channel_plumbing(model_output) or None
@@ -263,24 +284,46 @@ class MuseToolParser(ToolParser):
     # ------------------------------------------------------------------
 
     @classmethod
-    def _safe_content_prefix(cls, text: str) -> str:
-        """Hold back any tail that could grow into a sentinel."""
-        first_open = text.find(_BLOCK_OPEN)
+    def _visible_content(cls, text: str, *, hold_tail: bool = True) -> str:
+        """Channel-clean content emittable for ``text`` so far.
+
+        Completed ATEM blocks are removed (their calls surface on the
+        tool_calls channel), the region from any UNMATCHED opener on is
+        held, and — when ``hold_tail`` — the usual in-flight holds apply:
+        a growing channel header and partial sentinels. Content between
+        and after blocks therefore streams normally instead of being
+        swallowed once the first opener appears (codex r1 BLOCKING #1).
+
+        Monotonic in ``text`` by construction (each transform only
+        appends to or truncates the tail), which is what lets callers
+        emit ``curr[len(prev):]`` diffs.
+        """
+        work = _BLOCK_RE.sub("", text)
+        first_open = work.find(_BLOCK_OPEN)
         if first_open >= 0:
-            return text[:first_open]
-        # A ``<|start|>`` whose ``<|message|>`` has not arrived is a
-        # channel header still in flight — hold from it so its plain-word
-        # bytes ("assistant to=x") cannot leak once tokens are stripped.
-        pending = text.rfind("<|start|>")
-        if pending >= 0 and "<|message|>" not in text[pending:]:
-            return text[:pending]
-        # Same for the IMPLICIT first-segment header: while the entire
-        # output is still a growing `` to=recipient`` (no ``<|message|>``
-        # yet), classification is impossible and emitting would leak
-        # header bytes as content. Once any non-header shape appears the
-        # rule stops matching and normal emission resumes.
-        if "<|message|>" not in text and re.fullmatch(r"\s?(?:t|to|to=\S*)?", text):
-            return ""
+            work = work[:first_open]
+        elif hold_tail:
+            # A ``<|start|>`` whose ``<|message|>`` has not arrived is a
+            # channel header still in flight — hold from it so its
+            # plain-word bytes ("assistant to=x") cannot leak once
+            # tokens are stripped.
+            pending = work.rfind("<|start|>")
+            if pending >= 0 and "<|message|>" not in work[pending:]:
+                work = work[:pending]
+            # Same for the IMPLICIT first-segment header: while the
+            # entire output is still a growing `` to=recipient`` (no
+            # ``<|message|>`` yet), classification is impossible.
+            # Includes the prefixes of ``to=`` itself (`` t``, `` to``).
+            elif "<|message|>" not in work and re.fullmatch(
+                r"\s?(?:t|to|to=\S*)?", work
+            ):
+                work = ""
+            else:
+                work = cls._hold_partial_sentinel(work)
+        return _strip_channel_plumbing(work)
+
+    @classmethod
+    def _hold_partial_sentinel(cls, text: str) -> str:
         max_hold = 0
         for sentinel in _STREAMING_SENTINELS:
             for length in range(min(len(text), len(sentinel) - 1), 0, -1):
@@ -290,12 +333,20 @@ class MuseToolParser(ToolParser):
         return text if max_hold == 0 else text[: len(text) - max_hold]
 
     def has_pending_tool_call(self, text: str) -> bool:
-        return _BLOCK_OPEN in text or self._safe_content_prefix(text) != text
+        return _BLOCK_OPEN in _BLOCK_RE.sub("", text)
 
     def flush_held_content(self, full_text: str) -> str:
-        if _BLOCK_OPEN in full_text:
-            return ""
-        return full_text[len(self._safe_content_prefix(full_text)) :]
+        """Release held-but-safe bytes at end of stream.
+
+        The difference between the unheld view (partial sentinels
+        released — the stream is over, they can no longer grow into
+        markup) and what the per-delta path already emitted. An
+        UNMATCHED opener's markup stays dropped here; the finalize
+        fallback re-parses the full text if no call ever fired.
+        """
+        emitted = self._visible_content(full_text)
+        final = self._visible_content(full_text, hold_tail=False)
+        return final[len(emitted) :]
 
     def extract_tool_calls_streaming(
         self,
@@ -310,37 +361,43 @@ class MuseToolParser(ToolParser):
         if not hasattr(self, "_stream_calls_emitted"):
             self.reset()
 
-        # A block close just completed — surface any not-yet-emitted calls.
+        # A block close just completed — parse ONLY the newly completed
+        # blocks (already-emitted blocks keep their ids and are never
+        # re-scanned; codex r1 #4).
         prev_closes = previous_text.count(_BLOCK_CLOSE)
         curr_closes = current_text.count(_BLOCK_CLOSE)
         if curr_closes > prev_closes:
-            result = self.extract_tool_calls(current_text, request)
-            if result.tools_called:
-                fresh = result.tool_calls[self._stream_calls_emitted :]
-                if fresh:
-                    offset = self._stream_calls_emitted
-                    self._stream_calls_emitted = len(result.tool_calls)
-                    return {
-                        "tool_calls": [
-                            {
-                                "index": offset + i,
-                                "id": call["id"],
-                                "type": "function",
-                                "function": {
-                                    "name": call["name"],
-                                    "arguments": call["arguments"],
-                                },
-                            }
-                            for i, call in enumerate(fresh)
-                        ]
-                    }
+            blocks = list(_BLOCK_RE.finditer(current_text))
+            new_blocks = blocks[self._stream_blocks_emitted :]
+            self._stream_blocks_emitted = len(blocks)
+            fresh = [
+                call
+                for block in new_blocks
+                for call in self._parse_block(block.group("body"), request)
+            ]
+            if fresh:
+                offset = self._stream_calls_emitted
+                self._stream_calls_emitted += len(fresh)
+                return {
+                    "tool_calls": [
+                        {
+                            "index": offset + i,
+                            "id": call["id"],
+                            "type": "function",
+                            "function": {
+                                "name": call["name"],
+                                "arguments": call["arguments"],
+                            },
+                        }
+                        for i, call in enumerate(fresh)
+                    ]
+                }
             return None
 
-        # Inside (or before) a block: emit only channel-clean safe content.
-        if _BLOCK_OPEN in current_text:
-            return None
-        prev_safe = _strip_channel_plumbing(self._safe_content_prefix(previous_text))
-        curr_safe = _strip_channel_plumbing(self._safe_content_prefix(current_text))
+        # Content channel: everything outside completed blocks, held at
+        # any in-flight opener/header/sentinel.
+        prev_safe = self._visible_content(previous_text)
+        curr_safe = self._visible_content(current_text)
         if len(curr_safe) > len(prev_safe):
             return {"content": curr_safe[len(prev_safe) :]}
         return None

--- a/vllm_mlx/tool_parsers/muse_tool_parser.py
+++ b/vllm_mlx/tool_parsers/muse_tool_parser.py
@@ -1,0 +1,346 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tool-call parser for Meta Muse Glimmer's ATEM wire format.
+
+Muse Glimmer (meta-models/Muse-Glimmer-30B, 2026-08-10) renders tool
+calls as an Anthropic-style XML block inside a Harmony-style channel
+message::
+
+    <|start|>assistant to=get_weather<|message|><atem:function_calls>
+    <atem:invoke name="get_weather">
+    <atem:parameter name="city">Paris</atem:parameter>
+    </atem:invoke>
+    </atem:function_calls><|eot|>
+
+Everything the parser relies on is pinned by the model's own chat
+template (``chat_template.jinja`` on the HF repo):
+
+* String and scalar parameter values are rendered **as is** — no JSON
+  quoting, and "spaces for string values are not stripped". Lists and
+  objects are rendered with ``tojson``. So value typing comes from the
+  request's tool schema, not from the wire.
+* The template itself warns: "The output is not expected to be valid
+  XML and is parsed with regular expressions." A string value may
+  therefore contain XML-ish text, including a literal
+  ``</atem:parameter>`` — the same delimiter-ambiguity class as the
+  Qwen3-Coder fixes in #1730. Two defenses here: a parameter's value
+  runs to the LAST closer before the next opener (not the first), and
+  when the request declares the tool's parameter names, an opener whose
+  name is not declared is treated as literal value text
+  (``declared_parameter_names``, same rationale as the qwen scanner).
+* The tool name is duplicated in the channel header (``to=NAME``) and
+  the invoke tag; the invoke tag is authoritative — the header is
+  routing plumbing and is stripped with the other channel tokens.
+
+The companion ``MuseReasoningParser`` routes ``to=self`` segments to
+``reasoning_content`` BEFORE this parser sees the stream, so on the
+production path this parser receives channel-clean content plus ATEM
+blocks. It still strips channel tokens itself so that standalone use
+(no reasoning parser configured) does not leak plumbing into content.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import uuid
+from collections.abc import Sequence
+from typing import Any
+
+from .abstract_tool_parser import (
+    ExtractedToolCallInformation,
+    ToolParser,
+    ToolParserManager,
+    declared_parameter_names,
+)
+
+_BLOCK_OPEN = "<atem:function_calls>"
+_BLOCK_CLOSE = "</atem:function_calls>"
+_PARAM_CLOSE = "</atem:parameter>"
+
+_INVOKE_RE = re.compile(
+    r'<atem:invoke\s+name="(?P<name>[^"]+)">(?P<body>.*?)</atem:invoke>',
+    re.DOTALL,
+)
+_PARAM_OPEN_RE = re.compile(r'<atem:parameter\s+name="(?P<name>[^"]+)">')
+
+# Muse channel plumbing (Harmony-flavored, but a distinct token set:
+# <|eot|>/<|eom|> terminators instead of <|end|>/<|return|>/<|call|>,
+# and recipient routing via ``to=`` in the <|start|> header).
+_CHANNEL_HEADER_RE = re.compile(r"<\|start\|>assistant(?:\s+to=\S+?)?\s*<\|message\|>")
+# The FIRST segment of a generation has an implicit header: the prompt
+# ends with ``<|start|>assistant``, so output begins directly with
+# `` to=recipient<|message|>`` (or a bare ``<|message|>``).
+_IMPLICIT_HEADER_RE = re.compile(r"^\s?(?:to=\S+?)?\s*<\|message\|>")
+_SELF_SEGMENT_RE = re.compile(
+    r"(?:<\|start\|>assistant\s+|^\s?)to=self<\|message\|>.*?(?:<\|eom\|>|<\|eot\|>|$)",
+    re.DOTALL,
+)
+_CONTROL_TOKENS = ("<|start|>", "<|message|>", "<|eot|>", "<|eom|>")
+
+# Sentinels whose partial prefixes must be held back from streamed
+# content so per-char streaming doesn't leak ``<``, ``<a``, ``<atem:``…
+# before the full opener arrives (same bug class as #444/#480).
+_STREAMING_SENTINELS: tuple[str, ...] = (
+    _BLOCK_OPEN,
+    "<|start|>",
+    "<|message|>",
+    "<|eot|>",
+    "<|eom|>",
+)
+
+
+def _generate_tool_id() -> str:
+    return f"call_{uuid.uuid4().hex[:8]}"
+
+
+def _schema_properties(tool_name: str, request: dict[str, Any] | None) -> dict:
+    """The declared JSON-schema ``properties`` for ``tool_name``, or {}."""
+    if not isinstance(request, dict):
+        return {}
+    for tool in request.get("tools") or []:
+        fn = tool.get("function") if isinstance(tool, dict) else None
+        if isinstance(fn, dict) and fn.get("name") == tool_name:
+            props = (fn.get("parameters") or {}).get("properties")
+            return props if isinstance(props, dict) else {}
+    return {}
+
+
+def _convert_param_value(raw: str, param_name: str, props: dict) -> Any:
+    """Type a raw ATEM value using the tool schema.
+
+    ATEM's contract (from the chat template): strings and scalars are
+    rendered bare, lists/objects as JSON. So:
+
+    * declared string  -> raw, verbatim (whitespace preserved — the
+      template says so explicitly, and #1444's ``_decode_json_like``
+      whitespace-eating bug is the cautionary tale);
+    * declared boolean/integer/number -> parsed scalar (raw on failure,
+      so strict schema validation downstream rejects it visibly);
+    * declared object/array -> ``json.loads`` (raw on failure);
+    * ``null`` for a nullable non-string -> None;
+    * undeclared/unknown -> JSON only when it unambiguously parses to a
+      container (the template only emits JSON for containers); any other
+      shape stays a raw string. A bare ``5`` or ``true`` with no schema
+      stays a string — guessing would corrupt legitimate string values.
+    """
+    cfg = props.get(param_name)
+    declared = None
+    if isinstance(cfg, dict):
+        declared = cfg.get("type")
+    if declared == "string":
+        return raw
+    if raw == "null" and declared is not None:
+        return None
+    if declared == "boolean":
+        if raw in ("true", "false"):
+            return raw == "true"
+        return raw
+    if declared == "integer":
+        try:
+            return int(raw)
+        except ValueError:
+            return raw
+    if declared == "number":
+        try:
+            return float(raw)
+        except ValueError:
+            return raw
+    if declared in ("object", "array"):
+        try:
+            return json.loads(raw)
+        except json.JSONDecodeError:
+            return raw
+    # Undeclared or exotic type: containers self-identify as JSON.
+    stripped = raw.strip()
+    if stripped[:1] in ("{", "["):
+        try:
+            return json.loads(stripped)
+        except json.JSONDecodeError:
+            return raw
+    return raw
+
+
+def _scan_parameters(body: str, declared: set[str] | None) -> list[tuple[str, str]]:
+    """Extract ``(name, raw_value)`` pairs from an invoke body.
+
+    A value runs from its opener to the LAST ``</atem:parameter>``
+    before the next accepted opener (or the body end). Combined with
+    the declared-name filter, this survives values that contain a
+    literal closer or an XML-ish fake opener — the wire is genuinely
+    ambiguous there (the template says regex, not XML), and the schema
+    is the only disambiguator, exactly as in the qwen scanner.
+    """
+    openers = [
+        m
+        for m in _PARAM_OPEN_RE.finditer(body)
+        if declared is None or m.group("name") in declared
+    ]
+    params: list[tuple[str, str]] = []
+    for i, m in enumerate(openers):
+        seg_end = openers[i + 1].start() if i + 1 < len(openers) else len(body)
+        segment = body[m.end() : seg_end]
+        close = segment.rfind(_PARAM_CLOSE)
+        value = segment[:close] if close >= 0 else segment
+        params.append((m.group("name"), value))
+    return params
+
+
+def _strip_channel_plumbing(text: str) -> str:
+    """Remove Muse channel tokens and ``to=self`` reasoning segments."""
+    # Reasoning segments first (they carry their own header/terminator).
+    result = _SELF_SEGMENT_RE.sub("", text)
+    result = _CHANNEL_HEADER_RE.sub("", result)
+    result = _IMPLICIT_HEADER_RE.sub("", result)
+    for token in _CONTROL_TOKENS:
+        result = result.replace(token, "")
+    return result
+
+
+@ToolParserManager.register_module(["muse"])
+class MuseToolParser(ToolParser):
+    """Tool-call parser for Muse Glimmer's ATEM function-calls blocks."""
+
+    # The Muse chat template natively renders ``tool_calls`` (render_atem)
+    # and ``role="tool"`` results (<tool_output>) — without this flag the
+    # engine would flatten tool history into "[Calling tool: ...]" text
+    # the model never saw in training (#1593's bug class).
+    SUPPORTS_NATIVE_TOOL_FORMAT = True
+
+    EXPECTED_WIRE_FORMATS = ("muse_atem",)
+
+    def reset(self) -> None:
+        super().reset()
+        self._stream_calls_emitted = 0
+
+    # ------------------------------------------------------------------
+    # Non-streaming
+    # ------------------------------------------------------------------
+
+    def extract_tool_calls(
+        self, model_output: str, request: dict[str, Any] | None = None
+    ) -> ExtractedToolCallInformation:
+        if _BLOCK_OPEN not in model_output:
+            return ExtractedToolCallInformation(
+                False, [], _strip_channel_plumbing(model_output) or None
+            )
+
+        calls: list[dict[str, str]] = []
+        for match in _INVOKE_RE.finditer(model_output):
+            name = match.group("name")
+            props = _schema_properties(name, request)
+            declared = declared_parameter_names(name, request)
+            arguments = {
+                pname: _convert_param_value(raw, pname, props)
+                for pname, raw in _scan_parameters(match.group("body"), declared)
+            }
+            calls.append(
+                {
+                    "id": _generate_tool_id(),
+                    "name": name,
+                    "arguments": json.dumps(arguments, ensure_ascii=False),
+                }
+            )
+
+        # Content = whatever sits outside the ATEM blocks, channel-clean.
+        outside = re.sub(
+            re.escape(_BLOCK_OPEN) + r".*?" + re.escape(_BLOCK_CLOSE),
+            "",
+            model_output,
+            flags=re.DOTALL,
+        )
+        content = _strip_channel_plumbing(outside).strip() or None
+
+        if not calls:
+            # An opener with no parseable invoke (malformed / truncated):
+            # keep the raw text as content rather than dropping bytes.
+            return ExtractedToolCallInformation(
+                False, [], _strip_channel_plumbing(model_output) or None
+            )
+        return ExtractedToolCallInformation(True, calls, content)
+
+    # ------------------------------------------------------------------
+    # Streaming
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def _safe_content_prefix(cls, text: str) -> str:
+        """Hold back any tail that could grow into a sentinel."""
+        first_open = text.find(_BLOCK_OPEN)
+        if first_open >= 0:
+            return text[:first_open]
+        # A ``<|start|>`` whose ``<|message|>`` has not arrived is a
+        # channel header still in flight — hold from it so its plain-word
+        # bytes ("assistant to=x") cannot leak once tokens are stripped.
+        pending = text.rfind("<|start|>")
+        if pending >= 0 and "<|message|>" not in text[pending:]:
+            return text[:pending]
+        # Same for the IMPLICIT first-segment header: while the entire
+        # output is still a growing `` to=recipient`` (no ``<|message|>``
+        # yet), classification is impossible and emitting would leak
+        # header bytes as content. Once any non-header shape appears the
+        # rule stops matching and normal emission resumes.
+        if "<|message|>" not in text and re.fullmatch(r"\s?(?:t|to|to=\S*)?", text):
+            return ""
+        max_hold = 0
+        for sentinel in _STREAMING_SENTINELS:
+            for length in range(min(len(text), len(sentinel) - 1), 0, -1):
+                if text.endswith(sentinel[:length]):
+                    max_hold = max(max_hold, length)
+                    break
+        return text if max_hold == 0 else text[: len(text) - max_hold]
+
+    def has_pending_tool_call(self, text: str) -> bool:
+        return _BLOCK_OPEN in text or self._safe_content_prefix(text) != text
+
+    def flush_held_content(self, full_text: str) -> str:
+        if _BLOCK_OPEN in full_text:
+            return ""
+        return full_text[len(self._safe_content_prefix(full_text)) :]
+
+    def extract_tool_calls_streaming(
+        self,
+        previous_text: str,
+        current_text: str,
+        delta_text: str,
+        previous_token_ids: Sequence[int] | None = None,
+        current_token_ids: Sequence[int] | None = None,
+        delta_token_ids: Sequence[int] | None = None,
+        request: dict[str, Any] | None = None,
+    ) -> dict[str, Any] | None:
+        if not hasattr(self, "_stream_calls_emitted"):
+            self.reset()
+
+        # A block close just completed — surface any not-yet-emitted calls.
+        prev_closes = previous_text.count(_BLOCK_CLOSE)
+        curr_closes = current_text.count(_BLOCK_CLOSE)
+        if curr_closes > prev_closes:
+            result = self.extract_tool_calls(current_text, request)
+            if result.tools_called:
+                fresh = result.tool_calls[self._stream_calls_emitted :]
+                if fresh:
+                    offset = self._stream_calls_emitted
+                    self._stream_calls_emitted = len(result.tool_calls)
+                    return {
+                        "tool_calls": [
+                            {
+                                "index": offset + i,
+                                "id": call["id"],
+                                "type": "function",
+                                "function": {
+                                    "name": call["name"],
+                                    "arguments": call["arguments"],
+                                },
+                            }
+                            for i, call in enumerate(fresh)
+                        ]
+                    }
+            return None
+
+        # Inside (or before) a block: emit only channel-clean safe content.
+        if _BLOCK_OPEN in current_text:
+            return None
+        prev_safe = _strip_channel_plumbing(self._safe_content_prefix(previous_text))
+        curr_safe = _strip_channel_plumbing(self._safe_content_prefix(current_text))
+        if len(curr_safe) > len(prev_safe):
+            return {"content": curr_safe[len(prev_safe) :]}
+        return None

--- a/vllm_mlx/tool_parsers/muse_tool_parser.py
+++ b/vllm_mlx/tool_parsers/muse_tool_parser.py
@@ -20,16 +20,25 @@ template (``chat_template.jinja`` on the HF repo):
   request's tool schema, not from the wire.
 * The template itself warns: "The output is not expected to be valid
   XML and is parsed with regular expressions." A string value may
-  therefore contain XML-ish text, including a literal
-  ``</atem:parameter>`` — the same delimiter-ambiguity class as the
-  Qwen3-Coder fixes in #1730. Two defenses here: a parameter's value
-  runs to the LAST closer before the next opener (not the first), and
-  when the request declares the tool's parameter names, an opener whose
-  name is not declared is treated as literal value text
-  (``declared_parameter_names``, same rationale as the qwen scanner).
-* The tool name is duplicated in the channel header (``to=NAME``) and
-  the invoke tag; the invoke tag is authoritative — the header is
-  routing plumbing and is stripped with the other channel tokens.
+  therefore contain arbitrary XML-ish text — literal closers, literal
+  openers, whole fake structures (#1730's bug class, and the #44
+  injection-surface concern).
+
+The defense is a POSITIONAL structural scan, not substring counting: a
+closing tag only closes a structure when the text after it (skipping
+whitespace) is a legal continuation of the grammar — the next opener,
+the enclosing structure's closer, or end of input. Structural tags
+INSIDE a parameter value are never examined, because the scanner is in
+the value state until a boundary-valid closer appears. This is the
+same "canonical closing line" discipline the Qwen3-Coder series
+converged on. The residual ambiguity (a value whose literal text ends
+with a boundary-valid closer sequence) is irreducible on this wire;
+the failure mode is always "unparseable stays visible content", never
+a wrong or truncated executable call.
+
+The tool name is duplicated in the channel header (``to=NAME``) and
+the invoke tag; the invoke tag is authoritative — the header is
+routing plumbing and is stripped with the other channel tokens.
 
 The companion ``MuseReasoningParser`` routes ``to=self`` segments to
 ``reasoning_content`` BEFORE this parser sees the stream, so on the
@@ -41,6 +50,7 @@ blocks. It still strips channel tokens itself so that standalone use
 from __future__ import annotations
 
 import json
+import math
 import re
 import uuid
 from collections.abc import Sequence
@@ -56,10 +66,11 @@ from .abstract_tool_parser import (
 _BLOCK_OPEN = "<atem:function_calls>"
 _BLOCK_CLOSE = "</atem:function_calls>"
 _PARAM_CLOSE = "</atem:parameter>"
+_INVOKE_CLOSE = "</atem:invoke>"
 
 _INVOKE_OPEN_RE = re.compile(r'<atem:invoke\s+name="(?P<name>[^"]+)">')
-_INVOKE_CLOSE = "</atem:invoke>"
 _PARAM_OPEN_RE = re.compile(r'<atem:parameter\s+name="(?P<name>[^"]+)">')
+_WS_RE = re.compile(r"[ \t\r\n]*")
 
 # Muse channel plumbing (Harmony-flavored, but a distinct token set:
 # <|eot|>/<|eom|> terminators instead of <|end|>/<|return|>/<|call|>,
@@ -86,87 +97,106 @@ _STREAMING_SENTINELS: tuple[str, ...] = (
     "<|eom|>",
 )
 
+# A completed block: (start_offset, end_offset, invokes) where invokes
+# is [(tool_name, [(param_name, raw_value), ...]), ...].
+_Block = tuple[int, int, list[tuple[str, list[tuple[str, str]]]]]
+
 
 def _generate_tool_id() -> str:
     return f"call_{uuid.uuid4().hex[:8]}"
 
 
-def _completed_blocks(text: str) -> list[tuple[int, int, str]]:
-    """``(start, end, body)`` for each completed ATEM block, in order.
+def _walk_invoke(
+    text: str, opener: re.Match[str]
+) -> tuple[str, list[tuple[str, str]], int] | None:
+    """Walk one invoke starting at ``opener``; None if malformed/incomplete.
 
-    A block's close is the first ``</atem:function_calls>`` at which the
-    body's invoke structure is BALANCED (opens <= closes). A literal
-    block closer inside a parameter value sits between an
-    ``<atem:invoke`` and its ``</atem:invoke>``, leaves the count
-    unbalanced, and is skipped over instead of truncating the real call
-    (codex r3 #1 — the block-level twin of the parameter scan's
-    last-closer rule).
-
-    Prefix-stable: whether a block is complete, and where it closes,
-    depends only on text up to that close — so as a stream grows,
-    already-completed blocks never change. The streaming path's
-    ``_stream_blocks_emitted`` cursor relies on this.
+    Positional grammar walk: after the invoke opener, the only legal
+    tokens (whitespace-separated) are parameter openers and the invoke
+    closer. Inside a parameter value, NOTHING is structural until a
+    ``</atem:parameter>`` whose lookahead is a legal continuation — the
+    next parameter opener, the invoke closer, or end of input. Literal
+    tags inside values are therefore never mistaken for structure
+    (codex r4 #3 / r5 #1–#3), and a parameter that never closes makes
+    the whole invoke unparseable rather than an executable call with a
+    truncated value.
     """
-    blocks: list[tuple[int, int, str]] = []
+    params: list[tuple[str, str]] = []
+    cursor = opener.end()
+    while True:
+        j = _WS_RE.match(text, cursor).end()
+        pm = _PARAM_OPEN_RE.match(text, j)
+        if pm is not None:
+            value_start = pm.end()
+            pos = value_start
+            closed = False
+            while True:
+                idx = text.find(_PARAM_CLOSE, pos)
+                if idx < 0:
+                    break
+                after = idx + len(_PARAM_CLOSE)
+                k = _WS_RE.match(text, after).end()
+                if (
+                    k >= len(text)
+                    or _PARAM_OPEN_RE.match(text, k) is not None
+                    or text.startswith(_INVOKE_CLOSE, k)
+                ):
+                    params.append((pm.group("name"), text[value_start:idx]))
+                    cursor = after
+                    closed = True
+                    break
+                pos = after
+            if not closed:
+                return None
+            continue
+        if text.startswith(_INVOKE_CLOSE, j):
+            return (opener.group("name"), params, j + len(_INVOKE_CLOSE))
+        # Unexpected bytes (or end of input) inside the invoke.
+        return None
+
+
+def _completed_blocks(text: str) -> list[_Block]:
+    """Every completed, structurally valid ATEM block in ``text``.
+
+    Prefix-stable: a completed block's geometry depends only on the
+    bytes up to its close (every lookahead that validated a closer is
+    internal to the block once the block close itself validates), so as
+    a stream grows, already-completed blocks never change. The
+    streaming path's ``_stream_blocks_emitted`` cursor relies on this.
+
+    A block whose interior fails the walk is treated as in-flight /
+    malformed: scanning stops at its opener, and the bytes surface as
+    visible content instead of calls.
+    """
+    blocks: list[_Block] = []
     pos = 0
     while True:
         open_idx = text.find(_BLOCK_OPEN, pos)
         if open_idx < 0:
             break
-        body_start = open_idx + len(_BLOCK_OPEN)
-        search = body_start
-        close_idx = -1
+        invokes: list[tuple[str, list[tuple[str, str]]]] = []
+        cursor = open_idx + len(_BLOCK_OPEN)
+        completed = False
         while True:
-            candidate = text.find(_BLOCK_CLOSE, search)
-            if candidate < 0:
+            j = _WS_RE.match(text, cursor).end()
+            im = _INVOKE_OPEN_RE.match(text, j)
+            if im is not None:
+                walked = _walk_invoke(text, im)
+                if walked is None:
+                    break
+                name, params, end = walked
+                invokes.append((name, params))
+                cursor = end
+                continue
+            if text.startswith(_BLOCK_CLOSE, j):
+                blocks.append((open_idx, j + len(_BLOCK_CLOSE), invokes))
+                pos = j + len(_BLOCK_CLOSE)
+                completed = True
                 break
-            body = text[body_start:candidate]
-            if body.count("<atem:invoke") <= body.count("</atem:invoke>"):
-                close_idx = candidate
-                break
-            search = candidate + len(_BLOCK_CLOSE)
-        if close_idx < 0:
             break
-        end = close_idx + len(_BLOCK_CLOSE)
-        blocks.append((open_idx, end, text[body_start:close_idx]))
-        pos = end
+        if not completed:
+            break
     return blocks
-
-
-def _scan_invokes(body: str) -> list[tuple[str, str]]:
-    """``(name, inner)`` for each invoke in a block body.
-
-    An invoke's close is the first ``</atem:invoke>`` at which the
-    inner PARAMETER structure is balanced — a literal invoke closer
-    inside a parameter value sits between that parameter's opener and
-    closer, leaves the count unbalanced, and is skipped (codex r4 #3;
-    same rule one level down from ``_completed_blocks``). The rule errs
-    toward "unparseable stays content": a truly unbalanced body yields
-    no invoke rather than a wrong call.
-    """
-    out: list[tuple[str, str]] = []
-    pos = 0
-    while True:
-        opener = _INVOKE_OPEN_RE.search(body, pos)
-        if opener is None:
-            break
-        inner_start = opener.end()
-        search = inner_start
-        close_idx = -1
-        while True:
-            candidate = body.find(_INVOKE_CLOSE, search)
-            if candidate < 0:
-                break
-            inner = body[inner_start:candidate]
-            if inner.count("<atem:parameter") <= inner.count("</atem:parameter>"):
-                close_idx = candidate
-                break
-            search = candidate + len(_INVOKE_CLOSE)
-        if close_idx < 0:
-            break
-        out.append((opener.group("name"), body[inner_start:close_idx]))
-        pos = close_idx + len(_INVOKE_CLOSE)
-    return out
 
 
 def _allows_null(cfg: Any) -> bool:
@@ -235,10 +265,12 @@ def _convert_param_value(raw: str, param_name: str, props: dict) -> Any:
     * declared string  -> raw, verbatim (whitespace preserved — the
       template says so explicitly, and #1444's ``_decode_json_like``
       whitespace-eating bug is the cautionary tale);
-    * declared boolean/integer/number -> parsed scalar (raw on failure,
-      so strict schema validation downstream rejects it visibly);
+    * declared boolean/integer/number -> parsed scalar (raw on failure
+      or non-finite floats, so strict schema validation downstream
+      rejects it visibly and ``json.dumps`` never emits NaN/Infinity
+      tokens — codex r4 #1 / r5 #4);
     * declared object/array -> ``json.loads`` (raw on failure);
-    * ``null`` for a nullable non-string -> None;
+    * ``null`` -> None only when the schema explicitly permits null;
     * undeclared/unknown -> JSON only when it unambiguously parses to a
       container (the template only emits JSON for containers); any other
       shape stays a raw string. A bare ``5`` or ``true`` with no schema
@@ -249,10 +281,6 @@ def _convert_param_value(raw: str, param_name: str, props: dict) -> Any:
     if declared == "string":
         return raw
     if raw == "null" and _allows_null(cfg):
-        # Only when the schema PERMITS null (codex r4 #1): a bare
-        # ``null`` against a non-nullable type stays the raw string so
-        # downstream strict validation rejects it visibly instead of
-        # receiving a silently-forged None.
         return None
     if declared == "boolean":
         if raw in ("true", "false"):
@@ -265,9 +293,10 @@ def _convert_param_value(raw: str, param_name: str, props: dict) -> Any:
             return raw
     if declared == "number":
         try:
-            return float(raw)
+            value = float(raw)
         except ValueError:
             return raw
+        return value if math.isfinite(value) else raw
     if declared in ("object", "array"):
         try:
             return json.loads(raw)
@@ -281,41 +310,6 @@ def _convert_param_value(raw: str, param_name: str, props: dict) -> Any:
         except json.JSONDecodeError:
             return raw
     return raw
-
-
-def _scan_parameters(body: str, declared: set[str] | None) -> list[tuple[str, str]]:
-    """Extract ``(name, raw_value)`` pairs from an invoke body.
-
-    A value runs from its opener to the LAST ``</atem:parameter>``
-    before the next accepted opener (or the body end). Combined with
-    the declared-name filter, this survives values that contain a
-    literal closer or an XML-ish fake opener — the wire is genuinely
-    ambiguous there (the template says regex, not XML), and the schema
-    is the only disambiguator, exactly as in the qwen scanner.
-    """
-    openers: list[re.Match[str]] = []
-    seen: set[str] = set()
-    for m in _PARAM_OPEN_RE.finditer(body):
-        name = m.group("name")
-        if declared is not None and name not in declared:
-            continue
-        if name in seen:
-            # The template emits each parameter at most once, so a
-            # SECOND opener with the same name is value text — without
-            # this, a fake opener reusing a declared name would
-            # overwrite the real value (codex r4 #2). Its bytes stay in
-            # the current segment and the last-closer rule keeps them.
-            continue
-        seen.add(name)
-        openers.append(m)
-    params: list[tuple[str, str]] = []
-    for i, m in enumerate(openers):
-        seg_end = openers[i + 1].start() if i + 1 < len(openers) else len(body)
-        segment = body[m.end() : seg_end]
-        close = segment.rfind(_PARAM_CLOSE)
-        value = segment[:close] if close >= 0 else segment
-        params.append((m.group("name"), value))
-    return params
 
 
 def _strip_channel_plumbing(text: str) -> str:
@@ -353,23 +347,28 @@ class MuseToolParser(ToolParser):
         self._content_emitted = 0
 
     @staticmethod
-    def _parse_block(body: str, request: dict[str, Any] | None) -> list[dict[str, str]]:
-        """Parse the invokes of ONE completed block body.
+    def _convert_invokes(
+        invokes: list[tuple[str, list[tuple[str, str]]]],
+        request: dict[str, Any] | None,
+    ) -> list[dict[str, str]]:
+        """Turn structurally captured invokes into wire tool calls.
 
-        Scoping the invoke scan to completed block bodies (rather than the
-        whole response) is load-bearing: invoke-shaped text OUTSIDE a
-        block — the model quoting an example, documentation in prose —
-        must stay literal content, never become an executable call
-        (codex r1 BLOCKING #2; the #44 injection-surface concern).
+        The declared-name filter drops parameters the tool's schema does
+        not declare (#1551's ambiguity class); a duplicated name keeps
+        the FIRST occurrence so later text can never overwrite an
+        already-captured value (codex r4 #2).
         """
         calls: list[dict[str, str]] = []
-        for name, inner in _scan_invokes(body):
+        for name, params in invokes:
             props = _schema_properties(name, request)
             declared = declared_parameter_names(name, request)
-            arguments = {
-                pname: _convert_param_value(raw, pname, props)
-                for pname, raw in _scan_parameters(inner, declared)
-            }
+            arguments: dict[str, Any] = {}
+            for pname, raw in params:
+                if declared is not None and pname not in declared:
+                    continue
+                if pname in arguments:
+                    continue
+                arguments[pname] = _convert_param_value(raw, pname, props)
             calls.append(
                 {
                     "id": _generate_tool_id(),
@@ -388,8 +387,8 @@ class MuseToolParser(ToolParser):
     ) -> ExtractedToolCallInformation:
         calls = [
             call
-            for _, _, body in _completed_blocks(model_output)
-            for call in self._parse_block(body, request)
+            for _, _, invokes in _completed_blocks(model_output)
+            for call in self._convert_invokes(invokes, request)
         ]
         # One content rule for BOTH modes (codex r2 #2, r3 #2): the
         # ``hold_tail=False`` visible view — parseable blocks removed,
@@ -406,28 +405,26 @@ class MuseToolParser(ToolParser):
     def _visible_content(cls, text: str, *, hold_tail: bool = True) -> str:
         """Channel-clean content emittable for ``text`` so far.
 
-        Completed ATEM blocks are removed (their calls surface on the
-        tool_calls channel), the region from any UNMATCHED opener on is
-        held, and — when ``hold_tail`` — the usual in-flight holds apply:
-        a growing channel header and partial sentinels. Content between
-        and after blocks therefore streams normally instead of being
-        swallowed once the first opener appears (codex r1 BLOCKING #1).
+        Completed blocks WITH invokes are removed (their calls surface
+        on the tool_calls channel); a completed block with none is model
+        output the client must see (codex r3 #2). The region from any
+        unconsumed opener on is held while the stream runs, and — when
+        ``hold_tail`` — the usual in-flight holds apply: a growing
+        channel header and partial sentinels. Content between and after
+        blocks therefore streams normally (codex r1 #1).
 
         Monotonic in ``text`` by construction: completed blocks are
         prefix-stable (see ``_completed_blocks``), a parseable block's
-        removal never exposes earlier bytes, and a malformed block's
-        bytes appear in one piece at its close. That is what lets
-        callers emit from an absolute cursor.
+        removal never exposes earlier bytes, and an empty block's bytes
+        appear in one piece at its close. That is what lets callers
+        emit from an absolute cursor.
         """
         blocks = _completed_blocks(text)
         pieces: list[str] = []
         pos = 0
-        for start, end, body in blocks:
+        for start, end, invokes in blocks:
             pieces.append(text[pos:start])
-            if not _scan_invokes(body):
-                # Completed but malformed — no parseable invoke, so the
-                # bytes are model output the client must see (codex r3
-                # #2; non-stream applies the identical rule above).
+            if not invokes:
                 pieces.append(text[start:end])
             pos = end
         tail = text[pos:]
@@ -517,8 +514,8 @@ class MuseToolParser(ToolParser):
             self._stream_blocks_emitted = len(blocks)
             fresh = [
                 call
-                for _, _, body in new_blocks
-                for call in self._parse_block(body, request)
+                for _, _, invokes in new_blocks
+                for call in self._convert_invokes(invokes, request)
             ]
             if fresh:
                 offset = self._stream_calls_emitted


### PR DESCRIPTION
## Why

Meta released Muse Glimmer 30B today (2026-08-10, Apache 2.0) and pitched it directly at local agent workflows — its benchmark table targets Gemma4-31B and Qwen3.6-27B, and Ollama shipped day-0 support marketed at Claude Code/Codex local agents. Its tool-call wire is a format no existing parser handles: an Anthropic-style `<atem:function_calls>` XML block routed over Harmony-style channels (`<|start|>assistant to=…<|message|>…<|eot|>`), with reasoning on a `to=self` channel. Landing the parsers now means we work the day mlx-lm ships the `muse_glimmer` architecture (not on their `main` yet; Meta says MLX integration lands "in the coming days").

## What

- **`MuseToolParser`** (`--tool-call-parser muse`, wire label `muse_atem`): schema-typed bare-string/JSON-container values per the model's own `chat_template.jinja`. The template warns its output "is not expected to be valid XML", so parsing is a **positional structural scan** — a closer only closes when its lookahead is a legal grammar continuation, and nothing inside a parameter value is structural. Literal openers/closers of every level survive in values; every irreducible ambiguity degrades to visible content, never a wrong or truncated call. In-flight scan distinguishes INCOMPLETE (hold) from MALFORMED (resume; bytes stay content), with canonical-byte openers so the two classifiers stay prefix-stable under streaming.
- **`MuseReasoningParser`**: `to=self` → `reasoning_content`; tool/user segments → content with the ATEM block passing through (harmony division of labor). Stateless per-delta phase detection; holds in-flight headers, partial sentinels, and undecidable trailing terminators; `finalize_streaming` releases holds at end of stream. Literal channel tokens mid-prose survive in both modes.
- `model_auto_config` pattern for `muse[-_]glimmer` HF paths; parity fixture; **54 dedicated tests**, stream + non-stream, mostly per-character.

## Deliberately NOT in this PR

- **Aliases are deferred** (codex r6): publishing `muse-glimmer-30b-*` before mlx-lm can load the arch would list a model that downloads ~20 GB then fails at startup (the #1603/#1729 class). A follow-up re-adds them with an e2e smoke against real weights once upstream lands. Until then, an upgraded mlx-lm + explicit HF path picks the parsers up via auto-config.
- DFlash drafter wiring (`supports_dflash`) and the multimodal perception encoder — follow-ups after e2e.

## Verification

- `tests/test_muse_parsers.py`: **54 passed**; affected suites (wire-formats, streaming parity, `tests/parsers/`, alias contract, postprocessor): **3026 passed, 1 skipped, 6 xfailed** on the mlx-free lane (py3.14).
- `ruff format` + `ruff check` clean.
- **7 rounds of adversarial codex review** (gpt-5.6-sol via pr_validate), all substantive findings fixed with regression tests pinning each one; the only standing decline is per-delta full-rescan cost, which is the deliberate repo-wide stateless-parser pattern (gpt-oss/DSML/harmony) — codex itself downgraded it to NIT.
- **Not verified**: end-to-end generation — blocked on mlx-lm's `muse_glimmer` support. Wire shapes are pinned against the HF repo's `chat_template.jinja`; must be re-verified against real model output before the aliases ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)