### PR TITLE
fix(mac): install main-window close handling

### DIFF
--- a/.github/workflows/rapid-mac-ci.yml
+++ b/.github/workflows/rapid-mac-ci.yml
@@ -285,7 +285,7 @@ jobs:
       # than "golden flows failed". Each needs its own output directory: the
       # harness refuses to start on a non-empty one.
       #
-      # These four drive the app through `rapid-ax` alone (see
+      # These five drive the app through `rapid-ax` alone (see
       # `flow_requires_peekaboo` in the harness). Most other flows shell out to
       # peekaboo — a third-party install whose bridge socket comes from the
       # Peekaboo app rather than its CLI, with its own permission surface. The
@@ -319,6 +319,11 @@ jobs:
         run: ./scripts/gui-golden-flows.sh --flow image-generation
         env:
           RAPID_GUI_GOLDEN_OUT: ${{ runner.temp }}/golden/image-generation
+
+      - name: 'Golden flow: window-close-prompt'
+        run: ./scripts/gui-golden-flows.sh --flow window-close-prompt
+        env:
+          RAPID_GUI_GOLDEN_OUT: ${{ runner.temp }}/golden/window-close-prompt
 
       # The harness stops at the FIRST mismatched baseline and the job stops at
       # the first failing flow, so one red run reveals exactly one line. With 5

--- a/apps/rapid-mac/Sources/Rapid/RapidApp.swift
+++ b/apps/rapid-mac/Sources/Rapid/RapidApp.swift
@@ -453,6 +453,39 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// survive scene re-mount across hide/show cycles.
     var mainWindowCloseInterceptor: MainWindowCloseInterceptor?
 
+    /// Attach the AppKit-only main-window behaviours once SwiftUI has
+    /// materialised its concrete ``NSWindow``. Repeated accessor callbacks
+    /// are expected; installation is idempotent for the same window and is
+    /// repeated when SwiftUI creates a replacement after a normal close.
+    func attachMainWindow(_ window: NSWindow) {
+        let needsInstall = MainWindowCloseInterceptor.shouldReinstall(
+            currentAttachedWindow: mainWindowCloseInterceptor?.attachedWindow,
+            newWindow: window
+        )
+        guard let visibleFrame = window.screen?.visibleFrame ?? NSScreen.main?.visibleFrame else {
+            if needsInstall, let store = dockPromptStore {
+                mainWindowCloseInterceptor = MainWindowCloseInterceptor(window: window, store: store)
+            }
+            return
+        }
+
+        if needsInstall {
+            // Setting the name restores any saved frame synchronously. Clamp
+            // immediately afterwards so a monitor that was unplugged while
+            // the app was closed cannot strand the restored window.
+            window.setFrameAutosaveName("Rapid.MainWindow")
+            window.setFrame(WindowFrameClamp.clamp(frame: window.frame, to: visibleFrame), display: false)
+            if let store = dockPromptStore {
+                mainWindowCloseInterceptor = MainWindowCloseInterceptor(window: window, store: store)
+            }
+        } else if WindowFrameClamp.isStranded(frame: window.frame, in: visibleFrame) {
+            // The onboarding sheet can cause a later AppKit reposition after
+            // the initial autosave restore. Only fight genuinely stranded
+            // frames on repeat callbacks, preserving deliberate edge parking.
+            window.setFrame(WindowFrameClamp.clamp(frame: window.frame, to: visibleFrame), display: true)
+        }
+    }
+
     /// AppKit instantiates the delegate via the SwiftUI adaptor's
     /// `init()`. Returning the shared singleton on `init()` is not
     /// straightforward, so we let AppKit make its own instance and

--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -95,6 +95,16 @@ struct ContentView: View {
                 .frame(minWidth: 440, minHeight: Self.minWindowHeight)
                 .background(RapidTheme.surfaceCanvas)
         }
