### PR TITLE
fix(auth): fail closed on empty companion and duplicate x-api-key (#337)

### DIFF
--- a/tests/test_anthropic_route_auth.py
+++ b/tests/test_anthropic_route_auth.py
@@ -326,6 +326,69 @@ def test_anthropic_messages_rejects_mixed_invalid_x_api_key(anthropic_client):
     assert engine.calls == []
 
 
+def test_anthropic_messages_rejects_empty_companion_x_api_key(anthropic_client):
+    """A valid Bearer paired with a *present but empty* ``x-api-key`` header
+    must fail closed: presence of a credential header means it has to be
+    valid, so an empty companion can never satisfy it (#337)."""
+    client = anthropic_client.client
+    engine = anthropic_client.engine
+
+    response = client.post(
+        "/v1/messages",
+        json=_messages_payload(),
+        headers={
+            "Authorization": "Bearer test-secret",
+            "x-api-key": "",
+        },
+    )
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Invalid API key"
+    assert engine.calls == []
+
+
+def test_anthropic_messages_rejects_duplicate_x_api_key_when_one_invalid(
+    anthropic_client,
+):
+    """Multiple ``x-api-key`` headers must *all* match — the ``get`` accessor
+    only saw one value, letting a valid header smuggle an invalid twin past
+    the gate (#337). ``getlist`` closes that by verifying every value."""
+    client = anthropic_client.client
+    engine = anthropic_client.engine
+
+    response = client.post(
+        "/v1/messages",
+        json=_messages_payload(),
+        headers=[
+            (b"x-api-key", b"test-secret"),
+            (b"x-api-key", b"wrong-secret"),
+        ],
+    )
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Invalid API key"
+    assert engine.calls == []
+
+
+def test_anthropic_messages_accepts_duplicate_matching_x_api_key(anthropic_client):
+    """Repeating the *same* valid ``x-api-key`` stays accepted — the rule is
+    'every present credential must match,' not 'exactly one header.'"""
+    client = anthropic_client.client
+    engine = anthropic_client.engine
+
+    response = client.post(
+        "/v1/messages",
+        json=_messages_payload(),
+        headers=[
+            (b"x-api-key", b"test-secret"),
+            (b"x-api-key", b"test-secret"),
+        ],
+    )
+
+    assert response.status_code == 200
+    assert len(engine.calls) == 1
+
+
 def test_anthropic_messages_respects_rate_limit(anthropic_client):
     client = anthropic_client.client
     anthropic_client.rate_limiter.enabled = True

--- a/vllm_mlx/middleware/auth.py
+++ b/vllm_mlx/middleware/auth.py
@@ -254,7 +254,16 @@ async def check_rate_limit_or_x_api_key(request: Request):
 
 
 def _verify_api_key_values(*api_keys: str | None) -> bool:
-    """Verify one or more API key values against the configured key."""
+    """Verify one or more API key values against the configured key.
+
+    ``None`` marks a credential header that was *absent* and is skipped. Any
+    header that was *present* — including one carrying an empty value — reaches
+    the comparison below and must match, so a present-but-empty companion
+    ``x-api-key`` fails closed instead of being silently dropped (#337). An
+    empty string can never match a configured (non-empty) key, and
+    ``compare_digest`` returns ``False`` for it without a length short-circuit,
+    so the constant-time discipline is preserved.
+    """
     global _auth_warning_logged
 
     cfg = get_config()
@@ -267,7 +276,7 @@ def _verify_api_key_values(*api_keys: str | None) -> bool:
             _auth_warning_logged = True
         return True
 
-    provided_keys = [api_key for api_key in api_keys if api_key]
+    provided_keys = [api_key for api_key in api_keys if api_key is not None]
     if not provided_keys:
         raise HTTPException(status_code=401, detail="API key required")
     valid = True
@@ -298,4 +307,10 @@ async def verify_api_key_or_x_api_key(
 ):
     """Verify OpenAI Bearer auth or Anthropic x-api-key auth."""
     bearer_key = credentials.credentials if credentials is not None else None
-    return _verify_api_key_values(bearer_key, request.headers.get("x-api-key"))
+    # ``getlist`` so a duplicated ``x-api-key`` header can't smuggle an invalid
+    # value past the gate alongside a valid twin — every present value is
+    # verified, extending the "both must match" rule to multi-valued headers
+    # (#337). An absent header yields ``[]`` (nothing added), while a present
+    # empty header yields ``[""]`` and is checked as a supplied credential.
+    x_api_keys = request.headers.getlist("x-api-key")
+    return _verify_api_key_values(bearer_key, *x_api_keys)


### PR DESCRIPTION
## Why

Closes the two remaining auth-hardening follow-ups tracked in #337. Both are non-exploitable hardening gaps (not bypasses): a request that *should* be rejected was accepted.

## What

**`vllm_mlx/middleware/auth.py`**

1. **Empty companion header** — `_verify_api_key_values` filtered *falsy* values, so `Authorization: Bearer test-secret` + a present-but-empty `x-api-key:` header was accepted. The filter now drops only **absent** (`None`) credentials; a present empty value flows into `secrets.compare_digest` and fails. An empty string can't match a configured (non-empty) key and `compare_digest` returns `False` for it **without a length short-circuit**, so the constant-time discipline (#1271) is preserved.

2. **Duplicate `x-api-key` header** — `verify_api_key_or_x_api_key` used `request.headers.get("x-api-key")`, which only sees one value, letting an invalid duplicate ride past the gate next to a valid one. Switched to `request.headers.getlist("x-api-key")` and splat every value into the verifier, so the existing *"all supplied credentials must match"* rule extends to multi-valued headers.

The third item in #337 (bearer-token whitespace normalization) was already resolved by #1291 — this PR finishes the issue.

## Tests

`tests/test_anthropic_route_auth.py` — 3 new regression tests (fail before, pass after):
- `test_anthropic_messages_rejects_empty_companion_x_api_key` → 401
- `test_anthropic_messages_rejects_duplicate_x_api_key_when_one_invalid` → 401
- `test_anthropic_messages_accepts_duplicate_matching_x_api_key` → 200 (control: same valid value repeated stays accepted)

All 71 tests across the four auth suites (`test_anthropic_route_auth`, `test_http_auth`, `test_internal_route_auth`, `test_server_auth_ordering`) pass. Ruff check + format clean.

## Notes

- No version bump.
- Behavior change limited to previously-accepted malformed credential shapes; all valid single-header flows are untouched.
- Rate-limit *bucketing* (`_anthropic_rate_limit_client_id`) is intentionally left alone — #337's items are about auth verification, not bucketing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

AI-generated (Claude Opus 4.8) under human direction; author has reviewed.