### PR TITLE
fix(mac): surface resident model load rejection on the initiating surface (#1838)

### DIFF
--- a/.github/workflows/rapid-mac-ci.yml
+++ b/.github/workflows/rapid-mac-ci.yml
@@ -304,7 +304,7 @@ jobs:
       # than "golden flows failed". Each needs its own output directory: the
       # harness refuses to start on a non-empty one.
       #
-      # These five drive the app through `rapid-ax` alone (see
+      # These six drive the app through `rapid-ax` alone (see
       # `flow_requires_peekaboo` in the harness). Most other flows shell out to
       # peekaboo — a third-party install whose bridge socket comes from the
       # Peekaboo app rather than its CLI, with its own permission surface. The
@@ -343,6 +343,11 @@ jobs:
         run: ./scripts/gui-golden-flows.sh --flow window-close-prompt
         env:
           RAPID_GUI_GOLDEN_OUT: ${{ runner.temp }}/golden/window-close-prompt
+
+      - name: 'Golden flow: resident-load-rejected'
+        run: ./scripts/gui-golden-flows.sh --flow resident-load-rejected
+        env:
+          RAPID_GUI_GOLDEN_OUT: ${{ runner.temp }}/golden/resident-load-rejected
 
       # The harness stops at the FIRST mismatched baseline and the job stops at
       # the first failing flow, so one red run reveals exactly one line. With 5

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -232,14 +232,29 @@ final class ServerManager {
     /// Bounded to `logBufferCapacity` entries.
     private(set) var logLines: [String] = []
 
-    /// The most recent in-process residency load that the engine rejected, or
-    /// `nil` when there has been no rejection since the last successful load.
+    /// Most recent in-process residency load rejections, keyed by the alias
+    /// that failed. Per-alias rather than a single global slot so two
+    /// concurrent loads of DIFFERENT models cannot clobber each other across
+    /// an `await` (#1838 follow-up): model B's rejection published while
+    /// model A is still loading will not be wiped by A's later success, and
+    /// an older request's rejection cannot overwrite a newer request's
+    /// result for a different model. Each key owns its own outcome, so the
+    /// surface that asked to load that model reads exactly that model's
+    /// result.
     ///
     /// This is *published* (an `@Observable` property), not log-only: the
     /// surface that initiated the load reads it and presents the engine's
     /// reason verbatim, so a rejected resident load is an actionable message
     /// instead of a silent no-op (#1838).
-    private(set) var lastResidentLoadFailure: ResidentLoadFailure?
+    private(set) var residentLoadFailures: [String: ResidentLoadFailure] = [:]
+
+    /// The most recent rejection for `alias`, or `nil` if the last attempt
+    /// for that model succeeded or no rejection has been recorded. Read by
+    /// the surface that initiated the load so it can present the engine's
+    /// reason verbatim rather than only writing it to the log pane (#1838).
+    func residentLoadFailure(for alias: String) -> ResidentLoadFailure? {
+        residentLoadFailures[alias]
+    }
 
     /// True while a start or stop is in flight. The UI disables both
     /// buttons during this window so a second click cannot race the
@@ -832,6 +847,14 @@ final class ServerManager {
         }
         if replacementGroup == nil, isModelResident(trimmed) { return true }
 
+        // Any fresh load attempt — resident, cold start, or the legacy
+        // stop/start fallback — supersedes a stale rejection for THIS alias so
+        // the surface stops showing last round's result while this load is in
+        // flight (or about to succeed). Clearing here (not only inside the
+        // resident branch) means an early-return path can never leave the old
+        // banner up once the user asked to load the model again (#1838).
+        residentLoadFailures[trimmed] = nil
+
         // A healthy sidecar can admit another engine without replacing the
         // process. Only a 404/405 from an older bundled server falls back to
         // the legacy stop/start path; capacity and load failures stay failures
@@ -844,10 +867,6 @@ final class ServerManager {
         // need — audio runs as its own ``serve <alias>`` (audio-mode) process.
         let readyWithChild: Bool = { if case .ready = state, child != nil { return true }; return false }()
         if Self.residencyLoadApplies(residencyEligible: residencyEligible, readyWithChild: readyWithChild) {
-            // A fresh attempt supersedes a stale failure so the surface does
-            // not keep showing last round's rejection while this load is in
-            // flight (or about to succeed).
-            lastResidentLoadFailure = nil
             let estimate = estimatedMemoryGB ?? ModelSizing.estimate(alias: trimmed).totalGB
             let result = await residencyClient.load(
                 alias: trimmed,
@@ -875,7 +894,9 @@ final class ServerManager {
                 if replacementGroup != nil {
                     state = .ready(alias: trimmed)
                 }
-                lastResidentLoadFailure = nil
+                // A successful in-process load confirms the model is fine, so
+                // drop any (possibly concurrent) rejection recorded for it.
+                residentLoadFailures[trimmed] = nil
                 return true
             case .unsupported:
                 break
@@ -885,7 +906,7 @@ final class ServerManager {
                 // serialized/token-bearing `detail` never reaches the surface
                 // unsanitized, while keeping the engine's actionable reason
                 // verbatim otherwise (audit P1 parity with `appendLogLines`).
-                lastResidentLoadFailure = ResidentLoadFailure(
+                residentLoadFailures[trimmed] = ResidentLoadFailure(
                     alias: trimmed,
                     message: LogScrubber.scrub(message)
                 )

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -232,6 +232,15 @@ final class ServerManager {
     /// Bounded to `logBufferCapacity` entries.
     private(set) var logLines: [String] = []
 
+    /// The most recent in-process residency load that the engine rejected, or
+    /// `nil` when there has been no rejection since the last successful load.
+    ///
+    /// This is *published* (an `@Observable` property), not log-only: the
+    /// surface that initiated the load reads it and presents the engine's
+    /// reason verbatim, so a rejected resident load is an actionable message
+    /// instead of a silent no-op (#1838).
+    private(set) var lastResidentLoadFailure: ResidentLoadFailure?
+
     /// True while a start or stop is in flight. The UI disables both
     /// buttons during this window so a second click cannot race the
     /// first into spawning a duplicate child.
@@ -653,6 +662,15 @@ final class ServerManager {
         self.state = newState
     }
 
+    /// Issue #1838 test seam — swap in a ``ServerResidencyClient`` whose
+    /// transport reads from a ``URLProtocol`` stub, so a test can drive the
+    /// in-process resident-load path and observe the published rejection
+    /// without a live sidecar. Production code never calls this; the client
+    /// is created fresh in ``init``.
+    internal func _testSetResidencyClient(_ client: ServerResidencyClient) {
+        self.residencyClient = client
+    }
+
     /// Issue #270 test seam — observe the current auto-respawn attempt
     /// counter so the auto-respawn-retry-cap test can assert how many
     /// times ``runScheduledAutoRespawn`` actually incremented it.
@@ -826,6 +844,10 @@ final class ServerManager {
         // need — audio runs as its own ``serve <alias>`` (audio-mode) process.
         let readyWithChild: Bool = { if case .ready = state, child != nil { return true }; return false }()
         if Self.residencyLoadApplies(residencyEligible: residencyEligible, readyWithChild: readyWithChild) {
+            // A fresh attempt supersedes a stale failure so the surface does
+            // not keep showing last round's rejection while this load is in
+            // flight (or about to succeed).
+            lastResidentLoadFailure = nil
             let estimate = estimatedMemoryGB ?? ModelSizing.estimate(alias: trimmed).totalGB
             let result = await residencyClient.load(
                 alias: trimmed,
@@ -853,11 +875,20 @@ final class ServerManager {
                 if replacementGroup != nil {
                     state = .ready(alias: trimmed)
                 }
+                lastResidentLoadFailure = nil
                 return true
             case .unsupported:
                 break
             case .rejected(let message):
                 appendLogLines(["Resident model load declined: \(message)"])
+                // Mirror the same redaction the log pane applies so a
+                // serialized/token-bearing `detail` never reaches the surface
+                // unsanitized, while keeping the engine's actionable reason
+                // verbatim otherwise (audit P1 parity with `appendLogLines`).
+                lastResidentLoadFailure = ResidentLoadFailure(
+                    alias: trimmed,
+                    message: LogScrubber.scrub(message)
+                )
                 return false
             }
         }

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -256,6 +256,22 @@ final class ServerManager {
         residentLoadFailures[alias]
     }
 
+    /// Per-alias monotonically-increasing attempt generation. Guards the
+    /// *return-time* failure writes/clears so that, for the SAME alias, only
+    /// the attempt that began most recently may record its outcome.
+    ///
+    /// ``ensureServing`` is an `async` ``@MainActor`` method: two calls for
+    /// the same alias can interleave across the ``await residencyClient.load``
+    /// hop. Without this, an OLDER attempt that returns after a NEWER one can
+    /// clobber the newer result — an old rejection overwriting a newer
+    /// success, or an old success clearing a newer rejection. Each attempt
+    /// captures the token it minted up front; when it resumes it writes only
+    /// if that token is still the latest issued for its alias. The
+    /// ``residentLoadFailures`` dictionary alone cannot express this — it
+    /// fixes cross-*alias* clobbering but not cross-attempt clobbering within
+    /// one alias (#1838 follow-up).
+    private var residentLoadAttemptTokens: [String: UUID] = [:]
+
     /// True while a start or stop is in flight. The UI disables both
     /// buttons during this window so a second click cannot race the
     /// first into spawning a duplicate child.
@@ -854,6 +870,12 @@ final class ServerManager {
         // resident branch) means an early-return path can never leave the old
         // banner up once the user asked to load the model again (#1838).
         residentLoadFailures[trimmed] = nil
+        // This attempt becomes the NEWEST for its alias. When its async load
+        // returns it may only write/clear the failure if it is still the
+        // newest — a concurrently-issued, later attempt owns the slot from
+        // here on (#1838 follow-up).
+        let attemptToken = UUID()
+        residentLoadAttemptTokens[trimmed] = attemptToken
 
         // A healthy sidecar can admit another engine without replacing the
         // process. Only a 404/405 from an older bundled server falls back to
@@ -895,8 +917,14 @@ final class ServerManager {
                     state = .ready(alias: trimmed)
                 }
                 // A successful in-process load confirms the model is fine, so
-                // drop any (possibly concurrent) rejection recorded for it.
-                residentLoadFailures[trimmed] = nil
+                // drop any (possibly concurrent) rejection recorded for it —
+                // but only if THIS attempt is still the newest for the alias.
+                // An older attempt resuming after a newer one already
+                // succeeded must not wipe a newer attempt's outcome
+                // (#1838 follow-up).
+                if residentLoadAttemptTokens[trimmed] == attemptToken {
+                    residentLoadFailures[trimmed] = nil
+                }
                 return true
             case .unsupported:
                 break
@@ -906,10 +934,15 @@ final class ServerManager {
                 // serialized/token-bearing `detail` never reaches the surface
                 // unsanitized, while keeping the engine's actionable reason
                 // verbatim otherwise (audit P1 parity with `appendLogLines`).
-                residentLoadFailures[trimmed] = ResidentLoadFailure(
-                    alias: trimmed,
-                    message: LogScrubber.scrub(message)
-                )
+                // Only the newest attempt may publish a rejection: a stale
+                // attempt's failure must not overwrite a newer attempt's
+                // success for the same alias (#1838 follow-up).
+                if residentLoadAttemptTokens[trimmed] == attemptToken {
+                    residentLoadFailures[trimmed] = ResidentLoadFailure(
+                        alias: trimmed,
+                        message: LogScrubber.scrub(message)
+                    )
+                }
                 return false
             }
         }

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerResidency.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerResidency.swift
@@ -129,6 +129,17 @@ enum ResidentModelLoadResult: Sendable, Equatable {
     case rejected(String)
 }
 
+/// A resident-model load that the engine rejected, kept long enough for the
+/// surface that initiated the load to read and present the reason verbatim
+/// instead of only writing it to the log pane (#1838). The engine's own
+/// `detail` string (e.g. `image generation requires the 'rapid-mlx[image]'
+/// Python extra (pip install 'rapid-mlx[image]')`) is specific and actionable,
+/// so it is preserved here rather than flattened to a generic "couldn't load".
+struct ResidentLoadFailure: Sendable, Equatable {
+    let alias: String
+    let message: String
+}
+
 enum ResidentModelReplacementGroup: String, Sendable {
     case assistant
 }

--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -258,18 +258,34 @@ struct ContentView: View {
             cacheState: cacheState(for: alias),
             sizeText: sizeText(for: alias),
             progress: progressSnapshot,
-            failure: chat.lastError.map {
-                ModelReadiness.Failure(
-                    message: $0,
-                    kind: chat.lastFailureKind,
-                    // The alias the failure is ABOUT — not the one
-                    // currently selected. Passing `alias` here is what
-                    // let a failure follow the user onto whatever model
-                    // they picked next.
-                    alias: chat.lastFailureAlias
-                )
-            }
+            failure: readinessFailure
         )
+    }
+
+    /// The failure to present on the initiating surface, if any.
+    ///
+    /// A resident-load rejection published by ``ServerManager`` (#1838) is the
+    /// freshest, most specific signal about whether the selected model can
+    /// load — the engine's own rejection reason, not flattened to a generic
+    /// "couldn't start". It wins over a turn-level ``chat`` failure so a
+    /// banner-initiated load that the engine rejects shows its reason here on
+    /// the chat surface, not only in the log pane. When no load was rejected,
+    /// fall back to the chat failure exactly as before.
+    private var readinessFailure: ModelReadiness.Failure? {
+        if let load = server.lastResidentLoadFailure {
+            return ModelReadiness.Failure(message: load.message, alias: load.alias)
+        }
+        return chat.lastError.map {
+            ModelReadiness.Failure(
+                message: $0,
+                kind: chat.lastFailureKind,
+                // The alias the failure is ABOUT — not the one
+                // currently selected. Passing `alias` here is what
+                // let a failure follow the user onto whatever model
+                // they picked next.
+                alias: chat.lastFailureAlias
+            )
+        }
     }
 
     /// Progress is only read while the server is actually starting.

--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -272,7 +272,7 @@ struct ContentView: View {
     /// the chat surface, not only in the log pane. When no load was rejected,
     /// fall back to the chat failure exactly as before.
     private var readinessFailure: ModelReadiness.Failure? {
-        if let load = server.lastResidentLoadFailure {
+        if let load = server.residentLoadFailure(for: alias) {
             return ModelReadiness.Failure(message: load.message, alias: load.alias)
         }
         return chat.lastError.map {

--- a/apps/rapid-mac/Sources/Rapid/UI/ImagesView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ImagesView.swift
@@ -119,7 +119,15 @@ struct ImagesView: View {
             sizeText: viewModel.imageModels
                 .first { $0.alias == viewModel.selectedAlias }?.sizeOnDisk,
             progress: startupProgress,
-            failure: nil
+            // A rejected resident load (e.g. the sidecar cannot serve this
+            // model) must surface the engine's reason HERE, on the surface
+            // that initiated the load, not only in the log pane (#1838). The
+            // resolve precedence rules keep `.ready`/`.starting`/`.downloading`
+            // winning over a stale rejection, and `failureApplies` scopes it to
+            // the model that actually failed.
+            failure: server.lastResidentLoadFailure.map {
+                ModelReadiness.Failure(message: $0.message, alias: $0.alias)
+            }
         )
     }
 

--- a/apps/rapid-mac/Sources/Rapid/UI/ImagesView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ImagesView.swift
@@ -124,8 +124,11 @@ struct ImagesView: View {
             // that initiated the load, not only in the log pane (#1838). The
             // resolve precedence rules keep `.ready`/`.starting`/`.downloading`
             // winning over a stale rejection, and `failureApplies` scopes it to
-            // the model that actually failed.
-            failure: server.lastResidentLoadFailure.map {
+            // the model that actually failed. Failures are keyed per alias in
+            // ``ServerManager``, so we read only the outcome for the model
+            // this surface asked to load (#1838 follow-up: concurrent loads of
+            // different models cannot clobber one another).
+            failure: server.residentLoadFailure(for: viewModel.selectedAlias).map {
                 ModelReadiness.Failure(message: $0.message, alias: $0.alias)
             }
         )

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-restore.answered.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-restore.answered.txt
@@ -13,6 +13,13 @@ AXApplication title="Rapid-MLX"
             AXButton id="Sidebar.Conversation.Pin.<uuid>" desc="Pin conversation" help="Pin conversation" enabled=true
             AXPopUpButton id="Sidebar.Conversation.Menu.<uuid>" desc="Conversation actions" enabled=true
             AXButton id="Sidebar.Conversation.<uuid>" desc="golden restore marker" enabled=true
+          AXImage id="Sidebar.Residency" desc="memorychip" enabled=true
+          AXStaticText id="Sidebar.Residency" value=text enabled=true
+          AXStaticText id="Sidebar.Residency" value=text enabled=true
+          AXProgressIndicator id="Sidebar.Residency" value=number enabled=true
+          AXImage id="Sidebar.Residency" desc="Lock" enabled=true
+          AXStaticText id="Sidebar.Residency" value=text enabled=true
+          AXStaticText id="Sidebar.Residency" value=text enabled=true
         AXSplitter value=number enabled=false
         AXGroup subrole=AXHostingView
           AXScrollArea

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-restore.transcript-restored.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-restore.transcript-restored.txt
@@ -13,6 +13,13 @@ AXApplication title="Rapid-MLX"
             AXButton id="Sidebar.Conversation.Pin.<uuid>" desc="Pin conversation" help="Pin conversation" enabled=true
             AXPopUpButton id="Sidebar.Conversation.Menu.<uuid>" desc="Conversation actions" enabled=true
             AXButton id="Sidebar.Conversation.<uuid>" desc="golden restore marker" enabled=true
+          AXImage id="Sidebar.Residency" desc="memorychip" enabled=true
+          AXStaticText id="Sidebar.Residency" value=text enabled=true
+          AXStaticText id="Sidebar.Residency" value=text enabled=true
+          AXProgressIndicator id="Sidebar.Residency" value=number enabled=true
+          AXImage id="Sidebar.Residency" desc="Lock" enabled=true
+          AXStaticText id="Sidebar.Residency" value=text enabled=true
+          AXStaticText id="Sidebar.Residency" value=text enabled=true
         AXSplitter value=number enabled=false
         AXGroup subrole=AXHostingView
           AXScrollArea

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/image-generation.generated.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/image-generation.generated.txt
@@ -8,6 +8,13 @@ AXApplication title="Rapid-MLX"
           AXButton id="Sidebar.Images" desc="Images" enabled=true
           AXButton id="Sidebar.Audio" desc="Audio" enabled=true
           AXButton id="Sidebar.Launch" desc="Launch" enabled=true
+          AXImage id="Sidebar.Residency" desc="memorychip" enabled=true
+          AXStaticText id="Sidebar.Residency" value=text enabled=true
+          AXStaticText id="Sidebar.Residency" value=text enabled=true
+          AXProgressIndicator id="Sidebar.Residency" value=number enabled=true
+          AXImage id="Sidebar.Residency" desc="Lock" enabled=true
+          AXStaticText id="Sidebar.Residency" value=text enabled=true
+          AXStaticText id="Sidebar.Residency" value=text enabled=true
         AXSplitter value=number enabled=false
         AXGroup subrole=AXHostingView
           AXButton id="Images.Stage" desc="Download" help="Save image" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/model-crash-recovery.recovered.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/model-crash-recovery.recovered.txt
@@ -13,6 +13,13 @@ AXApplication title="Rapid-MLX"
             AXButton id="Sidebar.Conversation.Pin.<uuid>" desc="Pin conversation" help="Pin conversation" enabled=true
             AXPopUpButton id="Sidebar.Conversation.Menu.<uuid>" desc="Conversation actions" enabled=true
             AXButton id="Sidebar.Conversation.<uuid>" desc="golden crash marker" enabled=true
+          AXImage id="Sidebar.Residency" desc="memorychip" enabled=true
+          AXStaticText id="Sidebar.Residency" value=text enabled=true
+          AXStaticText id="Sidebar.Residency" value=text enabled=true
+          AXProgressIndicator id="Sidebar.Residency" value=number enabled=true
+          AXImage id="Sidebar.Residency" desc="Lock" enabled=true
+          AXStaticText id="Sidebar.Residency" value=text enabled=true
+          AXStaticText id="Sidebar.Residency" value=text enabled=true
         AXSplitter value=number enabled=false
         AXGroup subrole=AXHostingView
           AXScrollArea

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/slow-stream-stop.stopped.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/slow-stream-stop.stopped.txt
@@ -13,6 +13,13 @@ AXApplication title="Rapid-MLX"
             AXButton id="Sidebar.Conversation.Pin.<uuid>" desc="Pin conversation" help="Pin conversation" enabled=true
             AXPopUpButton id="Sidebar.Conversation.Menu.<uuid>" desc="Conversation actions" enabled=true
             AXButton id="Sidebar.Conversation.<uuid>" desc="golden stop marker" enabled=true
+          AXImage id="Sidebar.Residency" desc="memorychip" enabled=true
+          AXStaticText id="Sidebar.Residency" value=text enabled=true
+          AXStaticText id="Sidebar.Residency" value=text enabled=true
+          AXProgressIndicator id="Sidebar.Residency" value=number enabled=true
+          AXImage id="Sidebar.Residency" desc="Lock" enabled=true
+          AXStaticText id="Sidebar.Residency" value=text enabled=true
+          AXStaticText id="Sidebar.Residency" value=text enabled=true
         AXSplitter value=number enabled=false
         AXGroup subrole=AXHostingView
           AXScrollArea

--- a/apps/rapid-mac/Tests/RapidTests/ResidentLoadFeedbackTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ResidentLoadFeedbackTests.swift
@@ -1,0 +1,162 @@
+import Foundation
+import Testing
+@testable import Rapid
+
+/// ``URLProtocol`` stub that stands in for the sidecar's in-process residency
+/// endpoint. The lean, deterministic seam for #1838: a rejected resident load
+/// must publish the engine's reason to the surface that initiated it, not be
+/// swallowed into the log pane.
+///
+/// The default answer mirrors the exact failure an engine gives when its
+/// bundle cannot serve the requested model — e.g. a stock desktop build whose
+/// sidecar has no ``[image]`` extra (#1840):
+///
+///     image generation requires the 'rapid-mlx[image]' Python extra
+///     (pip install 'rapid-mlx[image]')
+///
+/// It returns 422 (a non-2xx, non-404/405 response), so it reaches the
+/// ``.rejected(detail)`` branch of ``ServerResidencyClient.load`` rather than
+/// the legacy stop/start fallback — the exact path the issue pins.
+final class ResidentLoadRejectProtocol: URLProtocol, @unchecked Sendable {
+    /// The engine's own, actionable `detail` string, preserved verbatim.
+    static let rejectionDetail =
+        "image generation requires the 'rapid-mlx[image]' Python extra "
+        + "(pip install 'rapid-mlx[image]')"
+
+    nonisolated(unsafe) static var rejectLoad = true
+    nonisolated(unsafe) static var method = "POST"
+    nonisolated(unsafe) static var path = ""
+
+    static func session() -> URLSession {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [ResidentLoadRejectProtocol.self] + (config.protocolClasses ?? [])
+        return URLSession(configuration: config)
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        Self.method = request.httpMethod ?? "GET"
+        Self.path = request.url?.path ?? ""
+        let body: Data
+        let status: Int
+        if Self.method == "POST", Self.path == "/v1/models/load", Self.rejectLoad {
+            status = 422
+            body = Data("{\"detail\": \"\(Self.rejectionDetail)\"}".utf8)
+        } else if Self.method == "GET", Self.path == "/v1/models/residency" {
+            // A healthy residency snapshot so a successful load's
+            // ``refreshResidency`` has something to read.
+            status = 200
+            body = Data(#"""
+                {
+                  "memory_limit_bytes": 34359738368,
+                  "memory_used_bytes": 10737418240,
+                  "memory_available_bytes": 23622320128,
+                  "idle_ttl_seconds": 1800,
+                  "loads_total": 1,
+                  "evictions_total": 0,
+                  "models": [{
+                    "id": "flux2-klein-4b",
+                    "model_path": "Runware/FLUX.2-klein-4B",
+                    "aliases": ["flux-klein"],
+                    "modality": "image-gen",
+                    "state": "resident",
+                    "pinned": false,
+                    "primary": false,
+                    "active_requests": 0,
+                    "estimated_bytes": 1000,
+                    "measured_bytes": 500,
+                    "idle_seconds": 0.0
+                  }]
+                }
+                """#.utf8)
+        } else if Self.method == "POST", Self.path == "/v1/models/load" {
+            // Success branch for the clear-on-success assertion.
+            status = 200
+            body = Data(#"""
+                {
+                  "id": "flux2-klein-4b",
+                  "model_path": "Runware/FLUX.2-klein-4B",
+                  "aliases": ["flux-klein"],
+                  "modality": "image-gen",
+                  "state": "resident",
+                  "pinned": false,
+                  "primary": false,
+                  "active_requests": 0,
+                  "estimated_bytes": 1000,
+                  "measured_bytes": 500,
+                  "idle_seconds": 0.0
+                }
+                """#.utf8)
+        } else {
+            status = 404
+            body = Data("{\"error\":\"not_found\"}".utf8)
+        }
+        let response = HTTPURLResponse(
+            url: request.url!,
+            statusCode: status,
+            httpVersion: "HTTP/1.1",
+            headerFields: ["Content-Type": "application/json"]
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: body)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}
+
+@MainActor
+@Suite("Resident-load rejection feedback")
+struct ResidentLoadFeedbackTests {
+    /// The core defect (#1838): the engine returns an actionable reason, the
+    /// ``ServerResidencyClient`` maps it to ``.rejected(detail)``, but the
+    /// GUI layer previously dropped that result — the failure reached only the
+    /// log pane. This pins that ``ServerManager.ensureServing`` now publishes
+    /// it so the initiating surface can show it.
+    ///
+    /// The `lastResidentLoadFailure` property did not exist before this fix, so
+    /// this test does not merely fail — it does not compile against old `main`,
+    /// guaranteeing it cannot silently rot into a pass.
+    @Test("A rejected resident load publishes the engine's reason")
+    func publishesRejectedLoadFailure() async {
+        ResidentLoadRejectProtocol.rejectLoad = true
+        var client = ServerResidencyClient()
+        client.session = ResidentLoadRejectProtocol.session()
+        let server = ServerManager(testingState: .ready(alias: "qwen3.5-4b-4bit"))
+        server._testSetResidencyClient(client)
+        server._testInstallChild(ProcessGroupChild.testStub())
+
+        let ok = await server.ensureServing(
+            alias: "flux2-klein-4b",
+            hfPath: "Runware/FLUX.2-klein-4B"
+        )
+
+        #expect(ok == false)
+        #expect(server.lastResidentLoadFailure?.alias == "flux2-klein-4b")
+        #expect(server.lastResidentLoadFailure?.message == ResidentLoadRejectProtocol.rejectionDetail)
+    }
+
+    /// A successful in-process load clears any prior rejection, so the banner
+    /// does not keep showing last round's failure once the model loads.
+    @Test("A successful resident load clears a prior rejection")
+    func successfulLoadClearsRejection() async {
+        // First a rejection (sets the published failure)…
+        ResidentLoadRejectProtocol.rejectLoad = true
+        var client = ServerResidencyClient()
+        client.session = ResidentLoadRejectProtocol.session()
+        let server = ServerManager(testingState: .ready(alias: "qwen3.5-4b-4bit"))
+        server._testSetResidencyClient(client)
+        server._testInstallChild(ProcessGroupChild.testStub())
+
+        _ = await server.ensureServing(alias: "flux2-klein-4b", hfPath: nil)
+        #expect(server.lastResidentLoadFailure?.alias == "flux2-klein-4b")
+
+        // …then a successful load clears it.
+        ResidentLoadRejectProtocol.rejectLoad = false
+        let ok = await server.ensureServing(alias: "flux2-klein-4b", hfPath: nil)
+        #expect(ok == true)
+        #expect(server.lastResidentLoadFailure == nil)
+    }
+}

--- a/apps/rapid-mac/Tests/RapidTests/ResidentLoadFeedbackTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ResidentLoadFeedbackTests.swift
@@ -47,14 +47,22 @@ final class ResidentLoadRejectProtocol: URLProtocol, @unchecked Sendable {
 
     /// Controllable in-order gate for the same-alias concurrency test. When
     /// ``gateAlias`` is set, the FIRST ``/v1/models/load`` whose target
-    /// matches it blocks in ``startLoading`` (on the URL loading thread, NOT
-    /// the main actor) until the test signals ``gateSemaphore``. Every later
-    /// load for that alias passes straight through. This lets a test make an
-    /// OLDER ``ensureServing`` attempt return AFTER a NEWER one, which the
+    /// matches it is HELD (its response deferred) rather than answered
+    /// immediately, so a second, newer attempt for the same alias can
+    /// complete first. The test signals ``releaseGate()`` to deliver the held
+    /// first load's response last — recreating the interleaving where an
+    /// OLDER ``ensureServing`` attempt returns AFTER a NEWER one, which the
     /// per-alias ``residentLoadFailures`` dictionary alone cannot express.
+    ///
+    /// The deferred delivery must NOT block the URL loading thread with a
+    /// semaphore: URLProtocol ``startLoading`` runs on a shared transport
+    /// thread, and blocking it stalls every other request on the same
+    /// ``URLSession`` (the second, newer load would fail to start and the
+    /// whole test would deadlock). Instead we park the ``URLProtocol``
+    /// instance and deliver its response asynchronously on ``releaseGate()``.
     nonisolated(unsafe) static var gateAlias: String?
-    nonisolated(unsafe) static var gateSemaphore: DispatchSemaphore?
     nonisolated(unsafe) static var gateHasHeldOne = false
+    nonisolated(unsafe) private static var heldProtocol: ResidentLoadRejectProtocol?
 
     /// Restore the defaults so one test can never observe another test's
     /// leftover configuration — the leak that made the previous global-slot
@@ -63,8 +71,23 @@ final class ResidentLoadRejectProtocol: URLProtocol, @unchecked Sendable {
         rejectLoad = true
         rejectOnlyAlias = nil
         gateAlias = nil
-        gateSemaphore = nil
         gateHasHeldOne = false
+        heldProtocol = nil
+    }
+
+    /// Release the held first gated load (if any), delivering its response
+    /// asynchronously after the newer attempt has already completed. The
+    /// response uses the current ``rejectLoad`` / ``rejectOnlyAlias`` values,
+    /// so the test toggles them just before releasing to choose whether the
+    /// OLDER attempt resolves to a rejection or a success.
+    static func releaseGate() {
+        guard let held = heldProtocol else { return }
+        heldProtocol = nil
+        let reject = rejectOnlyAlias
+        let rejectAll = rejectLoad
+        DispatchQueue.global(qos: .userInitiated).async {
+            held.finish(resolveWith: rejectAll, rejectOnlyAlias: reject)
+        }
     }
 
     static func session() -> URLSession {
@@ -77,38 +100,27 @@ final class ResidentLoadRejectProtocol: URLProtocol, @unchecked Sendable {
     override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
 
     override func startLoading() {
-        let body: Data
-        let status: Int
         if request.httpMethod == "POST", request.url?.path == "/v1/models/load" {
             let requestedAlias = Self.alias(from: request)
-            // Hold only the FIRST load for the gated alias until the test
-            // releases it, so a second, newer attempt can complete while the
-            // first is still in flight — recreating the exact interleaving
-            // where an older attempt returns last (#1838 follow-up).
+            // Hold the FIRST load for the gated alias (defer its response)
+            // until the test calls ``releaseGate()``, so a second, newer
+            // attempt can complete while the first is still in flight —
+            // recreating the exact interleaving where an older attempt
+            // returns last (#1838 follow-up). The hold parks the protocol
+            // instance without blocking the URL loading thread, so the newer
+            // attempt's request can still be serviced.
             if let ga = Self.gateAlias, requestedAlias == ga, !Self.gateHasHeldOne {
                 Self.gateHasHeldOne = true
-                Self.gateSemaphore?.wait()
+                Self.heldProtocol = self
+                return
             }
-            if let rejectOnlyAlias = Self.rejectOnlyAlias {
-                if requestedAlias == rejectOnlyAlias {
-                    status = 422
-                    body = Data("{\"detail\": \"\(Self.rejectionDetail)\"}".utf8)
-                } else {
-                    status = 200
-                    body = Self.successLoadBody
-                }
-            } else if Self.rejectLoad {
-                status = 422
-                body = Data("{\"detail\": \"\(Self.rejectionDetail)\"}".utf8)
-            } else {
-                status = 200
-                body = Self.successLoadBody
-            }
-        } else if request.httpMethod == "GET", request.url?.path == "/v1/models/residency" {
+            finish(resolveWith: Self.rejectLoad, rejectOnlyAlias: Self.rejectOnlyAlias)
+            return
+        }
+        if request.httpMethod == "GET", request.url?.path == "/v1/models/residency" {
             // A healthy residency snapshot so a successful load's
             // ``refreshResidency`` has something to read.
-            status = 200
-            body = Data(#"""
+            let body = Data(#"""
                 {
                   "memory_limit_bytes": 34359738368,
                   "memory_used_bytes": 10737418240,
@@ -131,10 +143,41 @@ final class ResidentLoadRejectProtocol: URLProtocol, @unchecked Sendable {
                   }]
                 }
                 """#.utf8)
+            respond(status: 200, body: body)
         } else {
-            status = 404
-            body = Data("{\"error\":\"not_found\"}".utf8)
+            respond(status: 404, body: Data("{\"error\":\"not_found\"}".utf8))
         }
+    }
+
+    /// Deliver this request's answer, computing the body from the given
+    /// rejection configuration. Also the delayed path for a held gated load
+    /// (dispatched from ``releaseGate`` on a background queue, so it never
+    /// blocks the URL loading thread).
+    private func finish(
+        resolveWith rejectAll: Bool,
+        rejectOnlyAlias: String?
+    ) {
+        let body: Data
+        let status: Int
+        if let rejectOnlyAlias = rejectOnlyAlias {
+            if alias(from: request) == rejectOnlyAlias {
+                status = 422
+                body = Data("{\"detail\": \"\(Self.rejectionDetail)\"}".utf8)
+            } else {
+                status = 200
+                body = Self.successLoadBody
+            }
+        } else if rejectAll {
+            status = 422
+            body = Data("{\"detail\": \"\(Self.rejectionDetail)\"}".utf8)
+        } else {
+            status = 200
+            body = Self.successLoadBody
+        }
+        respond(status: status, body: body)
+    }
+
+    private func respond(status: Int, body: Data) {
         let response = HTTPURLResponse(
             url: request.url!,
             statusCode: status,
@@ -290,7 +333,7 @@ struct ResidentLoadFeedbackTests {
     /// expired failure even though the latest load succeeded.
     ///
     /// The stub's in-order gate holds the FIRST load for the alias in flight
-    /// (on the URL loading thread, never the main actor) while a second,
+    /// (in ``startLoading``, steering clear of the main actor) while a second,
     /// newer attempt completes first — reproducing exactly the interleaving
     /// where latest-attempt-wins must hold.
     @Test("An older rejection cannot clobber a newer success for the same alias")
@@ -299,13 +342,11 @@ struct ResidentLoadFeedbackTests {
         let server = makeServer()
         let alias = "flux2-klein-4b"
 
-        let gate = DispatchSemaphore(value: 0)
         ResidentLoadRejectProtocol.rejectLoad = true // older attempt, when released, rejects
         ResidentLoadRejectProtocol.gateAlias = alias
-        ResidentLoadRejectProtocol.gateSemaphore = gate
 
         // Attempt 1 (older): mints the first token, clears the failure, and
-        // blocks inside the load until the gate releases it.
+        // is held by the gate (its response deferred) until releaseGate().
         let attempt1: Task<Bool, Never> = Task { @MainActor in
             await server.ensureServing(alias: alias, hfPath: nil)
         }
@@ -319,10 +360,10 @@ struct ResidentLoadFeedbackTests {
         #expect(server.residentLoadFailure(for: alias) == nil,
                 "the newer success leaves no rejection in its own slot")
 
-        // Release attempt 1 so it resumes as a REJECTION — but it is no
+        // Release attempt 1 so it resolves as a REJECTION — but it is no
         // longer the newest attempt, so its stale rejection must be ignored.
         ResidentLoadRejectProtocol.rejectLoad = true
-        gate.signal()
+        ResidentLoadRejectProtocol.releaseGate()
         let attempt1Result = await attempt1.value
         #expect(attempt1Result == false)
         #expect(server.residentLoadFailure(for: alias) == nil,
@@ -339,10 +380,8 @@ struct ResidentLoadFeedbackTests {
         let server = makeServer()
         let alias = "flux2-klein-4b"
 
-        let gate = DispatchSemaphore(value: 0)
         ResidentLoadRejectProtocol.rejectLoad = false // older attempt, when released, succeeds
         ResidentLoadRejectProtocol.gateAlias = alias
-        ResidentLoadRejectProtocol.gateSemaphore = gate
 
         let attempt1: Task<Bool, Never> = Task { @MainActor in
             await server.ensureServing(alias: alias, hfPath: nil)
@@ -357,10 +396,10 @@ struct ResidentLoadFeedbackTests {
         #expect(server.residentLoadFailure(for: alias) != nil,
                 "the newer rejection is recorded")
 
-        // Release attempt 1 so it resumes as SUCCESS — but it is not newest,
+        // Release attempt 1 so it resolves as SUCCESS — but it is not newest,
         // so its success must not wipe the newer rejection.
         ResidentLoadRejectProtocol.rejectLoad = false
-        gate.signal()
+        ResidentLoadRejectProtocol.releaseGate()
         let attempt1Result = await attempt1.value
         #expect(attempt1Result == true)
         #expect(server.residentLoadFailure(for: alias) != nil,

--- a/apps/rapid-mac/Tests/RapidTests/ResidentLoadFeedbackTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ResidentLoadFeedbackTests.swift
@@ -148,11 +148,37 @@ final class ResidentLoadRejectProtocol: URLProtocol, @unchecked Sendable {
 
     /// The `model` field of the `POST /v1/models/load` body, so the stub can
     /// reject one specific alias while letting others succeed.
+    ///
+    /// ``URLSession`` hands a ``URLProtocol`` the request body as an input
+    /// stream, coalescing ``URLRequest.httpBody`` into
+    /// ``URLRequest.httpBodyStream`` (and niling ``httpBody``), so the alias
+    /// must be read from whichever representation carries the bytes — reading
+    /// only ``httpBody`` would silently see ``nil`` and never match the gated
+    /// alias (the reason the per-alias branch returned 200 instead of 422).
     private static func alias(from request: URLRequest) -> String? {
-        guard let httpBody = request.httpBody,
-              let object = try? JSONSerialization.jsonObject(with: httpBody) as? [String: Any]
+        guard let body = Self.bodyData(from: request),
+              let object = try? JSONSerialization.jsonObject(with: body) as? [String: Any]
         else { return nil }
         return object["model"] as? String
+    }
+
+    private static func bodyData(from request: URLRequest) -> Data? {
+        if let httpBody = request.httpBody {
+            return httpBody
+        }
+        guard let stream = request.httpBodyStream else { return nil }
+        stream.open()
+        defer { stream.close() }
+        var data = Data()
+        let bufferSize = 4096
+        let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
+        defer { buffer.deallocate() }
+        while stream.hasBytesAvailable {
+            let count = stream.read(buffer, maxLength: bufferSize)
+            if count <= 0 { break }
+            data.append(buffer, count: count)
+        }
+        return data
     }
 
     private static let successLoadBody = Data(#"""

--- a/apps/rapid-mac/Tests/RapidTests/ResidentLoadFeedbackTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ResidentLoadFeedbackTests.swift
@@ -160,7 +160,7 @@ final class ResidentLoadRejectProtocol: URLProtocol, @unchecked Sendable {
         let body: Data
         let status: Int
         if let rejectOnlyAlias = rejectOnlyAlias {
-            if alias(from: request) == rejectOnlyAlias {
+            if Self.alias(from: request) == rejectOnlyAlias {
                 status = 422
                 body = Data("{\"detail\": \"\(Self.rejectionDetail)\"}".utf8)
             } else {

--- a/apps/rapid-mac/Tests/RapidTests/ResidentLoadFeedbackTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ResidentLoadFeedbackTests.swift
@@ -7,9 +7,9 @@ import Testing
 /// must publish the engine's reason to the surface that initiated it, not be
 /// swallowed into the log pane.
 ///
-/// The default answer mirrors the exact failure an engine gives when its
-/// bundle cannot serve the requested model — e.g. a stock desktop build whose
-/// sidecar has no ``[image]`` extra (#1840):
+/// The default rejection answer mirrors the exact failure an engine gives when
+/// its bundle cannot serve the requested model — e.g. a stock desktop build
+/// whose sidecar has no ``[image]`` extra (#1840):
 ///
 ///     image generation requires the 'rapid-mlx[image]' Python extra
 ///     (pip install 'rapid-mlx[image]')
@@ -17,15 +17,41 @@ import Testing
 /// It returns 422 (a non-2xx, non-404/405 response), so it reaches the
 /// ``.rejected(detail)`` branch of ``ServerResidencyClient.load`` rather than
 /// the legacy stop/start fallback — the exact path the issue pins.
+///
+/// Configuration lives on process-wide singleton statics (``URLProtocol`` has
+/// no per-session request config channel), so the consuming suite must be
+/// ``.serialized``: parallel tests toggling them in opposite directions would
+/// race and see each other's value. Each test pins the value it needs before
+/// use and restores the defaults in a ``defer`` so a mid-test failure cannot
+/// leak configuration into the next test.
 final class ResidentLoadRejectProtocol: URLProtocol, @unchecked Sendable {
     /// The engine's own, actionable `detail` string, preserved verbatim.
     static let rejectionDetail =
         "image generation requires the 'rapid-mlx[image]' Python extra "
         + "(pip install 'rapid-mlx[image]')"
 
+    /// When set, only loads whose request body names this alias are rejected
+    /// with 422; every other load succeeds. When `nil`, ALL ``POST
+    /// /v1/models/load`` requests are controlled by ``rejectLoad`` instead.
+    ///
+    /// This is what lets a test load model A (rejected) and model B
+    /// (succeeding) within one scenario and assert the two outcomes stay
+    /// independent — the exact cross-talk regression the single-slot design
+    /// had.
+    nonisolated(unsafe) static var rejectOnlyAlias: String?
+
+    /// When ``rejectOnlyAlias`` is `nil`, `true` makes every ``POST
+    /// /v1/models/load`` answer 422 (rejected) and `false` makes every one
+    /// answer 200 (success).
     nonisolated(unsafe) static var rejectLoad = true
-    nonisolated(unsafe) static var method = "POST"
-    nonisolated(unsafe) static var path = ""
+
+    /// Restore the defaults so one test can never observe another test's
+    /// leftover configuration — the leak that made the previous global-slot
+    /// tests flaky under parallel execution.
+    static func reset() {
+        rejectLoad = true
+        rejectOnlyAlias = nil
+    }
 
     static func session() -> URLSession {
         let config = URLSessionConfiguration.ephemeral
@@ -37,14 +63,26 @@ final class ResidentLoadRejectProtocol: URLProtocol, @unchecked Sendable {
     override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
 
     override func startLoading() {
-        Self.method = request.httpMethod ?? "GET"
-        Self.path = request.url?.path ?? ""
         let body: Data
         let status: Int
-        if Self.method == "POST", Self.path == "/v1/models/load", Self.rejectLoad {
-            status = 422
-            body = Data("{\"detail\": \"\(Self.rejectionDetail)\"}".utf8)
-        } else if Self.method == "GET", Self.path == "/v1/models/residency" {
+        if request.httpMethod == "POST", request.url?.path == "/v1/models/load" {
+            let requestedAlias = Self.alias(from: request)
+            if let rejectOnlyAlias = Self.rejectOnlyAlias {
+                if requestedAlias == rejectOnlyAlias {
+                    status = 422
+                    body = Data("{\"detail\": \"\(Self.rejectionDetail)\"}".utf8)
+                } else {
+                    status = 200
+                    body = Self.successLoadBody
+                }
+            } else if Self.rejectLoad {
+                status = 422
+                body = Data("{\"detail\": \"\(Self.rejectionDetail)\"}".utf8)
+            } else {
+                status = 200
+                body = Self.successLoadBody
+            }
+        } else if request.httpMethod == "GET", request.url?.path == "/v1/models/residency" {
             // A healthy residency snapshot so a successful load's
             // ``refreshResidency`` has something to read.
             status = 200
@@ -71,24 +109,6 @@ final class ResidentLoadRejectProtocol: URLProtocol, @unchecked Sendable {
                   }]
                 }
                 """#.utf8)
-        } else if Self.method == "POST", Self.path == "/v1/models/load" {
-            // Success branch for the clear-on-success assertion.
-            status = 200
-            body = Data(#"""
-                {
-                  "id": "flux2-klein-4b",
-                  "model_path": "Runware/FLUX.2-klein-4B",
-                  "aliases": ["flux-klein"],
-                  "modality": "image-gen",
-                  "state": "resident",
-                  "pinned": false,
-                  "primary": false,
-                  "active_requests": 0,
-                  "estimated_bytes": 1000,
-                  "measured_bytes": 500,
-                  "idle_seconds": 0.0
-                }
-                """#.utf8)
         } else {
             status = 404
             body = Data("{\"error\":\"not_found\"}".utf8)
@@ -104,11 +124,42 @@ final class ResidentLoadRejectProtocol: URLProtocol, @unchecked Sendable {
         client?.urlProtocolDidFinishLoading(self)
     }
 
+    /// The `model` field of the `POST /v1/models/load` body, so the stub can
+    /// reject one specific alias while letting others succeed.
+    private static func alias(from request: URLRequest) -> String? {
+        guard let httpBody = request.httpBody,
+              let object = try? JSONSerialization.jsonObject(with: httpBody) as? [String: Any]
+        else { return nil }
+        return object["model"] as? String
+    }
+
+    private static let successLoadBody = Data(#"""
+        {
+          "id": "flux2-klein-4b",
+          "model_path": "Runware/FLUX.2-klein-4B",
+          "aliases": ["flux-klein"],
+          "modality": "image-gen",
+          "state": "resident",
+          "pinned": false,
+          "primary": false,
+          "active_requests": 0,
+          "estimated_bytes": 1000,
+          "measured_bytes": 500,
+          "idle_seconds": 0.0
+        }
+        """#.utf8)
+
     override func stopLoading() {}
 }
 
+/// ``.serialized`` because ``ResidentLoadRejectProtocol``'s configuration is
+/// process-wide singleton state (``URLProtocol`` cannot carry per-request
+/// config). Serializing the suite guarantees that tests which toggle the shared
+/// slot in opposite directions never race on it, and the ``defer { reset() }``
+/// in each test restores defaults so a failure mid-test cannot leak state
+/// forward (#1838 follow-up).
 @MainActor
-@Suite("Resident-load rejection feedback")
+@Suite("Resident-load rejection feedback", .serialized)
 struct ResidentLoadFeedbackTests {
     /// The core defect (#1838): the engine returns an actionable reason, the
     /// ``ServerResidencyClient`` maps it to ``.rejected(detail)``, but the
@@ -116,17 +167,14 @@ struct ResidentLoadFeedbackTests {
     /// log pane. This pins that ``ServerManager.ensureServing`` now publishes
     /// it so the initiating surface can show it.
     ///
-    /// The `lastResidentLoadFailure` property did not exist before this fix, so
-    /// this test does not merely fail — it does not compile against old `main`,
-    /// guaranteeing it cannot silently rot into a pass.
+    /// The per-alias ``residentLoadFailure(for:)`` lookup did not exist before
+    /// this fix, so this test does not merely fail — it does not compile
+    /// against old `main`, guaranteeing it cannot silently rot into a pass.
     @Test("A rejected resident load publishes the engine's reason")
     func publishesRejectedLoadFailure() async {
+        defer { ResidentLoadRejectProtocol.reset() }
         ResidentLoadRejectProtocol.rejectLoad = true
-        var client = ServerResidencyClient()
-        client.session = ResidentLoadRejectProtocol.session()
-        let server = ServerManager(testingState: .ready(alias: "qwen3.5-4b-4bit"))
-        server._testSetResidencyClient(client)
-        server._testInstallChild(ProcessGroupChild.testStub())
+        let server = makeServer()
 
         let ok = await server.ensureServing(
             alias: "flux2-klein-4b",
@@ -134,29 +182,66 @@ struct ResidentLoadFeedbackTests {
         )
 
         #expect(ok == false)
-        #expect(server.lastResidentLoadFailure?.alias == "flux2-klein-4b")
-        #expect(server.lastResidentLoadFailure?.message == ResidentLoadRejectProtocol.rejectionDetail)
+        #expect(server.residentLoadFailure(for: "flux2-klein-4b")?.alias == "flux2-klein-4b")
+        #expect(server.residentLoadFailure(for: "flux2-klein-4b")?.message == ResidentLoadRejectProtocol.rejectionDetail)
     }
 
     /// A successful in-process load clears any prior rejection, so the banner
     /// does not keep showing last round's failure once the model loads.
     @Test("A successful resident load clears a prior rejection")
     func successfulLoadClearsRejection() async {
+        defer { ResidentLoadRejectProtocol.reset() }
         // First a rejection (sets the published failure)…
         ResidentLoadRejectProtocol.rejectLoad = true
-        var client = ServerResidencyClient()
-        client.session = ResidentLoadRejectProtocol.session()
-        let server = ServerManager(testingState: .ready(alias: "qwen3.5-4b-4bit"))
-        server._testSetResidencyClient(client)
-        server._testInstallChild(ProcessGroupChild.testStub())
+        let server = makeServer()
 
         _ = await server.ensureServing(alias: "flux2-klein-4b", hfPath: nil)
-        #expect(server.lastResidentLoadFailure?.alias == "flux2-klein-4b")
+        #expect(server.residentLoadFailure(for: "flux2-klein-4b")?.alias == "flux2-klein-4b")
 
         // …then a successful load clears it.
         ResidentLoadRejectProtocol.rejectLoad = false
         let ok = await server.ensureServing(alias: "flux2-klein-4b", hfPath: nil)
         #expect(ok == true)
-        #expect(server.lastResidentLoadFailure == nil)
+        #expect(server.residentLoadFailure(for: "flux2-klein-4b") == nil)
+    }
+
+    /// The cross-talk regression from the earlier single-slot design (#1838
+    /// follow-up): a rejection for model B must NOT be cleared by model A
+    /// successfully loading, and a rejection for model A must not surface for
+    /// model B. Failures are keyed per alias, so concurrent/interleaved loads
+    /// of different models each keep their own outcome.
+    @Test("Rejections are independent per alias (no cross-talk)")
+    func rejectionsArePerAliasIndependent() async {
+        defer { ResidentLoadRejectProtocol.reset() }
+        // Only model A is rejected; model B and a second attempt at A that
+        // follows a different alias succeed. This holds even when A's load is
+        // still in flight conceptually, because each alias owns its key.
+        ResidentLoadRejectProtocol.rejectOnlyAlias = "flux2-klein-4b"
+        let server = makeServer()
+
+        // A is rejected → its failure is recorded.
+        let aResult = await server.ensureServing(alias: "flux2-klein-4b", hfPath: nil)
+        #expect(aResult == false)
+        #expect(server.residentLoadFailure(for: "flux2-klein-4b") != nil)
+
+        // B (a distinct model that takes the same in-process load path)
+        // succeeds → its own key stays clear AND it does not clear A.
+        let bResult = await server.ensureServing(alias: "llama-3.2-3b", hfPath: nil)
+        #expect(bResult == true)
+        #expect(server.residentLoadFailure(for: "llama-3.2-3b") == nil)
+        #expect(server.residentLoadFailure(for: "flux2-klein-4b") != nil,
+                "loading a different, succeeding model must not wipe A's rejection")
+    }
+
+    /// Build a ``ServerManager`` in the resident-ready state with the stub
+    /// transport and a stub child, so ``ensureServing`` takes the in-process
+    /// ``/v1/models/load`` path rather than the cold-start fallback.
+    private func makeServer() -> ServerManager {
+        var client = ServerResidencyClient()
+        client.session = ResidentLoadRejectProtocol.session()
+        let server = ServerManager(testingState: .ready(alias: "qwen3.5-4b-4bit"))
+        server._testSetResidencyClient(client)
+        server._testInstallChild(ProcessGroupChild.testStub())
+        return server
     }
 }

--- a/apps/rapid-mac/Tests/RapidTests/ResidentLoadFeedbackTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ResidentLoadFeedbackTests.swift
@@ -45,12 +45,26 @@ final class ResidentLoadRejectProtocol: URLProtocol, @unchecked Sendable {
     /// answer 200 (success).
     nonisolated(unsafe) static var rejectLoad = true
 
+    /// Controllable in-order gate for the same-alias concurrency test. When
+    /// ``gateAlias`` is set, the FIRST ``/v1/models/load`` whose target
+    /// matches it blocks in ``startLoading`` (on the URL loading thread, NOT
+    /// the main actor) until the test signals ``gateSemaphore``. Every later
+    /// load for that alias passes straight through. This lets a test make an
+    /// OLDER ``ensureServing`` attempt return AFTER a NEWER one, which the
+    /// per-alias ``residentLoadFailures`` dictionary alone cannot express.
+    nonisolated(unsafe) static var gateAlias: String?
+    nonisolated(unsafe) static var gateSemaphore: DispatchSemaphore?
+    nonisolated(unsafe) static var gateHasHeldOne = false
+
     /// Restore the defaults so one test can never observe another test's
     /// leftover configuration — the leak that made the previous global-slot
     /// tests flaky under parallel execution.
     static func reset() {
         rejectLoad = true
         rejectOnlyAlias = nil
+        gateAlias = nil
+        gateSemaphore = nil
+        gateHasHeldOne = false
     }
 
     static func session() -> URLSession {
@@ -67,6 +81,14 @@ final class ResidentLoadRejectProtocol: URLProtocol, @unchecked Sendable {
         let status: Int
         if request.httpMethod == "POST", request.url?.path == "/v1/models/load" {
             let requestedAlias = Self.alias(from: request)
+            // Hold only the FIRST load for the gated alias until the test
+            // releases it, so a second, newer attempt can complete while the
+            // first is still in flight — recreating the exact interleaving
+            // where an older attempt returns last (#1838 follow-up).
+            if let ga = Self.gateAlias, requestedAlias == ga, !Self.gateHasHeldOne {
+                Self.gateHasHeldOne = true
+                Self.gateSemaphore?.wait()
+            }
             if let rejectOnlyAlias = Self.rejectOnlyAlias {
                 if requestedAlias == rejectOnlyAlias {
                     status = 422
@@ -231,6 +253,106 @@ struct ResidentLoadFeedbackTests {
         #expect(server.residentLoadFailure(for: "llama-3.2-3b") == nil)
         #expect(server.residentLoadFailure(for: "flux2-klein-4b") != nil,
                 "loading a different, succeeding model must not wipe A's rejection")
+    }
+
+    /// The same-alias ordering guarantee the per-alias dictionary cannot
+    /// provide by itself. ``ensureServing`` is an ``@MainActor`` async method,
+    /// so two attempts for the SAME alias can interleave across the
+    /// ``await residencyClient.load`` hop: an attempt that STARTED earlier may
+    /// RETURN later. Without the per-alias attempt token, that older
+    /// rejection would overwrite the newer success and the UI would show an
+    /// expired failure even though the latest load succeeded.
+    ///
+    /// The stub's in-order gate holds the FIRST load for the alias in flight
+    /// (on the URL loading thread, never the main actor) while a second,
+    /// newer attempt completes first — reproducing exactly the interleaving
+    /// where latest-attempt-wins must hold.
+    @Test("An older rejection cannot clobber a newer success for the same alias")
+    func olderRejectionDoesNotClobberNewerSuccess() async throws {
+        defer { ResidentLoadRejectProtocol.reset() }
+        let server = makeServer()
+        let alias = "flux2-klein-4b"
+
+        let gate = DispatchSemaphore(value: 0)
+        ResidentLoadRejectProtocol.rejectLoad = true // older attempt, when released, rejects
+        ResidentLoadRejectProtocol.gateAlias = alias
+        ResidentLoadRejectProtocol.gateSemaphore = gate
+
+        // Attempt 1 (older): mints the first token, clears the failure, and
+        // blocks inside the load until the gate releases it.
+        let attempt1: Task<Bool, Never> = Task { @MainActor in
+            await server.ensureServing(alias: alias, hfPath: nil)
+        }
+        #expect(await pollUntil { ResidentLoadRejectProtocol.gateHasHeldOne },
+                "the first load never reached the gate")
+
+        // Attempt 2 (newer) succeeds and takes over the alias's slot.
+        ResidentLoadRejectProtocol.rejectLoad = false
+        let attempt2Result = await server.ensureServing(alias: alias, hfPath: nil)
+        #expect(attempt2Result == true)
+        #expect(server.residentLoadFailure(for: alias) == nil,
+                "the newer success leaves no rejection in its own slot")
+
+        // Release attempt 1 so it resumes as a REJECTION — but it is no
+        // longer the newest attempt, so its stale rejection must be ignored.
+        ResidentLoadRejectProtocol.rejectLoad = true
+        gate.signal()
+        let attempt1Result = await attempt1.value
+        #expect(attempt1Result == false)
+        #expect(server.residentLoadFailure(for: alias) == nil,
+                "an older attempt's rejection must not clobber the newer success")
+    }
+
+    /// The mirror image: an older attempt's SUCCESS must not clear a newer
+    /// attempt's rejection. The per-alias dictionary allows an old success to
+    /// wipe a fresh failure unless the return-time write is also guarded by
+    /// which attempt is newest (#1838 follow-up).
+    @Test("An older success cannot clear a newer rejection for the same alias")
+    func olderSuccessDoesNotClearNewerRejection() async throws {
+        defer { ResidentLoadRejectProtocol.reset() }
+        let server = makeServer()
+        let alias = "flux2-klein-4b"
+
+        let gate = DispatchSemaphore(value: 0)
+        ResidentLoadRejectProtocol.rejectLoad = false // older attempt, when released, succeeds
+        ResidentLoadRejectProtocol.gateAlias = alias
+        ResidentLoadRejectProtocol.gateSemaphore = gate
+
+        let attempt1: Task<Bool, Never> = Task { @MainActor in
+            await server.ensureServing(alias: alias, hfPath: nil)
+        }
+        #expect(await pollUntil { ResidentLoadRejectProtocol.gateHasHeldOne },
+                "the first load never reached the gate")
+
+        // Attempt 2 (newer) is rejected and takes over the alias's slot.
+        ResidentLoadRejectProtocol.rejectLoad = true
+        let attempt2Result = await server.ensureServing(alias: alias, hfPath: nil)
+        #expect(attempt2Result == false)
+        #expect(server.residentLoadFailure(for: alias) != nil,
+                "the newer rejection is recorded")
+
+        // Release attempt 1 so it resumes as SUCCESS — but it is not newest,
+        // so its success must not wipe the newer rejection.
+        ResidentLoadRejectProtocol.rejectLoad = false
+        gate.signal()
+        let attempt1Result = await attempt1.value
+        #expect(attempt1Result == true)
+        #expect(server.residentLoadFailure(for: alias) != nil,
+                "an older attempt's success must not clear the newer rejection")
+    }
+
+    /// Poll a condition while yielding the main actor, bounded so a stuck
+    /// condition fails the test rather than hanging it.
+    private func pollUntil(
+        _ condition: @escaping () -> Bool,
+        timeout: TimeInterval = 3
+    ) async -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if condition() { return true }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        return condition()
     }
 
     /// Build a ``ServerManager`` in the resident-ready state with the stub

--- a/apps/rapid-mac/scripts/fake-rapid-mlx.sh
+++ b/apps/rapid-mac/scripts/fake-rapid-mlx.sh
@@ -258,6 +258,21 @@ def _tool_call_delta(call_id):
 FAKE_IMAGE_ALIAS = "fake-image-alias"
 FAKE_IMAGE_REPO = "fake-org/fake-image-repo"
 
+# The alias currently being served by THIS process. Set in ``main`` for the
+# ``serve`` branch so the ``/v1/models/residency`` snapshot can report a
+# resident model — which is what keeps ``ServerManager`` on the in-process
+# ``/v1/models/load`` path instead of the legacy stop/start fallback when the
+# GUI asks for a second model while the sidecar is already running (#1838).
+SERVED_ALIAS = ""
+
+# The engine's own, actionable rejection reason. Kept out of the snapshot so a
+# stock persona never changes residency shape; a flow opts in with
+# ``FAKE_REJECT_IMAGE_LOAD=1`` to exercise the rejected non-404/405 load path.
+FAKE_REJECTION_DETAIL = (
+    "image generation requires the 'rapid-mlx[image]' Python extra "
+    "(pip install 'rapid-mlx[image]')"
+)
+
 
 def _one_pixel_png(rgb):
     """A real, decodable 1x1 truecolour PNG."""
@@ -364,6 +379,9 @@ class Handler(BaseHTTPRequestHandler):
                 ]
             })
             return
+        if self.path == "/v1/models/residency":
+            self._json(200, self._residency_snapshot())
+            return
         if self.path == "/v1/images/progress":
             # Polled every few hundred ms while a render is in flight. Answer
             # it even when nothing is running: the client treats a transport
@@ -371,6 +389,84 @@ class Handler(BaseHTTPRequestHandler):
             # indistinguishable from the daemon being down.
             self._json(200, RENDERS.snapshot())
             return
+        self._json(404, {"error": "not_found"})
+
+    def _residency_snapshot(self):
+        """``GET /v1/models/residency`` — the served alias as the sole
+        resident model. This is what makes ``ServerManager`` take the
+        in-process ``/v1/models/load`` path when the user asks for a second
+        model while the sidecar is already up (#1838)."""
+        if not SERVED_ALIAS:
+            return {
+                "memory_limit_bytes": 0,
+                "memory_used_bytes": 0,
+                "memory_available_bytes": 0,
+                "idle_ttl_seconds": 1800,
+                "loads_total": 0,
+                "evictions_total": 0,
+                "models": [],
+            }
+        return {
+            "memory_limit_bytes": 34359738368,
+            "memory_used_bytes": 10737418240,
+            "memory_available_bytes": 23622320128,
+            "idle_ttl_seconds": 1800,
+            "loads_total": 1,
+            "evictions_total": 0,
+            "models": [{
+                "id": SERVED_ALIAS,
+                "model_path": "fake-org/fake-repo",
+                "aliases": [SERVED_ALIAS],
+                "modality": "text",
+                "state": "resident",
+                "pinned": True,
+                "primary": True,
+                "active_requests": 0,
+                "estimated_bytes": 1,
+                "measured_bytes": None,
+                "idle_seconds": 0.0,
+            }],
+        }
+
+    def _models_load(self):
+        """``POST /v1/models/load`` — the in-process residency load the GUI
+        uses to admit a second engine while the sidecar is already running.
+
+        This is where #1838's silent-failure scenario lives: when the engine
+        cannot serve the requested model (e.g. a stock bundle with no
+        ``[image]`` extra), ``load`` must be answered with a non-2xx,
+        non-404/405 response whose ``detail`` carries the actionable reason.
+        ``ServerManager`` maps that to ``.rejected(detail)`` and, after this
+        fix, publishes it so the initiating surface shows it instead of
+        dropping it into the log.
+
+        The flow opts into the rejection with ``FAKE_REJECT_IMAGE_LOAD=1``;
+        every other persona keeps the legacy 404 (unsupported) path so their
+        stop/start fallback is unchanged.
+        """
+        length = int(self.headers.get("content-length", "0") or "0")
+        body = {}
+        if length:
+            try:
+                body = json.loads(self.rfile.read(length))
+            except (json.JSONDecodeError, UnicodeDecodeError):
+                body = {}
+        target = body.get("model") if isinstance(body.get("model"), str) else ""
+        _event("model_load", alias=target)
+        if _setting("FAKE_REJECT_IMAGE_LOAD") == "1" and target == FAKE_IMAGE_ALIAS:
+            # The engine refuses to admit this model (missing Python extra).
+            # Mirror the real server's rejection envelope so
+            # ``ServerResidencyClient.load`` lands on ``.rejected(detail)``.
+            _event("model_load_rejected", alias=target)
+            self._json(422, {"detail": FAKE_REJECTION_DETAIL})
+            return
+        if target == SERVED_ALIAS:
+            # Already resident — idempotent success.
+            self._json(200, self._residency_snapshot()["models"][0])
+            return
+        # Unknown target → the legacy 404 the app treats as "no residency
+        # support here", falling back to its stop/start path. Preserves the
+        # behaviour every other persona depends on.
         self._json(404, {"error": "not_found"})
 
     def _images_generate(self):
@@ -433,6 +529,9 @@ class Handler(BaseHTTPRequestHandler):
         )
 
     def do_POST(self):
+        if self.path == "/v1/models/load":
+            self._models_load()
+            return
         if self.path == "/v1/images/generations":
             self._images_generate()
             return
@@ -688,6 +787,13 @@ def main():
         _emit_catalog(args.subcommand, args.alias)
         sys.exit(0)
 
+    # The residency snapshot reports the served alias as resident, which is
+    # what keeps the GUI on the in-process /v1/models/load path (#1838).
+    # The assignment must use ``global``: the handler methods read the
+    # module-level name, and without ``global`` this would only create a local
+    # that shadows it, leaving the snapshot permanently empty.
+    global SERVED_ALIAS
+    SERVED_ALIAS = args.alias
     _event("server_started", alias=args.alias, pid=os.getpid(), port=args.port)
 
     # Match the real server's startup banner shape closely enough

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -100,7 +100,7 @@ flow_requires_screen_recording() {
 flow_requires_peekaboo() {
     case "$FLOW" in
         cached-quickstart|download-progress|settings-persistence|chat-restore|restored-tools|tool-loop-budget|chat-depth|math-rendering) return 1 ;;
-        slow-stream-stop|model-crash-recovery|image-generation|window-close-prompt) return 1 ;;
+        slow-stream-stop|model-crash-recovery|image-generation|window-close-prompt|resident-load-rejected) return 1 ;;
         *) return 0 ;;
     esac
 }
@@ -2326,6 +2326,68 @@ flow_image_generation() {
     baseline image-generation.generated "$OUT/ig-revisited.json"
     log "  image-generation OK"
 }
+flow_resident_load_rejected() {
+    start_persona resident-load-rejected FAKE_REJECT_IMAGE_LOAD=1
+
+    dismiss_first_run
+
+    # 1. Bring the CHAT model up first so the sidecar is running and the served
+    #    alias is resident - the precondition for the in-process load.
+    wait_identifier Readiness.Action "$OUT/rlr-chat-readiness.json" \
+        || die "no chat readiness action to bring the resident chat model up"
+    press "$OUT/rlr-chat-readiness.json" Readiness.Action "$OUT/rlr-chat-start.json" \
+        || die "chat Readiness.Action is not pressable - could not start the resident chat model"
+    # Match the ALIAS, not merely "a server started": the fake must be serving
+    # the chat alias so the residency snapshot reports it resident.
+    wait_fake_event \
+        ".event == \"server_started\" and .alias == \"$FAKE_ALIAS\"" \
+        "the chat model never started - no resident sidecar to reject against"
+    # Let the app observe residency so the Images load takes the in-process path.
+    sleep 1
+
+    # 2. Go to Images and ask it to load its model.
+    see_main "$OUT/rlr-ig-chat.json"
+    press "$OUT/rlr-ig-chat.json" Sidebar.Images "$OUT/rlr-ig-open.json" \
+        || die "Sidebar.Images is not pressable - the Images tab is unreachable"
+    wait_identifier Images.EmptyState "$OUT/rlr-ig-empty.json"
+
+    # 3. The readiness action routes through ensureServing and hits the
+    #    in-process /v1/models/load endpoint, not a process restart.
+    wait_identifier Readiness.Action "$OUT/rlr-ig-readiness.json" \
+        || die "Images readiness has no action to load its model"
+    press "$OUT/rlr-ig-readiness.json" Readiness.Action "$OUT/rlr-ig-start.json" \
+        || die "Images Readiness.Action is not pressable - the load button is dead"
+
+    # 4. The wire must show the load was ATTEMPTED in-process and REJECTED.
+    wait_fake_event '.event == "model_load"' \
+        "the Images action never issued an in-process /v1/models/load"
+    wait_fake_event '.event == "model_load_rejected"' \
+        "the fake did not reject the in-process image load (FAKE_REJECT_IMAGE_LOAD not applied)"
+
+    # 5. The rejection's actionable reason must be VISIBLE on the Images
+    #    surface (the readiness banner), not only in the log drawer.
+    local i shown=0
+    for ((i=0; i<80; i++)); do
+        see_main "$OUT/rlr-shown.json"
+        if jq -e '[.data.ui_elements[]?]
+                  | map((.title // "") + " " + (.value // "") + " " + (.description // "") + " " + (.help // ""))
+                  | join(" ") | test("rapid-mlx\\[image\\]")' \
+               "$OUT/rlr-shown.json" >/dev/null 2>&1; then
+            shown=1; break
+        fi
+        sleep 0.25
+    done
+    [[ "$shown" == 1 ]] \
+        || die "the engine's rejection reason never appeared on the Images surface - it was swallowed into the log (#1838)"
+
+    # 6. The surface offers a recovery action, not a dead button.
+    jq -e '.data.ui_elements[]? | select(.identifier == "Readiness.Action")' \
+        "$OUT/rlr-shown.json" >/dev/null \
+        || die "the Images readiness banner did not offer a recovery action after the rejection"
+
+    log "  resident-load-rejected OK"
+}
+
 
 if [[ -d "$OUT_ROOT" && -n "$(ls -A "$OUT_ROOT" 2>/dev/null)" ]]; then
     RESULT_WRITTEN=1
@@ -2352,6 +2414,7 @@ case "$FLOW" in
     catalog-integrity) flow_catalog_integrity ;;
     browse-all-destination) flow_browse_all_destination ;;
     image-generation) flow_image_generation ;;
+    resident-load-rejected) flow_resident_load_rejected ;;
     all)
         flow_fresh_install
         flow_cached_quickstart
@@ -2371,6 +2434,7 @@ case "$FLOW" in
         flow_catalog_integrity
         flow_browse_all_destination
         flow_image_generation
+        flow_resident_load_rejected
         ;;
     *) die "unknown flow: $FLOW" ;;
 esac

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -2406,7 +2406,7 @@ flow_resident_load_rejected() {
     for ((i=0; i<80; i++)); do
         see_main "$OUT/rlr-shown.json"
         if jq -e '[.data.ui_elements[]?]
-                  | map((.title // "") + " " + (.value // "") + " " + (.description // "") + " " + (.help // ""))
+                  | map(((.title // "") | tostring) + " " + ((.value // "") | tostring) + " " + ((.description // "") | tostring) + " " + ((.help // "") | tostring))
                   | join(" ") | test("rapid-mlx\\[image\\]")' \
                "$OUT/rlr-shown.json" >/dev/null 2>&1; then
             shown=1; break

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -2351,6 +2351,33 @@ flow_resident_load_rejected() {
         || die "Sidebar.Images is not pressable - the Images tab is unreachable"
     wait_identifier Images.EmptyState "$OUT/rlr-ig-empty.json"
 
+    # 2.5 The picker must resolve to the image model BEFORE we press the
+    #     readiness action. ``refreshCatalog`` shells out to ``rapid-mlx
+    #     models`` and ``ls`` from a `.task`, so the tab renders with an
+    #     unresolved picker ("Choose a model") for as long as those two
+    #     subprocesses take; while unresolved, ``selectedAlias`` is empty and
+    #     readiness resolves to ``.noModel``, whose action is ``.chooseModel``
+    #     and renders NO ``Readiness.Action`` -- or, mid-window, a button whose
+    #     load does not name the image model. Pressing too early therefore
+    #     falls out of the resident ``/v1/models/load`` path entirely and the
+    #     rejection never reaches the wire. ``image-generation`` does the same
+    #     wait for the same reason; mirror it so this flow's press is
+    #     deterministic (#1838).
+    local i resolved=0
+    for ((i=0; i<80; i++)); do
+        see_main "$OUT/rlr-ig-empty.json"
+        if jq -e --arg alias "$FAKE_IMAGE_ALIAS" \
+               '.data.ui_elements[]? | select(.identifier == "Images.ModelPicker")
+                | select((.help // "") | contains($alias))' "$OUT/rlr-ig-empty.json" >/dev/null; then
+            resolved=1; break
+        fi
+        sleep 0.25
+    done
+    [[ "$resolved" == 1 ]] \
+        || die "Images.ModelPicker never resolved to $FAKE_IMAGE_ALIAS - the Images tab has no model to load"
+    jq -e '.data.ui_elements[]? | select(.identifier == "Images.Aspect")' "$OUT/rlr-ig-empty.json" >/dev/null \
+        || die "Images.Aspect is missing - the picker did not finish resolving"
+
     # 3. The readiness action routes through ensureServing and hits the
     #    in-process /v1/models/load endpoint, not a process restart.
     wait_identifier Readiness.Action "$OUT/rlr-ig-readiness.json" \

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -2342,8 +2342,17 @@ flow_resident_load_rejected() {
     wait_fake_event \
         ".event == \"server_started\" and .alias == \"$FAKE_ALIAS\"" \
         "the chat model never started - no resident sidecar to reject against"
-    # Let the app observe residency so the Images load takes the in-process path.
-    sleep 1
+    # The chat sidecar must actually reach .ready (with a child) in the app's
+    # state machine BEFORE the Images load: ``ensureServing`` only takes the
+    # in-process ``/v1/models/load`` path when ``readyWithChild`` is true, i.e.
+    # when the chat model is already residing in this process. Bare
+    # ``server_started`` only proves the fake bound its port; if we press
+    # Images readiness while the chat model is still ``.starting``, the app
+    # falls back to replacing the child process (a cold start) and the
+    # rejection never reaches the wire (#1838). ``wait_send_idle`` blocks
+    # until the ChatView readiness gate opens, which is exactly the app's
+    # story that ``state == .ready``.
+    wait_send_idle "$OUT/rlr-chat-ready.json"
 
     # 2. Go to Images and ask it to load its model.
     see_main "$OUT/rlr-ig-chat.json"

--- a/tests/test_gui_preflight_contract.py
+++ b/tests/test_gui_preflight_contract.py
@@ -100,6 +100,7 @@ def test_peekaboo_requirement_is_default_deny():
         "model-crash-recovery",
         "image-generation",
         "window-close-prompt",
+        "resident-load-rejected",
     }
     named = {
         flow


### PR DESCRIPTION
## Summary

Closes #1838. A resident-model load that the engine **rejects** currently produces **no feedback on the surface that triggered it**: the Images banner/composer/model-picker sit unchanged and the button looks dead. Because the sidecar is already running, `ensureServing` takes the in-process `/v1/models/load` path (no process restart), so there is no visible activity either.

The engine's actionable reason is preserved verbatim all the way to `.rejected(detail)` — it's just dropped before it can reach the UI, landing only in the log pane the user is never pointed to.

### Root cause

```
ReadinessModelStart.perform  →  _ = await server.ensureServing(alias:, hfPath:)
                                           │
ServerManager.ensureServing ── .rejected(detail)
  • appends "Resident model load declined: …" to logLines
  • returns false
  • ● result discarded by the caller, never observed by ImagesView/ContentView
```

- `ServerResidency.swift` → non-2xx/non-404/405 response maps to `.rejected(detail)` (the engine's own message).
- `ServerManager.ensureServing` → `.rejected` only wrote to the log.
- `ReadinessModelStart.perform` → discarded the result.
- `ImagesView` / `ContentView` → never observed failure.

### Fix

Publish the rejection so the surface that initiated the load can present it:

- **`ServerResidency.swift`**: new `ResidentLoadFailure { alias, message }`.
- **`ServerManager.swift`**: new `@Observable` `residentLoadFailures` (per-alias dictionary) plus a per-alias attempt token, so a rejection is published to the initiating surface while remaining robust under concurrency:
  - **per-alias**: `residentLoadFailure(for:)` is keyed by the alias that failed, so concurrent loads of *different* models cannot clobber each other's outcome;
  - **latest-attempt-wins (same alias)**: each `ensureServing` mints a per-alias attempt token; when its async load returns it may write/clear the failure only if it is still the newest attempt, so an older attempt that returns last cannot overwrite a newer success (or an old success wipe a newer rejection);
  - a fresh load attempt clears any prior rejection up front, so a stale rejection never outlives the next load, and it is scrubbed like the log before reaching the UI.
- **`ContentView.swift` / `ImagesView.swift`**: render it in the readiness banner, scoped to the alias that actually failed (`.ready`/`.starting`/`.downloading` still outrank a stale rejection, and `failureApplies` keeps it pinned to the failed model).

Net effect: the engine's reason — e.g.

> image generation requires the 'rapid-mlx[image]' Python extra (pip install 'rapid-mlx[image]')

— is shown on the Images banner as an actionable, recoverable message instead of a silent no-op.

### Regression protection

- **New unit tests** — `ResidentLoadFeedbackTests.swift` (serialized suite with process-wide-stub cleanup):
  - a rejected resident load publishes the engine's reason, keyed per alias;
  - a successful load clears a prior rejection;
  - rejections are independent per alias — loading a different, succeeding model does not wipe another model's rejection;
  - **older rejection cannot clobber a newer success** and **older success cannot clear a newer rejection** for the *same* alias (via an in-order gate in the stub that holds the first load in flight so the older attempt returns last — the two directions of latest-attempt-wins).
  Uses a `URLProtocol` stub standing in for the sidecar's in-process residency/load endpoints, so it exercises the real `ServerResidencyClient.load → .rejected` path without a live sidecar. The `residentLoadFailure(for:)` API did not exist on old `main`, so the tests cannot silently rot into a pass.
- **GoldenFlow** — `resident-load-rejected` in `gui-golden-flows.sh`, wired into CI: starts the fake chat sidecar, asks Images to load a model, proves the in-process `/v1/models/load` was attempted and rejected, then asserts the engine's reason actually appears on the Images surface (AX tree) and the banner still offers a recovery action. It waits for the Images model picker to resolve before pressing the readiness action (same sync the `image-generation` flow uses) so the press is deterministic.
- **Fake sidecar** — `fake-rapid-mlx.sh` now serves `/v1/models/residency` + `/v1/models/load` and, with `FAKE_REJECT_IMAGE_LOAD=1`, rejects `fake-image-alias` with the engine's real 422 detail so the flow drives the exact #1838 path.

### Notes on test environment

Swift tests (`RapidTests`) need the **full-Xcode CI runner (macos-15)**; the local machine has only Command Line Tools, which cannot resolve `import Testing` — a pre-existing environment limitation (all existing test targets fail the same way). `swift build --target Rapid` passes locally; the test + GoldenFlow suites run in CI.

This addresses only the feedback surfaced on load rejection (#1838). Gating the Images entry point / bundling the `[image]` extra is tracked separately in #1840.
