### PR TITLE
fix(mac): clarify onboarding and silence catalog probes

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Server/ModelCatalog.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ModelCatalog.swift
@@ -886,27 +886,13 @@ enum ModelCatalog {
             task.arguments = args
             // Issue #503: when the user pointed Rapid at a custom models
             // folder, run the probe with that folder so ``rapid-mlx ls``
-            // enumerates the right directory. Only override when set —
-            // a nil leaves ``task.environment`` unset so the child
-            // inherits the ambient env (default location), preserving
-            // the historical behaviour for every other caller.
-            if let hubCacheOverride {
-                var env = ProcessInfo.processInfo.environment
-                env["HF_HUB_CACHE"] = hubCacheOverride.path
-                // Issue #1718: the same folder is also handed to the engine
-                // as an extra scan root. The picker sets where we *download*
-                // to and assumes hub-cache layout, so pointing it at a tree
-                // another MLX runtime wrote — those use
-                // ``<root>/<publisher>/<repo>/`` — surfaced nothing, and the
-                // user was asked to re-download weights already on disk.
-                // Passing it both ways means either layout is found without
-                // making the user say which kind of folder they picked.
-                env[extraModelRootsEnvKey] = mergedExtraModelRoots(
-                    existing: env[extraModelRootsEnvKey],
-                    selected: hubCacheOverride.path
-                )
-                task.environment = env
-            }
+            // enumerates the right directory. The helper preserves the
+            // ambient environment either way, adding only the optional cache
+            // paths and the #1415 telemetry opt-out for internal probes.
+            task.environment = probeEnvironment(
+                ambient: ProcessInfo.processInfo.environment,
+                hubCacheOverride: hubCacheOverride
+            )
             let stdout = Pipe()
             let stderr = Pipe()
             task.standardOutput = stdout
@@ -1008,6 +994,29 @@ enum ModelCatalog {
 
     static func _testingRunRapidMlx(binary: URL, args: [String]) async -> String {
         await runRapidMlx(binary: binary, args: args)
+    }
+
+    /// Environment for app-owned, read-only catalog probes. These invocations
+    /// are implementation details, not engine sessions: one picker refresh can
+    /// execute `models`, `ls`, and several `info` commands. Letting each emit a
+    /// lifecycle pair inflated usage telemetry and made app shutdown wait on
+    /// probe POSTs (#1415). Override even an ambient opt-in; the real `serve`
+    /// child has its own environment path and keeps telemetry enabled.
+    nonisolated static func probeEnvironment(
+        ambient: [String: String],
+        hubCacheOverride: URL?
+    ) -> [String: String] {
+        var env = ambient
+        env["DO_NOT_TRACK"] = "1"
+        if let hubCacheOverride {
+            env["HF_HUB_CACHE"] = hubCacheOverride.path
+            // Issue #1718: scan both Hugging Face and external-runtime layouts.
+            env[extraModelRootsEnvKey] = mergedExtraModelRoots(
+                existing: env[extraModelRootsEnvKey],
+                selected: hubCacheOverride.path
+            )
+        }
+        return env
     }
 }
 

--- a/apps/rapid-mac/Sources/Rapid/UI/OnboardingComponents.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/OnboardingComponents.swift
@@ -3,10 +3,10 @@ import SwiftUI
 /// Shared primitives for the first-run onboarding wizard (#1524).
 ///
 /// These are the reusable pieces the ``QuickstartView`` steps compose:
-/// a brand mark, a top bar with step dots, a Back/primary footer, an
+/// a brand mark, a top bar with step progress, a Back/primary footer, an
 /// attribute chip, and the two model-choice cards. The patterns are
 /// borrowed from FluidVoice's onboarding framework (a shared footer
-/// scaffold + progress dots + selectable cards) but rebuilt on
+/// scaffold + progress affordance + selectable cards) but rebuilt on
 /// ``RapidTheme`` tokens — we deliberately did NOT port FluidVoice's
 /// whole theme-as-EnvironmentValue system for one wizard.
 ///
@@ -35,26 +35,33 @@ struct OnboardingBrandMark: View {
     }
 }
 
-// MARK: - Progress dots
+// MARK: - Step progress
 
