### PR TITLE
feat(mac): add image resolution controls and improve progress readability

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/DevSnapshot.swift
+++ b/apps/rapid-mac/Sources/Rapid/DevSnapshot.swift
@@ -193,6 +193,9 @@ enum DevSnapshot {
         render(contentView(width: 640, height: 560), to: "\(dir)/content-min.png")
         // Images tab (empty state — no results, catalog not yet resolved).
         render(imagesView(width: 700, height: 640), to: "\(dir)/images-empty.png")
+        // Narrow composer: the canvas controls wrap to the two-row
+        // ViewThatFits layout, which only this width exercises.
+        render(imagesView(width: 420, height: 640), to: "\(dir)/images-narrow.png")
         renderHosted(imagesView(width: 700, height: 640),
                      size: CGSize(width: 700, height: 640),
                      appearance: .darkAqua, to: "\(dir)/images-dark.png")

--- a/apps/rapid-mac/Sources/Rapid/Images/ImageGenViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Images/ImageGenViewModel.swift
@@ -8,7 +8,8 @@ import Observation
 @MainActor
 @Observable
 final class ImageGenViewModel {
-    /// Aspect ratio as three friendly buttons rather than a "512×512" string.
+    /// Aspect ratio stays independent from output resolution so changing one
+    /// never silently resets the other.
     enum Aspect: String, CaseIterable, Identifiable {
         case square, portrait, landscape
         var id: String { rawValue }
@@ -19,13 +20,32 @@ final class ImageGenViewModel {
             case .landscape: return "4:3"
             }
         }
-        var size: String {
+        func dimensions(for resolution: Resolution) -> (width: Int, height: Int) {
             switch self {
-            case .square: return "1024x1024"
-            case .portrait: return "768x1024"
-            case .landscape: return "1024x768"
+            case .square: return (resolution.longEdge, resolution.longEdge)
+            case .portrait: return (resolution.longEdge * 3 / 4, resolution.longEdge)
+            case .landscape: return (resolution.longEdge, resolution.longEdge * 3 / 4)
             }
         }
+
+        func size(for resolution: Resolution) -> String {
+            let dimensions = dimensions(for: resolution)
+            return "\(dimensions.width)x\(dimensions.height)"
+        }
+    }
+
+    /// Long-edge output presets. Every aspect maps these values to dimensions
+    /// accepted by the server (256...2048 and a multiple of 16).
+    enum Resolution: Int, CaseIterable, Identifiable {
+        case compact = 512
+        case balanced = 768
+        case detailed = 1024
+        case large = 1280
+        case high = 1536
+        case maximum = 2048
+
+        var id: Int { rawValue }
+        var longEdge: Int { rawValue }
     }
 
     /// The two phases of a render, shown very differently: a reassuring
@@ -43,6 +63,15 @@ final class ImageGenViewModel {
     // MARK: - Composed input
     var prompt: String = ""
     var aspect: Aspect = .square
+    var resolution: Resolution = .detailed
+
+    var outputSize: String {
+        aspect.size(for: resolution)
+    }
+
+    var outputSizeLabel: String {
+        outputSize.replacingOccurrences(of: "x", with: " × ")
+    }
 
     // MARK: - Catalog
     /// Every installed/available image model (the ``[image:gen]`` rows). The
@@ -192,7 +221,7 @@ final class ImageGenViewModel {
             let poll = self.startPolling(model: self.selectedAlias, port: port, bearer: bearer)
             defer { poll.cancel() }
             let images = try await self.client.generate(
-                prompt: trimmed, model: self.selectedAlias, size: self.aspect.size,
+                prompt: trimmed, model: self.selectedAlias, size: self.outputSize,
                 count: 1, seed: nil, port: port, bearer: bearer
             )
             if let first = images.first {
@@ -229,7 +258,7 @@ final class ImageGenViewModel {
             defer { poll.cancel() }
             let images = try await self.client.edit(
                 imagePNG: source.pngData, prompt: trimmed, model: self.selectedAlias,
-                size: self.aspect.size, count: 1, seed: nil, port: port, bearer: bearer
+                size: self.outputSize, count: 1, seed: nil, port: port, bearer: bearer
             )
             if let first = images.first {
                 self.results.insert(contentsOf: images, at: 0)

--- a/apps/rapid-mac/Sources/Rapid/Images/ImageGenViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Images/ImageGenViewModel.swift
@@ -201,6 +201,10 @@ final class ImageGenViewModel {
 
     private func runGenerate() async {
         let trimmed = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        // Snapshot at submission: the composer stays enabled through the
+        // (possibly minutes-long) warm-up await, so a later aspect/resolution
+        // change must not retarget the in-flight request.
+        let size = outputSize
         guard !trimmed.isEmpty, !selectedAlias.isEmpty else { return }
         await withRequest {
             let selected = self.imageModels.first { $0.alias == self.selectedAlias }
@@ -221,7 +225,7 @@ final class ImageGenViewModel {
             let poll = self.startPolling(model: self.selectedAlias, port: port, bearer: bearer)
             defer { poll.cancel() }
             let images = try await self.client.generate(
-                prompt: trimmed, model: self.selectedAlias, size: self.outputSize,
+                prompt: trimmed, model: self.selectedAlias, size: size,
                 count: 1, seed: nil, port: port, bearer: bearer
             )
             if let first = images.first {
@@ -237,6 +241,8 @@ final class ImageGenViewModel {
 
     private func runEdit(source: GeneratedImage) async {
         let trimmed = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        // Same snapshot rule as ``runGenerate``.
+        let size = outputSize
         guard !trimmed.isEmpty, !selectedAlias.isEmpty else { return }
         await withRequest {
             let selected = self.imageModels.first { $0.alias == self.selectedAlias }
@@ -258,7 +264,7 @@ final class ImageGenViewModel {
             defer { poll.cancel() }
             let images = try await self.client.edit(
                 imagePNG: source.pngData, prompt: trimmed, model: self.selectedAlias,
-                size: self.outputSize, count: 1, seed: nil, port: port, bearer: bearer
+                size: size, count: 1, seed: nil, port: port, bearer: bearer
             )
             if let first = images.first {
                 self.results.insert(contentsOf: images, at: 0)

--- a/apps/rapid-mac/Sources/Rapid/UI/ImagesView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ImagesView.swift
@@ -215,7 +215,7 @@ struct ImagesView: View {
                         if denoising {
                             Text("\(step) / \(total)")
                                 .font(.system(size: 12, weight: .semibold, design: .monospaced))
-                                .foregroundStyle(.secondary)
+                                .foregroundStyle(Color.primary.opacity(0.76))
                                 .monospacedDigit()
                         }
                         Button { viewModel.cancel() } label: {
@@ -236,8 +236,8 @@ struct ImagesView: View {
 
                     HStack {
                         Text(String(format: "%.1fs", max(0, elapsed)))
-                            .font(.system(size: 11, weight: .medium, design: .monospaced))
-                            .foregroundStyle(.secondary)
+                            .font(.system(size: 12, weight: .medium, design: .monospaced))
+                            .foregroundStyle(Color.primary.opacity(0.76))
                             .monospacedDigit()
                         Spacer()
                         // ETA from the denoise-phase clock, not total elapsed —
@@ -247,17 +247,17 @@ struct ImagesView: View {
                         Text(denoising
                              ? (etaText(step: step, total: total, elapsed: denoiseElapsed) ?? "finishing…")
                              : "First run — only happens once")
-                            .font(.system(size: 11))
-                            .foregroundStyle(.secondary)
+                            .font(.system(size: 12, weight: .medium))
+                            .foregroundStyle(Color.primary.opacity(0.76))
                     }
                 }
                 .padding(18)
                 .frame(width: 340)
-                .background(.ultraThinMaterial,
+                .background(RapidTheme.surfaceOverlay,
                             in: RoundedRectangle(cornerRadius: 18, style: .continuous))
                 .overlay(
                     RoundedRectangle(cornerRadius: 18, style: .continuous)
-                        .strokeBorder(.white.opacity(0.12), lineWidth: 1)
+                        .strokeBorder(RapidTheme.hairlineStrong, lineWidth: 1)
                 )
                 .shadow(color: .black.opacity(0.28), radius: 22, y: 10)
             }
@@ -416,15 +416,31 @@ struct ImagesView: View {
         .padding(.bottom, RapidTheme.Space.lg)
     }
 
-    /// Bottom row of the compose box: aspect on the left, then the inline
-    /// model picker + submit clustered on the right — the same
+    /// Bottom row of the compose box: canvas controls on the left, then the
+    /// inline model picker + submit clustered on the right — the same
     /// `model ▾  ⬆` grouping ChatView uses.
     private var composerControls: some View {
-        HStack(spacing: RapidTheme.Space.sm) {
-            aspectPicker
-            Spacer(minLength: 0)
-            modelPicker
-            sendOrStopButton
+        ViewThatFits(in: .horizontal) {
+            HStack(spacing: RapidTheme.Space.sm) {
+                aspectPicker
+                resolutionPicker
+                Spacer(minLength: 0)
+                modelPicker
+                sendOrStopButton
+            }
+
+            VStack(spacing: RapidTheme.Space.xs) {
+                HStack(spacing: RapidTheme.Space.sm) {
+                    aspectPicker
+                    resolutionPicker
+                    Spacer(minLength: 0)
+                }
+                HStack(spacing: RapidTheme.Space.sm) {
+                    Spacer(minLength: 0)
+                    modelPicker
+                    sendOrStopButton
+                }
+            }
         }
     }
 
@@ -476,6 +492,53 @@ struct ImagesView: View {
             }
         }
         .accessibilityIdentifier("Images.Aspect")
+    }
+
+    /// Output dimensions are explicit rather than hidden inside the aspect
+    /// buttons. The menu keeps the compact composer row stable while still
+    /// showing the exact width and height each preset will send to the server.
+    private var resolutionPicker: some View {
+        Menu {
+            ForEach(ImageGenViewModel.Resolution.allCases) { resolution in
+                let size = viewModel.aspect.size(for: resolution)
+                    .replacingOccurrences(of: "x", with: " × ")
+                Button {
+                    viewModel.resolution = resolution
+                } label: {
+                    if viewModel.resolution == resolution {
+                        Label(size, systemImage: "checkmark")
+                    } else {
+                        Text(size)
+                    }
+                }
+                .accessibilityIdentifier("Images.Resolution.\(resolution.rawValue)")
+            }
+        } label: {
+            HStack(spacing: 5) {
+                Image(systemName: "ruler")
+                    .font(.system(size: 11, weight: .medium))
+                    .accessibilityHidden(true)
+                Text(viewModel.outputSizeLabel)
+                    .font(.system(size: 11, weight: .medium))
+                    .monospacedDigit()
+                Image(systemName: "chevron.down")
+                    .font(.system(size: 8, weight: .semibold))
+                    .foregroundStyle(.secondary)
+                    .accessibilityHidden(true)
+            }
+            .foregroundStyle(Color.secondary)
+            .padding(.horizontal, 7)
+            .frame(height: RapidTheme.ControlHeight.small)
+            .contentShape(Rectangle())
+        }
+        .menuStyle(.button)
+        .buttonStyle(.plain)
+        .menuIndicator(.hidden)
+        .fixedSize()
+        .help("Output resolution: \(viewModel.outputSizeLabel)")
+        .accessibilityLabel("Output resolution")
+        .accessibilityValue(viewModel.outputSizeLabel)
+        .accessibilityIdentifier("Images.Resolution")
     }
 
     /// The inline model picker — same composer-embedded chip as chat

--- a/apps/rapid-mac/Sources/Rapid/UI/ImagesView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ImagesView.swift
@@ -512,6 +512,7 @@ struct ImagesView: View {
                     }
                 }
                 .accessibilityIdentifier("Images.Resolution.\(resolution.rawValue)")
+                .accessibilityAddTraits(viewModel.resolution == resolution ? .isSelected : [])
             }
         } label: {
             HStack(spacing: 5) {

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/image-generation.generated.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/image-generation.generated.txt
@@ -20,6 +20,7 @@ AXApplication title="Rapid-MLX"
           AXButton id="Images.Aspect" desc="1:1" enabled=true
           AXButton id="Images.Aspect" desc="3:4" enabled=true
           AXButton id="Images.Aspect" desc="4:3" enabled=true
+          AXPopUpButton id="Images.Resolution" desc="Output resolution" help="Output resolution: 1024 × 1024" value=text enabled=true
           AXPopUpButton id="Images.ModelPicker" desc="<model>" help="Model: <model>" enabled=true
           AXButton id="Images.Generate" desc="Up" help="Generate" enabled=true
       AXButton desc="Settings" help="Settings — ⌘," enabled=true

--- a/apps/rapid-mac/Tests/RapidTests/ImageGenerationResolutionTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ImageGenerationResolutionTests.swift
@@ -1,0 +1,60 @@
+import Testing
+@testable import Rapid
+
+@Suite("Image generation resolution")
+struct ImageGenerationResolutionTests {
+    @Test("Every aspect and resolution maps to the expected API size")
+    func outputSizes() {
+        let expected: [ImageGenViewModel.Resolution: [ImageGenViewModel.Aspect: String]] = [
+            .compact: [
+                .square: "512x512",
+                .portrait: "384x512",
+                .landscape: "512x384",
+            ],
+            .balanced: [
+                .square: "768x768",
+                .portrait: "576x768",
+                .landscape: "768x576",
+            ],
+            .detailed: [
+                .square: "1024x1024",
+                .portrait: "768x1024",
+                .landscape: "1024x768",
+            ],
+            .large: [
+                .square: "1280x1280",
+                .portrait: "960x1280",
+                .landscape: "1280x960",
+            ],
+            .high: [
+                .square: "1536x1536",
+                .portrait: "1152x1536",
+                .landscape: "1536x1152",
+            ],
+            .maximum: [
+                .square: "2048x2048",
+                .portrait: "1536x2048",
+                .landscape: "2048x1536",
+            ],
+        ]
+
+        for resolution in ImageGenViewModel.Resolution.allCases {
+            for aspect in ImageGenViewModel.Aspect.allCases {
+                #expect(aspect.size(for: resolution) == expected[resolution]?[aspect])
+            }
+        }
+    }
+
+    @Test("Generated dimensions satisfy the image API contract")
+    func dimensionsAreSupported() {
+        for resolution in ImageGenViewModel.Resolution.allCases {
+            for aspect in ImageGenViewModel.Aspect.allCases {
+                let dimensions = aspect.dimensions(for: resolution)
+                #expect((256...2048).contains(dimensions.width))
+                #expect((256...2048).contains(dimensions.height))
+                #expect(dimensions.width.isMultiple(of: 16))
+                #expect(dimensions.height.isMultiple(of: 16))
+            }
+        }
+    }
+}

--- a/apps/rapid-mac/Tests/RapidTests/ImageGenerationResolutionTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ImageGenerationResolutionTests.swift
@@ -45,6 +45,13 @@ struct ImageGenerationResolutionTests {
         }
     }
 
+    @Test("A fresh view model still defaults to the pre-existing 1024x1024")
+    @MainActor
+    func defaultOutputSize() {
+        let viewModel = ImageGenViewModel(server: ServerManager())
+        #expect(viewModel.outputSize == "1024x1024")
+    }
+
     @Test("Generated dimensions satisfy the image API contract")
     func dimensionsAreSupported() {
         for resolution in ImageGenViewModel.Resolution.allCases {

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -2113,6 +2113,8 @@ flow_image_generation() {
         || die "Images.ModelPicker never resolved to $FAKE_IMAGE_ALIAS — the tab has no model to render with"
     jq -e '.data.ui_elements[]? | select(.identifier == "Images.Aspect")' "$OUT/ig-empty.json" >/dev/null \
         || die "Images.Aspect is missing — no way to choose an aspect ratio"
+    jq -e '.data.ui_elements[]? | select(.identifier == "Images.Resolution")' "$OUT/ig-empty.json" >/dev/null \
+        || die "Images.Resolution is missing — no way to choose an output resolution"
 
     # 3. Load the model. rapid-mlx serves one model per process, so opening the
     #    tab cannot silently inherit a ready server: the readiness gate holds


### PR DESCRIPTION
## What does this PR do?

  Adds explicit output-resolution controls to the macOS Images tab.

  - Provides 512, 768, 1024, 1280, 1536, and 2048 long-edge presets.
  - Combines the selected resolution with the existing 1:1, 3:4, and 4:3 aspect ratios.
  - Sends the calculated dimensions to the image generation and editing APIs.
  - Keeps 1024 as the default to preserve existing behavior.
  - Uses a responsive two-row layout when the composer is narrow.
  - Improves generation progress readability with an opaque surface, stronger text contrast, and larger timing text.
  - Adds resolution mapping and API dimension-contract tests.
  - Updates the image-generation golden flow and snapshot harness.

  ## Why is this needed?

  The Images tab previously exposed only aspect-ratio controls, while output resolution was fixed and not visible to the user. Users could not choose between faster, lower-memory renders and more detailed
  high-resolution output.

  The translucent generation progress card also allowed bright or detailed images to reduce the contrast of step, elapsed-time, and ETA text, making progress difficult to read.

  This change makes output dimensions explicit and configurable while ensuring generation status remains legible over arbitrary image content.