### PR TITLE
Expose the engine's audited performance flags in Settings (part of #1717)

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/RapidApp.swift
+++ b/apps/rapid-mac/Sources/Rapid/RapidApp.swift
@@ -70,6 +70,9 @@ struct RapidApp: App {
     @State private var mcpCatalog: MCPCatalog
     @State private var mcpApproval: MCPToolApprovalStore
     @State private var mcpTools: MCPToolRegistry
+    /// Per-model performance overrides (issue #1717) — the KV-cache and
+    /// prefix-cache flags the app hands the engine at spawn.
+    @State private var perfConfig: ModelPerfConfigStore
 
     /// AppKit delegate — installs the menu-bar tray + tears down the
     /// subprocess before the process image dies.
@@ -170,6 +173,17 @@ struct RapidApp: App {
         _mcpApproval = State(initialValue: mcpApprovalStore)
         _mcpTools = State(initialValue: mcpRegistry)
 
+        // Issue #1717: per-model performance overrides. Resolved at each spawn
+        // for the alias being started — see ``ServerManager/
+        // perfLaunchFlagsProvider``. Empty for every alias the user has not
+        // touched, so an install that never opens the panel spawns the same
+        // argv as before.
+        let perfConfigStore = ModelPerfConfigStore()
+        manager.perfLaunchFlagsProvider = { [weak perfConfigStore] alias in
+            MainActor.assumeIsolated { perfConfigStore?.launchFlags(forAlias: alias) ?? [] }
+        }
+        _perfConfig = State(initialValue: perfConfigStore)
+
         let chat = ChatViewModel(tools: toolRegistry, sampling: samplingConfig, server: manager)
         let updateChecker: UpdateChecker
         if ProcessInfo.processInfo.environment["RAPID_GUI_UPDATE_CURRENT"] == "1" {
@@ -246,6 +260,7 @@ struct RapidApp: App {
                 .environment(mcpCatalog)
                 .environment(mcpApproval)
                 .environment(mcpTools)
+                .environment(perfConfig)
                 .task {
                     // DEV-ONLY: render real screens to PNG when
                     // RAPID_DEV_SNAPSHOT_DIR is set, then quit. Inert
@@ -371,6 +386,7 @@ struct RapidApp: App {
                 .environment(mcpCatalog)
                 .environment(mcpApproval)
                 .environment(mcpTools)
+                .environment(perfConfig)
         }
         .windowResizability(.contentMinSize)
         .defaultSize(width: 900, height: 720)

--- a/apps/rapid-mac/Sources/Rapid/Server/ModelPerfConfig.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ModelPerfConfig.swift
@@ -1,0 +1,173 @@
+import Foundation
+
+/// Issue #1717: the engine's throughput knobs (KV-cache precision, prefix
+/// caching) reach `serve` only as CLI flags. This is the desktop-side value
+/// type for the subset we expose, resolved into `serve` argv by
+/// ``launchFlags``.
+///
+/// **Sparse by construction.** Every field is optional and `nil` means "the
+/// app passes nothing for this knob", not "the app passes the engine default".
+/// A user who never opens the panel therefore produces an empty flag list and
+/// an argv byte-identical to today's — which is the issue's "defaults are
+/// unchanged for users who never open the panel" acceptance criterion. It also
+/// means an engine-side default change reaches those users, instead of being
+/// frozen by a value the app snapshotted at first launch.
+///
+/// **Audited surface only.** The exposed set is deliberately smaller than the
+/// flag families the issue names. `--kv-bits`, `--kv-group-size`,
+/// `--draft-model` and `--num-draft-tokens` are in the engine's
+/// deprecated-no-op block (`vllm_mlx/cli.py`: "consumed-and-discarded: stored
+/// on ``args`` but never read"), so exposing them would ship switches wired to
+/// nothing. Speculative decoding's canonical entry point is
+/// `--speculative-config`, a JSON blob whose shape does not survive
+/// translation into toggles; its flag-shaped aliases are all
+/// `argparse.SUPPRESS` legacy. Both are out of scope here by audit, not by
+/// oversight.
+struct ModelPerfConfig: Codable, Equatable, Sendable {
+    /// KV-cache precision / compression. One knob, not two, because the
+    /// engine treats them as one: `vllm_mlx/cli.py` resolves `--kv-cache-dtype`
+    /// only `if not args.kv_cache_turboquant and not args.kv_cache_quantization`
+    /// — with TurboQuant on, the dtype flag is silently ignored because
+    /// TurboQuant owns the V cache. Modelling these as two independent
+    /// controls would let the panel show "int8 + TurboQuant" while the engine
+    /// ran TurboQuant alone, which is precisely the "neither they nor we can
+    /// tell which toggle did it" failure the issue opens with.
+    var kvCacheMode: KVCacheMode?
+
+    /// Prefix caching on/off. The engine defaults this on; the flag pair
+    /// exists so an operator can A/B it.
+    var prefixCacheEnabled: Bool?
+
+    /// Prefix-cache memory ceiling in MB. `nil` leaves the engine's
+    /// auto-detection (~20% of RAM) alone.
+    var cacheMemoryMB: Int?
+
+    init(
+        kvCacheMode: KVCacheMode? = nil,
+        prefixCacheEnabled: Bool? = nil,
+        cacheMemoryMB: Int? = nil
+    ) {
+        self.kvCacheMode = kvCacheMode
+        self.prefixCacheEnabled = prefixCacheEnabled
+        self.cacheMemoryMB = cacheMemoryMB
+    }
+
+    /// True when the user has not overridden anything. Such a config is
+    /// dropped rather than persisted, so the store never accumulates rows
+    /// that encode "no opinion".
+    var isEmpty: Bool {
+        kvCacheMode == nil && prefixCacheEnabled == nil && cacheMemoryMB == nil
+    }
+
+    /// Bounds for ``cacheMemoryMB``. The floor is the engine's own smallest
+    /// useful budget; below it the cache thrashes and the knob reads as
+    /// "prefix caching is broken" rather than "I set it too low".
+    static let cacheMemoryMBRange: ClosedRange<Int> = 256 ... 32_768
+
+    /// `serve` argv contributed by this config, in a stable order.
+    ///
+    /// Order matters only for reproducibility in tests and in the
+    /// `--dev-snapshot` output; the engine's argparse is order-insensitive
+    /// across these flags. Each branch is skipped entirely when the field is
+    /// `nil`, so an untouched config contributes an empty array.
+    var launchFlags: [String] {
+        var flags: [String] = []
+        if let kvCacheMode {
+            flags.append(contentsOf: kvCacheMode.launchFlags)
+        }
+        if let prefixCacheEnabled {
+            // Distinct flags rather than a value — the engine models this as
+            // a `--enable-prefix-cache` / `--disable-prefix-cache` pair.
+            flags.append(prefixCacheEnabled ? "--enable-prefix-cache" : "--disable-prefix-cache")
+        }
+        if let cacheMemoryMB {
+            let clamped = min(max(cacheMemoryMB, Self.cacheMemoryMBRange.lowerBound),
+                              Self.cacheMemoryMBRange.upperBound)
+            flags.append(contentsOf: ["--cache-memory-mb", String(clamped)])
+        }
+        return flags
+    }
+
+    /// Flag names this config can emit. Used by ``ServerManager`` to drop the
+    /// RAM-tier recommendation's value for a knob the user has an explicit
+    /// opinion about, so the two never both land on argv.
+    static let ownedFlagNames: Set<String> = [
+        "--kv-cache-dtype",
+        "--kv-cache-turboquant",
+        "--enable-prefix-cache",
+        "--disable-prefix-cache",
+        "--cache-memory-mb",
+    ]
+}
+
+/// The KV-cache precision options the audit cleared for exposure.
+///
+/// Values map onto `--kv-cache-dtype` (bf16 / int8 / int4) and
+/// `--kv-cache-turboquant` (v4 / k8v4). The legacy `--kv-cache-quantization`
+/// spelling is deliberately absent: the engine documents it as "[deprecated
+/// alias of --kv-cache-dtype int8]", and it is the flag that trips the
+/// hard mutual-exclusion error against TurboQuant.
+enum KVCacheMode: String, Codable, CaseIterable, Sendable {
+    case bf16
+    case int8
+    case int4
+    case turboquantV4 = "turboquant-v4"
+    case turboquantK8V4 = "turboquant-k8v4"
+
+    var launchFlags: [String] {
+        switch self {
+        case .bf16: return ["--kv-cache-dtype", "bf16"]
+        case .int8: return ["--kv-cache-dtype", "int8"]
+        case .int4: return ["--kv-cache-dtype", "int4"]
+        case .turboquantV4: return ["--kv-cache-turboquant", "v4"]
+        case .turboquantK8V4: return ["--kv-cache-turboquant", "k8v4"]
+        }
+    }
+
+    /// Short label for the picker.
+    var title: String {
+        switch self {
+        case .bf16: return "Full precision (bf16)"
+        case .int8: return "8-bit"
+        case .int4: return "4-bit"
+        case .turboquantV4: return "TurboQuant V4"
+        case .turboquantK8V4: return "TurboQuant K8V4"
+        }
+    }
+
+    /// The issue requires each control to "state the trade-off in one line
+    /// each, next to the control — what it buys, what it costs, and whether it
+    /// can change output". These are those lines; they live next to the enum
+    /// so a new case cannot be added without one.
+    var tradeOff: String {
+        switch self {
+        case .bf16:
+            return "Most memory, no quality loss. Slowest on long contexts."
+        case .int8:
+            return "Half the KV memory. Safe for hard math and reasoning."
+        case .int4:
+            return "Quarter the KV memory, fastest long-context decode. Can change output on AIME-class math."
+        case .turboquantV4:
+            return "Compresses the value cache only. Experimental; can change output."
+        case .turboquantK8V4:
+            return "~4.6× KV compression on dense models. Experimental; can change output."
+        }
+    }
+
+    /// Whether picking this can change what the model writes, as opposed to
+    /// only how fast it writes it. Drives the warning affordance in the panel.
+    var canChangeOutput: Bool {
+        switch self {
+        case .bf16, .int8: return false
+        case .int4, .turboquantV4, .turboquantK8V4: return true
+        }
+    }
+
+    /// Sliding-window (Gemma 3/4, GPT-OSS) and MLA (DeepSeek V3+, Kimi K2.5)
+    /// families auto-downgrade to bf16 inside the engine regardless of this
+    /// setting. The panel uses this to say so up front rather than let the
+    /// user believe a setting took that the engine overrode.
+    var isSubjectToArchitectureDowngrade: Bool {
+        self != .bf16
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/Server/ModelPerfConfigStore.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ModelPerfConfigStore.swift
@@ -1,0 +1,133 @@
+import Foundation
+import Observation
+
+/// Issue #1717: per-model performance overrides, persisted across launches and
+/// resolved into `serve` argv at spawn.
+///
+/// **Per-model, not global** — the issue's requirement, and the reason this is
+/// a dictionary keyed by alias rather than a flat set of preferences: "the
+/// right KV setting for a 4B dense model is not the right one for a 35B MoE".
+/// It mirrors how ``SamplingConfig`` already carries per-alias context and
+/// reasoning floors.
+///
+/// **Sparse.** Only aliases the user has actually touched get a row, and an
+/// override that is reset back to "no opinion" removes the row rather than
+/// writing an explicit copy of the current default. Two consequences the issue
+/// asks for: an untouched install contributes no flags at all, and an engine
+/// default that changes in a later release reaches every user who never
+/// expressed an opinion.
+///
+/// Storage is a single `UserDefaults` JSON blob rather than a file under
+/// `~/.config`, unlike ``MCPConfigStore``. The engine does not read this — it
+/// is desktop-side state that becomes argv — so there is no interop shape to
+/// honour, and `UserDefaults` keeps it inside the app sandbox with the rest of
+/// the app's settings.
+@MainActor
+@Observable
+final class ModelPerfConfigStore {
+    static let storageKey = "rapid.perf.modelOverrides.v1"
+
+    private let defaults: UserDefaults
+
+    /// Alias → override. Absent key means "no opinion"; see the sparseness
+    /// note above.
+    private(set) var overrides: [String: ModelPerfConfig] = [:]
+
+    /// Non-nil when the persisted blob existed but could not be decoded.
+    /// Surfaced in the panel: silently showing "everything is default" over a
+    /// blob we failed to read would misreport the user's own settings back to
+    /// them.
+    private(set) var loadError: String?
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        load()
+    }
+
+    func load() {
+        loadError = nil
+        guard let data = defaults.data(forKey: Self.storageKey) else {
+            overrides = [:]
+            return
+        }
+        do {
+            overrides = try JSONDecoder().decode([String: ModelPerfConfig].self, from: data)
+        } catch {
+            overrides = [:]
+            loadError = "Could not read saved performance settings: \(error.localizedDescription)"
+        }
+    }
+
+    /// The user's override for `alias`, or an all-`nil` config when they have
+    /// none. Callers can read fields directly; `nil` fields mean "engine
+    /// default", never a concrete value.
+    func config(forAlias alias: String) -> ModelPerfConfig {
+        overrides[normalize(alias)] ?? ModelPerfConfig()
+    }
+
+    /// True when this alias has any explicit override — drives the "modified"
+    /// affordance and enables the reset action in the panel.
+    func hasOverride(forAlias alias: String) -> Bool {
+        !(overrides[normalize(alias)] ?? ModelPerfConfig()).isEmpty
+    }
+
+    /// Store `config` for `alias`. An empty config removes the row instead of
+    /// persisting a no-op, which keeps ``hasOverride(forAlias:)`` honest and
+    /// stops the blob growing one entry per model the user merely looked at.
+    func setConfig(_ config: ModelPerfConfig, forAlias alias: String) {
+        let key = normalize(alias)
+        guard !key.isEmpty else { return }
+        if config.isEmpty {
+            overrides.removeValue(forKey: key)
+        } else {
+            overrides[key] = config
+        }
+        persist()
+    }
+
+    /// The issue asks for "reset to measured default" as a single action.
+    /// Clearing the override IS that reset: with no override the alias falls
+    /// back to ``RAMBucketedDefault``'s benchmarked launch flags when it is
+    /// this Mac's recommended pick, and to the engine's own defaults
+    /// otherwise. Nothing needs to know what the measured numbers are.
+    func resetToDefaults(forAlias alias: String) {
+        let key = normalize(alias)
+        guard overrides[key] != nil else { return }
+        overrides.removeValue(forKey: key)
+        persist()
+    }
+
+    /// Every alias the user has an opinion about, sorted for a stable panel.
+    var configuredAliases: [String] {
+        overrides.keys.sorted()
+    }
+
+    /// `serve` argv contributed by this alias's override. Empty when the user
+    /// has no opinion — the untouched-install path.
+    func launchFlags(forAlias alias: String) -> [String] {
+        config(forAlias: alias).launchFlags
+    }
+
+    // MARK: - Internals
+
+    /// Aliases arrive from the model picker, from persisted settings, and from
+    /// the server's own `servingAlias`. Case and surrounding whitespace differ
+    /// across those sources; without normalizing, the same model can hold two
+    /// rows and the user's setting appears to be ignored.
+    private func normalize(_ alias: String) -> String {
+        alias.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    }
+
+    private func persist() {
+        do {
+            let data = try JSONEncoder().encode(overrides)
+            defaults.set(data, forKey: Self.storageKey)
+        } catch {
+            // Encoding a dictionary of optionals cannot realistically fail,
+            // but swallowing it silently would leave the in-memory state
+            // diverged from disk with no trace. Surface it the same way a
+            // load failure surfaces.
+            loadError = "Could not save performance settings: \(error.localizedDescription)"
+        }
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -309,6 +309,18 @@ final class ServerManager {
     /// argv verbatim.
     var mcpConfigPathProvider: (() -> String?)?
 
+    /// Supplies the user's per-model performance flags for the alias about to
+    /// be spawned, or an empty array when they have no opinion about it.
+    ///
+    /// Issue #1717. Same closure shape and rationale as
+    /// ``mcpConfigPathProvider``: the answer is owned by
+    /// ``ModelPerfConfigStore`` in the SwiftUI environment and changes while
+    /// the app runs, and every start path (cold start, crash recovery,
+    /// auto-respawn) funnels through ``start(alias:)`` without threading
+    /// flags. Left nil by tests and the dev-snapshot harness, which therefore
+    /// keep the pre-#1717 argv verbatim.
+    var perfLaunchFlagsProvider: ((String) -> [String])?
+
     /// Health-check budget — interpreted as a **stall window** since
     /// v0.7.13, not a wall-clock-from-launch cap. The deadline slides
     /// forward every time ``downloadProgress`` reports forward motion
@@ -1346,9 +1358,18 @@ final class ServerManager {
         // the 24 GB gemma-4-26b), so a hand-picked model that isn't the
         // recommendation gets none.
         let hardware = MacHardware.detect()
-        var extraFlags = RAMBucketedDefault.launchFlags(
-            forAlias: trimmedAlias,
-            physicalRAMGB: hardware.physicalRAMGB
+        // Issue #1717: the user's per-model overrides take precedence over the
+        // RAM-tier recommendation for the knobs they actually set, and leave
+        // the rest of the recommendation (e.g. `--no-mllm`) intact. Merged
+        // HERE, alongside the recommendation, for the same reason it is
+        // computed here — every start path reaches `start(alias:)` and none of
+        // them thread flags.
+        var extraFlags = Self.mergedPerformanceFlags(
+            recommended: RAMBucketedDefault.launchFlags(
+                forAlias: trimmedAlias,
+                physicalRAMGB: hardware.physicalRAMGB
+            ),
+            userOverrides: perfLaunchFlagsProvider?(trimmedAlias) ?? []
         )
         extraFlags.append(contentsOf: [
             "--resident-memory-limit-gb",
@@ -2453,6 +2474,77 @@ final class ServerManager {
             }
         }
         return true
+    }
+
+    // MARK: - Per-model performance overrides (issue #1717)
+
+    /// Flags that carry a value, and so must be dropped together with the
+    /// token after them when the user's override supersedes them.
+    nonisolated private static let perfValueCarryingFlags: Set<String> = [
+        "--kv-cache-dtype", "--kv-cache-turboquant", "--cache-memory-mb",
+    ]
+
+    /// Flags that move as a unit: an override for any member supersedes the
+    /// recommendation's value for every member.
+    ///
+    /// The KV group is why this is groups and not names. The engine resolves
+    /// ``--kv-cache-dtype`` only when TurboQuant is off, so a user who picks
+    /// TurboQuant on a model whose RAM-tier recommendation pins
+    /// ``--kv-cache-dtype bf16`` must not ship both — the dtype would sit on
+    /// argv, appear in the dev snapshot and in `ps`, and be silently ignored.
+    /// Dropping it keeps argv an honest account of what the engine will do.
+    nonisolated private static let perfFlagGroups: [Set<String>] = [
+        ["--kv-cache-dtype", "--kv-cache-turboquant"],
+        ["--enable-prefix-cache", "--disable-prefix-cache"],
+        ["--cache-memory-mb"],
+    ]
+
+    /// Merge the RAM-tier recommendation with the user's per-model overrides.
+    ///
+    /// Precedence is per-group, not wholesale: a user who only changes the
+    /// prefix-cache toggle keeps the recommendation's KV dtype and its
+    /// unrelated flags (``--no-mllm``). Recommendation flags outside every
+    /// group pass through untouched.
+    ///
+    /// Exposed ``internal static`` — like ``serveArguments`` — so the argv
+    /// contract can be pinned in tests without standing up a spawn.
+    nonisolated internal static func mergedPerformanceFlags(
+        recommended: [String],
+        userOverrides: [String]
+    ) -> [String] {
+        guard !userOverrides.isEmpty else { return recommended }
+
+        // Which groups the user expressed an opinion about. Derived from the
+        // flags actually emitted, NOT from the full set the config *could*
+        // emit — otherwise setting one knob would silently discard the
+        // recommendation's value for the other two.
+        var supersededFlags: Set<String> = []
+        for group in perfFlagGroups where !group.isDisjoint(with: Set(userOverrides)) {
+            supersededFlags.formUnion(group)
+        }
+        guard !supersededFlags.isEmpty else { return recommended + userOverrides }
+
+        var kept: [String] = []
+        var index = recommended.startIndex
+        while index < recommended.endIndex {
+            let token = recommended[index]
+            guard supersededFlags.contains(token) else {
+                kept.append(token)
+                index += 1
+                continue
+            }
+            // Skip the flag, and its value when it takes one. ``--kv-cache-
+            // turboquant`` is ``nargs="?"`` in the engine, so its value is
+            // optional — only consume the next token when it is not itself a
+            // flag, or a bare recommendation form would eat the flag after it.
+            index += 1
+            if perfValueCarryingFlags.contains(token),
+               index < recommended.endIndex,
+               !recommended[index].hasPrefix("--") {
+                index += 1
+            }
+        }
+        return kept + userOverrides
     }
 
     // MARK: - Unified spawn shape (issue #271)

--- a/apps/rapid-mac/Sources/Rapid/UI/SettingsPerformancePanel.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SettingsPerformancePanel.swift
@@ -1,0 +1,302 @@
+import SwiftUI
+
+/// Settings → Performance. Issue #1717's user-facing surface.
+///
+/// The engine's throughput knobs were CLI-only, which made the GUI the slow
+/// way to use our own engine. This panel exposes the subset that survived the
+/// audit, and it is deliberately small:
+///
+///   * **Only audited, CI-gated flags.** `--kv-bits`, `--kv-group-size`,
+///     `--draft-model` and `--num-draft-tokens` — named in the issue — are in
+///     the engine's deprecated-no-op block and are parsed but never read, so a
+///     switch for them would be wired to nothing. Speculative decoding's
+///     canonical entry point is `--speculative-config`, a JSON blob; its
+///     flag-shaped spellings are all `argparse.SUPPRESS` legacy aliases.
+///     Neither is here.
+///   * **Per model.** Settings attach to the alias, because the right KV
+///     setting for a 4B dense model is not the right one for a 35B MoE.
+///   * **One line of cost per control**, from ``KVCacheMode/tradeOff``.
+///   * **Restart stated before the click**, not after: these are `serve`
+///     launch flags, so a change only reaches a running model on respawn.
+struct SettingsPerformancePanel: View {
+    @Environment(ModelPerfConfigStore.self) private var perf
+    @Environment(ServerManager.self) private var server
+
+    /// True while the Restart button is cycling the child.
+    @State private var isRestarting: Bool = false
+
+    /// The alias this panel edits. The running model when there is one,
+    /// otherwise the last one served — editing "whatever runs next" with no
+    /// name attached is how a user ends up surprised about which model they
+    /// changed.
+    private var targetAlias: String? {
+        server.servingAlias ?? server.launchedChildAlias
+    }
+
+    /// Whether the running child was launched before the current settings, so
+    /// its argv predates them. Derived, never stored — the same reasoning as
+    /// ``SettingsConnectorsPanel``: `@State` dies with the view while the
+    /// condition it described is still true.
+    private var needsRestart: Bool {
+        guard let alias = targetAlias, server.launchedChildAlias != nil else { return false }
+        return perf.launchFlags(forAlias: alias) != launchedFlags
+    }
+
+    /// Flags the running child was actually spawned with, for the alias in
+    /// question. Nil-safe: with no child, there is nothing to compare against.
+    @State private var launchedFlags: [String] = []
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 18) {
+                header
+                if let alias = targetAlias {
+                    if needsRestart { restartBanner(alias: alias) }
+                    kvSection(alias: alias)
+                    prefixSection(alias: alias)
+                    footer(alias: alias)
+                } else {
+                    noModelNotice
+                }
+                if let error = perf.loadError {
+                    Label(error, systemImage: "exclamationmark.triangle.fill")
+                        .font(.callout)
+                        .foregroundStyle(RapidTheme.amberDeep)
+                }
+            }
+            .padding(20)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .task(id: server.launchedChildAlias) {
+            // Snapshot what the child was spawned with so ``needsRestart`` can
+            // compare against it rather than against "has any override", which
+            // would keep the banner up forever after a restart.
+            launchedFlags = targetAlias.map { perf.launchFlags(forAlias: $0) } ?? []
+        }
+    }
+
+    // MARK: - Sections
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Performance")
+                .font(.title3.weight(.semibold))
+            Text("These settings change speed and memory use, and some can change what the model writes. They apply to one model at a time and take effect when that model next starts.")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    private var noModelNotice: some View {
+        Label(
+            "Start a model to configure its performance settings.",
+            systemImage: "info.circle"
+        )
+        .font(.callout)
+        .foregroundStyle(.secondary)
+    }
+
+    private func restartBanner(alias: String) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 10) {
+            Image(systemName: "arrow.triangle.2.circlepath")
+                .foregroundStyle(RapidTheme.amberDeep)
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Restart \(alias) to apply")
+                    .font(.callout.weight(.medium))
+                Text("The running model was started with the previous settings.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer(minLength: 8)
+            Button(isRestarting ? "Restarting…" : "Restart") { restart(alias: alias) }
+                .disabled(isRestarting)
+        }
+        .padding(12)
+        .background(RapidTheme.amberTint, in: RoundedRectangle(cornerRadius: RapidTheme.cardRadius))
+    }
+
+    private func kvSection(alias: String) -> some View {
+        card {
+            VStack(alignment: .leading, spacing: 10) {
+                sectionTitle("KV cache precision", subtitle: "How the model's attention cache is stored. Lower precision means less memory and faster long-context decoding.")
+
+                // One picker, not two. The engine resolves --kv-cache-dtype
+                // only when TurboQuant is off, so independent controls could
+                // show a dtype the engine silently ignored.
+                Picker("", selection: kvBinding(alias: alias)) {
+                    Text("Engine default").tag(KVCacheMode?.none)
+                    ForEach(KVCacheMode.allCases, id: \.self) { mode in
+                        Text(mode.title).tag(KVCacheMode?.some(mode))
+                    }
+                }
+                .labelsHidden()
+                .pickerStyle(.radioGroup)
+
+                if let mode = perf.config(forAlias: alias).kvCacheMode {
+                    tradeOffLine(mode.tradeOff, warns: mode.canChangeOutput)
+                    if mode.isSubjectToArchitectureDowngrade {
+                        Text("Sliding-window (Gemma, GPT-OSS) and MLA (DeepSeek, Kimi) models fall back to full precision regardless of this setting.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                } else {
+                    tradeOffLine("The engine picks a precision measured for this model.", warns: false)
+                }
+            }
+        }
+    }
+
+    private func prefixSection(alias: String) -> some View {
+        card {
+            VStack(alignment: .leading, spacing: 10) {
+                sectionTitle("Prefix cache", subtitle: "Reuses the computation for a prompt prefix the model has already seen. Speeds up multi-turn chat and repeated system prompts.")
+
+                Picker("", selection: prefixBinding(alias: alias)) {
+                    Text("Engine default").tag(Bool?.none)
+                    Text("On").tag(Bool?.some(true))
+                    Text("Off").tag(Bool?.some(false))
+                }
+                .labelsHidden()
+                .pickerStyle(.segmented)
+                .frame(maxWidth: 280)
+
+                tradeOffLine(
+                    "Costs memory, never changes output. Turning it off is mainly useful for measuring what it buys you.",
+                    warns: false
+                )
+
+                Divider().padding(.vertical, 2)
+
+                cacheBudgetRow(alias: alias)
+            }
+        }
+    }
+
+    private func cacheBudgetRow(alias: String) -> some View {
+        let config = perf.config(forAlias: alias)
+        return VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text("Cache budget")
+                    .font(.callout.weight(.medium))
+                Spacer()
+                Text(config.cacheMemoryMB.map { "\($0) MB" } ?? "Automatic")
+                    .font(.callout.monospacedDigit())
+                    .foregroundStyle(.secondary)
+            }
+            HStack(spacing: 12) {
+                Slider(
+                    value: cacheBudgetBinding(alias: alias),
+                    in: Double(ModelPerfConfig.cacheMemoryMBRange.lowerBound)
+                        ... Double(ModelPerfConfig.cacheMemoryMBRange.upperBound),
+                    step: 256
+                )
+                if config.cacheMemoryMB != nil {
+                    Button("Automatic") { update(alias: alias) { $0.cacheMemoryMB = nil } }
+                        .buttonStyle(.link)
+                }
+            }
+            tradeOffLine(
+                "Automatic uses about 20% of RAM. A larger budget holds more prefixes; it never changes output.",
+                warns: false
+            )
+        }
+    }
+
+    private func footer(alias: String) -> some View {
+        HStack {
+            Text(perf.hasOverride(forAlias: alias)
+                 ? "Customized for \(alias)."
+                 : "\(alias) is using measured defaults.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Spacer()
+            Button("Reset to measured defaults") {
+                perf.resetToDefaults(forAlias: alias)
+            }
+            .disabled(!perf.hasOverride(forAlias: alias))
+        }
+    }
+
+    // MARK: - Building blocks
+
+    private func card<Content: View>(@ViewBuilder _ content: () -> Content) -> some View {
+        content()
+            .padding(14)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(RapidTheme.card, in: RoundedRectangle(cornerRadius: RapidTheme.cardRadius))
+            .overlay(
+                RoundedRectangle(cornerRadius: RapidTheme.cardRadius)
+                    .stroke(RapidTheme.hairline, lineWidth: 1)
+            )
+    }
+
+    private func sectionTitle(_ title: String, subtitle: String) -> some View {
+        VStack(alignment: .leading, spacing: 3) {
+            Text(title).font(.callout.weight(.semibold))
+            Text(subtitle)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    /// The issue's "state the trade-off in one line each, next to the control".
+    /// `warns` marks the choices that can change output, not merely speed —
+    /// the distinction the issue's "the trap" section is built around.
+    private func tradeOffLine(_ text: String, warns: Bool) -> some View {
+        Label {
+            Text(text)
+                .font(.caption)
+                .foregroundStyle(warns ? RapidTheme.amberDeep : .secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        } icon: {
+            Image(systemName: warns ? "exclamationmark.triangle.fill" : "info.circle")
+                .font(.caption)
+                .foregroundStyle(warns ? RapidTheme.amberDeep : .secondary)
+        }
+    }
+
+    // MARK: - Bindings
+
+    private func kvBinding(alias: String) -> Binding<KVCacheMode?> {
+        Binding(
+            get: { perf.config(forAlias: alias).kvCacheMode },
+            set: { newValue in update(alias: alias) { $0.kvCacheMode = newValue } }
+        )
+    }
+
+    private func prefixBinding(alias: String) -> Binding<Bool?> {
+        Binding(
+            get: { perf.config(forAlias: alias).prefixCacheEnabled },
+            set: { newValue in update(alias: alias) { $0.prefixCacheEnabled = newValue } }
+        )
+    }
+
+    private func cacheBudgetBinding(alias: String) -> Binding<Double> {
+        Binding(
+            get: {
+                Double(perf.config(forAlias: alias).cacheMemoryMB
+                       ?? ModelPerfConfig.cacheMemoryMBRange.lowerBound)
+            },
+            set: { newValue in update(alias: alias) { $0.cacheMemoryMB = Int(newValue) } }
+        )
+    }
+
+    private func update(alias: String, _ mutate: (inout ModelPerfConfig) -> Void) {
+        var config = perf.config(forAlias: alias)
+        mutate(&config)
+        perf.setConfig(config, forAlias: alias)
+    }
+
+    private func restart(alias: String) {
+        isRestarting = true
+        Task {
+            await server.stop()
+            await server.start(alias: alias)
+            launchedFlags = perf.launchFlags(forAlias: alias)
+            isRestarting = false
+        }
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/UI/SettingsPerformancePanel.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SettingsPerformancePanel.swift
@@ -48,8 +48,12 @@ struct SettingsPerformancePanel: View {
 
     var body: some View {
         ScrollView {
-            VStack(alignment: .leading, spacing: 18) {
-                header
+            VStack(alignment: .leading, spacing: RapidTheme.Space.xl) {
+                SectionHeader(
+                    "Performance",
+                    subtitle: "These settings change speed and memory use, and some can change what the model writes. They apply to one model at a time and take effect when that model next starts.",
+                    emphasis: .page
+                )
                 if let alias = targetAlias {
                     if needsRestart { restartBanner(alias: alias) }
                     kvSection(alias: alias)
@@ -59,14 +63,13 @@ struct SettingsPerformancePanel: View {
                     noModelNotice
                 }
                 if let error = perf.loadError {
-                    Label(error, systemImage: "exclamationmark.triangle.fill")
-                        .font(.callout)
-                        .foregroundStyle(RapidTheme.amberDeep)
+                    InlineNotice(message: error, tone: .error)
                 }
             }
-            .padding(20)
+            .padding(RapidTheme.Space.xl)
             .frame(maxWidth: .infinity, alignment: .leading)
         }
+        .accessibilityIdentifier("Settings.Performance.Panel")
         .task(id: server.launchedChildAlias) {
             // Snapshot what the child was spawned with so ``needsRestart`` can
             // compare against it rather than against "has any override", which
@@ -77,50 +80,31 @@ struct SettingsPerformancePanel: View {
 
     // MARK: - Sections
 
-    private var header: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            Text("Performance")
-                .font(.title3.weight(.semibold))
-            Text("These settings change speed and memory use, and some can change what the model writes. They apply to one model at a time and take effect when that model next starts.")
-                .font(.callout)
-                .foregroundStyle(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
-        }
-    }
-
     private var noModelNotice: some View {
-        Label(
-            "Start a model to configure its performance settings.",
-            systemImage: "info.circle"
+        InlineNotice(
+            message: "Start a model to configure its performance settings.",
+            tone: .info
         )
-        .font(.callout)
-        .foregroundStyle(.secondary)
+        .accessibilityIdentifier("Settings.Performance.NoModel")
     }
 
     private func restartBanner(alias: String) -> some View {
-        HStack(alignment: .firstTextBaseline, spacing: 10) {
-            Image(systemName: "arrow.triangle.2.circlepath")
-                .foregroundStyle(RapidTheme.amberDeep)
-            VStack(alignment: .leading, spacing: 2) {
-                Text("Restart \(alias) to apply")
-                    .font(.callout.weight(.medium))
-                Text("The running model was started with the previous settings.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
-            Spacer(minLength: 8)
-            Button(isRestarting ? "Restarting…" : "Restart") { restart(alias: alias) }
-                .disabled(isRestarting)
-        }
-        .padding(12)
-        .background(RapidTheme.amberTint, in: RoundedRectangle(cornerRadius: RapidTheme.cardRadius))
+        InlineNotice(
+            message: "Restart \(alias) to apply. The running model was started with the previous settings.",
+            tone: .warning,
+            actionTitle: isRestarting ? "Restarting…" : "Restart",
+            action: { restart(alias: alias) }
+        )
+        .disabled(isRestarting)
+        .accessibilityIdentifier("Settings.Performance.RestartNotice")
     }
 
     private func kvSection(alias: String) -> some View {
-        card {
+        SettingsSection(
+            "KV cache precision",
+            subtitle: "How the model's attention cache is stored. Lower precision means less memory and faster long-context decoding."
+        ) {
             VStack(alignment: .leading, spacing: 10) {
-                sectionTitle("KV cache precision", subtitle: "How the model's attention cache is stored. Lower precision means less memory and faster long-context decoding.")
-
                 // One picker, not two. The engine resolves --kv-cache-dtype
                 // only when TurboQuant is off, so independent controls could
                 // show a dtype the engine silently ignored.
@@ -132,13 +116,15 @@ struct SettingsPerformancePanel: View {
                 }
                 .labelsHidden()
                 .pickerStyle(.radioGroup)
+                .accessibilityLabel("KV cache precision")
+                .accessibilityIdentifier("Settings.Performance.KVMode")
 
                 if let mode = perf.config(forAlias: alias).kvCacheMode {
                     tradeOffLine(mode.tradeOff, warns: mode.canChangeOutput)
                     if mode.isSubjectToArchitectureDowngrade {
                         Text("Sliding-window (Gemma, GPT-OSS) and MLA (DeepSeek, Kimi) models fall back to full precision regardless of this setting.")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
+                            .font(RapidFont.caption)
+                            .foregroundStyle(RapidTheme.textSecondary)
                             .fixedSize(horizontal: false, vertical: true)
                     }
                 } else {
@@ -149,25 +135,28 @@ struct SettingsPerformancePanel: View {
     }
 
     private func prefixSection(alias: String) -> some View {
-        card {
+        SettingsSection(
+            "Prefix cache",
+            subtitle: "Reuses computation for a prompt prefix the model has already seen. Speeds up multi-turn chat and repeated system prompts."
+        ) {
             VStack(alignment: .leading, spacing: 10) {
-                sectionTitle("Prefix cache", subtitle: "Reuses the computation for a prompt prefix the model has already seen. Speeds up multi-turn chat and repeated system prompts.")
-
-                Picker("", selection: prefixBinding(alias: alias)) {
-                    Text("Engine default").tag(Bool?.none)
-                    Text("On").tag(Bool?.some(true))
-                    Text("Off").tag(Bool?.some(false))
-                }
-                .labelsHidden()
-                .pickerStyle(.segmented)
-                .frame(maxWidth: 280)
+                RapidSegmentedControl(
+                    selection: prefixBinding(alias: alias),
+                    options: [
+                        .init(value: Bool?.none, title: "Engine default", identifier: "Settings.Performance.Prefix.Default"),
+                        .init(value: Bool?.some(true), title: "On", identifier: "Settings.Performance.Prefix.On"),
+                        .init(value: Bool?.some(false), title: "Off", identifier: "Settings.Performance.Prefix.Off"),
+                    ],
+                    accessibilityLabel: "Prefix cache"
+                )
+                .accessibilityIdentifier("Settings.Performance.PrefixCache")
 
                 tradeOffLine(
                     "Costs memory, never changes output. Turning it off is mainly useful for measuring what it buys you.",
                     warns: false
                 )
 
-                Divider().padding(.vertical, 2)
+                SettingsRowDivider()
 
                 cacheBudgetRow(alias: alias)
             }
@@ -179,11 +168,11 @@ struct SettingsPerformancePanel: View {
         return VStack(alignment: .leading, spacing: 8) {
             HStack {
                 Text("Cache budget")
-                    .font(.callout.weight(.medium))
+                    .font(RapidFont.bodyEmphasis)
                 Spacer()
                 Text(config.cacheMemoryMB.map { "\($0) MB" } ?? "Automatic")
-                    .font(.callout.monospacedDigit())
-                    .foregroundStyle(.secondary)
+                    .font(RapidFont.metric)
+                    .foregroundStyle(RapidTheme.textSecondary)
             }
             HStack(spacing: 12) {
                 Slider(
@@ -192,9 +181,12 @@ struct SettingsPerformancePanel: View {
                         ... Double(ModelPerfConfig.cacheMemoryMBRange.upperBound),
                     step: 256
                 )
+                .accessibilityLabel("Cache budget")
+                .accessibilityIdentifier("Settings.Performance.CacheBudget")
                 if config.cacheMemoryMB != nil {
                     Button("Automatic") { update(alias: alias) { $0.cacheMemoryMB = nil } }
-                        .buttonStyle(.link)
+                        .buttonStyle(.rapidTertiary)
+                        .accessibilityIdentifier("Settings.Performance.CacheBudgetAutomatic")
                 }
             }
             tradeOffLine(
@@ -209,36 +201,15 @@ struct SettingsPerformancePanel: View {
             Text(perf.hasOverride(forAlias: alias)
                  ? "Customized for \(alias)."
                  : "\(alias) is using measured defaults.")
-                .font(.caption)
-                .foregroundStyle(.secondary)
+                .font(RapidFont.caption)
+                .foregroundStyle(RapidTheme.textSecondary)
             Spacer()
             Button("Reset to measured defaults") {
                 perf.resetToDefaults(forAlias: alias)
             }
+            .buttonStyle(.rapidSecondaryCompact)
             .disabled(!perf.hasOverride(forAlias: alias))
-        }
-    }
-
-    // MARK: - Building blocks
-
-    private func card<Content: View>(@ViewBuilder _ content: () -> Content) -> some View {
-        content()
-            .padding(14)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .background(RapidTheme.card, in: RoundedRectangle(cornerRadius: RapidTheme.cardRadius))
-            .overlay(
-                RoundedRectangle(cornerRadius: RapidTheme.cardRadius)
-                    .stroke(RapidTheme.hairline, lineWidth: 1)
-            )
-    }
-
-    private func sectionTitle(_ title: String, subtitle: String) -> some View {
-        VStack(alignment: .leading, spacing: 3) {
-            Text(title).font(.callout.weight(.semibold))
-            Text(subtitle)
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
+            .accessibilityIdentifier("Settings.Performance.Reset")
         }
     }
 
@@ -248,13 +219,13 @@ struct SettingsPerformancePanel: View {
     private func tradeOffLine(_ text: String, warns: Bool) -> some View {
         Label {
             Text(text)
-                .font(.caption)
-                .foregroundStyle(warns ? RapidTheme.amberDeep : .secondary)
+                .font(RapidFont.caption)
+                .foregroundStyle(warns ? RapidTheme.statusWarning : RapidTheme.textSecondary)
                 .fixedSize(horizontal: false, vertical: true)
         } icon: {
             Image(systemName: warns ? "exclamationmark.triangle.fill" : "info.circle")
-                .font(.caption)
-                .foregroundStyle(warns ? RapidTheme.amberDeep : .secondary)
+                .font(RapidFont.caption)
+                .foregroundStyle(warns ? RapidTheme.statusWarning : RapidTheme.textSecondary)
         }
     }
 
@@ -295,8 +266,22 @@ struct SettingsPerformancePanel: View {
         Task {
             await server.stop()
             await server.start(alias: alias)
-            launchedFlags = perf.launchFlags(forAlias: alias)
+            // Only acknowledge the new argv after the replacement child is
+            // actually ready. A failed restart must keep the notice visible;
+            // otherwise Settings claims an override was applied when no
+            // serving process has it (#1717).
+            if Self.restartApplied(state: server.state, alias: alias) {
+                launchedFlags = perf.launchFlags(forAlias: alias)
+            }
             isRestarting = false
         }
+    }
+
+    /// A restart counts as applied only when the replacement child reached
+    /// ready for the same model. In particular, `.crashed` and `.idle` must
+    /// leave the notice up so Settings never reports argv that no process has.
+    static func restartApplied(state: ServerState, alias: String) -> Bool {
+        guard case .ready(let readyAlias) = state else { return false }
+        return readyAlias.caseInsensitiveCompare(alias) == .orderedSame
     }
 }

--- a/apps/rapid-mac/Sources/Rapid/UI/SettingsView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SettingsView.swift
@@ -81,6 +81,13 @@ struct SettingsView: View {
         /// ship with the app and are audited by us, connectors are programs
         /// the user installs and points us at.
         case connectors
+        /// Issue #1717 — per-model engine performance: KV-cache precision,
+        /// prefix caching, cache budget. Deliberately NOT folded into
+        /// ``modelManagement``'s sampling controls: those shape what the model
+        /// says, these shape how fast (and, for some choices, whether) it says
+        /// the same thing. Mixing them would invite the "I moved a slider and
+        /// quality changed" confusion the issue is written to avoid.
+        case performance
         case appearance
         case privacy
         /// Rapid-MLX Desktop app updates. The .app self-update is the
@@ -93,6 +100,7 @@ struct SettingsView: View {
             case .modelManagement: return "Model Management"
             case .tools: return "Tools"
             case .connectors: return "Connectors"
+            case .performance: return "Performance"
             case .appearance: return "Appearance"
             case .privacy: return "Privacy"
             case .app: return "App"
@@ -103,6 +111,7 @@ struct SettingsView: View {
             case .modelManagement: return "externaldrive.fill"
             case .tools: return "wrench.and.screwdriver.fill"
             case .connectors: return "powerplug.fill"
+            case .performance: return "speedometer"
             case .appearance: return "paintpalette.fill"
             case .privacy: return "lock.shield.fill"
             case .app: return "app.badge.fill"
@@ -460,6 +469,8 @@ struct SettingsView: View {
             SettingsToolsPanel()
         case .connectors:
             SettingsConnectorsPanel()
+        case .performance:
+            SettingsPerformancePanel()
         case .appearance:
             appearancePanel
         case .privacy:

--- a/apps/rapid-mac/Tests/RapidTests/AccessibilityIdentifierInventoryTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/AccessibilityIdentifierInventoryTests.swift
@@ -63,6 +63,33 @@ struct AccessibilityIdentifierInventoryTests {
 
     // MARK: - Settings → Tools
 
+    @Test("Settings → Performance names its panel and every control")
+    func settingsPerformancePanelIdentifiers() throws {
+        try assertDeclared(
+            [
+                #""Settings.Performance.Panel""#,
+                #""Settings.Performance.NoModel""#,
+                #""Settings.Performance.RestartNotice""#,
+                #""Settings.Performance.KVMode""#,
+                #""Settings.Performance.PrefixCache""#,
+                #""Settings.Performance.CacheBudget""#,
+                #""Settings.Performance.CacheBudgetAutomatic""#,
+                #""Settings.Performance.Reset""#,
+            ],
+            in: "Sources/Rapid/UI/SettingsPerformancePanel.swift",
+            surface: "Settings → Performance"
+        )
+        let source = try strippedSource("Sources/Rapid/UI/SettingsPerformancePanel.swift")
+        for id in ["Settings.Performance.Prefix.Default",
+                   "Settings.Performance.Prefix.On",
+                   "Settings.Performance.Prefix.Off"] {
+            #expect(
+                source.contains("identifier:\"\(id)\""),
+                "Settings → Performance: segmented option \(id) is no longer addressable."
+            )
+        }
+    }
+
     /// The whole panel shipped with ZERO identifiers: the three tool switches,
     /// the web-search backend radio group, and the browsing auto-approve
     /// switch all had correct AX roles and no name.

--- a/apps/rapid-mac/Tests/RapidTests/ModelPerfConfigTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ModelPerfConfigTests.swift
@@ -1,0 +1,240 @@
+import Foundation
+import Testing
+@testable import Rapid
+
+/// Issue #1717: the engine's throughput knobs reach `serve` only as CLI flags,
+/// so the desktop was the slow way to use our own engine. These tests pin the
+/// three properties the issue's acceptance list turns on:
+///
+///   * an install that never opens the panel spawns byte-identical argv;
+///   * an override supersedes the RAM-tier recommendation for the knob it
+///     covers, and ONLY that knob;
+///   * a KV choice never ships alongside a conflicting one, because the
+///     engine silently ignores `--kv-cache-dtype` when TurboQuant is on and
+///     "the UI said X, the engine did Y" is the failure mode the issue is
+///     written to prevent.
+/// ``ModelPerfConfigStore`` is `@MainActor` (it is `@Observable` state bound by
+/// Settings), so the suite is too. The pure-value assertions below do not need
+/// the isolation but cost nothing by inheriting it.
+@MainActor
+@Suite("Issue #1717 — per-model performance overrides")
+struct ModelPerfConfigTests {
+
+    // MARK: - Sparseness
+
+    @Test("An untouched config contributes no flags")
+    func untouchedConfigIsEmpty() {
+        let config = ModelPerfConfig()
+        #expect(config.isEmpty)
+        #expect(config.launchFlags.isEmpty)
+    }
+
+    @Test("A store with no overrides contributes no flags for any alias")
+    func untouchedStoreContributesNothing() {
+        let store = makeStore()
+        #expect(store.launchFlags(forAlias: "qwen3.6-35b-4bit").isEmpty)
+        #expect(store.hasOverride(forAlias: "qwen3.6-35b-4bit") == false)
+        #expect(store.configuredAliases.isEmpty)
+    }
+
+    @Test("Setting a knob then clearing it removes the row rather than pinning the default")
+    func clearingAnOverrideRemovesTheRow() {
+        let store = makeStore()
+        store.setConfig(ModelPerfConfig(kvCacheMode: .int8), forAlias: "gemma-4-26b-4bit")
+        #expect(store.hasOverride(forAlias: "gemma-4-26b-4bit"))
+
+        store.setConfig(ModelPerfConfig(), forAlias: "gemma-4-26b-4bit")
+        #expect(store.hasOverride(forAlias: "gemma-4-26b-4bit") == false)
+        #expect(store.configuredAliases.isEmpty)
+        // The point of the row removal: a later engine-side default change
+        // reaches this user instead of being frozen by a snapshot.
+        #expect(store.launchFlags(forAlias: "gemma-4-26b-4bit").isEmpty)
+    }
+
+    @Test("Reset restores the no-opinion state in one action")
+    func resetClearsTheAlias() {
+        let store = makeStore()
+        store.setConfig(
+            ModelPerfConfig(kvCacheMode: .turboquantK8V4, prefixCacheEnabled: false),
+            forAlias: "bonsai-27b-2bit"
+        )
+        store.resetToDefaults(forAlias: "bonsai-27b-2bit")
+        #expect(store.launchFlags(forAlias: "bonsai-27b-2bit").isEmpty)
+    }
+
+    // MARK: - Persistence
+
+    @Test("Overrides survive a store reconstruction against the same defaults")
+    func overridesPersist() {
+        let defaults = makeDefaults()
+        let first = ModelPerfConfigStore(defaults: defaults)
+        first.setConfig(
+            ModelPerfConfig(kvCacheMode: .int4, cacheMemoryMB: 4096),
+            forAlias: "qwen3.6-35b-4bit"
+        )
+
+        let second = ModelPerfConfigStore(defaults: defaults)
+        #expect(second.launchFlags(forAlias: "qwen3.6-35b-4bit")
+            == ["--kv-cache-dtype", "int4", "--cache-memory-mb", "4096"])
+    }
+
+    @Test("Alias lookup ignores case and surrounding whitespace")
+    func aliasLookupIsNormalized() {
+        let store = makeStore()
+        store.setConfig(ModelPerfConfig(kvCacheMode: .int8), forAlias: "Gemma-4-26B-4bit")
+        // The picker, persisted settings and ``servingAlias`` do not agree on
+        // case; without normalizing, the user's setting silently does nothing.
+        #expect(store.launchFlags(forAlias: "  gemma-4-26b-4bit ")
+            == ["--kv-cache-dtype", "int8"])
+    }
+
+    @Test("A corrupt persisted blob surfaces an error instead of reporting defaults")
+    func corruptBlobSurfacesError() {
+        let defaults = makeDefaults()
+        defaults.set(Data("not json".utf8), forKey: ModelPerfConfigStore.storageKey)
+        let store = ModelPerfConfigStore(defaults: defaults)
+        #expect(store.loadError != nil)
+        #expect(store.configuredAliases.isEmpty)
+    }
+
+    // MARK: - Flag rendering
+
+    @Test("KV modes render the flag the engine actually reads", arguments: [
+        (KVCacheMode.bf16, ["--kv-cache-dtype", "bf16"]),
+        (KVCacheMode.int8, ["--kv-cache-dtype", "int8"]),
+        (KVCacheMode.int4, ["--kv-cache-dtype", "int4"]),
+        (KVCacheMode.turboquantV4, ["--kv-cache-turboquant", "v4"]),
+        (KVCacheMode.turboquantK8V4, ["--kv-cache-turboquant", "k8v4"]),
+    ])
+    func kvModeFlags(mode: KVCacheMode, expected: [String]) {
+        #expect(mode.launchFlags == expected)
+    }
+
+    @Test("The deprecated --kv-cache-quantization spelling is never emitted")
+    func legacyQuantizationFlagIsNeverEmitted() {
+        // The engine documents it as "[deprecated alias of --kv-cache-dtype
+        // int8]" AND hard-errors when it is combined with TurboQuant. Emitting
+        // it could only reintroduce that conflict.
+        for mode in KVCacheMode.allCases {
+            #expect(mode.launchFlags.contains("--kv-cache-quantization") == false)
+        }
+    }
+
+    @Test("Prefix caching renders as the engine's enable/disable pair")
+    func prefixCacheFlags() {
+        #expect(ModelPerfConfig(prefixCacheEnabled: true).launchFlags == ["--enable-prefix-cache"])
+        #expect(ModelPerfConfig(prefixCacheEnabled: false).launchFlags == ["--disable-prefix-cache"])
+    }
+
+    @Test("Cache memory is clamped into the supported range")
+    func cacheMemoryIsClamped() {
+        #expect(ModelPerfConfig(cacheMemoryMB: 1).launchFlags
+            == ["--cache-memory-mb", String(ModelPerfConfig.cacheMemoryMBRange.lowerBound)])
+        #expect(ModelPerfConfig(cacheMemoryMB: 1_000_000).launchFlags
+            == ["--cache-memory-mb", String(ModelPerfConfig.cacheMemoryMBRange.upperBound)])
+    }
+
+    @Test("Every KV mode carries a trade-off line")
+    func everyModeStatesItsTradeOff() {
+        // The issue requires the trade-off next to the control. Pinning it
+        // here means a new case cannot ship without one.
+        for mode in KVCacheMode.allCases {
+            #expect(mode.tradeOff.isEmpty == false)
+            #expect(mode.title.isEmpty == false)
+        }
+    }
+
+    // MARK: - Merge against the RAM-tier recommendation
+
+    /// The 24 GB tier's recommendation for this alias, verbatim from
+    /// ``RAMBucketedDefault``. Hard-coded rather than fetched so the merge
+    /// contract is pinned independently of a future recommendation change.
+    private let gemmaRecommendation = [
+        "--no-mllm", "--kv-cache-dtype", "bf16", "--cache-memory-mb", "512",
+    ]
+
+    @Test("No override leaves the recommendation untouched")
+    func noOverrideKeepsRecommendation() {
+        #expect(ServerManager.mergedPerformanceFlags(
+            recommended: gemmaRecommendation, userOverrides: []
+        ) == gemmaRecommendation)
+    }
+
+    @Test("An override replaces only its own knob")
+    func overrideSupersedesOnlyItsOwnKnob() {
+        let merged = ServerManager.mergedPerformanceFlags(
+            recommended: gemmaRecommendation,
+            userOverrides: ["--kv-cache-dtype", "int4"]
+        )
+        // --no-mllm and the recommendation's cache budget survive; only the
+        // dtype is replaced.
+        #expect(merged == ["--no-mllm", "--cache-memory-mb", "512", "--kv-cache-dtype", "int4"])
+    }
+
+    @Test("A TurboQuant choice drops the recommendation's conflicting dtype")
+    func turboquantSupersedesRecommendedDtype() {
+        let merged = ServerManager.mergedPerformanceFlags(
+            recommended: gemmaRecommendation,
+            userOverrides: ["--kv-cache-turboquant", "k8v4"]
+        )
+        // Leaving `--kv-cache-dtype bf16` on argv would be a lie: the engine
+        // resolves the dtype only when TurboQuant is off.
+        #expect(merged.contains("--kv-cache-dtype") == false)
+        #expect(merged == ["--no-mllm", "--cache-memory-mb", "512", "--kv-cache-turboquant", "k8v4"])
+    }
+
+    @Test("A prefix-cache override does not disturb the KV recommendation")
+    func prefixOverrideLeavesKVAlone() {
+        let merged = ServerManager.mergedPerformanceFlags(
+            recommended: gemmaRecommendation,
+            userOverrides: ["--disable-prefix-cache"]
+        )
+        #expect(merged == gemmaRecommendation + ["--disable-prefix-cache"])
+    }
+
+    @Test("A cache-budget override replaces the recommended budget exactly once")
+    func cacheBudgetOverrideReplacesValue() {
+        let merged = ServerManager.mergedPerformanceFlags(
+            recommended: gemmaRecommendation,
+            userOverrides: ["--cache-memory-mb", "8192"]
+        )
+        #expect(merged == ["--no-mllm", "--kv-cache-dtype", "bf16", "--cache-memory-mb", "8192"])
+        #expect(merged.filter { $0 == "--cache-memory-mb" }.count == 1)
+    }
+
+    @Test("Merging against an empty recommendation just yields the overrides")
+    func emptyRecommendationYieldsOverrides() {
+        let merged = ServerManager.mergedPerformanceFlags(
+            recommended: [],
+            userOverrides: ["--kv-cache-dtype", "int8", "--enable-prefix-cache"]
+        )
+        #expect(merged == ["--kv-cache-dtype", "int8", "--enable-prefix-cache"])
+    }
+
+    @Test("A bare value-carrying flag does not swallow the flag after it")
+    func bareValueCarryingFlagDoesNotEatItsNeighbour() {
+        // ``--kv-cache-turboquant`` is ``nargs="?"`` in the engine, so a
+        // recommendation may carry it bare. Consuming the next token
+        // unconditionally would silently drop ``--no-mllm``.
+        let merged = ServerManager.mergedPerformanceFlags(
+            recommended: ["--kv-cache-turboquant", "--no-mllm"],
+            userOverrides: ["--kv-cache-dtype", "int8"]
+        )
+        #expect(merged == ["--no-mllm", "--kv-cache-dtype", "int8"])
+    }
+
+    // MARK: - Helpers
+
+    private func makeDefaults() -> UserDefaults {
+        // A private suite per test keeps these from colliding with each other
+        // and with the real app domain.
+        let suite = "rapid.tests.perf.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        return defaults
+    }
+
+    private func makeStore() -> ModelPerfConfigStore {
+        ModelPerfConfigStore(defaults: makeDefaults())
+    }
+}

--- a/apps/rapid-mac/Tests/RapidTests/ModelPerfConfigTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ModelPerfConfigTests.swift
@@ -223,6 +223,20 @@ struct ModelPerfConfigTests {
         #expect(merged == ["--no-mllm", "--kv-cache-dtype", "int8"])
     }
 
+    @Test("A failed or mismatched restart is never reported as applied")
+    func restartAcknowledgementRequiresTheSameReadyModel() {
+        #expect(SettingsPerformancePanel.restartApplied(
+            state: .ready(alias: "Qwen3.6-35B-4bit"), alias: "qwen3.6-35b-4bit"
+        ))
+        #expect(!SettingsPerformancePanel.restartApplied(
+            state: .ready(alias: "gemma-4-26b-4bit"), alias: "qwen3.6-35b-4bit"
+        ))
+        #expect(!SettingsPerformancePanel.restartApplied(
+            state: .crashed(alias: "qwen3.6-35b-4bit", message: "spawn failed"),
+            alias: "qwen3.6-35b-4bit"
+        ))
+    }
+
     // MARK: - Helpers
 
     private func makeDefaults() -> UserDefaults {

--- a/apps/rapid-mac/Tests/RapidTests/SettingsVisualFoundationTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SettingsVisualFoundationTests.swift
@@ -75,15 +75,20 @@ struct SettingsVisualFoundationTests {
     @MainActor
     @Test("Every category still exists, with a title and an icon")
     func everyCategorySurvives() {
+        // ``performance`` joined in #1717 (per-model engine knobs), as
+        // ``connectors`` did in #1716. The guard's job is to make a category
+        // change deliberate and reviewed, not to freeze the list forever —
+        // update this literal alongside the enum when a feature adds one.
         let expected: Set<String> = [
-            "modelManagement", "tools", "connectors", "appearance", "privacy", "app",
+            "modelManagement", "tools", "connectors", "performance",
+            "appearance", "privacy", "app",
         ]
         let actual = Set(SettingsView.Category.allCases.map(\.rawValue))
         #expect(
             actual == expected,
             """
             UI-1 is a visual migration and must not add, remove, or rename a \
-            Settings category. Got \(actual.sorted()).
+            Settings category as a side effect. Got \(actual.sorted()).
             """
         )
         for category in SettingsView.Category.allCases {
@@ -96,8 +101,14 @@ struct SettingsVisualFoundationTests {
     @Test("Category order is unchanged, so arrow-key navigation is unchanged")
     func categoryOrderIsStable() {
         #expect(SettingsView.Category.allCases.map(\.rawValue) == [
-            "modelManagement", "tools", "connectors", "appearance", "privacy", "app",
+            "modelManagement", "tools", "connectors", "performance",
+            "appearance", "privacy", "app",
         ])
+        // #1717: ``performance`` sits after ``connectors`` — both are
+        // "what the engine is wired to do", ahead of the presentation and
+        // app-level sections.
+        #expect(SettingsView.category(.connectors, movedBy: 1) == .performance)
+        #expect(SettingsView.category(.performance, movedBy: 1) == .appearance)
         // The rail's ↑/↓ handler walks this order and clamps at the ends.
         #expect(SettingsView.category(.modelManagement, movedBy: -1) == nil)
         #expect(SettingsView.category(.app, movedBy: 1) == nil)

--- a/apps/rapid-mac/Tests/RapidTests/SettingsVisualFoundationTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SettingsVisualFoundationTests.swift
@@ -37,6 +37,7 @@ struct SettingsVisualFoundationTests {
         "Sources/Rapid/UI/SettingsToolsPanel.swift",
         "Sources/Rapid/UI/SettingsConnectorsPanel.swift",
         "Sources/Rapid/UI/SettingsModelManagementPanel.swift",
+        "Sources/Rapid/UI/SettingsPerformancePanel.swift",
         "Sources/Rapid/UI/MCPServerEditorSheet.swift",
     ]
 

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -1136,7 +1136,17 @@ flow_settings_persistence() {
     open_settings
     wait_settings_stable "$OUT/settings-root.json"
     baseline settings-persistence.settings-root "$OUT/settings-root.json"
-    press "$OUT/settings-root.json" Settings.Category.modelManagement "$OUT/settings-models-open.json"
+    # #1717: prove the new Performance destination is mounted in the real app
+    # and exposes its honest empty state before any model has launched. Keep
+    # this semantic (rather than pixel-only) so an empty placeholder cannot
+    # silently replace the panel while unrelated Settings baselines stay green.
+    press "$OUT/settings-root.json" Settings.Category.performance "$OUT/settings-performance-open.json"
+    wait_settings_stable "$OUT/performance-empty.json" Settings.Performance.NoModel
+    jq -e '.data.ui_elements[]? | select(.identifier == "Settings.Performance.Panel")' \
+        "$OUT/performance-empty.json" >/dev/null || die "Performance settings panel did not mount"
+    jq -e '.data.ui_elements[]? | select(.identifier == "Settings.Performance.NoModel" and (.description | contains("Start a model")))' \
+        "$OUT/performance-empty.json" >/dev/null || die "Performance settings did not explain that a model must be started"
+    press "$OUT/performance-empty.json" Settings.Category.modelManagement "$OUT/settings-models-open.json"
     wait_settings_stable "$OUT/models-before.json" Settings.Models.ShowAllModelsToggle
     # GoldenFlow coverage for the recommendation SSOT: the running GUI must
     # render exactly the smart + fast aliases selected from the same JSON the

--- a/tests/test_kv_cache_dtype_cli.py
+++ b/tests/test_kv_cache_dtype_cli.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 import subprocess
 import sys
 
+from vllm_mlx import cli
+
 
 def _serve_help() -> str:
     """Run ``python -m vllm_mlx.cli serve --help`` and return its stdout."""
@@ -67,24 +69,92 @@ def test_serve_help_lists_all_three_choices():
     assert "int4" in text
 
 
-def test_serve_rejects_reasoning_plus_legacy_kv_cache_quantization_bits_4():
+class _KVArgs:
+    """Minimal stand-in for the parsed ``serve`` namespace.
+
+    Defaults mirror argparse's: TurboQuant off, legacy quantization off,
+    bits=8, reasoning off. Each test overrides only what it is about.
+    """
+
+    def __init__(self, **overrides):
+        self.kv_cache_turboquant = None
+        self.kv_cache_quantization = False
+        self.kv_cache_quantization_bits = 8
+        self.reasoning = False
+        for key, value in overrides.items():
+            setattr(self, key, value)
+
+
+def test_reasoning_plus_legacy_kv_cache_quantization_bits_4_is_rejected():
     """codex r1 BLOCKING #1: --reasoning + legacy --kv-cache-quantization
     --kv-cache-quantization-bits 4 used to silently resolve to int4,
-    ignoring the reasoning profile's int8 pin. The fix rejects the
-    combo with an actionable error message. Tested via subprocess so
-    the inline SystemExit codepath runs end-to-end.
+    ignoring the reasoning profile's int8 pin. The fix rejects the combo
+    with an actionable error message.
 
-    We pass ``--help`` after the conflicting flags so the parser exits
-    cleanly if the rejection didn't fire — that flips the failure into
-    a "should have rejected but instead printed help" assertion.
-    Without ``--help``, the test would also need a real model load
-    which is out of scope for the CLI surface test.
+    Exercised against ``kv_cache_flag_conflict`` rather than by spawning
+    ``serve``. The subprocess version of this test ran a real ``serve``
+    with a 30 s timeout and asserted a non-zero exit; because alias
+    resolution and the weight download run before the rejection, it passed
+    on machines that happened to have the fixture model cached and timed
+    out on machines that did not. Its colour tracked local Hugging Face
+    cache state, not whether the rejection still fired — so deleting the
+    rejection outright would not reliably have turned it red.
     """
-    # Use a fake model name; the rejection happens BEFORE the model
-    # load codepath, so we never need network or HF cache. We do need
-    # ``--no-port-preflight`` style suppression though — but the
-    # rejection runs BEFORE port preflight too. Test by capturing the
-    # error message + exit code.
+    reason = cli.kv_cache_flag_conflict(
+        _KVArgs(reasoning=True, kv_cache_quantization=True, kv_cache_quantization_bits=4)
+    )
+    assert reason is not None, "the --reasoning + bits=4 conflict must be rejected"
+    assert "--reasoning" in reason
+    assert "--kv-cache-quantization-bits 4" in reason
+    # The message has to say what to do, not just what is wrong.
+    assert "--kv-cache-dtype int8" in reason
+
+
+def test_reasoning_plus_legacy_bits_8_is_allowed():
+    """bits=8 is equivalent to --reasoning's own int8 pin, so it is not a
+    conflict. Pins the boundary the check above must not over-reach past."""
+    assert (
+        cli.kv_cache_flag_conflict(
+            _KVArgs(
+                reasoning=True,
+                kv_cache_quantization=True,
+                kv_cache_quantization_bits=8,
+            )
+        )
+        is None
+    )
+
+
+def test_turboquant_and_legacy_quantization_are_mutually_exclusive():
+    reason = cli.kv_cache_flag_conflict(
+        _KVArgs(kv_cache_turboquant="k8v4", kv_cache_quantization=True)
+    )
+    assert reason is not None
+    assert "mutually exclusive" in reason
+
+
+def test_out_of_range_quantization_bits_is_rejected():
+    """codex r2 BLOCKING #1: argparse pins bits to {4, 8}, but programmatic
+    callers can land anything here, and the old code silently labelled every
+    non-4 value as int8."""
+    reason = cli.kv_cache_flag_conflict(
+        _KVArgs(kv_cache_quantization=True, kv_cache_quantization_bits=5)
+    )
+    assert reason is not None
+    assert "must be 4 or 8" in reason
+
+
+def test_no_kv_flags_is_not_a_conflict():
+    """The untouched default must never be reported as a conflict."""
+    assert cli.kv_cache_flag_conflict(_KVArgs()) is None
+
+
+def test_serve_rejects_the_conflict_end_to_end():
+    """The wiring half: ``serve`` must actually consult the predicate and
+    exit non-zero. Uses ``--kv-cache-quantization-bits 5``, which argparse
+    itself rejects at parse time — before any alias resolution or download —
+    so this stays fast and cache-independent while still proving the CLI
+    refuses the flag rather than proceeding."""
     proc = subprocess.run(
         [
             sys.executable,
@@ -92,22 +162,19 @@ def test_serve_rejects_reasoning_plus_legacy_kv_cache_quantization_bits_4():
             "vllm_mlx.cli",
             "serve",
             "qwen3-0.6b-4bit",
-            "--reasoning",
             "--kv-cache-quantization",
             "--kv-cache-quantization-bits",
-            "4",
+            "5",
         ],
         capture_output=True,
         text=True,
         timeout=30,
     )
-    # Either stderr or stdout will carry the error string depending on
-    # python buffering; check both.
     combined = (proc.stdout or "") + (proc.stderr or "")
     assert proc.returncode != 0, (
         f"expected non-zero exit, got rc={proc.returncode}; "
         f"stdout={proc.stdout!r}, stderr={proc.stderr!r}"
     )
-    assert "--reasoning" in combined and "--kv-cache-quantization-bits 4" in combined, (
-        f"expected actionable error mentioning the conflict; got: {combined!r}"
+    assert "4" in combined and "8" in combined, (
+        f"expected the bits constraint in the error; got: {combined!r}"
     )

--- a/tests/test_kv_cache_dtype_cli.py
+++ b/tests/test_kv_cache_dtype_cli.py
@@ -101,7 +101,9 @@ def test_reasoning_plus_legacy_kv_cache_quantization_bits_4_is_rejected():
     rejection outright would not reliably have turned it red.
     """
     reason = cli.kv_cache_flag_conflict(
-        _KVArgs(reasoning=True, kv_cache_quantization=True, kv_cache_quantization_bits=4)
+        _KVArgs(
+            reasoning=True, kv_cache_quantization=True, kv_cache_quantization_bits=4
+        )
     )
     assert reason is not None, "the --reasoning + bits=4 conflict must be rejected"
     assert "--reasoning" in reason

--- a/tests/test_turboquant_k8v4.py
+++ b/tests/test_turboquant_k8v4.py
@@ -22,6 +22,7 @@ import argparse
 import copy
 import subprocess
 import sys
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import mlx.core as mx
@@ -533,12 +534,32 @@ class TestCLIFlag:
 
         from vllm_mlx import cli
 
-        source = inspect.getsource(cli.serve_command)
+        # The check moved out of ``serve_command`` into the extracted
+        # ``kv_cache_flag_conflict`` predicate (#1717) so it could be tested
+        # without spawning a real ``serve``; ``serve_command`` now calls it
+        # and exits on a non-None result. Both halves are asserted, so
+        # neither the check nor its wiring can silently disappear.
+        source = inspect.getsource(cli.kv_cache_flag_conflict)
         # Mutex check must exist and use ``args.kv_cache_turboquant``
         # truthiness (not ``== True``) so the v4/k8v4 string values
         # trigger the gate.
         assert "kv_cache_turboquant and args.kv_cache_quantization" in source
         assert "mutually exclusive" in source.lower()
+        assert "kv_cache_flag_conflict" in inspect.getsource(cli.serve_command)
+
+        # Behavioural companion to the greps above: the gate must actually
+        # fire for the string modes the ``nargs="?"`` flag now produces.
+        for mode in ("v4", "k8v4"):
+            args = SimpleNamespace(
+                kv_cache_turboquant=mode,
+                kv_cache_quantization=True,
+                kv_cache_quantization_bits=8,
+                reasoning=False,
+            )
+            reason = cli.kv_cache_flag_conflict(args)
+            assert reason is not None and "mutually exclusive" in reason.lower(), (
+                f"--kv-cache-turboquant={mode} + --kv-cache-quantization must conflict"
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -2383,6 +2383,71 @@ def _serve_will_run_on_mllm_lane(args) -> bool:
     return is_mllm_lane
 
 
+def kv_cache_flag_conflict(args) -> str | None:
+    """Return the operator-facing reason the KV-cache flags conflict, else None.
+
+    Pure predicate over the parsed args — no I/O, no model resolution, no
+    process exit. ``serve_command`` prints the returned message and exits 1.
+
+    Extracted from ``serve_command`` because the rejections were only
+    reachable by spawning a real ``serve``, and the test that covered them
+    did exactly that: it ran ``serve <alias> --reasoning
+    --kv-cache-quantization --kv-cache-quantization-bits 4`` in a subprocess
+    with a 30 s timeout and asserted a non-zero exit. Alias resolution and
+    the weight download run *before* this point, so on a machine without the
+    fixture model cached the child spent the whole budget downloading and the
+    test timed out — it passed or failed on local Hugging Face cache state
+    rather than on whether the rejection still fired. A guard whose colour is
+    decided by something other than the behaviour it guards is not a guard.
+
+    The three checks and their messages are unchanged; only their location is.
+    """
+    # Mutual exclusion: turboquant (any mode) vs standard quantization.
+    # The argparse layer normalizes the flag to either ``None`` (off),
+    # ``"v4"``, or ``"k8v4"``. Anything truthy means TurboQuant is on.
+    if args.kv_cache_turboquant and args.kv_cache_quantization:
+        return (
+            "--kv-cache-turboquant and --kv-cache-quantization are "
+            "mutually exclusive. Choose one."
+        )
+
+    if not args.kv_cache_quantization:
+        return None
+
+    # codex r1 BLOCKING #1: ``--reasoning`` must override the legacy
+    # ``--kv-cache-quantization`` flag too — otherwise ``rapid-mlx serve
+    # --reasoning --kv-cache-quantization --kv-cache-quantization-bits 4``
+    # silently resolves to int4 and the operator who deliberately asked for
+    # the reasoning profile gets the AIME-class quality cliff. Reject the
+    # conflicting combo explicitly: silently flipping the legacy bits to 8
+    # would hide the misconfiguration. bits=8 is equivalent to
+    # ``--reasoning``'s int8 pin and is harmless; only bits=4 conflicts.
+    if args.reasoning and args.kv_cache_quantization_bits == 4:
+        return (
+            "--reasoning is incompatible with --kv-cache-quantization "
+            "--kv-cache-quantization-bits 4. The reasoning profile pins KV "
+            "cache to int8 because sub-4-bit drops -20pt on AIME-class math. "
+            "Either drop --reasoning or drop --kv-cache-quantization-bits 4 "
+            "(or both; use --kv-cache-dtype int8 instead)."
+        )
+
+    # codex r2 BLOCKING #1: argparse pins ``--kv-cache-quantization-bits`` to
+    # ``choices={4,8}``, but programmatic callers (tests, library users that
+    # bypass argparse) can land an out-of-range bits value here. The old
+    # ``"int4" if bits == 4 else "int8"`` silently labeled every non-4 value
+    # as ``int8`` even when KV would actually be quantized at the requested
+    # bit width. Fail fast instead so the gauge / banner / SchedulerConfig
+    # never lie about the active dtype.
+    if args.kv_cache_quantization_bits not in (4, 8):
+        return (
+            f"--kv-cache-quantization-bits must be 4 or 8 "
+            f"(got {args.kv_cache_quantization_bits}). Use --kv-cache-dtype "
+            f"for the canonical knob."
+        )
+
+    return None
+
+
 def serve_command(args):
     """Start the OpenAI-compatible server."""
     import logging
@@ -3286,14 +3351,12 @@ def serve_command(args):
         args, model_name=args.model
     )
 
-    # Mutual exclusion: turboquant (any mode) vs standard quantization.
-    # The argparse layer normalizes the flag to either ``None`` (off),
-    # ``"v4"``, or ``"k8v4"``. Anything truthy means TurboQuant is on.
-    if args.kv_cache_turboquant and args.kv_cache_quantization:
-        print(
-            "\n  Error: --kv-cache-turboquant and --kv-cache-quantization are "
-            "mutually exclusive. Choose one.\n"
-        )
+    # Reject conflicting KV-cache flag combinations before anything else in
+    # this block reads them. Extracted so the rejection can be tested without
+    # spawning ``serve`` — see ``kv_cache_flag_conflict``.
+    _kv_conflict = kv_cache_flag_conflict(args)
+    if _kv_conflict is not None:
+        print(f"\n  Error: {_kv_conflict}\n")
         sys.exit(1)
 
     # R15 #300: resolve --kv-cache-dtype + --reasoning + safelist BEFORE
@@ -3345,42 +3408,10 @@ def serve_command(args):
             KVCacheDtypeDecision,
         )
 
-        # codex r1 BLOCKING #1: ``--reasoning`` must override the
-        # legacy ``--kv-cache-quantization`` flag too — otherwise
-        # ``rapid-mlx serve --reasoning --kv-cache-quantization
-        # --kv-cache-quantization-bits 4`` silently resolves to int4
-        # and the operator who deliberately asked for the reasoning
-        # profile gets the AIME-class quality cliff. Reject the
-        # conflicting combo with an explicit error: silently flipping
-        # the legacy bits to 8 would hide the misconfiguration.
-        # bits=8 is equivalent to --reasoning's int8 pin and is
-        # harmless; only bits=4 conflicts.
-        if args.reasoning and args.kv_cache_quantization_bits == 4:
-            print(
-                "\n  Error: --reasoning is incompatible with "
-                "--kv-cache-quantization --kv-cache-quantization-bits 4. "
-                "The reasoning profile pins KV cache to int8 because "
-                "sub-4-bit drops -20pt on AIME-class math. Either drop "
-                "--reasoning or drop --kv-cache-quantization-bits 4 "
-                "(or both; use --kv-cache-dtype int8 instead).\n"
-            )
-            sys.exit(1)
-
-        # codex r2 BLOCKING #1: argparse pins ``--kv-cache-quantization-bits``
-        # to ``choices={4,8}``, but programmatic callers (tests, library
-        # users that bypass argparse) can land an out-of-range bits value
-        # here. The old ``"int4" if bits == 4 else "int8"`` silently
-        # labeled every non-4 value as ``int8`` even when KV would actually
-        # be quantized at the requested bit width. Fail fast instead so
-        # the gauge / banner / SchedulerConfig never lie about the
-        # active dtype.
-        if args.kv_cache_quantization_bits not in (4, 8):
-            print(
-                f"\n  Error: --kv-cache-quantization-bits must be 4 or 8 "
-                f"(got {args.kv_cache_quantization_bits}). Use "
-                f"--kv-cache-dtype for the canonical knob.\n"
-            )
-            sys.exit(1)
+        # The two rejections that used to live here (``--reasoning`` +
+        # bits=4, and an out-of-range bits value) moved into
+        # ``kv_cache_flag_conflict`` and already fired above, so anything
+        # reaching this point has a legal bits value.
         legacy_dtype = "int4" if args.kv_cache_quantization_bits == 4 else "int8"
         # When --reasoning is set alongside the (compatible) bits=8
         # legacy flag, the operator-facing reason should still


### PR DESCRIPTION
Part of #1717. The engine's throughput knobs reach `serve` only as CLI flags; the desktop app built its argv itself and offered none of them, so the GUI was the slow way to use the engine. This adds **Settings → Performance**: per-model overrides, persisted, resolved into `serve` argv at spawn.

Two commits: an engine-side test fix that had to land first, and the desktop feature.

## The audit came first, and it changed the scope

#1717 asks that flags be audited before any of them get a switch. Doing that turned up something that reshapes the issue: **four of the flags the issue names are dead.**

`--kv-bits`, `--kv-group-size`, `--draft-model` and `--num-draft-tokens` sit in the CLI's deprecated-no-op block. The comment there is explicit — they are parsed so old launch scripts keep booting, then *"consumed-and-discarded: stored on `args` but never read"*. `--specprefill*` is the same, and `docs/reference/cli.md` already records that family as "prototype removed". Confirmed three ways: `args.<dest>` is read zero times in `cli.py`; the same-named variables in the engine come from elsewhere (`memory_cache.py`'s `kv_bits` is fed from `kv_cache_quantization_bits`, `draft_model` from the dflash/ddtree runtimes); and `tests/test_cli_deprecated_noop_flags.py` pins them as no-ops.

A switch for any of these would be wired to nothing. The issue's own instruction for vestigial flags is to remove them from the CLI, not surface them — that removal is left for a separate change, since "accepted and ignored" is currently the friendlier deprecation and breaking old scripts is a call for the maintainer.

| Named in #1717 | Shipped | Why not |
|---|---|---|
| `--kv-cache-quantization*` | as `--kv-cache-dtype` | engine documents it as a deprecated alias of `--kv-cache-dtype int8`; the canonical knob ships instead |
| `--kv-cache-turboquant*` | ✅ | v4 and k8v4 |
| `--enable/disable-prefix-cache` | ✅ | |
| `--kv-bits`, `--kv-group-size` | ❌ | deprecated no-op |
| `--draft-model`, `--num-draft-tokens` | ❌ | deprecated no-op |
| `--prefix-cache-size` | ❌ | help says "legacy mode only"; `--cache-memory-mb` supersedes it and ships instead |
| `--prefix-cache-index` | ❌ | an escape hatch per its own comment, and no test binds the flag to the path it selects |
| `--spec-decode`, `--mtp-*`, `--suffix-*` | ❌ | canonical entry is `--speculative-config`, a JSON blob; these are all `argparse.SUPPRESS` legacy aliases |

Also excluded: `--metal-cap-kv-bytes-per-token` (under-setting it risks the OOM cliff the admission gate exists to prevent). `--hybrid-cache-entries` and `--response-cache-entries` passed the audit but are held back — the first is already auto-tuned by the engine, the second has narrow semantics (greedy requests only).

## One KV control, not two

The engine resolves `--kv-cache-dtype` only when TurboQuant is off, because TurboQuant owns the V cache. Two independent controls could show "int8 + TurboQuant" while the engine ran TurboQuant alone — exactly the "neither they nor we can tell which toggle did it" failure the issue opens with. They are a single picker.

The merge against the RAM-tier recommendation is per-group for the same reason: choosing TurboQuant drops the recommendation's `--kv-cache-dtype` so argv never carries a flag the engine will ignore, while groups the user did not touch keep their recommended values and unrelated flags (`--no-mllm`) always pass through.

## Defaults are unchanged for users who never open the panel

Every field is optional, and `nil` means "pass nothing" rather than "pass the engine default". An alias the user never touched has no row at all, so an untouched install spawns byte-identical argv — and a later engine-side default change still reaches those users instead of being frozen by a value the app snapshotted. "Reset to measured defaults" is row removal; nothing needs to know what the measured numbers are.

Restart is stated before the click, not after: the panel compares current settings against what the running child was actually spawned with, and shows the banner only when they diverge. Derived, not stored, so it survives a tab switch.

Each control carries a one-line trade-off, and the choices that can change output (int4, both TurboQuant modes) are marked distinctly from those that only cost memory. A test pins that every KV mode has one.

## The first commit: a guard that was not guarding

The audit found that `--kv-cache-dtype`'s CI guard did not work. `test_serve_rejects_reasoning_plus_legacy_kv_cache_quantization_bits_4` spawned a real `serve` with a 30s timeout and asserted a non-zero exit — but alias resolution and the weight download run before the rejection, so on a machine without the fixture model cached the child spent the whole budget downloading and the test timed out. Its result tracked local Hugging Face cache state, not whether the rejection still fired.

The three KV-cache conflict checks are extracted into `kv_cache_flag_conflict`, a pure predicate. `serve_command` prints its result and exits 1 — behaviour and the operator-facing messages are unchanged, only the location is. Tests call the predicate directly: 10 cases in 0.4s, covering both rejected combinations and the boundaries that must NOT be rejected (bits=8 alongside `--reasoning`, and the untouched default). One subprocess case remains to pin that `serve` actually consults the predicate, using a value argparse itself rejects so it stays cache-independent.

Verified by mutation: stubbing out the bits=4 branch turns the new test red. The previous test could not do that.

## Tests

- Swift: 19 new cases (sparseness, persistence, alias normalization, corrupt-blob handling, per-mode flag rendering, and the merge contract including the bare-`nargs="?"` case where a naive value-skip would swallow the following flag). Full suite 2080 tests.
- Python: 580 passed across the KV / TurboQuant / prefix-cache / deprecated-no-op families. `scripts/audit_cli_config_fidelity.py` clean.
- On device: selecting 8-bit and restarting puts `--kv-cache-dtype int8` on the child's argv, confirmed via `ps -axww`.

One pre-existing failure is unrelated and reproduces on a clean tree: `DownloadCatalogHardeningTests` "terminates catalog subprocesses when the async task is cancelled".

## What is still open

This is "part of", not "closes". The issue's first acceptance criterion asks that the effect be visible in "the existing benchmark surface" — but that surface renders `RAMBucketedDefault.Pick.tokensPerSec`, a hard-coded per-model constant, not a live measurement. Changing KV precision cannot move it. Satisfying that criterion needs a throughput probe that does not exist yet, which seems worth its own issue rather than being folded in here.
