### PR TITLE
feat: share RAM-tier recommendations across CLI and Mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ Also compatible with OpenAI-compatible clients that allow direct local endpoints
 
 ## Choose Your Model
 
-The installer's RAM detector picks a sensible default. If you want to shop the full catalog: `rapid-mlx models` lists every alias, `rapid-mlx info <alias>` shows the per-alias profile (parser, MoE / hybrid flags, KV codec eligibility, speculative-decoding gates).
+The installer and desktop app use the same RAM-tier recommendation catalog. Run `rapid-mlx recipe` to see its Smart and Fast picks for this Mac (`--max-ram 32` simulates another tier; `--json` is machine-readable). If you want to shop the full catalog: `rapid-mlx models` lists every alias, `rapid-mlx info <alias>` shows the per-alias profile (parser, MoE / hybrid flags, KV codec eligibility, speculative-decoding gates).
 
 This table is the same one the desktop app's picker reads, and the installer
 prints the matching line for your Mac — a CI test parses both files and fails

--- a/apps/rapid-mac/Sources/Rapid/Server/RAMBucketedDefault.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/RAMBucketedDefault.swift
@@ -1,5 +1,7 @@
 import Foundation
 
+private final class RecommendationBundleFinder: NSObject {}
+
 /// Pure RAM tier → curated model recommendation for "what should this
 /// Mac run". Replaces the old 6-bucket × 5-role matrix (Default / Speed /
 /// Quality / Coding / Vision) with a much simpler table: per RAM tier, a
@@ -92,122 +94,109 @@ enum RAMBucketedDefault {
         var picks: [Pick] { alt.map { [primary, $0] } ?? [primary] }
     }
 
-    /// Conservative general-purpose laptop picks. Both have verified tool
-    /// calling and stay within the same footprint budget enforced at launch.
-    private static let qwen4Pick = Pick(
-        alias: "qwen3.5-4b-4bit", footprintGB: 6.0, capabilityPct: 78,
-        tokensPerSec: 60.7, launchFlags: [])
+    /// Decoded from the repository-wide SSOT used by both Rapid Desktop and
+    /// ``rapid-mlx recipe``. A missing or malformed table is a packaging error:
+    /// silently inventing a fallback would recreate the cross-surface drift this
+    /// catalog exists to prevent.
+    static let tiers: [Tier] = loadTiers()
 
-    private static let qwen9Pick = Pick(
-        alias: "qwen3.5-9b-4bit", footprintGB: 8.7, capabilityPct: 82,
-        tokensPerSec: 35.7, launchFlags: [])
+    private struct Payload: Decodable {
+        let schemaVersion: Int
+        let tiers: [RawTier]
 
-    /// Latest release-eval mean: Tool 47, Code 50, Reasoning 40, General 50
-    /// = 46.75, rounded to 47. The Basic chat caveat remains user-facing.
-    private static let lfm1Pick = Pick(
-        alias: "lfm2.5-1b-4bit", footprintGB: 1.9, capabilityPct: 47,
-        tokensPerSec: 208.4, launchFlags: [], caveat: "Basic chat")
+        enum CodingKeys: String, CodingKey {
+            case schemaVersion = "schema_version"
+            case tiers
+        }
+    }
 
-    /// The 8 GB tier's smarter pick: LFM2.5-2.6B, a 2.6 B dense model whose
-    /// 30 layers are 22 short-convolution blocks and just 8 GQA. Those 8
-    /// attention layers are why it belongs here — the KV cache costs
-    /// ~16 KB/token, so a 32 K conversation adds only ~0.5 GB on top of
-    /// 1.6 GB of weights. On an M2 Pro it peaks at 3.0 GB on the standard
-    /// 8K prompt, decodes at
-    /// 93.5 tok/s on the short prompt, and prefills at 473 tok/s at 8K.
-    ///
-    /// It carries a caveat rather than a capability %, and the caveat is
-    /// Liquid's own: they publish this model as "not recommended for
-    /// agentic coding and knowledge-heavy tasks". It is post-trained for
-    /// tool use and instruction following, and on those it beats models
-    /// ~4x its size — but our users drive coding agents, and putting a
-    /// bare "64%" on this card would invite exactly the use Liquid warns
-    /// against. ``capabilityPct`` is never rendered for a caveat pick; the
-    /// 64 below is the mean of the latest local tool, coding, reasoning,
-    /// and general release-eval suites; the caveat remains more useful than
-    /// presenting that small-suite composite as a universal quality score.
-    private static let lfm26Pick = Pick(
-        alias: "lfm2.5-2.6b-4bit", footprintGB: 3.0, capabilityPct: 64,
-        tokensPerSec: 93.5, launchFlags: [], caveat: "Not for coding")
+    private struct RawTier: Decodable {
+        let floorGB: Double
+        let picks: [RawPick]
 
-    /// Latest release-eval mean: Tool 93, Code 90, Reasoning 70, General 90
-    /// = 85.75, rounded to 86.
-    private static let bonsaiPick = Pick(
-        alias: "bonsai-27b-2bit", footprintGB: 13.0, capabilityPct: 86,
-        tokensPerSec: 17.5, launchFlags: [])
+        enum CodingKeys: String, CodingKey {
+            case floorGB = "floor_gb"
+            case picks
+        }
+    }
 
