### PR TITLE
Fix macOS tests, model storage overview, and table accessibility

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Services/ModelCacheActions.swift
+++ b/apps/rapid-mac/Sources/Rapid/Services/ModelCacheActions.swift
@@ -420,6 +420,45 @@ enum ModelCacheActions {
         let missingSizeCount: Int
     }
 
+    /// Largest cache entry that this app can actually manage. External
+    /// runtime entries are visible in the inventory but live outside Rapid's
+    /// selected models folder, so including them would make the overview's
+    /// total and cleanup signal contradict its own delete surface (#1818).
+    static func largestManagedEntry(_ entries: [ModelEntry]) -> ModelEntry? {
+        entries
+            .filter { $0.cached && !$0.isExternal && parseSizeBytes($0.sizeOnDisk) != nil }
+            .max {
+                let lhs = parseSizeBytes($0.sizeOnDisk) ?? 0
+                let rhs = parseSizeBytes($1.sizeOnDisk) ?? 0
+                if lhs != rhs { return lhs < rhs }
+                return $0.alias.localizedStandardCompare($1.alias) == .orderedDescending
+            }
+    }
+
+    static func storageSummary(usage: DiskUsage, freeBytes: Int64?) -> String {
+        let used = usage.totalBytes.map {
+            ByteCountFormatter.string(fromByteCount: $0, countStyle: .file)
+        } ?? "size unavailable"
+        let models = "\(usage.cachedCount) model\(usage.cachedCount == 1 ? "" : "s")"
+        guard let freeBytes else { return "\(used) · \(models)" }
+        let free = ByteCountFormatter.string(fromByteCount: freeBytes, countStyle: .file)
+        return "\(used) · \(models) · \(free) free"
+    }
+
+    /// Conservative keep-signals shown beside chat models. They make the two
+    /// easy-to-regret deletions visible without claiming that everything else
+    /// is automatically safe to remove (#1818).
+    static func retentionBadges(
+        alias: String,
+        starterAlias: String,
+        lastServedAlias: String?
+    ) -> [String] {
+        var badges: [String] = []
+        if alias == starterAlias { badges.append("STARTER") }
+        if alias == lastServedAlias { badges.append("LAST USED") }
+        return badges
+    }
+
     static func aggregateOnDiskBytes(_ entries: [ModelEntry]) -> DiskUsage {
         var total: Int64 = 0
         var anyParsed = false

--- a/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
@@ -1898,6 +1898,9 @@ extension MarkdownUI.Theme {
             .markdownMargin(top: 8, bottom: 8)
         }
         .table { config in
+            let accessibilityTable = MarkdownTableAccessibility.parse(
+                config.content.renderMarkdown()
+            )
             config.label
                 // ``fixedSize`` vertically: without it a cell whose text
                 // wraps gets its height clipped to one line, because the
@@ -1905,6 +1908,11 @@ extension MarkdownUI.Theme {
                 .fixedSize(horizontal: false, vertical: true)
                 .markdownTableBorderStyle(.init(color: .secondary.opacity(0.4)))
                 .markdownMargin(top: 8, bottom: 8)
+                .accessibilityRepresentation {
+                    if let accessibilityTable {
+                        AccessibleMarkdownTable(model: accessibilityTable)
+                    }
+                }
         }
         // 2026-08: the theme set a table BORDER but never a cell style, so
         // MarkdownUI fell back to ``Theme.tableCell``'s default — the bare

--- a/apps/rapid-mac/Sources/Rapid/UI/Markdown/MarkdownTableAccessibility.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/Markdown/MarkdownTableAccessibility.swift
@@ -1,0 +1,166 @@
+import SwiftUI
+
+/// Accessibility-only model for a GFM table block. MarkdownUI draws tables
+/// with `Grid`, which looks correct but flattens to unrelated static text in
+/// AppKit's accessibility tree. The chat theme uses this model to provide a
+/// native SwiftUI `Table` as the visual block's accessibility representation.
+enum MarkdownTableAccessibility {
+    struct TableModel: Equatable {
+        let headers: [String]
+        let rows: [[String]]
+    }
+
+    static func parse(_ markdown: String) -> TableModel? {
+        let lines = markdown.split(whereSeparator: \Character.isNewline).map(String.init)
+        guard lines.count >= 2 else { return nil }
+        let headers = cells(in: lines[0])
+        let separator = cells(in: lines[1])
+        // SwiftUI's macOS 14.0 TableColumnBuilder has no dynamic-column
+        // primitive. Cover ordinary chat tables (up to eight columns) and
+        // leave wider tables on MarkdownUI's existing text accessibility
+        // instead of silently dropping columns from the representation.
+        guard !headers.isEmpty,
+              headers.count <= 8,
+              separator.count == headers.count,
+              separator.allSatisfy(isSeparatorCell) else { return nil }
+
+        let rows = lines.dropFirst(2).map { line in
+            let parsed = cells(in: line)
+            return headers.indices.map { index in
+                index < parsed.count ? parsed[index] : ""
+            }
+        }
+        return TableModel(headers: headers, rows: rows)
+    }
+
+    private static func cells(in line: String) -> [String] {
+        var result: [String] = []
+        var current = ""
+        var escaped = false
+        var codeFenceLength = 0
+
+        for character in line {
+            if escaped {
+                current.append(character)
+                escaped = false
+                continue
+            }
+            if character == "\\" {
+                escaped = true
+                continue
+            }
+            if character == "`" {
+                codeFenceLength = codeFenceLength == 0 ? 1 : 0
+                current.append(character)
+                continue
+            }
+            if character == "|", codeFenceLength == 0 {
+                result.append(clean(current))
+                current = ""
+            } else {
+                current.append(character)
+            }
+        }
+        if escaped { current.append("\\") }
+        result.append(clean(current))
+        if result.first == "" { result.removeFirst() }
+        if result.last == "" { result.removeLast() }
+        return result
+    }
+
+    private static func clean(_ value: String) -> String {
+        value.trimmingCharacters(in: .whitespacesAndNewlines)
+            .replacingOccurrences(of: "`", with: "")
+    }
+
+    private static func isSeparatorCell(_ value: String) -> Bool {
+        let trimmed = value.trimmingCharacters(in: CharacterSet(charactersIn: ":"))
+        return trimmed.count >= 3 && trimmed.allSatisfy { $0 == "-" }
+    }
+}
+
+private struct AccessibleMarkdownTableRow: Identifiable {
+    let id: Int
+    let cells: [String]
+}
+
+/// A native `Table` is used only as an accessibility representation; the
+/// visible MarkdownUI grid remains unchanged. VoiceOver therefore gains real
+/// table navigation and header association without duplicating visual output.
+struct AccessibleMarkdownTable: View {
+    let model: MarkdownTableAccessibility.TableModel
+
+    private var rows: [AccessibleMarkdownTableRow] {
+        model.rows.enumerated().map { .init(id: $0.offset, cells: $0.element) }
+    }
+
+    @ViewBuilder var body: some View {
+        switch model.headers.count {
+        case 1: table1
+        case 2: table2
+        case 3: table3
+        case 4: table4
+        case 5: table5
+        case 6: table6
+        case 7: table7
+        default: table8
+        }
+    }
+
+    private func cell(_ index: Int, in row: AccessibleMarkdownTableRow) -> String {
+        index < row.cells.count ? row.cells[index] : ""
+    }
+
+    private var table1: some View { Table(rows) {
+        TableColumn(model.headers[0]) { row in Text(cell(0, in: row)) }
+    }.accessibilityLabel("Markdown table") }
+    private var table2: some View { Table(rows) {
+        TableColumn(model.headers[0]) { row in Text(cell(0, in: row)) }
+        TableColumn(model.headers[1]) { row in Text(cell(1, in: row)) }
+    }.accessibilityLabel("Markdown table") }
+    private var table3: some View { Table(rows) {
+        TableColumn(model.headers[0]) { row in Text(cell(0, in: row)) }
+        TableColumn(model.headers[1]) { row in Text(cell(1, in: row)) }
+        TableColumn(model.headers[2]) { row in Text(cell(2, in: row)) }
+    }.accessibilityLabel("Markdown table") }
+    private var table4: some View { Table(rows) {
+        TableColumn(model.headers[0]) { row in Text(cell(0, in: row)) }
+        TableColumn(model.headers[1]) { row in Text(cell(1, in: row)) }
+        TableColumn(model.headers[2]) { row in Text(cell(2, in: row)) }
+        TableColumn(model.headers[3]) { row in Text(cell(3, in: row)) }
+    }.accessibilityLabel("Markdown table") }
+    private var table5: some View { Table(rows) {
+        TableColumn(model.headers[0]) { row in Text(cell(0, in: row)) }
+        TableColumn(model.headers[1]) { row in Text(cell(1, in: row)) }
+        TableColumn(model.headers[2]) { row in Text(cell(2, in: row)) }
+        TableColumn(model.headers[3]) { row in Text(cell(3, in: row)) }
+        TableColumn(model.headers[4]) { row in Text(cell(4, in: row)) }
+    }.accessibilityLabel("Markdown table") }
+    private var table6: some View { Table(rows) {
+        TableColumn(model.headers[0]) { row in Text(cell(0, in: row)) }
+        TableColumn(model.headers[1]) { row in Text(cell(1, in: row)) }
+        TableColumn(model.headers[2]) { row in Text(cell(2, in: row)) }
+        TableColumn(model.headers[3]) { row in Text(cell(3, in: row)) }
+        TableColumn(model.headers[4]) { row in Text(cell(4, in: row)) }
+        TableColumn(model.headers[5]) { row in Text(cell(5, in: row)) }
+    }.accessibilityLabel("Markdown table") }
+    private var table7: some View { Table(rows) {
+        TableColumn(model.headers[0]) { row in Text(cell(0, in: row)) }
+        TableColumn(model.headers[1]) { row in Text(cell(1, in: row)) }
+        TableColumn(model.headers[2]) { row in Text(cell(2, in: row)) }
+        TableColumn(model.headers[3]) { row in Text(cell(3, in: row)) }
+        TableColumn(model.headers[4]) { row in Text(cell(4, in: row)) }
+        TableColumn(model.headers[5]) { row in Text(cell(5, in: row)) }
+        TableColumn(model.headers[6]) { row in Text(cell(6, in: row)) }
+    }.accessibilityLabel("Markdown table") }
+    private var table8: some View { Table(rows) {
+        TableColumn(model.headers[0]) { row in Text(cell(0, in: row)) }
+        TableColumn(model.headers[1]) { row in Text(cell(1, in: row)) }
+        TableColumn(model.headers[2]) { row in Text(cell(2, in: row)) }
+        TableColumn(model.headers[3]) { row in Text(cell(3, in: row)) }
+        TableColumn(model.headers[4]) { row in Text(cell(4, in: row)) }
+        TableColumn(model.headers[5]) { row in Text(cell(5, in: row)) }
+        TableColumn(model.headers[6]) { row in Text(cell(6, in: row)) }
+        TableColumn(model.headers[7]) { row in Text(cell(7, in: row)) }
+    }.accessibilityLabel("Markdown table") }
+}

--- a/apps/rapid-mac/Sources/Rapid/UI/SettingsModelManagementPanel.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SettingsModelManagementPanel.swift
@@ -44,6 +44,7 @@ struct SettingsModelManagementPanel: View {
     @State private var pendingDeletion: ModelEntry?
     @State private var lastError: String?
     @State private var lastFreed: String?
+    @State private var modelsVolumeFreeBytes: Int64?
 
     @State private var query: String = ""
     /// Which capability tab is showing (Chat vs Image vs Audio vs future Video). Model
@@ -119,6 +120,7 @@ struct SettingsModelManagementPanel: View {
         VStack(alignment: .leading, spacing: 16) {
             header
             modelsFolderSection
+            storageOverviewSection
             preferencesSection
             capabilityTabs
             controlsRow
@@ -146,6 +148,7 @@ struct SettingsModelManagementPanel: View {
         // transition, which can overlay the spinner on stale model rows.
         .task {
             await refreshCatalog()
+            refreshStorageCapacity()
         }
         // codex r1 P2 / codex r2 P2 fix: catch the running → terminal
         // transition without relying on SwiftUI's observation graph,
@@ -371,6 +374,73 @@ struct SettingsModelManagementPanel: View {
         return resolved?.path ?? "~/.cache/huggingface/hub"
     }
 
+    private var effectiveModelsFolderURL: URL? {
+        ModelsFolderPreference.validatedOverrideURL()
+            ?? BundledModel.userHFCacheURL(environment: ProcessInfo.processInfo.environment)
+    }
+
+    private func refreshStorageCapacity() {
+        modelsVolumeFreeBytes = effectiveModelsFolderURL.flatMap {
+            DiskSpaceProbe.freeBytes(forPath: $0.path)
+        }
+    }
+
+    /// Always-visible cache overview. Unlike the old footer this spans Chat,
+    /// Image, and Audio, and it excludes read-only entries owned by another
+    /// runtime because this panel cannot reclaim those bytes.
+    @ViewBuilder
+    private var storageOverviewSection: some View {
+        let managed = catalog.filter { !$0.isExternal }
+        let usage = ModelCacheActions.aggregateOnDiskBytes(managed)
+        let largest = ModelCacheActions.largestManagedEntry(managed)
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Disk overview")
+                .font(.callout.weight(.semibold))
+                .foregroundStyle(.secondary)
+            VStack(alignment: .leading, spacing: 10) {
+                HStack {
+                    Label("Models", systemImage: "internaldrive")
+                        .font(.callout.weight(.medium))
+                    Spacer()
+                    Text(ModelCacheActions.storageSummary(
+                        usage: usage,
+                        freeBytes: modelsVolumeFreeBytes
+                    ))
+                    .font(.callout.monospacedDigit())
+                    .foregroundStyle(.secondary)
+                    .accessibilityIdentifier("Settings.ModelManagement.StorageSummary")
+                }
+                if let largest {
+                    Divider()
+                    HStack {
+                        Text("Largest")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        Text(largest.alias)
+                            .font(.caption.weight(.medium))
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                        Spacer()
+                        Text(largest.sizeOnDisk ?? "")
+                            .font(.caption.monospacedDigit())
+                            .foregroundStyle(.secondary)
+                    }
+                    .accessibilityElement(children: .combine)
+                    .accessibilityIdentifier("Settings.ModelManagement.LargestModel")
+                }
+            }
+            .padding(12)
+            .background(
+                RoundedRectangle(cornerRadius: RapidTheme.cardRadius, style: .continuous)
+                    .fill(RapidTheme.card)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: RapidTheme.cardRadius, style: .continuous)
+                    .stroke(RapidTheme.hairline, lineWidth: 1)
+            )
+        }
+    }
+
     /// Present a folder picker and persist the choice. Directories only;
     /// the app is not sandboxed so no security-scoped bookmark is
     /// needed to read/write the picked folder (including an external
@@ -391,6 +461,7 @@ struct SettingsModelManagementPanel: View {
         guard panel.runModal() == .OK, let url = panel.url else { return }
         ModelsFolderPreference.setStoredPath(url.path)
         customFolderPath = ModelsFolderPreference.storedPath()
+        refreshStorageCapacity()
         Task { await refreshCatalog() }
     }
 
@@ -398,6 +469,7 @@ struct SettingsModelManagementPanel: View {
     private func resetModelsFolder() {
         ModelsFolderPreference.setStoredPath(nil)
         customFolderPath = nil
+        refreshStorageCapacity()
         Task { await refreshCatalog() }
     }
 
@@ -825,6 +897,13 @@ struct SettingsModelManagementPanel: View {
             badgePill(badge, color: RapidTheme.brand)
         } else if ModelBrandStyle.modelType(forAlias: alias) == .vision {
             badgePill("VISION", color: Self.visionColor)
+        }
+        ForEach(ModelCacheActions.retentionBadges(
+            alias: alias,
+            starterAlias: QuickstartCoordinator.defaultChoice.alias,
+            lastServedAlias: ServerManager.lastServedAlias()
+        ), id: \.self) { badge in
+            badgePill(badge, color: badge == "STARTER" ? RapidTheme.amber : RapidTheme.green)
         }
     }
 

--- a/apps/rapid-mac/Tests/RapidTests/MarkdownTableAccessibilityTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/MarkdownTableAccessibilityTests.swift
@@ -1,0 +1,45 @@
+import Testing
+
+@testable import Rapid
+
+struct MarkdownTableAccessibilityTests {
+    @Test("GFM table becomes headers and rectangular data rows")
+    func parsesTable() {
+        let table = MarkdownTableAccessibility.parse("""
+        | model | size | speed |
+        | --- | ---: | :---: |
+        | qwen3.5-9b | 5.2 GB | 74 tok/s |
+        | llama-3.1-8b | 4.5 GB | 68 tok/s |
+        """)
+        #expect(table?.headers == ["model", "size", "speed"])
+        #expect(table?.rows == [
+            ["qwen3.5-9b", "5.2 GB", "74 tok/s"],
+            ["llama-3.1-8b", "4.5 GB", "68 tok/s"],
+        ])
+    }
+
+    @Test("Escaped and inline-code pipes stay inside their cells")
+    func preservesPipes() {
+        let table = MarkdownTableAccessibility.parse("""
+        | name | expression |
+        | --- | --- |
+        | escaped | a\\|b |
+        | code | `x|y` |
+        """)
+        #expect(table?.rows == [["escaped", "a|b"], ["code", "x|y"]])
+    }
+
+    @Test("Ordinary prose is not mistaken for a table")
+    func rejectsProse() {
+        #expect(MarkdownTableAccessibility.parse("hello\nworld") == nil)
+    }
+
+    @Test("Tables wider than the faithful macOS 14 representation keep the visual fallback")
+    func rejectsMoreThanEightColumns() {
+        #expect(MarkdownTableAccessibility.parse("""
+        | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 |
+        |---|---|---|---|---|---|---|---|---|
+        | a | b | c | d | e | f | g | h | i |
+        """) == nil)
+    }
+}

--- a/apps/rapid-mac/Tests/RapidTests/ModelCacheActionsTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ModelCacheActionsTests.swift
@@ -359,6 +359,42 @@ struct ModelCacheActionsTests {
         #expect(usage.missingSizeCount == 1)
     }
 
+    @Test("disk overview: largest excludes uncached and external entries")
+    func largestManagedEntry() {
+        let entries = [
+            entry("small", cached: true, size: "1 GB"),
+            ModelEntry(alias: "external", hfRepo: nil, sizeOnDisk: "9 GB", cached: true, isExternal: true),
+            entry("not-downloaded", cached: false, size: "8 GB"),
+            entry("largest", cached: true, size: "5 GB"),
+        ]
+        #expect(ModelCacheActions.largestManagedEntry(entries)?.alias == "largest")
+    }
+
+    @Test("disk overview: summary includes count and optional free space")
+    func storageSummary() {
+        let usage = ModelCacheActions.DiskUsage(
+            cachedCount: 2,
+            totalBytes: 3_000_000_000,
+            missingSizeCount: 0
+        )
+        let measured = ModelCacheActions.storageSummary(usage: usage, freeBytes: 20_000_000_000)
+        #expect(measured.contains("2 models"))
+        #expect(measured.contains("free"))
+        let unavailable = ModelCacheActions.storageSummary(usage: usage, freeBytes: nil)
+        #expect(unavailable.contains("2 models"))
+        #expect(!unavailable.contains("free"))
+    }
+
+    @Test("disk overview: starter and last-used badges are conservative keep signals")
+    func retentionBadges() {
+        #expect(ModelCacheActions.retentionBadges(
+            alias: "starter", starterAlias: "starter", lastServedAlias: "starter"
+        ) == ["STARTER", "LAST USED"])
+        #expect(ModelCacheActions.retentionBadges(
+            alias: "other", starterAlias: "starter", lastServedAlias: "recent"
+        ).isEmpty)
+    }
+
     @Test("diskUsageFooter: hidden when nothing cached")
     func diskUsageFooterHidden() {
         let usage = ModelCacheActions.DiskUsage(cachedCount: 0, totalBytes: nil, missingSizeCount: 0)

--- a/apps/rapid-mac/Tests/RapidUXTests/ModelReadinessTests.swift
+++ b/apps/rapid-mac/Tests/RapidUXTests/ModelReadinessTests.swift
@@ -1,19 +1,18 @@
-import XCTest
+import Testing
 
 @testable import Rapid
 
 /// Contract tests for ``ModelReadiness`` — the single source of truth for
 /// "can the user send right now, and if not, what should they do?".
 ///
-/// XCTest rather than swift-testing deliberately: the excluded legacy
-/// suite under `Tests/RapidTests` uses `import Testing`, and the package
-/// manifest records that the module does not resolve from the command
-/// line in this toolchain. XCTest always does, and a test that cannot be
-/// run is not a test.
+/// Swift Testing keeps this pure state-machine suite runnable from the same
+/// command-line toolchain as `RapidTests`. XCTest is not present in the
+/// Command Line Tools SDK used by `swift test` (#1638).
 ///
 /// Everything here is a pure value transform, so no SwiftUI host, no
 /// subprocess, and no live ``ServerManager`` is needed.
-final class ModelReadinessTests: XCTestCase {
+@Suite
+struct ModelReadinessTests {
 
     private let alias = "qwen3.5-9b-4bit"
 
@@ -87,6 +86,7 @@ final class ModelReadinessTests: XCTestCase {
 
     /// The core Phase 1 contract: sending is possible in exactly one
     /// state. Everything else keeps the field live and the action dark.
+    @Test
     func testSendAllowedOnlyWhenReady() {
         for state in allStates {
             if case .ready = state {
@@ -103,6 +103,7 @@ final class ModelReadinessTests: XCTestCase {
     /// A gated state must always be able to say WHY, in both the mouse
     /// channel (tooltip) and the copy channel (banner headline). An
     /// empty explanation is the silent-gate defect this phase removes.
+    @Test
     func testEveryGatedStateExplainsItself() {
         for state in allStates where !state.sendAllowed {
             XCTAssertFalse(
@@ -123,6 +124,7 @@ final class ModelReadinessTests: XCTestCase {
     /// Ready is the one state that must NOT nag: no banner detail, and a
     /// plain "Send" tooltip rather than an explanation of a problem that
     /// no longer exists.
+    @Test
     func testReadyIsQuiet() {
         let ready = ModelReadiness.ready(alias: alias)
         XCTAssertNil(ready.detail)
@@ -138,6 +140,7 @@ final class ModelReadinessTests: XCTestCase {
     /// was interpolated into failure copy, producing "Couldn't start ."
     /// with an empty model name. No surface may render a placeholder as
     /// if it were a model.
+    @Test
     func testUnresolvedAliasNeverBecomesAModelName() {
         // "" plus every internal placeholder ``ModelDisplayName`` knows.
         let placeholders = ["", "   ", "loading", "Loading", "STARTING",
@@ -163,6 +166,7 @@ final class ModelReadinessTests: XCTestCase {
     /// A `.ready` state carrying a placeholder alias is not ready — it
     /// falls back to "choose a model" rather than claiming to be
     /// chatting with nothing.
+    @Test
     func testReadyWithPlaceholderAliasIsNotReady() {
         let state = resolve(.ready(alias: ""), alias: "")
         XCTAssertEqual(state, .noModel)
@@ -171,6 +175,7 @@ final class ModelReadinessTests: XCTestCase {
 
     /// No user-facing string may ever contain an empty-name artefact
     /// like a double space, a dangling "start ." or a trailing " —".
+    @Test
     func testNoCopyContainsEmptyNameArtefacts() {
         for state in allStates {
             let strings = [
@@ -193,6 +198,7 @@ final class ModelReadinessTests: XCTestCase {
 
     // MARK: - Resolution precedence
 
+    @Test
     func testEngineMissingWinsOverEverything() {
         let state = resolve(
             .missing,
@@ -206,6 +212,7 @@ final class ModelReadinessTests: XCTestCase {
     /// An in-flight start outranks a stale failure. Otherwise pressing
     /// Retry would leave the banner reading "Couldn't start X" while X
     /// is visibly starting.
+    @Test
     func testInFlightStartBeatsStaleFailure() {
         let state = resolve(
             .starting(alias: alias),
@@ -219,6 +226,7 @@ final class ModelReadinessTests: XCTestCase {
 
     /// A crash outranks a chat-level failure and supplies its own
     /// classified message plus a retry aimed at the crashed alias.
+    @Test
     func testCrashedResolvesToFailedWithRetry() {
         let state = resolve(
             .crashed(alias: alias, message: "RuntimeError: out of memory"),
@@ -239,6 +247,7 @@ final class ModelReadinessTests: XCTestCase {
 
     /// ``ChatViewModel.lastFailureKind`` was previously computed and
     /// discarded. It must now choose the message the user reads.
+    @Test
     func testChatFailureUsesStructuredDiagnosisOverRawMessage() {
         let state = resolve(
             .idle,
@@ -260,6 +269,7 @@ final class ModelReadinessTests: XCTestCase {
 
     /// With no structured kind, the raw message is the fallback rather
     /// than a generic sentence that loses information.
+    @Test
     func testChatFailureWithoutKindKeepsItsMessage() {
         let state = resolve(.idle, failure: .init(message: "Disk is full.", alias: alias))
         guard case .failed(_, let message, _) = state else {
@@ -277,6 +287,7 @@ final class ModelReadinessTests: XCTestCase {
     /// ``.crashed`` short-circuited before the selection was consulted.
     private let crashed = "kimi-k2.6"
 
+    @Test
     func testCrashedAliasMatchingSelectionStillFails() {
         let state = resolve(
             .crashed(alias: crashed, message: "load failed"),
@@ -293,6 +304,7 @@ final class ModelReadinessTests: XCTestCase {
 
     /// The fix: a crash on a DIFFERENT model than the one now selected
     /// must not describe the new selection. Cached → needsStart.
+    @Test
     func testCrashedAliasDiffersFromSelectionResolvesToNeedsStart() {
         let state = resolve(
             .crashed(alias: crashed, message: "load failed"),
@@ -305,6 +317,7 @@ final class ModelReadinessTests: XCTestCase {
     }
 
     /// Same, uncached → needsDownload with the download CTA.
+    @Test
     func testCrashedAliasDiffersFromSelectionResolvesToNeedsDownload() {
         let state = resolve(
             .crashed(alias: crashed, message: "load failed"),
@@ -321,6 +334,7 @@ final class ModelReadinessTests: XCTestCase {
     /// is the second half of the bug. Previously the resolver read
     /// `failure.alias ?? alias`, so a failure recorded against Kimi (or
     /// with no alias at all) got re-attributed to the new pick.
+    @Test
     func testStaleChatFailureDoesNotFollowTheNewSelection() {
         let state = resolve(
             .idle,
@@ -334,6 +348,7 @@ final class ModelReadinessTests: XCTestCase {
     }
 
     /// A chat failure that DOES belong to the selection still shows.
+    @Test
     func testChatFailureMatchingSelectionStillShows() {
         let state = resolve(
             .idle,
@@ -351,6 +366,7 @@ final class ModelReadinessTests: XCTestCase {
     /// Regression for #1514: model-load failures are not retryable in place.
     /// The shared diagnosis contract sends the user to Model Management, but
     /// readiness used to overwrite that decision with an unconditional Retry.
+    @Test
     func testModelLoadFailureOffersModelManagementInsteadOfRetry() {
         let state = resolve(
             .idle,
@@ -362,6 +378,7 @@ final class ModelReadinessTests: XCTestCase {
         XCTAssertEqual(state.action, .openModelManagement)
     }
 
+    @Test
     func testOutOfMemoryFailureOffersModelManagementInsteadOfRetry() {
         let state = resolve(
             .idle,
@@ -373,6 +390,7 @@ final class ModelReadinessTests: XCTestCase {
         XCTAssertEqual(state.action, .openModelManagement)
     }
 
+    @Test
     func testEngineNotRunningFailureOffersRestartInsteadOfRetry() {
         let state = resolve(
             .idle,
@@ -384,6 +402,7 @@ final class ModelReadinessTests: XCTestCase {
         XCTAssertEqual(state.action, .restart(alias: alias))
     }
 
+    @Test
     func testOtherDiagnosedFailureKeepsLegacyRetry() {
         let state = resolve(
             .idle,
@@ -397,6 +416,7 @@ final class ModelReadinessTests: XCTestCase {
 
     /// An unattributable failure must not be pinned on the user's fresh
     /// pick. We show the selection's own (true) state instead.
+    @Test
     func testUnattributedFailureDoesNotBlameTheSelection() {
         let state = resolve(
             .idle,
@@ -409,6 +429,7 @@ final class ModelReadinessTests: XCTestCase {
 
     /// With nothing chosen there is no better thing to show, so the
     /// failure stays visible rather than silently vanishing.
+    @Test
     func testFailureStaysVisibleWhenNothingIsSelected() {
         let state = resolve(
             .crashed(alias: crashed, message: "load failed"),
@@ -423,6 +444,7 @@ final class ModelReadinessTests: XCTestCase {
 
     /// The reported repro in full: crash, then pick three different
     /// models in a row. None may fall back to Kimi's failure.
+    @Test
     func testSuccessiveSelectionsAfterCrashNeverReturnToTheFailedModel() {
         let picks = [
             ("bonsai-1.7b-2bit", true),
@@ -451,6 +473,7 @@ final class ModelReadinessTests: XCTestCase {
 
     /// Selecting the failed model AGAIN brings its failure back — the
     /// failure is scoped, not discarded.
+    @Test
     func testReselectingTheFailedModelRestoresItsFailure() {
         let away = resolve(
             .crashed(alias: crashed, message: "load failed"),
@@ -472,6 +495,7 @@ final class ModelReadinessTests: XCTestCase {
 
     /// The attribution rule on its own, so a future refactor of
     /// ``resolve`` cannot quietly change it.
+    @Test
     func testFailureAppliesRule() {
         // Nothing selected → always show.
         XCTAssertTrue(ModelReadiness.failureApplies(failedAlias: "a", selectedAlias: nil))
@@ -509,11 +533,13 @@ final class ModelReadinessTests: XCTestCase {
 
     // MARK: - Choose → download → start → ready
 
+    @Test
     func testNoModelWhenNothingChosen() {
         XCTAssertEqual(resolve(.idle, alias: "", cached: nil), .noModel)
         XCTAssertEqual(resolve(.stopped, alias: "", cached: nil), .noModel)
     }
 
+    @Test
     func testChosenButUncachedNeedsDownload() {
         let state = resolve(.idle, cached: false, sizeText: "5.0 GB")
         XCTAssertEqual(state, .needsDownload(alias: alias, sizeText: "5.0 GB"))
@@ -521,6 +547,7 @@ final class ModelReadinessTests: XCTestCase {
         XCTAssertTrue(state.detail?.contains("5.0 GB") == true)
     }
 
+    @Test
     func testChosenAndCachedNeedsStart() {
         let state = resolve(.idle, cached: true)
         XCTAssertEqual(state, .needsStart(alias: alias))
@@ -531,6 +558,7 @@ final class ModelReadinessTests: XCTestCase {
     /// resolve to "start", which is true either way — ``ServerManager``
     /// pulls on demand — rather than promising a multi-gigabyte wait we
     /// have no evidence for.
+    @Test
     func testUnknownCacheStateResolvesToStartNotDownload() {
         let state = resolve(.idle, cached: nil)
         XCTAssertEqual(state, .needsStart(alias: alias))
@@ -540,6 +568,7 @@ final class ModelReadinessTests: XCTestCase {
     /// ``needsStart`` and its "already downloaded" copy. This is the
     /// transient case the fallback was designed for, and it must not
     /// regress when the permanently-unknown case is split out below.
+    @Test
     func testCatalogPendingKeepsTheAlreadyDownloadedCopy() {
         let state = resolveCacheState(.idle, cacheState: .catalogPending)
         XCTAssertEqual(state, .needsStart(alias: alias))
@@ -552,6 +581,7 @@ final class ModelReadinessTests: XCTestCase {
     /// on disk. Nothing establishes that, and the picker chip beside the
     /// banner simultaneously showed the unknown-model glyph, so the same
     /// row said two different things.
+    @Test
     func testUnknownAliasDoesNotClaimItIsDownloaded() {
         let unknown = "mlx-community/Some-Custom-Repo"
         let state = resolveCacheState(
@@ -572,6 +602,7 @@ final class ModelReadinessTests: XCTestCase {
     /// gate on Send, and the status colour are identical to
     /// ``needsStart`` — ``ServerManager`` pulls on demand, so Start is
     /// still the right and only button.
+    @Test
     func testUnknownAliasStillOffersStartAndStaysGated() {
         let unknown = "mlx-community/Some-Custom-Repo"
         let state = resolveCacheState(.idle, alias: unknown, cacheState: .notInCatalog)
@@ -590,6 +621,7 @@ final class ModelReadinessTests: XCTestCase {
     /// engine is serving it, the live serve-state outranks the catalog —
     /// a custom model the user started must reach ``ready`` and enable
     /// Send like any other.
+    @Test
     func testUnknownAliasStillReachesReadyWhenServing() {
         let unknown = "mlx-community/Some-Custom-Repo"
         let state = resolveCacheState(
@@ -604,6 +636,7 @@ final class ModelReadinessTests: XCTestCase {
     /// A blank alias is "no model chosen" regardless of how the cache
     /// state describes it — the unknown-alias branch must not intercept
     /// the empty selection and start naming a placeholder.
+    @Test
     func testUnknownCacheStateWithNoAliasIsStillNoModel() {
         XCTAssertEqual(
             resolveCacheState(.idle, alias: "", cacheState: .notInCatalog),
@@ -613,12 +646,14 @@ final class ModelReadinessTests: XCTestCase {
 
     /// An empty size string means ``ModelSizing`` had no estimate. It
     /// must be dropped, not rendered as empty parentheses.
+    @Test
     func testBlankSizeTextIsDropped() {
         let state = resolve(.idle, cached: false, sizeText: "   ")
         XCTAssertEqual(state, .needsDownload(alias: alias, sizeText: nil))
         XCTAssertEqual(state.detail, "It downloads once, then starts in seconds.")
     }
 
+    @Test
     func testDownloadingCarriesProgress() {
         let state = resolve(
             .starting(alias: alias),
@@ -644,6 +679,7 @@ final class ModelReadinessTests: XCTestCase {
     /// Loading / warming up are NOT downloading. The word "Downloading"
     /// may only appear when bytes are provably moving — the invariant
     /// ``DownloadProgress.startupActivity`` exists to protect.
+    @Test
     func testLoadingAndWarmingAreStartingNotDownloading() {
         for activity in [DownloadProgress.StartupActivity.loading, .warmingUp, .starting] {
             let state = resolve(
@@ -663,6 +699,7 @@ final class ModelReadinessTests: XCTestCase {
 
     /// Only ``downloading`` gets a determinate bar. Everything else
     /// would be implying precision we do not have.
+    @Test
     func testOnlyDownloadingHasAProgressFraction() {
         for state in allStates {
             if case .downloading(_, _, let fraction) = state {
@@ -673,6 +710,7 @@ final class ModelReadinessTests: XCTestCase {
         }
     }
 
+    @Test
     func testReadyWhenServing() {
         let state = resolve(.ready(alias: alias))
         XCTAssertEqual(state, .ready(alias: alias))
@@ -683,6 +721,7 @@ final class ModelReadinessTests: XCTestCase {
 
     /// The full happy path, in order, asserting that send unlocks only
     /// at the final step.
+    @Test
     func testFullLifecycleSequence() {
         let steps: [(ServerState, Bool?, ModelReadiness)] = [
             (.idle, nil, .noModel),
@@ -714,6 +753,7 @@ final class ModelReadinessTests: XCTestCase {
 
     // MARK: - Status roles
 
+    @Test
     func testStatusRolesMapToTheFourTokens() {
         XCTAssertEqual(ModelReadiness.engineMissing.statusRole, .error)
         XCTAssertEqual(ModelReadiness.noModel.statusRole, .idle)
@@ -731,6 +771,7 @@ final class ModelReadinessTests: XCTestCase {
 
     /// Only genuine faults take the error treatment. "You haven't
     /// started it yet" is not a fault and must not paint red.
+    @Test
     func testIsFailureIsReservedForFaults() {
         XCTAssertTrue(ModelReadiness.engineMissing.isFailure)
         XCTAssertTrue(ModelReadiness.failed(alias: nil, message: "x", action: nil).isFailure)
@@ -746,6 +787,7 @@ final class ModelReadinessTests: XCTestCase {
     /// ``chooseModel`` must not render a button: the picker already
     /// carries those exact words 40pt away, and a second control saying
     /// the same thing is the duplicate-action defect.
+    @Test
     func testChooseModelIsNamedButNotRendered() {
         let state = ModelReadiness.noModel
         XCTAssertEqual(state.action, .chooseModel)
@@ -754,6 +796,7 @@ final class ModelReadinessTests: XCTestCase {
         XCTAssertNil(state.action?.alias)
     }
 
+    @Test
     func testActionableStatesRenderTheirButton() {
         let renderable: [ModelReadiness] = [
             .needsDownload(alias: alias, sizeText: nil),
@@ -773,6 +816,7 @@ final class ModelReadinessTests: XCTestCase {
 
     /// In-flight states offer no action — progress is the answer, and a
     /// button there would either duplicate Stop or do nothing.
+    @Test
     func testInFlightStatesOfferNoAction() {
         XCTAssertNil(
             ModelReadiness.downloading(alias: alias, detail: nil, fraction: nil).action)
@@ -786,6 +830,7 @@ final class ModelReadinessTests: XCTestCase {
     /// Connect Tools header said "start a chat to generate the key"
     /// while its body said "Start a model"; this pins the vocabulary so
     /// that cannot come back.
+    @Test
     func testVocabularyIsConsistent() {
         let chooseCopy = ModelReadiness.noModel
         XCTAssertTrue(chooseCopy.headline.contains("chosen"))
@@ -825,6 +870,7 @@ final class ModelReadinessTests: XCTestCase {
     /// Every state that is ABOUT a specific model names it in the
     /// headline, so the user always knows which model the sentence
     /// refers to.
+    @Test
     func testHeadlineNamesTheModelWhenThereIsOne() {
         let named: [ModelReadiness] = [
             .needsDownload(alias: alias, sizeText: nil),
@@ -852,6 +898,7 @@ final class ModelReadinessTests: XCTestCase {
     /// The first draft of this suite asserted the alias in EVERY named
     /// state's placeholder, which contradicted ``testReadyIsQuiet`` — the
     /// implementation was right and the expectation was wrong.
+    @Test
     func testPlaceholderNamesTheModelOnlyWhileItBlocksSending() {
         let blocking: [ModelReadiness] = [
             .needsDownload(alias: alias, sizeText: nil),
@@ -875,6 +922,7 @@ final class ModelReadinessTests: XCTestCase {
     /// The empty state's two approved strings survive verbatim — the
     /// visual redesign signed off on this copy and Phase 1 is not a
     /// licence to rewrite it.
+    @Test
     func testApprovedEmptyStateCopyIsPreserved() {
         XCTAssertEqual(ModelReadiness.noModel.emptyStateSubtitle, "Choose a model to start")
         XCTAssertEqual(
@@ -891,6 +939,7 @@ final class ModelReadinessTests: XCTestCase {
 
     /// The composed VoiceOver label must carry both halves, so a screen
     /// reader user gets the same information a sighted user reads.
+    @Test
     func testAccessibilityLabelComposesHeadlineAndDetail() {
         let state = ModelReadiness.needsDownload(alias: alias, sizeText: "5.0 GB")
         let label = state.accessibilityLabel
@@ -898,6 +947,7 @@ final class ModelReadinessTests: XCTestCase {
         XCTAssertTrue(label.contains(state.detail ?? "<missing>"))
     }
 
+    @Test
     func testAccessibilityLabelIsNeverEmpty() {
         for state in allStates {
             XCTAssertFalse(
@@ -916,6 +966,7 @@ final class ModelReadinessTests: XCTestCase {
     /// gated. (Regression: `.ready` previously described the serving alias
     /// unconditionally, enabling a send that ``ChatView`` would dispatch
     /// against the un-running selection.)
+    @Test
     func testReadyForADifferentModelResolvesTheSelection() {
         let other = "bonsai-1.7b-2bit"
         let state = resolve(.ready(alias: alias), alias: other, cached: true)
@@ -932,6 +983,7 @@ final class ModelReadinessTests: XCTestCase {
     /// with an empty/foreign alias — Send stays gated until a real model is
     /// actually selected, which the `onChange(of: server.state)` sync does a
     /// frame later.
+    @Test
     func testReadyWithNoSelectionYetIsNotSendable() {
         let state = resolve(.ready(alias: alias), alias: "", cached: true)
         XCTAssertFalse(state.sendAllowed)
@@ -939,6 +991,7 @@ final class ModelReadinessTests: XCTestCase {
     }
 
     /// The matching case is untouched: serving == selected → ready.
+    @Test
     func testReadyForTheSelectedModelStaysReady() {
         XCTAssertEqual(resolve(.ready(alias: alias), alias: alias), .ready(alias: alias))
         XCTAssertTrue(readyDescribesSelectionRef(serving: alias, selected: alias))
@@ -949,6 +1002,7 @@ final class ModelReadinessTests: XCTestCase {
     /// `.starting` is permissive (it never enables Send): a not-yet-synced
     /// selection at launch keeps the in-flight start visible, but a
     /// deliberate pick of a DIFFERENT real model resolves that model.
+    @Test
     func testStartingIsPermissiveExceptForADifferentRealModel() {
         // Launch: breadcrumb lags the auto-started model — still show it.
         let launch = resolve(.starting(alias: alias), alias: "")
@@ -981,6 +1035,7 @@ final class ModelReadinessTests: XCTestCase {
     /// A turn-level error is shown in the ready composer only when it
     /// belongs to the current model (or carries no alias at all). Switching
     /// to a healthy model must not inherit the previous model's error.
+    @Test
     func testTurnErrorScopedToSelection() {
         XCTAssertTrue(
             ModelReadiness.turnErrorApplies(failureAlias: nil, selectedAlias: alias),
@@ -1008,7 +1063,9 @@ final class ModelReadinessTests: XCTestCase {
 /// ``@MainActor`` because ``ContentView`` is a SwiftUI ``View``, which
 /// Swift 6 infers as main-actor-isolated — including its statics.
 @MainActor
-final class MainAreaBranchTests: XCTestCase {
+@Suite
+struct MainAreaBranchTests {
+    @Test
     func testOnlyMissingLeavesTheChatSurface() {
         XCTAssertEqual(ContentView.mainAreaBranch(for: .missing), .missing)
         for state: ServerState in [

--- a/apps/rapid-mac/Tests/RapidUXTests/XCTestCompatibility.swift
+++ b/apps/rapid-mac/Tests/RapidUXTests/XCTestCompatibility.swift
@@ -1,0 +1,46 @@
+import Testing
+
+/// Small source-compatible assertion surface for the state-machine suite's
+/// XCTest-era call sites. Keeping the existing messages avoids a noisy rewrite
+/// while Swift Testing owns discovery, execution, and failure reporting.
+func XCTAssertTrue(
+    _ expression: @autoclosure () -> Bool,
+    _ message: @autoclosure () -> String = ""
+) {
+    if !expression() { Issue.record(Comment(rawValue: message())) }
+}
+
+func XCTAssertFalse(
+    _ expression: @autoclosure () -> Bool,
+    _ message: @autoclosure () -> String = ""
+) {
+    if expression() { Issue.record(Comment(rawValue: message())) }
+}
+
+func XCTAssertFalse(
+    _ expression: @autoclosure () -> Bool,
+    _ message: @autoclosure () -> String = "",
+    file _: StaticString,
+    line _: UInt
+) {
+    if expression() { Issue.record(Comment(rawValue: message())) }
+}
+
+func XCTAssertEqual<T: Equatable>(
+    _ lhs: @autoclosure () -> T,
+    _ rhs: @autoclosure () -> T,
+    _ message: @autoclosure () -> String = ""
+) {
+    if lhs() != rhs() { Issue.record(Comment(rawValue: message())) }
+}
+
+func XCTAssertNil<T>(
+    _ expression: @autoclosure () -> T?,
+    _ message: @autoclosure () -> String = ""
+) {
+    if expression() != nil { Issue.record(Comment(rawValue: message())) }
+}
+
+func XCTFail(_ message: @autoclosure () -> String = "") {
+    Issue.record(Comment(rawValue: message()))
+}

--- a/apps/rapid-mac/docs/gui-golden-flows.md
+++ b/apps/rapid-mac/docs/gui-golden-flows.md
@@ -37,6 +37,9 @@ covered, and each one names the defect it would have caught:
     `[image:gen]` in their own section (mirroring `[video:gen]`), and the
     chat catalog's `hasNonChatKindTag` drops `image` alongside `audio`/`video`,
     so a 24 GB FLUX/Qwen-Image checkpoint can never surface in the chat picker.
+    The same flow opens Model Management and pins its always-visible disk
+    overview, including the largest app-managed model; read-only external
+    runtime entries remain visible but are excluded from that calculation.
 
 11. `image-generation` — a journey, not an invariant (listed here to keep the
     numbering stable): the Images tab turns a text prompt into a picture and
@@ -184,6 +187,10 @@ configured tokens (`background-color`, `@font-face`, `.PHONY`, `filter-out`),
 split across SSE chunks. The AX contract proves the source survives intact in
 separate rendered code blocks; `SyntaxHighlighterTests` owns the colour-run
 assertion because foreground colours are not exposed by `AXUIElement`.
+Its comparison response must also expose the native macOS SwiftUI `Table`
+shape (`AXOutline` with `AXRow`, `AXCell`, titled `AXColumn` children), not
+merely six sibling text nodes, so VoiceOver retains table navigation and
+header association (#1689).
 
 ### Low-memory recovery
 

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -591,12 +591,6 @@ PYEOF
 # subtree — a preview, a tooltip, an off-screen copy — answer for the
 # transcript.
 #
-# What this deliberately does NOT claim: that the table is a table. The app
-# exposes markdown tables as plain sibling AXStaticTexts with no AXTable role,
-# so a renderer that stripped the pipes and stacked the six cells as ordinary
-# paragraphs is indistinguishable from a real table at the AX layer. That is a
-# gap in what the app publishes, not something an assertion here can close —
-# tracked in #1689.
 assert_rendered_shapes() {
     local transcript="$1" scratch="$2"
     # These two hold anywhere in the transcript: no source syntax survives,
@@ -626,6 +620,19 @@ assert_rendered_shapes() {
     assistant_message_only "$transcript" 3 "$m3"
     assert_rendered_as_separate_nodes "$m3" "table cells" \
         "qwen3.5-9b" "5.2 GB" "74 tok/s" "llama-3.1-8b" "4.5 GB" "68 tok/s"
+    # AppKit exposes a native SwiftUI Table as AXOutline on macOS, with real
+    # row/cell/column children and titled column headers. Pin the whole shape;
+    # six loose AXStaticTexts cannot satisfy this contract (#1689).
+    jq -e '[.data.ui_elements[]?] as $e
+            | any($e[]; .role == "AXOutline" and .description == "Markdown table")
+              and ([ $e[] | select(.role == "AXRow") ] | length >= 2)
+              and ([ $e[] | select(.role == "AXCell") ] | length >= 6)
+              and ([ $e[] | select(.role == "AXColumn") ] | length >= 3)
+              and ([ $e[] | select(.title == "model") ] | length > 0)
+              and ([ $e[] | select(.title == "size") ] | length > 0)
+              and ([ $e[] | select(.title == "speed") ] | length > 0)' \
+        "$m3" >/dev/null \
+        || die "markdown comparison has no navigable table semantics in the AX tree (#1689)"
     assert_tree_text "$m3" "Both fit comfortably in 16 GB."
 
     assistant_message_only "$transcript" 4 "$m4"
@@ -1919,6 +1926,14 @@ flow_catalog_integrity() {
     jq -e '.data.ui_elements[]? | select(.identifier == "Settings.ModelManagement.Row.fake-external-alias")' \
         "$OUT/catalog-model-management.json" >/dev/null \
         || die "external model was not visible in Model Management"
+    jq -e '.data.ui_elements[]? | select(.identifier == "Settings.ModelManagement.StorageSummary")' \
+        "$OUT/catalog-model-management.json" >/dev/null \
+        || die "Model Management disk overview was not visible"
+    jq -e '.data.ui_elements[]? | select(.identifier == "Settings.ModelManagement.LargestModel")
+              | [(.title // ""), (.value // ""), (.description // "")]
+              | join(" ") | contains("fake-image-alias")' \
+        "$OUT/catalog-model-management.json" >/dev/null \
+        || die "disk overview did not identify the largest managed model"
     jq -e '[.data.ui_elements[]? | select(.identifier == "Settings.ModelManagement.Delete.fake-external-alias")] | length == 0' \
         "$OUT/catalog-model-management.json" >/dev/null \
         || die "external model exposed a delete action"


### PR DESCRIPTION
## Summary

- migrate `RapidUXTests` discovery from unavailable XCTest to Swift Testing so `swift test` can execute the complete package graph
- add an always-visible, cross-capability disk overview to Model Management with used/free space, largest managed model, and conservative starter/last-used keep signals
- give MarkdownUI tables a native SwiftUI `Table` accessibility representation with row, cell, column, and header semantics
- extend the existing catalog-integrity and chat-depth GoldenFlows to pin both GUI changes

## Root causes

`RapidUXTests` imported XCTest, but the Command Line Tools SDK used by SwiftPM does not provide that module. Even a filtered test therefore failed while compiling the full test graph.

Model Management exposed total usage only as a capability-scoped footer below the entire catalog. It had no volume context, largest-item signal, or indication that a model was the starter/last-used choice. The new overview deliberately excludes read-only external-runtime entries and does not guess that any model is automatically safe to delete.

MarkdownUI renders GFM tables with SwiftUI `Grid`. The visual parser was correct, but AppKit flattened that grid to unrelated static text. The theme now preserves the visual grid while replacing only its accessibility representation with a native table. On macOS this publishes `AXOutline` with `AXRow`, `AXCell`, titled `AXColumn`, and header association. The macOS 14-compatible representation supports up to eight columns; wider tables retain MarkdownUI's existing text fallback rather than losing data.

## Validation

- `swift test` — 2,033 tests passed
- focused post-change suite — 106 tests passed
- `SKIP_SIDECAR=1 scripts/build.sh`
- `bash -n scripts/gui-golden-flows.sh`
- `git diff --check`
- live `chat-depth` AX evidence confirmed the native table shape and model/size/speed headers; the local full flow later hit its documented transcript-virtualization count guard at turn five, while the table-specific contract itself passed against the captured turn-three tree

Closes #1638.
Closes #1818.
Closes #1689.
