### PR TITLE
fix(models): register ling-3.0-tiny in the download-size manifest

### DIFF
--- a/vllm_mlx/model_sizes.json
+++ b/vllm_mlx/model_sizes.json
@@ -193,6 +193,7 @@
     "pipenetwork/Holo-3.1-35B-A3B-MLX-8bit": 40810031931,
     "prism-ml/Ternary-Bonsai-1.7B-mlx-2bit": 495525300,
     "prism-ml/Ternary-Bonsai-27B-mlx-2bit": 8521052337,
+    "rapid-mlx/Ling-3.0-tiny-MLX-4bit": 4459772529,
     "rickylin20260522/Wan2.2-T2V-A14B-mlx": 69023632302,
     "rickylin20260522/Wan2.2-TI2V-5B-mlx": 24180286021,
     "unsloth/Qwen3.6-27B-MLX-8bit": 34733949671,


### PR DESCRIPTION
## Why

#1819 added the `ling-3.0-tiny-4bit` alias (`rapid-mlx/Ling-3.0-tiny-MLX-4bit`) to `aliases.json` but did **not** regenerate `vllm_mlx/model_sizes.json`. As a result:

- `tests/test_model_sizes.py::test_every_text_alias_has_a_manifest_entry` **fails on `main`** (red unit gate):
  ```
  text aliases missing from model_sizes.json — run `python3.12 scripts/gen_model_sizes.py`:
    ['rapid-mlx/Ling-3.0-tiny-MLX-4bit']
  ```
- The CLI `rapid-mlx models` listing and the desktop model-management UI can't show a download size for the new alias.

Caught while dogfooding `main` HEAD ahead of the next release. The auto-release Tier-1 gate runs `agent_smoke.sh` only (no unit suite), so this red gate would otherwise ship silently.

## What

Add the single missing manifest entry:

```json
"rapid-mlx/Ling-3.0-tiny-MLX-4bit": 4459772529
```

4.46 GB, from HF metadata — matches `scripts/gen_model_sizes.py` output for this repo. Kept minimal: only the one new alias, no unrelated manifest drift.

## Test

```
tests/test_model_sizes.py .............. [100%]
14 passed
```

Does not touch `pyproject.toml` (not a version bump).