-/// The thin capsule step indicator (current step widens + goes brand
-/// blue). ``current`` is 0-indexed.
-struct OnboardingStepDots: View {
+/// Honest wizard progress. The old three capsules looked like a carousel
+/// page control even though onboarding only advances through its explicit
+/// buttons (#1792). A labelled linear meter communicates position without
+/// advertising swipe, drag, or arbitrary-page navigation.
+/// ``current`` is 0-indexed.
+struct OnboardingStepProgress: View {
     let current: Int
     let total: Int
 
     var body: some View {
-        HStack(spacing: 7) {
-            ForEach(0..<total, id: \.self) { i in
-                Capsule()
-                    .fill(i == current ? RapidTheme.brand : RapidTheme.hairline)
-                    .frame(width: i == current ? 20 : 7, height: 6)
-            }
+        VStack(alignment: .trailing, spacing: 5) {
+            Text("Step \(current + 1) of \(total)")
+                .scaledSystemFont(10, weight: .medium)
+                .foregroundStyle(.secondary)
+            ProgressView(value: Double(current + 1), total: Double(total))
+                .progressViewStyle(.linear)
+                .tint(RapidTheme.brand)
+                .frame(width: 92)
         }
-        // #547 §3/§4: the active capsule springs 7→20pt as the user
-        // advances instead of hard-snapping; instant under Reduce Motion.
-        .rapidAnimation(RapidMotion.standard, value: current)
-        .accessibilityHidden(true)
+        .accessibilityElement(children: .ignore)
+        .accessibilityIdentifier("Quickstart.Progress")
+        // A custom SwiftUI container is AXUnknown on macOS and drops its
+        // AXValue. Keep the full status in the label so VoiceOver receives it
+        // reliably instead of announcing only "Setup progress".
+        .accessibilityLabel("Setup progress, step \(current + 1) of \(total)")
     }
 }
 
@@ -70,7 +77,7 @@ struct OnboardingTopBar: View {
             OnboardingBrandMark(size: 26)
             Text("Rapid-MLX").scaledSystemFont(13, weight: .semibold)
             Spacer()
-            OnboardingStepDots(current: step, total: 3)
+            OnboardingStepProgress(current: step, total: 3)
         }
     }
 }

--- a/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
@@ -1017,7 +1017,7 @@ struct QuickstartView: View {
             .accessibilityLabel("Skip onboarding and go to the app")
             .padding(.bottom, 18)
 
-            OnboardingStepDots(current: 0, total: 3).padding(.bottom, 34)
+            OnboardingStepProgress(current: 0, total: 3).padding(.bottom, 34)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .padding(.horizontal, 44)

--- a/apps/rapid-mac/Sources/Rapid/UI/SettingsToolsPanel.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SettingsToolsPanel.swift
@@ -64,6 +64,8 @@ struct SettingsToolsPanel: View {
                             }
                         }
                         .toggleStyle(TrailingSettingsToggleStyle())
+                        .accessibilityLabel(Self.voiceOverLabel(for: def.function.name))
+                        .accessibilityHint(def.function.description)
                         // Keyed on the TOOL NAME (the wire identifier the
                         // engine and the request body use), not on the row's
                         // display text — the label is the tool's own
@@ -80,6 +82,15 @@ struct SettingsToolsPanel: View {
             get: { !chat.disabledTools.contains(name) },
             set: { chat.setToolEnabled(name, $0) }
         )
+    }
+
+    private static func voiceOverLabel(for toolName: String) -> String {
+        switch toolName {
+        case "web_search": "Web search"
+        case "browse": "Browse pages"
+        case "weather": "Weather"
+        default: toolName.replacingOccurrences(of: "_", with: " ")
+        }
     }
 
     // MARK: - Web search
@@ -235,6 +246,8 @@ struct SettingsToolsPanel: View {
                     }
                 }
                 .toggleStyle(TrailingSettingsToggleStyle())
+                .accessibilityLabel("Approve every page automatically")
+                .accessibilityHint("Skips confirmation for public pages. Private and local addresses remain blocked.")
                 .accessibilityIdentifier("Settings.Tools.Browse.AutoApproveToggle")
             }
         }

--- a/apps/rapid-mac/Sources/Rapid/UI/SettingsView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SettingsView.swift
@@ -637,6 +637,8 @@ struct SettingsView: View {
                 }
             }
             .toggleStyle(TrailingSettingsToggleStyle())
