### PR TITLE
fix(muse): close the 5 red gates #1802 left for Muse Glimmer

### DIFF
--- a/scripts/audit_tool_parser_coverage.py
+++ b/scripts/audit_tool_parser_coverage.py
@@ -132,6 +132,19 @@ MATRIX_EXEMPT: dict[str, str] = {
         "tests/test_tool_call_streaming_parity.py."
     ),
     "liquid": "alias of lfm",
+    "muse": (
+        "TODO: add mlx-community/Muse-Glimmer-30B-4bit to golden_models "
+        "when the pr_validate boot budget has a slot for the 30B (~18 GB, "
+        "min_memory_gb=24 — feasible, unlike the Ultra-only Hy3/DeepSeek-V4 "
+        "entries). Wire format (ATEM <atem:function_calls> blocks on "
+        "recipient-routed to=<tool> channels) is verified end-to-end another "
+        "way in the meantime: real 2-turn agent loops on a live "
+        "muse-glimmer-30b-4bit boot over /v1/chat/completions, /v1/responses "
+        "(codex), and /v1/messages (claude-code) all round-trip tool calls "
+        "cleanly (2026-08-10), and muse is the 6th family in the "
+        "tests/integrations agent-gate matrix. Class + parser coverage lives "
+        "in tests/test_muse_parsers.py and tests/test_muse_glimmer_model.py."
+    ),
 }
 
 

--- a/tests/test_disconnect_guard_aborts_scheduler.py
+++ b/tests/test_disconnect_guard_aborts_scheduler.py
@@ -663,6 +663,11 @@ async def test_batched_engine_publishes_request_id_into_holder():
     eng._stream_interval = 1
     eng._is_hybrid_model = lambda: False
     eng._create_output_router = lambda: None
+    # The finished-chunk path calls ``_muse_wire_model()`` (ATEM channel
+    # demux gate added in #1802), which reads this lazily-resolved flag that
+    # the real ``__init__`` seeds to None. This ``__new__`` bypass skips
+    # ``__init__``, so pre-seed it: this fake engine is not a muse checkpoint.
+    eng._is_muse_wire = False
 
     # Fake AsyncEngineCore so add_request returns a concrete id and
     # stream_outputs yields one finished chunk.

