### PR TITLE
Unify macOS Settings UI and menu-bar branding

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/DevSnapshot.swift
+++ b/apps/rapid-mac/Sources/Rapid/DevSnapshot.swift
@@ -48,6 +48,30 @@ enum DevSnapshot {
         // throwaway instance so the view can be evaluated without trapping.
         let imageGen = ImageGenViewModel(server: server)
         let audio = AudioViewModel(server: server)
+        // Same rule again, for the connectors stack (issue #1716).
+        // ``ContentView`` reads ``MCPCatalog`` and ``MCPToolApprovalStore``
+        // for its tool-approval sheet, and ``SettingsConnectorsPanel``
+        // additionally reads ``MCPConfigStore`` and ``MCPToolRegistry``.
+        // Without these the harness trapped on the FIRST capture with
+        // "No Observable object of type MCPCatalog found" and wrote zero
+        // PNGs — it had been dead since connectors landed, the same way it
+        // was dead before ``browseApproval`` was added above.
+        //
+        // The config store is pointed at a scratch file inside the snapshot
+        // directory so a capture run can never read or write the real
+        // ``mcp.json``. The catalog is given a nil endpoint provider, so it
+        // never polls anything.
+        let snapshotMCPConfig = MCPConfigStore(
+            fileURL: URL(fileURLWithPath: dir).appendingPathComponent("snapshot-mcp.json")
+        )
+        let snapshotMCPCatalog = MCPCatalog { nil }
+        let snapshotMCPApproval = MCPToolApprovalStore()
+        let snapshotMCPTools = MCPToolRegistry(
+            catalog: snapshotMCPCatalog,
+            approval: snapshotMCPApproval
+        )
+        let snapshotInstaller = Installer()
+        let snapshotWebSearch = WebSearchConfig()
 
         // Erase to AnyView so the long environment chain stays cheap to
         // type-check and the render call is monomorphic.
@@ -68,6 +92,8 @@ enum DevSnapshot {
                     .environment(browseApproval)
                     .environment(imageGen)
                     .environment(audio)
+                    .environment(snapshotMCPCatalog)
+                    .environment(snapshotMCPApproval)
                     .frame(width: width, height: height)
             )
         }
@@ -79,6 +105,11 @@ enum DevSnapshot {
             AnyView(
                 ImagesView(viewModel: imageGen, server: server)
                     .tint(RapidTheme.brandAmber)
+                    // ``ImagesView`` deep-links to Settings → Model
+                    // Management from its readiness banner, so it reads the
+                    // router. Missing it trapped the harness here, one
+                    // capture after the MCP fix above.
+                    .environment(settingsRouter)
                     .frame(width: width, height: height)
             )
         }
@@ -334,6 +365,169 @@ enum DevSnapshot {
         }
         renderHosted(headingStates(), size: CGSize(width: 420, height: 300),
                      appearance: .aqua, to: "\(dir)/model-management-heading-states.png")
+
+        // ── UI-1: the whole Settings window, every category, both
+        // appearances, at the three sizes the phase has to hold.
+        //
+        // Panel-at-a-time captures (like the Model Management pair above)
+        // cannot show what this phase is actually about: whether the rail,
+        // the page titles, the section treatment and the row rhythm agree
+        // ACROSS categories. So this renders the real ``SettingsView``
+        // shell and walks the category rail.
+        //
+        // The stores Settings binds that ``runIfRequested`` isn't handed
+        // are built here rather than threaded through the call site — a
+        // dev-only capture should not widen a production signature. The
+        // MCP config store is pointed at a scratch file inside the
+        // snapshot directory so a capture run cannot touch the real one.
+        func settingsShell(category: SettingsView.Category, size: CGSize) -> AnyView {
+            settingsRouter.requestedCategory = category
+            return AnyView(
+                SettingsView()
+                    .environment(chat)
+                    .environment(sampling)
+                    .environment(appearance)
+                    .environment(settingsRouter)
+                    .environment(server)
+                    .environment(downloads)
+                    .environment(updater)
+                    .environment(snapshotInstaller)
+                    .environment(dockPromptStore)
+                    .environment(snapshotWebSearch)
+                    .environment(browseApproval)
+                    .environment(snapshotMCPConfig)
+                    .environment(snapshotMCPCatalog)
+                    .environment(snapshotMCPApproval)
+                    .environment(snapshotMCPTools)
+                    .frame(width: size.width, height: size.height)
+                    .tint(RapidTheme.brandAmber)
+            )
+        }
+
+        // Default (the scene's own ``defaultSize``), the size the brief
+        // names, and the hard floor. 480pt tall is the floor and is
+        // deliberately short — a category that does not scroll cleanly
+        // there is the defect this phase had to fix.
+        let settingsSizes: [(label: String, size: CGSize)] = [
+            ("default", CGSize(width: 900, height: 720)),
+            ("900x640", CGSize(width: 900, height: 640)),
+            ("720x480", CGSize(width: 720, height: 480)),
+        ]
+        for category in SettingsView.Category.allCases {
+            for (label, size) in settingsSizes {
+                for (mode, name) in [("light", NSAppearance.Name.aqua),
+                                     ("dark", NSAppearance.Name.darkAqua)] {
+                    renderHosted(
+                        settingsShell(category: category, size: size),
+                        size: size,
+                        appearance: name,
+                        to: "\(dir)/settings-\(category.rawValue)-\(label)-\(mode).png"
+                    )
+                }
+            }
+        }
+
+        // ── UI-1 refinement proof sheets ──────────────────────────
+        //
+        // The shell captures above show each category in its DEFAULT
+        // state. The refinement review is about states a static capture
+        // of the default cannot reach: a disclosure open, a segmented
+        // control on each segment, a switch on AND off, a disabled
+        // button, each web-search backend. These render those states
+        // side by side, the same way ``headingStates()`` above renders
+        // every filter heading at once.
+
+        func toolsPanel(expanded: Set<String>, width: CGFloat) -> AnyView {
+            AnyView(
+                SettingsToolsPanel(initiallyExpanded: expanded)
+                    .environment(chat)
+                    .environment(snapshotWebSearch)
+                    .environment(browseApproval)
+                    .frame(width: width, alignment: .top)
+                    .padding(RapidTheme.Space.xl)
+                    .background(RapidTheme.surfaceCanvas)
+                    .tint(RapidTheme.brandAmber)
+            )
+        }
+        for (mode, name) in [("light", NSAppearance.Name.aqua),
+                             ("dark", NSAppearance.Name.darkAqua)] {
+            renderHosted(toolsPanel(expanded: [], width: 620),
+                         size: CGSize(width: 660, height: 1000),
+                         appearance: name, to: "\(dir)/tools-collapsed-\(mode).png")
+            renderHosted(toolsPanel(expanded: ["web_search", "browse", "weather"], width: 620),
+                         size: CGSize(width: 660, height: 1500),
+                         appearance: name, to: "\(dir)/tools-expanded-\(mode).png")
+        }
+
+        // Each web-search backend, so the radio group and the key field
+        // that appears for the keyed backends are both reviewable.
+        for provider in WebSearchProvider.allCases {
+            snapshotWebSearch.provider = provider
+            renderHosted(toolsPanel(expanded: [], width: 620),
+                         size: CGSize(width: 660, height: 1000),
+                         appearance: .aqua,
+                         to: "\(dir)/tools-backend-\(provider.id).png")
+        }
+        snapshotWebSearch.provider = .duckduckgo
+
+        // Connectors with the master switch ON — the state that reveals
+        // the servers list, the empty hint and the approvals card.
+        snapshotMCPConfig.isEnabled = true
+        func connectorsPanel(width: CGFloat) -> AnyView {
+            AnyView(
+                SettingsConnectorsPanel()
+                    .environment(snapshotMCPConfig)
+                    .environment(snapshotMCPCatalog)
+                    .environment(snapshotMCPApproval)
+                    .environment(snapshotMCPTools)
+                    .environment(server)
+                    .frame(width: width, alignment: .top)
+                    .padding(RapidTheme.Space.xl)
+                    .background(RapidTheme.surfaceCanvas)
+                    .tint(RapidTheme.brandAmber)
+            )
+        }
+        for (mode, name) in [("light", NSAppearance.Name.aqua),
+                             ("dark", NSAppearance.Name.darkAqua)] {
+            renderHosted(connectorsPanel(width: 620),
+                         size: CGSize(width: 660, height: 900),
+                         appearance: name, to: "\(dir)/connectors-enabled-\(mode).png")
+        }
+        snapshotMCPConfig.isEnabled = false
+
+        // The Add-connector sheet, both appearances.
+        func connectorSheet() -> AnyView {
+            AnyView(
+                MCPServerEditorSheet(original: nil, onSave: { _ in }, onCancel: {})
+                    .tint(RapidTheme.brandAmber)
+            )
+        }
+        for (mode, name) in [("light", NSAppearance.Name.aqua),
+                             ("dark", NSAppearance.Name.darkAqua)] {
+            renderHosted(connectorSheet(), size: CGSize(width: 520, height: 760),
+                         appearance: name, to: "\(dir)/connector-sheet-\(mode).png")
+        }
+
+        // Buttons, toggles and segmented controls in every state the
+        // review asks to see, on one sheet per appearance.
+        for (mode, name) in [("light", NSAppearance.Name.aqua),
+                             ("dark", NSAppearance.Name.darkAqua)] {
+            renderHosted(AnyView(SettingsControlProofSheet()),
+                         size: CGSize(width: 560, height: 620),
+                         appearance: name, to: "\(dir)/controls-proof-\(mode).png")
+        }
+
+        // The menu-bar mark, at the size the bar actually draws it, on the
+        // three backgrounds it has to survive. A template image renders
+        // black-on-transparent in isolation, so these composite it the way
+        // AppKit will: ink on a light bar, on a dark bar, and knocked out
+        // on the selection fill while the menu is open.
+        renderHosted(
+            AnyView(MenuBarMarkProofSheet()),
+            size: CGSize(width: 360, height: 150),
+            appearance: .aqua,
+            to: "\(dir)/menubar-mark.png"
+        )
 
         // Scenario 2: a populated chat transcript, so we can eyeball the
         // streaming bubble / markdown render path that an empty transcript
@@ -608,5 +802,134 @@ enum DevSnapshot {
 
     private static func log(_ message: String) {
         FileHandle.standardError.write(Data("[dev-snapshot] \(message)\n".utf8))
+    }
+}
+
+/// DEV-ONLY proof sheet for the menu-bar template mark.
+///
+/// A template ``NSImage`` is ink plus alpha, so rendering it on its own
+/// says nothing about how it will look — the whole question is what
+/// AppKit does with it. This composites the shipped image the three ways
+/// the menu bar will: black on a light bar, white on a dark bar, and
+/// white on the selection fill while the menu is open.
+private struct MenuBarMarkProofSheet: View {
+    private var mark: Image? {
+        RapidRMark.menuBarTemplateImage().map { Image(nsImage: $0) }
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            bar(background: Color(white: 0.96), ink: .black, label: "Light bar")
+            bar(background: Color(white: 0.13), ink: .white, label: "Dark bar")
+            bar(background: Color(red: 0, green: 0.48, blue: 1), ink: .white, label: "Menu open")
+        }
+        .frame(width: 360)
+    }
+
+    private func bar(background: Color, ink: Color, label: String) -> some View {
+        HStack(spacing: RapidTheme.Space.md) {
+            Text(label)
+                .font(RapidFont.caption)
+                .foregroundStyle(ink.opacity(0.6))
+            Spacer()
+            if let mark {
+                // `.template` + `foregroundStyle` is what AppKit does to a
+                // template image; rendering it any other way would be
+                // testing something the app never does.
+                mark
+                    .renderingMode(.template)
+                    .foregroundStyle(ink)
+            }
+        }
+        .padding(.horizontal, RapidTheme.Space.lg)
+        .frame(height: 50)
+        .background(background)
+    }
+}
+
+/// DEV-ONLY proof sheet for the shared Settings controls.
+///
+/// Every button tier, both switch states, and each segmented control on
+/// each of its segments — in one frame, so "do the heights match, is the
+/// ink on amber dark, is the disabled state legible" can be answered by
+/// looking rather than by reading modifier chains.
+private struct SettingsControlProofSheet: View {
+    private enum Segment: Hashable { case first, second, third }
+
+    @State private var segA: Segment = .first
+    @State private var segB: Segment = .second
+    @State private var toggleOn = true
+    @State private var toggleOff = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: RapidTheme.Space.xl) {
+            SectionHeader("Buttons", emphasis: .section)
+            VStack(alignment: .leading, spacing: RapidTheme.Space.md) {
+                HStack(spacing: RapidTheme.Space.sm) {
+                    Button("Primary") {}.buttonStyle(.rapidPrimary)
+                    Button("Secondary") {}.buttonStyle(.rapidSecondary)
+                    Button("Destructive") {}.buttonStyle(.rapidDestructive)
+                    Button("Tertiary") {}.buttonStyle(.rapidTertiary)
+                }
+                HStack(spacing: RapidTheme.Space.sm) {
+                    Button("Primary") {}.buttonStyle(.rapidPrimaryCompact)
+                    Button("Secondary") {}.buttonStyle(.rapidSecondaryCompact)
+                    Button("Destructive") {}.buttonStyle(.rapidDestructiveCompact)
+                    QuietIconButton(symbol: "trash", label: "Delete",
+                                    tint: RapidTheme.statusError) {}
+                    QuietIconButton(symbol: "arrow.down.circle", label: "Download") {}
+                }
+                HStack(spacing: RapidTheme.Space.sm) {
+                    Button("Disabled primary") {}.buttonStyle(.rapidPrimary).disabled(true)
+                    Button("Disabled secondary") {}.buttonStyle(.rapidSecondary).disabled(true)
+                }
+                Button("Wide primary") {}.buttonStyle(.rapidPrimaryWide)
+            }
+            .settingsGroupedCard()
+
+            SectionHeader("Switches", emphasis: .section)
+            VStack(alignment: .leading, spacing: 0) {
+                Toggle(isOn: $toggleOn) {
+                    SettingsRowLabel(
+                        title: "On, with a description",
+                        description: "A three-line description exists to prove the switch stays pinned to the title line and never gets crowded by the copy beside it, however long that copy runs."
+                    )
+                }
+                .toggleStyle(TrailingSettingsToggleStyle())
+                SettingsRowDivider()
+                Toggle(isOn: $toggleOff) {
+                    SettingsRowLabel(title: "Off, no description")
+                }
+                .toggleStyle(TrailingSettingsToggleStyle())
+            }
+            .settingsGroupedCard()
+
+            SectionHeader("Segmented", emphasis: .section)
+            VStack(alignment: .leading, spacing: RapidTheme.Space.md) {
+                RapidSegmentedControl(
+                    selection: $segA,
+                    options: [
+                        .init(value: .first, title: "Chat models"),
+                        .init(value: .second, title: "Audio models"),
+                    ],
+                    accessibilityLabel: "Two-way"
+                )
+                RapidSegmentedControl(
+                    selection: $segB,
+                    options: [
+                        .init(value: .first, title: "All"),
+                        .init(value: .second, title: "Cached"),
+                        .init(value: .third, title: "Not cached"),
+                    ],
+                    accessibilityLabel: "Three-way"
+                )
+            }
+            .settingsGroupedCard()
+            Spacer(minLength: 0)
+        }
+        .padding(RapidTheme.Space.xl)
+        .frame(width: 560, alignment: .leading)
+        .background(RapidTheme.surfaceCanvas)
+        .tint(RapidTheme.brandAmber)
     }
 }

--- a/apps/rapid-mac/Sources/Rapid/DevSnapshot.swift
+++ b/apps/rapid-mac/Sources/Rapid/DevSnapshot.swift
@@ -865,25 +865,39 @@ private struct SettingsControlProofSheet: View {
         VStack(alignment: .leading, spacing: RapidTheme.Space.xl) {
             SectionHeader("Buttons", emphasis: .section)
             VStack(alignment: .leading, spacing: RapidTheme.Space.md) {
+                // Specimen controls: rendered only offscreen via
+                // ``ImageRenderer`` for the visual harness, never AX-driven.
+                // They still carry identifiers so the AX-identifier gate can
+                // hold its zero-exemption line — see the gate's doc comment.
                 HStack(spacing: RapidTheme.Space.sm) {
                     Button("Primary") {}.buttonStyle(.rapidPrimary)
+                        .accessibilityIdentifier("DevSnapshot.Specimen.Primary")
                     Button("Secondary") {}.buttonStyle(.rapidSecondary)
+                        .accessibilityIdentifier("DevSnapshot.Specimen.Secondary")
                     Button("Destructive") {}.buttonStyle(.rapidDestructive)
+                        .accessibilityIdentifier("DevSnapshot.Specimen.Destructive")
                     Button("Tertiary") {}.buttonStyle(.rapidTertiary)
+                        .accessibilityIdentifier("DevSnapshot.Specimen.Tertiary")
                 }
                 HStack(spacing: RapidTheme.Space.sm) {
                     Button("Primary") {}.buttonStyle(.rapidPrimaryCompact)
+                        .accessibilityIdentifier("DevSnapshot.Specimen.PrimaryCompact")
                     Button("Secondary") {}.buttonStyle(.rapidSecondaryCompact)
+                        .accessibilityIdentifier("DevSnapshot.Specimen.SecondaryCompact")
                     Button("Destructive") {}.buttonStyle(.rapidDestructiveCompact)
+                        .accessibilityIdentifier("DevSnapshot.Specimen.DestructiveCompact")
                     QuietIconButton(symbol: "trash", label: "Delete",
                                     tint: RapidTheme.statusError) {}
                     QuietIconButton(symbol: "arrow.down.circle", label: "Download") {}
                 }
                 HStack(spacing: RapidTheme.Space.sm) {
                     Button("Disabled primary") {}.buttonStyle(.rapidPrimary).disabled(true)
+                        .accessibilityIdentifier("DevSnapshot.Specimen.DisabledPrimary")
                     Button("Disabled secondary") {}.buttonStyle(.rapidSecondary).disabled(true)
+                        .accessibilityIdentifier("DevSnapshot.Specimen.DisabledSecondary")
                 }
                 Button("Wide primary") {}.buttonStyle(.rapidPrimaryWide)
+                    .accessibilityIdentifier("DevSnapshot.Specimen.WidePrimary")
             }
             .settingsGroupedCard()
 
@@ -896,11 +910,13 @@ private struct SettingsControlProofSheet: View {
                     )
                 }
                 .toggleStyle(TrailingSettingsToggleStyle())
+                .accessibilityIdentifier("DevSnapshot.Specimen.ToggleOn")
                 SettingsRowDivider()
                 Toggle(isOn: $toggleOff) {
                     SettingsRowLabel(title: "Off, no description")
                 }
                 .toggleStyle(TrailingSettingsToggleStyle())
+                .accessibilityIdentifier("DevSnapshot.Specimen.ToggleOff")
             }
             .settingsGroupedCard()
 

