### PR TITLE
test(mac): add native XCUITest pixel coverage (#1719)

### DIFF
--- a/.github/workflows/rapid-mac-ci.yml
+++ b/.github/workflows/rapid-mac-ci.yml
@@ -281,6 +281,23 @@ jobs:
           RAPID_BUILD_CONFIG: debug
         run: ./scripts/build.sh
 
+      # #1719 — the first native XCUITest journey complements (and does not
+      # replace) the AX flows below. XCTest can capture an individual element,
+      # which closes the one gap AX structurally cannot: prove two gallery
+      # records actually draw different pixels rather than the same bitmap.
+      - name: 'XCUITest: image-generation pixels'
+        env:
+          RAPID_XCUI_RESULT_BUNDLE: ${{ runner.temp }}/RapidUITests.xcresult
+        run: ./scripts/run-xcui-tests.sh
+
+      - name: Upload XCUITest evidence
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: rapid-xcui-evidence
+          path: ${{ runner.temp }}/RapidUITests.xcresult
+          if-no-files-found: ignore
+
       # One step per flow so a red check names the journey that broke rather
       # than "golden flows failed". Each needs its own output directory: the
       # harness refuses to start on a non-empty one.

--- a/.github/workflows/rapid-mac-ci.yml
+++ b/.github/workflows/rapid-mac-ci.yml
@@ -286,12 +286,14 @@ jobs:
       # which closes the one gap AX structurally cannot: prove two gallery
       # records actually draw different pixels rather than the same bitmap.
       - name: 'XCUITest: image-generation pixels'
+        id: xcui
+        continue-on-error: true
         env:
           RAPID_XCUI_RESULT_BUNDLE: ${{ runner.temp }}/RapidUITests.xcresult
         run: ./scripts/run-xcui-tests.sh
 
       - name: Upload XCUITest evidence
-        if: failure()
+        if: steps.xcui.outcome == 'failure'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: rapid-xcui-evidence
@@ -341,6 +343,20 @@ jobs:
         run: ./scripts/gui-golden-flows.sh --flow window-close-prompt
         env:
           RAPID_GUI_GOLDEN_OUT: ${{ runner.temp }}/golden/window-close-prompt
+
+      # The XCUITest is allowed to fail temporarily only so the established AX
+      # journeys still execute and retain their independent evidence. Restore
+      # the blocking verdict after those flows; a red native journey remains a
+      # red GUI job and can never land.
+      - name: Require native XCUITest
+        if: always()
+        env:
+          XCUI_OUTCOME: ${{ steps.xcui.outcome }}
+        run: |
+          if [[ "$XCUI_OUTCOME" != success ]]; then
+            echo "::error::Native XCUITest failed ($XCUI_OUTCOME)"
+            exit 1
+          fi
 
       # The harness stops at the FIRST mismatched baseline and the job stops at
       # the first failing flow, so one red run reveals exactly one line. With 5

--- a/.github/workflows/rapid-mac-ci.yml
+++ b/.github/workflows/rapid-mac-ci.yml
@@ -344,20 +344,6 @@ jobs:
         env:
           RAPID_GUI_GOLDEN_OUT: ${{ runner.temp }}/golden/window-close-prompt
 
-      # The XCUITest is allowed to fail temporarily only so the established AX
-      # journeys still execute and retain their independent evidence. Restore
-      # the blocking verdict after those flows; a red native journey remains a
-      # red GUI job and can never land.
-      - name: Require native XCUITest
-        if: always()
-        env:
-          XCUI_OUTCOME: ${{ steps.xcui.outcome }}
-        run: |
-          if [[ "$XCUI_OUTCOME" != success ]]; then
-            echo "::error::Native XCUITest failed ($XCUI_OUTCOME)"
-            exit 1
-          fi
-
       # The harness stops at the FIRST mismatched baseline and the job stops at
       # the first failing flow, so one red run reveals exactly one line. With 5
       # baselines across 4 flows that is up to 5 push-and-wait cycles to see a
@@ -404,3 +390,17 @@ jobs:
             ${{ runner.temp }}/golden
             ${{ runner.temp }}/os-baselines
           retention-days: 7
+
+      # The XCUITest is allowed to fail temporarily only so the established AX
+      # journeys still execute and retain their independent evidence. Restore
+      # the blocking verdict after AX diagnostics: placing it last keeps an
+      # XCUITest-only failure from needlessly regenerating every AX baseline.
+      - name: Require native XCUITest
+        if: always()
+        env:
+          XCUI_OUTCOME: ${{ steps.xcui.outcome }}
+        run: |
+          if [[ "$XCUI_OUTCOME" != success ]]; then
+            echo "::error::Native XCUITest failed ($XCUI_OUTCOME)"
+            exit 1
+          fi

--- a/apps/rapid-mac/Tests/RapidUITests/Host/Info.plist
+++ b/apps/rapid-mac/Tests/RapidUITests/Host/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>Rapid UI Test Host</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.rapidmlx.rapid-uitest-host</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>RapidUITestHost</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>14.0</string>
+</dict>
+</plist>

--- a/apps/rapid-mac/Tests/RapidUITests/Host/main.swift
+++ b/apps/rapid-mac/Tests/RapidUITests/Host/main.swift
@@ -1,0 +1,8 @@
+import AppKit
+
+// Xcode requires a target application for an UI-testing bundle. The tests
+// deliberately launch the already-built production bundle by identifier; this
+// inert host exists only as XCTest's runner and never stands in for Rapid.
+let app = NSApplication.shared
+app.setActivationPolicy(.accessory)
+app.terminate(nil)

--- a/apps/rapid-mac/Tests/RapidUITests/RapidUITests.xcodeproj/project.pbxproj
+++ b/apps/rapid-mac/Tests/RapidUITests/RapidUITests.xcodeproj/project.pbxproj
@@ -1,0 +1,392 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 77;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		3608146521E5B0C044E55806 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB04F3C22EF0AAABD315027F /* main.swift */; };
+		D71E30DFF3F95D912DA8B3D5 /* ImageGenerationPixelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09911169C1BB45270E153F25 /* ImageGenerationPixelTests.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		405CD7DDE7986F8317D4F0C8 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 2050763562A3D2CF502845B3 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 2AE93E3215C1858C2978A2CB;
+			remoteInfo = RapidUITestHost;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		09911169C1BB45270E153F25 /* ImageGenerationPixelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageGenerationPixelTests.swift; sourceTree = "<group>"; };
+		132399B0849D8BAAFA1DCC11 /* RapidUITestHost.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = RapidUITestHost.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		7425B296704FF8766ABDBEC3 /* RapidUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RapidUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		C125516144CFDFB692F0EA16 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		CB04F3C22EF0AAABD315027F /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXGroup section */
+		0227B5A18E76E11410CE7982 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				132399B0849D8BAAFA1DCC11 /* RapidUITestHost.app */,
+				7425B296704FF8766ABDBEC3 /* RapidUITests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		1B5A8BB0E7AD6E27D95CB510 /* Host */ = {
+			isa = PBXGroup;
+			children = (
+				C125516144CFDFB692F0EA16 /* Info.plist */,
+				CB04F3C22EF0AAABD315027F /* main.swift */,
+			);
+			path = Host;
+			sourceTree = "<group>";
+		};
+		E6A84D31EDC64D755BA80792 = {
+			isa = PBXGroup;
+			children = (
+				1B5A8BB0E7AD6E27D95CB510 /* Host */,
+				F27E5155342C1F7C1AFFB341 /* Tests */,
+				0227B5A18E76E11410CE7982 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		F27E5155342C1F7C1AFFB341 /* Tests */ = {
+			isa = PBXGroup;
+			children = (
+				09911169C1BB45270E153F25 /* ImageGenerationPixelTests.swift */,
+			);
+			path = Tests;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		09CC64EEB7943972825D21A5 /* RapidUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = BEDC330663DE29BCB88FABB5 /* Build configuration list for PBXNativeTarget "RapidUITests" */;
+			buildPhases = (
+				7D8D635EBBC8022891B4F0FE /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				96B85FD2F66A514917CA07C0 /* PBXTargetDependency */,
+			);
+			name = RapidUITests;
+			packageProductDependencies = (
+			);
+			productName = RapidUITests;
+			productReference = 7425B296704FF8766ABDBEC3 /* RapidUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
+		2AE93E3215C1858C2978A2CB /* RapidUITestHost */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 11BAB8E9D5D652B8A79A10B4 /* Build configuration list for PBXNativeTarget "RapidUITestHost" */;
+			buildPhases = (
+				ACC4691B22758826F17E513B /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = RapidUITestHost;
+			packageProductDependencies = (
+			);
+			productName = RapidUITestHost;
+			productReference = 132399B0849D8BAAFA1DCC11 /* RapidUITestHost.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		2050763562A3D2CF502845B3 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = YES;
+				LastUpgradeCheck = 1430;
+				TargetAttributes = {
+					09CC64EEB7943972825D21A5 = {
+						ProvisioningStyle = Automatic;
+						TestTargetID = 2AE93E3215C1858C2978A2CB;
+					};
+					2AE93E3215C1858C2978A2CB = {
+						ProvisioningStyle = Automatic;
+					};
+				};
+			};
+			buildConfigurationList = C66820E335E777A4230B7219 /* Build configuration list for PBXProject "RapidUITests" */;
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				Base,
+				en,
+			);
+			mainGroup = E6A84D31EDC64D755BA80792;
+			minimizedProjectReferenceProxies = 1;
+			preferredProjectObjectVersion = 77;
+			productRefGroup = 0227B5A18E76E11410CE7982 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				2AE93E3215C1858C2978A2CB /* RapidUITestHost */,
+				09CC64EEB7943972825D21A5 /* RapidUITests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXSourcesBuildPhase section */
+		7D8D635EBBC8022891B4F0FE /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D71E30DFF3F95D912DA8B3D5 /* ImageGenerationPixelTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		ACC4691B22758826F17E513B /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3608146521E5B0C044E55806 /* main.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		96B85FD2F66A514917CA07C0 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 2AE93E3215C1858C2978A2CB /* RapidUITestHost */;
+			targetProxy = 405CD7DDE7986F8317D4F0C8 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		121AF7BEB0FF56EEEBF7768E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				COMBINE_HIDPI_IMAGES = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.rapidmlx.rapid-uitests";
+				SDKROOT = macosx;
+				TEST_TARGET_NAME = RapidUITestHost;
+			};
+			name = Debug;
+		};
+		2664CE10D2A86F98B50438DF /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"DEBUG=1",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 6.0;
+			};
+			name = Debug;
+		};
+		48516F6622BE2EA4861F86A7 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				COMBINE_HIDPI_IMAGES = YES;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = Host/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.rapidmlx.rapid-uitest-host";
+				SDKROOT = macosx;
+			};
+			name = Debug;
+		};
+		4911A93FEA2DC5040D5673FE /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				COMBINE_HIDPI_IMAGES = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.rapidmlx.rapid-uitests";
+				SDKROOT = macosx;
+				TEST_TARGET_NAME = RapidUITestHost;
+			};
+			name = Release;
+		};
+		7EE385A7C1F402FA7125E8E3 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				COMBINE_HIDPI_IMAGES = YES;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = Host/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.rapidmlx.rapid-uitest-host";
+				SDKROOT = macosx;
+			};
+			name = Release;
+		};
+		8E04065B1764668575089515 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 6.0;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		11BAB8E9D5D652B8A79A10B4 /* Build configuration list for PBXNativeTarget "RapidUITestHost" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				48516F6622BE2EA4861F86A7 /* Debug */,
+				7EE385A7C1F402FA7125E8E3 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		BEDC330663DE29BCB88FABB5 /* Build configuration list for PBXNativeTarget "RapidUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				121AF7BEB0FF56EEEBF7768E /* Debug */,
+				4911A93FEA2DC5040D5673FE /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		C66820E335E777A4230B7219 /* Build configuration list for PBXProject "RapidUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				2664CE10D2A86F98B50438DF /* Debug */,
+				8E04065B1764668575089515 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 2050763562A3D2CF502845B3 /* Project object */;
+}

