### PR TITLE
feat(telemetry): alert on empty and short completions per release

### DIFF
--- a/docs/plans/telemetry-golden-profile.md
+++ b/docs/plans/telemetry-golden-profile.md
@@ -48,14 +48,15 @@ Phase 1 has **no event call sites** — `is_enabled()` exists, but
 nothing calls it to actually emit. The package compiles, has tests,
 and ships dark.
 
-### 2.2 Server (`~/work/Rapid-MLX-telemetry-worker/`) — Phase 1 complete, deploy blocked
+### 2.2 Server (`~/work/Rapid-MLX-telemetry-worker/`) — deployed
 
 | Component | State |
 |---|---|
 | Worker handler `src/index.js` (165 LOC) | POST `/v1/events`, validates `schema_version == 1`, body cap 256 KB, batch cap 100 events, 50ms CPU cap, stamps `received_at`. Writes one NDJSON object per batch to R2 key `events/YYYY/MM/DD/HH/<rand12>.ndjson`. |
 | Privacy invariants pinned by `test/worker.test.js` | (1) does not read `CF-Connecting-IP` / `X-Forwarded-For` / `X-Real-IP` / UA; (2) does not forward any request header to R2; (3) rejects `schema_version != 1`; (4) "do not log bodies" is code-review-only. |
