### PR TITLE
fix(mac): reconcile updater and image cache state

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/RapidApp.swift
+++ b/apps/rapid-mac/Sources/Rapid/RapidApp.swift
@@ -168,7 +168,25 @@ struct RapidApp: App {
         _mcpTools = State(initialValue: mcpRegistry)
 
         let chat = ChatViewModel(tools: toolRegistry, sampling: samplingConfig, server: manager)
-        let updateChecker = UpdateChecker()
+        let updateChecker: UpdateChecker
+        if ProcessInfo.processInfo.environment["RAPID_GUI_UPDATE_CURRENT"] == "1" {
+            // Deterministic GUI-golden fixture: exercise the restored update
+            // window while the published release equals the running build.
+            // Production launches never set this harness-only variable.
+            let current = UpdateChecker.bundleVersion()
+            let fixture = UpdateChecker.Release(
+                schemaVersion: 1,
+                version: current,
+                tagName: "rapid-mac-v\(current)",
+                htmlURL: "https://github.com/machinefi/rapid-desktop/releases/tag/rapid-mac-v\(current)",
+                notes: "",
+                publishedAt: "2026-08-10T00:00:00Z",
+                dmgURL: "https://dl.rapidmlx.com/rapid-mac/\(current)/rapid-mlx-desktop.dmg"
+            )
+            updateChecker = UpdateChecker(currentVersion: current) { fixture }
+        } else {
+            updateChecker = UpdateChecker()
+        }
         let installerInstance = Installer()
         let downloadsInstance = DownloadManager(binaryPath: manager.binaryPath)
         // #253: let ``ServerManager.start(alias:)`` await any in-flight
@@ -253,6 +271,9 @@ struct RapidApp: App {
                         settingsRouter.route(to: category) {
                             openWindow(id: "settings")
                         }
+                    }
+                    if ProcessInfo.processInfo.environment["RAPID_GUI_OPEN_UPDATE_WINDOW"] == "1" {
+                        openWindow(id: "update-install")
                     }
                 }
                 .task {

--- a/apps/rapid-mac/Sources/Rapid/Server/ModelCatalog.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ModelCatalog.swift
@@ -341,6 +341,17 @@ enum ModelCatalog {
         )
         let rows = parseImageRows(await modelsOut)
         let cachedRepos = Set((await cachedTask).compactMap { $0.1 })
+        return mergeImageRows(rows, cachedRepos: cachedRepos)
+    }
+
+    /// Join the engine's image catalog to its runnable-cache view. Keeping
+    /// this seam pure pins the cross-process contract: component-layout
+    /// mflux snapshots reported by `rapid-mlx ls` must reach the Images UI as
+    /// cached even though they intentionally have no root `config.json`.
+    static func mergeImageRows(
+        _ rows: [(alias: String, hfRepo: String?, size: String?)],
+        cachedRepos: Set<String>
+    ) -> [ModelEntry] {
         return rows.map { row in
             ModelEntry(
                 alias: row.alias,

--- a/apps/rapid-mac/Sources/Rapid/UI/UpdateInstallView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/UpdateInstallView.swift
@@ -21,6 +21,13 @@ import SwiftUI
 /// surrounding chrome, the in-app path is primary and the browser
 /// fallback is one click away on every state.
 struct UpdateInstallView: View {
+    enum Presentation: Equatable {
+        case update(UpdateChecker.Release)
+        case checking
+        case upToDate
+        case unavailable(String?)
+    }
+
     @Environment(UpdateChecker.self) private var updater
     @Environment(Installer.self) private var installer
     @Environment(\.dismissWindow) private var dismissWindow
@@ -48,14 +55,23 @@ struct UpdateInstallView: View {
                 .font(.system(size: 28, weight: .regular))
                 .foregroundStyle(.tint)
             VStack(alignment: .leading, spacing: 2) {
-                Text("A new version of Rapid-MLX is available")
+                Text(headerTitle)
                     .font(.headline)
-                if let release = updater.availableUpdate {
+                    .accessibilityIdentifier("UpdateInstall.Title")
+                if case .update(let release) = presentation {
                     Text("Rapid-MLX v\(release.version) — you have v\(updater.currentVersion)")
                         .font(.subheadline)
                         .foregroundStyle(.secondary)
-                } else {
+                } else if presentation == .upToDate {
                     Text("You're already on the latest version (v\(updater.currentVersion)).")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                } else if presentation == .checking {
+                    Text("Checking the update channel…")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                } else {
+                    Text("Update information isn't available right now.")
                         .font(.subheadline)
                         .foregroundStyle(.secondary)
                 }
@@ -66,14 +82,26 @@ struct UpdateInstallView: View {
 
     @ViewBuilder
     private var releaseNotes: some View {
-        if let release = updater.availableUpdate,
+        if case .update(let release) = presentation,
            !release.notes.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             // Render the CHANGELOG Markdown properly instead of dumping
             // raw ``##`` / ``-`` / ``**`` characters (pre-v0.8.18 the
             // bare ``Text(release.notes)`` showed the literal source).
             ReleaseNotesMarkdown(raw: release.notes)
-        } else {
+        } else if case .update = presentation {
             Text("No release notes provided.")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+        } else if presentation == .upToDate {
+            Text("Rapid-MLX is up to date. We'll let you know when a newer version is ready.")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .accessibilityIdentifier("UpdateInstall.UpToDate")
+        } else if presentation == .checking {
+            ProgressView("Checking for updates…")
+                .controlSize(.small)
+        } else if case .unavailable(let message) = presentation {
+            Text(message ?? "Check your connection and try again.")
                 .font(.callout)
                 .foregroundStyle(.secondary)
         }
@@ -102,6 +130,26 @@ struct UpdateInstallView: View {
     }
 
     private var idleFooter: some View {
+        Group {
+            if case .update = presentation {
+                updateFooter
+            } else {
+                HStack {
+                    Spacer()
+                    Button("Close") { dismissWindow(id: "update-install") }
+                        .keyboardShortcut(.cancelAction)
+                        .accessibilityIdentifier("UpdateInstall.Close")
+                    Button(updater.checking ? "Checking…" : "Check Again") {
+                        Task { await updater.check() }
+                    }
+                    .disabled(updater.checking)
+                    .accessibilityIdentifier("UpdateInstall.CheckAgain")
+                }
+            }
+        }
+    }
+
+    private var updateFooter: some View {
         VStack(alignment: .trailing, spacing: 8) {
             HStack {
                 Button("Open release page") { openReleasePage() }
@@ -149,6 +197,36 @@ struct UpdateInstallView: View {
     static func displayProgress(_ progress: Double) -> Double {
         guard progress.isFinite else { return 0 }
         return min(max(progress, 0), 1)
+    }
+
+    static func resolvePresentation(
+        availableUpdate: UpdateChecker.Release?,
+        latest: UpdateChecker.Release?,
+        checking: Bool,
+        lastError: String?
+    ) -> Presentation {
+        if let availableUpdate { return .update(availableUpdate) }
+        if checking { return .checking }
+        if latest != nil { return .upToDate }
+        return .unavailable(lastError)
+    }
+
+    private var presentation: Presentation {
+        Self.resolvePresentation(
+            availableUpdate: updater.availableUpdate,
+            latest: updater.latest,
+            checking: updater.checking,
+            lastError: updater.lastError
+        )
+    }
+
+    private var headerTitle: String {
+        switch presentation {
+        case .update: "A new version of Rapid-MLX is available"
+        case .checking: "Checking for updates"
+        case .upToDate: "Rapid-MLX is up to date"
+        case .unavailable: "Unable to check for updates"
+        }
     }
 
     private func failedFooter(message: String) -> some View {

--- a/apps/rapid-mac/Tests/RapidTests/ImageCatalogTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ImageCatalogTests.swift
@@ -48,6 +48,21 @@ struct ImageCatalogTests {
         #expect(klein?.size == "4.3 GiB")
     }
 
+    @Test("complete mflux caches are marked downloaded in Images")
+    func mfluxCachesReachImagesAsDownloaded() {
+        let rows = ModelCatalog.parseImageRows(Self.sample)
+        let cached = ModelCatalog.mergeImageRows(
+            rows,
+            cachedRepos: [
+                "Runpod/FLUX.2-klein-4B-mflux-4bit",
+                "filipstrand/Z-Image-Turbo-mflux-4bit",
+            ]
+        )
+
+        #expect(cached.first { $0.alias == "flux2-klein-4b" }?.cached == true)
+        #expect(cached.first { $0.alias == "z-image-turbo" }?.cached == true)
+    }
+
     @Test("[image:gen] rows are excluded from the chat catalog")
     func imageRowsExcludedFromChat() {
         // hasNonChatKindTag now drops image alongside audio/video.

--- a/apps/rapid-mac/Tests/RapidTests/UpdateInstallPresentationTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/UpdateInstallPresentationTests.swift
@@ -1,0 +1,40 @@
+import Testing
+@testable import Rapid
+
+@MainActor
+@Suite("Update install presentation")
+struct UpdateInstallPresentationTests {
+    private func release(_ version: String) -> UpdateChecker.Release {
+        UpdateChecker.Release(
+            schemaVersion: 1,
+            version: version,
+            tagName: "rapid-mac-v\(version)",
+            htmlURL: "https://github.com/machinefi/rapid-desktop/releases/tag/rapid-mac-v\(version)",
+            notes: "notes",
+            publishedAt: "2026-08-10T00:00:00Z",
+            dmgURL: "https://dl.rapidmlx.com/rapid-mac/\(version)/rapid-mlx-desktop.dmg"
+        )
+    }
+
+    @Test("current release renders up-to-date, not an unavailable installer")
+    func currentReleaseIsCoherent() {
+        let current = release("0.12.8")
+        #expect(UpdateInstallView.resolvePresentation(
+            availableUpdate: nil,
+            latest: current,
+            checking: false,
+            lastError: nil
+        ) == .upToDate)
+    }
+
+    @Test("a newer release remains installable")
+    func newerReleaseWins() {
+        let newer = release("0.12.9")
+        #expect(UpdateInstallView.resolvePresentation(
+            availableUpdate: newer,
+            latest: newer,
+            checking: false,
+            lastError: nil
+        ) == .update(newer))
+    }
+}

--- a/apps/rapid-mac/docs/gui-golden-flows.md
+++ b/apps/rapid-mac/docs/gui-golden-flows.md
@@ -21,7 +21,9 @@ Rapid-MLX Desktop app without loading a real model.
 added after a release where every escaped defect landed on a surface no journey
 covered, and each one names the defect it would have caught:
 
-8. `update-state` — Settings → App must name the version the app actually is.
+8. `update-state` — Settings → App must name the version the app actually is;
+   a restored updater window on that same release must show one coherent
+   up-to-date state (no install CTA or false missing-DMG warning).
 9. `no-dead-controls` — every Settings panel must expose controls of its own.
 10. `catalog-integrity` — a model that cannot chat must never be offered as one.
     Now covers **image-gen** aliases too: `rapid-mlx models` tags them

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -1312,6 +1312,24 @@ flow_update_state() {
         || die "update panel ($state) says '$shown' but the app is $expected"
     log "  update state names the running version ($expected, via ${state##*.})"
     cleanup_persona
+
+    # Reproduce #636 directly: a restorable updater window can exist even
+    # when the fetched release equals the running build. It must render a
+    # coherent up-to-date state, never an update CTA plus a false missing-DMG
+    # diagnosis. The fixture makes this independent of the live channel.
+    start_persona update-window-current \
+        RAPID_GUI_UPDATE_CURRENT=1 RAPID_GUI_OPEN_UPDATE_WINDOW=1
+    wait_identifier UpdateInstall.UpToDate "$OUT/update-window-current.json"
+    local title
+    title="$(element_field "$OUT/update-window-current.json" UpdateInstall.Title value)"
+    [[ "$title" == "Rapid-MLX is up to date" ]] \
+        || die "current-release updater title is contradictory: '$title'"
+    ! jq -e '.data.ui_elements[]? | select(
+        ((.value // .label // "") | tostring | test("DMG not available|doesn.t ship a DMG"; "i"))
+    )' "$OUT/update-window-current.json" >/dev/null \
+        || die "current-release updater still reports a missing DMG"
+    log "  restored updater window renders one coherent up-to-date state"
+    cleanup_persona
 }
 
 flow_no_dead_controls() {


### PR DESCRIPTION
## What changed

- Make the updater window resolve explicit update/checking/up-to-date/unavailable presentations, so a restored window on the current release no longer claims both that an update exists and that its DMG is missing.
- Add a deterministic updater-window golden flow for the shipped-current-release state.
- Pin the Images catalog handoff from rapid-mlx ls to cached image entries for the complete mflux layouts used by flux2-klein-4b and z-image-turbo.

## Why

The updater heading, release-note fallback, and installer footer were independently keyed, so availableUpdate == nil produced an up-to-date subtitle beneath an unconditional update heading and an unconditional disabled installer. For Images, current main already teaches the engine cache scan (via #1788) that complete component-layout mflux snapshots are runnable; the mac layer lacked a regression contract proving those repos remain cached when joined into the Images picker.

## Validation

- swift build
- SKIP_SIDECAR=1 bash scripts/build.sh
- bash scripts/gui-golden-flows.sh --flow update-state
- pytest -q tests/test_cli_models.py -k cached_view_renders_complete_mflux_alias
- bash -n apps/rapid-mac/scripts/gui-golden-flows.sh
- git diff --check

Internal reports: machinefi/rapid-desktop#636, machinefi/rapid-desktop#637