### PR TITLE
fix(ci): version-stamp installer checksums so cosign signing is idempotent (#1434)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -189,23 +189,100 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Create installer checksums
+        env:
+          TAG: ${{ github.event.release.tag_name }}
         run: |
-          sha256sum install.sh > SHA256SUMS.txt
+          # Version-stamp the manifest so each release signs UNIQUE content.
+          # install.sh is stable across releases, so a version-independent
+          # SHA256SUMS.txt yields a byte-identical blob every time; cosign
+          # keyless signatures are deterministic, so Rekor rejects the
+          # duplicate transparency-log entry with a 409 "equivalent entry
+          # already exists" and the signing step fails (#1434). A per-release
+          # header line makes the signed blob unique, so Rekor always gets a
+          # fresh entry. The header is a `#` comment line, which both GNU
+          # `sha256sum -c` (incl. --strict) and BSD `shasum -c` skip, so
+          # `install.sh` verification is unaffected. TAG comes via env (not
+          # inline GitHub Actions expression interpolation) to avoid script
+          # injection.
+          {
+            printf '# Rapid-MLX %s installer checksums\n' "$TAG"
+            sha256sum install.sh
+          } > SHA256SUMS.txt
           cat SHA256SUMS.txt
 
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - name: Sign checksums (keyless, GitHub OIDC)
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.event.release.tag_name }}
         run: |
-          cosign sign-blob --yes SHA256SUMS.txt \
-            --bundle SHA256SUMS.txt.sigstore.json
+          set -o pipefail
+          # The version-stamped manifest above makes the normal path 409-free,
+          # so cosign signs and writes the bundle as usual. Belt-and-suspenders
+          # for a re-published tag (identical content signed twice): tolerate
+          # ONLY the benign Rekor 409. But a 409 alone does NOT prove a usable
+          # signature is published — an earlier run could have created the
+          # transparency-log entry and then died before writing/uploading the
+          # bundle. So on a 409, require that the release already carries a
+          # bundle that cryptographically verifies against the current
+          # SHA256SUMS.txt; otherwise fail rather than publish unsigned
+          # checksums. Any other cosign failure also fails the job.
+          log="$(mktemp)"
+          trap 'rm -f "$log"' EXIT
+          if cosign sign-blob --yes SHA256SUMS.txt \
+              --bundle SHA256SUMS.txt.sigstore.json 2>&1 | tee "$log"; then
+            echo "signed SHA256SUMS.txt"
+          elif grep -q '409' "$log" \
+              && grep -qi 'equivalent entry already exists' "$log"; then
+            echo "::notice::cosign 409 (equivalent Rekor entry already exists) —" \
+              "re-published tag; validating the bundle already on the release"
+            rm -f SHA256SUMS.txt.sigstore.json
+            if ! gh release download "$TAG" \
+                --pattern SHA256SUMS.txt.sigstore.json --dir .; then
+              echo "::error::Rekor 409 but the release has no signature bundle" \
+                "to fall back on — refusing to publish unsigned checksums" >&2
+              exit 1
+            fi
+            # Pin the exact keyless identity — THIS publish workflow at THIS
+            # tag — not a repo-wide regexp, so the fallback cannot bless a
+            # bundle signed by any other workflow or ref. Exact match (not a
+            # regexp) also sidesteps escaping TAG. Worst case if the SAN
+            # differs is a fail-closed job on a rare re-publish, never a
+            # loosened check.
+            if ! cosign verify-blob SHA256SUMS.txt \
+                --bundle SHA256SUMS.txt.sigstore.json \
+                --certificate-identity \
+                  "https://github.com/${GITHUB_REPOSITORY}/.github/workflows/publish.yml@refs/tags/${TAG}" \
+                --certificate-oidc-issuer \
+                  "https://token.actions.githubusercontent.com"; then
+              echo "::error::existing release bundle does not verify against the" \
+                "current SHA256SUMS.txt — refusing to publish unsigned checksums" >&2
+              exit 1
+            fi
+            echo "::notice::existing release bundle verifies; keeping it"
+          else
+            echo "::error::cosign sign-blob failed for a reason other than a" \
+              "benign Rekor 409" >&2
+            exit 1
+          fi
 
       - name: Upload installer assets to the release
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ github.event.release.tag_name }}
         run: |
+          # The sign step guarantees a local bundle whenever the job reaches
+          # here: either freshly signed, or (on a tolerated 409 re-run)
+          # downloaded from the release and cryptographically verified. If it
+          # is somehow absent, fail rather than publish checksums without a
+          # signature — the signed-release guarantee is not optional.
+          if [ ! -f SHA256SUMS.txt.sigstore.json ]; then
+            echo "::error::no signature bundle present at upload — refusing to" \
+              "publish checksums without a signature" >&2
+            exit 1
+          fi
           gh release upload "$TAG" \
             install.sh SHA256SUMS.txt SHA256SUMS.txt.sigstore.json \
             --clobber


### PR DESCRIPTION
## Why

`publish.yml`'s `installer-assets` job signs `SHA256SUMS.txt` with cosign keyless (GitHub OIDC). The manifest only checksums `install.sh`, whose content is **stable across releases**, so the signed blob is byte-identical every release. cosign keyless signatures are deterministic, so Rekor rejects the duplicate transparency-log entry with a **409 `createLogEntryConflict` ("an equivalent entry already exists")** and the signing step fails. Every release whose installer is unchanged then loses its signed installer-checksum asset (observed on **v0.12.1**).

The signature genuinely already exists — this is an idempotency conflict, not a signing failure. cosign's own 409 handling is unreliable for the new bundle format ([sigstore/cosign#3356](https://github.com/sigstore/cosign/issues/3356)), so the robust fix is to **stop producing duplicate content** rather than depend on tolerating the 409 after the fact (the bundle may not be written on the 409 path, which would upload a broken/missing asset behind a green job).

## What

- **Version-stamp `SHA256SUMS.txt`** with a per-release header comment (`# Rapid-MLX <tag> installer checksums`) so each release signs unique content and Rekor always gets a fresh entry. The normal path is now **409-free** and produces a real signed bundle. The header is a `#` comment line, which both GNU `sha256sum -c` (incl. `--strict`) and BSD `shasum -c` **skip**, so `install.sh` verification is unaffected. `TAG` is passed via `env`, not inline `${{ }}`, to avoid script injection.
- **Belt-and-suspenders**: if the *same* tag is re-published (identical content signed twice), tolerate **only** the benign Rekor 409 so the re-run does not fail the release; any other cosign failure still fails the job.
- **Upload** the freshly signed bundle only when this run produced one; on a tolerated 409 re-run, keep the valid bundle the first run attached (it signs byte-identical content).

## Tests

Workflow-only change (no importable code), so the pytest suite does not cover it. Verified locally instead:

- `sha256sum -c` / `shasum -c` skip the `#` header and still verify `install.sh` (exit 0) on **GNU coreutils (incl. `--strict`)** and **BSD**.
- Dry-ran the sign + upload shell logic against a fake `cosign` in three modes:
  - **success** → bundle written → all 3 assets uploaded;
  - **benign 409** → no bundle → tolerated (exit 0), existing bundle kept;
  - **other failure** (e.g. Fulcio 500) → job fails, upload skipped (real failures not hidden).

## Notes

- I cannot run the real release-triggered OIDC signing locally. The 409 grep matches the exact Rekor error text from the v0.12.1 failure, and the version-stamp makes the normal path 409-free regardless of cosign's 409 behavior.
- No version bump.
- 🤖 AI-authored (Claude Code), human-reviewed.