--- a/tests/test_tool_call_value_fidelity.py
+++ b/tests/test_tool_call_value_fidelity.py
@@ -177,6 +177,7 @@ _FIDELITY_EXEMPT: dict[str, str] = {
     "meetkai": "alias of functionary",
     "hy3": "alias of hy_v3",
     "hy_v3": "hy3_native, renderer TODO",
+    "muse": "muse_atem: <atem:function_calls> invoke/parameter blocks, renderer TODO",
     "llama": "llama_python_tag, renderer TODO",
     "llama3": "alias of llama",
     "llama4": "alias of llama",

--- a/vllm_mlx/model_sizes.json
+++ b/vllm_mlx/model_sizes.json
@@ -55,6 +55,8 @@
     "mlx-community/Mistral-Small-3.1-24B-Instruct-2503-4bit": 14119055427,
     "mlx-community/Mistral-Small-4-119B-2603-4bit": 67790336757,
     "mlx-community/Mistral-Small-4-119B-2603-8bit": 127279723730,
+    "mlx-community/Muse-Glimmer-30B-4bit": 19443239525,
+    "mlx-community/Muse-Glimmer-30B-bf16": null,
     "mlx-community/Nanbeige4.1-3B-4bit": 2231499570,
     "mlx-community/Phi-3.5-mini-instruct-4bit": 2152081350,
     "mlx-community/Qwen2.5-14B-Instruct-4bit": 8321091241,

--- a/vllm_mlx/models/muse_glimmer.py
+++ b/vllm_mlx/models/muse_glimmer.py
@@ -61,13 +61,24 @@ from typing import Any
 
 import mlx.core as mx
 import mlx.nn as nn
-from mlx_lm.models.base import (
+
+# MUST install the MLX hardware-compat shim BEFORE any ``from mlx_lm.*``
+# import (see ``vllm_mlx/models/deepseek_v4.py`` / ``hy_v3.py`` for the full
+# explanation — ``mlx_lm/__init__.py`` captures a thread-local stream at
+# module-import time that is unusable on M5 single-stream GPUs). The shim is
+# idempotent and a no-op on hardware where the original API works. Pinned by
+# ``tests/test_mlx_compat.py::test_every_mlx_lm_consumer_installs_shim``.
+from .. import _mlx_compat as _mlx_compat
+
+_mlx_compat.install()
+
+from mlx_lm.models.base import (  # noqa: E402
     BaseModelArgs,
     create_attention_mask,
     scaled_dot_product_attention,
 )
-from mlx_lm.models.cache import KVCache, RotatingKVCache
-from mlx_lm.models.rope_utils import initialize_rope
+from mlx_lm.models.cache import KVCache, RotatingKVCache  # noqa: E402
+from mlx_lm.models.rope_utils import initialize_rope  # noqa: E402
 
 _SLIDING = "sliding_attention"
 _FULL = "full_attention"


### PR DESCRIPTION
## Why

#1802 vendored the **Muse Glimmer 30B** text backbone and registered the `muse` tool/reasoning parsers + aliases, but **merged with five muse-only tests red**. Two are real defects; three are unregistered coverage. The model itself serves fine — real 2-turn agent loops on `/v1/chat/completions`, `/v1/responses` (Codex), and `/v1/messages` (Claude Code) all round-trip tool calls cleanly (verified on a live `muse-glimmer-30b-4bit` boot, 2026-08-10) — so these are **completion gaps, not wire bugs**. But two would bite on M5 hardware / in the disconnect-guard path.

Single root cause: muse was half-wired into the cross-cutting gates.

## What

| Fix | File | Red test it closes |
|---|---|---|
| **Real #404 M5 bug** — module did `from mlx_lm…` at import time without calling `_mlx_compat.install()` first, so mlx_lm's import-time thread-local stream capture is unusable on single-stream M5 GPUs. Install the idempotent shim before the imports (deepseek_v4 / hy_v3 pattern; no-op where the original API works). | `models/muse_glimmer.py` | `test_mlx_compat::test_every_mlx_lm_consumer_installs_shim` |
| **Real AttributeError** — #1802 added `_muse_wire_model()` (reads the `_is_muse_wire` flag `__init__` seeds) into the finished-chunk clean path. This test builds an engine via `__new__` (skips `__init__`) and hand-seeds attrs; it lacked `_is_muse_wire` → the muse gate raised. Seed it `False` (the fake engine is not a muse model). | `test_disconnect_guard_aborts_scheduler.py` | `test_batched_engine_publishes_request_id_into_holder` |
| Two muse aliases were absent from the size manifest. Add `Muse-Glimmer-30B-4bit` (19443239525 B, from `estimate_repo_size_bytes`) and `-bf16` (`null` — the mlx-community bf16 repo currently ships only README + .gitattributes, **no weight blobs**, so the size is genuinely unresolvable; `null` is the manifest's documented "unknown"). | `vllm_mlx/model_sizes.json` | `test_model_sizes::test_every_text_alias_has_a_manifest_entry` |
| Register `muse` in `MATRIX_EXEMPT` with a documented reason (verified e2e + 6th family in the tests/integrations agent matrix; parser/model unit coverage; golden_models boot TODO'd on the pr_validate budget) — the lfm/hy_v3 pattern. | `scripts/audit_tool_parser_coverage.py` | `test_tool_parser_coverage::test_tool_parser_matrix_coverage_clean` |
| Add `muse` to `_FIDELITY_EXEMPT` (muse_atem wire, renderer TODO) — the hy_v3 pattern. | `tests/test_tool_call_value_fidelity.py` | `test_tool_call_value_fidelity::test_every_parser_is_covered_or_exempt` |

## Tests

- All **five** previously-red tests now PASS.
- `test_muse_parsers.py` (59) and `test_muse_glimmer_model.py` (15) stay green — the import reorder does not perturb the arch (numeric parity, cache, sanitize all still pass).
- `ruff check` + `ruff format` clean. **No version bump.**

## Notes

Companion to #1808 (adds muse as the 6th family to the agent-gate integration matrix). This PR restores a green `main` for the muse coverage/regression gates #1802 left red. The bf16 alias's empty upstream repo (README-only) is noted but out of scope — the alias resolves and the manifest records it honestly as unknown.

🤖 This PR was written by Claude Code (Opus 4.8).