+        .background {
+            // Bridge the SwiftUI scene to the AppKit behaviours that need the
+            // concrete main NSWindow: close interception, frame autosave, and
+            // recovery from a display-layout change. This was documented as
+            // the installation point but had never been mounted (#1590).
+            WindowAccessor { window in
+                AppDelegate.shared.attachMainWindow(window)
+            }
+            .frame(width: 0, height: 0)
+        }
         .onChange(of: server.state) { _, newState in
             // #223: clear the download-prompt CTA the moment the server
             // moves out of ``.idle``.

--- a/apps/rapid-mac/Sources/Rapid/UI/SettingsView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SettingsView.swift
@@ -630,7 +630,7 @@ struct SettingsView: View {
                 VStack(alignment: .leading, spacing: 2) {
                     Text("Hide Dock icon when closing window")
                         .font(.callout.weight(.medium))
-                    Text("Closing the window flips Rapid-MLX to the menu bar. Re-open via the menu-bar icon. Turn off to keep the Dock icon visible after closing.")
+                    Text("On close, Rapid-MLX stays available from the menu bar. Turn off to keep the Dock icon visible; disabling takes effect immediately.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
                         .fixedSize(horizontal: false, vertical: true)
@@ -651,16 +651,17 @@ struct SettingsView: View {
 
     /// Bridges the ``DockVisibilityPromptStore`` choice into a
     /// ``Toggle``-shaped binding. Set true → ``.hideAlways``; set
-    /// false → ``.keepAlways``. Both flip the live ``NSApp``
-    /// activation policy via ``applyHide`` so the user sees the
-    /// effect immediately — the Dock icon comes or goes without
-    /// requiring a relaunch.
+    /// false → ``.keepAlways``. Enabling applies on the next close, matching
+    /// the control's label. Disabling restores the Dock icon immediately so
+    /// a currently menu-bar-only app never traps the user in accessory mode.
     private var hideDockOnCloseBinding: Binding<Bool> {
         Binding(
             get: { dockPromptStore.choice == .hideAlways },
             set: { newValue in
                 dockPromptStore.setHideOnClose(newValue)
-                DockVisibilityPromptStore.applyHide(newValue)
+                if !newValue {
+                    DockVisibilityPromptStore.applyHide(false)
+                }
             }
         )
     }

--- a/apps/rapid-mac/docs/gui-golden-flows.md
+++ b/apps/rapid-mac/docs/gui-golden-flows.md
@@ -41,6 +41,10 @@ covered, and each one names the defect it would have caught:
     the Chat composer, renders it in the user turn, and sends typed
     `text` + `image_url` content; the same composer keeps its attachment
     control visible but disabled for a text-only alias and rejects paste/drop.
+13. `window-close-prompt` — the first native main-window close reaches the
+    Dock-visibility prompt, exposes both decisions plus “Don't ask again”, and
+    choosing No completes a normal close. This pins the SwiftUI-to-NSWindow
+    installation seam that #1590 found entirely disconnected.
 
 The distinction matters. A journey answers *"can someone do this?"*; an
 invariant answers *"is this still true everywhere?"*. The three defects below

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -38,7 +38,7 @@ Usage: gui-golden-flows.sh [--flow NAME] [--keep] [--update-baselines]
 Flows: fresh-install, settings-persistence, chat-restore, restored-tools, tool-loop-budget, chat-depth,
        slow-stream-stop,
        model-crash-recovery, low-memory-choice,
-       update-state, no-dead-controls, catalog-integrity,
+       update-state, window-close-prompt, no-dead-controls, catalog-integrity,
        browse-all-destination, image-generation, all
 
 chat-restore, chat-depth, slow-stream-stop, model-crash-recovery,
@@ -99,7 +99,7 @@ flow_requires_screen_recording() {
 flow_requires_peekaboo() {
     case "$FLOW" in
         chat-restore|restored-tools|tool-loop-budget|chat-depth) return 1 ;;
-        slow-stream-stop|model-crash-recovery|image-generation) return 1 ;;
+        slow-stream-stop|model-crash-recovery|image-generation|window-close-prompt) return 1 ;;
         *) return 0 ;;
     esac
 }
@@ -1332,6 +1332,39 @@ flow_update_state() {
     cleanup_persona
 }
 
+flow_window_close_prompt() {
+    # #1590: the prompt, persistence store and delegate proxy all existed, but
+    # no WindowAccessor ever attached the proxy to the real main NSWindow.
+    start_persona window-close-prompt
+    dismiss_first_run
+
+    # AXPress blocks while NSAlert.runModal is active, so issue the native
+    # close in the background, observe/answer the sheet from a second driver,
+    # then require the original close action to finish successfully.
+    "$AX_DRIVER" close-window "$APP_PID" Rapid-MLX > "$OUT/close-window.json" 2> "$OUT/close-window.err" &
+    local close_pid=$!
+    wait_identifier DockHidePrompt.NoButton "$OUT/dock-prompt.json"
+    jq -e '.data.ui_elements[]? | select(.identifier == "DockHidePrompt.YesButton")' \
+        "$OUT/dock-prompt.json" >/dev/null \
+        || die "first main-window close has no Yes choice"
+    jq -e '.data.ui_elements[]? | select(.identifier == "DockHidePrompt.DontAskCheckbox")' \
+        "$OUT/dock-prompt.json" >/dev/null \
+        || die "first main-window close has no Don.t ask again choice"
+    press "$OUT/dock-prompt.json" DockHidePrompt.NoButton "$OUT/dock-prompt-no.json"
+    wait "$close_pid" || die "native main-window close action failed: $(cat "$OUT/close-window.err")"
+
+    local probe=2
+    for _ in {1..40}; do
+        probe=0
+        ax_window_present Rapid-MLX "$OUT/after-close.json" || probe=$?
+        [[ "$probe" == 1 ]] && break
+        sleep 0.25
+    done
+    [[ "$probe" == 1 ]] || die "No choice did not close the main window normally"
+    log "  first main-window close presents and resolves the Dock prompt"
+    cleanup_persona
+}
+
 flow_no_dead_controls() {
     # Every advertised Settings control must do something observable.
     #
@@ -2009,6 +2042,7 @@ case "$FLOW" in
     model-crash-recovery) flow_model_crash_recovery ;;
     low-memory-choice) flow_low_memory_choice ;;
     update-state) flow_update_state ;;
