### PR TITLE
Polish Markdown table accessibility parsing

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/UI/Markdown/MarkdownTableAccessibility.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/Markdown/MarkdownTableAccessibility.swift
@@ -36,22 +36,32 @@ enum MarkdownTableAccessibility {
     private static func cells(in line: String) -> [String] {
         var result: [String] = []
         var current = ""
-        var escaped = false
         var codeFenceLength = 0
+        let characters = Array(line)
+        var index = 0
 
-        for character in line {
-            if escaped {
-                current.append(character)
-                escaped = false
-                continue
-            }
-            if character == "\\" {
-                escaped = true
+        while index < characters.count {
+            let character = characters[index]
+            if character == "\\",
+               index + 1 < characters.count,
+               isEscapablePunctuation(characters[index + 1]) {
+                current.append(characters[index + 1])
+                index += 2
                 continue
             }
             if character == "`" {
-                codeFenceLength = codeFenceLength == 0 ? 1 : 0
-                current.append(character)
+                var runEnd = index + 1
+                while runEnd < characters.count, characters[runEnd] == "`" {
+                    runEnd += 1
+                }
+                let runLength = runEnd - index
+                if codeFenceLength == 0 {
+                    codeFenceLength = runLength
+                } else if codeFenceLength == runLength {
+                    codeFenceLength = 0
+                }
+                current.append(contentsOf: String(repeating: "`", count: runLength))
+                index = runEnd
                 continue
             }
             if character == "|", codeFenceLength == 0 {
@@ -60,8 +70,8 @@ enum MarkdownTableAccessibility {
             } else {
                 current.append(character)
             }
+            index += 1
         }
-        if escaped { current.append("\\") }
         result.append(clean(current))
         if result.first == "" { result.removeFirst() }
         if result.last == "" { result.removeLast() }
@@ -71,6 +81,18 @@ enum MarkdownTableAccessibility {
     private static func clean(_ value: String) -> String {
         value.trimmingCharacters(in: .whitespacesAndNewlines)
             .replacingOccurrences(of: "`", with: "")
+    }
+
+    /// CommonMark backslash escapes apply only to ASCII punctuation. Treating
+    /// every backslash as an escape corrupts ordinary cell text such as a
+    /// Windows path before VoiceOver sees it.
+    private static func isEscapablePunctuation(_ character: Character) -> Bool {
+        guard character.unicodeScalars.count == 1,
+              let value = character.unicodeScalars.first?.value else { return false }
+        return (0x21...0x2F).contains(value)
+            || (0x3A...0x40).contains(value)
+            || (0x5B...0x60).contains(value)
+            || (0x7B...0x7E).contains(value)
     }
 
     private static func isSeparatorCell(_ value: String) -> Bool {

--- a/apps/rapid-mac/Tests/RapidTests/MarkdownTableAccessibilityTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/MarkdownTableAccessibilityTests.swift
@@ -29,6 +29,26 @@ struct MarkdownTableAccessibilityTests {
         #expect(table?.rows == [["escaped", "a|b"], ["code", "x|y"]])
     }
 
+    @Test("Pipes inside multi-backtick code spans stay inside their cells")
+    func preservesPipesInMultiBacktickCode() {
+        let table = MarkdownTableAccessibility.parse("""
+        | name | expression |
+        | --- | --- |
+        | code | ``x`|y`` |
+        """)
+        #expect(table?.rows == [["code", "x|y"]])
+    }
+
+    @Test("Backslashes outside CommonMark escapes remain in accessible text")
+    func preservesOrdinaryBackslashes() {
+        let table = MarkdownTableAccessibility.parse("""
+        | platform | path |
+        | --- | --- |
+        | Windows | C:\\Models |
+        """)
+        #expect(table?.rows == [["Windows", "C:\\Models"]])
+    }
+
     @Test("Ordinary prose is not mistaken for a table")
     func rejectsProse() {
         #expect(MarkdownTableAccessibility.parse("hello\nworld") == nil)


### PR DESCRIPTION
## Summary

- parse CommonMark code spans using their full backtick fence length so pipes inside multi-backtick spans remain in one accessible table cell
- preserve ordinary backslashes while still honoring CommonMark ASCII-punctuation escapes
- add focused regressions for both VoiceOver text-shape edge cases

## Root cause

The accessibility-only GFM parser toggled code-span state for every individual backtick and treated every backslash as an escape. Valid multi-backtick spans could therefore expose an internal pipe as a column delimiter, while ordinary text such as `C:\Models` lost its backslash before reaching VoiceOver.

## Validation

- `swift test --filter MarkdownTableAccessibilityTests` — 6 passed
- `swift test` — 2,037 passed
- `git diff --check`
