### PR TITLE
fix(mllm): exempt text-only prompts from prefill cap and surface stream errors (#1848, #1849)

### DIFF
--- a/tests/test_chat_route_vlm_image.py
+++ b/tests/test_chat_route_vlm_image.py
@@ -240,7 +240,7 @@ def test_chat_route_maps_per_batch_cap_error_to_http_400():
     """
     engine = _StubMLLMEngine(
         raise_msg=(
-            "Total prompt tokens (2292) exceeds the per-batch cap "
+            "Vision-request prompt tokens (2292) exceeds the per-batch cap "
             "(2048 for 1 request(s)). For image inputs, downscale the "
             "image; for text inputs, shorten the prompt or restart "
             "the server with --prefill-step-size set higher."

--- a/tests/test_mllm_batch_generator.py
+++ b/tests/test_mllm_batch_generator.py
@@ -1640,3 +1640,32 @@ def test_process_prompts_does_not_cap_large_text_only_prompt(monkeypatch):
         f"a 20k-token text-only prompt must pass the cap (then fail on the "
         f"bare-model prefill), but got the cap error: {err_msg}"
     )
+
+
+def test_prefill_cap_exempts_batch_of_long_text_only_prompts():
+    """A batch of MANY long text-only prompts must not trip the cap (#1848).
+
+    Concurrency concern raised in review: with text-only now exempt, several
+    >8k text prompts can batch together. Even though each is prefilled in
+    chunks, they all still need full KV at cache-merge time, so we must not
+    accidentally re-introduce a rejection for multi-long-text batches. The
+    cap is vision-only by design; an all-text-only batch (any count, any
+    length) must never violate it (#1848 / #682 contract preserved).
+    """
+    from vllm_mlx.mllm_batch_generator import _prefill_cap_violation
+
+    # 4 concurrent long text-only prompts, all > prefill_step_size.
+    batch = [_text_request(uid=i, token_count=20000) for i in range(4)]
+    assert _prefill_cap_violation(batch, prefill_step_size=8192) is None, (
+        "a batch of multiple 20k-token text-only prompts must stay exempt "
+        "from the vision-only per-batch cap (no DNF / no cap rejection)"
+    )
+
+    # And when one long VISION request joins them, the cap correctly fires
+    # only because of the vision request, not the text ones.
+    mixed = [_text_request(uid=i, token_count=20000) for i in range(3)]
+    mixed.append(_make_vision_cap_request(uid=3, token_count=10000))
+    assert _prefill_cap_violation(mixed, prefill_step_size=8192) is not None, (
+        "a 10k-token vision request among long text-only peers must still "
+        "trip the cap (#682 preserved)"
+    )

--- a/tests/test_mllm_batch_generator.py
+++ b/tests/test_mllm_batch_generator.py
@@ -1138,8 +1138,10 @@ def test_per_batch_cap_fires_on_oversized_batch_with_actionable_message(
     gen = _gen_with_prefill_cap(prefill_step_size=100)
     monkeypatch.setattr(gen, "_preprocess_request", lambda req: None)
 
-    # 500-token request, cap = 100 × 1 = 100 ⇒ 500 > 100 ⇒ raises.
-    request = _make_cap_request(uid=0, token_count=500)
+    # 500-token VISION request, cap = 100 × 1 = 100 ⇒ 500 > 100 ⇒ raises.
+    # (Text-only requests are exempt from the cap since #1848, so the cap
+    #  guard is pinned against a vision-bearing request.)
+    request = _make_vision_cap_request(uid=0, token_count=500)
 
     with pytest.raises(ValueError) as excinfo:
         MLLMBatchGenerator._process_prompts(gen, [request])
@@ -1174,8 +1176,9 @@ def test_per_batch_cap_does_not_fail_at_default_on_typical_screenshot(
     gen = _gen_with_prefill_cap(prefill_step_size=8192)
     monkeypatch.setattr(gen, "_preprocess_request", lambda req: None)
 
-    # 2292 tokens — typical Qwen3-VL token count for a 1920×1080 image.
-    request = _make_cap_request(uid=0, token_count=2292)
+    # 2292 tokens — typical Qwen3-VL token count for a 1920×1080 image,
+    # carried on a vision-bearing request (this is an image prompt).
+    request = _make_vision_cap_request(uid=0, token_count=2292)
 
     # The function will still raise SOMETHING downstream (we handed it
     # bare ``object()`` for model / language_model so the real prefill
@@ -1536,3 +1539,104 @@ def test_preprocess_request_no_key_for_unsupported_model(monkeypatch):
     )
     gen._preprocess_request(req)
     assert req.vision_feature_key is None
+
+
+# --------------------------------------------------------------------------- #
+# #1848 — a text-only prompt larger than ``prefill_step_size`` must not trip
+# the per-batch cap. The cap exists to bound vision-merge memory (#682);
+# text-only prompts are prefilled in chunks on the vision-encoding path and
+# contribute no vision tokens, so they are exempt.
+# --------------------------------------------------------------------------- #
+def _make_vision_cap_request(uid: int, token_count: int) -> MLLMBatchRequest:
+    """Like ``_make_cap_request`` but with a non-None ``pixel_values`` so it
+    counts as a vision-bearing request for the per-batch cap."""
+    req = _make_cap_request(uid=uid, token_count=token_count)
+    req.pixel_values = mx.zeros((1, 3, 32, 32), dtype=mx.float32)
+    req.image_grid_thw = mx.array([[2, 2, 1]], dtype=mx.int32)
+    return req
+
+
+def _text_request(uid: int, token_count: int) -> MLLMBatchRequest:
+    """A plain text-only request (no pixel values / grid)."""
+    return _make_cap_request(uid=uid, token_count=token_count)
+
+
+def test_prefill_cap_exempts_large_text_only_prompt():
+    """A >8k text-only prompt must NOT trip the per-batch cap (#1848).
+
+    Pre-fix the inline check used ``prefill_step_size * len(requests)`` and
+    rejected any single prompt longer than ``prefill_step_size`` (default
+    8192), even though the chunked text-only prefill path could handle it.
+    This is the regression the issue's DNF reported.
+    """
+    from vllm_mlx.mllm_batch_generator import _prefill_cap_violation
+
+    req = _text_request(uid=0, token_count=20000)
+    assert _prefill_cap_violation([req], prefill_step_size=8192) is None, (
+        "a 20k-token text-only prompt must be exempt from the per-batch cap "
+        "(it is prefilled in chunks and contributes no vision tokens)"
+    )
+
+
+def test_prefill_cap_still_fires_on_large_vision_request():
+    """The cap must STILL bound vision-merge memory: an image request whose
+    (text + vision) token count exceeds ``prefill_step_size × n_vision`` is
+    rejected with the actionable message (#682 preserved).
+    """
+    from vllm_mlx.mllm_batch_generator import _prefill_cap_violation
+
+    req = _make_vision_cap_request(uid=0, token_count=20000)
+    msg = _prefill_cap_violation([req], prefill_step_size=8192)
+    assert msg is not None, "a 20k-token vision request must trip the cap"
+    assert "exceeds the per-batch cap" in msg
+    assert "downscale the image" in msg
+
+
+def test_prefill_cap_counts_only_vision_requests_in_budget():
+    """In a mixed batch the cap budget scales with the number of *vision*
+    requests; text-only requests are exempt and do not inflate the multiplier
+    (#1848).
+    """
+    from vllm_mlx.mllm_batch_generator import _prefill_cap_violation
+
+    # 1 vision request + 1 huge text-only request, cap = 8192 × 1 vision.
+    batch = [
+        _make_vision_cap_request(uid=0, token_count=8000),  # under vision cap
+        _text_request(uid=1, token_count=9000),  # exempt, > 8192
+    ]
+    assert _prefill_cap_violation(batch, prefill_step_size=8192) is None, (
+        "the text-only request must not push the vision budget over the cap"
+    )
+
+    # Same batch but now the vision request itself exceeds the cap.
+    batch = [
+        _make_vision_cap_request(uid=0, token_count=10000),  # exceeds 8192
+        _text_request(uid=1, token_count=9000),
+    ]
+    assert _prefill_cap_violation(batch, prefill_step_size=8192) is not None, (
+        "a vision request over the cap must still trip the cap in a mixed batch"
+    )
+
+
+def test_process_prompts_does_not_cap_large_text_only_prompt(monkeypatch):
+    """End-to-end pin of the #1848 DNF through ``_process_prompts``.
+
+    With the production MLLM default ``prefill_step_size=8192``, a single
+    20000-token TEXT-ONLY prompt must NOT trip the per-batch cap. Pre-fix
+    this raised ValueError("exceeds the per-batch cap") and the request
+    DNF'd. It will still fail downstream (bare ``object()`` model cannot
+    actually prefill), but that failure must NOT be the cap error.
+    """
+    gen = _gen_with_prefill_cap(prefill_step_size=8192)
+    monkeypatch.setattr(gen, "_preprocess_request", lambda req: None)
+
+    request = _text_request(uid=0, token_count=20000)
+
+    with pytest.raises(Exception) as excinfo:  # noqa: BLE001 — see below
+        MLLMBatchGenerator._process_prompts(gen, [request])
+
+    err_msg = str(excinfo.value)
+    assert "exceeds the per-batch cap" not in err_msg, (
+        f"a 20k-token text-only prompt must pass the cap (then fail on the "
+        f"bare-model prefill), but got the cap error: {err_msg}"
+    )

--- a/tests/test_sse_keepalive.py
+++ b/tests/test_sse_keepalive.py
@@ -615,7 +615,7 @@ def test_disconnect_guard_surfaces_client_actionable_error_message():
     async def _generator():
         yield 'data: {"role":"assistant"}\n\n'
         raise ValueError(
-            "Total prompt tokens (20000) exceeds the per-batch cap "
+            "Vision-request prompt tokens (20000) exceeds the per-batch cap "
             "(8192 = prefill_step_size 8192 × 1 vision request(s)). "
             "For image inputs, downscale the image."
         )

--- a/tests/test_sse_keepalive.py
+++ b/tests/test_sse_keepalive.py
@@ -578,3 +578,82 @@ def test_disconnect_guard_keepalive_does_not_break_disconnect_detection():
     # We may have emitted a few keepalives before the disconnect, but
     # NOT the forever-stalled real chunk.
     assert "data: never\n\n" not in chunks
+
+
+# --------------------------------------------------------------------------- #
+# #1849 — a mid-stream client-actionable rejection (e.g. the MLLM per-batch
+# prefill cap, or a failed image/video fetch) must surface its REAL message
+# in the SSE error frame, not be swallowed into the generic
+# "Internal error during streaming" 200 envelope.
+# --------------------------------------------------------------------------- #
+def _collect_disconnect_guard_chunks(generator):
+    from vllm_mlx.service.helpers import _disconnect_guard
+
+    class _FakeRequest:
+        async def is_disconnected(self) -> bool:
+            return False
+
+    async def _run():
+        out = []
+        async for chunk in _disconnect_guard(
+            generator, _FakeRequest(), keepalive_seconds=60.0
+        ):
+            out.append(chunk)
+        return out
+
+    return asyncio.run(_run())
+
+
+def test_disconnect_guard_surfaces_client_actionable_error_message():
+    """#1849: the MLLM per-batch cap rejection (a client-correctable error)
+    must reach the caller with its real, actionable message and an
+    ``invalid_request_error`` type — NOT be masked into the generic
+    "Internal error during streaming". Pre-fix the F-131 sanitisation
+    swallowed it into a misleading 200 with a generic message.
+    """
+
+    async def _generator():
+        yield 'data: {"role":"assistant"}\n\n'
+        raise ValueError(
+            "Total prompt tokens (20000) exceeds the per-batch cap "
+            "(8192 = prefill_step_size 8192 × 1 vision request(s)). "
+            "For image inputs, downscale the image."
+        )
+
+    chunks = _collect_disconnect_guard_chunks(_generator())
+    error_frames = [c for c in chunks if '"error"' in c]
+    assert error_frames, f"expected an SSE error frame; got chunks={chunks!r}"
+    payload = json.loads(error_frames[-1].replace("data: ", "", 1).strip())
+    err = payload["error"]
+    assert err["type"] == "invalid_request_error", (
+        f"client-actionable error must carry type=invalid_request_error, got {err!r}"
+    )
+    assert "exceeds the per-batch cap" in err["message"], (
+        f"real, actionable message must be preserved; got {err['message']!r}"
+    )
+    assert "Internal error during streaming" not in err["message"]
+    # The stream terminates with [DONE].
+    assert "data: [DONE]\n\n" in chunks
+
+
+def test_disconnect_guard_still_masks_genuine_engine_fault():
+    """F-131 sanitisation must be preserved: a genuine engine fault (a raw
+    Python exception that is NOT a client-actionable marker) still surfaces
+    as the generic ``internal_error`` envelope — never leaking the raw
+    Python type name / message through the SSE payload.
+    """
+
+    async def _generator():
+        yield 'data: {"role":"assistant"}\n\n'
+        raise RuntimeError("TextEncodeInput must be str or List[str]")
+
+    chunks = _collect_disconnect_guard_chunks(_generator())
+    error_frames = [c for c in chunks if '"error"' in c]
+    assert error_frames, f"expected an SSE error frame; got chunks={chunks!r}"
+    payload = json.loads(error_frames[-1].replace("data: ", "", 1).strip())
+    err = payload["error"]
+    assert err["type"] == "internal_error"
+    assert err["message"] == "Internal error during streaming"
+    assert "TextEncodeInput" not in err["message"], (
+        f"raw Python exception detail must not leak; got {err['message']!r}"
+    )

--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -174,7 +174,7 @@ def _prefill_cap_violation(requests, prefill_step_size: int):
     max_batch_tokens = prefill_step_size * num_vision
     if vision_tokens > max_batch_tokens:
         return (
-            f"Total prompt tokens ({vision_tokens}) exceeds the "
+            f"Vision-request prompt tokens ({vision_tokens}) exceeds the "
             f"per-batch cap ({max_batch_tokens} = prefill_step_size "
             f"{prefill_step_size} × {num_vision} vision request(s)). "
             f"For image inputs, downscale the image; for text inputs, "

--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -127,6 +127,63 @@ def _attention_mask_is_droppable(mask) -> bool:
     return bool(mx.all(mask != 0))
 
 
+def _is_text_only_request(request: "MLLMBatchRequest") -> bool:
+    """Whether ``request`` carries no vision payload at all.
+
+    A text-only request has ``pixel_values is None`` and
+    ``image_grid_thw is None`` after ``_preprocess_request`` (there are no
+    images/videos, so no vision tokens are produced). Such a request does
+    *not* consume per-forward vision-token memory and is safely prefilled
+    on the chunked text-only path (``_run_vision_encoding``), so it is
+    exempt from the per-batch cap that exists purely to bound vision-merge
+    memory (#682 / #1848).
+    """
+    return request.pixel_values is None and request.image_grid_thw is None
+
+
+def _prefill_cap_violation(requests, prefill_step_size: int):
+    """Return the "exceeds the per-batch cap" error message when a batch of
+    requests violates the per-batch prefill cap, else ``None``.
+
+    The cap (issue #682) exists to bound merge-time memory for *vision*
+    prompts: each image request can embed thousands of vision-patch tokens
+    into the prompt, so a batch of them can blow past a single forward.
+    Text-only requests (``_is_text_only_request``) are prefilled in chunks
+    and do not contribute vision tokens, so only vision-bearing requests
+    count toward the cap, and their aggregate token count is compared
+    against ``prefill_step_size × num_vision`` (#1848). A batch with no
+    vision requests can never violate the cap.
+
+    The returned string MUST keep the ``exceeds the per-batch cap`` phrase:
+    ``MLLMScheduler._step_no_queue`` matches on it to classify the error as
+    client-actionable (#682) and ``routes/chat.py`` maps it to HTTP 400 with
+    the actionable message. If the phrase ever drifts, the soft-truncation
+    regression comes back (route returns HTTP 200 with empty content +
+    ``finish_reason="length"``).
+    """
+    vision_requests = [r for r in requests if not _is_text_only_request(r)]
+    if not vision_requests:
+        # All requests are text-only: the chunked text-only prefill path
+        # bounds per-forward memory, so there is no vision-merge budget to
+        # exceed (#1848).
+        return None
+    num_vision = len(vision_requests)
+    vision_tokens = sum(
+        r.input_ids.size if r.input_ids is not None else 1 for r in vision_requests
+    )
+    max_batch_tokens = prefill_step_size * num_vision
+    if vision_tokens > max_batch_tokens:
+        return (
+            f"Total prompt tokens ({vision_tokens}) exceeds the "
+            f"per-batch cap ({max_batch_tokens} = prefill_step_size "
+            f"{prefill_step_size} × {num_vision} vision request(s)). "
+            f"For image inputs, downscale the image; for text inputs, "
+            f"shorten the prompt or restart the server with "
+            f"--prefill-step-size set higher."
+        )
+    return None
+
+
 @dataclass
 class MLLMBatchRequest:
     """
@@ -1071,7 +1128,7 @@ class MLLMBatchGenerator:
         # them. The chunking only engages once the un-chunked activations +
         # full-sequence logits would actually spike memory (long contexts).
         chunk = max(1, min(self.prefill_step_size, _MLLM_PREFILL_CHUNK_TOKENS))
-        is_text_only = request.pixel_values is None and request.image_grid_thw is None
+        is_text_only = _is_text_only_request(request)
         no_extra_kwargs = not request.extra_kwargs
         if (
             cache is not None
@@ -1169,29 +1226,14 @@ class MLLMBatchGenerator:
         # Guard against excessive memory usage during cache merge.
         # Each token in the batch requires KV entries across all layers.
         #
-        # The error string MUST keep the ``exceeds the per-batch cap``
-        # phrase — ``MLLMScheduler._step_no_queue`` matches on it to
-        # classify the error as client-actionable (#682) and ``routes/
-        # chat.py`` maps it to HTTP 400 with the actionable message.
-        # If the phrase ever drifts, the soft-truncation regression
-        # comes back: the route would return HTTP 200 with empty
-        # content + ``finish_reason="length"`` and the Desktop client
-        # would render "Reached max_tokens before any output".
-        #
-        # The message also calls out image-downscale as a lever
-        # explicitly, because vision tokens dominate the prompt budget
-        # on a typical screenshot and "shorten the prompt" is not a
-        # useful instruction when the prompt is mostly image patches.
-        max_batch_tokens = self.prefill_step_size * len(requests)
-        if total_prompt_tokens > max_batch_tokens:
-            raise ValueError(
-                f"Total prompt tokens ({total_prompt_tokens}) exceeds the "
-                f"per-batch cap ({max_batch_tokens} = prefill_step_size "
-                f"{self.prefill_step_size} × {len(requests)} request(s)). "
-                f"For image inputs, downscale the image; for text inputs, "
-                f"shorten the prompt or restart the server with "
-                f"--prefill-step-size set higher."
-            )
+        # The cap exists to bound vision-merge memory for image-heavy
+        # prompts (#682). Text-only requests are prefilled in chunks on the
+        # vision-encoding path and do not contribute vision tokens, so they
+        # are exempt from the cap (#1848) — a >8k text-only prompt must not
+        # be rejected just because ``prefill_step_size`` defaults to 8192.
+        _cap_help = _prefill_cap_violation(requests, self.prefill_step_size)
+        if _cap_help is not None:
+            raise ValueError(_cap_help)
 
         # Run vision encoding for each request with its own KVCache.
         # Vision encoding cannot be batched because each request may have

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -3769,6 +3769,32 @@ def _force_abort_request(engine, request_id_holder) -> bool:
     return False
 
 
+_CLIENT_ACTIONABLE_STREAM_MARKERS = (
+    "exceeds the per-batch cap",
+    "Failed to process image",
+    "Failed to process video",
+    "Chat template error",
+)
+
+
+def _stream_error_is_client_actionable(message: str) -> bool:
+    """Whether a mid-stream generator exception carries a client-correctable
+    request error whose real message should be surfaced instead of masked.
+
+    Mirrors the markers the non-streaming chat route maps to HTTP 400
+    (#457 image/video fetch, #682 per-batch prefill cap, chat-template
+    errors). On the streaming path the SSE response has already started by
+    the time these surface mid-stream, so they cannot be turned into a 400
+    status; instead ``_disconnect_guard`` emits the real message with the
+    OpenAI ``invalid_request_error`` type so the caller sees the actionable
+    guidance rather than a generic "Internal error during streaming" (#1849).
+    Returns ``False`` for any other (genuine engine) fault, which keeps the
+    F-131 sanitisation intact for raw Python exception messages / class
+    names.
+    """
+    return any(marker in message for marker in _CLIENT_ACTIONABLE_STREAM_MARKERS)
+
+
 async def _disconnect_guard(
     generator: AsyncIterator[str],
     raw_request: Request,
@@ -3997,11 +4023,33 @@ async def _disconnect_guard(
                 # surface from this entry point. The full exception is
                 # logged above with ``exc_info`` so operators retain
                 # the diagnostic detail server-side.
+                # #1849: some exceptions are *client-actionable* request
+                # rejections whose real message must reach the caller —
+                # e.g. the MLLM per-batch-prefill cap ("exceeds the
+                # per-batch cap") or a failed image/video fetch. The
+                # non-streaming route already maps these to HTTP 400 with
+                # the real message; but on the streaming path the SSE
+                # response has already started (headers + role chunk were
+                # emitted), so we cannot change the HTTP status. F-131's
+                # generic masking would otherwise swallow the actionable
+                # message and hand the client a misleading 200 with
+                # "Internal error during streaming" — exactly the shape
+                # #1849 reports. Surface the real message for those
+                # known client-error markers (OpenAI ``invalid_request_error``
+                # type) while keeping F-131's sanitisation for every other
+                # (genuine engine) fault so a raw Python class name /
+                # traceback can never leak through the SSE payload.
+                if _stream_error_is_client_actionable(str(exc)):
+                    _sse_type = "invalid_request_error"
+                    _sse_message = str(exc)
+                else:
+                    _sse_type = "internal_error"
+                    _sse_message = "Internal error during streaming"
                 error_data = _json.dumps(
                     {
                         "error": {
-                            "message": "Internal error during streaming",
-                            "type": "internal_error",
+                            "message": _sse_message,
+                            "type": _sse_type,
                         }
                     }
                 )


### PR DESCRIPTION
Fixes **#1848** and partially addresses **#1849** (see the #1849 note below — layer 1 remains a follow-up, so #1849 is intentionally **kept open**).

## Summary

Two coupled MLLM-lane bugs that together made long (~>8k token) **text-only** prompts against any vision-capable alias fail as a DNF, and then swallow the actionable error into a misleading HTTP 200.

### 1. #1848 — text-only prompts >8192 tokens rejected (fixed)

`MLLMBatchGenerator._process_prompts` enforced a hard per-batch cap (`total_prompt_tokens > prefill_step_size × num_requests`). That cap exists purely to bound **vision-merge** memory (#682) — each image request can embed thousands of vision-patch tokens into one forward. But it also counted **text-only** requests, so any single text-only prompt longer than `prefill_step_size` (default 8192) was rejected, even though the chunked text-only prefill path exists (added for #1187/#1193).

**Fix**: only vision-bearing requests (`pixel_values` and `image_grid_thw` present) count toward the cap, comparing their aggregate tokens against `prefill_step_size × num_vision`. An all-text-only batch can never violate the cap — long text-only prompts flow through the existing chunk path, matching the text lane. New `_is_text_only_request` / `_prefill_cap_violation` helpers are shared with `_run_vision_encoding`.

**Review feedback addressed**:
- **Message clarity**: the cap error now reads `Vision-request prompt tokens (…)` instead of `Total prompt tokens (…)`, so a diagnostic can no longer mislead a user into thinking their *text* prompt tripped it.
- **Concurrency / cache-merge concern**: added `test_prefill_cap_exempts_batch_of_long_text_only_prompts` pinning that a batch of multiple >8k text-only prompts never trips the cap, while a long vision prompt among text peers still does (#682 preserved). Validated on real hardware (below).

### 2. #1849 — client-correctable rejection no longer swallowed as a generic 200 (layer 2 done; layer 1 = follow-up)

On the streaming path the MLLM rejection surfaced as a generator exception that `_disconnect_guard` (F-131 hardening) masked into `{"message":"Internal error during streaming","type":"internal_error"}` — HTTP 200 with no actionable message. The non-streaming route already maps the per-batch-cap / failed image-video / chat-template markers to HTTP 400 with the real message.

**Fix (layer 2)**: for known **client-correctable** markers, surface the real message with OpenAI `invalid_request_error` type, while preserving F-131's generic sanitisation for genuine engine faults (no traceback/class-name leak through SSE).

**⚠️ #1849 is NOT fully closed by this PR.** The issue asks for two layers:
1. **Before the first content token** → HTTP **4xx** (intact message).
2. **After the stream has started** → SSE error event with real message + distinguishing type.

This PR implements **layer 2** (the stream has already committed `StreamingResponse` + emitted the role chunk by the time the scheduler rejection surfaces, so we cannot change the HTTP status). Getting a true 4xx requires either a pre-completion preflight or pulling the first real scheduler result before committing the response headers — an architectural change with TTFT / keepalive / disconnect-semantics implications across the guided/strict/plain streaming variants. That is tracked as a **follow-up**; this PR deliberately does **not** claim full closure of #1849, and the issue stays open.

## Verification

- Regression tests added/updated in `tests/test_mllm_batch_generator.py`, `tests/test_sse_keepalive.py`, `tests/test_chat_route_vlm_image.py`.
- Focused suites: **53 passed** (`test_mllm_batch_generator`, `test_sse_keepalive`, `test_chat_route_vlm_image`).
- `ruff check` + `ruff format --check`: clean on all changed files.

### Real-hardware rebench (M3 Ultra / 256 GB, `mlx-community/gemma-4-26b-a4b-it-4bit`, fixed code, stream=true)

- **Single 16,000-token text-only prompt** (tokenizer-verified): HTTP 200, stream `[DONE]`, produced real output (`RB_OK`), 16k-token prompt completed in ~9.5s. Pre-fix this was the only DNF in the cross-runtime matrix (`Total prompt tokens (15993) exceeds the per-batch cap (8192 …)`).
- **Concurrent 3 × 16,000-token text-only streams**: all three completed (HTTP 200, `[DONE]`, 0 error events, unique correct outputs) in ~28s wall — no DNF, no cap rejection, **no OOM at cache merge** with multiple long text prompts batched concurrently.
- **#1849 layer-2 E2E**: a corrupt image produced `{"message":"Failed to process image: …","type":"invalid_request_error"}` in the SSE stream — the real actionable message now reaches the caller instead of the generic "Internal error during streaming".

## CI notes

Full local `tests/` run: 17,198 passed; only `test_event_loop.py` environment-dependent failures (require a live server on `127.0.0.1:8000`, absent on the headless runner). If CI shows the unrelated `hermes` parser-microbenchmark threshold failure on Python 3.12, that is runner noise unrelated to this PR and needs a rerun to green.