### PR TITLE
fix(mac): make golden-flow baselines portable across GPU probe and RAM total

### DIFF
--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-restore.answered.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-restore.answered.txt
@@ -39,8 +39,8 @@ AXApplication title="Rapid-MLX"
       AXUnknown desc="Server status" enabled=true
       AXUnknown desc="Tokens per second: no data yet" enabled=true
       AXUnknown desc="CPU <percent>" enabled=true
-      AXStaticText help="GPU probe unavailable — Intel Macs and sandboxed apps don't expose AGXAccelerator utilisation." value=text enabled=true
-      AXUnknown desc="Memory normal: <version> gigabytes used out of 7 gigabytes" enabled=true
+      AXUnknown desc="GPU <gpu>" enabled=true
+      AXUnknown desc="Memory normal: <size> used out of <size>" enabled=true
       AXButton id="Footer.DesktopVersionPill" desc="Rapid-MLX <version> · up to date" help="Rapid-MLX <version> is the latest release. Click to open Settings → App." enabled=true
     AXToolbar
       AXButton desc="Hide Sidebar" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-restore.transcript-restored.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-restore.transcript-restored.txt
@@ -39,8 +39,8 @@ AXApplication title="Rapid-MLX"
       AXUnknown desc="Server status" enabled=true
       AXUnknown desc="Tokens per second: no data yet" enabled=true
       AXUnknown desc="CPU <percent>" enabled=true
-      AXStaticText help="GPU probe unavailable — Intel Macs and sandboxed apps don't expose AGXAccelerator utilisation." value=text enabled=true
-      AXUnknown desc="Memory normal: <version> gigabytes used out of 7 gigabytes" enabled=true
+      AXUnknown desc="GPU <gpu>" enabled=true
+      AXUnknown desc="Memory normal: <size> used out of <size>" enabled=true
       AXButton id="Footer.DesktopVersionPill" desc="Rapid-MLX <version> · up to date" help="Rapid-MLX <version> is the latest release. Click to open Settings → App." enabled=true
     AXToolbar
       AXButton desc="Hide Sidebar" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/image-generation.generated.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/image-generation.generated.txt
@@ -28,8 +28,8 @@ AXApplication title="Rapid-MLX"
       AXUnknown desc="Server status" enabled=true
       AXUnknown desc="Tokens per second: no data yet" enabled=true
       AXUnknown desc="CPU <percent>" enabled=true
-      AXStaticText help="GPU probe unavailable — Intel Macs and sandboxed apps don't expose AGXAccelerator utilisation." value=text enabled=true
-      AXUnknown desc="Memory normal: <version> gigabytes used out of 7 gigabytes" enabled=true
+      AXUnknown desc="GPU <gpu>" enabled=true
+      AXUnknown desc="Memory normal: <size> used out of <size>" enabled=true
       AXButton id="Footer.DesktopVersionPill" desc="Rapid-MLX <version> · up to date" help="Rapid-MLX <version> is the latest release. Click to open Settings → App." enabled=true
     AXToolbar
       AXButton desc="Hide Sidebar" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/model-crash-recovery.recovered.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/model-crash-recovery.recovered.txt
@@ -39,8 +39,8 @@ AXApplication title="Rapid-MLX"
       AXUnknown desc="Server status" enabled=true
       AXUnknown desc="Tokens per second: no data yet" enabled=true
       AXUnknown desc="CPU <percent>" enabled=true
-      AXStaticText help="GPU probe unavailable — Intel Macs and sandboxed apps don't expose AGXAccelerator utilisation." value=text enabled=true
-      AXUnknown desc="Memory normal: <version> gigabytes used out of 7 gigabytes" enabled=true
+      AXUnknown desc="GPU <gpu>" enabled=true
+      AXUnknown desc="Memory normal: <size> used out of <size>" enabled=true
       AXButton id="Footer.DesktopVersionPill" desc="Rapid-MLX <version> · up to date" help="Rapid-MLX <version> is the latest release. Click to open Settings → App." enabled=true
     AXToolbar
       AXButton desc="Hide Sidebar" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/slow-stream-stop.stopped.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/slow-stream-stop.stopped.txt
@@ -39,8 +39,8 @@ AXApplication title="Rapid-MLX"
       AXUnknown desc="Server status" enabled=true
       AXUnknown desc="Tokens per second: no data yet" enabled=true
       AXUnknown desc="CPU <percent>" enabled=true
-      AXStaticText help="GPU probe unavailable — Intel Macs and sandboxed apps don't expose AGXAccelerator utilisation." value=text enabled=true
-      AXUnknown desc="Memory normal: <version> gigabytes used out of 7 gigabytes" enabled=true
+      AXUnknown desc="GPU <gpu>" enabled=true
+      AXUnknown desc="Memory normal: <size> used out of <size>" enabled=true
       AXButton id="Footer.DesktopVersionPill" desc="Rapid-MLX <version> · up to date" help="Rapid-MLX <version> is the latest release. Click to open Settings → App." enabled=true
     AXToolbar
       AXButton desc="Hide Sidebar" enabled=true

