### PR TITLE
feat: ling-3.0-tiny-4bit alias — first MLX conversion, hosted under rapid-mlx

### DIFF
--- a/tests/test_bailing_hybrid_model.py
+++ b/tests/test_bailing_hybrid_model.py
@@ -272,3 +272,19 @@ def test_gate_group_drop_masks_whole_group():
     idx, _ = gate(mx.zeros((1, 3, TINY["hidden_size"])))
     chosen = set(np.array(idx).flatten().tolist())
     assert chosen <= {4, 5, 6, 7}, chosen  # nothing from dropped group 0
+
+
+def test_alias_pins_ling_configuration():
+    import json
+    from pathlib import Path
+
+    aliases = json.loads(
+        (Path(__file__).parent.parent / "vllm_mlx" / "aliases.json").read_text()
+    )
+    entry = aliases["ling-3.0-tiny-4bit"]
+    assert entry["hf_path"] == "rapid-mlx/Ling-3.0-tiny-MLX-4bit"
+    assert entry["tool_call_parser"] == "glm47"
+    assert entry["reasoning_parser"] == "qwen3"
+    assert entry["is_hybrid"] is True
+    assert entry["is_hybrid_explicit"] is True
+    assert entry["is_moe"] is True

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -1208,6 +1208,16 @@
     "supports_spec_decode": false,
     "min_memory_gb": 96
   },
+  "ling-3.0-tiny-4bit": {
+    "hf_path": "rapid-mlx/Ling-3.0-tiny-MLX-4bit",
+    "tool_call_parser": "glm47",
+    "reasoning_parser": "qwen3",
+    "is_hybrid": true,
+    "is_hybrid_explicit": true,
+    "is_moe": true,
+    "supports_spec_decode": false,
+    "min_memory_gb": 8
+  },
   "qwen3-vl-8b-4bit": {
     "hf_path": "mlx-community/Qwen3-VL-8B-Instruct-4bit",
     "tool_call_parser": "hermes",


### PR DESCRIPTION
## Why

PR #1817 landed the vendored `bailing_hybrid` backbone; this wires the user-facing alias now that the converted checkpoint has a home: **rapid-mlx/Ling-3.0-tiny-MLX-4bit** (the first MLX conversion of Ling-3.0-tiny anywhere, 4.2 GB @ 4.507 bpw, converted and parity-verified by that PR's implementation). `min_memory_gb: 8` — this is the 8 GB tier's strongest agent-capable option.

## What

- `aliases.json`: `ling-3.0-tiny-4bit` → `rapid-mlx/Ling-3.0-tiny-MLX-4bit`, glm47 tool parser + qwen3 reasoning parser (both fixture-verified in #1817), `is_hybrid: true` explicit (#1764 discipline), `is_moe: true`, spec-decode off.
- Alias-pin test in `tests/test_bailing_hybrid_model.py`.

## Test plan

- [x] `pytest tests/test_bailing_hybrid_model.py` (12 passed)
- [x] Alias resolution exercised via the existing `detect_model_config` tests (name pattern) + new pin test
- [x] Real-weights e2e for this exact artifact done in #1817 (5-scenario battery on M2 Pro)

🤖 Generated with [Claude Code](https://claude.com/claude-code)