### PR TITLE
fix(mllm): serve hybrid vision models through a serialized lane

### DIFF
--- a/tests/test_mllm_hybrid_probe.py
+++ b/tests/test_mllm_hybrid_probe.py
@@ -14,11 +14,13 @@ from __future__ import annotations
 import builtins
 from unittest.mock import MagicMock
 
+import mlx.core as mx
 import pytest
-from mlx_lm.models.cache import KVCache, RotatingKVCache
+from mlx_lm.models.cache import ArraysCache, KVCache, RotatingKVCache
 
-from vllm_mlx.engine.batched import _probe_mllm_cache_type
+from vllm_mlx.engine.batched import _probe_mllm_cache_type, _resolve_mllm_cache_policy
 from vllm_mlx.mllm_cache_compat import first_incompatible_mllm_cache_type
+from vllm_mlx.mllm_scheduler import MLLMSchedulerConfig
 
 
 class _FakeArraysCache:
@@ -30,6 +32,13 @@ class _FakeArraysCache:
 
 
 _FakeArraysCache.__name__ = "ArraysCache"
+
+
+class _FakeMambaCache:
+    pass
+
+
+_FakeMambaCache.__name__ = "MambaCache"
 
 
 def _model_with_cache(cache_obj):
@@ -90,6 +99,78 @@ def test_compatibility_check_inspects_every_cache_layer():
     assert (
         first_incompatible_mllm_cache_type([KVCache(), _FakeArraysCache()])
         == "ArraysCache"
+    )
+
+
+def test_arrayscache_is_accepted_only_for_serialized_compatibility():
+    """The runtime allowlist is explicit; startup probing stays fail-closed."""
+    cache = _FakeArraysCache()
+    assert first_incompatible_mllm_cache_type([cache]) == "ArraysCache"
+    # A name-only stand-in is deliberately not enough to enter the allowlist.
+    # Production accepts only mlx-lm's concrete ArraysCache class.
+    assert (
+        first_incompatible_mllm_cache_type([cache], allow_arrays_cache=True)
+        == "ArraysCache"
+    )
+
+    real_cache = ArraysCache(2)
+    assert (
+        first_incompatible_mllm_cache_type(
+            [KVCache(), real_cache], allow_arrays_cache=True
+        )
+        is None
+    )
+
+
+def test_arrayscache_scheduler_mode_requires_singleton_limits():
+    config = MLLMSchedulerConfig(
+        max_num_seqs=1,
+        prefill_batch_size=1,
+        completion_batch_size=1,
+        allow_arrays_cache=True,
+    )
+    assert config.allow_arrays_cache is True
+
+    with pytest.raises(ValueError, match="all be 1"):
+        MLLMSchedulerConfig(
+            max_num_seqs=2,
+            prefill_batch_size=1,
+            completion_batch_size=1,
+            allow_arrays_cache=True,
+        )
+
+
+def test_engine_policy_serializes_only_arrayscache():
+    assert _resolve_mllm_cache_policy("ArraysCache", 16, 8, 32) == (1, 1, 1, True)
+    assert _resolve_mllm_cache_policy(None, 16, 8, 32) == (16, 8, 32, False)
+    assert _resolve_mllm_cache_policy("MambaCache", 16, 8, 32) == (
+        16,
+        8,
+        32,
+        False,
+    )
+
+
+def test_arrayscache_singleton_primitives_preserve_recurrent_state():
+    """The admitted cache supports the lifecycle used by MLLMBatch."""
+    first = ArraysCache(2)
+    first[0] = mx.array([[1.0, 2.0]])
+    first[1] = mx.array([[3.0]])
+
+    merged = ArraysCache.merge([first])
+    assert merged.batch_size == 1
+    assert merged[0].tolist() == [[1.0, 2.0]]
+
+    merged.filter(mx.array([0], mx.int32))
+    extracted = merged.extract(0)
+    assert extracted.batch_size == 1
+    assert extracted[1].tolist() == [[3.0]]
+
+
+def test_serialized_mode_does_not_admit_other_hybrid_caches():
+    assert (
+        first_incompatible_mllm_cache_type([_FakeMambaCache()], allow_arrays_cache=True)
+        == "MambaCache"
     )
 
 

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -555,6 +555,18 @@ def _probe_mllm_cache_type(language_model: Any) -> str | None:
     return first_incompatible_mllm_cache_type(test_cache)
 
 
