### PR TITLE
fix(scheduler): bound hybrid Metal cache handles

### DIFF
--- a/tests/test_scheduler_recurrent_cache_materialization.py
+++ b/tests/test_scheduler_recurrent_cache_materialization.py
@@ -30,6 +30,11 @@ class _Layer:
         self.head = _Node(self.head)
 
 
+class _UnclassifiableLayer(_Layer):
+    def is_trimmable(self):
+        raise RuntimeError("unknown cache classification")
+
+
 class _Batch:
     def __init__(self, cache):
         self.prompt_cache = cache
@@ -97,6 +102,18 @@ def test_dense_batch_does_not_pay_per_token_eval(monkeypatch):
 
     assert scheduler._materialize_active_recurrent_cache() == 0
     assert evaluations == []
+
+
+def test_unknown_cache_classification_fails_safe_to_materialization(monkeypatch):
+    unknown = _UnclassifiableLayer(trimmable=True)
+    scheduler = _scheduler_with([unknown])
+    evaluations = []
+    monkeypatch.setattr(
+        scheduler_module.mx, "eval", lambda value: evaluations.append(value)
+    )
+
+    assert scheduler._materialize_active_recurrent_cache() == 1
+    assert evaluations == [[[unknown.head]]]
 
 
 def test_legacy_active_batch_surface_is_covered(monkeypatch):

--- a/tests/test_scheduler_recurrent_cache_materialization.py
+++ b/tests/test_scheduler_recurrent_cache_materialization.py
@@ -35,6 +35,15 @@ class _UnclassifiableLayer(_Layer):
         raise RuntimeError("unknown cache classification")
 
 
+class _UnclassifiedLayer:
+    def __init__(self):
+        self.head = _Node()
+
+    @property
+    def state(self):
+        return [self.head]
+
+
 class _Batch:
     def __init__(self, cache):
         self.prompt_cache = cache
@@ -106,6 +115,18 @@ def test_dense_batch_does_not_pay_per_token_eval(monkeypatch):
 
 def test_unknown_cache_classification_fails_safe_to_materialization(monkeypatch):
     unknown = _UnclassifiableLayer(trimmable=True)
