### PR TITLE
test: fix two order-dependent full-suite flakes (parser-state leak, SIGHUP inheritance)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,54 @@ script modules themselves don't take a runtime ``import pytest``
 dependency (pytest is dev-only; codex R3 closure)."""
 
 
+@pytest.fixture(autouse=True)
+def _reset_global_parser_state_after_each_test():
+    """Keep the process-global parser state hermetic across tests.
+
+    Effective parser resolution reads TWO process-global sources (see
+    ``vllm_mlx/routes/models.py`` ``effective_parsers_for``): the
+    ``ServerConfig`` singleton (``cfg.tool_call_parser``) AND the
+    ``vllm_mlx.server`` module-level ``_tool_call_parser`` fallback. Several
+    suites mutate either one directly and never restore it:
+
+    * ``test_orphan_tool_validation`` / ``test_r12_reasoning_sanitizer_required``
+      do ``reset_config(); cfg.tool_call_parser = "hermes"``.
+    * ``test_capabilities_field`` does ``server._tool_call_parser = "hermes"``
+      by *direct assignment* (not ``monkeypatch``), so nothing restores it.
+
+    Either leak bleeds into a later test that reads the resolved parser under a
+    given collection order — most visibly
+    ``test_routes.py::TestModelsRoutes::test_retrieve_unknown_id_keeps_baseline_shape``,
+    whose unknown-id baseline expects the resolved ``tool_call_parser`` to be
+    ``None``. Pinning ``cfg.tool_call_parser=None`` in that test is not enough:
+    resolution then falls through to the ``server`` module global. That was a
+    real order-dependent flake (green in isolation, red in the full suite).
+
+    Reset BOTH sources to their module defaults after every test. Both resets
+    are cheap, and every suite that needs specific parser state sets it up at
+    the start of each test (or via ``monkeypatch``), so a teardown reset is
+    compatible.
+    """
+    yield
+
+    # Reset only the parser state a test actually loaded. Guarding on
+    # ``sys.modules`` (a) skips work for a module no test imported — it cannot
+    # have leaked — and (b) avoids importing ``vllm_mlx.server`` here, which
+    # pulls ``uvicorn``: the lightweight "no-MLX" CI test job does not install
+    # it, so an unconditional import ERRORs every test's teardown.
+    import sys
+
+    _config_mod = sys.modules.get("vllm_mlx.config.server_config")
+    if _config_mod is not None:
+        _config_mod.reset_config()
+
+    _server = sys.modules.get("vllm_mlx.server")
+    if _server is not None:
+        _server._tool_call_parser = None
+        _server._reasoning_parser = None
+        _server._reasoning_parser_name = None
+
+
 def pytest_addoption(parser):
     """Add custom command line options."""
     parser.addoption(

--- a/tests/test_signal_observability.py
+++ b/tests/test_signal_observability.py
@@ -406,9 +406,14 @@ def test_subprocess_sighup_default_disposition_dumps_and_terminates():
         import logging, os, signal, sys, time
         logging.basicConfig(level=logging.WARNING, stream=sys.stderr,
                             format="%(levelname)s %(name)s: %(message)s")
-        # Confirm we start from SIG_DFL — this is the production
-        # baseline for SIGHUP under uvicorn.
-        assert signal.getsignal(signal.SIGHUP) == signal.SIG_DFL
+        # Establish the production baseline explicitly: uvicorn does not
+        # install a SIGHUP handler, so SIGHUP starts at SIG_DFL. We SET it
+        # rather than ASSERT it — a SIG_IGN leaked by an earlier test in the
+        # parent pytest process is inherited across exec (POSIX: SIG_IGN
+        # survives execve, unlike caught handlers) and would otherwise fail
+        # this unrelated precondition, a full-suite ordering flake. The real
+        # contract is proven below: observability keeps SIGHUP terminating.
+        signal.signal(signal.SIGHUP, signal.SIG_DFL)
         from vllm_mlx._signal_observability import install_signal_observability
         assert install_signal_observability() is True
         sys.stdout.write("READY\\n"); sys.stdout.flush()


### PR DESCRIPTION
## Why

Two unit tests pass in isolation but fail under full-suite collection order — pre-existing flakes that make the unit gate unreliable for every PR (surfaced while dogfooding `main` HEAD). Neither reproduces standalone.

## Root causes + fixes

### 1. `test_routes::test_retrieve_unknown_id_keeps_baseline_shape` → `assert 'hermes' is None`

Effective parser resolution (`routes/models.py::effective_parsers_for`) reads **two** process-global sources: `ServerConfig.tool_call_parser` **and** the `vllm_mlx.server` module-level `_tool_call_parser` fallback. Leakers:

- `test_capabilities_field` sets `server._tool_call_parser = "hermes"` by **direct assignment** (not `monkeypatch` → nothing restores it).
- `test_orphan_tool_validation` / `test_r12_reasoning_sanitizer_required` set `cfg.tool_call_parser = "hermes"`.

The routes test pins `cfg.tool_call_parser=None`, but resolution then falls through to the leaked `server` global — which is why the test's own hermeticity attempt didn't hold.

**Fix:** an autouse `conftest.py` fixture resets **both** sources to their module defaults after every test.

### 2. `test_signal_observability::test_subprocess_sighup_default_disposition_dumps_and_terminates`

The subprocess asserted `getsignal(SIGHUP) == SIG_DFL` at startup, but a `SIG_IGN` leaked by an earlier test in the parent pytest process is **inherited across `execve`** (POSIX: `SIG_IGN` survives exec; caught handlers do not).

**Fix:** the subprocess now **sets** the `SIG_DFL` production baseline instead of asserting the inherited disposition. The real contract (observability keeps SIGHUP terminating) is still proven by `returncode == -SIGHUP`.

## Not changed: `test_parent_watchdog`

Investigated and found **not** a real flake. It only "fails" when pytest is launched via `nohup … &` and the launching shell exits, reparenting pytest to PID 1 → `os.getppid() == 1` → `install_parent_watchdog` returns `None` via its documented `expected_ppid <= 1` early-out. In CI / any foreground run (`getppid > 1`) it passes. Left untouched.

## Validation

- Full suite (proper launch): **17003 passed, 0 failed**.
- Each leaker→victim sequence reproduced the failure without the fix and passes with it (`test_capabilities_field → test_routes`; parent-`SIG_IGN` → sighup subprocess).

No production code changed; no `pyproject.toml` bump.