+def _resolve_mllm_cache_policy(
+    cache_type: str | None,
+    max_num_seqs: int,
+    prefill_batch_size: int,
+    completion_batch_size: int,
+) -> tuple[int, int, int, bool]:
+    """Return safe MLLM batch limits and ArraysCache admission policy."""
+    if cache_type == "ArraysCache":
+        return 1, 1, 1, True
+    return max_num_seqs, prefill_batch_size, completion_batch_size, False
+
+
 _CHANNEL_TO_STRING = {
     Channel.CONTENT: "content",
     Channel.REASONING: "reasoning",
@@ -1117,19 +1129,17 @@ class BatchedEngine(BaseEngine):
         self._model = self._mllm_instance.model
         self._processor = self._mllm_instance.processor
 
-        # Fail fast at startup if the language backbone is a hybrid model
-        # (linear-attention or recurrent layers, producing ArraysCache /
-        # MambaCache). MLLM continuous batching builds a BatchKVCache via
-        # KVCache.merge(), which requires standard KVCache or RotatingKVCache;
-        # otherwise the first request raises ValueError mid-prefill.
-        # Catching it now means a clear startup error instead of the user
-        # seeing "Batch generation failed" on their very first image request
-        # (GitHub #352, Qwen3.6-35B-A3B + --mllm).
+        # Probe the language-backbone cache before the port reports ready.
+        # ArraysCache has the merge/filter/extract primitives needed for a
+        # correctness-first serialized lane (#1796), but concurrent hybrid
+        # batching is intentionally not enabled. Mamba, quantized, and unknown
+        # cache types continue to fail at startup with the #352 diagnostic.
         language_model = getattr(self._model, "language_model", self._model)
         cache_type = self._model_load_executor.submit(
             _probe_mllm_cache_type, language_model
         ).result()
-        if cache_type is not None:
+        arrays_cache_compat = cache_type == "ArraysCache"
+        if cache_type is not None and not arrays_cache_compat:
             raise RuntimeError(
                 f"Model '{self._model_name}' uses a hybrid/linear-attention "
                 f"language backbone ({cache_type}), which is incompatible "
@@ -1152,6 +1162,23 @@ class BatchedEngine(BaseEngine):
         completion_batch_size = getattr(
             self._scheduler_config, "completion_batch_size", 32
         )
+        (
+            max_num_seqs,
+            prefill_batch_size,
+            completion_batch_size,
+            arrays_cache_compat,
+        ) = _resolve_mllm_cache_policy(
+            cache_type,
+            max_num_seqs,
+            prefill_batch_size,
+            completion_batch_size,
+        )
+        if arrays_cache_compat:
+            logger.warning(
+                "Model '%s' uses ArraysCache; enabling serialized hybrid MLLM "
+                "compatibility (one active request, additional requests queued).",
+                self._model_name,
+            )
         # ``prefill_step_size`` for MLLM is the per-request budget that
         # caps total prompt tokens (vision + text). See
         # ``_resolve_mllm_prefill_step_size`` for the bump-policy
@@ -1186,6 +1213,7 @@ class BatchedEngine(BaseEngine):
             enable_vision_cache=True,
             vision_cache_size=100,
             max_concurrent_requests=max_concurrent_requests,
+            allow_arrays_cache=arrays_cache_compat,
         )
 
         # Create and start MLLM scheduler — pass the model-owning executor so

--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -415,6 +415,7 @@ class MLLMBatchGenerator:
         sampler: Callable[[mx.array], mx.array] | None = None,
         prefill_batch_size: int = 4,  # Smaller for MLLM due to vision overhead
         completion_batch_size: int = 16,  # Can be larger for text generation
+        allow_arrays_cache: bool = False,
         prefill_step_size: int = 1024,
         enable_vision_cache: bool = True,
         vision_cache_size: int = 100,
@@ -431,6 +432,7 @@ class MLLMBatchGenerator:
             sampler: Sampling function (default: argmax)
             prefill_batch_size: Max requests to prefill together
             completion_batch_size: Max requests for completion batching
+            allow_arrays_cache: Permit mlx-lm ArraysCache in serialized mode
             prefill_step_size: Tokens to process per prefill step
             enable_vision_cache: Enable vision embedding caching
             vision_cache_size: Max entries in vision cache
@@ -460,6 +462,14 @@ class MLLMBatchGenerator:
 
         self.prefill_batch_size = prefill_batch_size
         self.completion_batch_size = max(completion_batch_size, prefill_batch_size)
+        self.allow_arrays_cache = allow_arrays_cache
+        if allow_arrays_cache and (
+            self.prefill_batch_size != 1 or self.completion_batch_size != 1
+        ):
+            raise ValueError(
+                "ArraysCache MLLM compatibility requires prefill and completion "
+                "batch sizes of 1"
+            )
         self.prefill_step_size = prefill_step_size
 
         # Request management
@@ -1095,13 +1105,12 @@ class MLLMBatchGenerator:
         # alignment, so all requests share a single batched cache for
         # subsequent generation steps.
         incompatible_cache_type = first_incompatible_mllm_cache_type(
-            per_request_caches[0]
+            per_request_caches[0], allow_arrays_cache=self.allow_arrays_cache
         )
         if incompatible_cache_type is not None:
             # Two distinct causes land here:
-            #   1. Hybrid/linear-attention backbone (ArraysCache /
-            #      MambaCache) — see GitHub #352. Should be caught at
-            #      startup by the probe in BatchedEngine._start_mllm.
+            #   1. A hybrid/linear-attention cache other than the explicitly
+            #      serialized ArraysCache lane — see GitHub #352/#1796.
             #   2. --kv-cache-quantization explicitly enabled on a
             #      non-hybrid MLLM.
             # Name both so the runtime message isn't misleading when

--- a/vllm_mlx/mllm_cache_compat.py
+++ b/vllm_mlx/mllm_cache_compat.py
@@ -5,18 +5,23 @@ from collections.abc import Iterable
 from typing import Any
 
 
-def first_incompatible_mllm_cache_type(caches: Iterable[Any]) -> str | None:
+def first_incompatible_mllm_cache_type(
+    caches: Iterable[Any], *, allow_arrays_cache: bool = False
+) -> str | None:
     """Return the first cache type that MLLM batching cannot merge.
 
     mlx-vlm 0.6.4 split its cache classes from mlx-lm's parallel classes.
     Models loaded by mlx-vlm therefore return native ``KVCache`` /
     ``RotatingKVCache`` instances that fail an mlx-lm-only ``isinstance``
     check despite exposing the supported batching API. Accept both namespaces
-    while continuing to reject ArraysCache, MambaCache, and quantized caches.
+    ``ArraysCache`` is accepted only for the explicitly serialized hybrid
+    compatibility lane. Mamba and quantized/unknown caches remain fail-closed.
     """
-    from mlx_lm.models.cache import KVCache, RotatingKVCache
+    from mlx_lm.models.cache import ArraysCache, KVCache, RotatingKVCache
 
     supported_types: tuple[type, ...] = (KVCache, RotatingKVCache)
+    if allow_arrays_cache:
+        supported_types += (ArraysCache,)
     try:
         from mlx_vlm.models import cache as vlm_cache
     except ImportError:

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -86,6 +86,20 @@ class MLLMSchedulerConfig:
     # prompt, not KV state). Operators who want admission tied to
     # ``max_num_seqs`` pass ``--max-concurrent-requests`` explicitly.
     max_concurrent_requests: int = 256
+    # Correctness-first compatibility lane for hybrid language backbones.
+    # This may only be enabled together with all three batch limits set to 1.
+    allow_arrays_cache: bool = False
+
+    def __post_init__(self) -> None:
+        if self.allow_arrays_cache and (
+            self.max_num_seqs != 1
+            or self.prefill_batch_size != 1
+            or self.completion_batch_size != 1
+        ):
+            raise ValueError(
+                "ArraysCache MLLM compatibility requires max_num_seqs, "
+                "prefill_batch_size, and completion_batch_size to all be 1"
+            )
 
 
 @dataclass
@@ -431,6 +445,7 @@ class MLLMScheduler:
                 sampler=sampler,
                 prefill_batch_size=self.config.prefill_batch_size,
                 completion_batch_size=self.config.completion_batch_size,
+                allow_arrays_cache=self.config.allow_arrays_cache,
                 prefill_step_size=self.config.prefill_step_size,
             )
 