-    private static let gemma26Pick = Pick(
-        alias: "gemma-4-26b-4bit", footprintGB: 17.0, capabilityPct: 87,
-        tokensPerSec: 49.5,
-        launchFlags: ["--no-mllm", "--kv-cache-dtype", "bf16", "--cache-memory-mb", "512"])
+    private struct RawPick: Decodable {
+        let role: String
+        let alias: String
+        let footprintGB: Double
+        let capabilityPct: Int
+        let tokensPerSec: Double?
+        let launchFlags: [String]
+        let caveat: String?
 
-    /// Existing reviewed fast/light pick for the unmeasured 48/64/96 GB tiers.
-    private static let qwen35bFastPick = Pick(
-        alias: "qwen3.6-35b-4bit", footprintGB: 20.0, capabilityPct: 87,
-        tokensPerSec: 60.0, launchFlags: [])
+        enum CodingKeys: String, CodingKey {
+            case role, alias, caveat
+            case footprintGB = "footprint_gb"
+            case capabilityPct = "capability_pct"
+            case tokensPerSec = "tokens_per_sec"
+            case launchFlags = "launch_flags"
+        }
 
-    /// Source of truth — ascending by ``floorGB``. A recommendation change
-    /// is a one-line edit here, verified by ``RAMBucketedDefaultTests`` and
-    /// the standalone ``scripts/verify-recommendation-tiers.swift`` contract
-    /// check against the bundled ``aliases.json``.
-    static let tiers: [Tier] = [
-        // 8 GB was a hole, not a tier. These Macs clamped up to the 16 GB
-        // picks, then ``isRecommendedPick``'s floor guard correctly refused
-        // to exempt them from the ``.tooBig`` gate — so launch auto-start
-        // rejected the only thing it was offered and fell through to
-        // ``SafeDefaultFallback``. The user's first run was a model the app
-        // had just told them not to run. Nothing in the catalog fit until
-        // LFM2.5-2.6B: 3.21 GB standard-8K peak leaves room for macOS on
-        // an 8 GB machine; LFM 1B supplies the even lighter fast choice.
-        Tier(floorGB: 8, primary: lfm26Pick, alt: lfm1Pick),
-        Tier(
-            floorGB: 16,
-            primary: qwen4Pick,
-            alt: lfm1Pick
-        ),
-        // 18 GB gets the verified 9B general-purpose model plus the 4B fast
-        // option. Do not promote bonsai-27b-2bit here: its 13 GB standard
-        // 8K peak leaves too little headroom at the 18 GB tier floor.
-        Tier(
-            floorGB: 18,
-            primary: qwen9Pick,
-            alt: qwen4Pick
-        ),
-        Tier(
-            floorGB: 24,
-            primary: bonsaiPick,
-            alt: qwen4Pick
-        ),
-        Tier(
-            floorGB: 32,
-            primary: gemma26Pick,
-            alt: qwen4Pick
-        ),
-        Tier(
-            floorGB: 48,
-            primary: gemma26Pick,
-            alt: qwen35bFastPick
-        ),
-        // 64 GB smart pick is the 8-bit of the same Qwen3.6-35B whose 4-bit
-        // is the fast alt. Its capability is floored at the 4-bit's measured
-        // 87 % — an 8-bit quant is strictly higher-fidelity than its own
-        // 4-bit, so it must never DISPLAY below it (an earlier 85 % estimate
-        // made the "Best pick" read as weaker than its "Faster" alt). We
-        // pin equality, not a fabricated margin: the 8-bit's edge is
-        // quantization fidelity on long / hard prompts, which the blended
-        // bench doesn't fully resolve, and the alt exists precisely for
-        // users who'd rather trade that fidelity for the 4-bit's speed.
-        Tier(
-            floorGB: 64,
-            primary: Pick(alias: "qwen3.6-35b-8bit", footprintGB: 37.7, capabilityPct: 87, tokensPerSec: nil, launchFlags: []),
-            alt: qwen35bFastPick
-        ),
-        Tier(
-            floorGB: 96,
-            primary: Pick(alias: "qwen3.5-122b-mxfp4", footprintGB: 65.0, capabilityPct: 88, tokensPerSec: nil, launchFlags: []),
-            alt: qwen35bFastPick
-        ),
-    ]
+        var pick: Pick {
+            Pick(alias: alias, footprintGB: footprintGB,
+                 capabilityPct: capabilityPct, tokensPerSec: tokensPerSec,
+                 launchFlags: launchFlags, caveat: caveat)
+        }
+    }
+
+    private static func loadTiers() -> [Tier] {
+        guard let url = recommendationResourceURL(),
+              let data = try? Data(contentsOf: url),
+              let payload = try? JSONDecoder().decode(Payload.self, from: data),
+              payload.schemaVersion == 1 else {
+            fatalError("model_recommendations.json is missing or invalid")
+        }
+        precondition(!payload.tiers.isEmpty, "recommendation catalog must contain tiers")
+        var previousFloor = -Double.infinity
+        return payload.tiers.map { raw in
+            precondition(raw.floorGB > previousFloor,
+                         "recommendation tiers must be sorted by RAM floor")
+            previousFloor = raw.floorGB
+            precondition(raw.picks.count == 2 && raw.picks.map(\.role) == ["smart", "fast"],
+                         "every RAM tier must contain smart + fast picks")
+            return Tier(floorGB: raw.floorGB, primary: raw.picks[0].pick,
+                        alt: raw.picks[1].pick)
+        }
+    }
+
+    private static func recommendationResourceURL() -> URL? {
+        if let url = Bundle.main.url(forResource: "model_recommendations", withExtension: "json") {
+            return url
+        }
+        let anchor = Bundle(for: RecommendationBundleFinder.self).bundleURL.deletingLastPathComponent()
+        if let bundle = Bundle(url: anchor.appendingPathComponent("Rapid_Rapid.bundle")),
+           let url = bundle.url(forResource: "model_recommendations", withExtension: "json") {
+            return url
+        }
+        // SwiftPM tests run from a source checkout. Keep the source fallback
+        // pointed at the Python package's canonical file; it is deliberately
+        // not a second copied table.
+        let sourceCandidate = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent() // Server
+            .deletingLastPathComponent() // Rapid
+            .deletingLastPathComponent() // Sources
+            .deletingLastPathComponent() // rapid-mac
+            .deletingLastPathComponent() // apps
+            .appendingPathComponent("vllm_mlx/model_recommendations.json")
+        if FileManager.default.fileExists(atPath: sourceCandidate.path) {
+            return sourceCandidate
+        }
+        // Some SwiftPM invocations preserve a relative #filePath. Walk upward
+        // from their working directory instead of resolving that relative path
+        // against an already-nested package directory.
+        var directory = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        for _ in 0..<6 {
+            let candidate = directory.appendingPathComponent("vllm_mlx/model_recommendations.json")
+            if FileManager.default.fileExists(atPath: candidate.path) { return candidate }
+            directory.deleteLastPathComponent()
+        }
+        return nil
+    }
 
     /// The tier a Mac with ``physicalRAMGB`` lands in: the highest floor
     /// ≤ RAM. A sub-16 GB Mac clamps to the smallest tier.

