### PR TITLE
chore: bump version to 0.12.9

### DIFF
--- a/apps/rapid-mac/CHANGELOG.md
+++ b/apps/rapid-mac/CHANGELOG.md
@@ -13,6 +13,55 @@ can actually understand.
 
 ## [Unreleased]
 
+## [0.12.9] — 2026-08-10
+
+The desktop app can hear and speak now: a new Audio tab turns recordings into
+text and text into speech, in a voice you pick — all on your Mac. Underneath,
+Chat and Images learned to keep more than one model warm at once so switching
+back to a recent one is instant, a new Muse Glimmer model joins the roster, and
+math in chat finally renders as math instead of raw markup. The rest is the app
+smoothing rough edges around updates, the main window, memory prompts, and
+reusing models you already have.
+
+Bundles the **Rapid-MLX 0.12.9** engine.
+
+### Added
+
+- **A new Audio tab: turn recordings into text, and text into speech.** Drop in
+  or record audio and get a transcript back; or type a line, choose a voice, and
+  hear it spoken aloud. Each built-in voice can be previewed before you pick it,
+  and everything runs locally on your Mac — no upload, no account.
+
+- **Chat and Images keep more than one model ready at once.** Within a memory
+  budget you control, the models you have been using stay loaded, so switching
+  back to a recent one responds immediately instead of pausing to reload it.
+  When the budget is tight, the least-recently-used model steps aside on its own.
+
+- **New model: Muse Glimmer 30B.** A native text model with tool-calling and
+  step-by-step reasoning, available in a compact 4-bit build or full precision —
+  no extra runtime needed.
+
+### Fixed
+
+- **Math in chat renders as math in the shipped app.** Equations now display as
+  formatted mathematics rather than the raw LaTeX they briefly showed in
+  downloaded copies.
+
+- **A fresh install reuses models you already downloaded** — both from an earlier
+  Rapid install and from another MLX app on your Mac — so first launch does not
+  re-download gigabytes you already have.
+
+- **Updates and image previews no longer get stuck in a stale state**, the main
+  window closes and reopens cleanly, and overlapping "free up memory?" prompts no
+  longer pile on top of each other.
+
+- **When a model wrongly insists it cannot access real-time information, Chat
+  quietly asks once more** so you still get a real answer instead of a refusal.
+
+- Under the hood: vision models that mix text and images now run through a single
+  ordered lane for stability, and model-status metrics are exposed for
+  diagnostics.
+
 ## [0.12.8] — 2026-08-10
 
 The desktop app makes pictures now: a new Images tab renders locally, and Chat

--- a/apps/rapid-mac/Resources/Info.plist
+++ b/apps/rapid-mac/Resources/Info.plist
@@ -19,9 +19,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.12.8</string>
+	<string>0.12.9</string>
 	<key>CFBundleVersion</key>
-	<string>152</string>
+	<string>153</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>14.0</string>
 	<key>NSHighResolutionCapable</key>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.12.8"
+version = "0.12.9"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Why

Cut the **0.12.9** release. 15 commits have landed on `main` since `v0.12.8`; this bumps the version so `auto-release.yml` tags `v0.12.9` + `rapid-mac-v0.12.9` (after the Studio Tier-1 agent gate) and publishes engine + app together.

Bumps `pyproject` `0.12.8 → 0.12.9`, `Info.plist` `CFBundleShortVersionString 0.12.8 → 0.12.9` / `CFBundleVersion 152 → 153`, and adds the `apps/rapid-mac/CHANGELOG.md` `## [0.12.9]` section the release job pre-checks. No product code changes.

## What ships (delta since v0.12.8)

**Added**
- Audio tab — transcription + speech + voice previews (#1786)
- Budgeted multi-model residency for Chat and Images (#1788)
- Muse Glimmer 30B native text model + ATEM tool/reasoning parsers (#1791, #1802)

**Fixed**
- Math rendering in the shipped desktop app (#1797)
- Updater + image-cache state (#1794), main-window close handling (#1795), overlapping memory confirmations (#1800)
- Reuse already-downloaded models on a fresh/isolated first run (#1801) and from another MLX runtime (#1785 / #1718)
- Re-synthesize once when a grounded answer wrongly denies real-time access (#1784)
- MLLM hybrid vision models serialized lane (#1798), MLLM status metrics (#1781)
- External-model Swift test contracts (#1799)

## Local build + dogfood (before tag)

Built `Rapid-MLX Desktop.app` from `main` HEAD with the **real bundled sidecar** (rapid-mlx 0.12.8 + mlx-audio 0.4.3 + soundfile + mlx-vlm + mflux), codesign seal verified. Drove the **bundled sidecar** headlessly (screen was locked, so no visual walk — GUI first-paint is covered by CI `release-smoke` + golden-flow AX snapshots, green on `main`):

- ✅ Chat (gpt-oss-20b) — real tokens, correct answer
- ✅ Tool-call — `tool_calls` fire correctly
- ✅ Multi-model residency `/v1/models/load` (#1788) — two models co-resident, HTTP 200
- ✅ Audio round-trip (#1786) — qwen3-tts → valid 161 KB WAV → whisper transcript ("the quick brown fox…", 9/10 words exact)
- ✅ Muse Glimmer parsers + backbone bundled (no unbundled-parser 500 risk); 30B weights not cached locally → live inference deferred to the Studio Tier-1 gate
- ✅ Graceful 503 for the unshipped Kokoro path (trimmed to qwen3_tts by design) — clean error, not a crash
- ✅ App launches without crash (isolated bundle-id + throwaway HOME; only an `unclean_shutdown` marker from SIGTERM, no signal/exception)
- ✅ `smoke.sh` — package compiles + fake-CLI contract holds

DevSnapshot LIVE could not complete offscreen because #1787 added `@Environment(MCPCatalog)` to the chat path that the dev harness's `liveContentView` doesn't inject — **harness-only**, the real scene injects it (`RapidApp.swift` L245-248/370-373).

Closes the 0.12.9 release train.