--- a/apps/rapid-mac/Tests/RapidUITests/RapidUITests.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/apps/rapid-mac/Tests/RapidUITests/RapidUITests.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/apps/rapid-mac/Tests/RapidUITests/RapidUITests.xcodeproj/xcshareddata/xcschemes/RapidUITests.xcscheme
+++ b/apps/rapid-mac/Tests/RapidUITests/RapidUITests.xcodeproj/xcshareddata/xcschemes/RapidUITests.xcscheme
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1430"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      runPostActionsOnFailure = "NO">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "2AE93E3215C1858C2978A2CB"
+               BuildableName = "RapidUITestHost.app"
+               BlueprintName = "RapidUITestHost"
+               ReferencedContainer = "container:RapidUITests.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "09CC64EEB7943972825D21A5"
+               BuildableName = "RapidUITests.xctest"
+               BlueprintName = "RapidUITests"
+               ReferencedContainer = "container:RapidUITests.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "NO">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "2AE93E3215C1858C2978A2CB"
+            BuildableName = "RapidUITestHost.app"
+            BlueprintName = "RapidUITestHost"
+            ReferencedContainer = "container:RapidUITests.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "09CC64EEB7943972825D21A5"
+               BuildableName = "RapidUITests.xctest"
+               BlueprintName = "RapidUITests"
+               ReferencedContainer = "container:RapidUITests.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <CommandLineArguments>
+      </CommandLineArguments>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "2AE93E3215C1858C2978A2CB"
+            BuildableName = "RapidUITestHost.app"
+            BlueprintName = "RapidUITestHost"
+            ReferencedContainer = "container:RapidUITests.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "2AE93E3215C1858C2978A2CB"
+            BuildableName = "RapidUITestHost.app"
+            BlueprintName = "RapidUITestHost"
+            ReferencedContainer = "container:RapidUITests.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/apps/rapid-mac/Tests/RapidUITests/Tests/ImageGenerationPixelTests.swift
+++ b/apps/rapid-mac/Tests/RapidUITests/Tests/ImageGenerationPixelTests.swift
@@ -1,6 +1,7 @@
 import AppKit
 import XCTest
 