+    scheduler = _scheduler_with([unknown])
+    evaluations = []
+    monkeypatch.setattr(
+        scheduler_module.mx, "eval", lambda value: evaluations.append(value)
+    )
+
+    assert scheduler._materialize_active_recurrent_cache() == 1
+    assert evaluations == [[[unknown.head]]]
+
+
+def test_missing_cache_classification_fails_safe_to_materialization(monkeypatch):
+    unknown = _UnclassifiedLayer()
     scheduler = _scheduler_with([unknown])
     evaluations = []
     monkeypatch.setattr(

--- a/tests/test_scheduler_recurrent_cache_materialization.py
+++ b/tests/test_scheduler_recurrent_cache_materialization.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-import inspect
+from types import SimpleNamespace
 
 from vllm_mlx import scheduler as scheduler_module
 from vllm_mlx.scheduler import Scheduler
@@ -149,10 +149,44 @@ def test_legacy_active_batch_surface_is_covered(monkeypatch):
     assert evaluations == [[[recurrent.head]]]
 
 
-def test_step_wires_barrier_immediately_after_batch_advance():
-    source = inspect.getsource(Scheduler.step)
-    advance = source.index("raw_next = self.batch_generator.next()")
-    barrier = source.index("self._materialize_active_recurrent_cache()")
-    response_handling = source.index("if isinstance(raw_next, tuple):")
+def test_step_runs_barrier_after_advance_before_response_handling(monkeypatch):
+    events = []
+    response = object()
 
-    assert advance < barrier < response_handling
+    class _StepGenerator:
+        def next(self):
+            events.append("next")
+            return [response]
+
+    scheduler = Scheduler.__new__(Scheduler)
+    scheduler.batch_generator = _StepGenerator()
+    scheduler.running = {"request": object()}
+    scheduler.finished_req_ids = set()
+    scheduler._stateful_tombstones = set()
+    scheduler._clear_cache_interval = 32
+    scheduler._step_count = 0
+    scheduler._memory_log_interval = 256
+    scheduler.config = SimpleNamespace()
+
+    monkeypatch.setattr(scheduler, "_process_pending_aborts", lambda: None)
+    monkeypatch.setattr(scheduler, "_reconcile_orphaned_running_requests", lambda: [])
+    monkeypatch.setattr(scheduler, "_schedule_waiting", lambda: [])
+    monkeypatch.setattr(scheduler, "_realign_guard_armed", lambda: False)
+    monkeypatch.setattr(scheduler, "_apply_adaptive_prefill_size", lambda: None)
+    monkeypatch.setattr(
+        scheduler,
+        "_materialize_active_recurrent_cache",
+        lambda: events.append("barrier"),
+    )
+
+    def process(responses):
+        assert responses == [response]
+        events.append("responses")
+        return [], set()
+
+    monkeypatch.setattr(scheduler, "_process_batch_responses", process)
+    monkeypatch.setattr(scheduler, "_cleanup_finished", lambda finished: None)
+
+    scheduler.step()
+
+    assert events == ["next", "barrier", "responses"]

--- a/tests/test_scheduler_recurrent_cache_materialization.py
+++ b/tests/test_scheduler_recurrent_cache_materialization.py
@@ -95,9 +95,10 @@ def test_recurrent_cache_barrier_bounds_lazy_decode_chain(monkeypatch):
     for _ in range(1_000):
         recurrent.advance()
         dense.advance()
-        assert scheduler._materialize_active_recurrent_cache() == 2
+        assert scheduler._materialize_active_recurrent_cache() == 1
 
     assert len(evaluations) == 1_000
+    assert evaluations[-1] == [[recurrent.head]]
     assert _chain_length(recurrent.head) == 1
 
 

--- a/tests/test_scheduler_recurrent_cache_materialization.py
+++ b/tests/test_scheduler_recurrent_cache_materialization.py
@@ -150,7 +150,7 @@ def test_legacy_active_batch_surface_is_covered(monkeypatch):
     assert evaluations == [[[recurrent.head]]]
 
 
-def test_step_runs_barrier_after_advance_before_response_handling(monkeypatch):
+def test_step_bounds_barrier_interval_and_preserves_event_order(monkeypatch):
     events = []
     response = object()
 
@@ -188,6 +188,10 @@ def test_step_runs_barrier_after_advance_before_response_handling(monkeypatch):
     monkeypatch.setattr(scheduler, "_process_batch_responses", process)
     monkeypatch.setattr(scheduler, "_cleanup_finished", lambda finished: None)
 
-    scheduler.step()
+    for _ in range(9):
+        scheduler.step()
 
-    assert events == ["next", "barrier", "responses"]
+    assert events[:3] == ["next", "barrier", "responses"]
+    assert events[-3:] == ["next", "barrier", "responses"]
+    assert events.count("barrier") == 2
+    assert events.count("next") == events.count("responses") == 9

--- a/tests/test_scheduler_recurrent_cache_materialization.py
+++ b/tests/test_scheduler_recurrent_cache_materialization.py
@@ -1,0 +1,120 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression coverage for Metal handle exhaustion in hybrid text batches."""
+
+from __future__ import annotations
+
+import inspect
+
+from vllm_mlx import scheduler as scheduler_module
+from vllm_mlx.scheduler import Scheduler
+
+
+class _Node:
+    def __init__(self, parent=None):
+        self.parent = parent
+
+
+class _Layer:
+    def __init__(self, *, trimmable: bool):
+        self._trimmable = trimmable
+        self.head = _Node()
+
+    @property
+    def state(self):
+        return [self.head]
+
+    def is_trimmable(self):
+        return self._trimmable
+
+    def advance(self):
+        self.head = _Node(self.head)
+
+
+class _Batch:
+    def __init__(self, cache):
+        self.prompt_cache = cache
+
+
+class _Generator:
+    def __init__(self, cache, *, modern=True):
+        if modern:
+            self._generation_batch = _Batch(cache)
+        else:
+            self.active_batch = _Batch(cache)
+
+
+def _scheduler_with(cache, *, modern=True):
+    scheduler = Scheduler.__new__(Scheduler)
+    scheduler.batch_generator = _Generator(cache, modern=modern)
+    return scheduler
+
+
+def _chain_length(node):
+    length = 0
+    while node is not None:
+        length += 1
+        node = node.parent
+    return length
+
+
+def test_recurrent_cache_barrier_bounds_lazy_decode_chain(monkeypatch):
+    """Fixed live cache count must not hide a per-step Metal handle chain.
+
+    ``_Node.parent`` models MLX's functional recurrent-state update: the live
+    head retains every prior update until ``mx.eval`` realizes and detaches it.
+    One cache entry and 1,000 decode steps therefore reproduce the issue's
+    count-vs-bytes distinction without loading 35B weights or waiting 90 min.
+    """
+    recurrent = _Layer(trimmable=False)
+    dense = _Layer(trimmable=True)
+    scheduler = _scheduler_with([dense, recurrent])
+    evaluations = []
+
+    def evaluate(states):
+        evaluations.append(states)
+        for state in states:
+            for node in state:
+                node.parent = None
+
+    monkeypatch.setattr(scheduler_module.mx, "eval", evaluate)
+
+    for _ in range(1_000):
+        recurrent.advance()
+        dense.advance()
+        assert scheduler._materialize_active_recurrent_cache() == 2
+
+    assert len(evaluations) == 1_000
+    assert _chain_length(recurrent.head) == 1
+
+
+def test_dense_batch_does_not_pay_per_token_eval(monkeypatch):
+    dense = _Layer(trimmable=True)
+    scheduler = _scheduler_with([dense])
+    evaluations = []
+    monkeypatch.setattr(
+        scheduler_module.mx, "eval", lambda value: evaluations.append(value)
+    )
+
+    assert scheduler._materialize_active_recurrent_cache() == 0
+    assert evaluations == []
+
+
+def test_legacy_active_batch_surface_is_covered(monkeypatch):
+    recurrent = _Layer(trimmable=False)
+    scheduler = _scheduler_with([recurrent], modern=False)
+    evaluations = []
+    monkeypatch.setattr(
+        scheduler_module.mx, "eval", lambda value: evaluations.append(value)
+    )
+
+    assert scheduler._materialize_active_recurrent_cache() == 1
+    assert evaluations == [[[recurrent.head]]]
+
+
+def test_step_wires_barrier_immediately_after_batch_advance():
+    source = inspect.getsource(Scheduler.step)
+    advance = source.index("raw_next = self.batch_generator.next()")
+    barrier = source.index("self._materialize_active_recurrent_cache()")
+    response_handling = source.index("if isinstance(raw_next, tuple):")
+
+    assert advance < barrier < response_handling

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -7459,6 +7459,7 @@ class Scheduler:
                     # cache-miss prefill is approaching the unified-memory cap.
                     self._apply_adaptive_prefill_size()
                     raw_next = self.batch_generator.next()
+                    self._materialize_active_recurrent_cache()
                     output.has_work = True
 
                     # mlx-lm 0.31+ returns (prompt_responses, generation_responses) tuple
@@ -7588,6 +7589,46 @@ class Scheduler:
                 pass
 
         return output
+
+    def _materialize_active_recurrent_cache(self) -> int:
+        """Detach lazy recurrent-cache updates from prior decode steps.
+
+        MLX cache implementations such as ``ArraysCache`` update recurrent
+        state functionally.  Without an evaluation barrier, the live batch
+        keeps the head of a graph that references every earlier decode step.
+        The byte footprint can stay flat while Metal's live buffer-handle
+        count grows until its 499000-resource ceiling is reached (#1827).
+
+        Dense KV caches use in-place writes and do not need this per-token
+        synchronization.  Gate on an affirmative non-trimmable layer and
+        evaluate the complete cache state only for hybrid batches.
+        """
+        batch_generator = self.batch_generator
+        if batch_generator is None:
+            return 0
+        generation_batch = getattr(batch_generator, "_generation_batch", None)
+        if generation_batch is None:
+            generation_batch = getattr(batch_generator, "active_batch", None)
+        cache = getattr(generation_batch, "prompt_cache", None)
+        if not cache:
+            return 0
+
+        has_recurrent_state = False
+        states = []
+        for layer in cache:
+            is_trimmable = getattr(layer, "is_trimmable", None)
+            if callable(is_trimmable):
+                try:
+                    has_recurrent_state |= not bool(is_trimmable())
+                except Exception:
+                    pass
+            state = getattr(layer, "state", None)
+            if state is not None:
+                states.append(state)
+        if not has_recurrent_state or not states:
+            return 0
+        mx.eval(states)
+        return len(states)
 
     def get_request(self, request_id: str) -> Request | None:
         """Get a request by ID."""

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -7626,6 +7626,11 @@ class Scheduler:
                     # preventing an unbounded lazy-state graph.  An extra eval
                     # is safe; skipping one for a recurrent cache is not.
                     has_recurrent_state = True
+            else:
+                # Supported modern dense caches affirmatively implement this
+                # method. Missing/non-callable classification is unknown, so
+                # retain the same safety-first behavior as a raised classifier.
+                has_recurrent_state = True
             state = getattr(layer, "state", None)
             if state is not None:
                 states.append(state)

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -7600,8 +7600,9 @@ class Scheduler:
         count grows until its 499000-resource ceiling is reached (#1827).
 
         Dense KV caches use in-place writes and do not need this per-token
-        synchronization.  Gate on an affirmative non-trimmable layer and
-        evaluate the complete cache state only for hybrid batches.
+        synchronization. Evaluate only the non-trimmable/unknown layer states:
+        materializing dense KV layers too would add an unnecessary per-token
+        synchronization cost to hybrid models.
         """
         batch_generator = self.batch_generator
         if batch_generator is None:
@@ -7613,28 +7614,28 @@ class Scheduler:
         if not cache:
             return 0
 
-        has_recurrent_state = False
         states = []
         for layer in cache:
             is_trimmable = getattr(layer, "is_trimmable", None)
             if callable(is_trimmable):
                 try:
-                    has_recurrent_state |= not bool(is_trimmable())
+                    materialize = not bool(is_trimmable())
                 except Exception:
                     # Classification is a safety gate: treating an unknown
                     # cache as dense would silently disable the only barrier
                     # preventing an unbounded lazy-state graph.  An extra eval
                     # is safe; skipping one for a recurrent cache is not.
-                    has_recurrent_state = True
+                    materialize = True
             else:
                 # Supported modern dense caches affirmatively implement this
                 # method. Missing/non-callable classification is unknown, so
                 # retain the same safety-first behavior as a raised classifier.
-                has_recurrent_state = True
-            state = getattr(layer, "state", None)
-            if state is not None:
-                states.append(state)
-        if not has_recurrent_state or not states:
+                materialize = True
+            if materialize:
+                state = getattr(layer, "state", None)
+                if state is not None:
+                    states.append(state)
+        if not states:
             return 0
         mx.eval(states)
         return len(states)

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -67,6 +67,11 @@ from .utils.mamba_cache import ensure_mamba_support
 
 logger = logging.getLogger(__name__)
 
+# Functional hybrid cache updates retain their prior lazy graph until an eval
+# barrier. Eight steps bounds that graph to a few hundred live Metal handles on
+# current 40-layer families while amortizing the synchronization cost.
+_RECURRENT_CACHE_MATERIALIZE_INTERVAL = 8
+
 
 def _pflash_compressed(request: Request) -> bool:
     """Whether PFlash replaced this request's prompt with a compressed
@@ -7459,7 +7464,12 @@ class Scheduler:
                     # cache-miss prefill is approaching the unified-memory cap.
                     self._apply_adaptive_prefill_size()
                     raw_next = self.batch_generator.next()
-                    self._materialize_active_recurrent_cache()
+                    # Bound functional recurrent-state graphs without forcing
+                    # a host synchronization on every token. Step zero arms
+                    # the barrier for a newly-created scheduler; thereafter a
+                    # live chain can retain at most eight decode updates.
+                    if self._step_count % _RECURRENT_CACHE_MATERIALIZE_INTERVAL == 0:
+                        self._materialize_active_recurrent_cache()
                     output.has_work = True
 
                     # mlx-lm 0.31+ returns (prompt_responses, generation_responses) tuple
@@ -7599,8 +7609,10 @@ class Scheduler:
         The byte footprint can stay flat while Metal's live buffer-handle
         count grows until its 499000-resource ceiling is reached (#1827).
 
-        Dense KV caches use in-place writes and do not need this per-token
-        synchronization. Evaluate only the non-trimmable/unknown layer states:
+        The caller runs this barrier on the first decode step and every eight
+        steps thereafter. That keeps graph depth O(1) while avoiding a costly
+        host synchronization on every token. Dense KV caches use in-place
+        writes and do not need it. Evaluate only non-trimmable/unknown states:
         materializing dense KV layers too would add an unnecessary per-token
         synchronization cost to hybrid models.
         """

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -7621,7 +7621,11 @@ class Scheduler:
                 try:
                     has_recurrent_state |= not bool(is_trimmable())
                 except Exception:
-                    pass
+                    # Classification is a safety gate: treating an unknown
+                    # cache as dense would silently disable the only barrier
+                    # preventing an unbounded lazy-state graph.  An extra eval
+                    # is safe; skipping one for a recurrent cache is not.
+                    has_recurrent_state = True
             state = getattr(layer, "state", None)
             if state is not None:
                 states.append(state)


### PR DESCRIPTION
## Summary

- materialize only live hybrid recurrent cache states on the first decode step and every eight steps thereafter
- keep dense KV batches on the existing fast path with no extra evaluation, while bounding a recurrent lazy graph to eight updates
- add an accelerated 1,000-update resource-lifetime regression plus behavioral scheduler wiring/interval coverage

## Root cause

Hybrid `ArraysCache` state is updated functionally. The active batch therefore retained a lazy graph back through prior decode steps. Periodic token evaluation and `mx.clear_cache()` did not evaluate that cache state, so Metal live buffer handles grew while active bytes and the bounded `--hybrid-cache-entries 8` entry count stayed stable. 0.12.x boundary/N-1 reuse made this batch-hybrid path frequent enough to hit Metal’s 499000-resource ceiling.

The fix evaluates only non-trimmable or unknown cache states on step zero and every eight decode advances. This keeps retained graph depth constant without imposing a per-token synchronization or evaluating dense KV state.

## Validation

- accelerated repro: one live hybrid cache, 1,000 functional updates; each barrier returns the chain to depth 1
- behavioral scheduler test: barrier order is `BatchGenerator.next()` → materialization → response handling, at steps 0 and 8
- adjacent hybrid/prefix suite: 87 passed
- full unit: 17,190 passed, 58 skipped
- hardware stress/integration/bench: 4 model families × 3 lanes, PASS
- Qwen3.5 diff-vs-base bench: cold -11.2%, warm +0.6%
- Codex review: no blocking issues
- pr_validate verdict: MERGE-SAFE

Closes #1827