--- a/apps/rapid-mac/scripts/build.sh
+++ b/apps/rapid-mac/scripts/build.sh
@@ -124,6 +124,17 @@ else
     echo "warning: benchmark-scores.json missing — picker hover tooltip will show dashed bars only" >&2
 fi
 
+# The recommendation catalog is owned by the Python package so the CLI and
+# desktop app consume one physical source file. Copy that SSOT into the shipped
+# app; SwiftPM source-checkout tests load it directly from ../../vllm_mlx.
+RECOMMENDATIONS_SRC="$ROOT/../../vllm_mlx/model_recommendations.json"
+if [[ -f "$RECOMMENDATIONS_SRC" ]]; then
+    cp "$RECOMMENDATIONS_SRC" "$CONTENTS/Resources/model_recommendations.json"
+else
+    echo "ERR: shared model_recommendations.json missing" >&2
+    exit 1
+fi
+
 # SwiftMath's upstream resource accessor looks beside `Contents/`, a location
 # that makes a strict app signature invalid. Our vendored resolver loads this
 # nested bundle through Bundle.main instead. Keep the full upstream bundle so

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -1138,6 +1138,38 @@ flow_settings_persistence() {
     baseline settings-persistence.settings-root "$OUT/settings-root.json"
     press "$OUT/settings-root.json" Settings.Category.modelManagement "$OUT/settings-models-open.json"
     wait_settings_stable "$OUT/models-before.json" Settings.Models.ShowAllModelsToggle
+    # GoldenFlow coverage for the recommendation SSOT: the running GUI must
+    # render exactly the smart + fast aliases selected from the same JSON the
+    # CLI consumes. This catches a missing app resource, a decoder drift, and a
+    # third recommendation accidentally creeping back into a tier.
+    local recommendation_json="$ROOT/../../vllm_mlx/model_recommendations.json"
+    local ram_bytes
+    ram_bytes="$(sysctl -n hw.memsize)"
+    local expected_recommendations
+    expected_recommendations="$(python3 - "$recommendation_json" "$ram_bytes" <<'PY'
+import json, sys
+payload = json.load(open(sys.argv[1], encoding="utf-8"))
+ram_gb = int(sys.argv[2]) / (1 << 30)
+tier = payload["tiers"][0]
+for candidate in payload["tiers"]:
+    if ram_gb >= candidate["floor_gb"]:
+        tier = candidate
+print("\n".join(pick["alias"] for pick in tier["picks"]))
+PY
+)"
+    local expected_smart expected_fast
+    expected_smart="$(printf '%s\n' "$expected_recommendations" | sed -n '1p')"
+    expected_fast="$(printf '%s\n' "$expected_recommendations" | sed -n '2p')"
+    [[ -n "$expected_smart" && -n "$expected_fast" && "$(printf '%s\n' "$expected_recommendations" | sed -n '3p')" == "" ]] \
+        || die "recommendation SSOT did not select exactly two aliases"
+    jq -e --arg alias "$expected_smart" \
+        '.data.ui_elements[]? | select(.identifier == ("Settings.ModelManagement.Recommended.Download." + $alias))' \
+        "$OUT/models-before.json" >/dev/null || die "GUI did not render SSOT smart recommendation $expected_smart"
+    jq -e --arg alias "$expected_fast" \
+        '.data.ui_elements[]? | select(.identifier == ("Settings.ModelManagement.Recommended.Download." + $alias))' \
+        "$OUT/models-before.json" >/dev/null || die "GUI did not render SSOT fast recommendation $expected_fast"
+    [[ "$(jq '[.data.ui_elements[]? | select(.identifier == "Settings.ModelManagement.Recommended.primary" or .identifier == "Settings.ModelManagement.Recommended.alt")] | length' "$OUT/models-before.json")" -eq 2 ]] \
+        || die "GUI recommendation section did not render exactly smart + fast cards"
     baseline settings-persistence.models-idle "$OUT/models-before.json"
     local preference_key="rapid.picker.show_all_models.v1"
     press "$OUT/models-before.json" Settings.Models.ShowAllModelsToggle "$OUT/models-toggle.json"