-| `wrangler.toml` | `r2_buckets.binding = "EVENTS"`, `bucket_name = "rapid-mlx-telemetry-events"`, `[observability] enabled = true`. |
-| Deploy state | **Blocked**. Per memory `project_telemetry_worker_deploy_blocked.md`: existing OAuth token lacks R2 + Workers scopes. Either re-auth `wrangler login` interactively in user shell, or mint a scoped API token (Workers Scripts:Edit, Account R2:Edit). |
+| `wrangler.toml` | `r2_buckets.binding = "EVENTS"`, hourly cron at `:17`, a 500-object scan cap, and observability enabled. |
+| Release-health canary (#1250) | The cron aggregates request/error events by `rapid_mlx_version`, compares the newest version with the three preceding versions, and evaluates empty, abnormally-short, degenerate/repetitive, and error rates. It requires both an absolute floor and a 3× baseline deviation with at least 50 samples. Alert state in R2 suppresses duplicate version/metric notifications for 24 hours. |
+| Deploy state | Worker version `88f56627-8218-4d26-92d9-6ddd25339e69` deployed 2026-08-11; both the workers.dev URL and `telemetry.rapidmlx.com/healthz` return schema v1 healthy. `ALERT_WEBHOOK` remains an operator-provided Wrangler secret; without it detections are emitted to structured Worker logs. |
 
 ### 2.3 rapidmlx.com infrastructure — already serves *other* workloads
 
@@ -212,31 +213,20 @@ it can attach to `rapidmlx.com` cleanly:
    add an explicit allowlist mirroring the `rapidserver` worker's
    atomic CORS-replace pattern (`gotcha_worker_cors_atomic_replace`).
 
-### 4.2 Token / OAuth unblock
+### 4.2 Release-health alert destination
 
-The original blocker is fully captured in memory
-`project_telemetry_worker_deploy_blocked.md`. Two paths:
+The Worker is deployed and its hourly Cron Trigger is active. Set the
+notification destination interactively so the secret never enters shell
+history or Git:
 
-**Path A — interactive re-auth (recommended, low blast radius):**
 ```bash
-# In a regular user terminal, NOT inside claude-code (see memory
-# gotcha_wrangler_oauth_claude_code — claude-code's bash strips
-# Authorization headers):
 cd ~/work/Rapid-MLX-telemetry-worker
-npx wrangler login       # browser opens, grants Workers + R2
-npx wrangler r2 bucket create rapid-mlx-telemetry-events --location enam
-npx wrangler deploy
+npx wrangler secret put ALERT_WEBHOOK
 ```
 
-**Path B — long-lived scoped API token:**
-Mint at https://dash.cloudflare.com/profile/api-tokens with:
-- Account · Workers Scripts · Edit
-- Account · Workers R2 Storage · Edit
-- Zone · `rapidmlx.com` · Workers Routes · Edit
-- Zone · `rapidmlx.com` · DNS · Edit (only if Workers Custom Domains
-  fails to mint the placeholder, which would surprise me)
-
-Export `CLOUDFLARE_API_TOKEN=…` and `npx wrangler deploy`.
+The payload contains a Slack-compatible `text` field plus a structured
+`alerts` array keyed by `version` and `metric`. Until this secret is set,
+detections remain visible in Worker logs rather than being silently dropped.
 
 ### 4.3 Operational dashboard
 

--- a/tests/test_telemetry_cli.py
+++ b/tests/test_telemetry_cli.py
@@ -125,6 +125,8 @@ def test_preview_shows_request_event_with_degenerate_flag(fake_home):
     assert r.returncode == 0, r.stderr
     assert '"event": "request"' in r.stdout
     assert '"output_degenerate": false' in r.stdout
+    assert '"completion_empty": false' in r.stdout
+    assert '"completion_abnormally_short": false' in r.stdout
     # Only bucketed numbers + booleans — no raw-text field ever surfaces.
     for forbidden in ('"prompt"', '"prompt_text"', '"completion"', '"messages"'):
         assert forbidden not in r.stdout, f"{forbidden} leaked into preview"

--- a/tests/test_telemetry_emit.py
+++ b/tests/test_telemetry_emit.py
@@ -458,6 +458,35 @@ def test_output_degenerate_true_when_caller_flags_it(opted_in, stub_queue):
     assert isinstance(r["output_degenerate"], bool)
 
 
+@pytest.mark.parametrize(
+    "completion_tokens,empty,short",
+    [(0, True, False), (1, False, True), (8, False, True), (9, False, False)],
+)
+def test_completion_health_signals_are_disjoint_booleans(
+    opted_in, stub_queue, completion_tokens, empty, short
+):
+    """The collector can distinguish empty from unusually short output while
+    exact token counts remain local and the coarse public bucket is unchanged."""
+    from vllm_mlx.telemetry import emit
+
+    emit.request(
+        endpoint="/v1/chat/completions",
+        model_alias="qwen3.5-9b-4bit",
+        stream=False,
+        tool_call_used=False,
+        prompt_tokens=10,
+        completion_tokens=completion_tokens,
+        ttft_ms=100.0,
+        tps=50.0,
+        status=200,
+    )
+    request = stub_queue[-1]["request"]
+    assert request["completion_empty"] is empty
+    assert request["completion_abnormally_short"] is short
+    assert isinstance(request["completion_empty"], bool)
+    assert isinstance(request["completion_abnormally_short"], bool)
+
+
 def test_error_category_and_phase_normalised_to_allowlist(opted_in, stub_queue):
     """Round 3 codex review: ``category`` + ``phase`` were stored
     verbatim. Same escape hatch as ``endpoint`` — a future caller

--- a/vllm_mlx/telemetry/emit.py
+++ b/vllm_mlx/telemetry/emit.py
@@ -477,6 +477,11 @@ def _normalize_endpoint(raw: str) -> str:
     return path if path in _ALLOWED_ENDPOINTS else "other"
 
 
+# A non-empty response this small is rarely a useful chat completion, while a
+# boolean avoids exporting its exact token count.
+_ABNORMALLY_SHORT_COMPLETION_MAX_TOKENS = 8
+
+
 @_safe
 def request(
     *,
@@ -522,6 +527,10 @@ def request(
         "status": int(status),
         "caller_agent": normalize_caller_agent(caller_agent),
         "output_degenerate": bool(output_degenerate),
+        "completion_empty": completion_tokens == 0,
+        "completion_abnormally_short": (
+            0 < completion_tokens <= _ABNORMALLY_SHORT_COMPLETION_MAX_TOKENS
+        ),
     }
     get_queue().enqueue(payload)
 

--- a/vllm_mlx/telemetry/schema.py
+++ b/vllm_mlx/telemetry/schema.py
@@ -99,6 +99,13 @@ class RequestPayload:
     # zero completion-token bucket) so this stays a clean "non-empty content
     # looks like garbage" signal.
     output_degenerate: bool = False
+    # v2.3 additions (#1250). Exact token counts remain local; these two
+    # booleans make empty and abnormally-short completions observable without
+    # narrowing the coarse token bucket (which would increase fingerprinting
+    # risk). ``completion_abnormally_short`` excludes empty completions so the
+    # collector can alert on the two failure modes independently.
+    completion_empty: bool = False
+    completion_abnormally_short: bool = False
 
 
 @dataclass(frozen=True)
@@ -221,6 +228,8 @@ def sample_request_preview_payload(
             status=200,
             caller_agent=normalize_caller_agent("claude-code/1.0"),
             output_degenerate=False,
+            completion_empty=False,
+            completion_abnormally_short=False,
         ),
     )
 


### PR DESCRIPTION
## What changed

- emit privacy-safe `completion_empty` and `completion_abnormally_short` booleans while retaining the coarse token bucket
- keep empty and short mutually exclusive; classify 1–8 tokens as abnormally short
- document the deployed per-version release-health cron, thresholds, cooldown, and webhook contract

## Reproduction / root cause

Main already emitted version, error, and degenerate-output signals, but `completion_tokens_bucket` grouped 0–255 tokens together. The collector therefore could not distinguish an empty completion from a legitimate short response, so two of #1250’s required rates were impossible to compute.

## Validation

- `uv run pytest -q tests/test_telemetry_*.py` — 223 passed
- collector Vitest suite — 33 passed
- Wrangler 4.120.1 dry-run; npm audit — 0 vulnerabilities
- production Worker version `88f56627-8218-4d26-92d9-6ddd25339e69` deployed; both health endpoints return schema v1 healthy

Closes #1250