### PR TITLE
fix(mac): choose quality-aware cached model defaults

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Server/RAMBucketedDefault.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/RAMBucketedDefault.swift
@@ -231,6 +231,22 @@ enum RAMBucketedDefault {
         tier(forPhysicalRAMGB: physicalRAMGB).picks
     }
 
+    /// Quality-aware order for choosing among models that are already on
+    /// disk. Begin with the closest tier this Mac qualifies for and walk
+    /// downward, preserving smart-before-fast within each tier and removing
+    /// aliases repeated across tiers.
+    static func preferenceOrder(forPhysicalRAMGB physicalRAMGB: Double) -> [String] {
+        var seen: Set<String> = []
+        var result: [String] = []
+        let effectiveRAMGB = max(physicalRAMGB, tiers[0].floorGB)
+        for tier in tiers.reversed() where tier.floorGB <= effectiveRAMGB {
+            for alias in tier.picks.map(\.alias) where seen.insert(alias).inserted {
+                result.append(alias)
+            }
+        }
+        return result
+    }
+
     /// Launch flags to apply when starting ``alias`` AS the recommended
     /// model for a Mac at ``physicalRAMGB`` — empty unless the alias is
     /// this Mac's primary or alt pick. This is why a 64 GB Mac that hand-
@@ -395,24 +411,17 @@ enum SafeDefaultFallback {
 ///    unparseable aliases so a coder/flash quant doesn't phantom-
 ///    classify as small).
 ///
-/// ## Why alphabetical tie-break inside the cached set
+/// ## Cached-candidate ordering
 ///
-/// ``localizedStandardCompare`` mirrors ``ModelCatalog.load``'s
-/// post-cached sort and ``AutoStartDecision.resolveAlias``'s
-/// first-cached fallback — three surfaces, one tie-break. A
-/// 256 GB Mac with both ``bonsai-1.7b-2bit`` and ``qwen3.6-35b-4bit``
-/// cached would land on ``bonsai-1.7b-2bit`` (alphabetically first),
-/// instant-boot. The user swaps via the picker the moment they
-/// want the larger model — same affordance as today, but
-/// without paying a multi-GB download just to swap back to a
-/// model that was already on disk.
-///
-/// "Smallest by footprint" was considered and rejected — on a
-/// catalog where every cached alias has a real ``<n>b`` token the
-/// two heuristics converge for the dominant Quickstart case
-/// (bonsai-1.7b-2bit wins on both), and alphabetical avoids the
-/// estimator-overhead the picker doesn't otherwise need on the
-/// hot path.
+/// A cached model is only useful as a default if it is also a good default.
+/// Alphabetical order made a 256 GB Mac choose ``bonsai-27b-2bit`` while the
+/// stronger ``qwen3.6-35b-4bit`` was already on disk. Rank known candidates
+/// by the curated RAM table instead: start at this Mac's tier, walk downward,
+/// and keep each tier's smart pick ahead of its fast alternative. This reuses
+/// the same measured capability decisions the recommendation UI presents.
+/// Aliases outside that table retain an alphabetical fallback; inventing a
+/// quality score from parameter count or quantization would be less honest
+/// than admitting that no curated comparison exists.
 ///
 /// ## Why we filter out unparseable-params aliases for step 2
 ///
@@ -484,7 +493,7 @@ enum CacheAwareDefault {
             .filter { $0.cached }
             .filter { ModelSizing.estimate(alias: $0.alias).paramsBillions != nil }
             .filter { isSafe($0, on: hardware) }
-        if let pick = firstAlphabetical(cachedCandidates) {
+        if let pick = preferredCachedAlias(cachedCandidates, on: hardware) {
             return pick
         }
 
@@ -512,5 +521,17 @@ enum CacheAwareDefault {
             .map(\.alias)
             .sorted(by: { $0.localizedStandardCompare($1) == .orderedAscending })
             .first
+    }
+
+    private static func preferredCachedAlias(
+        _ entries: [ModelEntry], on hardware: MacHardware
+    ) -> String? {
+        let aliases = Set(entries.map(\.alias))
+        if let curated = RAMBucketedDefault.preferenceOrder(
+            forPhysicalRAMGB: hardware.physicalRAMGB
+        ).first(where: aliases.contains) {
+            return curated
+        }
+        return firstAlphabetical(entries)
     }
 }

--- a/apps/rapid-mac/Tests/RapidTests/ModelPickerBarSectionOrderTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ModelPickerBarSectionOrderTests.swift
@@ -90,6 +90,24 @@ struct ModelPickerBarSectionOrderTests {
         #expect(pick != "bonsai-1.7b-2bit")
     }
 
+    @Test("#1564: skipping first-run guidance keeps the small starter instead of the 96 GB tier download")
+    func freshSkipKeepsStarterInsteadOfHugeTierDefault() {
+        let catalog = [
+            entry(QuickstartCoordinator.defaultChoice.alias,
+                  hfRepo: "mlx-community/LFM2.5-1.2B-Instruct-4bit", cached: false),
+            entry("qwen3.5-122b-mxfp4",
+                  hfRepo: "mlx-community/Qwen3.5-122B-A10B-mxfp4", cached: false),
+        ]
+
+        let pick = ModelPickerBar.quickstartEligibleDefault(
+            catalog: catalog,
+            eligible: true
+        )
+
+        #expect(pick == QuickstartCoordinator.defaultChoice.alias)
+        #expect(pick != "qwen3.5-122b-mxfp4")
+    }
+
     @Test("Completed or ineligible user is left to normal cache/RAM default policy")
     func ineligibleDefaultDoesNotOverrideNormalPolicy() {
         let catalog = [

--- a/apps/rapid-mac/Tests/RapidTests/ModelPickerBarSectionOrderTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ModelPickerBarSectionOrderTests.swift
@@ -90,24 +90,6 @@ struct ModelPickerBarSectionOrderTests {
         #expect(pick != "bonsai-1.7b-2bit")
     }
 
-    @Test("#1564: skipping first-run guidance keeps the small starter instead of the 96 GB tier download")
-    func freshSkipKeepsStarterInsteadOfHugeTierDefault() {
-        let catalog = [
-            entry(QuickstartCoordinator.defaultChoice.alias,
-                  hfRepo: "mlx-community/LFM2.5-1.2B-Instruct-4bit", cached: false),
-            entry("qwen3.5-122b-mxfp4",
-                  hfRepo: "mlx-community/Qwen3.5-122B-A10B-mxfp4", cached: false),
-        ]
-
-        let pick = ModelPickerBar.quickstartEligibleDefault(
-            catalog: catalog,
-            eligible: true
-        )
-
-        #expect(pick == QuickstartCoordinator.defaultChoice.alias)
-        #expect(pick != "qwen3.5-122b-mxfp4")
-    }
-
     @Test("Completed or ineligible user is left to normal cache/RAM default policy")
     func ineligibleDefaultDoesNotOverrideNormalPolicy() {
         let catalog = [

--- a/apps/rapid-mac/Tests/RapidTests/RAMBucketedDefaultTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/RAMBucketedDefaultTests.swift
@@ -362,6 +362,21 @@ struct CacheAwareDefaultTests {
         ModelEntry(alias: alias, hfRepo: "synthetic/\(alias)", sizeOnDisk: nil, cached: cached)
     }
 
+    @Test("Cached preference walks closest eligible tier downward, smart before fast")
+    func curatedPreferenceOrder() {
+        let order = RAMBucketedDefault.preferenceOrder(forPhysicalRAMGB: 256)
+        #expect(order.prefix(4) == [
+            "qwen3.5-122b-mxfp4",
+            "qwen3.6-35b-4bit",
+            "qwen3.6-35b-8bit",
+            "gemma-4-26b-4bit",
+        ])
+        #expect(Set(order).count == order.count)
+        #expect(RAMBucketedDefault.preferenceOrder(forPhysicalRAMGB: 4).prefix(2) == [
+            "lfm2.5-2.6b-4bit", "lfm2.5-1b-4bit",
+        ])
+    }
+
     // MARK: - Headline case (issue #436 repro)
 
     @Test("256 GB Mac with retired Bonsai cached — picker chooses coherent cached LFM")
@@ -399,19 +414,19 @@ struct CacheAwareDefaultTests {
 
     // MARK: - Step 2: cached-and-fits beats not-cached bucketed (the #436 fix)
 
-    @Test("Step 2: bucketed not cached, multiple cached candidates — alphabetical wins")
-    func multipleCachedAlphabeticalTieBreak() {
+    @Test("#1581 repro: cached fallback prefers the closest curated tier over alphabetical Bonsai")
+    func multipleCachedQualityAwareTieBreak() {
         let catalog = [
-            entry("qwen3.6-35b-4bit", cached: false),       // bucketed default
-            entry("gemma-4-12b-4bit", cached: true),        // alphabetical first
-            entry("qwen3.5-9b-4bit", cached: true),
+            entry("qwen3.5-122b-mxfp4", cached: false),
+            entry("bonsai-27b-2bit", cached: true),
+            entry("qwen3.6-35b-4bit", cached: true),
         ]
         let pick = CacheAwareDefault.pick(
             catalog: catalog,
             hardware: host(gb: 256),
-            bucketedDefault: "qwen3.6-35b-4bit"
+            bucketedDefault: "qwen3.5-122b-mxfp4"
         )
-        #expect(pick == "gemma-4-12b-4bit")
+        #expect(pick == "qwen3.6-35b-4bit")
     }
 
     @Test("Step 2: bucketed missing from catalog entirely — cached candidate wins")

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -997,6 +997,9 @@ flow_fresh_install() {
         || die "fresh install did not show telemetry consent"
     baseline fresh-install.consent "$OUT/consent-visible.json"
     dismiss_first_run
+    selected_model="$(element_field "$OUT/steady.json" ModelPickerBar.ModelMenu value)"
+    [[ "$selected_model" == *"lfm2.5-1b-4bit"* ]] \
+        || die "#1564: skipping Quickstart selected '$selected_model' instead of the small starter"
     for id in Sidebar.NewChat Sidebar.Launch rapid.chat.compose ChatView.SendOrStopButton ModelPickerBar.ModelMenu; do
         jq -e --arg id "$id" '.data.ui_elements[]? | select(.identifier == $id)' "$OUT/steady.json" >/dev/null \
             || die "post-onboarding shell missing $id"


### PR DESCRIPTION
## Summary

- replace alphabetical cached-model defaulting with the existing RAM-tier recommendation order
- keep the current small Quickstart starter after a fresh user chooses “Skip for now”
- strengthen the real fresh-install GoldenFlow to assert the selected alias, not only a scrubbed structural baseline

## Reproduction and root cause

- #1581 reproduces in `CacheAwareDefault`: on a 256 GB host with uncached `qwen3.5-122b-mxfp4` plus cached `bonsai-27b-2bit` and `qwen3.6-35b-4bit`, the old `localizedStandardCompare` fallback selects Bonsai solely because `b` sorts before `q`.
- #1564 no longer reproduces on main: the later Quickstart-eligible guard already pins the picker to `lfm2.5-1b-4bit` after Skip. The issue remained open and its GoldenFlow baseline scrubbed the alias, so this PR adds an explicit runtime assertion and regression test before closing it.

## Fix

`RAMBucketedDefault.preferenceOrder` walks from the closest RAM tier the Mac qualifies for toward smaller tiers, preserving Smart-before-Fast and deduplicating aliases. `CacheAwareDefault` selects the first safe cached candidate in that curated order. Models absent from the curated table retain the deterministic alphabetical fallback rather than receiving an invented quality score.

## Validation

- `swift build --package-path apps/rapid-mac`
- `bash -n apps/rapid-mac/scripts/gui-golden-flows.sh`
- assembled the full debug `.app` successfully
- local `swift test` is blocked by the selected Command Line Tools environment lacking the `Testing` module; macOS CI is authoritative
- local GoldenFlow launch is blocked because the current macOS screen session is locked; the PR GUI job runs the strengthened `fresh-install` flow

Closes #1581
Closes #1564
