### PR TITLE
fix(mac): complete per-model performance controls

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/RapidApp.swift
+++ b/apps/rapid-mac/Sources/Rapid/RapidApp.swift
@@ -182,6 +182,20 @@ struct RapidApp: App {
         manager.perfLaunchFlagsProvider = { [weak perfConfigStore] alias in
             MainActor.assumeIsolated { perfConfigStore?.launchFlags(forAlias: alias) ?? [] }
         }
+        manager.perfConfigProvider = { [weak perfConfigStore] alias in
+            MainActor.assumeIsolated {
+                let recommended = RAMBucketedDefault.launchFlags(
+                    forAlias: alias,
+                    physicalRAMGB: MacHardware.detect().physicalRAMGB
+                )
+                let merged = ServerManager.mergedPerformanceFlags(
+                    recommended: recommended,
+                    userOverrides: perfConfigStore?.launchFlags(forAlias: alias) ?? []
+                )
+                let value = ModelPerfConfig(launchFlags: merged)
+                return value.isEmpty ? nil : value
+            }
+        }
         _perfConfig = State(initialValue: perfConfigStore)
 
         let chat = ChatViewModel(tools: toolRegistry, sampling: samplingConfig, server: manager)

--- a/apps/rapid-mac/Sources/Rapid/Server/ModelPerfConfig.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ModelPerfConfig.swift
@@ -88,6 +88,38 @@ struct ModelPerfConfig: Codable, Equatable, Sendable {
         return flags
     }
 
+    /// Decode the audited subset from an already-resolved argv fragment.
+    /// This is how residency receives the same measured recommendation +
+    /// user override that a cold ``serve`` spawn receives.
+    init(launchFlags: [String]) {
+        self.init()
+        var index = 0
+        while index < launchFlags.count {
+            let flag = launchFlags[index]
+            let value = index + 1 < launchFlags.count ? launchFlags[index + 1] : nil
+            switch flag {
+            case "--kv-cache-dtype":
+                if let value { kvCacheMode = KVCacheMode(rawValue: value) }
+                index += 2
+            case "--kv-cache-turboquant":
+                if value == "v4" { kvCacheMode = .turboquantV4 }
+                if value == "k8v4" { kvCacheMode = .turboquantK8V4 }
+                index += 2
+            case "--enable-prefix-cache":
+                prefixCacheEnabled = true
+                index += 1
+            case "--disable-prefix-cache":
+                prefixCacheEnabled = false
+                index += 1
+            case "--cache-memory-mb":
+                if let value, let parsed = Int(value) { cacheMemoryMB = parsed }
+                index += 2
+            default:
+                index += 1
+            }
+        }
+    }
+
     /// Flag names this config can emit. Used by ``ServerManager`` to drop the
     /// RAM-tier recommendation's value for a knob the user has an explicit
     /// opinion about, so the two never both land on argv.

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -321,6 +321,12 @@ final class ServerManager {
     /// keep the pre-#1717 argv verbatim.
     var perfLaunchFlagsProvider: ((String) -> [String])?
 
+    /// Typed counterpart used by the in-process residency control plane.
+    /// Launch argv remains for cold starts; dynamic loads must receive the
+    /// same per-model opinion or Settings would silently work only for the
+    /// first model in the sidecar (#1717 + #1788).
+    var perfConfigProvider: ((String) -> ModelPerfConfig?)?
+
     /// Health-check budget — interpreted as a **stall window** since
     /// v0.7.13, not a wall-clock-from-launch cap. The deadline slides
     /// forward every time ``downloadProgress`` reports forward motion
@@ -826,6 +832,7 @@ final class ServerManager {
                 hfPath: hfPath,
                 estimatedSizeGB: estimate,
                 replaceGroup: replacementGroup,
+                performance: perfConfigProvider?(trimmed),
                 port: activePort,
                 bearer: activeBearer
             )
@@ -898,6 +905,33 @@ final class ServerManager {
             await awaitStartupSettled(alias: trimmed)
         }
         return isServing(trimmed)
+    }
+
+    /// Rebuild only the named resident engine with its current performance
+    /// config. The sidecar and sibling residents stay alive; this is the
+    /// multi-model-safe replacement for Settings' former process-wide stop.
+    func reloadResidentPerformance(
+        alias: String,
+        hfPath: String? = nil,
+        estimatedMemoryGB: Double? = nil
+    ) async -> ResidentModelLoadResult {
+        let trimmed = alias.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, child != nil, isModelResident(trimmed) else {
+            return .rejected("That model is not currently resident. Its settings will apply the next time it loads.")
+        }
+        let result = await residencyClient.load(
+            alias: trimmed,
+            hfPath: hfPath,
+            estimatedSizeGB: estimatedMemoryGB ?? ModelSizing.estimate(alias: trimmed).totalGB,
+            performance: perfConfigProvider?(trimmed),
+            reloadIfChanged: true,
+            port: activePort,
+            bearer: activeBearer
+        )
+        if case .loaded = result {
+            await refreshResidency()
+        }
+        return result
     }
 
     /// True when the child is serving exactly this alias.

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerResidency.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerResidency.swift
@@ -12,6 +12,7 @@ struct ResidentModelStatus: Codable, Sendable, Equatable, Identifiable {
     let estimatedBytes: UInt64
     let measuredBytes: UInt64?
     let idleSeconds: Double
+    var performance: ResidentPerformanceStatus? = nil
 
     enum CodingKeys: String, CodingKey {
         case id
@@ -25,6 +26,7 @@ struct ResidentModelStatus: Codable, Sendable, Equatable, Identifiable {
         case estimatedBytes = "estimated_bytes"
         case measuredBytes = "measured_bytes"
         case idleSeconds = "idle_seconds"
+        case performance
     }
 
     func matches(_ alias: String) -> Bool {
@@ -48,6 +50,43 @@ struct ResidentModelStatus: Codable, Sendable, Equatable, Identifiable {
     /// its first request materializes the weights. Never present that partial
     /// delta as smaller than the admission reservation.
     var displayBytes: UInt64 { max(estimatedBytes, measuredBytes ?? 0) }
+}
+
+struct ResidentPerformanceStatus: Codable, Sendable, Equatable {
+    let kvCacheDtype: String?
+    let kvCacheTurboquant: String?
+    let prefixCacheEnabled: Bool?
+    let cacheMemoryMB: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case kvCacheDtype = "kv_cache_dtype"
+        case kvCacheTurboquant = "kv_cache_turboquant"
+        case prefixCacheEnabled = "prefix_cache_enabled"
+        case cacheMemoryMB = "cache_memory_mb"
+    }
+
+    init(config: ModelPerfConfig) {
+        switch config.kvCacheMode {
+        case .bf16, .int8, .int4:
+            kvCacheDtype = config.kvCacheMode?.rawValue
+            kvCacheTurboquant = nil
+        case .turboquantV4:
+            kvCacheDtype = nil
+            kvCacheTurboquant = "v4"
+        case .turboquantK8V4:
+            kvCacheDtype = nil
+            kvCacheTurboquant = "k8v4"
+        case nil:
+            kvCacheDtype = nil
+            kvCacheTurboquant = nil
+        }
+        prefixCacheEnabled = config.prefixCacheEnabled
+        cacheMemoryMB = config.cacheMemoryMB
+    }
+
+    func matches(_ config: ModelPerfConfig) -> Bool {
+        self == ResidentPerformanceStatus(config: config)
+    }
 }
 
 struct ModelResidencySnapshot: Codable, Sendable, Equatable {
@@ -101,6 +140,8 @@ struct ServerResidencyClient {
         let estimated_size_gb: Double
         let pin: Bool
         let replace_group: String?
+        let performance: ResidentPerformanceStatus?
+        let reload_if_changed: Bool
     }
 
     private struct ErrorEnvelope: Decodable {
@@ -139,6 +180,8 @@ struct ServerResidencyClient {
         hfPath: String?,
         estimatedSizeGB: Double,
         replaceGroup: ResidentModelReplacementGroup? = nil,
+        performance: ModelPerfConfig? = nil,
+        reloadIfChanged: Bool = false,
         port: Int,
         bearer: String?
     ) async -> ResidentModelLoadResult {
@@ -151,7 +194,9 @@ struct ServerResidencyClient {
                 model_path: hfPath,
                 estimated_size_gb: estimatedSizeGB,
                 pin: false,
-                replace_group: replaceGroup?.rawValue
+                replace_group: replaceGroup?.rawValue,
+                performance: performance.map(ResidentPerformanceStatus.init),
+                reload_if_changed: reloadIfChanged
             )
         )
         do {

--- a/apps/rapid-mac/Sources/Rapid/UI/SettingsPerformancePanel.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SettingsPerformancePanel.swift
@@ -16,30 +16,63 @@ import SwiftUI
 ///   * **Per model.** Settings attach to the alias, because the right KV
 ///     setting for a 4B dense model is not the right one for a 35B MoE.
 ///   * **One line of cost per control**, from ``KVCacheMode/tradeOff``.
-///   * **Restart stated before the click**, not after: these are `serve`
-///     launch flags, so a change only reaches a running model on respawn.
+///   * **Reload stated before the click**, not after: these are engine
+///     construction settings, so a resident model must be rebuilt to apply.
 struct SettingsPerformancePanel: View {
     @Environment(ModelPerfConfigStore.self) private var perf
     @Environment(ServerManager.self) private var server
+    @Environment(DownloadManager.self) private var downloads
 
-    /// True while the Restart button is cycling the child.
-    @State private var isRestarting: Bool = false
+    /// True while the target resident model is being rebuilt.
+    @State private var isReloading: Bool = false
+    @State private var catalog: [ModelEntry] = []
+    @State private var selectedAlias: String?
+    @State private var applyError: String?
 
     /// The alias this panel edits. The running model when there is one,
     /// otherwise the last one served — editing "whatever runs next" with no
     /// name attached is how a user ends up surprised about which model they
     /// changed.
     private var targetAlias: String? {
-        server.servingAlias ?? server.launchedChildAlias
+        selectedAlias ?? server.servingAlias ?? server.launchedChildAlias
+    }
+
+    private var modelChoices: [ModelEntry] {
+        var byAlias = Dictionary(uniqueKeysWithValues: catalog
+            .filter { $0.kind == .chat }
+            .map { ($0.alias.lowercased(), $0) })
+        for alias in perf.configuredAliases where byAlias[alias.lowercased()] == nil {
+            byAlias[alias.lowercased()] = ModelEntry(
+                alias: alias, hfRepo: nil, sizeOnDisk: nil, cached: false
+            )
+        }
+        return byAlias.values.sorted {
+            $0.alias.localizedCaseInsensitiveCompare($1.alias) == .orderedAscending
+        }
     }
 
     /// Whether the running child was launched before the current settings, so
     /// its argv predates them. Derived, never stored — the same reasoning as
     /// ``SettingsConnectorsPanel``: `@State` dies with the view while the
     /// condition it described is still true.
-    private var needsRestart: Bool {
-        guard let alias = targetAlias, server.launchedChildAlias != nil else { return false }
+    private var needsReload: Bool {
+        guard let alias = targetAlias, server.isModelResident(alias) else { return false }
+        if let resident = server.residency.models.first(where: { $0.matches(alias) }),
+           let applied = resident.performance {
+            return !applied.matches(effectiveConfig(for: alias))
+        }
+        guard server.launchedChildAlias != nil else { return false }
         return perf.launchFlags(forAlias: alias) != launchedFlags
+    }
+
+    private func effectiveConfig(for alias: String) -> ModelPerfConfig {
+        ModelPerfConfig(launchFlags: ServerManager.mergedPerformanceFlags(
+            recommended: RAMBucketedDefault.launchFlags(
+                forAlias: alias,
+                physicalRAMGB: MacHardware.detect().physicalRAMGB
+            ),
+            userOverrides: perf.launchFlags(forAlias: alias)
+        ))
     }
 
     /// Flags the running child was actually spawned with, for the alias in
@@ -54,8 +87,9 @@ struct SettingsPerformancePanel: View {
                     subtitle: "These settings change speed and memory use, and some can change what the model writes. They apply to one model at a time and take effect when that model next starts.",
                     emphasis: .page
                 )
+                modelSection
                 if let alias = targetAlias {
-                    if needsRestart { restartBanner(alias: alias) }
+                    if needsReload { reloadBanner(alias: alias) }
                     kvSection(alias: alias)
                     prefixSection(alias: alias)
                     footer(alias: alias)
@@ -65,20 +99,59 @@ struct SettingsPerformancePanel: View {
                 if let error = perf.loadError {
                     InlineNotice(message: error, tone: .error)
                 }
+                if let applyError {
+                    InlineNotice(message: applyError, tone: .error)
+                }
             }
             .padding(RapidTheme.Space.xl)
             .frame(maxWidth: .infinity, alignment: .leading)
         }
         .accessibilityIdentifier("Settings.Performance.Panel")
         .task(id: server.launchedChildAlias) {
-            // Snapshot what the child was spawned with so ``needsRestart`` can
-            // compare against it rather than against "has any override", which
-            // would keep the banner up forever after a restart.
+            // Snapshot what the original child was spawned with so the legacy
+            // primary-record fallback can compare stored opinion with reality.
             launchedFlags = targetAlias.map { perf.launchFlags(forAlias: $0) } ?? []
+        }
+        .task(id: downloads.cacheGeneration) {
+            guard let binary = server.binaryPath else { return }
+            catalog = await ModelCatalogCache.shared.entries(
+                binary: binary, generation: downloads.cacheGeneration
+            )
+            if selectedAlias == nil {
+                selectedAlias = server.servingAlias
+                    ?? server.launchedChildAlias
+                    ?? modelChoices.first(where: { $0.cached })?.alias
+                    ?? modelChoices.first?.alias
+            }
+        }
+        .onChange(of: selectedAlias) { _, alias in
+            launchedFlags = alias.map { perf.launchFlags(forAlias: $0) } ?? []
+            applyError = nil
         }
     }
 
     // MARK: - Sections
+
+    private var modelSection: some View {
+        SettingsSection(
+            "Model",
+            subtitle: "Choose which model owns these settings. It does not need to be running."
+        ) {
+            if modelChoices.isEmpty {
+                Text("No chat models are available yet.")
+                    .font(RapidFont.body)
+                    .foregroundStyle(RapidTheme.textSecondary)
+            } else {
+                Picker("Model", selection: $selectedAlias) {
+                    ForEach(modelChoices) { entry in
+                        Text(entry.cached ? entry.alias : "\(entry.alias) · not downloaded")
+                            .tag(Optional(entry.alias))
+                    }
+                }
+                .accessibilityIdentifier("Settings.Performance.ModelPicker")
+            }
+        }
+    }
 
     private var noModelNotice: some View {
         InlineNotice(
@@ -88,14 +161,14 @@ struct SettingsPerformancePanel: View {
         .accessibilityIdentifier("Settings.Performance.NoModel")
     }
 
-    private func restartBanner(alias: String) -> some View {
+    private func reloadBanner(alias: String) -> some View {
         InlineNotice(
-            message: "Restart \(alias) to apply. The running model was started with the previous settings.",
+            message: "Reload \(alias) to apply. Other resident models will stay available.",
             tone: .warning,
-            actionTitle: isRestarting ? "Restarting…" : "Restart",
-            action: { restart(alias: alias) }
+            actionTitle: isReloading ? "Reloading…" : "Reload model",
+            action: { reload(alias: alias) }
         )
-        .disabled(isRestarting)
+        .disabled(isReloading)
         .accessibilityIdentifier("Settings.Performance.RestartNotice")
     }
 
@@ -197,19 +270,35 @@ struct SettingsPerformancePanel: View {
     }
 
     private func footer(alias: String) -> some View {
-        HStack {
-            Text(perf.hasOverride(forAlias: alias)
-                 ? "Customized for \(alias)."
-                 : "\(alias) is using measured defaults.")
+        let measured = !ModelPerfConfig(
+            launchFlags: RAMBucketedDefault.launchFlags(
+                forAlias: alias,
+                physicalRAMGB: MacHardware.detect().physicalRAMGB
+            )
+        ).isEmpty
+        return VStack(alignment: .leading, spacing: RapidTheme.Space.sm) {
+            HStack {
+                Text(perf.hasOverride(forAlias: alias)
+                     ? "Customized for \(alias)."
+                     : measured
+                        ? "\(alias) will use its measured defaults."
+                        : "\(alias) will use the engine defaults; no measured profile is published for it.")
                 .font(RapidFont.caption)
                 .foregroundStyle(RapidTheme.textSecondary)
-            Spacer()
-            Button("Reset to measured defaults") {
-                perf.resetToDefaults(forAlias: alias)
+                Spacer()
+                Button(measured ? "Reset to measured defaults" : "Reset to engine defaults") {
+                    perf.resetToDefaults(forAlias: alias)
+                }
+                .buttonStyle(.rapidSecondaryCompact)
+                .disabled(!perf.hasOverride(forAlias: alias))
+                .accessibilityIdentifier("Settings.Performance.Reset")
             }
-            .buttonStyle(.rapidSecondaryCompact)
-            .disabled(!perf.hasOverride(forAlias: alias))
-            .accessibilityIdentifier("Settings.Performance.Reset")
+            if !server.isModelResident(alias) {
+                Text("Saved. These settings will apply the next time this model loads.")
+                    .font(RapidFont.caption)
+                    .foregroundStyle(RapidTheme.textSecondary)
+                    .accessibilityIdentifier("Settings.Performance.AppliesNextLoad")
+            }
         }
     }
 
@@ -261,27 +350,24 @@ struct SettingsPerformancePanel: View {
         perf.setConfig(config, forAlias: alias)
     }
 
-    private func restart(alias: String) {
-        isRestarting = true
+    private func reload(alias: String) {
+        isReloading = true
+        applyError = nil
         Task {
-            await server.stop()
-            await server.start(alias: alias)
-            // Only acknowledge the new argv after the replacement child is
-            // actually ready. A failed restart must keep the notice visible;
-            // otherwise Settings claims an override was applied when no
-            // serving process has it (#1717).
-            if Self.restartApplied(state: server.state, alias: alias) {
+            let entry = modelChoices.first { $0.alias.caseInsensitiveCompare(alias) == .orderedSame }
+            let result = await server.reloadResidentPerformance(
+                alias: alias,
+                hfPath: entry?.hfRepo
+            )
+            if case .loaded = result {
                 launchedFlags = perf.launchFlags(forAlias: alias)
+            } else if case .rejected(let message) = result {
+                applyError = message
+            } else {
+                applyError = "This bundled model server cannot reload one resident model."
             }
-            isRestarting = false
+            isReloading = false
         }
     }
 
-    /// A restart counts as applied only when the replacement child reached
-    /// ready for the same model. In particular, `.crashed` and `.idle` must
-    /// leave the notice up so Settings never reports argv that no process has.
-    static func restartApplied(state: ServerState, alias: String) -> Bool {
-        guard case .ready(let readyAlias) = state else { return false }
-        return readyAlias.caseInsensitiveCompare(alias) == .orderedSame
-    }
 }

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.performance-saved.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.performance-saved.txt
@@ -1,0 +1,104 @@
+# rapid-mac AX structural baseline v1
+AXApplication title="Rapid-MLX"
+  AXWindow subrole=AXStandardWindow id="main" title="Rapid-MLX"
+    AXGroup subrole=AXHostingView
+      AXSplitGroup id="main, SidebarNavigationSplitView"
+        AXGroup subrole=AXHostingView
+          AXButton id="Sidebar.NewChat" desc="New Chat" enabled=true
+          AXButton id="Sidebar.Images" desc="Images" enabled=true
+          AXButton id="Sidebar.Audio" desc="Audio" enabled=true
+          AXButton id="Sidebar.Launch" desc="Launch" enabled=true
+        AXSplitter value=number enabled=false
+        AXGroup subrole=AXHostingView
+          AXStaticText value=text enabled=true
+          AXStaticText value=text enabled=true
+          AXGroup desc="<model> isn't running, It's already downloaded — starting takes a few seconds." enabled=true
+            AXStaticText value=text enabled=true
+            AXStaticText value=text enabled=true
+            AXButton id="Readiness.Action" desc="Start" enabled=true
+          AXStaticText value=text enabled=true
+          AXScrollArea
+            AXTextArea id="rapid.chat.compose" desc="Message compose field" value=empty
+          AXButton id="ChatView.AddPhotos" desc="Add photos" help="This model doesn't support images" enabled=false
+          AXPopUpButton id="ModelPickerBar.ModelMenu" desc="Model" help="Choose which model to run" value=text enabled=true
+          AXButton id="info.circle" desc="Show model details" help="Show model details" enabled=true
+          AXButton id="ChatView.SendOrStopButton" desc="Send message" help="Start <model> before sending." enabled=false
+      AXButton desc="Settings" help="Settings — ⌘," enabled=true
+      AXButton id="ContentView.ToggleLogs" desc="Show logs" help="Show logs" enabled=true
+      AXUnknown desc="Server status" enabled=true
+      AXUnknown desc="Tokens per second: no data yet" enabled=true
+      AXUnknown desc="CPU <percent>" enabled=true
+      AXUnknown desc="GPU <percent>" enabled=true
+      AXUnknown desc="Memory tight: <version> gigabytes used out of 18 gigabytes" enabled=true
+      AXButton id="Footer.DesktopVersionPill" desc="Rapid-MLX <version> · up to date" help="Rapid-MLX <version> is the latest release. Click to open Settings → App." enabled=true
+    AXToolbar
+      AXButton desc="Hide Sidebar" enabled=true
+    AXButton subrole=AXCloseButton enabled=true
+    AXButton subrole=AXFullScreenButton help="this button also has an action to zoom the window" enabled=true
+    AXButton subrole=AXMinimizeButton enabled=true
+    AXStaticText value=text enabled=true
+  AXWindow subrole=AXStandardWindow id="settings" title="Settings"
+    AXGroup subrole=AXHostingView
+      AXScrollArea
+        AXOutline desc="Settings categories" enabled=true
+          AXRow subrole=AXOutlineRow
+            AXCell enabled=true
+              AXButton id="Settings.Category.modelManagement" desc="Model Management" enabled=true
+          AXRow subrole=AXOutlineRow
+            AXCell enabled=true
+              AXButton id="Settings.Category.tools" desc="Tools" enabled=true
+          AXRow subrole=AXOutlineRow
+            AXCell enabled=true
+              AXButton id="Settings.Category.connectors" desc="Connectors" enabled=true
+          AXRow subrole=AXOutlineRow
+            AXCell enabled=true
+              AXButton id="Settings.Category.performance" desc="Performance" enabled=true
+          AXRow subrole=AXOutlineRow
+            AXCell enabled=true
+              AXButton id="Settings.Category.appearance" desc="Appearance" enabled=true
+          AXRow subrole=AXOutlineRow
+            AXCell enabled=true
+              AXButton id="Settings.Category.privacy" desc="Privacy" enabled=true
+          AXRow subrole=AXOutlineRow
+            AXCell enabled=true
+              AXButton id="Settings.Category.app" desc="App" enabled=true
+          AXColumn id="ListColumn"
+      AXScrollArea
+        AXScrollArea id="Settings.Performance.Panel"
+          AXHeading desc="Performance, These settings change speed and memory use, and some can change what the model writes. They apply to one model at a time and take effect when that model next starts." enabled=true
+          AXHeading desc="Model, Choose which model owns these settings. It does not need to be running." enabled=true
+          AXStaticText value=text enabled=true
+          AXPopUpButton id="Settings.Performance.ModelPicker" value=text enabled=true
+          AXHeading desc="KV cache precision, How the model's attention cache is stored. Lower precision means less memory and faster long-context decoding." enabled=true
+          AXRadioGroup id="Settings.Performance.KVMode" desc="KV cache precision" enabled=true
+            AXRadioButton desc="Engine default" value=bool:true enabled=true
+            AXRadioButton desc="Full precision (bf16)" value=bool:false enabled=true
+            AXRadioButton desc="8-bit" value=bool:false enabled=true
+            AXRadioButton desc="4-bit" value=bool:false enabled=true
+            AXRadioButton desc="TurboQuant V4" value=bool:false enabled=true
+            AXRadioButton desc="TurboQuant K8V4" value=bool:false enabled=true
+          AXStaticText value=text enabled=true
+          AXHeading desc="Prefix cache, Reuses computation for a prompt prefix the model has already seen. Speeds up multi-turn chat and repeated system prompts." enabled=true
+          AXGroup id="Settings.Performance.PrefixCache" desc="Prefix cache" enabled=true
+            AXButton id="Settings.Performance.Prefix.Default" desc="Engine default" enabled=true
+            AXButton id="Settings.Performance.Prefix.On" desc="On" enabled=true
+            AXButton id="Settings.Performance.Prefix.Off" desc="Off" enabled=true
+          AXStaticText value=text enabled=true
+          AXStaticText value=text enabled=true
+          AXStaticText value=text enabled=true
+          AXSlider id="Settings.Performance.CacheBudget" desc="Cache budget" value=number enabled=true
+            AXValueIndicator value=number
+          AXStaticText value=text enabled=true
+          AXStaticText value=text enabled=true
+          AXButton id="Settings.Performance.Reset" desc="Reset to engine defaults" enabled=true
+          AXStaticText id="Settings.Performance.AppliesNextLoad" value=text enabled=true
+        AXScrollBar value=number enabled=true
+          AXValueIndicator value=number
+          AXButton subrole=AXIncrementArrow
+          AXButton subrole=AXDecrementArrow
+          AXButton subrole=AXIncrementPage
+          AXButton subrole=AXDecrementPage
+    AXButton subrole=AXCloseButton enabled=true
+    AXButton subrole=AXZoomButton enabled=true
+    AXButton subrole=AXMinimizeButton enabled=true
+    AXStaticText value=text enabled=true

--- a/apps/rapid-mac/Tests/RapidTests/AccessibilityIdentifierInventoryTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/AccessibilityIdentifierInventoryTests.swift
@@ -70,11 +70,13 @@ struct AccessibilityIdentifierInventoryTests {
                 #""Settings.Performance.Panel""#,
                 #""Settings.Performance.NoModel""#,
                 #""Settings.Performance.RestartNotice""#,
+                #""Settings.Performance.ModelPicker""#,
                 #""Settings.Performance.KVMode""#,
                 #""Settings.Performance.PrefixCache""#,
                 #""Settings.Performance.CacheBudget""#,
                 #""Settings.Performance.CacheBudgetAutomatic""#,
                 #""Settings.Performance.Reset""#,
+                #""Settings.Performance.AppliesNextLoad""#,
             ],
             in: "Sources/Rapid/UI/SettingsPerformancePanel.swift",
             surface: "Settings → Performance"

--- a/apps/rapid-mac/Tests/RapidTests/ModelPerfConfigTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ModelPerfConfigTests.swift
@@ -110,6 +110,19 @@ struct ModelPerfConfigTests {
         #expect(mode.launchFlags == expected)
     }
 
+    @Test("Resolved launch flags round-trip into the residency config")
+    func resolvedFlagsRoundTrip() {
+        let config = ModelPerfConfig(launchFlags: [
+            "--no-mllm", "--kv-cache-turboquant", "k8v4",
+            "--disable-prefix-cache", "--cache-memory-mb", "4096",
+        ])
+        #expect(config == ModelPerfConfig(
+            kvCacheMode: .turboquantK8V4,
+            prefixCacheEnabled: false,
+            cacheMemoryMB: 4096
+        ))
+    }
+
     @Test("The deprecated --kv-cache-quantization spelling is never emitted")
     func legacyQuantizationFlagIsNeverEmitted() {
         // The engine documents it as "[deprecated alias of --kv-cache-dtype
@@ -221,20 +234,6 @@ struct ModelPerfConfigTests {
             userOverrides: ["--kv-cache-dtype", "int8"]
         )
         #expect(merged == ["--no-mllm", "--kv-cache-dtype", "int8"])
-    }
-
-    @Test("A failed or mismatched restart is never reported as applied")
-    func restartAcknowledgementRequiresTheSameReadyModel() {
-        #expect(SettingsPerformancePanel.restartApplied(
-            state: .ready(alias: "Qwen3.6-35B-4bit"), alias: "qwen3.6-35b-4bit"
-        ))
-        #expect(!SettingsPerformancePanel.restartApplied(
-            state: .ready(alias: "gemma-4-26b-4bit"), alias: "qwen3.6-35b-4bit"
-        ))
-        #expect(!SettingsPerformancePanel.restartApplied(
-            state: .crashed(alias: "qwen3.6-35b-4bit", message: "spawn failed"),
-            alias: "qwen3.6-35b-4bit"
-        ))
     }
 
     // MARK: - Helpers

--- a/apps/rapid-mac/Tests/RapidTests/ModelResidencyTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ModelResidencyTests.swift
@@ -27,7 +27,12 @@ struct ModelResidencyTests {
                 "active_requests": 0,
                 "estimated_bytes": 6335076761,
                 "measured_bytes": 5905580032,
-                "idle_seconds": 12.5
+                "idle_seconds": 12.5,
+                "performance": {
+                  "kv_cache_turboquant": "k8v4",
+                  "prefix_cache_enabled": true,
+                  "cache_memory_mb": 4096
+                }
               }]
             }
             """#.utf8
@@ -44,6 +49,13 @@ struct ModelResidencyTests {
         #expect(snapshot.contains("flux2-klein-4b"))
         #expect(snapshot.contains("flux-klein"))
         #expect(snapshot.contains("Runware/FLUX.2-klein-4B"))
+        #expect(snapshot.models.first?.performance == ResidentPerformanceStatus(
+            config: ModelPerfConfig(
+                kvCacheMode: .turboquantK8V4,
+                prefixCacheEnabled: true,
+                cacheMemoryMB: 4096
+            )
+        ))
     }
 
     @Test("Resident rows prefer the catalog alias over the HF path")
@@ -114,6 +126,41 @@ struct ModelResidencyTests {
         #expect(ModelSizing.residentMemoryCeilingGB(on: mockMac(ramGB: 4)) == 4)
     }
 
+    @Test("Residency load sends typed performance config and reload intent")
+    func loadRequestCarriesPerformance() async throws {
+        ResidencyLoadCaptureProtocol.capturedBody = nil
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [ResidencyLoadCaptureProtocol.self]
+        var client = ServerResidencyClient()
+        client.session = URLSession(configuration: configuration)
+
+        let result = await client.load(
+            alias: "qwen3.5-4b-4bit",
+            hfPath: "mlx-community/Qwen3.5-4B-MLX-4bit",
+            estimatedSizeGB: 4,
+            performance: ModelPerfConfig(
+                kvCacheMode: .turboquantK8V4,
+                prefixCacheEnabled: false,
+                cacheMemoryMB: 4096
+            ),
+            reloadIfChanged: true,
+            port: 8000,
+            bearer: "secret"
+        )
+        guard case .loaded = result else {
+            Issue.record("Expected the stubbed residency load to succeed")
+            return
+        }
+        let body = try #require(ResidencyLoadCaptureProtocol.capturedBody)
+        let json = try #require(JSONSerialization.jsonObject(with: body) as? [String: Any])
+        let performance = try #require(json["performance"] as? [String: Any])
+        #expect(json["reload_if_changed"] as? Bool == true)
+        #expect(performance["kv_cache_dtype"] == nil)
+        #expect(performance["kv_cache_turboquant"] as? String == "k8v4")
+        #expect(performance["prefix_cache_enabled"] as? Bool == false)
+        #expect(performance["cache_memory_mb"] as? Int == 4096)
+    }
+
     @Test("Image residency estimate uses catalog bytes plus runtime margin")
     func imageEstimateUsesDownloadSize() {
         let estimate = ModelSizing.residentEstimateGB(
@@ -163,5 +210,41 @@ struct ModelResidencyTests {
             physicalRAMBytes: UInt64(ramGB) * UInt64(1 << 30),
             memoryBandwidthGBs: 150
         )
+    }
+}
+
+private final class ResidencyLoadCaptureProtocol: URLProtocol, @unchecked Sendable {
+    nonisolated(unsafe) static var capturedBody: Data?
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        Self.capturedBody = request.httpBody ?? Self.readBodyStream(request.httpBodyStream)
+        let payload = #"{"id":"qwen3.5-4b-4bit","model_path":"mlx-community/Qwen3.5-4B-MLX-4bit","aliases":[],"modality":"text","state":"resident","pinned":true,"primary":true,"active_requests":0,"estimated_bytes":1,"measured_bytes":null,"idle_seconds":0,"performance":{"kv_cache_turboquant":"k8v4","prefix_cache_enabled":false,"cache_memory_mb":4096}}"#.data(using: .utf8)!
+        let response = HTTPURLResponse(
+            url: request.url!, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: nil
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: payload)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+
+    private static func readBodyStream(_ stream: InputStream?) -> Data? {
+        guard let stream else { return nil }
+        stream.open()
+        defer { stream.close() }
+        var data = Data()
+        var buffer = [UInt8](repeating: 0, count: 4096)
+        while true {
+            let count = buffer.withUnsafeMutableBufferPointer { pointer in
+                stream.read(pointer.baseAddress!, maxLength: pointer.count)
+            }
+            if count > 0 { data.append(buffer, count: count) }
+            if count == 0 { return data }
+            if count < 0 { return nil }
+        }
     }
 }

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -99,7 +99,7 @@ flow_requires_screen_recording() {
 # unattended without taking on any of that.
 flow_requires_peekaboo() {
     case "$FLOW" in
-        cached-quickstart|download-progress|chat-restore|restored-tools|tool-loop-budget|chat-depth|math-rendering) return 1 ;;
+        cached-quickstart|download-progress|settings-persistence|chat-restore|restored-tools|tool-loop-budget|chat-depth|math-rendering) return 1 ;;
         slow-stream-stop|model-crash-recovery|image-generation|window-close-prompt) return 1 ;;
         *) return 0 ;;
     esac
@@ -1136,17 +1136,19 @@ flow_settings_persistence() {
     open_settings
     wait_settings_stable "$OUT/settings-root.json"
     baseline settings-persistence.settings-root "$OUT/settings-root.json"
-    # #1717: prove the new Performance destination is mounted in the real app
-    # and exposes its honest empty state before any model has launched. Keep
-    # this semantic (rather than pixel-only) so an empty placeholder cannot
-    # silently replace the panel while unrelated Settings baselines stay green.
+    # #1717: configure a chosen model before it runs. This proves the panel is
+    # not coupled to the current child, its model selector is addressable, and
+    # a real control mutation reaches the honest "next load" state.
     press "$OUT/settings-root.json" Settings.Category.performance "$OUT/settings-performance-open.json"
-    wait_settings_stable "$OUT/performance-empty.json" Settings.Performance.NoModel
+    wait_settings_stable "$OUT/performance-open.json" Settings.Performance.ModelPicker
     jq -e '.data.ui_elements[]? | select(.identifier == "Settings.Performance.Panel")' \
-        "$OUT/performance-empty.json" >/dev/null || die "Performance settings panel did not mount"
-    jq -e '.data.ui_elements[]? | select(.identifier == "Settings.Performance.NoModel" and (.description | contains("Start a model")))' \
-        "$OUT/performance-empty.json" >/dev/null || die "Performance settings did not explain that a model must be started"
-    press "$OUT/performance-empty.json" Settings.Category.modelManagement "$OUT/settings-models-open.json"
+        "$OUT/performance-open.json" >/dev/null || die "Performance settings panel did not mount"
+    press "$OUT/performance-open.json" Settings.Performance.Prefix.Off "$OUT/performance-prefix-off.json"
+    wait_settings_stable "$OUT/performance-saved.json" Settings.Performance.AppliesNextLoad
+    jq -e '.data.ui_elements[]? | select(.identifier == "Settings.Performance.AppliesNextLoad" and (.value | contains("next time")))' \
+        "$OUT/performance-saved.json" >/dev/null || die "Performance settings did not explain deferred application"
+    baseline settings-persistence.performance-saved "$OUT/performance-saved.json"
+    press "$OUT/performance-saved.json" Settings.Category.modelManagement "$OUT/settings-models-open.json"
     wait_settings_stable "$OUT/models-before.json" Settings.Models.ShowAllModelsToggle
     # GoldenFlow coverage for the recommendation SSOT: the running GUI must
     # render exactly the smart + fast aliases selected from the same JSON the

--- a/tests/test_gui_preflight_contract.py
+++ b/tests/test_gui_preflight_contract.py
@@ -91,6 +91,7 @@ def test_peekaboo_requirement_is_default_deny():
         "chat-restore",
         "cached-quickstart",
         "download-progress",
+        "settings-persistence",
         "restored-tools",
         "tool-loop-budget",
         "chat-depth",

--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -9,9 +9,33 @@ from vllm_mlx.runtime.resident_models import (
     ResidentModelBusyError,
     ResidentModelCapacityError,
     ResidentModelManager,
+    ResidentPerformanceConfig,
+    resident_scheduler_kwargs,
 )
 
 GIB = 1024**3
+
+
+def test_resident_performance_maps_to_the_scheduler_contract():
+    assert resident_scheduler_kwargs(
+        ResidentPerformanceConfig(
+            kv_cache_dtype="int4",
+            prefix_cache_enabled=False,
+            cache_memory_mb=4096,
+        )
+    ) == {
+        "kv_cache_dtype": "int4",
+        "kv_cache_quantization": True,
+        "kv_cache_quantization_bits": 4,
+        "enable_prefix_cache": False,
+        "cache_memory_mb": 4096,
+    }
+    assert resident_scheduler_kwargs(
+        ResidentPerformanceConfig(kv_cache_turboquant="k8v4")
+    ) == {
+        "kv_cache_turboquant": True,
+        "kv_cache_turboquant_mode": "k8v4",
+    }
 
 
 class FakeEngine:
@@ -54,7 +78,7 @@ def manager_fixture(*, limit_gib=10, ttl=0):
     registry.add(primary, is_default=True)
     loaded: dict[str, FakeEngine] = {}
 
-    async def loader(name: str, path: str | None):
+    async def loader(name: str, path: str | None, performance=None):
         engine = FakeEngine()
         loaded[name] = engine
         return ModelEntry(
@@ -83,7 +107,7 @@ async def test_accounting_reserves_lazy_model_estimates_and_tracks_larger_actual
     registry.add(primary, is_default=True)
     process_usage = [1 * GIB]
 
-    async def loader(name: str, path: str | None):
+    async def loader(name: str, path: str | None, performance=None):
         return entry(name)
 
     manager = ResidentModelManager(
@@ -163,7 +187,7 @@ async def test_replacing_assistant_promotes_target_and_keeps_image_resident():
     loaded: dict[str, FakeEngine] = {}
     promoted: list[str] = []
 
-    async def loader(name: str, path: str | None):
+    async def loader(name: str, path: str | None, performance=None):
         engine = FakeImageEngine() if name == "image" else FakeEngine()
         loaded[name] = engine
         return ModelEntry(
@@ -222,6 +246,90 @@ async def test_failed_assistant_replacement_rolls_back_newly_loaded_model():
 
 
 @pytest.mark.asyncio
+async def test_per_model_performance_reload_replaces_only_the_target_engine():
+    manager, registry, loaded, _ = manager_fixture(limit_gib=20)
+    await manager.load("image", estimated_bytes=3 * GIB)
+    image_engine = loaded["image"]
+    old_chat_engine = registry.get_engine("chat")
+    config = ResidentPerformanceConfig(
+        kv_cache_dtype="int8",
+        prefix_cache_enabled=False,
+        cache_memory_mb=2048,
+    )
+
+    reloaded = await manager.load(
+        "chat",
+        performance=config,
+        reload_if_changed=True,
+    )
+
+    assert reloaded.performance == config
+    assert old_chat_engine.stopped is True
+    assert registry.get_engine("chat") is not old_chat_engine
+    assert loaded["image"] is image_engine
+    assert image_engine.stopped is False
+    assert {item["id"] for item in manager.snapshot()["models"]} == {
+        "chat",
+        "image",
+    }
+    chat = next(item for item in manager.snapshot()["models"] if item["id"] == "chat")
+    assert chat["performance"] == {
+        "kv_cache_dtype": "int8",
+        "prefix_cache_enabled": False,
+        "cache_memory_mb": 2048,
+    }
+
+
+@pytest.mark.asyncio
+async def test_failed_performance_reload_restores_the_last_known_good_engine():
+    registry = ModelRegistry()
+    primary = entry("chat")
+    registry.add(primary, is_default=True)
+    calls: list[ResidentPerformanceConfig | None] = []
+
+    async def loader(name: str, path: str | None, performance=None):
+        calls.append(performance)
+        if performance == ResidentPerformanceConfig(kv_cache_dtype="int4"):
+            raise RuntimeError("new config failed")
+        return entry(name)
+
+    manager = ResidentModelManager(registry, loader, memory_reader=lambda: 0)
+    manager.register_primary(primary, estimated_bytes=4 * GIB)
+
+    with pytest.raises(RuntimeError, match="new config failed"):
+        await manager.load(
+            "chat",
+            performance=ResidentPerformanceConfig(kv_cache_dtype="int4"),
+            reload_if_changed=True,
+        )
+
+    assert calls == [ResidentPerformanceConfig(kv_cache_dtype="int4"), None]
+    assert "chat" in registry
+    assert registry.get_engine("chat") is not primary.engine
+    assert manager.snapshot()["models"][0]["performance"] is None
+
+
+@pytest.mark.asyncio
+async def test_failed_stop_keeps_the_existing_engine_registered():
+    manager, registry, _, _ = manager_fixture(limit_gib=20)
+    old_engine = registry.get_engine("chat")
+
+    async def failed_stop():
+        raise RuntimeError("stop failed")
+
+    old_engine.stop = failed_stop
+    with pytest.raises(RuntimeError, match="stop failed"):
+        await manager.load(
+            "chat",
+            performance=ResidentPerformanceConfig(kv_cache_dtype="int8"),
+            reload_if_changed=True,
+        )
+
+    assert registry.get_engine("chat") is old_engine
+    assert manager.snapshot()["models"][0]["id"] == "chat"
+
+
+@pytest.mark.asyncio
 async def test_soak_load_evict_cycles_stay_inside_ceiling():
     manager, registry, loaded, clock = manager_fixture(limit_gib=8)
 
@@ -275,3 +383,83 @@ def test_residency_control_plane_load_pin_status_and_unload(monkeypatch):
         )
         assert client.delete("/v1/models/image").status_code == 204
         assert "image" not in registry
+
+
+def test_residency_control_plane_validates_and_forwards_performance(monkeypatch):
+    from types import SimpleNamespace
+
+    from vllm_mlx.routes.residency import router
+
+    manager, registry, loaded, _ = manager_fixture(limit_gib=20)
+    monkeypatch.setattr(
+        "vllm_mlx.routes.residency.get_config",
+        lambda: SimpleNamespace(residency_manager=manager),
+    )
+    app = FastAPI()
+    app.include_router(router)
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/v1/models/load",
+            json={
+                "model": "chat",
+                "reload_if_changed": True,
+                "performance": {
+                    "kv_cache_turboquant": "k8v4",
+                    "prefix_cache_enabled": True,
+                    "cache_memory_mb": 4096,
+                },
+            },
+        )
+        assert response.status_code == 200
+        assert response.json()["performance"] == {
+            "kv_cache_turboquant": "k8v4",
+            "prefix_cache_enabled": True,
+            "cache_memory_mb": 4096,
+        }
+        assert registry.get_engine("chat") is loaded["chat"]
+
+        conflict = client.post(
+            "/v1/models/load",
+            json={
+                "model": "chat",
+                "performance": {
+                    "kv_cache_dtype": "int4",
+                    "kv_cache_turboquant": "v4",
+                },
+            },
+        )
+        assert conflict.status_code == 422
+
+        monkeypatch.setattr(
+            "vllm_mlx.routes.residency.resolve_profile",
+            lambda _name: SimpleNamespace(modality="image-gen"),
+        )
+        image_override = client.post(
+            "/v1/models/load",
+            json={
+                "model": "image",
+                "performance": {"prefix_cache_enabled": True},
+            },
+        )
+        assert image_override.status_code == 422
+        assert "only supported for text" in image_override.json()["detail"]
+
+
+def test_resident_performance_uses_cli_kv_safety_gate(monkeypatch):
+    from vllm_mlx.runtime.resident_models import resolve_resident_performance
+
+    monkeypatch.setattr(
+        "vllm_mlx.cli._gather_kv_cache_dtype_inputs",
+        lambda _name: ({"sliding_window": 4096}, None),
+    )
+    resolved = resolve_resident_performance(
+        ResidentPerformanceConfig(kv_cache_dtype="int4", cache_memory_mb=2048),
+        model_name="example/sliding-model",
+        model_path=None,
+    )
+
+    assert resolved == ResidentPerformanceConfig(
+        kv_cache_dtype="bf16",
+        cache_memory_mb=2048,
+    )

--- a/vllm_mlx/routes/residency.py
+++ b/vllm_mlx/routes/residency.py
@@ -2,18 +2,40 @@
 
 from __future__ import annotations
 
+from typing import Literal
+
 from fastapi import APIRouter, Depends, HTTPException, Response
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from ..config import get_config
 from ..middleware.auth import verify_api_key
+from ..model_aliases import resolve_profile
 from ..runtime.resident_models import (
     ResidentModelBusyError,
     ResidentModelCapacityError,
     ResidentModelError,
+    ResidentPerformanceConfig,
+    resolve_resident_performance,
 )
 
 router = APIRouter(dependencies=[Depends(verify_api_key)])
+
+
+class ModelPerformanceRequest(BaseModel):
+    kv_cache_dtype: Literal["bf16", "int8", "int4"] | None = None
+    kv_cache_turboquant: Literal["v4", "k8v4"] | None = None
+    prefix_cache_enabled: bool | None = None
+    cache_memory_mb: int | None = Field(default=None, ge=256, le=32768)
+
+    @model_validator(mode="after")
+    def one_kv_mode(self):
+        if self.kv_cache_dtype is not None and self.kv_cache_turboquant is not None:
+            raise ValueError("KV dtype and TurboQuant are mutually exclusive")
+        return self
+
+    def runtime_value(self) -> ResidentPerformanceConfig | None:
+        value = ResidentPerformanceConfig(**self.model_dump())
+        return None if value.is_empty else value
 
 
 class ModelLoadRequest(BaseModel):
@@ -22,6 +44,8 @@ class ModelLoadRequest(BaseModel):
     estimated_size_gb: float | None = Field(default=None, gt=0, le=1024)
     pin: bool = False
     replace_group: str | None = Field(default=None, pattern="^(assistant)$")
+    performance: ModelPerformanceRequest | None = None
+    reload_if_changed: bool = False
 
 
 class ModelPinRequest(BaseModel):
@@ -64,13 +88,43 @@ async def load_resident_model(request: ModelLoadRequest):
         else None
     )
     try:
+        performance = (
+            request.performance.runtime_value() if request.performance else None
+        )
+        profile = resolve_profile(request.model) or (
+            resolve_profile(request.model_path) if request.model_path else None
+        )
+        if (
+            performance is not None
+            and profile is not None
+            and profile.modality
+            in {
+                "image-gen",
+                "text-diffusion",
+                "video-gen",
+                "audio",
+            }
+        ):
+            raise HTTPException(
+                status_code=422,
+                detail="Performance overrides are only supported for text models.",
+            )
+        performance = resolve_resident_performance(
+            performance,
+            model_name=request.model,
+            model_path=request.model_path,
+        )
         record = await manager.load(
             request.model,
             model_path=request.model_path,
             estimated_bytes=estimated_bytes,
             pin=request.pin,
             replace_group=request.replace_group,
+            performance=performance,
+            reload_if_changed=request.reload_if_changed,
         )
+    except HTTPException:
+        raise
     except ResidentModelCapacityError as exc:
         raise HTTPException(status_code=507, detail=str(exc)) from exc
     except ResidentModelError as exc:

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -33,6 +33,110 @@ class ResidentModelBusyError(ResidentModelError):
     """A model cannot be removed while it owns active work."""
 
 
+@dataclass(frozen=True)
+class ResidentPerformanceConfig:
+    """Audited scheduler overrides attached to one resident text model.
+
+    ``None`` fields mean no operator opinion. Keeping this import-light value
+    in the lifecycle layer lets the FastAPI request model and desktop client
+    share a typed contract without making residency depend on CLI argv.
+    """
+
+    kv_cache_dtype: str | None = None
+    kv_cache_turboquant: str | None = None
+    prefix_cache_enabled: bool | None = None
+    cache_memory_mb: int | None = None
+
+    @property
+    def is_empty(self) -> bool:
+        return all(
+            value is None
+            for value in (
+                self.kv_cache_dtype,
+                self.kv_cache_turboquant,
+                self.prefix_cache_enabled,
+                self.cache_memory_mb,
+            )
+        )
+
+    def payload(self) -> dict[str, object]:
+        return {
+            key: value
+            for key, value in {
+                "kv_cache_dtype": self.kv_cache_dtype,
+                "kv_cache_turboquant": self.kv_cache_turboquant,
+                "prefix_cache_enabled": self.prefix_cache_enabled,
+                "cache_memory_mb": self.cache_memory_mb,
+            }.items()
+            if value is not None
+        }
+
+
+def resident_scheduler_kwargs(
+    performance: ResidentPerformanceConfig | None,
+) -> dict[str, object]:
+    """Translate the control-plane value into ``SchedulerConfig`` fields."""
+
+    if performance is None:
+        return {}
+    result: dict[str, object] = {}
+    if performance.kv_cache_dtype is not None:
+        from ..kv_cache_dtype import dtype_to_quantization_bits
+
+        quantized, bits = dtype_to_quantization_bits(performance.kv_cache_dtype)
+        result.update(
+            kv_cache_dtype=performance.kv_cache_dtype,
+            kv_cache_quantization=quantized,
+            kv_cache_quantization_bits=bits,
+        )
+    if performance.kv_cache_turboquant is not None:
+        result.update(
+            kv_cache_turboquant=True,
+            kv_cache_turboquant_mode=performance.kv_cache_turboquant,
+        )
+    if performance.prefix_cache_enabled is not None:
+        result["enable_prefix_cache"] = performance.prefix_cache_enabled
+    if performance.cache_memory_mb is not None:
+        result["cache_memory_mb"] = performance.cache_memory_mb
+    return result
+
+
+def resolve_resident_performance(
+    performance: ResidentPerformanceConfig | None,
+    *,
+    model_name: str,
+    model_path: str | None,
+) -> ResidentPerformanceConfig | None:
+    """Apply the same audited KV-cache eligibility gate as CLI startup."""
+
+    if performance is None or performance.kv_cache_dtype is None:
+        return performance
+
+    # Keep startup and runtime residency on one gate. Importing lazily avoids
+    # pulling the CLI dependency graph into the lifecycle module at import time.
+    from ..cli import _gather_kv_cache_dtype_inputs
+    from ..kv_cache_dtype import log_kv_cache_decision, resolve_kv_cache_dtype
+
+    lookup_name = model_path or model_name
+    hf_config, alias_metadata = _gather_kv_cache_dtype_inputs(lookup_name)
+    decision = resolve_kv_cache_dtype(
+        performance.kv_cache_dtype,
+        model_name=model_name,
+        hf_path=model_path or (alias_metadata or {}).get("hf_path"),
+        hf_config=hf_config,
+        alias_metadata=alias_metadata,
+    )
+    log_kv_cache_decision(decision, model_name=model_name)
+    if decision.dtype == performance.kv_cache_dtype:
+        return performance
+    return ResidentPerformanceConfig(
+        kv_cache_dtype=decision.dtype,
+        kv_cache_turboquant=performance.kv_cache_turboquant,
+        prefix_cache_enabled=performance.prefix_cache_enabled,
+        cache_memory_mb=performance.cache_memory_mb,
+    )
+
+
 @dataclass
 class ResidencyRecord:
     """Mutable lifecycle metadata kept outside the route-facing registry entry."""
@@ -46,13 +150,16 @@ class ResidencyRecord:
     active_requests: int = 0
     state: str = "resident"
     measured_bytes: int = 0
+    performance: ResidentPerformanceConfig | None = None
 
     @property
     def model_id(self) -> str:
         return self.entry.model_name
 
 
-Loader = Callable[[str, str | None], Awaitable[ModelEntry]]
+Loader = Callable[
+    [str, str | None, ResidentPerformanceConfig | None], Awaitable[ModelEntry]
+]
 PrimaryChanged = Callable[[ModelEntry], None]
 
 
@@ -342,6 +449,8 @@ class ResidentModelManager:
         estimated_bytes: int | None = None,
         pin: bool = False,
         replace_group: str | None = None,
+        performance: ResidentPerformanceConfig | None = None,
+        reload_if_changed: bool = False,
     ) -> ResidencyRecord:
         model_name = model_name.strip()
         if not model_name:
@@ -352,6 +461,8 @@ class ResidentModelManager:
             canonical = self._canonical(model_name)
             if canonical is not None:
                 record = self._records[canonical]
+                if reload_if_changed and record.performance != performance:
+                    record = await self._reload_locked(record, performance)
                 record.last_used_at = self._clock()
                 if pin:
                     record.pinned = True
@@ -361,7 +472,7 @@ class ResidentModelManager:
 
             await self._evict_for_locked(estimate, exclude={model_name})
             before = self._read_memory()
-            entry = await self.loader(model_name, model_path)
+            entry = await self.loader(model_name, model_path, performance)
             now = self._clock()
             after = self._read_memory()
             delta = max(0, after - before) if before and after else 0
@@ -372,6 +483,7 @@ class ResidentModelManager:
                 loaded_at=now,
                 last_used_at=now,
                 pinned=pin,
+                performance=performance,
             )
             self.registry.add(entry)
             self._index_record(record)
@@ -388,6 +500,88 @@ class ResidentModelManager:
                 await self._evict_locked(record, reason="load_rollback", count=False)
                 raise
             return record
+
+    async def _reload_locked(
+        self,
+        record: ResidencyRecord,
+        performance: ResidentPerformanceConfig | None,
+    ) -> ResidencyRecord:
+        """Replace one idle engine without restarting or disturbing siblings."""
+
+        if record.active_requests or not _engine_is_idle(record.entry.engine):
+            raise ResidentModelBusyError("model is serving an active request")
+
+        model_name = record.model_id
+        model_path = record.entry.model_path
+        estimate = record.estimated_bytes
+        pinned = record.pinned
+        primary = record.primary
+
+        self.registry.remove(model_name)
+        self._drop_record(model_name)
+        try:
+            stop = getattr(record.entry.engine, "stop", None)
+            if callable(stop):
+                result = stop()
+                if asyncio.iscoroutine(result):
+                    await result
+        except BaseException:
+            # A failed stop must not also make the still-existing engine
+            # disappear from routing and residency accounting.
+            self.registry.add(record.entry, is_default=primary)
+            self._index_record(record)
+            raise
+        _release_allocator_cache()
+
+        before = self._read_memory()
+        try:
+            entry = await self.loader(model_name, model_path, performance)
+        except BaseException as reload_error:
+            # The old engine has already released its Metal allocations so the
+            # replacement can fit under the same budget. Best-effort restore
+            # the last known-good config; never let a rejected Settings change
+            # silently take every route for the primary model down.
+            try:
+                restored_entry = await self.loader(
+                    model_name, model_path, record.performance
+                )
+                restored = ResidencyRecord(
+                    entry=restored_entry,
+                    estimated_bytes=estimate,
+                    loaded_at=self._clock(),
+                    last_used_at=self._clock(),
+                    pinned=pinned,
+                    primary=primary,
+                    performance=record.performance,
+                )
+                self.registry.add(restored_entry, is_default=primary)
+                self._index_record(restored)
+                if primary and self._on_primary_changed is not None:
+                    self._on_primary_changed(restored_entry)
+            except BaseException:
+                logger.exception(
+                    "Failed to restore resident model %r after reload failure",
+                    model_name,
+                )
+            raise reload_error
+        after = self._read_memory()
+        now = self._clock()
+        replacement = ResidencyRecord(
+            entry=entry,
+            estimated_bytes=estimate,
+            measured_bytes=max(0, after - before) if before and after else 0,
+            loaded_at=now,
+            last_used_at=now,
+            pinned=pinned,
+            primary=primary,
+            performance=performance,
+        )
+        self.registry.add(entry, is_default=primary)
+        self._index_record(replacement)
+        self.loads_total += 1
+        if primary and self._on_primary_changed is not None:
+            self._on_primary_changed(entry)
+        return replacement
 
     async def _replace_group_locked(self, target: ResidencyRecord, group: str) -> None:
         """Make ``target`` the sole unpinned model in a lifecycle group.
@@ -513,6 +707,9 @@ class ResidentModelManager:
                     "estimated_bytes": record.estimated_bytes,
                     "measured_bytes": record.measured_bytes or None,
                     "idle_seconds": max(0.0, now - record.last_used_at),
+                    "performance": (
+                        record.performance.payload() if record.performance else None
+                    ),
                 }
             )
         usage = self._accounted_usage()

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -2112,7 +2112,9 @@ def load_model(
 
 
 async def _load_dynamic_resident_model(
-    model_name: str, model_path: str | None
+    model_name: str,
+    model_path: str | None,
+    performance=None,
 ) -> ModelEntry:
     """Construct and start one non-primary engine for the residency manager."""
 
@@ -2150,10 +2152,14 @@ async def _load_dynamic_resident_model(
             f"runtime residency loading is not available for modality {modality!r}"
         )
     else:
+        from .runtime.resident_models import resident_scheduler_kwargs
+        from .scheduler import SchedulerConfig
+
         engine = BatchedEngine(
             model_name=resolved_path,
             force_text=bool(profile is not None and profile.is_text_only),
             gpu_memory_utilization=_resident_gpu_memory_utilization,
+            scheduler_config=SchedulerConfig(**resident_scheduler_kwargs(performance)),
         )
         await engine.start()
         try:


### PR DESCRIPTION
Closes #1717

## What changed

- makes the audited performance settings apply to every dynamically resident text model, not only the sidecar process primary
- adds a model selector so settings can be configured before a model runs
- reloads only the selected idle resident engine and preserves sibling Chat/Images residency
- records effective per-model performance state in the residency API, including KV-cache safety downgrades
- rolls back to the last-known-good engine if reload fails and rejects ineffective media-model overrides
- adds unit/integration coverage plus a real AX GoldenFlow baseline for the saved-before-load Settings state

## Root cause

The first #1717 slice emitted CLI flags only when spawning the sidecar. The multi-model residency loader introduced later constructed secondary engines with a default SchedulerConfig, so the same Settings values were silently ignored. The Settings apply action also stopped the whole sidecar, defeating multi-model residency.

## Validation

- `uv run pytest -q tests/test_resident_models.py tests/test_kv_cache_dtype_cli.py tests/test_turboquant_k8v4.py` (85 passed)
- `swift test --package-path apps/rapid-mac` (2087 passed)
- `bash scripts/build.sh` (release app + bundled sidecar built)
- Settings persistence GoldenFlow driven through AX; new `settings-persistence.performance-saved` structural baseline generated and verified
- Ruff format/lint and `git diff --check`