### PR TITLE
chore: bump version to 0.12.10

### DIFF
--- a/apps/rapid-mac/CHANGELOG.md
+++ b/apps/rapid-mac/CHANGELOG.md
@@ -13,6 +13,47 @@ can actually understand.
 
 ## [Unreleased]
 
+## [0.12.10] — 2026-08-11
+
+Settings got a full visual refresh: every category now shares one design —
+consistent cards, buttons, switches, and spacing, in both Light and Dark —
+and tools and connectors introduce themselves with plain names and short
+descriptions instead of wire identifiers. The menu bar now shows the official
+Rapid "R" mark, drawn the native way so macOS keeps it crisp in Light, Dark,
+and while the menu is open. Update availability lives in the menu's
+"Update available" row and in Settings → App.
+
+### Added
+
+- A new model in the catalog: Ling 3.0 tiny, a fast hybrid model that runs
+  in about 5 GB of memory.
+- Very large mixture-of-experts models can now stream their expert weights
+  from disk instead of holding everything in memory (`--disk-stream` for
+  advanced setups).
+
+### Changed
+
+- Settings: unified visual system across Model Management, Tools,
+  Connectors, Appearance, Privacy, and App — amber selection, consistent
+  card padding and control heights, native switches and forms, and layouts
+  that adapt down to small windows.
+- The Audio tab's mode selector uses the same segmented control as
+  Settings, fixing the hard-to-read white-on-amber selection.
+- Model recommendations now share one RAM-tier source, so Chat and
+  first-run suggestions agree about what fits on your Mac.
+- Cached-model defaults prefer the best model you already have, not just
+  the most recent one.
+
+### Fixed
+
+- Downloads report honest progress and failures instead of optimistic
+  placeholders, and built-in web tools are harder to misuse.
+- First-launch no longer probes the model catalog before you've picked
+  anything, and onboarding language is clearer.
+- The storage overview adds up correctly, and Markdown tables read
+  properly with VoiceOver.
+- Third-party license texts ship inside the app bundle as required.
+
 ## [0.12.9] — 2026-08-10
 
 The desktop app can hear and speak now: a new Audio tab turns recordings into

--- a/apps/rapid-mac/Resources/Info.plist
+++ b/apps/rapid-mac/Resources/Info.plist
@@ -19,15 +19,15 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.12.9</string>
+	<string>0.12.10</string>
 	<key>CFBundleVersion</key>
-	<string>153</string>
+	<string>154</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>14.0</string>
-	<key>NSHighResolutionCapable</key>
-	<true/>
 	<key>NSAccentColorName</key>
 	<string>AccentColor</string>
+	<key>NSHighResolutionCapable</key>
+	<true/>
 	<key>NSNetworkVolumesUsageDescription</key>
 	<string>Rapid needs access when you choose a network drive for model storage or approve a file tool there. Click Allow to continue.</string>
 	<key>NSRemovableVolumesUsageDescription</key>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.12.9"
+version = "0.12.10"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Why

Cut the 0.12.10 release — 23-commit delta since v0.12.9, shipping:

- **Unified macOS Settings UI + official R menu-bar mark** (#1828)
- **Ling 3.0** vendored bailing_hybrid backbone + `ling-3.0-tiny-4bit` alias (#1817 / #1819 / #1823 / #1826)
- **`--disk-stream`**: stream MoE routed-expert weights from disk (#1803)
- MLLM scheduler error propagation (#1810), auth fail-closed (#1811)
- Suite order-flake fixes — full unit gate now deterministic (#1830)
- Shared RAM-tier model recommendations (#1832), XCUITest pixel coverage (#1820), download honesty + web-tool hardening (#1813), and assorted mac fixes

## Bump contents

- `pyproject.toml` → 0.12.10
- `apps/rapid-mac/Resources/Info.plist` → 0.12.10 / build 154
- `apps/rapid-mac/CHANGELOG.md` → new 0.12.10 section

## Pre-bump validation (local, on merged main 07324ab9)

- Full unit suite: **17011 passed, 0 failed**
- `make release-smoke`: clean-venv import of every release surface — OK
- `make lint`: clean; `tests/test_version_sync.py`: 23 passed
- Live smoke: qwen3.6-35b-8bit chat + forced tool-call — green
- rapid-mac: bundle builds; DevSnapshot GUI verification of the new Settings/menu-bar — clean

Merging fires auto-release: Studio Tier-1 agent gate → tag v0.12.10 + rapid-mac-v0.12.10 → PyPI + Homebrew + desktop DMG.