### PR TITLE
test(validation): remove state-dependent gate flakes

### DIFF
--- a/tests/integrations/test_pydantic_ai_full.py
+++ b/tests/integrations/test_pydantic_ai_full.py
@@ -70,12 +70,22 @@ if __name__ == "__main__":
             age: int
 
         # Keep the output-tool assertion deterministic and bound any retry.
+        # Be explicit about every required field: this test runs after the
+        # stress and two other agent suites in the PR lane, while a failure is
+        # confirmed against a fresh base server.  The terse "Extract" prompt
+        # made Qwen3.5 occasionally emit only ``age`` in the warmed lane even
+        # at temperature=0, producing a repeatable false PR/base differential.
+        # The contract under test is schema transport, not whether the model
+        # can infer which details to copy from an underspecified instruction.
         agent = Agent(
             model,
             output_type=Person,
             model_settings={"temperature": 0.0, "max_tokens": 256},
         )
-        r = agent.run_sync("Extract: 'Alice is 30 years old'")
+        r = agent.run_sync(
+            "Call the final_result output tool with both required fields: "
+            "name='Alice' and age=30. Do not omit either field."
+        )
         assert isinstance(r.output, Person), type(r.output)
         assert r.output.name.lower() == "alice", r.output.name
         assert r.output.age == 30, r.output.age

--- a/tests/test_release_check_random.py
+++ b/tests/test_release_check_random.py
@@ -539,6 +539,10 @@ def test_a_stolen_port_during_boot_aborts_the_sweep(g12, monkeypatch, tmp_path):
     report = tmp_path / "report.log"
 
     monkeypatch.setattr(g12.subprocess, "Popen", _popen)
+    # This is a unit test of takeover handling after launch. Do not let an
+    # unrelated local Rapid-MLX instance on the default port short-circuit
+    # ``main`` before the mocked boot path runs.
+    monkeypatch.setattr(g12, "_port_free", lambda port: True)
     monkeypatch.setattr(g12, "_free_disk_gb", lambda path: 10_000.0)
     # The stranger arrives while the FIRST model is booting.
     monkeypatch.setattr(
@@ -878,6 +882,7 @@ def test_the_bench_transcript_is_wired_to_the_bench_log_not_the_server_log(
     aliases.write_text(json.dumps(_fake_aliases()))
 
     monkeypatch.setattr(g12.subprocess, "Popen", lambda cmd, **kw: _Proc())
+    monkeypatch.setattr(g12, "_port_free", lambda port: True)
     monkeypatch.setattr(g12, "_free_disk_gb", lambda path: 10_000.0)
     monkeypatch.setattr(
         g12, "_wait_for_server", lambda proc, port, timeout, log: (True, False)
@@ -927,6 +932,7 @@ def test_the_report_defaults_into_the_private_directory(
     """An unspecified --report must not land on a fixed name in /tmp."""
     aliases = tmp_path / "aliases.json"
     aliases.write_text(json.dumps(_fake_aliases()))
+    monkeypatch.setattr(g12, "_port_free", lambda port: True)
     monkeypatch.setattr(g12, "_free_disk_gb", lambda path: 10_000.0)
     monkeypatch.setattr(
         g12, "_wait_for_server", lambda proc, port, timeout, log: (False, False)


### PR DESCRIPTION
## Summary

- make the PydanticAI structured-output prompt explicitly name both required schema fields
- isolate three random-release unit tests from unrelated listeners on the default port
- keep both gates focused on their intended contract instead of ambient model/process state

## Root causes

The PydanticAI PR lane runs after stress and two other agent suites, while failure confirmation uses a fresh base server. Qwen3.5 repeatedly omitted `name` only for the terse warmed-lane prompt, creating a false PR/base differential.

Separately, three `release_check_m3_random` unit tests mocked launch and readiness but not the pre-launch `_port_free` check. Any developer already running Rapid-MLX on port 8000 therefore short-circuited those tests before their subject executed.

## Validation

- real Qwen3.5-35B-A3B-8bit: PydanticAI 6/6 in three consecutive runs on the same progressively warmed process
- the three previously failing random-release tests pass while a real Rapid-MLX process remains bound to port 8000
- ruff check + format check on both changed files
- git diff --check