### PR TITLE
Fix external model Swift test contracts

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/UI/SettingsModelManagementPanel.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SettingsModelManagementPanel.swift
@@ -1455,7 +1455,7 @@ enum RecommendedCardLayout {
     static let actionButtonTitles = ["Download", "Delete", "Cancel", "Retry"]
 
     /// Every status pill the same slot can render.
-    static let actionPillTitles = ["On disk", "In use", "Serving"]
+    static let actionPillTitles = ["On disk", "In use", "Serving", "External"]
 
     /// Intrinsic width of a small push-button with this title.
     static func buttonWidth(title: String) -> CGFloat {

--- a/apps/rapid-mac/Tests/RapidTests/ExternalModelCatalogTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ExternalModelCatalogTests.swift
@@ -221,11 +221,13 @@ struct ExternalModelCatalogTests {
             selected: root + "/."
         )
 
-        #expect(merged == "[\"/first\",\"\(canonical)\"]")
+        #expect(Self.decodeRoots(merged) == ["/first", canonical])
 
         let colonPath = root + ":archive"
-        #expect(ModelCatalog.mergedExtraModelRoots(existing: nil, selected: colonPath)
-            == "[\"\(colonPath)\"]")
+        #expect(Self.decodeRoots(ModelCatalog.mergedExtraModelRoots(
+            existing: nil,
+            selected: colonPath
+        )) == [colonPath])
     }
 
     @Test("Serve child receives the same external root used for discovery")
@@ -236,7 +238,12 @@ struct ExternalModelCatalogTests {
             modelsFolderOverride: "/selected"
         )
 
-        #expect(env[ModelCatalog.extraModelRootsEnvKey] == "[\"/ambient\",\"/selected\"]")
+        #expect(Self.decodeRoots(env[ModelCatalog.extraModelRootsEnvKey]) == ["/ambient", "/selected"])
         #expect(env["HF_HUB_CACHE"] == "/selected")
+    }
+
+    private static func decodeRoots(_ value: String?) -> [String]? {
+        guard let value else { return nil }
+        return try? JSONDecoder().decode([String].self, from: Data(value.utf8))
     }
 }

--- a/apps/rapid-mac/Tests/RapidTests/SpawnEnvAllowlistTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SpawnEnvAllowlistTests.swift
@@ -262,6 +262,7 @@ struct SpawnEnvAllowlistTests {
             "SSL_CERT_FILE", "SSL_CERT_DIR",
             "__CFBundleIdentifier", "XPC_SERVICE_NAME",
             "HF_HOME", "HF_HUB_CACHE", "XDG_CACHE_HOME",
+            "RAPID_MLX_EXTRA_MODEL_ROOTS",
             "HF_ENDPOINT", "HF_HUB_OFFLINE",
             "HF_HUB_DISABLE_TELEMETRY", "HF_HUB_ENABLE_HF_TRANSFER",
         ]


### PR DESCRIPTION
## Summary

Follow-up to #1785 restoring the Swift build gate on current `main`:

- compare `RAPID_MLX_EXTRA_MODEL_ROOTS` by decoding its JSON contract instead of comparing encoder-specific slash escaping
- include the new extra-roots key in the security-sensitive serve allowlist expectation
- include the new `External` card label in the measured action-column width set

## Reproduction

`swift test --no-parallel` on current main reports five issues across `ExternalModelCatalogTests`, `ModelSurfaceRedesignTests`, and `SpawnEnvAllowlistTests`. The product behavior is correct; the first and third failures are stale test contracts, while the label failure identifies a real width-measurement omission.

## Validation

- `swift build -c release`
- `git diff --check`
- full Swift suite in PR CI (local host has Command Line Tools only and no XCTest module)
