### PR TITLE
fix(models): install mlx-compat shim before mlx-lm imports in bailing_hybrid (#1817 regression)

### DIFF
--- a/vllm_mlx/models/bailing_hybrid.py
+++ b/vllm_mlx/models/bailing_hybrid.py
@@ -59,6 +59,15 @@ from typing import Any
 
 import mlx.core as mx
 import mlx.nn as nn
+
+# Install the MLX hardware compatibility shim before importing any mlx-lm
+# module. mlx-lm captures its default stream during package import, which is
+# unsafe on the M5 single-stream path; every vendored model follows this
+# ordering contract.
+from .. import _mlx_compat as _mlx_compat
+
+_mlx_compat.install()
+
 from mlx_lm.models.base import (
     BaseModelArgs,
     create_attention_mask,


### PR DESCRIPTION
## Why

`test_mlx_compat.py::test_every_mlx_lm_consumer_installs_shim` is **RED on `main`** (HEAD `34070c17`). The vendored Ling 3.0 backbone `models/bailing_hybrid.py` (added in #1817) does `from mlx_lm.models.base import ...` at module load **without first calling `_mlx_compat.install()`**.

Importing any `mlx_lm` submodule triggers `mlx_lm/__init__.py` → `mlx_lm.generate`, which captures the default GPU stream at import time — unsafe on the M5 single-stream path (#404 M5). Every other vendored native backbone (`deepseek_v4`, `hy_v3`, `muse_glimmer`) installs the shim first; this one missed the ordering contract, so the guard test fails:

```
models/bailing_hybrid.py (mlx_lm import @ line 62, install @ line None)
```

## What

- Add `from .. import _mlx_compat as _mlx_compat` + `_mlx_compat.install()` immediately before the first `mlx_lm` import in `bailing_hybrid.py`, mirroring the exact placement and comment used by the sibling vendored models. No other change to the vendored file.

## Tests

- `tests/test_mlx_compat.py` now passes **8/8** (was 1 failed). ruff clean.
- Found while validating an unrelated workflow PR (#1821) whose `full_unit` went red on this pre-existing `main` regression despite a zero-Python diff.

## Notes

- No version bump; no functional change to the model — only import ordering, which the compat contract requires.
- 🤖 AI-authored (Claude Code), human-reviewed.