--- a/apps/rapid-mac/scripts/ax-baseline.py
+++ b/apps/rapid-mac/scripts/ax-baseline.py
@@ -78,8 +78,17 @@ _SCRUBBERS: tuple[tuple[re.Pattern[str], str], ...] = (
     (
         # Multi-character units only. A bare "B" would swallow "Sub-1B
         # models", where the B is a parameter count, not a byte count.
+        #
+        # The spelled-out units (…"gigabytes") are how VoiceOver reads the
+        # footer memory gauge — "12.3 gigabytes used out of 32 gigabytes" — so
+        # both the used reading AND the machine's total collapse here. Without
+        # them the total (an integer, no decimal) slips past every rule and a
+        # baseline written on a 32 GB Mac can never match a 7 GB runner.
         re.compile(
-            r"\b\d+(?:[.,]\d+)?\s*(?:KB|MB|GB|TB|PB|KiB|MiB|GiB|TiB|bytes?)\b",
+            r"\b\d+(?:[.,]\d+)?\s*"
+            r"(?:KB|MB|GB|TB|PB|KiB|MiB|GiB|TiB"
+            r"|kilobytes?|megabytes?|gigabytes?|terabytes?|petabytes?"
+            r"|bytes?)\b",
         ),
         "<size>",
     ),
@@ -170,6 +179,42 @@ def is_window_control(record: dict) -> bool:
         "Hide Sidebar",
         "Show Sidebar",
     }
+
+
+# The footer's GPU gauge has no stable cross-machine shape. Apple Silicon
+# publishes a live utilisation reading (``AXUnknown desc="GPU 47 percent"``);
+# Intel Macs and sandboxed apps can't probe AGXAccelerator at all and instead
+# publish a static "unavailable" note (``AXStaticText help="GPU probe
+# unavailable — …" value=text``). SAME footer item, different role, different
+# attribute, different text. Its reading is live state, not structure — exactly
+# like the CPU and memory gauges beside it — so collapse the whole element to
+# one token. Otherwise a baseline written on either machine turns the other red
+# on the GPU line alone, which is precisely how the golden flows regressed.
+#
+# The two exact shapes SystemPills.swift publishes, each keyed to the attribute
+# it lands in and full-matched end to end. The live reading is an
+# accessibilityLabel ("GPU <int> percent", an AXDescription); the note is a
+# .help string that names AGXAccelerator (an AXHelp). Full-matching both — and
+# never a bare "GPU " prefix or loose substring — means an unrelated control
+# ("GPU 47 percent limit", "GPU probe unavailable settings", a "GPU settings"
+# button) keeps its own structure, so a real regression there still fails.
+_GPU_READING = re.compile(r"GPU \d+ percent")
+_GPU_UNAVAILABLE = re.compile(r"GPU probe unavailable\b.*AGXAccelerator.*", re.DOTALL)
+
+
+def is_gpu_telemetry(record: dict) -> bool:
+    """True for the footer GPU utilisation readout, in either platform shape.
+
+    Keyed to the exact (role, attribute) pair each shape uses and full-matched,
+    so only the gauge itself is collapsed. A gauge whose role ever changes stops
+    matching and surfaces as a visible golden-flow diff, never a silent rewrite.
+    """
+    role = record.get("role")
+    if role == "AXUnknown":
+        return bool(_GPU_READING.fullmatch(record.get("description") or ""))
+    if role == "AXStaticText":
+        return bool(_GPU_UNAVAILABLE.fullmatch(record.get("help") or ""))
+    return False
 
 
 class Node:
@@ -272,6 +317,12 @@ def quote(text: str) -> str:
 
 def render_node(node: Node, extra_tokens: tuple[str, ...]) -> str:
     record = node.record
+    if is_gpu_telemetry(record):
+        # One canonical line for both platform shapes (see is_gpu_telemetry).
+        parts = ["AXUnknown", 'desc="GPU <gpu>"']
+        if "enabled" in record:
+            parts.append(f"enabled={str(bool(record['enabled'])).lower()}")
+        return " ".join(parts)
     raw_role = record.get("role", "AXUnknown")
     parts = [_ROLE_EQUIVALENTS.get(raw_role, raw_role)]
     subrole = record.get("subrole")

--- a/tests/test_ax_baseline_os_variance.py
+++ b/tests/test_ax_baseline_os_variance.py
@@ -174,6 +174,90 @@ def test_no_committed_baseline_pins_a_title_beside_a_description(baseline: Path)
     )
 
 