--- a/apps/rapid-mac/scripts/verify-recommendation-tiers.swift
+++ b/apps/rapid-mac/scripts/verify-recommendation-tiers.swift
@@ -9,9 +9,8 @@
 // free script is the CI-runnable verification of the recommendation
 // contract: run `swift apps/rapid-mac/scripts/verify-recommendation-tiers.swift`.
 //
-// It re-declares the pure logic from RAMBucketedDefault + ServerManager.
-// serveArguments. Keep it in sync with those sources; RAMBucketedDefaultTests
-// pins the same contract for the future in-target suite.
+// It decodes the same repository-wide JSON SSOT as RAMBucketedDefault and the
+// Python CLI, then exercises the desktop-specific selection contracts.
 //
 
 import Foundation
@@ -19,49 +18,38 @@ import Foundation
 // Faithful copies of the pure logic under test (RapidTests is excluded
 // from Package.swift, so this standalone script is the real verification).
 
-struct Pick: Equatable {
+struct Pick: Equatable, Decodable {
+    let role: String
     let alias: String
     let footprintGB: Double
     let capabilityPct: Int
     let tokensPerSec: Double?
     let launchFlags: [String]
-    var caveat: String? = nil
+    let caveat: String?
+    enum CodingKeys: String, CodingKey {
+        case role, alias, caveat
+        case footprintGB = "footprint_gb"
+        case capabilityPct = "capability_pct"
+        case tokensPerSec = "tokens_per_sec"
+        case launchFlags = "launch_flags"
+    }
 }
-struct Tier: Equatable {
+struct Tier: Equatable, Decodable {
     let floorGB: Double
-    let primary: Pick
-    let alt: Pick?
-    var picks: [Pick] { alt.map { [primary, $0] } ?? [primary] }
+    let picks: [Pick]
+    var primary: Pick { picks[0] }
+    var alt: Pick? { picks.count > 1 ? picks[1] : nil }
+    enum CodingKeys: String, CodingKey {
+        case floorGB = "floor_gb"
+        case picks
+    }
 }
-let qwen4Pick = Pick(alias: "qwen3.5-4b-4bit", footprintGB: 6.0, capabilityPct: 78,
-                     tokensPerSec: 60.7, launchFlags: [])
-let qwen9Pick = Pick(alias: "qwen3.5-9b-4bit", footprintGB: 8.7, capabilityPct: 82,
-                     tokensPerSec: 35.7, launchFlags: [])
-let lfm1Pick = Pick(alias: "lfm2.5-1b-4bit", footprintGB: 1.9, capabilityPct: 47,
-                    tokensPerSec: 208.4, launchFlags: [], caveat: "Basic chat")
-let lfm26Pick = Pick(alias: "lfm2.5-2.6b-4bit", footprintGB: 3.0, capabilityPct: 64,
-                     tokensPerSec: 93.5, launchFlags: [], caveat: "Not for coding")
-let bonsaiPick = Pick(alias: "bonsai-27b-2bit", footprintGB: 13.0, capabilityPct: 86,
-                      tokensPerSec: 17.5, launchFlags: [])
-let gemma26Pick = Pick(alias: "gemma-4-26b-4bit", footprintGB: 17.0, capabilityPct: 87,
-                       tokensPerSec: 49.5,
-                       launchFlags: ["--no-mllm", "--kv-cache-dtype", "bf16", "--cache-memory-mb", "512"])
-let qwen35bFastPick = Pick(alias: "qwen3.6-35b-4bit", footprintGB: 20.0, capabilityPct: 87,
-                           tokensPerSec: 60.0, launchFlags: [])
-let tiers: [Tier] = [
-    Tier(floorGB: 8, primary: lfm26Pick, alt: lfm1Pick),
-    Tier(floorGB: 16, primary: qwen4Pick, alt: lfm1Pick),
-    Tier(floorGB: 18, primary: qwen9Pick, alt: qwen4Pick),
-    Tier(floorGB: 24, primary: bonsaiPick, alt: qwen4Pick),
-    Tier(floorGB: 32, primary: gemma26Pick, alt: qwen4Pick),
-    Tier(floorGB: 48, primary: gemma26Pick, alt: qwen35bFastPick),
-    Tier(floorGB: 64,
-         primary: Pick(alias: "qwen3.6-35b-8bit", footprintGB: 37.7, capabilityPct: 87, tokensPerSec: nil, launchFlags: []),
-         alt: qwen35bFastPick),
-    Tier(floorGB: 96,
-         primary: Pick(alias: "qwen3.5-122b-mxfp4", footprintGB: 65.0, capabilityPct: 88, tokensPerSec: nil, launchFlags: []),
-         alt: qwen35bFastPick),
-]
+struct Payload: Decodable { let tiers: [Tier] }
+let sourceURL = URL(fileURLWithPath: #filePath)
+    .deletingLastPathComponent().deletingLastPathComponent()
+    .deletingLastPathComponent().deletingLastPathComponent()
+    .appendingPathComponent("vllm_mlx/model_recommendations.json")
+let tiers = try JSONDecoder().decode(Payload.self, from: Data(contentsOf: sourceURL)).tiers
 // Mirror SettingsModelManagementPanel.pickStatsLine / ModelPickerBar
 // tagline: a caveat replaces the capability %, speed leads, caveat trails.
 func pickStatsLine(_ pick: Pick) -> String {

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -8,6 +8,7 @@
 | `rapid-mlx chat` | Interactive chat REPL with a model |
 | `rapid-mlx bench` | Run performance benchmarks |
 | `rapid-mlx models` | List available model aliases |
+| `rapid-mlx recipe` | Recommend the Smart and Fast models for this Mac's RAM |
 | `rapid-mlx info` | Show the per-model profile for an alias or repo |
 | `rapid-mlx pull` | Download a model into the HuggingFace cache |
 | `rapid-mlx rm` | Remove a cached model |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -470,6 +470,7 @@ vllm-mlx-bench = "vllm_mlx.benchmark:main"
 [tool.setuptools.package-data]
 vllm_mlx = [
     "aliases.json",
+    "model_recommendations.json",
     "audio/aliases.json",
     # Download-size manifest (hf_path -> footprint bytes) powering the Size
     # column in `rapid-mlx models` and the size line in `rapid-mlx info`.

--- a/tests/test_model_recommendations.py
+++ b/tests/test_model_recommendations.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import json
+from argparse import Namespace
+
+from vllm_mlx import cli
+from vllm_mlx.model_aliases import list_aliases
+from vllm_mlx.recommendations import load_recommendation_tiers, recommendation_tier
+
+
+def test_every_tier_has_exactly_smart_and_fast() -> None:
+    tiers = load_recommendation_tiers()
+    assert [tier.floor_gb for tier in tiers] == [8, 16, 18, 24, 32, 48, 64, 96]
+    aliases = set(list_aliases())
+    for tier in tiers:
+        assert [pick.role for pick in tier.picks] == ["smart", "fast"]
+        assert all(pick.alias in aliases for pick in tier.picks)
+        assert all(pick.footprint_gb < tier.floor_gb * 0.75 for pick in tier.picks)
+
+
+def test_tier_rounds_down_and_clamps() -> None:
+    assert recommendation_tier(4).floor_gb == 8
+    assert recommendation_tier(20).floor_gb == 18
+    assert recommendation_tier(256).floor_gb == 96
+
+
+def test_recipe_json_is_stable_and_has_two_picks(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(cli, "_scan_hf_cache_models", lambda: [])
+    cli.recipe_command(Namespace(max_ram=32, json=True))
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["tier_floor_gb"] == 32
+    assert [pick["role"] for pick in payload["picks"]] == ["smart", "fast"]
+    assert [pick["alias"] for pick in payload["picks"]] == [
+        "gemma-4-26b-4bit",
+        "qwen3.5-4b-4bit",
+    ]
+    assert payload["picks"][0]["launch_flags"] == [
+        "--no-mllm",
+        "--kv-cache-dtype",
+        "bf16",
+        "--cache-memory-mb",
+        "512",
+    ]
+
+
+def test_recipe_text_prints_ready_to_run_commands(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(cli, "_scan_hf_cache_models", lambda: [])
+    cli.recipe_command(Namespace(max_ram=18, json=False))
+    output = capsys.readouterr().out
+    assert "Smart — qwen3.5-9b-4bit" in output
+    assert "Fast — qwen3.5-4b-4bit" in output
+    assert "rapid-mlx serve qwen3.5-9b-4bit" in output

--- a/tests/test_ram_tier_recommendations_agree.py
+++ b/tests/test_ram_tier_recommendations_agree.py
@@ -18,6 +18,7 @@ mlx-free: pure parsing, no engine import, runs on the Linux CI leg.
 
 from __future__ import annotations
 
+import json
 import re
 import subprocess
 from pathlib import Path
@@ -26,7 +27,7 @@ import pytest
 
 REPO = Path(__file__).resolve().parents[1]
 INSTALL_SH = REPO / "install.sh"
-APP_TIERS = REPO / "apps/rapid-mac/Sources/Rapid/Server/RAMBucketedDefault.swift"
+RECOMMENDATIONS = REPO / "vllm_mlx/model_recommendations.json"
 README = REPO / "README.md"
 
 
@@ -66,43 +67,12 @@ def _parse_install_sh() -> list[tuple[int, str, list[str]]]:
 
 
 def _parse_app_tiers() -> list[tuple[int, str, list[str]]]:
-    """``[(floor_gb, primary_alias, flags)]`` from RAMBucketedDefault."""
-    text = APP_TIERS.read_text()
-    body = re.search(r"static let tiers: \[Tier\] = \[(.*?)\n    \]", text, re.DOTALL)
-    assert body, "tiers array not found in RAMBucketedDefault.swift"
-
-    # Named picks declared above the array (lfm26Pick, lfm2FastPick, …).
-    named: dict[str, tuple[str, list[str]]] = {}
-    for m in re.finditer(
-        r"static let (\w+) = Pick\(\s*alias: \"([^\"]+)\".*?launchFlags: \[([^\]]*)\]",
-        text,
-        re.DOTALL,
-    ):
-        named[m.group(1)] = (m.group(2), re.findall(r'"([^"]+)"', m.group(3)))
-
-    tiers: list[tuple[int, str, list[str]]] = []
-    for chunk in re.finditer(
-        r"Tier\(\s*floorGB: (\d+),\s*primary: (.*?)(?:,\s*alt:|\s*\))",
-        body.group(1),
-        re.DOTALL,
-    ):
-        floor = int(chunk.group(1))
-        primary = chunk.group(2)
-        inline = re.search(
-            r"Pick\(\s*alias: \"([^\"]+)\".*?launchFlags: \[([^\]]*)\]",
-            primary,
-            re.DOTALL,
-        )
-        if inline:
-            tiers.append(
-                (floor, inline.group(1), re.findall(r'"([^"]+)"', inline.group(2)))
-            )
-        else:
-            key = primary.strip().rstrip(",").strip()
-            assert key in named, f"unknown named pick {key!r}"
-            alias, flags = named[key]
-            tiers.append((floor, alias, flags))
-    return tiers
+    """``[(floor_gb, primary_alias, flags)]`` from the shared SSOT."""
+    payload = json.loads(RECOMMENDATIONS.read_text())
+    return [
+        (tier["floor_gb"], tier["picks"][0]["alias"], tier["picks"][0]["launch_flags"])
+        for tier in payload["tiers"]
+    ]
 
 
 def test_both_tables_parse():

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -5258,6 +5258,57 @@ def _print_cached_models() -> None:
     print()
 
 
+def recipe_command(args) -> None:
+    """Recommend exactly two curated models for this Mac's RAM tier."""
+    import json
+
+    from vllm_mlx.model_aliases import resolve_profile
+    from vllm_mlx.recommendations import physical_ram_gb, recommendation_payload
+
+    ram_gb = (
+        float(args.max_ram)
+        if getattr(args, "max_ram", None) is not None
+        else physical_ram_gb()
+    )
+    if ram_gb <= 0:
+        raise SystemExit("Could not detect physical RAM. Pass --max-ram GB explicitly.")
+    payload = recommendation_payload(ram_gb)
+    cached_repos = {repo.casefold() for repo, _, _ in _scan_hf_cache_models()}
+    for pick in payload["picks"]:
+        try:
+            profile = resolve_profile(pick["alias"])
+            hf_path = profile.hf_path if profile is not None else None
+        except ValueError:
+            hf_path = None
+        pick["hf_path"] = hf_path
+        pick["cached"] = bool(hf_path and hf_path.casefold() in cached_repos)
+
+    if getattr(args, "json", False):
+        print(json.dumps(payload, indent=2, sort_keys=True))
+        return
+
+    print(
+        f"Recommended for this {payload['physical_ram_gb']:.1f} GB Mac "
+        f"({payload['tier_floor_gb']} GB tier)"
+    )
+    labels = {"smart": "Smart", "fast": "Fast"}
+    for index, pick in enumerate(payload["picks"], start=1):
+        stats = [f"{pick['footprint_gb']:.1f} GB"]
+        if pick.get("caveat"):
+            stats.append(pick["caveat"])
+        else:
+            stats.append(f"{pick['capability_pct']}% capability")
+        if pick.get("tokens_per_sec") is not None:
+            stats.append(f"~{round(pick['tokens_per_sec'])} tok/s")
+        cache_badge = " · cached" if pick["cached"] else ""
+        print(f"\n{index}. {labels[pick['role']]} — {pick['alias']}{cache_badge}")
+        print(f"   {' · '.join(stats)}")
+        command = f"rapid-mlx serve {pick['alias']}"
+        if pick["launch_flags"]:
+            command += " " + " ".join(pick["launch_flags"])
+        print(f"   {command}")
+
+
 def models_command(args):
     """List available model aliases with their per-model profile capabilities.
 
@@ -9252,6 +9303,19 @@ Examples:
         help="Only list models that are downloaded to the local HuggingFace "
         "cache (alias, HF repo, size on disk, last modified).",
     )
+    recipe_parser = subparsers.add_parser(
+        "recipe", help="Recommend the smart and fast models for this Mac"
+    )
+    recipe_parser.add_argument(
+        "--max-ram",
+        type=float,
+        default=None,
+        metavar="GB",
+        help="Use this RAM size instead of auto-detecting the current Mac",
+    )
+    recipe_parser.add_argument(
+        "--json", action="store_true", help="Print the recommendation as JSON"
+    )
     subparsers.add_parser(
         "ls",
         help="List models in the local HuggingFace cache (alias for `models --cached`)",
@@ -10009,6 +10073,8 @@ Examples:
         bench_command(args)
     elif args.command == "models":
         models_command(args)
+    elif args.command == "recipe":
+        recipe_command(args)
     elif args.command == "ls":
         # `ls` is a top-level alias for `models --cached`. Synthesize the
         # missing flag so models_command's branch fires without having to

--- a/vllm_mlx/model_recommendations.json
+++ b/vllm_mlx/model_recommendations.json
@@ -1,0 +1,62 @@
+{
+  "schema_version": 1,
+  "strategy": "Two curated general-purpose choices per RAM tier: smart first, fast second. Prefer models with verified agentic/tool use and measured Rapid-MLX serving behavior.",
+  "tiers": [
+    {
+      "floor_gb": 8,
+      "picks": [
+        {"role": "smart", "alias": "lfm2.5-2.6b-4bit", "footprint_gb": 3.0, "capability_pct": 64, "tokens_per_sec": 93.5, "caveat": "Not for coding", "launch_flags": []},
+        {"role": "fast", "alias": "lfm2.5-1b-4bit", "footprint_gb": 1.9, "capability_pct": 47, "tokens_per_sec": 208.4, "caveat": "Basic chat", "launch_flags": []}
+      ]
+    },
+    {
+      "floor_gb": 16,
+      "picks": [
+        {"role": "smart", "alias": "qwen3.5-4b-4bit", "footprint_gb": 6.0, "capability_pct": 78, "tokens_per_sec": 60.7, "launch_flags": []},
+        {"role": "fast", "alias": "lfm2.5-1b-4bit", "footprint_gb": 1.9, "capability_pct": 47, "tokens_per_sec": 208.4, "caveat": "Basic chat", "launch_flags": []}
+      ]
+    },
+    {
+      "floor_gb": 18,
+      "picks": [
+        {"role": "smart", "alias": "qwen3.5-9b-4bit", "footprint_gb": 8.7, "capability_pct": 82, "tokens_per_sec": 35.7, "launch_flags": []},
+        {"role": "fast", "alias": "qwen3.5-4b-4bit", "footprint_gb": 6.0, "capability_pct": 78, "tokens_per_sec": 60.7, "launch_flags": []}
+      ]
+    },
+    {
+      "floor_gb": 24,
+      "picks": [
+        {"role": "smart", "alias": "bonsai-27b-2bit", "footprint_gb": 13.0, "capability_pct": 86, "tokens_per_sec": 17.5, "launch_flags": []},
+        {"role": "fast", "alias": "qwen3.5-4b-4bit", "footprint_gb": 6.0, "capability_pct": 78, "tokens_per_sec": 60.7, "launch_flags": []}
+      ]
+    },
+    {
+      "floor_gb": 32,
+      "picks": [
+        {"role": "smart", "alias": "gemma-4-26b-4bit", "footprint_gb": 17.0, "capability_pct": 87, "tokens_per_sec": 49.5, "launch_flags": ["--no-mllm", "--kv-cache-dtype", "bf16", "--cache-memory-mb", "512"]},
+        {"role": "fast", "alias": "qwen3.5-4b-4bit", "footprint_gb": 6.0, "capability_pct": 78, "tokens_per_sec": 60.7, "launch_flags": []}
+      ]
+    },
+    {
+      "floor_gb": 48,
+      "picks": [
+        {"role": "smart", "alias": "gemma-4-26b-4bit", "footprint_gb": 17.0, "capability_pct": 87, "tokens_per_sec": 49.5, "launch_flags": ["--no-mllm", "--kv-cache-dtype", "bf16", "--cache-memory-mb", "512"]},
+        {"role": "fast", "alias": "qwen3.6-35b-4bit", "footprint_gb": 20.0, "capability_pct": 87, "tokens_per_sec": 60.0, "launch_flags": []}
+      ]
+    },
+    {
+      "floor_gb": 64,
+      "picks": [
+        {"role": "smart", "alias": "qwen3.6-35b-8bit", "footprint_gb": 37.7, "capability_pct": 87, "tokens_per_sec": null, "launch_flags": []},
+        {"role": "fast", "alias": "qwen3.6-35b-4bit", "footprint_gb": 20.0, "capability_pct": 87, "tokens_per_sec": 60.0, "launch_flags": []}
+      ]
+    },
+    {
+      "floor_gb": 96,
+      "picks": [
+        {"role": "smart", "alias": "qwen3.5-122b-mxfp4", "footprint_gb": 65.0, "capability_pct": 88, "tokens_per_sec": null, "launch_flags": []},
+        {"role": "fast", "alias": "qwen3.6-35b-4bit", "footprint_gb": 20.0, "capability_pct": 87, "tokens_per_sec": 60.0, "launch_flags": []}
+      ]
+    }
+  ]
+}

--- a/vllm_mlx/recommendations.py
+++ b/vllm_mlx/recommendations.py
@@ -1,0 +1,100 @@
+"""Shared RAM-tier model recommendations for CLI and Rapid Desktop."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from dataclasses import asdict, dataclass
+from importlib.resources import files
+from typing import Any
+
+
+@dataclass(frozen=True)
+class Recommendation:
+    role: str
+    alias: str
+    footprint_gb: float
+    capability_pct: int
+    tokens_per_sec: float | None
+    launch_flags: tuple[str, ...]
+    caveat: str | None = None
+
+
+@dataclass(frozen=True)
+class RecommendationTier:
+    floor_gb: int
+    picks: tuple[Recommendation, Recommendation]
+
+
+def load_recommendation_tiers() -> tuple[RecommendationTier, ...]:
+    resource = files("vllm_mlx").joinpath("model_recommendations.json")
+    payload = json.loads(resource.read_text(encoding="utf-8"))
+    if payload.get("schema_version") != 1:
+        raise ValueError("unsupported model recommendation schema")
+
+    tiers: list[RecommendationTier] = []
+    for raw_tier in payload["tiers"]:
+        picks = tuple(
+            Recommendation(
+                role=raw["role"],
+                alias=raw["alias"],
+                footprint_gb=float(raw["footprint_gb"]),
+                capability_pct=int(raw["capability_pct"]),
+                tokens_per_sec=(
+                    None
+                    if raw.get("tokens_per_sec") is None
+                    else float(raw["tokens_per_sec"])
+                ),
+                launch_flags=tuple(raw.get("launch_flags", ())),
+                caveat=raw.get("caveat"),
+            )
+            for raw in raw_tier["picks"]
+        )
+        if len(picks) != 2 or [pick.role for pick in picks] != ["smart", "fast"]:
+            raise ValueError(
+                f"RAM tier {raw_tier['floor_gb']} must contain smart + fast picks"
+            )
+        tiers.append(RecommendationTier(int(raw_tier["floor_gb"]), picks))
+    if not tiers or list(tiers) != sorted(tiers, key=lambda tier: tier.floor_gb):
+        raise ValueError("recommendation tiers must be sorted by floor_gb")
+    return tuple(tiers)
+
+
+def physical_ram_gb() -> float:
+    """Return physical RAM on macOS, or zero when the probe is unavailable."""
+    try:
+        output = subprocess.run(
+            ["sysctl", "-n", "hw.memsize"],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=2,
+        ).stdout.strip()
+        # Match Rapid Desktop's MacHardware.physicalRAMGB exactly. Apple sells
+        # RAM in GiB-sized tiers and the Swift side divides by 2^30; decimal GB
+        # here would select a different tier near an 18/24/48 GB boundary.
+        return int(output) / float(1 << 30)
+    except (OSError, ValueError, subprocess.SubprocessError):
+        return 0.0
+
+
+def recommendation_tier(ram_gb: float) -> RecommendationTier:
+    tiers = load_recommendation_tiers()
+    chosen = tiers[0]
+    for tier in tiers:
+        if ram_gb >= tier.floor_gb:
+            chosen = tier
+    return chosen
+
+
+def recommendation_payload(ram_gb: float) -> dict[str, Any]:
+    tier = recommendation_tier(ram_gb)
+    return {
+        "schema_version": 1,
+        "physical_ram_gb": round(ram_gb, 1),
+        "tier_floor_gb": tier.floor_gb,
+        "picks": [
+            {**asdict(pick), "launch_flags": list(pick.launch_flags)}
+            for pick in tier.picks
+        ],
+    }


### PR DESCRIPTION
## What changed

- adds `vllm_mlx/model_recommendations.json` as the single source of truth for eight RAM tiers
- keeps exactly two curated choices per tier: Smart and Fast
- migrates Rapid Desktop recommendation, cache preference, sizing exemptions, and launch flags to decode that catalog
- adds `rapid-mlx recipe`, with RAM auto-detection, `--max-ram`, cached badges, ready-to-run commands, and stable `--json` output
- packages the same catalog in wheels and the shipped macOS app
- updates installer/README parity checks and adds Python/Swift catalog contracts
- extends the Settings GoldenFlow to assert the running GUI renders exactly the SSOT-selected Smart and Fast cards

## Why

The installer, CLI, and desktop app have all answered “what should this Mac run,” but the recommendation data lived in Swift and was mirrored elsewhere. That makes model changes drift-prone and prevents the CLI from exposing the curated, measured desktop guidance. One declarative catalog gives both front ends the same aliases, footprints, capability scores, throughput, caveats, and required launch flags, and creates a small explicit model set for future performance tuning.

Closes #386.

## Validation

- `python3 -m pytest -q tests/test_model_recommendations.py tests/test_ram_tier_recommendations_agree.py` — 25 passed
- CLI neighboring suite — 118 passed; one existing argcomplete subprocess handshake returns no completions under local Python 3.14
- `swift apps/rapid-mac/scripts/verify-recommendation-tiers.swift` — all pass
- `swift test --package-path apps/rapid-mac` — 2037 passed
- `apps/rapid-mac/scripts/build.sh` — release app built; packaged catalog byte-identical to SSOT
- Ruff and `git diff --check` clean

## AI assistance disclosure

Codex implemented and reviewed the shared schema, Python/Swift consumers, CLI surface, tests, GoldenFlow assertion, documentation, and packaging changes. The maintainer chose the SSOT direction and the two-model-per-tier product policy.