### PR DESCRIPTION
## What

Allows explicit `--mllm` serving for vision models whose language backbone uses mlx-lm `ArraysCache`. These models now enter a correctness-first serialized lane: one active request, with additional admitted requests queued.

`MambaCache`, quantized cache types, and unknown cache implementations remain fail-closed. Standard KVCache/RotatingKVCache MLLM batching is unchanged.

Closes #1796.

## Why

Qwen3.5/Qwen3.6 hybrid vision checkpoints previously failed during application startup even though `ArraysCache` implements the merge/filter/extract lifecycle needed for singleton generation. Removing the guard alone would have exposed unqualified concurrent recurrent-state batching, so this change couples ArraysCache admission to hard singleton limits at the engine, scheduler-config, and batch-generator layers.

## Validation

- [x] 152 focused MLLM/cache/routing tests passed
- [x] Ruff check and format check passed on all changed files
- [x] Real `qwen3.5-9b-4bit --mllm` image request returned HTTP 200 and correctly identified the test logo
- [x] Two simultaneous image requests observed peak `num_running=1`, `num_waiting=1`, then both returned HTTP 200
- [x] Streaming client disconnect drained running/waiting to zero; a follow-up image request returned HTTP 200
- [x] Concrete ArraysCache merge/filter/extract state test included
- [x] Mamba/unknown caches remain rejected

The cached Qwen3.6-27B checkpoint was not loaded on this 18 GB machine because its projected working set exceeds physical RAM and the existing memory guard warns of kernel-panic risk. The same concrete ArraysCache compatibility path was qualified with the cached 9B hybrid VLM instead.

## Scope

Engine-only; no GUI changes or golden-flow coverage required.