### PR TITLE
fix(mllm): fail in-flight requests on scheduler errors

### DIFF
--- a/tests/test_mllm_process_loop_errors.py
+++ b/tests/test_mllm_process_loop_errors.py
@@ -27,9 +27,11 @@ async def test_process_loop_failure_unblocks_every_inflight_request() -> None:
     # two adjacent translation maps.
     scheduler.running = {running.request_id: running}
     aborted = "already-aborted-request"
+    full_running_queue: asyncio.Queue = asyncio.Queue(maxsize=1)
+    full_running_queue.put_nowait(object())  # stale partial output
     scheduler.output_queues = {
         waiting.request_id: asyncio.Queue(),
-        running.request_id: asyncio.Queue(),
+        running.request_id: full_running_queue,
         uid_only: asyncio.Queue(),
         aborted: asyncio.Queue(),
     }
@@ -51,6 +53,10 @@ async def test_process_loop_failure_unblocks_every_inflight_request() -> None:
 
     task = asyncio.create_task(scheduler._process_loop())
     try:
+        # Let the fatal distributor confront the already-full bounded queue
+        # before any consumer frees a slot.
+        while scheduler.requests:
+            await asyncio.sleep(0)
         outputs = await asyncio.wait_for(
             asyncio.gather(
                 scheduler.output_queues[waiting.request_id].get(),

--- a/tests/test_mllm_process_loop_errors.py
+++ b/tests/test_mllm_process_loop_errors.py
@@ -17,6 +17,7 @@ async def test_process_loop_failure_unblocks_every_inflight_request() -> None:
     scheduler = MLLMScheduler.__new__(MLLMScheduler)
     waiting = MLLMRequest(request_id="waiting-request", prompt="hello")
     running = MLLMRequest(request_id="running-request", prompt="hello")
+    uid_only = "uid-only-request"
     scheduler.requests = {
         waiting.request_id: waiting,
         running.request_id: running,
@@ -25,21 +26,25 @@ async def test_process_loop_failure_unblocks_every_inflight_request() -> None:
     # The running map is keyed by request ID; generator UIDs live only in the
     # two adjacent translation maps.
     scheduler.running = {running.request_id: running}
+    aborted = "already-aborted-request"
     scheduler.output_queues = {
         waiting.request_id: asyncio.Queue(),
         running.request_id: asyncio.Queue(),
+        uid_only: asyncio.Queue(),
+        aborted: asyncio.Queue(),
     }
-    scheduler.request_id_to_uid = {running.request_id: 42}
-    scheduler.uid_to_request_id = {42: running.request_id}
-    scheduler._detokenizer_pool = {}
-    scheduler._pending_abort_ids = set()
-    scheduler._aborted_queue_ids = set()
+    scheduler.request_id_to_uid = {running.request_id: 42, uid_only: 43}
+    scheduler.uid_to_request_id = {42: running.request_id, 43: uid_only}
+    scheduler._detokenizer_pool = {running.request_id: object()}
+    scheduler._pending_abort_ids = {running.request_id}
+    scheduler._aborted_queue_ids = {aborted}
     scheduler.finished_req_ids = set()
     scheduler._running = True
     scheduler._injected_step_executor = None
     scheduler._step_executor = None
     scheduler._owns_step_executor = True
-    scheduler.batch_generator = None
+    batch_generator = MagicMock()
+    scheduler.batch_generator = batch_generator
     scheduler._step_no_queue = MagicMock(
         side_effect=TypeError("Model.__call__() missing required argument: mask")
     )
@@ -50,6 +55,8 @@ async def test_process_loop_failure_unblocks_every_inflight_request() -> None:
             asyncio.gather(
                 scheduler.output_queues[waiting.request_id].get(),
                 scheduler.output_queues[running.request_id].get(),
+                scheduler.output_queues[uid_only].get(),
+                scheduler.output_queues[aborted].get(),
             ),
             timeout=0.5,
         )
@@ -61,15 +68,25 @@ async def test_process_loop_failure_unblocks_every_inflight_request() -> None:
         except asyncio.CancelledError:
             pass
 
-    assert {output.request_id for output in outputs} == {
+    assert {output.request_id for output in outputs[:-1]} == {
         waiting.request_id,
         running.request_id,
+        uid_only,
     }
-    for output in outputs:
+    assert outputs[-1] is None
+    for output in outputs[:-1]:
         assert output.finished is True
         assert output.finish_reason == "length"
-        assert "TypeError" in output.error
-        assert "mask" in output.error
+        assert output.error == "MLLM inference failed due to an internal engine error"
+        assert "mask" not in output.error
     assert scheduler._step_no_queue.call_count == 1
+    batch_generator.close.assert_called_once_with()
+    assert scheduler.batch_generator is None
     assert not scheduler.requests
     assert not scheduler.waiting
+    assert not scheduler.running
+    assert not scheduler.request_id_to_uid
+    assert not scheduler.uid_to_request_id
+    assert not scheduler._detokenizer_pool
+    assert not scheduler._pending_abort_ids
+    assert not scheduler._aborted_queue_ids

--- a/tests/test_mllm_process_loop_errors.py
+++ b/tests/test_mllm_process_loop_errors.py
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression coverage for scheduler-level MLLM step failures (#1367)."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+
+from vllm_mlx.mllm_scheduler import MLLMRequest, MLLMScheduler
+
+
+@pytest.mark.asyncio
+async def test_process_loop_failure_unblocks_every_inflight_request() -> None:
+    """Unexpected mlx-vlm/model errors must not be logged and retried forever."""
+    scheduler = MLLMScheduler.__new__(MLLMScheduler)
+    request = MLLMRequest(request_id="broken", prompt="hello")
+    scheduler.requests = {request.request_id: request}
+    scheduler.waiting = __import__("collections").deque([request])
+    scheduler.running = {}
+    scheduler.output_queues = {request.request_id: asyncio.Queue()}
+    scheduler.request_id_to_uid = {}
+    scheduler.uid_to_request_id = {}
+    scheduler._detokenizer_pool = {}
+    scheduler._pending_abort_ids = set()
+    scheduler._aborted_queue_ids = set()
+    scheduler.finished_req_ids = set()
+    scheduler._running = True
+    scheduler._injected_step_executor = None
+    scheduler._step_executor = None
+    scheduler._owns_step_executor = True
+    scheduler.batch_generator = None
+    scheduler._step_no_queue = MagicMock(
+        side_effect=TypeError("Model.__call__() missing required argument: mask")
+    )
+
+    task = asyncio.create_task(scheduler._process_loop())
+    try:
+        output = await asyncio.wait_for(
+            scheduler.output_queues[request.request_id].get(), timeout=0.5
+        )
+    finally:
+        scheduler._running = False
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    assert output.finished is True
+    assert output.finish_reason == "length"
+    assert "TypeError" in output.error
+    assert "mask" in output.error
+    assert scheduler._step_no_queue.call_count == 1
+    assert not scheduler.requests
+    assert not scheduler.waiting

--- a/tests/test_mllm_process_loop_errors.py
+++ b/tests/test_mllm_process_loop_errors.py
@@ -15,13 +15,22 @@ from vllm_mlx.mllm_scheduler import MLLMRequest, MLLMScheduler
 async def test_process_loop_failure_unblocks_every_inflight_request() -> None:
     """Unexpected mlx-vlm/model errors must not be logged and retried forever."""
     scheduler = MLLMScheduler.__new__(MLLMScheduler)
-    request = MLLMRequest(request_id="broken", prompt="hello")
-    scheduler.requests = {request.request_id: request}
-    scheduler.waiting = __import__("collections").deque([request])
-    scheduler.running = {}
-    scheduler.output_queues = {request.request_id: asyncio.Queue()}
-    scheduler.request_id_to_uid = {}
-    scheduler.uid_to_request_id = {}
+    waiting = MLLMRequest(request_id="waiting-request", prompt="hello")
+    running = MLLMRequest(request_id="running-request", prompt="hello")
+    scheduler.requests = {
+        waiting.request_id: waiting,
+        running.request_id: running,
+    }
+    scheduler.waiting = __import__("collections").deque([waiting])
+    # The running map is keyed by request ID; generator UIDs live only in the
+    # two adjacent translation maps.
+    scheduler.running = {running.request_id: running}
+    scheduler.output_queues = {
+        waiting.request_id: asyncio.Queue(),
+        running.request_id: asyncio.Queue(),
+    }
+    scheduler.request_id_to_uid = {running.request_id: 42}
+    scheduler.uid_to_request_id = {42: running.request_id}
     scheduler._detokenizer_pool = {}
     scheduler._pending_abort_ids = set()
     scheduler._aborted_queue_ids = set()
@@ -37,8 +46,12 @@ async def test_process_loop_failure_unblocks_every_inflight_request() -> None:
 
     task = asyncio.create_task(scheduler._process_loop())
     try:
-        output = await asyncio.wait_for(
-            scheduler.output_queues[request.request_id].get(), timeout=0.5
+        outputs = await asyncio.wait_for(
+            asyncio.gather(
+                scheduler.output_queues[waiting.request_id].get(),
+                scheduler.output_queues[running.request_id].get(),
+            ),
+            timeout=0.5,
         )
     finally:
         scheduler._running = False
@@ -48,10 +61,15 @@ async def test_process_loop_failure_unblocks_every_inflight_request() -> None:
         except asyncio.CancelledError:
             pass
 
-    assert output.finished is True
-    assert output.finish_reason == "length"
-    assert "TypeError" in output.error
-    assert "mask" in output.error
+    assert {output.request_id for output in outputs} == {
+        waiting.request_id,
+        running.request_id,
+    }
+    for output in outputs:
+        assert output.finished is True
+        assert output.finish_reason == "length"
+        assert "TypeError" in output.error
+        assert "mask" in output.error
     assert scheduler._step_no_queue.call_count == 1
     assert not scheduler.requests
     assert not scheduler.waiting

--- a/tests/test_mllm_process_loop_errors.py
+++ b/tests/test_mllm_process_loop_errors.py
@@ -18,6 +18,7 @@ async def test_process_loop_failure_unblocks_every_inflight_request() -> None:
     waiting = MLLMRequest(request_id="waiting-request", prompt="hello")
     running = MLLMRequest(request_id="running-request", prompt="hello")
     uid_only = "uid-only-request"
+    pending_only = "pending-only-request"
     scheduler.requests = {
         waiting.request_id: waiting,
         running.request_id: running,
@@ -33,12 +34,13 @@ async def test_process_loop_failure_unblocks_every_inflight_request() -> None:
         waiting.request_id: asyncio.Queue(),
         running.request_id: full_running_queue,
         uid_only: asyncio.Queue(),
+        pending_only: asyncio.Queue(),
         aborted: asyncio.Queue(),
     }
     scheduler.request_id_to_uid = {running.request_id: 42, uid_only: 43}
     scheduler.uid_to_request_id = {42: running.request_id, 43: uid_only}
     scheduler._detokenizer_pool = {running.request_id: object()}
-    scheduler._pending_abort_ids = {running.request_id}
+    scheduler._pending_abort_ids = {running.request_id, pending_only}
     scheduler._aborted_queue_ids = {aborted}
     scheduler.finished_req_ids = set()
     scheduler._running = True
@@ -55,13 +57,17 @@ async def test_process_loop_failure_unblocks_every_inflight_request() -> None:
     try:
         # Let the fatal distributor confront the already-full bounded queue
         # before any consumer frees a slot.
-        while scheduler.requests:
-            await asyncio.sleep(0)
+        async def _wait_until_failed() -> None:
+            while scheduler.requests:
+                await asyncio.sleep(0)
+
+        await asyncio.wait_for(_wait_until_failed(), timeout=0.5)
         outputs = await asyncio.wait_for(
             asyncio.gather(
                 scheduler.output_queues[waiting.request_id].get(),
                 scheduler.output_queues[running.request_id].get(),
                 scheduler.output_queues[uid_only].get(),
+                scheduler.output_queues[pending_only].get(),
                 scheduler.output_queues[aborted].get(),
             ),
             timeout=0.5,
@@ -78,6 +84,7 @@ async def test_process_loop_failure_unblocks_every_inflight_request() -> None:
         waiting.request_id,
         running.request_id,
         uid_only,
+        pending_only,
     }
     assert outputs[-1] is None
     for output in outputs[:-1]:

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -1234,6 +1234,53 @@ class MLLMScheduler:
                 except asyncio.QueueFull:
                     pass
 
+    def _fail_all_inflight(self, exc: Exception) -> MLLMSchedulerOutput:
+        """Fail and detach every request after an unexpected step exception.
+
+        A model/processor exception can escape before ``_step_no_queue`` has
+        produced an output.  Retrying that same batch is both unsafe (the
+        generator may already be partially mutated) and leaves every HTTP
+        waiter blocked.  Reset the poisoned batch and return terminal outputs
+        for event-loop-thread delivery instead.
+        """
+        request_ids = set(self.requests) | set(self.running)
+        request_ids.update(request.request_id for request in self.waiting)
+        err_text = f"MLLM engine loop error: {type(exc).__name__}: {exc}"
+
+        output = MLLMSchedulerOutput(
+            finished_request_ids=request_ids,
+            outputs=[
+                RequestOutput(
+                    request_id=request_id,
+                    output_text="",
+                    finished=True,
+                    finish_reason="length",
+                    error=err_text,
+                )
+                for request_id in request_ids
+            ],
+        )
+
+        for request_id in request_ids:
+            request = self.requests.get(request_id)
+            if request is not None:
+                request.status = RequestStatus.FINISHED_ABORTED
+        if self.batch_generator is not None:
+            try:
+                self.batch_generator.close()
+            except Exception:
+                logger.debug("Failed to close poisoned MLLM batch", exc_info=True)
+            self.batch_generator = None
+        self.waiting.clear()
+        self.running.clear()
+        self.requests.clear()
+        self.request_id_to_uid.clear()
+        self.uid_to_request_id.clear()
+        self._detokenizer_pool.clear()
+        self._pending_abort_ids.clear()
+        self.finished_req_ids.update(request_ids)
+        return output
+
     def step(self) -> MLLMSchedulerOutput:
         """
         Execute one scheduling step (includes queue distribution).
@@ -1491,8 +1538,11 @@ class MLLMScheduler:
                 except asyncio.CancelledError:
                     break
                 except Exception as e:
-                    logger.error(f"Error in MLLM process loop: {e}")
-                    await asyncio.sleep(0.1)
+                    logger.exception(
+                        "Error in MLLM process loop; failing in-flight requests"
+                    )
+                    self._distribute_outputs(self._fail_all_inflight(e))
+                    await asyncio.sleep(0)
         finally:
             cancel_to_reraise: asyncio.CancelledError | None = None
             if self._step_executor is not None:

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -1243,6 +1243,10 @@ class MLLMScheduler:
         waiter blocked.  Reset the poisoned batch and return terminal outputs
         for event-loop-thread delivery instead.
         """
+        # ``running`` is keyed by request ID (see ``_schedule_waiting``), not
+        # by the generator UID.  Include it explicitly because a partially
+        # failed scheduling step may have moved a request there before it was
+        # committed to every other bookkeeping map.
         request_ids = set(self.requests) | set(self.running)
         request_ids.update(request.request_id for request in self.waiting)
         err_text = f"MLLM engine loop error: {type(exc).__name__}: {exc}"
@@ -1278,6 +1282,9 @@ class MLLMScheduler:
         self.uid_to_request_id.clear()
         self._detokenizer_pool.clear()
         self._pending_abort_ids.clear()
+        # Do not clear ``_aborted_queue_ids`` here. ``_distribute_outputs``
+        # runs immediately after this helper and must still signal requests
+        # that completed an abort just before the fatal step exception.
         self.finished_req_ids.update(request_ids)
         return output
 

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -1249,7 +1249,15 @@ class MLLMScheduler:
         # committed to every other bookkeeping map.
         request_ids = set(self.requests) | set(self.running)
         request_ids.update(request.request_id for request in self.waiting)
-        err_text = f"MLLM engine loop error: {type(exc).__name__}: {exc}"
+        # A step can fail between generator admission and the scheduler-map
+        # commit. Include both sides of the UID translation so even that
+        # partially transitioned request gets its terminal queue signal.
+        request_ids.update(self.request_id_to_uid)
+        request_ids.update(self.uid_to_request_id.values())
+        # Third-party exceptions can contain paths, prompt fragments, or model
+        # internals. The detailed traceback is logged by the caller; clients
+        # receive only this stable 500-class message.
+        err_text = "MLLM inference failed due to an internal engine error"
 
         output = MLLMSchedulerOutput(
             finished_request_ids=request_ids,
@@ -1258,6 +1266,10 @@ class MLLMScheduler:
                     request_id=request_id,
                     output_text="",
                     finished=True,
+                    # RequestOutput/OpenAI schemas do not admit an "error"
+                    # finish reason. ``stream_outputs`` raises ``error``
+                    # before yielding this object, so clients cannot mistake
+                    # this compatibility literal for a successful truncation.
                     finish_reason="length",
                     error=err_text,
                 )

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -1222,7 +1222,19 @@ class MLLMScheduler:
                     if req_output.finished:
                         queue.put_nowait(None)  # Signal end
                 except asyncio.QueueFull:
-                    pass
+                    if req_output.finished:
+                        # A terminal result must never be dropped behind stale
+                        # deltas in a bounded/custom queue. Discard buffered
+                        # partial output and reserve the available slot for the
+                        # terminal object. ``stream_outputs`` stops (or raises
+                        # on ``error``) after reading it, so the optional None
+                        # sentinel is not required in this fallback path.
+                        while not queue.empty():
+                            try:
+                                queue.get_nowait()
+                            except asyncio.QueueEmpty:  # pragma: no cover - race
+                                break
+                        queue.put_nowait(req_output)
 
         # Signal queues for requests aborted during this step
         while self._aborted_queue_ids:

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -1266,6 +1266,10 @@ class MLLMScheduler:
         # partially transitioned request gets its terminal queue signal.
         request_ids.update(self.request_id_to_uid)
         request_ids.update(self.uid_to_request_id.values())
+        # An abort can be accepted after the request has otherwise been
+        # detached. Its queue still needs a terminal signal before the pending
+        # ledger is cleared below.
+        request_ids.update(self._pending_abort_ids)
         # Third-party exceptions can contain paths, prompt fragments, or model
         # internals. The detailed traceback is logged by the caller; clients
         # receive only this stable 500-class message.


### PR DESCRIPTION
## Summary

- fail every active MLLM request when an unexpected model/processor step exception escapes
- reset the potentially poisoned batch-generator state before accepting later work
- deliver a structured terminal error instead of logging and retrying the same batch forever

## Root cause

`MLLMScheduler._process_loop` caught unexpected exceptions from `_step_no_queue`, logged them, slept, and retried without changing request or batch state. Persistent signature/runtime failures therefore repeated indefinitely and left HTTP clients waiting forever.

## Reproduction

A deterministic regression injects the reported `TypeError` (`Model.__call__() missing required argument: mask`). On main, the same request was retried five times in 0.5 seconds and its output queue timed out. With this change it executes once, returns a terminal error, and clears in-flight state.

## Validation

- `pytest -q tests/test_mllm_process_loop_errors.py tests/test_mllm_continuous_batching.py tests/test_mllm_corrupt_image.py tests/test_mllm_executor_cancel.py` (66 passed, 3 deselected)
- `ruff check vllm_mlx/mllm_scheduler.py tests/test_mllm_process_loop_errors.py`
- `git diff --check`

Closes #1367