### PR TITLE
fix(mac): use cached models in isolated first run

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -475,6 +475,7 @@ struct ContentView: View {
             coordinator: quickstart,
             downloads: downloads,
             server: server,
+            cachedModels: catalogEntries,
             onSkip: { quickstartDismissedThisSession = true },
             onBrowseAll: { quickstartDismissedThisSession = true },
             onSeedWelcome: { true }

--- a/apps/rapid-mac/Sources/Rapid/UI/OnboardingComponents.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/OnboardingComponents.swift
@@ -261,6 +261,7 @@ struct QuickstartCompactCard: View {
     let choice: QuickstartModelChoice
     let selected: Bool
     let sizeText: String
+    var isCached: Bool = false
     let onTap: () -> Void
 
     private var accValue: String { ModelMeter.qualityMeter(for: choice.alias).formattedValue }
@@ -339,7 +340,11 @@ struct QuickstartCompactCard: View {
     private var accessibilityText: String {
         var parts = ["\(choice.displayName). \(choice.blurb)"]
         parts.append("Accuracy \(accValue), speed \(spdValue)")
-        if !sizeText.isEmpty { parts.append("download \(sizeText)") }
+        if isCached {
+            parts.append(sizeText.isEmpty ? "on disk" : "on disk \(sizeText)")
+        } else if !sizeText.isEmpty {
+            parts.append("download \(sizeText)")
+        }
         return parts.joined(separator: ". ")
     }
 

--- a/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
@@ -773,6 +773,11 @@ struct QuickstartView: View {
     @Bindable var downloads: DownloadManager
     @Bindable var server: ServerManager
 
+    /// Chat models the shared catalogue has positively identified on disk.
+    /// Quickstart used to ignore this snapshot and offered only a download
+    /// path even when the user's first model was already present (#1793).
+    var cachedModels: [ModelEntry] = []
+
     /// Callback the parent supplies for "Skip for now". The parent
     /// dismisses the Quickstart surface for the current session (without
     /// flipping the persisted flag) so the existing picker becomes visible.
@@ -1025,6 +1030,11 @@ struct QuickstartView: View {
     @ViewBuilder
     private var chooseModelStep: some View {
         let choices = QuickstartCoordinator.onboardingChoices
+        let existing = Array(Self.quickstartCachedModels(cachedModels).prefix(6))
+        let existingAliases = Set(existing.map(\.alias))
+        let starterChoices = choices.filter { $0.isStarter && !existingAliases.contains($0.alias) }
+        let lowMemoryChoices = choices.filter { $0.isLowMemory && !existingAliases.contains($0.alias) }
+        let tradeUpChoices = choices.filter { $0.tier == .tradeUp && !existingAliases.contains($0.alias) }
         VStack(alignment: .leading, spacing: 0) {
             OnboardingTopBar(step: 1).padding(.top, 22)
 
@@ -1037,7 +1047,28 @@ struct QuickstartView: View {
 
             ScrollView {
                 VStack(alignment: .leading, spacing: 0) {
-                    ForEach(choices.filter { $0.isStarter }) { choice in
+                    if !existing.isEmpty {
+                        Text("ALREADY ON THIS MAC")
+                            .scaledSystemFont(10, weight: .semibold).tracking(1)
+                            .foregroundStyle(.tertiary)
+                            .padding(.bottom, 9)
+
+                        VStack(spacing: 9) {
+                            ForEach(existing) { entry in
+                                let choice = Self.choice(forCachedModel: entry)
+                                QuickstartCompactCard(
+                                    choice: choice,
+                                    selected: coordinator.selection.alias == entry.alias,
+                                    sizeText: entry.sizeOnDisk ?? "",
+                                    isCached: true
+                                ) { coordinator.select(choice) }
+                                .accessibilityIdentifier("Quickstart.CachedModel.\(entry.alias)")
+                            }
+                        }
+                        .padding(.bottom, 16)
+                    }
+
+                    ForEach(starterChoices) { choice in
                         QuickstartRecommendedCard(
                             choice: choice,
                             selected: coordinator.selection.alias == choice.alias,
@@ -1046,32 +1077,36 @@ struct QuickstartView: View {
                         .padding(.bottom, 16)
                     }
 
-                    Text("NEED THE LIGHTEST OPTION?")
-                        .scaledSystemFont(10, weight: .semibold).tracking(1)
-                        .foregroundStyle(.tertiary)
-                        .padding(.bottom, 9)
+                    if !lowMemoryChoices.isEmpty {
+                        Text("NEED THE LIGHTEST OPTION?")
+                            .scaledSystemFont(10, weight: .semibold).tracking(1)
+                            .foregroundStyle(.tertiary)
+                            .padding(.bottom, 9)
 
-                    ForEach(choices.filter { $0.isLowMemory }) { choice in
-                        QuickstartLowMemoryCard(
-                            choice: choice,
-                            selected: coordinator.selection.alias == choice.alias,
-                            sizeText: Self.sizeText(for: choice.alias)
-                        ) { coordinator.select(choice) }
-                        .padding(.bottom, 16)
-                    }
-
-                    Text("OR PICK A BIGGER ONE")
-                        .scaledSystemFont(10, weight: .semibold).tracking(1)
-                        .foregroundStyle(.tertiary)
-                        .padding(.bottom, 9)
-
-                    VStack(spacing: 9) {
-                        ForEach(choices.filter { $0.tier == .tradeUp }) { choice in
-                            QuickstartCompactCard(
+                        ForEach(lowMemoryChoices) { choice in
+                            QuickstartLowMemoryCard(
                                 choice: choice,
                                 selected: coordinator.selection.alias == choice.alias,
                                 sizeText: Self.sizeText(for: choice.alias)
                             ) { coordinator.select(choice) }
+                            .padding(.bottom, 16)
+                        }
+                    }
+
+                    if !tradeUpChoices.isEmpty {
+                        Text("OR PICK A BIGGER ONE")
+                            .scaledSystemFont(10, weight: .semibold).tracking(1)
+                            .foregroundStyle(.tertiary)
+                            .padding(.bottom, 9)
+
+                        VStack(spacing: 9) {
+                            ForEach(tradeUpChoices) { choice in
+                                QuickstartCompactCard(
+                                    choice: choice,
+                                    selected: coordinator.selection.alias == choice.alias,
+                                    sizeText: Self.sizeText(for: choice.alias)
+                                ) { coordinator.select(choice) }
+                            }
                         }
                     }
 
@@ -1090,7 +1125,10 @@ struct QuickstartView: View {
             }
 
             OnboardingWizardFooter(
-                primaryTitle: "Download & start",
+                primaryTitle: Self.canStartWithoutDownload(
+                    alias: coordinator.selection.alias,
+                    cachedModels: cachedModels
+                ) ? "Start existing model" : "Download & start",
                 onBack: { coordinator.backToWelcome() },
                 onPrimary: { startQuickstart() }
             )
@@ -1116,6 +1154,33 @@ struct QuickstartView: View {
             return "~\(Int((gb * 1024).rounded())) MB"
         }
         return String(format: "%.1f GB", gb)
+    }
+
+    /// Stable, bounded presentation for models already on disk. The catalogue
+    /// supplied here is the chat catalogue; retain the kind check defensively
+    /// so a future combined snapshot cannot leak image/video aliases into the
+    /// first-chat path. This returns the complete eligible set because lookup
+    /// correctness must not depend on the UI's six-row presentation bound.
+    static func quickstartCachedModels(_ entries: [ModelEntry]) -> [ModelEntry] {
+        entries.filter { $0.cached && $0.kind == .chat }
+    }
+
+    static func choice(forCachedModel entry: ModelEntry) -> QuickstartModelChoice {
+        QuickstartModelChoice(
+            alias: entry.alias,
+            displayName: entry.alias,
+            hfRepo: entry.hfRepo,
+            blurb: entry.isExternal ? "Already downloaded by another MLX app." : "Already downloaded and ready to start.",
+            tier: .tradeUp
+        )
+    }
+
+    static func canStartWithoutDownload(alias: String, cachedModels: [ModelEntry]) -> Bool {
+        cachedModel(alias: alias, cachedModels: cachedModels) != nil
+    }
+
+    static func cachedModel(alias: String, cachedModels: [ModelEntry]) -> ModelEntry? {
+        quickstartCachedModels(cachedModels).first { $0.alias == alias }
     }
 
     // MARK: - Subviews
@@ -1481,6 +1546,13 @@ struct QuickstartView: View {
     /// Warn-only by design — see ``DiskSpaceProbe`` rationale and the
     /// ``feedback_copy_mature_competitors`` note.
     private func startQuickstart() {
+        if let cached = Self.cachedModel(
+            alias: coordinator.selection.alias,
+            cachedModels: cachedModels
+        ) {
+            startCachedModel(cached)
+            return
+        }
         QuickstartView.applyPreflightDecision(
             decision: DiskSpaceProbe.decide(
                 freeBytes: freeBytesProbe(),
@@ -1489,6 +1561,20 @@ struct QuickstartView: View {
             coordinator: coordinator,
             onKickoff: { kickoffDownload() }
         )
+    }
+
+    /// Cached models skip both the disk-space warning and DownloadManager.
+    /// `ServerManager.start` still owns cache validation, memory guarding and
+    /// the normal ready/failure transitions, so this is a shorter route into
+    /// the same serving lifecycle rather than a second implementation.
+    private func startCachedModel(_ cached: ModelEntry) {
+        coordinator.enterStarting()
+        Task { @MainActor in
+            await server.start(
+                alias: cached.alias,
+                hfPath: cached.hfRepo
+            )
+        }
     }
 
     /// Pure adapter mapping a ``DiskSpaceProbe.Decision`` onto the

--- a/apps/rapid-mac/Tests/RapidTests/QuickstartCachedModelTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/QuickstartCachedModelTests.swift
@@ -1,0 +1,72 @@
+import Testing
+@testable import Rapid
+
+@MainActor
+@Suite("#1793 — Quickstart can start an existing cached chat model")
+struct QuickstartCachedModelTests {
+    private func entry(
+        _ alias: String,
+        cached: Bool = true,
+        kind: ModelKind = .chat,
+        external: Bool = false
+    ) -> ModelEntry {
+        ModelEntry(
+            alias: alias,
+            hfRepo: "mlx-community/\(alias)",
+            sizeOnDisk: cached ? "2.9 GiB" : nil,
+            cached: cached,
+            isExternal: external,
+            kind: kind
+        )
+    }
+
+    @Test("only cached chat entries are eligible and lookup is not presentation-bounded")
+    func filtersCachedModels() {
+        let rows = (0..<8).map { entry("chat-\($0)") } + [
+            entry("not-downloaded", cached: false),
+            entry("image", kind: .image),
+        ]
+        let offered = QuickstartView.quickstartCachedModels(rows)
+        #expect(offered.count == 8)
+        #expect(offered.map(\.alias) == (0..<8).map { "chat-\($0)" })
+        #expect(QuickstartView.canStartWithoutDownload(
+            alias: "chat-7",
+            cachedModels: rows
+        ))
+    }
+
+    @Test("a selected cached alias takes the start-only path")
+    func cachedAliasNeedsNoDownload() {
+        let cached = entry("qwen3.5-4b-4bit")
+        #expect(QuickstartView.canStartWithoutDownload(
+            alias: cached.alias,
+            cachedModels: [cached]
+        ))
+        #expect(!QuickstartView.canStartWithoutDownload(
+            alias: "lfm2.5-1b-4bit",
+            cachedModels: [cached]
+        ))
+    }
+
+    @Test("external cached models retain their usable alias and honest copy")
+    func externalChoice() {
+        let choice = QuickstartView.choice(forCachedModel: entry("external-chat", external: true))
+        #expect(choice.alias == "external-chat")
+        #expect(choice.blurb.contains("another MLX app"))
+    }
+
+    @Test("cached lookup returns catalog provenance rather than the curated choice repo")
+    func cachedLookupUsesCatalogEntry() {
+        let cached = ModelEntry(
+            alias: QuickstartCoordinator.defaultChoice.alias,
+            hfRepo: "local/actual-cached-repo",
+            sizeOnDisk: "600 MiB",
+            cached: true
+        )
+        let resolved = QuickstartView.cachedModel(
+            alias: QuickstartCoordinator.defaultChoice.alias,
+            cachedModels: [cached]
+        )
+        #expect(resolved?.hfRepo == "local/actual-cached-repo")
+    }
+}

--- a/apps/rapid-mac/docs/gui-golden-flows.md
+++ b/apps/rapid-mac/docs/gui-golden-flows.md
@@ -5,7 +5,9 @@ Rapid-MLX Desktop app without loading a real model.
 
 **Journeys** — a user walking a path end to end:
 
-1. fresh install, consent, onboarding, and steady-state shell;
+1. fresh install, consent, onboarding, and steady-state shell; its
+   `cached-quickstart` companion proves a first-run user can select and start
+   an existing chat model without a second download (#1793);
 2. Settings mutation and persistence across an app relaunch;
 3. basic chat, persisted conversation row, and restored transcript;
 4. a deliberately slow stream and semantic **Stop generating** action;

--- a/apps/rapid-mac/scripts/dogfood-isolate.sh
+++ b/apps/rapid-mac/scripts/dogfood-isolate.sh
@@ -58,6 +58,9 @@ ENVIRONMENT:
                    Give the run an empty model cache too. Off by default:
                    the cache is tens of gigabytes and read-mostly, and a
                    cold one turns every launch into a multi-GB download.
+    DOGFOOD_PORT=<49152-65535>
+                   Pin the isolated app to this port. By default the helper
+                   chooses a free high port from the persona's random suffix.
 
 OUTPUT:
     Progress and diagnostics are written to STDERR.
@@ -231,6 +234,41 @@ if [[ ${#SUFFIX} -ne 8 ]]; then
 fi
 NEW_ID="${ORIGINAL_ID}.dogfood-${SUFFIX}"
 
+# The bundle id and HOME isolate preferences and files, but the app's default
+# port window is process-global. Before #1618 a dogfood launch swept :8000-
+# :8009 and could SIGTERM an operator's hand-started rapid-mlx server. Give
+# every persona one high port and disable heuristic launch sweeping entirely;
+# OwnedServerRecord in the throwaway HOME remains the authority for processes
+# this persona actually started.
+if [[ -n "${DOGFOOD_PORT:-}" ]]; then
+    if [[ ! "$DOGFOOD_PORT" =~ ^[0-9]+$ ]] \
+       || (( DOGFOOD_PORT < 49152 || DOGFOOD_PORT > 65535 )); then
+        die "DOGFOOD_PORT must be an integer from 49152 through 65535"
+    fi
+    ISOLATED_PORT="$DOGFOOD_PORT"
+else
+    # This is intentionally a fail-safe check, not a claim that a TCP port can
+    # be reserved across processes: POSIX exposes no way to hand an already
+    # bound socket to the Python/uvicorn sidecar this app launches. A process
+    # could claim the candidate after this probe; in that race the isolated
+    # sidecar gets EADDRINUSE and startup fails visibly. Crucially, sweep stays
+    # disabled, so resolving the race can never mean terminating that owner.
+    # The random 16K-port space makes two generated personas choosing the same
+    # candidate rare; the 128-step probe handles already-bound candidates.
+    port_seed=$((16#$SUFFIX))
+    port_offset=$((port_seed % 16384))
+    ISOLATED_PORT=""
+    for ((attempt = 0; attempt < 128; attempt++)); do
+        candidate=$((49152 + ((port_offset + attempt) % 16384)))
+        if ! lsof -nP -sTCP:LISTEN -ti :"$candidate" 2>/dev/null | grep -q .; then
+            ISOLATED_PORT="$candidate"
+            break
+        fi
+    done
+    [[ -n "$ISOLATED_PORT" ]] \
+        || die "could not find a free isolated port after 128 candidates"
+fi
+
 log "rewriting CFBundleIdentifier -> $NEW_ID"
 /usr/libexec/PlistBuddy -c "Set :CFBundleIdentifier $NEW_ID" "$PLIST"
 
@@ -342,6 +380,8 @@ cat > "$LAUNCHER" <<LAUNCHEOF
 set -euo pipefail
 export HOME="$HOME_DIR"
 export HF_HOME="$HF_HOME_FOR_RUN"
+export RAPID_DESKTOP_PORT="$ISOLATED_PORT"
+export RAPID_DESKTOP_NO_PORT_SWEEP=1
 # HF_HUB_CACHE wins over HF_HOME wherever both are read (see
 # BundledModel.userHFCacheURL), so an inherited one from the caller's shell
 # would quietly point the run back at their real cache — including under
@@ -356,6 +396,7 @@ log "isolated .app ready: $TARGET_APP"
 log "  new bundle-id: $NEW_ID"
 log "  throwaway HOME: $HOME_DIR"
 log "  model cache:    $HF_HOME_FOR_RUN"
+log "  isolated port:  $ISOLATED_PORT (launch sweep disabled)"
 log "  LAUNCH WITH:   $LAUNCHER &          # NOT 'open -n' — that drops \$HOME"
 log "  cleanup later: defaults delete '$NEW_ID' && rm -rf '$TARGET_ABS'"
 log "  shutdown:      pkill -f '$TARGET_APP'    # path-qualified, do NOT use bare 'pkill -f Rapid'"

--- a/apps/rapid-mac/scripts/fake-rapid-mlx.sh
+++ b/apps/rapid-mac/scripts/fake-rapid-mlx.sh
@@ -662,10 +662,11 @@ def main():
     # output rather than falling through to the server, so a future
     # ``ModelCatalog`` subcommand can't resurrect the hang.
     if args.subcommand != "serve":
+        _event("command", subcommand=args.subcommand, alias=args.alias, pid=os.getpid())
         _emit_catalog(args.subcommand, args.alias)
         sys.exit(0)
 
-    _event("server_started", alias=args.alias, pid=os.getpid())
+    _event("server_started", alias=args.alias, pid=os.getpid(), port=args.port)
 
     # Match the real server's startup banner shape closely enough
     # that DownloadProgress's "Loading model with" detection fires

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -23,6 +23,7 @@ UPDATE_BASELINES=0
 FLOW="all"
 KEEP=0
 APP_PID=""
+OPERATOR_SERVER_PID=""
 PERSONA=""
 OUT=""
 MAIN_WINDOW_ID=""
@@ -35,7 +36,7 @@ usage() {
     cat <<'EOF'
 Usage: gui-golden-flows.sh [--flow NAME] [--keep] [--update-baselines]
 
-Flows: fresh-install, settings-persistence, chat-restore, restored-tools, tool-loop-budget, chat-depth, math-rendering,
+Flows: fresh-install, cached-quickstart, settings-persistence, chat-restore, restored-tools, tool-loop-budget, chat-depth, math-rendering,
        slow-stream-stop,
        model-crash-recovery, low-memory-choice,
        update-state, window-close-prompt, no-dead-controls, catalog-integrity,
@@ -98,7 +99,7 @@ flow_requires_screen_recording() {
 # unattended without taking on any of that.
 flow_requires_peekaboo() {
     case "$FLOW" in
-        chat-restore|restored-tools|tool-loop-budget|chat-depth|math-rendering) return 1 ;;
+        cached-quickstart|chat-restore|restored-tools|tool-loop-budget|chat-depth|math-rendering) return 1 ;;
         slow-stream-stop|model-crash-recovery|image-generation|window-close-prompt) return 1 ;;
         *) return 0 ;;
     esac
@@ -121,6 +122,19 @@ cleanup_persona() {
         wait "$APP_PID" 2>/dev/null || true
     fi
     APP_PID=""
+    cleanup_fake_sidecars
+    if [[ "$KEEP" == 0 && -n "$BUNDLE_ID" ]]; then
+        defaults delete "$BUNDLE_ID" >/dev/null 2>&1 || true
+    fi
+    if [[ "$KEEP" == 0 && -n "$PERSONA" && -d "$PERSONA" ]]; then
+        rm -rf "$PERSONA"
+    fi
+    PERSONA=""
+    BUNDLE_ID=""
+    PERSONA_ENV=()
+}
+
+cleanup_fake_sidecars() {
     if [[ -n "$OUT" && -f "$OUT/fake-events.jsonl" ]]; then
         # Pair each pid with the alias it was started for, and require the
         # live command to still name THAT alias. A bare `serve fake-alias`
@@ -141,15 +155,14 @@ cleanup_persona() {
                         | "\(.pid)\t\(.alias // "")"' \
                      "$OUT/fake-events.jsonl" 2>/dev/null | sort -u)
     fi
-    if [[ "$KEEP" == 0 && -n "$BUNDLE_ID" ]]; then
-        defaults delete "$BUNDLE_ID" >/dev/null 2>&1 || true
+}
+
+cleanup_operator_server() {
+    if [[ -n "$OPERATOR_SERVER_PID" ]] && kill -0 "$OPERATOR_SERVER_PID" 2>/dev/null; then
+        kill "$OPERATOR_SERVER_PID" 2>/dev/null || true
+        wait "$OPERATOR_SERVER_PID" 2>/dev/null || true
     fi
-    if [[ "$KEEP" == 0 && -n "$PERSONA" && -d "$PERSONA" ]]; then
-        rm -rf "$PERSONA"
-    fi
-    PERSONA=""
-    BUNDLE_ID=""
-    PERSONA_ENV=()
+    OPERATOR_SERVER_PID=""
 }
 
 finish() {
@@ -162,10 +175,11 @@ finish() {
             > "$OUT_ROOT/result.json" 2>/dev/null || true
     fi
     cleanup_persona
+    cleanup_operator_server
 }
 trap finish EXIT
-trap 'cleanup_persona; exit 130' INT
-trap 'cleanup_persona; exit 143' TERM
+trap 'cleanup_persona; cleanup_operator_server; exit 130' INT
+trap 'cleanup_persona; cleanup_operator_server; exit 143' TERM
 
 # The preconditions every flow depends on and none of them can observe:
 # permission to read another process's AX tree, and a session that can actually
@@ -249,6 +263,11 @@ start_persona() {
 
 relaunch_persona() {
     stop_app
+    # A relaunch keeps the persona but starts a fresh app process. Reap only
+    # the fake sidecars this harness recorded before starting it again. Before
+    # #1618 the app's unsafe global port sweep hid this ownership leak by
+    # killing the old fake (and potentially an operator's real server too).
+    cleanup_fake_sidecars
     env RAPID_BIN="$ROOT/scripts/fake-rapid-mlx.sh" \
         FAKE_EVENT_LOG="$OUT/fake-events.jsonl" \
         "${PERSONA_ENV[@]+"${PERSONA_ENV[@]}"}" \
@@ -985,6 +1004,60 @@ flow_fresh_install() {
     baseline fresh-install.steady "$OUT/steady.json"
     pb image --window-id "$MAIN_WINDOW_ID" --path "$OUT/final.png" --json > "$OUT/final-image.json"
     cleanup_persona
+}
+
+flow_cached_quickstart() {
+    log "cached Quickstart starts without downloading (#1793)"
+    # Reproduce #1618, not merely its configuration strings: an
+    # operator-owned rapid-mlx-shaped listener is alive on the default port
+    # before the dogfood app launches. The isolated persona must bind its own
+    # high port without sweeping or terminating this process.
+    FAKE_EVENT_LOG="$OUT_ROOT/operator-events.jsonl" \
+        "$ROOT/scripts/fake-rapid-mlx.sh" serve operator-owned \
+        --host 127.0.0.1 --port 8000 > "$OUT_ROOT/operator-server.log" 2>&1 &
+    OPERATOR_SERVER_PID=$!
+    for _ in {1..40}; do
+        curl -fsS http://127.0.0.1:8000/healthz >/dev/null 2>&1 && break
+        sleep 0.1
+    done
+    curl -fsS http://127.0.0.1:8000/healthz >/dev/null \
+        || die "operator-shaped server did not bind :8000 for the isolation repro"
+    kill -0 "$OPERATOR_SERVER_PID" 2>/dev/null \
+        || die ":8000 was already occupied; cannot establish the owned-server isolation repro"
+
+    start_persona cached-quickstart
+
+    see_main "$OUT/consent.json"
+    if jq -e '.data.ui_elements[]? | select(.identifier == "TelemetryConsent.DontShare")' \
+        "$OUT/consent.json" >/dev/null; then
+        press "$OUT/consent.json" TelemetryConsent.DontShare "$OUT/consent-dismiss.json"
+    fi
+    wait_identifier Quickstart.GetStarted "$OUT/welcome.json"
+    press "$OUT/welcome.json" Quickstart.GetStarted "$OUT/get-started.json"
+    wait_identifier "Quickstart.CachedModel.$FAKE_ALIAS" "$OUT/chooser.json"
+    press "$OUT/chooser.json" "Quickstart.CachedModel.$FAKE_ALIAS" "$OUT/select-cached.json"
+    see_main "$OUT/selected.json"
+    assert_tree_text "$OUT/selected.json" "Start existing model"
+    press "$OUT/selected.json" Quickstart.Footer.Primary "$OUT/start-existing.json"
+
+    wait_fake_event \
+        ".event == \"server_started\" and .alias == \"$FAKE_ALIAS\"" \
+        "cached Quickstart did not start the selected model"
+    jq -e -s 'any(.[]; .event == "server_started" and .alias == "fake-alias"
+              and .port >= 49152 and .port <= 65535)' \
+        "$OUT/fake-events.jsonl" >/dev/null \
+        || die "isolated persona did not bind its selected high port"
+    kill -0 "$OPERATOR_SERVER_PID" 2>/dev/null \
+        || die "dogfood launch terminated the operator-owned :8000 server (#1618)"
+    curl -fsS http://127.0.0.1:8000/healthz >/dev/null \
+        || die "operator-owned :8000 server stopped responding after dogfood launch"
+    wait_identifier rapid.chat.compose "$OUT/ready.json"
+    if jq -e -s 'any(.[]; .event == "command" and .subcommand == "pull")' \
+        "$OUT/fake-events.jsonl" >/dev/null; then
+        die "cached Quickstart invoked rapid-mlx pull instead of the start-only path"
+    fi
+    cleanup_persona
+    cleanup_operator_server
 }
 
 flow_settings_persistence() {
@@ -2061,6 +2134,7 @@ mkdir -p "$OUT_ROOT"
 require_tools
 case "$FLOW" in
     fresh-install) flow_fresh_install ;;
+    cached-quickstart) flow_cached_quickstart ;;
     settings-persistence) flow_settings_persistence ;;
     chat-restore) flow_chat_restore ;;
     restored-tools) flow_restored_tools ;;
@@ -2078,6 +2152,7 @@ case "$FLOW" in
     image-generation) flow_image_generation ;;
     all)
         flow_fresh_install
+        flow_cached_quickstart
         flow_settings_persistence
         flow_chat_restore
         flow_restored_tools

--- a/tests/test_gui_preflight_contract.py
+++ b/tests/test_gui_preflight_contract.py
@@ -23,6 +23,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parent.parent
 DRIVER = ROOT / "apps/rapid-mac/scripts/rapid-ax.swift"
 HARNESS = ROOT / "apps/rapid-mac/scripts/gui-golden-flows.sh"
+DOGFOOD = ROOT / "apps/rapid-mac/scripts/dogfood-isolate.sh"
 
 
 def test_trust_command_checks_permission_reach_and_lock():
@@ -88,6 +89,7 @@ def test_peekaboo_requirement_is_default_deny():
     assert "*) return 0 ;;" in body, "the catch-all must REQUIRE peekaboo"
     peekaboo_free = {
         "chat-restore",
+        "cached-quickstart",
         "restored-tools",
         "tool-loop-budget",
         "chat-depth",
@@ -104,3 +106,33 @@ def test_peekaboo_requirement_is_default_deny():
         for flow in line.split(")", 1)[0].strip().split("|")
     }
     assert named == peekaboo_free
+
+
+def test_dogfood_launcher_isolates_port_and_disables_heuristic_sweep():
+    """A throwaway persona must never reap an operator's real server (#1618)."""
+    source = DOGFOOD.read_text()
+    launcher = source.split('cat > "$LAUNCHER" <<LAUNCHEOF', 1)[1].split(
+        "LAUNCHEOF", 1
+    )[0]
+    assert 'export RAPID_DESKTOP_PORT="$ISOLATED_PORT"' in launcher
+    assert "export RAPID_DESKTOP_NO_PORT_SWEEP=1" in launcher
+    assert "49152" in source and "65535" in source
+
+    # The macOS GoldenFlow is the executable proof: it keeps an
+    # operator-shaped listener on :8000 while launching the persona, then
+    # checks both process survival and the persona's actual bound port.
+    flow = (
+        HARNESS.read_text().split("flow_cached_quickstart() {", 1)[1].split("\n}", 1)[0]
+    )
+    assert "serve operator-owned" in flow
+    assert 'kill -0 "$OPERATOR_SERVER_PID"' in flow
+    assert ".port >= 49152 and .port <= 65535" in flow
+
+
+def test_harness_reaps_its_own_fake_before_relaunch_without_global_sweep():
+    source = HARNESS.read_text()
+    relaunch = source.split("relaunch_persona() {", 1)[1].split("\n}", 1)[0]
+    assert relaunch.index("stop_app") < relaunch.index("cleanup_fake_sidecars")
+    assert relaunch.index("cleanup_fake_sidecars") < relaunch.index(
+        '"$PERSONA/launch.sh"'
+    )


### PR DESCRIPTION
## Summary

- offer cached chat models directly in first-run Quickstart and start the selected model without invoking `rapid-mlx pull`
- give every dogfood persona a dedicated high port and disable heuristic launch sweeping so it cannot terminate an operator-owned server
- add unit/contract coverage plus a real assembled-app `cached-quickstart` GoldenFlow

## Root cause

Quickstart consumed no catalog snapshot, so its only action was download-then-start even when Model Management already knew a model was on disk. Separately, `dogfood-isolate.sh` isolated bundle preferences and `$HOME` but left the shared `:8000-:8009` window and launch sweep active.

## Validation

- `swift build --package-path apps/rapid-mac`
- `swift build --package-path apps/rapid-mac --target RapidTests` (includes the new Swift tests; this host cannot run `swift test` because Command Line Tools lacks XCTest for the existing `RapidUXTests` target)
- `SKIP_SIDECAR=1 apps/rapid-mac/scripts/build.sh`
- `gui-golden-flows.sh --flow cached-quickstart` against the assembled app: PASS; event log contains `models`, `ls`, and `server_started`, with no `pull`
- repeated the GoldenFlow while an operator-shaped fake `rapid-mlx serve` remained healthy on `:8000`; the persona used a high isolated port and did not terminate it
- 97 GUI harness / AX contract tests passed
- shell syntax and diff checks passed
- full Python suite started locally; GitHub CI remains authoritative

Closes #1793
Closes #1618