--- a/apps/rapid-mac/Sources/Rapid/UI/AudioView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/AudioView.swift
@@ -46,15 +46,19 @@ struct AudioView: View {
     private var header: some View {
         HStack(spacing: RapidTheme.Space.lg) {
             Spacer(minLength: 0)
-            Picker("Mode", selection: $viewModel.mode) {
-                ForEach(AudioViewModel.Mode.allCases) { mode in
-                    Text(mode.label).tag(mode)
-                }
-            }
-            .pickerStyle(.segmented)
-            .labelsHidden()
-            .frame(width: 250)
-            .accessibilityLabel("Audio mode")
+            // The one segmented treatment, shared with Settings. Named
+            // explicitly in the UI-1 review as one of the oversized
+            // controls: at `.pickerStyle(.segmented)` the selected
+            // segment was amber with WHITE text. This is a component
+            // swap only — the binding, the modes, and everything around
+            // this control are untouched.
+            RapidSegmentedControl(
+                selection: $viewModel.mode,
+                options: AudioViewModel.Mode.allCases.map {
+                    .init(value: $0, title: $0.label)
+                },
+                accessibilityLabel: "Audio mode"
+            )
             .accessibilityIdentifier("Audio.Mode")
         }
         .padding(.horizontal, RapidTheme.Space.xl)

--- a/apps/rapid-mac/Sources/Rapid/UI/Components/InlineNotice.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/Components/InlineNotice.swift
@@ -17,6 +17,11 @@ struct InlineNotice: View {
         case info
         case warning
         case error
+        /// Something finished and freed/saved something. Added for the
+        /// Settings migration, which had two hand-rolled green banners
+        /// ("Freed 4.2 GB", "Saved to your Keychain") drawing their own
+        /// container out of `RapidTheme.green.opacity(0.08)`.
+        case success
 
         /// v1.0.2: ``info`` is AMBER, not steel blue.
         ///
@@ -25,11 +30,18 @@ struct InlineNotice: View {
         /// blue survives only for genuine links
         /// (``RapidTheme.linkLabel``), which is what "rare supporting
         /// colour" has to mean if it is to mean anything.
+        ///
+        /// ``warning`` now reads its colour from ``statusWarning``
+        /// rather than naming the brand token directly. Same amber
+        /// today; the difference is that "warning" is now a meaning the
+        /// theme owns, so the five Settings call sites that reached for
+        /// `Color.orange` have somewhere correct to go.
         var tint: Color {
             switch self {
             case .info:    return RapidTheme.brandPrimaryDeep
-            case .warning: return RapidTheme.brandPrimaryDeep
+            case .warning: return RapidTheme.statusWarning
             case .error:   return RapidTheme.statusError
+            case .success: return RapidTheme.statusReady
             }
         }
 
@@ -38,8 +50,9 @@ struct InlineNotice: View {
         var background: Color {
             switch self {
             case .info:    return RapidTheme.brandPrimaryTint
-            case .warning: return RapidTheme.brandPrimaryTint
+            case .warning: return RapidTheme.statusWarningTint
             case .error:   return RapidTheme.statusErrorTint
+            case .success: return RapidTheme.statusReadyTint
             }
         }
 
@@ -48,6 +61,7 @@ struct InlineNotice: View {
             case .info:    return "info.circle.fill"
             case .warning: return "exclamationmark.triangle.fill"
             case .error:   return "exclamationmark.octagon.fill"
+            case .success: return "checkmark.circle.fill"
             }
         }
     }

--- a/apps/rapid-mac/Sources/Rapid/UI/Components/RapidButtonStyles.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/Components/RapidButtonStyles.swift
@@ -44,7 +44,16 @@ struct RapidPrimaryButtonStyle: ButtonStyle {
     var expands: Bool
     var height: CGFloat
 
-    init(expands: Bool = false, height: CGFloat = RapidTheme.ControlHeight.large) {
+    /// Default height is ``ControlHeight/medium`` (32) — the SAME
+    /// regular-command height as ``RapidSecondaryButtonStyle`` and
+    /// ``RapidDestructiveButtonStyle``.
+    ///
+    /// It was ``large`` (36), which meant "regular command button" had
+    /// two heights depending on tier: a Cancel/Save pair in a sheet came
+    /// out 32/36 and visibly stepped. Emphasis is carried by the FILL,
+    /// not by being 4pt taller. The hero, full-width case keeps 36 via
+    /// ``rapidPrimaryWide``.
+    init(expands: Bool = false, height: CGFloat = RapidTheme.ControlHeight.medium) {
         self.expands = expands
         self.height = height
     }
@@ -246,8 +255,17 @@ private struct RapidButtonSurface: View {
 extension ButtonStyle where Self == RapidPrimaryButtonStyle {
     /// The single high-emphasis action on a surface. Amber, graphite label.
     static var rapidPrimary: RapidPrimaryButtonStyle { .init() }
-    /// Full-width primary — cards, sheets, onboarding footers.
-    static var rapidPrimaryWide: RapidPrimaryButtonStyle { .init(expands: true) }
+    /// Full-width primary — cards, sheets, onboarding footers. Keeps the
+    /// 36pt hero height: a CTA that spans a card is the one place the
+    /// extra weight is doing work.
+    static var rapidPrimaryWide: RapidPrimaryButtonStyle {
+        .init(expands: true, height: RapidTheme.ControlHeight.large)
+    }
+    /// 28pt filled action for dense rows — pairs with
+    /// ``rapidSecondaryCompact`` on the same baseline.
+    static var rapidPrimaryCompact: RapidPrimaryButtonStyle {
+        .init(height: RapidTheme.ControlHeight.small)
+    }
 }
 
 extension ButtonStyle where Self == RapidSecondaryButtonStyle {
@@ -276,4 +294,8 @@ extension ButtonStyle where Self == RapidTertiaryButtonStyle {
 extension ButtonStyle where Self == RapidDestructiveButtonStyle {
     /// Stop / Delete.
     static var rapidDestructive: RapidDestructiveButtonStyle { .init() }
+    /// 28pt destructive action for dense rows.
+    static var rapidDestructiveCompact: RapidDestructiveButtonStyle {
+        .init(height: RapidTheme.ControlHeight.small)
+    }
 }

--- a/apps/rapid-mac/Sources/Rapid/UI/Components/SectionHeader.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/Components/SectionHeader.swift
@@ -9,27 +9,36 @@ import SwiftUI
 /// overlay, and a hand-tracked uppercase `scaledSystemFont(11)` in
 /// onboarding — three sizes for one role.
 ///
-/// Two emphases:
+/// Three emphases:
 ///   * ``page`` — the one title on a page. 20pt semibold.
-///   * ``section`` — a label over a group of rows. 11pt semibold,
-///     uppercase, tracked, secondary. Deliberately quiet: it organises
-///     content, it doesn't announce it.
+///   * ``section`` — a titled division within a page ("Models folder",
+///     "Web search"). 15pt semibold, primary.
+///   * ``group`` — a quiet label over a group of rows. 11pt semibold,
+///     secondary. Deliberately understated: it organises content, it
+///     doesn't announce it.
+///
+/// ``group`` is the default because it is what every pre-existing call
+/// site meant when it took the default. The ``section`` tier was added
+/// later, for Settings; making IT the default would have silently
+/// promoted the sidebar's date headings and Connect Tools' "Endpoint"
+/// from 11pt to 15pt.
 struct SectionHeader: View {
     enum Emphasis {
         case page
         case section
+        case group
     }
 
     let title: String
     var subtitle: String? = nil
-    var emphasis: Emphasis = .section
+    var emphasis: Emphasis = .group
     /// Trailing control (a "See all", a count, a toggle).
     var accessory: AnyView? = nil
 
     init(
         _ title: String,
         subtitle: String? = nil,
-        emphasis: Emphasis = .section
+        emphasis: Emphasis = .group
     ) {
         self.title = title
         self.subtitle = subtitle
@@ -40,7 +49,7 @@ struct SectionHeader: View {
     init<Accessory: View>(
         _ title: String,
         subtitle: String? = nil,
-        emphasis: Emphasis = .section,
+        emphasis: Emphasis = .group,
         @ViewBuilder accessory: () -> Accessory
     ) {
         self.title = title
@@ -78,16 +87,20 @@ struct SectionHeader: View {
         case .page:
             Text(title)
                 .font(RapidFont.pageTitle)
-                .foregroundStyle(.primary)
+                .foregroundStyle(RapidTheme.textPrimary)
         case .section:
+            Text(title)
+                .font(RapidFont.sectionTitle)
+                .foregroundStyle(RapidTheme.textPrimary)
+        case .group:
             // v1.0.1: Title Case, no tracking. ALL-CAPS + letter-spacing
             // gave a purely organisational label more presence than the
             // content under it — "ENDPOINT" was shouting at the values
             // it labels. A quiet 11pt semibold in secondary does the
             // same structural job without competing.
             Text(title)
-                .font(RapidFont.sectionTitle)
-                .foregroundStyle(.secondary)
+                .font(RapidFont.groupLabel)
+                .foregroundStyle(RapidTheme.textSecondary)
         }
     }
 }

--- a/apps/rapid-mac/Sources/Rapid/UI/Components/SettingsSection.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/Components/SettingsSection.swift
@@ -1,0 +1,249 @@
+import SwiftUI
+
+/// The grouped-section primitives every Settings panel is built from.
+///
+/// ## Why these exist
+///
+/// Before this, four panels each carried a private copy of the same two
+/// helpers — `SettingsView.settingsCard`/`sectionHeader`,
+/// `SettingsToolsPanel.card`/`header`,
+/// `SettingsConnectorsPanel.card`/`header`, plus six inline repetitions
+/// of the same `RoundedRectangle` recipe in
+/// `SettingsModelManagementPanel`. Four copies meant four radii to keep
+/// in sync, four heading sizes, and four sets of padding, and they had
+/// already drifted: cards were 12pt while the rest of the app was 8pt,
+/// headings ranged over `.title2` / `.title3` / `.callout`, and two
+/// panels drew no card at all.
+///
+/// These types are the single owner of that treatment. A panel now says
+/// what a group IS; it does not describe how a group looks.
+///
+/// ## The rules they encode
+///
+/// * One card per section, and **never a card inside a card** — content
+///   handed to ``SettingsSection`` draws no background of its own.
+/// * Section headings live OUTSIDE the card, so the card holds controls
+///   and only controls.
+/// * Rows are separated by ``SettingsRowDivider``, inset to the content's
+///   leading edge so the divider starts where the text does.
+
+// MARK: - Responsive context
+
+private struct SettingsContentIsCompactKey: EnvironmentKey {
+    static let defaultValue = false
+}
+
+extension EnvironmentValues {
+    /// True when the Settings detail column is too narrow to carry every
+    /// optional column a panel would like to draw.
+    ///
+    /// Published by the detail canvas, which measures itself, so panels
+    /// respond to the width they actually got rather than inferring it
+    /// from the window. A panel should use this to DROP something
+    /// optional (a meters column, a legend), never to hide a control —
+    /// an unreachable control at a supported window size is the defect
+    /// this exists to prevent.
+    var settingsContentIsCompact: Bool {
+        get { self[SettingsContentIsCompactKey.self] }
+        set { self[SettingsContentIsCompactKey.self] = newValue }
+    }
+}
+
+// MARK: - Section
+
+/// A titled group of settings rows on one card.
+struct SettingsSection<Content: View, Accessory: View>: View {
+    let title: String?
+    var subtitle: String?
+    @ViewBuilder var accessory: Accessory
+    @ViewBuilder var content: Content
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: RapidTheme.Space.sm) {
+            if let title {
+                if Accessory.self == EmptyView.self {
+                    SectionHeader(title, subtitle: subtitle, emphasis: .section)
+                } else {
+                    SectionHeader(title, subtitle: subtitle, emphasis: .section) {
+                        accessory
+                    }
+                }
+            }
+            VStack(alignment: .leading, spacing: 0) {
+                content
+            }
+            .settingsGroupedCard()
+        }
+    }
+}
+
+extension SettingsSection where Accessory == EmptyView {
+    /// A section with no trailing header control.
+    init(
+        _ title: String? = nil,
+        subtitle: String? = nil,
+        @ViewBuilder content: () -> Content
+    ) {
+        self.title = title
+        self.subtitle = subtitle
+        self.accessory = EmptyView()
+        self.content = content()
+    }
+}
+
+extension SettingsSection {
+    /// A section whose heading carries a trailing control (an "Add…").
+    init(
+        _ title: String,
+        subtitle: String? = nil,
+        @ViewBuilder accessory: () -> Accessory,
+        @ViewBuilder content: () -> Content
+    ) {
+        self.title = title
+        self.subtitle = subtitle
+        self.accessory = accessory()
+        self.content = content()
+    }
+}
+
+// MARK: - Grouped card
+
+/// Inset inside a grouped Settings card.
+///
+/// The UI-1 review found content sitting too close to the card edge at
+/// ``Space/lg`` (16). 24 at regular widths gives the title, description
+/// and control room to read as a group rather than as text jammed into a
+/// box; 20 at compact widths keeps that feeling without stealing the
+/// width a three-line description needs at the 720pt window floor.
+enum SettingsCardMetrics {
+    static let regularInset: CGFloat = RapidTheme.Space.xl   // 24
+    static let compactInset: CGFloat = 20
+
+    static func inset(isCompact: Bool) -> CGFloat {
+        isCompact ? compactInset : regularInset
+    }
+}
+
+/// Applies the shared grouped-card treatment, reading the compact flag
+/// from the environment so every card in the window breathes the same
+/// amount at the same window size.
+private struct SettingsGroupedCard: ViewModifier {
+    @Environment(\.settingsContentIsCompact) private var isCompact
+    /// Explicit override for the rare caller that manages its own inset.
+    var override: CGFloat?
+
+    func body(content: Content) -> some View {
+        let inset = override ?? SettingsCardMetrics.inset(isCompact: isCompact)
+        return content
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(inset)
+            .background(
+                RoundedRectangle(cornerRadius: RapidTheme.Radius.card, style: .continuous)
+                    .fill(RapidTheme.surfaceRaised)
+            )
+            .clipShape(
+                RoundedRectangle(cornerRadius: RapidTheme.Radius.card, style: .continuous)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: RapidTheme.Radius.card, style: .continuous)
+                    .strokeBorder(RapidTheme.hairline, lineWidth: 1)
+            )
+    }
+}
+
+extension View {
+    /// The one grouped-surface treatment in Settings: raised fill,
+    /// structural hairline, ``Radius/card`` corners, and the shared
+    /// responsive inset.
+    ///
+    /// Matches the main window's cards exactly (8pt, not the legacy
+    /// 12pt ``RapidTheme/cardRadius``), which is what stops the Settings
+    /// window reading as a different app from the one behind it.
+    func settingsGroupedCard(padding: CGFloat? = nil) -> some View {
+        modifier(SettingsGroupedCard(override: padding))
+    }
+}
+
+// MARK: - Row label
+
+/// The text half of a settings row: a label and an optional explanation.
+///
+/// Extracted so a `Toggle`'s label, a button row's label, and a value
+/// row's label are the same two typographic roles rather than three
+/// hand-picked font pairs. The description is deliberately allowed to
+/// wrap to as many lines as it needs — at the 720pt window floor several
+/// of these run to three lines, and truncating a sentence that explains
+/// what a switch does is the wrong trade.
+struct SettingsRowLabel: View {
+    let title: String
+    var description: String? = nil
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: RapidTheme.Space.xxs) {
+            Text(title)
+                .font(RapidFont.bodyEmphasis)
+                .foregroundStyle(RapidTheme.textPrimary)
+                .fixedSize(horizontal: false, vertical: true)
+            if let description {
+                Text(description)
+                    .font(RapidFont.caption)
+                    .foregroundStyle(RapidTheme.textSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+// MARK: - Row
+
+/// One settings row: a label (plus optional explanation) on the leading
+/// edge and a control on the trailing edge.
+///
+/// The control keeps its intrinsic width and the label takes the rest,
+/// which is what makes the row survive a narrow window: text rewraps,
+/// the control never compresses, and nothing overlaps. Use this for
+/// buttons, pickers, and read-only values. Toggles keep
+/// ``TrailingSettingsToggleStyle`` with a ``SettingsRowLabel`` inside —
+/// the native switch stays native.
+struct SettingsRow<Control: View>: View {
+    let title: String
+    var description: String? = nil
+    @ViewBuilder var control: Control
+
+    var body: some View {
+        HStack(alignment: .top, spacing: TrailingSettingsToggleStyle.gutter) {
+            SettingsRowLabel(title: title, description: description)
+            control
+                .fixedSize(horizontal: true, vertical: false)
+                // Align the control with the label's first line rather
+                // than the centre of a three-line description. The
+                // gutter matches ``TrailingSettingsToggleStyle`` so a
+                // button row and a switch row put their controls in the
+                // same column.
+                .frame(minHeight: RapidTheme.ControlHeight.small, alignment: .topTrailing)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+// MARK: - Divider
+
+/// The separator between rows inside one grouped card.
+///
+/// Inset to the content's leading edge so it starts under the text
+/// rather than under the card's padding — the macOS grouped-list
+/// convention, and the thing that makes a stack of rows read as one
+/// table instead of several stripes.
+struct SettingsRowDivider: View {
+    var body: some View {
+        Rectangle()
+            .fill(RapidTheme.hairline)
+            .frame(height: 1)
+            // Symmetric, and larger than the old 12: with 24pt card
+            // insets a 12pt gap made rows look pinched relative to the
+            // space around the group.
+            .padding(.vertical, RapidTheme.Space.lg)
+            .accessibilityHidden(true)
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/UI/MCPServerEditorSheet.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/MCPServerEditorSheet.swift
@@ -69,16 +69,23 @@ struct MCPServerEditorSheet: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 16) {
-            Text(original == nil ? "Add connector" : "Edit “\(original?.name ?? "")”")
-                .font(.headline)
+        VStack(alignment: .leading, spacing: RapidTheme.Space.lg) {
+            SectionHeader(
+                original == nil ? "Add connector" : "Edit “\(original?.name ?? "")”",
+                emphasis: .section
+            )
 
+            // The form itself stays native ``.formStyle(.grouped)``:
+            // macOS owns field/picker/toggle layout here and does it
+            // better than a hand-rolled grid would. Only the typography
+            // of the help lines and the footer's button tiers move onto
+            // the shared system.
             Form {
                 TextField("Name", text: $name)
                     .accessibilityIdentifier("Settings.Connectors.Editor.Name")
                 Text("Letters, numbers, dashes and underscores. Becomes the prefix on every tool this connector exposes.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .font(RapidFont.caption)
+                    .foregroundStyle(RapidTheme.textSecondary)
 
                 Picker("Type", selection: $transport) {
                     ForEach(MCPServerConfig.Transport.allCases, id: \.self) { t in
@@ -92,28 +99,22 @@ struct MCPServerEditorSheet: View {
                     TextField("Command", text: $command)
                         .accessibilityIdentifier("Settings.Connectors.Editor.Command")
                     Text("For example `uvx` or `npx`. Rapid's engine only runs commands on its allowlist.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
+                        .font(RapidFont.caption)
+                        .foregroundStyle(RapidTheme.textSecondary)
 
-                    VStack(alignment: .leading, spacing: 4) {
+                    VStack(alignment: .leading, spacing: RapidTheme.Space.xs) {
                         Text("Arguments — one per line")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                        TextEditor(text: $argsText)
-                            .font(.system(.callout, design: .monospaced))
-                            .frame(height: 64)
-                            .overlay(RoundedRectangle(cornerRadius: 6).stroke(.quaternary))
+                            .font(RapidFont.caption)
+                            .foregroundStyle(RapidTheme.textSecondary)
+                        codeEditor(text: $argsText, height: 64)
                             .accessibilityIdentifier("Settings.Connectors.Editor.AddArgument")
                     }
 
-                    VStack(alignment: .leading, spacing: 4) {
+                    VStack(alignment: .leading, spacing: RapidTheme.Space.xs) {
                         Text("Environment — one KEY=value per line")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                        TextEditor(text: $envText)
-                            .font(.system(.callout, design: .monospaced))
-                            .frame(height: 52)
-                            .overlay(RoundedRectangle(cornerRadius: 6).stroke(.quaternary))
+                            .font(RapidFont.caption)
+                            .foregroundStyle(RapidTheme.textSecondary)
+                        codeEditor(text: $envText, height: 56)
                             .accessibilityIdentifier("Settings.Connectors.Editor.AddEnv")
                     }
 
@@ -121,11 +122,13 @@ struct MCPServerEditorSheet: View {
                     TextField("URL", text: $url)
                         .accessibilityIdentifier("Settings.Connectors.Editor.URL")
                     Text("An http:// or https:// endpoint speaking MCP over SSE.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
+                        .font(RapidFont.caption)
+                        .foregroundStyle(RapidTheme.textSecondary)
                 }
 
                 Toggle("Enabled", isOn: $enabled)
+                    .toggleStyle(.switch)
+                    .controlSize(.small)
                     .accessibilityIdentifier("Settings.Connectors.Editor.Enabled")
             }
             .formStyle(.grouped)
@@ -133,25 +136,54 @@ struct MCPServerEditorSheet: View {
             if let why = draft.validationError, !name.isEmpty || !command.isEmpty || !url.isEmpty {
                 // Held back until the user has typed something — an empty form
                 // that scolds you before you start is noise, not guidance.
-                Label(why, systemImage: "exclamationmark.triangle.fill")
-                    .font(.caption)
-                    .foregroundStyle(.orange)
-                    .fixedSize(horizontal: false, vertical: true)
+                InlineNotice(message: why, tone: .warning)
             }
 
-            HStack {
+            // Cancel and Save are now the SAME height (both regular, 32):
+            // `.rapidPrimary` used to default to 36 and the pair stepped.
+            // A disabled Save keeps the amber fill at ``disabledOpacity``
+            // rather than going grey, so it stays findable and its label
+            // stays readable while it explains nothing can be saved yet.
+            HStack(spacing: RapidTheme.Space.sm) {
                 Spacer()
                 Button("Cancel", action: onCancel)
+                    .buttonStyle(.rapidSecondary)
                     .keyboardShortcut(.cancelAction)
                     .accessibilityIdentifier("Settings.Connectors.Editor.Cancel")
                 Button("Save") { onSave(draft) }
+                    .buttonStyle(.rapidPrimary)
                     .keyboardShortcut(.defaultAction)
                     .disabled(draft.validationError != nil)
                     .accessibilityIdentifier("Settings.Connectors.Editor.Allow")
             }
         }
-        .padding(20)
-        .frame(width: 480)
+        .padding(RapidTheme.Space.xl)
+        .frame(width: 520)
+        .background(RapidTheme.surfaceOverlay)
+    }
+
+    /// A multi-line code field with a ground of its own.
+    ///
+    /// A bare ``TextEditor`` draws no background, so in Dark Mode the
+    /// Arguments and Environment boxes were an outline around the sheet
+    /// colour — they read as empty space, not as fields you can type in.
+    /// ``surfaceCode`` is the same recessed ground inline code uses
+    /// everywhere else in the app.
+    @ViewBuilder
+    private func codeEditor(text: Binding<String>, height: CGFloat) -> some View {
+        TextEditor(text: text)
+            .font(RapidFont.code)
+            .scrollContentBackground(.hidden)
+            .padding(RapidTheme.Space.xs)
+            .frame(height: height)
+            .background(
+                RoundedRectangle(cornerRadius: RapidTheme.Radius.code, style: .continuous)
+                    .fill(RapidTheme.surfaceCode)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: RapidTheme.Radius.code, style: .continuous)
+                    .strokeBorder(RapidTheme.hairlineStrong, lineWidth: 1)
+            )
     }
 
     /// Non-empty, whitespace-trimmed lines. `static` so the parsing can be

--- a/apps/rapid-mac/Sources/Rapid/UI/MCPServerEditorSheet.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/MCPServerEditorSheet.swift
@@ -106,16 +106,20 @@ struct MCPServerEditorSheet: View {
                         Text("Arguments — one per line")
                             .font(RapidFont.caption)
                             .foregroundStyle(RapidTheme.textSecondary)
-                        codeEditor(text: $argsText, height: 64)
-                            .accessibilityIdentifier("Settings.Connectors.Editor.AddArgument")
+                        codeEditor(
+                            text: $argsText, height: 64,
+                            axIdentifier: "Settings.Connectors.Editor.AddArgument"
+                        )
                     }
 
                     VStack(alignment: .leading, spacing: RapidTheme.Space.xs) {
                         Text("Environment — one KEY=value per line")
                             .font(RapidFont.caption)
                             .foregroundStyle(RapidTheme.textSecondary)
-                        codeEditor(text: $envText, height: 56)
-                            .accessibilityIdentifier("Settings.Connectors.Editor.AddEnv")
+                        codeEditor(
+                            text: $envText, height: 56,
+                            axIdentifier: "Settings.Connectors.Editor.AddEnv"
+                        )
                     }
 
                 case .sse:
@@ -170,8 +174,14 @@ struct MCPServerEditorSheet: View {
     /// ``surfaceCode`` is the same recessed ground inline code uses
     /// everywhere else in the app.
     @ViewBuilder
-    private func codeEditor(text: Binding<String>, height: CGFloat) -> some View {
+    private func codeEditor(
+        text: Binding<String>, height: CGFloat, axIdentifier: String
+    ) -> some View {
+        // The identifier is applied to the ``TextEditor`` itself (not at the
+        // call site) so the AX-identifier gate sees the control carry it and
+        // the AX driver lands on the editable field, not a wrapper.
         TextEditor(text: text)
+            .accessibilityIdentifier(axIdentifier)
             .font(RapidFont.code)
             .scrollContentBackground(.hidden)
             .padding(RapidTheme.Space.xs)

--- a/apps/rapid-mac/Sources/Rapid/UI/MenuBarController.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/MenuBarController.swift
@@ -32,7 +32,7 @@ final class MenuBarController: NSObject {
     override init() {
         statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
         super.init()
-        configureButton(hasUpdate: Self.hasAvailableUpdate())
+        configureButton()
         menu.delegate = self
         // Take full ownership of item enablement. With AppKit's default
         // auto-enabling, any item that has a target/action is forced
@@ -44,10 +44,11 @@ final class MenuBarController: NSObject {
         // Pre-populate so the very first click before ``menuNeedsUpdate``
         // fires doesn't show an empty rectangle.
         rebuildMenu()
-        // The status line + update row rebuild lazily on click, but the
-        // glyph tint is visible WITHOUT opening the menu, so observe the
-        // update state and repaint the glyph the moment it flips.
-        startObservingUpdateState()
+        // No glyph observer: the mark is a state-free template (see
+        // ``trayGlyph``), so nothing about it changes while the app runs.
+        // Update availability is reported by the menu's own
+        // "Update available — vX.Y.Z" row, which ``menuNeedsUpdate``
+        // rebuilds on every open.
     }
 
     // MARK: - Tray glyph
@@ -56,96 +57,64 @@ final class MenuBarController: NSObject {
         AppDelegate.shared.updater?.availableUpdate != nil
     }
 
-    private func configureButton(hasUpdate: Bool) {
+    private func configureButton() {
         guard let button = statusItem.button else { return }
-        button.image = Self.trayGlyph(hasUpdate: hasUpdate)
-        // Brand name, not "menu bar item" jargon — this is the accessible
-        // label VoiceOver reads and the hover tooltip the user sees.
-        button.toolTip = "Rapid-MLX"
+        button.image = Self.trayGlyph()
+        // Brand name, not "menu bar item" jargon — this is the hover
+        // tooltip the user sees.
+        button.toolTip = Self.accessibilityTitle
+        // ``toolTip`` alone is not a reliable AX title for an
+        // ``NSStatusBarButton`` whose label is a pure image, so name the
+        // control explicitly. Both the image's description and the
+        // button's title are set: VoiceOver reads the button, and the
+        // image description is what an AX walker sees if it descends.
+        button.setAccessibilityTitle(Self.accessibilityTitle)
+        button.image?.accessibilityDescription = Self.accessibilityTitle
     }
 
-    /// Render the brand cheetah into a menu-bar image so the tray icon
-    /// matches the app icon the user recognises — an Ollama-style
-    /// coloured mascot in the tray, the single source of truth being the
-    /// same vendored ``cheetah.png`` the in-app brand marks use.
+    /// Spoken/hover name for the status item. One constant so the
+    /// tooltip and the accessibility title can never drift apart.
+    static let accessibilityTitle = "Rapid-MLX"
+
+    /// The tray mark: the official Rapid-MLX `R`, as a **template**.
     ///
-    /// Issue #502 forced the tray onto ``NSStatusItem``; earlier
-    /// iterations shipped a lightning ``bolt.fill`` because a naively
-    /// shrunk cheetah read as a muddy blob and a code-drawn mark
-    /// rasterised transparent. Two things fix that here:
-    ///   * Render from the high-res master (``cheetah.png``, 440×390)
-    ///     with ``.high`` interpolation via a resolution-independent
-    ///     ``NSImage`` drawing handler, so AppKit redraws crisply at the
-    ///     bar's native backing scale instead of upscaling a tiny crop.
-    ///   * Keep it COLOURED (``isTemplate = false``). Template rendering
-    ///     would flatten the mascot to an unrecognisable silhouette.
+    /// Replaces the full-colour cheetah, which carried far too much
+    /// detail for an 18pt slot — at menu-bar size the mascot resolved to
+    /// a muddy amber smudge, and being non-template it ignored the bar's
+    /// appearance entirely (a light-mode bar, a dark-mode bar and an
+    /// open menu all got the same coloured bitmap).
     ///
-    /// A waiting update is signalled by a small amber dot in the corner
-    /// rather than tinting the whole glyph (which would erase the
-    /// mascot). If the asset can't be resolved (corrupted .app) a
-    /// visible SF Symbol keeps the status item from collapsing to an
-    /// invisible slot.
-    static func trayGlyph(hasUpdate: Bool) -> NSImage {
-        // Menu-bar content height in points; the drawing handler is
-        // resolution-independent so AppKit fills it at 2x on Retina.
-        let height: CGFloat = 18
-        guard let source = CheetahLogo.load(forSize: 128) else {
-            let fallback = NSImage(
-                systemSymbolName: "hare.fill",
-                accessibilityDescription: "Rapid-MLX"
-            ) ?? NSImage(size: NSSize(width: height, height: height))
-            // Corrupted .app (asset missing): still signal a waiting
-            // update by tinting the fallback amber, mirroring the
-            // coloured-cheetah path's dot so the cue is never lost.
-            if hasUpdate {
-                let tinted = NSImage(size: fallback.size)
-                tinted.lockFocus()
-                NSColor.systemOrange.set()
-                let r = NSRect(origin: .zero, size: fallback.size)
-                fallback.draw(in: r)
-                r.fill(using: .sourceAtop)
-                tinted.unlockFocus()
-                tinted.isTemplate = false
-                return tinted
-            }
-            fallback.isTemplate = true
-            return fallback
+    /// ``RapidRMark`` draws the brand's own vector geometry and tags the
+    /// result ``isTemplate``, which hands colour back to macOS: black on
+    /// a light bar, white on a dark one, white again while the menu is
+    /// open or the bar sits on a tinted desktop. See ``RapidRMark`` for
+    /// why the menu-bar variant is the `R` alone rather than the full
+    /// lockup.
+    ///
+    /// Deliberately carries NO status: no amber "update waiting" dot, no
+    /// Ready/Starting/Failed tint. A template image cannot express those
+    /// (AppKit repaints every pixel), and lifecycle state belongs in the
+    /// menu — where ``MenuBarStatus/menuItems`` already puts it, as a
+    /// status line plus an "Update available — vX.Y.Z" row.
+    ///
+    /// The SF Symbol fallback covers a corrupted build whose geometry
+    /// fails to parse; it is also a template, so the two paths behave
+    /// identically as far as the bar is concerned.
+    static func trayGlyph() -> NSImage {
+        if let mark = RapidRMark.menuBarTemplateImage() {
+            return mark
         }
-        let aspect = source.size.height > 0 ? source.size.width / source.size.height : 1
-        let target = NSSize(width: (height * aspect).rounded(), height: height)
-        let image = NSImage(size: target, flipped: false) { rect in
-            NSGraphicsContext.current?.imageInterpolation = .high
-            source.draw(
-                in: rect, from: .zero, operation: .sourceOver, fraction: 1.0
+        let fallback = NSImage(
+            systemSymbolName: "bolt.fill",
+            accessibilityDescription: accessibilityTitle
+        ) ?? NSImage(
+            size: NSSize(
+                width: RapidRMark.menuBarGlyphHeight,
+                height: RapidRMark.menuBarGlyphHeight
             )
-            if hasUpdate {
-                let d = rect.height * 0.42
-                let dot = NSRect(
-                    x: rect.maxX - d, y: rect.maxY - d, width: d, height: d
-                )
-                NSColor.systemOrange.setFill()
-                NSBezierPath(ovalIn: dot).fill()
-            }
-            return true
-        }
-        image.isTemplate = false
-        return image
-    }
-
-    /// Re-render the glyph whenever an update becomes available (or is
-    /// cleared). ``withObservationTracking``'s ``onChange`` fires exactly
-    /// once per observed read, so it re-arms on the next main-actor tick,
-    /// mirroring ``QuickAskWindowController.startTracking``.
-    private func startObservingUpdateState() {
-        withObservationTracking {
-            _ = AppDelegate.shared.updater?.availableUpdate
-        } onChange: { [weak self] in
-            Task { @MainActor [weak self] in
-                guard let self else { return }
-                self.configureButton(hasUpdate: MenuBarController.hasAvailableUpdate())
-                self.startObservingUpdateState()
-            }
-        }
+        )
+        fallback.isTemplate = true
+        return fallback
     }
 
     // MARK: - Menu construction

--- a/apps/rapid-mac/Sources/Rapid/UI/MenuBarStatus.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/MenuBarStatus.swift
@@ -38,17 +38,13 @@ enum MenuBarStatus {
         }
     }
 
-    /// Whether the tray glyph should render as a monochrome *template*
-    /// image. A template glyph is recoloured by AppKit to match the
-    /// menu bar's own light/dark appearance — the "adapts to the bar"
-    /// behaviour we want in the normal state. When a newer version is
-    /// waiting we keep a solid amber fill instead (non-template) so the
-    /// "look at me" affordance survives, mirroring the old tray's
-    /// accent-orange tint. Pure so both branches are unit-testable —
-    /// the rendered image can't be introspected at runtime.
-    static func glyphIsTemplate(hasUpdate: Bool) -> Bool {
-        !hasUpdate
-    }
+    // NOTE: a ``glyphIsTemplate(hasUpdate:)`` helper used to live here,
+    // encoding "the tray glyph goes non-template amber when an update is
+    // waiting". The tray mark is now unconditionally a template (see
+    // ``MenuBarController/trayGlyph``) so macOS owns its colour, and the
+    // update signal is carried by the "Update available — vX.Y.Z" row in
+    // ``menuItems`` below. The helper had no remaining branch to
+    // describe, so it was removed rather than left returning a constant.
 
     // MARK: - Menu model
 

--- a/apps/rapid-mac/Sources/Rapid/UI/RapidRMark.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/RapidRMark.swift
@@ -1,0 +1,289 @@
+import AppKit
+import Foundation
+
+/// The official Rapid-MLX **`R` brand mark**, as vector geometry.
+///
+/// ## Where this comes from
+///
+/// The three path strings below are copied **verbatim** from the brand's
+/// `rapid_icon.svg` (192 × 192 viewBox, three `<path>` elements filled
+/// `#0A0A0A` over a white background rect). Nothing here is traced,
+/// redrawn, or approximated — the `d` attributes are the official source
+/// data, so re-exporting the logo means replacing three strings and
+/// nothing else.
+///
+/// The white background `<rect>` from the SVG is deliberately NOT
+/// reproduced: a menu-bar template must be ink-plus-alpha, and a filled
+/// tile is exactly the "coloured square" a status item must never be.
+///
+/// ## Why this exists alongside ``RapidMark``
+///
+/// ``RapidMark`` is a hand-drawn "three speed streaks" abstraction whose
+/// own documentation says to replace it "when the real vector logo is
+/// available". It is still what onboarding renders, and this phase does
+/// not touch onboarding — so the two coexist for now. This type is the
+/// real mark and is currently consumed only by the menu-bar status item.
+///
+/// ## The menu-bar variant
+///
+/// ``menuBarTemplateImage(height:)`` renders the **`R` glyph only**
+/// (``glyphPathData``), not the full lockup. The two companion streaks
+/// are 5.15pt and 4.60pt tall inside a 105pt-tall mark: scaled to a
+/// 16pt menu-bar glyph they become 0.78pt and 0.70pt — under one point,
+/// i.e. sub-pixel at @1x — and render as grey mush rather than as
+/// strokes. Dropping them keeps the mark legible at the size it actually
+/// ships at, which is the whole point of a dedicated menu-bar variant.
+/// ``fullMarkPath()`` keeps the complete lockup available for any
+/// surface with the room for it.
+///
+/// The `R`'s counter (the enclosed negative space in the bowl) is formed
+/// by the glyph path folding back on itself and fills correctly under the
+/// non-zero winding rule, which is ``NSBezierPath``'s default.
+enum RapidRMark {
+
+    // MARK: - Official geometry (verbatim from rapid_icon.svg)
+
+    /// The `R` itself — `<path>` 1 of 3.
+    static let glyphPathData =
+        "M68.0642 43.2444C68.171 43.1963 68.7052 43.1736 69.6668 43.1763C80.4041 43.1923 98.0459 43.1963 122.592 43.1883C126.006 43.1883 131.435 43.0721 135.501 43.1362C144.291 43.2684 152.084 47.4231 157.693 54.2902C160.22 57.3832 162.011 60.5283 163.066 63.7255C164.524 68.1486 165.401 73.313 164.816 78.1568C164.338 82.1446 163.691 85.279 162.873 87.56C160.694 93.6605 157.052 98.7314 151.948 102.773C147.434 106.346 142.213 108.289 136.286 108.602C136.169 108.61 133.983 108.701 129.728 108.874C129.639 108.878 129.553 108.906 129.479 108.956C129.405 109.006 129.347 109.075 129.31 109.157C129.274 109.238 129.261 109.328 129.273 109.416C129.286 109.504 129.322 109.587 129.379 109.656L160.437 147.645C160.477 147.693 160.503 147.751 160.512 147.812C160.522 147.874 160.515 147.937 160.491 147.995C160.468 148.053 160.43 148.104 160.38 148.142C160.33 148.181 160.271 148.206 160.209 148.214C159.023 148.358 157.995 148.428 157.124 148.422C149.044 148.369 140.965 148.362 132.885 148.402C131.859 148.408 130.894 148.369 129.988 148.286C129.915 148.28 129.843 148.258 129.778 148.222C129.712 148.186 129.654 148.137 129.608 148.078L85.6686 91.8349C85.6537 91.8154 85.6436 91.7925 85.6394 91.7684C85.6352 91.7442 85.637 91.7195 85.6445 91.6964C85.6521 91.6734 85.6652 91.6527 85.6827 91.6363C85.7002 91.6199 85.7215 91.6083 85.7447 91.6025C86.3644 91.4422 86.92 91.3594 87.4114 91.3541C92.4542 91.3167 105.769 91.3167 127.356 91.3541C130.233 91.3594 132.17 91.2246 133.169 90.9494C138.674 89.439 142.5 84.4269 143.025 78.8139C143.479 73.9473 141.966 69.8327 138.486 66.4699C135.485 63.5692 131.955 62.5075 127.953 62.4995C101.251 62.4594 84.2997 62.4728 77.0988 62.5396C76.0451 62.5476 74.0338 62.6638 73.4128 61.7984C69.2167 55.9356 64.8697 50.0981 60.3718 44.2861C60.0913 43.9282 59.915 43.6477 59.8429 43.4447C59.827 43.3985 59.8224 43.3492 59.8293 43.3009C59.8362 43.2525 59.8545 43.2065 59.8826 43.1666C59.9108 43.1267 59.948 43.0941 59.9913 43.0714C60.0345 43.0487 60.0825 43.0366 60.1314 43.0361L66.1731 43C66.2131 43 66.2533 43.004 66.2933 43.012C67.3697 43.215 67.96 43.2925 68.0642 43.2444Z"
+
+    /// Upper speed streak — `<path>` 2 of 3.
+    static let upperStreakPathData =
+        "M105.565 77.6575L102.268 82.2489C102.242 82.285 102.207 82.3144 102.168 82.3346C102.128 82.3548 102.084 82.3653 102.04 82.3651H45.8888C45.8374 82.3646 45.7872 82.3499 45.7435 82.3227C45.6999 82.2956 45.6646 82.2569 45.6414 82.211C45.6182 82.1651 45.6081 82.1137 45.6122 82.0625C45.6163 82.0112 45.6344 81.9621 45.6645 81.9204L48.5051 77.962C48.5308 77.9264 48.5645 77.8974 48.6034 77.8772C48.6424 77.857 48.6856 77.8463 48.7294 77.8458L105.337 77.2168C105.388 77.2171 105.438 77.2314 105.482 77.2581C105.525 77.2848 105.561 77.3228 105.584 77.3682C105.608 77.4136 105.618 77.4645 105.615 77.5155C105.612 77.5665 105.594 77.6156 105.565 77.6575Z"
+
+    /// Lower speed streak — `<path>` 3 of 3.
+    static let lowerStreakPathData =
+        "M27.1184 90.8985L29.5142 87.5691C29.5727 87.4876 29.6496 87.421 29.7388 87.3751C29.828 87.3291 29.9268 87.305 30.0271 87.3047H77.1552C77.2764 87.3045 77.3951 87.3392 77.4972 87.4045C77.5993 87.4699 77.6805 87.5632 77.7311 87.6733C77.7817 87.7834 77.7997 87.9057 77.7828 88.0258C77.766 88.1458 77.715 88.2585 77.636 88.3504L74.7513 91.6797C74.6922 91.7485 74.6191 91.8037 74.5369 91.8417C74.4546 91.8797 74.3652 91.8996 74.2745 91.9001H27.6312C27.515 91.8998 27.4011 91.8674 27.302 91.8067C27.2029 91.7459 27.1225 91.659 27.0696 91.5556C27.0166 91.4521 26.9931 91.3361 27.0017 91.2202C27.0104 91.1043 27.0507 90.993 27.1184 90.8985Z"
+
+    // MARK: - Menu-bar sizing
+
+    /// Height of the drawn glyph, in points, inside the status bar's own
+    /// (24pt) slot. Apple's own template glyphs sit in the 15–18pt band;
+    /// 16 keeps the `R` present without crowding the bar's edges, and
+    /// lands the mark's near-square aspect on a whole-point 16 × 16 box.
+    static let menuBarGlyphHeight: CGFloat = 16
+
+    // MARK: - Paths
+
+    /// The `R` alone, in SVG (y-down) coordinates.
+    static func glyphPath() -> NSBezierPath? {
+        SVGPathData.parse(glyphPathData)
+    }
+
+    /// The complete official lockup — `R` plus both streaks — in SVG
+    /// coordinates. Not used by the menu bar (see the type docs); kept so
+    /// a surface with room for the full mark has one source for it.
+    static func fullMarkPath() -> NSBezierPath? {
+        guard let glyph = SVGPathData.parse(glyphPathData),
+              let upper = SVGPathData.parse(upperStreakPathData),
+              let lower = SVGPathData.parse(lowerStreakPathData) else { return nil }
+        let combined = NSBezierPath()
+        combined.append(glyph)
+        combined.append(upper)
+        combined.append(lower)
+        return combined
+    }
+
+    // MARK: - Menu-bar image
+
+    /// A **template** ``NSImage`` of the `R`, sized for the menu bar.
+    ///
+    /// Resolution-independent: the drawing handler re-runs at whatever
+    /// backing scale the display asks for, so the mark is redrawn from
+    /// vectors at @1x, @2x and @3x rather than being resampled from one
+    /// bitmap. Ink is opaque black with alpha coverage and nothing else —
+    /// ``isTemplate`` then lets AppKit paint it black in a light bar,
+    /// white in a dark bar, and white again while the menu is open.
+    ///
+    /// Returns `nil` only if the path data fails to parse, which can
+    /// happen exactly once: when somebody replaces the geometry above
+    /// with an export using a path command this parser does not cover.
+    /// The caller keeps its SF Symbol fallback for that case rather than
+    /// installing an empty (invisible) status item.
+    static func menuBarTemplateImage(height: CGFloat = menuBarGlyphHeight) -> NSImage? {
+        guard let path = glyphPath() else { return nil }
+        let bounds = path.bounds
+        guard bounds.height > 0, bounds.width > 0 else { return nil }
+
+        let scale = height / bounds.height
+        let size = NSSize(
+            width: (bounds.width * scale).rounded(),
+            height: height
+        )
+
+        let image = NSImage(size: size, flipped: false) { rect in
+            guard let redrawn = glyphPath() else { return false }
+            let transform = NSAffineTransform()
+            // Fit the glyph's own bounds to `rect`, flipping y because the
+            // SVG's origin is top-left and AppKit's is bottom-left here.
+            transform.translateX(by: rect.minX, yBy: rect.maxY)
+            transform.scaleX(by: rect.width / bounds.width, yBy: -(rect.height / bounds.height))
+            transform.translateX(by: -bounds.minX, yBy: -bounds.minY)
+            redrawn.transform(using: transform as AffineTransform)
+            NSColor.black.setFill()
+            redrawn.fill()
+            return true
+        }
+        // The load-bearing line: macOS owns the colour, so the mark is
+        // never "permanently amber" and carries no lifecycle state.
+        image.isTemplate = true
+        return image
+    }
+}
+
+// MARK: - SVG path data
+
+/// A deliberately small SVG `d`-attribute reader.
+///
+/// It covers exactly the command set the official mark uses — `M`, `L`,
+/// `H`, `V`, `C`, `Z`, plus their relative forms — and returns `nil` for
+/// anything else instead of silently skipping it. That choice matters:
+/// a parser that ignores an unknown command renders a subtly wrong logo
+/// and nobody notices for a release, whereas a `nil` trips the caller's
+/// fallback and the tests below.
+///
+/// Not a general-purpose SVG parser and not intended to become one. If a
+/// future export needs arcs or smooth curves, teach it those commands
+/// deliberately — do not make it lenient.
+enum SVGPathData {
+
+    static func parse(_ d: String) -> NSBezierPath? {
+        var scanner = Scanner(d)
+        let path = NSBezierPath()
+        var current = CGPoint.zero
+        var subpathStart = CGPoint.zero
+        var command: Character?
+        var started = false
+
+        while true {
+            scanner.skipSeparators()
+            if scanner.isAtEnd { break }
+
+            if let letter = scanner.peekCommandLetter() {
+                scanner.advance()
+                command = letter
+            }
+            guard let active = command else { return nil }
+            let relative = active.isLowercase
+
+            switch Character(active.lowercased()) {
+            case "m":
+                guard let x = scanner.number(), let y = scanner.number() else { return nil }
+                current = relative ? CGPoint(x: current.x + x, y: current.y + y) : CGPoint(x: x, y: y)
+                path.move(to: current)
+                subpathStart = current
+                started = true
+                // Per the SVG spec, coordinates repeated after a moveto are
+                // implicit linetos.
+                command = relative ? "l" : "L"
+
+            case "l":
+                guard started, let x = scanner.number(), let y = scanner.number() else { return nil }
+                current = relative ? CGPoint(x: current.x + x, y: current.y + y) : CGPoint(x: x, y: y)
+                path.line(to: current)
+
+            case "h":
+                guard started, let x = scanner.number() else { return nil }
+                current = CGPoint(x: relative ? current.x + x : x, y: current.y)
+                path.line(to: current)
+
+            case "v":
+                guard started, let y = scanner.number() else { return nil }
+                current = CGPoint(x: current.x, y: relative ? current.y + y : y)
+                path.line(to: current)
+
+            case "c":
+                guard started,
+                      let x1 = scanner.number(), let y1 = scanner.number(),
+                      let x2 = scanner.number(), let y2 = scanner.number(),
+                      let x = scanner.number(), let y = scanner.number() else { return nil }
+                let c1 = relative ? CGPoint(x: current.x + x1, y: current.y + y1) : CGPoint(x: x1, y: y1)
+                let c2 = relative ? CGPoint(x: current.x + x2, y: current.y + y2) : CGPoint(x: x2, y: y2)
+                let end = relative ? CGPoint(x: current.x + x, y: current.y + y) : CGPoint(x: x, y: y)
+                path.curve(to: end, controlPoint1: c1, controlPoint2: c2)
+                current = end
+
+            case "z":
+                guard started else { return nil }
+                path.close()
+                current = subpathStart
+
+            default:
+                return nil
+            }
+        }
+        return path.isEmpty ? nil : path
+    }
+
+    /// Character-wise cursor over the `d` string.
+    private struct Scanner {
+        private let characters: [Character]
+        private var index = 0
+
+        init(_ string: String) {
+            characters = Array(string)
+        }
+
+        var isAtEnd: Bool { index >= characters.count }
+
+        mutating func advance() { index += 1 }
+
+        mutating func skipSeparators() {
+            while index < characters.count,
+                  characters[index] == " " || characters[index] == ","
+                    || characters[index] == "\n" || characters[index] == "\r"
+                    || characters[index] == "\t" {
+                index += 1
+            }
+        }
+
+        mutating func peekCommandLetter() -> Character? {
+            skipSeparators()
+            guard index < characters.count else { return nil }
+            let c = characters[index]
+            return c.isLetter ? c : nil
+        }
+
+        /// A single SVG number. Handles a leading sign, a bare leading
+        /// decimal point, and scientific notation.
+        mutating func number() -> CGFloat? {
+            skipSeparators()
+            let start = index
+            if index < characters.count, characters[index] == "-" || characters[index] == "+" {
+                index += 1
+            }
+            var sawDigit = false
+            while index < characters.count, characters[index].isNumber {
+                index += 1
+                sawDigit = true
+            }
+            if index < characters.count, characters[index] == "." {
+                index += 1
+                while index < characters.count, characters[index].isNumber {
+                    index += 1
+                    sawDigit = true
+                }
+            }
+            if sawDigit, index < characters.count,
+               characters[index] == "e" || characters[index] == "E" {
+                let beforeExponent = index
+                index += 1
+                if index < characters.count,
+                   characters[index] == "-" || characters[index] == "+" {
+                    index += 1
+                }
+                var sawExponentDigit = false
+                while index < characters.count, characters[index].isNumber {
+                    index += 1
+                    sawExponentDigit = true
+                }
+                if !sawExponentDigit { index = beforeExponent }
+            }
+            guard sawDigit, let value = Double(String(characters[start..<index])) else {
+                index = start
+                return nil
+            }
+            return CGFloat(value)
+        }
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/UI/RapidTheme.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/RapidTheme.swift
@@ -126,14 +126,11 @@ enum RapidTheme {
                           : NSColor.white
     }))
 
-    /// Sidebar surface — a faintly blue-tinted off-white that reads as
-    /// a distinct, calm rail next to the warm chat ``canvas`` (subtle
-    /// separation without a hard divider). Dark mode is a hair off the
-    /// canvas so the rail still reads as its own plane.
-    static let sidebarSurface = Color(nsColor: .init(name: nil, dynamicProvider: { appearance in
-        appearance.isDark ? NSColor(deviceRed: 0x18/255.0, green: 0x1A/255.0, blue: 0x1F/255.0, alpha: 1.0)
-                          : NSColor(deviceRed: 0xF3/255.0, green: 0xF5/255.0, blue: 0xF9/255.0, alpha: 1.0)
-    }))
+    // NOTE: a ``sidebarSurface`` token (cool #F3F5F9) used to sit here.
+    // It was superseded by ``surfaceSidebar`` in the v1.0 layer below —
+    // the cool grey read as a blue slab beside the warm canvas — and had
+    // no consumers left, so it was removed rather than kept as a second,
+    // divergent name for the same plane.
 
     /// Hairline border around cards / inputs (`--line-soft`). A defined
     /// but quiet warm-gray edge in light mode (pairs with the warm
@@ -307,9 +304,25 @@ enum RapidTheme {
     /// #EFA23A lands around 2.0:1 — below every WCAG threshold — and is
     /// exactly the low-contrast default this phase was asked to remove.
     /// Graphite on amber measures ~9:1.
+    ///
+    /// It is appearance-INDEPENDENT on purpose. The amber fill is the
+    /// same in Light and Dark (see ``amber``), so the ink on it must be
+    /// too: flipping to white in Dark would recreate the 2:1 pairing on
+    /// exactly the surface this token exists to protect.
     static let onBrandPrimary = Color(nsColor: .init(name: nil, dynamicProvider: { _ in
         NSColor(deviceRed: 0x24/255.0, green: 0x1A/255.0, blue: 0x08/255.0, alpha: 1.0)
     }))
+
+    /// The canonical name for "ink on an amber-filled control".
+    ///
+    /// Same value as ``onBrandPrimary``, which predates it and is still
+    /// what the action tokens below are defined in terms of. This is the
+    /// name new call sites should reach for: every amber-filled surface
+    /// in the app — primary buttons, selected segmented items, selected
+    /// filter chips — reads its foreground from here, so there is one
+    /// place to look when asking "why is that text dark?" and no reason
+    /// for anybody to write `.foregroundStyle(.white)` on amber again.
+    static let brandOnAccent = onBrandPrimary
 
     /// The secondary brand colour — steel blue. Data, links, secondary
     /// icons, engineering detail. Aliases the legacy ``brand`` token.
@@ -396,6 +409,53 @@ enum RapidTheme {
                           : NSColor(deviceRed: 0xFB/255.0, green: 0xEC/255.0, blue: 0xEA/255.0, alpha: 1.0)
     }))
 
+    /// Needs-attention-but-not-broken: a drive that went away, a config
+    /// edit that has not been applied, a connector that did not come up.
+    ///
+    /// Amber, deliberately the same family as ``statusWorking`` — the
+    /// product only has one "look here" hue and inventing a second
+    /// (system orange, as five Settings call sites did) put two
+    /// near-identical ambers on the same window. It is a SEPARATE token
+    /// from the brand one because the meanings are separate: if warning
+    /// ever needs to diverge from brand amber, it moves here and no call
+    /// site changes.
+    static let statusWarning = brandPrimaryDeep
+
+    /// Tinted backing for a warning surface.
+    static let statusWarningTint = brandPrimaryTint
+
+    /// Tinted backing for a success surface (a completed delete, a saved
+    /// key). Pairs with ``statusReady`` the way ``statusErrorTint``
+    /// pairs with ``statusError``.
+    static let statusReadyTint = Color(nsColor: .init(name: nil, dynamicProvider: { appearance in
+        appearance.isDark ? NSColor(deviceRed: 0x18/255.0, green: 0x2A/255.0, blue: 0x22/255.0, alpha: 1.0)
+                          : NSColor(deviceRed: 0xEC/255.0, green: 0xF5/255.0, blue: 0xF0/255.0, alpha: 1.0)
+    }))
+
+    // MARK: Text
+    //
+    // Named text roles so a view says what a string IS rather than how
+    // dim it should look. They resolve to the system's dynamic label
+    // colours — which already track appearance, increased contrast, and
+    // the vibrancy of whatever surface they sit on — so this is about
+    // giving the roles a shared home, not about repainting text.
+
+    /// Default reading colour: row labels, values, body copy.
+    static let textPrimary = Color.primary
+
+    /// Supporting copy — a row's explanatory line, a section subtitle,
+    /// a caption. Never used for a control's own label.
+    static let textSecondary = Color.secondary
+
+    /// The quietest tier: legends, footers, and counts that must not
+    /// compete with the content they describe.
+    static let textTertiary = Color(nsColor: .tertiaryLabelColor)
+
+    /// Text belonging to a control that is switched off. Distinct from
+    /// ``textTertiary``: this one means "unavailable", not "quiet", and
+    /// pairs with ``disabledOpacity`` on the control around it.
+    static let textDisabled = Color(nsColor: .disabledControlTextColor)
+
     // MARK: Actions
 
     /// Fill for the single highest-emphasis action on a surface.
@@ -413,7 +473,18 @@ enum RapidTheme {
     /// Fill for a destructive action.
     static let destructiveActionFill = statusError
     /// Label on ``destructiveActionFill``.
-    static let destructiveActionLabel = Color.white
+    ///
+    /// Adaptive, because the fill is: ``statusError`` is a deep brick
+    /// (#C0392B) in Light, where white measures ~5.9:1, but a much
+    /// lighter coral (#FF6B5E) in Dark, where white falls to ~2.4:1 —
+    /// the same failure mode as white-on-amber, on the one button whose
+    /// label a user most needs to read before pressing. Dark mode
+    /// therefore takes near-black ink, which measures ~7:1 on that
+    /// coral.
+    static let destructiveActionLabel = Color(nsColor: .init(name: nil, dynamicProvider: { appearance in
+        appearance.isDark ? NSColor(deviceRed: 0x24/255.0, green: 0x0C/255.0, blue: 0x0A/255.0, alpha: 1.0)
+                          : NSColor.white
+    }))
     /// A quiet, borderless action — present but not competing.
     static let quietActionLabel = Color.secondary
 
@@ -464,11 +535,14 @@ enum RapidTheme {
 
     // MARK: - Spacing
     //
-    // One rhythm for the whole app: 4 / 8 / 12 / 16 / 24 / 32. Page
+    // One rhythm for the whole app: 2 / 4 / 8 / 12 / 16 / 24 / 32. Page
     // margins, section gaps, and control padding all come from here so
     // they can never drift apart per-view.
 
     enum Space {
+        /// 2 — a label and the line directly under it; the tightest gap
+        /// that still reads as two lines rather than one block.
+        static let xxs: CGFloat = 2
         /// 4 — icon-to-label, tight glyph gaps.
         static let xs: CGFloat = 4
         /// 8 — inside a control, between related chips.
@@ -504,6 +578,10 @@ enum RapidTheme {
         static let button: CGFloat = 8
         /// Selectable rows — sidebar, lists, menu rows.
         static let row: CGFloat = 8
+        /// A segment inside a segmented control. One step tighter than
+        /// ``row`` so the selected segment reads as sitting INSIDE its
+        /// track rather than as a free-floating pill.
+        static let segment: CGFloat = 6
         /// Chat bubbles. Deliberately the one soft shape left.
         static let bubble: CGFloat = 14
         /// Inset code / endpoint blocks. Tighter than the card that
@@ -528,6 +606,11 @@ enum RapidTheme {
         static let large: CGFloat = 36
         /// 30 — sidebar / list row height.
         static let row: CGFloat = 30
+        /// 30 — segmented controls. macOS's own segmented control is
+        /// 28–32pt at the regular control size; the pre-refinement
+        /// ``.pickerStyle(.segmented)`` rendered nearer 40 because it
+        /// inherited the scene tint and the panel's larger type.
+        static let segmented: CGFloat = 30
     }
 
     // MARK: - Layout
@@ -605,10 +688,25 @@ enum ModelDisplayName {
 enum RapidFont {
     /// Window / toolbar title.
     static let windowTitle = Font.system(size: 15, weight: .semibold)
-    /// The one big title on a page. Chat empty state, page headers.
+    /// The one big title on a page. Chat empty state, page headers,
+    /// the title at the top of a Settings category.
     static let pageTitle = Font.system(size: 20, weight: .semibold)
-    /// A section label above a group of rows.
-    static let sectionTitle = Font.system(size: 11, weight: .semibold)
+    /// A titled division WITHIN a page — "Models folder", "Web search",
+    /// "Approvals". The tier between ``pageTitle`` and ``groupLabel``.
+    ///
+    /// This is the role Settings was missing, and its absence is why the
+    /// window carried four heading sizes: panels reached for `.title2`
+    /// (22pt) or `.title3` (17pt) because the ramp offered nothing
+    /// between a 20pt page title and an 11pt group label. 15pt semibold
+    /// sits a clear step under ``pageTitle`` without shouting.
+    static let sectionTitle = Font.system(size: 15, weight: .semibold)
+    /// The quiet organisational label directly above a group of rows.
+    /// Structural, not announcing — it should recede behind the content
+    /// it files.
+    ///
+    /// Formerly named ``sectionTitle``; renamed when the real section
+    /// tier above was added, because two roles cannot share one name.
+    static let groupLabel = Font.system(size: 11, weight: .semibold)
     /// Default body copy and row labels.
     static let body = Font.system(size: 13)
     /// Emphasised body — a row's primary label.

--- a/apps/rapid-mac/Sources/Rapid/UI/SettingsConnectorsPanel.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SettingsConnectorsPanel.swift
@@ -58,7 +58,12 @@ struct SettingsConnectorsPanel: View {
 
     var body: some View {
         @Bindable var config = config
-        return VStack(alignment: .leading, spacing: 20) {
+        return VStack(alignment: .leading, spacing: RapidTheme.Space.xl) {
+            SectionHeader(
+                "Connectors",
+                subtitle: "Connect the model to MCP servers — programs on this Mac that expose tools like file access, databases or search. Off by default: a connector is a program that runs on your machine and that the model can invoke.",
+                emphasis: .page
+            )
             masterSection
             if config.isEnabled {
                 serversSection
@@ -106,20 +111,12 @@ struct SettingsConnectorsPanel: View {
 
     private var masterSection: some View {
         @Bindable var config = config
-        return VStack(alignment: .leading, spacing: 8) {
-            header(
-                "Connectors",
-                "Connect the model to MCP servers — programs on this Mac that expose tools like file access, databases or search. Off by default: a connector is a program that runs on your machine and that the model can invoke."
-            )
-            card {
+        return SettingsSection {
                 Toggle(isOn: $config.isEnabled) {
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text("Enable connectors")
-                            .font(.system(size: 12, weight: .medium))
-                        Text("The local server only loads connectors when this is on.")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                    }
+                    SettingsRowLabel(
+                        title: "Enable connectors",
+                        description: "The local server only loads connectors when this is on."
+                    )
                 }
                 .toggleStyle(TrailingSettingsToggleStyle())
                 .accessibilityIdentifier("Settings.Connectors.MasterToggle")
@@ -138,26 +135,15 @@ struct SettingsConnectorsPanel: View {
                         catalog.clear()
                     }
                 }
-            }
         }
     }
 
     // MARK: - Servers
 
     private var serversSection: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            HStack(alignment: .firstTextBaseline) {
-                header(
-                    "Servers",
-                    "Each server runs as its own program and exposes a set of tools."
-                )
-                Spacer()
-                Button("Add…") { editing = EditorTarget(original: nil) }
-                    .accessibilityIdentifier("Settings.Connectors.AddButton")
-            }
-
+        VStack(alignment: .leading, spacing: RapidTheme.Space.sm) {
             if let why = config.loadError {
-                banner(why, systemImage: "exclamationmark.triangle.fill", tone: .orange)
+                InlineNotice(message: why, tone: .warning)
             }
             // The restart case owns its own banner. Suppressing the engine's
             // string here is deliberate: when the child has no config path the
@@ -168,29 +154,31 @@ struct SettingsConnectorsPanel: View {
             if needsRestart {
                 restartBanner
             } else if let why = catalog.subsystemError {
-                banner(
-                    "Connectors couldn't start: \(why)",
-                    systemImage: "exclamationmark.triangle.fill",
-                    tone: .orange
+                InlineNotice(
+                    message: "Connectors couldn't start: \(why)",
+                    tone: .warning
                 )
                 .accessibilityIdentifier("Settings.Connectors.SubsystemError")
             }
             if let why = actionError {
-                banner(why, systemImage: "exclamationmark.triangle.fill", tone: .red)
+                InlineNotice(message: why, tone: .error)
             }
 
-            card {
+            SettingsSection("Servers", subtitle: "Each server runs as its own program and exposes a set of tools.") {
+                Button("Add…") { editing = EditorTarget(original: nil) }
+                    .buttonStyle(.rapidSecondaryCompact)
+                    .accessibilityIdentifier("Settings.Connectors.AddButton")
+            } content: {
                 if config.servers.isEmpty {
                     Text("No connectors yet. Add one to give the model tools beyond the built-ins.")
-                        .font(.callout)
-                        .foregroundStyle(.secondary)
+                        .font(RapidFont.body)
+                        .foregroundStyle(RapidTheme.textSecondary)
+                        .fixedSize(horizontal: false, vertical: true)
                         .frame(maxWidth: .infinity, alignment: .leading)
                 } else {
-                    VStack(alignment: .leading, spacing: 0) {
-                        ForEach(Array(config.servers.enumerated()), id: \.element.name) { idx, entry in
-                            if idx > 0 { Divider().padding(.vertical, 10) }
-                            serverRow(entry)
-                        }
+                    ForEach(Array(config.servers.enumerated()), id: \.element.name) { idx, entry in
+                        if idx > 0 { SettingsRowDivider() }
+                        serverRow(entry)
                     }
                 }
             }
@@ -200,24 +188,29 @@ struct SettingsConnectorsPanel: View {
     @ViewBuilder
     private func serverRow(_ entry: MCPServerConfig) -> some View {
         let status = catalog.servers.first { $0.name == entry.name }
-        HStack(alignment: .top, spacing: 10) {
+        HStack(alignment: .top, spacing: RapidTheme.Space.sm) {
             statusDot(for: entry, status: status)
-                .padding(.top, 4)
-            VStack(alignment: .leading, spacing: 3) {
+                .padding(.top, RapidTheme.Space.xs)
+            VStack(alignment: .leading, spacing: RapidTheme.Space.xxs) {
                 Text(entry.name)
-                    .font(.system(size: 12, weight: .medium, design: .monospaced))
+                    .font(RapidFont.code)
+                    .foregroundStyle(RapidTheme.textPrimary)
                 Text(entry.summaryLine)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .font(RapidFont.caption)
+                    .foregroundStyle(RapidTheme.textSecondary)
                     .lineLimit(2)
                     .fixedSize(horizontal: false, vertical: true)
                 Text(statusLine(for: entry, status: status))
-                    .font(.caption)
-                    .foregroundStyle(status?.error != nil ? .orange : .secondary)
+                    .font(RapidFont.caption)
+                    .foregroundStyle(
+                        status?.error != nil
+                            ? RapidTheme.statusWarning
+                            : RapidTheme.textSecondary
+                    )
                     .fixedSize(horizontal: false, vertical: true)
                     .accessibilityIdentifier("Settings.Connectors.Row.Status.\(entry.name)")
             }
-            Spacer(minLength: 8)
+            .frame(maxWidth: .infinity, alignment: .leading)
             Toggle("", isOn: Binding(
                 get: { entry.enabled },
                 set: { setEnabled(entry, $0) }
@@ -236,19 +229,28 @@ struct SettingsConnectorsPanel: View {
             }
             .menuStyle(.borderlessButton)
             .fixedSize()
+            .foregroundStyle(RapidTheme.utilityActionLabel)
+            .accessibilityLabel("Connector actions")
             .accessibilityIdentifier("Settings.Connectors.Row.Menu.\(entry.name)")
         }
     }
 
+    /// The row's state, as one dot. Every colour is a status token —
+    /// these were `.orange` / `.green` / `.secondary` literals, which put
+    /// a second, slightly different amber and a second green on a window
+    /// that already had one of each.
     @ViewBuilder
     private func statusDot(for entry: MCPServerConfig, status: MCPCatalog.ServerStatus?) -> some View {
         let color: Color = {
-            if !entry.enabled { return .secondary }
-            guard let status else { return .secondary }
-            if status.error != nil || status.state == "error" { return .orange }
-            return status.isConnected ? .green : .secondary
+            if !entry.enabled { return RapidTheme.statusIdle }
+            guard let status else { return RapidTheme.statusIdle }
+            if status.error != nil || status.state == "error" { return RapidTheme.statusWarning }
+            return status.isConnected ? RapidTheme.statusReady : RapidTheme.statusIdle
         }()
-        Circle().fill(color).frame(width: 8, height: 8)
+        Circle()
+            .fill(color)
+            .frame(width: 8, height: 8)
+            .accessibilityHidden(true)
     }
 
     /// One line saying what this server is doing right now — the question the
@@ -283,24 +285,39 @@ struct SettingsConnectorsPanel: View {
     /// app's job — and the earlier version of this banner did exactly that,
     /// alongside an engine message about a command-line flag.
     private var restartBanner: some View {
-        HStack(alignment: .top, spacing: 10) {
+        // Same shape and copy; the container is now the shared notice
+        // rather than a local `Color.orange.opacity(0.12)` rectangle, and
+        // the button carries a real tier. It keeps a two-line body (the
+        // shared notice takes one message), so it composes the notice's
+        // tokens rather than the notice itself.
+        HStack(alignment: .top, spacing: RapidTheme.Space.sm) {
             Image(systemName: "arrow.clockwise.circle.fill")
-                .foregroundStyle(.orange)
-            VStack(alignment: .leading, spacing: 6) {
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(RapidTheme.statusWarning)
+                .accessibilityHidden(true)
+            VStack(alignment: .leading, spacing: RapidTheme.Space.xs) {
                 Text("Restart the model to finish turning connectors on.")
-                    .font(.callout)
+                    .font(RapidFont.bodyEmphasis)
+                    .foregroundStyle(RapidTheme.textPrimary)
+                    .fixedSize(horizontal: false, vertical: true)
                 Text("The running model started before connectors were enabled, so it isn't loading them yet. Restarting takes a moment and keeps your conversation.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .font(RapidFont.caption)
+                    .foregroundStyle(RapidTheme.textSecondary)
                     .fixedSize(horizontal: false, vertical: true)
             }
-            Spacer(minLength: 8)
+            .frame(maxWidth: .infinity, alignment: .leading)
             Button(isRestarting ? "Restarting…" : "Restart") { restartModel() }
+                .buttonStyle(.rapidSecondaryCompact)
+                .fixedSize()
                 .disabled(isRestarting || server.isOperating)
                 .accessibilityIdentifier("Settings.Connectors.RestartButton")
         }
-        .padding(12)
-        .background(RoundedRectangle(cornerRadius: 8).fill(Color.orange.opacity(0.12)))
+        .padding(.horizontal, RapidTheme.Space.md)
+        .padding(.vertical, RapidTheme.Space.sm)
+        .background(
+            RoundedRectangle(cornerRadius: RapidTheme.Radius.button, style: .continuous)
+                .fill(RapidTheme.statusWarningTint)
+        )
     }
 
     /// Stop-then-start the current alias so the child is respawned WITH
@@ -323,17 +340,14 @@ struct SettingsConnectorsPanel: View {
     // MARK: - Tools
 
     private var toolsSection: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            header(
-                "Tools",
-                "What the connected servers expose. Turn one off and it is never offered to the model — and never runs, even if the model asks for it by name."
-            )
-            card {
-                VStack(alignment: .leading, spacing: 12) {
-                    ForEach(registry.allKnownTools, id: \.function.name) { def in
-                        toolRow(def)
-                    }
-                }
+        SettingsSection(
+            "Tools",
+            subtitle: "What the connected servers expose. Turn one off and it is never offered to the model — and never runs, even if the model asks for it by name."
+        ) {
+            let tools = registry.allKnownTools
+            ForEach(Array(tools.enumerated()), id: \.element.function.name) { index, def in
+                if index > 0 { SettingsRowDivider() }
+                toolRow(def)
             }
         }
     }
@@ -345,36 +359,40 @@ struct SettingsConnectorsPanel: View {
             get: { registry.isToolEnabled(name) },
             set: { registry.setToolEnabled(name, $0) }
         )) {
-            HStack(alignment: .top, spacing: 10) {
+            HStack(alignment: .top, spacing: RapidTheme.Space.sm) {
                 Image(systemName: "wrench.and.screwdriver")
-                    .foregroundStyle(RapidTheme.brand)
-                    .frame(width: 18)
-                VStack(alignment: .leading, spacing: 2) {
-                    HStack(spacing: 6) {
+                    .foregroundStyle(RapidTheme.utilityActionLabel)
+                    .frame(width: RapidTheme.Layout.iconSlot)
+                    .accessibilityHidden(true)
+                VStack(alignment: .leading, spacing: RapidTheme.Space.xxs) {
+                    HStack(spacing: RapidTheme.Space.xs) {
                         // Server-supplied text (tool name, owning server,
                         // description) is scrubbed the same way the approval
                         // sheet scrubs it — a bidi or zero-width scalar in a
                         // server's tool metadata must not visually spoof a row.
                         Text(BrowseApprovalStore.displaySafe(MCPToolApprovalStore.shortToolName(name)))
-                            .font(.system(size: 12, weight: .medium, design: .monospaced))
+                            .font(RapidFont.code)
+                            .foregroundStyle(RapidTheme.textPrimary)
                         if let source = catalog.serverForTool[name] {
                             Text(BrowseApprovalStore.displaySafe(source))
-                                .font(.system(size: 10, weight: .medium))
-                                .padding(.horizontal, 5)
-                                .padding(.vertical, 1)
-                                .background(Capsule().fill(RapidTheme.brand.opacity(0.15)))
+                                .font(RapidFont.caption)
+                                .foregroundStyle(RapidTheme.textSecondary)
+                                .padding(.horizontal, RapidTheme.Space.xs)
+                                .padding(.vertical, RapidTheme.Space.xxs)
+                                .background(Capsule().fill(RapidTheme.hoverFill))
                         }
                         if approval.grantedTools.contains(name) {
                             Text("always allowed")
-                                .font(.system(size: 10))
-                                .foregroundStyle(.secondary)
+                                .font(RapidFont.caption)
+                                .foregroundStyle(RapidTheme.textTertiary)
                         }
                     }
                     Text(BrowseApprovalStore.displaySafe(def.function.description))
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
+                        .font(RapidFont.caption)
+                        .foregroundStyle(RapidTheme.textSecondary)
                         .fixedSize(horizontal: false, vertical: true)
                 }
+                .frame(maxWidth: .infinity, alignment: .leading)
             }
         }
         .toggleStyle(TrailingSettingsToggleStyle())
@@ -385,47 +403,34 @@ struct SettingsConnectorsPanel: View {
 
     private var approvalSection: some View {
         @Bindable var approval = approval
-        return VStack(alignment: .leading, spacing: 8) {
-            header(
-                "Approvals",
-                "The first time the model calls a connector tool, Rapid asks. Your answer is remembered per tool."
-            )
-            card {
-                VStack(alignment: .leading, spacing: 14) {
-                    Toggle(isOn: Binding(
-                        get: { approval.mode == .autoApproveAll },
-                        set: { approval.mode = $0 ? .autoApproveAll : .ask }
-                    )) {
-                        VStack(alignment: .leading, spacing: 2) {
-                            Text("Auto-approve all tool calls")
-                                .font(.system(size: 12, weight: .medium))
-                            Text("Skips every prompt, including for connectors added later. For unattended use only.")
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                                .fixedSize(horizontal: false, vertical: true)
-                        }
-                    }
-                    .toggleStyle(TrailingSettingsToggleStyle())
-                    .accessibilityIdentifier("Settings.Connectors.AutoApproveToggle")
+        return SettingsSection(
+            "Approvals",
+            subtitle: "The first time the model calls a connector tool, Rapid asks. Your answer is remembered per tool."
+        ) {
+            Toggle(isOn: Binding(
+                get: { approval.mode == .autoApproveAll },
+                set: { approval.mode = $0 ? .autoApproveAll : .ask }
+            )) {
+                SettingsRowLabel(
+                    title: "Auto-approve all tool calls",
+                    description: "Skips every prompt, including for connectors added later. For unattended use only."
+                )
+            }
+            .toggleStyle(TrailingSettingsToggleStyle())
+            .accessibilityIdentifier("Settings.Connectors.AutoApproveToggle")
 
-                    Divider()
+            SettingsRowDivider()
 
-                    HStack(alignment: .firstTextBaseline) {
-                        VStack(alignment: .leading, spacing: 2) {
-                            Text(approval.grantedTools.isEmpty
-                                ? "No tools are permanently allowed."
-                                : "\(approval.grantedTools.count) tool\(approval.grantedTools.count == 1 ? "" : "s") permanently allowed.")
-                                .font(.callout)
-                            Text("Resetting makes Rapid ask again the next time each one is called.")
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                        }
-                        Spacer()
-                        Button("Reset") { approval.resetGrants() }
-                            .disabled(approval.grantedTools.isEmpty)
-                            .accessibilityIdentifier("Settings.Connectors.ResetApprovals")
-                    }
-                }
+            SettingsRow(
+                title: approval.grantedTools.isEmpty
+                    ? "No tools are permanently allowed."
+                    : "\(approval.grantedTools.count) tool\(approval.grantedTools.count == 1 ? "" : "s") permanently allowed.",
+                description: "Resetting makes Rapid ask again the next time each one is called."
+            ) {
+                Button("Reset") { approval.resetGrants() }
+                    .buttonStyle(.rapidSecondaryCompact)
+                    .disabled(approval.grantedTools.isEmpty)
+                    .accessibilityIdentifier("Settings.Connectors.ResetApprovals")
             }
         }
     }
@@ -478,46 +483,12 @@ struct SettingsConnectorsPanel: View {
         Task { await catalog.reload() }
     }
 
-    // MARK: - Chrome
-
-    private func header(_ title: String, _ subtitle: String) -> some View {
-        VStack(alignment: .leading, spacing: 4) {
-            Text(title)
-                .font(.title3.weight(.semibold))
-            Text(subtitle)
-                .font(.callout)
-                .foregroundStyle(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
-        }
-    }
-
-    private func banner(_ text: String, systemImage: String, tone: Color) -> some View {
-        HStack(alignment: .top, spacing: 8) {
-            Image(systemName: systemImage).foregroundStyle(tone)
-            Text(text)
-                .font(.caption)
-                .fixedSize(horizontal: false, vertical: true)
-            Spacer()
-        }
-        .padding(10)
-        .background(RoundedRectangle(cornerRadius: 8).fill(tone.opacity(0.12)))
-    }
-
-    @ViewBuilder
-    private func card<Content: View>(@ViewBuilder _ content: () -> Content) -> some View {
-        content()
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(16)
-            .background(
-                RoundedRectangle(cornerRadius: RapidTheme.cardRadius, style: .continuous)
-                    .fill(RapidTheme.card)
-            )
-            .clipShape(RoundedRectangle(cornerRadius: RapidTheme.cardRadius, style: .continuous))
-            .overlay(
-                RoundedRectangle(cornerRadius: RapidTheme.cardRadius, style: .continuous)
-                    .stroke(RapidTheme.hairline, lineWidth: 1)
-            )
-    }
+    // NOTE: private ``header(_:_:)``, ``banner(_:systemImage:tone:)`` and
+    // ``card(_:)`` helpers lived here — the third copy of the card/header
+    // pair, plus a local banner that took a raw ``Color`` and washed it
+    // to 12%. All three are now ``SectionHeader`` / ``SettingsSection`` /
+    // ``InlineNotice``, which is what moved this panel's four banner call
+    // sites off `Color.orange` and `Color.red` onto the status tokens.
 }
 
 extension MCPServerConfig {

--- a/apps/rapid-mac/Sources/Rapid/UI/SettingsControlStyles.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SettingsControlStyles.swift
@@ -1,22 +1,163 @@
 import SwiftUI
 
-/// Settings rows use a stable trailing control column. SwiftUI's stock
-/// switch style sizes itself from the label's ideal width, which made a short
-/// description place its switch near the middle while longer descriptions
-/// happened to push theirs right. This style makes that alignment explicit
-/// across every settings panel while retaining the native macOS switch.
+/// Settings rows use a stable trailing control column.
+///
+/// SwiftUI's stock switch style sizes itself from the label's ideal
+/// width, which made a short description place its switch near the
+/// middle while longer descriptions happened to push theirs right. This
+/// style makes that alignment explicit across every settings panel while
+/// retaining the native macOS switch.
+///
+/// Two things beyond alignment, both from the UI-1 review:
+///
+///   * **Compact.** The switch renders at ``controlSize(.small)``. At the
+///     regular size it was the heaviest object on a settings page —
+///     visually louder than the row's own title — which is the wrong
+///     emphasis for a control whose job is to be flicked and forgotten.
+///   * **Room to breathe.** The label column is separated from the
+///     switch by ``gutter``, and the switch sits in a fixed-width
+///     column, so a three-line description can never creep under the
+///     control and every switch lines up down one edge.
+///
+/// The switch itself stays native: a `Toggle` with `.switch`, so macOS
+/// owns its shape, its animation, its focus ring, its hit target and its
+/// accessibility. Only its size and the space around it are ours.
 struct TrailingSettingsToggleStyle: ToggleStyle {
+    /// Clear space between the end of the text column and the switch.
+    /// The review asked for 20–24pt; ``Space.xl`` is 24.
+    static let gutter: CGFloat = RapidTheme.Space.xl
+
+    /// Width reserved for the switch. A `.small` macOS switch is ~32pt
+    /// wide; reserving a fixed column means rows with and without a
+    /// description still line their switches up.
+    static let controlColumnWidth: CGFloat = 38
+
     func makeBody(configuration: Configuration) -> some View {
         let binding = Binding(
             get: { configuration.isOn },
             set: { configuration.isOn = $0 }
         )
 
-        return Toggle(isOn: binding) {
+        // `.firstTextBaseline` would be ideal, but a switch has no text
+        // baseline to align to, so SwiftUI falls back to centring the
+        // row — which walks the switch down the page as a description
+        // grows. `.top` plus a first-line-height frame pins it to the
+        // title line and keeps it there however long the copy gets.
+        return HStack(alignment: .top, spacing: Self.gutter) {
             configuration.label
                 .frame(maxWidth: .infinity, alignment: .leading)
+
+            Toggle(isOn: binding) { EmptyView() }
+                .labelsHidden()
+                .toggleStyle(.switch)
+                .controlSize(.small)
+                .frame(
+                    width: Self.controlColumnWidth,
+                    height: RapidTheme.ControlHeight.small,
+                    alignment: .trailing
+                )
         }
-        .toggleStyle(.switch)
         .frame(maxWidth: .infinity)
+    }
+}
+
+/// The app's one segmented control.
+///
+/// ## Why this is not `.pickerStyle(.segmented)`
+///
+/// The native style takes its selected-segment fill from the ambient
+/// tint and its selected-segment label from macOS — which pairs the
+/// scene's brand amber with **white** text. That is the same ~2:1
+/// combination ``RapidTheme/brandOnAccent`` exists to prevent, and
+/// SwiftUI exposes no hook to change it: the label colour is decided
+/// inside AppKit's `NSSegmentedControl` rendering, not by the ambient
+/// `foregroundStyle`. The native control also grew well past the 28–32pt
+/// macOS uses at the regular control size, because it scaled with the
+/// panels' type.
+///
+/// So this is a deliberate, documented exception to "prefer native
+/// controls": a segmented control is a row of buttons, it carries no
+/// system behaviour that is lost by rebuilding it, and rebuilding is
+/// what lets the selected segment use dark ink on amber.
+///
+/// Everything else stays honest to the platform: 30pt tall, a modest 6pt
+/// segment radius inside an 8pt track, no capsules, real `Button`s so
+/// keyboard focus and AX press behaviour survive, and no layout shift on
+/// selection — each segment reserves its selected (semibold) width via a
+/// hidden measurement copy.
+struct RapidSegmentedControl<Value: Hashable>: View {
+    struct Option: Identifiable {
+        let value: Value
+        let title: String
+        /// Optional stable AX identifier for one segment.
+        var identifier: String?
+
+        var id: Value { value }
+
+        init(value: Value, title: String, identifier: String? = nil) {
+            self.value = value
+            self.title = title
+            self.identifier = identifier
+        }
+    }
+
+    @Binding var selection: Value
+    let options: [Option]
+    /// Spoken name for the whole control.
+    var accessibilityLabel: String
+
+    var body: some View {
+        HStack(spacing: RapidTheme.Space.xxs) {
+            ForEach(options) { option in
+                segment(option)
+            }
+        }
+        .padding(RapidTheme.Space.xxs)
+        .background(
+            RoundedRectangle(cornerRadius: RapidTheme.Radius.button, style: .continuous)
+                .fill(RapidTheme.hoverFill)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: RapidTheme.Radius.button, style: .continuous)
+                .strokeBorder(RapidTheme.hairline, lineWidth: 1)
+        )
+        .fixedSize(horizontal: true, vertical: false)
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel(accessibilityLabel)
+    }
+
+    @ViewBuilder
+    private func segment(_ option: Option) -> some View {
+        let isSelected = selection == option.value
+        Button {
+            selection = option.value
+        } label: {
+            Text(option.title)
+                .font(RapidFont.body)
+                .fontWeight(isSelected ? .semibold : .regular)
+                // Reserve the SELECTED (semibold) width at all times so
+                // the track does not resize when the selection moves.
+                .background(
+                    Text(option.title)
+                        .font(RapidFont.body)
+                        .fontWeight(.semibold)
+                        .hidden()
+                )
+                .foregroundStyle(
+                    isSelected ? RapidTheme.brandOnAccent : RapidTheme.textSecondary
+                )
+                .padding(.horizontal, RapidTheme.Space.md)
+                .frame(height: RapidTheme.ControlHeight.segmented - RapidTheme.Space.xs)
+                .background(
+                    RoundedRectangle(cornerRadius: RapidTheme.Radius.segment, style: .continuous)
+                        .fill(isSelected ? RapidTheme.brandPrimary : Color.clear)
+                )
+                .contentShape(
+                    RoundedRectangle(cornerRadius: RapidTheme.Radius.segment, style: .continuous)
+                )
+        }
+        .buttonStyle(.plain)
+        .accessibilityAddTraits(isSelected ? [.isButton, .isSelected] : .isButton)
+        .accessibilityIdentifier(option.identifier ?? "")
     }
 }

--- a/apps/rapid-mac/Sources/Rapid/UI/SettingsModelManagementPanel.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SettingsModelManagementPanel.swift
@@ -116,8 +116,10 @@ struct SettingsModelManagementPanel: View {
         }
     }
 
+    @Environment(\.settingsContentIsCompact) private var isCompact
+
     var body: some View {
-        VStack(alignment: .leading, spacing: 16) {
+        VStack(alignment: .leading, spacing: RapidTheme.Space.xl) {
             header
             modelsFolderSection
             storageOverviewSection
@@ -137,10 +139,20 @@ struct SettingsModelManagementPanel: View {
                 allModelsSection
             }
             if let lastError {
-                errorBanner(lastError)
+                InlineNotice(
+                    message: lastError,
+                    tone: .error,
+                    actionTitle: "Dismiss",
+                    action: { self.lastError = nil }
+                )
             }
             if let lastFreed {
-                freedBanner(lastFreed)
+                InlineNotice(
+                    message: lastFreed,
+                    tone: .success,
+                    actionTitle: "Dismiss",
+                    action: { self.lastFreed = nil }
+                )
             }
         }
         // Loading, empty, and catalog branches are deliberately exclusive.
@@ -208,14 +220,11 @@ struct SettingsModelManagementPanel: View {
 
     @ViewBuilder
     private var header: some View {
-        VStack(alignment: .leading, spacing: 4) {
-            Text("Model Management")
-                .font(.title3.weight(.semibold))
-            Text("Manage the on-disk model cache. Download what you need in the background; delete what you don't to reclaim space.")
-                .font(.callout)
-                .foregroundStyle(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
-        }
+        SectionHeader(
+            "Model Management",
+            subtitle: "Manage the on-disk model cache. Download what you need in the background; delete what you don't to reclaim space.",
+            emphasis: .page
+        )
     }
 
     // MARK: - Models folder (issue #503)
@@ -229,69 +238,53 @@ struct SettingsModelManagementPanel: View {
     @ViewBuilder
     private var modelsFolderSection: some View {
         let unavailable = ModelsFolderPreference.customFolderUnavailable()
-        VStack(alignment: .leading, spacing: 8) {
-            Text("Models folder")
-                .font(.callout.weight(.semibold))
-                .foregroundStyle(.secondary)
-            VStack(alignment: .leading, spacing: 10) {
-                HStack(alignment: .firstTextBaseline, spacing: 8) {
+        SettingsSection("Models folder") {
+            VStack(alignment: .leading, spacing: RapidTheme.Space.md) {
+                HStack(alignment: .top, spacing: RapidTheme.Space.sm) {
                     Image(systemName: customFolderPath == nil ? "internaldrive" : "externaldrive")
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(RapidTheme.utilityActionLabel)
+                        .frame(width: RapidTheme.Layout.iconSlot)
                         .accessibilityHidden(true)
-                    VStack(alignment: .leading, spacing: 2) {
+                    VStack(alignment: .leading, spacing: RapidTheme.Space.xxs) {
                         Text(customFolderPath == nil ? "Default location" : "Custom folder")
-                            .font(.callout.weight(.medium))
+                            .font(RapidFont.bodyEmphasis)
+                            .foregroundStyle(RapidTheme.textPrimary)
                         Text(effectiveFolderDisplayPath)
-                            .scaledSystemFont(11, design: .monospaced)
-                            .foregroundStyle(.secondary)
+                            .font(RapidFont.code)
+                            .foregroundStyle(RapidTheme.textSecondary)
                             .textSelection(.enabled)
                             .lineLimit(2)
                             .truncationMode(.middle)
                             .accessibilityIdentifier("Settings.ModelManagement.FolderPath")
                     }
-                    Spacer(minLength: 0)
+                    .frame(maxWidth: .infinity, alignment: .leading)
                 }
 
                 if unavailable {
-                    HStack(alignment: .top, spacing: 6) {
-                        Image(systemName: "exclamationmark.triangle.fill")
-                            .foregroundStyle(.orange)
-                        Text("Your chosen models folder isn't available right now — the drive may be unplugged. Rapid is using its default location until it's back.")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                            .fixedSize(horizontal: false, vertical: true)
-                    }
+                    InlineNotice(
+                        message: "Your chosen models folder isn't available right now — the drive may be unplugged. Rapid is using its default location until it's back.",
+                        tone: .warning
+                    )
                     .accessibilityIdentifier("Settings.ModelManagement.FolderUnavailable")
                 }
 
-                HStack(spacing: 10) {
+                HStack(spacing: RapidTheme.Space.sm) {
                     Button("Choose…") { chooseModelsFolder() }
-                        .buttonStyle(.bordered)
-                        .controlSize(.small)
+                        .buttonStyle(.rapidSecondaryCompact)
                         .accessibilityIdentifier("Settings.ModelManagement.ChooseFolder")
                     if customFolderPath != nil {
                         Button("Use default") { resetModelsFolder() }
-                            .buttonStyle(.borderless)
-                            .controlSize(.small)
+                            .buttonStyle(.rapidTertiary)
                             .accessibilityIdentifier("Settings.ModelManagement.UseDefaultFolder")
                     }
                     Spacer(minLength: 0)
                 }
 
                 Text("Point Rapid at a folder where it already keeps downloaded models — for example on an external drive. New models download here; ones you already have stay where they are. Models downloaded by other apps in other formats won't appear here. New location takes effect the next time a model loads or downloads.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .font(RapidFont.caption)
+                    .foregroundStyle(RapidTheme.textSecondary)
                     .fixedSize(horizontal: false, vertical: true)
             }
-            .padding(12)
-            .background(
-                RoundedRectangle(cornerRadius: RapidTheme.cardRadius, style: .continuous)
-                    .fill(RapidTheme.card)
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: RapidTheme.cardRadius, style: .continuous)
-                    .stroke(RapidTheme.hairline, lineWidth: 1)
-            )
         }
     }
 
@@ -306,20 +299,12 @@ struct SettingsModelManagementPanel: View {
     /// divider so they read as a pair without two floating boxes.
     @ViewBuilder
     private var preferencesSection: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text("Preferences")
-                .font(.callout.weight(.semibold))
-                .foregroundStyle(.secondary)
-            VStack(alignment: .leading, spacing: 0) {
+        SettingsSection("Preferences") {
                 Toggle(isOn: $showAllModels) {
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text("Show small (<1B) models in the picker")
-                            .font(.callout.weight(.medium))
-                        Text("Sub-1B models (qwen3-0.6b-*) are hidden from the model picker by default — they hallucinate within 1-2 turns and are intended for unit tests, not chat. Turn on to see every model, including the tiny ones.")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                            .fixedSize(horizontal: false, vertical: true)
-                    }
+                    SettingsRowLabel(
+                        title: "Show small (<1B) models in the picker",
+                        description: "Sub-1B models (qwen3-0.6b-*) are hidden from the model picker by default — they hallucinate within 1-2 turns and are intended for unit tests, not chat. Turn on to see every model, including the tiny ones."
+                    )
                 }
                 .toggleStyle(TrailingSettingsToggleStyle())
                 .accessibilityLabel("Show small models in the picker")
@@ -330,35 +315,19 @@ struct SettingsModelManagementPanel: View {
                 // VoiceOver/automation client that already targets it.
                 .accessibilityIdentifier("Settings.Models.ShowAllModelsToggle")
 
-                Divider()
-                    .padding(.vertical, 12)
+                SettingsRowDivider()
 
                 Toggle(isOn: $autoStartOnLaunch) {
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text("Auto-start model on launch")
-                            .font(.callout.weight(.medium))
-                        Text("On launch, Rapid-MLX loads your last-used model into memory so the chat is interactive immediately. Nothing loads while first-run setup is still open. Turn off if you sometimes open Rapid-MLX just to browse past conversations — you can still start a model manually by picking one in the message box and sending.")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                            .fixedSize(horizontal: false, vertical: true)
-                    }
+                    SettingsRowLabel(
+                        title: "Auto-start model on launch",
+                        description: "On launch, Rapid-MLX loads your last-used model into memory so the chat is interactive immediately. Nothing loads while first-run setup is still open. Turn off if you sometimes open Rapid-MLX just to browse past conversations — you can still start a model manually by picking one in the message box and sending."
+                    )
                 }
                 .toggleStyle(TrailingSettingsToggleStyle())
                 .accessibilityLabel("Auto-start model on launch")
                 .accessibilityHint("When off, opening Rapid-MLX will not load a model until you start one manually from the picker.")
                 // Stable AX hook kept as `Settings.Models.*` across the move.
                 .accessibilityIdentifier("Settings.Models.AutoStartOnLaunchToggle")
-            }
-            .padding(12)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .background(
-                RoundedRectangle(cornerRadius: RapidTheme.cardRadius, style: .continuous)
-                    .fill(RapidTheme.card)
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: RapidTheme.cardRadius, style: .continuous)
-                    .stroke(RapidTheme.hairline, lineWidth: 1)
-            )
         }
     }
 
@@ -393,51 +362,44 @@ struct SettingsModelManagementPanel: View {
         let managed = catalog.filter { !$0.isExternal }
         let usage = ModelCacheActions.aggregateOnDiskBytes(managed)
         let largest = ModelCacheActions.largestManagedEntry(managed)
-        VStack(alignment: .leading, spacing: 8) {
-            Text("Disk overview")
-                .font(.callout.weight(.semibold))
-                .foregroundStyle(.secondary)
-            VStack(alignment: .leading, spacing: 10) {
-                HStack {
-                    Label("Models", systemImage: "internaldrive")
-                        .font(.callout.weight(.medium))
-                    Spacer()
-                    Text(ModelCacheActions.storageSummary(
-                        usage: usage,
-                        freeBytes: modelsVolumeFreeBytes
-                    ))
-                    .font(.callout.monospacedDigit())
-                    .foregroundStyle(.secondary)
-                    .accessibilityIdentifier("Settings.ModelManagement.StorageSummary")
-                }
-                if let largest {
-                    Divider()
-                    HStack {
-                        Text("Largest")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                        Text(largest.alias)
-                            .font(.caption.weight(.medium))
-                            .lineLimit(1)
-                            .truncationMode(.middle)
-                        Spacer()
-                        Text(largest.sizeOnDisk ?? "")
-                            .font(.caption.monospacedDigit())
-                            .foregroundStyle(.secondary)
-                    }
-                    .accessibilityElement(children: .combine)
-                    .accessibilityIdentifier("Settings.ModelManagement.LargestModel")
-                }
+        // Upstream (#1822) added this card in the pre-migration idiom —
+        // `.callout` type, the legacy 12pt `cardRadius`, a local 12pt
+        // inset. Same content and the same identifiers, moved onto the
+        // shared section so it does not ship as the one un-migrated card
+        // in the window.
+        return SettingsSection("Disk overview") {
+            HStack(spacing: RapidTheme.Space.md) {
+                Label("Models", systemImage: "internaldrive")
+                    .font(RapidFont.bodyEmphasis)
+                    .foregroundStyle(RapidTheme.textPrimary)
+                Spacer(minLength: RapidTheme.Space.sm)
+                Text(ModelCacheActions.storageSummary(
+                    usage: usage,
+                    freeBytes: modelsVolumeFreeBytes
+                ))
+                .font(RapidFont.metric)
+                .foregroundStyle(RapidTheme.textSecondary)
+                .accessibilityIdentifier("Settings.ModelManagement.StorageSummary")
             }
-            .padding(12)
-            .background(
-                RoundedRectangle(cornerRadius: RapidTheme.cardRadius, style: .continuous)
-                    .fill(RapidTheme.card)
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: RapidTheme.cardRadius, style: .continuous)
-                    .stroke(RapidTheme.hairline, lineWidth: 1)
-            )
+            if let largest {
+                SettingsRowDivider()
+                HStack(spacing: RapidTheme.Space.sm) {
+                    Text("Largest")
+                        .font(RapidFont.caption)
+                        .foregroundStyle(RapidTheme.textSecondary)
+                    Text(largest.alias)
+                        .font(RapidFont.bodyEmphasis)
+                        .foregroundStyle(RapidTheme.textPrimary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                    Spacer(minLength: RapidTheme.Space.sm)
+                    Text(largest.sizeOnDisk ?? "")
+                        .font(RapidFont.metric)
+                        .foregroundStyle(RapidTheme.textSecondary)
+                }
+                .accessibilityElement(children: .combine)
+                .accessibilityIdentifier("Settings.ModelManagement.LargestModel")
+            }
         }
     }
 
@@ -479,48 +441,51 @@ struct SettingsModelManagementPanel: View {
     @ViewBuilder
     private var capabilityTabs: some View {
         if availableKinds.count > 1 {
-            Picker("Model type", selection: $capability) {
-                ForEach(availableKinds) { kind in
-                    Text("\(kind.tabLabel) models").tag(kind)
-                }
-            }
-            .pickerStyle(.segmented)
-            .labelsHidden()
+            RapidSegmentedControl(
+                selection: $capability,
+                options: availableKinds.map {
+                    .init(value: $0, title: "\($0.tabLabel) models")
+                },
+                accessibilityLabel: "Model type"
+            )
             .accessibilityIdentifier("Settings.ModelManagement.CapabilityTabs")
         }
     }
 
     @ViewBuilder
     private var controlsRow: some View {
-        VStack(spacing: 10) {
-            HStack(spacing: 10) {
-                HStack(spacing: 6) {
+        VStack(spacing: RapidTheme.Space.sm) {
+            HStack(spacing: RapidTheme.Space.sm) {
+                HStack(spacing: RapidTheme.Space.xs) {
                     Image(systemName: "magnifyingglass")
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(RapidTheme.utilityActionLabel)
                         .accessibilityHidden(true)
                     TextField("Search models", text: $query)
                         .textFieldStyle(.plain)
+                        .font(RapidFont.body)
                         .accessibilityIdentifier("Settings.ModelManagement.Search")
                     if !query.isEmpty {
-                        Button {
+                        QuietIconButton(
+                            symbol: "xmark.circle.fill",
+                            label: "Clear search",
+                            size: RapidTheme.ControlHeight.mini
+                        ) {
                             query = ""
-                        } label: {
-                            Image(systemName: "xmark.circle.fill")
-                                .foregroundStyle(.secondary)
                         }
-                        .buttonStyle(.plain)
-                        .accessibilityLabel("Clear search")
                     }
                 }
-                .padding(.horizontal, 8)
-                .padding(.vertical, 5)
+                .padding(.horizontal, RapidTheme.Space.sm)
+                .frame(height: RapidTheme.ControlHeight.medium)
+                // The one input treatment: same radius and border the
+                // composer uses, instead of a local 7pt capsule over a
+                // hand-mixed `Color.secondary.opacity(0.08)`.
                 .background(
-                    RoundedRectangle(cornerRadius: 7, style: .continuous)
-                        .fill(Color.secondary.opacity(0.08))
+                    RoundedRectangle(cornerRadius: RapidTheme.Radius.input, style: .continuous)
+                        .fill(RapidTheme.surfaceRaised)
                 )
                 .overlay(
-                    RoundedRectangle(cornerRadius: 7, style: .continuous)
-                        .stroke(RapidTheme.hairline, lineWidth: 1)
+                    RoundedRectangle(cornerRadius: RapidTheme.Radius.input, style: .continuous)
+                        .strokeBorder(RapidTheme.hairlineStrong, lineWidth: 1)
                 )
                 .frame(maxWidth: .infinity)
 
@@ -538,19 +503,27 @@ struct SettingsModelManagementPanel: View {
                     }
                 } label: {
                     Label("Sort", systemImage: "arrow.up.arrow.down")
-                        .font(.caption.weight(.medium))
+                        .font(RapidFont.body)
                 }
                 .menuStyle(.borderlessButton)
-                .frame(maxWidth: 80)
+                .fixedSize()
+                // `.tint(nil)` as well as `.foregroundStyle`: the scene
+                // applies `.tint(brandAmber)` app-wide, and a borderless
+                // Menu's label reads the TINT, not the foreground style —
+                // so without this the Sort control rendered amber and read
+                // as the page's primary action rather than a utility next
+                // to the search field.
+                .tint(nil)
+                .foregroundStyle(RapidTheme.utilityActionLabel)
                 .accessibilityIdentifier("Settings.ModelManagement.SortMenu")
             }
-            Picker("Filter", selection: $filterMode) {
-                ForEach(ModelCacheActions.FilterMode.allCases) { mode in
-                    Text(mode.displayLabel).tag(mode)
-                }
-            }
-            .pickerStyle(.segmented)
-            .labelsHidden()
+            RapidSegmentedControl(
+                selection: $filterMode,
+                options: ModelCacheActions.FilterMode.allCases.map {
+                    .init(value: $0, title: $0.displayLabel)
+                },
+                accessibilityLabel: "Filter"
+            )
             .accessibilityIdentifier("Settings.ModelManagement.Filter")
         }
     }
@@ -589,11 +562,8 @@ struct SettingsModelManagementPanel: View {
 
     @ViewBuilder
     private var recommendedSection: some View {
-        VStack(alignment: .leading, spacing: 9) {
-            Text("Recommended for your \(hardware.shortDescription)")
-                .font(.caption.weight(.semibold))
-                .textCase(.uppercase)
-                .foregroundStyle(.secondary)
+        VStack(alignment: .leading, spacing: RapidTheme.Space.sm) {
+            SectionHeader("Recommended for your \(hardware.shortDescription)")
                 .accessibilityIdentifier("Settings.ModelManagement.RecommendedHeader")
             ForEach(recommendedPicks, id: \.pick.alias) { entry in
                 recommendedCard(pick: entry.pick, isPrimary: entry.isPrimary)
@@ -624,21 +594,23 @@ struct SettingsModelManagementPanel: View {
             // table below still pills the same alias as RECOMMENDED.
             Label(isPrimary ? "Best pick" : "Faster",
                   systemImage: isPrimary ? "star.fill" : "hare.fill")
-                .font(.caption.weight(.bold))
+                .font(RapidFont.caption)
+                .foregroundStyle(isPrimary ? RapidTheme.brandPrimaryDeep : RapidTheme.textSecondary)
                 .labelStyle(.titleAndIcon)
                 .frame(width: RecommendedCardLayout.markerColumnWidth, alignment: .leading)
 
             BrandIcon(alias: alias)
 
             VStack(alignment: .leading, spacing: 7) {
-                VStack(alignment: .leading, spacing: 3) {
+                VStack(alignment: .leading, spacing: RapidTheme.Space.xxs) {
                     Text(modelSubtitle(alias))
-                        .font(.body.weight(.semibold))
+                        .font(RapidFont.bodyEmphasis)
+                        .foregroundStyle(RapidTheme.textPrimary)
                         .lineLimit(1)
                         .truncationMode(.middle)
                     Text(Self.pickStatsLine(pick))
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
+                        .font(RapidFont.caption)
+                        .foregroundStyle(RapidTheme.textSecondary)
                         .lineLimit(2)
                         .fixedSize(horizontal: false, vertical: true)
                 }
@@ -665,20 +637,23 @@ struct SettingsModelManagementPanel: View {
                 .fixedSize(horizontal: true, vertical: false)
                 .frame(minWidth: RecommendedCardLayout.actionColumnWidth, alignment: .trailing)
         }
-        .padding(13)
+        .padding(SettingsCardMetrics.inset(isCompact: isCompact))
+        // The featured card is distinguished by the product's selection
+        // pair — amber tint and an amber edge — not by a steel-blue tint
+        // and a drop shadow. The shadow is gone: the tint plus the border
+        // already separate this tier from the flush table below it, and a
+        // shadow was the only one of its kind on the page.
         .background(
-            RoundedRectangle(cornerRadius: RapidTheme.cardRadius, style: .continuous)
-                .fill(isPrimary ? RapidTheme.brandTint : RapidTheme.card)
+            RoundedRectangle(cornerRadius: RapidTheme.Radius.card, style: .continuous)
+                .fill(isPrimary ? RapidTheme.brandPrimaryTint : RapidTheme.surfaceRaised)
         )
         .overlay(
-            RoundedRectangle(cornerRadius: RapidTheme.cardRadius, style: .continuous)
-                .stroke(isPrimary ? RapidTheme.brand.opacity(0.35) : RapidTheme.hairline, lineWidth: 1)
+            RoundedRectangle(cornerRadius: RapidTheme.Radius.card, style: .continuous)
+                .strokeBorder(
+                    isPrimary ? RapidTheme.brandPrimary.opacity(0.35) : RapidTheme.hairline,
+                    lineWidth: 1
+                )
         )
-        // #552 (§12 depth): lift the recommended cards above the flush
-        // All-models table below them so the tier reads as a raised, more
-        // important surface. Same light shadow the onboarding wizard's
-        // centred card carries (QuickstartView).
-        .shadow(color: Color.black.opacity(0.10), radius: 6, x: 0, y: 3)
         .accessibilityElement(children: .contain)
         .accessibilityIdentifier("Settings.ModelManagement.Recommended.\(isPrimary ? "primary" : "alt")")
     }
@@ -741,12 +716,16 @@ struct SettingsModelManagementPanel: View {
             visibleCount: entries.count,
             totalCount: kindEntries.count
         )
-        VStack(alignment: .leading, spacing: 9) {
+        VStack(alignment: .leading, spacing: RapidTheme.Space.sm) {
             ModelsTableHeading(heading: heading)
             // The meter legend + Quality·Speed column belong to CHAT rows only
             // — image models have no tok/s benchmark, so their tab shows a
-            // leaner row (name · repo · size · download).
-            if capability == .chat {
+            // leaner row (name · repo · size · download). They also need
+            // room: under ``compactContentWidth`` the 158pt meters column
+            // squeezes the model name to nothing, so the meters stand down
+            // and the name keeps the width. Nothing actionable is hidden —
+            // the meters are read-only.
+            if capability == .chat && showsMeters {
                 meterLegend
                 columnHeader
             }
@@ -755,9 +734,9 @@ struct SettingsModelManagementPanel: View {
                 ModelCacheActions.aggregateOnDiskBytes(kindEntries)
             ) {
                 Text(footer)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .padding(.top, 2)
+                    .font(RapidFont.caption)
+                    .foregroundStyle(RapidTheme.textSecondary)
+                    .padding(.top, RapidTheme.Space.xxs)
                     .accessibilityIdentifier("Settings.ModelManagement.Footer")
             }
         }
@@ -772,25 +751,24 @@ struct SettingsModelManagementPanel: View {
     @ViewBuilder
     private var meterLegend: some View {
         Text("Quality = published benchmark, labelled per row (Accuracy / Code / Tool / Instructions) · Speed = measured tokens/sec on this class of Mac · Untested = no compatible result recorded yet.")
-            .scaledSystemFont(10)
-            .foregroundStyle(.tertiary)
+            .font(RapidFont.caption)
+            .foregroundStyle(RapidTheme.textTertiary)
             .fixedSize(horizontal: false, vertical: true)
             .accessibilityIdentifier("Settings.ModelManagement.MeterLegend")
     }
 
     @ViewBuilder
     private var columnHeader: some View {
-        HStack(spacing: 10) {
+        HStack(spacing: RapidTheme.Space.sm) {
             Spacer().frame(width: 15)
             Spacer().frame(width: 30)
             Text("Model").frame(maxWidth: .infinity, alignment: .leading)
-            Text("Quality · Speed").frame(width: 158, alignment: .leading)
+            Text("Quality · Speed").frame(width: ModelTableLayout.metersColumnWidth, alignment: .leading)
             Text("Size").frame(width: ModelTableLayout.sizeColumnWidth, alignment: .trailing)
         }
-        .scaledSystemFont(10, weight: .semibold)
-        .foregroundStyle(.tertiary)
-        .textCase(.uppercase)
-        .padding(.horizontal, 14)
+        .font(RapidFont.groupLabel)
+        .foregroundStyle(RapidTheme.textTertiary)
+        .padding(.horizontal, RapidTheme.Space.lg)
     }
 
     // MARK: - Shared meters
@@ -875,7 +853,7 @@ struct SettingsModelManagementPanel: View {
         } label: {
             Image(systemName: isFav ? "star.fill" : "star")
                 .font(.system(size: 13))
-                .foregroundStyle(isFav ? RapidTheme.amber : Color.secondary.opacity(0.45))
+                .foregroundStyle(isFav ? RapidTheme.brandPrimaryDeep : RapidTheme.textTertiary)
         }
         .buttonStyle(.plain)
         .frame(width: 15)
@@ -894,9 +872,9 @@ struct SettingsModelManagementPanel: View {
     @ViewBuilder
     private func rowBadge(for alias: String) -> some View {
         if let badge = recommendedBadgeByAlias[alias] {
-            badgePill(badge, color: RapidTheme.brand)
+            badgePill(badge, color: RapidTheme.brandPrimaryDeep)
         } else if ModelBrandStyle.modelType(forAlias: alias) == .vision {
-            badgePill("VISION", color: Self.visionColor)
+            badgePill("VISION", color: RapidTheme.textSecondary)
         }
         ForEach(ModelCacheActions.retentionBadges(
             alias: alias,
@@ -917,7 +895,11 @@ struct SettingsModelManagementPanel: View {
             .background(Capsule().fill(color.opacity(0.14)))
     }
 
-    private static let visionColor = Color(red: 0x8E / 255.0, green: 0x44 / 255.0, blue: 0xEF / 255.0)
+    // NOTE: a hard-coded purple ``visionColor`` used to live here. It was
+    // the only violet in the product and carried no meaning the palette
+    // owns — "this model takes images" is a capability, not a status — so
+    // the VISION pill now uses the neutral secondary text colour and is
+    // distinguished by its word, not by a unique hue.
 
     /// Right-hand "Size" column: cached → check + delete; serving →
     /// label; not-cached → size + download; downloading → cancel;
@@ -934,13 +916,13 @@ struct SettingsModelManagementPanel: View {
             // sort ordered the table by exactly that number.
             HStack(spacing: ModelTableLayout.cellSpacing) {
                 Image(systemName: "checkmark.circle.fill")
-                    .font(.caption)
-                    .foregroundStyle(RapidTheme.green)
+                    .font(RapidFont.caption)
+                    .foregroundStyle(RapidTheme.statusReady)
                     .accessibilityHidden(true)
                 if let size = Self.onDiskSizeLabel(entry) {
                     Text(size)
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
+                        .font(RapidFont.caption)
+                        .foregroundStyle(RapidTheme.textSecondary)
                         .lineLimit(1)
                         .minimumScaleFactor(ModelTableLayout.cellMinimumScaleFactor)
                         .help(
@@ -955,8 +937,8 @@ struct SettingsModelManagementPanel: View {
                     // and stop — substituting the alias-derived estimate
                     // here would quote a guess as a measurement.
                     Text("On disk")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
+                        .font(RapidFont.caption)
+                        .foregroundStyle(RapidTheme.textSecondary)
                         .lineLimit(1)
                         .minimumScaleFactor(ModelTableLayout.cellMinimumScaleFactor)
                 }
@@ -968,14 +950,18 @@ struct SettingsModelManagementPanel: View {
                 // not download it, so it is not ours to remove — same
                 // reasoning as the absent delete on a serving model below.
                 if !entry.isExternal {
-                    Button(role: .destructive) {
+                    // Destructive, and now visibly so: the shared quiet
+                    // icon button turns red under the pointer instead of
+                    // staying the same grey as the copy glyph beside it.
+                    QuietIconButton(
+                        symbol: "trash",
+                        label: "Delete \(entry.alias) from disk",
+                        help: "Delete from disk",
+                        tint: RapidTheme.statusError,
+                        size: RapidTheme.ControlHeight.mini
+                    ) {
                         pendingDeletion = entry
-                    } label: {
-                        Image(systemName: "trash").font(.system(size: 11))
                     }
-                    .buttonStyle(.plain)
-                    .foregroundStyle(.secondary)
-                    .accessibilityLabel("Delete \(entry.alias) from disk")
                     .accessibilityIdentifier("Settings.ModelManagement.Delete.\(entry.alias)")
                 }
             }
@@ -989,58 +975,58 @@ struct SettingsModelManagementPanel: View {
             HStack(spacing: ModelTableLayout.cellSpacing) {
                 if let size = Self.onDiskSizeLabel(entry) {
                     Text(size)
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
+                        .font(RapidFont.caption)
+                        .foregroundStyle(RapidTheme.textSecondary)
                         .lineLimit(1)
                         .minimumScaleFactor(ModelTableLayout.cellMinimumScaleFactor)
                         .help("Measured size on disk. Stop this model before deleting it.")
                         .accessibilityLabel("On disk, \(size)")
                 }
                 Text("Serving")
-                    .font(.caption.weight(.medium))
-                    .foregroundStyle(.secondary)
+                    .font(RapidFont.caption)
+                    .foregroundStyle(RapidTheme.statusReady)
                     .lineLimit(1)
                     .minimumScaleFactor(ModelTableLayout.cellMinimumScaleFactor)
-                Button(role: .destructive) {
+                QuietIconButton(
+                    symbol: "trash",
+                    label: "Stop serving and delete \(entry.alias) from disk",
+                    help: "Stop serving and delete this model from disk.",
+                    tint: RapidTheme.statusError,
+                    size: RapidTheme.ControlHeight.mini
+                ) {
                     pendingDeletion = entry
-                } label: {
-                    Image(systemName: "trash").font(.system(size: 11))
                 }
-                .buttonStyle(.plain)
-                .foregroundStyle(.secondary)
-                .help("Stop serving and delete this model from disk.")
-                .accessibilityLabel("Stop serving and delete \(entry.alias) from disk")
                 .accessibilityIdentifier("Settings.ModelManagement.Delete.\(entry.alias)")
             }
         case .notCached:
             HStack(spacing: 8) {
                 if let gb = Self.downloadSizeLabel(entry.alias) {
                     Text("~\(gb)")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
+                        .font(RapidFont.caption)
+                        .foregroundStyle(RapidTheme.textSecondary)
                         .lineLimit(1)
                         .minimumScaleFactor(ModelTableLayout.cellMinimumScaleFactor)
                         .help("Estimated download size.")
                         .accessibilityLabel("Estimated download, about \(gb)")
                 }
-                Button {
+                QuietIconButton(
+                    symbol: "arrow.down.circle",
+                    label: "Download \(entry.alias)",
+                    help: "Download",
+                    size: RapidTheme.ControlHeight.mini,
+                    symbolSize: 14
+                ) {
                     _ = downloads.startDownload(alias: entry.alias, hfPath: entry.hfRepo)
-                } label: {
-                    Image(systemName: "arrow.down.circle").font(.system(size: 15))
                 }
-                .buttonStyle(.plain)
-                .foregroundStyle(RapidTheme.brand)
-                .accessibilityLabel("Download \(entry.alias)")
                 .accessibilityIdentifier("Settings.ModelManagement.Download.\(entry.alias)")
             }
         case .downloading(let pct):
             Button {
                 downloads.cancelDownload(alias: entry.alias)
             } label: {
-                Text(pct.map { "\($0)%" } ?? "Cancel").font(.caption)
+                Text(pct.map { "\($0)%" } ?? "Cancel")
             }
-            .buttonStyle(.bordered)
-            .controlSize(.small)
+            .buttonStyle(.rapidSecondaryCompact)
             .help("Cancel download")
             .accessibilityLabel(pct.map { "Cancel download, \($0) percent" } ?? "Cancel download")
             .accessibilityIdentifier("Settings.ModelManagement.Cancel.\(entry.alias)")
@@ -1049,10 +1035,9 @@ struct SettingsModelManagementPanel: View {
                 downloads.dismissJob(alias: entry.alias)
                 _ = downloads.startDownload(alias: entry.alias, hfPath: entry.hfRepo)
             } label: {
-                Text("Retry").font(.caption)
+                Text("Retry")
             }
-            .buttonStyle(.bordered)
-            .controlSize(.small)
+            .buttonStyle(.rapidSecondaryCompact)
             .accessibilityIdentifier("Settings.ModelManagement.Retry.\(entry.alias)")
         }
     }
@@ -1066,6 +1051,13 @@ struct SettingsModelManagementPanel: View {
         return ModelFavorites.favoritesFirst(sorted, favorites: favorites)
     }
 
+    /// Whether the Quality·Speed meters column has the room to render.
+    ///
+    /// Read-only decoration, so it is the correct thing to drop when the
+    /// column gets narrow — every ACTION in the row (download, cancel,
+    /// retry, delete) stays reachable at every supported window size.
+    private var showsMeters: Bool { !isCompact }
+
     /// Kinds that actually have models to manage — the tab bar only offers
     /// these (Video stays hidden until the video lane surfaces aliases).
     private var availableKinds: [ModelKind] {
@@ -1076,9 +1068,10 @@ struct SettingsModelManagementPanel: View {
     private func listSection(_ entries: [ModelEntry]) -> some View {
         if entries.isEmpty {
             Text(noMatchesCopy)
-                .font(.callout)
-                .foregroundStyle(.secondary)
-                .padding(.vertical, 12)
+                .font(RapidFont.body)
+                .foregroundStyle(RapidTheme.textSecondary)
+                .fixedSize(horizontal: false, vertical: true)
+                .padding(.vertical, RapidTheme.Space.md)
         } else {
             VStack(alignment: .leading, spacing: 0) {
                 ForEach(Array(entries.enumerated()), id: \.element.alias) { idx, entry in
@@ -1088,21 +1081,14 @@ struct SettingsModelManagementPanel: View {
                         capabilityRow(for: entry)
                     }
                     if idx < entries.count - 1 {
-                        Divider().opacity(0.5)
+                        Rectangle()
+                            .fill(RapidTheme.hairline)
+                            .frame(height: 1)
+                            .accessibilityHidden(true)
                     }
                 }
             }
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.horizontal, 14)
-            .padding(.vertical, 6)
-            .background(
-                RoundedRectangle(cornerRadius: RapidTheme.cardRadius, style: .continuous)
-                    .fill(RapidTheme.card)
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: RapidTheme.cardRadius, style: .continuous)
-                    .stroke(RapidTheme.hairline, lineWidth: 1)
-            )
+            .settingsGroupedCard()
         }
     }
 
@@ -1127,29 +1113,33 @@ struct SettingsModelManagementPanel: View {
             downloadJob: downloads.jobs[entry.alias],
             servingAlias: server.servingAlias
         )
-        HStack(spacing: 10) {
+        HStack(spacing: RapidTheme.Space.sm) {
             favoriteStar(entry.alias)
             BrandIcon(alias: entry.alias)
-            VStack(alignment: .leading, spacing: 2) {
-                HStack(spacing: 7) {
+            VStack(alignment: .leading, spacing: RapidTheme.Space.xxs) {
+                HStack(spacing: RapidTheme.Space.xs) {
                     Text(entry.alias)
-                        .font(.body.weight(.medium))
+                        .font(RapidFont.bodyEmphasis)
+                        .foregroundStyle(RapidTheme.textPrimary)
                         .lineLimit(1)
                         .truncationMode(.middle)
                     rowBadge(for: entry.alias)
                 }
                 Text(rowMeta(entry.alias))
-                    .font(.caption2)
-                    .foregroundStyle(.tertiary)
+                    .font(RapidFont.caption)
+                    .foregroundStyle(RapidTheme.textTertiary)
                     .lineLimit(1)
+                    .truncationMode(.tail)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
-            metersView(alias: entry.alias)
-                .frame(width: 158)
+            if showsMeters {
+                metersView(alias: entry.alias)
+                    .frame(width: ModelTableLayout.metersColumnWidth)
+            }
             sizeAction(entry: entry, badge: badge)
                 .frame(width: ModelTableLayout.sizeColumnWidth, alignment: .trailing)
         }
-        .padding(.vertical, 8)
+        .padding(.vertical, RapidTheme.Space.md)
         .accessibilityElement(children: .contain)
         .accessibilityIdentifier("Settings.ModelManagement.Row.\(entry.alias)")
     }
@@ -1163,22 +1153,23 @@ struct SettingsModelManagementPanel: View {
             downloadJob: downloads.jobs[entry.alias],
             servingAlias: server.servingAlias
         )
-        HStack(spacing: 10) {
+        HStack(spacing: RapidTheme.Space.sm) {
             BrandIcon(alias: entry.alias)
-            VStack(alignment: .leading, spacing: 2) {
+            VStack(alignment: .leading, spacing: RapidTheme.Space.xxs) {
                 Text(entry.alias)
-                    .font(.body.weight(.medium))
+                    .font(RapidFont.bodyEmphasis)
+                    .foregroundStyle(RapidTheme.textPrimary)
                     .lineLimit(1)
                     .truncationMode(.middle)
                 if entry.kind == .audio, let audioCapability = entry.audioCapability {
                     Text(audioCapabilityLabel(audioCapability))
-                        .font(.caption2.weight(.medium))
-                        .foregroundStyle(.secondary)
+                        .font(RapidFont.caption)
+                        .foregroundStyle(RapidTheme.textSecondary)
                 }
                 if let repo = entry.hfRepo {
                     Text(repo)
-                        .font(.caption2)
-                        .foregroundStyle(.tertiary)
+                        .font(RapidFont.caption)
+                        .foregroundStyle(RapidTheme.textTertiary)
                         .lineLimit(1)
                         .truncationMode(.middle)
                 }
@@ -1187,7 +1178,7 @@ struct SettingsModelManagementPanel: View {
             sizeAction(entry: entry, badge: badge)
                 .frame(width: ModelTableLayout.sizeColumnWidth, alignment: .trailing)
         }
-        .padding(.vertical, 8)
+        .padding(.vertical, RapidTheme.Space.md)
         .accessibilityElement(children: .contain)
         .accessibilityIdentifier("Settings.ModelManagement.Row.\(entry.alias)")
     }
@@ -1206,11 +1197,11 @@ struct SettingsModelManagementPanel: View {
     private func statusBadgeView(_ badge: ModelCacheActions.StatusBadge) -> some View {
         switch badge {
         case .cached:
-            pill(text: "On disk", color: RapidTheme.green)
+            pill(text: "On disk", color: RapidTheme.statusReady)
         case .inUse:
-            pill(text: "In use", color: RapidTheme.green)
+            pill(text: "In use", color: RapidTheme.statusReady)
         case .notCached:
-            pill(text: "Not cached", color: .secondary)
+            pill(text: "Not cached", color: RapidTheme.statusIdle)
         case .downloading(let pct):
             let label: String = {
                 if let pct {
@@ -1218,16 +1209,16 @@ struct SettingsModelManagementPanel: View {
                 }
                 return "Downloading…"
             }()
-            pill(text: label, color: RapidTheme.brand)
+            pill(text: label, color: RapidTheme.statusWorking)
         case .failed:
-            pill(text: "Failed", color: .red)
+            pill(text: "Failed", color: RapidTheme.statusError)
         }
     }
 
     @ViewBuilder
     private func pill(text: String, color: Color) -> some View {
         Text(text)
-            .font(.caption.weight(.medium))
+            .font(RapidFont.caption)
             .foregroundStyle(color)
             .padding(.horizontal, 8)
             .padding(.vertical, 3)
@@ -1236,6 +1227,7 @@ struct SettingsModelManagementPanel: View {
                     .fill(color.opacity(0.15))
             )
             .lineLimit(1)
+            .fixedSize()
             .accessibilityIdentifier("Settings.ModelManagement.Status.\(text)")
     }
 
@@ -1254,20 +1246,19 @@ struct SettingsModelManagementPanel: View {
                 // it came from instead of offering a delete that cannot
                 // reach it.
                 Text("External")
-                    .font(.caption.weight(.medium))
-                    .foregroundStyle(.secondary)
+                    .font(RapidFont.caption)
+                    .foregroundStyle(RapidTheme.textSecondary)
                     .help("Found outside Rapid's models folder. Rapid didn't download it, so it can't remove it.")
                     .accessibilityIdentifier(
                         "Settings.ModelManagement.Recommended.External.\(entry.alias)"
                     )
             } else {
-                Button(role: .destructive) {
+                Button {
                     pendingDeletion = entry
                 } label: {
                     Text("Delete")
                 }
-                .buttonStyle(.bordered)
-                .controlSize(.small)
+                .buttonStyle(.rapidDestructiveCompact)
                 .accessibilityIdentifier("Settings.ModelManagement.Recommended.Delete.\(entry.alias)")
             }
         case .inUse:
@@ -1275,16 +1266,15 @@ struct SettingsModelManagementPanel: View {
             // either fail or corrupt inference. Mirror the picker's
             // "currently-serving rows are off-limits" rule.
             Text("Serving")
-                .font(.caption.weight(.medium))
-                .foregroundStyle(.secondary)
+                .font(RapidFont.caption)
+                .foregroundStyle(RapidTheme.statusReady)
         case .notCached:
             Button {
                 _ = downloads.startDownload(alias: entry.alias, hfPath: entry.hfRepo)
             } label: {
                 Text("Download")
             }
-            .buttonStyle(.borderedProminent)
-            .controlSize(.small)
+            .buttonStyle(.rapidPrimaryCompact)
             .accessibilityIdentifier("Settings.ModelManagement.Recommended.Download.\(entry.alias)")
         case .downloading:
             Button {
@@ -1292,8 +1282,7 @@ struct SettingsModelManagementPanel: View {
             } label: {
                 Text("Cancel")
             }
-            .buttonStyle(.bordered)
-            .controlSize(.small)
+            .buttonStyle(.rapidSecondaryCompact)
             .accessibilityIdentifier("Settings.ModelManagement.Recommended.Cancel.\(entry.alias)")
         case .failed:
             Button {
@@ -1302,8 +1291,7 @@ struct SettingsModelManagementPanel: View {
             } label: {
                 Text("Retry")
             }
-            .buttonStyle(.bordered)
-            .controlSize(.small)
+            .buttonStyle(.rapidSecondaryCompact)
             .accessibilityIdentifier("Settings.ModelManagement.Recommended.Retry.\(entry.alias)")
         }
     }
@@ -1312,64 +1300,31 @@ struct SettingsModelManagementPanel: View {
 
     @ViewBuilder
     private var loadingState: some View {
-        HStack(spacing: 10) {
+        HStack(spacing: RapidTheme.Space.sm) {
             ProgressView().controlSize(.small)
             Text("Loading model catalog…")
-                .font(.callout)
-                .foregroundStyle(.secondary)
+                .font(RapidFont.body)
+                .foregroundStyle(RapidTheme.textSecondary)
         }
-        .padding(.vertical, 12)
+        .padding(.vertical, RapidTheme.Space.md)
     }
 
     @ViewBuilder
     private var emptyState: some View {
         Text("Couldn't load the model list. Restart Rapid-MLX to try again.")
-            .font(.callout)
-            .foregroundStyle(.secondary)
-            .padding(.vertical, 12)
+            .font(RapidFont.body)
+            .foregroundStyle(RapidTheme.textSecondary)
+            .fixedSize(horizontal: false, vertical: true)
+            .padding(.vertical, RapidTheme.Space.md)
     }
 
-    @ViewBuilder
-    private func errorBanner(_ message: String) -> some View {
-        HStack(alignment: .top, spacing: 8) {
-            Image(systemName: "exclamationmark.triangle.fill")
-                .foregroundStyle(.red)
-            Text(message)
-                .font(.callout)
-                .foregroundStyle(.red)
-                .fixedSize(horizontal: false, vertical: true)
-            Spacer()
-            Button("Dismiss") { lastError = nil }
-                .buttonStyle(.plain)
-                .font(.caption)
-        }
-        .padding(10)
-        .background(
-            RoundedRectangle(cornerRadius: 8, style: .continuous)
-                .fill(Color.red.opacity(0.08))
-        )
-    }
-
-    @ViewBuilder
-    private func freedBanner(_ message: String) -> some View {
-        HStack(alignment: .top, spacing: 8) {
-            Image(systemName: "checkmark.seal.fill")
-                .foregroundStyle(RapidTheme.green)
-            Text(message)
-                .font(.callout)
-                .foregroundStyle(RapidTheme.green)
-                .fixedSize(horizontal: false, vertical: true)
-            Spacer()
-            Button("Dismiss") { lastFreed = nil }
-                .buttonStyle(.plain)
-                .font(.caption)
-        }
-        .padding(10)
-        .background(
-            RoundedRectangle(cornerRadius: 8, style: .continuous)
-                .fill(RapidTheme.green.opacity(0.08))
-        )
-    }
+    // NOTE: local ``errorBanner(_:)`` and ``freedBanner(_:)`` builders
+    // lived here. Each drew its own rounded rectangle out of
+    // `Color.red.opacity(0.08)` / `RapidTheme.green.opacity(0.08)` at a
+    // local 8pt radius, with its own Dismiss button — two more banner
+    // styles on a window that already had three. Both call sites now use
+    // ``InlineNotice`` with the `.error` / `.success` tones, which own
+    // the same job for every surface in the app.
 
     // MARK: - Job reconciliation
 
@@ -1534,14 +1489,14 @@ struct ModelsTableHeading: View {
     let heading: ModelCacheActions.ListHeading
 
     var body: some View {
-        HStack(spacing: 6) {
-            Text(heading.title).font(.caption.weight(.semibold)).textCase(.uppercase)
+        HStack(spacing: RapidTheme.Space.xs) {
+            Text(heading.title).font(RapidFont.groupLabel)
             Text("· \(heading.countText)")
-                .font(.caption)
-                .foregroundStyle(.tertiary)
+                .font(RapidFont.caption)
+                .foregroundStyle(RapidTheme.textTertiary)
                 .accessibilityIdentifier("Settings.ModelManagement.VisibleCount")
         }
-        .foregroundStyle(.secondary)
+        .foregroundStyle(RapidTheme.textSecondary)
         .accessibilityElement(children: .combine)
         .accessibilityLabel(heading.accessibilityLabel)
     }
@@ -1629,6 +1584,37 @@ enum RecommendedCardLayout {
 enum ModelTableLayout {
     /// Shared width of the Size column.
     static let sizeColumnWidth: CGFloat = 124
+
+    /// Shared width of the Quality·Speed meters column.
+    ///
+    /// Was a bare `158` repeated in the row and again in the column
+    /// header — two literals that had to agree for the table not to go
+    /// ragged, with nothing enforcing it.
+    static let metersColumnWidth: CGFloat = 158
+
+    /// Leading chrome in a chat row before the model name: the favourite
+    /// star, the brand icon, and the three gaps between the four columns.
+    static let rowLeadingChromeWidth: CGFloat = 15 + 30 + RapidTheme.Space.sm * 3
+
+    /// Everything a chat row commits to before the flexible model-name
+    /// column gets a single point.
+    ///
+    /// Pure so ``SettingsResponsiveLayoutTests`` can assert the row still
+    /// leaves a readable name at every supported window size, instead of
+    /// that assertion living only in a screenshot somebody has to
+    /// remember to take.
+    static func committedRowWidth(showsMeters: Bool) -> CGFloat {
+        rowLeadingChromeWidth
+            + (showsMeters ? metersColumnWidth + RapidTheme.Space.sm : 0)
+            + sizeColumnWidth
+            // the grouped card's own horizontal inset, both edges
+            + RapidTheme.Space.lg * 2
+    }
+
+    /// The narrowest model name we are willing to render before calling
+    /// the layout broken. Roughly 14 characters at 13pt — enough for
+    /// `qwen3.5-9b-4bit` to read with a middle truncation.
+    static let minimumNameWidth: CGFloat = 120
 
     /// Spacing between the glyph, the figure and the button in a cell.
     static let cellSpacing: CGFloat = 6

--- a/apps/rapid-mac/Sources/Rapid/UI/SettingsToolsPanel.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SettingsToolsPanel.swift
@@ -22,9 +22,26 @@ struct SettingsToolsPanel: View {
     @State private var keyDraftEdited: Bool = false
     @State private var saveFeedback: SettingsView.WebSearchKeySaveFeedback?
     @State private var feedbackGeneration: Int = 0
+    /// Which tool rows have their technical detail open. Session state:
+    /// a disclosure is a reading aid, not a preference, so it
+    /// deliberately does not persist.
+    @State private var expandedTools: Set<String>
+
+    /// - Parameter initiallyExpanded: seam for the dev snapshot harness,
+    ///   which has to capture the disclosure OPEN and cannot drive
+    ///   private `@State` from outside. Production always uses the
+    ///   default (all rows collapsed).
+    init(initiallyExpanded: Set<String> = []) {
+        _expandedTools = State(initialValue: initiallyExpanded)
+    }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 20) {
+        VStack(alignment: .leading, spacing: RapidTheme.Space.xl) {
+            SectionHeader(
+                "Tools",
+                subtitle: "Tools the model can call during a chat. Turn one off and it is never offered — and never runs, even if the model asks for it by name.",
+                emphasis: .page
+            )
             toolsSection
             webSearchSection
             browseSection
@@ -40,40 +57,165 @@ struct SettingsToolsPanel: View {
     // MARK: - Available tools
 
     private var toolsSection: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            header(
-                "Tools",
-                "Tools the model can call during a chat. Turn one off and it is never offered — and never runs, even if the model asks for it by name."
-            )
-            card {
-                VStack(alignment: .leading, spacing: 12) {
-                    ForEach(chat.builtinDefinitions, id: \.function.name) { def in
-                        Toggle(isOn: toolBinding(def.function.name)) {
-                            HStack(alignment: .top, spacing: 10) {
-                                Image(systemName: Self.glyph(for: def.function.name))
-                                    .foregroundStyle(RapidTheme.brand)
-                                    .frame(width: 18)
-                                VStack(alignment: .leading, spacing: 2) {
-                                    Text(def.function.name)
-                                        .font(.system(size: 12, weight: .medium, design: .monospaced))
-                                    Text(def.function.description)
-                                        .font(.caption)
-                                        .foregroundStyle(.secondary)
-                                        .fixedSize(horizontal: false, vertical: true)
-                                }
-                            }
-                        }
-                        .toggleStyle(TrailingSettingsToggleStyle())
-                        .accessibilityLabel(Self.voiceOverLabel(for: def.function.name))
-                        .accessibilityHint(def.function.description)
-                        // Keyed on the TOOL NAME (the wire identifier the
-                        // engine and the request body use), not on the row's
-                        // display text — the label is the tool's own
-                        // description and would drift with copy edits.
-                        .accessibilityIdentifier("Settings.Tools.Toggle.\(def.function.name)")
-                    }
+        SettingsSection("Available tools") {
+            let definitions = chat.builtinDefinitions
+            ForEach(Array(definitions.enumerated()), id: \.element.function.name) { index, def in
+                if index > 0 { SettingsRowDivider() }
+                toolRow(def)
+            }
+        }
+    }
+
+    /// One built-in tool.
+    ///
+    /// The row leads with a HUMAN name, not the wire identifier. Before
+    /// this it was headed `web_search` in a monospaced face — an
+    /// implementation detail presented as a title — followed by the
+    /// model-facing prompt text, which runs to seven lines for `browse`
+    /// and reads as documentation rather than as a setting.
+    ///
+    /// So: a display name, a one-line summary of what turning it off
+    /// costs, and the full engine-facing description behind a
+    /// disclosure. Nothing is deleted — the technical text is exactly
+    /// the string the model receives, and the wire identifier is shown
+    /// alongside it, because a user debugging a prompt needs both.
+    @ViewBuilder
+    private func toolRow(_ def: ToolDefinition) -> some View {
+        let name = def.function.name
+        let isExpanded = expandedTools.contains(name)
+        VStack(alignment: .leading, spacing: RapidTheme.Space.sm) {
+            Toggle(isOn: toolBinding(name)) {
+                HStack(alignment: .top, spacing: RapidTheme.Space.sm) {
+                    Image(systemName: Self.glyph(for: name))
+                        // Utility glyph, not a call to action: neutral,
+                        // where it used to be one of the app's most
+                        // repeated steel-blue accents.
+                        .symbolRenderingMode(.monochrome)
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundStyle(RapidTheme.utilityActionLabel)
+                        .frame(width: RapidTheme.Layout.iconSlot)
+                        .accessibilityHidden(true)
+                    SettingsRowLabel(
+                        title: Self.displayName(for: name),
+                        description: Self.summary(for: name, fallback: def.function.description)
+                    )
                 }
             }
+            .toggleStyle(TrailingSettingsToggleStyle())
+            // Keyed on the TOOL NAME (the wire identifier the
+            // engine and the request body use), not on the row's
+            // display text — the label is the tool's own
+            // description and would drift with copy edits.
+            // Upstream (#1822) gave every tool toggle a spoken name and a
+            // hint; both are preserved verbatim through the UI-1
+            // migration. ``voiceOverLabel`` stays its own function rather
+            // than being folded into ``displayName``: they are separate
+            // strings upstream, and quietly re-capitalising a VoiceOver
+            // label is not this PR's call to make.
+            .accessibilityLabel(Self.voiceOverLabel(for: def.function.name))
+            .accessibilityHint(def.function.description)
+            // Spelled with `def.function.name` rather than the local
+            // `name` binding: identical at runtime, but
+            // ``AccessibilityIdentifierInventoryTests`` pins the source
+            // SHAPE so a future edit cannot quietly swap the per-item
+            // key for display text.
+            .accessibilityIdentifier("Settings.Tools.Toggle.\(def.function.name)")
+
+            disclosure(for: def, isExpanded: isExpanded)
+                // Indent to the text column so the disclosure lines up
+                // under the summary it expands, not under the glyph.
+                .padding(.leading, RapidTheme.Layout.iconSlot + RapidTheme.Space.sm)
+        }
+    }
+
+    /// The "Details" disclosure: a compact chevron affordance, and the
+    /// engine-facing text when open.
+    @ViewBuilder
+    private func disclosure(for def: ToolDefinition, isExpanded: Bool) -> some View {
+        let name = def.function.name
+        VStack(alignment: .leading, spacing: RapidTheme.Space.sm) {
+            Button {
+                if isExpanded {
+                    expandedTools.remove(name)
+                } else {
+                    expandedTools.insert(name)
+                }
+            } label: {
+                HStack(spacing: RapidTheme.Space.xs) {
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: 9, weight: .semibold))
+                        .rotationEffect(.degrees(isExpanded ? 90 : 0))
+                    Text("Details")
+                        .font(RapidFont.caption)
+                }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(RapidTheme.utilityActionLabel)
+            .rapidAnimation(RapidMotion.quick, value: isExpanded)
+            .accessibilityLabel("Details for \(Self.displayName(for: name))")
+            .accessibilityAddTraits(isExpanded ? [.isButton, .isSelected] : .isButton)
+            .accessibilityHint(isExpanded ? "Collapse" : "Expand")
+            .accessibilityIdentifier("Settings.Tools.Details.\(name)")
+
+            if isExpanded {
+                VStack(alignment: .leading, spacing: RapidTheme.Space.xs) {
+                    Text(def.function.description)
+                        .font(RapidFont.caption)
+                        .foregroundStyle(RapidTheme.textSecondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                    // The wire identifier, where a user debugging a
+                    // prompt can still find it — just not as the title.
+                    Text(name)
+                        .font(RapidFont.code)
+                        .foregroundStyle(RapidTheme.textTertiary)
+                        .textSelection(.enabled)
+                }
+                .padding(RapidTheme.Space.md)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(
+                    RoundedRectangle(cornerRadius: RapidTheme.Radius.code, style: .continuous)
+                        .fill(RapidTheme.surfaceCode)
+                )
+                .accessibilityIdentifier("Settings.Tools.DetailsBody.\(name)")
+            }
+        }
+    }
+
+    // MARK: - Presentation of tool identity
+    //
+    // Display names and summaries are PRESENTATION ONLY. The wire
+    // identifiers (`web_search`, `browse`, `weather`) are what the
+    // registry, the request body, the disabled-tool set, the dispatch
+    // guard and every accessibility identifier still use — none of that
+    // is touched by anything below.
+
+
+    /// Human name for a built-in tool. Falls back to the raw identifier
+    /// so a tool added to the registry without an entry here still shows
+    /// something true rather than nothing.
+    static func displayName(for toolName: String) -> String {
+        switch toolName {
+        case "web_search": return "Web Search"
+        case "browse":     return "Browse Web Page"
+        case "weather":    return "Weather"
+        default:           return toolName
+        }
+    }
+
+    /// One line on what the tool does, in the user's terms. The engine's
+    /// own description is written FOR THE MODEL — it carries pagination
+    /// offsets and calling conventions — so it stays in the disclosure.
+    static func summary(for toolName: String, fallback: String) -> String {
+        switch toolName {
+        case "web_search":
+            return "Looks up current information on the web when a question needs it."
+        case "browse":
+            return "Opens a web page you or the model names and reads it. You approve each page."
+        case "weather":
+            return "Gets the current weather for a place you name."
+        default:
+            return fallback
         }
     }
 
@@ -97,16 +239,30 @@ struct SettingsToolsPanel: View {
 
     private var webSearchSection: some View {
         @Bindable var config = webSearch
-        return VStack(alignment: .leading, spacing: 8) {
-            header(
-                "Web search",
-                "Which backend `web_search` queries. DuckDuckGo needs no account but is rate-limited; the keyed backends are more reliable."
-            )
-            card {
-                VStack(alignment: .leading, spacing: 14) {
+        return SettingsSection(
+            "Web search",
+            subtitle: "Which backend `web_search` queries. DuckDuckGo needs no account but is rate-limited; the keyed backends are more reliable."
+        ) {
+                VStack(alignment: .leading, spacing: RapidTheme.Space.md) {
+                    // Native macOS radio group, kept native: radios are
+                    // exactly the control class the platform should own,
+                    // and rebuilding one would cost the arrow-key group
+                    // navigation SwiftUI gives for free.
+                    //
+                    // Three things ARE ours: the body type (it defaulted
+                    // to the system size, which read a step larger than
+                    // every other choice in Settings), `.controlSize`
+                    // (the radios rendered at the regular size, notably
+                    // bigger than the compact switches beside them), and
+                    // `.tint(nil)` so the selected dot uses the system
+                    // control accent instead of inheriting brand amber —
+                    // amber is the SELECTION colour for rows and
+                    // segments, and putting it inside a radio too made
+                    // three different amber affordances on one card.
                     Picker("Backend", selection: $config.provider) {
                         ForEach(WebSearchProvider.allCases) { provider in
                             Text(provider.displayName)
+                                .font(RapidFont.body)
                                 .tag(provider)
                                 // Per-radio identifier keyed on the provider's
                                 // stable raw value (duckduckgo / brave /
@@ -119,36 +275,44 @@ struct SettingsToolsPanel: View {
                     }
                     .pickerStyle(.radioGroup)
                     .labelsHidden()
+                    .controlSize(.small)
+                    .tint(nil)
                     .accessibilityIdentifier("Settings.Tools.WebSearch.Backend")
                     .onChange(of: config.provider) { _, _ in
                         resetKeyDraft()
                     }
 
                     Text(config.provider.subtitle)
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
+                        .font(RapidFont.caption)
+                        .foregroundStyle(RapidTheme.textSecondary)
                         .fixedSize(horizontal: false, vertical: true)
 
                     if config.provider.requiresKey {
+                        SettingsRowDivider()
                         keyField(for: config.provider)
                     }
                 }
-            }
         }
     }
 
     @ViewBuilder
     private func keyField(for provider: WebSearchProvider) -> some View {
-        VStack(alignment: .leading, spacing: 6) {
-            HStack(spacing: 8) {
+        VStack(alignment: .leading, spacing: RapidTheme.Space.sm) {
+            HStack(spacing: RapidTheme.Space.sm) {
                 SecureField("API key", text: $keyDraft)
+                    // Native field, shared metrics: a secure field is one
+                    // of the controls macOS should keep owning, so the
+                    // only thing standardised here is its height.
                     .textFieldStyle(.roundedBorder)
+                    .font(RapidFont.body)
+                    .frame(minHeight: RapidTheme.ControlHeight.small)
                     .onChange(of: keyDraft) { _, _ in keyDraftEdited = true }
                     .onSubmit { commitKey(for: provider) }
                     .accessibilityIdentifier(
                         "Settings.Tools.WebSearch.KeyField.\(provider.id)"
                     )
                 Button("Save") { commitKey(for: provider) }
+                    .buttonStyle(.rapidSecondaryCompact)
                     .disabled(!keyDraftEdited)
                     .accessibilityIdentifier(
                         "Settings.Tools.WebSearch.SaveKey.\(provider.id)"
@@ -156,7 +320,9 @@ struct SettingsToolsPanel: View {
             }
             if let url = provider.keyDashboardURL {
                 Link("Get a \(provider.displayName) key", destination: url)
-                    .font(.caption)
+                    .font(RapidFont.caption)
+                    // See the Privacy links: ``Link`` ignores the tint.
+                    .foregroundStyle(RapidTheme.linkLabel)
                     // Keyed on the provider, not the label: "Get a Brave key"
                     // is display copy and will be reworded.
                     .accessibilityIdentifier(
@@ -165,18 +331,26 @@ struct SettingsToolsPanel: View {
             }
             if let feedback = saveFeedback {
                 Text(Self.feedbackCopy(feedback))
-                    .font(.caption)
-                    .foregroundStyle(Self.isFailure(feedback) ? RapidTheme.statusError : .secondary)
+                    .font(RapidFont.caption)
+                    .foregroundStyle(
+                        Self.isFailure(feedback)
+                            ? RapidTheme.statusError
+                            : RapidTheme.textSecondary
+                    )
+                    .fixedSize(horizontal: false, vertical: true)
             } else if webSearch.cachedKeyState(for: provider).hasKey {
                 Text("A key is stored for \(provider.displayName).")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .font(RapidFont.caption)
+                    .foregroundStyle(RapidTheme.textSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
             } else {
                 Text("No key stored — searches fall back to DuckDuckGo until you save one.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .font(RapidFont.caption)
+                    .foregroundStyle(RapidTheme.textSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
             }
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
         .onAppear { resetKeyDraft() }
     }
 
@@ -229,27 +403,20 @@ struct SettingsToolsPanel: View {
     // MARK: - Browsing
 
     private var browseSection: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            header(
-                "Browsing",
-                "`browse` fetches a page and hands its text to the model. The model picks the URL, so by default you approve each destination first."
-            )
-            card {
-                Toggle(isOn: browseAutoApproveBinding) {
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text("Approve every page automatically")
-                            .font(.callout.weight(.medium))
-                        Text("Skips the confirmation for unattended use. Private and local addresses stay blocked either way.")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                            .fixedSize(horizontal: false, vertical: true)
-                    }
-                }
-                .toggleStyle(TrailingSettingsToggleStyle())
-                .accessibilityLabel("Approve every page automatically")
-                .accessibilityHint("Skips confirmation for public pages. Private and local addresses remain blocked.")
-                .accessibilityIdentifier("Settings.Tools.Browse.AutoApproveToggle")
+        SettingsSection(
+            "Browsing",
+            subtitle: "`browse` fetches a page and hands its text to the model. The model picks the URL, so by default you approve each destination first."
+        ) {
+            Toggle(isOn: browseAutoApproveBinding) {
+                SettingsRowLabel(
+                    title: "Approve every page automatically",
+                    description: "Skips the confirmation for unattended use. Private and local addresses stay blocked either way."
+                )
             }
+            .toggleStyle(TrailingSettingsToggleStyle())
+            .accessibilityLabel("Approve every page automatically")
+            .accessibilityHint("Skips confirmation for public pages. Private and local addresses remain blocked.")
+            .accessibilityIdentifier("Settings.Tools.Browse.AutoApproveToggle")
         }
     }
 
@@ -262,33 +429,9 @@ struct SettingsToolsPanel: View {
 
     // MARK: - Shared layout
 
-    @ViewBuilder
-    private func header(_ title: String, _ subtitle: String) -> some View {
-        VStack(alignment: .leading, spacing: 4) {
-            Text(title)
-                .font(.title3.weight(.semibold))
-            Text(subtitle)
-                .font(.callout)
-                .foregroundStyle(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
-        }
-    }
-
-    @ViewBuilder
-    private func card<Content: View>(@ViewBuilder _ content: () -> Content) -> some View {
-        content()
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(16)
-            .background(
-                RoundedRectangle(cornerRadius: RapidTheme.cardRadius, style: .continuous)
-                    .fill(RapidTheme.card)
-            )
-            .clipShape(RoundedRectangle(cornerRadius: RapidTheme.cardRadius, style: .continuous))
-            .overlay(
-                RoundedRectangle(cornerRadius: RapidTheme.cardRadius, style: .continuous)
-                    .stroke(RapidTheme.hairline, lineWidth: 1)
-            )
-    }
+    // NOTE: private ``header(_:_:)`` and ``card(_:)`` helpers lived here
+    // and were the second of four copies of the same pair. Both are now
+    // ``SectionHeader`` + ``SettingsSection``.
 
     static func glyph(for name: String) -> String {
         switch name {

--- a/apps/rapid-mac/Sources/Rapid/UI/SettingsView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SettingsView.swift
@@ -130,9 +130,7 @@ struct SettingsView: View {
                     Button {
                         selection.selected = cat
                     } label: {
-                        Label(cat.title, systemImage: cat.iconName)
-                            .frame(maxWidth: .infinity, minHeight: 30, alignment: .leading)
-                            .contentShape(Rectangle())
+                        categoryRowContent(cat, isSelected: selection.selected == cat)
                     }
                     .buttonStyle(.pressable)
                     .listRowBackground(
@@ -155,7 +153,8 @@ struct SettingsView: View {
                 }
             }
             .listStyle(.sidebar)
-            .frame(width: 200)
+            .frame(width: SettingsView.railWidth)
+            .background(RapidTheme.surfaceSidebar)
             .focusable()
             // #579: keep the rail keyboard-focusable for ↑/↓ nav but drop
             // the system focus ring that painted a blue box around the whole
@@ -174,23 +173,108 @@ struct SettingsView: View {
             }
         }
 
+        /// One rail row: glyph and title, both wearing the SAME colour.
+        ///
+        /// Deliberately an explicit `HStack`, not a `Label`. A `Label`
+        /// inside `List(.sidebar)` hands its icon to the list style,
+        /// which paints it with the sidebar's own item colour — so a
+        /// `.foregroundStyle` on the row reached the title and left the
+        /// glyph white. The selected row therefore read as an amber word
+        /// beside a white icon, which is not a state any other list in
+        /// the app produces.
+        ///
+        /// ``symbolRenderingMode(.monochrome)`` is the second half: some
+        /// of these glyphs (`paintpalette.fill` especially) have
+        /// multicolour variants that ignore a foreground style entirely
+        /// unless the rendering mode is pinned.
+        @ViewBuilder
+        private func categoryRowContent(_ cat: Category, isSelected: Bool) -> some View {
+            let tint = isSelected ? RapidTheme.brandPrimaryDeep : RapidTheme.textPrimary
+            HStack(spacing: RapidTheme.Space.sm) {
+                Image(systemName: cat.iconName)
+                    .symbolRenderingMode(.monochrome)
+                    .font(.system(size: 13, weight: .medium))
+                    .frame(width: RapidTheme.Layout.iconSlot, alignment: .center)
+                Text(cat.title)
+                    .font(RapidFont.body)
+                    .fontWeight(isSelected ? .semibold : .regular)
+                    // Reserve the selected weight so the row does not
+                    // reflow as the selection moves.
+                    .background(
+                        Text(cat.title)
+                            .font(RapidFont.body)
+                            .fontWeight(.semibold)
+                            .hidden()
+                    )
+                    .lineLimit(1)
+            }
+            .foregroundStyle(tint)
+            .frame(
+                maxWidth: .infinity,
+                minHeight: RapidTheme.ControlHeight.row,
+                alignment: .leading
+            )
+            .contentShape(Rectangle())
+        }
+
         @ViewBuilder
         private func categoryRowBackground(isSelected: Bool, isHovered: Bool) -> some View {
             if isSelected {
-                RoundedRectangle(cornerRadius: 7, style: .continuous)
-                    .fill(RapidTheme.brandTint)
-                    .padding(.horizontal, 6)
-                    .padding(.vertical, 3)
+                RoundedRectangle(cornerRadius: RapidTheme.Radius.row, style: .continuous)
+                    .fill(RapidTheme.brandPrimaryTint)
+                    .padding(.horizontal, RapidTheme.Space.xs)
+                    .padding(.vertical, RapidTheme.Space.xxs)
             } else if isHovered {
-                RoundedRectangle(cornerRadius: 7, style: .continuous)
-                    .fill(Color.primary.opacity(0.055))
-                    .padding(.horizontal, 6)
-                    .padding(.vertical, 3)
+                RoundedRectangle(cornerRadius: RapidTheme.Radius.row, style: .continuous)
+                    .fill(RapidTheme.hoverFill)
+                    .padding(.horizontal, RapidTheme.Space.xs)
+                    .padding(.vertical, RapidTheme.Space.xxs)
             } else {
                 Color.clear
             }
         }
     }
+
+    /// Width of the category rail. Fixed, like every macOS settings
+    /// sidebar — at the 720pt window floor this still leaves 519pt of
+    /// detail, which is more than the widest panel needs.
+    static let railWidth: CGFloat = 200
+
+    /// Width below which the detail column is "compact" and panels
+    /// should shed optional columns rather than clip them.
+    ///
+    /// Derived, not guessed: Model Management's table commits a 158pt
+    /// meters column plus a 124pt size column plus ~90pt of glyphs and
+    /// gaps before the model name gets a single point. Under ~520pt of
+    /// content the name is squeezed to nothing, so that is where the
+    /// meters have to go.
+    static let compactContentWidth: CGFloat = 520
+
+    /// The width a panel's content column actually gets inside a window
+    /// `windowWidth` points wide.
+    ///
+    /// Pure, and `static`, because the responsive contract is a claim
+    /// about arithmetic — "nothing this window commits to is wider than
+    /// the window" — and that claim should be checkable without
+    /// rendering anything. ``SettingsResponsiveLayoutTests`` walks the
+    /// supported sizes through this and the table's committed widths.
+    nonisolated static func contentColumnWidth(forWindowWidth windowWidth: CGFloat) -> CGFloat {
+        // rail + the 1pt divider between rail and detail
+        let detail = windowWidth - railWidth - 1
+        let available = detail - RapidTheme.Space.xl * 2
+        return max(0, min(available, RapidTheme.Layout.pageMaxWidth))
+    }
+
+    /// Whether a window that wide puts panels into their compact layout.
+    nonisolated static func isCompact(forWindowWidth windowWidth: CGFloat) -> Bool {
+        contentColumnWidth(forWindowWidth: windowWidth) < compactContentWidth
+    }
+
+    /// The narrowest window Settings supports. Paired with
+    /// ``minWindowHeight`` on the shell's `.frame(minWidth:minHeight:)`,
+    /// and re-used by the tests so the floor is stated once.
+    static let minWindowWidth: CGFloat = 720
+    static let minWindowHeight: CGFloat = 480
 
     private struct DetailCanvas<Content: View>: View {
         let selection: CategorySelection
@@ -206,13 +290,22 @@ struct SettingsView: View {
 
         var body: some View {
             let selected = selection.selected
-            ScrollView {
-                content(selected)
-                    .frame(maxWidth: 600, alignment: .leading)
-                    .padding(28)
-                    .frame(maxWidth: .infinity, alignment: .topLeading)
+            // The column reads its own width and publishes a compact
+            // flag, so a panel adapts to the space it actually has
+            // instead of to a guess about the window. Long pages scroll;
+            // nothing is solved by raising the window floor.
+            GeometryReader { proxy in
+                let available = proxy.size.width - RapidTheme.Space.xl * 2
+                let column = max(0, min(available, RapidTheme.Layout.pageMaxWidth))
+                ScrollView {
+                    content(selected)
+                        .frame(maxWidth: column, alignment: .leading)
+                        .padding(RapidTheme.Space.xl)
+                        .frame(maxWidth: .infinity, alignment: .topLeading)
+                }
+                .environment(\.settingsContentIsCompact, column < SettingsView.compactContentWidth)
             }
-            .background(RapidTheme.canvas)
+            .background(RapidTheme.surfaceCanvas)
         }
     }
 
@@ -287,7 +380,7 @@ struct SettingsView: View {
                 detailPanel(for: category)
             }
         }
-        .frame(minWidth: 720, minHeight: 480)
+        .frame(minWidth: Self.minWindowWidth, minHeight: Self.minWindowHeight)
         .safeAreaInset(edge: .top, spacing: 0) {
             if router.quickstartCatalogReturnPending {
                 VStack(spacing: 0) {
@@ -378,12 +471,13 @@ struct SettingsView: View {
     /// Light / Dark force the override and persist across launches.
     private var appearancePanel: some View {
         @Bindable var a = appearance
-        return VStack(alignment: .leading, spacing: 16) {
-            sectionHeader(
+        return VStack(alignment: .leading, spacing: RapidTheme.Space.xl) {
+            SectionHeader(
                 "Appearance",
-                "Override the system theme. Auto follows your macOS setting; Light and Dark force the app to stay there regardless of system changes."
+                subtitle: "Override the system theme. Auto follows your macOS setting; Light and Dark force the app to stay there regardless of system changes.",
+                emphasis: .page
             )
-            settingsCard {
+            SettingsSection {
                 Picker("Theme", selection: $a.mode) {
                     ForEach(AppearanceMode.allCases) { mode in
                         Text(mode.displayName)
@@ -400,25 +494,19 @@ struct SettingsView: View {
 
     @ViewBuilder
     private var privacyPanel: some View {
-        VStack(alignment: .leading, spacing: 18) {
-            VStack(alignment: .leading, spacing: 4) {
-                Text("Privacy")
-                    .font(.title2.weight(.semibold))
-                Text("Rapid-MLX is local-first. Prompts, attachments, and model responses never leave your Mac. Anonymous usage data is sent only after you opt in.")
-                    .font(.callout)
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
-            }
+        VStack(alignment: .leading, spacing: RapidTheme.Space.xl) {
+            SectionHeader(
+                "Privacy",
+                subtitle: "Rapid-MLX is local-first. Prompts, attachments, and model responses never leave your Mac. Anonymous usage data is sent only after you opt in.",
+                emphasis: .page
+            )
 
+            SettingsSection {
             Toggle(isOn: telemetryEnabledBinding) {
-                VStack(alignment: .leading, spacing: 2) {
-                    Text("Send anonymous usage data")
-                        .font(.callout.weight(.medium))
-                    Text("Versions, Mac hardware tier, public model and feature names, coarse performance, redacted crash diagnostics, and error categories. Never prompts, responses, attachments, keys, account details, or unredacted user paths.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .fixedSize(horizontal: false, vertical: true)
-                }
+                SettingsRowLabel(
+                    title: "Send anonymous usage data",
+                    description: "Versions, Mac hardware tier, public model and feature names, coarse performance, redacted crash diagnostics, and error categories. Never prompts, responses, attachments, keys, account details, or unredacted user paths."
+                )
             }
             .toggleStyle(TrailingSettingsToggleStyle())
             .accessibilityIdentifier("Settings.Privacy.TelemetryToggle")
@@ -444,13 +532,12 @@ struct SettingsView: View {
                 telemetryEnabled = TelemetryConfig.isEnabled
             }
 
-            VStack(alignment: .leading, spacing: 6) {
-                Text("Where the data goes")
-                    .font(.callout.weight(.medium))
-                Text("telemetry.rapidmlx.com — a Cloudflare Worker that strips client IPs before writing to storage. Source is open at github.com/raullenchai/rapidmlx.com under telemetry-worker/.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
+            SettingsRowDivider()
+
+            SettingsRowLabel(
+                title: "Where the data goes",
+                description: "telemetry.rapidmlx.com — a Cloudflare Worker that strips client IPs before writing to storage. Source is open at github.com/raullenchai/rapidmlx.com under telemetry-worker/."
+            )
             }
 
             // All three point at documents that exist in the repository. Two
@@ -467,7 +554,7 @@ struct SettingsView: View {
             // visible label: "License (EULA)" is the kind of string that gets
             // reworded, and ``RepositoryLinkTargetsTests`` already pins the
             // destinations, so the document is the stable half.
-            HStack(spacing: 12) {
+            HStack(spacing: RapidTheme.Space.lg) {
                 Link("Privacy policy",
                      destination: URL(string: "https://github.com/raullenchai/Rapid-MLX/blob/main/apps/rapid-mac/PRIVACY.md")!)
                     .accessibilityIdentifier("Settings.Privacy.Link.PrivacyPolicy")
@@ -478,7 +565,12 @@ struct SettingsView: View {
                      destination: URL(string: "https://github.com/raullenchai/Rapid-MLX/blob/main/apps/rapid-mac/THIRD_PARTY.md")!)
                     .accessibilityIdentifier("Settings.Privacy.Link.Credits")
             }
-            .font(.callout)
+            .font(RapidFont.body)
+            // `.foregroundStyle`, not `.tint`: a SwiftUI ``Link`` paints
+            // itself with the system link colour and ignores the ambient
+            // tint, so these three rendered in macOS blue while every
+            // other link in the app used the steel-blue link token.
+            .foregroundStyle(RapidTheme.linkLabel)
 
             Spacer(minLength: 0)
         }
@@ -532,17 +624,13 @@ struct SettingsView: View {
     ///     change and want to confirm.
     @ViewBuilder
     private var appPanel: some View {
-        VStack(alignment: .leading, spacing: 16) {
-            VStack(alignment: .leading, spacing: 4) {
-                Text("Rapid-MLX")
-                    .font(.title2.weight(.semibold))
-                Text("Self-update for Rapid-MLX. New releases bundle the latest models, performance improvements, and bug fixes.")
-                    .font(.callout)
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
-            }
-            Divider()
-            VStack(alignment: .leading, spacing: 12) {
+        VStack(alignment: .leading, spacing: RapidTheme.Space.xl) {
+            SectionHeader(
+                "Rapid-MLX",
+                subtitle: "Self-update for Rapid-MLX. New releases bundle the latest models, performance improvements, and bug fixes.",
+                emphasis: .page
+            )
+            SettingsSection("Version") {
                 versionRow(
                     label: "Installed",
                     value: "v\(appUpdater.currentVersion)",
@@ -561,6 +649,7 @@ struct SettingsView: View {
                 // so bypassed that judgement. Gate it on the same predicate.
                 if let release = appUpdater.latest,
                    !UpdateChecker.isNewer(appUpdater.currentVersion, than: release.version) {
+                    SettingsRowDivider()
                     versionRow(
                         label: "Latest release",
                         value: "v\(release.version)",
@@ -568,24 +657,23 @@ struct SettingsView: View {
                     )
                 }
             }
-            Divider()
-            appUpdateActionRow
-            if let release = appUpdater.availableUpdate,
-               !release.notes.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                appReleaseNotesPanel(notes: release.notes)
-            }
-            if let err = appUpdater.lastError {
-                HStack(spacing: 6) {
-                    Image(systemName: "wifi.exclamationmark")
-                        .foregroundStyle(.orange)
-                    Text("Last check failed: \(err)")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
+
+            SettingsSection("Updates") {
+                appUpdateActionRow
+                if let release = appUpdater.availableUpdate,
+                   !release.notes.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                    SettingsRowDivider()
+                    appReleaseNotesPanel(notes: release.notes)
                 }
             }
-            Divider()
+            if let err = appUpdater.lastError {
+                InlineNotice(
+                    message: "Last check failed: \(err)",
+                    tone: .warning
+                )
+            }
+
             diagnosticsSection
-            Divider()
             dockVisibilitySection
         }
     }
@@ -596,17 +684,23 @@ struct SettingsView: View {
     /// tail) so a bug report arrives actionable instead of "it broke".
     @ViewBuilder
     private var diagnosticsSection: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            sectionHeader(
-                "Diagnostics",
-                "Save a support report to share if something goes wrong. Includes your app version, Mac model, and recent logs — no prompts, files, or personal data."
-            )
-            Button {
-                DiagnosticsBundle.exportViaSavePanel(server: server)
-            } label: {
-                Label("Export diagnostics…", systemImage: "stethoscope")
+        // Copy is unchanged from before the migration: the explanation
+        // moves into the section subtitle (where every other panel puts
+        // it) and the button keeps its exact original label.
+        SettingsSection(
+            "Diagnostics",
+            subtitle: "Save a support report to share if something goes wrong. Includes your app version, Mac model, and recent logs — no prompts, files, or personal data."
+        ) {
+            HStack {
+                Button {
+                    DiagnosticsBundle.exportViaSavePanel(server: server)
+                } label: {
+                    Label("Export diagnostics…", systemImage: "stethoscope")
+                }
+                .buttonStyle(.rapidSecondaryCompact)
+                .accessibilityIdentifier("Settings.App.ExportDiagnostics")
+                Spacer(minLength: 0)
             }
-            .accessibilityIdentifier("Settings.App.ExportDiagnostics")
         }
     }
 
@@ -617,35 +711,31 @@ struct SettingsView: View {
     /// prompt back so a curious user can re-see it.
     @ViewBuilder
     private var dockVisibilitySection: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            VStack(alignment: .leading, spacing: 4) {
-                Text("Window")
-                    .font(.title3.weight(.semibold))
-                Text("Choose what happens when you close the main window. Rapid-MLX keeps running in the menu bar either way — this only affects whether the Dock icon stays visible.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
-            }
+        SettingsSection(
+            "Window",
+            subtitle: "Choose what happens when you close the main window. Rapid-MLX keeps running in the menu bar either way — this only affects whether the Dock icon stays visible."
+        ) {
             Toggle(isOn: hideDockOnCloseBinding) {
-                VStack(alignment: .leading, spacing: 2) {
-                    Text("Hide Dock icon when closing window")
-                        .font(.callout.weight(.medium))
-                    Text("On close, Rapid-MLX stays available from the menu bar. Turn off to keep the Dock icon visible; disabling takes effect immediately.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .fixedSize(horizontal: false, vertical: true)
-                }
+                SettingsRowLabel(
+                    title: "Hide Dock icon when closing window",
+                    description: "On close, Rapid-MLX stays available from the menu bar. Turn off to keep the Dock icon visible; disabling takes effect immediately."
+                )
             }
             .toggleStyle(TrailingSettingsToggleStyle())
             .accessibilityLabel("Hide Dock icon when closing window")
             .accessibilityHint("Rapid-MLX remains available from the menu bar.")
             .accessibilityIdentifier("Settings.App.HideDockOnCloseToggle")
+
+            SettingsRowDivider()
+
             HStack {
-                Spacer()
+                Spacer(minLength: 0)
+                // Label unchanged; only the button tier and the
+                // container around it moved onto the shared system.
                 Button("Reset onboarding alerts") {
                     dockPromptStore.resetOnboarding()
                 }
-                .controlSize(.small)
+                .buttonStyle(.rapidSecondaryCompact)
                 .accessibilityIdentifier("Settings.App.ResetDockOnboardingCTA")
             }
         }
@@ -771,17 +861,21 @@ struct SettingsView: View {
 
     @ViewBuilder
     private var appUpdateActionRow: some View {
-        HStack(spacing: 12) {
+        // `.top` rather than centre: at the 720pt floor the status
+        // sentences wrap to two lines, and a centred trailing button
+        // then drifts down the row as the text grows. Anchoring to the
+        // first line keeps the control still while the text reflows.
+        HStack(alignment: .top, spacing: RapidTheme.Space.md) {
             switch appUpdateStatus {
             case .available(let version):
-                HStack(spacing: 6) {
-                    Image(systemName: "arrow.up.circle.fill")
-                        .foregroundStyle(RapidTheme.brand)
-                    Text("Update available — v\(version)")
-                        .font(.callout.weight(.semibold))
-                        .accessibilityIdentifier("Settings.App.UpdateHeadline")
-                }
-                Spacer()
+                statusLine(
+                    symbol: "arrow.up.circle.fill",
+                    tint: RapidTheme.statusWorking,
+                    text: "Update available — v\(version)",
+                    emphasised: true,
+                    identifier: "Settings.App.UpdateHeadline"
+                )
+                Spacer(minLength: RapidTheme.Space.sm)
                 // Codex r1 P2 (CTA never disabled): the CTA only
                 // opens the existing update-install scene — leaving
                 // it tappable while ``appInstaller.isRunning`` lets
@@ -797,60 +891,82 @@ struct SettingsView: View {
                         Label("Update Rapid-MLX", systemImage: "arrow.down.circle.fill")
                     }
                 }
-                .buttonStyle(.borderedProminent)
-                .controlSize(.small)
+                .buttonStyle(.rapidPrimary)
                 .accessibilityIdentifier("Settings.App.UpdateCTA")
             case .upToDate(let version):
-                HStack(spacing: 6) {
-                    Image(systemName: "checkmark.circle.fill")
-                        .foregroundStyle(.green)
-                    Text("Up to date — v\(version) is the latest release.")
-                        .font(.callout)
-                        .foregroundStyle(.primary)
-                        .accessibilityIdentifier("Settings.App.UpToDate")
-                }
-                Spacer()
+                statusLine(
+                    symbol: "checkmark.circle.fill",
+                    tint: RapidTheme.statusReady,
+                    text: "Up to date — v\(version) is the latest release.",
+                    identifier: "Settings.App.UpToDate"
+                )
+                Spacer(minLength: RapidTheme.Space.sm)
                 appUpdateRecheckButton
             case .checking:
-                HStack(spacing: 6) {
+                HStack(alignment: .firstTextBaseline, spacing: RapidTheme.Space.sm) {
                     ProgressView()
                         .controlSize(.small)
                     Text("Checking for updates…")
-                        .font(.callout)
-                        .foregroundStyle(.secondary)
+                        .font(RapidFont.body)
+                        .foregroundStyle(RapidTheme.textSecondary)
+                        .fixedSize(horizontal: false, vertical: true)
                         .accessibilityIdentifier("Settings.App.Checking")
                 }
-                Spacer()
+                Spacer(minLength: RapidTheme.Space.sm)
                 appUpdateRecheckButton
             case .aheadOfManifest(let current, _):
-                HStack(spacing: 6) {
-                    Image(systemName: "checkmark.circle")
-                        .foregroundStyle(.secondary)
-                    Text("Up to date — v\(current).")
-                        .font(.callout)
-                        .foregroundStyle(.primary)
-                        .accessibilityIdentifier("Settings.App.AheadOfManifest")
-                }
-                Spacer()
+                statusLine(
+                    symbol: "checkmark.circle",
+                    tint: RapidTheme.textSecondary,
+                    text: "Up to date — v\(current).",
+                    identifier: "Settings.App.AheadOfManifest"
+                )
+                Spacer(minLength: RapidTheme.Space.sm)
                 // No re-check button. The poll already succeeded; the feed is
                 // simply behind this build, and pressing it again returns the
                 // same answer. An action that provably cannot change anything
                 // is worse than no action — it invites the user to keep
                 // trying and reads as if something is wrong.
             case .unknown(let reason):
-                HStack(spacing: 6) {
-                    Image(systemName: "questionmark.circle")
-                        .foregroundStyle(.secondary)
-                    Text(reason == nil
+                statusLine(
+                    symbol: "questionmark.circle",
+                    tint: RapidTheme.textSecondary,
+                    text: reason == nil
                         ? "Update status unknown — press Check for updates."
-                        : "Update status unknown — last check failed.")
-                        .font(.callout)
-                        .foregroundStyle(.secondary)
-                        .accessibilityIdentifier("Settings.App.Unknown")
-                }
-                Spacer()
+                        : "Update status unknown — last check failed.",
+                    secondary: true,
+                    identifier: "Settings.App.Unknown"
+                )
+                Spacer(minLength: RapidTheme.Space.sm)
                 appUpdateRecheckButton
             }
+        }
+    }
+
+    /// One "glyph + sentence" status line, shared by the four update
+    /// states that render one. They were four near-identical `HStack`s
+    /// with four hand-picked colours (`RapidTheme.brand`, `.green`,
+    /// `.secondary`, `.secondary`); folding them into one helper is what
+    /// makes "status colours are semantic" enforceable rather than
+    /// aspirational.
+    @ViewBuilder
+    private func statusLine(
+        symbol: String,
+        tint: Color,
+        text: String,
+        emphasised: Bool = false,
+        secondary: Bool = false,
+        identifier: String
+    ) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: RapidTheme.Space.sm) {
+            Image(systemName: symbol)
+                .foregroundStyle(tint)
+                .accessibilityHidden(true)
+            Text(text)
+                .font(emphasised ? RapidFont.bodyEmphasis : RapidFont.body)
+                .foregroundStyle(secondary ? RapidTheme.textSecondary : RapidTheme.textPrimary)
+                .fixedSize(horizontal: false, vertical: true)
+                .accessibilityIdentifier(identifier)
         }
     }
 
@@ -868,7 +984,7 @@ struct SettingsView: View {
                 Label("Check for updates", systemImage: "arrow.clockwise")
             }
         }
-        .controlSize(.small)
+        .buttonStyle(.rapidSecondaryCompact)
         .disabled(appUpdater.checking)
         .accessibilityIdentifier("Settings.App.RecheckCTA")
     }
@@ -878,23 +994,25 @@ struct SettingsView: View {
     /// render an inline scroll-bounded preview so the user can see
     /// "what's new" without opening another window.
     private func appReleaseNotesPanel(notes: String) -> some View {
-        VStack(alignment: .leading, spacing: 6) {
-            Text("Release notes")
-                .font(.caption.weight(.medium))
-                .foregroundStyle(.secondary)
+        VStack(alignment: .leading, spacing: RapidTheme.Space.sm) {
+            SectionHeader("Release notes")
             ScrollView(.vertical, showsIndicators: true) {
                 Text(notes)
                     .scaledSystemFont(12)
                     .textSelection(.enabled)
                     .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(8)
+                    .padding(RapidTheme.Space.sm)
             }
             .frame(maxHeight: 140)
+            // Recessed, not a second card: notes are inset INTO the
+            // Updates section, so they use the code/inset ground rather
+            // than another raised surface on top of a raised surface.
             .background(
-                RoundedRectangle(cornerRadius: 6, style: .continuous)
-                    .fill(Color.secondary.opacity(0.08))
+                RoundedRectangle(cornerRadius: RapidTheme.Radius.code, style: .continuous)
+                    .fill(RapidTheme.surfaceCode)
             )
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     /// Open the in-app installer window — same window the
@@ -911,86 +1029,38 @@ struct SettingsView: View {
         }
     }
 
+    /// A label/value pair inside the Version section.
+    ///
+    /// The label column is a shared constant rather than a literal so the
+    /// two rows line up, and it is a `maxWidth` rather than a hard
+    /// `width`: at the 720pt floor a fixed 120pt label column plus a
+    /// long version string was the row most likely to overrun.
     private func versionRow(label: String, value: String, monospaced: Bool) -> some View {
-        HStack(alignment: .firstTextBaseline, spacing: 12) {
+        HStack(alignment: .firstTextBaseline, spacing: RapidTheme.Space.md) {
             Text(label)
-                .font(.caption.weight(.medium))
-                .foregroundStyle(.secondary)
-                .frame(width: 120, alignment: .leading)
+                .font(RapidFont.caption)
+                .foregroundStyle(RapidTheme.textSecondary)
+                .frame(maxWidth: 120, alignment: .leading)
+                .fixedSize(horizontal: false, vertical: true)
             Text(value)
-                .font(monospaced
-                    ? .system(size: 12, design: .monospaced)
-                    : .system(size: 12))
+                .font(monospaced ? RapidFont.metric : RapidFont.secondary)
+                .foregroundStyle(RapidTheme.textPrimary)
                 .textSelection(.enabled)
                 .lineLimit(1)
                 .truncationMode(.middle)
-            Spacer()
+            Spacer(minLength: 0)
         }
     }
 
-    // MARK: - Shared layout (v0.5 card refresh)
-
-    /// Section header: a title + an optional descriptive subtitle,
-    /// rendered above a card. Keeps the heading typography consistent
-    /// across every panel and softer than a bare ``.title2`` slammed
-    /// onto the content.
-    @ViewBuilder
-    private func sectionHeader(_ title: String, _ subtitle: String? = nil) -> some View {
-        VStack(alignment: .leading, spacing: 4) {
-            Text(title)
-                .font(.title3.weight(.semibold))
-            if let subtitle {
-                Text(subtitle)
-                    .font(.callout)
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
-            }
-        }
-    }
-
-    /// Rounded "card" container for a group of settings controls. A
-    /// near-white fill on a light canvas, a hairline border, and a
-    /// generous inset — the Linear / Apple-System-Settings look the
-    /// v0.5 refresh targets. Every panel routes its controls through
-    /// this so the Settings window reads as a set of calm cards.
-    @ViewBuilder
-    private func settingsCard<Content: View>(
-        padding: CGFloat = 16,
-        @ViewBuilder _ content: () -> Content
-    ) -> some View {
-        content()
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(padding)
-            .background(
-                RoundedRectangle(cornerRadius: RapidTheme.cardRadius, style: .continuous)
-                    .fill(RapidTheme.card)
-            )
-            .clipShape(RoundedRectangle(cornerRadius: RapidTheme.cardRadius, style: .continuous))
-            .overlay(
-                RoundedRectangle(cornerRadius: RapidTheme.cardRadius, style: .continuous)
-                    .stroke(RapidTheme.hairline, lineWidth: 1)
-            )
-    }
-
-    /// Same glyph mapping as the compose-bar popover. Kept here
-    /// in duplicate (rather than refactored to a shared helper)
-    /// because v0.4.1 is the only commit they live side by side
-    /// in — the compose popover may collapse into a "quick
-    /// status" indicator in v0.5 once Settings is the canonical
-    /// surface, at which point the duplicate goes away.
-    private func glyph(for name: String) -> String {
-        switch name {
-        case "read_file", "list_directory": return "folder"
-        case "write_file": return "square.and.pencil"
-        case "edit_file": return "pencil.and.list.clipboard"
-        case "run_command": return "terminal"
-        case "web_search": return "magnifyingglass"
-        case "calculator": return "function"
-        case "weather": return "cloud.sun"
-        case "current_datetime": return "clock"
-        default: return "wrench.and.screwdriver"
-        }
-    }
+    // NOTE: three private helpers used to sit here and were removed by
+    // the UI-1 migration:
+    //
+    //   * ``sectionHeader(_:_:)`` and ``settingsCard(padding:_:)`` — one
+    //     of four copies of the same two helpers across the Settings
+    //     panels. Both are now ``SectionHeader`` + ``SettingsSection``.
+    //   * ``glyph(for:)`` — dead since the tools list moved to
+    //     ``SettingsToolsPanel`` (which has its own, live copy). It
+    //     mapped eight tool names, five of which no longer exist.
 }
 
 /// AppKit-backed because AXPress on a SwiftUI button in a secondary Window can

--- a/apps/rapid-mac/Sources/Rapid/UI/SettingsView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SettingsView.swift
@@ -238,7 +238,11 @@ struct SettingsView: View {
     /// Width of the category rail. Fixed, like every macOS settings
     /// sidebar — at the 720pt window floor this still leaves 519pt of
     /// detail, which is more than the widest panel needs.
-    static let railWidth: CGFloat = 200
+    // `nonisolated`: read by the nonisolated layout arithmetic below. An
+    // immutable Sendable constant is isolation-free on every compiler; the
+    // CI toolchain (stricter default isolation than the local one) otherwise
+    // rejects the reads.
+    nonisolated static let railWidth: CGFloat = 200
 
     /// Width below which the detail column is "compact" and panels
     /// should shed optional columns rather than clip them.
@@ -248,7 +252,7 @@ struct SettingsView: View {
     /// gaps before the model name gets a single point. Under ~520pt of
     /// content the name is squeezed to nothing, so that is where the
     /// meters have to go.
-    static let compactContentWidth: CGFloat = 520
+    nonisolated static let compactContentWidth: CGFloat = 520
 
     /// The width a panel's content column actually gets inside a window
     /// `windowWidth` points wide.

--- a/apps/rapid-mac/Sources/Rapid/UI/SidebarView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SidebarView.swift
@@ -516,6 +516,17 @@ struct SidebarView: View {
                 // ``pinControlIdentifier(for:)``.
                 .accessibilityIdentifier(Self.pinControlIdentifier(for: conv))
             }
+            // A native SwiftUI ``Menu`` — so the popup is an ``NSMenu``
+            // drawn entirely by macOS. Its padding, corner radius, item
+            // height and separator spacing are the system's on macOS 26
+            // and are not app-settable; ``.menuStyle`` and
+            // ``.menuIndicator`` below style the TRIGGER button, never
+            // the popup. The only app-level styling that ever reached
+            // the menu content was the scene tint, and ``rowMenuItems``
+            // already clears it (see that method's note). Do not try to
+            // give this Settings card padding or a custom radius —
+            // there is no hook, and a custom popover would cost the
+            // keyboard navigation and AX behaviour NSMenu provides.
             Menu {
                 rowMenuItems(conv)
             } label: {

--- a/apps/rapid-mac/Tests/RapidTests/AccessibilityIdentifierInventoryTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/AccessibilityIdentifierInventoryTests.swift
@@ -133,8 +133,6 @@ struct AccessibilityIdentifierInventoryTests {
                 #""Settings.Connectors.Editor.Transport""#,
                 #""Settings.Connectors.Editor.Command""#,
                 #""Settings.Connectors.Editor.URL""#,
-                #""Settings.Connectors.Editor.AddArgument""#,
-                #""Settings.Connectors.Editor.AddEnv""#,
                 #""Settings.Connectors.Editor.Enabled""#,
                 #""Settings.Connectors.Editor.Allow""#,
                 #""Settings.Connectors.Editor.Cancel""#,
@@ -142,6 +140,26 @@ struct AccessibilityIdentifierInventoryTests {
             in: "Sources/Rapid/UI/MCPServerEditorSheet.swift",
             surface: "Settings → Connectors → editor"
         )
+        // The two code editors route their identifier through the shared
+        // `codeEditor(text:height:axIdentifier:)` builder so the modifier
+        // lands on the `TextEditor` itself (the AX-identifier gate checks
+        // the control, and a wrapper-level duplicate would give the AX
+        // driver two hits). Pin the literal at the call sites instead —
+        // the identifier STRINGS are unchanged, so golden flows are
+        // unaffected.
+        let sheet = try strippedSource("Sources/Rapid/UI/MCPServerEditorSheet.swift")
+        for id in ["Settings.Connectors.Editor.AddArgument",
+                   "Settings.Connectors.Editor.AddEnv"] {
+            #expect(
+                sheet.contains(#"axIdentifier:"\#(id)""#),
+                """
+                Settings → Connectors → editor: MCPServerEditorSheet.swift no \
+                longer passes \(id) into codeEditor(text:height:axIdentifier:). \
+                Golden flows address this field by AXIdentifier — update \
+                scripts/gui-golden-flows.sh and this inventory together.
+                """
+            )
+        }
     }
 
     /// The consent prompt is the last thing standing between a model and a

--- a/apps/rapid-mac/Tests/RapidTests/AccessibilityIdentifierInventoryTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/AccessibilityIdentifierInventoryTests.swift
@@ -168,8 +168,18 @@ struct AccessibilityIdentifierInventoryTests {
     @Test("TrailingSettingsToggleStyle still renders a native switch Toggle")
     func trailingToggleStyleKeepsNativeSemantics() throws {
         let stripped = try strippedSource("Sources/Rapid/UI/SettingsControlStyles.swift")
+        // The invariant is that a REAL `Toggle` bound to the
+        // configuration is what draws the switch — not that the Toggle
+        // is the syntactic root of `makeBody`. UI-1's refinement pass
+        // wraps it in an `HStack` to hold the label column and the
+        // trailing gutter, which is layout around the control and does
+        // not touch its semantics: the switch is still a `Toggle`, still
+        // `.switch`, and still carries its own AXCheckBox role and
+        // value. The `.accessibilityRepresentation` assertion below is
+        // the one that actually catches a regression to #1608's
+        // hand-rolled row, and it is unchanged.
         #expect(
-            stripped.contains("returnToggle(isOn:binding){"),
+            stripped.contains("Toggle(isOn:binding){"),
             "TrailingSettingsToggleStyle must wrap a real Toggle — a hand-rolled row loses the AXCheckBox role and its value."
         )
         #expect(

--- a/apps/rapid-mac/Tests/RapidTests/MenuBarTemplateMarkTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/MenuBarTemplateMarkTests.swift
@@ -1,0 +1,137 @@
+import AppKit
+import Foundation
+import Testing
+@testable import Rapid
+
+/// Pins for the UI-1 menu-bar mark.
+///
+/// The tray icon moved from a full-colour cheetah bitmap to the official
+/// `R` drawn as vector geometry and tagged as a template. Three things
+/// have to stay true for that to keep working, and none of them is
+/// visible in a screenshot of a passing build:
+///
+///   1. the image is a TEMPLATE, so macOS owns its colour and it adapts
+///      to a light bar, a dark bar, and the highlighted state;
+///   2. the status item still has an accessible name;
+///   3. the geometry actually parses — a silent parser failure would
+///      fall through to the SF Symbol and nobody would notice until
+///      somebody looked at their menu bar.
+@MainActor
+@Suite("Menu-bar template mark")
+struct MenuBarTemplateMarkTests {
+
+    @Test("The tray glyph is a template image")
+    func trayGlyphIsTemplate() {
+        let image = MenuBarController.trayGlyph()
+        #expect(
+            image.isTemplate,
+            """
+            The tray glyph must be a template image. A non-template glyph \
+            ignores the menu bar's appearance: it renders identically on a \
+            light bar, a dark bar, and while the menu is open — which is the \
+            defect the full-colour cheetah had.
+            """
+        )
+    }
+
+    @Test("The tray glyph carries an accessible description")
+    func trayGlyphIsNamed() {
+        let image = MenuBarController.trayGlyph()
+        // ``configureButton`` sets this on the button's image; the fallback
+        // path sets it at construction. Either way the shipped image must
+        // be nameable — a status item whose label is a bare image and
+        // whose image has no description is unreachable to VoiceOver.
+        let described = image.accessibilityDescription ?? MenuBarController.accessibilityTitle
+        #expect(described == MenuBarController.accessibilityTitle)
+        #expect(!MenuBarController.accessibilityTitle.isEmpty)
+    }
+
+    @Test("The official R geometry parses and is the shipped glyph")
+    func officialGeometryParses() throws {
+        let path = try #require(
+            RapidRMark.glyphPath(),
+            """
+            The official `R` path data failed to parse, so the tray silently \
+            fell back to an SF Symbol. Check SVGPathData against the command \
+            set the current rapid_icon.svg export uses.
+            """
+        )
+        #expect(!path.isEmpty)
+        // The mark is very nearly square (105.17 × 105.42 in the 192pt
+        // viewBox). A wildly different aspect means the path data was
+        // replaced with something that is not this mark.
+        let bounds = path.bounds
+        #expect(bounds.width > 100 && bounds.width < 110)
+        #expect(bounds.height > 100 && bounds.height < 110)
+    }
+
+    @Test("The full lockup parses too, and is wider than the R alone")
+    func fullLockupParses() throws {
+        let glyph = try #require(RapidRMark.glyphPath())
+        let full = try #require(RapidRMark.fullMarkPath())
+        #expect(
+            full.bounds.width > glyph.bounds.width,
+            "The full lockup includes the two speed streaks, which extend left of the R."
+        )
+    }
+
+    @Test("The menu-bar image is sized to the menu-bar glyph height")
+    func menuBarImageIsCorrectlySized() throws {
+        let image = try #require(RapidRMark.menuBarTemplateImage())
+        #expect(image.size.height == RapidRMark.menuBarGlyphHeight)
+        // Near-square, and never taller than the 18pt an NSStatusItem
+        // gives its content inside the 24pt bar.
+        #expect(image.size.width > 0)
+        #expect(image.size.height <= 18)
+    }
+
+    /// The streaks are why the menu-bar variant is the `R` alone. If a
+    /// future export makes them substantial, this test fails and the
+    /// decision gets revisited on purpose rather than by accident.
+    @Test("The speed streaks are too fine to survive menu-bar scale")
+    func streaksAreSubPointAtMenuBarScale() throws {
+        let glyph = try #require(RapidRMark.glyphPath())
+        let upper = try #require(SVGPathData.parse(RapidRMark.upperStreakPathData))
+        let scale = RapidRMark.menuBarGlyphHeight / glyph.bounds.height
+        let scaledStreakHeight = upper.bounds.height * scale
+        #expect(
+            scaledStreakHeight < 1.0,
+            """
+            The upper streak now scales to \(scaledStreakHeight)pt at menu-bar \
+            size. It was sub-point (~0.78pt) when the R-only variant was \
+            chosen; if the artwork changed, re-evaluate whether the full \
+            lockup is now legible in the bar.
+            """
+        )
+    }
+
+    @Test("A malformed path is rejected rather than half-drawn")
+    func unsupportedCommandsAreRejected() {
+        // Arcs are not in the supported command set. The parser must
+        // return nil (so the caller falls back) instead of skipping the
+        // command and rendering a subtly wrong mark.
+        #expect(SVGPathData.parse("M0 0 A 10 10 0 0 1 20 20 Z") == nil)
+        #expect(SVGPathData.parse("") == nil)
+        // A path that never opens a subpath is not a shape.
+        #expect(SVGPathData.parse("L10 10") == nil)
+    }
+
+    @Test("The supported command set round-trips")
+    func supportedCommandsParse() throws {
+        // Absolute and relative forms of every command the official file
+        // uses, so a future export that leans on the relative forms is
+        // covered by something other than hope.
+        let box = try #require(SVGPathData.parse("M0 0 H10 V10 H0 Z"))
+        #expect(box.bounds.width == 10)
+        #expect(box.bounds.height == 10)
+
+        let relative = try #require(SVGPathData.parse("m0 0 h10 v10 h-10 z"))
+        #expect(relative.bounds.width == 10)
+
+        let curve = try #require(SVGPathData.parse("M0 0 C0 5 5 10 10 10 Z"))
+        #expect(curve.bounds.width > 0)
+
+        // Scientific notation and a bare leading decimal point.
+        #expect(SVGPathData.parse("M0 0 L1e1 .5 Z") != nil)
+    }
+}

--- a/apps/rapid-mac/Tests/RapidTests/SettingsVisualFoundationTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SettingsVisualFoundationTests.swift
@@ -1,0 +1,549 @@
+import AppKit
+import Foundation
+import SwiftUI
+import Testing
+@testable import Rapid
+
+/// Pins for the UI-1 Settings visual migration.
+///
+/// The migration's claim is narrow and checkable: every Settings panel
+/// draws from one set of tokens and one set of components, no category
+/// lost a control or a state owner, and the window's committed widths
+/// fit the smallest window it supports. These tests hold that claim;
+/// the screenshots hold everything about it that is a matter of taste.
+///
+/// Source-level guards use the same canonical (comment- and
+/// literal-stripped) form the existing ``SourceGuardSupport`` helpers
+/// produce, so a value inside a comment or a doc-string cannot pass or
+/// fail one by accident.
+@Suite("Settings visual foundation (UI-1)")
+struct SettingsVisualFoundationTests {
+
+    private static var packageRoot: URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()  // RapidTests
+            .deletingLastPathComponent()  // Tests
+            .deletingLastPathComponent()  // package root
+    }
+
+    /// Every Settings source this phase migrated.
+    private static let settingsSources = [
+        "Sources/Rapid/UI/SettingsView.swift",
+        "Sources/Rapid/UI/SettingsToolsPanel.swift",
+        "Sources/Rapid/UI/SettingsConnectorsPanel.swift",
+        "Sources/Rapid/UI/SettingsModelManagementPanel.swift",
+        "Sources/Rapid/UI/MCPServerEditorSheet.swift",
+    ]
+
+    /// Canonical form of each source, computed once per process.
+    ///
+    /// Six of the tests below read the same five files. Stripping is not
+    /// free (it walks every character to elide comments and literals), and
+    /// this suite runs alongside wall-clock-sensitive streaming tests —
+    /// paying it thirty times instead of five measurably slowed the whole
+    /// run and pushed two unrelated timing tests over their thresholds.
+    /// Immutable, computed once on first touch. A `let` dictionary keyed
+    /// by path is `Sendable`; a mutable cache would need a lock, which is
+    /// more machinery than five files justify.
+    private static let strippedSources: [String: String] = {
+        var out: [String: String] = [:]
+        for path in settingsSources {
+            let url = packageRoot.appendingPathComponent(path)
+            guard let body = try? String(contentsOf: url, encoding: .utf8) else { continue }
+            out[path] = CapabilityChipRenderGateSourceGuardTests
+                .stripCommentsAndWhitespace(body)
+        }
+        return out
+    }()
+
+    private func strippedSource(_ relativePath: String) throws -> String {
+        if let hit = Self.strippedSources[relativePath] { return hit }
+        // Not one of the five migrated panels — read it on demand.
+        let url = Self.packageRoot.appendingPathComponent(relativePath)
+        let body = try String(contentsOf: url, encoding: .utf8)
+        return CapabilityChipRenderGateSourceGuardTests
+            .stripCommentsAndWhitespace(body)
+    }
+
+    // MARK: - Navigation and ownership
+
+    @MainActor
+    @Test("Every category still exists, with a title and an icon")
+    func everyCategorySurvives() {
+        let expected: Set<String> = [
+            "modelManagement", "tools", "connectors", "appearance", "privacy", "app",
+        ]
+        let actual = Set(SettingsView.Category.allCases.map(\.rawValue))
+        #expect(
+            actual == expected,
+            """
+            UI-1 is a visual migration and must not add, remove, or rename a \
+            Settings category. Got \(actual.sorted()).
+            """
+        )
+        for category in SettingsView.Category.allCases {
+            #expect(!category.title.isEmpty, "\(category.rawValue) lost its title")
+            #expect(!category.iconName.isEmpty, "\(category.rawValue) lost its icon")
+        }
+    }
+
+    @MainActor
+    @Test("Category order is unchanged, so arrow-key navigation is unchanged")
+    func categoryOrderIsStable() {
+        #expect(SettingsView.Category.allCases.map(\.rawValue) == [
+            "modelManagement", "tools", "connectors", "appearance", "privacy", "app",
+        ])
+        // The rail's ↑/↓ handler walks this order and clamps at the ends.
+        #expect(SettingsView.category(.modelManagement, movedBy: -1) == nil)
+        #expect(SettingsView.category(.app, movedBy: 1) == nil)
+        #expect(SettingsView.category(.modelManagement, movedBy: 1) == .tools)
+        #expect(SettingsView.category(.app, movedBy: -1) == .privacy)
+    }
+
+    /// Each panel reaches its state through the SwiftUI environment. A
+    /// migration that dropped an `@Environment` line would compile and
+    /// then crash at runtime the first time that category was opened —
+    /// SwiftUI traps on a missing observable — so the ownership is
+    /// pinned at the source level where it can fail in CI instead.
+    @Test("No category loses its state owner")
+    func everyCategoryKeepsItsStateOwner() throws {
+        let requirements: [(path: String, owners: [String])] = [
+            ("Sources/Rapid/UI/SettingsView.swift", [
+                "@Environment(AppearanceConfig.self)",
+                "@Environment(SettingsRouter.self)",
+                "@Environment(ServerManager.self)",
+                "@Environment(UpdateChecker.self)",
+                "@Environment(Installer.self)",
+                "@Environment(DockVisibilityPromptStore.self)",
+            ]),
+            ("Sources/Rapid/UI/SettingsToolsPanel.swift", [
+                "@Environment(ChatViewModel.self)",
+                "@Environment(WebSearchConfig.self)",
+                "@Environment(BrowseApprovalStore.self)",
+            ]),
+            ("Sources/Rapid/UI/SettingsConnectorsPanel.swift", [
+                "@Environment(MCPConfigStore.self)",
+                "@Environment(MCPCatalog.self)",
+                "@Environment(MCPToolApprovalStore.self)",
+                "@Environment(MCPToolRegistry.self)",
+                "@Environment(ServerManager.self)",
+            ]),
+            ("Sources/Rapid/UI/SettingsModelManagementPanel.swift", [
+                "@Environment(ServerManager.self)",
+                "@Environment(DownloadManager.self)",
+            ]),
+        ]
+        for (path, owners) in requirements {
+            let source = try strippedSource(path)
+            for owner in owners {
+                #expect(
+                    source.contains(owner),
+                    "\(path) no longer declares \(owner) — that category's panel would trap on open."
+                )
+            }
+        }
+    }
+
+    @Test("Persisted settings keys are untouched")
+    func persistedKeysAreUnchanged() throws {
+        // The migration repainted controls; it must not have moved where
+        // any of them reads or writes.
+        let panel = try strippedSource("Sources/Rapid/UI/SettingsModelManagementPanel.swift")
+        #expect(panel.contains("@AppStorage(ModelPickerVisibility.showAllStorageKey)"))
+        #expect(panel.contains("@AppStorage(AutoStartPreference.storageKey)"))
+    }
+
+    // MARK: - Shared components are actually used
+
+    @Test("Every Settings panel is built from the shared section components")
+    func panelsUseSharedComponents() throws {
+        for path in Self.settingsSources where !path.hasSuffix("MCPServerEditorSheet.swift") {
+            let source = try strippedSource(path)
+            #expect(
+                source.contains("SettingsSection(") || source.contains("settingsGroupedCard("),
+                "\(path) draws no shared Settings section — it is still hand-rolling a card."
+            )
+        }
+        // The editor sheet keeps its native grouped Form, but must still
+        // use the shared header + button tiers.
+        let sheet = try strippedSource("Sources/Rapid/UI/MCPServerEditorSheet.swift")
+        #expect(sheet.contains("SectionHeader("))
+        #expect(sheet.contains("buttonStyle(.rapidPrimary)"))
+        #expect(sheet.contains("buttonStyle(.rapidSecondary)"))
+    }
+
+    @Test("Settings uses the shared button tiers, not the native ones")
+    func panelsUseSharedButtonTiers() throws {
+        for path in Self.settingsSources {
+            let source = try strippedSource(path)
+            for native in ["buttonStyle(.borderedProminent)", "buttonStyle(.bordered)"] {
+                #expect(
+                    !source.contains(native),
+                    """
+                    \(path) still uses \(native). Native prominent buttons \
+                    inherit the scene tint, which paints amber with white text \
+                    at ~2:1 — the contrast failure RapidPrimaryButtonStyle \
+                    exists to prevent.
+                    """
+                )
+            }
+        }
+    }
+
+    @Test("Destructive Settings actions use the destructive hierarchy")
+    func destructiveActionsAreStyled() throws {
+        let panel = try strippedSource("Sources/Rapid/UI/SettingsModelManagementPanel.swift")
+        #expect(
+            panel.contains("buttonStyle(.rapidDestructiveCompact)"),
+            "The recommended card's Delete must read as destructive."
+        )
+        #expect(
+            panel.contains("tint:RapidTheme.statusError"),
+            "The table's delete glyphs must carry the error tint."
+        )
+    }
+
+    // MARK: - One set of tokens
+
+    @Test("No Settings panel paints a raw colour or a one-off radius")
+    func panelsUseOnlyTokens() throws {
+        // Substrings checked against the stripped source, where comments
+        // and string literals are gone — so a token name mentioned in a
+        // doc-comment cannot trip this.
+        let banned = [
+            "Color.red", "Color.orange", "Color.green", "Color.blue", "Color.purple",
+            "foregroundStyle(.orange)", "foregroundStyle(.red)", "foregroundStyle(.green)",
+            "RapidTheme.cardRadius",
+            "RapidTheme.brandTint",
+        ]
+        for path in Self.settingsSources {
+            let source = try strippedSource(path)
+            for needle in banned {
+                #expect(
+                    !source.contains(needle),
+                    """
+                    \(path) still contains `\(needle)`. Settings draws from the \
+                    semantic tokens now: statusError / statusWarning / \
+                    statusReady / statusIdle for meaning, brandPrimaryTint for \
+                    selection, Radius.card for containers.
+                    """
+                )
+            }
+        }
+    }
+
+    @Test("No Settings panel invents a font size")
+    func panelsUseTheTypeRamp() throws {
+        let banned = [
+            "font(.title)", "font(.title2)", "font(.title3)",
+            "font(.headline)", "font(.subheadline)",
+            "font(.callout)", "font(.caption)", "font(.caption2)",
+            "font(.body)",
+        ]
+        for path in Self.settingsSources {
+            let source = try strippedSource(path)
+            for needle in banned {
+                #expect(
+                    !source.contains(needle),
+                    """
+                    \(path) still uses `\(needle)`. The Settings window had four \
+                    heading sizes because panels reached past the ramp; every \
+                    role now exists on RapidFont.
+                    """
+                )
+            }
+        }
+    }
+
+    // MARK: - UI-1 refinement invariants
+
+    /// Nothing in Settings may put white on an amber fill.
+    ///
+    /// The review found it on segmented controls; the general rule is
+    /// that ink on ``brandPrimary`` comes from ``brandOnAccent`` and
+    /// from nowhere else.
+    @Test("No Settings surface writes white on an accent fill")
+    func noWhiteOnAccent() throws {
+        for path in Self.settingsSources + [
+            "Sources/Rapid/UI/SettingsControlStyles.swift",
+            "Sources/Rapid/UI/Components/RapidButtonStyles.swift",
+        ] {
+            let source = try strippedSource(path)
+            for needle in ["foregroundStyle(.white)", "foregroundStyle(Color.white)"] {
+                #expect(
+                    !source.contains(needle),
+                    "\(path) puts white text on a control — use RapidTheme.brandOnAccent."
+                )
+            }
+        }
+    }
+
+    /// The destructive fill is much lighter in Dark, so its ink has to
+    /// change with it — white on the Dark coral is ~2.4:1.
+    @MainActor
+    @Test("Destructive ink adapts to its fill")
+    func destructiveInkAdapts() throws {
+        let light = try #require(Self.resolve(RapidTheme.destructiveActionLabel, appearance: .aqua))
+        let dark = try #require(Self.resolve(RapidTheme.destructiveActionLabel, appearance: .darkAqua))
+        #expect(light != dark, "Destructive ink must not be one colour for two very different reds.")
+        #expect(light.redComponent > 0.9, "Light mode: white on the deep brick fill.")
+        #expect(dark.redComponent < 0.3, "Dark mode: near-black on the light coral fill.")
+    }
+
+    @Test("brandOnAccent is dark ink and identical in Light and Dark")
+    @MainActor
+    func accentInkIsDarkInBothAppearances() throws {
+        let light = try #require(Self.resolve(RapidTheme.brandOnAccent, appearance: .aqua))
+        let dark = try #require(Self.resolve(RapidTheme.brandOnAccent, appearance: .darkAqua))
+        // The amber fill does not change between appearances, so its ink
+        // must not either — flipping to white in Dark is the exact 2:1
+        // pairing this token exists to prevent.
+        #expect(light == dark)
+        // Dark ink: comfortably below mid-grey on every channel.
+        #expect(light.redComponent < 0.35)
+        #expect(light.greenComponent < 0.35)
+        #expect(light.blueComponent < 0.35)
+    }
+
+    /// The native segmented style is what produced white-on-amber, so it
+    /// must not come back in Settings.
+    @Test("Settings uses the shared segmented control, not the native style")
+    func segmentedControlIsShared() throws {
+        for path in Self.settingsSources {
+            let source = try strippedSource(path)
+            #expect(
+                !source.contains("pickerStyle(.segmented)"),
+                """
+                \(path) uses .pickerStyle(.segmented). Its selected segment                 takes the ambient tint with WHITE text and exposes no hook to                 change it — use RapidSegmentedControl.
+                """
+            )
+        }
+        let panel = try strippedSource("Sources/Rapid/UI/SettingsModelManagementPanel.swift")
+        #expect(panel.contains("RapidSegmentedControl("))
+    }
+
+    @Test("The regular button tiers share one height")
+    func regularButtonTiersShareAHeight() {
+        // A Cancel/Save pair in a sheet must not step. Emphasis is the
+        // fill, not four extra points of height.
+        #expect(RapidPrimaryButtonStyle().height == RapidTheme.ControlHeight.medium)
+        #expect(RapidSecondaryButtonStyle().height == RapidTheme.ControlHeight.medium)
+        #expect(RapidDestructiveButtonStyle().height == RapidTheme.ControlHeight.medium)
+        // ...and the compact tiers agree too.
+        #expect(RapidPrimaryButtonStyle(height: RapidTheme.ControlHeight.small).height
+                == RapidSecondaryButtonStyle(height: RapidTheme.ControlHeight.small).height)
+    }
+
+    @Test("The settings toggle reserves a real gutter and a stable column")
+    func toggleGutterIsGenerous() {
+        // The review asked for 20–24pt of clear space so a three-line
+        // description can never run under the switch.
+        #expect(TrailingSettingsToggleStyle.gutter >= 20)
+        #expect(TrailingSettingsToggleStyle.controlColumnWidth > 0)
+    }
+
+    @Test("Card insets meet the reviewed minimums")
+    func cardInsetsAreGenerous() {
+        #expect(SettingsCardMetrics.regularInset >= 24)
+        #expect(SettingsCardMetrics.compactInset >= 20)
+        #expect(SettingsCardMetrics.inset(isCompact: false) == SettingsCardMetrics.regularInset)
+        #expect(SettingsCardMetrics.inset(isCompact: true) == SettingsCardMetrics.compactInset)
+    }
+
+    /// Tool rows lead with a human name; the wire identifier stays the
+    /// key for state, dispatch and accessibility.
+    @Test("Built-in tools present human names without losing their identifiers")
+    func toolDisplayNames() {
+        #expect(SettingsToolsPanel.displayName(for: "web_search") == "Web Search")
+        #expect(SettingsToolsPanel.displayName(for: "browse") == "Browse Web Page")
+        #expect(SettingsToolsPanel.displayName(for: "weather") == "Weather")
+        // An unmapped tool degrades to its identifier rather than to
+        // nothing, so a newly registered tool is never nameless.
+        #expect(SettingsToolsPanel.displayName(for: "future_tool") == "future_tool")
+
+        // Summaries are short enough to sit inside the three-line cap.
+        for tool in ["web_search", "browse", "weather"] {
+            let summary = SettingsToolsPanel.summary(for: tool, fallback: "")
+            #expect(!summary.isEmpty)
+            #expect(summary.count < 110, "\(tool) summary is long enough to wrap past three lines")
+        }
+        // An unmapped tool falls back to the engine's own description.
+        #expect(SettingsToolsPanel.summary(for: "future_tool", fallback: "raw") == "raw")
+    }
+
+    @Test("Tool rows still key their state on the wire identifier")
+    func toolRowsKeyOnWireIdentifier() throws {
+        let source = try strippedSource("Sources/Rapid/UI/SettingsToolsPanel.swift")
+        // The toggle binding and the AX identifier must both use the raw
+        // name, not the display name.
+        #expect(source.contains("toolBinding(name)"))
+        #expect(source.contains(#"accessibilityIdentifier("Settings.Tools.Toggle.\(def.function.name)")"#))
+    }
+
+    // MARK: - Removed tokens have no consumers
+
+    @Test("Tokens removed by this migration have no remaining consumers")
+    func removedTokensAreUnreferenced() throws {
+        let removed = [
+            // Superseded by ``surfaceSidebar``; the cool grey rail.
+            "RapidTheme.sidebarSurface",
+            // The tray glyph is unconditionally a template now.
+            "MenuBarStatus.glyphIsTemplate",
+            "glyphIsTemplate(",
+        ]
+        let sourcesRoot = Self.packageRoot.appendingPathComponent("Sources")
+        let files = FileManager.default
+            .enumerator(at: sourcesRoot, includingPropertiesForKeys: nil)?
+            .compactMap { $0 as? URL }
+            .filter { $0.pathExtension == "swift" } ?? []
+        #expect(!files.isEmpty, "Found no Swift sources to scan — the walk is broken.")
+
+        for file in files {
+            let body = try String(contentsOf: file, encoding: .utf8)
+            // Raw-substring pre-filter first: canonicalising ~160 files to
+            // prove a negative is wasted work, and this suite shares a
+            // process with tests that measure wall-clock latency. Only a
+            // file that mentions the symbol at all is worth stripping —
+            // and stripping is still what decides, so a mention inside a
+            // comment (which is how the removals are documented) passes.
+            guard removed.contains(where: { body.contains($0) }) else { continue }
+            let stripped = CapabilityChipRenderGateSourceGuardTests
+                .stripCommentsAndWhitespace(body)
+            for token in removed {
+                #expect(
+                    !stripped.contains(token),
+                    "\(file.lastPathComponent) still references removed symbol `\(token)`."
+                )
+            }
+        }
+    }
+
+    // MARK: - Light and Dark both resolve
+
+    /// Every token this phase added is dynamic. A token that resolves to
+    /// the same colour in both appearances is either a mistake or a
+    /// deliberate constant — and the ones below are deliberately NOT
+    /// constant, so equality means somebody dropped the dark branch.
+    @MainActor
+    @Test("New semantic tokens resolve differently in Light and Dark")
+    func tokensResolveInBothAppearances() {
+        let cases: [(name: String, color: Color)] = [
+            ("statusReadyTint", RapidTheme.statusReadyTint),
+            ("surfaceCanvas", RapidTheme.surfaceCanvas),
+            ("surfaceSidebar", RapidTheme.surfaceSidebar),
+            ("surfaceRaised", RapidTheme.surfaceRaised),
+            ("surfaceCode", RapidTheme.surfaceCode),
+            ("hairline", RapidTheme.hairline),
+            ("hairlineStrong", RapidTheme.hairlineStrong),
+            ("statusError", RapidTheme.statusError),
+            ("statusErrorTint", RapidTheme.statusErrorTint),
+        ]
+        for (name, color) in cases {
+            let light = Self.resolve(color, appearance: .aqua)
+            let dark = Self.resolve(color, appearance: .darkAqua)
+            #expect(light != nil, "\(name) did not resolve in Light")
+            #expect(dark != nil, "\(name) did not resolve in Dark")
+            #expect(
+                light != dark,
+                "\(name) resolves identically in Light and Dark — its dynamic provider lost a branch."
+            )
+        }
+    }
+
+    /// Text tokens delegate to the system's dynamic label colours, so
+    /// they only have to RESOLVE — asserting they differ would be
+    /// asserting something about macOS, not about this code.
+    @MainActor
+    @Test("Text tokens resolve in both appearances")
+    func textTokensResolve() {
+        for (name, color) in [
+            ("textPrimary", RapidTheme.textPrimary),
+            ("textSecondary", RapidTheme.textSecondary),
+            ("textTertiary", RapidTheme.textTertiary),
+            ("textDisabled", RapidTheme.textDisabled),
+        ] {
+            #expect(Self.resolve(color, appearance: .aqua) != nil, "\(name) failed in Light")
+            #expect(Self.resolve(color, appearance: .darkAqua) != nil, "\(name) failed in Dark")
+        }
+    }
+
+    @MainActor
+    private static func resolve(
+        _ color: Color,
+        appearance name: NSAppearance.Name
+    ) -> NSColor? {
+        guard let appearance = NSAppearance(named: name) else { return nil }
+        var resolved: NSColor?
+        appearance.performAsCurrentDrawingAppearance {
+            resolved = NSColor(color).usingColorSpace(.deviceRGB)
+        }
+        return resolved
+    }
+
+    // MARK: - Responsive contract
+
+    /// The arithmetic behind "no horizontal clipping at 720×480".
+    ///
+    /// This is the assertion the audit could not make from source: the
+    /// old panel committed a 158pt meters column and a 124pt size column
+    /// inside a hard 600pt content box, and nothing checked that the
+    /// model name had anywhere to go.
+    @Test(
+        "The models table leaves a readable name at every supported width",
+        arguments: [
+            CGFloat(720),   // the window floor
+            CGFloat(900),   // the size the brief calls out
+            CGFloat(1200),
+            CGFloat(1600),  // wide — the column caps, it does not sprawl
+        ]
+    )
+    func modelsTableFitsAtSupportedWidths(windowWidth: CGFloat) {
+        let column = SettingsView.contentColumnWidth(forWindowWidth: windowWidth)
+        #expect(column > 0, "No content column at \(windowWidth)pt")
+        #expect(
+            column <= RapidTheme.Layout.pageMaxWidth,
+            "The content column must cap at the shared page measure, not sprawl."
+        )
+
+        let showsMeters = !SettingsView.isCompact(forWindowWidth: windowWidth)
+        let committed = ModelTableLayout.committedRowWidth(showsMeters: showsMeters)
+        let remaining = column - committed
+        #expect(
+            remaining >= ModelTableLayout.minimumNameWidth,
+            """
+            At a \(windowWidth)pt window the models table commits \(committed)pt \
+            of a \(column)pt column, leaving \(remaining)pt for the model name \
+            (floor \(ModelTableLayout.minimumNameWidth)pt). Either the compact \
+            threshold or a column width is wrong.
+            """
+        )
+    }
+
+    @Test("The window floor puts the models table into its compact layout")
+    func floorIsCompact() {
+        #expect(
+            SettingsView.isCompact(forWindowWidth: SettingsView.minWindowWidth),
+            """
+            At the 720pt floor the meters column has to stand down; if this \
+            flips, the model name is being squeezed instead.
+            """
+        )
+        #expect(
+            !SettingsView.isCompact(forWindowWidth: 900),
+            "900pt is comfortably wide enough for the meters column."
+        )
+    }
+
+    @Test("Nothing the shell commits to is wider than the narrowest window")
+    func shellFitsItsOwnFloor() {
+        let floor = SettingsView.minWindowWidth
+        let committed = SettingsView.railWidth
+            + 1  // divider
+            + SettingsView.contentColumnWidth(forWindowWidth: floor)
+            + RapidTheme.Space.xl * 2  // page insets
+        #expect(
+            committed <= floor,
+            "The shell commits \(committed)pt inside a \(floor)pt window."
+        )
+    }
+}

--- a/apps/rapid-mac/Tests/RapidTests/SettingsVisualFoundationTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SettingsVisualFoundationTests.swift
@@ -17,6 +17,11 @@ import Testing
 /// produce, so a value inside a comment or a doc-string cannot pass or
 /// fail one by accident.
 @Suite("Settings visual foundation (UI-1)")
+@MainActor
+// The whole suite runs on the main actor: several tests construct SwiftUI
+// style/metric types whose initializers the CI toolchain (stricter default
+// isolation than the local one) treats as MainActor-isolated. Individual
+// @MainActor markers below become redundant but stay harmless.
 struct SettingsVisualFoundationTests {
 
     private static var packageRoot: URL {


### PR DESCRIPTION
## Summary

- replaces the detailed menu-bar artwork with the official Rapid `R` template icon for native Light, Dark, and selected rendering
- introduces a shared semantic visual foundation for the macOS Settings experience
- unifies all current Settings categories across typography, color, spacing, cards, buttons, toggles, segmented controls, notices, and responsive behavior
- improves tool and connector presentation with human-readable names, concise summaries, expandable technical details, and consistent forms
- adds focused regression coverage and an isolated visual-verification harness

## Visual system

- uses amber consistently for selection and primary actions
- uses dark foreground text on amber-filled controls in both appearances
- makes selected Settings icons follow the selected label color
- standardizes card padding, control heights, corner radii, and button hierarchy
- keeps native macOS switches, radio groups, forms, pickers, and menus where appropriate
- supports default, 900×640, and 720×480 Settings layouts

## Menu-bar icon

The menu-bar item now uses the official Rapid `R` mark as a monochrome macOS template image. macOS controls its Light, Dark, highlighted, and accessibility rendering.

The former fixed amber update dot is not drawn into the template icon. Update availability remains visible through the menu's Update command and version information.

## Testing

Run from the rebased commit:

- `git diff --check upstream/main...HEAD` — clean
- `swift build --package-path apps/rapid-mac` — succeeds
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --package-path apps/rapid-mac` — 2067 tests in 184 suites, passing on a clean run
- `SKIP_SIDECAR=1 bash apps/rapid-mac/scripts/build.sh` — bundle builds
- focused suites (Settings visual foundation, accessibility identifiers, menu-bar template icon, tool display names and disclosures, Settings controls and persistence, model cache actions, download-catalog hardening): 122 tests in 9 suites, all passing

`DownloadCatalogHardeningTests` — the previously documented wall-clock test — failed once during a full-suite run and passed both in its focused suite and on a clean full-suite rerun. It is a pre-existing intermittent (it also flakes on an unmodified `main` on this machine). No timing threshold was changed.

Isolated visual verification used the fake sidecar, an isolated preference domain, and `RAPID_DESKTOP_NO_PORT_SWEEP=1`: all six Settings categories in Light and Dark at default / 900×640 / 720×480, plus focused captures for the compact controls, Available Tools collapsed and expanded, all three Web Search backends, the connector sheet, and the menu-bar mark composited on light, dark, and selected backgrounds.

Not verified in this PR, and left for live review: the amber switch track (offscreen rendering does not reproduce the AppKit control accent), the native `NSMenu` popup (it does not appear in an offscreen render), populated connector lists, and VoiceOver navigation of the new disclosures.

## Scope

This PR intentionally does not redesign Chat, Images, Launch, Quickstart/onboarding, About, or the standalone Update window. Those surfaces remain planned for a later UI phase.

The one change outside Settings is the Audio tab's mode selector, which adopts the shared segmented control so it stops rendering white-on-amber; its bindings and surrounding page are untouched.

No model, download, connector, server, persistence, or inference behavior is intentionally changed.
