### PR TITLE
perf: fix long-context decode degradation — disk KV checkpoint + quantized live KV defaults (#1853)

### DIFF
--- a/tests/test_harmony_parsers.py
+++ b/tests/test_harmony_parsers.py
@@ -1292,6 +1292,9 @@ class TestServeLogLevelFlags:
         # Assert against the real parser (the flag moved from ``main``
         # into ``build_parser`` when the two split for #1853's
         # effective-default tests; source-scraping ``main`` went stale).
+        # Building the parser registers the share subcommand, which
+        # imports ``websockets`` — absent from the no-MLX CI lane.
+        pytest.importorskip("websockets")
         from vllm_mlx.cli import build_parser
 
         args = build_parser().parse_args(["serve", "m", "--log-level", "DEBUG"])

--- a/tests/test_harmony_parsers.py
+++ b/tests/test_harmony_parsers.py
@@ -1289,12 +1289,15 @@ class TestHarmonyCLIIntegration:
 
 class TestServeLogLevelFlags:
     def test_cli_serve_has_log_level_flag(self):
-        import importlib
-        import inspect
+        # Assert against the real parser (the flag moved from ``main``
+        # into ``build_parser`` when the two split for #1853's
+        # effective-default tests; source-scraping ``main`` went stale).
+        from vllm_mlx.cli import build_parser
 
-        source = inspect.getsource(importlib.import_module("vllm_mlx.cli").main)
-        assert '"--log-level"' in source
-        assert 'choices=["DEBUG", "INFO", "WARNING", "ERROR"]' in source
+        args = build_parser().parse_args(["serve", "m", "--log-level", "DEBUG"])
+        assert args.log_level == "DEBUG"
+        with pytest.raises(SystemExit):
+            build_parser().parse_args(["serve", "m", "--log-level", "TRACE"])
 
     def test_module_server_has_log_level_flag(self):
         from pathlib import Path

--- a/tests/test_kv_cache_dtype.py
+++ b/tests/test_kv_cache_dtype.py
@@ -337,11 +337,13 @@ def test_reasoning_wins_over_safelist():
 # ---------------------------------------------------------------------------
 
 
-def test_bf16_default_reason_marks_it_as_default():
+def test_bf16_reason_is_neutral_and_not_a_downgrade():
     decision = resolve_kv_cache_dtype("bf16", model_name="qwen3-4b-4bit")
-    # Operators should be able to see from the startup log that the
-    # default (not a downgrade) produced bf16.
-    assert "default" in decision.reason
+    # argparse cannot distinguish an explicit bf16 from the parser
+    # default, so the reason must not claim either; what matters is
+    # that bf16 resolution is never reported as a downgrade.
+    assert "bf16" in decision.reason
+    assert "default" not in decision.reason
     assert decision.downgraded is False
 
 

--- a/tests/test_kv_cache_dtype.py
+++ b/tests/test_kv_cache_dtype.py
@@ -23,10 +23,18 @@ from vllm_mlx.kv_cache_dtype import (
 # ---------------------------------------------------------------------------
 
 
-def test_default_is_int4():
-    """Locks the R15 #300 contract — int4 is the new default."""
-    assert DEFAULT_KV_CACHE_DTYPE == "int4"
-    assert "int4" in KV_CACHE_DTYPES
+def test_default_is_bf16():
+    """Locks the #1853 contract — bf16 is the default, quant is opt-in.
+
+    The R15 #300 int4 default assumed a bandwidth win, but the live
+    serve path (QuantizedBatchKVCache, dequant-on-read) materializes
+    full-precision K/V every decode step: measured 16k decode was
+    int4 98.2 tok/s vs bf16 134.6 on qwen3.5-4b. Anyone flipping the
+    default back to a quantized dtype must first land a fused
+    quantized-attention read path and re-run the long-context bench.
+    """
+    assert DEFAULT_KV_CACHE_DTYPE == "bf16"
+    assert "bf16" in KV_CACHE_DTYPES
 
 
 def test_reasoning_default_is_int8():
@@ -329,11 +337,20 @@ def test_reasoning_wins_over_safelist():
 # ---------------------------------------------------------------------------
 
 
-def test_default_int4_reason_mentions_bandwidth():
+def test_bf16_default_reason_marks_it_as_default():
+    decision = resolve_kv_cache_dtype("bf16", model_name="qwen3-4b-4bit")
+    # Operators should be able to see from the startup log that the
+    # default (not a downgrade) produced bf16.
+    assert "default" in decision.reason
+    assert decision.downgraded is False
+
+
+def test_int4_override_reason_cites_decode_cost():
     decision = resolve_kv_cache_dtype("int4", model_name="qwen3-4b-4bit")
-    # Operators should be able to grep "memory-bandwidth-bound" out of
-    # logs to verify the default kicked in for the right reason.
-    assert "memory-bandwidth-bound" in decision.reason
+    # Opting into quantized KV must leave a breadcrumb in the log that
+    # the operator accepted the O(context) dequant-on-read decode cost.
+    assert "#1853" in decision.reason
+    assert decision.downgraded is False
 
 
 def test_safelist_reason_mentions_sliding_window_for_gemma3():

--- a/tests/test_kv_cache_dtype_cli.py
+++ b/tests/test_kv_cache_dtype_cli.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 import subprocess
 import sys
 
+import pytest
+
 from vllm_mlx import cli
 
 
@@ -48,6 +50,9 @@ def test_serve_help_advertises_kv_cache_dtype_flag_with_choices():
 def test_serve_parses_bf16_as_effective_default():
     """The parsed namespace must carry bf16 when the flag is omitted
     (#1853) — locks the effective default, not just the help text."""
+    # build_parser registers the share subcommand → imports websockets,
+    # absent from the no-MLX CI lane.
+    pytest.importorskip("websockets")
     from vllm_mlx.cli import build_parser
 
     args = build_parser().parse_args(["serve", "some/model"])

--- a/tests/test_kv_cache_dtype_cli.py
+++ b/tests/test_kv_cache_dtype_cli.py
@@ -45,11 +45,16 @@ def test_serve_help_advertises_kv_cache_dtype_flag_with_choices():
     assert "--kv-cache-dtype {bf16,int8,int4}" in text
 
 
-def test_serve_help_advertises_int4_as_default():
-    """The R15 #300 contract — int4 is the *default*, not just a choice."""
+def test_serve_help_advertises_bf16_as_default():
+    """#1853 — bf16 is the *default*, not just a choice.
+
+    The R15 #300 int4 default was reverted: the live-cache
+    dequant-on-read implementation makes quantized KV O(context)
+    slower per decode step (-27% at 16k), so quantization is opt-in.
+    """
     text = _serve_help()
-    # The flag's help string explicitly carries ``default: int4``.
-    assert "default: int4" in text
+    # The flag's help string explicitly carries ``default: bf16``.
+    assert "default: bf16" in text
 
 
 def test_serve_help_advertises_reasoning_flag():

--- a/tests/test_kv_cache_dtype_cli.py
+++ b/tests/test_kv_cache_dtype_cli.py
@@ -45,6 +45,15 @@ def test_serve_help_advertises_kv_cache_dtype_flag_with_choices():
     assert "--kv-cache-dtype {bf16,int8,int4}" in text
 
 
+def test_serve_parses_bf16_as_effective_default():
+    """The parsed namespace must carry bf16 when the flag is omitted
+    (#1853) — locks the effective default, not just the help text."""
+    from vllm_mlx.cli import build_parser
+
+    args = build_parser().parse_args(["serve", "some/model"])
+    assert args.kv_cache_dtype == "bf16"
+
+
 def test_serve_help_advertises_bf16_as_default():
     """#1853 — bf16 is the *default*, not just a choice.
 

--- a/tests/test_scheduler_disk_kv_hook.py
+++ b/tests/test_scheduler_disk_kv_hook.py
@@ -360,30 +360,14 @@ def test_disk_checkpoint_default_is_opt_in():
 
 
 def test_disk_checkpoint_cli_default_is_opt_in():
-    """The serve CLI flag must default to 0 as well (#1853).
+    """The serve CLI must parse to interval 0 by default (#1853).
 
-    The parser is built inline in ``cli.main`` (no importable
-    factory), so pin the ``add_argument`` block's default in source:
-    a CLI default that silently diverges from SchedulerConfig's 0
-    re-enables the decode stall for every ``rapid-mlx serve`` user
-    while this file's config-level test stays green.
+    Asserts the EFFECTIVE default on the parsed namespace (not source
+    or help text), so a stray ``set_defaults`` or a re-added parser
+    default cannot silently re-enable the decode stall for every
+    ``rapid-mlx serve`` user while a config-level test stays green.
     """
-    import inspect
-    import re
+    from vllm_mlx.cli import build_parser
 
-    import vllm_mlx.cli as cli_mod
-
-    src = inspect.getsource(cli_mod)
-    # Scope the match to this add_argument call: stop at the first
-    # ``help=`` so a dropped default cannot let ``.*?`` skip ahead and
-    # capture an unrelated later flag's ``default=`` (codex nit).
-    m = re.search(
-        r'"--kv-disk-checkpoint-interval",[^)]*?default=(\d+)\s*,[^)]*?help=',
-        src,
-        flags=re.DOTALL,
-    )
-    assert m, "--kv-disk-checkpoint-interval add_argument block not found"
-    assert m.group(1) == "0", (
-        f"--kv-disk-checkpoint-interval CLI default must be 0 (opt-in, "
-        f"#1853); found {m.group(1)}"
-    )
+    args = build_parser().parse_args(["serve", "some/model"])
+    assert args.kv_disk_checkpoint_interval == 0

--- a/tests/test_scheduler_disk_kv_hook.py
+++ b/tests/test_scheduler_disk_kv_hook.py
@@ -367,6 +367,7 @@ def test_disk_checkpoint_cli_default_is_opt_in():
     default cannot silently re-enable the decode stall for every
     ``rapid-mlx serve`` user while a config-level test stays green.
     """
+    pytest.importorskip("websockets")  # share subcommand import, no-MLX lane
     from vllm_mlx.cli import build_parser
 
     args = build_parser().parse_args(["serve", "some/model"])

--- a/tests/test_scheduler_disk_kv_hook.py
+++ b/tests/test_scheduler_disk_kv_hook.py
@@ -374,8 +374,11 @@ def test_disk_checkpoint_cli_default_is_opt_in():
     import vllm_mlx.cli as cli_mod
 
     src = inspect.getsource(cli_mod)
+    # Scope the match to this add_argument call: stop at the first
+    # ``help=`` so a dropped default cannot let ``.*?`` skip ahead and
+    # capture an unrelated later flag's ``default=`` (codex nit).
     m = re.search(
-        r'"--kv-disk-checkpoint-interval",.*?default=(\d+)\s*,',
+        r'"--kv-disk-checkpoint-interval",[^)]*?default=(\d+)\s*,[^)]*?help=',
         src,
         flags=re.DOTALL,
     )

--- a/tests/test_scheduler_disk_kv_hook.py
+++ b/tests/test_scheduler_disk_kv_hook.py
@@ -338,3 +338,49 @@ def test_safe_disk_checkpoint_records_silent_failure(
     # double-check the second call ticked again, so a "swallows but
     # forgets to record" regression also fails here.
     assert _dkc.get_stats()["hook_errors"] == after + 1
+
+
+# ---------------------------------------------------------------------------
+# #1853 — the disk checkpoint must be OPT-IN.
+# ---------------------------------------------------------------------------
+
+
+def test_disk_checkpoint_default_is_opt_in():
+    """Default interval must be 0 — checkpointing is opt-in (#1853).
+
+    When this defaulted to 256, every server synchronously serialized
+    the FULL KV cache to disk every 256 generated tokens — an
+    O(context) stall on the decode thread (~0.6s per snapshot at 16k
+    on a 4B model) that degraded 16k-context decode from 150 to
+    82 tok/s, and nothing in the engine ever read the checkpoints
+    back. Anyone flipping the default back on must come armed with an
+    async writer and a wired-up load path.
+    """
+    assert SchedulerConfig().kv_disk_checkpoint_interval == 0
+
+
+def test_disk_checkpoint_cli_default_is_opt_in():
+    """The serve CLI flag must default to 0 as well (#1853).
+
+    The parser is built inline in ``cli.main`` (no importable
+    factory), so pin the ``add_argument`` block's default in source:
+    a CLI default that silently diverges from SchedulerConfig's 0
+    re-enables the decode stall for every ``rapid-mlx serve`` user
+    while this file's config-level test stays green.
+    """
+    import inspect
+    import re
+
+    import vllm_mlx.cli as cli_mod
+
+    src = inspect.getsource(cli_mod)
+    m = re.search(
+        r'"--kv-disk-checkpoint-interval",.*?default=(\d+)\s*,',
+        src,
+        flags=re.DOTALL,
+    )
+    assert m, "--kv-disk-checkpoint-interval add_argument block not found"
+    assert m.group(1) == "0", (
+        f"--kv-disk-checkpoint-interval CLI default must be 0 (opt-in, "
+        f"#1853); found {m.group(1)}"
+    )

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -7989,13 +7989,20 @@ def _parse_args_with_share_passthrough(
     return args
 
 
-def main():
+def _resolve_cli_version() -> str:
     from importlib.metadata import version as pkg_version
 
     try:
-        _version = pkg_version("rapid-mlx")
+        return pkg_version("rapid-mlx")
     except Exception:
-        _version = "dev"
+        return "dev"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Construct the full CLI parser (extracted from ``main`` so tests
+    can assert effective flag defaults on the parsed namespace instead
+    of scraping source or help text)."""
+    _version = _resolve_cli_version()
 
     parser = argparse.ArgumentParser(
         description="Rapid-MLX: AI inference for Apple Silicon",
@@ -8407,12 +8414,13 @@ Examples:
         default=0,
         help=(
             "Token interval at which the scheduler snapshots KV state to "
-            "~/.cache/rapid-mlx/kv_checkpoints/ for resume / shared-prefix "
-            "reload (R15 #296). 0 (default) disables. Each snapshot blocks "
-            "decode for O(context), so enable only when checkpoint reuse "
-            "is worth that stall (#1853). Pairs with the "
-            "RAPID_MLX_KV_CHECKPOINT_MAX_BYTES env var (default 20 GiB) "
-            "for the oldest-first disk-cap eviction policy."
+            "~/.cache/rapid-mlx/kv_checkpoints/ (R15 #296). 0 (default) "
+            "disables. Write-only today: no engine path reloads the "
+            "snapshots yet, and each one blocks decode for O(context) — "
+            "enable only for external tooling that consumes the files "
+            "(#1853). Pairs with the RAPID_MLX_KV_CHECKPOINT_MAX_BYTES "
+            "env var (default 20 GiB) for the oldest-first disk-cap "
+            "eviction policy."
         ),
     )
     serve_parser.add_argument(
@@ -9689,6 +9697,19 @@ Examples:
     from vllm_mlx.launch.cli import register as _register_launch
 
     _register_launch(subparsers)
+
+    return parser
+
+
+def main():
+    parser = build_parser()
+    _version = _resolve_cli_version()
+    # The subcommand help printer below needs the subparsers action;
+    # recover it from the parser rather than keeping it as a shared
+    # local across the build/parse split.
+    subparsers = next(
+        a for a in parser._actions if isinstance(a, argparse._SubParsersAction)
+    )
 
     # Shell tab completion via argcomplete. Must fire before parse_args:
     # when the shell completion handler invokes us with the

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -3557,11 +3557,12 @@ def serve_command(args):
         # the boolean ``kv_cache_turboquant`` for downstream callers;
         # the mode string rides on the dedicated ``_mode`` field.
         **_turboquant_scheduler_kwargs(args),
-        # R15-P1 (task #296): disk-backed KV checkpointing at 256-tok
-        # boundaries. ``0`` disables; the runtime module guards every
-        # hot-path call with ``should_checkpoint`` so the cost when off
-        # is one int comparison.
-        kv_disk_checkpoint_interval=getattr(args, "kv_disk_checkpoint_interval", 256),
+        # R15-P1 (task #296): disk-backed KV checkpointing. ``0``
+        # (default) disables; each snapshot blocks the decode thread for
+        # O(context) so the feature is opt-in (#1853). The runtime module
+        # guards every hot-path call with ``should_checkpoint`` so the
+        # cost when off is one int comparison.
+        kv_disk_checkpoint_interval=getattr(args, "kv_disk_checkpoint_interval", 0),
         # PFlash long-prompt compression (#287)
         pflash_config=pflash_config,
         # D-METAL-CAP: thread the user's --gpu-memory-utilization into
@@ -4668,11 +4669,10 @@ def bench_command(args):
             kv_cache_quantization_group_size=args.kv_cache_quantization_group_size,
             kv_cache_min_quantize_tokens=args.kv_cache_min_quantize_tokens,
             # R15-P1 (task #296): disk-backed KV checkpointing. Bench
-            # path mirrors serve so a regression in the boundary trigger
-            # surfaces in `rapid-mlx bench` numbers too.
-            kv_disk_checkpoint_interval=getattr(
-                args, "kv_disk_checkpoint_interval", 256
-            ),
+            # path mirrors serve (0 = off by default, #1853) so a
+            # regression in the boundary trigger surfaces in
+            # `rapid-mlx bench` numbers too.
+            kv_disk_checkpoint_interval=getattr(args, "kv_disk_checkpoint_interval", 0),
             # PFlash long-prompt compression (#287)
             pflash_config=bench_pflash_config,
         )
@@ -8391,19 +8391,25 @@ Examples:
         default=32,
         help="Group size for TurboQuant V-side quantization (default: 32)",
     )
-    # R15-P1 (task #296): disk-backed KV checkpointing at 256-tok boundaries.
-    # 0 disables the feature entirely (no scheduler-hot-path cost, no
-    # ~/.cache/rapid-mlx/kv_checkpoints/ directory creation); the default
-    # 256 matches MLX-LM's KVCache.step and LMCache's external-chunk size
-    # so the on-disk shape aligns with the in-memory shape on reload.
+    # R15-P1 (task #296): disk-backed KV checkpointing. 0 (default)
+    # disables the feature entirely (no scheduler-hot-path cost, no
+    # ~/.cache/rapid-mlx/kv_checkpoints/ directory creation). Opt-in
+    # only: each snapshot serializes the full KV cache synchronously on
+    # the decode thread — O(context) per boundary, which degraded 16k
+    # decode by up to 45% when this defaulted to 256 (#1853). When
+    # enabling, use a multiple of 256 to match MLX-LM's KVCache.step and
+    # LMCache's external-chunk size so the on-disk shape aligns with the
+    # in-memory shape on reload.
     serve_parser.add_argument(
         "--kv-disk-checkpoint-interval",
         type=int,
-        default=256,
+        default=0,
         help=(
             "Token interval at which the scheduler snapshots KV state to "
             "~/.cache/rapid-mlx/kv_checkpoints/ for resume / shared-prefix "
-            "reload (R15 #296, default 256). 0 disables. Pairs with the "
+            "reload (R15 #296). 0 (default) disables. Each snapshot blocks "
+            "decode for O(context), so enable only when checkpoint reuse "
+            "is worth that stall (#1853). Pairs with the "
             "RAPID_MLX_KV_CHECKPOINT_MAX_BYTES env var (default 20 GiB) "
             "for the oldest-first disk-cap eviction policy."
         ),

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -8282,32 +8282,33 @@ Examples:
         ),
     )
     # KV cache quantization options
-    # ``--kv-cache-dtype`` (R15 task #300) is the canonical knob: int4 is
-    # the new default because Apple Silicon decode is memory-bandwidth-
-    # bound and a 4×-smaller KV cache cuts bandwidth proportionally
-    # (mlx#3134 UMA discussion, Feb 2026 — Phi-3.5-mini +1.1%
-    # throughput, 3.2× more context room on Qwen2.5-14B). The
-    # safelist in :mod:`vllm_mlx.kv_cache_dtype` auto-downgrades
-    # sliding-window (Gemma 3, GPT-OSS) and MLA (DeepSeek V3+,
-    # Kimi-K2.5) families to bf16 where int4 breaks decode quality.
-    # ``--reasoning`` pins to int8 for AIME-class hard math where
-    # sub-4-bit drops -20pt on thinking variants.
-    #
-    # Qwen3.5-9B-4bit bench (M3, 292-tok prompt, 5×400-tok decode median):
-    # int4 113.6 tok/s / 119 ms TTFT / 5388 MB RSS vs bf16 113.7 tok/s /
-    # 120 ms TTFT / 5392 MB RSS — int4 is a free swap at this size; the
-    # +1.1 % / 3.2× headroom land at multi-k contexts (PR #910 comment).
+    # ``--kv-cache-dtype`` (R15 task #300) is the canonical knob. Default
+    # is bf16 (#1853): the R15 int4 default was justified by "4×-smaller
+    # KV cuts decode bandwidth proportionally", but the live serve path
+    # (QuantizedBatchKVCache, #1197) implements quantization as
+    # dequant-on-read — it MATERIALIZES full-precision K/V on every
+    # decode step, so per-token cost grows with context instead of
+    # shrinking. Measured on qwen3.5-4b, 16k context, N=2 (parity
+    # server, disk checkpoints off): bf16 134.6 tok/s, int4 98.2
+    # (-27%), int8 86.1 (-36%); at 128-ctx: bf16 167, int4 161,
+    # int8 160. The #910 numbers that motivated the int4 default were
+    # short-context (292-tok prompt), where the regression is invisible.
+    # int4/int8 remain available as explicit opt-ins for
+    # memory-constrained hosts (KV is 4×/2× smaller); ``--reasoning``
+    # still pins to int8.
     serve_parser.add_argument(
         "--kv-cache-dtype",
         type=str,
-        default="int4",
+        default="bf16",
         choices=["bf16", "int8", "int4"],
         help=(
-            "KV cache dtype (R15 #300, default: int4). Apple Silicon decode "
-            "is memory-bandwidth-bound; int4 yields ~4× less bandwidth per "
-            "decode step with 97-98%% quality retention. Sliding-window "
-            "(Gemma 3, GPT-OSS) and MLA (DeepSeek V3+, Kimi K2.5) models "
-            "auto-downgrade to bf16. Use --reasoning for AIME / hard math."
+            "KV cache dtype (R15 #300, default: bf16). int8/int4 shrink the "
+            "KV cache 2x/4x for memory-constrained hosts, but the live-cache "
+            "dequant-on-read costs O(context) per decode step — measured "
+            "-27%% (int4) / -36%% (int8) at 16k context (#1853). "
+            "Sliding-window (Gemma 3, GPT-OSS) and MLA (DeepSeek V3+, "
+            "Kimi K2.5) models auto-downgrade to bf16. Use --reasoning "
+            "for AIME / hard math."
         ),
     )
     serve_parser.add_argument(

--- a/vllm_mlx/kv_cache_dtype.py
+++ b/vllm_mlx/kv_cache_dtype.py
@@ -312,11 +312,11 @@ def resolve_kv_cache_dtype(
                 requested=requested,
             )
 
-    # Pass-through for the safe-to-use cases. Reason text varies so the
-    # operator can distinguish "default kicked in" from "I asked for it
-    # explicitly".
+    # Pass-through for the safe-to-use cases. argparse cannot tell an
+    # explicit ``--kv-cache-dtype bf16`` from the parser default, so the
+    # reason makes no default-vs-override claim.
     if requested == "bf16":
-        reason = "bf16 selected (default; no QuantizedKVCache wrap)"
+        reason = "bf16 selected (no QuantizedKVCache wrap)"
     else:
         reason = (
             f"{requested} selected (operator override; dequant-on-read "

--- a/vllm_mlx/kv_cache_dtype.py
+++ b/vllm_mlx/kv_cache_dtype.py
@@ -1,19 +1,29 @@
 # SPDX-License-Identifier: Apache-2.0
 """KV-cache dtype resolution (R15 task #300).
 
-Apple Silicon decode is memory-bandwidth-bound: a 4×-smaller KV cache
-gives 4× less bandwidth on every decode step. The mlx-lm
-``QuantizedKVCache`` is the production knob for that; this module
-centralizes the policy for *when* to flip it on by default.
+This module centralizes the policy for when the mlx-lm
+``QuantizedKVCache`` is used for the live KV cache.
 
 Three user-facing dtypes:
 
 * ``bf16`` — full-precision KV cache (mlx-lm ``KVCache`` /
-  ``RotatingKVCache``). Safe everywhere.
+  ``RotatingKVCache``). Safe everywhere. The default (#1853).
 * ``int8`` — 8-bit ``QuantizedKVCache``. 97-98% quality retention on most
   workloads, used as the reasoning/code profile.
-* ``int4`` — 4-bit ``QuantizedKVCache``. Biggest bandwidth win, default
-  for new installs on non-safelisted architectures.
+* ``int4`` — 4-bit ``QuantizedKVCache``. Smallest KV footprint.
+
+The R15 rollout defaulted to int4 on the theory that Apple Silicon
+decode is memory-bandwidth-bound, so a 4×-smaller KV cache should
+speed up every decode step. The live serve path
+(``QuantizedBatchKVCache``, #1197) implements quantization as
+dequant-on-read — it materializes full-precision K/V every decode
+step — so the bandwidth win never materializes and per-token cost
+GROWS with context instead: measured on qwen3.5-4b at 16k context,
+bf16 134.6 tok/s vs int4 98.2 (-27%) vs int8 86.1 (-36%); the
+short-context numbers that motivated the int4 default (#910,
+292-token prompts) could not see this. Until the read path uses a
+fused quantized-attention kernel, quantized KV is a memory/quality
+trade-off the operator must opt into, not a free speedup (#1853).
 
 Auto-downgrade safelist (forces ``bf16``):
 
@@ -40,7 +50,7 @@ logger = logging.getLogger(__name__)
 # ``dtype="int4"`` works without parsing.
 KV_CACHE_DTYPES = ("bf16", "int8", "int4")
 
-DEFAULT_KV_CACHE_DTYPE = "int4"
+DEFAULT_KV_CACHE_DTYPE = "bf16"
 REASONING_KV_CACHE_DTYPE = "int8"
 
 # ---------------------------------------------------------------------------
@@ -305,16 +315,14 @@ def resolve_kv_cache_dtype(
     # Pass-through for the safe-to-use cases. Reason text varies so the
     # operator can distinguish "default kicked in" from "I asked for it
     # explicitly".
-    if requested == DEFAULT_KV_CACHE_DTYPE:
-        reason = (
-            f"Defaulting to {DEFAULT_KV_CACHE_DTYPE} (memory-bandwidth-bound "
-            f"on M-series); model={model_name or hf_path or 'unknown'} not "
-            f"in safelist"
-        )
-    elif requested == "bf16":
-        reason = "bf16 selected (no QuantizedKVCache wrap)"
+    if requested == "bf16":
+        reason = "bf16 selected (default; no QuantizedKVCache wrap)"
     else:
-        reason = f"{requested} selected (operator override)"
+        reason = (
+            f"{requested} selected (operator override; dequant-on-read "
+            f"costs O(context) per decode step — #1853); "
+            f"model={model_name or hf_path or 'unknown'} not in safelist"
+        )
 
     return KVCacheDtypeDecision(
         dtype=requested,

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -194,14 +194,18 @@ class SchedulerConfig:
     kv_cache_turboquant_mode: str = "v4"
 
     # R15-P1 (task #296): disk-backed KV checkpointing.
-    # ``0`` disables the feature so the scheduler hot-path never touches
-    # the disk module; the default 256 matches MLX-LM's ``KVCache.step``
+    # ``0`` (default) disables the feature so the scheduler hot-path never
+    # touches the disk module. Opt-in only: each snapshot serializes the
+    # FULL KV cache synchronously on the decode thread, which costs
+    # O(context) per boundary — at 16k context on a 4B model one snapshot
+    # is ~0.6s, degrading long-context decode by up to 45% (#1853). When
+    # enabling, use a multiple of 256 to match MLX-LM's ``KVCache.step``
     # so the on-disk shape lines up with the in-memory shape on reload.
     # The disk cap is resolved at runtime via
     # ``RAPID_MLX_KV_CHECKPOINT_MAX_BYTES`` so a single field on the
     # SchedulerConfig is enough — see
     # :mod:`vllm_mlx.runtime.disk_kv_checkpoint`.
-    kv_disk_checkpoint_interval: int = 256
+    kv_disk_checkpoint_interval: int = 0
 
     # Paged cache settings (experimental - for memory efficiency)
     use_paged_cache: bool = (


### PR DESCRIPTION
## Why

The 2026-08-11 cross-runtime benchmark (#1853) found rapid last or second-to-last in every 16k-context decode cell: qwen3.5-4b dropped 150 → 82 tok/s (−45%) while oMLX / mlx-lm / Ollama on the same stack lost only 10–15%. Layer-by-layer isolation (raw BatchGenerator → Scheduler → BatchedEngine → stream_chat → live HTTP server, all measured on the same model/prompt) attributed the entire gap to two default-on features, each adding an O(context) cost to every decode step:

1. **Disk KV checkpointing (R15-P1 #296) defaulted to interval 256.** Every 256 generated tokens the scheduler serializes the FULL KV cache (`save_prompt_cache` + fsync) synchronously on the decode thread — ~0.6s per snapshot at 16k on a 4B model. Nothing in the engine reads the checkpoints back: `load_checkpoint` / `scan_checkpoints` have no callers outside the module and its tests (the docstring's "loads checkpoints during startup" integration never landed). The module's own docs already describe 0/opt-in as the intended shape.

2. **Live KV cache quantization (R15 #300 + #1197) defaulted to int4.** The premise was "4×-smaller KV = 4× less decode bandwidth", but the live path (`QuantizedBatchKVCache`) implements quantization as dequant-on-read — it materializes full-precision K/V on every decode step, so per-token cost grows with context instead of shrinking. The #910 numbers behind the default used 292-token prompts, where this is invisible.

## Measurements

qwen3.5-4b, parity server (prefix cache / spec decode / PFlash off), N=3 medians via the `bench/cross-runtime` harness, plus N=2 flag-isolated runs:

| config | decode_b1 (128 ctx) | decode_16k |
|---|---|---|
| shipped defaults (ckpt=256 + int4 KV) | 149.7 | 82.2 |
| checkpoint off | 160.9 | 102.3 |
| checkpoint off + bf16 KV (**new defaults**) | **167.0** | **134.6** |
| in-process mlx-lm BatchGenerator (floor) | 167.7 | 138.2 |
| oMLX / mlx-lm / Ollama (same cell) | 175 / ~131 / 116 | 149 / 113 / 97 |

Isolated dtype A/B at 16k (checkpoint off): bf16 134.6, int4 98.2 (−27%), int8 86.1 (−36%).

Net: 16k decode **82 → 134.6 tok/s (+64%)**, from last place to second (behind oMLX 149); the residual gap is the known B=1 scheduler-overhead family, tracked separately. Post-fix the server is within ~3% of the in-process library floor at both context lengths.

## What changed

- `SchedulerConfig.kv_disk_checkpoint_interval`: 256 → 0 (opt-in), same for the `--kv-disk-checkpoint-interval` serve flag and the bench-path fallback. Feature unchanged when explicitly enabled.
- `DEFAULT_KV_CACHE_DTYPE` / `--kv-cache-dtype`: int4 → bf16. int4/int8 remain explicit opt-ins for memory-constrained hosts (KV 4×/2× smaller); `--reasoning` still pins int8; the sliding-window/MLA auto-downgrade safelist is unchanged.
- Regression tests pin both opt-in defaults (config + CLI), verified red against the pre-fix source.

Closes #1853

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Compatibility: KV memory impact of int4 → bf16

Reviewer concern: bf16 live KV is ~4× larger than int4, so a deployment near its memory ceiling with long contexts could regress on upgrade. Why this does not gate the change:

- **No hard-OOM path.** The engine enforces `gpu_memory_utilization` via `mx.set_memory_limit` (default 0.90) **and** the D-METAL-CAP admission gate, which rejects over-cap requests with 503 + Retry-After instead of letting the allocator crash. A host that no longer fits a given context degrades to backpressure, not a crash loop.
- **The int4 default is weeks old.** bf16 was the default for the project's entire history before R15 #300; "previously working deployments" overwhelmingly means bf16 deployments. The measured cost of keeping int4 is −27% decode at 16k for every user, traded against a memory ceiling that only affects hosts within 4× of their KV limit.
- **One flag away.** Memory-constrained hosts keep the exact prior behavior with `--kv-cache-dtype int4`; the `--reasoning` int8 pin and the sliding-window/MLA safelist are unchanged.
- **Industry default.** Ollama and LM Studio both ship full-precision KV by default; quantized KV is opt-in everywhere else in the ecosystem.

The right long-term fix for wanting int4 back as default is a fused quantized-attention read path (no per-step materialization) — tracked in #1853 discussion, out of scope here.