+def test_gpu_gauge_normalizes_identically_across_machines():
+    """Apple Silicon reads a live GPU %, Intel/sandboxed says "unavailable".
+
+    Same footer item, different role + attribute + text. A baseline generated
+    on one turns the other red on the GPU line unless the normalizer collapses
+    both to one token — the exact regression these flows hit.
+    """
+    apple_silicon = _render(
+        {"role": "AXUnknown", "description": "GPU 47 percent", "enabled": True}
+    )
+    intel_sandboxed = _render(
+        {
+            "role": "AXStaticText",
+            "help": (
+                "GPU probe unavailable — Intel Macs and sandboxed apps don't "
+                "expose AGXAccelerator utilisation."
+            ),
+            "value": "text",
+            "enabled": True,
+        }
+    )
+    assert apple_silicon == intel_sandboxed
+    assert "percent" not in apple_silicon
+    assert "AGXAccelerator" not in intel_sandboxed
+
+
+def test_gpu_canonicalization_does_not_swallow_unrelated_controls():
+    """The gauge is matched on its exact wording, not a bare "GPU " prefix.
+
+    A control that merely starts with "GPU" — a settings row, a menu item —
+    keeps its own structure, so a real regression there still fails the gate.
+    """
+    # A gauge-shaped button keeps its own structure — the role guard rejects it
+    # even though its text starts like the live reading.
+    rendered = _render(
+        {
+            "role": "AXButton",
+            "identifier": "Settings.Category.gpu",
+            "description": "GPU settings",
+            "enabled": True,
+        }
+    )
+    assert 'desc="GPU settings"' in rendered
+    assert "<gpu>" not in rendered
+    assert 'id="Settings.Category.gpu"' in rendered
+
+    # Neither guard alone suffices: each of these clears the role check but the
+    # full-match rejects the text, so a "GPU 47 percent settings" reading, a
+    # "GPU probe unavailable options" note, or an incidental AGXAccelerator
+    # mention is never mistaken for the gauge.
+    for record in (
+        {"role": "AXUnknown", "description": "GPU 47 percent settings"},
+        {"role": "AXStaticText", "help": "GPU probe unavailable options"},
+        {
+            "role": "AXStaticText",
+            "help": "Enable AGXAccelerator logging in the developer menu",
+        },
+    ):
+        rendered = _render({**record, "enabled": True})
+        assert "<gpu>" not in rendered, rendered
+
+
+def test_memory_gauge_total_is_machine_independent():
+    """The footer memory readout names the machine's total RAM. A 32 GB Mac and
+    a 7 GB runner must still normalize to the same line."""
+    big = _render(
+        {
+            "role": "AXUnknown",
+            "description": "Memory normal: 12.3 gigabytes used out of 32 gigabytes",
+            "enabled": True,
+        }
+    )
+    small = _render(
+        {
+            "role": "AXUnknown",
+            "description": "Memory normal: 4.1 gigabytes used out of 7 gigabytes",
+            "enabled": True,
+        }
+    )
+    assert big == small
+    # Neither the used reading nor the total survives as a literal number.
+    assert "32" not in big and "7" not in big
+
+
 def test_window_ordering_ignores_a_title_the_baseline_hides():
     """Sorting must use what is rendered, or two OSes order windows differently
     while rendering identical lines."""


### PR DESCRIPTION
## Why
The four golden flows that capture the main-window footer — `chat-restore`, `slow-stream-stop`, `model-crash-recovery`, `image-generation` — fail the AX structural gate on **every Apple Silicon developer machine**, the platform the app targets. CI stays green because the baselines committed in #1835 were generated on the hosted runner (Intel/sandboxed, 7 GB RAM), so the gate silently only holds on that one environment and is useless as a local dogfood tool.

Two footer gauges read machine-specific state the normalizer never scrubbed:

- **GPU gauge** has no stable cross-machine shape. Apple Silicon publishes a live reading (`AXUnknown desc="GPU 47 percent"`); Intel Macs and sandboxed apps can't probe AGXAccelerator and publish a static note (`AXStaticText help="GPU probe unavailable — …" value=text`) — same footer item, different role, attribute, and text.
- **Memory gauge** names the machine's total RAM (`… out of 32 gigabytes`). The spelled-out unit slipped past the `<size>` rule, so the integer total stayed literal (`7` on the runner vs `32` on a dev Mac).

## What
Fix in `ax-baseline.py`, where the live footer values already collapse (CPU `<percent>`, tok/s `<rate>`):
- Fold spelled-out byte units (`gigabytes`, …) into the size rule so both the memory reading and the total become `<size>`.
- Canonicalize the GPU gauge to one `desc="GPU <gpu>"` line regardless of platform shape (mirrors how `_ROLE_EQUIVALENTS` already unifies a control's role across macOS releases).

The five affected baselines are regenerated; the diff is exactly the two footer lines per file, nothing else.

## Tests
- New regression cases in `tests/test_ax_baseline_os_variance.py` feed **both** platform shapes of each gauge through the normalizer and assert one output. They fail on `main` (GPU/memory lines differ) and pass here.
- `pytest tests/test_ax_baseline.py tests/test_ax_baseline_os_variance.py` → 24 passed.
- All four golden flows PASS locally on Apple Silicon (M2 Pro, 32 GB) with the regenerated baselines.

## Notes
- Normalizer + baseline only; no Swift/product change, no version bump.
- 🤖 Generated with [Claude Code](https://claude.com/claude-code)