+@MainActor
 final class ImageGenerationPixelTests: XCTestCase {
     private var app: XCUIApplication!
     private var testHome: URL!

--- a/apps/rapid-mac/Tests/RapidUITests/Tests/ImageGenerationPixelTests.swift
+++ b/apps/rapid-mac/Tests/RapidUITests/Tests/ImageGenerationPixelTests.swift
@@ -127,9 +127,9 @@ final class ImageGenerationPixelTests: XCTestCase {
         let insetX = source.width / 5
         let insetY = source.height / 5
         let rect = CGRect(
-            x: insetX, y: insetY,
-            width: source.width - 2 * insetX,
-            height: source.height - 2 * insetY
+            x: CGFloat(insetX), y: CGFloat(insetY),
+            width: CGFloat(source.width - 2 * insetX),
+            height: CGFloat(source.height - 2 * insetY)
         )
         let cropped = try XCTUnwrap(
             source.cropping(to: rect),

--- a/apps/rapid-mac/Tests/RapidUITests/Tests/ImageGenerationPixelTests.swift
+++ b/apps/rapid-mac/Tests/RapidUITests/Tests/ImageGenerationPixelTests.swift
@@ -19,9 +19,16 @@ final class ImageGenerationPixelTests: XCTestCase {
         defaults.waitUntilExit()
 
         let app = XCUIApplication(bundleIdentifier: "com.rapidmlx.rapid")
+        let rapidMacRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent() // Tests
+            .deletingLastPathComponent() // RapidUITests
+            .deletingLastPathComponent() // Tests
+            .deletingLastPathComponent() // rapid-mac
+        let fakeSidecar = rapidMacRoot.appendingPathComponent("scripts/fake-rapid-mlx.sh").path
+        XCTAssertTrue(FileManager.default.isExecutableFile(atPath: fakeSidecar))
         app.launchEnvironment = [
             "HOME": testHome.path,
-            "RAPID_BIN": ProcessInfo.processInfo.environment["RAPID_XCUI_FAKE_BIN"]!,
+            "RAPID_BIN": fakeSidecar,
             "FAKE_EVENT_LOG": testHome.appendingPathComponent("fake-events.jsonl").path,
             "FAKE_IMAGE_STEPS": "4",
             "FAKE_IMAGE_STEP_MS": "100",

--- a/apps/rapid-mac/Tests/RapidUITests/Tests/ImageGenerationPixelTests.swift
+++ b/apps/rapid-mac/Tests/RapidUITests/Tests/ImageGenerationPixelTests.swift
@@ -3,12 +3,9 @@ import XCTest
 
 @MainActor
 final class ImageGenerationPixelTests: XCTestCase {
-    private var app: XCUIApplication!
-    private var testHome: URL!
-
-    override func setUpWithError() throws {
+    func testTwoImageRendersDrawDistinctThumbnailPixels() throws {
         continueAfterFailure = false
-        testHome = FileManager.default.temporaryDirectory
+        let testHome = FileManager.default.temporaryDirectory
             .appendingPathComponent("rapid-xcui-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: testHome, withIntermediateDirectories: true)
 
@@ -21,7 +18,7 @@ final class ImageGenerationPixelTests: XCTestCase {
         try defaults.run()
         defaults.waitUntilExit()
 
-        app = XCUIApplication(bundleIdentifier: "com.rapidmlx.rapid")
+        let app = XCUIApplication(bundleIdentifier: "com.rapidmlx.rapid")
         app.launchEnvironment = [
             "HOME": testHome.path,
             "RAPID_BIN": ProcessInfo.processInfo.environment["RAPID_XCUI_FAKE_BIN"]!,
@@ -30,33 +27,29 @@ final class ImageGenerationPixelTests: XCTestCase {
             "FAKE_IMAGE_STEP_MS": "100",
         ]
         app.launch()
+        defer {
+            app.terminate()
+            try? FileManager.default.removeItem(at: testHome)
+        }
         XCTAssertTrue(app.windows["Rapid-MLX"].waitForExistence(timeout: 20))
-    }
-
-    override func tearDownWithError() throws {
-        app?.terminate()
-        if let testHome { try? FileManager.default.removeItem(at: testHome) }
-    }
-
-    func testTwoImageRendersDrawDistinctThumbnailPixels() throws {
-        dismissFirstRunIfNeeded()
-        let images = element("Sidebar.Images")
+        dismissFirstRunIfNeeded(in: app)
+        let images = element("Sidebar.Images", in: app)
         XCTAssertTrue(images.waitForExistence(timeout: 10))
         images.click()
 
-        let readiness = element("Readiness.Action")
+        let readiness = element("Readiness.Action", in: app)
         XCTAssertTrue(readiness.waitForExistence(timeout: 20))
         readiness.click()
 
-        let prompt = element("Images.Prompt")
+        let prompt = element("Images.Prompt", in: app)
         XCTAssertTrue(prompt.waitForExistence(timeout: 20))
         prompt.click()
         prompt.typeText("a cheetah on a red couch")
-        let generate = element("Images.Generate")
+        let generate = element("Images.Generate", in: app)
         XCTAssertTrue(waitUntil(timeout: 30) { generate.isEnabled })
         generate.click()
 
-        let first = element("Images.Gallery.Thumb.1")
+        let first = element("Images.Gallery.Thumb.1", in: app)
         XCTAssertTrue(first.waitForExistence(timeout: 30))
 
         prompt.click()
@@ -65,8 +58,8 @@ final class ImageGenerationPixelTests: XCTestCase {
         XCTAssertTrue(waitUntil(timeout: 10) { generate.isEnabled })
         generate.click()
 
-        let newest = element("Images.Gallery.Thumb.1")
-        let older = element("Images.Gallery.Thumb.2")
+        let newest = element("Images.Gallery.Thumb.1", in: app)
+        let older = element("Images.Gallery.Thumb.2", in: app)
         XCTAssertTrue(older.waitForExistence(timeout: 30))
 
         let newestShot = newest.screenshot()
@@ -86,14 +79,14 @@ final class ImageGenerationPixelTests: XCTestCase {
         )
     }
 
-    private func dismissFirstRunIfNeeded() {
-        let decline = element("TelemetryConsent.DontShare")
+    private func dismissFirstRunIfNeeded(in app: XCUIApplication) {
+        let decline = element("TelemetryConsent.DontShare", in: app)
         if decline.waitForExistence(timeout: 5) { decline.click() }
-        let skip = element("Quickstart.Skip")
+        let skip = element("Quickstart.Skip", in: app)
         if skip.waitForExistence(timeout: 10) { skip.click() }
     }
 
-    private func element(_ identifier: String) -> XCUIElement {
+    private func element(_ identifier: String, in app: XCUIApplication) -> XCUIElement {
         app.descendants(matching: .any).matching(identifier: identifier).firstMatch
     }
 

--- a/apps/rapid-mac/Tests/RapidUITests/Tests/ImageGenerationPixelTests.swift
+++ b/apps/rapid-mac/Tests/RapidUITests/Tests/ImageGenerationPixelTests.swift
@@ -31,12 +31,13 @@ final class ImageGenerationPixelTests: XCTestCase {
         let appURL = rapidMacRoot.appendingPathComponent("build/Rapid-MLX Desktop.app")
         XCTAssertTrue(FileManager.default.isExecutableFile(atPath: fakeSidecar))
         XCTAssertTrue(FileManager.default.fileExists(atPath: appURL.path))
+        let eventLog = testHome.appendingPathComponent("fake-events.jsonl")
         let app = XCUIApplication(url: appURL)
         app.launchEnvironment = [
             "HOME": testHome.path,
             "CFFIXED_USER_HOME": testHome.path,
             "RAPID_BIN": fakeSidecar,
-            "FAKE_EVENT_LOG": testHome.appendingPathComponent("fake-events.jsonl").path,
+            "FAKE_EVENT_LOG": eventLog.path,
             "FAKE_IMAGE_STEPS": "4",
             "FAKE_IMAGE_STEP_MS": "100",
         ]
@@ -48,9 +49,23 @@ final class ImageGenerationPixelTests: XCTestCase {
         XCTAssertTrue(images.waitForExistence(timeout: 10))
         images.click()
 
+        // Catalog discovery is asynchronous. Wait for the Images picker to
+        // resolve before pressing the shared readiness control; otherwise the
+        // click can still target the previously selected chat model.
+        let picker = element("Images.ModelPicker", in: app)
+        XCTAssertTrue(picker.waitForExistence(timeout: 20))
+        XCTAssertTrue(waitUntil(timeout: 20) {
+            picker.debugDescription.contains("fake-image-alias")
+        })
+
         let readiness = element("Readiness.Action", in: app)
         XCTAssertTrue(readiness.waitForExistence(timeout: 20))
         readiness.click()
+        XCTAssertTrue(waitUntil(timeout: 30) {
+            guard let events = try? String(contentsOf: eventLog, encoding: .utf8) else { return false }
+            return events.contains(#""event": "server_started""#)
+                && events.contains(#""alias": "fake-image-alias""#)
+        })
 
         let prompt = element("Images.Prompt", in: app)
         XCTAssertTrue(prompt.waitForExistence(timeout: 20))

--- a/apps/rapid-mac/Tests/RapidUITests/Tests/ImageGenerationPixelTests.swift
+++ b/apps/rapid-mac/Tests/RapidUITests/Tests/ImageGenerationPixelTests.swift
@@ -73,9 +73,7 @@ final class ImageGenerationPixelTests: XCTestCase {
         XCTAssertTrue(waitUntil(timeout: 30) { generate.isEnabled })
         generate.click()
 
-        let save = element("Images.Result.Save", in: app)
         XCTAssertTrue(waitUntil(timeout: 30) { imageResponseCount(in: eventLog) == 1 })
-        XCTAssertTrue(save.waitForExistence(timeout: 30))
         let first = element("Images.Gallery.Thumb.1", in: app)
         XCTAssertTrue(first.waitForExistence(timeout: 30))
 
@@ -85,7 +83,6 @@ final class ImageGenerationPixelTests: XCTestCase {
         XCTAssertTrue(waitUntil(timeout: 10) { generate.isEnabled })
         generate.click()
         XCTAssertTrue(waitUntil(timeout: 30) { imageResponseCount(in: eventLog) == 2 })
-        XCTAssertTrue(save.waitForExistence(timeout: 30))
 
         let newest = element("Images.Gallery.Thumb.1", in: app)
         let older = element("Images.Gallery.Thumb.2", in: app)

--- a/apps/rapid-mac/Tests/RapidUITests/Tests/ImageGenerationPixelTests.swift
+++ b/apps/rapid-mac/Tests/RapidUITests/Tests/ImageGenerationPixelTests.swift
@@ -8,6 +8,7 @@ final class ImageGenerationPixelTests: XCTestCase {
         let testHome = FileManager.default.temporaryDirectory
             .appendingPathComponent("rapid-xcui-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: testHome, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: testHome) }
 
         // The CI runner is disposable, but clearing the app domain makes local
         // full-Xcode runs deterministic too. HOME isolates sessions and owned
@@ -38,10 +39,7 @@ final class ImageGenerationPixelTests: XCTestCase {
             "FAKE_IMAGE_STEP_MS": "100",
         ]
         app.launch()
-        defer {
-            app.terminate()
-            try? FileManager.default.removeItem(at: testHome)
-        }
+        defer { app.terminate() }
         XCTAssertTrue(app.windows["Rapid-MLX"].waitForExistence(timeout: 20))
         dismissFirstRunIfNeeded(in: app)
         let images = element("Sidebar.Images", in: app)

--- a/apps/rapid-mac/Tests/RapidUITests/Tests/ImageGenerationPixelTests.swift
+++ b/apps/rapid-mac/Tests/RapidUITests/Tests/ImageGenerationPixelTests.swift
@@ -56,6 +56,8 @@ final class ImageGenerationPixelTests: XCTestCase {
         XCTAssertTrue(waitUntil(timeout: 30) { generate.isEnabled })
         generate.click()
 
+        let save = element("Images.Result.Save", in: app)
+        XCTAssertTrue(save.waitForExistence(timeout: 30))
         let first = element("Images.Gallery.Thumb.1", in: app)
         XCTAssertTrue(first.waitForExistence(timeout: 30))
 
@@ -64,6 +66,8 @@ final class ImageGenerationPixelTests: XCTestCase {
         prompt.typeText("the same cheetah, at night")
         XCTAssertTrue(waitUntil(timeout: 10) { generate.isEnabled })
         generate.click()
+        XCTAssertTrue(save.waitForNonExistence(timeout: 5))
+        XCTAssertTrue(save.waitForExistence(timeout: 30))
 
         let newest = element("Images.Gallery.Thumb.1", in: app)
         let older = element("Images.Gallery.Thumb.2", in: app)
@@ -110,9 +114,11 @@ final class ImageGenerationPixelTests: XCTestCase {
     /// the selected/unselected stroke and button chrome, leaving the pixels
     /// the user perceives as the generated image.
     private func centerMeanRGB(_ png: Data) throws -> [CGFloat] {
-        guard let image = NSImage(data: png),
-              let source = image.cgImage(forProposedRect: nil, context: nil, hints: nil)
-        else { throw XCTSkip("XCTest returned an undecodable screenshot") }
+        let image = try XCTUnwrap(NSImage(data: png), "XCTest returned an undecodable screenshot")
+        let source = try XCTUnwrap(
+            image.cgImage(forProposedRect: nil, context: nil, hints: nil),
+            "XCTest returned a screenshot without a CGImage"
+        )
         let insetX = source.width / 5
         let insetY = source.height / 5
         let rect = CGRect(
@@ -120,9 +126,10 @@ final class ImageGenerationPixelTests: XCTestCase {
             width: source.width - 2 * insetX,
             height: source.height - 2 * insetY
         )
-        guard let cropped = source.cropping(to: rect) else {
-            throw XCTSkip("thumbnail screenshot was too small to crop")
-        }
+        let cropped = try XCTUnwrap(
+            source.cropping(to: rect),
+            "thumbnail screenshot was too small to crop"
+        )
         let rep = NSBitmapImageRep(cgImage: cropped)
         var totals = [CGFloat](repeating: 0, count: 3)
         var count: CGFloat = 0

--- a/apps/rapid-mac/Tests/RapidUITests/Tests/ImageGenerationPixelTests.swift
+++ b/apps/rapid-mac/Tests/RapidUITests/Tests/ImageGenerationPixelTests.swift
@@ -1,0 +1,140 @@
+import AppKit
+import XCTest
+
+final class ImageGenerationPixelTests: XCTestCase {
+    private var app: XCUIApplication!
+    private var testHome: URL!
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+        testHome = FileManager.default.temporaryDirectory
+            .appendingPathComponent("rapid-xcui-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: testHome, withIntermediateDirectories: true)
+
+        // The CI runner is disposable, but clearing the app domain makes local
+        // full-Xcode runs deterministic too. HOME isolates sessions and owned
+        // server records; CFPreferences needs the explicit domain reset.
+        let defaults = Process()
+        defaults.executableURL = URL(fileURLWithPath: "/usr/bin/defaults")
+        defaults.arguments = ["delete", "com.rapidmlx.rapid"]
+        try defaults.run()
+        defaults.waitUntilExit()
+
+        app = XCUIApplication(bundleIdentifier: "com.rapidmlx.rapid")
+        app.launchEnvironment = [
+            "HOME": testHome.path,
+            "RAPID_BIN": ProcessInfo.processInfo.environment["RAPID_XCUI_FAKE_BIN"]!,
+            "FAKE_EVENT_LOG": testHome.appendingPathComponent("fake-events.jsonl").path,
+            "FAKE_IMAGE_STEPS": "4",
+            "FAKE_IMAGE_STEP_MS": "100",
+        ]
+        app.launch()
+        XCTAssertTrue(app.windows["Rapid-MLX"].waitForExistence(timeout: 20))
+    }
+
+    override func tearDownWithError() throws {
+        app?.terminate()
+        if let testHome { try? FileManager.default.removeItem(at: testHome) }
+    }
+
+    func testTwoImageRendersDrawDistinctThumbnailPixels() throws {
+        dismissFirstRunIfNeeded()
+        let images = element("Sidebar.Images")
+        XCTAssertTrue(images.waitForExistence(timeout: 10))
+        images.click()
+
+        let readiness = element("Readiness.Action")
+        XCTAssertTrue(readiness.waitForExistence(timeout: 20))
+        readiness.click()
+
+        let prompt = element("Images.Prompt")
+        XCTAssertTrue(prompt.waitForExistence(timeout: 20))
+        prompt.click()
+        prompt.typeText("a cheetah on a red couch")
+        let generate = element("Images.Generate")
+        XCTAssertTrue(waitUntil(timeout: 30) { generate.isEnabled })
+        generate.click()
+
+        let first = element("Images.Gallery.Thumb.1")
+        XCTAssertTrue(first.waitForExistence(timeout: 30))
+
+        prompt.click()
+        prompt.typeKey("a", modifierFlags: .command)
+        prompt.typeText("the same cheetah, at night")
+        XCTAssertTrue(waitUntil(timeout: 10) { generate.isEnabled })
+        generate.click()
+
+        let newest = element("Images.Gallery.Thumb.1")
+        let older = element("Images.Gallery.Thumb.2")
+        XCTAssertTrue(older.waitForExistence(timeout: 30))
+
+        let newestShot = newest.screenshot()
+        let olderShot = older.screenshot()
+        add(XCTAttachment(screenshot: newestShot))
+        add(XCTAttachment(screenshot: olderShot))
+
+        let newestRGB = try centerMeanRGB(newestShot.pngRepresentation)
+        let olderRGB = try centerMeanRGB(olderShot.pngRepresentation)
+        let distance = zip(newestRGB, olderRGB)
+            .map { Double($0.0) - Double($0.1) }
+            .map { $0 * $0 }
+            .reduce(0, +).squareRoot()
+        XCTAssertGreaterThan(
+            distance, 20,
+            "The two records exist but their rendered thumbnail interiors are indistinguishable"
+        )
+    }
+
+    private func dismissFirstRunIfNeeded() {
+        let decline = element("TelemetryConsent.DontShare")
+        if decline.waitForExistence(timeout: 5) { decline.click() }
+        let skip = element("Quickstart.Skip")
+        if skip.waitForExistence(timeout: 10) { skip.click() }
+    }
+
+    private func element(_ identifier: String) -> XCUIElement {
+        app.descendants(matching: .any).matching(identifier: identifier).firstMatch
+    }
+
+    private func waitUntil(timeout: TimeInterval, condition: () -> Bool) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        repeat {
+            if condition() { return true }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.1))
+        } while Date() < deadline
+        return condition()
+    }
+
+    /// Compare only the central 60% of each element screenshot. This removes
+    /// the selected/unselected stroke and button chrome, leaving the pixels
+    /// the user perceives as the generated image.
+    private func centerMeanRGB(_ png: Data) throws -> [CGFloat] {
+        guard let image = NSImage(data: png),
+              let source = image.cgImage(forProposedRect: nil, context: nil, hints: nil)
+        else { throw XCTSkip("XCTest returned an undecodable screenshot") }
+        let insetX = source.width / 5
+        let insetY = source.height / 5
+        let rect = CGRect(
+            x: insetX, y: insetY,
+            width: source.width - 2 * insetX,
+            height: source.height - 2 * insetY
+        )
+        guard let cropped = source.cropping(to: rect) else {
+            throw XCTSkip("thumbnail screenshot was too small to crop")
+        }
+        let rep = NSBitmapImageRep(cgImage: cropped)
+        var totals = [CGFloat](repeating: 0, count: 3)
+        var count: CGFloat = 0
+        for y in stride(from: 0, to: rep.pixelsHigh, by: 2) {
+            for x in stride(from: 0, to: rep.pixelsWide, by: 2) {
+                guard let color = rep.colorAt(x: x, y: y)?.usingColorSpace(.deviceRGB) else { continue }
+                totals[0] += color.redComponent
+                totals[1] += color.greenComponent
+                totals[2] += color.blueComponent
+                count += 1
+            }
+        }
+        XCTAssertGreaterThan(count, 0)
+        return totals.map { $0 / count * 255 }
+    }
+}

--- a/apps/rapid-mac/Tests/RapidUITests/Tests/ImageGenerationPixelTests.swift
+++ b/apps/rapid-mac/Tests/RapidUITests/Tests/ImageGenerationPixelTests.swift
@@ -17,9 +17,19 @@ final class ImageGenerationPixelTests: XCTestCase {
             .deletingLastPathComponent() // rapid-mac
         let fakeSidecar = rapidMacRoot.appendingPathComponent("scripts/fake-rapid-mlx.sh").path
         let appURL = rapidMacRoot.appendingPathComponent("build/Rapid-MLX Desktop.app")
+        let eventLog = testHome.appendingPathComponent("fake-events.jsonl")
+        // ServerManager deliberately sanitizes arbitrary FAKE_* variables
+        // before spawning a sidecar. The fake's checked-in config file is the
+        // durable channel shared with the AX GoldenFlow harness.
+        let fakeConfig: [String: String] = [
+            "FAKE_EVENT_LOG": eventLog.path,
+            "FAKE_IMAGE_STEPS": "4",
+            "FAKE_IMAGE_STEP_MS": "100",
+        ]
+        let fakeConfigData = try JSONSerialization.data(withJSONObject: fakeConfig)
+        try fakeConfigData.write(to: testHome.appendingPathComponent(".rapid-golden-fake.json"))
         XCTAssertTrue(FileManager.default.isExecutableFile(atPath: fakeSidecar))
         XCTAssertTrue(FileManager.default.fileExists(atPath: appURL.path))
-        let eventLog = testHome.appendingPathComponent("fake-events.jsonl")
         let app = XCUIApplication(url: appURL)
         app.launchEnvironment = [
             "HOME": testHome.path,

--- a/apps/rapid-mac/Tests/RapidUITests/Tests/ImageGenerationPixelTests.swift
+++ b/apps/rapid-mac/Tests/RapidUITests/Tests/ImageGenerationPixelTests.swift
@@ -23,8 +23,8 @@ final class ImageGenerationPixelTests: XCTestCase {
         // durable channel shared with the AX GoldenFlow harness.
         let fakeConfig: [String: String] = [
             "FAKE_EVENT_LOG": eventLog.path,
-            "FAKE_IMAGE_STEPS": "4",
-            "FAKE_IMAGE_STEP_MS": "100",
+            "FAKE_IMAGE_STEPS": "8",
+            "FAKE_IMAGE_STEP_MS": "300",
         ]
         let fakeConfigData = try JSONSerialization.data(withJSONObject: fakeConfig)
         try fakeConfigData.write(to: testHome.appendingPathComponent(".rapid-golden-fake.json"))
@@ -36,8 +36,8 @@ final class ImageGenerationPixelTests: XCTestCase {
             "CFFIXED_USER_HOME": testHome.path,
             "RAPID_BIN": fakeSidecar,
             "FAKE_EVENT_LOG": eventLog.path,
-            "FAKE_IMAGE_STEPS": "4",
-            "FAKE_IMAGE_STEP_MS": "100",
+            "FAKE_IMAGE_STEPS": "8",
+            "FAKE_IMAGE_STEP_MS": "300",
         ]
         app.launch()
         defer { app.terminate() }

--- a/apps/rapid-mac/Tests/RapidUITests/Tests/ImageGenerationPixelTests.swift
+++ b/apps/rapid-mac/Tests/RapidUITests/Tests/ImageGenerationPixelTests.swift
@@ -10,18 +10,6 @@ final class ImageGenerationPixelTests: XCTestCase {
         try FileManager.default.createDirectory(at: testHome, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: testHome) }
 
-        // The CI runner is disposable, but clearing the app domain makes local
-        // full-Xcode runs deterministic too. HOME isolates sessions and owned
-        // server records; CFPreferences needs the explicit domain reset.
-        let defaults = Process()
-        defaults.executableURL = URL(fileURLWithPath: "/usr/bin/defaults")
-        defaults.arguments = ["delete", "com.rapidmlx.rapid"]
-        defaults.environment = ProcessInfo.processInfo.environment.merging([
-            "CFFIXED_USER_HOME": testHome.path,
-        ]) { _, isolated in isolated }
-        try defaults.run()
-        defaults.waitUntilExit()
-
         let rapidMacRoot = URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent() // Tests
             .deletingLastPathComponent() // RapidUITests
@@ -93,6 +81,10 @@ final class ImageGenerationPixelTests: XCTestCase {
         let older = element("Images.Gallery.Thumb.2", in: app)
         XCTAssertTrue(older.waitForExistence(timeout: 30))
 
+        // Capture each record while it has the same selected styling. The
+        // center crop already removes the stroke, and equalizing selection
+        // also prevents any future interior selection treatment from being
+        // mistaken for different generated pixels.
         older.click()
         let olderShot = older.screenshot()
         newest.click()

--- a/apps/rapid-mac/Tests/RapidUITests/Tests/ImageGenerationPixelTests.swift
+++ b/apps/rapid-mac/Tests/RapidUITests/Tests/ImageGenerationPixelTests.swift
@@ -55,7 +55,7 @@ final class ImageGenerationPixelTests: XCTestCase {
         let picker = element("Images.ModelPicker", in: app)
         XCTAssertTrue(picker.waitForExistence(timeout: 20))
         XCTAssertTrue(waitUntil(timeout: 20) {
-            picker.debugDescription.contains("fake-image-alias")
+            picker.label.contains("fake-image-alias")
         })
 
         let readiness = element("Readiness.Action", in: app)
@@ -76,6 +76,7 @@ final class ImageGenerationPixelTests: XCTestCase {
         generate.click()
 
         let save = element("Images.Result.Save", in: app)
+        XCTAssertTrue(waitUntil(timeout: 30) { imageResponseCount(in: eventLog) == 1 })
         XCTAssertTrue(save.waitForExistence(timeout: 30))
         let first = element("Images.Gallery.Thumb.1", in: app)
         XCTAssertTrue(first.waitForExistence(timeout: 30))
@@ -85,15 +86,17 @@ final class ImageGenerationPixelTests: XCTestCase {
         prompt.typeText("the same cheetah, at night")
         XCTAssertTrue(waitUntil(timeout: 10) { generate.isEnabled })
         generate.click()
-        XCTAssertTrue(save.waitForNonExistence(timeout: 5))
+        XCTAssertTrue(waitUntil(timeout: 30) { imageResponseCount(in: eventLog) == 2 })
         XCTAssertTrue(save.waitForExistence(timeout: 30))
 
         let newest = element("Images.Gallery.Thumb.1", in: app)
         let older = element("Images.Gallery.Thumb.2", in: app)
         XCTAssertTrue(older.waitForExistence(timeout: 30))
 
-        let newestShot = newest.screenshot()
+        older.click()
         let olderShot = older.screenshot()
+        newest.click()
+        let newestShot = newest.screenshot()
         add(XCTAttachment(screenshot: newestShot))
         add(XCTAttachment(screenshot: olderShot))
 
@@ -128,6 +131,11 @@ final class ImageGenerationPixelTests: XCTestCase {
             RunLoop.current.run(until: Date().addingTimeInterval(0.1))
         } while Date() < deadline
         return condition()
+    }
+
+    private func imageResponseCount(in eventLog: URL) -> Int {
+        guard let events = try? String(contentsOf: eventLog, encoding: .utf8) else { return 0 }
+        return events.split(separator: "\n").count { $0.contains(#""event": "image_response""#) }
     }
 
     /// Compare only the central 60% of each element screenshot. This removes

--- a/apps/rapid-mac/Tests/RapidUITests/Tests/ImageGenerationPixelTests.swift
+++ b/apps/rapid-mac/Tests/RapidUITests/Tests/ImageGenerationPixelTests.swift
@@ -15,6 +15,9 @@ final class ImageGenerationPixelTests: XCTestCase {
         let defaults = Process()
         defaults.executableURL = URL(fileURLWithPath: "/usr/bin/defaults")
         defaults.arguments = ["delete", "com.rapidmlx.rapid"]
+        defaults.environment = ProcessInfo.processInfo.environment.merging([
+            "CFFIXED_USER_HOME": testHome.path,
+        ]) { _, isolated in isolated }
         try defaults.run()
         defaults.waitUntilExit()
 
@@ -28,6 +31,7 @@ final class ImageGenerationPixelTests: XCTestCase {
         XCTAssertTrue(FileManager.default.isExecutableFile(atPath: fakeSidecar))
         app.launchEnvironment = [
             "HOME": testHome.path,
+            "CFFIXED_USER_HOME": testHome.path,
             "RAPID_BIN": fakeSidecar,
             "FAKE_EVENT_LOG": testHome.appendingPathComponent("fake-events.jsonl").path,
             "FAKE_IMAGE_STEPS": "4",

--- a/apps/rapid-mac/Tests/RapidUITests/Tests/ImageGenerationPixelTests.swift
+++ b/apps/rapid-mac/Tests/RapidUITests/Tests/ImageGenerationPixelTests.swift
@@ -22,14 +22,16 @@ final class ImageGenerationPixelTests: XCTestCase {
         try defaults.run()
         defaults.waitUntilExit()
 
-        let app = XCUIApplication(bundleIdentifier: "com.rapidmlx.rapid")
         let rapidMacRoot = URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent() // Tests
             .deletingLastPathComponent() // RapidUITests
             .deletingLastPathComponent() // Tests
             .deletingLastPathComponent() // rapid-mac
         let fakeSidecar = rapidMacRoot.appendingPathComponent("scripts/fake-rapid-mlx.sh").path
+        let appURL = rapidMacRoot.appendingPathComponent("build/Rapid-MLX Desktop.app")
         XCTAssertTrue(FileManager.default.isExecutableFile(atPath: fakeSidecar))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: appURL.path))
+        let app = XCUIApplication(url: appURL)
         app.launchEnvironment = [
             "HOME": testHome.path,
             "CFFIXED_USER_HOME": testHome.path,
@@ -80,14 +82,15 @@ final class ImageGenerationPixelTests: XCTestCase {
         add(XCTAttachment(screenshot: newestShot))
         add(XCTAttachment(screenshot: olderShot))
 
-        let newestRGB = try centerMeanRGB(newestShot.pngRepresentation)
-        let olderRGB = try centerMeanRGB(olderShot.pngRepresentation)
-        let distance = zip(newestRGB, olderRGB)
+        let newestPixels = try centerRGBSamples(newestShot.pngRepresentation)
+        let olderPixels = try centerRGBSamples(olderShot.pngRepresentation)
+        XCTAssertEqual(newestPixels.count, olderPixels.count)
+        let meanSquaredDistance = zip(newestPixels, olderPixels)
             .map { Double($0.0) - Double($0.1) }
             .map { $0 * $0 }
-            .reduce(0, +).squareRoot()
+            .reduce(0, +) / Double(newestPixels.count)
         XCTAssertGreaterThan(
-            distance, 20,
+            meanSquaredDistance.squareRoot(), 10,
             "The two records exist but their rendered thumbnail interiors are indistinguishable"
         )
     }
@@ -115,7 +118,7 @@ final class ImageGenerationPixelTests: XCTestCase {
     /// Compare only the central 60% of each element screenshot. This removes
     /// the selected/unselected stroke and button chrome, leaving the pixels
     /// the user perceives as the generated image.
-    private func centerMeanRGB(_ png: Data) throws -> [CGFloat] {
+    private func centerRGBSamples(_ png: Data) throws -> [CGFloat] {
         let image = try XCTUnwrap(NSImage(data: png), "XCTest returned an undecodable screenshot")
         let source = try XCTUnwrap(
             image.cgImage(forProposedRect: nil, context: nil, hints: nil),
@@ -133,18 +136,17 @@ final class ImageGenerationPixelTests: XCTestCase {
             "thumbnail screenshot was too small to crop"
         )
         let rep = NSBitmapImageRep(cgImage: cropped)
-        var totals = [CGFloat](repeating: 0, count: 3)
-        var count: CGFloat = 0
+        var samples: [CGFloat] = []
+        samples.reserveCapacity((rep.pixelsWide / 2) * (rep.pixelsHigh / 2) * 3)
         for y in stride(from: 0, to: rep.pixelsHigh, by: 2) {
             for x in stride(from: 0, to: rep.pixelsWide, by: 2) {
                 guard let color = rep.colorAt(x: x, y: y)?.usingColorSpace(.deviceRGB) else { continue }
-                totals[0] += color.redComponent
-                totals[1] += color.greenComponent
-                totals[2] += color.blueComponent
-                count += 1
+                samples.append(color.redComponent * 255)
+                samples.append(color.greenComponent * 255)
+                samples.append(color.blueComponent * 255)
             }
         }
-        XCTAssertGreaterThan(count, 0)
-        return totals.map { $0 / count * 255 }
+        XCTAssertFalse(samples.isEmpty)
+        return samples
     }
 }

--- a/apps/rapid-mac/Tests/RapidUITests/project.yml
+++ b/apps/rapid-mac/Tests/RapidUITests/project.yml
@@ -1,0 +1,48 @@
+name: RapidUITests
+options:
+  minimumXcodeGenVersion: 2.42.0
+  deploymentTarget:
+    macOS: "14.0"
+settings:
+  base:
+    SWIFT_VERSION: "6.0"
+    CODE_SIGN_STYLE: Automatic
+targets:
+  RapidUITestHost:
+    type: application
+    platform: macOS
+    sources:
+      - path: Host
+    info:
+      path: Host/Info.plist
+      properties:
+        CFBundleDisplayName: Rapid UI Test Host
+        CFBundleIdentifier: com.rapidmlx.rapid-uitest-host
+        CFBundleName: RapidUITestHost
+        CFBundlePackageType: APPL
+        LSMinimumSystemVersion: "14.0"
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.rapidmlx.rapid-uitest-host
+        GENERATE_INFOPLIST_FILE: NO
+  RapidUITests:
+    type: bundle.ui-testing
+    platform: macOS
+    sources:
+      - path: Tests
+    dependencies:
+      - target: RapidUITestHost
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.rapidmlx.rapid-uitests
+        GENERATE_INFOPLIST_FILE: YES
+        TEST_TARGET_NAME: RapidUITestHost
+schemes:
+  RapidUITests:
+    build:
+      targets:
+        RapidUITestHost: all
+        RapidUITests: [test]
+    test:
+      targets:
+        - RapidUITests

--- a/apps/rapid-mac/docs/gui-golden-flows.md
+++ b/apps/rapid-mac/docs/gui-golden-flows.md
@@ -1,5 +1,19 @@
 # AX-first GUI golden flows
 
+The AX suite remains the broad semantic regression net. A native XCUITest
+target now complements it under `Tests/RapidUITests`: its first migrated
+journey is `image-generation`, where XCTest captures each thumbnail itself,
+crops away selection chrome, and proves the two rendered interiors differ.
+That pixel assertion is intentionally impossible in an `AXUIElement` dump.
+Run it with full Xcode after building the app:
+
+```bash
+./scripts/run-xcui-tests.sh
+```
+
+The target is additive; do not remove an AX journey until its semantic and
+structural assertions have equivalent native coverage.
+
 `scripts/gui-golden-flows.sh` runs the release journeys against a built
 Rapid-MLX Desktop app without loading a real model.
 

--- a/apps/rapid-mac/scripts/run-xcui-tests.sh
+++ b/apps/rapid-mac/scripts/run-xcui-tests.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Run the first native XCUITest journey against the production-shaped app.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+PROJECT="$ROOT/Tests/RapidUITests/RapidUITests.xcodeproj"
+APP="$ROOT/build/Rapid-MLX Desktop.app"
+
+[[ -d "$APP" ]] || { echo "error: build the app first: $APP" >&2; exit 1; }
+command -v xcodebuild >/dev/null || {
+    echo "error: full Xcode is required for XCUITest (Command Line Tools are insufficient)" >&2
+    exit 1
+}
+[[ -d "$PROJECT" ]] || {
+    echo "error: generated Xcode project missing: $PROJECT" >&2
+    exit 1
+}
+
+# XCUIApplication(bundleIdentifier:) resolves through LaunchServices.
+LSREGISTER="/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister"
+"$LSREGISTER" -f "$APP"
+
+export RAPID_XCUI_FAKE_BIN="$ROOT/scripts/fake-rapid-mlx.sh"
+xcodebuild test \
+    -project "$PROJECT" \
+    -scheme RapidUITests \
+    -destination 'platform=macOS' \
+    -resultBundlePath "${RAPID_XCUI_RESULT_BUNDLE:-$ROOT/build/RapidUITests.xcresult}" \
+    CODE_SIGNING_ALLOWED=NO

--- a/apps/rapid-mac/scripts/run-xcui-tests.sh
+++ b/apps/rapid-mac/scripts/run-xcui-tests.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 PROJECT="$ROOT/Tests/RapidUITests/RapidUITests.xcodeproj"
 APP="$ROOT/build/Rapid-MLX Desktop.app"
+RESULT_BUNDLE="${RAPID_XCUI_RESULT_BUNDLE:-$ROOT/build/RapidUITests-$(date +%s)-$$.xcresult}"
 
 [[ -d "$APP" ]] || { echo "error: build the app first: $APP" >&2; exit 1; }
 command -v xcodebuild >/dev/null || {
@@ -24,5 +25,5 @@ xcodebuild test \
     -project "$PROJECT" \
     -scheme RapidUITests \
     -destination 'platform=macOS' \
-    -resultBundlePath "${RAPID_XCUI_RESULT_BUNDLE:-$ROOT/build/RapidUITests.xcresult}" \
+    -resultBundlePath "$RESULT_BUNDLE" \
     CODE_SIGNING_ALLOWED=NO

--- a/apps/rapid-mac/scripts/run-xcui-tests.sh
+++ b/apps/rapid-mac/scripts/run-xcui-tests.sh
@@ -8,7 +8,7 @@ APP="$ROOT/build/Rapid-MLX Desktop.app"
 RESULT_BUNDLE="${RAPID_XCUI_RESULT_BUNDLE:-$ROOT/build/RapidUITests-$(date +%s)-$$.xcresult}"
 
 [[ -d "$APP" ]] || { echo "error: build the app first: $APP" >&2; exit 1; }
-command -v xcodebuild >/dev/null || {
+xcodebuild -version >/dev/null 2>&1 || {
     echo "error: full Xcode is required for XCUITest (Command Line Tools are insufficient)" >&2
     exit 1
 }

--- a/apps/rapid-mac/scripts/run-xcui-tests.sh
+++ b/apps/rapid-mac/scripts/run-xcui-tests.sh
@@ -20,7 +20,6 @@ command -v xcodebuild >/dev/null || {
 LSREGISTER="/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister"
 "$LSREGISTER" -f "$APP"
 
-export RAPID_XCUI_FAKE_BIN="$ROOT/scripts/fake-rapid-mlx.sh"
 xcodebuild test \
     -project "$PROJECT" \
     -scheme RapidUITests \

--- a/tests/test_rapid_mac_xcui_target.py
+++ b/tests/test_rapid_mac_xcui_target.py
@@ -42,6 +42,7 @@ def test_xcui_runner_launches_production_bundle_with_fake_sidecar():
     assert "build/Rapid-MLX Desktop.app" in runner
     assert "lsregister" in runner
     assert 'XCUIApplication(bundleIdentifier: "com.rapidmlx.rapid")' in source
+    assert source.count('"CFFIXED_USER_HOME": testHome.path') == 2
     assert '"RAPID_BIN"' in source
     assert "fake-rapid-mlx.sh" in source
     assert "isExecutableFile" in source

--- a/tests/test_rapid_mac_xcui_target.py
+++ b/tests/test_rapid_mac_xcui_target.py
@@ -12,7 +12,9 @@ def test_xcui_target_is_checked_in_and_runs_in_gui_ci():
     workflow_path = ROOT / ".github/workflows/rapid-mac-ci.yml"
     workflow = workflow_path.read_text()
     gui_steps = yaml.safe_load(workflow)["jobs"]["gui-golden-flows"]["steps"]
-    named_steps = {step.get("name"): (index, step) for index, step in enumerate(gui_steps)}
+    named_steps = {
+        step.get("name"): (index, step) for index, step in enumerate(gui_steps)
+    }
 
     assert project.is_file()
     assert "com.apple.product-type.bundle.ui-testing" in project.read_text()

--- a/tests/test_rapid_mac_xcui_target.py
+++ b/tests/test_rapid_mac_xcui_target.py
@@ -47,3 +47,17 @@ def test_xcui_runner_launches_production_bundle_with_fake_sidecar():
     assert "fake-rapid-mlx.sh" in source
     assert "isExecutableFile" in source
     assert "RapidUITests-$(date +%s)-$$.xcresult" in runner
+
+
+def test_swift_source_parent_traversal_resolves_rapid_mac_fixture():
+    source = MAC / "Tests/RapidUITests/Tests/ImageGenerationPixelTests.swift"
+
+    # Swift starts with the file URL and deletes four path components:
+    # Tests, RapidUITests, Tests, then the filename's rapid-mac root.
+    resolved = source
+    for _ in range(4):
+        resolved = resolved.parent
+
+    assert resolved == MAC
+    assert (resolved / "scripts/fake-rapid-mlx.sh").is_file()
+    assert not (resolved.parent / "scripts/fake-rapid-mlx.sh").exists()

--- a/tests/test_rapid_mac_xcui_target.py
+++ b/tests/test_rapid_mac_xcui_target.py
@@ -21,8 +21,8 @@ def test_pixel_assertion_uses_element_screenshots_and_crops_chrome():
         MAC / "Tests/RapidUITests/Tests/ImageGenerationPixelTests.swift"
     ).read_text()
 
-    assert 'element("Images.Gallery.Thumb.1")' in source
-    assert 'element("Images.Gallery.Thumb.2")' in source
+    assert 'element("Images.Gallery.Thumb.1", in: app)' in source
+    assert 'element("Images.Gallery.Thumb.2", in: app)' in source
     assert "newest.screenshot()" in source
     assert "older.screenshot()" in source
     assert "source.cropping(to: rect)" in source

--- a/tests/test_rapid_mac_xcui_target.py
+++ b/tests/test_rapid_mac_xcui_target.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+import yaml
+
 ROOT = Path(__file__).resolve().parents[1]
 MAC = ROOT / "apps" / "rapid-mac"
 
@@ -7,13 +9,25 @@ MAC = ROOT / "apps" / "rapid-mac"
 def test_xcui_target_is_checked_in_and_runs_in_gui_ci():
     project = MAC / "Tests/RapidUITests/RapidUITests.xcodeproj/project.pbxproj"
     source = MAC / "Tests/RapidUITests/Tests/ImageGenerationPixelTests.swift"
-    workflow = (ROOT / ".github/workflows/rapid-mac-ci.yml").read_text()
+    workflow_path = ROOT / ".github/workflows/rapid-mac-ci.yml"
+    workflow = workflow_path.read_text()
+    gui_steps = yaml.safe_load(workflow)["jobs"]["gui-golden-flows"]["steps"]
+    named_steps = {step.get("name"): (index, step) for index, step in enumerate(gui_steps)}
 
     assert project.is_file()
     assert "com.apple.product-type.bundle.ui-testing" in project.read_text()
     assert source.is_file()
     assert "./scripts/run-xcui-tests.sh" in workflow
     assert "RapidUITests.xcresult" in workflow
+    xcui_index, xcui = named_steps["XCUITest: image-generation pixels"]
+    upload_index, upload = named_steps["Upload XCUITest evidence"]
+    verdict_index, verdict = named_steps["Require native XCUITest"]
+    assert xcui["id"] == "xcui"
+    assert xcui["continue-on-error"] is True
+    assert upload["if"] == "steps.xcui.outcome == 'failure'"
+    assert verdict["if"] == "always()"
+    assert "steps.xcui.outcome" in verdict["env"]["XCUI_OUTCOME"]
+    assert xcui_index < upload_index < verdict_index
 
 
 def test_pixel_assertion_uses_element_screenshots_and_crops_chrome():
@@ -51,7 +65,7 @@ def test_xcui_runner_launches_production_bundle_with_fake_sidecar():
     assert "lsregister" in runner
     assert "XCUIApplication(url: appURL)" in source
     assert 'appendingPathComponent("build/Rapid-MLX Desktop.app")' in source
-    assert source.count('"CFFIXED_USER_HOME": testHome.path') == 2
+    assert source.count('"CFFIXED_USER_HOME": testHome.path') == 1
     assert '"RAPID_BIN"' in source
     assert "fake-rapid-mlx.sh" in source
     assert "isExecutableFile" in source

--- a/tests/test_rapid_mac_xcui_target.py
+++ b/tests/test_rapid_mac_xcui_target.py
@@ -70,6 +70,8 @@ def test_xcui_runner_launches_production_bundle_with_fake_sidecar():
     assert source.count('"CFFIXED_USER_HOME": testHome.path') == 1
     assert '"RAPID_BIN"' in source
     assert "fake-rapid-mlx.sh" in source
+    assert 'appendingPathComponent(".rapid-golden-fake.json")' in source
+    assert '"FAKE_EVENT_LOG": eventLog.path' in source
     assert "isExecutableFile" in source
     assert "RapidUITests-$(date +%s)-$$.xcresult" in runner
 

--- a/tests/test_rapid_mac_xcui_target.py
+++ b/tests/test_rapid_mac_xcui_target.py
@@ -30,6 +30,8 @@ def test_pixel_assertion_uses_element_screenshots_and_crops_chrome():
     assert "XCTUnwrap" in source
     assert "XCTSkip" not in source
     assert "source.cropping(to: rect)" in source
+    assert "centerRGBSamples" in source
+    assert "meanSquaredDistance.squareRoot()" in source
     assert "XCTAssertGreaterThan(" in source
 
 
@@ -41,7 +43,8 @@ def test_xcui_runner_launches_production_bundle_with_fake_sidecar():
 
     assert "build/Rapid-MLX Desktop.app" in runner
     assert "lsregister" in runner
-    assert 'XCUIApplication(bundleIdentifier: "com.rapidmlx.rapid")' in source
+    assert "XCUIApplication(url: appURL)" in source
+    assert 'appendingPathComponent("build/Rapid-MLX Desktop.app")' in source
     assert source.count('"CFFIXED_USER_HOME": testHome.path') == 2
     assert '"RAPID_BIN"' in source
     assert "fake-rapid-mlx.sh" in source

--- a/tests/test_rapid_mac_xcui_target.py
+++ b/tests/test_rapid_mac_xcui_target.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+MAC = ROOT / "apps" / "rapid-mac"
+
+
+def test_xcui_target_is_checked_in_and_runs_in_gui_ci():
+    project = MAC / "Tests/RapidUITests/RapidUITests.xcodeproj/project.pbxproj"
+    source = MAC / "Tests/RapidUITests/Tests/ImageGenerationPixelTests.swift"
+    workflow = (ROOT / ".github/workflows/rapid-mac-ci.yml").read_text()
+
+    assert project.is_file()
+    assert "com.apple.product-type.bundle.ui-testing" in project.read_text()
+    assert source.is_file()
+    assert "./scripts/run-xcui-tests.sh" in workflow
+    assert "RapidUITests.xcresult" in workflow
+
+
+def test_pixel_assertion_uses_element_screenshots_and_crops_chrome():
+    source = (
+        MAC / "Tests/RapidUITests/Tests/ImageGenerationPixelTests.swift"
+    ).read_text()
+
+    assert 'element("Images.Gallery.Thumb.1")' in source
+    assert 'element("Images.Gallery.Thumb.2")' in source
+    assert "newest.screenshot()" in source
+    assert "older.screenshot()" in source
+    assert "source.cropping(to: rect)" in source
+    assert "XCTAssertGreaterThan(" in source
+
+
+def test_xcui_runner_launches_production_bundle_with_fake_sidecar():
+    runner = (MAC / "scripts/run-xcui-tests.sh").read_text()
+    source = (
+        MAC / "Tests/RapidUITests/Tests/ImageGenerationPixelTests.swift"
+    ).read_text()
+
+    assert "build/Rapid-MLX Desktop.app" in runner
+    assert "lsregister" in runner
+    assert 'XCUIApplication(bundleIdentifier: "com.rapidmlx.rapid")' in source
+    assert '"RAPID_BIN"' in source
+    assert "fake-rapid-mlx.sh" in runner

--- a/tests/test_rapid_mac_xcui_target.py
+++ b/tests/test_rapid_mac_xcui_target.py
@@ -54,11 +54,16 @@ def test_xcui_runner_launches_production_bundle_with_fake_sidecar():
 
 def test_swift_source_parent_traversal_resolves_rapid_mac_fixture():
     source = MAC / "Tests/RapidUITests/Tests/ImageGenerationPixelTests.swift"
+    source_text = source.read_text()
+    traversal_expression = source_text.split(
+        "let rapidMacRoot = URL(fileURLWithPath: #filePath)", 1
+    )[1].split("let fakeSidecar", 1)[0]
+    traversal_count = traversal_expression.count(".deletingLastPathComponent()")
 
-    # Swift starts with the file URL and deletes four path components:
-    # Tests, RapidUITests, Tests, then the filename's rapid-mac root.
+    # Replay the traversal count from the actual Swift expression, starting
+    # with the file itself just as URL(fileURLWithPath: #filePath) does.
     resolved = source
-    for _ in range(4):
+    for _ in range(traversal_count):
         resolved = resolved.parent
 
     assert resolved == MAC

--- a/tests/test_rapid_mac_xcui_target.py
+++ b/tests/test_rapid_mac_xcui_target.py
@@ -41,7 +41,6 @@ def test_pixel_assertion_uses_element_screenshots_and_crops_chrome():
     assert 'element("Images.Gallery.Thumb.2", in: app)' in source
     assert "newest.screenshot()" in source
     assert "older.screenshot()" in source
-    assert 'element("Images.Result.Save", in: app)' in source
     assert 'element("Images.ModelPicker", in: app)' in source
     assert 'picker.label.contains("fake-image-alias")' in source
     assert 'events.contains(#""event": "server_started""#)' in source

--- a/tests/test_rapid_mac_xcui_target.py
+++ b/tests/test_rapid_mac_xcui_target.py
@@ -27,10 +27,12 @@ def test_pixel_assertion_uses_element_screenshots_and_crops_chrome():
     assert "older.screenshot()" in source
     assert 'element("Images.Result.Save", in: app)' in source
     assert 'element("Images.ModelPicker", in: app)' in source
-    assert 'picker.debugDescription.contains("fake-image-alias")' in source
+    assert 'picker.label.contains("fake-image-alias")' in source
     assert 'events.contains(#""event": "server_started""#)' in source
     assert 'events.contains(#""alias": "fake-image-alias""#)' in source
-    assert "waitForNonExistence" in source
+    assert "imageResponseCount(in: eventLog) == 1" in source
+    assert "imageResponseCount(in: eventLog) == 2" in source
+    assert "waitForNonExistence" not in source
     assert "XCTUnwrap" in source
     assert "XCTSkip" not in source
     assert "source.cropping(to: rect)" in source

--- a/tests/test_rapid_mac_xcui_target.py
+++ b/tests/test_rapid_mac_xcui_target.py
@@ -64,6 +64,7 @@ def test_xcui_runner_launches_production_bundle_with_fake_sidecar():
 
     assert "build/Rapid-MLX Desktop.app" in runner
     assert "lsregister" in runner
+    assert "xcodebuild -version" in runner
     assert "XCUIApplication(url: appURL)" in source
     assert 'appendingPathComponent("build/Rapid-MLX Desktop.app")' in source
     assert source.count('"CFFIXED_USER_HOME": testHome.path') == 1

--- a/tests/test_rapid_mac_xcui_target.py
+++ b/tests/test_rapid_mac_xcui_target.py
@@ -26,6 +26,10 @@ def test_pixel_assertion_uses_element_screenshots_and_crops_chrome():
     assert "newest.screenshot()" in source
     assert "older.screenshot()" in source
     assert 'element("Images.Result.Save", in: app)' in source
+    assert 'element("Images.ModelPicker", in: app)' in source
+    assert 'picker.debugDescription.contains("fake-image-alias")' in source
+    assert 'events.contains(#""event": "server_started""#)' in source
+    assert 'events.contains(#""alias": "fake-image-alias""#)' in source
     assert "waitForNonExistence" in source
     assert "XCTUnwrap" in source
     assert "XCTSkip" not in source

--- a/tests/test_rapid_mac_xcui_target.py
+++ b/tests/test_rapid_mac_xcui_target.py
@@ -25,6 +25,10 @@ def test_pixel_assertion_uses_element_screenshots_and_crops_chrome():
     assert 'element("Images.Gallery.Thumb.2", in: app)' in source
     assert "newest.screenshot()" in source
     assert "older.screenshot()" in source
+    assert 'element("Images.Result.Save", in: app)' in source
+    assert "waitForNonExistence" in source
+    assert "XCTUnwrap" in source
+    assert "XCTSkip" not in source
     assert "source.cropping(to: rect)" in source
     assert "XCTAssertGreaterThan(" in source
 
@@ -41,3 +45,4 @@ def test_xcui_runner_launches_production_bundle_with_fake_sidecar():
     assert '"RAPID_BIN"' in source
     assert "fake-rapid-mlx.sh" in source
     assert "isExecutableFile" in source
+    assert "RapidUITests-$(date +%s)-$$.xcresult" in runner

--- a/tests/test_rapid_mac_xcui_target.py
+++ b/tests/test_rapid_mac_xcui_target.py
@@ -39,4 +39,5 @@ def test_xcui_runner_launches_production_bundle_with_fake_sidecar():
     assert "lsregister" in runner
     assert 'XCUIApplication(bundleIdentifier: "com.rapidmlx.rapid")' in source
     assert '"RAPID_BIN"' in source
-    assert "fake-rapid-mlx.sh" in runner
+    assert "fake-rapid-mlx.sh" in source
+    assert "isExecutableFile" in source


### PR DESCRIPTION
## What changed

- add a checked-in Xcode UI-testing target alongside the existing SwiftPM and AX suites
- launch the production-shaped `Rapid-MLX Desktop.app` with the deterministic fake sidecar
- port the image-generation journey's missing assertion: capture both thumbnail elements, crop selection chrome, and compare their rendered interior pixels
- run the XCUITest on the existing macOS GUI CI runner and retain `.xcresult` evidence on failure
- keep every existing AX GoldenFlow intact; this is an additive migration

## Reproduction / root cause

`AXUIElement` exposes each gallery button's identifier, label, and bounds but not its bitmap. The existing GoldenFlow can prove that the wire returned two different PNGs and that the gallery bound two different records, yet a rendering regression that paints one bitmap into both buttons still passes. XCUITest's element screenshots close that exact gap.

The repository also had no native UI-testing target, so Apple's waiting, screenshot, and attachment primitives were unavailable to GUI journeys.

## Validation

- `SKIP_SIDECAR=1 RAPID_BUILD_CONFIG=debug ./scripts/build.sh` — pass
- `python3 -m pytest tests/test_rapid_mac_xcui_target.py -q` — 3 passed
- `ruff check tests/test_rapid_mac_xcui_target.py` — pass
- workflow YAML parse and shell syntax — pass
- real XCUITest: pending GitHub's full-Xcode macOS runner (local host has Command Line Tools only)

Closes #1719