+    window-close-prompt) flow_window_close_prompt ;;
     no-dead-controls) flow_no_dead_controls ;;
     catalog-integrity) flow_catalog_integrity ;;
     browse-all-destination) flow_browse_all_destination ;;
@@ -2024,6 +2058,7 @@ case "$FLOW" in
         flow_model_crash_recovery
         flow_low_memory_choice
         flow_update_state
+        flow_window_close_prompt
         flow_no_dead_controls
         flow_catalog_integrity
         flow_browse_all_destination

--- a/apps/rapid-mac/scripts/rapid-ax.swift
+++ b/apps/rapid-mac/scripts/rapid-ax.swift
@@ -1,6 +1,7 @@
 #!/usr/bin/env swift
 // Minimal native Accessibility driver for deterministic Rapid GUI journeys.
-// It deliberately exposes only semantic operations: dump, press and set-value.
+// It deliberately exposes only semantic operations: dump, press, set-value,
+// and closing a named native window through its AXCloseButton.
 import ApplicationServices
 import Foundation
 
@@ -109,7 +110,7 @@ if CommandLine.arguments.count >= 2, CommandLine.arguments[1] == "trust" {
 
 guard CommandLine.arguments.count >= 3,
       let pid = pid_t(CommandLine.arguments[2]) else {
-    fail("usage: rapid-ax <dump|press|set-value|trust> <pid> [identifier] [value]")
+    fail("usage: rapid-ax <dump|press|set-value|close-window|trust> <pid> [identifier-or-window-title] [value]")
 }
 
 let command = CommandLine.arguments[1]
@@ -265,6 +266,22 @@ if let rootChildren = attribute(application, kAXChildrenAttribute as CFString) a
 
 walk(application, depth: 0)
 elementWalkComplete = elementWalkComplete && windowListComplete
+
+if command == "close-window" {
+    guard let wanted else { fail("close-window requires a window title") }
+    guard let window = windowElements.first(where: {
+        string($0, kAXTitleAttribute as CFString) == wanted
+    }) else {
+        fail("window not found: \(wanted)")
+    }
+    guard let closeButton = attribute(window, kAXCloseButtonAttribute as CFString) else {
+        fail("window has no AXCloseButton: \(wanted)")
+    }
+    let result = AXUIElementPerformAction(closeButton as! AXUIElement, kAXPressAction as CFString)
+    guard result == .success else { fail("AXPress close window \(wanted) failed: \(result.rawValue)") }
+    print("{\"success\":true,\"window\":\"\(wanted)\",\"action\":\"close-window\"}")
+    exit(0)
+}
 
 if command == "dump" {
     let payload: [String: Any] = [

--- a/tests/test_gui_preflight_contract.py
+++ b/tests/test_gui_preflight_contract.py
@@ -94,6 +94,7 @@ def test_peekaboo_requirement_is_default_deny():
         "slow-stream-stop",
         "model-crash-recovery",
         "image-generation",
+        "window-close-prompt",
     }
     named = {
         flow


### PR DESCRIPTION
## What changed

- Mount the existing WindowAccessor in ContentView and attach the real main NSWindow to MainWindowCloseInterceptor.
- Restore the intended frame autosave and display-layout clamp at the same AppKit bridge.
- Make the Hide Dock icon toggle apply enabling on the next close while still restoring the Dock immediately when disabled.
- Extend the native AX driver with a semantic close-window action and add a CI golden journey for the first-close prompt.

## Why

The close interceptor, Dock prompt, persistence state machine, and frame clamp were implemented and unit-tested, but no production view ever mounted WindowAccessor. As a result the NSWindow delegate proxy was never installed, the first-close prompt was unreachable, reset-onboarding did nothing observable, and frame restoration never clamped against the active display.

Closes #1590.

## Validation

- swift build
- SKIP_SIDECAR=1 bash scripts/build.sh
- bash scripts/gui-golden-flows.sh --flow window-close-prompt
- swiftc scripts/rapid-ax.swift
- bash -n scripts/gui-golden-flows.sh
- git diff --check