+            .accessibilityLabel("Hide Dock icon when closing window")
+            .accessibilityHint("Rapid-MLX remains available from the menu bar.")
             .accessibilityIdentifier("Settings.App.HideDockOnCloseToggle")
             HStack {
                 Spacer()

--- a/apps/rapid-mac/Tests/RapidTests/DownloadCatalogHardeningTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/DownloadCatalogHardeningTests.swift
@@ -258,6 +258,37 @@ struct DownloadCatalogHardeningTests {
         #expect(output.utf8.count == ModelCatalog.maxSubprocessStdoutBytes)
     }
 
+    @Test("ModelCatalog internal probes disable engine telemetry")
+    func modelCatalogProbeDisablesTelemetry() async throws {
+        let script = try makeExecutableScript(
+            """
+            #!/bin/sh
+            printf '%s' "${DO_NOT_TRACK-unset}"
+            """
+        )
+
+        let output = await ModelCatalog._testingRunRapidMlx(binary: script, args: ["models"])
+        #expect(output == "1")
+    }
+
+    @Test("ModelCatalog probe environment preserves caller paths but overrides telemetry")
+    func modelCatalogProbeEnvironmentComposition() throws {
+        let selected = URL(fileURLWithPath: "/Volumes/models")
+        let env = ModelCatalog.probeEnvironment(
+            ambient: [
+                "DO_NOT_TRACK": "0",
+                "KEEP_ME": "yes",
+                ModelCatalog.extraModelRootsEnvKey: "[\"/ambient\"]",
+            ],
+            hubCacheOverride: selected
+        )
+
+        #expect(env["DO_NOT_TRACK"] == "1")
+        #expect(env["KEEP_ME"] == "yes")
+        #expect(env["HF_HUB_CACHE"] == selected.path)
+        #expect(env[ModelCatalog.extraModelRootsEnvKey] == "[\"/ambient\",\"/Volumes/models\"]")
+    }
+
     @Test("ModelCatalog terminates catalog subprocesses when the async task is cancelled")
     func modelCatalogCancelsSubprocess() async throws {
         let dir = try makeTemporaryDirectory()

--- a/apps/rapid-mac/Tests/RapidTests/DownloadCatalogHardeningTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/DownloadCatalogHardeningTests.swift
@@ -291,7 +291,9 @@ struct DownloadCatalogHardeningTests {
         #expect(env["DO_NOT_TRACK"] == "1")
         #expect(env["KEEP_ME"] == "yes")
         #expect(env["HF_HUB_CACHE"] == selected.path)
-        #expect(env[ModelCatalog.extraModelRootsEnvKey] == "[\"/ambient\",\"/Volumes/models\"]")
+        let encodedRoots = try #require(env[ModelCatalog.extraModelRootsEnvKey])
+        let roots = try JSONDecoder().decode([String].self, from: Data(encodedRoots.utf8))
+        #expect(roots == ["/ambient", "/Volumes/models"])
     }
 
     @Test("ModelCatalog terminates catalog subprocesses when the async task is cancelled")

--- a/apps/rapid-mac/Tests/RapidTests/DownloadCatalogHardeningTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/DownloadCatalogHardeningTests.swift
@@ -267,8 +267,13 @@ struct DownloadCatalogHardeningTests {
             """
         )
 
-        let output = await ModelCatalog._testingRunRapidMlx(binary: script, args: ["models"])
-        #expect(output == "1")
+        for subcommand in ["models", "ls", "info"] {
+            let output = await ModelCatalog._testingRunRapidMlx(
+                binary: script,
+                args: [subcommand, "fixture-alias"]
+            )
+            #expect(output == "1", "\(subcommand) probe inherited engine telemetry")
+        }
     }
 
     @Test("ModelCatalog probe environment preserves caller paths but overrides telemetry")

--- a/apps/rapid-mac/scripts/fake-rapid-mlx.sh
+++ b/apps/rapid-mac/scripts/fake-rapid-mlx.sh
@@ -662,7 +662,13 @@ def main():
     # output rather than falling through to the server, so a future
     # ``ModelCatalog`` subcommand can't resurrect the hang.
     if args.subcommand != "serve":
-        _event("command", subcommand=args.subcommand, alias=args.alias, pid=os.getpid())
+        _event(
+            "command",
+            subcommand=args.subcommand,
+            alias=args.alias,
+            pid=os.getpid(),
+            do_not_track=os.environ.get("DO_NOT_TRACK"),
+        )
         _emit_catalog(args.subcommand, args.alias)
         sys.exit(0)
 

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -1036,8 +1036,16 @@ flow_cached_quickstart() {
         press "$OUT/consent.json" TelemetryConsent.DontShare "$OUT/consent-dismiss.json"
     fi
     wait_identifier Quickstart.GetStarted "$OUT/welcome.json"
+    jq -e '.data.ui_elements[]?
+            | select(.identifier == "Quickstart.Progress")
+            | select(.description == "Setup progress, step 1 of 3")' "$OUT/welcome.json" >/dev/null \
+        || die "Quickstart welcome does not expose honest step progress"
     press "$OUT/welcome.json" Quickstart.GetStarted "$OUT/get-started.json"
     wait_identifier "Quickstart.CachedModel.$FAKE_ALIAS" "$OUT/chooser.json"
+    jq -e '.data.ui_elements[]?
+            | select(.identifier == "Quickstart.Progress")
+            | select(.description == "Setup progress, step 2 of 3")' "$OUT/chooser.json" >/dev/null \
+        || die "Quickstart chooser does not advance its honest step progress"
     press "$OUT/chooser.json" "Quickstart.CachedModel.$FAKE_ALIAS" "$OUT/select-cached.json"
     see_main "$OUT/selected.json"
     assert_tree_text "$OUT/selected.json" "Start existing model"
@@ -1491,6 +1499,25 @@ flow_no_dead_controls() {
             || die "Settings > $category exposes no identified controls of its own"
         log "  $category: $count identified controls"
     done
+
+    local ax_contracts=(
+        "dead-panel-tools.json|Settings.Tools.Toggle.web_search|Web search"
+        "dead-panel-tools.json|Settings.Tools.Toggle.browse|Browse pages"
+        "dead-panel-tools.json|Settings.Tools.Toggle.weather|Weather"
+        "dead-panel-tools.json|Settings.Tools.Browse.AutoApproveToggle|Approve every page automatically"
+        "dead-panel-app.json|Settings.App.HideDockOnCloseToggle|Hide Dock icon when closing window"
+    )
+    local contract file identifier label
+    for contract in "${ax_contracts[@]}"; do
+        IFS='|' read -r file identifier label <<< "$contract"
+        jq -e --arg identifier "$identifier" --arg label "$label" \
+            '.data.ui_elements[]?
+             | select(.identifier == $identifier)
+             | select(.description == $label)' \
+            "$OUT/$file" >/dev/null \
+            || die "$identifier has no readable VoiceOver label"
+    done
+    log "  Settings toggles expose readable VoiceOver labels"
     cleanup_persona
 }
 
@@ -1796,6 +1823,15 @@ flow_catalog_integrity() {
     start_persona catalog-integrity
     dismiss_first_run
     see_main "$OUT/catalog-main.json"
+
+    # The catalog is populated by app-owned `models` / `ls` / `info` probes.
+    # They are implementation details, not real engine sessions (#1415).
+    wait_fake_event '.event == "command"' \
+        "the catalog did not invoke the fake CLI probes"
+    jq -e -s '[.[] | select(.event == "command")]
+              | length > 0 and all(.[]; .do_not_track == "1")' \
+        "$OUT/fake-events.jsonl" >/dev/null \
+        || die "an internal catalog probe launched with engine telemetry enabled"
 
     jq -e '.data.walk.complete == true' "$OUT/catalog-main.json" >/dev/null \
         || die "could not completely observe the chat catalog"

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -1822,22 +1822,33 @@ flow_catalog_integrity() {
     # not today's registry contents.
     start_persona catalog-integrity
     dismiss_first_run
-    see_main "$OUT/catalog-main.json"
+    local catalog_ready=0
+    for _ in {1..40}; do
+        see_main "$OUT/catalog-main.json"
+        if jq -e '.data.ui_elements[]?
+                  | select(.identifier == "ModelPickerBar.ModelMenu" and .value == "fake-alias")' \
+               "$OUT/catalog-main.json" >/dev/null; then
+            catalog_ready=1
+            break
+        fi
+        sleep 0.25
+    done
+    [[ "$catalog_ready" == 1 ]] || die "chat catalog inventory was not observed"
 
     # The catalog is populated by app-owned `models` / `ls` / `info` probes.
     # They are implementation details, not real engine sessions (#1415).
-    wait_fake_event '.event == "command"' \
-        "the catalog did not invoke the fake CLI probes"
+    # The model-menu value above is the completion barrier: ModelCatalog.load
+    # publishes that merged inventory only after its models/ls/info tasks have
+    # all returned, so the event log now contains the full initial probe set.
     jq -e -s '[.[] | select(.event == "command")]
-              | length > 0 and all(.[]; .do_not_track == "1")' \
+              | (map(.subcommand) | index("models") != null)
+                and (map(.subcommand) | index("ls") != null)
+                and all(.[]; .do_not_track == "1")' \
         "$OUT/fake-events.jsonl" >/dev/null \
         || die "an internal catalog probe launched with engine telemetry enabled"
 
     jq -e '.data.walk.complete == true' "$OUT/catalog-main.json" >/dev/null \
         || die "could not completely observe the chat catalog"
-    jq -e '.data.ui_elements[]? | select(.identifier == "ModelPickerBar.ModelMenu" and .value == "fake-alias")' \
-        "$OUT/catalog-main.json" >/dev/null \
-        || die "chat catalog inventory was not observed"
     jq -e '[.data.ui_elements[]? | select([(.identifier // ""), (.value // ""), (.title // ""), (.description // "")] | map(tostring) | join(" ") | test("fake-video-alias"))] | length == 0' \
         "$OUT/catalog-main.json" >/dev/null \
         || die "a video-gen alias reached the chat surface"

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -1835,10 +1835,12 @@ flow_catalog_integrity() {
     done
     [[ "$catalog_ready" == 1 ]] || die "chat catalog inventory was not observed"
 
-    # The catalog is populated by app-owned `models` / `ls` / `info` probes.
+    # This fixture's catalog is populated by app-owned `models` / `ls` probes.
+    # (The Swift subprocess test separately exercises the conditional `info`
+    # sibling probe, which this fixture deliberately has no candidate for.)
     # They are implementation details, not real engine sessions (#1415).
     # The model-menu value above is the completion barrier: ModelCatalog.load
-    # publishes that merged inventory only after its models/ls/info tasks have
+    # publishes that merged inventory only after its models/ls tasks have
     # all returned, so the event log now contains the full initial probe set.
     jq -e -s '[.[] | select(.event == "command")]
               | (map(.subcommand) | index("models") != null)


### PR DESCRIPTION
## Summary

- give the five Settings toggles from #1687 stable VoiceOver labels and hints
- replace Quickstart's carousel-like dots with labelled linear step progress for #1792
- mark app-owned `models` / `ls` / `info` catalog probes with `DO_NOT_TRACK=1` for #1415, without changing real serve telemetry
- extend GoldenFlow coverage for all three regressions

## Root cause

The custom trailing toggle style did not reliably promote compound SwiftUI labels into `AXDescription`. Quickstart used decorative capsules that visually resembled page controls despite having no navigation behavior. ModelCatalog only constructed a child environment for custom cache paths, so ordinary internal CLI probes inherited telemetry opt-in unchanged.

## Reproduction

- `no-dead-controls` showed all five target checkboxes with identifier/value/enabled but no title, description, or help
- `cached-quickstart` exposed no step-progress semantic node on the welcome screen
- a fake catalog CLI observed internal probe children without `DO_NOT_TRACK`

## Validation

- `swift build --package-path apps/rapid-mac --target RapidTests`
- 18 GUI harness/fake-sidecar Python contract tests
- GoldenFlow `cached-quickstart`
- GoldenFlow `no-dead-controls`
- GoldenFlow `catalog-integrity`
- assembled release app with `SKIP_SIDECAR=1 ./scripts/build.sh`
- shell syntax and `git diff --check`

Local `swift test` remains blocked by #1638 under the selected Command Line Tools (`RapidUXTests` cannot import XCTest); the new Swift tests compile in the full `RapidTests` target and will execute on CI.

Closes #1687
Closes #1415
Closes #1792
